### PR TITLE
feat(cloudflare-worker): redirect apex domain sliccy.ai to www.sliccy.ai

### DIFF
--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -16,6 +16,12 @@ export interface WorkerEnv {
 export async function handleWorkerRequest(request: Request, env: WorkerEnv): Promise<Response> {
   const url = new URL(request.url);
 
+  if (url.hostname === 'sliccy.ai') {
+    const target = new URL(url.toString());
+    target.hostname = 'www.sliccy.ai';
+    return Response.redirect(target.toString(), 301);
+  }
+
   if (url.pathname === '/tray' && request.method === 'POST') {
     return createTray(request, env);
   }

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1138,4 +1138,17 @@ describe('tray worker skeleton', () => {
       ],
     });
   });
+
+  it('redirects apex sliccy.ai to www.sliccy.ai with 301 preserving path and query', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(new Request('https://sliccy.ai/some/path?q=1'), env);
+    expect(response.status).toBe(301);
+    expect(response.headers.get('Location')).toBe('https://www.sliccy.ai/some/path?q=1');
+  });
+
+  it('does not redirect requests to www.sliccy.ai', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(new Request('https://www.sliccy.ai/'), env);
+    expect(response.status).toBe(200);
+  });
 });

--- a/packages/cloudflare-worker/wrangler.jsonc
+++ b/packages/cloudflare-worker/wrangler.jsonc
@@ -4,7 +4,10 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-03-11",
   "workers_dev": true,
-  "routes": [{ "pattern": "www.sliccy.ai/*", "zone_name": "sliccy.ai" }],
+  "routes": [
+    { "pattern": "www.sliccy.ai/*", "zone_name": "sliccy.ai" },
+    { "pattern": "sliccy.ai/*", "zone_name": "sliccy.ai" },
+  ],
   "vars": {
     "CLOUDFLARE_TURN_KEY_ID": "6c2201a0453bd6695ecb24a00b2b6ed1",
   },


### PR DESCRIPTION
Adds a 301 redirect from \ (apex) to \, preserving path and query string.

## Changes
- **wrangler.jsonc**: Added \ route so the worker receives apex requests
- **src/index.ts**: Added hostname check at the top of \ to 301 redirect
- **tests/index.test.ts**: Added tests for redirect and pass-through behavior

## DNS Note
The apex domain needs a proxied DNS record in Cloudflare (A/AAAA with orange cloud) for the route to match.