### PR TITLE
fix(git): always re-read GitHub token from VFS

### DIFF
--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -180,7 +180,7 @@ async function fetchUserProfile(accessToken: string): Promise<{ name?: string; a
 async function writeGitToken(token: string): Promise<void> {
   try {
     const { VirtualFS } = await import('../src/fs/index.js');
-    const fs = VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+    const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
     await fs.writeFile('/workspace/.git/github-token', token);
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('github-token-changed'));
@@ -197,7 +197,7 @@ async function writeGitToken(token: string): Promise<void> {
 async function clearGitToken(): Promise<void> {
   try {
     const { VirtualFS } = await import('../src/fs/index.js');
-    const fs = VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+    const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
     await fs.rm('/workspace/.git/github-token');
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('github-token-changed'));

--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -41,6 +41,7 @@ import {
   revokeOAuthToken,
   getWorkerBaseUrl,
 } from '../src/providers/oauth-code-exchange.js';
+import { GLOBAL_FS_DB_NAME } from '../src/fs/global-db.js';
 
 // ── Config ─────────────────────────────────────────────────────────
 
@@ -179,7 +180,7 @@ async function fetchUserProfile(accessToken: string): Promise<{ name?: string; a
 async function writeGitToken(token: string): Promise<void> {
   try {
     const { VirtualFS } = await import('../src/fs/index.js');
-    const fs = VirtualFS.create({ dbName: 'browser-coding-agent' });
+    const fs = VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
     await fs.writeFile('/workspace/.git/github-token', token);
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('github-token-changed'));
@@ -196,7 +197,7 @@ async function writeGitToken(token: string): Promise<void> {
 async function clearGitToken(): Promise<void> {
   try {
     const { VirtualFS } = await import('../src/fs/index.js');
-    const fs = VirtualFS.create({ dbName: 'browser-coding-agent' });
+    const fs = VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
     await fs.rm('/workspace/.git/github-token');
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('github-token-changed'));

--- a/packages/webapp/src/fs/global-db.ts
+++ b/packages/webapp/src/fs/global-db.ts
@@ -1,0 +1,8 @@
+/**
+ * IndexedDB name of the global VirtualFS used to persist cross-cwd state
+ * (GitHub auth token, global gitconfig, etc.). Must be referenced by every
+ * writer and reader of these files — using the wrong DB silently writes to
+ * the wrong place. The git provider, the upskill command, and `GitCommands`
+ * all import this so the wiring stays in sync.
+ */
+export const GLOBAL_FS_DB_NAME = 'slicc-fs-global';

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -10,6 +10,7 @@ import '../shims/buffer-polyfill.js';
 
 import * as git from 'isomorphic-git';
 import { VirtualFS } from '../fs/index.js';
+import { GLOBAL_FS_DB_NAME } from '../fs/global-db.js';
 import { gitHttp } from './git-http.js';
 import { unifiedDiff, diffStat } from './diff.js';
 import { createIsomorphicGitFs, type IsoGitFsPromises } from './vfs-fs-adapter.js';
@@ -55,7 +56,7 @@ export class GitCommands {
     this.corsProxy = options.corsProxy;
     this.authorName = options.authorName ?? 'User';
     this.authorEmail = options.authorEmail ?? 'user@example.com';
-    this.globalDbName = options.globalDbName ?? 'slicc-fs-global';
+    this.globalDbName = options.globalDbName ?? GLOBAL_FS_DB_NAME;
   }
 
   /**

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -46,7 +46,6 @@ export class GitCommands {
   private globalDbName: string;
   /** GitHub token for authentication (avoids rate limits on public repos, required for private). */
   private githubToken?: string;
-  private githubTokenLoaded = false;
 
   constructor(private options: GitCommandsOptions) {
     // Route through a VirtualFS-backed adapter so isomorphic-git sees mount
@@ -81,10 +80,13 @@ export class GitCommands {
     return created;
   }
 
-  /** Load GitHub token from global VFS if not loaded in-memory yet. */
-  private async ensureGithubTokenLoaded(): Promise<void> {
-    if (this.githubTokenLoaded) return;
-    this.githubTokenLoaded = true;
+  /**
+   * Load the GitHub token from the global VFS. Re-reads on every call: the
+   * file is the source of truth and may be updated by other writers (notably
+   * the GitHub OAuth provider after login) without going through this
+   * instance, so we cannot cache absence or presence.
+   */
+  private async loadGithubToken(): Promise<void> {
     try {
       const globalFs = await this.getGlobalFs();
       const token = (await globalFs.readTextFile('/workspace/.git/github-token')).trim();
@@ -105,12 +107,10 @@ export class GitCommands {
         // ignore if not present
       }
       this.githubToken = undefined;
-      this.githubTokenLoaded = true;
       return;
     }
     await globalFs.writeFile('/workspace/.git/github-token', trimmed);
     this.githubToken = trimmed;
-    this.githubTokenLoaded = true;
   }
 
   /**
@@ -126,7 +126,7 @@ export class GitCommands {
     const [command, ...rest] = args;
 
     try {
-      await this.ensureGithubTokenLoaded();
+      await this.loadGithubToken();
       switch (command) {
         case 'init':
           return this.init(cwd, rest);

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'just-bash';
 import type { Command, CommandContext, SecureFetch } from 'just-bash';
 import type { VirtualFS } from '../../fs/index.js';
 import { VirtualFS as SharedVirtualFS } from '../../fs/index.js';
+import { GLOBAL_FS_DB_NAME } from '../../fs/global-db.js';
 import type { DiscoveredSkill } from '../../skills/types.js';
 import { SLICC_DIR, STATE_FILE } from '../../skills/constants.js';
 import { unzipSync } from 'fflate';
@@ -12,7 +13,7 @@ import { decodeFetchBody, getFetchBodyBytes, parseFetchJson } from '../fetch-bod
 const CLAWHUB_API = 'https://wry-manatee-359.convex.site/api/v1';
 const TESSL_API = 'https://api.tessl.io';
 const SKILLS_DIR = '/workspace/skills';
-const GITHUB_GLOBAL_DB = 'slicc-fs-global';
+const GITHUB_GLOBAL_DB = GLOBAL_FS_DB_NAME;
 const GITHUB_TOKEN_PATH = '/workspace/.git/github-token';
 const GITHUB_API_ACCEPT = 'application/vnd.github.v3+json';
 const SKILL_CATALOG_URL = 'https://www.sliccy.com/skills/catalog.json';

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -170,6 +170,22 @@ describe('GitCommands', () => {
     expect(getResult.stdout.trim()).toBe('ghp_shared_token');
   });
 
+  it('picks up github token written by another writer after a git command has run', async () => {
+    // Reproduces the bug where the OAuth login provider writes the token to
+    // the global VFS but a GitCommands instance whose token-load already ran
+    // (and saw no file) keeps a stale "no token" cache and ignores it.
+    await git.execute(['init'], '/project');
+
+    // OAuth provider would write here — bypassing setGithubToken on this
+    // instance, exactly as github.ts:writeGitToken() does.
+    const globalFs = await VirtualFS.create({ dbName: globalDbName });
+    await globalFs.writeFile('/workspace/.git/github-token', 'ghp_post_login_token');
+
+    const getResult = await git.execute(['config', 'github.token'], '/project');
+    expect(getResult.exitCode).toBe(0);
+    expect(getResult.stdout.trim()).toBe('ghp_post_login_token');
+  });
+
   it('supports --no-single-branch for clone', async () => {
     const cloneSpy = vi.spyOn(isoGit, 'clone').mockResolvedValue();
     const listFilesSpy = vi.spyOn(isoGit, 'listFiles').mockResolvedValue([]);

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -6,6 +6,7 @@ import 'fake-indexeddb/auto';
 vi.mock('isomorphic-git', async (importOriginal) => ({ ...(await importOriginal()) }));
 import * as isoGit from 'isomorphic-git';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { GLOBAL_FS_DB_NAME } from '../../src/fs/global-db.js';
 import { GitCommands } from '../../src/git/git-commands.js';
 
 describe('GitCommands', () => {
@@ -184,6 +185,31 @@ describe('GitCommands', () => {
     const getResult = await git.execute(['config', 'github.token'], '/project');
     expect(getResult.exitCode).toBe(0);
     expect(getResult.stdout.trim()).toBe('ghp_post_login_token');
+  });
+
+  it('reads token written via the shared GLOBAL_FS_DB_NAME (writer/reader contract)', async () => {
+    // Asserts the wiring: the OAuth provider writes to GLOBAL_FS_DB_NAME, and
+    // a GitCommands constructed with no explicit globalDbName must read from
+    // the same database. Catches drift between the writer's hardcoded DB and
+    // the reader's default.
+    const isolatedFs = await VirtualFS.create({
+      dbName: `git-test-isolated-${dbCounter++}`,
+      wipe: true,
+    });
+    const defaultGit = new GitCommands({
+      fs: isolatedFs,
+      authorName: 'Test',
+      authorEmail: 'test@example.com',
+      // intentionally no globalDbName — exercises the default
+    });
+    await defaultGit.execute(['init'], '/project');
+
+    const sharedGlobalFs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+    await sharedGlobalFs.writeFile('/workspace/.git/github-token', 'ghp_via_shared_const');
+
+    const getResult = await defaultGit.execute(['config', 'github.token'], '/project');
+    expect(getResult.exitCode).toBe(0);
+    expect(getResult.stdout.trim()).toBe('ghp_via_shared_const');
   });
 
   it('supports --no-single-branch for clone', async () => {


### PR DESCRIPTION
## Summary

`GitCommands.ensureGithubTokenLoaded` cached the result of its first VFS read for the lifetime of the instance. Other writers — notably the GitHub OAuth provider's `writeGitToken` in `packages/webapp/providers/github.ts:179` — update `/workspace/.git/github-token` directly, bypassing `setGithubToken` on the in-memory instance. So once the cache was set (especially when the file didn't exist yet at first read), the token written by the OAuth flow was never picked up: subsequent `git push` etc. authenticated as unauthenticated and silently failed against private repos / hit rate limits on public ones.

The fix drops the `githubTokenLoaded` flag and always re-reads in `execute()`. The read is one IndexedDB hit per git invocation — negligible.

## Why it bit harder in the extension

Two independent `GitCommands` instances exist in extension mode (one in the side panel's `WasmShell`, one in the offscreen document's `WasmShell`). The offscreen shell can run git autonomously as part of an agent turn before the user logs in, locking in an empty cache that survives the login. Standalone has the same bug, just rarely hits it since users typically log in before touching git.

## Test plan

- [x] New regression test in `git-commands.test.ts` reproducing the OAuth-after-shell-init scenario: run a git command, externally write `/workspace/.git/github-token` (mirroring `github.ts:writeGitToken`), then verify `git config github.token` returns the new value. Fails on `main`, passes after the fix.
- [x] Existing token tests still pass (`persists github token in global virtual filesystem`, `shares github token across git command instances`).
- [x] Full suite: 3181 passing
- [x] Typecheck clean
- [x] Extension build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)