### PR TITLE
fix(swift-server): stop ChromeOutputMonitor busy-loop on pipe EOF

### DIFF
--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -375,10 +375,22 @@ private final class ChromeOutputMonitor: @unchecked Sendable {
 
     private func startReading() {
         stdout.readabilityHandler = { [weak self] handle in
-            self?.consumeStdout(handle.availableData)
+            let data = handle.availableData
+            // Detach synchronously on EOF: if `self` has already been released,
+            // the async hop inside `consumeStdout` becomes a no-op and the
+            // handler would otherwise stay armed, busy-looping on the
+            // NSFileHandle.fd_monitoring queue.
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+            }
+            self?.consumeStdout(data)
         }
         stderr.readabilityHandler = { [weak self] handle in
-            self?.consumeStderr(handle.availableData)
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+            }
+            self?.consumeStderr(data)
         }
     }
 


### PR DESCRIPTION
## Symptom

After Chrome exits (user quits or crash), `slicc-server` spins to 100–200% CPU indefinitely. Each Chrome-kill/relaunch cycle adds another orphan, stacking CPU load over time.

## Root cause

In `ChromeLauncher.swift`, `ChromeOutputMonitor.startReading()` installs this on each pipe:

```swift
stdout.readabilityHandler = { [weak self] handle in
    self?.consumeStdout(handle.availableData)   // async-hops to self.queue
}

private func consumeStdout(_ data: Data) {
    queue.async {
        if data.isEmpty {
            self.stdout.readabilityHandler = nil   // clears handler HERE, async
            ...
        }
    }
}
```

When Chrome exits the pipe hits EOF. The fd_monitoring dispatch source keeps firing (EOF persists). While things are healthy, the first `queue.async` block runs, sees empty data, and clears the handler. But if `ChromeLauncher` has already released the monitor in the meantime, `[weak self]` is nil → `self?.consumeStdout(...)` is a no-op → the handler is never cleared → the dispatch source keeps calling the closure forever. Pure CPU burn with no progress.

## Fix

Clear `handle.readabilityHandler` **synchronously inside the closure** when `handle.availableData` is empty, before any async hop. The cleanup no longer depends on `self` still being alive.

```swift
stdout.readabilityHandler = { [weak self] handle in
    let data = handle.availableData
    if data.isEmpty {
        handle.readabilityHandler = nil
    }
    self?.consumeStdout(data)
}
```

Same for stderr.

## Verification

Repro: launch Sliccstart → kill Chrome → sample slicc-server.

**Before:** `sample` showed a dispatch queue `com.apple.NSFileHandle.fd_monitoring` looping through `-[NSConcreteFileHandle _monitor:]_block_invoke → closure #1 in ChromeOutputMonitor.startReading()` with slicc-server at 99–198% CPU.

**After this patch:**
- `swift test`: 114/114 passed
- `swift build --configuration release`: clean
- Fresh Sliccstart boot → kill Chrome subtree → slicc-server stays at ~0.2–0.9% CPU across 20 s (vs. 100%+ before). Exact log from the verification run:

```
t=1s  CPU=0.3%
t=2s  CPU=0.3%
t=3s  CPU=0.5%
t=5s  CPU=0.9%
t=10s CPU=0.5%
t=20s CPU=0.2%
```

## Scope

One-file change, no behavior change on the happy path (non-empty data still flows through `consumeStdout`/`consumeStderr` on the custom serial queue exactly as before). Setting `readabilityHandler` to nil twice is idempotent, so the existing `self.stdout.readabilityHandler = nil` in `consumeStdout` stays in place for defense-in-depth.