### PR TITLE
fix(shell/man): route through /api/fetch-proxy so it works in kernel-worker mode

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/man-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/man-command.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from 'just-bash';
 import type { Command } from 'just-bash';
+import { createProxiedFetch } from '../proxied-fetch.js';
 
 function manHelp(): { stdout: string; stderr: string; exitCode: number } {
   return {
@@ -22,6 +23,14 @@ function stripHtml(html: string): string {
 }
 
 export function createManCommand(): Command {
+  // Route through the same proxied fetch path that `curl` uses so the
+  // request bypasses the CORS wall in CLI / kernel-worker mode (the
+  // bare `fetch()` previously used here only worked in extension mode
+  // where `host_permissions` grants direct cross-origin access). Built
+  // once per command so the `SecureFetch` closure is shared across
+  // invocations.
+  const proxiedFetch = createProxiedFetch();
+
   return defineCommand('man', async (args) => {
     if (args.includes('--help') || args.includes('-h')) {
       return manHelp();
@@ -39,7 +48,7 @@ export function createManCommand(): Command {
     const url = `https://www.sliccy.com/man/${topic}.plain.html`;
 
     try {
-      const response = await fetch(url);
+      const response = await proxiedFetch(url, { method: 'GET' });
 
       if (response.status === 404) {
         return {
@@ -49,7 +58,7 @@ export function createManCommand(): Command {
         };
       }
 
-      if (!response.ok) {
+      if (response.status < 200 || response.status >= 300) {
         return {
           stdout: '',
           stderr: `man: failed to fetch manual page for ${topic}: ${response.status} ${response.statusText}\n`,
@@ -57,7 +66,7 @@ export function createManCommand(): Command {
         };
       }
 
-      const html = await response.text();
+      const html = new TextDecoder('utf-8').decode(response.body);
       const plainText = stripHtml(html);
 
       return {
@@ -65,10 +74,11 @@ export function createManCommand(): Command {
         stderr: '',
         exitCode: 0,
       };
-    } catch (err: any) {
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       return {
         stdout: '',
-        stderr: `man: ${err.message || String(err)}\n`,
+        stderr: `man: ${message}\n`,
         exitCode: 1,
       };
     }

--- a/packages/webapp/tests/shell/supplemental-commands/man-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/man-command.test.ts
@@ -15,6 +15,30 @@ function createMockCtx() {
   };
 }
 
+/**
+ * Build a minimal `Response`-shaped mock that satisfies what
+ * `createProxiedFetch` reads: `arrayBuffer`, `headers.get`,
+ * `headers.forEach`, and the status fields. The man command goes
+ * through proxied-fetch (same path as `curl`) so the request can
+ * reach `sliccy.com` from the kernel-worker without CORS.
+ */
+function fetchResponse(status: number, body: string, headers: Record<string, string> = {}) {
+  const bytes = new TextEncoder().encode(body);
+  const lowered = Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : status === 404 ? 'Not Found' : '',
+    arrayBuffer: async () => bytes.buffer.slice(0),
+    headers: {
+      get: (name: string) => lowered[name.toLowerCase()] ?? null,
+      forEach: (cb: (value: string, key: string) => void) => {
+        for (const [k, v] of Object.entries(headers)) cb(v, k);
+      },
+    },
+  };
+}
+
 describe('man command', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -52,11 +76,7 @@ describe('man command', () => {
   it('fetches and returns plain text for valid topic', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: async () => '<h1>Commands</h1><p>List of commands</p>',
-      })
+      vi.fn().mockResolvedValue(fetchResponse(200, '<h1>Commands</h1><p>List of commands</p>'))
     );
 
     const cmd = createManCommand();
@@ -71,15 +91,33 @@ describe('man command', () => {
     expect(result.stdout).toContain('List of commands');
   });
 
+  it('routes through /api/fetch-proxy in CLI mode', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(fetchResponse(200, '<p>ok</p>'));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const cmd = createManCommand();
+    await cmd.execute(['bash'], createMockCtx());
+
+    // The first argument to fetch should be the proxy endpoint, with
+    // the real target URL passed in the X-Target-URL header.
+    const [requestUrl, init] = fetchSpy.mock.calls[0];
+    expect(requestUrl).toBe('/api/fetch-proxy');
+    expect(init.headers['X-Target-URL']).toBe('https://www.sliccy.com/man/bash.plain.html');
+  });
+
+  it('joins multi-word topics with hyphens in the URL', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(fetchResponse(200, '<p>ok</p>'));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const cmd = createManCommand();
+    await cmd.execute(['file', 'system'], createMockCtx());
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers['X-Target-URL']).toBe('https://www.sliccy.com/man/file-system.plain.html');
+  });
+
   it('returns error for 404 response', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 404,
-        text: async () => 'Not found',
-      })
-    );
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fetchResponse(404, 'Not found')));
 
     const cmd = createManCommand();
     const result = await cmd.execute(['nonexistent'], createMockCtx());
@@ -101,11 +139,11 @@ describe('man command', () => {
   it('strips HTML entities', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: async () => '<p>A &amp; B &lt; C &gt; D &quot;E&quot; &#39;F&#39;</p>',
-      })
+      vi
+        .fn()
+        .mockResolvedValue(
+          fetchResponse(200, '<p>A &amp; B &lt; C &gt; D &quot;E&quot; &#39;F&#39;</p>')
+        )
     );
 
     const cmd = createManCommand();


### PR DESCRIPTION
## Summary

After PR #607 moved the shell into a DedicatedWorker, `man <topic>` started failing with a CORS error in standalone mode. \`curl\` continued to work because it already routes through \`createProxiedFetch\`; \`man\` was using bare \`fetch()\` directly. This switches \`man\` to the same proxied-fetch path \`curl\` uses.

## Investigation

Verified live via CDP on \`http://localhost:5720/\`:

- Page-side bare \`fetch('https://www.sliccy.com/man/sprinkle.plain.html')\` resolves to \`http://localhost:5720/api/fetch-proxy\` because the LLM-proxy service worker intercepts cross-origin requests on the page.
- The kernel-worker is a DedicatedWorker spawned from the page; it does **not** receive the page's service-worker interception for its outgoing requests, so a bare \`fetch\` to sliccy.com hits the cross-origin wall.
- \`createProxiedFetch\` (in \`packages/webapp/src/shell/proxied-fetch.ts\`) explicitly POSTs to \`/api/fetch-proxy\` with the real URL in \`X-Target-URL\`, which works from any context.

## Test plan

- [x] \`npx vitest run packages/webapp/tests/shell/supplemental-commands/man-command.test.ts\` — 10/10 pass.
- [x] \`npm run typecheck\` clean.
- [ ] Manual: open the kernel-worker dev server (\`PORT=5720 npm run dev\`), run \`man sprinkle\` in the panel terminal, confirm the man page renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)