### PR TITLE
feat: port CLI server from Node.js to Swift

### DIFF
--- a/sliccserver/Sources/CLI/ServerCommand.swift
+++ b/sliccserver/Sources/CLI/ServerCommand.swift
@@ -155,6 +155,10 @@ struct ServerCommand: AsyncParsableCommand {
             router: router,
             server: .http1WebSocketUpgrade(
                 webSocketRouter: wsRouter,
+                // Hummingbird's WebSocket frame size is configured at the server-builder level,
+                // not per route. `/cdp` needs large frames for Chrome payloads, while `/licks-ws`
+                // only carries small local JSON messages, so keeping the higher localhost-only
+                // limit here is wasteful but not a security concern.
                 configuration: .init(maxFrameSize: CDPProxy.defaultMaxMessageSize)
             ),
             configuration: .init(
@@ -400,11 +404,8 @@ extension ServerCommand {
         from environment: [String: String],
         resolveAvailablePort: (Int) async throws -> Int = findAvailablePort(startingFrom:)
     ) async throws -> Int {
-        if let explicitPort = preferredServePort(from: environment) {
-            return explicitPort
-        }
-
-        return try await resolveAvailablePort(defaultServePort)
+        let preferredPort = preferredServePort(from: environment) ?? defaultServePort
+        return try await resolveAvailablePort(preferredPort)
     }
 
     static func preferredServePort(from environment: [String: String]) -> Int? {

--- a/sliccserver/Sources/WebSocket/CDPProxy.swift
+++ b/sliccserver/Sources/WebSocket/CDPProxy.swift
@@ -17,9 +17,11 @@ actor CDPProxy {
     private let discoverer: @Sendable (Int) async throws -> String
     private let chromeConnector: ChromeSocketConnector
     private let maxMessageSize: Int
+    private let maxBufferSize = 1_000
     private let reconnectDelayNanoseconds: UInt64
     private let sleep: @Sendable (UInt64) async throws -> Void
 
+    private var cdpPort: Int?
     private var cachedCDPPort: Int?
     private var cachedCDPURL: String?
     private var chromeSocket: ChromeSocketHandle?
@@ -56,6 +58,7 @@ actor CDPProxy {
     }
 
     func install(on router: Router<BasicWebSocketRequestContext>, cdpPort: Int) {
+        self.cdpPort = cdpPort
         router.ws("/cdp") { _, _ in
             .upgrade([:])
         } onUpgrade: { inbound, outbound, context in
@@ -69,6 +72,7 @@ actor CDPProxy {
     }
 
     func preWarm(cdpPort: Int) async throws {
+        self.cdpPort = cdpPort
         let cdpURL = try await self.cdpURL(for: cdpPort)
         try await self.ensureChromeConnection(url: cdpURL)
     }
@@ -171,7 +175,7 @@ actor CDPProxy {
                 )
             }
         } else if self.messageBuffer != nil {
-            self.messageBuffer?.append(message)
+            self.appendBufferedMessage(message)
             let logLine = "[cdp-proxy] Client→Chrome (buffered): \(preview)"
             if self.logDedup.shouldLog(logLine) {
                 self.logger.debug("\(logLine)")
@@ -191,6 +195,7 @@ actor CDPProxy {
 
     func prepareClientConnection(for clientID: UUID, cdpPort: Int) async {
         do {
+            self.cdpPort = cdpPort
             let cdpURL = try await self.cdpURL(for: cdpPort)
             try await self.ensureChromeConnection(url: cdpURL)
         } catch {
@@ -226,11 +231,25 @@ actor CDPProxy {
             return cachedCDPURL
         }
 
-        let discoveredURL = try await self.discoverer(port)
+        let discoveredURL = try await Self.cdpURL(for: port, using: self.discoverer)
         self.cachedCDPPort = port
         self.cachedCDPURL = discoveredURL
         self.logger.info("[cdp-proxy] CDP available at: \(discoveredURL)")
         return discoveredURL
+    }
+
+    private func appendBufferedMessage(_ message: ProxyMessage) {
+        guard var buffer = self.messageBuffer else {
+            return
+        }
+
+        if buffer.count >= self.maxBufferSize {
+            self.logger.warning("[cdp-proxy] Message buffer full (\(self.maxBufferSize)), dropping oldest message")
+            buffer.removeFirst()
+        }
+
+        buffer.append(message)
+        self.messageBuffer = buffer
     }
 
     private func flushBufferedMessages(using chromeSocket: ChromeSocketHandle) async throws {
@@ -338,6 +357,13 @@ actor CDPProxy {
         return payload.webSocketDebuggerUrl
     }
 
+    private static func cdpURL(
+        for port: Int,
+        using discoverer: @escaping @Sendable (Int) async throws -> String
+    ) async throws -> String {
+        try await discoverer(port)
+    }
+
     private func handleChromeDisconnect(reason: String, bufferMessage: ProxyMessage? = nil) {
         self.chromeSocket = nil
         self.chromeConnectionID = nil
@@ -348,7 +374,7 @@ actor CDPProxy {
         }
 
         if let bufferMessage {
-            self.messageBuffer?.append(bufferMessage)
+            self.appendBufferedMessage(bufferMessage)
         }
 
         self.scheduleChromeReconnect(reason: reason)
@@ -359,18 +385,19 @@ actor CDPProxy {
             return
         }
 
-        guard let cachedCDPURL else {
-            self.logger.warning("[cdp-proxy] Chrome WS dropped but no cached CDP URL is available for reconnect")
+        guard let cdpPort = self.cdpPort else {
+            self.logger.warning("[cdp-proxy] Chrome WS dropped but no CDP port is available for reconnect")
             return
         }
 
-        self.logger.info("[cdp-proxy] Scheduling Chrome WS reconnect in 1s (\(reason))")
-        self.chromeReconnectTask = Task { [url = cachedCDPURL] in
-            await self.runChromeReconnectLoop(url: url)
+        let delayMs = self.reconnectDelayNanoseconds / 1_000_000
+        self.logger.info("[cdp-proxy] Scheduling Chrome WS reconnect in \(delayMs)ms (\(reason))")
+        self.chromeReconnectTask = Task { [cdpPort] in
+            await self.runChromeReconnectLoop(cdpPort: cdpPort)
         }
     }
 
-    private func runChromeReconnectLoop(url: String) async {
+    private func runChromeReconnectLoop(cdpPort: Int) async {
         defer {
             self.chromeReconnectTask = nil
         }
@@ -378,7 +405,10 @@ actor CDPProxy {
         while !Task.isCancelled {
             do {
                 try await self.sleep(self.reconnectDelayNanoseconds)
-                try await self.ensureChromeConnection(url: url)
+                let freshURL = try await Self.cdpURL(for: cdpPort, using: self.discoverer)
+                self.cachedCDPPort = cdpPort
+                self.cachedCDPURL = freshURL
+                try await self.ensureChromeConnection(url: freshURL)
                 self.logger.info("[cdp-proxy] Chrome WS auto-reconnected")
                 return
             } catch is CancellationError {

--- a/sliccserver/Tests/CDPProxyTests.swift
+++ b/sliccserver/Tests/CDPProxyTests.swift
@@ -96,10 +96,85 @@ final class CDPProxyTests: XCTestCase {
         XCTAssertEqual(harness.sentTextsSnapshot(), [])
 
         await reconnectGate.open()
-        try await Task.sleep(nanoseconds: 50_000_000)
+        for _ in 0..<200 {
+            if harness.connectCountSnapshot() >= 2 {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
 
         XCTAssertEqual(harness.connectCountSnapshot(), 2)
         XCTAssertEqual(harness.sentTextsSnapshot(), ["{\"id\":24,\"method\":\"Target.getTargets\"}"])
+    }
+
+    func testChromeReconnectRediscoversCDPURL() async throws {
+        let reconnectGate = AsyncGate()
+        let discoverer = DiscovererHarness(urls: [
+            "ws://127.0.0.1:9222/devtools/browser/first",
+            "ws://127.0.0.1:9222/devtools/browser/second",
+        ])
+        let harness = ChromeConnectorHarness()
+        let proxy = CDPProxy(
+            logger: Logger(label: "test.cdp-proxy"),
+            discoverer: { port in
+                await discoverer.discover(port: port)
+            },
+            chromeConnector: { url, onMessage, onEvent in
+                try await harness.connect(url: url, onMessage: onMessage, onEvent: onEvent)
+            },
+            reconnectDelayNanoseconds: 0,
+            sleep: { _ in await reconnectGate.wait() }
+        )
+        let client = ClientRecorder()
+
+        try await proxy.preWarm(cdpPort: 9222)
+        await proxy.addClient(client.handle)
+
+        await harness.emitEvent(.closed("code=Optional(normalClosure)"))
+        await reconnectGate.open()
+
+        for _ in 0..<200 {
+            if harness.connectCountSnapshot() >= 2 {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTAssertEqual(harness.connectedURLsSnapshot(), [
+            "ws://127.0.0.1:9222/devtools/browser/first",
+            "ws://127.0.0.1:9222/devtools/browser/second",
+        ])
+        let discovererCallCount = await discoverer.callCount()
+        XCTAssertEqual(discovererCallCount, 2)
+    }
+
+    func testBufferedMessagesDropOldestWhenBufferReachesLimit() async {
+        let harness = ChromeConnectorHarness(waitForExplicitResume: true)
+        let proxy = CDPProxy(
+            logger: Logger(label: "test.cdp-proxy"),
+            discoverer: { _ in "ws://127.0.0.1:9222/devtools/browser/test" },
+            chromeConnector: { url, onMessage, onEvent in
+                try await harness.connect(url: url, onMessage: onMessage, onEvent: onEvent)
+            }
+        )
+        let client = ClientRecorder()
+
+        await proxy.addClient(client.handle)
+        let prepareTask = Task {
+            await proxy.prepareClientConnection(for: client.handle.id, cdpPort: 9222)
+        }
+
+        for id in 1...1_001 {
+            await proxy.receive(.text("{\"id\":\(id)}"), from: client.handle.id)
+        }
+
+        await harness.resumePendingConnection()
+        await prepareTask.value
+
+        let sentTexts = harness.sentTextsSnapshot()
+        XCTAssertEqual(sentTexts.count, 1_000)
+        XCTAssertEqual(sentTexts.first, "{\"id\":2}")
+        XCTAssertEqual(sentTexts.last, "{\"id\":1001}")
     }
 }
 
@@ -301,6 +376,26 @@ private final class HarnessState: @unchecked Sendable {
         self.lock.lock()
         self.isOpen = isOpen
         self.lock.unlock()
+    }
+}
+
+private actor DiscovererHarness {
+    private let urls: [String]
+    private var nextIndex = 0
+
+    init(urls: [String]) {
+        self.urls = urls
+    }
+
+    func discover(port: Int) -> String {
+        XCTAssertEqual(port, 9222)
+        let index = min(self.nextIndex, self.urls.count - 1)
+        self.nextIndex += 1
+        return self.urls[index]
+    }
+
+    func callCount() -> Int {
+        self.nextIndex
     }
 }
 

--- a/sliccserver/Tests/ServerCommandTests.swift
+++ b/sliccserver/Tests/ServerCommandTests.swift
@@ -133,13 +133,13 @@ final class ServerCommandTests: XCTestCase {
         XCTAssertEqual(root, "/Applications/Sliccstart.app/Contents/Resources/slicc/dist/ui")
     }
 
-    func testResolveServePortUsesPortEnvironmentDirectly() async throws {
-        let resolvedPort = try await ServerCommand.resolveServePort(from: ["PORT": "5710"]) { _ in
-            XCTFail("PORT override should not call findAvailablePort")
-            return 0
+    func testResolveServePortUsesPortEnvironmentAsPreferredPort() async throws {
+        let resolvedPort = try await ServerCommand.resolveServePort(from: ["PORT": "5710"]) { startingFrom in
+            XCTAssertEqual(startingFrom, 5710)
+            return 5800
         }
 
-        XCTAssertEqual(resolvedPort, 5710)
+        XCTAssertEqual(resolvedPort, 5800)
     }
 
     func testResolveServePortFallsBackToResolverWhenPortEnvironmentMissing() async throws {


### PR DESCRIPTION
## Summary

Replaces the Node.js CLI server (`src/cli/index.ts`) with a native Swift implementation at `sliccserver/`. After this change, Node.js is no longer required to run SLICC in standalone mode on macOS. The Node.js server remains available for Linux/Windows users.

### What's included
- Complete Swift server using Hummingbird 2 (HTTP + WebSocket)
- All REST API endpoints ported (`/api/runtime-config`, `/api/fetch-proxy`, `/api/webhooks`, `/api/crontasks`, `/api/oauth-result`, `/auth/callback`)
- CDP WebSocket proxy (`/cdp`) with message buffering, 100MB frame size, and auto-reconnect
- Lick WebSocket system (`/licks-ws`) for server↔browser communication
- Chrome and Electron process launchers
- Console forwarding from browser to CLI terminal
- Graceful shutdown with `Browser.close` + SIGKILL fallback
- Sliccstart integration (Swift server only — no Node.js in the macOS app bundle)
- Shared integration test suite at `test/server-integration/`
- Debug tool at `tools/slicc-prompt.mjs`

### Size impact
- Swift server binary: ~31 MB (release)
- Removed from bundle: Node.js binary (~87 MB) + node_modules (~4 MB) + dist/cli (~0.5 MB)
- App bundle: 209 MB → 51 MB (**75% reduction**)
- DMG: **20 MB**

### Testing
- 43 Swift unit tests passing
- 8 integration tests passing (server-agnostic, works against both Node and Swift servers)
- Manually verified: static serving, CDP proxy, playwright-cli (tab-list, snapshot, screenshot), webhook receiver, OAuth flow
- Verified bundled Sliccstart.app launches and works end-to-end
- Verified release DMG installs and runs correctly

Closes #166