### PR TITLE
fix: restrict OAuth server polling to Electron overlay mode

### DIFF
--- a/src/providers/oauth-service.test.ts
+++ b/src/providers/oauth-service.test.ts
@@ -28,6 +28,9 @@ vi.stubGlobal('window', mockWindow);
 // Stub fetch for the server-side polling fallback (returns 204 = no result yet)
 vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ status: 204 })));
 
+// Default location: standalone CLI (no polling)
+vi.stubGlobal('location', { pathname: '/', search: '' });
+
 function fireMessage(data: unknown) {
   for (const handler of messageListeners) {
     handler({ data } as MessageEvent);
@@ -154,7 +157,10 @@ describe('createOAuthLauncher', () => {
     // Should not throw when trying to close a null popup
   });
 
-  it('resolves via server-side polling when postMessage is unavailable', async () => {
+  it('resolves via server-side polling in Electron overlay mode', async () => {
+    // Simulate Electron overlay URL
+    vi.stubGlobal('location', { pathname: '/electron', search: '' });
+
     const mockFetch = vi.mocked(fetch);
     // First poll: no result yet
     mockFetch.mockResolvedValueOnce({ status: 204 } as Response);
@@ -176,9 +182,38 @@ describe('createOAuthLauncher', () => {
 
     const result = await promise;
     expect(result).toBe('http://localhost:5710/auth/callback#token=polled');
+
+    // Restore default location
+    vi.stubGlobal('location', { pathname: '/', search: '' });
   });
 
-  it('continues polling on server errors and resolves when result arrives', async () => {
+  it('does not poll in standalone CLI mode', async () => {
+    vi.stubGlobal('location', { pathname: '/', search: '' });
+
+    const mockFetch = vi.mocked(fetch);
+
+    const launcher = createOAuthLauncher();
+    const promise = launcher('https://idp.example.com/authorize');
+
+    // Advance past where polling would fire
+    await vi.advanceTimersByTimeAsync(2000);
+
+    // fetch should NOT have been called (no polling in standalone mode)
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    // Resolve via postMessage
+    fireMessage({
+      type: 'oauth-callback',
+      redirectUrl: 'http://localhost:5710/auth/callback#token=msg',
+    });
+
+    const result = await promise;
+    expect(result).toBe('http://localhost:5710/auth/callback#token=msg');
+  });
+
+  it('continues polling on server errors in Electron overlay mode', async () => {
+    vi.stubGlobal('location', { pathname: '/electron', search: '' });
+
     const mockFetch = vi.mocked(fetch);
     // First poll: server error
     mockFetch.mockResolvedValueOnce({ status: 500 } as Response);
@@ -200,6 +235,8 @@ describe('createOAuthLauncher', () => {
 
     const result = await promise;
     expect(result).toBe('http://localhost:5710/auth/callback#token=recovered');
+
+    vi.stubGlobal('location', { pathname: '/', search: '' });
   });
 
   it('does not resolve twice on duplicate callbacks', async () => {

--- a/src/providers/oauth-service.ts
+++ b/src/providers/oauth-service.ts
@@ -57,31 +57,37 @@ async function launchOAuthCli(authorizeUrl: string): Promise<string | null> {
 
     window.addEventListener('message', handler);
 
-    // Poll the server for the OAuth result (Electron overlay fallback).
-    // In normal CLI mode the postMessage handler above resolves first and
-    // cleanup() stops the polling. In Electron overlay mode this is the
-    // only path that works.
-    pollTimer = setInterval(async () => {
-      if (resolved) return;
-      try {
-        const res = await fetch('/api/oauth-result');
-        if (res.status === 204) return; // no result yet
-        const data = await res.json() as { redirectUrl?: string; error?: string };
+    // Poll the server for the OAuth result — Electron overlay only.
+    // In Electron overlay mode, window.open opens the system browser so
+    // window.opener is null and postMessage won't work. The callback page
+    // falls back to POSTing the result to /api/oauth-result, and we poll.
+    // In normal CLI mode, postMessage works so polling is unnecessary.
+    const isElectronOverlay =
+      location.pathname.startsWith('/electron') ||
+      new URLSearchParams(location.search).get('runtime') === 'electron-overlay';
+    if (isElectronOverlay) {
+      pollTimer = setInterval(async () => {
         if (resolved) return;
-        cleanup();
+        try {
+          const res = await fetch('/api/oauth-result');
+          if (res.status === 204) return; // no result yet
+          const data = await res.json() as { redirectUrl?: string; error?: string };
+          if (resolved) return;
+          cleanup();
 
-        if (data.error) {
-          console.error('[oauth-service] Server relay OAuth error:', data.error);
-          resolve(null);
-          return;
+          if (data.error) {
+            console.error('[oauth-service] Server relay OAuth error:', data.error);
+            resolve(null);
+            return;
+          }
+
+          resolve(data.redirectUrl ?? null);
+        } catch (err) {
+          // Network error or JSON parse failure — keep polling
+          console.warn('[oauth-service] Poll failed:', err instanceof Error ? err.message : String(err));
         }
-
-        resolve(data.redirectUrl ?? null);
-      } catch (err) {
-        // Network error or JSON parse failure — keep polling
-        console.warn('[oauth-service] Poll failed:', err instanceof Error ? err.message : String(err));
-      }
-    }, 1000);
+      }, 1000);
+    }
 
     // Timeout after 2 minutes
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Summary

- PR #140 added server-side polling (`/api/oauth-result`) as a fallback for Electron overlay OAuth where `window.opener` is null
- The polling ran unconditionally in CLI standalone mode too, breaking Adobe login via popup
- Now the poll only activates when the URL indicates Electron overlay mode (`/electron` path or `?runtime=electron-overlay`)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (12 OAuth tests, including new "does not poll in standalone CLI mode" test)
- [x] `npm run build:extension` passes
- [x] Manual: CLI mode Adobe OAuth login works
- [x] Manual: Extension mode Adobe OAuth login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)