### PR TITLE
fix(shell): register .jsh commands as first-class bash commands

### DIFF
--- a/packages/webapp/src/shell/wasm-shell.ts
+++ b/packages/webapp/src/shell/wasm-shell.ts
@@ -293,6 +293,10 @@ export class WasmShell {
   private builtinCommandNames: Set<string>;
   private readonly scriptCatalog: ScriptCatalog;
   private readonly ownsScriptCatalog: boolean;
+  /** Names of .jsh commands already registered as just-bash custom commands. */
+  private registeredJshCommands = new Set<string>();
+  /** Promise for the currently in-flight jsh sync, so callers can await it. */
+  private jshSyncInflight: Promise<void> | null = null;
 
   constructor(private options: WasmShellOptions) {
     this.vfsAdapter = new VfsAdapter(options.fs);
@@ -327,6 +331,15 @@ export class WasmShell {
         watcher: scriptWatcher,
       });
     this.ownsScriptCatalog = !options.scriptCatalog;
+
+    // When .jsh files change on disk, re-sync registered commands
+    if (scriptWatcher) {
+      scriptWatcher.watch(
+        '/',
+        (path) => path.endsWith('.jsh'),
+        () => this.syncJshCommands()
+      );
+    }
 
     // Create custom commands for just-bash
     const gitCommand = this.createGitCustomCommand();
@@ -367,6 +380,82 @@ export class WasmShell {
 
     this.lastEnv = { ...initialEnv };
     this.cwd = initialCwd;
+
+    // Kick off initial .jsh registration (async, non-blocking)
+    this.syncJshCommands();
+  }
+
+  /**
+   * Discover .jsh commands and register any new ones as just-bash custom commands.
+   * This makes .jsh scripts work inside pipelines, subshells, and command substitution —
+   * not just as top-level commands caught by the exit-code-127 fallback.
+   */
+  async syncJshCommands(): Promise<void> {
+    if (this.jshSyncInflight) return this.jshSyncInflight;
+    this.jshSyncInflight = this.doSyncJshCommands();
+    return this.jshSyncInflight;
+  }
+
+  private async doSyncJshCommands(): Promise<void> {
+    try {
+      const jshMap = await this.scriptCatalog.getJshCommands();
+      const discoveryFs = this.options.jshDiscoveryFs ?? this.options.fs;
+
+      for (const [name, scriptPath] of jshMap) {
+        // Skip if already a built-in/custom command or already registered as jsh
+        if (this.builtinCommandNames.has(name) || this.registeredJshCommands.has(name)) continue;
+
+        // Capture scriptPath for the closure
+        const capturedPath = scriptPath;
+        const capturedDiscoveryFs = discoveryFs;
+        const shell = this;
+
+        const command: Command = {
+          name,
+          async execute(args: string[], ctx) {
+            // Read the script source using the discovery FS
+            let code: string;
+            try {
+              const raw = await capturedDiscoveryFs.readFile(capturedPath, { encoding: 'utf-8' });
+              code =
+                typeof raw === 'string'
+                  ? raw
+                  : new TextDecoder().decode(raw as unknown as ArrayBuffer);
+            } catch {
+              return {
+                stdout: '',
+                stderr: `jsh: cannot read script '${capturedPath}'\n`,
+                exitCode: 127,
+              };
+            }
+
+            const argv = ['node', capturedPath, ...args];
+            // When running as a custom command inside just-bash, ctx.exec is always
+            // provided by the interpreter. Fall back to bash.exec for safety.
+            const execFn: typeof ctx.exec =
+              ctx.exec ??
+              ((cmd, opts) =>
+                shell.bash.exec(cmd, {
+                  env: shell.lastEnv,
+                  cwd: opts?.cwd ?? shell.cwd,
+                }));
+            return executeJsCode(code, argv, {
+              fs: ctx.fs,
+              cwd: ctx.cwd,
+              env: ctx.env,
+              stdin: ctx.stdin,
+              exec: execFn,
+            });
+          },
+        };
+
+        this.bash.registerCommand(command);
+        this.registeredJshCommands.add(name);
+        this.builtinCommandNames.add(name);
+      }
+    } finally {
+      this.jshSyncInflight = null;
+    }
   }
 
   /** Create a custom git command for just-bash. */
@@ -510,7 +599,12 @@ export class WasmShell {
     // If bash returned 127 (command not found), try .jsh fallback
     if (result.exitCode === 127) {
       const jshResult = await this.tryJshFallback(command);
-      if (jshResult) return jshResult;
+      if (jshResult) {
+        // A .jsh command was found but wasn't registered — re-sync so it's
+        // available as a first-class bash command for future pipelines/subshells.
+        this.syncJshCommands();
+        return jshResult;
+      }
     }
 
     return result;

--- a/packages/webapp/src/shell/wasm-shell.ts
+++ b/packages/webapp/src/shell/wasm-shell.ts
@@ -293,10 +293,12 @@ export class WasmShell {
   private builtinCommandNames: Set<string>;
   private readonly scriptCatalog: ScriptCatalog;
   private readonly ownsScriptCatalog: boolean;
-  /** Names of .jsh commands already registered as just-bash custom commands. */
-  private registeredJshCommands = new Set<string>();
+  /** Maps .jsh command names to their registered script paths (for staleness detection). */
+  private registeredJshCommands = new Map<string, string>();
   /** Promise for the currently in-flight jsh sync, so callers can await it. */
   private jshSyncInflight: Promise<void> | null = null;
+  /** Set when a sync is requested while one is already in-flight. */
+  private jshSyncDirty = false;
 
   constructor(private options: WasmShellOptions) {
     this.vfsAdapter = new VfsAdapter(options.fs);
@@ -337,7 +339,9 @@ export class WasmShell {
       scriptWatcher.watch(
         '/',
         (path) => path.endsWith('.jsh'),
-        () => this.syncJshCommands()
+        () => {
+          void this.syncJshCommands().catch(() => undefined);
+        }
       );
     }
 
@@ -382,7 +386,7 @@ export class WasmShell {
     this.cwd = initialCwd;
 
     // Kick off initial .jsh registration (async, non-blocking)
-    this.syncJshCommands();
+    void this.syncJshCommands().catch(() => undefined);
   }
 
   /**
@@ -391,7 +395,11 @@ export class WasmShell {
    * not just as top-level commands caught by the exit-code-127 fallback.
    */
   async syncJshCommands(): Promise<void> {
-    if (this.jshSyncInflight) return this.jshSyncInflight;
+    if (this.jshSyncInflight) {
+      // Another sync is running — mark dirty so it re-runs when done.
+      this.jshSyncDirty = true;
+      return this.jshSyncInflight;
+    }
     this.jshSyncInflight = this.doSyncJshCommands();
     return this.jshSyncInflight;
   }
@@ -402,42 +410,57 @@ export class WasmShell {
       const discoveryFs = this.options.jshDiscoveryFs ?? this.options.fs;
 
       for (const [name, scriptPath] of jshMap) {
-        // Skip if already a built-in/custom command or already registered as jsh
-        if (this.builtinCommandNames.has(name) || this.registeredJshCommands.has(name)) continue;
+        // Never shadow built-in or custom commands
+        if (this.builtinCommandNames.has(name) && !this.registeredJshCommands.has(name)) {
+          continue;
+        }
 
-        // Capture scriptPath for the closure
-        const capturedPath = scriptPath;
-        const capturedDiscoveryFs = discoveryFs;
+        // Skip if already registered with the same path (no change)
+        if (this.registeredJshCommands.get(name) === scriptPath) continue;
+
+        // Register (or re-register if the path changed) as a just-bash custom
+        // command. The execute closure resolves the script path at call-time via
+        // the catalog so it stays current even if a later sync hasn't fired yet.
+        const catalog = this.scriptCatalog;
         const shell = this;
+        const cmdName = name;
 
         const command: Command = {
           name,
           async execute(args: string[], ctx) {
-            // Read the script source using the discovery FS
-            let code: string;
-            try {
-              const raw = await capturedDiscoveryFs.readFile(capturedPath, { encoding: 'utf-8' });
-              code =
-                typeof raw === 'string'
-                  ? raw
-                  : new TextDecoder().decode(raw as unknown as ArrayBuffer);
-            } catch {
+            // Resolve the current script path from the catalog at call-time
+            // so we always read the latest version, even if the file moved.
+            const currentMap = await catalog.getJshCommands();
+            const currentPath = currentMap.get(cmdName);
+            if (!currentPath) {
               return {
                 stdout: '',
-                stderr: `jsh: cannot read script '${capturedPath}'\n`,
+                stderr: `jsh: command '${cmdName}' no longer exists\n`,
                 exitCode: 127,
               };
             }
 
-            const argv = ['node', capturedPath, ...args];
+            let code: string;
+            try {
+              const raw = await discoveryFs.readFile(currentPath, { encoding: 'utf-8' });
+              code = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+            } catch {
+              return {
+                stdout: '',
+                stderr: `jsh: cannot read script '${currentPath}'\n`,
+                exitCode: 127,
+              };
+            }
+
+            const argv = ['node', currentPath, ...args];
             // When running as a custom command inside just-bash, ctx.exec is always
             // provided by the interpreter. Fall back to bash.exec for safety.
             const execFn: typeof ctx.exec =
               ctx.exec ??
               ((cmd, opts) =>
                 shell.bash.exec(cmd, {
-                  env: shell.lastEnv,
-                  cwd: opts?.cwd ?? shell.cwd,
+                  env: Object.fromEntries(ctx.env),
+                  cwd: opts?.cwd ?? ctx.cwd,
                 }));
             return executeJsCode(code, argv, {
               fs: ctx.fs,
@@ -450,11 +473,16 @@ export class WasmShell {
         };
 
         this.bash.registerCommand(command);
-        this.registeredJshCommands.add(name);
+        this.registeredJshCommands.set(name, scriptPath);
         this.builtinCommandNames.add(name);
       }
     } finally {
       this.jshSyncInflight = null;
+      // If another sync was requested while we were running, re-run.
+      if (this.jshSyncDirty) {
+        this.jshSyncDirty = false;
+        void this.syncJshCommands().catch(() => undefined);
+      }
     }
   }
 
@@ -602,7 +630,7 @@ export class WasmShell {
       if (jshResult) {
         // A .jsh command was found but wasn't registered — re-sync so it's
         // available as a first-class bash command for future pipelines/subshells.
-        this.syncJshCommands();
+        void this.syncJshCommands().catch(() => undefined);
         return jshResult;
       }
     }

--- a/packages/webapp/tests/shell/wasm-shell.test.ts
+++ b/packages/webapp/tests/shell/wasm-shell.test.ts
@@ -305,3 +305,76 @@ describe('WasmShell playwright command discoverability', () => {
     ]);
   });
 });
+
+describe('WasmShell .jsh command registration', () => {
+  let fs: VirtualFS;
+
+  beforeEach(async () => {
+    fs = await VirtualFS.create({ dbName: `test-jsh-reg-${Date.now()}`, wipe: true });
+    await fs.mkdir('/workspace/skills/test-cmd/scripts', { recursive: true });
+  });
+
+  it('registers .jsh commands as first-class bash commands available in pipelines', async () => {
+    // Create a .jsh script that outputs text
+    await fs.writeFile(
+      '/workspace/skills/test-cmd/scripts/hello.jsh',
+      'console.log("hello from jsh");'
+    );
+
+    const shell = new WasmShell({ fs });
+    // Wait for async syncJshCommands to complete
+    await shell.syncJshCommands();
+
+    // Direct invocation should work
+    const direct = await shell.executeCommand('hello');
+    expect(direct.exitCode).toBe(0);
+    expect(direct.stdout).toContain('hello from jsh');
+
+    // Pipeline should also work (this was the bug — before registration,
+    // jsh commands in pipes would fail because exit code 127 from the pipe
+    // component doesn't propagate to the top-level runCommand fallback)
+    const piped = await shell.executeCommand('hello | cat');
+    expect(piped.exitCode).toBe(0);
+    expect(piped.stdout).toContain('hello from jsh');
+  });
+
+  it('makes .jsh commands visible via which and /usr/bin', async () => {
+    await fs.writeFile('/workspace/skills/test-cmd/scripts/mycmd.jsh', 'console.log("ok");');
+
+    const shell = new WasmShell({ fs });
+    await shell.syncJshCommands();
+
+    const whichResult = await shell.executeCommand('which mycmd');
+    expect(whichResult.exitCode).toBe(0);
+
+    const lsResult = await shell.executeCommand('ls /usr/bin | grep mycmd');
+    expect(lsResult.exitCode).toBe(0);
+    expect(lsResult.stdout).toContain('mycmd');
+  });
+
+  it('passes arguments to registered .jsh commands', async () => {
+    await fs.writeFile(
+      '/workspace/skills/test-cmd/scripts/greet.jsh',
+      'console.log("hello " + process.argv.slice(2).join(" "));'
+    );
+
+    const shell = new WasmShell({ fs });
+    await shell.syncJshCommands();
+
+    const result = await shell.executeCommand('greet world');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('hello world');
+  });
+
+  it('does not shadow built-in commands with .jsh files of the same name', async () => {
+    // Create a .jsh file named "echo" — should NOT override the built-in
+    await fs.writeFile('/workspace/skills/test-cmd/scripts/echo.jsh', 'console.log("fake echo");');
+
+    const shell = new WasmShell({ fs });
+    await shell.syncJshCommands();
+
+    const result = await shell.executeCommand('echo real');
+    expect(result.stdout).toContain('real');
+    expect(result.stdout).not.toContain('fake echo');
+  });
+});

--- a/packages/webapp/tests/shell/wasm-shell.test.ts
+++ b/packages/webapp/tests/shell/wasm-shell.test.ts
@@ -306,11 +306,16 @@ describe('WasmShell playwright command discoverability', () => {
   });
 });
 
+let jshRegistrationDbCounter = 0;
+
 describe('WasmShell .jsh command registration', () => {
   let fs: VirtualFS;
 
   beforeEach(async () => {
-    fs = await VirtualFS.create({ dbName: `test-jsh-reg-${Date.now()}`, wipe: true });
+    fs = await VirtualFS.create({
+      dbName: `test-jsh-reg-${jshRegistrationDbCounter++}`,
+      wipe: true,
+    });
     await fs.mkdir('/workspace/skills/test-cmd/scripts', { recursive: true });
   });
 


### PR DESCRIPTION
## Summary

- **.jsh scripts now work in pipelines, subshells, and command chaining** — previously they only worked as standalone top-level commands
- Root cause: the exit-code-127 fallback in `runCommand()` can't intercept `.jsh` commands inside pipelines (e.g. `slack 2>&1 | head`) because the pipeline exit code comes from the last command, not the failing lookup
- Fix: `syncJshCommands()` discovers `.jsh` files and registers each as a just-bash custom command via `bash.registerCommand()`, making them first-class citizens in bash's command resolution
- The old 127 fallback remains as a safety net for race conditions (newly installed skills)

## Test plan

- [x] New tests: `.jsh` commands in pipelines, `which`/`/usr/bin` visibility, argument passing, built-in shadowing protection
- [x] All 2609 existing tests pass
- [x] Typecheck clean
- [ ] Manual: run a SLICC instance, install a skill with `.jsh` commands, verify `slack --help` works both standalone and in `slack --help | head`

🤖 Generated with [Claude Code](https://claude.com/claude-code)