### PR TITLE
fix(provider-settings): clear stale selected-model when its account is removed

### DIFF
--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -275,9 +275,24 @@ export class Layout {
    */
   private initModelSelection(): void {
     const ensureModelSelected = () => {
-      const currentModelId = getSelectedModelId();
-      if (currentModelId) return;
       const groups = getAllAvailableModels();
+      // Validate that the stored selection still resolves against
+      // a configured account. Without this, deleting the active
+      // provider through Settings leaves a dangling `selected-model`
+      // (e.g. `bedrock-camp:…`) that the header dropdown silently
+      // ignores while message-send continues routing to the removed
+      // provider — surfacing as "No API key configured for provider".
+      const raw = localStorage.getItem('selected-model') ?? '';
+      const sep = raw.indexOf(':');
+      const storedProvider = sep > 0 ? raw.slice(0, sep) : '';
+      const storedModelId = sep > 0 ? raw.slice(sep + 1) : raw;
+      const stillResolves =
+        !!storedProvider &&
+        groups.some(
+          (g) => g.providerId === storedProvider && g.models.some((m) => m.id === storedModelId)
+        );
+      if (raw && stillResolves) return;
+      // Re-pick a default from the surviving accounts.
       for (const group of groups) {
         if (group.models.length > 0) {
           const { defaultModelId } = getProviderConfig(group.providerId);
@@ -288,6 +303,12 @@ export class Layout {
           setSelectedModelId(`${group.providerId}:${model.id}`);
           return;
         }
+      }
+      // No accounts at all → leave the selection empty so the chat
+      // header surfaces the "no provider configured" state instead
+      // of silently routing to a stale one.
+      if (raw && groups.length === 0) {
+        localStorage.removeItem('selected-model');
       }
     };
     ensureModelSelected();

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -407,6 +407,18 @@ export function addAccount(
 
 export function removeAccount(providerId: string): void {
   saveAccounts(getAccounts().filter((a) => a.providerId !== providerId));
+  // Clear the stored `selected-model` if it pointed at the deleted
+  // account. Without this, header dropdowns and the next message
+  // continue to resolve `getSelectedProvider()` to the removed
+  // provider — which then surfaces as
+  // "No API key configured for provider …" the next time the user
+  // sends a chat. The follow-up `ensureModelSelected` call in
+  // layout.ts re-picks a default from the surviving accounts.
+  const raw = localStorage.getItem(MODEL_KEY) ?? '';
+  const sep = raw.indexOf(':');
+  if (sep > 0 && raw.slice(0, sep) === providerId) {
+    localStorage.removeItem(MODEL_KEY);
+  }
 }
 
 /** Save an OAuth account (used by external providers after token exchange). */


### PR DESCRIPTION
Follow-up to #537. Surfaced while testing that PR.

## Bug

Deleting an account through the Settings dialog left the `selected-model` localStorage key pointing at the removed provider. The chat-header dropdown silently filtered the orphaned selection out of the visible list, but message-send continued to resolve `getSelectedProvider()` to the deleted id and surfaced

> No API key configured for provider "bedrock-camp". Open Settings to add one.

on the next chat turn.

## Fix

- `removeAccount()` now wipes `selected-model` when its prefix matches the removed providerId.
- Layout's `ensureModelSelected()` re-validates the stored selection on each `refreshModels()` call: if the prefix doesn't resolve against any surviving account, it re-picks the first available model so the dropdown and the agent stay in lock-step.

## Verification

- `npm run typecheck` passes
- All onboarding-orchestrator tests still pass
- Reproduced the bug live (CDP-side: stored `bedrock-camp:claude-opus-4-7` while only `opencode` configured); after fix, deleting an account now resets the dropdown to the first surviving provider's default model.

## Why a separate PR

PR #537 is in the merge queue — keeping that one untouched. This change is independent and only touches `provider-settings.ts` + `layout.ts`.