### PR TITLE
Expand Swift launcher Chromium browser detection

### DIFF
--- a/packages/swift-launcher/README.md
+++ b/packages/swift-launcher/README.md
@@ -60,6 +60,9 @@ and build the native server: `cd packages/swift-server && swift build`
 
 - **Launch browser**: Click any Chromium browser to start SLICC CLI server
   with that browser (standalone mode, temporary profile).
+  Supported bundle IDs include Chrome stable/beta/dev/canary, Chrome for
+  Testing, Edge stable/beta/dev/canary, Brave stable/beta/nightly, Vivaldi,
+  Arc, Dia, ChatGPT Atlas, Opera, and Chromium.
 - **Launch Electron app**: Click any Electron app to attach SLICC as a
   side panel overlay. Multiple apps can run simultaneously on separate ports.
 - **Get extension**: Opens the Chrome Web Store listing to install the

--- a/packages/swift-launcher/Sliccstart/Models/AppTarget.swift
+++ b/packages/swift-launcher/Sliccstart/Models/AppTarget.swift
@@ -25,11 +25,23 @@ struct AppTarget: Identifiable {
 
     static let knownChromiumBrowsers: [(bundleId: String, name: String)] = [
         ("com.google.Chrome", "Google Chrome"),
+        ("com.google.Chrome.beta", "Google Chrome Beta"),
+        ("com.google.Chrome.dev", "Google Chrome Dev"),
         ("com.google.Chrome.canary", "Chrome Canary"),
+        ("com.google.chrome.for.testing", "Chrome for Testing"),
         ("com.brave.Browser", "Brave Browser"),
+        ("com.brave.Browser.beta", "Brave Beta"),
+        ("com.brave.Browser.nightly", "Brave Nightly"),
         ("com.microsoft.edgemac", "Microsoft Edge"),
+        ("com.microsoft.edgemac.Beta", "Microsoft Edge Beta"),
+        ("com.microsoft.edgemac.Dev", "Microsoft Edge Dev"),
+        ("com.microsoft.edgemac.Canary", "Microsoft Edge Canary"),
         ("com.vivaldi.Vivaldi", "Vivaldi"),
+        ("com.vivaldi.Vivaldi.snapshot", "Vivaldi Snapshot"),
         ("com.operasoftware.Opera", "Opera"),
+        ("company.thebrowser.Browser", "Arc"),
+        ("company.thebrowser.dia", "Dia"),
+        ("com.openai.atlas", "ChatGPT Atlas"),
         ("org.chromium.Chromium", "Chromium"),
     ]
 

--- a/packages/swift-launcher/SliccstartTests/AppScannerTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppScannerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Sliccstart
+
+final class AppScannerTests: XCTestCase {
+    func testKnownChromiumBrowserBundleIdsIncludeSupportedChannels() {
+        let knownBundleIds = Set(AppTarget.knownChromiumBrowsers.map(\.bundleId))
+
+        let expectedBundleIds: Set<String> = [
+            "com.google.Chrome",
+            "com.google.Chrome.beta",
+            "com.google.Chrome.dev",
+            "com.google.Chrome.canary",
+            "com.google.chrome.for.testing",
+            "com.brave.Browser",
+            "com.brave.Browser.beta",
+            "com.brave.Browser.nightly",
+            "com.microsoft.edgemac",
+            "com.microsoft.edgemac.Beta",
+            "com.microsoft.edgemac.Dev",
+            "com.microsoft.edgemac.Canary",
+            "com.vivaldi.Vivaldi",
+            "com.vivaldi.Vivaldi.snapshot",
+            "com.operasoftware.Opera",
+            "company.thebrowser.Browser",
+            "company.thebrowser.dia",
+            "com.openai.atlas",
+            "org.chromium.Chromium",
+        ]
+
+        XCTAssertEqual(knownBundleIds, expectedBundleIds)
+    }
+
+    func testIsChromiumBrowserMatchesExpandedBrowserList() {
+        XCTAssertTrue(AppScanner.isChromiumBrowser(bundleId: "company.thebrowser.dia"))
+        XCTAssertTrue(AppScanner.isChromiumBrowser(bundleId: "com.openai.atlas"))
+        XCTAssertTrue(AppScanner.isChromiumBrowser(bundleId: "company.thebrowser.Browser"))
+        XCTAssertTrue(AppScanner.isChromiumBrowser(bundleId: "com.google.chrome.for.testing"))
+        XCTAssertTrue(AppScanner.isChromiumBrowser(bundleId: "com.microsoft.edgemac.Dev"))
+        XCTAssertTrue(AppScanner.isChromiumBrowser(bundleId: "com.brave.Browser.nightly"))
+        XCTAssertFalse(AppScanner.isChromiumBrowser(bundleId: "com.openai.chat"))
+    }
+}

--- a/packages/swift-launcher/SliccstartTests/AppScannerTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppScannerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Sliccstart
 
 final class AppScannerTests: XCTestCase {
-    func testKnownChromiumBrowserBundleIdsIncludeSupportedChannels() {
+    func testKnownChromiumBrowserBundleIdsMatchCanonicalSet() {
         let knownBundleIds = Set(AppTarget.knownChromiumBrowsers.map(\.bundleId))
 
         let expectedBundleIds: Set<String> = [


### PR DESCRIPTION
## Summary
- add more known Chromium-family macOS bundle IDs, including Arc, Dia, ChatGPT Atlas, and browser channel variants
- add AppScanner coverage for the expanded bundle ID list and keep ChatGPT excluded
- document the broader Swift launcher browser detection in the package README

## Testing
- npx prettier --write --ignore-unknown packages/swift-launcher/README.md packages/swift-launcher/Sliccstart/Models/AppTarget.swift packages/swift-launcher/SliccstartTests/AppScannerTests.swift
- env HOME=/tmp/codex-home CLANG_MODULE_CACHE_PATH=/tmp/codex-clang-cache SWIFTPM_CUSTOM_CACHE_DIR=/tmp/codex-swiftpm-cache swift test