### PR TITLE
fix(swift-server): fix Electron overlay injection pipeline

### DIFF
--- a/packages/swift-server/Sources/Browser/ElectronLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ElectronLauncher.swift
@@ -376,7 +376,6 @@ final class ElectronOverlayInjector: @unchecked Sendable {
     private let session: URLSession
     private let logger: Logger
     private let stateQueue = DispatchQueue(label: "slicc.browser.electron-overlay-injector")
-    private var injectedTargets = Set<String>()
     private var inFlightTargets = Set<String>()
     private var pollTask: Task<Void, Never>?
 
@@ -411,7 +410,6 @@ final class ElectronOverlayInjector: @unchecked Sendable {
         stateQueue.sync {
             pollTask?.cancel()
             pollTask = nil
-            injectedTargets.removeAll()
             inFlightTargets.removeAll()
         }
     }
@@ -446,7 +444,6 @@ final class ElectronOverlayInjector: @unchecked Sendable {
         let liveTargetIDs = Set(selectedTargets.compactMap(\.webSocketDebuggerURL))
 
         stateQueue.sync {
-            injectedTargets = injectedTargets.intersection(liveTargetIDs)
             inFlightTargets = inFlightTargets.intersection(liveTargetIDs)
         }
 
@@ -587,35 +584,52 @@ final class ElectronOverlayInjector: @unchecked Sendable {
     }
 
     private func waitForResponseValue(id: Int, over socket: URLSessionWebSocketTask, timeout: UInt64 = 5_000_000_000) async throws -> Any? {
-        let deadline = DispatchTime.now().uptimeNanoseconds + timeout
-        while DispatchTime.now().uptimeNanoseconds < deadline {
-            let message = try await socket.receive()
-            if case .string(let text) = message,
-               let data = text.data(using: .utf8),
-               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let responseId = json["id"] as? Int,
-               responseId == id {
-                if let result = json["result"] as? [String: Any],
-                   let innerResult = result["result"] as? [String: Any] {
-                    return innerResult["value"]
+        try await withThrowingTaskGroup(of: Any?.self) { group in
+            group.addTask {
+                while true {
+                    let message = try await socket.receive()
+                    if case .string(let text) = message,
+                       let data = text.data(using: .utf8),
+                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let responseId = json["id"] as? Int,
+                       responseId == id {
+                        if let result = json["result"] as? [String: Any],
+                           let innerResult = result["result"] as? [String: Any] {
+                            return innerResult["value"]
+                        }
+                        return nil
+                    }
                 }
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: timeout)
                 return nil
             }
+            let result = try await group.next() ?? nil
+            group.cancelAll()
+            return result
         }
-        return nil
     }
 
     private func waitForResponse(id: Int, over socket: URLSessionWebSocketTask, timeout: UInt64 = 5_000_000_000) async throws {
-        let deadline = DispatchTime.now().uptimeNanoseconds + timeout
-        while DispatchTime.now().uptimeNanoseconds < deadline {
-            let message = try await socket.receive()
-            if case .string(let text) = message,
-               let data = text.data(using: .utf8),
-               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let responseId = json["id"] as? Int,
-               responseId == id {
-                return
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                while true {
+                    let message = try await socket.receive()
+                    if case .string(let text) = message,
+                       let data = text.data(using: .utf8),
+                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let responseId = json["id"] as? Int,
+                       responseId == id {
+                        return
+                    }
+                }
             }
+            group.addTask {
+                try await Task.sleep(nanoseconds: timeout)
+            }
+            _ = try await group.next()
+            group.cancelAll()
         }
     }
 

--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -180,10 +180,24 @@ struct ServerCommand: AsyncParsableCommand {
         }
 
         do {
-            // Wait only for the startup latch. Don't add appTask to the group —
-            // withThrowingTaskGroup implicitly awaits all children, and appTask
-            // runs forever, which would block everything after this point.
+            // Race the startup latch against appTask failure. If the server
+            // fails before onServerRunning fires (e.g. bind error), we need
+            // to surface that instead of hanging on the latch forever.
+            // A separate Task watches appTask and signals the latch on failure.
+            let startupFailure = StartupFailureBox()
+            let errorObserver = Task { [startupLatch] in
+                do {
+                    try await appTask.value
+                } catch {
+                    await startupFailure.set(error)
+                    await startupLatch.signalStarted()
+                }
+            }
             await startupLatch.waitUntilStarted()
+            errorObserver.cancel()
+            if let error = await startupFailure.get() {
+                throw error
+            }
 
             do {
                 try await cdpProxy.preWarm(cdpPort: cdpPort)
@@ -340,6 +354,13 @@ struct ServerConfig: Sendable, Equatable {
         let expandedPath = NSString(string: value).expandingTildeInPath
         return URL(fileURLWithPath: expandedPath).standardizedFileURL
     }
+}
+
+@available(macOS 14, *)
+private actor StartupFailureBox {
+    private var error: Error?
+    func set(_ error: Error) { self.error = error }
+    func get() -> Error? { error }
 }
 
 @available(macOS 14, *)


### PR DESCRIPTION
## Summary

- **100% CPU spin**: `waitForProcessExit` used `try?` which swallowed `CancellationError`, spinning forever after CDP connected. Now catches cancellation explicitly.
- **Overlay injector never started**: `withThrowingTaskGroup` implicitly awaits all children — since the HTTP server task runs forever, everything after it (CDP preWarm, overlay injector, console forwarder) was permanently blocked. Replaced with a direct `await startupLatch`.
- **`repositoryRoot` path wrong**: `#filePath` fallback needed 5 levels up (not 4) after monorepo restructure moved sources to `packages/swift-server/`.
- **WebSocket closed too early**: `injectOverlay` closed the CDP WebSocket before Chrome could process `Runtime.evaluate`. Now waits for the response.
- **One-shot injection wiped by Slack**: Overlay was injected once then never re-injected after client-side re-renders wiped the DOM. Replaced permanent `injectedTargets` set with a probe that checks `__SLICC_ELECTRON_OVERLAY__` still exists.

## Test plan

- [x] `swift test` — 55 passed
- [x] Launch Slack via `slicc-server --electron-app=/Applications/Slack.app` — overlay button + sidebar visible
- [x] Overlay survives Slack client-side navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)