### PR TITLE
feat: install migration bundle on AEM-page-migration onboarding task

### DIFF
--- a/packages/vfs-root/shared/sprinkles/welcome/welcome.shtml
+++ b/packages/vfs-root/shared/sprinkles/welcome/welcome.shtml
@@ -348,6 +348,7 @@
 
       var TASKS = [
         { id: 'build-websites',     label: 'Build websites',      icon: 'globe' },
+        { id: 'migrate-page-aem',   label: 'Migrate a page to AEM', icon: 'book-up' },
         { id: 'automate',           label: 'Automate tasks',      icon: 'zap' },
         { id: 'research',           label: 'Research & analyze',  icon: 'search' },
         { id: 'write-content',      label: 'Write content',       icon: 'file-text' },
@@ -361,7 +362,7 @@
 
       var APPS = [
         { id: 'aem',      label: 'Adobe Experience Manager', icon: 'box',
-          relevance: ['build-websites','write-content','seo','content-creator','marketer','designer'] },
+          relevance: ['build-websites','migrate-page-aem','write-content','seo','content-creator','marketer','designer'] },
         { id: 'imessage', label: 'iMessage',                 icon: 'message-circle',
           relevance: ['personal','side-project','exploring'] },
         { id: 'teams',    label: 'Microsoft Teams',          icon: 'users',

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -73,6 +73,13 @@ interface CatalogSkillSource {
   repo: string;
   path?: string;
   skill?: string;
+  /**
+   * When true, install ALL skills found under `path` (not just the one named
+   * in `skill`). Used for bundle entries — e.g. `migrate-page` is the primary
+   * skill name (for display + dedup), but the migration bundle ships four
+   * companion skills that should land together.
+   */
+  installAll?: boolean;
 }
 
 interface CatalogSkill {
@@ -114,6 +121,8 @@ interface RemoteCatalogRow {
   role: string;
   purpose: string;
   boost: string;
+  /** Sheet column — truthy values ("true", "TRUE", "1", "yes") opt the entry into bundle install. */
+  installAll?: string;
 }
 
 interface ScoredSkill {
@@ -130,6 +139,12 @@ function splitField(value: string): string[] | undefined {
     .filter(Boolean);
 }
 
+function parseInstallAll(raw: string | undefined): boolean {
+  if (!raw) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes';
+}
+
 function parseRemoteCatalog(data: RemoteCatalogRow[]): CatalogSkill[] {
   return data.map((row) => {
     const boost = row.boost ? parseFloat(row.boost) : NaN;
@@ -143,6 +158,7 @@ function parseRemoteCatalog(data: RemoteCatalogRow[]): CatalogSkill[] {
         repo: row.repo,
         path: row.path || undefined,
         skill: row.skill || undefined,
+        installAll: parseInstallAll(row.installAll),
       },
       affinity: {
         apps: splitField(row.apps),
@@ -196,7 +212,8 @@ export function scoreSkills(catalog: CatalogSkill[], profile: UserProfile): Scor
 function buildInstallCmd(source: CatalogSkillSource): string {
   let cmd = `upskill ${source.repo}`;
   if (source.path) cmd += ` --path ${source.path}`;
-  if (source.skill) cmd += ` --skill ${source.skill}`;
+  if (source.installAll) cmd += ` --all`;
+  else if (source.skill) cmd += ` --skill ${source.skill}`;
   return cmd;
 }
 
@@ -1543,6 +1560,59 @@ export async function installRecommendedSkills(
 
       for (const rec of recs) {
         const src = rec.entry.source;
+
+        // Bundle install: install ALL skills under src.path. The catalog
+        // entry's `name` / `skill` is the primary identifier (used for
+        // dedup against an already-installed bundle), but the actual
+        // install fans out across every SKILL.md found under the path.
+        if (src.installAll && src.path) {
+          const pathPrefix = src.path.replace(/^\/|\/$/g, '');
+          const targets: Array<{ name: string; path: string }> = [];
+          for (const [name, p] of skillIndex) {
+            if (p === pathPrefix || p.startsWith(pathPrefix + '/')) {
+              targets.push({ name, path: p });
+            }
+          }
+          completedSkills++;
+          const bundleEta =
+            completedSkills < totalSkills
+              ? ` (~${Math.round(((totalSkills - completedSkills) * (Date.now() - startTime)) / completedSkills / 1000)}s remaining)`
+              : '';
+
+          if (targets.length === 0) {
+            const error = `no skills found under "${src.path}" in ${repoKey}`;
+            results.push({ ok: false, name: rec.entry.name, error });
+            output += `[${completedSkills}/${totalSkills}] Failed "${rec.entry.name}" bundle from ${repoKey}: ${error}${bundleEta}\n`;
+            continue;
+          }
+
+          const bundleStart = Date.now();
+          let bundleSuccess = 0;
+          let bundleFailed = 0;
+          for (const target of targets) {
+            // Per-sub-skill dedup so a partially-installed bundle still
+            // gets the missing companions filled in.
+            if (installed.has(target.name)) continue;
+            const subResult = await installSkillFromZip(target.path, target.name, files, fs, false);
+            if (subResult.ok) {
+              results.push({ ok: true, name: target.name });
+              bundleSuccess++;
+            } else {
+              results.push({ ok: false, name: target.name, error: subResult.error });
+              bundleFailed++;
+            }
+          }
+          const bundleDuration = ((Date.now() - bundleStart) / 1000).toFixed(1);
+          if (bundleSuccess === 0 && bundleFailed === 0) {
+            output += `[${completedSkills}/${totalSkills}] Skipped "${rec.entry.name}" bundle from ${repoKey}: all sub-skills already installed${bundleEta}\n`;
+          } else if (bundleFailed === 0) {
+            output += `[${completedSkills}/${totalSkills}] Installed "${rec.entry.name}" bundle (${bundleSuccess} skill(s)) from ${repoKey} (${bundleDuration}s)${bundleEta}\n`;
+          } else {
+            output += `[${completedSkills}/${totalSkills}] Installed "${rec.entry.name}" bundle (${bundleSuccess}/${bundleSuccess + bundleFailed} skill(s)) from ${repoKey} (${bundleDuration}s)${bundleEta}\n`;
+          }
+          continue;
+        }
+
         let skillPath: string;
         let skillName: string;
 

--- a/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
@@ -1062,4 +1062,164 @@ describe('installRecommendedSkills helper (no-shell entry point)', () => {
     expect(result.skipped).toBe('all-installed');
     expect(result.installedNames).toEqual([]);
   });
+
+  it('installs a whole bundle when catalog row sets installAll', async () => {
+    // Profile picks up the migration bundle via tasks: ['build-websites'].
+    await fs.mkdir('/home/test', { recursive: true });
+    await fs.writeFile(
+      '/home/test/.welcome.json',
+      JSON.stringify({
+        purpose: 'work',
+        role: 'developer',
+        tasks: ['build-websites'],
+        apps: ['aem'],
+        name: 'Test',
+      })
+    );
+
+    const encoder = new TextEncoder();
+    const zipBytes = zipSync({
+      'skills-main/skills/migration/migrate-page/SKILL.md': encoder.encode(
+        '---\nname: migrate-page\n---\n# Migrate Page\n'
+      ),
+      'skills-main/skills/migration/migrate-block/SKILL.md': encoder.encode(
+        '---\nname: migrate-block\n---\n# Migrate Block\n'
+      ),
+      'skills-main/skills/migration/migrate-header/SKILL.md': encoder.encode(
+        '---\nname: migrate-header\n---\n# Migrate Header\n'
+      ),
+      'skills-main/skills/migration/dismiss-overlays/SKILL.md': encoder.encode(
+        '---\nname: dismiss-overlays\n---\n# Dismiss Overlays\n'
+      ),
+    });
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/skills/catalog.json')) {
+        return response(
+          200,
+          JSON.stringify({
+            data: [
+              {
+                name: 'migrate-page',
+                displayName: 'AEM Page Import',
+                description: 'Migration bundle',
+                repo: 'aemcoder/skills',
+                path: 'skills/migration/',
+                skill: 'migrate-page',
+                apps: 'aem',
+                tasks: 'build-websites',
+                role: 'developer',
+                purpose: 'work',
+                boost: '',
+                installAll: 'true',
+              },
+            ],
+          })
+        );
+      }
+      if (url.includes('codeload.github.com')) {
+        return response(200, zipBytes);
+      }
+      if (url.includes('api.github.com')) {
+        return response(403, JSON.stringify({ message: 'rate limited' }), {}, 'Forbidden');
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const result = await installRecommendedSkills(fs, fetchMock as unknown as SecureFetch);
+    expect(result.skipped).toBeNull();
+    expect(result.errors).toEqual([]);
+    expect(result.installedNames.sort()).toEqual([
+      'dismiss-overlays',
+      'migrate-block',
+      'migrate-header',
+      'migrate-page',
+    ]);
+    await expect(fs.readTextFile('/workspace/skills/migrate-page/SKILL.md')).resolves.toContain(
+      '# Migrate Page'
+    );
+    await expect(fs.readTextFile('/workspace/skills/migrate-block/SKILL.md')).resolves.toContain(
+      '# Migrate Block'
+    );
+    await expect(fs.readTextFile('/workspace/skills/migrate-header/SKILL.md')).resolves.toContain(
+      '# Migrate Header'
+    );
+    await expect(fs.readTextFile('/workspace/skills/dismiss-overlays/SKILL.md')).resolves.toContain(
+      '# Dismiss Overlays'
+    );
+  });
+
+  it('fills in missing companions when only some bundle skills are installed', async () => {
+    // Pre-install ONE bundle skill — but NOT the primary `migrate-page`,
+    // so the catalog filter doesn't drop the entry. The bundle install
+    // should skip the already-installed companion and install the rest.
+    await fs.mkdir('/home/test', { recursive: true });
+    await fs.writeFile(
+      '/home/test/.welcome.json',
+      JSON.stringify({
+        purpose: 'work',
+        role: 'developer',
+        tasks: ['build-websites'],
+        apps: ['aem'],
+        name: 'Test',
+      })
+    );
+    await fs.mkdir('/workspace/skills/migrate-block', { recursive: true });
+    await fs.writeFile('/workspace/skills/migrate-block/SKILL.md', '# pre-existing\n');
+
+    const encoder = new TextEncoder();
+    const zipBytes = zipSync({
+      'skills-main/skills/migration/migrate-page/SKILL.md': encoder.encode(
+        '---\nname: migrate-page\n---\n# Migrate Page\n'
+      ),
+      'skills-main/skills/migration/migrate-block/SKILL.md': encoder.encode(
+        '---\nname: migrate-block\n---\n# Migrate Block (new)\n'
+      ),
+      'skills-main/skills/migration/migrate-header/SKILL.md': encoder.encode(
+        '---\nname: migrate-header\n---\n# Migrate Header\n'
+      ),
+    });
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/skills/catalog.json')) {
+        return response(
+          200,
+          JSON.stringify({
+            data: [
+              {
+                name: 'migrate-page',
+                displayName: 'AEM Page Import',
+                description: 'Migration bundle',
+                repo: 'aemcoder/skills',
+                path: 'skills/migration/',
+                skill: 'migrate-page',
+                apps: 'aem',
+                tasks: 'build-websites',
+                role: 'developer',
+                purpose: 'work',
+                boost: '',
+                installAll: 'true',
+              },
+            ],
+          })
+        );
+      }
+      if (url.includes('codeload.github.com')) {
+        return response(200, zipBytes);
+      }
+      if (url.includes('api.github.com')) {
+        return response(403, JSON.stringify({ message: 'rate limited' }), {}, 'Forbidden');
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const result = await installRecommendedSkills(fs, fetchMock as unknown as SecureFetch);
+    expect(result.skipped).toBeNull();
+    expect(result.errors).toEqual([]);
+    expect(result.installedNames.sort()).toEqual(['migrate-header', 'migrate-page']);
+    // The pre-existing companion was left untouched.
+    await expect(fs.readTextFile('/workspace/skills/migrate-block/SKILL.md')).resolves.toContain(
+      'pre-existing'
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- **Bundle install in catalog**: Catalog rows can now opt into "install every skill under this path" by setting `installAll: TRUE`. The recommendation installer fans out across every SKILL.md found under the row's path and dedupes per-sub-skill, so a partially-installed bundle still gets its missing companions filled in.
- **New onboarding task**: Adds "Migrate a page to AEM" as a first-class task pill in the welcome wizard, next to "Build websites". The new task ID also boosts AEM's rank in the apps step.

Together these mean a user who picks "Migrate a page to AEM" during onboarding gets the full migration workflow (`migrate-page`, `migrate-block`, `migrate-header`, `dismiss-overlays`) installed in the background after they connect a provider — closing a gap where only `migrate-page` landed.

## Catalog (sheet) change required

The remote catalog at `https://www.sliccy.com/skills/catalog.json` needs two edits on the `migrate-page` row to make this fire:

1. Set `installAll` column to `TRUE`
2. Add `migrate-page-aem` to the `tasks` column (alongside the existing `build-websites,extract-data`)

Without these edits, the new `installAll` code path is dormant and the new task pill scores no recommendations. With them, `migrate-page-aem` selection drives the bundle install end-to-end.

## Test plan

- [x] Unit tests cover bundle install with `installAll: 'true'` (full bundle lands; partially-installed bundle gets missing companions filled in)
- [x] Existing 30 upskill tests still pass
- [x] `npm run typecheck` clean
- [x] `npm run test` — 3272 passed
- [x] `npm run build -w @slicc/chrome-extension` succeeds
- [ ] Visual: welcome wizard shows the new task pill (confirm after sheet edit + manual onboarding run)
- [ ] E2E: pick the new task, complete onboarding with a provider, verify all 4 migration skills land under `/workspace/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)