### PR TITLE
fix(sliccstart): set correct releasePrefix and add Check for Updates menu item

### DIFF
--- a/sliccstart/Sliccstart/SliccstartApp.swift
+++ b/sliccstart/Sliccstart/SliccstartApp.swift
@@ -29,7 +29,7 @@ struct SliccstartApp: App {
     @State private var debugBuildTarget: AppTarget?
     @State private var isCreatingDebugBuild = false
     @State private var debugBuildProgress: String = ""
-    @StateObject private var appUpdater = AppUpdater(owner: "ai-ecoverse", repo: "slicc")
+    @StateObject private var appUpdater = AppUpdater(owner: "ai-ecoverse", repo: "slicc", releasePrefix: "Sliccstart")
 
     init() {
         NSApplication.shared.setActivationPolicy(.regular)
@@ -144,6 +144,13 @@ struct SliccstartApp: App {
         .defaultSize(width: 340, height: 100)
         .windowStyle(.titleBar)
         .windowResizability(.contentSize)
+        .commands {
+            CommandGroup(after: .appInfo) {
+                Button("Check for Updates…") {
+                    appUpdater.check()
+                }
+            }
+        }
     }
 
     private func initialize() async {


### PR DESCRIPTION
## Summary

Fixes two issues with the auto-updater from #171:

1. **Updates not detected**: `releasePrefix` defaulted to the repo name (`slicc`), so AppUpdater searched for assets named `slicc-{version}.zip`. The actual asset is `Sliccstart-{version}.zip`. Fixed by explicitly setting `releasePrefix: "Sliccstart"`.

2. **No menu bar entry**: Standard macOS apps have "Check for Updates…" in the app menu, right below "About". Added a `CommandGroup(after: .appInfo)` with the check action.

## Changes

- `sliccstart/Sliccstart/SliccstartApp.swift` — Set `releasePrefix: "Sliccstart"` in AppUpdater init, add "Check for Updates…" menu command
