### PR TITLE
fix: regenerate Package.resolved for async-http-client 1.33.1

### DIFF
--- a/packages/swift-server/Package.resolved
+++ b/packages/swift-server/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "275bf3d58e3797170d3c7ea23f324edf5a83831ca106e2366d0a61926667a375",
+  "originHash" : "c810138d92c8a86434268bba08432ad72190a650fdbb52045657acd9476de26d",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client",
       "state" : {
-        "revision" : "3b57e00556515b126ad74455de1e6fa456856391",
-        "version" : "1.33.0"
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
       }
     },
     {

--- a/packages/swift-server/Package.swift
+++ b/packages/swift-server/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird", from: "2.21.1"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-websocket", from: "2.6.0"),
-        .package(url: "https://github.com/swift-server/async-http-client", from: "1.33.0"),
+        .package(url: "https://github.com/swift-server/async-http-client", from: "1.33.1"),
         .package(url: "https://github.com/vapor/websocket-kit", from: "2.16.1"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.1"),
         .package(url: "https://github.com/apple/swift-log", from: "1.10.1"),


### PR DESCRIPTION
Unblocks #285.

Renovate bot corrupted \ by replacing the version value with Package.swift syntax (\ instead of \), producing invalid JSON. This caused \ to fail immediately.

**Changes:**
- Update \ dependency from \ to \
- Regenerate \ with valid JSON via \