### PR TITLE
fix: check image dimensions before passing through to API

### DIFF
--- a/src/core/image-processor.test.ts
+++ b/src/core/image-processor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   getImageByteSize,
+  getImageDimensions,
   isSupportedImageFormat,
   processImageContent,
   MAX_IMAGE_BYTES,
@@ -77,6 +78,100 @@ describe('isSupportedImageFormat', () => {
 
   it('rejects empty string', () => {
     expect(isSupportedImageFormat('')).toBe(false);
+  });
+});
+
+describe('getImageDimensions', () => {
+  function makeBase64(bytes: number[]): string {
+    return btoa(String.fromCharCode(...bytes));
+  }
+
+  it('extracts PNG dimensions from IHDR chunk', () => {
+    // PNG signature (8 bytes) + IHDR length (4) + "IHDR" (4) + width (4) + height (4) = 24 bytes
+    const png = [
+      0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+      0x00, 0x00, 0x00, 0x0D,                           // IHDR chunk length
+      0x49, 0x48, 0x44, 0x52,                           // "IHDR"
+      0x00, 0x00, 0x03, 0x20,                           // width = 800
+      0x00, 0x00, 0x02, 0x58,                           // height = 600
+    ];
+    expect(getImageDimensions(makeBase64(png), 'image/png')).toEqual({ width: 800, height: 600 });
+  });
+
+  it('extracts large PNG dimensions (> 8000px)', () => {
+    const png = [
+      0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+      0x00, 0x00, 0x00, 0x0D,
+      0x49, 0x48, 0x44, 0x52,
+      0x00, 0x00, 0x04, 0x00,                           // width = 1024
+      0x00, 0x00, 0x27, 0x10,                           // height = 10000
+    ];
+    expect(getImageDimensions(makeBase64(png), 'image/png')).toEqual({ width: 1024, height: 10000 });
+  });
+
+  it('extracts GIF dimensions', () => {
+    const gif = [
+      0x47, 0x49, 0x46, 0x38, 0x39, 0x61,             // "GIF89a"
+      0x20, 0x03,                                       // width = 800 (LE)
+      0x58, 0x02,                                       // height = 600 (LE)
+    ];
+    expect(getImageDimensions(makeBase64(gif), 'image/gif')).toEqual({ width: 800, height: 600 });
+  });
+
+  it('extracts JPEG dimensions from SOF0 marker', () => {
+    // Minimal JPEG: SOI + SOF0 with dimensions
+    const jpeg = [
+      0xFF, 0xD8,                                       // SOI
+      0xFF, 0xC0,                                       // SOF0
+      0x00, 0x11,                                       // length
+      0x08,                                             // precision
+      0x02, 0x58,                                       // height = 600
+      0x03, 0x20,                                       // width = 800
+    ];
+    expect(getImageDimensions(makeBase64(jpeg), 'image/jpeg')).toEqual({ width: 800, height: 600 });
+  });
+
+  it('extracts JPEG dimensions from SOF2 (progressive) marker', () => {
+    const jpeg = [
+      0xFF, 0xD8,
+      0xFF, 0xC2,                                       // SOF2 (progressive)
+      0x00, 0x11, 0x08,
+      0x02, 0x58,                                       // height = 600
+      0x03, 0x20,                                       // width = 800
+    ];
+    expect(getImageDimensions(makeBase64(jpeg), 'image/jpeg')).toEqual({ width: 800, height: 600 });
+  });
+
+  it('returns null for JPEG with no SOF marker', () => {
+    const jpeg = [
+      0xFF, 0xD8,                                       // SOI
+      0xFF, 0xE0,                                       // APP0 (not SOF)
+      0x00, 0x10, 0x4A, 0x46, 0x49, 0x46,
+    ];
+    expect(getImageDimensions(makeBase64(jpeg), 'image/jpeg')).toBeNull();
+  });
+
+  it('returns null for PNG with zero width', () => {
+    const png = [
+      0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+      0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+      0x00, 0x00, 0x00, 0x00,                           // width = 0
+      0x00, 0x00, 0x02, 0x58,                           // height = 600
+    ];
+    expect(getImageDimensions(makeBase64(png), 'image/png')).toBeNull();
+  });
+
+  it('returns null for too-short base64', () => {
+    expect(getImageDimensions('AA==', 'image/png')).toBeNull();
+  });
+
+  it('returns null for unknown format', () => {
+    expect(getImageDimensions('AAAA', 'image/webp')).toBeNull();
+  });
+
+  it('returns null for corrupt header', () => {
+    // Invalid base64 that will fail atob
+    expect(getImageDimensions('!!!', 'image/png')).toBeNull();
   });
 });
 
@@ -165,6 +260,31 @@ describe('processImageContent', () => {
     // Should attempt resize (WASM unavailable in test → text placeholder)
     const result = await processImageContent(image);
     expect(result.type).toBe('text');
+    expect((result as any).text).toContain('Image removed');
+  });
+
+  it('triggers resize for small image with dimensions > 8000px', async () => {
+    // Regression: full-page screenshots can be under 5MB but exceed 8000px height.
+    // Build a minimal PNG header with height = 10000px, padded to look like a small image.
+    const pngHeader = [
+      0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+      0x00, 0x00, 0x00, 0x0D,
+      0x49, 0x48, 0x44, 0x52,
+      0x00, 0x00, 0x04, 0x00,  // width = 1024
+      0x00, 0x00, 0x27, 0x10,  // height = 10000 (> 8000)
+    ];
+    const headerBase64 = btoa(String.fromCharCode(...pngHeader));
+    // Pad with valid base64 to make it a reasonable size (but well under 5MB)
+    const data = headerBase64 + 'A'.repeat(1000);
+    const image: ImageContent = {
+      type: 'image',
+      data,
+      mimeType: 'image/png',
+    };
+
+    // Should trigger resize due to dimensions, even though size is tiny
+    const result = await processImageContent(image);
+    expect(result.type).toBe('text'); // WASM unavailable in test
     expect((result as any).text).toContain('Image removed');
   });
 

--- a/src/core/image-processor.ts
+++ b/src/core/image-processor.ts
@@ -31,6 +31,52 @@ export function isSupportedImageFormat(mimeType: string): boolean {
 }
 
 /**
+ * Extract image dimensions from base64 data by parsing format headers.
+ * Returns null if dimensions can't be determined (unknown format, corrupt header).
+ */
+export function getImageDimensions(base64: string, mimeType: string): { width: number; height: number } | null {
+  try {
+    if (mimeType === 'image/png') {
+      // PNG IHDR: width @ bytes 16-19, height @ bytes 20-23 (big-endian uint32)
+      // Need first 24 raw bytes = 32 base64 chars
+      if (base64.length < 32) return null;
+      const raw = atob(base64.slice(0, 32));
+      const w = (raw.charCodeAt(16) << 24) | (raw.charCodeAt(17) << 16) | (raw.charCodeAt(18) << 8) | raw.charCodeAt(19);
+      const h = (raw.charCodeAt(20) << 24) | (raw.charCodeAt(21) << 16) | (raw.charCodeAt(22) << 8) | raw.charCodeAt(23);
+      return (w > 0 && h > 0) ? { width: w, height: h } : null;
+    }
+
+    if (mimeType === 'image/gif') {
+      // GIF: width @ bytes 6-7, height @ bytes 8-9 (little-endian uint16)
+      if (base64.length < 16) return null;
+      const raw = atob(base64.slice(0, 16));
+      const w = raw.charCodeAt(6) | (raw.charCodeAt(7) << 8);
+      const h = raw.charCodeAt(8) | (raw.charCodeAt(9) << 8);
+      return (w > 0 && h > 0) ? { width: w, height: h } : null;
+    }
+
+    if (mimeType === 'image/jpeg') {
+      // JPEG: scan for SOF0 (0xFFC0) or SOF2 (0xFFC2) marker in first 64KB
+      const scanBytes = Math.min(Math.ceil(65536 / 3) * 4, base64.length);
+      const raw = atob(base64.slice(0, scanBytes));
+      for (let i = 0; i < raw.length - 8; i++) {
+        if (raw.charCodeAt(i) === 0xFF) {
+          const marker = raw.charCodeAt(i + 1);
+          if (marker === 0xC0 || marker === 0xC2) {
+            const h = (raw.charCodeAt(i + 5) << 8) | raw.charCodeAt(i + 6);
+            const w = (raw.charCodeAt(i + 7) << 8) | raw.charCodeAt(i + 8);
+            return (w > 0 && h > 0) ? { width: w, height: h } : null;
+          }
+        }
+      }
+    }
+  } catch {
+    // Corrupt header — can't determine dimensions
+  }
+  return null;
+}
+
+/**
  * Process an ImageContent block: validate and resize if needed.
  *
  * Returns the original or resized ImageContent, or a TextContent placeholder
@@ -50,13 +96,22 @@ export async function processImageContent(image: ImageContent): Promise<ImageCon
   // base64 inflates size by ~33%, so we must check image.data.length directly.
   const base64Size = image.data.length;
 
-  // If under the limit, pass through without touching ImageMagick
-  if (base64Size <= MAX_IMAGE_BYTES) {
+  // Check dimensions — API rejects images > 8000px on any side.
+  // Parse from header bytes (no full decode needed).
+  const dims = getImageDimensions(image.data, image.mimeType);
+  const needsResize = base64Size > MAX_IMAGE_BYTES
+    || (dims !== null && (dims.width > MAX_DIMENSION || dims.height > MAX_DIMENSION))
+    || (dims !== null && Math.max(dims.width, dims.height) > OPTIMAL_LONG_EDGE);
+
+  if (!needsResize) {
     return image;
   }
 
-  // Over 5MB base64 — attempt resize via ImageMagick WASM
-  log.info('Image exceeds 5MB base64 limit, attempting resize', { base64Size, mimeType: image.mimeType });
+  log.info('Image needs processing', {
+    base64Size,
+    dimensions: dims ? `${dims.width}x${dims.height}` : 'unknown',
+    reason: base64Size > MAX_IMAGE_BYTES ? 'size' : 'dimensions',
+  });
 
   // Step 1: Load ImageMagick WASM
   let getMagick: typeof import('../shell/supplemental-commands/magick-wasm.js').getMagick;


### PR DESCRIPTION
## Summary

- Full-page screenshots can be under 5MB but exceed the API's **8000px dimension limit**, causing `invalid_request_error`
- `MAX_DIMENSION` (8000px) was defined but **never checked** — images under 5MB skipped all processing
- Added `getImageDimensions()` that parses PNG/GIF/JPEG headers from base64 without full decode
- `processImageContent` now checks both size AND dimensions before deciding whether to resize
- Also triggers resize when any dimension exceeds `OPTIMAL_LONG_EDGE` (1568px), preventing unnecessary server-side rescaling

## Changes

- **`src/core/image-processor.ts`** — Added `getImageDimensions()`, restructured gate logic to check dimensions
- **`src/core/image-processor.test.ts`** — 8 new tests (7 for header parsing, 1 regression for dimension gate)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (1503/1503)
- [x] `npm run build` passes
- [x] `npm run build:extension` passes
- [x] Regression test: 1024x10000 PNG (under 5MB) triggers resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)