### PR TITLE
fix: add 'Clear chat' to extension avatar popover

### DIFF
--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -548,6 +548,22 @@ export class Layout {
       popover.appendChild(clearAllBtn);
     }
 
+    // Clear chat
+    const sepChat = document.createElement('div');
+    sepChat.className = 'avatar-popover__separator';
+    popover.appendChild(sepChat);
+
+    const clearChatBtn = document.createElement('button');
+    clearChatBtn.className = 'avatar-popover__item avatar-popover__item--danger';
+    clearChatBtn.textContent = 'Clear chat';
+    clearChatBtn.addEventListener('click', async () => {
+      popover.remove();
+      await this.panels?.chat?.clearSession();
+      await this.onClearChat?.();
+      location.reload();
+    });
+    popover.appendChild(clearChatBtn);
+
     // Account settings link
     const sep2 = document.createElement('div');
     sep2.className = 'avatar-popover__separator';


### PR DESCRIPTION
## Summary

The UXC redesign (PR #159) moved destructive actions to the avatar popover but didn't include a "Clear chat" option. In the extension, there's no way to clear the chat.

Adds a "Clear chat" button to the avatar profile popover, styled as a danger action (red text). Clears the session and reloads the page, matching the standalone layout behavior.

## Test plan

- [x] `npm run build:extension` passes
- [ ] Manual: Extension → click avatar → "Clear chat" → chat cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)