### PR TITLE
fix: route sprinkles through sandbox in extension mode to avoid CSP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,9 @@ Virtual Filesystem (src/fs/) → RestrictedFS → Shell (src/shell/) + Git (src/
 
 **Preview SW** (`src/ui/preview-sw.ts`): Intercepts `/preview/*` requests, serves VFS content. Built as IIFE via esbuild (not rollup — avoids code-splitting issues in SWs).
 
-**Sprinkle Rendering** (`src/ui/sprinkle-renderer.ts`): Renders `.shtml` files as interactive UI panels in sandbox iframes. See the sprinkles skill (`src/defaults/workspace/skills/sprinkles/`) for rendering modes, bridge API, and style guide.
+**Sprinkle Rendering** (`src/ui/sprinkle-renderer.ts`): Renders `.shtml` files as interactive UI panels. CLI mode: fragments injected into DOM directly, full documents rendered via srcdoc iframe. Extension mode: ALL content routes through `sprinkle-sandbox.html` (CSP-exempt manifest sandbox) — fragments rendered in sandbox body, full documents via nested srcdoc iframe inside sandbox. See the sprinkles skill (`src/defaults/workspace/skills/sprinkles/`) for rendering modes, bridge API, and style guide.
 
-**Inline Sprinkles** (`src/ui/inline-sprinkle.ts`): Agent ` ```shtml ` code blocks in chat messages are hydrated into sandboxed srcdoc iframes after streaming completes. Minimal bridge (lick-only, no state) via postMessage. Auto-height via ResizeObserver. No sprinkle manager involvement. Lick events route to the cone via `routeLickToScoop` (CLI) or `client.sendSprinkleLick` (extension). CSS: `.msg__inline-sprinkle` container, `.sprinkle-action-card` component.
+**Inline Sprinkles** (`src/ui/inline-sprinkle.ts`): Agent ` ```shtml ` code blocks in chat messages are hydrated into sandboxed iframes after streaming completes. Minimal bridge (lick-only, no state) via postMessage. Auto-height via ResizeObserver. CLI mode: direct srcdoc iframe. Extension mode: routes through `sprinkle-sandbox.html` (same CSP-exempt sandbox as panel sprinkles). Lick events route to the cone via `routeLickToScoop` (CLI) or `client.sendSprinkleLick` (extension). CSS: `.msg__inline-sprinkle` container, `.sprinkle-action-card` component.
 
 **Skills** (`src/skills/`, `src/scoops/skills.ts`): SKILL.md files in `/workspace/skills/` auto-load into system prompt. Installation engine supports manifest-based packages with dependency/conflict checking.
 
@@ -118,7 +118,7 @@ User → ChatPanel → Orchestrator → ScoopContext.prompt() → pi-agent-core 
 - **Colocated tests**: `foo.test.ts` next to `foo.ts`. Vitest, globals: true, environment: node. Use `fake-indexeddb/auto` for VFS tests.
 - **Logging**: `createLogger('namespace')` from `src/core/logger.ts`. DEBUG in dev, ERROR in prod.
 - **Extension detection**: `typeof chrome !== 'undefined' && !!chrome?.runtime?.id`
-- **Dual-mode compatibility**: Features MUST work in both CLI and extension. Extension CSP blocks eval/CDN — use `sandbox.html` for dynamic code, `chrome.runtime.getURL()` for bundled assets.
+- **Dual-mode compatibility**: Features MUST work in both CLI and extension. Extension CSP blocks eval/CDN — use `sandbox.html` for dynamic code, `sprinkle-sandbox.html` for sprinkles/inline widgets, `chrome.runtime.getURL()` for bundled assets.
 - **Extension `window.open()` returns `null`**: Fire-and-forget; don't treat null as failure.
 - **Model ID aliases**: Use pi-ai aliases (e.g., `claude-opus-4-6`) not dated snapshot IDs.
 - **Provider composition**: Auto-discovered from pi-ai. External providers: drop `.ts` in root `providers/`. OAuth via `createOAuthLauncher()` in `src/providers/oauth-service.ts`. Registration runs in both `main.ts` and `offscreen.ts`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,7 +216,8 @@
 | `tab-zone.ts` | Generic reusable tab bar + content area manager for a single zone |
 | `sprinkle-manager.ts` | Registry of available and open `.shtml` sprinkle panels with placement and lifecycle management |
 | `sprinkle-discovery.ts` | Scans VirtualFS for `.shtml` sprinkle files and builds a map of names to metadata (path, title) |
-| `sprinkle-renderer.ts` | Loads `.shtml` content from VFS and renders into DOM; uses sandbox iframe in extension mode for CSP compliance |
+| `sprinkle-renderer.ts` | Loads `.shtml` content from VFS and renders into DOM. CLI: direct DOM injection (fragments) or srcdoc iframe (full docs). Extension: ALL content routes through `sprinkle-sandbox.html` (CSP-exempt) |
+| `inline-sprinkle.ts` | Hydrates ` ```shtml ` code blocks in chat into sandboxed iframes. CLI: direct srcdoc. Extension: routes through `sprinkle-sandbox.html` |
 | `sprinkle-bridge.ts` | API available to `.shtml` sprinkle scripts for communicating with the agent via lick events and state persistence |
 | `sprinkle-picker.ts` | Popup menu listing closed panels and unopened sprinkles for opening in a zone |
 | `index.ts` | Re-exports |
@@ -512,7 +513,7 @@ Scoop removal / app clear
 | I need to... | Modify |
 |---|---|
 | Add/change sprinkle discovery | `src/ui/sprinkle-discovery.ts` |
-| Change sprinkle rendering or CSP handling | `src/ui/sprinkle-renderer.ts` |
+| Change sprinkle rendering or CSP handling | `src/ui/sprinkle-renderer.ts`, `src/ui/inline-sprinkle.ts`, `sprinkle-sandbox.html` |
 | Change the sprinkle↔agent bridge API | `src/ui/sprinkle-bridge.ts` |
 | Change sprinkle lifecycle/placement | `src/ui/sprinkle-manager.ts` |
 | Add sprinkle picker UI features | `src/ui/sprinkle-picker.ts` |

--- a/docs/development.md
+++ b/docs/development.md
@@ -199,7 +199,7 @@ New features MUST work in the relevant runtimes:
 - **Extension mode** (`npm run build:extension`)
   - Runs in Chrome side panel
   - CSP blocks dynamic eval and CDN fetches
-  - Must use sandbox iframe for dynamic code (`sandbox.html`)
+  - Must use sandbox iframe for dynamic code (`sandbox.html`) and sprinkles/inline widgets (`sprinkle-sandbox.html`)
   - Must use `chrome.runtime.getURL()` for bundled assets
   - Must detect runtime via `typeof chrome !== 'undefined' && !!chrome?.runtime?.id`
 

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -13,13 +13,15 @@ Chrome extension Manifest V3 blocks dynamic code construction on extension pages
 
 **The Solution: Sandbox Iframe**
 
-All dynamic code execution (JavaScript tool, `node -e`) routes through a sandboxed iframe (`sandbox.html`) exempt from extension CSP.
+All dynamic code execution (JavaScript tool, `node -e`) routes through a sandboxed iframe (`sandbox.html`) exempt from extension CSP. Sprinkles and inline widgets use a separate sandbox (`sprinkle-sandbox.html`).
 
 | Component | CLI Behavior | Extension Behavior |
 |-----------|--------------|-------------------|
 | **JavaScript tool** | Inline iframe with IFRAME_HTML string and constructor | Routes through `sandbox.html` via postMessage |
 | **Node command** | Direct constructor usage | Wraps user code, posts to sandbox iframe |
 | **Fetch proxy** | `/api/fetch-proxy` endpoint | Same sandbox iframe postMessage |
+| **Panel sprinkles** | Fragments: direct DOM; Full docs: srcdoc iframe | ALL: routes through `sprinkle-sandbox.html` via postMessage |
+| **Inline sprinkles** | Direct srcdoc iframe | Routes through `sprinkle-sandbox.html` via postMessage |
 
 **Code Pattern: Three-Branch Detection**
 

--- a/sprinkle-sandbox.html
+++ b/sprinkle-sandbox.html
@@ -121,6 +121,86 @@ window.slicc = {
 };
 window.bridge = window.slicc;
 
+// ── Helper: inject content into a full HTML document's <head> ─────
+function injectIntoHead(html, injection) {
+  var headMatch = html.match(/<head\b[^>]*>/i);
+  if (headMatch) {
+    var pos = headMatch.index + headMatch[0].length;
+    return html.slice(0, pos) + injection + html.slice(pos);
+  }
+  var scriptMatch = html.match(/<script\b/i);
+  if (scriptMatch) {
+    return html.slice(0, scriptMatch.index) + injection + html.slice(scriptMatch.index);
+  }
+  var htmlMatch = html.match(/<html\b[^>]*>/i);
+  if (htmlMatch) {
+    var pos2 = htmlMatch.index + htmlMatch[0].length;
+    return html.slice(0, pos2) + injection + html.slice(pos2);
+  }
+  return injection + html;
+}
+
+// ── Helper: build a self-contained bridge script for nested iframe ─
+function buildNestedBridgeScript(savedState, savedStorage, name) {
+  var stateJson, storageJson, nameJson;
+  try { stateJson = JSON.stringify(savedState || null); } catch(e) { stateJson = 'null'; }
+  try { storageJson = JSON.stringify(savedStorage || {}); } catch(e) { storageJson = '{}'; }
+  try { nameJson = JSON.stringify(name); } catch(e) { nameJson = '""'; }
+
+  return '(function() {' +
+    'window.__slicc_sd = ' + storageJson + ';' +
+    'window.__slicc_storage = {' +
+      'getItem: function(key) { var v = window.__slicc_sd[key]; return v === undefined ? null : v; },' +
+      'setItem: function(key, value) { window.__slicc_sd[key] = String(value); parent.postMessage({ type: "sprinkle-storage-set", key: key, value: String(value) }, "*"); },' +
+      'removeItem: function(key) { delete window.__slicc_sd[key]; parent.postMessage({ type: "sprinkle-storage-remove", key: key }, "*"); },' +
+      'clear: function() { var ks = Object.keys(window.__slicc_sd); for (var i = 0; i < ks.length; i++) delete window.__slicc_sd[ks[i]]; parent.postMessage({ type: "sprinkle-storage-clear" }, "*"); },' +
+      'get length() { return Object.keys(window.__slicc_sd).length; },' +
+      'key: function(index) { var ks = Object.keys(window.__slicc_sd); return index >= 0 && index < ks.length ? ks[index] : null; }' +
+    '};' +
+    'try { Object.defineProperty(window, "localStorage", { get: function() { return window.__slicc_storage; }, configurable: true }); } catch(e) {' +
+      'try { Object.defineProperty(Window.prototype, "localStorage", { get: function() { return window.__slicc_storage; }, configurable: true }); } catch(e2) {}' +
+    '}' +
+    'window.__slicc_listeners = new Set();' +
+    'window.__slicc_name = ' + nameJson + ';' +
+    'window.__slicc_state = ' + stateJson + ';' +
+    'window.slicc = {' +
+      'get name() { return window.__slicc_name; },' +
+      'lick: function(event) {' +
+        'var action = typeof event === "string" ? event : event.action;' +
+        'var data = typeof event === "string" ? undefined : event.data;' +
+        'parent.postMessage({ type: "sprinkle-lick", action: action, data: data }, "*");' +
+      '},' +
+      'on: function(event, callback) { if (event === "update") window.__slicc_listeners.add(callback); },' +
+      'off: function(event, callback) { if (event === "update") window.__slicc_listeners.delete(callback); },' +
+      'readFile: function(path) {' +
+        'return new Promise(function(resolve, reject) {' +
+          'var id = "rf-" + Math.random().toString(36).slice(2);' +
+          'function handler(event) {' +
+            'if (event.data && event.data.type === "sprinkle-readfile-response" && event.data.id === id) {' +
+              'removeEventListener("message", handler);' +
+              'if (event.data.error) reject(new Error(event.data.error)); else resolve(event.data.content);' +
+            '}' +
+          '}' +
+          'addEventListener("message", handler);' +
+          'parent.postMessage({ type: "sprinkle-readfile", id: id, path: path }, "*");' +
+        '});' +
+      '},' +
+      'setState: function(data) { window.__slicc_state = data; parent.postMessage({ type: "sprinkle-set-state", data: data }, "*"); },' +
+      'getState: function() { return window.__slicc_state; },' +
+      'open: function(path, opts) { parent.postMessage({ type: "sprinkle-open", path: path, projectRoot: opts && opts.projectRoot || null }, "*"); },' +
+      'close: function() { parent.postMessage({ type: "sprinkle-close" }, "*"); }' +
+    '};' +
+    'window.bridge = window.slicc;' +
+    'addEventListener("message", function(e) {' +
+      'var msg = e.data;' +
+      'if (!msg || !msg.type) return;' +
+      'if (msg.type === "sprinkle-update") {' +
+        'window.__slicc_listeners.forEach(function(cb) { try { cb(msg.data); } catch(err) {} });' +
+      '}' +
+    '});' +
+  '})();';
+}
+
 // ── Message handler ────────────────────────────────────────────────
 addEventListener('message', function(e) {
   var msg = e.data;
@@ -138,48 +218,107 @@ addEventListener('message', function(e) {
       }
     }
 
-    // Inject parent page's CSS custom properties (theme tokens)
-    if (msg.themeCSS) {
-      var themeStyle = document.createElement('style');
-      themeStyle.textContent = msg.themeCSS;
-      document.head.appendChild(themeStyle);
-    }
+    if (msg.fullDoc) {
+      // ── Full-document mode: render in a nested srcdoc iframe ──────
+      // The sandbox is CSP-exempt, so the nested iframe's inline scripts
+      // execute freely. We inject bridge + localStorage polyfill into
+      // the full document HTML, then relay messages between parent and child.
+      var bridgeScript = buildNestedBridgeScript(msg.savedState, msg.savedStorage, msg.name || '');
+      var themeTag = msg.themeCSS ? '<style>' + msg.themeCSS + '</style>' : '';
+      var injection = '<script>' + bridgeScript + '<\/script>' + themeTag;
+      var modifiedHtml = injectIntoHead(msg.content, injection);
 
-    // Render the SHTML content (trusted user/agent-authored sprinkle)
-    // eslint-disable-next-line no-unsanitized/property -- trusted content, same as CLI renderer
-    document.body.innerHTML = msg.content;
+      while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+      var childIframe = document.createElement('iframe');
+      childIframe.setAttribute('sandbox', 'allow-scripts');
+      childIframe.style.cssText = 'width: 100%; height: 100%; border: none;';
+      childIframe.srcdoc = modifiedHtml;
+      document.body.appendChild(childIframe);
 
-    // Auto-set width on .fill elements
-    var fills = document.querySelectorAll('.fill[data-value]');
-    for (var i = 0; i < fills.length; i++) {
-      var v = parseFloat(fills[i].getAttribute('data-value') || '0');
-      if (v >= 0 && v <= 100) fills[i].style.width = v + '%';
-    }
+      window.__slicc_childIframe = childIframe;
 
-    // Execute scripts (sandbox is CSP-exempt)
-    // IMPORTANT: scope to body — document.querySelectorAll would also grab
-    // the head script, re-execute it, and reset all window state.
-    var deadScripts = Array.from(document.body.querySelectorAll('script'));
-    for (var j = 0; j < deadScripts.length; j++) {
-      var dead = deadScripts[j];
-      dead.remove();
-      var live = document.createElement('script');
-      for (var k = 0; k < dead.attributes.length; k++) {
-        live.setAttribute(dead.attributes[k].name, dead.attributes[k].value);
+      parent.postMessage({ type: 'sprinkle-rendered' }, '*');
+    } else {
+      // ── Partial-content mode (existing path) ──────────────────────
+
+      // Inject parent page's CSS custom properties (theme tokens)
+      if (msg.themeCSS) {
+        var themeStyle = document.createElement('style');
+        themeStyle.textContent = msg.themeCSS;
+        document.head.appendChild(themeStyle);
       }
-      if (!dead.src) {
-        live.textContent = dead.textContent;
-      }
-      document.body.appendChild(live);
-    }
 
-    parent.postMessage({ type: 'sprinkle-rendered' }, '*');
+      // Render the SHTML content (trusted user/agent-authored sprinkle)
+      // eslint-disable-next-line no-unsanitized/property -- trusted content, same as CLI renderer
+      document.body.innerHTML = msg.content;
+
+      // Auto-set width on .fill elements
+      var fills = document.querySelectorAll('.fill[data-value]');
+      for (var i = 0; i < fills.length; i++) {
+        var v = parseFloat(fills[i].getAttribute('data-value') || '0');
+        if (v >= 0 && v <= 100) fills[i].style.width = v + '%';
+      }
+
+      // Execute scripts (sandbox is CSP-exempt)
+      // IMPORTANT: scope to body — document.querySelectorAll would also grab
+      // the head script, re-execute it, and reset all window state.
+      var deadScripts = Array.from(document.body.querySelectorAll('script'));
+      for (var j = 0; j < deadScripts.length; j++) {
+        var dead = deadScripts[j];
+        dead.remove();
+        var live = document.createElement('script');
+        for (var k = 0; k < dead.attributes.length; k++) {
+          live.setAttribute(dead.attributes[k].name, dead.attributes[k].value);
+        }
+        if (!dead.src) {
+          live.textContent = dead.textContent;
+        }
+        document.body.appendChild(live);
+      }
+
+      parent.postMessage({ type: 'sprinkle-rendered' }, '*');
+    }
   }
 
   if (msg.type === 'sprinkle-update') {
+    if (window.__slicc_childIframe && window.__slicc_childIframe.contentWindow) {
+      window.__slicc_childIframe.contentWindow.postMessage({ type: 'sprinkle-update', data: msg.data }, '*');
+    }
     window.__slicc_listeners.forEach(function(cb) {
       try { cb(msg.data); } catch(e) { /* ignore */ }
     });
+  }
+
+  // Forward readfile responses to nested child iframe
+  if (msg.type === 'sprinkle-readfile-response') {
+    if (window.__slicc_childIframe && window.__slicc_childIframe.contentWindow) {
+      window.__slicc_childIframe.contentWindow.postMessage(msg, '*');
+    }
+  }
+
+  // ── Inline sprinkle rendering (extension mode) ─────────────────────
+  if (msg.type === 'inline-sprinkle-render') {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+    var inlineIframe = document.createElement('iframe');
+    inlineIframe.setAttribute('sandbox', 'allow-scripts');
+    inlineIframe.style.cssText = 'width: 100%; height: 100%; border: none; overflow: hidden;';
+    document.body.style.overflow = 'hidden';
+    inlineIframe.srcdoc = msg.srcdoc;
+    document.body.appendChild(inlineIframe);
+    window.__slicc_childIframe = inlineIframe;
+  }
+
+  // Relay bridge messages FROM the nested child iframe TO the extension page.
+  if (window.__slicc_childIframe && e.source === window.__slicc_childIframe.contentWindow) {
+    var bridgeTypes = [
+      'sprinkle-lick', 'sprinkle-set-state', 'sprinkle-close',
+      'sprinkle-open', 'sprinkle-readfile',
+      'sprinkle-storage-set', 'sprinkle-storage-remove', 'sprinkle-storage-clear',
+      'inline-sprinkle-lick', 'inline-sprinkle-height'
+    ];
+    if (bridgeTypes.indexOf(msg.type) !== -1) {
+      parent.postMessage(msg, '*');
+    }
   }
 });
 </script>

--- a/src/ui/inline-sprinkle.ts
+++ b/src/ui/inline-sprinkle.ts
@@ -8,6 +8,8 @@
 
 import { collectThemeCSS } from './sprinkle-renderer.js';
 
+const isExtension = typeof chrome !== 'undefined' && !!(chrome as any)?.runtime?.id;
+
 /** Minimal bridge script: lick-only + auto-height reporting. */
 const BRIDGE_SCRIPT = `(function() {
   window.slicc = window.bridge = {
@@ -95,6 +97,10 @@ mark{background:color-mix(in srgb,var(--s2-accent) 25%,transparent);color:inheri
 </head>
 <body class="sprinkle-inline">${content}</body></html>`;
 
+  if (isExtension) {
+    return mountInlineSprinkleExtension(container, srcdoc, onLick);
+  }
+
   const iframe = document.createElement('iframe');
   iframe.setAttribute('sandbox', 'allow-scripts');
   iframe.style.cssText = 'width:100%;border:none;overflow:hidden;display:block;';
@@ -152,7 +158,48 @@ export function hydrateInlineSprinkles(
 /** Dispose all inline sprinkle instances and clear the array. */
 export function disposeInlineSprinkles(instances: InlineSprinkleInstance[]): void {
   for (const inst of instances) {
-    inst.dispose();
+    try { inst.dispose(); } catch { /* best-effort cleanup */ }
   }
   instances.length = 0;
+}
+
+/**
+ * Extension mode: route inline sprinkle through the manifest sandbox (CSP-exempt).
+ * The sandbox creates a nested srcdoc iframe and relays messages back.
+ */
+function mountInlineSprinkleExtension(
+  container: HTMLElement,
+  srcdoc: string,
+  onLick: (action: string, data: unknown) => void,
+): InlineSprinkleInstance {
+  const iframe = document.createElement('iframe');
+  iframe.src = chrome.runtime.getURL('sprinkle-sandbox.html');
+  iframe.style.cssText = 'width:100%;border:none;overflow:hidden;display:block;';
+  container.appendChild(iframe);
+
+  const messageHandler = (event: MessageEvent) => {
+    if (event.source !== iframe.contentWindow) return;
+    const msg = event.data;
+    if (!msg?.type) return;
+
+    if (msg.type === 'inline-sprinkle-lick') {
+      onLick(msg.action, msg.data);
+    } else if (msg.type === 'inline-sprinkle-height') {
+      iframe.style.height = msg.height + 'px';
+    }
+  };
+  window.addEventListener('message', messageHandler);
+
+  iframe.addEventListener('load', () => {
+    iframe.contentWindow?.postMessage(
+      { type: 'inline-sprinkle-render', srcdoc }, '*',
+    );
+  }, { once: true });
+
+  return {
+    dispose() {
+      window.removeEventListener('message', messageHandler);
+      iframe.remove();
+    },
+  };
 }

--- a/src/ui/sprinkle-renderer.ts
+++ b/src/ui/sprinkle-renderer.ts
@@ -39,10 +39,12 @@ export class SprinkleRenderer {
   async render(content: string, sprinkleName: string): Promise<void> {
     this.dispose();
 
-    if (isFullDocument(content)) {
+    if (isExtension) {
+      // Extension mode: always route through manifest sandbox (CSP-exempt).
+      // Full documents need the fullDoc flag so the sandbox creates a nested iframe.
+      await this.renderInSandbox(content, sprinkleName, isFullDocument(content));
+    } else if (isFullDocument(content)) {
       await this.renderFullDoc(content, sprinkleName);
-    } else if (isExtension) {
-      await this.renderInSandbox(content, sprinkleName);
     } else {
       this.renderInline(content, sprinkleName);
     }
@@ -52,7 +54,7 @@ export class SprinkleRenderer {
    * Extension mode: render inside a sandbox iframe (CSP-exempt).
    * Bridge communication happens via postMessage.
    */
-  private async renderInSandbox(content: string, sprinkleName: string): Promise<void> {
+  private async renderInSandbox(content: string, sprinkleName: string, fullDoc = false): Promise<void> {
     const iframe = document.createElement('iframe');
     iframe.src = chrome.runtime.getURL('sprinkle-sandbox.html');
     iframe.style.cssText = 'width: 100%; flex: 1; border: none; min-height: 0;';
@@ -139,7 +141,7 @@ export class SprinkleRenderer {
     // Send content to the sandbox for rendering, including saved state + localStorage
     const savedState = this.bridge.getState();
     iframe.contentWindow!.postMessage(
-      { type: 'sprinkle-render', content, name: sprinkleName, themeCSS, savedState, savedStorage }, '*',
+      { type: 'sprinkle-render', content, name: sprinkleName, themeCSS, savedState, savedStorage, fullDoc }, '*',
     );
   }
 


### PR DESCRIPTION
## Summary

In extension mode, `srcdoc` iframes inherit the parent page's CSP (`script-src 'self' 'wasm-unsafe-eval'`), which blocks all inline scripts. This breaks both full-document panel sprinkles and inline sprinkles.

### Panel sprinkles (full-doc)

`SprinkleRenderer.render()` now routes all extension-mode content through the manifest sandbox (CSP-exempt). Full documents get a `fullDoc` flag that triggers a nested `srcdoc` iframe inside the sandbox, with an injected bridge script + localStorage polyfill. The sandbox relays bridge messages (lick, setState, readFile, storage, etc.) between the child iframe and the extension page.

### Inline sprinkles (shtml code blocks + tool UI)

`mountInlineSprinkle()` now detects extension mode and routes through the same sandbox with a new `inline-sprinkle-render` message type. The sandbox creates a nested `srcdoc` iframe and relays `inline-sprinkle-lick` and `inline-sprinkle-height` messages back to the extension page.

### Files changed

- **`src/ui/sprinkle-renderer.ts`** — Extension mode always uses `renderInSandbox` with `fullDoc` flag
- **`src/ui/inline-sprinkle.ts`** — Extension mode routes through sandbox via `mountInlineSprinkleExtension`
- **`sprinkle-sandbox.html`** — `injectIntoHead` + `buildNestedBridgeScript` helpers, `fullDoc` branch in render handler, `inline-sprinkle-render` handler, message relay for both bridge and inline message types

### What stays unchanged

- CLI mode panel sprinkles (renderFullDoc / renderInline)
- CLI mode inline sprinkles (direct srcdoc)
- Extension mode partial-content sprinkles (existing renderInSandbox path)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (1640 tests)
- [x] `npm run build` passes
- [x] `npm run build:extension` passes
- [x] Manual: full-document sprinkle with buttons/scripts works in extension — no CSP errors
- [x] Manual: inline sprinkles (shtml code blocks) work in extension with lick events
- [x] Manual: partial-HTML sprinkles in extension still work
- [x] Manual: CLI mode sprinkles still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)