### PR TITLE
fix(scoops): await createScoopTab in registerScoop to prevent dropped prompt

### DIFF
--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -231,23 +231,52 @@ export class Orchestrator {
     };
   }
 
-  /** Register a new scoop and fully initialize its context before returning.
+  /** Register a new scoop and wait until its tab/context has been registered
+   *  before returning. Does NOT guarantee successful initialization:
+   *  `ScoopContext.init()` can handle failures internally and leave the tab
+   *  in 'error' state while `createScoopTab` still resolves. The guarantee
+   *  here is that by the time this resolves, the tab/context entry exists in
+   *  `this.contexts` / `this.tabs` (ready or error).
    *
-   *  Awaiting createScoopTab here (rather than firing-and-forgetting it) is
-   *  what prevents a race with the caller's immediate follow-up sendPrompt.
-   *  `scoop_scoop` with an initial prompt fires `onFeedScoop` the moment this
-   *  resolves: if the tab has not yet been registered in `this.contexts` /
-   *  `this.tabs`, sendPrompt calls createScoopTab itself, and both calls race
-   *  past the `this.contexts.has(jid)` early-return guard (the guard only
-   *  catches duplicates once contexts.set has run, which happens partway
-   *  through the function). The losing context ends up orphaned and the
-   *  initial prompt is dropped. See issue #440. */
+   *  Awaiting createScoopTab (rather than firing-and-forgetting it) is what
+   *  prevents a race with the caller's immediate follow-up sendPrompt.
+   *  `scoop_scoop` with an initial prompt fires `onFeedScoop` the moment
+   *  this resolves: if the tab had not yet been registered in `this.contexts`
+   *  / `this.tabs`, sendPrompt would call createScoopTab itself, and both
+   *  calls would race past the `this.contexts.has(jid)` early-return guard
+   *  (the guard only catches duplicates once `contexts.set` has run, which
+   *  happens partway through the function). The losing context ends up
+   *  orphaned and the initial prompt is silently dropped. See issue #440.
+   *
+   *  On failure, rolls back the in-memory and on-disk scoop records so the
+   *  caller doesn't see a half-registered scoop, and rethrows so the caller
+   *  can surface the error. */
   async registerScoop(scoop: RegisteredScoop): Promise<void> {
     await db.saveScoop(scoop);
     this.scoops.set(scoop.jid, scoop);
     this.messageQueues.set(scoop.jid, []);
     log.info('Scoop registered', { jid: scoop.jid, name: scoop.name });
-    await this.createScoopTab(scoop.jid);
+    try {
+      await this.createScoopTab(scoop.jid);
+    } catch (err) {
+      log.error('Scoop init failed', {
+        jid: scoop.jid,
+        name: scoop.name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Best-effort rollback — leave no half-registered scoop behind.
+      await this.destroyScoopTab(scoop.jid).catch(() => {});
+      this.scoops.delete(scoop.jid);
+      this.messageQueues.delete(scoop.jid);
+      await db.deleteScoop(scoop.jid).catch((rollbackErr) => {
+        log.warn('Failed to rollback scoop registration', {
+          jid: scoop.jid,
+          name: scoop.name,
+          error: rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
+        });
+      });
+      throw err;
+    }
   }
 
   /** Unregister a scoop. Throws if the scoop has active licks (webhooks/cron tasks). */

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -231,20 +231,23 @@ export class Orchestrator {
     };
   }
 
-  /** Register a new scoop. Initialization is non-blocking — the scoop
-   *  starts as 'initializing' and becomes 'ready' in the background.
-   *  `sendPrompt` already handles this by waiting for 'ready' status. */
+  /** Register a new scoop and fully initialize its context before returning.
+   *
+   *  Awaiting createScoopTab here (rather than firing-and-forgetting it) is
+   *  what prevents a race with the caller's immediate follow-up sendPrompt.
+   *  `scoop_scoop` with an initial prompt fires `onFeedScoop` the moment this
+   *  resolves: if the tab has not yet been registered in `this.contexts` /
+   *  `this.tabs`, sendPrompt calls createScoopTab itself, and both calls race
+   *  past the `this.contexts.has(jid)` early-return guard (the guard only
+   *  catches duplicates once contexts.set has run, which happens partway
+   *  through the function). The losing context ends up orphaned and the
+   *  initial prompt is dropped. See issue #440. */
   async registerScoop(scoop: RegisteredScoop): Promise<void> {
     await db.saveScoop(scoop);
     this.scoops.set(scoop.jid, scoop);
     this.messageQueues.set(scoop.jid, []);
     log.info('Scoop registered', { jid: scoop.jid, name: scoop.name });
-
-    // Fire-and-forget: init runs in background. sendPrompt waits if needed.
-    this.createScoopTab(scoop.jid).catch((err) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.error('Scoop init failed', { jid: scoop.jid, error: msg });
-    });
+    await this.createScoopTab(scoop.jid);
   }
 
   /** Unregister a scoop. Throws if the scoop has active licks (webhooks/cron tasks). */

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -214,14 +214,17 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
 
             log.info('Scoop created', { name, folder });
 
-            // If prompt provided, feed immediately (fire-and-forget)
+            // If prompt provided, feed immediately (fire-and-forget). The
+            // scoop's context is already initialized by the time
+            // onScoopScoop resolves (orchestrator.registerScoop awaits
+            // createScoopTab), so the prompt won't race init.
             if (taskPrompt && onFeedScoop) {
               onFeedScoop(newScoop.jid, taskPrompt).catch((err) => {
                 const msg = err instanceof Error ? err.message : String(err);
                 log.error('Auto-feed failed', { name, error: msg });
               });
               return {
-                content: `Scoop "${name}" created as "${folder}" and task sent. It will start working as soon as initialization completes.`,
+                content: `Scoop "${name}" created as "${folder}" and task sent. It is now working on it.`,
               };
             }
 

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -214,15 +214,28 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
 
             log.info('Scoop created', { name, folder });
 
-            // If prompt provided, feed immediately (fire-and-forget). The
-            // scoop's context is already initialized by the time
-            // onScoopScoop resolves (orchestrator.registerScoop awaits
-            // createScoopTab), so the prompt won't race init.
+            // If prompt provided, feed immediately and await the delegate
+            // call so setup failures (e.g. db.saveMessage) surface to the
+            // cone instead of being logged after a success response.
+            // onFeedScoop → delegateToScoop awaits only the persistence +
+            // prompt dispatch; the scoop's agent loop still runs
+            // fire-and-forget in the background, so this doesn't block on
+            // the LLM turn. The scoop's context is already initialized by
+            // the time onScoopScoop resolves (orchestrator.registerScoop
+            // awaits createScoopTab), so the prompt won't race init either.
             if (taskPrompt && onFeedScoop) {
-              onFeedScoop(newScoop.jid, taskPrompt).catch((err) => {
+              try {
+                await onFeedScoop(newScoop.jid, taskPrompt);
+              } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
                 log.error('Auto-feed failed', { name, error: msg });
-              });
+                return {
+                  content:
+                    `Scoop "${name}" created as "${folder}" but the initial task could not be sent: ${msg}. ` +
+                    `Use feed_scoop to retry.`,
+                  isError: true,
+                };
+              }
               return {
                 content: `Scoop "${name}" created as "${folder}" and task sent. It is now working on it.`,
               };


### PR DESCRIPTION
Closes #440.

## Summary

- `scoop_scoop` with a `prompt` silently dropped the initial task and the scoop went idle.
- Fix: `orchestrator.registerScoop` now awaits `createScoopTab` instead of firing it and forgetting it, so the context is fully registered before the caller's immediate follow-up `onFeedScoop` runs. No more race.

## Root cause (as diagnosed in the issue)

1. `scoop_scoop` handler in `scoop-management-tools.ts` awaits `onScoopScoop(...)` then fires `onFeedScoop(newScoop.jid, taskPrompt).catch(...)` — fire-and-forget.
2. `onScoopScoop` → `orchestrator.registerScoop`, which previously called `this.createScoopTab(jid).catch(...)` as fire-and-forget and returned. By the time registerScoop resolved, `this.contexts.has(jid)` was still `false`.
3. The fire-and-forget `onFeedScoop` → `orchestrator.delegateToScoop` → `orchestrator.sendPrompt(jid, ...)`.
4. `sendPrompt` read `this.contexts.get(jid)` → undefined → called `await this.createScoopTab(jid)`. Meanwhile the original fire-and-forget createScoopTab from (2) was in flight.
5. Two concurrent `createScoopTab` calls raced past the `this.contexts.has(jid)` early-return guard (lines 454–465 of `orchestrator.ts`). The guard only catches duplicates *after* `this.contexts.set(...)` has run (line 622), which happens partway through the function — both invocations had already blown past the guard before either set anything.
6. Both built full fs + callbacks + `new ScoopContext(...)`. The second `contexts.set(...)` overwrote the first. `sendPrompt` was holding the reference it fetched after awaiting its own createScoopTab, which may or may not be the one that won the `contexts.set` race. The orphaned context's agent never routed responses through the orchestrator; the prompt was silently dropped.

## Fix

`registerScoop` now awaits `createScoopTab`. By the time `onScoopScoop` resolves in `scoop-management-tools.ts`, the context is registered and `'ready'`, so sendPrompt's `if (!context)` branch doesn't fire and there's no race.

Callers of `registerScoop`:
- `scoops-panel.ts:612` (UI add-scoop flow) — already awaited; now waits slightly longer (~init time) before the UI returns to idle.
- `orchestrator.ts:600` (internal) — already awaited.

Also updated the `scoop_scoop` tool result string — it said "It will start working as soon as initialization completes," but post-fix init *is* complete by the time the tool returns, so the cone got a stale nudge.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test -w @slicc/webapp` — 2275/2275 pass
- [ ] Live: `scoop_scoop` with a `prompt` in the cone — scoop actually runs the prompt (previously went straight to idle)
- [ ] Live: `scoop_scoop` without a prompt — scoop is created and stays idle until `feed_scoop`, no regression
- [ ] Live: "Add scoop" button in the UI scoops panel still works (no hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)