### PR TITLE
fix(ios): capture PIPESTATUS atomically under set -u

### DIFF
--- a/packages/ios-app/scripts/package-and-upload-testflight.sh
+++ b/packages/ios-app/scripts/package-and-upload-testflight.sh
@@ -320,9 +320,17 @@ xcrun altool --upload-app \
 # Capture both halves of the pipeline before re-enabling errexit. tee
 # can fail independently of altool (e.g. .build is read-only), and we
 # don't want a write failure to look like a successful upload.
-ALTOOL_STATUS="${PIPESTATUS[0]}"
-TEE_STATUS="${PIPESTATUS[1]}"
+#
+# PIPESTATUS is rewritten after EVERY command (including a plain
+# assignment), so two separate `VAR=${PIPESTATUS[N]}` lines read from a
+# stale, single-element array — under `set -u` that aborts with
+# "PIPESTATUS[1]: unbound variable" (broke release v2.34.3 → 0 GitHub
+# release after a successful TestFlight upload). Capture the whole
+# array in one expansion so both indices are available afterwards.
+PIPE_STATUS=("${PIPESTATUS[@]}")
 set -e
+ALTOOL_STATUS="${PIPE_STATUS[0]}"
+TEE_STATUS="${PIPE_STATUS[1]}"
 if [ "$ALTOOL_STATUS" -ne 0 ]; then
   echo "error: altool exited $ALTOOL_STATUS" >&2
   exit 1


### PR DESCRIPTION
## Summary

Hotfix for a bug I introduced in PR #592 (commit db61028b). The release run for v2.34.3 (run [25508502870](https://github.com/ai-ecoverse/slicc/actions/runs/25508502870)) **uploaded the iOS build to TestFlight successfully** but then died here:

```
packages/ios-app/scripts/package-and-upload-testflight.sh: line 324:
PIPESTATUS[1]: unbound variable
```

…which exited the prepareCmd non-zero, so semantic-release never published the GitHub release tag, Chrome Web Store, Cloudflare Worker, or npm package for v2.34.3.

## Root cause

`PIPESTATUS` is rewritten after every command — *including* a plain assignment. The previous patch read it twice in sequence:

```bash
ALTOOL_STATUS="${PIPESTATUS[0]}"
TEE_STATUS="${PIPESTATUS[1]}"   # ← PIPESTATUS already shrank to [0] after the line above
```

Under `set -u`, that aborts.

## Fix

Copy the whole array in one expansion before reading individual indices:

```bash
PIPE_STATUS=("${PIPESTATUS[@]}")
set -e
ALTOOL_STATUS="${PIPE_STATUS[0]}"
TEE_STATUS="${PIPE_STATUS[1]}"
```

Verified under bash: new pattern reads both statuses correctly (`A=0 B=0`); old pattern reproduces the CI error verbatim (`PIPESTATUS[1]: unbound variable`).

## Status of v2.34.3

The iOS build itself **is** in TestFlight (Delivery UUID `f0b9206f-b450-4962-8aa5-240e9eafe052`, 15 MB, build 372). The user-visible damage is:
- No `v2.34.3` GitHub release / tag.
- No Chrome Web Store push for v2.34.3.
- No Cloudflare Worker / npm publish for v2.34.3.

These will all happen on the next merge to `main` (which will become v2.34.4). No replay needed.

## Test plan

- [ ] Merge → release workflow runs through the script
- [ ] No `PIPESTATUS[1]: unbound variable` error
- [ ] Script reaches `=== SliccFollower v… (build N) uploaded ===`
- [ ] semantic-release proceeds to publish GitHub release / Chrome / Worker / npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)