### PR TITLE
fix(ios): add NSCameraUsageDescription to resolve App Store rejection

### DIFF
--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -339,7 +339,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_KEY_NSCameraUsageDescription = "SliccFollower uses WebRTC for screen sharing and remote browser control between your devices.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -423,7 +423,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_KEY_NSCameraUsageDescription = "SliccFollower uses WebRTC for screen sharing and remote browser control between your devices.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_KEY_NSCameraUsageDescription = "SliccFollower uses WebRTC for screen sharing and remote browser control between your devices.";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -422,6 +423,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_KEY_NSCameraUsageDescription = "SliccFollower uses WebRTC for screen sharing and remote browser control between your devices.";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/packages/ios-app/project.yml
+++ b/packages/ios-app/project.yml
@@ -26,7 +26,7 @@ targets:
         PRODUCT_NAME: SliccFollower
         SUPPORTED_PLATFORMS: 'iphoneos iphonesimulator'
         SUPPORTS_MACCATALYST: NO
-        INFOPLIST_KEY_NSCameraUsageDescription: 'SliccFollower uses WebRTC for screen sharing and remote browser control between your devices.'
+        INFOPLIST_KEY_NSCameraUsageDescription: 'This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.'
     dependencies:
       - package: WebRTC
       - sdk: WebKit.framework

--- a/packages/ios-app/project.yml
+++ b/packages/ios-app/project.yml
@@ -26,6 +26,7 @@ targets:
         PRODUCT_NAME: SliccFollower
         SUPPORTED_PLATFORMS: 'iphoneos iphonesimulator'
         SUPPORTS_MACCATALYST: NO
+        INFOPLIST_KEY_NSCameraUsageDescription: 'SliccFollower uses WebRTC for screen sharing and remote browser control between your devices.'
     dependencies:
       - package: WebRTC
       - sdk: WebKit.framework


### PR DESCRIPTION
## Summary

- Adds `NSCameraUsageDescription` to `project.yml` (XcodeGen source) and directly to both Debug and Release build configurations in `project.pbxproj`
- Resolves App Store rejection **ITMS-90683**: the WebRTC dependency references camera APIs, which requires a purpose string in Info.plist even though the app does not actively use the camera

## Test plan

- [ ] Build and archive `SliccFollower` — confirm `NSCameraUsageDescription` appears in the generated `Info.plist` inside the `.ipa`
- [ ] Upload to App Store Connect and verify no ITMS-90683 warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)