### PR TITLE
feat: set default Adobe proxy endpoint

### DIFF
--- a/providers/adobe-config.json
+++ b/providers/adobe-config.json
@@ -1,5 +1,5 @@
 {
-  "proxyEndpoint": "",
+  "proxyEndpoint": "https://adobe-llm-proxy.paolo-moz.workers.dev",
   "redirectUri": "http://localhost:3000/auth/callback",
   "extensionRedirectUri": "https://dcebfdclgcnjkpnmhfgoelnkgedglhpo.chromiumapp.org/adobe"
 }


### PR DESCRIPTION
## Summary
- Set `proxyEndpoint` in `providers/adobe-config.json` to `https://adobe-llm-proxy.paolo-moz.workers.dev`
- Adobe provider now works out of the box without requiring manual base URL configuration in Settings
- `requiresBaseUrl` becomes `false` since the endpoint is populated at build time

## Test plan
- [ ] Fresh install: Adobe provider available without configuring base URL
- [ ] `oauth-token adobe` triggers login flow successfully
- [ ] LLM requests route through the proxy endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)