### PR TITLE
fix(server): load Keychain secrets before launching the browser

### DIFF
--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -90,44 +90,24 @@ struct ServerCommand: AsyncParsableCommand {
         var browserLabel = config.electron ? "Electron" : "Chrome"
         var overlayInjector: ElectronOverlayInjector?
 
-        // Load secrets from the Keychain BEFORE the browser launches.
-        //
-        // Without this hoist, `SecretInjector.loadSecrets()` ran several
-        // hundred milliseconds after Chrome / Electron took window focus,
-        // and every macOS Keychain access prompt for an `ai.sliccy.slicc`
-        // entry appeared *behind* the browser window — one dialog per
-        // secret, all stacked under whichever Chrome tab the user happened
-        // to have on top. Pulling the load forward keeps the prompts in
-        // front of the terminal / Finder window the user already has
-        // focus on, so they can answer them before the browser opens.
-        //
-        // (Note: macOS Keychain Services does not expose a way to coalesce
-        // ACL prompts for N items into one — `kSecMatchItemList` requires
-        // `kSecMatchLimitOne`, and `kSecReturnAttributes` + `kSecReturnData`
-        // + `kSecMatchLimitAll` together returns `errSecParam`. The number
-        // of dialogs is therefore set by the per-item ACL: items added with
-        // `security add-generic-password -A` show no prompt at all; items
-        // added without `-A` prompt once per item until the user clicks
-        // "Always Allow". See skills/google-workspace/SKILL.md.)
-        let envFileSecrets: [Secret] = config.envFileURL.flatMap { Self.parseEnvFileSecrets(at: $0) } ?? []
-        let secretInjector = SecretInjector(sessionId: UUID().uuidString, envFileSecrets: envFileSecrets)
-
+        // Resolve and validate the browser launch plan up-front so any
+        // ValidationError or URL-resolution failure surfaces *before* we
+        // touch the Keychain. Otherwise a misconfigured invocation
+        // (e.g. `--electron` without `--electron-app`) would still pop
+        // Keychain prompts on the way to throwing.
+        enum BrowserLaunchPlan {
+            case electron(appPath: String)
+            case chrome(executable: String?, launchURL: String, userDataDir: String)
+            case serveOnly
+        }
+        let launchPlan: BrowserLaunchPlan
         if config.electron, !config.serveOnly {
             guard let electronApp = config.electronApp else {
                 throw ValidationError(
                     "Electron mode requires an app path. Pass --electron <path> or --electron-app=<path>."
                 )
             }
-
-            let electronLauncher = ElectronLauncher(logger: Logger(label: "slicc.browser.electron-launcher"))
-            let launchedElectron = try await electronLauncher.launch(
-                appPath: electronApp,
-                cdpPort: cdpPort,
-                kill: config.kill
-            )
-            browserProcess = launchedElectron.process
-            browserLabel = launchedElectron.displayName
-            cdpPort = launchedElectron.cdpPort
+            launchPlan = .electron(appPath: electronApp)
         } else if !config.serveOnly {
             let chromeLauncher = ChromeLauncher(logger: Logger(label: "slicc.chrome-launcher"))
             let chromeExecutable = chromeLauncher.findChromeExecutable()
@@ -140,7 +120,53 @@ struct ServerCommand: AsyncParsableCommand {
                 tmpDir: environment["TMPDIR"],
                 servePort: servePort
             )
+            launchPlan = .chrome(
+                executable: chromeExecutable,
+                launchURL: launchURL,
+                userDataDir: userDataDir
+            )
+        } else {
+            launchPlan = .serveOnly
+        }
 
+        // Load secrets from the Keychain BEFORE the browser launches.
+        //
+        // Without this hoist, `SecretInjector.loadSecrets()` ran several
+        // hundred milliseconds after Chrome / Electron took window focus,
+        // and every macOS Keychain access prompt for an `ai.sliccy.slicc`
+        // entry appeared *behind* the browser window — one dialog per
+        // secret, all stacked under whichever Chrome tab the user happened
+        // to have on top. Pulling the load forward keeps the prompts in
+        // front of the terminal / Finder window the user already has
+        // focus on, so they can answer them before the browser opens.
+        //
+        // The CLI/launch-config validation above runs first so we don't
+        // pop Keychain prompts only to bail out with a `ValidationError`.
+        //
+        // (Note: macOS Keychain Services does not expose a way to coalesce
+        // ACL prompts for N items into one — `kSecMatchItemList` requires
+        // `kSecMatchLimitOne`, and `kSecReturnAttributes` + `kSecReturnData`
+        // + `kSecMatchLimitAll` together returns `errSecParam`. The number
+        // of dialogs is therefore set by the per-item ACL: items added with
+        // `security add-generic-password -A` show no prompt at all; items
+        // added without `-A` prompt once per item until the user clicks
+        // "Always Allow". See skills/google-workspace/SKILL.md.)
+        let envFileSecrets: [Secret] = config.envFileURL.flatMap { Self.parseEnvFileSecrets(at: $0) } ?? []
+        let secretInjector = SecretInjector(sessionId: UUID().uuidString, envFileSecrets: envFileSecrets)
+
+        switch launchPlan {
+        case .electron(let electronApp):
+            let electronLauncher = ElectronLauncher(logger: Logger(label: "slicc.browser.electron-launcher"))
+            let launchedElectron = try await electronLauncher.launch(
+                appPath: electronApp,
+                cdpPort: cdpPort,
+                kill: config.kill
+            )
+            browserProcess = launchedElectron.process
+            browserLabel = launchedElectron.displayName
+            cdpPort = launchedElectron.cdpPort
+        case .chrome(let chromeExecutable, let launchURL, let userDataDir):
+            let chromeLauncher = ChromeLauncher(logger: Logger(label: "slicc.chrome-launcher"))
             let launchedChrome = try await chromeLauncher.launch(
                 config: ChromeLaunchConfig(
                     projectRoot: repositoryRoot.path,
@@ -154,6 +180,8 @@ struct ServerCommand: AsyncParsableCommand {
             browserProcess = launchedChrome.process
             browserLabel = "Chrome"
             cdpPort = launchedChrome.cdpPort
+        case .serveOnly:
+            break
         }
 
         let lickSystem = LickSystem()

--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -90,6 +90,28 @@ struct ServerCommand: AsyncParsableCommand {
         var browserLabel = config.electron ? "Electron" : "Chrome"
         var overlayInjector: ElectronOverlayInjector?
 
+        // Load secrets from the Keychain BEFORE the browser launches.
+        //
+        // Without this hoist, `SecretInjector.loadSecrets()` ran several
+        // hundred milliseconds after Chrome / Electron took window focus,
+        // and every macOS Keychain access prompt for an `ai.sliccy.slicc`
+        // entry appeared *behind* the browser window — one dialog per
+        // secret, all stacked under whichever Chrome tab the user happened
+        // to have on top. Pulling the load forward keeps the prompts in
+        // front of the terminal / Finder window the user already has
+        // focus on, so they can answer them before the browser opens.
+        //
+        // (Note: macOS Keychain Services does not expose a way to coalesce
+        // ACL prompts for N items into one — `kSecMatchItemList` requires
+        // `kSecMatchLimitOne`, and `kSecReturnAttributes` + `kSecReturnData`
+        // + `kSecMatchLimitAll` together returns `errSecParam`. The number
+        // of dialogs is therefore set by the per-item ACL: items added with
+        // `security add-generic-password -A` show no prompt at all; items
+        // added without `-A` prompt once per item until the user clicks
+        // "Always Allow". See skills/google-workspace/SKILL.md.)
+        let envFileSecrets: [Secret] = config.envFileURL.flatMap { Self.parseEnvFileSecrets(at: $0) } ?? []
+        let secretInjector = SecretInjector(sessionId: UUID().uuidString, envFileSecrets: envFileSecrets)
+
         if config.electron, !config.serveOnly {
             guard let electronApp = config.electronApp else {
                 throw ValidationError(
@@ -148,8 +170,6 @@ struct ServerCommand: AsyncParsableCommand {
                 logger: Logger(label: "slicc.static-files")
             )
         )
-        let envFileSecrets: [Secret] = config.envFileURL.flatMap { Self.parseEnvFileSecrets(at: $0) } ?? []
-        let secretInjector = SecretInjector(sessionId: UUID().uuidString, envFileSecrets: envFileSecrets)
         registerAPIRoutes(router: router, lickSystem: lickSystem, config: config, httpClient: httpClient, secretInjector: secretInjector)
 
         let wsRouter = Router(context: BasicWebSocketRequestContext.self)


### PR DESCRIPTION
## Problem

When `sliccstart` launches `slicc-server`, the macOS Keychain access prompts for the `ai.sliccy.slicc` entries appear **after** Chrome / Electron has taken window focus. They end up visually stacked behind whichever browser tab the user has on top. Multiple secrets (e.g. four `GWS_*` entries from the Google Workspace skill) produce four sequential dialogs the user has to alt-tab through.

## Fix

Hoist the `SecretInjector(sessionId:envFileSecrets:)` construction before the Chrome / Electron launch block. The keychain reads now happen while the user's terminal / Finder is still in front, so the dialogs are visible immediately and can be dismissed before the browser opens.

## Why not coalesce N prompts into 1?

Investigated; the answer is no — captured in the in-source comment so future readers don't repeat the experiment:

- `kSecReturnAttributes` + `kSecReturnData` + `kSecMatchLimitAll` together returns `errSecParam` (-50). _Tested empirically._
- `kSecMatchItemList` requires `kSecMatchLimitOne` per Apple's docs, so feeding back persistent refs from a first attributes-only query also can't be batched.

The number of prompts is driven by each item's ACL, not the call shape:

- Items added with `security add-generic-password -A` (or by `slicc-server` itself, which trusts its own binary) show **no prompt**.
- Items added with the default ACL prompt **once per item** until the user clicks _Always Allow_.

A follow-up commit on the skills repo will recommend `-A` in the GWS install recipe so the four-prompts-on-first-launch problem disappears outright for new installs.

## Tests

`swift test` — all 124 swift-server tests pass.

🤖 Generated with [Factory](https://factory.ai)