### PR TITLE
ci: add release status check to optionally pause merge queue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -19,11 +20,24 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      statuses: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      # Post a "pending" commit status to signal that a release is in progress.
+      # When added as a required status check, this will pause the merge queue
+      # until the release completes.
+      - name: Lock merge queue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -f state=pending \
+            -f context=release \
+            -f description="Release in progress — merge queue paused"
 
       - uses: actions/setup-node@v4
         with:
@@ -77,3 +91,20 @@ jobs:
           if [ -n "$KEYCHAIN_PATH" ]; then
             security delete-keychain "$KEYCHAIN_PATH" || true
           fi
+
+      - name: Unlock merge queue
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            STATE=success
+            DESC="Release completed"
+          else
+            STATE=error
+            DESC="Release failed or was cancelled"
+          fi
+          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -f state="$STATE" \
+            -f context=release \
+            -f description="$DESC"


### PR DESCRIPTION
## Summary

- Posts a `pending` commit status (`context: release`) when the release workflow starts
- Resolves to `success` or `error` when the release completes or fails
- **No-op by default** — to activate, add `release` as a required status check in branch protection, which will make the merge queue wait for the release to finish before merging the next PR

This prevents the merge queue from pushing to main during a release, which would either cancel the release (with `cancel-in-progress: true`) or cause semantic-release to skip with "local branch is behind."

## Test plan

- [ ] Verify CI passes (this only changes release.yml, no CI impact)
- [ ] After merge, confirm the `release` status appears on main commits when the release workflow runs
- [ ] Optionally enable as required check in branch protection to activate queue pausing

🤖 Generated with [Claude Code](https://claude.com/claude-code)