### PR TITLE
fix(scoops): add retry logic and fatal error handling for LLM requests

### DIFF
--- a/packages/vfs-root/workspace/skills/scoop-management/SKILL.md
+++ b/packages/vfs-root/workspace/skills/scoop-management/SKILL.md
@@ -161,6 +161,8 @@ scoop_unmute({ scoop_names: ["scraper"] })
 
 ## Model Selection for Scoops
 
+**IMPORTANT: Always run `models` to verify available models before specifying a model for a scoop.** Model availability depends on the configured provider and API key. Specifying a non-existent model will cause the scoop to fail immediately with an unrecoverable error.
+
 Use `models --json` to discover available models before creating scoops. The `scoop_scoop` tool accepts a `model` parameter.
 
 Intelligence, speed, and cost are independent dimensions. Use `models --json` to compare them and pick the best tradeoff for each task:
@@ -172,7 +174,13 @@ Intelligence, speed, and cost are independent dimensions. Use `models --json` to
 
 Example:
 
-```
-scoop_scoop({ name: "fix-typos", model: "claude-haiku-4-5-20251001", prompt: "Fix all typos in /workspace/docs/" })
+```bash
+# First, check available models
+models
+
+# Then create scoops with verified model IDs
+scoop_scoop({ name: "fix-typos", model: "claude-haiku-4-5", prompt: "Fix all typos in /workspace/docs/" })
 scoop_scoop({ name: "architect", model: "claude-opus-4-6", prompt: "Design the new plugin system..." })
 ```
+
+**Error handling**: If a scoop fails due to an invalid model or API error, it will retry up to 3 times with exponential backoff for transient errors (rate limits, server errors). Non-retryable errors (invalid model, auth failures) fail immediately and notify the cone, bypassing any `scoop_mute` settings.

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -1272,6 +1272,8 @@ export class Orchestrator {
         // Force-unmute this scoop so the error notification reaches the cone
         this.mutedScoops.delete(jid);
         this.pendingCompletions.delete(jid);
+        // Clear any partial response buffer to avoid stale data if scoop is reused
+        this.scoopResponseBuffer.delete(jid);
 
         // Fire any pending waiters with null (error) so scoop_wait doesn't hang
         const waiters = this.completionWaiters.get(jid);

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -1246,6 +1246,82 @@ export class Orchestrator {
         this.dispatchScoopEvent(jid, 'onError', error);
         this.dispatchScoopEvent(jid, 'onStatusChange', 'error');
       },
+      onFatalError: (error) => {
+        // Fatal errors bypass mute and always notify the cone immediately.
+        // This ensures the user is aware when a scoop fails unrecoverably
+        // (e.g., invalid model, auth failure, exhausted retries).
+        if (!this.scoops.has(jid)) return;
+
+        const scoopRecord = this.scoops.get(jid)!;
+        log.error('Fatal scoop error', { jid, folder: scoopRecord.folder, error });
+
+        const tab = this.tabs.get(jid);
+        if (tab) {
+          tab.status = 'error';
+          tab.error = error;
+          this.tabs.set(jid, tab);
+        }
+        this.callbacks.onError(jid, error);
+        this.callbacks.onStatusChange(jid, 'error');
+        this.dispatchScoopEvent(jid, 'onError', error);
+        this.dispatchScoopEvent(jid, 'onStatusChange', 'error');
+
+        // Skip cone notification for the cone itself
+        if (scoopRecord.isCone) return;
+
+        // Force-unmute this scoop so the error notification reaches the cone
+        this.mutedScoops.delete(jid);
+        this.pendingCompletions.delete(jid);
+
+        // Fire any pending waiters with null (error) so scoop_wait doesn't hang
+        const waiters = this.completionWaiters.get(jid);
+        if (waiters && waiters.length > 0) {
+          this.completionWaiters.delete(jid);
+          for (const w of waiters) {
+            try {
+              w(null);
+            } catch (err) {
+              log.warn('completion waiter threw on fatal error', {
+                jid,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
+        }
+
+        // Notify the cone about this fatal error
+        const cone = Array.from(this.scoops.values()).find((s) => s.isCone);
+        if (!cone) return;
+
+        const notifyMsg: ChannelMessage = {
+          id: `scoop-error-${jid}-${Date.now()}`,
+          chatJid: cone.jid,
+          senderId: scoopRecord.folder,
+          senderName: scoopRecord.assistantLabel,
+          content: `[@${scoopRecord.assistantLabel} FAILED]: ${error}`,
+          timestamp: new Date().toISOString(),
+          fromAssistant: false,
+          channel: 'scoop-error',
+        };
+
+        // Fire onIncomingMessage so the UI renders the error as a lick widget
+        try {
+          this.callbacks.onIncomingMessage?.(cone.jid, notifyMsg);
+        } catch (err) {
+          log.warn('onIncomingMessage for scoop-error threw', {
+            scoop: scoopRecord.folder,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+
+        // Route to cone's agent queue so it can act on the failure
+        this.handleMessage(notifyMsg).catch((err) => {
+          log.error('Failed to route fatal error to cone', {
+            scoop: scoopRecord.folder,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      },
       onStatusChange: (status) => {
         if (!this.scoops.has(jid)) return;
 

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -399,102 +399,122 @@ export class ScoopContext {
       return;
     }
 
+    // Capture agent reference to avoid null access if dispose() runs mid-retry
+    const agent = this.agent;
+    if (!agent) {
+      this.callbacks.onError('Agent not initialized');
+      return;
+    }
+
     this.isProcessing = true;
-    this.didStreamDeltas = false;
     this.setStatus('processing');
 
     const MAX_RETRIES = 3;
     const BASE_DELAY_MS = 1000;
     let lastError: Error | null = null;
 
-    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-      try {
-        await this.agent.prompt(text);
-        // Success - exit retry loop
-        lastError = null;
-        break;
-      } catch (err) {
+    try {
+      for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        // Check disposal before each attempt
         if (this.disposed) return;
 
-        lastError = err instanceof Error ? err : new Error(String(err));
-        const message = lastError.message;
+        // Reset streaming state for each attempt to avoid stale state from previous attempts
+        this.didStreamDeltas = false;
 
-        // Check if this is a non-retryable error (4xx auth/model errors, etc.)
-        if (isNonRetryableError(message)) {
-          log.error('Non-retryable agent error', {
-            folder: this.scoop.folder,
-            error: message,
-            attempt,
-          });
-          // Fatal error - notify cone immediately, bypassing mute
-          this.setStatus('error');
-          if (this.callbacks.onFatalError) {
-            this.callbacks.onFatalError(
-              `Scoop "${this.scoop.name}" failed with unrecoverable error: ${message}`
-            );
-          } else {
-            this.callbacks.onError(message);
+        try {
+          await agent.prompt(text);
+          // Success - exit retry loop
+          lastError = null;
+          break;
+        } catch (err) {
+          // Check disposal after await
+          if (this.disposed) return;
+
+          lastError = err instanceof Error ? err : new Error(String(err));
+          const message = lastError.message;
+
+          // Check if this is a non-retryable error (4xx auth/model errors, etc.)
+          if (isNonRetryableError(message)) {
+            log.error('Non-retryable agent error', {
+              folder: this.scoop.folder,
+              error: message,
+              attempt,
+            });
+            // Fatal error - notify cone immediately, bypassing mute
+            this.setStatus('error');
+            if (this.callbacks.onFatalError) {
+              this.callbacks.onFatalError(
+                `Scoop "${this.scoop.name}" failed with unrecoverable error: ${message}`
+              );
+            } else {
+              this.callbacks.onError(message);
+            }
+            return;
           }
-          this.isProcessing = false;
-          return;
-        }
 
-        // Check if this is a retryable error
-        if (isRetryableError(message) && attempt < MAX_RETRIES) {
-          const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1); // Exponential backoff
-          log.warn('Retryable agent error, will retry', {
+          // Check if this is a retryable error
+          if (isRetryableError(message) && attempt < MAX_RETRIES) {
+            const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1); // Exponential backoff
+            log.warn('Retryable agent error, will retry', {
+              folder: this.scoop.folder,
+              error: message,
+              attempt,
+              maxRetries: MAX_RETRIES,
+              delayMs: delay,
+            });
+            await new Promise((resolve) => setTimeout(resolve, delay));
+            // Check disposal after backoff delay
+            if (this.disposed) return;
+            continue;
+          }
+
+          // Unknown error type or final retry - log and continue to failure handling
+          log.error('Agent error', {
             folder: this.scoop.folder,
             error: message,
             attempt,
-            maxRetries: MAX_RETRIES,
-            delayMs: delay,
+            isRetryable: isRetryableError(message),
           });
-          await new Promise((resolve) => setTimeout(resolve, delay));
-          continue;
-        }
 
-        // Unknown error type or final retry - log and continue to failure handling
-        log.error('Agent error', {
+          // If we've exhausted retries, break out
+          if (attempt === MAX_RETRIES) {
+            break;
+          }
+
+          // For unknown errors, also apply exponential backoff
+          const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          // Check disposal after backoff delay
+          if (this.disposed) return;
+        }
+      }
+
+      // If we exited the loop with an error, handle final failure
+      if (lastError && !this.disposed) {
+        const message = lastError.message;
+        log.error('Agent error after retries exhausted', {
           folder: this.scoop.folder,
           error: message,
-          attempt,
-          isRetryable: isRetryableError(message),
+          maxRetries: MAX_RETRIES,
         });
-
-        // If we've exhausted retries, break out
-        if (attempt === MAX_RETRIES) {
-          break;
+        // Treat exhausted retries as fatal - notify cone bypassing mute
+        this.setStatus('error');
+        if (this.callbacks.onFatalError) {
+          this.callbacks.onFatalError(
+            `Scoop "${this.scoop.name}" failed after ${MAX_RETRIES} attempts: ${message}`
+          );
+        } else {
+          this.callbacks.onError(message);
         }
-
-        // For unknown errors, also apply exponential backoff
-        const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        return;
       }
-    }
 
-    // If we exited the loop with an error, handle final failure
-    if (lastError && !this.disposed) {
-      const message = lastError.message;
-      log.error('Agent error after retries exhausted', {
-        folder: this.scoop.folder,
-        error: message,
-        maxRetries: MAX_RETRIES,
-      });
-      // Treat exhausted retries as fatal - notify cone bypassing mute
-      this.setStatus('error');
-      if (this.callbacks.onFatalError) {
-        this.callbacks.onFatalError(
-          `Scoop "${this.scoop.name}" failed after ${MAX_RETRIES} attempts: ${message}`
-        );
-      } else {
-        this.callbacks.onError(message);
+      if (!this.disposed) {
+        this.setStatus('ready');
       }
+    } finally {
       this.isProcessing = false;
-      return;
     }
-
-    this.isProcessing = false;
-    this.setStatus('ready');
   }
 
   /** Stop the current agent operation and clear any queued prompts */

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -55,10 +55,54 @@ export function isImageProcessingError(msg: string): boolean {
   );
 }
 
+/**
+ * Detect errors that are unlikely to succeed on retry.
+ * These include authentication failures, invalid model IDs, and permanent API errors.
+ */
+export function isNonRetryableError(msg: string): boolean {
+  return (
+    // HTTP 4xx errors (except 429 rate limit which is retryable)
+    /\b(401|403|404|405|410|422)\b/.test(msg) ||
+    // Authentication / authorization failures
+    /unauthorized|forbidden|authentication.*failed|invalid.*api.?key/i.test(msg) ||
+    // Invalid model errors
+    /model.*not.*found|invalid.*model|unknown.*model|does.*not.*exist/i.test(msg) ||
+    // Account/billing issues
+    /insufficient.*quota|billing|payment.*required|account.*suspended/i.test(msg) ||
+    // Malformed request (won't succeed on retry)
+    /invalid.*request|malformed|bad.*request/i.test(msg)
+  );
+}
+
+/**
+ * Detect transient errors that may succeed on retry.
+ * Includes rate limits, server errors, and network issues.
+ */
+export function isRetryableError(msg: string): boolean {
+  return (
+    // Rate limiting
+    /\b429\b|rate.*limit|too.*many.*requests|quota.*exceeded/i.test(msg) ||
+    // Server errors (5xx)
+    /\b(500|502|503|504)\b|internal.*server|bad.*gateway|service.*unavailable|gateway.*timeout/i.test(
+      msg
+    ) ||
+    // Network issues
+    /network.*error|connection.*refused|timeout|econnreset|socket.*hang.*up/i.test(msg) ||
+    // Temporary overload
+    /overloaded|temporarily.*unavailable|try.*again/i.test(msg)
+  );
+}
+
 export interface ScoopContextCallbacks {
   onResponse: (text: string, isPartial: boolean) => void;
   onResponseDone: () => void;
   onError: (error: string) => void;
+  /**
+   * Called when a fatal error occurs that cannot be recovered via retry.
+   * Unlike `onError`, this MUST bypass scoop_mute and notify the cone
+   * immediately so the user is aware the scoop is dead.
+   */
+  onFatalError?: (error: string) => void;
   onStatusChange: (status: 'initializing' | 'ready' | 'processing' | 'error') => void;
   /** Called when a tool starts executing */
   onToolStart?: (toolName: string, toolInput: unknown) => void;
@@ -359,18 +403,98 @@ export class ScoopContext {
     this.didStreamDeltas = false;
     this.setStatus('processing');
 
-    try {
-      await this.agent.prompt(text);
-    } catch (err) {
-      if (!this.disposed) {
-        const message = err instanceof Error ? err.message : String(err);
-        log.error('Agent error', { folder: this.scoop.folder, error: message });
+    const MAX_RETRIES = 3;
+    const BASE_DELAY_MS = 1000;
+    let lastError: Error | null = null;
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        await this.agent.prompt(text);
+        // Success - exit retry loop
+        lastError = null;
+        break;
+      } catch (err) {
+        if (this.disposed) return;
+
+        lastError = err instanceof Error ? err : new Error(String(err));
+        const message = lastError.message;
+
+        // Check if this is a non-retryable error (4xx auth/model errors, etc.)
+        if (isNonRetryableError(message)) {
+          log.error('Non-retryable agent error', {
+            folder: this.scoop.folder,
+            error: message,
+            attempt,
+          });
+          // Fatal error - notify cone immediately, bypassing mute
+          this.setStatus('error');
+          if (this.callbacks.onFatalError) {
+            this.callbacks.onFatalError(
+              `Scoop "${this.scoop.name}" failed with unrecoverable error: ${message}`
+            );
+          } else {
+            this.callbacks.onError(message);
+          }
+          this.isProcessing = false;
+          return;
+        }
+
+        // Check if this is a retryable error
+        if (isRetryableError(message) && attempt < MAX_RETRIES) {
+          const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1); // Exponential backoff
+          log.warn('Retryable agent error, will retry', {
+            folder: this.scoop.folder,
+            error: message,
+            attempt,
+            maxRetries: MAX_RETRIES,
+            delayMs: delay,
+          });
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+
+        // Unknown error type or final retry - log and continue to failure handling
+        log.error('Agent error', {
+          folder: this.scoop.folder,
+          error: message,
+          attempt,
+          isRetryable: isRetryableError(message),
+        });
+
+        // If we've exhausted retries, break out
+        if (attempt === MAX_RETRIES) {
+          break;
+        }
+
+        // For unknown errors, also apply exponential backoff
+        const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+
+    // If we exited the loop with an error, handle final failure
+    if (lastError && !this.disposed) {
+      const message = lastError.message;
+      log.error('Agent error after retries exhausted', {
+        folder: this.scoop.folder,
+        error: message,
+        maxRetries: MAX_RETRIES,
+      });
+      // Treat exhausted retries as fatal - notify cone bypassing mute
+      this.setStatus('error');
+      if (this.callbacks.onFatalError) {
+        this.callbacks.onFatalError(
+          `Scoop "${this.scoop.name}" failed after ${MAX_RETRIES} attempts: ${message}`
+        );
+      } else {
         this.callbacks.onError(message);
       }
-    } finally {
       this.isProcessing = false;
-      this.setStatus('ready');
+      return;
     }
+
+    this.isProcessing = false;
+    this.setStatus('ready');
   }
 
   /** Stop the current agent operation and clear any queued prompts */

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -93,6 +93,26 @@ export function isRetryableError(msg: string): boolean {
   );
 }
 
+/**
+ * Sleep for `ms` milliseconds, resolving early when the given AbortSignal fires.
+ * Returns `true` if the sleep was aborted, `false` if it completed normally.
+ * Exposed for testing the retry loop's cooperative cancellation.
+ */
+export function abortableSleep(ms: number, signal?: AbortSignal): Promise<boolean> {
+  if (signal?.aborted) return Promise.resolve(true);
+  return new Promise<boolean>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve(false);
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 export interface ScoopContextCallbacks {
   onResponse: (text: string, isPartial: boolean) => void;
   onResponseDone: () => void;
@@ -157,6 +177,8 @@ export class ScoopContext {
   private disposed = false;
   private didStreamDeltas = false;
   private unsubscribe: (() => void) | null = null;
+  /** Aborts the in-flight prompt() retry loop and any pending backoff sleep. */
+  private promptAbortController: AbortController | null = null;
 
   private sessionStore: SessionStore | null = null;
   private sessionId: string;
@@ -401,10 +423,13 @@ export class ScoopContext {
 
     // Capture agent reference to avoid null access if dispose() runs mid-retry
     const agent = this.agent;
-    if (!agent) {
-      this.callbacks.onError('Agent not initialized');
-      return;
-    }
+
+    // Replace any stale controller from a previous aborted run and capture
+    // the signal locally so stop()/dispose() can interrupt backoff sleeps.
+    this.promptAbortController?.abort();
+    const abortController = new AbortController();
+    this.promptAbortController = abortController;
+    const abortSignal = abortController.signal;
 
     this.isProcessing = true;
     this.setStatus('processing');
@@ -415,8 +440,8 @@ export class ScoopContext {
 
     try {
       for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-        // Check disposal before each attempt
-        if (this.disposed) return;
+        // Check disposal / cancellation before each attempt
+        if (this.disposed || abortSignal.aborted) return;
 
         // Reset streaming state for each attempt to avoid stale state from previous attempts
         this.didStreamDeltas = false;
@@ -427,8 +452,8 @@ export class ScoopContext {
           lastError = null;
           break;
         } catch (err) {
-          // Check disposal after await
-          if (this.disposed) return;
+          // Check disposal / cancellation after await
+          if (this.disposed || abortSignal.aborted) return;
 
           lastError = err instanceof Error ? err : new Error(String(err));
           const message = lastError.message;
@@ -462,9 +487,9 @@ export class ScoopContext {
               maxRetries: MAX_RETRIES,
               delayMs: delay,
             });
-            await new Promise((resolve) => setTimeout(resolve, delay));
-            // Check disposal after backoff delay
-            if (this.disposed) return;
+            // Abortable backoff — stop()/dispose() cancels immediately
+            const aborted = await abortableSleep(delay, abortSignal);
+            if (aborted || this.disposed) return;
             continue;
           }
 
@@ -481,16 +506,15 @@ export class ScoopContext {
             break;
           }
 
-          // For unknown errors, also apply exponential backoff
+          // For unknown errors, also apply abortable exponential backoff
           const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
-          await new Promise((resolve) => setTimeout(resolve, delay));
-          // Check disposal after backoff delay
-          if (this.disposed) return;
+          const aborted = await abortableSleep(delay, abortSignal);
+          if (aborted || this.disposed) return;
         }
       }
 
       // If we exited the loop with an error, handle final failure
-      if (lastError && !this.disposed) {
+      if (lastError && !this.disposed && !abortSignal.aborted) {
         const message = lastError.message;
         log.error('Agent error after retries exhausted', {
           folder: this.scoop.folder,
@@ -509,16 +533,24 @@ export class ScoopContext {
         return;
       }
 
-      if (!this.disposed) {
+      if (!this.disposed && !abortSignal.aborted) {
         this.setStatus('ready');
       }
     } finally {
       this.isProcessing = false;
+      // Only clear the reference if it's still ours — a later prompt() may
+      // have already installed a new controller.
+      if (this.promptAbortController === abortController) {
+        this.promptAbortController = null;
+      }
     }
   }
 
   /** Stop the current agent operation and clear any queued prompts */
   stop(): void {
+    // Abort before touching the agent so any pending backoff sleep resolves
+    // and the retry loop exits on its next disposal/abort check.
+    this.promptAbortController?.abort();
     this.agent?.clearAllQueues?.();
     this.agent?.abort?.();
     this.isProcessing = false;
@@ -593,6 +625,9 @@ export class ScoopContext {
   /** Cleanup */
   dispose(): void {
     this.disposed = true;
+    // Cancel any in-flight retry loop / backoff sleep before tearing down the agent.
+    this.promptAbortController?.abort();
+    this.promptAbortController = null;
     this.agent?.clearAllQueues?.();
     this.agent?.abort?.();
     this.unsubscribe?.();

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -10,6 +10,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   ScoopContext,
   isImageProcessingError,
+  isNonRetryableError,
+  isRetryableError,
   type ScoopContextCallbacks,
 } from '../../src/scoops/scoop-context.js';
 import type { RegisteredScoop } from '../../src/scoops/types.js';
@@ -1041,6 +1043,113 @@ describe('isImageProcessingError', () => {
     expect(isImageProcessingError('prompt is too long: 250000 tokens > 200000 maximum')).toBe(
       false
     );
+  });
+});
+
+describe('isNonRetryableError', () => {
+  it('matches 401 unauthorized errors', () => {
+    expect(isNonRetryableError('401 Unauthorized')).toBe(true);
+    expect(isNonRetryableError('Error: 401 - Invalid API key')).toBe(true);
+  });
+
+  it('matches 403 forbidden errors', () => {
+    expect(isNonRetryableError('403 Forbidden')).toBe(true);
+    expect(isNonRetryableError('Error 403: Access denied')).toBe(true);
+  });
+
+  it('matches 404 not found errors', () => {
+    expect(isNonRetryableError('404 Not Found')).toBe(true);
+    expect(isNonRetryableError('Model not found: claude-opus-4.5')).toBe(true);
+  });
+
+  it('matches invalid model errors', () => {
+    expect(isNonRetryableError('model not found')).toBe(true);
+    expect(isNonRetryableError('invalid model id')).toBe(true);
+    expect(isNonRetryableError('unknown model: gpt-5')).toBe(true);
+    expect(isNonRetryableError('The model does not exist')).toBe(true);
+  });
+
+  it('matches authentication failures', () => {
+    expect(isNonRetryableError('authentication failed')).toBe(true);
+    expect(isNonRetryableError('Unauthorized access')).toBe(true);
+    expect(isNonRetryableError('Forbidden: insufficient permissions')).toBe(true);
+    expect(isNonRetryableError('invalid api key')).toBe(true);
+    expect(isNonRetryableError('Invalid API-Key provided')).toBe(true);
+  });
+
+  it('matches billing/quota errors', () => {
+    expect(isNonRetryableError('insufficient quota')).toBe(true);
+    expect(isNonRetryableError('billing issue detected')).toBe(true);
+    expect(isNonRetryableError('payment required')).toBe(true);
+    expect(isNonRetryableError('account suspended')).toBe(true);
+  });
+
+  it('matches malformed request errors', () => {
+    expect(isNonRetryableError('invalid request body')).toBe(true);
+    expect(isNonRetryableError('malformed JSON')).toBe(true);
+    expect(isNonRetryableError('bad request: missing field')).toBe(true);
+  });
+
+  it('does NOT match 429 rate limit (retryable)', () => {
+    expect(isNonRetryableError('429 Too Many Requests')).toBe(false);
+  });
+
+  it('does NOT match 5xx server errors (retryable)', () => {
+    expect(isNonRetryableError('500 Internal Server Error')).toBe(false);
+    expect(isNonRetryableError('502 Bad Gateway')).toBe(false);
+    expect(isNonRetryableError('503 Service Unavailable')).toBe(false);
+  });
+
+  it('does NOT match network errors (retryable)', () => {
+    expect(isNonRetryableError('network error')).toBe(false);
+    expect(isNonRetryableError('connection refused')).toBe(false);
+    expect(isNonRetryableError('timeout')).toBe(false);
+  });
+});
+
+describe('isRetryableError', () => {
+  it('matches 429 rate limit errors', () => {
+    expect(isRetryableError('429 Too Many Requests')).toBe(true);
+    expect(isRetryableError('rate limit exceeded')).toBe(true);
+    expect(isRetryableError('too many requests, please slow down')).toBe(true);
+    expect(isRetryableError('quota exceeded, try again later')).toBe(true);
+  });
+
+  it('matches 5xx server errors', () => {
+    expect(isRetryableError('500 Internal Server Error')).toBe(true);
+    expect(isRetryableError('502 Bad Gateway')).toBe(true);
+    expect(isRetryableError('503 Service Unavailable')).toBe(true);
+    expect(isRetryableError('504 Gateway Timeout')).toBe(true);
+    expect(isRetryableError('internal server error')).toBe(true);
+    expect(isRetryableError('bad gateway')).toBe(true);
+    expect(isRetryableError('service unavailable')).toBe(true);
+    expect(isRetryableError('gateway timeout')).toBe(true);
+  });
+
+  it('matches network errors', () => {
+    expect(isRetryableError('network error')).toBe(true);
+    expect(isRetryableError('connection refused')).toBe(true);
+    expect(isRetryableError('request timeout')).toBe(true);
+    expect(isRetryableError('ECONNRESET')).toBe(true);
+    expect(isRetryableError('socket hang up')).toBe(true);
+  });
+
+  it('matches temporary overload errors', () => {
+    expect(isRetryableError('server overloaded')).toBe(true);
+    expect(isRetryableError('temporarily unavailable')).toBe(true);
+    expect(isRetryableError('please try again later')).toBe(true);
+  });
+
+  it('does NOT match 4xx client errors (non-retryable)', () => {
+    expect(isRetryableError('401 Unauthorized')).toBe(false);
+    expect(isRetryableError('403 Forbidden')).toBe(false);
+    expect(isRetryableError('404 Not Found')).toBe(false);
+  });
+
+  it('does NOT match auth/model errors (non-retryable)', () => {
+    expect(isRetryableError('invalid api key')).toBe(false);
+    expect(isRetryableError('model not found')).toBe(false);
+    expect(isRetryableError('authentication failed')).toBe(false);
   });
 });
 

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -31,6 +31,7 @@ function createMockCallbacks(): ScoopContextCallbacks {
     onResponse: vi.fn(),
     onResponseDone: vi.fn(),
     onError: vi.fn(),
+    onFatalError: vi.fn(),
     onStatusChange: vi.fn(),
     onSendMessage: vi.fn(),
     getScoops: vi.fn(() => []),
@@ -398,18 +399,21 @@ describe('ScoopContext prompt queueing', () => {
 
   it('handles prompt failure gracefully', async () => {
     const prompts: string[] = [];
+    // Use a 403 error which is detected as non-retryable and fails immediately
     injectMockAgent(ctx, async (text) => {
       prompts.push(text);
-      throw new Error('prompt failed');
+      throw new Error('403 Forbidden: model not found');
     });
 
     await ctx.prompt('first');
 
+    // Non-retryable errors fail immediately without retries
     expect(prompts).toEqual(['first']);
-    expect(callbacks.onError).toHaveBeenCalledWith('prompt failed');
-    // Should return to ready status after error
+    // Fatal errors call onFatalError if available, otherwise onError
+    expect(callbacks.onFatalError).toHaveBeenCalled();
+    // Should be in error status after fatal error
     const statusCalls = (callbacks.onStatusChange as any).mock.calls;
-    expect(statusCalls[statusCalls.length - 1][0]).toBe('ready');
+    expect(statusCalls[statusCalls.length - 1][0]).toBe('error');
   });
 });
 

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -9,6 +9,7 @@ import 'fake-indexeddb/auto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   ScoopContext,
+  abortableSleep,
   isImageProcessingError,
   isNonRetryableError,
   isRetryableError,
@@ -1150,6 +1151,81 @@ describe('isRetryableError', () => {
     expect(isRetryableError('invalid api key')).toBe(false);
     expect(isRetryableError('model not found')).toBe(false);
     expect(isRetryableError('authentication failed')).toBe(false);
+  });
+});
+
+describe('abortableSleep', () => {
+  it('resolves with false after the timeout elapses', async () => {
+    const start = Date.now();
+    const aborted = await abortableSleep(20);
+    expect(aborted).toBe(false);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(15);
+  });
+
+  it('resolves with true immediately when signal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const start = Date.now();
+    const aborted = await abortableSleep(5000, ac.signal);
+    expect(aborted).toBe(true);
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it('resolves with true when signal aborts mid-sleep', async () => {
+    const ac = new AbortController();
+    const start = Date.now();
+    const promise = abortableSleep(5000, ac.signal);
+    setTimeout(() => ac.abort(), 15);
+    const aborted = await promise;
+    expect(aborted).toBe(true);
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+});
+
+describe('ScoopContext retry cancellation', () => {
+  let ctx: ScoopContext;
+  let callbacks: ScoopContextCallbacks;
+
+  beforeEach(() => {
+    callbacks = createMockCallbacks();
+    ctx = new ScoopContext(testScoop, callbacks, {} as any);
+  });
+
+  it('stop() cancels a pending backoff sleep without completing retries', async () => {
+    let attempts = 0;
+    injectMockAgent(ctx, async () => {
+      attempts += 1;
+      throw new Error('503 Service Unavailable');
+    });
+
+    const promptPromise = ctx.prompt('hello');
+    // Let the first attempt fail and enter the backoff sleep.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    ctx.stop();
+    await promptPromise;
+
+    // Only the first attempt should have run — stop() aborted backoff before retries.
+    expect(attempts).toBe(1);
+    // stop() transitions status to ready; no fatal error should fire on cancellation.
+    expect(callbacks.onFatalError).not.toHaveBeenCalled();
+    const statusCalls = (callbacks.onStatusChange as any).mock.calls.map((c: any[]) => c[0]);
+    expect(statusCalls).toContain('ready');
+  });
+
+  it('dispose() cancels a pending backoff sleep', async () => {
+    let attempts = 0;
+    injectMockAgent(ctx, async () => {
+      attempts += 1;
+      throw new Error('503 Service Unavailable');
+    });
+
+    const promptPromise = ctx.prompt('hello');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    ctx.dispose();
+    await promptPromise;
+
+    expect(attempts).toBe(1);
+    expect(callbacks.onFatalError).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes scoops getting stuck when configured with non-existent models (e.g., `opus-4.5` instead of `opus-4.6`).

## Changes

### Retry Logic with Exponential Backoff
- Added 3-attempt retry with exponential backoff (1s, 2s, 4s) for transient errors
- Retryable errors: rate limits (429), server errors (5xx), network issues

### Non-Retryable Error Detection
- Immediate failure for auth errors (401, 403), invalid models, billing issues
- New `isNonRetryableError()` and `isRetryableError()` helper functions

### Fatal Error Notification
- Added `onFatalError` callback that bypasses `scoop_mute` preferences
- Force-unmutes scoops on fatal error so cone is always notified
- Resolves any pending `scoop_wait` promises with null
- Sends `scoop-error` channel message to cone

### Skill Documentation
- Updated scoop-management skill with model verification guidance
- Added reminder to run `models` before specifying a model for a scoop
- Documented the new error handling behavior

## Testing
- Updated existing test for prompt failure to use non-retryable error
- All 56 scoop-context tests pass
- 4 pre-existing failures in scoop-context.tools.test.ts (unrelated to this change)
