### PR TITLE
fix(swift-launcher): allow dots/hyphens in Settings → Secrets names

### DIFF
--- a/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
@@ -9,19 +9,34 @@ private let log = Logger(subsystem: "com.slicc.sliccstart", category: "Settings"
 let autoLaunchAppIdKey = "autoLaunchAppId"
 
 /// Validation rules for secret names entered in the Settings → Secrets
-/// editor. Mount-profile keys use the shape `s3.<profile>.<field>` (dots),
-/// and tokens are commonly named with hyphens (e.g. `gh-prod`). The
-/// swift-server's `SignAndForward.isValidProfileName` accepts the same
-/// set for the profile portion of the key, so the UI and server agree on
-/// what's a valid name.
+/// editor. Accepted set: `^[a-zA-Z0-9._-]+$` (ASCII letters/digits plus
+/// dot, underscore, hyphen, non-empty). Mount-profile keys use the shape
+/// `s3.<profile>.<field>` (dots), and tokens are commonly named with
+/// hyphens (e.g. `gh-prod`).
+///
+/// **Must stay byte-for-byte identical with `SignAndForward.isValidProfileName`
+/// in `packages/swift-server/Sources/Server/SignAndForward.swift`.** The UI
+/// saves names that the server later validates on every signed request;
+/// any character the UI accepts that the server rejects becomes a
+/// post-save failure that surfaces as `400 invalid_profile` on each mount
+/// call rather than as inline feedback. We therefore explicitly enumerate
+/// ASCII bytes rather than using `CharacterSet.alphanumerics`, which is
+/// Unicode-broad and would silently accept e.g. Cyrillic homoglyphs that
+/// the server rejects.
 ///
 /// Lives at file scope (not nested inside the private `SecretEditorSheet`)
 /// so unit tests can reach it via `@testable import Sliccstart`.
 enum SecretNameValidator {
     static func isValid(_ name: String) -> Bool {
         guard !name.isEmpty else { return false }
-        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_.-"))
-        return CharacterSet(charactersIn: name).isSubset(of: allowed)
+        for scalar in name.unicodeScalars {
+            let v = scalar.value
+            let alpha = (v >= 0x41 && v <= 0x5A) || (v >= 0x61 && v <= 0x7A)
+            let digit = v >= 0x30 && v <= 0x39
+            let punct = v == 0x2E || v == 0x5F || v == 0x2D  // . _ -
+            if !(alpha || digit || punct) { return false }
+        }
+        return true
     }
 }
 

--- a/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
@@ -8,6 +8,23 @@ private let log = Logger(subsystem: "com.slicc.sliccstart", category: "Settings"
 /// "None". Read at app startup by `SliccstartApp.initialize`.
 let autoLaunchAppIdKey = "autoLaunchAppId"
 
+/// Validation rules for secret names entered in the Settings → Secrets
+/// editor. Mount-profile keys use the shape `s3.<profile>.<field>` (dots),
+/// and tokens are commonly named with hyphens (e.g. `gh-prod`). The
+/// swift-server's `SignAndForward.isValidProfileName` accepts the same
+/// set for the profile portion of the key, so the UI and server agree on
+/// what's a valid name.
+///
+/// Lives at file scope (not nested inside the private `SecretEditorSheet`)
+/// so unit tests can reach it via `@testable import Sliccstart`.
+enum SecretNameValidator {
+    static func isValid(_ name: String) -> Bool {
+        guard !name.isEmpty else { return false }
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_.-"))
+        return CharacterSet(charactersIn: name).isSubset(of: allowed)
+    }
+}
+
 struct SettingsView: View {
     var body: some View {
         TabView {
@@ -359,13 +376,7 @@ private struct SecretEditorSheet: View {
     }
 
     private var nameIsValid: Bool {
-        guard !trimmedName.isEmpty else { return false }
-        // Allow dot and hyphen as well as underscore. Mount-profile keys
-        // use the shape `s3.<profile>.<field>` (dots), and tokens are
-        // commonly named with hyphens (e.g. `gh-prod`). The swift-server's
-        // `SignAndForward.isValidProfileName` accepts the same set.
-        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_.-"))
-        return CharacterSet(charactersIn: trimmedName).isSubset(of: allowed)
+        SecretNameValidator.isValid(trimmedName)
     }
 
     private var nameCollides: Bool {

--- a/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
@@ -360,7 +360,11 @@ private struct SecretEditorSheet: View {
 
     private var nameIsValid: Bool {
         guard !trimmedName.isEmpty else { return false }
-        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
+        // Allow dot and hyphen as well as underscore. Mount-profile keys
+        // use the shape `s3.<profile>.<field>` (dots), and tokens are
+        // commonly named with hyphens (e.g. `gh-prod`). The swift-server's
+        // `SignAndForward.isValidProfileName` accepts the same set.
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_.-"))
         return CharacterSet(charactersIn: trimmedName).isSubset(of: allowed)
     }
 
@@ -383,7 +387,7 @@ private struct SecretEditorSheet: View {
 
     private var validationMessage: String? {
         if trimmedName.isEmpty { return "Name is required." }
-        if !nameIsValid { return "Name may only contain letters, numbers, and underscores." }
+        if !nameIsValid { return "Name may only contain letters, numbers, dots, underscores, and hyphens." }
         if nameCollides { return "A secret named \"\(trimmedName)\" already exists." }
         if value.isEmpty { return "Value is required." }
         if trimmedDomains.isEmpty { return "Add at least one hostname pattern." }

--- a/packages/swift-launcher/SliccstartTests/SecretNameValidatorTests.swift
+++ b/packages/swift-launcher/SliccstartTests/SecretNameValidatorTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Sliccstart
+
+/// Pins the character set the Settings → Secrets editor accepts. Must
+/// stay aligned with `SignAndForward.isValidProfileName` in the
+/// swift-server target — the UI accepts the same set the server accepts
+/// for the profile portion of an `s3.<profile>.<field>` key, so users
+/// can't enter a name the server would later reject.
+final class SecretNameValidatorTests: XCTestCase {
+
+    func testAcceptsAlphanumerics() {
+        XCTAssertTrue(SecretNameValidator.isValid("token"))
+        XCTAssertTrue(SecretNameValidator.isValid("TOKEN"))
+        XCTAssertTrue(SecretNameValidator.isValid("Token123"))
+        XCTAssertTrue(SecretNameValidator.isValid("X"))
+        XCTAssertTrue(SecretNameValidator.isValid("abc123XYZ"))
+    }
+
+    func testAcceptsDotsForMountProfileKeyShape() {
+        // The motivating case: mount profile credentials are stored as
+        // `s3.<profile>.<field>` and previously couldn't be entered at all.
+        XCTAssertTrue(SecretNameValidator.isValid("s3.default.access_key_id"))
+        XCTAssertTrue(SecretNameValidator.isValid("s3.r2.secret_access_key"))
+        XCTAssertTrue(SecretNameValidator.isValid("s3.minio-prod.endpoint"))
+    }
+
+    func testAcceptsUnderscoresAndHyphens() {
+        XCTAssertTrue(SecretNameValidator.isValid("AWS_ACCESS_KEY"))
+        XCTAssertTrue(SecretNameValidator.isValid("gh-prod"))
+        XCTAssertTrue(SecretNameValidator.isValid("a-b_c.d"))
+    }
+
+    func testRejectsEmpty() {
+        XCTAssertFalse(SecretNameValidator.isValid(""))
+    }
+
+    func testRejectsWhitespace() {
+        XCTAssertFalse(SecretNameValidator.isValid("foo bar"))
+        XCTAssertFalse(SecretNameValidator.isValid("\t"))
+    }
+
+    func testRejectsShellMetacharacters() {
+        XCTAssertFalse(SecretNameValidator.isValid("foo;rm"))
+        XCTAssertFalse(SecretNameValidator.isValid("foo|bar"))
+        XCTAssertFalse(SecretNameValidator.isValid("foo$bar"))
+        XCTAssertFalse(SecretNameValidator.isValid("`foo`"))
+        XCTAssertFalse(SecretNameValidator.isValid("foo&bar"))
+    }
+
+    func testRejectsPathSeparators() {
+        XCTAssertFalse(SecretNameValidator.isValid("foo/bar"))
+        XCTAssertFalse(SecretNameValidator.isValid("foo\\bar"))
+    }
+
+    func testRejectsAtAndOtherSymbols() {
+        XCTAssertFalse(SecretNameValidator.isValid("user@host"))
+        XCTAssertFalse(SecretNameValidator.isValid("foo:bar"))
+        XCTAssertFalse(SecretNameValidator.isValid("foo!bar"))
+        XCTAssertFalse(SecretNameValidator.isValid("foo#bar"))
+    }
+
+}

--- a/packages/swift-launcher/SliccstartTests/SecretNameValidatorTests.swift
+++ b/packages/swift-launcher/SliccstartTests/SecretNameValidatorTests.swift
@@ -59,4 +59,55 @@ final class SecretNameValidatorTests: XCTestCase {
         XCTAssertFalse(SecretNameValidator.isValid("foo#bar"))
     }
 
+    func testRejectsNonAsciiAlphanumerics() {
+        // A previous iteration used `CharacterSet.alphanumerics`, which is
+        // Unicode-broad and silently accepted Cyrillic homoglyphs, CJK
+        // ideographs, accented Latin, Arabic-Indic digits, full-width
+        // digits, etc. — the kind of input the server-side ASCII check
+        // rejects with `400 invalid_profile` after the UI has saved.
+        // These cases pin the implementation to ASCII-only.
+        XCTAssertFalse(SecretNameValidator.isValid("café"))                 // accented Latin
+        XCTAssertFalse(SecretNameValidator.isValid("s3.р2.access_key_id"))  // Cyrillic 'р' (U+0440)
+        XCTAssertFalse(SecretNameValidator.isValid("数字"))                   // CJK ideographs
+        XCTAssertFalse(SecretNameValidator.isValid("token\u{0661}"))        // Arabic-Indic digit 1
+        XCTAssertFalse(SecretNameValidator.isValid("token\u{FF11}"))        // full-width digit 1
+        XCTAssertFalse(SecretNameValidator.isValid("Ω"))                    // Greek capital omega
+    }
+
+    /// Pinned corpus shared with the server-side validator's tests. Each
+    /// row is `(input, expected)`. If this test fails on a particular
+    /// row, the UI/server contract on that input has drifted — at least
+    /// one side needs an update so they agree.
+    ///
+    /// The corpus reuses inputs from `SignAndForwardTests.swift`'s profile-name
+    /// suite (`packages/swift-server/Tests/SignAndForwardTests.swift`) so
+    /// the two test files visibly share vocabulary.
+    func testValidatorMatchesServerProfileNameSpec() {
+        let cases: [(String, Bool)] = [
+            // Positives — exercised in SignAndForwardTests.testValidProfileName...
+            ("default", true),
+            ("dev-1", true),
+            ("team.us_west", true),
+            ("ABC123", true),
+            ("s3.r2.access_key_id", true),
+            // Negatives — exercised in SignAndForwardTests.testInvalidProfileName...
+            ("", false),
+            ("foo/bar", false),
+            ("../etc", false),
+            ("foo bar", false),
+            ("foo;rm", false),
+            // Unicode drift sentinels — UI must agree with server (both reject)
+            ("s3.р2.x", false),
+            ("\u{FF11}23", false),
+        ]
+        for (input, expected) in cases {
+            let scalars = input.unicodeScalars
+                .map { String(format: "U+%04X", $0.value) }
+                .joined(separator: " ")
+            XCTAssertEqual(
+                SecretNameValidator.isValid(input), expected,
+                "Drift on input \(input.debugDescription) (scalars: \(scalars))"
+            )
+        }
+    }
 }

--- a/packages/swift-server/Sources/Server/SignAndForward.swift
+++ b/packages/swift-server/Sources/Server/SignAndForward.swift
@@ -24,6 +24,11 @@ enum SignAndForward {
     /// Allowed characters in profile names — restricts secret-key path traversal.
     /// `^[a-zA-Z0-9._-]+$` expressed as a character predicate to avoid pulling in
     /// NSRegularExpression for one match.
+    ///
+    /// **Kept in sync with `SecretNameValidator.isValid` in swift-launcher**
+    /// (`packages/swift-launcher/Sliccstart/Views/SettingsView.swift`). Tighten
+    /// only after updating both sides — narrowing the server alone would silently
+    /// reject names the UI claimed to save.
     static func isValidProfileName(_ name: String) -> Bool {
         guard !name.isEmpty else { return false }
         for ch in name.unicodeScalars {


### PR DESCRIPTION
## Summary

The Sliccstart Settings → Secrets editor rejected secret names containing dots or hyphens, which made it impossible to enter mount-profile keys like `s3.<profile>.access_key_id` (the canonical scheme from #565) or any token named with a hyphen (e.g. `gh-prod`). On a fresh Sliccstart install hitting the mount flow, users couldn't save their AWS credentials at all.

Widened the allowed character set in `nameIsValid` to letters, numbers, dot, underscore, and hyphen — matching `SignAndForward.isValidProfileName` server-side, so the UI and server agree on valid names. Updated the inline validation message to match.

## Test plan

- [ ] Build Sliccstart, open Settings → Secrets
- [ ] Confirm `s3.testfinal.access_key_id` saves cleanly with hostname `*.amazonaws.com`
- [ ] Confirm `gh-prod` saves cleanly
- [ ] Confirm names with disallowed chars (e.g. `foo@bar`) still trip the new error message
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)