### PR TITLE
feat: persist mount table across page reloads

### DIFF
--- a/packages/webapp/src/fs/mount-table-store.ts
+++ b/packages/webapp/src/fs/mount-table-store.ts
@@ -1,0 +1,102 @@
+/**
+ * Mount Table Store — persist mount entries (path → FileSystemDirectoryHandle)
+ * in IndexedDB so they survive page reloads.
+ *
+ * Uses a dedicated database (`slicc-mount-table`) to avoid schema conflicts
+ * with other stores.  Handles are structured-cloneable and can be stored
+ * directly in IDB.
+ */
+
+const DB_NAME = 'slicc-mount-table';
+const DB_VERSION = 1;
+const STORE_NAME = 'mounts';
+
+/** Open (or create) the mount-table database. */
+function openDB(): Promise<IDBDatabase> {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export interface MountEntry {
+  path: string;
+  handle: FileSystemDirectoryHandle;
+}
+
+/** Save a mount entry (path → handle) to IndexedDB. */
+export async function saveMountEntry(
+  path: string,
+  handle: FileSystemDirectoryHandle
+): Promise<void> {
+  const db = await openDB();
+  try {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(handle, path);
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** Remove a mount entry from IndexedDB. */
+export async function removeMountEntry(path: string): Promise<void> {
+  const db = await openDB();
+  try {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(path);
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** Retrieve all persisted mount entries. */
+export async function getAllMountEntries(): Promise<MountEntry[]> {
+  const db = await openDB();
+  try {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
+      const req = store.getAllKeys();
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    const values = await new Promise<FileSystemDirectoryHandle[]>((resolve, reject) => {
+      const req = store.getAll();
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    return keys.map((key, i) => ({ path: key as string, handle: values[i] }));
+  } finally {
+    db.close();
+  }
+}
+
+/** Remove all mount entries from IndexedDB. */
+export async function clearMountEntries(): Promise<void> {
+  const db = await openDB();
+  try {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).clear();
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+}

--- a/packages/webapp/src/fs/mount-table-store.ts
+++ b/packages/webapp/src/fs/mount-table-store.ts
@@ -43,6 +43,8 @@ export async function saveMountEntry(
     await new Promise<void>((resolve, reject) => {
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
+      tx.onabort = () =>
+        reject(tx.error ?? new DOMException('IndexedDB transaction aborted', 'AbortError'));
     });
   } finally {
     db.close();
@@ -58,6 +60,8 @@ export async function removeMountEntry(path: string): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
+      tx.onabort = () =>
+        reject(tx.error ?? new DOMException('IndexedDB transaction aborted', 'AbortError'));
     });
   } finally {
     db.close();
@@ -70,15 +74,19 @@ export async function getAllMountEntries(): Promise<MountEntry[]> {
   try {
     const tx = db.transaction(STORE_NAME, 'readonly');
     const store = tx.objectStore(STORE_NAME);
+    const abortError = () =>
+      tx.error ?? new DOMException('IndexedDB transaction aborted', 'AbortError');
     const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
       const req = store.getAllKeys();
       req.onsuccess = () => resolve(req.result);
       req.onerror = () => reject(req.error);
+      tx.onabort = () => reject(abortError());
     });
     const values = await new Promise<FileSystemDirectoryHandle[]>((resolve, reject) => {
       const req = store.getAll();
       req.onsuccess = () => resolve(req.result);
       req.onerror = () => reject(req.error);
+      tx.onabort = () => reject(abortError());
     });
     return keys.map((key, i) => ({ path: key as string, handle: values[i] }));
   } finally {
@@ -95,6 +103,8 @@ export async function clearMountEntries(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
+      tx.onabort = () =>
+        reject(tx.error ?? new DOMException('IndexedDB transaction aborted', 'AbortError'));
     });
   } finally {
     db.close();

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -22,7 +22,7 @@ import type {
 import { FsError } from './types.js';
 import { normalizePath, splitPath, joinPath } from './path-utils.js';
 import type { FsWatcher } from './fs-watcher.js';
-import { saveMountEntry, removeMountEntry } from './mount-table-store.js';
+import { saveMountEntry, removeMountEntry, clearMountEntries } from './mount-table-store.js';
 
 /** Maximum number of symlink hops before throwing ELOOP. */
 const MAX_SYMLINK_DEPTH = 10;
@@ -82,6 +82,9 @@ export class VirtualFS {
     const wipe = options?.wipe ?? false;
     const vfs = new VirtualFS(dbName, wipe);
     await vfs._ready;
+    if (wipe) {
+      await clearMountEntries().catch(() => {});
+    }
     return vfs;
   }
 
@@ -212,12 +215,16 @@ export class VirtualFS {
       /* Best-effort sync: local mount is already registered */
     }
     this.watcher?.notify([{ type: 'modify', path: normalized, entryType: 'directory' }]);
-    // Persist to IndexedDB (best-effort — don't block on it)
-    saveMountEntry(normalized, handle).catch(() => {});
+    // Persist to IndexedDB (best-effort)
+    try {
+      await saveMountEntry(normalized, handle);
+    } catch {
+      /* best-effort persistence */
+    }
   }
 
   /** Remove a mount point (the LFS placeholder directory is left in place). */
-  unmount(absolutePath: string): void {
+  async unmount(absolutePath: string): Promise<void> {
     const normalized = normalizePath(absolutePath);
     this.mountPoints.delete(normalized);
     try {
@@ -227,7 +234,11 @@ export class VirtualFS {
     }
     this.watcher?.notify([{ type: 'modify', path: normalized, entryType: 'directory' }]);
     // Remove from IndexedDB (best-effort)
-    removeMountEntry(normalized).catch(() => {});
+    try {
+      await removeMountEntry(normalized);
+    } catch {
+      /* best-effort persistence */
+    }
   }
 
   /** Return the list of currently active mount paths. */

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -22,6 +22,7 @@ import type {
 import { FsError } from './types.js';
 import { normalizePath, splitPath, joinPath } from './path-utils.js';
 import type { FsWatcher } from './fs-watcher.js';
+import { saveMountEntry, removeMountEntry } from './mount-table-store.js';
 
 /** Maximum number of symlink hops before throwing ELOOP. */
 const MAX_SYMLINK_DEPTH = 10;
@@ -211,6 +212,8 @@ export class VirtualFS {
       /* Best-effort sync: local mount is already registered */
     }
     this.watcher?.notify([{ type: 'modify', path: normalized, entryType: 'directory' }]);
+    // Persist to IndexedDB (best-effort — don't block on it)
+    saveMountEntry(normalized, handle).catch(() => {});
   }
 
   /** Remove a mount point (the LFS placeholder directory is left in place). */
@@ -223,6 +226,8 @@ export class VirtualFS {
       /* best-effort sync */
     }
     this.watcher?.notify([{ type: 'modify', path: normalized, entryType: 'directory' }]);
+    // Remove from IndexedDB (best-effort)
+    removeMountEntry(normalized).catch(() => {});
   }
 
   /** Return the list of currently active mount paths. */

--- a/packages/webapp/src/scoops/lick-manager.ts
+++ b/packages/webapp/src/scoops/lick-manager.ts
@@ -33,7 +33,7 @@ export interface CronTaskEntry {
 }
 
 export interface LickEvent {
-  type: 'webhook' | 'cron' | 'sprinkle' | 'fswatch';
+  type: 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload';
   webhookId?: string;
   webhookName?: string;
   cronId?: string;

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -227,7 +227,7 @@ export class ChatPanel {
   addLickMessage(
     id: string,
     content: string,
-    channel: 'webhook' | 'cron' | 'sprinkle' | 'fswatch'
+    channel: 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload'
   ): void {
     const msg: ChatMessage = {
       id,

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1464,7 +1464,15 @@ async function main(): Promise<void> {
         const needsRemount: Array<{ path: string; dirName: string }> = [];
         for (const { path, handle } of entries) {
           try {
-            const perm = await (handle as any).queryPermission({ mode: 'readwrite' });
+            if (!('queryPermission' in handle)) {
+              needsRemount.push({ path, dirName: handle.name });
+              continue;
+            }
+            const perm = await (
+              handle as unknown as {
+                queryPermission: (desc: { mode: string }) => Promise<string>;
+              }
+            ).queryPermission({ mode: 'readwrite' });
             if (perm === 'granted') {
               await sharedFs.mount(path, handle);
               log.info('Restored mount from previous session', { path, name: handle.name });

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -79,6 +79,7 @@ import {
 } from '../shell/supplemental-commands/playwright-command.js';
 import { SprinkleManager } from './sprinkle-manager.js';
 import { initTelemetry } from './telemetry.js';
+import { getAllMountEntries } from '../fs/mount-table-store.js';
 import { formatAcceptedHandoffMessage } from './accepted-handoff-message.js';
 import { StandaloneHandoffWatcher } from './standalone-handoff-watcher.js';
 import type { PendingHandoff } from '../../../chrome-extension/src/messages.js';
@@ -1306,20 +1307,25 @@ async function main(): Promise<void> {
     const isWebhook = event.type === 'webhook';
     const isSprinkle = event.type === 'sprinkle';
     const isFsWatch = event.type === 'fswatch';
+    const isSessionReload = event.type === 'session-reload';
     const eventName = isWebhook
       ? event.webhookName
       : isSprinkle
         ? event.sprinkleName
         : isFsWatch
           ? event.fswatchName
-          : event.cronName;
+          : isSessionReload
+            ? 'session-reload'
+            : event.cronName;
     const eventId = isWebhook
       ? event.webhookId
       : isSprinkle
         ? event.sprinkleName
         : isFsWatch
           ? event.fswatchId
-          : event.cronId;
+          : isSessionReload
+            ? 'session-reload'
+            : event.cronId;
     const channel = event.type;
 
     log.debug('Lick event', { type: event.type, name: eventName, targetScoop: event.targetScoop });
@@ -1404,7 +1410,9 @@ async function main(): Promise<void> {
           ? 'Sprinkle Event'
           : isFsWatch
             ? 'File Watch Event'
-            : 'Cron Event';
+            : isSessionReload
+              ? 'Session Reload'
+              : 'Cron Event';
       const content = `[${eventLabel}: ${eventName}]\n\`\`\`json\n${JSON.stringify(event.body, null, 2)}\n\`\`\``;
 
       const msg: ChannelMessage = {
@@ -1431,7 +1439,7 @@ async function main(): Promise<void> {
         layout.panels.chat.addLickMessage(
           msgId,
           content,
-          channel as 'webhook' | 'cron' | 'sprinkle' | 'fswatch'
+          channel as 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload'
         );
       }
 
@@ -1447,6 +1455,38 @@ async function main(): Promise<void> {
   };
 
   lickManager.setEventHandler(routeLickToScoop);
+
+  // ── Restore persisted mounts from IndexedDB ──────────────────────────
+  if (sharedFs) {
+    getAllMountEntries()
+      .then(async (entries) => {
+        if (entries.length === 0) return;
+        const needsRemount: Array<{ path: string; dirName: string }> = [];
+        for (const { path, handle } of entries) {
+          try {
+            const perm = await (handle as any).queryPermission({ mode: 'readwrite' });
+            if (perm === 'granted') {
+              await sharedFs.mount(path, handle);
+              log.info('Restored mount from previous session', { path, name: handle.name });
+            } else {
+              needsRemount.push({ path, dirName: handle.name });
+            }
+          } catch {
+            needsRemount.push({ path, dirName: handle.name });
+          }
+        }
+        if (needsRemount.length > 0) {
+          const event: LickEvent = {
+            type: 'session-reload',
+            targetScoop: undefined,
+            timestamp: new Date().toISOString(),
+            body: { reason: 'mount-recovery', mounts: needsRemount },
+          };
+          routeLickToScoop(event);
+        }
+      })
+      .catch((err) => log.warn('Failed to restore persisted mounts', err));
+  }
 
   // Wire inline sprinkle lick callback — routes to cone as a sprinkle lick event
   layout.panels.chat.onInlineSprinkleLick = (action: string, data: unknown) => {

--- a/packages/webapp/tests/fs/mount-table-store.test.ts
+++ b/packages/webapp/tests/fs/mount-table-store.test.ts
@@ -1,0 +1,73 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  saveMountEntry,
+  removeMountEntry,
+  getAllMountEntries,
+  clearMountEntries,
+} from '../../src/fs/mount-table-store.js';
+
+/** Minimal mock of FileSystemDirectoryHandle for IDB storage tests. */
+function mockHandle(name: string): FileSystemDirectoryHandle {
+  return { kind: 'directory', name } as unknown as FileSystemDirectoryHandle;
+}
+
+describe('mount-table-store', () => {
+  beforeEach(async () => {
+    await clearMountEntries();
+  });
+
+  it('starts with no entries', async () => {
+    const entries = await getAllMountEntries();
+    expect(entries).toEqual([]);
+  });
+
+  it('saves and retrieves a mount entry', async () => {
+    const handle = mockHandle('my-project');
+    await saveMountEntry('/workspace/my-project', handle);
+    const entries = await getAllMountEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].path).toBe('/workspace/my-project');
+    expect(entries[0].handle.name).toBe('my-project');
+  });
+
+  it('saves multiple entries', async () => {
+    await saveMountEntry('/workspace/a', mockHandle('a'));
+    await saveMountEntry('/workspace/b', mockHandle('b'));
+    const entries = await getAllMountEntries();
+    expect(entries).toHaveLength(2);
+    const paths = entries.map((e) => e.path).sort();
+    expect(paths).toEqual(['/workspace/a', '/workspace/b']);
+  });
+
+  it('overwrites entry with same path', async () => {
+    await saveMountEntry('/workspace/x', mockHandle('old'));
+    await saveMountEntry('/workspace/x', mockHandle('new'));
+    const entries = await getAllMountEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].handle.name).toBe('new');
+  });
+
+  it('removes a mount entry', async () => {
+    await saveMountEntry('/workspace/a', mockHandle('a'));
+    await saveMountEntry('/workspace/b', mockHandle('b'));
+    await removeMountEntry('/workspace/a');
+    const entries = await getAllMountEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].path).toBe('/workspace/b');
+  });
+
+  it('remove is a no-op for non-existent path', async () => {
+    await removeMountEntry('/does/not/exist');
+    const entries = await getAllMountEntries();
+    expect(entries).toEqual([]);
+  });
+
+  it('clears all entries', async () => {
+    await saveMountEntry('/workspace/a', mockHandle('a'));
+    await saveMountEntry('/workspace/b', mockHandle('b'));
+    await clearMountEntries();
+    const entries = await getAllMountEntries();
+    expect(entries).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Saves `FileSystemDirectoryHandle` entries to IndexedDB (`slicc-mount-table`) on `mount()`/`unmount()`
- On page reload, silently re-mounts directories that still have granted permission
- Sends a `session-reload` lick to the cone for mounts needing re-authorization, so the agent can prompt the user

Fixes #325

## Test plan
- [x] New `mount-table-store.test.ts` covers CRUD operations
- [x] Typecheck passes
- [x] Build passes
- [ ] Manual: mount a local directory, reload the page, verify it re-mounts silently
- [ ] Manual: mount a directory, close/reopen browser (permission revoked), verify lick appears in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)