### PR TITLE
refactor(fs/mount): drop consent dip for remote mounts

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -216,11 +216,9 @@ mount unmount --clear-cache /mnt/r2  # drops cache as well
 
 ### Approval flow
 
-Cone-initiated mounts always render an approval card before the mount lands. Backend-specific copy comes from `MountBackend.describeForApproval()`:
+Only **local** mounts render an approval card. The card is not a consent gate — it's the click that satisfies Chrome's user-gesture rule for the File System Access API, since `showDirectoryPicker()` must be invoked from inside a user event handler. In the extension, the click also routes through a popup window because Chrome crashes if the picker is invoked from side-panel context for system directories.
 
-- **Local**: "Approve and select directory" with the picker integration.
-- **S3**: "Approve mount of `s3://<bucket>/<prefix>` (profile `<name>`)".
-- **DA**: "Approve mount of `da://<org>/<repo>` using your IMS identity".
+**S3** and **DA** mounts have no approval card. The trust boundary lives at the credential profile resolver in node-server (`/api/s3-sign-and-forward`, `/api/da-sign-and-forward`) or the SW signing path in extension mode — not in the chat. The probe at mount time will fail with an actionable error if the profile is misconfigured.
 
 Local mounts are gated to cone context only because the directory picker requires a real user gesture. S3 and DA mounts are allowed from scoops since their credentials come from the secret store and no UI gesture is required.
 

--- a/packages/webapp/src/fs/mount-commands.ts
+++ b/packages/webapp/src/fs/mount-commands.ts
@@ -3,10 +3,16 @@
  * their respective backend factories. Handles flag parsing for --source,
  * --profile, --no-probe, --max-body-mb, --clear-cache, and --bodies.
  *
- * Local mounts (no --source) launch the picker UI (cone approval / extension popup / direct).
- * Remote mounts (s3://... or da://...) dispatch through resolveS3Profile / resolveDaProfile
- * and render approval cards for cone-initiated calls (no picker integration for remotes).
- * Scoop fail-fast moved into LocalMountBackend.create().
+ * Local mounts (no --source) launch the picker UI via LocalMountBackend.create
+ * (cone approval card + popup, extension terminal popup, or standalone direct
+ * picker). The click is required to satisfy Chrome's user-gesture rule for the
+ * File System Access API, not as a consent gate.
+ *
+ * Remote mounts (s3://... or da://...) build their backend, probe the source,
+ * and mount directly — no approval ceremony, since the trust boundary lives at
+ * the credential profile resolver in node-server / SW, not in the chat.
+ *
+ * Scoop fail-fast lives in LocalMountBackend.create().
  */
 
 import type { VirtualFS } from './virtual-fs.js';
@@ -16,7 +22,7 @@ import { DaMountBackend, type SignedFetchDa } from './mount/backend-da.js';
 import { RemoteMountCache } from './mount/remote-cache.js';
 import { makeSignedFetchS3, makeSignedFetchDa } from './mount/signed-fetch.js';
 import { newMountId } from './mount/mount-id.js';
-import { getToolExecutionContext, showToolUI, toolUIRegistry } from '../tools/tool-ui.js';
+import { getToolExecutionContext } from '../tools/tool-ui.js';
 
 export interface MountCommandResult {
   stdout: string;
@@ -198,22 +204,6 @@ export class MountCommands {
       }
     }
 
-    // Cone-initiated: render approval card.
-    const ctx = getToolExecutionContext();
-    if (ctx) {
-      const approved = await this.renderApprovalCard(
-        {
-          summary: `Mount S3: ${parsed.source}`,
-          needsPicker: false,
-        },
-        ctx
-      );
-      if (!approved) {
-        await backend.close();
-        return { stdout: '', stderr: 'mount: denied by user\n', exitCode: 1 };
-      }
-    }
-
     await this.options.fs.mount(targetPath, backend);
     const desc = backend.describe();
     return {
@@ -254,22 +244,6 @@ export class MountCommands {
           stderr: `mount: probe failed for ${parsed.source} — ${err instanceof Error ? err.message : String(err)}\n`,
           exitCode: 1,
         };
-      }
-    }
-
-    // Cone-initiated: render approval card.
-    const ctx = getToolExecutionContext();
-    if (ctx) {
-      const approved = await this.renderApprovalCard(
-        {
-          summary: `Mount DA: ${parsed.source}`,
-          needsPicker: false,
-        },
-        ctx
-      );
-      if (!approved) {
-        await backend.close();
-        return { stdout: '', stderr: 'mount: denied by user\n', exitCode: 1 };
       }
     }
 
@@ -387,57 +361,6 @@ export class MountCommands {
         exitCode: 1,
       };
     }
-  }
-
-  private async renderApprovalCard(
-    copy: { summary: string; needsPicker: boolean },
-    ctx: Exclude<ReturnType<typeof getToolExecutionContext>, null>
-  ): Promise<boolean> {
-    const uiRequestId = toolUIRegistry.generateId();
-    let timedOut = false;
-    const TIMEOUT_MS = 5 * 60 * 1000;
-
-    const rawUiPromise = showToolUI(
-      {
-        id: uiRequestId,
-        html: `
-        <div class="sprinkle-action-card">
-          <div class="sprinkle-action-card__header">${copy.summary} <span class="sprinkle-badge sprinkle-badge--notice">approval</span></div>
-          <div class="sprinkle-action-card__actions">
-            <button class="sprinkle-btn sprinkle-btn--secondary" data-action="deny">Deny</button>
-            <button class="sprinkle-btn sprinkle-btn--primary" data-action="approve">Approve</button>
-          </div>
-        </div>
-      `,
-        onAction: async (action) => {
-          if (action === 'approve') {
-            return { approved: true };
-          }
-          return { denied: true };
-        },
-      },
-      ctx.onUpdate
-    );
-
-    const safeUiPromise = rawUiPromise.catch((err: unknown) => {
-      if (timedOut) return { timeout: true };
-      throw err;
-    });
-
-    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-    const timeoutPromise = new Promise<{ timeout: true }>((resolve) => {
-      timeoutHandle = setTimeout(() => {
-        timedOut = true;
-        toolUIRegistry.cancel(uiRequestId, 'mount: timed out');
-        resolve({ timeout: true });
-      }, TIMEOUT_MS);
-    });
-
-    const result = await Promise.race([safeUiPromise, timeoutPromise]);
-    if (timeoutHandle) clearTimeout(timeoutHandle);
-
-    const res = result as { approved?: boolean; denied?: boolean; timeout?: boolean };
-    return res.approved === true;
   }
 
   private resolvePath(target: string, cwd: string): string {

--- a/packages/webapp/src/fs/mount/backend-da.ts
+++ b/packages/webapp/src/fs/mount/backend-da.ts
@@ -24,7 +24,6 @@ import type {
   MountDirEntry,
   MountStat,
   MountDescription,
-  MountApprovalCopy,
   RefreshReport,
 } from './backend.js';
 import { type RemoteMountCache } from './remote-cache.js';
@@ -499,13 +498,6 @@ export class DaMountBackend implements MountBackend {
       displayName: `${this.parsed.org}/${this.parsed.repo}${this.parsed.path ? `/${this.parsed.path}` : ''}`,
       source: this.source,
       profile: this.profile,
-    };
-  }
-
-  describeForApproval(): MountApprovalCopy {
-    return {
-      summary: `Approve mount of \`${this.source}\` using your IMS identity`,
-      needsPicker: false,
     };
   }
 

--- a/packages/webapp/src/fs/mount/backend-local.ts
+++ b/packages/webapp/src/fs/mount/backend-local.ts
@@ -1,9 +1,20 @@
 /**
  * `LocalMountBackend` wraps a `FileSystemDirectoryHandle` and implements
- * `MountBackend` on top of the File System Access API. Lifts the read/write
- * paths that previously lived directly in `virtual-fs.ts`; the picker dance
- * (cone approval, extension popup, standalone direct picker) lifts in a
- * follow-up task as the `create()` factory.
+ * `MountBackend` over the File System Access API.
+ *
+ * The static `create()` factory drives the picker dance — required because
+ * `showDirectoryPicker()` must run inside a real user gesture, and because
+ * Chrome crashes when the picker is invoked from side-panel context for
+ * system directories. Three picker contexts are handled:
+ *   - cone (toolContext present) — render approval card via `showToolUI`,
+ *     then either route the click through the extension popup
+ *     (`openMountPickerPopup`, surfaced via `data-picker="directory"`) or
+ *     run the picker inline (standalone)
+ *   - extension terminal (no toolContext, isExtension true) — popup picker
+ *   - standalone (no toolContext, no extension) — direct picker
+ *
+ * `create()` also enforces scoop fail-fast: scoops have no human at chat to
+ * approve a picker, so they get an immediate error.
  */
 
 import { FsError } from '../types.js';

--- a/packages/webapp/src/fs/mount/backend-local.ts
+++ b/packages/webapp/src/fs/mount/backend-local.ts
@@ -6,12 +6,15 @@
  * `showDirectoryPicker()` must run inside a real user gesture, and because
  * Chrome crashes when the picker is invoked from side-panel context for
  * system directories. Three picker contexts are handled:
- *   - cone (toolContext present) — render approval card via `showToolUI`,
- *     then either route the click through the extension popup
- *     (`openMountPickerPopup`, surfaced via `data-picker="directory"`) or
- *     run the picker inline (standalone)
- *   - extension terminal (no toolContext, isExtension true) — popup picker
- *   - standalone (no toolContext, no extension) — direct picker
+ *   - cone (toolContext present) — render approval card via `showToolUI`.
+ *     The factory itself only ever calls `showDirectoryPicker()` inline
+ *     from `onAction`; the popup detour for the extension is invisible
+ *     here — the panel-side `tool-ui-renderer.ts` transparently swaps in
+ *     `openMountPickerPopup` for buttons marked `data-picker="directory"`
+ *     and posts back `{ handleInIdb, idbKey }`, which `create()` then
+ *     resolves via `loadAndClearPendingHandle` + `reactivateHandle`.
+ *   - extension terminal (no toolContext, isExtension true) — popup picker.
+ *   - standalone (no toolContext, no extension) — direct picker.
  *
  * `create()` also enforces scoop fail-fast: scoops have no human at chat to
  * approve a picker, so they get an immediate error.

--- a/packages/webapp/src/fs/mount/backend-local.ts
+++ b/packages/webapp/src/fs/mount/backend-local.ts
@@ -18,7 +18,6 @@ import type {
   MountDirEntry,
   MountStat,
   MountDescription,
-  MountApprovalCopy,
   RefreshReport,
 } from './backend.js';
 
@@ -414,15 +413,6 @@ export class LocalMountBackend implements MountBackend {
 
   describe(): MountDescription {
     return { displayName: this.handle.name };
-  }
-
-  describeForApproval(): MountApprovalCopy {
-    return {
-      summary: `Mount local directory '${this.handle.name}'`,
-      // `create()` factory owns the picker; reactivation after recovery
-      // needs a separate user gesture flow not driven from here.
-      needsPicker: false,
-    };
   }
 
   async close(): Promise<void> {

--- a/packages/webapp/src/fs/mount/backend-s3.ts
+++ b/packages/webapp/src/fs/mount/backend-s3.ts
@@ -26,7 +26,6 @@ import type {
   MountDirEntry,
   MountStat,
   MountDescription,
-  MountApprovalCopy,
   RefreshReport,
 } from './backend.js';
 import { type RemoteMountCache } from './remote-cache.js';
@@ -512,13 +511,6 @@ export class S3MountBackend implements MountBackend {
         : this.parsed.bucket,
       source: this.source,
       profile: this.profile,
-    };
-  }
-
-  describeForApproval(): MountApprovalCopy {
-    return {
-      summary: `Approve mount of \`${this.source}\` (profile \`${this.profile}\`)`,
-      needsPicker: false,
     };
   }
 

--- a/packages/webapp/src/fs/mount/backend.ts
+++ b/packages/webapp/src/fs/mount/backend.ts
@@ -57,17 +57,6 @@ export interface MountDescription {
   extra?: string;
 }
 
-/**
- * Approval-card copy used by mount-commands.ts when a cone-initiated mount
- * needs user confirmation. Never used outside the approval flow — keep
- * approval strings out of `MountDescription`.
- */
-export interface MountApprovalCopy {
-  summary: string;
-  needsPicker: boolean;
-  pickerKind?: 'directory';
-}
-
 export interface MountBackend {
   readonly kind: MountKind;
   /** URL form: 's3://bucket/prefix', 'da://org/repo', undefined for local. */
@@ -90,7 +79,6 @@ export interface MountBackend {
   refresh(opts?: { bodies?: boolean }): Promise<RefreshReport>;
 
   describe(): MountDescription;
-  describeForApproval(): MountApprovalCopy;
 
   /**
    * Lifecycle: marks the backend closed (subsequent ops throw EBADF), aborts

--- a/packages/webapp/src/fs/mount/index.ts
+++ b/packages/webapp/src/fs/mount/index.ts
@@ -6,7 +6,6 @@ export type {
   MountStat,
   RefreshReport,
   MountDescription,
-  MountApprovalCopy,
   MountBackend,
 } from './backend.js';
 export { RemoteMountCache } from './remote-cache.js';

--- a/packages/webapp/tests/fs/mount-commands.test.ts
+++ b/packages/webapp/tests/fs/mount-commands.test.ts
@@ -284,6 +284,73 @@ describe('MountCommands', () => {
       expect(backend.kind).toBe('da');
       expect(backend.source).toBe('da://my-org/my-repo');
     });
+
+    // Lock-down for the new contract (PR #603): remote mounts mount directly
+    // even when called from a cone-style ToolExecutionContext. A regression
+    // that re-introduces an Approve/Deny dip would register a `tool_ui`
+    // entry on toolUIRegistry and emit a `tool_ui` content block on
+    // ctx.onUpdate; both must stay zero for s3:// and da://.
+    it('s3:// in cone (tool) context mounts directly without registering a tool_ui', async () => {
+      const fs = makeFs();
+      const onUpdate = vi.fn();
+      const ctx: ToolExecutionContext = pushToolExecutionContext({
+        onUpdate,
+        toolName: 'bash',
+        toolCallId: 'tc-mount-s3-no-consent',
+      });
+      try {
+        const cmd = new MountCommands({
+          fs,
+          signedFetchS3: async () => new Response('', { status: 200 }),
+        });
+        const pendingBefore = toolUIRegistry.getPendingIds().length;
+        const result = await cmd.execute(
+          ['--source', 's3://b/p', '--no-probe', '/mnt/r2'],
+          '/workspace'
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(toolUIRegistry.getPendingIds().length).toBe(pendingBefore);
+        const blocks = onUpdate.mock.calls.flatMap(
+          (call) => (call[0]?.content ?? []) as Array<{ type?: string }>
+        );
+        expect(blocks.some((b) => b.type === 'tool_ui')).toBe(false);
+        expect(fs.mount as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+      } finally {
+        popToolExecutionContext(ctx);
+      }
+    });
+
+    it('da:// in cone (tool) context mounts directly without registering a tool_ui', async () => {
+      const fs = makeFs();
+      const onUpdate = vi.fn();
+      const ctx: ToolExecutionContext = pushToolExecutionContext({
+        onUpdate,
+        toolName: 'bash',
+        toolCallId: 'tc-mount-da-no-consent',
+      });
+      try {
+        const cmd = new MountCommands({
+          fs,
+          signedFetchDa: async () => new Response('[]', { status: 200 }),
+        });
+        const pendingBefore = toolUIRegistry.getPendingIds().length;
+        const result = await cmd.execute(
+          ['--source', 'da://my-org/my-repo', '--no-probe', '/mnt/da'],
+          '/workspace'
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(toolUIRegistry.getPendingIds().length).toBe(pendingBefore);
+        const blocks = onUpdate.mock.calls.flatMap(
+          (call) => (call[0]?.content ?? []) as Array<{ type?: string }>
+        );
+        expect(blocks.some((b) => b.type === 'tool_ui')).toBe(false);
+        expect(fs.mount as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+      } finally {
+        popToolExecutionContext(ctx);
+      }
+    });
   });
 
   describe('mount refresh outputs RefreshReport summary', () => {

--- a/packages/webapp/tests/fs/mount/backend-local.test.ts
+++ b/packages/webapp/tests/fs/mount/backend-local.test.ts
@@ -102,14 +102,6 @@ describe('LocalMountBackend basic ops', () => {
     const backend = LocalMountBackend.fromHandle(handle, { mountId: 'm1' });
     expect(backend.describe()).toEqual({ displayName: 'my-dir' });
   });
-
-  it('describeForApproval references the handle name', async () => {
-    const handle = createDirectoryHandle({}, 'my-dir');
-    const backend = LocalMountBackend.fromHandle(handle, { mountId: 'm1' });
-    const copy = backend.describeForApproval();
-    expect(copy.summary).toContain('my-dir');
-    expect(copy.needsPicker).toBe(false);
-  });
 });
 
 describe('LocalMountBackend close lifecycle', () => {


### PR DESCRIPTION
## Summary

- The mount approval dip (Approve/Deny card in chat) was added to satisfy Chrome's user-gesture rule for `showDirectoryPicker()` — not as a real consent gate. It was applied uniformly to local, S3, and DA mounts even though only local needs it.
- This PR drops the dip for `s3://` and `da://` mounts. They now probe and mount directly. The trust boundary stays where it actually lives: the credential profile resolver in node-server (`/api/s3-sign-and-forward`, `/api/da-sign-and-forward`) and the SW signing path in extension mode.
- Local-mount approval (`LocalMountBackend.create`) is **unchanged**. Cone-in-extension still routes through the popup window via `data-picker="directory"` → `openMountPickerPopup` → IDB handle handoff (`loadAndClearPendingHandle` + `reactivateHandle`). That popup exists because Chrome crashes when `showDirectoryPicker()` runs from side-panel context for system directories, and because terminal-mode mounts (no dip) need the popup to satisfy the user-gesture rule.
- Bundled cleanup: removed the now-unused `MountApprovalCopy` type, the `describeForApproval()` interface method on `MountBackend`, all three backend implementations of it, the `backend-local.test.ts` unit test that exercised it in isolation, the orphan `renderApprovalCard` helper in `mount-commands.ts`, and the barrel re-export. No orphan API.

8 files changed, **13 insertions / 139 deletions**.

## Test plan

Unit / integration:
- [x] `npm run typecheck` (cli + browser + worker) — pass
- [x] `npm run test` — 3627 pass / 3 skipped / 0 failing
- [x] `npm run test:coverage` — above per-package floors (statements 65.76%, branches 56.20%, functions 67.52%, lines 67.24%)
- [x] `npm run build -w @slicc/webapp` — pass
- [x] `npm run build -w @slicc/node-server` — pass
- [x] `npm run build -w @slicc/cloudflare-worker` — pass
- [x] `npm run build -w @slicc/chrome-extension` — pass

End-to-end smoke (please run before merge — divergent behaviors must all hold):
- [ ] **Remote, CLI**: `npm run dev -- --prompt "mount --source s3://<bucket> --profile <profile> /mnt/r2"` — expect `Mounted '<bucket>' → /mnt/r2 (profile: ...)` with **no Approve/Deny card** between the prompt and the success line. Repeat with `--source da://<org>/<repo>`.
- [ ] **Local cone, CLI**: `npm run dev -- --prompt "mount /mnt/local"` — approval card with "Select directory" button still appears; click opens the native directory picker in the same window.
- [ ] **Local cone, Extension**: `SLICC_EXT_DEV=1 npm run build -w @slicc/chrome-extension`, side-load, ask the cone to mount a local dir — dip in chat → click "Select directory" → **popup window opens** → click Approve in popup → native picker → mount lands.
- [ ] **Local terminal, Extension**: in the side-panel terminal, run `mount /mnt/local` — **no dip**, but a popup opens with the Approve button → picker → mount lands.
- [ ] **Local terminal, CLI**: in the standalone, run `mount /mnt/local` from the terminal panel — native picker opens directly, no dip and no popup.
- [ ] In all cases finish with `mount list` to confirm the entry; in (1) also `ls /mnt/r2` to confirm the backend is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)