### PR TITLE
feat: enable semantic-release PR/issue comments and released labels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -20,11 +20,9 @@
     [
       "@semantic-release/github",
       {
-        "successComment": false,
         "failComment": false,
         "failTitle": false,
         "labels": false,
-        "releasedLabels": false,
         "assets": [
           "artifacts/release/*.zip",
           "artifacts/release/*.tgz",


### PR DESCRIPTION
## What

Enable \ to comment on PRs/issues included in a release and add \ labels.

## Changes

- **\**: Removed \ and \ from the \ plugin config (defaults to enabled)
- **\**: Added \ and \ permissions so the GitHub token can comment and label

## Result

On each release, semantic-release will:
- Comment on every PR/issue included in the release
- Add a \ label to those PRs/issues

No new secrets required — uses the existing \.