### PR TITLE
feat(scoops): make scoop_wait non-blocking and surface results via a scoop-wait lick

### DIFF
--- a/packages/vfs-root/workspace/skills/scoop-management/SKILL.md
+++ b/packages/vfs-root/workspace/skills/scoop-management/SKILL.md
@@ -128,22 +128,25 @@ These three cone-only tools let you collapse that fan-out into a single follow-u
 
 - **`scoop_mute({ scoop_names })`** — suspends `scoop-notify` delivery for the listed scoops. A completion that arrives while muted is stashed (full response persisted to `/shared/scoop-notifications/*.md`); it does NOT trigger a cone turn.
 - **`scoop_unmute({ scoop_names })`** — resumes notifications AND returns every stashed completion inline as this tool's result. The cone reads the summaries in the current turn instead of taking one extra turn per scoop.
-- **`scoop_wait({ scoop_names, timeout_ms? })`** — implicitly mutes the listed scoops, blocks until each completes (or times out), and returns all captured summaries as the tool result. Completions that arrived before the call are consumed immediately. `timeout_ms: 0` means "return only the scoops that are already done". Omit `timeout_ms` to wait indefinitely. After the wait resolves, only scoops muted by this call are unmuted — pre-existing `scoop_mute` state survives.
+- **`scoop_wait({ scoop_names, timeout_ms? })`** — schedules a NON-BLOCKING wait. The tool returns immediately so the cone can keep working; when every listed scoop has completed (or the timeout fires) the orchestrator delivers a single `scoop-wait` channel lick containing all captured summaries. Target scoops are implicitly muted for the duration so individual `scoop-notify` events don't pre-empt the eventual `scoop-wait` lick. Completions that arrived before the call are folded into the same lick. `timeout_ms: 0` means "fire the lick on the next tick with whatever is already done". Omit `timeout_ms` to wait indefinitely. After the wait resolves, only scoops muted by this call are unmuted — pre-existing `scoop_mute` state survives.
 
 ### When to use which
 
 - **Fire-and-forget background work you'll check later** → `scoop_mute` now, do other work, `scoop_unmute` when you want the summaries.
-- **Fan-out with synthesis** (you delegate to several scoops and your next useful step depends on all of them) → `scoop_wait`. One tool call, one cone turn after they all finish.
+- **Fan-out with synthesis** (you delegate to several scoops and your next useful step depends on all of them) → `scoop_wait`. One tool call schedules the wait without blocking the cone; a single `scoop-wait` lick wakes the cone once they all finish (or the timeout fires) with every summary in one payload.
 - **Single delegation, no parallelism** → don't mute. The default `scoop-notify` path is fine.
 
 ### Examples
 
 ```
-# Fan-out + synthesize in one extra turn:
+# Fan-out + synthesize:
 feed_scoop({ scoop_name: "writer-a", prompt: "Draft intro" })
 feed_scoop({ scoop_name: "writer-b", prompt: "Draft outro" })
 scoop_wait({ scoop_names: ["writer-a", "writer-b"], timeout_ms: 600000 })
-# -> tool result contains both summaries; merge them in the next message.
+# -> Returns immediately. Cone can keep working, ask the user follow-ups,
+#    or end its turn. When both scoops finish (or 10 min elapses) a
+#    single `scoop-wait` lick is delivered with both summaries; the
+#    cone's next turn synthesizes them.
 
 # Start background work, poll non-blockingly:
 scoop_mute({ scoop_names: ["scraper"] })

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -888,6 +888,108 @@ export class Orchestrator {
     });
   }
 
+  /**
+   * Non-blocking variant of {@link waitForScoops}. Kicks off the wait
+   * in the background and emits a `scoop-wait` channel message to the
+   * cone when the wait resolves (all listed scoops complete or the
+   * timeout expires). Returns synchronously so the caller — typically
+   * the `scoop_wait` tool — can release its turn immediately and let
+   * the cone keep working until the lick fires.
+   *
+   * Sandbox / mute semantics are inherited from `waitForScoops`: the
+   * listed scoops are muted during the wait so individual completions
+   * flow into this lick instead of firing extra cone turns. The mute is
+   * installed synchronously by the time this method returns (the first
+   * await in `waitForScoops` is the actual wait — all setup is sync).
+   *
+   * @returns the breakdown of which jids were registered and which were
+   * unknown — so the tool can summarize the schedule in its synchronous
+   * result without having to wait for completion.
+   */
+  scheduleScoopWait(
+    jids: readonly string[],
+    timeoutMs?: number
+  ): { scheduled: string[]; unknown: string[] } {
+    const uniqueJids = Array.from(new Set(jids));
+    const scheduled = uniqueJids.filter((jid) => this.scoops.has(jid));
+    const unknown = uniqueJids.filter((jid) => !this.scoops.has(jid));
+
+    // Kick off the wait in the background. `waitForScoops` runs its
+    // sync setup (mute install, pending-completion drain, waiter
+    // registration) before its first await, so by the time control
+    // returns to us the scoops are already muted and any race with a
+    // just-completed scoop is closed.
+    void this.waitForScoops(jids, timeoutMs)
+      .then((results) => this.deliverWaitResultsToCone(results))
+      .catch((err) => {
+        log.error('scheduleScoopWait failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+
+    return { scheduled, unknown };
+  }
+
+  /**
+   * Build the `scoop-wait` lick payload from a finished
+   * `waitForScoops` result and deliver it to the cone via the same
+   * onIncomingMessage + handleMessage wiring used by `scoop-notify`.
+   * Skips silently when no cone is registered or the result list is
+   * empty.
+   */
+  private async deliverWaitResultsToCone(
+    results: Array<{ jid: string; summary: string | null; timedOut: boolean }>
+  ): Promise<void> {
+    if (results.length === 0) return;
+    const cone = Array.from(this.scoops.values()).find((s) => s.isCone);
+    if (!cone) return;
+
+    const lines: string[] = ['[scoop_wait completed]'];
+    let timedOutCount = 0;
+    let completedCount = 0;
+    for (const r of results) {
+      const target = this.scoops.get(r.jid);
+      const label = target?.folder ?? r.jid;
+      if (r.timedOut) {
+        timedOutCount += 1;
+        lines.push(`--- ${label} (timed out) ---`);
+      } else {
+        completedCount += 1;
+        lines.push(`--- ${label} ---`);
+        lines.push(r.summary ?? '(no output)');
+      }
+    }
+    const summary = `${completedCount} completed, ${timedOutCount} timed out`;
+    lines.splice(1, 0, summary);
+
+    const msg: ChannelMessage = {
+      id: `scoop-wait-${Date.now()}`,
+      chatJid: cone.jid,
+      senderId: 'scoop-wait',
+      senderName: 'scoop-wait',
+      content: lines.join('\n'),
+      timestamp: new Date().toISOString(),
+      fromAssistant: false,
+      channel: 'scoop-wait',
+    };
+
+    try {
+      this.callbacks.onIncomingMessage?.(cone.jid, msg);
+    } catch (err) {
+      log.warn('onIncomingMessage for scoop-wait threw', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    try {
+      await this.handleMessage(msg);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log.error('Failed to route scoop-wait result to cone', { error: errMsg });
+      this.callbacks.onError(cone.jid, `scoop_wait completed but notification failed: ${errMsg}`);
+    }
+  }
+
   private dispatchScoopEvent<K extends keyof ScoopObserver>(
     jid: string,
     event: K,
@@ -1386,8 +1488,8 @@ export class Orchestrator {
         : undefined,
       onMuteScoops: scoop.isCone ? (jids) => this.muteScoops(jids) : undefined,
       onUnmuteScoops: scoop.isCone ? (jids) => this.unmuteScoops(jids) : undefined,
-      onWaitForScoops: scoop.isCone
-        ? (jids, timeoutMs) => this.waitForScoops(jids, timeoutMs)
+      onScheduleScoopWait: scoop.isCone
+        ? (jids, timeoutMs) => this.scheduleScoopWait(jids, timeoutMs)
         : undefined,
       getGlobalMemory: () => this.getGlobalMemory(),
       setGlobalMemory: scoop.isCone ? (content) => this.setGlobalMemory(content) : undefined,

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -918,8 +918,12 @@ export class Orchestrator {
     // sync setup (mute install, pending-completion drain, waiter
     // registration) before its first await, so by the time control
     // returns to us the scoops are already muted and any race with a
-    // just-completed scoop is closed.
-    void this.waitForScoops(jids, timeoutMs)
+    // just-completed scoop is closed. Pass the de-duped, known-scheduled
+    // list (NOT the raw `jids`) so the emitted `scoop-wait` lick matches
+    // the synchronous ack: duplicates are collapsed into one row and
+    // unknown jids are excluded entirely instead of showing up as
+    // timed-out rows the caller already saw in the ack.
+    void this.waitForScoops(scheduled, timeoutMs)
       .then((results) => this.deliverWaitResultsToCone(results))
       .catch((err) => {
         log.error('scheduleScoopWait failed', {
@@ -962,8 +966,16 @@ export class Orchestrator {
     const summary = `${completedCount} completed, ${timedOutCount} timed out`;
     lines.splice(1, 0, summary);
 
+    // ID needs entropy beyond `Date.now()` because the lick path now
+    // settles asynchronously: two waits scheduled in the same tick
+    // (e.g. timeout_ms: 0, or all targets already pending in
+    // `pendingCompletions`) can resolve in the same millisecond. Lick
+    // rendering de-dupes by id in `chat-panel.ts` and persistence uses
+    // `put` keyed by id in `db.ts`, so a colliding id silently drops
+    // one of the lick payloads. Mirror the `delegate-...` id shape
+    // used elsewhere in this file: timestamp + random suffix.
     const msg: ChannelMessage = {
-      id: `scoop-wait-${Date.now()}`,
+      id: `scoop-wait-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
       chatJid: cone.jid,
       senderId: 'scoop-wait',
       senderName: 'scoop-wait',

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -154,11 +154,13 @@ export interface ScoopContextCallbacks {
   ) => Promise<
     Array<{ jid: string; summary: string; timestamp: string; notificationPath: string | null }>
   >;
-  /** Wait for a batch of scoops to complete (cone only). */
-  onWaitForScoops?: (
+  /** Schedule a non-blocking wait for a batch of scoops (cone only).
+   *  Returns synchronously; the orchestrator emits a `scoop-wait` lick
+   *  to the cone when all listed scoops complete or the timeout fires. */
+  onScheduleScoopWait?: (
     jids: readonly string[],
     timeoutMs?: number
-  ) => Promise<Array<{ jid: string; summary: string | null; timedOut: boolean }>>;
+  ) => { scheduled: string[]; unknown: string[] };
   /** Get global CLAUDE.md content (shared across all scoops) */
   getGlobalMemory: () => Promise<string>;
   /** Update global CLAUDE.md (cone only) */
@@ -269,7 +271,7 @@ export class ScoopContext {
         onDropScoop: this.callbacks.onDropScoop,
         onMuteScoops: this.callbacks.onMuteScoops,
         onUnmuteScoops: this.callbacks.onUnmuteScoops,
-        onWaitForScoops: this.callbacks.onWaitForScoops,
+        onScheduleScoopWait: this.callbacks.onScheduleScoopWait,
         onSetGlobalMemory: this.callbacks.setGlobalMemory,
         getGlobalMemory: this.callbacks.getGlobalMemory,
       };

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -33,12 +33,15 @@ export interface ScoopManagementToolsConfig {
   ) => Promise<
     Array<{ jid: string; summary: string; timestamp: string; notificationPath: string | null }>
   >;
-  /** Block until a list of scoops completes (or timeout). Returns each scoop's
-   *  captured summary (or null on timeout). Cone only. */
-  onWaitForScoops?: (
+  /** Schedule a non-blocking wait for a list of scoops to complete.
+   *  Returns synchronously; when the wait resolves (every listed scoop
+   *  completes or the timeout fires) the orchestrator delivers a
+   *  `scoop-wait` channel lick to the cone with the per-scoop summary.
+   *  Cone only. */
+  onScheduleScoopWait?: (
     jids: readonly string[],
     timeoutMs?: number
-  ) => Promise<Array<{ jid: string; summary: string | null; timedOut: boolean }>>;
+  ) => { scheduled: string[]; unknown: string[] };
 }
 
 /** Resolve a list of user-supplied scoop names (folder or display name) to
@@ -76,7 +79,7 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
     getGlobalMemory,
     onMuteScoops,
     onUnmuteScoops,
-    onWaitForScoops,
+    onScheduleScoopWait,
   } = config;
 
   const tools: ToolDefinition[] = [];
@@ -479,15 +482,18 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
       });
     }
 
-    // Cone only: scoop_wait — block until a set of scoops completes, with
-    // an optional timeout. Target scoops are implicitly muted for the
-    // duration so the cone gets a single tool result summarizing all of
-    // them instead of one cone turn per completion.
-    if (onWaitForScoops) {
+    // Cone only: scoop_wait — schedule a NON-BLOCKING wait for a set of
+    // scoops. The tool returns immediately so the cone can keep working;
+    // when all listed scoops complete (or the optional timeout expires)
+    // the orchestrator delivers a `scoop-wait` channel lick to the cone
+    // with each scoop's summary. Target scoops are implicitly muted for
+    // the duration so individual `scoop-notify` events don't fire on top
+    // of the eventual `scoop-wait` lick.
+    if (onScheduleScoopWait) {
       tools.push({
         name: 'scoop_wait',
         description:
-          'Block until the given scoops complete or an optional timeout expires. Use this to coordinate parallel work: you feed several scoops, then call scoop_wait to receive all their results in one go without the cone being pinged for each individual completion. Already-completed scoops (including those whose completion arrived while you were processing your previous turn) are returned immediately.',
+          "Schedule a non-blocking wait for the given scoops. Returns immediately — the cone keeps its turn — and a `scoop-wait` lick is delivered when every listed scoop completes or the optional timeout fires. Use this to coordinate parallel work without freezing the cone: feed several scoops, call scoop_wait, then continue with other work; you'll be woken by the lick with all per-scoop summaries in one shot. Already-completed scoops (including those whose completion arrived while you were processing your previous turn) are folded into the same lick.",
         inputSchema: {
           type: 'object',
           properties: {
@@ -500,7 +506,7 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
             timeout_ms: {
               type: 'number',
               description:
-                'Optional timeout in milliseconds. If any listed scoop has not completed by the deadline, it is reported as timed-out in the result and the wait returns. Omit for no timeout.',
+                'Optional timeout in milliseconds. If any listed scoop has not completed by the deadline, it is reported as timed-out in the eventual `scoop-wait` lick. Omit for no timeout.',
             },
           },
           required: ['scoop_names'],
@@ -530,27 +536,19 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
             };
           }
           const jids = resolved.map((s) => s.jid);
-          const jidToFolder = new Map(resolved.map((s) => [s.jid, s.folder]));
-          const results = await onWaitForScoops(jids, timeout_ms);
-          log.info('Wait completed', {
+          onScheduleScoopWait(jids, timeout_ms);
+          log.info('Wait scheduled', {
             names: resolved.map((s) => s.folder),
             timeout_ms,
-            timedOut: results.filter((r) => r.timedOut).length,
           });
-          const lines: string[] = [];
-          if (unknown.length > 0) {
-            lines.push(`Unknown scoops (skipped): ${unknown.join(', ')}`);
-          }
-          for (const r of results) {
-            const folder = jidToFolder.get(r.jid) ?? r.jid;
-            if (r.timedOut) {
-              lines.push(`--- ${folder} (timed out) ---`);
-            } else {
-              lines.push(`--- ${folder} ---`);
-              lines.push(r.summary ?? '(no output)');
-            }
-          }
-          return { content: lines.join('\n') };
+          const folders = resolved.map((s) => s.folder).join(', ');
+          const tail = timeout_ms !== undefined ? ` (timeout: ${timeout_ms}ms)` : ' (no timeout)';
+          const warn = unknown.length > 0 ? ` Unknown (skipped): ${unknown.join(', ')}.` : '';
+          return {
+            content:
+              `scoop_wait scheduled for: ${folders}${tail}.${warn} ` +
+              `Continue with other work — a 'scoop-wait' lick will be delivered when all listed scoops complete or the timeout fires.`,
+          };
         },
       });
     }

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -536,17 +536,47 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
             };
           }
           const jids = resolved.map((s) => s.jid);
-          onScheduleScoopWait(jids, timeout_ms);
+          // Use the orchestrator's return value to build the
+          // acknowledgement: a scoop can be dropped between name
+          // resolution and the schedule call, in which case the
+          // orchestrator will report it as `unknown` even though
+          // `resolveScoopNames` accepted it. Trusting only the
+          // tool-side resolution would tell the cone "scheduled for X"
+          // when X is no longer registered and will never produce a
+          // result row in the eventual lick.
+          const ack = onScheduleScoopWait(jids, timeout_ms);
+          const jidToFolder = new Map(resolved.map((s) => [s.jid, s.folder]));
+          const scheduledFolders = ack.scheduled
+            .map((jid) => jidToFolder.get(jid) ?? jid)
+            .join(', ');
+          const droppedFolders = ack.unknown.map((jid) => jidToFolder.get(jid) ?? jid).join(', ');
           log.info('Wait scheduled', {
-            names: resolved.map((s) => s.folder),
+            scheduled: ack.scheduled.map((jid) => jidToFolder.get(jid) ?? jid),
+            droppedAtSchedule: droppedFolders ? droppedFolders.split(', ') : [],
+            unknownNames: unknown,
             timeout_ms,
           });
-          const folders = resolved.map((s) => s.folder).join(', ');
+          if (ack.scheduled.length === 0) {
+            // Every resolved jid was dropped between resolution and
+            // scheduling; nothing to wait on. Report this as an error
+            // so the cone retries instead of waiting on a lick that
+            // will never fire.
+            const dropped = droppedFolders || ack.unknown.join(', ');
+            const unknownTail = unknown.length > 0 ? ` Unknown names: ${unknown.join(', ')}.` : '';
+            return {
+              content: `scoop_wait could not be scheduled — every listed scoop was unregistered before the wait could start (dropped: ${dropped}).${unknownTail}`,
+              isError: true,
+            };
+          }
           const tail = timeout_ms !== undefined ? ` (timeout: ${timeout_ms}ms)` : ' (no timeout)';
-          const warn = unknown.length > 0 ? ` Unknown (skipped): ${unknown.join(', ')}.` : '';
+          const warnUnknown =
+            unknown.length > 0 ? ` Unknown (skipped): ${unknown.join(', ')}.` : '';
+          const warnDropped = droppedFolders
+            ? ` Dropped before schedule (skipped): ${droppedFolders}.`
+            : '';
           return {
             content:
-              `scoop_wait scheduled for: ${folders}${tail}.${warn} ` +
+              `scoop_wait scheduled for: ${scheduledFolders}${tail}.${warnUnknown}${warnDropped} ` +
               `Continue with other work — a 'scoop-wait' lick will be delivered when all listed scoops complete or the timeout fires.`,
           };
         },

--- a/packages/webapp/src/ui/lick-channels.ts
+++ b/packages/webapp/src/ui/lick-channels.ts
@@ -6,9 +6,10 @@
  * `scoops/lick-manager.ts`: it covers the external-event types emitted
  * by the LickManager (webhook, cron, sprinkle, fswatch, session-reload,
  * navigate) AND the synthetic scoop-lifecycle channels
- * (`scoop-notify`, `scoop-idle`) the Orchestrator fires when a scoop
- * completes or stays idle. We render both with the same widget so the
- * cone's chat history stays visually coherent across "something
+ * (`scoop-notify`, `scoop-idle`, `scoop-wait`) the Orchestrator fires
+ * when a scoop completes, stays idle, or when a previously scheduled
+ * `scoop_wait` resolves. We render all of them with the same widget so
+ * the cone's chat history stays visually coherent across "something
  * external happened" and "a scoop finished" events.
  *
  * Anything rendering lick messages (chat panel, main.ts history
@@ -24,7 +25,8 @@ export type LickChannel =
   | 'session-reload'
   | 'navigate'
   | 'scoop-notify'
-  | 'scoop-idle';
+  | 'scoop-idle'
+  | 'scoop-wait';
 
 export const LICK_CHANNELS: ReadonlySet<LickChannel> = new Set<LickChannel>([
   'webhook',
@@ -35,6 +37,7 @@ export const LICK_CHANNELS: ReadonlySet<LickChannel> = new Set<LickChannel>([
   'navigate',
   'scoop-notify',
   'scoop-idle',
+  'scoop-wait',
 ]);
 
 export function isLickChannel(channel: string | null | undefined): channel is LickChannel {

--- a/packages/webapp/src/ui/lick-view.ts
+++ b/packages/webapp/src/ui/lick-view.ts
@@ -16,6 +16,7 @@ import {
   Bell,
   IceCream,
   Hourglass,
+  ListChecks,
 } from 'lucide';
 import type { ChatMessage } from './types.js';
 
@@ -67,6 +68,14 @@ const DESCRIPTORS: Record<string, LickDescriptor> = {
     icon: Hourglass as unknown as IconNode,
     label: 'idle',
   },
+  'scoop-wait': {
+    // ListChecks visually echoes the lick body — a per-scoop checklist
+    // of completions / timeouts — and distinguishes scoop_wait (a
+    // fan-in barrier across multiple scoops) from `scoop-idle`'s
+    // single-scoop hourglass.
+    icon: ListChecks as unknown as IconNode,
+    label: 'wait',
+  },
 };
 
 export function getLickDescriptor(msg: ChatMessage): LickDescriptor {
@@ -85,6 +94,13 @@ const HEADER_RE = /^\[([^\]:]+?)(?:\s+Event)?:\s*([^\]]+?)\]\s*\n?/;
  *  instead of the first body line. */
 const SCOOP_HEADER_RE = /^\[@([^\]]+?)\s+(completed|idle)\]\s*:?\s*\n?/;
 
+/** Matches the `[scoop_wait completed]\nN completed, M timed out\n…`
+ *  header that the orchestrator writes when a scheduled `scoop_wait`
+ *  resolves. Captures the count-summary line so the collapsed row
+ *  surfaces e.g. "2 completed, 0 timed out" instead of the raw
+ *  `[scoop_wait completed]` literal. */
+const SCOOP_WAIT_HEADER_RE = /^\[scoop_wait completed\]\s*\n([^\n]+)\n?/;
+
 export interface ParsedLick {
   /** Human-readable event name (e.g. "github-push", "daily-digest",
    *  full URL for navigate). Used for the collapsed row preview. */
@@ -97,8 +113,16 @@ export interface ParsedLick {
 /** Parse a lick message's content into { preview, body }. Falls back to
  *  the first non-empty line if the expected header pattern is missing.
  *  Recognizes both the generic `[Xyz Event: name]` header and the
- *  scoop-specific `[@name completed]` / `[@name idle]` headers. */
+ *  scoop-specific `[@name completed]` / `[@name idle]` /
+ *  `[scoop_wait completed]` headers. */
 export function parseLickContent(content: string): ParsedLick {
+  const waitMatch = SCOOP_WAIT_HEADER_RE.exec(content);
+  if (waitMatch) {
+    return {
+      preview: waitMatch[1].trim(),
+      body: content.slice(waitMatch[0].length).replace(/^\s+/, ''),
+    };
+  }
   const scoopMatch = SCOOP_HEADER_RE.exec(content);
   if (scoopMatch) {
     return {

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -1858,6 +1858,12 @@ describe('Orchestrator scoop-notify onIncomingMessage visibility', () => {
   });
 
   it('scheduleScoopWait reports unknown jids in the sync ack and skips them in the lick', async () => {
+    // The lick body must match the synchronous ack: unknown jids stay
+    // in the ack only and are NOT re-rendered as timed-out rows in the
+    // eventual lick. Without this contract the cone sees the same
+    // unknown scoop twice (once in the tool result, once in the lick),
+    // contradicting the "ack tells you what's scheduled, lick tells
+    // you what completed" split.
     const scoop: RegisteredScoop = {
       jid: 'scoop_sched_partial_1',
       name: 'sched-partial',
@@ -1871,18 +1877,134 @@ describe('Orchestrator scoop-notify onIncomingMessage visibility', () => {
     };
     await saveScoop(scoop);
 
+    const incoming: ChannelMessage[] = [];
     const container =
       typeof document !== 'undefined'
         ? document.createElement('div')
         : ({ appendChild: () => {} } as unknown as HTMLElement);
     orch = new Orchestrator(
       container,
-      noopCallbacksWith(() => {})
+      noopCallbacksWith((_jid, msg) => {
+        incoming.push(msg);
+      })
     );
     await orch.init();
+
+    const priv = orch as unknown as OrchestratorPrivate;
+    priv.handleMessage = async () => {};
 
     const ack = orch.scheduleScoopWait([scoop.jid, 'scoop_unknown_42'], 10);
     expect(ack.scheduled).toEqual([scoop.jid]);
     expect(ack.unknown).toEqual(['scoop_unknown_42']);
+
+    // Let the timeout fire and the lick land.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(incoming).toHaveLength(1);
+    const lick = incoming[0];
+    expect(lick.channel).toBe('scoop-wait');
+    // Unknown jid must NOT appear in the lick — only the scheduled one.
+    expect(lick.content).not.toContain('scoop_unknown_42');
+    expect(lick.content).toContain('--- sched-partial-scoop (timed out) ---');
+    expect(lick.content).toContain('0 completed, 1 timed out');
+  });
+
+  it('scheduleScoopWait collapses duplicate jids into a single lick row', async () => {
+    // `waitForScoops` already dedupes its input, but `scheduleScoopWait`
+    // must also pass the de-duped list so the lick body has one row
+    // per scoop instead of N copies. The synchronous ack reflects the
+    // same de-duplication.
+    const scoop: RegisteredScoop = {
+      jid: 'scoop_sched_dedup_1',
+      name: 'sched-dedup',
+      folder: 'sched-dedup-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'sched-dedup-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    await saveScoop(scoop);
+
+    const incoming: ChannelMessage[] = [];
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(
+      container,
+      noopCallbacksWith((_jid, msg) => {
+        incoming.push(msg);
+      })
+    );
+    await orch.init();
+
+    const priv = orch as unknown as OrchestratorPrivate;
+    priv.handleMessage = async () => {};
+
+    const ack = orch.scheduleScoopWait([scoop.jid, scoop.jid], 30);
+    expect(ack.scheduled).toEqual([scoop.jid]);
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(incoming).toHaveLength(1);
+    const lick = incoming[0];
+    // Exactly one row for the duplicated jid.
+    const rowCount = (lick.content.match(/--- sched-dedup-scoop /g) ?? []).length;
+    expect(rowCount).toBe(1);
+    expect(lick.content).toContain('0 completed, 1 timed out');
+  });
+
+  it('scheduleScoopWait stamps unique message IDs for back-to-back schedules', async () => {
+    // Date.now() alone is not enough entropy: two waits scheduled in
+    // the same tick (e.g. timeout_ms: 0) can resolve in the same
+    // millisecond, and the chat panel + persistence layer dedupe by
+    // msg.id. A collision drops one lick. Verify each wait gets a
+    // distinct id.
+    const scoopA: RegisteredScoop = {
+      jid: 'scoop_sched_id_a',
+      name: 'sched-id-a',
+      folder: 'sched-id-a-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'sched-id-a-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    const scoopB: RegisteredScoop = {
+      ...scoopA,
+      jid: 'scoop_sched_id_b',
+      folder: 'sched-id-b-scoop',
+      assistantLabel: 'sched-id-b-scoop',
+    };
+    await saveScoop(scoopA);
+    await saveScoop(scoopB);
+
+    const incoming: ChannelMessage[] = [];
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(
+      container,
+      noopCallbacksWith((_jid, msg) => {
+        incoming.push(msg);
+      })
+    );
+    await orch.init();
+
+    const priv = orch as unknown as OrchestratorPrivate;
+    priv.handleMessage = async () => {};
+
+    // Two zero-timeout waits scheduled in the same tick; both will
+    // resolve essentially simultaneously.
+    orch.scheduleScoopWait([scoopA.jid], 0);
+    orch.scheduleScoopWait([scoopB.jid], 0);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(incoming).toHaveLength(2);
+    expect(incoming[0].id).not.toBe(incoming[1].id);
+    expect(incoming[0].id.startsWith('scoop-wait-')).toBe(true);
+    expect(incoming[1].id.startsWith('scoop-wait-')).toBe(true);
   });
 });

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -1735,4 +1735,154 @@ describe('Orchestrator scoop-notify onIncomingMessage visibility', () => {
     // null out the suite-level orch so afterEach doesn't double-shutdown.
     orch = undefined as unknown as Orchestrator;
   });
+
+  it('scheduleScoopWait returns synchronously, mutes targets, and fires a scoop-wait lick on completion', async () => {
+    // The whole point of the refactor: scoop_wait must NOT freeze the
+    // cone. scheduleScoopWait kicks the wait off in the background and
+    // returns immediately; when every listed scoop has completed, the
+    // orchestrator must fire a single `scoop-wait` channel message
+    // through onIncomingMessage so the UI renders the lick.
+    const a: RegisteredScoop = {
+      jid: 'scoop_sched_a',
+      name: 'sched-a',
+      folder: 'sched-a-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'sched-a-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    const b: RegisteredScoop = {
+      ...a,
+      jid: 'scoop_sched_b',
+      folder: 'sched-b-scoop',
+      assistantLabel: 'sched-b-scoop',
+    };
+    await saveScoop(a);
+    await saveScoop(b);
+
+    const incoming: ChannelMessage[] = [];
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(
+      container,
+      noopCallbacksWith((_jid, msg) => {
+        incoming.push(msg);
+      })
+    );
+    await orch.init();
+
+    const priv = orch as unknown as OrchestratorPrivate;
+    priv.handleMessage = async () => {};
+
+    const start = Date.now();
+    const ack = orch.scheduleScoopWait([a.jid, b.jid], 2000);
+    const elapsed = Date.now() - start;
+    // Sync return — must not have done any actual waiting.
+    expect(elapsed).toBeLessThan(50);
+    expect(ack.scheduled).toEqual([a.jid, b.jid]);
+    expect(ack.unknown).toEqual([]);
+    // Mute is installed synchronously by waitForScoops' sync setup.
+    expect(priv.mutedScoops.has(a.jid)).toBe(true);
+    expect(priv.mutedScoops.has(b.jid)).toBe(true);
+
+    priv.scoopResponseBuffer.set(a.jid, 'result A');
+    await priv.maybeNotifyConeOnScoopComplete(a.jid);
+    priv.scoopResponseBuffer.set(b.jid, 'result B');
+    await priv.maybeNotifyConeOnScoopComplete(b.jid);
+
+    // Allow the background `void this.waitForScoops(...).then(...)` to
+    // settle and emit the scoop-wait lick.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Exactly one scoop-wait lick — completed scoops must NOT also
+    // fire individual scoop-notify licks while a wait is active.
+    expect(incoming).toHaveLength(1);
+    const lick = incoming[0];
+    expect(lick.channel).toBe('scoop-wait');
+    expect(lick.content).toContain('[scoop_wait completed]');
+    expect(lick.content).toContain('2 completed, 0 timed out');
+    expect(lick.content).toContain('--- sched-a-scoop ---');
+    expect(lick.content).toContain('result A');
+    expect(lick.content).toContain('--- sched-b-scoop ---');
+    expect(lick.content).toContain('result B');
+
+    // Mute released after completion.
+    expect(priv.mutedScoops.has(a.jid)).toBe(false);
+    expect(priv.mutedScoops.has(b.jid)).toBe(false);
+  });
+
+  it('scheduleScoopWait fires a scoop-wait lick when the timeout elapses', async () => {
+    const scoop: RegisteredScoop = {
+      jid: 'scoop_sched_timeout_1',
+      name: 'sched-timeout',
+      folder: 'sched-timeout-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'sched-timeout-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    await saveScoop(scoop);
+
+    const incoming: ChannelMessage[] = [];
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(
+      container,
+      noopCallbacksWith((_jid, msg) => {
+        incoming.push(msg);
+      })
+    );
+    await orch.init();
+
+    const priv = orch as unknown as OrchestratorPrivate;
+    priv.handleMessage = async () => {};
+
+    orch.scheduleScoopWait([scoop.jid], 30);
+    // Wait long enough for the timer to fire and the lick to be
+    // dispatched on the microtask queue.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    expect(incoming).toHaveLength(1);
+    const lick = incoming[0];
+    expect(lick.channel).toBe('scoop-wait');
+    expect(lick.content).toContain('0 completed, 1 timed out');
+    expect(lick.content).toContain('--- sched-timeout-scoop (timed out) ---');
+  });
+
+  it('scheduleScoopWait reports unknown jids in the sync ack and skips them in the lick', async () => {
+    const scoop: RegisteredScoop = {
+      jid: 'scoop_sched_partial_1',
+      name: 'sched-partial',
+      folder: 'sched-partial-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'sched-partial-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    await saveScoop(scoop);
+
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(
+      container,
+      noopCallbacksWith(() => {})
+    );
+    await orch.init();
+
+    const ack = orch.scheduleScoopWait([scoop.jid, 'scoop_unknown_42'], 10);
+    expect(ack.scheduled).toEqual([scoop.jid]);
+    expect(ack.unknown).toEqual(['scoop_unknown_42']);
+  });
 });

--- a/packages/webapp/tests/scoops/scoop-management-tools.test.ts
+++ b/packages/webapp/tests/scoops/scoop-management-tools.test.ts
@@ -192,18 +192,19 @@ describe('scoop_mute / scoop_unmute / scoop_wait tools', () => {
   ) {
     const onMuteScoops = vi.fn();
     const onUnmuteScoops = vi.fn(async () => options.unmuteReturns ?? []);
-    const onWaitForScoops = vi.fn(async (jids: readonly string[]) =>
-      jids.map((jid) => ({ jid, summary: `summary-${jid}`, timedOut: false }))
-    );
+    const onScheduleScoopWait = vi.fn((jids: readonly string[]) => ({
+      scheduled: [...jids],
+      unknown: [],
+    }));
     const tools = createScoopManagementTools({
       scoop: cone,
       onSendMessage: vi.fn(),
       getScoops: () => [cone, targetScoop],
       onMuteScoops,
       onUnmuteScoops,
-      onWaitForScoops,
+      onScheduleScoopWait,
     });
-    return { tools, onMuteScoops, onUnmuteScoops, onWaitForScoops };
+    return { tools, onMuteScoops, onUnmuteScoops, onScheduleScoopWait };
   }
 
   it('scoop_mute forwards resolved jids and reports unknown names', async () => {
@@ -272,42 +273,48 @@ describe('scoop_mute / scoop_unmute / scoop_wait tools', () => {
     );
   });
 
-  it('scoop_wait awaits completion and formats per-scoop output', async () => {
-    const { tools, onWaitForScoops } = buildConeTools();
+  it('scoop_wait schedules a non-blocking wait and returns immediately', async () => {
+    // The whole point of the refactor: scoop_wait MUST NOT freeze the
+    // cone. The tool returns a synchronous acknowledgement and the
+    // orchestrator delivers a `scoop-wait` lick later when the wait
+    // resolves. The mock `onScheduleScoopWait` is intentionally sync —
+    // wrapping its call in a never-resolving promise here would still
+    // return immediately because the tool no longer awaits the result.
+    const { tools, onScheduleScoopWait } = buildConeTools();
     const tool = tools.find((t) => t.name === 'scoop_wait');
     expect(tool).toBeDefined();
 
+    const start = Date.now();
     const result = await tool!.execute({ scoop_names: ['alpha-scoop'], timeout_ms: 1000 });
-    expect(onWaitForScoops).toHaveBeenCalledWith([targetScoop.jid], 1000);
-    expect(result.content).toContain('--- alpha-scoop ---');
-    expect(result.content).toContain('summary-scoop_alpha_1');
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(50);
+    expect(onScheduleScoopWait).toHaveBeenCalledWith([targetScoop.jid], 1000);
+    expect(result.content).toContain('scoop_wait scheduled for: alpha-scoop');
+    expect(result.content).toContain('timeout: 1000ms');
+    expect(result.content).toContain("'scoop-wait' lick");
+    expect(result.isError).toBeUndefined();
   });
 
-  it('scoop_wait marks timed-out scoops distinctly', async () => {
-    const onWaitForScoops = vi.fn(async () => [
-      { jid: targetScoop.jid, summary: null, timedOut: true },
-    ]);
-    const tools = createScoopManagementTools({
-      scoop: cone,
-      onSendMessage: vi.fn(),
-      getScoops: () => [cone, targetScoop],
-      onMuteScoops: vi.fn(),
-      onUnmuteScoops: vi.fn(async () => []),
-      onWaitForScoops,
-    });
+  it('scoop_wait reports unknown names but still schedules known ones', async () => {
+    const { tools, onScheduleScoopWait } = buildConeTools();
     const tool = tools.find((t) => t.name === 'scoop_wait');
-    const result = await tool!.execute({ scoop_names: ['alpha-scoop'], timeout_ms: 10 });
-    expect(result.content).toContain('--- alpha-scoop (timed out) ---');
+
+    const result = await tool!.execute({ scoop_names: ['alpha-scoop', 'ghost'] });
+    expect(onScheduleScoopWait).toHaveBeenCalledWith([targetScoop.jid], undefined);
+    expect(result.content).toContain('scoop_wait scheduled for: alpha-scoop');
+    expect(result.content).toContain('no timeout');
+    expect(result.content).toContain('Unknown (skipped): ghost');
   });
 
   it('scoop_wait rejects non-finite or negative timeouts', async () => {
-    const { tools, onWaitForScoops } = buildConeTools();
+    const { tools, onScheduleScoopWait } = buildConeTools();
     const tool = tools.find((t) => t.name === 'scoop_wait');
     const neg = await tool!.execute({ scoop_names: ['alpha-scoop'], timeout_ms: -5 });
     expect(neg.isError).toBe(true);
     const nan = await tool!.execute({ scoop_names: ['alpha-scoop'], timeout_ms: Number.NaN });
     expect(nan.isError).toBe(true);
-    expect(onWaitForScoops).not.toHaveBeenCalled();
+    expect(onScheduleScoopWait).not.toHaveBeenCalled();
   });
 
   it('mute/unmute/wait tools are absent on non-cone scoops', async () => {
@@ -318,7 +325,7 @@ describe('scoop_mute / scoop_unmute / scoop_wait tools', () => {
       getScoops: () => [cone, nonCone],
       onMuteScoops: vi.fn(),
       onUnmuteScoops: vi.fn(async () => []),
-      onWaitForScoops: vi.fn(async () => []),
+      onScheduleScoopWait: vi.fn(() => ({ scheduled: [], unknown: [] })),
     });
     expect(tools.find((t) => t.name === 'scoop_mute')).toBeUndefined();
     expect(tools.find((t) => t.name === 'scoop_unmute')).toBeUndefined();

--- a/packages/webapp/tests/scoops/scoop-management-tools.test.ts
+++ b/packages/webapp/tests/scoops/scoop-management-tools.test.ts
@@ -307,6 +307,62 @@ describe('scoop_mute / scoop_unmute / scoop_wait tools', () => {
     expect(result.content).toContain('Unknown (skipped): ghost');
   });
 
+  it('scoop_wait surfaces scoops dropped between resolve and schedule', async () => {
+    // Race: the scoop existed when resolveScoopNames ran but was
+    // dropped before the orchestrator could install the wait. The
+    // orchestrator reports it back via `unknown`; the tool must use
+    // that — not the resolved list — to build the ack so the cone
+    // doesn't believe the wait is active for a vanished scoop.
+    const onScheduleScoopWait = vi.fn(() => ({
+      scheduled: [],
+      unknown: [targetScoop.jid],
+    }));
+    const tools = createScoopManagementTools({
+      scoop: cone,
+      onSendMessage: vi.fn(),
+      getScoops: () => [cone, targetScoop],
+      onMuteScoops: vi.fn(),
+      onUnmuteScoops: vi.fn(async () => []),
+      onScheduleScoopWait,
+    });
+    const tool = tools.find((t) => t.name === 'scoop_wait');
+    const result = await tool!.execute({ scoop_names: ['alpha-scoop'] });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('could not be scheduled');
+    expect(result.content).toContain('alpha-scoop');
+  });
+
+  it('scoop_wait reports partial schedule when some jids are dropped', async () => {
+    const otherScoop: RegisteredScoop = {
+      ...targetScoop,
+      jid: 'scoop_beta_1',
+      name: 'beta',
+      folder: 'beta-scoop',
+      assistantLabel: 'beta-scoop',
+    };
+    const onScheduleScoopWait = vi.fn(() => ({
+      scheduled: [targetScoop.jid],
+      unknown: [otherScoop.jid],
+    }));
+    const tools = createScoopManagementTools({
+      scoop: cone,
+      onSendMessage: vi.fn(),
+      getScoops: () => [cone, targetScoop, otherScoop],
+      onMuteScoops: vi.fn(),
+      onUnmuteScoops: vi.fn(async () => []),
+      onScheduleScoopWait,
+    });
+    const tool = tools.find((t) => t.name === 'scoop_wait');
+    const result = await tool!.execute({
+      scoop_names: ['alpha-scoop', 'beta-scoop'],
+      timeout_ms: 500,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toContain('scoop_wait scheduled for: alpha-scoop');
+    expect(result.content).toContain('timeout: 500ms');
+    expect(result.content).toContain('Dropped before schedule (skipped): beta-scoop');
+  });
+
   it('scoop_wait rejects non-finite or negative timeouts', async () => {
     const { tools, onScheduleScoopWait } = buildConeTools();
     const tool = tools.find((t) => t.name === 'scoop_wait');


### PR DESCRIPTION
## Why

`scoop_wait` used to `await` `waitForScoops`, freezing the cone for the entire duration of the wait. A single hung scoop or long timeout stalled the whole turn — the cone could not ask the user follow-ups, react to other licks, or do interleaved work while parallel scoops were running. That defeats the point of the tool: coordinating fan-out work without paying for one cone turn per scoop.

## What

- New `Orchestrator.scheduleScoopWait(jids, timeoutMs)` — synchronous, fire-and-forget. Wraps the existing `waitForScoops` Promise and on resolution dispatches a `scoop-wait` channel `ChannelMessage` to the cone via the same `onIncomingMessage` + `handleMessage` wiring `scoop-notify` already uses.
- `scoop_wait` tool now calls `scheduleScoopWait` and returns immediately with `scoop_wait scheduled for: <names> (timeout: Nms). Continue with other work — a 'scoop-wait' lick will be delivered when all listed scoops complete or the timeout fires.`
- Mute semantics preserved: target scoops are muted synchronously by the time `scheduleScoopWait` returns, so individual `scoop-notify` events do not pre-empt the eventual `scoop-wait` lick. The mute is released only for scoops the wait itself muted, leaving any pre-existing `scoop_mute` state intact.
- Already-completed scoops (whose completion arrived while the cone was processing its previous turn) are folded into the same `scoop-wait` lick.
- The `scoop-management-tools` callback contract was renamed from `onWaitForScoops` (Promise-returning) to `onScheduleScoopWait` (sync, returns `{ scheduled, unknown }`).

## UI

- `scoop-wait` added to `LICK_CHANNELS` so the chat panel renders it with the standard collapsible lick widget.
- `lick-view.ts` gets a `scoop-wait` descriptor using the `ListChecks` icon — visually echoes the lick body (a per-scoop checklist of completions / timeouts) and distinguishes `scoop_wait` (a fan-in barrier across multiple scoops) from `scoop-idle`'s single-scoop hourglass.
- New `SCOOP_WAIT_HEADER_RE` parser so the collapsed row preview surfaces `N completed, M timed out` instead of the raw `[scoop_wait completed]` literal.

## Tests

- 3 new orchestrator tests for `scheduleScoopWait`: sync return + one consolidated lick on completion, timeout fires the lick, unknown jids reported in the sync ack.
- Updated 3 `scoop_wait` tool tests to assert the new contract (sync ack, no awaiting on completion).
- All 3039 existing tests continue to pass.

## Verification

```
npx prettier --check .   # passes
npm run typecheck        # passes
npm run test             # 3037 passed, 2 skipped
npm run build -w @slicc/webapp   # builds
```

## Skill doc

`packages/vfs-root/workspace/skills/scoop-management/SKILL.md` updated to describe the non-blocking semantics so the agent surfaces them correctly when delegating.