### PR TITLE
fix(ui): seed scoop buffer from SessionStore on first select

### DIFF
--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1849,7 +1849,9 @@ async function main(): Promise<void> {
 
     if (!isFirstSelect && buffer && buffer.length > 0) {
       // Mid-session switch: the buffer carries transient detail (screenshots)
-      // not in SessionStore, so prefer it over the persisted view.
+      // not in SessionStore, so prefer it over the persisted view. The buffer
+      // was seeded with the canonical history on first-select, so it contains
+      // prior-runtime messages in addition to runtime-only events.
       await layout.panels.chat.switchToContext(contextId, !scoop.isCone, scoopName);
       layout.panels.chat.loadMessages(buffer);
     } else {
@@ -1867,28 +1869,10 @@ async function main(): Promise<void> {
 
           if (isLick) {
             // Lick events - show as incoming with tongue emoji
-            const chatMsg: ChatMessage = {
-              id: msg.id,
-              role: 'user',
-              content: msg.content,
-              timestamp: new Date(msg.timestamp).getTime(),
-              source: 'lick',
-              channel: msg.channel,
-            };
-            getBuffer(scoop.jid).push(chatMsg);
             layout.panels.chat.addUserMessage(msg.content);
           } else if (isDelegation) {
             // Delegation from cone - show as incoming instructions
-            const chatMsg: ChatMessage = {
-              id: msg.id,
-              role: 'user',
-              content: `**[Instructions from sliccy]**\n\n${msg.content}`,
-              timestamp: new Date(msg.timestamp).getTime(),
-              source: 'delegation',
-              channel: 'delegation',
-            };
-            getBuffer(scoop.jid).push(chatMsg);
-            layout.panels.chat.addUserMessage(chatMsg.content);
+            layout.panels.chat.addUserMessage(`**[Instructions from sliccy]**\n\n${msg.content}`);
           } else if (msg.fromAssistant) {
             // Scoop's own response
             emitToUI({ type: 'message_start', messageId: msg.id });
@@ -1898,6 +1882,33 @@ async function main(): Promise<void> {
             layout.panels.chat.addUserMessage(msg.content);
           }
         }
+      }
+
+      // Merge the canonical view with any runtime-only buffer entries.
+      //
+      // Context: the buffer accumulates orchestrator events (streamed content,
+      // tool calls, delegations, licks) regardless of whether this scoop was
+      // selected. For scoops the cone delegates to, the buffer can hold rich
+      // transient detail (including tool-call results with screenshots) that
+      // was never written to SessionStore — we don't want to drop it on the
+      // first open.
+      //
+      // At the same time, a later switch back to this scoop will take the
+      // buffer branch above and call loadMessages(buffer), which replaces
+      // this.messages wholesale. So the buffer needs to carry the full
+      // history too, not just what arrived during this runtime.
+      //
+      // Solution: rebuild the buffer as [canonical + runtime-only entries],
+      // deduped by id. If there were runtime-only entries, also surface them
+      // in the chat view now so the first open isn't missing them.
+      const canonical = layout.panels.chat.getMessages();
+      const canonicalIds = new Set(canonical.map((m) => m.id));
+      const buf = getBuffer(scoop.jid);
+      const runtimeOnly = buf.filter((m) => !canonicalIds.has(m.id));
+      buf.length = 0;
+      buf.push(...canonical, ...runtimeOnly);
+      if (runtimeOnly.length > 0) {
+        layout.panels.chat.loadMessages(buf);
       }
     }
 


### PR DESCRIPTION
Stacks on top of #438. Review #438 first.

## Summary

- After #438 restores history on boot, `cone → scoop → cone` still truncates the cone view (and SessionStore) on the return trip because `loadMessages(buffer)` replaces `this.messages` wholesale.
- The first-select gate in #438 also drops rich transient detail (tool calls, screenshots) that the orchestrator had already accumulated in the buffer for scoops the cone delegated to — pointed out as a P2 on #438 by Codex.
- Fix: on first-select per scoop, merge the canonical chat view with any runtime-only buffer entries (deduped by id), rebuild the buffer from that merge, and call `loadMessages(buf)` when runtime-only entries were present so the first-open view includes them.

## Root cause

`scoopMessageBuffers` accumulates events that arrive during the current runtime — streamed assistant content (`onResponse`), tool calls (`onToolStart`/`onToolEnd`), user sends (`coneAgentHandle.sendMessage`), incoming delegations (`onIncomingMessage`), licks (`routeLickToScoop`). Prior-runtime history lives only in SessionStore. Neither source has everything:

- SessionStore is missing runtime events that fired while this scoop wasn't selected (tool-call detail for scoops the cone delegated to).
- The buffer is missing prior-runtime history (anything from before this page load).

The buffer branch (`loadMessages(buffer)`) replaces `chat.messages` with buffer-only, then `persistSession()` writes that replacement back to SessionStore. Either the scoop-switch truncates the cone, or the first-open misses transient detail.

## Fix

On first-select per scoop, after `switchToContext` + the orchestrator-DB fallback:

```ts
const canonical = layout.panels.chat.getMessages();
const canonicalIds = new Set(canonical.map((m) => m.id));
const buf = getBuffer(scoop.jid);
const runtimeOnly = buf.filter((m) => !canonicalIds.has(m.id));
buf.length = 0;
buf.push(...canonical, ...runtimeOnly);
if (runtimeOnly.length > 0) {
  layout.panels.chat.loadMessages(buf);
}
```

Ids are consistent across the two sources: `routeLickToScoop` uses the same `msgId` for the buffer push and `addLickMessage`; the orchestrator's streaming flow uses a shared `scoopCurrentMessageId` for both the buffer and the `emitToUI` message-start, which is what `chat-panel.handleAgentEvent` records.

After the merge, the next time the buffer branch runs, `loadMessages(buffer)` replaces `this.messages` with `[prior history + runtime events]` — correct.

## Secondary cleanup

The `getBuffer().push(chatMsg)` calls inside the orchestrator-DB fallback (for isLick / isDelegation) were pushing entries with the `ChannelMessage.id` while `addUserMessage` creates a new `uid()` for the corresponding `chat.messages` entry. Ids didn't match, so the buffer and chat entries were effectively duplicates with different ids. The merge step rebuilds the buffer from the canonical view anyway, making those pushes dead code. Dropped.

## Test plan

- [x] `npm run typecheck` (only pre-existing unrelated `lucide-icons.ts` error)
- [x] `npm run test -w @slicc/webapp` — 2275/2275 pass
- [x] Live: `cone → new scoop → cone` preserves cone's prior history (confirmed working)
- [ ] Live: scoop the cone has been delegating to — first click shows tool-call detail accumulated while on cone
- [ ] Live: scoop A receives a webhook while on cone — switching to A after shows both prior-session history and the webhook lick

## Performance note (out of scope)

With full history now in `chat.messages`, `persistSessionAsync` at the start of `switchToContext` writes a larger array on every switch. For long conversations (e.g. a cone with 100+ messages) this could perceptibly delay the scoop-switch UI update. A follow-up could make the persist fire-and-forget and only `await` on explicit flush.

🤖 Generated with [Claude Code](https://claude.com/claude-code)