### PR TITLE
feat: manual Chrome Web Store publish workflow

### DIFF
--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -1,0 +1,70 @@
+name: Publish Chrome Extension
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag (e.g. v0.3.2). Leave empty for latest release.'
+        required: false
+        default: ''
+        type: string
+      force_replace_pending_review:
+        description: 'Cancel any pending CWS review before uploading'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Resolve release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            TAG="${{ inputs.version }}"
+          else
+            TAG=$(gh release view --json tagName -q '.tagName')
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved release: $TAG"
+
+      - name: Download extension zip
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/cws
+          gh release download "${{ steps.release.outputs.tag }}" \
+            --pattern '*-extension-*.zip' \
+            --dir /tmp/cws
+          ZIP_FILE=$(ls /tmp/cws/*.zip)
+          echo "Downloaded: $ZIP_FILE"
+
+      - name: Publish to Chrome Web Store
+        env:
+          CWS_CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
+          CWS_CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
+          CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
+        run: |
+          node build/publish-chrome.js /tmp/cws/*.zip \
+            ${{ inputs.force_replace_pending_review == true && '--force' || '' }}
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "## Chrome Extension Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** ${{ steps.release.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Dashboard:** https://chrome.google.com/webstore/devconsole" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -38,6 +38,10 @@ jobs:
           else
             TAG=$(gh release view --json tagName -q '.tagName')
           fi
+          if [ -z "$TAG" ]; then
+            echo "::error::No release found"
+            exit 1
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved release: $TAG"
 
@@ -58,8 +62,9 @@ jobs:
           CWS_CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
           CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
         run: |
-          node build/publish-chrome.js /tmp/cws/*.zip \
-            ${{ inputs.force_replace_pending_review == true && '--force' || '' }}
+          ARGS=""
+          [ "${{ inputs.force_replace_pending_review }}" = "true" ] && ARGS="--force"
+          node build/publish-chrome.js /tmp/cws/*.zip $ARGS
 
       - name: Summary
         if: success()

--- a/build/publish-chrome.js
+++ b/build/publish-chrome.js
@@ -151,7 +151,7 @@ async function main() {
   if (status.publicationState === 'ITEM_PENDING_REVIEW') {
     if (!force) {
       console.error(
-        'Version pending review. Re-run with force_replace_pending_review enabled to cancel and re-submit.'
+        'Version pending review. Re-run the workflow with force_replace_pending_review checked to cancel and re-submit.'
       );
       process.exit(1);
     }

--- a/build/publish-chrome.js
+++ b/build/publish-chrome.js
@@ -1,0 +1,170 @@
+// build/publish-chrome.js
+import { readFileSync } from 'fs';
+
+const CWS_API_BASE = 'https://chromewebstore.googleapis.com/v2';
+const OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const force = args.includes('--force');
+  const zipPath = args.find((a) => !a.startsWith('--'));
+  if (!zipPath) {
+    console.error('Usage: node build/publish-chrome.js <zip-path> [--force]');
+    process.exit(1);
+  }
+  return { zipPath, force };
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+async function authenticate(clientId, clientSecret, refreshToken) {
+  const response = await fetch(OAUTH_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OAuth authentication failed (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}
+
+async function getItemStatus(extensionId, token) {
+  const response = await fetch(
+    `${CWS_API_BASE}/publishers/default/items/${extensionId}?projection=DRAFT`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to get item status (${response.status}): ${text}`);
+  }
+
+  return response.json();
+}
+
+async function cancelSubmission(extensionId, token) {
+  const response = await fetch(
+    `${CWS_API_BASE}/publishers/default/items/${extensionId}:cancelSubmission`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to cancel submission (${response.status}): ${text}`);
+  }
+
+  console.log('Cancelled pending review.');
+}
+
+async function upload(extensionId, zipPath, token) {
+  const zipData = readFileSync(zipPath);
+
+  const response = await fetch(
+    `${CWS_API_BASE}/publishers/default/items/${extensionId}`,
+    {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/zip',
+        'x-goog-api-version': '2',
+      },
+      body: zipData,
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Upload failed (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  if (data.uploadState !== 'SUCCESS') {
+    const errors = (data.itemError || []).map((e) => e.detail || e.error_code).join(', ');
+    throw new Error(`Upload rejected: state=${data.uploadState}, errors: ${errors}`);
+  }
+
+  console.log('Upload successful.');
+  return data;
+}
+
+async function publish(extensionId, token) {
+  const response = await fetch(
+    `${CWS_API_BASE}/publishers/default/items/${extensionId}:publish`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Publish failed (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  const status = data.status || [];
+  if (!status.includes('OK')) {
+    const detail = (data.statusDetail || []).join(', ');
+    throw new Error(`Publish rejected: status=${status.join(',')}, detail: ${detail}`);
+  }
+
+  console.log('Publish successful — submitted for review.');
+  return data;
+}
+
+const { zipPath, force } = parseArgs(process.argv);
+const clientId = requireEnv('CWS_CLIENT_ID');
+const clientSecret = requireEnv('CWS_CLIENT_SECRET');
+const refreshToken = requireEnv('CWS_REFRESH_TOKEN');
+const extensionId = process.env.CWS_EXTENSION_ID || 'akggccfpkleihhemkkikggopnifgelbk';
+
+async function main() {
+  console.log(`Publishing ${zipPath} to extension ${extensionId}...`);
+
+  const token = await authenticate(clientId, clientSecret, refreshToken);
+  console.log('Authenticated.');
+
+  const status = await getItemStatus(extensionId, token);
+  if (status.publicationState === 'ITEM_PENDING_REVIEW') {
+    if (!force) {
+      console.error(
+        'Version pending review. Re-run with force_replace_pending_review enabled to cancel and re-submit.'
+      );
+      process.exit(1);
+    }
+    await cancelSubmission(extensionId, token);
+  }
+
+  await upload(extensionId, zipPath, token);
+  await publish(extensionId, token);
+
+  console.log('Done. Check status at https://chrome.google.com/webstore/devconsole');
+}
+
+main().catch((error) => {
+  console.error(`[publish-chrome] ${error.message}`);
+  process.exit(1);
+});

--- a/build/publish-chrome.js
+++ b/build/publish-chrome.js
@@ -79,18 +79,15 @@ async function cancelSubmission(extensionId, token) {
 async function upload(extensionId, zipPath, token) {
   const zipData = readFileSync(zipPath);
 
-  const response = await fetch(
-    `${CWS_API_BASE}/publishers/default/items/${extensionId}`,
-    {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/zip',
-        'x-goog-api-version': '2',
-      },
-      body: zipData,
-    }
-  );
+  const response = await fetch(`${CWS_API_BASE}/publishers/default/items/${extensionId}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/zip',
+      'x-goog-api-version': '2',
+    },
+    body: zipData,
+  });
 
   if (!response.ok) {
     const text = await response.text();
@@ -108,16 +105,13 @@ async function upload(extensionId, zipPath, token) {
 }
 
 async function publish(extensionId, token) {
-  const response = await fetch(
-    `${CWS_API_BASE}/publishers/default/items/${extensionId}:publish`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    }
-  );
+  const response = await fetch(`${CWS_API_BASE}/publishers/default/items/${extensionId}:publish`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
 
   if (!response.ok) {
     const text = await response.text();

--- a/docs/superpowers/plans/2026-03-25-cws-manual-publish.md
+++ b/docs/superpowers/plans/2026-03-25-cws-manual-publish.md
@@ -1,0 +1,343 @@
+# Manual CWS Publish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a manual GitHub Actions workflow that publishes the Chrome extension to the Chrome Web Store from a GitHub Release artifact.
+
+**Architecture:** A `workflow_dispatch` workflow downloads the extension zip from a GitHub Release and passes it to `build/publish-chrome.js`, a zero-dependency Node script that authenticates via OAuth, checks for pending reviews, and uploads + publishes to the CWS V2 API.
+
+**Tech Stack:** GitHub Actions, Node.js 22 (native fetch), Chrome Web Store V2 API, Google OAuth2
+
+**Spec:** `docs/superpowers/specs/2026-03-25-cws-manual-publish-design.md`
+
+---
+
+### Task 1: Create the publish script
+
+**Files:**
+- Create: `build/publish-chrome.js`
+
+- [ ] **Step 1: Create `build/` directory if needed and scaffold the script with argument parsing and env var validation**
+
+```js
+// build/publish-chrome.js
+import { readFileSync } from 'fs';
+
+const CWS_API_BASE = 'https://chromewebstore.googleapis.com/v2';
+const OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const force = args.includes('--force');
+  const zipPath = args.find((a) => !a.startsWith('--'));
+  if (!zipPath) {
+    console.error('Usage: node build/publish-chrome.js <zip-path> [--force]');
+    process.exit(1);
+  }
+  return { zipPath, force };
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+const { zipPath, force } = parseArgs(process.argv);
+const clientId = requireEnv('CWS_CLIENT_ID');
+const clientSecret = requireEnv('CWS_CLIENT_SECRET');
+const refreshToken = requireEnv('CWS_REFRESH_TOKEN');
+const extensionId = process.env.CWS_EXTENSION_ID || 'akggccfpkleihhemkkikggopnifgelbk';
+```
+
+- [ ] **Step 2: Add the OAuth authentication function**
+
+```js
+async function authenticate(clientId, clientSecret, refreshToken) {
+  const response = await fetch(OAUTH_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OAuth authentication failed (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}
+```
+
+- [ ] **Step 3: Add the status check and cancel submission functions**
+
+```js
+async function getItemStatus(extensionId, token) {
+  const response = await fetch(
+    `${CWS_API_BASE}/publishers/default/items/${extensionId}?projection=DRAFT`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to get item status (${response.status}): ${text}`);
+  }
+
+  return response.json();
+}
+
+async function cancelSubmission(extensionId, token) {
+  const response = await fetch(
+    `${CWS_API_BASE}/publishers/default/items/${extensionId}:cancelSubmission`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to cancel submission (${response.status}): ${text}`);
+  }
+
+  console.log('Cancelled pending review.');
+}
+```
+
+- [ ] **Step 4: Add the upload and publish functions**
+
+```js
+async function upload(extensionId, zipPath, token) {
+  const zipData = readFileSync(zipPath);
+
+  const response = await fetch(
+    `${CWS_API_BASE}/publishers/default/items/${extensionId}`,
+    {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/zip',
+        'x-goog-api-version': '2',
+      },
+      body: zipData,
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Upload failed (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  if (data.uploadState !== 'SUCCESS') {
+    const errors = (data.itemError || []).map((e) => e.detail || e.error_code).join(', ');
+    throw new Error(`Upload rejected: state=${data.uploadState}, errors: ${errors}`);
+  }
+
+  console.log('Upload successful.');
+  return data;
+}
+
+async function publish(extensionId, token) {
+  const response = await fetch(
+    `${CWS_API_BASE}/publishers/default/items/${extensionId}:publish`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Publish failed (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  const status = data.status || [];
+  if (!status.includes('OK')) {
+    const detail = (data.statusDetail || []).join(', ');
+    throw new Error(`Publish rejected: status=${status.join(',')}, detail: ${detail}`);
+  }
+
+  console.log('Publish successful — submitted for review.');
+  return data;
+}
+```
+
+- [ ] **Step 5: Add the main orchestration logic**
+
+```js
+async function main() {
+  console.log(`Publishing ${zipPath} to extension ${extensionId}...`);
+
+  const token = await authenticate(clientId, clientSecret, refreshToken);
+  console.log('Authenticated.');
+
+  const status = await getItemStatus(extensionId, token);
+  if (status.publicationState === 'ITEM_PENDING_REVIEW') {
+    if (!force) {
+      console.error(
+        'Version pending review. Re-run with force_replace_pending_review enabled to cancel and re-submit.'
+      );
+      process.exit(1);
+    }
+    await cancelSubmission(extensionId, token);
+  }
+
+  await upload(extensionId, zipPath, token);
+  await publish(extensionId, token);
+
+  console.log('Done. Check status at https://chrome.google.com/webstore/devconsole');
+}
+
+main().catch((error) => {
+  console.error(`[publish-chrome] ${error.message}`);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 6: Verify the script parses correctly**
+
+Run: `node --check build/publish-chrome.js`
+Expected: no output (clean parse)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add build/publish-chrome.js
+git commit -m "feat: add CWS publish script (build/publish-chrome.js)"
+```
+
+---
+
+### Task 2: Create the workflow
+
+**Files:**
+- Create: `.github/workflows/publish-chrome.yml`
+
+- [ ] **Step 1: Write the workflow file**
+
+```yaml
+name: Publish Chrome Extension
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag (e.g. v0.3.2). Leave empty for latest release.'
+        required: false
+        default: ''
+        type: string
+      force_replace_pending_review:
+        description: 'Cancel any pending CWS review before uploading'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Resolve release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            TAG="${{ inputs.version }}"
+          else
+            TAG=$(gh release view --json tagName -q '.tagName')
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved release: $TAG"
+
+      - name: Download extension zip
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/cws
+          gh release download "${{ steps.release.outputs.tag }}" \
+            --pattern '*-extension-*.zip' \
+            --dir /tmp/cws
+          ZIP_FILE=$(ls /tmp/cws/*.zip)
+          echo "Downloaded: $ZIP_FILE"
+
+      - name: Publish to Chrome Web Store
+        env:
+          CWS_CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
+          CWS_CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
+          CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
+        run: |
+          node build/publish-chrome.js /tmp/cws/*.zip \
+            ${{ inputs.force_replace_pending_review == true && '--force' || '' }}
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "## Chrome Extension Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** ${{ steps.release.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Dashboard:** https://chrome.google.com/webstore/devconsole" >> "$GITHUB_STEP_SUMMARY"
+```
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+Run: `node -e "const yaml = require('yaml'); yaml.parse(require('fs').readFileSync('.github/workflows/publish-chrome.yml', 'utf8')); console.log('Valid YAML')"`
+
+If `yaml` is not available, use: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-chrome.yml')); print('Valid YAML')"`
+
+Expected: "Valid YAML"
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/publish-chrome.yml
+git commit -m "ci: add manual Chrome Web Store publish workflow"
+```
+
+---
+
+### Task 3: Format and verify
+
+- [ ] **Step 1: Run Prettier on new files**
+
+```bash
+npx prettier --write build/publish-chrome.js .github/workflows/publish-chrome.yml
+```
+
+- [ ] **Step 2: Verify the full build still passes**
+
+```bash
+npm run typecheck && npm run test && npm run build && npm run build:extension
+```
+
+Expected: all four gates pass (new files are standalone, no integration with existing code).
+
+- [ ] **Step 3: Commit any formatting changes**
+
+```bash
+git add -A
+git diff --cached --quiet || git commit -m "style: format new CWS publish files"
+```

--- a/docs/superpowers/plans/2026-03-25-cws-manual-publish.md
+++ b/docs/superpowers/plans/2026-03-25-cws-manual-publish.md
@@ -15,6 +15,7 @@
 ### Task 1: Create the publish script
 
 **Files:**
+
 - Create: `build/publish-chrome.js`
 
 - [ ] **Step 1: Create `build/` directory if needed and scaffold the script with argument parsing and env var validation**
@@ -119,18 +120,15 @@ async function cancelSubmission(extensionId, token) {
 async function upload(extensionId, zipPath, token) {
   const zipData = readFileSync(zipPath);
 
-  const response = await fetch(
-    `${CWS_API_BASE}/publishers/default/items/${extensionId}`,
-    {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/zip',
-        'x-goog-api-version': '2',
-      },
-      body: zipData,
-    }
-  );
+  const response = await fetch(`${CWS_API_BASE}/publishers/default/items/${extensionId}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/zip',
+      'x-goog-api-version': '2',
+    },
+    body: zipData,
+  });
 
   if (!response.ok) {
     const text = await response.text();
@@ -148,16 +146,13 @@ async function upload(extensionId, zipPath, token) {
 }
 
 async function publish(extensionId, token) {
-  const response = await fetch(
-    `${CWS_API_BASE}/publishers/default/items/${extensionId}:publish`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    }
-  );
+  const response = await fetch(`${CWS_API_BASE}/publishers/default/items/${extensionId}:publish`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
 
   if (!response.ok) {
     const text = await response.text();
@@ -225,6 +220,7 @@ git commit -m "feat: add CWS publish script (build/publish-chrome.js)"
 ### Task 2: Create the workflow
 
 **Files:**
+
 - Create: `.github/workflows/publish-chrome.yml`
 
 - [ ] **Step 1: Write the workflow file**

--- a/docs/superpowers/specs/2026-03-25-cws-manual-publish-design.md
+++ b/docs/superpowers/specs/2026-03-25-cws-manual-publish-design.md
@@ -1,0 +1,112 @@
+# Manual Chrome Web Store Publish Workflow
+
+## Problem
+
+The release pipeline builds a Chrome extension zip and attaches it to GitHub Releases, but there is no automation to upload or publish it to the Chrome Web Store. Publishing is currently a manual dashboard operation. With several changes a day landing on main, each producing a new release, we need a controlled way to push a chosen version to the store without publishing every single release automatically.
+
+## Decision
+
+A manual `workflow_dispatch` GitHub Actions workflow that downloads an extension zip from a GitHub Release and uploads + publishes it to the Chrome Web Store via the V2 API. A companion `build/publish-chrome.js` script handles the CWS API calls.
+
+### Why manual, not automatic
+
+- Multiple releases per day would cause review churn (each upload cancels a pending review).
+- Uploads are blocked while a version is under review — automatic uploads would fail intermittently.
+- Manual triggering gives control over what version reaches users and when.
+
+## Workflow: `publish-chrome.yml`
+
+### Trigger
+
+`workflow_dispatch` with two inputs:
+
+| Input                         | Type    | Default | Description                                                              |
+| ----------------------------- | ------- | ------- | ------------------------------------------------------------------------ |
+| `version`                     | string  | `""`    | Release tag (e.g. `v0.3.2`). Empty string resolves to the latest release |
+| `force_replace_pending_review`| boolean | `false` | Cancel any pending CWS review before uploading                           |
+
+### Secrets
+
+| Secret             | Purpose                        |
+| ------------------ | ------------------------------ |
+| `CWS_CLIENT_ID`   | Google OAuth client ID         |
+| `CWS_CLIENT_SECRET`| Google OAuth client secret    |
+| `CWS_REFRESH_TOKEN`| Google OAuth refresh token    |
+
+### Job steps
+
+1. **Checkout** — needed for `build/publish-chrome.js`.
+2. **Setup Node 22** — script uses native `fetch`, no `npm install` required.
+3. **Resolve release** — if `version` input is empty, query latest release via `gh release view --json tagName`. Otherwise use the provided tag.
+4. **Download extension zip** — `gh release download <tag> --pattern '*-extension-*.zip' --dir /tmp/cws`.
+5. **Publish** — `node build/publish-chrome.js /tmp/cws/*.zip [--force]` with `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN` as env vars.
+6. **Summary** — annotate the workflow run with the version published and a link to the CWS developer dashboard.
+
+### Runner
+
+`ubuntu-latest` — no macOS needed. The script downloads a pre-built zip and makes HTTP calls.
+
+## Script: `build/publish-chrome.js`
+
+Plain Node.js (ES modules), zero external dependencies. Uses Node 22 native `fetch` and `fs`.
+
+### Interface
+
+```
+node build/publish-chrome.js <zip-path> [--force]
+```
+
+- `<zip-path>` — path to the extension zip file.
+- `--force` — cancel any pending CWS review before uploading.
+
+### Environment variables
+
+| Variable            | Required | Default                            |
+| ------------------- | -------- | ---------------------------------- |
+| `CWS_CLIENT_ID`    | yes      | —                                  |
+| `CWS_CLIENT_SECRET`| yes      | —                                  |
+| `CWS_REFRESH_TOKEN`| yes      | —                                  |
+| `CWS_EXTENSION_ID` | no       | `akggccfpkleihhemkkikggopnifgelbk` |
+
+### Steps
+
+1. **Authenticate** — POST `https://oauth2.googleapis.com/token` with `grant_type=refresh_token`, client credentials, and refresh token. Extract `access_token`.
+2. **Check status** — GET item status from CWS V2 API. If the item is `ITEM_PENDING_REVIEW`:
+   - With `--force`: call `cancelSubmission` (V2 endpoint), then proceed.
+   - Without `--force`: exit code 1 with message: `"Version pending review. Re-run with force_replace_pending_review enabled to cancel and re-submit."`.
+3. **Upload** — PUT the zip to the CWS V2 upload endpoint with the access token. Validate `uploadState === 'SUCCESS'`.
+4. **Publish** — POST to the CWS V2 publish endpoint. Validate response status contains `'OK'`.
+
+### Exit codes
+
+- `0` — published successfully.
+- `1` — error (descriptive message printed to stderr).
+
+### CWS API version
+
+V2 (`chromewebstore.googleapis.com/v2/`). V1 is deprecated and scheduled for removal October 15, 2026.
+
+## Error handling
+
+| Scenario                               | Behavior                                                                                         |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| No extension zip in release assets     | Workflow fails: "no extension zip found for release vX.Y.Z"                                      |
+| Invalid or expired refresh token       | Script fails with Google OAuth error                                                             |
+| Version pending review, no `--force`   | Script fails: "Version pending review. Re-run with force_replace_pending_review enabled..."      |
+| Version pending review, with `--force` | Cancel submission, then upload and publish                                                       |
+| Upload fails                           | Script fails with CWS `uploadState` and `itemError` detail                                      |
+| Publish fails                          | Script fails with CWS `status` and `statusDetail`                                               |
+
+## Out of scope
+
+- Draft-only uploads (no partial publish mode).
+- Slack/Discord notifications (can be added later).
+- Automatic triggering from the release workflow.
+- New npm dependencies.
+
+## Files changed
+
+| File                                  | Change   |
+| ------------------------------------- | -------- |
+| `.github/workflows/publish-chrome.yml`| new      |
+| `build/publish-chrome.js`             | new      |

--- a/docs/superpowers/specs/2026-03-25-cws-manual-publish-design.md
+++ b/docs/superpowers/specs/2026-03-25-cws-manual-publish-design.md
@@ -20,18 +20,18 @@ A manual `workflow_dispatch` GitHub Actions workflow that downloads an extension
 
 `workflow_dispatch` with two inputs:
 
-| Input                         | Type    | Default | Description                                                              |
-| ----------------------------- | ------- | ------- | ------------------------------------------------------------------------ |
-| `version`                     | string  | `""`    | Release tag (e.g. `v0.3.2`). Empty string resolves to the latest release |
-| `force_replace_pending_review`| boolean | `false` | Cancel any pending CWS review before uploading                           |
+| Input                          | Type    | Default | Description                                                              |
+| ------------------------------ | ------- | ------- | ------------------------------------------------------------------------ |
+| `version`                      | string  | `""`    | Release tag (e.g. `v0.3.2`). Empty string resolves to the latest release |
+| `force_replace_pending_review` | boolean | `false` | Cancel any pending CWS review before uploading                           |
 
 ### Secrets
 
-| Secret             | Purpose                        |
-| ------------------ | ------------------------------ |
-| `CWS_CLIENT_ID`   | Google OAuth client ID         |
-| `CWS_CLIENT_SECRET`| Google OAuth client secret    |
-| `CWS_REFRESH_TOKEN`| Google OAuth refresh token    |
+| Secret              | Purpose                    |
+| ------------------- | -------------------------- |
+| `CWS_CLIENT_ID`     | Google OAuth client ID     |
+| `CWS_CLIENT_SECRET` | Google OAuth client secret |
+| `CWS_REFRESH_TOKEN` | Google OAuth refresh token |
 
 ### Job steps
 
@@ -67,10 +67,10 @@ node build/publish-chrome.js <zip-path> [--force]
 
 | Variable            | Required | Default                            |
 | ------------------- | -------- | ---------------------------------- |
-| `CWS_CLIENT_ID`    | yes      | —                                  |
-| `CWS_CLIENT_SECRET`| yes      | —                                  |
-| `CWS_REFRESH_TOKEN`| yes      | —                                  |
-| `CWS_EXTENSION_ID` | no       | `akggccfpkleihhemkkikggopnifgelbk` |
+| `CWS_CLIENT_ID`     | yes      | —                                  |
+| `CWS_CLIENT_SECRET` | yes      | —                                  |
+| `CWS_REFRESH_TOKEN` | yes      | —                                  |
+| `CWS_EXTENSION_ID`  | no       | `akggccfpkleihhemkkikggopnifgelbk` |
 
 ### Steps
 
@@ -92,15 +92,15 @@ V2 (`chromewebstore.googleapis.com/v2/`). V1 is deprecated and scheduled for rem
 
 ## Error handling
 
-| Scenario                               | Behavior                                                                                         |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| No releases exist                      | Workflow fails: `gh release view` exits non-zero, step fails                                     |
-| No extension zip in release assets     | Workflow fails: "no extension zip found for release vX.Y.Z"                                      |
-| Invalid or expired refresh token       | Script fails with Google OAuth error                                                             |
-| Version pending review, no `--force`   | Script fails: "Version pending review. Re-run with force_replace_pending_review enabled..."      |
-| Version pending review, with `--force` | Cancel submission, then upload and publish                                                       |
-| Upload fails                           | Script fails with CWS `uploadState` and `itemError` detail                                      |
-| Publish fails                          | Script fails with CWS `status` and `statusDetail`                                               |
+| Scenario                               | Behavior                                                                                    |
+| -------------------------------------- | ------------------------------------------------------------------------------------------- |
+| No releases exist                      | Workflow fails: `gh release view` exits non-zero, step fails                                |
+| No extension zip in release assets     | Workflow fails: "no extension zip found for release vX.Y.Z"                                 |
+| Invalid or expired refresh token       | Script fails with Google OAuth error                                                        |
+| Version pending review, no `--force`   | Script fails: "Version pending review. Re-run with force_replace_pending_review enabled..." |
+| Version pending review, with `--force` | Cancel submission, then upload and publish                                                  |
+| Upload fails                           | Script fails with CWS `uploadState` and `itemError` detail                                  |
+| Publish fails                          | Script fails with CWS `status` and `statusDetail`                                           |
 
 ## Out of scope
 
@@ -111,7 +111,7 @@ V2 (`chromewebstore.googleapis.com/v2/`). V1 is deprecated and scheduled for rem
 
 ## Files changed
 
-| File                                  | Change   |
-| ------------------------------------- | -------- |
-| `.github/workflows/publish-chrome.yml`| new      |
-| `build/publish-chrome.js`             | new      |
+| File                                   | Change |
+| -------------------------------------- | ------ |
+| `.github/workflows/publish-chrome.yml` | new    |
+| `build/publish-chrome.js`              | new    |

--- a/docs/superpowers/specs/2026-03-25-cws-manual-publish-design.md
+++ b/docs/superpowers/specs/2026-03-25-cws-manual-publish-design.md
@@ -38,9 +38,13 @@ A manual `workflow_dispatch` GitHub Actions workflow that downloads an extension
 1. **Checkout** — needed for `build/publish-chrome.js`.
 2. **Setup Node 22** — script uses native `fetch`, no `npm install` required.
 3. **Resolve release** — if `version` input is empty, query latest release via `gh release view --json tagName`. Otherwise use the provided tag.
-4. **Download extension zip** — `gh release download <tag> --pattern '*-extension-*.zip' --dir /tmp/cws`.
-5. **Publish** — `node build/publish-chrome.js /tmp/cws/*.zip [--force]` with `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN` as env vars.
-6. **Summary** — annotate the workflow run with the version published and a link to the CWS developer dashboard.
+4. **Download extension zip** — `gh release download <tag> --pattern '*-extension-*.zip' --dir /tmp/cws`. The release pipeline produces files named `slicc-extension-v{version}.zip` (via `sanitizeArtifactName` in `release-package.ts`).
+5. **Publish** — invoke the script with the force flag mapped from the workflow input:
+   ```
+   node build/publish-chrome.js /tmp/cws/*.zip ${{ inputs.force_replace_pending_review == true && '--force' || '' }}
+   ```
+   Env vars: `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN`.
+6. **Summary** — write version published and CWS developer dashboard link to `$GITHUB_STEP_SUMMARY`.
 
 ### Runner
 
@@ -90,6 +94,7 @@ V2 (`chromewebstore.googleapis.com/v2/`). V1 is deprecated and scheduled for rem
 
 | Scenario                               | Behavior                                                                                         |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| No releases exist                      | Workflow fails: `gh release view` exits non-zero, step fails                                     |
 | No extension zip in release assets     | Workflow fails: "no extension zip found for release vX.Y.Z"                                      |
 | Invalid or expired refresh token       | Script fails with Google OAuth error                                                             |
 | Version pending review, no `--force`   | Script fails: "Version pending review. Re-run with force_replace_pending_review enabled..."      |


### PR DESCRIPTION
## Summary

- Add `build/publish-chrome.js` — zero-dependency Node script that authenticates via Google OAuth, checks for pending reviews, and uploads + publishes to the CWS V2 API
- Add `.github/workflows/publish-chrome.yml` — manual `workflow_dispatch` workflow with optional version input (defaults to latest release) and force flag to cancel pending reviews
- Design spec and implementation plan in `docs/superpowers/specs/` and `docs/superpowers/plans/`

## Setup Required

Before first use, add these GitHub secrets:
- `CWS_CLIENT_ID` — Google OAuth client ID
- `CWS_CLIENT_SECRET` — Google OAuth client secret
- `CWS_REFRESH_TOKEN` — Google OAuth refresh token

## Test Plan

- [ ] Verify `node --check build/publish-chrome.js` passes
- [ ] Verify workflow appears in Actions tab after merge
- [ ] Add CWS credentials to repo secrets
- [ ] Run workflow with default inputs (latest release)
- [ ] Verify extension appears in CWS developer dashboard

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>