### PR TITLE
fix: show Clear FS button in extension mode

### DIFF
--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -193,10 +193,7 @@ export class Layout {
       } catch { /* OPFS not available or already empty */ }
       location.reload();
     });
-    // Only show in dev mode
-    if (typeof __DEV__ !== 'undefined' && __DEV__) {
-      this.actionsEl.appendChild(this.clearFsBtn);
-    }
+    this.actionsEl.appendChild(this.clearFsBtn);
 
     // Clear Groups DB (dev mode only) - clears all group data including global memory
     const clearGroupsBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- The "Clear FS" button was hidden in the Chrome extension because it was only appended to the DOM inside a `__DEV__` guard
- Removed the dev-only gate so the button is always in the DOM
- In extension mode, `updateButtonVisibility()` correctly shows it only when the Files tab is active

## Test plan
- [ ] Load the extension in Chrome and verify the "Clear FS" button appears when the Files tab is selected
- [ ] Verify the button is hidden on Chat and Terminal tabs
- [ ] Verify clicking it clears the virtual filesystem and reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)