### PR TITLE
fix(ios): avoid SIGPIPE on Xcode version detection

### DIFF
--- a/packages/ios-app/scripts/package-and-upload-testflight.sh
+++ b/packages/ios-app/scripts/package-and-upload-testflight.sh
@@ -104,7 +104,14 @@ pick_xcode() {
 }
 
 if XCODE_APP="$(pick_xcode)" && [ -n "$XCODE_APP" ]; then
-  XCODE_VERSION="$("$XCODE_APP/Contents/Developer/usr/bin/xcodebuild" -version 2>/dev/null | head -1)"
+  # Don't use `xcodebuild -version | head -1` here. Under
+  # `set -o pipefail`, if xcodebuild keeps writing after head closes
+  # its stdin (it has 2 lines), xcodebuild takes SIGPIPE and the
+  # pipeline exits 141 — which kills this entire script and leaves
+  # semantic-release wedged. Capture the full output, take the first
+  # line in pure shell.
+  XCODE_VERSION_RAW="$("$XCODE_APP/Contents/Developer/usr/bin/xcodebuild" -version 2>/dev/null || true)"
+  XCODE_VERSION="${XCODE_VERSION_RAW%%$'\n'*}"
   XCODE_MAJOR="$(echo "$XCODE_VERSION" | sed -E 's/^Xcode[[:space:]]+([0-9]+).*/\1/')"
   if [ -z "$XCODE_MAJOR" ] || [ "$XCODE_MAJOR" -lt 26 ]; then
     if [ -n "${GITHUB_RUN_NUMBER:-}" ]; then


### PR DESCRIPTION
Run 25398938498 (after #578 merged) failed at exit code 141 (SIGPIPE) right after the iOS script's banner line:

```
=== SliccFollower TestFlight v2.30.1 (build 361) ===
[semantic-release] Failed step "prepare" ... exit code 141
```

The next thing the script did was:

```bash
XCODE_VERSION="$(xcodebuild -version 2>/dev/null | head -1)"
```

Script runs under `set -euo pipefail`. `xcodebuild -version` on Xcode 26 prints two lines (Xcode version + Build version). `head -1` takes the first line and closes stdin. xcodebuild tries to write the second line, gets SIGPIPE, exits 141. With `pipefail`, the whole pipeline exits 141, `set -e` kills the script, semantic-release sees exit 141 and aborts.

Replace the pipeline with pure-shell first-line extraction:

```bash
XCODE_VERSION_RAW="$(xcodebuild -version 2>/dev/null || true)"
XCODE_VERSION="${XCODE_VERSION_RAW%%$'\n'*}"
```

No pipe, no SIGPIPE, no 141.