### PR TITLE
fix(ci): scope staging worker secret uploads to staging environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,12 @@ jobs:
           path: coverage/
           if-no-files-found: ignore
 
-      # Deploy to staging on PRs (not forks) and pushes to main
+      # Deploy to staging on PRs (not forks) and pushes to main.
+      # `environment: staging` is required so `wrangler secret bulk` targets the
+      # staging Worker. wrangler-action@v3 does not parse `--env` out of `command:`
+      # for the secret upload step — it only honors the `environment:` input.
+      # Without this, secrets uploaded here land on the production Worker
+      # (slicc-tray-hub) instead of slicc-tray-hub-staging.
       - name: Deploy staging worker (attempt 1)
         id: deploy_attempt_1
         if: |
@@ -348,6 +353,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/cloudflare-worker
+          environment: staging
           command: deploy --env staging
           secrets: |
             CLOUDFLARE_TURN_API_TOKEN
@@ -365,6 +371,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/cloudflare-worker
+          environment: staging
           command: deploy --env staging
           secrets: |
             CLOUDFLARE_TURN_API_TOKEN
@@ -382,6 +389,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/cloudflare-worker
+          environment: staging
           command: deploy --env staging
           secrets: |
             CLOUDFLARE_TURN_API_TOKEN

--- a/.github/workflows/worker-staging.yml
+++ b/.github/workflows/worker-staging.yml
@@ -41,6 +41,12 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/cloudflare-worker
+          # `environment:` is required so `wrangler secret bulk` targets the
+          # staging Worker. wrangler-action@v3 does not parse `--env` out of
+          # `command:` for the secret upload step — it only honors the
+          # `environment:` input. Without this, secrets uploaded here land on
+          # the production Worker (slicc-tray-hub) instead of slicc-tray-hub-staging.
+          environment: staging
           command: deploy --env staging
           secrets: |
             CLOUDFLARE_TURN_API_TOKEN
@@ -62,6 +68,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/cloudflare-worker
+          environment: staging
           command: deploy --env staging
           secrets: |
             CLOUDFLARE_TURN_API_TOKEN


### PR DESCRIPTION
## Summary

- `cloudflare/wrangler-action@v3` does **not** parse `--env` out of `command:` for the secret-upload step — it only honors the `environment:` input (see [`uploadSecrets` in wranglerAction.ts](https://github.com/cloudflare/wrangler-action/blob/main/src/wranglerAction.ts)).
- In `worker-staging.yml` and `ci.yml`, the deploy correctly targets `slicc-tray-hub-staging` (because `--env staging` is in the command string), but `wrangler secret bulk` ran against the default Worker — `slicc-tray-hub`, **production** — silently overwriting `GITHUB_CLIENT_SECRET` on prod with `OAUTH_GITHUB_SECRET_STAGING` on every PR run that touched the cloudflare-worker / provider paths.
- This is the cause of the recurring "GitHub OAuth credentials wrong on prod" incidents that we've been fixing by manually re-running `worker.yml`.
- Adds `environment: staging` to all 5 wrangler-action invocations (2 in `worker-staging.yml`, 3 in `ci.yml`) so secret uploads target the right Worker. `CLOUDFLARE_TURN_API_TOKEN` is also affected but was a silent no-op since the same Actions secret value is used in both environments.

## Test plan

- [ ] Merge fix; confirm next staging-worker PR run no longer overwrites prod's `GITHUB_CLIENT_SECRET` (e.g. by `wrangler secret list` against both Workers after a staging deploy).
- [ ] Verify that the deployed staging smoke test in this PR's own staging-worker run still passes (the `GITHUB_CLIENT_SECRET` for staging should now be set on `slicc-tray-hub-staging`, not on prod).
- [ ] After landing, run the production `Worker Production Deploy` workflow once to restore prod's `GITHUB_CLIENT_SECRET` to `OAUTH_GITHUB_SECRET`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)