### PR TITLE
feat: jumphost relay enables GitHub OAuth in extension

### DIFF
--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -36,16 +36,29 @@ try {
   var raw = params.get('state') || hashParams.get('state');
   if (!raw) throw new Error('Missing state parameter');
   var state = JSON.parse(atob(raw));
-  var port = Number(state.port);
+  var source = state.source || 'local';
   var path = state.path || '/auth/callback';
   var nonce = state.nonce || '';
-  if (!port || port < 1024 || port > 65535) throw new Error('Invalid port: ' + port);
   if (!path.startsWith('/')) throw new Error('Invalid path');
-  // Forward all original query params (except state, which we consumed) to
-  // localhost so authorization codes (?code=xxx) survive the relay.
+  // Forward all original query params (except state, which we consumed) so
+  // authorization codes (?code=xxx) survive the relay.
   params.delete('state');
   params.set('nonce', nonce);
-  var target = 'http://localhost:' + port + path + '?' + params.toString();
+  var query = '?' + params.toString();
+  var target;
+  if (source === 'local') {
+    var port = Number(state.port);
+    if (!port || port < 1024 || port > 65535) throw new Error('Invalid port: ' + port);
+    target = 'http://localhost:' + port + path + query;
+  } else if (source === 'extension') {
+    // Chrome extension IDs are 32 chars in [a-p]. Strict format check prevents
+    // open-redirect via subdomain injection (e.g. "evil.com.").
+    var extensionId = state.extensionId || '';
+    if (!/^[a-p]{32}$/.test(extensionId)) throw new Error('Invalid extensionId');
+    target = 'https://' + extensionId + '.chromiumapp.org' + path + query;
+  } else {
+    throw new Error('Unknown source: ' + source);
+  }
   location.replace(target + location.hash);
 } catch (e) {
   document.getElementById('msg').textContent = 'OAuth redirect failed: ' + e.message + '. Close this window and try again.';

--- a/packages/cloudflare-worker/tests/auth-relay.test.ts
+++ b/packages/cloudflare-worker/tests/auth-relay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { handleWorkerRequest } from '../src/index.js';
+import { handleWorkerRequest, type WorkerEnv } from '../src/index.js';
 
 const fakeAssets = {
   fetch: async (_req: Request) =>
@@ -8,20 +8,63 @@ const fakeAssets = {
     }),
 };
 
-const env = { TRAY_HUB: {}, ASSETS: fakeAssets } as any;
+const env = { TRAY_HUB: {}, ASSETS: fakeAssets } as unknown as WorkerEnv;
 
 function relayRequest(query: string): Request {
   return new Request(`https://www.sliccy.ai/auth/callback${query}`);
 }
 
-describe('OAuth callback relay', () => {
+async function fetchRelayBody(query: string): Promise<string> {
+  const res = await handleWorkerRequest(relayRequest(query), env);
+  return res.text();
+}
+
+/**
+ * Run the inline relay script against a fake `location` and `document` and
+ * return what would have been navigated to (or the error text shown to the
+ * user). This is the behavioural test seam — the relay's logic lives in the
+ * page's <script> tag, not in worker code, so we exercise the script directly.
+ */
+function runRelay(html: string, search: string, hash = ''): { replaced?: string; error?: string } {
+  const match = html.match(/<script>([\s\S]*?)<\/script>/);
+  if (!match) throw new Error('No <script> in relay HTML');
+  let replaced: string | undefined;
+  let errorText: string | undefined;
+  const fakeLocation = {
+    search,
+    hash,
+    replace: (url: string) => {
+      replaced = url;
+    },
+  };
+  const msgEl = { textContent: '' };
+  const fakeDocument = { getElementById: (_id: string) => msgEl };
+  const fn = new Function(
+    'location',
+    'document',
+    'btoa',
+    'atob',
+    'URLSearchParams',
+    'JSON',
+    'Number',
+    match[1]!
+  );
+  fn(fakeLocation, fakeDocument, btoa, atob, URLSearchParams, JSON, Number);
+  if (!replaced && msgEl.textContent.startsWith('OAuth redirect failed: ')) {
+    errorText = msgEl.textContent
+      .replace(/^OAuth redirect failed: /, '')
+      .replace(/\. Close.*$/, '');
+  }
+  return { replaced, error: errorText };
+}
+
+describe('OAuth callback relay — page response', () => {
   it('returns relay HTML for valid state', async () => {
     const state = btoa(JSON.stringify({ port: 5720, path: '/auth/callback', nonce: 'abc123' }));
     const res = await handleWorkerRequest(relayRequest(`?state=${state}`), env);
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('text/html');
     const body = await res.text();
-    expect(body).toContain('localhost');
     expect(body).toContain('Redirecting');
   });
 
@@ -31,37 +74,158 @@ describe('OAuth callback relay', () => {
     expect(res.headers.get('content-type')).toContain('text/html');
   });
 
-  it('relay HTML contains security validation script', async () => {
-    const state = btoa(JSON.stringify({ port: 5720, path: '/auth/callback', nonce: 'x' }));
-    const res = await handleWorkerRequest(relayRequest(`?state=${state}`), env);
-    const body = await res.text();
-    expect(body).toContain('port < 1024');
-    expect(body).toContain("path.startsWith('/')");
-  });
-
   it('relay page is static and identical regardless of state content', async () => {
     const state1 = btoa(JSON.stringify({ port: 5710, path: '/auth/callback', nonce: 'a' }));
-    const state2 = btoa(JSON.stringify({ port: 9999, path: '/auth/github', nonce: 'b' }));
+    const state2 = btoa(
+      JSON.stringify({
+        source: 'extension',
+        extensionId: 'akjjllgokmbgpbdbmafpiefnhidlmbgf',
+        path: '/github',
+        nonce: 'b',
+      })
+    );
     const res1 = await handleWorkerRequest(relayRequest(`?state=${state1}`), env);
     const res2 = await handleWorkerRequest(relayRequest(`?state=${state2}`), env);
     expect(await res1.text()).toBe(await res2.text());
   });
 
-  it('relay page only redirects to localhost (hardcoded)', async () => {
-    const state = btoa(JSON.stringify({ port: 5720, path: '/auth/callback', nonce: 'x' }));
-    const res = await handleWorkerRequest(relayRequest(`?state=${state}`), env);
-    const body = await res.text();
-    // The redirect target is always localhost — not configurable from state
-    expect(body).toContain("'http://localhost:'");
-    expect(body).not.toContain('https://');
-  });
-
   it('does not interfere with existing tray routes', async () => {
-    // /auth/callback is not a capability token route
     const trayReq = new Request('https://www.sliccy.ai/join/some-token');
     const res = await handleWorkerRequest(trayReq, env);
-    // Should NOT return relay HTML — should hit the tray token route
     const body = await res.text();
     expect(body).not.toContain('Redirecting to SLICC');
+  });
+});
+
+describe('OAuth callback relay — local source (CLI)', () => {
+  it('redirects to localhost when no source field is set (back-compat)', async () => {
+    const state = btoa(JSON.stringify({ port: 5720, path: '/auth/callback', nonce: 'n1' }));
+    const html = await fetchRelayBody(`?state=${state}&code=abc`);
+    const { replaced, error } = runRelay(html, `?state=${state}&code=abc`);
+    expect(error).toBeUndefined();
+    expect(replaced).toMatch(/^http:\/\/localhost:5720\/auth\/callback\?/);
+    expect(replaced).toContain('code=abc');
+    expect(replaced).toContain('nonce=n1');
+    expect(replaced).not.toContain('state=');
+  });
+
+  it('redirects to localhost when source is "local"', async () => {
+    const state = btoa(
+      JSON.stringify({ source: 'local', port: 5710, path: '/auth/callback', nonce: 'n2' })
+    );
+    const html = await fetchRelayBody(`?state=${state}&code=xyz`);
+    const { replaced } = runRelay(html, `?state=${state}&code=xyz`);
+    expect(replaced).toMatch(/^http:\/\/localhost:5710\/auth\/callback\?/);
+  });
+
+  it('rejects ports below 1024', async () => {
+    const state = btoa(JSON.stringify({ port: 80, path: '/auth/callback', nonce: 'n' }));
+    const html = await fetchRelayBody(`?state=${state}`);
+    const { replaced, error } = runRelay(html, `?state=${state}`);
+    expect(replaced).toBeUndefined();
+    expect(error).toContain('Invalid port');
+  });
+
+  it('rejects ports above 65535', async () => {
+    const state = btoa(JSON.stringify({ port: 99999, path: '/auth/callback', nonce: 'n' }));
+    const html = await fetchRelayBody(`?state=${state}`);
+    const { replaced, error } = runRelay(html, `?state=${state}`);
+    expect(replaced).toBeUndefined();
+    expect(error).toContain('Invalid port');
+  });
+
+  it('rejects paths that do not start with /', async () => {
+    const state = btoa(JSON.stringify({ port: 5710, path: 'evil.com/path', nonce: 'n' }));
+    const html = await fetchRelayBody(`?state=${state}`);
+    const { replaced, error } = runRelay(html, `?state=${state}`);
+    expect(replaced).toBeUndefined();
+    expect(error).toContain('Invalid path');
+  });
+});
+
+describe('OAuth callback relay — extension source', () => {
+  const validId = 'akjjllgokmbgpbdbmafpiefnhidlmbgf';
+
+  it('redirects to chromiumapp.org for a valid extensionId', async () => {
+    const state = btoa(
+      JSON.stringify({ source: 'extension', extensionId: validId, path: '/github', nonce: 'n1' })
+    );
+    const html = await fetchRelayBody(`?state=${state}&code=abc`);
+    const { replaced, error } = runRelay(html, `?state=${state}&code=abc`);
+    expect(error).toBeUndefined();
+    expect(replaced).toMatch(new RegExp(`^https://${validId}\\.chromiumapp\\.org/github\\?`));
+    expect(replaced).toContain('code=abc');
+    expect(replaced).toContain('nonce=n1');
+    expect(replaced).not.toContain('state=');
+  });
+
+  it('rejects extensionId with wrong character set (uppercase)', async () => {
+    const state = btoa(
+      JSON.stringify({
+        source: 'extension',
+        extensionId: validId.toUpperCase(),
+        path: '/github',
+        nonce: 'n',
+      })
+    );
+    const html = await fetchRelayBody(`?state=${state}`);
+    const { replaced, error } = runRelay(html, `?state=${state}`);
+    expect(replaced).toBeUndefined();
+    expect(error).toContain('Invalid extensionId');
+  });
+
+  it('rejects extensionId with wrong length', async () => {
+    const state = btoa(
+      JSON.stringify({ source: 'extension', extensionId: 'abc', path: '/github', nonce: 'n' })
+    );
+    const html = await fetchRelayBody(`?state=${state}`);
+    const { replaced, error } = runRelay(html, `?state=${state}`);
+    expect(replaced).toBeUndefined();
+    expect(error).toContain('Invalid extensionId');
+  });
+
+  it('rejects extensionId attempting subdomain injection', async () => {
+    // 32 chars total but containing a dot — must fail the strict format check
+    const evilId = 'a'.repeat(15) + '.evil' + 'a'.repeat(12);
+    expect(evilId.length).toBe(32);
+    const state = btoa(
+      JSON.stringify({
+        source: 'extension',
+        extensionId: evilId,
+        path: '/github',
+        nonce: 'n',
+      })
+    );
+    const html = await fetchRelayBody(`?state=${state}`);
+    const { replaced, error } = runRelay(html, `?state=${state}`);
+    expect(replaced).toBeUndefined();
+    expect(error).toContain('Invalid extensionId');
+  });
+
+  it('rejects path that does not start with /', async () => {
+    const state = btoa(
+      JSON.stringify({
+        source: 'extension',
+        extensionId: validId,
+        path: 'github',
+        nonce: 'n',
+      })
+    );
+    const html = await fetchRelayBody(`?state=${state}`);
+    const { replaced, error } = runRelay(html, `?state=${state}`);
+    expect(replaced).toBeUndefined();
+    expect(error).toContain('Invalid path');
+  });
+});
+
+describe('OAuth callback relay — unknown source', () => {
+  it('rejects an unknown source value', async () => {
+    const state = btoa(
+      JSON.stringify({ source: 'phishing', extensionId: 'x', path: '/x', nonce: 'n' })
+    );
+    const html = await fetchRelayBody(`?state=${state}`);
+    const { replaced, error } = runRelay(html, `?state=${state}`);
+    expect(replaced).toBeUndefined();
+    expect(error).toContain('Unknown source');
   });
 });

--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -36,7 +36,11 @@ import type {
   OpenAICompletionsOptions,
 } from '@mariozechner/pi-ai';
 import { saveOAuthAccount, getAccounts } from '../src/ui/provider-settings.js';
-import { exchangeOAuthCode, revokeOAuthToken } from '../src/providers/oauth-code-exchange.js';
+import {
+  exchangeOAuthCode,
+  revokeOAuthToken,
+  getWorkerBaseUrl,
+} from '../src/providers/oauth-code-exchange.js';
 
 // ── Config ─────────────────────────────────────────────────────────
 
@@ -63,6 +67,25 @@ let runtimeWorkerBaseUrl: string | null = null;
 
 async function resolveClientId(): Promise<string> {
   if (runtimeClientId) return runtimeClientId;
+
+  // Extension mode: there is no local server, so go straight to the worker.
+  // (A relative /api/runtime-config would resolve to chrome-extension://<id>/...
+  // and 404.)
+  if (isExtension) {
+    try {
+      const res = await fetch(`${getWorkerBaseUrl()}/api/runtime-config`);
+      if (res.ok) {
+        const data = (await res.json()) as { oauth?: { github?: string } };
+        if (data.oauth?.github) {
+          runtimeClientId = data.oauth.github;
+          return runtimeClientId;
+        }
+      }
+    } catch {
+      // Fall through to build-time config
+    }
+    return githubConfig.clientId;
+  }
 
   // Try fetching from the local runtime-config first (works when served from
   // the worker directly — the worker injects oauth.github into the response).
@@ -350,24 +373,27 @@ export const config: ProviderConfig = {
 
     const scopes = options?.scopes ?? githubConfig.scopes;
 
-    // The redirect URI must match the GitHub App's configured callback URL.
-    // In dev mode, runtimeWorkerBaseUrl points to staging; in production the
-    // worker serves the app directly so we use the page origin.
+    // Both flows redirect through the worker's /auth/callback relay. The relay
+    // reads the `state` param (source=local|extension) and forwards to the
+    // correct final destination. Using one registered URL per OAuth App lets
+    // GitHub OAuth Apps (single-callback) work for both CLI and extension.
     const redirectUri = isExtension
-      ? `https://${(chrome as any).runtime.id}.chromiumapp.org/`
+      ? `${getWorkerBaseUrl()}/auth/callback`
       : `${runtimeWorkerBaseUrl ?? window.location.origin}/auth/callback`;
 
-    // Build OAuth state with port and CSRF nonce for the sliccy.ai relay (CLI only)
-    const oauthState = !isExtension
-      ? btoa(
-          JSON.stringify({
-            port: parseInt(new URL(window.location.href).port || '5710', 10),
-            path: '/auth/callback',
-            nonce: crypto.randomUUID(),
-          })
-        )
-      : undefined;
-    const expectedNonce = oauthState ? JSON.parse(atob(oauthState)).nonce : null;
+    const nonce = crypto.randomUUID();
+    const extensionId = isExtension
+      ? (chrome as unknown as { runtime: { id: string } }).runtime.id
+      : '';
+    const stateData = isExtension
+      ? { source: 'extension', extensionId, path: '/github', nonce }
+      : {
+          port: parseInt(new URL(window.location.href).port || '5710', 10),
+          path: '/auth/callback',
+          nonce,
+        };
+    const oauthState = btoa(JSON.stringify(stateData));
+    const expectedNonce = nonce;
 
     const params = new URLSearchParams({
       client_id: clientId,

--- a/packages/webapp/src/providers/oauth-code-exchange.ts
+++ b/packages/webapp/src/providers/oauth-code-exchange.ts
@@ -15,7 +15,7 @@ import {
 } from '../scoops/tray-runtime-config.js';
 
 /** Resolve the worker base URL (localStorage override → production default). */
-function getWorkerBaseUrl(): string {
+export function getWorkerBaseUrl(): string {
   try {
     const stored = localStorage.getItem(TRAY_WORKER_STORAGE_KEY);
     if (stored) return stored.replace(/\/$/, '');


### PR DESCRIPTION
## Summary

- **Worker `/auth/callback` relay** now branches on `state.source`. `local` (default, back-compat) keeps the existing localhost behavior; `extension` redirects to `<extension-id>.chromiumapp.org<path>` with strict `^[a-p]{32}$` ID validation to prevent open-redirect via subdomain injection.
- **GitHub provider** sends `redirect_uri=<worker>/auth/callback` in both modes and encodes `{source: 'extension', extensionId, path: '/github', nonce}` for extension. The worker bounces it to chromiumapp.org, where `chrome.identity.launchWebAuthFlow` intercepts.
- **Net effect**: GitHub OAuth Apps (single-callback-URL) work for the extension without a second OAuth App or migration to a GitHub App. The single registered URL stays `https://www.sliccy.ai/auth/callback`.
- **Also fixes** `resolveClientId()` in extension mode: previously the relative `fetch('/api/runtime-config')` 404'd under `chrome-extension://`, leaving `clientId` empty and the OAuth flow throwing. Now it goes straight to the worker.

## Why not simpler approaches

- *Pin the chromiumapp URL on the OAuth App* — GitHub OAuth Apps allow exactly one callback URL with strict host matching (per their docs). The chromiumapp.org and sliccy.ai hosts can't share one app. This is the constraint Adobe sidesteps by having Adobe IMS register the chromiumapp URL directly on the IMS app.
- *Two OAuth Apps* — workable but means a second client ID/secret and a worker-side branch on which app to use per request.
- *Convert to a GitHub App* — supports up to 10 callback URLs but changes the auth model (installations, fine-grained perms) and the user-token shape; would risk breaking GitHub Models API access via pi-ai.

The jumphost is the smallest change that keeps the existing OAuth App and adds extension support behind it.

## Test plan

- [x] Worker `auth-relay.test.ts`: 15 cases covering both branches, unknown `source`, malformed extensionId, subdomain injection attempts, port/path validation. Uses a script-execution test seam (`runRelay()`) so we exercise the relay's actual JS, not just string-match the HTML.
- [x] Full repo test suite: 3145 passing
- [x] Typecheck clean (`npm run typecheck`)
- [x] Extension build clean (`npm run build -w @slicc/chrome-extension`)
- [ ] **Staging deploy via this PR** (`worker-staging.yml` triggers on PR) — once the staging URL bot-comment lands, manually verify the GitHub login flow in the extension by setting `localStorage['slicc.trayWorkerBaseUrl']` to the staging worker URL.

## Files

| File | Change |
|---|---|
| `packages/cloudflare-worker/src/index.ts` | `OAUTH_RELAY_HTML`: source-aware branching with strict extensionId validation |
| `packages/cloudflare-worker/tests/auth-relay.test.ts` | Replaced "localhost-only invariant" test; added script-execution seam + 9 new behavior tests |
| `packages/webapp/providers/github.ts` | Extension `resolveClientId` branch; redirect URI through worker for both modes; state encodes source/extensionId/path; nonce verification now in both modes |
| `packages/webapp/src/providers/oauth-code-exchange.ts` | Export `getWorkerBaseUrl` (was private) |

Adobe is intentionally untouched — its IMS already accepts the chromiumapp URL directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)