### PR TITLE
test(worker): smoke-test OAuth broker credentials on deploy

### DIFF
--- a/packages/cloudflare-worker/tests/deployed.test.ts
+++ b/packages/cloudflare-worker/tests/deployed.test.ts
@@ -232,6 +232,22 @@ describeIfConfigured('deployed tray worker', () => {
     const body = await response.text();
     expect(body).toContain('<!DOCTYPE html>');
   }, 15_000);
+
+  // GitHub validates (client_id, client_secret) before the code, so a fake-code
+  // probe distinguishes "credentials wrong" from "credentials fine, code fake".
+  it('exchanges fake GitHub OAuth codes through valid worker credentials', async () => {
+    const baseUrl = new URL(workerBaseUrl!);
+    const response = await fetch(new URL('/oauth/token', baseUrl), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'github',
+        code: 'FAKE_CODE_FOR_SMOKE_TEST',
+      }),
+    });
+    const body = (await response.json()) as { error?: string; error_description?: string };
+    expect(body.error).toBe('bad_verification_code');
+  }, 15_000);
 });
 
 function openWebSocket(


### PR DESCRIPTION
## Summary
- Adds a smoke test in `packages/cloudflare-worker/tests/deployed.test.ts` that POSTs a fake authorization code to `/oauth/token` and asserts GitHub returns `bad_verification_code`.
- GitHub validates `(client_id, client_secret)` before the code, so this distinguishes a missing/stale `GITHUB_CLIENT_SECRET` from a valid configuration.
- Runs against both prod and staging via the existing `describeIfConfigured` gate in `worker.yml` and `worker-staging.yml` — neither workflow needs changes.

## Why
A misconfigured `GITHUB_CLIENT_SECRET` deployed silently with a green checkmark earlier this cycle because the existing deployed-test only exercises tray flow, not the OAuth broker. This closes that gap.

## Test plan
- [x] `npx prettier --write packages/cloudflare-worker/tests/deployed.test.ts` (no changes — already formatted)
- [x] `npm run typecheck` passes
- [x] `WORKER_BASE_URL=https://www.sliccy.ai npx vitest run --project cloudflare-worker packages/cloudflare-worker/tests/deployed.test.ts` — 3/3 pass against prod
- [ ] Staging smoke test passes when this PR triggers `worker-staging.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)