### PR TITLE
fix(ios): force manual signing for archive on CI

### DIFF
--- a/packages/ios-app/scripts/package-and-upload-testflight.sh
+++ b/packages/ios-app/scripts/package-and-upload-testflight.sh
@@ -215,6 +215,13 @@ EOF
 
 # --- Archive ---------------------------------------------------------------
 echo "  archiving..."
+# Force manual signing for the archive even though the project file
+# defaults to Automatic. CI's keychain only has the Apple Distribution
+# cert (Development is intentionally not in the secrets surface), so
+# automatic signing aborts looking for "Apple Development". Overriding
+# at the command line keeps the .pbxproj friendly for local Xcode
+# builds while pinning CI to the manual cert + provisioning profile we
+# already imported.
 xcodebuild \
   -project "$IOS_PROJECT_DIR/SliccFollower.xcodeproj" \
   -scheme SliccFollower \
@@ -225,6 +232,11 @@ xcodebuild \
   -authenticationKeyID "$APPLE_API_KEY_ID" \
   -authenticationKeyIssuerID "$APPLE_API_KEY_ISSUER_ID" \
   -authenticationKeyPath "$P8_PATH" \
+  CODE_SIGN_STYLE=Manual \
+  CODE_SIGN_IDENTITY="Apple Distribution" \
+  DEVELOPMENT_TEAM="$TEAM_ID" \
+  PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
+  PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
   MARKETING_VERSION="$VERSION" \
   CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
   archive >/tmp/slicc-archive.log 2>&1 \


### PR DESCRIPTION
Run 25395539071 (the first run where semantic-release actually picked up the prepareCmd because PR #574's `fix(release):` was a real release-bumping commit) failed on:

```
error: No signing certificate "iOS Development" found: No "iOS Development" signing certificate matching team ID "***" with a private key was found.
** ARCHIVE FAILED **
```

The .pbxproj has `CODE_SIGN_STYLE=Automatic` + `CODE_SIGN_IDENTITY="Apple Development"` for both Debug and Release. With automatic signing, `xcodebuild archive` looks for an Apple Development cert in the keychain to satisfy the hint — even though the resulting archive ends up signed with Apple Distribution. CI's keychain only has Apple Distribution (the only iOS-side secret we push), so it aborts.

Override on the xcodebuild command line so the project file stays auto-signed for local Xcode builds (devs don't fight profiles) while CI archives are pinned to the manual cert + profile we already imported:

```
CODE_SIGN_STYLE=Manual
CODE_SIGN_IDENTITY="Apple Distribution"
DEVELOPMENT_TEAM="$TEAM_ID"
PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME"
PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID"
```

This matches what `ExportOptions-AppStore.plist` already specifies for the export step, so archive + export now use the same signing policy.