### PR TITLE
feat(sprinkles): per-sprinkle rail icons via <link rel=icon> / data-sprinkle-icon

### DIFF
--- a/packages/chrome-extension/src/sprinkle-proxy.ts
+++ b/packages/chrome-extension/src/sprinkle-proxy.ts
@@ -14,6 +14,7 @@ interface Sprinkle {
   title: string;
   path: string;
   autoOpen: boolean;
+  icon?: string;
 }
 
 const TIMEOUT = 8000;

--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -18,9 +18,45 @@ allowed-tools: bash
 **Creating a sprinkle**:
 
 1. `read_file /workspace/skills/sprinkles/style-guide.md` — **always read first** before writing any sprinkle
-2. `write_file` to `/shared/sprinkles/<name>/<name>.shtml` (follow the style guide templates)
-3. `bash` → `sprinkle open <name>`
-4. **CRITICAL: Do NOT finish or send a completion message.** You own this sprinkle for its entire lifetime. The cone will send you follow-up instructions (modifications, lick events) via `feed_scoop`. If you finish, you lose your context and cannot handle future work on this sprinkle.
+2. **Pick a rail icon** that matches the sprinkle's purpose (see "Sprinkle icon" below). Every new sprinkle MUST declare an icon — the generic Sparkles default is reserved for sprinkles that genuinely have no thematic anchor.
+3. `write_file` to `/shared/sprinkles/<name>/<name>.shtml` (follow the style guide templates)
+4. `bash` → `sprinkle open <name>`
+5. **CRITICAL: Do NOT finish or send a completion message.** You own this sprinkle for its entire lifetime. The cone will send you follow-up instructions (modifications, lick events) via `feed_scoop`. If you finish, you lose your context and cannot handle future work on this sprinkle.
+
+## Sprinkle icon
+
+Each sprinkle gets its own glyph in the rail so users can tell them apart at a glance. Declare it in the `.shtml`. Three formats, in order of preference:
+
+**1. Lucide icon name** (preferred — covers ~1500 icons from [lucide.dev/icons](https://lucide.dev/icons)):
+
+```html
+<link rel="icon" href="music" />
+```
+
+Use the kebab-case name from lucide.dev. Common picks: `music`, `code`, `terminal`, `chart-bar`, `chart-line`, `calendar`, `calendar-clock`, `clock`, `image`, `file-text`, `globe`, `book-open`, `compass`, `gauge`, `wrench`, `palette`, `bug`, `flask-conical`, `database`, `cloud`, `package`, `shopping-cart`, `dollar-sign`, `mail`, `message-square`, `bell`, `users`, `user`, `settings`, `sparkles`.
+
+**2. SVG file in the sprinkle's directory** (when no Lucide icon fits):
+
+```html
+<link rel="icon" href="/shared/sprinkles/<name>/icon.svg" />
+```
+
+Author the SVG with `viewBox="0 0 24 24"` and `stroke="currentColor"` so it inherits the rail's color. Keep paths simple — the rail renders at 16×16.
+
+**3. Inline SVG or data URL** (one-off icons, no extra file):
+
+```html
+<link
+  rel="icon"
+  href='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="..."/></svg>'
+/>
+```
+
+Or, for inline SVG, use `data-sprinkle-icon` on the root element with the SVG markup escaped. Prefer formats 1 and 2.
+
+**Where to put it**: Inside `<head>` for full-document mode, or as the very first element in fragment mode. The `<link rel="icon">` form is the standard favicon convention and matches what browsers expect, so it's the recommended form.
+
+**Fallback**: If the icon spec is missing or unresolvable, the rail uses a generic Sparkles glyph.
 
 **Updating a sprinkle** (when you receive follow-up instructions):
 
@@ -77,9 +113,10 @@ scoop_scoop("giro-winners")
 feed_scoop("giro-winners", "You own the sprinkle 'giro-winners'. Your job:
 1. Run: read_file /workspace/skills/sprinkles/style-guide.md
 2. Research the last 3 Giro d'Italia winners
-3. Write the sprinkle to /shared/sprinkles/giro-winners/giro-winners.shtml
-4. Run: sprinkle open giro-winners
-5. IMPORTANT: After opening the sprinkle, do NOT finish. Stay ready — you will receive follow-up instructions and lick events for this sprinkle via feed_scoop. Do not send a completion message.")
+3. Pick a rail icon — for cycling, use <link rel=\"icon\" href=\"bike\" /> in <head>. See the sprinkles SKILL.md \"Sprinkle icon\" section for the full list.
+4. Write the sprinkle to /shared/sprinkles/giro-winners/giro-winners.shtml
+5. Run: sprinkle open giro-winners
+6. IMPORTANT: After opening the sprinkle, do NOT finish. Stay ready — you will receive follow-up instructions and lick events for this sprinkle via feed_scoop. Do not send a completion message.")
 ```
 
 **Rule 4: Modifying sprinkles** — Feed the EXISTING scoop that owns it. Do NOT create a new scoop:

--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -41,7 +41,7 @@ Use the kebab-case name from lucide.dev. Common picks: `music`, `code`, `termina
 <link rel="icon" href="/shared/sprinkles/<name>/icon.svg" />
 ```
 
-Author the SVG with `viewBox="0 0 24 24"` and `stroke="currentColor"` so it inherits the rail's color. Keep paths simple — the rail renders at 16×16.
+Author the SVG with `viewBox="0 0 24 24"`. Keep paths simple — the rail renders at 16×16. **Note**: only Lucide icons inherit `currentColor` from the rail; author-supplied SVGs render through `<img>` (script-disabled), so set explicit colors in the SVG itself.
 
 **3. Inline SVG or data URL** (one-off icons, no extra file):
 
@@ -55,6 +55,8 @@ Author the SVG with `viewBox="0 0 24 24"` and `stroke="currentColor"` so it inhe
 Or, for inline SVG, use `data-sprinkle-icon` on the root element with the SVG markup escaped. Prefer formats 1 and 2.
 
 **Where to put it**: Inside `<head>` for full-document mode, or as the very first element in fragment mode. The `<link rel="icon">` form is the standard favicon convention and matches what browsers expect, so it's the recommended form.
+
+**Quoting tip**: When the `href` value itself contains quotes (inline-SVG data URLs do), wrap the attribute in single quotes so the inner double quotes don't terminate it: `href='data:image/svg+xml;utf8,<svg xmlns="...">...'`. The parser is quote-aware.
 
 **Fallback**: If the icon spec is missing or unresolvable, the rail uses a generic Sparkles glyph.
 

--- a/packages/vfs-root/workspace/skills/sprinkles/style-guide.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/style-guide.md
@@ -2,6 +2,16 @@
 
 Use these CSS classes in `.shtml` sprinkles. Do NOT write custom CSS — these components cover all common UI patterns.
 
+## Rail icon (favicon)
+
+Every sprinkle declares its own glyph for the side rail. Add this to the sprinkle's `<head>` (full-document mode) or as the first element (fragment mode):
+
+```html
+<link rel="icon" href="music" />
+```
+
+The `href` accepts a Lucide icon name (preferred), a VFS path to an SVG (`/shared/sprinkles/<name>/icon.svg`), or a `data:image/svg+xml;...` URL. See the SKILL.md "Sprinkle icon" section for the full list. **Never skip this** — generic Sparkles tiles are reserved for sprinkles that genuinely have no thematic anchor.
+
 ## Icons (Lucide)
 
 Lucide icons are available globally via the `LucideIcons` object. Use declarative `data-lucide` attributes for automatic rendering, or create icons programmatically.
@@ -527,6 +537,7 @@ Panels should look like professional tools, not chatbot output. Follow these rul
 
 ```html
 <title>Report Title</title>
+<link rel="icon" href="clipboard-list" />
 <div class="sprinkle-stack">
   <div>
     <h2 class="sprinkle-heading">Report Title</h2>
@@ -639,13 +650,14 @@ Every built-in sprinkle has three view states: **empty** (URL input form), **loa
 scoop_scoop("<sprinkle-name>")
 feed_scoop("<sprinkle-name>", "You own the sprinkle '<sprinkle-name>'.
 1. Run: read_file /workspace/skills/sprinkles/style-guide.md
-2. Write the sprinkle to /shared/sprinkles/<sprinkle-name>/<sprinkle-name>.shtml — define the DATA CONTRACT at the top of the <script>.
-3. Run: sprinkle open <sprinkle-name>
-4. IMMEDIATELY push status: sprinkle send <sprinkle-name> '{\"status\":\"loading\",\"context\":\"<what>\"}'
-5. Gather the data the user needs.
-6. Push results to the sprinkle in the format specified by the DATA CONTRACT.
-7. Stay ready — you will receive lick events when the user clicks buttons in the sprinkle.
-8. When the user confirms an edit, attempt to apply it to the underlying source (see 'Applying Changes' below).
+2. Pick a Lucide icon name that matches the sprinkle's purpose. Add <link rel=\"icon\" href=\"<icon-name>\" /> to the .shtml. See sprinkles SKILL.md \"Sprinkle icon\" for examples.
+3. Write the sprinkle to /shared/sprinkles/<sprinkle-name>/<sprinkle-name>.shtml — define the DATA CONTRACT at the top of the <script>.
+4. Run: sprinkle open <sprinkle-name>
+5. IMMEDIATELY push status: sprinkle send <sprinkle-name> '{\"status\":\"loading\",\"context\":\"<what>\"}'
+6. Gather the data the user needs.
+7. Push results to the sprinkle in the format specified by the DATA CONTRACT.
+8. Stay ready — you will receive lick events when the user clicks buttons in the sprinkle.
+9. When the user confirms an edit, attempt to apply it to the underlying source (see 'Applying Changes' below).
 Do not send a completion message.")
 ```
 

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -148,6 +148,13 @@ export class Layout {
   public getAvailableSprinkles?: () => Array<{ name: string; title: string }>;
   /** Callback to open a sprinkle by name. */
   public onOpenSprinkle?: (name: string, zone?: ZoneId) => Promise<void>;
+  /**
+   * Resolver for sprinkle icon specs → SVG/HTML markup.
+   * `addSprinkle()` calls this when a sprinkle declares an icon
+   * (Lucide name, VFS path, inline SVG, or data URL). Returns null
+   * to fall back to the default Sparkles glyph.
+   */
+  public resolveSprinkleIcon?: (spec: string | undefined) => Promise<string | null>;
 
   // Layout uses CSS flex — no manual width fractions needed
 
@@ -1072,7 +1079,7 @@ export class Layout {
     title: string,
     element: HTMLElement,
     targetZone?: ZoneId,
-    options?: { attention?: boolean }
+    options?: { attention?: boolean; icon?: string }
   ): void {
     const zone = targetZone ?? 'primary';
     const tabId = `sprinkle-${name}`;
@@ -1100,6 +1107,20 @@ export class Layout {
       closable: true,
     });
     this.dynamicSprinkles.set(name, container);
+
+    // Resolve the per-sprinkle icon asynchronously and swap it in
+    // when ready. We add the rail item with the default icon
+    // first so the entry is clickable immediately, then upgrade
+    // the SVG once the resolver responds.
+    if (options?.icon && this.resolveSprinkleIcon) {
+      this.resolveSprinkleIcon(options.icon)
+        .then((html) => {
+          if (html) this.primaryRail.setItemIcon(tabId, html);
+        })
+        .catch(() => {
+          /* fall back to default — already rendered */
+        });
+    }
 
     if (options?.attention) {
       // Auto-installed sprinkle in extension mode: leave the panel

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -93,6 +93,7 @@ import {
   setPlaywrightTeleportConnectedFollowers,
 } from '../shell/supplemental-commands/playwright-command.js';
 import { SprinkleManager } from './sprinkle-manager.js';
+import { resolveSprinkleIconHtml } from './sprinkle-icon.js';
 import { initTelemetry } from './telemetry.js';
 import { getAllMountEntries } from '../fs/mount-table-store.js';
 import { recoverMounts, formatMountRecoveryPrompt } from '../fs/mount-recovery.js';
@@ -1287,6 +1288,7 @@ async function mainExtension(app: HTMLElement): Promise<void> {
       .map((p) => ({ name: p.name, title: p.title }));
   };
   layout.onOpenSprinkle = (name, zone) => sprinkleManager.open(name, zone);
+  layout.resolveSprinkleIcon = (spec) => resolveSprinkleIconHtml(spec, localFs);
   layout.updateAddButtons();
   await sprinkleManager.restoreOpenSprinkles();
 
@@ -2699,6 +2701,7 @@ async function main(): Promise<void> {
         .map((p) => ({ name: p.name, title: p.title }));
     };
     layout.onOpenSprinkle = (name, zone) => sprinkleManager!.open(name, zone);
+    layout.resolveSprinkleIcon = (spec) => resolveSprinkleIconHtml(spec, sharedFs);
     layout.updateAddButtons();
 
     // Auto-surface newly-added .shtml files in the rail (skill installs,

--- a/packages/webapp/src/ui/rail-zone.ts
+++ b/packages/webapp/src/ui/rail-zone.ts
@@ -157,6 +157,25 @@ export class RailZone {
   }
 
   /**
+   * Replace the icon SVG/HTML for an existing rail item. Preserves
+   * the press-ripple layer so the click-and-hold animation still
+   * works after the swap. Used when a sprinkle's icon spec is
+   * resolved asynchronously (Lucide lookup, VFS read).
+   */
+  setItemIcon(id: string, iconHtml: string): void {
+    const entry = this.entries.get(id);
+    if (!entry) return;
+    const press = entry.btn.querySelector('.rail__item-press-layer');
+    entry.btn.innerHTML = iconHtml;
+    if (press) entry.btn.insertBefore(press, entry.btn.firstChild);
+    else {
+      const layer = document.createElement('span');
+      layer.className = 'rail__item-press-layer';
+      entry.btn.insertBefore(layer, entry.btn.firstChild);
+    }
+  }
+
+  /**
    * Mark a rail item as needing attention — the icon pulses until
    * the user clicks it (or `activateItem` runs for any reason). Used
    * for auto-installed sprinkles in the extension where popping the

--- a/packages/webapp/src/ui/sprinkle-discovery.ts
+++ b/packages/webapp/src/ui/sprinkle-discovery.ts
@@ -27,6 +27,17 @@ export interface Sprinkle {
   title: string;
   /** Whether this sprinkle should auto-open on first run */
   autoOpen: boolean;
+  /**
+   * Raw icon spec from the .shtml. Resolved by `sprinkle-icon.ts`.
+   * Can be:
+   * - a Lucide icon name (kebab-case, e.g. `"music"`, `"calendar-clock"`)
+   * - a VFS path to an SVG/PNG (e.g. `/workspace/skills/foo/icon.svg`)
+   * - an inline `<svg>...</svg>` markup
+   * - a `data:image/svg+xml;...` URL
+   * Sourced from `<link rel="icon" href="...">` (preferred) or
+   * `data-sprinkle-icon="..."` on any element.
+   */
+  icon?: string;
 }
 
 /**
@@ -72,6 +83,7 @@ async function scanDir(
         path: filePath,
         title: extractTitle(content, name),
         autoOpen: extractAutoOpen(content),
+        icon: extractIcon(content),
       });
     }
   }
@@ -99,4 +111,29 @@ export function extractTitle(content: string, fallback: string): string {
 /** Check if content has data-sprinkle-autoopen attribute. */
 export function extractAutoOpen(content: string): boolean {
   return /data-sprinkle-autoopen\b/.test(content);
+}
+
+/**
+ * Extract the sprinkle icon spec.
+ *
+ * Priority:
+ *   1. `<link rel="icon" href="...">` (the conventional favicon hook).
+ *   2. `data-sprinkle-icon="..."` attribute on any element.
+ *
+ * Returns the raw spec as authored — the resolver in
+ * `sprinkle-icon.ts` decides whether it's a Lucide name, a VFS
+ * path, an inline SVG, or a data URL.
+ */
+export function extractIcon(content: string): string | undefined {
+  const link = content.match(
+    /<link\b[^>]*\brel\s*=\s*["'](?:icon|shortcut icon)["'][^>]*\bhref\s*=\s*["']([^"']+)["']/i
+  );
+  if (link?.[1]) return link[1].trim();
+  const reverseLink = content.match(
+    /<link\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*\brel\s*=\s*["'](?:icon|shortcut icon)["']/i
+  );
+  if (reverseLink?.[1]) return reverseLink[1].trim();
+  const attr = content.match(/data-sprinkle-icon\s*=\s*["']([^"']+)["']/);
+  if (attr?.[1]) return attr[1].trim();
+  return undefined;
 }

--- a/packages/webapp/src/ui/sprinkle-discovery.ts
+++ b/packages/webapp/src/ui/sprinkle-discovery.ts
@@ -123,17 +123,60 @@ export function extractAutoOpen(content: string): boolean {
  * Returns the raw spec as authored — the resolver in
  * `sprinkle-icon.ts` decides whether it's a Lucide name, a VFS
  * path, an inline SVG, or a data URL.
+ *
+ * The parser is intentionally quote-aware: a `data:image/svg+xml;...`
+ * href can legitimately contain both `"` and `>` characters from
+ * inline SVG markup, so we walk the tag manually rather than rely
+ * on a `[^>]*` regex that bails at the first `>` inside an
+ * attribute value.
  */
 export function extractIcon(content: string): string | undefined {
-  const link = content.match(
-    /<link\b[^>]*\brel\s*=\s*["'](?:icon|shortcut icon)["'][^>]*\bhref\s*=\s*["']([^"']+)["']/i
-  );
-  if (link?.[1]) return link[1].trim();
-  const reverseLink = content.match(
-    /<link\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*\brel\s*=\s*["'](?:icon|shortcut icon)["']/i
-  );
-  if (reverseLink?.[1]) return reverseLink[1].trim();
-  const attr = content.match(/data-sprinkle-icon\s*=\s*["']([^"']+)["']/);
-  if (attr?.[1]) return attr[1].trim();
+  const tagRe = /<link\b/gi;
+  let m: RegExpExecArray | null;
+  while ((m = tagRe.exec(content)) !== null) {
+    const attrsStart = m.index + m[0].length;
+    const tagEnd = findUnquotedTagEnd(content, attrsStart);
+    if (tagEnd < 0) continue;
+    const attrs = content.slice(attrsStart, tagEnd);
+    if (!/\brel\s*=\s*("|')\s*(?:shortcut\s+)?icon\s*\1/i.test(attrs)) continue;
+    const href = matchAttrValue(attrs, 'href');
+    if (href !== undefined) return href.trim();
+  }
+  const dataAttr = matchAttrValue(content, 'data-sprinkle-icon');
+  if (dataAttr !== undefined) return dataAttr.trim();
   return undefined;
+}
+
+/**
+ * Find the index of the closing `>` for a tag whose attributes
+ * start at `from`, skipping `>` characters that occur inside
+ * quoted attribute values.
+ */
+function findUnquotedTagEnd(s: string, from: number): number {
+  let inDouble = false;
+  let inSingle = false;
+  for (let i = from; i < s.length; i++) {
+    const ch = s.charCodeAt(i);
+    if (inDouble) {
+      if (ch === 34 /* " */) inDouble = false;
+    } else if (inSingle) {
+      if (ch === 39 /* ' */) inSingle = false;
+    } else if (ch === 34) inDouble = true;
+    else if (ch === 39) inSingle = true;
+    else if (ch === 62 /* > */) return i;
+  }
+  return -1;
+}
+
+/**
+ * Match `name="value"` or `name='value'` and return the captured
+ * value. Inner quotes of the opposite kind are preserved verbatim,
+ * so e.g. a single-quoted href can carry an inline-SVG payload that
+ * uses double quotes for its own attributes.
+ */
+function matchAttrValue(haystack: string, name: string): string | undefined {
+  const re = new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, 'i');
+  const m = haystack.match(re);
+  if (!m) return undefined;
+  return m[1] ?? m[2] ?? undefined;
 }

--- a/packages/webapp/src/ui/sprinkle-icon.ts
+++ b/packages/webapp/src/ui/sprinkle-icon.ts
@@ -13,9 +13,14 @@
  * `resolveSprinkleIconHtml(spec, fs)` returns SVG/HTML markup ready
  * to drop into `RailItem.icon`, or `null` if the spec is missing or
  * unresolvable. Callers fall back to their own default glyph.
+ *
+ * Security: only Lucide-registry SVGs (which we ship and trust) are
+ * inlined as raw markup. Author-supplied SVG (inline spec or VFS
+ * file) is rendered through an `<img src="data:image/svg+xml;base64,...">`
+ * tag so it lands in the browser's script-disabled SVG context and
+ * cannot escape the rail back into the parent UI.
  */
 
-import { icons as lucideIcons } from 'lucide';
 import type { VirtualFS } from '../fs/index.js';
 import { createLogger } from '../core/logger.js';
 
@@ -29,6 +34,20 @@ const SVG_OPEN =
   '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">';
 const SVG_CLOSE = '</svg>';
 
+/**
+ * Lazy-load the Lucide icon registry. Lucide ships ~1500 SVG glyphs
+ * and pulling the whole `icons` map at module-eval time would bloat
+ * the main UI bundle even for sprinkles that use a VFS file or no
+ * icon at all. We import on first lookup and cache the promise.
+ */
+let lucideRegistryPromise: Promise<IconRegistry> | null = null;
+function loadLucideRegistry(): Promise<IconRegistry> {
+  if (!lucideRegistryPromise) {
+    lucideRegistryPromise = import('lucide').then((mod) => mod.icons as unknown as IconRegistry);
+  }
+  return lucideRegistryPromise;
+}
+
 /** kebab-case → PascalCase: "calendar-clock" → "CalendarClock". */
 function kebabToPascal(name: string): string {
   return name
@@ -38,8 +57,19 @@ function kebabToPascal(name: string): string {
     .join('');
 }
 
+/**
+ * Escape a value for safe insertion inside an HTML attribute.
+ * Escapes the full set of attribute-breaking characters — escaping
+ * only `"` lets entity-encoded payloads (e.g. `&quot;`) close the
+ * attribute and inject new ones such as `onerror=`.
+ */
 function escapeAttr(value: string | number): string {
-  return String(value).replace(/"/g, '&quot;');
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 /** Render a lucide IconNode array to inline SVG markup. */
@@ -55,10 +85,15 @@ function renderLucideToSvg(nodes: LucideNode[]): string {
   return `${SVG_OPEN}${inner}${SVG_CLOSE}`;
 }
 
-/** Look up a Lucide icon by kebab-case name. Returns the SVG HTML or null. */
-export function lucideIconHtml(name: string): string | null {
+/**
+ * Look up a Lucide icon by kebab-case name. Returns the SVG HTML or
+ * null. Async because it lazy-loads the Lucide registry on first
+ * use to keep the main bundle slim.
+ */
+export async function lucideIconHtml(name: string): Promise<string | null> {
   const key = kebabToPascal(name);
-  const node = (lucideIcons as IconRegistry)[key];
+  const icons = await loadLucideRegistry();
+  const node = icons[key];
   if (!node) return null;
   return renderLucideToSvg(node);
 }
@@ -92,6 +127,12 @@ function imgTag(src: string): string {
  * Resolve a sprinkle icon spec to inline HTML the rail can render.
  * Returns `null` when the spec is missing or unresolvable so the
  * caller can fall back to its default glyph.
+ *
+ * Author-supplied SVG (inline spec, VFS file) is wrapped as
+ * `<img src="data:image/svg+xml;base64,...">` so it renders in the
+ * browser's script-disabled SVG context. Lucide-registry SVGs are
+ * inlined verbatim because we own the registry and inline rendering
+ * lets `stroke="currentColor"` inherit the rail's foreground color.
  */
 export async function resolveSprinkleIconHtml(
   spec: string | undefined,
@@ -99,22 +140,23 @@ export async function resolveSprinkleIconHtml(
 ): Promise<string | null> {
   if (!spec) return null;
 
-  // 1. Inline SVG — return verbatim. Authors are responsible for
-  //    producing a 16×16-friendly viewBox; we don't rewrite their
-  //    markup here so they keep full control.
-  if (isInlineSvg(spec)) return spec;
+  // 1. Inline SVG — wrap as a data URL <img>. Direct innerHTML of
+  //    author-supplied SVG would let `<svg onload=…>`, embedded
+  //    `<script>`, or `<foreignObject>` execute in the parent UI
+  //    context.
+  if (isInlineSvg(spec)) return imgTag(svgToDataUrl(spec));
 
-  // 2. data: URL — wrap as <img>.
+  // 2. data: URL — wrap as <img>. Same script-disabled rendering.
   if (isDataUrl(spec)) return imgTag(spec);
 
-  // 3. VFS path — read and inline (SVG) or wrap as data URL (raster).
+  // 3. VFS path — read and wrap as a data URL <img>.
   if (looksLikeVfsPath(spec) && fs) {
     try {
       if (isImagePath(spec) && spec.toLowerCase().endsWith('.svg')) {
         const raw = await fs.readFile(spec, { encoding: 'utf-8' });
         const text = typeof raw === 'string' ? raw : new TextDecoder('utf-8').decode(raw);
         const svg = extractFirstSvg(text);
-        return svg ?? null;
+        return svg ? imgTag(svgToDataUrl(svg)) : null;
       }
       if (isImagePath(spec)) {
         const raw = await fs.readFile(spec, { encoding: 'binary' });
@@ -126,7 +168,7 @@ export async function resolveSprinkleIconHtml(
       const raw = await fs.readFile(spec, { encoding: 'utf-8' });
       const text = typeof raw === 'string' ? raw : new TextDecoder('utf-8').decode(raw);
       const svg = extractFirstSvg(text);
-      if (svg) return svg;
+      if (svg) return imgTag(svgToDataUrl(svg));
     } catch (err) {
       log.warn('Failed to read sprinkle icon from VFS', {
         path: spec,
@@ -138,12 +180,17 @@ export async function resolveSprinkleIconHtml(
 
   // 4. Lucide icon name.
   if (isLucideName(spec)) {
-    const html = lucideIconHtml(spec);
+    const html = await lucideIconHtml(spec);
     if (html) return html;
     log.warn('Unknown Lucide icon name', { spec });
   }
 
   return null;
+}
+
+function svgToDataUrl(svg: string): string {
+  const bytes = new TextEncoder().encode(svg);
+  return `data:image/svg+xml;base64,${bytesToBase64(bytes)}`;
 }
 
 /** Pull the first `<svg>...</svg>` block out of a text blob. */

--- a/packages/webapp/src/ui/sprinkle-icon.ts
+++ b/packages/webapp/src/ui/sprinkle-icon.ts
@@ -1,0 +1,177 @@
+/**
+ * Sprinkle icon resolver.
+ *
+ * Sprinkles can specify a rail icon via `<link rel="icon" href="...">`
+ * or `data-sprinkle-icon="..."`. The raw spec captured by
+ * `sprinkle-discovery.ts` is one of:
+ *
+ * - a Lucide icon name in kebab-case (e.g. `music`, `calendar-clock`)
+ * - a VFS path to an SVG or PNG (e.g. `/workspace/skills/foo/icon.svg`)
+ * - an inline SVG (`<svg ...>...</svg>`)
+ * - a `data:image/...` URL
+ *
+ * `resolveSprinkleIconHtml(spec, fs)` returns SVG/HTML markup ready
+ * to drop into `RailItem.icon`, or `null` if the spec is missing or
+ * unresolvable. Callers fall back to their own default glyph.
+ */
+
+import { icons as lucideIcons } from 'lucide';
+import type { VirtualFS } from '../fs/index.js';
+import { createLogger } from '../core/logger.js';
+
+const log = createLogger('sprinkle-icon');
+
+type LucideAttrs = Record<string, string | number | undefined>;
+type LucideNode = [tag: string, attrs: LucideAttrs];
+type IconRegistry = Record<string, LucideNode[]>;
+
+const SVG_OPEN =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">';
+const SVG_CLOSE = '</svg>';
+
+/** kebab-case → PascalCase: "calendar-clock" → "CalendarClock". */
+function kebabToPascal(name: string): string {
+  return name
+    .split('-')
+    .filter(Boolean)
+    .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+    .join('');
+}
+
+function escapeAttr(value: string | number): string {
+  return String(value).replace(/"/g, '&quot;');
+}
+
+/** Render a lucide IconNode array to inline SVG markup. */
+function renderLucideToSvg(nodes: LucideNode[]): string {
+  const inner = nodes
+    .map(([tag, attrs]) => {
+      const parts = Object.entries(attrs)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => `${k}="${escapeAttr(v as string | number)}"`);
+      return parts.length ? `<${tag} ${parts.join(' ')}/>` : `<${tag}/>`;
+    })
+    .join('');
+  return `${SVG_OPEN}${inner}${SVG_CLOSE}`;
+}
+
+/** Look up a Lucide icon by kebab-case name. Returns the SVG HTML or null. */
+export function lucideIconHtml(name: string): string | null {
+  const key = kebabToPascal(name);
+  const node = (lucideIcons as IconRegistry)[key];
+  if (!node) return null;
+  return renderLucideToSvg(node);
+}
+
+function isInlineSvg(spec: string): boolean {
+  return /^\s*<svg\b/i.test(spec);
+}
+
+function isDataUrl(spec: string): boolean {
+  return /^data:/i.test(spec);
+}
+
+function looksLikeVfsPath(spec: string): boolean {
+  return spec.startsWith('/');
+}
+
+function isImagePath(spec: string): boolean {
+  return /\.(svg|png|jpe?g|webp|gif|ico)$/i.test(spec);
+}
+
+function isLucideName(spec: string): boolean {
+  return /^[a-z][a-z0-9-]*$/.test(spec);
+}
+
+/** Wrap a URL/data URL as a 16×16 `<img>` for the rail. */
+function imgTag(src: string): string {
+  return `<img src="${escapeAttr(src)}" width="16" height="16" alt="" style="display:block;width:16px;height:16px;object-fit:contain"/>`;
+}
+
+/**
+ * Resolve a sprinkle icon spec to inline HTML the rail can render.
+ * Returns `null` when the spec is missing or unresolvable so the
+ * caller can fall back to its default glyph.
+ */
+export async function resolveSprinkleIconHtml(
+  spec: string | undefined,
+  fs: VirtualFS | null | undefined
+): Promise<string | null> {
+  if (!spec) return null;
+
+  // 1. Inline SVG — return verbatim. Authors are responsible for
+  //    producing a 16×16-friendly viewBox; we don't rewrite their
+  //    markup here so they keep full control.
+  if (isInlineSvg(spec)) return spec;
+
+  // 2. data: URL — wrap as <img>.
+  if (isDataUrl(spec)) return imgTag(spec);
+
+  // 3. VFS path — read and inline (SVG) or wrap as data URL (raster).
+  if (looksLikeVfsPath(spec) && fs) {
+    try {
+      if (isImagePath(spec) && spec.toLowerCase().endsWith('.svg')) {
+        const raw = await fs.readFile(spec, { encoding: 'utf-8' });
+        const text = typeof raw === 'string' ? raw : new TextDecoder('utf-8').decode(raw);
+        const svg = extractFirstSvg(text);
+        return svg ?? null;
+      }
+      if (isImagePath(spec)) {
+        const raw = await fs.readFile(spec, { encoding: 'binary' });
+        const bytes = raw instanceof Uint8Array ? raw : new Uint8Array(0);
+        const mime = mimeForPath(spec);
+        return imgTag(`data:${mime};base64,${bytesToBase64(bytes)}`);
+      }
+      // Path doesn't end with a known image extension — try as text SVG.
+      const raw = await fs.readFile(spec, { encoding: 'utf-8' });
+      const text = typeof raw === 'string' ? raw : new TextDecoder('utf-8').decode(raw);
+      const svg = extractFirstSvg(text);
+      if (svg) return svg;
+    } catch (err) {
+      log.warn('Failed to read sprinkle icon from VFS', {
+        path: spec,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return null;
+  }
+
+  // 4. Lucide icon name.
+  if (isLucideName(spec)) {
+    const html = lucideIconHtml(spec);
+    if (html) return html;
+    log.warn('Unknown Lucide icon name', { spec });
+  }
+
+  return null;
+}
+
+/** Pull the first `<svg>...</svg>` block out of a text blob. */
+function extractFirstSvg(text: string): string | null {
+  const match = text.match(/<svg\b[\s\S]*?<\/svg>/i);
+  return match ? match[0] : null;
+}
+
+function mimeForPath(path: string): string {
+  const lower = path.toLowerCase();
+  if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+  if (lower.endsWith('.webp')) return 'image/webp';
+  if (lower.endsWith('.gif')) return 'image/gif';
+  if (lower.endsWith('.ico')) return 'image/x-icon';
+  return 'application/octet-stream';
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + CHUNK)) as unknown as number[]
+    );
+  }
+  if (typeof btoa !== 'undefined') return btoa(binary);
+  // Node fallback (tests).
+  return Buffer.from(binary, 'binary').toString('base64');
+}

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -25,6 +25,15 @@ export interface AddSprinkleOptions {
   attention?: boolean;
 }
 
+export interface SprinkleAddOptions extends AddSprinkleOptions {
+  /**
+   * Raw icon spec from the .shtml. Forwarded so the layout can
+   * render a per-sprinkle rail glyph instead of the generic
+   * Sparkles default. See `sprinkle-icon.ts` for accepted formats.
+   */
+  icon?: string;
+}
+
 export interface SprinkleManagerCallbacks {
   /** Called to add a sprinkle to the layout (standalone: right column, extension: tab). */
   addSprinkle(
@@ -32,7 +41,7 @@ export interface SprinkleManagerCallbacks {
     title: string,
     element: HTMLElement,
     zone?: string,
-    options?: AddSprinkleOptions
+    options?: SprinkleAddOptions
   ): void;
   /** Called to remove a sprinkle from the layout. */
   removeSprinkle(name: string): void;
@@ -327,7 +336,10 @@ export class SprinkleManager {
     this.openSprinkles.set(name, { renderer: null!, container });
     if (options.attention) this.attentionOnly.add(name);
     else this.attentionOnly.delete(name);
-    this.callbacks.addSprinkle(name, sprinkle.title, container, zone, options);
+    this.callbacks.addSprinkle(name, sprinkle.title, container, zone, {
+      ...options,
+      icon: sprinkle.icon,
+    });
 
     const api = this.bridge.createAPI(name);
     const renderer = new SprinkleRenderer(container, api);

--- a/packages/webapp/tests/ui/sprinkle-discovery.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-discovery.test.ts
@@ -185,6 +185,27 @@ describe('extractIcon', () => {
   it('handles single-quoted attributes', () => {
     expect(extractIcon("<link rel='icon' href='star' />")).toBe('star');
   });
+
+  it('preserves embedded double quotes inside a single-quoted href', () => {
+    const svg =
+      'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>';
+    const tag = `<link rel="icon" href='${svg}' />`;
+    expect(extractIcon(tag)).toBe(svg);
+  });
+
+  it('preserves embedded > characters inside a quoted href value', () => {
+    // `>` inside a quoted attribute is legal HTML; a parser that
+    // bails at the first `>` would truncate the data URL.
+    const svg = "data:image/svg+xml;utf8,<svg viewBox='0 0 1 1'><path d='M0 0'/></svg>";
+    const tag = `<link rel="icon" href="${svg}" />`;
+    expect(extractIcon(tag)).toBe(svg);
+  });
+
+  it('preserves embedded single quotes inside a double-quoted href', () => {
+    const svg = "data:image/svg+xml;utf8,<svg viewBox='0 0 24 24'/>";
+    const tag = `<link rel="icon" href="${svg}" />`;
+    expect(extractIcon(tag)).toBe(svg);
+  });
 });
 
 describe('discoverSprinkles icon', () => {

--- a/packages/webapp/tests/ui/sprinkle-discovery.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-discovery.test.ts
@@ -5,6 +5,7 @@ import {
   discoverSprinkles,
   extractTitle,
   extractAutoOpen,
+  extractIcon,
 } from '../../src/ui/sprinkle-discovery.js';
 
 describe('discoverSprinkles', () => {
@@ -144,6 +145,81 @@ describe('extractAutoOpen', () => {
 
   it('returns false for empty content', () => {
     expect(extractAutoOpen('')).toBe(false);
+  });
+});
+
+describe('extractIcon', () => {
+  it('returns href from <link rel="icon"> tag', () => {
+    expect(extractIcon('<link rel="icon" href="music" />')).toBe('music');
+  });
+
+  it('returns href from <link rel="shortcut icon"> tag', () => {
+    expect(extractIcon('<link rel="shortcut icon" href="/icons/foo.svg" />')).toBe(
+      '/icons/foo.svg'
+    );
+  });
+
+  it('handles attribute order rel before href and href before rel', () => {
+    expect(extractIcon('<link href="bell" rel="icon" />')).toBe('bell');
+    expect(extractIcon('<link rel="icon" href="bell" />')).toBe('bell');
+  });
+
+  it('falls back to data-sprinkle-icon attribute', () => {
+    expect(extractIcon('<html data-sprinkle-icon="calendar-clock"><body/></html>')).toBe(
+      'calendar-clock'
+    );
+  });
+
+  it('prefers <link rel="icon"> over data-sprinkle-icon', () => {
+    expect(
+      extractIcon(
+        '<html data-sprinkle-icon="calendar"><head><link rel="icon" href="music" /></head></html>'
+      )
+    ).toBe('music');
+  });
+
+  it('returns undefined when neither hint is present', () => {
+    expect(extractIcon('<div>no icon here</div>')).toBeUndefined();
+  });
+
+  it('handles single-quoted attributes', () => {
+    expect(extractIcon("<link rel='icon' href='star' />")).toBe('star');
+  });
+});
+
+describe('discoverSprinkles icon', () => {
+  let vfs: VirtualFS;
+  let dbCounter = 200;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({
+      dbName: `test-sprinkle-icon-discovery-${dbCounter++}`,
+      wipe: true,
+    });
+  });
+
+  it('captures the icon spec from <link rel="icon">', async () => {
+    await vfs.writeFile(
+      '/shared/sprinkles/strudel-music/strudel-music.shtml',
+      '<head><link rel="icon" href="music" /></head><body><div>jam</div></body>'
+    );
+    const result = await discoverSprinkles(vfs);
+    expect(result.get('strudel-music')!.icon).toBe('music');
+  });
+
+  it('captures the icon spec from data-sprinkle-icon', async () => {
+    await vfs.writeFile(
+      '/shared/sprinkles/cal/cal.shtml',
+      '<div data-sprinkle-icon="calendar-clock">cal</div>'
+    );
+    const result = await discoverSprinkles(vfs);
+    expect(result.get('cal')!.icon).toBe('calendar-clock');
+  });
+
+  it('leaves icon undefined when no spec is present', async () => {
+    await vfs.writeFile('/shared/sprinkles/plain/plain.shtml', '<div>plain</div>');
+    const result = await discoverSprinkles(vfs);
+    expect(result.get('plain')!.icon).toBeUndefined();
   });
 });
 

--- a/packages/webapp/tests/ui/sprinkle-icon.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-icon.test.ts
@@ -1,0 +1,75 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { resolveSprinkleIconHtml, lucideIconHtml } from '../../src/ui/sprinkle-icon.js';
+
+describe('lucideIconHtml', () => {
+  it('returns SVG markup for a known kebab-case name', () => {
+    const html = lucideIconHtml('music');
+    expect(html).not.toBeNull();
+    expect(html!).toContain('<svg');
+    expect(html!).toContain('viewBox="0 0 24 24"');
+    expect(html!).toContain('stroke="currentColor"');
+  });
+
+  it('handles multi-segment names like calendar-clock', () => {
+    const html = lucideIconHtml('calendar-clock');
+    expect(html).not.toBeNull();
+    expect(html!).toContain('<svg');
+  });
+
+  it('returns null for unknown icon names', () => {
+    expect(lucideIconHtml('not-a-real-icon-xyz')).toBeNull();
+  });
+});
+
+describe('resolveSprinkleIconHtml', () => {
+  let vfs: VirtualFS;
+  let dbCounter = 300;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({
+      dbName: `test-sprinkle-icon-${dbCounter++}`,
+      wipe: true,
+    });
+  });
+
+  it('returns null for an undefined spec', async () => {
+    expect(await resolveSprinkleIconHtml(undefined, vfs)).toBeNull();
+  });
+
+  it('resolves a Lucide icon name to inline SVG', async () => {
+    const html = await resolveSprinkleIconHtml('terminal', vfs);
+    expect(html).not.toBeNull();
+    expect(html!.startsWith('<svg')).toBe(true);
+  });
+
+  it('passes inline SVG through unchanged', async () => {
+    const inline = '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>';
+    expect(await resolveSprinkleIconHtml(inline, vfs)).toBe(inline);
+  });
+
+  it('wraps a data: URL in an <img>', async () => {
+    const dataUrl = 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"/>';
+    const html = await resolveSprinkleIconHtml(dataUrl, vfs);
+    expect(html).not.toBeNull();
+    expect(html!.startsWith('<img')).toBe(true);
+    expect(html!).toContain('width="16"');
+    expect(html!).toContain(dataUrl.replace(/"/g, '&quot;'));
+  });
+
+  it('reads an SVG file from the VFS and inlines it', async () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>';
+    await vfs.writeFile('/shared/icons/foo.svg', svg);
+    const html = await resolveSprinkleIconHtml('/shared/icons/foo.svg', vfs);
+    expect(html).toBe(svg);
+  });
+
+  it('returns null for an unknown Lucide name', async () => {
+    expect(await resolveSprinkleIconHtml('definitely-not-an-icon', vfs)).toBeNull();
+  });
+
+  it('returns null when a VFS path does not exist', async () => {
+    expect(await resolveSprinkleIconHtml('/missing/icon.svg', vfs)).toBeNull();
+  });
+});

--- a/packages/webapp/tests/ui/sprinkle-icon.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-icon.test.ts
@@ -4,22 +4,22 @@ import { VirtualFS } from '../../src/fs/virtual-fs.js';
 import { resolveSprinkleIconHtml, lucideIconHtml } from '../../src/ui/sprinkle-icon.js';
 
 describe('lucideIconHtml', () => {
-  it('returns SVG markup for a known kebab-case name', () => {
-    const html = lucideIconHtml('music');
+  it('returns SVG markup for a known kebab-case name', async () => {
+    const html = await lucideIconHtml('music');
     expect(html).not.toBeNull();
     expect(html!).toContain('<svg');
     expect(html!).toContain('viewBox="0 0 24 24"');
     expect(html!).toContain('stroke="currentColor"');
   });
 
-  it('handles multi-segment names like calendar-clock', () => {
-    const html = lucideIconHtml('calendar-clock');
+  it('handles multi-segment names like calendar-clock', async () => {
+    const html = await lucideIconHtml('calendar-clock');
     expect(html).not.toBeNull();
     expect(html!).toContain('<svg');
   });
 
-  it('returns null for unknown icon names', () => {
-    expect(lucideIconHtml('not-a-real-icon-xyz')).toBeNull();
+  it('returns null for unknown icon names', async () => {
+    expect(await lucideIconHtml('not-a-real-icon-xyz')).toBeNull();
   });
 });
 
@@ -44,9 +44,25 @@ describe('resolveSprinkleIconHtml', () => {
     expect(html!.startsWith('<svg')).toBe(true);
   });
 
-  it('passes inline SVG through unchanged', async () => {
+  it('wraps inline SVG as a base64 data-url <img> (script-disabled context)', async () => {
     const inline = '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>';
-    expect(await resolveSprinkleIconHtml(inline, vfs)).toBe(inline);
+    const html = await resolveSprinkleIconHtml(inline, vfs);
+    expect(html).not.toBeNull();
+    expect(html!.startsWith('<img')).toBe(true);
+    expect(html!).toContain('src="data:image/svg+xml;base64,');
+    // The raw SVG must NOT be inlined verbatim — that would let
+    // <svg onload=...>, <script>, and <foreignObject> escape into
+    // the parent UI's DOM.
+    expect(html!).not.toContain('<circle');
+  });
+
+  it('does not allow event-handler escapes from a malicious inline SVG', async () => {
+    const malicious = '<svg onload="alert(1)"><script>alert(2)</script></svg>';
+    const html = await resolveSprinkleIconHtml(malicious, vfs);
+    expect(html).not.toBeNull();
+    expect(html!).not.toContain('onload=');
+    expect(html!).not.toContain('<script');
+    expect(html!.startsWith('<img')).toBe(true);
   });
 
   it('wraps a data: URL in an <img>', async () => {
@@ -55,14 +71,29 @@ describe('resolveSprinkleIconHtml', () => {
     expect(html).not.toBeNull();
     expect(html!.startsWith('<img')).toBe(true);
     expect(html!).toContain('width="16"');
-    expect(html!).toContain(dataUrl.replace(/"/g, '&quot;'));
+    // Verify proper attribute escaping: <, >, &, " all encoded.
+    expect(html!).toContain('&lt;svg');
+    expect(html!).toContain('xmlns=&quot;');
   });
 
-  it('reads an SVG file from the VFS and inlines it', async () => {
+  it('escapes & in the src attribute so entity payloads cannot break out', async () => {
+    const dataUrl = 'data:image/svg+xml;utf8,<svg/>?x=&quot;onerror=&quot;';
+    const html = await resolveSprinkleIconHtml(dataUrl, vfs);
+    expect(html).not.toBeNull();
+    // & must be escaped as &amp; — otherwise &quot; entities in the
+    // payload would close the src attribute and inject new ones.
+    expect(html!).toContain('&amp;quot;');
+    expect(html!).not.toMatch(/src="[^"]*&quot;[^"]*"/);
+  });
+
+  it('reads an SVG file from the VFS and renders it via <img> (no innerHTML escape)', async () => {
     const svg = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>';
     await vfs.writeFile('/shared/icons/foo.svg', svg);
     const html = await resolveSprinkleIconHtml('/shared/icons/foo.svg', vfs);
-    expect(html).toBe(svg);
+    expect(html).not.toBeNull();
+    expect(html!.startsWith('<img')).toBe(true);
+    expect(html!).toContain('src="data:image/svg+xml;base64,');
+    expect(html!).not.toContain('<path');
   });
 
   it('returns null for an unknown Lucide name', async () => {


### PR DESCRIPTION
**Stacked on top of #545.** Merge #545 first.

## Why

Every sprinkle currently uses the same generic Sparkles glyph in the rail. Once #545 starts surfacing newly-installed sprinkles in the rail by default, that uniformity becomes a real problem — three or four installed sprinkles all look identical. Authors need a way to give their sprinkle a distinct icon.

## What

Sprinkles can now declare their own rail glyph via the standard favicon hook:

```html
<link rel="icon" href="music" />
```

Three accepted formats, in order of preference:

1. **Lucide icon name** (kebab-case, e.g. `music`, `calendar-clock`, `chart-bar`) — preferred, covers the full ~1500-icon Lucide set.
2. **VFS path** to an SVG/PNG file: `<link rel="icon" href="/shared/sprinkles/foo/icon.svg">`.
3. **Inline SVG** or **`data:image/svg+xml;...` URL** for one-offs.

`data-sprinkle-icon="..."` on any element is also accepted as a fallback hint.

## Implementation

- `packages/webapp/src/ui/sprinkle-discovery.ts` — `Sprinkle` gains `icon?: string`. New `extractIcon(content)` helper parses `<link rel="icon">` (preferred) and `data-sprinkle-icon`.
- `packages/webapp/src/ui/sprinkle-icon.ts` (new) — `resolveSprinkleIconHtml(spec, fs)` and `lucideIconHtml(name)`. Backed by the full Lucide registry (`import { icons } from 'lucide'`). Inline SVG passes through verbatim; `data:` URLs are wrapped in a 16×16 `<img>`; raster VFS paths are inlined as base64 data URLs.
- `packages/webapp/src/ui/sprinkle-manager.ts` — `SprinkleAddOptions` carries `icon`; `open()` forwards `sprinkle.icon` to the `addSprinkle` callback.
- `packages/webapp/src/ui/layout.ts` — `addSprinkle` accepts `options.icon` and calls a new `Layout.resolveSprinkleIcon` callback to upgrade the rail glyph asynchronously. The default Sparkles icon is still rendered first so the entry stays clickable while the resolver runs.
- `packages/webapp/src/ui/rail-zone.ts` — new `setItemIcon(id, html)` swaps an item's SVG while preserving the press-ripple layer.
- `packages/webapp/src/ui/main.ts` — both runtimes (standalone + extension panel) wire `layout.resolveSprinkleIcon = (spec) => resolveSprinkleIconHtml(spec, fs)`.
- `packages/chrome-extension/src/sprinkle-proxy.ts` — `Sprinkle` interface mirrors the new `icon` field so cached records survive the relay.

## vfs-root skill

The sprinkles authoring skill is updated so newly created sprinkles get a proper icon by default:

- `packages/vfs-root/workspace/skills/sprinkles/SKILL.md` — adds a "Sprinkle icon" section explaining the three formats with a curated icon-name list. The cone-orchestration brief tells future scoops to pick an icon (step 2).
- `packages/vfs-root/workspace/skills/sprinkles/style-guide.md` — boilerplate snippets include `<link rel="icon" href="...">` and the scoop brief template names "pick a Lucide icon" as an explicit step.

## Testing

- New `packages/webapp/tests/ui/sprinkle-icon.test.ts` (10 tests) covers the resolver: Lucide name → SVG, inline SVG passthrough, `data:` URL → `<img>`, VFS-path SVG inlining, unknown specs → `null`.
- `packages/webapp/tests/ui/sprinkle-discovery.test.ts` extended (10 new tests) covering `extractIcon` priority and `Sprinkle.icon` propagation.
- **Live verification**: after adding `<link rel="icon" href="music" />` to the strudel sprinkle the rail icon SVG matches the Lucide music path (`M9 18V5...`) instead of the Sparkles default. Verified via CDP.
- `npm run typecheck` clean.
- `npx prettier --check` clean.
- 49 sprinkle-related vitest cases passing.

## Files

- `packages/webapp/src/ui/sprinkle-discovery.ts`
- `packages/webapp/src/ui/sprinkle-icon.ts` (new)
- `packages/webapp/src/ui/sprinkle-manager.ts`
- `packages/webapp/src/ui/layout.ts`
- `packages/webapp/src/ui/rail-zone.ts`
- `packages/webapp/src/ui/main.ts`
- `packages/chrome-extension/src/sprinkle-proxy.ts`
- `packages/vfs-root/workspace/skills/sprinkles/SKILL.md`
- `packages/vfs-root/workspace/skills/sprinkles/style-guide.md`
- `packages/webapp/tests/ui/sprinkle-icon.test.ts` (new)
- `packages/webapp/tests/ui/sprinkle-discovery.test.ts`
