### PR TITLE
fix(github): update models to free-tier offerings and fix API endpoint

### DIFF
--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -218,45 +218,33 @@ async function getValidAccessToken(): Promise<string> {
 
 // ── GitHub Models ──────────────────────────────────────────────────
 
-const GITHUB_MODELS_BASE = 'https://models.inference.ai.azure.com';
+// New unified GitHub Models endpoint (replaces the old Azure inference endpoint).
+// Model IDs use vendor-prefixed format: "openai/gpt-4.1"
+const GITHUB_MODELS_BASE = 'https://models.github.ai/inference';
 
-/** Known models available via GitHub Models. */
+/**
+ * Models available via GitHub Models free tier (no Copilot subscription required).
+ * gpt-4o / gpt-4o-mini / o3-mini are deprecated; o4-mini requires a paid Copilot plan.
+ * Model IDs use the vendor-prefixed format required by the models.github.ai endpoint.
+ */
 const GITHUB_MODELS: Array<{ id: string; name: string } & ModelMetadata> = [
   {
-    id: 'gpt-4o',
-    name: 'GPT-4o',
+    id: 'openai/gpt-4.1',
+    name: 'GPT-4.1',
     api: 'openai',
-    context_window: 128000,
-    max_tokens: 16384,
+    context_window: 1047576,
+    max_tokens: 32768,
     reasoning: false,
     input: ['text', 'image'],
   },
   {
-    id: 'gpt-4o-mini',
-    name: 'GPT-4o Mini',
+    id: 'openai/gpt-4.1-mini',
+    name: 'GPT-4.1 mini',
     api: 'openai',
-    context_window: 128000,
-    max_tokens: 16384,
+    context_window: 1047576,
+    max_tokens: 32768,
     reasoning: false,
     input: ['text', 'image'],
-  },
-  {
-    id: 'o4-mini',
-    name: 'o4-mini',
-    api: 'openai',
-    context_window: 200000,
-    max_tokens: 100000,
-    reasoning: true,
-    input: ['text', 'image'],
-  },
-  {
-    id: 'o3-mini',
-    name: 'o3-mini',
-    api: 'openai',
-    context_window: 200000,
-    max_tokens: 100000,
-    reasoning: true,
-    input: ['text'],
   },
 ];
 
@@ -298,9 +286,17 @@ const streamGitHub = (
       const accessToken = await getValidAccessToken();
       const proxyModel = {
         ...model,
-        baseUrl: `${GITHUB_MODELS_BASE}/v1`,
+        baseUrl: GITHUB_MODELS_BASE,
         api: 'openai-completions' as Api,
-        compat: { ...(model as any).compat, supportsStore: false, supportsDeveloperRole: false },
+        compat: {
+          ...(model as any).compat,
+          supportsStore: false,
+          supportsDeveloperRole: false,
+          // models.github.ai/inference does not support stream_options.include_usage
+          // (causes 500 after ~30s timeout) or max_completion_tokens (use max_tokens).
+          supportsUsageInStreaming: false,
+          maxTokensField: 'max_tokens',
+        },
       };
       const inner = streamOpenAICompletions(proxyModel as any, context, {
         ...options,
@@ -327,9 +323,17 @@ const streamSimpleGitHub = (model: Model<Api>, context: Context, options?: Simpl
       const accessToken = await getValidAccessToken();
       const proxyModel = {
         ...model,
-        baseUrl: `${GITHUB_MODELS_BASE}/v1`,
+        baseUrl: GITHUB_MODELS_BASE,
         api: 'openai-completions' as Api,
-        compat: { ...(model as any).compat, supportsStore: false, supportsDeveloperRole: false },
+        compat: {
+          ...(model as any).compat,
+          supportsStore: false,
+          supportsDeveloperRole: false,
+          // models.github.ai/inference does not support stream_options.include_usage
+          // (causes 500 after ~30s timeout) or max_completion_tokens (use max_tokens).
+          supportsUsageInStreaming: false,
+          maxTokensField: 'max_tokens',
+        },
       };
       const inner = streamSimpleOpenAICompletions(proxyModel as any, context, {
         ...options,
@@ -358,7 +362,7 @@ export const config: ProviderConfig = {
   requiresApiKey: false,
   requiresBaseUrl: false,
   isOAuth: true,
-  defaultModelId: 'gpt-4o',
+  defaultModelId: 'gpt-4.1', // substring-matched against openai/gpt-4.1
 
   getModelIds: () => GITHUB_MODELS,
 

--- a/packages/webapp/tests/providers/github-provider.test.ts
+++ b/packages/webapp/tests/providers/github-provider.test.ts
@@ -115,25 +115,79 @@ describe('GitHub account storage', () => {
 });
 
 describe('GitHub Models configuration', () => {
-  it('known models are OpenAI-compatible', () => {
-    // These match the GITHUB_MODELS array in github.ts
-    const models = [
-      { id: 'gpt-4o', api: 'openai' },
-      { id: 'gpt-4o-mini', api: 'openai' },
-      { id: 'o4-mini', api: 'openai' },
-      { id: 'o3-mini', api: 'openai' },
-    ];
+  // Free-tier models available to all GitHub accounts (no paid Copilot plan required).
+  // gpt-4o / gpt-4o-mini / o3-mini are deprecated by GitHub; o4-mini requires a paid plan.
+  // Model IDs use the vendor-prefixed format required by models.github.ai.
+  const GITHUB_MODELS = [
+    {
+      id: 'openai/gpt-4.1',
+      name: 'GPT-4.1',
+      api: 'openai',
+      context_window: 1047576,
+      max_tokens: 32768,
+      reasoning: false,
+    },
+    {
+      id: 'openai/gpt-4.1-mini',
+      name: 'GPT-4.1 mini',
+      api: 'openai',
+      context_window: 1047576,
+      max_tokens: 32768,
+      reasoning: false,
+    },
+  ];
 
-    for (const m of models) {
-      expect(m.api).toBe('openai');
+  it('only contains free-tier models (no paid-plan-only models)', () => {
+    const paidOnlyIds = ['o4-mini', 'o3-mini', 'o1', 'o1-mini', 'o3'].flatMap((m) => [
+      m,
+      `openai/${m}`,
+    ]);
+    for (const model of GITHUB_MODELS) {
+      expect(paidOnlyIds).not.toContain(model.id);
     }
-    expect(models.length).toBeGreaterThan(0);
   });
 
-  it('models endpoint is OpenAI-compatible', () => {
-    const baseUrl = 'https://models.inference.ai.azure.com';
-    // The provider appends /v1 so the OpenAI SDK adds /chat/completions
-    expect(`${baseUrl}/v1`).toBe('https://models.inference.ai.azure.com/v1');
+  it('does not contain deprecated models', () => {
+    const deprecatedIds = ['gpt-4o', 'gpt-4o-mini', 'o3-mini', 'gpt-4.5', 'o1'].flatMap((m) => [
+      m,
+      `openai/${m}`,
+    ]);
+    for (const model of GITHUB_MODELS) {
+      expect(deprecatedIds).not.toContain(model.id);
+    }
+  });
+
+  it('all models are OpenAI-compatible', () => {
+    for (const m of GITHUB_MODELS) {
+      expect(m.api).toBe('openai');
+    }
+  });
+
+  it('uses vendor-prefixed model IDs required by models.github.ai', () => {
+    for (const m of GITHUB_MODELS) {
+      expect(m.id).toMatch(/^openai\//);
+    }
+  });
+
+  it('includes current flagship and mini models', () => {
+    const ids = GITHUB_MODELS.map((m) => m.id);
+    expect(ids).toContain('openai/gpt-4.1');
+    expect(ids).toContain('openai/gpt-4.1-mini');
+  });
+
+  it('models have correct context windows for gpt-4.1 series (1M tokens)', () => {
+    for (const m of GITHUB_MODELS) {
+      expect(m.context_window).toBe(1047576);
+      expect(m.max_tokens).toBe(32768);
+    }
+  });
+
+  it('models endpoint uses new GitHub inference base URL', () => {
+    const baseUrl = 'https://models.github.ai/inference';
+    // pi-ai appends /chat/completions directly — no /v1 in the new endpoint
+    expect(`${baseUrl}/chat/completions`).toBe(
+      'https://models.github.ai/inference/chat/completions'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace deprecated/gated models (`gpt-4o`, `gpt-4o-mini`, `o3-mini`, `o4-mini`) with current free-tier offerings (`gpt-4.1`, `gpt-4.1-mini`)
- Migrate from the deprecated Azure inference endpoint to the new `models.github.ai/inference` endpoint with vendor-prefixed model IDs (`openai/gpt-4.1`)
- Fix two compat flags that caused 500 errors after ~30s timeouts on the new endpoint

## What changed

**Model list** — the previous list mixed deprecated and paid-only models. The new list covers only what any logged-in GitHub account can access for free:

| Model | GitHub tier | Free? |
|---|---|---|
| `openai/gpt-4.1` | High | ✅ free to all GitHub accounts |
| `openai/gpt-4.1-mini` | Low/High | ✅ free to all GitHub accounts |
| ~~`gpt-4o`~~ | High | removed — deprecated Aug 2025 |
| ~~`gpt-4o-mini`~~ | High | removed — deprecated |
| ~~`o3-mini`~~ | Advanced | removed — deprecated, paid-only |
| ~~`o4-mini`~~ | Advanced | removed — **requires paid Copilot plan** |

**API endpoint** — GitHub has migrated away from `models.inference.ai.azure.com`. The new endpoint is `models.github.ai/inference` and requires vendor-prefixed model IDs (`openai/gpt-4.1` instead of `gpt-4o`).

**Compat fix** — pi-ai auto-detects compat flags from the base URL. Since `models.github.ai` isn't in its known-provider list it defaulted to full OpenAI-standard mode, which injected two fields the new endpoint doesn't support:
- `stream_options: {include_usage: true}` → caused a ~30s hang then 500
- `max_completion_tokens` → must be `max_tokens` for the Chat Completions API

Both are now explicitly overridden via `supportsUsageInStreaming: false` and `maxTokensField: 'max_tokens'`.

## Test plan

- [ ] Add GitHub account via OAuth in provider settings
- [ ] Confirm dropdown shows only GPT-4.1 and GPT-4.1 mini (no deprecated or paid-only models)
- [ ] Send a chat message and verify a response arrives without 404 or 500 errors
- [ ] Confirm requests go to `https://models.github.ai/inference/chat/completions` (check network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)