### PR TITLE
fix(bedrock-camp): picker compatibility filter, Opus 4.7, URL encoding

### DIFF
--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -42,6 +42,42 @@ export const config: ProviderConfig = {
   baseUrlDescription: 'Bedrock runtime endpoint from CAMP portal',
 };
 
+// Picker filter: keep only Claude 4.x on an inference-profile prefix.
+//
+// 1. Inference profile (us./eu./global./apac.) — bare anthropic.* 400s with
+//    "on-demand throughput isn't supported".
+// 2. Claude 4.x only — older Claude 3.x are weaker at resisting prompt
+//    injection; non-Claude Bedrock models (Nova, Llama, Writer, …) are
+//    similarly risky, and DeepSeek R1 specifically 400s on toolConfig
+//    ("This model doesn't support tool use") which breaks the agent loop.
+const BEDROCK_CAMP_INFERENCE_PROFILE_RE = /^(us|eu|global|apac)\./;
+const BEDROCK_CAMP_CLAUDE_4_RE = /\.anthropic\.claude-(opus|sonnet|haiku)-4/;
+
+export function isBedrockCampCompatible(model: { id: string }): boolean {
+  return (
+    BEDROCK_CAMP_INFERENCE_PROFILE_RE.test(model.id) && BEDROCK_CAMP_CLAUDE_4_RE.test(model.id)
+  );
+}
+
+// Models not yet in pi-ai's amazon-bedrock registry that CAMP already serves.
+// Opus 4.7 shape mirrors 4.6 until pi-ai regenerates.
+export function getBedrockCampExtraModels(): Model<Api>[] {
+  const shared = {
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+    contextWindow: 1_000_000,
+    maxTokens: 128_000,
+    baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+    api: 'bedrock-converse-stream' as Api,
+    provider: 'amazon-bedrock',
+  };
+  return [
+    { ...shared, id: 'us.anthropic.claude-opus-4-7', name: 'Claude Opus 4.7 (US)' },
+    { ...shared, id: 'global.anthropic.claude-opus-4-7', name: 'Claude Opus 4.7 (Global)' },
+  ] as unknown as Model<Api>[];
+}
+
 // Extension detection
 const isExtension = typeof chrome !== 'undefined' && !!(chrome as any)?.runtime?.id;
 

--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -40,9 +40,11 @@ export const config: ProviderConfig = {
   requiresBaseUrl: true,
   baseUrlPlaceholder: 'https://bedrock-runtime.us-west-2.amazonaws.com',
   baseUrlDescription: 'Bedrock runtime endpoint from CAMP portal',
+  defaultModelId: 'claude-sonnet-4-6',
 };
 
-// Picker filter: keep only Claude 4.x on an inference-profile prefix.
+// Picker filter: keep only Claude 4.x on an inference-profile prefix that
+// is reachable from the configured endpoint region.
 //
 // 1. Inference profile (us./eu./global./apac.) — bare anthropic.* 400s with
 //    "on-demand throughput isn't supported".
@@ -50,13 +52,32 @@ export const config: ProviderConfig = {
 //    injection; non-Claude Bedrock models (Nova, Llama, Writer, …) are
 //    similarly risky, and DeepSeek R1 specifically 400s on toolConfig
 //    ("This model doesn't support tool use") which breaks the agent loop.
+// 3. Region must match the endpoint — e.g. `eu.*` IDs 400 with "invalid
+//    model identifier" when sent to a `us-*` runtime, and vice versa.
+//    `global.*` works anywhere.
 const BEDROCK_CAMP_INFERENCE_PROFILE_RE = /^(us|eu|global|apac)\./;
 const BEDROCK_CAMP_CLAUDE_4_RE = /\.anthropic\.claude-(opus|sonnet|haiku)-4/;
+const BEDROCK_RUNTIME_HOST_RE = /bedrock-runtime\.([a-z0-9-]+)\.amazonaws\.com/i;
 
-export function isBedrockCampCompatible(model: { id: string }): boolean {
-  return (
-    BEDROCK_CAMP_INFERENCE_PROFILE_RE.test(model.id) && BEDROCK_CAMP_CLAUDE_4_RE.test(model.id)
-  );
+export function bedrockCampRegionFromBaseUrl(baseUrl: string | null | undefined): string | null {
+  if (!baseUrl) return null;
+  return baseUrl.match(BEDROCK_RUNTIME_HOST_RE)?.[1] ?? null;
+}
+
+function profileMatchesRegion(prefix: string, region: string): boolean {
+  if (prefix === 'global') return true;
+  if (prefix === 'us') return region.startsWith('us-');
+  if (prefix === 'eu') return region.startsWith('eu-');
+  if (prefix === 'apac') return region.startsWith('ap-');
+  return false;
+}
+
+export function isBedrockCampCompatible(model: { id: string }, region?: string | null): boolean {
+  if (!BEDROCK_CAMP_INFERENCE_PROFILE_RE.test(model.id)) return false;
+  if (!BEDROCK_CAMP_CLAUDE_4_RE.test(model.id)) return false;
+  if (!region) return true; // no endpoint configured yet — stay permissive
+  const prefix = model.id.split('.', 1)[0];
+  return profileMatchesRegion(prefix, region);
 }
 
 // Models not yet in pi-ai's amazon-bedrock registry that CAMP already serves.

--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -40,8 +40,6 @@ export const config: ProviderConfig = {
   requiresBaseUrl: true,
   baseUrlPlaceholder: 'https://bedrock-runtime.us-west-2.amazonaws.com',
   baseUrlDescription: 'Bedrock runtime endpoint from CAMP portal',
-  requiresModelSelection: true,
-  defaultModelId: 'claude-sonnet-4-6',
 };
 
 // Extension detection

--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -60,9 +60,11 @@ export function isBedrockCampCompatible(model: { id: string }): boolean {
 }
 
 // Models not yet in pi-ai's amazon-bedrock registry that CAMP already serves.
-// Opus 4.7 shape mirrors 4.6 until pi-ai regenerates.
+// Opus 4.7 shape mirrors 4.6 until pi-ai regenerates. Caller must dedupe
+// against the registry — once pi-ai ships these IDs, the dedup drops them
+// and this function becomes a no-op that can be removed.
 export function getBedrockCampExtraModels(): Model<Api>[] {
-  const shared = {
+  const shared: Omit<Model<Api>, 'id' | 'name'> = {
     reasoning: true,
     input: ['text', 'image'],
     cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
@@ -70,12 +72,12 @@ export function getBedrockCampExtraModels(): Model<Api>[] {
     maxTokens: 128_000,
     baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
     api: 'bedrock-converse-stream' as Api,
-    provider: 'amazon-bedrock',
+    provider: 'amazon-bedrock' as Model<Api>['provider'],
   };
   return [
     { ...shared, id: 'us.anthropic.claude-opus-4-7', name: 'Claude Opus 4.7 (US)' },
     { ...shared, id: 'global.anthropic.claude-opus-4-7', name: 'Claude Opus 4.7 (Global)' },
-  ] as unknown as Model<Api>[];
+  ];
 }
 
 // Opus 4.7 returns 400 "temperature is deprecated for this model" when the

--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -78,6 +78,12 @@ export function getBedrockCampExtraModels(): Model<Api>[] {
   ] as unknown as Model<Api>[];
 }
 
+// Opus 4.7 returns 400 "temperature is deprecated for this model" when the
+// param is set. Keep temperature for every other model.
+function supportsTemperature(modelId: string): boolean {
+  return !modelId.includes('claude-opus-4-7');
+}
+
 // Extension detection
 const isExtension = typeof chrome !== 'undefined' && !!(chrome as any)?.runtime?.id;
 
@@ -490,14 +496,15 @@ export const streamBedrockCamp = (
       if (!baseUrl) throw new Error('Base URL is required for Bedrock CAMP');
 
       // Build request body (Converse API format)
+      const inferenceConfig: Record<string, unknown> = { maxTokens: options.maxTokens };
+      if (supportsTemperature(model.id)) {
+        inferenceConfig.temperature = options.temperature;
+      }
       const body: any = {
         modelId: model.id,
         messages: convertMessages(context, model),
         system: buildSystemPrompt(context.systemPrompt, model),
-        inferenceConfig: {
-          maxTokens: options.maxTokens,
-          temperature: options.temperature,
-        },
+        inferenceConfig,
         toolConfig: convertToolConfig(context.tools, options.toolChoice),
         additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
       };

--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -476,7 +476,7 @@ export const streamBedrockCamp = (
       notifyPayload(options.onPayload, body, model);
 
       // Build URL: POST {baseUrl}/model/{modelId}/converse
-      const targetUrl = `${baseUrl.replace(/\/$/, '')}/model/${encodeURIComponent(model.id)}/converse`;
+      const targetUrl = `${baseUrl.replace(/\/$/, '')}/model/${model.id}/converse`;
 
       // Route through CORS proxy in CLI mode, direct in extension mode
       const fetchUrl = isExtension ? targetUrl : '/api/fetch-proxy';

--- a/packages/webapp/src/providers/types.ts
+++ b/packages/webapp/src/providers/types.ts
@@ -61,8 +61,6 @@ export interface ProviderConfig {
    * Falls back to the first model in the list if no match is found.
    */
   defaultModelId?: string;
-  /** When true, the setup dialog shows a model selector dropdown. */
-  requiresModelSelection?: boolean;
   /** When true, the setup dialog shows a deployment name text input. */
   requiresDeployment?: boolean;
   deploymentPlaceholder?: string;

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -19,6 +19,7 @@ import type { ProviderConfig } from '../providers/index.js';
 import {
   isBedrockCampCompatible,
   getBedrockCampExtraModels,
+  bedrockCampRegionFromBaseUrl,
 } from '../providers/built-in/bedrock-camp.js';
 
 export type { ProviderConfig } from '../providers/index.js';
@@ -127,14 +128,19 @@ function applyModelMetadata(
 export function getProviderModels(providerId: string): Model<Api>[] {
   try {
     // Bedrock CAMP uses Amazon Bedrock models with custom API.
-    // Filter to inference-profile-prefixed Claude 4.x (bare IDs aren't
-    // invokable on-demand) and inject models missing from pi-ai's registry
-    // (e.g. opus-4.7). Dedupe by ID so extras auto-drop when pi-ai ships
-    // the same IDs.
+    // Filter to inference-profile-prefixed Claude 4.x whose region matches
+    // the configured endpoint (eu.* against us-* 400s "invalid model
+    // identifier"), and inject models missing from pi-ai's registry (e.g.
+    // opus-4.7). Dedupe by ID so extras auto-drop when pi-ai ships them.
     if (providerId === 'bedrock-camp') {
-      const bedrockModels = getModelsDynamic('amazon-bedrock').filter(isBedrockCampCompatible);
+      const region = bedrockCampRegionFromBaseUrl(getBaseUrlForProvider('bedrock-camp'));
+      const bedrockModels = getModelsDynamic('amazon-bedrock').filter((m) =>
+        isBedrockCampCompatible(m, region)
+      );
       const existingIds = new Set(bedrockModels.map((m) => m.id));
-      const extras = getBedrockCampExtraModels().filter((m) => !existingIds.has(m.id));
+      const extras = getBedrockCampExtraModels().filter(
+        (m) => isBedrockCampCompatible(m, region) && !existingIds.has(m.id)
+      );
       return [...bedrockModels, ...extras].map((m) => ({
         ...m,
         api: 'bedrock-camp-converse' as Api,

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -16,6 +16,10 @@ import {
   shouldIncludeProvider,
 } from '../providers/index.js';
 import type { ProviderConfig } from '../providers/index.js';
+import {
+  isBedrockCampCompatible,
+  getBedrockCampExtraModels,
+} from '../providers/built-in/bedrock-camp.js';
 
 export type { ProviderConfig } from '../providers/index.js';
 
@@ -122,10 +126,14 @@ function applyModelMetadata(
 // Get models for a provider
 export function getProviderModels(providerId: string): Model<Api>[] {
   try {
-    // Bedrock CAMP uses Amazon Bedrock models with custom API
+    // Bedrock CAMP uses Amazon Bedrock models with custom API.
+    // Filter to inference-profile-prefixed Claude 4.x (bare IDs aren't
+    // invokable on-demand) and inject models missing from pi-ai's registry
+    // (e.g. opus-4.7).
     if (providerId === 'bedrock-camp') {
-      const bedrockModels = getModelsDynamic('amazon-bedrock');
-      return bedrockModels.map((m) => ({
+      const bedrockModels = getModelsDynamic('amazon-bedrock').filter(isBedrockCampCompatible);
+      const extras = getBedrockCampExtraModels();
+      return [...bedrockModels, ...extras].map((m) => ({
         ...m,
         api: 'bedrock-camp-converse' as Api,
         provider: 'bedrock-camp',

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -129,10 +129,12 @@ export function getProviderModels(providerId: string): Model<Api>[] {
     // Bedrock CAMP uses Amazon Bedrock models with custom API.
     // Filter to inference-profile-prefixed Claude 4.x (bare IDs aren't
     // invokable on-demand) and inject models missing from pi-ai's registry
-    // (e.g. opus-4.7).
+    // (e.g. opus-4.7). Dedupe by ID so extras auto-drop when pi-ai ships
+    // the same IDs.
     if (providerId === 'bedrock-camp') {
       const bedrockModels = getModelsDynamic('amazon-bedrock').filter(isBedrockCampCompatible);
-      const extras = getBedrockCampExtraModels();
+      const existingIds = new Set(bedrockModels.map((m) => m.id));
+      const extras = getBedrockCampExtraModels().filter((m) => !existingIds.has(m.id));
       return [...bedrockModels, ...extras].map((m) => ({
         ...m,
         api: 'bedrock-camp-converse' as Api,

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -50,7 +50,6 @@ export interface Account {
   providerId: string;
   apiKey: string;
   baseUrl?: string;
-  modelId?: string;
   deployment?: string;
   apiVersion?: string;
   // OAuth fields (used by OAuth providers)
@@ -126,12 +125,7 @@ export function getProviderModels(providerId: string): Model<Api>[] {
     // Bedrock CAMP uses Amazon Bedrock models with custom API
     if (providerId === 'bedrock-camp') {
       const bedrockModels = getModelsDynamic('amazon-bedrock');
-      // Filter to selected model if one is configured
-      const selectedModelId = getModelIdForProvider('bedrock-camp');
-      const filtered = selectedModelId
-        ? bedrockModels.filter((m) => m.id === selectedModelId)
-        : bedrockModels;
-      return (filtered.length > 0 ? filtered : bedrockModels).map((m) => ({
+      return bedrockModels.map((m) => ({
         ...m,
         api: 'bedrock-camp-converse' as Api,
         provider: 'bedrock-camp',
@@ -339,22 +333,16 @@ export function addAccount(
   providerId: string,
   apiKey: string,
   baseUrl?: string,
-  modelId?: string,
   deployment?: string,
   apiVersion?: string
 ): void {
   const accounts = getAccounts().filter((a) => a.providerId !== providerId);
   const entry: Account = { providerId, apiKey };
   if (baseUrl) entry.baseUrl = baseUrl;
-  if (modelId) entry.modelId = modelId;
   if (deployment) entry.deployment = deployment;
   if (apiVersion) entry.apiVersion = apiVersion;
   accounts.push(entry);
   saveAccounts(accounts);
-}
-
-export function getModelIdForProvider(providerId: string): string | undefined {
-  return getAccounts().find((a) => a.providerId === providerId)?.modelId;
 }
 
 export function removeAccount(providerId: string): void {
@@ -1092,29 +1080,6 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
 
       dialog.appendChild(apiVersionSection);
 
-      // Model selector section (shown for providers with requiresModelSelection)
-      const modelSection = document.createElement('div');
-      modelSection.style.display = 'none';
-
-      const modelLabel = document.createElement('div');
-      modelLabel.className = 'dialog__desc';
-      modelLabel.textContent = 'Model:';
-      modelSection.appendChild(modelLabel);
-
-      const modelSelect = document.createElement('select');
-      modelSelect.className = 'dialog__input';
-      modelSelect.style.marginBottom = '16px';
-      modelSection.appendChild(modelSelect);
-
-      const modelDesc = document.createElement('div');
-      modelDesc.className = 'dialog__desc';
-      modelDesc.style.cssText =
-        'font-size: 11px; color: var(--s2-content-secondary); margin-top: -12px; margin-bottom: 16px;';
-      modelDesc.textContent = 'Select the model available in your deployment';
-      modelSection.appendChild(modelDesc);
-
-      dialog.appendChild(modelSection);
-
       // Error message area
       const errorEl = document.createElement('div');
       errorEl.style.cssText =
@@ -1175,32 +1140,6 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
         } else {
           apiVersionSection.style.display = 'none';
         }
-
-        // Model selector (shown when requiresModelSelection is set)
-        if (providerConfig.requiresModelSelection) {
-          modelSection.style.display = '';
-          modelSelect.innerHTML = '';
-          const sourceProvider = pid === 'bedrock-camp' ? 'amazon-bedrock' : pid;
-          const models = getModelsDynamic(sourceProvider);
-          for (const m of models) {
-            const opt = document.createElement('option');
-            opt.value = m.id;
-            opt.textContent = m.name || m.id;
-            modelSelect.appendChild(opt);
-          }
-          // Pre-select if editing
-          if (isEdit && editing.modelId) {
-            modelSelect.value = editing.modelId;
-          } else if (providerConfig.defaultModelId) {
-            // Try to match the default model by substring
-            const defaultMatch = models.find((m) =>
-              m.id.toLowerCase().includes(providerConfig.defaultModelId!.toLowerCase())
-            );
-            if (defaultMatch) modelSelect.value = defaultMatch.id;
-          }
-        } else {
-          modelSection.style.display = 'none';
-        }
       }
 
       providerSelect.addEventListener('change', () => {
@@ -1235,14 +1174,10 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
           return;
         }
 
-        const selectedModelId = config.requiresModelSelection
-          ? modelSelect.value || undefined
-          : undefined;
         addAccount(
           pid,
           apiKeyInput.value.trim(),
           baseUrlInput.value.trim() || undefined,
-          selectedModelId,
           deploymentInput.value.trim() || undefined,
           apiVersionInput.value.trim() || undefined
         );


### PR DESCRIPTION
## Summary

Four-commit fix for the `bedrock-camp` provider, driven by direct testing against a live CAMP endpoint. Supersedes the UX from #375 and includes the URL-encoding fix from #133.

1. **`fix: don't encode Bedrock model ID in URL path`** — cherry-picks #133.
2. **`revert(bedrock-camp): remove single-model picker from setup dialog`** — the `requiresModelSelection` flow added in #375 was premised on "CAMP grants access to one model." Live testing invokes six Claude 4.x models with one key, so the premise was wrong and the single-model picker hides real capability. Keeps the prompt-caching changes from #375.
3. **`feat(bedrock-camp): filter picker to Claude 4.x and add Opus 4.7`** — tightens `getProviderModels('bedrock-camp')` to inference-profile-prefixed Claude 4.x (opus/sonnet/haiku) and injects `us./global.anthropic.claude-opus-4-7`, which CAMP serves but pi-ai's registry hasn't regenerated for.
4. **`fix(bedrock-camp): omit temperature for Opus 4.7`** — Opus 4.7 returns `400 "temperature is deprecated for this model"` when the Converse API receives `inferenceConfig.temperature`. pi-ai always supplies a default, so every opus-4.7 call was 400-ing.

## Why the filter

Measured behavior against `https://bedrock-runtime.us-west-2.amazonaws.com` with a real CAMP token:

- Bare `anthropic.*` IDs → `400 on-demand throughput isn't supported` (must use an inference profile)
- Older Claudes (3.x) — weaker at resisting prompt injection, deliberately excluded
- Nova / Llama / Writer / TwelveLabs — same injection concern
- DeepSeek R1 → `400 "This model doesn't support tool use"` on `toolConfig`, which breaks the agent loop entirely

Final picker contents: Opus 4 / 4.1 / 4.5 / 4.6 / 4.7, Sonnet 4 / 4.5 / 4.6, Haiku 4.5 — each in `us.` and `global.` where available.

## Test plan

- [x] `npm run typecheck` — passes (one pre-existing `lucide-icons` error unrelated to this change)
- [x] `npx prettier --check` — clean
- [x] Live API: opus-4.5 / opus-4.6 / opus-4.7 / sonnet-4.5 / sonnet-4.6 / haiku-4.5 return 200 via CLI fetch-proxy
- [x] opus-4.7 no longer 400s on `temperature is deprecated`
- [ ] Manual smoke in extension mode (direct fetch)
- [ ] Verify picker shows 15 Claude 4.x entries (no 3.x, Nova, Llama, etc.)

## Notes

- `packages/webapp/tests/providers/built-in/bedrock-camp.test.ts` was failing on `main` before this PR (deep import into `pi-ai/dist/providers/transform-messages.js` doesn't resolve in Vitest). Not regressed here, but worth a follow-up.
- Opus 4.7 capability shape (1M context, 128K max tokens, cost) mirrors 4.6 — refresh when pi-ai updates `models.generated.js`.