### PR TITLE
feat(scoops): per-scoop visiblePaths (pure replace) + restore compat

### DIFF
--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -171,8 +171,12 @@ export class Orchestrator {
   }
 
   /**
-   * One-shot compat migration for `ScoopConfig`. Mutates the scoop record in
-   * place so the next `saveScoop` persists the normalized shape.
+   * One-shot in-memory compat migration for `ScoopConfig`. Mutates the scoop
+   * record in place so the rest of the runtime sees the normalized shape;
+   * the DB copy stays legacy until some other operation happens to call
+   * `db.saveScoop` (e.g. a user-initiated scoop update). That's fine — this
+   * migration is idempotent and cheap, so re-running it on every boot until
+   * the record gets rewritten is a non-issue.
    *
    * Gated on {@link RegisteredScoop.configSchemaVersion} rather than a truthy
    * check on individual fields, so a record explicitly saved with

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -9,7 +9,13 @@
  * - Owns a single shared VirtualFS instance
  */
 
-import type { RegisteredScoop, ChannelMessage, ScoopTabState, ScheduledTask } from './types.js';
+import {
+  CURRENT_SCOOP_CONFIG_VERSION,
+  type RegisteredScoop,
+  type ChannelMessage,
+  type ScoopTabState,
+  type ScheduledTask,
+} from './types.js';
 import * as db from './db.js';
 import { createLogger } from '../core/logger.js';
 import { ScoopContext, type ScoopContextCallbacks } from './scoop-context.js';
@@ -118,12 +124,7 @@ export class Orchestrator {
         scoop.requiresTrigger = false;
         scoop.assistantLabel = scoop.assistantLabel || 'sliccy';
       }
-      // Restore compat: non-cone scoops saved before `visiblePaths` existed
-      // default to the historical `['/workspace/']` so existing scoops keep
-      // seeing skills. Written back on the next `saveScoop`.
-      if (!scoop.isCone && !scoop.config?.visiblePaths) {
-        scoop.config = { ...scoop.config, visiblePaths: ['/workspace/'] };
-      }
+      this.migrateScoopConfig(scoop);
       this.scoops.set(scoop.jid, scoop);
       this.messageQueues.set(scoop.jid, []);
 
@@ -167,6 +168,35 @@ export class Orchestrator {
 
     // Start polling for pending messages
     this.startMessageLoop();
+  }
+
+  /**
+   * One-shot compat migration for `ScoopConfig`. Mutates the scoop record in
+   * place so the next `saveScoop` persists the normalized shape.
+   *
+   * Gated on {@link RegisteredScoop.configSchemaVersion} rather than a truthy
+   * check on individual fields, so a record explicitly saved with
+   * `visiblePaths: undefined` (or an empty array) under the current schema
+   * keeps that authoritative value — "no read-only paths" stays "no read-only
+   * paths." Only records that predate a field get the historical default
+   * filled in.
+   *
+   * Cones have no `ScoopConfig` path surface at all; they ignore the version.
+   */
+  private migrateScoopConfig(scoop: RegisteredScoop): void {
+    if (scoop.isCone) return;
+    const version = scoop.configSchemaVersion ?? 0;
+    if (version >= CURRENT_SCOOP_CONFIG_VERSION) return;
+
+    if (version < 1) {
+      // Pre-visiblePaths era: default to the historical `/workspace/` read
+      // access so skills stay visible after restart.
+      scoop.config = {
+        ...scoop.config,
+        visiblePaths: scoop.config?.visiblePaths ?? ['/workspace/'],
+      };
+    }
+    scoop.configSchemaVersion = CURRENT_SCOOP_CONFIG_VERSION;
   }
 
   /** Ensure root directory structure exists on the shared FS */

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -118,6 +118,12 @@ export class Orchestrator {
         scoop.requiresTrigger = false;
         scoop.assistantLabel = scoop.assistantLabel || 'sliccy';
       }
+      // Restore compat: non-cone scoops saved before `visiblePaths` existed
+      // default to the historical `['/workspace/']` so existing scoops keep
+      // seeing skills. Written back on the next `saveScoop`.
+      if (!scoop.isCone && !scoop.config?.visiblePaths) {
+        scoop.config = { ...scoop.config, visiblePaths: ['/workspace/'] };
+      }
       this.scoops.set(scoop.jid, scoop);
       this.messageQueues.set(scoop.jid, []);
 
@@ -501,10 +507,17 @@ export class Orchestrator {
 
     const contextId = `scoop-${scoop.folder}-${Date.now()}`;
 
-    // Create the appropriate filesystem for this scoop
+    // Create the appropriate filesystem for this scoop.
+    // Cone gets unrestricted access; non-cone scoops use a RestrictedFS whose
+    // read-only prefixes come straight from config (pure replace — defaults
+    // live in `scoop_scoop` and in the restore backfill, not here).
     const fs = scoop.isCone
-      ? this.sharedFs // Cone gets unrestricted access
-      : new RestrictedFS(this.sharedFs, [`/scoops/${scoop.folder}/`, '/shared/'], ['/workspace/']);
+      ? this.sharedFs
+      : new RestrictedFS(
+          this.sharedFs,
+          [`/scoops/${scoop.folder}/`, '/shared/'],
+          scoop.config?.visiblePaths ? [...scoop.config.visiblePaths] : []
+        );
 
     // Create the scoop context with full callbacks
     const contextCallbacks: ScoopContextCallbacks = {

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ToolDefinition } from '../core/types.js';
-import type { RegisteredScoop } from './types.js';
+import { CURRENT_SCOOP_CONFIG_VERSION, type RegisteredScoop } from './types.js';
 import { createLogger } from '../core/logger.js';
 
 const log = createLogger('scoop-management-tools');
@@ -205,6 +205,9 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
             // skills. The orchestrator itself does not inject any defaults —
             // keeping the default at the tool layer means the `ScoopConfig`
             // surface stays pure-replace (what you set is what you get).
+            // Stamping `configSchemaVersion` tells the orchestrator this
+            // record was created with explicit config and its `visiblePaths`
+            // value is authoritative — no compat migration on restore.
             const newScoop = await onScoopScoop({
               name,
               folder,
@@ -218,6 +221,7 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
                 ...(model ? { modelId: model } : {}),
                 visiblePaths: ['/workspace/'],
               },
+              configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
             });
 
             log.info('Scoop created', { name, folder });

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -200,6 +200,11 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
               .slice(0, 50) + '-scoop';
 
           try {
+            // Every scoop created through the tool gets the standard sandbox:
+            // read-only access to `/workspace/` so it can see the cone's
+            // skills. The orchestrator itself does not inject any defaults —
+            // keeping the default at the tool layer means the `ScoopConfig`
+            // surface stays pure-replace (what you set is what you get).
             const newScoop = await onScoopScoop({
               name,
               folder,
@@ -209,7 +214,10 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
               requiresTrigger: true,
               assistantLabel: folder,
               addedAt: new Date().toISOString(),
-              config: model ? { modelId: model } : undefined,
+              config: {
+                ...(model ? { modelId: model } : {}),
+                visiblePaths: ['/workspace/'],
+              },
             });
 
             log.info('Scoop created', { name, folder });

--- a/packages/webapp/src/scoops/types.ts
+++ b/packages/webapp/src/scoops/types.ts
@@ -6,6 +6,17 @@
  * and restricted filesystem access.
  */
 
+/**
+ * Current `ScoopConfig` schema generation. Bumped whenever a new field is
+ * introduced that demands a compat backfill for records saved before it
+ * existed. Scoops created today are stamped with this value; the orchestrator
+ * runs one-shot migrations for any record whose version is strictly lower
+ * and never touches records already at the current version.
+ *
+ * - `1`: `visiblePaths` is authoritative (may be an explicit empty list).
+ */
+export const CURRENT_SCOOP_CONFIG_VERSION = 1;
+
 /** Registered scoop metadata */
 export interface RegisteredScoop {
   /** Unique identifier */
@@ -28,6 +39,14 @@ export interface RegisteredScoop {
   addedAt: string;
   /** Scoop-specific config */
   config?: ScoopConfig;
+  /**
+   * Generation of `ScoopConfig` that produced this record. `undefined` means
+   * "truly legacy" — a record saved before any of the path-config fields
+   * existed. The orchestrator migrates up to {@link CURRENT_SCOOP_CONFIG_VERSION}
+   * on restore; records already at the current version are left alone so
+   * explicit `undefined`/empty values stay authoritative.
+   */
+  configSchemaVersion?: number;
 }
 
 /** Per-scoop configuration */

--- a/packages/webapp/src/scoops/types.ts
+++ b/packages/webapp/src/scoops/types.ts
@@ -40,6 +40,14 @@ export interface ScoopConfig {
   assistantName?: string;
   /** Model ID override (e.g., "claude-sonnet-4-20250514"). Uses globally selected model if not set. */
   modelId?: string;
+  /**
+   * VFS paths this scoop can READ (but not write). Pure replace — when
+   * `undefined` the scoop gets no read-only paths at all. The `scoop_scoop`
+   * tool injects the standard `['/workspace/']` default when creating scoops
+   * so existing agent-facing behavior is preserved. Cone scoops ignore this
+   * field — they always use an unrestricted filesystem.
+   */
+  visiblePaths?: readonly string[];
 }
 
 /** Message from any channel */

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -475,7 +475,7 @@ describe('Orchestrator session-restore compat for visiblePaths', () => {
     return orch;
   }
 
-  it('backfills visiblePaths = ["/workspace/"] for legacy non-cone scoops', async () => {
+  it('backfills visiblePaths = ["/workspace/"] for truly-legacy non-cone scoops (no configSchemaVersion)', async () => {
     const legacy: RegisteredScoop = {
       jid: 'scoop_legacy_1',
       name: 'legacy',
@@ -486,16 +486,18 @@ describe('Orchestrator session-restore compat for visiblePaths', () => {
       requiresTrigger: true,
       assistantLabel: 'legacy-scoop',
       addedAt: new Date().toISOString(),
-      // Deliberately no `config` — mirrors a scoop saved before this field existed.
+      // Deliberately no `config` and no `configSchemaVersion` — mirrors a
+      // scoop saved before the path-config fields existed.
     };
     await saveScoop(legacy);
 
     const o = await initOrchestrator();
     const restored = o.getScoop('scoop_legacy_1');
     expect(restored?.config?.visiblePaths).toEqual(['/workspace/']);
+    expect(restored?.configSchemaVersion).toBe(1);
   });
 
-  it('preserves an explicitly-set visiblePaths (no overwrite)', async () => {
+  it('preserves an explicitly-set visiblePaths under the current schema version', async () => {
     const configured: RegisteredScoop = {
       jid: 'scoop_configured_1',
       name: 'configured',
@@ -507,12 +509,59 @@ describe('Orchestrator session-restore compat for visiblePaths', () => {
       assistantLabel: 'configured-scoop',
       addedAt: new Date().toISOString(),
       config: { visiblePaths: ['/custom/'] },
+      configSchemaVersion: 1,
     };
     await saveScoop(configured);
 
     const o = await initOrchestrator();
     const restored = o.getScoop('scoop_configured_1');
     expect(restored?.config?.visiblePaths).toEqual(['/custom/']);
+  });
+
+  it('preserves an explicit undefined visiblePaths on a current-schema record (no silent backfill)', async () => {
+    // A scoop created deliberately with no read-only paths under the new
+    // schema must keep that contract — the migration only fires for truly
+    // legacy records (versions below the current schema).
+    const strict: RegisteredScoop = {
+      jid: 'scoop_strict_1',
+      name: 'strict',
+      folder: 'strict-scoop',
+      trigger: '@strict-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: true,
+      assistantLabel: 'strict-scoop',
+      addedAt: new Date().toISOString(),
+      config: { modelId: 'claude-sonnet-4-6' }, // has config, no visiblePaths
+      configSchemaVersion: 1,
+    };
+    await saveScoop(strict);
+
+    const o = await initOrchestrator();
+    const restored = o.getScoop('scoop_strict_1');
+    expect(restored?.config?.visiblePaths).toBeUndefined();
+    expect(restored?.configSchemaVersion).toBe(1);
+  });
+
+  it('preserves an explicit empty-array visiblePaths across restart', async () => {
+    const strict: RegisteredScoop = {
+      jid: 'scoop_empty_1',
+      name: 'empty',
+      folder: 'empty-scoop',
+      trigger: '@empty-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: true,
+      assistantLabel: 'empty-scoop',
+      addedAt: new Date().toISOString(),
+      config: { visiblePaths: [] },
+      configSchemaVersion: 1,
+    };
+    await saveScoop(strict);
+
+    const o = await initOrchestrator();
+    const restored = o.getScoop('scoop_empty_1');
+    expect(restored?.config?.visiblePaths).toEqual([]);
   });
 
   it('does not touch cone records (cones ignore visiblePaths)', async () => {
@@ -531,5 +580,7 @@ describe('Orchestrator session-restore compat for visiblePaths', () => {
     const o = await initOrchestrator();
     const restored = o.getScoop('cone_legacy_1');
     expect(restored?.config?.visiblePaths).toBeUndefined();
+    // Cones never get a schema stamp — they have no path-config surface.
+    expect(restored?.configSchemaVersion).toBeUndefined();
   });
 });

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -5,7 +5,7 @@
  * Uses the DB layer directly to verify message persistence and routing.
  */
 
-import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import 'fake-indexeddb/auto';
 import {
   initDB,
@@ -429,12 +429,28 @@ describe('Scoop idle detection', () => {
 
 describe('Orchestrator session-restore compat for visiblePaths', () => {
   let orch: Orchestrator;
+  let priorWindow: unknown;
+  let windowWasShimmed = false;
 
   beforeAll(() => {
     // TaskScheduler.start() calls window.setInterval; vitest runs in node.
-    // Expose a minimal shim so orchestrator.init() can boot.
+    // Expose a minimal shim so orchestrator.init() can boot, remembering the
+    // prior value so afterAll can restore it (vitest may share a worker
+    // across test files and we don't want to leak a globalThis.window shim).
     if (typeof (globalThis as any).window === 'undefined') {
+      priorWindow = (globalThis as any).window;
       (globalThis as any).window = globalThis;
+      windowWasShimmed = true;
+    }
+  });
+
+  afterAll(() => {
+    if (windowWasShimmed) {
+      if (priorWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = priorWindow;
+      }
     }
   });
 
@@ -450,8 +466,11 @@ describe('Orchestrator session-restore compat for visiblePaths', () => {
   });
 
   afterEach(async () => {
-    // Stop the scheduler's poll timer so tests don't leak across runs.
+    // Stop the scheduler's poll timer AND dispose the shared VirtualFS so
+    // BroadcastChannel / IndexedDB handles don't leak across test runs.
+    const sharedFs = orch?.getSharedFS();
     await orch?.shutdown();
+    await sharedFs?.dispose();
   });
 
   function noopCallbacks() {

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -5,10 +5,16 @@
  * Uses the DB layer directly to verify message persistence and routing.
  */
 
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import 'fake-indexeddb/auto';
-import { initDB, saveScoop, getMessagesForScoop, clearAllMessages } from '../../src/scoops/db.js';
-import { SCOOP_IDLE_TIMEOUT_MS } from '../../src/scoops/orchestrator.js';
+import {
+  initDB,
+  saveScoop,
+  getMessagesForScoop,
+  clearAllMessages,
+  getAllScoops,
+} from '../../src/scoops/db.js';
+import { Orchestrator, SCOOP_IDLE_TIMEOUT_MS } from '../../src/scoops/orchestrator.js';
 import type { RegisteredScoop, ChannelMessage } from '../../src/scoops/types.js';
 
 // Test helpers — we can't instantiate a full Orchestrator (needs VirtualFS, DOM, etc.)
@@ -418,5 +424,112 @@ describe('Scoop idle detection', () => {
     // Verify it does NOT show up in the scoop's messages
     const scoopMessages = await getMessagesForScoop(testScoop.jid);
     expect(scoopMessages).toHaveLength(0);
+  });
+});
+
+describe('Orchestrator session-restore compat for visiblePaths', () => {
+  let orch: Orchestrator;
+
+  beforeAll(() => {
+    // TaskScheduler.start() calls window.setInterval; vitest runs in node.
+    // Expose a minimal shim so orchestrator.init() can boot.
+    if (typeof (globalThis as any).window === 'undefined') {
+      (globalThis as any).window = globalThis;
+    }
+  });
+
+  beforeEach(async () => {
+    // Fresh DB state — clear any scoops from previous tests so we control
+    // exactly what gets hydrated.
+    await initDB();
+    const existing = await getAllScoops();
+    const { deleteScoop } = await import('../../src/scoops/db.js');
+    for (const jid of Object.keys(existing)) {
+      await deleteScoop(jid);
+    }
+  });
+
+  afterEach(async () => {
+    // Stop the scheduler's poll timer so tests don't leak across runs.
+    await orch?.shutdown();
+  });
+
+  function noopCallbacks() {
+    return {
+      onResponse: vi.fn(),
+      onResponseDone: vi.fn(),
+      onSendMessage: vi.fn(),
+      onStatusChange: vi.fn(),
+      onError: vi.fn(),
+      getBrowserAPI: vi.fn(() => ({}) as any),
+    };
+  }
+
+  async function initOrchestrator(): Promise<Orchestrator> {
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(container, noopCallbacks());
+    await orch.init();
+    return orch;
+  }
+
+  it('backfills visiblePaths = ["/workspace/"] for legacy non-cone scoops', async () => {
+    const legacy: RegisteredScoop = {
+      jid: 'scoop_legacy_1',
+      name: 'legacy',
+      folder: 'legacy-scoop',
+      trigger: '@legacy-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: true,
+      assistantLabel: 'legacy-scoop',
+      addedAt: new Date().toISOString(),
+      // Deliberately no `config` — mirrors a scoop saved before this field existed.
+    };
+    await saveScoop(legacy);
+
+    const o = await initOrchestrator();
+    const restored = o.getScoop('scoop_legacy_1');
+    expect(restored?.config?.visiblePaths).toEqual(['/workspace/']);
+  });
+
+  it('preserves an explicitly-set visiblePaths (no overwrite)', async () => {
+    const configured: RegisteredScoop = {
+      jid: 'scoop_configured_1',
+      name: 'configured',
+      folder: 'configured-scoop',
+      trigger: '@configured-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: true,
+      assistantLabel: 'configured-scoop',
+      addedAt: new Date().toISOString(),
+      config: { visiblePaths: ['/custom/'] },
+    };
+    await saveScoop(configured);
+
+    const o = await initOrchestrator();
+    const restored = o.getScoop('scoop_configured_1');
+    expect(restored?.config?.visiblePaths).toEqual(['/custom/']);
+  });
+
+  it('does not touch cone records (cones ignore visiblePaths)', async () => {
+    const legacyCone: RegisteredScoop = {
+      jid: 'cone_legacy_1',
+      name: 'Cone',
+      folder: 'cone',
+      isCone: true,
+      type: 'cone',
+      requiresTrigger: false,
+      assistantLabel: 'sliccy',
+      addedAt: new Date().toISOString(),
+    };
+    await saveScoop(legacyCone);
+
+    const o = await initOrchestrator();
+    const restored = o.getScoop('cone_legacy_1');
+    expect(restored?.config?.visiblePaths).toBeUndefined();
   });
 });

--- a/packages/webapp/tests/scoops/scoop-management-tools.test.ts
+++ b/packages/webapp/tests/scoops/scoop-management-tools.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { createScoopManagementTools } from '../../src/scoops/scoop-management-tools.js';
-import type { RegisteredScoop } from '../../src/scoops/types.js';
+import { CURRENT_SCOOP_CONFIG_VERSION, type RegisteredScoop } from '../../src/scoops/types.js';
 
 const cone: RegisteredScoop = {
   jid: 'cone_main_1',
@@ -67,5 +67,13 @@ describe('scoop_scoop tool — config defaults', () => {
     const created = onScoopScoop.mock.calls[0][0];
     expect(created.isCone).toBe(false);
     expect(created.folder).toBe('hero-block-1-scoop');
+  });
+
+  it('stamps the current configSchemaVersion so the orchestrator skips compat migration', async () => {
+    const { tool, onScoopScoop } = findScoopScoopTool();
+    await tool.execute({ name: 'hero-block' });
+
+    const created = onScoopScoop.mock.calls[0][0];
+    expect(created.configSchemaVersion).toBe(CURRENT_SCOOP_CONFIG_VERSION);
   });
 });

--- a/packages/webapp/tests/scoops/scoop-management-tools.test.ts
+++ b/packages/webapp/tests/scoops/scoop-management-tools.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the `scoop_scoop` management tool — specifically the defaults it
+ * injects into each newly created scoop's `ScoopConfig`. The orchestrator
+ * layer uses pure-replace semantics, so any default the historical behavior
+ * relied on MUST be injected here.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createScoopManagementTools } from '../../src/scoops/scoop-management-tools.js';
+import type { RegisteredScoop } from '../../src/scoops/types.js';
+
+const cone: RegisteredScoop = {
+  jid: 'cone_main_1',
+  name: 'Main',
+  folder: 'main',
+  isCone: true,
+  type: 'cone',
+  requiresTrigger: false,
+  assistantLabel: 'sliccy',
+  addedAt: new Date().toISOString(),
+};
+
+function findScoopScoopTool() {
+  const onScoopScoop = vi.fn(
+    async (scoop: Omit<RegisteredScoop, 'jid'>): Promise<RegisteredScoop> => ({
+      ...scoop,
+      jid: `scoop_${scoop.folder}_${Date.now()}`,
+    })
+  );
+
+  const tools = createScoopManagementTools({
+    scoop: cone,
+    onSendMessage: vi.fn(),
+    getScoops: () => [cone],
+    onScoopScoop,
+  });
+
+  const tool = tools.find((t) => t.name === 'scoop_scoop');
+  if (!tool) throw new Error('scoop_scoop tool missing from cone toolset');
+  return { tool, onScoopScoop };
+}
+
+describe('scoop_scoop tool — config defaults', () => {
+  it('injects visiblePaths: ["/workspace/"] when no model is specified', async () => {
+    const { tool, onScoopScoop } = findScoopScoopTool();
+    await tool.execute({ name: 'hero-block' });
+
+    expect(onScoopScoop).toHaveBeenCalledTimes(1);
+    const created = onScoopScoop.mock.calls[0][0];
+    expect(created.config).toBeDefined();
+    expect(created.config?.visiblePaths).toEqual(['/workspace/']);
+  });
+
+  it('keeps visiblePaths when a model is also specified', async () => {
+    const { tool, onScoopScoop } = findScoopScoopTool();
+    await tool.execute({ name: 'hero-block', model: 'claude-sonnet-4-6' });
+
+    const created = onScoopScoop.mock.calls[0][0];
+    expect(created.config?.visiblePaths).toEqual(['/workspace/']);
+    expect(created.config?.modelId).toBe('claude-sonnet-4-6');
+  });
+
+  it('passes an isCone=false scoop with a sanitized folder', async () => {
+    const { tool, onScoopScoop } = findScoopScoopTool();
+    await tool.execute({ name: 'Hero Block #1' });
+
+    const created = onScoopScoop.mock.calls[0][0];
+    expect(created.isCone).toBe(false);
+    expect(created.folder).toBe('hero-block-1-scoop');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `ScoopConfig.visiblePaths?: readonly string[]` — the list of VFS paths a non-cone scoop can READ but not write. Orchestrator wires it straight to `RestrictedFS`'s `readOnlyPaths` with **pure-replace semantics**: `undefined` means no read-only paths at all. Defaults live at the boundary, not in the orchestrator.

- **`scoop_scoop` tool** injects the historical `['/workspace/']` default when creating scoops, preserving existing agent-facing behavior (scoops still see the cone's skills).
- **Orchestrator session restore** backfills `['/workspace/']` for non-cone scoops saved before this field existed. The next `saveScoop` persists the normalized shape — no DB migration needed.
- **Cones** ignore the field entirely — they always use an unrestricted VFS, no RestrictedFS at all.

## Files touched (+220 / -7)

- `packages/webapp/src/scoops/types.ts` — add `visiblePaths` to `ScoopConfig`.
- `packages/webapp/src/scoops/orchestrator.ts` — pure-replace wiring + restore backfill.
- `packages/webapp/src/scoops/scoop-management-tools.ts` — `scoop_scoop` injects the `['/workspace/']` default.
- `packages/webapp/tests/scoops/scoop-management-tools.test.ts` — 3 new tests verifying the tool's default injection.
- `packages/webapp/tests/scoops/orchestrator.test.ts` — 3 new tests verifying the restore backfill (legacy / explicit / cone-skip).

## Depends on

Logically follows #434 (cleaning up the dead non-cone UI flow so `scoop_scoop` is the sole non-cone creation path and the only place the default is injected). Technically mergeable independently — no file overlap with #434.

## Test plan

- [x] `npm run test` — 2621 pass / 2 skipped (6 new tests)
- [x] `npx prettier --check` on changed files
- [x] `npm run typecheck` — no new errors (pre-existing unrelated `lucide` resolution error untouched)
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`

🤖 Generated with [Claude Code](https://claude.com/claude-code)