### PR TITLE
fix: remove manual "New scoop" button from extension UI

### DIFF
--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -261,9 +261,6 @@ export class Layout {
       this.scoopSwitcherEl.className = 'scoop-switcher';
       this.scoopSwitcher = new ScoopSwitcher(this.scoopSwitcherEl, {
         onScoopSelect: (scoop) => this.onScoopSelect?.(scoop),
-        onCreateScoop: (name) => {
-          this.panels?.scoops?.createScoop(name);
-        },
         onDeleteScoop: (jid) => {
           this.panels?.scoops?.deleteScoop?.(jid);
         },

--- a/packages/webapp/src/ui/scoop-switcher.ts
+++ b/packages/webapp/src/ui/scoop-switcher.ts
@@ -8,7 +8,6 @@ import type { Orchestrator } from '../scoops/orchestrator.js';
 
 export interface ScoopSwitcherCallbacks {
   onScoopSelect: (scoop: RegisteredScoop) => void;
-  onCreateScoop: (name: string) => void;
   onDeleteScoop: (jid: string) => void;
 }
 
@@ -157,26 +156,6 @@ export class ScoopSwitcher {
 
         menu.appendChild(item);
       }
-
-      // Add scoop button
-      const addItem = document.createElement('div');
-      addItem.className = 'scoop-dd__item scoop-dd__item--add';
-      const addIcon = document.createElement('span');
-      addIcon.textContent = '+';
-      addIcon.style.cssText = 'font-weight: bold; width: 20px; text-align: center;';
-      addItem.appendChild(addIcon);
-      const addLabel = document.createElement('span');
-      addLabel.textContent = 'New scoop';
-      addItem.appendChild(addLabel);
-      addItem.addEventListener('click', () => {
-        this.dropdownOpen = false;
-        this.render();
-        const name = prompt('Enter scoop name:');
-        if (name?.trim()) {
-          this.callbacks.onCreateScoop(name.trim());
-        }
-      });
-      menu.appendChild(addItem);
 
       this.container.appendChild(menu);
     }


### PR DESCRIPTION
## Summary

- Removes the manual "New scoop" button from the extension UI scoop switcher
- Scoops are created exclusively by the cone via `scoop_scoop` tool — the button created a dead-end UX where users hit a blank read-only chat with no way to interact
- Deletes the button element from `layout.ts` and its click-handler wiring from `scoop-switcher.ts` (24 lines removed, 0 added)

## Test plan

- [ ] Verify the extension side panel no longer shows a "New scoop" button
- [ ] Verify cone-initiated scoop creation via `scoop_scoop` still works normally
- [ ] Verify the scoop switcher panel renders correctly without the button


Made with [Cursor](https://cursor.com)