### PR TITLE
fix(sprinkles): auto-surface installed .shtml files in the rail

### DIFF
--- a/packages/chrome-extension/src/offscreen.ts
+++ b/packages/chrome-extension/src/offscreen.ts
@@ -453,8 +453,33 @@ async function init(): Promise<void> {
   // The real SprinkleManager runs in the side panel (needs DOM). This proxy relays
   // operations via BroadcastChannel.
   const { createSprinkleManagerProxy } = await import('./sprinkle-proxy.js');
-  (globalThis as unknown as Record<string, unknown>).__slicc_sprinkleManager =
-    createSprinkleManagerProxy();
+  const sprinkleManagerProxy = createSprinkleManagerProxy();
+  (globalThis as unknown as Record<string, unknown>).__slicc_sprinkleManager = sprinkleManagerProxy;
+
+  // Relay .shtml file changes from the offscreen FS to the panel
+  // SprinkleManager. The panel's localFs is a separate VirtualFS
+  // instance over the same IndexedDB, so its in-memory watcher
+  // can't see writes made by the agent's bash tool here. Bridge
+  // them via the sprinkle proxy: when offscreen sees a new/changed
+  // .shtml, ask the panel to refresh + auto-open. Debounced to
+  // coalesce bursty installs.
+  {
+    const offscreenWatcher = orchestrator.getSharedFS()?.getWatcher();
+    if (offscreenWatcher) {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      offscreenWatcher.watch(
+        '/',
+        (path) => path.endsWith('.shtml'),
+        () => {
+          if (timer) return;
+          timer = setTimeout(() => {
+            timer = null;
+            void sprinkleManagerProxy.openNewAutoOpenSprinkles().catch(() => {});
+          }, 150);
+        }
+      );
+    }
+  }
 
   // Start BSH navigation watchdog — auto-executes .bsh scripts on matching navigations
   // Mirrors the setup in packages/webapp/src/ui/main.ts

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -137,6 +137,12 @@ export class Layout {
   public onClearChat?: () => Promise<void>;
   public onClearFilesystem?: () => Promise<void>;
   public onSprinkleClose?: (name: string) => void;
+  /**
+   * Fired when the user clicks a sprinkle's rail icon. Lets the
+   * SprinkleManager promote attention-mode entries (which the user
+   * has now actually engaged with) into persistently-open ones.
+   */
+  public onSprinkleActivate?: (name: string) => void;
 
   /** Callback to get available sprinkles for the [+] picker. */
   public getAvailableSprinkles?: () => Array<{ name: string; title: string }>;
@@ -810,6 +816,9 @@ export class Layout {
         onItemActivate: (id) => {
           if (id === 'terminal') this.panels?.terminal?.refit();
           if (id === 'memory') this.panels?.memory?.refresh();
+          if (id.startsWith('sprinkle-')) {
+            this.onSprinkleActivate?.(id.slice(9));
+          }
         },
         onItemClose: (id) => {
           const name = id.startsWith('sprinkle-') ? id.slice(9) : id;

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1278,6 +1278,7 @@ async function mainExtension(app: HTMLElement): Promise<void> {
 
   await sprinkleManager.refresh();
   layout.onSprinkleClose = (name) => sprinkleManager.close(name);
+  layout.onSprinkleActivate = (name) => sprinkleManager.markActivated(name);
   layout.getAvailableSprinkles = () => {
     const opened = new Set(sprinkleManager.opened());
     return sprinkleManager
@@ -2687,6 +2688,7 @@ async function main(): Promise<void> {
 
     await sprinkleManager.refresh();
     layout.onSprinkleClose = (name) => sprinkleManager!.close(name);
+    layout.onSprinkleActivate = (name) => sprinkleManager!.markActivated(name);
 
     // Wire [+] picker: available sprinkles + open callback
     layout.getAvailableSprinkles = () => {

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -2657,8 +2657,14 @@ async function main(): Promise<void> {
       sharedFs,
       routeLickToScoop,
       {
-        addSprinkle: (name, title, element, zone) =>
-          layout.addSprinkle(name, title, element, zone as 'primary' | 'drawer' | undefined),
+        addSprinkle: (name, title, element, zone, options) =>
+          layout.addSprinkle(
+            name,
+            title,
+            element,
+            zone as 'primary' | 'drawer' | undefined,
+            options
+          ),
         removeSprinkle: (name) => layout.removeSprinkle(name),
       },
       () => {

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1289,6 +1289,20 @@ async function mainExtension(app: HTMLElement): Promise<void> {
   layout.updateAddButtons();
   await sprinkleManager.restoreOpenSprinkles();
 
+  // Auto-surface newly-added .shtml files in the rail. The panel's
+  // `localFs` doesn't have the orchestrator's watcher (that lives in
+  // offscreen), so attach a fresh one to catch panel-side writes
+  // (e.g. skill drag-and-drop installs). Offscreen-side writes are
+  // relayed separately from `offscreen.ts` via the sprinkle proxy.
+  if (!localFs.getWatcher()) {
+    const { FsWatcher } = await import('../fs/index.js');
+    localFs.setWatcher(new FsWatcher());
+  }
+  const panelWatcher = localFs.getWatcher();
+  if (panelWatcher) {
+    sprinkleManager.setupWatcher(panelWatcher);
+  }
+
   // Migrate legacy localStorage flag to VFS marker
   if (!(await localFs.exists('/shared/.welcomed')) && localStorage.getItem('slicc-welcomed')) {
     await localFs.writeFile('/shared/.welcomed', '1').catch(() => {});
@@ -2678,6 +2692,15 @@ async function main(): Promise<void> {
     };
     layout.onOpenSprinkle = (name, zone) => sprinkleManager!.open(name, zone);
     layout.updateAddButtons();
+
+    // Auto-surface newly-added .shtml files in the rail (skill installs,
+    // direct file writes, mounted folders). Reuses the orchestrator's
+    // shared FsWatcher — same instance the bsh watchdog and other
+    // subsystems hang off of.
+    const sharedWatcher = sharedFs.getWatcher();
+    if (sharedWatcher) {
+      sprinkleManager.setupWatcher(sharedWatcher);
+    }
 
     // Migrate legacy localStorage flag to VFS marker
     if (!(await sharedFs.exists('/shared/.welcomed')) && localStorage.getItem('slicc-welcomed')) {

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -60,6 +60,22 @@ export interface SprinkleManagerOptions {
   autoOpenBehavior?: 'activate' | 'attention';
 }
 
+/**
+ * Roots that `discoverSprinkles` actually mines for `.shtml` files.
+ * The watcher only registers under these so saves inside mounted
+ * project folders (which can sit anywhere in the VFS) don't trigger
+ * a full sprinkle rescan on every keystroke.
+ */
+const WATCHER_ROOTS = ['/workspace', '/shared', '/scoops'] as const;
+
+/**
+ * Minimum gap between back-to-back rescans triggered by
+ * `openNewAutoOpenSprinkles()`. Coalesces watcher events and
+ * post-install hooks (upskill, drag-drop, manual writes) that
+ * otherwise drive two passes for the same install burst.
+ */
+const REFRESH_COOLDOWN_MS = 250;
+
 export class SprinkleManager {
   private fs: VirtualFS;
   private bridge: SprinkleBridge;
@@ -73,6 +89,16 @@ export class SprinkleManager {
       container: HTMLElement;
     }
   >();
+  /**
+   * Sprinkle names whose rail entry is currently in attention-only
+   * mode. They're tracked so they're excluded from
+   * `slicc-open-sprinkles` — the user never actually opened the
+   * panel, and persisting them as user-opened would resurrect
+   * uninvited panels on every reload.
+   */
+  private attentionOnly = new Set<string>();
+  private inflightRefresh: Promise<void> | null = null;
+  private lastRefreshAt = 0;
   private autoOpenBehavior: 'activate' | 'attention';
 
   constructor(
@@ -149,8 +175,6 @@ export class SprinkleManager {
         log.warn('Failed to surface unseen sprinkle', { name: sprinkle.name });
       }
     }
-    // Seed/refresh the ledger so future boots only surface what's
-    // actually new.
     this.persistKnownSprinkles(new Set(this.availableSprinkles.keys()));
   }
 
@@ -165,17 +189,34 @@ export class SprinkleManager {
     }
   }
 
+  /**
+   * Union the given names into the persistent ledger. The ledger is
+   * monotonic — a previously-known sprinkle that is temporarily
+   * absent (mount unavailable, branch checkout, transient FS error)
+   * must NOT be forgotten, otherwise it would re-surface as "new"
+   * and pulse for attention again the next time it reappears.
+   */
   private persistKnownSprinkles(names: Set<string>): void {
     try {
-      localStorage.setItem(KNOWN_SPRINKLES_KEY, JSON.stringify([...names]));
+      const merged = new Set<string>([...this.loadKnownSprinkles(), ...names]);
+      localStorage.setItem(KNOWN_SPRINKLES_KEY, JSON.stringify([...merged]));
     } catch {
       /* localStorage full, ignore */
     }
   }
 
+  /**
+   * Persist only sprinkles the user has actively opened. Entries
+   * still in `attentionOnly` (passive surfacing, never clicked) are
+   * filtered out — restoring a panel the user never engaged with
+   * would be surprising on reload.
+   */
   private persistOpenSprinkles(): void {
     try {
-      localStorage.setItem(OPEN_SPRINKLES_KEY, JSON.stringify([...this.openSprinkles.keys()]));
+      const userOpened = [...this.openSprinkles.keys()].filter(
+        (name) => !this.attentionOnly.has(name)
+      );
+      localStorage.setItem(OPEN_SPRINKLES_KEY, JSON.stringify(userOpened));
     } catch {
       /* localStorage full, ignore */
     }
@@ -184,19 +225,32 @@ export class SprinkleManager {
   /**
    * Refresh and surface newly-discovered sprinkles in the rail.
    *
-   * Sprinkles that were already in the available list before the
-   * refresh are treated as pre-existing and left alone (otherwise
-   * every refresh would re-pop everything on every reload). New
-   * sprinkles — i.e. those that just appeared in the VFS — are
-   * opened so their icon shows up in the rail:
+   * Only sprinkles that just appeared in the VFS (relative to the
+   * pre-refresh available set) are surfaced. Pre-existing sprinkles
+   * are left alone — if the user has closed an auto-open sprinkle,
+   * an unrelated `.shtml` write must NOT pop it back open.
    *
-   * - `data-sprinkle-autoopen` ones honor `autoOpenBehavior`
+   * - `data-sprinkle-autoopen` + isNew → honor `autoOpenBehavior`
    *   (panel activates in standalone, attention-pulse in extension).
-   * - Plain new sprinkles open in `attention` mode unconditionally
-   *   so the icon shows but the panel stays collapsed and we don't
-   *   cover whatever the user is doing.
+   * - Plain new sprinkle → attention mode (icon pulses, panel stays
+   *   collapsed; doesn't cover whatever the user is doing).
+   *
+   * Concurrent / back-to-back invocations within
+   * `REFRESH_COOLDOWN_MS` are coalesced. Watcher events and the
+   * post-install `refreshSprinklesAfterInstall()` hook would
+   * otherwise fire two passes for the same install burst.
    */
   async openNewAutoOpenSprinkles(): Promise<void> {
+    if (this.inflightRefresh) return this.inflightRefresh;
+    if (Date.now() - this.lastRefreshAt < REFRESH_COOLDOWN_MS) return;
+    this.inflightRefresh = this.runOpenNewAutoOpenSprinkles().finally(() => {
+      this.lastRefreshAt = Date.now();
+      this.inflightRefresh = null;
+    });
+    return this.inflightRefresh;
+  }
+
+  private async runOpenNewAutoOpenSprinkles(): Promise<void> {
     const previouslyKnown = new Set(this.availableSprinkles.keys());
     await this.refresh();
     const attentionForAutoOpen = this.autoOpenBehavior === 'attention';
@@ -204,7 +258,8 @@ export class SprinkleManager {
     for (const sprinkle of this.availableSprinkles.values()) {
       if (this.openSprinkles.has(sprinkle.name)) continue;
       const isNew = !previouslyKnown.has(sprinkle.name);
-      if (isNew) changed = true;
+      if (!isNew) continue;
+      changed = true;
       if (sprinkle.autoOpen) {
         try {
           await this.open(sprinkle.name, undefined, { attention: attentionForAutoOpen });
@@ -215,7 +270,7 @@ export class SprinkleManager {
         } catch {
           log.warn('Failed to auto-open new sprinkle', { name: sprinkle.name });
         }
-      } else if (isNew) {
+      } else {
         try {
           await this.open(sprinkle.name, undefined, { attention: true });
           log.info('Surfaced newly-installed sprinkle in rail', { name: sprinkle.name });
@@ -270,6 +325,8 @@ export class SprinkleManager {
     // (extension mode) gets added to a live DOM subtree. Iframes in detached
     // subtrees won't fire their load event.
     this.openSprinkles.set(name, { renderer: null!, container });
+    if (options.attention) this.attentionOnly.add(name);
+    else this.attentionOnly.delete(name);
     this.callbacks.addSprinkle(name, sprinkle.title, container, zone, options);
 
     const api = this.bridge.createAPI(name);
@@ -282,6 +339,19 @@ export class SprinkleManager {
     log.info('Sprinkle opened', { name, title: sprinkle.title });
   }
 
+  /**
+   * Mark an attention-mode sprinkle as user-activated. Called from
+   * the layout when the user clicks a pulsing rail icon — flips the
+   * entry from passive surfacing to genuinely "open", so it now
+   * persists into `slicc-open-sprinkles` and survives reload.
+   */
+  markActivated(name: string): void {
+    if (!this.attentionOnly.has(name)) return;
+    this.attentionOnly.delete(name);
+    this.persistOpenSprinkles();
+    log.info('Sprinkle promoted from attention to user-opened', { name });
+  }
+
   /** Close a sprinkle by name. */
   close(name: string): void {
     const entry = this.openSprinkles.get(name);
@@ -291,6 +361,7 @@ export class SprinkleManager {
     entry.container.remove();
     this.bridge.removeSprinkle(name);
     this.openSprinkles.delete(name);
+    this.attentionOnly.delete(name);
     this.callbacks.removeSprinkle(name);
     this.persistOpenSprinkles();
     log.info('Sprinkle closed', { name });
@@ -307,33 +378,45 @@ export class SprinkleManager {
   }
 
   /**
-   * Set up a watcher that auto-surfaces newly-added `.shtml` files
-   * in the rail. Calls `openNewAutoOpenSprinkles()` (which refreshes
-   * the available list AND opens any new auto-open sprinkles), so
-   * non-auto-open sprinkles still appear in the [+] picker without
-   * a reload. Watches the whole VFS — `.shtml` files can land in
-   * `/workspace/skills/`, `/shared/sprinkles/`, or anywhere else
-   * `discoverSprinkles()` walks. Bursts are coalesced with a small
-   * debounce so a single skill install doesn't trigger one refresh
-   * per file.
+   * Set up watchers that auto-surface newly-added `.shtml` files in
+   * the rail. Calls `openNewAutoOpenSprinkles()` (refreshes the
+   * available list AND surfaces new sprinkles), so non-auto-open
+   * sprinkles appear in the rail without a reload.
+   *
+   * Watches only canonical sprinkle roots (`WATCHER_ROOTS`). A
+   * watcher rooted at `/` would re-scan the entire VFS on every
+   * `.shtml` save anywhere, including saves inside mounted project
+   * folders — expensive and unnecessary, since `discoverSprinkles`
+   * doesn't surface sprinkles outside these roots.
+   *
+   * Bursts are coalesced with a small debounce so a single skill
+   * install doesn't trigger one refresh per file. Concurrent
+   * invocations on the SprinkleManager itself are deduped via
+   * `REFRESH_COOLDOWN_MS`.
    */
   setupWatcher(watcher: FsWatcher): void {
     let timer: ReturnType<typeof setTimeout> | null = null;
-    this.watcherUnsub = watcher.watch(
-      '/',
-      (path) => path.endsWith('.shtml'),
-      () => {
-        if (timer) return;
-        timer = setTimeout(() => {
-          timer = null;
-          void this.openNewAutoOpenSprinkles().catch((err) => {
-            log.warn('Sprinkle refresh on watcher event failed', {
-              error: err instanceof Error ? err.message : String(err),
-            });
+    const trigger = () => {
+      if (timer) return;
+      timer = setTimeout(() => {
+        timer = null;
+        void this.openNewAutoOpenSprinkles().catch((err) => {
+          log.warn('Sprinkle refresh on watcher event failed', {
+            error: err instanceof Error ? err.message : String(err),
           });
-        }, 150);
-      }
+        });
+      }, 150);
+    };
+    const unsubs: Array<() => void> = WATCHER_ROOTS.map((root) =>
+      watcher.watch(root, (path) => path.endsWith('.shtml'), trigger)
     );
+    this.watcherUnsub = () => {
+      for (const u of unsubs) u();
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
   }
 
   /** Clean up watcher subscriptions. */

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -218,12 +218,33 @@ export class SprinkleManager {
     return Array.from(this.openSprinkles.keys());
   }
 
-  /** Set up a watcher for auto-refreshing when .shtml files change. */
+  /**
+   * Set up a watcher that auto-surfaces newly-added `.shtml` files
+   * in the rail. Calls `openNewAutoOpenSprinkles()` (which refreshes
+   * the available list AND opens any new auto-open sprinkles), so
+   * non-auto-open sprinkles still appear in the [+] picker without
+   * a reload. Watches the whole VFS — `.shtml` files can land in
+   * `/workspace/skills/`, `/shared/sprinkles/`, or anywhere else
+   * `discoverSprinkles()` walks. Bursts are coalesced with a small
+   * debounce so a single skill install doesn't trigger one refresh
+   * per file.
+   */
   setupWatcher(watcher: FsWatcher): void {
+    let timer: ReturnType<typeof setTimeout> | null = null;
     this.watcherUnsub = watcher.watch(
-      '/workspace',
+      '/',
       (path) => path.endsWith('.shtml'),
-      () => void this.refresh()
+      () => {
+        if (timer) return;
+        timer = setTimeout(() => {
+          timer = null;
+          void this.openNewAutoOpenSprinkles().catch((err) => {
+            log.warn('Sprinkle refresh on watcher event failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
+        }, 150);
+      }
     );
   }
 

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -39,6 +39,14 @@ export interface SprinkleManagerCallbacks {
 }
 
 const OPEN_SPRINKLES_KEY = 'slicc-open-sprinkles';
+/**
+ * Persistent ledger of every sprinkle name we've ever discovered in
+ * this profile. When `restoreOpenSprinkles()` runs and finds an
+ * entry in `availableSprinkles` that isn't in the ledger, it's a
+ * just-installed sprinkle that hasn't been surfaced yet — open it
+ * in attention mode so the rail icon shows up.
+ */
+const KNOWN_SPRINKLES_KEY = 'slicc-known-sprinkles';
 
 export interface SprinkleManagerOptions {
   /**
@@ -81,14 +89,27 @@ export class SprinkleManager {
   }
 
   /** Restore sprinkles that were open in the previous session.
-   *  On first run (no localStorage entry), auto-open sprinkles marked with data-sprinkle-autoopen. */
+   *  On first run (no localStorage entry), auto-open sprinkles marked with data-sprinkle-autoopen.
+   *  Always surfaces sprinkles that have landed in the VFS since
+   *  the last time the panel saw them (skill installs in a prior
+   *  session, or the very first time we boot a profile that
+   *  predates the known-sprinkles ledger). */
   async restoreOpenSprinkles(): Promise<void> {
     try {
       const raw = localStorage.getItem(OPEN_SPRINKLES_KEY);
-      if (!raw) {
-        // First run — open sprinkles with autoOpen flag (or just
-        // surface them as attention-grabbing rail icons in
-        // `'attention'` mode).
+      if (raw) {
+        const names: string[] = JSON.parse(raw);
+        for (const name of names) {
+          try {
+            await this.open(name);
+          } catch {
+            log.warn('Failed to restore sprinkle', { name });
+          }
+        }
+      } else {
+        // No previously-opened sprinkles — open autoopen ones
+        // (legacy behavior). The non-autoopen ones get a rail
+        // icon via `surfaceUnseenSprinkles()` below.
         const attention = this.autoOpenBehavior === 'attention';
         for (const sprinkle of this.availableSprinkles.values()) {
           if (sprinkle.autoOpen) {
@@ -99,18 +120,56 @@ export class SprinkleManager {
             }
           }
         }
-        return;
-      }
-      const names: string[] = JSON.parse(raw);
-      for (const name of names) {
-        try {
-          await this.open(name);
-        } catch {
-          log.warn('Failed to restore sprinkle', { name });
-        }
       }
     } catch {
       /* corrupt localStorage, ignore */
+    }
+    await this.surfaceUnseenSprinkles();
+  }
+
+  /**
+   * Diff the current available list against the persisted
+   * known-sprinkles ledger. Anything new gets opened in attention
+   * mode (or activated for `data-sprinkle-autoopen` ones, honoring
+   * `autoOpenBehavior`). Updates the ledger so the next reload
+   * doesn't re-pop the same sprinkles.
+   */
+  private async surfaceUnseenSprinkles(): Promise<void> {
+    const known = this.loadKnownSprinkles();
+    const attentionForAutoOpen = this.autoOpenBehavior === 'attention';
+    for (const sprinkle of this.availableSprinkles.values()) {
+      if (known.has(sprinkle.name)) continue;
+      if (this.openSprinkles.has(sprinkle.name)) continue;
+      try {
+        await this.open(sprinkle.name, undefined, {
+          attention: sprinkle.autoOpen ? attentionForAutoOpen : true,
+        });
+        log.info('Surfaced previously-unseen sprinkle', { name: sprinkle.name });
+      } catch {
+        log.warn('Failed to surface unseen sprinkle', { name: sprinkle.name });
+      }
+    }
+    // Seed/refresh the ledger so future boots only surface what's
+    // actually new.
+    this.persistKnownSprinkles(new Set(this.availableSprinkles.keys()));
+  }
+
+  private loadKnownSprinkles(): Set<string> {
+    try {
+      const raw = localStorage.getItem(KNOWN_SPRINKLES_KEY);
+      if (!raw) return new Set();
+      const arr = JSON.parse(raw);
+      return Array.isArray(arr) ? new Set(arr.filter((x) => typeof x === 'string')) : new Set();
+    } catch {
+      return new Set();
+    }
+  }
+
+  private persistKnownSprinkles(names: Set<string>): void {
+    try {
+      localStorage.setItem(KNOWN_SPRINKLES_KEY, JSON.stringify([...names]));
+    } catch {
+      /* localStorage full, ignore */
     }
   }
 
@@ -122,22 +181,51 @@ export class SprinkleManager {
     }
   }
 
-  /** Refresh and auto-open any new sprinkles with autoOpen that aren't already open. */
+  /**
+   * Refresh and surface newly-discovered sprinkles in the rail.
+   *
+   * Sprinkles that were already in the available list before the
+   * refresh are treated as pre-existing and left alone (otherwise
+   * every refresh would re-pop everything on every reload). New
+   * sprinkles — i.e. those that just appeared in the VFS — are
+   * opened so their icon shows up in the rail:
+   *
+   * - `data-sprinkle-autoopen` ones honor `autoOpenBehavior`
+   *   (panel activates in standalone, attention-pulse in extension).
+   * - Plain new sprinkles open in `attention` mode unconditionally
+   *   so the icon shows but the panel stays collapsed and we don't
+   *   cover whatever the user is doing.
+   */
   async openNewAutoOpenSprinkles(): Promise<void> {
+    const previouslyKnown = new Set(this.availableSprinkles.keys());
     await this.refresh();
-    const attention = this.autoOpenBehavior === 'attention';
+    const attentionForAutoOpen = this.autoOpenBehavior === 'attention';
+    let changed = false;
     for (const sprinkle of this.availableSprinkles.values()) {
-      if (sprinkle.autoOpen && !this.openSprinkles.has(sprinkle.name)) {
+      if (this.openSprinkles.has(sprinkle.name)) continue;
+      const isNew = !previouslyKnown.has(sprinkle.name);
+      if (isNew) changed = true;
+      if (sprinkle.autoOpen) {
         try {
-          await this.open(sprinkle.name, undefined, { attention });
+          await this.open(sprinkle.name, undefined, { attention: attentionForAutoOpen });
           log.info('Auto-opened new sprinkle after install', {
             name: sprinkle.name,
-            attention,
+            attention: attentionForAutoOpen,
           });
         } catch {
           log.warn('Failed to auto-open new sprinkle', { name: sprinkle.name });
         }
+      } else if (isNew) {
+        try {
+          await this.open(sprinkle.name, undefined, { attention: true });
+          log.info('Surfaced newly-installed sprinkle in rail', { name: sprinkle.name });
+        } catch {
+          log.warn('Failed to surface newly-installed sprinkle', { name: sprinkle.name });
+        }
       }
+    }
+    if (changed) {
+      this.persistKnownSprinkles(new Set(this.availableSprinkles.keys()));
     }
   }
 

--- a/packages/webapp/tests/ui/sprinkle-manager.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-manager.test.ts
@@ -1,9 +1,59 @@
+// @vitest-environment jsdom
 import 'fake-indexeddb/auto';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
 import { FsWatcher } from '../../src/fs/fs-watcher.js';
 import { SprinkleManager } from '../../src/ui/sprinkle-manager.js';
 import type { LickEvent } from '../../src/scoops/lick-manager.js';
+
+vi.mock('../../src/ui/sprinkle-renderer.js', () => ({
+  SprinkleRenderer: class {
+    constructor(_c: unknown, _api: unknown) {}
+    async render() {}
+    dispose() {}
+    pushUpdate() {}
+  },
+}));
+
+function makeMemoryStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    key: (i: number) => Array.from(data.keys())[i] ?? null,
+    getItem: (k: string) => (data.has(k) ? data.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      data.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      data.delete(k);
+    },
+    clear: () => {
+      data.clear();
+    },
+  };
+}
+
+interface FakeElement {
+  className: string;
+  style: { cssText: string };
+  dataset: Record<string, string>;
+  appendChild(child: FakeElement): void;
+  remove(): void;
+}
+
+function makeFakeDocument() {
+  return {
+    createElement: (_tag: string): FakeElement => ({
+      className: '',
+      style: { cssText: '' },
+      dataset: {},
+      appendChild() {},
+      remove() {},
+    }),
+  };
+}
 
 describe('SprinkleManager', () => {
   let vfs: VirtualFS;
@@ -14,6 +64,8 @@ describe('SprinkleManager', () => {
   let mgr: SprinkleManager;
 
   beforeEach(async () => {
+    vi.stubGlobal('localStorage', makeMemoryStorage());
+    vi.stubGlobal('document', makeFakeDocument());
     vfs = await VirtualFS.create({
       dbName: `test-sprinkle-manager-${dbCounter++}`,
       wipe: true,
@@ -34,6 +86,11 @@ describe('SprinkleManager', () => {
       },
       vi.fn()
     );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it('refresh discovers available sprinkles', async () => {
@@ -66,6 +123,7 @@ describe('SprinkleManager', () => {
   });
 
   it('setupWatcher refreshes available list when new .shtml files appear', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
     const watcher = new FsWatcher();
     vfs.setWatcher(watcher);
     mgr.setupWatcher(watcher);
@@ -77,11 +135,90 @@ describe('SprinkleManager', () => {
       '<title>Migrate Page</title><div/>'
     );
 
-    // Wait past the debounce window plus the async refresh chain.
-    await new Promise<void>((resolve) => setTimeout(resolve, 250));
+    // Drain the 150ms debounce. The timer callback fires a
+    // void-async openNewAutoOpenSprinkles(); awaiting an explicit
+    // call here joins (or no-ops via cooldown if already done) so
+    // we get a deterministic flush without wall-clock waits.
+    await vi.advanceTimersByTimeAsync(200);
+    await mgr.openNewAutoOpenSprinkles();
 
     const names = mgr.available().map((s) => s.name);
     expect(names).toContain('migrate-page');
+  });
+
+  it('setupWatcher leaves a previously-closed auto-open sprinkle closed when an unrelated .shtml is added', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const watcher = new FsWatcher();
+    vfs.setWatcher(watcher);
+    mgr.setupWatcher(watcher);
+
+    // Pre-existing auto-open sprinkle that the user has already
+    // dismissed (never present in openSprinkles after close).
+    await vfs.writeFile(
+      '/shared/sprinkles/dash/dash.shtml',
+      '<title>Dash</title><div data-sprinkle-autoopen>hi</div>'
+    );
+    await mgr.refresh();
+    expect(mgr.available().find((s) => s.name === 'dash')?.autoOpen).toBe(true);
+    addSprinkle.mockClear();
+
+    // Unrelated .shtml lands in the VFS — must NOT pop dash open.
+    await vfs.writeFile('/shared/sprinkles/other/other.shtml', '<title>Other</title><div>hi</div>');
+    await vi.advanceTimersByTimeAsync(200);
+    await mgr.openNewAutoOpenSprinkles();
+
+    const names = addSprinkle.mock.calls.map((c) => c[0]);
+    expect(names).toContain('other');
+    expect(names).not.toContain('dash');
+  });
+
+  it('attention-mode opens are not persisted into slicc-open-sprinkles', async () => {
+    await vfs.writeFile('/shared/sprinkles/quiet/quiet.shtml', '<title>Quiet</title><div>hi</div>');
+    await mgr.refresh();
+    await mgr.open('quiet', undefined, { attention: true });
+
+    const stored = JSON.parse(localStorage.getItem('slicc-open-sprinkles') ?? '[]');
+    expect(stored).toEqual([]);
+    expect(mgr.opened()).toContain('quiet');
+  });
+
+  it('markActivated promotes an attention-mode sprinkle into the persisted set', async () => {
+    await vfs.writeFile('/shared/sprinkles/q/q.shtml', '<title>Q</title><div>hi</div>');
+    await mgr.refresh();
+    await mgr.open('q', undefined, { attention: true });
+    expect(JSON.parse(localStorage.getItem('slicc-open-sprinkles') ?? '[]')).toEqual([]);
+
+    mgr.markActivated('q');
+    expect(JSON.parse(localStorage.getItem('slicc-open-sprinkles') ?? '[]')).toEqual(['q']);
+  });
+
+  it('persistKnownSprinkles unions with the existing ledger so absent names are not forgotten', async () => {
+    // Seed a previously-known sprinkle that is no longer present
+    // (e.g. mounted folder unavailable this session).
+    localStorage.setItem('slicc-known-sprinkles', JSON.stringify(['mounted-only']));
+
+    await vfs.writeFile('/shared/sprinkles/local/local.shtml', '<title>Local</title><div>hi</div>');
+    await mgr.refresh();
+    await mgr.restoreOpenSprinkles();
+
+    const known = new Set(JSON.parse(localStorage.getItem('slicc-known-sprinkles') ?? '[]'));
+    expect(known.has('mounted-only')).toBe(true);
+    expect(known.has('local')).toBe(true);
+  });
+
+  it('openNewAutoOpenSprinkles dedupes back-to-back calls within the cooldown', async () => {
+    await vfs.writeFile('/shared/sprinkles/a/a.shtml', '<title>A</title><div>hi</div>');
+    await mgr.refresh();
+    addSprinkle.mockClear();
+
+    // Second sprinkle appears, then two refreshes fire (e.g.
+    // watcher event + post-install hook). The cooldown should
+    // collapse them into a single surfacing pass.
+    await vfs.writeFile('/shared/sprinkles/b/b.shtml', '<title>B</title><div>hi</div>');
+    await Promise.all([mgr.openNewAutoOpenSprinkles(), mgr.openNewAutoOpenSprinkles()]);
+
+    const surfaced = addSprinkle.mock.calls.filter((c) => c[0] === 'b');
+    expect(surfaced.length).toBe(1);
   });
 
   it('open throws descriptive error when file content is undefined', async () => {

--- a/packages/webapp/tests/ui/sprinkle-manager.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-manager.test.ts
@@ -1,6 +1,7 @@
 import 'fake-indexeddb/auto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { FsWatcher } from '../../src/fs/fs-watcher.js';
 import { SprinkleManager } from '../../src/ui/sprinkle-manager.js';
 import type { LickEvent } from '../../src/scoops/lick-manager.js';
 
@@ -62,6 +63,25 @@ describe('SprinkleManager', () => {
 
   it('sendToSprinkle does not throw for closed sprinkle', () => {
     expect(() => mgr.sendToSprinkle('unknown', {})).not.toThrow();
+  });
+
+  it('setupWatcher refreshes available list when new .shtml files appear', async () => {
+    const watcher = new FsWatcher();
+    vfs.setWatcher(watcher);
+    mgr.setupWatcher(watcher);
+    await mgr.refresh();
+    expect(mgr.available()).toEqual([]);
+
+    await vfs.writeFile(
+      '/workspace/skills/migrate/migrate-page.shtml',
+      '<title>Migrate Page</title><div/>'
+    );
+
+    // Wait past the debounce window plus the async refresh chain.
+    await new Promise<void>((resolve) => setTimeout(resolve, 250));
+
+    const names = mgr.available().map((s) => s.name);
+    expect(names).toContain('migrate-page');
   });
 
   it('open throws descriptive error when file content is undefined', async () => {


### PR DESCRIPTION
## Why

Since the sidebar refactor in #519, newly-installed sprinkles stopped showing up in the rail. Installing the strudel skill (or any other skill that ships a `.shtml`) silently added the file to the VFS but the rail showed nothing — the user had to know to click `[+]` and pick it manually.

Reported regression:

> we've refactored the sidebar recently in pr 519. since then, when new skills get installed, or .shtml files get added to the file system, the sprinkles no longer get shown in the sidebar.

## What

Two related changes, both leaning on the existing FS watcher rather than adding new infrastructure:

### 1. Wire `SprinkleManager.setupWatcher` into both runtimes

The method existed but was never called.

- **Standalone** uses the orchestrator's existing `sharedFs.getWatcher()`.
- **Extension panel** gets a fresh `FsWatcher` on its `localFs` for panel-side writes (skill drag-and-drop installs).
- **Extension offscreen** subscribes to its own watcher and forwards `.shtml` events to the panel via the existing sprinkle proxy (`__slicc_sprinkleManager.openNewAutoOpenSprinkles`), since the panel's `localFs` watcher cannot see writes made by the agent's offscreen FS.

The watcher hook now refreshes the available list **and** opens any newly-discovered sprinkles, debounced 150 ms to coalesce bursty installs.

### 2. Surface non-autoopen sprinkles in attention mode

Previously `openNewAutoOpenSprinkles` only opened sprinkles carrying `data-sprinkle-autoopen`. The strudel sprinkle does not have that flag, so even with a working watcher it would have been ignored.

The method now also opens **newly-discovered non-autoopen** sprinkles, but in **attention mode** — the rail icon pulses, the panel stays collapsed. This matches the existing extension behavior for autoopen sprinkles (so we do not cover chat) and gives the user a clear visual cue that their install landed.

A new persistent `slicc-known-sprinkles` localStorage ledger tracks every sprinkle name ever discovered for the profile. `restoreOpenSprinkles` always runs `surfaceUnseenSprinkles` afterward, so skills installed in a prior session also get a rail icon on next boot. The ledger is updated after each surfacing so future boots only flag what is truly new.

Standalone `main()`'s `addSprinkle` callback now forwards the `options` argument so attention mode actually reaches `layout.addSprinkle` (extension path already did this).

## Testing

- Live verification via CDP after installing the strudel skill: rail shows `Strudel Music` icon with `attention: true, active: false` (pulsing, panel stays collapsed). `mgr.opened()` reports `["strudel-music"]`.
- New unit test in `packages/webapp/tests/ui/sprinkle-manager.test.ts` exercises the watcher path:

  ```
  it('setupWatcher refreshes available list when new .shtml files appear', ...)
  ```

- `npm run typecheck` passes.
- `npm run test` for sprinkle-manager passes (7/7); same set of pre-existing failures as `main` for unrelated tests (chat-panel, telemetry, provider-settings).
- `npx prettier --check` clean on all changed files.

## Files

- `packages/webapp/src/ui/sprinkle-manager.ts` — watcher integration, `surfaceUnseenSprinkles`, persistent ledger
- `packages/webapp/src/ui/main.ts` — wire `setupWatcher` in both standalone and extension panel; forward `options.attention` in standalone
- `packages/chrome-extension/src/offscreen.ts` — relay offscreen `.shtml` events to panel via sprinkle proxy
- `packages/webapp/tests/ui/sprinkle-manager.test.ts` — coverage for the watcher path
