### PR TITLE
fix: raise scoop completion notification truncation limit to 20k chars

### DIFF
--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -391,7 +391,9 @@ export class Orchestrator {
     if (!cone) return;
 
     const summary =
-      responseText.length > 20000 ? responseText.slice(0, 20000) + '\n... (truncated)' : responseText;
+      responseText.length > 20000
+        ? responseText.slice(0, 20000) + '\n... (truncated)'
+        : responseText;
     const notifyMsg: ChannelMessage = {
       id: `scoop-done-${jid}-${Date.now()}`,
       chatJid: cone.jid,

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -391,7 +391,7 @@ export class Orchestrator {
     if (!cone) return;
 
     const summary =
-      responseText.length > 2000 ? responseText.slice(0, 2000) + '\n... (truncated)' : responseText;
+      responseText.length > 20000 ? responseText.slice(0, 20000) + '\n... (truncated)' : responseText;
     const notifyMsg: ChannelMessage = {
       id: `scoop-done-${jid}-${Date.now()}`,
       chatJid: cone.jid,

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -819,6 +819,183 @@ describe('Orchestrator scoop-notify gating (notifyOnComplete)', () => {
   });
 });
 
+describe('Orchestrator scoop-notify truncation', () => {
+  let orch: Orchestrator;
+  let priorWindow: unknown;
+  let windowWasShimmed = false;
+
+  beforeAll(() => {
+    if (typeof (globalThis as any).window === 'undefined') {
+      priorWindow = (globalThis as any).window;
+      (globalThis as any).window = globalThis;
+      windowWasShimmed = true;
+    }
+  });
+
+  afterAll(() => {
+    if (windowWasShimmed) {
+      if (priorWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = priorWindow;
+      }
+    }
+  });
+
+  beforeEach(async () => {
+    await initDB();
+    await clearAllMessages();
+    const existing = await getAllScoops();
+    const { deleteScoop } = await import('../../src/scoops/db.js');
+    for (const jid of Object.keys(existing)) {
+      await deleteScoop(jid);
+    }
+    await saveScoop(cone);
+  });
+
+  afterEach(async () => {
+    const sharedFs = orch?.getSharedFS();
+    await orch?.shutdown();
+    await sharedFs?.dispose();
+  });
+
+  function noopCallbacks() {
+    return {
+      onResponse: vi.fn(),
+      onResponseDone: vi.fn(),
+      onSendMessage: vi.fn(),
+      onStatusChange: vi.fn(),
+      onError: vi.fn(),
+      getBrowserAPI: vi.fn(() => ({}) as any),
+    };
+  }
+
+  interface OrchestratorPrivate {
+    scoopResponseBuffer: Map<string, string>;
+    maybeNotifyConeOnScoopComplete(jid: string): void;
+    handleMessage(msg: ChannelMessage): Promise<void>;
+  }
+
+  it('truncates scoop response >20000 chars and appends truncation marker', async () => {
+    const scoop: RegisteredScoop = {
+      jid: 'scoop_truncate_test_1',
+      name: 'truncate-test',
+      folder: 'truncate-test-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'truncate-test-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    await saveScoop(scoop);
+
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(container, noopCallbacks());
+    await orch.init();
+
+    const priv = orch as unknown as OrchestratorPrivate;
+    const captured: ChannelMessage[] = [];
+    priv.handleMessage = async (msg) => {
+      captured.push(msg);
+    };
+
+    // Create a response that exceeds 20000 chars
+    const longResponse = 'x'.repeat(25000);
+    priv.scoopResponseBuffer.set(scoop.jid, longResponse);
+    priv.maybeNotifyConeOnScoopComplete(scoop.jid);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].channel).toBe('scoop-notify');
+    // The content includes the prefix "[@truncate-test-scoop completed]:\n" plus truncated text
+    expect(captured[0].content).toContain('\n... (truncated)');
+    // Verify actual truncation: prefix + 20000 chars + truncation marker
+    const prefix = `[@${scoop.assistantLabel} completed]:\n`;
+    const expectedContent = prefix + longResponse.slice(0, 20000) + '\n... (truncated)';
+    expect(captured[0].content).toBe(expectedContent);
+  });
+
+  it('does not truncate scoop response <=20000 chars', async () => {
+    const scoop: RegisteredScoop = {
+      jid: 'scoop_no_truncate_test_1',
+      name: 'no-truncate-test',
+      folder: 'no-truncate-test-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'no-truncate-test-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    await saveScoop(scoop);
+
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(container, noopCallbacks());
+    await orch.init();
+
+    const priv = orch as unknown as OrchestratorPrivate;
+    const captured: ChannelMessage[] = [];
+    priv.handleMessage = async (msg) => {
+      captured.push(msg);
+    };
+
+    // Create a response exactly at the limit
+    const exactLimitResponse = 'y'.repeat(20000);
+    priv.scoopResponseBuffer.set(scoop.jid, exactLimitResponse);
+    priv.maybeNotifyConeOnScoopComplete(scoop.jid);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].channel).toBe('scoop-notify');
+    // Should NOT be truncated
+    expect(captured[0].content).not.toContain('(truncated)');
+    const prefix = `[@${scoop.assistantLabel} completed]:\n`;
+    expect(captured[0].content).toBe(prefix + exactLimitResponse);
+  });
+
+  it('forwards short responses unmodified', async () => {
+    const scoop: RegisteredScoop = {
+      jid: 'scoop_short_test_1',
+      name: 'short-test',
+      folder: 'short-test-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'short-test-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    await saveScoop(scoop);
+
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(container, noopCallbacks());
+    await orch.init();
+
+    const priv = orch as unknown as OrchestratorPrivate;
+    const captured: ChannelMessage[] = [];
+    priv.handleMessage = async (msg) => {
+      captured.push(msg);
+    };
+
+    const shortResponse = 'Short completion message';
+    priv.scoopResponseBuffer.set(scoop.jid, shortResponse);
+    priv.maybeNotifyConeOnScoopComplete(scoop.jid);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].content).not.toContain('(truncated)');
+    const prefix = `[@${scoop.assistantLabel} completed]:\n`;
+    expect(captured[0].content).toBe(prefix + shortResponse);
+  });
+});
+
 describe('Orchestrator observer cleanup on scoop teardown', () => {
   let orch: Orchestrator;
   let priorWindow: unknown;


### PR DESCRIPTION
## Problem

When a scoop finishes its work, the orchestrator routes the response back to the cone as a notification. The response was truncated to **2000 characters** — far too aggressive for research, analysis, or code generation scoops that routinely produce larger outputs.

This caused the cone to receive incomplete results and lose critical information needed to act on scoop work (e.g., wiki pages, patch files, research summaries).

## Fix

Raise the truncation threshold from 2000 to **20000 characters**. The cone is an LLM with a large context window — 20k is generous enough for virtually all scoop outputs while still providing a safety valve against truly enormous responses.

## Changes

- `packages/webapp/src/scoops/orchestrator.ts`: `2000` → `20000` in both the length check and `.slice()` call

One-line fix. No test changes needed — the behavior is identical, just with a higher threshold.