### PR TITLE
fix(welcome): remove model selection from connect-llm dip

### DIFF
--- a/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
+++ b/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
@@ -163,7 +163,8 @@
       .field-help {
         font-size: 11px;
         color: var(--s2-content-secondary, #a1a1a1);
-        margin-top: -4px;
+        margin-top: 6px;
+        line-height: 1.4;
       }
     </style>
   </head>

--- a/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
+++ b/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
@@ -185,10 +185,6 @@
           <label for="baseUrlIn">Base URL</label>
           <input id="baseUrlIn" type="text" autocomplete="off" spellcheck="false" placeholder="https://…" />
         </div>
-        <div id="modelRow">
-          <label for="modelSel">Model</label>
-          <select id="modelSel"></select>
-        </div>
       </div>
       <div id="status" class="status"></div>
       <div class="actions">
@@ -207,9 +203,10 @@
 
     <script>
       // Provider catalogue is injected by the parent via slicc-message.
-      // Until it arrives we render a tiny placeholder.
+      // Until it arrives we render a tiny placeholder. Model selection
+      // intentionally lives in the chat header (not the dip), so we
+      // ignore the `models` map and never surface it here.
       var providers = [];
-      var modelsByProvider = {};
       var current = { provider: null, providerConfig: null };
 
       var providerListEl = document.getElementById('providerList');
@@ -219,8 +216,6 @@
       var apiKeyIn = document.getElementById('apiKeyIn');
       var baseUrlRow = document.getElementById('baseUrlRow');
       var baseUrlIn = document.getElementById('baseUrlIn');
-      var modelRow = document.getElementById('modelRow');
-      var modelSel = document.getElementById('modelSel');
       var statusEl = document.getElementById('status');
       var connectBtn = document.getElementById('connectBtn');
       var backBtn = document.getElementById('backBtn');
@@ -282,30 +277,12 @@
         metaEl.textContent = '';
         apiKeyIn.value = '';
 
-        // OAuth providers don't take an API key OR a model — they
-        // delegate everything to a popup login flow handled by the
-        // host page. The dip just emits an `oauth-attempt` and waits
-        // for `slicc-connect-result`.
+        // OAuth providers delegate everything to a popup login flow
+        // handled by the host page. The dip just emits an
+        // `oauth-attempt` and waits for `slicc-connect-result`.
         var isOAuth = !!p.isOAuth;
         apiKeyRow.hidden = isOAuth;
-        modelRow.hidden = isOAuth;
 
-        // Populate model list (if known up-front).
-        modelSel.innerHTML = '';
-        var models = modelsByProvider[p.id] || [];
-        if (models.length === 0) {
-          var opt = document.createElement('option');
-          opt.value = '';
-          opt.textContent = '(default)';
-          modelSel.appendChild(opt);
-        } else {
-          models.forEach(function (m) {
-            var opt = document.createElement('option');
-            opt.value = m.id;
-            opt.textContent = m.name || m.id;
-            modelSel.appendChild(opt);
-          });
-        }
         connectBtn.disabled = false;
         connectBtn.textContent = isOAuth ? 'Login with ' + p.name : 'Connect';
         go('sCreds');
@@ -347,7 +324,11 @@
             provider: current.provider,
             apiKey: key,
             baseUrl: (baseUrlIn.value || '').trim() || null,
-            model: modelSel.value || null,
+            // Model picking is handled by the chat header dropdown,
+            // not by the welcome dip — leave it null so the
+            // orchestrator preserves whatever model the user (or
+            // provider defaults) has already chosen.
+            model: null,
           },
         });
       };
@@ -361,7 +342,9 @@
         var msg = e.detail || {};
         if (msg.type === 'slicc-providers') {
           providers = (msg.providers || []).slice();
-          modelsByProvider = msg.models || {};
+          // The dip used to read `msg.models` to populate a per-provider
+          // model dropdown; that responsibility now lives in the chat
+          // header so we deliberately ignore the models map.
           renderProviders();
         } else if (msg.type === 'slicc-already-connected') {
           // Reload of a chat that already finished onboarding —

--- a/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
+++ b/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
@@ -160,6 +160,11 @@
         color: var(--s2-content-secondary, #a1a1a1);
         margin-top: 6px;
       }
+      .field-help {
+        font-size: 11px;
+        color: var(--s2-content-secondary, #a1a1a1);
+        margin-top: -4px;
+      }
     </style>
   </head>
   <body>
@@ -178,12 +183,23 @@
       <div class="step-sub" id="providerDesc"></div>
       <div class="form">
         <div id="apiKeyRow">
-          <label for="apiKeyIn">API Key</label>
+          <label for="apiKeyIn" id="apiKeyLabel">API Key</label>
           <input id="apiKeyIn" type="password" autocomplete="off" spellcheck="false" placeholder="sk-…" />
         </div>
         <div id="baseUrlRow" hidden>
           <label for="baseUrlIn">Base URL</label>
           <input id="baseUrlIn" type="text" autocomplete="off" spellcheck="false" placeholder="https://…" />
+          <div id="baseUrlHelp" class="field-help" hidden></div>
+        </div>
+        <div id="deploymentRow" hidden>
+          <label for="deploymentIn">Deployment</label>
+          <input id="deploymentIn" type="text" autocomplete="off" spellcheck="false" placeholder="deployment-name" />
+          <div id="deploymentHelp" class="field-help" hidden></div>
+        </div>
+        <div id="apiVersionRow" hidden>
+          <label for="apiVersionIn">API Version</label>
+          <input id="apiVersionIn" type="text" autocomplete="off" spellcheck="false" placeholder="api-version" />
+          <div id="apiVersionHelp" class="field-help" hidden></div>
         </div>
       </div>
       <div id="status" class="status"></div>
@@ -213,13 +229,31 @@
       var providerNameEl = document.getElementById('providerName');
       var providerDescEl = document.getElementById('providerDesc');
       var apiKeyRow = document.getElementById('apiKeyRow');
+      var apiKeyLabelEl = document.getElementById('apiKeyLabel');
       var apiKeyIn = document.getElementById('apiKeyIn');
       var baseUrlRow = document.getElementById('baseUrlRow');
       var baseUrlIn = document.getElementById('baseUrlIn');
+      var baseUrlHelpEl = document.getElementById('baseUrlHelp');
+      var deploymentRow = document.getElementById('deploymentRow');
+      var deploymentIn = document.getElementById('deploymentIn');
+      var deploymentHelpEl = document.getElementById('deploymentHelp');
+      var apiVersionRow = document.getElementById('apiVersionRow');
+      var apiVersionIn = document.getElementById('apiVersionIn');
+      var apiVersionHelpEl = document.getElementById('apiVersionHelp');
       var statusEl = document.getElementById('status');
       var connectBtn = document.getElementById('connectBtn');
       var backBtn = document.getElementById('backBtn');
       var metaEl = document.getElementById('meta');
+
+      function setHelpText(el, text) {
+        if (text) {
+          el.textContent = text;
+          el.hidden = false;
+        } else {
+          el.textContent = '';
+          el.hidden = true;
+        }
+      }
 
       function renderProviders() {
         providerListEl.innerHTML = '';
@@ -270,18 +304,54 @@
         var fallback = (p.id || '') + ' provider';
         providerDescEl.textContent =
           p.description && p.description !== fallback ? p.description : '';
-        baseUrlRow.hidden = !p.requiresBaseUrl;
-        baseUrlIn.value = p.defaultBaseUrl || '';
         statusEl.className = 'status';
         statusEl.textContent = '';
         metaEl.textContent = '';
+
+        // ── API key field ─────────────────────────────────────────
         apiKeyIn.value = '';
+        // Mirror the Settings → Add Account dialog's "API Key (ENVVAR):"
+        // label so users see which env-var SLICC will read on import.
+        apiKeyLabelEl.textContent =
+          'API Key' + (p.apiKeyEnvVar ? ' (' + p.apiKeyEnvVar + ')' : '');
+        apiKeyIn.placeholder = p.apiKeyPlaceholder || 'sk-…';
+
+        // ── Base URL field ────────────────────────────────────────
+        baseUrlRow.hidden = !p.requiresBaseUrl;
+        baseUrlIn.value = p.defaultBaseUrl || '';
+        baseUrlIn.placeholder = p.defaultBaseUrl || 'https://…';
+        setHelpText(baseUrlHelpEl, p.requiresBaseUrl ? p.baseUrlDescription || '' : '');
+
+        // ── Deployment field ──────────────────────────────────────
+        deploymentRow.hidden = !p.requiresDeployment;
+        deploymentIn.value = '';
+        deploymentIn.placeholder = p.deploymentPlaceholder || 'deployment-name';
+        setHelpText(
+          deploymentHelpEl,
+          p.requiresDeployment ? p.deploymentDescription || '' : ''
+        );
+
+        // ── API version field ─────────────────────────────────────
+        apiVersionRow.hidden = !p.requiresApiVersion;
+        apiVersionIn.value = p.apiVersionDefault || '';
+        apiVersionIn.placeholder = p.apiVersionDefault || 'api-version';
+        setHelpText(
+          apiVersionHelpEl,
+          p.requiresApiVersion ? p.apiVersionDescription || '' : ''
+        );
 
         // OAuth providers delegate everything to a popup login flow
         // handled by the host page. The dip just emits an
         // `oauth-attempt` and waits for `slicc-connect-result`.
         var isOAuth = !!p.isOAuth;
         apiKeyRow.hidden = isOAuth;
+        // OAuth + per-provider extras don't combine in the settings
+        // dialog either, so hide deployment/api-version on OAuth
+        // providers regardless of catalogue flags.
+        if (isOAuth) {
+          deploymentRow.hidden = true;
+          apiVersionRow.hidden = true;
+        }
 
         connectBtn.disabled = false;
         connectBtn.textContent = isOAuth ? 'Login with ' + p.name : 'Connect';
@@ -308,12 +378,27 @@
           return;
         }
         var key = (apiKeyIn.value || '').trim();
-        if (!key) {
+        if (p.requiresApiKey !== false && !key) {
           statusEl.className = 'status error';
           statusEl.textContent = 'Please enter an API key.';
           apiKeyIn.focus();
           return;
         }
+        var baseUrlVal = (baseUrlIn.value || '').trim();
+        if (p.requiresBaseUrl && !baseUrlVal) {
+          statusEl.className = 'status error';
+          statusEl.textContent = 'Please enter a base URL.';
+          baseUrlIn.focus();
+          return;
+        }
+        var deploymentVal = (deploymentIn.value || '').trim();
+        if (p.requiresDeployment && !deploymentVal) {
+          statusEl.className = 'status error';
+          statusEl.textContent = 'Please enter a deployment name.';
+          deploymentIn.focus();
+          return;
+        }
+        var apiVersionVal = (apiVersionIn.value || '').trim();
         connectBtn.disabled = true;
         connectBtn.textContent = 'Validating…';
         statusEl.className = 'status busy';
@@ -323,7 +408,9 @@
           data: {
             provider: current.provider,
             apiKey: key,
-            baseUrl: (baseUrlIn.value || '').trim() || null,
+            baseUrl: baseUrlVal || null,
+            deployment: deploymentVal || null,
+            apiVersion: apiVersionVal || null,
             // Model picking is handled by the chat header dropdown,
             // not by the welcome dip — leave it null so the
             // orchestrator preserves whatever model the user (or
@@ -333,9 +420,13 @@
         });
       };
 
-      apiKeyIn.addEventListener('keydown', function (e) {
+      function submitOnEnter(e) {
         if (e.key === 'Enter') connectBtn.click();
-      });
+      }
+      apiKeyIn.addEventListener('keydown', submitOnEnter);
+      baseUrlIn.addEventListener('keydown', submitOnEnter);
+      deploymentIn.addEventListener('keydown', submitOnEnter);
+      apiVersionIn.addEventListener('keydown', submitOnEnter);
 
       // Listen for parent → dip messages.
       document.addEventListener('slicc-message', function (e) {

--- a/packages/webapp/src/scoops/onboarding-orchestrator.ts
+++ b/packages/webapp/src/scoops/onboarding-orchestrator.ts
@@ -34,14 +34,42 @@ import { validateApiKey, type ValidationResult } from './api-key-validator.js';
 
 const log = createLogger('onboarding-orchestrator');
 
-/** Snapshot describing a single provider, dip-safe (no functions). */
+/**
+ * Snapshot describing a single provider, dip-safe (no functions).
+ *
+ * Mirrors the field set the Settings → Add Account dialog renders so
+ * the welcome dip can stay in lock-step with it. When the settings
+ * dialog gains a new per-provider input, this interface and the
+ * `buildProviderCatalogue` callsites in `main.ts` should grow with it
+ * — otherwise the dip silently saves an account missing required
+ * fields (the original symptom that motivated this contract).
+ */
 export interface ProviderEntry {
   id: string;
   name: string;
   description?: string;
   requiresApiKey: boolean;
   requiresBaseUrl: boolean;
+  /** True when the provider needs a deployment name (Azure OpenAI). */
+  requiresDeployment?: boolean;
+  /** True when the provider needs a custom api-version (Azure OpenAI). */
+  requiresApiVersion?: boolean;
+  /** Optional API-key placeholder shown in the dip's input. */
+  apiKeyPlaceholder?: string;
+  /** Optional env-var hint appended to the API-key label. */
+  apiKeyEnvVar?: string;
+  /** Default value pre-filled into the base-url input. */
   defaultBaseUrl?: string;
+  /** Helper text shown below the base-url input. */
+  baseUrlDescription?: string;
+  /** Placeholder for the deployment input. */
+  deploymentPlaceholder?: string;
+  /** Helper text shown below the deployment input. */
+  deploymentDescription?: string;
+  /** Default value (and placeholder) for the api-version input. */
+  apiVersionDefault?: string;
+  /** Helper text shown below the api-version input. */
+  apiVersionDescription?: string;
   /** True when this provider authenticates via an OAuth popup. */
   isOAuth?: boolean;
 }
@@ -62,6 +90,10 @@ export interface ConnectAttemptPayload {
   provider: string;
   apiKey: string;
   baseUrl?: string | null;
+  /** Deployment name for providers with `requiresDeployment` (Azure OpenAI). */
+  deployment?: string | null;
+  /** API version for providers with `requiresApiVersion` (Azure OpenAI). */
+  apiVersion?: string | null;
   model?: string | null;
 }
 
@@ -91,7 +123,13 @@ export interface OrchestratorDeps {
   /** Get the live provider catalogue snapshot. */
   getProviderCatalogue: () => ProviderCatalogue;
   /** Persist credentials. Mirrors `provider-settings.addAccount`. */
-  saveAccount: (providerId: string, apiKey: string, baseUrl?: string) => void;
+  saveAccount: (
+    providerId: string,
+    apiKey: string,
+    baseUrl?: string,
+    deployment?: string,
+    apiVersion?: string
+  ) => void;
   /** Set the active model id (mirrors `setSelectedModelId`). */
   setSelectedModel: (modelId: string) => void;
   /** Optional human label for the model that gets selected. */
@@ -212,13 +250,46 @@ export class OnboardingOrchestrator {
     if (this.stage !== 'awaiting-connect' && this.stage !== 'connecting') return;
     this.stage = 'connecting';
 
-    const { provider, apiKey, baseUrl, model } = payload;
+    const { provider, apiKey, baseUrl, deployment, apiVersion, model } = payload;
     if (!provider || typeof apiKey !== 'string' || !apiKey.trim()) {
       this.deps.broadcastToDip({
         type: 'slicc-connect-result',
         ok: false,
         kind: 'failed',
         message: 'Provider and API key are required.',
+      });
+      this.stage = 'awaiting-connect';
+      return;
+    }
+
+    // Match the Settings → Add Account dialog's required-field gate
+    // so the dip can't silently save half-configured Azure-style
+    // accounts. Without this, picking azure-openai from the welcome
+    // dip used to write an account missing deployment + api-version
+    // and break at the first chat request.
+    const providerEntry = (() => {
+      try {
+        return this.deps.getProviderCatalogue().providers.find((p) => p.id === provider);
+      } catch {
+        return undefined;
+      }
+    })();
+    if (providerEntry?.requiresDeployment && !deployment?.trim()) {
+      this.deps.broadcastToDip({
+        type: 'slicc-connect-result',
+        ok: false,
+        kind: 'failed',
+        message: `${providerEntry.name} requires a deployment name.`,
+      });
+      this.stage = 'awaiting-connect';
+      return;
+    }
+    if (providerEntry?.requiresBaseUrl && !baseUrl?.trim()) {
+      this.deps.broadcastToDip({
+        type: 'slicc-connect-result',
+        ok: false,
+        kind: 'failed',
+        message: `${providerEntry.name} requires a base URL.`,
       });
       this.stage = 'awaiting-connect';
       return;
@@ -278,7 +349,13 @@ export class OnboardingOrchestrator {
       }
     }
     try {
-      this.deps.saveAccount(provider, apiKey.trim(), baseUrl ?? undefined);
+      this.deps.saveAccount(
+        provider,
+        apiKey.trim(),
+        baseUrl?.trim() || undefined,
+        deployment?.trim() || undefined,
+        apiVersion?.trim() || undefined
+      );
       if (effectiveModel) this.deps.setSelectedModel(effectiveModel);
     } catch (err) {
       log.warn('saveAccount failed', err);

--- a/packages/webapp/src/scoops/onboarding-orchestrator.ts
+++ b/packages/webapp/src/scoops/onboarding-orchestrator.ts
@@ -259,9 +259,27 @@ export class OnboardingOrchestrator {
 
     // Both `ok` and `skipped` count as accept-and-save for the
     // orchestrator; the dip surfaces the difference inline.
+    //
+    // When the dip omits a model (the welcome dip no longer
+    // surfaces a model picker), fall back to the first model the
+    // provider catalogue advertises for the just-saved provider.
+    // Without this fallback, a stale `selected-model` from a
+    // previously-removed provider would survive onboarding and
+    // immediately fail chat requests until the user manually
+    // corrected the header dropdown.
+    let effectiveModel = model || null;
+    if (!effectiveModel) {
+      try {
+        const catalogue = this.deps.getProviderCatalogue();
+        const fallback = catalogue.models?.[provider]?.[0]?.id;
+        if (fallback) effectiveModel = fallback;
+      } catch (err) {
+        log.warn('Failed to resolve fallback model for provider', { provider, err });
+      }
+    }
     try {
       this.deps.saveAccount(provider, apiKey.trim(), baseUrl ?? undefined);
-      if (model) this.deps.setSelectedModel(model);
+      if (effectiveModel) this.deps.setSelectedModel(effectiveModel);
     } catch (err) {
       log.warn('saveAccount failed', err);
       this.deps.broadcastToDip({
@@ -288,16 +306,16 @@ export class OnboardingOrchestrator {
     // Hand off to the cone — now that an LLM is configured, the cone
     // can comment on the choice. SKILL.md spells out the exact reply.
     const modelLabel =
-      model && this.deps.resolveModelLabel?.(provider, model)
-        ? this.deps.resolveModelLabel?.(provider, model)
-        : model || null;
+      effectiveModel && this.deps.resolveModelLabel?.(provider, effectiveModel)
+        ? this.deps.resolveModelLabel?.(provider, effectiveModel)
+        : effectiveModel || null;
     this.stage = 'complete';
     this.deps.fireFinalLick({
       action: 'onboarding-complete-with-provider',
       data: {
         profile: this.profile,
         provider,
-        model: model ?? null,
+        model: effectiveModel ?? null,
         modelLabel,
         validation: result.kind,
       },

--- a/packages/webapp/src/scoops/onboarding-orchestrator.ts
+++ b/packages/webapp/src/scoops/onboarding-orchestrator.ts
@@ -234,9 +234,22 @@ export class OnboardingOrchestrator {
     return true;
   }
 
-  /** Dip is mounted and asking for the provider catalogue. */
+  /** Dip is mounted and asking for the provider catalogue.
+   *
+   * Responds in any non-complete stage. The dip emits `connect-ready`
+   * whenever it (re)mounts — including after a reload where the
+   * persistent welcome-flow ledger suppressed the prior
+   * `onboarding-complete` and left the orchestrator at `idle`. We
+   * still need to feed the catalogue so the dip leaves its
+   * "Loading providers…" state.
+   *
+   * If onboarding has already wired a provider, the host short-
+   * circuits with a `slicc-already-connected` message before this
+   * runs, so the only remaining `complete` case is a programmatic
+   * re-fire we can safely ignore.
+   */
   handleConnectReady(): void {
-    if (this.stage !== 'awaiting-connect' && this.stage !== 'connecting') return;
+    if (this.stage === 'complete') return;
     const catalogue = this.deps.getProviderCatalogue();
     this.deps.broadcastToDip({
       type: 'slicc-providers',
@@ -245,9 +258,15 @@ export class OnboardingOrchestrator {
     });
   }
 
-  /** User submitted a provider + key. */
+  /** User submitted a provider + key.
+   *
+   * Idle is also a valid entry stage — see `handleConnectReady` for
+   * the reload case where the dip is re-mounted from chat history
+   * after the welcome-flow ledger already suppressed
+   * `onboarding-complete`.
+   */
   async handleConnectAttempt(payload: ConnectAttemptPayload): Promise<void> {
-    if (this.stage !== 'awaiting-connect' && this.stage !== 'connecting') return;
+    if (this.stage === 'complete') return;
     this.stage = 'connecting';
 
     const { provider, apiKey, baseUrl, deployment, apiVersion, model } = payload;
@@ -399,9 +418,15 @@ export class OnboardingOrchestrator {
     });
   }
 
-  /** User picked an OAuth provider and clicked "Login". */
+  /** User picked an OAuth provider and clicked "Login".
+   *
+   * Idle is also a valid entry stage — see `handleConnectReady` for
+   * the reload case where the dip is re-mounted from chat history
+   * after the welcome-flow ledger already suppressed
+   * `onboarding-complete`.
+   */
   async handleOAuthAttempt(payload: OAuthAttemptPayload): Promise<void> {
-    if (this.stage !== 'awaiting-connect' && this.stage !== 'connecting') return;
+    if (this.stage === 'complete') return;
     if (!this.deps.launchOAuth) {
       this.deps.broadcastToDip({
         type: 'slicc-connect-result',

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -852,7 +852,16 @@ async function mainExtension(app: HTMLElement): Promise<void> {
           description: cfg.description,
           requiresApiKey: cfg.requiresApiKey ?? true,
           requiresBaseUrl: cfg.requiresBaseUrl ?? false,
+          requiresDeployment: !!cfg.requiresDeployment,
+          requiresApiVersion: !!cfg.requiresApiVersion,
+          apiKeyPlaceholder: cfg.apiKeyPlaceholder ?? undefined,
+          apiKeyEnvVar: cfg.apiKeyEnvVar ?? undefined,
           defaultBaseUrl: cfg.baseUrlPlaceholder ?? undefined,
+          baseUrlDescription: cfg.baseUrlDescription ?? undefined,
+          deploymentPlaceholder: cfg.deploymentPlaceholder ?? undefined,
+          deploymentDescription: cfg.deploymentDescription ?? undefined,
+          apiVersionDefault: cfg.apiVersionDefault ?? undefined,
+          apiVersionDescription: cfg.apiVersionDescription ?? undefined,
           isOAuth: !!cfg.isOAuth,
         };
       })
@@ -880,7 +889,8 @@ async function mainExtension(app: HTMLElement): Promise<void> {
       postSystemMessage: (line) => layout.panels.chat.addSystemMessage(line),
       postDipReference: (md) => layout.panels.chat.addSystemMessage(md),
       getProviderCatalogue: buildExtProviderCatalogue,
-      saveAccount: (id, key, baseUrl) => addAccountExt(id, key, baseUrl),
+      saveAccount: (id, key, baseUrl, deployment, apiVersion) =>
+        addAccountExt(id, key, baseUrl, deployment, apiVersion),
       setSelectedModel: (id) => setSelectedModelIdExt(id),
       resolveModelLabel: (provider, modelId) => {
         try {
@@ -1053,6 +1063,14 @@ async function mainExtension(app: HTMLElement): Promise<void> {
             provider: String(data.provider ?? ''),
             apiKey: String(data.apiKey ?? ''),
             baseUrl: typeof data.baseUrl === 'string' && data.baseUrl ? String(data.baseUrl) : null,
+            deployment:
+              typeof data.deployment === 'string' && data.deployment
+                ? String(data.deployment)
+                : null,
+            apiVersion:
+              typeof data.apiVersion === 'string' && data.apiVersion
+                ? String(data.apiVersion)
+                : null,
             model: data.model == null ? null : String(data.model),
           })
           .catch((err) => log.warn('handleConnectAttempt failed', err));
@@ -2031,7 +2049,16 @@ async function main(): Promise<void> {
           description: cfg.description,
           requiresApiKey: cfg.requiresApiKey ?? true,
           requiresBaseUrl: cfg.requiresBaseUrl ?? false,
+          requiresDeployment: !!cfg.requiresDeployment,
+          requiresApiVersion: !!cfg.requiresApiVersion,
+          apiKeyPlaceholder: cfg.apiKeyPlaceholder ?? undefined,
+          apiKeyEnvVar: cfg.apiKeyEnvVar ?? undefined,
           defaultBaseUrl: cfg.baseUrlPlaceholder ?? undefined,
+          baseUrlDescription: cfg.baseUrlDescription ?? undefined,
+          deploymentPlaceholder: cfg.deploymentPlaceholder ?? undefined,
+          deploymentDescription: cfg.deploymentDescription ?? undefined,
+          apiVersionDefault: cfg.apiVersionDefault ?? undefined,
+          apiVersionDescription: cfg.apiVersionDescription ?? undefined,
           isOAuth: !!cfg.isOAuth,
         };
       })
@@ -2059,7 +2086,8 @@ async function main(): Promise<void> {
       postSystemMessage: (line) => layout.panels.chat.addSystemMessage(line),
       postDipReference: (md) => layout.panels.chat.addSystemMessage(md),
       getProviderCatalogue: buildProviderCatalogue,
-      saveAccount: (id, key, baseUrl) => addAccount(id, key, baseUrl),
+      saveAccount: (id, key, baseUrl, deployment, apiVersion) =>
+        addAccount(id, key, baseUrl, deployment, apiVersion),
       setSelectedModel: (id) => setSelectedModelId(id),
       resolveModelLabel: (provider, modelId) => {
         try {
@@ -2284,6 +2312,14 @@ async function main(): Promise<void> {
               apiKey: String(data.apiKey ?? ''),
               baseUrl:
                 typeof data.baseUrl === 'string' && data.baseUrl ? String(data.baseUrl) : null,
+              deployment:
+                typeof data.deployment === 'string' && data.deployment
+                  ? String(data.deployment)
+                  : null,
+              apiVersion:
+                typeof data.apiVersion === 'string' && data.apiVersion
+                  ? String(data.apiVersion)
+                  : null,
               model: data.model == null ? null : String(data.model),
             })
             .catch((err) => log.warn('handleConnectAttempt failed', err));

--- a/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
@@ -29,10 +29,22 @@ const baseCatalogue: ProviderCatalogue = {
       requiresApiKey: true,
       requiresBaseUrl: false,
     },
+    {
+      id: 'azure-openai',
+      name: 'Azure OpenAI',
+      description: 'GPT models via Azure AI Foundry',
+      requiresApiKey: true,
+      requiresBaseUrl: true,
+      requiresDeployment: true,
+      requiresApiVersion: true,
+      defaultBaseUrl: 'https://your-resource.cognitiveservices.azure.com/',
+      apiVersionDefault: '2024-08-01-preview',
+    },
   ],
   models: {
     openai: [{ id: 'gpt-4o', name: 'GPT-4o' }],
     anthropic: [{ id: 'claude-opus-4-6', name: 'Claude Opus 4.6' }],
+    'azure-openai': [{ id: 'gpt-4o', name: 'GPT-4o' }],
   },
 };
 
@@ -55,7 +67,8 @@ function makeHarness(
     postSystemMessage: (line) => systemMessages.push(line),
     postDipReference: (md) => dipRefs.push(md),
     getProviderCatalogue: () => baseCatalogue,
-    saveAccount: (id, key, baseUrl) => accounts.push({ id, key, baseUrl }),
+    saveAccount: (id, key, baseUrl, deployment, apiVersion) =>
+      accounts.push({ id, key, baseUrl, deployment, apiVersion }),
     setSelectedModel: (id) => selectedModels.push(id),
     resolveModelLabel: (_p, m) => m.toUpperCase(),
     broadcastToDip: (msg) => dipInbox.push(msg),
@@ -208,7 +221,15 @@ describe('OnboardingOrchestrator', () => {
         baseUrl: null,
         model: 'gpt-4o',
       });
-      expect(h.accounts).toEqual([{ id: 'openai', key: 'sk-good', baseUrl: undefined }]);
+      expect(h.accounts).toEqual([
+        {
+          id: 'openai',
+          key: 'sk-good',
+          baseUrl: undefined,
+          deployment: undefined,
+          apiVersion: undefined,
+        },
+      ]);
       expect(h.selectedModels).toEqual(['gpt-4o']);
       expect(h.finalLicks).toHaveLength(1);
       expect(h.finalLicks[0].action).toBe('onboarding-complete-with-provider');
@@ -324,6 +345,63 @@ describe('OnboardingOrchestrator', () => {
       });
       expect(selectedModels).toEqual([]);
       expect(finalLicks[0].data.model).toBeNull();
+    });
+
+    it('forwards deployment + apiVersion to saveAccount for Azure-style providers', async () => {
+      const h = makeHarness();
+      await h.orchestrator.handleOnboardingComplete({});
+      await h.orchestrator.handleConnectAttempt({
+        provider: 'azure-openai',
+        apiKey: 'azure-key',
+        baseUrl: 'https://example.cognitiveservices.azure.com/',
+        deployment: 'gpt4o-eastus',
+        apiVersion: '2024-08-01-preview',
+        model: null,
+      });
+      expect(h.accounts).toEqual([
+        {
+          id: 'azure-openai',
+          key: 'azure-key',
+          baseUrl: 'https://example.cognitiveservices.azure.com/',
+          deployment: 'gpt4o-eastus',
+          apiVersion: '2024-08-01-preview',
+        },
+      ]);
+      expect(h.finalLicks).toHaveLength(1);
+      expect(h.finalLicks[0].data.provider).toBe('azure-openai');
+    });
+
+    it('rejects when a requiresDeployment provider is missing the deployment field', async () => {
+      const h = makeHarness();
+      await h.orchestrator.handleOnboardingComplete({});
+      await h.orchestrator.handleConnectAttempt({
+        provider: 'azure-openai',
+        apiKey: 'azure-key',
+        baseUrl: 'https://example.cognitiveservices.azure.com/',
+        deployment: null,
+        apiVersion: '2024-08-01-preview',
+      });
+      expect(h.accounts).toEqual([]);
+      expect(h.finalLicks).toEqual([]);
+      const reject = h.dipInbox.find((m) => m.type === 'slicc-connect-result');
+      expect(reject.ok).toBe(false);
+      expect(reject.message).toContain('deployment');
+      expect(h.orchestrator.getStage()).toBe('awaiting-connect');
+    });
+
+    it('rejects when a requiresBaseUrl provider is missing the base URL', async () => {
+      const h = makeHarness();
+      await h.orchestrator.handleOnboardingComplete({});
+      await h.orchestrator.handleConnectAttempt({
+        provider: 'azure-openai',
+        apiKey: 'azure-key',
+        baseUrl: null,
+        deployment: 'gpt4o-eastus',
+      });
+      expect(h.accounts).toEqual([]);
+      const reject = h.dipInbox.find((m) => m.type === 'slicc-connect-result');
+      expect(reject.ok).toBe(false);
+      expect(reject.message.toLowerCase()).toContain('base url');
     });
 
     it('rejects empty payloads gracefully', async () => {

--- a/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
@@ -277,6 +277,55 @@ describe('OnboardingOrchestrator', () => {
       expect(orch.getStage()).toBe('complete');
     });
 
+    it('falls back to the first catalogue model when the dip omits one', async () => {
+      // Mirrors the new welcome-dip path: dip no longer picks a
+      // model, so the orchestrator must pick a sensible default
+      // matching the just-saved provider. Without this fallback a
+      // stale `selected-model` from a previously-removed provider
+      // would survive onboarding and break chat requests.
+      const h = makeHarness();
+      await h.orchestrator.handleOnboardingComplete({});
+      await h.orchestrator.handleConnectAttempt({
+        provider: 'anthropic',
+        apiKey: 'sk-good',
+        baseUrl: null,
+        model: null,
+      });
+      expect(h.selectedModels).toEqual(['claude-opus-4-6']);
+      expect(h.finalLicks).toHaveLength(1);
+      expect(h.finalLicks[0].data.model).toBe('claude-opus-4-6');
+      expect(h.finalLicks[0].data.modelLabel).toBe('CLAUDE-OPUS-4-6');
+    });
+
+    it('leaves the selected model untouched when the catalogue has no models for the provider', async () => {
+      const fs = new VirtualFS('no-models-' + Math.random());
+      const selectedModels: string[] = [];
+      const finalLicks: any[] = [];
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => ({
+          providers: baseCatalogue.providers,
+          models: { openai: [], anthropic: [] },
+        }),
+        saveAccount: () => {},
+        setSelectedModel: (id) => selectedModels.push(id),
+        broadcastToDip: () => {},
+        fireFinalLick: (data) => finalLicks.push(data),
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleConnectAttempt({
+        provider: 'openai',
+        apiKey: 'sk-good',
+        model: null,
+      });
+      expect(selectedModels).toEqual([]);
+      expect(finalLicks[0].data.model).toBeNull();
+    });
+
     it('rejects empty payloads gracefully', async () => {
       const h = makeHarness();
       await h.orchestrator.handleOnboardingComplete({});

--- a/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
@@ -204,10 +204,37 @@ describe('OnboardingOrchestrator', () => {
       ]);
     });
 
-    it('ignores stray ready events when the orchestrator is idle', () => {
+    it('also responds when the orchestrator is idle (reload after ledger suppressed onboarding-complete)', () => {
+      // The connect-llm dip re-mounts from chat history on reload
+      // and emits `connect-ready` again. The persistent welcome-
+      // flow ledger may have already swallowed `onboarding-complete`
+      // so the orchestrator stays at `idle`. The catalogue must
+      // still flow through, otherwise the dip is stuck on
+      // "Loading providers…" forever.
       const h = makeHarness();
       h.orchestrator.handleConnectReady();
-      expect(h.dipInbox).toHaveLength(0);
+      expect(h.dipInbox).toEqual([
+        {
+          type: 'slicc-providers',
+          providers: baseCatalogue.providers,
+          models: baseCatalogue.models,
+        },
+      ]);
+    });
+
+    it('ignores ready events after onboarding has fully completed', async () => {
+      const h = makeHarness();
+      await h.orchestrator.handleOnboardingComplete({});
+      await h.orchestrator.handleConnectAttempt({
+        provider: 'openai',
+        apiKey: 'sk-good',
+        baseUrl: null,
+        model: 'gpt-4o',
+      });
+      expect(h.orchestrator.getStage()).toBe('complete');
+      h.dipInbox.length = 0;
+      h.orchestrator.handleConnectReady();
+      expect(h.dipInbox).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

The welcome `connect-llm` dip used to require picking a provider, entering an API key (or OAuth), AND selecting a model from a dropdown. Since model selection already lives in the chat header dropdown, that step was redundant.

## Changes

`packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml`:

- Removed the `#modelRow` UI element (label + `<select>`)
- Removed the `modelsByProvider` state and per-provider model dropdown population
- The `connect-attempt` lick now sends `model: null`
- The `slicc-providers` message handler now ignores the `models` map (the host still sends it; the dip just doesn't surface it)

## Compatibility

No host-side changes are required. `OnboardingOrchestrator.handleConnectAttempt` already handles `model: null` correctly: it skips `setSelectedModel` and fires the final `onboarding-complete-with-provider` lick with `model: null`. The user's currently-selected model (provider default or whatever they pick from the chat header) is preserved.

## Verification

- `npm run typecheck` passes
- Targeted tests pass: `onboarding-orchestrator.test.ts`, `welcome-detection.test.ts`, `dip.test.ts`
- Pre-existing build failures (`@pierre/diffs` module resolution) and 24 pre-existing test failures (jsdom `localStorage.getItem`) are present on `main` as well and are unrelated to this change