### PR TITLE
fix: Chrome extension compatibility for HAR filter and ImageMagick WASM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,10 @@ WasmShell wraps just-bash 2.11.7 (WASM Bash interpreter) and connects it to Virt
 - `sqlite3` — SQLite database operations
 - `webhook` — Manage webhooks for event-driven automation
 - `mount` — Mount a local directory into the virtual filesystem via the File System Access API
+- `convert` — ImageMagick-style image conversion (resize, rotate, crop, quality) via `@imagemagick/magick-wasm`
 - `commands` — Show all available commands (type `commands` in terminal)
 
-**Extension CSP workaround**: `node -e` in extension mode routes through the sandbox iframe (CSP blocks `AsyncFunction` constructor on extension pages). Python uses bundled Pyodide loaded from `chrome.runtime.getURL('pyodide/')`.
+**Extension CSP workaround**: `node -e` in extension mode routes through the sandbox iframe (CSP blocks `AsyncFunction` constructor on extension pages). Python uses bundled Pyodide loaded from `chrome.runtime.getURL('pyodide/')`. ImageMagick WASM is fetched as bytes from `chrome.runtime.getURL('magick.wasm')` since `initializeImageMagick` rejects `chrome-extension://` URLs.
 
 ### Skills System (src/skills/, src/scoops/skills.ts)
 Two complementary skill systems:
@@ -117,6 +118,8 @@ CDPTransport interface (`transport.ts`) abstracts the underlying protocol. Two i
 - **DebuggerClient** (`debugger-client.ts`): Uses `chrome.debugger` API in extension mode. Intercepts `Target.*` commands and maps them to `chrome.tabs`/`chrome.debugger`. Manages tab attach/detach lifecycle with session-to-tab mapping.
 
 BrowserAPI: high-level Playwright-style API built on either transport (listPages, navigate, screenshot, evaluate, click, type, waitForSelector, getAccessibilityTree). Auto-selects transport based on extension detection. TargetInfo and PageInfo types include `active` field (boolean, extension mode only) to identify the user's currently focused tab, enabling intelligent tool auto-dispatch.
+
+**HarRecorder** (`har-recorder.ts`): Records network traffic from browser tabs as HAR 1.2 files. Supports user-provided JS filter functions (`(entry) => false | true | object`). Filter application is deferred to snapshot save time (batch, not per-entry) to support extension mode — in extensions, filter code is sent to the sandbox iframe (CSP-exempt) via `postMessage`; in CLI mode, compiled directly. Snapshots saved to `/recordings/{id}/` on navigation and recording stop. Graceful fallback: filter errors return unfiltered entries.
 
 ### Tools (src/tools/)
 All tools use the legacy ToolDefinition interface (name, description, inputSchema, execute). Active agent tools: bash, read_file, write_file, edit_file, browser (with sub-actions), javascript. Factory functions take their dependency (VirtualFS, WasmShell, or BrowserAPI).
@@ -194,11 +197,12 @@ Delegation:
 ## Key Conventions
 
 - **Two type systems**: Legacy ToolDefinition/ToolResult (in src/tools/) and pi-compatible AgentTool/AgentToolResult (in src/core/). The adapter in tool-adapter.ts bridges them.
-- **Tests are colocated**: foo.test.ts next to foo.ts. Vitest with globals: true, environment: node. New pure-logic code (utilities, adapters, data transformations) should always have tests. DOM-dependent code (UI panels, layout) and chrome.* API code (DebuggerClient) are acceptable to skip in Node tests but should be manually verified. Use `fake-indexeddb/auto` for tests that need VFS. Current count: 396 tests across 28 files.
+- **Tests are colocated**: foo.test.ts next to foo.ts. Vitest with globals: true, environment: node. New pure-logic code (utilities, adapters, data transformations) should always have tests. DOM-dependent code (UI panels, layout) and chrome.* API code (DebuggerClient) are acceptable to skip in Node tests but should be manually verified. Use `fake-indexeddb/auto` for tests that need VFS. Current count: 610 tests across 34 files.
 - **Logging**: createLogger('namespace') from src/core/logger.ts. Level-filtered, DEBUG in dev, ERROR in prod. Uses __DEV__ global (set by Vite define).
 - **Node shims**: src/shims/empty.ts stubs out node:zlib and node:module for the browser bundle (just-bash references them).
 - **Multi-provider auth**: Provider settings in `src/ui/provider-settings.ts`. Supports Anthropic (direct), Azure AI Foundry (Claude on Azure), Azure OpenAI (GPT), AWS Bedrock, and many more via pi-ai. Provider/API key/baseUrl stored in localStorage. Model resolved via `resolveCurrentModel()` with baseUrl override.
 - **Extension detection**: `typeof chrome !== 'undefined' && !!chrome?.runtime?.id` — used throughout to select CDP transport, layout mode, fetch strategy, JS tool sandbox mechanism, and Pyodide loading path.
+- **Dual-mode compatibility**: New features MUST work in both standalone CLI mode and Chrome extension mode. Extension CSP blocks dynamic eval and CDN fetches. Pattern: use sandbox iframe (`sandbox.html`) for dynamic code execution, `chrome.runtime.getURL()` + fetch for bundled WASM/assets, and three-branch detection (Node/Extension/Browser) for resource loading. Bundle extension assets in `vite.config.extension.ts` `closeBundle` hook. Always test in both modes.
 
 ## Git Integration (src/git/)
 Git support via isomorphic-git with LightningFS as the backing store. GitCommands class provides CLI-like interface for git operations (init, clone, add, commit, status, log, branch, checkout, diff, remote, fetch, pull, push, config, rev-parse). Registered as a custom command in just-bash so it works in compound commands and via the bash tool.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ A browser-based coding agent that runs as a **Chrome extension** or with a thin 
 - :file_folder: **Virtual Filesystem** — OPFS + IndexedDB-backed filesystem right in the browser, with folder ZIP download
 - :shell: **WebAssembly Bash Shell** — real Bash via [just-bash](https://github.com/nicolo-ribaudo/just-bash) compiled to WASM
 - :git: **Git Support** — clone, commit, push, pull via [isomorphic-git](https://isomorphic-git.org/) (see [available commands](#git-commands))
-- :robot: **Browser Automation** — screenshots (full page / element / saved to VFS), inline image display, navigation, JS eval, element clicking via Chrome DevTools Protocol (chrome.debugger in extension, WebSocket in CLI). Auto-detects user's active tab.
+- :robot: **Browser Automation** — screenshots (full page / element / saved to VFS), inline image display, navigation, JS eval, element clicking via Chrome DevTools Protocol (chrome.debugger in extension, WebSocket in CLI). Auto-detects user's active tab. HAR recording with user-defined JS filters.
 - :earth_americas: **VFS Web Preview** — serve agent-created HTML/CSS/JS apps in real browser tabs via a Service Worker that reads directly from the virtual filesystem. The agent can build a UI, preview it, screenshot it, and iterate — all without leaving Chrome.
+- :art: **Image Processing** — `convert` command for resize, rotate, crop, and quality adjustment via ImageMagick WASM
 - :pencil2: **File Operations** — read, write, edit files with syntax-aware tools
 - :mag: **Shell Search Commands** — use `grep`, `find`, and `rg` via the bash shell
 - :globe_with_meridians: **Networking** — curl and fetch support with binary-safe downloads
@@ -166,9 +167,9 @@ Source layout:
 | `src/core/` | Agent types, tool registry, context compaction, session management |
 | `src/tools/` | Tool implementations (file ops, search, browser, javascript) |
 | `src/fs/` | Virtual filesystem (IndexedDB/LightningFS) + RestrictedFS |
-| `src/shell/` | WebAssembly Bash shell + supplemental commands (node, python, sqlite) |
+| `src/shell/` | WebAssembly Bash shell + supplemental commands (node, python, sqlite, convert, skill, mount, webhook) |
 | `src/git/` | Git via isomorphic-git (clone, commit, push, pull, etc.) |
-| `src/cdp/` | Chrome DevTools Protocol client (WebSocket + chrome.debugger) |
+| `src/cdp/` | Chrome DevTools Protocol client (WebSocket + chrome.debugger), HAR recorder |
 | `src/cli/` | CLI server — Chrome launch, CDP proxy, Express |
 | `src/extension/` | Chrome extension service worker and type declarations |
 

--- a/sandbox.html
+++ b/sandbox.html
@@ -105,6 +105,35 @@ addEventListener('message', async (e) => {
     return;
   }
 
+  if (msg.type === 'har_filter') {
+    // Apply HAR filter function to entries (sandbox is CSP-exempt by design)
+    try {
+      const filterFn = new Function('entry', `return (${msg.filterCode})(entry);`);
+      const filtered = [];
+      for (const entry of msg.entries) {
+        try {
+          const result = filterFn(entry);
+          if (result === false) continue;
+          if (typeof result === 'object' && result !== null) {
+            filtered.push(result);
+          } else {
+            filtered.push(entry);
+          }
+        } catch (filterErr) {
+          console.warn('[har_filter] Error filtering entry:', entry?.request?.url, filterErr);
+          filtered.push(entry);
+        }
+      }
+      parent.postMessage({ type: 'har_filter_result', id: msg.id, entries: filtered }, '*');
+    } catch (err) {
+      parent.postMessage({
+        type: 'har_filter_result', id: msg.id,
+        error: err instanceof Error ? err.message : String(err),
+      }, '*');
+    }
+    return;
+  }
+
   if (msg.type === 'exec') {
     const logs = [];
     const origLog = console.log;

--- a/src/cdp/har-recorder.test.ts
+++ b/src/cdp/har-recorder.test.ts
@@ -107,10 +107,12 @@ describe('HarRecorder', () => {
       expect(exists).toBe(true);
     });
 
-    it('throws on invalid filter function', async () => {
-      await expect(
-        recorder.startRecording('target-1', 'session-1', 'invalid syntax {{{'),
-      ).rejects.toThrow('Invalid filter function');
+    it('stores invalid filter code without throwing (deferred to save time)', async () => {
+      // Invalid filter code is stored as-is; compilation error surfaces at save time
+      const recordingId = await recorder.startRecording('target-1', 'session-1', 'invalid syntax {{{');
+      expect(recordingId).toBeTruthy();
+      const session = recorder.getRecording(recordingId);
+      expect(session?.filterCode).toBe('invalid syntax {{{');
     });
 
     it('accepts valid filter function', async () => {
@@ -212,14 +214,14 @@ describe('HarRecorder', () => {
   });
 
   describe('filter function', () => {
-    it('excludes entries when filter returns false', async () => {
+    it('excludes entries when filter returns false (applied at save time)', async () => {
       const recordingId = await recorder.startRecording(
         'target-1',
         'session-1',
         '(entry) => !entry.request.url.includes("exclude")',
       );
 
-      // Request that should be excluded
+      // Request that should be excluded by filter
       transport.emit('Network.requestWillBeSent', {
         sessionId: 'session-1',
         requestId: 'req-1',
@@ -239,11 +241,16 @@ describe('HarRecorder', () => {
 
       await new Promise((r) => setTimeout(r, 50));
 
+      // Entries are stored unfiltered
       const session = recorder.getRecording(recordingId);
-      expect(session?.entries).toHaveLength(0);
+      expect(session?.entries).toHaveLength(1);
+
+      // Filter is applied at save time — snapshot should be null (all filtered out)
+      const path = await recorder.saveSnapshot(session!, 'close');
+      expect(path).toBeNull();
     });
 
-    it('transforms entries when filter returns object', async () => {
+    it('transforms entries when filter returns object (applied at save time)', async () => {
       const recordingId = await recorder.startRecording(
         'target-1',
         'session-1',
@@ -269,8 +276,141 @@ describe('HarRecorder', () => {
 
       await new Promise((r) => setTimeout(r, 50));
 
+      // Entries stored unfiltered
       const session = recorder.getRecording(recordingId);
-      expect(session?.entries[0].request.url).toBe('transformed');
+      expect(session?.entries[0].request.url).toBe('https://example.com/original');
+
+      // Filter transforms at save time — verify in saved HAR file
+      const path = await recorder.saveSnapshot(session!, 'close');
+      expect(path).toBeTruthy();
+      const harContent = await fs.readFile(path!, { encoding: 'utf-8' });
+      const har = JSON.parse(harContent as string);
+      expect(har.log.entries[0].request.url).toBe('transformed');
+    });
+
+    it('returns unfiltered entries when filter code is invalid (graceful fallback)', async () => {
+      const recordingId = await recorder.startRecording(
+        'target-1',
+        'session-1',
+        'invalid syntax {{{',
+      );
+
+      transport.emit('Network.requestWillBeSent', {
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        timestamp: 1000,
+        request: { method: 'GET', url: 'https://example.com/api', headers: {} },
+      });
+      transport.emit('Network.responseReceived', {
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        response: { status: 200, statusText: 'OK', headers: {} },
+      });
+      transport.emit('Network.loadingFinished', {
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        timestamp: 1001,
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const session = recorder.getRecording(recordingId);
+      const path = await recorder.saveSnapshot(session!, 'close');
+      expect(path).toBeTruthy();
+      const harContent = await fs.readFile(path!, { encoding: 'utf-8' });
+      const har = JSON.parse(harContent as string);
+      expect(har.log.entries).toHaveLength(1);
+      expect(har.log.entries[0].request.url).toBe('https://example.com/api');
+    });
+
+    it('filters mixed entries, keeping only those that pass', async () => {
+      const recordingId = await recorder.startRecording(
+        'target-1',
+        'session-1',
+        '(entry) => !entry.request.url.includes("analytics")',
+      );
+
+      // Entry that should pass filter
+      transport.emit('Network.requestWillBeSent', {
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        timestamp: 1000,
+        request: { method: 'GET', url: 'https://example.com/api/data', headers: {} },
+      });
+      transport.emit('Network.responseReceived', {
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        response: { status: 200, statusText: 'OK', headers: {} },
+      });
+      transport.emit('Network.loadingFinished', {
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        timestamp: 1001,
+      });
+
+      // Entry that should be filtered out
+      transport.emit('Network.requestWillBeSent', {
+        sessionId: 'session-1',
+        requestId: 'req-2',
+        timestamp: 1002,
+        request: { method: 'GET', url: 'https://analytics.example.com/track', headers: {} },
+      });
+      transport.emit('Network.responseReceived', {
+        sessionId: 'session-1',
+        requestId: 'req-2',
+        response: { status: 200, statusText: 'OK', headers: {} },
+      });
+      transport.emit('Network.loadingFinished', {
+        sessionId: 'session-1',
+        requestId: 'req-2',
+        timestamp: 1003,
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const session = recorder.getRecording(recordingId);
+      expect(session?.entries).toHaveLength(2);
+
+      const path = await recorder.saveSnapshot(session!, 'close');
+      expect(path).toBeTruthy();
+      const harContent = await fs.readFile(path!, { encoding: 'utf-8' });
+      const har = JSON.parse(harContent as string);
+      expect(har.log.entries).toHaveLength(1);
+      expect(har.log.entries[0].request.url).toBe('https://example.com/api/data');
+    });
+
+    it('keeps entries when filter throws per-entry error', async () => {
+      const recordingId = await recorder.startRecording(
+        'target-1',
+        'session-1',
+        '(entry) => entry.nonexistent.property',
+      );
+
+      transport.emit('Network.requestWillBeSent', {
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        timestamp: 1000,
+        request: { method: 'GET', url: 'https://example.com', headers: {} },
+      });
+      transport.emit('Network.responseReceived', {
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        response: { status: 200, statusText: 'OK', headers: {} },
+      });
+      transport.emit('Network.loadingFinished', {
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        timestamp: 1001,
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const session = recorder.getRecording(recordingId);
+      const path = await recorder.saveSnapshot(session!, 'close');
+      expect(path).toBeTruthy();
+      const harContent = await fs.readFile(path!, { encoding: 'utf-8' });
+      const har = JSON.parse(harContent as string);
+      expect(har.log.entries).toHaveLength(1);
     });
   });
 

--- a/src/cdp/har-recorder.ts
+++ b/src/cdp/har-recorder.ts
@@ -134,7 +134,7 @@ export interface RecordingSession {
   id: string;
   targetId: string;
   sessionId: string;
-  filter?: HarFilterFn;
+  filterCode?: string;
   pendingRequests: Map<string, PendingRequest>;
   entries: HarEntry[];
   startTime: number;
@@ -167,26 +167,6 @@ export class HarRecorder {
   ): Promise<string> {
     const recordingId = `rec-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     
-    // Parse filter function if provided
-    let filter: HarFilterFn | undefined;
-    if (filterCode) {
-      try {
-        // Create filter function in agent context (synchronous)
-        // eslint-disable-next-line @typescript-eslint/no-implied-eval
-        const filterFn = new Function('entry', `return (${filterCode})(entry);`) as (entry: HarEntry) => boolean | HarEntry;
-        filter = (entry: HarEntry) => {
-          try {
-            return filterFn(entry);
-          } catch (err) {
-            log.error('Filter function error', { recordingId, error: err instanceof Error ? err.message : String(err) });
-            return true; // Keep entry on error
-          }
-        };
-      } catch (err) {
-        throw new Error(`Invalid filter function: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    }
-
     // Enable Network domain
     await this.client.send('Network.enable', {}, sessionId);
     await this.client.send('Page.enable', {}, sessionId);
@@ -202,7 +182,7 @@ export class HarRecorder {
       id: recordingId,
       targetId,
       sessionId,
-      filter,
+      filterCode,
       pendingRequests: new Map(),
       entries: [],
       startTime: Date.now(),
@@ -347,22 +327,9 @@ export class HarRecorder {
       // Body might not be available (e.g., for redirects)
     }
 
-    // Build and store HAR entry
+    // Build and store HAR entry (filtering applied at snapshot save, not per-entry)
     const entry = this.buildHarEntry(pending);
     if (entry) {
-      // Apply filter if defined
-      if (session.filter) {
-        const result = session.filter(entry);
-        if (result === false) {
-          session.pendingRequests.delete(requestId);
-          return;
-        }
-        if (typeof result === 'object' && result !== null) {
-          session.entries.push(result as HarEntry);
-          session.pendingRequests.delete(requestId);
-          return;
-        }
-      }
       session.entries.push(entry);
     }
 
@@ -478,6 +445,95 @@ export class HarRecorder {
   }
 
   /**
+   * Apply filter to entries. In extension mode, uses the sandbox iframe (CSP-exempt).
+   * In non-extension mode, compiles and applies directly.
+   * Returns entries unfiltered on error (graceful fallback).
+   */
+  private async applyFilter(entries: HarEntry[], filterCode: string): Promise<HarEntry[]> {
+    const isExtensionMode = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
+
+    if (isExtensionMode) {
+      // Route through sandbox iframe (CSP-exempt, allows Function constructor)
+      try {
+        let sandbox = document.querySelector('iframe[data-js-tool]') as HTMLIFrameElement | null;
+        if (!sandbox) {
+          sandbox = document.createElement('iframe');
+          sandbox.style.display = 'none';
+          sandbox.dataset.jsTool = 'true';
+          sandbox.src = chrome.runtime.getURL('sandbox.html');
+          document.body.appendChild(sandbox);
+          await Promise.race([
+            new Promise<void>(resolve => {
+              sandbox!.addEventListener('load', () => resolve(), { once: true });
+            }),
+            new Promise<void>((_, reject) => {
+              setTimeout(() => reject(new Error('Sandbox iframe failed to load')), 5000);
+            }),
+          ]);
+        }
+
+        const id = `har-filter-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const filtered = await new Promise<HarEntry[]>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            window.removeEventListener('message', handler);
+            reject(new Error('HAR filter sandbox timeout'));
+          }, 10000);
+
+          const handler = (event: MessageEvent) => {
+            if (event.data?.type === 'har_filter_result' && event.data.id === id) {
+              window.removeEventListener('message', handler);
+              clearTimeout(timeout);
+              if (event.data.error) {
+                reject(new Error(event.data.error));
+              } else {
+                resolve(event.data.entries);
+              }
+            }
+          };
+
+          window.addEventListener('message', handler);
+          sandbox!.contentWindow!.postMessage({
+            type: 'har_filter',
+            id,
+            entries,
+            filterCode,
+          }, '*');
+        });
+
+        return filtered;
+      } catch (err) {
+        log.error('HAR filter sandbox error, returning unfiltered', { error: err instanceof Error ? err.message : String(err) });
+        return entries;
+      }
+    } else {
+      // Non-extension: compile and apply directly (intentional dynamic eval for developer tool filter)
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval
+        const filterFn = new Function('entry', `return (${filterCode})(entry);`) as HarFilterFn;
+        const result: HarEntry[] = [];
+        for (const entry of entries) {
+          try {
+            const filterResult = filterFn(entry);
+            if (filterResult === false) continue;
+            if (typeof filterResult === 'object' && filterResult !== null) {
+              result.push(filterResult as HarEntry);
+            } else {
+              result.push(entry);
+            }
+          } catch (err) {
+            log.error('Filter function error on entry, keeping it', { error: err instanceof Error ? err.message : String(err) });
+            result.push(entry);
+          }
+        }
+        return result;
+      } catch (err) {
+        log.error('Failed to compile filter, returning unfiltered', { error: err instanceof Error ? err.message : String(err) });
+        return entries;
+      }
+    }
+  }
+
+  /**
    * Save a HAR snapshot with specific entries and URL (used to avoid race conditions).
    */
   private async saveSnapshotWithEntries(
@@ -491,6 +547,16 @@ export class HarRecorder {
       return null;
     }
 
+    // Apply filter at save time (deferred from per-entry to batch)
+    const filteredEntries = session.filterCode
+      ? await this.applyFilter(entries, session.filterCode)
+      : entries;
+
+    if (filteredEntries.length === 0) {
+      log.debug('All entries filtered out', { recordingId: session.id, trigger });
+      return null;
+    }
+
     session.snapshotCount++;
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const urlSlug = this.urlToSlug(url);
@@ -501,12 +567,12 @@ export class HarRecorder {
       log: {
         version: '1.2',
         creator: { name: 'SLICC HAR Recorder', version: '1.0.0' },
-        entries,
+        entries: filteredEntries,
       } as HarLog,
     };
 
     await this.fs.writeFile(path, JSON.stringify(har, null, 2));
-    log.debug('Saved HAR snapshot', { recordingId: session.id, path, entryCount: entries.length });
+    log.debug('Saved HAR snapshot', { recordingId: session.id, path, entryCount: filteredEntries.length });
 
     return path;
   }

--- a/src/shell/supplemental-commands/convert-command.ts
+++ b/src/shell/supplemental-commands/convert-command.ts
@@ -37,17 +37,26 @@ interface IMagickImage {
 
 let magickPromise: Promise<ImageMagickModule> | null = null;
 const MAGICK_WASM_CDN = 'https://cdn.jsdelivr.net/npm/@imagemagick/magick-wasm@0.0.38/dist/';
+const isExtension = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
 
 async function getMagick(): Promise<ImageMagickModule> {
   if (!magickPromise) {
     magickPromise = (async () => {
       const magickModule = await import('@imagemagick/magick-wasm');
-      const wasmBase = typeof window === 'undefined'
-        ? new URL('../../../node_modules/@imagemagick/magick-wasm/dist/', import.meta.url).toString()
-        : MAGICK_WASM_CDN;
-
-      const wasmUrl = new URL('magick.wasm', wasmBase);
-      await magickModule.initializeImageMagick(wasmUrl);
+      if (isExtension) {
+        // Chrome extension — fetch bundled WASM as bytes
+        // initializeImageMagick rejects chrome-extension:// URLs, so pass Uint8Array
+        const wasmUrl = chrome.runtime.getURL('magick.wasm');
+        const resp = await fetch(wasmUrl);
+        const wasmBytes = new Uint8Array(await resp.arrayBuffer());
+        await magickModule.initializeImageMagick(wasmBytes);
+      } else {
+        const wasmBase = typeof window === 'undefined'
+          ? new URL('../../../node_modules/@imagemagick/magick-wasm/dist/', import.meta.url).toString()
+          : MAGICK_WASM_CDN;
+        const wasmUrl = new URL('magick.wasm', wasmBase);
+        await magickModule.initializeImageMagick(wasmUrl);
+      }
 
       return magickModule as unknown as ImageMagickModule;
     })();

--- a/vite.config.extension.ts
+++ b/vite.config.extension.ts
@@ -87,6 +87,14 @@ export default defineConfig(({ mode }) => ({
         for (const file of ['pyodide.asm.js', 'pyodide.asm.wasm', 'pyodide.js', 'pyodide-lock.json', 'python_stdlib.zip']) {
           try { copyFileSync(resolve(pyodideSrc, file), resolve(pyodideDest, file)); } catch { /* optional file */ }
         }
+
+        // Bundle ImageMagick WASM for extension (CDN blocked by extension CSP)
+        try {
+          copyFileSync(
+            resolve(__dirname, 'node_modules/@imagemagick/magick-wasm/dist/magick.wasm'),
+            resolve(outDir, 'magick.wasm'),
+          );
+        } catch { /* @imagemagick/magick-wasm not installed */ }
       },
     },
   ],


### PR DESCRIPTION
## Summary

- **HAR filter**: Moved from synchronous per-entry `new Function()` compilation (CSP violation in extension) to deferred batch filtering at save time. Extension mode routes filter code through the sandbox iframe via `postMessage`; CLI mode compiles directly. Graceful fallback returns unfiltered entries on error.
- **ImageMagick WASM**: Added three-branch loading (Node/Extension/Browser). Extension fetches bundled `magick.wasm` as `Uint8Array` via `chrome.runtime.getURL()` since `initializeImageMagick` rejects `chrome-extension://` URLs. Build config copies WASM to `dist/extension/`.
- **Documentation**: Updated CLAUDE.md (HAR recorder, convert command, dual-mode convention, test count), README.md (features, directory descriptions), and auto-memory.

## Changed Files

| File | Change |
|------|--------|
| `src/cdp/har-recorder.ts` | Deferred filtering, `applyFilter()` with sandbox integration, iframe load timeout |
| `sandbox.html` | `har_filter` message handler with per-entry error logging |
| `src/cdp/har-recorder.test.ts` | 6 new/updated tests (17 total): deferred filter, mixed entries, error fallback |
| `src/shell/supplemental-commands/convert-command.ts` | Three-branch WASM loading, fetch as bytes for extension |
| `vite.config.extension.ts` | Copy `magick.wasm` (~14MB) to `dist/extension/` |
| `CLAUDE.md` | HAR recorder docs, convert command, dual-mode convention |
| `README.md` | HAR recording, image processing features |

## Test plan

- [x] `npm test` — 610 tests pass (3 new filter tests added)
- [x] `npm run build` — CLI build succeeds
- [x] `npm run build:extension` — extension build succeeds
- [x] `dist/extension/magick.wasm` exists (~14MB)
- [x] Manual: `convert` command works in extension side panel
- [x] Manual: `new_recorded_tab` with filter param works in extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)