### PR TITLE
feat(fs): add MountIndex for fast mounted directory walks

### DIFF
--- a/packages/webapp/src/fs/index.ts
+++ b/packages/webapp/src/fs/index.ts
@@ -17,3 +17,5 @@ export type {
 export { normalizePath, splitPath, pathSegments, joinPath } from './path-utils.js';
 export { FsWatcher } from './fs-watcher.js';
 export type { FsChangeEvent, FsChangeType, FsWatchFilter, FsWatchCallback } from './fs-watcher.js';
+export { MountIndex } from './mount-index.js';
+export type { MountIndexEntry, MountIndexState, IndexingStatus } from './mount-index.js';

--- a/packages/webapp/src/fs/mount-commands.ts
+++ b/packages/webapp/src/fs/mount-commands.ts
@@ -60,9 +60,9 @@ export class MountCommands {
         const state = mountIndex.getState(m);
         if (!state) return m;
         if (state.status === 'ready') {
-          return `${m} (indexed: ${state.indexed} files)`;
+          return `${m} (indexed: ${state.indexed} entries)`;
         } else if (state.status === 'indexing') {
-          return `${m} (indexing: ${state.indexed} files...)`;
+          return `${m} (indexing: ${state.indexed} entries...)`;
         } else if (state.status === 'error') {
           return `${m} (index error: ${state.error})`;
         }

--- a/packages/webapp/src/fs/mount-commands.ts
+++ b/packages/webapp/src/fs/mount-commands.ts
@@ -55,7 +55,41 @@ export class MountCommands {
     if (sub === 'list' || sub === '-l') {
       const mounts = this.options.fs.listMounts();
       if (mounts.length === 0) return { stdout: 'No active mounts\n', stderr: '', exitCode: 0 };
-      return { stdout: mounts.map((m) => m).join('\n') + '\n', stderr: '', exitCode: 0 };
+      const mountIndex = this.options.fs.getMountIndex();
+      const lines = mounts.map((m) => {
+        const state = mountIndex.getState(m);
+        if (!state) return m;
+        if (state.status === 'ready') {
+          return `${m} (indexed: ${state.indexed} files)`;
+        } else if (state.status === 'indexing') {
+          return `${m} (indexing: ${state.indexed} files...)`;
+        } else if (state.status === 'error') {
+          return `${m} (index error: ${state.error})`;
+        }
+        return `${m} (pending index)`;
+      });
+      return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
+    }
+
+    // refresh <path> - re-index a mounted directory
+    if (sub === 'refresh') {
+      const target = args[1];
+      if (!target) return { stdout: '', stderr: 'mount refresh: path required', exitCode: 1 };
+      const targetPath = target.startsWith('/') ? target : `${cwd.replace(/\/$/, '')}/${target}`;
+      try {
+        await this.options.fs.refreshMount(targetPath);
+        return {
+          stdout: `Re-indexed ${targetPath}\n`,
+          stderr: '',
+          exitCode: 0,
+        };
+      } catch (err) {
+        return {
+          stdout: '',
+          stderr: `mount refresh: ${err instanceof Error ? err.message : String(err)}`,
+          exitCode: 1,
+        };
+      }
     }
 
     // mount <target-path>
@@ -168,7 +202,10 @@ export class MountCommands {
     try {
       await this.options.fs.mount(targetPath, dirHandle);
       return {
-        stdout: `Mounted '${dirHandle.name}' → ${targetPath} (live bridge — reads and writes go to the real filesystem)\n`,
+        stdout:
+          `Mounted '${dirHandle.name}' → ${targetPath}\n` +
+          `Indexing in background for fast file discovery.\n` +
+          `Note: External changes are not auto-detected — use 'mount refresh ${targetPath}' after modifying files outside the browser.\n`,
         stderr: '',
         exitCode: 0,
       };
@@ -188,22 +225,29 @@ export class MountCommands {
           'Usage: mount <target-path>',
           '       mount unmount <path>',
           '       mount list',
+          '       mount refresh <path>',
           '',
           'Transparently bridge a real filesystem directory into the virtual filesystem.',
           'Opens a directory picker; all reads and writes under <target-path> go directly',
           'to the real directory — no copying occurs. Changes are immediately visible on',
           'both sides. Mount points must be empty so existing VFS files are not hidden.',
           '',
+          'Upon mounting, files are indexed asynchronously for fast discovery. External',
+          'changes (made outside the browser) are NOT automatically detected — use',
+          '`mount refresh` to re-index after external modifications.',
+          '',
           'Arguments:',
           '  <target-path>  Mount point in the virtual filesystem (required).',
           '',
           'Sub-commands:',
-          '  unmount <path>  Remove a mount point',
-          '  list            Show active mount points',
+          '  unmount <path>   Remove a mount point',
+          '  list             Show active mount points and index status',
+          '  refresh <path>   Re-index a mount after external changes',
           '',
           'Examples:',
-          '  mount /mnt/myapp         # Mount selected dir at /mnt/myapp',
-          '  mount list               # Show active mounts',
+          '  mount /mnt/myapp           # Mount selected dir at /mnt/myapp',
+          '  mount list                 # Show active mounts with index status',
+          '  mount refresh /mnt/myapp   # Re-index after external changes',
           '  mount unmount /mnt/myapp',
         ].join('\n') + '\n',
       stderr: '',

--- a/packages/webapp/src/fs/mount-index.ts
+++ b/packages/webapp/src/fs/mount-index.ts
@@ -175,6 +175,43 @@ export class MountIndex {
   }
 
   /**
+   * Get directory entries (immediate children) for a path within a mount.
+   * Returns undefined if the index is not ready (caller should use slow path).
+   */
+  getDirectoryEntries(
+    mountPath: string,
+    dirPath: string
+  ): Array<{ name: string; type: 'file' | 'directory' }> | undefined {
+    const data = this.mounts.get(mountPath);
+    if (!data || data.state.status !== 'ready') {
+      return undefined;
+    }
+
+    const prefix = dirPath === '/' ? '/' : dirPath + '/';
+    const entries = new Map<string, 'file' | 'directory'>();
+
+    // Find all files that are immediate children of dirPath
+    for (const path of data.files) {
+      if (!path.startsWith(prefix)) continue;
+      const rest = path.slice(prefix.length);
+      if (!rest.includes('/')) {
+        entries.set(rest, 'file');
+      }
+    }
+
+    // Find all directories that are immediate children of dirPath
+    for (const path of data.directories) {
+      if (!path.startsWith(prefix)) continue;
+      const rest = path.slice(prefix.length);
+      if (!rest.includes('/')) {
+        entries.set(rest, 'directory');
+      }
+    }
+
+    return [...entries.entries()].map(([name, type]) => ({ name, type }));
+  }
+
+  /**
    * Check if a path exists in the index.
    * Returns undefined if the index is not ready.
    */

--- a/packages/webapp/src/fs/mount-index.ts
+++ b/packages/webapp/src/fs/mount-index.ts
@@ -1,0 +1,370 @@
+/**
+ * MountIndex — maintains a cached file listing for mounted directories.
+ *
+ * Problem: Walking mounted directories via FileSystemDirectoryHandle is slow
+ * because each readDir requires an async IPC round-trip to the browser's file
+ * system access layer. For large directories (e.g., node_modules), this can
+ * take seconds.
+ *
+ * Solution: Build an in-memory index of all files in each mount when mounting.
+ * The index is built asynchronously and non-blocking. While indexing is in
+ * progress, callers fall back to the slow path. Once complete, file discovery
+ * (jsh, bsh, skills, etc.) can query the index in O(1).
+ *
+ * The index is updated incrementally on write/delete operations that go through
+ * VirtualFS. External changes (made outside the browser) are NOT automatically
+ * detected — use `mount refresh` to re-index.
+ */
+
+import { createLogger } from '../core/logger.js';
+
+const log = createLogger('mount-index');
+
+export interface MountIndexEntry {
+  /** Absolute VFS path */
+  path: string;
+  /** 'file' or 'directory' */
+  type: 'file' | 'directory';
+}
+
+export type IndexingStatus = 'pending' | 'indexing' | 'ready' | 'error';
+
+export interface MountIndexState {
+  status: IndexingStatus;
+  /** Number of entries indexed so far (for progress reporting) */
+  indexed: number;
+  /** Total entries if known, undefined while still discovering */
+  total?: number;
+  /** Error message if status is 'error' */
+  error?: string;
+}
+
+interface MountData {
+  handle: FileSystemDirectoryHandle;
+  state: MountIndexState;
+  /** Set of all file paths under this mount (absolute VFS paths) */
+  files: Set<string>;
+  /** Set of all directory paths under this mount (absolute VFS paths) */
+  directories: Set<string>;
+  /** Abort controller for cancelling in-progress indexing */
+  abortController: AbortController | null;
+}
+
+export class MountIndex {
+  private mounts = new Map<string, MountData>();
+  private listeners = new Set<() => void>();
+
+  /**
+   * Register a mount point and begin async indexing.
+   * Returns immediately — indexing runs in the background.
+   */
+  registerMount(mountPath: string, handle: FileSystemDirectoryHandle): void {
+    // Cancel any existing indexing for this path
+    this.mounts.get(mountPath)?.abortController?.abort();
+
+    const abortController = new AbortController();
+    const data: MountData = {
+      handle,
+      state: { status: 'pending', indexed: 0 },
+      files: new Set(),
+      directories: new Set(),
+      abortController,
+    };
+
+    this.mounts.set(mountPath, data);
+    this.notifyListeners();
+
+    // Start async indexing
+    void this.indexMount(mountPath, data, abortController.signal);
+  }
+
+  /**
+   * Unregister a mount point and clear its index.
+   */
+  unregisterMount(mountPath: string): void {
+    const data = this.mounts.get(mountPath);
+    if (data) {
+      data.abortController?.abort();
+      this.mounts.delete(mountPath);
+      this.notifyListeners();
+    }
+  }
+
+  /**
+   * Re-index a mount point. Use after external changes.
+   */
+  async refreshMount(mountPath: string): Promise<void> {
+    const data = this.mounts.get(mountPath);
+    if (!data) {
+      throw new Error(`No mount at ${mountPath}`);
+    }
+
+    // Cancel existing indexing
+    data.abortController?.abort();
+
+    // Reset and re-index
+    const abortController = new AbortController();
+    data.abortController = abortController;
+    data.state = { status: 'pending', indexed: 0 };
+    data.files.clear();
+    data.directories.clear();
+    this.notifyListeners();
+
+    await this.indexMount(mountPath, data, abortController.signal);
+  }
+
+  /**
+   * Check if a mount's index is ready for fast queries.
+   */
+  isReady(mountPath: string): boolean {
+    return this.mounts.get(mountPath)?.state.status === 'ready';
+  }
+
+  /**
+   * Check if ANY mount is still indexing (for progress UI).
+   */
+  isAnyIndexing(): boolean {
+    for (const data of this.mounts.values()) {
+      if (data.state.status === 'indexing' || data.state.status === 'pending') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Get the indexing state for a mount.
+   */
+  getState(mountPath: string): MountIndexState | undefined {
+    return this.mounts.get(mountPath)?.state;
+  }
+
+  /**
+   * Get all file paths under a mount that match a filter.
+   * Returns undefined if the index is not ready (caller should use slow path).
+   */
+  getFiles(mountPath: string, filter?: (path: string) => boolean): string[] | undefined {
+    const data = this.mounts.get(mountPath);
+    if (!data || data.state.status !== 'ready') {
+      return undefined;
+    }
+
+    if (!filter) {
+      return [...data.files];
+    }
+
+    const result: string[] = [];
+    for (const path of data.files) {
+      if (filter(path)) {
+        result.push(path);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Check if a path exists in the index.
+   * Returns undefined if the index is not ready.
+   */
+  hasPath(mountPath: string, absolutePath: string): boolean | undefined {
+    const data = this.mounts.get(mountPath);
+    if (!data || data.state.status !== 'ready') {
+      return undefined;
+    }
+    return data.files.has(absolutePath) || data.directories.has(absolutePath);
+  }
+
+  /**
+   * Notify the index that a file was created/written.
+   * Called by VirtualFS after write operations.
+   */
+  notifyWrite(absolutePath: string): void {
+    const mountPath = this.findMountForPath(absolutePath);
+    if (!mountPath) return;
+
+    const data = this.mounts.get(mountPath);
+    if (!data || data.state.status !== 'ready') return;
+
+    data.files.add(absolutePath);
+
+    // Ensure parent directories are indexed
+    let parent = absolutePath;
+    while (parent !== mountPath) {
+      const lastSlash = parent.lastIndexOf('/');
+      if (lastSlash <= 0) break;
+      parent = parent.slice(0, lastSlash) || '/';
+      if (parent.length >= mountPath.length) {
+        data.directories.add(parent);
+      }
+    }
+  }
+
+  /**
+   * Notify the index that a file/directory was deleted.
+   * Called by VirtualFS after delete operations.
+   */
+  notifyDelete(absolutePath: string): void {
+    const mountPath = this.findMountForPath(absolutePath);
+    if (!mountPath) return;
+
+    const data = this.mounts.get(mountPath);
+    if (!data || data.state.status !== 'ready') return;
+
+    // Remove the path and all children
+    data.files.delete(absolutePath);
+    data.directories.delete(absolutePath);
+
+    const prefix = absolutePath + '/';
+    for (const path of data.files) {
+      if (path.startsWith(prefix)) {
+        data.files.delete(path);
+      }
+    }
+    for (const path of data.directories) {
+      if (path.startsWith(prefix)) {
+        data.directories.delete(path);
+      }
+    }
+  }
+
+  /**
+   * Notify the index that a file/directory was renamed.
+   */
+  notifyRename(oldPath: string, newPath: string): void {
+    const mountPath = this.findMountForPath(oldPath);
+    if (!mountPath) return;
+
+    const data = this.mounts.get(mountPath);
+    if (!data || data.state.status !== 'ready') return;
+
+    // Handle file rename
+    if (data.files.has(oldPath)) {
+      data.files.delete(oldPath);
+      data.files.add(newPath);
+      return;
+    }
+
+    // Handle directory rename (move all children)
+    if (data.directories.has(oldPath)) {
+      data.directories.delete(oldPath);
+      data.directories.add(newPath);
+
+      const oldPrefix = oldPath + '/';
+      const newPrefix = newPath + '/';
+
+      for (const path of [...data.files]) {
+        if (path.startsWith(oldPrefix)) {
+          data.files.delete(path);
+          data.files.add(newPrefix + path.slice(oldPrefix.length));
+        }
+      }
+      for (const path of [...data.directories]) {
+        if (path.startsWith(oldPrefix)) {
+          data.directories.delete(path);
+          data.directories.add(newPrefix + path.slice(oldPrefix.length));
+        }
+      }
+    }
+  }
+
+  /**
+   * Subscribe to index state changes (for UI updates).
+   */
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /**
+   * Find which mount (if any) contains an absolute path.
+   */
+  private findMountForPath(absolutePath: string): string | undefined {
+    for (const mountPath of this.mounts.keys()) {
+      if (absolutePath === mountPath || absolutePath.startsWith(mountPath + '/')) {
+        return mountPath;
+      }
+    }
+    return undefined;
+  }
+
+  private notifyListeners(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener();
+      } catch {
+        // Ignore listener errors
+      }
+    }
+  }
+
+  /**
+   * Perform the actual indexing of a mount point.
+   */
+  private async indexMount(mountPath: string, data: MountData, signal: AbortSignal): Promise<void> {
+    data.state = { status: 'indexing', indexed: 0 };
+    this.notifyListeners();
+
+    try {
+      await this.walkHandle(mountPath, data.handle, data, signal);
+
+      if (signal.aborted) return;
+
+      data.state = {
+        status: 'ready',
+        indexed: data.files.size + data.directories.size,
+        total: data.files.size + data.directories.size,
+      };
+      data.abortController = null;
+
+      log.info('Mount indexed', {
+        path: mountPath,
+        files: data.files.size,
+        directories: data.directories.size,
+      });
+    } catch (err) {
+      if (signal.aborted) return;
+
+      const message = err instanceof Error ? err.message : String(err);
+      data.state = { status: 'error', indexed: 0, error: message };
+      log.error('Mount indexing failed', { path: mountPath, error: message });
+    }
+
+    this.notifyListeners();
+  }
+
+  /**
+   * Recursively walk a FileSystemDirectoryHandle and index all entries.
+   */
+  private async walkHandle(
+    basePath: string,
+    handle: FileSystemDirectoryHandle,
+    data: MountData,
+    signal: AbortSignal
+  ): Promise<void> {
+    if (signal.aborted) return;
+
+    data.directories.add(basePath);
+
+    // Type assertion for async iteration over directory entries
+    const entries = handle as unknown as AsyncIterable<[string, FileSystemHandle]>;
+
+    for await (const [name, childHandle] of entries) {
+      if (signal.aborted) return;
+
+      const childPath = basePath === '/' ? `/${name}` : `${basePath}/${name}`;
+
+      if (childHandle.kind === 'file') {
+        data.files.add(childPath);
+        data.state.indexed++;
+      } else if (childHandle.kind === 'directory') {
+        await this.walkHandle(childPath, childHandle as FileSystemDirectoryHandle, data, signal);
+      }
+
+      // Yield to event loop periodically to keep UI responsive
+      if (data.state.indexed % 500 === 0) {
+        this.notifyListeners();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+    }
+  }
+}

--- a/packages/webapp/src/fs/mount-index.ts
+++ b/packages/webapp/src/fs/mount-index.ts
@@ -133,6 +133,18 @@ export class MountIndex {
   }
 
   /**
+   * Dispose of all mounts and cancel any in-flight indexing.
+   * Call this when the VirtualFS is disposed to avoid resource leaks.
+   */
+  dispose(): void {
+    for (const data of this.mounts.values()) {
+      data.abortController?.abort();
+    }
+    this.mounts.clear();
+    this.listeners.clear();
+  }
+
+  /**
    * Get the indexing state for a mount.
    */
   getState(mountPath: string): MountIndexState | undefined {
@@ -278,13 +290,17 @@ export class MountIndex {
   /**
    * Find which mount (if any) contains an absolute path.
    */
+  /** Find the most specific mount that owns this path (longest prefix wins). */
   private findMountForPath(absolutePath: string): string | undefined {
+    let bestMatch: string | undefined;
     for (const mountPath of this.mounts.keys()) {
       if (absolutePath === mountPath || absolutePath.startsWith(mountPath + '/')) {
-        return mountPath;
+        if (!bestMatch || mountPath.length > bestMatch.length) {
+          bestMatch = mountPath;
+        }
       }
     }
-    return undefined;
+    return bestMatch;
   }
 
   private notifyListeners(): void {

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -460,12 +460,12 @@ export class VirtualFS {
 
   /**
    * Find the mount point that owns `path`.
-   * Returns the handle and the path segments relative to the mount root,
+   * Returns the mount path, handle, and the path segments relative to the mount root,
    * or null if the path is not under any mount.
    */
   private findMount(
     path: string
-  ): { handle: FileSystemDirectoryHandle; relParts: string[] } | null {
+  ): { path: string; handle: FileSystemDirectoryHandle; relParts: string[] } | null {
     let bestMatch: { mountPath: string; handle: FileSystemDirectoryHandle } | null = null;
 
     for (const [mountPath, handle] of this.mountPoints) {
@@ -479,10 +479,11 @@ export class VirtualFS {
     if (!bestMatch) return null;
 
     if (path === bestMatch.mountPath) {
-      return { handle: bestMatch.handle, relParts: [] };
+      return { path: bestMatch.mountPath, handle: bestMatch.handle, relParts: [] };
     }
 
     return {
+      path: bestMatch.mountPath,
       handle: bestMatch.handle,
       relParts: path
         .slice(bestMatch.mountPath.length + 1)
@@ -660,6 +661,27 @@ export class VirtualFS {
     const normalized = normalizePath(path);
     const mount = this.findMount(normalized);
     if (mount) {
+      // Fast path: use MountIndex if available
+      const indexedEntries = this.mountIndex.getDirectoryEntries(mount.path, normalized);
+      if (indexedEntries !== undefined) {
+        const entries = new Map<string, DirEntry>();
+        for (const entry of indexedEntries) {
+          entries.set(entry.name, { name: entry.name, type: entry.type });
+        }
+        // Also include nested mount points as virtual directories
+        const childPrefix = normalized === '/' ? '/' : `${normalized}/`;
+        for (const mountPath of this.mountPoints.keys()) {
+          if (mountPath === normalized || !mountPath.startsWith(childPrefix)) continue;
+          const relPath = mountPath.slice(childPrefix.length);
+          if (!relPath || relPath.includes('/')) continue;
+          if (!entries.has(relPath)) {
+            entries.set(relPath, { name: relPath, type: 'directory' });
+          }
+        }
+        return [...entries.values()];
+      }
+
+      // Slow path: iterate over FSA handle
       try {
         const dirHandle =
           mount.relParts.length === 0

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -67,9 +67,12 @@ export class VirtualFS {
           const { type, path, handle } = event.data ?? {};
           if (type === 'mount' && typeof path === 'string' && handle) {
             this.mountPoints.set(path, handle);
+            // Register with MountIndex so peer instances also get fast walks
+            this.mountIndex.registerMount(path, handle);
             this.watcher?.notify([{ type: 'modify', path, entryType: 'directory' }]);
           } else if (type === 'unmount' && typeof path === 'string') {
             this.mountPoints.delete(path);
+            this.mountIndex.unregisterMount(path);
             this.watcher?.notify([{ type: 'modify', path, entryType: 'directory' }]);
           }
         };
@@ -125,6 +128,7 @@ export class VirtualFS {
     this.mountSyncChannel = null;
     this.watcher?.dispose();
     this.watcher = null;
+    this.mountIndex.dispose();
 
     const pfs = this.lfs as any;
 
@@ -425,7 +429,6 @@ export class VirtualFS {
 
   /**
    * Get the mount index for fast file discovery in mounted directories.
-   * Returns undefined if mount indexing is not available.
    */
   getMountIndex(): MountIndex {
     return this.mountIndex;
@@ -608,10 +611,8 @@ export class VirtualFS {
           entryType: 'file',
         },
       ]);
-      // Update mount index for fast discovery
-      if (!wasExisting) {
-        this.mountIndex.notifyWrite(normalized);
-      }
+      // Update mount index for fast discovery (idempotent, safe to call always)
+      this.mountIndex.notifyWrite(normalized);
       return;
     }
     // Resolve symlinks before writing
@@ -955,41 +956,26 @@ export class VirtualFS {
   async *walk(path: string, _visited?: Set<string>): AsyncGenerator<string> {
     const normalized = normalizePath(path);
 
-    // Fast path optimization: only check mounts at the top-level call (when _visited is undefined)
-    // to avoid repeated mount lookups on every recursive iteration.
-    if (_visited === undefined && this.mountPoints.size > 0) {
-      // Find the most specific mount that owns this path (longest mount path wins)
-      let owningMount: string | null = null;
-      for (const mountPath of this.mountPoints.keys()) {
-        if (normalized === mountPath || normalized.startsWith(mountPath + '/')) {
-          if (!owningMount || mountPath.length > owningMount.length) {
-            owningMount = mountPath;
-          }
-        }
-      }
+    // Fast path: check if this path is exactly a mount point with a ready index.
+    // We check on every call (including recursive) so that walking from '/' can
+    // switch to indexed iteration when it enters a mounted subtree.
+    // Only use fast path when:
+    // 1. The path IS the mount point (not a subdirectory of it)
+    // 2. The mount's index is ready
+    // 3. There are no nested mounts under this path
+    if (this.mountPoints.size > 0 && this.mountPoints.has(normalized)) {
+      const hasNestedMounts = [...this.mountPoints.keys()].some(
+        (mp) => mp !== normalized && mp.startsWith(normalized + '/')
+      );
 
-      if (owningMount) {
-        // Check for nested mounts under the walk path — if any exist, use slow path
-        // so we properly traverse into each nested mount
-        const hasNestedMounts = [...this.mountPoints.keys()].some(
-          (mp) => mp !== owningMount && mp.startsWith(normalized + '/')
-        );
-
-        if (!hasNestedMounts && this.mountIndex.isReady(owningMount)) {
-          // Use the indexed file list — filter to paths under `normalized`
-          const prefix = normalized === '/' ? '/' : normalized + '/';
-          const files = this.mountIndex.getFiles(
-            owningMount,
-            (p) => p === normalized || p.startsWith(prefix)
-          );
-          if (files) {
-            for (const filePath of files) {
-              yield filePath;
-            }
-            return;
+      if (!hasNestedMounts && this.mountIndex.isReady(normalized)) {
+        const files = this.mountIndex.getFiles(normalized);
+        if (files) {
+          for (const filePath of files) {
+            yield filePath;
           }
+          return;
         }
-        // Path is under a mount but can't use fast path — fall through to slow path
       }
     }
 

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -23,6 +23,7 @@ import { FsError } from './types.js';
 import { normalizePath, splitPath, joinPath } from './path-utils.js';
 import type { FsWatcher } from './fs-watcher.js';
 import { saveMountEntry, removeMountEntry, clearMountEntries } from './mount-table-store.js';
+import { MountIndex } from './mount-index.js';
 
 /** Maximum number of symlink hops before throwing ELOOP. */
 const MAX_SYMLINK_DEPTH = 10;
@@ -44,6 +45,8 @@ export class VirtualFS {
   private readonly dbName: string;
   /** BroadcastChannel for syncing mount registrations across VFS instances with the same dbName. */
   private mountSyncChannel: BroadcastChannel | null = null;
+  /** Index of files in mounted directories for fast discovery. */
+  private mountIndex = new MountIndex();
 
   private constructor(dbName: string, wipe: boolean) {
     this.dbName = dbName;
@@ -380,6 +383,8 @@ export class VirtualFS {
       /* EEXIST is fine */
     }
     this.mountPoints.set(normalized, handle);
+    // Start async indexing for fast file discovery
+    this.mountIndex.registerMount(normalized, handle);
     try {
       this.mountSyncChannel?.postMessage({ type: 'mount', path: normalized, handle });
     } catch {
@@ -398,6 +403,7 @@ export class VirtualFS {
   async unmount(absolutePath: string): Promise<void> {
     const normalized = normalizePath(absolutePath);
     this.mountPoints.delete(normalized);
+    this.mountIndex.unregisterMount(normalized);
     try {
       this.mountSyncChannel?.postMessage({ type: 'unmount', path: normalized });
     } catch {
@@ -415,6 +421,26 @@ export class VirtualFS {
   /** Return the list of currently active mount paths. */
   listMounts(): string[] {
     return [...this.mountPoints.keys()];
+  }
+
+  /**
+   * Get the mount index for fast file discovery in mounted directories.
+   * Returns undefined if mount indexing is not available.
+   */
+  getMountIndex(): MountIndex {
+    return this.mountIndex;
+  }
+
+  /**
+   * Re-index a mounted directory. Use after external changes.
+   * @throws Error if the path is not a mount point
+   */
+  async refreshMount(mountPath: string): Promise<void> {
+    const normalized = normalizePath(mountPath);
+    if (!this.mountPoints.has(normalized)) {
+      throw new FsError('ENOENT', 'not a mount point', normalized);
+    }
+    await this.mountIndex.refreshMount(normalized);
   }
 
   /**
@@ -582,6 +608,10 @@ export class VirtualFS {
           entryType: 'file',
         },
       ]);
+      // Update mount index for fast discovery
+      if (!wasExisting) {
+        this.mountIndex.notifyWrite(normalized);
+      }
       return;
     }
     // Resolve symlinks before writing
@@ -761,6 +791,8 @@ export class VirtualFS {
         throw this.convertFsaError(err, normalized);
       }
       this.watcher?.notify([{ type: 'delete', path: normalized, entryType }]);
+      // Update mount index
+      this.mountIndex.notifyDelete(normalized);
       return;
     }
     try {
@@ -900,6 +932,8 @@ export class VirtualFS {
       { type: 'delete', path: normalizedOld, entryType },
       { type: 'create', path: normalizedNew, entryType },
     ]);
+    // Update mount index if paths are under mounts
+    this.mountIndex.notifyRename(normalizedOld, normalizedNew);
   }
 
   /**
@@ -914,9 +948,52 @@ export class VirtualFS {
   /**
    * Recursively walk a directory tree, yielding all file paths.
    * Follows symlinks to directories but tracks visited real paths to avoid infinite loops.
+   *
+   * For mounted directories with a ready index, uses the fast path (O(n) iteration
+   * over cached file list). Falls back to slow recursive readDir otherwise.
    */
   async *walk(path: string, _visited?: Set<string>): AsyncGenerator<string> {
     const normalized = normalizePath(path);
+
+    // Fast path optimization: only check mounts at the top-level call (when _visited is undefined)
+    // to avoid repeated mount lookups on every recursive iteration.
+    if (_visited === undefined && this.mountPoints.size > 0) {
+      // Find the most specific mount that owns this path (longest mount path wins)
+      let owningMount: string | null = null;
+      for (const mountPath of this.mountPoints.keys()) {
+        if (normalized === mountPath || normalized.startsWith(mountPath + '/')) {
+          if (!owningMount || mountPath.length > owningMount.length) {
+            owningMount = mountPath;
+          }
+        }
+      }
+
+      if (owningMount) {
+        // Check for nested mounts under the walk path — if any exist, use slow path
+        // so we properly traverse into each nested mount
+        const hasNestedMounts = [...this.mountPoints.keys()].some(
+          (mp) => mp !== owningMount && mp.startsWith(normalized + '/')
+        );
+
+        if (!hasNestedMounts && this.mountIndex.isReady(owningMount)) {
+          // Use the indexed file list — filter to paths under `normalized`
+          const prefix = normalized === '/' ? '/' : normalized + '/';
+          const files = this.mountIndex.getFiles(
+            owningMount,
+            (p) => p === normalized || p.startsWith(prefix)
+          );
+          if (files) {
+            for (const filePath of files) {
+              yield filePath;
+            }
+            return;
+          }
+        }
+        // Path is under a mount but can't use fast path — fall through to slow path
+      }
+    }
+
+    // Slow path: recursive readDir
     const visited = _visited ?? new Set<string>();
 
     // Track the real path to detect symlink loops

--- a/packages/webapp/tests/fs/mount-commands.test.ts
+++ b/packages/webapp/tests/fs/mount-commands.test.ts
@@ -2,11 +2,19 @@ import { describe, it, expect, vi } from 'vitest';
 import { MountCommands } from '../../src/fs/mount-commands.js';
 import type { VirtualFS } from '../../src/fs/virtual-fs.js';
 
+function makeMockMountIndex() {
+  return {
+    getState: vi.fn(() => undefined),
+    isReady: vi.fn(() => false),
+  };
+}
+
 function makeFs(overrides: Partial<VirtualFS> = {}): VirtualFS {
   return {
     listMounts: vi.fn(() => []),
     unmount: vi.fn(),
     mount: vi.fn(),
+    getMountIndex: vi.fn(() => makeMockMountIndex()),
     ...overrides,
   } as unknown as VirtualFS;
 }

--- a/packages/webapp/tests/shell/script-catalog.test.ts
+++ b/packages/webapp/tests/shell/script-catalog.test.ts
@@ -235,6 +235,8 @@ describe('ScriptCatalog', () => {
     expect((await catalog.getJshCommands()).get('one')).toBe('/mnt/repo/one.jsh');
 
     mounted.setFile('two.jsh', 'console.log("two");');
+    // External changes require mount refresh to update the index
+    await vfs.refreshMount('/mnt/repo');
     expect((await catalog.getJshCommands()).get('two')).toBe('/mnt/repo/two.jsh');
   });
 
@@ -255,6 +257,8 @@ describe('ScriptCatalog', () => {
     expect((await catalog.getJshCommands()).get('one')).toBe('/workspace/repo/one.jsh');
 
     mounted.setFile('two.jsh', 'console.log("two");');
+    // External changes require mount refresh to update the index
+    await vfs.refreshMount('/workspace/repo');
     expect((await catalog.getJshCommands()).get('two')).toBe('/workspace/repo/two.jsh');
   });
 
@@ -276,6 +280,9 @@ describe('ScriptCatalog', () => {
     ]);
 
     mounted.setFile('login.example.com.bsh', 'console.log("example");');
+    // External changes (via mock handle, not VirtualFS) require a mount refresh
+    // to update the MountIndex. This simulates running `mount refresh /workspace/repo`.
+    await vfs.refreshMount('/workspace/repo');
     expect((await catalog.getBshEntries()).map((entry) => entry.path)).toEqual([
       '/workspace/repo/-.okta.com.bsh',
       '/workspace/repo/login.example.com.bsh',


### PR DESCRIPTION
Add an async indexing layer for mounted directories to speed up file discovery.

## Problem

When scoops are created, skill discovery does a BFS from `/` looking for `.agents/skills/` and `.claude/skills/` directories. With large mounted directories (e.g., a monorepo), this can take a long time because every file system access goes through the File System Access API.

## Solution

Add `MountIndex` - an in-memory cache that indexes all files in mounted directories:

- **Async indexing**: Index is built in the background when `mount` is called, non-blocking
- **Fast path in `walk()`**: When index is ready, file discovery is O(n) iteration over cached list instead of recursive readDir calls  
- **Incremental updates**: Write/delete operations through VirtualFS update the index
- **`mount refresh <path>` command**: Re-indexes after external changes (git pull, file manager, etc.)
- **`mount list` enhancement**: Shows index status (ready, indexing, pending, error)

## Behavior Change

External changes (via file manager, git, other processes) are NOT auto-detected. Users need to run `mount refresh <path>` after modifying files outside the browser. The mount success message now warns about this:

```
Mounted 'mydir' → /mnt/mydir
Indexing in background for fast file discovery.
Note: External changes are not auto-detected — use 'mount refresh /mnt/mydir' after modifying files outside the browser.
```

## Testing

- All 2869 tests pass
- Added mock `getMountIndex` to mount-commands test helper
- Updated script-catalog tests to call `refreshMount()` after simulated external changes