### PR TITLE
fix(extension): make tray host actually start

### DIFF
--- a/packages/chrome-extension/src/offscreen.ts
+++ b/packages/chrome-extension/src/offscreen.ts
@@ -17,6 +17,8 @@ import {
 } from '../../../packages/webapp/src/scoops/agent-bridge.js';
 import { LeaderTrayManager } from '../../../packages/webapp/src/scoops/tray-leader.js';
 import {
+  DEFAULT_PRODUCTION_TRAY_WORKER_BASE_URL,
+  DEFAULT_STAGING_TRAY_WORKER_BASE_URL,
   hasStoredTrayJoinUrl,
   resolveTrayRuntimeConfig,
   TRAY_JOIN_STORAGE_KEY,
@@ -363,6 +365,9 @@ async function init(): Promise<void> {
       locationHref: window.location.href,
       storage: window.localStorage,
       envBaseUrl: import.meta.env.VITE_WORKER_BASE_URL ?? null,
+      defaultWorkerBaseUrl: __DEV__
+        ? DEFAULT_STAGING_TRAY_WORKER_BASE_URL
+        : DEFAULT_PRODUCTION_TRAY_WORKER_BASE_URL,
     });
     const nextTrayRuntimeKey = JSON.stringify(trayRuntimeConfig);
     if (nextTrayRuntimeKey === activeTrayRuntimeKey) {

--- a/packages/webapp/src/scoops/tray-leader.ts
+++ b/packages/webapp/src/scoops/tray-leader.ts
@@ -581,7 +581,10 @@ function parseSocketMessage(data: unknown): WorkerToLeaderControlMessage | null 
 export function createTrayFetch(fetchImpl: typeof fetch = fetch): typeof fetch {
   const isExtension = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
   if (isExtension) {
-    return fetchImpl;
+    // Wrap so calling `this.fetchImpl(...)` doesn't rebind `this` to the
+    // LeaderTrayManager instance and trigger "Illegal invocation" against
+    // the global fetch.
+    return (url, init) => fetchImpl(url, init);
   }
 
   return async (url, init = {}) => {

--- a/packages/webapp/tests/scoops/tray-leader.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   LeaderTrayManager,
+  createTrayFetch,
   getLeaderTrayRuntimeStatus,
   parseLeaderTraySession,
   type LeaderTraySession,
@@ -915,5 +916,62 @@ describe('tray-leader', () => {
     expect(sockets[0].closeCalls).toBe(1);
 
     manager.stop();
+  });
+});
+
+describe('createTrayFetch', () => {
+  // Browsers reject `fetch` calls whose `this` is not the global Window /
+  // WorkerGlobalScope, throwing "Illegal invocation". The leader stores the
+  // returned function on `this.fetchImpl` and invokes it as a method, so
+  // returning a bare reference to `fetch` would rebind `this` to the
+  // LeaderTrayManager and break every request. The wrappers below assert that
+  // the returned function tolerates an arbitrary `this` for both the
+  // extension and standalone branches.
+  const stubChromeRuntime = (mode: 'extension' | 'standalone') => {
+    const original = (globalThis as { chrome?: unknown }).chrome;
+    if (mode === 'extension') {
+      (globalThis as { chrome?: unknown }).chrome = { runtime: { id: 'test' } };
+    } else {
+      delete (globalThis as { chrome?: unknown }).chrome;
+    }
+    return () => {
+      if (original === undefined) {
+        delete (globalThis as { chrome?: unknown }).chrome;
+      } else {
+        (globalThis as { chrome?: unknown }).chrome = original;
+      }
+    };
+  };
+
+  it('preserves the underlying fetch when invoked as a method (extension branch)', async () => {
+    const restore = stubChromeRuntime('extension');
+    try {
+      const inner = vi.fn<typeof fetch>().mockResolvedValue(new Response('ok'));
+      const wrapped = createTrayFetch(inner);
+      const holder = { call: wrapped };
+      await expect(holder.call('https://example.com/x')).resolves.toBeInstanceOf(Response);
+      expect(inner).toHaveBeenCalledTimes(1);
+      expect(inner.mock.calls[0]?.[0]).toBe('https://example.com/x');
+    } finally {
+      restore();
+    }
+  });
+
+  it('routes cross-origin requests through the fetch proxy in non-extension mode', async () => {
+    const restore = stubChromeRuntime('standalone');
+    try {
+      // Non-extension branch already wraps fetch in an arrow, so this case
+      // existed pre-fix; included to lock in the existing behavior alongside
+      // the new method-call invariant above.
+      const inner = vi.fn<typeof fetch>().mockResolvedValue(new Response('ok'));
+      const wrapped = createTrayFetch(inner);
+      const holder = { call: wrapped };
+      await expect(holder.call('https://tray.example.com/tray')).resolves.toBeInstanceOf(Response);
+      expect(inner).toHaveBeenCalledTimes(1);
+      // Standalone branch routes off-origin requests through /api/fetch-proxy.
+      expect(inner.mock.calls[0]?.[0]).toBe('/api/fetch-proxy');
+    } finally {
+      restore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Two bugs in the Chrome extension prevented `host` from ever surfacing a join URL on a clean install — the agent reported "the host is inactive and no join URL is available" instead of bootstrapping a tray. This is what Eric hit on 2.29.1.

- **Offscreen never resolved a worker URL.** `packages/chrome-extension/src/offscreen.ts` called `resolveTrayRuntimeConfig` without `defaultWorkerBaseUrl`, so a fresh extension with no `VITE_WORKER_BASE_URL`, no stored config, and no URL override returned `null` and `LeaderTrayManager` was never constructed. Standalone passes a default; the extension silently did not. Now uses the production worker in production builds, staging in dev builds — mirroring standalone.
- **`createTrayFetch` lost the Window binding.** In the extension branch it returned the bare `fetch` reference. `LeaderTrayManager` invokes it as `this.fetchImpl(...)`, which rebinds `this` to the manager instance and trips the browser's "Illegal invocation" check on the global fetch. Wrapped in an arrow so the call site can't rebind `this`. Captured live: `Leader tray join failed: Failed to execute 'fetch' on 'Window': Illegal invocation`.

The "WebRTC flakiness / missing auto-reconnect" theory in the original thread was wrong — `LeaderTrayManager` already has a full reconnect loop. The leader simply never started, so there was nothing to reconnect.

## Test plan

- [x] `npx vitest run --project webapp packages/webapp/tests/scoops/tray-leader.test.ts` — 13/13 pass (includes 2 new `createTrayFetch` tests covering the method-call invocation invariant)
- [x] `npm run typecheck`
- [x] `npm run test` — 3541 passed / 3 skipped
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] End-to-end smoke: fresh extension profile in Chrome for Testing now auto-attaches to the production tray worker and IndexedDB shows a real `leader-tray-session` with a `trayId` on first run.

## Merge note

Use a merge commit, not squash — per the repo policy avoiding the squash-merge-queue regression bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)