### PR TITLE
feat(webapp/ui): LLM-suggested labels for tool clusters and prompt placeholder

### DIFF
--- a/packages/webapp/src/scoops/llm-session-id.ts
+++ b/packages/webapp/src/scoops/llm-session-id.ts
@@ -43,10 +43,28 @@ function safeLocalStorage(): Storage | null {
   }
 }
 
-function getDailyUuid(coneJid: string): string {
+/**
+ * Daily-rotated UUID anchored to a free-form key. Shared across every
+ * Adobe `X-Session-Id` producer in the codebase so rotation cadence
+ * and fallback semantics stay identical:
+ *
+ *  - Keyed on `DAILY_UUID_KEY_PREFIX + anchor` in `localStorage` when
+ *    available.
+ *  - Falls through to an in-memory `Map` when storage is locked or
+ *    unavailable. The in-memory cache rotates on the next call past
+ *    UTC midnight, exactly like the persisted path.
+ *  - Returns a fresh `crypto.randomUUID()` if both reads/writes fail,
+ *    so the caller still gets a usable id (worst case: the id rotates
+ *    every call).
+ *
+ * Anchors are arbitrary identifying strings — a scoop's cone JID for
+ * scoop traffic, a fixed sentinel like `'ui-quick-llm'` for ad-hoc UI
+ * label calls.
+ */
+export function getDailyAdobeUuid(anchor: string): string {
   const today = todayUtc();
   const storage = safeLocalStorage();
-  const key = DAILY_UUID_KEY_PREFIX + coneJid;
+  const key = DAILY_UUID_KEY_PREFIX + anchor;
 
   if (storage) {
     let raw: string | null = null;
@@ -72,10 +90,10 @@ function getDailyUuid(coneJid: string): string {
     return uuid;
   }
 
-  const cached = inMemoryFallback.get(coneJid);
+  const cached = inMemoryFallback.get(anchor);
   if (cached && cached.date === today) return cached.uuid;
   const uuid = crypto.randomUUID();
-  inMemoryFallback.set(coneJid, { uuid, date: today });
+  inMemoryFallback.set(anchor, { uuid, date: today });
   return uuid;
 }
 
@@ -99,7 +117,7 @@ export async function getAdobeSessionId(
   coneJid: string | undefined
 ): Promise<string> {
   const anchor = coneJid ?? scoop.jid;
-  const uuid = getDailyUuid(anchor);
+  const uuid = getDailyAdobeUuid(anchor);
   if (scoop.isCone) return uuid;
   const folderHash = await hashFolder(scoop.folder, uuid);
   return `${uuid}/${folderHash}`;

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -245,12 +245,20 @@ export class ChatPanel {
   private openClusterAnchors = new Set<string>();
   /** Cache of LLM-generated cluster labels keyed by sorted tool-call ids. */
   private clusterLabelCache = new Map<string, string>();
-  /** In-flight cluster-label requests, keyed the same way as the cache. */
-  private clusterLabelInflight = new Set<string>();
+  /** In-flight cluster-label requests, keyed by the same signature. The
+   *  value tracks every preview element awaiting that signature's label,
+   *  so a cluster rebuilt mid-flight (re-render during streaming) still
+   *  picks up the eventual response instead of being stuck on the
+   *  comma-joined fallback. */
+  private clusterLabelInflight = new Map<string, Set<HTMLElement>>();
   /** Default placeholder before any LLM-suggested replacement. */
   private static readonly DEFAULT_PLACEHOLDER = 'What shall we build?';
   /** AbortController for the most recent placeholder-suggestion request. */
   private placeholderAbort: AbortController | null = null;
+  /** Previous `setStreamingState` value. The placeholder refresh fires
+   *  only on the streaming→idle edge — not on every "still idle" call
+   *  (e.g. context switches that pass `false` while already idle). */
+  private wasStreaming = false;
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -307,6 +315,7 @@ export class ChatPanel {
   /** Clear the current session and reset messages. */
   async clearSession(): Promise<void> {
     this.messages = [];
+    this.resetEphemeralLlmState();
     this.renderMessages();
     await this.sessionStore.delete(this.sessionId);
   }
@@ -327,6 +336,15 @@ export class ChatPanel {
     this.currentStreamId = null;
     this.cancelPendingDelta();
 
+    // Drop ephemeral LLM-suggestion state from the prior scoop. The
+    // cluster cache is keyed by tool-call ids (which are scoped to the
+    // outgoing scoop) and the placeholder we generated reflects the
+    // outgoing transcript; both would be misleading in the new context.
+    this.resetEphemeralLlmState();
+    // Reset the placeholder back to the static default until the next
+    // streaming→idle transition computes a fresh one for this scoop.
+    if (this.textarea) this.textarea.placeholder = ChatPanel.DEFAULT_PLACEHOLDER;
+
     // Switch
     this.sessionId = contextId;
     this.currentScoopName = scoopName ?? null; // null means cone
@@ -343,6 +361,20 @@ export class ChatPanel {
       this.messages = [];
     }
     this.renderMessages();
+  }
+
+  /** Drop all ephemeral state tied to a scoop's lifetime: cluster
+   *  labels (keyed by tool-call ids that vanish with the scoop) and
+   *  any in-flight placeholder suggestion. Called on every session
+   *  reset (`switchToContext`, `clearSession`, `dispose`) so the
+   *  ChatPanel never carries unbounded label entries across switches
+   *  or applies a label resolved from a previous scoop's signatures. */
+  private resetEphemeralLlmState(): void {
+    this.clusterLabelCache.clear();
+    this.clusterLabelInflight.clear();
+    this.placeholderAbort?.abort();
+    this.placeholderAbort = null;
+    this.wasStreaming = false;
   }
 
   /** Set read-only mode (hide input for non-cone scoops). */
@@ -1297,6 +1329,9 @@ export class ChatPanel {
     this.updateSendButtonState();
     // Textarea stays enabled so the user can queue follow-up messages
     this.textarea.disabled = false;
+    const transitionedToIdle = this.wasStreaming && !streaming;
+    this.wasStreaming = streaming;
+
     // Mic button stays enabled during streaming so user can toggle voice mode off
     if (streaming) {
       if (this.voiceInput?.isListening()) {
@@ -1311,6 +1346,10 @@ export class ChatPanel {
         oldestQueued.queued = false;
         this.updateMessageEl(oldestQueued.id);
       }
+      // Cancel any in-flight placeholder suggestion: its source
+      // transcript is now stale (this turn will append new context).
+      this.placeholderAbort?.abort();
+      this.placeholderAbort = null;
     }
     if (!streaming) {
       if (this.voiceMode) {
@@ -1324,9 +1363,15 @@ export class ChatPanel {
       }
       // Fire-and-forget: regenerate the textarea placeholder from recent
       // turns so the next prompt suggestion reflects the current
-      // conversation. quickLabel returns null on any failure, in which
-      // case we keep whatever placeholder is already set.
-      void this.refreshSuggestedPlaceholder();
+      // conversation. Only fires on the streaming→idle edge — calls
+      // that pass `false` while already idle (e.g. switchToContext
+      // resetting streaming state on a fresh scoop) should NOT refresh
+      // off whatever messages happen to be loaded at that moment.
+      // quickLabel returns null on any failure, in which case we keep
+      // whatever placeholder is already set.
+      if (transitionedToIdle) {
+        void this.refreshSuggestedPlaceholder();
+      }
     }
   }
 
@@ -1343,7 +1388,15 @@ export class ChatPanel {
   /** Replace a cluster's comma-joined preview with an LLM-generated label
    *  describing what the tool calls accomplish together. Uses inputs only
    *  (per-tool args), not return values. Cached by the sorted set of
-   *  tool-call ids so reflow re-renders reuse the prior label. */
+   *  tool-call ids so reflow re-renders reuse the prior label.
+   *
+   *  Mid-flight rebuilds: when reflow rebuilds a cluster while its
+   *  label request is still in flight, the new previewEl joins the
+   *  same signature's pending set so the eventual response writes
+   *  into every still-connected element. Without this, the original
+   *  previewEl was the only one updated — and after reflow it has
+   *  been replaced by a fresh element, so the visible cluster stayed
+   *  on its comma-joined fallback. */
   private scheduleClusterLabel(previewEl: HTMLElement, toolCalls: readonly ToolCall[]): void {
     if (toolCalls.length === 0) return;
     const signature = toolCalls
@@ -1357,8 +1410,13 @@ export class ChatPanel {
       previewEl.textContent = cached;
       return;
     }
-    if (this.clusterLabelInflight.has(signature)) return;
-    this.clusterLabelInflight.add(signature);
+    const inflight = this.clusterLabelInflight.get(signature);
+    if (inflight) {
+      inflight.add(previewEl);
+      return;
+    }
+    const pending = new Set<HTMLElement>([previewEl]);
+    this.clusterLabelInflight.set(signature, pending);
 
     const formatted = toolCalls
       .map((tc, i) => {
@@ -1388,21 +1446,31 @@ export class ChatPanel {
       '1. bash: {"command":"python3 -c \\"print(1+1)\\""}\n' +
       'Example output: Run a Python sanity check';
 
+    const settle = (trimmed: string | null): void => {
+      const elements = this.clusterLabelInflight.get(signature);
+      this.clusterLabelInflight.delete(signature);
+      if (!trimmed || !elements) return;
+      this.clusterLabelCache.set(signature, trimmed);
+      for (const el of elements) {
+        if (el.isConnected) el.textContent = trimmed;
+      }
+    };
+
     void quickLabel({
       system,
       prompt: `Label these tool calls (inputs only):\n${formatted}`,
       maxTokens: 40,
     })
       .then((label) => {
-        this.clusterLabelInflight.delete(signature);
-        if (!label) return;
+        if (!label) {
+          settle(null);
+          return;
+        }
         const trimmed = label.replace(/^["']|["']$|\.$/g, '').trim();
-        if (!isUsefulClusterLabel(trimmed)) return;
-        this.clusterLabelCache.set(signature, trimmed);
-        if (previewEl.isConnected) previewEl.textContent = trimmed;
+        settle(isUsefulClusterLabel(trimmed) ? trimmed : null);
       })
       .catch(() => {
-        this.clusterLabelInflight.delete(signature);
+        settle(null);
       });
   }
 
@@ -2618,6 +2686,7 @@ export class ChatPanel {
   dispose(): void {
     this.cancelPendingDelta();
     this.disposeAllDips();
+    this.resetEphemeralLlmState();
     this.unsubscribe?.();
     this.voiceInput?.destroy();
     if (this.keydownListener) {

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -38,6 +38,7 @@ import {
   setSelectedModelId,
   getProviderConfig,
 } from './provider-settings.js';
+import { quickLabel } from './quick-llm.js';
 import { trackChatSend, trackImageView } from './telemetry.js';
 import { attachLongPressGesture } from './long-press.js';
 
@@ -66,6 +67,18 @@ const MAX_INLINE_TEXT_BYTES = 512 * 1024;
 /** Generate a simple unique ID. */
 function uid(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+/** Reject degenerate cluster labels: too short, just digits/punctuation, or
+ *  a single word. The LLM occasionally treats tool inputs as code to run
+ *  and replies with the *result* (e.g., "3" for `console.log(1+2)`); this
+ *  guards against displaying that as the cluster's label. */
+function isUsefulClusterLabel(text: string): boolean {
+  if (text.length < 6) return false;
+  if (!/[a-zA-Z]/.test(text)) return false;
+  // Reject single-word labels; cluster summaries should be a phrase.
+  if (!/\s/.test(text.trim())) return false;
+  return true;
 }
 
 /** Read a tool-call element's current status from its `tool-call--<status>`
@@ -230,6 +243,14 @@ export class ChatPanel {
    *  msgId is used as the anchor: it's the chain's first call and stays
    *  stable as the cluster grows. */
   private openClusterAnchors = new Set<string>();
+  /** Cache of LLM-generated cluster labels keyed by sorted tool-call ids. */
+  private clusterLabelCache = new Map<string, string>();
+  /** In-flight cluster-label requests, keyed the same way as the cache. */
+  private clusterLabelInflight = new Set<string>();
+  /** Default placeholder before any LLM-suggested replacement. */
+  private static readonly DEFAULT_PLACEHOLDER = 'What shall we build?';
+  /** AbortController for the most recent placeholder-suggestion request. */
+  private placeholderAbort: AbortController | null = null;
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -705,7 +726,7 @@ export class ChatPanel {
 
     this.textarea = document.createElement('textarea');
     this.textarea.className = 'chat__textarea';
-    this.textarea.placeholder = 'What shall we build?';
+    this.textarea.placeholder = ChatPanel.DEFAULT_PLACEHOLDER;
     this.textarea.rows = 1;
 
     this.sendBtn = document.createElement('button');
@@ -1279,7 +1300,134 @@ export class ChatPanel {
       } else {
         this.textarea.focus();
       }
+      // Fire-and-forget: regenerate the textarea placeholder from recent
+      // turns so the next prompt suggestion reflects the current
+      // conversation. quickLabel returns null on any failure, in which
+      // case we keep whatever placeholder is already set.
+      void this.refreshSuggestedPlaceholder();
     }
+  }
+
+  /** Look up a ToolCall by owning message id and tool-call id. */
+  private lookupToolCall(
+    msgId: string | undefined,
+    toolCallId: string | undefined
+  ): ToolCall | undefined {
+    if (!msgId || !toolCallId) return undefined;
+    const msg = this.messages.find((m) => m.id === msgId);
+    return msg?.toolCalls?.find((tc) => tc.id === toolCallId);
+  }
+
+  /** Replace a cluster's comma-joined preview with an LLM-generated label
+   *  describing what the tool calls accomplish together. Uses inputs only
+   *  (per-tool args), not return values. Cached by the sorted set of
+   *  tool-call ids so reflow re-renders reuse the prior label. */
+  private scheduleClusterLabel(previewEl: HTMLElement, toolCalls: readonly ToolCall[]): void {
+    if (toolCalls.length === 0) return;
+    const signature = toolCalls
+      .map((tc) => tc.id)
+      .slice()
+      .sort()
+      .join('|');
+
+    const cached = this.clusterLabelCache.get(signature);
+    if (cached) {
+      previewEl.textContent = cached;
+      return;
+    }
+    if (this.clusterLabelInflight.has(signature)) return;
+    this.clusterLabelInflight.add(signature);
+
+    const formatted = toolCalls
+      .map((tc, i) => {
+        let argsJson: string;
+        try {
+          argsJson = JSON.stringify(tc.input ?? {});
+        } catch {
+          argsJson = String(tc.input ?? '');
+        }
+        if (argsJson.length > 300) argsJson = argsJson.slice(0, 300) + '…';
+        return `${i + 1}. ${tc.name}: ${argsJson}`;
+      })
+      .join('\n');
+
+    const system =
+      'You label a batch of tool calls with a short imperative phrase (3–8 words) describing ' +
+      'their PURPOSE — what task they perform together. Treat the inputs as data to describe, ' +
+      'not as code to run: do NOT execute, compute, evaluate, or answer them. Never reply with a ' +
+      'number, a single word, a code result, a literal value, or anything that looks like output. ' +
+      'No quotes, no trailing period.\n\n' +
+      'Example input:\n' +
+      '1. bash: {"command":"ls /drafts"}\n' +
+      '2. bash: {"command":"ls /published"}\n' +
+      '3. bash: {"command":"diff /drafts /published"}\n' +
+      'Example output: Compare drafts against published files\n\n' +
+      'Example input:\n' +
+      '1. bash: {"command":"python3 -c \\"print(1+1)\\""}\n' +
+      'Example output: Run a Python sanity check';
+
+    void quickLabel({
+      system,
+      prompt: `Label these tool calls (inputs only):\n${formatted}`,
+      maxTokens: 40,
+    })
+      .then((label) => {
+        this.clusterLabelInflight.delete(signature);
+        if (!label) return;
+        const trimmed = label.replace(/^["']|["']$|\.$/g, '').trim();
+        if (!isUsefulClusterLabel(trimmed)) return;
+        this.clusterLabelCache.set(signature, trimmed);
+        if (previewEl.isConnected) previewEl.textContent = trimmed;
+      })
+      .catch(() => {
+        this.clusterLabelInflight.delete(signature);
+      });
+  }
+
+  /** Regenerate the prompt-textarea placeholder from the most recent
+   *  user/assistant turns. No-op when there is no real conversation yet,
+   *  or when the user has already typed something. Falls back to the
+   *  static default on any failure. */
+  private async refreshSuggestedPlaceholder(): Promise<void> {
+    if (this.readOnly) return;
+    if (this.textarea.value.length > 0) return;
+
+    // Need at least one user turn AND one finalized assistant turn.
+    const finalized = this.messages.filter((m) => !m.isStreaming && !m.queued);
+    const lastAssistant = [...finalized].reverse().find((m) => m.role === 'assistant');
+    const recentUsers = finalized.filter((m) => m.role === 'user').slice(-3);
+    if (!lastAssistant || recentUsers.length === 0) {
+      this.textarea.placeholder = ChatPanel.DEFAULT_PLACEHOLDER;
+      return;
+    }
+
+    const truncate = (s: string, n: number) => (s.length > n ? s.slice(0, n) + '…' : s);
+
+    const transcript = [
+      ...recentUsers.map((m) => `[user]: ${truncate(m.content, 400)}`),
+      `[assistant]: ${truncate(lastAssistant.content, 800)}`,
+    ].join('\n\n');
+
+    const system =
+      "You suggest the user's next prompt in a coding-agent chat. Based on the recent " +
+      'conversation, output ONE concrete follow-up the user might type next. Reply with just ' +
+      'the prompt text — no quotes, no preamble, no list. Max 80 characters. If nothing useful ' +
+      'comes to mind, reply exactly: What shall we build?';
+
+    this.placeholderAbort?.abort();
+    const controller = new AbortController();
+    this.placeholderAbort = controller;
+
+    const suggestion = await quickLabel({
+      system,
+      prompt: `Recent conversation:\n${transcript}`,
+      maxTokens: 40,
+      signal: controller.signal,
+    });
+    if (controller.signal.aborted) return;
+    if (this.textarea.value.length > 0) return; // user started typing while we waited
+    this.textarea.placeholder =
+      suggestion && suggestion.length > 0 ? suggestion : ChatPanel.DEFAULT_PLACEHOLDER;
   }
 
   /** Render the model selector — full list when empty, compact active-only when chat started. */
@@ -2063,6 +2211,7 @@ export class ChatPanel {
     // Tag with the owning message id so reflow can return the element to
     // its home msg-group when unwrapping a cross-message cluster.
     el.dataset.msgId = msgId;
+    el.dataset.toolCallId = tc.id;
 
     const summary = document.createElement('summary');
     summary.className = 'tool-call__header';
@@ -2149,12 +2298,14 @@ export class ChatPanel {
     summary.appendChild(nameEl);
 
     const previewText = clusterPreview(toolCalls);
+    let previewEl: HTMLElement | null = null;
     if (previewText) {
-      const preview = document.createElement('span');
-      preview.className = 'tool-call__preview';
-      preview.textContent = previewText;
-      summary.appendChild(preview);
+      previewEl = document.createElement('span');
+      previewEl.className = 'tool-call__preview';
+      previewEl.textContent = previewText;
+      summary.appendChild(previewEl);
     }
+    if (previewEl) this.scheduleClusterLabel(previewEl, toolCalls);
 
     // One bubble per inner tool call, colored to the call's status.
     // Each bubble carries only the `tool-call--<status>` modifier (no
@@ -2351,11 +2502,18 @@ export class ChatPanel {
       (tcEl) => tcEl.querySelector('.tool-call__name')?.textContent ?? ''
     );
     const previewText = clusterPreviewFromTitles(titles);
+    let previewEl: HTMLElement | null = null;
     if (previewText) {
-      const preview = document.createElement('span');
-      preview.className = 'tool-call__preview';
-      preview.textContent = previewText;
-      summary.appendChild(preview);
+      previewEl = document.createElement('span');
+      previewEl.className = 'tool-call__preview';
+      previewEl.textContent = previewText;
+      summary.appendChild(previewEl);
+    }
+    const resolvedToolCalls = toolCallEls
+      .map((tcEl) => this.lookupToolCall(tcEl.dataset.msgId, tcEl.dataset.toolCallId))
+      .filter((tc): tc is ToolCall => !!tc);
+    if (previewEl && resolvedToolCalls.length === toolCallEls.length) {
+      this.scheduleClusterLabel(previewEl, resolvedToolCalls);
     }
 
     const dotsEl = document.createElement('span');

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -853,6 +853,28 @@ export class ChatPanel {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         this.sendMessage();
+        return;
+      }
+      // Tab accepts the LLM-suggested placeholder as the textarea value.
+      // Only fires when the textarea is empty AND the placeholder is a
+      // real suggestion (not the static default), so it doesn't steal Tab
+      // from the user's intended focus shift in the empty initial state.
+      if (
+        e.key === 'Tab' &&
+        !e.shiftKey &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        this.textarea.value.length === 0 &&
+        this.textarea.placeholder.length > 0 &&
+        this.textarea.placeholder !== ChatPanel.DEFAULT_PLACEHOLDER
+      ) {
+        e.preventDefault();
+        this.textarea.value = this.textarea.placeholder;
+        this.adjustTextareaHeight();
+        this.updateSendButtonState();
+        const end = this.textarea.value.length;
+        this.textarea.setSelectionRange(end, end);
       }
     });
 

--- a/packages/webapp/src/ui/quick-llm.ts
+++ b/packages/webapp/src/ui/quick-llm.ts
@@ -1,0 +1,200 @@
+/**
+ * One-shot LLM helper for ad-hoc UI labels (placeholder hints, tool-cluster
+ * summaries, follow-up suggestions). Wraps pi-ai's `completeSimple` so the
+ * caller doesn't have to plumb credentials, model selection, or the Adobe
+ * session-id header.
+ *
+ * Picks a cheaper sibling in the same model family when one exists
+ * (Claude → haiku, GPT/o-series → mini/nano, Gemini → flash, Grok → fast/mini),
+ * otherwise falls back to the active model.
+ *
+ * Returns `null` on any failure (no API key, network error, empty response)
+ * so callers can quietly fall back to a static label without try/catch.
+ */
+
+import { completeSimple } from '@mariozechner/pi-ai';
+import type { Api, Model, UserMessage } from '@mariozechner/pi-ai';
+import { createLogger } from '../core/logger.js';
+import {
+  getApiKey,
+  getProviderModels,
+  getSelectedModelId,
+  getSelectedProvider,
+} from './provider-settings.js';
+
+const log = createLogger('quick-llm');
+
+export interface QuickLabelOptions {
+  /** User-facing prompt. Keep it short — labels aren't conversations. */
+  prompt: string;
+  /** Optional system prompt. Use it to constrain output shape (length, tone). */
+  system?: string;
+  /** Maximum output tokens. Default: 60. */
+  maxTokens?: number;
+  /** Sampling temperature. Default: 0.3 (favor consistent labels). */
+  temperature?: number;
+  /** Abort signal for the underlying request. */
+  signal?: AbortSignal;
+  /**
+   * Force a specific model id within the active provider. Skips the
+   * cheap-fallback picker. Falls back to the active model if the id is
+   * not registered for the active provider.
+   */
+  modelId?: string;
+}
+
+/**
+ * Run a one-shot LLM call. Returns the trimmed assistant text, or `null`
+ * when the call is unavailable or fails.
+ */
+export async function quickLabel(opts: QuickLabelOptions): Promise<string | null> {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    log.debug('No API key for active provider — skipping');
+    return null;
+  }
+
+  const providerId = getSelectedProvider();
+  const activeModelId = getSelectedModelId();
+
+  let model: Model<Api> | undefined;
+  if (opts.modelId) {
+    model = findModel(providerId, opts.modelId) ?? findModel(providerId, activeModelId);
+  } else {
+    model = pickCheapModel(providerId, activeModelId);
+  }
+  if (!model) {
+    log.debug('No model available for provider', { providerId });
+    return null;
+  }
+
+  const userMessage: UserMessage = {
+    role: 'user',
+    content: opts.prompt,
+    timestamp: Date.now(),
+  };
+
+  const headers: Record<string, string> = {};
+  if (model.provider === 'adobe') {
+    headers['X-Session-Id'] = getQuickLlmAdobeSessionId();
+  }
+
+  try {
+    const message = await completeSimple(
+      model,
+      { systemPrompt: opts.system, messages: [userMessage] },
+      {
+        apiKey,
+        maxTokens: opts.maxTokens ?? 60,
+        temperature: opts.temperature ?? 0.3,
+        signal: opts.signal,
+        headers: Object.keys(headers).length > 0 ? headers : undefined,
+      }
+    );
+
+    const text = message.content
+      .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+      .map((c) => c.text)
+      .join('')
+      .trim();
+
+    return text.length > 0 ? text : null;
+  } catch (err) {
+    log.debug('Quick label call failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+// --- Model picking ---
+
+type ModelFamily = 'claude' | 'gpt' | 'gemini' | 'grok' | 'unknown';
+
+function pickCheapModel(providerId: string, activeModelId: string): Model<Api> | undefined {
+  const all = getProviderModels(providerId);
+  if (all.length === 0) return undefined;
+
+  const active = all.find((m) => m.id === activeModelId) ?? all[0];
+  const family = familyOf(active.id);
+
+  const candidates = all.filter((m) => isCheapSibling(m, active, family));
+  if (candidates.length === 0) return active;
+
+  candidates.sort((a, b) => (a.cost?.input ?? 0) - (b.cost?.input ?? 0));
+  return candidates[0];
+}
+
+function isCheapSibling(m: Model<Api>, active: Model<Api>, family: ModelFamily): boolean {
+  if (m.id === active.id) return false;
+  const activeCost = active.cost?.input ?? Number.POSITIVE_INFINITY;
+  const candidateCost = m.cost?.input ?? Number.POSITIVE_INFINITY;
+  if (candidateCost >= activeCost) return false;
+
+  const id = m.id.toLowerCase();
+  switch (family) {
+    case 'claude':
+      return id.includes('haiku');
+    case 'gpt':
+      return /(^|-)mini(-|$)|(^|-)nano(-|$)/.test(id);
+    case 'gemini':
+      return id.includes('flash');
+    case 'grok':
+      return /(^|-)mini(-|$)|(^|-)fast(-|$)/.test(id);
+    case 'unknown':
+      // Without a known family, accept any cheaper sibling in the same provider.
+      return true;
+  }
+}
+
+function familyOf(id: string): ModelFamily {
+  const lower = id.toLowerCase();
+  if (lower.includes('claude')) return 'claude';
+  if (lower.includes('gemini')) return 'gemini';
+  if (lower.includes('grok')) return 'grok';
+  if (/^(gpt|o\d)/.test(lower)) return 'gpt';
+  return 'unknown';
+}
+
+function findModel(providerId: string, modelId: string): Model<Api> | undefined {
+  return getProviderModels(providerId).find((m) => m.id === modelId);
+}
+
+// --- Adobe session id for ad-hoc UI calls ---
+//
+// The Adobe LLM proxy groups requests by `X-Session-Id`. The cone/scoop
+// session ids are scoped to scoop folders; ad-hoc UI labels don't have
+// a scoop, so they get a separate daily-rotated UUID anchored to a
+// fixed key. This keeps label calls visible to the proxy as their own
+// session without leaking anything about the user's scoops.
+
+const QUICK_LLM_SESSION_KEY = 'slicc:adobe-daily-uuid:ui-quick-llm';
+let inMemoryQuickLlmSession: { uuid: string; date: string } | undefined;
+
+function getQuickLlmAdobeSessionId(): string {
+  const today = new Date().toISOString().slice(0, 10);
+  try {
+    const raw = localStorage.getItem(QUICK_LLM_SESSION_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as { uuid?: string; date?: string };
+      if (parsed.date === today && typeof parsed.uuid === 'string') return parsed.uuid;
+    }
+    const uuid = crypto.randomUUID();
+    localStorage.setItem(QUICK_LLM_SESSION_KEY, JSON.stringify({ uuid, date: today }));
+    return uuid;
+  } catch {
+    if (inMemoryQuickLlmSession?.date === today) return inMemoryQuickLlmSession.uuid;
+    const uuid = crypto.randomUUID();
+    inMemoryQuickLlmSession = { uuid, date: today };
+    return uuid;
+  }
+}
+
+/** Test-only: drop the in-memory Adobe session cache. */
+export const __test__ = {
+  resetAdobeSession(): void {
+    inMemoryQuickLlmSession = undefined;
+  },
+  pickCheapModel,
+  familyOf,
+};

--- a/packages/webapp/src/ui/quick-llm.ts
+++ b/packages/webapp/src/ui/quick-llm.ts
@@ -15,6 +15,7 @@
 import { completeSimple } from '@mariozechner/pi-ai';
 import type { Api, Model, UserMessage } from '@mariozechner/pi-ai';
 import { createLogger } from '../core/logger.js';
+import { getDailyAdobeUuid } from '../scoops/llm-session-id.js';
 import {
   getApiKey,
   getProviderModels,
@@ -164,37 +165,22 @@ function findModel(providerId: string, modelId: string): Model<Api> | undefined 
 //
 // The Adobe LLM proxy groups requests by `X-Session-Id`. The cone/scoop
 // session ids are scoped to scoop folders; ad-hoc UI labels don't have
-// a scoop, so they get a separate daily-rotated UUID anchored to a
-// fixed key. This keeps label calls visible to the proxy as their own
-// session without leaking anything about the user's scoops.
+// a scoop, so they get their own daily-rotated UUID anchored to a
+// fixed sentinel. This keeps label calls visible to the proxy as their
+// own session without leaking anything about the user's scoops, and
+// shares rotation/storage semantics with `getAdobeSessionId` (the
+// scoop-traffic generator) by going through the same shared helper.
 
-const QUICK_LLM_SESSION_KEY = 'slicc:adobe-daily-uuid:ui-quick-llm';
-let inMemoryQuickLlmSession: { uuid: string; date: string } | undefined;
+const QUICK_LLM_SESSION_ANCHOR = 'ui-quick-llm';
 
 function getQuickLlmAdobeSessionId(): string {
-  const today = new Date().toISOString().slice(0, 10);
-  try {
-    const raw = localStorage.getItem(QUICK_LLM_SESSION_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw) as { uuid?: string; date?: string };
-      if (parsed.date === today && typeof parsed.uuid === 'string') return parsed.uuid;
-    }
-    const uuid = crypto.randomUUID();
-    localStorage.setItem(QUICK_LLM_SESSION_KEY, JSON.stringify({ uuid, date: today }));
-    return uuid;
-  } catch {
-    if (inMemoryQuickLlmSession?.date === today) return inMemoryQuickLlmSession.uuid;
-    const uuid = crypto.randomUUID();
-    inMemoryQuickLlmSession = { uuid, date: today };
-    return uuid;
-  }
+  return getDailyAdobeUuid(QUICK_LLM_SESSION_ANCHOR);
 }
 
-/** Test-only: drop the in-memory Adobe session cache. */
+/** Test-only hooks. Resetting the Adobe session cache lives in
+ *  `llm-session-id.ts` (`__resetAdobeSessionIdCacheForTests`); tests
+ *  that need a clean slate should call that. */
 export const __test__ = {
-  resetAdobeSession(): void {
-    inMemoryQuickLlmSession = undefined;
-  },
   pickCheapModel,
   familyOf,
 };

--- a/packages/webapp/tests/ui/quick-llm.test.ts
+++ b/packages/webapp/tests/ui/quick-llm.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Api, Model } from '@mariozechner/pi-ai';
+
+const completeSimple = vi.fn();
+
+vi.mock('@mariozechner/pi-ai', () => ({
+  completeSimple: (...args: unknown[]) => completeSimple(...args),
+}));
+
+const providerSettings = {
+  apiKey: 'sk-test',
+  providerId: 'anthropic',
+  modelId: 'claude-opus-4-7',
+  models: [] as Model<Api>[],
+};
+
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => providerSettings.apiKey,
+  getSelectedProvider: () => providerSettings.providerId,
+  getSelectedModelId: () => providerSettings.modelId,
+  getProviderModels: () => providerSettings.models,
+}));
+
+import { quickLabel, __test__ } from '../../src/ui/quick-llm.js';
+
+function makeModel(
+  id: string,
+  cost: number,
+  provider: string = 'anthropic',
+  reasoning = false
+): Model<Api> {
+  return {
+    id,
+    name: id,
+    api: 'anthropic-messages' as Api,
+    provider,
+    baseUrl: '',
+    reasoning,
+    input: ['text'],
+    cost: { input: cost, output: cost * 5, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 8192,
+  } as unknown as Model<Api>;
+}
+
+function assistantTextMessage(text: string) {
+  return {
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    api: 'anthropic-messages',
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'stop',
+    timestamp: 0,
+  };
+}
+
+beforeEach(() => {
+  completeSimple.mockReset();
+  __test__.resetAdobeSession();
+  providerSettings.apiKey = 'sk-test';
+  providerSettings.providerId = 'anthropic';
+  providerSettings.modelId = 'claude-opus-4-7';
+  providerSettings.models = [];
+});
+
+describe('quickLabel', () => {
+  it('returns null when no API key is configured', async () => {
+    providerSettings.apiKey = '';
+    const result = await quickLabel({ prompt: 'hi' });
+    expect(result).toBeNull();
+    expect(completeSimple).not.toHaveBeenCalled();
+  });
+
+  it('returns null when provider has no models', async () => {
+    providerSettings.models = [];
+    expect(await quickLabel({ prompt: 'hi' })).toBeNull();
+  });
+
+  it('returns null when LLM call throws', async () => {
+    providerSettings.models = [makeModel('claude-opus-4-7', 15)];
+    completeSimple.mockRejectedValue(new Error('network down'));
+    expect(await quickLabel({ prompt: 'hi' })).toBeNull();
+  });
+
+  it('returns trimmed assistant text on success', async () => {
+    providerSettings.models = [makeModel('claude-opus-4-7', 15)];
+    completeSimple.mockResolvedValue(assistantTextMessage('  Comparing files in drafts.  '));
+    expect(await quickLabel({ prompt: 'summarize' })).toBe('Comparing files in drafts.');
+  });
+
+  it('prefers haiku over opus in the Claude family', async () => {
+    providerSettings.models = [
+      makeModel('claude-opus-4-7', 15),
+      makeModel('claude-sonnet-4-6', 3),
+      makeModel('claude-haiku-4-5', 1),
+    ];
+    completeSimple.mockResolvedValue(assistantTextMessage('ok'));
+
+    await quickLabel({ prompt: 'hi' });
+
+    const [model] = completeSimple.mock.calls[0];
+    expect((model as Model<Api>).id).toBe('claude-haiku-4-5');
+  });
+
+  it('prefers gpt-mini over gpt for the GPT family', async () => {
+    providerSettings.providerId = 'openai';
+    providerSettings.modelId = 'gpt-5';
+    providerSettings.models = [
+      makeModel('gpt-5', 10, 'openai'),
+      makeModel('gpt-5-mini', 1, 'openai'),
+      makeModel('gpt-5-nano', 0.5, 'openai'),
+    ];
+    completeSimple.mockResolvedValue(assistantTextMessage('ok'));
+
+    await quickLabel({ prompt: 'hi' });
+
+    const [model] = completeSimple.mock.calls[0];
+    expect((model as Model<Api>).id).toBe('gpt-5-nano');
+  });
+
+  it('prefers gemini-flash over gemini-pro', async () => {
+    providerSettings.providerId = 'google';
+    providerSettings.modelId = 'gemini-2.5-pro';
+    providerSettings.models = [
+      makeModel('gemini-2.5-pro', 5, 'google'),
+      makeModel('gemini-2.5-flash', 0.3, 'google'),
+    ];
+    completeSimple.mockResolvedValue(assistantTextMessage('ok'));
+
+    await quickLabel({ prompt: 'hi' });
+
+    const [model] = completeSimple.mock.calls[0];
+    expect((model as Model<Api>).id).toBe('gemini-2.5-flash');
+  });
+
+  it('falls back to active model when no cheaper sibling exists', async () => {
+    providerSettings.models = [makeModel('claude-haiku-4-5', 1)];
+    providerSettings.modelId = 'claude-haiku-4-5';
+    completeSimple.mockResolvedValue(assistantTextMessage('ok'));
+
+    await quickLabel({ prompt: 'hi' });
+
+    const [model] = completeSimple.mock.calls[0];
+    expect((model as Model<Api>).id).toBe('claude-haiku-4-5');
+  });
+
+  it('honors an explicit modelId override', async () => {
+    providerSettings.models = [makeModel('claude-opus-4-7', 15), makeModel('claude-haiku-4-5', 1)];
+    completeSimple.mockResolvedValue(assistantTextMessage('ok'));
+
+    await quickLabel({ prompt: 'hi', modelId: 'claude-opus-4-7' });
+
+    const [model] = completeSimple.mock.calls[0];
+    expect((model as Model<Api>).id).toBe('claude-opus-4-7');
+  });
+
+  it('attaches X-Session-Id header for adobe provider', async () => {
+    providerSettings.providerId = 'adobe';
+    providerSettings.modelId = 'claude-opus-4-7';
+    providerSettings.models = [
+      makeModel('claude-opus-4-7', 15, 'adobe'),
+      makeModel('claude-haiku-4-5', 1, 'adobe'),
+    ];
+    completeSimple.mockResolvedValue(assistantTextMessage('ok'));
+
+    await quickLabel({ prompt: 'hi' });
+
+    const [, , options] = completeSimple.mock.calls[0] as [
+      unknown,
+      unknown,
+      { headers?: Record<string, string> },
+    ];
+    expect(options.headers?.['X-Session-Id']).toMatch(/[0-9a-f-]{36}/i);
+  });
+
+  it('does not attach X-Session-Id for non-adobe providers', async () => {
+    providerSettings.models = [makeModel('claude-haiku-4-5', 1)];
+    providerSettings.modelId = 'claude-haiku-4-5';
+    completeSimple.mockResolvedValue(assistantTextMessage('ok'));
+
+    await quickLabel({ prompt: 'hi' });
+
+    const [, , options] = completeSimple.mock.calls[0] as [
+      unknown,
+      unknown,
+      { headers?: Record<string, string> },
+    ];
+    expect(options.headers).toBeUndefined();
+  });
+
+  it('passes prompt as user message and forwards system prompt', async () => {
+    providerSettings.models = [makeModel('claude-haiku-4-5', 1)];
+    providerSettings.modelId = 'claude-haiku-4-5';
+    completeSimple.mockResolvedValue(assistantTextMessage('label'));
+
+    await quickLabel({ prompt: 'describe', system: 'be brief' });
+
+    const [, context] = completeSimple.mock.calls[0] as [
+      unknown,
+      { systemPrompt?: string; messages: Array<{ role: string; content: string }> },
+    ];
+    expect(context.systemPrompt).toBe('be brief');
+    expect(context.messages[0].role).toBe('user');
+    expect(context.messages[0].content).toBe('describe');
+  });
+});
+
+describe('familyOf', () => {
+  it('classifies Claude, GPT, Gemini, Grok, and unknown ids', () => {
+    expect(__test__.familyOf('claude-opus-4-7')).toBe('claude');
+    expect(__test__.familyOf('gpt-5-mini')).toBe('gpt');
+    expect(__test__.familyOf('o4-mini')).toBe('gpt');
+    expect(__test__.familyOf('gemini-2.5-flash')).toBe('gemini');
+    expect(__test__.familyOf('grok-4-fast')).toBe('grok');
+    expect(__test__.familyOf('llama-3.1-70b')).toBe('unknown');
+  });
+});

--- a/packages/webapp/tests/ui/quick-llm.test.ts
+++ b/packages/webapp/tests/ui/quick-llm.test.ts
@@ -22,6 +22,7 @@ vi.mock('../../src/ui/provider-settings.js', () => ({
 }));
 
 import { quickLabel, __test__ } from '../../src/ui/quick-llm.js';
+import { __resetAdobeSessionIdCacheForTests } from '../../src/scoops/llm-session-id.js';
 
 function makeModel(
   id: string,
@@ -65,7 +66,7 @@ function assistantTextMessage(text: string) {
 
 beforeEach(() => {
   completeSimple.mockReset();
-  __test__.resetAdobeSession();
+  __resetAdobeSessionIdCacheForTests();
   providerSettings.apiKey = 'sk-test';
   providerSettings.providerId = 'anthropic';
   providerSettings.modelId = 'claude-opus-4-7';
@@ -111,7 +112,7 @@ describe('quickLabel', () => {
     expect((model as Model<Api>).id).toBe('claude-haiku-4-5');
   });
 
-  it('prefers gpt-mini over gpt for the GPT family', async () => {
+  it('picks the cheapest mini/nano sibling for the GPT family', async () => {
     providerSettings.providerId = 'openai';
     providerSettings.modelId = 'gpt-5';
     providerSettings.models = [


### PR DESCRIPTION
## Summary

- Adds `quickLabel()`, a one-shot wrapper around pi-ai's `completeSimple` that reuses the active provider's credentials and prefers a cheaper sibling in the same model family (Claude → haiku, GPT/o-series → mini/nano, Gemini → flash, Grok → fast/mini), falling back to the active model if nothing qualifies. Returns `null` on any failure so call sites can quietly keep their static fallback.
- Wires it into the chat input placeholder: after each agent turn ends, the static `"What shall we build?"` is replaced with a follow-up suggested from the last 3 user turns + last finalized assistant response. Aborted on the next turn; reverts to the default if the user has started typing.
- Wires it into the tool-call cluster preview: replaces `bash, bash, bash` with a short imperative phrase describing what the calls accomplish. Uses tool **inputs only** (never return values) so the label is stable while the run is still in progress. Cached by sorted tool-call ids so reflow re-renders reuse the prior result.

## Hardening (cluster prompt)

When bash inputs contain expressions like `console.log(1+2)` or `print(1+1)`, the LLM was treating them as code to evaluate and replying with the *result* (`"3"`, `"2"`). Two layers now prevent that:

1. The system prompt explicitly forbids executing/computing/answering inputs and includes worked examples covering an arithmetic-in-bash case.
2. An `isUsefulClusterLabel` filter rejects degenerate replies (< 6 chars, no letters, single word) so they fall back to the static comma-joined preview instead of being displayed and cached.

## Adobe-provider compatibility

Ad-hoc UI calls don't have a scoop session, so they get their own daily-rotated `X-Session-Id` anchored to a fixed `ui-quick-llm` localStorage key. This preserves the proxy's session-grouping invariant without leaking scoop folder names.

## Test plan

- [x] `npx vitest run packages/webapp/tests/ui/quick-llm.test.ts` — 13 tests covering family-based model picking (Claude/GPT/Gemini), active-model fallback, `modelId` override, Adobe header gating, prompt/system forwarding, and the three null-return paths.
- [x] `npx vitest run packages/webapp/tests/ui/` — all 604 UI tests pass.
- [x] `npm run typecheck` clean.
- [x] `npx prettier --check` clean.
- [ ] Manual: send a few prompts in `PORT=5720 npm run dev`, confirm the textarea placeholder rotates after each agent turn and that 3+-tool-call clusters get a meaningful imperative label (with `bash, bash, bash` fallback when the LLM call fails or returns a degenerate result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)