### PR TITLE
perf(shell): synchronous CacheFS fast-path for find/grep

### DIFF
--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -164,6 +164,122 @@ export class VirtualFS {
   }
 
   // ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Synchronous fast-path: direct CacheFS access for non-mounted paths
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Access the LightningFS in-memory CacheFS tree directly.
+   * Returns null if the cache is not activated or the internal structure
+   * doesn't match expectations (e.g. after a LightningFS upgrade).
+   *
+   * The CacheFS tree is a nested Map where:
+   * - Key 0 (STAT) holds { mode, type, size, ino, mtimeMs }
+   * - String keys are child entry names mapping to sub-Maps
+   *
+   * This is a private LightningFS internal. The `cachefs-internals` test
+   * suite validates the structure so upgrades that break it are caught.
+   */
+  private getCacheFS(): any | null {
+    try {
+      const cache = (this.lfs as any)._backend?._cache;
+      if (cache?.activated && cache._root instanceof Map) return cache;
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Synchronous readDir for non-mounted LightningFS paths.
+   * Returns null if the path is under a mount or the CacheFS fast path is
+   * unavailable — callers must fall back to the async `readDir()`.
+   */
+  readDirSync(path: string): DirEntry[] | null {
+    const normalized = normalizePath(path);
+    if (this.findMount(normalized)) return null;
+    const cache = this.getCacheFS();
+    if (!cache) return null;
+    try {
+      // CacheFS.readdir follows symlinks in the path (via _lookup with follow=true)
+      const names: string[] = cache.readdir(normalized);
+      const entries: DirEntry[] = [];
+      for (const name of names) {
+        const childPath = normalized === '/' ? `/${name}` : `${normalized}/${name}`;
+        try {
+          // lstat does NOT follow the leaf symlink — gives us the entry's own type
+          const stat = cache.lstat(childPath);
+          const type: EntryType =
+            stat.type === 'symlink' ? 'symlink' : stat.type === 'dir' ? 'directory' : 'file';
+          entries.push({ name, type });
+        } catch {
+          // Skip entries we can't stat (shouldn't happen in CacheFS)
+        }
+      }
+      return entries;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Synchronous stat (follows symlinks) for non-mounted LightningFS paths.
+   * Returns null if the path is under a mount, the CacheFS fast path is
+   * unavailable, or the symlink target is in a mounted tree.
+   */
+  statSync(path: string): Stats | null {
+    const normalized = normalizePath(path);
+    if (this.findMount(normalized)) return null;
+    const cache = this.getCacheFS();
+    if (!cache) return null;
+    try {
+      // CacheFS.stat follows symlinks — if the target is outside the CacheFS
+      // tree (e.g. pointing into a mount), _lookup throws ENOENT and we
+      // return null so the caller falls back to the async path.
+      const s = cache.stat(normalized);
+      return {
+        type: s.type === 'dir' ? 'directory' : s.type === 'file' ? 'file' : 'symlink',
+        size: s.size ?? 0,
+        mtime: s.mtimeMs ?? Date.now(),
+        ctime: s.mtimeMs ?? Date.now(),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Synchronous lstat (does NOT follow symlinks) for non-mounted paths.
+   * Returns null if the fast path is unavailable.
+   */
+  lstatSync(path: string): Stats | null {
+    const normalized = normalizePath(path);
+    if (this.findMount(normalized)) return null;
+    const cache = this.getCacheFS();
+    if (!cache) return null;
+    try {
+      const s = cache.lstat(normalized);
+      if (s.type === 'symlink') {
+        return {
+          type: 'symlink',
+          size: s.size ?? 0,
+          mtime: s.mtimeMs ?? Date.now(),
+          ctime: s.mtimeMs ?? Date.now(),
+          isSymlink: true,
+          symlinkTarget: s.target,
+        };
+      }
+      return {
+        type: s.type === 'dir' ? 'directory' : 'file',
+        size: s.size ?? 0,
+        mtime: s.mtimeMs ?? Date.now(),
+        ctime: s.mtimeMs ?? Date.now(),
+      };
+    } catch {
+      return null;
+    }
+  }
+
   // File System Access API mount support
   // ---------------------------------------------------------------------------
 

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -226,6 +226,10 @@ export class VirtualFS {
    * Synchronous stat (follows symlinks) for non-mounted LightningFS paths.
    * Returns null if the path is under a mount, the CacheFS fast path is
    * unavailable, or the symlink target is in a mounted tree.
+   *
+   * Enforces MAX_SYMLINK_DEPTH to stay consistent with the async realpath().
+   * CacheFS._lookup follows symlinks internally without a depth limit, so we
+   * manually resolve symlinks with a hop counter before calling stat.
    */
   statSync(path: string): Stats | null {
     const normalized = normalizePath(path);
@@ -233,12 +237,13 @@ export class VirtualFS {
     const cache = this.getCacheFS();
     if (!cache) return null;
     try {
-      // CacheFS.stat follows symlinks — if the target is outside the CacheFS
-      // tree (e.g. pointing into a mount), _lookup throws ENOENT and we
-      // return null so the caller falls back to the async path.
-      const s = cache.stat(normalized);
+      // Manually resolve symlinks with a depth limit matching the async path.
+      const resolved = this.resolveSymlinksSync(cache, normalized);
+      if (resolved === null) return null;
+      const s = cache.lstat(resolved);
+      // After full resolution, result should be file or dir, not symlink.
       return {
-        type: s.type === 'dir' ? 'directory' : s.type === 'file' ? 'file' : 'symlink',
+        type: s.type === 'dir' ? 'directory' : 'file',
         size: s.size ?? 0,
         mtime: s.mtimeMs ?? Date.now(),
         ctime: s.mtimeMs ?? Date.now(),
@@ -246,6 +251,46 @@ export class VirtualFS {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Synchronously resolve all symlinks in a path using CacheFS, with a hop
+   * limit matching MAX_SYMLINK_DEPTH. Returns null if the limit is exceeded
+   * or the target is unresolvable (e.g. in a mount).
+   *
+   * Uses a shared mutable counter so that hops accumulate across recursive
+   * calls (matching the async realpath behavior).
+   */
+  private resolveSymlinksSync(
+    cache: any,
+    path: string,
+    hops: { count: number } = { count: 0 }
+  ): string | null {
+    const parts = path.split('/').filter(Boolean);
+    let resolved = '/';
+    for (const part of parts) {
+      resolved = resolved === '/' ? `/${part}` : `${resolved}/${part}`;
+      try {
+        const s = cache.lstat(resolved);
+        if (s.type === 'symlink') {
+          if (++hops.count > MAX_SYMLINK_DEPTH) return null;
+          const target = s.target;
+          if (target.startsWith('/')) {
+            resolved = normalizePath(target);
+          } else {
+            const { dir } = splitPath(resolved);
+            resolved = normalizePath(joinPath(dir, target));
+          }
+          // Recursively resolve — shared hops object accumulates across calls
+          const full = this.resolveSymlinksSync(cache, resolved, hops);
+          if (full === null) return null;
+          resolved = full;
+        }
+      } catch {
+        return null;
+      }
+    }
+    return resolved;
   }
 
   /**

--- a/packages/webapp/src/shell/vfs-adapter.ts
+++ b/packages/webapp/src/shell/vfs-adapter.ts
@@ -260,7 +260,7 @@ export class VfsAdapter implements IFileSystem {
     if (normalized === '/usr/bin') return this.getVirtualBinCommands().slice().sort();
     // Fast path: synchronous CacheFS read for non-mounted paths
     const fast = this.vfs.readDirSync(normalized);
-    if (fast) return fast.map((e) => e.name);
+    if (fast !== null) return fast.map((e) => e.name);
     const entries = await this.vfs.readDir(normalized);
     return entries.map((e) => e.name);
   }
@@ -286,7 +286,7 @@ export class VfsAdapter implements IFileSystem {
     // readDirSync returns null when the path is under a mount or
     // the CacheFS internal isn't available.
     const fastEntries = this.vfs.readDirSync(normalized);
-    if (fastEntries) {
+    if (fastEntries !== null) {
       const result: DirentEntry[] = [];
       for (const e of fastEntries) {
         if (e.type === 'symlink') {

--- a/packages/webapp/src/shell/vfs-adapter.ts
+++ b/packages/webapp/src/shell/vfs-adapter.ts
@@ -202,6 +202,18 @@ export class VfsAdapter implements IFileSystem {
         };
       }
     }
+    // Fast path: synchronous CacheFS stat for non-mounted paths
+    const fast = this.vfs.statSync(normalized);
+    if (fast) {
+      return {
+        isFile: fast.type === 'file',
+        isDirectory: fast.type === 'directory',
+        isSymbolicLink: !!fast.isSymlink,
+        mode: fast.type === 'directory' ? 0o755 : 0o644,
+        size: fast.size,
+        mtime: new Date(fast.mtime),
+      };
+    }
     const s = await this.vfs.stat(normalized);
     return {
       isFile: s.type === 'file',
@@ -215,6 +227,18 @@ export class VfsAdapter implements IFileSystem {
 
   async lstat(path: string): Promise<FsStat> {
     const normalized = normalizePath(path);
+    // Fast path: synchronous CacheFS lstat for non-mounted paths
+    const fast = this.vfs.lstatSync(normalized);
+    if (fast) {
+      return {
+        isFile: fast.type === 'file',
+        isDirectory: fast.type === 'directory',
+        isSymbolicLink: fast.type === 'symlink',
+        mode: fast.type === 'directory' ? 0o755 : fast.type === 'symlink' ? 0o777 : 0o644,
+        size: fast.size,
+        mtime: new Date(fast.mtime),
+      };
+    }
     const s = await this.vfs.lstat(normalized);
     return {
       isFile: s.type === 'file',
@@ -234,6 +258,9 @@ export class VfsAdapter implements IFileSystem {
     const normalized = normalizePath(path);
     if (normalized === '/usr') return ['bin'];
     if (normalized === '/usr/bin') return this.getVirtualBinCommands().slice().sort();
+    // Fast path: synchronous CacheFS read for non-mounted paths
+    const fast = this.vfs.readDirSync(normalized);
+    if (fast) return fast.map((e) => e.name);
     const entries = await this.vfs.readDir(normalized);
     return entries.map((e) => e.name);
   }
@@ -254,6 +281,51 @@ export class VfsAdapter implements IFileSystem {
           isSymbolicLink: false,
         }));
     }
+
+    // Fast path: synchronous CacheFS read for non-mounted paths.
+    // readDirSync returns null when the path is under a mount or
+    // the CacheFS internal isn't available.
+    const fastEntries = this.vfs.readDirSync(normalized);
+    if (fastEntries) {
+      const result: DirentEntry[] = [];
+      for (const e of fastEntries) {
+        if (e.type === 'symlink') {
+          const childPath = normalized === '/' ? `/${e.name}` : `${normalized}/${e.name}`;
+          // Try synchronous stat first (follows symlinks via CacheFS)
+          const targetStat = this.vfs.statSync(childPath);
+          if (targetStat) {
+            result.push({
+              name: e.name,
+              isFile: targetStat.type === 'file',
+              isDirectory: targetStat.type === 'directory',
+              isSymbolicLink: true,
+            });
+          } else {
+            // Symlink target is in a mount or unresolvable — fall back to async
+            let isFile = false;
+            let isDir = false;
+            try {
+              const asyncStat = await this.vfs.stat(childPath);
+              isFile = asyncStat.type === 'file';
+              isDir = asyncStat.type === 'directory';
+            } catch {
+              // Dangling symlink
+            }
+            result.push({ name: e.name, isFile, isDirectory: isDir, isSymbolicLink: true });
+          }
+        } else {
+          result.push({
+            name: e.name,
+            isFile: e.type === 'file',
+            isDirectory: e.type === 'directory',
+            isSymbolicLink: false,
+          });
+        }
+      }
+      return result;
+    }
+
+    // Slow path: async VirtualFS readDir for mounted paths.
     const entries = await this.vfs.readDir(normalized);
     const result: DirentEntry[] = [];
     for (const e of entries) {

--- a/packages/webapp/tests/fs/cachefs-internals.test.ts
+++ b/packages/webapp/tests/fs/cachefs-internals.test.ts
@@ -1,0 +1,127 @@
+/**
+ * CacheFS internal structure canary tests.
+ *
+ * VirtualFS.readDirSync/statSync/lstatSync reach into LightningFS private
+ * internals (PromisifiedFS._backend._cache) for synchronous file-tree access.
+ * These tests validate the internal structure so that a LightningFS upgrade
+ * that changes the CacheFS layout is caught immediately rather than silently
+ * degrading to the async fallback.
+ *
+ * If these tests break after upgrading @isomorphic-git/lightning-fs, update
+ * VirtualFS.getCacheFS() and the sync methods to match the new layout.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+
+const STAT = 0; // CacheFS uses numeric key 0 for stat entries
+
+describe('CacheFS internal structure', () => {
+  let vfs: VirtualFS;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ dbName: 'test-cachefs-internals', wipe: true });
+  });
+
+  afterEach(async () => {
+    await new Promise((r) => setTimeout(r, 600));
+  });
+
+  function getCache(): any {
+    return (vfs as any).lfs._backend._cache;
+  }
+
+  it('_backend._cache exists and is activated after create', () => {
+    const cache = getCache();
+    expect(cache).toBeDefined();
+    expect(cache.activated).toBe(true);
+  });
+
+  it('_root is a Map with "/" key', () => {
+    const cache = getCache();
+    expect(cache._root).toBeInstanceOf(Map);
+    expect(cache._root.has('/')).toBe(true);
+  });
+
+  it('root directory entry has STAT key 0 with type "dir"', () => {
+    const root = getCache()._root.get('/');
+    expect(root).toBeInstanceOf(Map);
+    const stat = root.get(STAT);
+    expect(stat).toBeDefined();
+    expect(stat.type).toBe('dir');
+    expect(typeof stat.mode).toBe('number');
+    expect(typeof stat.mtimeMs).toBe('number');
+  });
+
+  it('file entries have type "file" with size and ino', async () => {
+    await vfs.writeFile('/hello.txt', 'world');
+    const root = getCache()._root.get('/');
+    const entry = root.get('hello.txt');
+    expect(entry).toBeInstanceOf(Map);
+    const stat = entry.get(STAT);
+    expect(stat.type).toBe('file');
+    expect(stat.size).toBe(5);
+    expect(typeof stat.ino).toBe('number');
+    expect(stat.ino).toBeGreaterThan(0);
+  });
+
+  it('directory entries have type "dir" with nested children', async () => {
+    await vfs.writeFile('/project/src/index.ts', 'export {}');
+    const root = getCache()._root.get('/');
+    const project = root.get('project');
+    expect(project).toBeInstanceOf(Map);
+    expect(project.get(STAT).type).toBe('dir');
+    const src = project.get('src');
+    expect(src).toBeInstanceOf(Map);
+    expect(src.get(STAT).type).toBe('dir');
+    const indexTs = src.get('index.ts');
+    expect(indexTs.get(STAT).type).toBe('file');
+  });
+
+  it('symlink entries have type "symlink" with target property', async () => {
+    await vfs.writeFile('/target.txt', 'data');
+    await vfs.symlink('/target.txt', '/link.txt');
+    const root = getCache()._root.get('/');
+    const link = root.get('link.txt');
+    expect(link).toBeInstanceOf(Map);
+    const stat = link.get(STAT);
+    expect(stat.type).toBe('symlink');
+    expect(stat.target).toBe('/target.txt');
+  });
+
+  it('readdir() is synchronous and returns string array of child names', async () => {
+    await vfs.writeFile('/dir/a.txt', 'a');
+    await vfs.writeFile('/dir/b.txt', 'b');
+    const cache = getCache();
+    const names = cache.readdir('/dir');
+    expect(Array.isArray(names)).toBe(true);
+    expect(names.sort()).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('stat() is synchronous, follows symlinks, returns stat object', async () => {
+    await vfs.writeFile('/real.txt', 'content');
+    await vfs.symlink('/real.txt', '/sym.txt');
+    const cache = getCache();
+    const stat = cache.stat('/sym.txt');
+    expect(stat.type).toBe('file');
+    expect(stat.size).toBe(7);
+  });
+
+  it('lstat() is synchronous, does NOT follow symlinks', async () => {
+    await vfs.writeFile('/real.txt', 'data');
+    await vfs.symlink('/real.txt', '/sym.txt');
+    const cache = getCache();
+    const stat = cache.lstat('/sym.txt');
+    expect(stat.type).toBe('symlink');
+    expect(stat.target).toBe('/real.txt');
+  });
+
+  it('readdir() follows symlinks in the directory path', async () => {
+    await vfs.writeFile('/actual/file.txt', 'f');
+    await vfs.symlink('/actual', '/alias');
+    const cache = getCache();
+    const names = cache.readdir('/alias');
+    expect(names).toContain('file.txt');
+  });
+});

--- a/packages/webapp/tests/fs/cachefs-internals.test.ts
+++ b/packages/webapp/tests/fs/cachefs-internals.test.ts
@@ -25,6 +25,7 @@ describe('CacheFS internal structure', () => {
   });
 
   afterEach(async () => {
+    await vfs.dispose();
     await new Promise((r) => setTimeout(r, 600));
   });
 

--- a/packages/webapp/tests/fs/virtual-fs-sync.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs-sync.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for VirtualFS synchronous fast-path methods (readDirSync, statSync, lstatSync).
+ *
+ * These methods bypass async LightningFS wrappers by reading directly from the
+ * in-memory CacheFS tree. They return null when the path is under a mount or
+ * the CacheFS internal isn't available, signaling the caller to fall back to
+ * the async path.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+
+describe('VirtualFS sync fast-path', () => {
+  let vfs: VirtualFS;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ dbName: 'test-vfs-sync', wipe: true });
+  });
+
+  afterEach(async () => {
+    await new Promise((r) => setTimeout(r, 600));
+  });
+
+  describe('readDirSync', () => {
+    it('returns entries for a directory with files', async () => {
+      await vfs.writeFile('/project/a.ts', 'a');
+      await vfs.writeFile('/project/b.ts', 'b');
+      const entries = vfs.readDirSync('/project');
+      expect(entries).not.toBeNull();
+      const names = entries!.map((e) => e.name).sort();
+      expect(names).toEqual(['a.ts', 'b.ts']);
+      entries!.forEach((e) => expect(e.type).toBe('file'));
+    });
+
+    it('returns directory entries with correct type', async () => {
+      await vfs.mkdir('/parent/child', { recursive: true });
+      await vfs.writeFile('/parent/file.txt', 'f');
+      const entries = vfs.readDirSync('/parent');
+      expect(entries).not.toBeNull();
+      const childDir = entries!.find((e) => e.name === 'child');
+      const file = entries!.find((e) => e.name === 'file.txt');
+      expect(childDir?.type).toBe('directory');
+      expect(file?.type).toBe('file');
+    });
+
+    it('returns symlink entries with type "symlink"', async () => {
+      await vfs.writeFile('/dir/target.txt', 'data');
+      await vfs.symlink('/dir/target.txt', '/dir/link.txt');
+      const entries = vfs.readDirSync('/dir');
+      expect(entries).not.toBeNull();
+      const link = entries!.find((e) => e.name === 'link.txt');
+      expect(link?.type).toBe('symlink');
+    });
+
+    it('follows symlinks in the directory path', async () => {
+      await vfs.writeFile('/real-dir/file.txt', 'content');
+      await vfs.symlink('/real-dir', '/linked-dir');
+      const entries = vfs.readDirSync('/linked-dir');
+      expect(entries).not.toBeNull();
+      expect(entries!.map((e) => e.name)).toContain('file.txt');
+    });
+
+    it('returns null for nonexistent directory', () => {
+      const entries = vfs.readDirSync('/nonexistent');
+      expect(entries).toBeNull();
+    });
+
+    it('returns empty array for empty directory', async () => {
+      await vfs.mkdir('/empty');
+      const entries = vfs.readDirSync('/empty');
+      expect(entries).not.toBeNull();
+      expect(entries).toEqual([]);
+    });
+
+    it('matches async readDir results', async () => {
+      await vfs.writeFile('/cmp/a.ts', 'a');
+      await vfs.writeFile('/cmp/b.ts', 'b');
+      await vfs.mkdir('/cmp/sub');
+      await vfs.symlink('/cmp/a.ts', '/cmp/link.ts');
+
+      const syncEntries = vfs.readDirSync('/cmp');
+      const asyncEntries = await vfs.readDir('/cmp');
+
+      expect(syncEntries).not.toBeNull();
+      const syncSorted = syncEntries!.slice().sort((a, b) => a.name.localeCompare(b.name));
+      const asyncSorted = asyncEntries.slice().sort((a, b) => a.name.localeCompare(b.name));
+      expect(syncSorted).toEqual(asyncSorted);
+    });
+  });
+
+  describe('statSync', () => {
+    it('returns stats for a file', async () => {
+      await vfs.writeFile('/file.txt', 'hello');
+      const s = vfs.statSync('/file.txt');
+      expect(s).not.toBeNull();
+      expect(s!.type).toBe('file');
+      expect(s!.size).toBe(5);
+    });
+
+    it('returns stats for a directory', async () => {
+      await vfs.mkdir('/mydir');
+      const s = vfs.statSync('/mydir');
+      expect(s).not.toBeNull();
+      expect(s!.type).toBe('directory');
+    });
+
+    it('follows symlinks to file', async () => {
+      await vfs.writeFile('/target.txt', 'data');
+      await vfs.symlink('/target.txt', '/link.txt');
+      const s = vfs.statSync('/link.txt');
+      expect(s).not.toBeNull();
+      expect(s!.type).toBe('file');
+      expect(s!.size).toBe(4);
+    });
+
+    it('follows symlinks to directory', async () => {
+      await vfs.mkdir('/real-dir');
+      await vfs.symlink('/real-dir', '/dir-link');
+      const s = vfs.statSync('/dir-link');
+      expect(s).not.toBeNull();
+      expect(s!.type).toBe('directory');
+    });
+
+    it('returns null for nonexistent path', () => {
+      const s = vfs.statSync('/nope');
+      expect(s).toBeNull();
+    });
+
+    it('returns null for dangling symlink', async () => {
+      await vfs.symlink('/nonexistent', '/dangling');
+      const s = vfs.statSync('/dangling');
+      expect(s).toBeNull();
+    });
+
+    it('matches async stat results for files', async () => {
+      await vfs.writeFile('/check.txt', 'verify');
+      const sync = vfs.statSync('/check.txt');
+      const async_ = await vfs.stat('/check.txt');
+      expect(sync).not.toBeNull();
+      expect(sync!.type).toBe(async_.type);
+      expect(sync!.size).toBe(async_.size);
+    });
+  });
+
+  describe('lstatSync', () => {
+    it('returns file stats without following symlinks', async () => {
+      await vfs.writeFile('/file.txt', 'data');
+      const s = vfs.lstatSync('/file.txt');
+      expect(s).not.toBeNull();
+      expect(s!.type).toBe('file');
+    });
+
+    it('returns symlink type for symlinks (does not follow)', async () => {
+      await vfs.writeFile('/target.txt', 'data');
+      await vfs.symlink('/target.txt', '/link.txt');
+      const s = vfs.lstatSync('/link.txt');
+      expect(s).not.toBeNull();
+      expect(s!.type).toBe('symlink');
+      expect(s!.isSymlink).toBe(true);
+      expect(s!.symlinkTarget).toBe('/target.txt');
+    });
+
+    it('returns null for nonexistent path', () => {
+      expect(vfs.lstatSync('/nope')).toBeNull();
+    });
+
+    it('matches async lstat results', async () => {
+      await vfs.writeFile('/target.txt', 'data');
+      await vfs.symlink('/target.txt', '/link.txt');
+      const sync = vfs.lstatSync('/link.txt');
+      const async_ = await vfs.lstat('/link.txt');
+      expect(sync).not.toBeNull();
+      expect(sync!.type).toBe(async_.type);
+      expect(sync!.isSymlink).toBe(async_.isSymlink);
+      expect(sync!.symlinkTarget).toBe(async_.symlinkTarget);
+    });
+  });
+});

--- a/packages/webapp/tests/fs/virtual-fs-sync.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs-sync.test.ts
@@ -19,6 +19,7 @@ describe('VirtualFS sync fast-path', () => {
   });
 
   afterEach(async () => {
+    await vfs.dispose();
     await new Promise((r) => setTimeout(r, 600));
   });
 
@@ -131,6 +132,41 @@ describe('VirtualFS sync fast-path', () => {
       await vfs.symlink('/nonexistent', '/dangling');
       const s = vfs.statSync('/dangling');
       expect(s).toBeNull();
+    });
+
+    it('returns null for circular symlinks (ELOOP parity)', async () => {
+      await vfs.symlink('/b', '/a');
+      await vfs.symlink('/a', '/b');
+      // Async stat throws ELOOP
+      await expect(vfs.stat('/a')).rejects.toMatchObject({ code: 'ELOOP' });
+      // Sync stat returns null (signals fallback) rather than infinite recursion
+      expect(vfs.statSync('/a')).toBeNull();
+    });
+
+    it('returns null for long symlink chains exceeding depth limit', async () => {
+      // Create a chain: /s0 -> /s1 -> /s2 -> ... -> /s11 -> /target
+      await vfs.writeFile('/target', 'data');
+      for (let i = 11; i >= 0; i--) {
+        const next = i === 11 ? '/target' : `/s${i + 1}`;
+        await vfs.symlink(next, `/s${i}`);
+      }
+      // 12 hops exceeds MAX_SYMLINK_DEPTH (10) — async throws ELOOP
+      await expect(vfs.stat('/s0')).rejects.toMatchObject({ code: 'ELOOP' });
+      // Sync should also reject by returning null
+      expect(vfs.statSync('/s0')).toBeNull();
+    });
+
+    it('resolves symlink chains within depth limit', async () => {
+      // Create a chain of 5 hops (within limit of 10)
+      await vfs.writeFile('/end', 'found');
+      for (let i = 4; i >= 0; i--) {
+        const next = i === 4 ? '/end' : `/c${i + 1}`;
+        await vfs.symlink(next, `/c${i}`);
+      }
+      const s = vfs.statSync('/c0');
+      expect(s).not.toBeNull();
+      expect(s!.type).toBe('file');
+      expect(s!.size).toBe(5);
     });
 
     it('matches async stat results for files', async () => {


### PR DESCRIPTION
## Summary

- Add `readDirSync`/`statSync`/`lstatSync` to VirtualFS that read directly from LightningFS's in-memory CacheFS tree, bypassing 4 layers of async wrappers
- Wire fast paths into VfsAdapter's `readdir`, `readdirWithFileTypes`, `stat`, and `lstat` — the hot methods called by just-bash's `find` and `grep`
- Mounted paths (File System Access API) return `null` from the sync methods, falling through to the existing async implementation with zero behavior change
- Symlinks in LFS are resolved synchronously via CacheFS; cross-mount symlinks fall back to async

### Why this works

LightningFS loads the entire filesystem metadata tree (all paths, types, sizes, mtimes) into an in-memory `CacheFS` Map on activation. Operations like `readdir()` and `stat()` are synchronous lookups on this Map, but they're wrapped in `async` at every layer. This PR short-circuits the async wrappers for non-mounted paths.

### CacheFS internal guard

Instead of pinning the LightningFS version, a dedicated `cachefs-internals` test suite validates the internal structure (`_backend._cache._root`, STAT key `0`, entry types). If a LightningFS upgrade changes the layout, these tests break at CI time rather than silently falling back to the slow async path.

Closes #338

## Test plan

- [x] 28 new tests pass (10 canary + 18 functional)
- [x] All 2602 existing tests pass
- [x] Typecheck clean
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)