### PR TITLE
fix(github): auto-configure git identity from OAuth login

### DIFF
--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -145,8 +145,18 @@ export function extractCodeFromUrl(url: string): string | null {
   }
 }
 
-/** Fetch GitHub user profile (name + avatar). */
-async function fetchUserProfile(accessToken: string): Promise<{ name?: string; avatar?: string }> {
+interface GitHubUserProfile {
+  /** Display name to surface in the UI (full name or login fallback). */
+  name?: string;
+  avatar?: string;
+  /** GitHub login (username). */
+  login?: string;
+  /** Numeric account id, used to compose the privacy-preserving noreply email. */
+  id?: number;
+}
+
+/** Fetch GitHub user profile (name + avatar + login + id). */
+async function fetchUserProfile(accessToken: string): Promise<GitHubUserProfile> {
   try {
     const res = await fetch('https://api.github.com/user', {
       headers: {
@@ -156,6 +166,7 @@ async function fetchUserProfile(accessToken: string): Promise<{ name?: string; a
     });
     if (res.ok) {
       const user = (await res.json()) as {
+        id?: number;
         login?: string;
         name?: string;
         avatar_url?: string;
@@ -163,6 +174,8 @@ async function fetchUserProfile(accessToken: string): Promise<{ name?: string; a
       return {
         name: user.name || user.login,
         avatar: user.avatar_url,
+        login: user.login,
+        id: user.id,
       };
     }
   } catch (err) {
@@ -172,6 +185,16 @@ async function fetchUserProfile(accessToken: string): Promise<{ name?: string; a
     );
   }
   return {};
+}
+
+/**
+ * Compose GitHub's privacy-preserving "noreply" email for a given account.
+ * Format: `<id>+<login>@users.noreply.github.com`. This is the safe default
+ * — it works even when the user has "Keep my email addresses private"
+ * enabled, and never leaks a real email address.
+ */
+export function buildNoreplyEmail(id: number, login: string): string {
+  return `${id}+${login}@users.noreply.github.com`;
 }
 
 // ── Git token bridge ───────────────────────────────────────────────
@@ -204,6 +227,51 @@ async function clearGitToken(): Promise<void> {
     }
   } catch {
     // Ignore if file doesn't exist
+  }
+}
+
+// ── Git identity bridge ────────────────────────────────────────────
+
+/**
+ * Seed `user.name` and `user.email` in the global git config from the
+ * authenticated GitHub identity. Idempotent — only fills in values that are
+ * not already set, so any prior `git config --global user.{name,email} ...`
+ * customizations are preserved.
+ *
+ * Email defaults to GitHub's privacy-preserving noreply address
+ * (`<id>+<login>@users.noreply.github.com`) so we don't expose a real email
+ * unless the user explicitly chooses to override it later.
+ */
+export async function syncGitIdentityFromGitHub(profile: GitHubUserProfile): Promise<void> {
+  if (!profile.login || profile.id === undefined) {
+    // Profile fetch failed or token doesn't grant the needed scope; skip
+    // silently — git identity stays at whatever the user already configured.
+    return;
+  }
+
+  try {
+    const { VirtualFS } = await import('../src/fs/index.js');
+    const { readGlobalGitConfigValue, writeGlobalGitConfigValue } =
+      await import('../src/git/git-config.js');
+    const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+
+    const desiredName = profile.name || profile.login;
+    const desiredEmail = buildNoreplyEmail(profile.id, profile.login);
+
+    const existingName = await readGlobalGitConfigValue(fs, 'user.name');
+    if (!existingName && desiredName) {
+      await writeGlobalGitConfigValue(fs, 'user.name', desiredName);
+    }
+
+    const existingEmail = await readGlobalGitConfigValue(fs, 'user.email');
+    if (!existingEmail) {
+      await writeGlobalGitConfigValue(fs, 'user.email', desiredEmail);
+    }
+  } catch (err) {
+    console.warn(
+      '[github] Failed to seed git identity:',
+      err instanceof Error ? err.message : String(err)
+    );
   }
 }
 
@@ -455,6 +523,11 @@ export const config: ProviderConfig = {
 
     // Bridge token to isomorphic-git
     await writeGitToken(tokenResult.access_token);
+
+    // Seed git user.name / user.email so commits are attributed to the
+    // authenticated GitHub identity instead of the placeholder
+    // "User <user@example.com>". Idempotent: existing values are preserved.
+    await syncGitIdentityFromGitHub(userProfile);
 
     onSuccess();
   },

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -14,6 +14,12 @@ import { GLOBAL_FS_DB_NAME } from '../fs/global-db.js';
 import { gitHttp } from './git-http.js';
 import { unifiedDiff, diffStat } from './diff.js';
 import { createIsomorphicGitFs, type IsoGitFsPromises } from './vfs-fs-adapter.js';
+import {
+  GLOBAL_GITCONFIG_PATH,
+  readGlobalGitConfigValue,
+  writeGlobalGitConfigValue,
+  removeGitConfigKey,
+} from './git-config.js';
 
 export interface GitCommandResult {
   stdout: string;
@@ -112,6 +118,33 @@ export class GitCommands {
     }
     await globalFs.writeFile('/workspace/.git/github-token', trimmed);
     this.githubToken = trimmed;
+  }
+
+  /**
+   * Resolve the git author identity for an operation, mirroring git's lookup
+   * order: local repo config → global config → in-memory defaults from the
+   * constructor. This way values written to /workspace/.gitconfig (e.g. by
+   * the GitHub OAuth provider or by `git config --global`) take effect on
+   * subsequent commits without requiring a fresh GitCommands instance.
+   */
+  private async resolveAuthor(cwd: string): Promise<{ name: string; email: string }> {
+    const readLocal = async (key: string): Promise<string | undefined> => {
+      try {
+        return await git.getConfig({ fs: this.lfs, dir: cwd, path: key });
+      } catch {
+        return undefined;
+      }
+    };
+    const globalFs = await this.getGlobalFs();
+    const name =
+      (await readLocal('user.name')) ??
+      (await readGlobalGitConfigValue(globalFs, 'user.name')) ??
+      this.authorName;
+    const email =
+      (await readLocal('user.email')) ??
+      (await readGlobalGitConfigValue(globalFs, 'user.email')) ??
+      this.authorEmail;
+    return { name, email };
   }
 
   /**
@@ -555,10 +588,7 @@ Available commands:
       fs: this.lfs,
       dir: cwd,
       message,
-      author: {
-        name: this.authorName,
-        email: this.authorEmail,
-      },
+      author: await this.resolveAuthor(cwd),
       amend,
       noUpdateBranch: undefined,
     });
@@ -1354,10 +1384,7 @@ Available commands:
       dir: cwd,
       remote,
       corsProxy: this.corsProxy,
-      author: {
-        name: this.authorName,
-        email: this.authorEmail,
-      },
+      author: await this.resolveAuthor(cwd),
       onAuth: this.getOnAuth(),
       onProgress: (event) => {
         output += `${event.phase}: ${event.loaded}/${event.total}\n`;
@@ -1445,10 +1472,7 @@ Available commands:
         theirs,
         fastForward: !noFf,
         fastForwardOnly: ffOnly,
-        author: {
-          name: this.authorName,
-          email: this.authorEmail,
-        },
+        author: await this.resolveAuthor(cwd),
         abortOnConflict: true,
       });
 
@@ -1563,6 +1587,7 @@ Available commands:
     const target = positional[1]; // optional commit
 
     if (annotate || message) {
+      const tagger = await this.resolveAuthor(cwd);
       // Annotated tag
       await git.annotatedTag({
         fs: this.lfs,
@@ -1571,8 +1596,7 @@ Available commands:
         message: message ?? tagName,
         object: target,
         tagger: {
-          name: this.authorName,
-          email: this.authorEmail,
+          ...tagger,
           timestamp: Math.floor(Date.now() / 1000),
           timezoneOffset: 0,
         },
@@ -1694,9 +1718,9 @@ Available commands:
       if (globalFlag) {
         const globalFs = await this.getGlobalFs();
         try {
-          const content = await globalFs.readTextFile('/workspace/.gitconfig');
-          const newContent = this.removeConfigKey(content, path);
-          await globalFs.writeFile('/workspace/.gitconfig', newContent);
+          const content = await globalFs.readTextFile(GLOBAL_GITCONFIG_PATH);
+          const newContent = removeGitConfigKey(content, path);
+          await globalFs.writeFile(GLOBAL_GITCONFIG_PATH, newContent);
         } catch {
           /* file may not exist */
         }
@@ -1705,7 +1729,7 @@ Available commands:
         try {
           const configPath = `${cwd}/.git/config`;
           const content = await this.options.fs.readTextFile(configPath);
-          const newContent = this.removeConfigKey(content, path);
+          const newContent = removeGitConfigKey(content, path);
           await this.options.fs.writeFile(configPath, newContent);
         } catch {
           /* ignore */
@@ -1742,7 +1766,7 @@ Available commands:
 
       if (globalFlag) {
         // Store in global config file
-        await this.setGlobalConfig(path, value);
+        await writeGlobalGitConfigValue(await this.getGlobalFs(), path, value);
       } else {
         // Set config in repo
         await git.setConfig({ fs: this.lfs, dir: cwd, path, value });
@@ -1765,11 +1789,11 @@ Available commands:
     // When --global, only read global config; otherwise try repo first, then global
     let result: string | undefined;
     if (globalFlag) {
-      result = await this.getGlobalConfig(path);
+      result = await readGlobalGitConfigValue(await this.getGlobalFs(), path);
     } else {
       result = await git.getConfig({ fs: this.lfs, dir: cwd, path });
       if (!result) {
-        result = await this.getGlobalConfig(path);
+        result = await readGlobalGitConfigValue(await this.getGlobalFs(), path);
       }
     }
 
@@ -1800,7 +1824,7 @@ Available commands:
     // Read global config
     try {
       const globalFs = await this.getGlobalFs();
-      const content = await globalFs.readTextFile('/workspace/.gitconfig');
+      const content = await globalFs.readTextFile(GLOBAL_GITCONFIG_PATH);
       output += this.parseGitConfigToList(content);
     } catch {
       /* no global config */
@@ -1838,159 +1862,6 @@ Available commands:
     }
 
     return output;
-  }
-
-  /**
-   * Remove a key from git config INI content.
-   */
-  private removeConfigKey(content: string, key: string): string {
-    const parts = key.split('.');
-    const targetKey = parts.pop()!;
-    const targetSection = parts.join('.');
-
-    const lines = content.split('\n');
-    const result: string[] = [];
-    let currentSection = '';
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-      const sectionMatch = trimmed.match(/^\[(\w+)(?:\s+"([^"]*)")?\]$/);
-      if (sectionMatch) {
-        const sec = sectionMatch[1].toLowerCase();
-        const sub = sectionMatch[2] ?? '';
-        currentSection = sub ? `${sec}.${sub}` : sec;
-        result.push(line);
-        continue;
-      }
-
-      if (currentSection === targetSection) {
-        const kvMatch = trimmed.match(/^(\w+)\s*=/);
-        if (kvMatch && kvMatch[1] === targetKey) {
-          continue; // Skip this line (remove it)
-        }
-      }
-
-      result.push(line);
-    }
-
-    return result.join('\n');
-  }
-
-  /**
-   * Set a value in the global config file.
-   */
-  private async setGlobalConfig(key: string, value: string): Promise<void> {
-    const globalFs = await this.getGlobalFs();
-    const configPath = '/workspace/.gitconfig';
-
-    let content = '';
-    try {
-      content = await globalFs.readTextFile(configPath);
-    } catch {
-      /* file doesn't exist yet */
-    }
-
-    const parts = key.split('.');
-    const configKey = parts.pop()!;
-    const section = parts.join('.');
-
-    // Try to update existing key in the right section
-    const lines = content.split('\n');
-    let currentSection = '';
-    let found = false;
-    let sectionExists = false;
-
-    for (let i = 0; i < lines.length; i++) {
-      const trimmed = lines[i].trim();
-      const sectionMatch = trimmed.match(/^\[(\w+)(?:\s+"([^"]*)")?\]$/);
-      if (sectionMatch) {
-        const sec = sectionMatch[1].toLowerCase();
-        const sub = sectionMatch[2] ?? '';
-        currentSection = sub ? `${sec}.${sub}` : sec;
-        if (currentSection === section) sectionExists = true;
-        continue;
-      }
-
-      if (currentSection === section) {
-        const kvMatch = trimmed.match(/^(\w+)\s*=/);
-        if (kvMatch && kvMatch[1] === configKey) {
-          lines[i] = `\t${configKey} = ${value}`;
-          found = true;
-          break;
-        }
-      }
-    }
-
-    if (found) {
-      await globalFs.writeFile(configPath, lines.join('\n'));
-      return;
-    }
-
-    if (sectionExists) {
-      // Add key to existing section
-      for (let i = lines.length - 1; i >= 0; i--) {
-        const trimmed = lines[i].trim();
-        const sectionMatch = trimmed.match(/^\[(\w+)(?:\s+"([^"]*)")?\]$/);
-        if (sectionMatch) {
-          const sec = sectionMatch[1].toLowerCase();
-          const sub = sectionMatch[2] ?? '';
-          const cs = sub ? `${sec}.${sub}` : sec;
-          if (cs === section) {
-            lines.splice(i + 1, 0, `\t${configKey} = ${value}`);
-            break;
-          }
-        }
-      }
-      await globalFs.writeFile(configPath, lines.join('\n'));
-      return;
-    }
-
-    // Create new section
-    const sectionParts = section.split('.');
-    let sectionHeader: string;
-    if (sectionParts.length > 1) {
-      sectionHeader = `[${sectionParts[0]} "${sectionParts.slice(1).join('.')}"]`;
-    } else {
-      sectionHeader = `[${section}]`;
-    }
-    const newContent = content
-      ? content.trimEnd() + `\n${sectionHeader}\n\t${configKey} = ${value}\n`
-      : `${sectionHeader}\n\t${configKey} = ${value}\n`;
-    await globalFs.writeFile(configPath, newContent);
-  }
-
-  /**
-   * Get a value from the global config file.
-   */
-  private async getGlobalConfig(key: string): Promise<string | undefined> {
-    const globalFs = await this.getGlobalFs();
-    try {
-      const content = await globalFs.readTextFile('/workspace/.gitconfig');
-      const parts = key.split('.');
-      const configKey = parts.pop()!;
-      const section = parts.join('.');
-
-      let currentSection = '';
-      for (const rawLine of content.split('\n')) {
-        const line = rawLine.trim();
-        const sectionMatch = line.match(/^\[(\w+)(?:\s+"([^"]*)")?\]$/);
-        if (sectionMatch) {
-          const sec = sectionMatch[1].toLowerCase();
-          const sub = sectionMatch[2] ?? '';
-          currentSection = sub ? `${sec}.${sub}` : sec;
-          continue;
-        }
-        if (currentSection === section) {
-          const kvMatch = line.match(/^(\w+)\s*=\s*(.*)$/);
-          if (kvMatch && kvMatch[1] === configKey) {
-            return kvMatch[2].trim();
-          }
-        }
-      }
-    } catch {
-      /* no global config */
-    }
-    return undefined;
   }
 
   private async reset(cwd: string, args: string[]): Promise<GitCommandResult> {
@@ -2259,24 +2130,16 @@ Available commands:
 
     const { commit: headCommit } = await git.readCommit({ fs: this.lfs, dir: cwd, oid: headOid });
     const message = `WIP on ${branch}: ${headOid.slice(0, 7)} ${headCommit.message.split('\n')[0]}`;
+    const author = await this.resolveAuthor(cwd);
+    const timestamp = Math.floor(Date.now() / 1000);
     const stashOid = await git.writeCommit({
       fs: this.lfs,
       dir: cwd,
       commit: {
         tree: treeOid,
         parent: parents,
-        author: {
-          name: this.authorName,
-          email: this.authorEmail,
-          timestamp: Math.floor(Date.now() / 1000),
-          timezoneOffset: 0,
-        },
-        committer: {
-          name: this.authorName,
-          email: this.authorEmail,
-          timestamp: Math.floor(Date.now() / 1000),
-          timezoneOffset: 0,
-        },
+        author: { ...author, timestamp, timezoneOffset: 0 },
+        committer: { ...author, timestamp, timezoneOffset: 0 },
         message,
       },
     });

--- a/packages/webapp/src/git/git-config.ts
+++ b/packages/webapp/src/git/git-config.ts
@@ -1,0 +1,157 @@
+/**
+ * Shared helpers for reading and writing the global git config file at
+ * `/workspace/.gitconfig` in the Global VirtualFS.
+ *
+ * Used by both `GitCommands` (for `git config --global` operations and
+ * author-identity resolution) and the GitHub OAuth provider (for seeding
+ * `user.name` / `user.email` after a successful login).
+ *
+ * Implements just enough of git's INI dialect for our needs: subsections
+ * with `"name"` quoting, repeated section headers, and tab/space-indented
+ * key=value pairs.
+ */
+
+import type { VirtualFS } from '../fs/index.js';
+
+export const GLOBAL_GITCONFIG_PATH = '/workspace/.gitconfig';
+
+/** Look up a `section.key` (or `section.subsection.key`) value. */
+export async function readGlobalGitConfigValue(
+  fs: VirtualFS,
+  key: string
+): Promise<string | undefined> {
+  let content: string;
+  try {
+    content = await fs.readTextFile(GLOBAL_GITCONFIG_PATH);
+  } catch {
+    return undefined;
+  }
+
+  const parts = key.split('.');
+  const configKey = parts.pop()!;
+  const section = parts.join('.');
+
+  let currentSection = '';
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    const sectionMatch = line.match(/^\[(\w+)(?:\s+"([^"]*)")?\]$/);
+    if (sectionMatch) {
+      const sec = sectionMatch[1].toLowerCase();
+      const sub = sectionMatch[2] ?? '';
+      currentSection = sub ? `${sec}.${sub}` : sec;
+      continue;
+    }
+    if (currentSection === section) {
+      const kvMatch = line.match(/^(\w+)\s*=\s*(.*)$/);
+      if (kvMatch && kvMatch[1] === configKey) {
+        return kvMatch[2].trim();
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Set a `section.key` (or `section.subsection.key`) value, creating sections as needed. */
+export async function writeGlobalGitConfigValue(
+  fs: VirtualFS,
+  key: string,
+  value: string
+): Promise<void> {
+  let content = '';
+  try {
+    content = await fs.readTextFile(GLOBAL_GITCONFIG_PATH);
+  } catch {
+    /* file doesn't exist yet */
+  }
+
+  const parts = key.split('.');
+  const configKey = parts.pop()!;
+  const section = parts.join('.');
+
+  const lines = content.split('\n');
+  let currentSection = '';
+  let sectionExists = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    const sectionMatch = trimmed.match(/^\[(\w+)(?:\s+"([^"]*)")?\]$/);
+    if (sectionMatch) {
+      const sec = sectionMatch[1].toLowerCase();
+      const sub = sectionMatch[2] ?? '';
+      currentSection = sub ? `${sec}.${sub}` : sec;
+      if (currentSection === section) sectionExists = true;
+      continue;
+    }
+
+    if (currentSection === section) {
+      const kvMatch = trimmed.match(/^(\w+)\s*=/);
+      if (kvMatch && kvMatch[1] === configKey) {
+        lines[i] = `\t${configKey} = ${value}`;
+        await fs.writeFile(GLOBAL_GITCONFIG_PATH, lines.join('\n'));
+        return;
+      }
+    }
+  }
+
+  if (sectionExists) {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const trimmed = lines[i].trim();
+      const sectionMatch = trimmed.match(/^\[(\w+)(?:\s+"([^"]*)")?\]$/);
+      if (sectionMatch) {
+        const sec = sectionMatch[1].toLowerCase();
+        const sub = sectionMatch[2] ?? '';
+        const cs = sub ? `${sec}.${sub}` : sec;
+        if (cs === section) {
+          lines.splice(i + 1, 0, `\t${configKey} = ${value}`);
+          break;
+        }
+      }
+    }
+    await fs.writeFile(GLOBAL_GITCONFIG_PATH, lines.join('\n'));
+    return;
+  }
+
+  const sectionParts = section.split('.');
+  const sectionHeader =
+    sectionParts.length > 1
+      ? `[${sectionParts[0]} "${sectionParts.slice(1).join('.')}"]`
+      : `[${section}]`;
+  const newContent = content
+    ? content.trimEnd() + `\n${sectionHeader}\n\t${configKey} = ${value}\n`
+    : `${sectionHeader}\n\t${configKey} = ${value}\n`;
+  await fs.writeFile(GLOBAL_GITCONFIG_PATH, newContent);
+}
+
+/** Remove a key from a parsed git config INI string. */
+export function removeGitConfigKey(content: string, key: string): string {
+  const parts = key.split('.');
+  const targetKey = parts.pop()!;
+  const targetSection = parts.join('.');
+
+  const lines = content.split('\n');
+  const result: string[] = [];
+  let currentSection = '';
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const sectionMatch = trimmed.match(/^\[(\w+)(?:\s+"([^"]*)")?\]$/);
+    if (sectionMatch) {
+      const sec = sectionMatch[1].toLowerCase();
+      const sub = sectionMatch[2] ?? '';
+      currentSection = sub ? `${sec}.${sub}` : sec;
+      result.push(line);
+      continue;
+    }
+
+    if (currentSection === targetSection) {
+      const kvMatch = trimmed.match(/^(\w+)\s*=/);
+      if (kvMatch && kvMatch[1] === targetKey) {
+        continue;
+      }
+    }
+
+    result.push(line);
+  }
+
+  return result.join('\n');
+}

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -2139,6 +2139,72 @@ describe('GitCommands', () => {
       expect(row?.slice(1)).toEqual([1, 0, 0]); // staged deletion
     });
   });
+
+  describe('author identity resolution', () => {
+    /**
+     * Reads the author from the most recent commit using isomorphic-git's
+     * own log API. We assert against this rather than parsing `git log`
+     * output to keep the test independent of formatting changes.
+     */
+    async function readLatestAuthor(
+      cwd: string
+    ): Promise<{ name: string; email: string } | undefined> {
+      const log = await isoGit.log({ fs: vfs.getLightningFS(), dir: cwd, depth: 1 });
+      const entry = log[0];
+      return entry
+        ? { name: entry.commit.author.name, email: entry.commit.author.email }
+        : undefined;
+    }
+
+    it('uses constructor defaults when no config is set', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'hello');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+      expect(await readLatestAuthor('/project')).toEqual({
+        name: 'Test User',
+        email: 'test@example.com',
+      });
+    });
+
+    it('uses values written directly to /workspace/.gitconfig (OAuth provider path)', async () => {
+      // Simulate what syncGitIdentityFromGitHub does: write directly to the
+      // global config without going through `git config --global` on this
+      // GitCommands instance. Without a per-command resolveAuthor read, the
+      // commit would still be attributed to the constructor defaults.
+      await git.execute(['init'], '/project');
+      const globalFs = await VirtualFS.create({ dbName: globalDbName });
+      await globalFs.writeFile(
+        '/workspace/.gitconfig',
+        '[user]\n\tname = Octocat\n\temail = 1+octocat@users.noreply.github.com\n'
+      );
+      await vfs.writeFile('/project/file.txt', 'hello');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+      expect(await readLatestAuthor('/project')).toEqual({
+        name: 'Octocat',
+        email: '1+octocat@users.noreply.github.com',
+      });
+    });
+
+    it('prefers local repo config over global config', async () => {
+      await git.execute(['init'], '/project');
+      const globalFs = await VirtualFS.create({ dbName: globalDbName });
+      await globalFs.writeFile(
+        '/workspace/.gitconfig',
+        '[user]\n\tname = Global User\n\temail = global@example.com\n'
+      );
+      await git.execute(['config', 'user.name', 'Repo User'], '/project');
+      await git.execute(['config', 'user.email', 'repo@example.com'], '/project');
+      await vfs.writeFile('/project/file.txt', 'hello');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+      expect(await readLatestAuthor('/project')).toEqual({
+        name: 'Repo User',
+        email: 'repo@example.com',
+      });
+    });
+  });
 });
 
 // Regression for issue #507: git ops in a scoop sandbox failed because

--- a/packages/webapp/tests/git/git-config.test.ts
+++ b/packages/webapp/tests/git/git-config.test.ts
@@ -95,16 +95,20 @@ describe('GitHub identity helpers', () => {
 
   describe('syncGitIdentityFromGitHub', () => {
     /**
-     * The provider hardcodes GLOBAL_FS_DB_NAME, so each test wipes that
-     * shared db before running. fake-indexeddb gives us full isolation
-     * across test files, but tests within this file share the db within
-     * the same vitest worker — wipe explicitly for a clean slate.
+     * The provider hardcodes GLOBAL_FS_DB_NAME so we cannot pass a unique db
+     * per test. Instead share one VirtualFS instance for the whole describe
+     * and reset state by deleting the single file the tests touch. We avoid
+     * `VirtualFS.create({ wipe: true })` per-test because that races with
+     * still-open IndexedDB handles from prior tests — Node 24+'s Web Locks
+     * API rejects the second wipe with an AbortError and trips Vitest's
+     * unhandled-rejection guard. (Locally on Node 22 it slips through.)
      */
+    let sharedFs: VirtualFS;
+
     beforeEach(async () => {
-      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME, wipe: true });
-      // touch to ensure wipe took effect
+      sharedFs ??= await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
       try {
-        await fs.rm(GLOBAL_GITCONFIG_PATH);
+        await sharedFs.rm(GLOBAL_GITCONFIG_PATH);
       } catch {
         /* not present */
       }
@@ -114,9 +118,8 @@ describe('GitHub identity helpers', () => {
       const { syncGitIdentityFromGitHub } = await import('../../providers/github.js');
       await syncGitIdentityFromGitHub({ id: 42, login: 'octocat', name: 'The Octocat' });
 
-      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
-      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBe('The Octocat');
-      expect(await readGlobalGitConfigValue(fs, 'user.email')).toBe(
+      expect(await readGlobalGitConfigValue(sharedFs, 'user.name')).toBe('The Octocat');
+      expect(await readGlobalGitConfigValue(sharedFs, 'user.email')).toBe(
         '42+octocat@users.noreply.github.com'
       );
     });
@@ -125,29 +128,26 @@ describe('GitHub identity helpers', () => {
       const { syncGitIdentityFromGitHub } = await import('../../providers/github.js');
       await syncGitIdentityFromGitHub({ id: 7, login: 'mona', name: undefined });
 
-      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
-      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBe('mona');
+      expect(await readGlobalGitConfigValue(sharedFs, 'user.name')).toBe('mona');
     });
 
     it('preserves existing user.name and user.email values (idempotent)', async () => {
-      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
-      await writeGlobalGitConfigValue(fs, 'user.name', 'Custom Name');
-      await writeGlobalGitConfigValue(fs, 'user.email', 'custom@example.com');
+      await writeGlobalGitConfigValue(sharedFs, 'user.name', 'Custom Name');
+      await writeGlobalGitConfigValue(sharedFs, 'user.email', 'custom@example.com');
 
       const { syncGitIdentityFromGitHub } = await import('../../providers/github.js');
       await syncGitIdentityFromGitHub({ id: 42, login: 'octocat', name: 'The Octocat' });
 
-      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBe('Custom Name');
-      expect(await readGlobalGitConfigValue(fs, 'user.email')).toBe('custom@example.com');
+      expect(await readGlobalGitConfigValue(sharedFs, 'user.name')).toBe('Custom Name');
+      expect(await readGlobalGitConfigValue(sharedFs, 'user.email')).toBe('custom@example.com');
     });
 
     it('skips silently when the profile is missing id or login', async () => {
       const { syncGitIdentityFromGitHub } = await import('../../providers/github.js');
       await syncGitIdentityFromGitHub({ name: 'Anonymous' });
 
-      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
-      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBeUndefined();
-      expect(await readGlobalGitConfigValue(fs, 'user.email')).toBeUndefined();
+      expect(await readGlobalGitConfigValue(sharedFs, 'user.name')).toBeUndefined();
+      expect(await readGlobalGitConfigValue(sharedFs, 'user.email')).toBeUndefined();
     });
   });
 });

--- a/packages/webapp/tests/git/git-config.test.ts
+++ b/packages/webapp/tests/git/git-config.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { GLOBAL_FS_DB_NAME } from '../../src/fs/global-db.js';
+import {
+  GLOBAL_GITCONFIG_PATH,
+  readGlobalGitConfigValue,
+  writeGlobalGitConfigValue,
+  removeGitConfigKey,
+} from '../../src/git/git-config.js';
+
+let dbCounter = 0;
+
+describe('git-config helpers', () => {
+  let fs: VirtualFS;
+
+  beforeEach(async () => {
+    fs = await VirtualFS.create({ dbName: `git-config-${dbCounter++}`, wipe: true });
+  });
+
+  describe('readGlobalGitConfigValue', () => {
+    it('returns undefined when the config file does not exist', async () => {
+      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBeUndefined();
+    });
+
+    it('returns undefined when the key is absent', async () => {
+      await fs.writeFile(GLOBAL_GITCONFIG_PATH, '[user]\n\tname = Octocat\n');
+      expect(await readGlobalGitConfigValue(fs, 'user.email')).toBeUndefined();
+    });
+
+    it('reads a simple key', async () => {
+      await fs.writeFile(GLOBAL_GITCONFIG_PATH, '[user]\n\tname = Octocat\n');
+      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBe('Octocat');
+    });
+
+    it('reads a subsection key', async () => {
+      await fs.writeFile(GLOBAL_GITCONFIG_PATH, '[branch "main"]\n\tremote = origin\n');
+      expect(await readGlobalGitConfigValue(fs, 'branch.main.remote')).toBe('origin');
+    });
+  });
+
+  describe('writeGlobalGitConfigValue', () => {
+    it('creates the file when missing', async () => {
+      await writeGlobalGitConfigValue(fs, 'user.name', 'Octocat');
+      const content = await fs.readTextFile(GLOBAL_GITCONFIG_PATH);
+      expect(content).toContain('[user]');
+      expect(content).toContain('name = Octocat');
+    });
+
+    it('updates an existing key in place rather than appending a duplicate', async () => {
+      await fs.writeFile(GLOBAL_GITCONFIG_PATH, '[user]\n\tname = Old Name\n');
+      await writeGlobalGitConfigValue(fs, 'user.name', 'New Name');
+      const content = await fs.readTextFile(GLOBAL_GITCONFIG_PATH);
+      expect(content).toContain('name = New Name');
+      expect(content).not.toContain('Old Name');
+      expect(content.match(/name =/g)?.length ?? 0).toBe(1);
+    });
+
+    it('adds a new key to an existing section', async () => {
+      await fs.writeFile(GLOBAL_GITCONFIG_PATH, '[user]\n\tname = Octocat\n');
+      await writeGlobalGitConfigValue(fs, 'user.email', 'octo@example.com');
+      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBe('Octocat');
+      expect(await readGlobalGitConfigValue(fs, 'user.email')).toBe('octo@example.com');
+    });
+
+    it('round-trips a subsection key', async () => {
+      await writeGlobalGitConfigValue(fs, 'branch.main.remote', 'origin');
+      expect(await readGlobalGitConfigValue(fs, 'branch.main.remote')).toBe('origin');
+    });
+  });
+
+  describe('removeGitConfigKey', () => {
+    it('removes only the matching key, preserving section headers and other keys', () => {
+      const content = '[user]\n\tname = Octocat\n\temail = octo@example.com\n';
+      const result = removeGitConfigKey(content, 'user.email');
+      expect(result).toContain('name = Octocat');
+      expect(result).not.toContain('octo@example.com');
+      expect(result).toContain('[user]');
+    });
+
+    it('returns the input unchanged when the key is not present', () => {
+      const content = '[user]\n\tname = Octocat\n';
+      expect(removeGitConfigKey(content, 'user.email')).toBe(content);
+    });
+  });
+});
+
+describe('GitHub identity helpers', () => {
+  describe('buildNoreplyEmail', () => {
+    it('formats <id>+<login>@users.noreply.github.com', async () => {
+      const { buildNoreplyEmail } = await import('../../providers/github.js');
+      expect(buildNoreplyEmail(583231, 'octocat')).toBe('583231+octocat@users.noreply.github.com');
+    });
+  });
+
+  describe('syncGitIdentityFromGitHub', () => {
+    /**
+     * The provider hardcodes GLOBAL_FS_DB_NAME, so each test wipes that
+     * shared db before running. fake-indexeddb gives us full isolation
+     * across test files, but tests within this file share the db within
+     * the same vitest worker — wipe explicitly for a clean slate.
+     */
+    beforeEach(async () => {
+      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME, wipe: true });
+      // touch to ensure wipe took effect
+      try {
+        await fs.rm(GLOBAL_GITCONFIG_PATH);
+      } catch {
+        /* not present */
+      }
+    });
+
+    it('writes user.name and a noreply email when neither is set', async () => {
+      const { syncGitIdentityFromGitHub } = await import('../../providers/github.js');
+      await syncGitIdentityFromGitHub({ id: 42, login: 'octocat', name: 'The Octocat' });
+
+      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBe('The Octocat');
+      expect(await readGlobalGitConfigValue(fs, 'user.email')).toBe(
+        '42+octocat@users.noreply.github.com'
+      );
+    });
+
+    it('falls back to the login when the GitHub display name is empty', async () => {
+      const { syncGitIdentityFromGitHub } = await import('../../providers/github.js');
+      await syncGitIdentityFromGitHub({ id: 7, login: 'mona', name: undefined });
+
+      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBe('mona');
+    });
+
+    it('preserves existing user.name and user.email values (idempotent)', async () => {
+      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+      await writeGlobalGitConfigValue(fs, 'user.name', 'Custom Name');
+      await writeGlobalGitConfigValue(fs, 'user.email', 'custom@example.com');
+
+      const { syncGitIdentityFromGitHub } = await import('../../providers/github.js');
+      await syncGitIdentityFromGitHub({ id: 42, login: 'octocat', name: 'The Octocat' });
+
+      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBe('Custom Name');
+      expect(await readGlobalGitConfigValue(fs, 'user.email')).toBe('custom@example.com');
+    });
+
+    it('skips silently when the profile is missing id or login', async () => {
+      const { syncGitIdentityFromGitHub } = await import('../../providers/github.js');
+      await syncGitIdentityFromGitHub({ name: 'Anonymous' });
+
+      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+      expect(await readGlobalGitConfigValue(fs, 'user.name')).toBeUndefined();
+      expect(await readGlobalGitConfigValue(fs, 'user.email')).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- After a successful GitHub OAuth login, seed `user.name` and `user.email` in `/workspace/.gitconfig` from the authenticated identity. Email defaults to the privacy-preserving noreply address (`<id>+<login>@users.noreply.github.com`); existing values are preserved (idempotent).
- Make `GitCommands` resolve author identity at every commit/merge/pull/tag/stash via a new `resolveAuthor(cwd)` that consults local repo config → global config → in-memory defaults, matching git's own lookup order. Without this, values written to the global config only took effect on the session that wrote them.
- Extract the global-config INI parser/writer to a shared `git-config.ts` module so both `GitCommands` and the GitHub provider use the same code.

Fixes the reported bug where commits made shortly after onboarding were attributed to the placeholder `User <user@example.com>` despite the GitHub OAuth flow having access to the real identity.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests` — 3115/3115 pass, including 18 new tests for `resolveAuthor`, the shared INI helpers, and `syncGitIdentityFromGitHub` (writes-when-absent, login-fallback, idempotency, missing-id/login skip).
- [x] `npm run test:coverage:webapp` — `git-config.ts` 100% lines / 100% functions, `git-commands.ts` 83.7% lines (no regression), totals above thresholds.
- [x] `npm run build -w @slicc/webapp` and `-w @slicc/chrome-extension`
- [x] `npx prettier --check` clean on all changed files
- [ ] Manual smoke: fresh SLICC session, complete onboarding with GitHub OAuth, clone a repo, commit a change, verify `git log -1` shows the GitHub identity instead of `User <user@example.com>`.
- [ ] Manual smoke: with `git config --global user.email custom@example.com` already set, log in via GitHub OAuth and verify the custom email is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)