### PR TITLE
fix: don't encode Bedrock model ID in URL path

### DIFF
--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -421,7 +421,7 @@ export const streamBedrockCamp = (
       options?.onPayload?.(body, model);
 
       // Build URL: POST {baseUrl}/model/{modelId}/converse
-      const targetUrl = `${baseUrl.replace(/\/$/, '')}/model/${encodeURIComponent(model.id)}/converse`;
+      const targetUrl = `${baseUrl.replace(/\/$/, '')}/model/${model.id}/converse`;
 
       // Route through CORS proxy in CLI mode, direct in extension mode
       const fetchUrl = isExtension ? targetUrl : '/api/fetch-proxy';


### PR DESCRIPTION
## Summary
- Remove `encodeURIComponent` from Bedrock Converse API URL construction
- The colon in model IDs like `global.anthropic.claude-opus-4-5-20251101-v1:0` was being encoded to `%3A`, causing 404s

## Test plan
- [ ] Verify Bedrock CAMP requests succeed with model IDs containing colons

🤖 Generated with [Claude Code](https://claude.com/claude-code)