### PR TITLE
revert: re-enable automated Chrome Web Store publishing

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,7 +14,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "node dist/node-server/sync-release-version.js ${nextRelease.version} && npm run build -w @slicc/chrome-extension && npm run package:release && chmod +x packages/swift-launcher/sign-and-package.sh && packages/swift-launcher/sign-and-package.sh ${nextRelease.version}",
-        "publishCmd": "npm run publish:worker"
+        "publishCmd": "npm run publish:worker && npm run publish:chrome"
       }
     ],
     [


### PR DESCRIPTION
Reverts #412.

Summit is over — safe to resume automated CWS publish on every release. The `npm run publish:chrome` step was temporarily removed to avoid pushing untested builds during the event.

**Change:** adds `&& npm run publish:chrome` back to `publishCmd` in `.releaserc.json`.