### PR TITLE
fix(release): unblock macOS pipeline; soft-skip iOS when secrets are bad

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,23 +61,49 @@ jobs:
           # cert was exported with legacy RC2-40 PKCS#12 encryption which
           # newer macOS-arm64 runners' `security import` rejects with
           # "SecKeychainItemImport: Unable to decode the provided data".
-          # Round-tripping via openssl normalizes both legacy and modern
-          # exports to a format `security` reliably accepts.
+          # Round-tripping via openssl normalizes that to a format
+          # `security` reliably accepts.
+          #
+          # Mode "required" (default) errors out if the secret is empty
+          # or the cert can't be decrypted; "optional" logs a warning
+          # and returns 0 so the macOS pipeline isn't blocked by an iOS
+          # cert that's missing or temporarily mis-set.
           import_p12() {
             local label="$1" b64="$2" pass="$3"
+            local mode="${4:-required}"
             local raw="$RUNNER_TEMP/${label}-raw.p12"
             local pem="$RUNNER_TEMP/${label}.pem"
             local norm="$RUNNER_TEMP/${label}.p12"
+            local errlog="$RUNNER_TEMP/${label}.openssl.log"
+            local size
 
-            printf '%s' "$b64" | base64 --decode > "$raw"
-            echo "  ${label}: raw .p12 = $(wc -c < "$raw") bytes"
+            printf '%s' "$b64" | base64 --decode > "$raw" 2>/dev/null || true
+            size="$(wc -c < "$raw" | tr -d ' ')"
+            echo "  ${label}: decoded .p12 = ${size} bytes"
 
-            # Try modern read first; fall back to -legacy for OpenSSL 3.x
-            # decoding RC2-40 / SHA-1 PKCS#12.
+            if [ "$size" -eq 0 ]; then
+              rm -f "$raw"
+              if [ "$mode" = "required" ]; then
+                echo "::error::${label} secret is empty after base64 decode"
+                return 1
+              fi
+              echo "::warning::${label} secret is empty — skipping import"
+              return 0
+            fi
+
+            # macOS-15 runner ships LibreSSL, which decodes legacy
+            # RC2-40 / SHA-1 PKCS#12 natively (no `-legacy` flag).
             if ! openssl pkcs12 -in "$raw" -nodes -out "$pem" \
-                 -passin "pass:${pass}" 2>/dev/null; then
-              openssl pkcs12 -in "$raw" -nodes -out "$pem" \
-                -passin "pass:${pass}" -legacy
+                 -passin "pass:${pass}" 2>"$errlog"; then
+              if [ "$mode" = "required" ]; then
+                echo "::error::openssl could not read ${label} .p12:"
+                cat "$errlog"
+                return 1
+              fi
+              echo "::warning::openssl could not read ${label} .p12 — skipping import"
+              cat "$errlog"
+              rm -f "$raw" "$pem" "$errlog"
+              return 0
             fi
 
             openssl pkcs12 -export -in "$pem" -out "$norm" \
@@ -85,15 +111,15 @@ jobs:
               -keypbe AES-256-CBC -certpbe AES-256-CBC -macalg sha256
 
             security import "$norm" -P "${pass}" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-            rm -f "$raw" "$pem" "$norm"
+            rm -f "$raw" "$pem" "$norm" "$errlog"
           }
 
           echo "Importing Developer ID Application cert (macOS / Sliccstart)..."
-          import_p12 certificate "$APPLE_CERTIFICATE_BASE64" "$APPLE_CERTIFICATE_PASSWORD"
+          import_p12 certificate "$APPLE_CERTIFICATE_BASE64" "$APPLE_CERTIFICATE_PASSWORD" required
 
           if [ -n "${APPLE_DISTRIBUTION_CERT_BASE64:-}" ]; then
             echo "Importing Apple Distribution cert (iOS / SliccFollower TestFlight)..."
-            import_p12 apple-distribution "$APPLE_DISTRIBUTION_CERT_BASE64" "$APPLE_DISTRIBUTION_CERT_PASSWORD"
+            import_p12 apple-distribution "$APPLE_DISTRIBUTION_CERT_BASE64" "$APPLE_DISTRIBUTION_CERT_PASSWORD" optional
           fi
 
           security set-key-partition-list -S apple-tool:,apple:,codesign: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"

--- a/packages/ios-app/scripts/package-and-upload-testflight.sh
+++ b/packages/ios-app/scripts/package-and-upload-testflight.sh
@@ -34,6 +34,22 @@ if [ "${SLICC_SKIP_TESTFLIGHT:-}" = "1" ]; then
   exit 0
 fi
 
+# Soft-skip when the TestFlight secrets aren't usable. semantic-release's
+# prepareCmd treats any non-zero exit as a release failure, which would
+# block the macOS DMG / Chrome / Worker publish too. Exiting 0 here lets
+# the rest of the pipeline ship and we can re-set the iOS secrets out of
+# band without rolling back a release.
+if [ -z "${APPLE_DISTRIBUTION_CERT_BASE64:-}" ] || [ "${APPLE_DISTRIBUTION_CERT_BASE64:-}" = "-" ] \
+   || [ -z "${APPLE_API_KEY_P8_BASE64:-}" ] || [ "${APPLE_API_KEY_P8_BASE64:-}" = "-" ] \
+   || [ -z "${APPLE_PROVISIONING_PROFILE_BASE64:-}" ] || [ "${APPLE_PROVISIONING_PROFILE_BASE64:-}" = "-" ]; then
+  if [ -n "${GITHUB_RUN_NUMBER:-}" ]; then
+    echo "::warning::TestFlight secrets are missing or empty — skipping iOS upload."
+  else
+    echo "TestFlight secrets are missing or empty — skipping iOS upload."
+  fi
+  exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 IOS_PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROJECT_ROOT="$(cd "$IOS_PROJECT_DIR/../.." && pwd)"

--- a/packages/ios-app/scripts/setup-testflight-secrets.sh
+++ b/packages/ios-app/scripts/setup-testflight-secrets.sh
@@ -129,8 +129,12 @@ fi
 set_secret() {
   local name="$1" value="$2"
   printf '  %-40s ' "$name"
-  if printf '%s' "$value" | "$GH_BIN" secret set "$name" -R "$REPO" --body - >/dev/null; then
-    echo "ok"
+  # NOTE: pass the value via stdin WITHOUT `--body -`. `gh secret set
+  # --body -` treats the literal "-" as the body string and ignores the
+  # pipe, which is how every TestFlight secret on this repo ended up
+  # set to a single dash. Omitting `--body` makes gh read stdin.
+  if printf '%s' "$value" | "$GH_BIN" secret set "$name" -R "$REPO" >/dev/null; then
+    echo "ok ($(printf '%s' "$value" | wc -c | tr -d ' ') bytes)"
   else
     echo "FAILED"
     return 1


### PR DESCRIPTION
Run after #572 still failed:
```
Importing Developer ID Application cert (macOS / Sliccstart)...
  certificate: raw .p12 =     3215 bytes
Importing Apple Distribution cert (iOS / SliccFollower TestFlight)...
  apple-distribution: raw .p12 =        0 bytes
pkcs12: Unrecognized flag legacy
```

Two real bugs surfaced (failing run: https://github.com/ai-ecoverse/slicc/actions/runs/25391087588/job/74465466500):

**1. Every TestFlight secret was set to the literal string `-`.** `setup-testflight-secrets.sh` did `printf '%s' "$value" | gh secret set NAME -R repo --body -` — but `gh secret set` only reads stdin when `--body` is omitted. With `--body -` it sets the secret to the string `"-"` and ignores the pipe. Drop `--body`. Print the byte count after each set for verification.

**2. macos-15-arm64 runner ships LibreSSL, which doesn't have `-legacy`.** The fallback added in #572 would only help OpenSSL 3.x runners (Linux), and on macOS it crashes the step with `pkcs12: Unrecognized flag legacy`. LibreSSL handles RC2-40 / SHA-1 PKCS#12 natively, so drop the fallback. Also split required vs optional cert imports so a busted iOS secret never blocks macOS.

**3. Soft-skip iOS in semantic-release prepareCmd.** `package-and-upload-testflight.sh` now exits 0 with a `::warning::` when the iOS base64 secrets are empty or set to `"-"`, instead of crashing semantic-release. macOS DMG / Chrome / Worker / npm publish ship; the iOS upload re-tries on the next release after the secrets are re-set.

Once this lands, I'll have you re-run `setup-testflight-secrets.sh` (now fixed) to push real values for the six TestFlight secrets.