### PR TITLE
fix: Vite dev server 404 after monorepo refactor

### DIFF
--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -970,6 +970,7 @@ async function main() {
           port: HMR_PORT, // Use a separate port for HMR WebSocket to avoid conflicting with /cdp
         },
       },
+      appType: 'custom', // We handle index.html serving ourselves via the handler below
       root: process.cwd(),
     });
     app.use(vite.middlewares);


### PR DESCRIPTION
## Summary

After the monorepo modularization (#187), `index.html` moved from the repo root to `packages/webapp/index.html`. The Vite dev server in middleware mode was trying to serve `index.html` from the repo root, returning 404 on `GET /`.

- Added `appType: 'custom'` to the Vite dev server config, which tells Vite not to serve `index.html` itself
- The existing custom HTML handler (lines 976-993) already reads from `packages/webapp/index.html` and transforms it with Vite — it just wasn't being reached because Vite middleware claimed the request first

One-line fix in `packages/node-server/src/index.ts`.

## Test Plan

- [x] `npm run typecheck` passes
- [ ] `npm run dev:full` loads the UI at http://localhost:5710

🤖 Generated with [Claude Code](https://claude.com/claude-code)