### PR TITLE
Persist scoop completion notifications to VFS

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,7 +338,8 @@ User input in chat → ChatPanel.sendMessage()
           → results
           → back to agent loop
     → Scoop completes
-      → Orchestrator notification
+      → Orchestrator writes full output to /shared/scoop-notifications/
+      → Orchestrator notification (path + preview + line count)
         → Cone's message queue
         → Cone processes completion
 ```
@@ -353,9 +354,10 @@ Cone executes feed_scoop tool
         → Tool calls
         → Scoop processes independently
     → Scoop completes
-      → Orchestrator notification
+      → Orchestrator writes full output to /shared/scoop-notifications/
+      → Orchestrator notification (path + preview + line count)
         → Cone's message queue
-        → Cone receives result
+        → Cone decides whether to read the file or act on the preview
 ```
 
 ### Lick (Event) Flow

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -38,11 +38,18 @@ const log = createLogger('orchestrator');
 /** Time in ms to wait before notifying cone that a scoop hasn't started work. */
 export const SCOOP_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
 const SCOOP_NOTIFICATION_DIR = '/shared/scoop-notifications';
+const SCOOP_NOTIFICATION_MAX_FILES = 200;
 const SCOOP_NOTIFICATION_PREVIEW_CHARS = 1000;
 
 function countTextLines(text: string): number {
-  if (text.length === 0) return 0;
-  return text.replace(/\r\n/g, '\n').split('\n').length;
+  const normalized = text.replace(/\r\n?/g, '\n');
+  if (normalized.length === 0) return 0;
+
+  let lines = 1;
+  for (let i = 0; i < normalized.length; i++) {
+    if (normalized[i] === '\n') lines++;
+  }
+  return normalized.endsWith('\n') ? lines - 1 : lines;
 }
 
 export interface OrchestratorCallbacks {
@@ -399,31 +406,55 @@ export class Orchestrator {
     const cone = Array.from(this.scoops.values()).find((s) => s.isCone);
     if (!cone) return;
 
+    const lineCount = countTextLines(responseText);
+    const preview = responseText.slice(0, SCOOP_NOTIFICATION_PREVIEW_CHARS);
+    let notifyContent: string;
+    let artifactError: string | null = null;
+    let notificationPath: string | null = null;
+
     try {
-      const notificationPath = await this.writeScoopCompletionArtifact(scoop, responseText);
-      const lineCount = countTextLines(responseText);
-      const preview = responseText.slice(0, SCOOP_NOTIFICATION_PREVIEW_CHARS);
-      const notifyMsg: ChannelMessage = {
-        id: `scoop-done-${jid}-${Date.now()}`,
-        chatJid: cone.jid,
-        senderId: scoop.folder,
-        senderName: scoop.assistantLabel,
-        content: this.formatScoopCompletionNotification(
-          scoop.assistantLabel,
-          notificationPath,
-          lineCount,
-          preview
-        ),
-        timestamp: new Date().toISOString(),
-        fromAssistant: false,
-        channel: 'scoop-notify',
-      };
+      notificationPath = await this.writeScoopCompletionArtifact(scoop, responseText);
       log.info('Routing scoop completion to cone', {
         scoop: scoop.folder,
         responseLength: responseText.length,
         lineCount,
         notificationPath,
       });
+    } catch (err) {
+      artifactError = err instanceof Error ? err.message : String(err);
+      log.warn('Failed to persist scoop completion artifact, falling back to inline preview', {
+        scoop: scoop.folder,
+        error: artifactError,
+      });
+    }
+
+    if (artifactError === null) {
+      notifyContent = this.formatScoopCompletionNotification(
+        scoop.assistantLabel,
+        notificationPath ?? 'unavailable',
+        lineCount,
+        preview
+      );
+    } else {
+      notifyContent = this.formatScoopCompletionFallbackNotification(
+        scoop.assistantLabel,
+        lineCount,
+        preview,
+        artifactError
+      );
+    }
+
+    try {
+      const notifyMsg: ChannelMessage = {
+        id: `scoop-done-${jid}-${Date.now()}`,
+        chatJid: cone.jid,
+        senderId: scoop.folder,
+        senderName: scoop.assistantLabel,
+        content: notifyContent,
+        timestamp: new Date().toISOString(),
+        fromAssistant: false,
+        channel: 'scoop-notify',
+      };
       await this.handleMessage(notifyMsg);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -445,12 +476,46 @@ export class Orchestrator {
     if (!this.sharedFs) throw new Error('Shared filesystem not initialized');
 
     await this.sharedFs.mkdir(SCOOP_NOTIFICATION_DIR, { recursive: true });
+    await this.pruneScoopCompletionArtifacts(SCOOP_NOTIFICATION_MAX_FILES - 1);
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const suffix = Math.random().toString(36).slice(2, 8);
     const path = `${SCOOP_NOTIFICATION_DIR}/${timestamp}-${scoop.folder}-${suffix}.md`;
     await this.sharedFs.writeFile(path, responseText);
+    await this.pruneScoopCompletionArtifacts();
     return path;
+  }
+
+  private async pruneScoopCompletionArtifacts(
+    maxArtifacts: number = SCOOP_NOTIFICATION_MAX_FILES
+  ): Promise<void> {
+    if (!this.sharedFs) return;
+
+    let entries: Awaited<ReturnType<VirtualFS['readDir']>>;
+    try {
+      entries = await this.sharedFs.readDir(SCOOP_NOTIFICATION_DIR);
+    } catch {
+      return;
+    }
+
+    const files = entries
+      .filter((entry) => entry.type === 'file')
+      .map((entry) => entry.name)
+      .sort();
+    const excess = files.length - maxArtifacts;
+    if (excess <= 0) return;
+
+    for (const name of files.slice(0, excess)) {
+      const path = `${SCOOP_NOTIFICATION_DIR}/${name}`;
+      try {
+        await this.sharedFs.rm(path);
+      } catch (err) {
+        log.warn('Failed to prune scoop completion artifact', {
+          path,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 
   private formatScoopCompletionNotification(
@@ -462,6 +527,22 @@ export class Orchestrator {
     return [
       `[@${assistantLabel} completed]`,
       `VFS path: ${notificationPath}`,
+      `Total lines: ${lineCount}`,
+      `Preview (up to ${SCOOP_NOTIFICATION_PREVIEW_CHARS} chars):`,
+      preview,
+    ].join('\n');
+  }
+
+  private formatScoopCompletionFallbackNotification(
+    assistantLabel: string,
+    lineCount: number,
+    preview: string,
+    artifactError: string
+  ): string {
+    return [
+      `[@${assistantLabel} completed]`,
+      'VFS path: unavailable',
+      `Artifact persistence error: ${artifactError}`,
       `Total lines: ${lineCount}`,
       `Preview (up to ${SCOOP_NOTIFICATION_PREVIEW_CHARS} chars):`,
       preview,

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -37,6 +37,13 @@ const log = createLogger('orchestrator');
 
 /** Time in ms to wait before notifying cone that a scoop hasn't started work. */
 export const SCOOP_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
+const SCOOP_NOTIFICATION_DIR = '/shared/scoop-notifications';
+const SCOOP_NOTIFICATION_PREVIEW_CHARS = 1000;
+
+function countTextLines(text: string): number {
+  if (text.length === 0) return 0;
+  return text.replace(/\r\n/g, '\n').split('\n').length;
+}
 
 export interface OrchestratorCallbacks {
   /** Called when a scoop sends a response */
@@ -364,9 +371,11 @@ export class Orchestrator {
 
   /**
    * Scoop-completion side effect: forward the scoop's buffered response
-   * to the cone as a `scoop-notify` message so the cone's agent can
-   * react. Always clears the response buffer (bounded memory) regardless
-   * of whether a notify was actually sent.
+   * to the cone as a `scoop-notify` message that points at a VFS file
+   * containing the full output, so the cone can decide whether to read
+   * the file or act on the preview alone. Always clears the response
+   * buffer (bounded memory) regardless of whether a notify was actually
+   * sent.
    *
    * Suppressed entirely when `RegisteredScoop.notifyOnComplete === false`.
    * Ephemeral scoops spawned via the `agent` supplemental shell command
@@ -378,7 +387,7 @@ export class Orchestrator {
    * Extracted from the scoop's `onStatusChange` callback so tests can
    * exercise the gate without standing up a full ScoopContext.
    */
-  private maybeNotifyConeOnScoopComplete(jid: string): void {
+  private async maybeNotifyConeOnScoopComplete(jid: string): Promise<void> {
     const scoop = this.scoops.get(jid);
     if (!scoop || scoop.isCone) return;
 
@@ -390,25 +399,33 @@ export class Orchestrator {
     const cone = Array.from(this.scoops.values()).find((s) => s.isCone);
     if (!cone) return;
 
-    const summary =
-      responseText.length > 20000
-        ? responseText.slice(0, 20000) + '\n... (truncated)'
-        : responseText;
-    const notifyMsg: ChannelMessage = {
-      id: `scoop-done-${jid}-${Date.now()}`,
-      chatJid: cone.jid,
-      senderId: scoop.folder,
-      senderName: scoop.assistantLabel,
-      content: `[@${scoop.assistantLabel} completed]:\n${summary}`,
-      timestamp: new Date().toISOString(),
-      fromAssistant: false,
-      channel: 'scoop-notify',
-    };
-    log.info('Routing scoop completion to cone', {
-      scoop: scoop.folder,
-      responseLength: responseText.length,
-    });
-    this.handleMessage(notifyMsg).catch((err) => {
+    try {
+      const notificationPath = await this.writeScoopCompletionArtifact(scoop, responseText);
+      const lineCount = countTextLines(responseText);
+      const preview = responseText.slice(0, SCOOP_NOTIFICATION_PREVIEW_CHARS);
+      const notifyMsg: ChannelMessage = {
+        id: `scoop-done-${jid}-${Date.now()}`,
+        chatJid: cone.jid,
+        senderId: scoop.folder,
+        senderName: scoop.assistantLabel,
+        content: this.formatScoopCompletionNotification(
+          scoop.assistantLabel,
+          notificationPath,
+          lineCount,
+          preview
+        ),
+        timestamp: new Date().toISOString(),
+        fromAssistant: false,
+        channel: 'scoop-notify',
+      };
+      log.info('Routing scoop completion to cone', {
+        scoop: scoop.folder,
+        responseLength: responseText.length,
+        lineCount,
+        notificationPath,
+      });
+      await this.handleMessage(notifyMsg);
+    } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error('Failed to route scoop completion to cone', {
         scoop: scoop.folder,
@@ -418,7 +435,37 @@ export class Orchestrator {
         cone.jid,
         `Scoop ${scoop.folder} completed but notification failed: ${msg}`
       );
-    });
+    }
+  }
+
+  private async writeScoopCompletionArtifact(
+    scoop: RegisteredScoop,
+    responseText: string
+  ): Promise<string> {
+    if (!this.sharedFs) throw new Error('Shared filesystem not initialized');
+
+    await this.sharedFs.mkdir(SCOOP_NOTIFICATION_DIR, { recursive: true });
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const suffix = Math.random().toString(36).slice(2, 8);
+    const path = `${SCOOP_NOTIFICATION_DIR}/${timestamp}-${scoop.folder}-${suffix}.md`;
+    await this.sharedFs.writeFile(path, responseText);
+    return path;
+  }
+
+  private formatScoopCompletionNotification(
+    assistantLabel: string,
+    notificationPath: string,
+    lineCount: number,
+    preview: string
+  ): string {
+    return [
+      `[@${assistantLabel} completed]`,
+      `VFS path: ${notificationPath}`,
+      `Total lines: ${lineCount}`,
+      `Preview (up to ${SCOOP_NOTIFICATION_PREVIEW_CHARS} chars):`,
+      preview,
+    ].join('\n');
   }
 
   private dispatchScoopEvent<K extends keyof ScoopObserver>(
@@ -774,9 +821,9 @@ export class Orchestrator {
         this.dispatchScoopEvent(jid, 'onStatusChange', status);
 
         // When a non-cone scoop finishes, route its response to the cone
-        // so the cone's agent can react (e.g., move files, report to user).
+        // with a VFS path + preview so the cone can decide how to follow up.
         if (status === 'ready' && !scoop.isCone) {
-          this.maybeNotifyConeOnScoopComplete(jid);
+          void this.maybeNotifyConeOnScoopComplete(jid);
         }
       },
       onToolStart: (toolName, toolInput) => {

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -830,9 +830,9 @@ Use the **delegate_to_scoop** tool to send work to scoops. IMPORTANT:
 - If the user says "do the same" or references earlier work, YOU must expand that into explicit instructions
 - Use **list_scoops** first to see available scoop names
 
-**You will automatically receive a notification when a scoop finishes.** The notification contains their full response.
+**You will automatically receive a notification when a scoop finishes.** The notification includes a VFS path to the full output, the total line count, and the first 1000 characters.
 You do NOT need to schedule polling tasks or check for completion markers — just delegate and wait. You will be
-prompted again with the scoop's results when they are done. Then you can act on those results (move files, etc.).
+prompted again when they are done, and you can decide whether to inspect the saved file before acting on the result.
 `
     : `
 You are a scoop with restricted filesystem access:

--- a/packages/webapp/src/scoops/types.ts
+++ b/packages/webapp/src/scoops/types.ts
@@ -52,8 +52,9 @@ export interface RegisteredScoop {
    * When `false`, suppresses the orchestrator's cone-notify side effect
    * that fires when this scoop reaches the terminal `ready` status after
    * processing a prompt. Default (`undefined` / `true`) preserves the
-   * historical behavior: the cone receives a `scoop-notify` message with
-   * the scoop's last response, triggering a cone turn.
+   * default behavior: the cone receives a `scoop-notify` message with a
+   * VFS path to the scoop's full output, a 1000-character preview, and
+   * the total line count, triggering a cone turn.
    *
    * Set to `false` for ephemeral, self-contained invocations (e.g. scoops
    * spawned through the `agent` shell command) where the caller already

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -153,7 +153,11 @@ describe('Orchestrator Message Routing (DB-level)', () => {
         chatJid: cone.jid,
         senderId: testScoop.folder,
         senderName: testScoop.assistantLabel,
-        content: `[@${testScoop.assistantLabel} completed]:\nDownloaded 15 images`,
+        content:
+          `[@${testScoop.assistantLabel} completed]\n` +
+          `VFS path: /shared/scoop-notifications/test-scoop.md\n` +
+          `Total lines: 1\n` +
+          `Preview (up to 1000 chars):\nDownloaded 15 images`,
         fromAssistant: false,
         channel: 'scoop-notify',
       });
@@ -170,7 +174,11 @@ describe('Orchestrator Message Routing (DB-level)', () => {
       const notifyMsg = makeMessage({
         chatJid: cone.jid,
         channel: 'scoop-notify',
-        content: '[@test-scoop completed]: done',
+        content:
+          '[@test-scoop completed]\n' +
+          'VFS path: /shared/scoop-notifications/test-scoop.md\n' +
+          'Total lines: 1\n' +
+          'Preview (up to 1000 chars):\ndone',
       });
       await saveMessage(notifyMsg);
 
@@ -262,7 +270,11 @@ describe('Orchestrator Message Routing (DB-level)', () => {
       // Completion notification contains @test-scoop — must NOT loop back
       const notifyMsg = makeMessage({
         chatJid: cone.jid,
-        content: '[@test-scoop completed]: I finished downloading',
+        content:
+          '[@test-scoop completed]\n' +
+          'VFS path: /shared/scoop-notifications/test-scoop.md\n' +
+          'Total lines: 1\n' +
+          'Preview (up to 1000 chars):\nI finished downloading',
         channel: 'scoop-notify',
       });
       await saveMessage(notifyMsg);
@@ -474,6 +486,7 @@ describe('Orchestrator session-restore compat for path config', () => {
     // BroadcastChannel / IndexedDB handles don't leak across test runs.
     const sharedFs = orch?.getSharedFS();
     await orch?.shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 600));
     await sharedFs?.dispose();
   });
 
@@ -679,6 +692,7 @@ describe('Orchestrator scoop-notify gating (notifyOnComplete)', () => {
   afterEach(async () => {
     const sharedFs = orch?.getSharedFS();
     await orch?.shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 600));
     await sharedFs?.dispose();
   });
 
@@ -709,16 +723,19 @@ describe('Orchestrator scoop-notify gating (notifyOnComplete)', () => {
    * a full `ScoopContext` through an agent loop, which is what the
    * production code path uses to reach this method.
    *
-   * We ALSO stub out `handleMessage` per-test so the fire-and-forget
-   * notify path is fully in-memory and doesn't touch LightningFS —
-   * otherwise afterEach's VFS dispose can race the 500ms LightningFS
-   * deactivation timer and produce "Cannot read properties of null
-   * (reading 'deactivate')" unhandled rejections.
+   * We stub out `handleMessage` per-test so the completion path only
+   * writes the artifact file and never queues a real message save.
    */
   interface OrchestratorPrivate {
     scoopResponseBuffer: Map<string, string>;
-    maybeNotifyConeOnScoopComplete(jid: string): void;
+    maybeNotifyConeOnScoopComplete(jid: string): Promise<void>;
     handleMessage(msg: ChannelMessage): Promise<void>;
+  }
+
+  function extractVfsPath(content: string): string {
+    const match = content.match(/^VFS path: (.+)$/m);
+    expect(match).not.toBeNull();
+    return match![1];
   }
 
   it('writes a scoop-notify to the cone when notifyOnComplete is unset (default)', async () => {
@@ -743,18 +760,21 @@ describe('Orchestrator scoop-notify gating (notifyOnComplete)', () => {
       captured.push(msg);
     };
 
-    priv.scoopResponseBuffer.set(notifyingScoop.jid, 'all done');
-    priv.maybeNotifyConeOnScoopComplete(notifyingScoop.jid);
+    const responseText = 'all done\nwith details';
+    priv.scoopResponseBuffer.set(notifyingScoop.jid, responseText);
+    await priv.maybeNotifyConeOnScoopComplete(notifyingScoop.jid);
 
-    // handleMessage is invoked synchronously inside the method (the
-    // `.catch(...)` chain it wires up is not awaited, but the call itself
-    // runs before the method returns), so the stub sees the payload
-    // immediately.
     expect(captured).toHaveLength(1);
     expect(captured[0].channel).toBe('scoop-notify');
     expect(captured[0].chatJid).toBe(cone.jid);
-    expect(captured[0].content).toContain('all done');
+    expect(captured[0].content).toContain('VFS path: /shared/scoop-notifications/');
+    expect(captured[0].content).toContain('Total lines: 2');
+    expect(captured[0].content).toContain(responseText);
     expect(captured[0].senderId).toBe(notifyingScoop.folder);
+    const sharedFs = o.getSharedFS()!;
+    const artifactPath = extractVfsPath(captured[0].content);
+    const stored = await sharedFs.readFile(artifactPath, { encoding: 'utf-8' });
+    expect(stored).toBe(responseText);
     // Buffer cleared on fire.
     expect(priv.scoopResponseBuffer.has(notifyingScoop.jid)).toBe(false);
   });
@@ -782,7 +802,7 @@ describe('Orchestrator scoop-notify gating (notifyOnComplete)', () => {
     };
 
     priv.scoopResponseBuffer.set(ephemeralScoop.jid, 'final ephemeral output');
-    priv.maybeNotifyConeOnScoopComplete(ephemeralScoop.jid);
+    await priv.maybeNotifyConeOnScoopComplete(ephemeralScoop.jid);
 
     expect(captured).toHaveLength(0);
     // Buffer still cleared so memory stays bounded even when the notify
@@ -812,14 +832,14 @@ describe('Orchestrator scoop-notify gating (notifyOnComplete)', () => {
     };
 
     // No response buffer entry — scoop said nothing.
-    priv.maybeNotifyConeOnScoopComplete(notifyingScoop.jid);
+    await priv.maybeNotifyConeOnScoopComplete(notifyingScoop.jid);
 
     // Even with notifyOnComplete default, empty output => no notify sent.
     expect(captured).toHaveLength(0);
   });
 });
 
-describe('Orchestrator scoop-notify truncation', () => {
+describe('Orchestrator scoop-notify file artifacts', () => {
   let orch: Orchestrator;
   let priorWindow: unknown;
   let windowWasShimmed = false;
@@ -856,6 +876,7 @@ describe('Orchestrator scoop-notify truncation', () => {
   afterEach(async () => {
     const sharedFs = orch?.getSharedFS();
     await orch?.shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 600));
     await sharedFs?.dispose();
   });
 
@@ -872,11 +893,17 @@ describe('Orchestrator scoop-notify truncation', () => {
 
   interface OrchestratorPrivate {
     scoopResponseBuffer: Map<string, string>;
-    maybeNotifyConeOnScoopComplete(jid: string): void;
+    maybeNotifyConeOnScoopComplete(jid: string): Promise<void>;
     handleMessage(msg: ChannelMessage): Promise<void>;
   }
 
-  it('truncates scoop response >20000 chars and appends truncation marker', async () => {
+  function extractVfsPath(content: string): string {
+    const match = content.match(/^VFS path: (.+)$/m);
+    expect(match).not.toBeNull();
+    return match![1];
+  }
+
+  it('writes the full response to VFS and sends only a 1000-char preview to the cone', async () => {
     const scoop: RegisteredScoop = {
       jid: 'scoop_truncate_test_1',
       name: 'truncate-test',
@@ -903,22 +930,27 @@ describe('Orchestrator scoop-notify truncation', () => {
       captured.push(msg);
     };
 
-    // Create a response that exceeds 20000 chars
-    const longResponse = 'x'.repeat(25000);
+    const preview = 'a'.repeat(1000);
+    const hiddenMarker = 'SECOND-LINE-HIDDEN-FROM-PREVIEW';
+    const longResponse = `${preview}\n${hiddenMarker}\nthird line`;
     priv.scoopResponseBuffer.set(scoop.jid, longResponse);
-    priv.maybeNotifyConeOnScoopComplete(scoop.jid);
+    await priv.maybeNotifyConeOnScoopComplete(scoop.jid);
 
     expect(captured).toHaveLength(1);
     expect(captured[0].channel).toBe('scoop-notify');
-    // The content includes the prefix "[@truncate-test-scoop completed]:\n" plus truncated text
-    expect(captured[0].content).toContain('\n... (truncated)');
-    // Verify actual truncation: prefix + 20000 chars + truncation marker
-    const prefix = `[@${scoop.assistantLabel} completed]:\n`;
-    const expectedContent = prefix + longResponse.slice(0, 20000) + '\n... (truncated)';
-    expect(captured[0].content).toBe(expectedContent);
+    expect(captured[0].content).toContain(`[@${scoop.assistantLabel} completed]`);
+    expect(captured[0].content).toContain('VFS path: /shared/scoop-notifications/');
+    expect(captured[0].content).toContain('Total lines: 3');
+    expect(captured[0].content).toContain(preview);
+    expect(captured[0].content).not.toContain(hiddenMarker);
+
+    const sharedFs = orch.getSharedFS()!;
+    const artifactPath = extractVfsPath(captured[0].content);
+    const stored = await sharedFs.readFile(artifactPath, { encoding: 'utf-8' });
+    expect(stored).toBe(longResponse);
   });
 
-  it('does not truncate scoop response <=20000 chars', async () => {
+  it('includes the full short response in the preview metadata', async () => {
     const scoop: RegisteredScoop = {
       jid: 'scoop_no_truncate_test_1',
       name: 'no-truncate-test',
@@ -945,54 +977,20 @@ describe('Orchestrator scoop-notify truncation', () => {
       captured.push(msg);
     };
 
-    // Create a response exactly at the limit
-    const exactLimitResponse = 'y'.repeat(20000);
-    priv.scoopResponseBuffer.set(scoop.jid, exactLimitResponse);
-    priv.maybeNotifyConeOnScoopComplete(scoop.jid);
+    const shortResponse = 'Short completion message\nwith two lines';
+    priv.scoopResponseBuffer.set(scoop.jid, shortResponse);
+    await priv.maybeNotifyConeOnScoopComplete(scoop.jid);
 
     expect(captured).toHaveLength(1);
     expect(captured[0].channel).toBe('scoop-notify');
-    // Should NOT be truncated
-    expect(captured[0].content).not.toContain('(truncated)');
-    const prefix = `[@${scoop.assistantLabel} completed]:\n`;
-    expect(captured[0].content).toBe(prefix + exactLimitResponse);
-  });
+    expect(captured[0].content).toContain(`[@${scoop.assistantLabel} completed]`);
+    expect(captured[0].content).toContain('Total lines: 2');
+    expect(captured[0].content).toContain(shortResponse);
 
-  it('forwards short responses unmodified', async () => {
-    const scoop: RegisteredScoop = {
-      jid: 'scoop_short_test_1',
-      name: 'short-test',
-      folder: 'short-test-scoop',
-      isCone: false,
-      type: 'scoop',
-      requiresTrigger: false,
-      assistantLabel: 'short-test-scoop',
-      addedAt: new Date().toISOString(),
-      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
-    };
-    await saveScoop(scoop);
-
-    const container =
-      typeof document !== 'undefined'
-        ? document.createElement('div')
-        : ({ appendChild: () => {} } as unknown as HTMLElement);
-    orch = new Orchestrator(container, noopCallbacks());
-    await orch.init();
-
-    const priv = orch as unknown as OrchestratorPrivate;
-    const captured: ChannelMessage[] = [];
-    priv.handleMessage = async (msg) => {
-      captured.push(msg);
-    };
-
-    const shortResponse = 'Short completion message';
-    priv.scoopResponseBuffer.set(scoop.jid, shortResponse);
-    priv.maybeNotifyConeOnScoopComplete(scoop.jid);
-
-    expect(captured).toHaveLength(1);
-    expect(captured[0].content).not.toContain('(truncated)');
-    const prefix = `[@${scoop.assistantLabel} completed]:\n`;
-    expect(captured[0].content).toBe(prefix + shortResponse);
+    const sharedFs = orch.getSharedFS()!;
+    const artifactPath = extractVfsPath(captured[0].content);
+    const stored = await sharedFs.readFile(artifactPath, { encoding: 'utf-8' });
+    expect(stored).toBe(shortResponse);
   });
 });
 
@@ -1032,6 +1030,7 @@ describe('Orchestrator observer cleanup on scoop teardown', () => {
   afterEach(async () => {
     const sharedFs = orch?.getSharedFS();
     await orch?.shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 600));
     await sharedFs?.dispose();
   });
 

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -73,6 +73,32 @@ function makeMessage(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
   };
 }
 
+function extractVfsPath(content: string): string {
+  const match = content.match(/^VFS path: (.+)$/m);
+  expect(match).not.toBeNull();
+  return match![1];
+}
+
+async function settleAndDisposeSharedFs(
+  sharedFs: ReturnType<Orchestrator['getSharedFS']>
+): Promise<void> {
+  if (!sharedFs) return;
+
+  const lfs = sharedFs.getLightningFS() as any;
+  if (lfs?._operations?.size > 0) {
+    await lfs._gracefulShutdown?.();
+  }
+  if (lfs?._deactivationTimeout) {
+    clearTimeout(lfs._deactivationTimeout);
+    lfs._deactivationTimeout = null;
+  }
+  if (lfs?._deactivate) {
+    await lfs._deactivate();
+  }
+
+  await sharedFs.dispose();
+}
+
 describe('Orchestrator Message Routing (DB-level)', () => {
   beforeAll(async () => {
     await initDB();
@@ -486,8 +512,7 @@ describe('Orchestrator session-restore compat for path config', () => {
     // BroadcastChannel / IndexedDB handles don't leak across test runs.
     const sharedFs = orch?.getSharedFS();
     await orch?.shutdown();
-    await new Promise((resolve) => setTimeout(resolve, 600));
-    await sharedFs?.dispose();
+    await settleAndDisposeSharedFs(sharedFs);
   });
 
   function noopCallbacks() {
@@ -692,8 +717,7 @@ describe('Orchestrator scoop-notify gating (notifyOnComplete)', () => {
   afterEach(async () => {
     const sharedFs = orch?.getSharedFS();
     await orch?.shutdown();
-    await new Promise((resolve) => setTimeout(resolve, 600));
-    await sharedFs?.dispose();
+    await settleAndDisposeSharedFs(sharedFs);
   });
 
   function noopCallbacks() {
@@ -730,12 +754,6 @@ describe('Orchestrator scoop-notify gating (notifyOnComplete)', () => {
     scoopResponseBuffer: Map<string, string>;
     maybeNotifyConeOnScoopComplete(jid: string): Promise<void>;
     handleMessage(msg: ChannelMessage): Promise<void>;
-  }
-
-  function extractVfsPath(content: string): string {
-    const match = content.match(/^VFS path: (.+)$/m);
-    expect(match).not.toBeNull();
-    return match![1];
   }
 
   it('writes a scoop-notify to the cone when notifyOnComplete is unset (default)', async () => {
@@ -777,6 +795,41 @@ describe('Orchestrator scoop-notify gating (notifyOnComplete)', () => {
     expect(stored).toBe(responseText);
     // Buffer cleared on fire.
     expect(priv.scoopResponseBuffer.has(notifyingScoop.jid)).toBe(false);
+  });
+
+  it('falls back to an inline preview notification when artifact persistence fails', async () => {
+    const notifyingScoop: RegisteredScoop = {
+      jid: 'scoop_notify_fallback_1',
+      name: 'notify-fallback',
+      folder: 'notify-fallback-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'notify-fallback-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    await saveScoop(notifyingScoop);
+    const o = await initOrchestrator();
+    const priv = o as unknown as OrchestratorPrivate & {
+      writeScoopCompletionArtifact(scoop: RegisteredScoop, responseText: string): Promise<string>;
+    };
+
+    const captured: ChannelMessage[] = [];
+    priv.handleMessage = async (msg) => {
+      captured.push(msg);
+    };
+    priv.writeScoopCompletionArtifact = vi.fn().mockRejectedValue(new Error('quota exceeded'));
+
+    const responseText = 'artifact fallback result\nsecond line';
+    priv.scoopResponseBuffer.set(notifyingScoop.jid, responseText);
+    await priv.maybeNotifyConeOnScoopComplete(notifyingScoop.jid);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].content).toContain('VFS path: unavailable');
+    expect(captured[0].content).toContain('Artifact persistence error: quota exceeded');
+    expect(captured[0].content).toContain('Total lines: 2');
+    expect(captured[0].content).toContain(responseText);
   });
 
   it('suppresses the scoop-notify when notifyOnComplete is false', async () => {
@@ -876,8 +929,7 @@ describe('Orchestrator scoop-notify file artifacts', () => {
   afterEach(async () => {
     const sharedFs = orch?.getSharedFS();
     await orch?.shutdown();
-    await new Promise((resolve) => setTimeout(resolve, 600));
-    await sharedFs?.dispose();
+    await settleAndDisposeSharedFs(sharedFs);
   });
 
   function noopCallbacks() {
@@ -895,12 +947,6 @@ describe('Orchestrator scoop-notify file artifacts', () => {
     scoopResponseBuffer: Map<string, string>;
     maybeNotifyConeOnScoopComplete(jid: string): Promise<void>;
     handleMessage(msg: ChannelMessage): Promise<void>;
-  }
-
-  function extractVfsPath(content: string): string {
-    const match = content.match(/^VFS path: (.+)$/m);
-    expect(match).not.toBeNull();
-    return match![1];
   }
 
   it('writes the full response to VFS and sends only a 1000-char preview to the cone', async () => {
@@ -992,6 +1038,81 @@ describe('Orchestrator scoop-notify file artifacts', () => {
     const stored = await sharedFs.readFile(artifactPath, { encoding: 'utf-8' });
     expect(stored).toBe(shortResponse);
   });
+
+  it('counts trailing-newline output as a single line', async () => {
+    const scoop: RegisteredScoop = {
+      jid: 'scoop_trailing_newline_1',
+      name: 'trailing-newline',
+      folder: 'trailing-newline-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'trailing-newline-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    await saveScoop(scoop);
+
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(container, noopCallbacks());
+    await orch.init();
+
+    const priv = orch as unknown as OrchestratorPrivate;
+    const captured: ChannelMessage[] = [];
+    priv.handleMessage = async (msg) => {
+      captured.push(msg);
+    };
+
+    priv.scoopResponseBuffer.set(scoop.jid, 'line one\n');
+    await priv.maybeNotifyConeOnScoopComplete(scoop.jid);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].content).toContain('Total lines: 1');
+  });
+
+  it('prunes old scoop notification artifacts to keep the directory bounded', async () => {
+    const scoop: RegisteredScoop = {
+      jid: 'scoop_prune_test_1',
+      name: 'prune-test',
+      folder: 'prune-test-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'prune-test-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    await saveScoop(scoop);
+
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(container, noopCallbacks());
+    await orch.init();
+
+    const sharedFs = orch.getSharedFS()!;
+    await sharedFs.mkdir('/shared/scoop-notifications', { recursive: true });
+    await sharedFs.writeFile('/shared/scoop-notifications/2026-01-01T00-00-00-000Z-a.md', 'a');
+    await sharedFs.writeFile('/shared/scoop-notifications/2026-01-01T00-00-01-000Z-b.md', 'b');
+    await sharedFs.writeFile('/shared/scoop-notifications/2026-01-01T00-00-02-000Z-c.md', 'c');
+
+    const priv = orch as unknown as OrchestratorPrivate & {
+      pruneScoopCompletionArtifacts(maxArtifacts?: number): Promise<void>;
+    };
+    await priv.pruneScoopCompletionArtifacts(2);
+
+    const entries = await sharedFs.readDir('/shared/scoop-notifications');
+    const names = entries
+      .filter((entry) => entry.type === 'file')
+      .map((entry) => entry.name)
+      .sort();
+
+    expect(names).toEqual(['2026-01-01T00-00-01-000Z-b.md', '2026-01-01T00-00-02-000Z-c.md']);
+  });
 });
 
 describe('Orchestrator observer cleanup on scoop teardown', () => {
@@ -1030,8 +1151,7 @@ describe('Orchestrator observer cleanup on scoop teardown', () => {
   afterEach(async () => {
     const sharedFs = orch?.getSharedFS();
     await orch?.shutdown();
-    await new Promise((resolve) => setTimeout(resolve, 600));
-    await sharedFs?.dispose();
+    await settleAndDisposeSharedFs(sharedFs);
   });
 
   function noopCallbacks() {


### PR DESCRIPTION
## Summary
- write full scoop completion output to `/shared/scoop-notifications/`
- notify the cone with the saved VFS path, a 1000-character preview, and total line count
- update cone-facing prompt/docs and replace truncation tests with file-backed notification coverage

## Testing
- npm run typecheck
- npm run test -- packages/webapp/tests/scoops/orchestrator.test.ts