### PR TITLE
feat(git): close gap to most commonly used AI agent git commands

### DIFF
--- a/src/git/diff.test.ts
+++ b/src/git/diff.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { unifiedDiff, diffStat } from './diff.js';
+
+describe('unifiedDiff', () => {
+  it('returns empty string for identical content', () => {
+    const result = unifiedDiff({
+      oldContent: 'hello\nworld\n',
+      newContent: 'hello\nworld\n',
+      oldName: 'file.txt',
+      newName: 'file.txt',
+      color: false,
+    });
+    expect(result).toBe('');
+  });
+
+  it('shows added lines', () => {
+    const result = unifiedDiff({
+      oldContent: 'line1\nline2\n',
+      newContent: 'line1\nline2\nline3\n',
+      oldName: 'file.txt',
+      newName: 'file.txt',
+      color: false,
+    });
+    expect(result).toContain('+line3');
+    expect(result).toContain('--- a/file.txt');
+    expect(result).toContain('+++ b/file.txt');
+    expect(result).toContain('@@');
+  });
+
+  it('shows deleted lines', () => {
+    const result = unifiedDiff({
+      oldContent: 'line1\nline2\nline3\n',
+      newContent: 'line1\nline3\n',
+      oldName: 'file.txt',
+      newName: 'file.txt',
+      color: false,
+    });
+    expect(result).toContain('-line2');
+  });
+
+  it('shows modified lines as delete+insert', () => {
+    const result = unifiedDiff({
+      oldContent: 'hello world\n',
+      newContent: 'hello universe\n',
+      oldName: 'file.txt',
+      newName: 'file.txt',
+      color: false,
+    });
+    expect(result).toContain('-hello world');
+    expect(result).toContain('+hello universe');
+  });
+
+  it('handles new file (empty old content)', () => {
+    const result = unifiedDiff({
+      oldContent: '',
+      newContent: 'new content\n',
+      oldName: 'file.txt',
+      newName: 'file.txt',
+      color: false,
+    });
+    expect(result).toContain('+new content');
+  });
+
+  it('handles deleted file (empty new content)', () => {
+    const result = unifiedDiff({
+      oldContent: 'old content\n',
+      newContent: '',
+      oldName: 'file.txt',
+      newName: 'file.txt',
+      color: false,
+    });
+    expect(result).toContain('-old content');
+  });
+
+  it('includes context lines around changes', () => {
+    const result = unifiedDiff({
+      oldContent: 'a\nb\nc\nd\ne\nf\ng\n',
+      newContent: 'a\nb\nc\nX\ne\nf\ng\n',
+      oldName: 'file.txt',
+      newName: 'file.txt',
+      color: false,
+    });
+    // Context should include lines around the change
+    expect(result).toContain(' a');
+    expect(result).toContain(' b');
+    expect(result).toContain(' c');
+    expect(result).toContain('-d');
+    expect(result).toContain('+X');
+    expect(result).toContain(' e');
+    expect(result).toContain(' f');
+    expect(result).toContain(' g');
+  });
+
+  it('includes color codes when color is enabled', () => {
+    const result = unifiedDiff({
+      oldContent: 'old\n',
+      newContent: 'new\n',
+      oldName: 'file.txt',
+      newName: 'file.txt',
+      color: true,
+    });
+    expect(result).toContain('\x1b[31m'); // red for deletions
+    expect(result).toContain('\x1b[32m'); // green for insertions
+    expect(result).toContain('\x1b[36m'); // cyan for @@ headers
+  });
+
+  it('produces correct hunk header format', () => {
+    const result = unifiedDiff({
+      oldContent: 'line1\nline2\n',
+      newContent: 'line1\nmodified\n',
+      oldName: 'file.txt',
+      newName: 'file.txt',
+      color: false,
+    });
+    // Should have @@ -start,count +start,count @@ format
+    expect(result).toMatch(/@@ -\d+,\d+ \+\d+,\d+ @@/);
+  });
+});
+
+describe('diffStat', () => {
+  it('returns zero for identical content', () => {
+    const result = diffStat('hello\n', 'hello\n');
+    expect(result).toEqual({ insertions: 0, deletions: 0 });
+  });
+
+  it('counts insertions', () => {
+    const result = diffStat('line1\n', 'line1\nline2\n');
+    expect(result.insertions).toBeGreaterThan(0);
+    expect(result.deletions).toBe(0);
+  });
+
+  it('counts deletions', () => {
+    const result = diffStat('line1\nline2\n', 'line1\n');
+    expect(result.deletions).toBeGreaterThan(0);
+    expect(result.insertions).toBe(0);
+  });
+
+  it('counts both insertions and deletions', () => {
+    const result = diffStat('old line\n', 'new line\n');
+    expect(result.insertions).toBeGreaterThan(0);
+    expect(result.deletions).toBeGreaterThan(0);
+  });
+});

--- a/src/git/diff.ts
+++ b/src/git/diff.ts
@@ -1,0 +1,264 @@
+/**
+ * Minimal unified diff implementation using Myers diff algorithm.
+ * Produces standard unified diff output with @@ hunk headers.
+ */
+
+interface Edit {
+  type: 'equal' | 'insert' | 'delete';
+  line: string;
+}
+
+/**
+ * Myers diff algorithm — computes shortest edit script between two line arrays.
+ */
+function myersDiff(a: string[], b: string[]): Edit[] {
+  const n = a.length;
+  const m = b.length;
+
+  if (n === 0 && m === 0) return [];
+  if (n === 0) return b.map((line) => ({ type: 'insert' as const, line }));
+  if (m === 0) return a.map((line) => ({ type: 'delete' as const, line }));
+
+  const max = n + m;
+  const offset = max;
+  const size = 2 * max + 1;
+
+  // Forward pass: compute trace of furthest-reaching points
+  const trace: number[][] = [];
+  const v = new Array<number>(size).fill(0);
+
+  let finalD = -1;
+  outer: for (let d = 0; d <= max; d++) {
+    trace.push(v.slice());
+    for (let k = -d; k <= d; k += 2) {
+      let x: number;
+      if (k === -d || (k !== d && v[k - 1 + offset] < v[k + 1 + offset])) {
+        x = v[k + 1 + offset]; // insert: come from k+1
+      } else {
+        x = v[k - 1 + offset] + 1; // delete: come from k-1
+      }
+      let y = x - k;
+      while (x < n && y < m && a[x] === b[y]) {
+        x++;
+        y++;
+      }
+      v[k + offset] = x;
+      if (x >= n && y >= m) {
+        finalD = d;
+        break outer;
+      }
+    }
+  }
+
+  if (finalD === -1) finalD = max;
+
+  // Backtrack from (n, m) to (0, 0) using the trace
+  const edits: Edit[] = [];
+  let x = n;
+  let y = m;
+
+  for (let d = finalD; d > 0; d--) {
+    // trace[d] holds v state AFTER d-1 was processed (pushed at start of d loop)
+    const prev = trace[d];
+    const k = x - y;
+
+    let prevK: number;
+    if (k === -d || (k !== d && prev[k - 1 + offset] < prev[k + 1 + offset])) {
+      prevK = k + 1; // came from insert
+    } else {
+      prevK = k - 1; // came from delete
+    }
+
+    const prevX = prev[prevK + offset];
+    const prevY = prevX - prevK;
+
+    // Diagonal (equal) moves after the edit at step d
+    while (x > prevX && y > prevY) {
+      x--;
+      y--;
+      edits.push({ type: 'equal', line: a[x] });
+    }
+
+    // The actual edit at step d
+    if (x === prevX && y > prevY) {
+      y--;
+      edits.push({ type: 'insert', line: b[y] });
+    } else if (y === prevY && x > prevX) {
+      x--;
+      edits.push({ type: 'delete', line: a[x] });
+    }
+  }
+
+  // Remaining diagonal at d=0 (matches from the very beginning)
+  while (x > 0 && y > 0) {
+    x--;
+    y--;
+    edits.push({ type: 'equal', line: a[x] });
+  }
+
+  edits.reverse();
+  return edits;
+}
+
+interface Hunk {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+  lines: string[];
+}
+
+/**
+ * Group edits into unified diff hunks with context lines.
+ */
+function buildHunks(edits: Edit[], contextLines = 3): Hunk[] {
+  const hunks: Hunk[] = [];
+
+  // Find ranges of changes
+  const changeIndices: number[] = [];
+  for (let i = 0; i < edits.length; i++) {
+    if (edits[i].type !== 'equal') {
+      changeIndices.push(i);
+    }
+  }
+
+  if (changeIndices.length === 0) return [];
+
+  // Group changes that are close together (within 2*context)
+  let groupStart = 0;
+  const groups: [number, number][] = [];
+
+  for (let i = 1; i < changeIndices.length; i++) {
+    if (changeIndices[i] - changeIndices[i - 1] > 2 * contextLines) {
+      groups.push([groupStart, i - 1]);
+      groupStart = i;
+    }
+  }
+  groups.push([groupStart, changeIndices.length - 1]);
+
+  for (const [gStart, gEnd] of groups) {
+    const firstChange = changeIndices[gStart];
+    const lastChange = changeIndices[gEnd];
+
+    const hunkStart = Math.max(0, firstChange - contextLines);
+    const hunkEnd = Math.min(edits.length - 1, lastChange + contextLines);
+
+    const lines: string[] = [];
+
+    // Count old/new line positions up to hunkStart
+    let oldLine = 0;
+    let newLine = 0;
+    for (let i = 0; i < hunkStart; i++) {
+      if (edits[i].type === 'equal' || edits[i].type === 'delete') oldLine++;
+      if (edits[i].type === 'equal' || edits[i].type === 'insert') newLine++;
+    }
+
+    const oldStart = oldLine + 1;
+    const newStart = newLine + 1;
+    let oldCount = 0;
+    let newCount = 0;
+
+    for (let i = hunkStart; i <= hunkEnd; i++) {
+      const edit = edits[i];
+      switch (edit.type) {
+        case 'equal':
+          lines.push(` ${edit.line}`);
+          oldCount++;
+          newCount++;
+          break;
+        case 'delete':
+          lines.push(`-${edit.line}`);
+          oldCount++;
+          break;
+        case 'insert':
+          lines.push(`+${edit.line}`);
+          newCount++;
+          break;
+      }
+    }
+
+    hunks.push({ oldStart, oldCount, newStart, newCount, lines });
+  }
+
+  return hunks;
+}
+
+export interface UnifiedDiffOptions {
+  oldContent: string;
+  newContent: string;
+  oldName: string;
+  newName: string;
+  color?: boolean;
+}
+
+/**
+ * Produce a unified diff string between two texts.
+ * Returns empty string if the contents are identical.
+ */
+export function unifiedDiff(opts: UnifiedDiffOptions): string {
+  const { oldContent, newContent, oldName, newName, color = true } = opts;
+
+  if (oldContent === newContent) return '';
+
+  const oldLines = oldContent.split('\n');
+  const newLines = newContent.split('\n');
+
+  // Remove trailing empty element from split if content ends with \n
+  // (avoids a phantom empty-line diff)
+  if (oldLines.length > 0 && oldLines[oldLines.length - 1] === '') oldLines.pop();
+  if (newLines.length > 0 && newLines[newLines.length - 1] === '') newLines.pop();
+
+  const edits = myersDiff(oldLines, newLines);
+  const hunks = buildHunks(edits);
+
+  if (hunks.length === 0) return '';
+
+  const RED = color ? '\x1b[31m' : '';
+  const GREEN = color ? '\x1b[32m' : '';
+  const CYAN = color ? '\x1b[36m' : '';
+  const BOLD = color ? '\x1b[1m' : '';
+  const RESET = color ? '\x1b[0m' : '';
+
+  let output = '';
+  output += `${BOLD}diff --git a/${oldName} b/${newName}${RESET}\n`;
+  output += `${BOLD}--- a/${oldName}${RESET}\n`;
+  output += `${BOLD}+++ b/${newName}${RESET}\n`;
+
+  for (const hunk of hunks) {
+    output += `${CYAN}@@ -${hunk.oldStart},${hunk.oldCount} +${hunk.newStart},${hunk.newCount} @@${RESET}\n`;
+    for (const line of hunk.lines) {
+      if (line.startsWith('+')) {
+        output += `${GREEN}${line}${RESET}\n`;
+      } else if (line.startsWith('-')) {
+        output += `${RED}${line}${RESET}\n`;
+      } else {
+        output += `${line}\n`;
+      }
+    }
+  }
+
+  return output;
+}
+
+/**
+ * Compute --stat summary for a single file diff.
+ * Returns { insertions, deletions } counts.
+ */
+export function diffStat(oldContent: string, newContent: string): { insertions: number; deletions: number } {
+  if (oldContent === newContent) return { insertions: 0, deletions: 0 };
+
+  const oldLines = oldContent.split('\n');
+  const newLines = newContent.split('\n');
+  if (oldLines.length > 0 && oldLines[oldLines.length - 1] === '') oldLines.pop();
+  if (newLines.length > 0 && newLines[newLines.length - 1] === '') newLines.pop();
+
+  const edits = myersDiff(oldLines, newLines);
+
+  let insertions = 0;
+  let deletions = 0;
+  for (const edit of edits) {
+    if (edit.type === 'insert') insertions++;
+    if (edit.type === 'delete') deletions++;
+  }
+  return { insertions, deletions };
+}

--- a/src/git/git-commands.test.ts
+++ b/src/git/git-commands.test.ts
@@ -69,7 +69,7 @@ describe('GitCommands', () => {
     expect(commitResult.stdout).toContain('Initial commit');
   });
 
-  it('stages deleted files with git add .', async () => {
+  it('git add . does NOT stage deletions (use -A for that)', async () => {
     await git.execute(['init'], '/project');
     await vfs.writeFile('/project/file.txt', 'content');
     await git.execute(['add', 'file.txt'], '/project');
@@ -81,7 +81,8 @@ describe('GitCommands', () => {
     const matrix = await isoGit.statusMatrix({ fs: vfs.getLightningFS(), dir: '/project' });
     const row = matrix.find((r) => r[0] === 'file.txt');
     expect(row).toBeTruthy();
-    expect(row?.slice(1)).toEqual([1, 0, 0]); // staged deletion
+    // git add . should NOT stage deletions — file remains as unstaged deletion
+    expect(row?.slice(1)).toEqual([1, 0, 1]); // unstaged deletion
   });
 
   it('shows commit log', async () => {
@@ -253,7 +254,7 @@ describe('GitCommands', () => {
       await git.execute(['add', 'file.txt'], '/project');
       await git.execute(['commit', '-m', 'initial'], '/project');
       await vfs.rm('/project/file.txt');
-      await git.execute(['add', '.'], '/project');
+      await git.execute(['add', '-A'], '/project');
 
       const result = await git.execute(['status', '--short'], '/project');
       expect(result.exitCode).toBe(0);
@@ -1900,6 +1901,183 @@ describe('GitCommands', () => {
       const result = await git.execute(['config'], '/project');
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('usage');
+    });
+
+    it('--global get does not read repo config', async () => {
+      await git.execute(['init'], '/project');
+      // Set a value in repo config only
+      await git.execute(['config', 'user.name', 'Repo User'], '/project');
+
+      // --global get should NOT find repo-level config
+      const result = await git.execute(['config', '--global', 'user.name'], '/project');
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe('');
+    });
+  });
+
+  describe('PR review fixes', () => {
+    it('#1: reset --hard preserves untracked files', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/tracked.txt', 'v1');
+      await git.execute(['add', 'tracked.txt'], '/project');
+      await git.execute(['commit', '-m', 'first'], '/project');
+
+      const firstCommit = await isoGit.resolveRef({
+        fs: vfs.getLightningFS(),
+        dir: '/project',
+        ref: 'HEAD',
+      });
+
+      await vfs.writeFile('/project/tracked.txt', 'v2');
+      await git.execute(['add', 'tracked.txt'], '/project');
+      await git.execute(['commit', '-m', 'second'], '/project');
+
+      // Create an untracked file
+      await vfs.writeFile('/project/untracked.txt', 'should survive');
+
+      await git.execute(['reset', '--hard', firstCommit], '/project');
+
+      // Untracked file should still exist
+      const exists = await vfs.exists('/project/untracked.txt');
+      expect(exists).toBe(true);
+      const content = await vfs.readTextFile('/project/untracked.txt');
+      expect(content).toBe('should survive');
+
+      // Tracked file should be reverted
+      const trackedContent = await vfs.readTextFile('/project/tracked.txt');
+      expect(trackedContent).toBe('v1');
+    });
+
+    it('#2: stash drop removes deep stash entries correctly', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'original');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      // Create 3 stash entries
+      await vfs.writeFile('/project/file.txt', 'change1');
+      await git.execute(['stash'], '/project');
+
+      await vfs.writeFile('/project/file.txt', 'change2');
+      await git.execute(['stash'], '/project');
+
+      await vfs.writeFile('/project/file.txt', 'change3');
+      await git.execute(['stash'], '/project');
+
+      // Verify we have 3 stash entries
+      const listBefore = await git.execute(['stash', 'list'], '/project');
+      expect(listBefore.stdout).toContain('stash@{0}');
+      expect(listBefore.stdout).toContain('stash@{1}');
+      expect(listBefore.stdout).toContain('stash@{2}');
+
+      // Drop the middle entry (stash@{1})
+      const dropResult = await git.execute(['stash', 'drop', 'stash@{1}'], '/project');
+      expect(dropResult.exitCode).toBe(0);
+
+      // Should now have only 2 entries
+      const listAfter = await git.execute(['stash', 'list'], '/project');
+      const lines = listAfter.stdout.trim().split('\n').filter(Boolean);
+      expect(lines).toHaveLength(2);
+    });
+
+    it('#3: default diff shows only unstaged changes (index vs workdir)', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'line1\nline2\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      // Stage a change
+      await vfs.writeFile('/project/file.txt', 'line1\nstaged-change\n');
+      await git.execute(['add', 'file.txt'], '/project');
+
+      // Default diff should show nothing (workdir matches index)
+      const result1 = await git.execute(['diff'], '/project');
+      expect(result1.stdout).toBe('');
+
+      // Make another change without staging
+      await vfs.writeFile('/project/file.txt', 'line1\nstaged-change\nunstaged-line\n');
+
+      // Default diff should show only the unstaged change
+      const result2 = await git.execute(['diff'], '/project');
+      expect(result2.stdout).toContain('+unstaged-line');
+      expect(result2.stdout).not.toContain('+staged-change');
+
+      // --staged should show the staged change
+      const result3 = await git.execute(['diff', '--staged'], '/project');
+      expect(result3.stdout).toContain('+staged-change');
+      expect(result3.stdout).not.toContain('+unstaged-line');
+    });
+
+    it('#4: expandCombinedFlags preserves -m=msg style args', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'original content');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      await vfs.writeFile('/project/file.txt', 'modified');
+      await git.execute(['add', 'file.txt'], '/project');
+
+      // Use -m=message syntax
+      const result = await git.execute(['commit', '-m=inline message'], '/project');
+      // The parseArg method handles --flag=value for long flags.
+      // For short flags, -m=inline message should be left as-is by expandCombinedFlags
+      // and then handled by parseArg's = handling
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('inline message');
+    });
+
+    it('#7: git show resolves short OIDs', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'content');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'First commit'], '/project');
+
+      const logResult = await git.execute(['rev-parse', 'HEAD'], '/project');
+      const fullSha = logResult.stdout.trim();
+      const shortSha = fullSha.slice(0, 7);
+
+      const result = await git.execute(['show', shortSha], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('First commit');
+      expect(result.stdout).toContain(`commit ${fullSha}`);
+    });
+
+    it('#8: git add . does not stage deletions', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/keep.txt', 'keep');
+      await vfs.writeFile('/project/delete-me.txt', 'will be deleted');
+      await git.execute(['add', '.'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      // Delete a file and create a new one
+      await vfs.rm('/project/delete-me.txt');
+      await vfs.writeFile('/project/new.txt', 'new file');
+
+      // git add . should stage the new file but NOT the deletion
+      await git.execute(['add', '.'], '/project');
+
+      const matrix = await isoGit.statusMatrix({ fs: vfs.getLightningFS(), dir: '/project' });
+      const deletedRow = matrix.find((r) => r[0] === 'delete-me.txt');
+      const newRow = matrix.find((r) => r[0] === 'new.txt');
+
+      // Deletion should NOT be staged (still shows as unstaged deletion)
+      expect(deletedRow?.slice(1)).toEqual([1, 0, 1]);
+      // New file should be staged
+      expect(newRow?.slice(1)).toEqual([0, 2, 2]);
+    });
+
+    it('#8: git add -A DOES stage deletions', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'content');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      await vfs.rm('/project/file.txt');
+      await git.execute(['add', '-A'], '/project');
+
+      const matrix = await isoGit.statusMatrix({ fs: vfs.getLightningFS(), dir: '/project' });
+      const row = matrix.find((r) => r[0] === 'file.txt');
+      expect(row?.slice(1)).toEqual([1, 0, 0]); // staged deletion
     });
   });
 });

--- a/src/git/git-commands.ts
+++ b/src/git/git-commands.ts
@@ -339,7 +339,7 @@ Available commands:
       };
     }
 
-    if (allFlag || paths.includes('.')) {
+    if (allFlag) {
       // Stage ALL changes (new, modified, deleted)
       const matrix = await git.statusMatrix({ fs: this.lfs, dir: cwd });
       for (const [file, , workdir, stage] of matrix) {
@@ -349,6 +349,15 @@ Available commands:
         } else {
           await git.add({ fs: this.lfs, dir: cwd, filepath: file, force });
         }
+      }
+    } else if (paths.includes('.')) {
+      // Stage new and modified files, but NOT deletions (unlike -A/--all)
+      const matrix = await git.statusMatrix({ fs: this.lfs, dir: cwd });
+      for (const [file, , workdir, stage] of matrix) {
+        if (workdir === stage) continue;
+        // Skip deletions — git add . does not stage removals
+        if (workdir === 0) continue;
+        await git.add({ fs: this.lfs, dir: cwd, filepath: file, force });
       }
     } else if (updateFlag) {
       // Stage modifications and deletions of tracked files only (no new/untracked files)
@@ -586,7 +595,8 @@ Available commands:
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
       // Match combined flags like -am, -avm, etc. (single dash, multiple letters)
-      if (arg.startsWith('-') && !arg.startsWith('--') && arg.length > 2) {
+      // Skip args containing '=' (e.g., -m=msg) to avoid corrupting them
+      if (arg.startsWith('-') && !arg.startsWith('--') && arg.length > 2 && !arg.includes('=')) {
         const flags = arg.slice(1);
         for (const ch of flags) {
           result.push(`-${ch}`);
@@ -940,42 +950,44 @@ Available commands:
         },
       });
     } else {
-      // Default: compare HEAD tree vs workdir by reading files directly
-      // Get all tracked files from HEAD
-      let headFiles: string[] = [];
-      try {
-        headFiles = await git.listFiles({ fs: this.lfs, dir: cwd, ref: 'HEAD' });
-      } catch { /* no HEAD yet */ }
+      // Default: compare index (stage) vs workdir — shows only unstaged changes
+      // Collect all index entries with their OIDs
+      const indexEntries = new Map<string, string>();
+      await git.walk({
+        fs: this.lfs,
+        dir: cwd,
+        trees: [git.STAGE()],
+        map: async (filepath, [entry]) => {
+          if (filepath === '.' || filepath.startsWith('.git') || !entry) return undefined;
+          const type = await entry.type();
+          if (type !== 'blob') return undefined;
+          const oid = await entry.oid();
+          if (oid) indexEntries.set(filepath, oid);
+          return undefined;
+        },
+      });
 
-      // Also get files from the index (for newly added files not yet committed)
-      const indexFiles = await git.listFiles({ fs: this.lfs, dir: cwd });
-      const allFiles = new Set([...headFiles, ...indexFiles]);
-
-      const headOid = headFiles.length > 0
-        ? await git.resolveRef({ fs: this.lfs, dir: cwd, ref: 'HEAD' })
-        : undefined;
-
-      for (const file of allFiles) {
-        // Read HEAD content
+      // Compare each index entry with workdir content directly
+      // (bypasses statusMatrix stat-caching issues for same-length modifications)
+      for (const [file, stageOid] of indexEntries) {
         let oldText = '';
-        if (headOid && headFiles.includes(file)) {
-          try {
-            const { blob } = await git.readBlob({ fs: this.lfs, dir: cwd, oid: headOid, filepath: file });
-            oldText = new TextDecoder().decode(blob);
-          } catch { /* not in HEAD */ }
-        }
+        try {
+          const { blob } = await git.readBlob({ fs: this.lfs, dir: cwd, oid: stageOid });
+          oldText = new TextDecoder().decode(blob);
+        } catch { /* not readable */ }
 
-        // Read workdir content directly from VFS
         let newText = '';
         try {
           newText = await this.options.fs.readTextFile(`${cwd}/${file}`);
         } catch { /* file deleted in workdir */ }
 
-        // Only include if content actually differs
         if (oldText !== newText) {
           changes.push({ filepath: file, oldContent: oldText, newContent: newText });
         }
       }
+
+      // Also check for tracked files deleted in workdir but still in index
+      // (handled above since deleted workdir files would have newText = '')
     }
 
     if (changes.length === 0) {
@@ -1151,11 +1163,16 @@ Available commands:
     try {
       oid = await git.resolveRef({ fs: this.lfs, dir: cwd, ref: commitRef });
     } catch {
-      return {
-        stdout: '',
-        stderr: `fatal: bad object ${commitRef}\n`,
-        exitCode: 128,
-      };
+      // Try expanding as a short OID
+      try {
+        oid = await git.expandOid({ fs: this.lfs, dir: cwd, oid: commitRef });
+      } catch {
+        return {
+          stdout: '',
+          stderr: `fatal: bad object ${commitRef}\n`,
+          exitCode: 128,
+        };
+      }
     }
 
     const { commit } = await git.readCommit({ fs: this.lfs, dir: cwd, oid });
@@ -1706,14 +1723,15 @@ Available commands:
       };
     }
 
-    // Try repo config first, then global
-    let result = await git.getConfig({ fs: this.lfs, dir: cwd, path });
-    if (!result && !globalFlag) {
-      // Fall back to global config
+    // When --global, only read global config; otherwise try repo first, then global
+    let result: string | undefined;
+    if (globalFlag) {
       result = await this.getGlobalConfig(path);
-    }
-    if (globalFlag && !result) {
-      result = await this.getGlobalConfig(path);
+    } else {
+      result = await git.getConfig({ fs: this.lfs, dir: cwd, path });
+      if (!result) {
+        result = await this.getGlobalConfig(path);
+      }
     }
 
     return {
@@ -1993,8 +2011,9 @@ Available commands:
     }
 
     // --mixed (default) or --hard: reset index to match the target commit
-    const indexFiles = await git.listFiles({ fs: this.lfs, dir: cwd });
-    for (const file of indexFiles) {
+    // Collect previously tracked files before resetting index (needed for --hard cleanup)
+    const previouslyTracked = new Set(await git.listFiles({ fs: this.lfs, dir: cwd }));
+    for (const file of previouslyTracked) {
       await git.remove({ fs: this.lfs, dir: cwd, filepath: file });
     }
     await this.resetIndexToCommit(cwd, targetOid);
@@ -2004,7 +2023,7 @@ Available commands:
     }
 
     // --hard: also restore workdir to match the target commit
-    await this.resetWorkdirToCommit(cwd, targetOid);
+    await this.resetWorkdirToCommit(cwd, targetOid, previouslyTracked);
 
     return { stdout: `HEAD is now at ${targetOid.slice(0, 7)}\n`, stderr: '', exitCode: 0 };
   }
@@ -2035,7 +2054,7 @@ Available commands:
     }
   }
 
-  private async resetWorkdirToCommit(cwd: string, oid: string): Promise<void> {
+  private async resetWorkdirToCommit(cwd: string, oid: string, previouslyTracked: Set<string>): Promise<void> {
     const targetFiles = new Set<string>();
     const { tree } = await git.readTree({ fs: this.lfs, dir: cwd, oid });
     await this.collectTreeFiles(cwd, tree, '', targetFiles);
@@ -2049,10 +2068,10 @@ Available commands:
       await this.options.fs.writeFile(`${cwd}/${filepath}`, blob);
     }
 
-    // Remove workdir files not in the target commit
-    const matrix = await git.statusMatrix({ fs: this.lfs, dir: cwd });
-    for (const [file, , workdir] of matrix) {
-      if (workdir !== 0 && !targetFiles.has(file)) {
+    // Remove previously-tracked workdir files not in the target commit
+    // Only remove files that were tracked before the reset — skip untracked files
+    for (const file of previouslyTracked) {
+      if (!targetFiles.has(file)) {
         try {
           await this.options.fs.rm(`${cwd}/${file}`);
         } catch {
@@ -2306,6 +2325,18 @@ Available commands:
         await this.options.fs.mkdir(`${cwd}/${filepath.slice(0, slashIdx)}`, { recursive: true });
       }
       await this.options.fs.writeFile(`${cwd}/${filepath}`, blob);
+      // Restore index state: stage files that differ from HEAD
+      const blobText = new TextDecoder().decode(blob);
+      let headText: string | undefined;
+      if (headFileSet.has(filepath)) {
+        try {
+          const { blob: headBlob } = await git.readBlob({ fs: this.lfs, dir: cwd, oid: headOid, filepath });
+          headText = new TextDecoder().decode(headBlob);
+        } catch { /* not in HEAD */ }
+      }
+      if (headText !== blobText) {
+        await git.add({ fs: this.lfs, dir: cwd, filepath });
+      }
     }
 
     for (const filepath of headFileSet) {
@@ -2364,34 +2395,41 @@ Available commands:
       return { stdout: `Dropped refs/stash@{0} (${topOid.slice(0, 7)})\n`, stderr: '', exitCode: 0 };
     }
 
+    // Collect the stash chain from top to the entry just before the dropped one
+    const chain: { oid: string; commit: git.CommitObject }[] = [];
     let current = topOid;
-    for (let i = 0; i < index - 1; i++) {
+    for (let i = 0; i < index; i++) {
       const { commit } = await git.readCommit({ fs: this.lfs, dir: cwd, oid: current });
+      chain.push({ oid: current, commit });
       if (commit.parent.length <= 1) {
         return { stdout: '', stderr: `error: stash@{${index}} not found\n`, exitCode: 1 };
       }
       current = commit.parent[1];
     }
 
-    const { commit: beforeDrop } = await git.readCommit({ fs: this.lfs, dir: cwd, oid: current });
-    if (beforeDrop.parent.length <= 1) {
-      return { stdout: '', stderr: `error: stash@{${index}} not found\n`, exitCode: 1 };
-    }
-
-    const dropOid = beforeDrop.parent[1];
+    // `current` is now the stash entry to drop
+    const dropOid = current;
     const { commit: droppedCommit } = await git.readCommit({ fs: this.lfs, dir: cwd, oid: dropOid });
     const nextStash = droppedCommit.parent.length > 1 ? droppedCommit.parent[1] : undefined;
 
-    const newParents = [beforeDrop.parent[0]];
-    if (nextStash) newParents.push(nextStash);
-    const newCommitOid = await git.writeCommit({
-      fs: this.lfs,
-      dir: cwd,
-      commit: { ...beforeDrop, parent: newParents },
-    });
+    // Rewrite the chain from the entry just before the drop backwards to the top
+    let newChild = nextStash;
+    for (let i = chain.length - 1; i >= 0; i--) {
+      const entry = chain[i];
+      const newParents = [entry.commit.parent[0]];
+      if (newChild) newParents.push(newChild);
+      newChild = await git.writeCommit({
+        fs: this.lfs,
+        dir: cwd,
+        commit: { ...entry.commit, parent: newParents },
+      });
+    }
 
-    if (current === topOid) {
-      await git.writeRef({ fs: this.lfs, dir: cwd, ref: 'refs/stash', value: newCommitOid, force: true });
+    // newChild is now the rewritten top stash entry
+    if (newChild) {
+      await git.writeRef({ fs: this.lfs, dir: cwd, ref: 'refs/stash', value: newChild, force: true });
+    } else {
+      await this.deleteRef(cwd, 'refs/stash');
     }
 
     return { stdout: `Dropped refs/stash@{${index}} (${dropOid.slice(0, 7)})\n`, stderr: '', exitCode: 0 };


### PR DESCRIPTION
## Summary
- **Fixed `git diff`** — was showing headers only, now produces real unified diffs (the #1 most used command at 389 invocations)
- **Added 10 new commands**: `show`, `reset`, `stash`, `merge`, `rm`, `mv`, `tag`, `ls-files`, `show-ref` plus major enhancements to `log`, `status`, `push`, `checkout`, `add`, `commit`, `config`
- **118 git tests** (up from ~30), all 361 project tests passing, typecheck clean

## Motivation
Analysis of 2000+ real AI agent git command invocations revealed significant gaps in slicc's git implementation. The top issues were:
1. `git diff` was broken (389 uses, showed no content)
2. `git show` was missing (76 uses)
3. `git stash` was missing (38 uses)
4. `git merge` was missing (24 uses)
5. Key flags missing on `log`, `status`, `add`, `commit`, `push`, `checkout`

## Changes by command

| Command | Changes |
|---------|---------|
| `diff` | Full unified diffs, `--staged`, `--name-only`, `--stat`, commit-to-commit comparison |
| `log` | `--format`, `--stat`, `--all`, `--author`, `--grep`, `--follow`, `--reverse` |
| `show` | New — commit inspection, `<sha>:<path>`, `--stat`, `--format` |
| `reset` | New — `--soft`, `--mixed`, `--hard`, file unstaging |
| `status` | `--short`/`-s`, `--porcelain` |
| `push` | `-u`/`--set-upstream` |
| `stash` | New — `push`, `pop`, `list`, `drop`, `show` |
| `merge` | New — fast-forward, `--no-ff`, `--ff-only`, conflict detection |
| `rm` | New — `--cached`, `-r` |
| `mv` | New — file rename tracking |
| `checkout` | File restoration with `-- <file>` |
| `add` | `-A`/`--all`, `-u`/`--update` |
| `commit` | `-a`, `--allow-empty`, `-am` |
| `tag` | New — create/delete/list, annotated tags, `-l <pattern>` |
| `ls-files` | New — `--cached`, `--modified`, `--others`, `--deleted` |
| `show-ref` | New — `--heads`, `--tags`, pattern filter |
| `config` | `--list`, `--unset`, `--global` |

## Test plan
- [x] `npm run test -- src/git/git-commands.test.ts` — 118 tests pass
- [x] `npm run test` — 361 total tests pass
- [x] `npm run typecheck` — clean on both tsconfig targets
- [ ] Manual verification in browser with `npm run dev:full`

🤖 Generated with [Claude Code](https://claude.com/claude-code)