### PR TITLE
fix: resolve pre-existing TypeScript compilation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.tsbuildinfo
 .DS_STORE
 workspace/
+coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -6419,7 +6419,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7923,7 +7922,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src/shell/supplemental-commands/python-command.ts
+++ b/src/shell/supplemental-commands/python-command.ts
@@ -60,7 +60,7 @@ async function syncPyodideToVfs(fs: IFileSystem, pyodide: PyodideInterface, dirs
           await fs.mkdir(full, { recursive: true });
           await writeBack(full);
         } else {
-          const content = FS.readFile(full, { encoding: 'utf8' }) as string;
+          const content = new TextDecoder().decode(FS.readFile(full));
           await fs.mkdir(pyPath, { recursive: true });
           await fs.writeFile(full, content);
         }

--- a/src/shell/wasm-shell.ts
+++ b/src/shell/wasm-shell.ts
@@ -273,7 +273,6 @@ export class WasmShell {
     // Dynamic imports so this module can be loaded in Node.js (tests) without xterm
     const { Terminal } = await import('@xterm/xterm');
     const { FitAddon } = await import('@xterm/addon-fit');
-    // @ts-expect-error — Vite handles CSS imports at build time
     await import('@xterm/xterm/css/xterm.css');
 
     this.terminal = new Terminal({
@@ -810,7 +809,8 @@ export class WasmShell {
     this.clearMediaPreview();
 
     for (const item of items) {
-      const url = URL.createObjectURL(new Blob([item.bytes], { type: item.mimeType }));
+      const bytes = new Uint8Array(item.bytes);
+      const url = URL.createObjectURL(new Blob([bytes], { type: item.mimeType }));
       this.previewUrls.push(url);
 
       const previewItem = document.createElement('div');

--- a/src/ui/provider-settings.ts
+++ b/src/ui/provider-settings.ts
@@ -6,6 +6,19 @@
 
 import { getProviders, getModels, getModel } from '../core/index.js';
 import type { Model } from '../core/index.js';
+import type { Api } from '@mariozechner/pi-ai';
+
+// Dynamic wrappers — pi-ai's getModel/getModels use strict generics
+// that require KnownProvider literals, but provider-settings works
+// with runtime strings from localStorage/user selection.
+const getModelDynamic = getModel as (
+  provider: string,
+  modelId: string
+) => Model<Api>;
+
+const getModelsDynamic = getModels as (
+  provider: string
+) => Model<Api>[];
 
 // Storage keys
 const STORAGE_KEYS = {
@@ -164,7 +177,7 @@ const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
 // Get all available providers — pi-ai providers + custom providers (e.g., azure-ai-foundry)
 export function getAvailableProviders(): string[] {
   const piProviders = getProviders();
-  const customProviders = Object.keys(PROVIDER_CONFIGS).filter(id => !piProviders.includes(id));
+  const customProviders = Object.keys(PROVIDER_CONFIGS).filter(id => !(piProviders as string[]).includes(id));
   return [...piProviders, ...customProviders];
 }
 
@@ -180,11 +193,11 @@ export function getProviderConfig(providerId: string): ProviderConfig {
 }
 
 // Get models for a provider
-export function getProviderModels(providerId: string): Model<any>[] {
+export function getProviderModels(providerId: string): Model<Api>[] {
   try {
     // Azure AI Foundry uses Anthropic's Claude models
     const effectiveProvider = providerId === 'azure-ai-foundry' ? 'anthropic' : providerId;
-    return getModels(effectiveProvider as any);
+    return getModelsDynamic(effectiveProvider);
   } catch {
     return [];
   }
@@ -295,29 +308,29 @@ export function clearAllSettings(): void {
 }
 
 // Resolve the current model with provider-specific baseUrl override
-export function resolveCurrentModel(): Model<any> {
+export function resolveCurrentModel(): Model<Api> {
   const providerId = getSelectedProvider();
   const modelId = getSelectedModelId();
   const baseUrl = getBaseUrl();
-  
+
   // Get default model if none selected
   const models = getProviderModels(providerId);
   const effectiveModelId = modelId || models[0]?.id || 'claude-sonnet-4-20250514';
-  
+
   try {
     // Azure AI Foundry uses Anthropic's model registry
     const effectiveProvider = providerId === 'azure-ai-foundry' ? 'anthropic' : providerId;
-    let model = getModel(effectiveProvider as any, effectiveModelId as any);
+    let model = getModelDynamic(effectiveProvider, effectiveModelId);
 
     // Override baseUrl if custom one is set
     if (baseUrl) {
       model = { ...model, baseUrl };
     }
-    
+
     return model;
   } catch {
     // Fallback to anthropic
-    return getModel('anthropic', 'claude-sonnet-4-20250514' as any);
+    return getModelDynamic('anthropic', 'claude-sonnet-4-20250514');
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "types": ["vite/client"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/cli/**/*.ts"]


### PR DESCRIPTION
## Summary
- Add `vite/client` types to `tsconfig.json` so `import.meta.glob` is recognized
- Fix `Uint8Array<ArrayBufferLike>` incompatibilities from TypeScript 5.7+ (wasm-shell Blob constructor, python-command Pyodide FS.readFile)
- Replace `Model<any>` and `as any` casts in provider-settings with properly typed dynamic wrappers using `Model<Api>`
- Add `coverage/` to `.gitignore`

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npx vitest run` — all 607 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)