### PR TITLE
fix(ios): declare ITSAppUsesNonExemptEncryption=NO to skip ASC questionnaire

### DIFF
--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -423,6 +424,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/packages/ios-app/project.yml
+++ b/packages/ios-app/project.yml
@@ -27,6 +27,7 @@ targets:
         SUPPORTED_PLATFORMS: 'iphoneos iphonesimulator'
         SUPPORTS_MACCATALYST: NO
         INFOPLIST_KEY_NSCameraUsageDescription: 'This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.'
+        INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO
     dependencies:
       - package: WebRTC
       - sdk: WebKit.framework


### PR DESCRIPTION
## Summary

Add `ITSAppUsesNonExemptEncryption = NO` to the SliccFollower Info.plist so App Store Connect stops prompting the export-compliance questionnaire on every new TestFlight build. Same answer ("None of the algorithms mentioned above") declared up front, in code, signed.

## Justification

SliccFollower's encryption surface:
- **TLS** for HTTPS / signaling — provided by iOS via WebKit / `URLSession`.
- **DTLS-SRTP** for WebRTC media — standard IETF crypto in the bundled `WebRTC.framework` (stasel/WebRTC 147.0.0).
- No proprietary algorithms, no on-device file encryption beyond what iOS provides, no novel cryptography.

That qualifies as exempt under EAR §740.17(b) (mass-market software using standard, widely-available encryption ancillary to the app's primary function — communication transport). Same treatment routine for other WebRTC consumer apps.

## Changes

- `packages/ios-app/project.yml`: add `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO` to the target build settings.
- `packages/ios-app/SliccFollower.xcodeproj/project.pbxproj`: same key in both Debug and Release configs (kept in sync with the XcodeGen source).

## Test plan

- [ ] Merge → release workflow uploads the next build (likely v2.34.6 / build 376).
- [ ] In App Store Connect TestFlight tab, the new build skips the "Encryption" / "Export Compliance Information" questionnaire entirely.
- [ ] Build appears as VALID and ready-to-test without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)