### PR TITLE
fix(ui): make a href links clickable in inline sprinkles

### DIFF
--- a/packages/chrome-extension/sprinkle-sandbox.html
+++ b/packages/chrome-extension/sprinkle-sandbox.html
@@ -523,7 +523,7 @@ addEventListener('message', function(e) {
       'sprinkle-stat', 'sprinkle-mkdir', 'sprinkle-rm',
       'sprinkle-storage-set', 'sprinkle-storage-remove', 'sprinkle-storage-clear',
       'sprinkle-fetch-script',
-      'inline-sprinkle-lick', 'inline-sprinkle-height'
+      'inline-sprinkle-lick', 'inline-sprinkle-height', 'inline-sprinkle-open-link'
     ];
     if (bridgeTypes.indexOf(msg.type) !== -1) {
       parent.postMessage(msg, '*');

--- a/packages/webapp/src/ui/inline-sprinkle.ts
+++ b/packages/webapp/src/ui/inline-sprinkle.ts
@@ -33,7 +33,9 @@ const BRIDGE_SCRIPT = `(function() {
     reportHeight();
     new ResizeObserver(reportHeight).observe(document.body);
   });
-  /* Support data-action attributes (Tool UI compat) — auto-lick on click */
+  /* Support data-action attributes (Tool UI compat) — auto-lick on click.
+     Also intercept <a href> clicks and relay to the parent so links open
+     despite the iframe sandbox blocking top-level navigation. */
   document.addEventListener('click', function(e) {
     var el = e.target;
     while (el && el !== document.body) {
@@ -41,6 +43,19 @@ const BRIDGE_SCRIPT = `(function() {
         var actionData = el.dataset.actionData;
         if (actionData) { try { actionData = JSON.parse(actionData); } catch(ex) {} }
         window.slicc.lick({ action: el.dataset.action, data: actionData || null });
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      if (el.tagName === 'A' && el.getAttribute('href')) {
+        var href = el.getAttribute('href');
+        /* Allow in-iframe anchor navigation (#foo). Skip javascript: for safety. */
+        if (href.charAt(0) === '#') return;
+        if (/^javascript:/i.test(href)) { e.preventDefault(); return; }
+        /* Resolve relative URLs against the iframe's base. */
+        var resolved;
+        try { resolved = new URL(href, document.baseURI).href; } catch(ex) { resolved = href; }
+        parent.postMessage({ type: 'inline-sprinkle-open-link', url: resolved }, '*');
         e.preventDefault();
         e.stopPropagation();
         return;
@@ -136,6 +151,8 @@ ${content.includes('<slicc-diff') ? '<script src="/slicc-diff.js"></script>' : '
       onLick(msg.action, msg.data);
     } else if (msg.type === 'inline-sprinkle-height') {
       iframe.style.height = msg.height + 'px';
+    } else if (msg.type === 'inline-sprinkle-open-link') {
+      openInlineSprinkleLink(msg.url);
     }
   };
   window.addEventListener('message', messageHandler);
@@ -147,6 +164,21 @@ ${content.includes('<slicc-diff') ? '<script src="/slicc-diff.js"></script>' : '
       iframe.remove();
     },
   };
+}
+
+/**
+ * Open a link from a sandboxed inline sprinkle in a new tab. Only http(s)
+ * and mailto: URLs are allowed to avoid navigating the host page through
+ * javascript:/data: schemes relayed from the iframe.
+ */
+function openInlineSprinkleLink(url: unknown): void {
+  if (typeof url !== 'string' || !url) return;
+  if (!/^(https?:|mailto:)/i.test(url)) return;
+  try {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  } catch {
+    /* extension window.open may return null — fire and forget */
+  }
 }
 
 /**
@@ -211,6 +243,8 @@ function mountInlineSprinkleExtension(
       onLick(msg.action, msg.data);
     } else if (msg.type === 'inline-sprinkle-height') {
       iframe.style.height = msg.height + 'px';
+    } else if (msg.type === 'inline-sprinkle-open-link') {
+      openInlineSprinkleLink(msg.url);
     }
   };
   window.addEventListener('message', messageHandler);


### PR DESCRIPTION
Inline sprinkle iframes use `sandbox="allow-scripts allow-same-origin"` (CLI) or `sandbox="allow-scripts"` (extension nested iframe), which blocks top-level navigation. As a result, plain `<a href>` clicks inside agent-authored ```shtml blocks did nothing.

## Fix

- **`packages/webapp/src/ui/inline-sprinkle.ts`**: The in-iframe bridge click handler now also walks up to the nearest `<a href>`, `preventDefault()`s the click, resolves the URL against the iframe's base, and posts an `inline-sprinkle-open-link` message to the parent. Internal `#` anchors keep default (in-iframe) behavior; `javascript:` URLs are dropped. The CLI and extension parent handlers open the URL via `window.open(url, '_blank', 'noopener,noreferrer')`, gated to `http(s):`/`mailto:` schemes for safety.
- **`packages/chrome-extension/sprinkle-sandbox.html`**: Added `inline-sprinkle-open-link` to the child→parent relay list so extension-mode clicks reach the side panel.

## Verification

- `npx prettier --write` on touched files
- `npm run typecheck` — green
- Targeted sprinkle tests (17/17 passed): `packages/webapp/tests/ui/inline-sprinkle.test.ts`, `packages/chrome-extension/tests/sprinkle-sandbox.test.ts`
- `npm run build` and `npm run build -w @slicc/chrome-extension` — both green