### PR TITLE
fix: force isomorphic-git ESM entry to avoid browser crypto breakage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3074,9 +3074,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3094,9 +3091,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3114,9 +3108,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3134,9 +3125,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3154,9 +3142,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3174,9 +3159,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/chrome-extension/vite.config.ts
+++ b/packages/chrome-extension/vite.config.ts
@@ -24,6 +24,10 @@ export default defineConfig(({ mode }) => ({
   },
   resolve: {
     alias: {
+      // isomorphic-git >=1.37.5 exports map points "." to index.cjs which
+      // calls require('crypto').createHash — Node-only, breaks in browsers.
+      // Force the ESM entry which uses sha.js (pure JS, browser-safe).
+      'isomorphic-git': resolve(repoRoot, 'node_modules/isomorphic-git/index.js'),
       'node:zlib': resolve(__dirname, '../webapp/src/shims/empty.ts'),
       'node:module': resolve(__dirname, '../webapp/src/shims/empty.ts'),
       stream: resolve(__dirname, '../webapp/src/shims/stream.ts'),

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import 'fake-indexeddb/auto';
+// Wrap isomorphic-git in a mutable object so vi.spyOn can redefine exports.
+// The ESM namespace is frozen by spec; spreading importOriginal creates a
+// plain object whose properties are configurable.
+vi.mock('isomorphic-git', async (importOriginal) => ({ ...(await importOriginal()) }));
 import * as isoGit from 'isomorphic-git';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
 import { GitCommands } from '../../src/git/git-commands.js';
@@ -476,9 +480,10 @@ describe('GitCommands', () => {
       // Mock push to avoid real network call
       const pushSpy = vi.spyOn(isoGit, 'push').mockResolvedValue({
         ok: true,
+        error: null,
         refs: {},
         headers: {},
-      } as any);
+      });
       const setConfigSpy = vi.spyOn(isoGit, 'setConfig').mockResolvedValue();
 
       try {
@@ -512,9 +517,10 @@ describe('GitCommands', () => {
 
       const pushSpy = vi.spyOn(isoGit, 'push').mockResolvedValue({
         ok: true,
+        error: null,
         refs: {},
         headers: {},
-      } as any);
+      });
       const setConfigSpy = vi.spyOn(isoGit, 'setConfig').mockResolvedValue();
 
       try {
@@ -537,9 +543,10 @@ describe('GitCommands', () => {
 
       const pushSpy = vi.spyOn(isoGit, 'push').mockResolvedValue({
         ok: true,
+        error: null,
         refs: {},
         headers: {},
-      } as any);
+      });
       const setConfigSpy = vi.spyOn(isoGit, 'setConfig').mockResolvedValue();
 
       try {

--- a/packages/webapp/tests/git/isomorphic-git-esm.test.ts
+++ b/packages/webapp/tests/git/isomorphic-git-esm.test.ts
@@ -11,30 +11,31 @@
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
 
-const isoGitDir = resolve(__dirname, '../../../../node_modules/isomorphic-git');
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const isoGitDir = resolve(currentDir, '../../../../node_modules/isomorphic-git');
+const nodeCryptoRequirePattern = /require\s*\(\s*['"](?:node:)?crypto['"]\s*\)/;
 
 describe('isomorphic-git browser compatibility', () => {
   it('ESM entry does not depend on Node crypto', () => {
     const esm = readFileSync(resolve(isoGitDir, 'index.js'), 'utf-8');
-    expect(esm).not.toContain("require('crypto')");
-    expect(esm).not.toContain('require("crypto")');
+    expect(esm).not.toMatch(nodeCryptoRequirePattern);
   });
 
   it('CJS entry has the Node crypto dependency (documents the upstream bug)', () => {
     const cjs = readFileSync(resolve(isoGitDir, 'index.cjs'), 'utf-8');
     // If this assertion fails, the upstream bug may be fixed and the
     // resolve.alias workaround in vite configs can be removed.
-    expect(cjs).toContain("require('crypto')");
+    expect(cjs).toMatch(nodeCryptoRequirePattern);
   });
 
-  it('hashBlob produces a valid SHA-1 via the browser-safe path', async () => {
+  it('hashBlob produces the expected SHA-1 via the browser-safe path', async () => {
     const git = await import('isomorphic-git');
     const result = await git.hashBlob({
       object: new Uint8Array([72, 101, 108, 108, 111]),
     });
-    expect(result.oid).toHaveLength(40);
-    expect(result.oid).toMatch(/^[0-9a-f]{40}$/);
+    expect(result.oid).toBe('5ab2f8a4323abafb10abb68657d9d39f1a775057');
   });
 });

--- a/packages/webapp/tests/git/isomorphic-git-esm.test.ts
+++ b/packages/webapp/tests/git/isomorphic-git-esm.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Guards against isomorphic-git CJS/ESM resolution regression.
+ *
+ * isomorphic-git >=1.37.5 added `require('crypto').createHash('sha1')` to
+ * the CJS bundle (index.cjs) via a new `shasumRange` function. The ESM
+ * bundle (index.js) uses sha.js instead — browser-safe. The package's
+ * exports map only has a "default" condition (no "import"), so bundlers
+ * resolve to the broken CJS entry unless overridden via resolve.alias
+ * in vite.config.ts, the extension vite.config.ts, and vitest.config.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const isoGitDir = resolve(__dirname, '../../../../node_modules/isomorphic-git');
+
+describe('isomorphic-git browser compatibility', () => {
+  it('ESM entry does not depend on Node crypto', () => {
+    const esm = readFileSync(resolve(isoGitDir, 'index.js'), 'utf-8');
+    expect(esm).not.toContain("require('crypto')");
+    expect(esm).not.toContain('require("crypto")');
+  });
+
+  it('CJS entry has the Node crypto dependency (documents the upstream bug)', () => {
+    const cjs = readFileSync(resolve(isoGitDir, 'index.cjs'), 'utf-8');
+    // If this assertion fails, the upstream bug may be fixed and the
+    // resolve.alias workaround in vite configs can be removed.
+    expect(cjs).toContain("require('crypto')");
+  });
+
+  it('hashBlob produces a valid SHA-1 via the browser-safe path', async () => {
+    const git = await import('isomorphic-git');
+    const result = await git.hashBlob({
+      object: new Uint8Array([72, 101, 108, 108, 111]),
+    });
+    expect(result.oid).toHaveLength(40);
+    expect(result.oid).toMatch(/^[0-9a-f]{40}$/);
+  });
+});

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -182,6 +182,10 @@ export default defineConfig(({ mode }) => ({
     alias: {
       // Buffer polyfill for isomorphic-git (browser compatibility)
       buffer: 'buffer/',
+      // isomorphic-git >=1.37.5 exports map points "." to index.cjs which
+      // calls require('crypto').createHash — Node-only, breaks in browsers.
+      // Force the ESM entry which uses sha.js (pure JS, browser-safe).
+      'isomorphic-git': resolve(workspaceRoot, 'node_modules/isomorphic-git/index.js'),
       // just-bash's browser bundle references node:zlib and node:module for
       // gzip/gunzip commands that aren't functional in browsers anyway.
       // Alias to empty stubs so the bundled JS never tries to fetch them.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
         resolve: {
           alias: {
             buffer: 'buffer/',
+            // isomorphic-git >=1.37.5 exports map points "." to index.cjs which
+            // calls require('crypto').createHash — Node-only, breaks in browsers.
+            // Force the ESM entry which uses sha.js (pure JS, browser-safe).
+            'isomorphic-git': resolve(workspaceRoot, 'node_modules/isomorphic-git/index.js'),
             'node:zlib': resolve(webappDir, 'src/shims/empty.ts'),
             'node:module': resolve(webappDir, 'src/shims/empty.ts'),
             stream: resolve(webappDir, 'src/shims/stream.ts'),


### PR DESCRIPTION
## Summary

- isomorphic-git 1.37.5 added `require('crypto').createHash('sha1')` to its CJS bundle via a new `shasumRange` function. The package's `exports` map only has a `"default"` condition (no `"import"`), so Vite resolves to the broken CJS entry — `crypto.createHash` doesn't exist in browsers.
- Add `resolve.alias` in both Vite configs and `vitest.config.ts` to force resolution to `index.js` (ESM), which uses `sha.js` (pure JS, browser-safe).
- Add guard tests that verify the ESM entry is browser-safe and will flag when the upstream bug is fixed (so the alias can be removed).
- Fix `vi.spyOn` compatibility with ESM namespace (frozen by spec) and replace pre-existing `as any` casts.

## Test plan

- [x] `npm run build -w @slicc/chrome-extension` succeeds with no `crypto` externalization warning from isomorphic-git
- [x] All 142 git tests pass (`npx vitest run packages/webapp/tests/git/`)
- [x] New guard test verifies ESM entry has no `require('crypto')` dependency
- [x] Manual test: git commands work in the extension without `createHash is not a function` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)