### PR TITLE
feat(secrets): collapse Keychain storage into a single .env blob

### DIFF
--- a/packages/swift-launcher/Sliccstart/Models/Secrets.swift
+++ b/packages/swift-launcher/Sliccstart/Models/Secrets.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Security
+
+/// A SLICC secret managed by the Settings UI. `name` doubles as the stable
+/// identity for SwiftUI lists and selection.
+struct Secret: Equatable, Identifiable, Hashable {
+    var name: String
+    var value: String
+    var domains: [String]
+
+    var id: String { name }
+}
+
+enum SecretsError: LocalizedError {
+    case keychainError(status: Int32)
+    case emptyDomains
+    case emptyName
+    case duplicateName(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .keychainError(let status):
+            return "Keychain error (\(status))"
+        case .emptyDomains:
+            return "At least one hostname pattern is required."
+        case .emptyName:
+            return "Name must not be empty."
+        case .duplicateName(let name):
+            return "A secret named \"\(name)\" already exists."
+        }
+    }
+}
+
+/// Read/write the single Keychain item that holds every SLICC secret.
+///
+/// Service: `ai.sliccy.slicc`
+/// Account: `__envfile__`
+/// Value: `.env`-formatted blob, identical layout to swift-server's
+/// `SecretStore` and node-server's `~/.slicc/secrets.env`.
+enum SecretsKeychain {
+    static let service = "ai.sliccy.slicc"
+    static let account = "__envfile__"
+
+    static func readBlob() -> String {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let text = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return text
+    }
+
+    static func writeBlob(_ content: String) throws {
+        let valueData = Data(content.utf8)
+        let searchQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+
+        let updateStatus = SecItemUpdate(
+            searchQuery as CFDictionary,
+            [kSecValueData as String: valueData] as CFDictionary
+        )
+        if updateStatus == errSecSuccess { return }
+
+        if updateStatus == errSecItemNotFound {
+            var addQuery = searchQuery
+            addQuery[kSecValueData as String] = valueData
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw SecretsError.keychainError(status: addStatus)
+            }
+            return
+        }
+
+        throw SecretsError.keychainError(status: updateStatus)
+    }
+}
+
+/// Parser/serializer for the env-file blob. Mirrors swift-server's
+/// `EnvFileFormat` and node-server's `env-file.ts`.
+enum EnvFileFormat {
+    static let domainsSuffix = "_DOMAINS"
+
+    private struct Entry {
+        let key: String
+        let value: String
+    }
+
+    static func parseSecrets(_ content: String) -> [Secret] {
+        let entries = parseEntries(content)
+        var values: [String: String] = [:]
+        var domains: [String: String] = [:]
+        var order: [String] = []
+
+        for entry in entries {
+            if entry.key.hasSuffix(domainsSuffix) {
+                let name = String(entry.key.dropLast(domainsSuffix.count))
+                if !name.isEmpty {
+                    domains[name] = entry.value
+                }
+            } else {
+                if values[entry.key] == nil { order.append(entry.key) }
+                values[entry.key] = entry.value
+            }
+        }
+
+        var secrets: [Secret] = []
+        for name in order {
+            guard let value = values[name],
+                  let domainsLine = domains[name] else { continue }
+            let parsed = parseDomains(domainsLine)
+            guard !parsed.isEmpty else { continue }
+            secrets.append(Secret(name: name, value: value, domains: parsed))
+        }
+        return secrets
+    }
+
+    static func serialize(_ secrets: [Secret]) -> String {
+        var lines: [String] = []
+        for secret in secrets {
+            lines.append("\(secret.name)=\(serializeValue(secret.value))")
+            lines.append("\(secret.name)\(domainsSuffix)=\(serializeValue(secret.domains.joined(separator: ",")))")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    static func parseDomains(_ raw: String) -> [String] {
+        raw.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func parseEntries(_ content: String) -> [Entry] {
+        var entries: [Entry] = []
+        for raw in content.components(separatedBy: "\n") {
+            let line = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            guard let eq = line.firstIndex(of: "=") else { continue }
+            let key = line[line.startIndex..<eq].trimmingCharacters(in: .whitespacesAndNewlines)
+            var value = line[line.index(after: eq)...].trimmingCharacters(in: .whitespacesAndNewlines)
+            if value.hasPrefix("\"") && value.hasSuffix("\"") && value.count >= 2 {
+                value = String(value.dropFirst().dropLast())
+                    .replacingOccurrences(of: "\\\"", with: "\"")
+            } else if value.hasPrefix("'") && value.hasSuffix("'") && value.count >= 2 {
+                value = String(value.dropFirst().dropLast())
+            }
+            if !key.isEmpty {
+                entries.append(Entry(key: key, value: value))
+            }
+        }
+        return entries
+    }
+
+    private static func serializeValue(_ value: String) -> String {
+        let needsQuoting = value.contains { ch in
+            ch.isWhitespace || ch == "#" || ch == "\"" || ch == "'"
+        }
+        if !needsQuoting { return value }
+        let escaped = value.replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+}

--- a/packages/swift-launcher/Sliccstart/Models/Secrets.swift
+++ b/packages/swift-launcher/Sliccstart/Models/Secrets.swift
@@ -41,7 +41,15 @@ enum SecretsKeychain {
     static let service = "ai.sliccy.slicc"
     static let account = "__envfile__"
 
-    static func readBlob() -> String {
+    /// Read the env-file blob from Keychain.
+    ///
+    /// Returns `""` only when the item legitimately doesn't exist
+    /// (`errSecItemNotFound`). Any other failure — auth cancelled, decode
+    /// error, etc. — is reported as `SecretsError.keychainError`. The
+    /// Settings UI uses this to keep its overlay in place after a denied
+    /// prompt instead of presenting an empty list that could later overwrite
+    /// real secrets.
+    static func readBlob() throws -> String {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -51,10 +59,15 @@ enum SecretsKeychain {
         ]
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess,
-              let data = result as? Data,
-              let text = String(data: data, encoding: .utf8) else {
+        if status == errSecItemNotFound {
             return ""
+        }
+        guard status == errSecSuccess else {
+            throw SecretsError.keychainError(status: status)
+        }
+        guard let data = result as? Data,
+              let text = String(data: data, encoding: .utf8) else {
+            throw SecretsError.keychainError(status: errSecDecode)
         }
         return text
     }
@@ -139,6 +152,36 @@ enum EnvFileFormat {
         raw.split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
+    }
+
+    /// Whether `pattern` is a syntactically valid hostname pattern accepted
+    /// by the fetch-proxy domain matcher. Allowed shapes:
+    ///   `*`                — match any host
+    ///   `*.example.com`    — wildcard subdomain
+    ///   `example.com`      — exact host
+    ///
+    /// Each label must be 1+ chars of `[A-Za-z0-9_-]`, may not start or end
+    /// with `-`, and there can be no empty labels (`..` is rejected).
+    static func isValidHostnamePattern(_ pattern: String) -> Bool {
+        let trimmed = pattern.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return false }
+        if trimmed == "*" { return true }
+
+        var rest = trimmed
+        if rest.hasPrefix("*.") {
+            rest = String(rest.dropFirst(2))
+        }
+        if rest.isEmpty { return false }
+
+        for label in rest.split(separator: ".", omittingEmptySubsequences: false) {
+            if label.isEmpty { return false }
+            if label.first == "-" || label.last == "-" { return false }
+            for ch in label {
+                let valid = ch.isLetter || ch.isNumber || ch == "-" || ch == "_"
+                if !valid { return false }
+            }
+        }
+        return true
     }
 
     private static func parseEntries(_ content: String) -> [Entry] {

--- a/packages/swift-launcher/Sliccstart/SliccstartApp.swift
+++ b/packages/swift-launcher/Sliccstart/SliccstartApp.swift
@@ -142,6 +142,10 @@ struct SliccstartApp: App {
                 }
             }
         }
+
+        Settings {
+            SettingsView()
+        }
     }
 
     private func initialize() async {

--- a/packages/swift-launcher/Sliccstart/SliccstartApp.swift
+++ b/packages/swift-launcher/Sliccstart/SliccstartApp.swift
@@ -167,6 +167,26 @@ struct SliccstartApp: App {
         if SliccBootstrapper.isBundled {
             appUpdater.check()
         }
+
+        autoLaunchConfiguredBrowser()
+    }
+
+    /// Launch the browser the user picked in Settings > Startup, if any.
+    /// Stored as the `AppTarget.id` (bundle path) under
+    /// `autoLaunchAppIdKey`. Failures are logged but never block startup.
+    private func autoLaunchConfiguredBrowser() {
+        let savedId = UserDefaults.standard.string(forKey: autoLaunchAppIdKey) ?? ""
+        guard !savedId.isEmpty else { return }
+        guard let target = targets.first(where: { $0.id == savedId && $0.type == .chromiumBrowser }) else {
+            log.info("autoLaunch: no matching browser found for id=\(savedId, privacy: .public)")
+            return
+        }
+        log.info("autoLaunch: launching \(target.name, privacy: .public)")
+        do {
+            try sliccProcess.launchStandalone(target)
+        } catch {
+            log.error("autoLaunch failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     private func createDebugBuild(for target: AppTarget) async {

--- a/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
@@ -3,52 +3,87 @@ import os
 
 private let log = Logger(subsystem: "com.slicc.sliccstart", category: "Settings")
 
+/// UserDefaults key for the auto-launch browser. The value is the
+/// `AppTarget.id` (bundle path) of the browser, or an empty string for
+/// "None". Read at app startup by `SliccstartApp.initialize`.
+let autoLaunchAppIdKey = "autoLaunchAppId"
+
 struct SettingsView: View {
+    var body: some View {
+        TabView {
+            StartupSettingsView()
+                .tabItem { Label("Startup", systemImage: "power") }
+            SecretsSettingsView()
+                .tabItem { Label("Secrets", systemImage: "key.fill") }
+        }
+    }
+}
+
+// MARK: - Startup tab
+
+struct StartupSettingsView: View {
+    @AppStorage(autoLaunchAppIdKey) private var autoLaunchAppId: String = ""
+    @State private var browsers: [AppTarget] = []
+
+    var body: some View {
+        Form {
+            Picker(selection: $autoLaunchAppId) {
+                Text("None").tag("")
+                if !browsers.isEmpty {
+                    Divider()
+                    ForEach(browsers) { browser in
+                        Text(browser.name).tag(browser.id)
+                    }
+                }
+            } label: {
+                Text("Launch on startup:")
+            }
+            .pickerStyle(.menu)
+        }
+        .padding(20)
+        .frame(width: 460)
+        .fixedSize()
+        .onAppear {
+            browsers = AppScanner.scan(hasAppManagementPermission: false)
+                .filter { $0.type == .chromiumBrowser }
+        }
+    }
+}
+
+// MARK: - Secrets tab
+
+struct SecretsSettingsView: View {
     @State private var secrets: [Secret] = []
+    @State private var unlocked = false
     @State private var selection: Secret.ID?
     @State private var editorDraft: SecretDraft?
     @State private var deletionTarget: Secret?
     @State private var errorMessage: String?
 
-    var body: some View {
-        TabView {
-            secretsTab
-                .tabItem { Label("Secrets", systemImage: "key.fill") }
-        }
-        .frame(width: 620, height: 420)
-        .onAppear { reload() }
+    /// Decorative rows shown blurred behind the unlock prompt before the
+    /// user has authorised Keychain access. Real values are never used.
+    private static let placeholders: [Secret] = [
+        Secret(name: "GITHUB_TOKEN", value: "******", domains: ["api.github.com"]),
+        Secret(name: "OPENAI_API_KEY", value: "******", domains: ["api.openai.com"]),
+        Secret(name: "ANTHROPIC_API_KEY", value: "******", domains: ["api.anthropic.com"]),
+        Secret(name: "AWS_SECRET_ACCESS_KEY", value: "******", domains: ["*.amazonaws.com"]),
+        Secret(name: "SLACK_BOT_TOKEN", value: "******", domains: ["slack.com"]),
+        Secret(name: "STRIPE_SECRET_KEY", value: "******", domains: ["api.stripe.com"]),
+    ]
+
+    private var displayedSecrets: [Secret] {
+        unlocked ? secrets : Self.placeholders
     }
 
-    private var secretsTab: some View {
+    var body: some View {
         VStack(spacing: 0) {
-            Table(secrets, selection: $selection) {
-                TableColumn("Name") { secret in
-                    Text(secret.name)
-                        .font(.system(.body, design: .monospaced))
-                }
-                .width(min: 140, ideal: 180)
+            ZStack {
+                table
+                    .blur(radius: unlocked ? 0 : 6)
+                    .allowsHitTesting(unlocked)
 
-                TableColumn("Value") { _ in
-                    Text("••••••••")
-                        .foregroundStyle(.secondary)
-                        .font(.system(.body, design: .monospaced))
-                }
-                .width(min: 80, ideal: 100)
-
-                TableColumn("Hostname patterns") { secret in
-                    Text(secret.domains.joined(separator: ", "))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-            }
-            .contextMenu(forSelectionType: Secret.ID.self) { ids in
-                if let id = ids.first, let secret = secrets.first(where: { $0.id == id }) {
-                    Button("Edit…") { editorDraft = .editing(secret) }
-                    Button("Delete…", role: .destructive) { deletionTarget = secret }
-                }
-            } primaryAction: { ids in
-                if let id = ids.first, let secret = secrets.first(where: { $0.id == id }) {
-                    editorDraft = .editing(secret)
+                if !unlocked {
+                    unlockOverlay
                 }
             }
 
@@ -56,6 +91,7 @@ struct SettingsView: View {
 
             HStack(spacing: 6) {
                 Button {
+                    if !unlocked { unlock() }
                     editorDraft = .creating
                 } label: {
                     Image(systemName: "plus")
@@ -73,7 +109,7 @@ struct SettingsView: View {
                         .frame(width: 22, height: 22)
                 }
                 .buttonStyle(.borderless)
-                .disabled(selection == nil)
+                .disabled(!unlocked || selection == nil)
                 .help("Delete selected secret")
 
                 Spacer()
@@ -83,7 +119,7 @@ struct SettingsView: View {
                         editorDraft = .editing(secret)
                     }
                 }
-                .disabled(selection == nil)
+                .disabled(!unlocked || selection == nil)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
@@ -127,14 +163,80 @@ struct SettingsView: View {
         } message: {
             Text(errorMessage ?? "")
         }
+        .frame(width: 620, height: 420)
     }
 
-    private func reload() {
+    private var table: some View {
+        Table(displayedSecrets, selection: $selection) {
+            TableColumn("Name") { secret in
+                Text(secret.name)
+                    .font(.system(.body, design: .monospaced))
+            }
+            .width(min: 140, ideal: 180)
+
+            TableColumn("Value") { _ in
+                Text("••••••••")
+                    .foregroundStyle(.secondary)
+                    .font(.system(.body, design: .monospaced))
+            }
+            .width(min: 80, ideal: 100)
+
+            TableColumn("Hostname patterns") { secret in
+                Text(secret.domains.joined(separator: ", "))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .contextMenu(forSelectionType: Secret.ID.self) { ids in
+            if let id = ids.first, let secret = secrets.first(where: { $0.id == id }) {
+                Button("Edit…") { editorDraft = .editing(secret) }
+                Button("Delete…", role: .destructive) { deletionTarget = secret }
+            }
+        } primaryAction: { ids in
+            if let id = ids.first, let secret = secrets.first(where: { $0.id == id }) {
+                editorDraft = .editing(secret)
+            }
+        }
+    }
+
+    private var unlockOverlay: some View {
+        Button {
+            unlock()
+        } label: {
+            VStack(spacing: 10) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 28))
+                    .foregroundStyle(.secondary)
+                Text("Stored in macOS Keychain")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Text("Click to show secrets")
+                    .font(.callout.weight(.medium))
+            }
+            .padding(.horizontal, 32)
+            .padding(.vertical, 22)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .strokeBorder(.separator, lineWidth: 0.5)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+
+    private func unlock() {
+        guard !unlocked else { return }
         secrets = EnvFileFormat.parseSecrets(SecretsKeychain.readBlob())
             .sorted(by: { $0.name < $1.name })
+        unlocked = true
     }
 
     private func save(draft: SecretDraft, secret: Secret) {
+        if !unlocked { unlock() }
         var working = secrets
         if case .editing(let original) = draft {
             working.removeAll { $0.name == original.name }
@@ -162,6 +264,8 @@ struct SettingsView: View {
     }
 }
 
+// MARK: - Editor sheet
+
 enum SecretDraft: Identifiable {
     case creating
     case editing(Secret)
@@ -174,6 +278,11 @@ enum SecretDraft: Identifiable {
     }
 }
 
+private struct DomainEntry: Identifiable, Equatable {
+    let id = UUID()
+    var pattern: String
+}
+
 private struct SecretEditorSheet: View {
     let draft: SecretDraft
     let existingNames: Set<String>
@@ -182,7 +291,7 @@ private struct SecretEditorSheet: View {
 
     @State private var name: String
     @State private var value: String
-    @State private var domainsText: String
+    @State private var domainEntries: [DomainEntry]
 
     init(
         draft: SecretDraft,
@@ -198,11 +307,12 @@ private struct SecretEditorSheet: View {
         case .creating:
             _name = State(initialValue: "")
             _value = State(initialValue: "")
-            _domainsText = State(initialValue: "")
+            _domainEntries = State(initialValue: [DomainEntry(pattern: "")])
         case .editing(let secret):
             _name = State(initialValue: secret.name)
             _value = State(initialValue: secret.value)
-            _domainsText = State(initialValue: secret.domains.joined(separator: ", "))
+            let entries = secret.domains.map { DomainEntry(pattern: $0) }
+            _domainEntries = State(initialValue: entries.isEmpty ? [DomainEntry(pattern: "")] : entries)
         }
     }
 
@@ -210,8 +320,10 @@ private struct SecretEditorSheet: View {
         name.trimmingCharacters(in: .whitespaces)
     }
 
-    private var parsedDomains: [String] {
-        EnvFileFormat.parseDomains(domainsText)
+    private var trimmedDomains: [String] {
+        domainEntries
+            .map { $0.pattern.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
     }
 
     private var nameIsValid: Bool {
@@ -230,7 +342,7 @@ private struct SecretEditorSheet: View {
     }
 
     private var canSave: Bool {
-        nameIsValid && !nameCollides && !value.isEmpty && !parsedDomains.isEmpty
+        nameIsValid && !nameCollides && !value.isEmpty && !trimmedDomains.isEmpty
     }
 
     private var validationMessage: String? {
@@ -238,8 +350,13 @@ private struct SecretEditorSheet: View {
         if !nameIsValid { return "Name may only contain letters, numbers, and underscores." }
         if nameCollides { return "A secret named \"\(trimmedName)\" already exists." }
         if value.isEmpty { return "Value is required." }
-        if parsedDomains.isEmpty { return "Add at least one hostname pattern." }
+        if trimmedDomains.isEmpty { return "Add at least one hostname pattern." }
         return nil
+    }
+
+    private var isEditing: Bool {
+        if case .editing = draft { return true }
+        return false
     }
 
     var body: some View {
@@ -261,16 +378,39 @@ private struct SecretEditorSheet: View {
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
                 }
-                GridRow {
-                    Text("Hostnames").gridColumnAlignment(.trailing)
-                    TextField("api.github.com, *.github.com", text: $domainsText)
-                        .textFieldStyle(.roundedBorder)
-                        .disableAutocorrection(true)
-                        .font(.system(.body, design: .monospaced))
+                GridRow(alignment: .top) {
+                    Text("Hostnames")
+                        .gridColumnAlignment(.trailing)
+                        .padding(.top, 5)
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach($domainEntries) { $entry in
+                            HStack(spacing: 6) {
+                                TextField("api.github.com or *.github.com", text: $entry.pattern)
+                                    .textFieldStyle(.roundedBorder)
+                                    .disableAutocorrection(true)
+                                    .font(.system(.body, design: .monospaced))
+                                Button {
+                                    removeDomain(entry.id)
+                                } label: {
+                                    Image(systemName: "minus.circle.fill")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.borderless)
+                                .help("Remove hostname pattern")
+                            }
+                        }
+                        Button {
+                            domainEntries.append(DomainEntry(pattern: ""))
+                        } label: {
+                            Label("Add hostname", systemImage: "plus.circle")
+                                .font(.callout)
+                        }
+                        .buttonStyle(.borderless)
+                    }
                 }
             }
 
-            Text("Comma-separated. `*` matches any host; `*.example.com` matches subdomains only.")
+            Text("Each pattern matches one host. `*` matches any host; `*.example.com` matches subdomains only.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -288,18 +428,22 @@ private struct SecretEditorSheet: View {
                 Button("Cancel", role: .cancel) { onCancel() }
                     .keyboardShortcut(.cancelAction)
                 Button("Save") {
-                    onSave(Secret(name: trimmedName, value: value, domains: parsedDomains))
+                    onSave(Secret(name: trimmedName, value: value, domains: trimmedDomains))
                 }
                 .keyboardShortcut(.defaultAction)
                 .disabled(!canSave)
             }
         }
         .padding(20)
-        .frame(width: 480)
+        .frame(width: 520)
     }
 
-    private var isEditing: Bool {
-        if case .editing = draft { return true }
-        return false
+    private func removeDomain(_ id: UUID) {
+        guard let idx = domainEntries.firstIndex(where: { $0.id == id }) else { return }
+        if domainEntries.count > 1 {
+            domainEntries.remove(at: idx)
+        } else {
+            domainEntries[idx].pattern = ""
+        }
     }
 }

--- a/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+import os
+
+private let log = Logger(subsystem: "com.slicc.sliccstart", category: "Settings")
+
+struct SettingsView: View {
+    @State private var secrets: [Secret] = []
+    @State private var selection: Secret.ID?
+    @State private var editorDraft: SecretDraft?
+    @State private var deletionTarget: Secret?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        TabView {
+            secretsTab
+                .tabItem { Label("Secrets", systemImage: "key.fill") }
+        }
+        .frame(width: 620, height: 420)
+        .onAppear { reload() }
+    }
+
+    private var secretsTab: some View {
+        VStack(spacing: 0) {
+            Table(secrets, selection: $selection) {
+                TableColumn("Name") { secret in
+                    Text(secret.name)
+                        .font(.system(.body, design: .monospaced))
+                }
+                .width(min: 140, ideal: 180)
+
+                TableColumn("Value") { _ in
+                    Text("••••••••")
+                        .foregroundStyle(.secondary)
+                        .font(.system(.body, design: .monospaced))
+                }
+                .width(min: 80, ideal: 100)
+
+                TableColumn("Hostname patterns") { secret in
+                    Text(secret.domains.joined(separator: ", "))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .contextMenu(forSelectionType: Secret.ID.self) { ids in
+                if let id = ids.first, let secret = secrets.first(where: { $0.id == id }) {
+                    Button("Edit…") { editorDraft = .editing(secret) }
+                    Button("Delete…", role: .destructive) { deletionTarget = secret }
+                }
+            } primaryAction: { ids in
+                if let id = ids.first, let secret = secrets.first(where: { $0.id == id }) {
+                    editorDraft = .editing(secret)
+                }
+            }
+
+            Divider()
+
+            HStack(spacing: 6) {
+                Button {
+                    editorDraft = .creating
+                } label: {
+                    Image(systemName: "plus")
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.borderless)
+                .help("Add new secret")
+
+                Button {
+                    if let id = selection, let secret = secrets.first(where: { $0.id == id }) {
+                        deletionTarget = secret
+                    }
+                } label: {
+                    Image(systemName: "minus")
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.borderless)
+                .disabled(selection == nil)
+                .help("Delete selected secret")
+
+                Spacer()
+
+                Button("Edit…") {
+                    if let id = selection, let secret = secrets.first(where: { $0.id == id }) {
+                        editorDraft = .editing(secret)
+                    }
+                }
+                .disabled(selection == nil)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(.bar)
+        }
+        .sheet(item: $editorDraft) { draft in
+            SecretEditorSheet(
+                draft: draft,
+                existingNames: Set(secrets.map { $0.name }),
+                onCancel: { editorDraft = nil },
+                onSave: { saved in
+                    save(draft: draft, secret: saved)
+                    editorDraft = nil
+                }
+            )
+        }
+        .alert(
+            "Delete secret?",
+            isPresented: Binding(
+                get: { deletionTarget != nil },
+                set: { if !$0 { deletionTarget = nil } }
+            ),
+            presenting: deletionTarget
+        ) { target in
+            Button("Cancel", role: .cancel) { deletionTarget = nil }
+            Button("Delete", role: .destructive) {
+                delete(target)
+                deletionTarget = nil
+            }
+        } message: { target in
+            Text("Delete \(target.name)? This can't be undone.")
+        }
+        .alert(
+            "Could not save secrets",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )
+        ) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private func reload() {
+        secrets = EnvFileFormat.parseSecrets(SecretsKeychain.readBlob())
+            .sorted(by: { $0.name < $1.name })
+    }
+
+    private func save(draft: SecretDraft, secret: Secret) {
+        var working = secrets
+        if case .editing(let original) = draft {
+            working.removeAll { $0.name == original.name }
+        }
+        working.removeAll { $0.name == secret.name }
+        working.append(secret)
+        persist(working)
+    }
+
+    private func delete(_ secret: Secret) {
+        var working = secrets
+        working.removeAll { $0.name == secret.name }
+        persist(working)
+    }
+
+    private func persist(_ working: [Secret]) {
+        let sorted = working.sorted(by: { $0.name < $1.name })
+        do {
+            try SecretsKeychain.writeBlob(EnvFileFormat.serialize(sorted))
+            secrets = sorted
+        } catch {
+            log.error("persist failed: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+enum SecretDraft: Identifiable {
+    case creating
+    case editing(Secret)
+
+    var id: String {
+        switch self {
+        case .creating: return "__new__"
+        case .editing(let secret): return "edit:\(secret.name)"
+        }
+    }
+}
+
+private struct SecretEditorSheet: View {
+    let draft: SecretDraft
+    let existingNames: Set<String>
+    let onCancel: () -> Void
+    let onSave: (Secret) -> Void
+
+    @State private var name: String
+    @State private var value: String
+    @State private var domainsText: String
+
+    init(
+        draft: SecretDraft,
+        existingNames: Set<String>,
+        onCancel: @escaping () -> Void,
+        onSave: @escaping (Secret) -> Void
+    ) {
+        self.draft = draft
+        self.existingNames = existingNames
+        self.onCancel = onCancel
+        self.onSave = onSave
+        switch draft {
+        case .creating:
+            _name = State(initialValue: "")
+            _value = State(initialValue: "")
+            _domainsText = State(initialValue: "")
+        case .editing(let secret):
+            _name = State(initialValue: secret.name)
+            _value = State(initialValue: secret.value)
+            _domainsText = State(initialValue: secret.domains.joined(separator: ", "))
+        }
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespaces)
+    }
+
+    private var parsedDomains: [String] {
+        EnvFileFormat.parseDomains(domainsText)
+    }
+
+    private var nameIsValid: Bool {
+        guard !trimmedName.isEmpty else { return false }
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
+        return CharacterSet(charactersIn: trimmedName).isSubset(of: allowed)
+    }
+
+    private var nameCollides: Bool {
+        switch draft {
+        case .creating:
+            return existingNames.contains(trimmedName)
+        case .editing(let original):
+            return trimmedName != original.name && existingNames.contains(trimmedName)
+        }
+    }
+
+    private var canSave: Bool {
+        nameIsValid && !nameCollides && !value.isEmpty && !parsedDomains.isEmpty
+    }
+
+    private var validationMessage: String? {
+        if trimmedName.isEmpty { return "Name is required." }
+        if !nameIsValid { return "Name may only contain letters, numbers, and underscores." }
+        if nameCollides { return "A secret named \"\(trimmedName)\" already exists." }
+        if value.isEmpty { return "Value is required." }
+        if parsedDomains.isEmpty { return "Add at least one hostname pattern." }
+        return nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(isEditing ? "Edit Secret" : "New Secret")
+                .font(.headline)
+
+            Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 10, verticalSpacing: 10) {
+                GridRow {
+                    Text("Name").gridColumnAlignment(.trailing)
+                    TextField("GITHUB_TOKEN", text: $name)
+                        .textFieldStyle(.roundedBorder)
+                        .disableAutocorrection(true)
+                        .font(.system(.body, design: .monospaced))
+                }
+                GridRow {
+                    Text("Value").gridColumnAlignment(.trailing)
+                    SecureField("ghp_…", text: $value)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                }
+                GridRow {
+                    Text("Hostnames").gridColumnAlignment(.trailing)
+                    TextField("api.github.com, *.github.com", text: $domainsText)
+                        .textFieldStyle(.roundedBorder)
+                        .disableAutocorrection(true)
+                        .font(.system(.body, design: .monospaced))
+                }
+            }
+
+            Text("Comma-separated. `*` matches any host; `*.example.com` matches subdomains only.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if let message = validationMessage {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            } else {
+                Text(" ")
+                    .font(.caption)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Save") {
+                    onSave(Secret(name: trimmedName, value: value, domains: parsedDomains))
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSave)
+            }
+        }
+        .padding(20)
+        .frame(width: 480)
+    }
+
+    private var isEditing: Bool {
+        if case .editing = draft { return true }
+        return false
+    }
+}

--- a/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
@@ -91,7 +91,10 @@ struct SecretsSettingsView: View {
 
             HStack(spacing: 6) {
                 Button {
-                    if !unlocked { unlock() }
+                    if !unlocked {
+                        unlock()
+                        guard unlocked else { return }
+                    }
                     editorDraft = .creating
                 } label: {
                     Image(systemName: "plus")
@@ -228,15 +231,30 @@ struct SecretsSettingsView: View {
         }
     }
 
+    /// Read the Keychain blob and reveal real secrets. On failure (auth
+    /// cancelled, decode error, etc.) `unlocked` stays `false` so the
+    /// overlay remains and the editor can't open against an empty
+    /// snapshot — preventing a later save from overwriting stored secrets.
     private func unlock() {
         guard !unlocked else { return }
-        secrets = EnvFileFormat.parseSecrets(SecretsKeychain.readBlob())
-            .sorted(by: { $0.name < $1.name })
-        unlocked = true
+        do {
+            let blob = try SecretsKeychain.readBlob()
+            secrets = EnvFileFormat.parseSecrets(blob)
+                .sorted(by: { $0.name < $1.name })
+            errorMessage = nil
+            unlocked = true
+        } catch {
+            log.error("unlock failed: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+            unlocked = false
+        }
     }
 
     private func save(draft: SecretDraft, secret: Secret) {
-        if !unlocked { unlock() }
+        if !unlocked {
+            unlock()
+            guard unlocked else { return }
+        }
         var working = secrets
         if case .editing(let original) = draft {
             working.removeAll { $0.name == original.name }
@@ -326,6 +344,20 @@ private struct SecretEditorSheet: View {
             .filter { !$0.isEmpty }
     }
 
+    /// First non-empty hostname pattern that fails the syntactic check, or
+    /// `nil` if every pattern is valid (or empty — empties are filtered out
+    /// before save).
+    private var firstInvalidPattern: String? {
+        for entry in domainEntries {
+            let trimmed = entry.pattern.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { continue }
+            if !EnvFileFormat.isValidHostnamePattern(trimmed) {
+                return trimmed
+            }
+        }
+        return nil
+    }
+
     private var nameIsValid: Bool {
         guard !trimmedName.isEmpty else { return false }
         let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
@@ -342,7 +374,11 @@ private struct SecretEditorSheet: View {
     }
 
     private var canSave: Bool {
-        nameIsValid && !nameCollides && !value.isEmpty && !trimmedDomains.isEmpty
+        nameIsValid
+            && !nameCollides
+            && !value.isEmpty
+            && !trimmedDomains.isEmpty
+            && firstInvalidPattern == nil
     }
 
     private var validationMessage: String? {
@@ -351,6 +387,9 @@ private struct SecretEditorSheet: View {
         if nameCollides { return "A secret named \"\(trimmedName)\" already exists." }
         if value.isEmpty { return "Value is required." }
         if trimmedDomains.isEmpty { return "Add at least one hostname pattern." }
+        if let bad = firstInvalidPattern {
+            return "\"\(bad)\" is not a valid hostname pattern. Use `example.com`, `*.example.com`, or `*`."
+        }
         return nil
     }
 

--- a/packages/swift-launcher/SliccstartTests/EnvFileFormatTests.swift
+++ b/packages/swift-launcher/SliccstartTests/EnvFileFormatTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import Sliccstart
+
+final class EnvFileFormatTests: XCTestCase {
+
+    func testRoundTripPreservesNamesValuesAndDomains() {
+        let original = [
+            Secret(name: "GITHUB_TOKEN", value: "ghp_abc", domains: ["api.github.com", "*.github.com"]),
+            Secret(name: "OPENAI_KEY", value: "sk-xyz", domains: ["api.openai.com"]),
+        ]
+        let blob = EnvFileFormat.serialize(original)
+        let parsed = EnvFileFormat.parseSecrets(blob)
+        XCTAssertEqual(parsed, original)
+    }
+
+    func testRoundTripPreservesValuesWithQuotesAndHash() {
+        let original = [
+            Secret(name: "TOKEN", value: #"value with "quotes" and #hash"#, domains: ["a.com"]),
+        ]
+        let blob = EnvFileFormat.serialize(original)
+        let parsed = EnvFileFormat.parseSecrets(blob)
+        XCTAssertEqual(parsed, original)
+    }
+
+    func testParseSkipsKeysWithoutDomains() {
+        let blob = """
+        ORPHAN=value-no-domains
+        VALID=v
+        VALID_DOMAINS=a.com
+        """
+        let secrets = EnvFileFormat.parseSecrets(blob)
+        XCTAssertEqual(secrets.count, 1)
+        XCTAssertEqual(secrets.first?.name, "VALID")
+    }
+
+    func testParseAcceptsReversedOrder() {
+        let blob = """
+        TOKEN_DOMAINS=api.example.com
+        TOKEN=hello
+        """
+        let parsed = EnvFileFormat.parseSecrets(blob)
+        XCTAssertEqual(parsed, [Secret(name: "TOKEN", value: "hello", domains: ["api.example.com"])])
+    }
+
+    func testParseSkipsBlankAndCommentLines() {
+        let blob = """
+
+        # comment
+        FOO=bar
+        FOO_DOMAINS=a.com
+
+        # another comment
+        """
+        let parsed = EnvFileFormat.parseSecrets(blob)
+        XCTAssertEqual(parsed, [Secret(name: "FOO", value: "bar", domains: ["a.com"])])
+    }
+
+    func testParseDomainsTrimsAndDropsEmpties() {
+        XCTAssertEqual(EnvFileFormat.parseDomains(" a.com , , *.b.com "), ["a.com", "*.b.com"])
+        XCTAssertTrue(EnvFileFormat.parseDomains("").isEmpty)
+        XCTAssertTrue(EnvFileFormat.parseDomains(" , , ").isEmpty)
+    }
+}

--- a/packages/swift-launcher/SliccstartTests/EnvFileFormatTests.swift
+++ b/packages/swift-launcher/SliccstartTests/EnvFileFormatTests.swift
@@ -60,4 +60,41 @@ final class EnvFileFormatTests: XCTestCase {
         XCTAssertTrue(EnvFileFormat.parseDomains("").isEmpty)
         XCTAssertTrue(EnvFileFormat.parseDomains(" , , ").isEmpty)
     }
+
+    // MARK: - hostname pattern validation
+
+    func testIsValidHostnamePatternAcceptsAllowedShapes() {
+        XCTAssertTrue(EnvFileFormat.isValidHostnamePattern("*"))
+        XCTAssertTrue(EnvFileFormat.isValidHostnamePattern("example.com"))
+        XCTAssertTrue(EnvFileFormat.isValidHostnamePattern("api.github.com"))
+        XCTAssertTrue(EnvFileFormat.isValidHostnamePattern("*.example.com"))
+        XCTAssertTrue(EnvFileFormat.isValidHostnamePattern("*.api.github.com"))
+        // Single-label hosts are valid (e.g. localhost, internal services).
+        XCTAssertTrue(EnvFileFormat.isValidHostnamePattern("localhost"))
+        // Underscores and dashes inside labels are accepted.
+        XCTAssertTrue(EnvFileFormat.isValidHostnamePattern("my_service.internal"))
+        XCTAssertTrue(EnvFileFormat.isValidHostnamePattern("a-b.example.com"))
+    }
+
+    func testIsValidHostnamePatternRejectsBadShapes() {
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern(""))
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("   "))
+        // Empty labels.
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("."))
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern(".com"))
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("example."))
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("a..b"))
+        // Wildcard misuse.
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("**"))
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("*."))
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("*foo.com"))
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("foo.*.com"))
+        // Leading/trailing dash in a label.
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("-foo.com"))
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("foo-.com"))
+        // Disallowed characters.
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("foo bar.com"))
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("foo:8080"))
+        XCTAssertFalse(EnvFileFormat.isValidHostnamePattern("https://foo.com"))
+    }
 }

--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -635,51 +635,13 @@ extension ServerCommand {
     /// Parse a .env file into `[Secret]` entries.
     ///
     /// Expects KEY=VALUE lines and KEY_DOMAINS=domain1,domain2 lines.
-    /// Keys without a matching _DOMAINS entry are skipped.
+    /// Keys without a matching _DOMAINS entry are skipped. Shares its parser
+    /// with `SecretStore`'s Keychain blob, so a `--env-file` override and the
+    /// stored blob accept exactly the same syntax.
     static func parseEnvFileSecrets(at url: URL) -> [Secret]? {
         guard let content = try? String(contentsOf: url, encoding: .utf8) else {
             return nil
         }
-
-        let domainsSuffix = "_DOMAINS"
-        var entries: [(key: String, value: String)] = []
-
-        for raw in content.components(separatedBy: "\n") {
-            let line = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            if line.isEmpty || line.hasPrefix("#") { continue }
-
-            guard let eqIndex = line.firstIndex(of: "=") else { continue }
-            let key = line[line.startIndex..<eqIndex].trimmingCharacters(in: .whitespacesAndNewlines)
-            var value = line[line.index(after: eqIndex)...].trimmingCharacters(in: .whitespacesAndNewlines)
-
-            // Strip matching quotes
-            if (value.hasPrefix("\"") && value.hasSuffix("\""))
-                || (value.hasPrefix("'") && value.hasSuffix("'")) {
-                value = String(value.dropFirst().dropLast())
-            }
-
-            if !key.isEmpty {
-                entries.append((key: key, value: value))
-            }
-        }
-
-        var secrets: [Secret] = []
-        for entry in entries {
-            if entry.key.hasSuffix(domainsSuffix) { continue }
-
-            let domainsKey = entry.key + domainsSuffix
-            guard let domainsEntry = entries.first(where: { $0.key == domainsKey }) else { continue }
-
-            let domains = domainsEntry.value
-                .components(separatedBy: ",")
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty }
-
-            if !domains.isEmpty {
-                secrets.append(Secret(name: entry.key, value: entry.value, domains: domains))
-            }
-        }
-
-        return secrets
+        return EnvFileFormat.secretsFromBlob(content)
     }
 }

--- a/packages/swift-server/Sources/Keychain/EnvFileFormat.swift
+++ b/packages/swift-server/Sources/Keychain/EnvFileFormat.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// A single line in an .env file: `KEY=VALUE`.
+struct EnvEntry: Sendable, Equatable {
+    let key: String
+    let value: String
+}
+
+/// Suffix used to pair a `KEY` line with its `KEY_DOMAINS` allowlist.
+private let domainsSuffix = "_DOMAINS"
+
+/// Parser/serializer for `.env`-style secret storage.
+///
+/// Mirrors `packages/node-server/src/secrets/env-file.ts` so the same blob
+/// can round-trip between the Node store, the Swift Keychain blob, and
+/// `--env-file` overrides without divergence.
+enum EnvFileFormat {
+
+    /// Parse `.env` content into ordered key-value pairs. Skips blank lines
+    /// and `#` comments. Strips matching surrounding double or single quotes
+    /// and unescapes `\"` inside double-quoted values.
+    static func parse(_ content: String) -> [EnvEntry] {
+        var entries: [EnvEntry] = []
+        for raw in content.components(separatedBy: "\n") {
+            let line = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            guard let eq = line.firstIndex(of: "=") else { continue }
+            let key = line[line.startIndex..<eq].trimmingCharacters(in: .whitespacesAndNewlines)
+            var value = line[line.index(after: eq)...].trimmingCharacters(in: .whitespacesAndNewlines)
+            if value.hasPrefix("\"") && value.hasSuffix("\"") && value.count >= 2 {
+                value = String(value.dropFirst().dropLast())
+                    .replacingOccurrences(of: "\\\"", with: "\"")
+            } else if value.hasPrefix("'") && value.hasSuffix("'") && value.count >= 2 {
+                value = String(value.dropFirst().dropLast())
+            }
+            if !key.isEmpty {
+                entries.append(EnvEntry(key: key, value: value))
+            }
+        }
+        return entries
+    }
+
+    /// Serialize entries back to `.env` text. Values containing whitespace,
+    /// `#`, or quotes are double-quoted with embedded `"` escaped as `\"`.
+    static func serialize(_ entries: [EnvEntry]) -> String {
+        var lines: [String] = []
+        for entry in entries {
+            lines.append("\(entry.key)=\(serializeValue(entry.value))")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Convert an env-file blob into `Secret` values. Pairs each `KEY` with
+    /// its corresponding `KEY_DOMAINS` line; entries without a non-empty
+    /// `KEY_DOMAINS` are dropped. Order follows the first `KEY` occurrence.
+    static func secretsFromBlob(_ content: String) -> [Secret] {
+        let entries = parse(content)
+        var values: [String: String] = [:]
+        var domains: [String: String] = [:]
+        var order: [String] = []
+
+        for entry in entries {
+            if entry.key.hasSuffix(domainsSuffix) {
+                let name = String(entry.key.dropLast(domainsSuffix.count))
+                if !name.isEmpty {
+                    domains[name] = entry.value
+                }
+            } else {
+                if values[entry.key] == nil {
+                    order.append(entry.key)
+                }
+                values[entry.key] = entry.value
+            }
+        }
+
+        var result: [Secret] = []
+        for name in order {
+            guard let value = values[name],
+                  let domainsLine = domains[name] else { continue }
+            let parsed = parseDomains(domainsLine)
+            guard !parsed.isEmpty else { continue }
+            result.append(Secret(name: name, value: value, domains: parsed))
+        }
+        return result
+    }
+
+    /// Serialize a list of secrets into an env-file blob. Each secret emits
+    /// a `KEY=value` line followed by `KEY_DOMAINS=domain1,domain2`.
+    static func blobFromSecrets(_ secrets: [Secret]) -> String {
+        var entries: [EnvEntry] = []
+        for secret in secrets {
+            entries.append(EnvEntry(key: secret.name, value: secret.value))
+            entries.append(EnvEntry(
+                key: secret.name + domainsSuffix,
+                value: secret.domains.joined(separator: ",")
+            ))
+        }
+        return serialize(entries)
+    }
+
+    /// Split a comma-separated domain list, trimming whitespace and dropping
+    /// empties.
+    static func parseDomains(_ raw: String) -> [String] {
+        raw.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func serializeValue(_ value: String) -> String {
+        let needsQuoting = value.contains { ch in
+            ch.isWhitespace || ch == "#" || ch == "\"" || ch == "'"
+        }
+        if !needsQuoting { return value }
+        let escaped = value.replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+}

--- a/packages/swift-server/Sources/Keychain/SecretInjector.swift
+++ b/packages/swift-server/Sources/Keychain/SecretInjector.swift
@@ -86,11 +86,11 @@ public final class SecretInjector: Sendable {
 
     private func loadSecrets() {
         guard let sessionId else { return }
-        let entries = SecretStore.list()
+        // Single Keychain read + parse for every secret. Previously this did
+        // SecretStore.list() followed by per-name SecretStore.get(...), which
+        // re-parsed the same blob N+1 times.
         var loaded: [LoadedSecret] = []
-        var loadedNames: Set<String> = []
-        for entry in entries {
-            guard let secret = SecretStore.get(name: entry.name) else { continue }
+        for secret in SecretStore.all() {
             let masked = mask(sessionId: sessionId, secretName: secret.name, realValue: secret.value)
             loaded.append(LoadedSecret(
                 name: secret.name,
@@ -98,7 +98,6 @@ public final class SecretInjector: Sendable {
                 maskedValue: masked,
                 domains: secret.domains
             ))
-            loadedNames.insert(secret.name)
         }
 
         // Merge env-file secrets: override existing by name, append new ones

--- a/packages/swift-server/Sources/Keychain/SecretStore.swift
+++ b/packages/swift-server/Sources/Keychain/SecretStore.swift
@@ -68,11 +68,23 @@ enum SecretStore {
         readSecrets().map { SecretEntry(name: $0.name, domains: $0.domains) }
     }
 
+    /// Returns every secret in a single Keychain read + parse. Prefer this
+    /// over `list()` followed by per-name `get(name:)` — the latter parses
+    /// the full blob on each call (N+1 against the same item).
+    static func all() -> [Secret] {
+        readSecrets()
+    }
+
     // MARK: - Blob accessors
 
-    /// Read the env-file blob from Keychain. Returns `""` if the item does
-    /// not exist yet.
-    static func readBlob() -> String {
+    /// Read the env-file blob from Keychain.
+    ///
+    /// Returns `""` only when the item legitimately does not exist
+    /// (`errSecItemNotFound`). Any other failure — auth cancelled, decode
+    /// error, etc. — is reported as `SecretStoreError.keychainError` so
+    /// callers can avoid mutating against an empty baseline (which would
+    /// silently wipe stored secrets on the next write).
+    static func readBlob() throws -> String {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: keychainService,
@@ -82,10 +94,15 @@ enum SecretStore {
         ]
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess,
-              let data = result as? Data,
-              let text = String(data: data, encoding: .utf8) else {
+        if status == errSecItemNotFound {
             return ""
+        }
+        guard status == errSecSuccess else {
+            throw SecretStoreError.keychainError(status: status)
+        }
+        guard let data = result as? Data,
+              let text = String(data: data, encoding: .utf8) else {
+            throw SecretStoreError.keychainError(status: errSecDecode)
         }
         return text
     }
@@ -123,14 +140,21 @@ enum SecretStore {
 
     // MARK: - Private
 
+    /// Read-only path: a Keychain failure surfaces as an empty list rather
+    /// than a thrown error. Callers like `get` / `list` can't usefully
+    /// recover on the failure, and a missing return value is no worse than
+    /// the prior behaviour. Mutations use `mutate` instead, which DOES
+    /// propagate read failures so a transient error never silently wipes
+    /// the blob.
     private static func readSecrets() -> [Secret] {
-        EnvFileFormat.secretsFromBlob(readBlob())
+        EnvFileFormat.secretsFromBlob((try? readBlob()) ?? "")
     }
 
     private static func mutate(_ change: (inout [Secret]) -> Void) throws {
         lock.lock()
         defer { lock.unlock() }
-        var secrets = EnvFileFormat.secretsFromBlob(readBlob())
+        let blob = try readBlob()
+        var secrets = EnvFileFormat.secretsFromBlob(blob)
         change(&secrets)
         try writeBlob(EnvFileFormat.blobFromSecrets(secrets))
     }

--- a/packages/swift-server/Sources/Keychain/SecretStore.swift
+++ b/packages/swift-server/Sources/Keychain/SecretStore.swift
@@ -19,77 +19,98 @@ enum SecretStoreError: Error, Sendable, Equatable {
     case keychainError(status: Int32)
 }
 
-/// Keychain service identifier used for all SLICC secrets.
+/// Keychain service identifier used for the SLICC secrets blob.
 private let keychainService = "ai.sliccy.slicc"
+
+/// Account name for the single Keychain item that holds every secret.
+private let keychainAccount = "__envfile__"
 
 /// CRUD operations for secrets stored in the macOS Keychain.
 ///
-/// - Service: `ai.sliccy.slicc`
-/// - Account: secret name (e.g. `GITHUB_TOKEN`)
-/// - Value: secret value in `kSecValueData`
-/// - Domains: comma-separated in `kSecAttrComment`
+/// All secrets live in a single `kSecClassGenericPassword` item under
+/// service `ai.sliccy.slicc` and account `__envfile__`. The item's value
+/// is an `.env`-formatted blob (`KEY=value` paired with `KEY_DOMAINS=...`)
+/// using the same format as `~/.slicc/secrets.env` consumed by node-server.
+///
+/// One item means one Keychain access prompt per signed binary, regardless
+/// of how many secrets the user stores. The same item is read by Sliccstart
+/// to power its Settings UI.
 enum SecretStore {
 
-    /// Retrieve a secret and its domains from the Keychain.
+    /// Serializes blob mutations within a single process.
+    private static let lock = NSLock()
+
     static func get(name: String) -> Secret? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: keychainService,
-            kSecAttrAccount as String: name,
-            kSecReturnData as String: true,
-            kSecReturnAttributes as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-
-        guard status == errSecSuccess,
-            let attrs = result as? [String: Any],
-            let data = attrs[kSecValueData as String] as? Data,
-            let value = String(data: data, encoding: .utf8)
-        else {
-            return nil
-        }
-
-        let comment = attrs[kSecAttrComment as String] as? String ?? ""
-        let domains = parseDomains(comment)
-        return Secret(name: name, value: value, domains: domains)
+        readSecrets().first(where: { $0.name == name })
     }
 
-    /// Store or update a secret in the Keychain.
-    /// - Throws: `SecretStoreError.emptyDomains` if `domains` is empty.
     static func set(name: String, value: String, domains: [String]) throws {
         guard !domains.isEmpty else {
             throw SecretStoreError.emptyDomains
         }
+        try mutate { secrets in
+            let entry = Secret(name: name, value: value, domains: domains)
+            if let idx = secrets.firstIndex(where: { $0.name == name }) {
+                secrets[idx] = entry
+            } else {
+                secrets.append(entry)
+            }
+        }
+    }
 
-        let comment = domains.joined(separator: ",")
-        let valueData = Data(value.utf8)
+    static func delete(name: String) throws {
+        try mutate { secrets in
+            secrets.removeAll { $0.name == name }
+        }
+    }
 
-        // Try to update first.
+    static func list() -> [SecretEntry] {
+        readSecrets().map { SecretEntry(name: $0.name, domains: $0.domains) }
+    }
+
+    // MARK: - Blob accessors
+
+    /// Read the env-file blob from Keychain. Returns `""` if the item does
+    /// not exist yet.
+    static func readBlob() -> String {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let text = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return text
+    }
+
+    /// Replace the env-file blob in Keychain (creates the item on first use).
+    static func writeBlob(_ content: String) throws {
+        let valueData = Data(content.utf8)
         let searchQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: keychainService,
-            kSecAttrAccount as String: name,
-        ]
-        let updateAttrs: [String: Any] = [
-            kSecValueData as String: valueData,
-            kSecAttrComment as String: comment,
+            kSecAttrAccount as String: keychainAccount,
         ]
 
-        let updateStatus = SecItemUpdate(searchQuery as CFDictionary, updateAttrs as CFDictionary)
+        let updateStatus = SecItemUpdate(
+            searchQuery as CFDictionary,
+            [kSecValueData as String: valueData] as CFDictionary
+        )
 
         if updateStatus == errSecSuccess {
             return
         }
 
         if updateStatus == errSecItemNotFound {
-            // Add new item.
             var addQuery = searchQuery
             addQuery[kSecValueData as String] = valueData
-            addQuery[kSecAttrComment as String] = comment
-
             let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
             guard addStatus == errSecSuccess else {
                 throw SecretStoreError.keychainError(status: addStatus)
@@ -100,53 +121,17 @@ enum SecretStore {
         throw SecretStoreError.keychainError(status: updateStatus)
     }
 
-    /// Remove a secret from the Keychain.
-    static func delete(name: String) throws {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: keychainService,
-            kSecAttrAccount as String: name,
-        ]
+    // MARK: - Private
 
-        let status = SecItemDelete(query as CFDictionary)
-        guard status == errSecSuccess || status == errSecItemNotFound else {
-            throw SecretStoreError.keychainError(status: status)
-        }
+    private static func readSecrets() -> [Secret] {
+        EnvFileFormat.secretsFromBlob(readBlob())
     }
 
-    /// List all secret names and domains (never values).
-    static func list() -> [SecretEntry] {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: keychainService,
-            kSecReturnAttributes as String: true,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-        ]
-
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-
-        guard status == errSecSuccess,
-            let items = result as? [[String: Any]]
-        else {
-            return []
-        }
-
-        return items.compactMap { attrs in
-            guard let account = attrs[kSecAttrAccount as String] as? String else {
-                return nil
-            }
-            let comment = attrs[kSecAttrComment as String] as? String ?? ""
-            return SecretEntry(name: account, domains: parseDomains(comment))
-        }
-    }
-
-    /// Parse a comma-separated domain string, trimming whitespace and
-    /// dropping empty entries.
-    private static func parseDomains(_ raw: String) -> [String] {
-        raw.split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
+    private static func mutate(_ change: (inout [Secret]) -> Void) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        var secrets = EnvFileFormat.secretsFromBlob(readBlob())
+        change(&secrets)
+        try writeBlob(EnvFileFormat.blobFromSecrets(secrets))
     }
 }
-

--- a/packages/swift-server/Tests/EnvFileFormatTests.swift
+++ b/packages/swift-server/Tests/EnvFileFormatTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import slicc_server
+
+final class EnvFileFormatTests: XCTestCase {
+
+    // MARK: - parse
+
+    func testParseSkipsBlankLinesAndComments() {
+        let blob = """
+
+        # this is a comment
+        FOO=bar
+
+        # another comment
+        BAZ=qux
+        """
+        let entries = EnvFileFormat.parse(blob)
+        XCTAssertEqual(entries.map(\.key), ["FOO", "BAZ"])
+        XCTAssertEqual(entries.map(\.value), ["bar", "qux"])
+    }
+
+    func testParseStripsMatchingDoubleQuotesAndUnescapes() {
+        let entries = EnvFileFormat.parse(#"GREETING="hello \"world\"""#)
+        XCTAssertEqual(entries.first?.value, #"hello "world""#)
+    }
+
+    func testParseStripsMatchingSingleQuotes() {
+        let entries = EnvFileFormat.parse("MSG='hi there'")
+        XCTAssertEqual(entries.first?.value, "hi there")
+    }
+
+    func testParseSkipsLinesWithoutEquals() {
+        let entries = EnvFileFormat.parse("not_a_pair\nFOO=bar")
+        XCTAssertEqual(entries.map(\.key), ["FOO"])
+    }
+
+    // MARK: - serialize
+
+    func testSerializeQuotesValuesWithSpacesOrSpecialChars() {
+        let blob = EnvFileFormat.serialize([
+            EnvEntry(key: "PLAIN", value: "hello"),
+            EnvEntry(key: "SPACED", value: "hello world"),
+            EnvEntry(key: "HASH", value: "abc#def"),
+            EnvEntry(key: "QUOTED", value: #"v"x"#),
+        ])
+        XCTAssertTrue(blob.contains("PLAIN=hello\n"))
+        XCTAssertTrue(blob.contains(#"SPACED="hello world""#))
+        XCTAssertTrue(blob.contains(#"HASH="abc#def""#))
+        XCTAssertTrue(blob.contains(#"QUOTED="v\"x""#))
+    }
+
+    // MARK: - secretsFromBlob / blobFromSecrets
+
+    func testSecretsBlobRoundTrip() {
+        let original = [
+            Secret(name: "GITHUB_TOKEN", value: "ghp_abc", domains: ["api.github.com", "*.github.com"]),
+            Secret(name: "OPENAI_KEY", value: "sk-xyz", domains: ["api.openai.com"]),
+        ]
+        let blob = EnvFileFormat.blobFromSecrets(original)
+        let parsed = EnvFileFormat.secretsFromBlob(blob)
+        XCTAssertEqual(parsed, original)
+    }
+
+    func testSecretsBlobPreservesQuotedValues() {
+        let original = [
+            Secret(name: "TOKEN", value: #"value with "quotes" and #hash"#, domains: ["a.com"]),
+        ]
+        let blob = EnvFileFormat.blobFromSecrets(original)
+        let parsed = EnvFileFormat.secretsFromBlob(blob)
+        XCTAssertEqual(parsed, original)
+    }
+
+    func testSecretsFromBlobSkipsKeysWithoutDomains() {
+        let blob = """
+        ORPHAN=value-no-domains
+        VALID=v
+        VALID_DOMAINS=a.com
+        """
+        let secrets = EnvFileFormat.secretsFromBlob(blob)
+        XCTAssertEqual(secrets.count, 1)
+        XCTAssertEqual(secrets.first?.name, "VALID")
+    }
+
+    func testSecretsFromBlobSkipsEmptyDomainsList() {
+        let blob = """
+        EMPTY=v
+        EMPTY_DOMAINS=
+        """
+        XCTAssertTrue(EnvFileFormat.secretsFromBlob(blob).isEmpty)
+    }
+
+    func testSecretsFromBlobAcceptsAnyDeclarationOrder() {
+        let blob = """
+        TOKEN_DOMAINS=api.example.com
+        TOKEN=hello
+        """
+        let secrets = EnvFileFormat.secretsFromBlob(blob)
+        XCTAssertEqual(secrets, [Secret(name: "TOKEN", value: "hello", domains: ["api.example.com"])])
+    }
+}

--- a/packages/swift-server/Tests/KeychainSecretStoreTests.swift
+++ b/packages/swift-server/Tests/KeychainSecretStoreTests.swift
@@ -90,5 +90,34 @@ final class KeychainSecretStoreTests: XCTestCase {
         }
         XCTAssertNil(SecretStore.get(name: name))
     }
+
+    // MARK: - bulk read
+
+    func testAllReturnsEverySecretInOneCall() throws {
+        let n1 = secretName("BULK_A")
+        let n2 = secretName("BULK_B")
+        try SecretStore.set(name: n1, value: "v1", domains: ["a.com"])
+        try SecretStore.set(name: n2, value: "v2", domains: ["b.com", "*.b.com"])
+
+        let all = SecretStore.all().filter { $0.name.hasPrefix(prefix) }
+        let byName = Dictionary(uniqueKeysWithValues: all.map { ($0.name, $0) })
+
+        XCTAssertEqual(byName[n1]?.value, "v1")
+        XCTAssertEqual(byName[n1]?.domains, ["a.com"])
+        XCTAssertEqual(byName[n2]?.value, "v2")
+        XCTAssertEqual(byName[n2]?.domains, ["b.com", "*.b.com"])
+    }
+
+    // MARK: - read errors
+
+    /// `errSecItemNotFound` is the only legitimate "empty" — readBlob must
+    /// not collapse other failures into "" or set/delete would silently
+    /// wipe stored secrets after a transient auth failure.
+    func testReadBlobReturnsEmptyForMissingItem() throws {
+        // After tearDown, the test prefix's secrets are gone, but the shared
+        // blob may still hold unrelated user data. Just verify readBlob does
+        // not throw on a normal read.
+        XCTAssertNoThrow(try SecretStore.readBlob())
+    }
 }
 


### PR DESCRIPTION
## Summary

- Replaces the per-secret Keychain layout with one item under service `ai.sliccy.slicc`, account `__envfile__`, whose value is an `.env`-formatted blob (`KEY=value` paired with `KEY_DOMAINS=...`). Same format as node-server's `~/.slicc/secrets.env`. One item = one macOS access prompt instead of N.
- Adds a Sliccstart **Settings** scene (Sliccstart > Settings…, `⌘,`) with a table-based secrets manager — add, edit, delete, hostname-pattern validation, error surface for Keychain failures.
- Centralises env-file parsing in a shared `EnvFileFormat` so the `--env-file` CLI override and the Keychain blob can't drift.

## Why

Each secret was its own Keychain item, and macOS prompted for the user's password once per item access at `SecretStore.list() + get(name:)` time. Consolidating to a single item means one prompt per signed-binary lifetime, regardless of how many secrets the user stores.

## Layout

```
KEYCHAIN
└── service: ai.sliccy.slicc
    └── account: __envfile__
        value: |
            GITHUB_TOKEN=ghp_...
            GITHUB_TOKEN_DOMAINS=api.github.com,*.github.com
            OPENAI_KEY=sk-...
            OPENAI_KEY_DOMAINS=api.openai.com
```

Both Sliccstart (settings UI) and swift-server (read at startup) hit this same item. `SecretStore`'s public API (`get`/`set`/`delete`/`list`) is unchanged, so `SecretInjector`, `APIRoutes`, and `ServerCommand` work without further touch-ups.

## Files

**swift-server**
- `Sources/Keychain/EnvFileFormat.swift` (new) — parser/serializer + blob↔Secret helpers, mirrors `node-server/src/secrets/env-file.ts`.
- `Sources/Keychain/SecretStore.swift` (rewritten) — single-item R-M-W with `NSLock`.
- `Sources/CLI/ServerCommand.swift` — `parseEnvFileSecrets` collapsed to a 4-line wrapper around the shared parser.
- `Tests/EnvFileFormatTests.swift` (new) — 10 tests.

**Sliccstart**
- `Sliccstart/Models/Secrets.swift` (new) — `Secret` type, Keychain accessors, parallel `EnvFileFormat`.
- `Sliccstart/Views/SettingsView.swift` (new) — `Table` + add/edit/delete sheets, validates name characters, blocks duplicates, requires ≥1 hostname pattern.
- `Sliccstart/SliccstartApp.swift` — registers `Settings { SettingsView() }`.
- `SliccstartTests/EnvFileFormatTests.swift` (new) — 6 tests pinning Sliccstart's parser to the same behaviour.

## Notes

- **No migration**: per the request, legacy per-name Keychain entries are not folded in — the feature isn't widely used yet.
- **Tradeoff**: all secrets share one ACL. Anyone allowed to read the blob reads all of them. This was implicitly true before too (all entries shared the same service identifier), but worth naming.
- **Format compatibility**: the blob format matches node-server's `~/.slicc/secrets.env` exactly, so `swift-server --env-file ~/.slicc/secrets.env` works for cross-runtime sharing.

## Test plan

- [x] `swift build` clean in both packages
- [x] `swift test` — 136 swift-server tests pass (10 new), 18 Sliccstart tests pass (6 new)
- [ ] Manually open Sliccstart > Settings…, add a secret, verify it shows up in `slicc-server`'s `GET /api/secrets`
- [ ] Verify only one Keychain prompt fires when slicc-server starts with multiple secrets stored
- [ ] Sanity-check that `--env-file` still overrides Keychain entries with the same name

🤖 Generated with [Claude Code](https://claude.com/claude-code)