### PR TITLE
ci(release): use deploy key for semantic-release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Replaces the GITHUB_TOKEN-based HTTPS clone in the release workflow with an SSH clone using the new `RELEASE_DEPLOY_KEY` secret (deploy key id 150300326, write access). The deploy key is already a bypass actor on the Merge Queue ruleset (`DeployKey: always`), so `@semantic-release/git`'s `git push --tags HEAD:main` for the `chore(release)` version bump will succeed instead of being rejected with GH013.

Context: PR #529 added `@semantic-release/git` to `.releaserc.json`, which is what introduced the push-to-main step that's been blocked since.