### PR TITLE
fix(ios): build TestFlight archive with Xcode 26+ on macos-26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,13 @@ concurrency:
 
 jobs:
   release:
-    runs-on: macos-latest
+    # macos-26 GA'd 2026-02-26 and is the image that ships Xcode 26
+    # by default. Apple now rejects App Store submissions built with
+    # anything older: "Validation failed (409) SDK version issue.
+    # This app was built with the iOS 18.5 SDK. All iOS and iPadOS
+    # apps must be built with the iOS 26 SDK or later." macos-latest
+    # still resolves to macos-15 (Xcode 16.x) as of this commit.
+    runs-on: macos-26
     timeout-minutes: 30
     permissions:
       contents: write

--- a/packages/ios-app/scripts/package-and-upload-testflight.sh
+++ b/packages/ios-app/scripts/package-and-upload-testflight.sh
@@ -77,6 +77,47 @@ PROFILE_NAME="${APPLE_PROVISIONING_PROFILE_NAME:-Slicc Follower App Store}"
 
 echo "=== SliccFollower TestFlight v${VERSION} (build ${BUILD_NUMBER}) ==="
 
+# Apple requires App Store submissions to be built with Xcode 26+
+# (iOS 26 SDK). The default Xcode on macos-15 runners is 16.x, which
+# fails altool validation with "SDK version issue ... must be built
+# with the iOS 26 SDK or later". Pick the highest /Applications/Xcode_*
+# we can find and set DEVELOPER_DIR for the rest of this script. If
+# none are >= 26, surface a clear error so we know to bump the runner
+# image (or wait for macos-26 GA) instead of getting another opaque
+# 409 from altool.
+pick_xcode() {
+  local best="" best_major=0 candidate major
+  for candidate in /Applications/Xcode_26*.app /Applications/Xcode-26*.app /Applications/Xcode_*.app; do
+    [ -d "$candidate" ] || continue
+    # Grab the leading numeric component of the version, e.g. "26" from
+    # "Xcode_26.0.1.app". Anything we can't parse is treated as 0.
+    major="$(basename "$candidate" | sed -E 's/^Xcode[_-]?([0-9]+).*/\1/' | grep -E '^[0-9]+$' || echo 0)"
+    if [ "${major:-0}" -gt "$best_major" ]; then
+      best="$candidate"
+      best_major="$major"
+    fi
+  done
+  if [ -z "$best" ]; then
+    return 1
+  fi
+  echo "$best"
+}
+
+if XCODE_APP="$(pick_xcode)" && [ -n "$XCODE_APP" ]; then
+  XCODE_VERSION="$("$XCODE_APP/Contents/Developer/usr/bin/xcodebuild" -version 2>/dev/null | head -1)"
+  XCODE_MAJOR="$(echo "$XCODE_VERSION" | sed -E 's/^Xcode[[:space:]]+([0-9]+).*/\1/')"
+  if [ -z "$XCODE_MAJOR" ] || [ "$XCODE_MAJOR" -lt 26 ]; then
+    if [ -n "${GITHUB_RUN_NUMBER:-}" ]; then
+      echo "::warning::Highest installed Xcode is '$XCODE_VERSION' (< 26). App Store now rejects pre-Xcode-26 builds. Skipping iOS upload."
+    else
+      echo "warn: Highest installed Xcode is '$XCODE_VERSION' (< 26). App Store now rejects pre-Xcode-26 builds. Skipping iOS upload."
+    fi
+    exit 0
+  fi
+  export DEVELOPER_DIR="$XCODE_APP/Contents/Developer"
+  echo "  using $XCODE_VERSION (DEVELOPER_DIR=$DEVELOPER_DIR)"
+fi
+
 ARCHIVE="$IOS_PROJECT_DIR/.build/SliccFollower.xcarchive"
 EXPORT_DIR="$IOS_PROJECT_DIR/.build/export"
 EXPORT_OPTS="$IOS_PROJECT_DIR/.build/ExportOptions-AppStore.generated.plist"


### PR DESCRIPTION
Run 25397374756 finally got the .ipa uploaded to App Store Connect, but Apple rejected it:

```
Validation failed (409) SDK version issue. This app was built with the iOS 18.5
SDK. All iOS and iPadOS apps must be built with the iOS 26 SDK or later,
included in Xcode 26 or later
```

The macos-15 / macos-latest runner only ships Xcode 16.x (iOS 18.5 SDK). Apple's policy now requires Xcode 26 / iOS 26 SDK for App Store submissions.

Two-part fix:

1. **`release.yml`** — pin `runs-on: macos-26` (GA'd 2026-02-26), which ships Xcode 26 by default. macOS Sliccstart Developer ID signing/notarization tooling is OS-version-agnostic so this should not regress the desktop pipeline.

2. **`package-and-upload-testflight.sh`** — forward-compatible Xcode picker that prefers `/Applications/Xcode_26*.app` and falls back to the highest-version `/Applications/Xcode_*.app` it can parse. Sets `DEVELOPER_DIR` before `xcodebuild` + `altool`. If the highest installed Xcode is < 26 (e.g. macos-26 image regression), soft-skip with a clear `::warning::` instead of getting another opaque 409 from altool.

Each iteration in this fix sequence has been a real layer:
- #574 (cert hardening) → semantic-release re-runs prepareCmd
- #575 (manual signing override) → archive succeeds
- #576 (.p8 in altool's path) → altool authenticates + uploads
- this PR (Xcode 26 / macos-26) → Apple accepts the build