### PR TITLE
fix(fs): guard mount-recovery lick and give cone an actionable prompt

### DIFF
--- a/packages/webapp/src/fs/mount-recovery.ts
+++ b/packages/webapp/src/fs/mount-recovery.ts
@@ -1,0 +1,157 @@
+/**
+ * Mount recovery — bridge between the persisted mount table and the
+ * File System Access API's permission model.
+ *
+ * ## Why some reloads require recovery and some don't
+ *
+ * A `FileSystemDirectoryHandle` is structured-cloneable and survives an
+ * IndexedDB round-trip, but its readwrite permission is *not* part of the
+ * clone. Chrome's behaviour:
+ *
+ * - **Same tab, soft navigation / Vite HMR / SPA route change**
+ *   → `queryPermission({ mode: 'readwrite' })` usually returns `granted`
+ *   because the permission lives on the tab's top-level document. We can
+ *   silently re-`mount()` the handle with no user interaction.
+ *
+ * - **Full page reload / cold tab open / browser restart**
+ *   → permission drops to `prompt` (or occasionally `denied`). The only
+ *   way to restore it is a user gesture that calls
+ *   `handle.requestPermission({ mode: 'readwrite' })` or a fresh
+ *   `showDirectoryPicker()`. We cannot prompt without a gesture, so we
+ *   surface the list to the cone and ask it to walk the user through
+ *   re-mounting.
+ *
+ * - **Very old handle, browser upgrade, or missing methods**
+ *   → `queryPermission` may throw or be absent on the rehydrated object.
+ *   We treat that the same as "needs recovery" — better to ask than to
+ *   silently leave the path mounted-but-empty.
+ *
+ * The upshot for users: a full browser restart will typically need
+ * re-authorization; a tab reload while the browser was running may not.
+ * This is File System Access API policy, not SLICC policy — the recovery
+ * helper just observes which bucket each handle is in.
+ */
+
+import type { MountEntry } from './mount-table-store.js';
+
+export interface MountRecoveryEntry {
+  /** VFS mount point (e.g. `/workspace/my-project`). */
+  path: string;
+  /** Original directory name captured from the handle (`handle.name`). */
+  dirName: string;
+}
+
+export interface MountRecoveryResult {
+  /** Entries that were silently re-mounted because permission was still granted. */
+  restored: MountRecoveryEntry[];
+  /** Entries that require a new user gesture to regain filesystem access. */
+  needsRecovery: MountRecoveryEntry[];
+}
+
+/** Minimal FS surface needed to re-mount a handle — lets tests stub this. */
+export interface MountRecoveryFS {
+  mount(path: string, handle: FileSystemDirectoryHandle): Promise<void> | void;
+}
+
+/** Logger surface accepted by `recoverMounts`. Everything is optional. */
+export interface MountRecoveryLogger {
+  info?: (msg: string, data?: unknown) => void;
+  warn?: (msg: string, data?: unknown) => void;
+}
+
+/**
+ * Walk persisted mount entries and try to silently re-mount each one.
+ * Returns two buckets: handles we restored, and handles that need the
+ * user to re-grant permission.
+ *
+ * Callers should only surface `needsRecovery` to the agent — if the list
+ * is empty, the reload was a silent success and no lick should fire.
+ */
+export async function recoverMounts(
+  entries: MountEntry[],
+  fs: MountRecoveryFS,
+  log?: MountRecoveryLogger
+): Promise<MountRecoveryResult> {
+  const restored: MountRecoveryEntry[] = [];
+  const needsRecovery: MountRecoveryEntry[] = [];
+
+  for (const { path, handle } of entries) {
+    const dirName = typeof handle?.name === 'string' ? handle.name : '';
+
+    if (!handle || !('queryPermission' in handle)) {
+      needsRecovery.push({ path, dirName });
+      continue;
+    }
+
+    let perm: string;
+    try {
+      perm = await (
+        handle as unknown as {
+          queryPermission: (desc: { mode: string }) => Promise<string>;
+        }
+      ).queryPermission({ mode: 'readwrite' });
+    } catch (err) {
+      log?.warn?.('queryPermission threw on persisted handle', {
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      needsRecovery.push({ path, dirName });
+      continue;
+    }
+
+    if (perm !== 'granted') {
+      needsRecovery.push({ path, dirName });
+      continue;
+    }
+
+    try {
+      await fs.mount(path, handle);
+      log?.info?.('Restored mount from previous session', { path, name: dirName });
+      restored.push({ path, dirName });
+    } catch (err) {
+      log?.warn?.('Failed to re-mount persisted handle', {
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      needsRecovery.push({ path, dirName });
+    }
+  }
+
+  return { restored, needsRecovery };
+}
+
+/**
+ * Build a natural-language prompt for the cone describing mount points
+ * that lost their permission on reload. The prompt is self-contained:
+ * it tells the cone to inform the user and offer the exact `mount`
+ * commands needed to re-authorize.
+ *
+ * Returns `null` when there is nothing to report — callers should treat
+ * a `null` result as "do not emit a lick".
+ */
+export function formatMountRecoveryPrompt(mounts: MountRecoveryEntry[]): string | null {
+  if (!Array.isArray(mounts) || mounts.length === 0) return null;
+
+  const listLines = mounts.map(({ path, dirName }) => {
+    const origin = dirName ? ` (previously mounted from \`${dirName}\`)` : '';
+    return `- \`${path}\`${origin}`;
+  });
+  const mountCmds = mounts.map(({ path }) => `    mount ${path}`);
+
+  const noun = mounts.length === 1 ? 'mount point' : 'mount points';
+  const pronoun = mounts.length === 1 ? 'it' : 'them';
+
+  return [
+    `[Session Reload] Mount recovery required for ${mounts.length} ${noun}.`,
+    '',
+    `The page was reloaded and the following ${noun} lost filesystem permission. The browser cannot restore access without a fresh user gesture, so ${pronoun} cannot be used until the user re-authorizes:`,
+    '',
+    ...listLines,
+    '',
+    'Please tell the user what happened and ask whether they want to re-mount. If yes, run the corresponding command(s) so the folder picker opens and they can re-select the same directory:',
+    '',
+    ...mountCmds,
+    '',
+    'If the user no longer needs a mount, run `mount unmount <path>` instead to clear the stale entry.',
+  ].join('\n');
+}

--- a/packages/webapp/src/fs/mount-recovery.ts
+++ b/packages/webapp/src/fs/mount-recovery.ts
@@ -121,10 +121,42 @@ export async function recoverMounts(
 }
 
 /**
+ * POSIX single-quote shell quoting. Wraps `value` in `'…'` and escapes
+ * any embedded single quotes as `'\''`. The result is a single argv
+ * token, safe to paste after `mount ` regardless of spaces, globs, or
+ * shell metacharacters in the path (e.g. `/mnt/My Project`, `It's`).
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Wrap `value` in a Markdown inline-code span. Newlines (illegal in
+ * inline code) collapse to spaces. If the value contains backticks, the
+ * delimiter grows to the smallest run that cannot collide with the
+ * content, per CommonMark §6.1, so `path`s like `` `weird` `` still
+ * render correctly in any downstream renderer.
+ */
+export function mdInlineCode(value: string): string {
+  const collapsed = value.replace(/\r\n|[\r\n]/g, ' ');
+  const runs = collapsed.match(/`+/g);
+  const delimLen = runs ? Math.max(...runs.map((r) => r.length)) + 1 : 1;
+  const delim = '`'.repeat(delimLen);
+  const needsPad = collapsed.startsWith('`') || collapsed.endsWith('`');
+  const body = needsPad ? ` ${collapsed} ` : collapsed;
+  return `${delim}${body}${delim}`;
+}
+
+/**
  * Build a natural-language prompt for the cone describing mount points
  * that lost their permission on reload. The prompt is self-contained:
  * it tells the cone to inform the user and offer the exact `mount`
  * commands needed to re-authorize.
+ *
+ * Mount paths are shell-quoted in command suggestions so paths with
+ * spaces or metacharacters parse as a single argv token, and they are
+ * embedded in Markdown inline code with a delimiter that survives
+ * embedded backticks or newlines.
  *
  * Returns `null` when there is nothing to report — callers should treat
  * a `null` result as "do not emit a lick".
@@ -133,10 +165,10 @@ export function formatMountRecoveryPrompt(mounts: MountRecoveryEntry[]): string 
   if (!Array.isArray(mounts) || mounts.length === 0) return null;
 
   const listLines = mounts.map(({ path, dirName }) => {
-    const origin = dirName ? ` (previously mounted from \`${dirName}\`)` : '';
-    return `- \`${path}\`${origin}`;
+    const origin = dirName ? ` (previously mounted from ${mdInlineCode(dirName)})` : '';
+    return `- ${mdInlineCode(path)}${origin}`;
   });
-  const mountCmds = mounts.map(({ path }) => `    mount ${path}`);
+  const mountCmds = mounts.map(({ path }) => `    mount ${shellQuote(path)}`);
 
   const noun = mounts.length === 1 ? 'mount point' : 'mount points';
   const pronoun = mounts.length === 1 ? 'it' : 'them';
@@ -152,6 +184,6 @@ export function formatMountRecoveryPrompt(mounts: MountRecoveryEntry[]): string 
     '',
     ...mountCmds,
     '',
-    'If the user no longer needs a mount, run `mount unmount <path>` instead to clear the stale entry.',
+    'If the user no longer needs a mount, run `mount unmount <path>` (with the path shell-quoted the same way) to clear the stale entry instead.',
   ].join('\n');
 }

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -81,6 +81,7 @@ import {
 import { SprinkleManager } from './sprinkle-manager.js';
 import { initTelemetry } from './telemetry.js';
 import { getAllMountEntries } from '../fs/mount-table-store.js';
+import { recoverMounts, formatMountRecoveryPrompt } from '../fs/mount-recovery.js';
 
 const log = createLogger('main');
 
@@ -1451,7 +1452,28 @@ async function main(): Promise<void> {
               : isNavigate
                 ? 'Navigate Event'
                 : 'Cron Event';
-      const content = `[${eventLabel}: ${eventName}]\n\`\`\`json\n${JSON.stringify(event.body, null, 2)}\n\`\`\``;
+      let content: string | null = null;
+      if (isSessionReload) {
+        const body = event.body as
+          | {
+              reason?: string;
+              mounts?: Array<{ path: string; dirName: string }>;
+            }
+          | null
+          | undefined;
+        if (body?.reason === 'mount-recovery') {
+          content = formatMountRecoveryPrompt(body.mounts ?? []);
+          if (content === null) {
+            // Nothing actually needs recovery — drop the lick instead of
+            // pestering the cone with an empty notification.
+            log.debug('Dropping session-reload lick with empty mount-recovery list');
+            return;
+          }
+        }
+      }
+      if (content === null) {
+        content = `[${eventLabel}: ${eventName}]\n\`\`\`json\n${JSON.stringify(event.body, null, 2)}\n\`\`\``;
+      }
 
       const msg: ChannelMessage = {
         id: msgId,
@@ -1522,41 +1544,24 @@ async function main(): Promise<void> {
   })();
 
   // ── Restore persisted mounts from IndexedDB ──────────────────────────
+  // See `fs/mount-recovery.ts` for why some reloads require recovery and
+  // some don't (short version: Chrome only retains readwrite permission
+  // within a tab's active session, so a full restart drops every handle
+  // back to `prompt`). The `session-reload` lick is only emitted when at
+  // least one handle actually needs re-authorization.
   if (sharedFs) {
     getAllMountEntries()
       .then(async (entries) => {
         if (entries.length === 0) return;
-        const needsRemount: Array<{ path: string; dirName: string }> = [];
-        for (const { path, handle } of entries) {
-          try {
-            if (!('queryPermission' in handle)) {
-              needsRemount.push({ path, dirName: handle.name });
-              continue;
-            }
-            const perm = await (
-              handle as unknown as {
-                queryPermission: (desc: { mode: string }) => Promise<string>;
-              }
-            ).queryPermission({ mode: 'readwrite' });
-            if (perm === 'granted') {
-              await sharedFs.mount(path, handle);
-              log.info('Restored mount from previous session', { path, name: handle.name });
-            } else {
-              needsRemount.push({ path, dirName: handle.name });
-            }
-          } catch {
-            needsRemount.push({ path, dirName: handle.name });
-          }
-        }
-        if (needsRemount.length > 0) {
-          const event: LickEvent = {
-            type: 'session-reload',
-            targetScoop: undefined,
-            timestamp: new Date().toISOString(),
-            body: { reason: 'mount-recovery', mounts: needsRemount },
-          };
-          routeLickToScoop(event);
-        }
+        const { needsRecovery } = await recoverMounts(entries, sharedFs, log);
+        if (needsRecovery.length === 0) return;
+        const event: LickEvent = {
+          type: 'session-reload',
+          targetScoop: undefined,
+          timestamp: new Date().toISOString(),
+          body: { reason: 'mount-recovery', mounts: needsRecovery },
+        };
+        routeLickToScoop(event);
       })
       .catch((err) => log.warn('Failed to restore persisted mounts', err));
   }

--- a/packages/webapp/tests/fs/mount-recovery.test.ts
+++ b/packages/webapp/tests/fs/mount-recovery.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  recoverMounts,
+  formatMountRecoveryPrompt,
+  type MountRecoveryFS,
+} from '../../src/fs/mount-recovery.js';
+import type { MountEntry } from '../../src/fs/mount-table-store.js';
+
+type PermissionState = 'granted' | 'prompt' | 'denied';
+
+interface MockHandleOptions {
+  name: string;
+  permission?: PermissionState;
+  /** Omit `queryPermission` from the handle object (simulates stale/old record). */
+  withoutQueryPermission?: boolean;
+  /** Force `queryPermission` to throw. */
+  throwOnQuery?: boolean;
+}
+
+function mockHandle(opts: MockHandleOptions): FileSystemDirectoryHandle {
+  const { name, permission = 'granted', withoutQueryPermission, throwOnQuery } = opts;
+  const handle: Record<string, unknown> = { kind: 'directory', name };
+  if (!withoutQueryPermission) {
+    handle.queryPermission = async (_desc: { mode: string }) => {
+      if (throwOnQuery) throw new Error('boom');
+      return permission;
+    };
+  }
+  return handle as unknown as FileSystemDirectoryHandle;
+}
+
+function mockFs(mountImpl?: (path: string, handle: FileSystemDirectoryHandle) => Promise<void>): {
+  fs: MountRecoveryFS;
+  mounts: Array<{ path: string; name: string }>;
+} {
+  const mounts: Array<{ path: string; name: string }> = [];
+  const fs: MountRecoveryFS = {
+    mount: async (path: string, handle: FileSystemDirectoryHandle) => {
+      if (mountImpl) await mountImpl(path, handle);
+      mounts.push({ path, name: handle.name });
+    },
+  };
+  return { fs, mounts };
+}
+
+describe('recoverMounts', () => {
+  it('silently remounts handles whose permission is still granted', async () => {
+    const entries: MountEntry[] = [
+      { path: '/workspace/a', handle: mockHandle({ name: 'a', permission: 'granted' }) },
+      { path: '/workspace/b', handle: mockHandle({ name: 'b', permission: 'granted' }) },
+    ];
+    const { fs, mounts } = mockFs();
+    const result = await recoverMounts(entries, fs);
+    expect(result.restored).toEqual([
+      { path: '/workspace/a', dirName: 'a' },
+      { path: '/workspace/b', dirName: 'b' },
+    ]);
+    expect(result.needsRecovery).toEqual([]);
+    expect(mounts).toEqual([
+      { path: '/workspace/a', name: 'a' },
+      { path: '/workspace/b', name: 'b' },
+    ]);
+  });
+
+  it('flags handles whose permission dropped to `prompt` as needing recovery', async () => {
+    const entries: MountEntry[] = [
+      { path: '/workspace/a', handle: mockHandle({ name: 'a', permission: 'prompt' }) },
+      { path: '/workspace/b', handle: mockHandle({ name: 'b', permission: 'denied' }) },
+    ];
+    const { fs, mounts } = mockFs();
+    const result = await recoverMounts(entries, fs);
+    expect(result.restored).toEqual([]);
+    expect(result.needsRecovery).toEqual([
+      { path: '/workspace/a', dirName: 'a' },
+      { path: '/workspace/b', dirName: 'b' },
+    ]);
+    expect(mounts).toEqual([]);
+  });
+
+  it('flags handles that lost `queryPermission` as needing recovery', async () => {
+    const entries: MountEntry[] = [
+      {
+        path: '/workspace/legacy',
+        handle: mockHandle({ name: 'legacy', withoutQueryPermission: true }),
+      },
+    ];
+    const { fs } = mockFs();
+    const result = await recoverMounts(entries, fs);
+    expect(result.restored).toEqual([]);
+    expect(result.needsRecovery).toEqual([{ path: '/workspace/legacy', dirName: 'legacy' }]);
+  });
+
+  it('flags handles whose queryPermission throws as needing recovery', async () => {
+    const warn = vi.fn();
+    const entries: MountEntry[] = [
+      {
+        path: '/workspace/broken',
+        handle: mockHandle({ name: 'broken', throwOnQuery: true }),
+      },
+    ];
+    const { fs } = mockFs();
+    const result = await recoverMounts(entries, fs, { warn });
+    expect(result.restored).toEqual([]);
+    expect(result.needsRecovery).toEqual([{ path: '/workspace/broken', dirName: 'broken' }]);
+    expect(warn).toHaveBeenCalledWith(
+      'queryPermission threw on persisted handle',
+      expect.objectContaining({ path: '/workspace/broken' })
+    );
+  });
+
+  it('falls back to needsRecovery when the fs mount call itself throws', async () => {
+    const warn = vi.fn();
+    const entries: MountEntry[] = [
+      { path: '/workspace/x', handle: mockHandle({ name: 'x', permission: 'granted' }) },
+    ];
+    const fs: MountRecoveryFS = {
+      mount: async () => {
+        throw new Error('mount failed');
+      },
+    };
+    const result = await recoverMounts(entries, fs, { warn });
+    expect(result.restored).toEqual([]);
+    expect(result.needsRecovery).toEqual([{ path: '/workspace/x', dirName: 'x' }]);
+    expect(warn).toHaveBeenCalledWith(
+      'Failed to re-mount persisted handle',
+      expect.objectContaining({ path: '/workspace/x' })
+    );
+  });
+
+  it('returns empty arrays when there are no entries', async () => {
+    const { fs } = mockFs();
+    const result = await recoverMounts([], fs);
+    expect(result).toEqual({ restored: [], needsRecovery: [] });
+  });
+
+  it('mixes restored and needs-recovery correctly in a single pass', async () => {
+    const entries: MountEntry[] = [
+      { path: '/workspace/ok', handle: mockHandle({ name: 'ok', permission: 'granted' }) },
+      { path: '/workspace/stale', handle: mockHandle({ name: 'stale', permission: 'prompt' }) },
+    ];
+    const { fs } = mockFs();
+    const result = await recoverMounts(entries, fs);
+    expect(result.restored).toEqual([{ path: '/workspace/ok', dirName: 'ok' }]);
+    expect(result.needsRecovery).toEqual([{ path: '/workspace/stale', dirName: 'stale' }]);
+  });
+});
+
+describe('formatMountRecoveryPrompt', () => {
+  it('returns null when there are no mounts to recover', () => {
+    expect(formatMountRecoveryPrompt([])).toBeNull();
+  });
+
+  it('returns null for non-array input (defensive)', () => {
+    expect(formatMountRecoveryPrompt(undefined as unknown as [])).toBeNull();
+  });
+
+  it('produces a single-mount prompt that includes the mount command', () => {
+    const prompt = formatMountRecoveryPrompt([
+      { path: '/workspace/my-project', dirName: 'my-project' },
+    ]);
+    expect(prompt).not.toBeNull();
+    expect(prompt).toContain('Mount recovery required');
+    expect(prompt).toContain('1 mount point');
+    expect(prompt).toContain('/workspace/my-project');
+    expect(prompt).toContain('previously mounted from `my-project`');
+    expect(prompt).toContain('mount /workspace/my-project');
+    expect(prompt).toContain('mount unmount');
+  });
+
+  it('pluralizes when multiple mounts need recovery', () => {
+    const prompt = formatMountRecoveryPrompt([
+      { path: '/workspace/a', dirName: 'a' },
+      { path: '/workspace/b', dirName: 'b' },
+    ]);
+    expect(prompt).not.toBeNull();
+    expect(prompt).toContain('2 mount points');
+    expect(prompt).toContain('mount /workspace/a');
+    expect(prompt).toContain('mount /workspace/b');
+  });
+
+  it('omits the original directory name when it is unknown', () => {
+    const prompt = formatMountRecoveryPrompt([{ path: '/mnt/data', dirName: '' }]);
+    expect(prompt).not.toBeNull();
+    expect(prompt).not.toContain('previously mounted');
+    expect(prompt).toContain('/mnt/data');
+  });
+});

--- a/packages/webapp/tests/fs/mount-recovery.test.ts
+++ b/packages/webapp/tests/fs/mount-recovery.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   recoverMounts,
   formatMountRecoveryPrompt,
+  mdInlineCode,
+  shellQuote,
   type MountRecoveryFS,
 } from '../../src/fs/mount-recovery.js';
 import type { MountEntry } from '../../src/fs/mount-table-store.js';
@@ -161,9 +163,9 @@ describe('formatMountRecoveryPrompt', () => {
     expect(prompt).not.toBeNull();
     expect(prompt).toContain('Mount recovery required');
     expect(prompt).toContain('1 mount point');
-    expect(prompt).toContain('/workspace/my-project');
+    expect(prompt).toContain('`/workspace/my-project`');
     expect(prompt).toContain('previously mounted from `my-project`');
-    expect(prompt).toContain('mount /workspace/my-project');
+    expect(prompt).toContain("mount '/workspace/my-project'");
     expect(prompt).toContain('mount unmount');
   });
 
@@ -174,8 +176,8 @@ describe('formatMountRecoveryPrompt', () => {
     ]);
     expect(prompt).not.toBeNull();
     expect(prompt).toContain('2 mount points');
-    expect(prompt).toContain('mount /workspace/a');
-    expect(prompt).toContain('mount /workspace/b');
+    expect(prompt).toContain("mount '/workspace/a'");
+    expect(prompt).toContain("mount '/workspace/b'");
   });
 
   it('omits the original directory name when it is unknown', () => {
@@ -183,5 +185,88 @@ describe('formatMountRecoveryPrompt', () => {
     expect(prompt).not.toBeNull();
     expect(prompt).not.toContain('previously mounted');
     expect(prompt).toContain('/mnt/data');
+  });
+
+  it('shell-quotes mount paths containing spaces so they parse as one argv token', () => {
+    const prompt = formatMountRecoveryPrompt([{ path: '/mnt/My Project', dirName: 'My Project' }]);
+    expect(prompt).not.toBeNull();
+    // The command must keep the path as a single argv token.
+    expect(prompt).toContain("mount '/mnt/My Project'");
+    // And must NOT emit the unsafe, whitespace-splitting form.
+    expect(prompt).not.toMatch(/^ {4}mount \/mnt\/My Project$/m);
+  });
+
+  it('escapes single quotes inside shell-quoted mount paths', () => {
+    const prompt = formatMountRecoveryPrompt([{ path: "/mnt/It's Work", dirName: "It's Work" }]);
+    expect(prompt).not.toBeNull();
+    // POSIX single-quote escape: close, escape, reopen.
+    expect(prompt).toContain("mount '/mnt/It'\\''s Work'");
+  });
+
+  it('uses a wider backtick delimiter when a value contains backticks', () => {
+    const prompt = formatMountRecoveryPrompt([{ path: '/mnt/weird`path', dirName: 'weird`dir' }]);
+    expect(prompt).not.toBeNull();
+    // Embedded `s force a `` … `` inline code fence so markdown stays valid.
+    expect(prompt).toContain('``/mnt/weird`path``');
+    expect(prompt).toContain('``weird`dir``');
+  });
+
+  it('collapses newlines inside Markdown inline code so the bullet renders on one line', () => {
+    const prompt = formatMountRecoveryPrompt([
+      { path: '/mnt/line1\nline2', dirName: 'weird\r\nname' },
+    ]);
+    expect(prompt).not.toBeNull();
+    // Inline code must not straddle a newline (CommonMark forbids it).
+    expect(prompt).toContain('`/mnt/line1 line2`');
+    expect(prompt).toContain('`weird name`');
+    // The indented shell command is a code block, not inline code, so the
+    // POSIX-correct single-quote form still preserves the real newline
+    // there — callers treat the path as opaque, we don't rewrite it.
+  });
+});
+
+describe('shellQuote', () => {
+  it('wraps plain values in single quotes', () => {
+    expect(shellQuote('/workspace/app')).toBe("'/workspace/app'");
+  });
+
+  it('preserves spaces inside the quoted form', () => {
+    expect(shellQuote('/mnt/My Project')).toBe("'/mnt/My Project'");
+  });
+
+  it('escapes embedded single quotes using the POSIX close-reopen trick', () => {
+    expect(shellQuote("It's")).toBe("'It'\\''s'");
+  });
+
+  it('handles strings with only single quotes', () => {
+    expect(shellQuote("'")).toBe("''\\'''");
+  });
+
+  it('handles empty strings', () => {
+    expect(shellQuote('')).toBe("''");
+  });
+});
+
+describe('mdInlineCode', () => {
+  it('wraps plain values in single backticks', () => {
+    expect(mdInlineCode('/workspace/app')).toBe('`/workspace/app`');
+  });
+
+  it('uses a longer delimiter when the value contains a backtick', () => {
+    expect(mdInlineCode('a`b')).toBe('``a`b``');
+  });
+
+  it('uses a still-longer delimiter when the value contains a run of backticks', () => {
+    expect(mdInlineCode('a``b')).toBe('```a``b```');
+  });
+
+  it('pads leading/trailing backticks with a space so CommonMark parses cleanly', () => {
+    expect(mdInlineCode('`leading')).toBe('`` `leading ``');
+    expect(mdInlineCode('trailing`')).toBe('`` trailing` ``');
+  });
+
+  it('collapses CR/LF to a single space', () => {
+    expect(mdInlineCode('line1\nline2')).toBe('`line1 line2`');
+    expect(mdInlineCode('a\r\nb')).toBe('`a b`');
   });
 });


### PR DESCRIPTION
## Summary

Fixes three issues with mount-point recovery after a page reload:

1. **Documents when recovery is required.** Chrome's File System Access API only retains readwrite permission inside a tab's active session, so a soft navigation usually keeps `queryPermission` at `granted` while a full browser restart drops handles back to `prompt`. The new `fs/mount-recovery.ts` header explains this, and the comment in `main.ts` points readers there so the behaviour is no longer surprising.

2. **Only fires the `session-reload` lick when recovery is actually needed.** The recovery logic now lives in a pure helper `recoverMounts(entries, fs)` that returns a `needsRecovery` bucket. `main.ts` early-returns when the bucket is empty, and `routeLickToScoop` defensively drops any `mount-recovery` event with an empty mounts list so the cone is never pestered with an empty notification.

3. **Gives the cone an actionable prompt instead of a raw JSON dump.** `formatMountRecoveryPrompt` produces a natural-language message that tells the cone to inform the user, lists the affected paths (with the original directory name when available), and offers the exact `mount <path>` / `mount unmount <path>` commands needed to re-authorize each one.

## Tests

New `packages/webapp/tests/fs/mount-recovery.test.ts` (12 tests) covers:

- `granted` / `prompt` / `denied` permission states
- handles missing `queryPermission` entirely (legacy records)
- handles whose `queryPermission` throws
- `fs.mount()` itself failing after permission check
- mixed restored + needs-recovery runs, empty input
- prompt formatter: null-on-empty contract, pluralisation, omission of dirName when unknown, inclusion of `mount` and `mount unmount` commands

## Verification

```
npx prettier --write <changed-files>    # clean
npm run typecheck                        # passes
npm run test                             # 2341 passing (pre-existing 4 unrelated failures unchanged)
npm run build                            # passes
```

## Non-changes

- No changes to the persistence layer in `mount-table-store.ts` — the recovery fix is purely on the consumption side.
- No user-facing docs updated; the new module header and inline comment in `main.ts` are where anyone debugging reload behaviour will look first.