### PR TITLE
fix(chat): preserve tool call collapse state and fix cluster gap

### DIFF
--- a/docs/superpowers/specs/2026-05-05-tool-call-collapse-fix-design.md
+++ b/docs/superpowers/specs/2026-05-05-tool-call-collapse-fix-design.md
@@ -1,0 +1,60 @@
+# Tool Call Collapse State Preservation
+
+**Date:** 2026-05-05
+**Status:** Approved
+
+## Problem
+
+Individual tool call rows and "Working" clusters both use `<details>` elements. Every time the agent makes a new tool call, `updateMessageEl` fires and replaces the entire message DOM element — destroying any `open` state the user had set. Similarly, `reflowToolClusters` tears down existing cluster elements and rebuilds them, also discarding open state.
+
+Concretely: if a user expands a tool call or cluster while the agent is still running, the next tool call collapses it back.
+
+## Scope
+
+- Preserve open state within a browser session across mid-session DOM rebuilds.
+- Browser refresh does not need to be preserved.
+
+## Design
+
+### New instance variables on `ChatPanel`
+
+```ts
+private userOpenedToolCalls = new Set<string>();  // keyed by ToolCall.id
+private userOpenedClusters = new Set<string>();   // keyed by joined ToolCall IDs
+```
+
+### Individual tool calls (`createToolCallEl`)
+
+1. Tag the `<details>` element: `el.dataset.toolCallId = tc.id`
+2. Restore open state: `el.open = this.userOpenedToolCalls.has(tc.id)`
+3. Attach a `toggle` listener:
+   - On open: `this.userOpenedToolCalls.add(tc.id)`
+   - On close: `this.userOpenedToolCalls.delete(tc.id)`
+
+### Clusters (`createToolClusterEl` and `buildClusterFromElements`)
+
+Cluster key = constituent tool call IDs joined with `,`. This is stable because `ToolCall.id` is assigned once via `uid()` when the tool call starts and never changes.
+
+**`createToolClusterEl(toolCalls, msgId)`:**
+1. Compute key: `toolCalls.map(tc => tc.id).join(',')`
+2. Restore open state: `el.open = this.userOpenedClusters.has(key)`
+3. Attach a `toggle` listener: add/remove key from `userOpenedClusters`
+
+**`buildClusterFromElements(toolCallEls)`:**
+1. Compute key: `toolCallEls.map(el => el.dataset.toolCallId ?? '').join(',')`
+2. Same open restore + toggle listener pattern
+
+### Side effect: force-open via tool UI
+
+The existing logic that force-opens a cluster when a tool emits interactive UI (`enclosingCluster.open = true` at line 1151) continues to work correctly — the `toggle` listener fires when `open` is set programmatically, so the user-opened state is automatically recorded.
+
+## Files Changed
+
+- `packages/webapp/src/ui/chat-panel.ts` — two new Sets, toggle listeners, open restore in `createToolCallEl`, `createToolClusterEl`, `buildClusterFromElements`
+
+## Testing
+
+- Existing cluster tests in `packages/webapp/tests/ui/` should be reviewed for open-state assertions.
+- Manual: expand a tool call mid-run, verify it stays open when the next tool call fires.
+- Manual: expand a "Working" cluster mid-run, verify it stays open.
+- Manual: collapse an expanded tool call, verify it stays collapsed.

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -2044,7 +2044,7 @@ export class ChatPanel {
    *  glance; expanding the cluster reveals the individual tool-call rows
    *  (each with their own full row + status bubble). */
   private createToolClusterEl(toolCalls: ToolCall[], msgId: string, stale = false): HTMLElement {
-    const clusterKey = toolCalls.map((tc) => tc.id).join(',');
+    const clusterKey = toolCalls[0].id;
     const el = document.createElement('details');
     el.className = `tool-call-cluster${stale ? ' tool-call--stale' : ''}`;
     if (this.userOpenedClusters.has(clusterKey)) el.open = true;
@@ -2224,7 +2224,7 @@ export class ChatPanel {
    *  recent `createToolCallEl` render. */
   private buildClusterFromElements(toolCallEls: readonly HTMLElement[]): HTMLElement {
     const stale = toolCallEls.every((el) => el.classList.contains('tool-call--stale'));
-    const clusterKey = toolCallEls.map((tcEl) => tcEl.dataset.toolCallId ?? '').join(',');
+    const clusterKey = toolCallEls[0].dataset.toolCallId ?? '';
 
     const el = document.createElement('details');
     el.className = `tool-call-cluster${stale ? ' tool-call--stale' : ''}`;

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -2155,6 +2155,7 @@ export class ChatPanel {
         } else {
           home.appendChild(call);
         }
+        home.classList.remove('msg-group--emptied');
       }
       cluster.remove();
     }
@@ -2211,6 +2212,12 @@ export class ChatPanel {
           } else {
             lastGroup.appendChild(cluster);
           }
+        }
+        // Hide continuation groups that are now empty (all tool calls moved
+        // into the cluster). Kept in the DOM so unwrapToolClusters can find
+        // and restore calls on the next reflow.
+        for (let k = 1; k < chain.length; k++) {
+          if (chain[k].children.length === 0) chain[k].classList.add('msg-group--emptied');
         }
       }
       i = j;

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -174,6 +174,8 @@ export class ChatPanel {
   private streamingRafId: number | null = null;
   private dips = new Map<string, DipInstance[]>();
   public onDipLick?: (action: string, data: unknown) => void;
+  private userOpenedToolCalls = new Set<string>();
+  private userOpenedClusters = new Set<string>();
   private modelSelectorEl!: HTMLElement;
   public onModelChange?: (modelId: string) => void;
   private thinkingBtn!: HTMLButtonElement;
@@ -1964,6 +1966,15 @@ export class ChatPanel {
     // Tag with the owning message id so reflow can return the element to
     // its home msg-group when unwrapping a cross-message cluster.
     el.dataset.msgId = msgId;
+    el.dataset.toolCallId = tc.id;
+    if (this.userOpenedToolCalls.has(tc.id)) el.open = true;
+    el.addEventListener('toggle', () => {
+      if (el.open) {
+        this.userOpenedToolCalls.add(tc.id);
+      } else {
+        this.userOpenedToolCalls.delete(tc.id);
+      }
+    });
 
     const summary = document.createElement('summary');
     summary.className = 'tool-call__header';
@@ -2033,8 +2044,17 @@ export class ChatPanel {
    *  glance; expanding the cluster reveals the individual tool-call rows
    *  (each with their own full row + status bubble). */
   private createToolClusterEl(toolCalls: ToolCall[], msgId: string, stale = false): HTMLElement {
+    const clusterKey = toolCalls.map((tc) => tc.id).join(',');
     const el = document.createElement('details');
     el.className = `tool-call-cluster${stale ? ' tool-call--stale' : ''}`;
+    if (this.userOpenedClusters.has(clusterKey)) el.open = true;
+    el.addEventListener('toggle', () => {
+      if (el.open) {
+        this.userOpenedClusters.add(clusterKey);
+      } else {
+        this.userOpenedClusters.delete(clusterKey);
+      }
+    });
 
     const summary = document.createElement('summary');
     summary.className = 'tool-call__header';
@@ -2204,9 +2224,18 @@ export class ChatPanel {
    *  recent `createToolCallEl` render. */
   private buildClusterFromElements(toolCallEls: readonly HTMLElement[]): HTMLElement {
     const stale = toolCallEls.every((el) => el.classList.contains('tool-call--stale'));
+    const clusterKey = toolCallEls.map((tcEl) => tcEl.dataset.toolCallId ?? '').join(',');
 
     const el = document.createElement('details');
     el.className = `tool-call-cluster${stale ? ' tool-call--stale' : ''}`;
+    if (this.userOpenedClusters.has(clusterKey)) el.open = true;
+    el.addEventListener('toggle', () => {
+      if (el.open) {
+        this.userOpenedClusters.add(clusterKey);
+      } else {
+        this.userOpenedClusters.delete(clusterKey);
+      }
+    });
 
     const summary = document.createElement('summary');
     summary.className = 'tool-call__header';

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -216,6 +216,13 @@
   gap: 8px;
 }
 
+/* Continuation groups whose tool calls were absorbed into a cluster become
+   empty shells. JS marks them with this class; unwrapToolClusters removes it
+   when calls are restored, keeping the DOM node alive for re-clustering. */
+.msg-group--emptied {
+  display: none;
+}
+
 /* Queued messages — dimmed to distinguish from sent messages */
 .msg--queued {
   opacity: 0.55;


### PR DESCRIPTION
## Summary

- **Preserve open state across rebuilds**: `updateMessageEl` and `reflowToolClusters` replace/rebuild DOM on every tool call, collapsing any `<details>` the user had expanded. Two new Sets on `ChatPanel` (`userOpenedToolCalls`, `userOpenedClusters`) record user intent via `toggle` listeners; element creation restores open state from those Sets.
- **Stable cluster key**: uses the first tool call's ID only (not all IDs joined) so the key stays the same as the cluster grows.
- **Fix visual gap after clustering**: when `reflowToolClusters` moves tool calls from continuation `msg-group` elements into a cross-message cluster, those groups become empty shells that create a visible gap. They are now marked `msg-group--emptied` (`display: none`) to close the gap, while staying in the DOM so `unwrapToolClusters` can restore calls on the next reflow.

## Test plan

- [ ] Run several bash commands in sequence — a Working cluster should appear with no gap between it and subsequent output
- [ ] Expand the Working cluster mid-run — it stays open when the next tool call fires
- [ ] Expand an individual tool call mid-run — it stays open on subsequent calls
- [ ] Collapse an expanded item — it stays collapsed
- [ ] Refresh the page — open state is not required to survive (by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)