### PR TITLE
fix(webapp): handle undefined content in sprinkle open

### DIFF
--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -125,7 +125,13 @@ export class SprinkleManager {
       throw new Error(`Sprinkle not found: ${name}`);
     }
 
-    const content = (await this.fs.readFile(sprinkle.path, { encoding: 'utf-8' })) as string;
+    const rawContent = await this.fs.readFile(sprinkle.path, { encoding: 'utf-8' });
+    if (rawContent === undefined || rawContent === null) {
+      throw new Error(
+        `Failed to read sprinkle content: ${sprinkle.path} (file may be corrupted or missing)`
+      );
+    }
+    const content = rawContent as string;
     const container = document.createElement('div');
     container.className = 'sprinkle-panel';
     container.style.cssText =

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -131,7 +131,8 @@ export class SprinkleManager {
         `Failed to read sprinkle content: ${sprinkle.path} (file may be corrupted or missing)`
       );
     }
-    const content = rawContent as string;
+    const content =
+      typeof rawContent === 'string' ? rawContent : new TextDecoder('utf-8').decode(rawContent);
     const container = document.createElement('div');
     container.className = 'sprinkle-panel';
     container.style.cssText =

--- a/packages/webapp/tests/ui/sprinkle-manager.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-manager.test.ts
@@ -63,4 +63,19 @@ describe('SprinkleManager', () => {
   it('sendToSprinkle does not throw for closed sprinkle', () => {
     expect(() => mgr.sendToSprinkle('unknown', {})).not.toThrow();
   });
+
+  it('open throws descriptive error when file content is undefined', async () => {
+    await vfs.writeFile('/shared/sprinkles/broken/broken.shtml', '<title>Broken</title><div/>');
+    await mgr.refresh();
+
+    // Mock readFile to return undefined (simulating VFS corruption)
+    const originalReadFile = vfs.readFile.bind(vfs);
+    vfs.readFile = vi.fn().mockResolvedValue(undefined) as typeof vfs.readFile;
+
+    await expect(mgr.open('broken')).rejects.toThrow(
+      'Failed to read sprinkle content: /shared/sprinkles/broken/broken.shtml'
+    );
+
+    vfs.readFile = originalReadFile;
+  });
 });


### PR DESCRIPTION
## Problem

When opening a sprinkle, if the VFS is in a corrupted state (e.g., superblock references files whose content is missing from IndexedDB), `readFile` returns `undefined` instead of throwing. This caused a cryptic `TypeError`:

```
TypeError: Cannot read properties of undefined (reading 'trimStart')
    at isFullDocument (sprinkle-renderer.ts)
    at SprinkleRenderer.render
    at SprinkleManager.open
```

## Root Cause

The VFS IndexedDB can get into an inconsistent state where the superblock/cache references inodes whose file content was never written or was corrupted. In this case, `fs.readFile()` returns `undefined` rather than throwing `ENOENT`.

## Solution

Add a defensive check in `SprinkleManager.open()` that throws a clear error when file content is undefined/null, failing fast with a descriptive message instead of passing undefined down the call chain.

## Testing

- Typecheck passes
- All tests pass (except pre-existing flaky LightningFS cleanup issues in orchestrator tests)