### PR TITLE
fix(webapp): honor defaultFullpage on programmatic rail activation

### DIFF
--- a/packages/webapp/src/ui/rail-zone.ts
+++ b/packages/webapp/src/ui/rail-zone.ts
@@ -218,7 +218,11 @@ export class RailZone {
       // localStorage may be unavailable in some contexts.
     }
 
-    if (options.fullpage !== undefined) this.setFullpage(options.fullpage);
+    // Match the click handler: when the caller doesn't specify
+    // `fullpage`, fall back to `defaultFullpage` so a panel that's too
+    // narrow to host rail content beside chat (i.e. defaultFullpage)
+    // doesn't render a side-by-side layout.
+    this.setFullpage(options.fullpage ?? this.defaultFullpage);
 
     target.item.onActivate?.();
     this.callbacks.onItemActivate?.(id);

--- a/packages/webapp/tests/ui/rail-zone.test.ts
+++ b/packages/webapp/tests/ui/rail-zone.test.ts
@@ -248,6 +248,43 @@ describe('RailZone', () => {
     expect(onItemClose).not.toHaveBeenCalled();
   });
 
+  it('programmatic activateItem honors defaultFullpage when caller omits the flag', () => {
+    const { railEl, contentEl } = makeRail();
+    const onFullpageToggle = vi.fn();
+    const rail = new RailZone(
+      railEl,
+      contentEl,
+      'primary',
+      { onFullpageToggle },
+      { defaultFullpage: true }
+    );
+    rail.addItem(makeItem('sprinkle-foo', 'top'));
+
+    rail.activateItem('sprinkle-foo');
+
+    expect(rail.isFullpage()).toBe(true);
+    expect(onFullpageToggle).toHaveBeenCalledWith(true);
+  });
+
+  it('explicit fullpage option still wins over defaultFullpage', () => {
+    const { railEl, contentEl } = makeRail();
+    const rail = new RailZone(railEl, contentEl, 'primary', {}, { defaultFullpage: true });
+    rail.addItem(makeItem('terminal', 'bottom'));
+
+    rail.activateItem('terminal', { fullpage: false });
+    expect(rail.isFullpage()).toBe(false);
+  });
+
+  it('programmatic activateItem leaves fullpage off when defaultFullpage is unset (standalone)', () => {
+    const { railEl, contentEl } = makeRail();
+    const rail = new RailZone(railEl, contentEl, 'primary');
+    rail.addItem(makeItem('sprinkle-foo', 'top'));
+
+    rail.activateItem('sprinkle-foo');
+
+    expect(rail.isFullpage()).toBe(false);
+  });
+
   it('persists and restores the last active item across constructor calls', () => {
     const { railEl, contentEl } = makeRail();
     let rail = new RailZone(railEl, contentEl, 'primary');


### PR DESCRIPTION
## Summary

- Restoring a previously-opened sprinkle at extension boot left the rail content rendering beside chat at 360px, squeezing the chat column. Click-driven activation already routed through `defaultFullpage`; the programmatic path didn't.
- Default `options.fullpage` to `this.defaultFullpage` in `RailZone.activateItem` so sprinkle restore, `setActiveTab` deep-linking, and `openTerminal` all match the click-handler behavior.
- Closing and reopening the sprinkle previously worked around the bug because the click handler explicitly passed `defaultFullpage`.

## Test plan

- [x] `npx vitest run packages/webapp/tests/ui/rail-zone.test.ts` — 3 new cases (programmatic activation honors `defaultFullpage`, explicit option still wins, standalone stays non-fullpage)
- [x] `npm run typecheck`
- [x] `npm run test` (3323 passed)
- [x] `npm run build -w @slicc/webapp`
- [x] `npm run build -w @slicc/chrome-extension`
- [ ] Manual: open the extension side panel with a sprinkle saved in `slicc-open-sprinkles` and confirm the panel renders fullpage on first paint instead of side-by-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)