### PR TITLE
feat: `debug` command to toggle Terminal/Memory tabs in extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Virtual Filesystem (src/fs/) → RestrictedFS → Shell (src/shell/) + Git (src/
 
 **VirtualFS** (`src/fs/`): POSIX-like async FS backed by LightningFS (IndexedDB). `RestrictedFS` wraps it with path ACLs for scoops. `FsError` carries POSIX error codes.
 
-**Shell** (`src/shell/`): WasmShell wraps just-bash 2.11.7 (WASM). 78+ commands including `git`, `node -e`, `python3 -c`, `playwright-cli`, `open`, `serve`, `sqlite3`, `convert`, `pdftk`, `skill`, `upskill`, `webhook`, `crontask`, `mount`, `oauth-token`. Any `*.jsh` file on VFS is auto-discovered as a command. Extension CSP workaround: dynamic code routes through `sandbox.html`.
+**Shell** (`src/shell/`): WasmShell wraps just-bash 2.11.7 (WASM). 78+ commands including `git`, `node -e`, `python3 -c`, `playwright-cli`, `open`, `serve`, `sqlite3`, `convert`, `pdftk`, `skill`, `upskill`, `webhook`, `crontask`, `mount`, `oauth-token`, `debug`. Any `*.jsh` file on VFS is auto-discovered as a command. Extension CSP workaround: dynamic code routes through `sandbox.html`. **Two shell contexts in extension mode**: side panel has its own WasmShell (mounted in terminal tab), offscreen document has the agent's WasmShell (runs bash tool calls). Commands that affect the UI must handle both — use `window.__slicc_*` hooks for direct calls (panel) and `chrome.runtime.sendMessage` relay for offscreen→panel communication.
 
 **CDP** (`src/cdp/`): `CDPTransport` interface with WebSocket (CLI) and `chrome.debugger` (extension) implementations. `BrowserAPI` provides Playwright-style API (listPages, navigate, screenshot, evaluate, click, etc.). Screenshots normalize DPR to 1.
 
@@ -92,9 +92,9 @@ Virtual Filesystem (src/fs/) → RestrictedFS → Shell (src/shell/) + Git (src/
 
 **Context Compaction** (`src/core/context-compaction.ts`): LLM-summarized compaction at ~183K tokens. Images auto-resized before LLM (5MB base64 limit). Overflow recovery replaces oversized messages (>40K chars) with placeholders.
 
-**UI** (`src/ui/`): Vanilla TypeScript, no framework. Extension mode: compact tabbed interface. Standalone: resizable split layout. `main.ts` delegates to `mainExtension()` (OffscreenClient) or bootstraps Orchestrator directly.
+**UI** (`src/ui/`): Vanilla TypeScript, no framework. Extension mode: compact tabbed interface (Chat + Files visible by default; Terminal + Memory hidden — toggle with `debug on`). Standalone: resizable split layout with all panels visible. `main.ts` delegates to `mainExtension()` (OffscreenClient) or bootstraps Orchestrator directly. Tab bar is fully dynamic — `TabZone.addTab()`/`removeTab()` adds/removes tabs at runtime (used by sprinkle panels and the `debug` command).
 
-**Extension** (`src/extension/`): Service worker relays messages + proxies chrome.debugger. Offscreen document runs agent engine (survives side panel close). Chat persistence: `browser-coding-agent` IndexedDB is single source of truth.
+**Extension** (`src/extension/`): Service worker relays messages + proxies chrome.debugger. Offscreen document runs agent engine (survives side panel close). Chat persistence: `browser-coding-agent` IndexedDB is single source of truth. **Key architecture detail**: the extension has two separate execution contexts with independent shell instances — the side panel (UI, terminal shell, Layout) and the offscreen document (agent engine, bash tool shell, Orchestrator). They share IndexedDB but NOT window globals. Communication is via `chrome.runtime` messages routed through the service worker. See `docs/architecture.md` "Extension Three-Layer Architecture".
 
 **Preview SW** (`src/ui/preview-sw.ts`): Intercepts `/preview/*` requests, serves VFS content. Built as IIFE via esbuild (not rollup — avoids code-splitting issues in SWs).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,6 +143,7 @@
 | `oauth-token-command.ts` | `oauth-token` — retrieve OAuth access tokens for configured providers with auto-login |
 | `playwright-command.ts` | `playwright-cli` / `playwright` / `puppeteer` — browser automation shell commands (navigate, snapshot, click, screenshot, cookies, HAR recording) |
 | `sprinkle-command.ts` | `sprinkle` — list, open, close, and refresh `.shtml` sprinkle panels from the agent |
+| `debug-command.ts` | `debug` — toggle Terminal/Memory tabs in extension mode (extension-only, uses dual-context hook+relay pattern) |
 | `magick-wasm.ts` | Shared ImageMagick WASM initialization module for dual-mode (CLI/browser CDN vs extension bundled) image processing |
 
 ### src/skills/ — Skill Package Manager
@@ -304,6 +305,8 @@ The Chrome extension uses a three-layer design to keep the agent engine alive ac
 - `slicc-groups` DB: Orchestrator routing data (scoops, tasks, webhooks, crontasks)
 
 **CDP Proxy:** Offscreen documents can't call `chrome.debugger` directly. Instead, offscreen sends `CdpProxyMessage` through the service worker, which translates to `chrome.debugger` commands and routes results back.
+
+**Dual Shell Context:** Both the side panel and offscreen document run their own WasmShell instance. The panel shell powers the Terminal tab; the offscreen shell executes agent bash tool calls. They share VFS via IndexedDB but NOT window globals or DOM. Shell commands that affect the panel UI (e.g., `debug on`) must use the dual-context pattern: try `window.__slicc_*` hook first (panel), fall back to `chrome.runtime.sendMessage` relay (offscreen → panel). See `docs/pitfalls.md` "Extension Dual-Shell Context".
 
 ## Data Flow Diagrams
 

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -423,6 +423,45 @@ The service worker must only import **types** (erased at compile time) from othe
 
 **Current example**: `addToSliccGroup` has an inline copy in `service-worker.ts` and a canonical version in `tab-group.ts` (imported by `debugger-client.ts` in the offscreen document, which IS an ES module).
 
+## Extension Dual-Shell Context
+
+**The Problem**
+
+In extension mode, there are **two separate WasmShell instances** running in different execution contexts:
+
+| Context | Location | Shell purpose | Window globals |
+|---------|----------|---------------|----------------|
+| **Side panel** | `src/ui/main.ts` (mainExtension) | Terminal tab — user-facing shell | Has Layout, `__slicc_debug_tabs`, DOM |
+| **Offscreen document** | `src/extension/offscreen.ts` | Agent's bash tool — LLM-driven | Has Orchestrator, no DOM/Layout |
+
+These contexts share IndexedDB (VFS, sessions) but **NOT** window globals, DOM, or Layout instances. They communicate via `chrome.runtime` messages routed through the service worker.
+
+**The Pattern: UI-Affecting Shell Commands**
+
+Shell commands that need to affect the side panel UI (e.g., `debug on` toggling tabs) must handle both contexts:
+
+1. **Direct hook** (panel context): check `window.__slicc_*` — if present, call directly
+2. **Message relay** (offscreen context): send `chrome.runtime.sendMessage({ source: 'offscreen', payload: { type: '...', ... } })` → service worker routes to panel → `OffscreenClient` handles in `setupMessageListener()`
+
+```typescript
+// Pattern: try direct hook, fall back to message relay
+const toggle = (window as any).__slicc_debug_tabs;
+if (toggle) {
+  toggle(show); // Running in panel context
+} else {
+  chrome.runtime.sendMessage({ source: 'offscreen', payload: { type: 'debug-tabs', show } });
+}
+```
+
+**Current example**: `debug-command.ts` uses this pattern. Panel registers hook in `main.ts`; `offscreen-client.ts` handles the relay message.
+
+**Related Files**
+- `src/shell/supplemental-commands/debug-command.ts` (dual-context command, tries hook then relay)
+- `src/ui/main.ts` line 187 (registers `__slicc_debug_tabs` hook)
+- `src/ui/offscreen-client.ts` line 235 (relays `debug-tabs` message to hook)
+- `src/ui/layout.ts` `setDebugTabs()` (UI state — adds/removes tabs dynamically)
+- `src/ui/tabbed-ui.ts` `setHiddenTabs()` (persistence — saves to localStorage)
+
 ## Dual-Mode Testing Checklist
 
 When adding a feature that touches:

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -38,6 +38,7 @@ Custom commands implemented in TypeScript and registered in just-bash.
 | **screencapture** | `screencapture-command.ts` | Capture user's screen via browser screen sharing API | `<output.png>`, `-c` (clipboard), `-v` / `--view` (agent vision) |
 | **upskill** | `upskill-command.ts` | Install skills from GitHub/ClawHub | `upskill owner/repo`, `upskill clawhub:name`, `upskill search "query"` |
 | **sprinkle** | `sprinkle-command.ts` | Manage `.shtml` sprinkle panels and inline chat UI | `sprinkle list`, `sprinkle open <name>`, `sprinkle chat '<html>'` |
+| **debug** | `debug-command.ts` | Toggle Terminal/Memory tabs in extension mode | `debug on`, `debug off`, no args = show state; extension-only (not registered in CLI) |
 | **git** | (isomorphic-git) | Full git support | `git clone`, `git commit`, `git push`, etc. |
 
 **Example usage**:

--- a/src/shell/supplemental-commands/debug-command.test.ts
+++ b/src/shell/supplemental-commands/debug-command.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { IFileSystem } from 'just-bash';
+import { createDebugCommand } from './debug-command.js';
+
+function createMockCtx() {
+  return {
+    fs: { resolvePath: (b: string, p: string) => p.startsWith('/') ? p : `${b}/${p}` } as IFileSystem,
+    cwd: '/home',
+    env: new Map<string, string>(),
+    stdin: '',
+  };
+}
+
+describe('debug command', () => {
+  const ctx = createMockCtx();
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+    });
+    vi.stubGlobal('window', {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('has correct name', () => {
+    expect(createDebugCommand().name).toBe('debug');
+  });
+
+  it('shows help with --help', async () => {
+    const result = await createDebugCommand().execute(['--help'], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('usage: debug');
+  });
+
+  it('rejects unknown arguments', async () => {
+    const result = await createDebugCommand().execute(['maybe'], ctx);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("unknown argument 'maybe'");
+  });
+
+  it('shows current state as off by default', async () => {
+    const result = await createDebugCommand().execute([], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('off');
+  });
+
+  it('shows current state as on when hidden tabs is empty', async () => {
+    vi.mocked(localStorage.getItem).mockReturnValue('[]');
+    const result = await createDebugCommand().execute([], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('on');
+  });
+
+  it('calls direct hook when available (panel context)', async () => {
+    const toggle = vi.fn();
+    (window as any).__slicc_debug_tabs = toggle;
+
+    const result = await createDebugCommand().execute(['on'], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('enabled');
+    expect(toggle).toHaveBeenCalledWith(true);
+  });
+
+  it('calls direct hook with false for off', async () => {
+    const toggle = vi.fn();
+    (window as any).__slicc_debug_tabs = toggle;
+
+    const result = await createDebugCommand().execute(['off'], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('hidden');
+    expect(toggle).toHaveBeenCalledWith(false);
+  });
+
+  it('falls back to chrome.runtime.sendMessage when no direct hook (offscreen context)', async () => {
+    const sendMessage = vi.fn();
+    vi.stubGlobal('chrome', { runtime: { sendMessage } });
+
+    const result = await createDebugCommand().execute(['on'], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(sendMessage).toHaveBeenCalledWith({
+      source: 'offscreen',
+      payload: { type: 'debug-tabs', show: true },
+    });
+  });
+
+  it('returns error when neither hook nor chrome.runtime available', async () => {
+    const result = await createDebugCommand().execute(['on'], ctx);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('failed');
+  });
+});

--- a/src/shell/supplemental-commands/debug-command.ts
+++ b/src/shell/supplemental-commands/debug-command.ts
@@ -1,0 +1,64 @@
+import { defineCommand } from 'just-bash';
+import type { Command } from 'just-bash';
+
+/**
+ * Extension-only command to toggle debug tabs (Terminal, Memory).
+ *
+ * May run in either the side panel shell or the offscreen agent shell.
+ * Tries the direct window hook first (panel), then falls back to
+ * chrome.runtime messaging (offscreen → service worker → panel).
+ */
+export function createDebugCommand(): Command {
+  return defineCommand('debug', async (args) => {
+    if (args.includes('--help') || args.includes('-h')) {
+      return {
+        stdout:
+          'usage: debug [on|off]\n\n' +
+          '  Toggle debug tabs (Terminal, Memory) in extension mode.\n' +
+          '  Without arguments, shows current state.\n',
+        stderr: '',
+        exitCode: 0,
+      };
+    }
+
+    const arg = args[0]?.toLowerCase();
+    if (arg !== 'on' && arg !== 'off' && arg !== undefined) {
+      return {
+        stdout: '',
+        stderr: `debug: unknown argument '${arg}' (use 'on' or 'off')\n`,
+        exitCode: 1,
+      };
+    }
+
+    if (!arg) {
+      try {
+        const raw = localStorage.getItem('slicc-hidden-tabs');
+        const hidden = raw ? JSON.parse(raw) as string[] : ['terminal', 'memory'];
+        const on = !hidden.includes('terminal');
+        return { stdout: `Debug tabs: ${on ? 'on' : 'off'}\n`, stderr: '', exitCode: 0 };
+      } catch {
+        return { stdout: 'Debug tabs: off\n', stderr: '', exitCode: 0 };
+      }
+    }
+
+    const show = arg === 'on';
+
+    // Try direct hook (works when running in the side panel's shell)
+    const toggle = (window as any).__slicc_debug_tabs as ((show: boolean) => void) | undefined;
+    if (toggle) {
+      toggle(show);
+      return { stdout: `Debug tabs ${show ? 'enabled' : 'hidden'}\n`, stderr: '', exitCode: 0 };
+    }
+
+    // Offscreen context: relay via chrome.runtime to the panel
+    try {
+      (chrome as any).runtime.sendMessage({
+        source: 'offscreen',
+        payload: { type: 'debug-tabs', show },
+      });
+      return { stdout: `Debug tabs ${show ? 'enabled' : 'hidden'}\n`, stderr: '', exitCode: 0 };
+    } catch {
+      return { stdout: '', stderr: 'debug: failed to send toggle message\n', exitCode: 1 };
+    }
+  });
+}

--- a/src/shell/supplemental-commands/index.ts
+++ b/src/shell/supplemental-commands/index.ts
@@ -25,6 +25,7 @@ import { createScreencaptureCommand } from './screencapture-command.js';
 import { createPbcopyCommand, createPbpasteCommand, createClipboardAutoCommand } from './clipboard-commands.js';
 import { createSayCommand } from './say-command.js';
 import { createAfplayCommand, createChimeCommand } from './afplay-command.js';
+import { createDebugCommand } from './debug-command.js';
 import type { BrowserAPI } from '../../cdp/index.js';
 export type {
   ImgcatCommandOptions as SupplementalCommandOptions,
@@ -72,6 +73,12 @@ export function createSupplementalCommands(options: SupplementalCommandsConfig =
     createAfplayCommand(),
     createChimeCommand(),
   ];
+
+  // Extension-only commands
+  const isExtension = typeof chrome !== 'undefined' && !!(chrome as any)?.runtime?.id;
+  if (isExtension) {
+    commands.push(createDebugCommand());
+  }
 
   if (options.fs) {
     commands.push(

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -37,7 +37,7 @@ import {
   getAllAvailableModels,
   getProviderConfig,
 } from './provider-settings.js';
-import { EXTENSION_TAB_SPECS, type ExtensionTabId } from './tabbed-ui.js';
+import { EXTENSION_TAB_SPECS, setHiddenTabs, type ExtensionTabId } from './tabbed-ui.js';
 import { TabZone } from './tab-zone.js';
 import { PanelRegistry } from './panel-registry.js';
 import { showSprinklePicker } from './sprinkle-picker.js';
@@ -82,6 +82,8 @@ export class Layout {
   // Tabbed-layout elements (extension only)
   private tabContainers = new Map<TabId, HTMLElement>();
   private activeTab: TabId = 'chat';
+  /** Pre-created containers for debug tabs (terminal, memory) — always created, tab added on demand. */
+  private debugTabContainers: { terminal: HTMLElement; memory: HTMLElement } | null = null;
   private actionsEl!: HTMLElement;
 
   // Scoop switcher (extension mode)
@@ -164,6 +166,28 @@ export class Layout {
   openTerminal(): void {
     if (this.isExtension) return;
     this.drawerZone.activateTab('terminal');
+  }
+
+  /** Show or hide debug tabs (terminal, memory) in extension mode. */
+  setDebugTabs(show: boolean): void {
+    if (!this.isExtension || !this.debugTabContainers) return;
+
+    const DEBUG_TABS = [
+      { id: 'terminal' as const, label: 'Terminal', container: this.debugTabContainers.terminal, onActivate: () => this.panels?.terminal?.refit?.() },
+      { id: 'memory' as const, label: 'Memory', container: this.debugTabContainers.memory, onActivate: () => this.panels?.memory?.refresh() },
+    ];
+
+    for (const { id, label, container, onActivate } of DEBUG_TABS) {
+      if (show && !this.extensionZone.hasTab(id)) {
+        this.extensionZone.addTab({ id, label, closable: false, element: container, onActivate });
+        this.tabContainers.set(id, container);
+      } else if (!show && this.extensionZone.hasTab(id)) {
+        this.extensionZone.removeTab(id);
+        this.tabContainers.delete(id);
+      }
+    }
+
+    setHiddenTabs(show ? [] : ['terminal', 'memory']);
   }
 
   // ── Shared: Header ──────────────────────────────────────────────────
@@ -755,6 +779,9 @@ export class Layout {
       // Keep tabContainers in sync for backward compat
       this.tabContainers.set(id, container);
     }
+
+    // Store debug tab containers for dynamic add/remove
+    this.debugTabContainers = { terminal: terminalContainer, memory: memoryContainer };
 
     this.extensionZone.enableAddButton();
 

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -183,6 +183,8 @@ async function mainExtension(app: HTMLElement): Promise<void> {
   const { VirtualFS } = await import('../fs/index.js');
 
   const layout = new Layout(app, true);
+  // Expose debug tab toggle for the shell `debug` command
+  (window as any).__slicc_debug_tabs = (show: boolean) => layout.setDebugTabs(show);
   await layout.panels.chat.initSession('session-cone');
 
   let selectedScoop: RegisteredScoop | null = null;

--- a/src/ui/offscreen-client.ts
+++ b/src/ui/offscreen-client.ts
@@ -231,8 +231,11 @@ export class OffscreenClient {
 
         if (msg.source === 'offscreen') {
           const payload = msg.payload as any;
-          // Route sprinkle-op to the registered handler
-          if (payload?.type === 'sprinkle-op' && this.sprinkleOpHandler) {
+          // Route debug-tabs toggle to the panel's Layout
+          if (payload?.type === 'debug-tabs') {
+            const toggle = (window as any).__slicc_debug_tabs as ((show: boolean) => void) | undefined;
+            toggle?.(!!payload.show);
+          } else if (payload?.type === 'sprinkle-op' && this.sprinkleOpHandler) {
             this.sprinkleOpHandler(payload);
           } else {
             this.handleOffscreenMessage(msg.payload as OffscreenToPanelMessage | StateSnapshotMsg);


### PR DESCRIPTION
## Summary

In extension mode, Terminal and Memory tabs are hidden by default to keep the UI compact. This adds a `debug` shell command to dynamically show/hide them.

```
debug on    # Show Terminal and Memory tabs
debug off   # Hide them
debug       # Show current state
```

### How it works

- `Layout.setDebugTabs(show)` dynamically adds/removes tabs via `TabZone.addTab()`/`removeTab()` — same mechanism used by sprinkle panels
- Setting persists in localStorage (`slicc-hidden-tabs`) across reloads
- Works from both the side panel terminal (direct call) and agent bash tool (offscreen → chrome.runtime message → panel)
- Command only registered in extension mode — doesn't exist in CLI/standalone

### Files changed

- **`src/shell/supplemental-commands/debug-command.ts`** — New command, tries direct hook then falls back to chrome.runtime relay
- **`src/shell/supplemental-commands/index.ts`** — Register command in extension mode only
- **`src/ui/layout.ts`** — `setDebugTabs()` method, stores debug tab containers as instance fields
- **`src/ui/main.ts`** — Exposes `window.__slicc_debug_tabs` hook in extension mode
- **`src/ui/offscreen-client.ts`** — Handles `debug-tabs` message from offscreen agent

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (1640 tests)
- [x] `npm run build` passes
- [x] `npm run build:extension` passes
- [ ] Manual: `debug on` in extension shows Terminal + Memory tabs
- [ ] Manual: `debug off` hides them
- [ ] Manual: Agent running `debug on` via bash tool works (offscreen relay)
- [ ] Manual: Setting persists after side panel reload
- [ ] Manual: Command not available in CLI mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)