### PR TITLE
fix(ui): don't let boot-time licks wipe restored chat history

### DIFF
--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1849,7 +1849,9 @@ async function main(): Promise<void> {
 
     if (!isFirstSelect && buffer && buffer.length > 0) {
       // Mid-session switch: the buffer carries transient detail (screenshots)
-      // not in SessionStore, so prefer it over the persisted view.
+      // not in SessionStore, so prefer it over the persisted view. The buffer
+      // was seeded with the canonical history on first-select, so it contains
+      // prior-runtime messages in addition to runtime-only events.
       await layout.panels.chat.switchToContext(contextId, !scoop.isCone, scoopName);
       layout.panels.chat.loadMessages(buffer);
     } else {
@@ -1867,28 +1869,10 @@ async function main(): Promise<void> {
 
           if (isLick) {
             // Lick events - show as incoming with tongue emoji
-            const chatMsg: ChatMessage = {
-              id: msg.id,
-              role: 'user',
-              content: msg.content,
-              timestamp: new Date(msg.timestamp).getTime(),
-              source: 'lick',
-              channel: msg.channel,
-            };
-            getBuffer(scoop.jid).push(chatMsg);
             layout.panels.chat.addUserMessage(msg.content);
           } else if (isDelegation) {
             // Delegation from cone - show as incoming instructions
-            const chatMsg: ChatMessage = {
-              id: msg.id,
-              role: 'user',
-              content: `**[Instructions from sliccy]**\n\n${msg.content}`,
-              timestamp: new Date(msg.timestamp).getTime(),
-              source: 'delegation',
-              channel: 'delegation',
-            };
-            getBuffer(scoop.jid).push(chatMsg);
-            layout.panels.chat.addUserMessage(chatMsg.content);
+            layout.panels.chat.addUserMessage(`**[Instructions from sliccy]**\n\n${msg.content}`);
           } else if (msg.fromAssistant) {
             // Scoop's own response
             emitToUI({ type: 'message_start', messageId: msg.id });
@@ -1898,6 +1882,33 @@ async function main(): Promise<void> {
             layout.panels.chat.addUserMessage(msg.content);
           }
         }
+      }
+
+      // Merge the canonical view with any runtime-only buffer entries.
+      //
+      // Context: the buffer accumulates orchestrator events (streamed content,
+      // tool calls, delegations, licks) regardless of whether this scoop was
+      // selected. For scoops the cone delegates to, the buffer can hold rich
+      // transient detail (including tool-call results with screenshots) that
+      // was never written to SessionStore — we don't want to drop it on the
+      // first open.
+      //
+      // At the same time, a later switch back to this scoop will take the
+      // buffer branch above and call loadMessages(buffer), which replaces
+      // this.messages wholesale. So the buffer needs to carry the full
+      // history too, not just what arrived during this runtime.
+      //
+      // Solution: rebuild the buffer as [canonical + runtime-only entries],
+      // deduped by id. If there were runtime-only entries, also surface them
+      // in the chat view now so the first open isn't missing them.
+      const canonical = layout.panels.chat.getMessages();
+      const canonicalIds = new Set(canonical.map((m) => m.id));
+      const buf = getBuffer(scoop.jid);
+      const runtimeOnly = buf.filter((m) => !canonicalIds.has(m.id));
+      buf.length = 0;
+      buf.push(...canonical, ...runtimeOnly);
+      if (runtimeOnly.length > 0) {
+        layout.panels.chat.loadMessages(buf);
       }
     }
 

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1833,8 +1833,13 @@ async function main(): Promise<void> {
     layout.panels.memory.setSelectedScoop(scoop.jid);
     layout.panels.scoops.setSelectedJid(scoop.jid);
 
-    // Switch chat context. Load from per-scoop message buffer (has full tool call detail)
-    // falling back to SessionStore, then orchestrator DB.
+    // Switch chat context.
+    // - First select per scoop (this runtime): load from SessionStore, then
+    //   fall back to orchestrator DB. The in-memory buffer is ignored here
+    //   because boot-time licks pushed to it before the UI rendered, and
+    //   loadMessages(buffer) would replace restored history with just the lick.
+    // - Subsequent selects: prefer the buffer, which carries transient detail
+    //   (screenshots, streamed tool calls) not in SessionStore.
     const contextId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
     const buffer = scoopMessageBuffers.get(scoop.jid);
     const isFirstSelect = !selectedOnceThisRuntime.has(scoop.jid);
@@ -1848,7 +1853,8 @@ async function main(): Promise<void> {
       await layout.panels.chat.switchToContext(contextId, !scoop.isCone, scoopName);
       layout.panels.chat.loadMessages(buffer);
     } else {
-      // No buffer — load from SessionStore (persisted from previous sessions)
+      // First select, or no buffer — load from SessionStore (persisted from
+      // previous sessions), then fall back to orchestrator DB if nothing there.
       await layout.panels.chat.switchToContext(contextId, !scoop.isCone, scoopName);
 
       // If still empty, fall back to orchestrator DB (simple text, no tool calls)

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1805,10 +1805,18 @@ async function main(): Promise<void> {
     orchestrator.updateModel();
   };
 
+  // Track which scoops have been selected at least once this runtime.
+  // The first select per scoop must load from SessionStore — the in-memory
+  // buffer may contain boot-time lick events (e.g. mount-recovery from PR #325)
+  // pushed before the UI rendered, and loadMessages(buffer) would wipe the
+  // restored history by replacing this.messages with just the lick.
+  const selectedOnceThisRuntime = new Set<string>();
+
   // Wire clear chat to also clear orchestrator messages + buffers
   layout.onClearChat = async () => {
     await orchestrator.clearAllMessages();
     scoopMessageBuffers.clear();
+    selectedOnceThisRuntime.clear();
   };
 
   layout.onClearFilesystem = async () => {
@@ -1829,12 +1837,14 @@ async function main(): Promise<void> {
     // falling back to SessionStore, then orchestrator DB.
     const contextId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
     const buffer = scoopMessageBuffers.get(scoop.jid);
+    const isFirstSelect = !selectedOnceThisRuntime.has(scoop.jid);
 
     // Pass scoop name for non-cone contexts
     const scoopName = scoop.isCone ? undefined : scoop.name;
 
-    if (buffer && buffer.length > 0) {
-      // Load from in-memory buffer (has tool calls captured during this session)
+    if (!isFirstSelect && buffer && buffer.length > 0) {
+      // Mid-session switch: the buffer carries transient detail (screenshots)
+      // not in SessionStore, so prefer it over the persisted view.
       await layout.panels.chat.switchToContext(contextId, !scoop.isCone, scoopName);
       layout.panels.chat.loadMessages(buffer);
     } else {
@@ -1891,6 +1901,8 @@ async function main(): Promise<void> {
     if (scoop.isCone && orchestrator.isProcessing(scoop.jid)) {
       layout.panels.chat.setProcessing(true);
     }
+
+    selectedOnceThisRuntime.add(scoop.jid);
   };
 
   layout.onScoopSelect = handleScoopSelect;


### PR DESCRIPTION
## Summary

- A page reload would drop the restored chat history and leave only a single lick message (the mount-recovery `session-reload` lick from #325) — and the bug was sticky because it also corrupted the persisted `session-cone` SessionStore entry.
- Fix: gate the `scoopMessageBuffers` branch in `handleScoopSelect` on a per-scoop first-select flag so the first select after boot always goes through SessionStore. Mid-session switches still use the buffer (screenshots / transient detail).

## Root cause

On reload:

1. `initSession('session-cone')` restores history into `chat.messages` from SessionStore.
2. The fire-and-forget `getAllMountEntries()` (`main.ts:1529`, added in #325) detects any mount whose FSA permission is no longer `'granted'` and fires a `session-reload` lick.
3. `routeLickToScoop()` does two things: calls `addLickMessage()` (which pushes to `chat.messages` and persists via `persistSession()` — fine), **and** unconditionally pushes to `scoopMessageBuffers[cone.jid]` at `main.ts:1497`.
4. `handleScoopSelect(cone)` at `main.ts:1902` runs the buffer branch because `buffer.length > 0`:

    ```ts
    if (buffer && buffer.length > 0) {
      await layout.panels.chat.switchToContext(contextId, !scoop.isCone, scoopName);
      layout.panels.chat.loadMessages(buffer);  // ← replaces this.messages with [lick]
    }
    ```

5. `loadMessages()` (`chat-panel.ts:251`) replaces `this.messages` with the buffer and calls `persistSession()` — **overwriting** the SessionStore entry with a single-entry array. Every subsequent reload then re-renders only the lick until new assistant output arrives.

The branch was designed for mid-session scoop switches where the buffer has screenshots not in SessionStore. It shouldn't fire on the first select after boot.

## Fix

- Introduce `selectedOnceThisRuntime: Set<string>` alongside `scoopMessageBuffers`.
- Gate the buffer branch on `!isFirstSelect && buffer.length > 0`.
- Flip the flag at the end of `handleScoopSelect`.
- Clear the set alongside `scoopMessageBuffers.clear()` on clear-chat so the next select behaves like a fresh boot.

SessionStore already contains `[history + any boot-time licks]` by the time `switchToContext` runs (because `addLickMessage` inlines + persists the lick), so the else-branch produces the correct view without touching the data flow for mid-session switches.

## Test plan

- [x] `npm run typecheck` (only pre-existing unrelated `lucide-icons.ts` error)
- [x] `npm run test -w @slicc/webapp` — 2275/2275 pass
- [x] Live repro: reload with a mount whose permission carries over → history preserved, no lick fires (verified)
- [ ] Live repro: reload with a mount whose permission was revoked → history **and** the session-reload lick both visible
- [ ] Scoop switch mid-session (cone ↔ scoop) — buffer-branch detail (screenshots) still shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)