### PR TITLE
docs: fix dev server port in CLAUDE.md (3000 → 5710)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build and Development Commands
 
 ```bash
-npm run dev:full        # Full dev mode: Vite HMR + Chrome + CDP proxy (port 3000)
+npm run dev:full        # Full dev mode: Vite HMR + Chrome + CDP proxy (port 5710)
 npm run dev:electron -- /Applications/Slack.app  # Electron attach mode
 npm run dev             # Vite dev server only (no Chrome/CDP)
 npm run build           # Production build (UI via Vite + CLI/Electron via TSC)
@@ -15,7 +15,7 @@ npm run test            # Vitest run (all tests)
 npx vitest run src/fs/virtual-fs.test.ts  # Single test file
 ```
 
-**Requires Node >= 22** (LTS). Ports: 3000 (UI), 9222 (Chrome CDP), 9223 (Electron CDP), 24679 (Vite HMR)
+**Requires Node >= 22** (LTS). Ports: 5710 (UI), 9222 (Chrome CDP), 9223 (Electron CDP), 24679 (Vite HMR)
 
 ## Philosophy
 


### PR DESCRIPTION
## Summary
- Default port was changed to 5710 but CLAUDE.md still referenced 3000 in two places

## Test plan
- [x] Verified `src/cli/index.ts` uses port 5710 as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)