### PR TITLE
feat: add --scope flag to oauth-token command

### DIFF
--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -16,7 +16,12 @@
  *   so isomorphic-git picks it up for push/pull/clone operations.
  */
 
-import type { ProviderConfig, OAuthLauncher, ModelMetadata } from '../src/providers/types.js';
+import type {
+  ProviderConfig,
+  OAuthLauncher,
+  OAuthLoginOptions,
+  ModelMetadata,
+} from '../src/providers/types.js';
 import {
   registerApiProvider,
   streamOpenAICompletions,
@@ -333,11 +338,17 @@ export const config: ProviderConfig = {
 
   getModelIds: () => GITHUB_MODELS,
 
-  onOAuthLogin: async (launcher: OAuthLauncher, onSuccess: () => void) => {
+  onOAuthLogin: async (
+    launcher: OAuthLauncher,
+    onSuccess: () => void,
+    options?: OAuthLoginOptions
+  ) => {
     const clientId = await resolveClientId();
     if (!clientId) {
       throw new Error('GitHub OAuth not configured — no client ID available');
     }
+
+    const scopes = options?.scopes ?? githubConfig.scopes;
 
     // The redirect URI must match the GitHub App's configured callback URL.
     // In dev mode, runtimeWorkerBaseUrl points to staging; in production the
@@ -360,7 +371,7 @@ export const config: ProviderConfig = {
 
     const params = new URLSearchParams({
       client_id: clientId,
-      scope: githubConfig.scopes,
+      scope: scopes,
       redirect_uri: redirectUri,
     });
     if (oauthState) params.set('state', oauthState);

--- a/packages/webapp/src/providers/types.ts
+++ b/packages/webapp/src/providers/types.ts
@@ -11,7 +11,12 @@ export type OAuthLauncher = (authorizeUrl: string) => Promise<string | null>;
 
 /** Options passed to onOAuthLogin from the caller (e.g. oauth-token command). */
 export interface OAuthLoginOptions {
-  /** Override the default scopes for this login. Comma-separated (e.g. "repo,models:read"). */
+  /**
+   * Override the default scopes for this login. Passed directly to the
+   * provider's authorize URL as the `scope` parameter. Format is
+   * provider-specific (GitHub uses comma-separated, Google uses
+   * space-separated). The provider is responsible for any normalization.
+   */
   scopes?: string;
 }
 

--- a/packages/webapp/src/providers/types.ts
+++ b/packages/webapp/src/providers/types.ts
@@ -9,6 +9,12 @@
  */
 export type OAuthLauncher = (authorizeUrl: string) => Promise<string | null>;
 
+/** Options passed to onOAuthLogin from the caller (e.g. oauth-token command). */
+export interface OAuthLoginOptions {
+  /** Override the default scopes for this login. Comma-separated (e.g. "repo,models:read"). */
+  scopes?: string;
+}
+
 /**
  * Optional model capability overrides.
  * Used by both modelOverrides (static) and getModelIds (dynamic).
@@ -47,7 +53,11 @@ export interface ProviderConfig {
    * Receives a launcher that opens the OAuth flow and returns the redirect URL.
    * The provider builds the authorize URL, calls the launcher, then handles the result.
    */
-  onOAuthLogin?: (launcher: OAuthLauncher, onSuccess: () => void) => Promise<void>;
+  onOAuthLogin?: (
+    launcher: OAuthLauncher,
+    onSuccess: () => void,
+    options?: OAuthLoginOptions
+  ) => Promise<void>;
   /** Called when the user clicks logout for this OAuth provider. */
   onOAuthLogout?: () => Promise<void>;
   /**

--- a/packages/webapp/src/shell/supplemental-commands/oauth-token-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/oauth-token-command.ts
@@ -9,15 +9,21 @@ Usage:
   oauth-token --provider <id>     Same, using flag form
   oauth-token                     Get token for the currently selected provider
   oauth-token --list              List OAuth providers with status
+  oauth-token --scope <scopes>    Request specific OAuth scopes (comma-separated)
   oauth-token --help              Show this help message
 
 If no valid token exists or the token is expired, the OAuth login flow
 is triggered automatically. The raw access token is printed to stdout
 on success.
 
+The --scope flag overrides the provider's default scopes for this login.
+This forces a new login even if a valid token exists, since the existing
+token may not have the requested scopes.
+
 Examples:
   oauth-token adobe
-  curl -H "Authorization: Bearer $(oauth-token adobe)" https://api.corp.com/data
+  oauth-token github --scope "repo,models:read"
+  curl -H "Authorization: Bearer $(oauth-token github)" https://api.github.com/user
 `;
 }
 
@@ -41,6 +47,18 @@ export function createOAuthTokenCommand(): Command {
         getRegisteredProviderConfig,
         getOAuthAccountInfo
       );
+    }
+
+    // Parse --scope flag
+    let scopeOverride: string | undefined;
+    const scopeFlagIdx = args.indexOf('--scope');
+    if (scopeFlagIdx >= 0) {
+      scopeOverride = args[scopeFlagIdx + 1];
+      if (!scopeOverride) {
+        return { stdout: '', stderr: 'oauth-token: --scope requires a value\n', exitCode: 1 };
+      }
+      // Remove --scope and its value so they don't interfere with provider ID parsing
+      args.splice(scopeFlagIdx, 2);
     }
 
     // Determine provider ID
@@ -89,19 +107,26 @@ export function createOAuthTokenCommand(): Command {
       };
     }
 
-    // Check for existing valid token
-    const info = getOAuthAccountInfo(providerId);
-    if (info && !info.expired) {
-      return { stdout: `${info.token}\n`, stderr: '', exitCode: 0 };
+    // Check for existing valid token (skip if --scope is set, since the
+    // existing token may not have the requested scopes)
+    if (!scopeOverride) {
+      const info = getOAuthAccountInfo(providerId);
+      if (info && !info.expired) {
+        return { stdout: `${info.token}\n`, stderr: '', exitCode: 0 };
+      }
     }
 
-    // No valid token — trigger the login flow
+    // No valid token (or --scope override) — trigger the login flow
     try {
       const { createOAuthLauncher } = await import('../../providers/oauth-service.js');
       const launcher = createOAuthLauncher();
-      await config.onOAuthLogin(launcher, () => {
-        /* onSuccess callback */
-      });
+      await config.onOAuthLogin(
+        launcher,
+        () => {
+          /* onSuccess callback */
+        },
+        scopeOverride ? { scopes: scopeOverride } : undefined
+      );
 
       // Read the newly saved token
       const newInfo = getOAuthAccountInfo(providerId);

--- a/packages/webapp/src/shell/supplemental-commands/oauth-token-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/oauth-token-command.ts
@@ -53,8 +53,8 @@ export function createOAuthTokenCommand(): Command {
     let scopeOverride: string | undefined;
     const scopeFlagIdx = args.indexOf('--scope');
     if (scopeFlagIdx >= 0) {
-      scopeOverride = args[scopeFlagIdx + 1];
-      if (!scopeOverride) {
+      scopeOverride = args[scopeFlagIdx + 1]?.trim();
+      if (!scopeOverride || scopeOverride.startsWith('-')) {
         return { stdout: '', stderr: 'oauth-token: --scope requires a value\n', exitCode: 1 };
       }
       // Remove --scope and its value so they don't interfere with provider ID parsing

--- a/packages/webapp/tests/shell/supplemental-commands/oauth-token-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/oauth-token-command.test.ts
@@ -380,4 +380,83 @@ describe('oauth-token command', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('No OAuth providers');
   });
+
+  it('--scope bypasses valid token cache and triggers login with scopes', async () => {
+    const mockOnOAuthLogin = vi.fn(async (_launcher, _onSuccess, _options) => {
+      mockGetOAuthAccountInfo.mockReturnValue({
+        token: 'scoped-token',
+        expired: false,
+      });
+    });
+
+    mockGetRegisteredProviderConfig.mockReturnValue({
+      id: 'github',
+      name: 'GitHub',
+      description: '',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      isOAuth: true,
+      onOAuthLogin: mockOnOAuthLogin,
+    });
+    // Valid token exists — normally would return immediately
+    mockGetOAuthAccountInfo.mockReturnValue({
+      token: 'existing-token',
+      expired: false,
+    });
+    mockCreateOAuthLauncher.mockReturnValue(vi.fn());
+
+    const cmd = createOAuthTokenCommand();
+    const result = await cmd.execute(['github', '--scope', 'repo,models:read'], createMockCtx());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('scoped-token\n');
+    // Login was triggered despite valid token
+    expect(mockOnOAuthLogin).toHaveBeenCalled();
+    // Scopes were passed through as the third argument
+    expect(mockOnOAuthLogin).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), {
+      scopes: 'repo,models:read',
+    });
+  });
+
+  it('--scope without value returns error', async () => {
+    const cmd = createOAuthTokenCommand();
+    const result = await cmd.execute(['github', '--scope'], createMockCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--scope requires a value');
+  });
+
+  it('--scope with flag-like value returns error', async () => {
+    const cmd = createOAuthTokenCommand();
+    const result = await cmd.execute(['github', '--scope', '--provider'], createMockCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--scope requires a value');
+  });
+
+  it('without --scope, does not pass options to onOAuthLogin', async () => {
+    const mockOnOAuthLogin = vi.fn(async (_launcher, _onSuccess, _options) => {
+      mockGetOAuthAccountInfo.mockReturnValue({
+        token: 'default-token',
+        expired: false,
+      });
+    });
+
+    mockGetRegisteredProviderConfig.mockReturnValue({
+      id: 'github',
+      name: 'GitHub',
+      description: '',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      isOAuth: true,
+      onOAuthLogin: mockOnOAuthLogin,
+    });
+    mockGetOAuthAccountInfo.mockReturnValue(null);
+    mockCreateOAuthLauncher.mockReturnValue(vi.fn());
+
+    const cmd = createOAuthTokenCommand();
+    await cmd.execute(['github'], createMockCtx());
+    expect(mockOnOAuthLogin).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      undefined
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `--scope` flag to `oauth-token` for on-demand OAuth scope override
- Extends `ProviderConfig.onOAuthLogin` with an optional `OAuthLoginOptions` parameter
- GitHub provider uses override scopes when provided, falls back to defaults
- Forces fresh login when `--scope` is set (existing token may lack requested scopes)

## Usage

```bash
oauth-token github                              # default scopes (repo,read:user,user:email)
oauth-token github --scope "repo,models:read"   # request specific scopes
```

Generalizable to all OAuth providers — scopes are part of the OAuth 2.0 spec.

## Test plan

- [x] Existing oauth-token tests pass (29/29)
- [x] `--scope` bypasses token cache and triggers fresh login
- [x] Backward compatible — existing callers (UI settings dialog) don't pass options

🤖 Generated with [Claude Code](https://claude.com/claude-code)