### PR TITLE
fix(server): hoist Keychain read above browser launch

### DIFF
--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -90,6 +90,15 @@ struct ServerCommand: AsyncParsableCommand {
         var browserLabel = config.electron ? "Electron" : "Chrome"
         var overlayInjector: ElectronOverlayInjector?
 
+        // Read the Keychain before launching the browser so the macOS ACL
+        // prompt appears in front of the still-focused terminal instead of
+        // stacking behind the new Chrome/Electron window. Post-#493 there
+        // is at most one prompt (single `__envfile__` blob), but it still
+        // pops on the first slicc-server run after Sliccstart wrote the
+        // blob, and SecretStore.all() is what triggers it.
+        let envFileSecrets: [Secret] = config.envFileURL.flatMap { Self.parseEnvFileSecrets(at: $0) } ?? []
+        let secretInjector = SecretInjector(sessionId: UUID().uuidString, envFileSecrets: envFileSecrets)
+
         if config.electron, !config.serveOnly {
             guard let electronApp = config.electronApp else {
                 throw ValidationError(
@@ -148,8 +157,6 @@ struct ServerCommand: AsyncParsableCommand {
                 logger: Logger(label: "slicc.static-files")
             )
         )
-        let envFileSecrets: [Secret] = config.envFileURL.flatMap { Self.parseEnvFileSecrets(at: $0) } ?? []
-        let secretInjector = SecretInjector(sessionId: UUID().uuidString, envFileSecrets: envFileSecrets)
         registerAPIRoutes(router: router, lickSystem: lickSystem, config: config, httpClient: httpClient, secretInjector: secretInjector)
 
         let wsRouter = Router(context: BasicWebSocketRequestContext.self)


### PR DESCRIPTION
## Summary

Move `SecretInjector` construction above the Chrome/Electron launch in `ServerCommand.swift` so the macOS Keychain ACL prompt appears in front of the still-focused terminal instead of stacking behind the new browser window.

## Context

After #493 collapsed the per-secret Keychain layout into a single `__envfile__` blob, there is at most one ACL prompt per signed-binary lifetime. But it still pops on the first `slicc-server` run after Sliccstart writes the blob, and `SecretStore.all()` is what triggers it. Currently `SecretInjector(sessionId:envFileSecrets:)` runs ~150ms after `ChromeLauncher.launch()` returns, so the dialog ends up behind the new Chrome window.

## Why this PR replaces #488

#488 was written against the pre-#493 world where every secret had its own Keychain item and a fresh `slicc-server` run could pop four stacked dialogs (one per `GWS_*` entry). #493 killed that scaling problem outright. This PR keeps only the residual single-prompt z-order fix:

- No `BrowserLaunchPlan` enum.
- No N-prompt rationale in the in-source comment.
- Drops the secondary `--electron`-without-`--electron-app` validation hoist (post-#493 the cost of that mistake is one wasted prompt, not four).

Net diff: +9 / -2 in one file.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 138/138 pass
- [ ] Manual: with a Sliccstart-written secret, run `slicc-server` from a fresh terminal and verify the Keychain dialog appears in front of the terminal, not behind Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)