### PR TITLE
fix(webapp): split tool-call clusters at interleaved assistant text

### DIFF
--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -2142,11 +2142,16 @@ export class ChatPanel {
 
   /** Walk continuation chains (one non-continuation `.msg-group` followed
    *  by zero or more `--continuation` siblings) and collapse runs of
-   *  three or more direct-child `.tool-call` elements into a single
-   *  "Working" cluster appended to the chain's last msg-group. This
-   *  generalises the per-message clustering to spans where each individual
-   *  message contributes one or two calls but the whole assistant turn
-   *  fires many — exactly the case the per-message rule misses. */
+   *  three or more direct-child `.tool-call` elements into a "Working"
+   *  cluster anchored at the run's first tool call.
+   *
+   *  A run is a maximal sequence of contiguous tool calls in DOM order
+   *  with no assistant text bubble between them. Text bubbles in
+   *  continuation groups represent content the agent emitted *between*
+   *  tool runs and must split clusters — otherwise the cluster would
+   *  hoist later tool calls above the prose the agent produced before
+   *  them. Leading text in the very first group of the chain doesn't
+   *  break anything because the run hasn't started yet. */
   private reflowToolClusters(): void {
     this.unwrapToolClusters();
     const groups = Array.from(
@@ -2159,28 +2164,32 @@ export class ChatPanel {
         j++;
       }
       const chain = groups.slice(i, j);
-      const toolCallEls: HTMLElement[] = [];
+
+      const runs: HTMLElement[][] = [];
+      let current: HTMLElement[] = [];
       for (const grp of chain) {
-        grp
-          .querySelectorAll<HTMLElement>(':scope > .tool-call')
-          .forEach((el) => toolCallEls.push(el));
+        // `.msg` is appended before any tool calls inside a group (see
+        // createMessageEl), so a text bubble here always sits between
+        // the prior group's tools and this group's tools.
+        const hasText = !!grp.querySelector(':scope > .msg');
+        if (hasText && current.length > 0) {
+          runs.push(current);
+          current = [];
+        }
+        grp.querySelectorAll<HTMLElement>(':scope > .tool-call').forEach((el) => current.push(el));
       }
-      if (toolCallEls.length >= TOOL_CLUSTER_MIN) {
-        // Anchor the cluster at the chronological position of the first
-        // tool call so any text the assistant produces *after* the tool
-        // run (typically a summary in a continuation msg-group) renders
-        // below the cluster instead of above it. Appending to the
-        // chain's last msg-group reorders post-tool text to appear
-        // before the tools, which contradicts how the agent generated
-        // them.
-        const firstCall = toolCallEls[0];
+      if (current.length > 0) runs.push(current);
+
+      for (const run of runs) {
+        if (run.length < TOOL_CLUSTER_MIN) continue;
+        const firstCall = run[0];
         const anchorParent = firstCall.parentElement;
-        const moved = new Set<Node>(toolCallEls);
+        const moved = new Set<Node>(run);
         let anchorNext: Node | null = firstCall.nextSibling;
         while (anchorNext && moved.has(anchorNext)) {
           anchorNext = anchorNext.nextSibling;
         }
-        const cluster = this.buildClusterFromElements(toolCallEls);
+        const cluster = this.buildClusterFromElements(run);
         if (anchorParent && anchorParent.isConnected) {
           anchorParent.insertBefore(cluster, anchorNext);
         } else {

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -196,6 +196,14 @@ export class ChatPanel {
   // load→mutate→save cycles behind the previous in-flight call so bursty
   // licks (e.g. fswatch) for a non-selected scoop can't clobber each other.
   private lickPersistQueues = new Map<string, Promise<void>>();
+  /** Anchor msgIds of tool-call clusters that were expanded immediately
+   *  before the most recent unwrap. Populated by `unwrapToolClusters` and
+   *  consumed (then cleared) by `reflowToolClusters`, so the rebuilt
+   *  cluster preserves the user's expanded state when a new tool call
+   *  streams into the chain. The first contained tool-call's owning
+   *  msgId is used as the anchor: it's the chain's first call and stays
+   *  stable as the cluster grows. */
+  private openClusterAnchors = new Set<string>();
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -1109,7 +1117,7 @@ export class ChatPanel {
     }
 
     // Store the request ID for later cleanup
-    (tc as any)._toolUIRequestId = requestId;
+    tc._toolUIRequestId = requestId;
 
     // Find the tool call element and add a UI container
     const wrapper = this.messagesEl.querySelector(`.msg-group[data-msg-id="${messageId}"]`);
@@ -2109,11 +2117,19 @@ export class ChatPanel {
       if (id && g.querySelector(':scope > .tool-call')) freshGroups.add(id);
     });
 
-    const clusters = this.messagesInner.querySelectorAll('.tool-call-cluster');
+    const clusters = this.messagesInner.querySelectorAll<HTMLElement>('.tool-call-cluster');
     for (const cluster of clusters) {
       const calls = cluster.querySelectorAll<HTMLElement>(
         ':scope > .tool-call-cluster__body > .tool-call'
       );
+      // If the user (or `handleToolUI`) had this cluster expanded, record
+      // its anchor so the next reflow can re-open the rebuilt cluster.
+      // The anchor is the first contained call's owning msgId — the
+      // chain's first call, which stays put as the cluster grows.
+      if (cluster instanceof HTMLDetailsElement && cluster.open) {
+        const anchorId = calls[0]?.dataset.msgId;
+        if (anchorId) this.openClusterAnchors.add(anchorId);
+      }
       for (const call of calls) {
         const msgId = call.dataset.msgId;
         // Restrict the home lookup to top-level msg-group wrappers —
@@ -2181,6 +2197,13 @@ export class ChatPanel {
           anchorNext = anchorNext.nextSibling;
         }
         const cluster = this.buildClusterFromElements(toolCallEls);
+        // Restore the user-expanded state captured by the most recent
+        // unwrap so a streaming tool call doesn't snap the cluster shut
+        // while the user is reading it.
+        const anchorId = firstCall.dataset.msgId;
+        if (anchorId && this.openClusterAnchors.has(anchorId)) {
+          cluster.open = true;
+        }
         if (anchorParent && anchorParent.isConnected) {
           anchorParent.insertBefore(cluster, anchorNext);
         } else {
@@ -2195,6 +2218,9 @@ export class ChatPanel {
       }
       i = j;
     }
+    // Drop any anchors that didn't map to a rebuilt cluster — chain may
+    // have shrunk below the threshold or been broken by a user turn.
+    this.openClusterAnchors.clear();
   }
 
   /** Build a "Working" cluster around an existing list of `.tool-call`
@@ -2202,7 +2228,7 @@ export class ChatPanel {
    *  derived from each element's name text and status class so the
    *  cluster reflects the live per-call state captured by the most
    *  recent `createToolCallEl` render. */
-  private buildClusterFromElements(toolCallEls: readonly HTMLElement[]): HTMLElement {
+  private buildClusterFromElements(toolCallEls: readonly HTMLElement[]): HTMLDetailsElement {
     const stale = toolCallEls.every((el) => el.classList.contains('tool-call--stale'));
 
     const el = document.createElement('details');

--- a/packages/webapp/src/ui/types.ts
+++ b/packages/webapp/src/ui/types.ts
@@ -67,6 +67,10 @@ export interface ToolCall {
   isError?: boolean;
   /** Transient screenshot data URL — not persisted to session store. */
   _screenshotDataUrl?: string;
+  /** Transient tool-UI request id used by `handleToolUI` to thread the
+   *  approval/result roundtrip back to the offscreen agent. Not
+   *  persisted. */
+  _toolUIRequestId?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/tests/ui/chat-panel-cluster.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-cluster.test.ts
@@ -52,6 +52,16 @@ const tc = (overrides: Partial<ToolCall> & { name: string; id: string }): ToolCa
   isError: overrides.isError,
 });
 
+/** Typed view of the private `ChatPanel` members the streaming-path tests
+ *  need to drive — mirrors what the agent loop calls into in production
+ *  but keeps the tests honest with `unknown`-cast accesses. */
+type ChatPanelInternals = {
+  messages: ChatMessage[];
+  appendMessageEl: (msg: ChatMessage) => void;
+  updateMessageEl: (messageId: string) => void;
+};
+const internals = (p: ChatPanel): ChatPanelInternals => p as unknown as ChatPanelInternals;
+
 const assistantMsg = (
   id: string,
   toolCalls: ToolCall[],
@@ -198,19 +208,17 @@ describe('ChatPanel cross-message tool-call clustering', () => {
     expect(container.querySelectorAll('.tool-call-cluster').length).toBe(0);
 
     // Streaming append crosses the threshold — cluster should appear.
-    (panel as any).messages.push(
-      assistantMsg('a3', [tc({ id: 'tc-3', name: 'read_file', result: 'c' })], 2200)
-    );
-    (panel as any).appendMessageEl((panel as any).messages.at(-1));
+    const a3 = assistantMsg('a3', [tc({ id: 'tc-3', name: 'read_file', result: 'c' })], 2200);
+    internals(panel).messages.push(a3);
+    internals(panel).appendMessageEl(a3);
 
     expect(container.querySelectorAll('.tool-call-cluster').length).toBe(1);
     expect(container.querySelectorAll('.tool-call-cluster .tool-call-cluster__dot').length).toBe(3);
 
     // A fourth continuation message extends the cluster — still one cluster.
-    (panel as any).messages.push(
-      assistantMsg('a4', [tc({ id: 'tc-4', name: 'bash', result: 'd' })], 2300)
-    );
-    (panel as any).appendMessageEl((panel as any).messages.at(-1));
+    const a4 = assistantMsg('a4', [tc({ id: 'tc-4', name: 'bash', result: 'd' })], 2300);
+    internals(panel).messages.push(a4);
+    internals(panel).appendMessageEl(a4);
 
     expect(container.querySelectorAll('.tool-call-cluster').length).toBe(1);
     expect(container.querySelectorAll('.tool-call-cluster .tool-call-cluster__dot').length).toBe(4);
@@ -234,7 +242,7 @@ describe('ChatPanel cross-message tool-call clustering', () => {
 
     // Tool result for a2 lands — its dot should flip to success after rebuild.
     t2.result = 'ok';
-    (panel as any).updateMessageEl('a2');
+    internals(panel).updateMessageEl('a2');
 
     const afterDots = [...container.querySelectorAll('.tool-call-cluster__dot')].map((d) =>
       [...d.classList].find((c) => c.startsWith('tool-call--'))
@@ -244,6 +252,62 @@ describe('ChatPanel cross-message tool-call clustering', () => {
     // Cluster still anchors at the chain's first tool call.
     const firstGroup = container.querySelector('.msg-group[data-msg-id="a1"]');
     expect(firstGroup!.querySelector(':scope > .tool-call-cluster')).not.toBeNull();
+  });
+
+  it('keeps the cluster expanded when new continuation tool calls stream in', () => {
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'read_file', result: 'a' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'read_file', result: 'b' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'read_file', result: 'c' })], 2200),
+    ]);
+
+    const cluster = container.querySelector('.tool-call-cluster');
+    expect(cluster).toBeInstanceOf(HTMLDetailsElement);
+    expect((cluster as HTMLDetailsElement).open).toBe(false);
+
+    // User expands the cluster.
+    (cluster as HTMLDetailsElement).open = true;
+
+    // A new tool call streams in via append. The reflow must not snap
+    // the cluster shut while the user is reading it.
+    const a4 = assistantMsg('a4', [tc({ id: 'tc-4', name: 'read_file', result: 'd' })], 2300);
+    internals(panel).messages.push(a4);
+    internals(panel).appendMessageEl(a4);
+
+    const rebuilt = container.querySelector('.tool-call-cluster');
+    expect(rebuilt).toBeInstanceOf(HTMLDetailsElement);
+    expect((rebuilt as HTMLDetailsElement).open).toBe(true);
+    expect(container.querySelectorAll('.tool-call-cluster .tool-call-cluster__dot').length).toBe(4);
+
+    // And again when an existing message gets a tool result update —
+    // updateMessageEl rebuilds the wrapper from scratch, so this is the
+    // path most likely to lose the open state.
+    internals(panel).updateMessageEl('a2');
+    const afterUpdate = container.querySelector('.tool-call-cluster');
+    expect(afterUpdate).toBeInstanceOf(HTMLDetailsElement);
+    expect((afterUpdate as HTMLDetailsElement).open).toBe(true);
+  });
+
+  it('lets the user re-collapse the cluster after the streaming reflow', () => {
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'read_file', result: 'a' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'read_file', result: 'b' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'read_file', result: 'c' })], 2200),
+    ]);
+
+    const cluster = container.querySelector('.tool-call-cluster') as HTMLDetailsElement;
+    cluster.open = true;
+    cluster.open = false;
+
+    // Append after collapse — must stay collapsed.
+    const a4 = assistantMsg('a4', [tc({ id: 'tc-4', name: 'read_file', result: 'd' })], 2300);
+    internals(panel).messages.push(a4);
+    internals(panel).appendMessageEl(a4);
+
+    const rebuilt = container.querySelector('.tool-call-cluster') as HTMLDetailsElement;
+    expect(rebuilt.open).toBe(false);
   });
 
   it('does not double-cluster when a single message already has 3+ tool calls in the chain', () => {

--- a/packages/webapp/tests/ui/chat-panel-cluster.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-cluster.test.ts
@@ -133,7 +133,14 @@ describe('ChatPanel cross-message tool-call clustering', () => {
     expect(container.querySelectorAll('.tool-call').length).toBe(4);
   });
 
-  it('anchors the cluster at the chain’s first tool call so post-tool text renders below it', () => {
+  it('splits clusters when text in a continuation group sits between tool calls', () => {
+    // The agent emitted text inside `a3` *before* `tc-3` (per render
+    // order), so chronologically the run looks like
+    //   tc-1, tc-2, "done", tc-3
+    // Collapsing all three calls would hoist `tc-3` above the "done"
+    // text, contradicting the order the agent produced. Each side of
+    // the text break is shorter than the cluster threshold, so neither
+    // side clusters.
     panel.loadMessages([
       { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
       assistantMsg('a1', [tc({ id: 'tc-1', name: 'read_file', result: 'a' })], 2000),
@@ -141,22 +148,93 @@ describe('ChatPanel cross-message tool-call clustering', () => {
       assistantMsg('a3', [tc({ id: 'tc-3', name: 'read_file', result: 'c' })], 2200, 'done'),
     ]);
 
-    const firstGroup = container.querySelector('.msg-group[data-msg-id="a1"]');
-    expect(firstGroup).not.toBeNull();
-    const cluster = firstGroup!.querySelector(':scope > .tool-call-cluster');
-    expect(cluster).not.toBeNull();
+    expect(container.querySelectorAll('.tool-call-cluster').length).toBe(0);
+    expect(container.querySelectorAll('.tool-call').length).toBe(3);
 
     const lastGroup = container.querySelector('.msg-group[data-msg-id="a3"]') as HTMLElement;
-    expect(lastGroup.querySelector(':scope > .tool-call-cluster')).toBeNull();
-
-    // The cluster must precede the assistant's post-tool text bubble in
-    // document order — otherwise the reply visually jumps above the
-    // tools that produced it.
     const summary = lastGroup.querySelector('.msg__content');
+    const tcThree = lastGroup.querySelector(':scope > .tool-call[data-msg-id="a3"]');
     expect(summary?.textContent ?? '').toContain('done');
-    expect(cluster!.compareDocumentPosition(summary!) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    expect(tcThree).not.toBeNull();
+    // The text in `a3` still precedes `tc-3` inside its own group.
+    expect(summary!.compareDocumentPosition(tcThree!) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
+  });
+
+  it('splits a chain into two clusters when a pure-text continuation lands between tool runs', () => {
+    // Three calls before the text break and three after — both sides
+    // cluster independently, with the text bubble preserved in between.
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg(
+        'a1',
+        [
+          tc({ id: 'tc-1', name: 'bash', result: 'a' }),
+          tc({ id: 'tc-2', name: 'bash', result: 'b' }),
+          tc({ id: 'tc-3', name: 'bash', result: 'c' }),
+        ],
+        2000
+      ),
+      assistantMsg('a2', [], 2100, 'thinking…'),
+      assistantMsg(
+        'a3',
+        [
+          tc({ id: 'tc-4', name: 'bash', result: 'd' }),
+          tc({ id: 'tc-5', name: 'bash', result: 'e' }),
+          tc({ id: 'tc-6', name: 'bash', result: 'f' }),
+        ],
+        2200
+      ),
+    ]);
+
+    const clusters = container.querySelectorAll('.tool-call-cluster');
+    expect(clusters.length).toBe(2);
+
+    const dotCounts = [...clusters].map(
+      (c) => c.querySelectorAll('.tool-call-cluster__dot').length
+    );
+    expect(dotCounts).toEqual([3, 3]);
+
+    const text = container.querySelector('.msg-group[data-msg-id="a2"] .msg__content');
+    expect(text?.textContent ?? '').toContain('thinking');
+
+    // First cluster precedes the text bubble; second cluster follows it.
+    expect(clusters[0].compareDocumentPosition(text!) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+    expect(text!.compareDocumentPosition(clusters[1]) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+  });
+
+  it('does not merge two short tool runs across a pure-text continuation', () => {
+    // Two calls on each side of the text break — neither side meets the
+    // cluster threshold on its own, so the calls render inline rather
+    // than being hoisted into a single misleading cluster.
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg(
+        'a1',
+        [
+          tc({ id: 'tc-1', name: 'bash', result: 'a' }),
+          tc({ id: 'tc-2', name: 'bash', result: 'b' }),
+        ],
+        2000
+      ),
+      assistantMsg('a2', [], 2100, 'let me think'),
+      assistantMsg(
+        'a3',
+        [
+          tc({ id: 'tc-3', name: 'bash', result: 'c' }),
+          tc({ id: 'tc-4', name: 'bash', result: 'd' }),
+        ],
+        2200
+      ),
+    ]);
+
+    expect(container.querySelectorAll('.tool-call-cluster').length).toBe(0);
+    expect(container.querySelectorAll('.tool-call').length).toBe(4);
   });
 
   it('keeps a continuation summary message after the cluster when text follows the tools', () => {


### PR DESCRIPTION
## Bug

PR #563 aggregated **every** `.tool-call` in a continuation chain into one bag and clustered them anchored at the first call. When the assistant emitted prose *between* tool batches inside a continuation chain, those text bubbles got stranded around the merged cluster — the resulting render hoisted later tool calls above the narration the agent produced before them, making it look like one uninterrupted `Working` run when the agent had actually narrated mid-flight.

```
chain: [a1: tc-1, tc-2] [a2: text 'thinking…'] [a3: tc-3, tc-4]

before: [cluster(tc-1, tc-2, tc-3, tc-4)] [a2 text] (text appears AFTER tools it preceded)
after:  [tc-1] [tc-2] [a2 text] [tc-3] [tc-4]      (chronology preserved)
```

## Fix

`reflowToolClusters` now walks the chain in DOM order and builds **runs** of contiguous tool calls separated by any `.msg` bubble in a continuation group. `.msg` is appended before any tool calls in a group (per `createMessageEl`), so a text bubble there always sits between the prior group's tools and this group's tools — that's a hard split. Leading text in the chain's first group still doesn't break the run (it hasn't started yet, and remains preamble in front of the first cluster).

Each run that meets `TOOL_CLUSTER_MIN` (3) becomes its own cluster anchored at its first tool call; shorter runs render inline. Multiple clusters per chain are now possible — e.g. 3 calls + text + 3 calls renders as cluster + text + cluster.

## Tests

- **New:** `splits clusters when text in a continuation group sits between tool calls` — three single-call continuations with trailing `'done'` text in the last group no longer collapse; tc-1, tc-2, tc-3 stay inline (replaces the old test that asserted the now-incorrect cross-text merge).
- **New:** `splits a chain into two clusters when a pure-text continuation lands between tool runs` — 3 + text-only + 3 renders as two clusters with the text bubble preserved between them.
- **New:** `does not merge two short tool runs across a pure-text continuation` — 2 + text-only + 2 renders inline (no clusters), exactly the user-reported regression scenario.
- Existing `keeps a continuation summary message after the cluster when text follows the tools` still passes — the post-tool summary lives in its own pure-text `a4`, which closes the run cleanly.

## Verification

- `npx vitest run packages/webapp/tests/ui/chat-panel-cluster.test.ts` — 10/10 pass.
- `npx vitest run packages/webapp/tests/ui/chat-panel` — 28/28 pass across cluster, attachments, lick, and telemetry suites.
- `npx prettier --write` clean on both files.
- The two pre-existing `getSupportedThinkingLevels` typecheck errors in `scoop-context.ts` and `main.ts` are unrelated (untouched by this change).