### PR TITLE
fix: render send_message in extension UI in real-time

### DIFF
--- a/src/extension/offscreen-bridge.test.ts
+++ b/src/extension/offscreen-bridge.test.ts
@@ -288,6 +288,36 @@ describe('OffscreenBridge createCallbacks', () => {
     expect(emitted.payload.scoopJid).toBe(scoopJid);
     expect(emitted.payload.error).toBe('Something went wrong');
   });
+
+  it('onSendMessage buffers, persists, and emits text_delta + response_done', () => {
+    (bridge as any).orchestrator = mockOrchestrator;
+    const mockStore = new SessionStore();
+    (bridge as any).sessionStore = mockStore;
+
+    const targetJid = 'cone_1';
+    callbacks.onSendMessage(targetJid, 'Hello from scoop!');
+
+    // Should buffer
+    const buf = (bridge as any).getBuffer(targetJid);
+    expect(buf.length).toBe(1);
+    expect(buf[0].role).toBe('assistant');
+    expect(buf[0].content).toBe('Hello from scoop!');
+
+    // Should persist
+    expect(mockStore.saveMessages).toHaveBeenCalledWith('session-cone', expect.anything());
+
+    // Should emit text_delta then response_done
+    const events = sentMessages.map((m: any) => m.payload);
+    const textDelta = events.find((e: any) => e.eventType === 'text_delta');
+    const responseDone = events.find((e: any) => e.eventType === 'response_done');
+
+    expect(textDelta).toBeDefined();
+    expect(textDelta.scoopJid).toBe(targetJid);
+    expect(textDelta.text).toBe('Hello from scoop!');
+
+    expect(responseDone).toBeDefined();
+    expect(responseDone.scoopJid).toBe(targetJid);
+  });
 });
 
 describe('OffscreenBridge buildStateSnapshot', () => {

--- a/src/extension/offscreen-bridge.ts
+++ b/src/extension/offscreen-bridge.ts
@@ -114,6 +114,20 @@ export class OffscreenBridge {
         const buf = bridge.getBuffer(targetJid);
         const msgId = `msg-${uid()}`;
         buf.push({ id: msgId, role: 'assistant', content: text, timestamp: Date.now() });
+        bridge.persistScoop(targetJid);
+
+        // Emit agent events so the panel renders the message in real-time
+        bridge.emit({
+          type: 'agent-event',
+          scoopJid: targetJid,
+          eventType: 'text_delta',
+          text,
+        });
+        bridge.emit({
+          type: 'agent-event',
+          scoopJid: targetJid,
+          eventType: 'response_done',
+        });
       },
 
       onStatusChange: (scoopJid, status) => {


### PR DESCRIPTION
## Summary

- `onSendMessage` in the offscreen bridge only buffered messages — it never emitted agent events to the panel or persisted to the session store
- This caused `send_message` tool calls to be invisible in the extension chat until a full page reload
- Added `text_delta` + `response_done` emissions and `persistScoop()` call, matching the pattern used by `onResponse`/`onResponseDone` for regular assistant messages

**Root cause**: `send_message` is in the hidden tools set (suppressed from `onToolStart`/`onToolEnd`), so its content must come through `onSendMessage`. The CLI mode handler emits `message_start` + `content_delta` + `content_done` to the UI, but the extension bridge handler was missing equivalent emissions.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes — 1091 tests across 55 files, including new `onSendMessage` test
- [x] `npm run build` passes
- [x] `npm run build:extension` passes
- [x] Manual: Load extension, ask agent to use `send_message` — message should render in real-time
- [x] Manual: Reload extension — previously sent messages should still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)