### PR TITLE
fix: preserve syntax highlight spans in js renderer

### DIFF
--- a/packages/webapp/src/ui/message-renderer.ts
+++ b/packages/webapp/src/ui/message-renderer.ts
@@ -39,6 +39,30 @@ function highlightCode(code: string, lang: string): string {
   return html;
 }
 
+function protectHighlightedSpans(html: string): {
+  html: string;
+  restore: (input: string) => string;
+} {
+  const protectedSpans: string[] = [];
+  const protectedHtml = html.replace(
+    /<span class="tok-(?:comment|string)">[\s\S]*?<\/span>/g,
+    (match) => {
+      const token = String.fromCharCode(0xe000 + protectedSpans.length);
+      protectedSpans.push(match);
+      return token;
+    }
+  );
+
+  return {
+    html: protectedHtml,
+    restore: (input: string) =>
+      input.replace(/[\ue000-\uf8ff]/g, (token) => {
+        const index = token.charCodeAt(0) - 0xe000;
+        return protectedSpans[index] ?? token;
+      }),
+  };
+}
+
 function highlightJS(html: string): string {
   html = html.replace(/(\/\/[^\n]*)/g, '<span class="tok-comment">$1</span>');
   html = html.replace(/(\/\*[\s\S]*?\*\/)/g, '<span class="tok-comment">$1</span>');
@@ -46,6 +70,8 @@ function highlightJS(html: string): string {
     /(&quot;[^&]*?&quot;|&#x27;[^&]*?&#x27;|`[^`]*?`)/g,
     '<span class="tok-string">$1</span>'
   );
+  const protectedSpans = protectHighlightedSpans(html);
+  html = protectedSpans.html;
   const kw = [
     'const',
     'let',
@@ -93,7 +119,7 @@ function highlightJS(html: string): string {
   );
   html = html.replace(/\b(\d+\.?\d*)\b/g, '<span class="tok-number">$1</span>');
   html = html.replace(/\b([a-zA-Z_$][\w$]*)\s*(?=\()/g, '<span class="tok-fn">$1</span>');
-  return html;
+  return protectedSpans.restore(html);
 }
 
 function highlightJSON(html: string): string {

--- a/packages/webapp/tests/ui/message-renderer.test.ts
+++ b/packages/webapp/tests/ui/message-renderer.test.ts
@@ -91,6 +91,25 @@ describe('renderMessageContent', () => {
     expect(html).toContain('tok-keyword');
   });
 
+  it('does not corrupt syntax highlighting HTML when JS includes export-from statements', () => {
+    const content = [
+      '```js',
+      '// index.js',
+      "export { DataChunks } from './distiller.js';",
+      "export { pageViews, lcp } from './series.js';",
+      "export { url, userAgent } from './facets.js';",
+      '```',
+    ].join('\n');
+
+    const html = renderMessageContent(content);
+
+    expect(html).toContain('<span class="tok-comment">// index.js</span>');
+    expect(html).toContain('<span class="tok-string">\'./distiller.js\'</span>');
+    expect(html).not.toContain('<span <span class="tok-keyword">class</span>=');
+    expect(html).not.toContain('<span class="tok-keyword">class</span>="tok-comment"&gt;');
+    expect(html).not.toContain('<span class="tok-keyword">from</span> class="tok-string"&gt;');
+  });
+
   it('renders code blocks without a language', () => {
     const content = '```\nplain text\n```';
     const html = renderMessageContent(content);


### PR DESCRIPTION
highlightJS() wrapped comments/strings with <span class="tok-*">…</span> and then ran the keyword regex afterward. Because class is one of the highlighted JS keywords, that later pass matched the literal class= inside the injected HTML and corrupted the tags into things like <span <span class="tok-keyword">class</span>=...>. 
After sanitization/rendering, that surfaced as broken text like class="tok-string">
