### PR TITLE
fix(mount): fail fast in scoop context, add 5-min timeout (#508)

### DIFF
--- a/packages/webapp/src/fs/mount-commands.ts
+++ b/packages/webapp/src/fs/mount-commands.ts
@@ -30,6 +30,34 @@ export interface MountCommandResult {
 
 export interface MountCommandsOptions {
   fs: VirtualFS;
+  /**
+   * Returns true when the command is running inside a non-interactive scoop
+   * context (no human at the keyboard to approve a directory picker). When
+   * true, mount fails fast instead of hanging on a tool UI prompt nobody
+   * will see. Defaults to false (interactive).
+   */
+  isScoop?: () => boolean;
+}
+
+/**
+ * Maximum time the agent-driven (cone) mount flow waits for the user to
+ * resolve the approval / picker UI. Five minutes matches the slowest
+ * realistic human response while preventing indefinite hangs.
+ */
+const MOUNT_TOOL_UI_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Race a promise against a timeout that resolves with a sentinel value. */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | { __timeout: true }> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<{ __timeout: true }>((resolve) => {
+    timer = setTimeout(() => resolve({ __timeout: true }), ms);
+  });
+  return Promise.race([
+    promise.finally(() => {
+      if (timer) clearTimeout(timer);
+    }),
+    timeout,
+  ]);
 }
 
 type ShowDirectoryPickerFn = (opts?: object) => Promise<FileSystemDirectoryHandle>;
@@ -101,6 +129,19 @@ export class MountCommands {
       };
     }
 
+    // Fail fast when invoked from a non-interactive scoop: there is no human
+    // attached to the scoop's chat to approve the picker, so the tool UI
+    // would hang indefinitely. Cone (interactive) keeps the existing flow.
+    if (this.options.isScoop?.()) {
+      return {
+        stdout: '',
+        stderr:
+          'mount: cannot mount from a scoop (non-interactive context). ' +
+          'Ask the cone to mount the directory and share the path.\n',
+        exitCode: 1,
+      };
+    }
+
     if (typeof window === 'undefined' || !('showDirectoryPicker' in window)) {
       return {
         stdout: '',
@@ -124,7 +165,7 @@ export class MountCommands {
 
     if (toolContext) {
       // Agent-driven: show approval UI before opening picker
-      const result = await showToolUIFromContext({
+      const uiPromise = showToolUIFromContext({
         html: `
           <div class="sprinkle-action-card">
             <div class="sprinkle-action-card__header">Mount at <code>${escapeHtml(targetPath)}</code> <span class="sprinkle-badge sprinkle-badge--notice">approval</span></div>
@@ -168,6 +209,24 @@ export class MountCommands {
           return { denied: true };
         },
       });
+
+      const raced = await withTimeout(
+        // showToolUIFromContext returns Promise<unknown | null> — keep that shape
+        Promise.resolve(uiPromise),
+        MOUNT_TOOL_UI_TIMEOUT_MS
+      );
+
+      if (raced && typeof raced === 'object' && '__timeout' in raced) {
+        return {
+          stdout: '',
+          stderr:
+            `mount: timed out after ${Math.round(MOUNT_TOOL_UI_TIMEOUT_MS / 60000)} minute(s) ` +
+            'waiting for user approval\n',
+          exitCode: 1,
+        };
+      }
+
+      const result = raced;
 
       if (!result) {
         return { stdout: '', stderr: 'mount: tool UI not available', exitCode: 1 };

--- a/packages/webapp/src/fs/mount-commands.ts
+++ b/packages/webapp/src/fs/mount-commands.ts
@@ -10,7 +10,7 @@
  */
 
 import type { VirtualFS } from './virtual-fs.js';
-import { getToolExecutionContext, showToolUIFromContext } from '../tools/tool-ui.js';
+import { getToolExecutionContext, showToolUI, toolUIRegistry } from '../tools/tool-ui.js';
 
 /** Escape HTML special characters to prevent XSS */
 function escapeHtml(text: string): string {
@@ -34,7 +34,8 @@ export interface MountCommandsOptions {
    * Returns true when the command is running inside a non-interactive scoop
    * context (no human at the keyboard to approve a directory picker). When
    * true, mount fails fast instead of hanging on a tool UI prompt nobody
-   * will see. Defaults to false (interactive).
+   * will see. Omit this option in interactive (cone / standalone) contexts;
+   * when omitted it is treated as undefined / not a scoop.
    */
   isScoop?: () => boolean;
 }
@@ -46,19 +47,12 @@ export interface MountCommandsOptions {
  */
 const MOUNT_TOOL_UI_TIMEOUT_MS = 5 * 60 * 1000;
 
-/** Race a promise against a timeout that resolves with a sentinel value. */
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | { __timeout: true }> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<{ __timeout: true }>((resolve) => {
-    timer = setTimeout(() => resolve({ __timeout: true }), ms);
-  });
-  return Promise.race([
-    promise.finally(() => {
-      if (timer) clearTimeout(timer);
-    }),
-    timeout,
-  ]);
-}
+/**
+ * Unique sentinel returned by the timeout race so it can never be confused
+ * with a legitimate tool UI result (which is `unknown`). Compared by
+ * reference identity, not structural shape.
+ */
+const MOUNT_TIMEOUT_SENTINEL: unique symbol = Symbol('mount:timeout');
 
 type ShowDirectoryPickerFn = (opts?: object) => Promise<FileSystemDirectoryHandle>;
 
@@ -164,9 +158,18 @@ export class MountCommands {
     let dirHandle: FileSystemDirectoryHandle;
 
     if (toolContext) {
-      // Agent-driven: show approval UI before opening picker
-      const uiPromise = showToolUIFromContext({
-        html: `
+      // Agent-driven: show approval UI before opening picker. We drive
+      // showToolUI directly (rather than the helper) so we own the request
+      // id and can cancel the registry entry when the timeout fires —
+      // otherwise a late click would still run the picker callback after
+      // the command has already exited.
+      const uiRequestId = toolUIRegistry.generateId();
+      let timedOut = false;
+
+      const rawUiPromise = showToolUI(
+        {
+          id: uiRequestId,
+          html: `
           <div class="sprinkle-action-card">
             <div class="sprinkle-action-card__header">Mount at <code>${escapeHtml(targetPath)}</code> <span class="sprinkle-badge sprinkle-badge--notice">approval</span></div>
             <div class="sprinkle-action-card__actions">
@@ -175,48 +178,66 @@ export class MountCommands {
             </div>
           </div>
         `,
-        onAction: async (action, data) => {
-          if (action === 'approve') {
-            const d = data as Record<string, unknown> | undefined;
+          onAction: async (action, data) => {
+            if (action === 'approve') {
+              const d = data as Record<string, unknown> | undefined;
 
-            if (d?.handleInIdb && typeof d.idbKey === 'string') {
+              if (d?.handleInIdb && typeof d.idbKey === 'string') {
+                try {
+                  const handle = await loadAndClearPendingHandle(d.idbKey);
+                  if (!handle) return { error: 'No directory handle found in storage' };
+                  await reactivateHandle(handle);
+                  return { approved: true, handle };
+                } catch (err: unknown) {
+                  return { error: err instanceof Error ? err.message : String(err) };
+                }
+              }
+
+              if (d?.cancelled) return { cancelled: true };
+              if (d?.error) return { error: String(d.error) };
+
               try {
-                const handle = await loadAndClearPendingHandle(d.idbKey);
-                if (!handle) return { error: 'No directory handle found in storage' };
-                await reactivateHandle(handle);
+                const handle = await (
+                  window as Window &
+                    typeof globalThis & { showDirectoryPicker: ShowDirectoryPickerFn }
+                ).showDirectoryPicker({ mode: 'readwrite' });
                 return { approved: true, handle };
               } catch (err: unknown) {
+                if (err instanceof Error && err.name === 'AbortError') {
+                  return { cancelled: true };
+                }
                 return { error: err instanceof Error ? err.message : String(err) };
               }
             }
-
-            if (d?.cancelled) return { cancelled: true };
-            if (d?.error) return { error: String(d.error) };
-
-            try {
-              const handle = await (
-                window as Window &
-                  typeof globalThis & { showDirectoryPicker: ShowDirectoryPickerFn }
-              ).showDirectoryPicker({ mode: 'readwrite' });
-              return { approved: true, handle };
-            } catch (err: unknown) {
-              if (err instanceof Error && err.name === 'AbortError') {
-                return { cancelled: true };
-              }
-              return { error: err instanceof Error ? err.message : String(err) };
-            }
-          }
-          return { denied: true };
+            return { denied: true };
+          },
         },
-      });
-
-      const raced = await withTimeout(
-        // showToolUIFromContext returns Promise<unknown | null> — keep that shape
-        Promise.resolve(uiPromise),
-        MOUNT_TOOL_UI_TIMEOUT_MS
+        toolContext.onUpdate
       );
 
-      if (raced && typeof raced === 'object' && '__timeout' in raced) {
+      // Swallow the registry rejection produced by our own cancel() call so
+      // it doesn't surface as an unhandled promise rejection. Other
+      // rejections (e.g. agent abort) are still observable via the race.
+      const safeUiPromise = rawUiPromise.catch((err: unknown) => {
+        if (timedOut) return MOUNT_TIMEOUT_SENTINEL;
+        throw err;
+      });
+
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<typeof MOUNT_TIMEOUT_SENTINEL>((resolve) => {
+        timeoutHandle = setTimeout(() => {
+          timedOut = true;
+          // Cancelling rejects the pending UI, removes the registry entry,
+          // and lets showToolUI emit tool_ui_done so the panel cleans up.
+          toolUIRegistry.cancel(uiRequestId, 'mount: timed out');
+          resolve(MOUNT_TIMEOUT_SENTINEL);
+        }, MOUNT_TOOL_UI_TIMEOUT_MS);
+      });
+
+      const result = await Promise.race([safeUiPromise, timeoutPromise]);
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+
+      if (result === MOUNT_TIMEOUT_SENTINEL) {
         return {
           stdout: '',
           stderr:
@@ -225,8 +246,6 @@ export class MountCommands {
           exitCode: 1,
         };
       }
-
-      const result = raced;
 
       if (!result) {
         return { stdout: '', stderr: 'mount: tool UI not available', exitCode: 1 };

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -253,6 +253,10 @@ export class ScoopContext {
         // tell the AgentBridge which scoop is the parent of any nested
         // `agent <cwd> ... <prompt>` invocation — used for model inheritance.
         getParentJid: () => this.scoop.jid,
+        // Mark non-cone scoops as non-interactive so commands like `mount`
+        // that need a human gesture fail fast instead of hanging on a tool
+        // UI nobody will see (issue #508).
+        isScoop: () => !this.scoop.isCone,
       });
       log.info('WasmShell initialized', { folder: this.scoop.folder });
       const skills = await loadSkills(effectiveSkillsFs, this.skillsDir);

--- a/packages/webapp/src/shell/wasm-shell.ts
+++ b/packages/webapp/src/shell/wasm-shell.ts
@@ -275,6 +275,13 @@ export interface WasmShellOptions {
    * shells that have no scoop owner.
    */
   getParentJid?: () => string | undefined;
+  /**
+   * Returns true when this shell is owned by a non-interactive scoop. Used by
+   * commands like `mount` that need a human at the keyboard to approve a
+   * picker — in scoop context they should fail fast instead of hanging on a
+   * tool UI nobody will see. Defaults to undefined (interactive).
+   */
+  isScoop?: () => boolean;
 }
 
 type BashExecOptionsWithSignal = NonNullable<Parameters<Bash['exec']>[1]> & {
@@ -345,7 +352,7 @@ export class WasmShell {
     });
 
     // Initialize mount commands with VirtualFS
-    this.mountCommands = new MountCommands({ fs: options.fs });
+    this.mountCommands = new MountCommands({ fs: options.fs, isScoop: options.isScoop });
 
     const scriptDiscoveryFs = options.jshDiscoveryFs ?? options.fs;
     const bshDiscoveryFs = options.bshDiscoveryFs ?? options.fs;

--- a/packages/webapp/tests/fs/mount-commands.test.ts
+++ b/packages/webapp/tests/fs/mount-commands.test.ts
@@ -94,6 +94,32 @@ describe('MountCommands', () => {
     });
   });
 
+  describe('scoop (non-interactive) context', () => {
+    it('fails fast with exitCode 1 when invoked from a scoop', async () => {
+      const cmd = new MountCommands({ fs: makeFs(), isScoop: () => true });
+      const result = await cmd.execute(['/workspace/myapp'], '/workspace');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('cannot mount from a scoop');
+    });
+
+    it('does not invoke the file picker in scoop context', async () => {
+      const mount = vi.fn();
+      const cmd = new MountCommands({ fs: makeFs({ mount }), isScoop: () => true });
+      const result = await cmd.execute(['/workspace/myapp'], '/workspace');
+      expect(result.exitCode).toBe(1);
+      expect(mount).not.toHaveBeenCalled();
+    });
+
+    it('still allows list/unmount/refresh subcommands inside a scoop', async () => {
+      const cmd = new MountCommands({
+        fs: makeFs({ listMounts: vi.fn(() => []) }),
+        isScoop: () => true,
+      });
+      const result = await cmd.execute(['list'], '/workspace');
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
   describe('--help', () => {
     it('returns exitCode 0', async () => {
       const cmd = new MountCommands({ fs: makeFs() });

--- a/packages/webapp/tests/fs/mount-commands.test.ts
+++ b/packages/webapp/tests/fs/mount-commands.test.ts
@@ -1,6 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { MountCommands } from '../../src/fs/mount-commands.js';
 import type { VirtualFS } from '../../src/fs/virtual-fs.js';
+import {
+  pushToolExecutionContext,
+  popToolExecutionContext,
+  toolUIRegistry,
+  type ToolExecutionContext,
+} from '../../src/tools/tool-ui.js';
 
 function makeMockMountIndex() {
   return {
@@ -102,12 +108,19 @@ describe('MountCommands', () => {
       expect(result.stderr).toContain('cannot mount from a scoop');
     });
 
-    it('does not invoke the file picker in scoop context', async () => {
+    it('does not invoke the directory picker or fs.mount in scoop context', async () => {
       const mount = vi.fn();
-      const cmd = new MountCommands({ fs: makeFs({ mount }), isScoop: () => true });
-      const result = await cmd.execute(['/workspace/myapp'], '/workspace');
-      expect(result.exitCode).toBe(1);
-      expect(mount).not.toHaveBeenCalled();
+      const showDirectoryPicker = vi.fn();
+      vi.stubGlobal('window', { showDirectoryPicker });
+      try {
+        const cmd = new MountCommands({ fs: makeFs({ mount }), isScoop: () => true });
+        const result = await cmd.execute(['/workspace/myapp'], '/workspace');
+        expect(result.exitCode).toBe(1);
+        expect(showDirectoryPicker).not.toHaveBeenCalled();
+        expect(mount).not.toHaveBeenCalled();
+      } finally {
+        vi.unstubAllGlobals();
+      }
     });
 
     it('still allows list/unmount/refresh subcommands inside a scoop', async () => {
@@ -117,6 +130,61 @@ describe('MountCommands', () => {
       });
       const result = await cmd.execute(['list'], '/workspace');
       expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('cone (interactive) timeout', () => {
+    let pushedCtx: ToolExecutionContext | null = null;
+
+    afterEach(() => {
+      if (pushedCtx) {
+        popToolExecutionContext(pushedCtx);
+        pushedCtx = null;
+      }
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    });
+
+    it('times out after 5 minutes, cancels the pending UI, and exits 1', async () => {
+      vi.useFakeTimers();
+      // mount only enters the timeout branch when window.showDirectoryPicker
+      // exists; never resolved by the test, so the user-action path stays
+      // pending and the timeout fires.
+      vi.stubGlobal('window', { showDirectoryPicker: vi.fn() });
+
+      const onUpdate = vi.fn();
+      pushedCtx = pushToolExecutionContext({
+        onUpdate,
+        toolName: 'bash',
+        toolCallId: 'tc-mount-timeout',
+      });
+
+      const cmd = new MountCommands({ fs: makeFs() });
+      const pendingBefore = toolUIRegistry.getPendingIds().length;
+
+      const promise = cmd.execute(['/workspace/myapp'], '/workspace');
+
+      // Let the synchronous showToolUI register before advancing timers.
+      await Promise.resolve();
+      expect(toolUIRegistry.getPendingIds().length).toBe(pendingBefore + 1);
+
+      // Trigger the 5-minute timeout deterministically.
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
+      const result = await promise;
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('timed out');
+
+      // Registry was cleaned up so a late click cannot re-trigger the
+      // picker callback after the command exited.
+      expect(toolUIRegistry.getPendingIds().length).toBe(pendingBefore);
+
+      // tool_ui_done was emitted via onUpdate so the panel can clear the
+      // approval prompt.
+      const blocks = onUpdate.mock.calls.flatMap(
+        (call) => (call[0]?.content ?? []) as Array<{ type?: string }>
+      );
+      expect(blocks.some((b) => b.type === 'tool_ui_done')).toBe(true);
     });
   });
 


### PR DESCRIPTION
Fixes #508.

## Problem

`mount` opens a directory picker that requires a human gesture. When the agent runs `mount` inside a non-interactive scoop, the tool UI is shown but no one is at the keyboard to approve it, so the call hangs indefinitely. The cone path can also wait forever if the user simply never interacts with the prompt.

Per @trieloff in the issue:

> 1. there is no timeout for mount. 5 minutes would help
> 2. there is no detection if the command is run from interactive cone or non-interactive scoop. in a scoop it should fail immediately

## Fix

- **Scoop guard**: `MountCommandsOptions` gains an `isScoop?: () => boolean` predicate, plumbed through `WasmShellOptions` from `ScoopContext` (`isScoop: () => !this.scoop.isCone`). When set, `mount` returns `exitCode 1` with a clear error before reaching the picker — `list`, `unmount`, and `refresh` still work in scoops.
- **5-minute timeout**: the agent-driven (cone) flow now races `showToolUIFromContext` against a 5-minute timeout. If the prompt is ignored, `mount` exits `1` with a timed-out message instead of pinning the agent forever.

## Tests

Added `mount-commands.test.ts` cases for the scoop guard and verified non-mount sub-commands still succeed in scoop context. `npm run typecheck` clean. The mount-related test files all pass; pre-existing failures in `isomorphic-git-esm`, `skills/catalog`, and `skills/install-from-drop` reproduce on `main` and are unrelated to this change.