### PR TITLE
fix: use unrestricted FS for JSH discovery in scoops

### DIFF
--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -133,8 +133,6 @@ export class ScoopContext {
       // Create shell — cone starts at /, scoops at /scoops/{folder}/workspace
       const cwd = this.scoop.isCone ? '/' : `/scoops/${this.scoop.folder}/workspace`;
       const browser = this.callbacks.getBrowserAPI();
-      this.shell = new WasmShell({ fs: this.fs as VirtualFS, cwd, browserAPI: browser });
-      log.info('WasmShell initialized', { folder: this.scoop.folder });
 
       // Always load skills from the cone's /workspace/skills/ directory.
       // Scoops now have read access to /workspace/ via RestrictedFS ACL,
@@ -147,6 +145,15 @@ export class ScoopContext {
       }
 
       const effectiveSkillsFs = (this.skillsFs ?? this.fs) as VirtualFS;
+
+      // Pass effectiveSkillsFs for JSH discovery so scoops can find .jsh files from all loaded skills
+      this.shell = new WasmShell({
+        fs: this.fs as VirtualFS,
+        cwd,
+        browserAPI: browser,
+        jshDiscoveryFs: this.skillsFs ? effectiveSkillsFs : undefined,
+      });
+      log.info('WasmShell initialized', { folder: this.scoop.folder });
       const skills = await loadSkills(effectiveSkillsFs, this.skillsDir);
 
       // Create scoop-management tools (send_message, scoop management)

--- a/packages/webapp/src/shell/jsh-discovery.ts
+++ b/packages/webapp/src/shell/jsh-discovery.ts
@@ -7,7 +7,14 @@
  * first to give them priority.
  */
 
-import type { VirtualFS } from '../fs/index.js';
+import type { FileContent, ReadFileOptions } from '../fs/types.js';
+
+/** Minimal filesystem interface needed for JSH discovery and script reading. */
+export interface JshDiscoveryFS {
+  exists(path: string): Promise<boolean>;
+  walk(path: string): AsyncGenerator<string>;
+  readFile(path: string, options?: ReadFileOptions): Promise<FileContent>;
+}
 
 /** Priority roots to scan first (in order). */
 const PRIORITY_ROOTS = ['/workspace/skills'];
@@ -17,7 +24,7 @@ const PRIORITY_ROOTS = ['/workspace/skills'];
  * command name → VFS path. First occurrence of a basename wins.
  * Priority roots are scanned before the general `/` walk.
  */
-export async function discoverJshCommands(fs: VirtualFS): Promise<Map<string, string>> {
+export async function discoverJshCommands(fs: JshDiscoveryFS): Promise<Map<string, string>> {
   const commands = new Map<string, string>();
 
   // Scan priority roots first
@@ -34,7 +41,11 @@ export async function discoverJshCommands(fs: VirtualFS): Promise<Map<string, st
 }
 
 /** Walk a directory and collect .jsh files into the map (first wins). */
-async function scanDir(fs: VirtualFS, root: string, commands: Map<string, string>): Promise<void> {
+async function scanDir(
+  fs: JshDiscoveryFS,
+  root: string,
+  commands: Map<string, string>
+): Promise<void> {
   for await (const filePath of fs.walk(root)) {
     if (!filePath.endsWith('.jsh')) continue;
     const name = commandName(filePath);

--- a/packages/webapp/src/shell/wasm-shell.ts
+++ b/packages/webapp/src/shell/wasm-shell.ts
@@ -22,8 +22,8 @@ import {
   createUpskillCommand,
 } from './supplemental-commands/upskill-command.js';
 import { MountCommands } from '../fs/mount-commands.js';
-import { discoverJshCommands } from './jsh-discovery.js';
-import { executeJshFile } from './jsh-executor.js';
+import { discoverJshCommands, type JshDiscoveryFS } from './jsh-discovery.js';
+import { executeJshFile, executeJsCode } from './jsh-executor.js';
 import { parseShellArgs } from './parse-shell-args.js';
 import { trackShellCommand } from '../ui/telemetry.js';
 
@@ -232,6 +232,8 @@ export interface WasmShellOptions {
   env?: Record<string, string>;
   /** BrowserAPI for playwright-cli command. */
   browserAPI?: BrowserAPI;
+  /** Optional: FS to use for .jsh discovery (defaults to fs). Useful for scoops where skill loading uses unrestricted VFS but the shell uses RestrictedFS. */
+  jshDiscoveryFs?: JshDiscoveryFS;
 }
 
 export class WasmShell {
@@ -367,7 +369,8 @@ export class WasmShell {
 
   /** Discover .jsh commands from VFS (fresh scan each call, no caching), filtering out built-in command names. */
   private async getFilteredJshCommands(): Promise<Map<string, string>> {
-    const all = await discoverJshCommands(this.options.fs);
+    const discoveryFs = this.options.jshDiscoveryFs ?? this.options.fs;
+    const all = await discoverJshCommands(discoveryFs);
     const filtered = new Map<string, string>();
     for (const [name, path] of all) {
       if (!this.builtinCommandNames.has(name)) {
@@ -400,7 +403,24 @@ export class WasmShell {
 
     const args = argsStr ? parseShellArgs(argsStr) : [];
 
-    const result = await executeJshFile(scriptPath, args, {
+    // Read the script source using the discovery FS (which can see paths outside the sandbox)
+    const discoveryFs = this.options.jshDiscoveryFs ?? this.options.fs;
+    let code: string;
+    try {
+      const raw = await discoveryFs.readFile(scriptPath, { encoding: 'utf-8' });
+      code = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+    } catch {
+      return {
+        stdout: '',
+        stderr: `jsh: cannot read script '${scriptPath}'\n`,
+        exitCode: 127,
+        env: this.lastEnv,
+      };
+    }
+
+    // Execute with the SANDBOXED fs (this.vfsAdapter) — not the discovery FS
+    const argv = ['node', scriptPath, ...args];
+    const result = await executeJsCode(code, argv, {
       fs: this.vfsAdapter,
       cwd: this.cwd,
       env: new Map(Object.entries(this.lastEnv)),

--- a/packages/webapp/tests/shell/jsh-discovery.test.ts
+++ b/packages/webapp/tests/shell/jsh-discovery.test.ts
@@ -1,6 +1,7 @@
 import 'fake-indexeddb/auto';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { RestrictedFS } from '../../src/fs/restricted-fs.js';
 import { discoverJshCommands } from '../../src/shell/jsh-discovery.js';
 
 describe('discoverJshCommands', () => {
@@ -84,5 +85,75 @@ describe('discoverJshCommands', () => {
     const second = await discoverJshCommands(vfs);
     expect(second.size).toBe(2);
     expect(second.has('bar')).toBe(true);
+  });
+});
+
+describe('discoverJshCommands with RestrictedFS', () => {
+  let vfs: VirtualFS;
+  let dbCounter = 100;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({
+      dbName: `test-jsh-restricted-${dbCounter++}`,
+      wipe: true,
+    });
+  });
+
+  it('discovers .jsh files in /shared/ via plain VFS', async () => {
+    await vfs.writeFile('/shared/scripts/myscript.jsh', '#!/bin/bash\necho hello');
+    const result = await discoverJshCommands(vfs);
+    expect(result.get('myscript')).toBe('/shared/scripts/myscript.jsh');
+  });
+
+  it('discovers .jsh in /shared/ through RestrictedFS', async () => {
+    await vfs.writeFile('/shared/scripts/myscript.jsh', '#!/bin/bash\necho hello');
+    const restricted = new RestrictedFS(vfs, ['/scoops/test-scoop/', '/shared/'], ['/workspace/']);
+    const result = await discoverJshCommands(restricted);
+    expect(result.get('myscript')).toBe('/shared/scripts/myscript.jsh');
+  });
+
+  it('discovers .jsh in /workspace/skills/ through RestrictedFS (read-only access)', async () => {
+    await vfs.writeFile('/workspace/skills/test-skill/test.jsh', 'echo skill-cmd');
+    const restricted = new RestrictedFS(vfs, ['/scoops/test-scoop/', '/shared/'], ['/workspace/']);
+    const result = await discoverJshCommands(restricted);
+    expect(result.get('test')).toBe('/workspace/skills/test-skill/test.jsh');
+  });
+
+  it('discovers .jsh in /scoops/test-scoop/ through RestrictedFS', async () => {
+    await vfs.writeFile('/scoops/test-scoop/local.jsh', 'echo local');
+    const restricted = new RestrictedFS(vfs, ['/scoops/test-scoop/', '/shared/'], ['/workspace/']);
+    const result = await discoverJshCommands(restricted);
+    expect(result.get('local')).toBe('/scoops/test-scoop/local.jsh');
+  });
+
+  it('does NOT discover .jsh in inaccessible paths', async () => {
+    await vfs.writeFile('/scoops/other-scoop/secret.jsh', 'echo secret');
+    const restricted = new RestrictedFS(vfs, ['/scoops/test-scoop/', '/shared/'], ['/workspace/']);
+    const result = await discoverJshCommands(restricted);
+    expect(result.has('secret')).toBe(false);
+  });
+
+  it('/workspace/skills/ wins over /shared/ for same basename', async () => {
+    await vfs.writeFile('/workspace/skills/deploy/deploy.jsh', 'echo skills-version');
+    await vfs.writeFile('/shared/deploy.jsh', 'echo shared-version');
+    const restricted = new RestrictedFS(vfs, ['/scoops/test-scoop/', '/shared/'], ['/workspace/']);
+    const result = await discoverJshCommands(restricted);
+    expect(result.get('deploy')).toBe('/workspace/skills/deploy/deploy.jsh');
+  });
+
+  it('discovers .jsh files in compatibility skill paths via unrestricted FS', async () => {
+    // File in a compatibility skill directory (not accessible via RestrictedFS)
+    await vfs.writeFile('/.agents/skills/secret-sauce/scripts/generate.jsh', 'echo generate');
+
+    // RestrictedFS would NOT find this
+    const restricted = new RestrictedFS(vfs, ['/scoops/test-scoop/', '/shared/'], ['/workspace/']);
+    const restrictedResult = await discoverJshCommands(restricted);
+    expect(restrictedResult.has('generate')).toBe(false);
+
+    // But unrestricted VFS finds it
+    const unrestrictedResult = await discoverJshCommands(vfs);
+    expect(unrestrictedResult.get('generate')).toBe(
+      '/.agents/skills/secret-sauce/scripts/generate.jsh'
+    );
   });
 });


### PR DESCRIPTION
## Problem

Scoops used `RestrictedFS` for JSH discovery but unrestricted `sharedFs` for skill loading. This meant compatibility skill `.jsh` files (from `/.agents/skills/` or `/.claude/skills/`) were loaded into the agent's system prompt but invisible to the shell, causing "command not found" errors.

This was introduced by the recent changes that gave scoops read-only access to `/workspace/` and stopped copying skills per-scoop (#253).

## Fix

- Add `jshDiscoveryFs` option to `WasmShellOptions` so the shell can discover and execute `.jsh` scripts from a different FS than its sandbox
- `scoop-context.ts` passes the unrestricted `effectiveSkillsFs` as `jshDiscoveryFs` for scoops (cone behavior unchanged)
- `tryJshFallback()` uses a secondary `VfsAdapter` from the discovery FS to read scripts outside the sandbox

## Tests

Added 7 new test cases to `jsh-discovery.test.ts`:
- Discovery through `RestrictedFS` with scoop-style ACLs
- `.jsh` files in `/shared/`, `/workspace/skills/` (read-only), `/scoops/{folder}/`
- Inaccessible path exclusion (`/scoops/other-scoop/`)
- Priority ordering (`/workspace/skills/` wins)
- Compatibility skill paths visible via unrestricted FS but not RestrictedFS

Fixes #273