### PR TITLE
fix(node): route fetch() through SecureFetch so secret injection works

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/node-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/node-command.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from 'just-bash';
 import type { Command } from 'just-bash';
+import { createNodeFetchAdapter } from './node-fetch-adapter.js';
 import { NODE_VERSION, NodeExitError, formatConsoleArg, nodeRuntimeState } from './shared.js';
 
 const NODE_BUILTINS_UNAVAILABLE = new Set([
@@ -181,6 +182,17 @@ export function createNodeCommand(): Command {
       const result = await ctx.exec(command, { cwd: ctx.cwd });
       return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
     };
+
+    // Build a `fetch` shim that routes through the same proxied SecureFetch
+    // the curl shim uses (i.e. /api/fetch-proxy in CLI mode), so masked
+    // secret values are substituted server-side and domain allow-listing is
+    // enforced. Without this, `fetch` inside `node -e` would resolve to the
+    // browser's native global and bypass secret injection — leading to
+    // upstream APIs receiving the literal masked value (e.g. `e5be41af...`)
+    // and rejecting it with `invalid_client` / 401 / 403.
+    const nodeFetch: typeof globalThis.fetch = ctx.fetch
+      ? createNodeFetchAdapter(ctx.fetch)
+      : globalThis.fetch.bind(globalThis);
 
     const isExtensionMode = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
 
@@ -554,7 +566,8 @@ export function createNodeCommand(): Command {
         module: typeof moduleShim,
         exports: Record<string, unknown>,
         __state: Record<string, unknown>,
-        exec: typeof execBridge
+        exec: typeof execBridge,
+        fetch: typeof globalThis.fetch
       ) => Promise<unknown>;
       const fn = new AsyncFunction(
         'fs',
@@ -565,6 +578,7 @@ export function createNodeCommand(): Command {
         'exports',
         '__state',
         'exec',
+        'fetch',
         `"use strict";\nconst globalThis = __state;\nconst global = __state;\n${code}`
       );
       await fn(
@@ -575,7 +589,8 @@ export function createNodeCommand(): Command {
         moduleShim,
         moduleShim.exports,
         nodeRuntimeState,
-        execBridge
+        execBridge,
+        nodeFetch
       );
       return {
         stdout: stdoutChunks.join(''),

--- a/packages/webapp/src/shell/supplemental-commands/node-fetch-adapter.ts
+++ b/packages/webapp/src/shell/supplemental-commands/node-fetch-adapter.ts
@@ -23,13 +23,58 @@ import type { SecureFetch } from 'just-bash';
  * Build a `globalThis.fetch`-shaped function from a just-bash `SecureFetch`.
  * The returned function returns a real `Response` instance so callers can
  * use `.ok`, `.json()`, `.text()`, `.arrayBuffer()`, `.headers`, etc.
+ *
+ * Faithfully implements the `fetch(input, init?)` contract:
+ *
+ * - When `input` is a `Request`, its method, headers, and body are read from
+ *   the Request and used as defaults; any field also present in `init`
+ *   overrides the Request's value (matching the browser's behavior).
+ * - `URLSearchParams` bodies cause `Content-Type:
+ *   application/x-www-form-urlencoded;charset=UTF-8` to be set automatically
+ *   when no Content-Type was provided — this is what real `fetch` does and
+ *   is required for OAuth token endpoints (otherwise Google rejects the
+ *   request because the body is treated as `text/plain`).
  */
 export function createNodeFetchAdapter(secureFetch: SecureFetch): typeof globalThis.fetch {
   return async function nodeFetch(input, init) {
+    const request = input instanceof Request ? input : null;
+
     const url = resolveUrl(input);
-    const method = (init?.method ?? 'GET').toUpperCase();
-    const headers = headersToRecord(init?.headers);
-    const body = encodeBody(init?.body, method);
+    const method = (init?.method ?? request?.method ?? 'GET').toUpperCase();
+
+    // Headers: start with the Request's headers (if any), then layer init.headers
+    // on top so explicit init values win — mirroring the browser fetch spec.
+    const headers = mergeHeaders(request?.headers, init?.headers);
+
+    // Body: prefer init.body when explicitly provided. When init.body is
+    // omitted but a Request was passed, read the Request's body so prebuilt
+    // Request objects with auth bodies still go through the proxy intact.
+    let body: string | undefined;
+    let bodyForContentType: BodyInit | null | undefined;
+    if (init && 'body' in init && init.body !== undefined) {
+      body = encodeBody(init.body, method);
+      bodyForContentType = init.body;
+    } else if (request && method !== 'GET' && method !== 'HEAD') {
+      const buf = await request.arrayBuffer();
+      body =
+        buf.byteLength === 0 ? undefined : new TextDecoder('utf-8').decode(new Uint8Array(buf));
+      bodyForContentType = undefined; // Content-Type already on request.headers
+    } else {
+      body = undefined;
+      bodyForContentType = undefined;
+    }
+
+    // Real fetch sets `Content-Type: application/x-www-form-urlencoded;
+    // charset=UTF-8` automatically when the body is a URLSearchParams and no
+    // Content-Type is explicitly set. Without this, OAuth token POSTs land
+    // with the wrong Content-Type and get rejected with `invalid_request`.
+    if (
+      bodyForContentType instanceof URLSearchParams &&
+      headers &&
+      !hasHeader(headers, 'content-type')
+    ) {
+      headers['Content-Type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
+    }
 
     const result = await secureFetch(url, {
       method,
@@ -47,8 +92,12 @@ export function createNodeFetchAdapter(secureFetch: SecureFetch): typeof globalT
       }
     }
 
-    // Response body must be null when the response cannot have a body
-    // (status 1xx/204/205/304) — otherwise the constructor throws.
+    // Response body must be null for 204/205/304 — the constructor rejects
+    // a body otherwise. (Note: 1xx informational responses can't be modeled
+    // by the Response constructor at all — `init.status must be in the
+    // range of 200 to 599`. They never surface here because HTTP libraries
+    // consume them transparently before the fetch resolves; we therefore
+    // do not special-case 1xx and would re-throw the constructor error.)
     const noBodyStatus = result.status === 204 || result.status === 205 || result.status === 304;
     // Uint8Array is a valid BodyInit at runtime, but the lib.dom.d.ts
     // shipped with TypeScript narrows BodyInit to a set that does not
@@ -108,6 +157,40 @@ function headersToRecord(headers?: HeadersInit): Record<string, string> | undefi
 }
 
 /**
+ * Merge a `Request`'s headers (if any) with explicit `init.headers`, with
+ * init winning on conflicts — matches how the browser's fetch combines a
+ * `Request` input with an `init` argument. Always returns an object so we
+ * can attach an auto-Content-Type later if the body is `URLSearchParams`.
+ */
+function mergeHeaders(
+  requestHeaders: Headers | undefined,
+  initHeaders: HeadersInit | undefined
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  if (requestHeaders) {
+    requestHeaders.forEach((v, k) => {
+      merged[k] = v;
+    });
+  }
+  const initRec = headersToRecord(initHeaders);
+  if (initRec) {
+    for (const [k, v] of Object.entries(initRec)) {
+      merged[k] = v;
+    }
+  }
+  return merged;
+}
+
+/** Case-insensitive presence check for a header name in a record. */
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  const lower = name.toLowerCase();
+  for (const k of Object.keys(headers)) {
+    if (k.toLowerCase() === lower) return true;
+  }
+  return false;
+}
+
+/**
  * SecureFetch's body type is `string | undefined`, so we coerce common
  * BodyInit shapes (URLSearchParams, ArrayBuffer, typed arrays) into a
  * string. Streaming bodies (Blob, FormData, ReadableStream) throw — they
@@ -138,6 +221,15 @@ function encodeBody(body: BodyInit | null | undefined, method: string): string |
       'node fetch shim: FormData request bodies are not supported (post raw application/x-www-form-urlencoded with URLSearchParams instead)'
     );
   }
-  // ReadableStream and other exotics — let String() do its best.
-  return String(body);
+  if (typeof ReadableStream !== 'undefined' && body instanceof ReadableStream) {
+    throw new Error(
+      'node fetch shim: ReadableStream request bodies are not supported (collect into a Uint8Array or string before calling fetch)'
+    );
+  }
+  // Anything else (a non-string non-typed-array object) is unsupported —
+  // refuse explicitly instead of silently sending "[object Foo]" through
+  // the proxy, which would never match an upstream API contract.
+  throw new Error(
+    `node fetch shim: unsupported request body type (${Object.prototype.toString.call(body)}); use a string, Uint8Array, ArrayBuffer, or URLSearchParams`
+  );
 }

--- a/packages/webapp/src/shell/supplemental-commands/node-fetch-adapter.ts
+++ b/packages/webapp/src/shell/supplemental-commands/node-fetch-adapter.ts
@@ -1,0 +1,143 @@
+/**
+ * Adapt the just-bash `SecureFetch` (which is what the curl shim uses to route
+ * outbound requests through the CLI server's `/api/fetch-proxy` endpoint, with
+ * masked-secret -> real-secret injection) into a function that satisfies the
+ * Web Fetch API contract — i.e. `(input, init) => Promise<Response>`.
+ *
+ * Without this adapter, `node -e "fetch(...)"` resolves `fetch` to the
+ * browser's native global, which:
+ *   1. Bypasses `/api/fetch-proxy` entirely, so masked secret values
+ *      (e.g. the `e5be41af...` placeholders the GWS skill receives) are
+ *      sent to upstream APIs literally and rejected with `invalid_client`
+ *      / 401 / 403 etc.
+ *   2. Is subject to browser CORS rules from the slicc page origin.
+ *
+ * Wrapping `ctx.fetch` here keeps node `fetch()` on the same proxied path
+ * as `curl`, so secret injection, domain allow-listing, and the
+ * `X-Proxy-Error` marker all apply.
+ */
+
+import type { SecureFetch } from 'just-bash';
+
+/**
+ * Build a `globalThis.fetch`-shaped function from a just-bash `SecureFetch`.
+ * The returned function returns a real `Response` instance so callers can
+ * use `.ok`, `.json()`, `.text()`, `.arrayBuffer()`, `.headers`, etc.
+ */
+export function createNodeFetchAdapter(secureFetch: SecureFetch): typeof globalThis.fetch {
+  return async function nodeFetch(input, init) {
+    const url = resolveUrl(input);
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const headers = headersToRecord(init?.headers);
+    const body = encodeBody(init?.body, method);
+
+    const result = await secureFetch(url, {
+      method,
+      headers,
+      body,
+    });
+
+    const responseHeaders = new Headers();
+    for (const [k, v] of Object.entries(result.headers)) {
+      // Skip headers Response constructor refuses (rare).
+      try {
+        responseHeaders.set(k, v);
+      } catch {
+        // ignore unsettable header
+      }
+    }
+
+    // Response body must be null when the response cannot have a body
+    // (status 1xx/204/205/304) — otherwise the constructor throws.
+    const noBodyStatus = result.status === 204 || result.status === 205 || result.status === 304;
+    // Uint8Array is a valid BodyInit at runtime, but the lib.dom.d.ts
+    // shipped with TypeScript narrows BodyInit to a set that does not
+    // include Uint8Array<ArrayBufferLike>; cast through BodyInit to
+    // satisfy the compiler without copying the bytes.
+    const responseBody: BodyInit | null =
+      noBodyStatus || !result.body || result.body.byteLength === 0
+        ? null
+        : (result.body as unknown as BodyInit);
+
+    const response = new Response(responseBody, {
+      status: result.status,
+      statusText: result.statusText,
+      headers: responseHeaders,
+    });
+
+    // The `Response` constructor does not allow setting the `url` field —
+    // expose the upstream URL via defineProperty so `response.url` matches
+    // what real fetch would return. Some runtimes lock the property; if
+    // so, fall through silently and `response.url` stays "".
+    try {
+      Object.defineProperty(response, 'url', {
+        value: result.url || url,
+        writable: false,
+        configurable: true,
+        enumerable: false,
+      });
+    } catch {
+      // ignore — non-fatal
+    }
+
+    return response;
+  };
+}
+
+function resolveUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+function headersToRecord(headers?: HeadersInit): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) {
+    const rec: Record<string, string> = {};
+    headers.forEach((v, k) => {
+      rec[k] = v;
+    });
+    return rec;
+  }
+  if (Array.isArray(headers)) {
+    const rec: Record<string, string> = {};
+    for (const [k, v] of headers) rec[k] = v;
+    return rec;
+  }
+  return { ...(headers as Record<string, string>) };
+}
+
+/**
+ * SecureFetch's body type is `string | undefined`, so we coerce common
+ * BodyInit shapes (URLSearchParams, ArrayBuffer, typed arrays) into a
+ * string. Streaming bodies (Blob, FormData, ReadableStream) throw — they
+ * aren't compatible with the proxy contract on the wire today.
+ */
+function encodeBody(body: BodyInit | null | undefined, method: string): string | undefined {
+  if (body == null) return undefined;
+  if (method === 'GET' || method === 'HEAD') return undefined;
+  if (typeof body === 'string') return body;
+  if (body instanceof URLSearchParams) return body.toString();
+  if (body instanceof Uint8Array) return new TextDecoder('utf-8').decode(body);
+  if (body instanceof ArrayBuffer) {
+    return new TextDecoder('utf-8').decode(new Uint8Array(body));
+  }
+  if (ArrayBuffer.isView(body)) {
+    const view = body as ArrayBufferView;
+    return new TextDecoder('utf-8').decode(
+      new Uint8Array(view.buffer, view.byteOffset, view.byteLength)
+    );
+  }
+  if (typeof Blob !== 'undefined' && body instanceof Blob) {
+    throw new Error(
+      'node fetch shim: Blob request bodies are not supported (use a string, Uint8Array, or URLSearchParams)'
+    );
+  }
+  if (typeof FormData !== 'undefined' && body instanceof FormData) {
+    throw new Error(
+      'node fetch shim: FormData request bodies are not supported (post raw application/x-www-form-urlencoded with URLSearchParams instead)'
+    );
+  }
+  // ReadableStream and other exotics — let String() do its best.
+  return String(body);
+}

--- a/packages/webapp/tests/shell/node-fetch-adapter.test.ts
+++ b/packages/webapp/tests/shell/node-fetch-adapter.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SecureFetch } from 'just-bash';
+import { createNodeFetchAdapter } from '../../src/shell/supplemental-commands/node-fetch-adapter.js';
+
+const okResult = (
+  overrides: Partial<{
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    body: Uint8Array;
+    url: string;
+  }> = {}
+) => ({
+  status: overrides.status ?? 200,
+  statusText: overrides.statusText ?? 'OK',
+  headers: overrides.headers ?? { 'content-type': 'application/json' },
+  body: overrides.body ?? new TextEncoder().encode('{"ok":true}'),
+  url: overrides.url ?? 'https://api.example.com/x',
+});
+
+describe('createNodeFetchAdapter', () => {
+  it('routes through SecureFetch with the given URL string', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const resp = await fetch('https://oauth2.googleapis.com/token');
+
+    expect(secureFetch).toHaveBeenCalledTimes(1);
+    expect((secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      'https://oauth2.googleapis.com/token'
+    );
+    expect(resp.status).toBe(200);
+    expect(resp.ok).toBe(true);
+  });
+
+  it('serializes URL objects to string', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    await fetch(new URL('https://api.example.com/path'));
+
+    expect((secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      'https://api.example.com/path'
+    );
+  });
+
+  it('passes method and headers to SecureFetch', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    await fetch('https://api.example.com/x', {
+      method: 'post',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer x' },
+    });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      method: string;
+      headers: Record<string, string>;
+    };
+    expect(opts.method).toBe('POST');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+    expect(opts.headers['Authorization']).toBe('Bearer x');
+  });
+
+  it('converts Headers instance to a plain record', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const h = new Headers();
+    h.set('X-Custom', 'value');
+    h.set('Accept', 'application/json');
+    await fetch('https://api.example.com/x', { method: 'GET', headers: h });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    expect(opts.headers['x-custom']).toBe('value');
+    expect(opts.headers['accept']).toBe('application/json');
+  });
+
+  it('converts header tuples array to a record', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    await fetch('https://api.example.com/x', {
+      method: 'POST',
+      headers: [
+        ['X-A', '1'],
+        ['X-B', '2'],
+      ],
+    });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    expect(opts.headers['X-A']).toBe('1');
+    expect(opts.headers['X-B']).toBe('2');
+  });
+
+  it('passes string body through verbatim', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    await fetch('https://api.example.com/x', {
+      method: 'POST',
+      body: '{"a":1}',
+    });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as { body: string };
+    expect(opts.body).toBe('{"a":1}');
+  });
+
+  it('serializes URLSearchParams body to a urlencoded string', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const params = new URLSearchParams();
+    params.set('grant_type', 'refresh_token');
+    params.set('client_id', 'GWS_CLIENT_ID_MASKED');
+    await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      body: params,
+    });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as { body: string };
+    expect(opts.body).toBe('grant_type=refresh_token&client_id=GWS_CLIENT_ID_MASKED');
+  });
+
+  it('decodes Uint8Array body as UTF-8 text', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const bytes = new TextEncoder().encode('hello body');
+    await fetch('https://api.example.com/x', { method: 'POST', body: bytes });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as { body: string };
+    expect(opts.body).toBe('hello body');
+  });
+
+  it('strips bodies on GET / HEAD per fetch semantics', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    await fetch('https://api.example.com/x', { method: 'GET', body: 'should be dropped' });
+    await fetch('https://api.example.com/x', { method: 'HEAD', body: 'should be dropped' });
+
+    const calls = (secureFetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0][1].body).toBeUndefined();
+    expect(calls[1][1].body).toBeUndefined();
+  });
+
+  it('returns a real Response with status, statusText, and JSON body', async () => {
+    const body = new TextEncoder().encode('{"foo":"bar"}');
+    const secureFetch: SecureFetch = vi.fn(async () =>
+      okResult({ status: 201, statusText: 'Created', body })
+    );
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const resp = await fetch('https://api.example.com/x');
+
+    expect(resp.status).toBe(201);
+    expect(resp.statusText).toBe('Created');
+    expect(resp.ok).toBe(true);
+    expect(await resp.json()).toEqual({ foo: 'bar' });
+  });
+
+  it('exposes upstream response headers via Response.headers', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () =>
+      okResult({
+        headers: { 'content-type': 'text/plain', 'x-rate-limit': '99' },
+      })
+    );
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const resp = await fetch('https://api.example.com/x');
+
+    expect(resp.headers.get('content-type')).toBe('text/plain');
+    expect(resp.headers.get('x-rate-limit')).toBe('99');
+  });
+
+  it('lets upstream 4xx flow through with ok=false (non-throwing)', async () => {
+    const errBody = new TextEncoder().encode('{"error":"invalid_client"}');
+    const secureFetch: SecureFetch = vi.fn(async () =>
+      okResult({ status: 401, statusText: 'Unauthorized', body: errBody })
+    );
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const resp = await fetch('https://oauth2.googleapis.com/token', { method: 'POST' });
+
+    expect(resp.status).toBe(401);
+    expect(resp.ok).toBe(false);
+    expect(await resp.text()).toBe('{"error":"invalid_client"}');
+  });
+
+  it('uses null body for 204 responses (Response constructor invariant)', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () =>
+      okResult({ status: 204, statusText: 'No Content', body: new Uint8Array() })
+    );
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const resp = await fetch('https://api.example.com/x');
+
+    expect(resp.status).toBe(204);
+    // Reading body should resolve cleanly (empty).
+    expect(await resp.text()).toBe('');
+  });
+
+  it('rejects Blob and FormData bodies with a clear message', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    await expect(
+      fetch('https://api.example.com/x', { method: 'POST', body: new Blob(['x']) })
+    ).rejects.toThrow(/Blob request bodies are not supported/);
+
+    const fd = new FormData();
+    fd.set('a', 'b');
+    await expect(fetch('https://api.example.com/x', { method: 'POST', body: fd })).rejects.toThrow(
+      /FormData request bodies are not supported/
+    );
+  });
+
+  it('exposes the upstream URL on Response.url', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () =>
+      okResult({ url: 'https://api.example.com/x' })
+    );
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const resp = await fetch('https://api.example.com/x');
+    expect(resp.url).toBe('https://api.example.com/x');
+  });
+});

--- a/packages/webapp/tests/shell/node-fetch-adapter.test.ts
+++ b/packages/webapp/tests/shell/node-fetch-adapter.test.ts
@@ -229,4 +229,132 @@ describe('createNodeFetchAdapter', () => {
     const resp = await fetch('https://api.example.com/x');
     expect(resp.url).toBe('https://api.example.com/x');
   });
+
+  it('uses URL, method, headers, and body from a Request input', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const request = new Request('https://api.example.com/request', {
+      method: 'patch',
+      headers: {
+        'Content-Type': 'text/plain',
+        Authorization: 'Bearer from-request',
+      },
+      body: 'from-request-body',
+    });
+
+    await fetch(request);
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      method: string;
+      headers: Record<string, string>;
+      body?: string;
+    };
+    expect((secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      'https://api.example.com/request'
+    );
+    expect(opts.method).toBe('PATCH');
+    expect(opts.headers['content-type']).toBe('text/plain');
+    expect(opts.headers['authorization']).toBe('Bearer from-request');
+    expect(opts.body).toBe('from-request-body');
+  });
+
+  it('lets init override method, headers, and body from a Request input', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const request = new Request('https://api.example.com/request', {
+      method: 'patch',
+      headers: {
+        'Content-Type': 'text/plain',
+        Authorization: 'Bearer from-request',
+      },
+      body: 'from-request-body',
+    });
+
+    await fetch(request, {
+      method: 'post',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer from-init' },
+      body: '{"from":"init"}',
+    });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      method: string;
+      headers: Record<string, string>;
+      body?: string;
+    };
+    expect(opts.method).toBe('POST');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+    expect(opts.headers['Authorization']).toBe('Bearer from-init');
+    expect(opts.body).toBe('{"from":"init"}');
+  });
+
+  it('auto-sets Content-Type for URLSearchParams bodies (matches native fetch)', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const params = new URLSearchParams();
+    params.set('grant_type', 'refresh_token');
+    await fetch('https://oauth2.googleapis.com/token', { method: 'POST', body: params });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    expect(opts.headers['Content-Type']).toBe('application/x-www-form-urlencoded;charset=UTF-8');
+  });
+
+  it('does not override an explicit Content-Type when body is URLSearchParams', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'refresh_token' }),
+    });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    expect(opts.headers['content-type']).toBe('application/x-www-form-urlencoded');
+    // Should not also have a 'Content-Type' (different case) — the explicit
+    // header is preserved as-is.
+    expect(opts.headers['Content-Type']).toBeUndefined();
+  });
+
+  it('rejects ReadableStream request bodies with a clear message', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('hi'));
+        controller.close();
+      },
+    });
+
+    await expect(
+      // The native Request type for body when streaming requires an extra
+      // option in some environments; we cast to BodyInit so the test
+      // exercises the adapter's runtime check.
+      fetch('https://api.example.com/x', {
+        method: 'POST',
+        body: stream as unknown as BodyInit,
+        // @ts-expect-error duplex is required for stream bodies in some envs
+        duplex: 'half',
+      })
+    ).rejects.toThrow(/ReadableStream request bodies are not supported/);
+  });
+
+  it('rejects unknown body shapes instead of stringifying them', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    await expect(
+      fetch('https://api.example.com/x', {
+        method: 'POST',
+        body: { foo: 'bar' } as unknown as BodyInit,
+      })
+    ).rejects.toThrow(/unsupported request body type/);
+  });
 });


### PR DESCRIPTION
## Problem

`fetch()` inside `node -e "..."` (the just-bash node shim) resolves to **`globalThis.fetch`** — the browser's native global. That bypasses `/api/fetch-proxy` entirely, so:

1. **Masked secret values are sent verbatim.** The GWS skill (and any skill pulling from `/api/secrets/masked`) hands the model placeholders like `e5be41af...`. When the model writes `fetch('https://oauth2.googleapis.com/token', { body: 'client_id=' + GWS_CLIENT_ID })`, the proxy never sees the request, so the server-side substitution never happens. Google rejects with `invalid_client`.
2. **CORS rules apply.** Cross-origin requests from `http://localhost:5710` are governed by the upstream's CORS policy instead of the proxy's allow-list.
3. **No `X-Proxy-Error` handling.** Upstream 4xx error bodies (`{error: {message: ...}}`) are not run through `isProxyError` / `readProxyErrorMessage` from #487.

`curl` does not have this problem because the curl shim uses `ctx.fetch` — the just-bash `SecureFetch` that `WasmShell` wires to `/api/fetch-proxy` (where the `SecretInjector` does masked → real value substitution).

## Fix

Mirror the curl path for node:

1. New `packages/webapp/src/shell/supplemental-commands/node-fetch-adapter.ts` — wraps a `SecureFetch` into a Web Fetch API-shaped function. Returns a real `Response` so `resp.ok`, `resp.json()`, `resp.text()`, `resp.headers` all work as callers expect.
2. `node-command.ts` builds the adapter from `ctx.fetch` and passes it as a `fetch` parameter to the `AsyncFunction` that evaluates user code, shadowing the global `fetch` identifier inside the script body.

## Scope

CLI mode only. Extension-mode (sandboxed iframe via `fetch_proxy` postMessage) is a separate concern — its host handler currently calls `fetch(msg.url, init)` directly, which has the same problem but different security envelope (host_permissions). That migration is straightforward but better as its own PR.

## Tests

15 unit tests for `createNodeFetchAdapter` covering URL/header/body shapes, GET/HEAD body stripping, 4xx flow-through, 204 invariant, and Blob/FormData rejection. `npm run typecheck` clean.

🤖 Generated with [Factory](https://factory.ai)