### PR TITLE
fix(webapp): derive Pyodide CDN URL from installed package version

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -103,6 +103,8 @@ Extension CSP also blocks CDN fetches and dynamic asset loading. ImageMagick WAS
 | **Pyodide**          | Bundled at `dist/extension/pyodide/`. Load path: `chrome.runtime.getURL('pyodide/')` (trailing slash required)                                                                              |
 | **Sandbox HTML**     | Loaded via `chrome.runtime.getURL('sandbox.html')` as iframe src                                                                                                                            |
 
+Standalone browser mode loads Pyodide assets from jsdelivr. Keep `pyodide` pinned to an exact version in `package.json`; `packages/webapp/src/shell/supplemental-commands/shared.ts` derives the CDN URL from the installed `pyodide/package.json` version so Renovate updates the npm loader and browser assets together.
+
 **Build Integration**
 
 File: `packages/chrome-extension/vite.config.ts` `closeBundle` hook must:

--- a/packages/webapp/src/shell/supplemental-commands/shared.ts
+++ b/packages/webapp/src/shell/supplemental-commands/shared.ts
@@ -1,4 +1,5 @@
 import type { PyodideInterface } from 'pyodide';
+import { version as pyodidePackageVersion } from 'pyodide/package.json';
 import { getMimeType } from '../../core/mime-types.js';
 import { normalizePath } from '../../fs/path-utils.js';
 
@@ -20,7 +21,16 @@ export interface SqlJsModule {
 type InitSqlJs = (options?: { locateFile?: (file: string) => string }) => Promise<SqlJsModule>;
 
 const SQLJS_WASM_CDN = 'https://sql.js.org/dist/';
-const PYODIDE_CDN = 'https://cdn.jsdelivr.net/pyodide/v0.27.7/full/';
+
+export function resolvePinnedPackageVersion(packageName: string, versionSpec: unknown): string {
+  if (typeof versionSpec !== 'string' || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(versionSpec)) {
+    throw new Error(`${packageName} must use an exact semver version in package.json`);
+  }
+  return versionSpec;
+}
+
+export const PYODIDE_VERSION = resolvePinnedPackageVersion('pyodide', pyodidePackageVersion);
+export const PYODIDE_CDN = `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`;
 
 export const NODE_VERSION = 'v20.0.0-js-shim';
 

--- a/packages/webapp/tests/shell/supplemental-commands/shared.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/shared.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { version as pyodidePackageVersion } from 'pyodide/package.json';
+import rootPackageJson from '../../../../../package.json';
 import {
   toPreviewUrl,
   isLikelyUrl,
@@ -9,6 +11,9 @@ import {
   isSafeServeEntry,
   resolveServeEntryPath,
   resolveNodePackageBaseUrl,
+  PYODIDE_CDN,
+  PYODIDE_VERSION,
+  resolvePinnedPackageVersion,
 } from '../../../src/shell/supplemental-commands/shared.js';
 
 describe('toPreviewUrl', () => {
@@ -200,5 +205,23 @@ describe('resolveNodePackageBaseUrl', () => {
       resolveNodePackageBaseUrl('pyodide/pyodide.mjs', '../../../../../node_modules/pyodide/')
         .pathname
     ).toContain('/node_modules/pyodide/');
+  });
+});
+
+describe('Pyodide version resolution', () => {
+  it('uses the installed pyodide package version for the browser CDN fallback', () => {
+    expect(PYODIDE_VERSION).toBe(pyodidePackageVersion);
+    expect(PYODIDE_CDN).toBe(`https://cdn.jsdelivr.net/pyodide/v${pyodidePackageVersion}/full/`);
+  });
+
+  it('keeps the root pyodide dependency pinned to the installed package version', () => {
+    const pyodideVersion = rootPackageJson.dependencies.pyodide;
+    expect(pyodideVersion).toBe(pyodidePackageVersion);
+  });
+
+  it('rejects version ranges so CDN assets cannot drift from the npm loader', () => {
+    expect(() => resolvePinnedPackageVersion('pyodide', '^0.29.3')).toThrow(
+      'pyodide must use an exact semver version in package.json'
+    );
   });
 });

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
   "platformAutomerge": true,
   "packageRules": [
     {
+      "matchPackageNames": ["pyodide"],
+      "rangeStrategy": "pin"
+    },
+    {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "non-major dependencies",
       "groupSlug": "non-major"


### PR DESCRIPTION
## Summary
- derive the standalone browser Pyodide CDN URL from the installed `pyodide/package.json` version instead of a hardcoded CDN version
- add regression coverage that the CDN URL matches the installed package and that the root dependency remains pinned
- pin Pyodide Renovate updates and document why the loader/assets must move together

## Cause
Renovate updated the npm `pyodide` dependency to `0.29.3`, but `PYODIDE_CDN` in `shared.ts` still pointed at jsdelivr `v0.27.7`. In standalone browser mode that mixed the npm loader from `0.29.3` with runtime assets from `0.27.7`, triggering Pyodide's version check. Extension mode was less exposed because it loads bundled assets via `chrome.runtime.getURL('pyodide/')`.

## Drift prevention
The runtime now derives the CDN URL from the installed Pyodide package metadata, so dependency updates automatically update the asset URL in the bundle. A test also requires the root `package.json` dependency to equal the installed package version, and Renovate is configured with `rangeStrategy: pin` for Pyodide so future update PRs keep that exact-version relationship.

## Verification
- `npx prettier --write packages/webapp/src/shell/supplemental-commands/shared.ts packages/webapp/tests/shell/supplemental-commands/shared.test.ts docs/pitfalls.md renovate.json`
- `npx vitest run --config vitest.config.ts --project webapp packages/webapp/tests/shell/supplemental-commands/shared.test.ts`
- `npm run typecheck`
- `npm run build -w @slicc/webapp`
- `npm run build -w @slicc/chrome-extension`
- `npm run build` passed before the final import-source refinement; the changed webapp/extension builds were rerun afterward
- `npm run test` still fails in existing `packages/webapp/tests/scoops/scoop-context.tools.test.ts` tests because `mocks.agentCtorCalls[0]` is undefined; this is outside the Pyodide path and reproduced after the final change.