### PR TITLE
fix: unify VFS and bash mount visibility

### DIFF
--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -39,10 +39,16 @@ export class RestrictedFS {
     this.readOnlyPrefixes = readOnlyPaths.map(normalize);
   }
 
+  /** Get all prefixes including dynamic mount paths (as read-only). */
+  private getAllPrefixes(): string[] {
+    const mountPrefixes = this.vfs.listMounts().map((p) => (p.endsWith('/') ? p : p + '/'));
+    return [...this.allowedPrefixes, ...this.readOnlyPrefixes, ...mountPrefixes];
+  }
+
   /** Check if a path is within or is a parent of allowed or read-only prefixes. */
   private isAllowed(path: string): boolean {
     const normalized = normalizePath(path);
-    const allPrefixes = [...this.allowedPrefixes, ...this.readOnlyPrefixes];
+    const allPrefixes = this.getAllPrefixes();
     return allPrefixes.some(
       (prefix) =>
         normalized === prefix.slice(0, -1) ||
@@ -55,7 +61,7 @@ export class RestrictedFS {
   /** Check if a path is within allowed or read-only prefixes (strict — no parent access). */
   private isAllowedStrict(path: string): boolean {
     const normalized = normalizePath(path);
-    const allPrefixes = [...this.allowedPrefixes, ...this.readOnlyPrefixes];
+    const allPrefixes = this.getAllPrefixes();
     return allPrefixes.some(
       (prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix)
     );
@@ -76,6 +82,34 @@ export class RestrictedFS {
     }
   }
 
+  /** Resolve symlinks and verify the resolved path is still within allowed read areas. */
+  private async resolveAndCheckRead(path: string): Promise<string> {
+    try {
+      const resolved = await this.vfs.realpath(path);
+      if (!this.isAllowedStrict(resolved)) {
+        throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
+      }
+      return resolved;
+    } catch (err) {
+      if (err instanceof FsError) throw err;
+      throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
+    }
+  }
+
+  /** Resolve symlinks and verify the resolved path is still within writable areas. */
+  private async resolveAndCheckWrite(path: string): Promise<string> {
+    try {
+      const resolved = await this.vfs.realpath(path);
+      if (!this.isWritable(resolved)) {
+        throw new FsError('EACCES', 'permission denied', normalizePath(path));
+      }
+      return resolved;
+    } catch (err) {
+      if (err instanceof FsError) throw err;
+      throw new FsError('EACCES', 'permission denied', normalizePath(path));
+    }
+  }
+
   /** Get the underlying unrestricted VirtualFS (cone-only escape hatch). */
   getUnderlyingFS(): VirtualFS {
     return this.vfs;
@@ -92,12 +126,22 @@ export class RestrictedFS {
     if (!this.isAllowedStrict(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }
-    return this.vfs.readFile(path, options);
+    const resolved = await this.resolveAndCheckRead(path);
+    return this.vfs.readFile(resolved, options);
   }
 
   async readDir(path: string): Promise<DirEntry[]> {
     if (!this.isAllowed(path)) return [];
-    const entries = await this.vfs.readDir(path);
+    // Resolve symlinks on the directory path itself when strictly allowed
+    let resolvedPath = path;
+    if (this.isAllowedStrict(path)) {
+      try {
+        resolvedPath = await this.resolveAndCheckRead(path);
+      } catch {
+        return [];
+      }
+    }
+    const entries = await this.vfs.readDir(resolvedPath);
     // If this is a parent dir (not strictly allowed), filter to only entries
     // that lead toward allowed paths
     if (!this.isAllowedStrict(path)) {
@@ -114,11 +158,22 @@ export class RestrictedFS {
     if (!this.isAllowed(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }
+    if (this.isAllowedStrict(path)) {
+      const resolved = await this.resolveAndCheckRead(path);
+      return this.vfs.stat(resolved);
+    }
     return this.vfs.stat(path);
   }
 
   async exists(path: string): Promise<boolean> {
     if (!this.isAllowed(path)) return false;
+    if (this.isAllowedStrict(path)) {
+      try {
+        await this.resolveAndCheckRead(path);
+      } catch {
+        return false;
+      }
+    }
     return this.vfs.exists(path);
   }
 
@@ -126,12 +181,21 @@ export class RestrictedFS {
     if (!this.isAllowedStrict(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }
-    return this.vfs.readTextFile(path);
+    const resolved = await this.resolveAndCheckRead(path);
+    return this.vfs.readTextFile(resolved);
   }
 
   async *walk(path: string): AsyncGenerator<string> {
     if (!this.isAllowed(path)) return;
-    for await (const filePath of this.vfs.walk(path)) {
+    let resolvedBase = path;
+    if (this.isAllowedStrict(path)) {
+      try {
+        resolvedBase = await this.resolveAndCheckRead(path);
+      } catch {
+        return;
+      }
+    }
+    for await (const filePath of this.vfs.walk(resolvedBase)) {
       if (this.isAllowed(filePath)) {
         yield filePath;
       }
@@ -146,22 +210,65 @@ export class RestrictedFS {
     options?: { recursive?: boolean }
   ): Promise<void> {
     this.checkWrite(path);
+    // Resolve symlinks in parent path to prevent escape via symlinked directories.
+    // The file itself may not exist yet, so resolve the parent directory.
+    const dir = this.vfs.dirname(path);
+    const base = this.vfs.basename(path);
+    try {
+      const resolvedDir = await this.vfs.realpath(dir);
+      if (!this.isWritable(resolvedDir + '/' + base)) {
+        throw new FsError('EACCES', 'permission denied', normalizePath(path));
+      }
+    } catch (err) {
+      if (err instanceof FsError && err.code === 'EACCES') throw err;
+      // Parent doesn't exist yet — will be created by recursive, original check suffices
+    }
     return this.vfs.writeFile(path, content, options);
   }
 
   async mkdir(path: string, options?: MkdirOptions): Promise<void> {
     this.checkWrite(path);
+    // Resolve symlinks in parent to prevent escape
+    const dir = this.vfs.dirname(path);
+    const base = this.vfs.basename(path);
+    try {
+      const resolvedDir = await this.vfs.realpath(dir);
+      if (!this.isWritable(resolvedDir + '/' + base)) {
+        throw new FsError('EACCES', 'permission denied', normalizePath(path));
+      }
+    } catch (err) {
+      if (err instanceof FsError && err.code === 'EACCES') throw err;
+      // Parent doesn't exist — recursive mkdir will handle, original check suffices
+    }
     return this.vfs.mkdir(path, options);
   }
 
   async rm(path: string, options?: RmOptions): Promise<void> {
     this.checkWrite(path);
+    try {
+      await this.resolveAndCheckWrite(path);
+    } catch (err) {
+      if (err instanceof FsError && err.code === 'EACCES') throw err;
+      // Path doesn't exist — let vfs.rm handle the error
+    }
     return this.vfs.rm(path, options);
   }
 
   async rename(oldPath: string, newPath: string): Promise<void> {
     this.checkWrite(oldPath);
     this.checkWrite(newPath);
+    // Resolve symlinks in both paths to prevent escape
+    await this.resolveAndCheckWrite(oldPath);
+    const destDir = this.vfs.dirname(newPath);
+    const destBase = this.vfs.basename(newPath);
+    try {
+      const resolvedDir = await this.vfs.realpath(destDir);
+      if (!this.isWritable(resolvedDir + '/' + destBase)) {
+        throw new FsError('EACCES', 'permission denied', normalizePath(newPath));
+      }
+    } catch (err) {
+      if (err instanceof FsError && err.code === 'EACCES') throw err;
+    }
     return this.vfs.rename(oldPath, newPath);
   }
 
@@ -171,13 +278,37 @@ export class RestrictedFS {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(src));
     }
     this.checkWrite(dest);
-    return this.vfs.copyFile(src, dest);
+    // Resolve symlinks in source path
+    const resolvedSrc = await this.resolveAndCheckRead(src);
+    // Resolve symlinks in dest parent
+    const destDir = this.vfs.dirname(dest);
+    const destBase = this.vfs.basename(dest);
+    try {
+      const resolvedDir = await this.vfs.realpath(destDir);
+      if (!this.isWritable(resolvedDir + '/' + destBase)) {
+        throw new FsError('EACCES', 'permission denied', normalizePath(dest));
+      }
+    } catch (err) {
+      if (err instanceof FsError && err.code === 'EACCES') throw err;
+    }
+    return this.vfs.copyFile(resolvedSrc, dest);
   }
 
   // ── Symlink operations ───────────────────────────────────────────────
 
   async symlink(target: string, linkPath: string): Promise<void> {
     this.checkWrite(linkPath);
+    // Resolve symlinks in the link path's parent to prevent escape
+    const linkDir = this.vfs.dirname(linkPath);
+    const linkBase = this.vfs.basename(linkPath);
+    try {
+      const resolvedDir = await this.vfs.realpath(linkDir);
+      if (!this.isWritable(resolvedDir + '/' + linkBase)) {
+        throw new FsError('EACCES', 'permission denied', normalizePath(linkPath));
+      }
+    } catch (err) {
+      if (err instanceof FsError && err.code === 'EACCES') throw err;
+    }
     return this.vfs.symlink(target, linkPath);
   }
 
@@ -185,7 +316,19 @@ export class RestrictedFS {
     if (!this.isAllowedStrict(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }
-    return this.vfs.readlink(path);
+    const target = await this.vfs.readlink(path);
+    // Resolve the target relative to the link's parent to get the absolute path
+    let absoluteTarget: string;
+    if (target.startsWith('/')) {
+      absoluteTarget = normalizePath(target);
+    } else {
+      const linkDir = this.vfs.dirname(path);
+      absoluteTarget = normalizePath(linkDir + '/' + target);
+    }
+    if (!this.isAllowedStrict(absoluteTarget)) {
+      throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
+    }
+    return target;
   }
 
   async lstat(path: string): Promise<Stats> {

--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -223,6 +223,16 @@ export class RestrictedFS {
       if (err instanceof FsError && err.code === 'EACCES') throw err;
       // Parent doesn't exist yet — will be created by recursive, original check suffices
     }
+    // Also check if destination itself is a symlink pointing outside sandbox
+    try {
+      const destStat = await this.vfs.lstat(path);
+      if (destStat.type === 'symlink') {
+        await this.resolveAndCheckWrite(path);
+      }
+    } catch (err) {
+      if (err instanceof FsError && err.code === 'EACCES') throw err;
+      // File doesn't exist yet — that's fine, no symlink to follow
+    }
     return this.vfs.writeFile(path, content, options);
   }
 
@@ -245,11 +255,18 @@ export class RestrictedFS {
 
   async rm(path: string, options?: RmOptions): Promise<void> {
     this.checkWrite(path);
+    // For symlinks, check only the link path (not target) — we're removing the link node
     try {
-      await this.resolveAndCheckWrite(path);
+      const st = await this.vfs.lstat(path);
+      if (st.type === 'symlink') {
+        // Link itself is in a writable area (already confirmed by checkWrite above)
+        // Don't resolve target — we're deleting the link, not the target
+      } else {
+        await this.resolveAndCheckWrite(path);
+      }
     } catch (err) {
       if (err instanceof FsError && err.code === 'EACCES') throw err;
-      // Path doesn't exist — let vfs.rm handle the error
+      // Path doesn't exist — let VFS handle the error
     }
     return this.vfs.rm(path, options);
   }
@@ -290,6 +307,16 @@ export class RestrictedFS {
       }
     } catch (err) {
       if (err instanceof FsError && err.code === 'EACCES') throw err;
+    }
+    // Also check if destination itself is a symlink pointing outside sandbox
+    try {
+      const destStat = await this.vfs.lstat(dest);
+      if (destStat.type === 'symlink') {
+        await this.resolveAndCheckWrite(dest);
+      }
+    } catch (err) {
+      if (err instanceof FsError && err.code === 'EACCES') throw err;
+      // File doesn't exist yet — that's fine, no symlink to follow
     }
     return this.vfs.copyFile(resolvedSrc, dest);
   }

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -179,14 +179,22 @@ export class VirtualFS {
       /* EEXIST is fine */
     }
     this.mountPoints.set(normalized, handle);
-    this.mountSyncChannel?.postMessage({ type: 'mount', path: normalized, handle });
+    try {
+      this.mountSyncChannel?.postMessage({ type: 'mount', path: normalized, handle });
+    } catch {
+      /* Best-effort sync: local mount is already registered */
+    }
   }
 
   /** Remove a mount point (the LFS placeholder directory is left in place). */
   unmount(absolutePath: string): void {
     const normalized = normalizePath(absolutePath);
     this.mountPoints.delete(normalized);
-    this.mountSyncChannel?.postMessage({ type: 'unmount', path: normalized });
+    try {
+      this.mountSyncChannel?.postMessage({ type: 'unmount', path: normalized });
+    } catch {
+      /* best-effort sync */
+    }
   }
 
   /** Return the list of currently active mount paths. */

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -40,6 +40,8 @@ export class VirtualFS {
   private mountPoints = new Map<string, FileSystemDirectoryHandle>();
   private watcher: FsWatcher | null = null;
   private readonly dbName: string;
+  /** BroadcastChannel for syncing mount registrations across VFS instances with the same dbName. */
+  private mountSyncChannel: BroadcastChannel | null = null;
 
   private constructor(dbName: string, wipe: boolean) {
     this.dbName = dbName;
@@ -51,6 +53,23 @@ export class VirtualFS {
       .stat('/')
       .then(() => {})
       .catch(() => {});
+
+    // Set up BroadcastChannel for mount point synchronization
+    if (typeof BroadcastChannel !== 'undefined') {
+      try {
+        this.mountSyncChannel = new BroadcastChannel(`vfs-mount-sync:${dbName}`);
+        this.mountSyncChannel.onmessage = (event: MessageEvent) => {
+          const { type, path, handle } = event.data ?? {};
+          if (type === 'mount' && typeof path === 'string' && handle) {
+            this.mountPoints.set(path, handle);
+          } else if (type === 'unmount' && typeof path === 'string') {
+            this.mountPoints.delete(path);
+          }
+        };
+      } catch {
+        // BroadcastChannel may fail in some contexts — mount sync is best-effort
+      }
+    }
   }
 
   /** Create a VirtualFS instance. */
@@ -82,6 +101,8 @@ export class VirtualFS {
    * Must be called when the VirtualFS instance is no longer needed (e.g., in test cleanup).
    */
   async dispose(): Promise<void> {
+    this.mountSyncChannel?.close();
+    this.mountSyncChannel = null;
     this.watcher?.dispose();
     this.watcher = null;
 
@@ -158,11 +179,14 @@ export class VirtualFS {
       /* EEXIST is fine */
     }
     this.mountPoints.set(normalized, handle);
+    this.mountSyncChannel?.postMessage({ type: 'mount', path: normalized, handle });
   }
 
   /** Remove a mount point (the LFS placeholder directory is left in place). */
   unmount(absolutePath: string): void {
-    this.mountPoints.delete(normalizePath(absolutePath));
+    const normalized = normalizePath(absolutePath);
+    this.mountPoints.delete(normalized);
+    this.mountSyncChannel?.postMessage({ type: 'unmount', path: normalized });
   }
 
   /** Return the list of currently active mount paths. */

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -337,6 +337,44 @@ describe('RestrictedFS', () => {
     });
   });
 
+  // ── Destination symlink escape and rm symlink tests ─────────────────
+
+  describe('destination symlink escape', () => {
+    let escVfs: VirtualFS;
+    let escRestricted: RestrictedFS;
+
+    beforeAll(async () => {
+      escVfs = await VirtualFS.create({ dbName: 'test-restricted-fs-dest-symlink', wipe: true });
+      await escVfs.mkdir('/scoops/my-scoop', { recursive: true });
+      await escVfs.mkdir('/outside', { recursive: true });
+      await escVfs.writeFile('/outside/secret', 'top secret');
+
+      escRestricted = new RestrictedFS(escVfs, ['/scoops/my-scoop/']);
+    });
+
+    it('writeFile through existing symlink pointing outside sandbox is blocked', async () => {
+      await escVfs.symlink('/outside/secret', '/scoops/my-scoop/escape-write');
+      await expect(
+        escRestricted.writeFile('/scoops/my-scoop/escape-write', 'hacked')
+      ).rejects.toThrow('EACCES');
+    });
+
+    it('copyFile to existing symlink pointing outside sandbox is blocked', async () => {
+      await escVfs.writeFile('/scoops/my-scoop/src.txt', 'source');
+      await escVfs.symlink('/outside/secret', '/scoops/my-scoop/escape-copy');
+      await expect(
+        escRestricted.copyFile('/scoops/my-scoop/src.txt', '/scoops/my-scoop/escape-copy')
+      ).rejects.toThrow('EACCES');
+    });
+
+    it('rm can delete a symlink whose target is outside writable prefixes', async () => {
+      await escVfs.symlink('/outside/data', '/scoops/my-scoop/rm-link');
+      // Should succeed — we're removing the link node, not the target
+      await escRestricted.rm('/scoops/my-scoop/rm-link');
+      expect(await escVfs.exists('/scoops/my-scoop/rm-link')).toBe(false);
+    });
+  });
+
   it('rename checks both paths', async () => {
     await restricted.writeFile('/scoops/andy-scoop/rename-src.txt', 'src');
     // Rename within allowed - should work

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -186,6 +186,157 @@ describe('RestrictedFS', () => {
     ).rejects.toThrow('ENOENT');
   });
 
+  // ── Mount path access (dynamic read-only) ──────────────────────────
+
+  describe('mount paths as dynamic read-only prefixes', () => {
+    let mountVfs: VirtualFS;
+    let mountRestricted: RestrictedFS;
+
+    beforeAll(async () => {
+      mountVfs = await VirtualFS.create({ dbName: 'test-restricted-fs-mounts', wipe: true });
+      await mountVfs.mkdir('/scoops/scoop-a', { recursive: true });
+      await mountVfs.writeFile('/scoops/scoop-a/file.txt', 'scoop file');
+
+      // Simulate a mount by creating the directory and adding files,
+      // then registering it as a mount point via the VFS mount mechanism.
+      // Since we can't use real FileSystemDirectoryHandle in tests, we
+      // create the content in LFS and mock listMounts to include the path.
+      await mountVfs.mkdir('/mnt/kb', { recursive: true });
+      await mountVfs.writeFile('/mnt/kb/README.md', 'mount readme');
+      await mountVfs.writeFile('/mnt/kb/data.json', '{"key":"value"}');
+
+      // Spy on listMounts to return our simulated mount path
+      const originalListMounts = mountVfs.listMounts.bind(mountVfs);
+      mountVfs.listMounts = () => [...originalListMounts(), '/mnt/kb'];
+
+      mountRestricted = new RestrictedFS(mountVfs, ['/scoops/scoop-a/']);
+    });
+
+    it('readFile on a mounted path succeeds', async () => {
+      const content = await mountRestricted.readFile('/mnt/kb/README.md', { encoding: 'utf-8' });
+      expect(content).toBe('mount readme');
+    });
+
+    it('writeFile on a mounted path throws EACCES', async () => {
+      await expect(mountRestricted.writeFile('/mnt/kb/new.txt', 'nope')).rejects.toThrow('EACCES');
+    });
+
+    it('readDir on a mounted path returns entries', async () => {
+      const entries = await mountRestricted.readDir('/mnt/kb');
+      const names = entries.map((e) => e.name);
+      expect(names).toContain('README.md');
+      expect(names).toContain('data.json');
+    });
+
+    it('stat on a mounted path works', async () => {
+      const stat = await mountRestricted.stat('/mnt/kb');
+      expect(stat.type).toBe('directory');
+    });
+
+    it('exists on a mounted path returns true', async () => {
+      expect(await mountRestricted.exists('/mnt/kb')).toBe(true);
+      expect(await mountRestricted.exists('/mnt/kb/README.md')).toBe(true);
+    });
+
+    it('mkdir on a mounted path throws EACCES', async () => {
+      await expect(mountRestricted.mkdir('/mnt/kb/subdir')).rejects.toThrow('EACCES');
+    });
+
+    it('rm on a mounted path throws EACCES', async () => {
+      await expect(mountRestricted.rm('/mnt/kb/README.md')).rejects.toThrow('EACCES');
+    });
+
+    it('readDir on root includes mount parent paths', async () => {
+      const entries = await mountRestricted.readDir('/');
+      const names = entries.map((e) => e.name);
+      expect(names).toContain('mnt');
+      expect(names).toContain('scoops');
+    });
+  });
+
+  // ── Symlink target validation ─────────────────────────────────────
+
+  describe('symlink target validation', () => {
+    let symlinkVfs: VirtualFS;
+    let symlinkRestricted: RestrictedFS;
+
+    beforeAll(async () => {
+      symlinkVfs = await VirtualFS.create({ dbName: 'test-restricted-fs-symlinks', wipe: true });
+      // Set up directory structure
+      await symlinkVfs.mkdir('/scoops/my-scoop', { recursive: true });
+      await symlinkVfs.mkdir('/shared', { recursive: true });
+      await symlinkVfs.mkdir('/secret', { recursive: true });
+      await symlinkVfs.writeFile('/scoops/my-scoop/legit.txt', 'allowed content');
+      await symlinkVfs.writeFile('/shared/data.txt', 'shared data');
+      await symlinkVfs.writeFile('/secret/data.txt', 'top secret');
+
+      // Create symlinks:
+      // escape-link -> /secret/data.txt (points outside allowed)
+      await symlinkVfs.symlink('/secret/data.txt', '/scoops/my-scoop/escape-link');
+      // good-link -> /shared/data.txt (points to another allowed path)
+      await symlinkVfs.symlink('/shared/data.txt', '/scoops/my-scoop/good-link');
+      // chain: /scoops/my-scoop/chain-link -> /scoops/my-scoop/escape-link -> /secret/data.txt
+      await symlinkVfs.symlink('/scoops/my-scoop/escape-link', '/scoops/my-scoop/chain-link');
+
+      symlinkRestricted = new RestrictedFS(symlinkVfs, ['/scoops/my-scoop/'], ['/shared/']);
+    });
+
+    it('readFile through symlink pointing outside throws ENOENT', async () => {
+      await expect(
+        symlinkRestricted.readFile('/scoops/my-scoop/escape-link', { encoding: 'utf-8' })
+      ).rejects.toThrow('ENOENT');
+    });
+
+    it('readFile through symlink pointing to allowed path succeeds', async () => {
+      const content = await symlinkRestricted.readFile('/scoops/my-scoop/good-link', {
+        encoding: 'utf-8',
+      });
+      expect(content).toBe('shared data');
+    });
+
+    it('readTextFile through symlink pointing outside throws ENOENT', async () => {
+      await expect(symlinkRestricted.readTextFile('/scoops/my-scoop/escape-link')).rejects.toThrow(
+        'ENOENT'
+      );
+    });
+
+    it('stat through symlink pointing outside throws ENOENT', async () => {
+      await expect(symlinkRestricted.stat('/scoops/my-scoop/escape-link')).rejects.toThrow(
+        'ENOENT'
+      );
+    });
+
+    it('exists returns false for symlink pointing outside', async () => {
+      expect(await symlinkRestricted.exists('/scoops/my-scoop/escape-link')).toBe(false);
+    });
+
+    it('symlink chain where final target is outside throws ENOENT', async () => {
+      await expect(
+        symlinkRestricted.readFile('/scoops/my-scoop/chain-link', { encoding: 'utf-8' })
+      ).rejects.toThrow('ENOENT');
+    });
+
+    it('writeFile through symlink pointing outside throws EACCES', async () => {
+      // Create a symlink to a directory outside allowed
+      await symlinkVfs.mkdir('/outside-dir', { recursive: true });
+      await symlinkVfs.symlink('/outside-dir', '/scoops/my-scoop/dir-escape');
+      await expect(
+        symlinkRestricted.writeFile('/scoops/my-scoop/dir-escape/file.txt', 'hacked')
+      ).rejects.toThrow('EACCES');
+    });
+
+    it('readlink on symlink pointing outside throws ENOENT', async () => {
+      await expect(symlinkRestricted.readlink('/scoops/my-scoop/escape-link')).rejects.toThrow(
+        'ENOENT'
+      );
+    });
+
+    it('readlink on symlink pointing to allowed path succeeds', async () => {
+      const target = await symlinkRestricted.readlink('/scoops/my-scoop/good-link');
+      expect(target).toBe('/shared/data.txt');
+    });
+  });
+
   it('rename checks both paths', async () => {
     await restricted.writeFile('/scoops/andy-scoop/rename-src.txt', 'src');
     // Rename within allowed - should work

--- a/packages/webapp/tests/fs/virtual-fs-mount-sync.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs-mount-sync.test.ts
@@ -1,5 +1,5 @@
 import 'fake-indexeddb/auto';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // BroadcastChannel mock — Node doesn't provide one.

--- a/packages/webapp/tests/fs/virtual-fs-mount-sync.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs-mount-sync.test.ts
@@ -1,0 +1,99 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// BroadcastChannel mock — Node doesn't provide one.
+// We simulate the real behaviour: posting on one channel delivers to all
+// *other* channels with the same name (never to the sender itself).
+// ---------------------------------------------------------------------------
+const channelRegistry = new Map<string, Set<MockBroadcastChannel>>();
+
+class MockBroadcastChannel {
+  readonly name: string;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+
+  constructor(name: string) {
+    this.name = name;
+    if (!channelRegistry.has(name)) channelRegistry.set(name, new Set());
+    channelRegistry.get(name)!.add(this);
+  }
+
+  postMessage(data: unknown): void {
+    const peers = channelRegistry.get(this.name);
+    if (!peers) return;
+    for (const peer of peers) {
+      if (peer === this) continue; // real BC never delivers to sender
+      peer.onmessage?.({ data } as MessageEvent);
+    }
+  }
+
+  close(): void {
+    channelRegistry.get(this.name)?.delete(this);
+  }
+}
+
+// Install globally before any VirtualFS import
+(globalThis as any).BroadcastChannel = MockBroadcastChannel;
+
+// Dynamic import so the module sees the global BroadcastChannel
+const { VirtualFS } = await import('../../src/fs/virtual-fs.js');
+
+describe('VirtualFS mount-point sync via BroadcastChannel', () => {
+  let vfsA: InstanceType<typeof VirtualFS>;
+  let vfsB: InstanceType<typeof VirtualFS>;
+
+  beforeEach(async () => {
+    channelRegistry.clear();
+    vfsA = await VirtualFS.create({ dbName: 'sync-test', wipe: true });
+    vfsB = await VirtualFS.create({ dbName: 'sync-test' });
+  });
+
+  afterEach(async () => {
+    await vfsA.dispose();
+    await vfsB.dispose();
+    channelRegistry.clear();
+    await new Promise((r) => setTimeout(r, 600));
+  });
+
+  it('syncs mount from A to B', async () => {
+    const fakeHandle = { kind: 'directory', name: 'fake' } as unknown as FileSystemDirectoryHandle;
+    await vfsA.mount('/mnt/real', fakeHandle);
+
+    expect(vfsA.listMounts()).toContain('/mnt/real');
+    expect(vfsB.listMounts()).toContain('/mnt/real');
+  });
+
+  it('syncs unmount from A to B', async () => {
+    const fakeHandle = { kind: 'directory', name: 'fake' } as unknown as FileSystemDirectoryHandle;
+    await vfsA.mount('/mnt/real', fakeHandle);
+    expect(vfsB.listMounts()).toContain('/mnt/real');
+
+    vfsA.unmount('/mnt/real');
+    expect(vfsA.listMounts()).not.toContain('/mnt/real');
+    expect(vfsB.listMounts()).not.toContain('/mnt/real');
+  });
+
+  it('does not sync between different dbNames', async () => {
+    const vfsOther = await VirtualFS.create({ dbName: 'other-db', wipe: true });
+    const fakeHandle = { kind: 'directory', name: 'fake' } as unknown as FileSystemDirectoryHandle;
+    await vfsA.mount('/mnt/real', fakeHandle);
+
+    expect(vfsOther.listMounts()).not.toContain('/mnt/real');
+    await vfsOther.dispose();
+  });
+
+  it('stops syncing after dispose', async () => {
+    const fakeHandle = { kind: 'directory', name: 'fake' } as unknown as FileSystemDirectoryHandle;
+    await vfsB.dispose();
+
+    await vfsA.mount('/mnt/real', fakeHandle);
+    // vfsB was disposed, so it shouldn't receive the mount — but we can't
+    // check vfsB.listMounts() after dispose. Instead verify the channel was closed:
+    const channelSet = channelRegistry.get('vfs-mount-sync:sync-test');
+    // Only vfsA's channel should remain
+    expect(channelSet?.size ?? 0).toBe(1);
+
+    // Re-create vfsB so afterEach cleanup works
+    vfsB = await VirtualFS.create({ dbName: 'sync-test' });
+  });
+});


### PR DESCRIPTION
## Summary
- **RestrictedFS** now dynamically includes VirtualFS mount paths as read-only prefixes, so scoop file tools and sprinkles can read mounted filesystems (e.g. `/mnt/kb/`)
- **VirtualFS** synchronizes mount registrations across instances via `BroadcastChannel`, fixing extension mode where the side panel's VFS didn't see mounts from the offscreen document
- **RestrictedFS** resolves symlink targets before access checks, preventing sandbox escapes where a symlink in an allowed path could point outside the sandbox

## Test plan
- [x] 121 fs tests pass (including new mount-path access, symlink validation, and BroadcastChannel sync tests)
- [x] Typecheck clean
- [x] Production build passes
- [x] Chrome extension build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)