### PR TITLE
fix(git): route isomorphic-git through VirtualFS so mounts work

### DIFF
--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -532,14 +532,15 @@ export class VirtualFS {
       try {
         const fh = await VirtualFS.fsaGetFile(mount.handle, mount.relParts, true);
         const writable = await fh.createWritable();
+        // Preserve byteOffset/byteLength: pooled Buffer instances share a
+        // backing ArrayBuffer with other allocations, so `content.buffer`
+        // alone would write the whole pool.
         const data =
           typeof content === 'string'
             ? new TextEncoder().encode(content)
-            : new Uint8Array(
-                content instanceof Uint8Array
-                  ? (content.buffer as ArrayBuffer)
-                  : (content as ArrayBuffer)
-              );
+            : content instanceof Uint8Array
+              ? new Uint8Array(content.buffer, content.byteOffset, content.byteLength)
+              : new Uint8Array(content as ArrayBuffer);
         await writable.write(data as unknown as FileSystemWriteChunkType);
         await writable.close();
       } catch (err) {

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -408,6 +408,18 @@ export class VirtualFS {
   }
 
   /**
+   * Check whether an absolute path is under any active mount point.
+   * Non-allocating (iterates the mount map directly) — safe to call on a hot
+   * path such as the per-operation check in the isomorphic-git fs adapter.
+   */
+  isPathUnderMount(path: string): boolean {
+    for (const mountPath of this.mountPoints.keys()) {
+      if (path === mountPath || path.startsWith(mountPath + '/')) return true;
+    }
+    return false;
+  }
+
+  /**
    * Find the mount point that owns `path`.
    * Returns the handle and the path segments relative to the mount root,
    * or null if the path is not under any mount.
@@ -471,6 +483,13 @@ export class VirtualFS {
         return new FsError('ENOENT', 'no such file or directory', path);
       if (err.name === 'TypeMismatchError') return new FsError('ENOTDIR', 'not a directory', path);
       if (err.name === 'NotAllowedError') return new FsError('EINVAL', 'permission denied', path);
+      // FSA throws InvalidModificationError from removeEntry() when the target
+      // is a non-empty directory and `recursive` was not requested. Surface
+      // that as ENOTEMPTY so callers (notably isomorphic-git's checkout/reset
+      // cleanup path) can tolerate untracked files the same way they do on
+      // the LightningFS-backed path.
+      if (err.name === 'InvalidModificationError')
+        return new FsError('ENOTEMPTY', 'directory not empty', path);
     }
     return new FsError('EINVAL', err instanceof Error ? err.message : String(err), path);
   }

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -9,10 +9,10 @@
 import '../shims/buffer-polyfill.js';
 
 import * as git from 'isomorphic-git';
-import type FS from '@isomorphic-git/lightning-fs';
 import { VirtualFS } from '../fs/index.js';
 import { gitHttp } from './git-http.js';
 import { unifiedDiff, diffStat } from './diff.js';
+import { createIsomorphicGitFs, type IsoGitFsPromises } from './vfs-fs-adapter.js';
 
 export interface GitCommandResult {
   stdout: string;
@@ -39,7 +39,7 @@ export interface GitCommandsOptions {
 export class GitCommands {
   private static globalFsByDbName: Map<string, Promise<VirtualFS>> = new Map();
 
-  private lfs: FS.PromisifiedFS;
+  private lfs: IsoGitFsPromises;
   private corsProxy?: string;
   private authorName: string;
   private authorEmail: string;
@@ -49,8 +49,10 @@ export class GitCommands {
   private githubTokenLoaded = false;
 
   constructor(private options: GitCommandsOptions) {
-    // Use the shared VirtualFS's underlying LightningFS
-    this.lfs = options.fs.getLightningFS();
+    // Route through a VirtualFS-backed adapter so isomorphic-git sees mount
+    // points (File System Access API) the same way shell/agent tools do.
+    // See packages/webapp/src/git/vfs-fs-adapter.ts.
+    this.lfs = createIsomorphicGitFs(options.fs).promises;
     this.corsProxy = options.corsProxy;
     this.authorName = options.authorName ?? 'User';
     this.authorEmail = options.authorEmail ?? 'user@example.com';

--- a/packages/webapp/src/git/vfs-fs-adapter.ts
+++ b/packages/webapp/src/git/vfs-fs-adapter.ts
@@ -67,13 +67,6 @@ function toStats(type: 'file' | 'dir' | 'symlink', raw: Partial<NodeLikeStats>):
   };
 }
 
-function isPathUnderAnyMount(path: string, mounts: string[]): boolean {
-  for (const m of mounts) {
-    if (path === m || path.startsWith(m + '/')) return true;
-  }
-  return false;
-}
-
 function wantsUtf8(options: unknown): boolean {
   if (typeof options === 'string') return /^utf-?8$/i.test(options);
   if (options && typeof options === 'object') {
@@ -87,7 +80,7 @@ function wantsUtf8(options: unknown): boolean {
 export function createIsomorphicGitFs(vfs: VirtualFS): PromiseFsClient {
   const lfs: FS.PromisifiedFS = vfs.getLightningFS();
 
-  const inMount = (path: string): boolean => isPathUnderAnyMount(path, vfs.listMounts());
+  const inMount = (path: string): boolean => vfs.isPathUnderMount(path);
 
   const promises: IsoGitFsPromises = {
     async readFile(path, options) {
@@ -128,12 +121,18 @@ export function createIsomorphicGitFs(vfs: VirtualFS): PromiseFsClient {
       return (await lfs.readdir(path)) as string[];
     },
 
-    async mkdir(path, _options) {
+    async mkdir(path, options) {
+      const opts = (options ?? undefined) as { recursive?: boolean; mode?: number } | undefined;
       if (inMount(path)) {
-        await vfs.mkdir(path);
+        await vfs.mkdir(
+          path,
+          opts?.recursive !== undefined ? { recursive: opts.recursive } : undefined
+        );
         return;
       }
-      await lfs.mkdir(path);
+      // LightningFS accepts { mode } (but not recursive). Drop `recursive` so
+      // callers that include it don't break the signature.
+      await lfs.mkdir(path, opts?.mode !== undefined ? { mode: opts.mode } : undefined);
     },
 
     async rmdir(path) {

--- a/packages/webapp/src/git/vfs-fs-adapter.ts
+++ b/packages/webapp/src/git/vfs-fs-adapter.ts
@@ -1,0 +1,199 @@
+/**
+ * Adapter exposing a {@link VirtualFS} as a `PromiseFsClient` for isomorphic-git.
+ *
+ * Why this exists: `VirtualFS.getLightningFS()` returns the raw LightningFS
+ * instance, which only sees IndexedDB. Mounted directories (File System Access
+ * API) are transparently routed through `VirtualFS` — so isomorphic-git needs
+ * to go through `VirtualFS` to see `.git/HEAD` on mounted paths.
+ *
+ * For non-mounted paths we still read mode/size/mtime directly from the
+ * underlying LightningFS to keep behavior byte-identical to the pre-adapter
+ * code path (notably `statusMatrix`'s filemode comparison).
+ */
+
+import type FS from '@isomorphic-git/lightning-fs';
+import { type VirtualFS } from '../fs/index.js';
+import { FsError } from '../fs/types.js';
+
+export type PromiseFsClient = { promises: IsoGitFsPromises };
+
+export interface IsoGitFsPromises {
+  readFile(path: string, options?: unknown): Promise<Uint8Array | string>;
+  writeFile(path: string, data: Uint8Array | string, options?: unknown): Promise<void>;
+  unlink(path: string): Promise<void>;
+  readdir(path: string): Promise<string[]>;
+  mkdir(path: string, options?: unknown): Promise<void>;
+  rmdir(path: string): Promise<void>;
+  stat(path: string): Promise<NodeLikeStats>;
+  lstat(path: string): Promise<NodeLikeStats>;
+  readlink(path: string): Promise<string>;
+  symlink(target: string, path: string): Promise<void>;
+}
+
+export interface NodeLikeStats {
+  type: 'file' | 'dir' | 'symlink';
+  mode: number;
+  size: number;
+  ino: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  uid: number;
+  gid: number;
+  dev: number;
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+}
+
+const FILE_MODE = 0o100644;
+const DIR_MODE = 0o040755;
+const SYMLINK_MODE = 0o120000;
+
+function toStats(type: 'file' | 'dir' | 'symlink', raw: Partial<NodeLikeStats>): NodeLikeStats {
+  const mtimeMs = raw.mtimeMs ?? 0;
+  return {
+    type,
+    mode: raw.mode ?? (type === 'dir' ? DIR_MODE : type === 'symlink' ? SYMLINK_MODE : FILE_MODE),
+    size: raw.size ?? 0,
+    ino: raw.ino ?? 0,
+    mtimeMs,
+    ctimeMs: raw.ctimeMs ?? mtimeMs,
+    uid: 1,
+    gid: 1,
+    dev: 1,
+    isFile: () => type === 'file',
+    isDirectory: () => type === 'dir',
+    isSymbolicLink: () => type === 'symlink',
+  };
+}
+
+function isPathUnderAnyMount(path: string, mounts: string[]): boolean {
+  for (const m of mounts) {
+    if (path === m || path.startsWith(m + '/')) return true;
+  }
+  return false;
+}
+
+function wantsUtf8(options: unknown): boolean {
+  if (typeof options === 'string') return /^utf-?8$/i.test(options);
+  if (options && typeof options === 'object') {
+    const enc = (options as { encoding?: unknown }).encoding;
+    if (typeof enc === 'string') return /^utf-?8$/i.test(enc);
+  }
+  return false;
+}
+
+/** Build an isomorphic-git-compatible PromiseFsClient over a VirtualFS. */
+export function createIsomorphicGitFs(vfs: VirtualFS): PromiseFsClient {
+  const lfs: FS.PromisifiedFS = vfs.getLightningFS();
+
+  const inMount = (path: string): boolean => isPathUnderAnyMount(path, vfs.listMounts());
+
+  const promises: IsoGitFsPromises = {
+    async readFile(path, options) {
+      if (inMount(path)) {
+        const content = await vfs.readFile(
+          path,
+          wantsUtf8(options) ? { encoding: 'utf-8' } : { encoding: 'binary' }
+        );
+        return content;
+      }
+      if (wantsUtf8(options)) {
+        return (await lfs.readFile(path, { encoding: 'utf8' })) as string;
+      }
+      return (await lfs.readFile(path)) as Uint8Array;
+    },
+
+    async writeFile(path, data, _options) {
+      if (inMount(path)) {
+        await vfs.writeFile(path, data);
+        return;
+      }
+      await lfs.writeFile(path, data);
+    },
+
+    async unlink(path) {
+      if (inMount(path)) {
+        await vfs.rm(path);
+        return;
+      }
+      await lfs.unlink(path);
+    },
+
+    async readdir(path) {
+      if (inMount(path)) {
+        const entries = await vfs.readDir(path);
+        return entries.map((e) => e.name);
+      }
+      return (await lfs.readdir(path)) as string[];
+    },
+
+    async mkdir(path, _options) {
+      if (inMount(path)) {
+        await vfs.mkdir(path);
+        return;
+      }
+      await lfs.mkdir(path);
+    },
+
+    async rmdir(path) {
+      if (inMount(path)) {
+        await vfs.rm(path);
+        return;
+      }
+      await lfs.rmdir(path);
+    },
+
+    async stat(path) {
+      if (inMount(path)) {
+        const s = await vfs.stat(path);
+        return toStats(s.type === 'directory' ? 'dir' : 'file', {
+          size: s.size,
+          mtimeMs: s.mtime,
+          ctimeMs: s.ctime,
+        });
+      }
+      const s = await lfs.stat(path);
+      return toStats(s.isDirectory() ? 'dir' : s.isSymbolicLink() ? 'symlink' : 'file', {
+        mode: s.mode,
+        size: s.size,
+        ino: s.ino,
+        mtimeMs: s.mtimeMs,
+        ctimeMs: s.ctimeMs,
+      });
+    },
+
+    async lstat(path) {
+      if (inMount(path)) {
+        const s = await vfs.lstat(path);
+        const type: 'file' | 'dir' | 'symlink' =
+          s.type === 'directory' ? 'dir' : s.type === 'symlink' ? 'symlink' : 'file';
+        return toStats(type, { size: s.size, mtimeMs: s.mtime, ctimeMs: s.ctime });
+      }
+      const s = await lfs.lstat(path);
+      return toStats(s.isDirectory() ? 'dir' : s.isSymbolicLink() ? 'symlink' : 'file', {
+        mode: s.mode,
+        size: s.size,
+        ino: s.ino,
+        mtimeMs: s.mtimeMs,
+        ctimeMs: s.ctimeMs,
+      });
+    },
+
+    async readlink(path) {
+      if (inMount(path)) {
+        throw new FsError('EINVAL', 'symlinks not supported on mounted filesystems', path);
+      }
+      return lfs.readlink(path);
+    },
+
+    async symlink(target, path) {
+      if (inMount(path)) {
+        throw new FsError('EINVAL', 'symlinks not supported on mounted filesystems', path);
+      }
+      await lfs.symlink(target, path);
+    },
+  };
+
+  return { promises };
+}

--- a/packages/webapp/tests/fs/fsa-test-helpers.ts
+++ b/packages/webapp/tests/fs/fsa-test-helpers.ts
@@ -42,6 +42,43 @@ class MockFileHandle {
       arrayBuffer: async () => bytes.slice().buffer,
     } as File;
   }
+
+  async createWritable(): Promise<FileSystemWritableFileStream> {
+    const node = this.node;
+    const chunks: Uint8Array[] = [];
+    return {
+      async write(chunk: unknown): Promise<void> {
+        let bytes: Uint8Array;
+        if (typeof chunk === 'string') {
+          bytes = new TextEncoder().encode(chunk);
+        } else if (chunk instanceof Uint8Array) {
+          bytes = chunk;
+        } else if (chunk instanceof ArrayBuffer) {
+          bytes = new Uint8Array(chunk);
+        } else if (chunk && typeof chunk === 'object' && 'data' in chunk) {
+          const data = (chunk as { data: unknown }).data;
+          if (typeof data === 'string') bytes = new TextEncoder().encode(data);
+          else if (data instanceof Uint8Array) bytes = data;
+          else if (data instanceof ArrayBuffer) bytes = new Uint8Array(data);
+          else throw new Error('Unsupported chunk data type');
+        } else {
+          throw new Error('Unsupported chunk type');
+        }
+        chunks.push(bytes);
+      },
+      async close(): Promise<void> {
+        const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+        const merged = new Uint8Array(total);
+        let offset = 0;
+        for (const c of chunks) {
+          merged.set(c, offset);
+          offset += c.byteLength;
+        }
+        node.content = merged;
+        node.mtime = Date.now();
+      },
+    } as unknown as FileSystemWritableFileStream;
+  }
 }
 
 class MockDirectoryHandle {
@@ -99,6 +136,17 @@ class MockDirectoryHandle {
         yield [name, new MockFileHandle(name, entry)];
       }
     }
+  }
+
+  async removeEntry(name: string, options?: { recursive?: boolean }): Promise<void> {
+    const entry = this.node.entries.get(name);
+    if (!entry) {
+      throw new MockFsError('NotFoundError', `No such entry: ${name}`);
+    }
+    if (entry.kind === 'directory' && entry.entries.size > 0 && !options?.recursive) {
+      throw new MockFsError('InvalidModificationError', `Directory not empty: ${name}`);
+    }
+    this.node.entries.delete(name);
   }
 }
 

--- a/packages/webapp/tests/fs/virtual-fs.mount.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.mount.test.ts
@@ -38,6 +38,27 @@ describe('VirtualFS mount interactions with script discovery', () => {
     expect(commands.get('run')).toBe('/workspace/skills/test-skill/run.jsh');
   });
 
+  it('maps FSA InvalidModificationError to ENOTEMPTY when rm-ing a non-empty mounted directory', async () => {
+    await vfs.mkdir('/mnt/repo', { recursive: true });
+    await vfs.mount(
+      '/mnt/repo',
+      createDirectoryHandle({
+        pack: {
+          'entry.txt': 'contents',
+        },
+      })
+    );
+
+    // Non-recursive rm on a non-empty mounted directory must surface ENOTEMPTY
+    // so callers (isomorphic-git checkout/reset cleanup) can tolerate it.
+    await expect(vfs.rm('/mnt/repo/pack')).rejects.toEqual(
+      expect.objectContaining<FsError>({
+        code: 'ENOTEMPTY',
+        path: '/mnt/repo/pack',
+      })
+    );
+  });
+
   it('discovers nested mounted .jsh and .bsh scripts through the parent mount', async () => {
     await vfs.mount(
       '/workspace/repo',

--- a/packages/webapp/tests/git/git-commands-mount.test.ts
+++ b/packages/webapp/tests/git/git-commands-mount.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression tests for https://github.com/ai-ecoverse/slicc/issues/421 —
+ * git commands fail on mounted directories because isomorphic-git was handed
+ * raw LightningFS instead of a mount-aware adapter.
+ *
+ * Mounts an FSA-backed directory and runs a full init → add → commit → log
+ * cycle, plus a status check that the pre-adapter code could not satisfy
+ * (HEAD was invisible through LightningFS).
+ */
+
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { GitCommands } from '../../src/git/git-commands.js';
+import { createDirectoryHandle } from '../fs/fsa-test-helpers.js';
+
+let dbCounter = 0;
+
+describe('GitCommands on mounted directories (issue #421)', () => {
+  let vfs: VirtualFS;
+  let git: GitCommands;
+
+  beforeEach(async () => {
+    const testId = dbCounter++;
+    vfs = await VirtualFS.create({ dbName: `git-mount-test-${testId}`, wipe: true });
+    git = new GitCommands({
+      fs: vfs,
+      authorName: 'Test User',
+      authorEmail: 'test@example.com',
+      globalDbName: `git-mount-global-${testId}`,
+    });
+  });
+
+  async function mountEmpty(path: string): Promise<void> {
+    await vfs.mkdir(path, { recursive: true });
+    await vfs.mount(path, createDirectoryHandle({}));
+  }
+
+  it('git init creates .git/HEAD inside a mounted directory', async () => {
+    await mountEmpty('/mnt/repo');
+
+    const result = await git.execute(['init'], '/mnt/repo');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Initialized empty Git repository');
+
+    // The pre-adapter code wrote HEAD to LightningFS but read through VFS,
+    // so verifying the file exists via VFS closes the whole loop.
+    expect(await vfs.exists('/mnt/repo/.git/HEAD')).toBe(true);
+    const head = await vfs.readTextFile('/mnt/repo/.git/HEAD');
+    expect(head).toMatch(/^ref: refs\/heads\//);
+  });
+
+  it('status reports clean after a commit on a mounted repo', async () => {
+    await mountEmpty('/mnt/repo');
+    await git.execute(['init'], '/mnt/repo');
+
+    await vfs.writeFile('/mnt/repo/readme.txt', 'mounted hello');
+    const add = await git.execute(['add', 'readme.txt'], '/mnt/repo');
+    expect(add.exitCode).toBe(0);
+
+    const commit = await git.execute(['commit', '-m', 'first'], '/mnt/repo');
+    expect(commit.exitCode).toBe(0);
+
+    const status = await git.execute(['status'], '/mnt/repo');
+    expect(status.exitCode).toBe(0);
+    // The primary symptom of #421 was "HEAD not found" — surface any such
+    // failure clearly before asserting the happy path.
+    expect(status.stderr).not.toMatch(/HEAD not found/i);
+    expect(status.stdout).toMatch(/nothing to commit|working tree clean/);
+  });
+
+  it('log --oneline shows the commit made inside the mount', async () => {
+    await mountEmpty('/mnt/repo');
+    await git.execute(['init'], '/mnt/repo');
+    await vfs.writeFile('/mnt/repo/file.txt', 'content');
+    await git.execute(['add', 'file.txt'], '/mnt/repo');
+    await git.execute(['commit', '-m', 'mounted commit'], '/mnt/repo');
+
+    const log = await git.execute(['log', '--oneline'], '/mnt/repo');
+    expect(log.exitCode).toBe(0);
+    expect(log.stdout).toContain('mounted commit');
+  });
+
+  it('still works on a non-mounted LightningFS-backed repo (no regression)', async () => {
+    await git.execute(['init'], '/project');
+    await vfs.writeFile('/project/a.txt', 'a');
+    await git.execute(['add', 'a.txt'], '/project');
+    const commit = await git.execute(['commit', '-m', 'lfs repo'], '/project');
+    expect(commit.exitCode).toBe(0);
+
+    const log = await git.execute(['log', '--oneline'], '/project');
+    expect(log.exitCode).toBe(0);
+    expect(log.stdout).toContain('lfs repo');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #421 — `git` commands fail on mounted directories with "HEAD not found", because `GitCommands` passed raw LightningFS to isomorphic-git instead of a mount-aware FS.

- **New `vfs-fs-adapter.ts`** — builds a `PromiseFsClient` over `VirtualFS`. Mounted paths route through `VirtualFS` (File System Access API); LFS paths stay on the raw LightningFS fast path so `statusMatrix` filemode bytes remain byte-identical to the pre-adapter behavior.
- **`git-commands.ts`** — one-line constructor change (`this.lfs = createIsomorphicGitFs(options.fs).promises`). All 58 `git.*` call sites untouched.
- **`virtual-fs.ts`** — fixes a latent mount-write bug surfaced while testing: `new Uint8Array(content.buffer)` dropped `byteOffset`/`byteLength`, so pooled `Buffer` views (e.g. from iso-git's `Buffer.concat` when writing `.git/index`) wrote the whole backing pool. Now preserves the view bounds.
- **Tests** — new `git-commands-mount.test.ts` does an end-to-end `init → add → commit → log` on a mounted repo, plus a "status doesn't say 'HEAD not found'" guard and an LFS-only regression check. `fsa-test-helpers.ts` gained `createWritable()` and `removeEntry()` on the mock handles so full round-trip tests are possible.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run -w packages/webapp` — 2274/2274 pass
- [x] `npx prettier --check` on all touched files — clean
- [ ] Manual: mount a real folder via the `mount` command, run `git status` / `git log` inside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)