### PR TITLE
feat: export configured accounts as providers.json

### DIFF
--- a/src/ui/provider-settings.test.ts
+++ b/src/ui/provider-settings.test.ts
@@ -88,6 +88,7 @@ import {
   getBaseUrlForProvider,
   getAllAvailableModels,
   applyProviderDefaults,
+  exportProviders,
 } from './provider-settings.js';
 import type { ProviderDefault } from './provider-settings.js';
 
@@ -463,5 +464,67 @@ describe('applyProviderDefaults', () => {
     ];
     applyProviderDefaults(defaults);
     expect(storage.get('selected-model')).toBe('openai:gpt-5');
+  });
+});
+
+describe('exportProviders', () => {
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('returns empty array when no accounts', () => {
+    expect(exportProviders()).toEqual([]);
+  });
+
+  it('exports all accounts with providerId and apiKey', () => {
+    addAccount('anthropic', 'ant-key');
+    addAccount('openai', 'oai-key');
+    const result = exportProviders();
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ providerId: 'anthropic', apiKey: 'ant-key' });
+    expect(result[1]).toEqual({ providerId: 'openai', apiKey: 'oai-key' });
+  });
+
+  it('includes baseUrl only when present', () => {
+    addAccount('anthropic', 'ant-key');
+    addAccount('azure-ai-foundry', 'az-key', 'https://contoso.azure.com/anthropic');
+    const result = exportProviders();
+    expect(result[0].baseUrl).toBeUndefined();
+    expect(result[1].baseUrl).toBe('https://contoso.azure.com/anthropic');
+  });
+
+  it('attaches model to matching selected provider', () => {
+    addAccount('anthropic', 'ant-key');
+    addAccount('openai', 'oai-key');
+    storage.set('selected-model', 'openai:gpt-5');
+    const result = exportProviders();
+    expect(result[0].model).toBeUndefined();
+    expect(result[1].model).toBe('gpt-5');
+  });
+
+  it('omits model when no model is selected', () => {
+    addAccount('anthropic', 'ant-key');
+    const result = exportProviders();
+    expect(result[0].model).toBeUndefined();
+  });
+
+  it('round-trips with applyProviderDefaults', () => {
+    addAccount('anthropic', 'ant-key');
+    addAccount('openai', 'oai-key', 'https://proxy.example.com');
+    storage.set('selected-model', 'anthropic:claude-sonnet-4-20250514');
+
+    const exported = exportProviders();
+
+    // Clear and re-apply
+    storage.clear();
+    applyProviderDefaults(exported);
+
+    expect(getAccounts()).toHaveLength(2);
+    expect(getApiKeyForProvider('anthropic')).toBe('ant-key');
+    expect(getApiKeyForProvider('openai')).toBe('oai-key');
+    expect(getBaseUrlForProvider('openai')).toBe('https://proxy.example.com');
+    expect(getSelectedModelId()).toBe('claude-sonnet-4-20250514');
+    expect(getSelectedProvider()).toBe('anthropic');
   });
 });

--- a/src/ui/provider-settings.ts
+++ b/src/ui/provider-settings.ts
@@ -457,6 +457,39 @@ export function clearBaseUrl(): void {
   }
 }
 
+// --- Export accounts as providers.json ---
+
+/** Build a ProviderDefault[] from current accounts (pure, testable). */
+export function exportProviders(): ProviderDefault[] {
+  const accounts = getAccounts();
+  const selectedProvider = getSelectedProvider();
+  const selectedModel = getSelectedModelId();
+
+  return accounts.map((account) => {
+    const entry: ProviderDefault = {
+      providerId: account.providerId,
+      apiKey: account.apiKey,
+    };
+    if (account.baseUrl) entry.baseUrl = account.baseUrl;
+    if (account.providerId === selectedProvider && selectedModel) {
+      entry.model = selectedModel;
+    }
+    return entry;
+  });
+}
+
+/** Trigger a browser download of the current accounts as providers.json. */
+export function downloadProviders(): void {
+  const json = JSON.stringify(exportProviders(), null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'providers.json';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 // Clear all provider settings
 export function clearAllSettings(): void {
   localStorage.removeItem(ACCOUNTS_KEY);
@@ -659,12 +692,25 @@ export function showProviderSettings(): Promise<void> {
         dialog.appendChild(list);
       }
 
-      // Add Account button
+      // Action buttons row
+      const btnRow = document.createElement('div');
+      btnRow.style.cssText = 'display: flex; gap: 8px;';
+
       const addBtn = document.createElement('button');
       addBtn.className = 'dialog__btn';
+      addBtn.style.flex = '1';
       addBtn.textContent = 'Add Account';
       addBtn.addEventListener('click', () => renderAccountForm());
-      dialog.appendChild(addBtn);
+      btnRow.appendChild(addBtn);
+
+      const exportBtn = document.createElement('button');
+      exportBtn.className = 'dialog__btn dialog__btn--secondary';
+      exportBtn.style.flex = '1';
+      exportBtn.textContent = 'Export';
+      exportBtn.addEventListener('click', () => downloadProviders());
+      btnRow.appendChild(exportBtn);
+
+      dialog.appendChild(btnRow);
 
       // ── Theme section ───────────────────────────────────────────
       const themeSep = document.createElement('hr');


### PR DESCRIPTION
## Summary

- Add `exportProviders()` function that serializes current localStorage accounts into the `ProviderDefault[]` format, attaching the selected model to its matching provider
- Add "Export" button in the Accounts dialog (side-by-side with "Add Account") that triggers a `providers.json` download
- Output round-trips with the existing `applyProviderDefaults()` import path

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (44/44 provider-settings tests, 6 new)
- [x] `npm run build` succeeds
- [x] `npm run build:extension` succeeds
- [ ] Manual: open Accounts dialog, verify Export button visible next to Add Account
- [ ] Manual: click Export, verify `providers.json` downloads with correct content
- [ ] Manual: place exported file at project root, rebuild, verify accounts auto-configure

🤖 Generated with [Claude Code](https://claude.com/claude-code)