### PR TITLE
fix: route man command through SecureFetch proxy

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/index.ts
+++ b/packages/webapp/src/shell/supplemental-commands/index.ts
@@ -1,4 +1,4 @@
-import type { Command } from 'just-bash';
+import type { Command, SecureFetch } from 'just-bash';
 import type { VirtualFS } from '../../fs/index.js';
 import { createCommandsCommand } from './help-command.js';
 import { createConvertCommand } from './convert-command.js';
@@ -49,6 +49,8 @@ export interface SupplementalCommandsConfig extends ImgcatCommandOptions {
   fs?: VirtualFS;
   /** Browser automation backend for playwright-cli aliases. Optional so aliases stay discoverable even without browser support. */
   browserAPI?: BrowserAPI;
+  /** Fetch function that routes through the CLI proxy when available. */
+  fetchFn?: SecureFetch;
 }
 
 export function createSupplementalCommands(options: SupplementalCommandsConfig = {}): Command[] {
@@ -75,7 +77,7 @@ export function createSupplementalCommands(options: SupplementalCommandsConfig =
     createConvertCommand('magick'),
     createWhichCommand(options.fs),
     createUnameCommand(),
-    createManCommand(),
+    createManCommand(options.fetchFn),
     createOAuthTokenCommand(),
     createSecretCommand(),
     createRsyncCommand({ fs: options.fs }),

--- a/packages/webapp/src/shell/supplemental-commands/man-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/man-command.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from 'just-bash';
-import type { Command } from 'just-bash';
+import type { Command, SecureFetch } from 'just-bash';
 
 function manHelp(): { stdout: string; stderr: string; exitCode: number } {
   return {
@@ -21,7 +21,7 @@ function stripHtml(html: string): string {
     .trimEnd();
 }
 
-export function createManCommand(): Command {
+export function createManCommand(fetchFn?: SecureFetch): Command {
   return defineCommand('man', async (args) => {
     if (args.includes('--help') || args.includes('-h')) {
       return manHelp();
@@ -39,9 +39,23 @@ export function createManCommand(): Command {
     const url = `https://www.sliccy.com/man/${topic}.plain.html`;
 
     try {
-      const response = await fetch(url);
+      let status: number;
+      let statusText: string;
+      let html: string;
 
-      if (response.status === 404) {
+      if (fetchFn) {
+        const result = await fetchFn(url);
+        status = result.status;
+        statusText = result.statusText;
+        html = result.body;
+      } else {
+        const result = await fetch(url);
+        status = result.status;
+        statusText = result.statusText;
+        html = await result.text();
+      }
+
+      if (status === 404) {
         return {
           stdout: '',
           stderr: `No manual entry for ${topic}\n`,
@@ -49,15 +63,14 @@ export function createManCommand(): Command {
         };
       }
 
-      if (!response.ok) {
+      if (status < 200 || status >= 300) {
         return {
           stdout: '',
-          stderr: `man: failed to fetch manual page for ${topic}: ${response.status} ${response.statusText}\n`,
+          stderr: `man: failed to fetch manual page for ${topic}: ${status} ${statusText}\n`,
           exitCode: 1,
         };
       }
 
-      const html = await response.text();
       const plainText = stripHtml(html);
 
       return {

--- a/packages/webapp/src/shell/wasm-shell.ts
+++ b/packages/webapp/src/shell/wasm-shell.ts
@@ -291,14 +291,15 @@ export class WasmShell {
 
     // Create custom commands for just-bash
     const gitCommand = this.createGitCustomCommand();
+    const fetchFn = createProxiedFetch();
     const supplementalCommands = createSupplementalCommands({
       onMediaPreview: async (items) => this.renderMediaPreview(items),
       getJshCommands: () => this.getJshCommandNames(),
       fs: options.fs,
       browserAPI: options.browserAPI,
+      fetchFn,
     });
     const mountCommand = this.createMountCustomCommand();
-    const fetchFn = createProxiedFetch();
 
     const customCommands = [
       gitCommand,

--- a/packages/webapp/tests/shell/supplemental-commands/man-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/man-command.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { IFileSystem } from 'just-bash';
 import { createManCommand } from '../../../src/shell/supplemental-commands/man-command.js';
 
@@ -16,10 +16,6 @@ function createMockCtx() {
 }
 
 describe('man command', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it('has correct name', () => {
     const cmd = createManCommand();
     expect(cmd.name).toBe('man');
@@ -50,16 +46,15 @@ describe('man command', () => {
   });
 
   it('fetches and returns plain text for valid topic', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: async () => '<h1>Commands</h1><p>List of commands</p>',
-      })
-    );
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      body: '<h1>Commands</h1><p>List of commands</p>',
+      headers: {},
+      url: '',
+    });
 
-    const cmd = createManCommand();
+    const cmd = createManCommand(mockFetch);
     const result = await cmd.execute(['bash'], createMockCtx());
 
     expect(result.exitCode).toBe(0);
@@ -72,16 +67,15 @@ describe('man command', () => {
   });
 
   it('returns error for 404 response', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 404,
-        text: async () => 'Not found',
-      })
-    );
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 404,
+      statusText: 'Not Found',
+      body: 'Not found',
+      headers: {},
+      url: '',
+    });
 
-    const cmd = createManCommand();
+    const cmd = createManCommand(mockFetch);
     const result = await cmd.execute(['nonexistent'], createMockCtx());
 
     expect(result.exitCode).toBe(1);
@@ -89,9 +83,9 @@ describe('man command', () => {
   });
 
   it('handles network errors gracefully', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network failure')));
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network failure'));
 
-    const cmd = createManCommand();
+    const cmd = createManCommand(mockFetch);
     const result = await cmd.execute(['bash'], createMockCtx());
 
     expect(result.exitCode).toBe(1);
@@ -99,16 +93,15 @@ describe('man command', () => {
   });
 
   it('strips HTML entities', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: async () => '<p>A &amp; B &lt; C &gt; D &quot;E&quot; &#39;F&#39;</p>',
-      })
-    );
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      body: '<p>A &amp; B &lt; C &gt; D &quot;E&quot; &#39;F&#39;</p>',
+      headers: {},
+      url: '',
+    });
 
-    const cmd = createManCommand();
+    const cmd = createManCommand(mockFetch);
     const result = await cmd.execute(['test'], createMockCtx());
 
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- The `man` command used raw `fetch()` which fails in CLI mode due to CORS when fetching from `sliccy.com`
- Now accepts `SecureFetch` via `SupplementalCommandsConfig`, routing through `/api/fetch-proxy` in CLI mode
- Updated tests to use injected mock fetch instead of `vi.stubGlobal`

## Test plan
- [x] Typecheck passes
- [x] All 8 man-command tests pass
- [x] Full test suite passes (3 pre-existing failures in chat-panel unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)