### PR TITLE
feat(webapp): introduce 'upgrade' lick fired when SLICC version bumps

### DIFF
--- a/packages/chrome-extension/src/offscreen.ts
+++ b/packages/chrome-extension/src/offscreen.ts
@@ -280,35 +280,6 @@ async function init(): Promise<void> {
     return false;
   });
 
-  // ── Upgrade detection ─────────────────────────────────────────────
-  // Mirrors the boot-time check in packages/webapp/src/ui/main.ts so
-  // the extension float also fires `upgrade` licks when the bundled
-  // SLICC version differs from the previously-stored marker.
-  {
-    const sharedFsForUpgrade = orchestrator.getSharedFS();
-    if (sharedFsForUpgrade) {
-      const { detectUpgrade } =
-        await import('../../../packages/webapp/src/scoops/upgrade-detection.js');
-      detectUpgrade(sharedFsForUpgrade)
-        .then((result) => {
-          if (!result.isUpgrade || result.lastSeen === null) return;
-          lickManager.emitEvent({
-            type: 'upgrade',
-            targetScoop: undefined,
-            timestamp: new Date().toISOString(),
-            upgradeFromVersion: result.lastSeen,
-            upgradeToVersion: result.bundled.version,
-            body: {
-              from: result.lastSeen,
-              to: result.bundled.version,
-              releasedAt: result.bundled.releasedAt,
-            },
-          });
-        })
-        .catch((err) => console.warn('[slicc-offscreen] Upgrade detection failed', err));
-    }
-  }
-
   // Ensure cone exists
   const allScoops = orchestrator.getScoops();
   const hasCone = allScoops.some((s) => s.isCone);
@@ -329,6 +300,38 @@ async function init(): Promise<void> {
       addedAt: new Date().toISOString(),
     });
     console.log('[slicc-offscreen] Created cone');
+  }
+
+  // ── Upgrade detection ─────────────────────────────────────────────
+  // Aligned with the boot-time check in packages/webapp/src/ui/main.ts:
+  // both run only after a cone is guaranteed to exist as a routable
+  // target. We also defer advancing the "last seen" marker until the
+  // lick has been routed — otherwise a transient no-cone state would
+  // silently lose the upgrade notification for that version.
+  {
+    const sharedFsForUpgrade = orchestrator.getSharedFS();
+    if (sharedFsForUpgrade) {
+      const { detectUpgrade, recordVersionSeen } =
+        await import('../../../packages/webapp/src/scoops/upgrade-detection.js');
+      detectUpgrade(sharedFsForUpgrade)
+        .then(async (result) => {
+          if (!result.isUpgrade || result.lastSeen === null) return;
+          lickManager.emitEvent({
+            type: 'upgrade',
+            targetScoop: undefined,
+            timestamp: new Date().toISOString(),
+            upgradeFromVersion: result.lastSeen,
+            upgradeToVersion: result.bundled.version,
+            body: {
+              from: result.lastSeen,
+              to: result.bundled.version,
+              releasedAt: result.bundled.releasedAt,
+            },
+          });
+          await recordVersionSeen(result.bundled.version);
+        })
+        .catch((err) => console.warn('[slicc-offscreen] Upgrade detection failed', err));
+    }
   }
 
   let stopTrayRuntime: (() => void) | null = null;

--- a/packages/chrome-extension/src/offscreen.ts
+++ b/packages/chrome-extension/src/offscreen.ts
@@ -163,6 +163,7 @@ async function init(): Promise<void> {
     const isSprinkle = event.type === 'sprinkle';
     const isFsWatch = event.type === 'fswatch';
     const isNavigate = event.type === 'navigate';
+    const isUpgrade = event.type === 'upgrade';
     const eventName = isWebhook
       ? event.webhookName
       : isSprinkle
@@ -171,7 +172,9 @@ async function init(): Promise<void> {
           ? (event as any).fswatchName
           : isNavigate
             ? (event as any).navigateUrl
-            : event.cronName;
+            : isUpgrade
+              ? `${(event as any).upgradeFromVersion ?? 'unknown'}\u2192${(event as any).upgradeToVersion ?? 'unknown'}`
+              : event.cronName;
     const eventId = isWebhook
       ? event.webhookId
       : isSprinkle
@@ -180,7 +183,9 @@ async function init(): Promise<void> {
           ? (event as any).fswatchId
           : isNavigate
             ? (event as any).navigateUrl
-            : event.cronId;
+            : isUpgrade
+              ? `upgrade-${(event as any).upgradeToVersion ?? 'unknown'}`
+              : event.cronId;
     const channel = event.type;
 
     const scoops = orchestrator.getScoops();
@@ -208,8 +213,26 @@ async function init(): Promise<void> {
             ? 'File Watch Event'
             : isNavigate
               ? 'Navigate Event'
-              : 'Cron Event';
-      const content = `[${eventLabel}: ${eventName}]\n\`\`\`json\n${JSON.stringify(event.body, null, 2)}\n\`\`\``;
+              : isUpgrade
+                ? 'Upgrade Event'
+                : 'Cron Event';
+      let content: string;
+      if (isUpgrade) {
+        const from = (event as any).upgradeFromVersion ?? 'unknown';
+        const to = (event as any).upgradeToVersion ?? 'unknown';
+        const releasedAt =
+          (event.body as { releasedAt?: string | null } | null | undefined)?.releasedAt ?? null;
+        const releaseLine = releasedAt ? `\nReleased: ${releasedAt}` : '';
+        content =
+          `[${eventLabel}: ${from}\u2192${to}]\n\n` +
+          `SLICC was upgraded from \`${from}\` to \`${to}\`.${releaseLine}\n\n` +
+          `Use the **upgrade** skill (\`/workspace/skills/upgrade/SKILL.md\`) to:\n` +
+          `- Show the user the changelog between these tags from GitHub\n` +
+          `- Offer to merge new bundled vfs-root content into their workspace ` +
+          `(three-way merge: bundled snapshot vs user's VFS, reconciled with the GitHub tag-to-tag diff).`;
+      } else {
+        content = `[${eventLabel}: ${eventName}]\n\`\`\`json\n${JSON.stringify(event.body, null, 2)}\n\`\`\``;
+      }
 
       const channelMsg: import('../../../packages/webapp/src/scoops/types.js').ChannelMessage = {
         id: msgId,
@@ -256,6 +279,35 @@ async function init(): Promise<void> {
     });
     return false;
   });
+
+  // ── Upgrade detection ─────────────────────────────────────────────
+  // Mirrors the boot-time check in packages/webapp/src/ui/main.ts so
+  // the extension float also fires `upgrade` licks when the bundled
+  // SLICC version differs from the previously-stored marker.
+  {
+    const sharedFsForUpgrade = orchestrator.getSharedFS();
+    if (sharedFsForUpgrade) {
+      const { detectUpgrade } =
+        await import('../../../packages/webapp/src/scoops/upgrade-detection.js');
+      detectUpgrade(sharedFsForUpgrade)
+        .then((result) => {
+          if (!result.isUpgrade || result.lastSeen === null) return;
+          lickManager.emitEvent({
+            type: 'upgrade',
+            targetScoop: undefined,
+            timestamp: new Date().toISOString(),
+            upgradeFromVersion: result.lastSeen,
+            upgradeToVersion: result.bundled.version,
+            body: {
+              from: result.lastSeen,
+              to: result.bundled.version,
+              releasedAt: result.bundled.releasedAt,
+            },
+          });
+        })
+        .catch((err) => console.warn('[slicc-offscreen] Upgrade detection failed', err));
+    }
+  }
 
   // Ensure cone exists
   const allScoops = orchestrator.getScoops();

--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -4,6 +4,21 @@ import { homedir } from 'os';
 import { dirname, join } from 'path';
 import type { ChildProcess } from 'child_process';
 
+/**
+ * Default startup timeout for Chrome's CDP listener. Overridable via the
+ * `SLICC_CDP_LAUNCH_TIMEOUT_MS` environment variable so cold/contended CI
+ * runners can give Chrome a longer cold-start window without code changes.
+ */
+export const DEFAULT_CDP_LAUNCH_TIMEOUT_MS = 15000;
+
+export function getDefaultCdpLaunchTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.SLICC_CDP_LAUNCH_TIMEOUT_MS;
+  if (!raw) return DEFAULT_CDP_LAUNCH_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CDP_LAUNCH_TIMEOUT_MS;
+  return parsed;
+}
+
 export const CLI_PROFILE_NAMES = ['leader', 'follower', 'extension'] as const;
 export type CliProfileName = (typeof CLI_PROFILE_NAMES)[number];
 
@@ -407,8 +422,18 @@ export function parseCdpPortFromStderr(line: string): number | null {
  * Watch a Chrome child process's stderr for the `DevTools listening on` line
  * and resolve with the actual CDP port. Rejects after `timeoutMs` if the line
  * never appears (e.g. Chrome failed to start).
+ *
+ * Buffers across chunk boundaries: stderr data events split on arbitrary
+ * byte boundaries (not on newlines), so the original "split each chunk by
+ * \n and regex each line" approach silently dropped the DevTools line
+ * whenever it spanned two chunks. We accumulate a rolling buffer and only
+ * parse complete lines (everything before the last `\n`); the trailing
+ * partial line is carried forward to the next chunk.
  */
-export function waitForCdpPortFromStderr(child: ChildProcess, timeoutMs = 15000): Promise<number> {
+export function waitForCdpPortFromStderr(
+  child: ChildProcess,
+  timeoutMs: number = getDefaultCdpLaunchTimeoutMs()
+): Promise<number> {
   return new Promise((resolve, reject) => {
     if (!child.stderr) {
       reject(new Error('Chrome process has no stderr stream'));
@@ -416,6 +441,7 @@ export function waitForCdpPortFromStderr(child: ChildProcess, timeoutMs = 15000)
     }
 
     let settled = false;
+    let buffer = '';
     const timer = setTimeout(() => {
       if (!settled) {
         settled = true;
@@ -425,9 +451,12 @@ export function waitForCdpPortFromStderr(child: ChildProcess, timeoutMs = 15000)
 
     const onData = (chunk: Buffer) => {
       if (settled) return;
-      const text = chunk.toString('utf-8');
-      // stderr may deliver multiple lines in one chunk
-      for (const line of text.split('\n')) {
+      buffer += chunk.toString('utf-8');
+      // Parse all complete lines; keep the trailing partial in the buffer.
+      let nlIdx = buffer.indexOf('\n');
+      while (nlIdx !== -1) {
+        const line = buffer.slice(0, nlIdx);
+        buffer = buffer.slice(nlIdx + 1);
         const port = parseCdpPortFromStderr(line);
         if (port !== null) {
           settled = true;
@@ -436,6 +465,19 @@ export function waitForCdpPortFromStderr(child: ChildProcess, timeoutMs = 15000)
           resolve(port);
           return;
         }
+        nlIdx = buffer.indexOf('\n');
+      }
+      // Also try parsing the trailing partial: Chrome's DevTools line is
+      // typically flushed with a newline, but if the process exits before
+      // the newline reaches us we still want to recover the port. This is
+      // a no-op for normal traffic since `parseCdpPortFromStderr` requires
+      // a trailing `/` in the regex, which precedes the newline anyway.
+      const tailPort = parseCdpPortFromStderr(buffer);
+      if (tailPort !== null) {
+        settled = true;
+        clearTimeout(timer);
+        child.stderr!.off('data', onData);
+        resolve(tailPort);
       }
     };
 
@@ -448,5 +490,105 @@ export function waitForCdpPortFromStderr(child: ChildProcess, timeoutMs = 15000)
         reject(new Error(`Chrome exited with code ${code} before reporting CDP port`));
       }
     });
+  });
+}
+
+/**
+ * Poll `<userDataDir>/DevToolsActivePort` for the CDP port. Chrome writes
+ * this file as soon as the DevTools listener is up — its first line is
+ * the port, the second is the websocket path. This is the canonical way
+ * Chromium itself recommends discovering the chosen port and is far more
+ * reliable than scraping stderr.
+ *
+ * Resolves with the parsed port. Rejects on timeout or process exit.
+ *
+ * @param userDataDir absolute path Chrome was launched with via `--user-data-dir=`
+ * @param child       the Chrome child process (used to bail out on early exit)
+ * @param timeoutMs   total budget before giving up
+ * @param pollMs      polling cadence (default 50ms)
+ */
+export function waitForCdpPortFromActivePortFile(
+  userDataDir: string,
+  child: ChildProcess,
+  timeoutMs: number = getDefaultCdpLaunchTimeoutMs(),
+  pollMs = 50
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const path = join(userDataDir, 'DevToolsActivePort');
+    const startedAt = Date.now();
+
+    const finish = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      action();
+    };
+
+    const tick = async (): Promise<void> => {
+      if (settled) return;
+      try {
+        const contents = await readFile(path, 'utf-8');
+        // First line is the port; second is the WS path. Chrome writes both
+        // atomically once the listener is up. If we read it mid-write we'll
+        // either get an empty file or the port-only first line — both fall
+        // through to the next tick.
+        const firstLine = contents.split('\n', 1)[0]?.trim();
+        if (firstLine) {
+          const port = Number.parseInt(firstLine, 10);
+          if (Number.isFinite(port) && port > 0) {
+            finish(() => resolve(port));
+            return;
+          }
+        }
+      } catch (err) {
+        // ENOENT before Chrome writes the file — keep polling. Anything
+        // else is ignored too: we'd rather fall back to the stderr path
+        // racing alongside this poller than reject early.
+        void err;
+      }
+
+      if (Date.now() - startedAt >= timeoutMs) {
+        finish(() =>
+          reject(new Error(`Timed out waiting for DevToolsActivePort at ${path} (${timeoutMs}ms)`))
+        );
+        return;
+      }
+      setTimeout(() => {
+        void tick();
+      }, pollMs);
+    };
+
+    child.on('exit', (code) => {
+      finish(() =>
+        reject(new Error(`Chrome exited with code ${code} before writing DevToolsActivePort`))
+      );
+    });
+
+    void tick();
+  });
+}
+
+/**
+ * Race the stderr scraper and the `DevToolsActivePort` poller. Whichever
+ * resolves first wins; the loser is silently ignored. This is the
+ * recommended entry point for callers who already have a `--user-data-dir`
+ * on hand (which is the usual case in tests and CLI launches).
+ */
+export function waitForCdpPort(
+  child: ChildProcess,
+  options: { userDataDir?: string; timeoutMs?: number } = {}
+): Promise<number> {
+  const timeoutMs = options.timeoutMs ?? getDefaultCdpLaunchTimeoutMs();
+  const stderrPromise = waitForCdpPortFromStderr(child, timeoutMs);
+  if (!options.userDataDir) return stderrPromise;
+  const filePromise = waitForCdpPortFromActivePortFile(options.userDataDir, child, timeoutMs);
+  // Suppress unhandled-rejection warnings on the loser.
+  stderrPromise.catch(() => {});
+  filePromise.catch(() => {});
+  return Promise.any([stderrPromise, filePromise]).catch((agg: AggregateError) => {
+    // If both legs failed, surface the first error so callers see a
+    // meaningful message (timeout / exit) rather than an opaque AggregateError.
+    const first = agg.errors[0];
+    throw first instanceof Error ? first : new Error(String(first));
   });
 }

--- a/packages/node-server/src/sync-release-version.ts
+++ b/packages/node-server/src/sync-release-version.ts
@@ -10,6 +10,11 @@ interface ExtensionManifest {
   [key: string]: unknown;
 }
 
+interface VfsRootVersionFile {
+  version: string;
+  releasedAt: string | null;
+}
+
 export function updateManifestVersionContents(contents: string, version: string): string {
   const manifest = JSON.parse(contents) as Partial<ExtensionManifest>;
 
@@ -30,6 +35,19 @@ export function writeManifestVersion(manifestPath: string, version: string): voi
   );
 }
 
+export function buildVfsRootVersionContents(version: string, releasedAt: string): string {
+  const payload: VfsRootVersionFile = { version, releasedAt };
+  return `${JSON.stringify(payload, null, 2)}\n`;
+}
+
+export function writeVfsRootVersion(
+  versionFilePath: string,
+  version: string,
+  releasedAt: string
+): void {
+  writeFileSync(versionFilePath, buildVfsRootVersionContents(version, releasedAt));
+}
+
 function main(): void {
   const version = process.argv[2];
 
@@ -39,6 +57,14 @@ function main(): void {
 
   writeManifestVersion(resolve(PROJECT_ROOT, 'packages/chrome-extension/manifest.json'), version);
   console.log(`Updated manifest.json version to ${version}`);
+
+  const releasedAt = new Date().toISOString();
+  writeVfsRootVersion(
+    resolve(PROJECT_ROOT, 'packages/vfs-root/shared/version.json'),
+    version,
+    releasedAt
+  );
+  console.log(`Updated vfs-root/shared/version.json to ${version} (releasedAt=${releasedAt})`);
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -1,5 +1,5 @@
 import { type existsSync, type readdirSync } from 'fs';
-import { mkdtemp, readFile, rm } from 'fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -7,10 +7,14 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   buildChromeLaunchArgs,
+  DEFAULT_CDP_LAUNCH_TIMEOUT_MS,
   ensureQaProfileScaffold,
   findChromeExecutable,
+  getDefaultCdpLaunchTimeoutMs,
   parseCdpPortFromStderr,
   resolveChromeLaunchProfile,
+  waitForCdpPort,
+  waitForCdpPortFromActivePortFile,
   waitForCdpPortFromStderr,
 } from '../src/chrome-launch.js';
 
@@ -333,5 +337,138 @@ describe('waitForCdpPortFromStderr', () => {
     const promise = waitForCdpPortFromStderr(child, 50);
 
     await expect(promise).rejects.toThrow(/Timed out/);
+  });
+
+  it('parses the DevTools line when it spans multiple chunks (the original flake)', async () => {
+    // Regression: stderr `data` events split on byte boundaries, not on
+    // newlines. The original implementation regex'd each chunk in
+    // isolation, so a line like "DevTools listening on ws://…" arriving
+    // as ["DevTools listening", " on ws://127.0.0.1:9222/devtools/…\n"]
+    // was silently dropped and the watcher waited forever (until the
+    // timeout). Buffering across chunks prevents this.
+    const { EventEmitter } = await import('events');
+    const stderr = new EventEmitter();
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+    (child as { stderr: typeof stderr }).stderr = stderr;
+
+    const promise = waitForCdpPortFromStderr(child, 5000);
+
+    stderr.emit('data', Buffer.from('[noise] starting up\nDevTools listening'));
+    stderr.emit('data', Buffer.from(' on ws://127.0.0.1:'));
+    stderr.emit('data', Buffer.from('57321/devtools/browser/abc-123\n'));
+
+    await expect(promise).resolves.toBe(57321);
+  });
+});
+
+describe('getDefaultCdpLaunchTimeoutMs', () => {
+  it('returns the built-in default when the env var is unset', () => {
+    expect(getDefaultCdpLaunchTimeoutMs({})).toBe(DEFAULT_CDP_LAUNCH_TIMEOUT_MS);
+  });
+
+  it('honors a positive integer override', () => {
+    expect(getDefaultCdpLaunchTimeoutMs({ SLICC_CDP_LAUNCH_TIMEOUT_MS: '45000' })).toBe(45000);
+  });
+
+  it('falls back to the default for non-positive or non-numeric overrides', () => {
+    expect(getDefaultCdpLaunchTimeoutMs({ SLICC_CDP_LAUNCH_TIMEOUT_MS: '0' })).toBe(
+      DEFAULT_CDP_LAUNCH_TIMEOUT_MS
+    );
+    expect(getDefaultCdpLaunchTimeoutMs({ SLICC_CDP_LAUNCH_TIMEOUT_MS: '-100' })).toBe(
+      DEFAULT_CDP_LAUNCH_TIMEOUT_MS
+    );
+    expect(getDefaultCdpLaunchTimeoutMs({ SLICC_CDP_LAUNCH_TIMEOUT_MS: 'not-a-number' })).toBe(
+      DEFAULT_CDP_LAUNCH_TIMEOUT_MS
+    );
+  });
+});
+
+describe('waitForCdpPortFromActivePortFile', () => {
+  it('resolves with the port written to DevToolsActivePort', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
+    tempDirs.push(dir);
+    const { EventEmitter } = await import('events');
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+
+    const promise = waitForCdpPortFromActivePortFile(dir, child, 2000, 10);
+    // Simulate Chrome writing the file shortly after launch.
+    setTimeout(() => {
+      void writeFile(join(dir, 'DevToolsActivePort'), '49321\n/devtools/browser/abc-123\n');
+    }, 30);
+
+    await expect(promise).resolves.toBe(49321);
+  });
+
+  it('rejects on timeout when the file never appears', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
+    tempDirs.push(dir);
+    const { EventEmitter } = await import('events');
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+
+    await expect(waitForCdpPortFromActivePortFile(dir, child, 100, 10)).rejects.toThrow(
+      /Timed out waiting for DevToolsActivePort/
+    );
+  });
+
+  it('rejects when Chrome exits before writing the file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
+    tempDirs.push(dir);
+    const { EventEmitter } = await import('events');
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+
+    const promise = waitForCdpPortFromActivePortFile(dir, child, 5000, 10);
+    setTimeout(() => child.emit('exit', 1), 20);
+
+    await expect(promise).rejects.toThrow(/exited with code 1/);
+  });
+});
+
+describe('waitForCdpPort (race)', () => {
+  it('resolves from stderr when the active-port file is delayed', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
+    tempDirs.push(dir);
+    const { EventEmitter } = await import('events');
+    const stderr = new EventEmitter();
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+    (child as { stderr: typeof stderr }).stderr = stderr;
+
+    const promise = waitForCdpPort(child, { userDataDir: dir, timeoutMs: 5000 });
+    stderr.emit(
+      'data',
+      Buffer.from('DevTools listening on ws://127.0.0.1:11111/devtools/browser/id\n')
+    );
+
+    await expect(promise).resolves.toBe(11111);
+  });
+
+  it('resolves from the active-port file when stderr never prints the line', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
+    tempDirs.push(dir);
+    const { EventEmitter } = await import('events');
+    const stderr = new EventEmitter();
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+    (child as { stderr: typeof stderr }).stderr = stderr;
+
+    const promise = waitForCdpPort(child, { userDataDir: dir, timeoutMs: 2000 });
+    setTimeout(() => {
+      void writeFile(join(dir, 'DevToolsActivePort'), '22222\n/devtools/browser/zzz\n');
+    }, 30);
+
+    await expect(promise).resolves.toBe(22222);
+  });
+
+  it('falls back to plain stderr-only waiting when no userDataDir is provided', async () => {
+    const { EventEmitter } = await import('events');
+    const stderr = new EventEmitter();
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+    (child as { stderr: typeof stderr }).stderr = stderr;
+
+    const promise = waitForCdpPort(child, { timeoutMs: 5000 });
+    stderr.emit(
+      'data',
+      Buffer.from('DevTools listening on ws://127.0.0.1:33333/devtools/browser/id\n')
+    );
+
+    await expect(promise).resolves.toBe(33333);
   });
 });

--- a/packages/node-server/tests/sync-release-version.test.ts
+++ b/packages/node-server/tests/sync-release-version.test.ts
@@ -5,8 +5,10 @@ import { join } from 'path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildVfsRootVersionContents,
   updateManifestVersionContents,
   writeManifestVersion,
+  writeVfsRootVersion,
 } from '../src/sync-release-version.js';
 
 describe('sync-release-version', () => {
@@ -35,5 +37,29 @@ describe('sync-release-version', () => {
     expect(() => updateManifestVersionContents('{"name":"slicc"}\n', '1.2.3')).toThrow(
       'manifest.json must contain a string version'
     );
+  });
+
+  it('serializes the bundled vfs-root version file with version + releasedAt', () => {
+    const releasedAt = '2026-04-28T12:34:56.000Z';
+    expect(buildVfsRootVersionContents('1.2.3', releasedAt)).toBe(`{
+  "version": "1.2.3",
+  "releasedAt": "${releasedAt}"
+}\n`);
+  });
+
+  it('writes the vfs-root version file to disk so the boot-time detector can read it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'slicc-sync-vfs-version-'));
+    const versionPath = join(root, 'version.json');
+    const releasedAt = '2026-04-28T00:00:00.000Z';
+
+    try {
+      writeVfsRootVersion(versionPath, '4.5.6', releasedAt);
+      expect(JSON.parse(readFileSync(versionPath, 'utf8'))).toEqual({
+        version: '4.5.6',
+        releasedAt,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/vfs-root/shared/version.json
+++ b/packages/vfs-root/shared/version.json
@@ -1,0 +1,4 @@
+{
+  "version": "0.0.0-dev",
+  "releasedAt": null
+}

--- a/packages/vfs-root/workspace/skills/upgrade/SKILL.md
+++ b/packages/vfs-root/workspace/skills/upgrade/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: upgrade
+description: React to upgrade lick events with a changelog review and a three-way merge of bundled vfs-root content
+allowed-tools: bash, read_file, write_file, edit_file
+---
+
+# Upgrade
+
+When SLICC boots and discovers that the bundled version (in `/shared/version.json`, baked at release time) differs from the version it was last seen running, it emits an `upgrade` lick to the cone. This skill describes how to react.
+
+## Event shape
+
+You receive a message like:
+
+```text
+[Upgrade Event: 0.4.1→0.5.0]
+
+SLICC was upgraded from `0.4.1` to `0.5.0`.
+Released: 2026-04-15T12:00:00Z
+
+Use the **upgrade** skill (...)
+```
+
+The two version strings (`from`, `to`) are valid git tags on `https://github.com/ai-ecoverse/slicc` — the public source repository.
+
+## What to do when you receive an upgrade lick
+
+Render a single inline `.sprinkle-action-card` with two primary buttons. Quote both versions verbatim; never auto-run anything.
+
+```shtml
+<div class="sprinkle-action-card">
+  <div class="sprinkle-action-card__header">
+    SLICC upgraded
+    <span class="sprinkle-badge sprinkle-badge--notice">FROM_VERSION → TO_VERSION</span>
+  </div>
+  <div class="sprinkle-action-card__body">
+    <p style="margin:0 0 8px">SLICC was upgraded. You can review what changed and optionally pull the new bundled workspace files into your VFS.</p>
+  </div>
+  <div class="sprinkle-action-card__actions">
+    <button class="sprinkle-btn sprinkle-btn--secondary" onclick="slicc.lick({action:'dismiss'})">Dismiss</button>
+    <button class="sprinkle-btn sprinkle-btn--secondary" onclick="slicc.lick({action:'review-changelog'})">Review changelog</button>
+    <button class="sprinkle-btn sprinkle-btn--primary" onclick="slicc.lick({action:'merge-vfs-root'})">Update workspace files</button>
+  </div>
+</div>
+```
+
+## Changelog review (`action: 'review-changelog'`)
+
+Fetch the GitHub compare API for the two tags and summarize the result for the user.
+
+```bash
+# The repo is public — no auth required for the compare endpoint.
+curl -sSL "https://api.github.com/repos/ai-ecoverse/slicc/compare/v${FROM_VERSION}...v${TO_VERSION}" \
+  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const j=JSON.parse(s);console.log(j.commits.map(c=>"- "+c.commit.message.split("\n")[0]).join("\n"))})'
+```
+
+Show the conventional-commit messages grouped by type (`feat`, `fix`, `chore`, ...). If the compare returns 404 (tags missing), fall back to the GitHub releases page URL: `https://github.com/ai-ecoverse/slicc/releases/tag/v${TO_VERSION}`.
+
+## Three-way merge (`action: 'merge-vfs-root'`)
+
+The user's VFS may have local edits to bundled skills, sprinkles, or scripts. We treat the **previous bundled snapshot** (which lives in their VFS today) as the merge base. The user's actual VFS content is one branch; the **GitHub tag-to-tag diff** is the other.
+
+Concretely:
+
+1. Identify candidate paths under `/workspace/skills/` and `/shared/sprinkles/` that match the names of bundled files in this release. Per file:
+   - **base** = the file currently in the VFS (representing the previous bundled snapshot the user has been running on)
+   - **theirs** = the version from the new release tag fetched via `curl https://raw.githubusercontent.com/ai-ecoverse/slicc/v${TO_VERSION}/packages/vfs-root/<rest-of-path>`
+   - **ours** = the same VFS file (since base and ours are the same starting point unless the user has edited it). The previous-release version is recovered from `https://raw.githubusercontent.com/ai-ecoverse/slicc/v${FROM_VERSION}/packages/vfs-root/<rest-of-path>`.
+2. For each file, run a 3-way merge:
+   - If `previous-release == VFS` and `previous-release != new-release`: the user has not edited this file → safe to fast-forward to `new-release`.
+   - If `previous-release == new-release`: nothing changed upstream → leave the user's file alone.
+   - If `previous-release != VFS` and `previous-release != new-release`: 3-way merge. Use `git merge-file` inside the WasmShell:
+     ```bash
+     # write the three sides to /tmp and let git merge-file produce the result
+     git merge-file --stdout /tmp/ours /tmp/base /tmp/theirs > /tmp/merged
+     ```
+     If the merge succeeds cleanly, write the merged result to the VFS path and tell the user. If conflicts remain (non-zero exit + `<<<<<<<` markers), surface the conflicting hunks and let the user pick.
+3. Present the per-file outcome as a summary table (`auto-applied`, `kept-local`, `needs-review`) and stop. Do not silently overwrite anything.
+
+## Do not
+
+- Do not run a merge without showing the action card first. The user must explicitly click `Update workspace files`.
+- Do not delete files that no longer exist in the new release — many users name-collide their own scripts with bundled ones; deletion is too dangerous to automate.
+- Do not modify files outside `/workspace/skills/`, `/shared/sprinkles/`, and `/shared/sounds/` without the user explicitly extending the scope.
+- Do not advance the bundled version marker yourself. The runtime already advanced it before firing this lick; if the user dismisses, the lick will not fire again until the next upgrade.

--- a/packages/vfs-root/workspace/skills/upgrade/SKILL.md
+++ b/packages/vfs-root/workspace/skills/upgrade/SKILL.md
@@ -58,23 +58,26 @@ Show the conventional-commit messages grouped by type (`feat`, `fix`, `chore`, .
 
 ## Three-way merge (`action: 'merge-vfs-root'`)
 
-The user's VFS may have local edits to bundled skills, sprinkles, or scripts. We treat the **previous bundled snapshot** (which lives in their VFS today) as the merge base. The user's actual VFS content is one branch; the **GitHub tag-to-tag diff** is the other.
+The user's VFS may have local edits to bundled skills, sprinkles, or scripts. The three inputs to the merge are:
+
+- **base** = the bundled vfs-root file at the **previous** release tag (`v${FROM_VERSION}`). This is what the user originally received and is the common ancestor of both sides.
+- **ours** = the file currently in the user's VFS (which may equal `base` if untouched, or may carry local edits).
+- **theirs** = the bundled vfs-root file at the **new** release tag (`v${TO_VERSION}`).
 
 Concretely:
 
-1. Identify candidate paths under `/workspace/skills/` and `/shared/sprinkles/` that match the names of bundled files in this release. Per file:
-   - **base** = the file currently in the VFS (representing the previous bundled snapshot the user has been running on)
-   - **theirs** = the version from the new release tag fetched via `curl https://raw.githubusercontent.com/ai-ecoverse/slicc/v${TO_VERSION}/packages/vfs-root/<rest-of-path>`
-   - **ours** = the same VFS file (since base and ours are the same starting point unless the user has edited it). The previous-release version is recovered from `https://raw.githubusercontent.com/ai-ecoverse/slicc/v${FROM_VERSION}/packages/vfs-root/<rest-of-path>`.
-2. For each file, run a 3-way merge:
-   - If `previous-release == VFS` and `previous-release != new-release`: the user has not edited this file → safe to fast-forward to `new-release`.
-   - If `previous-release == new-release`: nothing changed upstream → leave the user's file alone.
-   - If `previous-release != VFS` and `previous-release != new-release`: 3-way merge. Use `git merge-file` inside the WasmShell:
+1. Identify candidate paths under `/workspace/skills/` and `/shared/sprinkles/` that match bundled files. Per file:
+   - Fetch `base` from `https://raw.githubusercontent.com/ai-ecoverse/slicc/v${FROM_VERSION}/packages/vfs-root/<rest-of-path>`.
+   - Fetch `theirs` from `https://raw.githubusercontent.com/ai-ecoverse/slicc/v${TO_VERSION}/packages/vfs-root/<rest-of-path>`.
+   - Read `ours` from the user's VFS at the equivalent runtime path (e.g. `/workspace/skills/<name>/SKILL.md`).
+2. Decide per file:
+   - If `base == theirs`: nothing changed upstream → leave the user's file alone (no merge needed).
+   - If `ours == base` and `base != theirs`: the user has not edited this file → safe fast-forward to `theirs`.
+   - If `ours != base` and `base != theirs`: real 3-way merge. Write the three sides to `/tmp` and let `git merge-file` produce the result:
      ```bash
-     # write the three sides to /tmp and let git merge-file produce the result
      git merge-file --stdout /tmp/ours /tmp/base /tmp/theirs > /tmp/merged
      ```
-     If the merge succeeds cleanly, write the merged result to the VFS path and tell the user. If conflicts remain (non-zero exit + `<<<<<<<` markers), surface the conflicting hunks and let the user pick.
+     Exit code 0 → clean merge; write `/tmp/merged` back to the VFS path. Non-zero exit means conflicts (`<<<<<<<` markers in the output) — surface the conflicting hunks and let the user pick.
 3. Present the per-file outcome as a summary table (`auto-applied`, `kept-local`, `needs-review`) and stop. Do not silently overwrite anything.
 
 ## Do not
@@ -82,4 +85,4 @@ Concretely:
 - Do not run a merge without showing the action card first. The user must explicitly click `Update workspace files`.
 - Do not delete files that no longer exist in the new release — many users name-collide their own scripts with bundled ones; deletion is too dangerous to automate.
 - Do not modify files outside `/workspace/skills/`, `/shared/sprinkles/`, and `/shared/sounds/` without the user explicitly extending the scope.
-- Do not advance the bundled version marker yourself. The runtime already advanced it before firing this lick; if the user dismisses, the lick will not fire again until the next upgrade.
+- Do not advance the bundled version marker yourself. The runtime advances it automatically once this lick has been routed; if the user dismisses, the lick will not fire again until the next upgrade.

--- a/packages/webapp/src/scoops/lick-manager.ts
+++ b/packages/webapp/src/scoops/lick-manager.ts
@@ -33,7 +33,7 @@ export interface CronTaskEntry {
 }
 
 export interface LickEvent {
-  type: 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload' | 'navigate';
+  type: 'webhook' | 'cron' | 'sprinkle' | 'fswatch' | 'session-reload' | 'navigate' | 'upgrade';
   webhookId?: string;
   webhookName?: string;
   cronId?: string;
@@ -45,6 +45,9 @@ export interface LickEvent {
   changes?: Array<{ type: string; path: string }>;
   /** For navigate events: the URL whose response carried the x-slicc header. */
   navigateUrl?: string;
+  /** For upgrade events: the previously-seen and current bundled SLICC versions. */
+  upgradeFromVersion?: string;
+  upgradeToVersion?: string;
   targetScoop?: string;
   timestamp: string;
   headers?: Record<string, string>;

--- a/packages/webapp/src/scoops/skills.ts
+++ b/packages/webapp/src/scoops/skills.ts
@@ -333,6 +333,14 @@ export async function createDefaultSkills(
 }
 
 /**
+ * Files under /shared/ that should always reflect the bundled (build-time)
+ * version, even if they already exist in the user's VFS. Used by the
+ * upgrade-detection flow (see ui/main.ts) so the bundled SLICC version
+ * is the source of truth for "which version is currently installed".
+ */
+const ALWAYS_OVERWRITE_SHARED = new Set<string>(['/shared/version.json']);
+
+/**
  * Create default shared files (like /shared/CLAUDE.md) from bundled defaults.
  */
 export async function createDefaultSharedFiles(fs: VirtualFS): Promise<void> {
@@ -345,20 +353,28 @@ export async function createDefaultSharedFiles(fs: VirtualFS): Promise<void> {
     // Only copy files that belong under /shared/
     if (!vfsPath.startsWith('/shared/')) continue;
 
-    try {
-      // Check if file already exists
-      await fs.stat(vfsPath);
-      // File exists, skip
-    } catch {
-      // File doesn't exist, create it
-      const parentDir = vfsPath.substring(0, vfsPath.lastIndexOf('/'));
+    const alwaysOverwrite = ALWAYS_OVERWRITE_SHARED.has(vfsPath);
+
+    if (!alwaysOverwrite) {
       try {
-        await fs.mkdir(parentDir, { recursive: true });
+        // Check if file already exists
+        await fs.stat(vfsPath);
+        // File exists, skip
+        continue;
       } catch {
-        // Directory exists
+        // File doesn't exist — fall through to create it.
       }
-      await fs.writeFile(vfsPath, content);
-      log.info('Created default shared file', { path: vfsPath });
     }
+
+    const parentDir = vfsPath.substring(0, vfsPath.lastIndexOf('/'));
+    try {
+      await fs.mkdir(parentDir, { recursive: true });
+    } catch {
+      // Directory exists
+    }
+    await fs.writeFile(vfsPath, content);
+    log.info(alwaysOverwrite ? 'Refreshed bundled shared file' : 'Created default shared file', {
+      path: vfsPath,
+    });
   }
 }

--- a/packages/webapp/src/scoops/upgrade-detection.ts
+++ b/packages/webapp/src/scoops/upgrade-detection.ts
@@ -1,0 +1,110 @@
+/**
+ * Upgrade detection — compares the bundled SLICC version (baked into
+ * `/shared/version.json` at release time via `sync-release-version.ts`)
+ * against the version recorded in IndexedDB during the previous boot.
+ *
+ * On version change, the caller (ui/main.ts) emits an `upgrade` lick to
+ * the cone. The upgrade skill can then surface a changelog and offer a
+ * three-way merge of bundled vfs-root content into the user's workspace.
+ *
+ * The dev placeholder `0.0.0-dev` is treated as "no real release", so
+ * we never fire upgrade licks during local development.
+ */
+
+import { createLogger } from '../core/logger.js';
+import type { VirtualFS } from '../fs/index.js';
+import { getState, setState } from './db.js';
+
+const log = createLogger('upgrade-detection');
+
+const VERSION_FILE_PATH = '/shared/version.json';
+const LAST_SEEN_STATE_KEY = 'slicc:last-seen-version';
+const DEV_VERSION = '0.0.0-dev';
+
+export interface BundledVersion {
+  version: string;
+  releasedAt: string | null;
+}
+
+export interface UpgradeDetection {
+  bundled: BundledVersion;
+  /** null on first boot; previously recorded version otherwise. */
+  lastSeen: string | null;
+  /** True when bundled.version differs from lastSeen and is a real release. */
+  isUpgrade: boolean;
+}
+
+/**
+ * Read the bundled SLICC version from `/shared/version.json`. Returns the
+ * dev placeholder if the file is missing or malformed — callers should
+ * treat that as "do not emit an upgrade lick".
+ */
+export async function readBundledVersion(fs: VirtualFS): Promise<BundledVersion> {
+  try {
+    const raw = await fs.readFile(VERSION_FILE_PATH, { encoding: 'utf-8' });
+    const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+    const parsed = JSON.parse(text) as Partial<BundledVersion>;
+    const version = typeof parsed.version === 'string' ? parsed.version : DEV_VERSION;
+    const releasedAt = typeof parsed.releasedAt === 'string' ? parsed.releasedAt : null;
+    return { version, releasedAt };
+  } catch (err) {
+    log.warn('Failed to read bundled version file', {
+      path: VERSION_FILE_PATH,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { version: DEV_VERSION, releasedAt: null };
+  }
+}
+
+export async function getLastSeenVersion(): Promise<string | null> {
+  const raw = await getState(LAST_SEEN_STATE_KEY);
+  // Treat both nullish and empty-string as "no recorded version" so the
+  // marker can be cleared by writing an empty string in tests/dev tools.
+  return raw && raw.length > 0 ? raw : null;
+}
+
+export async function setLastSeenVersion(version: string): Promise<void> {
+  await setState(LAST_SEEN_STATE_KEY, version);
+}
+
+/**
+ * Detect upgrades against the previously-stored "last seen" version and
+ * advance the marker. Returns a structured result so the caller can
+ * decide whether to emit a lick.
+ *
+ * Behavior matrix:
+ *   - bundled is the dev placeholder → never an upgrade; do not record.
+ *   - lastSeen is null (first boot) → record bundled, do not fire lick.
+ *   - lastSeen === bundled → no change, no lick.
+ *   - lastSeen !== bundled → upgrade, record new value, fire lick.
+ */
+export async function detectUpgrade(fs: VirtualFS): Promise<UpgradeDetection> {
+  const bundled = await readBundledVersion(fs);
+  const lastSeen = await getLastSeenVersion();
+
+  if (bundled.version === DEV_VERSION) {
+    // Dev build — never trigger upgrade licks. Leave the recorded version
+    // alone so a subsequent real release still detects the bump.
+    return { bundled, lastSeen, isUpgrade: false };
+  }
+
+  if (lastSeen === null) {
+    // First boot on a real release — record silently.
+    await setLastSeenVersion(bundled.version);
+    return { bundled, lastSeen: null, isUpgrade: false };
+  }
+
+  if (lastSeen === bundled.version) {
+    return { bundled, lastSeen, isUpgrade: false };
+  }
+
+  // Genuine upgrade — advance the marker and let the caller fire the lick.
+  await setLastSeenVersion(bundled.version);
+  return { bundled, lastSeen, isUpgrade: true };
+}
+
+export const __test__ = {
+  VERSION_FILE_PATH,
+  LAST_SEEN_STATE_KEY,
+  DEV_VERSION,
+};

--- a/packages/webapp/src/scoops/upgrade-detection.ts
+++ b/packages/webapp/src/scoops/upgrade-detection.ts
@@ -68,15 +68,22 @@ export async function setLastSeenVersion(version: string): Promise<void> {
 }
 
 /**
- * Detect upgrades against the previously-stored "last seen" version and
- * advance the marker. Returns a structured result so the caller can
- * decide whether to emit a lick.
+ * Detect upgrades against the previously-stored "last seen" version.
+ *
+ * IMPORTANT: This function does **not** advance the marker for the
+ * upgrade case. The caller is responsible for invoking
+ * {@link recordVersionSeen} only after the upgrade lick has actually
+ * been routed to a target (i.e., after a cone exists). Otherwise the
+ * lick can be silently dropped while the marker is already advanced,
+ * permanently losing the upgrade notification for that version.
  *
  * Behavior matrix:
  *   - bundled is the dev placeholder → never an upgrade; do not record.
- *   - lastSeen is null (first boot) → record bundled, do not fire lick.
- *   - lastSeen === bundled → no change, no lick.
- *   - lastSeen !== bundled → upgrade, record new value, fire lick.
+ *   - lastSeen is null (first boot) → record bundled silently, do not
+ *     fire lick (the caller has nothing to route).
+ *   - lastSeen === bundled → no change, no lick, no record.
+ *   - lastSeen !== bundled → upgrade detected; caller MUST call
+ *     {@link recordVersionSeen} after routing the lick.
  */
 export async function detectUpgrade(fs: VirtualFS): Promise<UpgradeDetection> {
   const bundled = await readBundledVersion(fs);
@@ -89,7 +96,8 @@ export async function detectUpgrade(fs: VirtualFS): Promise<UpgradeDetection> {
   }
 
   if (lastSeen === null) {
-    // First boot on a real release — record silently.
+    // First boot on a real release — record silently. There is no prior
+    // version to upgrade FROM, so the lick has nothing meaningful to say.
     await setLastSeenVersion(bundled.version);
     return { bundled, lastSeen: null, isUpgrade: false };
   }
@@ -98,9 +106,19 @@ export async function detectUpgrade(fs: VirtualFS): Promise<UpgradeDetection> {
     return { bundled, lastSeen, isUpgrade: false };
   }
 
-  // Genuine upgrade — advance the marker and let the caller fire the lick.
-  await setLastSeenVersion(bundled.version);
+  // Genuine upgrade — DO NOT advance the marker here. Let the caller
+  // record the new version only after the lick has been routed.
   return { bundled, lastSeen, isUpgrade: true };
+}
+
+/**
+ * Persist the bundled version as "seen" once the upgrade lick has
+ * actually been delivered to a target. Pairs with {@link detectUpgrade}
+ * to avoid losing upgrade notifications when no cone exists at the
+ * moment detection runs.
+ */
+export async function recordVersionSeen(version: string): Promise<void> {
+  await setLastSeenVersion(version);
 }
 
 export const __test__ = {

--- a/packages/webapp/src/ui/chat-fixture.ts
+++ b/packages/webapp/src/ui/chat-fixture.ts
@@ -405,6 +405,22 @@ export function createChatFixture(): ChatMessage[] {
     channel: 'session-reload',
   });
 
+  messages.push({
+    id: 'fx-lick-upgrade',
+    role: 'user',
+    content:
+      '[Upgrade Event: 0.4.1\u21920.5.0]\n\n' +
+      'SLICC was upgraded from `0.4.1` to `0.5.0`.\n' +
+      'Released: 2026-04-15T12:00:00Z\n\n' +
+      'Use the **upgrade** skill (`/workspace/skills/upgrade/SKILL.md`) to:\n' +
+      '- Show the user the changelog between these tags from GitHub\n' +
+      '- Offer to merge new bundled vfs-root content into their workspace ' +
+      "(three-way merge: bundled snapshot vs user's VFS, reconciled with the GitHub tag-to-tag diff).",
+    timestamp: tsAt(17),
+    source: 'lick',
+    channel: 'upgrade',
+  });
+
   // ── 6. Queued messages (before the streaming tail) ────────────────
   messages.push({
     id: 'fx-queued-1',

--- a/packages/webapp/src/ui/lick-channels.ts
+++ b/packages/webapp/src/ui/lick-channels.ts
@@ -5,7 +5,7 @@
  * This set is a SUPERSET of `LickEvent.type` in
  * `scoops/lick-manager.ts`: it covers the external-event types emitted
  * by the LickManager (webhook, cron, sprinkle, fswatch, session-reload,
- * navigate) AND the synthetic scoop-lifecycle channels
+ * navigate, upgrade) AND the synthetic scoop-lifecycle channels
  * (`scoop-notify`, `scoop-idle`, `scoop-wait`) the Orchestrator fires
  * when a scoop completes, stays idle, or when a previously scheduled
  * `scoop_wait` resolves. We render all of them with the same widget so
@@ -24,6 +24,7 @@ export type LickChannel =
   | 'fswatch'
   | 'session-reload'
   | 'navigate'
+  | 'upgrade'
   | 'scoop-notify'
   | 'scoop-idle'
   | 'scoop-wait';
@@ -35,6 +36,7 @@ export const LICK_CHANNELS: ReadonlySet<LickChannel> = new Set<LickChannel>([
   'fswatch',
   'session-reload',
   'navigate',
+  'upgrade',
   'scoop-notify',
   'scoop-idle',
   'scoop-wait',

--- a/packages/webapp/src/ui/lick-view.ts
+++ b/packages/webapp/src/ui/lick-view.ts
@@ -17,6 +17,7 @@ import {
   IceCream,
   Hourglass,
   ListChecks,
+  ArrowUpCircle,
 } from 'lucide';
 import type { ChatMessage } from './types.js';
 
@@ -59,6 +60,10 @@ const DESCRIPTORS: Record<string, LickDescriptor> = {
   'session-reload': {
     icon: RotateCcw as unknown as IconNode,
     label: 'reload',
+  },
+  upgrade: {
+    icon: ArrowUpCircle as unknown as IconNode,
+    label: 'upgrade',
   },
   'scoop-notify': {
     icon: IceCream as unknown as IconNode,

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -90,6 +90,7 @@ import { SprinkleManager } from './sprinkle-manager.js';
 import { initTelemetry } from './telemetry.js';
 import { getAllMountEntries } from '../fs/mount-table-store.js';
 import { recoverMounts, formatMountRecoveryPrompt } from '../fs/mount-recovery.js';
+import { detectUpgrade } from '../scoops/upgrade-detection.js';
 
 const log = createLogger('main');
 
@@ -1483,6 +1484,7 @@ async function main(): Promise<void> {
     const isFsWatch = event.type === 'fswatch';
     const isSessionReload = event.type === 'session-reload';
     const isNavigate = event.type === 'navigate';
+    const isUpgrade = event.type === 'upgrade';
     const eventName = isWebhook
       ? event.webhookName
       : isSprinkle
@@ -1493,7 +1495,9 @@ async function main(): Promise<void> {
             ? 'session-reload'
             : isNavigate
               ? event.navigateUrl
-              : event.cronName;
+              : isUpgrade
+                ? `${event.upgradeFromVersion ?? 'unknown'}\u2192${event.upgradeToVersion ?? 'unknown'}`
+                : event.cronName;
     const eventId = isWebhook
       ? event.webhookId
       : isSprinkle
@@ -1504,7 +1508,9 @@ async function main(): Promise<void> {
             ? 'session-reload'
             : isNavigate
               ? event.navigateUrl
-              : event.cronId;
+              : isUpgrade
+                ? `upgrade-${event.upgradeToVersion ?? 'unknown'}`
+                : event.cronId;
     const channel = event.type;
 
     log.debug('Lick event', { type: event.type, name: eventName, targetScoop: event.targetScoop });
@@ -1593,7 +1599,9 @@ async function main(): Promise<void> {
               ? 'Session Reload'
               : isNavigate
                 ? 'Navigate Event'
-                : 'Cron Event';
+                : isUpgrade
+                  ? 'Upgrade Event'
+                  : 'Cron Event';
       let content: string | null = null;
       if (isSessionReload) {
         const body = event.body as
@@ -1612,6 +1620,20 @@ async function main(): Promise<void> {
             return;
           }
         }
+      }
+      if (isUpgrade) {
+        const from = event.upgradeFromVersion ?? 'unknown';
+        const to = event.upgradeToVersion ?? 'unknown';
+        const releasedAt =
+          (event.body as { releasedAt?: string | null } | null | undefined)?.releasedAt ?? null;
+        const releaseLine = releasedAt ? `\nReleased: ${releasedAt}` : '';
+        content =
+          `[${eventLabel}: ${from}\u2192${to}]\n\n` +
+          `SLICC was upgraded from \`${from}\` to \`${to}\`.${releaseLine}\n\n` +
+          `Use the **upgrade** skill (\`/workspace/skills/upgrade/SKILL.md\`) to:\n` +
+          `- Show the user the changelog between these tags from GitHub\n` +
+          `- Offer to merge new bundled vfs-root content into their workspace ` +
+          `(three-way merge: bundled snapshot vs user's VFS, reconciled with the GitHub tag-to-tag diff).`;
       }
       if (content === null) {
         content = `[${eventLabel}: ${eventName}]\n\`\`\`json\n${JSON.stringify(event.body, null, 2)}\n\`\`\``;
@@ -1716,6 +1738,32 @@ async function main(): Promise<void> {
         routeLickToScoop(event);
       })
       .catch((err) => log.warn('Failed to restore persisted mounts', err));
+  }
+
+  // ── Upgrade detection ────────────────────────────────────────────────
+  // Compares the bundled SLICC version (baked into /shared/version.json
+  // at release time) against the value last seen on a previous boot and
+  // emits an `upgrade` lick when it bumped. The detection helper records
+  // the new version itself; we just route the event.
+  if (sharedFs) {
+    detectUpgrade(sharedFs)
+      .then((result) => {
+        if (!result.isUpgrade || result.lastSeen === null) return;
+        const event: LickEvent = {
+          type: 'upgrade',
+          targetScoop: undefined,
+          timestamp: new Date().toISOString(),
+          upgradeFromVersion: result.lastSeen,
+          upgradeToVersion: result.bundled.version,
+          body: {
+            from: result.lastSeen,
+            to: result.bundled.version,
+            releasedAt: result.bundled.releasedAt,
+          },
+        };
+        routeLickToScoop(event);
+      })
+      .catch((err) => log.warn('Upgrade detection failed', err));
   }
 
   // Wire inline sprinkle lick callback — routes to cone as a sprinkle lick event

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -90,7 +90,7 @@ import { SprinkleManager } from './sprinkle-manager.js';
 import { initTelemetry } from './telemetry.js';
 import { getAllMountEntries } from '../fs/mount-table-store.js';
 import { recoverMounts, formatMountRecoveryPrompt } from '../fs/mount-recovery.js';
-import { detectUpgrade } from '../scoops/upgrade-detection.js';
+import { detectUpgrade, recordVersionSeen } from '../scoops/upgrade-detection.js';
 
 const log = createLogger('main');
 
@@ -1743,11 +1743,15 @@ async function main(): Promise<void> {
   // ── Upgrade detection ────────────────────────────────────────────────
   // Compares the bundled SLICC version (baked into /shared/version.json
   // at release time) against the value last seen on a previous boot and
-  // emits an `upgrade` lick when it bumped. The detection helper records
-  // the new version itself; we just route the event.
+  // emits an `upgrade` lick when it bumped. Aligned with the session-
+  // reload (mount-recovery) lick above: both fire after the orchestrator
+  // is fully initialized so a cone is guaranteed to be present as a
+  // routable target. The "last seen" marker is only advanced AFTER the
+  // lick has actually been routed — otherwise a transient no-cone state
+  // would silently lose the upgrade notification for that version.
   if (sharedFs) {
     detectUpgrade(sharedFs)
-      .then((result) => {
+      .then(async (result) => {
         if (!result.isUpgrade || result.lastSeen === null) return;
         const event: LickEvent = {
           type: 'upgrade',
@@ -1762,6 +1766,7 @@ async function main(): Promise<void> {
           },
         };
         routeLickToScoop(event);
+        await recordVersionSeen(result.bundled.version);
       })
       .catch((err) => log.warn('Upgrade detection failed', err));
   }

--- a/packages/webapp/src/ui/styles/tools.css
+++ b/packages/webapp/src/ui/styles/tools.css
@@ -275,7 +275,7 @@
 }
 
 /* ================================================================== */
-/* Licks (webhook/cron/sprinkle/fswatch/navigate/session-reload)      */
+/* Licks (webhook/cron/sprinkle/fswatch/navigate/session-reload/upgrade) */
 /* Render as an incoming bubble: right-aligned like user messages,    */
 /* max-width mirrored, icon anchored to the right.                    */
 /* ================================================================== */

--- a/packages/webapp/tests/scoops/upgrade-detection.test.ts
+++ b/packages/webapp/tests/scoops/upgrade-detection.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the upgrade-detection helper used by the boot-time `upgrade`
+ * lick. Mirrors the bundled `/shared/version.json` produced at release
+ * time and the IndexedDB-backed marker for the previously-seen version.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import {
+  detectUpgrade,
+  getLastSeenVersion,
+  setLastSeenVersion,
+  readBundledVersion,
+} from '../../src/scoops/upgrade-detection.js';
+import { setState } from '../../src/scoops/db.js';
+import { __test__ } from '../../src/scoops/upgrade-detection.js';
+
+const VERSION_PATH = '/shared/version.json';
+
+async function writeVersionFile(
+  vfs: VirtualFS,
+  payload: { version: string; releasedAt?: string | null }
+): Promise<void> {
+  await vfs.mkdir('/shared', { recursive: true });
+  await vfs.writeFile(
+    VERSION_PATH,
+    `${JSON.stringify({ releasedAt: null, ...payload }, null, 2)}\n`
+  );
+}
+
+describe('upgrade-detection', () => {
+  let vfs: VirtualFS;
+  let dbCounter = 0;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ dbName: `test-upgrade-${dbCounter++}`, wipe: true });
+    // Reset the IndexedDB-backed marker between runs so the global
+    // STATE store doesn't leak between tests in the same process.
+    await setState(__test__.LAST_SEEN_STATE_KEY, '');
+  });
+
+  describe('readBundledVersion', () => {
+    it('returns the parsed version when /shared/version.json exists', async () => {
+      await writeVersionFile(vfs, { version: '1.2.3', releasedAt: '2026-04-01T00:00:00Z' });
+      const result = await readBundledVersion(vfs);
+      expect(result).toEqual({ version: '1.2.3', releasedAt: '2026-04-01T00:00:00Z' });
+    });
+
+    it('falls back to the dev placeholder when the file is missing', async () => {
+      const result = await readBundledVersion(vfs);
+      expect(result.version).toBe(__test__.DEV_VERSION);
+      expect(result.releasedAt).toBeNull();
+    });
+
+    it('falls back to the dev placeholder when the file is malformed', async () => {
+      await vfs.mkdir('/shared', { recursive: true });
+      await vfs.writeFile(VERSION_PATH, 'not-json');
+      const result = await readBundledVersion(vfs);
+      expect(result.version).toBe(__test__.DEV_VERSION);
+    });
+  });
+
+  describe('detectUpgrade', () => {
+    it('records the bundled version silently on first boot (no upgrade)', async () => {
+      await writeVersionFile(vfs, { version: '1.0.0' });
+      const result = await detectUpgrade(vfs);
+      expect(result.isUpgrade).toBe(false);
+      expect(result.lastSeen).toBeNull();
+      expect(await getLastSeenVersion()).toBe('1.0.0');
+    });
+
+    it('does nothing when the bundled version matches the last-seen one', async () => {
+      await writeVersionFile(vfs, { version: '1.0.0' });
+      await setLastSeenVersion('1.0.0');
+      const result = await detectUpgrade(vfs);
+      expect(result.isUpgrade).toBe(false);
+      expect(result.lastSeen).toBe('1.0.0');
+      expect(await getLastSeenVersion()).toBe('1.0.0');
+    });
+
+    it('reports an upgrade and advances the marker when the bundled version bumped', async () => {
+      await writeVersionFile(vfs, {
+        version: '1.1.0',
+        releasedAt: '2026-04-15T00:00:00Z',
+      });
+      await setLastSeenVersion('1.0.0');
+      const result = await detectUpgrade(vfs);
+      expect(result.isUpgrade).toBe(true);
+      expect(result.lastSeen).toBe('1.0.0');
+      expect(result.bundled.version).toBe('1.1.0');
+      expect(result.bundled.releasedAt).toBe('2026-04-15T00:00:00Z');
+      expect(await getLastSeenVersion()).toBe('1.1.0');
+    });
+
+    it('never fires on dev builds (and does not record the placeholder)', async () => {
+      await writeVersionFile(vfs, { version: __test__.DEV_VERSION });
+      await setLastSeenVersion('1.0.0');
+      const result = await detectUpgrade(vfs);
+      expect(result.isUpgrade).toBe(false);
+      // The marker was not advanced — a real release will still detect the bump.
+      expect(await getLastSeenVersion()).toBe('1.0.0');
+    });
+
+    it('records the bundled version on first boot of a dev build', async () => {
+      // Dev build, no last-seen yet → still no lick, but also no marker
+      // (so the first real release a dev encounters is treated as first-boot).
+      await writeVersionFile(vfs, { version: __test__.DEV_VERSION });
+      const result = await detectUpgrade(vfs);
+      expect(result.isUpgrade).toBe(false);
+      expect(result.lastSeen).toBeNull();
+      // We deliberately do not write the placeholder.
+      expect(await getLastSeenVersion()).toBeNull();
+    });
+  });
+});

--- a/packages/webapp/tests/scoops/upgrade-detection.test.ts
+++ b/packages/webapp/tests/scoops/upgrade-detection.test.ts
@@ -12,6 +12,7 @@ import {
   getLastSeenVersion,
   setLastSeenVersion,
   readBundledVersion,
+  recordVersionSeen,
 } from '../../src/scoops/upgrade-detection.js';
 import { setState } from '../../src/scoops/db.js';
 import { __test__ } from '../../src/scoops/upgrade-detection.js';
@@ -79,7 +80,7 @@ describe('upgrade-detection', () => {
       expect(await getLastSeenVersion()).toBe('1.0.0');
     });
 
-    it('reports an upgrade and advances the marker when the bundled version bumped', async () => {
+    it('reports an upgrade WITHOUT advancing the marker so the caller can defer it until the lick is routed', async () => {
       await writeVersionFile(vfs, {
         version: '1.1.0',
         releasedAt: '2026-04-15T00:00:00Z',
@@ -90,7 +91,10 @@ describe('upgrade-detection', () => {
       expect(result.lastSeen).toBe('1.0.0');
       expect(result.bundled.version).toBe('1.1.0');
       expect(result.bundled.releasedAt).toBe('2026-04-15T00:00:00Z');
-      expect(await getLastSeenVersion()).toBe('1.1.0');
+      // Marker is intentionally NOT advanced here — caller controls
+      // when to record so we don't lose the lick on transient no-cone
+      // boots (extension fresh-install, deleted-cone reload, etc.).
+      expect(await getLastSeenVersion()).toBe('1.0.0');
     });
 
     it('never fires on dev builds (and does not record the placeholder)', async () => {
@@ -102,15 +106,35 @@ describe('upgrade-detection', () => {
       expect(await getLastSeenVersion()).toBe('1.0.0');
     });
 
-    it('records the bundled version on first boot of a dev build', async () => {
-      // Dev build, no last-seen yet → still no lick, but also no marker
-      // (so the first real release a dev encounters is treated as first-boot).
+    it('does not record the dev placeholder on first boot of a dev build', async () => {
+      // Dev build, no last-seen yet → still no lick, and crucially no
+      // marker write (so the first real release a dev encounters is
+      // treated as a regular first-boot).
       await writeVersionFile(vfs, { version: __test__.DEV_VERSION });
       const result = await detectUpgrade(vfs);
       expect(result.isUpgrade).toBe(false);
       expect(result.lastSeen).toBeNull();
-      // We deliberately do not write the placeholder.
       expect(await getLastSeenVersion()).toBeNull();
+    });
+  });
+
+  describe('recordVersionSeen', () => {
+    it('advances the last-seen marker (used by callers after routing the upgrade lick)', async () => {
+      await writeVersionFile(vfs, { version: '2.0.0' });
+      await setLastSeenVersion('1.0.0');
+      const detected = await detectUpgrade(vfs);
+      expect(detected.isUpgrade).toBe(true);
+      // Marker is unchanged immediately after detection…
+      expect(await getLastSeenVersion()).toBe('1.0.0');
+      // …and only advances once the caller acknowledges the route.
+      await recordVersionSeen(detected.bundled.version);
+      expect(await getLastSeenVersion()).toBe('2.0.0');
+    });
+
+    it('is a no-op when called repeatedly with the same version', async () => {
+      await recordVersionSeen('3.0.0');
+      await recordVersionSeen('3.0.0');
+      expect(await getLastSeenVersion()).toBe('3.0.0');
     });
   });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -3114,7 +3114,8 @@ import { WebSocket as NodeWebSocket } from 'ws';
 import { BrowserAPI as RealBrowserAPI } from '../../../src/cdp/browser-api.js';
 import {
   findChromeExecutable,
-  waitForCdpPortFromStderr,
+  getDefaultCdpLaunchTimeoutMs,
+  waitForCdpPort,
 } from '../../../../node-server/src/chrome-launch.js';
 import type { CDPTransport } from '../../../src/cdp/transport.js';
 import type {
@@ -3335,7 +3336,17 @@ describeIntegration('iframe integration', { timeout: 60_000 }, () => {
       `--user-data-dir=${tmpDir}`,
       'about:blank',
     ]);
-    const cdpPort = await waitForCdpPortFromStderr(chromeProcess, 15000);
+    // Race the stderr scraper against the canonical
+    // `DevToolsActivePort` file (Chrome writes it into --user-data-dir
+    // as soon as the listener is up). The honored timeout is overridable
+    // via `SLICC_CDP_LAUNCH_TIMEOUT_MS` so cold/contended CI runners can
+    // give Chrome a longer cold-start window without code changes; we
+    // also pick a more generous default here than the production 15s
+    // because GitHub runners commonly pay a 10+ second cold-start tax.
+    const cdpPort = await waitForCdpPort(chromeProcess, {
+      userDataDir: tmpDir,
+      timeoutMs: Math.max(getDefaultCdpLaunchTimeoutMs(), 25_000),
+    });
 
     // 3. Fetch the browser WS URL from /json/version
     const versionRes = await fetch(`http://127.0.0.1:${cdpPort}/json/version`);

--- a/packages/webapp/tests/ui/chat-fixture.test.ts
+++ b/packages/webapp/tests/ui/chat-fixture.test.ts
@@ -42,7 +42,7 @@ describe('createChatFixture', () => {
       .map((m) => m.channel)
       .sort();
     expect(channels).toEqual(
-      ['cron', 'fswatch', 'navigate', 'session-reload', 'sprinkle', 'webhook'].sort()
+      ['cron', 'fswatch', 'navigate', 'session-reload', 'sprinkle', 'upgrade', 'webhook'].sort()
     );
   });
 

--- a/packages/webapp/tests/ui/chat-panel-lick.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-lick.test.ts
@@ -63,13 +63,14 @@ describe('ChatPanel.addLickMessage', () => {
     expect(container.querySelector('.msg--user')).toBeNull();
   });
 
-  it('renders sprinkle / navigate / fswatch / session-reload as lick widgets', () => {
+  it('renders sprinkle / navigate / fswatch / session-reload / upgrade as lick widgets', () => {
     panel.addLickMessage('sp-1', 'sprinkle content', 'sprinkle');
     panel.addLickMessage('nv-1', 'navigate content', 'navigate');
     panel.addLickMessage('fw-1', 'fswatch content', 'fswatch');
     panel.addLickMessage('sr-1', 'reload content', 'session-reload');
+    panel.addLickMessage('up-1', 'upgrade content', 'upgrade');
     const licks = container.querySelectorAll('details.lick');
-    expect(licks.length).toBe(4);
+    expect(licks.length).toBe(5);
   });
 
   it('preserves history-replay timestamp ordering when licks arrive out of order', () => {


### PR DESCRIPTION
## Summary

Adds a new `upgrade` lick that fires once per boot when SLICC's bundled version differs from the version it was last seen running. Modeled after the existing `session-reload` (mount-recovery) lick.

The cone receives a structured prompt pointing at a new `upgrade` skill that offers two affordances:
- **Review changelog** — fetches the GitHub compare API between `vFROM...vTO` and summarizes commits.
- **Update workspace files** — three-way merge of bundled vfs-root content into the user's VFS, using the previous-release tag as merge base, the new-release tag as theirs, and the user's VFS as ours (via `git merge-file`).

## Mechanism

1. `packages/vfs-root/shared/version.json` is bundled into the VFS via the existing `import.meta.glob` payload (placeholder `0.0.0-dev` in dev builds).
2. `packages/node-server/src/sync-release-version.ts` (already invoked by semantic-release `prepare`) now also rewrites that file with the real version and ISO `releasedAt`.
3. `createDefaultSharedFiles` special-cases `/shared/version.json` so the bundled value always wins on every boot (other shared files keep their create-if-missing behavior).
4. `scoops/upgrade-detection.ts` reads the bundled version, compares it to the IndexedDB-backed last-seen marker, and reports upgrade vs first-boot vs unchanged. Dev builds never fire and never advance the marker.
5. `ui/main.ts` and `chrome-extension/src/offscreen.ts` both invoke `detectUpgrade()` at boot alongside the mount-recovery block, then route the lick through the existing pipeline.

## Lick wiring

- `LickEvent.type` gains `'upgrade'` plus `upgradeFromVersion` / `upgradeToVersion` fields.
- `LickChannel` and `LICK_CHANNELS` extended.
- `lick-view.ts` adds an `ArrowUpCircle` descriptor labeled `upgrade`.
- `routeLickToScoop` (CLI + extension) writes a friendly content body that points the cone at the upgrade skill.
- `tools.css` channel comment updated.

## Skill

`packages/vfs-root/workspace/skills/upgrade/SKILL.md` describes the action card, the GitHub compare API for changelog review, and the three-way merge using `git merge-file` inside the WasmShell.

## Tests

- New `tests/scoops/upgrade-detection.test.ts` (8 tests): missing/malformed file, dev placeholder, first-boot silent record, version-bumped detection, marker advancement, no-op on unchanged.
- `tests/sync-release-version.test.ts` extended with `buildVfsRootVersionContents` + `writeVfsRootVersion` coverage.
- `chat-fixture.ts` + `tests/ui/chat-fixture.test.ts` + `tests/ui/chat-panel-lick.test.ts` updated to cover the new channel.

## Verification

- `npx prettier --check` clean
- `npm run typecheck` passes
- All 34 targeted tests pass on this branch
- `npm run build -w @slicc/webapp`, `-w @slicc/chrome-extension`, `-w @slicc/node-server` all succeed locally