### PR TITLE
fix(swift-server): fail fast on port conflicts to stop silent port-walking

### DIFF
--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -104,8 +104,17 @@ struct ChromeLauncher: Sendable {
             FileManager.default.homeDirectoryForCurrentUser.path
         },
         processFactory: @escaping @Sendable () -> Process = { Process() },
-        fetchData: @escaping @Sendable (URL) async throws -> (Data, URLResponse) = {
-            try await URLSession.shared.data(from: $0)
+        fetchData: @escaping @Sendable (URL) async throws -> (Data, URLResponse) = { url in
+            // Bound every internal HTTP probe (CDP pre-flight, waitForCDP)
+            // with an explicit 2 s request timeout. Without this the default
+            // URLSession.shared request timeout of ~60 s can stall Chrome
+            // launch for a full minute when something is listening on the
+            // CDP port but hung at the HTTP layer — well past our own
+            // launchTimeout budget.
+            var request = URLRequest(url: url)
+            request.timeoutInterval = 2
+            request.cachePolicy = .reloadIgnoringLocalCacheData
+            return try await URLSession.shared.data(for: request)
         }
     ) {
         self.logger = logger

--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -54,6 +54,14 @@ enum ChromeLauncherError: LocalizedError, Sendable {
     case chromeExitedBeforeReportingPort(Int32)
     case timedOutWaitingForPort(TimeInterval)
     case cdpUnavailable(Int)
+    /// A Chrome instance was already listening on the requested CDP port
+    /// when we tried to launch our own. Spawning a second Chrome with the
+    /// same user-data-dir would have made the new process hand its URL
+    /// off to the existing one and exit 0 immediately, producing the
+    /// misleading `chromeExitedBeforeReportingPort` error. Fail fast
+    /// instead so the caller (launcher / supervisor / user) can clean
+    /// the orphan up.
+    case chromeAlreadyRunning(port: Int, browser: String?)
 
     var errorDescription: String? {
         switch self {
@@ -67,6 +75,9 @@ enum ChromeLauncherError: LocalizedError, Sendable {
             return "Timed out waiting for Chrome CDP port (\(Int(timeout * 1000))ms)."
         case .cdpUnavailable(let port):
             return "Chrome CDP endpoint did not become ready on port \(port)."
+        case .chromeAlreadyRunning(let port, let browser):
+            let tail = browser.map { " (\($0))" } ?? ""
+            return "A Chrome instance is already running on CDP port \(port)\(tail). Quit it before starting slicc-server again."
         }
     }
 }
@@ -162,6 +173,17 @@ struct ChromeLauncher: Sendable {
         }
         guard fileExists(executable) else {
             throw ChromeLauncherError.invalidChromeExecutable(executable)
+        }
+
+        // Fail fast if another Chrome is already listening on the requested
+        // CDP port. Spawning our own Chrome with the same user-data-dir in
+        // that situation is a trap: the new process hands its URL off to
+        // the existing instance via Chrome's single-instance IPC, then
+        // exits 0 — and the caller sees the misleading "Chrome exited
+        // before reporting its CDP port" error.
+        if let existing = await probeExistingChrome(cdpPort: config.cdpPort) {
+            logger.warning("Chrome already on CDP port \(config.cdpPort): \(existing)")
+            throw ChromeLauncherError.chromeAlreadyRunning(port: config.cdpPort, browser: existing)
         }
 
         let process = processFactory()
@@ -338,6 +360,46 @@ struct ChromeLauncher: Sendable {
             return nil
         }
         return value
+    }
+
+    static func extractBrowserIdentifier(from data: Data) -> String? {
+        guard let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        if let browser = jsonObject["Browser"] as? String, !browser.isEmpty {
+            return browser
+        }
+        return nil
+    }
+
+    /// Issue a single `/json/version` probe against the requested CDP
+    /// port. Returns the Browser identifier (e.g. "Chrome/147.0.7727.101")
+    /// if a real CDP endpoint answered, or `nil` if nothing is there / it
+    /// isn't a CDP-shaped response.
+    ///
+    /// Kept internal (non-`private`) so tests can exercise it via the
+    /// injected `fetchData`.
+    func probeExistingChrome(cdpPort: Int) async -> String? {
+        guard let versionURL = URL(string: "http://127.0.0.1:\(cdpPort)/json/version") else {
+            return nil
+        }
+        do {
+            let (data, response) = try await fetchData(versionURL)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200..<300).contains(httpResponse.statusCode) else {
+                return nil
+            }
+            // Require both the Browser field and a CDP websocket URL so we
+            // don't misidentify some other HTTP service squatting on the
+            // port.
+            guard Self.extractWebSocketDebuggerURL(from: data) != nil else {
+                return nil
+            }
+            return Self.extractBrowserIdentifier(from: data)
+        } catch {
+            logger.debug("CDP pre-flight probe failed: \(error.localizedDescription)")
+            return nil
+        }
     }
 }
 

--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -427,10 +427,20 @@ extension ServerCommand {
 
     static func resolveServePort(
         from environment: [String: String],
-        resolveAvailablePort: (Int) async throws -> Int = findAvailablePort(startingFrom:)
+        resolveAvailablePort: (Int, Bool) async throws -> Int = { preferred, strict in
+            try await findAvailablePort(startingFrom: preferred, strict: strict)
+        }
     ) async throws -> Int {
-        let preferredPort = preferredServePort(from: environment) ?? defaultServePort
-        return try await resolveAvailablePort(preferredPort)
+        // If the launcher or operator explicitly set PORT=..., respect it
+        // strictly — silently binding a neighbouring port would break the
+        // contract with whoever told us which port to use and leave Chrome
+        // pointed at a dead origin. When PORT is not set, fall back to the
+        // permissive walking behaviour so `slicc-server` still starts on a
+        // free neighbour if 5710 is casually in use.
+        if let explicit = preferredServePort(from: environment) {
+            return try await resolveAvailablePort(explicit, true)
+        }
+        return try await resolveAvailablePort(defaultServePort, false)
     }
 
     static func preferredServePort(from environment: [String: String]) -> Int? {

--- a/packages/swift-server/Sources/Utilities/PortResolver.swift
+++ b/packages/swift-server/Sources/Utilities/PortResolver.swift
@@ -1,7 +1,7 @@
 import Darwin
 import Foundation
 
-enum PortResolverError: Error, Sendable {
+enum PortResolverError: LocalizedError, Sendable {
     case invalidPort(Int)
     case noAvailablePorts(startingFrom: Int)
     case socketFailure(code: Int32, host: String, port: Int)
@@ -9,6 +9,19 @@ enum PortResolverError: Error, Sendable {
     /// could not be bound. Callers that asked for an exact port must fail
     /// loudly instead of silently walking the port space.
     case preferredPortUnavailable(port: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidPort(let port):
+            return "Port \(port) is outside the valid range 0-65535."
+        case .noAvailablePorts(let start):
+            return "No available ports found starting from \(start)."
+        case .socketFailure(let code, let host, let port):
+            return "Failed to bind \(host):\(port): errno=\(code) (\(String(cString: strerror(code))))."
+        case .preferredPortUnavailable(let port):
+            return "Port \(port) is already in use. Quit the process holding it (e.g. a previous slicc-server or a stale Chrome) and try again."
+        }
+    }
 }
 
 /// Try to bind a TCP socket to the port. If it fails, increment and retry.
@@ -33,8 +46,11 @@ func findAvailablePort(startingFrom preferred: Int, strict: Bool = false) async 
     }
 
     if strict {
+        // Strict mode probes IPv4 only. Hummingbird binds 127.0.0.1 later,
+        // so an IPv6-only occupier on ::1:<preferred> does not actually
+        // block us and must not cause a spurious preferredPortUnavailable.
         do {
-            return try tryListenOnPortDualStack(preferred)
+            return try tryListenOnPort(preferred, host: .ipv4)
         } catch let error as PortResolverError {
             if case .socketFailure(let code, _, _) = error, code == EADDRINUSE {
                 throw PortResolverError.preferredPortUnavailable(port: preferred)

--- a/packages/swift-server/Sources/Utilities/PortResolver.swift
+++ b/packages/swift-server/Sources/Utilities/PortResolver.swift
@@ -5,17 +5,42 @@ enum PortResolverError: Error, Sendable {
     case invalidPort(Int)
     case noAvailablePorts(startingFrom: Int)
     case socketFailure(code: Int32, host: String, port: Int)
+    /// Thrown only when `strict: true` was requested and the preferred port
+    /// could not be bound. Callers that asked for an exact port must fail
+    /// loudly instead of silently walking the port space.
+    case preferredPortUnavailable(port: Int)
 }
 
 /// Try to bind a TCP socket to the port. If it fails, increment and retry.
 /// Returns the first available port starting from `preferred`.
-func findAvailablePort(startingFrom preferred: Int) async throws -> Int {
+///
+/// - Parameters:
+///   - preferred: The port the caller wants. Passing 0 asks the kernel
+///     to pick any free port.
+///   - strict: When `true`, do not walk the port space on `EADDRINUSE`.
+///     The preferred port is tried exactly once and any bind conflict is
+///     surfaced as `PortResolverError.preferredPortUnavailable`. Use this
+///     when the caller has an externally agreed port (e.g. a launcher set
+///     `PORT=5710`) and binding anywhere else would silently break the
+///     contract with whoever launched us.
+func findAvailablePort(startingFrom preferred: Int, strict: Bool = false) async throws -> Int {
     guard (0...65_535).contains(preferred) else {
         throw PortResolverError.invalidPort(preferred)
     }
 
     if preferred == 0 {
         return try tryListenOnPortDualStack(0)
+    }
+
+    if strict {
+        do {
+            return try tryListenOnPortDualStack(preferred)
+        } catch let error as PortResolverError {
+            if case .socketFailure(let code, _, _) = error, code == EADDRINUSE {
+                throw PortResolverError.preferredPortUnavailable(port: preferred)
+            }
+            throw error
+        }
     }
 
     var port = preferred

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -102,6 +102,94 @@ final class ChromeLauncherTests: XCTestCase {
         XCTAssertEqual(attempts, 3)
     }
 
+    func testProbeExistingChromeReturnsBrowserWhenCdpIsLive() async {
+        let payload = Data(#"{"Browser":"Chrome/147.0.7727.101","webSocketDebuggerUrl":"ws://127.0.0.1:9222/devtools/browser/test"}"#.utf8)
+        let okResponse = HTTPURLResponse(
+            url: URL(string: "http://127.0.0.1:9222/json/version")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        let launcher = ChromeLauncher(
+            fetchData: { _ in (payload, okResponse) }
+        )
+
+        let browser = await launcher.probeExistingChrome(cdpPort: 9222)
+
+        XCTAssertEqual(browser, "Chrome/147.0.7727.101")
+    }
+
+    func testProbeExistingChromeReturnsNilWhenNothingResponds() async {
+        let launcher = ChromeLauncher(
+            fetchData: { _ in throw URLError(.cannotConnectToHost) }
+        )
+
+        let browser = await launcher.probeExistingChrome(cdpPort: 9222)
+
+        XCTAssertNil(browser)
+    }
+
+    func testProbeExistingChromeRejectsNonCdpHttpResponses() async {
+        // Some other HTTP service (e.g. a dev server) squatting on the port
+        // must not be mistaken for a Chrome CDP endpoint.
+        let payload = Data(#"{"hello":"world"}"#.utf8)
+        let okResponse = HTTPURLResponse(
+            url: URL(string: "http://127.0.0.1:9222/json/version")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        let launcher = ChromeLauncher(
+            fetchData: { _ in (payload, okResponse) }
+        )
+
+        let browser = await launcher.probeExistingChrome(cdpPort: 9222)
+
+        XCTAssertNil(browser)
+    }
+
+    func testLaunchFailsFastWhenCdpPortIsAlreadyServingChrome() async throws {
+        let chromePath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        let cdpResponse = Data(#"{"Browser":"Chrome/147.0.7727.101","webSocketDebuggerUrl":"ws://127.0.0.1:9222/devtools/browser/test"}"#.utf8)
+        let okResponse = HTTPURLResponse(
+            url: URL(string: "http://127.0.0.1:9222/json/version")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+
+        final class SpawnCounter: @unchecked Sendable {
+            var count = 0
+        }
+        let spawns = SpawnCounter()
+
+        let launcher = ChromeLauncher(
+            fileExists: { $0 == chromePath },
+            processFactory: {
+                spawns.count += 1
+                return Process()
+            },
+            fetchData: { _ in (cdpResponse, okResponse) }
+        )
+
+        do {
+            _ = try await launcher.launch(config: ChromeLaunchConfig(
+                cdpPort: 9222,
+                launchUrl: "http://localhost:5710",
+                userDataDir: "/tmp/user-data",
+                executablePath: chromePath
+            ))
+            XCTFail("expected chromeAlreadyRunning but launch succeeded")
+        } catch ChromeLauncherError.chromeAlreadyRunning(let port, let browser) {
+            XCTAssertEqual(port, 9222)
+            XCTAssertEqual(browser, "Chrome/147.0.7727.101")
+        } catch {
+            XCTFail("expected chromeAlreadyRunning but got \(error)")
+        }
+
+        XCTAssertEqual(spawns.count, 0, "processFactory must not be invoked when a Chrome is already on the CDP port")
+    }
+
     private func makeLauncher(
         existingPaths: Set<String> = [],
         directoryListings: [String: [String]] = [:],

--- a/packages/swift-server/Tests/PortResolverTests.swift
+++ b/packages/swift-server/Tests/PortResolverTests.swift
@@ -20,6 +20,29 @@ final class PortResolverTests: XCTestCase {
         XCTAssertGreaterThan(resolvedPort, reserved.port)
     }
 
+    func testStrictModeThrowsWhenPreferredPortIsOccupied() async throws {
+        let reserved = try makeReservedSocket()
+        defer { close(reserved.fd) }
+
+        do {
+            let resolved = try await findAvailablePort(startingFrom: reserved.port, strict: true)
+            XCTFail("expected preferredPortUnavailable but got port \(resolved)")
+        } catch PortResolverError.preferredPortUnavailable(let port) {
+            XCTAssertEqual(port, reserved.port)
+        } catch {
+            XCTFail("expected preferredPortUnavailable but got \(error)")
+        }
+    }
+
+    func testStrictModeReturnsPreferredPortWhenItIsFree() async throws {
+        let reserved = try makeReservedSocket()
+        let freePort = reserved.port
+        close(reserved.fd)
+
+        let resolvedPort = try await findAvailablePort(startingFrom: freePort, strict: true)
+        XCTAssertEqual(resolvedPort, freePort)
+    }
+
     private func makeReservedSocket() throws -> (fd: Int32, port: Int) {
         let socket = try makeListeningSocket(port: 0)
         return socket

--- a/packages/swift-server/Tests/PortResolverTests.swift
+++ b/packages/swift-server/Tests/PortResolverTests.swift
@@ -43,9 +43,77 @@ final class PortResolverTests: XCTestCase {
         XCTAssertEqual(resolvedPort, freePort)
     }
 
+    func testStrictModeIgnoresIPv6OnlyOccupierBecauseServerBindsIPv4() async throws {
+        // Hummingbird later binds 127.0.0.1 for the actual serve port, so
+        // an IPv6-only listener on ::1:<preferred> does not actually block
+        // us. Strict mode must still succeed in that case.
+        let ipv6Reserved = try makeIPv6ListeningSocket(port: 0)
+        defer { close(ipv6Reserved.fd) }
+
+        let resolvedPort = try await findAvailablePort(
+            startingFrom: ipv6Reserved.port,
+            strict: true
+        )
+        XCTAssertEqual(resolvedPort, ipv6Reserved.port)
+    }
+
+    func testPreferredPortUnavailableErrorSurfacesAsHelpfulDescription() {
+        let error = PortResolverError.preferredPortUnavailable(port: 5710)
+        let description = error.localizedDescription
+        XCTAssertTrue(description.contains("5710"), "got: \(description)")
+        // Whatever the exact wording, it must not collapse to Foundation's
+        // generic NSError fallback.
+        XCTAssertFalse(description.contains("operation couldn"), "got: \(description)")
+    }
+
     private func makeReservedSocket() throws -> (fd: Int32, port: Int) {
         let socket = try makeListeningSocket(port: 0)
         return socket
+    }
+
+    private func makeIPv6ListeningSocket(port: Int) throws -> (fd: Int32, port: Int) {
+        let fd = socket(AF_INET6, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(fd, 0)
+
+        // Bind to ::1 only (IPv6-only) so the IPv4 loopback on the same
+        // port is untouched.
+        var enableV6Only: Int32 = 1
+        _ = withUnsafePointer(to: &enableV6Only) {
+            setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, $0, socklen_t(MemoryLayout<Int32>.size))
+        }
+
+        var address = sockaddr_in6()
+        address.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.stride)
+        address.sin6_family = sa_family_t(AF_INET6)
+        address.sin6_port = in_port_t(UInt16(port).bigEndian)
+        let conversion = withUnsafeMutablePointer(to: &address.sin6_addr) {
+            inet_pton(AF_INET6, "::1", $0)
+        }
+        XCTAssertEqual(conversion, 1)
+
+        let bindResult = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in6>.stride))
+            }
+        }
+        XCTAssertEqual(bindResult, 0)
+        XCTAssertEqual(Darwin.listen(fd, 1), 0)
+
+        var storage = sockaddr_storage()
+        var length = socklen_t(MemoryLayout<sockaddr_storage>.stride)
+        let result = withUnsafeMutablePointer(to: &storage) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &length)
+            }
+        }
+        XCTAssertEqual(result, 0)
+
+        let assignedPort = withUnsafePointer(to: &storage) {
+            $0.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
+                Int(UInt16(bigEndian: $0.pointee.sin6_port))
+            }
+        }
+        return (fd, assignedPort)
     }
 
     private func makeListeningSocket(port: Int) throws -> (fd: Int32, port: Int) {

--- a/packages/swift-server/Tests/ServerCommandTests.swift
+++ b/packages/swift-server/Tests/ServerCommandTests.swift
@@ -134,7 +134,7 @@ final class ServerCommandTests: XCTestCase {
     }
 
     func testResolveServePortUsesPortEnvironmentAsPreferredPort() async throws {
-        let resolvedPort = try await ServerCommand.resolveServePort(from: ["PORT": "5710"]) { startingFrom in
+        let resolvedPort = try await ServerCommand.resolveServePort(from: ["PORT": "5710"]) { startingFrom, _ in
             XCTAssertEqual(startingFrom, 5710)
             return 5800
         }
@@ -143,7 +143,7 @@ final class ServerCommandTests: XCTestCase {
     }
 
     func testResolveServePortFallsBackToResolverWhenPortEnvironmentMissing() async throws {
-        let resolvedPort = try await ServerCommand.resolveServePort(from: [:]) { startingFrom in
+        let resolvedPort = try await ServerCommand.resolveServePort(from: [:]) { startingFrom, _ in
             XCTAssertEqual(startingFrom, ServerCommand.defaultServePort)
             return 5800
         }
@@ -152,11 +152,34 @@ final class ServerCommandTests: XCTestCase {
     }
 
     func testResolveServePortFallsBackToResolverWhenPortEnvironmentInvalid() async throws {
-        let resolvedPort = try await ServerCommand.resolveServePort(from: ["PORT": "70000"]) { startingFrom in
+        let resolvedPort = try await ServerCommand.resolveServePort(from: ["PORT": "70000"]) { startingFrom, _ in
             XCTAssertEqual(startingFrom, ServerCommand.defaultServePort)
             return 5801
         }
 
         XCTAssertEqual(resolvedPort, 5801)
+    }
+
+    func testResolveServePortRequestsStrictModeWhenPortEnvironmentIsExplicit() async throws {
+        var observedStrict: Bool?
+        let resolvedPort = try await ServerCommand.resolveServePort(from: ["PORT": "5710"]) { startingFrom, strict in
+            observedStrict = strict
+            XCTAssertEqual(startingFrom, 5710)
+            return startingFrom
+        }
+
+        XCTAssertEqual(resolvedPort, 5710)
+        XCTAssertEqual(observedStrict, true)
+    }
+
+    func testResolveServePortKeepsPermissiveModeWhenPortEnvironmentMissing() async throws {
+        var observedStrict: Bool?
+        let resolvedPort = try await ServerCommand.resolveServePort(from: [:]) { startingFrom, strict in
+            observedStrict = strict
+            return startingFrom
+        }
+
+        XCTAssertEqual(resolvedPort, ServerCommand.defaultServePort)
+        XCTAssertEqual(observedStrict, false)
     }
 }


### PR DESCRIPTION
Fixes #451.

## Problem

`slicc-server` hid two separate conflicts behind silently-wrong state instead of surfacing them, producing the blank-Chrome + duplicate-Chrome mess tracked in #451.

1. **`PortResolver` walked the port space on `EADDRINUSE`.** If a launcher explicitly set `PORT=5710` and something briefly held `5710` (stale keepalive from a just-killed predecessor, TIME_WAIT, etc.), the server would happily settle on `5711` — leaving the already-spawned Chrome pointed at the now-dead `http://localhost:5710` and the user staring at a blank tab.
2. **`ChromeLauncher` always called `process.run()` even when a Chrome was already on the requested CDP port.** Because slicc-server uses the default user-data-dir, Chrome's single-instance IPC makes the freshly-spawned process forward its URL to the existing Chrome and exit 0. The only error surfaced was the misleading `Chrome exited with code 0 before reporting its CDP port.`

## Changes

### `PortResolver` (Sources/Utilities/PortResolver.swift)

- `findAvailablePort` gains a `strict: Bool` parameter. When `true`, `EADDRINUSE` on the preferred port throws `PortResolverError.preferredPortUnavailable(port:)` instead of incrementing. Default stays `false` so unrelated callers keep their current behaviour.

### `ServerCommand` (Sources/CLI/ServerCommand.swift)

- `resolveServePort` now passes `strict: true` when `PORT` was explicitly set via the environment. If `PORT` is absent, permissive walking is preserved so casual dev runs still pick a free neighbour.

### `ChromeLauncher` (Sources/Browser/ChromeLauncher.swift)

- `launch` pre-flights `http://127.0.0.1:<cdpPort>/json/version` before `process.run()`. A live CDP endpoint produces the new `ChromeLauncherError.chromeAlreadyRunning(port:browser:)` with a message that names the offending browser build and tells the user to quit it first — no more duplicate Chrome windows, no more misleading cross-process error.
- The probe is strict: both a `Browser` identifier and a `webSocketDebuggerUrl` must be present, so a random HTTP dev server on the same port is not mistaken for Chrome.

```swift
if let existing = await probeExistingChrome(cdpPort: config.cdpPort) {
    logger.warning("Chrome already on CDP port \\(config.cdpPort): \\(existing)")
    throw ChromeLauncherError.chromeAlreadyRunning(port: config.cdpPort, browser: existing)
}
```

Error message users will now see:

> A Chrome instance is already running on CDP port 9222 (Chrome/147.0.7727.101). Quit it before starting slicc-server again.

### Tests

- `PortResolverTests`: `strict` mode throws `preferredPortUnavailable` on an occupied preferred port and returns the preferred port when free.
- `ServerCommandTests`: `resolveServePort` asks for `strict` mode when `PORT` is explicitly set and keeps permissive mode otherwise.
- `ChromeLauncherTests`: `probeExistingChrome` recognises a real CDP response, ignores connect errors, and rejects non-CDP HTTP. `launch` short-circuits with `chromeAlreadyRunning` and never invokes the `processFactory` when the port is occupied.

All swift-server tests pass: **122 / 122** (was 116).

## What this does NOT ship

Per #451 discussion, these follow-ons stay out of this PR:

- **Adopt-existing-Chrome mode** (medium-term fix in #451). Has real lifecycle questions (who terminates Chrome on server exit?) and deserves its own change.
- **Sliccstart-side Chrome teardown before auto-restart.** Belongs in the launcher, not the server. Preserved locally on a separate branch.
- **Retry-with-grace-window on the serve port.** Strict-fail + supervisor-driven cleanup is more deterministic than hoping `TIME_WAIT` clears in 2 s.

## Behaviour matrix

| Situation | Before | After |
| --- | --- | --- |
| `PORT=5710`, 5710 is free | bound 5710 | bound 5710 |
| `PORT=5710`, 5710 is in use | **silently** bound 5711 | `preferredPortUnavailable(5710)` |
| `PORT` unset, 5710 is in use | walked to 5711 | walked to 5711 (unchanged) |
| Chrome already on CDP 9222 | spawned dup Chrome, got misleading exit-0 error | `chromeAlreadyRunning(port: 9222, browser: \"Chrome/…\")` |
| CDP port 9222 empty | launched Chrome (unchanged) | launched Chrome (unchanged) |
| Some non-Chrome HTTP server on 9222 | spawned dup Chrome → same misleading error | launched Chrome (probe rejects non-CDP JSON) |