### PR TITLE
feat: support CHROME_PATH env var for browser selection

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,6 +33,9 @@ function requestLogger(req: Request, res: Response, next: NextFunction) {
 // ---------------------------------------------------------------------------
 
 function findChrome(): string | null {
+  const envPath = process.env['CHROME_PATH'];
+  if (envPath && existsSync(envPath)) return envPath;
+
   const candidates: Record<string, string[]> = {
     darwin: [
       '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',


### PR DESCRIPTION
## Summary

- Honor `CHROME_PATH` environment variable in the CLI's Chrome finder, checked before the platform candidate list
- Fixes a bug where the error message referenced `CHROME_PATH` but the code never read it
- Lets users target Chrome Canary (or any Chromium-based browser) without code changes:
  ```
  CHROME_PATH="/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary" npm run dev:full
  ```

## Test plan

- [x] Verified `CHROME_PATH` pointing to Chrome Canary launches Canary successfully
- [ ] Verify fallback to candidate list when `CHROME_PATH` is unset
- [ ] Verify graceful error when `CHROME_PATH` points to a non-existent path

🤖 Generated with [Claude Code](https://claude.com/claude-code)