### PR TITLE
chore(ui): replace ScoopsPanel.createScoop with createCone

### DIFF
--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1231,7 +1231,7 @@ async function main(): Promise<void> {
   if (allowProviderlessTrayJoin) {
     log.info('Skipping local cone bootstrap while joining a tray without a configured provider');
   } else if (!hasCone) {
-    const cone = await layout.panels.scoops.createScoop('Cone', true);
+    const cone = await layout.panels.scoops.createCone();
     selectedScoop = cone;
     log.info('Created cone');
   } else {

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -111,7 +111,7 @@ export class OffscreenClient {
     return this.scoopStatuses.get(jid) === 'processing';
   }
 
-  /** Called by ScoopsPanel.createScoop(). Adds optimistically so the UI
+  /** Called by ScoopsPanel.createCone(). Adds optimistically so the UI
    *  updates immediately, then sends to offscreen. The real scoop (with a
    *  different JID) replaces the optimistic one when scoop-created arrives. */
   async registerScoop(scoop: RegisteredScoop): Promise<void> {

--- a/packages/webapp/src/ui/scoops-panel.ts
+++ b/packages/webapp/src/ui/scoops-panel.ts
@@ -588,43 +588,32 @@ export class ScoopsPanel {
     log.info('Scoop deleted', { jid, name: scoop.name });
   }
 
-  /** Create a new scoop */
-  async createScoop(name: string, isCone = false): Promise<RegisteredScoop> {
+  /**
+   * Bootstrap the cone. Only ever used once, from `main.ts`, when the
+   * orchestrator starts with no existing cone on disk. Non-cone scoops come
+   * exclusively from the agent's `scoop_scoop` tool.
+   */
+  async createCone(name = 'Cone'): Promise<RegisteredScoop> {
     if (!this.orchestrator) {
       throw new Error('Orchestrator not set');
     }
 
-    const folder = isCone ? 'cone' : this.sanitizeFolderName(name) + '-scoop';
-    const jid = isCone ? `cone_${Date.now()}` : `scoop_${folder}_${Date.now()}`;
-
     const scoop: RegisteredScoop = {
-      jid,
+      jid: `cone_${Date.now()}`,
       name,
-      folder,
-      trigger: isCone ? undefined : `@${folder}`,
-      requiresTrigger: !isCone,
-      isCone,
-      type: isCone ? 'cone' : 'scoop',
-      assistantLabel: isCone ? 'sliccy' : folder,
+      folder: 'cone',
+      requiresTrigger: false,
+      isCone: true,
+      type: 'cone',
+      assistantLabel: 'sliccy',
       addedAt: new Date().toISOString(),
     };
 
     await this.orchestrator.registerScoop(scoop);
     this.refreshScoops();
 
-    log.info('Scoop created', { jid, name, isCone });
+    log.info('Cone created', { jid: scoop.jid, name });
     return scoop;
-  }
-
-  /** Sanitize a name into a valid folder name */
-  private sanitizeFolderName(name: string): string {
-    return (
-      name
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '')
-        .slice(0, 50) || 'scoop'
-    );
   }
 
   /** Render the panel as an icon-only nav rail (UXC design). */


### PR DESCRIPTION
## Summary

`ScoopsPanel.createScoop(name, isCone?)` has a single caller — `main.ts`'s bootstrap-cone path — and it always passes `isCone=true`. No UI button creates non-cone scoops through it; those come exclusively from the agent's `scoop_scoop` tool. The `isCone=false` branch is dead and the method lies about its scope.

This PR makes the method truthful:
- Rename `createScoop(name, isCone?)` → `createCone(name = 'Cone')`
- Drop the `isCone=false` arm (trigger / requiresTrigger / non-cone folder / non-cone jid branches)
- Remove the `sanitizeFolderName` helper, which existed only for the removed branch
- Update the one caller in `main.ts`
- Fix a stale JSDoc reference in `offscreen-client.ts`

Net: `+15 / -26` across three files.

Groundwork for upcoming per-scoop `visiblePaths` / `writablePaths` config — we want `scoop_scoop` to be the sole non-cone creation path so default injection lives in exactly one place.

## Test plan

- [x] `npm run typecheck` — no new errors (pre-existing unrelated `lucide` resolution error untouched)
- [x] `npx vitest run packages/webapp/tests/ui/` — 360/360 pass
- [x] `npx prettier --check` on changed files
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`

🤖 Generated with [Claude Code](https://claude.com/claude-code)