### PR TITLE
ci: add merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary
- Adds `merge_group` event trigger to CI workflow so status checks pass when PRs go through the merge queue

## Test plan
- [x] CI should trigger on `merge_group` events in addition to `pull_request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)