### PR TITLE
perf(upskill): optimize recommendations command (~45s → <1s)

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -3,6 +3,7 @@ import type { Command, CommandContext, SecureFetch } from 'just-bash';
 import type { VirtualFS } from '../../fs/index.js';
 import { VirtualFS as SharedVirtualFS } from '../../fs/index.js';
 import type { DiscoveredSkill } from '../../skills/types.js';
+import { SLICC_DIR, STATE_FILE } from '../../skills/constants.js';
 import { unzipSync } from 'fflate';
 import { consumeCachedBinaryByUrl } from '../binary-cache.js';
 
@@ -206,7 +207,7 @@ async function getInstalledSkillNames(fs: VirtualFS): Promise<Set<string>> {
   const names = new Set<string>();
   // 1. Native skills dir listing
   try {
-    const entries = await fs.readDir('/workspace/skills');
+    const entries = await fs.readDir(SKILLS_DIR);
     for (const e of entries) {
       if (e.type === 'directory') names.add(e.name);
     }
@@ -215,11 +216,33 @@ async function getInstalledSkillNames(fs: VirtualFS): Promise<Set<string>> {
   }
   // 2. State file (tracks applied skills)
   try {
-    const raw = await fs.readTextFile('/.slicc/state.json');
+    const raw = await fs.readTextFile(`/${SLICC_DIR}/${STATE_FILE}`);
     const state = JSON.parse(raw) as { applied_skills?: Array<{ name: string }> };
     for (const s of state.applied_skills ?? []) names.add(s.name);
   } catch {
     /* file may not exist */
+  }
+  // 3. Compatibility skill roots (.agents/skills/, .claude/skills/) — scan
+  //    top-level VFS directories (no deep BFS) for these well-known paths.
+  const COMPAT_DIRS = ['.agents', '.claude'] as const;
+  try {
+    const topLevel = await fs.readDir('/');
+    for (const dir of topLevel) {
+      if (dir.type !== 'directory') continue;
+      for (const compatDir of COMPAT_DIRS) {
+        try {
+          const skillsRoot = `/${dir.name}/${compatDir}/skills`;
+          const skillEntries = await fs.readDir(skillsRoot);
+          for (const se of skillEntries) {
+            if (se.type === 'directory') names.add(se.name);
+          }
+        } catch {
+          /* no compat skills dir */
+        }
+      }
+    }
+  } catch {
+    /* root listing failed */
   }
   return names;
 }

--- a/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
@@ -799,4 +799,57 @@ describe('upskill recommendations subcommand', () => {
     expect(result.stderr).toContain('failed to fetch skill catalog');
     expect(result.stderr).toContain('sliccy.com/skills/catalog.json');
   });
+
+  it('excludes already-installed skills from recommendations', async () => {
+    // Write profile
+    await fs.mkdir('/home/test', { recursive: true });
+    await fs.writeFile(
+      '/home/test/.welcome.json',
+      JSON.stringify({
+        purpose: 'work',
+        role: 'developer',
+        tasks: ['build-websites'],
+        apps: ['aem'],
+        name: 'Test',
+      })
+    );
+
+    // Create an installed skill directory
+    await fs.mkdir('/workspace/skills/aem', { recursive: true });
+    await fs.writeFile('/workspace/skills/aem/SKILL.md', '# AEM Skill\n');
+
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/skills/catalog.json')) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            data: [
+              {
+                name: 'aem',
+                displayName: 'AEM',
+                description: 'AEM skill',
+                repo: 'adobe/skills',
+                path: 'skills/aem',
+                skill: 'aem',
+                apps: 'aem',
+                tasks: 'build-websites',
+                role: 'developer',
+                purpose: 'work',
+                boost: '',
+              },
+            ],
+          }),
+          headers: {},
+        };
+      }
+      return { status: 404, body: '', headers: {} };
+    });
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['recommendations'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    // AEM should be filtered out since it's already installed
+    expect(result.stdout).toContain('all matching skills are already installed');
+    expect(result.stdout).not.toContain('AEM');
+  });
 });


### PR DESCRIPTION
## Problem

`upskill recommendations` took ~45 seconds even for display-only mode (no installs).

## Root Cause

1. **Expensive full-VFS BFS walk**: `discoverSkills(fs)` was called just to get installed skill names for filtering, but it triggers a breadth-first search of the entire virtual filesystem from `/`, traversing thousands of directories on mounted workspaces.

2. **Sequential operations**: The catalog network fetch and VFS walk ran sequentially instead of in parallel.

## Fix

- **New `getInstalledSkillNames()` helper**: Lists `/workspace/skills/` directories + reads `/.slicc/state.json` — two cheap operations instead of a full BFS walk.
- **Parallelized with `Promise.all`**: Catalog fetch and installed-names lookup now run concurrently.

## Verification

- Prettier ✓
- Typecheck ✓
- All 2324 tests pass ✓
