### PR TITLE
feat(webapp): auto-grow chat prompt textarea up to 30% of panel height

### DIFF
--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -424,9 +424,7 @@ export class ChatPanel {
     });
 
     this.textarea.addEventListener('input', () => {
-      // Auto-resize textarea
-      this.textarea.style.height = 'auto';
-      this.textarea.style.height = Math.min(this.textarea.scrollHeight, 120) + 'px';
+      this.adjustTextareaHeight();
     });
 
     this.sendBtn.addEventListener('click', () => this.sendMessage());
@@ -446,8 +444,7 @@ export class ChatPanel {
     this.voiceInput = new VoiceInput({
       onTranscript: (text, _isFinal) => {
         this.textarea.value = text;
-        this.textarea.style.height = 'auto';
-        this.textarea.style.height = Math.min(this.textarea.scrollHeight, 120) + 'px';
+        this.adjustTextareaHeight();
       },
       onStateChange: (state) => {
         if (state === 'error') {
@@ -508,6 +505,27 @@ export class ChatPanel {
     }
   }
 
+  /**
+   * Grow the textarea to fit its content, up to 30% of the chat panel's
+   * available height. Falls back to 30% of the window height when the
+   * panel hasn't laid out yet (e.g. first input before layout).
+   */
+  private adjustTextareaHeight(): void {
+    const panelHeight =
+      this.container.clientHeight || (typeof window !== 'undefined' ? window.innerHeight : 0) || 0;
+    const maxHeight = Math.max(18, Math.floor(panelHeight * 0.3));
+    this.textarea.style.height = 'auto';
+    const next = Math.min(this.textarea.scrollHeight, maxHeight);
+    this.textarea.style.height = next + 'px';
+    this.textarea.style.overflowY = this.textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+  }
+
+  /** Reset the textarea back to a single row after submit or clear. */
+  private resetTextareaHeight(): void {
+    this.textarea.style.height = 'auto';
+    this.textarea.style.overflowY = 'hidden';
+  }
+
   private sendMessage(): void {
     const text = this.textarea.value.trim();
     if (!text) return;
@@ -528,9 +546,9 @@ export class ChatPanel {
     this.appendMessageEl(msg);
     this.persistSession();
 
-    // Clear input
+    // Clear input and shrink back to a single row
     this.textarea.value = '';
-    this.textarea.style.height = 'auto';
+    this.resetTextareaHeight();
 
     // Only lock input if not already streaming (first message triggers streaming)
     if (!this.isStreaming) {

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -515,9 +515,12 @@ export class ChatPanel {
       this.container.clientHeight || (typeof window !== 'undefined' ? window.innerHeight : 0) || 0;
     const maxHeight = Math.max(18, Math.floor(panelHeight * 0.3));
     this.textarea.style.height = 'auto';
-    const next = Math.min(this.textarea.scrollHeight, maxHeight);
+    // Cache scrollHeight once — it's layout-dependent and reading it twice
+    // would force an extra reflow.
+    const scrollHeight = this.textarea.scrollHeight;
+    const next = Math.min(scrollHeight, maxHeight);
     this.textarea.style.height = next + 'px';
-    this.textarea.style.overflowY = this.textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+    this.textarea.style.overflowY = scrollHeight > maxHeight ? 'auto' : 'hidden';
   }
 
   /** Reset the textarea back to a single row after submit or clear. */

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -337,7 +337,10 @@
     0 4px 16px 0 rgba(0, 0, 0, 0.12);
 }
 .chat__textarea {
-  flex: 1;
+  /* Let the inline height set by JS control the textarea's size.
+     Using flex:1 here would make the flex distribution override our
+     inline height and pin the textarea to the wrapper's min-height. */
+  flex: 0 0 auto;
   resize: none;
   min-height: 18px;
   /* JS sets height dynamically up to 30% of the chat panel height;
@@ -359,11 +362,14 @@
   color: var(--s2-content-tertiary);
 }
 
-/* Action bar — bottom row of prompt bar */
+/* Action bar — bottom row of prompt bar.
+   margin-top: auto pins this to the bottom of the flex column so the
+   wrapper's min-height still shows an empty-state gap above the bar. */
 .chat__action-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  margin-top: auto;
   flex-shrink: 0;
 }
 .chat__action-bar-left {

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -340,7 +340,10 @@
   flex: 1;
   resize: none;
   min-height: 18px;
-  max-height: 120px;
+  /* JS sets height dynamically up to 30% of the chat panel height;
+     this max-height is a fallback cap when JS has not yet run. */
+  max-height: 30vh;
+  overflow-y: auto;
   padding: 0;
   border: none;
   background: transparent;


### PR DESCRIPTION
## Summary

The prompt textarea in the chat panel currently caps at 120px regardless of how much text you've typed, so longer drafts are stuck scrolling inside a small field. This PR lets the textarea grow with the text up to 30% of the chat panel's available height, and shrinks it back to a single row after submit (or after the voice input clears it).

## Changes

- `packages/webapp/src/ui/chat-panel.ts`:
  - New `adjustTextareaHeight()` helper — grows the textarea to fit content, capped at `Math.floor(container.clientHeight * 0.3)`. Toggles `overflow-y` so the scrollbar only appears once the cap is hit.
  - New `resetTextareaHeight()` helper — snaps back to one row on submit/clear.
  - Replaced the three inline `Math.min(scrollHeight, 120)` sites (input handler, voice transcript, send-clear) with these helpers.
- `packages/webapp/src/ui/styles/chat.css`: replaced `max-height: 120px` with `max-height: 30vh` as a CSS fallback (in case JS hasn't run yet) and added `overflow-y: auto`.

## Verification

- `npx prettier --write` on changed files
- `npm run typecheck` — passes
- `npm run test` — all UI tests pass (unrelated isomorphic-git and skills-catalog failures are pre-existing on `main`)