### PR TITLE
fix(webapp): anchor chain-level tool-call cluster at first call

### DIFF
--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -604,7 +604,7 @@ export class ChatPanel {
     const idx = this.messages.findIndex((m) => m.id === messageId);
     if (idx === -1) return;
     this.messages.splice(idx, 1);
-    const el = this.messagesEl.querySelector(`[data-msg-id="${messageId}"]`);
+    const el = this.messagesEl.querySelector(`.msg-group[data-msg-id="${messageId}"]`);
     if (el) el.remove();
     this.persistSession();
     this.onDeleteQueuedMessage?.(messageId);
@@ -1112,7 +1112,7 @@ export class ChatPanel {
     (tc as any)._toolUIRequestId = requestId;
 
     // Find the tool call element and add a UI container
-    const wrapper = this.messagesEl.querySelector(`[data-msg-id="${messageId}"]`);
+    const wrapper = this.messagesEl.querySelector(`.msg-group[data-msg-id="${messageId}"]`);
     if (!wrapper) {
       // DOM element might not be rendered yet - retry
       if (retryCount < 10) {
@@ -1466,7 +1466,7 @@ export class ChatPanel {
   private updateStreamingContent(messageId: string): void {
     const msg = this.findMessage(messageId);
     if (!msg) return;
-    const wrapper = this.messagesEl.querySelector(`[data-msg-id="${messageId}"]`);
+    const wrapper = this.messagesEl.querySelector(`.msg-group[data-msg-id="${messageId}"]`);
     if (!wrapper) return;
     const contentEl = wrapper.querySelector('.msg__content');
     if (contentEl) {
@@ -1658,7 +1658,7 @@ export class ChatPanel {
   private updateMessageEl(messageId: string): void {
     const msg = this.findMessage(messageId);
     if (!msg) return;
-    const existing = this.messagesEl.querySelector(`[data-msg-id="${messageId}"]`);
+    const existing = this.messagesEl.querySelector(`.msg-group[data-msg-id="${messageId}"]`);
     if (existing) {
       this.disposeDipsForMessage(messageId);
       // Tool calls for sibling messages in this chain may be inside a
@@ -2116,12 +2116,19 @@ export class ChatPanel {
       );
       for (const call of calls) {
         const msgId = call.dataset.msgId;
+        // Restrict the home lookup to top-level msg-group wrappers —
+        // tool-call elements also carry `data-msg-id`, so a bare
+        // `[data-msg-id=...]` selector picks up clustered calls (which
+        // are descendants of an earlier msg-group) before reaching the
+        // wrapper, and we'd end up trying to reparent a node into
+        // itself.
         const home = msgId
-          ? this.messagesInner.querySelector<HTMLElement>(`[data-msg-id="${msgId}"]`)
+          ? this.messagesInner.querySelector<HTMLElement>(
+              `:scope > .msg-group[data-msg-id="${msgId}"]`
+            )
           : null;
         if (!home) continue;
         if (msgId && freshGroups.has(msgId)) continue;
-        // Insert before any feedback row so it stays at the bottom.
         const feedback = home.querySelector(':scope > .msg__feedback');
         if (feedback) {
           home.insertBefore(call, feedback);
@@ -2159,13 +2166,31 @@ export class ChatPanel {
           .forEach((el) => toolCallEls.push(el));
       }
       if (toolCallEls.length >= TOOL_CLUSTER_MIN) {
+        // Anchor the cluster at the chronological position of the first
+        // tool call so any text the assistant produces *after* the tool
+        // run (typically a summary in a continuation msg-group) renders
+        // below the cluster instead of above it. Appending to the
+        // chain's last msg-group reorders post-tool text to appear
+        // before the tools, which contradicts how the agent generated
+        // them.
+        const firstCall = toolCallEls[0];
+        const anchorParent = firstCall.parentElement;
+        const moved = new Set<Node>(toolCallEls);
+        let anchorNext: Node | null = firstCall.nextSibling;
+        while (anchorNext && moved.has(anchorNext)) {
+          anchorNext = anchorNext.nextSibling;
+        }
         const cluster = this.buildClusterFromElements(toolCallEls);
-        const lastGroup = chain[chain.length - 1];
-        const feedback = lastGroup.querySelector(':scope > .msg__feedback');
-        if (feedback) {
-          lastGroup.insertBefore(cluster, feedback);
+        if (anchorParent && anchorParent.isConnected) {
+          anchorParent.insertBefore(cluster, anchorNext);
         } else {
-          lastGroup.appendChild(cluster);
+          const lastGroup = chain[chain.length - 1];
+          const feedback = lastGroup.querySelector(':scope > .msg__feedback');
+          if (feedback) {
+            lastGroup.insertBefore(cluster, feedback);
+          } else {
+            lastGroup.appendChild(cluster);
+          }
         }
       }
       i = j;

--- a/packages/webapp/tests/ui/chat-panel-cluster.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-cluster.test.ts
@@ -133,7 +133,7 @@ describe('ChatPanel cross-message tool-call clustering', () => {
     expect(container.querySelectorAll('.tool-call').length).toBe(4);
   });
 
-  it('places the cluster inside the chain’s last msg-group so feedback rows stay attached', () => {
+  it('anchors the cluster at the chain’s first tool call so post-tool text renders below it', () => {
     panel.loadMessages([
       { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
       assistantMsg('a1', [tc({ id: 'tc-1', name: 'read_file', result: 'a' })], 2000),
@@ -141,9 +141,51 @@ describe('ChatPanel cross-message tool-call clustering', () => {
       assistantMsg('a3', [tc({ id: 'tc-3', name: 'read_file', result: 'c' })], 2200, 'done'),
     ]);
 
-    const lastGroup = container.querySelector('[data-msg-id="a3"]');
-    expect(lastGroup).not.toBeNull();
-    expect(lastGroup!.querySelector(':scope > .tool-call-cluster')).not.toBeNull();
+    const firstGroup = container.querySelector('.msg-group[data-msg-id="a1"]');
+    expect(firstGroup).not.toBeNull();
+    const cluster = firstGroup!.querySelector(':scope > .tool-call-cluster');
+    expect(cluster).not.toBeNull();
+
+    const lastGroup = container.querySelector('.msg-group[data-msg-id="a3"]') as HTMLElement;
+    expect(lastGroup.querySelector(':scope > .tool-call-cluster')).toBeNull();
+
+    // The cluster must precede the assistant's post-tool text bubble in
+    // document order — otherwise the reply visually jumps above the
+    // tools that produced it.
+    const summary = lastGroup.querySelector('.msg__content');
+    expect(summary?.textContent ?? '').toContain('done');
+    expect(cluster!.compareDocumentPosition(summary!) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+  });
+
+  it('keeps a continuation summary message after the cluster when text follows the tools', () => {
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'bash', result: 'a' })], 2000, 'starting'),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'bash', result: 'b' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'bash', result: 'c' })], 2200),
+      // A pure-text continuation that summarises what the tools did.
+      assistantMsg('a4', [], 2300, 'all good'),
+    ]);
+
+    const cluster = container.querySelector('.tool-call-cluster');
+    expect(cluster).not.toBeNull();
+
+    const summary = container.querySelector('.msg-group[data-msg-id="a4"] .msg__content');
+    expect(summary?.textContent ?? '').toContain('all good');
+
+    expect(cluster!.compareDocumentPosition(summary!) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+
+    // And the leading "starting" preamble in the same chain still
+    // precedes the cluster — chronology preserved on both sides.
+    const preamble = container.querySelector('.msg-group[data-msg-id="a1"] .msg__content');
+    expect(preamble?.textContent ?? '').toContain('starting');
+    expect(preamble!.compareDocumentPosition(cluster!) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
   });
 
   it('rebuilds the cluster as new continuation messages stream in', () => {
@@ -199,9 +241,9 @@ describe('ChatPanel cross-message tool-call clustering', () => {
     );
     expect(afterDots).toEqual(['tool-call--running', 'tool-call--success', 'tool-call--running']);
 
-    // Cluster still sits in the chain's last msg-group.
-    const lastGroup = container.querySelector('[data-msg-id="a3"]');
-    expect(lastGroup!.querySelector(':scope > .tool-call-cluster')).not.toBeNull();
+    // Cluster still anchors at the chain's first tool call.
+    const firstGroup = container.querySelector('.msg-group[data-msg-id="a1"]');
+    expect(firstGroup!.querySelector(':scope > .tool-call-cluster')).not.toBeNull();
   });
 
   it('does not double-cluster when a single message already has 3+ tool calls in the chain', () => {


### PR DESCRIPTION
## Bug

When an assistant turn fires three or more tool calls across a continuation chain, `ChatPanel` collapses them into one "Working" cluster. The cluster used to be appended to the chain's **last** msg-group — but that group often carries the assistant's post-tool summary text. The result on screen: the reply visually appeared **above** the cluster even though the agent produced it **after** the tools ran.

```
before: [preamble text] [post-tool summary] [Working cluster]
after:  [preamble text] [Working cluster]   [post-tool summary]
```

## Fix

1. Anchor the cluster at the DOM position of the first tool call (`anchorParent.insertBefore(cluster, anchorNext)`) instead of appending to `chain[chain.length - 1]`. Preserves chronology on both sides of the cluster.

2. Tighten four `[data-msg-id="…"]` selectors in `ChatPanel` to `.msg-group[data-msg-id="…"]`. Clustered tool-call elements share the home msg-id, and once the cluster lives in an *earlier* msg-group those tool-calls appear before their wrapper in DFS order, so the bare selector matched the wrong element — manifested as a `HierarchyRequestError` in `updateMessageEl` (tries to reparent a node into itself) and silent breakage in the delete / tool-ui / streaming-content paths.

3. Two new unit tests pin the ordering invariant (cluster precedes any post-tool text bubble; preamble text precedes the cluster). The existing test that asserted the buggy "cluster in last group" position was updated to assert the new "first tool call" anchor.

## Verification

- 8/8 cluster tests, 26/26 chat-panel tests, full webapp suite (2941 tests) pass.
- `npm run typecheck` clean. Webapp + chrome-extension builds clean.
- Live via CDP against the running extension panel: previously-buggy chains 17 (5-bash cluster) and 21 (7-bash cluster) now render with the `Working` cluster **above** the assistant's reply text.

```
=== CHAIN 17 (6 groups) ===
 group[0] TOOL-CLUSTER [bash, bash, bash, bash, bash]
 group[1..4] (empty — tool calls moved into cluster)
 group[5] msg [Two active slicc tabs (both pointing at the staging tray hub)…]
```