### PR TITLE
fix(webapp): preserve tool-call cluster open state across reflow

### DIFF
--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -196,6 +196,14 @@ export class ChatPanel {
   // load→mutate→save cycles behind the previous in-flight call so bursty
   // licks (e.g. fswatch) for a non-selected scoop can't clobber each other.
   private lickPersistQueues = new Map<string, Promise<void>>();
+  /** Anchor msgIds of tool-call clusters that were expanded immediately
+   *  before the most recent unwrap. Populated by `unwrapToolClusters` and
+   *  consumed (then cleared) by `reflowToolClusters`, so the rebuilt
+   *  cluster preserves the user's expanded state when a new tool call
+   *  streams into the chain. The first contained tool-call's owning
+   *  msgId is used as the anchor: it's the chain's first call and stays
+   *  stable as the cluster grows. */
+  private openClusterAnchors = new Set<string>();
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -1109,7 +1117,7 @@ export class ChatPanel {
     }
 
     // Store the request ID for later cleanup
-    (tc as any)._toolUIRequestId = requestId;
+    tc._toolUIRequestId = requestId;
 
     // Find the tool call element and add a UI container
     const wrapper = this.messagesEl.querySelector(`.msg-group[data-msg-id="${messageId}"]`);
@@ -2109,11 +2117,19 @@ export class ChatPanel {
       if (id && g.querySelector(':scope > .tool-call')) freshGroups.add(id);
     });
 
-    const clusters = this.messagesInner.querySelectorAll('.tool-call-cluster');
+    const clusters = this.messagesInner.querySelectorAll<HTMLElement>('.tool-call-cluster');
     for (const cluster of clusters) {
       const calls = cluster.querySelectorAll<HTMLElement>(
         ':scope > .tool-call-cluster__body > .tool-call'
       );
+      // If the user (or `handleToolUI`) had this cluster expanded, record
+      // its anchor so the next reflow can re-open the rebuilt cluster.
+      // The anchor is the first contained call's owning msgId — the
+      // chain's first call, which stays put as the cluster grows.
+      if (cluster instanceof HTMLDetailsElement && cluster.open) {
+        const anchorId = calls[0]?.dataset.msgId;
+        if (anchorId) this.openClusterAnchors.add(anchorId);
+      }
       for (const call of calls) {
         const msgId = call.dataset.msgId;
         // Restrict the home lookup to top-level msg-group wrappers —
@@ -2181,6 +2197,13 @@ export class ChatPanel {
           anchorNext = anchorNext.nextSibling;
         }
         const cluster = this.buildClusterFromElements(toolCallEls);
+        // Restore the user-expanded state captured by the most recent
+        // unwrap so a streaming tool call doesn't snap the cluster shut
+        // while the user is reading it.
+        const anchorId = firstCall.dataset.msgId;
+        if (anchorId && this.openClusterAnchors.has(anchorId)) {
+          cluster.open = true;
+        }
         if (anchorParent && anchorParent.isConnected) {
           anchorParent.insertBefore(cluster, anchorNext);
         } else {
@@ -2195,6 +2218,9 @@ export class ChatPanel {
       }
       i = j;
     }
+    // Drop any anchors that didn't map to a rebuilt cluster — chain may
+    // have shrunk below the threshold or been broken by a user turn.
+    this.openClusterAnchors.clear();
   }
 
   /** Build a "Working" cluster around an existing list of `.tool-call`
@@ -2202,7 +2228,7 @@ export class ChatPanel {
    *  derived from each element's name text and status class so the
    *  cluster reflects the live per-call state captured by the most
    *  recent `createToolCallEl` render. */
-  private buildClusterFromElements(toolCallEls: readonly HTMLElement[]): HTMLElement {
+  private buildClusterFromElements(toolCallEls: readonly HTMLElement[]): HTMLDetailsElement {
     const stale = toolCallEls.every((el) => el.classList.contains('tool-call--stale'));
 
     const el = document.createElement('details');

--- a/packages/webapp/src/ui/types.ts
+++ b/packages/webapp/src/ui/types.ts
@@ -67,6 +67,10 @@ export interface ToolCall {
   isError?: boolean;
   /** Transient screenshot data URL — not persisted to session store. */
   _screenshotDataUrl?: string;
+  /** Transient tool-UI request id used by `handleToolUI` to thread the
+   *  approval/result roundtrip back to the offscreen agent. Not
+   *  persisted. */
+  _toolUIRequestId?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/tests/ui/chat-panel-cluster.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-cluster.test.ts
@@ -52,6 +52,16 @@ const tc = (overrides: Partial<ToolCall> & { name: string; id: string }): ToolCa
   isError: overrides.isError,
 });
 
+/** Typed view of the private `ChatPanel` members the streaming-path tests
+ *  need to drive — mirrors what the agent loop calls into in production
+ *  but keeps the tests honest with `unknown`-cast accesses. */
+type ChatPanelInternals = {
+  messages: ChatMessage[];
+  appendMessageEl: (msg: ChatMessage) => void;
+  updateMessageEl: (messageId: string) => void;
+};
+const internals = (p: ChatPanel): ChatPanelInternals => p as unknown as ChatPanelInternals;
+
 const assistantMsg = (
   id: string,
   toolCalls: ToolCall[],
@@ -198,19 +208,17 @@ describe('ChatPanel cross-message tool-call clustering', () => {
     expect(container.querySelectorAll('.tool-call-cluster').length).toBe(0);
 
     // Streaming append crosses the threshold — cluster should appear.
-    (panel as any).messages.push(
-      assistantMsg('a3', [tc({ id: 'tc-3', name: 'read_file', result: 'c' })], 2200)
-    );
-    (panel as any).appendMessageEl((panel as any).messages.at(-1));
+    const a3 = assistantMsg('a3', [tc({ id: 'tc-3', name: 'read_file', result: 'c' })], 2200);
+    internals(panel).messages.push(a3);
+    internals(panel).appendMessageEl(a3);
 
     expect(container.querySelectorAll('.tool-call-cluster').length).toBe(1);
     expect(container.querySelectorAll('.tool-call-cluster .tool-call-cluster__dot').length).toBe(3);
 
     // A fourth continuation message extends the cluster — still one cluster.
-    (panel as any).messages.push(
-      assistantMsg('a4', [tc({ id: 'tc-4', name: 'bash', result: 'd' })], 2300)
-    );
-    (panel as any).appendMessageEl((panel as any).messages.at(-1));
+    const a4 = assistantMsg('a4', [tc({ id: 'tc-4', name: 'bash', result: 'd' })], 2300);
+    internals(panel).messages.push(a4);
+    internals(panel).appendMessageEl(a4);
 
     expect(container.querySelectorAll('.tool-call-cluster').length).toBe(1);
     expect(container.querySelectorAll('.tool-call-cluster .tool-call-cluster__dot').length).toBe(4);
@@ -234,7 +242,7 @@ describe('ChatPanel cross-message tool-call clustering', () => {
 
     // Tool result for a2 lands — its dot should flip to success after rebuild.
     t2.result = 'ok';
-    (panel as any).updateMessageEl('a2');
+    internals(panel).updateMessageEl('a2');
 
     const afterDots = [...container.querySelectorAll('.tool-call-cluster__dot')].map((d) =>
       [...d.classList].find((c) => c.startsWith('tool-call--'))
@@ -244,6 +252,62 @@ describe('ChatPanel cross-message tool-call clustering', () => {
     // Cluster still anchors at the chain's first tool call.
     const firstGroup = container.querySelector('.msg-group[data-msg-id="a1"]');
     expect(firstGroup!.querySelector(':scope > .tool-call-cluster')).not.toBeNull();
+  });
+
+  it('keeps the cluster expanded when new continuation tool calls stream in', () => {
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'read_file', result: 'a' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'read_file', result: 'b' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'read_file', result: 'c' })], 2200),
+    ]);
+
+    const cluster = container.querySelector('.tool-call-cluster');
+    expect(cluster).toBeInstanceOf(HTMLDetailsElement);
+    expect((cluster as HTMLDetailsElement).open).toBe(false);
+
+    // User expands the cluster.
+    (cluster as HTMLDetailsElement).open = true;
+
+    // A new tool call streams in via append. The reflow must not snap
+    // the cluster shut while the user is reading it.
+    const a4 = assistantMsg('a4', [tc({ id: 'tc-4', name: 'read_file', result: 'd' })], 2300);
+    internals(panel).messages.push(a4);
+    internals(panel).appendMessageEl(a4);
+
+    const rebuilt = container.querySelector('.tool-call-cluster');
+    expect(rebuilt).toBeInstanceOf(HTMLDetailsElement);
+    expect((rebuilt as HTMLDetailsElement).open).toBe(true);
+    expect(container.querySelectorAll('.tool-call-cluster .tool-call-cluster__dot').length).toBe(4);
+
+    // And again when an existing message gets a tool result update —
+    // updateMessageEl rebuilds the wrapper from scratch, so this is the
+    // path most likely to lose the open state.
+    internals(panel).updateMessageEl('a2');
+    const afterUpdate = container.querySelector('.tool-call-cluster');
+    expect(afterUpdate).toBeInstanceOf(HTMLDetailsElement);
+    expect((afterUpdate as HTMLDetailsElement).open).toBe(true);
+  });
+
+  it('lets the user re-collapse the cluster after the streaming reflow', () => {
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'read_file', result: 'a' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'read_file', result: 'b' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'read_file', result: 'c' })], 2200),
+    ]);
+
+    const cluster = container.querySelector('.tool-call-cluster') as HTMLDetailsElement;
+    cluster.open = true;
+    cluster.open = false;
+
+    // Append after collapse — must stay collapsed.
+    const a4 = assistantMsg('a4', [tc({ id: 'tc-4', name: 'read_file', result: 'd' })], 2300);
+    internals(panel).messages.push(a4);
+    internals(panel).appendMessageEl(a4);
+
+    const rebuilt = container.querySelector('.tool-call-cluster') as HTMLDetailsElement;
+    expect(rebuilt.open).toBe(false);
   });
 
   it('does not double-cluster when a single message already has 3+ tool calls in the chain', () => {


### PR DESCRIPTION
## Summary

- ChatPanel rebuilt the chain-level tool-call cluster `<details>` from scratch on every message append/update, so an expanded cluster snapped shut as soon as the next tool call streamed in.
- `unwrapToolClusters` now records the open state keyed by the chain anchor (first contained tool-call's `data-msg-id`); `reflowToolClusters` re-applies it on the rebuilt cluster, then clears the set so stale anchors don't leak.
- Drive-by: replaced a pre-existing `(tc as any)._toolUIRequestId` write with a typed transient field on `ToolCall`, and `(panel as any)` test casts with a typed `internals()` helper so the wider file stays green under `check-any-changed`.

## Test plan

- [x] `npx vitest run packages/webapp/tests/ui/chat-panel-cluster.test.ts` — 10/10 pass, including two new regression tests covering append, updateMessageEl, and the user-collapse path.
- [x] Manually verified in a Canary build: expand the cluster, let the agent fire more tool calls, the cluster stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)