### PR TITLE
fix(ios): hide connection indicator when connected

### DIFF
--- a/packages/ios-app/SliccFollower/Views/ConnectionStatusView.swift
+++ b/packages/ios-app/SliccFollower/Views/ConnectionStatusView.swift
@@ -56,7 +56,6 @@ struct ConnectionStatusView: View {
                             .stroke(dotColor.opacity(0.3), lineWidth: 0.5)
                     )
             )
-            .opacity(state == .connecting ? 1.0 : 1.0)
             .animation(
                 state == .connecting
                     ? .easeInOut(duration: 1.0).repeatForever(autoreverses: true)
@@ -71,16 +70,12 @@ struct ConnectionStatusView: View {
             .padding(.top, 4)
             .padding(.bottom, 2)
             .transition(.move(edge: .top).combined(with: .opacity))
-        } else {
-            // Connected: minimal green dot
-            HStack {
-                Circle()
-                    .fill(Color.green)
-                    .frame(width: 6, height: 6)
-            }
-            .padding(.top, 2)
-            .transition(.move(edge: .top).combined(with: .opacity))
         }
+        // Connected: render nothing. The presence of chat content
+        // already signals connectivity; a stray green dot in its own
+        // VStack row floats unattached and visually overlaps the first
+        // chat message. Only surface the banner when something needs
+        // the user's attention.
     }
 }
 


### PR DESCRIPTION
## Summary

The else branch of \`ConnectionStatusView\` rendered a 6×6 green \`Circle\` in an \`HStack\` with \`.padding(.top, 2)\`. Without a clear container shape it floats unattached at the top of the chat column and visually overlaps the first message — the disconnect pill works because it's a real banner, the green dot doesn't.

This PR renders nothing when \`state == .connected\`. The presence of chat content already signals \"connection works\", and the gear/Settings sheet shows the explicit tray status if the user wants explicit confirmation.

## Test plan

- [ ] Build clean: \`xcodebuild -scheme SliccFollower -sdk iphonesimulator\`
- [ ] In a connected session, no green dot appears between the navigation bar and the first chat message
- [ ] Disconnected / Connecting / Failed states still render the banner pill correctly
- [ ] Transition from connecting → connected slides the banner out without leaving artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)