### PR TITLE
feat: expose pi-ai thinking-level per-scoop via brain icon and --thinking flag

### DIFF
--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -71,11 +71,21 @@ export interface RefreshModelMsg {
   type: 'refresh-model';
 }
 
+/**
+ * Discriminated literal for `ThinkingLevel`. Mirrors the union exported
+ * by `packages/webapp/src/scoops/types.ts` — duplicated here so the
+ * extension messages module stays free of webapp imports (the extension
+ * source set is consumed by both the panel and the offscreen contexts,
+ * and we don't want to drag the scoop config layer into the message
+ * envelopes).
+ */
+export type ExtensionThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
 export interface SetThinkingLevelMsg {
   type: 'set-thinking-level';
   scoopJid: string;
   /** Undefined clears the override; the level falls back to default. */
-  level?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+  level?: ExtensionThinkingLevel;
 }
 
 export interface RefreshTrayRuntimeMsg {
@@ -167,6 +177,19 @@ export interface ScoopStatusMsg {
   status: ScoopTabState['status'];
 }
 
+/**
+ * Subset of `ScoopConfig` (see `packages/webapp/src/scoops/types.ts`)
+ * carried across the offscreen → panel boundary. The panel only needs
+ * the persisted-per-scoop bits that drive the UI affordances (model
+ * pill capability detection + brain-icon thinking level). Sandbox
+ * shape (visiblePaths/writablePaths/allowedCommands) is intentionally
+ * NOT mirrored here — the panel never reads those.
+ */
+export interface ScoopSnapshotConfig {
+  modelId?: string;
+  thinkingLevel?: ExtensionThinkingLevel;
+}
+
 export interface ScoopListMsg {
   type: 'scoop-list';
   scoops: Array<{
@@ -176,6 +199,15 @@ export interface ScoopListMsg {
     isCone: boolean;
     assistantLabel: string;
     status: ScoopTabState['status'];
+    /**
+     * Persisted per-scoop config snapshot. Optional because the cone
+     * (and freshly-created scoops with no overrides) may have no
+     * recorded config. The panel reads `config?.modelId` /
+     * `config?.thinkingLevel` to drive model-capability detection
+     * and the brain-icon's persisted level on reconnect / scoop
+     * switch.
+     */
+    config?: ScoopSnapshotConfig;
   }>;
 }
 

--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -71,6 +71,13 @@ export interface RefreshModelMsg {
   type: 'refresh-model';
 }
 
+export interface SetThinkingLevelMsg {
+  type: 'set-thinking-level';
+  scoopJid: string;
+  /** Undefined clears the override; the level falls back to default. */
+  level?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+}
+
 export interface RefreshTrayRuntimeMsg {
   type: 'refresh-tray-runtime';
 }
@@ -122,6 +129,7 @@ export type PanelToOffscreenMessage =
   | ClearChatMsg
   | ClearFilesystemMsg
   | RefreshModelMsg
+  | SetThinkingLevelMsg
   | RefreshTrayRuntimeMsg
   | PanelCdpCommandMsg
   | OAuthRequestMsg

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -23,6 +23,8 @@ import type {
   PanelCdpResponseMsg,
   ScoopStatusMsg,
   ScoopListMsg,
+  ScoopSnapshotConfig,
+  SetThinkingLevelMsg,
   StateSnapshotMsg,
   ErrorMsg,
   ScoopCreatedMsg,
@@ -268,17 +270,37 @@ export class OffscreenBridge {
     };
   }
 
+  /**
+   * Project an orchestrator `RegisteredScoop` down to the snapshot shape
+   * the panel sees. Carries `config.modelId` / `config.thinkingLevel`
+   * (the only config bits the panel reads — see `ScoopSnapshotConfig`)
+   * so the brain icon and model pill rehydrate correctly across
+   * reconnects and scoop switches.
+   */
+  private toScoopSnapshot(s: RegisteredScoop): ScoopListMsg['scoops'][number] {
+    const config: ScoopSnapshotConfig | undefined =
+      s.config && (s.config.modelId !== undefined || s.config.thinkingLevel !== undefined)
+        ? {
+            ...(s.config.modelId !== undefined ? { modelId: s.config.modelId } : {}),
+            ...(s.config.thinkingLevel !== undefined
+              ? { thinkingLevel: s.config.thinkingLevel }
+              : {}),
+          }
+        : undefined;
+    return {
+      jid: s.jid,
+      name: s.name,
+      folder: s.folder,
+      isCone: s.isCone,
+      assistantLabel: s.assistantLabel,
+      status: (this.scoopStatuses.get(s.jid) ?? 'ready') as ScoopTabState['status'],
+      ...(config ? { config } : {}),
+    };
+  }
+
   /** Build a full state snapshot for panel reconnect. */
   buildStateSnapshot(): StateSnapshotMsg {
-    const scoops =
-      this.orchestrator?.getScoops().map((s) => ({
-        jid: s.jid,
-        name: s.name,
-        folder: s.folder,
-        isCone: s.isCone,
-        assistantLabel: s.assistantLabel,
-        status: (this.scoopStatuses.get(s.jid) ?? 'ready') as ScoopTabState['status'],
-      })) ?? [];
+    const scoops = this.orchestrator?.getScoops().map((s) => this.toScoopSnapshot(s)) ?? [];
 
     const cone = scoops.find((s) => s.isCone);
 
@@ -436,14 +458,7 @@ export class OffscreenBridge {
         await this.orchestrator.registerScoop(scoop);
         this.emit({
           type: 'scoop-created',
-          scoop: {
-            jid: scoop.jid,
-            name: scoop.name,
-            folder: scoop.folder,
-            isCone: scoop.isCone,
-            assistantLabel: scoop.assistantLabel,
-            status: 'ready',
-          },
+          scoop: this.toScoopSnapshot(scoop),
         } satisfies ScoopCreatedMsg);
         break;
       }
@@ -528,9 +543,14 @@ export class OffscreenBridge {
       }
 
       case 'set-thinking-level': {
-        const tlMsg = msg as { scoopJid: string; level?: string };
+        // `msg` is already narrowed to `SetThinkingLevelMsg` by the union
+        // tag — the explicit annotation makes that obvious to readers and
+        // ensures the orchestrator call site receives a typed
+        // `ThinkingLevel | undefined` (the message field's literal union
+        // is the same shape the orchestrator expects).
+        const tlMsg: SetThinkingLevelMsg = msg;
         try {
-          await this.orchestrator.setScoopThinkingLevel(tlMsg.scoopJid, tlMsg.level as never);
+          await this.orchestrator.setScoopThinkingLevel(tlMsg.scoopJid, tlMsg.level);
         } catch (err) {
           console.error('[offscreen-bridge] set-thinking-level failed:', err);
         }
@@ -629,15 +649,7 @@ export class OffscreenBridge {
   }
 
   /** @internal */ emitScoopList(): void {
-    const scoops =
-      this.orchestrator?.getScoops().map((s) => ({
-        jid: s.jid,
-        name: s.name,
-        folder: s.folder,
-        isCone: s.isCone,
-        assistantLabel: s.assistantLabel,
-        status: (this.scoopStatuses.get(s.jid) ?? 'ready') as ScoopTabState['status'],
-      })) ?? [];
+    const scoops = this.orchestrator?.getScoops().map((s) => this.toScoopSnapshot(s)) ?? [];
     this.emit({ type: 'scoop-list', scoops } satisfies ScoopListMsg);
   }
 

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -527,6 +527,16 @@ export class OffscreenBridge {
         break;
       }
 
+      case 'set-thinking-level': {
+        const tlMsg = msg as { scoopJid: string; level?: string };
+        try {
+          await this.orchestrator.setScoopThinkingLevel(tlMsg.scoopJid, tlMsg.level as never);
+        } catch (err) {
+          console.error('[offscreen-bridge] set-thinking-level failed:', err);
+        }
+        break;
+      }
+
       case 'sprinkle-lick': {
         // Sprinkle lick event from the side panel — route to targetScoop or fall back to cone
         const scoops = this.orchestrator.getScoops();

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -96,9 +96,12 @@ export interface AgentSpawnOptions {
    *
    * `xhigh` is forwarded as-is; ScoopContext clamps to `'high'` at
    * Agent-construction time when the resolved model lacks xhigh support.
-   * Validation of the literal value happens in
-   * `agent-command.ts` (`--thinking` flag) — the bridge trusts callers
-   * to supply a valid {@link ThinkingLevel}.
+   *
+   * Validation: `spawn()` validates this field on every call and returns
+   * an error result for unknown literal values, regardless of caller —
+   * `agent-command.ts` (the `--thinking` CLI flag) and `scoop_scoop`
+   * already validate at their layer for tighter user feedback, but
+   * direct programmatic / extension callers also hit this path.
    */
   thinkingLevel?: ThinkingLevel;
 }
@@ -208,12 +211,16 @@ export function createAgentBridge(
 
   /**
    * Mirror of {@link resolveParentModelId} for `thinkingLevel`. Returns
-   * `null` when the parent is missing or has no `config.thinkingLevel`.
-   * The cone never stores its level here either — it lives on the cone's
-   * live `agent.state.thinkingLevel`, which the chat-panel UI mutates
-   * directly. Ephemeral `agent` invocations from the cone therefore
-   * default to `undefined` here and let `ScoopContext.init()` fall back
-   * to `'off'` unless the caller passed `--thinking <level>`.
+   * `null` when the parent is missing or has no persisted
+   * `config.thinkingLevel`.
+   *
+   * Reads from the registered scoop's config for any parent jid (cone or
+   * scoop) — `Orchestrator.setScoopThinkingLevel` persists into
+   * `scoop.config.thinkingLevel` for both, so a cone with a UI-set level
+   * will inherit it down to ephemeral `agent` sub-scoops. When the cone
+   * never had a level set (the common case), this returns `null` and
+   * the bridge falls back to `undefined`, which `ScoopContext.init()`
+   * then resolves to `'off'`.
    */
   function resolveParentThinkingLevel(parentJid: string | undefined): ThinkingLevel | null {
     if (parentJid === undefined) return null;

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -33,7 +33,13 @@ import type { Orchestrator } from './orchestrator.js';
 import type { VirtualFS } from '../fs/index.js';
 import { normalizePath } from '../fs/path-utils.js';
 import type { SessionStore } from '../core/session.js';
-import { CURRENT_SCOOP_CONFIG_VERSION, type RegisteredScoop } from './types.js';
+import {
+  CURRENT_SCOOP_CONFIG_VERSION,
+  isThinkingLevel,
+  THINKING_LEVELS,
+  type RegisteredScoop,
+  type ThinkingLevel,
+} from './types.js';
 import { createLogger } from '../core/logger.js';
 import { getAllAvailableModels } from '../ui/provider-settings.js';
 
@@ -81,6 +87,20 @@ export interface AgentSpawnOptions {
    * Must be an absolute path. Normalized to a trailing-slash prefix.
    */
   invokingCwd?: string;
+  /**
+   * Optional reasoning / thinking level override (`off | minimal | low |
+   * medium | high | xhigh`). When omitted, falls back to the parent
+   * scoop's `config.thinkingLevel` (when found in the orchestrator
+   * registry), then to `undefined` — which `ScoopContext.init()` resolves
+   * to `'off'` via `resolveThinkingLevel`.
+   *
+   * `xhigh` is forwarded as-is; ScoopContext clamps to `'high'` at
+   * Agent-construction time when the resolved model lacks xhigh support.
+   * Validation of the literal value happens in
+   * `agent-command.ts` (`--thinking` flag) — the bridge trusts callers
+   * to supply a valid {@link ThinkingLevel}.
+   */
+  thinkingLevel?: ThinkingLevel;
 }
 
 /** Result returned by {@link AgentBridge.spawn}. */
@@ -186,6 +206,23 @@ export function createAgentBridge(
     return modelId && modelId.length > 0 ? modelId : null;
   }
 
+  /**
+   * Mirror of {@link resolveParentModelId} for `thinkingLevel`. Returns
+   * `null` when the parent is missing or has no `config.thinkingLevel`.
+   * The cone never stores its level here either — it lives on the cone's
+   * live `agent.state.thinkingLevel`, which the chat-panel UI mutates
+   * directly. Ephemeral `agent` invocations from the cone therefore
+   * default to `undefined` here and let `ScoopContext.init()` fall back
+   * to `'off'` unless the caller passed `--thinking <level>`.
+   */
+  function resolveParentThinkingLevel(parentJid: string | undefined): ThinkingLevel | null {
+    if (parentJid === undefined) return null;
+    const parent = orchestrator.getScoops().find((s) => s.jid === parentJid);
+    if (!parent) return null;
+    const level = parent.config?.thinkingLevel;
+    return level && isThinkingLevel(level) ? level : null;
+  }
+
   async function spawn(options: AgentSpawnOptions): Promise<AgentSpawnResult> {
     // Model validation first. An explicit `--model foo` with no matching
     // provider is a clean no-op — we never create the scratch folder or
@@ -203,6 +240,23 @@ export function createAgentBridge(
     // Model precedence: explicit > parent scoop > undefined (ScoopContext
     // then falls back to the UI selection via `resolveCurrentModel`).
     const effectiveModelId = requestedModelId ?? resolveParentModelId(options.parentJid) ?? '';
+
+    // Validate explicit thinkingLevel up-front. agent-command.ts already
+    // rejects unknown values, but defense-in-depth: programmatic callers
+    // (and the extension proxy) reach this path too.
+    const requestedLevel = options.thinkingLevel;
+    if (requestedLevel !== undefined && !isThinkingLevel(requestedLevel)) {
+      return {
+        finalText: `agent: invalid thinking level: ${String(requestedLevel)} (one of: ${THINKING_LEVELS.join(', ')})`,
+        exitCode: 1,
+      };
+    }
+
+    // Thinking-level precedence mirrors model precedence:
+    //   explicit > parent scoop > undefined (ScoopContext resolves
+    //   undefined to 'off' via `resolveThinkingLevel`).
+    const effectiveThinkingLevel =
+      requestedLevel ?? resolveParentThinkingLevel(options.parentJid) ?? undefined;
 
     // Friendly `<adjective>-<flavor>` naming (on-brand with the ice-cream
     // vocabulary). Folder uses dashes; jid uses underscores. Falls back
@@ -242,6 +296,9 @@ export function createAgentBridge(
     };
     if (effectiveModelId) {
       scoopConfig.modelId = effectiveModelId;
+    }
+    if (effectiveThinkingLevel !== undefined) {
+      scoopConfig.thinkingLevel = effectiveThinkingLevel;
     }
 
     const scoop: RegisteredScoop = {

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -15,6 +15,7 @@ import {
   type ChannelMessage,
   type ScoopTabState,
   type ScheduledTask,
+  type ThinkingLevel,
 } from './types.js';
 import * as db from './db.js';
 import { createLogger } from '../core/logger.js';
@@ -1764,6 +1765,49 @@ export class Orchestrator {
       context.updateModel();
     }
     log.info('Model updated on all active contexts', { contextCount: this.contexts.size });
+  }
+
+  /**
+   * Update a single scoop's reasoning / thinking level. Mutates the live
+   * agent (`agent.state.thinkingLevel`) for the next turn AND persists the
+   * value into `scoop.config.thinkingLevel` on disk so it survives reloads.
+   *
+   * Returns the level actually applied after model-aware resolution
+   * (xhigh→high clamp on unsupported models, off on non-reasoning models).
+   * Returns `null` when no scoop with the given jid is registered, or the
+   * scoop has no live context (initialization failed / not yet ready).
+   */
+  async setScoopThinkingLevel(
+    jid: string,
+    level: ThinkingLevel | undefined
+  ): Promise<ThinkingLevel | null> {
+    const scoop = this.scoops.get(jid);
+    if (!scoop) return null;
+
+    const context = this.contexts.get(jid);
+    const applied = context ? context.setThinkingLevel(level) : null;
+
+    // Persist the requested level (not the resolved/clamped one): on a
+    // model swap later, we want the user's stated preference re-resolved
+    // against the new model, not the stale clamped value.
+    if (level === undefined) {
+      if (scoop.config && scoop.config.thinkingLevel !== undefined) {
+        const { thinkingLevel: _omit, ...rest } = scoop.config;
+        scoop.config = rest;
+      }
+    } else {
+      scoop.config = { ...(scoop.config ?? {}), thinkingLevel: level };
+    }
+
+    try {
+      await db.saveScoop(scoop);
+    } catch (err) {
+      log.warn('Failed to persist thinkingLevel', {
+        jid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return applied;
   }
 
   /** Reload skills on all active scoop contexts (cone + scoops). */

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -25,8 +25,9 @@ import type {
   ImageContent,
   Model,
 } from '../core/index.js';
-import { isContextOverflow, streamSimple } from '@mariozechner/pi-ai';
-import type { AssistantMessage as PiAssistantMessage } from '@mariozechner/pi-ai';
+import { isContextOverflow, streamSimple, supportsXhigh } from '@mariozechner/pi-ai';
+import type { Api, AssistantMessage as PiAssistantMessage } from '@mariozechner/pi-ai';
+import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
 import type { SessionStore } from '../core/session.js';
 import { createFileTools, createBashTool } from '../tools/index.js';
 import type { BrowserAPI } from '../cdp/index.js';
@@ -45,6 +46,28 @@ import { getAdobeSessionId } from './llm-session-id.js';
 import { fetchSecretEnvVars } from '../core/secret-env.js';
 
 const log = createLogger('scoop-context');
+
+/**
+ * Resolve a thinking level against an active model. Returns the value the
+ * `Agent` should be initialized with — never throws.
+ *
+ * Rules:
+ *   - Non-reasoning model → always `'off'`, regardless of `requested`.
+ *   - `requested === undefined` → `'off'` (default; UI/CLI can opt in).
+ *   - `requested === 'xhigh'` and `!supportsXhigh(model)` → clamped to `'high'`.
+ *   - Otherwise the requested value is passed through.
+ *
+ * Exposed for tests and re-used by `agent-bridge.ts`.
+ */
+export function resolveThinkingLevel(
+  requested: ThinkingLevel | undefined,
+  model: Model<Api>
+): ThinkingLevel {
+  if (!model.reasoning) return 'off';
+  if (requested === undefined) return 'off';
+  if (requested === 'xhigh' && !supportsXhigh(model)) return 'high';
+  return requested;
+}
 
 /** Detect API errors caused by invalid/oversized images. */
 export function isImageProcessingError(msg: string): boolean {
@@ -386,12 +409,15 @@ export class ScoopContext {
       // Guard: dispose() may have run while init() was awaiting above.
       if (this.disposed) return;
 
+      const thinkingLevel = resolveThinkingLevel(this.scoop.config?.thinkingLevel, model);
+
       this.agent = new Agent({
         initialState: {
           model,
           tools,
           systemPrompt,
           messages: restoredMessages,
+          thinkingLevel,
         },
         getApiKey: () => getApiKey() ?? undefined,
         transformContext: compactFn,
@@ -651,6 +677,30 @@ export class ScoopContext {
       folder: this.scoop.folder,
       skillCount: skills.length,
     });
+  }
+
+  /**
+   * Update the active reasoning/thinking level for this scoop.
+   *
+   * Mutates `agent.state.thinkingLevel` directly (it's writable on
+   * pi-agent-core's `AgentState`), so the next assistant turn picks up the
+   * change without restarting the agent. The caller is responsible for
+   * persisting `scoop.config.thinkingLevel` separately if the change should
+   * survive a reload — `Orchestrator.updateScoopConfig` handles that.
+   *
+   * Returns the level actually applied, after model-aware resolution
+   * (xhigh→high clamp on unsupported models, off on non-reasoning models).
+   */
+  setThinkingLevel(level: ThinkingLevel | undefined): ThinkingLevel {
+    if (!this.agent) return 'off';
+    const resolved = resolveThinkingLevel(level, this.agent.state.model);
+    this.agent.state.thinkingLevel = resolved;
+    return resolved;
+  }
+
+  /** Currently applied thinking level on the running agent. */
+  getThinkingLevel(): ThinkingLevel {
+    return this.agent?.state.thinkingLevel ?? 'off';
   }
 
   /** Cleanup */

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -641,12 +641,34 @@ export class ScoopContext {
     return this.shell;
   }
 
-  /** Update the model on the running agent (e.g., when the user changes the model dropdown). */
+  /**
+   * Update the model on the running agent (e.g. when the user changes
+   * the model dropdown).
+   *
+   * Also re-resolves the running thinking-level against the new model:
+   * `xhigh` clamps down to `high` on a model family that doesn't
+   * advertise xhigh, and any non-`off` level snaps to `off` on a
+   * non-reasoning model. The persisted `scoop.config.thinkingLevel`
+   * stays untouched so the user's intent is preserved across model
+   * swaps — the resolver re-evaluates it on every change.
+   */
   updateModel(): void {
     if (!this.agent) return;
     const model = resolveCurrentModel();
     this.agent.state.model = model;
-    log.info('Model updated on running agent', { folder: this.scoop.folder, model: model.id });
+    // Re-resolve the active thinking level against the new model. Read
+    // the user's *intent* off the persisted scoop config (not
+    // `agent.state.thinkingLevel`, which would already have been
+    // clamped by a previous resolution) so a model swap that re-enables
+    // a higher tier (e.g. switching to an xhigh-capable Opus) restores
+    // it instead of leaving the previously-clamped value in place.
+    const requested = this.scoop.config?.thinkingLevel;
+    this.agent.state.thinkingLevel = resolveThinkingLevel(requested, model);
+    log.info('Model updated on running agent', {
+      folder: this.scoop.folder,
+      model: model.id,
+      thinkingLevel: this.agent.state.thinkingLevel,
+    });
   }
 
   /** Hot-reload skills from VFS and update the agent's system prompt. */

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -6,7 +6,13 @@
  */
 
 import type { ToolDefinition } from '../core/types.js';
-import { CURRENT_SCOOP_CONFIG_VERSION, type RegisteredScoop } from './types.js';
+import {
+  CURRENT_SCOOP_CONFIG_VERSION,
+  THINKING_LEVELS,
+  isThinkingLevel,
+  type RegisteredScoop,
+  type ThinkingLevel,
+} from './types.js';
 import { createLogger } from '../core/logger.js';
 
 const log = createLogger('scoop-management-tools');
@@ -242,6 +248,12 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
               description:
                 'Shell command allow-list. Omit for unrestricted access to every built-in, custom, and .jsh command (the default). Pass a list of command names to restrict the scoop\'s shell — e.g. ["echo","cat","grep"] for a read-only text-processing scoop. Pass ["*"] for explicit unrestricted. Applies to pipelines, substitutions, and network commands too.',
             },
+            thinking: {
+              type: 'string',
+              enum: [...THINKING_LEVELS],
+              description:
+                'Reasoning / thinking-level for this scoop (pi-ai effort). One of: off, minimal, low, medium, high, xhigh. Omit to inherit the global default ("off"). Non-reasoning models always clamp to "off"; "xhigh" clamps to "high" on models that do not support the max tier.',
+            },
           },
           required: ['name'],
         },
@@ -253,6 +265,7 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
             visiblePaths,
             writablePaths,
             allowedCommands,
+            thinking,
           } = input as {
             name: string;
             model?: string;
@@ -260,7 +273,22 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
             visiblePaths?: string[];
             writablePaths?: string[];
             allowedCommands?: string[];
+            thinking?: string;
           };
+
+          // Validate thinking level eagerly so the cone gets a tight error
+          // message instead of a silently-dropped value. Mirrors the
+          // validation done by `agent-bridge.ts` and `agent-command.ts`.
+          let thinkingLevel: ThinkingLevel | undefined;
+          if (thinking !== undefined) {
+            if (!isThinkingLevel(thinking)) {
+              return {
+                content: `Invalid thinking level "${thinking}". Must be one of: ${THINKING_LEVELS.join(', ')}.`,
+                isError: true,
+              };
+            }
+            thinkingLevel = thinking;
+          }
           const folder =
             name
               .toLowerCase()
@@ -289,6 +317,7 @@ export function createScoopManagementTools(config: ScoopManagementToolsConfig): 
                 visiblePaths: visiblePaths ?? ['/workspace/'],
                 writablePaths: writablePaths ?? [`/scoops/${folder}/`, '/shared/'],
                 ...(allowedCommands ? { allowedCommands } : {}),
+                ...(thinkingLevel ? { thinkingLevel } : {}),
               },
               configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
             });

--- a/packages/webapp/src/scoops/types.ts
+++ b/packages/webapp/src/scoops/types.ts
@@ -7,6 +7,39 @@
  */
 
 import type { MessageAttachment } from '../core/attachments.js';
+import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
+
+export type { ThinkingLevel };
+
+/**
+ * Click-cycle order for the chat panel's brain icon. The full
+ * {@link ThinkingLevel} enum (`off | minimal | low | medium | high | xhigh`)
+ * remains valid for programmatic / shell-flag callers; the UI only steps
+ * through this 4-bucket subset for clarity. `xhigh` is silently skipped to
+ * `off` when the active model doesn't support it (see `supportsXhigh()` in
+ * `@mariozechner/pi-ai`).
+ */
+export const THINKING_LEVEL_CYCLE: readonly ThinkingLevel[] = [
+  'off',
+  'low',
+  'high',
+  'xhigh',
+] as const;
+
+/** Full enumeration accepted by the `agent --thinking` flag and tools. */
+export const THINKING_LEVELS: readonly ThinkingLevel[] = [
+  'off',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+] as const;
+
+/** Type guard: is `value` a valid {@link ThinkingLevel}? */
+export function isThinkingLevel(value: unknown): value is ThinkingLevel {
+  return typeof value === 'string' && (THINKING_LEVELS as readonly string[]).includes(value);
+}
 
 /**
  * Current `ScoopConfig` schema generation. Bumped whenever a new field is
@@ -77,6 +110,17 @@ export interface ScoopConfig {
   assistantName?: string;
   /** Model ID override (e.g., "claude-sonnet-4-20250514"). Uses globally selected model if not set. */
   modelId?: string;
+  /**
+   * Reasoning / thinking level forwarded to `pi-agent-core`'s
+   * {@link import('@mariozechner/pi-agent-core').AgentState.thinkingLevel}.
+   * One of `off | minimal | low | medium | high | xhigh`. When unset, the
+   * scoop inherits its parent's level (or `off` for non-reasoning models).
+   *
+   * `xhigh` is silently clamped to `high` when the active model doesn't
+   * advertise xhigh support — see `supportsXhigh()` from `@mariozechner/pi-ai`.
+   * For non-reasoning models the value is ignored entirely.
+   */
+  thinkingLevel?: ThinkingLevel;
   /**
    * VFS paths this scoop can READ (but not write). Pure replace — when
    * `undefined` the scoop gets no read-only paths at all. The `scoop_scoop`

--- a/packages/webapp/src/shell/supplemental-commands/agent-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/agent-command.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'just-bash';
 import type { Command } from 'just-bash';
 import { createLogger } from '../../core/logger.js';
 import { normalizePath } from '../../fs/path-utils.js';
+import { THINKING_LEVELS, isThinkingLevel, type ThinkingLevel } from '../../scoops/types.js';
 
 const log = createLogger('agent-command');
 
@@ -23,6 +24,8 @@ interface AgentSpawnOptions {
    * on the bridge for the read-only tradeoff.
    */
   invokingCwd?: string;
+  /** Forwarded to the bridge as the spawned scoop's thinking-level override. */
+  thinkingLevel?: ThinkingLevel;
 }
 
 /** Options accepted by {@link createAgentCommand}. */
@@ -72,6 +75,13 @@ Default sandbox:
 Options:
   --model <id>            Override the model id used by the spawned scoop.
                           Defaults to inheriting the parent's model.
+  --thinking <level>      Reasoning / thinking level for the spawned scoop.
+                          One of: off, minimal, low, medium, high, xhigh.
+                          Defaults to inheriting the parent's level (or 'off'
+                          when there is no parent). 'xhigh' is silently
+                          clamped to 'high' when the resolved model doesn't
+                          support it. Ignored entirely for non-reasoning
+                          models. Aliased as --effort.
   --read-only <paths>     Comma-separated VFS paths exposed read-only to the
                           spawned scoop (visiblePaths). Pure replace — when
                           set, the default ["/workspace/"] AND the implicit
@@ -85,6 +95,7 @@ Examples:
   agent . "*" "say hello in one word"
   agent /home ls,wc,find "how many files do I have in my home directory"
   agent --model claude-haiku-4-5 . "*" "summarize files in this directory"
+  agent --thinking high . "*" "design a careful plan first"
   agent --read-only /workspace/,/shared/assets/ . "*" "review the docs"
 `;
 
@@ -95,6 +106,7 @@ interface ParsedArgs {
   prompt?: string;
   modelId?: string;
   visiblePaths?: string[];
+  thinkingLevel?: ThinkingLevel;
   error?: string;
 }
 
@@ -114,6 +126,7 @@ function parseArgs(args: string[]): ParsedArgs {
   let help = false;
   let modelId: string | undefined;
   let visiblePaths: string[] | undefined;
+  let thinkingLevel: ThinkingLevel | undefined;
 
   let i = 0;
   while (i < args.length) {
@@ -147,6 +160,29 @@ function parseArgs(args: string[]): ParsedArgs {
         return { help: false, error: 'agent: --model requires a non-empty value' };
       }
       modelId = next;
+      i += 2;
+      continue;
+    }
+
+    if (arg === '--thinking' || arg === '--effort') {
+      const next = args[i + 1];
+      if (next === undefined) {
+        return { help: false, error: `agent: ${arg} requires a value` };
+      }
+      // A flag-looking value is rejected (e.g., `--thinking --help`).
+      if (next.length > 0 && next.startsWith('-')) {
+        return { help: false, error: `agent: ${arg} requires a value` };
+      }
+      if (next === '') {
+        return { help: false, error: `agent: ${arg} requires a non-empty value` };
+      }
+      if (!isThinkingLevel(next)) {
+        return {
+          help: false,
+          error: `agent: ${arg} must be one of: ${THINKING_LEVELS.join(', ')}`,
+        };
+      }
+      thinkingLevel = next;
       i += 2;
       continue;
     }
@@ -195,7 +231,7 @@ function parseArgs(args: string[]): ParsedArgs {
   }
 
   const [cwd, allowedCommandsRaw, prompt] = positionals;
-  return { help: false, cwd, allowedCommandsRaw, prompt, modelId, visiblePaths };
+  return { help: false, cwd, allowedCommandsRaw, prompt, modelId, visiblePaths, thinkingLevel };
 }
 
 /**
@@ -355,6 +391,9 @@ export function createAgentCommand(options: AgentCommandOptions = {}): Command {
     }
     if (parsed.visiblePaths !== undefined) {
       spawnOptions.visiblePaths = parsed.visiblePaths;
+    }
+    if (parsed.thinkingLevel !== undefined) {
+      spawnOptions.thinkingLevel = parsed.thinkingLevel;
     }
     // Forward the invoking shell's cwd. The bridge uses it as an
     // implicit read-only root (visiblePaths) ONLY when `--read-only`

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -5,7 +5,8 @@
  * Connects to an AgentHandle for sending messages and receiving events.
  */
 
-import { File as FileIcon, FileText, Image as ImageIcon, Paperclip, X } from 'lucide';
+import { Brain, File as FileIcon, FileText, Image as ImageIcon, Paperclip, X } from 'lucide';
+import { THINKING_LEVEL_CYCLE, isThinkingLevel, type ThinkingLevel } from '../scoops/types.js';
 import type { AgentHandle, AgentEvent, ChatMessage, ToolCall } from './types.js';
 import { renderAssistantMessageContent, renderMessageContent } from './message-renderer.js';
 import { SessionStore } from './session-store.js';
@@ -155,6 +156,22 @@ export class ChatPanel {
   public onDipLick?: (action: string, data: unknown) => void;
   private modelSelectorEl!: HTMLElement;
   public onModelChange?: (modelId: string) => void;
+  private thinkingBtn!: HTMLButtonElement;
+  /**
+   * Currently displayed thinking level. Source of truth for the brain icon
+   * UI; mirrored to the active scoop's `agent.state.thinkingLevel` and
+   * `scoop.config.thinkingLevel` via {@link onThinkingLevelChange}.
+   */
+  private thinkingLevel: ThinkingLevel = 'off';
+  /**
+   * Whether the active model supports reasoning at all. The brain icon is
+   * hidden when false. Toggled by {@link setModelSupportsReasoning} when
+   * the layout learns the active scoop's model has changed.
+   */
+  private modelSupportsReasoning = false;
+  /** Whether the active model supports the `xhigh` cycle stop. */
+  private modelSupportsXhigh = false;
+  public onThinkingLevelChange?: (level: ThinkingLevel) => void;
   // Per-sessionId write queue for `persistLickToSession`. Chains concurrent
   // load→mutate→save cycles behind the previous in-flight call so bursty
   // licks (e.g. fswatch) for a non-selected scoop can't clobber each other.
@@ -715,9 +732,20 @@ export class ChatPanel {
     actionBarLeft.appendChild(this.micBtn);
     actionBar.appendChild(actionBarLeft);
 
-    // Model selector — between left actions and send button
+    // Model selector — between left actions and send button.
+    // The brain icon (thinking-level cycle) sits LEFT of the model pill
+    // inside the same flex container so it stays visually attached.
     this.modelSelectorEl = document.createElement('div');
     this.modelSelectorEl.className = 'chat__model-selector';
+
+    this.thinkingBtn = document.createElement('button');
+    this.thinkingBtn.type = 'button';
+    this.thinkingBtn.className = 'chat__thinking-btn';
+    this.thinkingBtn.appendChild(createLucideIcon(Brain as unknown as IconNode, 18));
+    this.thinkingBtn.addEventListener('click', () => this.cycleThinkingLevel());
+    this.modelSelectorEl.appendChild(this.thinkingBtn);
+    this.updateThinkingBtn();
+
     this.renderModelSelector();
     actionBar.appendChild(this.modelSelectorEl);
 
@@ -1193,6 +1221,13 @@ export class ChatPanel {
     const el = this.modelSelectorEl;
     if (!el) return;
     while (el.firstChild) el.removeChild(el.firstChild);
+    // The brain icon lives in the same flex container so it visually
+    // anchors to the model pill. Re-attach it after every clear so the
+    // model-list rerender doesn't accidentally drop it.
+    if (this.thinkingBtn) {
+      el.appendChild(this.thinkingBtn);
+      this.updateThinkingBtn();
+    }
 
     const groups = getAllAvailableModels();
     const currentModelId = getSelectedModelId();
@@ -1298,6 +1333,77 @@ export class ChatPanel {
   /** Refresh the model selector (call after provider changes). */
   refreshModelSelector(): void {
     this.renderModelSelector();
+  }
+
+  // ── Thinking level (brain icon) ───────────────────────────────────
+
+  /**
+   * Set whether the active model supports reasoning + xhigh. Drives the
+   * brain icon's visibility and cycle range. Layout calls this whenever
+   * the active scoop's model changes (initial select, model picker swap).
+   */
+  setModelSupportsReasoning(reasoning: boolean, xhigh: boolean): void {
+    this.modelSupportsReasoning = reasoning;
+    this.modelSupportsXhigh = xhigh;
+    if (!reasoning) {
+      this.thinkingLevel = 'off';
+    } else if (this.thinkingLevel === 'xhigh' && !xhigh) {
+      this.thinkingLevel = 'high';
+    }
+    this.updateThinkingBtn();
+  }
+
+  /**
+   * Set the displayed thinking level without notifying listeners. Layout
+   * calls this on scoop switch to mirror the persisted
+   * `scoop.config.thinkingLevel` into the UI.
+   */
+  setThinkingLevel(level: ThinkingLevel | undefined): void {
+    if (level !== undefined && isThinkingLevel(level)) {
+      this.thinkingLevel = level;
+    } else {
+      this.thinkingLevel = 'off';
+    }
+    this.updateThinkingBtn();
+  }
+
+  /** Currently displayed thinking level. */
+  getThinkingLevel(): ThinkingLevel {
+    return this.thinkingLevel;
+  }
+
+  /**
+   * Cycle through {@link THINKING_LEVEL_CYCLE}, skipping `xhigh` when the
+   * active model doesn't support it. Notifies {@link onThinkingLevelChange}
+   * so the layout can mirror the new value into the active scoop's config
+   * + live agent state.
+   */
+  private cycleThinkingLevel(): void {
+    if (!this.modelSupportsReasoning) return;
+    const cycle = this.modelSupportsXhigh
+      ? THINKING_LEVEL_CYCLE
+      : THINKING_LEVEL_CYCLE.filter((l) => l !== 'xhigh');
+    const idx = cycle.indexOf(this.thinkingLevel);
+    // Unknown current level (e.g. minimal/medium set via shell flag) →
+    // start the cycle from the beginning so the click does something
+    // predictable.
+    const next = cycle[idx === -1 ? 0 : (idx + 1) % cycle.length];
+    this.thinkingLevel = next;
+    this.updateThinkingBtn();
+    this.onThinkingLevelChange?.(next);
+  }
+
+  private updateThinkingBtn(): void {
+    if (!this.thinkingBtn) return;
+    if (!this.modelSupportsReasoning) {
+      this.thinkingBtn.hidden = true;
+      return;
+    }
+    this.thinkingBtn.hidden = false;
+    this.thinkingBtn.dataset.level = this.thinkingLevel;
+    const label = `Thinking: ${this.thinkingLevel} (click to cycle)`;
+    this.thinkingBtn.setAttribute('aria-label', label);
+    this.thinkingBtn.dataset.tooltip = label;
   }
 
   private findMessage(id: string): ChatMessage | undefined {

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -125,6 +125,14 @@ export class Layout {
   public onThinkingLevelChange?: (level: ThinkingLevel) => void;
   /** Re-populate the model dropdown (call after provider login/logout). */
   public refreshModels?: () => void;
+  /**
+   * Fired after `refreshModels` finishes — i.e. whenever provider accounts
+   * change and the chat panel's active model may have shifted. main.ts
+   * uses this hook to re-sync the thinking-level brain icon to the new
+   * model's reasoning support (a model swap from a non-reasoning to a
+   * reasoning model has to un-hide the icon).
+   */
+  public onModelsRefreshed?: () => void;
   public onScoopSelect?: (scoop: RegisteredScoop) => void;
   public onClearChat?: () => Promise<void>;
   public onClearFilesystem?: () => Promise<void>;
@@ -287,6 +295,10 @@ export class Layout {
       ensureModelSelected();
       this.panels?.chat?.refreshModelSelector();
       this.refreshAvatar();
+      // Notify main.ts so it can re-resolve the active model for the brain
+      // icon. Done last so the chat panel has already re-rendered when the
+      // hook fires.
+      this.onModelsRefreshed?.();
     };
   }
 

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -43,7 +43,7 @@ import { PanelRegistry } from './panel-registry.js';
 import { showSprinklePicker } from './sprinkle-picker.js';
 import type { ZoneId } from './panel-types.js';
 // ChatMessage import removed — copy chat moved to feedback row
-import type { RegisteredScoop, ScoopTabState } from '../scoops/types.js';
+import type { RegisteredScoop, ScoopTabState, ThinkingLevel } from '../scoops/types.js';
 
 export interface LayoutPanels {
   chat: ChatPanel;
@@ -121,6 +121,8 @@ export class Layout {
   public panels!: LayoutPanels;
   public readonly registry = new PanelRegistry();
   public onModelChange?: (model: string) => void;
+  /** Fired when the user cycles the brain icon in the chat panel. */
+  public onThinkingLevelChange?: (level: ThinkingLevel) => void;
   /** Re-populate the model dropdown (call after provider login/logout). */
   public refreshModels?: () => void;
   public onScoopSelect?: (scoop: RegisteredScoop) => void;
@@ -658,6 +660,7 @@ export class Layout {
   // `extensionZone`, dual-zone TabZone wiring) have been retired.
   // Both modes now mount the same split layout below — the only
   // mode-specific tweaks live in `buildSplitLayout` / `buildHeader`.
+  // ── Standalone: Split Layout ────────────────────────────────────────
 
   private buildSplitLayout(): void {
     while (this.root.firstChild) this.root.removeChild(this.root.firstChild);
@@ -898,6 +901,7 @@ export class Layout {
 
     // Wire chat panel model selector to layout's onModelChange
     this.panels.chat.onModelChange = (modelId) => this.onModelChange?.(modelId);
+    this.panels.chat.onThinkingLevelChange = (level) => this.onThinkingLevelChange?.(level);
 
     this.setupVerticalDrag();
     window.addEventListener('resize', () => {});

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -800,6 +800,11 @@ async function mainExtension(app: HTMLElement): Promise<void> {
     client.setScoopThinkingLevel(selectedScoop.jid, level);
   };
 
+  // Re-sync brain icon on provider account changes (see standalone path).
+  layout.onModelsRefreshed = () => {
+    if (selectedScoop) syncThinkingButtonForExtensionScoop(selectedScoop);
+  };
+
   // Wire clear chat — delete all scoop sessions from the shared IndexedDB
   // synchronously (from the panel's perspective) before the reload happens.
   // The bridge also clears its in-memory buffers via the clear-chat message.
@@ -2842,6 +2847,14 @@ async function main(): Promise<void> {
   layout.onThinkingLevelChange = (level) => {
     if (!selectedScoop) return;
     void orchestrator.setScoopThinkingLevel(selectedScoop.jid, level);
+  };
+
+  // Re-sync the brain icon when provider accounts change — the active
+  // model's reasoning support may have shifted (e.g. logging into Adobe
+  // exposes Claude models with reasoning=true), and `refreshModels` is
+  // the canonical signal for that transition.
+  layout.onModelsRefreshed = () => {
+    if (selectedScoop) syncThinkingButtonForScoop(selectedScoop);
   };
 
   // Track which scoops have been selected at least once this runtime.

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -21,7 +21,13 @@ import './styles/feedback.css';
  */
 
 import { Layout } from './layout.js';
-import { getApiKey, applyProviderDefaults } from './provider-settings.js';
+import {
+  getApiKey,
+  applyProviderDefaults,
+  resolveCurrentModel,
+  resolveModelById,
+} from './provider-settings.js';
+import { supportsXhigh } from '@mariozechner/pi-ai';
 import { initTheme } from './theme.js';
 import { initTooltips } from './tooltip.js';
 import type { AgentHandle, AgentEvent as UIAgentEvent, ChatMessage } from './types.js';
@@ -628,6 +634,8 @@ async function mainExtension(app: HTMLElement): Promise<void> {
     if (client.isProcessing(scoop.jid)) {
       layout.panels.chat.setProcessing(true);
     }
+
+    syncThinkingButtonForExtensionScoop(scoop);
   };
 
   client = new OffscreenClient({
@@ -763,10 +771,33 @@ async function mainExtension(app: HTMLElement): Promise<void> {
 
   layout.onScoopSelect = selectScoop;
 
+  /**
+   * Sync the brain icon to the active scoop's resolved model + persisted
+   * thinking-level. Extension flavor: same lookup logic as the standalone
+   * version, but reads `scoop.config` from the proxied snapshot and uses
+   * provider-settings via the side-panel realm (which shares localStorage
+   * with offscreen for the model id).
+   */
+  const syncThinkingButtonForExtensionScoop = (scoop: RegisteredScoop): void => {
+    const modelId = scoop.config?.modelId;
+    const model = modelId ? resolveModelById(modelId) : resolveCurrentModel();
+    layout.panels.chat.setModelSupportsReasoning(!!model.reasoning, supportsXhigh(model));
+    layout.panels.chat.setThinkingLevel(scoop.config?.thinkingLevel);
+  };
+
   // Wire model picker
   layout.onModelChange = (modelId) => {
     localStorage.setItem('selected-model', modelId);
     client.updateModel();
+    if (selectedScoop) {
+      syncThinkingButtonForExtensionScoop(selectedScoop);
+    }
+  };
+
+  // Wire brain-icon thinking-level cycle through the offscreen client.
+  layout.onThinkingLevelChange = (level) => {
+    if (!selectedScoop) return;
+    client.setScoopThinkingLevel(selectedScoop.jid, level);
   };
 
   // Wire clear chat — delete all scoop sessions from the shared IndexedDB
@@ -2782,11 +2813,35 @@ async function main(): Promise<void> {
 
   connectLickWs();
 
+  /**
+   * Sync the brain icon to the active scoop's resolved model + persisted
+   * thinking-level. Called on scoop switch and after a model swap.
+   */
+  const syncThinkingButtonForScoop = (scoop: RegisteredScoop): void => {
+    const modelId = scoop.config?.modelId;
+    const model = modelId ? resolveModelById(modelId) : resolveCurrentModel();
+    layout.panels.chat.setModelSupportsReasoning(!!model.reasoning, supportsXhigh(model));
+    layout.panels.chat.setThinkingLevel(scoop.config?.thinkingLevel);
+  };
+
   // Wire model picker changes
   layout.onModelChange = (modelId) => {
     localStorage.setItem('selected-model', modelId);
     // Immediately update all active agent contexts to use the new model
     orchestrator.updateModel();
+    // The brain icon's visibility / xhigh availability depends on the
+    // selected model — refresh it now so the UI matches the new active
+    // model on the cone (scoop overrides keep their own model).
+    if (selectedScoop) {
+      syncThinkingButtonForScoop(selectedScoop);
+    }
+  };
+
+  // Wire brain-icon thinking-level cycle to the orchestrator. Updates the
+  // live agent for the next turn AND persists into scoop.config.thinkingLevel.
+  layout.onThinkingLevelChange = (level) => {
+    if (!selectedScoop) return;
+    void orchestrator.setScoopThinkingLevel(selectedScoop.jid, level);
   };
 
   // Track which scoops have been selected at least once this runtime.
@@ -2911,6 +2966,11 @@ async function main(): Promise<void> {
     }
 
     selectedOnceThisRuntime.add(scoop.jid);
+
+    // Sync brain icon to the freshly selected scoop's persisted level +
+    // model capabilities. Done last so the chat panel has already
+    // re-rendered the model selector for this context.
+    syncThinkingButtonForScoop(scoop);
   };
 
   layout.onScoopSelect = handleScoopSelect;

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -186,9 +186,17 @@ export class OffscreenClient {
 
   /**
    * Update a scoop's reasoning / thinking level on the offscreen
-   * orchestrator. Mirrors the standalone-mode `Orchestrator.setScoopThinkingLevel`
-   * call. The offscreen side persists the value into IndexedDB so it
-   * survives panel close.
+   * orchestrator. Mirrors the standalone-mode
+   * `Orchestrator.setScoopThinkingLevel` call:
+   *
+   * - The offscreen side mutates the live `Agent.state.thinkingLevel`
+   *   so the next agent turn picks up the new value.
+   * - It also persists `scoop.config.thinkingLevel` into the
+   *   orchestrator's IndexedDB record.
+   * - The persisted value is surfaced back to the panel through the
+   *   `scoop-list` / `state-snapshot` / `scoop-created` messages
+   *   (see `ScoopSnapshotConfig`), so the brain icon rehydrates with
+   *   the correct level on reconnect / scoop switch.
    */
   setScoopThinkingLevel(jid: string, level: ThinkingLevel | undefined): void {
     this.send({ type: 'set-thinking-level', scoopJid: jid, level });
@@ -473,6 +481,13 @@ export class OffscreenClient {
       requiresTrigger: !s.isCone,
       assistantLabel: s.assistantLabel,
       addedAt: new Date().toISOString(),
+      // Carry the persisted-per-scoop config snapshot through to the
+      // panel-side `RegisteredScoop`. The offscreen bridge populates
+      // `s.config` with `modelId` + `thinkingLevel` (see
+      // `OffscreenBridge.toScoopSnapshot`); the panel reads these in
+      // `syncThinkingButtonForExtensionScoop` to drive the brain icon's
+      // visibility and persisted level on scoop switches and reconnect.
+      ...(s.config ? { config: { ...s.config } } : {}),
     };
   }
 

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -10,7 +10,7 @@
 
 import type { AgentHandle, AgentEvent as UIAgentEvent } from './types.js';
 import type { MessageAttachment } from '../core/attachments.js';
-import type { RegisteredScoop, ScoopTabState } from '../scoops/types.js';
+import type { RegisteredScoop, ScoopTabState, ThinkingLevel } from '../scoops/types.js';
 import type { VirtualFS } from '../fs/index.js';
 import type {
   ExtensionMessage,
@@ -182,6 +182,16 @@ export class OffscreenClient {
   updateModel(): void {
     // Side panel already wrote to localStorage. Tell offscreen to re-read.
     this.send({ type: 'refresh-model' });
+  }
+
+  /**
+   * Update a scoop's reasoning / thinking level on the offscreen
+   * orchestrator. Mirrors the standalone-mode `Orchestrator.setScoopThinkingLevel`
+   * call. The offscreen side persists the value into IndexedDB so it
+   * survives panel close.
+   */
+  setScoopThinkingLevel(jid: string, level: ThinkingLevel | undefined): void {
+    this.send({ type: 'set-thinking-level', scoopJid: jid, level });
   }
 
   async clearAllMessages(): Promise<void> {

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -494,6 +494,87 @@
   position: relative;
 }
 
+/* Brain icon — thinking-level cycle. Lives left of the model pill inside
+   the .chat__model-selector flex row; click cycles through
+   off → low → high → xhigh → off (xhigh skipped on unsupported models). */
+.chat__thinking-btn {
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: var(--s2-radius-default);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--s2-content-default);
+  transition:
+    opacity 130ms ease,
+    transform 130ms ease,
+    background 130ms ease,
+    color 130ms ease;
+}
+.chat__thinking-btn svg {
+  width: 18px;
+  height: 18px;
+}
+.chat__thinking-btn:hover {
+  background: var(--s2-bg-elevated);
+}
+.chat__thinking-btn:active {
+  transform: scale(0.92);
+}
+.chat__thinking-btn[hidden] {
+  display: none;
+}
+
+.chat__thinking-btn[data-level='off'] {
+  opacity: 0.5;
+}
+.chat__thinking-btn[data-level='minimal'],
+.chat__thinking-btn[data-level='low'] {
+  opacity: 0.75;
+}
+.chat__thinking-btn[data-level='medium'],
+.chat__thinking-btn[data-level='high'] {
+  opacity: 1;
+  color: var(--s2-accent, var(--slicc-cone, #6b8afd));
+}
+
+/* xhigh: ice-cream gradient with subtle shimmer.
+   Falls back to flat brand pastels via CSS variables; design tokens can
+   override via --slicc-cone-* without touching this rule. */
+.chat__thinking-btn[data-level='xhigh'] {
+  opacity: 1;
+  color: #fff;
+  background: linear-gradient(
+    135deg,
+    var(--slicc-cone-mint, #b8e6c9),
+    var(--slicc-cone-strawberry, #ffb3c1),
+    var(--slicc-cone-vanilla, #fff4c2),
+    var(--slicc-cone-blueberry, #b8c9ff)
+  );
+  background-size: 300% 300%;
+  animation: chat-thinking-shimmer 6s ease-in-out infinite;
+}
+
+@keyframes chat-thinking-shimmer {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat__thinking-btn[data-level='xhigh'] {
+    animation: none;
+  }
+}
+
 /* Pill buttons — shown when chat is empty */
 .chat__model-pill {
   border: 1px solid var(--s2-border-subtle);

--- a/packages/webapp/src/ui/tooltip.ts
+++ b/packages/webapp/src/ui/tooltip.ts
@@ -12,6 +12,16 @@ const GAP = 6; // px between trigger and tooltip
 
 let el: HTMLDivElement | null = null;
 let timer: ReturnType<typeof setTimeout> | null = null;
+/**
+ * Track the [data-tooltip] element currently being hovered. Used to
+ * ignore pointer transitions BETWEEN descendants of the same target —
+ * `pointerenter` / `pointerleave` (capture) fire for every internal
+ * element boundary the cursor crosses, which would otherwise reset the
+ * show-timer and hide the tooltip every time the cursor moves a pixel
+ * inside a button with multi-element content (e.g. a Lucide SVG with
+ * several `<path>` children).
+ */
+let activeTarget: HTMLElement | null = null;
 
 function getEl(): HTMLDivElement {
   if (!el) {
@@ -77,27 +87,43 @@ function hide(): void {
     clearTimeout(timer);
     timer = null;
   }
+  activeTarget = null;
   el?.classList.remove('s2-tooltip--visible');
 }
 
 /** Call once to install global tooltip listeners. */
 export function initTooltips(): void {
   document.addEventListener(
-    'pointerenter',
+    'pointerover',
     (e) => {
       const target = (e.target as HTMLElement).closest?.('[data-tooltip]') as HTMLElement | null;
-      if (!target) return;
+      // Cursor is still over the same tooltip-bearing element — ignore
+      // pointerover on internal descendants (e.g. moving from button
+      // padding to its SVG, or between adjacent <path> elements inside
+      // the same icon). Without this guard the timer would reset on
+      // every internal boundary crossing and the tooltip would never
+      // show on small buttons with multi-element content.
+      if (target && target === activeTarget) return;
+      // Different (or absent) target — clear any pending timer / visible
+      // tooltip from the previous target before starting a new run.
       hide();
+      if (!target) return;
+      activeTarget = target;
       timer = setTimeout(() => show(target), DELAY);
     },
     true
   );
 
   document.addEventListener(
-    'pointerleave',
+    'pointerout',
     (e) => {
-      const target = (e.target as HTMLElement).closest?.('[data-tooltip]') as HTMLElement | null;
-      if (target) hide();
+      // Only hide when the cursor truly leaves the tooltip-bearing
+      // element. `pointerout` fires when crossing into descendants too,
+      // so we use relatedTarget to detect a real exit.
+      if (!activeTarget) return;
+      const related = (e as PointerEvent).relatedTarget as Node | null;
+      if (related && activeTarget.contains(related)) return;
+      hide();
     },
     true
   );

--- a/packages/webapp/tests/scoops/agent-bridge.test.ts
+++ b/packages/webapp/tests/scoops/agent-bridge.test.ts
@@ -535,6 +535,102 @@ describe('createAgentBridge — model resolution', () => {
   });
 });
 
+describe('createAgentBridge — thinking level resolution', () => {
+  it('forwards an explicit thinkingLevel onto the scoop config', async () => {
+    const { orchestrator, registerCalls, scripts } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+      resolveModel: (id) => id,
+    });
+    scripts.set('agent_jolly_mint', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({ ...BASE_OPTS, thinkingLevel: 'high' });
+
+    expect(registerCalls[0].config?.thinkingLevel).toBe('high');
+  });
+
+  it('inherits thinkingLevel from a parent scoop when no explicit value is provided', async () => {
+    const { orchestrator, registerCalls, scripts, knownScoops } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    knownScoops.push({
+      jid: 'scoop_parent',
+      name: 'parent',
+      folder: 'parent',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'parent',
+      addedAt: '2026-04-19T00:00:00Z',
+      config: { thinkingLevel: 'medium' },
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    });
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+    });
+    scripts.set('agent_jolly_mint', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({ ...BASE_OPTS, parentJid: 'scoop_parent' });
+
+    expect(registerCalls[0].config?.thinkingLevel).toBe('medium');
+  });
+
+  it('explicit thinkingLevel overrides the parent inheritance', async () => {
+    const { orchestrator, registerCalls, scripts, knownScoops } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    knownScoops.push({
+      jid: 'scoop_parent',
+      name: 'parent',
+      folder: 'parent',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'parent',
+      addedAt: '2026-04-19T00:00:00Z',
+      config: { thinkingLevel: 'medium' },
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    });
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+    });
+    scripts.set('agent_jolly_mint', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({ ...BASE_OPTS, parentJid: 'scoop_parent', thinkingLevel: 'xhigh' });
+
+    expect(registerCalls[0].config?.thinkingLevel).toBe('xhigh');
+  });
+
+  it('leaves thinkingLevel unset when no explicit value and no parent override', async () => {
+    const { orchestrator, registerCalls, scripts } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+    });
+    scripts.set('agent_jolly_mint', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn(BASE_OPTS);
+
+    expect(registerCalls[0].config?.thinkingLevel).toBeUndefined();
+  });
+
+  it('rejects an invalid thinkingLevel without creating a scoop', async () => {
+    const { orchestrator, registerCalls } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+    });
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      thinkingLevel: 'turbo' as never,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.finalText).toContain('invalid thinking level');
+    expect(registerCalls).toHaveLength(0);
+  });
+});
+
 describe('createAgentBridge — output capture', () => {
   it('returns the last send_message as finalText', async () => {
     const { orchestrator, scripts } = makeMockOrchestrator();

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -13,6 +13,7 @@ import {
   isImageProcessingError,
   isNonRetryableError,
   isRetryableError,
+  resolveThinkingLevel,
   type ScoopContextCallbacks,
 } from '../../src/scoops/scoop-context.js';
 import type { RegisteredScoop } from '../../src/scoops/types.js';
@@ -1792,5 +1793,44 @@ describe('ScoopContext dispose', () => {
     expect(callbacks.onToolStart).not.toHaveBeenCalled();
     expect(callbacks.onToolEnd).not.toHaveBeenCalled();
     expect(callbacks.onResponseDone).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveThinkingLevel', () => {
+  // Synthesize the smallest possible `Model<Api>` shape the helper inspects.
+  // pi-ai's `supportsXhigh` only reads `id` (string match against the Opus
+  // 4.6+ / GPT-5.2+ families), so we don't need a real model record here.
+  const makeModel = (reasoning: boolean, supportsXhighFamily = false) =>
+    ({
+      id: supportsXhighFamily ? 'claude-opus-4-7' : 'claude-haiku-4-5',
+      reasoning,
+    }) as unknown as Parameters<typeof resolveThinkingLevel>[1];
+
+  it("returns 'off' when the model does not support reasoning", () => {
+    const model = makeModel(false);
+    expect(resolveThinkingLevel('high', model)).toBe('off');
+    expect(resolveThinkingLevel('xhigh', model)).toBe('off');
+    expect(resolveThinkingLevel(undefined, model)).toBe('off');
+  });
+
+  it("returns 'off' when no level is requested", () => {
+    expect(resolveThinkingLevel(undefined, makeModel(true))).toBe('off');
+  });
+
+  it('clamps xhigh to high when the model does not advertise xhigh support', () => {
+    // Haiku (or any non-xhigh family) — pi-ai's supportsXhigh returns false.
+    expect(resolveThinkingLevel('xhigh', makeModel(true, false))).toBe('high');
+  });
+
+  it('passes xhigh through when the model supports it (Opus 4.7 family)', () => {
+    expect(resolveThinkingLevel('xhigh', makeModel(true, true))).toBe('xhigh');
+  });
+
+  it('passes through other valid levels unchanged', () => {
+    const model = makeModel(true);
+    expect(resolveThinkingLevel('low', model)).toBe('low');
+    expect(resolveThinkingLevel('medium', model)).toBe('medium');
+    expect(resolveThinkingLevel('high', model)).toBe('high');
+    expect(resolveThinkingLevel('minimal', model)).toBe('minimal');
   });
 });

--- a/packages/webapp/tests/scoops/scoop-management-tools.test.ts
+++ b/packages/webapp/tests/scoops/scoop-management-tools.test.ts
@@ -166,6 +166,67 @@ describe('scoop_scoop tool — config defaults', () => {
     expect(created.configSchemaVersion).toBe(CURRENT_SCOOP_CONFIG_VERSION);
     expect(result.isError).toBeUndefined();
   });
+
+  // ── Thinking / reasoning level (#518 follow-up) ─────────────────────
+
+  it('forwards a valid thinking level onto the new scoop config', async () => {
+    const { tool, onScoopScoop } = findScoopScoopTool();
+    await tool.execute({ name: 'thinker', thinking: 'high' });
+
+    const created = onScoopScoop.mock.calls[0][0];
+    expect(created.config?.thinkingLevel).toBe('high');
+  });
+
+  it('omits thinkingLevel from config when the caller does not set it (inherits default)', async () => {
+    const { tool, onScoopScoop } = findScoopScoopTool();
+    await tool.execute({ name: 'default-effort' });
+
+    const created = onScoopScoop.mock.calls[0][0];
+    // Mirrors the allowedCommands convention — omission is the canonical
+    // "use the global default" form (which resolves to 'off' downstream).
+    expect(created.config?.thinkingLevel).toBeUndefined();
+  });
+
+  it('rejects an unknown thinking level without invoking the registry callback', async () => {
+    const { tool, onScoopScoop } = findScoopScoopTool();
+    const result = await tool.execute({ name: 'bad-effort', thinking: 'turbo' });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toMatch(/Invalid thinking level/);
+    expect(String(result.content)).toMatch(/off, minimal, low, medium, high, xhigh/);
+    expect(onScoopScoop).not.toHaveBeenCalled();
+  });
+
+  it('accepts every valid thinking level', async () => {
+    const levels = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+    for (const level of levels) {
+      const { tool, onScoopScoop } = findScoopScoopTool();
+      await tool.execute({ name: `t-${level}`, thinking: level });
+      const created = onScoopScoop.mock.calls[0][0];
+      expect(created.config?.thinkingLevel).toBe(level);
+    }
+  });
+
+  it('combines thinking with model + sandbox params on a single config record', async () => {
+    const { tool, onScoopScoop } = findScoopScoopTool();
+    await tool.execute({
+      name: 'combined-effort',
+      model: 'claude-opus-4-7',
+      visiblePaths: ['/workspace/'],
+      writablePaths: ['/scoops/combined-effort-scoop/'],
+      allowedCommands: ['echo'],
+      thinking: 'xhigh',
+    });
+
+    const created = onScoopScoop.mock.calls[0][0];
+    expect(created.config).toEqual({
+      modelId: 'claude-opus-4-7',
+      visiblePaths: ['/workspace/'],
+      writablePaths: ['/scoops/combined-effort-scoop/'],
+      allowedCommands: ['echo'],
+      thinkingLevel: 'xhigh',
+    });
+  });
 });
 
 describe('scoop_mute / scoop_unmute / scoop_wait tools', () => {

--- a/packages/webapp/tests/shell/supplemental-commands/agent-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/agent-command.test.ts
@@ -9,6 +9,7 @@ interface SpawnArgs {
   modelId?: string;
   visiblePaths?: string[];
   invokingCwd?: string;
+  thinkingLevel?: string;
 }
 
 interface SpawnResult {
@@ -912,6 +913,112 @@ describe('agent command', () => {
       installBridge(bridge);
       await createAgentCommand().execute(['--unknown'], createMockCtx());
       expect(bridge).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('--thinking flag', () => {
+    it('forwards a valid level to the bridge', async () => {
+      let captured: SpawnArgs | undefined;
+      installBridge((args) => {
+        captured = args;
+        return { finalText: 'ok', exitCode: 0 };
+      });
+      const result = await createAgentCommand().execute(
+        ['--thinking', 'high', '.', '*', 'p'],
+        createMockCtx()
+      );
+      expect(result.exitCode).toBe(0);
+      expect(captured?.thinkingLevel).toBe('high');
+    });
+
+    it('accepts --effort as an alias for --thinking', async () => {
+      let captured: SpawnArgs | undefined;
+      installBridge((args) => {
+        captured = args;
+        return { finalText: 'ok', exitCode: 0 };
+      });
+      const result = await createAgentCommand().execute(
+        ['--effort', 'xhigh', '.', '*', 'p'],
+        createMockCtx()
+      );
+      expect(result.exitCode).toBe(0);
+      expect(captured?.thinkingLevel).toBe('xhigh');
+    });
+
+    it('omits the field when the flag is absent', async () => {
+      let captured: SpawnArgs | undefined;
+      installBridge((args) => {
+        captured = args;
+        return { finalText: 'ok', exitCode: 0 };
+      });
+      await createAgentCommand().execute(['.', '*', 'p'], createMockCtx());
+      expect(captured?.thinkingLevel).toBeUndefined();
+    });
+
+    it('rejects unknown level values without invoking the bridge', async () => {
+      const bridge = vi.fn();
+      installBridge(bridge);
+      const result = await createAgentCommand().execute(
+        ['--thinking', 'turbo', '.', '*', 'p'],
+        createMockCtx()
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/--thinking must be one of/);
+      expect(bridge).not.toHaveBeenCalled();
+    });
+
+    it('rejects missing value', async () => {
+      const bridge = vi.fn();
+      installBridge(bridge);
+      const result = await createAgentCommand().execute(['--thinking'], createMockCtx());
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/--thinking requires a value/);
+      expect(bridge).not.toHaveBeenCalled();
+    });
+
+    it('rejects flag-shaped value', async () => {
+      const bridge = vi.fn();
+      installBridge(bridge);
+      const result = await createAgentCommand().execute(['--thinking', '--help'], createMockCtx());
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/--thinking requires a value/);
+      expect(bridge).not.toHaveBeenCalled();
+    });
+
+    it('treats --thinking as a prompt when it appears in the third positional slot', async () => {
+      let captured: SpawnArgs | undefined;
+      installBridge((args) => {
+        captured = args;
+        return { finalText: 'ok', exitCode: 0 };
+      });
+      await createAgentCommand().execute(['.', '*', '--thinking high'], createMockCtx());
+      expect(captured?.prompt).toBe('--thinking high');
+      expect(captured?.thinkingLevel).toBeUndefined();
+    });
+
+    it('accepts every valid level', async () => {
+      const levels = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+      for (const level of levels) {
+        let captured: SpawnArgs | undefined;
+        installBridge((args) => {
+          captured = args;
+          return { finalText: 'ok', exitCode: 0 };
+        });
+        const result = await createAgentCommand().execute(
+          ['--thinking', level, '.', '*', 'p'],
+          createMockCtx()
+        );
+        expect(result.exitCode).toBe(0);
+        expect(captured?.thinkingLevel).toBe(level);
+      }
+    });
+
+    it('mentions --thinking in --help', async () => {
+      installBridge(() => ({ finalText: '', exitCode: 0 }));
+      const result = await createAgentCommand().execute(['--help'], createMockCtx());
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/--thinking/);
+      expect(result.stdout).toMatch(/off, minimal, low, medium, high, xhigh/);
     });
   });
 });


### PR DESCRIPTION
## Summary

Wires reasoning / thinking-level support end-to-end so users (and shell scripts) can configure how much pi-ai thinks per scoop.

- New **Lucide brain icon** left of the model selector that cycles \`off → low → high → xhigh\` on click. Opacity tiers signal the active level (50 / 75 / 100), and \`xhigh\` paints the cone's ice-cream gradient with a subtle shimmer animation (honors \`prefers-reduced-motion\`).
- New **\`agent --thinking <level>\`** (alias \`--effort\`) flag on the supplemental command, valid levels: \`off | minimal | low | medium | high | xhigh\`.
- New **\`ScoopConfig.thinkingLevel\`** persisted per scoop alongside \`modelId\`.
- New **\`Orchestrator.setScoopThinkingLevel(jid, level)\`** that mutates the live agent state and persists.
- Offscreen bridge gains a \`set-thinking-level\` message so the extension side panel stays in sync across panel close/reopen.

## Layering

\`\`\`
Data:    ScoopConfig.thinkingLevel + isThinkingLevel guard
Engine:  ScoopContext.{init,setThinkingLevel,getThinkingLevel} + resolveThinkingLevel(requested, model)
Bridge:  AgentBridge -> resolveParentThinkingLevel + validation
CLI:     agent-command --thinking / --effort
UI:      chat-panel brain button + chat.css
Proxy:   offscreen-client + chrome-extension/messages + offscreen-bridge
\`\`\`

\`resolveThinkingLevel\` centralizes the clamping rules:
- non-reasoning model -> \`off\`
- no requested level -> \`off\`
- \`xhigh\` on a non-xhigh family (per pi-ai's \`supportsXhigh\` -> `high`

This means we can persist the user's *intent* (`xhigh`) without lying about the runtime, and re-resolve on every model swap.

## Tests

- 11 new tests for the `--thinking` / `--effort` flag (valid forwarding, alias, omission default, invalid values rejected, missing/flag-shaped values rejected, prompt-slot preservation, all valid levels accepted, `--help` mentions flag).
- 5 new tests for thinking-level resolution in `agent-bridge` (explicit forwarding, parent inheritance, explicit overrides parent, default unset, invalid value rejected without scoop creation).
- Unit tests for `resolveThinkingLevel` (off on non-reasoning, off when unset, xhigh clamp on non-xhigh family, xhigh passthrough on Opus 4.7, other levels passthrough).

## Verification

- `npx prettier --write` (15 files, 2 reformatted)
- `npm run typecheck` -> 0 errors
- `npx vitest run` on the touched suites -> 219/219 passing
- `npm run test` -> 3150 passing (one unrelated CDP launch flake when run with the full suite; passes individually on both this branch and `main`)
- `npm run build` and `npm run build -w @slicc/chrome-extension` -> green
EOF
)