### PR TITLE
fix(extension): advertise follower tab targets to cone

### DIFF
--- a/packages/chrome-extension/src/offscreen.ts
+++ b/packages/chrome-extension/src/offscreen.ts
@@ -391,9 +391,15 @@ async function init(): Promise<void> {
 
     if (trayRuntimeConfig?.joinUrl) {
       let activeSync: FollowerSyncManager | null = null;
+      let targetRefreshInterval: ReturnType<typeof setInterval> | null = null;
       const detachSync = () => {
+        if (targetRefreshInterval) {
+          clearInterval(targetRefreshInterval);
+          targetRefreshInterval = null;
+        }
         if (!activeSync) return;
         bridge.setFollowerSync(null);
+        browser.setTrayTargetProvider(null);
         activeSync.close();
         activeSync = null;
       };
@@ -407,11 +413,27 @@ async function init(): Promise<void> {
           onConnected: (connection) => {
             log.info('Extension follower connected', { trayId: connection.trayId });
             detachSync();
+            const runtimeId = `follower-${connection.bootstrapId}`;
+            const refreshTargets = async () => {
+              if (!activeSync) return;
+              try {
+                const pages = await browser.listPages();
+                activeSync.advertiseTargets(
+                  pages.map((p) => ({ targetId: p.targetId, title: p.title, url: p.url })),
+                  runtimeId
+                );
+              } catch {
+                /* ignore — best-effort target advertisement */
+              }
+            };
             const sync = new FollowerSyncManager(connection.channel, {
+              browserTransport: browser.getTransport(),
+              browserAPI: browser,
               onSnapshot: (messages) => bridge.applyFollowerSnapshot(messages),
               onUserMessage: (text, messageId) =>
                 bridge.emitFollowerIncomingMessage(messageId, text),
               onStatus: (scoopStatus) => bridge.emitFollowerStatus(scoopStatus),
+              onTargetsChanged: () => void refreshTargets(),
               onDisconnect: (reason) => {
                 log.warn('Follower sync disconnected', { reason });
                 detachSync();
@@ -419,8 +441,11 @@ async function init(): Promise<void> {
             });
             sync.onEvent((event) => bridge.emitFollowerAgentEvent(event));
             activeSync = sync;
+            browser.setTrayTargetProvider(sync);
             bridge.setFollowerSync(sync);
             sync.requestSnapshot();
+            targetRefreshInterval = setInterval(() => void refreshTargets(), 5000);
+            void refreshTargets();
           },
           onGaveUp: (lastError) => {
             log.warn('Extension follower reconnect gave up', { lastError });

--- a/packages/chrome-extension/src/offscreen.ts
+++ b/packages/chrome-extension/src/offscreen.ts
@@ -414,19 +414,7 @@ async function init(): Promise<void> {
             log.info('Extension follower connected', { trayId: connection.trayId });
             detachSync();
             const runtimeId = `follower-${connection.bootstrapId}`;
-            const refreshTargets = async () => {
-              if (!activeSync) return;
-              try {
-                const pages = await browser.listPages();
-                activeSync.advertiseTargets(
-                  pages.map((p) => ({ targetId: p.targetId, title: p.title, url: p.url })),
-                  runtimeId
-                );
-              } catch {
-                /* ignore — best-effort target advertisement */
-              }
-            };
-            const sync = new FollowerSyncManager(connection.channel, {
+            const sync: FollowerSyncManager = new FollowerSyncManager(connection.channel, {
               browserTransport: browser.getTransport(),
               browserAPI: browser,
               onSnapshot: (messages) => bridge.applyFollowerSnapshot(messages),
@@ -439,6 +427,21 @@ async function init(): Promise<void> {
                 detachSync();
               },
             });
+            const refreshTargets = async () => {
+              try {
+                const pages = await browser.listPages();
+                // Bail if a reconnect swapped activeSync while listPages was in
+                // flight — otherwise we'd advertise this connection's runtimeId
+                // against the new sync (or vice versa), polluting the registry.
+                if (activeSync !== sync) return;
+                sync.advertiseTargets(
+                  pages.map((p) => ({ targetId: p.targetId, title: p.title, url: p.url })),
+                  runtimeId
+                );
+              } catch {
+                /* ignore — best-effort target advertisement */
+              }
+            };
             sync.onEvent((event) => bridge.emitFollowerAgentEvent(event));
             activeSync = sync;
             browser.setTrayTargetProvider(sync);


### PR DESCRIPTION
## Summary

- Fixes #593: when the Chrome extension runs as a follower, tabs opened in its Chrome instance were not visible to the cone in `playwright-cli tab-list`. Only pre-existing tabs (Slack, etc., enumerated by the cone itself) showed up.
- Root cause: the offscreen `FollowerSyncManager` was instantiated without `browserTransport`, `browserAPI`, or `onTargetsChanged`, and there was no periodic `advertiseTargets()` loop. The standalone webapp follower already had this wiring (`packages/webapp/src/ui/main.ts:3169-3213`); the extension was missing it.
- Mirror that pattern in `packages/chrome-extension/src/offscreen.ts`: pass `browserTransport`/`browserAPI`, define `refreshTargets()` (calls `browser.listPages()` → `sync.advertiseTargets()`), wire `onTargetsChanged`, register the follower as the tray target provider, and run a 5s refresh interval. Tear it all down in `detachSync` so reconnects don't leak.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npx vitest run packages/chrome-extension/tests/` — 151/151 pass
- [ ] `npx vitest run packages/webapp/tests/scoops/tray-follower-sync.test.ts` — 50/50 pass
- [ ] Manual: launch CLI cone, connect extension as follower, open a new tab in the extension's Chrome, run `playwright-cli tab-list` from the cone, confirm new tab appears with `[remote:follower-...]` prefix
- [ ] Manual: open a tab via cone-issued `tab.open` (already worked), confirm it still appears
- [ ] Manual: disconnect/reconnect follower, confirm no leaked intervals (devtools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)