### PR TITLE
fix(ci): update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   ci:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` to v6.0.2 and `actions/setup-node` to v6.3.0 (SHA-pinned)
- Resolves Node.js 20 deprecation warning in CI (Node.js 20 actions deprecated, forced to Node.js 24 starting June 2, 2026)

## Test plan
- [ ] CI workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)