### PR TITLE
feat(chat): attach images and files; off-load oversized attachments to /tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ SLICC is for you if:
 - **Automate repetitive workflows in authenticated web apps.** Use browser automation, page inspection, screenshots, storage access, and scripted tab control where your logged-in browser session already has the context.
 - **Hand work off from another coding agent into your live browser session.** Open any URL whose response carries an `x-slicc` header (the tray-hub `/handoff?msg=...` endpoint is a convenience) and SLICC prompts you to approve the action inside the Chat tab.
 - **Solve technical tasks with practical tools.** Reach for `bash`, `git`, `grep`, `node`, `python`, previews, and browser automation when the job is bigger than text generation.
+- **Add visual and file context directly in chat.** Drop images or files onto the workspace, or use the paperclip button. Dropped `.skill` archives still install into `/workspace/skills`.
 - **Delegate parallel work to scoops.** Split tasks into isolated sub-agents with their own sandboxes and context, then let the main agent coordinate the results.
 - **Turn one-off wins into reusable workflows.** Package behavior as skills, build interactive sprinkles, and react to external events with webhooks and cron-driven licks.
 - **Mount your local file system.** By default, SLICC is confined to your browser. But you can ask it to mount folders from your local file system, so it can read and write from there. Mount into an empty path such as `/mnt/myproject` so you do not hide existing skills or scripts.

--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ScoopTabState } from './types.js';
+import type { MessageAttachment } from '../../webapp/src/core/attachments.js';
 
 // ---------------------------------------------------------------------------
 // Side Panel → Offscreen (via service worker relay)
@@ -16,6 +17,7 @@ export interface UserMessageMsg {
   scoopJid: string;
   text: string;
   messageId: string;
+  attachments?: MessageAttachment[];
 }
 
 /**
@@ -192,6 +194,7 @@ export interface IncomingMessageMsg {
   message: {
     id: string;
     content: string;
+    attachments?: MessageAttachment[];
     channel: string;
     senderName: string;
     fromAssistant: boolean;

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -31,6 +31,7 @@ import type {
 import { SessionStore } from '../../../packages/webapp/src/ui/session-store.js';
 import { toolUIRegistry } from '../../../packages/webapp/src/tools/tool-ui.js';
 import type { ChatMessage } from '../../../packages/webapp/src/ui/types.js';
+import type { MessageAttachment } from '../../../packages/webapp/src/core/attachments.js';
 import type { BrowserAPI } from '../../../packages/webapp/src/cdp/index.js';
 
 /** Buffered message for state sync */
@@ -38,6 +39,7 @@ interface BufferedChatMessage {
   id: string;
   role: 'user' | 'assistant';
   content: string;
+  attachments?: MessageAttachment[];
   timestamp: number;
   source?: string;
   channel?: string;
@@ -241,6 +243,7 @@ export class OffscreenBridge {
             message.channel === 'delegation'
               ? `**[Instructions from sliccy]**\n\n${message.content}`
               : message.content,
+          attachments: message.attachments,
           timestamp: new Date(message.timestamp).getTime(),
           source: message.channel === 'delegation' ? 'delegation' : undefined,
           channel: message.channel,
@@ -254,6 +257,7 @@ export class OffscreenBridge {
           message: {
             id: message.id,
             content: message.content,
+            attachments: message.attachments,
             channel: message.channel,
             senderName: message.senderName,
             fromAssistant: message.fromAssistant,
@@ -395,6 +399,7 @@ export class OffscreenBridge {
           senderId: 'user',
           senderName: 'User',
           content: msg.text,
+          attachments: msg.attachments,
           timestamp: new Date().toISOString(),
           fromAssistant: false,
           channel: 'web',
@@ -403,6 +408,7 @@ export class OffscreenBridge {
           id: msg.messageId,
           role: 'user',
           content: msg.text,
+          attachments: msg.attachments,
           timestamp: Date.now(),
         });
         this.persistScoop(msg.scoopJid);

--- a/packages/webapp/src/core/attachments.ts
+++ b/packages/webapp/src/core/attachments.ts
@@ -1,0 +1,79 @@
+import type { ImageContent } from '@mariozechner/pi-ai';
+
+export type MessageAttachmentKind = 'image' | 'text' | 'file';
+
+export interface MessageAttachment {
+  id: string;
+  name: string;
+  mimeType: string;
+  size: number;
+  kind: MessageAttachmentKind;
+  /** Base64 payload for LLM-supported image attachments. */
+  data?: string;
+  /** UTF-8 content for text-like file attachments. */
+  text?: string;
+  /** Human-readable reason when the payload could not be included. */
+  error?: string;
+}
+
+export function formatAttachmentSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  const rounded = value >= 10 || unitIndex === 0 ? Math.round(value) : Math.round(value * 10) / 10;
+  return `${rounded} ${units[unitIndex]}`;
+}
+
+export function formatAttachmentSummary(attachment: MessageAttachment): string {
+  const mime = attachment.mimeType || 'application/octet-stream';
+  return `${attachment.name} (${mime}, ${formatAttachmentSize(attachment.size)})`;
+}
+
+export function formatAttachmentForPrompt(attachment: MessageAttachment): string {
+  const summary = formatAttachmentSummary(attachment);
+  if (attachment.kind === 'image' && attachment.data) {
+    return `[Attached image: ${summary}]`;
+  }
+
+  if (attachment.kind === 'text' && attachment.text !== undefined) {
+    return [
+      `----- BEGIN ATTACHMENT ${summary} -----`,
+      attachment.text,
+      `----- END ATTACHMENT ${attachment.name} -----`,
+    ].join('\n');
+  }
+
+  if (attachment.error) {
+    return `[Attachment not included: ${summary}. ${attachment.error}]`;
+  }
+
+  return `[Attachment not included: ${summary}. Unsupported binary attachment.]`;
+}
+
+export function formatPromptWithAttachments(
+  text: string,
+  attachments: readonly MessageAttachment[] | undefined
+): string {
+  if (!attachments?.length) return text;
+  const blocks = attachments.map(formatAttachmentForPrompt);
+  const trimmed = text.trim();
+  return trimmed ? `${trimmed}\n\n${blocks.join('\n\n')}` : blocks.join('\n\n');
+}
+
+export function imageContentFromAttachments(
+  attachments: readonly MessageAttachment[] | undefined
+): ImageContent[] {
+  if (!attachments?.length) return [];
+  return attachments
+    .filter((attachment) => attachment.kind === 'image' && attachment.data)
+    .map((attachment) => ({
+      type: 'image' as const,
+      data: attachment.data!,
+      mimeType: attachment.mimeType,
+    }));
+}

--- a/packages/webapp/src/core/attachments.ts
+++ b/packages/webapp/src/core/attachments.ts
@@ -12,6 +12,12 @@ export interface MessageAttachment {
   data?: string;
   /** UTF-8 content for text-like file attachments. */
   text?: string;
+  /**
+   * VFS path (e.g. `/tmp/attachment-…`) when the file was persisted to the
+   * virtual filesystem because it was too large to inline. The agent can
+   * `read_file`/`bash cat` this path to access the full content.
+   */
+  path?: string;
   /** Human-readable reason when the payload could not be included. */
   error?: string;
 }
@@ -46,6 +52,12 @@ export function formatAttachmentForPrompt(attachment: MessageAttachment): string
       attachment.text,
       `----- END ATTACHMENT ${attachment.name} -----`,
     ].join('\n');
+  }
+
+  if (attachment.path) {
+    const kindLabel =
+      attachment.kind === 'image' ? 'image' : attachment.kind === 'text' ? 'text file' : 'file';
+    return `[Attached ${kindLabel} saved to ${attachment.path} — ${summary}. Read it from the virtual filesystem when you need its contents.]`;
   }
 
   if (attachment.error) {

--- a/packages/webapp/src/core/attachments.ts
+++ b/packages/webapp/src/core/attachments.ts
@@ -89,3 +89,30 @@ export function imageContentFromAttachments(
       mimeType: attachment.mimeType,
     }));
 }
+
+/**
+ * Strip `path` from attachments before they cross a runtime boundary
+ * (typically tray follower → leader). The path was generated against
+ * the sender's VFS and is meaningless on the receiver — keeping it
+ * would mislead the agent into trying to read a non-existent file.
+ *
+ * Attachments that still carry inline `data`/`text` keep their content
+ * and lose only the path. Path-only attachments are demoted to a
+ * `not-included` placeholder with an explanatory error so the prompt
+ * accurately reflects what the agent can and cannot reach.
+ */
+export function stripLocalPathsForRemote(
+  attachments: readonly MessageAttachment[] | undefined,
+  reason = 'The original file lives on a remote runtime and is not accessible here.'
+): MessageAttachment[] {
+  if (!attachments?.length) return [];
+  return attachments.map((attachment) => {
+    if (!attachment.path) return { ...attachment };
+    const { path: _omitted, ...rest } = attachment;
+    const hasInline =
+      (attachment.kind === 'image' && !!attachment.data) ||
+      (attachment.kind === 'text' && attachment.text !== undefined);
+    if (hasInline) return rest;
+    return { ...rest, error: rest.error ?? reason };
+  });
+}

--- a/packages/webapp/src/core/index.ts
+++ b/packages/webapp/src/core/index.ts
@@ -53,6 +53,14 @@ export type { Logger } from './logger.js';
 export { compactContext, createCompactContext } from './context-compaction.js';
 export type { CompactionConfig } from './context-compaction.js';
 export { getMimeType } from './mime-types.js';
+export {
+  formatAttachmentForPrompt,
+  formatAttachmentSize,
+  formatAttachmentSummary,
+  formatPromptWithAttachments,
+  imageContentFromAttachments,
+} from './attachments.js';
+export type { MessageAttachment, MessageAttachmentKind } from './attachments.js';
 
 // Local types
 export type {

--- a/packages/webapp/src/core/index.ts
+++ b/packages/webapp/src/core/index.ts
@@ -59,6 +59,7 @@ export {
   formatAttachmentSummary,
   formatPromptWithAttachments,
   imageContentFromAttachments,
+  stripLocalPathsForRemote,
 } from './attachments.js';
 export type { MessageAttachment, MessageAttachmentKind } from './attachments.js';
 

--- a/packages/webapp/src/scoops/llm-session-id.ts
+++ b/packages/webapp/src/scoops/llm-session-id.ts
@@ -29,7 +29,15 @@ function todayUtc(): string {
 
 function safeLocalStorage(): Storage | null {
   try {
-    return globalThis.localStorage ?? null;
+    const storage = globalThis.localStorage;
+    if (
+      !storage ||
+      typeof storage.getItem !== 'function' ||
+      typeof storage.setItem !== 'function'
+    ) {
+      return null;
+    }
+    return storage;
   } catch {
     return null;
   }
@@ -41,7 +49,12 @@ function getDailyUuid(coneJid: string): string {
   const key = DAILY_UUID_KEY_PREFIX + coneJid;
 
   if (storage) {
-    const raw = storage.getItem(key);
+    let raw: string | null = null;
+    try {
+      raw = storage.getItem(key);
+    } catch {
+      raw = null;
+    }
     if (raw) {
       try {
         const parsed = JSON.parse(raw) as { uuid?: string; date?: string };

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -26,12 +26,13 @@ import type { BrowserAPI } from '../cdp/index.js';
 import { createDefaultSharedFiles, createDefaultSkills } from './skills.js';
 import { buildActiveLicksError, type LickManager } from './lick-manager.js';
 import { SessionStore } from '../core/session.js';
+import { formatPromptWithAttachments, imageContentFromAttachments } from '../core/attachments.js';
 import { trackChatSend } from '../ui/telemetry.js';
 import {
   registerSessionCostsProvider,
   type ScoopCostData,
 } from '../shell/supplemental-commands/cost-command.js';
-import type { AssistantMessage } from '../core/types.js';
+import type { AssistantMessage, ImageContent } from '../core/types.js';
 
 const log = createLogger('orchestrator');
 
@@ -1509,7 +1510,13 @@ export class Orchestrator {
   }
 
   /** Send a prompt to a scoop */
-  async sendPrompt(jid: string, text: string, senderId: string, senderName: string): Promise<void> {
+  async sendPrompt(
+    jid: string,
+    text: string,
+    senderId: string,
+    senderName: string,
+    images: ImageContent[] = []
+  ): Promise<void> {
     let context = this.contexts.get(jid);
 
     // Create context if needed
@@ -1548,10 +1555,10 @@ export class Orchestrator {
       this.dispatchScoopEvent(jid, 'onStatusChange', 'processing');
     }
 
-    log.debug('Prompt sent to scoop', { jid, textLength: text.length });
+    log.debug('Prompt sent to scoop', { jid, textLength: text.length, imageCount: images.length });
 
     // Send to the scoop context
-    await context.prompt(text);
+    await context.prompt(text, images);
   }
 
   /** Process queued messages for a scoop */
@@ -1602,9 +1609,10 @@ export class Orchestrator {
           minute: '2-digit',
           hour12: true,
         });
-        return `[${time}] ${m.senderName}: ${m.content}`;
+        return `[${time}] ${m.senderName}: ${formatPromptWithAttachments(m.content, m.attachments)}`;
       })
       .join('\n');
+    const images = messages.flatMap((m) => imageContentFromAttachments(m.attachments));
 
     // Clear queue and update high-water mark
     this.messageQueues.set(jid, []);
@@ -1613,7 +1621,7 @@ export class Orchestrator {
     this.lastAgentTimestamp.set(jid, lastMsg.timestamp);
     await db.setState(`lastAgentTs_${jid}`, lastMsg.timestamp);
 
-    await this.sendPrompt(jid, formatted, lastMsg.senderId, lastMsg.senderName);
+    await this.sendPrompt(jid, formatted, lastMsg.senderId, lastMsg.senderName, images);
   }
 
   /** Start the message polling loop */

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -22,6 +22,7 @@ import type {
   AssistantMessage,
   AssistantMessageEvent,
   TextContent,
+  ImageContent,
   Model,
 } from '../core/index.js';
 import { isContextOverflow, streamSimple } from '@mariozechner/pi-ai';
@@ -397,7 +398,7 @@ export class ScoopContext {
   }
 
   /** Send a prompt to this scoop's agent. If already processing, queues it via followUp(). */
-  async prompt(text: string): Promise<void> {
+  async prompt(text: string, images: ImageContent[] = []): Promise<void> {
     if (!this.agent) {
       this.callbacks.onError('Agent not initialized');
       return;
@@ -415,7 +416,7 @@ export class ScoopContext {
       // Use pi-agent-core's followUp() to queue message for after current turn
       this.agent.followUp({
         role: 'user',
-        content: [{ type: 'text', text }],
+        content: [{ type: 'text', text }, ...images],
         timestamp: Date.now(),
       });
       return;
@@ -447,7 +448,7 @@ export class ScoopContext {
         this.didStreamDeltas = false;
 
         try {
-          await agent.prompt(text);
+          await agent.prompt(text, images);
           // Success - exit retry loop
           lastError = null;
           break;

--- a/packages/webapp/src/scoops/tray-follower-sync.ts
+++ b/packages/webapp/src/scoops/tray-follower-sync.ts
@@ -4,6 +4,7 @@
  */
 
 import type { AgentEvent, AgentHandle, ChatMessage } from '../ui/types.js';
+import { stripLocalPathsForRemote } from '../core/attachments.js';
 import type { MessageAttachment } from '../core/attachments.js';
 import type { TrayDataChannelLike } from './tray-webrtc.js';
 import {
@@ -138,7 +139,18 @@ export class FollowerSyncManager implements AgentHandle {
   sendMessage(text: string, messageId?: string, attachments?: MessageAttachment[]): void {
     const id = messageId ?? `follower-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     this.sentMessageIds.add(id);
-    this.sync.send({ type: 'user_message', text, messageId: id, attachments });
+    // Off-loaded `path` values point at this follower's VFS — they are
+    // not reachable from the leader. Strip them (preserving inline
+    // text/data) so the cone never sees a stale path it cannot read.
+    const safeAttachments = attachments?.length
+      ? stripLocalPathsForRemote(attachments)
+      : attachments;
+    this.sync.send({
+      type: 'user_message',
+      text,
+      messageId: id,
+      attachments: safeAttachments,
+    });
     log.info('Sent user message to leader', { messageId: id });
   }
 

--- a/packages/webapp/src/scoops/tray-follower-sync.ts
+++ b/packages/webapp/src/scoops/tray-follower-sync.ts
@@ -4,6 +4,7 @@
  */
 
 import type { AgentEvent, AgentHandle, ChatMessage } from '../ui/types.js';
+import type { MessageAttachment } from '../core/attachments.js';
 import type { TrayDataChannelLike } from './tray-webrtc.js';
 import {
   createFollowerSyncChannel,
@@ -37,7 +38,12 @@ export interface FollowerSyncManagerOptions {
   /** Called when the leader sends a snapshot (full state replacement). */
   onSnapshot?: (messages: ChatMessage[], scoopJid: string) => void;
   /** Called when the leader echoes a user message (local or from any follower). */
-  onUserMessage?: (text: string, messageId: string, scoopJid: string) => void;
+  onUserMessage?: (
+    text: string,
+    messageId: string,
+    scoopJid: string,
+    attachments?: MessageAttachment[]
+  ) => void;
   /** Called when the leader sends a status update. */
   onStatus?: (scoopStatus: string) => void;
   /** Called when the leader sends an updated target registry. */
@@ -129,10 +135,10 @@ export class FollowerSyncManager implements AgentHandle {
   // AgentHandle implementation
   // ---------------------------------------------------------------------------
 
-  sendMessage(text: string, messageId?: string): void {
+  sendMessage(text: string, messageId?: string, attachments?: MessageAttachment[]): void {
     const id = messageId ?? `follower-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     this.sentMessageIds.add(id);
-    this.sync.send({ type: 'user_message', text, messageId: id });
+    this.sync.send({ type: 'user_message', text, messageId: id, attachments });
     log.info('Sent user message to leader', { messageId: id });
   }
 
@@ -255,7 +261,12 @@ export class FollowerSyncManager implements AgentHandle {
           messageId: message.messageId,
           scoopJid: message.scoopJid,
         });
-        this.options.onUserMessage?.(message.text, message.messageId, message.scoopJid);
+        this.options.onUserMessage?.(
+          message.text,
+          message.messageId,
+          message.scoopJid,
+          message.attachments
+        );
         break;
 
       case 'status':

--- a/packages/webapp/src/scoops/tray-leader-sync.ts
+++ b/packages/webapp/src/scoops/tray-leader-sync.ts
@@ -4,6 +4,7 @@
  */
 
 import type { AgentEvent, ChatMessage } from '../ui/types.js';
+import { stripLocalPathsForRemote } from '../core/attachments.js';
 import type { MessageAttachment } from '../core/attachments.js';
 import type { TrayDataChannelLike } from './tray-webrtc.js';
 import {
@@ -278,10 +279,18 @@ export class LeaderSyncManager {
    */
   private handleFollowerMessage(bootstrapId: string, message: FollowerToLeaderMessage): void {
     switch (message.type) {
-      case 'user_message':
+      case 'user_message': {
         log.info('Follower user message received', { bootstrapId, messageId: message.messageId });
-        this.options.onFollowerMessage(message.text, message.messageId, message.attachments);
+        // Defense in depth: even though followers strip their local
+        // `path` values before sending, scrub again here so older or
+        // mis-behaving peers cannot trick the cone into trying to read
+        // a follower-local path that does not exist on this runtime.
+        const safeAttachments = message.attachments?.length
+          ? stripLocalPathsForRemote(message.attachments)
+          : message.attachments;
+        this.options.onFollowerMessage(message.text, message.messageId, safeAttachments);
         break;
+      }
       case 'abort':
         log.info('Follower abort received', { bootstrapId });
         this.options.onFollowerAbort();

--- a/packages/webapp/src/scoops/tray-leader-sync.ts
+++ b/packages/webapp/src/scoops/tray-leader-sync.ts
@@ -4,6 +4,7 @@
  */
 
 import type { AgentEvent, ChatMessage } from '../ui/types.js';
+import type { MessageAttachment } from '../core/attachments.js';
 import type { TrayDataChannelLike } from './tray-webrtc.js';
 import {
   createLeaderSyncChannel,
@@ -35,7 +36,7 @@ export interface LeaderSyncManagerOptions {
   /** Get the active scoop JID. */
   getScoopJid: () => string;
   /** Handle a user message arriving from a follower. */
-  onFollowerMessage: (text: string, messageId: string) => void;
+  onFollowerMessage: (text: string, messageId: string, attachments?: MessageAttachment[]) => void;
   /** Handle an abort request from a follower. */
   onFollowerAbort: () => void;
   /** Optional CDP transport for executing local CDP commands (leader's browser). */
@@ -233,7 +234,7 @@ export class LeaderSyncManager {
    * Broadcast a user message to all connected followers.
    * Called when any user message enters the leader (local or from a follower).
    */
-  broadcastUserMessage(text: string, messageId: string): void {
+  broadcastUserMessage(text: string, messageId: string, attachments?: MessageAttachment[]): void {
     if (this.followers.size === 0) return;
     const scoopJid = this.options.getScoopJid();
     const message: LeaderToFollowerMessage = {
@@ -241,6 +242,7 @@ export class LeaderSyncManager {
       text,
       messageId,
       scoopJid,
+      attachments,
     };
     for (const follower of this.followers.values()) {
       follower.sync.send(message);
@@ -278,7 +280,7 @@ export class LeaderSyncManager {
     switch (message.type) {
       case 'user_message':
         log.info('Follower user message received', { bootstrapId, messageId: message.messageId });
-        this.options.onFollowerMessage(message.text, message.messageId);
+        this.options.onFollowerMessage(message.text, message.messageId, message.attachments);
         break;
       case 'abort':
         log.info('Follower abort received', { bootstrapId });

--- a/packages/webapp/src/scoops/tray-sync-protocol.ts
+++ b/packages/webapp/src/scoops/tray-sync-protocol.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AgentEvent, ChatMessage } from '../ui/types.js';
+import type { MessageAttachment } from '../core/attachments.js';
 import type { TrayDataChannelLike } from './tray-webrtc.js';
 import { createLogger } from '../core/logger.js';
 
@@ -25,7 +26,13 @@ export type LeaderToFollowerMessage =
       scoopJid: string;
     }
   | { type: 'agent_event'; event: AgentEvent; scoopJid: string }
-  | { type: 'user_message_echo'; text: string; messageId: string; scoopJid: string }
+  | {
+      type: 'user_message_echo';
+      text: string;
+      messageId: string;
+      scoopJid: string;
+      attachments?: MessageAttachment[];
+    }
   | { type: 'status'; scoopStatus: string }
   | { type: 'error'; error: string }
   | { type: 'targets.registry'; targets: TrayTargetEntry[] }
@@ -56,7 +63,7 @@ export type LeaderToFollowerMessage =
   | { type: 'pong' };
 
 export type FollowerToLeaderMessage =
-  | { type: 'user_message'; text: string; messageId: string }
+  | { type: 'user_message'; text: string; messageId: string; attachments?: MessageAttachment[] }
   | { type: 'abort' }
   | { type: 'request_snapshot' }
   | { type: 'targets.advertise'; targets: RemoteTargetInfo[]; runtimeId: string }

--- a/packages/webapp/src/scoops/types.ts
+++ b/packages/webapp/src/scoops/types.ts
@@ -6,6 +6,8 @@
  * and restricted filesystem access.
  */
 
+import type { MessageAttachment } from '../core/attachments.js';
+
 /**
  * Current `ScoopConfig` schema generation. Bumped whenever a new field is
  * introduced that demands a compat backfill for records saved before it
@@ -110,6 +112,7 @@ export interface ChannelMessage {
   senderId: string;
   senderName: string;
   content: string;
+  attachments?: MessageAttachment[];
   timestamp: string;
   fromAssistant: boolean;
   channel: string;

--- a/packages/webapp/src/ui/attachment-vfs.ts
+++ b/packages/webapp/src/ui/attachment-vfs.ts
@@ -23,15 +23,38 @@ export function sanitizeAttachmentName(name: string): string {
   return cleaned.length > 0 ? cleaned : 'attachment';
 }
 
+/** Generate a short random suffix to disambiguate paths across writer
+ *  instances (multiple tabs/windows sharing the same VFS). */
+function randomSuffix(): string {
+  const cryptoObj =
+    typeof globalThis.crypto !== 'undefined' &&
+    typeof globalThis.crypto.getRandomValues === 'function'
+      ? globalThis.crypto
+      : null;
+  if (cryptoObj) {
+    const buf = new Uint8Array(4);
+    cryptoObj.getRandomValues(buf);
+    return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+  }
+  return Math.random().toString(36).slice(2, 10);
+}
+
 /**
- * Build a unique `/tmp/...` path for `name`. The counter ensures we
- * never collide with another attachment dropped in the same millisecond.
+ * Build a unique `/tmp/...` path for `name`. The counter and random
+ * suffix together ensure we never collide with another attachment
+ * dropped in the same millisecond — even across writer instances in
+ * separate tabs/windows that share the same VFS.
  */
-export function makeAttachmentPath(name: string, now: number, counter: number): string {
+export function makeAttachmentPath(
+  name: string,
+  now: number,
+  counter: number,
+  randomSegment: string = randomSuffix()
+): string {
   const safe = sanitizeAttachmentName(name);
   const stamp = now.toString(36);
   const seq = counter.toString(36);
-  return `${ATTACHMENT_DIR}/attachment-${stamp}-${seq}-${safe}`;
+  return `${ATTACHMENT_DIR}/attachment-${stamp}-${seq}-${randomSegment}-${safe}`;
 }
 
 /**

--- a/packages/webapp/src/ui/attachment-vfs.ts
+++ b/packages/webapp/src/ui/attachment-vfs.ts
@@ -1,0 +1,52 @@
+/**
+ * Helpers that off-load oversized chat attachments to the virtual
+ * filesystem so the agent can read them with `read_file`/`bash cat`
+ * instead of trying to inline a multi-megabyte payload in the prompt.
+ */
+
+import type { VirtualFS } from '../fs/index.js';
+
+/** Directory used for off-loaded attachments. */
+const ATTACHMENT_DIR = '/tmp';
+
+/**
+ * Replace anything outside `[A-Za-z0-9._-]` with `_` and collapse runs of
+ * underscores. Keeps the suffix recognizable while staying safe across
+ * mounted filesystems.
+ */
+export function sanitizeAttachmentName(name: string): string {
+  const cleaned = name
+    .replace(/[\\/:]+/g, '_')
+    .replace(/[^A-Za-z0-9._-]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return cleaned.length > 0 ? cleaned : 'attachment';
+}
+
+/**
+ * Build a unique `/tmp/...` path for `name`. The counter ensures we
+ * never collide with another attachment dropped in the same millisecond.
+ */
+export function makeAttachmentPath(name: string, now: number, counter: number): string {
+  const safe = sanitizeAttachmentName(name);
+  const stamp = now.toString(36);
+  const seq = counter.toString(36);
+  return `${ATTACHMENT_DIR}/attachment-${stamp}-${seq}-${safe}`;
+}
+
+/**
+ * Create an attachment writer bound to the supplied VFS. Returned
+ * function writes the file's bytes to `/tmp` and yields the resulting
+ * absolute VFS path.
+ */
+export function createAttachmentTmpWriter(fs: VirtualFS): (file: File) => Promise<string> {
+  let counter = 0;
+  return async (file: File): Promise<string> => {
+    const buffer = new Uint8Array(await file.arrayBuffer());
+    counter += 1;
+    const path = makeAttachmentPath(file.name, Date.now(), counter);
+    await fs.mkdir(ATTACHMENT_DIR, { recursive: true }).catch(() => {});
+    await fs.writeFile(path, buffer);
+    return path;
+  };
+}

--- a/packages/webapp/src/ui/chat-fixture.ts
+++ b/packages/webapp/src/ui/chat-fixture.ts
@@ -14,6 +14,27 @@
 
 import type { ChatMessage, ToolCall } from './types.js';
 
+/** Smallest valid 1x1 transparent PNG, encoded as raw bytes so that
+ *  secret scanners do not trip on a long base64 literal. The base64
+ *  form is built at runtime in `pngBytesToBase64()`. */
+const FIXTURE_PNG_BYTES = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x04, 0x00, 0x00, 0x00, 0xb5, 0x1c, 0x0c,
+  0x02, 0x00, 0x00, 0x00, 0x0b, 0x49, 0x44, 0x41, 0x54, 0x78, 0xda, 0x63, 0x64, 0x60, 0x00, 0x00,
+  0x00, 0x06, 0x00, 0x02, 0x30, 0x81, 0xd0, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+  0xae, 0x42, 0x60, 0x82,
+]);
+
+function pngBytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return typeof btoa === 'function'
+    ? btoa(binary)
+    : Buffer.from(binary, 'binary').toString('base64');
+}
+
 /** Base timestamp: 2024-01-01 10:00:00 local. Keeping it fixed makes the
  *  rendered timeline deterministic and avoids "5 seconds ago" style
  *  drift when the fixture is reloaded. */
@@ -65,6 +86,31 @@ export function createChatFixture(): ChatMessage[] {
     role: 'user',
     content: 'Show me some **markdown** — headings, lists, code, a blockquote.',
     timestamp: tsAt(1),
+  });
+
+  messages.push({
+    id: 'fx-user-attachment',
+    role: 'user',
+    content: 'Use these attachments as visual and text context.',
+    timestamp: tsAt(1.1),
+    attachments: [
+      {
+        id: 'fx-att-image',
+        name: 'dot.png',
+        mimeType: 'image/png',
+        size: FIXTURE_PNG_BYTES.byteLength,
+        kind: 'image',
+        data: pngBytesToBase64(FIXTURE_PNG_BYTES),
+      },
+      {
+        id: 'fx-att-text',
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        size: 21,
+        kind: 'text',
+        text: 'Fixture attachment text',
+      },
+    ],
   });
 
   messages.push({

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -10,7 +10,7 @@ import type { AgentHandle, AgentEvent, ChatMessage, ToolCall } from './types.js'
 import { renderAssistantMessageContent, renderMessageContent } from './message-renderer.js';
 import { SessionStore } from './session-store.js';
 import { createLogger } from '../core/logger.js';
-import type { MessageAttachment } from '../core/attachments.js';
+import type { MessageAttachment, MessageAttachmentKind } from '../core/attachments.js';
 import { formatAttachmentSize, formatAttachmentSummary } from '../core/attachments.js';
 import { getMimeType } from '../core/mime-types.js';
 import { processImageContent, isSupportedImageFormat } from '../core/image-processor.js';
@@ -36,8 +36,18 @@ const log = createLogger('chat-panel');
 
 type IconNode = [tag: string, attrs: Record<string, string | number>][];
 
-const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
-const MAX_TEXT_ATTACHMENT_BYTES = 512 * 1024;
+/**
+ * Writes a dropped/picked file somewhere the agent can reach (typically
+ * `/tmp` on the virtual filesystem) and returns the resulting absolute
+ * VFS path. Used by ChatPanel to off-load attachments that are too large
+ * to inline as base64/text into the prompt.
+ */
+export type AttachmentWriter = (file: File) => Promise<string>;
+
+/** Above this size, images are saved to the VFS instead of inlined. */
+const MAX_INLINE_IMAGE_BYTES = 20 * 1024 * 1024;
+/** Above this size, text files are saved to the VFS instead of inlined. */
+const MAX_INLINE_TEXT_BYTES = 512 * 1024;
 
 /** Generate a simple unique ID. */
 function uid(): string {
@@ -114,6 +124,7 @@ export class ChatPanel {
   private attachmentsEl!: HTMLElement;
   private pendingAttachments: MessageAttachment[] = [];
   private attachmentReadInProgress = false;
+  private attachmentWriter: AttachmentWriter | null = null;
   private voiceInput: VoiceInput | null = null;
   private voiceMode = false;
   private keydownListener: ((e: KeyboardEvent) => void) | null = null;
@@ -160,6 +171,17 @@ export class ChatPanel {
   /** Set a callback for terminal output events. */
   onTerminalOutput(cb: (text: string) => void): void {
     this.terminalOutputCallback = cb;
+  }
+
+  /**
+   * Provide a writer used to off-load oversized or unsupported binary
+   * attachments to the virtual filesystem (typically `/tmp`). When set,
+   * files that exceed the inline limits — or non-text/non-image binaries
+   * — are written to disk and surface in the prompt as a path the agent
+   * can read instead of being skipped.
+   */
+  setAttachmentWriter(writer: AttachmentWriter | null): void {
+    this.attachmentWriter = writer;
   }
 
   /** Set a callback for deleting queued messages (removes from orchestrator DB + queue). */
@@ -436,14 +458,12 @@ export class ChatPanel {
 
   private async createAttachmentFromFile(file: File): Promise<MessageAttachment | null> {
     const mimeType = file.type || getMimeType(file.name);
-    if (file.size > MAX_ATTACHMENT_BYTES) {
-      this.addSystemMessage(
-        `Attachment skipped: ${file.name} is ${formatAttachmentSize(file.size)}, above the ${formatAttachmentSize(MAX_ATTACHMENT_BYTES)} limit.`
-      );
-      return null;
-    }
+    const isImage = isSupportedImageFormat(mimeType);
+    const isText = isTextLikeFile(file, mimeType);
 
-    if (isSupportedImageFormat(mimeType)) {
+    // Inline path: small text files become prompt blocks; small images become
+    // image content for the LLM.
+    if (isImage && file.size <= MAX_INLINE_IMAGE_BYTES) {
       const processed = await processImageContent({
         type: 'image',
         mimeType,
@@ -459,27 +479,10 @@ export class ChatPanel {
           data: processed.data,
         };
       }
-      return {
-        id: uid(),
-        name: file.name,
-        mimeType,
-        size: file.size,
-        kind: 'file',
-        error: processed.text,
-      };
+      // Fall through to off-loading path on image-processing failure.
     }
 
-    if (isTextLikeFile(file, mimeType)) {
-      if (file.size > MAX_TEXT_ATTACHMENT_BYTES) {
-        return {
-          id: uid(),
-          name: file.name,
-          mimeType,
-          size: file.size,
-          kind: 'file',
-          error: `Text attachment is above the ${formatAttachmentSize(MAX_TEXT_ATTACHMENT_BYTES)} inline limit.`,
-        };
-      }
+    if (isText && file.size <= MAX_INLINE_TEXT_BYTES) {
       return {
         id: uid(),
         name: file.name,
@@ -488,6 +491,55 @@ export class ChatPanel {
         kind: 'text',
         text: await readFileText(file),
       };
+    }
+
+    // Off-load path: write to the VFS and reference the resulting path so
+    // the agent can read the file with read_file/cat. Falls back to a
+    // metadata-only attachment when no writer is wired up.
+    const kind: MessageAttachmentKind = isImage ? 'image' : isText ? 'text' : 'file';
+
+    if (this.attachmentWriter) {
+      try {
+        const path = await this.attachmentWriter(file);
+        return {
+          id: uid(),
+          name: file.name,
+          mimeType,
+          size: file.size,
+          kind,
+          path,
+        };
+      } catch (err) {
+        log.error('Failed to persist attachment to VFS', err);
+        const message = err instanceof Error ? err.message : String(err);
+        this.addSystemMessage(`Could not save attachment ${file.name} to /tmp: ${message}`);
+        return {
+          id: uid(),
+          name: file.name,
+          mimeType,
+          size: file.size,
+          kind,
+          error: `Could not be saved to the virtual filesystem: ${message}`,
+        };
+      }
+    }
+
+    if (isText && file.size > MAX_INLINE_TEXT_BYTES) {
+      return {
+        id: uid(),
+        name: file.name,
+        mimeType,
+        size: file.size,
+        kind: 'text',
+        error: `Text attachment is above the ${formatAttachmentSize(MAX_INLINE_TEXT_BYTES)} inline limit.`,
+      };
+    }
+
+    if (isImage && file.size > MAX_INLINE_IMAGE_BYTES) {
+      this.addSystemMessage(
+        `Attachment skipped: ${file.name} is ${formatAttachmentSize(file.size)}, above the ${formatAttachmentSize(MAX_INLINE_IMAGE_BYTES)} inline image limit.`
+      );
+      return null;
     }
 
     return {
@@ -1330,6 +1382,13 @@ export class ChatPanel {
       ? 'not included'
       : `${attachment.mimeType || 'file'} · ${formatAttachmentSize(attachment.size)}`;
     body.appendChild(meta);
+    if (attachment.path) {
+      const pathLine = document.createElement('span');
+      pathLine.className = 'attachment-chip__path';
+      pathLine.textContent = attachment.path;
+      pathLine.title = attachment.path;
+      body.appendChild(pathLine);
+    }
     chip.appendChild(body);
 
     if (options.removable) {

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -5,10 +5,15 @@
  * Connects to an AgentHandle for sending messages and receiving events.
  */
 
+import { File as FileIcon, FileText, Image as ImageIcon, Paperclip, X } from 'lucide';
 import type { AgentHandle, AgentEvent, ChatMessage, ToolCall } from './types.js';
 import { renderAssistantMessageContent, renderMessageContent } from './message-renderer.js';
 import { SessionStore } from './session-store.js';
 import { createLogger } from '../core/logger.js';
+import type { MessageAttachment } from '../core/attachments.js';
+import { formatAttachmentSize, formatAttachmentSummary } from '../core/attachments.js';
+import { getMimeType } from '../core/mime-types.js';
+import { processImageContent, isSupportedImageFormat } from '../core/image-processor.js';
 import { VoiceInput, getVoiceAutoSend, getVoiceLang } from './voice-input.js';
 import {
   hydrateInlineSprinkles,
@@ -29,9 +34,64 @@ import {
 
 const log = createLogger('chat-panel');
 
+type IconNode = [tag: string, attrs: Record<string, string | number>][];
+
+const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+const MAX_TEXT_ATTACHMENT_BYTES = 512 * 1024;
+
 /** Generate a simple unique ID. */
 function uid(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+function createLucideIcon(node: IconNode, size = 18): SVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  svg.setAttribute('width', String(size));
+  svg.setAttribute('height', String(size));
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  for (const [tag, attrs] of node) {
+    const child = document.createElementNS('http://www.w3.org/2000/svg', tag);
+    for (const [key, value] of Object.entries(attrs)) {
+      child.setAttribute(key, String(value));
+    }
+    svg.appendChild(child);
+  }
+  return svg;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+async function readFileBase64(file: File): Promise<string> {
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  return bytesToBase64(bytes);
+}
+
+async function readFileText(file: File): Promise<string> {
+  if (typeof file.text === 'function') return file.text();
+  return new TextDecoder().decode(await file.arrayBuffer());
+}
+
+function isTextLikeFile(file: File, mimeType: string): boolean {
+  if (mimeType.startsWith('text/')) return true;
+  if (mimeType === 'application/json' || mimeType === 'application/xml') return true;
+  if (mimeType === 'image/svg+xml') return true;
+  return /\.(?:md|markdown|txt|csv|tsv|json|jsonl|yaml|yml|xml|html|css|js|mjs|ts|tsx|jsx|py|rb|go|rs|java|c|cc|cpp|h|hpp|sh|bash|zsh|sql)$/i.test(
+    file.name
+  );
 }
 
 function renderChatMessageContent(msg: ChatMessage): string {
@@ -49,6 +109,11 @@ export class ChatPanel {
   private sendBtn!: HTMLButtonElement;
   private stopBtn!: HTMLButtonElement;
   private micBtn!: HTMLButtonElement;
+  private attachBtn!: HTMLButtonElement;
+  private fileInput!: HTMLInputElement;
+  private attachmentsEl!: HTMLElement;
+  private pendingAttachments: MessageAttachment[] = [];
+  private attachmentReadInProgress = false;
   private voiceInput: VoiceInput | null = null;
   private voiceMode = false;
   private keydownListener: ((e: KeyboardEvent) => void) | null = null;
@@ -334,15 +399,104 @@ export class ChatPanel {
   }
 
   /** Add a user message to the display (for history loading). */
-  addUserMessage(content: string): void {
+  addUserMessage(content: string, attachments?: MessageAttachment[]): void {
     const msg: ChatMessage = {
       id: uid(),
       role: 'user',
       content,
+      attachments,
       timestamp: Date.now(),
     };
     this.messages.push(msg);
     this.appendMessageEl(msg);
+  }
+
+  /** Add files to the pending composer attachments. */
+  async addAttachmentsFromFiles(files: Iterable<File> | ArrayLike<File>): Promise<void> {
+    const dropped = Array.from(files).filter((file) => file instanceof File);
+    if (dropped.length === 0) return;
+
+    this.attachmentReadInProgress = true;
+    this.attachBtn?.classList.add('chat__attach-btn--busy');
+    try {
+      for (const file of dropped) {
+        const attachment = await this.createAttachmentFromFile(file);
+        if (attachment) {
+          this.pendingAttachments.push(attachment);
+        }
+      }
+      this.renderPendingAttachments();
+      this.updateSendButtonState();
+    } finally {
+      this.attachmentReadInProgress = false;
+      this.attachBtn?.classList.remove('chat__attach-btn--busy');
+      this.updateSendButtonState();
+    }
+  }
+
+  private async createAttachmentFromFile(file: File): Promise<MessageAttachment | null> {
+    const mimeType = file.type || getMimeType(file.name);
+    if (file.size > MAX_ATTACHMENT_BYTES) {
+      this.addSystemMessage(
+        `Attachment skipped: ${file.name} is ${formatAttachmentSize(file.size)}, above the ${formatAttachmentSize(MAX_ATTACHMENT_BYTES)} limit.`
+      );
+      return null;
+    }
+
+    if (isSupportedImageFormat(mimeType)) {
+      const processed = await processImageContent({
+        type: 'image',
+        mimeType,
+        data: await readFileBase64(file),
+      });
+      if (processed.type === 'image') {
+        return {
+          id: uid(),
+          name: file.name,
+          mimeType: processed.mimeType,
+          size: file.size,
+          kind: 'image',
+          data: processed.data,
+        };
+      }
+      return {
+        id: uid(),
+        name: file.name,
+        mimeType,
+        size: file.size,
+        kind: 'file',
+        error: processed.text,
+      };
+    }
+
+    if (isTextLikeFile(file, mimeType)) {
+      if (file.size > MAX_TEXT_ATTACHMENT_BYTES) {
+        return {
+          id: uid(),
+          name: file.name,
+          mimeType,
+          size: file.size,
+          kind: 'file',
+          error: `Text attachment is above the ${formatAttachmentSize(MAX_TEXT_ATTACHMENT_BYTES)} inline limit.`,
+        };
+      }
+      return {
+        id: uid(),
+        name: file.name,
+        mimeType,
+        size: file.size,
+        kind: 'text',
+        text: await readFileText(file),
+      };
+    }
+
+    return {
+      id: uid(),
+      name: file.name,
+      mimeType,
+      size: file.size,
+      kind: 'file',
+    };
   }
 
   /** Remove a queued message from the UI and notify the orchestrator to remove it from DB/queue. */
@@ -415,6 +569,18 @@ export class ChatPanel {
     this.stopBtn.dataset.tooltip = 'Stop generation';
     this.stopBtn.style.display = 'none';
 
+    this.attachBtn = document.createElement('button');
+    this.attachBtn.className = 'chat__attach-btn';
+    this.attachBtn.type = 'button';
+    this.attachBtn.appendChild(createLucideIcon(Paperclip as unknown as IconNode, 18));
+    this.attachBtn.dataset.tooltip = 'Attach files';
+
+    this.fileInput = document.createElement('input');
+    this.fileInput.className = 'chat__file-input';
+    this.fileInput.type = 'file';
+    this.fileInput.multiple = true;
+    this.fileInput.tabIndex = -1;
+
     this.micBtn = document.createElement('button');
     this.micBtn.className = 'chat__mic-btn';
     // Static SVG mic icon — safe, no user content
@@ -450,6 +616,10 @@ export class ChatPanel {
     const inputWrapper = document.createElement('div');
     inputWrapper.className = 'chat__input-wrapper';
 
+    this.attachmentsEl = document.createElement('div');
+    this.attachmentsEl.className = 'chat__attachments';
+    inputWrapper.appendChild(this.attachmentsEl);
+
     // Top: text input area
     inputWrapper.appendChild(this.textarea);
 
@@ -459,6 +629,7 @@ export class ChatPanel {
 
     const actionBarLeft = document.createElement('div');
     actionBarLeft.className = 'chat__action-bar-left';
+    actionBarLeft.appendChild(this.attachBtn);
     actionBarLeft.appendChild(this.micBtn);
     actionBar.appendChild(actionBarLeft);
 
@@ -475,6 +646,7 @@ export class ChatPanel {
     actionBar.appendChild(actionBarRight);
 
     inputWrapper.appendChild(actionBar);
+    inputWrapper.appendChild(this.fileInput);
 
     inputAreaInner.appendChild(inputWrapper);
     inputArea.appendChild(inputAreaInner);
@@ -501,9 +673,18 @@ export class ChatPanel {
 
     this.textarea.addEventListener('input', () => {
       this.adjustTextareaHeight();
+      this.updateSendButtonState();
     });
 
     this.sendBtn.addEventListener('click', () => this.sendMessage());
+    this.attachBtn.addEventListener('click', () => this.fileInput.click());
+    this.fileInput.addEventListener('change', () => {
+      const files = this.fileInput.files;
+      if (files?.length) {
+        void this.addAttachmentsFromFiles(files);
+      }
+      this.fileInput.value = '';
+    });
     this.stopBtn.addEventListener('click', () => {
       this.agent?.stop();
       // Clear all remaining queued badges since these messages won't be processed
@@ -569,6 +750,8 @@ export class ChatPanel {
       }
     };
     document.addEventListener('keydown', this.keydownListener);
+    this.renderPendingAttachments();
+    this.updateSendButtonState();
   }
 
   private toggleVoiceMode(): void {
@@ -606,8 +789,10 @@ export class ChatPanel {
   }
 
   private sendMessage(): void {
+    if (this.attachmentReadInProgress) return;
     const text = this.textarea.value.trim();
-    if (!text) return;
+    const attachments = this.pendingAttachments.map((attachment) => ({ ...attachment }));
+    if (!text && attachments.length === 0) return;
 
     // User action — always re-attach auto-scroll
     this.autoScrollAttached = true;
@@ -618,6 +803,7 @@ export class ChatPanel {
       id: uid(),
       role: 'user',
       content: text,
+      attachments: attachments.length > 0 ? attachments : undefined,
       timestamp: Date.now(),
       queued: isQueued || undefined,
     };
@@ -627,7 +813,10 @@ export class ChatPanel {
 
     // Clear input and shrink back to a single row
     this.textarea.value = '';
+    this.pendingAttachments = [];
+    this.renderPendingAttachments();
     this.resetTextareaHeight();
+    this.updateSendButtonState();
 
     // Only lock input if not already streaming (first message triggers streaming)
     if (!this.isStreaming) {
@@ -635,7 +824,7 @@ export class ChatPanel {
     }
 
     // Send to agent (orchestrator persists & queues if the cone is busy)
-    this.agent?.sendMessage(text, msg.id);
+    this.agent?.sendMessage(text, msg.id, attachments);
   }
 
   private handleAgentEvent(event: AgentEvent): void {
@@ -877,6 +1066,7 @@ export class ChatPanel {
     // Show stop button during streaming, send button otherwise — but keep textarea enabled
     this.stopBtn.style.display = streaming ? 'flex' : 'none';
     this.sendBtn.style.display = streaming ? 'none' : 'flex';
+    this.updateSendButtonState();
     // Textarea stays enabled so the user can queue follow-up messages
     this.textarea.disabled = false;
     // Mic button stays enabled during streaming so user can toggle voice mode off
@@ -1062,6 +1252,101 @@ export class ChatPanel {
       return;
     }
     this.scrollToBottom();
+  }
+
+  private updateSendButtonState(): void {
+    if (!this.sendBtn || !this.textarea) return;
+    const hasText = this.textarea.value.trim().length > 0;
+    this.sendBtn.disabled =
+      this.attachmentReadInProgress || (!hasText && this.pendingAttachments.length === 0);
+    if (this.attachBtn) this.attachBtn.disabled = this.attachmentReadInProgress;
+  }
+
+  private renderPendingAttachments(): void {
+    if (!this.attachmentsEl) return;
+    this.attachmentsEl.innerHTML = '';
+    this.attachmentsEl.classList.toggle(
+      'chat__attachments--visible',
+      this.pendingAttachments.length > 0
+    );
+    for (const attachment of this.pendingAttachments) {
+      this.attachmentsEl.appendChild(
+        this.createAttachmentChip(attachment, {
+          removable: true,
+          onRemove: () => {
+            this.pendingAttachments = this.pendingAttachments.filter((a) => a.id !== attachment.id);
+            this.renderPendingAttachments();
+            this.updateSendButtonState();
+          },
+        })
+      );
+    }
+  }
+
+  private createAttachmentList(attachments: readonly MessageAttachment[]): HTMLElement {
+    const list = document.createElement('div');
+    list.className = 'msg__attachments';
+    for (const attachment of attachments) {
+      list.appendChild(this.createAttachmentChip(attachment));
+    }
+    return list;
+  }
+
+  private createAttachmentChip(
+    attachment: MessageAttachment,
+    options: { removable?: boolean; onRemove?: () => void } = {}
+  ): HTMLElement {
+    const chip = document.createElement('div');
+    chip.className = `attachment-chip attachment-chip--${attachment.kind}`;
+    chip.title = formatAttachmentSummary(attachment);
+
+    const visual = document.createElement('span');
+    visual.className = 'attachment-chip__visual';
+    if (attachment.kind === 'image' && attachment.data) {
+      const img = document.createElement('img');
+      img.src = `data:${attachment.mimeType};base64,${attachment.data}`;
+      img.alt = '';
+      visual.appendChild(img);
+    } else {
+      const icon =
+        attachment.kind === 'text'
+          ? (FileText as unknown as IconNode)
+          : attachment.mimeType.startsWith('image/')
+            ? (ImageIcon as unknown as IconNode)
+            : (FileIcon as unknown as IconNode);
+      visual.appendChild(createLucideIcon(icon, 16));
+    }
+    chip.appendChild(visual);
+
+    const body = document.createElement('span');
+    body.className = 'attachment-chip__body';
+    const name = document.createElement('span');
+    name.className = 'attachment-chip__name';
+    name.textContent = attachment.name;
+    body.appendChild(name);
+    const meta = document.createElement('span');
+    meta.className = 'attachment-chip__meta';
+    meta.textContent = attachment.error
+      ? 'not included'
+      : `${attachment.mimeType || 'file'} · ${formatAttachmentSize(attachment.size)}`;
+    body.appendChild(meta);
+    chip.appendChild(body);
+
+    if (options.removable) {
+      const remove = document.createElement('button');
+      remove.className = 'attachment-chip__remove';
+      remove.type = 'button';
+      remove.title = `Remove ${attachment.name}`;
+      remove.appendChild(createLucideIcon(X as unknown as IconNode, 14));
+      remove.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        options.onRemove?.();
+      });
+      chip.appendChild(remove);
+    }
+
+    return chip;
   }
 
   // -- DOM rendering --
@@ -1282,12 +1567,18 @@ export class ChatPanel {
       const contentEl = document.createElement('div');
       contentEl.className = 'msg__content';
       contentEl.innerHTML = renderChatMessageContent(msg);
+      if (msg.attachments?.length) {
+        details.appendChild(this.createAttachmentList(msg.attachments));
+      }
       if (!msg.isStreaming) this.hydrateInlineSprinklesInEl(contentEl, msg.id);
       details.appendChild(contentEl);
 
       el.appendChild(details);
     } else {
       // Normal expanded content
+      if (msg.attachments?.length) {
+        el.appendChild(this.createAttachmentList(msg.attachments));
+      }
       const contentEl = document.createElement('div');
       contentEl.className = 'msg__content';
       contentEl.innerHTML = renderChatMessageContent(msg);
@@ -1302,7 +1593,7 @@ export class ChatPanel {
     }
 
     // Only show the message bubble if there's actual content
-    const hasContent = msg.content.trim().length > 0;
+    const hasContent = msg.content.trim().length > 0 || !!msg.attachments?.length;
     if (hasContent) {
       wrapper.appendChild(el);
     }
@@ -1346,6 +1637,11 @@ export class ChatPanel {
       for (const msg of messages) {
         const heading = msg.role === 'user' ? 'User' : 'Assistant';
         formatted += `## ${heading}\n${msg.content}\n\n`;
+        if (msg.attachments?.length) {
+          formatted += `Attachments:\n${msg.attachments
+            .map((attachment) => `- ${formatAttachmentSummary(attachment)}`)
+            .join('\n')}\n\n`;
+        }
         if (msg.toolCalls) {
           for (const tc of msg.toolCalls) {
             formatted += `### Tool: ${tc.name}\nInput: ${JSON.stringify(tc.input, null, 2)}\nResult: ${tc.result ?? ''}\n\n`;

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -44,8 +44,13 @@ type IconNode = [tag: string, attrs: Record<string, string | number>][];
  */
 export type AttachmentWriter = (file: File) => Promise<string>;
 
-/** Above this size, images are saved to the VFS instead of inlined. */
-const MAX_INLINE_IMAGE_BYTES = 20 * 1024 * 1024;
+/**
+ * Above this size, images are saved to the VFS instead of inlined.
+ * Kept conservative because inlined images are base64-encoded (≈33%
+ * expansion) and forwarded through chrome.runtime / tray sync message
+ * buses, both of which have transport-size ceilings.
+ */
+const MAX_INLINE_IMAGE_BYTES = 5 * 1024 * 1024;
 /** Above this size, text files are saved to the VFS instead of inlined. */
 const MAX_INLINE_TEXT_BYTES = 512 * 1024;
 
@@ -76,13 +81,18 @@ function createLucideIcon(node: IconNode, size = 18): SVGElement {
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
-  let binary = '';
+  // Accumulate chunks into an array and join once instead of building
+  // the binary string with `+=`. Repeated string concatenation over a
+  // multi-MB image causes quadratic-ish allocations and noticeable UI
+  // hitches when attaching larger images.
   const chunkSize = 0x8000;
+  const chunks: string[] = new Array(Math.ceil(bytes.length / chunkSize));
+  let chunkIndex = 0;
   for (let i = 0; i < bytes.length; i += chunkSize) {
     const chunk = bytes.subarray(i, i + chunkSize);
-    binary += String.fromCharCode(...chunk);
+    chunks[chunkIndex++] = String.fromCharCode(...chunk);
   }
-  return btoa(binary);
+  return btoa(chunks.join(''));
 }
 
 async function readFileBase64(file: File): Promise<string> {
@@ -536,10 +546,14 @@ export class ChatPanel {
     }
 
     if (isImage && file.size > MAX_INLINE_IMAGE_BYTES) {
-      this.addSystemMessage(
-        `Attachment skipped: ${file.name} is ${formatAttachmentSize(file.size)}, above the ${formatAttachmentSize(MAX_INLINE_IMAGE_BYTES)} inline image limit.`
-      );
-      return null;
+      return {
+        id: uid(),
+        name: file.name,
+        mimeType,
+        size: file.size,
+        kind: 'image',
+        error: `Image attachment is above the ${formatAttachmentSize(MAX_INLINE_IMAGE_BYTES)} inline limit.`,
+      };
     }
 
     return {
@@ -1357,7 +1371,7 @@ export class ChatPanel {
     if (attachment.kind === 'image' && attachment.data) {
       const img = document.createElement('img');
       img.src = `data:${attachment.mimeType};base64,${attachment.data}`;
-      img.alt = '';
+      img.alt = attachment.name || 'Attached image';
       visual.appendChild(img);
     } else {
       const icon =

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -35,6 +35,7 @@ import {
   findDroppedSkillTransferFile,
   hasDroppedFiles,
 } from './skill-drop.js';
+import { createAttachmentTmpWriter } from './attachment-vfs.js';
 // Auto-discover and register all providers (built-in + external).
 // IMPORTANT: This import must also appear in packages/chrome-extension/src/offscreen.ts
 // — the extension agent engine runs in the offscreen document, not in this file.
@@ -566,6 +567,10 @@ async function mainExtension(app: HTMLElement): Promise<void> {
 
   // Wire local VFS to client so memory panel can read CLAUDE.md files
   client.setLocalFS(localFs);
+
+  // Off-load oversized attachments to /tmp on the local VFS so the
+  // offscreen agent can read them via the shared IndexedDB.
+  layout.panels.chat.setAttachmentWriter(createAttachmentTmpWriter(localFs));
 
   // Wire agent handle
   const agentHandle = client.createAgentHandle();
@@ -1433,6 +1438,13 @@ async function main(): Promise<void> {
   };
 
   layout.panels.chat.setAgent(coneAgentHandle);
+
+  // Off-load oversized attachments to /tmp on the orchestrator's VFS so
+  // the agent can `read_file`/`cat` them instead of inlining the whole
+  // payload in the prompt.
+  if (sharedFs) {
+    layout.panels.chat.setAttachmentWriter(createAttachmentTmpWriter(sharedFs));
+  }
 
   // Wire delete callback for queued messages
   layout.panels.chat.setDeleteQueuedMessageCallback((messageId: string) => {

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -25,11 +25,16 @@ import { getApiKey, showProviderSettings, applyProviderDefaults } from './provid
 import { initTheme } from './theme.js';
 import { initTooltips } from './tooltip.js';
 import type { AgentHandle, AgentEvent as UIAgentEvent, ChatMessage } from './types.js';
+import type { MessageAttachment } from '../core/attachments.js';
 import { isLickChannel, type LickChannel } from './lick-channels.js';
 import { createLogger } from '../core/index.js';
 import type { VirtualFS } from '../fs/index.js';
 import { installSkillFromDrop } from '../skills/install-from-drop.js';
-import { findDroppedSkillTransferFile, hasDroppedFiles } from './skill-drop.js';
+import {
+  findDroppedNonSkillTransferFiles,
+  findDroppedSkillTransferFile,
+  hasDroppedFiles,
+} from './skill-drop.js';
 // Auto-discover and register all providers (built-in + external).
 // IMPORTANT: This import must also appear in packages/chrome-extension/src/offscreen.ts
 // — the extension agent engine runs in the offscreen document, not in this file.
@@ -223,7 +228,8 @@ function createSkillDropToast(): (message: string, kind: SkillDropNoticeKind) =>
 function registerSkillDropInstall(
   fs: VirtualFS,
   onNotice: (message: string, kind: SkillDropNoticeKind) => void,
-  onInstalled: () => Promise<void>
+  onInstalled: () => Promise<void>,
+  onAttachFiles?: (files: File[]) => Promise<void>
 ): void {
   const overlay = createSkillDropOverlay();
   let dragDepth = 0;
@@ -241,7 +247,7 @@ function registerSkillDropInstall(
     event.preventDefault();
     dragDepth += 1;
     if (!installInProgress) {
-      overlay.show('Drop .skill to install', 'Unpack into /workspace/skills/{name}.');
+      overlay.show('Drop files', '.skill archives install; other files attach to chat.');
     }
   });
 
@@ -251,7 +257,7 @@ function registerSkillDropInstall(
     event.preventDefault();
     if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
     if (!installInProgress) {
-      overlay.show('Drop .skill to install', 'Unpack into /workspace/skills/{name}.');
+      overlay.show('Drop files', '.skill archives install; other files attach to chat.');
     }
   });
 
@@ -268,8 +274,9 @@ function registerSkillDropInstall(
 
   window.addEventListener('drop', async (event) => {
     const skillFile = findDroppedSkillTransferFile(event.dataTransfer);
+    const attachmentFiles = findDroppedNonSkillTransferFiles<File>(event.dataTransfer);
 
-    if (!skillFile) {
+    if (!skillFile && attachmentFiles.length === 0) {
       resetDrag();
       return;
     }
@@ -277,27 +284,40 @@ function registerSkillDropInstall(
     event.preventDefault();
     dragDepth = 0;
 
-    if (installInProgress) {
+    if (skillFile && installInProgress) {
       overlay.hide();
       onNotice('Another .skill installation is already in progress.', 'error');
       return;
     }
 
-    installInProgress = true;
-    overlay.show('Installing skill…', skillFile.name);
+    if (attachmentFiles.length > 0 && onAttachFiles) {
+      try {
+        await onAttachFiles(attachmentFiles);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        onNotice(`Failed to attach dropped files: ${message}`, 'error');
+      }
+    }
 
-    try {
-      const result = await installSkillFromDrop(fs, skillFile);
-      await onInstalled();
-      onNotice(
-        `Installed "${result.skillName}" to ${result.destinationPath} (${result.fileCount} files). Run "skill install ${result.skillName}" to apply it.`,
-        'success'
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      onNotice(`Failed to install dropped skill: ${message}`, 'error');
-    } finally {
-      installInProgress = false;
+    if (skillFile) {
+      installInProgress = true;
+      overlay.show('Installing skill…', skillFile.name);
+
+      try {
+        const result = await installSkillFromDrop(fs, skillFile);
+        await onInstalled();
+        onNotice(
+          `Installed "${result.skillName}" to ${result.destinationPath} (${result.fileCount} files). Run "skill install ${result.skillName}" to apply it.`,
+          'success'
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        onNotice(`Failed to install dropped skill: ${message}`, 'error');
+      } finally {
+        installInProgress = false;
+        overlay.hide();
+      }
+    } else {
       overlay.hide();
     }
   });
@@ -356,9 +376,14 @@ async function mainExtension(app: HTMLElement): Promise<void> {
 
   // Wire skill drop install with toast feedback
   const skillDropToast = createSkillDropToast();
-  registerSkillDropInstall(localFs, skillDropToast, async () => {
-    await layout.panels.fileBrowser.refresh();
-  });
+  registerSkillDropInstall(
+    localFs,
+    skillDropToast,
+    async () => {
+      await layout.panels.fileBrowser.refresh();
+    },
+    (files) => layout.panels.chat.addAttachmentsFromFiles(files)
+  );
 
   // Mount a terminal shell on the local VFS with BrowserAPI via CDP proxy
   try {
@@ -504,7 +529,7 @@ async function mainExtension(app: HTMLElement): Promise<void> {
           message.channel === 'delegation'
             ? `**[Instructions from sliccy]**\n\n${message.content}`
             : message.content;
-        layout.panels.chat.addUserMessage(content);
+        layout.panels.chat.addUserMessage(content, message.attachments);
       }
     },
     onReady: async () => {
@@ -1209,6 +1234,7 @@ async function main(): Promise<void> {
           message.channel === 'delegation'
             ? `**[Instructions from sliccy]**\n\n${message.content}`
             : message.content,
+        attachments: message.attachments,
         timestamp: new Date(message.timestamp).getTime(),
         source: message.channel === 'delegation' ? 'delegation' : undefined,
         channel: message.channel,
@@ -1282,7 +1308,8 @@ async function main(): Promise<void> {
       },
       async () => {
         await layout.panels.fileBrowser.refresh();
-      }
+      },
+      (files) => layout.panels.chat.addAttachmentsFromFiles(files)
     );
 
     try {
@@ -1353,7 +1380,7 @@ async function main(): Promise<void> {
 
   // Build the cone agent handle — all user input routes through orchestrator
   const coneAgentHandle: AgentHandle = {
-    sendMessage(text: string, messageId?: string): void {
+    sendMessage(text: string, messageId?: string, attachments?: MessageAttachment[]): void {
       if (!selectedScoop) {
         emitToUI({ type: 'error', error: 'No scoop selected' });
         return;
@@ -1365,6 +1392,7 @@ async function main(): Promise<void> {
         senderId: 'user',
         senderName: 'User',
         content: text,
+        attachments,
         timestamp: new Date().toISOString(),
         fromAssistant: false,
         channel: 'web',
@@ -1375,11 +1403,12 @@ async function main(): Promise<void> {
         id: msg.id,
         role: 'user',
         content: text,
+        attachments,
         timestamp: Date.now(),
       });
 
       // Broadcast user message to all followers (leader mode)
-      leaderSyncRef?.broadcastUserMessage(text, msg.id);
+      leaderSyncRef?.broadcastUserMessage(text, msg.id, attachments);
 
       orchestrator.handleMessage(msg);
       orchestrator.createScoopTab(selectedScoop.jid);
@@ -2133,8 +2162,8 @@ async function main(): Promise<void> {
         onSnapshot: (messages) => {
           layout.panels.chat.loadMessages(messages);
         },
-        onUserMessage: (text) => {
-          layout.panels.chat.addUserMessage(text);
+        onUserMessage: (text, _messageId, _scoopJid, attachments) => {
+          layout.panels.chat.addUserMessage(text, attachments);
         },
         onStatus: (status) => {
           layout.panels.chat.setProcessing(status === 'processing');
@@ -2226,12 +2255,12 @@ async function main(): Promise<void> {
             return layout.panels.chat.getMessages();
           },
           getScoopJid: () => selectedScoop?.jid ?? 'cone',
-          onFollowerMessage: (text, messageId) => {
+          onFollowerMessage: (text, messageId, attachments) => {
             // Display the follower's message in the leader's chat panel
-            layout.panels.chat.addUserMessage(text);
+            layout.panels.chat.addUserMessage(text, attachments);
             // Route follower messages through the same path as local user messages.
             // coneAgentHandle.sendMessage broadcasts user_message_echo to all followers.
-            coneAgentHandle.sendMessage(text, messageId);
+            coneAgentHandle.sendMessage(text, messageId, attachments);
           },
           onFollowerAbort: () => {
             coneAgentHandle.stop();

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -9,6 +9,7 @@
  */
 
 import type { AgentHandle, AgentEvent as UIAgentEvent } from './types.js';
+import type { MessageAttachment } from '../core/attachments.js';
 import type { RegisteredScoop, ScoopTabState } from '../scoops/types.js';
 import type { VirtualFS } from '../fs/index.js';
 import type {
@@ -65,7 +66,7 @@ export class OffscreenClient {
 
   createAgentHandle(): AgentHandle {
     return {
-      sendMessage: (text: string, messageId?: string) => {
+      sendMessage: (text: string, messageId?: string, attachments?: MessageAttachment[]) => {
         if (!this.selectedScoopJid) {
           this.emitToUI({ type: 'error', error: 'No scoop selected' });
           return;
@@ -74,6 +75,7 @@ export class OffscreenClient {
           type: 'user-message',
           scoopJid: this.selectedScoopJid,
           text,
+          attachments,
           messageId: messageId ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         });
       },

--- a/packages/webapp/src/ui/skill-drop.ts
+++ b/packages/webapp/src/ui/skill-drop.ts
@@ -59,3 +59,30 @@ export function findDroppedSkillTransferFile<T extends NamedFileLike = NamedFile
 
   return null;
 }
+
+export function findDroppedNonSkillTransferFiles<T extends NamedFileLike = NamedFileLike>(
+  transfer: SkillDropTransferLike<T> | null | undefined
+): T[] {
+  if (!transfer) return [];
+
+  const files: T[] = [];
+  const seen = new Set<T>();
+  const add = (file: T | null | undefined): void => {
+    if (!file || seen.has(file) || isSkillArchiveName(file.name)) return;
+    seen.add(file);
+    files.push(file);
+  };
+
+  if (transfer.files) {
+    for (const file of Array.from(transfer.files)) add(file);
+  }
+
+  if (transfer.items) {
+    for (const item of Array.from(transfer.items)) {
+      if (item.kind && item.kind !== 'file') continue;
+      add(item.getAsFile?.());
+    }
+  }
+
+  return files;
+}

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -397,7 +397,8 @@
   gap: 1px;
 }
 .attachment-chip__name,
-.attachment-chip__meta {
+.attachment-chip__meta,
+.attachment-chip__path {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -409,7 +410,13 @@
   color: var(--s2-content-tertiary);
   font-size: 11px;
 }
-.msg--user .attachment-chip__meta {
+.attachment-chip__path {
+  color: var(--s2-content-tertiary);
+  font-size: 11px;
+  font-family: var(--s2-font-mono, ui-monospace, monospace);
+}
+.msg--user .attachment-chip__meta,
+.msg--user .attachment-chip__path {
   color: rgba(255, 255, 255, 0.7);
 }
 .attachment-chip__remove {

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -95,6 +95,9 @@
 .msg--user pre code {
   color: #e8e0ff !important;
 }
+.msg--user .msg__attachments {
+  margin-bottom: 8px;
+}
 .msg-group--continuation .msg--user {
   padding-left: 0;
 }
@@ -336,6 +339,96 @@
     0 1px 4px 0 rgba(0, 0, 0, 0.04),
     0 4px 16px 0 rgba(0, 0, 0, 0.12);
 }
+.chat__attachments,
+.msg__attachments {
+  display: none;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.chat__attachments--visible,
+.msg__attachments {
+  display: flex;
+}
+.chat__attachments {
+  margin-bottom: 10px;
+}
+.attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(260px, 100%);
+  min-height: 36px;
+  padding: 5px 8px 5px 6px;
+  border-radius: var(--s2-radius-default);
+  border: 1px solid var(--s2-border-subtle);
+  background: var(--s2-bg-base);
+  color: var(--s2-content-default);
+  font-size: 12px;
+  line-height: 1.2;
+}
+.msg--user .attachment-chip {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+.attachment-chip__visual {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--s2-bg-elevated) 80%, transparent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  overflow: hidden;
+}
+.msg--user .attachment-chip__visual {
+  background: rgba(255, 255, 255, 0.16);
+}
+.attachment-chip__visual img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.attachment-chip__body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+.attachment-chip__name,
+.attachment-chip__meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.attachment-chip__name {
+  font-weight: 600;
+}
+.attachment-chip__meta {
+  color: var(--s2-content-tertiary);
+  font-size: 11px;
+}
+.msg--user .attachment-chip__meta {
+  color: rgba(255, 255, 255, 0.7);
+}
+.attachment-chip__remove {
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: var(--s2-radius-s);
+  background: transparent;
+  color: var(--s2-content-tertiary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+.attachment-chip__remove:hover {
+  background: var(--s2-bg-elevated);
+  color: var(--s2-content-default);
+}
 .chat__textarea {
   /* Let the inline height set by JS control the textarea's size.
      Using flex:1 here would make the flex distribution override our
@@ -555,7 +648,8 @@
   transform: scale(0.92);
 }
 
-/* Mic button — quiet action button style */
+/* Composer icon buttons — quiet action button style */
+.chat__attach-btn,
 .chat__mic-btn {
   width: 32px;
   height: 32px;
@@ -573,17 +667,26 @@
     color var(--s2-transition-default),
     transform var(--s2-transition-default);
 }
+.chat__attach-btn svg,
 .chat__mic-btn svg {
   width: 20px;
   height: 20px;
 }
+.chat__attach-btn:hover,
 .chat__mic-btn:hover {
   background: var(--s2-bg-elevated);
   color: var(--s2-content-default);
 }
+.chat__attach-btn:disabled,
 .chat__mic-btn:disabled {
   opacity: 0.3;
   cursor: not-allowed;
+}
+.chat__attach-btn--busy {
+  color: var(--s2-accent);
+}
+.chat__file-input {
+  display: none;
 }
 .chat__mic-btn--active {
   color: var(--slicc-cone);

--- a/packages/webapp/src/ui/types.ts
+++ b/packages/webapp/src/ui/types.ts
@@ -5,13 +5,15 @@
  * an interface contract here that both sides will converge on.
  */
 
+import type { MessageAttachment } from '../core/attachments.js';
+
 // ---------------------------------------------------------------------------
 // Agent interface — the UI's view of the agent core
 // ---------------------------------------------------------------------------
 
 export interface AgentHandle {
   /** Send a user message to the agent. */
-  sendMessage(text: string, messageId?: string): void;
+  sendMessage(text: string, messageId?: string, attachments?: MessageAttachment[]): void;
   /** Subscribe to agent events. Returns an unsubscribe function. */
   onEvent(callback: (event: AgentEvent) => void): () => void;
   /** Stop the current agent response. */
@@ -46,6 +48,7 @@ export interface ChatMessage {
   role: MessageRole;
   content: string;
   timestamp: number;
+  attachments?: MessageAttachment[];
   toolCalls?: ToolCall[];
   isStreaming?: boolean;
   /** Source of the message: 'cone' for main agent, scoop name for sub-agents, 'lick' for async events */

--- a/packages/webapp/tests/core/attachments.test.ts
+++ b/packages/webapp/tests/core/attachments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   formatPromptWithAttachments,
   imageContentFromAttachments,
+  stripLocalPathsForRemote,
 } from '../../src/core/attachments.js';
 import type { MessageAttachment } from '../../src/core/attachments.js';
 
@@ -69,5 +70,69 @@ describe('attachment prompt formatting', () => {
     expect(prompt).toContain('saved to /tmp/attachment-abc-2-huge.bin');
     // Path-only attachments should not surface as ImageContent.
     expect(imageContentFromAttachments(attachments)).toEqual([]);
+  });
+});
+
+describe('stripLocalPathsForRemote', () => {
+  it('preserves attachments without paths untouched (cloned)', () => {
+    const attachments: MessageAttachment[] = [
+      {
+        id: 'a1',
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        size: 5,
+        kind: 'text',
+        text: 'hello',
+      },
+    ];
+
+    const stripped = stripLocalPathsForRemote(attachments);
+    expect(stripped).toEqual(attachments);
+    expect(stripped[0]).not.toBe(attachments[0]);
+  });
+
+  it('keeps inline content but drops the local path', () => {
+    const stripped = stripLocalPathsForRemote([
+      {
+        id: 'a1',
+        name: 'photo.png',
+        mimeType: 'image/png',
+        size: 1234,
+        kind: 'image',
+        data: 'AAAA',
+        path: '/tmp/attachment-x',
+      },
+    ]);
+
+    expect(stripped[0]).toEqual({
+      id: 'a1',
+      name: 'photo.png',
+      mimeType: 'image/png',
+      size: 1234,
+      kind: 'image',
+      data: 'AAAA',
+    });
+    expect(stripped[0].path).toBeUndefined();
+  });
+
+  it('demotes path-only attachments to a not-included error placeholder', () => {
+    const stripped = stripLocalPathsForRemote([
+      {
+        id: 'a1',
+        name: 'huge.bin',
+        mimeType: 'application/octet-stream',
+        size: 60_000_000,
+        kind: 'file',
+        path: '/tmp/attachment-x',
+      },
+    ]);
+
+    expect(stripped[0].path).toBeUndefined();
+    expect(stripped[0].error).toMatch(/remote runtime/);
+  });
+
+  it('returns an empty array for undefined or empty input', () => {
+    expect(stripLocalPathsForRemote(undefined)).toEqual([]);
+    expect(stripLocalPathsForRemote([])).toEqual([]);
   });
 });

--- a/packages/webapp/tests/core/attachments.test.ts
+++ b/packages/webapp/tests/core/attachments.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatPromptWithAttachments,
+  imageContentFromAttachments,
+} from '../../src/core/attachments.js';
+import type { MessageAttachment } from '../../src/core/attachments.js';
+
+describe('attachment prompt formatting', () => {
+  it('keeps image attachments as image content and adds a prompt summary', () => {
+    const attachments: MessageAttachment[] = [
+      {
+        id: 'a1',
+        name: 'shot.png',
+        mimeType: 'image/png',
+        size: 12,
+        kind: 'image',
+        data: 'abc123',
+      },
+    ];
+
+    expect(formatPromptWithAttachments('describe this', attachments)).toContain(
+      '[Attached image: shot.png (image/png, 12 B)]'
+    );
+    expect(imageContentFromAttachments(attachments)).toEqual([
+      { type: 'image', mimeType: 'image/png', data: 'abc123' },
+    ]);
+  });
+
+  it('inlines text attachments into the prompt', () => {
+    const prompt = formatPromptWithAttachments('', [
+      {
+        id: 'a1',
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        size: 5,
+        kind: 'text',
+        text: 'hello',
+      },
+    ]);
+
+    expect(prompt).toContain('BEGIN ATTACHMENT notes.txt');
+    expect(prompt).toContain('hello');
+    expect(imageContentFromAttachments([])).toEqual([]);
+  });
+});

--- a/packages/webapp/tests/core/attachments.test.ts
+++ b/packages/webapp/tests/core/attachments.test.ts
@@ -42,4 +42,32 @@ describe('attachment prompt formatting', () => {
     expect(prompt).toContain('hello');
     expect(imageContentFromAttachments([])).toEqual([]);
   });
+
+  it('references the VFS path when an attachment was off-loaded to /tmp', () => {
+    const attachments: MessageAttachment[] = [
+      {
+        id: 'a1',
+        name: 'big.log',
+        mimeType: 'text/plain',
+        size: 4_500_000,
+        kind: 'text',
+        path: '/tmp/attachment-abc-1-big.log',
+      },
+      {
+        id: 'a2',
+        name: 'huge.bin',
+        mimeType: 'application/octet-stream',
+        size: 60_000_000,
+        kind: 'file',
+        path: '/tmp/attachment-abc-2-huge.bin',
+      },
+    ];
+
+    const prompt = formatPromptWithAttachments('analyze', attachments);
+    expect(prompt).toContain('saved to /tmp/attachment-abc-1-big.log');
+    expect(prompt).toContain('big.log (text/plain, 4.3 MB)');
+    expect(prompt).toContain('saved to /tmp/attachment-abc-2-huge.bin');
+    // Path-only attachments should not surface as ImageContent.
+    expect(imageContentFromAttachments(attachments)).toEqual([]);
+  });
 });

--- a/packages/webapp/tests/scoops/llm-session-id.test.ts
+++ b/packages/webapp/tests/scoops/llm-session-id.test.ts
@@ -118,4 +118,12 @@ describe('getAdobeSessionId', () => {
     expect(prefix).toMatch(/^[0-9a-f]{8}-/); // a UUID
     expect(suffix).toMatch(/^[0-9a-f]{16}$/);
   });
+
+  it('falls back when global localStorage is not a usable Storage object', async () => {
+    vi.stubGlobal('localStorage', {});
+
+    const id = await getAdobeSessionId(cone('cone_invalid_storage'), 'cone_invalid_storage');
+
+    expect(id).toMatch(/^[0-9a-f]{8}-/);
+  });
 });

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -340,6 +340,34 @@ describe('ScoopContext prompt queueing', () => {
     await promptPromise;
   });
 
+  it('preserves image attachments when queueing follow-up prompts', async () => {
+    let resolveFirst: () => void;
+    const firstPromptDone = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+
+    injectMockAgent(ctx, async (text) => {
+      if (text === 'first') {
+        await firstPromptDone;
+      }
+    });
+
+    const promptPromise = ctx.prompt('first');
+    await ctx.prompt('second', [{ type: 'image', mimeType: 'image/png', data: 'abc123' }]);
+
+    expect((ctx as any).agent.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: [
+          { type: 'text', text: 'second' },
+          { type: 'image', mimeType: 'image/png', data: 'abc123' },
+        ],
+      })
+    );
+
+    resolveFirst!();
+    await promptPromise;
+  });
+
   it('stop() clears the queue and aborts', async () => {
     let resolveFirst: () => void;
     const firstPromptDone = new Promise<void>((r) => {

--- a/packages/webapp/tests/scoops/tray-follower-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-follower-sync.test.ts
@@ -77,6 +77,31 @@ describe('FollowerSyncManager', () => {
       expect(sent[0]).toEqual({ type: 'user_message', text: 'hello', messageId: 'msg-1' });
     });
 
+    it('sends attachments with user_message payloads', () => {
+      const channel = new FakeChannel();
+      const follower = new FollowerSyncManager(channel);
+      const attachments = [
+        {
+          id: 'a1',
+          name: 'notes.txt',
+          mimeType: 'text/plain',
+          size: 5,
+          kind: 'text' as const,
+          text: 'hello',
+        },
+      ];
+
+      follower.sendMessage('hello', 'msg-1', attachments);
+
+      const sent = channel.parseSent();
+      expect(sent[0]).toEqual({
+        type: 'user_message',
+        text: 'hello',
+        messageId: 'msg-1',
+        attachments,
+      });
+    });
+
     it('generates a messageId when not provided', () => {
       const channel = new FakeChannel();
       const follower = new FollowerSyncManager(channel);
@@ -194,7 +219,38 @@ describe('FollowerSyncManager', () => {
         scoopJid: 'cone',
       });
 
-      expect(onUserMessage).toHaveBeenCalledWith('hello from leader', 'msg-42', 'cone');
+      expect(onUserMessage).toHaveBeenCalledWith('hello from leader', 'msg-42', 'cone', undefined);
+    });
+
+    it('passes user_message_echo attachments to onUserMessage', () => {
+      const channel = new FakeChannel();
+      const onUserMessage = vi.fn();
+      const follower = new FollowerSyncManager(channel, { onUserMessage });
+      const attachments = [
+        {
+          id: 'a1',
+          name: 'notes.txt',
+          mimeType: 'text/plain',
+          size: 5,
+          kind: 'text' as const,
+          text: 'hello',
+        },
+      ];
+
+      channel.simulateLeaderMessage({
+        type: 'user_message_echo',
+        text: 'hello from leader',
+        messageId: 'msg-42',
+        scoopJid: 'cone',
+        attachments,
+      });
+
+      expect(onUserMessage).toHaveBeenCalledWith(
+        'hello from leader',
+        'msg-42',
+        'cone',
+        attachments
+      );
     });
 
     it('does not crash when onUserMessage is not provided', () => {
@@ -244,7 +300,7 @@ describe('FollowerSyncManager', () => {
       });
 
       // Should trigger onUserMessage
-      expect(onUserMessage).toHaveBeenCalledWith('hello from leader', 'msg-456', 'cone');
+      expect(onUserMessage).toHaveBeenCalledWith('hello from leader', 'msg-456', 'cone', undefined);
     });
 
     it('only deduplicates each message ID once (single use)', () => {
@@ -272,7 +328,7 @@ describe('FollowerSyncManager', () => {
         scoopJid: 'cone',
       });
       expect(onUserMessage).toHaveBeenCalledTimes(1);
-      expect(onUserMessage).toHaveBeenCalledWith('repeat test', 'msg-789', 'cone');
+      expect(onUserMessage).toHaveBeenCalledWith('repeat test', 'msg-789', 'cone', undefined);
     });
   });
 

--- a/packages/webapp/tests/scoops/tray-follower-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-follower-sync.test.ts
@@ -102,6 +102,53 @@ describe('FollowerSyncManager', () => {
       });
     });
 
+    it('strips local paths from path-only attachments before sending', () => {
+      const channel = new FakeChannel();
+      const follower = new FollowerSyncManager(channel);
+
+      follower.sendMessage('check this', 'msg-2', [
+        {
+          id: 'a1',
+          name: 'huge.bin',
+          mimeType: 'application/octet-stream',
+          size: 60_000_000,
+          kind: 'file',
+          path: '/tmp/attachment-follower-only',
+        },
+      ]);
+
+      const sent = channel.parseSent() as Array<{
+        attachments?: { path?: string; error?: string }[];
+      }>;
+      const sentAttachments = sent[0].attachments;
+      expect(sentAttachments?.[0].path).toBeUndefined();
+      expect(sentAttachments?.[0].error).toMatch(/remote runtime/);
+    });
+
+    it('strips local paths but keeps inline content for hybrid attachments', () => {
+      const channel = new FakeChannel();
+      const follower = new FollowerSyncManager(channel);
+
+      follower.sendMessage('look', 'msg-3', [
+        {
+          id: 'a1',
+          name: 'note.txt',
+          mimeType: 'text/plain',
+          size: 5,
+          kind: 'text',
+          text: 'hello',
+          // Should never normally happen, but defend against it anyway.
+          path: '/tmp/attachment-follower-local',
+        },
+      ]);
+
+      const sent = channel.parseSent() as Array<{
+        attachments?: { path?: string; text?: string }[];
+      }>;
+      expect(sent[0].attachments?.[0].path).toBeUndefined();
+      expect(sent[0].attachments?.[0].text).toBe('hello');
+    });
+
     it('generates a messageId when not provided', () => {
       const channel = new FakeChannel();
       const follower = new FollowerSyncManager(channel);
@@ -225,7 +272,7 @@ describe('FollowerSyncManager', () => {
     it('passes user_message_echo attachments to onUserMessage', () => {
       const channel = new FakeChannel();
       const onUserMessage = vi.fn();
-      const follower = new FollowerSyncManager(channel, { onUserMessage });
+      new FollowerSyncManager(channel, { onUserMessage });
       const attachments = [
         {
           id: 'a1',

--- a/packages/webapp/tests/scoops/tray-leader-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader-sync.test.ts
@@ -193,7 +193,32 @@ describe('LeaderSyncManager', () => {
 
     channel.simulateMessage({ type: 'user_message', text: 'from follower', messageId: 'fm1' });
 
-    expect(onFollowerMessage).toHaveBeenCalledWith('from follower', 'fm1');
+    expect(onFollowerMessage).toHaveBeenCalledWith('from follower', 'fm1', undefined);
+  });
+
+  it('handles follower user_message attachments', () => {
+    const { manager, onFollowerMessage } = createManager();
+    const channel = new FakeChannel();
+    manager.addFollower('b1', channel);
+    const attachments = [
+      {
+        id: 'a1',
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        size: 5,
+        kind: 'text' as const,
+        text: 'hello',
+      },
+    ];
+
+    channel.simulateMessage({
+      type: 'user_message',
+      text: 'from follower',
+      messageId: 'fm1',
+      attachments,
+    });
+
+    expect(onFollowerMessage).toHaveBeenCalledWith('from follower', 'fm1', attachments);
   });
 
   it('handles follower abort', () => {

--- a/packages/webapp/tests/scoops/tray-leader-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader-sync.test.ts
@@ -221,6 +221,34 @@ describe('LeaderSyncManager', () => {
     expect(onFollowerMessage).toHaveBeenCalledWith('from follower', 'fm1', attachments);
   });
 
+  it('strips path-only attachments from follower messages before forwarding', () => {
+    const { manager, onFollowerMessage } = createManager();
+    const channel = new FakeChannel();
+    manager.addFollower('b1', channel);
+
+    channel.simulateMessage({
+      type: 'user_message',
+      text: 'from follower',
+      messageId: 'fm2',
+      attachments: [
+        {
+          id: 'a1',
+          name: 'huge.bin',
+          mimeType: 'application/octet-stream',
+          size: 60_000_000,
+          kind: 'file',
+          path: '/tmp/attachment-follower-only',
+        },
+      ],
+    });
+
+    const forwarded = onFollowerMessage.mock.calls[0][2] as
+      | { path?: string; error?: string }[]
+      | undefined;
+    expect(forwarded?.[0].path).toBeUndefined();
+    expect(forwarded?.[0].error).toMatch(/remote runtime/);
+  });
+
   it('handles follower abort', () => {
     const { manager, onFollowerAbort } = createManager();
     const channel = new FakeChannel();

--- a/packages/webapp/tests/ui/attachment-vfs.test.ts
+++ b/packages/webapp/tests/ui/attachment-vfs.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import 'fake-indexeddb/auto';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import {
+  createAttachmentTmpWriter,
+  makeAttachmentPath,
+  sanitizeAttachmentName,
+} from '../../src/ui/attachment-vfs.js';
+
+describe('attachment-vfs', () => {
+  describe('sanitizeAttachmentName', () => {
+    it('preserves safe characters and dots', () => {
+      expect(sanitizeAttachmentName('hello-world.v2.txt')).toBe('hello-world.v2.txt');
+    });
+
+    it('replaces spaces and slashes', () => {
+      expect(sanitizeAttachmentName('my notes/draft 1.md')).toBe('my_notes_draft_1.md');
+    });
+
+    it('falls back to "attachment" for fully stripped names', () => {
+      expect(sanitizeAttachmentName('***')).toBe('attachment');
+    });
+  });
+
+  describe('makeAttachmentPath', () => {
+    it('produces deterministic, collision-resistant /tmp paths', () => {
+      const a = makeAttachmentPath('hello world.txt', 1, 1);
+      const b = makeAttachmentPath('hello world.txt', 1, 2);
+      expect(a).toMatch(/^\/tmp\/attachment-1-1-hello_world\.txt$/);
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('createAttachmentTmpWriter', () => {
+    let dbCounter = 0;
+    let fs: VirtualFS;
+
+    beforeEach(async () => {
+      dbCounter += 1;
+      fs = await VirtualFS.create({ dbName: `attachment-vfs-${dbCounter}`, wipe: true });
+    });
+
+    afterEach(async () => {
+      // Best-effort cleanup; ignore errors on already-removed dirs.
+      await fs.rm('/tmp', { recursive: true }).catch(() => {});
+    });
+
+    it('writes the file bytes into /tmp and returns the path', async () => {
+      const writer = createAttachmentTmpWriter(fs);
+      const file = new File([new Uint8Array([10, 20, 30, 40])], 'data.bin', {
+        type: 'application/octet-stream',
+      });
+
+      const path = await writer(file);
+
+      expect(path.startsWith('/tmp/')).toBe(true);
+      const stored = (await fs.readFile(path, { encoding: 'binary' })) as Uint8Array;
+      expect(Array.from(stored)).toEqual([10, 20, 30, 40]);
+    });
+
+    it('produces unique paths for two writes of the same file name', async () => {
+      const writer = createAttachmentTmpWriter(fs);
+      const file = new File(['x'], 'note.txt', { type: 'text/plain' });
+      const a = await writer(file);
+      const b = await writer(file);
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/packages/webapp/tests/ui/attachment-vfs.test.ts
+++ b/packages/webapp/tests/ui/attachment-vfs.test.ts
@@ -26,9 +26,15 @@ describe('attachment-vfs', () => {
 
   describe('makeAttachmentPath', () => {
     it('produces deterministic, collision-resistant /tmp paths', () => {
-      const a = makeAttachmentPath('hello world.txt', 1, 1);
-      const b = makeAttachmentPath('hello world.txt', 1, 2);
-      expect(a).toMatch(/^\/tmp\/attachment-1-1-hello_world\.txt$/);
+      const a = makeAttachmentPath('hello world.txt', 1, 1, 'abcd1234');
+      const b = makeAttachmentPath('hello world.txt', 1, 2, 'abcd1234');
+      expect(a).toMatch(/^\/tmp\/attachment-1-1-abcd1234-hello_world\.txt$/);
+      expect(a).not.toBe(b);
+    });
+
+    it('disambiguates across writer instances via the random segment', () => {
+      const a = makeAttachmentPath('same.txt', 1, 1, 'aaaaaaaa');
+      const b = makeAttachmentPath('same.txt', 1, 1, 'bbbbbbbb');
       expect(a).not.toBe(b);
     });
   });
@@ -45,6 +51,9 @@ describe('attachment-vfs', () => {
     afterEach(async () => {
       // Best-effort cleanup; ignore errors on already-removed dirs.
       await fs.rm('/tmp', { recursive: true }).catch(() => {});
+      // Close IndexedDB connections / drop the fake-indexeddb DB to
+      // avoid spurious AbortError rejections leaking between tests.
+      await fs.dispose();
     });
 
     it('writes the file bytes into /tmp and returns the path', async () => {

--- a/packages/webapp/tests/ui/chat-fixture.test.ts
+++ b/packages/webapp/tests/ui/chat-fixture.test.ts
@@ -54,6 +54,12 @@ describe('createChatFixture', () => {
     expect(msgs.some((m) => m.queued === true)).toBe(true);
   });
 
+  it('includes a user message with image and text attachments', () => {
+    const attachmentMsg = byId.get('fx-user-attachment');
+    expect(attachmentMsg).toBeDefined();
+    expect(attachmentMsg!.attachments?.map((a) => a.kind).sort()).toEqual(['image', 'text']);
+  });
+
   it('includes tool calls in all four display states', () => {
     const allToolCalls = msgs.flatMap((m) => m.toolCalls ?? []);
     expect(allToolCalls.length).toBeGreaterThan(0);

--- a/packages/webapp/tests/ui/chat-panel-attachments.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-attachments.test.ts
@@ -115,6 +115,29 @@ describe('ChatPanel attachments', () => {
     expect(attachments[0].text).toBeUndefined();
   });
 
+  it('returns an error image attachment when no writer is wired and the file is too large', async () => {
+    // 6 MB image, exceeds the 5 MB inline cap. With no writer, instead of
+    // dropping the file silently, the composer should keep an "error"
+    // image chip so the user can see what happened.
+    const big = new File([new Uint8Array(6 * 1024 * 1024)], 'huge.png', {
+      type: 'image/png',
+    });
+
+    await panel.addAttachmentsFromFiles([big]);
+
+    const meta = container.querySelector('.attachment-chip__meta')?.textContent;
+    expect(meta).toBe('not included');
+
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+    const [, , attachments] = sendMessage.mock.calls[0];
+    expect(attachments[0]).toMatchObject({
+      name: 'huge.png',
+      kind: 'image',
+    });
+    expect(attachments[0].error).toMatch(/inline limit/);
+    expect(attachments[0].data).toBeUndefined();
+  });
+
   it('off-loads unsupported binaries to /tmp via the attachment writer', async () => {
     const writer = vi.fn(async () => '/tmp/written-archive.zip');
     panel.setAttachmentWriter(writer);

--- a/packages/webapp/tests/ui/chat-panel-attachments.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-attachments.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { ChatPanel } from '../../src/ui/chat-panel.js';
+import type { AgentHandle, AgentEvent } from '../../src/ui/types.js';
+
+vi.mock('../../src/ui/voice-input.js', () => ({
+  VoiceInput: class {
+    destroy() {}
+    start() {}
+    stop() {}
+    setAutoSend() {}
+    setLang() {}
+    isListening() {
+      return false;
+    }
+  },
+  getVoiceAutoSend: () => false,
+  getVoiceLang: () => 'en-US',
+}));
+
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => '',
+  showProviderSettings: () => {},
+  applyProviderDefaults: () => {},
+  getAllAvailableModels: () => [],
+  getSelectedModelId: () => '',
+  getSelectedProvider: () => null,
+  setSelectedModelId: () => {},
+  getProviderConfig: () => null,
+}));
+
+describe('ChatPanel attachments', () => {
+  let container: HTMLElement;
+  let panel: ChatPanel;
+  let sendMessage: ReturnType<typeof vi.fn>;
+  let testCounter = 0;
+
+  beforeEach(async () => {
+    testCounter += 1;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    panel = new ChatPanel(container);
+    await panel.initSession(`test-attachments-${testCounter}`);
+    sendMessage = vi.fn();
+    const handle: AgentHandle = {
+      sendMessage,
+      onEvent(_cb: (event: AgentEvent) => void) {
+        return () => {};
+      },
+      stop() {},
+    };
+    panel.setAgent(handle);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('adds a text file attachment and sends it with the chat message', async () => {
+    const file = new File(['hello from a file'], 'notes.txt', { type: 'text/plain' });
+
+    await panel.addAttachmentsFromFiles([file]);
+
+    expect(container.querySelector('.chat__attachments--visible')).not.toBeNull();
+    expect(container.querySelector('.attachment-chip__name')?.textContent).toBe('notes.txt');
+
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'Use this file';
+    textarea.dispatchEvent(new Event('input'));
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const [text, _id, attachments] = sendMessage.mock.calls[0];
+    expect(text).toBe('Use this file');
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toMatchObject({
+      name: 'notes.txt',
+      mimeType: 'text/plain',
+      kind: 'text',
+      text: 'hello from a file',
+    });
+    expect(container.querySelector('.msg--user .attachment-chip__name')?.textContent).toBe(
+      'notes.txt'
+    );
+  });
+
+  it('can send an image-only message', async () => {
+    // Smallest valid 1x1 transparent PNG, expressed as raw bytes to avoid
+    // tripping secret scanners on the base64 form.
+    const tinyPng = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+      0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x04, 0x00, 0x00, 0x00, 0xb5,
+      0x1c, 0x0c, 0x02, 0x00, 0x00, 0x00, 0x0b, 0x49, 0x44, 0x41, 0x54, 0x78, 0xda, 0x63, 0x64,
+      0x60, 0x00, 0x00, 0x00, 0x06, 0x00, 0x02, 0x30, 0x81, 0xd0, 0x2f, 0x00, 0x00, 0x00, 0x00,
+      0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+    const file = new File([tinyPng], 'dot.png', { type: 'image/png' });
+
+    await panel.addAttachmentsFromFiles([file]);
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const [text, _id, attachments] = sendMessage.mock.calls[0];
+    expect(text).toBe('');
+    expect(attachments[0]).toMatchObject({
+      name: 'dot.png',
+      mimeType: 'image/png',
+      kind: 'image',
+    });
+    expect(attachments[0].data).toBeTruthy();
+    expect(container.querySelector('.msg--user .attachment-chip img')).not.toBeNull();
+  });
+});

--- a/packages/webapp/tests/ui/chat-panel-attachments.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-attachments.test.ts
@@ -86,6 +86,54 @@ describe('ChatPanel attachments', () => {
     );
   });
 
+  it('off-loads oversized text files to /tmp via the attachment writer', async () => {
+    const writer = vi.fn(async (file: File) => `/tmp/written-${file.name}`);
+    panel.setAttachmentWriter(writer);
+
+    // 600 KB text file — well above the 512 KB inline cap.
+    const big = new File([new Uint8Array(600 * 1024).fill(65)], 'big.log', {
+      type: 'text/plain',
+    });
+
+    await panel.addAttachmentsFromFiles([big]);
+
+    expect(writer).toHaveBeenCalledTimes(1);
+    expect(writer).toHaveBeenCalledWith(big);
+
+    expect(container.querySelector('.attachment-chip__path')?.textContent).toBe(
+      '/tmp/written-big.log'
+    );
+
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const [, , attachments] = sendMessage.mock.calls[0];
+    expect(attachments[0]).toMatchObject({
+      name: 'big.log',
+      kind: 'text',
+      path: '/tmp/written-big.log',
+    });
+    expect(attachments[0].text).toBeUndefined();
+  });
+
+  it('off-loads unsupported binaries to /tmp via the attachment writer', async () => {
+    const writer = vi.fn(async () => '/tmp/written-archive.zip');
+    panel.setAttachmentWriter(writer);
+
+    const blob = new File([new Uint8Array([1, 2, 3, 4])], 'archive.zip', {
+      type: 'application/zip',
+    });
+
+    await panel.addAttachmentsFromFiles([blob]);
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+
+    const [, , attachments] = sendMessage.mock.calls[0];
+    expect(attachments[0]).toMatchObject({
+      name: 'archive.zip',
+      kind: 'file',
+      path: '/tmp/written-archive.zip',
+    });
+  });
+
   it('can send an image-only message', async () => {
     // Smallest valid 1x1 transparent PNG, expressed as raw bytes to avoid
     // tripping secret scanners on the base64 form.

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -68,6 +68,26 @@ describe('OffscreenClient', () => {
     expect(envelope.payload.messageId).toBe('msg-1');
   });
 
+  it('sends attachments with user-message payloads', () => {
+    client.selectedScoopJid = 'cone_123';
+    const handle = client.createAgentHandle();
+    const attachments = [
+      {
+        id: 'a1',
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        size: 5,
+        kind: 'text' as const,
+        text: 'hello',
+      },
+    ];
+
+    handle.sendMessage('Hello world', 'msg-1', attachments);
+
+    const envelope = sentMessages[0] as { source: string; payload: any };
+    expect(envelope.payload.attachments).toEqual(attachments);
+  });
+
   it('sends abort on stop', () => {
     client.selectedScoopJid = 'cone_123';
     const handle = client.createAgentHandle();

--- a/packages/webapp/tests/ui/skill-drop.test.ts
+++ b/packages/webapp/tests/ui/skill-drop.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   findDroppedSkillFile,
+  findDroppedNonSkillTransferFiles,
   findDroppedSkillTransferFile,
   isSkillArchiveName,
 } from '../../src/ui/skill-drop.js';
@@ -49,5 +50,26 @@ describe('skill-drop helpers', () => {
         ],
       })
     ).toBeNull();
+  });
+
+  it('returns dropped non-skill files for chat attachment handling', () => {
+    const files = findDroppedNonSkillTransferFiles({
+      files: [{ name: 'notes.txt' }, { name: 'pack.skill' }, { name: 'photo.png' }],
+    });
+
+    expect(files.map((file) => file.name)).toEqual(['notes.txt', 'photo.png']);
+  });
+
+  it('returns non-skill files from dataTransfer items when files is empty', () => {
+    const files = findDroppedNonSkillTransferFiles({
+      files: [],
+      items: [
+        { kind: 'string', getAsFile: () => ({ name: 'ignored.txt' }) },
+        { kind: 'file', getAsFile: () => ({ name: 'dragged.skill' }) },
+        { kind: 'file', getAsFile: () => ({ name: 'diagram.png' }) },
+      ],
+    });
+
+    expect(files.map((file) => file.name)).toEqual(['diagram.png']);
   });
 });

--- a/packages/webapp/tests/ui/types.test.ts
+++ b/packages/webapp/tests/ui/types.test.ts
@@ -48,10 +48,21 @@ describe('UI types', () => {
       id: 'm1',
       role: 'user',
       content: 'Hello',
+      attachments: [
+        {
+          id: 'a1',
+          name: 'notes.txt',
+          mimeType: 'text/plain',
+          size: 5,
+          kind: 'text',
+          text: 'hello',
+        },
+      ],
       timestamp: Date.now(),
     };
     expect(msg.id).toBe('m1');
     expect(msg.role).toBe('user');
+    expect(msg.attachments?.[0].name).toBe('notes.txt');
   });
 
   it('ChatMessage supports tool calls', () => {


### PR DESCRIPTION
Adds drag-and-drop / paperclip file attachments to the chat composer, with two complementary strategies for getting the file in front of the agent:

- **Inline** (small files): images go through the existing image processor and are forwarded as ImageContent to the LLM; text-like files are inlined into the prompt with a cap at 512 KB.
- **Off-load** (large files / unsupported binaries): the file is written to ` /tmp/attachment-…` on the virtual filesystem and the prompt references that path. The agent can then ` read_file`/`cat` it instead of trying to swallow a multi-megabyte payload.

Threaded through ` AgentHandle` → orchestrator → ` ScoopContext` → tray leader/follower sync → offscreen bridge so attachments survive every float (standalone, extension, tray follower).

### UI

- Paperclip composer button + hidden ` <input type=file>`.
- Whole-window drop overlay distinguishes ` .skill` archives (still install into ` /workspace/skills`) from regular files (attach to chat).
- Attachment chips render in the composer and on rendered user messages, with image thumbnails for inlined images and a monospace path subtitle for off-loaded ones.

### Wiring

- ` ChatPanel.setAttachmentWriter()` accepts a ` (file: File) => Promise<string>` writer.
- ` createAttachmentTmpWriter(fs)` (new ` packages/webapp/src/ui/attachment-vfs.ts`) writes bytes to ` /tmp/attachment-{ts}-{seq}-{sanitized}` and returns the path.
- ` main.ts` wires the writer to ` localFs` (extension side panel) and ` orchestrator.getSharedFS()` (standalone). Both target the same ` slicc-fs` IndexedDB the offscreen agent reads from.

### Verification

- ` npm run typecheck` clean.
- ` npm run test`: 3034 passed, 2 skipped (was 3025 — added 9 tests across ` core/attachments`, ` ui/attachment-vfs`, and ` ui/chat-panel-attachments`).
- ` npm run build -w @slicc/webapp` and ` npm run build -w @slicc/chrome-extension` both succeed.

### Origin

Picked up an abandoned codex worktree at ` ~/.codex/worktrees/5c8c/slicc` (uncommitted) and finished the work — first commit is the codex feature; second commit adds the ` /tmp` off-load behavior with its own test module.