### PR TITLE
chore(extension): scope panel→offscreen scoop-create to cones

### DIFF
--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -35,10 +35,15 @@ export interface UserMessageMsg {
   messageId: string;
 }
 
-export interface ScoopCreateMsg {
-  type: 'scoop-create';
+/**
+ * Panel → offscreen: bootstrap the cone. Sent exactly once per side-panel
+ * session when no cone exists on disk yet. Non-cone scoops are created by
+ * the agent's `scoop_scoop` tool inside the offscreen orchestrator, not
+ * through this message.
+ */
+export interface ConeCreateMsg {
+  type: 'cone-create';
   name: string;
-  isCone: boolean;
 }
 
 export interface ScoopFeedMsg {
@@ -130,7 +135,7 @@ export interface HandoffDismissMsg {
 
 export type PanelToOffscreenMessage =
   | UserMessageMsg
-  | ScoopCreateMsg
+  | ConeCreateMsg
   | ScoopFeedMsg
   | ScoopDropMsg
   | AbortMsg

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -152,7 +152,7 @@ export class OffscreenBridge {
 
         // Also emit the full scoop list so the panel can update its switcher.
         // This catches agent-created scoops (via scoop_scoop tool) that bypass
-        // the panel's scoop-create → scoop-created flow.
+        // the panel's cone-create → scoop-created flow.
         bridge.emitScoopList();
       },
 
@@ -390,21 +390,20 @@ export class OffscreenBridge {
         break;
       }
 
-      case 'scoop-create': {
-        const folder =
-          msg.name
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, '-')
-            .replace(/-+$/, '') + (msg.isCone ? '' : '-scoop');
+      case 'cone-create': {
+        // This path is cone-only. Non-cone scoops are created inside the
+        // offscreen orchestrator by the agent's `scoop_scoop` tool, which is
+        // where their path-config defaults (visiblePaths / writablePaths) get
+        // injected. Building a non-cone scoop here would bypass that layer
+        // and yield a sandbox with no writable paths — see review of #436.
         const scoop: RegisteredScoop = {
-          jid: msg.isCone ? `cone_${Date.now()}` : `scoop_${folder}_${Date.now()}`,
+          jid: `cone_${Date.now()}`,
           name: msg.name,
-          folder,
-          isCone: msg.isCone,
-          type: msg.isCone ? 'cone' : 'scoop',
-          trigger: msg.isCone ? undefined : `@${folder}`,
-          requiresTrigger: !msg.isCone,
-          assistantLabel: msg.isCone ? 'sliccy' : folder,
+          folder: 'cone',
+          isCone: true,
+          type: 'cone',
+          requiresTrigger: false,
+          assistantLabel: 'sliccy',
           addedAt: new Date().toISOString(),
         };
         await this.orchestrator.registerScoop(scoop);

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -395,7 +395,7 @@ export class OffscreenBridge {
         // offscreen orchestrator by the agent's `scoop_scoop` tool, which is
         // where their path-config defaults (visiblePaths / writablePaths) get
         // injected. Building a non-cone scoop here would bypass that layer
-        // and yield a sandbox with no writable paths — see review of #436.
+        // and yield a sandbox with no writable paths; see #436.
         const scoop: RegisteredScoop = {
           jid: `cone_${Date.now()}`,
           name: msg.name,

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -111,15 +111,23 @@ export class OffscreenClient {
     return this.scoopStatuses.get(jid) === 'processing';
   }
 
-  /** Called by ScoopsPanel.createCone(). Adds optimistically so the UI
-   *  updates immediately, then sends to offscreen. The real scoop (with a
-   *  different JID) replaces the optimistic one when scoop-created arrives. */
+  /** Bootstrap the cone. Only called once per session when no cone exists on
+   *  disk. Non-cone scoops are created inside the offscreen orchestrator by
+   *  the agent's `scoop_scoop` tool — never through this path. Adds
+   *  optimistically so the UI updates immediately, then sends to offscreen.
+   *  The real scoop (with a different JID) replaces the optimistic one when
+   *  `scoop-created` arrives. */
   async registerScoop(scoop: RegisteredScoop): Promise<void> {
+    if (!scoop.isCone) {
+      throw new Error(
+        'OffscreenClient.registerScoop is cone-only; use scoop_scoop for non-cone scoops'
+      );
+    }
     if (!this.scoops.find((s) => s.name === scoop.name)) {
       this.scoops.push(scoop);
       this.scoopStatuses.set(scoop.jid, 'initializing');
     }
-    this.send({ type: 'scoop-create', name: scoop.name, isCone: scoop.isCone });
+    this.send({ type: 'cone-create', name: scoop.name });
   }
 
   /** Called by ScoopsPanel delete button. */

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -274,8 +274,8 @@ describe('OffscreenClient', () => {
     ]);
   });
 
-  it('registerScoop sends a cone-create message (cone-only path)', () => {
-    client.registerScoop({
+  it('registerScoop sends a cone-create message (cone-only path)', async () => {
+    await client.registerScoop({
       jid: 'temp',
       name: 'Cone',
       folder: 'cone',

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -274,21 +274,37 @@ describe('OffscreenClient', () => {
     ]);
   });
 
-  it('registerScoop sends scoop-create message', () => {
+  it('registerScoop sends a cone-create message (cone-only path)', () => {
     client.registerScoop({
       jid: 'temp',
-      name: 'Test',
-      folder: 'test-scoop',
-      isCone: false,
-      type: 'scoop',
-      requiresTrigger: true,
-      assistantLabel: 'test-scoop',
+      name: 'Cone',
+      folder: 'cone',
+      isCone: true,
+      type: 'cone',
+      requiresTrigger: false,
+      assistantLabel: 'sliccy',
       addedAt: '',
     });
     const envelope = sentMessages[0] as { payload: any };
-    expect(envelope.payload.type).toBe('scoop-create');
-    expect(envelope.payload.name).toBe('Test');
-    expect(envelope.payload.isCone).toBe(false);
+    expect(envelope.payload.type).toBe('cone-create');
+    expect(envelope.payload.name).toBe('Cone');
+    // No `isCone` on the wire — the bridge handler knows this path is cone-only.
+    expect(envelope.payload.isCone).toBeUndefined();
+  });
+
+  it('registerScoop rejects when called with a non-cone scoop', async () => {
+    await expect(
+      client.registerScoop({
+        jid: 'temp',
+        name: 'Rogue',
+        folder: 'rogue-scoop',
+        isCone: false,
+        type: 'scoop',
+        requiresTrigger: true,
+        assistantLabel: 'rogue-scoop',
+        addedAt: '',
+      })
+    ).rejects.toThrow(/cone-only/i);
   });
 
   it('unregisterScoop sends scoop-drop and removes locally', () => {


### PR DESCRIPTION
## Summary

Follow-up to #434 and addresses the Codex P1 observation on #436: the panel→offscreen \`scoop-create\` handler in \`offscreen-bridge.ts\` supported both cone and non-cone creation, but the non-cone branch built a \`RegisteredScoop\` with no \`config\` at all. Under the new pure-replace path-config contract (#435 / #436), such a scoop would land in the orchestrator with empty \`visiblePaths\`/\`writablePaths\` and hit \`EACCES\` on its own sandbox.

In practice this path has been cone-only since #434 (\`ScoopsPanel.createCone\`). Non-cone scoops are created by the agent's \`scoop_scoop\` tool inside the offscreen orchestrator, which is where the path-config defaults live. This PR makes the panel→offscreen message surface reflect that reality.

- Rename \`ScoopCreateMsg\` → \`ConeCreateMsg\`, type \`'scoop-create'\` → \`'cone-create'\`, drop the \`isCone\` field.
- Collapse \`offscreen-bridge.ts:393\` to cone-only — no \`isCone\` ternaries, no non-cone folder/jid computation.
- \`OffscreenClient.registerScoop\` throws if called with a non-cone scoop, making the cone-only contract explicit at the API boundary.
- Add a unit test for the rejection path.

## Test plan

- [x] \`npm run test\` — 2616 pass / 2 skipped (1 new test, 1 updated)
- [x] \`npx prettier --check\` on changed files
- [x] \`npm run typecheck\` — no new errors (pre-existing unrelated \`lucide\` resolution error untouched)
- [ ] \`npm run build\`
- [ ] \`npm run build -w @slicc/chrome-extension\`

## Depends on

None. Independent of #434 / #435 / #436 — touches extension messaging and \`OffscreenClient\` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)