### PR TITLE
feat(scoops): idle detection and status visibility for scoops

### DIFF
--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -554,6 +554,7 @@ export class Orchestrator {
         this.callbacks.onSendMessage(jid, `${sender ? `[${sender}] ` : ''}${text}`);
       },
       getScoops: () => this.getScoops(),
+      getScoopTabState: scoop.isCone ? (jid: string) => this.tabs.get(jid) : undefined,
       onFeedScoop: scoop.isCone
         ? (scoopJid, prompt) => this.delegateToScoop(scoopJid, prompt, scoop.assistantLabel)
         : undefined,

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -29,6 +29,9 @@ import type { AssistantMessage } from '../core/types.js';
 
 const log = createLogger('orchestrator');
 
+/** Time in ms to wait before notifying cone that a scoop hasn't started work. */
+export const SCOOP_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
+
 export interface OrchestratorCallbacks {
   /** Called when a scoop sends a response */
   onResponse: (scoopJid: string, text: string, isPartial: boolean) => void;
@@ -76,6 +79,8 @@ export class Orchestrator {
   private scoopResponseBuffer: Map<string, string> = new Map();
   private lickManager: LickManager | null = null;
   private sessionStore: SessionStore | null = null;
+  /** Tracks idle timers for scoops that haven't started work after becoming ready. */
+  private idleTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
 
   constructor(
     container: HTMLElement,
@@ -241,6 +246,7 @@ export class Orchestrator {
       if (err) throw err;
     }
 
+    this.clearIdleTimer(jid);
     await this.destroyScoopTab(jid);
     this.sessionStore?.delete(jid).catch((err) => {
       log.warn('Failed to delete agent session', {
@@ -598,11 +604,18 @@ export class Orchestrator {
       this.callbacks.onStatusChange(jid, 'ready');
     }
 
+    // Start idle timer for non-cone scoops
+    const scoopForTimer = this.scoops.get(jid);
+    if (scoopForTimer && !scoopForTimer.isCone) {
+      this.startIdleTimer(jid);
+    }
+
     log.info('Scoop context created', { jid, contextId });
   }
 
   /** Destroy a scoop context */
   async destroyScoopTab(jid: string): Promise<void> {
+    this.clearIdleTimer(jid);
     const context = this.contexts.get(jid);
     if (context) {
       context.dispose();
@@ -697,6 +710,9 @@ export class Orchestrator {
       log.error('Context not found after creation', { jid });
       return;
     }
+
+    // Cancel idle timer — this scoop has started work
+    this.clearIdleTimer(jid);
 
     // Update status and clear response buffer for fresh accumulation
     this.scoopResponseBuffer.delete(jid);
@@ -890,9 +906,58 @@ export class Orchestrator {
     return results;
   }
 
+  /** Start an idle timer for a scoop. If the scoop doesn't start processing within
+   *  SCOOP_IDLE_TIMEOUT_MS, send a notification to the cone. */
+  private startIdleTimer(jid: string): void {
+    this.clearIdleTimer(jid);
+    const timer = setTimeout(() => {
+      this.idleTimers.delete(jid);
+      const scoop = this.scoops.get(jid);
+      if (!scoop || scoop.isCone) return;
+
+      // Only notify if still in ready state (never processed)
+      const tab = this.tabs.get(jid);
+      if (tab?.status !== 'ready') return;
+
+      const cone = Array.from(this.scoops.values()).find((s) => s.isCone);
+      if (!cone) return;
+
+      const notifyMsg: ChannelMessage = {
+        id: `scoop-idle-${jid}-${Date.now()}`,
+        chatJid: cone.jid,
+        senderId: scoop.folder,
+        senderName: scoop.assistantLabel,
+        content: `[@${scoop.assistantLabel} idle]: Scoop "${scoop.name}" has been ready for 2 minutes without receiving any work. This is expected if the scoop is waiting for webhooks or cron tasks. If you intended to delegate work, use feed_scoop to send a prompt.`,
+        timestamp: new Date().toISOString(),
+        fromAssistant: false,
+        channel: 'scoop-idle',
+      };
+      log.info('Scoop idle timeout', { jid, scoop: scoop.folder });
+      this.handleMessage(notifyMsg).catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error('Failed to send idle notification', { jid, error: msg });
+      });
+    }, SCOOP_IDLE_TIMEOUT_MS);
+    this.idleTimers.set(jid, timer);
+  }
+
+  /** Clear an idle timer for a scoop. */
+  private clearIdleTimer(jid: string): void {
+    const timer = this.idleTimers.get(jid);
+    if (timer) {
+      clearTimeout(timer);
+      this.idleTimers.delete(jid);
+    }
+  }
+
   /** Cleanup */
   async shutdown(): Promise<void> {
     this.stopMessageLoop();
+
+    // Clear all idle timers
+    for (const jid of this.idleTimers.keys()) {
+      this.clearIdleTimer(jid);
+    }
 
     // Stop the scheduler
     this.scheduler?.stop();

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -275,6 +275,7 @@ export class Orchestrator {
   async resetFilesystem(): Promise<void> {
     // Destroy all scoop contexts (they hold references to the old VFS)
     for (const [jid, ctx] of this.contexts.entries()) {
+      this.clearIdleTimer(jid);
       ctx.stop();
       this.contexts.delete(jid);
     }
@@ -911,6 +912,9 @@ export class Orchestrator {
    *  SCOOP_IDLE_TIMEOUT_MS, send a notification to the cone. */
   private startIdleTimer(jid: string): void {
     this.clearIdleTimer(jid);
+    // Guard: don't start if the scoop is already processing (e.g. auto-feed race)
+    const currentTab = this.tabs.get(jid);
+    if (currentTab?.status === 'processing') return;
     const timer = setTimeout(() => {
       this.idleTimers.delete(jid);
       const scoop = this.scoops.get(jid);

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -70,6 +70,8 @@ export interface ScoopContextCallbacks {
   onSendMessage: (text: string, sender?: string) => void;
   /** Get all scoops (for cone) */
   getScoops: () => RegisteredScoop[];
+  /** Get tab state for a scoop by JID (cone only). */
+  getScoopTabState?: (jid: string) => import('./types.js').ScoopTabState | undefined;
   /** Feed a prompt to a specific scoop (cone only). */
   onFeedScoop?: (scoopJid: string, prompt: string) => Promise<void>;
   /** Create a new scoop (cone only) */
@@ -161,6 +163,7 @@ export class ScoopContext {
         scoop: this.scoop,
         onSendMessage: this.callbacks.onSendMessage,
         getScoops: this.callbacks.getScoops,
+        getScoopTabState: this.callbacks.getScoopTabState,
         onFeedScoop: this.callbacks.onFeedScoop,
         onScoopScoop: this.callbacks.onScoopScoop,
         onDropScoop: this.callbacks.onDropScoop,

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -17,6 +17,8 @@ export interface ScoopManagementToolsConfig {
   /** Feed a prompt to a specific scoop (cone only). */
   onFeedScoop?: (scoopJid: string, prompt: string) => Promise<void>;
   getScoops: () => RegisteredScoop[];
+  /** Get tab state for a scoop by JID (status, lastActivity). */
+  getScoopTabState?: (jid: string) => import('./types.js').ScoopTabState | undefined;
   onScoopScoop?: (scoop: Omit<RegisteredScoop, 'jid'>) => Promise<RegisteredScoop>;
   onDropScoop?: (scoopJid: string) => Promise<void>;
   onSetGlobalMemory?: (content: string) => Promise<void>;
@@ -32,6 +34,7 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
     onSendMessage,
     onFeedScoop,
     getScoops,
+    getScoopTabState,
     onScoopScoop,
     onDropScoop,
     onSetGlobalMemory,
@@ -136,8 +139,20 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
 
         const formatted = scoops
           .map((s) => {
-            if (s.isCone) return `- ${s.assistantLabel} (${s.folder}) [CONE]`;
-            return `- ${s.name} (${s.folder})`;
+            const tab = getScoopTabState?.(s.jid);
+            const status = tab?.status ?? 'unknown';
+            const activity = tab?.lastActivity
+              ? new Date(tab.lastActivity).toLocaleString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit',
+                  hour12: true,
+                })
+              : '';
+            const statusSuffix = activity ? ` — ${status} (since ${activity})` : ` — ${status}`;
+            if (s.isCone) return `- ${s.assistantLabel} (${s.folder}) [CONE]${statusSuffix}`;
+            return `- ${s.name} (${s.folder})${statusSuffix}`;
           })
           .join('\n');
 

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -384,7 +384,7 @@ describe('Scoop idle detection', () => {
       chatJid: cone.jid,
       senderId: testScoop.folder,
       senderName: testScoop.assistantLabel,
-      content: `[@${testScoop.assistantLabel} idle]: Scoop "${testScoop.name}" has been ready for 2 minutes without receiving any work.`,
+      content: `[@${testScoop.assistantLabel} idle]: Scoop "${testScoop.name}" has been ready for 2 minutes without receiving any work. This is expected if the scoop is waiting for webhooks or cron tasks. If you intended to delegate work, use feed_scoop to send a prompt.`,
       fromAssistant: false,
       channel: 'scoop-idle',
     });
@@ -396,6 +396,9 @@ describe('Scoop idle detection', () => {
     expect(coneMessages[0].senderId).toBe(testScoop.folder);
     expect(coneMessages[0].senderName).toBe(testScoop.assistantLabel);
     expect(coneMessages[0].content).toContain(`[@${testScoop.assistantLabel} idle]`);
+    expect(coneMessages[0].content).toBe(
+      `[@${testScoop.assistantLabel} idle]: Scoop "${testScoop.name}" has been ready for 2 minutes without receiving any work. This is expected if the scoop is waiting for webhooks or cron tasks. If you intended to delegate work, use feed_scoop to send a prompt.`
+    );
     expect(coneMessages[0].fromAssistant).toBe(false);
   });
 
@@ -406,7 +409,7 @@ describe('Scoop idle detection', () => {
       chatJid: cone.jid,
       senderId: testScoop.folder,
       senderName: testScoop.assistantLabel,
-      content: `[@${testScoop.assistantLabel} idle]: Scoop "${testScoop.name}" has been ready for 2 minutes without receiving any work.`,
+      content: `[@${testScoop.assistantLabel} idle]: Scoop "${testScoop.name}" has been ready for 2 minutes without receiving any work. This is expected if the scoop is waiting for webhooks or cron tasks. If you intended to delegate work, use feed_scoop to send a prompt.`,
       fromAssistant: false,
       channel: 'scoop-idle',
     });

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import 'fake-indexeddb/auto';
 import { initDB, saveScoop, getMessagesForScoop, clearAllMessages } from '../../src/scoops/db.js';
+import { SCOOP_IDLE_TIMEOUT_MS } from '../../src/scoops/orchestrator.js';
 import type { RegisteredScoop, ChannelMessage } from '../../src/scoops/types.js';
 
 // Test helpers — we can't instantiate a full Orchestrator (needs VirtualFS, DOM, etc.)
@@ -349,5 +350,70 @@ describe('Orchestrator SessionStore integration', () => {
     });
 
     await expect(clearResult).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * Tests for scoop idle detection.
+ *
+ * Validates the idle notification message format and routing
+ * that the orchestrator uses when a scoop sits in ready state
+ * without receiving work.
+ */
+describe('Scoop idle detection', () => {
+  beforeAll(async () => {
+    await initDB();
+    await saveScoop(cone);
+    await saveScoop(testScoop);
+    await saveScoop(otherScoop);
+  });
+
+  beforeEach(async () => {
+    await clearAllMessages();
+  });
+
+  it('SCOOP_IDLE_TIMEOUT_MS is exported and equals 120000', () => {
+    expect(SCOOP_IDLE_TIMEOUT_MS).toBe(120000);
+  });
+
+  it('idle notification message has correct format', async () => {
+    const { saveMessage } = await import('../../src/scoops/db.js');
+    // Simulate what the idle timer does — build and save the notification
+    const idleMsg = makeMessage({
+      id: `scoop-idle-${testScoop.jid}-${Date.now()}`,
+      chatJid: cone.jid,
+      senderId: testScoop.folder,
+      senderName: testScoop.assistantLabel,
+      content: `[@${testScoop.assistantLabel} idle]: Scoop "${testScoop.name}" has been ready for 2 minutes without receiving any work.`,
+      fromAssistant: false,
+      channel: 'scoop-idle',
+    });
+    await saveMessage(idleMsg);
+
+    const coneMessages = await getMessagesForScoop(cone.jid);
+    expect(coneMessages).toHaveLength(1);
+    expect(coneMessages[0].channel).toBe('scoop-idle');
+    expect(coneMessages[0].senderId).toBe(testScoop.folder);
+    expect(coneMessages[0].senderName).toBe(testScoop.assistantLabel);
+    expect(coneMessages[0].content).toContain(`[@${testScoop.assistantLabel} idle]`);
+    expect(coneMessages[0].fromAssistant).toBe(false);
+  });
+
+  it('idle notification does not appear in scoop messages', async () => {
+    const { saveMessage } = await import('../../src/scoops/db.js');
+    // Save an idle notification to the cone
+    const idleMsg = makeMessage({
+      chatJid: cone.jid,
+      senderId: testScoop.folder,
+      senderName: testScoop.assistantLabel,
+      content: `[@${testScoop.assistantLabel} idle]: Scoop "${testScoop.name}" has been ready for 2 minutes without receiving any work.`,
+      fromAssistant: false,
+      channel: 'scoop-idle',
+    });
+    await saveMessage(idleMsg);
+
+    // Verify it does NOT show up in the scoop's messages
+    const scoopMessages = await getMessagesForScoop(testScoop.jid);
+    expect(scoopMessages).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Implements scoop inspection improvements from #324.

### Idle Detection
When a non-cone scoop becomes ready but doesn't receive any work (no `feed_scoop` / delegation) within **2 minutes**, the orchestrator sends an idle notification to the cone:

```
[@hero-block-scoop idle]: Scoop "hero-block" has been ready for 2 minutes without receiving any work. This is expected if the scoop is waiting for webhooks or cron tasks. If you intended to delegate work, use feed_scoop to send a prompt.
```

The notification is informational — it acknowledges that idle scoops can be intentional (e.g., waiting for hooks/licks) while also alerting the cone if a `feed_scoop` was forgotten.

The timer is cancelled when:
- The scoop starts processing (receives a prompt)
- The scoop is unregistered or destroyed
- The orchestrator shuts down

### Status in `list_scoops`
`list_scoops` now shows the current status and last activity time for each scoop:

```
Registered scoops:
- sliccy (main) [CONE] — processing (since Apr 9, 3:52 PM)
- hero-block (hero-block-scoop) — ready (since Apr 9, 3:50 PM)
- api-fetcher (api-fetcher-scoop) — initializing (since Apr 9, 3:55 PM)
```

This gives the cone visibility into whether scoops are actively working, idle, or stuck.

### Files Changed
- `packages/webapp/src/scoops/orchestrator.ts` — idle timer logic
- `packages/webapp/src/scoops/scoop-management-tools.ts` — status in `list_scoops`
- `packages/webapp/src/scoops/scoop-context.ts` — `getScoopTabState` callback
- `packages/webapp/tests/scoops/orchestrator.test.ts` — 3 new tests

Closes #324