### PR TITLE
fix(mount): route welcome-sprinkle picker through popup to stop side-panel crash

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -89,7 +89,7 @@ Manifest sandbox pages (`sandbox.html`, `sprinkle-sandbox.html`, `tool-ui-sandbo
 
 **macOS TCC and Side Panel Crashes**
 
-Chrome's side panel cannot host macOS TCC (Transparency, Consent, and Control) permission dialogs. If code in the side panel triggers a TCC dialog (e.g., iterating a `FileSystemDirectoryHandle` for `~/Downloads`), Chrome's renderer crashes instead of showing the dialog. Solution: route operations that might trigger TCC through a popup window (`chrome.windows.create({ type: 'popup' })`) — see `mount-popup.html` for the pattern.
+Chrome's side panel cannot host macOS TCC (Transparency, Consent, and Control) permission dialogs, and it also crashes (rather than throwing a normal error) when `showDirectoryPicker()` is called against a system folder Chrome refuses to share (Documents, Downloads, Desktop, the home directory). Solution: never call `showDirectoryPicker()` from the side panel — route directory selection through a popup window where TCC and the system-folder rejection render correctly. The pattern is implemented by `packages/chrome-extension/mount-popup.html` and the shared helpers in `packages/webapp/src/fs/mount-picker-popup.ts` (`openMountPickerPopup` + `loadAndClearPendingHandle` + `reactivateHandle`). All three extension-side mount entry points use it: the shell `mount` command, agent-driven approval dips, and the welcome sprinkle's `request-mount` lick.
 
 ## WASM & Bundled Assets in Extension Mode
 

--- a/packages/webapp/src/fs/mount-commands.ts
+++ b/packages/webapp/src/fs/mount-commands.ts
@@ -11,6 +11,11 @@
 
 import type { VirtualFS } from './virtual-fs.js';
 import { getToolExecutionContext, showToolUI, toolUIRegistry } from '../tools/tool-ui.js';
+import {
+  openMountPickerPopup,
+  loadAndClearPendingHandle,
+  reactivateHandle,
+} from './mount-picker-popup.js';
 
 /** Escape HTML special characters to prevent XSS */
 function escapeHtml(text: string): string {
@@ -378,81 +383,4 @@ export class MountCommands {
       exitCode: 0,
     };
   }
-}
-
-async function reactivateHandle(handle: FileSystemDirectoryHandle): Promise<void> {
-  type HandleWithPermission = FileSystemDirectoryHandle & {
-    requestPermission?: (opts: { mode: string }) => Promise<string>;
-  };
-  const h = handle as HandleWithPermission;
-  if (h.requestPermission) {
-    const state = await h.requestPermission({ mode: 'readwrite' });
-    if (state !== 'granted') {
-      throw new Error(`Permission denied for "${handle.name}" (${state})`);
-    }
-  }
-}
-
-function openMountPickerPopup(): Promise<Record<string, unknown>> {
-  const popupRequestId = `mount-${Date.now().toString(36)}`;
-  return new Promise((resolve) => {
-    const url = chrome.runtime.getURL(
-      `mount-popup.html?requestId=${encodeURIComponent(popupRequestId)}`
-    );
-
-    const cleanup = () => {
-      clearTimeout(timer);
-      chrome.runtime.onMessage.removeListener(listener);
-    };
-
-    const timer = setTimeout(() => {
-      cleanup();
-      resolve({ cancelled: true });
-    }, 60_000);
-
-    const listener = (msg: unknown) => {
-      const m = msg as Record<string, unknown>;
-      if (!m || m.source !== 'mount-popup' || m.requestId !== popupRequestId) return;
-      cleanup();
-      resolve(m);
-    };
-    chrome.runtime.onMessage.addListener(listener);
-
-    chrome.windows
-      .create({ url, type: 'popup', width: 300, height: 80, focused: true })
-      .catch(() => {
-        cleanup();
-        resolve({ error: 'Failed to open directory picker window' });
-      });
-  });
-}
-
-async function loadAndClearPendingHandle(
-  idbKey: string
-): Promise<FileSystemDirectoryHandle | null> {
-  const db = await new Promise<IDBDatabase>((resolve, reject) => {
-    const req = indexedDB.open('slicc-pending-mount', 1);
-    req.onupgradeneeded = () => {
-      if (!req.result.objectStoreNames.contains('handles')) {
-        req.result.createObjectStore('handles');
-      }
-    };
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-  });
-  const tx = db.transaction('handles', 'readwrite');
-  const store = tx.objectStore('handles');
-  const getReq = store.get(idbKey);
-  const deleteReq = store.delete(idbKey);
-  deleteReq.onerror = () => {
-    console.warn('[mount] Failed to delete pending handle from IDB', idbKey, deleteReq.error);
-  };
-  const handle = await new Promise<FileSystemDirectoryHandle | null>((resolve, reject) => {
-    tx.oncomplete = () => resolve(getReq.result ?? null);
-    getReq.onerror = () => reject(getReq.error ?? new Error('IDB get failed'));
-    tx.onerror = () => reject(tx.error ?? new Error('IDB transaction failed'));
-    tx.onabort = () => reject(tx.error ?? new Error('IDB transaction aborted'));
-  });
-  db.close();
-  return handle;
 }

--- a/packages/webapp/src/fs/mount-picker-popup.ts
+++ b/packages/webapp/src/fs/mount-picker-popup.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared helpers for opening the directory picker via a separate Chrome popup
+ * window. Used by every extension-side mount entry point: the shell `mount`
+ * command, agent-driven approval dips (tool-ui-renderer), and the welcome
+ * sprinkle's `request-mount` lick.
+ *
+ * Why a popup instead of `window.showDirectoryPicker()` directly? Picking a
+ * macOS TCC-protected folder (Documents, Downloads, Desktop, home) from the
+ * side panel context crashes the panel renderer instead of throwing a normal
+ * error. The popup is a regular browser window where TCC dialogs and Chrome's
+ * "system folder" rejection render correctly.
+ *
+ * The popup posts the picked handle to a per-request key in the
+ * `slicc-pending-mount` IndexedDB store; callers retrieve it with
+ * {@link loadAndClearPendingHandle}, then call {@link reactivateHandle} to
+ * re-prompt for permission before using the handle.
+ */
+
+const PENDING_MOUNT_DB = 'slicc-pending-mount';
+const POPUP_TIMEOUT_MS = 60_000;
+
+/**
+ * Opens `mount-popup.html` and resolves with the popup's response message.
+ * The response shape is one of:
+ *   - `{ handleInIdb: true, idbKey, dirName }` — handle was stored in IDB
+ *   - `{ cancelled: true }` — user closed the popup or aborted the picker
+ *   - `{ error: string }` — popup failed (e.g. window.create rejected)
+ *
+ * @param requestId Optional request id used to correlate the popup result
+ *   with a caller-managed registry entry. Generated if omitted.
+ */
+export function openMountPickerPopup(requestId?: string): Promise<Record<string, unknown>> {
+  const popupRequestId = requestId ?? `mount-${Date.now().toString(36)}`;
+  return new Promise((resolve) => {
+    const url = chrome.runtime.getURL(
+      `mount-popup.html?requestId=${encodeURIComponent(popupRequestId)}`
+    );
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      chrome.runtime.onMessage.removeListener(listener);
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve({ cancelled: true });
+    }, POPUP_TIMEOUT_MS);
+
+    const listener = (msg: unknown) => {
+      const m = msg as Record<string, unknown>;
+      if (!m || m.source !== 'mount-popup' || m.requestId !== popupRequestId) return;
+      cleanup();
+      resolve(m);
+    };
+    chrome.runtime.onMessage.addListener(listener);
+
+    chrome.windows
+      .create({ url, type: 'popup', width: 300, height: 80, focused: true })
+      .catch(() => {
+        cleanup();
+        resolve({ error: 'Failed to open directory picker window' });
+      });
+  });
+}
+
+/**
+ * Reads and removes the pending FileSystemDirectoryHandle the popup wrote
+ * under `idbKey`. Returns null if the entry is missing.
+ */
+export async function loadAndClearPendingHandle(
+  idbKey: string
+): Promise<FileSystemDirectoryHandle | null> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open(PENDING_MOUNT_DB, 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains('handles')) {
+        req.result.createObjectStore('handles');
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  const tx = db.transaction('handles', 'readwrite');
+  const store = tx.objectStore('handles');
+  const getReq = store.get(idbKey);
+  const deleteReq = store.delete(idbKey);
+  deleteReq.onerror = () => {
+    console.warn('[mount] Failed to delete pending handle from IDB', idbKey, deleteReq.error);
+  };
+  const handle = await new Promise<FileSystemDirectoryHandle | null>((resolve, reject) => {
+    tx.oncomplete = () => resolve(getReq.result ?? null);
+    getReq.onerror = () => reject(getReq.error ?? new Error('IDB get failed'));
+    tx.onerror = () => reject(tx.error ?? new Error('IDB transaction failed'));
+    tx.onabort = () => reject(tx.error ?? new Error('IDB transaction aborted'));
+  });
+  db.close();
+  return handle;
+}
+
+/**
+ * Re-prompts for readwrite permission on a handle loaded from IndexedDB.
+ * Without this, persisted handles raise NotAllowedError on first use.
+ */
+export async function reactivateHandle(handle: FileSystemDirectoryHandle): Promise<void> {
+  type HandleWithPermission = FileSystemDirectoryHandle & {
+    requestPermission?: (opts: { mode: string }) => Promise<string>;
+  };
+  const h = handle as HandleWithPermission;
+  if (h.requestPermission) {
+    const state = await h.requestPermission({ mode: 'readwrite' });
+    if (state !== 'granted') {
+      throw new Error(`Permission denied for "${handle.name}" (${state})`);
+    }
+  }
+}

--- a/packages/webapp/src/fs/mount-picker-popup.ts
+++ b/packages/webapp/src/fs/mount-picker-popup.ts
@@ -16,15 +16,23 @@
  * re-prompt for permission before using the handle.
  */
 
+import { createLogger } from '../core/logger.js';
+
+const log = createLogger('mount-picker-popup');
+
 const PENDING_MOUNT_DB = 'slicc-pending-mount';
 const POPUP_TIMEOUT_MS = 60_000;
 
 /**
  * Opens `mount-popup.html` and resolves with the popup's response message.
  * The response shape is one of:
- *   - `{ handleInIdb: true, idbKey, dirName }` — handle was stored in IDB
+ *   - `{ handleInIdb: true, idbKey, dirName }` — handle was stored in IDB;
+ *     callers must use {@link loadAndClearPendingHandle} to retrieve it,
+ *     then {@link reactivateHandle} before using it. The handle itself is
+ *     never sent through the runtime message channel — only the IDB key.
  *   - `{ cancelled: true }` — user closed the popup or aborted the picker
- *   - `{ error: string }` — popup failed (e.g. window.create rejected)
+ *   - `{ error: string }` — popup failed (e.g. window.create rejected); the
+ *     full error is logged separately, callers get a generic message
  *
  * @param requestId Optional request id used to correlate the popup result
  *   with a caller-managed registry entry. Generated if omitted.
@@ -56,8 +64,13 @@ export function openMountPickerPopup(requestId?: string): Promise<Record<string,
 
     chrome.windows
       .create({ url, type: 'popup', width: 300, height: 80, focused: true })
-      .catch(() => {
+      .catch((err: unknown) => {
         cleanup();
+        log.error('chrome.windows.create failed for mount picker popup', {
+          requestId: popupRequestId,
+          error: err instanceof Error ? err.message : String(err),
+          name: err instanceof Error ? err.name : undefined,
+        });
         resolve({ error: 'Failed to open directory picker window' });
       });
   });
@@ -84,8 +97,11 @@ export async function loadAndClearPendingHandle(
   const store = tx.objectStore('handles');
   const getReq = store.get(idbKey);
   const deleteReq = store.delete(idbKey);
+  // Non-fatal: the handle was retrieved successfully; failing to clean up the
+  // IDB entry leaves an orphan keyed by an ephemeral request id but doesn't
+  // affect this mount. Log via project logger so it surfaces in collected logs.
   deleteReq.onerror = () => {
-    console.warn('[mount] Failed to delete pending handle from IDB', idbKey, deleteReq.error);
+    log.warn('Failed to delete pending handle from IDB', { idbKey, error: deleteReq.error });
   };
   const handle = await new Promise<FileSystemDirectoryHandle | null>((resolve, reject) => {
     tx.oncomplete = () => resolve(getReq.result ?? null);

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -90,6 +90,11 @@ import { SprinkleManager } from './sprinkle-manager.js';
 import { initTelemetry } from './telemetry.js';
 import { getAllMountEntries } from '../fs/mount-table-store.js';
 import { recoverMounts, formatMountRecoveryPrompt } from '../fs/mount-recovery.js';
+import {
+  openMountPickerPopup,
+  loadAndClearPendingHandle,
+  reactivateHandle,
+} from '../fs/mount-picker-popup.js';
 import { detectUpgrade, recordVersionSeen } from '../scoops/upgrade-detection.js';
 
 const log = createLogger('main');
@@ -640,28 +645,45 @@ async function mainExtension(app: HTMLElement): Promise<void> {
             );
           }
         }
-        // Handle request-mount from welcome sprinkle (sandbox can't call showDirectoryPicker)
+        // Handle request-mount from welcome sprinkle (sandbox can't call showDirectoryPicker).
+        // Route through mount-popup.html — calling showDirectoryPicker directly from the
+        // side panel context crashes the renderer when the user picks a TCC-protected
+        // folder (Documents, Downloads, Desktop, home). The popup is a regular browser
+        // window where TCC dialogs and Chrome's system-folder rejection render correctly.
         if (
           event.sprinkleName === 'welcome' &&
           (event.body as Record<string, unknown> | null)?.action === 'request-mount'
         ) {
           try {
-            const w = window as Window & {
-              showDirectoryPicker?: (
-                opts: Record<string, unknown>
-              ) => Promise<FileSystemDirectoryHandle>;
-            };
-            if (!w.showDirectoryPicker) throw new Error('showDirectoryPicker not supported');
-            const handle = await w.showDirectoryPicker({ mode: 'readwrite' });
+            const result = await openMountPickerPopup();
+            if (result.cancelled) {
+              sprinkleManager.sendToSprinkle('welcome', { action: 'mount-cancelled' });
+              return;
+            }
+            if (result.error) {
+              log.warn('Mount picker popup failed', result.error);
+              sprinkleManager.sendToSprinkle('welcome', { action: 'mount-cancelled' });
+              return;
+            }
+            if (!result.handleInIdb || typeof result.idbKey !== 'string') {
+              log.warn('Mount picker popup returned unexpected result', result);
+              sprinkleManager.sendToSprinkle('welcome', { action: 'mount-cancelled' });
+              return;
+            }
+            const handle = await loadAndClearPendingHandle(result.idbKey);
+            if (!handle) {
+              log.warn('Mount picker popup did not store a handle');
+              sprinkleManager.sendToSprinkle('welcome', { action: 'mount-cancelled' });
+              return;
+            }
+            await reactivateHandle(handle);
             await storePendingMount(handle);
             sprinkleManager.sendToSprinkle('welcome', {
               action: 'mount-complete',
               dirName: handle.name,
             });
           } catch (err: unknown) {
-            if ((err as { name?: string }).name !== 'AbortError') {
-              log.warn('Mount picker failed', err);
-            }
+            log.warn('Mount picker failed', err);
             sprinkleManager.sendToSprinkle('welcome', { action: 'mount-cancelled' });
           }
           return; // Don't forward to orchestrator

--- a/packages/webapp/src/ui/tool-ui-renderer.ts
+++ b/packages/webapp/src/ui/tool-ui-renderer.ts
@@ -15,6 +15,7 @@ import { mountDip, type DipInstance } from './dip.js';
 import { collectThemeCSS } from './sprinkle-renderer.js';
 import { isThemeLight } from './theme.js';
 import { createLogger } from '../core/logger.js';
+import { openMountPickerPopup } from '../fs/mount-picker-popup.js';
 
 const log = createLogger('tool-ui-renderer');
 
@@ -150,7 +151,7 @@ export class ToolUIRenderer {
     let actionData = data;
 
     if (picker === 'directory') {
-      actionData = await openMountPopup(this.requestId);
+      actionData = await openMountPickerPopup(this.requestId);
     }
 
     chrome.runtime
@@ -188,39 +189,6 @@ export class ToolUIRenderer {
       this.dip = null;
     }
   }
-}
-
-function openMountPopup(requestId: string): Promise<Record<string, unknown>> {
-  return new Promise((resolve) => {
-    const url = chrome.runtime.getURL(
-      `mount-popup.html?requestId=${encodeURIComponent(requestId)}`
-    );
-
-    const cleanup = () => {
-      clearTimeout(timer);
-      chrome.runtime.onMessage.removeListener(listener);
-    };
-
-    const timer = setTimeout(() => {
-      cleanup();
-      resolve({ cancelled: true });
-    }, 60_000);
-
-    const listener = (msg: unknown) => {
-      const m = msg as Record<string, unknown>;
-      if (!m || m.source !== 'mount-popup' || m.requestId !== requestId) return;
-      cleanup();
-      resolve(m);
-    };
-    chrome.runtime.onMessage.addListener(listener);
-
-    chrome.windows
-      .create({ url, type: 'popup', width: 300, height: 80, focused: true })
-      .catch(() => {
-        cleanup();
-        resolve({ error: 'Failed to open directory picker window' });
-      });
-  });
 }
 
 /** Map of active renderers by request ID */

--- a/packages/webapp/tests/fs/mount-picker-popup.test.ts
+++ b/packages/webapp/tests/fs/mount-picker-popup.test.ts
@@ -100,6 +100,21 @@ describe('reactivateHandle', () => {
       'Permission denied for "denied-folder" (denied)'
     );
   });
+
+  it('throws when permission stays in "prompt" state (user dismissed without choosing)', async () => {
+    // The File System Access API spec defines `prompt` alongside granted/denied
+    // — Chromium can return it when the user closes the permission dialog
+    // without making a choice. Treat it the same as denied: no readwrite
+    // access, fail fast with a useful message.
+    const handle = {
+      kind: 'directory',
+      name: 'unresolved-folder',
+      requestPermission: vi.fn().mockResolvedValue('prompt'),
+    } as unknown as FileSystemDirectoryHandle;
+    await expect(reactivateHandle(handle)).rejects.toThrow(
+      'Permission denied for "unresolved-folder" (prompt)'
+    );
+  });
 });
 
 describe('openMountPickerPopup', () => {

--- a/packages/webapp/tests/fs/mount-picker-popup.test.ts
+++ b/packages/webapp/tests/fs/mount-picker-popup.test.ts
@@ -1,0 +1,207 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  openMountPickerPopup,
+  loadAndClearPendingHandle,
+  reactivateHandle,
+} from '../../src/fs/mount-picker-popup.js';
+
+/** Minimal mock of FileSystemDirectoryHandle. */
+function mockHandle(name: string): FileSystemDirectoryHandle {
+  return { kind: 'directory', name } as unknown as FileSystemDirectoryHandle;
+}
+
+/** Write a handle directly to the popup's IDB store (simulating mount-popup.js). */
+async function seedHandle(idbKey: string, handle: FileSystemDirectoryHandle): Promise<void> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open('slicc-pending-mount', 1);
+    req.onupgradeneeded = () => req.result.createObjectStore('handles');
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  const tx = db.transaction('handles', 'readwrite');
+  tx.objectStore('handles').put(handle, idbKey);
+  await new Promise<void>((resolve) => {
+    tx.oncomplete = () => resolve();
+  });
+  db.close();
+}
+
+async function readHandle(idbKey: string): Promise<FileSystemDirectoryHandle | null> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open('slicc-pending-mount', 1);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  const tx = db.transaction('handles', 'readonly');
+  const result = await new Promise<FileSystemDirectoryHandle | null>((resolve) => {
+    const req = tx.objectStore('handles').get(idbKey);
+    req.onsuccess = () => resolve((req.result as FileSystemDirectoryHandle | undefined) ?? null);
+    req.onerror = () => resolve(null);
+  });
+  db.close();
+  return result;
+}
+
+describe('loadAndClearPendingHandle', () => {
+  beforeEach(async () => {
+    indexedDB.deleteDatabase('slicc-pending-mount');
+  });
+
+  it('returns null when no handle is stored under the key', async () => {
+    const result = await loadAndClearPendingHandle('missing-key');
+    expect(result).toBeNull();
+  });
+
+  it('returns the stored handle and removes it from IDB', async () => {
+    const handle = mockHandle('my-project');
+    await seedHandle('pendingMount:request-1', handle);
+    const result = await loadAndClearPendingHandle('pendingMount:request-1');
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('my-project');
+    // Subsequent read should be empty (load-and-clear semantics)
+    const after = await readHandle('pendingMount:request-1');
+    expect(after).toBeNull();
+  });
+
+  it('only clears the targeted key, leaving other entries intact', async () => {
+    await seedHandle('pendingMount:a', mockHandle('a'));
+    await seedHandle('pendingMount:b', mockHandle('b'));
+    await loadAndClearPendingHandle('pendingMount:a');
+    const survivor = await readHandle('pendingMount:b');
+    expect(survivor?.name).toBe('b');
+  });
+});
+
+describe('reactivateHandle', () => {
+  it('is a no-op when handle has no requestPermission method', async () => {
+    const handle = mockHandle('legacy-handle');
+    await expect(reactivateHandle(handle)).resolves.toBeUndefined();
+  });
+
+  it('resolves when permission is granted', async () => {
+    const requestPermission = vi.fn().mockResolvedValue('granted');
+    const handle = {
+      kind: 'directory',
+      name: 'granted-folder',
+      requestPermission,
+    } as unknown as FileSystemDirectoryHandle;
+    await reactivateHandle(handle);
+    expect(requestPermission).toHaveBeenCalledWith({ mode: 'readwrite' });
+  });
+
+  it('throws with the handle name and state when permission is denied', async () => {
+    const handle = {
+      kind: 'directory',
+      name: 'denied-folder',
+      requestPermission: vi.fn().mockResolvedValue('denied'),
+    } as unknown as FileSystemDirectoryHandle;
+    await expect(reactivateHandle(handle)).rejects.toThrow(
+      'Permission denied for "denied-folder" (denied)'
+    );
+  });
+});
+
+describe('openMountPickerPopup', () => {
+  type Listener = (msg: unknown) => void;
+  let listeners: Listener[];
+  let createCalls: Array<{ url: string }>;
+  let createImpl: () => Promise<unknown>;
+
+  beforeEach(() => {
+    listeners = [];
+    createCalls = [];
+    createImpl = () => Promise.resolve({});
+    vi.useFakeTimers();
+    (globalThis as unknown as { chrome: unknown }).chrome = {
+      runtime: {
+        getURL: (path: string) => `chrome-extension://test-id/${path}`,
+        onMessage: {
+          addListener: (l: Listener) => {
+            listeners.push(l);
+          },
+          removeListener: (l: Listener) => {
+            listeners = listeners.filter((x) => x !== l);
+          },
+        },
+      },
+      windows: {
+        create: (opts: { url: string }) => {
+          createCalls.push({ url: opts.url });
+          return createImpl();
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+  });
+
+  it('opens a popup window pointed at mount-popup.html with the request id', async () => {
+    const promise = openMountPickerPopup('test-req-1');
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].url).toContain('mount-popup.html');
+    expect(createCalls[0].url).toContain('requestId=test-req-1');
+    // Resolve via popup message
+    listeners[0]({
+      source: 'mount-popup',
+      requestId: 'test-req-1',
+      handleInIdb: true,
+      idbKey: 'pendingMount:test-req-1',
+    });
+    const result = await promise;
+    expect(result).toMatchObject({ handleInIdb: true, idbKey: 'pendingMount:test-req-1' });
+  });
+
+  it('generates a fallback request id when none is provided', async () => {
+    const promise = openMountPickerPopup();
+    expect(createCalls[0].url).toMatch(/requestId=mount-[a-z0-9]+/);
+    listeners[0]({ source: 'mount-popup', requestId: extractRequestId(createCalls[0].url) });
+    await promise;
+  });
+
+  it('ignores messages with mismatched request ids', async () => {
+    const promise = openMountPickerPopup('req-A');
+    listeners[0]({ source: 'mount-popup', requestId: 'req-B', cancelled: true });
+    listeners[0]({ source: 'something-else', requestId: 'req-A', cancelled: true });
+    // Still pending — only the matching message resolves
+    listeners[0]({ source: 'mount-popup', requestId: 'req-A', cancelled: true });
+    const result = await promise;
+    expect(result).toMatchObject({ cancelled: true });
+  });
+
+  it('resolves with cancelled when 60s timeout fires', async () => {
+    const promise = openMountPickerPopup('timeout-req');
+    vi.advanceTimersByTime(60_000);
+    const result = await promise;
+    expect(result).toMatchObject({ cancelled: true });
+    // Listener was unregistered on timeout
+    expect(listeners).toHaveLength(0);
+  });
+
+  it('resolves with error when chrome.windows.create rejects', async () => {
+    createImpl = () => Promise.reject(new Error('window blocked'));
+    const promise = openMountPickerPopup('err-req');
+    const result = await promise;
+    expect(result).toMatchObject({ error: 'Failed to open directory picker window' });
+    expect(listeners).toHaveLength(0);
+  });
+
+  it('removes listener and clears timer after a successful resolve', async () => {
+    const promise = openMountPickerPopup('cleanup-req');
+    expect(listeners).toHaveLength(1);
+    listeners[0]({ source: 'mount-popup', requestId: 'cleanup-req', handleInIdb: true });
+    await promise;
+    expect(listeners).toHaveLength(0);
+    // Advancing past the timeout shouldn't double-resolve or throw
+    vi.advanceTimersByTime(120_000);
+  });
+});
+
+function extractRequestId(url: string): string {
+  const match = url.match(/requestId=([^&]+)/);
+  if (!match) throw new Error(`No requestId in url: ${url}`);
+  return decodeURIComponent(match[1]);
+}


### PR DESCRIPTION
## Summary

- Picking a TCC-protected folder (Documents/Downloads/Desktop/home) via the welcome sprinkle's "Yes, connect a folder" pill crashed Chrome's side panel renderer instead of throwing a normal "can't share this folder" error. The shell `mount` command and agent-driven approval dips already worked around this by routing the picker through `mount-popup.html`, but the welcome sprinkle's `request-mount` lick handler in `main.ts` called `showDirectoryPicker` directly from the panel — exactly the path Chrome crashes on.
- Extracted the popup workaround helpers (`openMountPickerPopup`, `loadAndClearPendingHandle`, `reactivateHandle`) into a shared `packages/webapp/src/fs/mount-picker-popup.ts` so all three extension-side entry points (shell mount, agent-approval dip, welcome sprinkle) use the same logic. Net −123 lines of duplication, +363 lines (mostly new shared module + 12 unit tests).
- CLI welcome sprinkle path (`main()` at `main.ts:1542`) intentionally unchanged — TCC dialogs render fine in standalone page context.

## Repro (before fix)

1. Install extension v2.17.1 in Chrome/Edge
2. Open the welcome sprinkle (or click "Welcome" sprinkle from a fresh state)
3. Click "Yes, connect a folder"
4. In the directory picker, choose `~/Documents` (or Downloads/Desktop/home)
5. Browser side panel renderer crashes

After this PR: same flow shows Chrome's normal "can't share this folder, choose a subfolder" error in a popup window — no crash.

## Test plan

- [ ] Reload the unpacked extension from this branch
- [ ] Run through the welcome onboarding to the "connect a folder" step
- [ ] Click "Yes, connect a folder" → popup window opens
- [ ] Pick `~/Documents` (or Downloads/Desktop/home) → see Chrome's "can't share" error in the popup, no panel crash
- [ ] Pick a subfolder of Documents (e.g. `~/Documents/foo`) → mount completes, welcome flow advances to next step
- [ ] Cancel the picker → welcome sends `mount-cancelled`, sprinkle re-enables the pill
- [ ] Verify shell `mount /mnt/test` still works (regression — same shared helper)
- [ ] Verify agent-driven mount approval dip still works (regression — same shared helper)

## Verification

- `npm run typecheck` ✓
- `npm run test` ✓ (3192 passing, 12 new)
- `npm run build -w @slicc/webapp` ✓
- `npm run build -w @slicc/chrome-extension` ✓
- `npm run build -w @slicc/node-server` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)