### PR TITLE
fix(webapp): show provider name in model dropdown when multi-provider

### DIFF
--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -1274,12 +1274,18 @@ export class ChatPanel {
     const currentProvider = getSelectedProvider();
 
     // Flatten all models with their provider info
-    const allModels: Array<{ providerId: string; id: string; name: string; reasoning?: boolean }> =
-      [];
+    const allModels: Array<{
+      providerId: string;
+      providerName: string;
+      id: string;
+      name: string;
+      reasoning?: boolean;
+    }> = [];
     for (const group of groups) {
       for (const model of group.models) {
         allModels.push({
           providerId: group.providerId,
+          providerName: group.providerName,
           id: model.id,
           name: model.name,
           reasoning: (model as { reasoning?: boolean }).reasoning,
@@ -1298,13 +1304,26 @@ export class ChatPanel {
       allModels[0];
     if (!activeModel) return;
 
+    // Show provider labels only when more than one provider is configured —
+    // single-provider users already know the cost center, multi-provider
+    // users need the disambiguator to know which account a model bills to.
+    const showProviderLabel = new Set(allModels.map((m) => m.providerId)).size > 1;
+
     // Dropdown is always available except during active streaming
     const locked = this.isStreaming;
 
     const btn = document.createElement('button');
     btn.className = 'chat__model-btn chat__model-btn--compact';
     if (locked) btn.classList.add('chat__model-btn--disabled');
-    btn.textContent = activeModel.name;
+    const btnLabel = document.createElement('span');
+    btnLabel.textContent = activeModel.name;
+    btn.appendChild(btnLabel);
+    if (showProviderLabel) {
+      const btnProvider = document.createElement('span');
+      btnProvider.className = 'chat__model-btn-provider';
+      btnProvider.textContent = activeModel.providerName;
+      btn.appendChild(btnProvider);
+    }
     if (!locked) {
       const chevron = document.createElement('span');
       chevron.className = 'chat__model-chevron';
@@ -1331,9 +1350,18 @@ export class ChatPanel {
           item.className = 'chat__model-menu-item';
           const isActive = model.id === currentModelId && model.providerId === currentProvider;
           if (isActive) item.classList.add('chat__model-menu-item--active');
+          const left = document.createElement('span');
+          left.className = 'chat__model-menu-left';
           const label = document.createElement('span');
           label.textContent = model.name;
-          item.appendChild(label);
+          left.appendChild(label);
+          if (showProviderLabel) {
+            const provider = document.createElement('span');
+            provider.className = 'chat__model-menu-provider';
+            provider.textContent = model.providerName;
+            left.appendChild(provider);
+          }
+          item.appendChild(left);
           if (isActive) {
             const check = document.createElement('span');
             check.className = 'chat__model-check';

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -632,6 +632,13 @@
   align-items: center;
   opacity: 0.6;
 }
+.chat__model-btn-provider {
+  color: var(--s2-content-secondary);
+  font-weight: 400;
+  margin-left: 6px;
+  padding-left: 6px;
+  border-left: 1px solid var(--s2-border-subtle);
+}
 .chat__model-btn--disabled {
   cursor: default;
   opacity: 0.5;
@@ -658,6 +665,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   padding: 8px 12px;
   border-radius: 8px;
   cursor: pointer;
@@ -671,6 +679,17 @@
 }
 .chat__model-menu-item--active {
   font-weight: 600;
+}
+.chat__model-menu-left {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+.chat__model-menu-provider {
+  color: var(--s2-content-secondary);
+  font-weight: 400;
+  font-size: 11px;
 }
 .chat__model-check {
   color: var(--s2-accent);

--- a/packages/webapp/tests/ui/chat-panel-model-selector.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-model-selector.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { ChatPanel } from '../../src/ui/chat-panel.js';
+
+vi.mock('../../src/ui/voice-input.js', () => ({
+  VoiceInput: class {
+    destroy() {}
+    start() {}
+    stop() {}
+    setAutoSend() {}
+    setLang() {}
+    isListening() {
+      return false;
+    }
+  },
+  getVoiceAutoSend: () => false,
+  getVoiceLang: () => 'en-US',
+}));
+
+const groupsRef: { value: Array<Record<string, unknown>> } = { value: [] };
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => '',
+  showProviderSettings: () => {},
+  applyProviderDefaults: () => {},
+  getAllAvailableModels: () => groupsRef.value,
+  getSelectedModelId: () => 'claude-sonnet',
+  getSelectedProvider: () => 'anthropic',
+  setSelectedModelId: () => {},
+  getProviderConfig: () => null,
+}));
+
+describe('ChatPanel model selector — multi-provider provider labels', () => {
+  let container: HTMLElement;
+  let panel: ChatPanel;
+  let testCounter = 0;
+
+  beforeEach(async () => {
+    testCounter += 1;
+    const store: Record<string, string> = { 'selected-model': 'anthropic:claude-sonnet' };
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    panel = new ChatPanel(container);
+    await panel.initSession(`test-model-selector-${testCounter}`);
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.unstubAllGlobals();
+    groupsRef.value = [];
+  });
+
+  it('omits the provider label when only one provider is configured', () => {
+    groupsRef.value = [
+      {
+        providerId: 'anthropic',
+        providerName: 'Anthropic',
+        models: [
+          { id: 'claude-sonnet', name: 'Claude Sonnet' },
+          { id: 'claude-opus', name: 'Claude Opus' },
+        ],
+      },
+    ];
+    panel.refreshModelSelector();
+
+    expect(container.querySelector('.chat__model-btn-provider')).toBeNull();
+    expect(container.querySelector('.chat__model-menu-provider')).toBeNull();
+    const btn = container.querySelector('.chat__model-btn--compact');
+    expect(btn?.textContent).toContain('Claude Sonnet');
+    expect(btn?.textContent).not.toContain('Anthropic');
+  });
+
+  it('shows the provider label on the trigger and every menu item when multiple providers are configured', () => {
+    groupsRef.value = [
+      {
+        providerId: 'anthropic',
+        providerName: 'Anthropic',
+        models: [{ id: 'claude-sonnet', name: 'Claude Sonnet' }],
+      },
+      {
+        providerId: 'bedrock',
+        providerName: 'AWS Bedrock',
+        models: [{ id: 'claude-sonnet', name: 'Claude Sonnet' }],
+      },
+    ];
+    panel.refreshModelSelector();
+
+    const btnProvider = container.querySelector('.chat__model-btn-provider');
+    expect(btnProvider).not.toBeNull();
+    expect(btnProvider?.textContent).toBe('Anthropic');
+
+    // Open the menu so menu items render.
+    (container.querySelector('.chat__model-btn--compact') as HTMLButtonElement).click();
+
+    const menuProviders = container.querySelectorAll('.chat__model-menu-provider');
+    expect(menuProviders).toHaveLength(2);
+    const labels = Array.from(menuProviders).map((el) => el.textContent);
+    expect(labels).toEqual(expect.arrayContaining(['Anthropic', 'AWS Bedrock']));
+  });
+});


### PR DESCRIPTION
## Summary

- The chat model dropdown rendered only `model.name`, so users with two or more provider accounts (e.g. Anthropic + Bedrock both serving Claude Sonnet) could not tell which provider — and which cost center — a selection was billing to.
- `getAllAvailableModels()` already exposes `providerName`; the flattening in `renderModelSelector` (`packages/webapp/src/ui/chat-panel.ts`) was discarding it. Now it carries through, and when more than one provider is configured the provider name is rendered as a muted secondary label on both the trigger pill and each menu item.
- Single-provider users see no visual change — the labels only appear when `new Set(providerIds).size > 1`.

<img width="824" height="270" alt="Screenshot 2026-05-06 at 15 46 57" src="https://github.com/user-attachments/assets/a89ee880-b78f-4e89-8900-3c0a11ba295c" />

## Changes

- `packages/webapp/src/ui/chat-panel.ts` — extend the flattened `allModels` list with `providerName`, compute `showProviderLabel`, and append the muted label to the trigger and each menu item when multi-provider.
- `packages/webapp/src/ui/styles/chat.css` — three new selectors (`.chat__model-btn-provider`, `.chat__model-menu-left`, `.chat__model-menu-provider`) reusing existing S2 tokens; trigger gets a thin divider, menu sub-label is smaller and muted.
- `packages/webapp/tests/ui/chat-panel-model-selector.test.ts` — new regression test covering the single-provider (no labels) and multi-provider (labels on trigger + every menu item) cases.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/ui/` — 567/567 pass (incl. the 2 new cases)
- [x] `npx prettier --check` on touched files — clean
- [x] `npm run build` — succeeds (pre-existing warnings unrelated)
- [x] Manual UI verification with two provider accounts configured — provider names render on the pill and menu items; single-provider mode unchanged