### PR TITLE
fix(welcome): single canonical skill install at end of onboarding

### DIFF
--- a/packages/vfs-root/workspace/skills/welcome/SKILL.md
+++ b/packages/vfs-root/workspace/skills/welcome/SKILL.md
@@ -35,24 +35,13 @@ When you receive a `[Sprinkle Event: welcome]` with `action: 'onboarding-complet
 Your one and only job is to send a single short reply (≤ 6 sentences total) that:
 
 1. Greets the user by name (or warmly acknowledges them anonymously if `profile.name` is empty) and reacts genuinely to the chosen `provider` + `modelLabel` (or `model`) — a sentence or two. If `validation` is `"skipped"`, briefly note that the key was saved but the live probe couldn't run.
-2. Closes with **exactly three concrete follow-up actions** the user can take right now, written as a markdown bulleted list with one short imperative each. Before you write them, take a quick look at the skills currently installed under `/workspace/skills/` — the orchestrator just finished installing the user's recommended set, so those skills (and their sprinkles / commands) are the most relevant surface to suggest. Ground the suggestions in BOTH the user's `profile.tasks` / `profile.role` / `profile.purpose` AND the available skills. The three bullets must follow this mix exactly:
+2. Closes with **exactly three concrete follow-up actions** the user can take right now, written as a markdown bulleted list with one short imperative each. Ground the suggestions in the user's `profile.tasks` / `profile.role` / `profile.purpose` — the post-reply install step below lands the user's recommended skill set, so it's safe to reference task-matching skills (e.g. `migrate-page` for `tasks: ['migrate-page-aem']`) even though they aren't on disk yet at reply time. The three bullets must follow this mix exactly:
    - **One obvious** — the natural next step a user with this profile would expect, ideally invoking a freshly installed skill that matches their stated tasks (e.g. for an AEM developer with `migration` installed: "Try `migrate-page` on a real AEM URL").
    - **One obligatory** — the practical setup-or-housekeeping step they really should do before anything else (e.g. "Run `git config --global user.email …` so your commits are attributed", "Open the Files tab and mount your project directory", or "Drop your team's coding-style doc into chat so I can pick it up").
    - **One outrageous** — a deliberately bold, slightly-cheeky use of the available skills that pushes the user beyond their stated profile and shows what's possible (e.g. "Ask me to rewrite your homepage in pirate English", "Have me generate a brand-compliance report for your competitor's site", or "Spin up a scoop that drafts your next pull request from a one-line brief"). Keep it tasteful but unmistakably playful.
 
    Pick concrete suggestions that actually fit what's installed; do **not** copy the examples above verbatim if they don't fit. If you cannot ground a bullet in the profile or the skill set, fall back to a useful generic one (e.g. "Drop a URL into the chat for me to inspect", "Paste a screenshot you'd like me to analyse").
 
-Do **not** print a capability table, do **not** call `update_global_memory`, do **not** install anything (the orchestrator already kicked off the recommended-skills install in the background), do **not** edit `/shared/CLAUDE.md`.
+Do **not** print a capability table, do **not** call `update_global_memory`, do **not** install other skills beyond the `upskill recommendations --install` step below, do **not** edit `/shared/CLAUDE.md`.
 
-## Handling shortcut-migrate
-
-When you receive a `[Sprinkle Event: welcome]` with `shortcut-migrate`:
-
-1. Run this command silently (do NOT show the output to the user):
-
-```bash
-upskill aemcoder/skills --path migration --all
-```
-
-2. If it succeeds, do nothing further. The `migrate-page.shtml` sprinkle has `data-sprinkle-autoopen` and opens automatically after installation.
-3. If it fails, tell the user the install failed and suggest they retry manually with `upskill aemcoder/skills --path migration --all`.
+After sending the reply, silently run `upskill recommendations --install` (do **not** show the output to the user) to land the user's recommended skill set. The command is profile-driven (it reads `/home/<user>/.welcome.json`, which the webapp persisted when the wizard finished) and idempotent.

--- a/packages/webapp/src/scoops/onboarding-orchestrator.ts
+++ b/packages/webapp/src/scoops/onboarding-orchestrator.ts
@@ -144,16 +144,6 @@ export interface OrchestratorDeps {
    * Optional — providers without OAuth support can skip this.
    */
   launchOAuth?: (providerId: string, baseUrl?: string | null) => Promise<OAuthLaunchResult>;
-  /**
-   * Direct (no-shell) installer for the recommended-skills set. Used to
-   * land the user's matching skills immediately after the welcome wizard
-   * without going through the wasm shell layer (which lives in a different
-   * execution context in extension mode and isn't reachable from the
-   * panel-side orchestrator). The orchestrator passes the freshly-collected
-   * profile so the installer doesn't race with the parallel `persistProfile`
-   * write. Errors are logged and swallowed by the orchestrator.
-   */
-  installRecommendedSkills?: (profile: OnboardingProfile) => Promise<void>;
   /** Optional fetch override for tests. */
   fetchImpl?: typeof fetch;
   /** Optional RNG for deterministic message picking in tests. */
@@ -211,19 +201,12 @@ export class OnboardingOrchestrator {
     // Persist the welcome marker + profile in parallel. We don't
     // wait for the writes — even if they fail, the on-screen flow
     // continues so the user is never blocked by a transient FS hiccup.
+    // Skill install happens at the tail of the cone's
+    // `onboarding-complete-with-provider` reply (see welcome/SKILL.md),
+    // not here — keeping it cone-driven gives the user one canonical
+    // install point and avoids racing two concurrent installs.
     void recordWelcomed(this.deps.fs).catch((err) => log.warn('recordWelcomed failed', err));
     void this.persistProfile(this.profile).catch((err) => log.warn('persistProfile failed', err));
-
-    // Kick off skill install in the background — no UI block, no shell
-    // round-trip. We pass the in-memory profile directly so the installer
-    // doesn't race the parallel persistProfile write to /home/<user>/.welcome.json.
-    // The helper handles "all installed" / "catalog fetch failed" internally,
-    // so we just fire and forget.
-    if (this.deps.installRecommendedSkills) {
-      void this.deps
-        .installRecommendedSkills(this.profile)
-        .catch((err) => log.warn('installRecommendedSkills failed', err));
-    }
 
     // Three deterministic lines, then the connect-llm dip.
     const lines = buildIntroMessages(this.profile, this.deps.rand);

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -975,24 +975,6 @@ async function mainExtension(app: HTMLElement): Promise<void> {
           };
         }
       },
-      installRecommendedSkills: async (profile) => {
-        // Direct (no-shell) skill install — reuses the same code path the
-        // upskill command does, but via a non-shell entry point so it
-        // works from the panel side of the extension where the agent
-        // shell isn't reachable. Profile is forwarded so the installer
-        // doesn't race the parallel persistProfile write.
-        const [{ installRecommendedSkills }, { createProxiedFetch }] = await Promise.all([
-          import('../shell/supplemental-commands/upskill-command.js'),
-          import('../shell/proxied-fetch.js'),
-        ]);
-        const result = await installRecommendedSkills(localFs, createProxiedFetch(), profile);
-        log.info('Recommended skills install finished', {
-          installedNames: result.installedNames,
-          errors: result.errors,
-          skipped: result.skipped,
-          elapsedSeconds: result.elapsedSeconds,
-        });
-      },
     });
     return extOnboardingOrchestrator;
   };
@@ -2185,23 +2167,6 @@ async function main(): Promise<void> {
         // so this synthetic `onboarding-complete-with-provider` lick
         // falls straight through to the cone like a regular sprinkle.
         routeLickToScoop(completionEvent);
-      },
-      installRecommendedSkills: async (profile) => {
-        // Direct (no-shell) skill install — see extension wiring above
-        // for why we deliberately avoid going through `__slicc_shell`.
-        // Profile is forwarded so the installer doesn't race persistProfile.
-        if (!sharedFs) return;
-        const [{ installRecommendedSkills }, { createProxiedFetch }] = await Promise.all([
-          import('../shell/supplemental-commands/upskill-command.js'),
-          import('../shell/proxied-fetch.js'),
-        ]);
-        const result = await installRecommendedSkills(sharedFs, createProxiedFetch(), profile);
-        log.info('Recommended skills install finished', {
-          installedNames: result.installedNames,
-          errors: result.errors,
-          skipped: result.skipped,
-          elapsedSeconds: result.elapsedSeconds,
-        });
       },
       launchOAuth: async (providerId, baseUrl) => {
         try {

--- a/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
@@ -7,6 +7,18 @@ import {
 } from '../../src/scoops/onboarding-orchestrator.js';
 import { __test__ as messageTest } from '../../src/scoops/onboarding-messages.js';
 
+type AccountSnapshot = {
+  id: string;
+  key: string;
+  baseUrl?: string;
+  deployment?: string;
+  apiVersion?: string;
+};
+
+type DipMessage = Record<string, unknown> & { type: string };
+
+type FinalLickPayload = Record<string, unknown> & { action: string };
+
 function fakeFetch(impl: (url: string) => Response | Promise<Response>) {
   return vi.fn(async (input: RequestInfo | URL) => {
     return await impl(String(input));
@@ -57,11 +69,10 @@ function makeHarness(
   const fs = new VirtualFS('test-' + Math.random());
   const systemMessages: string[] = [];
   const dipRefs: string[] = [];
-  const dipInbox: any[] = [];
-  const finalLicks: any[] = [];
-  const accounts: any[] = [];
+  const dipInbox: DipMessage[] = [];
+  const finalLicks: FinalLickPayload[] = [];
+  const accounts: AccountSnapshot[] = [];
   const selectedModels: string[] = [];
-  const skillInstallCalls: Array<{ at: number; profile: unknown }> = [];
   const orchestrator = new OnboardingOrchestrator({
     fs,
     postSystemMessage: (line) => systemMessages.push(line),
@@ -73,9 +84,6 @@ function makeHarness(
     resolveModelLabel: (_p, m) => m.toUpperCase(),
     broadcastToDip: (msg) => dipInbox.push(msg),
     fireFinalLick: (data) => finalLicks.push(data),
-    installRecommendedSkills: async (profile) => {
-      skillInstallCalls.push({ at: Date.now(), profile });
-    },
     fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
     rand: () => 0,
   });
@@ -88,7 +96,6 @@ function makeHarness(
     finalLicks,
     accounts,
     selectedModels,
-    skillInstallCalls,
   };
 }
 
@@ -145,37 +152,6 @@ describe('OnboardingOrchestrator', () => {
         await new Promise((r) => setTimeout(r, 10));
       }
       expect(await h.fs.exists('/home/user/.welcome.json')).toBe(true);
-    });
-
-    it('kicks off the recommended-skills installer with the in-memory profile', async () => {
-      const h = makeHarness();
-      await h.orchestrator.handleOnboardingComplete({ name: 'Kim', role: 'developer' });
-      await new Promise((r) => setTimeout(r, 5));
-      expect(h.skillInstallCalls).toHaveLength(1);
-      // Profile is passed by reference so the installer doesn't have to wait
-      // for the parallel persistProfile write to land on disk.
-      expect(h.skillInstallCalls[0].profile).toMatchObject({ name: 'Kim', role: 'developer' });
-    });
-
-    it('silently no-ops when no skill installer was wired', async () => {
-      const fs = new VirtualFS('no-installer-' + Math.random());
-      const finalLicks: any[] = [];
-      const orch = new OnboardingOrchestrator({
-        fs,
-        postSystemMessage: () => {},
-        postDipReference: () => {},
-        getProviderCatalogue: () => baseCatalogue,
-        saveAccount: () => {},
-        setSelectedModel: () => {},
-        broadcastToDip: () => {},
-        fireFinalLick: (data) => finalLicks.push(data),
-        // installRecommendedSkills omitted on purpose.
-        rand: () => 0,
-      });
-      const handled = await orch.handleOnboardingComplete({ name: 'NoInstaller' });
-      expect(handled).toBe(true);
-      // No throw, orchestrator still advances to awaiting-connect.
-      expect(orch.getStage()).toBe('awaiting-connect');
     });
 
     it('is idempotent for duplicate complete events in the same session', async () => {
@@ -269,9 +245,9 @@ describe('OnboardingOrchestrator', () => {
     it('rejects when the validator says the key is bad — does NOT save or fire the cone lick', async () => {
       const fetchImpl = fakeFetch(() => new Response('{"error":"bad"}', { status: 401 }));
       const fs = new VirtualFS('reject-' + Math.random());
-      const accounts: any[] = [];
-      const finalLicks: any[] = [];
-      const dipInbox: any[] = [];
+      const accounts: AccountSnapshot[] = [];
+      const finalLicks: FinalLickPayload[] = [];
+      const dipInbox: DipMessage[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
         postSystemMessage: () => {},
@@ -300,9 +276,9 @@ describe('OnboardingOrchestrator', () => {
         throw new TypeError('Failed to fetch');
       }) as unknown as typeof fetch;
       const fs = new VirtualFS('skipped-' + Math.random());
-      const accounts: any[] = [];
-      const finalLicks: any[] = [];
-      const dipInbox: any[] = [];
+      const accounts: AccountSnapshot[] = [];
+      const finalLicks: FinalLickPayload[] = [];
+      const dipInbox: DipMessage[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
         postSystemMessage: () => {},
@@ -348,7 +324,7 @@ describe('OnboardingOrchestrator', () => {
     it('leaves the selected model untouched when the catalogue has no models for the provider', async () => {
       const fs = new VirtualFS('no-models-' + Math.random());
       const selectedModels: string[] = [];
-      const finalLicks: any[] = [];
+      const finalLicks: FinalLickPayload[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
         postSystemMessage: () => {},
@@ -437,7 +413,7 @@ describe('OnboardingOrchestrator', () => {
       await h.orchestrator.handleConnectAttempt({
         provider: '',
         apiKey: '',
-      } as any);
+      });
       expect(h.accounts).toEqual([]);
       const reject = h.dipInbox.find((m) => m.type === 'slicc-connect-result');
       expect(reject.ok).toBe(false);


### PR DESCRIPTION
## Summary

Replaces a hidden, AEM-flavoured pre-install with a single explicit install step at the tail of welcome onboarding.

**Before:** when the user finished the welcome wizard, `OnboardingOrchestrator.handleOnboardingComplete()` fire-and-forgot a background `installRecommendedSkills(profile)` call from the panel JS. For a profile with `tasks: ["migrate-page-aem"]` this resolved through the catalog to a bundle install of `aemcoder/skills/skills/migration/` (`migrate-page`, `migrate-block`, `migrate-header`, `dismiss-overlays`) that ran while the user was busy in the OAuth popup. The cone's SKILL.md then asserted those skills were already on disk and wrote a three-bullet reply referencing them. When the background install fell through silently — catalog hiccup, race, fetch-proxy unhappy — the bullets pointed at skills that weren't there and there was no error surface.

**After:** the orchestrator's pre-install is gone. The cone runs `upskill recommendations --install` itself as the final action of its `onboarding-complete-with-provider` reply. Same profile-driven, catalog-driven install logic — just one call site, at the end of the welcome flow, owned by the cone. No "specific migrate-page installation" lurking before the user even sees a model wired up; the AEM migration bundle now arrives through the same standard recommendation path that any other task pill flows through.

## Changes

- `packages/webapp/src/scoops/onboarding-orchestrator.ts` — drop the `installRecommendedSkills?` field on `OrchestratorDeps` and the call site in `handleOnboardingComplete`. Replacement comment points to the welcome SKILL.md as the install owner.
- `packages/webapp/src/ui/main.ts` — drop the two `installRecommendedSkills` callback wirings (extension + standalone modes).
- `packages/vfs-root/workspace/skills/welcome/SKILL.md` — append `upskill recommendations --install` step after the reply. Bullet 2 no longer claims "the orchestrator just finished installing"; install paragraph no longer "belt-and-suspenders" — it's the canonical install. Drop the dead `## Handling shortcut-migrate` section (the wizard never fires that lick).
- `packages/webapp/tests/scoops/onboarding-orchestrator.test.ts` — remove the two install-related tests; type the harness arrays so the file is `any`-free.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` (4 changed files) clean
- [x] `npx vitest run packages/webapp/tests/scoops/` — 630/630 passing
- [x] `npm run build` clean
- [x] Manual: fresh Slicc instance in Canary → welcome wizard → "Migrate a page to AEM" → connect Adobe via OAuth → cone composes its welcome reply, then runs `upskill recommendations --install` once at the end. No earlier install fires during the wizard → OAuth gap (verified — that pre-install was the orchestrator path that is now removed).