### PR TITLE
feat(sliccstart): show app version in footer

### DIFF
--- a/sliccstart/Sliccstart/Views/AppListView.swift
+++ b/sliccstart/Sliccstart/Views/AppListView.swift
@@ -92,6 +92,11 @@ struct AppListView: View {
                     Button("Update") { onUpdate() }
                         .buttonStyle(.borderless).font(.caption)
                 }
+                if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                    Text("v\(version)")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
                 Spacer()
                 Button("Rescan") { onRescan() }
                     .buttonStyle(.borderless).font(.caption)


### PR DESCRIPTION
## Summary

Show the app version number in the Sliccstart footer bar. This is a small UI improvement and also serves as a trigger for a follow-up release to test the auto-updater from PR #171.

## Changes

- `sliccstart/Sliccstart/Views/AppListView.swift` — Display `v{version}` from `CFBundleShortVersionString` in the footer, styled as tertiary caption text.

**Do not merge until PR #171 is merged and its release is installed.**
