### PR TITLE
fix: disable automated extension publish to cws

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,7 +14,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "node dist/node-server/sync-release-version.js ${nextRelease.version} && npm run build -w @slicc/chrome-extension && npm run package:release && chmod +x packages/swift-launcher/sign-and-package.sh && packages/swift-launcher/sign-and-package.sh ${nextRelease.version}",
-        "publishCmd": "npm run publish:worker && npm run publish:chrome"
+        "publishCmd": "npm run publish:worker"
       }
     ],
     [


### PR DESCRIPTION
@trieloff, @karlpauls, proposing to disable extension automated publish (at least for the time of Summit) to ensure we have a working version for our labs.