### PR TITLE
perf(scoops): use RestrictedFS for scoop skill discovery

### DIFF
--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -825,12 +825,15 @@ export class Orchestrator {
       getBrowserAPI: () => this.callbacks.getBrowserAPI(),
     };
 
+    // Cone gets unrestricted skillsFs for full compatibility skill discovery.
+    // Scoops use their RestrictedFS (passed as `fs`) so skill discovery is
+    // bounded by their ACLs — no expensive BFS over the entire VFS.
     const context = new ScoopContext(
       scoop,
       contextCallbacks,
       fs,
       this.sessionStore ?? undefined,
-      this.sharedFs ?? undefined
+      scoop.isCone ? (this.sharedFs ?? undefined) : undefined
     );
 
     this.contexts.set(jid, context);


### PR DESCRIPTION
Scoops now use their RestrictedFS for skill discovery instead of the unrestricted sharedFs. This bounds the compatibility skill BFS scan by the scoop's ACL - it can only see directories it has access to.

**Problem**: When creating a new scoop, the compatibility skill discovery (`discoverCompatibilitySkillCandidates`) does a BFS from `/` looking for `.agents/skills/` and `.claude/skills/` directories. If you have mounted directories with many folders, this is very slow.

**Solution**: Pass the scoop's `RestrictedFS` instead of `sharedFs` for skill discovery. The scan naturally stops at ACL boundaries. The cone still gets full unrestricted access.

This is a minimal, targeted fix. A follow-up PR will add a MountIndex for faster mounted directory walks.