### PR TITLE
fix: aem put temp file uses cwd instead of /tmp

### DIFF
--- a/src/defaults/workspace/skills/aem/aem.jsh
+++ b/src/defaults/workspace/skills/aem/aem.jsh
@@ -168,7 +168,7 @@ async function cmdPut(args) {
   const url = `${DA_ADMIN_BASE}/source/${target.org}/${target.repo}/${aemPath}`;
 
   // Write HTML to a temp file, then use curl -F to upload
-  const tmpPath = '/tmp/_aem_put_' + Date.now() + '.html';
+  const tmpPath = process.cwd() + '/_aem_put_' + Date.now() + '.html';
   await fs.writeFile(tmpPath, html);
   await aemFetch('PUT', url, token, ['-F', `data=@${tmpPath};type=text/html`]);
   await fs.rm(tmpPath);


### PR DESCRIPTION
## Summary
- `aem put` writes a temp file for curl FormData upload
- It used `/tmp/` which scoops can't access (RestrictedFS EACCES)
- Changed to `process.cwd()` so the temp file lands in the scoop's own workspace

## Test plan
- [ ] Run `aem put` from a scoop context — should no longer get EACCES
- [ ] Run `aem put` from the cone — should still work (cwd is `/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)