### PR TITLE
fix(dev): anchor .yolo/.intent watcher ignore to workspace root

### DIFF
--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -344,7 +344,12 @@ export default defineConfig(({ mode }) => ({
   },
   server: {
     watch: {
-      ignored: ['**/.yolo/**', '**/.intent/**'],
+      // Anchor to workspaceRoot so the ignore only matches the top-level
+      // .yolo/.intent dirs in the main checkout. Using a bare `**/.yolo/**`
+      // glob matches chokidar's absolute paths, which silently mutes the
+      // watcher for every file when the dev server runs from *inside* a
+      // .yolo/ worktree (e.g. `PORT=5720 npm run dev` in `.yolo/claude-1`).
+      ignored: [resolve(workspaceRoot, '.yolo/**'), resolve(workspaceRoot, '.intent/**')],
     },
   },
   build: {


### PR DESCRIPTION
## Summary

Closes #423.

Change `packages/webapp/vite.config.ts` to anchor the `.yolo/` and `.intent/` watcher-ignore patterns to `workspaceRoot` instead of using bare `**/.yolo/**` globs. The bare form gets matched by chokidar against absolute paths, so when the dev server runs from inside a parallel-agent worktree (any `PORT=… npm run dev` launched from `.yolo/claude-*`) every file in the workspace sits under `/.yolo/` and the watcher is silently muted — HMR never fires, the browser's ESM modules go stale, and the dev log looks completely healthy the whole time.

Anchoring means:
- **Main checkout**: `resolve(workspaceRoot, '.yolo/**')` → `/<repo>/.yolo/**` — still excludes all worktrees, which is the original intent.
- **Inside `.yolo/claude-1`**: `workspaceRoot` is the worktree, so the resolved pattern is `/<repo>/.yolo/claude-1/.yolo/**` — matches nothing in the worktree, HMR works normally.

## Test plan

- [x] `npx prettier --check packages/webapp/vite.config.ts`
- [x] `npm run typecheck` unaffected (one pre-existing `lucide-icons` error unrelated)
- [ ] In a fresh `.yolo/test` worktree: `PORT=5720 npm run dev`, edit any `packages/webapp/src/**` file, confirm `[vite] hmr update …` fires and the browser reloads that module.
- [ ] In the main checkout: `npm run dev` on 5710, edit an unrelated parallel-agent worktree file, confirm the main dev server does **not** react (watcher still excludes sibling worktrees).

## Context

Found while testing #422. One-liner functional change; the comment explains the anchoring so the next person doesn't re-broaden the glob.