### PR TITLE
fix(webapp): keep sprinkle rail icon visible in active state

### DIFF
--- a/packages/webapp/src/ui/styles/tabs.css
+++ b/packages/webapp/src/ui/styles/tabs.css
@@ -414,6 +414,17 @@
   background: var(--s2-gray-800);
   color: var(--s2-gray-25);
 }
+/* Author-supplied icons render via <img> (see imgTag in
+   sprinkle-icon.ts) so they can't inherit the active state's `color`
+   the way inline Lucide SVGs can — they'd disappear into the dark
+   active background. Recolor img-rendered icons to match the active
+   foreground via filter (theme-aware). */
+.rail__item--active img {
+  filter: brightness(0);
+}
+:root.theme-light .rail__item--active img {
+  filter: brightness(0) invert(1);
+}
 .rail__item:focus-visible {
   outline: 2px solid var(--s2-accent);
   outline-offset: 2px;


### PR DESCRIPTION
## Summary

Sprinkle rail icons rendered as `<img>` (author SVG, data URL, VFS file) disappeared into the dark active background — the icon kept its intrinsic dark fill while the Lucide siblings flipped to white. After: a theme-aware `filter` on `.rail__item--active img` recolors img-rendered icons to match the active foreground.

## Why

`sprinkle-icon.ts` wraps non-Lucide icons as `<img src="data:image/svg+xml;base64,...">` so author SVG renders in the browser's script-disabled SVG context. That sandboxing also blocks `currentColor` inheritance, so when `.rail__item--active` sets `color: var(--s2-gray-25)`, only the inline Lucide SVGs (`stroke="currentColor"`) follow — img icons stay dark.

**Repro**

1. Install a sprinkle whose icon resolves to a non-Lucide source (inline SVG, data URL, or `/workspace/...` SVG).
2. Click its rail icon to activate.
3. Expected: icon visible against the dark active background.
4. Actual: icon renders dark-on-dark — see the Snowflake screenshot in the originating thread.

## Approach / Implementation notes

CSS-only change in `packages/webapp/src/ui/styles/tabs.css`:

- `.rail__item--active img { filter: brightness(0); }` — dark theme: active bg is `--s2-gray-800` = `#cfcfcf`, foreground `--s2-gray-25` = `#1a1a1a`. `brightness(0)` produces a near-black silhouette.
- `:root.theme-light .rail__item--active img { filter: brightness(0) invert(1); }` — light theme: active bg is `#292929`, foreground `#ffffff`. `brightness(0) invert(1)` produces a white silhouette.

Doesn't touch:
- Lucide icons (inline `<svg>`, not `<img>`) — already inherit `currentColor`.
- The `[+]` add button (inline SVG).
- The press ripple (`<span>`).
- The non-active state — img icons retain their intrinsic colors when idle.

Trade-off: multicolor img icons become flat silhouettes when active. Acceptable — rail icons are conventionally monochrome and the alternative is invisible.

## Cross-cutting impact

- **Floats exercised**: CLI (verified manually with the Snowflake sprinkle on Canary). Extension consumes the same `tabs.css` so the fix applies there too — not separately verified.
- **Persisted state**: none.
- **Security**: unchanged. The `<img>`-with-data-URL sandboxing in `sprinkle-icon.ts` stays as-is; the filter is purely a paint-time recolor.

## Test plan

- [x] `npx prettier --check packages/webapp/src/ui/styles/tabs.css` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test -w @slicc/webapp -- ui/rail-zone ui/sprinkle-icon` — 28/28 pass
- [x] `npm run build -w @slicc/webapp` — succeeds; rule bundles correctly
- [x] Manual smoke (CLI): `CHROME_PATH=…Canary npm run dev`, active Snowflake sprinkle renders as a clean white silhouette on the dark active background
- [ ] Manual smoke (extension) — same CSS, not separately verified
- [ ] Unit test — CSS-only change; no behavior in JS to assert against. Existing rail-zone tests still cover the active class toggle.

## Documentation

- [x] No documentation changes needed

## Risk & rollback

Single-file CSS change, paint-only effect. Revert this PR cleanly to roll back. No persisted state, no migrations.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs (none)
- [x] If this changes a contract used by other floats, I checked the followers/leader/offscreen paths (CSS shared; same selector resolves in both)