### PR TITLE
fix: sprinkle sandbox script tag terminated by comment

### DIFF
--- a/packages/chrome-extension/sprinkle-sandbox.html
+++ b/packages/chrome-extension/sprinkle-sandbox.html
@@ -385,7 +385,7 @@ addEventListener('message', function(e) {
       // the full document HTML, then relay messages between parent and child.
       var bridgeScript = buildNestedBridgeScript(msg.savedState, msg.savedStorage, msg.name || '', !!msg.isLight);
       var themeTag = msg.themeCSS ? '<style>' + msg.themeCSS + '</style>' : '';
-      // Escape </script> sequences in inlined bundles to prevent premature tag termination
+      // Escape closing script tags in inlined bundles to prevent premature tag termination
       function escapeForScript(code) { return code.replace(/<\/script/gi, '<\\/script'); }
       var editorTag = msg.editorScript ? '<script>' + escapeForScript(msg.editorScript) + '<\/script>' : '';
       var diffTag = msg.diffScript ? '<script>' + escapeForScript(msg.diffScript) + '<\/script>' : '';


### PR DESCRIPTION
## Summary
- A JS comment in `sprinkle-sandbox.html` contained the literal string `</script>`, which the HTML parser interpreted as the closing tag — causing all subsequent JavaScript to render as visible text in extension-mode full-document sprinkles (e.g. the welcome screen)
- Rewrote the comment to avoid the literal `</script>` sequence

## Test plan
- [ ] Load the extension via `chrome://extensions` → Load unpacked → `dist/extension/`
- [ ] Open the side panel — the welcome sprinkle should render the onboarding wizard, not raw JavaScript source
- [ ] Verify other full-document sprinkles render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)