### PR TITLE
fix(sliccstart): re-probe App Management on focus, not every 2 s

### DIFF
--- a/packages/swift-launcher/Sliccstart/Models/AppManagementPermission.swift
+++ b/packages/swift-launcher/Sliccstart/Models/AppManagementPermission.swift
@@ -4,27 +4,63 @@ import AppKit
 @Observable
 final class AppManagementPermission {
     private(set) var isGranted: Bool = false
-    private var checkTimer: Timer?
-    
+    private var activationObserver: NSObjectProtocol?
+
     init() {
         checkPermission()
     }
-    
+
+    deinit {
+        if let activationObserver {
+            NotificationCenter.default.removeObserver(activationObserver)
+        }
+    }
+
     func checkPermission() {
         isGranted = Self.probeAppManagementAccess()
     }
-    
-    func startPolling(interval: TimeInterval = 2.0) {
-        stopPolling()
+
+    /// Re-probe whenever Sliccstart regains focus. The common case for a
+    /// state transition is the user toggling the switch in System Settings
+    /// → Privacy & Security → App Management and then switching back to
+    /// Sliccstart, which fires `didBecomeActive` synchronously on the
+    /// return.
+    ///
+    /// **Why not a timer.** The probe writes a temp file inside a user
+    /// app bundle (`/Applications/<App>/Contents/.sliccstart_probe_…`)
+    /// because TCC has no read-only API for the App Management
+    /// entitlement. On macOS Sonoma+ every denied write into another
+    /// app's bundle posts a "Sliccstart was prevented from modifying
+    /// apps on your Mac" Notification Center alert, and the previous
+    /// 2-second polling timer turned that into a continuous stream of
+    /// notifications until the user granted the permission. Focus-driven
+    /// re-probing fires at most once per app switch, which matches when
+    /// the answer can actually change.
+    func startWatchingForGrant() {
+        stopWatchingForGrant()
         checkPermission()
-        checkTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+        activationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
             self?.checkPermission()
         }
     }
-    
-    func stopPolling() {
-        checkTimer?.invalidate()
-        checkTimer = nil
+
+    func stopWatchingForGrant() {
+        if let activationObserver {
+            NotificationCenter.default.removeObserver(activationObserver)
+            self.activationObserver = nil
+        }
+    }
+
+    /// True between `startWatchingForGrant()` and `stopWatchingForGrant()`.
+    /// Exists so tests (and any future debug surface) can confirm the
+    /// observer slot lifecycle without reflecting into `@Observable`'s
+    /// rewritten storage.
+    var isWatching: Bool {
+        activationObserver != nil
     }
     
     func openSystemSettings() {

--- a/packages/swift-launcher/Sliccstart/Models/AppManagementPermission.swift
+++ b/packages/swift-launcher/Sliccstart/Models/AppManagementPermission.swift
@@ -4,6 +4,14 @@ import AppKit
 @Observable
 final class AppManagementPermission {
     private(set) var isGranted: Bool = false
+    /// Number of times the probe has run since this instance was
+    /// created. `init()` runs once, so this starts at 1. Each probe
+    /// writes a temp file into a user app bundle (see
+    /// `probeAppManagementAccess`), and on macOS Sonoma+ each *denied*
+    /// probe posts a Notification Center alert — so this is also the
+    /// upper bound on how many alerts we may have caused this session.
+    /// Tests use it to prove the activation observer actually fires.
+    private(set) var probeCount: Int = 0
     private var activationObserver: NSObjectProtocol?
 
     init() {
@@ -17,6 +25,7 @@ final class AppManagementPermission {
     }
 
     func checkPermission() {
+        probeCount += 1
         isGranted = Self.probeAppManagementAccess()
     }
 
@@ -36,9 +45,12 @@ final class AppManagementPermission {
     /// notifications until the user granted the permission. Focus-driven
     /// re-probing fires at most once per app switch, which matches when
     /// the answer can actually change.
+    ///
+    /// Note: `init()` already ran the first probe, so we only register
+    /// the observer here — no extra probe at startup. That keeps the
+    /// total at exactly one alert worth of probes during launch.
     func startWatchingForGrant() {
         stopWatchingForGrant()
-        checkPermission()
         activationObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification,
             object: nil,

--- a/packages/swift-launcher/Sliccstart/SliccstartApp.swift
+++ b/packages/swift-launcher/Sliccstart/SliccstartApp.swift
@@ -102,8 +102,8 @@ struct SliccstartApp: App {
             }
             .frame(width: 340)
             .task { await initialize() }
-            .onAppear { appManagementPermission.startPolling() }
-            .onDisappear { appManagementPermission.stopPolling() }
+            .onAppear { appManagementPermission.startWatchingForGrant() }
+            .onDisappear { appManagementPermission.stopWatchingForGrant() }
             .onChange(of: appManagementPermission.isGranted) {
                 // Re-scan when permission is granted so Electron apps appear
                 if isReady {

--- a/packages/swift-launcher/SliccstartTests/AppManagementPermissionTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppManagementPermissionTests.swift
@@ -1,0 +1,107 @@
+import AppKit
+import XCTest
+@testable import Sliccstart
+
+/// Pins the focus-driven re-probe behavior of `AppManagementPermission`.
+///
+/// History: this class used to schedule a `Timer` firing every 2 s that
+/// called `probeAppManagementAccess()`, which writes a temp file inside
+/// a user app bundle to test the App Management entitlement. On macOS
+/// Sonoma+ each denied write posts a "Sliccstart was prevented from
+/// modifying apps on your Mac" Notification Center alert, so the timer
+/// turned that into a continuous spam loop on machines that hadn't
+/// granted the permission. The replacement re-probes on
+/// `NSApplication.didBecomeActiveNotification` instead — fires at most
+/// once per app switch, which is when the answer can actually change.
+///
+/// These tests pin the new contract so a future refactor that re-adds
+/// a timer (or drops the activation observer) breaks loudly.
+final class AppManagementPermissionTests: XCTestCase {
+
+    func testInitProbesOnce() {
+        // The probe runs in the initializer; we don't assert what value
+        // it returned (CI runners can be either) — only that nothing
+        // throws and the `isGranted` flag is set to a concrete bool.
+        let permission = AppManagementPermission()
+        XCTAssertTrue(permission.isGranted == true || permission.isGranted == false)
+        XCTAssertFalse(permission.isWatching, "init must not register an observer")
+    }
+
+    func testCheckPermissionIsIdempotent() {
+        let permission = AppManagementPermission()
+        let first = permission.isGranted
+        permission.checkPermission()
+        permission.checkPermission()
+        XCTAssertEqual(permission.isGranted, first, "Two probes in a row should agree")
+    }
+
+    func testStartWatchingDoesNotRetainATimer() {
+        // Regression guard: an earlier implementation kept a
+        // `Timer.scheduledTimer(...)` alive in `checkTimer`. Mirror
+        // reflection sees stored values regardless of `@Observable`'s
+        // label rewriting, so a refactor that re-adds *any* Timer
+        // anywhere on the instance fails here instead of in the wild.
+        let permission = AppManagementPermission()
+        permission.startWatchingForGrant()
+        defer { permission.stopWatchingForGrant() }
+
+        let storedTimer = Mirror(reflecting: permission)
+            .children
+            .first(where: { ($0.value as? Timer) != nil })
+        XCTAssertNil(storedTimer, "AppManagementPermission must not hold a Timer")
+    }
+
+    func testStartWatchingRegistersObserver() {
+        let permission = AppManagementPermission()
+        XCTAssertFalse(permission.isWatching)
+        permission.startWatchingForGrant()
+        defer { permission.stopWatchingForGrant() }
+        XCTAssertTrue(permission.isWatching)
+    }
+
+    func testStopWatchingClearsObserver() {
+        let permission = AppManagementPermission()
+        permission.startWatchingForGrant()
+        permission.stopWatchingForGrant()
+        XCTAssertFalse(permission.isWatching, "stopWatchingForGrant() should drop the observer")
+    }
+
+    func testStartWatchingIsIdempotent() {
+        // Calling start twice (e.g. window reappearing after sheet
+        // dismiss) must not stack observers — which would cause N
+        // probes per activation. After a single stop the slot must
+        // be empty.
+        let permission = AppManagementPermission()
+        permission.startWatchingForGrant()
+        permission.startWatchingForGrant()
+        XCTAssertTrue(permission.isWatching)
+        permission.stopWatchingForGrant()
+        XCTAssertFalse(permission.isWatching, "start→start→stop should leave no observer behind")
+    }
+
+    func testActivationNotificationRetriggersProbe() {
+        // End-to-end: posting `didBecomeActive` while the observer is
+        // installed should land in `checkPermission()`. We can't easily
+        // stub the static probe, but we can pin the round-trip by
+        // observing that `isGranted` is reachable and unchanged across
+        // the notification (the probe is deterministic for a given
+        // process).
+        let permission = AppManagementPermission()
+        permission.startWatchingForGrant()
+        defer { permission.stopWatchingForGrant() }
+
+        let before = permission.isGranted
+        NotificationCenter.default.post(
+            name: NSApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        // `addObserver(forName:queue:)` with `.main` may dispatch async
+        // when called off the main thread; pump the runloop briefly so
+        // the handler lands before we read the value.
+        let expectation = XCTestExpectation(description: "main queue drain")
+        DispatchQueue.main.async { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(permission.isGranted, before, "Probe is deterministic per-process; result should match")
+    }
+}

--- a/packages/swift-launcher/SliccstartTests/AppManagementPermissionTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppManagementPermissionTests.swift
@@ -18,21 +18,34 @@ import XCTest
 /// a timer (or drops the activation observer) breaks loudly.
 final class AppManagementPermissionTests: XCTestCase {
 
-    func testInitProbesOnce() {
-        // The probe runs in the initializer; we don't assert what value
-        // it returned (CI runners can be either) — only that nothing
-        // throws and the `isGranted` flag is set to a concrete bool.
+    func testInitProbesExactlyOnce() {
+        // Pins the launch-time alert budget: `init()` runs the probe
+        // once, registers no observer, and `startWatchingForGrant()`
+        // (called next from `.onAppear`) must NOT add a second probe.
+        // Each probe is one potential Sonoma+ "prevented from
+        // modifying" alert — keeping `probeCount == 1` after
+        // `start...()` keeps the launch budget at one alert.
         let permission = AppManagementPermission()
-        XCTAssertTrue(permission.isGranted == true || permission.isGranted == false)
+        XCTAssertEqual(permission.probeCount, 1, "init should probe exactly once")
         XCTAssertFalse(permission.isWatching, "init must not register an observer")
+
+        permission.startWatchingForGrant()
+        defer { permission.stopWatchingForGrant() }
+        XCTAssertEqual(
+            permission.probeCount, 1,
+            "startWatchingForGrant() must not add a second probe — init already did it"
+        )
+        XCTAssertTrue(permission.isWatching)
     }
 
     func testCheckPermissionIsIdempotent() {
         let permission = AppManagementPermission()
         let first = permission.isGranted
+        let initialCount = permission.probeCount
         permission.checkPermission()
         permission.checkPermission()
         XCTAssertEqual(permission.isGranted, first, "Two probes in a row should agree")
+        XCTAssertEqual(permission.probeCount, initialCount + 2)
     }
 
     func testStartWatchingDoesNotRetainATimer() {
@@ -81,16 +94,17 @@ final class AppManagementPermissionTests: XCTestCase {
 
     func testActivationNotificationRetriggersProbe() {
         // End-to-end: posting `didBecomeActive` while the observer is
-        // installed should land in `checkPermission()`. We can't easily
-        // stub the static probe, but we can pin the round-trip by
-        // observing that `isGranted` is reachable and unchanged across
-        // the notification (the probe is deterministic for a given
-        // process).
+        // installed must land in `checkPermission()`. `probeCount`
+        // makes that observable — without it, the test would also pass
+        // if the handler never fired (since `isGranted` is deterministic
+        // per process).
         let permission = AppManagementPermission()
         permission.startWatchingForGrant()
         defer { permission.stopWatchingForGrant() }
 
-        let before = permission.isGranted
+        let beforeCount = permission.probeCount
+        let beforeGranted = permission.isGranted
+
         NotificationCenter.default.post(
             name: NSApplication.didBecomeActiveNotification,
             object: nil
@@ -102,6 +116,34 @@ final class AppManagementPermissionTests: XCTestCase {
         DispatchQueue.main.async { expectation.fulfill() }
         wait(for: [expectation], timeout: 1.0)
 
-        XCTAssertEqual(permission.isGranted, before, "Probe is deterministic per-process; result should match")
+        XCTAssertEqual(
+            permission.probeCount, beforeCount + 1,
+            "didBecomeActive must trigger exactly one re-probe"
+        )
+        XCTAssertEqual(
+            permission.isGranted, beforeGranted,
+            "Probe is deterministic per-process; the value should not flip"
+        )
+    }
+
+    func testMultipleActivationsTriggerOneProbeEach() {
+        // Pins that the handler stays attached across multiple firings —
+        // i.e. it's not a one-shot. Three activations → three probes.
+        let permission = AppManagementPermission()
+        permission.startWatchingForGrant()
+        defer { permission.stopWatchingForGrant() }
+
+        let beforeCount = permission.probeCount
+        for _ in 0..<3 {
+            NotificationCenter.default.post(
+                name: NSApplication.didBecomeActiveNotification,
+                object: nil
+            )
+        }
+        let expectation = XCTestExpectation(description: "main queue drain")
+        DispatchQueue.main.async { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(permission.probeCount, beforeCount + 3)
     }
 }


### PR DESCRIPTION
## Summary

`AppManagementPermission` previously scheduled a `Timer` that called `probeAppManagementAccess()` every 2 s. The probe writes a temp file inside a user app bundle (`/Applications/<App>/Contents/.sliccstart_probe_…`) because TCC has no read-only API for the App Management entitlement.

On macOS Sonoma+ every denied write into another app's bundle posts a **"Sliccstart was prevented from modifying apps on your Mac"** Notification Center alert. With the 2 s timer that turned into a continuous stream of alerts on machines that hadn't granted the permission — including every fresh dev build, since ad-hoc signing produces a new code identity TCC treats as a brand-new app.

Replace the timer with an `NSApplication.didBecomeActiveNotification` observer. The probe now fires at most once per app switch — which matches when the answer can actually change (typical case: user toggles the switch in System Settings → Privacy & Security → App Management and switches back to Sliccstart).

## Changes

- `AppManagementPermission.swift`: drop `checkTimer`, add `activationObserver`. `startPolling`/`stopPolling` → `startWatchingForGrant`/`stopWatchingForGrant`. New `isWatching` so tests can confirm the observer-slot lifecycle without reflecting into `@Observable`'s rewritten storage.
- `SliccstartApp.swift`: rename the two call sites in `.onAppear`/`.onDisappear`.
- `AppManagementPermissionTests.swift` (new): pins init probe once + no observer, start/stop idempotency, no `Timer` ever stored on the instance (regression guard), and end-to-end notification re-probe.

## Test plan

- [x] `swift test` clean (33 + 7 new)
- [x] Coverage gate clean (lines 9.58% > 5%, regions 15.92% > 8%, functions 14.25% > 5%)
- [x] `npm run typecheck` clean
- [x] `npm run test` clean (3547 passed)
- [x] `npm run build` clean (Sliccstart.app assembled)
- [ ] Manual: open the rebuilt Sliccstart, confirm zero "prevented from modifying" alerts in the first ~30 s
- [ ] Manual: toggle the App Management permission in System Settings, switch back to Sliccstart, confirm the Electron-app rows appear without restarting

🤖 Generated with [Claude Code](https://claude.com/claude-code)