### PR TITLE
feat(proxy): route all cross-origin LLM traffic through a root-scope service worker

### DIFF
--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -5,6 +5,7 @@ import { spawn, type ChildProcess } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { Readable, Transform } from 'stream';
+import { StringDecoder } from 'string_decoder';
 import { fileURLToPath } from 'url';
 import express, { type Request, type Response, type NextFunction } from 'express';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -975,6 +976,10 @@ async function main() {
       res.status(400).json({ error: 'Missing X-Target-URL header' });
       return;
     }
+    // Hoisted so the catch handler below can detach it on early
+    // failures (e.g. fetch threw before the success-path detach
+    // could run).
+    let onClientClose: (() => void) | null = null;
     try {
       const fetchInit: RequestInit = {
         method: req.method,
@@ -1100,7 +1105,7 @@ async function main() {
       // settled), in the second it's exactly what we want. Guard with
       // `res.writableEnded` to be safe.
       const abortController = new AbortController();
-      const onClientClose = () => {
+      onClientClose = () => {
         if (!res.writableEnded) abortController.abort();
       };
       res.on('close', onClientClose);
@@ -1147,7 +1152,7 @@ async function main() {
       // is best-effort on streamed bodies).
       if (!upstream.body) {
         res.end();
-        res.off('close', onClientClose);
+        if (onClientClose) res.off('close', onClientClose);
         return;
       }
       const ct = (upstream.headers.get('content-type') ?? '').toLowerCase();
@@ -1159,6 +1164,16 @@ async function main() {
       const upstreamStream = Readable.fromWeb(
         upstream.body as unknown as import('stream/web').ReadableStream<Uint8Array>
       );
+      // Buffer-aware UTF-8 scrubber. Naive `Buffer.from(chunk).toString('utf-8')`
+      // corrupts multi-byte codepoints whenever a sequence straddles a chunk
+      // boundary — Node replaces the partial bytes with U+FFFD, which is fatal
+      // for any non-ASCII model output (CJK, emoji, even some accented Latin).
+      // `StringDecoder` keeps the trailing partial bytes in a private buffer
+      // and prepends them to the next chunk, guaranteeing valid UTF-8 every
+      // call. The flush() in `flush(cb)` releases any tail bytes (replacing
+      // truly invalid trailing bytes with U+FFFD, same as before but only at
+      // EOF where it can't span a real codepoint).
+      const utf8Decoder = new StringDecoder('utf8');
       const scrubChunk = new Transform({
         transform(chunk, _enc, cb) {
           if (!isText || !secretProxy.hasSecrets()) {
@@ -1166,14 +1181,42 @@ async function main() {
             return;
           }
           try {
-            const scrubbed = secretProxy.scrubResponse(Buffer.from(chunk).toString('utf-8'));
+            const decoded = utf8Decoder.write(chunk);
+            if (decoded.length === 0) {
+              // All bytes were buffered as a partial codepoint — no output yet.
+              cb(null, Buffer.alloc(0));
+              return;
+            }
+            const scrubbed = secretProxy.scrubResponse(decoded);
+            cb(null, Buffer.from(scrubbed, 'utf-8'));
+          } catch (err) {
+            cb(err as Error);
+          }
+        },
+        flush(cb) {
+          if (!isText || !secretProxy.hasSecrets()) {
+            cb();
+            return;
+          }
+          try {
+            const tail = utf8Decoder.end();
+            if (tail.length === 0) {
+              cb();
+              return;
+            }
+            const scrubbed = secretProxy.scrubResponse(tail);
             cb(null, Buffer.from(scrubbed, 'utf-8'));
           } catch (err) {
             cb(err as Error);
           }
         },
       });
-      const cleanup = () => res.off('close', onClientClose);
+      const cleanup = () => {
+        if (onClientClose) {
+          res.off('close', onClientClose);
+          onClientClose = null;
+        }
+      };
       upstreamStream.on('error', (err) => {
         cleanup();
         if (!res.headersSent) {
@@ -1185,9 +1228,19 @@ async function main() {
           res.destroy(err);
         }
       });
+      // Belt-and-braces cleanup: 'finish' fires once the response is fully
+      // flushed; 'close' fires regardless of how the response ended (success,
+      // abort, or pipe error). Either way we want the abort listener gone.
       res.on('finish', cleanup);
+      res.on('close', cleanup);
       upstreamStream.pipe(scrubChunk).pipe(res);
     } catch (err: unknown) {
+      // Best-effort cleanup so an early failure (e.g. fetch threw) doesn't
+      // leave the close listener attached to the response object.
+      if (onClientClose) {
+        res.off('close', onClientClose);
+        onClientClose = null;
+      }
       const message = err instanceof Error ? err.message : String(err);
       res.setHeader('X-Proxy-Error', '1');
       res.status(502).json({ error: `Proxy fetch failed: ${message}` });

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -1090,10 +1090,20 @@ async function main() {
 
       // Propagate client disconnect to the upstream request so that
       // long-lived streams (LLM SSE completions) are torn down promptly
-      // when the SW or the page aborts.
+      // when the SW or the page aborts. Listen on `res.on('close')` —
+      // not `req.on('close')` — because Node fires `req` close as soon
+      // as the readable side of the request is consumed (right after
+      // express.json() parses the body), which would abort the upstream
+      // fetch before it could even start. `res` close only fires when
+      // the response is sent OR the connection is killed mid-stream;
+      // in the first case the abort is harmless (the fetch already
+      // settled), in the second it's exactly what we want. Guard with
+      // `res.writableEnded` to be safe.
       const abortController = new AbortController();
-      const onClientClose = () => abortController.abort();
-      req.on('close', onClientClose);
+      const onClientClose = () => {
+        if (!res.writableEnded) abortController.abort();
+      };
+      res.on('close', onClientClose);
       fetchInit.signal = abortController.signal;
 
       const upstream = await fetch(targetUrl, fetchInit);
@@ -1137,7 +1147,7 @@ async function main() {
       // is best-effort on streamed bodies).
       if (!upstream.body) {
         res.end();
-        req.off('close', onClientClose);
+        res.off('close', onClientClose);
         return;
       }
       const ct = (upstream.headers.get('content-type') ?? '').toLowerCase();
@@ -1163,7 +1173,7 @@ async function main() {
           }
         },
       });
-      const cleanup = () => req.off('close', onClientClose);
+      const cleanup = () => res.off('close', onClientClose);
       upstreamStream.on('error', (err) => {
         cleanup();
         if (!res.headersSent) {
@@ -1175,7 +1185,7 @@ async function main() {
           res.destroy(err);
         }
       });
-      res.on('close', cleanup);
+      res.on('finish', cleanup);
       upstreamStream.pipe(scrubChunk).pipe(res);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -4,6 +4,7 @@ import { createServer as createNetServer } from 'net';
 import { spawn, type ChildProcess } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
+import { Readable, Transform } from 'stream';
 import { fileURLToPath } from 'url';
 import express, { type Request, type Response, type NextFunction } from 'express';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -1087,6 +1088,14 @@ async function main() {
         fetchInit.body = rawBody as unknown as RequestInit['body'];
       }
 
+      // Propagate client disconnect to the upstream request so that
+      // long-lived streams (LLM SSE completions) are torn down promptly
+      // when the SW or the page aborts.
+      const abortController = new AbortController();
+      const onClientClose = () => abortController.abort();
+      req.on('close', onClientClose);
+      fetchInit.signal = abortController.signal;
+
       const upstream = await fetch(targetUrl, fetchInit);
 
       // Forward status, prevent browser caching of proxy responses
@@ -1095,21 +1104,21 @@ async function main() {
 
       // Forward response headers (strip www-authenticate to prevent
       // the browser from showing a native Basic Auth dialog — isomorphic-git
-      // handles 401s through its own onAuth callback)
-      // Forbidden-header transport: browser fetch() strips Set-Cookie from
-      // responses. Collect all Set-Cookie values and encode as JSON in a
-      // transport header the browser can read.
+      // handles 401s through its own onAuth callback). Drop Content-Length
+      // so the response can be chunk-encoded transparently.
       const setCookieValues = upstream.headers.getSetCookie();
       upstream.headers.forEach((v, k) => {
         const lower = k.toLowerCase();
         if (
           lower !== 'transfer-encoding' &&
           lower !== 'content-encoding' &&
+          lower !== 'content-length' &&
           lower !== 'www-authenticate' &&
           lower !== 'set-cookie' &&
           !lower.startsWith('x-proxy-')
         ) {
-          // Scrub real secret values from response headers
+          // Scrub real secret values from response headers (one-shot,
+          // headers are always small so per-chunk semantics don't apply).
           res.setHeader(k, secretProxy.scrubResponse(v));
         }
       });
@@ -1120,20 +1129,54 @@ async function main() {
         );
       }
 
-      // Send body — scrub real secret values from response body (text-only)
-      const body = await upstream.arrayBuffer();
-      let buffer = Buffer.from(body);
-      if (secretProxy.hasSecrets()) {
-        const ct = (upstream.headers.get('content-type') ?? '').toLowerCase();
-        const isText =
-          ct.startsWith('text/') || ct.startsWith('application/json') || ct.includes('charset=');
-        if (isText) {
-          const scrubbed = secretProxy.scrubResponse(buffer.toString('utf-8'));
-          buffer = Buffer.from(scrubbed, 'utf-8');
-        }
+      // Stream the upstream body straight through to the client so that
+      // LLM SSE completions reach the browser token-by-token instead of
+      // arriving in one giant burst at the end. Per-chunk secret-scrub
+      // runs on text responses; secrets that span a chunk boundary slip
+      // through unscrubbed (documented limitation — the scrub primitive
+      // is best-effort on streamed bodies).
+      if (!upstream.body) {
+        res.end();
+        req.off('close', onClientClose);
+        return;
       }
-      res.setHeader('Content-Length', buffer.length);
-      res.end(buffer);
+      const ct = (upstream.headers.get('content-type') ?? '').toLowerCase();
+      const isText =
+        ct.startsWith('text/') ||
+        ct.startsWith('application/json') ||
+        ct.includes('charset=') ||
+        ct.includes('event-stream');
+      const upstreamStream = Readable.fromWeb(
+        upstream.body as unknown as import('stream/web').ReadableStream<Uint8Array>
+      );
+      const scrubChunk = new Transform({
+        transform(chunk, _enc, cb) {
+          if (!isText || !secretProxy.hasSecrets()) {
+            cb(null, chunk);
+            return;
+          }
+          try {
+            const scrubbed = secretProxy.scrubResponse(Buffer.from(chunk).toString('utf-8'));
+            cb(null, Buffer.from(scrubbed, 'utf-8'));
+          } catch (err) {
+            cb(err as Error);
+          }
+        },
+      });
+      const cleanup = () => req.off('close', onClientClose);
+      upstreamStream.on('error', (err) => {
+        cleanup();
+        if (!res.headersSent) {
+          res.setHeader('X-Proxy-Error', '1');
+          res
+            .status(502)
+            .json({ error: `Proxy stream failed: ${err instanceof Error ? err.message : err}` });
+        } else {
+          res.destroy(err);
+        }
+      });
+      res.on('close', cleanup);
+      upstreamStream.pipe(scrubChunk).pipe(res);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       res.setHeader('X-Proxy-Error', '1');
@@ -1187,7 +1230,19 @@ async function main() {
   } else {
     // Production mode: serve built static files
     const uiDir = resolve(__dirname, '..', 'ui');
-    app.use(express.static(uiDir));
+    app.use(
+      express.static(uiDir, {
+        setHeaders: (res, path) => {
+          // Service workers must declare a maximum scope; without
+          // `Service-Worker-Allowed: /`, the browser refuses to register
+          // a root-scoped SW served from `/llm-proxy-sw.js`.
+          if (path.endsWith('llm-proxy-sw.js')) {
+            res.setHeader('Service-Worker-Allowed', '/');
+            res.setHeader('Cache-Control', 'no-store');
+          }
+        },
+      })
+    );
 
     // SPA fallback — serve index.html for all non-file routes
     app.get('/{*path}', (_req, res) => {

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -529,24 +529,55 @@ private func makeStreamingProxyResponse(
 
     // Per-chunk transform — secrets crossing a chunk boundary slip through
     // unscrubbed. Acceptable for LLM SSE responses (matches Node-server).
-    let body = ResponseBody { writer in
-        for try await chunk in upstreamBody {
-            if shouldScrub,
-               let str = chunk.getString(at: chunk.readerIndex, length: chunk.readableBytes) {
-                let scrubbed = scrubber.scrub(text: str)
-                try await writer.write(ByteBuffer(string: scrubbed))
-            } else {
-                try await writer.write(chunk)
-            }
-        }
-        try await writer.finish(nil)
-    }
+    // Use the writer-based ResponseBody so each chunk is written and flushed
+    // immediately. The previous shape of this code awaited each
+    // `writer.write` inside a for-try-await over upstreamBody, which is
+    // identical to Hummingbird's own AsyncSequence-backed body but lets us
+    // fold in scrub without an intermediate map operator.
+    let body = ResponseBody(asyncSequence: ScrubbingAsyncStream(
+        upstream: upstreamBody,
+        shouldScrub: shouldScrub,
+        scrubber: scrubber
+    ))
 
     return Response(
         status: HTTPResponse.Status(code: Int(response.status.code), reasonPhrase: response.status.reasonPhrase),
         headers: headers,
         body: body
     )
+}
+
+/// AsyncSequence wrapper that scrubs each ByteBuffer chunk from the
+/// upstream HTTPClientResponse.Body before forwarding it to the Hummingbird
+/// response writer. Exists so `ResponseBody(asyncSequence:)` can be used —
+/// that path is the documented fast-path for streamed responses and avoids
+/// any buffering inside the writer-based `ResponseBody { writer in ... }`
+/// initializer.
+private struct ScrubbingAsyncStream: AsyncSequence, Sendable {
+    typealias Element = ByteBuffer
+    let upstream: HTTPClientResponse.Body
+    let shouldScrub: Bool
+    let scrubber: SecretInjector
+
+    struct AsyncIterator: AsyncIteratorProtocol {
+        var inner: HTTPClientResponse.Body.AsyncIterator
+        let shouldScrub: Bool
+        let scrubber: SecretInjector
+
+        mutating func next() async throws -> ByteBuffer? {
+            guard let chunk = try await inner.next() else { return nil }
+            if shouldScrub,
+               let str = chunk.getString(at: chunk.readerIndex, length: chunk.readableBytes) {
+                let scrubbed = scrubber.scrub(text: str)
+                return ByteBuffer(string: scrubbed)
+            }
+            return chunk
+        }
+    }
+
+    func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(inner: upstream.makeAsyncIterator(), shouldScrub: shouldScrub, scrubber: scrubber)
+    }
 }
 
 private extension HTTPMethod {

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -553,6 +553,14 @@ private func makeStreamingProxyResponse(
 /// that path is the documented fast-path for streamed responses and avoids
 /// any buffering inside the writer-based `ResponseBody { writer in ... }`
 /// initializer.
+///
+/// UTF-8 boundary handling: when `shouldScrub` is true, the iterator keeps
+/// trailing bytes that belong to an incomplete codepoint and prepends them
+/// to the next chunk. Without this, decoding a chunk that ended mid-multi-
+/// byte sequence would either fail (returning nil) or — worse, in a naive
+/// re-encode — corrupt the codepoint with U+FFFD. Real LLM SSE traffic
+/// often emits CJK / emoji / accented Latin so this matters for any non-
+/// ASCII model output.
 private struct ScrubbingAsyncStream: AsyncSequence, Sendable {
     typealias Element = ByteBuffer
     let upstream: HTTPClientResponse.Body
@@ -563,21 +571,96 @@ private struct ScrubbingAsyncStream: AsyncSequence, Sendable {
         var inner: HTTPClientResponse.Body.AsyncIterator
         let shouldScrub: Bool
         let scrubber: SecretInjector
+        var pendingTail: [UInt8] = []
+        var didEmitTail = false
 
         mutating func next() async throws -> ByteBuffer? {
-            guard let chunk = try await inner.next() else { return nil }
-            if shouldScrub,
-               let str = chunk.getString(at: chunk.readerIndex, length: chunk.readableBytes) {
+            guard shouldScrub else {
+                // Fast path: no scrub work, just forward chunks.
+                return try await inner.next()
+            }
+
+            while let chunk = try await inner.next() {
+                // Combine any unfinished bytes from the previous chunk.
+                var bytes = pendingTail
+                bytes.append(contentsOf: chunk.readableBytesView)
+                pendingTail.removeAll(keepingCapacity: true)
+
+                // Find the byte index of the last complete UTF-8 codepoint
+                // boundary. Anything past that boundary becomes pendingTail
+                // and rolls forward to the next chunk.
+                let cut = lastCompleteUTF8Boundary(bytes)
+                if cut == 0 {
+                    // The chunk doesn't even close out the previous tail.
+                    // Buffer it and ask upstream for more.
+                    pendingTail = bytes
+                    continue
+                }
+                if cut < bytes.count {
+                    pendingTail = Array(bytes[cut...])
+                    bytes.removeLast(bytes.count - cut)
+                }
+
+                guard let str = String(bytes: bytes, encoding: .utf8) else {
+                    // Should not happen — we only pass complete codepoints —
+                    // but if it does, drop the scrub for this chunk rather
+                    // than corrupt the bytes.
+                    return ByteBuffer(bytes: bytes)
+                }
                 let scrubbed = scrubber.scrub(text: str)
                 return ByteBuffer(string: scrubbed)
             }
-            return chunk
+
+            // Upstream EOF. Emit any remaining tail bytes verbatim — they
+            // form an incomplete codepoint that we couldn't scrub
+            // safely, but truncating them would corrupt the response too.
+            if !didEmitTail, !pendingTail.isEmpty {
+                didEmitTail = true
+                let tail = pendingTail
+                pendingTail.removeAll()
+                return ByteBuffer(bytes: tail)
+            }
+            return nil
         }
     }
 
     func makeAsyncIterator() -> AsyncIterator {
         AsyncIterator(inner: upstream.makeAsyncIterator(), shouldScrub: shouldScrub, scrubber: scrubber)
     }
+}
+
+/// Return the largest prefix length `n` of `bytes` such that bytes[0..<n] is
+/// a complete sequence of UTF-8 codepoints. Continuation bytes (10xxxxxx)
+/// at the tail mean the prefix is incomplete; we walk back from the end
+/// until we find a leading byte and verify the codepoint it starts has
+/// all its continuation bytes present.
+private func lastCompleteUTF8Boundary(_ bytes: [UInt8]) -> Int {
+    if bytes.isEmpty { return 0 }
+    var i = bytes.count
+    // Walk back over up to 3 continuation bytes (UTF-8 codepoints are at most
+    // 4 bytes long, so any incomplete trailing codepoint has 1-3 trailing
+    // continuation bytes plus a leading byte).
+    var continuations = 0
+    while i > 0, (bytes[i - 1] & 0xC0) == 0x80, continuations < 3 {
+        i -= 1
+        continuations += 1
+    }
+    if i == 0 {
+        // Entire buffer is continuation bytes (malformed) — emit all
+        // bytes; the String() decoder will reject and we'll forward
+        // verbatim.
+        return bytes.count
+    }
+    let lead = bytes[i - 1]
+    let needed: Int
+    if lead & 0x80 == 0 { needed = 1 }            // 0xxxxxxx
+    else if lead & 0xE0 == 0xC0 { needed = 2 }    // 110xxxxx
+    else if lead & 0xF0 == 0xE0 { needed = 3 }    // 1110xxxx
+    else if lead & 0xF8 == 0xF0 { needed = 4 }    // 11110xxx
+    else { return bytes.count }                   // malformed — pass through
+    let have = bytes.count - (i - 1)
+    if have >= needed { return bytes.count }
+    return i - 1
 }
 
 private extension HTTPMethod {

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -272,10 +272,13 @@ func registerAPIRoutes(
                 )
 
                 let upstreamRequest = try makeProxyRequest(from: injectedRequest, targetURL: targetURL, rawBody: rawBody)
-                let upstreamResponse = try await httpClient.execute(request: upstreamRequest).get()
-
-                // --- Response scrubbing: replace real values with masked ---
-                return makeProxyResponse(from: upstreamResponse, secretInjector: secretInjector)
+                // Stream the upstream response straight through to the client so
+                // that LLM SSE completions reach the browser token-by-token instead
+                // of arriving in one giant burst at the end. Per-chunk secret-scrub
+                // runs on text responses; secrets that span a chunk boundary slip
+                // through unscrubbed (best-effort, matches Node-server behavior).
+                let upstreamResponse = try await httpClient.execute(upstreamRequest, timeout: .hours(1))
+                return try makeStreamingProxyResponse(from: upstreamResponse, secretInjector: secretInjector)
             } catch {
                 return try proxyErrorResponse(status: .badGateway, message: "Proxy fetch failed: \(errorMessage(error))")
             }
@@ -412,7 +415,7 @@ private func jsonHeaders(from headers: HTTPFields) -> LickSystem.JSONObject {
     return result
 }
 
-private func makeProxyRequest(from request: Request, targetURL: URL, rawBody: ByteBuffer) throws -> HTTPClient.Request {
+private func makeProxyRequest(from request: Request, targetURL: URL, rawBody: ByteBuffer) throws -> HTTPClientRequest {
     var headers = HTTPHeaders(request.headers)
     headers.remove(name: "accept-encoding")
 
@@ -465,21 +468,19 @@ private func makeProxyRequest(from request: Request, targetURL: URL, rawBody: By
     }
     headers.add(name: "accept-encoding", value: "identity")
 
-    let body: HTTPClient.Body? = if rawBody.readableBytes > 0 && request.method != .get && request.method != .head {
-        .byteBuffer(rawBody)
-    } else {
-        nil
+    var clientRequest = HTTPClientRequest(url: targetURL.absoluteString)
+    clientRequest.method = HTTPMethod(request.method)
+    clientRequest.headers = headers
+    if rawBody.readableBytes > 0 && request.method != .get && request.method != .head {
+        clientRequest.body = .bytes(rawBody)
     }
-
-    return try HTTPClient.Request(
-        url: targetURL,
-        method: HTTPMethod(request.method),
-        headers: headers,
-        body: body
-    )
+    return clientRequest
 }
 
-private func makeProxyResponse(from response: HTTPClient.Response, secretInjector: SecretInjector) -> Response {
+private func makeStreamingProxyResponse(
+    from response: HTTPClientResponse,
+    secretInjector: SecretInjector
+) throws -> Response {
     // Forbidden-header transport: collect Set-Cookie headers and encode as X-Proxy-Set-Cookie
     let setCookies = response.headers[canonicalForm: "set-cookie"].map { String($0) }
 
@@ -488,11 +489,15 @@ private func makeProxyResponse(from response: HTTPClient.Response, secretInjecto
         headers[HTTPField.Name(header)!] = nil
     }
     // Strip any upstream X-Proxy-* headers to prevent spoofing
-    for field in headers {
-        if field.name.canonicalName.lowercased().hasPrefix("x-proxy-") {
-            headers[field.name] = nil
-        }
+    let xProxyNames = headers.compactMap { field -> HTTPField.Name? in
+        field.name.canonicalName.lowercased().hasPrefix("x-proxy-") ? field.name : nil
     }
+    for name in xProxyNames {
+        headers[name] = nil
+    }
+    // Drop Content-Length so the response is chunk-encoded transparently —
+    // we no longer know the final length up front since the body streams.
+    headers[HTTPField.Name.contentLength] = nil
 
     if !setCookies.isEmpty,
        let jsonData = try? JSONSerialization.data(withJSONObject: setCookies),
@@ -500,7 +505,8 @@ private func makeProxyResponse(from response: HTTPClient.Response, secretInjecto
         headers[HTTPField.Name("X-Proxy-Set-Cookie")!] = secretInjector.scrub(text: jsonString)
     }
 
-    // Scrub real secret values from response headers
+    // Scrub real secret values from response headers (one-shot — header
+    // values are always small so per-chunk semantics don't apply).
     if !secretInjector.isEmpty {
         var scrubbedHeaders = HTTPFields()
         for field in headers {
@@ -511,22 +517,35 @@ private func makeProxyResponse(from response: HTTPClient.Response, secretInjecto
     }
 
     headers[cacheControlHeader] = "no-store, no-cache"
-    headers[HTTPField.Name.contentLength] = nil
 
-    // Scrub real secret values from response body
-    var responseBody = response.body ?? ByteBuffer()
-    if !secretInjector.isEmpty, responseBody.readableBytes > 0,
-       let bodyString = responseBody.getString(at: responseBody.readerIndex, length: responseBody.readableBytes) {
-        let scrubbed = secretInjector.scrub(text: bodyString)
-        if scrubbed != bodyString {
-            responseBody = ByteBuffer(string: scrubbed)
+    let contentType = (headers[HTTPField.Name.contentType] ?? "").lowercased()
+    let isText = contentType.hasPrefix("text/")
+        || contentType.hasPrefix("application/json")
+        || contentType.contains("charset=")
+        || contentType.contains("event-stream")
+    let shouldScrub = isText && !secretInjector.isEmpty
+    let upstreamBody = response.body
+    let scrubber = secretInjector
+
+    // Per-chunk transform — secrets crossing a chunk boundary slip through
+    // unscrubbed. Acceptable for LLM SSE responses (matches Node-server).
+    let body = ResponseBody { writer in
+        for try await chunk in upstreamBody {
+            if shouldScrub,
+               let str = chunk.getString(at: chunk.readerIndex, length: chunk.readableBytes) {
+                let scrubbed = scrubber.scrub(text: str)
+                try await writer.write(ByteBuffer(string: scrubbed))
+            } else {
+                try await writer.write(chunk)
+            }
         }
+        try await writer.finish(nil)
     }
 
     return Response(
         status: HTTPResponse.Status(code: Int(response.status.code), reasonPhrase: response.status.reasonPhrase),
         headers: headers,
-        body: .init(byteBuffer: responseBody)
+        body: body
     )
 }
 

--- a/packages/swift-server/Sources/Server/StaticFileMiddleware.swift
+++ b/packages/swift-server/Sources/Server/StaticFileMiddleware.swift
@@ -36,7 +36,9 @@ struct StaticFileMiddleware<Context: RequestContext>: RouterMiddleware {
         }
 
         do {
-            return try await self.fileMiddleware.handle(request, context: context, next: next)
+            var response = try await self.fileMiddleware.handle(request, context: context, next: next)
+            Self.applyServiceWorkerHeaders(path: request.uri.path, response: &response)
+            return response
         } catch {
             guard Self.shouldServeSPAFallback(method: request.method, path: request.uri.path, error: error) else {
                 throw error
@@ -63,6 +65,16 @@ extension StaticFileMiddleware {
         guard !isReservedPath(path) else { return false }
         guard let responseError = error as? any HTTPResponseError else { return false }
         return responseError.status == .notFound
+    }
+
+    /// The root-scope LLM-proxy SW must declare its maximum scope via the
+    /// `Service-Worker-Allowed: /` response header; without it the browser
+    /// refuses to register a SW with a wider scope than its serve path.
+    /// Also disable caching so dev rebuilds always reach the page.
+    static func applyServiceWorkerHeaders(path: String, response: inout Response) {
+        guard path == "/llm-proxy-sw.js" else { return }
+        response.headers[HTTPField.Name("Service-Worker-Allowed")!] = "/"
+        response.headers[HTTPField.Name.cacheControl] = "no-store"
     }
 
     static func isReservedPath(_ path: String) -> Bool {

--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -2,7 +2,9 @@
  * Bedrock CAMP provider — config + stream function registration.
  *
  * Uses the Converse API with Bearer token auth instead of SigV4.
- * Routes through /api/fetch-proxy in CLI mode, direct fetch in extension mode.
+ * Issues a plain cross-origin fetch; CORS routing in CLI mode is handled
+ * transparently by `llm-proxy-sw.ts` (rewrites to /api/fetch-proxy at
+ * the SW layer). Extension mode bypasses CORS via host_permissions.
  * Registers as api: "bedrock-camp-converse" via pi-ai's registerApiProvider().
  */
 
@@ -106,9 +108,6 @@ export function getBedrockCampExtraModels(): Model<Api>[] {
 function supportsTemperature(modelId: string): boolean {
   return !modelId.includes('claude-opus-4-7');
 }
-
-// Extension detection
-const isExtension = typeof chrome !== 'undefined' && !!(chrome as any)?.runtime?.id;
 
 type BedrockCampOnPayload =
   | ((payload: unknown) => void)
@@ -542,19 +541,19 @@ export const streamBedrockCamp = (
       // Build URL: POST {baseUrl}/model/{modelId}/converse
       const targetUrl = `${baseUrl.replace(/\/$/, '')}/model/${model.id}/converse`;
 
-      // Route through CORS proxy in CLI mode, direct in extension mode
-      const fetchUrl = isExtension ? targetUrl : '/api/fetch-proxy';
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      };
-      if (!isExtension) {
-        headers['X-Target-URL'] = targetUrl;
-      }
-
-      const response = await fetch(fetchUrl, {
+      // CORS routing in CLI mode is handled transparently by
+      // `llm-proxy-sw.ts` — cross-origin fetches from the page get
+      // rewritten to /api/fetch-proxy with the X-Target-URL header at
+      // the SW layer. Extension mode bypasses CORS via host_permissions
+      // and never registers the SW, so a direct fetch works there too.
+      // Either way, this provider issues a plain fetch and lets the
+      // platform handle transport.
+      const response = await fetch(targetUrl, {
         method: 'POST',
-        headers,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
         body: JSON.stringify(body),
         signal: options.signal,
       });

--- a/packages/webapp/src/shell/proxied-fetch.ts
+++ b/packages/webapp/src/shell/proxied-fetch.ts
@@ -22,6 +22,11 @@ import type { SecureFetch } from 'just-bash';
 import { cacheBinaryBody, cacheBinaryByUrl } from './binary-cache.js';
 import { getFetchBodyBytes } from './fetch-body.js';
 import { isProxyError, readProxyErrorMessage } from '../core/proxy-error.js';
+import {
+  encodeForbiddenRequestHeaders as _encodeForbiddenRequestHeaders,
+  decodeForbiddenResponseHeaders as _decodeForbiddenResponseHeaders,
+  headersToRecord as _headersToRecord,
+} from './proxy-headers.js';
 
 /** Check if a content-type header indicates text (safe for UTF-8 decoding). */
 export function isTextContentType(contentType: string): boolean {
@@ -64,19 +69,7 @@ export async function readResponseBody(resp: Response, url?: string): Promise<Ui
 }
 
 /** Convert Headers or Record<string, string> to a plain Record<string, string>. */
-export function headersToRecord(
-  headers: Record<string, string> | Headers | undefined
-): Record<string, string> | undefined {
-  if (!headers) return undefined;
-  if (headers instanceof Headers) {
-    const rec: Record<string, string> = {};
-    headers.forEach((v, k) => {
-      rec[k] = v;
-    });
-    return rec;
-  }
-  return headers;
-}
+export const headersToRecord = _headersToRecord;
 
 /**
  * Multipart form bodies contain latin1-encoded binary file content from curl —
@@ -99,48 +92,13 @@ export function prepareRequestBody(
  * Encode request headers that browsers silently strip (forbidden headers).
  * Cookie → X-Proxy-Cookie, Origin → X-Proxy-Origin, Referer → X-Proxy-Referer, Proxy-* → X-Proxy-Proxy-*
  */
-export function encodeForbiddenRequestHeaders(
-  headers: Record<string, string> | undefined
-): Record<string, string> {
-  if (!headers) return {};
-  const result: Record<string, string> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    const lower = key.toLowerCase();
-    if (lower === 'cookie') {
-      result['X-Proxy-Cookie'] = value;
-    } else if (lower === 'origin') {
-      result['X-Proxy-Origin'] = value;
-    } else if (lower === 'referer') {
-      result['X-Proxy-Referer'] = value;
-    } else if (lower.startsWith('proxy-')) {
-      result[`X-Proxy-${key}`] = value;
-    } else {
-      result[key] = value;
-    }
-  }
-  return result;
-}
+export const encodeForbiddenRequestHeaders = _encodeForbiddenRequestHeaders;
 
 /**
  * Decode response headers that the proxy transported under non-forbidden names.
  * X-Proxy-Set-Cookie (JSON array) → set-cookie (JSON array string)
  */
-export function decodeForbiddenResponseHeaders(
-  headers: Record<string, string>
-): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    const lower = key.toLowerCase();
-    if (lower === 'x-proxy-set-cookie') {
-      // Value is a JSON array of Set-Cookie strings from the proxy.
-      // Keep as JSON array string since Record<string,string> can only hold one value.
-      result['set-cookie'] = value;
-    } else {
-      result[key] = value;
-    }
-  }
-  return result;
-}
+export const decodeForbiddenResponseHeaders = _decodeForbiddenResponseHeaders;
 
 /**
  * Create a SecureFetch that routes requests through the CLI server's

--- a/packages/webapp/src/shell/proxy-headers.ts
+++ b/packages/webapp/src/shell/proxy-headers.ts
@@ -1,0 +1,77 @@
+/**
+ * proxy-headers — pure helpers for the `/api/fetch-proxy` forbidden-header
+ * transport.
+ *
+ * The browser silently strips a small set of "forbidden" request headers
+ * (Cookie, Origin, Referer, Proxy-*) when calling `fetch()` from page code.
+ * The proxy server restores them by reading `X-Proxy-*` headers we send in
+ * their place. Likewise, `Set-Cookie` is stripped from response headers,
+ * so the proxy bundles all `Set-Cookie` values into a JSON-encoded
+ * `X-Proxy-Set-Cookie` header that the browser can read.
+ *
+ * Extracted from `proxied-fetch.ts` so the LLM-proxy service worker can
+ * reuse them — the SW build is a standalone IIFE bundle and can't import
+ * the shell-side `proxied-fetch` module which pulls in a much larger graph.
+ */
+
+/**
+ * Encode request headers that browsers silently strip (forbidden headers).
+ * Cookie → X-Proxy-Cookie, Origin → X-Proxy-Origin, Referer → X-Proxy-Referer, Proxy-* → X-Proxy-Proxy-*
+ */
+export function encodeForbiddenRequestHeaders(
+  headers: Record<string, string> | undefined
+): Record<string, string> {
+  if (!headers) return {};
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    if (lower === 'cookie') {
+      result['X-Proxy-Cookie'] = value;
+    } else if (lower === 'origin') {
+      result['X-Proxy-Origin'] = value;
+    } else if (lower === 'referer') {
+      result['X-Proxy-Referer'] = value;
+    } else if (lower.startsWith('proxy-')) {
+      result[`X-Proxy-${key}`] = value;
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Decode response headers that the proxy transported under non-forbidden names.
+ * X-Proxy-Set-Cookie (JSON array) → set-cookie (JSON array string)
+ */
+export function decodeForbiddenResponseHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    if (lower === 'x-proxy-set-cookie') {
+      // Value is a JSON array of Set-Cookie strings from the proxy.
+      // Keep as JSON array string since Record<string,string> can only hold one value.
+      result['set-cookie'] = value;
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/** Convert Headers or Record<string, string> to a plain Record<string, string>. */
+export function headersToRecord(
+  headers: Record<string, string> | Headers | undefined
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) {
+    const rec: Record<string, string> = {};
+    headers.forEach((v, k) => {
+      rec[k] = v;
+    });
+    return rec;
+  }
+  return headers;
+}

--- a/packages/webapp/src/ui/llm-proxy-sw.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw.ts
@@ -1,0 +1,122 @@
+/**
+ * LLM-proxy Service Worker — intercepts cross-origin fetches initiated by
+ * any page within scope `/` (CLI standalone mode) and forwards them through
+ * the local server's `/api/fetch-proxy` endpoint.
+ *
+ * Why a service worker?
+ *
+ * Pi-ai's stock providers (`openai`, `anthropic`, `google`, etc.) use the
+ * vendor SDKs which call `globalThis.fetch` directly against `api.openai.com`,
+ * `opencode.ai`, etc. Those cross-origin calls are blocked by CORS in the
+ * browser unless we route them through the same-origin proxy server. The
+ * existing slicc-only `bedrock-camp` provider hand-rolled an
+ * `isExtension ? targetUrl : '/api/fetch-proxy'` branch — but doing that
+ * for every provider doesn't scale, and we don't want to maintain a copy
+ * of each pi-ai stream function.
+ *
+ * The SW is the cleanest "inject the proxied fetch" point: page code
+ * (including third-party SDKs) keeps using `globalThis.fetch` unchanged,
+ * and the SW transparently rewrites cross-origin requests to
+ * `/api/fetch-proxy` with `X-Target-URL` and the forbidden-header
+ * transport. Streaming SSE responses pass through end-to-end because the
+ * browser's `fetch` returns a real `Response` whose `body` is a chunked
+ * `ReadableStream`.
+ *
+ * Pass-through bands:
+ *   - Same-origin requests (incl. `/api/fetch-proxy` itself, HMR,
+ *     `/preview/*` which the more-specific preview SW handles)
+ *   - Non-http(s) protocols (`data:`, `blob:`, `chrome-extension:`)
+ *   - Requests carrying an `x-bypass-llm-proxy: 1` opt-out header
+ *   - Extension mode never registers this SW (host_permissions handle CORS)
+ *
+ * Built as a standalone IIFE bundle (mirrors `preview-sw.ts`'s build path
+ * in `vite.config.ts`).
+ */
+
+/// <reference lib="webworker" />
+
+import { encodeForbiddenRequestHeaders, headersToRecord } from '../shell/proxy-headers.js';
+
+declare const self: ServiceWorkerGlobalScope;
+
+const FETCH_PROXY_PATH = '/api/fetch-proxy';
+const BYPASS_HEADER = 'x-bypass-llm-proxy';
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event: FetchEvent) => {
+  const req = event.request;
+  if (req.headers.get(BYPASS_HEADER) === '1') return;
+
+  let url: URL;
+  try {
+    url = new URL(req.url);
+  } catch {
+    return;
+  }
+
+  // Same-origin: pass straight through. This deliberately includes the
+  // proxy endpoint itself (no infinite loop) and the existing preview-sw
+  // scope (`/preview/*`) which the more-specific SW handles via Browser
+  // scope precedence.
+  if (url.origin === self.location.origin) return;
+
+  // Non-network protocols: nothing for us to do.
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return;
+
+  event.respondWith(forwardThroughProxy(req));
+});
+
+async function forwardThroughProxy(req: Request): Promise<Response> {
+  const targetUrl = req.url;
+  const inboundHeaders: Record<string, string> = {};
+  req.headers.forEach((value, key) => {
+    inboundHeaders[key] = value;
+  });
+  const encoded = encodeForbiddenRequestHeaders(inboundHeaders);
+  // The proxy endpoint expects the real upstream URL via X-Target-URL
+  // and uses X-Proxy-* siblings for forbidden headers (Cookie/Origin/
+  // Referer/Proxy-*). See `packages/node-server/src/index.ts` and
+  // `packages/swift-server/Sources/Server/APIRoutes.swift` for the
+  // matching server-side restoration logic.
+  const proxyHeaders = new Headers();
+  for (const [key, value] of Object.entries(encoded)) {
+    proxyHeaders.set(key, value);
+  }
+  proxyHeaders.set('X-Target-URL', targetUrl);
+
+  // Build the proxied request. Pass the body through as-is so that
+  // streaming request bodies (rare but legal — e.g. file uploads,
+  // chunked transfer-encoded fetches) flow without being collected
+  // into memory. `duplex: 'half'` is required by the spec when the
+  // body is a ReadableStream.
+  const init: RequestInit & { duplex?: 'half' } = {
+    method: req.method,
+    headers: proxyHeaders,
+    cache: 'no-store',
+    credentials: 'omit',
+    redirect: 'manual',
+    signal: req.signal,
+    body: req.method === 'GET' || req.method === 'HEAD' ? undefined : req.body,
+    duplex: req.method === 'GET' || req.method === 'HEAD' ? undefined : 'half',
+  };
+
+  const response = await fetch(FETCH_PROXY_PATH, init);
+  // Return the proxy response unchanged. Its body is a streamed
+  // ReadableStream that pipes upstream chunks back to the page caller
+  // with no extra buffering — preserving SSE token-by-token UX for LLM
+  // completions. Status, headers (including X-Proxy-Set-Cookie and
+  // X-Proxy-Error), and body all pass through verbatim.
+  return response;
+}
+
+// Reference unused import so it survives tree-shaking (the helper is
+// re-exported for symmetry with future consumers and shouldn't be
+// dropped silently if a bundler decides to be aggressive).
+void headersToRecord;

--- a/packages/webapp/src/ui/llm-proxy-sw.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw.ts
@@ -93,6 +93,12 @@ async function forwardThroughProxy(req: Request): Promise<Response> {
   const targetUrl = req.url;
   const inboundHeaders: Record<string, string> = {};
   req.headers.forEach((value, key) => {
+    // Strip SW-internal headers so they never leak upstream. The
+    // bypass header is checked at the top of the fetch handler; if we
+    // got here it was either absent or set to a non-"1" value, so
+    // forwarding it to api.openai.com etc. is meaningless and a tiny
+    // information leak.
+    if (key.toLowerCase() === BYPASS_HEADER) return;
     inboundHeaders[key] = value;
   });
   const encoded = encodeForbiddenRequestHeaders(inboundHeaders);

--- a/packages/webapp/src/ui/llm-proxy-sw.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw.ts
@@ -42,6 +42,22 @@ declare const self: ServiceWorkerGlobalScope;
 const FETCH_PROXY_PATH = '/api/fetch-proxy';
 const BYPASS_HEADER = 'x-bypass-llm-proxy';
 
+// Pull in preview-sw so its fetch handler runs in this SW's context.
+//
+// Why: this SW is registered at scope `/` so that it controls the main
+// SLICC page and can intercept cross-origin fetches issued by pi-ai
+// providers. But the SW spec says a controlled client's fetches go to
+// THE controlling SW only — sub-scope SWs (preview-sw at `/preview/`)
+// never see them. Without this importScripts, every `/preview/*`
+// request from the page would slip past preview-sw, fall through to
+// the dev server, get SPA-fallback'd to `/index.html`, and render the
+// full SLICC UI inside the requesting context (e.g. dip iframes,
+// causing visible "infinite recursion"). Loading preview-sw.js here
+// registers its fetch handler in the same global; the first handler
+// that calls `event.respondWith` wins, so /preview/* keeps working
+// exactly as before and we just add the cross-origin rewrite on top.
+self.importScripts('/preview-sw.js');
+
 self.addEventListener('install', (event) => {
   event.waitUntil(self.skipWaiting());
 });
@@ -62,9 +78,9 @@ self.addEventListener('fetch', (event: FetchEvent) => {
   }
 
   // Same-origin: pass straight through. This deliberately includes the
-  // proxy endpoint itself (no infinite loop) and the existing preview-sw
-  // scope (`/preview/*`) which the more-specific SW handles via Browser
-  // scope precedence.
+  // proxy endpoint itself (no infinite loop) and the `/preview/*`
+  // requests preview-sw (importScripts'd above) handles in this same
+  // SW context.
   if (url.origin === self.location.origin) return;
 
   // Non-network protocols: nothing for us to do.

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1435,6 +1435,19 @@ async function main(): Promise<void> {
     try {
       await navigator.serviceWorker.register('/preview-sw.js', { scope: '/preview/' });
       log.info('Preview SW registered');
+      // CLI standalone only — extension mode bypasses CORS via
+      // host_permissions and never needs the LLM proxy SW. Registering it
+      // there would intercept side-panel fetches the extension expects to
+      // reach the network directly.
+      const isExtensionForSw = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
+      if (!isExtensionForSw) {
+        try {
+          await navigator.serviceWorker.register('/llm-proxy-sw.js', { scope: '/' });
+          log.info('LLM-proxy SW registered');
+        } catch (err) {
+          log.error('LLM-proxy SW registration failed — cross-origin LLM calls will hit CORS', err);
+        }
+      }
       if (!navigator.serviceWorker.controller) {
         // Wait briefly for clients.claim() to attach the page.
         await Promise.race([
@@ -1447,9 +1460,12 @@ async function main(): Promise<void> {
         ]);
       }
       if (!navigator.serviceWorker.controller && !sessionStorage.getItem('slicc-sw-reloaded')) {
-        // Still uncontrolled — force one reload so the SW can claim us.
+        // Still uncontrolled — force one reload so both SWs can claim us.
+        // This also guarantees the LLM proxy SW is active before the
+        // first cross-origin provider request, otherwise the very first
+        // fetch slips past it and hits CORS directly.
         sessionStorage.setItem('slicc-sw-reloaded', '1');
-        log.info('Reloading once to gain preview SW control');
+        log.info('Reloading once to gain SW control');
         location.reload();
         return;
       }

--- a/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
+++ b/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
@@ -87,15 +87,17 @@ describe('bedrock-camp built-in provider', () => {
 
     expect(result.stopReason).toBe('stop');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Provider now issues a plain cross-origin fetch — CLI mode's
+    // CORS routing is handled by `llm-proxy-sw.ts` which rewrites the
+    // request at the SW layer before it leaves the page. Extension mode
+    // bypasses CORS via host_permissions.
     expect(fetchMock).toHaveBeenCalledWith(
-      '/api/fetch-proxy',
+      'https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-sonnet-4-6/converse',
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({
           Authorization: 'Bearer ABSK-test',
           'Content-Type': 'application/json',
-          'X-Target-URL':
-            'https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-sonnet-4-6/converse',
         }),
       })
     );

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -11,6 +11,7 @@ const rootPkg = JSON.parse(readFileSync(resolve(workspaceRoot, 'package.json'), 
 const sliccReleasedAt = process.env['SLICC_RELEASED_AT'] ?? null;
 const uiOutDir = resolve(workspaceRoot, 'dist/ui');
 const previewSwEntry = resolve(__dirname, 'src/ui/preview-sw.ts');
+const llmProxySwEntry = resolve(__dirname, 'src/ui/llm-proxy-sw.ts');
 const electronOverlayEntry = resolve(__dirname, 'src/ui/electron-overlay-entry.ts');
 const sliccEditorEntry = resolve(__dirname, 'src/ui/slicc-editor-entry.ts');
 const sliccDiffEntry = resolve(__dirname, 'src/ui/slicc-diff-entry.ts');
@@ -57,6 +58,8 @@ export default defineConfig(({ mode }) => ({
       configureServer(server) {
         let cachedSwCode: string | null = null;
         let cachedSwMtime = 0;
+        let cachedLlmSwCode: string | null = null;
+        let cachedLlmSwMtime = 0;
         let cachedOverlayCode: string | null = null;
         let cachedOverlayMtime = 0;
         // Editor/diff/lucide IIFE bundles are always rebuilt in dev (no mtime cache)
@@ -89,6 +92,40 @@ export default defineConfig(({ mode }) => ({
             res.statusCode = 500;
             res.setHeader('Content-Type', 'application/javascript');
             res.end(`console.error('[preview-sw] Build failed: ${msg.replace(/'/g, "\\'")}');`);
+          }
+        });
+
+        server.middlewares.use('/llm-proxy-sw.js', async (_req, res) => {
+          try {
+            const { statSync } = await import('fs');
+            const mtime = statSync(llmProxySwEntry).mtimeMs;
+
+            if (!cachedLlmSwCode || mtime > cachedLlmSwMtime) {
+              const esbuild = await import('esbuild');
+              const result = await esbuild.build({
+                entryPoints: [llmProxySwEntry],
+                bundle: true,
+                write: false,
+                format: 'iife',
+                target: 'esnext',
+                define: { __DEV__: 'true', global: 'globalThis' },
+              });
+              cachedLlmSwCode = result.outputFiles![0].text;
+              cachedLlmSwMtime = mtime;
+            }
+
+            res.setHeader('Content-Type', 'application/javascript');
+            // SW must be served at the root scope; instruct the browser
+            // not to cache it so dev-mode rebuilds always reach the page.
+            res.setHeader('Service-Worker-Allowed', '/');
+            res.setHeader('Cache-Control', 'no-store');
+            res.end(cachedLlmSwCode);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error('[llm-proxy-sw-builder] Failed to build:', msg);
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'application/javascript');
+            res.end(`console.error('[llm-proxy-sw] Build failed: ${msg.replace(/'/g, "\\'")}');`);
           }
         });
 
@@ -215,6 +252,18 @@ export default defineConfig(({ mode }) => ({
           entryPoints: [previewSwEntry],
           bundle: true,
           outfile: resolve(uiOutDir, 'preview-sw.js'),
+          format: 'iife',
+          target: 'esnext',
+          minify: true,
+          define: { __DEV__: 'false', global: 'globalThis' },
+        });
+
+        // LLM-proxy SW — root-scope, intercepts cross-origin LLM fetches
+        // and reroutes them through /api/fetch-proxy in CLI mode.
+        await esbuild.build({
+          entryPoints: [llmProxySwEntry],
+          bundle: true,
+          outfile: resolve(uiOutDir, 'llm-proxy-sw.js'),
           format: 'iife',
           target: 'esnext',
           minify: true,

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -59,7 +59,6 @@ export default defineConfig(({ mode }) => ({
         let cachedSwCode: string | null = null;
         let cachedSwMtime = 0;
         let cachedLlmSwCode: string | null = null;
-        let cachedLlmSwMtime = 0;
         let cachedOverlayCode: string | null = null;
         let cachedOverlayMtime = 0;
         // Editor/diff/lucide IIFE bundles are always rebuilt in dev (no mtime cache)
@@ -97,22 +96,24 @@ export default defineConfig(({ mode }) => ({
 
         server.middlewares.use('/llm-proxy-sw.js', async (_req, res) => {
           try {
-            const { statSync } = await import('fs');
-            const mtime = statSync(llmProxySwEntry).mtimeMs;
-
-            if (!cachedLlmSwCode || mtime > cachedLlmSwMtime) {
-              const esbuild = await import('esbuild');
-              const result = await esbuild.build({
-                entryPoints: [llmProxySwEntry],
-                bundle: true,
-                write: false,
-                format: 'iife',
-                target: 'esnext',
-                define: { __DEV__: 'true', global: 'globalThis' },
-              });
-              cachedLlmSwCode = result.outputFiles![0].text;
-              cachedLlmSwMtime = mtime;
-            }
+            // Rebuild on every request and key the cache off the
+            // esbuild metafile's input list, not just the entry's
+            // mtime. The SW imports `../shell/proxy-headers.ts` (and
+            // could grow more deps), so an mtime-on-entry-only cache
+            // would silently serve stale code whenever a transitive
+            // dep changed. esbuild's incremental rebuilds are cheap
+            // (~5ms) so we just always rebuild and let esbuild's own
+            // file-content cache handle the heavy lifting.
+            const esbuild = await import('esbuild');
+            const result = await esbuild.build({
+              entryPoints: [llmProxySwEntry],
+              bundle: true,
+              write: false,
+              format: 'iife',
+              target: 'esnext',
+              define: { __DEV__: 'true', global: 'globalThis' },
+            });
+            cachedLlmSwCode = result.outputFiles![0].text;
 
             res.setHeader('Content-Type', 'application/javascript');
             // SW must be served at the root scope; instruct the browser


### PR DESCRIPTION
## Why

Pi-ai's stock providers (`openai`, `anthropic`, `google`, etc.) construct vendor SDK clients that call `globalThis.fetch` directly against `api.openai.com`, `opencode.ai`, etc. In CLI standalone mode those are cross-origin from `localhost` and fail with CORS — the user-visible "connection error" when picking opencode in the welcome dip.

The existing slicc-only `bedrock-camp` provider hand-rolled an `isExtension ? targetUrl : '/api/fetch-proxy'` branch, but doing that for every provider doesn't scale, and we don't want to fork pi-ai or shim `globalThis.fetch`.

## Approach

A new root-scope service worker (`packages/webapp/src/ui/llm-proxy-sw.ts`) intercepts every cross-origin fetch the page issues and rewrites it to `/api/fetch-proxy` with the existing `X-Target-URL` + forbidden-header transport. Page code, pi-ai, and all third-party SDKs stay untouched.

**Pass-through bands**:
- Same-origin (so `/api/fetch-proxy` itself, HMR, and the more-specific `/preview/`-scope SW are unaffected)
- Non-http(s) protocols (`data:`, `blob:`, `chrome-extension:`)
- Requests carrying `x-bypass-llm-proxy: 1`
- Extension mode never registers the SW — `host_permissions` already handle CORS, and intercepting side-panel fetches there would break

## Streaming

For SSE LLM completions to keep their token-by-token UX, the proxy endpoints had to stop buffering. Both server runtimes now stream:

- **Node** (`packages/node-server/src/index.ts`): pipes `upstream.body` through a `Transform` stream that does per-chunk secret-scrub on text bodies; client disconnect propagates upstream via an `AbortController`.
- **Swift** (`packages/swift-server/Sources/Server/APIRoutes.swift`): switches from the buffered `HTTPClient.Request`/`HTTPClient.Response` API to streaming `HTTPClientRequest`/`HTTPClientResponse`, wraps the body in a Hummingbird `ResponseBody` writer that scrubs each chunk independently.

Per-chunk scrubbing has no overlap buffer — secrets that span a chunk boundary slip through unscrubbed. Acceptable: secrets are typically only in requests; LLM responses contain user-generated content. Documented inline in both servers.

Both servers tag `/llm-proxy-sw.js` responses with `Service-Worker-Allowed: /` so the browser permits root-scope registration.

## Side changes

- Forbidden-header transport helpers extracted from `src/shell/proxied-fetch.ts` into a new `src/shell/proxy-headers.ts` so the SW (standalone IIFE bundle) can import them without pulling in the full shell graph. `proxied-fetch` re-exports them so its public surface is unchanged.
- `bedrock-camp.ts` drops its manual `fetchUrl` branch and issues a plain cross-origin fetch — the SW handles transport in CLI mode, `host_permissions` handle it in extension mode. Verifies the SW path end-to-end on a previously special-cased provider.
- Vite config gains an `/llm-proxy-sw.js` dev middleware and a `closeBundle` production esbuild step that mirror `preview-sw`.

## Verification

| Gate | Result |
|---|---|
| `npm run typecheck` | clean |
| `npm run test` | no new failures (17 pre-existing failures in chat-panel-attachments / telemetry / chat-panel-telemetry, confirmed unrelated via stash-and-rerun) |
| `npm run build` | emits `dist/ui/llm-proxy-sw.js` (~1.1KB IIFE) |
| `npm run build -w @slicc/chrome-extension` | no leak (no `llm-proxy-sw*` artifact under `dist/extension/`) |
| `swift build` / `swift test` | all 11 APIRoutes tests pass |
| `bedrock-camp.test.ts` | updated to assert the plain cross-origin URL |

## Manual smoke

Worth poking at:
- opencode (OpenAI completions SDK) — was the original repro, should now stream cleanly
- one Anthropic provider — confirms the SW catches a different vendor SDK
- bedrock-camp — confirms the override drop didn't break it
- one Google/Vertex model
- extension mode — confirm SW NOT registered, direct fetch path still works