### PR TITLE
Fix link contrast in chat messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,6 +233,9 @@
       .msg__content blockquote {
         border-left: 3px solid #3a3a5a; padding-left: 10px; color: #a0a0b0;
       }
+      .msg__content a { color: #82aaff; text-decoration: none; }
+      .msg__content a:hover { text-decoration: underline; color: #a0c4ff; }
+      .msg__content a:visited { color: #82aaff; }
       .msg pre {
         background: #16162a; padding: 10px; border-radius: 4px;
         overflow-x: auto; margin: 8px 0; font-size: 13px;


### PR DESCRIPTION
## Summary
- Links in chat messages used the browser default blue, which had poor contrast on the dark blue backgrounds (`#222240` and `#2a2a5e`)
- Added `.msg__content a` styles using `#82aaff` — passes WCAG AA on both backgrounds (6.67:1 and 5.75:1)
- Hover state lightens to `#a0c4ff` with underline; visited stays consistent

## Test plan
- [ ] Visual check: links in assistant messages are readable on `#222240`
- [ ] Visual check: links in user messages are readable on `#2a2a5e`
- [ ] Hover shows underline + lighter color
- [ ] Works in both CLI and extension mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)