### PR TITLE
feat: add Google Workspace OAuth provider

### DIFF
--- a/.github/workflows/worker-staging.yml
+++ b/.github/workflows/worker-staging.yml
@@ -45,9 +45,11 @@ jobs:
           secrets: |
             CLOUDFLARE_TURN_API_TOKEN
             GITHUB_CLIENT_SECRET
+            GOOGLE_CLIENT_SECRET
         env:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET_STAGING }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_WORKSPACE_SECRET }}
 
       - name: Wait before staging deploy retry 2
         if: steps.deploy_attempt_1.outcome == 'failure'
@@ -66,9 +68,11 @@ jobs:
           secrets: |
             CLOUDFLARE_TURN_API_TOKEN
             GITHUB_CLIENT_SECRET
+            GOOGLE_CLIENT_SECRET
         env:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET_STAGING }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_WORKSPACE_SECRET }}
 
       - name: Finalize staging deploy metadata
         id: deploy

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -48,9 +48,11 @@ jobs:
           secrets: |
             CLOUDFLARE_TURN_API_TOKEN
             GITHUB_CLIENT_SECRET
+            GOOGLE_CLIENT_SECRET
         env:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_WORKSPACE_SECRET }}
       - name: Wait before production deploy retry 2
         if: steps.deploy_attempt_1.outcome == 'failure'
         run: sleep 20
@@ -68,9 +70,11 @@ jobs:
           secrets: |
             CLOUDFLARE_TURN_API_TOKEN
             GITHUB_CLIENT_SECRET
+            GOOGLE_CLIENT_SECRET
         env:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_WORKSPACE_SECRET }}
       - name: Wait before production deploy retry 3
         if: steps.deploy_attempt_1.outcome == 'failure' && steps.deploy_attempt_2.outcome == 'failure'
         run: sleep 40
@@ -88,9 +92,11 @@ jobs:
           secrets: |
             CLOUDFLARE_TURN_API_TOKEN
             GITHUB_CLIENT_SECRET
+            GOOGLE_CLIENT_SECRET
         env:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_WORKSPACE_SECRET }}
       - name: Finalize production deploy metadata
         id: deploy
         env:

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -121,6 +121,8 @@ export async function handleWorkerRequest(
         oauth: {
           github:
             typeof envRecord.GITHUB_CLIENT_ID === 'string' ? envRecord.GITHUB_CLIENT_ID : undefined,
+          google:
+            typeof envRecord.GOOGLE_CLIENT_ID === 'string' ? envRecord.GOOGLE_CLIENT_ID : undefined,
         },
       },
       200,

--- a/packages/cloudflare-worker/src/oauth-registry.ts
+++ b/packages/cloudflare-worker/src/oauth-registry.ts
@@ -59,4 +59,12 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderDef> = {
     clientIdEnvKey: 'GITHUB_CLIENT_ID',
     clientSecretEnvKey: 'GITHUB_CLIENT_SECRET',
   },
+  google: {
+    name: 'Google',
+    tokenEndpoint: 'https://oauth2.googleapis.com/token',
+    revokeEndpoint: 'https://oauth2.googleapis.com/revoke',
+    revokeMethod: 'post-body',
+    clientIdEnvKey: 'GOOGLE_CLIENT_ID',
+    clientSecretEnvKey: 'GOOGLE_CLIENT_SECRET',
+  },
 };

--- a/packages/cloudflare-worker/wrangler.jsonc
+++ b/packages/cloudflare-worker/wrangler.jsonc
@@ -18,10 +18,12 @@
     "CLOUDFLARE_TURN_KEY_ID": "6c2201a0453bd6695ecb24a00b2b6ed1",
     // OAuth provider client IDs (public, safe to commit)
     "GITHUB_CLIENT_ID": "Ov23li6DZA5dPBZIaqFS",
+    "GOOGLE_CLIENT_ID": "1060201354894-f9p3m1qbkk9ck4kmqr4l15lb4k1n7043.apps.googleusercontent.com",
   },
   // Secrets must be set via: npx wrangler secret put <SECRET_NAME>
   // - CLOUDFLARE_TURN_API_TOKEN
   // - GITHUB_CLIENT_SECRET
+  // - GOOGLE_CLIENT_SECRET
   "durable_objects": {
     "bindings": [
       {
@@ -50,6 +52,7 @@
       "vars": {
         "CLOUDFLARE_TURN_KEY_ID": "6c2201a0453bd6695ecb24a00b2b6ed1",
         "GITHUB_CLIENT_ID": "Ov23liUe1b3b6GDjPGz4",
+        "GOOGLE_CLIENT_ID": "1060201354894-f9p3m1qbkk9ck4kmqr4l15lb4k1n7043.apps.googleusercontent.com",
       },
       "durable_objects": {
         "bindings": [

--- a/packages/webapp/providers/google-config.json
+++ b/packages/webapp/providers/google-config.json
@@ -1,4 +1,4 @@
 {
   "clientId": "1060201354894-f9p3m1qbkk9ck4kmqr4l15lb4k1n7043.apps.googleusercontent.com",
-  "scopes": "openid email profile https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/documents"
+  "scopes": "openid email profile https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/spreadsheets"
 }

--- a/packages/webapp/providers/google-config.json
+++ b/packages/webapp/providers/google-config.json
@@ -1,0 +1,4 @@
+{
+  "clientId": "1060201354894-f9p3m1qbkk9ck4kmqr4l15lb4k1n7043.apps.googleusercontent.com",
+  "scopes": "openid email profile https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/documents"
+}

--- a/packages/webapp/providers/google.ts
+++ b/packages/webapp/providers/google.ts
@@ -1,0 +1,250 @@
+/**
+ * Google Workspace Provider — OAuth login for Google APIs.
+ *
+ * Authentication:
+ *   Authorization code grant via the generic OAuth token broker.
+ *   Google issues refresh tokens, so tokens can be renewed without user interaction.
+ *
+ * Use cases:
+ *   - Google Drive, Gmail, Calendar, Sheets, Docs access via oauth-token
+ *   - Scopes can be customized per-request via `oauth-token google --scope "..."`
+ */
+
+import type { ProviderConfig, OAuthLauncher, OAuthLoginOptions } from '../src/providers/types.js';
+import { saveOAuthAccount, getAccounts } from '../src/ui/provider-settings.js';
+import { exchangeOAuthCode, revokeOAuthToken } from '../src/providers/oauth-code-exchange.js';
+
+// ── Config ─────────────────────────────────────────────────────────
+
+interface GoogleConfig {
+  clientId: string;
+  scopes: string;
+}
+
+const configFiles = import.meta.glob('/packages/webapp/providers/google-config.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, GoogleConfig>;
+
+const googleConfig: GoogleConfig = configFiles['/packages/webapp/providers/google-config.json'] ?? {
+  clientId: '',
+  scopes: 'openid email profile',
+};
+
+// ── Runtime config (fetches correct client ID per environment) ──────
+
+let runtimeClientId: string | null = null;
+let runtimeWorkerBaseUrl: string | null = null;
+
+async function resolveClientId(): Promise<string> {
+  if (runtimeClientId) return runtimeClientId;
+
+  try {
+    const localRes = await fetch('/api/runtime-config');
+    if (localRes.ok) {
+      const localData = (await localRes.json()) as {
+        oauth?: { google?: string };
+        trayWorkerBaseUrl?: string;
+      };
+      if (localData.oauth?.google) {
+        runtimeClientId = localData.oauth.google;
+        return runtimeClientId;
+      }
+      if (localData.trayWorkerBaseUrl) {
+        runtimeWorkerBaseUrl = localData.trayWorkerBaseUrl;
+        const workerRes = await fetch(`${localData.trayWorkerBaseUrl}/api/runtime-config`);
+        if (workerRes.ok) {
+          const workerData = (await workerRes.json()) as { oauth?: { google?: string } };
+          if (workerData.oauth?.google) {
+            runtimeClientId = workerData.oauth.google;
+            return runtimeClientId;
+          }
+        }
+      }
+    }
+  } catch {
+    // Network error — fall through to build-time config
+  }
+
+  return googleConfig.clientId;
+}
+
+// ── Runtime detection ──────────────────────────────────────────────
+
+const isExtension = typeof chrome !== 'undefined' && !!(chrome as any)?.runtime?.id;
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function getGoogleAccount() {
+  return getAccounts().find((a) => a.providerId === 'google');
+}
+
+/** Extract the authorization code from a redirect URL (?code=...). */
+function extractCodeFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.searchParams.get('code');
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch Google user profile (name + avatar). */
+async function fetchUserProfile(accessToken: string): Promise<{ name?: string; avatar?: string }> {
+  try {
+    const res = await fetch('https://www.googleapis.com/oauth2/v1/userinfo?alt=json', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (res.ok) {
+      const user = (await res.json()) as {
+        name?: string;
+        email?: string;
+        picture?: string;
+      };
+      return {
+        name: user.name || user.email,
+        avatar: user.picture,
+      };
+    }
+  } catch (err) {
+    console.warn(
+      '[google] Failed to fetch user profile:',
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+  return {};
+}
+
+// ── Token access ───────────────────────────────────────────────────
+
+async function getValidAccessToken(): Promise<string> {
+  const account = getGoogleAccount();
+  if (!account?.accessToken) throw new Error('Not logged in to Google — please log in first');
+
+  // Check expiry with 60s buffer
+  const expiresIn = (account.tokenExpiresAt ?? 0) - Date.now();
+  if (expiresIn > 60000) return account.accessToken;
+
+  // Token expired — Google issues refresh tokens, but refresh requires the
+  // client secret (server-side). For now, prompt re-login.
+  throw new Error('Google session expired — please log in again');
+}
+
+// ── Provider config ────────────────────────────────────────────────
+
+export const config: ProviderConfig = {
+  id: 'google',
+  name: 'Google Workspace',
+  description: 'Drive, Gmail, Calendar, Sheets — login with your Google account',
+  requiresApiKey: false,
+  requiresBaseUrl: false,
+  isOAuth: true,
+
+  onOAuthLogin: async (
+    launcher: OAuthLauncher,
+    onSuccess: () => void,
+    options?: OAuthLoginOptions
+  ) => {
+    const clientId = await resolveClientId();
+    if (!clientId) {
+      throw new Error('Google OAuth not configured — no client ID available');
+    }
+
+    // Google uses space-separated scopes
+    const scopes = options?.scopes ?? googleConfig.scopes;
+
+    const redirectUri = isExtension
+      ? `https://${(chrome as any).runtime.id}.chromiumapp.org/`
+      : `${runtimeWorkerBaseUrl ?? window.location.origin}/auth/callback`;
+
+    // Build OAuth state with port and CSRF nonce for the relay (CLI only)
+    const oauthState = !isExtension
+      ? btoa(
+          JSON.stringify({
+            port: parseInt(new URL(window.location.href).port || '5710', 10),
+            path: '/auth/callback',
+            nonce: crypto.randomUUID(),
+          })
+        )
+      : undefined;
+    const expectedNonce = oauthState ? JSON.parse(atob(oauthState)).nonce : null;
+
+    const params = new URLSearchParams({
+      client_id: clientId,
+      scope: scopes,
+      response_type: 'code',
+      redirect_uri: redirectUri,
+      access_type: 'offline', // Request refresh token
+      prompt: 'consent', // Force consent to get refresh token
+    });
+    if (oauthState) params.set('state', oauthState);
+    const authorizeUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
+
+    const redirectUrl = await launcher(authorizeUrl);
+    if (!redirectUrl) return;
+
+    // Verify CSRF nonce from relay callback
+    if (expectedNonce) {
+      try {
+        const callbackUrl = new URL(redirectUrl);
+        const receivedNonce = callbackUrl.searchParams.get('nonce');
+        if (receivedNonce !== expectedNonce) {
+          console.error('[google] OAuth nonce mismatch — possible CSRF');
+          return;
+        }
+      } catch (err) {
+        console.warn(
+          '[google] Nonce check skipped (URL parse failed):',
+          err instanceof Error ? err.message : String(err)
+        );
+      }
+    }
+
+    // Extract authorization code
+    const code = extractCodeFromUrl(redirectUrl);
+    if (!code) {
+      console.error('[google] Could not extract authorization code from redirect URL');
+      return;
+    }
+
+    // Exchange code for tokens via the generic OAuth broker
+    const tokenResult = await exchangeOAuthCode({
+      provider: 'google',
+      code,
+      redirectUri,
+    });
+
+    // Fetch user profile
+    const userProfile = await fetchUserProfile(tokenResult.access_token);
+
+    // Save account (Google returns expires_in in seconds)
+    saveOAuthAccount({
+      providerId: 'google',
+      accessToken: tokenResult.access_token,
+      refreshToken: tokenResult.refresh_token,
+      tokenExpiresAt: tokenResult.expires_in
+        ? Date.now() + tokenResult.expires_in * 1000
+        : undefined,
+      userName: userProfile.name,
+      userAvatar: userProfile.avatar,
+    });
+
+    onSuccess();
+  },
+
+  onOAuthLogout: async () => {
+    const account = getGoogleAccount();
+    if (account?.accessToken) {
+      await revokeOAuthToken({ provider: 'google', accessToken: account.accessToken }).catch(
+        (err) =>
+          console.warn(
+            '[google] Token revocation failed:',
+            err instanceof Error ? err.message : String(err)
+          )
+      );
+    }
+    saveOAuthAccount({ providerId: 'google', accessToken: '' });
+  },
+};
+
+export { getValidAccessToken };


### PR DESCRIPTION
## Summary

- Adds Google as the second provider in the generic OAuth token broker
- Uses one Google OAuth client for both staging and prod (multiple redirect URIs)
- Default scopes: Drive, Gmail, Calendar, Sheets, Docs
- Supports `--scope` override: `oauth-token google --scope "https://www.googleapis.com/auth/drive"`
- Requests refresh tokens (`access_type=offline`)

## Changes

- `oauth-registry.ts`: Google entry (token + revoke endpoints, RFC 7009 style)
- `packages/webapp/providers/google.ts`: Full provider with auth, profile fetch, token expiry
- `packages/webapp/providers/google-config.json`: Client ID + default scopes
- `wrangler.jsonc`: GOOGLE_CLIENT_ID in vars (both envs)
- CI workflows: GOOGLE_CLIENT_SECRET passed to Wrangler deploys

## Secrets configured

- Wrangler: GOOGLE_CLIENT_SECRET (staging + production)
- GitHub Actions: OAUTH_GOOGLE_WORKSPACE_SECRET

## Test plan

- [x] Worker tests pass (53/53)
- [x] Lint passes
- [ ] End-to-end: `oauth-token google` on localhost against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)