### PR TITLE
ci: fix duplicate GitHub Actions runs blocking merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   merge_group:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "rebaseWhen": "conflicted",
   "automerge": true,
   "automergeType": "pr",
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "non-major dependencies",
+      "groupSlug": "non-major"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Add `concurrency` group to CI workflow — new pushes cancel stale runs for the same PR
- Change Renovate `rebaseWhen` to `conflicted` — only rebase when there are actual merge conflicts, not on every merge to main
- Group non-major Renovate updates (minor/patch/pin/digest) into a single PR to reduce open PR count

## Context

Observed 58 queued CI runs where only ~12 were needed. Each merge to main triggered Renovate to rebase all ~10 open PRs, each spawning a new CI run without canceling the old one — creating a compounding queue backlog.

## Test plan

- [ ] Verify CI concurrency cancels stale runs when a PR gets a new push
- [ ] Verify merge queue runs are not affected (each gets a unique `github.ref`)
- [ ] Confirm Renovate groups non-major updates into one PR after next dependency scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)