### PR TITLE
fix: prevent context compaction from splitting assistant+toolResult pairs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,7 +325,7 @@ Delegation:
 ## Key Conventions
 
 - **Two type systems**: Legacy ToolDefinition/ToolResult (in src/tools/) and pi-compatible AgentTool/AgentToolResult (in src/core/). The adapter in tool-adapter.ts bridges them.
-- **Tests are colocated**: foo.test.ts next to foo.ts. Vitest with globals: true, environment: node. New pure-logic code (utilities, adapters, data transformations) should always have tests. DOM-dependent code (UI panels, layout) and chrome.* API code (DebuggerClient) are acceptable to skip in Node tests but should be manually verified. Use `fake-indexeddb/auto` for tests that need VFS. Current count: 1056 tests across 54 files.
+- **Tests are colocated**: foo.test.ts next to foo.ts. Vitest with globals: true, environment: node. New pure-logic code (utilities, adapters, data transformations) should always have tests. DOM-dependent code (UI panels, layout) and chrome.* API code (DebuggerClient) are acceptable to skip in Node tests but should be manually verified. Use `fake-indexeddb/auto` for tests that need VFS. Current count: 1058 tests across 54 files.
 - **Logging**: createLogger('namespace') from src/core/logger.ts. Level-filtered, DEBUG in dev, ERROR in prod. Uses __DEV__ global (set by Vite define).
 - **Node shims**: Browser-bundle shims live in `src/shims/`. `empty.ts` stubs `node:zlib` and `node:module`; additional shim/polyfill files include `buffer-polyfill.ts`, `http.ts`, `https.ts`, `http2.ts`, and `stream.ts`.
 - **Multi-provider auth**: Provider settings in `src/ui/provider-settings.ts`. Supports Anthropic (direct), Azure AI Foundry (Claude on Azure), Azure OpenAI (GPT), AWS Bedrock, and many more via pi-ai. Provider/API key/baseUrl stored in localStorage. Model resolved via `resolveCurrentModel()` with baseUrl override.

--- a/src/core/context-compaction.test.ts
+++ b/src/core/context-compaction.test.ts
@@ -11,10 +11,27 @@ function createMessage(role: 'user' | 'assistant' | 'toolResult', text: string):
 }
 
 /** Helper to create a toolResult message */
-function createToolResult(text: string): AgentMessage {
+function createToolResult(text: string, toolCallId = 'tool-1'): AgentMessage {
   return {
     role: 'toolResult',
+    toolCallId,
     content: [{ type: 'text' as const, text }],
+  } as any;
+}
+
+/** Helper to create an assistant message with tool calls */
+function createAssistantWithToolCalls(text: string, toolCallIds: string[]): AgentMessage {
+  return {
+    role: 'assistant',
+    content: [
+      { type: 'text' as const, text },
+      ...toolCallIds.map((id) => ({
+        type: 'toolCall' as const,
+        id,
+        name: 'test_tool',
+        arguments: {},
+      })),
+    ],
   } as any;
 }
 
@@ -275,6 +292,85 @@ describe('compactContext', () => {
     const lastMsg = result[result.length - 1];
     expect((firstMsg.content as any)[0].text).toContain('message-0');
     expect((lastMsg.content as any)[0].text).toContain('message-19');
+  });
+
+  it('never splits assistant+toolResult pairs when compacting', async () => {
+    // Reproduce the bug: compaction drops the assistant message with tool_use
+    // but keeps the orphaned toolResult, causing API error:
+    // "unexpected tool_use_id found in tool_result blocks"
+    const baseMsg = 'x'.repeat(65000);
+    const messages: AgentMessage[] = [
+      createMessage('user', baseMsg),                                    // 0 - preserved (first 2)
+      createMessage('assistant', baseMsg),                               // 1 - preserved (first 2)
+      createMessage('user', baseMsg),                                    // 2 - droppable
+      createMessage('assistant', baseMsg),                               // 3 - droppable
+      createMessage('user', baseMsg),                                    // 4 - droppable
+      createMessage('assistant', baseMsg),                               // 5 - droppable
+      createMessage('user', baseMsg),                                    // 6 - droppable
+      createMessage('assistant', baseMsg),                               // 7 - droppable
+      createMessage('user', baseMsg),                                    // 8 - droppable
+      createAssistantWithToolCalls(baseMsg, ['tool-a', 'tool-b']),       // 9 - has tool calls
+      createToolResult(baseMsg, 'tool-a'),                               // 10 - must stay with 9
+      createToolResult(baseMsg, 'tool-b'),                               // 11 - must stay with 9
+      createMessage('user', 'follow up'),                                // 12
+      createMessage('assistant', 'response'),                            // 13
+    ];
+
+    const result = await compactContext(messages);
+
+    // Verify: every toolResult must have a preceding assistant with matching toolCall
+    for (let i = 0; i < result.length; i++) {
+      const msg = result[i] as any;
+      if (msg.role === 'toolResult' && msg.toolCallId) {
+        // Find the preceding assistant message
+        let found = false;
+        for (let j = i - 1; j >= 0; j--) {
+          const prev = result[j] as any;
+          if (prev.role === 'assistant' && Array.isArray(prev.content)) {
+            const hasToolCall = prev.content.some(
+              (c: any) => c.type === 'toolCall' && c.id === msg.toolCallId,
+            );
+            if (hasToolCall) { found = true; break; }
+          }
+          // Stop searching at non-toolResult, non-assistant boundaries
+          if (prev.role !== 'toolResult') break;
+        }
+        expect(found).toBe(true);
+      }
+    }
+  });
+
+  it('keeps toolResult with its assistant when at compaction boundary', async () => {
+    // The "last 10" boundary might land on a toolResult — compaction must
+    // include the assistant message too
+    const baseMsg = 'x'.repeat(65000);
+    const messages: AgentMessage[] = [
+      createMessage('user', baseMsg),                                    // 0
+      createMessage('assistant', baseMsg),                               // 1
+      createMessage('user', baseMsg),                                    // 2
+      createMessage('assistant', baseMsg),                               // 3
+      createAssistantWithToolCalls(baseMsg, ['t1']),                     // 4 - tool call
+      createToolResult(baseMsg, 't1'),                                   // 5 - result
+      createMessage('user', baseMsg),                                    // 6
+      createMessage('assistant', baseMsg),                               // 7
+      createMessage('user', baseMsg),                                    // 8
+      createMessage('assistant', baseMsg),                               // 9
+      createMessage('user', baseMsg),                                    // 10
+      createMessage('assistant', baseMsg),                               // 11
+      createMessage('user', baseMsg),                                    // 12
+      createMessage('assistant', baseMsg),                               // 13
+    ];
+
+    const result = await compactContext(messages);
+
+    // If toolResult 't1' is in the result, its assistant must also be present
+    const hasToolResult = result.some((m: any) => m.toolCallId === 't1');
+    if (hasToolResult) {
+      const hasMatchingAssistant = result.some(
+        (m: any) => m.role === 'assistant' && m.content?.some?.((c: any) => c.type === 'toolCall' && c.id === 't1'),
+      );
+      expect(hasMatchingAssistant).toBe(true);
+    }
   });
 
   it('does not modify input messages array', async () => {

--- a/src/core/context-compaction.ts
+++ b/src/core/context-compaction.ts
@@ -49,16 +49,26 @@ export async function compactContext(messages: AgentMessage[]): Promise<AgentMes
   let result = truncated;
   let totalChars = estimateSize(result);
 
-  // Keep dropping oldest non-system messages until under limit (preserve first 2 and last 10)
+  // Keep dropping oldest non-system messages until under limit (preserve first 2 and last N)
   // Safety limit to prevent infinite loop if compaction can't reduce size enough
   let compactionRounds = 0;
-  while (totalChars > MAX_CONTEXT_CHARS && result.length > 12 && compactionRounds < 50) {
+  const KEEP_LAST = 10;
+  while (totalChars > MAX_CONTEXT_CHARS && result.length > KEEP_LAST + 2 && compactionRounds < 50) {
     compactionRounds++;
     const compactedMsg = {
       role: 'user' as const,
       content: [{ type: 'text' as const, text: '[Earlier conversation messages were compacted to save context space]' }],
     };
-    result = [result[0], result[1], compactedMsg as any, ...result.slice(result.length - 10)];
+    // Find a safe cut point that doesn't split assistant+toolResult pairs.
+    // Walk backward from the target cut to find a message that isn't a toolResult.
+    let cutIndex = result.length - KEEP_LAST;
+    while (cutIndex > 2 && (result[cutIndex] as any).role === 'toolResult') {
+      cutIndex--;
+    }
+    // If we walked all the way back to index 2, we can't compact further without
+    // breaking pairs — stop trying.
+    if (cutIndex <= 2) break;
+    result = [result[0], result[1], compactedMsg as any, ...result.slice(cutIndex)];
     totalChars = estimateSize(result);
   }
   if (compactionRounds >= 50) {


### PR DESCRIPTION
## Summary

Context compaction was splitting assistant+toolResult message pairs, causing the Anthropic API to reject requests with:

> unexpected tool_use_id found in tool_result blocks. Each tool_result block must have a corresponding tool_use block in the previous message.

**Root cause**: `compactContext()` blindly sliced messages as `first 2 + marker + last 10`. If the boundary landed between an assistant message (with `tool_use` blocks) and its `toolResult` messages, the tool results became orphaned.

**Trigger**: Agent uses parallel tool calls (e.g., two `scoop_scoop` calls in one message). The assistant response has 2 `tool_use` blocks, followed by 2 `toolResult` messages. Compaction drops the assistant but keeps the results.

### Fix

When computing the cut point, walk backward from the target boundary to skip past any `toolResult` messages. This ensures the assistant message with matching `tool_use` blocks is always included:

```typescript
let cutIndex = result.length - KEEP_LAST;
while (cutIndex > 2 && result[cutIndex].role === 'toolResult') {
  cutIndex--;
}
```

If we can't find a safe cut (all messages are toolResults), compaction stops early rather than breaking the conversation.

## Test plan

- [x] Test: never splits assistant+toolResult pairs (verifies every toolResult has a preceding assistant with matching toolCallId)
- [x] Test: keeps toolResult with its assistant at compaction boundary
- [x] All 1058 tests pass across 54 files
- [x] `npm run typecheck` ✓
- [x] `npm run build` ✓
- [x] `npm run build:extension` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)