### PR TITLE
Fix tool call continuation indentation in chat UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,9 +416,8 @@
         color: var(--s2-gray-800);
       }
 
-      /* Continuation messages (same sender, no label) — indent to align with content */
+      /* Continuation messages (same sender, no label) — indent message content only */
       .msg-group--continuation .msg { padding-left: 26px; }
-      .msg-group--continuation .tool-call { margin-left: 26px; }
 
       /* S2 Detail typography for role labels */
       .msg__role {


### PR DESCRIPTION
## Summary
- remove the continuation-specific left margin override for chat tool-call rows
- keep continuation indentation for message content only
- preserve existing chat-panel rendering logic

## Root cause
Sequential tool-call rows used inconsistent left offsets in the chat UI: default `.tool-call` rows used `margin-left: 20px`, while continuation groups overrode them to `26px`, causing follow-on tool calls to drift slightly to the right.

## Testing
- npm ci
- npm run typecheck
- npm run test
- npm run build
- npm run build:extension

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author