### PR TITLE
feat(shell): per-scoop command allow-list via just-bash commands filter

### DIFF
--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -161,6 +161,7 @@ export class ScoopContext {
         env: Object.keys(secretEnv).length > 0 ? secretEnv : undefined,
         browserAPI: browser,
         jshDiscoveryFs: this.skillsFs ? effectiveSkillsFs : undefined,
+        allowedCommands: this.scoop.config?.allowedCommands,
       });
       log.info('WasmShell initialized', { folder: this.scoop.folder });
       const skills = await loadSkills(effectiveSkillsFs, this.skillsDir);

--- a/packages/webapp/src/scoops/types.ts
+++ b/packages/webapp/src/scoops/types.ts
@@ -77,6 +77,13 @@ export interface ScoopConfig {
    * they always use an unrestricted filesystem.
    */
   writablePaths?: readonly string[];
+  /**
+   * Shell command allow-list. When omitted (or when it contains `'*'`), every
+   * built-in, custom, and `.jsh` command is available — the default. Otherwise
+   * only commands whose names appear in the list can execute inside this
+   * scoop's shell, including through pipelines and substitution.
+   */
+  allowedCommands?: readonly string[];
 }
 
 /** Message from any channel */

--- a/packages/webapp/src/shell/wasm-shell.ts
+++ b/packages/webapp/src/shell/wasm-shell.ts
@@ -404,6 +404,31 @@ export class WasmShell {
       customCommands,
     });
 
+    // Network-command post-registration cleanup (Codex P1 on #433).
+    //
+    // just-bash's `BashOptions.commands` filter controls only the non-network
+    // built-ins. When `fetch` (or `network`) is set, just-bash unconditionally
+    // registers EVERY name from `getNetworkCommandNames()` regardless of
+    // `commands` — see `Bash` constructor in just-bash's bundle:
+    //   `if (t.fetch || t.network) for (let i of U0()) this.registerCommand(i);`
+    // We always pass `fetch` (via `createProxiedFetch()`), so without this
+    // cleanup a scoop with `allowedCommands: ['echo']` could still execute
+    // `curl`, `wget`, etc. — defeating the per-scoop isolation guarantee.
+    //
+    // Delete the disallowed network commands from the already-populated
+    // registry. Reaches into `Bash`'s private `commands: Map` via cast; the
+    // property name is stable across versions and tests below guard the
+    // behavior, but the upstream ergonomics here are what warrants the
+    // comment.
+    if (this.allowedCommands !== null) {
+      const bashInternals = this.bash as unknown as { commands: Map<string, unknown> };
+      for (const name of getNetworkCommandNames()) {
+        if (!this.isCommandAllowed(name)) {
+          bashInternals.commands.delete(name);
+        }
+      }
+    }
+
     // Wire up /usr/bin virtual directory with all registered command names
     const customCommandNames = customCommands.map((c) => c.name);
     const registeredBuiltinNames = allowedBuiltinNames ?? [

--- a/packages/webapp/src/shell/wasm-shell.ts
+++ b/packages/webapp/src/shell/wasm-shell.ts
@@ -10,7 +10,7 @@ import type { Terminal } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
 import type { FsWatcher, VirtualFS } from '../fs/index.js';
 import { Bash, defineCommand, getCommandNames, getNetworkCommandNames } from 'just-bash';
-import type { BashExecResult, SecureFetch, Command } from 'just-bash';
+import type { BashExecResult, SecureFetch, Command, CommandName } from 'just-bash';
 import { VfsAdapter } from './vfs-adapter.js';
 import { cacheBinaryBody, cacheBinaryByUrl } from './binary-cache.js';
 import { getFetchBodyBytes } from './fetch-body.js';
@@ -259,6 +259,16 @@ export interface WasmShellOptions {
   bshDiscoveryFs?: BshDiscoveryFS;
   /** Optional shared script catalog. When omitted, WasmShell creates and owns one. */
   scriptCatalog?: ScriptCatalog;
+  /**
+   * Optional command allow-list. When omitted (or when the list contains `'*'`),
+   * every built-in, custom, and `.jsh` command is available — the default. When
+   * provided, only command heads whose names appear in the list are registered
+   * on the underlying Bash instance; anything else fails at dispatch with
+   * "command not found" (exit code 127), including inside pipelines, subshells,
+   * and command substitution, because just-bash resolves every simple command
+   * through the same registry.
+   */
+  allowedCommands?: readonly string[];
 }
 
 type BashExecOptionsWithSignal = NonNullable<Parameters<Bash['exec']>[1]> & {
@@ -291,6 +301,11 @@ export class WasmShell {
   private cwd: string;
   /** Set of all built-in + custom command names (for shadowing protection). */
   private builtinCommandNames: Set<string>;
+  /**
+   * Allow-list of command names. `null` means unrestricted — every command is
+   * permitted. Otherwise only names in the set may be registered or executed.
+   */
+  private readonly allowedCommands: ReadonlySet<string> | null;
   private readonly scriptCatalog: ScriptCatalog;
   private readonly ownsScriptCatalog: boolean;
   /** Maps .jsh command names to their registered script paths (for staleness detection). */
@@ -302,6 +317,10 @@ export class WasmShell {
 
   constructor(private options: WasmShellOptions) {
     this.vfsAdapter = new VfsAdapter(options.fs);
+    this.allowedCommands =
+      options.allowedCommands && !options.allowedCommands.includes('*')
+        ? new Set(options.allowedCommands)
+        : null;
     const initialCwd = options.cwd ?? '/';
     const initialEnv: Record<string, string> = {
       HOME: '/',
@@ -357,29 +376,41 @@ export class WasmShell {
     const mountCommand = this.createMountCustomCommand();
     const fetchFn = createProxiedFetch();
 
-    const customCommands = [
+    const allCustomCommands = [
       gitCommand,
       mountCommand,
       createSkillCommand(options.fs),
       createUpskillCommand(options.fs, fetchFn),
       ...supplementalCommands,
     ];
+    const customCommands = allCustomCommands.filter((c) => this.isCommandAllowed(c.name));
+
+    // When restricted, pass `commands:` so just-bash only registers allow-listed
+    // built-ins. When unrestricted, leave it undefined to get the full default set.
+    const allBuiltinNames = [
+      ...getCommandNames(),
+      ...getNetworkCommandNames(),
+    ] as readonly CommandName[];
+    const allowedBuiltinNames: CommandName[] | undefined = this.allowedCommands
+      ? allBuiltinNames.filter((n) => this.isCommandAllowed(n))
+      : undefined;
 
     this.bash = new Bash({
       fs: this.vfsAdapter,
       cwd: initialCwd,
       env: initialEnv,
       fetch: fetchFn,
+      commands: allowedBuiltinNames,
       customCommands,
     });
 
     // Wire up /usr/bin virtual directory with all registered command names
     const customCommandNames = customCommands.map((c) => c.name);
-    this.builtinCommandNames = new Set([
+    const registeredBuiltinNames = allowedBuiltinNames ?? [
       ...getCommandNames(),
       ...getNetworkCommandNames(),
-      ...customCommandNames,
-    ]);
+    ];
+    this.builtinCommandNames = new Set([...registeredBuiltinNames, ...customCommandNames]);
     this.vfsAdapter.setRegisteredCommandsFn(() => [...this.builtinCommandNames]);
 
     this.lastEnv = { ...initialEnv };
@@ -387,6 +418,11 @@ export class WasmShell {
 
     // Kick off initial .jsh registration (async, non-blocking)
     void this.syncJshCommands().catch(() => undefined);
+  }
+
+  /** True when `name` is registrable/executable under the current allow-list. */
+  private isCommandAllowed(name: string): boolean {
+    return this.allowedCommands === null || this.allowedCommands.has(name);
   }
 
   /**
@@ -410,6 +446,9 @@ export class WasmShell {
       const discoveryFs = this.options.jshDiscoveryFs ?? this.options.fs;
 
       for (const [name, scriptPath] of jshMap) {
+        // Skip commands blocked by the allow-list.
+        if (!this.isCommandAllowed(name)) continue;
+
         // Never shadow built-in or custom commands
         if (this.builtinCommandNames.has(name) && !this.registeredJshCommands.has(name)) {
           continue;
@@ -539,9 +578,9 @@ export class WasmShell {
     const all = await this.scriptCatalog.getJshCommands();
     const filtered = new Map<string, string>();
     for (const [name, path] of all) {
-      if (!this.builtinCommandNames.has(name)) {
-        filtered.set(name, path);
-      }
+      if (this.builtinCommandNames.has(name)) continue;
+      if (!this.isCommandAllowed(name)) continue;
+      filtered.set(name, path);
     }
     return filtered;
   }

--- a/packages/webapp/tests/shell/wasm-shell.test.ts
+++ b/packages/webapp/tests/shell/wasm-shell.test.ts
@@ -400,6 +400,10 @@ describe('WasmShell command allow-list', () => {
     });
   });
 
+  afterEach(async () => {
+    await fs.dispose();
+  });
+
   it('registers all commands when allowedCommands is omitted (default)', async () => {
     const shell = new WasmShell({ fs });
 
@@ -506,5 +510,38 @@ describe('WasmShell command allow-list', () => {
     expect(listing.stdout).toContain('ls');
     // `cat` exists in just-bash but was not allowed — it must not appear.
     expect(listing.stdout.split(/\s+/).filter((w) => w === 'cat')).toHaveLength(0);
+  });
+
+  it('blocks network commands (curl, wget) that just-bash auto-registers when fetch is set', async () => {
+    // just-bash's constructor unconditionally registers every network command
+    // when `fetch` or `network` is provided, regardless of `BashOptions.commands`.
+    // `WasmShell` always provides `fetch`, so without post-construction cleanup
+    // a scoop with `allowedCommands: ['echo']` could still run `curl`. This
+    // test guards the cleanup in `WasmShell`'s constructor. See Codex review
+    // of #433.
+    const shell = new WasmShell({ fs, allowedCommands: ['echo'] });
+
+    const curl = await shell.executeCommand('curl http://example.com');
+    expect(curl.exitCode).toBe(127);
+    expect(curl.stderr).toMatch(/curl/);
+    expect(curl.stderr).toMatch(/not found/i);
+
+    const wget = await shell.executeCommand('wget http://example.com');
+    expect(wget.exitCode).toBe(127);
+    expect(wget.stderr).toMatch(/wget/);
+    expect(wget.stderr).toMatch(/not found/i);
+  });
+
+  it('keeps network commands available when they are on the allow-list', async () => {
+    // Inverse of the above — when a network command IS allowed, the cleanup
+    // must not remove it. We don't try to actually fetch (would need a real
+    // network); it's enough that the command name is recognized at dispatch.
+    const shell = new WasmShell({ fs, allowedCommands: ['curl'] });
+
+    const result = await shell.executeCommand('curl');
+    // curl with no args exits with usage error (2) — NOT 127. If cleanup
+    // accidentally removed it, we'd see 127 / "command not found" instead.
+    expect(result.exitCode).not.toBe(127);
+    expect(result.stderr).not.toMatch(/not found/i);
   });
 });

--- a/packages/webapp/tests/shell/wasm-shell.test.ts
+++ b/packages/webapp/tests/shell/wasm-shell.test.ts
@@ -387,3 +387,124 @@ describe('WasmShell .jsh command registration', () => {
     expect(result.stdout).not.toContain('fake echo');
   });
 });
+
+let allowlistDbCounter = 0;
+
+describe('WasmShell command allow-list', () => {
+  let fs: VirtualFS;
+
+  beforeEach(async () => {
+    fs = await VirtualFS.create({
+      dbName: `test-allowlist-${allowlistDbCounter++}`,
+      wipe: true,
+    });
+  });
+
+  it('registers all commands when allowedCommands is omitted (default)', async () => {
+    const shell = new WasmShell({ fs });
+
+    expect((await shell.executeCommand('echo hi')).exitCode).toBe(0);
+    expect((await shell.executeCommand('pwd')).exitCode).toBe(0);
+    expect((await shell.executeCommand('ls /')).exitCode).toBe(0);
+  });
+
+  it('registers all commands when allowedCommands is the wildcard ["*"]', async () => {
+    const shell = new WasmShell({ fs, allowedCommands: ['*'] });
+
+    expect((await shell.executeCommand('echo hi')).exitCode).toBe(0);
+    expect((await shell.executeCommand('ls /')).exitCode).toBe(0);
+  });
+
+  it('blocks every command when allowedCommands is empty', async () => {
+    const shell = new WasmShell({ fs, allowedCommands: [] });
+
+    const result = await shell.executeCommand('echo hi');
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/command not found|not found/i);
+  });
+
+  it('allows listed commands and rejects unlisted ones with exit 127', async () => {
+    const shell = new WasmShell({ fs, allowedCommands: ['echo'] });
+
+    const ok = await shell.executeCommand('echo hello');
+    expect(ok.exitCode).toBe(0);
+    expect(ok.stdout).toContain('hello');
+
+    const blocked = await shell.executeCommand('ls /');
+    expect(blocked.exitCode).toBe(127);
+    expect(blocked.stderr).toMatch(/ls/);
+    expect(blocked.stderr).toMatch(/not found/i);
+  });
+
+  it('blocks disallowed commands inside a pipeline', async () => {
+    const shell = new WasmShell({ fs, allowedCommands: ['echo'] });
+
+    // `echo` is allowed but `cat` is not — the pipeline should fail at `cat`.
+    const piped = await shell.executeCommand('echo hi | cat');
+    expect(piped.exitCode).not.toBe(0);
+    expect(piped.stderr).toMatch(/cat/);
+    expect(piped.stderr).toMatch(/not found/i);
+  });
+
+  it('blocks disallowed commands inside command substitution', async () => {
+    const shell = new WasmShell({ fs, allowedCommands: ['echo'] });
+
+    // The substitution `$(ls /)` invokes `ls`, which must be blocked. Bash
+    // continues and runs `echo` with an empty substitution, but stderr
+    // carries the substitution failure.
+    const result = await shell.executeCommand('echo "before:$(ls /):after"');
+    expect(result.stderr).toMatch(/ls/);
+    expect(result.stderr).toMatch(/not found/i);
+    expect(result.stdout).toContain('before::after');
+  });
+
+  it('filters custom (supplemental) commands the same way as built-ins', async () => {
+    // Use a custom command — `mount` is created by MountCommands. Omitting it
+    // from the allow-list should block it; including it should keep it working.
+    const blockedShell = new WasmShell({ fs, allowedCommands: ['echo'] });
+    const blocked = await blockedShell.executeCommand('mount');
+    expect(blocked.exitCode).toBe(127);
+    expect(blocked.stderr).toMatch(/mount/);
+    expect(blocked.stderr).toMatch(/not found/i);
+
+    // When `mount` is allow-listed the custom command is dispatched — even if
+    // it returns non-zero for missing args, the stderr must not say
+    // "command not found" (that would mean the allow-list blocked it).
+    const allowedShell = new WasmShell({ fs, allowedCommands: ['mount'] });
+    const allowed = await allowedShell.executeCommand('mount');
+    expect(allowed.stderr).not.toMatch(/not found/i);
+  });
+
+  it('filters .jsh commands the same way as built-ins', async () => {
+    await fs.mkdir('/workspace/skills/allowlist-jsh/scripts', { recursive: true });
+    await fs.writeFile(
+      '/workspace/skills/allowlist-jsh/scripts/greet.jsh',
+      'console.log("hello from greet");'
+    );
+
+    // With `greet` blocked, the shell should not dispatch to the .jsh file.
+    const blocked = new WasmShell({ fs, allowedCommands: ['echo'] });
+    await blocked.syncJshCommands();
+    const blockedResult = await blocked.executeCommand('greet');
+    expect(blockedResult.exitCode).toBe(127);
+    expect(blockedResult.stderr).toMatch(/not found/i);
+
+    // With `greet` listed, the .jsh file is registered and runs normally.
+    const allowed = new WasmShell({ fs, allowedCommands: ['greet'] });
+    await allowed.syncJshCommands();
+    const allowedResult = await allowed.executeCommand('greet');
+    expect(allowedResult.exitCode).toBe(0);
+    expect(allowedResult.stdout).toContain('hello from greet');
+  });
+
+  it('omits blocked commands from the /usr/bin virtual directory', async () => {
+    const shell = new WasmShell({ fs, allowedCommands: ['echo', 'ls'] });
+
+    const listing = await shell.executeCommand('ls /usr/bin');
+    expect(listing.exitCode).toBe(0);
+    expect(listing.stdout).toContain('echo');
+    expect(listing.stdout).toContain('ls');
+    // `cat` exists in just-bash but was not allowed — it must not appear.
+    expect(listing.stdout.split(/\s+/).filter((w) => w === 'cat')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional `allowedCommands` to `WasmShellOptions` (and surfaces it on `ScoopConfig`) so each scoop can restrict which shell commands are executable. Leans on just-bash's native `commands:` filter — no AST walker, no vendored types.

- **Default (omitted / `['*']`):** every built-in, custom, and `.jsh` command is available. Existing behavior unchanged.
- **Restricted:** only listed names are registered on the underlying `Bash` instance. Anything else fails with exit code 127 (`command not found`) at dispatch — including inside pipelines, subshells, and command substitution, because just-bash resolves every simple command through the same registry.
- Applies uniformly to:
  - just-bash built-ins (`getCommandNames()` + `getNetworkCommandNames()`)
  - slicc custom commands (`git`, `mount`, skills, supplemental)
  - `.jsh` auto-discovered scripts

4 files, +176/-8:

- `packages/webapp/src/shell/wasm-shell.ts` — the filter plus `isCommandAllowed()` gate on jsh registration/fallback
- `packages/webapp/src/scoops/types.ts` — new `ScoopConfig.allowedCommands`
- `packages/webapp/src/scoops/scoop-context.ts` — thread the config field through when constructing the scoop's `WasmShell`
- `packages/webapp/tests/shell/wasm-shell.test.ts` — 9 new tests covering default / wildcard / empty / pipeline / substitution / custom / `.jsh` / `/usr/bin`

Motivation: the existing allow-list infrastructure on `droid-2`/PR #430 parses every bash invocation into an AST and walks every node looking for disallowed substitutions (~600 LOC + vendored just-bash internal type surface). That work is redundant with just-bash's `BashOptions.commands` primitive, which filters the command registry directly. Disallowed names in `$(...)`, `<(...)`, subshells, eval, etc. all resolve through the same registry and therefore fail the same way.

## Test plan

- [x] `npm run test` — 2624 pass / 2 skipped (including 9 new `WasmShell command allow-list` cases)
- [x] `npx prettier --check` on all changed files
- [x] `npm run typecheck` — no new errors (pre-existing unrelated `lucide` type resolution error on `main` untouched)
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`

🤖 Generated with [Claude Code](https://claude.com/claude-code)