### PR TITLE
feat(webapp): plain-language multi-browser sync UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,12 @@ Load `dist/extension/` as an unpacked extension in `chrome://extensions`, then o
 
 ### 5. Run a second browser
 
-If you want to control a second browser (even on another machine), ask your main browser agent for a Tray Join URL. You can also type `host` in the built-in terminal, to get it. Copy that URL and launch a second browser throught the CLI.
+SLICC can mirror itself across multiple browsers, even on other machines:
 
-In the dialog, click "Join Tray" and paste the URL. Once you connect, the sessions are fully synchronized.
+1. **First browser:** click your avatar in the top-right header and choose **Enable multi-browser sync**. A dialog opens with the sync URL (already copied to your clipboard) and step-by-step instructions. The same dialog has a **Reset URL** button if you want to invalidate the link and disconnect connected browsers. (You can also type `host` in the built-in terminal to print the URL.)
+2. **Second browser:** open the account dialog, click **Connect to another browser**, and paste the URL. The "How do I get the sync URL?" hint inside the dialog walks through the same steps.
+
+Both browsers must run the same SLICC version. Once connected, the sessions stay in sync in real time.
 
 ### 6. Electron
 

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -80,6 +80,87 @@ The side panel emits Helix RUM beacons via the inlined `packages/webapp/src/ui/r
 
 - `packages/chrome-extension/vite.config.ts` builds the side panel UI, service worker, offscreen document, and copied static assets into `dist/extension/`.
 - The extension consumes shared browser code from `packages/webapp/` rather than duplicating core runtime logic.
+- `manifest.json` ships a stable `key` (so the production ID is fixed). For local debugging that key triggers `Content verify job failed for extension … at path: index.html` and the extension refuses to load. Build with `SLICC_EXT_DEV=1 npm run build -w @slicc/chrome-extension` to strip `key` so Chrome assigns a path-derived ID instead.
+
+## Local QA: dedicated profile preinstalled with the extension
+
+Use this when you want a clean Chrome instance running only the unpacked
+extension — for example to drive the extension UI alongside a separate
+standalone leader. The shared `chrome-launch.ts` helper exposes the
+`extension` profile (`npm run dev -- --profile extension`), but that
+also boots a node-server. The recipe below runs Chrome standalone.
+
+1. **Build with `SLICC_EXT_DEV=1`** so the manifest key is stripped:
+
+   ```bash
+   SLICC_EXT_DEV=1 npm run build -w @slicc/chrome-extension
+   ```
+
+2. **Use Chrome for Testing**, not your day-driver Chrome. Chrome
+   release builds (>=137) silently drop `--load-extension` unless
+   developer mode is already toggled on in the profile, which is awkward
+   to seed from CLI. Chrome for Testing accepts the flag without that
+   ceremony. The repo's `findChromeExecutable` helper already prefers
+   `~/.cache/puppeteer/chrome/mac_arm-*/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`.
+
+3. **Copy `dist/extension/` to a stable scratch path** so multiple runs
+   reuse the same path-derived extension ID:
+
+   ```bash
+   rm -rf /tmp/slicc-ext-build && cp -r dist/extension /tmp/slicc-ext-build
+   ```
+
+4. **Launch Chrome for Testing** with an isolated profile and the
+   extension preloaded. `--remote-debugging-port=0` lets Chrome pick a
+   free CDP port and write it to `<userDataDir>/DevToolsActivePort`:
+
+   ```bash
+   CFT="$HOME/.cache/puppeteer/chrome/mac_arm-146.0.7680.153/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+   EXT="/tmp/slicc-ext-build"
+   PROFILE="/tmp/slicc-ext-profile"
+   rm -rf "$PROFILE" && mkdir -p "$PROFILE"
+   GOOGLE_CRASHPAD_DISABLE=1 "$CFT" \
+     --user-data-dir="$PROFILE" \
+     --remote-debugging-port=0 \
+     --no-first-run \
+     --no-default-browser-check \
+     --disable-crash-reporter \
+     --disable-extensions-except="$EXT" \
+     --load-extension="$EXT" \
+     "chrome://extensions" &
+   ```
+
+5. **Find the extension ID** from CDP — it's path-derived from the
+   `--load-extension` argument, so a fixed `EXT` path produces a fixed
+   ID across runs:
+
+   ```bash
+   CDP=$(cat "$PROFILE/DevToolsActivePort" | head -1)
+   curl -sS "http://localhost:$CDP/json/list" \
+     | python3 -c 'import json,sys; [print(t["url"]) for t in json.load(sys.stdin) if "service-worker.js" in (t.get("url") or "")]'
+   # → chrome-extension://<id>/service-worker.js
+   ```
+
+6. **Open the side panel UI** by navigating directly to
+   `chrome-extension://<id>/index.html` in a tab — the side panel runs
+   the same `index.html`, so you can drive it via CDP exactly like a
+   normal page:
+
+   ```bash
+   curl -sS -X PUT "http://localhost:$CDP/json/new?chrome-extension://<id>/index.html"
+   ```
+
+   The real Chrome side panel only opens via a user gesture on the
+   extension icon, which CDP cannot synthesize headlessly.
+
+### Tear down
+
+```bash
+pkill -f "Google Chrome.*slicc-ext-profile"
+```
+
+The same `EXT` and `PROFILE` paths can be reused on the next run, but
+re-running step 1 + step 3 is the safest way to pick up code changes.
 
 ## Related Guides
 

--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -90,6 +90,15 @@ export interface SetThinkingLevelMsg {
 
 export interface RefreshTrayRuntimeMsg {
   type: 'refresh-tray-runtime';
+  /**
+   * Snapshot of the panel's tray-join localStorage values, copied into
+   * the message because the side panel and offscreen document each have
+   * their own localStorage in MV3. Without this, the offscreen never
+   * sees a URL the user pasted into the panel and silently fails to
+   * start the follower.
+   */
+  joinUrl?: string | null;
+  workerBaseUrl?: string | null;
 }
 
 export interface PanelCdpCommandMsg {
@@ -242,6 +251,35 @@ export interface IncomingMessageMsg {
   };
 }
 
+/**
+ * Wholesale replace the chat history for a given scoop. Used when the
+ * offscreen acts as a tray follower and the leader sends a snapshot —
+ * the panel needs to drop whatever it had cached and render the
+ * leader's view. The bridge persists to IndexedDB before emitting so
+ * a panel reload picks up the same messages.
+ */
+export interface ScoopMessagesReplacedMsg {
+  type: 'scoop-messages-replaced';
+  scoopJid: string;
+  messages: Array<{
+    id: string;
+    role: 'user' | 'assistant';
+    content: string;
+    attachments?: MessageAttachment[];
+    timestamp: number;
+    source?: string;
+    channel?: string;
+    toolCalls?: Array<{
+      id: string;
+      name: string;
+      input: unknown;
+      result?: string;
+      isError?: boolean;
+    }>;
+    isStreaming?: boolean;
+  }>;
+}
+
 export interface OffscreenReadyMsg {
   type: 'offscreen-ready';
 }
@@ -285,6 +323,7 @@ export type OffscreenToPanelMessage =
   | ErrorMsg
   | ScoopCreatedMsg
   | IncomingMessageMsg
+  | ScoopMessagesReplacedMsg
   | PanelCdpResponseMsg
   | OAuthResultMsg;
 

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -35,6 +35,7 @@ import { toolUIRegistry } from '../../../packages/webapp/src/tools/tool-ui.js';
 import type { ChatMessage } from '../../../packages/webapp/src/ui/types.js';
 import type { MessageAttachment } from '../../../packages/webapp/src/core/attachments.js';
 import type { BrowserAPI } from '../../../packages/webapp/src/cdp/index.js';
+import type { FollowerSyncManager } from '../../../packages/webapp/src/scoops/tray-follower-sync.js';
 
 /** Buffered message for state sync */
 interface BufferedChatMessage {
@@ -66,6 +67,14 @@ export class OffscreenBridge {
   private scoopStatuses = new Map<string, ScoopTabState['status']>();
   /** Shared UI session store — writes to browser-coding-agent IndexedDB */
   private sessionStore: SessionStore | null = null;
+  /**
+   * When set, the offscreen is acting as a tray follower: user messages
+   * from the panel are forwarded to the leader over WebRTC instead of
+   * being handed to the local orchestrator, and snapshots/agent events
+   * coming back from the leader are bridged into the panel via the same
+   * messages the local orchestrator would emit.
+   */
+  private followerSync: FollowerSyncManager | null = null;
 
   /**
    * Bind the orchestrator and start listening for panel messages.
@@ -312,6 +321,134 @@ export class OffscreenBridge {
   }
 
   /**
+   * Switch to / out of follower mode. When `sync` is set, panel-issued
+   * user messages are forwarded to the leader instead of the local
+   * orchestrator. Pass `null` to detach.
+   */
+  setFollowerSync(sync: FollowerSyncManager | null): void {
+    this.followerSync = sync;
+  }
+
+  /**
+   * Replace the local cone scoop's chat history with `messages` (typically
+   * from a leader snapshot), persist them to IndexedDB so panel reloads
+   * see them, and notify the panel to update its open chat.
+   */
+  applyFollowerSnapshot(messages: ChatMessage[]): void {
+    if (!this.orchestrator) return;
+    const cone = this.orchestrator.getScoops().find((s) => s.isCone);
+    if (!cone) return;
+    const buf = messages.map((m) => ({
+      id: m.id,
+      role: m.role,
+      content: m.content,
+      attachments: m.attachments,
+      timestamp: m.timestamp,
+      source: m.source,
+      channel: m.channel,
+      toolCalls: m.toolCalls?.map((tc) => ({
+        id: tc.id,
+        name: tc.name,
+        input: tc.input,
+        result: tc.result,
+        isError: tc.isError,
+      })),
+      isStreaming: m.isStreaming,
+    }));
+    this.messageBuffers.set(cone.jid, buf);
+    this.currentMessageId.delete(cone.jid);
+    if (this.sessionStore) {
+      const sessionId = cone.isCone ? 'session-cone' : `session-${cone.folder}`;
+      this.sessionStore.saveMessages(sessionId, messages).catch((err) => {
+        console.warn('[offscreen-bridge] applyFollowerSnapshot persist failed:', err);
+      });
+    }
+    this.emit({
+      type: 'scoop-messages-replaced',
+      scoopJid: cone.jid,
+      messages: buf,
+    });
+  }
+
+  /** Resolve the local cone scoop's jid (panel-known), if any. */
+  getConeJid(): string | null {
+    return this.orchestrator?.getScoops().find((s) => s.isCone)?.jid ?? null;
+  }
+
+  /** Bridge follower-side AgentEvents into panel-bound agent-event messages. */
+  emitFollowerAgentEvent(
+    event: import('../../../packages/webapp/src/ui/types.js').AgentEvent
+  ): void {
+    const scoopJid = this.getConeJid();
+    if (!scoopJid) return;
+    switch (event.type) {
+      case 'content_delta':
+        this.emit({
+          type: 'agent-event',
+          scoopJid,
+          eventType: 'text_delta',
+          text: event.text,
+        });
+        break;
+      case 'content_done':
+        this.emit({ type: 'agent-event', scoopJid, eventType: 'response_done' });
+        break;
+      case 'tool_use_start':
+        this.emit({
+          type: 'agent-event',
+          scoopJid,
+          eventType: 'tool_start',
+          toolName: event.toolName,
+          toolInput: event.toolInput,
+        });
+        break;
+      case 'tool_result':
+        this.emit({
+          type: 'agent-event',
+          scoopJid,
+          eventType: 'tool_end',
+          toolName: event.toolName,
+          toolResult: event.result,
+          isError: event.isError,
+        });
+        break;
+      case 'turn_end':
+        this.emit({ type: 'agent-event', scoopJid, eventType: 'turn_end' });
+        break;
+      case 'error':
+        this.emit({ type: 'error', scoopJid, error: event.error });
+        break;
+    }
+  }
+
+  /** Emit an incoming-message for the cone (used by follower mode for echoes). */
+  emitFollowerIncomingMessage(messageId: string, text: string): void {
+    const scoopJid = this.getConeJid();
+    if (!scoopJid) return;
+    this.emit({
+      type: 'incoming-message',
+      scoopJid,
+      message: {
+        id: messageId,
+        content: text,
+        channel: 'web',
+        senderName: 'User',
+        fromAssistant: false,
+        timestamp: new Date().toISOString(),
+      },
+    });
+  }
+
+  /** Bridge a follower status string to a scoop-status emission for the cone. */
+  emitFollowerStatus(scoopStatus: string): void {
+    const scoopJid = this.getConeJid();
+    if (!scoopJid) return;
+    const status: ScoopTabState['status'] = scoopStatus === 'processing' ? 'processing' : 'ready';
+    this.scoopStatuses.set(scoopJid, status);
+    this.emit({ type: 'scoop-status', scoopJid, status });
+  }
+
+  /**
    * Persist a scoop's message buffer to the shared UI session store.
    * Fire-and-forget — errors are swallowed to avoid blocking agent processing.
    */
@@ -415,6 +552,21 @@ export class OffscreenBridge {
 
     switch (msg.type) {
       case 'user-message': {
+        // In follower mode, route the message to the leader over WebRTC
+        // and let the leader's echo populate our buffer; the local
+        // orchestrator must stay out of the way.
+        if (this.followerSync) {
+          this.getBuffer(msg.scoopJid).push({
+            id: msg.messageId,
+            role: 'user',
+            content: msg.text,
+            attachments: msg.attachments,
+            timestamp: Date.now(),
+          });
+          this.persistScoop(msg.scoopJid);
+          this.followerSync.sendMessage(msg.text, msg.messageId, msg.attachments);
+          break;
+        }
         const channelMsg: ChannelMessage = {
           id: msg.messageId,
           chatJid: msg.scoopJid,

--- a/packages/chrome-extension/src/offscreen.ts
+++ b/packages/chrome-extension/src/offscreen.ts
@@ -19,12 +19,15 @@ import { LeaderTrayManager } from '../../../packages/webapp/src/scoops/tray-lead
 import {
   hasStoredTrayJoinUrl,
   resolveTrayRuntimeConfig,
+  TRAY_JOIN_STORAGE_KEY,
+  TRAY_WORKER_STORAGE_KEY,
 } from '../../../packages/webapp/src/scoops/tray-runtime-config.js';
 import {
   FollowerTrayManager,
   LeaderTrayPeerManager,
   startFollowerWithAutoReconnect,
 } from '../../../packages/webapp/src/scoops/tray-webrtc.js';
+import { FollowerSyncManager } from '../../../packages/webapp/src/scoops/tray-follower-sync.js';
 import { OffscreenBridge } from './offscreen-bridge.js';
 import { ServiceWorkerLeaderTraySocket } from './tray-socket-proxy.js';
 import { createLogger } from '../../../packages/webapp/src/core/index.js';
@@ -353,6 +356,14 @@ async function init(): Promise<void> {
     activeTrayRuntimeKey = nextTrayRuntimeKey;
 
     if (trayRuntimeConfig?.joinUrl) {
+      let activeSync: FollowerSyncManager | null = null;
+      const detachSync = () => {
+        if (!activeSync) return;
+        bridge.setFollowerSync(null);
+        activeSync.close();
+        activeSync = null;
+      };
+
       const reconnectHandle = startFollowerWithAutoReconnect(
         {
           joinUrl: trayRuntimeConfig.joinUrl,
@@ -361,13 +372,32 @@ async function init(): Promise<void> {
         {
           onConnected: (connection) => {
             log.info('Extension follower connected', { trayId: connection.trayId });
+            detachSync();
+            const sync = new FollowerSyncManager(connection.channel, {
+              onSnapshot: (messages) => bridge.applyFollowerSnapshot(messages),
+              onUserMessage: (text, messageId) =>
+                bridge.emitFollowerIncomingMessage(messageId, text),
+              onStatus: (scoopStatus) => bridge.emitFollowerStatus(scoopStatus),
+              onDisconnect: (reason) => {
+                log.warn('Follower sync disconnected', { reason });
+                detachSync();
+              },
+            });
+            sync.onEvent((event) => bridge.emitFollowerAgentEvent(event));
+            activeSync = sync;
+            bridge.setFollowerSync(sync);
+            sync.requestSnapshot();
           },
           onGaveUp: (lastError) => {
             log.warn('Extension follower reconnect gave up', { lastError });
+            detachSync();
           },
         }
       );
-      stopTrayRuntime = () => reconnectHandle.cancel();
+      stopTrayRuntime = () => {
+        detachSync();
+        reconnectHandle.cancel();
+      };
       return;
     }
 
@@ -424,6 +454,22 @@ async function init(): Promise<void> {
     }
     if (message.payload.type !== 'refresh-tray-runtime') {
       return false;
+    }
+    // Mirror the panel's localStorage values into ours: in MV3 the side
+    // panel and the offscreen document are independent contexts with
+    // separate localStorage instances, so a join URL the user pasted in
+    // the panel is invisible to `resolveTrayRuntimeConfig` here unless
+    // we persist it locally first.
+    const { joinUrl, workerBaseUrl } = message.payload;
+    if (typeof joinUrl === 'string' && joinUrl) {
+      window.localStorage.setItem(TRAY_JOIN_STORAGE_KEY, joinUrl);
+    } else if (joinUrl === null) {
+      window.localStorage.removeItem(TRAY_JOIN_STORAGE_KEY);
+    }
+    if (typeof workerBaseUrl === 'string' && workerBaseUrl) {
+      window.localStorage.setItem(TRAY_WORKER_STORAGE_KEY, workerBaseUrl);
+    } else if (workerBaseUrl === null && joinUrl === null) {
+      window.localStorage.removeItem(TRAY_WORKER_STORAGE_KEY);
     }
     void syncTrayRuntime();
     return false;

--- a/packages/chrome-extension/tests/offscreen-bridge.test.ts
+++ b/packages/chrome-extension/tests/offscreen-bridge.test.ts
@@ -839,3 +839,225 @@ describe('OffscreenBridge handlePanelMessage', () => {
     });
   });
 });
+
+describe('OffscreenBridge follower mode', () => {
+  let bridge: InstanceType<typeof OffscreenBridge>;
+  let mockOrchestrator: any;
+  let mockSync: any;
+  let mockStore: any;
+
+  beforeEach(async () => {
+    sentMessages.length = 0;
+    messageListeners.length = 0;
+    vi.clearAllMocks();
+
+    bridge = new OffscreenBridge();
+    mockOrchestrator = {
+      getScoops: vi.fn(() => [
+        { jid: 'cone_1', name: 'Cone', folder: 'cone', isCone: true, assistantLabel: 'sliccy' },
+        {
+          jid: 'scoop_test',
+          name: 'Test',
+          folder: 'test-scoop',
+          isCone: false,
+          assistantLabel: 'test-scoop',
+        },
+      ]),
+      handleMessage: vi.fn().mockResolvedValue(undefined),
+      createScoopTab: vi.fn(),
+      registerScoop: vi.fn().mockResolvedValue(undefined),
+      unregisterScoop: vi.fn().mockResolvedValue(undefined),
+      stopScoop: vi.fn(),
+      clearQueuedMessages: vi.fn().mockResolvedValue(undefined),
+      clearAllMessages: vi.fn().mockResolvedValue(undefined),
+      delegateToScoop: vi.fn().mockResolvedValue(undefined),
+      updateModel: vi.fn(),
+    };
+    await bridge.bind(mockOrchestrator);
+
+    mockSync = {
+      sendMessage: vi.fn(),
+      close: vi.fn(),
+    };
+    mockStore = (bridge as any).sessionStore;
+  });
+
+  function simulatePanelMessage(payload: unknown): void {
+    for (const listener of messageListeners) {
+      listener({ source: 'panel', payload }, {}, () => {});
+    }
+  }
+
+  it('setFollowerSync stores the manager and clears with null', () => {
+    bridge.setFollowerSync(mockSync);
+    expect((bridge as any).followerSync).toBe(mockSync);
+    bridge.setFollowerSync(null);
+    expect((bridge as any).followerSync).toBeNull();
+  });
+
+  it('user-message in follower mode forwards to followerSync, skips orchestrator', async () => {
+    bridge.setFollowerSync(mockSync);
+
+    simulatePanelMessage({
+      type: 'user-message',
+      scoopJid: 'cone_1',
+      text: 'leader, do x',
+      messageId: 'msg-f1',
+      attachments: [{ kind: 'text', name: 'a.md', text: 'hi' }],
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockSync.sendMessage).toHaveBeenCalledWith('leader, do x', 'msg-f1', [
+      { kind: 'text', name: 'a.md', text: 'hi' },
+    ]);
+    expect(mockOrchestrator.handleMessage).not.toHaveBeenCalled();
+    expect(mockOrchestrator.createScoopTab).not.toHaveBeenCalled();
+
+    // Should still buffer the local user message for echo dedup
+    const buf = (bridge as any).getBuffer('cone_1');
+    expect(buf).toHaveLength(1);
+    expect(buf[0].id).toBe('msg-f1');
+  });
+
+  it('user-message falls through to orchestrator when follower mode inactive', async () => {
+    simulatePanelMessage({
+      type: 'user-message',
+      scoopJid: 'cone_1',
+      text: 'local',
+      messageId: 'msg-l1',
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockOrchestrator.handleMessage).toHaveBeenCalled();
+    expect(mockSync.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('applyFollowerSnapshot replaces cone buffer, persists, emits scoop-messages-replaced', () => {
+    // Pre-populate with stale local content to verify replacement.
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push({ id: 'old', role: 'user', content: 'stale', timestamp: 1 });
+
+    bridge.applyFollowerSnapshot([
+      { id: 'a', role: 'user', content: 'hi', timestamp: 100 },
+      {
+        id: 'b',
+        role: 'assistant',
+        content: 'reply',
+        timestamp: 200,
+        toolCalls: [{ id: 't1', name: 'bash', input: { cmd: 'ls' }, result: 'a\nb' }],
+      },
+    ] as any);
+
+    const after = (bridge as any).getBuffer('cone_1');
+    expect(after).toHaveLength(2);
+    expect(after[0].id).toBe('a');
+    expect(after[1].toolCalls?.[0]?.name).toBe('bash');
+
+    expect(mockStore.saveMessages).toHaveBeenCalledWith('session-cone', expect.any(Array));
+
+    const replaced = sentMessages.find(
+      (m: any) => m.payload?.type === 'scoop-messages-replaced'
+    ) as any;
+    expect(replaced).toBeDefined();
+    expect(replaced.payload.scoopJid).toBe('cone_1');
+    expect(replaced.payload.messages).toHaveLength(2);
+  });
+
+  it('applyFollowerSnapshot is a noop when no orchestrator or no cone', () => {
+    (bridge as any).orchestrator = null;
+    bridge.applyFollowerSnapshot([{ id: 'a', role: 'user', content: 'hi', timestamp: 100 }] as any);
+    expect(sentMessages).toHaveLength(0);
+
+    (bridge as any).orchestrator = { getScoops: () => [] };
+    bridge.applyFollowerSnapshot([{ id: 'a', role: 'user', content: 'hi', timestamp: 100 }] as any);
+    expect(sentMessages).toHaveLength(0);
+  });
+
+  it('getConeJid returns the cone jid or null', () => {
+    expect(bridge.getConeJid()).toBe('cone_1');
+    (bridge as any).orchestrator = { getScoops: () => [] };
+    expect(bridge.getConeJid()).toBeNull();
+    (bridge as any).orchestrator = null;
+    expect(bridge.getConeJid()).toBeNull();
+  });
+
+  it('emitFollowerAgentEvent maps each AgentEvent type to the matching agent-event payload', () => {
+    bridge.emitFollowerAgentEvent({
+      type: 'content_delta',
+      messageId: 'm1',
+      text: 'partial',
+    } as any);
+    bridge.emitFollowerAgentEvent({ type: 'content_done', messageId: 'm1' } as any);
+    bridge.emitFollowerAgentEvent({
+      type: 'tool_use_start',
+      messageId: 'm1',
+      toolName: 'bash',
+      toolInput: { cmd: 'ls' },
+    } as any);
+    bridge.emitFollowerAgentEvent({
+      type: 'tool_result',
+      messageId: 'm1',
+      toolName: 'bash',
+      result: 'ok',
+      isError: false,
+    } as any);
+    bridge.emitFollowerAgentEvent({ type: 'turn_end', messageId: 'm1' } as any);
+    bridge.emitFollowerAgentEvent({ type: 'error', error: 'boom' } as any);
+
+    const types = sentMessages.map((m: any) => ({
+      type: m.payload?.type,
+      eventType: m.payload?.eventType,
+      error: m.payload?.error,
+    }));
+    expect(types).toEqual([
+      { type: 'agent-event', eventType: 'text_delta', error: undefined },
+      { type: 'agent-event', eventType: 'response_done', error: undefined },
+      { type: 'agent-event', eventType: 'tool_start', error: undefined },
+      { type: 'agent-event', eventType: 'tool_end', error: undefined },
+      { type: 'agent-event', eventType: 'turn_end', error: undefined },
+      { type: 'error', eventType: undefined, error: 'boom' },
+    ]);
+  });
+
+  it('emitFollowerAgentEvent is a noop without a cone', () => {
+    (bridge as any).orchestrator = { getScoops: () => [] };
+    bridge.emitFollowerAgentEvent({
+      type: 'content_delta',
+      messageId: 'm1',
+      text: 'x',
+    } as any);
+    expect(sentMessages).toHaveLength(0);
+  });
+
+  it('emitFollowerStatus emits scoop-status processing/ready for cone', () => {
+    bridge.emitFollowerStatus('processing');
+    bridge.emitFollowerStatus('idle');
+
+    const statusMsgs = sentMessages
+      .filter((m: any) => m.payload?.type === 'scoop-status')
+      .map((m: any) => m.payload);
+    expect(statusMsgs).toEqual([
+      { type: 'scoop-status', scoopJid: 'cone_1', status: 'processing' },
+      { type: 'scoop-status', scoopJid: 'cone_1', status: 'ready' },
+    ]);
+  });
+
+  it('emitFollowerIncomingMessage emits incoming-message for cone', () => {
+    bridge.emitFollowerIncomingMessage('echo-1', 'leader-side text');
+    const m = sentMessages.find((x: any) => x.payload?.type === 'incoming-message') as any;
+    expect(m.payload).toMatchObject({
+      type: 'incoming-message',
+      scoopJid: 'cone_1',
+      message: {
+        id: 'echo-1',
+        content: 'leader-side text',
+        channel: 'web',
+        senderName: 'User',
+        fromAssistant: false,
+      },
+    });
+    expect(typeof m.payload.message.timestamp).toBe('string');
+  });
+});

--- a/packages/webapp/src/ui/clipboard.ts
+++ b/packages/webapp/src/ui/clipboard.ts
@@ -1,0 +1,47 @@
+/**
+ * Tiny clipboard helpers shared by UI components.
+ *
+ * The async Clipboard API is the happy path, but extension popups,
+ * cross-origin iframes, and older runtimes can deny access. The
+ * helpers below fall back to a hidden textarea so the user still
+ * gets working copy/paste.
+ */
+
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (!text) return false;
+
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      /* fall through to textarea fallback */
+    }
+  }
+
+  if (typeof document === 'undefined') return false;
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.cssText = 'position:fixed; opacity:0; pointer-events:none; left:-9999px;';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand?.('copy') ?? false;
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function readTextFromClipboard(): Promise<string | null> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.readText) {
+    try {
+      return await navigator.clipboard.readText();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -37,6 +37,12 @@ import {
   getProviderConfig,
   removeAccount,
 } from './provider-settings.js';
+import { getLeaderTrayRuntimeStatus } from '../scoops/tray-leader.js';
+import { getFollowerTrayRuntimeStatus } from '../scoops/tray-follower-status.js';
+import { copyTextToClipboard } from './clipboard.js';
+import { computeTrayMenuModel } from './tray-join-url.js';
+import { showSyncEnabledDialog } from './sync-dialog.js';
+import { getTrayResetter } from '../shell/supplemental-commands/host-command.js';
 import { getHiddenTabs, setHiddenTabs, type ExtensionTabId } from './tabbed-ui.js';
 import { RailZone } from './rail-zone.js';
 import { PanelRegistry } from './panel-registry.js';
@@ -527,6 +533,74 @@ export class Layout {
     return name.slice(0, 2).toUpperCase();
   }
 
+  /**
+   * Render the Tray block of the avatar popover.
+   *
+   * Three shapes:
+   *   - Leader with `state === 'leader'` and a session: a primary "Copy
+   *     tray join URL" item plus a small status caption.
+   *   - Leader connecting / reconnecting / error: a disabled item showing
+   *     why no URL is available yet.
+   *   - Follower with state !== 'inactive': a status caption showing the
+   *     follower connection state.
+   *
+   * Returns nothing when this runtime is neither a leader nor a follower —
+   * keeps the popover compact for users that don't use trays.
+   */
+  private appendTrayMenu(popover: HTMLElement): void {
+    const model = computeTrayMenuModel(
+      getLeaderTrayRuntimeStatus(),
+      getFollowerTrayRuntimeStatus()
+    );
+    if (model.kind === 'hidden') return;
+
+    const sep = document.createElement('div');
+    sep.className = 'avatar-popover__separator';
+    popover.appendChild(sep);
+
+    if (model.kind === 'leader-copy') {
+      const enableBtn = document.createElement('button');
+      enableBtn.className = 'avatar-popover__item';
+      enableBtn.textContent = model.label;
+      enableBtn.addEventListener('click', async () => {
+        popover.remove();
+        const copied = await copyTextToClipboard(model.joinUrl);
+        showSyncEnabledDialog({
+          joinUrl: model.joinUrl,
+          copied,
+          onReset: getTrayResetter(),
+        });
+      });
+      popover.appendChild(enableBtn);
+      const caption = document.createElement('div');
+      caption.className = 'avatar-popover__caption';
+      caption.textContent = model.caption;
+      popover.appendChild(caption);
+    } else if (model.kind === 'leader-pending') {
+      const item = document.createElement('button');
+      item.className = 'avatar-popover__item';
+      item.textContent = model.label;
+      item.disabled = true;
+      item.style.opacity = '0.6';
+      item.style.cursor = 'not-allowed';
+      popover.appendChild(item);
+      const caption = document.createElement('div');
+      caption.className = 'avatar-popover__caption';
+      caption.textContent = model.caption;
+      popover.appendChild(caption);
+    } else {
+      const item = document.createElement('div');
+      item.className = 'avatar-popover__item';
+      item.textContent = model.label;
+      item.style.cursor = 'default';
+      popover.appendChild(item);
+      const caption = document.createElement('div');
+      caption.className = 'avatar-popover__caption';
+      caption.textContent = model.caption;
+      popover.appendChild(caption);
+    }
+  }
+
   /** Build the user avatar element — 28px circle, three states. */
   private buildUserAvatar(): HTMLElement {
     const el = document.createElement('div');
@@ -621,6 +695,12 @@ export class Layout {
       });
       popover.appendChild(signOutBtn);
     }
+
+    // Tray section — surface the leader's join URL (only visible
+    // when this runtime owns a tray) or the follower's connection
+    // state, so first-time users can find the URL without dropping
+    // into the shell.
+    this.appendTrayMenu(popover);
 
     // Clear all accounts (danger)
     if (accounts.length > 0) {

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -64,6 +64,7 @@ import {
   hasStoredTrayJoinUrl,
   resolveTrayRuntimeConfig,
   TRAY_JOIN_STORAGE_KEY,
+  TRAY_WORKER_STORAGE_KEY,
 } from '../scoops/tray-runtime-config.js';
 import {
   FollowerTrayManager,
@@ -721,15 +722,26 @@ async function mainExtension(app: HTMLElement): Promise<void> {
         layout.panels.chat.addUserMessage(content, message.attachments);
       }
     },
+    onScoopMessagesReplaced: (scoopJid, messages) => {
+      if (selectedScoop?.jid !== scoopJid) return;
+      // The offscreen has already persisted the messages to IndexedDB,
+      // so a panel reload would pick them up. Repaint the open chat.
+      layout.panels.chat.loadMessages(messages as unknown as ChatMessage[]);
+    },
     onReady: async () => {
       try {
         log.info('Offscreen engine ready, scoop count:', client.getScoops().length);
 
-        if (window.localStorage.getItem(TRAY_JOIN_STORAGE_KEY)) {
+        const storedJoinUrl = window.localStorage.getItem(TRAY_JOIN_STORAGE_KEY);
+        if (storedJoinUrl) {
           void chrome.runtime
             .sendMessage({
               source: 'panel' as const,
-              payload: { type: 'refresh-tray-runtime' as const },
+              payload: {
+                type: 'refresh-tray-runtime' as const,
+                joinUrl: storedJoinUrl,
+                workerBaseUrl: window.localStorage.getItem(TRAY_WORKER_STORAGE_KEY),
+              },
             })
             .catch(() => {
               // Offscreen may already be syncing runtime state.

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -23,6 +23,7 @@ import type {
   ErrorMsg,
   IncomingMessageMsg,
   ScoopListMsg,
+  ScoopMessagesReplacedMsg,
 } from '../../../chrome-extension/src/messages.js';
 import { createLogger } from '../core/logger.js';
 
@@ -33,6 +34,16 @@ export interface OffscreenClientCallbacks {
   onScoopCreated: (scoop: RegisteredScoop) => void;
   onScoopListUpdate: (scoops: ScoopListMsg['scoops']) => void;
   onIncomingMessage: (scoopJid: string, message: IncomingMessageMsg['message']) => void;
+  /**
+   * Whole-history replacement (used when the offscreen acts as a tray
+   * follower and receives a snapshot from the leader). The payload has
+   * already been persisted to IndexedDB by the offscreen, so callers
+   * just need to repaint the chat for the matching scoop.
+   */
+  onScoopMessagesReplaced?: (
+    scoopJid: string,
+    messages: ScoopMessagesReplacedMsg['messages']
+  ) => void;
   /** Called when the offscreen engine is ready and state has been received. */
   onReady?: () => void;
 }
@@ -318,6 +329,12 @@ export class OffscreenClient {
       case 'incoming-message':
         this.handleIncomingMessage(msg as IncomingMessageMsg);
         break;
+
+      case 'scoop-messages-replaced': {
+        const m = msg as ScoopMessagesReplacedMsg;
+        this.callbacks.onScoopMessagesReplaced?.(m.scoopJid, m.messages);
+        break;
+      }
     }
   }
 

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -8,6 +8,9 @@ import { getProviders, getModels, getModel, createLogger } from '../core/index.j
 import type { Model } from '../core/index.js';
 import type { Api } from '@mariozechner/pi-ai';
 import { storeTrayJoinUrl, hasStoredTrayJoinUrl } from '../scoops/tray-runtime-config.js';
+import { describeInvalidJoinUrl } from './tray-join-url.js';
+
+export { describeInvalidJoinUrl };
 import { getFollowerTrayRuntimeStatus } from '../scoops/tray-follower-status.js';
 import type { RefreshTrayRuntimeMsg } from '../../../chrome-extension/src/messages.js';
 import {
@@ -935,7 +938,10 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
 
       const joinTrayBtn = document.createElement('button');
       joinTrayBtn.className = 'dialog__btn dialog__btn--secondary';
-      joinTrayBtn.textContent = isFollowerActive || hasJoinUrl ? 'Rejoin tray' : 'Join a tray';
+      joinTrayBtn.textContent =
+        isFollowerActive || hasJoinUrl
+          ? 'Reconnect to other browser'
+          : 'Connect to another browser';
       joinTrayBtn.addEventListener('click', () => renderJoinTrayForm());
       dialog.appendChild(joinTrayBtn);
 
@@ -1291,7 +1297,7 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
         const joinBtn = document.createElement('button');
         joinBtn.className = 'dialog__btn dialog__btn--secondary';
         joinBtn.style.marginTop = '8px';
-        joinBtn.textContent = 'Join a tray';
+        joinBtn.textContent = 'Connect to another browser';
         joinBtn.addEventListener('click', () => {
           renderJoinTrayForm();
         });
@@ -1324,14 +1330,14 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
 
       const title = document.createElement('div');
       title.className = 'dialog__title';
-      title.textContent = 'Join this tray';
+      title.textContent = 'Connect this browser?';
       dialog.appendChild(title);
 
       const desc = document.createElement('div');
       desc.className = 'dialog__desc';
       desc.style.marginBottom = '12px';
       desc.textContent =
-        'You\u2019ve been invited to join a SLICC tray session. Click below to connect.';
+        'You\u2019ve been invited to mirror another SLICC browser. Click below to start syncing.';
       dialog.appendChild(desc);
 
       // Show truncated URL for context
@@ -1351,11 +1357,11 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
 
       const joinBtn = document.createElement('button');
       joinBtn.className = 'dialog__btn';
-      joinBtn.textContent = 'Join tray';
+      joinBtn.textContent = 'Connect';
       joinBtn.addEventListener('click', () => {
         const stored = storeTrayJoinUrl(window.localStorage, joinUrl);
         if (!stored) {
-          statusEl.textContent = 'Invalid tray join URL.';
+          statusEl.textContent = 'Invalid sync URL.';
           statusEl.style.display = '';
           statusEl.style.color = 'var(--slicc-cone)';
           return;
@@ -1372,7 +1378,7 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
           );
         }
 
-        statusEl.textContent = 'Connecting to tray...';
+        statusEl.textContent = 'Connecting\u2026';
         statusEl.style.display = '';
         statusEl.style.color = 'var(--s2-content-secondary)';
 
@@ -1398,19 +1404,45 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
 
       const title = document.createElement('div');
       title.className = 'dialog__title';
-      title.textContent = 'Join a tray';
+      title.textContent = 'Connect to another browser';
       dialog.appendChild(title);
 
       const desc = document.createElement('div');
       desc.className = 'dialog__desc';
       desc.style.marginBottom = '12px';
-      desc.textContent =
-        'Paste the tray join URL shared by the tray leader. It must include a /join/... capability.';
+      desc.textContent = 'Paste a multi-browser sync URL to mirror another SLICC browser.';
       dialog.appendChild(desc);
+
+      const hint = document.createElement('details');
+      hint.style.cssText =
+        'margin-bottom: 12px; font-size: 12px; color: var(--s2-content-secondary);';
+      const hintSummary = document.createElement('summary');
+      hintSummary.style.cssText =
+        'cursor: pointer; user-select: none; color: var(--s2-content-secondary);';
+      hintSummary.textContent = 'How do I get the sync URL?';
+      hint.appendChild(hintSummary);
+      const hintBody = document.createElement('div');
+      hintBody.style.cssText =
+        'margin-top: 8px; padding: 10px 12px; background: var(--s2-bg-layer-2); border-radius: var(--s2-radius-default); border: 1px solid var(--s2-border-subtle); line-height: 1.5;';
+      const hintList = document.createElement('ol');
+      hintList.style.cssText = 'margin: 0; padding-left: 20px;';
+      const steps = [
+        'On the other SLICC, click the avatar (top right).',
+        'Choose \u201cEnable multi-browser sync\u201d \u2014 the URL is copied automatically.',
+        'Paste it below. Both browsers must be on the same SLICC version.',
+      ];
+      for (const step of steps) {
+        const li = document.createElement('li');
+        li.textContent = step;
+        hintList.appendChild(li);
+      }
+      hintBody.appendChild(hintList);
+      hint.appendChild(hintBody);
+      dialog.appendChild(hint);
 
       const trayUrlLabel = document.createElement('div');
       trayUrlLabel.className = 'dialog__desc';
-      trayUrlLabel.textContent = 'Tray URL:';
+      trayUrlLabel.textContent = 'Sync URL:';
       dialog.appendChild(trayUrlLabel);
 
       const trayUrlInput = document.createElement('input');
@@ -1418,8 +1450,7 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
       trayUrlInput.type = 'text';
       trayUrlInput.autocomplete = 'off';
       trayUrlInput.spellcheck = false;
-      trayUrlInput.placeholder = 'https://tray.example.com/base/join/tray-123.capability-token';
-      trayUrlInput.style.marginBottom = '12px';
+      trayUrlInput.placeholder = 'https://www.sliccy.ai/join/<token>';
       dialog.appendChild(trayUrlInput);
 
       const errorEl = document.createElement('div');
@@ -1433,11 +1464,18 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
 
       const joinBtn = document.createElement('button');
       joinBtn.className = 'dialog__btn';
-      joinBtn.textContent = 'Join tray';
+      joinBtn.textContent = 'Connect';
       joinBtn.addEventListener('click', () => {
-        const stored = storeTrayJoinUrl(window.localStorage, trayUrlInput.value);
+        const raw = trayUrlInput.value.trim();
+        if (!raw) {
+          errorEl.textContent = 'Paste a sync URL to continue.';
+          errorEl.style.display = '';
+          trayUrlInput.focus();
+          return;
+        }
+        const stored = storeTrayJoinUrl(window.localStorage, raw);
         if (!stored) {
-          errorEl.textContent = 'Enter a valid tray join URL with a /join/... capability.';
+          errorEl.textContent = describeInvalidJoinUrl(raw);
           errorEl.style.display = '';
           trayUrlInput.focus();
           return;
@@ -1449,7 +1487,6 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
             // Offscreen may not be ready yet; mainExtension will reconnect shortly.
           });
         } else {
-          // Trigger follower join in standalone mode without page reload
           window.dispatchEvent(
             new CustomEvent('slicc:tray-join', {
               detail: { joinUrl: stored.joinUrl },
@@ -1457,11 +1494,10 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
           );
         }
 
-        statusEl.textContent = 'Connecting to tray...';
+        statusEl.textContent = 'Connecting\u2026';
         statusEl.style.display = '';
         statusEl.style.color = 'var(--s2-content-secondary)';
 
-        // Close dialog after brief feedback
         setTimeout(() => {
           overlay.remove();
           resolve(false);

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -1368,7 +1368,11 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
         }
 
         if (isExtensionRuntime()) {
-          const payload: RefreshTrayRuntimeMsg = { type: 'refresh-tray-runtime' };
+          const payload: RefreshTrayRuntimeMsg = {
+            type: 'refresh-tray-runtime',
+            joinUrl: stored.joinUrl,
+            workerBaseUrl: stored.workerBaseUrl,
+          };
           void chrome.runtime.sendMessage({ source: 'panel' as const, payload }).catch(() => {});
         } else {
           window.dispatchEvent(
@@ -1482,7 +1486,11 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
         }
 
         if (isExtensionRuntime()) {
-          const payload: RefreshTrayRuntimeMsg = { type: 'refresh-tray-runtime' };
+          const payload: RefreshTrayRuntimeMsg = {
+            type: 'refresh-tray-runtime',
+            joinUrl: stored.joinUrl,
+            workerBaseUrl: stored.workerBaseUrl,
+          };
           void chrome.runtime.sendMessage({ source: 'panel' as const, payload }).catch(() => {
             // Offscreen may not be ready yet; mainExtension will reconnect shortly.
           });

--- a/packages/webapp/src/ui/styles/header.css
+++ b/packages/webapp/src/ui/styles/header.css
@@ -285,6 +285,11 @@
   color: var(--s2-content-tertiary);
   margin-top: 2px;
 }
+.avatar-popover__caption {
+  padding: 4px 16px 8px;
+  font-size: 11px;
+  color: var(--s2-content-tertiary);
+}
 .avatar-popover__item {
   display: flex;
   align-items: center;

--- a/packages/webapp/src/ui/sync-dialog.ts
+++ b/packages/webapp/src/ui/sync-dialog.ts
@@ -1,0 +1,120 @@
+import { copyTextToClipboard } from './clipboard.js';
+
+export interface SyncEnabledDialogOptions {
+  joinUrl: string;
+  copied: boolean;
+  onReset?: (() => Promise<unknown>) | null;
+}
+
+export function showSyncEnabledDialog(options: SyncEnabledDialogOptions): void {
+  document.querySelectorAll('.dialog-overlay[data-sync-dialog]').forEach((el) => el.remove());
+
+  const overlay = document.createElement('div');
+  overlay.className = 'dialog-overlay';
+  overlay.dataset.syncDialog = '1';
+
+  const dialog = document.createElement('div');
+  dialog.className = 'dialog';
+  overlay.appendChild(dialog);
+
+  const title = document.createElement('div');
+  title.className = 'dialog__title';
+  title.textContent = 'Multi-browser sync is on';
+  dialog.appendChild(title);
+
+  const desc = document.createElement('div');
+  desc.className = 'dialog__desc';
+  desc.textContent = options.copied
+    ? 'The sync URL is copied to your clipboard. Paste it into another SLICC browser to mirror this one.'
+    : 'Couldn\u2019t copy automatically. Use the button below to copy the sync URL, then paste it into another SLICC browser.';
+  dialog.appendChild(desc);
+
+  const stepsBox = document.createElement('div');
+  stepsBox.style.cssText =
+    'margin-bottom: 12px; padding: 10px 12px; background: var(--s2-bg-layer-1); border-radius: var(--s2-radius-default); border: 1px solid var(--s2-border-subtle); line-height: 1.5; font-size: 12px; color: var(--s2-content-secondary);';
+  const stepsList = document.createElement('ol');
+  stepsList.style.cssText = 'margin: 0; padding-left: 20px;';
+  const steps = [
+    'Open SLICC in another browser.',
+    'Click the avatar (top right) \u2192 \u201cConnect to another browser\u201d.',
+    'Paste the URL there. Both browsers must be on the same SLICC version.',
+  ];
+  for (const step of steps) {
+    const li = document.createElement('li');
+    li.textContent = step;
+    stepsList.appendChild(li);
+  }
+  stepsBox.appendChild(stepsList);
+  dialog.appendChild(stepsBox);
+
+  const urlDisplay = document.createElement('div');
+  urlDisplay.style.cssText =
+    'font-family: var(--s2-font-mono); font-size: 11px; color: var(--s2-content-secondary); word-break: break-all; margin-bottom: 12px; padding: 8px 12px; background: var(--s2-bg-sunken); border-radius: var(--s2-radius-default); border: 1px solid var(--s2-border-subtle);';
+  urlDisplay.textContent = options.joinUrl;
+  dialog.appendChild(urlDisplay);
+
+  const statusEl = document.createElement('div');
+  statusEl.style.cssText =
+    'font-size: 12px; color: var(--s2-content-secondary); margin-bottom: 8px; display: none;';
+  dialog.appendChild(statusEl);
+  if (options.copied) {
+    statusEl.textContent = 'URL copied to clipboard.';
+    statusEl.style.display = '';
+  }
+
+  const copyAgainBtn = document.createElement('button');
+  copyAgainBtn.className = 'dialog__btn dialog__btn--secondary';
+  copyAgainBtn.style.marginBottom = '8px';
+  copyAgainBtn.textContent = options.copied ? 'Copy again' : 'Copy URL';
+  copyAgainBtn.addEventListener('click', async () => {
+    const ok = await copyTextToClipboard(options.joinUrl);
+    statusEl.textContent = ok
+      ? 'URL copied to clipboard.'
+      : 'Couldn\u2019t copy. Select and copy manually.';
+    statusEl.style.color = ok ? 'var(--s2-content-secondary)' : 'var(--slicc-cone)';
+    statusEl.style.display = '';
+  });
+  dialog.appendChild(copyAgainBtn);
+
+  const doneBtn = document.createElement('button');
+  doneBtn.className = 'dialog__btn';
+  doneBtn.textContent = 'Done';
+  doneBtn.addEventListener('click', () => overlay.remove());
+  dialog.appendChild(doneBtn);
+
+  if (options.onReset) {
+    const resetBtn = document.createElement('button');
+    resetBtn.className = 'dialog__btn dialog__btn--secondary';
+    resetBtn.style.marginTop = '8px';
+    resetBtn.textContent = 'Reset URL (disconnect connected browsers)';
+    resetBtn.addEventListener('click', async () => {
+      resetBtn.disabled = true;
+      doneBtn.disabled = true;
+      copyAgainBtn.disabled = true;
+      statusEl.textContent = 'Resetting sync URL\u2026';
+      statusEl.style.color = 'var(--s2-content-secondary)';
+      statusEl.style.display = '';
+      try {
+        await options.onReset!();
+        statusEl.textContent =
+          'Sync URL reset. Reopen this dialog from the avatar to share the new URL.';
+        statusEl.style.color = 'var(--s2-content-secondary)';
+        urlDisplay.textContent = '\u2014';
+        copyAgainBtn.disabled = true;
+      } catch (err) {
+        statusEl.textContent = `Reset failed: ${err instanceof Error ? err.message : String(err)}`;
+        statusEl.style.color = 'var(--slicc-cone)';
+        resetBtn.disabled = false;
+        doneBtn.disabled = false;
+        copyAgainBtn.disabled = false;
+      }
+    });
+    dialog.appendChild(resetBtn);
+  }
+
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) overlay.remove();
+  });
+
+  document.body.appendChild(overlay);
+}

--- a/packages/webapp/src/ui/tray-join-url.ts
+++ b/packages/webapp/src/ui/tray-join-url.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure helpers for the "Join a tray" UX surfaces (settings dialog +
+ * avatar popover). Kept module-level and dependency-free so they can
+ * be unit tested without dragging in the rest of provider-settings or
+ * the layout class.
+ */
+
+export interface TrayMenuLeaderInput {
+  state: string;
+  session?: { joinUrl: string } | null;
+  error?: string | null;
+}
+
+export interface TrayMenuFollowerInput {
+  state: string;
+  error?: string | null;
+  lastError?: string | null;
+}
+
+export type TrayMenuModel =
+  | { kind: 'hidden' }
+  | { kind: 'leader-copy'; joinUrl: string; label: string; caption: string }
+  | { kind: 'leader-pending'; label: string; caption: string }
+  | { kind: 'follower'; label: string; caption: string };
+
+/**
+ * Decide what the Tray section of the avatar popover should render,
+ * given leader and follower status snapshots. Returns `{ kind: 'hidden' }`
+ * when neither runtime is active so callers can skip the section
+ * entirely.
+ */
+export function computeTrayMenuModel(
+  leader: TrayMenuLeaderInput,
+  follower: TrayMenuFollowerInput
+): TrayMenuModel {
+  if (leader.state === 'inactive' && follower.state === 'inactive') {
+    return { kind: 'hidden' };
+  }
+  if (leader.state === 'leader' && leader.session?.joinUrl) {
+    return {
+      kind: 'leader-copy',
+      joinUrl: leader.session.joinUrl,
+      label: 'Enable multi-browser sync',
+      caption: 'Share this URL to connect more browsers.',
+    };
+  }
+  if (leader.state !== 'inactive') {
+    const fallback =
+      leader.state === 'connecting'
+        ? 'Setting up multi-browser sync\u2026'
+        : leader.state === 'reconnecting'
+          ? 'Reconnecting\u2026'
+          : 'Sync service unreachable.';
+    return {
+      kind: 'leader-pending',
+      label: 'Multi-browser sync',
+      caption: leader.error ?? fallback,
+    };
+  }
+  return {
+    kind: 'follower',
+    label: 'Multi-browser sync',
+    caption:
+      follower.error ??
+      follower.lastError ??
+      describeFollowerState(follower.state) ??
+      'Mirroring another browser.',
+  };
+}
+
+function describeFollowerState(state: string): string | null {
+  switch (state) {
+    case 'connected':
+      return 'Connected — mirroring another browser.';
+    case 'connecting':
+      return 'Connecting to the other browser\u2026';
+    case 'reconnecting':
+      return 'Reconnecting\u2026';
+    case 'disconnected':
+      return 'Disconnected from the other browser.';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Produce a human-readable validation message for a tray join URL the
+ * webapp couldn't parse. The branches are kept narrow so a single
+ * unit test asserts the user-facing copy for each failure mode.
+ */
+export function describeInvalidJoinUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return 'Paste a sync URL to continue.';
+  let parsed: URL | null = null;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return 'That doesn\u2019t look like a URL. Paste the full https://\u2026 link from the other browser.';
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return 'Sync URLs must start with https://.';
+  }
+  if (!parsed.pathname.includes('/join/')) {
+    return 'This URL is missing the /join/\u2026 capability. Use \u201cEnable multi-browser sync\u201d on the other browser.';
+  }
+  return 'That sync URL is malformed. Re-copy it from the other browser and try again.';
+}

--- a/packages/webapp/tests/ui/clipboard.test.ts
+++ b/packages/webapp/tests/ui/clipboard.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { copyTextToClipboard, readTextFromClipboard } from '../../src/ui/clipboard.js';
+
+interface MockNavigator {
+  clipboard?: {
+    writeText?: (t: string) => Promise<void>;
+    readText?: () => Promise<string>;
+  };
+}
+
+let originalNavigator: unknown;
+
+beforeEach(() => {
+  originalNavigator = (globalThis as { navigator?: unknown }).navigator;
+});
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: originalNavigator,
+    configurable: true,
+    writable: true,
+  });
+  // Reset document.execCommand stub
+  (document as unknown as { execCommand?: () => boolean }).execCommand = undefined;
+});
+
+function setNavigator(nav: MockNavigator): void {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: nav,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe('copyTextToClipboard', () => {
+  it('uses navigator.clipboard.writeText when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setNavigator({ clipboard: { writeText } });
+
+    await expect(copyTextToClipboard('hello')).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('returns false for empty input without touching the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setNavigator({ clipboard: { writeText } });
+
+    await expect(copyTextToClipboard('')).resolves.toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('falls back to document.execCommand when the async API is missing', async () => {
+    setNavigator({});
+    const exec = vi.fn().mockReturnValue(true);
+    (document as unknown as { execCommand: typeof exec }).execCommand = exec;
+
+    await expect(copyTextToClipboard('hi')).resolves.toBe(true);
+    expect(exec).toHaveBeenCalledWith('copy');
+  });
+
+  it('falls back to execCommand when writeText throws', async () => {
+    setNavigator({ clipboard: { writeText: () => Promise.reject(new Error('denied')) } });
+    const exec = vi.fn().mockReturnValue(true);
+    (document as unknown as { execCommand: typeof exec }).execCommand = exec;
+
+    await expect(copyTextToClipboard('hi')).resolves.toBe(true);
+    expect(exec).toHaveBeenCalled();
+  });
+});
+
+describe('readTextFromClipboard', () => {
+  it('returns the clipboard contents when readText is available', async () => {
+    const readText = vi.fn().mockResolvedValue('  pasted  ');
+    setNavigator({ clipboard: { readText } });
+
+    await expect(readTextFromClipboard()).resolves.toBe('  pasted  ');
+  });
+
+  it('returns null when the API is missing', async () => {
+    setNavigator({});
+    await expect(readTextFromClipboard()).resolves.toBeNull();
+  });
+
+  it('returns null when readText throws (e.g. permission denied)', async () => {
+    setNavigator({
+      clipboard: { readText: () => Promise.reject(new Error('NotAllowedError')) },
+    });
+    await expect(readTextFromClipboard()).resolves.toBeNull();
+  });
+});

--- a/packages/webapp/tests/ui/tray-join-url.test.ts
+++ b/packages/webapp/tests/ui/tray-join-url.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { computeTrayMenuModel, describeInvalidJoinUrl } from '../../src/ui/tray-join-url.js';
+
+describe('computeTrayMenuModel', () => {
+  it('hides the section when nothing is active', () => {
+    expect(computeTrayMenuModel({ state: 'inactive' }, { state: 'inactive' })).toEqual({
+      kind: 'hidden',
+    });
+  });
+
+  it('returns leader-copy with the join URL when the leader is healthy', () => {
+    const model = computeTrayMenuModel(
+      { state: 'leader', session: { joinUrl: 'https://www.sliccy.ai/join/abc.def' } },
+      { state: 'inactive' }
+    );
+    expect(model).toEqual({
+      kind: 'leader-copy',
+      joinUrl: 'https://www.sliccy.ai/join/abc.def',
+      label: 'Enable multi-browser sync',
+      caption: 'Share this URL to connect more browsers.',
+    });
+  });
+
+  it('returns leader-pending while the leader is connecting', () => {
+    const model = computeTrayMenuModel(
+      { state: 'connecting', session: null },
+      { state: 'inactive' }
+    );
+    expect(model).toMatchObject({ kind: 'leader-pending', label: 'Multi-browser sync' });
+    expect((model as { caption: string }).caption).toMatch(/Setting up/);
+  });
+
+  it('returns leader-pending with the error caption when the leader errored', () => {
+    const model = computeTrayMenuModel(
+      { state: 'error', session: null, error: 'Sync hub 503' },
+      { state: 'inactive' }
+    );
+    expect(model).toEqual({
+      kind: 'leader-pending',
+      label: 'Multi-browser sync',
+      caption: 'Sync hub 503',
+    });
+  });
+
+  it('falls back to follower display when only the follower is active', () => {
+    const model = computeTrayMenuModel(
+      { state: 'inactive' },
+      { state: 'connected', error: null, lastError: null }
+    );
+    expect(model).toEqual({
+      kind: 'follower',
+      label: 'Multi-browser sync',
+      caption: 'Connected — mirroring another browser.',
+    });
+  });
+
+  it('describes follower connecting state without leaking jargon', () => {
+    const model = computeTrayMenuModel(
+      { state: 'inactive' },
+      { state: 'connecting', error: null, lastError: null }
+    );
+    expect((model as { caption: string }).caption).toMatch(/Connecting to the other browser/);
+  });
+
+  it('surfaces the follower error when present', () => {
+    const model = computeTrayMenuModel(
+      { state: 'inactive' },
+      { state: 'error', error: 'Sync hub unreachable' }
+    );
+    expect(model).toMatchObject({
+      kind: 'follower',
+      label: 'Multi-browser sync',
+      caption: 'Sync hub unreachable',
+    });
+  });
+
+  it('prefers leader status over follower status when both are active', () => {
+    const model = computeTrayMenuModel(
+      { state: 'leader', session: { joinUrl: 'https://www.sliccy.ai/join/x.y' } },
+      { state: 'connected' }
+    );
+    expect(model.kind).toBe('leader-copy');
+  });
+});
+
+describe('describeInvalidJoinUrl', () => {
+  it('asks the user to paste something when the input is empty', () => {
+    expect(describeInvalidJoinUrl('')).toMatch(/Paste a sync URL/);
+    expect(describeInvalidJoinUrl('   ')).toMatch(/Paste a sync URL/);
+  });
+
+  it('reports a non-URL string clearly', () => {
+    expect(describeInvalidJoinUrl('just some text')).toMatch(/doesn’t look like a URL/);
+  });
+
+  it('rejects non-http(s) protocols', () => {
+    expect(describeInvalidJoinUrl('ftp://example.com/join/abc.def')).toMatch(
+      /must start with https/
+    );
+  });
+
+  it('flags URLs that lack a /join/ capability', () => {
+    expect(describeInvalidJoinUrl('https://www.sliccy.ai/tray/abc')).toMatch(/missing the \/join/);
+    expect(describeInvalidJoinUrl('https://www.sliccy.ai/')).toMatch(/missing the \/join/);
+  });
+
+  it('returns a generic malformed message for /join/ URLs that still fail to parse', () => {
+    expect(describeInvalidJoinUrl('https://www.sliccy.ai/join/')).toMatch(/malformed|missing/);
+  });
+
+  it('does not surface tray/leader/follower jargon', () => {
+    const samples = [
+      describeInvalidJoinUrl(''),
+      describeInvalidJoinUrl('not a url'),
+      describeInvalidJoinUrl('ftp://example.com/join/abc.def'),
+      describeInvalidJoinUrl('https://www.sliccy.ai/tray/abc'),
+      describeInvalidJoinUrl('https://www.sliccy.ai/join/'),
+    ];
+    for (const msg of samples) {
+      expect(msg.toLowerCase()).not.toMatch(/\btray\b|leader|follower/);
+    }
+  });
+});


### PR DESCRIPTION
## Why

Cedric reported that on 2.22.2 he had no idea where to find the tray join URL or what to do with it. The functionality has worked since 2.26.x, but the UX shipped tray/leader/follower jargon and hid the URL behind the host shell command. New users couldn't discover the feature.

## What changes

**Discoverability**

- Avatar popover (top right) now has an Enable multi-browser sync entry on the leader, or a connection-status caption on the follower. No terminal required.

**Plain-language copy** — replaced everywhere user-facing:

| Before | After |
|---|---|
| Copy tray join URL | Enable multi-browser sync |
| Share this URL with followers to join your tray. | Share this URL to connect more browsers. |
| Tray follower: connected | Multi-browser sync (with state caption) |
| Join a tray / Rejoin tray | Connect to another browser / Reconnect to other browser |
| Paste the tray join URL shared by the tray leader. | Paste a multi-browser sync URL to mirror another SLICC browser. |
| Tray URL: | Sync URL: |
| Join tray (button) | Connect |
| You've been invited to join a SLICC tray session. | You've been invited to mirror another SLICC browser. |

Validation messages also drop tray/leader/follower in favor of sync URL / the other browser.

**Next-steps dialog on the leader**

Clicking Enable multi-browser sync copies the URL and opens a modal with:
- Title: Multi-browser sync is on
- Status (URL copied to clipboard)
- 3 numbered steps for the receiving browser
- The URL itself in a monospace box
- Copy URL / Done / Reset URL (disconnect connected browsers)

The Reset URL button calls the existing `getTrayResetter()` which rotates the tray session, invalidating the shared link and kicking any connected followers — same code path `host reset` uses.

## Files

- New: `packages/webapp/src/ui/{clipboard,sync-dialog,tray-join-url}.ts` and matching tests
- Updated: `layout.ts` (avatar popover), `provider-settings.ts` (join dialog + entry buttons + auto-join confirmation), `styles/header.css` (caption padding fix), `README.md` section 5

## Verification

- `npm run typecheck` clean
- `npx vitest run packages/webapp/tests/ui/{tray-join-url,clipboard}.test.ts` — 21/21 passing
- Live test: leader on 5710 + follower on 5720, end-to-end WebRTC handshake confirmed (`Follower tray connected`, `Snapshot received from leader`, `Target registry received from leader`)
- CDP-driven verification: avatar click → button labeled correctly → click writes the exact join URL to `navigator.clipboard.writeText` → next-steps dialog opens with all expected fields
- Caption indent fix verified at 16px L/R padding in both windows