### PR TITLE
ci(release): pin repositoryUrl to SSH form

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": ["main"],
+  "repositoryUrl": "git@github.com:ai-ecoverse/slicc.git",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Follow-up to #546. `@semantic-release/git` resolves its push URL from `package.json`'s `repository.url` (HTTPS), not from the configured git remote. Even with the deploy key configured by `actions/checkout`, semantic-release was still running `git push --tags https://github.com/ai-ecoverse/slicc HEAD:main` (anonymous), which is rejected by the merge queue ruleset.

Override `repositoryUrl` in `.releaserc.json` so the push goes through `git@github.com` using the `RELEASE_DEPLOY_KEY` (already a bypass actor). `@semantic-release/github` keeps using `GITHUB_TOKEN` over the REST API.