### PR TITLE
fix(webapp): render licks from history + ?ui-fixture=1 design harness

### DIFF
--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -83,6 +83,7 @@ User → ChatPanel → Orchestrator → ScoopContext.prompt() → pi-agent-core 
 - `main.ts` boots standalone mode or delegates to the extension offscreen client.
 - `layout.ts`, `tabbed-ui.ts`, and `tab-zone.ts` manage the main container model.
 - `preview-sw.ts` serves `/preview/*` content from VFS and is built as a standalone IIFE.
+- **Design-time chat fixture**: load the app with `?ui-fixture=1` (also accepts `?ui-fixture` or `?ui-fixture=true`) to swap the chat view for a synthetic session covering every message variant — user/assistant bubbles, markdown + code blocks, all four tool-call states, the six lick channels, delegation, queued messages, and a streaming tail. Messages live in `chat-fixture.ts` (pure `createChatFixture()`) and persist to a dedicated `session-ui-fixture` id so real scoop storage is untouched; clicking any real scoop cleanly exits fixture mode. Vite HMR picks up CSS changes live against the fixture. When adding new message UI variants, extend `createChatFixture()` and the matching assertion in `tests/ui/chat-fixture.test.ts` so the harness stays comprehensive.
 
 ### Skills
 

--- a/packages/webapp/src/ui/chat-fixture.ts
+++ b/packages/webapp/src/ui/chat-fixture.ts
@@ -153,6 +153,93 @@ export function createChatFixture(): ChatMessage[] {
     ],
   });
 
+  // ── 3b. Cone-only scoop management tools ──────────────────────────
+  // Covers every tool in scoops/scoop-management-tools.ts so styling
+  // changes to the tool-call widget can be judged against realistic
+  // scoop-wrangling flows, not only file/bash operations.
+  const toolCallListScoops: ToolCall = {
+    id: 'fx-tc-list-scoops',
+    name: 'list_scoops',
+    input: {},
+    result:
+      'Registered scoops:\n' +
+      '- sliccy (cone) [CONE] — ready (since Jan 1, 9:58 AM)\n' +
+      '- Hero Block (hero-block-scoop) — ready (since Jan 1, 9:59 AM)\n' +
+      '- Install Doc Writer (install-doc-writer-scoop) — idle',
+  };
+  const toolCallScoopScoop: ToolCall = {
+    id: 'fx-tc-scoop-scoop',
+    name: 'scoop_scoop',
+    input: {
+      name: 'Release Notes',
+      model: 'claude-sonnet-4-6',
+      prompt: 'Draft release notes for v0.3.2 using the merged PR titles from the last 7 days.',
+      visiblePaths: ['/workspace/', '/shared/releases/'],
+      writablePaths: ['/scoops/release-notes-scoop/', '/shared/releases/'],
+    },
+    result:
+      'Scoop "Release Notes" created as "release-notes-scoop" and task sent. It is now working on it.',
+  };
+  const toolCallScoopScoopError: ToolCall = {
+    id: 'fx-tc-scoop-scoop-err',
+    name: 'scoop_scoop',
+    input: { name: 'Release Notes' },
+    result: 'Failed to create scoop: a scoop named "release-notes-scoop" already exists.',
+    isError: true,
+  };
+  const toolCallFeedScoop: ToolCall = {
+    id: 'fx-tc-feed',
+    name: 'feed_scoop',
+    input: {
+      scoop_name: 'hero-block-scoop',
+      prompt:
+        'Update the hero block to use the new gradient background defined in /shared/tokens/brand.css. ' +
+        'Preserve the existing copy. Run the snapshot tests when done.',
+    },
+    result: 'Task sent to hero-block-scoop. You will be notified when it completes.',
+  };
+  const toolCallSendMessage: ToolCall = {
+    id: 'fx-tc-send',
+    name: 'send_message',
+    input: {
+      text: 'Checkpoint: finished the CSS token pass, starting on the test snapshots.',
+      sender: 'hero-block-scoop',
+    },
+    result: 'Message sent.',
+  };
+  const toolCallDropScoop: ToolCall = {
+    id: 'fx-tc-drop',
+    name: 'drop_scoop',
+    input: { scoop_name: 'install-doc-writer-scoop' },
+    result: 'Scoop "Install Doc Writer" (install-doc-writer-scoop) has been dropped.',
+  };
+  const toolCallUpdateGlobalMemory: ToolCall = {
+    id: 'fx-tc-memory',
+    name: 'update_global_memory',
+    input: {
+      content:
+        '# Global Memory\n\n- Brand colors now live in /shared/tokens/brand.css\n' +
+        '- Release notes ship on Wednesdays\n',
+    },
+    result: 'Global memory updated successfully.',
+  };
+
+  messages.push({
+    id: 'fx-assistant-scoop-mgmt',
+    role: 'assistant',
+    content: 'Spinning up the scoops I need and handing out the work.',
+    timestamp: tsAt(3),
+    toolCalls: [
+      toolCallListScoops,
+      toolCallScoopScoop,
+      toolCallScoopScoopError,
+      toolCallFeedScoop,
+      toolCallSendMessage,
+      toolCallDropScoop,
+      toolCallUpdateGlobalMemory,
+    ],
+  });
+
   // ── 4. Delegation from cone ────────────────────────────────────────
   messages.push({
     id: 'fx-delegation-1',

--- a/packages/webapp/src/ui/chat-fixture.ts
+++ b/packages/webapp/src/ui/chat-fixture.ts
@@ -1,0 +1,303 @@
+/**
+ * UI fixture — a synthetic chat session covering every message UI
+ * variant so designers can iterate on the chat panel without having to
+ * drive a real conversation.
+ *
+ * Activated by loading the app with `?ui-fixture=1`. The messages are
+ * persisted to a dedicated `session-ui-fixture` session id so they
+ * survive reloads without touching real scoop storage.
+ *
+ * When updating the fixture, add variants rather than replacing old
+ * ones — the goal is for every CSS rule in chat/tools/lick/feedback
+ * styles to have a matching sample here.
+ */
+
+import type { ChatMessage, ToolCall } from './types.js';
+
+/** Base timestamp: 2024-01-01 10:00:00 local. Keeping it fixed makes the
+ *  rendered timeline deterministic and avoids "5 seconds ago" style
+ *  drift when the fixture is reloaded. */
+const T0 = new Date('2024-01-01T10:00:00').getTime();
+
+/** Advance the clock by `minutes` from T0 — used so lick messages pass
+ *  `shouldShowLabel`'s >2min-gap check and trigger a new avatar row. */
+function tsAt(minutes: number): number {
+  return T0 + minutes * 60_000;
+}
+
+/** Session id used by `loadFixtureSession`. Exported so main.ts and
+ *  tests can reference it without duplicating the string. */
+export const FIXTURE_SESSION_ID = 'session-ui-fixture';
+
+/** Scoop name shown in the header when the fixture is active.
+ *  Passed to `switchToContext(_, _, scoopName)` so message labels
+ *  render as `@ui-fixture` instead of `sliccy`. */
+export const FIXTURE_SCOOP_NAME = 'ui-fixture';
+
+/** Build the synthetic chat history. Pure function — no side effects.
+ *  Each message has a stable id so the fixture is idempotent under
+ *  re-renders and matches exact-id lookups in tests. */
+export function createChatFixture(): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+
+  // ── 1. User + short assistant ──────────────────────────────────────
+  messages.push({
+    id: 'fx-user-1',
+    role: 'user',
+    content: 'Hey sliccy — can you summarize what this fixture covers?',
+    timestamp: tsAt(0),
+  });
+
+  messages.push({
+    id: 'fx-assistant-1',
+    role: 'assistant',
+    content:
+      'Sure! This session walks through every chat UI variant I know about. ' +
+      "You'll see user and assistant bubbles, tool calls in every status, " +
+      'the six lick channels, a delegation, queued messages, and a streaming ' +
+      'tail at the end so you can inspect the live state.',
+    timestamp: tsAt(0.2),
+  });
+
+  // ── 2. Markdown + code block + inline formatting ──────────────────
+  messages.push({
+    id: 'fx-user-2',
+    role: 'user',
+    content: 'Show me some **markdown** — headings, lists, code, a blockquote.',
+    timestamp: tsAt(1),
+  });
+
+  messages.push({
+    id: 'fx-assistant-2',
+    role: 'assistant',
+    content: [
+      '## Rich content sample',
+      '',
+      'Here is a short list:',
+      '',
+      '- `renderAssistantMessageContent` handles GFM markdown',
+      '- Code blocks get syntax highlighting',
+      '- Inline `code` uses the mono token',
+      '',
+      'A fenced code block:',
+      '',
+      '```ts',
+      "import { createChatFixture } from './chat-fixture.js';",
+      '',
+      'const msgs = createChatFixture();',
+      'console.log(msgs.length);',
+      '```',
+      '',
+      '> Blockquotes should feel quieter than regular text.',
+      '',
+      'And a nested ordered list:',
+      '',
+      '1. First step',
+      '2. Second step',
+      '   1. Sub-step A',
+      '   2. Sub-step B',
+      '3. Third step',
+    ].join('\n'),
+    timestamp: tsAt(1.3),
+  });
+
+  // ── 3. Assistant with tool calls in every status ───────────────────
+  const toolCallSuccess: ToolCall = {
+    id: 'fx-tc-read',
+    name: 'read_file',
+    input: { path: '/workspace/README.md' },
+    result: '# Sample README\n\nThis is the contents that read_file returned.',
+  };
+  const toolCallBashSuccess: ToolCall = {
+    id: 'fx-tc-bash',
+    name: 'bash',
+    input: { command: 'ls -la /workspace' },
+    result:
+      'total 24\ndrwxr-xr-x 4 user user 4096 Jan 01 10:00 .\ndrwxr-xr-x 6 user user 4096 Jan 01 10:00 ..\n-rw-r--r-- 1 user user  187 Jan 01 10:00 README.md\ndrwxr-xr-x 2 user user 4096 Jan 01 10:00 src',
+  };
+  const toolCallError: ToolCall = {
+    id: 'fx-tc-err',
+    name: 'edit_file',
+    input: { path: '/workspace/missing.ts', old_str: 'x', new_str: 'y' },
+    result: 'ENOENT: no such file or directory, open "/workspace/missing.ts"',
+    isError: true,
+  };
+  // Running / streaming tool call — result undefined renders the spinner.
+  const toolCallRunning: ToolCall = {
+    id: 'fx-tc-run',
+    name: 'bash',
+    input: { command: 'npm run test -- --coverage' },
+  };
+  // A tool call carrying a transient screenshot (1x1 transparent PNG is
+  // enough to exercise the thumbnail rendering path).
+  const toolCallScreenshot: ToolCall = {
+    id: 'fx-tc-shot',
+    name: 'bash',
+    input: { command: 'playwright-cli screenshot' },
+    result: 'Screenshot saved to /tmp/shot.png',
+    _screenshotDataUrl:
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+  };
+
+  messages.push({
+    id: 'fx-assistant-3',
+    role: 'assistant',
+    content: 'Let me check a few things before I answer.',
+    timestamp: tsAt(2),
+    toolCalls: [
+      toolCallSuccess,
+      toolCallBashSuccess,
+      toolCallError,
+      toolCallRunning,
+      toolCallScreenshot,
+    ],
+  });
+
+  // ── 4. Delegation from cone ────────────────────────────────────────
+  messages.push({
+    id: 'fx-delegation-1',
+    role: 'user',
+    content:
+      '**[Instructions from sliccy]**\n\nRead `/workspace/README.md` and extract the install steps into `/shared/install.md`.',
+    timestamp: tsAt(4),
+    source: 'delegation',
+    channel: 'delegation',
+  });
+
+  messages.push({
+    id: 'fx-assistant-delegated',
+    role: 'assistant',
+    content:
+      'Extracted the install steps. Wrote them to `/shared/install.md`. ' +
+      'The section covers prerequisites, npm install, and the dev server launch.',
+    timestamp: tsAt(4.4),
+    source: 'cone',
+  });
+
+  // ── 5. Licks — one per channel ────────────────────────────────────
+  messages.push({
+    id: 'fx-lick-webhook',
+    role: 'user',
+    content:
+      '[Webhook Event: github-push]\n```json\n' +
+      JSON.stringify(
+        {
+          ref: 'refs/heads/main',
+          repository: { full_name: 'example/repo' },
+          head_commit: { message: 'fix(ui): tighten button contrast in dark mode' },
+        },
+        null,
+        2
+      ) +
+      '\n```',
+    timestamp: tsAt(6),
+    source: 'lick',
+    channel: 'webhook',
+  });
+
+  messages.push({
+    id: 'fx-lick-cron',
+    role: 'user',
+    content:
+      '[Cron Event: daily-digest]\n```json\n' +
+      JSON.stringify({ time: new Date(tsAt(8)).toISOString() }, null, 2) +
+      '\n```',
+    timestamp: tsAt(8),
+    source: 'lick',
+    channel: 'cron',
+  });
+
+  messages.push({
+    id: 'fx-lick-sprinkle',
+    role: 'user',
+    content:
+      '[Sprinkle Event: welcome]\n```json\n' +
+      JSON.stringify({ action: 'onboarding-complete', data: { mountWorkspace: true } }, null, 2) +
+      '\n```',
+    timestamp: tsAt(10),
+    source: 'lick',
+    channel: 'sprinkle',
+  });
+
+  messages.push({
+    id: 'fx-lick-fswatch',
+    role: 'user',
+    content:
+      '[File Watch Event: src-watch]\n```json\n' +
+      JSON.stringify(
+        {
+          changes: [
+            { type: 'modified', path: '/workspace/src/app.ts' },
+            { type: 'created', path: '/workspace/src/utils.ts' },
+          ],
+        },
+        null,
+        2
+      ) +
+      '\n```',
+    timestamp: tsAt(12),
+    source: 'lick',
+    channel: 'fswatch',
+  });
+
+  messages.push({
+    id: 'fx-lick-navigate',
+    role: 'user',
+    content:
+      '[Navigate Event: https://www.sliccy.ai/handoff?msg=handoff%3Ademo]\n```json\n' +
+      JSON.stringify(
+        {
+          url: 'https://www.sliccy.ai/handoff?msg=handoff%3Ademo',
+          sliccHeader: 'handoff:demo',
+          title: 'Handoff',
+        },
+        null,
+        2
+      ) +
+      '\n```',
+    timestamp: tsAt(14),
+    source: 'lick',
+    channel: 'navigate',
+  });
+
+  messages.push({
+    id: 'fx-lick-session-reload',
+    role: 'user',
+    content:
+      '[Session Reload: mount-recovery]\n\n' +
+      'A previously-mounted directory needs to be reauthorized:\n\n' +
+      '- `/mnt/workspace` (was `workspace/`)',
+    timestamp: tsAt(16),
+    source: 'lick',
+    channel: 'session-reload',
+  });
+
+  // ── 6. Queued messages (before the streaming tail) ────────────────
+  messages.push({
+    id: 'fx-queued-1',
+    role: 'user',
+    content: 'Also double-check the install.md formatting after you finish.',
+    timestamp: tsAt(18),
+    queued: true,
+  });
+
+  // ── 7. Streaming / live-state tail ────────────────────────────────
+  // Assistant message mid-stream — the cursor keeps blinking via CSS.
+  messages.push({
+    id: 'fx-assistant-streaming',
+    role: 'assistant',
+    content: "Great, running the coverage suite now. I'll report back as soon as it ",
+    timestamp: tsAt(20),
+    isStreaming: true,
+    toolCalls: [
+      {
+        id: 'fx-tc-streaming',
+        name: 'bash',
+        input: { command: 'npm run test -- --coverage' },
+        // No result — renders the running spinner.
+      },
+    ],
+  });
+
+  return messages;
+}

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -196,6 +196,52 @@ export class ChatPanel {
     }
   }
 
+  /** Persist a lick message into an arbitrary session (by id).
+   *
+   * Used by `routeLickToScoop` when the lick arrives for a scoop that isn't
+   * currently selected: we still want the next reload's first-select to
+   * render the lick as a lick widget, not as a plain user bubble loaded from
+   * orchestrator DB. Safe to call concurrently with the panel's own saves —
+   * writes are scoped to the non-selected session id so there's no overlap.
+   */
+  async persistLickToSession(
+    sessionId: string,
+    lick: {
+      id: string;
+      content: string;
+      channel: 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload' | 'navigate';
+      timestamp: number;
+    }
+  ): Promise<void> {
+    try {
+      const existing = await this.sessionStore.load(sessionId);
+      const messages = existing?.messages ?? [];
+      if (messages.some((m) => m.id === lick.id)) return; // already there
+      const msg: ChatMessage = {
+        id: lick.id,
+        role: 'user',
+        content: lick.content,
+        timestamp: lick.timestamp,
+        source: 'lick',
+        channel: lick.channel,
+      };
+      // Insert in timestamp order so the persisted history stays monotonic.
+      let insertAt = messages.length;
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i].timestamp <= lick.timestamp) {
+          insertAt = i + 1;
+          break;
+        }
+        insertAt = i;
+      }
+      messages.splice(insertAt, 0, msg);
+      await this.sessionStore.saveMessages(sessionId, messages);
+    } catch {
+      // Persistence errors are non-fatal — the orchestrator DB remains
+      // authoritative and will backfill via the DB fallback on next open.
+    }
+  }
+
   /** Lock/unlock input based on external processing state (e.g., cone auto-activated by scoop notification). */
   setProcessing(busy: boolean): void {
     if (busy) {
@@ -218,22 +264,47 @@ export class ChatPanel {
     this.persistSession();
   }
 
-  /** Add a lick message (webhook/cron/sprinkle event). */
+  /** Add a lick message (webhook/cron/sprinkle event).
+   *
+   * Pass `timestamp` when replaying from history so ordering is preserved.
+   * Omit it (defaults to `Date.now()`) for live events. History replays
+   * insert the message in timestamp order so backfill doesn't break the
+   * chronological flow; live events append.
+   */
   addLickMessage(
     id: string,
     content: string,
-    channel: 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload' | 'navigate'
+    channel: 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload' | 'navigate',
+    timestamp?: number
   ): void {
+    const ts = timestamp ?? Date.now();
+    // Ignore duplicate id (can happen when merging live buffer + DB fallback).
+    if (this.messages.some((m) => m.id === id)) return;
     const msg: ChatMessage = {
       id,
       role: 'user',
       content,
-      timestamp: Date.now(),
+      timestamp: ts,
       source: 'lick',
       channel,
     };
-    this.messages.push(msg);
-    this.appendMessageEl(msg);
+
+    // Find the correct insertion index so history-replay stays ordered.
+    let insertAt = this.messages.length;
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      if (this.messages[i].timestamp <= ts) {
+        insertAt = i + 1;
+        break;
+      }
+      insertAt = i;
+    }
+    if (insertAt === this.messages.length) {
+      this.messages.push(msg);
+      this.appendMessageEl(msg);
+    } else {
+      this.messages.splice(insertAt, 0, msg);
+      this.renderMessages();
+    }
     this.persistSession();
   }
 

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -17,6 +17,7 @@ import {
 } from './inline-sprinkle.js';
 import { createToolUIRenderer, disposeToolUIRenderer } from './tool-ui-renderer.js';
 import { getToolDescriptor, createToolIcon, createToolBody, toolStatus } from './tool-call-view.js';
+import { getLickDescriptor, createLickIcon, parseLickContent } from './lick-view.js';
 import {
   getAllAvailableModels,
   getSelectedModelId,
@@ -1338,44 +1339,44 @@ export class ChatPanel {
     return row;
   }
 
-  /** Create a lick element (webhook/cron event) styled like tool calls */
+  /** Create a lick element (webhook/cron/sprinkle/...) styled as an
+   *  incoming bubble — right-aligned like user messages, icon on the
+   *  right side, collapsed preview carries the canonical event name. */
   private createLickEl(msg: ChatMessage): HTMLElement {
+    const desc = getLickDescriptor(msg);
+    const { preview, body } = parseLickContent(msg.content);
+
     const el = document.createElement('details');
-    el.className = 'lick';
+    el.className = `lick lick--${msg.channel ?? 'event'}`;
 
-    const channelType =
-      msg.channel === 'webhook'
-        ? 'Webhook'
-        : msg.channel === 'cron'
-          ? 'Cron'
-          : msg.channel === 'fswatch'
-            ? 'File Watch'
-            : msg.channel === 'navigate'
-              ? 'Navigate'
-              : 'Event';
-
-    // Summary shows tongue emoji and type
     const summary = document.createElement('summary');
     summary.className = 'lick__header';
-    summary.innerHTML = `<span class="lick__icon">E</span> <span class="lick__type">${channelType}</span>`;
 
-    // Add brief preview
-    const preview = document.createElement('span');
-    preview.className = 'lick__preview';
-    // Extract a meaningful preview from the content
-    const contentPreview = msg.content
-      .replace(/\[Webhook Event:.*?\]\n```json\n?/s, '')
-      .slice(0, 50);
-    preview.textContent =
-      contentPreview.replace(/\n/g, ' ') + (contentPreview.length >= 50 ? '...' : '');
-    summary.appendChild(preview);
+    const label = document.createElement('span');
+    label.className = 'lick__type';
+    label.textContent = desc.label;
+    summary.appendChild(label);
+
+    if (preview) {
+      const previewEl = document.createElement('span');
+      previewEl.className = 'lick__preview';
+      previewEl.textContent = preview;
+      summary.appendChild(previewEl);
+    }
+
+    const iconWrap = document.createElement('span');
+    iconWrap.className = 'lick__icon';
+    iconWrap.appendChild(createLickIcon(msg));
+    summary.appendChild(iconWrap);
 
     el.appendChild(summary);
 
-    // Details content
+    // Expanded body — render the remainder (sans the `[Xyz Event: name]`
+    // header) as markdown. Payload JSON stays as a raw fenced code block
+    // because the shape isn't fixed and we don't want to alter it.
     const details = document.createElement('div');
     details.className = 'lick__details';
-    details.innerHTML = renderMessageContent(msg.content);
+    details.innerHTML = renderMessageContent(body);
     el.appendChild(details);
 
     return el;

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -6,12 +6,7 @@
  */
 
 import type { AgentHandle, AgentEvent, ChatMessage, ToolCall } from './types.js';
-import {
-  renderAssistantMessageContent,
-  renderMessageContent,
-  renderToolInput,
-  escapeHtml,
-} from './message-renderer.js';
+import { renderAssistantMessageContent, renderMessageContent } from './message-renderer.js';
 import { SessionStore } from './session-store.js';
 import { createLogger } from '../core/logger.js';
 import { VoiceInput, getVoiceAutoSend, getVoiceLang } from './voice-input.js';
@@ -21,6 +16,7 @@ import {
   type InlineSprinkleInstance,
 } from './inline-sprinkle.js';
 import { createToolUIRenderer, disposeToolUIRenderer } from './tool-ui-renderer.js';
+import { getToolDescriptor, createToolIcon, createToolBody, toolStatus } from './tool-call-view.js';
 import {
   getAllAvailableModels,
   getSelectedModelId,
@@ -34,28 +30,6 @@ const log = createLogger('chat-panel');
 /** Generate a simple unique ID. */
 function uid(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
-}
-
-/** Tool icons — compact text abbreviations instead of emojis */
-const TOOL_ICONS: Record<string, string> = {
-  bash: '$',
-  browser: 'B',
-  read_file: 'R',
-  write_file: 'W',
-  edit_file: 'E',
-  javascript: 'JS',
-  delegate_to_scoop: 'D',
-  send_message: 'M',
-  schedule_task: 'T',
-  list_scoops: 'LS',
-  list_tasks: 'LT',
-  register_scoop: 'RS',
-  update_global_memory: 'GM',
-};
-
-/** Get icon for a tool */
-function getToolIcon(toolName: string): string {
-  return TOOL_ICONS[toolName] ?? '?';
 }
 
 function renderChatMessageContent(msg: ChatMessage): string {
@@ -1074,10 +1048,14 @@ export class ChatPanel {
         break;
       }
     }
+    // Last real user turn — licks and delegation frames don't count.
+    // Tool calls in earlier messages render with a muted status dot.
+    const lastRealUserIdx = this.findLastRealUserIdx();
     for (let i = 0; i < this.messages.length; i++) {
       const msg = this.messages[i];
       const showLabel = this.shouldShowLabel(msg, prevRole, prevTimestamp);
-      const el = this.createMessageEl(msg, showLabel, i === lastAssistantIdx);
+      const stale = lastRealUserIdx > i;
+      const el = this.createMessageEl(msg, showLabel, i === lastAssistantIdx, stale);
       this.messagesInner.appendChild(el);
       prevRole = msg.role;
       prevTimestamp = msg.timestamp;
@@ -1096,6 +1074,13 @@ export class ChatPanel {
     const prev = this.messages.length >= 2 ? this.messages[this.messages.length - 2] : null;
     const showLabel = this.shouldShowLabel(msg, prev?.role ?? null, prev?.timestamp ?? 0);
     const isLastAssistant = msg.role === 'assistant';
+    // If this new message is itself a real user turn, any previously-
+    // rendered tool calls should become stale — retint them now.
+    if (this.isRealUserTurn(msg)) {
+      this.messagesInner
+        .querySelectorAll('.tool-call')
+        .forEach((el) => el.classList.add('tool-call--stale'));
+    }
     const el = this.createMessageEl(msg, showLabel, isLastAssistant);
     this.messagesInner.appendChild(el);
     this.scrollToBottom();
@@ -1138,16 +1123,34 @@ export class ChatPanel {
         }
         isLastAssistant = idx === lastIdx;
       }
-      const newEl = this.createMessageEl(msg, showLabel, isLastAssistant);
+      const stale = this.findLastRealUserIdx() > idx;
+      const newEl = this.createMessageEl(msg, showLabel, isLastAssistant, stale);
       existing.replaceWith(newEl);
     }
     this.scrollToBottom();
   }
 
+  /** A plain user turn — not a lick and not a cone delegation frame. */
+  private isRealUserTurn(msg: ChatMessage): boolean {
+    if (msg.role !== 'user') return false;
+    if (msg.source === 'lick') return false;
+    if (msg.source === 'delegation' || msg.channel === 'delegation') return false;
+    return true;
+  }
+
+  /** Index of the most recent real user turn, or -1 if none. */
+  private findLastRealUserIdx(): number {
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      if (this.isRealUserTurn(this.messages[i])) return i;
+    }
+    return -1;
+  }
+
   private createMessageEl(
     msg: ChatMessage,
     showLabel = true,
-    isLastAssistant = false
+    isLastAssistant = false,
+    stale = false
   ): HTMLElement {
     // Licks (webhook/cron) get their own compact style like tool calls
     const isLick =
@@ -1282,7 +1285,7 @@ export class ChatPanel {
     // Tool calls rendered outside the message bubble for compact display
     if (msg.toolCalls) {
       for (const tc of msg.toolCalls) {
-        wrapper.appendChild(this.createToolCallEl(tc));
+        wrapper.appendChild(this.createToolCallEl(tc, stale));
       }
     }
 
@@ -1378,73 +1381,46 @@ export class ChatPanel {
     return el;
   }
 
-  private createToolCallEl(tc: ToolCall): HTMLElement {
-    const icon = getToolIcon(tc.name);
+  private createToolCallEl(tc: ToolCall, stale = false): HTMLElement {
+    const desc = getToolDescriptor(tc.name);
+    const status = toolStatus(tc);
 
     // Use <details> for collapsible behavior - collapsed by default, expand on hover/click
     const el = document.createElement('details');
-    el.className = 'tool-call';
+    el.className = `tool-call tool-call--${status}${stale ? ' tool-call--stale' : ''}`;
 
-    // Summary shows icon and tool name
     const summary = document.createElement('summary');
     summary.className = 'tool-call__header';
-    summary.innerHTML = `<span class="tool-call__icon"><svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"><path d="M2 3.5L5 6.5L8 3.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></span> <span class="tool-call__name">${escapeHtml(tc.name)}</span>`;
 
-    // Add brief input preview to summary
-    if (tc.input !== undefined) {
+    const iconWrap = document.createElement('span');
+    iconWrap.className = 'tool-call__icon';
+    iconWrap.appendChild(createToolIcon(tc.name));
+    summary.appendChild(iconWrap);
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'tool-call__name';
+    nameEl.textContent = desc.title;
+    summary.appendChild(nameEl);
+
+    const previewText = desc.preview(tc.input);
+    if (previewText) {
       const preview = document.createElement('span');
       preview.className = 'tool-call__preview';
-      const inputStr = typeof tc.input === 'string' ? tc.input : JSON.stringify(tc.input);
-      preview.textContent = inputStr.slice(0, 40) + (inputStr.length > 40 ? '...' : '');
+      preview.textContent = previewText;
       summary.appendChild(preview);
     }
 
-    // Status indicator — text-based
     const statusEl = document.createElement('span');
-    if (tc.result === undefined) {
-      statusEl.className = 'tool-call__status tool-call__status--running';
-    } else if (tc.isError) {
-      statusEl.className = 'tool-call__status tool-call__status--error';
-      statusEl.textContent = 'failed';
-    } else {
-      statusEl.className = 'tool-call__status tool-call__status--success';
-      statusEl.textContent = '\u2713'; // ✓
-    }
+    statusEl.className = `tool-call__status tool-call__status--${status}`;
+    statusEl.setAttribute('aria-label', status);
     summary.appendChild(statusEl);
 
     el.appendChild(summary);
 
-    // Details content (shown on expand)
     const details = document.createElement('div');
     details.className = 'tool-call__details';
+    details.appendChild(createToolBody(tc));
 
-    if (tc.input !== undefined) {
-      const inputEl = document.createElement('div');
-      inputEl.className = 'tool-call__input';
-      const inputLabel = document.createElement('div');
-      inputLabel.className = 'tool-call__label';
-      inputLabel.textContent = 'Input:';
-      inputEl.appendChild(inputLabel);
-      const inputCode = document.createElement('pre');
-      inputCode.innerHTML = renderToolInput(tc.input);
-      inputEl.appendChild(inputCode);
-      details.appendChild(inputEl);
-    }
-
-    if (tc.result !== undefined) {
-      const resultEl = document.createElement('div');
-      resultEl.className = `tool-call__result${tc.isError ? ' tool-call__result--error' : ''}`;
-      const resultLabel = document.createElement('div');
-      resultLabel.className = 'tool-call__label';
-      resultLabel.textContent = tc.isError ? 'Error:' : 'Result:';
-      resultEl.appendChild(resultLabel);
-      const resultPre = document.createElement('pre');
-      resultPre.textContent = tc.result;
-      resultEl.appendChild(resultPre);
-      details.appendChild(resultEl);
-    }
-
-    // Render screenshot thumbnail from transient data (not persisted in messages)
     const screenshotUrl = tc._screenshotDataUrl;
     if (screenshotUrl) {
       const imgEl = document.createElement('img');

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -71,6 +71,10 @@ export class ChatPanel {
   public onInlineSprinkleLick?: (action: string, data: unknown) => void;
   private modelSelectorEl!: HTMLElement;
   public onModelChange?: (modelId: string) => void;
+  // Per-sessionId write queue for `persistLickToSession`. Chains concurrent
+  // load→mutate→save cycles behind the previous in-flight call so bursty
+  // licks (e.g. fswatch) for a non-selected scoop can't clobber each other.
+  private lickPersistQueues = new Map<string, Promise<void>>();
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -178,8 +182,38 @@ export class ChatPanel {
    * render the lick as a lick widget, not as a plain user bubble loaded from
    * orchestrator DB. Safe to call concurrently with the panel's own saves —
    * writes are scoped to the non-selected session id so there's no overlap.
+   *
+   * Per-sessionId writes are serialized via `lickPersistQueues` so bursty
+   * channels (fswatch, rapid webhook fanout) can't interleave their
+   * load→mutate→save cycles and clobber each other.
    */
   async persistLickToSession(
+    sessionId: string,
+    lick: {
+      id: string;
+      content: string;
+      channel: 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload' | 'navigate';
+      timestamp: number;
+    }
+  ): Promise<void> {
+    const prior = this.lickPersistQueues.get(sessionId) ?? Promise.resolve();
+    const next = prior
+      .catch(() => {
+        /* swallow upstream errors so this write still runs */
+      })
+      .then(() => this.writeLickToSession(sessionId, lick));
+    this.lickPersistQueues.set(sessionId, next);
+    // Evict the entry once it settles if no newer write has queued behind it,
+    // to keep the map bounded across long-lived panels.
+    void next.finally(() => {
+      if (this.lickPersistQueues.get(sessionId) === next) {
+        this.lickPersistQueues.delete(sessionId);
+      }
+    });
+    return next;
+  }
+
+  private async writeLickToSession(
     sessionId: string,
     lick: {
       id: string;

--- a/packages/webapp/src/ui/lick-view.ts
+++ b/packages/webapp/src/ui/lick-view.ts
@@ -1,0 +1,115 @@
+/**
+ * Lick view helpers — per-channel icon, header label, preview extraction,
+ * and body-stripping logic for the chat panel's `.lick` rows.
+ *
+ * Keeps the rendering rules for every lick channel in one place so the
+ * chat panel just consumes descriptors. All helpers are pure.
+ */
+
+import { Webhook, CalendarClock, Sparkles, FolderSync, Compass, RotateCcw, Bell } from 'lucide';
+import type { ChatMessage } from './types.js';
+
+type IconNode = [tag: string, attrs: Record<string, string | number>][];
+
+/** Per-channel metadata driving the compact row + expanded body. */
+export interface LickDescriptor {
+  icon: IconNode;
+  /** Label shown after the icon (e.g. "webhook", "cron"). Lowercase on
+   *  purpose so it reads like a noun, matching the tool-call row. */
+  label: string;
+}
+
+const DEFAULT: LickDescriptor = {
+  icon: Bell as unknown as IconNode,
+  label: 'event',
+};
+
+const DESCRIPTORS: Record<string, LickDescriptor> = {
+  webhook: {
+    icon: Webhook as unknown as IconNode,
+    label: 'webhook',
+  },
+  cron: {
+    icon: CalendarClock as unknown as IconNode,
+    label: 'cron',
+  },
+  sprinkle: {
+    icon: Sparkles as unknown as IconNode,
+    label: 'sprinkle',
+  },
+  fswatch: {
+    icon: FolderSync as unknown as IconNode,
+    label: 'files',
+  },
+  navigate: {
+    icon: Compass as unknown as IconNode,
+    label: 'navigate',
+  },
+  'session-reload': {
+    icon: RotateCcw as unknown as IconNode,
+    label: 'reload',
+  },
+};
+
+export function getLickDescriptor(msg: ChatMessage): LickDescriptor {
+  const key = msg.channel ?? '';
+  return DESCRIPTORS[key] ?? DEFAULT;
+}
+
+/** Matches the `[Xyz Event: name]` or `[Session Reload: name]` header
+ *  the orchestrator prepends to each lick. Captures name + optional
+ *  trailing code-fence opener so we can strip both cleanly. */
+const HEADER_RE = /^\[([^\]:]+?)(?:\s+Event)?:\s*([^\]]+?)\]\s*\n?/;
+
+export interface ParsedLick {
+  /** Human-readable event name (e.g. "github-push", "daily-digest",
+   *  full URL for navigate). Used for the collapsed row preview. */
+  preview: string;
+  /** Content with the `[Xyz Event: name]` header removed so the expanded
+   *  view does not repeat information already in the summary. */
+  body: string;
+}
+
+/** Parse a lick message's content into { preview, body }. Falls back to
+ *  the first non-empty line if the expected header pattern is missing. */
+export function parseLickContent(content: string): ParsedLick {
+  const match = HEADER_RE.exec(content);
+  if (match) {
+    return {
+      preview: match[2].trim(),
+      body: content.slice(match[0].length).replace(/^\s+/, ''),
+    };
+  }
+  const firstLine = content.split('\n').find((l) => l.trim().length > 0) ?? '';
+  return {
+    preview: firstLine.trim().slice(0, 80),
+    body: content,
+  };
+}
+
+/** Build the lucide SVG element for a channel. */
+export function createLickIcon(msg: ChatMessage): SVGElement {
+  const desc = getLickDescriptor(msg);
+  return iconNodeToSvg(desc.icon);
+}
+
+function iconNodeToSvg(node: IconNode): SVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  svg.setAttribute('width', '14');
+  svg.setAttribute('height', '14');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  for (const [tag, attrs] of node) {
+    const child = document.createElementNS('http://www.w3.org/2000/svg', tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      child.setAttribute(k, String(v));
+    }
+    svg.appendChild(child);
+  }
+  return svg;
+}

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -88,6 +88,19 @@ const log = createLogger('main');
 const PENDING_MOUNT_DB = 'slicc-pending-mount';
 const PENDING_MOUNT_KEY = 'pendingMount';
 
+/** Lick channels — kept in sync with LickEvent.type in scoops/lick-manager.ts.
+ *  Used when routing history-replayed messages so they render as licks
+ *  instead of plain user bubbles. */
+type LickChannel = 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload' | 'navigate';
+const LICK_CHANNELS: ReadonlySet<string> = new Set<LickChannel>([
+  'webhook',
+  'cron',
+  'sprinkle',
+  'fswatch',
+  'session-reload',
+  'navigate',
+]);
+
 /** Store a directory handle for later mount during onboarding completion. */
 async function storePendingMount(handle: FileSystemDirectoryHandle): Promise<void> {
   const db = await new Promise<IDBDatabase>((resolve, reject) => {
@@ -1486,21 +1499,31 @@ async function main(): Promise<void> {
         channel,
       };
 
+      const lickTs = Date.now();
       getBuffer(resolvedTarget.jid).push({
         id: msgId,
         role: 'user',
         content,
-        timestamp: Date.now(),
+        timestamp: lickTs,
         source: 'lick',
         channel,
       });
 
       if (selectedScoop?.jid === resolvedTarget.jid) {
-        layout.panels.chat.addLickMessage(
-          msgId,
+        layout.panels.chat.addLickMessage(msgId, content, channel as LickChannel, lickTs);
+      } else {
+        // Non-selected target: persist directly to the target scoop's
+        // SessionStore so a reload's first-select can render this lick
+        // as a lick widget (not a plain user bubble from the DB fallback).
+        const targetSessionId = resolvedTarget.isCone
+          ? 'session-cone'
+          : `session-${resolvedTarget.folder}`;
+        void layout.panels.chat.persistLickToSession(targetSessionId, {
+          id: msgId,
           content,
-          channel as 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload' | 'navigate'
-        );
+          channel: channel as LickChannel,
+          timestamp: lickTs,
+        });
       }
 
       log.info('Routing lick to scoop', {
@@ -1881,12 +1904,20 @@ async function main(): Promise<void> {
         const messages = await orchestrator.getMessagesForScoop(scoop.jid);
         for (const msg of messages) {
           // Determine the proper role and source for display
-          const isLick = msg.channel === 'webhook' || msg.channel === 'cron';
+          const isLick = LICK_CHANNELS.has(msg.channel ?? '');
           const isDelegation = msg.channel === 'delegation';
 
           if (isLick) {
-            // Lick events - show as incoming with tongue emoji
-            layout.panels.chat.addUserMessage(msg.content);
+            // Preserve lick metadata (source/channel/timestamp) so the chat
+            // renders licks as their distinctive collapsible widget instead
+            // of a plain "You" bubble. Covers every lick channel, including
+            // sprinkle/navigate/fswatch/session-reload.
+            layout.panels.chat.addLickMessage(
+              msg.id,
+              msg.content,
+              msg.channel as LickChannel,
+              new Date(msg.timestamp).getTime()
+            );
           } else if (isDelegation) {
             // Delegation from cone - show as incoming instructions
             layout.panels.chat.addUserMessage(`**[Instructions from sliccy]**\n\n${msg.content}`);

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -101,6 +101,37 @@ const LICK_CHANNELS: ReadonlySet<string> = new Set<LickChannel>([
   'navigate',
 ]);
 
+/** True when the current URL requests the design-time UI fixture
+ *  (`?ui-fixture=1`). Accepts `1`, `true`, and the bare presence of the key
+ *  so both `?ui-fixture` and `?ui-fixture=1` work for quick toggling. */
+function isUIFixtureRequested(): boolean {
+  try {
+    const raw = new URLSearchParams(window.location.search).get('ui-fixture');
+    if (raw === null) return false;
+    return raw === '' || raw === '1' || raw.toLowerCase() === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Load the design-time UI fixture into the chat panel.
+ *
+ * Writes messages to a dedicated `session-ui-fixture` session id so the
+ * fixture survives reloads without touching real scoop storage. Real
+ * scoops remain selectable in the sidebar — clicking one switches away
+ * and saves any fixture state under its own session id. */
+async function loadUIFixtureIntoChat(chatPanel: {
+  switchToContext: (id: string, readOnly: boolean, scoopName?: string) => Promise<void>;
+  loadMessages: (msgs: ChatMessage[]) => void;
+}): Promise<void> {
+  const [{ createChatFixture, FIXTURE_SESSION_ID, FIXTURE_SCOOP_NAME }] = await Promise.all([
+    import('./chat-fixture.js'),
+  ]);
+  await chatPanel.switchToContext(FIXTURE_SESSION_ID, true, FIXTURE_SCOOP_NAME);
+  chatPanel.loadMessages(createChatFixture());
+  log.info('Loaded UI fixture session for design iteration');
+}
+
 /** Store a directory handle for later mount during onboarding completion. */
 async function storePendingMount(handle: FileSystemDirectoryHandle): Promise<void> {
   const db = await new Promise<IDBDatabase>((resolve, reject) => {
@@ -715,6 +746,13 @@ async function mainExtension(app: HTMLElement): Promise<void> {
   client.requestState();
 
   log.info('Extension UI connected to offscreen agent engine');
+
+  // `?ui-fixture=1` — same design-time override as the CLI path, but run
+  // last so the normal extension boot (state sync, scoop selection) has
+  // populated the sidebar before we overwrite the chat view.
+  if (isUIFixtureRequested()) {
+    await loadUIFixtureIntoChat(layout.panels.chat);
+  }
 
   // Initialize operational telemetry (fire-and-forget)
   initTelemetry().catch(() => {});
@@ -1977,6 +2015,14 @@ async function main(): Promise<void> {
     orchestrator.createScoopTab(selectedScoop.jid);
     // Trigger scoop select to properly load the chat context
     await handleScoopSelect(selectedScoop);
+  }
+
+  // `?ui-fixture=1` — design-time override: replace the live chat context
+  // with a synthetic session covering every message UI variant. Runs after
+  // the normal scoop select so real scoops stay listed in the sidebar and
+  // clicking one cleanly exits fixture mode.
+  if (isUIFixtureRequested()) {
+    await loadUIFixtureIntoChat(layout.panels.chat);
   }
 
   if (runtimeMode === 'standalone' || runtimeMode === 'electron-overlay') {

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -92,7 +92,7 @@ const PENDING_MOUNT_KEY = 'pendingMount';
  *  Used when routing history-replayed messages so they render as licks
  *  instead of plain user bubbles. */
 type LickChannel = 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload' | 'navigate';
-const LICK_CHANNELS: ReadonlySet<string> = new Set<LickChannel>([
+const LICK_CHANNELS: ReadonlySet<LickChannel> = new Set<LickChannel>([
   'webhook',
   'cron',
   'sprinkle',
@@ -100,6 +100,9 @@ const LICK_CHANNELS: ReadonlySet<string> = new Set<LickChannel>([
   'session-reload',
   'navigate',
 ]);
+function isLickChannel(channel: string | null | undefined): channel is LickChannel {
+  return channel !== null && channel !== undefined && LICK_CHANNELS.has(channel as LickChannel);
+}
 
 /** True when the current URL requests the design-time UI fixture
  *  (`?ui-fixture=1`). Accepts `1`, `true`, and the bare presence of the key
@@ -1548,7 +1551,7 @@ async function main(): Promise<void> {
       });
 
       if (selectedScoop?.jid === resolvedTarget.jid) {
-        layout.panels.chat.addLickMessage(msgId, content, channel as LickChannel, lickTs);
+        layout.panels.chat.addLickMessage(msgId, content, channel, lickTs);
       } else {
         // Non-selected target: persist directly to the target scoop's
         // SessionStore so a reload's first-select can render this lick
@@ -1559,7 +1562,7 @@ async function main(): Promise<void> {
         void layout.panels.chat.persistLickToSession(targetSessionId, {
           id: msgId,
           content,
-          channel: channel as LickChannel,
+          channel,
           timestamp: lickTs,
         });
       }
@@ -1942,10 +1945,9 @@ async function main(): Promise<void> {
         const messages = await orchestrator.getMessagesForScoop(scoop.jid);
         for (const msg of messages) {
           // Determine the proper role and source for display
-          const isLick = LICK_CHANNELS.has(msg.channel ?? '');
           const isDelegation = msg.channel === 'delegation';
 
-          if (isLick) {
+          if (isLickChannel(msg.channel)) {
             // Preserve lick metadata (source/channel/timestamp) so the chat
             // renders licks as their distinctive collapsible widget instead
             // of a plain "You" bubble. Covers every lick channel, including
@@ -1953,7 +1955,7 @@ async function main(): Promise<void> {
             layout.panels.chat.addLickMessage(
               msg.id,
               msg.content,
-              msg.channel as LickChannel,
+              msg.channel,
               new Date(msg.timestamp).getTime()
             );
           } else if (isDelegation) {

--- a/packages/webapp/src/ui/styles/tools.css
+++ b/packages/webapp/src/ui/styles/tools.css
@@ -228,9 +228,8 @@
 }
 .tool-call__diff {
   margin: 0;
-  padding: 10px 12px;
-  border-radius: var(--s2-radius-s);
-  background: var(--s2-bg-sunken);
+  padding: 0;
+  background: transparent;
   font-family: var(--s2-font-mono);
   font-size: var(--s2-font-size-75);
   line-height: 1.55;
@@ -238,22 +237,21 @@
   word-break: break-word;
   max-height: 320px;
   overflow-y: auto;
-  display: flex;
-  flex-direction: column;
+  overflow-x: hidden;
 }
-.tool-call__diff-del {
+.tool-call__diff-del,
+.tool-call__diff-add {
   display: block;
   padding: 1px 6px;
-  margin: 0 -6px;
   border-radius: 2px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.tool-call__diff-del {
   background: color-mix(in oklch, var(--s2-negative) 15%, transparent);
   color: var(--s2-negative);
 }
 .tool-call__diff-add {
-  display: block;
-  padding: 1px 6px;
-  margin: 0 -6px;
-  border-radius: 2px;
   background: color-mix(in oklch, var(--s2-positive) 18%, transparent);
   color: var(--s2-positive);
 }
@@ -272,23 +270,34 @@
   border-color: var(--slicc-cone);
 }
 
+.tool-call__ui {
+  margin-top: 8px;
+}
+
 /* ================================================================== */
-/* Licks (webhook/cron events) — unchanged                             */
+/* Licks (webhook/cron/sprinkle/fswatch/navigate/session-reload)      */
+/* Render as an incoming bubble: right-aligned like user messages,    */
+/* max-width mirrored, icon anchored to the right.                    */
 /* ================================================================== */
 .lick {
   padding: 0;
+  align-self: flex-end;
+  width: 100%;
+  max-width: 560px;
   font-size: var(--s2-font-size-75);
-  margin-left: 20px;
 }
 .lick summary {
   list-style: none;
   cursor: pointer;
-  padding: 2px var(--s2-spacing-75);
+  padding: 8px 12px;
   display: flex;
   align-items: center;
-  gap: var(--s2-spacing-50);
-  border-radius: var(--s2-radius-default);
-  color: var(--s2-content-tertiary);
+  gap: 8px;
+  flex-direction: row;
+  border-radius: 10px;
+  background: var(--s2-bg-layer-1);
+  color: var(--s2-content-secondary);
+  border: 1px solid var(--s2-border-subtle);
   transition: background var(--s2-transition-default);
 }
 .lick summary:hover {
@@ -300,51 +309,83 @@
 .lick__header {
   display: flex;
   align-items: center;
-  gap: var(--s2-spacing-50);
+  gap: 8px;
   cursor: pointer;
-}
-.lick__icon {
-  font-size: 10px;
-  width: 18px;
-  height: 18px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--s2-radius-s);
-  background: var(--s2-gray-200);
-  flex-shrink: 0;
-  font-weight: 700;
-  color: var(--s2-content-secondary);
+  width: 100%;
+  justify-content: flex-start;
 }
 .lick__type {
   color: var(--s2-content-secondary);
   font-weight: 500;
+  font-size: var(--s2-font-size-75);
+  flex-shrink: 0;
 }
 .lick__preview {
   color: var(--s2-content-tertiary);
-  font-size: var(--s2-font-size-50);
-  margin-left: var(--s2-spacing-50);
+  font-size: var(--s2-font-size-75);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 300px;
+  min-width: 0;
+  flex: 1;
   font-family: var(--s2-font-mono);
 }
-.tool-call__ui {
-  margin-top: 8px;
+.lick__icon {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--s2-content-secondary);
+  order: 99;
+}
+.lick__icon svg {
+  display: block;
+  width: 14px;
+  height: 14px;
 }
 .lick__details {
-  padding: var(--s2-spacing-50) var(--s2-spacing-75) var(--s2-spacing-75) 22px;
-  margin-top: 2px;
-  border-left: 2px solid var(--s2-border-subtle);
-  margin-left: var(--s2-spacing-75);
-  font-size: var(--s2-font-size-75);
-  color: var(--s2-content-secondary);
-}
-.lick__details pre {
-  background: var(--s2-bg-sunken);
-  padding: var(--s2-spacing-75);
+  margin-top: 6px;
+  padding: 12px 14px;
   border-radius: var(--s2-radius-s);
-  font-size: var(--s2-font-size-50);
+  background: var(--s2-bg-sunken);
+  color: var(--s2-content-secondary);
+  font-size: var(--s2-font-size-75);
+  line-height: 1.55;
+  word-break: break-word;
+}
+.lick__details > *:first-child {
+  margin-top: 0;
+}
+.lick__details > *:last-child {
+  margin-bottom: 0;
+}
+/* Markdown prose — the reset in base.css strips list padding, which
+ * clips bullets against the container edge. Restore enough gutter so
+ * `-` bullets sit inside the padded frame. */
+.lick__details p,
+.lick__details ul,
+.lick__details ol {
+  margin: 0.5em 0;
+}
+.lick__details ul,
+.lick__details ol {
+  padding-left: 1.4em;
+}
+/* The enclosing .lick__details already carries the container look —
+ * letting the code block draw its own frame creates a "box inside a
+ * box" feel. Strip its chrome and let the content breathe. */
+.lick__details pre {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font-size: var(--s2-font-size-75);
+  font-family: var(--s2-font-mono);
   overflow-x: auto;
+  max-height: 320px;
+  overflow-y: auto;
+  white-space: pre;
 }

--- a/packages/webapp/src/ui/styles/tools.css
+++ b/packages/webapp/src/ui/styles/tools.css
@@ -1,23 +1,38 @@
 /* ================================================================== */
-/* Tool calls — S2 compact inline style                               */
+/* Tool calls — compact row with lucide icon, summary preview,         */
+/* colored status circle, and expanded YAML/terminal/diff body.        */
 /* ================================================================== */
 .tool-call {
   padding: 0;
-  font-size: 12px;
+  font-size: var(--s2-font-size-75);
+  --tool-status-color: var(--s2-gray-500);
 }
+.tool-call--running {
+  --tool-status-color: #e6a23c;
+}
+.tool-call--success {
+  --tool-status-color: var(--s2-positive);
+}
+.tool-call--error {
+  --tool-status-color: var(--s2-negative);
+}
+.tool-call--other {
+  --tool-status-color: var(--s2-accent);
+}
+
 .tool-call summary {
   list-style: none;
   cursor: pointer;
-  padding: 11px 12px;
+  padding: 8px 12px;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
   border-radius: 8px;
   background: var(--s2-bg-layer-1);
   color: var(--s2-content-secondary);
   font-weight: 400;
-  font-size: 12px;
-  line-height: 1.5;
+  font-size: var(--s2-font-size-75);
+  line-height: 1.4;
   transition: background var(--s2-transition-default);
 }
 .tool-call summary:hover {
@@ -26,108 +41,224 @@
 .tool-call summary::-webkit-details-marker {
   display: none;
 }
+
 .tool-call__header {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
   cursor: pointer;
+  width: 100%;
 }
 .tool-call__icon {
-  font-size: 10px;
-  width: 10px;
-  height: 10px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0;
-  background: transparent;
+  width: 16px;
+  height: 16px;
   flex-shrink: 0;
-  transition: transform 150ms ease;
+  color: var(--s2-content-secondary);
 }
-.tool-call[open] .tool-call__icon {
-  transform: rotate(180deg);
+.tool-call__icon svg {
+  display: block;
+  width: 14px;
+  height: 14px;
 }
 .tool-call__name {
   color: var(--s2-content-secondary);
-  font-weight: 400;
+  font-weight: 500;
   font-family: var(--s2-font-family);
-  font-size: 12px;
+  font-size: var(--s2-font-size-75);
+  flex-shrink: 0;
 }
 .tool-call__preview {
   color: var(--s2-content-tertiary);
-  font-size: 11px;
-  margin-left: 4px;
+  font-size: var(--s2-font-size-75);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 300px;
+  min-width: 0;
+  flex: 1;
   font-family: var(--s2-font-mono);
 }
 .tool-call__status {
   margin-left: auto;
-  font-size: 10px;
-  font-weight: 500;
-  font-family: var(--s2-font-mono);
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--tool-status-color);
+  flex-shrink: 0;
 }
 .tool-call__status--running {
-  color: var(--s2-content-tertiary);
+  animation: tool-status-pulse 1.2s ease-in-out infinite;
 }
-.tool-call__status--running::after {
-  content: '';
-  display: inline-block;
-  width: 16px;
-  height: 2px;
-  background: var(--s2-content-tertiary);
-  margin-left: 4px;
-  vertical-align: middle;
-  border-radius: 1px;
-  animation: status-bar 1s ease-in-out infinite;
-}
-@keyframes status-bar {
+@keyframes tool-status-pulse {
   0%,
   100% {
-    opacity: 0.3;
+    opacity: 0.4;
   }
   50% {
     opacity: 1;
   }
 }
-.tool-call__status--success {
-  color: var(--s2-content-tertiary);
+/* A later user turn has happened — the dot fades into the background so
+ * only currently-relevant work draws the eye. */
+.tool-call--stale .tool-call__status {
+  opacity: 0.5;
 }
-.tool-call__status--error {
-  color: var(--s2-negative);
+.tool-call--stale .tool-call__status--running {
+  animation: none;
 }
 
+/* ── Expanded body ────────────────────────────────────────────────── */
 .tool-call__details {
-  padding: var(--s2-spacing-50) var(--s2-spacing-75) var(--s2-spacing-75) 22px;
+  padding: 8px 12px 12px 30px;
   margin-top: 2px;
-  border-left: 2px solid var(--s2-border-subtle);
-  margin-left: var(--s2-spacing-75);
 }
-.tool-call__label {
-  font-size: 9px;
-  color: var(--s2-content-tertiary);
-  text-transform: none;
-  font-weight: 500;
-  margin-bottom: 2px;
+.tool-call__body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
-.tool-call__input pre,
-.tool-call__result pre {
-  white-space: pre-wrap;
-  font-family: var(--s2-font-mono);
-  font-size: var(--s2-font-size-50);
-  color: var(--s2-content-secondary);
-  max-height: 150px;
-  overflow-y: auto;
-  background: var(--s2-bg-sunken);
-  padding: var(--s2-spacing-75);
-  border-radius: var(--s2-radius-s);
+
+/* YAML input */
+.tool-call__yaml {
   margin: 0;
+  padding: 10px 12px;
+  border-radius: var(--s2-radius-s);
+  background: var(--s2-bg-sunken);
+  color: var(--s2-content-default);
+  font-family: var(--s2-font-mono);
+  font-size: var(--s2-font-size-75);
+  line-height: 1.55;
+  white-space: pre;
+  overflow-x: auto;
+  max-height: 320px;
 }
-.tool-call__result--error pre {
+.tool-call__yaml-key {
+  color: var(--slicc-scoop-blue);
+  font-weight: 600;
+}
+.tool-call__yaml-string {
+  color: var(--s2-content-default);
+}
+.tool-call__yaml-scalar {
+  color: var(--s2-content-tertiary);
+}
+.tool-call__yaml-null {
+  color: var(--s2-content-tertiary);
+  font-style: italic;
+}
+
+/* Generic result block (for non-bash tools, after YAML input) */
+.tool-call__result {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: var(--s2-radius-s);
+  background: var(--s2-bg-sunken);
+  color: var(--s2-content-secondary);
+  font-family: var(--s2-font-mono);
+  font-size: var(--s2-font-size-75);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+  overflow-y: auto;
+}
+.tool-call__result--error {
+  color: var(--s2-negative);
+  background: color-mix(in oklch, var(--s2-negative) 10%, var(--s2-bg-sunken));
+}
+
+/* ── Bash terminal body ───────────────────────────────────────────── */
+.tool-call__terminal {
+  border-radius: var(--s2-radius-s);
+  background: #0d0d0f;
+  color: #e6e6e6;
+  font-family: var(--s2-font-mono);
+  font-size: var(--s2-font-size-75);
+  line-height: 1.55;
+  padding: 12px 14px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+.tool-call__terminal-prompt {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  color: #f5f5f5;
+  word-break: break-word;
+}
+.tool-call__terminal-sigil {
+  color: #50d79a;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.tool-call__terminal-cmd {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.tool-call__terminal-output {
+  margin: 8px 0 0;
+  padding: 0;
+  background: transparent;
+  color: #c8c8c8;
+  font-family: var(--s2-font-mono);
+  font-size: var(--s2-font-size-75);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 280px;
+  overflow-y: auto;
+}
+.tool-call__terminal-output--error {
+  color: #f38ba8;
+}
+.tool-call__terminal-pending {
+  margin-top: 8px;
+  color: #808080;
+  letter-spacing: 2px;
+}
+
+/* ── edit_file diff body ──────────────────────────────────────────── */
+.tool-call__diff-path {
+  font-family: var(--s2-font-mono);
+  font-size: var(--s2-font-size-75);
+  color: var(--s2-content-secondary);
+  padding: 4px 0;
+}
+.tool-call__diff {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: var(--s2-radius-s);
+  background: var(--s2-bg-sunken);
+  font-family: var(--s2-font-mono);
+  font-size: var(--s2-font-size-75);
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.tool-call__diff-del {
+  display: block;
+  padding: 1px 6px;
+  margin: 0 -6px;
+  border-radius: 2px;
+  background: color-mix(in oklch, var(--s2-negative) 15%, transparent);
   color: var(--s2-negative);
 }
+.tool-call__diff-add {
+  display: block;
+  padding: 1px 6px;
+  margin: 0 -6px;
+  border-radius: 2px;
+  background: color-mix(in oklch, var(--s2-positive) 18%, transparent);
+  color: var(--s2-positive);
+}
+
+/* Screenshot thumb */
 .tool-call__screenshot {
   max-width: 100%;
   max-height: 200px;
@@ -142,7 +273,7 @@
 }
 
 /* ================================================================== */
-/* Licks (webhook/cron events)                                        */
+/* Licks (webhook/cron events) — unchanged                             */
 /* ================================================================== */
 .lick {
   padding: 0;
@@ -198,6 +329,9 @@
   white-space: nowrap;
   max-width: 300px;
   font-family: var(--s2-font-mono);
+}
+.tool-call__ui {
+  margin-top: 8px;
 }
 .lick__details {
   padding: var(--s2-spacing-50) var(--s2-spacing-75) var(--s2-spacing-75) 22px;

--- a/packages/webapp/src/ui/tool-call-view.ts
+++ b/packages/webapp/src/ui/tool-call-view.ts
@@ -400,7 +400,10 @@ function renderEditBody(tc: ToolCall): HTMLElement {
   for (const line of newLines) {
     rows.push(`<span class="tool-call__diff-add">+ ${escapeHtml(line)}</span>`);
   }
-  diff.innerHTML = rows.join('\n');
+  // Block-level children stack on their own — joining with '\n' in a
+  // `pre` would add a visible blank line between the deletion and
+  // addition groups.
+  diff.innerHTML = rows.join('');
   body.appendChild(diff);
 
   if (tc.result !== undefined) {

--- a/packages/webapp/src/ui/tool-call-view.ts
+++ b/packages/webapp/src/ui/tool-call-view.ts
@@ -1,0 +1,410 @@
+/**
+ * Tool-call view helpers — per-tool icon, preview summary, and expanded body.
+ *
+ * The chat panel delegates here so the rendering logic for every tool lives
+ * in one file instead of being sprinkled through `chat-panel.ts`. All helpers
+ * are pure: they take a `ToolCall` and return DOM nodes or strings.
+ */
+
+import {
+  IceCreamCone,
+  FileText,
+  FilePen,
+  FilePlus,
+  Terminal,
+  Globe,
+  Code2,
+  MessageCircle,
+  Send,
+  Trash2,
+  List,
+  ListChecks,
+  BrainCog,
+  UserRoundPlus,
+  UtensilsCrossed,
+  Clock,
+  Wrench,
+} from 'lucide';
+import type { ToolCall } from './types.js';
+import { escapeHtml } from './message-renderer.js';
+
+type IconNode = [tag: string, attrs: Record<string, string | number>][];
+
+/** Per-tool metadata driving the compact row + expanded body. */
+interface ToolDescriptor {
+  icon: IconNode;
+  /** Short lowercase noun describing the action, used as the row title. */
+  title: string;
+  /** Returns the inline summary shown to the right of the title. */
+  preview: (input: unknown) => string;
+  /** Optional custom expanded-body renderer. Falls back to YAML rendering. */
+  renderBody?: (tc: ToolCall) => HTMLElement;
+}
+
+const FALLBACK: ToolDescriptor = {
+  icon: Wrench as unknown as IconNode,
+  title: 'tool',
+  preview: (input) => shortValue(input, 80),
+};
+
+const DESCRIPTORS: Record<string, ToolDescriptor> = {
+  read_file: {
+    icon: FileText as unknown as IconNode,
+    title: 'read',
+    preview: (input) => getField(input, 'path') ?? '',
+    // Path already in the collapsed preview — the expanded body only
+    // needs to show what the file returned (or the error).
+    renderBody: renderResultOnlyBody,
+  },
+  write_file: {
+    icon: FilePlus as unknown as IconNode,
+    title: 'write',
+    preview: (input) => getField(input, 'path') ?? '',
+  },
+  edit_file: {
+    icon: FilePen as unknown as IconNode,
+    title: 'edit',
+    preview: (input) => getField(input, 'path') ?? '',
+    renderBody: renderEditBody,
+  },
+  bash: {
+    icon: Terminal as unknown as IconNode,
+    title: 'bash',
+    preview: (input) => {
+      const cmd = getField(input, 'command') ?? '';
+      return cmd ? `$ ${truncate(cmd, 120)}` : '';
+    },
+    renderBody: renderBashBody,
+  },
+  browser: {
+    icon: Globe as unknown as IconNode,
+    title: 'browser',
+    preview: (input) => shortValue(input, 80),
+  },
+  javascript: {
+    icon: Code2 as unknown as IconNode,
+    title: 'javascript',
+    preview: (input) => {
+      const code = getField(input, 'code') ?? '';
+      return truncate(code.replace(/\s+/g, ' '), 100);
+    },
+  },
+  send_message: {
+    icon: MessageCircle as unknown as IconNode,
+    title: 'message',
+    preview: (input) => {
+      const text = getField(input, 'text') ?? '';
+      return text ? `"${truncate(text, 100)}"` : '';
+    },
+  },
+  feed_scoop: {
+    icon: UtensilsCrossed as unknown as IconNode,
+    title: 'feed',
+    preview: (input) => getField(input, 'scoop_name') ?? '',
+  },
+  scoop_scoop: {
+    icon: IceCreamCone as unknown as IconNode,
+    title: 'scoop',
+    preview: (input) => getField(input, 'name') ?? '',
+  },
+  drop_scoop: {
+    icon: Trash2 as unknown as IconNode,
+    title: 'drop',
+    preview: (input) => getField(input, 'scoop_name') ?? '',
+  },
+  list_scoops: {
+    icon: List as unknown as IconNode,
+    title: 'list scoops',
+    preview: () => '',
+  },
+  list_tasks: {
+    icon: ListChecks as unknown as IconNode,
+    title: 'list tasks',
+    preview: () => '',
+  },
+  register_scoop: {
+    icon: UserRoundPlus as unknown as IconNode,
+    title: 'register',
+    preview: (input) => getField(input, 'name') ?? '',
+  },
+  schedule_task: {
+    icon: Clock as unknown as IconNode,
+    title: 'schedule',
+    preview: (input) => getField(input, 'cron') ?? getField(input, 'name') ?? '',
+  },
+  update_global_memory: {
+    icon: BrainCog as unknown as IconNode,
+    title: 'memory',
+    preview: (input) => {
+      const content = getField(input, 'content') ?? '';
+      const firstLine = content.split('\n').find((l) => l.trim().length > 0) ?? '';
+      return truncate(firstLine, 100);
+    },
+  },
+  delegate_to_scoop: {
+    icon: Send as unknown as IconNode,
+    title: 'delegate',
+    preview: (input) => getField(input, 'scoop_name') ?? '',
+  },
+};
+
+/** Public entry point: returns the metadata used to render a tool call. */
+export function getToolDescriptor(name: string): ToolDescriptor {
+  return DESCRIPTORS[name] ?? { ...FALLBACK, title: name };
+}
+
+/** Status variants for the colored circle indicator. */
+export type ToolStatus = 'running' | 'success' | 'error' | 'other';
+
+/** Classify a ToolCall into a status bucket. */
+export function toolStatus(tc: ToolCall): ToolStatus {
+  if (tc.result === undefined) return 'running';
+  if (tc.isError) return 'error';
+  return 'success';
+}
+
+/** Build the icon element for the collapsed row. */
+export function createToolIcon(name: string): SVGElement {
+  const desc = getToolDescriptor(name);
+  return iconNodeToSvg(desc.icon);
+}
+
+/** Build the expanded body for a tool call. Custom bodies for bash/edit_file
+ *  fall through to the YAML renderer when inputs are missing. */
+export function createToolBody(tc: ToolCall): HTMLElement {
+  const desc = getToolDescriptor(tc.name);
+  if (desc.renderBody) {
+    try {
+      return desc.renderBody(tc);
+    } catch {
+      // fall through to default
+    }
+  }
+  return renderDefaultBody(tc);
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+function getField(input: unknown, key: string): string | undefined {
+  if (!input || typeof input !== 'object') return undefined;
+  const value = (input as Record<string, unknown>)[key];
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return undefined;
+}
+
+function shortValue(input: unknown, max: number): string {
+  if (input === undefined || input === null) return '';
+  if (typeof input === 'string') return truncate(input, max);
+  try {
+    return truncate(JSON.stringify(input), max);
+  } catch {
+    return truncate(String(input), max);
+  }
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + '…';
+}
+
+function iconNodeToSvg(node: IconNode): SVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  svg.setAttribute('width', '14');
+  svg.setAttribute('height', '14');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  for (const [tag, attrs] of node) {
+    const child = document.createElementNS('http://www.w3.org/2000/svg', tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      child.setAttribute(k, String(v));
+    }
+    svg.appendChild(child);
+  }
+  return svg;
+}
+
+// ── body renderers ──────────────────────────────────────────────────
+
+function renderDefaultBody(tc: ToolCall): HTMLElement {
+  const body = document.createElement('div');
+  body.className = 'tool-call__body';
+
+  if (tc.input !== undefined) {
+    body.appendChild(renderYamlInput(tc.input));
+  }
+  if (tc.result !== undefined) {
+    body.appendChild(renderResultPre(tc));
+  }
+  return body;
+}
+
+/** Used by tools whose only interesting input is already mirrored in the
+ *  collapsed preview (read_file → path). Skip the YAML echo and only show
+ *  what the tool returned. */
+function renderResultOnlyBody(tc: ToolCall): HTMLElement {
+  const body = document.createElement('div');
+  body.className = 'tool-call__body';
+  if (tc.result !== undefined) {
+    body.appendChild(renderResultPre(tc));
+  }
+  return body;
+}
+
+function renderResultPre(tc: ToolCall): HTMLPreElement {
+  const resultEl = document.createElement('pre');
+  resultEl.className = `tool-call__result${tc.isError ? ' tool-call__result--error' : ''}`;
+  resultEl.textContent = tc.result ?? '';
+  return resultEl;
+}
+
+/** Render input as a YAML-like block with colored keys. Arrays render as
+ *  bullet lists, nested objects indent one level deeper. */
+function renderYamlInput(input: unknown): HTMLElement {
+  const pre = document.createElement('pre');
+  pre.className = 'tool-call__yaml';
+  pre.innerHTML = yamlHtml(input, 0);
+  return pre;
+}
+
+function yamlHtml(value: unknown, indent: number): string {
+  const pad = '  '.repeat(indent);
+  if (value === null || value === undefined) {
+    return `${pad}<span class="tool-call__yaml-null">~</span>`;
+  }
+  if (typeof value === 'string') {
+    return renderStringValue(value, indent);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return `${pad}<span class="tool-call__yaml-scalar">${escapeHtml(String(value))}</span>`;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return `${pad}<span class="tool-call__yaml-scalar">[]</span>`;
+    return value
+      .map((item) => {
+        if (isPrimitive(item)) {
+          return `${pad}- ${inlinePrimitive(item)}`;
+        }
+        const inner = yamlHtml(item, indent + 1).replace(/^\s+/, '');
+        return `${pad}- ${inner}`;
+      })
+      .join('\n');
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return `${pad}<span class="tool-call__yaml-scalar">{}</span>`;
+    return entries.map(([k, v]) => renderKeyValue(k, v, indent)).join('\n');
+  }
+  return `${pad}${escapeHtml(String(value))}`;
+}
+
+function renderKeyValue(key: string, value: unknown, indent: number): string {
+  const pad = '  '.repeat(indent);
+  const keyHtml = `<span class="tool-call__yaml-key">${escapeHtml(key)}</span>`;
+  if (isPrimitive(value)) {
+    return `${pad}${keyHtml}: ${inlinePrimitive(value)}`;
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return `${pad}${keyHtml}: <span class="tool-call__yaml-scalar">[]</span>`;
+  }
+  if (typeof value === 'object' && value && Object.keys(value).length === 0) {
+    return `${pad}${keyHtml}: <span class="tool-call__yaml-scalar">{}</span>`;
+  }
+  return `${pad}${keyHtml}:\n${yamlHtml(value, indent + 1)}`;
+}
+
+function isPrimitive(v: unknown): boolean {
+  return v === null || v === undefined || typeof v !== 'object';
+}
+
+function inlinePrimitive(v: unknown): string {
+  if (v === null || v === undefined) return '<span class="tool-call__yaml-null">~</span>';
+  if (typeof v === 'string') {
+    if (v.includes('\n')) {
+      // inline form — fall back to block string (handled by caller via
+      // renderStringValue when not primitive context). For safety we show
+      // the first line + ellipsis here; full multi-line strings land on
+      // their own indent level via renderKeyValue's recursion.
+      const first = v.split('\n')[0];
+      return `<span class="tool-call__yaml-string">${escapeHtml(first)}</span><span class="tool-call__yaml-scalar">…</span>`;
+    }
+    return `<span class="tool-call__yaml-string">${escapeHtml(v)}</span>`;
+  }
+  return `<span class="tool-call__yaml-scalar">${escapeHtml(String(v))}</span>`;
+}
+
+function renderStringValue(value: string, indent: number): string {
+  const pad = '  '.repeat(indent);
+  if (!value.includes('\n')) {
+    return `${pad}<span class="tool-call__yaml-string">${escapeHtml(value)}</span>`;
+  }
+  // multi-line block string using YAML literal `|` indicator.
+  const lines = value
+    .split('\n')
+    .map((l) => `${pad}  <span class="tool-call__yaml-string">${escapeHtml(l)}</span>`)
+    .join('\n');
+  return `${pad}<span class="tool-call__yaml-scalar">|</span>\n${lines}`;
+}
+
+// ── bash terminal body ──────────────────────────────────────────────
+
+function renderBashBody(tc: ToolCall): HTMLElement {
+  const cmd = getField(tc.input, 'command') ?? '';
+  const body = document.createElement('div');
+  body.className = 'tool-call__terminal';
+
+  const prompt = document.createElement('div');
+  prompt.className = 'tool-call__terminal-prompt';
+  prompt.innerHTML =
+    `<span class="tool-call__terminal-sigil">$</span> ` +
+    `<span class="tool-call__terminal-cmd">${escapeHtml(cmd)}</span>`;
+  body.appendChild(prompt);
+
+  if (tc.result !== undefined) {
+    const out = document.createElement('pre');
+    out.className = `tool-call__terminal-output${tc.isError ? ' tool-call__terminal-output--error' : ''}`;
+    out.textContent = tc.result;
+    body.appendChild(out);
+  } else {
+    const pending = document.createElement('div');
+    pending.className = 'tool-call__terminal-pending';
+    pending.textContent = '…';
+    body.appendChild(pending);
+  }
+  return body;
+}
+
+// ── edit_file diff body ─────────────────────────────────────────────
+
+function renderEditBody(tc: ToolCall): HTMLElement {
+  const oldStr = getField(tc.input, 'old_str') ?? '';
+  const newStr = getField(tc.input, 'new_str') ?? '';
+
+  const body = document.createElement('div');
+  body.className = 'tool-call__body';
+
+  // Path is already shown in the collapsed preview — no need to repeat it.
+  const diff = document.createElement('pre');
+  diff.className = 'tool-call__diff';
+  const oldLines = oldStr.split('\n');
+  const newLines = newStr.split('\n');
+  const rows: string[] = [];
+  for (const line of oldLines) {
+    rows.push(`<span class="tool-call__diff-del">- ${escapeHtml(line)}</span>`);
+  }
+  for (const line of newLines) {
+    rows.push(`<span class="tool-call__diff-add">+ ${escapeHtml(line)}</span>`);
+  }
+  diff.innerHTML = rows.join('\n');
+  body.appendChild(diff);
+
+  if (tc.result !== undefined) {
+    body.appendChild(renderResultPre(tc));
+  }
+  return body;
+}

--- a/packages/webapp/tests/ui/chat-fixture.test.ts
+++ b/packages/webapp/tests/ui/chat-fixture.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the UI design-time chat fixture.
+ *
+ * The fixture is the single source of truth for every message UI variant
+ * a designer might need to iterate on. Each test asserts a specific
+ * variant is present so refactors don't accidentally drop coverage.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createChatFixture,
+  FIXTURE_SESSION_ID,
+  FIXTURE_SCOOP_NAME,
+} from '../../src/ui/chat-fixture.js';
+
+describe('createChatFixture', () => {
+  const msgs = createChatFixture();
+  const byId = new Map(msgs.map((m) => [m.id, m]));
+
+  it('returns a stable, non-empty message list', () => {
+    expect(msgs.length).toBeGreaterThan(5);
+    // Calling twice should produce structurally equal results (pure fn).
+    const second = createChatFixture();
+    expect(second).toEqual(msgs);
+  });
+
+  it('uses deterministic timestamps (no Date.now drift)', () => {
+    // All timestamps anchor to 2024-01-01T10:00:00 local; monotonic within seconds.
+    const sorted = [...msgs].sort((a, b) => a.timestamp - b.timestamp);
+    expect(sorted.map((m) => m.id)).toEqual(msgs.map((m) => m.id));
+    expect(new Date(msgs[0].timestamp).getFullYear()).toBe(2024);
+  });
+
+  it('includes at least one user message and one assistant message', () => {
+    expect(msgs.some((m) => m.role === 'user' && !m.source)).toBe(true);
+    expect(msgs.some((m) => m.role === 'assistant')).toBe(true);
+  });
+
+  it('covers every lick channel exactly once', () => {
+    const channels = msgs
+      .filter((m) => m.source === 'lick')
+      .map((m) => m.channel)
+      .sort();
+    expect(channels).toEqual(
+      ['cron', 'fswatch', 'navigate', 'session-reload', 'sprinkle', 'webhook'].sort()
+    );
+  });
+
+  it('includes a delegation message from cone', () => {
+    expect(msgs.some((m) => m.channel === 'delegation' || m.source === 'delegation')).toBe(true);
+  });
+
+  it('includes a queued message with the `queued` flag set', () => {
+    expect(msgs.some((m) => m.queued === true)).toBe(true);
+  });
+
+  it('includes tool calls in all four display states', () => {
+    const allToolCalls = msgs.flatMap((m) => m.toolCalls ?? []);
+    expect(allToolCalls.length).toBeGreaterThan(0);
+
+    const running = allToolCalls.filter((tc) => tc.result === undefined);
+    const success = allToolCalls.filter((tc) => tc.result !== undefined && !tc.isError);
+    const failed = allToolCalls.filter((tc) => tc.isError === true);
+    const withScreenshot = allToolCalls.filter((tc) => !!tc._screenshotDataUrl);
+
+    expect(running.length).toBeGreaterThan(0);
+    expect(success.length).toBeGreaterThan(0);
+    expect(failed.length).toBeGreaterThan(0);
+    expect(withScreenshot.length).toBeGreaterThan(0);
+  });
+
+  it('includes a streaming (live) assistant message', () => {
+    expect(msgs.some((m) => m.role === 'assistant' && m.isStreaming === true)).toBe(true);
+  });
+
+  it('includes a markdown-heavy assistant message with a fenced code block', () => {
+    const markdownMsg = byId.get('fx-assistant-2');
+    expect(markdownMsg).toBeDefined();
+    expect(markdownMsg!.content).toContain('```ts');
+    expect(markdownMsg!.content).toContain('## ');
+  });
+
+  it('all messages have unique ids', () => {
+    const ids = msgs.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('exports stable identifiers used by main.ts', () => {
+    expect(FIXTURE_SESSION_ID).toBe('session-ui-fixture');
+    expect(FIXTURE_SCOOP_NAME).toBe('ui-fixture');
+  });
+});

--- a/packages/webapp/tests/ui/chat-fixture.test.ts
+++ b/packages/webapp/tests/ui/chat-fixture.test.ts
@@ -69,6 +69,25 @@ describe('createChatFixture', () => {
     expect(withScreenshot.length).toBeGreaterThan(0);
   });
 
+  it('covers every scoop-management tool from scoop-management-tools.ts', () => {
+    // Keep this list in sync with the tool names registered in
+    // packages/webapp/src/scoops/scoop-management-tools.ts. If you add
+    // or rename a scoop-management tool, extend both the fixture and
+    // this assertion so the design harness stays comprehensive.
+    const requiredTools = [
+      'send_message',
+      'feed_scoop',
+      'list_scoops',
+      'scoop_scoop',
+      'drop_scoop',
+      'update_global_memory',
+    ];
+    const toolNames = new Set(msgs.flatMap((m) => (m.toolCalls ?? []).map((tc) => tc.name)));
+    for (const name of requiredTools) {
+      expect(toolNames.has(name), `fixture is missing a ${name} tool call`).toBe(true);
+    }
+  });
+
   it('includes a streaming (live) assistant message', () => {
     expect(msgs.some((m) => m.role === 'assistant' && m.isStreaming === true)).toBe(true);
   });

--- a/packages/webapp/tests/ui/chat-panel-lick.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-lick.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+/**
+ * Tests for ChatPanel lick rendering + SessionStore persistence path.
+ *
+ * Covers the bug where licks loaded from the orchestrator DB were rendered
+ * as plain user bubbles because their source/channel metadata was dropped.
+ * With the fix, `addLickMessage` accepts a timestamp and the DB-fallback
+ * path preserves lick metadata so every channel renders as a lick widget.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { ChatPanel } from '../../src/ui/chat-panel.js';
+import { SessionStore } from '../../src/ui/session-store.js';
+
+// Stub out dependencies that require browser globals unavailable under jsdom.
+vi.mock('../../src/ui/voice-input.js', () => ({
+  VoiceInput: class {
+    destroy() {}
+    start() {}
+    stop() {}
+    setAutoSend() {}
+    setLang() {}
+  },
+  getVoiceAutoSend: () => false,
+  getVoiceLang: () => 'en-US',
+}));
+
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => '',
+  showProviderSettings: () => {},
+  applyProviderDefaults: () => {},
+  getAllAvailableModels: () => [],
+  getSelectedModelId: () => '',
+  getSelectedProvider: () => null,
+  setSelectedModelId: () => {},
+  getProviderConfig: () => null,
+}));
+
+describe('ChatPanel.addLickMessage', () => {
+  let container: HTMLElement;
+  let panel: ChatPanel;
+  let testCounter = 0;
+
+  beforeEach(async () => {
+    testCounter += 1;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    panel = new ChatPanel(container);
+    // Unique session id per test — fake-indexeddb persists state across tests
+    // in the same process, so a shared id would leak history between them.
+    await panel.initSession(`test-lick-add-${testCounter}`);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('renders a webhook lick as the lick details widget, not a user bubble', () => {
+    panel.addLickMessage('wh-1', '[Webhook Event: hook]\n```json\n{"a":1}\n```', 'webhook');
+    const lick = container.querySelector('details.lick');
+    expect(lick).not.toBeNull();
+    expect(container.querySelector('.msg--user')).toBeNull();
+  });
+
+  it('renders sprinkle / navigate / fswatch / session-reload as lick widgets', () => {
+    panel.addLickMessage('sp-1', 'sprinkle content', 'sprinkle');
+    panel.addLickMessage('nv-1', 'navigate content', 'navigate');
+    panel.addLickMessage('fw-1', 'fswatch content', 'fswatch');
+    panel.addLickMessage('sr-1', 'reload content', 'session-reload');
+    const licks = container.querySelectorAll('details.lick');
+    expect(licks.length).toBe(4);
+  });
+
+  it('preserves history-replay timestamp ordering when licks arrive out of order', () => {
+    // Simulate DB-fallback replay where history has mixed timestamps.
+    panel.addLickMessage('l-3', 'third', 'webhook', 3000);
+    panel.addLickMessage('l-1', 'first', 'webhook', 1000);
+    panel.addLickMessage('l-2', 'second', 'webhook', 2000);
+    const msgs = panel.getMessages();
+    expect(msgs.map((m) => m.id)).toEqual(['l-1', 'l-2', 'l-3']);
+  });
+
+  it('ignores duplicate ids (idempotent replay)', () => {
+    panel.addLickMessage('dupe', 'once', 'cron', 1000);
+    panel.addLickMessage('dupe', 'twice', 'cron', 1000);
+    expect(panel.getMessages()).toHaveLength(1);
+  });
+});
+
+describe('ChatPanel.persistLickToSession', () => {
+  let container: HTMLElement;
+  let panel: ChatPanel;
+  let testCounter = 0;
+
+  beforeEach(async () => {
+    testCounter += 1;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    panel = new ChatPanel(container);
+    // Init on a *different* session — we'll persist licks to another one.
+    await panel.initSession(`persist-test-selected-${testCounter}`);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('writes the lick into the target session store with source=lick and channel preserved', async () => {
+    const sid = `persist-write-${testCounter}`;
+    await panel.persistLickToSession(sid, {
+      id: 'persisted-1',
+      content: 'webhook fired',
+      channel: 'webhook',
+      timestamp: 5000,
+    });
+
+    const store = new SessionStore();
+    await store.init();
+    const session = await store.load(sid);
+    expect(session).not.toBeNull();
+    expect(session!.messages).toHaveLength(1);
+    expect(session!.messages[0]).toMatchObject({
+      id: 'persisted-1',
+      role: 'user',
+      content: 'webhook fired',
+      source: 'lick',
+      channel: 'webhook',
+      timestamp: 5000,
+    });
+  });
+
+  it('inserts in timestamp order when appending to existing history', async () => {
+    const sid = `persist-order-${testCounter}`;
+    const store = new SessionStore();
+    await store.init();
+    await store.saveMessages(sid, [
+      { id: 'old-1', role: 'user', content: 'old', timestamp: 1000 },
+      { id: 'old-2', role: 'user', content: 'later', timestamp: 9000 },
+    ]);
+
+    await panel.persistLickToSession(sid, {
+      id: 'mid-lick',
+      content: 'in between',
+      channel: 'sprinkle',
+      timestamp: 5000,
+    });
+
+    const session = await store.load(sid);
+    expect(session!.messages.map((m) => m.id)).toEqual(['old-1', 'mid-lick', 'old-2']);
+  });
+
+  it('is idempotent — persisting the same lick id twice is a no-op', async () => {
+    const sid = `persist-dupe-${testCounter}`;
+    await panel.persistLickToSession(sid, {
+      id: 'once',
+      content: 'a',
+      channel: 'cron',
+      timestamp: 2000,
+    });
+    await panel.persistLickToSession(sid, {
+      id: 'once',
+      content: 'b',
+      channel: 'cron',
+      timestamp: 2000,
+    });
+
+    const store = new SessionStore();
+    await store.init();
+    const session = await store.load(sid);
+    expect(session!.messages).toHaveLength(1);
+    expect(session!.messages[0].content).toBe('a');
+  });
+});

--- a/packages/webapp/tests/ui/chat-panel-lick.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-lick.test.ts
@@ -171,4 +171,33 @@ describe('ChatPanel.persistLickToSession', () => {
     expect(session!.messages).toHaveLength(1);
     expect(session!.messages[0].content).toBe('a');
   });
+
+  it('serializes concurrent writes to the same session so no event is clobbered', async () => {
+    const sid = `persist-concurrent-${testCounter}`;
+    // Fire a burst of overlapping writes (simulating bursty fswatch/webhook
+    // traffic). Each call shares the same load→save cycle; without the
+    // per-session queue the final save would win and drop earlier events.
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        panel.persistLickToSession(sid, {
+          id: `burst-${i}`,
+          content: `burst ${i}`,
+          channel: 'fswatch',
+          timestamp: 1000 + i,
+        })
+      )
+    );
+
+    const store = new SessionStore();
+    await store.init();
+    const session = await store.load(sid);
+    expect(session).not.toBeNull();
+    expect(session!.messages).toHaveLength(10);
+    expect(session!.messages.map((m) => m.id).sort()).toEqual(
+      Array.from({ length: 10 }, (_, i) => `burst-${i}`).sort()
+    );
+    // Timestamps stayed monotonic across the serialized writes.
+    const ts = session!.messages.map((m) => m.timestamp);
+    expect(ts).toEqual([...ts].sort((a, b) => a - b));
+  });
 });


### PR DESCRIPTION
## Summary

Two related webapp UI changes that share a branch because the fixture helped verify the lick-history fix.

### 1. Licks from history now render as lick widgets (commit `7a694eb`)

Licks (webhook, cron, sprinkle, fswatch, navigate, session-reload) entered the orchestrator's conversation history but rendered as plain user bubbles after a reload, making it hard to see what the model was reacting to.

Root cause: two gaps in `packages/webapp/src/ui/main.ts`.
- The orchestrator-DB fallback in `handleScoopSelect` called `addUserMessage`, dropping `source: 'lick'` and `channel` — and only handled `webhook`/`cron`, missing the other four channels.
- When a lick arrived for a non-selected scoop, it was written to the orchestrator DB and the in-memory buffer but never to SessionStore, so the broken DB fallback was the only path on reload.

Fix:
- `ChatPanel.addLickMessage` now accepts an optional `timestamp` so history replays preserve chronological order; duplicates are ignored.
- New `ChatPanel.persistLickToSession` writes a lick (with source/channel/timestamp) into an arbitrary session id, used by `routeLickToScoop` when the target scoop isn't the selected one.
- The DB fallback dispatches every lick channel via `addLickMessage` using the persisted id + timestamp, so every channel renders as its collapsible widget instead of a "You" bubble.

### 2. `?ui-fixture=1` design-time harness (commit `9a946e6`)

Opens a synthetic, isolated chat session that exercises every message UI variant — user/assistant bubbles, markdown with code, all four tool-call states (success, error, running, with screenshot), a delegation, the six lick channels, a queued message, and a streaming tail — so designers can iterate on the chat panel without driving a real conversation.

- Wired in both standalone `main()` and `mainExtension()`, run after normal scoop select so real scoops stay listed in the sidebar and clicking one cleanly exits fixture mode.
- Persists to a dedicated `session-ui-fixture` id; real scoop storage is untouched.
- Activate with `?ui-fixture=1`, `?ui-fixture`, or `?ui-fixture=true`.

## Files

- `packages/webapp/src/ui/chat-panel.ts` — `addLickMessage` timestamp support + `persistLickToSession`
- `packages/webapp/src/ui/main.ts` — DB fallback fix, SessionStore persistence for non-selected targets, `isUIFixtureRequested` + `loadUIFixtureIntoChat` wired into both entry points
- `packages/webapp/src/ui/chat-fixture.ts` — new, pure `createChatFixture()`
- `packages/webapp/tests/ui/chat-panel-lick.test.ts` — new, 7 tests covering lick rendering + SessionStore persistence semantics
- `packages/webapp/tests/ui/chat-fixture.test.ts` — new, 11 tests asserting every variant remains covered

## Verification

- `npx prettier --check` clean on all changed files
- `npm run typecheck` green
- `npm run test` — 2867 passed, 2 skipped (up from 2856 with 18 new tests). Pre-existing LightningFS `_deactivate` rejections in `orchestrator.test.ts` are unrelated and predate this branch.
- `npm run build -w @slicc/webapp` and `-w @slicc/chrome-extension` both succeed.

## Try the fixture

```bash
npm run dev
# then open http://localhost:5710/?ui-fixture=1
```
