### PR TITLE
feat: add Azure OpenAI provider (Chat Completions)

### DIFF
--- a/packages/webapp/src/providers/built-in/azure-openai.ts
+++ b/packages/webapp/src/providers/built-in/azure-openai.ts
@@ -1,0 +1,399 @@
+/**
+ * Azure OpenAI — GPT models via Azure AI Foundry Chat Completions API.
+ *
+ * Uses AzureOpenAI client from the openai SDK which handles deployment
+ * routing, api-version query params, and api-key auth automatically.
+ *
+ * LOCAL TESTING ONLY — not committed.
+ */
+
+import type { ProviderConfig } from '../types.js';
+import {
+  registerApiProvider,
+  calculateCost,
+  createAssistantMessageEventStream,
+} from '@mariozechner/pi-ai';
+import type { AssistantMessageEventStream } from '@mariozechner/pi-ai';
+import { transformMessages } from '@mariozechner/pi-ai/dist/providers/transform-messages.js';
+import { buildBaseOptions } from '@mariozechner/pi-ai/dist/providers/simple-options.js';
+import type {
+  Api,
+  Model,
+  Context,
+  SimpleStreamOptions,
+  AssistantMessage,
+  TextContent,
+  ToolCall,
+} from '@mariozechner/pi-ai';
+import { AzureOpenAI } from 'openai';
+import type {
+  ChatCompletionChunk,
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+} from 'openai/resources/chat/completions';
+import { getDeploymentForProvider, getApiVersionForProvider } from '../../ui/provider-settings.js';
+
+// ── Config ─────────────────────────────────────────────────────────
+
+const PROVIDER_ID = 'azure-openai';
+const API_VERSION = '2024-12-01-preview';
+
+export const config: ProviderConfig = {
+  id: PROVIDER_ID,
+  name: 'Azure OpenAI',
+  description: 'GPT models via Azure AI Foundry',
+  requiresApiKey: true,
+  apiKeyPlaceholder: 'Azure API key',
+  apiKeyEnvVar: 'AZURE_OPENAI_API_KEY',
+  requiresBaseUrl: true,
+  baseUrlPlaceholder: 'https://your-resource.cognitiveservices.azure.com/',
+  baseUrlDescription: 'Azure resource endpoint',
+  requiresDeployment: true,
+  deploymentPlaceholder: 'gpt-4.1-mini, gpt-4o, o4-mini',
+  deploymentDescription: 'Comma-separated deployment names (from Azure Portal → Deployments)',
+  requiresApiVersion: true,
+  apiVersionDefault: API_VERSION,
+  apiVersionDescription: 'Azure OpenAI API version',
+  // Each deployment becomes a selectable model in the chat dropdown.
+  getModelIds: () => {
+    const raw = getDeploymentForProvider(PROVIDER_ID);
+    if (!raw)
+      return [{ id: 'azure-unconfigured', name: 'Azure OpenAI (set deployments in Settings)' }];
+    const deployments = raw
+      .split(',')
+      .map((d) => d.trim())
+      .filter(Boolean);
+    if (deployments.length === 0)
+      return [{ id: 'azure-unconfigured', name: 'Azure OpenAI (set deployments in Settings)' }];
+    return deployments.map((d) => {
+      const isReasoning = d.startsWith('o1') || d.startsWith('o3') || d.startsWith('o4');
+      return { id: d, name: `${d} (Azure)`, reasoning: isReasoning, input: ['text', 'image'] };
+    });
+  },
+};
+
+// ── Message conversion ─────────────────────────────────────────────
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+  mimeType?: string;
+  data?: string;
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
+  toolCallId?: string;
+  isError?: boolean;
+  content?: ContentBlock[];
+}
+
+interface TransformedMessage {
+  role: string;
+  content: string | ContentBlock[];
+  toolCallId?: string;
+  isError?: boolean;
+}
+
+function normalizeToolCallId(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64);
+}
+
+function convertMessages(context: Context, model: Model<Api>): ChatCompletionMessageParam[] {
+  const transformed = transformMessages(
+    context.messages,
+    model,
+    normalizeToolCallId
+  ) as TransformedMessage[];
+  const result: ChatCompletionMessageParam[] = [];
+
+  for (const m of transformed) {
+    if (m.role === 'user') {
+      if (typeof m.content === 'string') {
+        result.push({ role: 'user', content: m.content });
+      } else {
+        const parts = (m.content as ContentBlock[]).map((c) => {
+          if (c.type === 'text') return { type: 'text' as const, text: c.text ?? '' };
+          if (c.type === 'image')
+            return {
+              type: 'image_url' as const,
+              image_url: { url: `data:${c.mimeType};base64,${c.data}` },
+            };
+          return { type: 'text' as const, text: JSON.stringify(c) };
+        });
+        result.push({ role: 'user', content: parts });
+      }
+    } else if (m.role === 'assistant') {
+      const blocks = m.content as ContentBlock[];
+      const content = blocks
+        .filter((c) => c.type === 'text')
+        .map((c) => c.text ?? '')
+        .join('');
+      const toolCalls = blocks
+        .filter((c) => c.type === 'toolCall')
+        .map((c) => ({
+          id: c.id ?? '',
+          type: 'function' as const,
+          function: { name: c.name ?? '', arguments: JSON.stringify(c.arguments ?? {}) },
+        }));
+      if (toolCalls.length) {
+        result.push({ role: 'assistant', content: content || null, tool_calls: toolCalls });
+      } else {
+        result.push({ role: 'assistant', content });
+      }
+    } else if (m.role === 'toolResult') {
+      const blocks = m.content as ContentBlock[] | undefined;
+      result.push({
+        role: 'tool',
+        tool_call_id: m.toolCallId ?? '',
+        content:
+          blocks?.map((c) => (c.type === 'text' ? (c.text ?? '') : JSON.stringify(c))).join('') ||
+          '',
+      });
+    }
+  }
+  return result;
+}
+
+function convertTools(tools: Context['tools']): ChatCompletionTool[] | undefined {
+  if (!tools?.length) return undefined;
+  return tools.map((t) => ({
+    type: 'function' as const,
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters as Record<string, unknown>,
+    },
+  }));
+}
+
+// ── Streaming helpers ──────────────────────────────────────────────
+
+interface ToolCallAccumulator extends ToolCall {
+  _partialJson: string;
+}
+
+function findOrCreateTextBlock(output: AssistantMessage): { block: TextContent; index: number } {
+  const existing = output.content.find((b): b is TextContent => b.type === 'text');
+  if (existing) return { block: existing, index: output.content.indexOf(existing) };
+  const block: TextContent = { type: 'text', text: '' };
+  output.content.push(block);
+  return { block, index: output.content.length - 1 };
+}
+
+function findToolCallById(output: AssistantMessage, id: string): ToolCallAccumulator | undefined {
+  return output.content.find((b): b is ToolCallAccumulator => b.type === 'toolCall' && b.id === id);
+}
+
+// ── Stream function ────────────────────────────────────────────────
+
+const streamAzureOpenAI = (
+  model: Model<Api>,
+  context: Context,
+  options: SimpleStreamOptions & { apiKey?: string } = {}
+): AssistantMessageEventStream => {
+  const stream = createAssistantMessageEventStream();
+
+  (async () => {
+    const output: AssistantMessage = {
+      role: 'assistant',
+      content: [],
+      api: 'azure-openai-anthropic' as Api,
+      provider: PROVIDER_ID,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: 'stop',
+      timestamp: Date.now(),
+    };
+
+    try {
+      const apiKey = options.apiKey;
+      if (!apiKey) throw new Error('Azure API key is required');
+
+      const endpoint = model.baseUrl;
+      if (!endpoint) throw new Error('Azure endpoint is required');
+
+      // model.id = deployment name (selected from the chat dropdown, one per deployment)
+      const deployment = model.id;
+
+      const headers: Record<string, string> = {};
+      if (model.headers) Object.assign(headers, model.headers);
+      if (options.headers) Object.assign(headers, options.headers);
+
+      // Match the Azure Portal SDK snippet:
+      //   new AzureOpenAI({ endpoint, apiKey, deployment, apiVersion })
+      const apiVersion = getApiVersionForProvider(PROVIDER_ID) || API_VERSION;
+
+      const client = new AzureOpenAI({
+        endpoint: endpoint.replace(/\/+$/, ''),
+        apiKey,
+        deployment,
+        apiVersion,
+        dangerouslyAllowBrowser: true,
+        defaultHeaders: headers,
+      });
+
+      const messages: ChatCompletionMessageParam[] = [
+        ...(context.systemPrompt
+          ? [{ role: 'system' as const, content: context.systemPrompt }]
+          : []),
+        ...convertMessages(context, model),
+      ];
+
+      const tools = convertTools(context.tools);
+      const openaiStream = await client.chat.completions.create({
+        model: deployment,
+        messages,
+        stream: true,
+        stream_options: { include_usage: true },
+        ...(options.maxTokens ? { max_completion_tokens: options.maxTokens } : {}),
+        ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+        ...(tools ? { tools } : {}),
+      });
+
+      stream.push({ type: 'start', partial: output });
+
+      for await (const chunk of openaiStream as AsyncIterable<ChatCompletionChunk>) {
+        if (chunk.usage) {
+          output.usage.input = chunk.usage.prompt_tokens ?? 0;
+          output.usage.output = chunk.usage.completion_tokens ?? 0;
+          output.usage.totalTokens = chunk.usage.total_tokens ?? 0;
+          calculateCost(model, output.usage);
+        }
+
+        for (const choice of chunk.choices ?? []) {
+          const delta = choice.delta;
+          if (!delta) continue;
+
+          if (delta.content) {
+            const { block, index } = findOrCreateTextBlock(output);
+            if (block.text === '') {
+              stream.push({ type: 'text_start', contentIndex: index, partial: output });
+            }
+            block.text += delta.content;
+            stream.push({
+              type: 'text_delta',
+              contentIndex: index,
+              delta: delta.content,
+              partial: output,
+            });
+          }
+
+          if (delta.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              let existing = tc.id ? findToolCallById(output, tc.id) : undefined;
+              if (!existing && tc.id) {
+                existing = {
+                  type: 'toolCall',
+                  id: tc.id,
+                  name: tc.function?.name ?? '',
+                  arguments: {},
+                  _partialJson: '',
+                } satisfies ToolCallAccumulator;
+                output.content.push(existing);
+                stream.push({
+                  type: 'toolcall_start',
+                  contentIndex: output.content.length - 1,
+                  partial: output,
+                });
+              }
+              if (existing && tc.function?.arguments) {
+                existing._partialJson += tc.function.arguments;
+                try {
+                  existing.arguments = JSON.parse(existing._partialJson);
+                } catch {
+                  /* partial JSON, keep accumulating */
+                }
+                stream.push({
+                  type: 'toolcall_delta',
+                  contentIndex: output.content.indexOf(existing),
+                  delta: tc.function.arguments,
+                  partial: output,
+                });
+              }
+            }
+          }
+
+          if (choice.finish_reason) {
+            output.stopReason =
+              choice.finish_reason === 'tool_calls'
+                ? 'toolUse'
+                : choice.finish_reason === 'length'
+                  ? 'length'
+                  : 'stop';
+          }
+        }
+      }
+
+      // Finalize content blocks
+      for (const block of output.content) {
+        const idx = output.content.indexOf(block);
+        if (block.type === 'toolCall') {
+          const tc = block as ToolCallAccumulator;
+          try {
+            tc.arguments = JSON.parse(tc._partialJson || '{}');
+          } catch {
+            /* keep partial */
+          }
+          delete (tc as Partial<ToolCallAccumulator>)._partialJson;
+          stream.push({
+            type: 'toolcall_end',
+            contentIndex: idx,
+            toolCall: block as ToolCall,
+            partial: output,
+          });
+        } else if (block.type === 'text') {
+          stream.push({
+            type: 'text_end',
+            contentIndex: idx,
+            content: (block as TextContent).text,
+            partial: output,
+          });
+        }
+      }
+
+      stream.push({
+        type: 'done',
+        reason: output.stopReason as 'stop' | 'length' | 'toolUse',
+        message: output,
+      });
+      stream.end();
+    } catch (error) {
+      output.stopReason = options.signal?.aborted ? 'aborted' : 'error';
+      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      stream.push({ type: 'error', reason: output.stopReason, error: output });
+      stream.end();
+    }
+  })();
+
+  return stream;
+};
+
+const streamSimpleAzureOpenAI = (
+  model: Model<Api>,
+  context: Context,
+  options?: SimpleStreamOptions
+): AssistantMessageEventStream => {
+  const apiKey = options?.apiKey;
+  if (!apiKey) throw new Error('Azure API key is required');
+  const base = buildBaseOptions(model, options, apiKey);
+  return streamAzureOpenAI(model, context, { ...base });
+};
+
+// ── Registration ───────────────────────────────────────────────────
+
+export function register(): void {
+  registerApiProvider({
+    api: 'azure-openai-anthropic' as Api,
+    stream: streamAzureOpenAI as Parameters<typeof registerApiProvider>[0]['stream'],
+    streamSimple: streamSimpleAzureOpenAI as Parameters<
+      typeof registerApiProvider
+    >[0]['streamSimple'],
+  });
+}

--- a/packages/webapp/src/providers/types.ts
+++ b/packages/webapp/src/providers/types.ts
@@ -63,6 +63,14 @@ export interface ProviderConfig {
   defaultModelId?: string;
   /** When true, the setup dialog shows a model selector dropdown. */
   requiresModelSelection?: boolean;
+  /** When true, the setup dialog shows a deployment name text input. */
+  requiresDeployment?: boolean;
+  deploymentPlaceholder?: string;
+  deploymentDescription?: string;
+  /** When true, the setup dialog shows an API version text input with a default value. */
+  requiresApiVersion?: boolean;
+  apiVersionDefault?: string;
+  apiVersionDescription?: string;
   /**
    * Optional: return the model IDs this provider supports.
    * When present, getProviderModels uses this instead of returning all Anthropic models.

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -51,6 +51,8 @@ export interface Account {
   apiKey: string;
   baseUrl?: string;
   modelId?: string;
+  deployment?: string;
+  apiVersion?: string;
   // OAuth fields (used by OAuth providers)
   accessToken?: string;
   refreshToken?: string;
@@ -337,12 +339,16 @@ export function addAccount(
   providerId: string,
   apiKey: string,
   baseUrl?: string,
-  modelId?: string
+  modelId?: string,
+  deployment?: string,
+  apiVersion?: string
 ): void {
   const accounts = getAccounts().filter((a) => a.providerId !== providerId);
   const entry: Account = { providerId, apiKey };
   if (baseUrl) entry.baseUrl = baseUrl;
   if (modelId) entry.modelId = modelId;
+  if (deployment) entry.deployment = deployment;
+  if (apiVersion) entry.apiVersion = apiVersion;
   accounts.push(entry);
   saveAccounts(accounts);
 }
@@ -389,6 +395,14 @@ export function getApiKeyForProvider(providerId: string): string | null {
 
 export function getBaseUrlForProvider(providerId: string): string | null {
   return getAccounts().find((a) => a.providerId === providerId)?.baseUrl ?? null;
+}
+
+export function getDeploymentForProvider(providerId: string): string | null {
+  return getAccounts().find((a) => a.providerId === providerId)?.deployment ?? null;
+}
+
+export function getApiVersionForProvider(providerId: string): string | null {
+  return getAccounts().find((a) => a.providerId === providerId)?.apiVersion ?? null;
 }
 
 // --- Selected model (format: "providerId:modelId") ---
@@ -1028,6 +1042,56 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
 
       dialog.appendChild(baseUrlSection);
 
+      // Deployment section (shown for providers with requiresDeployment)
+      const deploymentSection = document.createElement('div');
+      deploymentSection.style.display = 'none';
+
+      const deploymentLabel = document.createElement('div');
+      deploymentLabel.className = 'dialog__desc';
+      deploymentLabel.textContent = 'Deployment:';
+      deploymentSection.appendChild(deploymentLabel);
+
+      const deploymentInput = document.createElement('input');
+      deploymentInput.className = 'dialog__input';
+      deploymentInput.type = 'text';
+      deploymentInput.autocomplete = 'off';
+      deploymentInput.spellcheck = false;
+      if (isEdit && editing.deployment) deploymentInput.value = editing.deployment;
+      deploymentSection.appendChild(deploymentInput);
+
+      const deploymentDesc = document.createElement('div');
+      deploymentDesc.className = 'dialog__desc';
+      deploymentDesc.style.cssText =
+        'font-size: 11px; color: var(--s2-content-secondary); margin-top: -12px; margin-bottom: 16px;';
+      deploymentSection.appendChild(deploymentDesc);
+
+      dialog.appendChild(deploymentSection);
+
+      // API version section (shown for providers with requiresApiVersion)
+      const apiVersionSection = document.createElement('div');
+      apiVersionSection.style.display = 'none';
+
+      const apiVersionLabel = document.createElement('div');
+      apiVersionLabel.className = 'dialog__desc';
+      apiVersionLabel.textContent = 'API Version:';
+      apiVersionSection.appendChild(apiVersionLabel);
+
+      const apiVersionInput = document.createElement('input');
+      apiVersionInput.className = 'dialog__input';
+      apiVersionInput.type = 'text';
+      apiVersionInput.autocomplete = 'off';
+      apiVersionInput.spellcheck = false;
+      if (isEdit && editing.apiVersion) apiVersionInput.value = editing.apiVersion;
+      apiVersionSection.appendChild(apiVersionInput);
+
+      const apiVersionDesc = document.createElement('div');
+      apiVersionDesc.className = 'dialog__desc';
+      apiVersionDesc.style.cssText =
+        'font-size: 11px; color: var(--s2-content-secondary); margin-top: -12px; margin-bottom: 16px;';
+      apiVersionSection.appendChild(apiVersionDesc);
+
+      dialog.appendChild(apiVersionSection);
+
       // Model selector section (shown for providers with requiresModelSelection)
       const modelSection = document.createElement('div');
       modelSection.style.display = 'none';
@@ -1091,6 +1155,27 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
           saveBtn.style.display = '';
         }
 
+        // Deployment field
+        if (providerConfig.requiresDeployment) {
+          deploymentSection.style.display = '';
+          deploymentInput.placeholder = providerConfig.deploymentPlaceholder || 'deployment-name';
+          deploymentDesc.textContent = providerConfig.deploymentDescription || '';
+        } else {
+          deploymentSection.style.display = 'none';
+        }
+
+        // API version field
+        if (providerConfig.requiresApiVersion) {
+          apiVersionSection.style.display = '';
+          if (!apiVersionInput.value && providerConfig.apiVersionDefault) {
+            apiVersionInput.value = providerConfig.apiVersionDefault;
+          }
+          apiVersionInput.placeholder = providerConfig.apiVersionDefault || 'api-version';
+          apiVersionDesc.textContent = providerConfig.apiVersionDescription || '';
+        } else {
+          apiVersionSection.style.display = 'none';
+        }
+
         // Model selector (shown when requiresModelSelection is set)
         if (providerConfig.requiresModelSelection) {
           modelSection.style.display = '';
@@ -1143,6 +1228,13 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
           return;
         }
 
+        if (config.requiresDeployment && !deploymentInput.value.trim()) {
+          errorEl.textContent = 'Deployment name is required for this provider.';
+          errorEl.style.display = '';
+          deploymentInput.focus();
+          return;
+        }
+
         const selectedModelId = config.requiresModelSelection
           ? modelSelect.value || undefined
           : undefined;
@@ -1150,7 +1242,9 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
           pid,
           apiKeyInput.value.trim(),
           baseUrlInput.value.trim() || undefined,
-          selectedModelId
+          selectedModelId,
+          deploymentInput.value.trim() || undefined,
+          apiVersionInput.value.trim() || undefined
         );
 
         renderAccountsList();
@@ -1163,6 +1257,8 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
       };
       apiKeyInput.addEventListener('keydown', handleEnter);
       baseUrlInput.addEventListener('keydown', handleEnter);
+      deploymentInput.addEventListener('keydown', handleEnter);
+      apiVersionInput.addEventListener('keydown', handleEnter);
 
       dialog.appendChild(saveBtn);
 


### PR DESCRIPTION
## Summary

- Adds an **Azure OpenAI** built-in provider using the `AzureOpenAI` SDK client with the Chat Completions API
- Extends the provider settings UI with **deployment** (comma-separated for multiple models) and **API version** (pre-filled default) fields
- Each deployment appears as a selectable model in the chat dropdown, suffixed with `(Azure)`
- Adds generic `requiresDeployment` and `requiresApiVersion` fields to `ProviderConfig` for reuse by other providers

## Test plan

- [x] Typecheck passes
- [ ] Configure Azure OpenAI provider with API key, endpoint, deployment(s), and API version
- [ ] Verify deployment names appear in chat model dropdown
- [ ] Send a message and verify request goes to Azure endpoint (not api.anthropic.com)
- [ ] Test comma-separated deployments show multiple models in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)