### PR TITLE
fix: image processor checks base64 size, not decoded bytes, against 5MB API limit

### DIFF
--- a/src/core/image-processor.test.ts
+++ b/src/core/image-processor.test.ts
@@ -118,10 +118,9 @@ describe('processImageContent', () => {
     expect((result as any).text).toContain('unsupported format');
   });
 
-  it('attempts resize for images over 5MB', async () => {
-    // Create a base64 string that decodes to > 5MB
-    const overFiveMB = Math.ceil((MAX_IMAGE_BYTES + 1024) / 3) * 4;
-    const largeData = 'A'.repeat(overFiveMB);
+  it('attempts resize for images over 5MB base64', async () => {
+    // Create a base64 string that is > 5MB (the API limit is on base64 length)
+    const largeData = 'A'.repeat(MAX_IMAGE_BYTES + 1024);
     const image: ImageContent = {
       type: 'image',
       data: largeData,
@@ -135,35 +134,44 @@ describe('processImageContent', () => {
     expect((result as any).text).toContain('Image removed');
   });
 
-  it('passes through image at exactly 5MB', async () => {
-    // Create base64 for exactly MAX_IMAGE_BYTES
-    const exactFiveMB = Math.ceil(MAX_IMAGE_BYTES / 3) * 4;
-    const data = 'A'.repeat(exactFiveMB);
+  it('passes through image at exactly 5MB base64', async () => {
+    // Create base64 string of exactly MAX_IMAGE_BYTES length
+    const data = 'A'.repeat(MAX_IMAGE_BYTES);
     const image: ImageContent = {
       type: 'image',
       data,
       mimeType: 'image/jpeg',
     };
 
-    // getImageByteSize may be slightly over due to rounding, so check behavior
-    const byteSize = getImageByteSize(data);
-    if (byteSize <= MAX_IMAGE_BYTES) {
-      const result = await processImageContent(image);
-      expect(result).toEqual(image);
-    } else {
-      // Slightly over due to rounding — will attempt resize
-      const result = await processImageContent(image);
-      expect(result.type).toBe('text'); // fails in test env without WASM
-    }
+    const result = await processImageContent(image);
+    // Should pass through — base64 string is exactly at the limit
+    expect(result).toEqual(image);
+  });
+
+  it('triggers resize for image with raw bytes under 5MB but base64 over 5MB', async () => {
+    // Regression test: ~4.9MB raw → ~6.5MB base64 → should NOT pass through
+    // Create base64 that decodes to ~4.9MB but is ~6.5MB as a string
+    const rawBytes = 4.9 * 1024 * 1024;
+    const base64Len = Math.ceil(rawBytes / 3) * 4; // ~6.5MB
+    expect(base64Len).toBeGreaterThan(MAX_IMAGE_BYTES); // confirm base64 > 5MB
+    expect(getImageByteSize('A'.repeat(base64Len))).toBeLessThan(MAX_IMAGE_BYTES); // confirm raw < 5MB
+
+    const image: ImageContent = {
+      type: 'image',
+      data: 'A'.repeat(base64Len),
+      mimeType: 'image/png',
+    };
+
+    // Should attempt resize (WASM unavailable in test → text placeholder)
+    const result = await processImageContent(image);
+    expect(result.type).toBe('text');
+    expect((result as any).text).toContain('Image removed');
   });
 
   it('handles corrupt base64 data gracefully when resize is attempted', async () => {
-    // Not actually valid base64 that decodes to >5MB, but the size check
-    // uses the formula, not actual decode, so we need valid base64 chars
-    const overFiveMB = Math.ceil((MAX_IMAGE_BYTES + 1024) / 3) * 4;
     const image: ImageContent = {
       type: 'image',
-      data: 'X'.repeat(overFiveMB), // valid base64 chars but not a real image
+      data: 'X'.repeat(MAX_IMAGE_BYTES + 1024),
       mimeType: 'image/jpeg',
     };
 

--- a/src/core/image-processor.ts
+++ b/src/core/image-processor.ts
@@ -11,7 +11,9 @@ import { createLogger } from './logger.js';
 
 const log = createLogger('image-processor');
 
-export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;    // 5MB API limit
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;    // 5MB API limit (on base64 string)
+/** Max raw bytes that fit within the base64 limit (base64 inflates by 4/3). */
+const MAX_RAW_BYTES = Math.floor(MAX_IMAGE_BYTES * 3 / 4);
 export const OPTIMAL_LONG_EDGE = 1568;              // px — avoids server-side resize
 export const MAX_DIMENSION = 8000;                  // px — hard reject by API
 export const SUPPORTED_MIMES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
@@ -44,15 +46,17 @@ export async function processImageContent(image: ImageContent): Promise<ImageCon
     };
   }
 
-  const byteSize = getImageByteSize(image.data);
+  // The API enforces the 5MB limit on the base64 string, not decoded bytes.
+  // base64 inflates size by ~33%, so we must check image.data.length directly.
+  const base64Size = image.data.length;
 
   // If under the limit, pass through without touching ImageMagick
-  if (byteSize <= MAX_IMAGE_BYTES) {
+  if (base64Size <= MAX_IMAGE_BYTES) {
     return image;
   }
 
-  // Over 5MB — attempt resize via ImageMagick WASM
-  log.info('Image exceeds 5MB, attempting resize', { byteSize, mimeType: image.mimeType });
+  // Over 5MB base64 — attempt resize via ImageMagick WASM
+  log.info('Image exceeds 5MB base64 limit, attempting resize', { base64Size, mimeType: image.mimeType });
 
   // Step 1: Load ImageMagick WASM
   let getMagick: typeof import('../shell/supplemental-commands/magick-wasm.js').getMagick;
@@ -111,14 +115,14 @@ export async function processImageContent(image: ImageContent): Promise<ImageCon
       });
 
       // If still over 5MB, try JPEG at quality 80
-      if (output.data && output.data.length > MAX_IMAGE_BYTES && format !== 'JPEG') {
+      if (output.data && output.data.length > MAX_RAW_BYTES && format !== 'JPEG') {
         log.info('Still over 5MB, compressing to JPEG q80');
         img.quality = 80;
         img.write('JPEG', (data: Uint8Array) => {
           output.data = new Uint8Array(data);
         });
         output.mime = 'image/jpeg';
-      } else if (output.data && output.data.length > MAX_IMAGE_BYTES) {
+      } else if (output.data && output.data.length > MAX_RAW_BYTES) {
         // Already JPEG, try lower quality
         log.info('Still over 5MB as JPEG, reducing quality to 60');
         img.quality = 60;
@@ -137,7 +141,7 @@ export async function processImageContent(image: ImageContent): Promise<ImageCon
     }
 
     // Final size check
-    if (output.data.length > MAX_IMAGE_BYTES) {
+    if (output.data.length > MAX_RAW_BYTES) {
       log.warn('Image still over 5MB after resize+compress', { size: output.data.length });
       return {
         type: 'text',
@@ -153,8 +157,8 @@ export async function processImageContent(image: ImageContent): Promise<ImageCon
     const newBase64 = btoa(binary);
 
     log.info('Image processed successfully', {
-      originalBytes: byteSize,
-      newBytes: output.data.length,
+      originalBase64: base64Size,
+      newBase64: newBase64.length,
       mimeType: output.mime,
     });
 
@@ -166,7 +170,7 @@ export async function processImageContent(image: ImageContent): Promise<ImageCon
   } catch (err) {
     log.error('Image data processing failed (corrupt or unreadable)', {
       mimeType: image.mimeType,
-      estimatedBytes: byteSize,
+      estimatedBytes: base64Size,
       error: err instanceof Error ? err.message : String(err),
     });
     return {


### PR DESCRIPTION
## Summary

- The Anthropic API enforces the 5MB image limit on the **base64 string length**, not decoded byte size
- Base64 inflates data by ~33%, so images between 3.75MB and 5MB raw passed the size gate but were rejected by the API with `image exceeds 5 MB maximum`
- Initial gate now checks `image.data.length` (base64 string) directly instead of `getImageByteSize()` (decoded estimate)
- Intermediate and final raw-byte checks use `MAX_RAW_BYTES` (3.75MB) to account for base64 inflation

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (1495/1495)
- [x] `npm run build` passes
- [x] `npm run build:extension` passes
- [x] Regression test: 4.9MB raw / 6.5MB base64 image now triggers resize instead of passing through

🤖 Generated with [Claude Code](https://claude.com/claude-code)