### PR TITLE
fix(webapp): keep leader tray alive across Chrome tab discards

### DIFF
--- a/packages/chrome-extension/src/offscreen.ts
+++ b/packages/chrome-extension/src/offscreen.ts
@@ -339,6 +339,15 @@ async function init(): Promise<void> {
             });
           });
         },
+        onReconnecting: (attempt, lastError) => {
+          log.info('Extension leader tray reconnecting', { attempt, lastError });
+        },
+        onReconnected: (session) => {
+          log.info('Extension leader tray reconnected', { trayId: session.trayId });
+        },
+        onReconnectGaveUp: (lastError, attempts) => {
+          log.warn('Extension leader tray reconnect gave up', { lastError, attempts });
+        },
       });
       void trayLeader.start().catch((error) => {
         log.warn('Leader tray join failed', {

--- a/packages/webapp/src/scoops/tab-persistence-guard.ts
+++ b/packages/webapp/src/scoops/tab-persistence-guard.ts
@@ -153,11 +153,19 @@ export class TabPersistenceGuard {
       manager
         .request(LOCK_NAME, { mode: 'exclusive', signal: controller.signal }, () => {
           return new Promise<void>((resolve) => {
+            // The abort may already have happened between AbortController
+            // construction and the lock manager invoking the callback. In
+            // that case the 'abort' event will not fire again, so we'd
+            // hold the lock forever — short-circuit on signal.aborted.
+            if (controller.signal.aborted) {
+              resolve();
+              return;
+            }
             const onAbort = () => {
               controller.signal.removeEventListener('abort', onAbort);
               resolve();
             };
-            controller.signal.addEventListener('abort', onAbort);
+            controller.signal.addEventListener('abort', onAbort, { once: true });
           });
         })
         .catch((error: unknown) => {

--- a/packages/webapp/src/scoops/tab-persistence-guard.ts
+++ b/packages/webapp/src/scoops/tab-persistence-guard.ts
@@ -1,0 +1,218 @@
+/**
+ * Prevents the host browser tab from being discarded by Chrome's memory
+ * pressure heuristics while followers are attached to a tray leader.
+ *
+ * Chrome considers tabs with active inaudible audio playback, held Web Locks,
+ * and registered `beforeunload` handlers as "important" and rarely discards
+ * them. We combine all three to maximize the chance the leader stays
+ * resident while followers are connected.
+ *
+ * The guard is a no-op in environments where AudioContext / navigator.locks
+ * are unavailable (e.g. node tests, restricted iframes); failures are logged
+ * but never propagated.
+ */
+
+import { createLogger } from '../core/logger.js';
+
+const log = createLogger('tab-persistence-guard');
+
+export interface TabPersistenceGuardOptions {
+  /** Override the AudioContext constructor (testing). */
+  audioContextFactory?: () => AudioContextLike | null;
+  /** Override navigator.locks-style API (testing). */
+  lockManager?: LockManagerLike | null;
+  /** Override window for adding beforeunload listener (testing). */
+  windowRef?: WindowLike | null;
+}
+
+export interface AudioContextLike {
+  state: string;
+  resume(): Promise<void>;
+  close(): Promise<void>;
+  createOscillator(): { connect(node: unknown): void; start(): void; stop(): void };
+  createGain(): { connect(node: unknown): void; gain: { value: number } };
+  readonly destination: unknown;
+}
+
+export interface LockManagerLike {
+  request(
+    name: string,
+    options: { mode?: 'shared' | 'exclusive'; signal?: AbortSignal },
+    callback: () => Promise<unknown>
+  ): Promise<unknown>;
+}
+
+export interface WindowLike {
+  addEventListener(type: 'beforeunload', listener: () => void): void;
+  removeEventListener(type: 'beforeunload', listener: () => void): void;
+}
+
+const LOCK_NAME = 'slicc-tray-leader-active';
+
+export class TabPersistenceGuard {
+  private active = false;
+  private audioCtx: AudioContextLike | null = null;
+  private oscillator: { stop(): void } | null = null;
+  private lockController: AbortController | null = null;
+  private beforeUnloadHandler: (() => void) | null = null;
+
+  constructor(private readonly options: TabPersistenceGuardOptions = {}) {}
+
+  /**
+   * Start holding all the anti-discard signals. Idempotent.
+   */
+  activate(): void {
+    if (this.active) return;
+    this.active = true;
+    this.startSilentAudio();
+    this.acquireWebLock();
+    this.installBeforeUnload();
+    log.info('Tab persistence guard activated');
+  }
+
+  /**
+   * Release all anti-discard signals. Idempotent.
+   */
+  deactivate(): void {
+    if (!this.active) return;
+    this.active = false;
+    this.stopSilentAudio();
+    this.releaseWebLock();
+    this.removeBeforeUnload();
+    log.info('Tab persistence guard deactivated');
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  private startSilentAudio(): void {
+    try {
+      const factory =
+        this.options.audioContextFactory ??
+        (() => {
+          const Ctor =
+            typeof globalThis !== 'undefined'
+              ? ((globalThis as { AudioContext?: { new (): AudioContextLike } }).AudioContext ??
+                (globalThis as { webkitAudioContext?: { new (): AudioContextLike } })
+                  .webkitAudioContext)
+              : undefined;
+          return Ctor ? new Ctor() : null;
+        });
+      const ctx = factory();
+      if (!ctx) {
+        log.warn('AudioContext unavailable — discard prevention via silent audio disabled');
+        return;
+      }
+      // Resume the context (browsers often start it suspended without a gesture).
+      void ctx.resume?.().catch(() => {});
+      const oscillator = ctx.createOscillator();
+      const gain = ctx.createGain();
+      // Silent: gain of 0 keeps the audio graph "active" without emitting sound.
+      gain.gain.value = 0;
+      oscillator.connect(gain);
+      gain.connect(ctx.destination);
+      oscillator.start();
+      this.audioCtx = ctx;
+      this.oscillator = oscillator;
+    } catch (error) {
+      log.warn('Failed to start silent audio guard', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private stopSilentAudio(): void {
+    try {
+      this.oscillator?.stop();
+    } catch {
+      // Already stopped.
+    }
+    this.oscillator = null;
+    if (this.audioCtx) {
+      void this.audioCtx.close?.().catch(() => {});
+      this.audioCtx = null;
+    }
+  }
+
+  private acquireWebLock(): void {
+    try {
+      const manager =
+        this.options.lockManager ??
+        (typeof navigator !== 'undefined' && 'locks' in navigator
+          ? (navigator as unknown as { locks: LockManagerLike }).locks
+          : null);
+      if (!manager) {
+        log.warn('navigator.locks unavailable — discard prevention via Web Lock disabled');
+        return;
+      }
+      const controller = new AbortController();
+      this.lockController = controller;
+      // Hold the lock indefinitely by returning a promise that only resolves
+      // when the abort signal fires.
+      manager
+        .request(LOCK_NAME, { mode: 'exclusive', signal: controller.signal }, () => {
+          return new Promise<void>((resolve) => {
+            const onAbort = () => {
+              controller.signal.removeEventListener('abort', onAbort);
+              resolve();
+            };
+            controller.signal.addEventListener('abort', onAbort);
+          });
+        })
+        .catch((error: unknown) => {
+          // AbortError is expected during deactivate.
+          const name = (error as { name?: string } | null)?.name;
+          if (name !== 'AbortError') {
+            log.warn('Web Lock request rejected', {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        });
+    } catch (error) {
+      log.warn('Failed to acquire Web Lock', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private releaseWebLock(): void {
+    try {
+      this.lockController?.abort();
+    } catch {
+      // Ignore.
+    }
+    this.lockController = null;
+  }
+
+  private installBeforeUnload(): void {
+    try {
+      const win =
+        this.options.windowRef ??
+        (typeof window !== 'undefined' ? (window as unknown as WindowLike) : null);
+      if (!win) return;
+      const handler = () => {
+        // Presence of the listener is the discard-prevention signal; we
+        // intentionally do not show a confirmation prompt.
+      };
+      win.addEventListener('beforeunload', handler);
+      this.beforeUnloadHandler = handler;
+    } catch {
+      // Ignore.
+    }
+  }
+
+  private removeBeforeUnload(): void {
+    try {
+      const win =
+        this.options.windowRef ??
+        (typeof window !== 'undefined' ? (window as unknown as WindowLike) : null);
+      if (win && this.beforeUnloadHandler) {
+        win.removeEventListener('beforeunload', this.beforeUnloadHandler);
+      }
+    } catch {
+      // Ignore.
+    }
+    this.beforeUnloadHandler = null;
+  }
+}

--- a/packages/webapp/src/scoops/tray-leader-sync.ts
+++ b/packages/webapp/src/scoops/tray-leader-sync.ts
@@ -46,6 +46,8 @@ export interface LeaderSyncManagerOptions {
   onFollowerDead?: (bootstrapId: string) => void;
   /** VirtualFS instance for handling remote fs requests targeting the leader. */
   vfs?: VirtualFS;
+  /** Called whenever a follower is added or removed (incl. via dead detection or stop). */
+  onFollowerCountChanged?: (count: number) => void;
 }
 
 /** Derived float type from the runtime string (e.g. 'slicc-standalone' → 'standalone'). */
@@ -172,6 +174,7 @@ export class LeaderSyncManager {
       floatType: deriveFloatType(meta?.runtime),
     });
     log.info('Follower added to sync', { bootstrapId, followerCount: this.followers.size });
+    this.options.onFollowerCountChanged?.(this.followers.size);
 
     // Send initial snapshot
     this.sendSnapshotToFollower(bootstrapId);
@@ -210,6 +213,7 @@ export class LeaderSyncManager {
     }
 
     log.info('Follower removed from sync', { bootstrapId, followerCount: this.followers.size });
+    this.options.onFollowerCountChanged?.(this.followers.size);
   }
 
   /**

--- a/packages/webapp/src/scoops/tray-leader.ts
+++ b/packages/webapp/src/scoops/tray-leader.ts
@@ -7,6 +7,10 @@ const log = createLogger('tray-leader');
 const LEADER_TRAY_STATE_KEY = 'leader-tray-session';
 const LEADER_TRAY_PING_INTERVAL_MS = 30_000;
 const LEADER_TRAY_CONNECT_TIMEOUT_MS = 10_000;
+const LEADER_TRAY_RECONNECT_BASE_DELAY_MS = 1_000;
+const LEADER_TRAY_RECONNECT_MAX_DELAY_MS = 30_000;
+const LEADER_TRAY_RECONNECT_BACKOFF_MULTIPLIER = 2;
+const LEADER_TRAY_RECONNECT_MAX_ATTEMPTS = 20;
 
 interface CreateTrayResponse {
   trayId: string;
@@ -40,9 +44,10 @@ export interface LeaderTraySession {
 }
 
 export interface LeaderTrayRuntimeStatus {
-  state: 'inactive' | 'connecting' | 'leader' | 'error';
+  state: 'inactive' | 'connecting' | 'leader' | 'reconnecting' | 'error';
   session: LeaderTraySession | null;
   error: string | null;
+  reconnectAttempts?: number;
 }
 
 let leaderTrayRuntimeStatus: LeaderTrayRuntimeStatus = {
@@ -80,6 +85,19 @@ export interface LeaderTrayWebSocket {
   close(code?: number, reason?: string): void;
 }
 
+export interface LeaderTrayReconnectOptions {
+  /** Base delay in ms before the first reconnect attempt. Default: 1000. */
+  baseDelayMs?: number;
+  /** Multiplier applied to the delay after each failed attempt. Default: 2. */
+  backoffMultiplier?: number;
+  /** Maximum delay between reconnect attempts in ms. Default: 30000. */
+  maxDelayMs?: number;
+  /** Maximum number of reconnect attempts before giving up. Default: 20. */
+  maxAttempts?: number;
+  /** Sleep implementation for testing. Default: setTimeout-based. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
 export interface LeaderTrayManagerOptions {
   workerBaseUrl: string;
   runtime: string;
@@ -89,6 +107,14 @@ export interface LeaderTrayManagerOptions {
   onControlMessage?: (message: WorkerToLeaderControlMessage) => void;
   pingIntervalMs?: number;
   connectTimeoutMs?: number;
+  /** Reconnect options. If omitted, auto-reconnect is enabled with defaults. Pass `false` to disable. */
+  reconnect?: LeaderTrayReconnectOptions | false;
+  /** Called when the leader WebSocket dies and a reconnect attempt is starting. */
+  onReconnecting?: (attempt: number, lastError: string) => void;
+  /** Called when reconnect succeeds with a (possibly identical) session. */
+  onReconnected?: (session: LeaderTraySession) => void;
+  /** Called when reconnection fails permanently (max attempts exhausted). */
+  onReconnectGaveUp?: (lastError: string, attempts: number) => void;
 }
 
 export class IndexedDbLeaderTraySessionStore implements LeaderTraySessionStore {
@@ -149,9 +175,18 @@ export class LeaderTrayManager {
   private readonly webSocketFactory: (url: string) => LeaderTrayWebSocket;
   private readonly pingIntervalMs: number;
   private readonly connectTimeoutMs: number;
+  private readonly reconnectEnabled: boolean;
+  private readonly reconnectBaseDelayMs: number;
+  private readonly reconnectMaxDelayMs: number;
+  private readonly reconnectBackoffMultiplier: number;
+  private readonly reconnectMaxAttempts: number;
+  private readonly reconnectSleep: (ms: number) => Promise<void>;
   private socket: LeaderTrayWebSocket | null = null;
   private pingTimer: ReturnType<typeof setInterval> | null = null;
   private currentSession: LeaderTraySession | null = null;
+  private stopped = false;
+  private reconnecting = false;
+  private reconnectGeneration = 0;
 
   constructor(private readonly options: LeaderTrayManagerOptions) {
     this.store = options.store ?? new IndexedDbLeaderTraySessionStore();
@@ -159,9 +194,20 @@ export class LeaderTrayManager {
     this.webSocketFactory = options.webSocketFactory ?? ((url) => new WebSocket(url));
     this.pingIntervalMs = options.pingIntervalMs ?? LEADER_TRAY_PING_INTERVAL_MS;
     this.connectTimeoutMs = options.connectTimeoutMs ?? LEADER_TRAY_CONNECT_TIMEOUT_MS;
+    const reconnect = options.reconnect;
+    this.reconnectEnabled = reconnect !== false;
+    const cfg: LeaderTrayReconnectOptions = reconnect === false || !reconnect ? {} : reconnect;
+    this.reconnectBaseDelayMs = cfg.baseDelayMs ?? LEADER_TRAY_RECONNECT_BASE_DELAY_MS;
+    this.reconnectMaxDelayMs = cfg.maxDelayMs ?? LEADER_TRAY_RECONNECT_MAX_DELAY_MS;
+    this.reconnectBackoffMultiplier =
+      cfg.backoffMultiplier ?? LEADER_TRAY_RECONNECT_BACKOFF_MULTIPLIER;
+    this.reconnectMaxAttempts = cfg.maxAttempts ?? LEADER_TRAY_RECONNECT_MAX_ATTEMPTS;
+    this.reconnectSleep =
+      cfg.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   }
 
   async start(): Promise<LeaderTraySession> {
+    this.stopped = false;
     if (this.currentSession && this.socket) {
       setLeaderTrayRuntimeStatus({ state: 'leader', session: this.currentSession, error: null });
       return this.currentSession;
@@ -171,17 +217,7 @@ export class LeaderTrayManager {
     this.currentSession = null;
 
     try {
-      const storedSession = await this.store.load();
-      const reusableSession =
-        storedSession?.workerBaseUrl === this.options.workerBaseUrl ? storedSession : null;
-
-      const session = await this.attachWithRecovery(reusableSession);
-      this.currentSession = session;
-      const socket = await this.openLeaderSocket(session.leaderWebSocketUrl!);
-      this.socket = socket;
-      this.startPingLoop(socket);
-      setLeaderTrayRuntimeStatus({ state: 'leader', session, error: null });
-
+      const session = await this.connectOnce();
       log.info('Leader joined tray', {
         trayId: session.trayId,
         controllerId: session.controllerId,
@@ -199,6 +235,16 @@ export class LeaderTrayManager {
   }
 
   stop(): void {
+    this.stopped = true;
+    this.reconnecting = false;
+    this.reconnectGeneration++;
+    this.tearDownSocket();
+
+    this.currentSession = null;
+    setLeaderTrayRuntimeStatus({ state: 'inactive', session: null, error: null });
+  }
+
+  private tearDownSocket(): void {
     if (this.pingTimer) {
       clearInterval(this.pingTimer);
       this.pingTimer = null;
@@ -212,9 +258,106 @@ export class LeaderTrayManager {
       }
       this.socket = null;
     }
+  }
 
-    this.currentSession = null;
-    setLeaderTrayRuntimeStatus({ state: 'inactive', session: null, error: null });
+  /**
+   * Run a single attach + WebSocket open cycle. On success, sets `socket`,
+   * `currentSession`, and runtime status, and starts the ping loop. The
+   * caller is responsible for surfacing errors.
+   */
+  private async connectOnce(): Promise<LeaderTraySession> {
+    const storedSession = await this.store.load();
+    const reusableSession =
+      storedSession?.workerBaseUrl === this.options.workerBaseUrl ? storedSession : null;
+
+    const session = await this.attachWithRecovery(reusableSession);
+    this.currentSession = session;
+    const socket = await this.openLeaderSocket(session.leaderWebSocketUrl!);
+    this.socket = socket;
+    this.startPingLoop(socket);
+    setLeaderTrayRuntimeStatus({ state: 'leader', session, error: null });
+    return session;
+  }
+
+  /**
+   * Handle an unexpected socket close/error after a successful start.
+   * Tears the existing socket down, then runs a backoff loop to re-attach
+   * and reopen the leader WebSocket. Stays a no-op once `stop()` has been
+   * called or when reconnect is disabled.
+   */
+  private async handleUnexpectedDisconnect(reason: string): Promise<void> {
+    if (this.stopped) return;
+    if (!this.reconnectEnabled) {
+      log.warn('Leader WebSocket dropped and auto-reconnect is disabled', { reason });
+      this.tearDownSocket();
+      this.currentSession = null;
+      setLeaderTrayRuntimeStatus({
+        state: 'error',
+        session: null,
+        error: `Leader WebSocket dropped: ${reason}`,
+      });
+      return;
+    }
+    if (this.reconnecting) return;
+    this.reconnecting = true;
+    const generation = ++this.reconnectGeneration;
+
+    log.warn('Leader WebSocket dropped — starting reconnect loop', { reason });
+    this.tearDownSocket();
+
+    let attempt = 0;
+    let delay = this.reconnectBaseDelayMs;
+    let lastError = reason;
+
+    while (
+      !this.stopped &&
+      generation === this.reconnectGeneration &&
+      attempt < this.reconnectMaxAttempts
+    ) {
+      attempt++;
+      setLeaderTrayRuntimeStatus({
+        state: 'reconnecting',
+        session: this.currentSession,
+        error: null,
+        reconnectAttempts: attempt,
+      });
+      this.options.onReconnecting?.(attempt, lastError);
+
+      log.info('Leader reconnect attempt', { attempt, delay });
+      await this.reconnectSleep(delay);
+      if (this.stopped || generation !== this.reconnectGeneration) break;
+
+      try {
+        const session = await this.connectOnce();
+        if (this.stopped || generation !== this.reconnectGeneration) {
+          this.tearDownSocket();
+          break;
+        }
+        this.reconnecting = false;
+        log.info('Leader reconnect successful', { attempt, trayId: session.trayId });
+        this.options.onReconnected?.(session);
+        return;
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+        log.warn('Leader reconnect attempt failed', { attempt, error: lastError });
+        this.tearDownSocket();
+      }
+
+      delay = Math.min(delay * this.reconnectBackoffMultiplier, this.reconnectMaxDelayMs);
+    }
+
+    if (!this.stopped && generation === this.reconnectGeneration) {
+      this.reconnecting = false;
+      this.currentSession = null;
+      setLeaderTrayRuntimeStatus({
+        state: 'error',
+        session: null,
+        error: `Leader reconnect failed after ${attempt} attempts: ${lastError}`,
+        reconnectAttempts: attempt,
+      });
+      log.warn('Leader reconnect gave up', { attempts: attempt, lastError });
+      this.options.onReconnectGaveUp?.(lastError, attempt);
+    }
   }
 
   async clearSession(): Promise<void> {
@@ -352,18 +495,30 @@ export class LeaderTrayManager {
       clearInterval(this.pingTimer);
     }
 
+    const onSocketDown = (reason: string) => {
+      // Only trigger if this is still our active socket and we haven't been stopped.
+      if (this.stopped || this.socket !== socket) return;
+      this.handleUnexpectedDisconnect(reason).catch((error) => {
+        log.warn('Leader reconnect loop crashed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    };
+
     const sendPing = () => {
       try {
         socket.send(JSON.stringify({ type: 'ping' }));
-      } catch {
-        this.stop();
+      } catch (error) {
+        onSocketDown(
+          `Leader ping send failed: ${error instanceof Error ? error.message : String(error)}`
+        );
       }
     };
 
     sendPing();
     this.pingTimer = setInterval(sendPing, this.pingIntervalMs);
-    socket.addEventListener('close', () => this.stop());
-    socket.addEventListener('error', () => this.stop());
+    socket.addEventListener('close', () => onSocketDown('Leader WebSocket closed'));
+    socket.addEventListener('error', () => onSocketDown('Leader WebSocket errored'));
   }
 
   private async fetchJson<T>(url: string, init: RequestInit): Promise<T> {

--- a/packages/webapp/src/scoops/tray-leader.ts
+++ b/packages/webapp/src/scoops/tray-leader.ts
@@ -250,13 +250,19 @@ export class LeaderTrayManager {
       this.pingTimer = null;
     }
 
-    if (this.socket) {
+    // Clear `this.socket` BEFORE calling close(): some socket implementations
+    // (and our test fakes) emit 'close' synchronously from `close()`, which
+    // would re-enter `handleUnexpectedDisconnect` via the ping-loop close
+    // listener. The listener guards on `this.socket !== socket`, so once we
+    // null out `this.socket` here, the synchronous re-entry is a no-op.
+    const socket = this.socket;
+    this.socket = null;
+    if (socket) {
       try {
-        this.socket.close();
+        socket.close();
       } catch {
         // Ignore teardown failures.
       }
-      this.socket = null;
     }
   }
 

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -61,6 +61,7 @@ import {
 } from '../scoops/tray-webrtc.js';
 import { LeaderSyncManager } from '../scoops/tray-leader-sync.js';
 import { FollowerSyncManager } from '../scoops/tray-follower-sync.js';
+import { TabPersistenceGuard } from '../scoops/tab-persistence-guard.js';
 import {
   getElectronOverlayInitialTab,
   getLickWebSocketUrl,
@@ -2215,6 +2216,7 @@ async function main(): Promise<void> {
       let leaderSync!: LeaderSyncManager;
       let trayPeers!: LeaderTrayPeerManager;
       let leaderTargetRefreshInterval: ReturnType<typeof setInterval>;
+      const tabPersistenceGuard = new TabPersistenceGuard();
 
       const createAndWireLeaderSync = () => {
         leaderSync = new LeaderSyncManager({
@@ -2233,6 +2235,15 @@ async function main(): Promise<void> {
           },
           onFollowerAbort: () => {
             coneAgentHandle.stop();
+          },
+          onFollowerCountChanged: (count) => {
+            // Keep this tab resident in Chrome's memory while followers are attached
+            // — discarded leader tabs drop the join URL and force a hard reload.
+            if (count > 0) {
+              tabPersistenceGuard.activate();
+            } else {
+              tabPersistenceGuard.deactivate();
+            }
           },
         });
         leaderSyncRef = leaderSync;
@@ -2294,6 +2305,23 @@ async function main(): Promise<void> {
             });
           });
         },
+        onReconnecting: (attempt, lastError) => {
+          log.info('Leader tray reconnecting', { attempt, lastError });
+        },
+        onReconnected: (session) => {
+          log.info('Leader tray reconnected', { trayId: session.trayId });
+          const trayUrl = buildTrayLaunchUrl(
+            window.location.href,
+            session.workerBaseUrl,
+            session.trayId
+          );
+          if (trayUrl !== window.location.href) {
+            window.history.replaceState(window.history.state, '', trayUrl);
+          }
+        },
+        onReconnectGaveUp: (lastError, attempts) => {
+          log.warn('Leader tray reconnect gave up', { lastError, attempts });
+        },
       });
       // Wire the tray reset callback for `host reset` command
       setTrayResetter(async () => {
@@ -2339,6 +2367,7 @@ async function main(): Promise<void> {
           leaderSync.stop();
           trayPeers.stop();
           leaderTray.stop();
+          tabPersistenceGuard.deactivate();
         },
         { once: true }
       );

--- a/packages/webapp/tests/scoops/tab-persistence-guard.test.ts
+++ b/packages/webapp/tests/scoops/tab-persistence-guard.test.ts
@@ -159,4 +159,40 @@ describe('TabPersistenceGuard', () => {
     expect(() => guard.deactivate()).not.toThrow();
     expect(guard.isActive()).toBe(false);
   });
+
+  it('releases the Web Lock immediately if the AbortSignal is already aborted when the callback runs', async () => {
+    const { ctx } = createFakeAudioContext();
+
+    // A LockManager that delays calling the callback by one microtask, giving
+    // the test a window to abort the signal before the callback registers
+    // its 'abort' listener. Without the already-aborted short-circuit in
+    // acquireWebLock, the callback's promise would never resolve.
+    const callbackInvoked = vi.fn();
+    let callbackResolved = false;
+    const manager: LockManagerLike = {
+      request: async (_name, options, callback) => {
+        await Promise.resolve();
+        callbackInvoked();
+        await callback();
+        callbackResolved = true;
+      },
+    };
+
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => ctx,
+      lockManager: manager,
+      windowRef: createFakeWindow(),
+    });
+
+    guard.activate();
+    // Immediately deactivate — this aborts the controller before the
+    // delayed manager callback runs.
+    guard.deactivate();
+
+    // Drain microtasks so the manager callback can run.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    expect(callbackInvoked).toHaveBeenCalledTimes(1);
+    expect(callbackResolved).toBe(true);
+  });
 });

--- a/packages/webapp/tests/scoops/tab-persistence-guard.test.ts
+++ b/packages/webapp/tests/scoops/tab-persistence-guard.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  TabPersistenceGuard,
+  type AudioContextLike,
+  type LockManagerLike,
+  type WindowLike,
+} from '../../src/scoops/tab-persistence-guard.js';
+
+function createFakeAudioContext() {
+  const oscillator = { connect: vi.fn(), start: vi.fn(), stop: vi.fn() };
+  const gain = { connect: vi.fn(), gain: { value: 1 } };
+  const ctx: AudioContextLike & { closed: boolean } = {
+    state: 'running',
+    closed: false,
+    resume: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockImplementation(async function (this: typeof ctx) {
+      this.closed = true;
+    }),
+    createOscillator: () => oscillator,
+    createGain: () => gain,
+    destination: {},
+  };
+  return { ctx, oscillator, gain };
+}
+
+function createFakeLockManager() {
+  const requests: Array<{ name: string; signal?: AbortSignal; resolved: boolean }> = [];
+  const manager: LockManagerLike = {
+    request: vi.fn().mockImplementation(async (name, options, callback) => {
+      const entry = { name, signal: options.signal, resolved: false };
+      requests.push(entry);
+      try {
+        await callback();
+      } finally {
+        entry.resolved = true;
+      }
+    }),
+  };
+  return { manager, requests };
+}
+
+function createFakeWindow(): WindowLike & { listeners: Array<() => void> } {
+  const listeners: Array<() => void> = [];
+  return {
+    listeners,
+    addEventListener: (_type, listener) => {
+      listeners.push(listener);
+    },
+    removeEventListener: (_type, listener) => {
+      const idx = listeners.indexOf(listener);
+      if (idx >= 0) listeners.splice(idx, 1);
+    },
+  };
+}
+
+describe('TabPersistenceGuard', () => {
+  it('starts silent audio, holds a Web Lock, and registers beforeunload on activate', () => {
+    const { ctx, oscillator, gain } = createFakeAudioContext();
+    const { manager, requests } = createFakeLockManager();
+    const win = createFakeWindow();
+
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => ctx,
+      lockManager: manager,
+      windowRef: win,
+    });
+
+    guard.activate();
+
+    expect(guard.isActive()).toBe(true);
+    expect(oscillator.start).toHaveBeenCalledTimes(1);
+    expect(gain.gain.value).toBe(0);
+    expect(oscillator.connect).toHaveBeenCalledWith(gain);
+    expect(gain.connect).toHaveBeenCalledWith(ctx.destination);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].name).toBe('slicc-tray-leader-active');
+    expect(win.listeners).toHaveLength(1);
+  });
+
+  it('is idempotent — calling activate twice does not double up resources', () => {
+    const { ctx, oscillator } = createFakeAudioContext();
+    const { manager, requests } = createFakeLockManager();
+    const win = createFakeWindow();
+
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => ctx,
+      lockManager: manager,
+      windowRef: win,
+    });
+
+    guard.activate();
+    guard.activate();
+
+    expect(oscillator.start).toHaveBeenCalledTimes(1);
+    expect(requests).toHaveLength(1);
+    expect(win.listeners).toHaveLength(1);
+  });
+
+  it('releases all resources on deactivate', async () => {
+    const { ctx, oscillator } = createFakeAudioContext();
+    const { manager, requests } = createFakeLockManager();
+    const win = createFakeWindow();
+
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => ctx,
+      lockManager: manager,
+      windowRef: win,
+    });
+
+    guard.activate();
+    guard.deactivate();
+
+    // Allow microtasks to drain (lock release uses an abort signal).
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(guard.isActive()).toBe(false);
+    expect(oscillator.stop).toHaveBeenCalledTimes(1);
+    expect(ctx.close).toHaveBeenCalledTimes(1);
+    expect(win.listeners).toHaveLength(0);
+    expect(requests[0].signal?.aborted).toBe(true);
+  });
+
+  it('logs a warning and continues if AudioContext is unavailable', () => {
+    const { manager } = createFakeLockManager();
+    const win = createFakeWindow();
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => null,
+      lockManager: manager,
+      windowRef: win,
+    });
+
+    expect(() => guard.activate()).not.toThrow();
+    expect(guard.isActive()).toBe(true);
+    expect(win.listeners).toHaveLength(1);
+  });
+
+  it('continues to function if Web Lock manager is unavailable', () => {
+    const { ctx } = createFakeAudioContext();
+    const win = createFakeWindow();
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => ctx,
+      lockManager: null,
+      windowRef: win,
+    });
+
+    expect(() => guard.activate()).not.toThrow();
+    expect(guard.isActive()).toBe(true);
+    expect(win.listeners).toHaveLength(1);
+  });
+
+  it('deactivate() is safe when never activated', () => {
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => null,
+      lockManager: null,
+      windowRef: null,
+    });
+    expect(() => guard.deactivate()).not.toThrow();
+    expect(guard.isActive()).toBe(false);
+  });
+});

--- a/packages/webapp/tests/scoops/tray-leader-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader-sync.test.ts
@@ -94,6 +94,21 @@ describe('LeaderSyncManager', () => {
     }
   });
 
+  it('fires onFollowerCountChanged on add and remove', () => {
+    const onFollowerCountChanged = vi.fn();
+    const { manager } = createManager({ onFollowerCountChanged });
+    const ch1 = new FakeChannel();
+    const ch2 = new FakeChannel();
+
+    manager.addFollower('b1', ch1);
+    manager.addFollower('b2', ch2);
+    expect(onFollowerCountChanged.mock.calls.map((c) => c[0])).toEqual([1, 2]);
+
+    manager.removeFollower('b1');
+    manager.removeFollower('b2');
+    expect(onFollowerCountChanged.mock.calls.map((c) => c[0])).toEqual([1, 2, 1, 0]);
+  });
+
   it('sends a large snapshot as chunks on addFollower', () => {
     // Create messages large enough to exceed the 64KB chunk threshold
     const largeMessages: ChatMessage[] = [];

--- a/packages/webapp/tests/scoops/tray-leader.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader.test.ts
@@ -838,6 +838,81 @@ describe('tray-leader', () => {
       state: 'error',
       error: expect.stringContaining('Leader WebSocket dropped'),
     });
+    // Regression: tearDownSocket calling socket.close() must NOT re-enter
+    // the close handler in an unbounded loop (FakeWebSocket dispatches
+    // 'close' synchronously from close()).
+    expect(sockets[0].closeCalls).toBeLessThanOrEqual(2);
+
+    manager.stop();
+  });
+
+  it('does not re-enter the close handler when teardown synchronously dispatches close', async () => {
+    // Regression test for re-entrant close: when reconnect is disabled and
+    // tearDownSocket() invokes socket.close(), some socket implementations
+    // synchronously fire the close event. The ping-loop close listener must
+    // not re-run handleUnexpectedDisconnect's branch and recurse.
+    const store = new MemorySessionStore();
+    store.value = {
+      workerBaseUrl: 'https://tray.example.com',
+      trayId: 'tray-1',
+      createdAt: '2026-03-11T00:00:00.000Z',
+      controllerId: 'controller-1',
+      controllerUrl: 'https://tray.example.com/controller/token',
+      joinUrl: 'https://tray.example.com/join/token',
+      webhookUrl: 'https://tray.example.com/webhook/token',
+      leaderKey: 'leader-key-1',
+      leaderWebSocketUrl: 'wss://tray.example.com/ws/1',
+      runtime: 'slicc-standalone',
+    };
+
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          trayId: 'tray-1',
+          controllerId: 'controller-1',
+          role: 'leader',
+          leaderKey: 'leader-key-1',
+          websocket: { url: 'wss://tray.example.com/ws/1' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+
+    const sockets: FakeWebSocket[] = [];
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((r) => {
+      resolveReady = r;
+    });
+
+    const manager = new LeaderTrayManager({
+      workerBaseUrl: 'https://tray.example.com',
+      runtime: 'slicc-standalone',
+      store,
+      fetchImpl,
+      webSocketFactory: () => {
+        const s = new FakeWebSocket();
+        sockets.push(s);
+        resolveReady();
+        return s;
+      },
+      pingIntervalMs: 60_000,
+      reconnect: false,
+    });
+
+    const startPromise = manager.start();
+    await ready;
+    sockets[0].dispatch('message', {
+      data: JSON.stringify({ type: 'leader.connected', trayId: 'tray-1' }),
+    });
+    await startPromise;
+
+    // Triggering close should run cleanup exactly once: the manual dispatch
+    // here calls listeners (no extra closeCalls), and tearDownSocket nulls
+    // this.socket BEFORE invoking socket.close() so the synchronous
+    // re-dispatch is filtered by the listener's `this.socket !== socket`
+    // guard (no recursion, no further closeCalls).
+    sockets[0].dispatch('close', {});
+    expect(sockets[0].closeCalls).toBe(1);
 
     manager.stop();
   });

--- a/packages/webapp/tests/scoops/tray-leader.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader.test.ts
@@ -506,4 +506,339 @@ describe('tray-leader', () => {
 
     manager.stop();
   });
+
+  it('auto-reconnects after the leader WebSocket closes unexpectedly', async () => {
+    const store = new MemorySessionStore();
+    const sockets: FakeWebSocket[] = [];
+    const socketReadyPromises: Array<{ promise: Promise<void>; resolve: () => void }> = [];
+    for (let i = 0; i < 2; i++) {
+      let resolve!: () => void;
+      const promise = new Promise<void>((r) => {
+        resolve = r;
+      });
+      socketReadyPromises.push({ promise, resolve });
+    }
+
+    // Pre-seed the store so the manager re-attaches without recreating the tray.
+    store.value = {
+      workerBaseUrl: 'https://tray.example.com',
+      trayId: 'tray-1',
+      createdAt: '2026-03-11T00:00:00.000Z',
+      controllerId: 'controller-1',
+      controllerUrl: 'https://tray.example.com/controller/token',
+      joinUrl: 'https://tray.example.com/join/token',
+      webhookUrl: 'https://tray.example.com/webhook/token',
+      leaderKey: 'leader-key-1',
+      leaderWebSocketUrl: 'wss://tray.example.com/ws/1',
+      runtime: 'slicc-standalone',
+    };
+
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      // Initial attach
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            trayId: 'tray-1',
+            controllerId: 'controller-1',
+            role: 'leader',
+            leaderKey: 'leader-key-1',
+            websocket: { url: 'wss://tray.example.com/ws/1' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      // Reconnect attach
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            trayId: 'tray-1',
+            controllerId: 'controller-1',
+            role: 'leader',
+            leaderKey: 'leader-key-1',
+            websocket: { url: 'wss://tray.example.com/ws/2' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      );
+
+    const onReconnecting = vi.fn();
+    const onReconnected = vi.fn();
+    let socketIndex = 0;
+
+    const manager = new LeaderTrayManager({
+      workerBaseUrl: 'https://tray.example.com',
+      runtime: 'slicc-standalone',
+      store,
+      fetchImpl,
+      webSocketFactory: () => {
+        const s = new FakeWebSocket();
+        sockets.push(s);
+        socketReadyPromises[socketIndex].resolve();
+        socketIndex++;
+        return s;
+      },
+      pingIntervalMs: 60_000,
+      reconnect: { sleep: () => Promise.resolve(), baseDelayMs: 1, maxDelayMs: 1 },
+      onReconnecting,
+      onReconnected,
+    });
+
+    const startPromise = manager.start();
+    await socketReadyPromises[0].promise;
+    sockets[0].dispatch('message', {
+      data: JSON.stringify({ type: 'leader.connected', trayId: 'tray-1' }),
+    });
+    const session1 = await startPromise;
+    expect(session1.trayId).toBe('tray-1');
+
+    // Simulate the leader tab being woken back up: the WebSocket dies.
+    sockets[0].dispatch('close', {});
+
+    // Yield to the microtask queue so the reconnect loop can run.
+    await socketReadyPromises[1].promise;
+    sockets[1].dispatch('message', {
+      data: JSON.stringify({ type: 'leader.connected', trayId: 'tray-1' }),
+    });
+
+    // Wait for the reconnect to complete (callback is invoked at end of connectOnce).
+    await vi.waitFor(() => {
+      expect(onReconnected).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onReconnecting).toHaveBeenCalledWith(1, expect.any(String));
+    expect(getLeaderTrayRuntimeStatus()).toMatchObject({ state: 'leader' });
+    expect(sockets).toHaveLength(2);
+
+    manager.stop();
+  });
+
+  it('gives up reconnect after maxAttempts and surfaces the error', async () => {
+    const store = new MemorySessionStore();
+    store.value = {
+      workerBaseUrl: 'https://tray.example.com',
+      trayId: 'tray-1',
+      createdAt: '2026-03-11T00:00:00.000Z',
+      controllerId: 'controller-1',
+      controllerUrl: 'https://tray.example.com/controller/token',
+      joinUrl: 'https://tray.example.com/join/token',
+      webhookUrl: 'https://tray.example.com/webhook/token',
+      leaderKey: 'leader-key-1',
+      leaderWebSocketUrl: 'wss://tray.example.com/ws/1',
+      runtime: 'slicc-standalone',
+    };
+
+    // First fetch: initial attach. Subsequent fetches: always reject (reconnect attempts fail).
+    let callCount = 0;
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            trayId: 'tray-1',
+            controllerId: 'controller-1',
+            role: 'leader',
+            leaderKey: 'leader-key-1',
+            websocket: { url: 'wss://tray.example.com/ws/1' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      throw new Error('network down');
+    });
+
+    const onReconnectGaveUp = vi.fn();
+    const sockets: FakeWebSocket[] = [];
+    let resolveFirstReady!: () => void;
+    const firstReady = new Promise<void>((r) => {
+      resolveFirstReady = r;
+    });
+
+    const manager = new LeaderTrayManager({
+      workerBaseUrl: 'https://tray.example.com',
+      runtime: 'slicc-standalone',
+      store,
+      fetchImpl,
+      webSocketFactory: () => {
+        const s = new FakeWebSocket();
+        sockets.push(s);
+        if (sockets.length === 1) resolveFirstReady();
+        return s;
+      },
+      pingIntervalMs: 60_000,
+      reconnect: {
+        sleep: () => new Promise<void>((resolve) => setTimeout(resolve, 0)),
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 1,
+      },
+      onReconnectGaveUp,
+    });
+
+    const startPromise = manager.start();
+    await firstReady;
+    sockets[0].dispatch('message', {
+      data: JSON.stringify({ type: 'leader.connected', trayId: 'tray-1' }),
+    });
+    await startPromise;
+
+    sockets[0].dispatch('close', {});
+
+    await vi.waitFor(() => {
+      expect(onReconnectGaveUp).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onReconnectGaveUp).toHaveBeenCalledWith(expect.any(String), 3);
+    expect(getLeaderTrayRuntimeStatus()).toMatchObject({
+      state: 'error',
+      error: expect.stringContaining('Leader reconnect failed after 3 attempts'),
+    });
+
+    manager.stop();
+  });
+
+  it('does not reconnect after stop() is called explicitly', async () => {
+    const store = new MemorySessionStore();
+    store.value = {
+      workerBaseUrl: 'https://tray.example.com',
+      trayId: 'tray-1',
+      createdAt: '2026-03-11T00:00:00.000Z',
+      controllerId: 'controller-1',
+      controllerUrl: 'https://tray.example.com/controller/token',
+      joinUrl: 'https://tray.example.com/join/token',
+      webhookUrl: 'https://tray.example.com/webhook/token',
+      leaderKey: 'leader-key-1',
+      leaderWebSocketUrl: 'wss://tray.example.com/ws/1',
+      runtime: 'slicc-standalone',
+    };
+
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          trayId: 'tray-1',
+          controllerId: 'controller-1',
+          role: 'leader',
+          leaderKey: 'leader-key-1',
+          websocket: { url: 'wss://tray.example.com/ws/1' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+
+    const onReconnecting = vi.fn();
+    const sockets: FakeWebSocket[] = [];
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((r) => {
+      resolveReady = r;
+    });
+
+    const manager = new LeaderTrayManager({
+      workerBaseUrl: 'https://tray.example.com',
+      runtime: 'slicc-standalone',
+      store,
+      fetchImpl,
+      webSocketFactory: () => {
+        const s = new FakeWebSocket();
+        sockets.push(s);
+        if (sockets.length === 1) resolveReady();
+        return s;
+      },
+      pingIntervalMs: 60_000,
+      reconnect: { sleep: () => Promise.resolve(), baseDelayMs: 1, maxDelayMs: 1 },
+      onReconnecting,
+    });
+
+    const startPromise = manager.start();
+    await ready;
+    sockets[0].dispatch('message', {
+      data: JSON.stringify({ type: 'leader.connected', trayId: 'tray-1' }),
+    });
+    await startPromise;
+
+    manager.stop();
+    sockets[0].dispatch('close', {}); // would normally trigger reconnect
+
+    // Wait a tick to give any errant reconnect a chance to fire.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onReconnecting).not.toHaveBeenCalled();
+    expect(sockets).toHaveLength(1);
+    expect(getLeaderTrayRuntimeStatus()).toEqual({
+      state: 'inactive',
+      session: null,
+      error: null,
+    });
+  });
+
+  it('respects reconnect: false to disable auto-reconnect', async () => {
+    const store = new MemorySessionStore();
+    store.value = {
+      workerBaseUrl: 'https://tray.example.com',
+      trayId: 'tray-1',
+      createdAt: '2026-03-11T00:00:00.000Z',
+      controllerId: 'controller-1',
+      controllerUrl: 'https://tray.example.com/controller/token',
+      joinUrl: 'https://tray.example.com/join/token',
+      webhookUrl: 'https://tray.example.com/webhook/token',
+      leaderKey: 'leader-key-1',
+      leaderWebSocketUrl: 'wss://tray.example.com/ws/1',
+      runtime: 'slicc-standalone',
+    };
+
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          trayId: 'tray-1',
+          controllerId: 'controller-1',
+          role: 'leader',
+          leaderKey: 'leader-key-1',
+          websocket: { url: 'wss://tray.example.com/ws/1' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+
+    const sockets: FakeWebSocket[] = [];
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((r) => {
+      resolveReady = r;
+    });
+    const onReconnecting = vi.fn();
+
+    const manager = new LeaderTrayManager({
+      workerBaseUrl: 'https://tray.example.com',
+      runtime: 'slicc-standalone',
+      store,
+      fetchImpl,
+      webSocketFactory: () => {
+        const s = new FakeWebSocket();
+        sockets.push(s);
+        resolveReady();
+        return s;
+      },
+      pingIntervalMs: 60_000,
+      reconnect: false,
+      onReconnecting,
+    });
+
+    const startPromise = manager.start();
+    await ready;
+    sockets[0].dispatch('message', {
+      data: JSON.stringify({ type: 'leader.connected', trayId: 'tray-1' }),
+    });
+    await startPromise;
+
+    sockets[0].dispatch('close', {});
+    await Promise.resolve();
+
+    expect(onReconnecting).not.toHaveBeenCalled();
+    expect(sockets).toHaveLength(1);
+    expect(getLeaderTrayRuntimeStatus()).toMatchObject({
+      state: 'error',
+      error: expect.stringContaining('Leader WebSocket dropped'),
+    });
+
+    manager.stop();
+  });
 });


### PR DESCRIPTION
## Problem

When a Chrome tab hosting a tray leader is discarded under memory pressure (typical for backgrounded tabs), the WebSocket to the cloudflare-worker dies and never recovers. Followers get stuck and the user has to hard-reload the leader to mint a new tray URL.

## Changes

### 1. `LeaderTrayManager` auto-reconnect (`packages/webapp/src/scoops/tray-leader.ts`)
- After a successful start, an unexpected WebSocket close/error now triggers a reconnect loop with exponential backoff (default 1s → 30s, max 20 attempts).
- Reconnect re-attaches with the persisted `leaderKey` so the same `trayId`/`joinUrl` is reused; the existing 403/404/410 recovery path still recreates the tray when stored state is genuinely stale.
- New callbacks: `onReconnecting`, `onReconnected`, `onReconnectGaveUp`. Pass `reconnect: false` to opt out, or override `baseDelayMs`/`maxDelayMs`/`maxAttempts`/`backoffMultiplier`/`sleep`.
- New runtime status state: `reconnecting` (with `reconnectAttempts`).
- `main.ts` updates `window.history` after a successful reconnect (in case the trayId did change).

### 2. Tab discard prevention (`packages/webapp/src/scoops/tab-persistence-guard.ts`)
- New `TabPersistenceGuard` combines three Chrome anti-discard signals: a silent muted-gain `OscillatorNode`, an exclusive `navigator.locks` reservation, and a no-op `beforeunload` listener. Each degrades gracefully if its API is unavailable.
- `LeaderSyncManager` gained an `onFollowerCountChanged` callback so `main.ts` can activate the guard the moment the first follower joins and deactivate it when the last leaves.

### 3. Extension parity (`packages/chrome-extension/src/offscreen.ts`)
- The extension's offscreen leader also wires reconnect callbacks for logging.

## Tests
- 4 new `LeaderTrayManager` reconnect tests: success, give-up after `maxAttempts`, post-`stop()` no-op, and `reconnect: false` opt-out.
- 6 new `TabPersistenceGuard` tests covering activation, idempotency, deactivation, and degraded environments.
- 1 new `LeaderSyncManager` test for `onFollowerCountChanged`.

## Verification
- `npm run typecheck` ✓
- `npx prettier --check` ✓
- `npx eslint` 0 errors (only pre-existing warnings)
- `npm run build` ✓
- `npm run build -w @slicc/chrome-extension` ✓
- 127 tray-related Vitest tests pass; the 4 unrelated `scoop-context.tools.test.ts` failures pre-exist on `main`.