### PR TITLE
fix(llm-session-id): attach X-Session-Id on compaction summaries

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -523,3 +523,95 @@ When adding a feature that touches:
 - [ ] Test in extension mode (`npm run build -w @slicc/chrome-extension` → load in chrome://extensions)
 - [ ] If added WASM, verify bundled path in extension build
 - [ ] If added command, test in both terminal modes
+
+## Adobe Proxy `X-Session-Id` on LLM Call Paths
+
+**The Problem**
+
+Every request from SLICC to the Adobe LLM proxy must carry an
+`X-Session-Id` HTTP header. The proxy uses it to group requests into
+one logical session for usage telemetry. When the header is absent,
+the proxy falls back to a content-derived `sha256(userId +
+firstHumanText[:200])` — a 64-char hex hash that fragments multi-turn
+conversations across many session ids and leaves them unclassified in
+the dashboard. Every individual event is still captured correctly;
+only session-level grouping breaks.
+
+The header rides on `pi-ai`'s `StreamOptions.headers`, which every
+provider's `streamSimple` honors. Any code path that calls the LLM
+without going through the agent loop or the compaction transformer
+will silently bypass it — and the resulting events can't be re-grouped
+after the fact.
+
+**The Two Enforcement Points**
+
+| Code path                                     | Wiring                                           | Where                                                               |
+| --------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------- |
+| Agent loop (cone, scoops, tool turns)         | `streamFn` wrapper passed to `Agent` constructor | `packages/webapp/src/scoops/scoop-context.ts` `streamWithSessionId` |
+| Compaction summaries (Pi packed-conversation) | `headers` config on `createCompactContext`       | `packages/webapp/src/scoops/scoop-context.ts` `compactionHeaders`   |
+
+Both paths attach the same identifier from `getAdobeSessionId(scoop,
+coneJid)` in `packages/webapp/src/scoops/llm-session-id.ts` (a
+daily-rotating UUID for the cone, `<uuid>/<hash(folder, uuid)>` for
+scoops), gated on `model.provider === 'adobe'`. Other providers
+receive no header.
+
+**Adding a New LLM Call Site**
+
+If you add code that calls `pi-ai`'s `streamSimple` / `completeSimple`
+directly — or any helper from `@mariozechner/pi-coding-agent` that
+routes there (compaction, branch summarization, etc.) — you MUST
+attach `X-Session-Id` for the Adobe provider. The cleanest pattern is
+to take a `headers: Record<string, string>` parameter and let the
+caller inject it the same way `createCompactContext` does. Don't
+replicate the Adobe-provider check at every site — push it up to
+whoever owns the call.
+
+**The pi-coding-agent Stub Tripwire**
+
+`pi-coding-agent`'s `generateSummary` is positional, and our local
+ambient stub at
+`packages/webapp/src/types/pi-coding-agent-compaction.d.ts` shadows
+resolution to upstream's `.d.ts` under `moduleResolution: bundler`.
+Upstream 0.63.0 inserted `headers?` at slot 4 and shifted `signal?`
+to slot 5. Our stub kept the pre-0.63 shape, so our positional caller
+silently routed the AbortSignal into the new `headers` slot — and we
+lost the header on every compaction summary for ~6 weeks before proxy
+telemetry surfaced it.
+
+The compile-time contract at
+`packages/webapp/src/types/pi-coding-agent-compaction.contract.ts`
+pins slot 4 (`headers`) and slot 5 (`signal`). If a future stub edit
+shifts those positions, `tsc` fails. It does **not** catch
+upstream-only drift (a renovate bump that ships without any stub
+edit) — that requires either an upstream PR exposing `./compaction` in
+pi-coding-agent's exports map (so we can drop the stub) or a tsconfig
+`paths` mapping bypassing the exports map. The upstream PR is in
+flight; tracked separately.
+
+**Verifying a Fix**
+
+After deploying anything that touches LLM call paths or the session-id
+wiring, query the LLM-monitoring D1:
+
+```sql
+SELECT date(created_at) AS day, COUNT(*) AS hex_events
+FROM usage_events
+WHERE created_at >= '<deploy-day>T00:00:00Z'
+  AND length(session_id) = 64
+  AND session_id GLOB '[0-9a-f]*'
+  AND session_id NOT LIKE '%-%'
+GROUP BY day ORDER BY day DESC;
+```
+
+`hex_events` should be ~0 on new days. If it spikes after a change
+that touched LLM call paths, a new code path is bypassing the wiring.
+
+**Related**
+
+- Bug fix: PR #600 attached `X-Session-Id` to compaction; PR #378
+  attached it to the agent loop.
+- Tripwire: PR #600 added the positional contract.
+- Coverage: `tests/scoops/scoop-context.session-id.test.ts` asserts
+  both wiring points use the same identifier; gates against future
+  reverts.

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -113,6 +113,7 @@ User → ChatPanel → Orchestrator → ScoopContext.prompt() → pi-agent-core 
 - **Dual-mode compatibility**: browser features must work in both standalone/CLI and extension runtimes.
 - **Model IDs**: use pi-ai aliases such as `claude-opus-4-6`, not dated snapshot names.
 - **Provider composition**: providers are auto-discovered from pi-ai plus `packages/webapp/src/providers/built-in/`; external provider configs live in `packages/webapp/providers/`, and build-time filtering lives in `packages/dev-tools/providers.build.json`.
+- **Adobe `X-Session-Id` invariant**: every LLM call to the Adobe proxy must attach the `X-Session-Id` header (`scoops/scoop-context.ts` wires it for both the agent `streamFn` and compaction `headers`). New LLM call sites — direct `streamSimple` / `completeSimple` callers, or pi-coding-agent helpers like `generateSummary` — must attach it explicitly or the proxy session-id grouping breaks. See `docs/pitfalls.md` for the full contract, tripwire, and verification SQL.
 
 ## VFS API Patterns
 

--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -11,7 +11,7 @@
  */
 
 import type { AgentMessage } from '@mariozechner/pi-agent-core';
-import type { Model } from '@mariozechner/pi-ai';
+import type { Api, Model, UserMessage } from '@mariozechner/pi-ai';
 // Deep import to the compaction submodule — the main entry re-exports 113 Node-only
 // modules that would break Vite's browser bundle. The compaction submodule itself
 // only depends on @mariozechner/pi-ai (already a browser-safe dependency).
@@ -29,12 +29,28 @@ const log = createLogger('context-compaction');
 /** Default context window for Claude models. */
 const DEFAULT_CONTEXT_WINDOW = 200000;
 
+/**
+ * Discriminator narrow on `AgentMessage`. The union includes pi-agent-core's
+ * `CustomAgentMessages` extension point, so a plain `m.role === 'x'` check
+ * does not narrow cleanly; a typed shape view does the same job without `any`.
+ */
+function hasRole(message: AgentMessage, role: string): boolean {
+  return (message as { role: string }).role === role;
+}
+
 export interface CompactionConfig {
-  model: Model<any>;
+  model: Model<Api>;
   getApiKey: () => string | undefined;
   contextWindow?: number;
   reserveTokens?: number;
   keepRecentTokens?: number;
+  /**
+   * HTTP headers forwarded to the LLM provider for the summarization
+   * request. Used by the Adobe LLM proxy path to attach `X-Session-Id`
+   * so compaction calls land in the same session as the agent's tool
+   * turns. Other providers ignore unknown headers.
+   */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -91,7 +107,7 @@ export function createCompactContext(
 
     // Don't split assistant+toolResult pairs: if cutIndex lands on a toolResult,
     // walk backward to include its assistant message
-    while (cutIndex > 0 && (messages[cutIndex] as any).role === 'toolResult') {
+    while (cutIndex > 0 && hasRole(messages[cutIndex], 'toolResult')) {
       cutIndex--;
     }
 
@@ -118,13 +134,15 @@ export function createCompactContext(
           config.model,
           reserveTokens,
           apiKey,
+          config.headers,
           signal
         );
 
-        const summaryMessage: AgentMessage = {
+        const summaryMessage: UserMessage = {
           role: 'user',
           content: [{ type: 'text', text: `<context-summary>\n${summary}\n</context-summary>` }],
-        } as any;
+          timestamp: Date.now(),
+        };
 
         log.info('LLM summarization successful', {
           originalMessages: messages.length,
@@ -143,7 +161,7 @@ export function createCompactContext(
     }
 
     // Fallback: naive drop (same as old behavior but without eager truncation)
-    const compactedMsg: AgentMessage = {
+    const compactedMsg: UserMessage = {
       role: 'user',
       content: [
         {
@@ -151,7 +169,8 @@ export function createCompactContext(
           text: '[Earlier conversation messages were compacted to save context space]',
         },
       ],
-    } as any;
+      timestamp: Date.now(),
+    };
 
     log.info('Naive compaction applied', {
       originalMessages: messages.length,
@@ -195,7 +214,7 @@ export async function compactContext(messages: AgentMessage[]): Promise<AgentMes
   }
 
   // Don't split assistant+toolResult pairs
-  while (cutIndex > 0 && (messages[cutIndex] as any).role === 'toolResult') {
+  while (cutIndex > 0 && hasRole(messages[cutIndex], 'toolResult')) {
     cutIndex--;
   }
 
@@ -203,7 +222,7 @@ export async function compactContext(messages: AgentMessage[]): Promise<AgentMes
     return messages;
   }
 
-  const compactedMsg: AgentMessage = {
+  const compactedMsg: UserMessage = {
     role: 'user',
     content: [
       {
@@ -211,7 +230,8 @@ export async function compactContext(messages: AgentMessage[]): Promise<AgentMes
         text: '[Earlier conversation messages were compacted to save context space]',
       },
     ],
-  } as any;
+    timestamp: Date.now(),
+  };
 
   const result = [compactedMsg, ...messages.slice(cutIndex)];
 

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -70,6 +70,22 @@ export function resolveThinkingLevel(
   return requested;
 }
 
+/**
+ * Structural view of an `AgentMessage` used by the overflow / image recovery
+ * passes. They walk every kind of message and only need `role` plus a list of
+ * content blocks discriminated by `type` — narrower than the full union of
+ * pi-ai message shapes, but enough to do the trimming safely without `any`.
+ */
+type RecoveryContentBlock = {
+  type: string;
+  text?: string;
+  data?: string;
+};
+type RecoveryMessage = {
+  role: string;
+  content: RecoveryContentBlock[] | string;
+};
+
 /** Detect API errors caused by invalid/oversized images. */
 export function isImageProcessingError(msg: string): boolean {
   return (
@@ -391,11 +407,6 @@ export class ScoopContext {
         }
       }
 
-      const compactFn = createCompactContext({
-        model,
-        getApiKey: () => getApiKey() ?? undefined,
-      });
-
       // Compute the Adobe session identifier once per init. It is a
       // daily-rotating random UUID for the cone, and `<uuid>/<hash(folder, uuid)>`
       // for scoops — salted with the UUID so the scoop folder name never
@@ -409,6 +420,18 @@ export class ScoopContext {
           headers: { ...opts?.headers, 'X-Session-Id': adobeSessionId },
         });
       };
+
+      // Compaction hits the LLM via pi-coding-agent's `completeSimple`, which
+      // bypasses our `streamWithSessionId` wrapper. Forward the same Adobe
+      // session header through `createCompactContext` so summarization calls
+      // join the same session as the agent's tool turns.
+      const compactionHeaders =
+        model.provider === 'adobe' ? { 'X-Session-Id': adobeSessionId } : undefined;
+      const compactFn = createCompactContext({
+        model,
+        getApiKey: () => getApiKey() ?? undefined,
+        headers: compactionHeaders,
+      });
 
       // Guard: dispose() may have run while init() was awaiting above.
       if (this.disposed) return;
@@ -920,7 +943,7 @@ export class ScoopContext {
       let replaced = 0;
 
       for (let i = trimmed.length - 1; i >= 0 && replaced < 5; i--) {
-        const msg = trimmed[i] as any;
+        const msg = trimmed[i] as RecoveryMessage;
         if (!Array.isArray(msg.content)) continue;
 
         let msgSize = 0;
@@ -940,16 +963,16 @@ export class ScoopContext {
           // must stay paired with subsequent toolResult messages. Only replace
           // text/image/thinking content blocks.
           if (msg.role === 'assistant') {
-            const toolCalls = msg.content.filter((block: any) => block.type === 'toolCall');
+            const toolCalls = msg.content.filter((block) => block.type === 'toolCall');
             trimmed[i] = {
               ...msg,
               content: [placeholder, ...toolCalls],
-            };
+            } as AgentMessage;
           } else {
             trimmed[i] = {
               ...msg,
               content: [placeholder],
-            };
+            } as AgentMessage;
           }
           replaced++;
           log.info('Replaced oversized message', {
@@ -958,7 +981,7 @@ export class ScoopContext {
             size: msgSize,
             preservedToolCalls:
               msg.role === 'assistant'
-                ? msg.content.filter((b: any) => b.type === 'toolCall').length
+                ? msg.content.filter((b) => b.type === 'toolCall').length
                 : 0,
           });
         }
@@ -1023,23 +1046,23 @@ export class ScoopContext {
       const limit = Math.max(0, trimmed.length - 10);
 
       for (let i = trimmed.length - 1; i >= limit; i--) {
-        const msg = trimmed[i] as any;
+        const msg = trimmed[i] as RecoveryMessage;
         if (!Array.isArray(msg.content)) continue;
 
-        const hasImages = msg.content.some((block: any) => block.type === 'image');
+        const hasImages = msg.content.some((block) => block.type === 'image');
         if (!hasImages) continue;
 
         // Remove image blocks, keep text blocks
-        const filtered = msg.content.filter((block: any) => block.type !== 'image');
+        const filtered = msg.content.filter((block) => block.type !== 'image');
 
         if (filtered.length === 0) {
           // All content was images — replace with placeholder
           trimmed[i] = {
             ...msg,
             content: [{ type: 'text' as const, text: '[Image removed: rejected by API]' }],
-          };
+          } as AgentMessage;
         } else {
-          trimmed[i] = { ...msg, content: filtered };
+          trimmed[i] = { ...msg, content: filtered } as AgentMessage;
         }
         stripped++;
       }

--- a/packages/webapp/src/types/pi-coding-agent-compaction.contract.ts
+++ b/packages/webapp/src/types/pi-coding-agent-compaction.contract.ts
@@ -1,0 +1,55 @@
+/**
+ * Compile-time positional contract for `generateSummary` from
+ * `@mariozechner/pi-coding-agent`.
+ *
+ * pi-coding-agent 0.63.0 (renovate bump 637c4f17, 2026-03-27) inserted
+ * `headers?: Record<string, string>` at slot 4 of `generateSummary`,
+ * shifting `signal?: AbortSignal` to slot 5. The local ambient stub at
+ * `pi-coding-agent-compaction.d.ts` was originally written against 0.57
+ * and silently kept `signal?` at slot 4 — so our positional caller in
+ * `core/context-compaction.ts` passed the AbortSignal into the new
+ * `headers` slot and the Adobe LLM proxy lost `X-Session-Id` for every
+ * compaction summary. The bug was only caught weeks later via proxy
+ * telemetry (commit a78968dc).
+ *
+ * This file is a tripwire on the slot positions that carry semantic load
+ * for the Adobe proxy contract:
+ *
+ *   slot 4: headers ──── must accept `Record<string, string>`
+ *   slot 5: signal  ──── must accept `AbortSignal`
+ *
+ * Scope (be honest about it):
+ *
+ *   - Catches: a future stub edit that swaps these slots back, or a
+ *     renovate-bump-plus-stub-update PR that gets the new shape wrong.
+ *   - Does NOT catch: a renovate bump that ships without any stub edit.
+ *     The local ambient `declare module` shadows upstream resolution
+ *     under `moduleResolution: bundler`, so tsc never reads upstream's
+ *     real `.d.ts`. Catching that class of drift would require either an
+ *     upstream PR exposing `./dist/*` in the package's exports map (so
+ *     we can drop the stub), or a tsconfig `paths` mapping that bypasses
+ *     the exports map (which surfaces unrelated pre-existing type
+ *     tensions in scoop-context.ts and core/session.ts — out of scope
+ *     for this commit).
+ *
+ * The file emits no runtime code worth keeping; the `void _checkN`
+ * lines exist purely to anchor the assertions in a value position so
+ * tsc has something to fail on if the contract breaks.
+ */
+
+import type { generateSummary } from '@mariozechner/pi-coding-agent/dist/core/compaction/compaction.js';
+
+type Params = Parameters<typeof generateSummary>;
+
+// If slot 4 stops accepting `Record<string, string>`, the conditional
+// resolves to `never` and the assignment below fails to compile.
+type _Slot4HeadersContract = Params[4] extends Record<string, string> | undefined ? true : never;
+
+// If `signal?` slides back to slot 4 (or any other shape lands at slot 5),
+// this assignment fails to compile.
+type _Slot5SignalContract = Params[5] extends AbortSignal | undefined ? true : never;
+
+const _slot4Check: _Slot4HeadersContract = true;
+const _slot5Check: _Slot5SignalContract = true;
+void _slot4Check;
+void _slot5Check;

--- a/packages/webapp/src/types/pi-coding-agent-compaction.d.ts
+++ b/packages/webapp/src/types/pi-coding-agent-compaction.d.ts
@@ -10,7 +10,7 @@
  */
 declare module '@mariozechner/pi-coding-agent/dist/core/compaction/compaction.js' {
   import type { AgentMessage } from '@mariozechner/pi-agent-core';
-  import type { Model } from '@mariozechner/pi-ai';
+  import type { Api, Model } from '@mariozechner/pi-ai';
 
   export interface CompactionSettings {
     enabled: boolean;
@@ -30,9 +30,10 @@ declare module '@mariozechner/pi-coding-agent/dist/core/compaction/compaction.js
 
   export function generateSummary(
     currentMessages: AgentMessage[],
-    model: Model<any>,
+    model: Model<Api>,
     reserveTokens: number,
     apiKey: string,
+    headers?: Record<string, string>,
     signal?: AbortSignal,
     customInstructions?: string,
     previousSummary?: string

--- a/packages/webapp/tests/core/context-compaction.test.ts
+++ b/packages/webapp/tests/core/context-compaction.test.ts
@@ -1,11 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { AgentMessage } from '@mariozechner/pi-agent-core';
+import type { Api, Model } from '@mariozechner/pi-ai';
+
+/** Structural views used in test helpers and assertions to avoid `any`. */
+type TestContentBlock = {
+  type: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
+};
+type TestMessage = {
+  role: string;
+  content: TestContentBlock[] | string;
+  toolCallId?: string;
+};
+type CompactionSettingsArg = { enabled: boolean; reserveTokens: number; keepRecentTokens: number };
 
 const mockGenerateSummary = vi.fn().mockResolvedValue('## Summary\nGoal: testing\nProgress: done');
 
 // Mock the pi-coding-agent compaction submodule (deep import path used in context-compaction.ts)
 vi.mock('@mariozechner/pi-coding-agent/dist/core/compaction/compaction.js', () => ({
-  estimateTokens: (msg: any) => {
+  estimateTokens: (msg: TestMessage) => {
     // Simple chars/4 heuristic matching the real implementation
     let chars = 0;
     if (Array.isArray(msg.content)) {
@@ -15,11 +31,15 @@ vi.mock('@mariozechner/pi-coding-agent/dist/core/compaction/compaction.js', () =
     }
     return Math.ceil(chars / 4);
   },
-  shouldCompact: (contextTokens: number, contextWindow: number, settings: any) => {
+  shouldCompact: (
+    contextTokens: number,
+    contextWindow: number,
+    settings: CompactionSettingsArg
+  ) => {
     if (!settings.enabled) return false;
     return contextTokens > contextWindow - settings.reserveTokens;
   },
-  generateSummary: (...args: any[]) => mockGenerateSummary(...args),
+  generateSummary: (...args: unknown[]) => mockGenerateSummary(...args),
   DEFAULT_COMPACTION_SETTINGS: {
     enabled: true,
     reserveTokens: 16384,
@@ -29,12 +49,25 @@ vi.mock('@mariozechner/pi-coding-agent/dist/core/compaction/compaction.js', () =
 
 import { compactContext, createCompactContext } from '../../src/core/context-compaction.js';
 
+/** Cast helper used in assertions where a typed AgentMessage view of an array of content blocks is needed. */
+function asTestMessage(message: AgentMessage): TestMessage {
+  return message as unknown as TestMessage;
+}
+
+/** Read the text of the first content block on an `AgentMessage`. Tests assert on this often. */
+function firstText(message: AgentMessage): string {
+  const content = asTestMessage(message).content;
+  if (!Array.isArray(content)) return '';
+  return content[0]?.text ?? '';
+}
+
 /** Helper to create an AgentMessage */
 function createMessage(role: 'user' | 'assistant' | 'toolResult', text: string): AgentMessage {
   return {
     role,
     content: [{ type: 'text' as const, text }],
-  } as any;
+    timestamp: 0,
+  } as unknown as AgentMessage;
 }
 
 /** Helper to create a toolResult message */
@@ -42,8 +75,11 @@ function createToolResult(text: string, toolCallId = 'tool-1'): AgentMessage {
   return {
     role: 'toolResult',
     toolCallId,
+    toolName: 'test_tool',
     content: [{ type: 'text' as const, text }],
-  } as any;
+    isError: false,
+    timestamp: 0,
+  } as unknown as AgentMessage;
 }
 
 /** Helper to create an assistant message with tool calls */
@@ -59,7 +95,8 @@ function createAssistantWithToolCalls(text: string, toolCallIds: string[]): Agen
         arguments: {},
       })),
     ],
-  } as any;
+    timestamp: 0,
+  } as unknown as AgentMessage;
 }
 
 describe('compactContext (legacy)', () => {
@@ -89,7 +126,7 @@ describe('compactContext (legacy)', () => {
     // Should be smaller than original
     expect(result.length).toBeLessThan(messages.length);
     // First message should be the compaction marker
-    expect((result[0].content as any)[0].text).toContain('Earlier conversation');
+    expect(firstText(result[0])).toContain('Earlier conversation');
   });
 
   it('inserts compaction marker', async () => {
@@ -99,8 +136,7 @@ describe('compactContext (legacy)', () => {
     const result = await compactContext(messages);
 
     const marker = result.find(
-      (msg) =>
-        msg.role === 'user' && (msg.content as any)[0]?.text?.includes('Earlier conversation')
+      (msg) => msg.role === 'user' && firstText(msg).includes('Earlier conversation')
     );
     expect(marker).toBeDefined();
     expect(marker!.role).toBe('user');
@@ -127,14 +163,14 @@ describe('compactContext (legacy)', () => {
 
     // Every toolResult must have a preceding assistant with matching toolCall
     for (let i = 0; i < result.length; i++) {
-      const msg = result[i] as any;
+      const msg = asTestMessage(result[i]);
       if (msg.role === 'toolResult' && msg.toolCallId) {
         let found = false;
         for (let j = i - 1; j >= 0; j--) {
-          const prev = result[j] as any;
+          const prev = asTestMessage(result[j]);
           if (prev.role === 'assistant' && Array.isArray(prev.content)) {
             const hasToolCall = prev.content.some(
-              (c: any) => c.type === 'toolCall' && c.id === msg.toolCallId
+              (c: TestContentBlock) => c.type === 'toolCall' && c.id === msg.toolCallId
             );
             if (hasToolCall) {
               found = true;
@@ -184,14 +220,14 @@ describe('compactContext (legacy)', () => {
 
     // If toolResult t1 is in the result, its assistant must also be present
     for (let i = 0; i < result.length; i++) {
-      const msg = result[i] as any;
+      const msg = asTestMessage(result[i]);
       if (msg.role === 'toolResult' && msg.toolCallId) {
         let found = false;
         for (let j = i - 1; j >= 0; j--) {
-          const prev = result[j] as any;
+          const prev = asTestMessage(result[j]);
           if (prev.role === 'assistant' && Array.isArray(prev.content)) {
             const hasToolCall = prev.content.some(
-              (c: any) => c.type === 'toolCall' && c.id === msg.toolCallId
+              (c: TestContentBlock) => c.type === 'toolCall' && c.id === msg.toolCallId
             );
             if (hasToolCall) {
               found = true;
@@ -207,7 +243,7 @@ describe('compactContext (legacy)', () => {
 });
 
 describe('createCompactContext', () => {
-  const mockModel = { id: 'test-model' } as any;
+  const mockModel = { id: 'test-model' } as unknown as Model<Api>;
   const mockConfig = {
     model: mockModel,
     getApiKey: () => 'test-key' as string | undefined,
@@ -245,8 +281,8 @@ describe('createCompactContext', () => {
     expect(mockGenerateSummary).toHaveBeenCalledOnce();
     // Result should contain the summary + kept recent messages
     expect(result.length).toBeLessThan(messages.length);
-    expect((result[0].content as any)[0].text).toContain('<context-summary>');
-    expect((result[0].content as any)[0].text).toContain('Summary');
+    expect(firstText(result[0])).toContain('<context-summary>');
+    expect(firstText(result[0])).toContain('Summary');
   });
 
   it('preserves recent messages after summarization', async () => {
@@ -262,7 +298,7 @@ describe('createCompactContext', () => {
 
     // Last messages should be preserved
     const lastMsg = result[result.length - 1];
-    expect((lastMsg.content as any)[0].text).toBe('recent-2');
+    expect(firstText(lastMsg)).toBe('recent-2');
   });
 
   it('falls back to naive drop when generateSummary fails', async () => {
@@ -276,7 +312,7 @@ describe('createCompactContext', () => {
 
     // Should still compact, just without summary
     expect(result.length).toBeLessThan(messages.length);
-    expect((result[0].content as any)[0].text).toContain('Earlier conversation');
+    expect(firstText(result[0])).toContain('Earlier conversation');
   });
 
   it('falls back to naive drop when no API key', async () => {
@@ -291,7 +327,7 @@ describe('createCompactContext', () => {
 
     expect(mockGenerateSummary).not.toHaveBeenCalled();
     expect(result.length).toBeLessThan(messages.length);
-    expect((result[0].content as any)[0].text).toContain('Earlier conversation');
+    expect(firstText(result[0])).toContain('Earlier conversation');
   });
 
   it('does not split assistant+toolResult pairs', async () => {
@@ -311,14 +347,14 @@ describe('createCompactContext', () => {
 
     // Every toolResult must have its assistant
     for (let i = 0; i < result.length; i++) {
-      const msg = result[i] as any;
+      const msg = asTestMessage(result[i]);
       if (msg.role === 'toolResult' && msg.toolCallId) {
         let found = false;
         for (let j = i - 1; j >= 0; j--) {
-          const prev = result[j] as any;
+          const prev = asTestMessage(result[j]);
           if (prev.role === 'assistant' && Array.isArray(prev.content)) {
             const hasToolCall = prev.content.some(
-              (c: any) => c.type === 'toolCall' && c.id === msg.toolCallId
+              (c: TestContentBlock) => c.type === 'toolCall' && c.id === msg.toolCallId
             );
             if (hasToolCall) {
               found = true;
@@ -354,7 +390,7 @@ describe('createCompactContext', () => {
 
     const result = await compact(messages);
 
-    const summaryText = (result[0].content as any)[0].text;
+    const summaryText = firstText(result[0]);
     expect(summaryText).toMatch(/^<context-summary>\n/);
     expect(summaryText).toMatch(/\n<\/context-summary>$/);
   });
@@ -368,9 +404,11 @@ describe('createCompactContext', () => {
     await compact(messages, controller.signal);
 
     expect(mockGenerateSummary).toHaveBeenCalledOnce();
-    // 5th argument is the signal
+    // pi-coding-agent generateSummary positional signature is
+    //   (messages, model, reserveTokens, apiKey, headers, signal, ...)
+    // signal lands at index 5; index 4 is reserved for headers.
     const callArgs = mockGenerateSummary.mock.calls[0];
-    expect(callArgs[4]).toBe(controller.signal);
+    expect(callArgs[5]).toBe(controller.signal);
   });
 
   it('passes model and reserveTokens to generateSummary', async () => {
@@ -384,10 +422,41 @@ describe('createCompactContext', () => {
     await compact(messages);
 
     const callArgs = mockGenerateSummary.mock.calls[0];
-    // generateSummary(messages, model, reserveTokens, apiKey, signal)
+    // generateSummary(messages, model, reserveTokens, apiKey, headers, signal, ...)
     expect(callArgs[1]).toBe(mockConfig.model); // model
     expect(callArgs[2]).toBe(8000); // reserveTokens
     expect(callArgs[3]).toBe('test-key'); // apiKey
+  });
+
+  it('forwards configured headers to generateSummary', async () => {
+    // Regression test: SLICC's Adobe LLM proxy needs the X-Session-Id header
+    // on compaction calls. Without this wiring the header lands as undefined
+    // and the proxy falls back to its content-derived hash, fragmenting
+    // sessions across multiple ids.
+    const compact = createCompactContext({
+      ...mockConfig,
+      headers: { 'X-Session-Id': 'cone_42/abcd1234' },
+    });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+
+    await compact(messages);
+
+    expect(mockGenerateSummary).toHaveBeenCalledOnce();
+    const callArgs = mockGenerateSummary.mock.calls[0];
+    // headers lands at index 4 (between apiKey and signal).
+    expect(callArgs[4]).toEqual({ 'X-Session-Id': 'cone_42/abcd1234' });
+  });
+
+  it('passes undefined headers when not configured', async () => {
+    const compact = createCompactContext(mockConfig);
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+
+    await compact(messages);
+
+    const callArgs = mockGenerateSummary.mock.calls[0];
+    expect(callArgs[4]).toBeUndefined();
   });
 
   it('returns messages unchanged when single message exceeds window (no valid cut)', async () => {
@@ -417,6 +486,6 @@ describe('createCompactContext', () => {
     // Under threshold, messages pass through unchanged
     expect(result).toEqual(messages);
     // Tool result preserved at full size
-    expect((result[2].content as any)[0].text).toBe(largeResult);
+    expect(firstText(result[2])).toBe(largeResult);
   });
 });

--- a/packages/webapp/tests/scoops/scoop-context.session-id.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.session-id.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Regression coverage for the Adobe `X-Session-Id` wiring in `ScoopContext.init()`.
+ *
+ * Two paths must both attach the same identifier on the Adobe provider so the
+ * LLM proxy can group requests into a single logical session:
+ *
+ *  1. The agent's `streamFn` wrapper (Anthropic / OpenAI streaming).
+ *  2. The compaction `transformContext` returned by `createCompactContext`,
+ *     which calls pi-coding-agent's `completeSimple` directly and bypasses
+ *     the `streamFn` wrapper.
+ *
+ * Without (2), pi-mode summarization requests landed in the proxy without the
+ * header and were assigned a content-derived hex session id, fragmenting
+ * sessions and leaving Pi conversations unclassified in the dashboard.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RegisteredScoop } from '../../src/scoops/types.js';
+
+type AgentCtorOptions = {
+  streamFn?: unknown;
+  transformContext?: unknown;
+};
+
+type StreamFn = (
+  model: { provider: string },
+  context: unknown,
+  options?: { headers?: Record<string, string> }
+) => unknown;
+
+type CompactConfig = { headers?: Record<string, string> };
+
+const captures = vi.hoisted(() => ({
+  agentCtorCalls: [] as AgentCtorOptions[],
+  createCompactContextCalls: [] as CompactConfig[],
+  streamSimpleCalls: [] as Array<{
+    model: { provider: string };
+    options?: { headers?: Record<string, string> };
+  }>,
+}));
+
+const mocks = vi.hoisted(() => ({
+  resolveCurrentModel: vi.fn(() => ({ id: 'test-model', provider: 'anthropic' })),
+}));
+
+vi.mock('../../src/core/index.js', () => {
+  class MockAgent {
+    constructor(options: AgentCtorOptions) {
+      captures.agentCtorCalls.push(options);
+    }
+
+    subscribe = vi.fn(() => () => {});
+    abort = vi.fn();
+  }
+  return {
+    Agent: MockAgent,
+    adaptTools: (tools: unknown[]) => tools,
+    createLogger: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() }),
+  };
+});
+
+vi.mock('../../src/core/context-compaction.js', () => ({
+  createCompactContext: (config: CompactConfig) => {
+    captures.createCompactContextCalls.push(config);
+    return async (messages: unknown[]) => messages;
+  },
+}));
+
+vi.mock('@mariozechner/pi-ai', () => ({
+  isContextOverflow: () => false,
+  streamSimple: (
+    model: { provider: string },
+    _context: unknown,
+    options?: { headers?: Record<string, string> }
+  ) => {
+    captures.streamSimpleCalls.push({ model, options });
+    return { result: () => Promise.resolve(null) };
+  },
+  getSupportedThinkingLevels: () => ['off'],
+}));
+
+vi.mock('../../src/tools/index.js', () => ({
+  createFileTools: () => [],
+  createBashTool: () => ({ name: 'bash' }),
+}));
+
+vi.mock('../../src/shell/index.js', () => ({
+  WasmShell: vi.fn(function () {
+    return {};
+  }),
+}));
+
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => 'test-api-key',
+  getSelectedProvider: () => 'anthropic',
+  resolveCurrentModel: mocks.resolveCurrentModel,
+  resolveModelById: () => ({ id: 'test-model', provider: 'anthropic' }),
+}));
+
+vi.mock('../../src/scoops/skills.js', () => ({
+  createDefaultSkills: async () => {},
+  loadSkills: async () => [],
+  formatSkillsForPrompt: () => '',
+}));
+
+vi.mock('../../src/scoops/scoop-management-tools.js', () => ({
+  createScoopManagementTools: () => [],
+}));
+
+vi.mock('../../src/core/secret-env.js', () => ({
+  fetchSecretEnvVars: async () => ({}),
+}));
+
+const { ScoopContext } = await import('../../src/scoops/scoop-context.js');
+
+const baseScoop: RegisteredScoop = {
+  jid: 'cone_test_1',
+  name: 'cone',
+  folder: '',
+  isCone: true,
+  type: 'cone',
+  requiresTrigger: false,
+  assistantLabel: 'sliccy',
+  addedAt: new Date().toISOString(),
+};
+
+function createMockCallbacks() {
+  return {
+    onResponse: vi.fn(),
+    onResponseDone: vi.fn(),
+    onError: vi.fn(),
+    onStatusChange: vi.fn(),
+    onSendMessage: vi.fn(),
+    getScoops: vi.fn(() => []),
+    getGlobalMemory: vi.fn(async () => ''),
+    getBrowserAPI: vi.fn(() => ({})),
+  };
+}
+
+function createMockFs() {
+  const files = new Map<string, string>();
+  return {
+    mkdir: vi.fn(async () => {}),
+    readFile: vi.fn(async (path: string) => {
+      if (!files.has(path)) throw new Error('ENOENT');
+      return files.get(path)!;
+    }),
+    writeFile: vi.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    }),
+  };
+}
+
+describe('ScoopContext Adobe X-Session-Id wiring', () => {
+  beforeEach(() => {
+    captures.agentCtorCalls.length = 0;
+    captures.createCompactContextCalls.length = 0;
+    captures.streamSimpleCalls.length = 0;
+    mocks.resolveCurrentModel.mockReset();
+  });
+
+  it('forwards X-Session-Id to compaction headers when the model is Adobe', async () => {
+    mocks.resolveCurrentModel.mockReturnValue({ id: 'test-model', provider: 'adobe' });
+
+    const ctx = new ScoopContext(
+      baseScoop,
+      createMockCallbacks() as never,
+      createMockFs() as never
+    );
+    await ctx.init();
+
+    expect(captures.createCompactContextCalls).toHaveLength(1);
+    const passed = captures.createCompactContextCalls[0];
+    expect(passed.headers).toBeDefined();
+    expect(passed.headers!['X-Session-Id']).toEqual(expect.any(String));
+    expect(passed.headers!['X-Session-Id'].length).toBeGreaterThan(0);
+  });
+
+  it('omits compaction headers when the model is not Adobe', async () => {
+    mocks.resolveCurrentModel.mockReturnValue({ id: 'test-model', provider: 'anthropic' });
+
+    const ctx = new ScoopContext(
+      baseScoop,
+      createMockCallbacks() as never,
+      createMockFs() as never
+    );
+    await ctx.init();
+
+    expect(captures.createCompactContextCalls).toHaveLength(1);
+    expect(captures.createCompactContextCalls[0].headers).toBeUndefined();
+  });
+
+  it('streamFn injects X-Session-Id only when invoked with an Adobe model', async () => {
+    mocks.resolveCurrentModel.mockReturnValue({ id: 'test-model', provider: 'adobe' });
+
+    const ctx = new ScoopContext(
+      baseScoop,
+      createMockCallbacks() as never,
+      createMockFs() as never
+    );
+    await ctx.init();
+
+    expect(captures.agentCtorCalls).toHaveLength(1);
+    const streamFn = captures.agentCtorCalls[0].streamFn as StreamFn;
+    expect(typeof streamFn).toBe('function');
+
+    streamFn({ provider: 'adobe' }, { messages: [] });
+    streamFn({ provider: 'anthropic' }, { messages: [] });
+
+    expect(captures.streamSimpleCalls).toHaveLength(2);
+    expect(captures.streamSimpleCalls[0].options?.headers?.['X-Session-Id']).toEqual(
+      expect.any(String)
+    );
+    expect(captures.streamSimpleCalls[1].options?.headers).toBeUndefined();
+  });
+
+  it('uses the same X-Session-Id for streamFn and compaction headers', async () => {
+    // Both code paths must agree on the identifier or the proxy splits a single
+    // logical session into two clusters (one for tool turns, one for Pi
+    // summarization).
+    mocks.resolveCurrentModel.mockReturnValue({ id: 'test-model', provider: 'adobe' });
+
+    const ctx = new ScoopContext(
+      baseScoop,
+      createMockCallbacks() as never,
+      createMockFs() as never
+    );
+    await ctx.init();
+
+    const compactionId = captures.createCompactContextCalls[0].headers!['X-Session-Id'];
+    const streamFn = captures.agentCtorCalls[0].streamFn as StreamFn;
+    streamFn({ provider: 'adobe' }, { messages: [] });
+    const streamId = captures.streamSimpleCalls[0].options!.headers!['X-Session-Id'];
+
+    expect(compactionId).toBe(streamId);
+  });
+});


### PR DESCRIPTION
## Summary

- Pi-mode summarization calls (compaction) bypassed the `streamWithSessionId` wrapper installed by #378, so the Adobe LLM proxy fell back to a content-derived hex hash and Pi sessions appeared unclassified in the dashboard. Forwarded the same `X-Session-Id` through the `headers` option `pi-ai`'s `StreamOptions` already supports.
- Root cause: `pi-coding-agent` 0.63.0 (renovate bump 637c4f17, 2026-03-27) inserted `headers?` at slot 4 of `generateSummary` and shifted `signal?` to slot 5. The local ambient stub at `packages/webapp/src/types/pi-coding-agent-compaction.d.ts` kept the pre-0.63 shape, so our positional caller routed `AbortSignal` into the new `headers` slot. TypeScript stayed silent because the `declare module` shadows upstream resolution under `moduleResolution: bundler`.
- Added a compile-time positional contract (`packages/webapp/src/types/pi-coding-agent-compaction.contract.ts`) pinned to slot 4 (`headers`) and slot 5 (`signal`). If a future stub edit (manual or renovate-bump-plus-update) shifts those positions, `tsc` fails. Verified by reverse test: swapping the slots produces `Type 'true' is not assignable to type 'never'` exactly matching the original drift shape.

The contract catches drift in the local stub. Catching upstream-only drift (renovate bump that ships without any stub edit) requires either an upstream PR exposing `./dist/*` in pi-coding-agent's exports map (so we can drop the stub) or a `paths` mapping that bypasses the exports map (which surfaces unrelated pre-existing type tensions in `scoop-context.ts` and `core/session.ts` — out of scope here). Tracked separately.

## Verification SQL

After this lands, on `llm-monitoring-usage`:

```sql
SELECT date(created_at) AS day, COUNT(*) AS hex_events
FROM usage_events
WHERE created_at >= '2026-05-08T00:00:00Z'
  AND length(session_id) = 64
  AND session_id GLOB '[0-9a-f]*'
  AND session_id NOT LIKE '%-%'
GROUP BY day ORDER BY day DESC;
```

`hex_events` should drop to ~0 for new days; dash-format ids absorb the previously-Pi traffic.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test` (3590 pass, 3 unrelated skipped)
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npx prettier --check` on touched files
- [x] New tests: `tests/core/context-compaction.test.ts` (headers forwarded vs. undefined) and `tests/scoops/scoop-context.session-id.test.ts` (4 wiring tests covering Adobe / non-Adobe / streamFn / same-id-across-paths)
- [x] Tripwire reverse-tested by deliberately swapping `headers?` and `signal?` in the stub