### PR TITLE
feat: Chrome on-device Prompt API (Gemini Nano) provider

### DIFF
--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -163,6 +163,11 @@ export function buildChromeLaunchArgs(options: {
     '--disable-crash-reporter',
     '--disable-background-tracing',
     `--user-data-dir=${options.profile.userDataDir}`,
+    // Chrome on-device Prompt API (Gemini Nano) — multimodal origin trial.
+    // Inert until window.LanguageModel.create() is invoked; the on-device
+    // model is downloaded lazily on first use.
+    '--enable-features=OptimizationGuideOnDeviceModel:on_device_model_image_input/true',
+    '--enable-blink-features=AIPromptAPIMultimodalInput',
   ];
 
   if (options.profile.extensionPath) {

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -101,6 +101,8 @@ describe('chrome-launch', () => {
       '--disable-crash-reporter',
       '--disable-background-tracing',
       '--user-data-dir=/repo/.qa/chrome/extension',
+      '--enable-features=OptimizationGuideOnDeviceModel:on_device_model_image_input/true',
+      '--enable-blink-features=AIPromptAPIMultimodalInput',
       '--disable-extensions-except=/repo/dist/extension',
       '--load-extension=/repo/dist/extension',
       'http://localhost:3000',

--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -149,6 +149,11 @@ struct ChromeLauncher: Sendable {
             "--disable-crash-reporter",
             "--disable-background-tracing",
             "--user-data-dir=\(userDataDir)",
+            // Chrome on-device Prompt API (Gemini Nano) — multimodal origin trial.
+            // Inert until window.LanguageModel.create() is invoked; the on-device
+            // model is downloaded lazily on first use.
+            "--enable-features=OptimizationGuideOnDeviceModel:on_device_model_image_input/true",
+            "--enable-blink-features=AIPromptAPIMultimodalInput",
         ]
 
         if let extensionPath, !extensionPath.isEmpty {

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -49,6 +49,12 @@ final class ChromeLauncherTests: XCTestCase {
         XCTAssertTrue(args.contains("--user-data-dir=/tmp/profile"))
         XCTAssertTrue(args.contains("--disable-extensions-except=/tmp/ext"))
         XCTAssertTrue(args.contains("--load-extension=/tmp/ext"))
+        XCTAssertTrue(
+            args.contains(
+                "--enable-features=OptimizationGuideOnDeviceModel:on_device_model_image_input/true"
+            )
+        )
+        XCTAssertTrue(args.contains("--enable-blink-features=AIPromptAPIMultimodalInput"))
         XCTAssertEqual(args.last, "http://127.0.0.1:5710")
     }
 

--- a/packages/webapp/src/providers/built-in/chrome-prompt-api.ts
+++ b/packages/webapp/src/providers/built-in/chrome-prompt-api.ts
@@ -15,7 +15,7 @@
  * Tools are not supported by the Prompt API and are silently ignored.
  */
 
-import type { ProviderConfig } from '../types.js';
+import type { ProviderConfig, ModelMetadata } from '../types.js';
 import { registerApiProvider, createAssistantMessageEventStream } from '@mariozechner/pi-ai';
 import type { AssistantMessageEventStream } from '@mariozechner/pi-ai';
 import type {
@@ -31,28 +31,13 @@ import type {
 
 const PROVIDER_ID = 'chrome-prompt-api';
 const API_NAME = 'chrome-prompt-api-openai' as Api;
+const MODEL_ID = 'gemini-nano';
+const MODELS_CACHE_KEY = 'chrome-prompt-api:models';
 
-export const config: ProviderConfig = {
-  id: PROVIDER_ID,
-  name: 'Chrome (Gemini Nano)',
-  description: 'On-device Prompt API — runs locally in Chrome (no API key)',
-  requiresApiKey: false,
-  requiresBaseUrl: false,
-  // The Prompt API only ever exposes one local model at a time. Mark it as
-  // openai-flavoured purely so getProviderModels routes through our custom
-  // api name; the streaming function we register handles the real shape.
-  getModelIds: () => [
-    {
-      id: 'gemini-nano',
-      name: 'Gemini Nano (on-device)',
-      api: 'openai',
-      input: ['text', 'image'],
-      context_window: 6144,
-      max_tokens: 1024,
-      reasoning: false,
-    },
-  ],
-};
+const isBrowser =
+  typeof localStorage !== 'undefined' &&
+  typeof window !== 'undefined' &&
+  typeof globalThis !== 'undefined';
 
 // ── Prompt API typings (subset of the origin trial) ────────────────
 
@@ -109,6 +94,88 @@ function getLanguageModel(): LanguageModelGlobal | undefined {
   }
   return undefined;
 }
+
+// ── Availability cache (mirrors swiftlm.ts) ────────────────────────
+
+interface CachedModel {
+  /** Whether the local model can accept image inputs (multimodal flag on). */
+  supportsVision?: boolean;
+}
+
+/** Read the cached availability snapshot. Same shape contract as
+ *  `swiftlm.ts`: when the entry is absent, the provider's model list is
+ *  empty and the entry silently disappears from the chat dropdown. */
+function readCachedModels(): Array<{ id: string; name?: string } & ModelMetadata> {
+  if (!isBrowser) return [];
+  const raw = localStorage.getItem(MODELS_CACHE_KEY);
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) return [];
+  const entry = parsed[0] as CachedModel;
+  return [
+    {
+      id: MODEL_ID,
+      name: 'Gemini Nano (on-device)',
+      api: 'openai',
+      input: entry.supportsVision ? ['text', 'image'] : ['text'],
+      // Gemini Nano on Chrome ships a 6 144-token context window with a
+      // 1 024-token output cap; matches the documented Prompt API limits.
+      context_window: 6144,
+      max_tokens: 1024,
+      reasoning: false,
+    },
+  ];
+}
+
+/** Best-effort probe of `window.LanguageModel.availability(...)`. Refreshes
+ *  the cache on success; clears it on absence/unavailable so the provider
+ *  transparently disappears from the dropdown when the API isn't reachable
+ *  (flags off, browser too old, model failed to download, …). */
+async function refreshModelsCache(): Promise<void> {
+  if (!isBrowser) return;
+  const lm = getLanguageModel();
+  if (!lm) {
+    localStorage.removeItem(MODELS_CACHE_KEY);
+    return;
+  }
+  try {
+    // Probe text first (cheap), then escalate to image; if the multimodal
+    // origin trial flag is off, the second probe will return 'unavailable'
+    // and we fall back to text-only.
+    const textOk = await lm.availability({ expectedInputs: [{ type: 'text' }] });
+    if (textOk === 'unavailable') {
+      localStorage.removeItem(MODELS_CACHE_KEY);
+      return;
+    }
+    let supportsVision = false;
+    try {
+      const imageOk = await lm.availability({
+        expectedInputs: [{ type: 'text' }, { type: 'image' }],
+      });
+      supportsVision = imageOk !== 'unavailable';
+    } catch {
+      supportsVision = false;
+    }
+    const cached: CachedModel[] = [{ supportsVision }];
+    localStorage.setItem(MODELS_CACHE_KEY, JSON.stringify(cached));
+  } catch {
+    if (isBrowser) localStorage.removeItem(MODELS_CACHE_KEY);
+  }
+}
+
+export const config: ProviderConfig = {
+  id: PROVIDER_ID,
+  name: 'Chrome (Gemini Nano)',
+  description: 'On-device Prompt API — runs locally in Chrome (no API key)',
+  requiresApiKey: false,
+  requiresBaseUrl: false,
+  getModelIds: readCachedModels,
+};
 
 // ── Message conversion ─────────────────────────────────────────────
 
@@ -325,6 +392,12 @@ const streamChromePromptApi = (
 // ── Registration ───────────────────────────────────────────────────
 
 export function register(): void {
+  // Kick off the availability probe once at module load. `getModelIds` is
+  // sync so the first chat-panel render after boot will see whatever was
+  // last cached (or empty); subsequent renders pick up live data — same
+  // pattern as `swiftlm.ts`.
+  void refreshModelsCache();
+
   registerApiProvider({
     api: API_NAME,
     stream: streamChromePromptApi as Parameters<typeof registerApiProvider>[0]['stream'],
@@ -333,3 +406,5 @@ export function register(): void {
     >[0]['streamSimple'],
   });
 }
+
+export const __refreshChromePromptApiModels = refreshModelsCache;

--- a/packages/webapp/src/providers/built-in/chrome-prompt-api.ts
+++ b/packages/webapp/src/providers/built-in/chrome-prompt-api.ts
@@ -1,0 +1,335 @@
+/**
+ * Chrome on-device Prompt API (Gemini Nano) provider.
+ *
+ * Uses the browser-native `window.LanguageModel` surface exposed by Chrome's
+ * Built-in AI / Multimodal Prompt API origin trial. No network or API key —
+ * the model runs locally on the user's device.
+ *
+ * Requires Chrome ~139+ launched with:
+ *   --enable-features=OptimizationGuideOnDeviceModel:on_device_model_image_input/true
+ *   --enable-blink-features=AIPromptAPIMultimodalInput
+ *
+ * Or `chrome://flags/#optimization-guide-on-device-model` +
+ * `#prompt-api-for-gemini-nano-multimodal-input` set to Enabled.
+ *
+ * Tools are not supported by the Prompt API and are silently ignored.
+ */
+
+import type { ProviderConfig } from '../types.js';
+import { registerApiProvider, createAssistantMessageEventStream } from '@mariozechner/pi-ai';
+import type { AssistantMessageEventStream } from '@mariozechner/pi-ai';
+import type {
+  Api,
+  Model,
+  Context,
+  SimpleStreamOptions,
+  AssistantMessage,
+  TextContent,
+} from '@mariozechner/pi-ai';
+
+// ── Provider config ────────────────────────────────────────────────
+
+const PROVIDER_ID = 'chrome-prompt-api';
+const API_NAME = 'chrome-prompt-api-openai' as Api;
+
+export const config: ProviderConfig = {
+  id: PROVIDER_ID,
+  name: 'Chrome (Gemini Nano)',
+  description: 'On-device Prompt API — runs locally in Chrome (no API key)',
+  requiresApiKey: false,
+  requiresBaseUrl: false,
+  // The Prompt API only ever exposes one local model at a time. Mark it as
+  // openai-flavoured purely so getProviderModels routes through our custom
+  // api name; the streaming function we register handles the real shape.
+  getModelIds: () => [
+    {
+      id: 'gemini-nano',
+      name: 'Gemini Nano (on-device)',
+      api: 'openai',
+      input: ['text', 'image'],
+      context_window: 6144,
+      max_tokens: 1024,
+      reasoning: false,
+    },
+  ],
+};
+
+// ── Prompt API typings (subset of the origin trial) ────────────────
+
+type LMInputType = 'text' | 'image' | 'audio';
+
+interface LMExpectedInput {
+  type: LMInputType;
+  languages?: string[];
+}
+
+interface LMMessageContent {
+  type: LMInputType;
+  value: string | Blob | ImageBitmap | HTMLImageElement;
+}
+
+interface LMMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string | LMMessageContent[];
+}
+
+interface LMSessionCreateOptions {
+  expectedInputs?: LMExpectedInput[];
+  initialPrompts?: LMMessage[];
+  signal?: AbortSignal;
+}
+
+interface LMSession {
+  promptStreaming(input: LMMessage[], options?: { signal?: AbortSignal }): ReadableStream<string>;
+  destroy(): void;
+}
+
+interface LanguageModelGlobal {
+  availability(options?: {
+    expectedInputs?: LMExpectedInput[];
+  }): Promise<'unavailable' | 'downloadable' | 'downloading' | 'available'>;
+  create(options?: LMSessionCreateOptions): Promise<LMSession>;
+}
+
+declare global {
+  interface Window {
+    LanguageModel?: LanguageModelGlobal;
+  }
+  // Chromium also exposes it as a bare global in some channels.
+  var LanguageModel: LanguageModelGlobal | undefined;
+}
+
+function getLanguageModel(): LanguageModelGlobal | undefined {
+  if (typeof window !== 'undefined' && window.LanguageModel) return window.LanguageModel;
+  if (
+    typeof globalThis !== 'undefined' &&
+    (globalThis as { LanguageModel?: LanguageModelGlobal }).LanguageModel
+  ) {
+    return (globalThis as { LanguageModel?: LanguageModelGlobal }).LanguageModel;
+  }
+  return undefined;
+}
+
+// ── Message conversion ─────────────────────────────────────────────
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+  mimeType?: string;
+  data?: string;
+  source?: { data?: string; mediaType?: string; media_type?: string };
+}
+
+interface ConversationMessage {
+  role: string;
+  content: string | ContentBlock[];
+}
+
+function base64ToBlob(base64: string, mimeType: string): Blob {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new Blob([bytes], { type: mimeType });
+}
+
+function blocksToLMContent(blocks: ContentBlock[]): LMMessageContent[] {
+  const parts: LMMessageContent[] = [];
+  for (const b of blocks) {
+    if (b.type === 'text' && typeof b.text === 'string') {
+      parts.push({ type: 'text', value: b.text });
+    } else if (b.type === 'image') {
+      const data = b.data ?? b.source?.data;
+      const mime = b.mimeType ?? b.source?.mediaType ?? b.source?.media_type ?? 'image/png';
+      if (data) parts.push({ type: 'image', value: base64ToBlob(data, mime) });
+    }
+  }
+  return parts;
+}
+
+function convertMessages(context: Context): {
+  initialPrompts: LMMessage[];
+  tail: LMMessage[];
+  hasMultimodal: boolean;
+} {
+  const initialPrompts: LMMessage[] = [];
+  if (context.systemPrompt) {
+    initialPrompts.push({ role: 'system', content: context.systemPrompt });
+  }
+
+  // We treat the conversation as a sequential turn list; the most recent
+  // user message becomes the streamed prompt while everything before it is
+  // seeded as initialPrompts on the session.
+  const all = context.messages as ConversationMessage[];
+  let hasMultimodal = false;
+
+  const toLM = (m: ConversationMessage): LMMessage | null => {
+    const role: LMMessage['role'] =
+      m.role === 'assistant' ? 'assistant' : m.role === 'system' ? 'system' : 'user';
+    if (typeof m.content === 'string') return { role, content: m.content };
+    const parts = blocksToLMContent(m.content);
+    if (parts.length === 0) return null;
+    if (parts.some((p) => p.type === 'image')) hasMultimodal = true;
+    if (parts.length === 1 && parts[0].type === 'text') {
+      return { role, content: parts[0].value as string };
+    }
+    return { role, content: parts };
+  };
+
+  // Find last user message; everything else (including any trailing
+  // toolResult blocks we cannot represent) is dropped from the tail.
+  let lastUserIdx = -1;
+  for (let i = all.length - 1; i >= 0; i--) {
+    if (all[i].role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  if (lastUserIdx < 0) {
+    return { initialPrompts, tail: [], hasMultimodal };
+  }
+
+  for (let i = 0; i < lastUserIdx; i++) {
+    const lm = toLM(all[i]);
+    if (lm) initialPrompts.push(lm);
+  }
+  const tail: LMMessage[] = [];
+  const lm = toLM(all[lastUserIdx]);
+  if (lm) tail.push(lm);
+  return { initialPrompts, tail, hasMultimodal };
+}
+
+// ── Stream function ────────────────────────────────────────────────
+
+function emptyAssistant(model: Model<Api>): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: [],
+    api: API_NAME,
+    provider: PROVIDER_ID,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'stop',
+    timestamp: Date.now(),
+  };
+}
+
+const streamChromePromptApi = (
+  model: Model<Api>,
+  context: Context,
+  options: SimpleStreamOptions = {}
+): AssistantMessageEventStream => {
+  const stream = createAssistantMessageEventStream();
+
+  (async () => {
+    const output = emptyAssistant(model);
+
+    try {
+      const lm = getLanguageModel();
+      if (!lm) {
+        throw new Error(
+          'Chrome Prompt API is not available. Launch Chrome with --enable-blink-features=AIPromptAPIMultimodalInput, or enable chrome://flags/#prompt-api-for-gemini-nano-multimodal-input.'
+        );
+      }
+
+      const { initialPrompts, tail, hasMultimodal } = convertMessages(context);
+      if (tail.length === 0) throw new Error('No user message to send to the Prompt API.');
+
+      const expectedInputs: LMExpectedInput[] = [{ type: 'text' }];
+      if (hasMultimodal) expectedInputs.push({ type: 'image' });
+
+      const availability = await lm.availability({ expectedInputs });
+      if (availability === 'unavailable') {
+        throw new Error(
+          'Gemini Nano is unavailable on this device. Check chrome://on-device-internals.'
+        );
+      }
+
+      const session = await lm.create({
+        expectedInputs,
+        initialPrompts,
+        signal: options.signal,
+      });
+
+      stream.push({ type: 'start', partial: output });
+
+      const textBlock: TextContent = { type: 'text', text: '' };
+      output.content.push(textBlock);
+      const idx = output.content.length - 1;
+      stream.push({ type: 'text_start', contentIndex: idx, partial: output });
+
+      try {
+        const reader = session.promptStreaming(tail, { signal: options.signal }).getReader();
+        // The Prompt API emits incremental string deltas (per-token-ish).
+        // Some Chrome versions emit cumulative strings instead — handle both.
+        let lastSeen = '';
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          if (typeof value !== 'string' || value.length === 0) continue;
+          let delta = value;
+          if (value.startsWith(textBlock.text) && value.length >= textBlock.text.length) {
+            // Cumulative mode: strip the already-emitted prefix.
+            delta = value.slice(textBlock.text.length);
+            if (delta.length === 0) continue;
+          } else if (value === lastSeen) {
+            continue;
+          }
+          lastSeen = value;
+          textBlock.text += delta;
+          stream.push({
+            type: 'text_delta',
+            contentIndex: idx,
+            delta,
+            partial: output,
+          });
+        }
+      } finally {
+        try {
+          session.destroy();
+        } catch {
+          /* noop */
+        }
+      }
+
+      stream.push({
+        type: 'text_end',
+        contentIndex: idx,
+        content: textBlock.text,
+        partial: output,
+      });
+
+      output.usage.output = Math.ceil(textBlock.text.length / 4);
+      output.usage.totalTokens = output.usage.output;
+
+      stream.push({ type: 'done', reason: 'stop', message: output });
+      stream.end();
+    } catch (error) {
+      output.stopReason = options.signal?.aborted ? 'aborted' : 'error';
+      output.errorMessage = error instanceof Error ? error.message : String(error);
+      stream.push({ type: 'error', reason: output.stopReason, error: output });
+      stream.end();
+    }
+  })();
+
+  return stream;
+};
+
+// ── Registration ───────────────────────────────────────────────────
+
+export function register(): void {
+  registerApiProvider({
+    api: API_NAME,
+    stream: streamChromePromptApi as Parameters<typeof registerApiProvider>[0]['stream'],
+    streamSimple: streamChromePromptApi as Parameters<
+      typeof registerApiProvider
+    >[0]['streamSimple'],
+  });
+}


### PR DESCRIPTION
Experimental: lets users chat with Gemini Nano running locally inside Chrome (text + image, no API key, no network).

## What

1. **Chrome launch flags** (`node-server` and `swift-server`):
   - `--enable-features=OptimizationGuideOnDeviceModel:on_device_model_image_input/true`
   - `--enable-blink-features=AIPromptAPIMultimodalInput`

   Inert until `window.LanguageModel.create()` is called; the on-device model is downloaded lazily on first use.

2. **New built-in provider** `chrome-prompt-api` (`packages/webapp/src/providers/built-in/chrome-prompt-api.ts`):
   - `requiresApiKey: false`, `requiresBaseUrl: false`
   - Single model `gemini-nano` advertised with `input: ['text', 'image']`
   - Custom api `chrome-prompt-api-openai` whose stream function wraps `LanguageModel.availability()`, `create({ expectedInputs, initialPrompts, signal })`, and `session.promptStreaming(...)`
   - Bridges chunks to pi-ai's `AssistantMessageEventStream` (handles both incremental and cumulative emit modes), converts pi-ai content blocks to Prompt API `LMMessageContent[]` (text + image `Blob`), and tears down the session in `finally`
   - Tools are unsupported by the Prompt API and are dropped silently

## How to try

1. `npm run dev` — Chrome boots with the flags
2. Wait for Gemini Nano to download (`chrome://on-device-internals`)
3. Settings -> add account for **Chrome (Gemini Nano)** (no API key) -> save
4. Pick model `Gemini Nano (on-device)` and chat (attach images via the normal flow)

## Verification

- `npm run typecheck` clean
- chrome-launch unit tests updated and green in both `node-server` (Vitest) and `swift-server` (XCTest)
- `eslint` + `prettier` clean on the new file

## Notes

- Pre-existing test failures in `bedrock-camp.test.ts` and `isomorphic-git-esm.test.ts` are unrelated env issues (missing transitive `node_modules`)
- Origin trial covers Chrome 139-144; flags above let it work locally without a token
