### PR TITLE
ci: release-gate and queue-leader optimization for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,8 @@ jobs:
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    permissions:
+      actions: read
     steps:
       - name: Wait for active release
         env:


### PR DESCRIPTION
## Summary

Two merge queue optimizations:

- **Release gate**: Adds a `release-gate` job that only runs on `merge_group` events. It polls the Actions API for active release workflow runs and waits for them to complete, preventing the merge queue from pushing to main during a release (which would cancel it or cause "local branch is behind").

- **Queue leader optimization**: Only position #1 in the merge queue runs the expensive macOS jobs (`swift-server`, `swift-launcher`). Positions #2+ skip them since each entry is a cumulative superset of the previous — if #1 passes, the others are very likely to pass too. When #1 merges and the queue advances, the new #1 gets its own macOS run.

For regular PRs, both features are transparent: `release-gate` skips, and `is-queue-leader` defaults to `true`.

## Test plan

- [ ] Verify PR CI passes with `release-gate` skipped and swift jobs running normally
- [ ] After merge, verify merge queue position #1 runs swift jobs
- [ ] Verify merge queue positions #2+ skip swift jobs
- [ ] Verify merge queue waits when a release is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)