### PR TITLE
fix(fs): add isPathUnderMount to RestrictedFS so git ops work in scoops

### DIFF
--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -141,6 +141,17 @@ export class RestrictedFS {
     return this.vfs.getLightningFS();
   }
 
+  /**
+   * Mount-membership query — needed by the isomorphic-git fs adapter,
+   * which routes mount-backed paths through the async VFS API instead of
+   * raw LightningFS. Delegates to the underlying VirtualFS; this is a
+   * read-only query with no sandbox security implications (scoops
+   * typically have no mounts, so it returns `false` for all their paths).
+   */
+  isPathUnderMount(path: string): boolean {
+    return this.vfs.isPathUnderMount(path);
+  }
+
   // ── Read operations: return "not found" for outside paths ────────────
 
   async readFile(path: string, options?: ReadFileOptions): Promise<FileContent> {

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -426,21 +426,29 @@ describe('RestrictedFS', () => {
     // missing method threw "e.isPathUnderMount is not a function" and
     // broke ALL git operations inside scoops. The method must exist and
     // delegate to the underlying VirtualFS.
-    it('delegates to the underlying VirtualFS', () => {
-      // Scoops typically have no mounts — so any path returns false.
+    it('returns false when there are no mounts (scoops are mountless by default)', () => {
       expect(restricted.isPathUnderMount('/scoops/andy-scoop/file.txt')).toBe(false);
       expect(restricted.isPathUnderMount('/shared/data.txt')).toBe(false);
       expect(restricted.isPathUnderMount('/anywhere/else')).toBe(false);
     });
 
-    it('returns true when the underlying VFS reports the path is under a mount', () => {
+    it('forwards the call to the underlying VFS with the original path', () => {
+      const calls: string[] = [];
       const stubVfs = {
-        isPathUnderMount: (p: string) => p.startsWith('/mnt/'),
+        isPathUnderMount: (p: string) => {
+          calls.push(p);
+          return p.startsWith('/mnt/');
+        },
         listMounts: () => ['/mnt'],
       } as unknown as VirtualFS;
       const r = new RestrictedFS(stubVfs, ['/scoops/andy-scoop/']);
+
       expect(r.isPathUnderMount('/mnt/foo')).toBe(true);
       expect(r.isPathUnderMount('/scoops/andy-scoop/file.txt')).toBe(false);
+      // Proves delegation: the underlying VFS must have been invoked with
+      // each input path verbatim. A no-op `return false` implementation
+      // would fail the `/mnt/foo` assertion above AND leave `calls` empty.
+      expect(calls).toEqual(['/mnt/foo', '/scoops/andy-scoop/file.txt']);
     });
   });
 });

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -418,4 +418,29 @@ describe('RestrictedFS', () => {
       expect(readOnly.canWrite('/scoops/andy-scoop/foo.txt')).toBe(true);
     });
   });
+
+  describe('isPathUnderMount', () => {
+    // Regression for issue #507 — git fs adapter calls
+    // `vfs.isPathUnderMount(path)` on whatever fs the WasmShell was
+    // constructed with. When that's a `RestrictedFS` (every scoop), the
+    // missing method threw "e.isPathUnderMount is not a function" and
+    // broke ALL git operations inside scoops. The method must exist and
+    // delegate to the underlying VirtualFS.
+    it('delegates to the underlying VirtualFS', () => {
+      // Scoops typically have no mounts — so any path returns false.
+      expect(restricted.isPathUnderMount('/scoops/andy-scoop/file.txt')).toBe(false);
+      expect(restricted.isPathUnderMount('/shared/data.txt')).toBe(false);
+      expect(restricted.isPathUnderMount('/anywhere/else')).toBe(false);
+    });
+
+    it('returns true when the underlying VFS reports the path is under a mount', () => {
+      const stubVfs = {
+        isPathUnderMount: (p: string) => p.startsWith('/mnt/'),
+        listMounts: () => ['/mnt'],
+      } as unknown as VirtualFS;
+      const r = new RestrictedFS(stubVfs, ['/scoops/andy-scoop/']);
+      expect(r.isPathUnderMount('/mnt/foo')).toBe(true);
+      expect(r.isPathUnderMount('/scoops/andy-scoop/file.txt')).toBe(false);
+    });
+  });
 });

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -2098,3 +2098,37 @@ describe('GitCommands', () => {
     });
   });
 });
+
+// Regression for issue #507: git ops in a scoop sandbox failed because
+// `RestrictedFS` (which scoops pass to `WasmShell`/`GitCommands`) was
+// missing `isPathUnderMount`. Exercising every basic git op through a
+// `RestrictedFS` confirms the adapter no longer crashes on the missing
+// method.
+describe('GitCommands with RestrictedFS (scoop sandbox, issue #507)', () => {
+  it('runs init/status/add/commit through a RestrictedFS without "isPathUnderMount is not a function"', async () => {
+    const { RestrictedFS } = await import('../../src/fs/restricted-fs.js');
+    const vfs = await VirtualFS.create({ dbName: 'git-restricted-fs-507', wipe: true });
+    await vfs.mkdir('/scoops/regression-507', { recursive: true });
+    const restricted = new RestrictedFS(vfs, ['/scoops/regression-507/', '/shared/']);
+    // The cone's WasmShell does the same cast — we mirror it here so
+    // the test reproduces the exact runtime configuration that crashed.
+    const git = new GitCommands({
+      fs: restricted as unknown as VirtualFS,
+      authorName: 'Test User',
+      authorEmail: 'test@example.com',
+      globalDbName: 'git-restricted-fs-global-507',
+    });
+
+    const initResult = await git.execute(['init'], '/scoops/regression-507');
+    expect(initResult.exitCode).toBe(0);
+    expect(initResult.stdout).toContain('Initialized empty Git repository');
+
+    await restricted.writeFile('/scoops/regression-507/readme.txt', 'hello scoop');
+    const addResult = await git.execute(['add', 'readme.txt'], '/scoops/regression-507');
+    expect(addResult.exitCode).toBe(0);
+
+    const commitResult = await git.execute(['commit', '-m', 'initial'], '/scoops/regression-507');
+    expect(commitResult.exitCode).toBe(0);
+    expect(commitResult.stdout).toContain('initial');
+  });
+});

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -2105,9 +2105,15 @@ describe('GitCommands', () => {
 // `RestrictedFS` confirms the adapter no longer crashes on the missing
 // method.
 describe('GitCommands with RestrictedFS (scoop sandbox, issue #507)', () => {
+  // Generate unique DB names per run to avoid leaking the cached
+  // `globalFsByDbName` entry across tests / watch-mode reruns. Mirrors
+  // the `dbCounter` pattern used by the main `GitCommands` suite above.
+  let dbCounter = 0;
+
   it('runs init/status/add/commit through a RestrictedFS without "isPathUnderMount is not a function"', async () => {
     const { RestrictedFS } = await import('../../src/fs/restricted-fs.js');
-    const vfs = await VirtualFS.create({ dbName: 'git-restricted-fs-507', wipe: true });
+    const testId = dbCounter++;
+    const vfs = await VirtualFS.create({ dbName: `git-restricted-fs-507-${testId}`, wipe: true });
     await vfs.mkdir('/scoops/regression-507', { recursive: true });
     const restricted = new RestrictedFS(vfs, ['/scoops/regression-507/', '/shared/']);
     // The cone's WasmShell does the same cast — we mirror it here so
@@ -2116,12 +2122,20 @@ describe('GitCommands with RestrictedFS (scoop sandbox, issue #507)', () => {
       fs: restricted as unknown as VirtualFS,
       authorName: 'Test User',
       authorEmail: 'test@example.com',
-      globalDbName: 'git-restricted-fs-global-507',
+      globalDbName: `git-restricted-fs-global-507-${testId}`,
     });
 
     const initResult = await git.execute(['init'], '/scoops/regression-507');
     expect(initResult.exitCode).toBe(0);
     expect(initResult.stdout).toContain('Initialized empty Git repository');
+
+    // `status` exercises a different isomorphic-git code path than
+    // `init` — it walks the working tree via the fs adapter, which is
+    // exactly where `isPathUnderMount` is invoked per file. Run it
+    // explicitly so the regression covers that path too.
+    const statusResult = await git.execute(['status'], '/scoops/regression-507');
+    expect(statusResult.exitCode).toBe(0);
+    expect(statusResult.stdout).toContain('On branch');
 
     await restricted.writeFile('/scoops/regression-507/readme.txt', 'hello scoop');
     const addResult = await git.execute(['add', 'readme.txt'], '/scoops/regression-507');


### PR DESCRIPTION
## Summary

Fixes #507. All git operations (`clone`, `init`, `status`, `add`, `commit`, etc.) failed with `git: e.isPathUnderMount is not a function` when invoked inside a scoop's sandboxed shell.

## Root cause

`scoop-context.ts` constructs the scoop's `WasmShell` (and therefore `GitCommands`) with `fs: this.fs as VirtualFS` — but `this.fs` is a `RestrictedFS` for non-cone scoops. The isomorphic-git fs adapter (`vfs-fs-adapter.ts:83`) calls `vfs.isPathUnderMount(path)` on every read/write to decide whether the path needs mount-aware routing. `RestrictedFS` didn't implement that method, so the cast crashed at runtime on every git op.

## Fix

Add `isPathUnderMount()` to `RestrictedFS`, delegating to the underlying `VirtualFS`. This is a read-only mount-membership query with no sandbox security implications — scoops typically have no mounts, so it returns `false` for all their paths.

I also audited the rest of the `RestrictedFS as VirtualFS` cast surface (file-tools, skills, mount-commands, script-catalog, wasm-shell, vfs-adapter) — all other consumers either use methods already present on `RestrictedFS` or duck-type via `getUnderlyingFS()`. `isPathUnderMount` was the only missing method on the hot path.

## Tests

- `packages/webapp/tests/fs/restricted-fs.test.ts`: new `isPathUnderMount` group covers both delegation to the underlying VFS and the no-mount case.
- `packages/webapp/tests/git/git-commands.test.ts`: end-to-end regression that runs `init`/`add`/`commit` through a `GitCommands` wired to a `RestrictedFS` (mirroring the exact runtime configuration that previously crashed).

## Verification

- `npx prettier --write` ran via lint-staged on commit
- `npm run typecheck` — pass
- `npm run test` — 3037 passed (plus the new regression tests)
- `npm run build` — pass
- `npm run build -w @slicc/chrome-extension` — pass

Fixes #507
