### PR TITLE
feat: add edit and icon-only action buttons for LLM accounts

### DIFF
--- a/src/ui/provider-settings.ts
+++ b/src/ui/provider-settings.ts
@@ -843,7 +843,7 @@ export function showProviderSettings(): Promise<void> {
         addAccount(
           pid,
           apiKeyInput.value.trim(),
-          config.requiresBaseUrl ? baseUrlInput.value.trim() : undefined,
+          baseUrlInput.value.trim() || undefined,
         );
 
         renderAccountsList();


### PR DESCRIPTION
## Summary

- Add edit functionality to existing LLM accounts (previously only add/remove was possible)
- Replace text "Remove" button with icon-only pen (edit) and trash (delete) buttons
- Unify add/edit into a single form: pre-populated fields with locked provider dropdown in edit mode

## Details

The accounts dialog (`showProviderSettings`) had no way to edit an existing account — the only option was to remove and re-add, losing the API key in the process. 

Changes in `src/ui/provider-settings.ts`:
- `renderAccountForm(editing?: Account)` — single function handles both add and edit modes
- Icon buttons use S2 outline SVG style (matching `layout.ts`), neutral at rest, colored on hover (accent for edit, red for delete)
- Provider dropdown is disabled in edit mode (changing provider = delete + create new)

## Automated UI testing

Full CRUD flow verified via Playwright against `npm run dev`:

| Test | Action | Verified |
|------|--------|----------|
| Add first account | Anthropic with fake key | Form → list transition, masked key `sk-a...5678` |
| Add second account | OpenRouter | Anthropic filtered from dropdown, both rows shown |
| Edit account | Change Anthropic API key | Pen icon → form pre-populated, provider locked, key updated to `sk-a...9999` |
| Delete account | Remove OpenRouter | Trash icon → row removed |
| Delete last account | Remove Anthropic | Empty state "No accounts configured." |

Screenshots captured at each step confirming icon alignment, hover states, and form behavior.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run src/ui/provider-settings.test.ts` — 28 tests pass
- [x] Full test suite — 751/753 pass (2 pre-existing pyodide failures unrelated to this change)
- [x] Automated Playwright UI testing (add, edit, delete flows)
- [ ] Manual verification in Chrome extension mode

Generated with [Claude Code](https://claude.ai/code)