### PR TITLE
feat(chat): stream dip preview into iframe as agent writes shtml

### DIFF
--- a/packages/chrome-extension/sprinkle-sandbox.html
+++ b/packages/chrome-extension/sprinkle-sandbox.html
@@ -375,6 +375,17 @@ addEventListener('message', function(e) {
     return;
   }
 
+  // Streaming-draft body updates: the parent posts incremental shtml
+  // content while the agent is still writing the block. The nested
+  // iframe's DRAFT_BRIDGE_EXTENSION listener swaps document.body.innerHTML
+  // on each message. We just relay — the child does the actual work.
+  if (e.source === parent && msg.type === 'dip-draft-update') {
+    if (window.__slicc_childIframe && window.__slicc_childIframe.contentWindow) {
+      window.__slicc_childIframe.contentWindow.postMessage(msg, '*');
+    }
+    return;
+  }
+
   if (msg.type === 'sprinkle-render') {
     // Apply initial theme class so CSS variables resolve correctly on first paint.
     if (typeof msg.isLight === 'boolean') {
@@ -526,6 +537,25 @@ addEventListener('message', function(e) {
     inlineIframe.srcdoc = msg.srcdoc;
     document.body.appendChild(inlineIframe);
     window.__slicc_childIframe = inlineIframe;
+  }
+
+  // ── Streaming-draft dip rendering (extension mode) ─────
+  // Same shape as `dip-render`, but the inner iframe is non-interactive
+  // (`pointer-events: none`) until stream end — a final `dip-render`
+  // replaces this draft once the cone finishes the block. The srcdoc
+  // already includes the DRAFT_BRIDGE_EXTENSION listener, so subsequent
+  // `dip-draft-update` messages relayed from the parent can swap the
+  // body content without touching the iframe wrapper.
+  if (msg.type === 'dip-draft-render') {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+    var draftIframe = document.createElement('iframe');
+    draftIframe.setAttribute('sandbox', 'allow-scripts');
+    draftIframe.style.cssText =
+      'width: 100%; height: 100%; border: none; overflow: hidden; pointer-events: none;';
+    document.body.style.overflow = 'hidden';
+    draftIframe.srcdoc = msg.srcdoc;
+    document.body.appendChild(draftIframe);
+    window.__slicc_childIframe = draftIframe;
   }
 
   // Relay bridge messages FROM the nested child iframe TO the extension page.

--- a/packages/chrome-extension/tests/sprinkle-sandbox.test.ts
+++ b/packages/chrome-extension/tests/sprinkle-sandbox.test.ts
@@ -130,3 +130,27 @@ describe('sprinkle-sandbox.html extension sandbox fixes', () => {
     expect(mainScript).toContain('unsupported src');
   });
 });
+
+describe('sprinkle-sandbox.html streaming-draft dip support', () => {
+  it('handles dip-draft-render by mounting a non-interactive child iframe', () => {
+    const scripts = extractScriptBlocks(sandboxHtml);
+    const mainScript = scripts.find((s) => s.includes("msg.type === 'dip-draft-render'"));
+    expect(mainScript, 'no dip-draft-render handler found').toBeTruthy();
+    // The child iframe must be non-interactive while the agent streams
+    // partial markup — same security/UX guarantee as the standalone path.
+    expect(mainScript).toContain('pointer-events: none');
+    // It must use srcdoc + sandbox just like the final dip-render path.
+    expect(mainScript).toContain('msg.srcdoc');
+    expect(mainScript).toContain("'allow-scripts'");
+  });
+
+  it('relays dip-draft-update from parent to nested child iframe', () => {
+    const scripts = extractScriptBlocks(sandboxHtml);
+    const relayScript = scripts.find((s) => s.includes("msg.type === 'dip-draft-update'"));
+    expect(relayScript, 'no dip-draft-update relay found').toBeTruthy();
+    // The relay must forward to __slicc_childIframe — that's where
+    // DRAFT_BRIDGE_EXTENSION listens and replaces document.body.innerHTML.
+    expect(relayScript).toContain('__slicc_childIframe');
+    expect(relayScript).toContain('postMessage');
+  });
+});

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -1639,9 +1639,9 @@ export class ChatPanel {
         if (!draft) {
           draft = mountDraftDip((action, data) => this.onDipLick?.(action, data));
           drafts[shtmlIdx] = draft;
-          if (draft) container.appendChild(draft.element);
+          container.appendChild(draft.element);
         }
-        if (draft && container.dataset.body !== seg.body) {
+        if (container.dataset.body !== seg.body) {
           draft.update(seg.body);
           container.dataset.body = seg.body;
         }

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -16,7 +16,14 @@ import { formatAttachmentSize, formatAttachmentSummary } from '../core/attachmen
 import { getMimeType } from '../core/mime-types.js';
 import { processImageContent, isSupportedImageFormat } from '../core/image-processor.js';
 import { VoiceInput, getVoiceAutoSend, getVoiceLang } from './voice-input.js';
-import { hydrateDips, disposeDips, type DipInstance } from './dip.js';
+import {
+  hydrateDips,
+  disposeDips,
+  mountDraftDip,
+  splitContentSegments,
+  type DipInstance,
+  type DraftDipInstance,
+} from './dip.js';
 import { createToolUIRenderer, disposeToolUIRenderer } from './tool-ui-renderer.js';
 import {
   getToolDescriptor,
@@ -135,8 +142,22 @@ function isTextLikeFile(file: File, mimeType: string): boolean {
 
 function renderChatMessageContent(msg: ChatMessage): string {
   return msg.role === 'assistant'
-    ? renderAssistantMessageContent(msg.content)
+    ? renderAssistantMessageContent(msg.content, msg.isStreaming === true)
     : renderMessageContent(msg.content);
+}
+
+/**
+ * Render a single prose segment of a streaming assistant message. Called
+ * once per prose segment per flush by `renderStreamingSegmented`. The
+ * `isStreaming` flag is always false here because the caller has
+ * already split shtml fences out into their own segments — there's no
+ * shtml block in the prose to swap for a placeholder, and rendering
+ * with the streaming flag would only suppress legitimate code blocks.
+ */
+function renderProseSegment(text: string, role: ChatMessage['role']): string {
+  return role === 'assistant'
+    ? renderAssistantMessageContent(text, false)
+    : renderMessageContent(text);
 }
 
 /**
@@ -199,6 +220,16 @@ export class ChatPanel {
   private pendingDeltaText = '';
   private streamingRafId: number | null = null;
   private dips = new Map<string, DipInstance[]>();
+  /**
+   * Streaming-draft iframes by message id, indexed in shtml-block order.
+   * Slot is `null` when a placeholder exists but no draft has been mounted
+   * (e.g. extension mode, or the block content is still empty). Drafts
+   * persist across `updateStreamingContent` re-renders by being re-parented
+   * onto the freshly-rendered `.msg__dip-pending` element — re-parenting
+   * within the same document does not reload the iframe, which is the
+   * whole point of this mechanism. Disposed before final `hydrateDips`.
+   */
+  private drafts = new Map<string, Array<DraftDipInstance | null>>();
   public onDipLick?: (action: string, data: unknown) => void;
   private modelSelectorEl!: HTMLElement;
   public onModelChange?: (modelId: string) => void;
@@ -1530,19 +1561,119 @@ export class ChatPanel {
     if (!msg) return;
     const wrapper = this.messagesEl.querySelector(`.msg-group[data-msg-id="${messageId}"]`);
     if (!wrapper) return;
-    const contentEl = wrapper.querySelector('.msg__content');
-    if (contentEl) {
-      contentEl.innerHTML = renderChatMessageContent(msg);
-      if (msg.isStreaming) {
-        const cursor = document.createElement('span');
-        cursor.className = 'streaming-cursor';
-        contentEl.appendChild(cursor);
-      }
-    } else if (msg.content.trim().length > 0) {
-      this.updateMessageEl(messageId);
+    const contentEl = wrapper.querySelector('.msg__content') as HTMLElement | null;
+    if (!contentEl) {
+      if (msg.content.trim().length > 0) this.updateMessageEl(messageId);
       return;
     }
+
+    this.renderStreamingSegmented(contentEl, msg);
+    if (msg.isStreaming) {
+      const cursor = document.createElement('span');
+      cursor.className = 'streaming-cursor';
+      contentEl.appendChild(cursor);
+    }
     this.scrollToBottom();
+  }
+
+  /**
+   * Reconcile `contentEl`'s children against the segments derived from
+   * `msg.content`. Each segment owns a stable container element:
+   *
+   * - **prose** containers use `innerHTML` (no iframes inside, so
+   *   wiping/replacing is safe).
+   * - **shtml** containers hold a draft iframe that is mounted ONCE and
+   *   never re-parented. WHATWG-compliant browsers destroy an iframe's
+   *   contentWindow on disconnect, so any `appendChild` move or
+   *   `innerHTML` wipe of the parent triggers a reload — verified
+   *   empirically against this Canary build. Keeping the iframe pinned
+   *   to its container is the only reliable way to stream into it.
+   *
+   * On the very first call after `createMessageEl` built `contentEl`
+   * with the legacy placeholder-based path, we wipe and re-install
+   * segment containers so subsequent flushes have a stable structure
+   * to reconcile against.
+   */
+  private renderStreamingSegmented(contentEl: HTMLElement, msg: ChatMessage): void {
+    contentEl.querySelector(':scope > .streaming-cursor')?.remove();
+
+    const existing = Array.from(
+      contentEl.querySelectorAll<HTMLElement>(':scope > [data-seg-kind]')
+    );
+    if (existing.length === 0 && contentEl.childNodes.length > 0) {
+      contentEl.replaceChildren();
+    }
+
+    const segments = splitContentSegments(msg.content);
+    let drafts = this.drafts.get(msg.id);
+    if (!drafts) {
+      drafts = [];
+      this.drafts.set(msg.id, drafts);
+    }
+    let shtmlIdx = 0;
+
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i];
+      if (!seg) continue;
+      let container: HTMLElement | null = existing[i] ?? null;
+
+      if (container && container.dataset.segKind !== seg.kind) {
+        container.remove();
+        container = null;
+      }
+
+      if (!container) {
+        container = document.createElement('div');
+        container.dataset.segKind = seg.kind;
+        container.className = `msg__seg msg__seg--${seg.kind}`;
+        contentEl.appendChild(container);
+      }
+
+      if (seg.kind === 'prose') {
+        if (container.dataset.text !== seg.text) {
+          container.innerHTML = renderProseSegment(seg.text, msg.role);
+          container.dataset.text = seg.text;
+        }
+      } else {
+        let draft = drafts[shtmlIdx] ?? null;
+        if (!draft) {
+          draft = mountDraftDip((action, data) => this.onDipLick?.(action, data));
+          drafts[shtmlIdx] = draft;
+          if (draft) container.appendChild(draft.element);
+        }
+        if (draft && container.dataset.body !== seg.body) {
+          draft.update(seg.body);
+          container.dataset.body = seg.body;
+        }
+        shtmlIdx++;
+      }
+    }
+
+    // Trim leftover segment containers whose segment vanished.
+    for (let i = segments.length; i < existing.length; i++) {
+      existing[i]?.remove();
+    }
+    // Trim drafts that no longer correspond to an shtml segment.
+    let totalShtml = 0;
+    for (const seg of segments) if (seg.kind === 'shtml') totalShtml++;
+    for (let i = totalShtml; i < drafts.length; i++) {
+      drafts[i]?.dispose();
+    }
+    drafts.length = totalShtml;
+  }
+
+  private disposeDraftsForMessage(messageId: string): void {
+    const drafts = this.drafts.get(messageId);
+    if (!drafts) return;
+    for (const draft of drafts) draft?.dispose();
+    this.drafts.delete(messageId);
+  }
+
+  private disposeAllDrafts(): void {
+    for (const [, drafts] of this.drafts) {
+      for (const draft of drafts) draft?.dispose();
+    }
+    this.drafts.clear();
   }
 
   private updateSendButtonState(): void {
@@ -2410,6 +2541,12 @@ export class ChatPanel {
   }
 
   private disposeDipsForMessage(messageId: string): void {
+    // Drafts (streaming preview iframes) and dips (final hydrated iframes)
+    // share a message lifecycle: when one is being torn down or rebuilt,
+    // the other should go too. The streaming flow disposes drafts itself
+    // before the final hydration call, so most of the time this branch is
+    // a no-op — but it's the right safety net for re-render paths.
+    this.disposeDraftsForMessage(messageId);
     const instances = this.dips.get(messageId);
     if (instances) {
       disposeDips(instances);
@@ -2418,6 +2555,7 @@ export class ChatPanel {
   }
 
   private disposeAllDips(): void {
+    this.disposeAllDrafts();
     for (const [, instances] of this.dips) {
       disposeDips(instances);
     }

--- a/packages/webapp/src/ui/dip.ts
+++ b/packages/webapp/src/ui/dip.ts
@@ -452,16 +452,16 @@ export function mountDip(
  * height + link-open all work the same as final dips so partial UI is
  * still interactive (within the same security model as inline shtml).
  *
- * Returns `null` in extension mode — `sprinkle-sandbox.html` has no
- * draft-update path yet, and a sandbox-routed iframe can't be re-
- * parented across innerHTML re-renders without reloading. Callers
- * should leave the placeholder visible and rely on final hydration.
+ * Extension mode routes through `sprinkle-sandbox.html` (CSP-exempt
+ * manifest sandbox) — same shape as the final-dip path, just with a
+ * `dip-draft-render` setup message and `dip-draft-update` relay for
+ * incremental body swaps. The chat panel's segment renderer keeps the
+ * iframe pinned to its container in both runtimes, so re-parenting
+ * isn't an issue here.
  */
-export function mountDraftDip(
-  onLick: (action: string, data: unknown) => void
-): DraftDipInstance | null {
-  if (isExtension) return null;
+export function mountDraftDip(onLick: (action: string, data: unknown) => void): DraftDipInstance {
   const srcdoc = buildDipSrcdoc('', /* isDraft */ true);
+  if (isExtension) return mountDraftDipExtension(srcdoc, onLick);
 
   const iframe = document.createElement('iframe');
   iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
@@ -824,6 +824,85 @@ function mountDipExtension(
         liveDipWindows.delete(iframe.contentWindow);
         trustedDipWindows.delete(iframe.contentWindow);
       }
+      iframe.remove();
+    },
+  };
+}
+
+/**
+ * Extension-mode draft dip. Mirrors `mountDipExtension` but with
+ * draft-specific wiring:
+ *
+ * - Posts `dip-draft-render { srcdoc }` instead of `dip-render` so the
+ *   sandbox knows to mount the child iframe in non-interactive mode.
+ * - `update(content)` posts `dip-draft-update { content }` to the
+ *   sandbox; the sandbox relays it to the nested child iframe, where
+ *   the `DRAFT_BRIDGE_EXTENSION` listener (already inlined into the
+ *   draft srcdoc by `buildDipSrcdoc`) replaces `document.body.innerHTML`.
+ * - `pointer-events: none` lives on the outer (sandbox) iframe and on
+ *   the inner srcdoc — both layers block clicks until final hydration.
+ *
+ * The element is detached on construction so the caller (the chat
+ * panel's segment renderer) controls placement. Drafts are not
+ * registered in `trustedDipWindows` and never service VFS requests.
+ */
+function mountDraftDipExtension(
+  srcdoc: string,
+  onLick: (action: string, data: unknown) => void
+): DraftDipInstance {
+  const iframe = document.createElement('iframe');
+  iframe.src = chrome.runtime.getURL('sprinkle-sandbox.html');
+  iframe.style.cssText =
+    'width:100%;border:none;overflow:hidden;display:block;pointer-events:none;';
+
+  let ready = false;
+  let pendingContent: string | null = null;
+  let lastSent: string | null = null;
+  const sendUpdate = (content: string) => {
+    if (lastSent === content) return;
+    lastSent = content;
+    iframe.contentWindow?.postMessage({ type: 'dip-draft-update', content }, '*');
+  };
+
+  const messageHandler = (event: MessageEvent) => {
+    if (event.source !== iframe.contentWindow) return;
+    const msg = event.data;
+    if (!msg?.type) return;
+    if (msg.type === 'dip-lick') onLick(msg.action, msg.data);
+    else if (msg.type === 'dip-height') iframe.style.height = msg.height + 'px';
+    else if (msg.type === 'dip-open-link') openDipLink(msg.url);
+    // Drafts never service VFS requests — silently ignore them.
+  };
+  window.addEventListener('message', messageHandler);
+
+  iframe.addEventListener(
+    'load',
+    () => {
+      registerSprinkleWindow(iframe.contentWindow);
+      if (iframe.contentWindow) liveDipWindows.add(iframe.contentWindow);
+      iframe.contentWindow?.postMessage(
+        { type: 'dip-draft-render', srcdoc, isLight: isThemeLight() },
+        '*'
+      );
+      ready = true;
+      if (pendingContent !== null) {
+        sendUpdate(pendingContent);
+        pendingContent = null;
+      }
+    },
+    { once: true }
+  );
+
+  return {
+    element: iframe,
+    update(content: string) {
+      if (ready) sendUpdate(content);
+      else pendingContent = content;
+    },
+    dispose() {
+      window.removeEventListener('message', messageHandler);
+      unregisterSprinkleWindow(iframe.contentWindow);
+      if (iframe.contentWindow) liveDipWindows.delete(iframe.contentWindow);
       iframe.remove();
     },
   };

--- a/packages/webapp/src/ui/dip.ts
+++ b/packages/webapp/src/ui/dip.ts
@@ -12,7 +12,8 @@ import FS from '@isomorphic-git/lightning-fs';
 import { collectThemeCSS } from './sprinkle-renderer.js';
 import { isThemeLight, registerSprinkleWindow, unregisterSprinkleWindow } from './theme.js';
 
-const isExtension = typeof chrome !== 'undefined' && !!(chrome as any)?.runtime?.id;
+const isExtension =
+  typeof chrome !== 'undefined' && !!(chrome as { runtime?: { id?: string } })?.runtime?.id;
 
 /**
  * Fallback VFS reader for `.shtml` dips. The preview service worker is
@@ -182,6 +183,152 @@ export interface DipInstance {
 }
 
 /**
+ * Inline draft of a dip whose content streams in over time. The chat
+ * panel mounts one of these as soon as a fenced ```shtml block opens
+ * during an in-flight assistant message, then calls `update()` with the
+ * accumulating partial markup. Disposed before final `hydrateDips()`
+ * runs so the trusted iframe replaces the draft cleanly.
+ */
+export interface DraftDipInstance {
+  /** The iframe element. Caller is responsible for placement. */
+  readonly element: HTMLIFrameElement;
+  /** Push a new partial shtml content string into the draft. */
+  update(content: string): void;
+  /** Tear down the iframe and detach listeners. */
+  dispose(): void;
+}
+
+/**
+ * Pull the body of every fenced ```shtml block out of an in-flight
+ * assistant message. Closed blocks (`...```\n`) and the trailing
+ * unclosed block (still streaming) are both captured, in document
+ * order, so callers can match each entry to its corresponding
+ * placeholder/draft iframe by index.
+ */
+export function extractShtmlBlocks(content: string): string[] {
+  const blocks: string[] = [];
+  const re = /```shtml\n([\s\S]*?)(?:\n```|$)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    blocks.push(m[1] ?? '');
+    if (m.index === re.lastIndex) re.lastIndex++;
+  }
+  return blocks;
+}
+
+/** A segment of an in-flight assistant message: prose markdown or shtml. */
+export type ContentSegment =
+  | { kind: 'prose'; text: string }
+  | { kind: 'shtml'; body: string; closed: boolean };
+
+/**
+ * Split `content` into ordered segments at every ```shtml fence boundary.
+ * Each shtml block (open or closed) becomes its own segment so the chat
+ * panel can give it a stable container — iframes inside that container
+ * never get re-parented across re-renders, which is what avoids the
+ * iframe-reload-per-frame failure mode that wiping an `innerHTML` parent
+ * triggers in WHATWG-compliant browsers.
+ */
+export function splitContentSegments(content: string): ContentSegment[] {
+  const segments: ContentSegment[] = [];
+  let lastEnd = 0;
+  const re = /```shtml\n([\s\S]*?)(\n```|$)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    if (m.index > lastEnd) {
+      segments.push({ kind: 'prose', text: content.slice(lastEnd, m.index) });
+    }
+    segments.push({
+      kind: 'shtml',
+      body: m[1] ?? '',
+      closed: m[2] === '\n```',
+    });
+    lastEnd = m.index + m[0].length;
+    if (m.index === re.lastIndex) re.lastIndex++;
+  }
+  if (lastEnd < content.length) {
+    segments.push({ kind: 'prose', text: content.slice(lastEnd) });
+  }
+  return segments;
+}
+
+/** Common styles injected into every dip iframe (final + draft). */
+const DIP_HOST_STYLES = `html,body{margin:0;padding:0;overflow:hidden;background:transparent;box-sizing:border-box}
+*,*::before,*::after{box-sizing:inherit}
+/* Vertical breathing room around dip content. Horizontal padding is owned
+   by the dip's own content (e.g. .sprinkle-action-card__body) so shtml
+   widgets that already pad themselves don't end up double-indented. The
+   ResizeObserver on document.body reports the post-padding scrollHeight
+   correctly, so auto-height continues to work. */
+body{padding:12px 0;font-family:var(--s2-font-family, sans-serif);font-size:13px;color:var(--s2-content-default)}
+.sprinkle-inline{padding:var(--s2-spacing-100) 0}
+.sprinkle-inline .sprinkle-btn{padding:4px 12px;font-size:12px;height:28px;box-shadow:none}
+.sprinkle-inline .sprinkle-btn:not([class*="sprinkle-btn--"]){background:var(--s2-bg-elevated)}
+.sprinkle-inline .sprinkle-card{box-shadow:none;margin:0}
+.sprinkle-inline .sprinkle-action-card{margin:0;width:100%}
+.sprinkle-inline .sprinkle-action-card .sprinkle-table{width:100%}
+.sprinkle-inline .sprinkle-grid{width:100%}
+input[type="range"]{width:100%;height:4px;-webkit-appearance:none;appearance:none;background:var(--s2-gray-300);border-radius:2px;outline:none;cursor:default}
+input[type="range"]::-webkit-slider-thumb{-webkit-appearance:none;width:18px;height:18px;border-radius:50%;background:var(--s2-accent);cursor:default;border:2px solid var(--s2-bg-base)}
+input[type="range"]::-moz-range-thumb{width:14px;height:14px;border-radius:50%;background:var(--s2-accent);cursor:default;border:2px solid var(--s2-bg-base)}
+input[type="text"],input[type="number"],textarea{width:100%;padding:7px 12px;font-size:13px;font-family:var(--s2-font-family,sans-serif);color:var(--s2-content-default);background:var(--s2-bg-layer-2);border:1px solid var(--s2-border-subtle,var(--s2-gray-300));border-radius:8px;outline:none;box-sizing:border-box}
+input[type="text"]:focus,input[type="number"]:focus,textarea:focus{border-color:var(--s2-accent);box-shadow:0 0 0 1px var(--s2-accent)}
+input[type="text"]::placeholder,textarea::placeholder{color:var(--s2-content-disabled,var(--s2-gray-400))}
+select{padding:6px 12px;font-size:13px;font-family:var(--s2-font-family,sans-serif);color:var(--s2-content-default);background:var(--s2-bg-layer-2);border:1px solid var(--s2-border-subtle,var(--s2-gray-300));border-radius:8px;outline:none;cursor:default}
+select:focus{border-color:var(--s2-accent);box-shadow:0 0 0 1px var(--s2-accent)}
+button{display:inline-flex;align-items:center;justify-content:center;gap:6px;height:28px;padding:4px 12px;border:1px solid var(--s2-border-default,var(--s2-gray-300));border-radius:9999px;background:transparent;color:var(--s2-content-default);font-size:12px;font-weight:700;font-family:var(--s2-font-family,sans-serif);cursor:default;transition:background 130ms ease}
+button:hover{background:color-mix(in srgb,var(--s2-content-default) 6%,transparent)}
+button:disabled{opacity:0.4;pointer-events:none}
+canvas{display:block;width:100%;border-radius:8px}
+mark{background:color-mix(in srgb,var(--s2-accent) 25%,transparent);color:inherit;border-radius:2px;padding:0 2px}
+.c-purple{background:#3C3489;color:#EEEDFE}.c-teal{background:#085041;color:#E1F5EE}
+.c-coral{background:#712B13;color:#FAECE7}.c-pink{background:#72243E;color:#FBEAF0}
+.c-gray{background:#444441;color:#F1EFE8}.c-blue{background:#0C447C;color:#E6F1FB}
+.c-amber{background:#633806;color:#FAEEDA}.c-red{background:#791F1F;color:#FCEBEB}
+.c-green{background:#27500A;color:#EAF3DE}`;
+
+/**
+ * Listens for `dip-draft-update` messages from the parent and replaces the
+ * iframe body content with the new partial shtml. Lucide icons are re-run
+ * after each update so newly-arrived `<i data-lucide>` markers materialize.
+ * Custom elements (slicc-editor, slicc-diff) are upgraded automatically
+ * by the browser when their tags appear in the DOM.
+ */
+const DRAFT_BRIDGE_EXTENSION = `(function(){
+  window.addEventListener('message', function(e){
+    if (!e.data || e.data.type !== 'dip-draft-update') return;
+    var content = typeof e.data.content === 'string' ? e.data.content : '';
+    document.body.innerHTML = content;
+    if (window.lucide && typeof window.lucide.createIcons === 'function') {
+      try { window.lucide.createIcons(); } catch(ex){}
+    }
+  });
+})();`;
+
+function buildDipSrcdoc(content: string, isDraft: boolean): string {
+  const themeCSS = collectThemeCSS();
+  const htmlClass = isThemeLight() ? ' class="theme-light"' : '';
+  // Drafts can't introspect content (it streams), so always include the
+  // custom element bundles. Final dips only include them when needed to
+  // keep the srcdoc small for short-lived widgets.
+  const includeEditor = isDraft || content.includes('<slicc-editor');
+  const includeDiff = isDraft || content.includes('<slicc-diff');
+  const draftScript = isDraft ? `<script>${DRAFT_BRIDGE_EXTENSION}</script>` : '';
+  return `<!DOCTYPE html>
+<html${htmlClass}><head>
+<meta charset="utf-8">
+<style>${themeCSS}</style>
+<style>${DIP_HOST_STYLES}</style>
+<script>${BRIDGE_SCRIPT}</script>
+${draftScript}
+${includeEditor ? '<script src="/slicc-editor.js"></script>' : ''}
+${includeDiff ? '<script src="/slicc-diff.js"></script>' : ''}
+<script src="/lucide-icons.js"></script>
+</head>
+<body class="sprinkle-inline">${content}</body></html>`;
+}
+
+/**
  * Live dip iframes. Used by `broadcastToDips` so the host UI can post
  * a message to every mounted dip — handy for cases where a workflow
  * spans multiple turns (e.g. the onboarding `connect-llm` dip needs
@@ -223,61 +370,7 @@ export function mountDip(
   onLick: (action: string, data: unknown) => void,
   trusted = false
 ): DipInstance {
-  const themeCSS = collectThemeCSS();
-  const htmlClass = isThemeLight() ? ' class="theme-light"' : '';
-
-  const srcdoc = `<!DOCTYPE html>
-<html${htmlClass}><head>
-<meta charset="utf-8">
-<style>${themeCSS}</style>
-<style>html,body{margin:0;padding:0;overflow:hidden;background:transparent;box-sizing:border-box}
-*,*::before,*::after{box-sizing:inherit}
-/* Vertical breathing room around dip content. Horizontal padding is owned
-   by the dip's own content (e.g. .sprinkle-action-card__body) so shtml
-   widgets that already pad themselves don't end up double-indented. The
-   ResizeObserver on document.body reports the post-padding scrollHeight
-   correctly, so auto-height continues to work. */
-body{padding:12px 0;font-family:var(--s2-font-family, sans-serif);font-size:13px;color:var(--s2-content-default)}</style>
-<style>.sprinkle-inline{padding:var(--s2-spacing-100) 0}
-.sprinkle-inline .sprinkle-btn{padding:4px 12px;font-size:12px;height:28px;box-shadow:none}
-.sprinkle-inline .sprinkle-btn:not([class*="sprinkle-btn--"]){background:var(--s2-bg-elevated)}
-.sprinkle-inline .sprinkle-card{box-shadow:none;margin:0}
-.sprinkle-inline .sprinkle-action-card{margin:0;width:100%}
-.sprinkle-inline .sprinkle-action-card .sprinkle-table{width:100%}
-.sprinkle-inline .sprinkle-grid{width:100%}
-/* Pre-styled form elements for inline widgets */
-input[type="range"]{width:100%;height:4px;-webkit-appearance:none;appearance:none;background:var(--s2-gray-300);border-radius:2px;outline:none;cursor:default}
-input[type="range"]::-webkit-slider-thumb{-webkit-appearance:none;width:18px;height:18px;border-radius:50%;background:var(--s2-accent);cursor:default;border:2px solid var(--s2-bg-base)}
-input[type="range"]::-moz-range-thumb{width:14px;height:14px;border-radius:50%;background:var(--s2-accent);cursor:default;border:2px solid var(--s2-bg-base)}
-input[type="text"],input[type="number"],textarea{width:100%;padding:7px 12px;font-size:13px;font-family:var(--s2-font-family,sans-serif);color:var(--s2-content-default);background:var(--s2-bg-layer-2);border:1px solid var(--s2-border-subtle,var(--s2-gray-300));border-radius:8px;outline:none;box-sizing:border-box}
-input[type="text"]:focus,input[type="number"]:focus,textarea:focus{border-color:var(--s2-accent);box-shadow:0 0 0 1px var(--s2-accent)}
-input[type="text"]::placeholder,textarea::placeholder{color:var(--s2-content-disabled,var(--s2-gray-400))}
-select{padding:6px 12px;font-size:13px;font-family:var(--s2-font-family,sans-serif);color:var(--s2-content-default);background:var(--s2-bg-layer-2);border:1px solid var(--s2-border-subtle,var(--s2-gray-300));border-radius:8px;outline:none;cursor:default}
-select:focus{border-color:var(--s2-accent);box-shadow:0 0 0 1px var(--s2-accent)}
-button{display:inline-flex;align-items:center;justify-content:center;gap:6px;height:28px;padding:4px 12px;border:1px solid var(--s2-border-default,var(--s2-gray-300));border-radius:9999px;background:transparent;color:var(--s2-content-default);font-size:12px;font-weight:700;font-family:var(--s2-font-family,sans-serif);cursor:default;transition:background 130ms ease}
-button:hover{background:color-mix(in srgb,var(--s2-content-default) 6%,transparent)}
-button:disabled{opacity:0.4;pointer-events:none}
-canvas{display:block;width:100%;border-radius:8px}
-mark{background:color-mix(in srgb,var(--s2-accent) 25%,transparent);color:inherit;border-radius:2px;padding:0 2px}
-/* Categorical color palette for charts/diagrams */
-.c-purple{background:#3C3489;color:#EEEDFE}.c-teal{background:#085041;color:#E1F5EE}
-.c-coral{background:#712B13;color:#FAECE7}.c-pink{background:#72243E;color:#FBEAF0}
-.c-gray{background:#444441;color:#F1EFE8}.c-blue{background:#0C447C;color:#E6F1FB}
-.c-amber{background:#633806;color:#FAEEDA}.c-red{background:#791F1F;color:#FCEBEB}
-.c-green{background:#27500A;color:#EAF3DE}
-</style>
-<script>${BRIDGE_SCRIPT}</script>
-${
-  // Custom element bundles are loaded via src in CLI mode (same-origin).
-  // In extension mode, dips route through sprinkle-sandbox.html
-  // which handles lazy-loading for fragment content. Full custom element
-  // support in extension dips requires the full-doc inlining path.
-  content.includes('<slicc-editor') ? '<script src="/slicc-editor.js"></script>' : ''
-}
-${content.includes('<slicc-diff') ? '<script src="/slicc-diff.js"></script>' : ''}
-<script src="/lucide-icons.js"></script>
-</head>
-<body class="sprinkle-inline">${content}</body></html>`;
+  const srcdoc = buildDipSrcdoc(content, /* isDraft */ false);
 
   if (isExtension) {
     return mountDipExtension(container, srcdoc, onLick, trusted);
@@ -342,6 +435,94 @@ ${content.includes('<slicc-diff') ? '<script src="/slicc-diff.js"></script>' : '
         liveDipWindows.delete(iframe.contentWindow);
         trustedDipWindows.delete(iframe.contentWindow);
       }
+      iframe.remove();
+    },
+  };
+}
+
+/**
+ * Mount a streaming-draft dip iframe. The caller is responsible for
+ * placement (the returned `element` is detached on construction so it
+ * can be re-parented across re-renders without reloading the iframe —
+ * critical, otherwise every animation-frame flush would tear down the
+ * preview).
+ *
+ * Drafts are NEVER trusted: they're not registered in `trustedDipWindows`
+ * and the bridge does not service VFS requests for them. Lick + auto-
+ * height + link-open all work the same as final dips so partial UI is
+ * still interactive (within the same security model as inline shtml).
+ *
+ * Returns `null` in extension mode — `sprinkle-sandbox.html` has no
+ * draft-update path yet, and a sandbox-routed iframe can't be re-
+ * parented across innerHTML re-renders without reloading. Callers
+ * should leave the placeholder visible and rely on final hydration.
+ */
+export function mountDraftDip(
+  onLick: (action: string, data: unknown) => void
+): DraftDipInstance | null {
+  if (isExtension) return null;
+  const srcdoc = buildDipSrcdoc('', /* isDraft */ true);
+
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+  // `pointer-events:none` keeps users from clicking partial UI while the
+  // agent is still writing it — half-typed `slicc.lick()` arguments or
+  // unfinished forms shouldn't be reachable. Final dips replace the draft
+  // on stream end and get the normal interactive iframe styles.
+  iframe.style.cssText =
+    'width:100%;border:none;overflow:hidden;display:block;pointer-events:none;';
+  iframe.srcdoc = srcdoc;
+
+  // Drafts queue updates that arrive before the iframe finishes loading.
+  // The first post-load update flushes the queue.
+  let ready = false;
+  let pendingContent: string | null = null;
+  let lastSent: string | null = null;
+  const sendUpdate = (content: string) => {
+    if (lastSent === content) return;
+    lastSent = content;
+    iframe.contentWindow?.postMessage({ type: 'dip-draft-update', content }, '*');
+  };
+
+  if (iframe.contentWindow) {
+    registerSprinkleWindow(iframe.contentWindow);
+    liveDipWindows.add(iframe.contentWindow);
+  }
+  iframe.addEventListener(
+    'load',
+    () => {
+      registerSprinkleWindow(iframe.contentWindow);
+      if (iframe.contentWindow) liveDipWindows.add(iframe.contentWindow);
+      ready = true;
+      if (pendingContent !== null) {
+        sendUpdate(pendingContent);
+        pendingContent = null;
+      }
+    },
+    { once: true }
+  );
+
+  const messageHandler = (event: MessageEvent) => {
+    if (event.source !== iframe.contentWindow) return;
+    const msg = event.data;
+    if (!msg?.type) return;
+    if (msg.type === 'dip-lick') onLick(msg.action, msg.data);
+    else if (msg.type === 'dip-height') iframe.style.height = msg.height + 'px';
+    else if (msg.type === 'dip-open-link') openDipLink(msg.url);
+    // Drafts never service VFS requests — silently ignore them.
+  };
+  window.addEventListener('message', messageHandler);
+
+  return {
+    element: iframe,
+    update(content: string) {
+      if (ready) sendUpdate(content);
+      else pendingContent = content;
+    },
+    dispose() {
+      window.removeEventListener('message', messageHandler);
+      unregisterSprinkleWindow(iframe.contentWindow);
+      if (iframe.contentWindow) liveDipWindows.delete(iframe.contentWindow);
       iframe.remove();
     },
   };

--- a/packages/webapp/src/ui/message-renderer.ts
+++ b/packages/webapp/src/ui/message-renderer.ts
@@ -284,6 +284,23 @@ function forceNewTabLinks(html: string): string {
 
 const SURFACED_ERROR_PARAGRAPH_RE = /<p><strong>Error:<\/strong>\s*([\s\S]*?)<\/p>/g;
 
+// Match a fenced shtml code block as emitted by the marked renderer above.
+// Used to swap raw shtml in for a "pending" placeholder while streaming, so
+// users see a loading hint instead of the markup typing out — the closing
+// fence may not have arrived yet, but marked still wraps the partial content
+// in <pre><code class="language-shtml">…</code></pre>.
+const SHTML_CODE_BLOCK_RE = /<pre><code class="language-shtml">[\s\S]*?<\/code><\/pre>/g;
+
+// Mirrors the tool-call row layout (label on the left, pulsing status circle
+// pinned to the right) so the placeholder reads as another in-progress step
+// rather than a separate widget. Reuses the `tool-status-pulse` keyframe and
+// the same orange used by `.tool-call--running`.
+const DIP_PENDING_PLACEHOLDER =
+  '<div class="msg__dip-pending" role="status" aria-live="polite" aria-label="Pouring a dip">' +
+  '<span class="msg__dip-pending-label">Pouring a dip…</span>' +
+  '<span class="msg__dip-pending-status" aria-hidden="true"></span>' +
+  '</div>';
+
 function renderBaseMessageContent(content: string): string {
   const raw = marked.parse(content) as string;
   return forceNewTabLinks(sanitize(raw));
@@ -298,6 +315,17 @@ function renderSurfacedErrorBlocks(html: string): string {
 }
 
 /**
+ * While the assistant streams a fenced ```shtml block, replace the raw
+ * markup with a placeholder card. Hydration into a real dip iframe still
+ * happens later (after the stream ends) via `hydrateDips()`, which keys off
+ * the `pre > code.language-shtml` shape — so this swap MUST be skipped on
+ * the final render, otherwise the code blocks disappear before hydration.
+ */
+function replaceShtmlWithDipPlaceholder(html: string): string {
+  return html.replace(SHTML_CODE_BLOCK_RE, DIP_PENDING_PLACEHOLDER);
+}
+
+/**
  * Render a message content string to HTML.
  * Uses marked with GFM for full GFM support:
  * tables, strikethrough, task lists, autolinks, and more.
@@ -308,10 +336,16 @@ export function renderMessageContent(content: string): string {
 
 /**
  * Render assistant message content, upgrading surfaced runtime/provider errors
- * into dedicated error blocks rather than normal prose paragraphs.
+ * into dedicated error blocks rather than normal prose paragraphs. When
+ * `isStreaming` is true, in-progress shtml fenced blocks are swapped for a
+ * "pouring a dip" placeholder so users see a loading hint instead of the
+ * raw HTML typing out. On the final render `isStreaming` must be false so
+ * the shtml code blocks survive for `hydrateDips()` to mount as iframes.
  */
-export function renderAssistantMessageContent(content: string): string {
-  return renderSurfacedErrorBlocks(renderBaseMessageContent(content));
+export function renderAssistantMessageContent(content: string, isStreaming = false): string {
+  let html = renderSurfacedErrorBlocks(renderBaseMessageContent(content));
+  if (isStreaming) html = replaceShtmlWithDipPlaceholder(html);
+  return html;
 }
 
 /**

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -167,6 +167,56 @@
   background: transparent;
 }
 
+/* Streaming-segment containers built by `renderStreamingSegmented`. The
+   shtml variant holds a non-interactive draft iframe while the agent is
+   still writing markup into the block. The `cursor: progress` hint and
+   slight opacity dimming tell users this is a preview that isn't ready
+   to interact with yet — the iframe itself has `pointer-events: none`,
+   so clicks/hovers can't reach partial UI. Replaced on stream end by
+   the fully-interactive `.msg__dip` from `hydrateDips()`. */
+.msg__seg--shtml {
+  margin: 0.6em 0;
+  cursor: progress;
+  opacity: 0.92;
+}
+
+/* Streaming placeholder — replaces a fenced ```shtml block while the
+   assistant is still emitting it, so users see a loading affordance
+   instead of raw markup typing out. Replaced by the real dip iframe
+   once streaming ends. Visually matches `.tool-call` rows: label on
+   the left, pulsing orange status circle pinned to the right. */
+.msg__dip-pending {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0.6em 0;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: var(--s2-bg-layer-1);
+  color: var(--s2-content-secondary);
+  font-size: var(--s2-font-size-75);
+  line-height: 1.4;
+}
+.msg__dip-pending-label {
+  font-family: var(--s2-font-family);
+  font-weight: 500;
+  color: var(--s2-content-secondary);
+}
+.msg__dip-pending-status {
+  margin-left: auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #e6a23c;
+  flex-shrink: 0;
+  animation: tool-status-pulse 1.2s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .msg__dip-pending-status {
+    animation: none;
+  }
+}
+
 /* Continuation messages (same sender, no label) */
 .msg-group--continuation .msg {
   padding-left: 0;

--- a/packages/webapp/tests/ui/dip.test.ts
+++ b/packages/webapp/tests/ui/dip.test.ts
@@ -317,22 +317,21 @@ describe('splitContentSegments', () => {
 describe('mountDraftDip', () => {
   it('returns an instance with a detached iframe element in CLI mode', () => {
     const draft = mountDraftDip(vi.fn());
-    expect(draft).not.toBeNull();
-    expect(draft!.element.tagName).toBe('IFRAME');
-    expect(draft!.element.parentElement).toBeNull();
-    expect(typeof draft!.update).toBe('function');
-    expect(typeof draft!.dispose).toBe('function');
-    draft!.dispose();
+    expect(draft.element.tagName).toBe('IFRAME');
+    expect(draft.element.parentElement).toBeNull();
+    expect(typeof draft.update).toBe('function');
+    expect(typeof draft.dispose).toBe('function');
+    draft.dispose();
   });
 
   it('disables pointer events on the iframe so partial UI is not clickable', () => {
-    const draft = mountDraftDip(vi.fn())!;
+    const draft = mountDraftDip(vi.fn());
     expect(draft.element.style.pointerEvents).toBe('none');
     draft.dispose();
   });
 
   it('queues the first update before iframe load and posts after', async () => {
-    const draft = mountDraftDip(vi.fn())!;
+    const draft = mountDraftDip(vi.fn());
     const iframe = draft.element;
     document.body.appendChild(iframe);
 
@@ -360,7 +359,7 @@ describe('mountDraftDip', () => {
   });
 
   it('skips redundant updates with identical content', async () => {
-    const draft = mountDraftDip(vi.fn())!;
+    const draft = mountDraftDip(vi.fn());
     const iframe = draft.element;
     document.body.appendChild(iframe);
     const postSpy = vi.fn();
@@ -384,7 +383,7 @@ describe('mountDraftDip', () => {
   });
 
   it('removes the iframe and detaches its message listener on dispose', () => {
-    const draft = mountDraftDip(vi.fn())!;
+    const draft = mountDraftDip(vi.fn());
     const iframe = draft.element;
     document.body.appendChild(iframe);
     expect(iframe.isConnected).toBe(true);

--- a/packages/webapp/tests/ui/dip.test.ts
+++ b/packages/webapp/tests/ui/dip.test.ts
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 import 'fake-indexeddb/auto';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { hydrateDips, disposeDips, type DipInstance } from '../../src/ui/dip.js';
+import {
+  hydrateDips,
+  disposeDips,
+  mountDraftDip,
+  extractShtmlBlocks,
+  splitContentSegments,
+  type DipInstance,
+} from '../../src/ui/dip.js';
 
 // Mock collectThemeCSS — avoid needing a real DOM with stylesheets
 vi.mock('./sprinkle-renderer.js', () => ({
@@ -225,5 +232,163 @@ describe('disposeDips', () => {
     expect(disposeFn1).toHaveBeenCalledOnce();
     expect(disposeFn2).toHaveBeenCalledOnce();
     expect(instances).toHaveLength(0);
+  });
+});
+
+describe('extractShtmlBlocks', () => {
+  it('returns an empty array when there are no shtml fences', () => {
+    expect(extractShtmlBlocks('just prose, no fences')).toEqual([]);
+  });
+
+  it('captures a single closed shtml block', () => {
+    const out = extractShtmlBlocks('Sure:\n\n```shtml\n<div>x</div>\n```\n');
+    expect(out).toEqual(['<div>x</div>']);
+  });
+
+  it('captures the trailing unclosed block while streaming', () => {
+    const out = extractShtmlBlocks('Sure:\n\n```shtml\n<div>partial');
+    expect(out).toEqual(['<div>partial']);
+  });
+
+  it('captures multiple blocks in order', () => {
+    const out = extractShtmlBlocks(
+      '```shtml\n<div>a</div>\n```\n\nand\n\n```shtml\n<div>b</div>\n```'
+    );
+    expect(out).toEqual(['<div>a</div>', '<div>b</div>']);
+  });
+
+  it('captures an empty open block (just the language identifier typed)', () => {
+    expect(extractShtmlBlocks('```shtml\n')).toEqual(['']);
+  });
+
+  it('ignores fenced code blocks of other languages', () => {
+    expect(extractShtmlBlocks('```js\nconst x = 1;\n```')).toEqual([]);
+  });
+});
+
+describe('splitContentSegments', () => {
+  it('returns a single prose segment for plain text', () => {
+    expect(splitContentSegments('Hello world')).toEqual([{ kind: 'prose', text: 'Hello world' }]);
+  });
+
+  it('emits prose + open shtml for a streaming-in-progress block', () => {
+    expect(splitContentSegments('Sure:\n\n```shtml\n<div>partial')).toEqual([
+      { kind: 'prose', text: 'Sure:\n\n' },
+      { kind: 'shtml', body: '<div>partial', closed: false },
+    ]);
+  });
+
+  it('emits a closed shtml segment when the closing fence has arrived', () => {
+    expect(splitContentSegments('```shtml\n<div>x</div>\n```')).toEqual([
+      { kind: 'shtml', body: '<div>x</div>', closed: true },
+    ]);
+  });
+
+  it('emits prose between two closed shtml blocks', () => {
+    const segs = splitContentSegments('```shtml\n<a/>\n```\n\nbetween\n\n```shtml\n<b/>\n```');
+    expect(segs).toEqual([
+      { kind: 'shtml', body: '<a/>', closed: true },
+      { kind: 'prose', text: '\n\nbetween\n\n' },
+      { kind: 'shtml', body: '<b/>', closed: true },
+    ]);
+  });
+
+  it('emits trailing prose after a closed shtml block', () => {
+    const segs = splitContentSegments('```shtml\n<x/>\n```\n\nDone.');
+    expect(segs).toEqual([
+      { kind: 'shtml', body: '<x/>', closed: true },
+      { kind: 'prose', text: '\n\nDone.' },
+    ]);
+  });
+
+  it('handles an empty open block (just the language identifier typed)', () => {
+    expect(splitContentSegments('```shtml\n')).toEqual([
+      { kind: 'shtml', body: '', closed: false },
+    ]);
+  });
+
+  it('does not split on non-shtml fenced code blocks', () => {
+    const segs = splitContentSegments('```js\nconst x = 1;\n```');
+    expect(segs).toHaveLength(1);
+    expect(segs[0]?.kind).toBe('prose');
+  });
+});
+
+describe('mountDraftDip', () => {
+  it('returns an instance with a detached iframe element in CLI mode', () => {
+    const draft = mountDraftDip(vi.fn());
+    expect(draft).not.toBeNull();
+    expect(draft!.element.tagName).toBe('IFRAME');
+    expect(draft!.element.parentElement).toBeNull();
+    expect(typeof draft!.update).toBe('function');
+    expect(typeof draft!.dispose).toBe('function');
+    draft!.dispose();
+  });
+
+  it('disables pointer events on the iframe so partial UI is not clickable', () => {
+    const draft = mountDraftDip(vi.fn())!;
+    expect(draft.element.style.pointerEvents).toBe('none');
+    draft.dispose();
+  });
+
+  it('queues the first update before iframe load and posts after', async () => {
+    const draft = mountDraftDip(vi.fn())!;
+    const iframe = draft.element;
+    document.body.appendChild(iframe);
+
+    // Spy on the contentWindow's postMessage; jsdom srcdoc creates a
+    // contentWindow synchronously so the call after dispatching `load`
+    // exercises the post-load path. The pre-load path is exercised
+    // simply by the `update()` call queueing into `pendingContent`.
+    const postSpy = vi.fn();
+    Object.defineProperty(iframe.contentWindow, 'postMessage', {
+      configurable: true,
+      value: postSpy,
+    });
+
+    draft.update('<div>hi</div>');
+    expect(postSpy).not.toHaveBeenCalled(); // queued, not yet sent
+
+    iframe.dispatchEvent(new Event('load'));
+    expect(postSpy).toHaveBeenCalledWith(
+      { type: 'dip-draft-update', content: '<div>hi</div>' },
+      '*'
+    );
+
+    draft.dispose();
+    iframe.remove();
+  });
+
+  it('skips redundant updates with identical content', async () => {
+    const draft = mountDraftDip(vi.fn())!;
+    const iframe = draft.element;
+    document.body.appendChild(iframe);
+    const postSpy = vi.fn();
+    Object.defineProperty(iframe.contentWindow, 'postMessage', {
+      configurable: true,
+      value: postSpy,
+    });
+
+    iframe.dispatchEvent(new Event('load'));
+
+    draft.update('<div>same</div>');
+    draft.update('<div>same</div>');
+    draft.update('<div>same</div>');
+    expect(postSpy).toHaveBeenCalledTimes(1);
+
+    draft.update('<div>changed</div>');
+    expect(postSpy).toHaveBeenCalledTimes(2);
+
+    draft.dispose();
+    iframe.remove();
+  });
+
+  it('removes the iframe and detaches its message listener on dispose', () => {
+    const draft = mountDraftDip(vi.fn())!;
+    const iframe = draft.element;
+    document.body.appendChild(iframe);
+    expect(iframe.isConnected).toBe(true);
+    draft.dispose();
+    expect(iframe.isConnected).toBe(false);
   });
 });

--- a/packages/webapp/tests/ui/message-renderer.test.ts
+++ b/packages/webapp/tests/ui/message-renderer.test.ts
@@ -196,6 +196,62 @@ describe('renderAssistantMessageContent', () => {
     expect(html).toContain('class="msg__error"');
     expect(html).toContain('Provider timeout after 30s');
   });
+
+  describe('streaming dip placeholder', () => {
+    const finishedShtml = 'Here you go:\n\n```shtml\n<div class="card">Hi</div>\n```\n\nDone.';
+
+    it('replaces a closed shtml fenced block with the pending placeholder while streaming', () => {
+      const html = renderAssistantMessageContent(finishedShtml, true);
+
+      expect(html).toContain('class="msg__dip-pending"');
+      expect(html).toContain('Pouring a dip…');
+      expect(html).not.toContain('class="language-shtml"');
+      expect(html).not.toContain('&lt;div class="card"&gt;');
+    });
+
+    it('replaces an in-progress (unclosed) shtml fenced block while streaming', () => {
+      const html = renderAssistantMessageContent(
+        'Here you go:\n\n```shtml\n<div class="card">Hi',
+        true
+      );
+
+      expect(html).toContain('class="msg__dip-pending"');
+      expect(html).not.toContain('class="language-shtml"');
+    });
+
+    it('keeps the shtml code block intact when not streaming so hydrateDips can find it', () => {
+      const html = renderAssistantMessageContent(finishedShtml, false);
+
+      expect(html).toContain('class="language-shtml"');
+      expect(html).toContain('&lt;div class="card"&gt;Hi&lt;/div&gt;');
+      expect(html).not.toContain('msg__dip-pending');
+    });
+
+    it('defaults to non-streaming behavior when isStreaming is omitted', () => {
+      const html = renderAssistantMessageContent(finishedShtml);
+
+      expect(html).toContain('class="language-shtml"');
+      expect(html).not.toContain('msg__dip-pending');
+    });
+
+    it('replaces every shtml block when multiple appear in one message', () => {
+      const html = renderAssistantMessageContent(
+        '```shtml\n<div>one</div>\n```\n\nand\n\n```shtml\n<div>two</div>\n```',
+        true
+      );
+
+      const matches = html.match(/msg__dip-pending"/g) ?? [];
+      expect(matches.length).toBe(2);
+      expect(html).not.toContain('class="language-shtml"');
+    });
+
+    it('leaves non-shtml fenced blocks untouched while streaming', () => {
+      const html = renderAssistantMessageContent('```js\nconst x = 1;\n```', true);
+
+      expect(html).toContain('class="language-js"');
+      expect(html).not.toContain('msg__dip-pending');
+    });
+  });
 });
 
 describe('renderToolInput', () => {


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/4b82132b-7cea-4aca-9bba-20caf7d3eca4



- Streams fenced ```shtml blocks into a sandboxed iframe as the agent writes them, replacing the previous "raw markup typing out then sudden swap" experience with a live preview that takes shape in place.
- **The streaming preview is non-interactive** until the agent finishes the block (`pointer-events: none` on the iframe + `cursor: progress` on the segment container). Half-typed `slicc.lick()` calls and unfinished forms can be looked at but not clicked. Full interactivity returns when stream-end hydration mounts the final trusted dip.
- Adds a segment-based renderer in `chat-panel` that keeps each shtml block in a stable container the iframe never has to leave — re-parenting an iframe destroys its `contentWindow` in WHATWG-compliant browsers, so the previous per-frame `innerHTML` rebuild was reloading the iframe every animation frame and never finishing.

## How it works

**Streaming path** (`renderStreamingSegmented` in `chat-panel.ts`):
- `splitContentSegments(content)` slices `msg.content` at every ```shtml fence into ordered prose / shtml segments.
- Prose segments update via `innerHTML` only when the text changes.
- Shtml segments hold a draft iframe mounted exactly once. Updates flow via `postMessage` (`dip-draft-update`) — the iframe's body is replaced in place, lucide icons re-rendered, custom elements upgraded.

**Final hydration is unchanged**: stream-end disposes drafts and the existing `hydrateDips()` mounts the trusted final iframe with the full bridge.

**Security**: drafts are never registered in `trustedDipWindows` and the bridge ignores `dip-readfile`/`dip-exists`/`dip-stat` for them. Lick + auto-height + link-open work the same as final dips so partial UI is still wireable, within the same security envelope as inline shtml.

**Extension mode**: `mountDraftDip` returns `null` because `sprinkle-sandbox.html` doesn't yet have a draft-update path. The placeholder stays visible during streaming and final hydration runs as before — clean follow-up.

## Files

- `packages/webapp/src/ui/dip.ts` — adds `mountDraftDip`, `extractShtmlBlocks`, `splitContentSegments`, `DraftDipInstance`, `ContentSegment`. Refactors `mountDip` to share scaffolding via a `buildDipSrcdoc` helper.
- `packages/webapp/src/ui/chat-panel.ts` — replaces `updateStreamingContent` with the segment renderer. Adds a `drafts` map alongside `dips`, fanned into `disposeDipsForMessage` and `disposeAllDips`.
- `packages/webapp/src/ui/message-renderer.ts` — `renderAssistantMessageContent` gains an `isStreaming` flag that swaps closed shtml code blocks for a "Pouring a dip…" placeholder. Used as the first-frame affordance before content arrives.
- `packages/webapp/src/ui/styles/chat.css` — `.msg__dip-pending` placeholder (mirrors `.tool-call--running` row), `.msg__seg--shtml` container with the non-interactive cue.
- `packages/webapp/tests/ui/dip.test.ts` — 18 new tests (`mountDraftDip` lifecycle, `extractShtmlBlocks`, `splitContentSegments`).
- `packages/webapp/tests/ui/message-renderer.test.ts` — 6 new tests for the streaming placeholder swap.

## Test plan

- [ ] Hard reload, ask the agent to emit a sizable shtml block. Verify the iframe content streams in progressively without flicker.
- [ ] Try clicking buttons inside the dip while it's still streaming — clicks should not register, cursor should show `progress`.
- [ ] Wait for the stream to finish — buttons become interactive, lick events fire correctly.
- [ ] Ask the agent for a message with multiple shtml blocks interleaved with prose — each block should stream independently into its own iframe; prose between them should appear normally.
- [ ] `npm run typecheck` — clean
- [ ] `npx vitest run tests/ui/` — 615 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)