### PR TITLE
fix(release): re-add -legacy fallback for OpenSSL 3.x on macos-26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,23 +107,41 @@ jobs:
               return 0
             fi
 
-            # macOS-15 runner ships LibreSSL, which decodes legacy
-            # RC2-40 / SHA-1 PKCS#12 natively (no `-legacy` flag).
+            # macos-15 ran LibreSSL (decodes legacy RC2-40 / SHA-1
+            # PKCS#12 natively, no `-legacy` flag and chokes on it).
+            # macos-26 ships OpenSSL 3.x, which DOES require `-legacy`
+            # to enable RC2-40-CBC. Try the modern call first, fall
+            # back to `-legacy` only when the first call fails — that
+            # way LibreSSL never runs the failing -legacy branch and
+            # OpenSSL 3.x gets the legacy provider.
             if ! openssl pkcs12 -in "$raw" -nodes -out "$pem" \
                  -passin "pass:${pass}" 2>"$errlog"; then
-              if [ "$mode" = "required" ]; then
-                echo "::error::openssl could not read ${label} .p12:"
+              if ! openssl pkcs12 -in "$raw" -nodes -out "$pem" \
+                   -passin "pass:${pass}" -legacy 2>>"$errlog"; then
+                if [ "$mode" = "required" ]; then
+                  echo "::error::openssl could not read ${label} .p12 (modern + -legacy both failed):"
+                  cat "$errlog"
+                  return 1
+                fi
+                echo "::warning::openssl could not read ${label} .p12 — skipping import"
                 cat "$errlog"
-                return 1
+                return 0
               fi
-              echo "::warning::openssl could not read ${label} .p12 — skipping import"
-              cat "$errlog"
-              return 0
             fi
 
-            openssl pkcs12 -export -in "$pem" -out "$norm" \
-              -password "pass:${pass}" \
-              -keypbe AES-256-CBC -certpbe AES-256-CBC -macalg sha256
+            # On OpenSSL 3.x, `-legacy` is also needed to write a
+            # PKCS#12 with the modern AES-256 ciphers from a key that
+            # came in via the legacy provider. Be permissive: try
+            # without `-legacy` first, fall back if that errors.
+            if ! openssl pkcs12 -export -in "$pem" -out "$norm" \
+                 -password "pass:${pass}" \
+                 -keypbe AES-256-CBC -certpbe AES-256-CBC -macalg sha256 \
+                 2>"$errlog"; then
+              openssl pkcs12 -export -in "$pem" -out "$norm" \
+                -password "pass:${pass}" \
+                -keypbe AES-256-CBC -certpbe AES-256-CBC -macalg sha256 \
+                -legacy
+            fi
 
             security import "$norm" -P "${pass}" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           }


### PR DESCRIPTION
After bumping to macos-26 in #577, the very first cert import failed:

```
openssl could not read certificate .p12:
Error outputting keys and certificates
8070A6FF01000000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:376:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
```

macos-15 shipped LibreSSL, which decodes RC2-40 / SHA-1 PKCS#12 natively. macos-26 ships **OpenSSL 3.x**, which moved RC2-40-CBC into the 'legacy' provider and refuses to use it without `-legacy`.

#573 dropped the `-legacy` fallback because LibreSSL chokes with `pkcs12: Unrecognized flag legacy` if you pass it. But the fallback only runs when the first openssl call has already failed — and on LibreSSL the first call always succeeds, so the fallback never gets hit. Re-adding the fallback now serves both runners:

- **LibreSSL** (macos-15): first call succeeds, fallback never runs.
- **OpenSSL 3.x** (macos-26): first call fails, fallback enables legacy provider, RC2-40 reads correctly.

Same fallback added to both read (`openssl pkcs12 -in`) and re-export (`openssl pkcs12 -export`) — OpenSSL 3.x needs `-legacy` on the write side too once the key has come in via the legacy provider.