### PR TITLE
fix: avoid killing launcher process when using --kill with Electron app

### DIFF
--- a/src/cli/electron-controller.test.ts
+++ b/src/cli/electron-controller.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { findMatchingElectronAppPids } from './electron-controller.js';
 
 describe('findMatchingElectronAppPids', () => {
-  it('excludes the current CLI pid while keeping other matching Electron app pids', () => {
+  it('matches Slack process where app path is the executable', () => {
     expect(
       findMatchingElectronAppPids(
         [
@@ -21,6 +21,35 @@ describe('findMatchingElectronAppPids', () => {
             pid: 333,
             commandLine: '/Applications/Linear.app/Contents/MacOS/Linear',
             executablePath: '/Applications/Linear.app/Contents/MacOS/Linear',
+          },
+        ],
+        ['/Applications/Slack.app', '/Applications/Slack.app/Contents/MacOS/Slack'],
+        111,
+      ),
+    ).toEqual([222]);
+  });
+
+  it('does not match node/npx/tsx ancestor processes that have the app path as a CLI argument', () => {
+    expect(
+      findMatchingElectronAppPids(
+        [
+          {
+            // npm/npx parent — has app path as argument, not as the executable
+            pid: 100,
+            commandLine: 'node /usr/local/bin/npx tsx src/cli/index.ts --electron --kill /Applications/Slack.app',
+            executablePath: '/usr/local/bin/node',
+          },
+          {
+            // Current tsx process — also has app path as argument
+            pid: 111,
+            commandLine: 'node dist/cli/index.js --electron --kill /Applications/Slack.app',
+            executablePath: '/usr/local/bin/node',
+          },
+          {
+            // Actual Slack process — app path is the executable
+            pid: 222,
+            commandLine: '/Applications/Slack.app/Contents/MacOS/Slack --remote-debugging-port=9223',
+            executablePath: '/Applications/Slack.app/Contents/MacOS/Slack',
           },
         ],
         ['/Applications/Slack.app', '/Applications/Slack.app/Contents/MacOS/Slack'],

--- a/src/cli/electron-controller.ts
+++ b/src/cli/electron-controller.ts
@@ -25,6 +25,16 @@ interface RunningProcessInfo {
   executablePath: string | null;
 }
 
+function commandLineExecutableMatchesPattern(commandLine: string, pattern: string): boolean {
+  // Extract the executable (first whitespace-separated token) from the command line.
+  // Only match when the target app path is the executable itself, not an argument —
+  // this avoids false positives when the path appears as a CLI flag (e.g. --kill /App.app).
+  const executable = commandLine.trimStart().split(/\s+/)[0] ?? '';
+  return executable === pattern
+    || executable.startsWith(pattern + '/')
+    || executable.startsWith(pattern + '\\');
+}
+
 export function findMatchingElectronAppPids(
   runningProcesses: RunningProcessInfo[],
   processMatchPatterns: string[],
@@ -32,7 +42,7 @@ export function findMatchingElectronAppPids(
 ): number[] {
   const matches = runningProcesses.filter((processInfo) => {
     return processMatchPatterns.some((pattern) => {
-      return processInfo.commandLine.includes(pattern)
+      return commandLineExecutableMatchesPattern(processInfo.commandLine, pattern)
         || (processInfo.executablePath?.includes(pattern) ?? false);
     });
   });


### PR DESCRIPTION
When running `npm run dev:electron -- --kill /App.app`, ancestor processes (npm, npx, tsx) all have the app path as a CLI argument, causing findMatchingElectronAppPids to match and kill them — taking down our own process.

Fix: match on executable position only (first token of commandLine) rather than anywhere in the command line string.