### PR TITLE
fix(chat-panel): rebuild scoop history from the worker on scoop select

### DIFF
--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -63,6 +63,19 @@ export interface RequestStateMsg {
   type: 'request-state';
 }
 
+/**
+ * Ask the worker for the canonical chat history of a scoop. The
+ * worker translates the `AgentMessage[]` it holds into the panel's
+ * `ChatMessage[]` shape and emits a `scoop-messages-replaced`
+ * response. Used after the panel re-mounts (HMR, full reload) so the
+ * UI rebuilds from the live agent state instead of from its own
+ * potentially-stale `browser-coding-agent` IDB snapshot.
+ */
+export interface RequestScoopMessagesMsg {
+  type: 'request-scoop-messages';
+  scoopJid: string;
+}
+
 export interface ClearChatMsg {
   type: 'clear-chat';
 }
@@ -176,6 +189,7 @@ export type PanelToOffscreenMessage =
   | AbortMsg
   | SetModelMsg
   | RequestStateMsg
+  | RequestScoopMessagesMsg
   | ClearChatMsg
   | ClearFilesystemMsg
   | RefreshModelMsg

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -36,6 +36,7 @@ import type {
 } from './messages.js';
 import { getLeaderTrayRuntimeStatus } from '../../../packages/webapp/src/scoops/tray-leader.js';
 import { getFollowerTrayRuntimeStatus } from '../../../packages/webapp/src/scoops/tray-follower-status.js';
+import { HIDDEN_TOOL_NAMES } from '../../../packages/webapp/src/scoops/hidden-tools.js';
 import { SessionStore } from '../../../packages/webapp/src/ui/session-store.js';
 import { toolUIRegistry } from '../../../packages/webapp/src/tools/tool-ui.js';
 import type { ChatMessage } from '../../../packages/webapp/src/ui/types.js';
@@ -226,8 +227,7 @@ export class OffscreenBridge implements KernelFacade {
       },
 
       onToolStart: (scoopJid, toolName, toolInput) => {
-        const hiddenTools = new Set(['send_message', 'list_scoops', 'list_tasks']);
-        if (hiddenTools.has(toolName)) return;
+        if (HIDDEN_TOOL_NAMES.has(toolName)) return;
 
         const msg = bridge.getOrCreateAssistantMsg(scoopJid);
         if (!msg.toolCalls) msg.toolCalls = [];
@@ -243,8 +243,7 @@ export class OffscreenBridge implements KernelFacade {
       },
 
       onToolEnd: (scoopJid, toolName, result, isError) => {
-        const hiddenTools = new Set(['send_message', 'list_scoops', 'list_tasks']);
-        if (hiddenTools.has(toolName)) return;
+        if (HIDDEN_TOOL_NAMES.has(toolName)) return;
 
         const msgId = bridge.currentMessageId.get(scoopJid);
         if (msgId) {
@@ -586,6 +585,10 @@ export class OffscreenBridge implements KernelFacade {
         // Hydrate the buffer so subsequent agent events extend the
         // restored history instead of starting from empty (which
         // would silently overwrite the UI store via persistScoop).
+        // Clear `currentMessageId` for the same reason: a stale id
+        // pointing at a (now non-existent) buffer entry would have
+        // `getOrCreateAssistantMsg` write into the rehydrated buffer
+        // under an unrelated id.
         const buf: BufferedChatMessage[] = chatMessages.map((m) => ({
           id: m.id,
           role: m.role,
@@ -604,6 +607,12 @@ export class OffscreenBridge implements KernelFacade {
           isStreaming: false,
         }));
         this.messageBuffers.set(scoopJid, buf);
+        this.currentMessageId.delete(scoopJid);
+        // Persist the rebuilt buffer back to the UI session store so
+        // a subsequent panel reload (without further agent activity)
+        // sees the canonical history instead of whatever truncated
+        // snapshot the panel last wrote during the remount race.
+        this.persistScoop(scoopJid);
         this.emit({
           type: 'scoop-messages-replaced',
           scoopJid,
@@ -613,13 +622,20 @@ export class OffscreenBridge implements KernelFacade {
       }
     }
 
-    // Last resort: load from the UI session store.
+    // Last resort: load from the UI session store. Hydrate the buffer
+    // (and clear `currentMessageId`) here too — without this, a later
+    // agent event would call `getOrCreateAssistantMsg` against an
+    // empty buffer and `persistScoop` would overwrite IDB with only
+    // the new entries, reintroducing the truncation race this
+    // handler exists to prevent.
     if (this.sessionStore) {
       const sessionId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
       try {
         const session = await this.sessionStore.load(sessionId);
         const messages = session?.messages ?? [];
         if (messages.length > 0) {
+          this.messageBuffers.set(scoopJid, messages as unknown as BufferedChatMessage[]);
+          this.currentMessageId.delete(scoopJid);
           this.emit({
             type: 'scoop-messages-replaced',
             scoopJid,

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -544,6 +544,95 @@ export class OffscreenBridge implements KernelFacade {
   }
 
   /**
+   * Rebuild the panel's chat history for a scoop from the live agent
+   * state. Replies via `scoop-messages-replaced`. Used after a panel
+   * remount (HMR or full reload) to override the panel's own
+   * `browser-coding-agent` IDB snapshot, which may have been
+   * truncated by save races during the remount.
+   *
+   * Resolution order:
+   *   1. In-flight `messageBuffers` (current session, possibly with
+   *      a streaming tail).
+   *   2. Translate the scoop's `AgentMessage[]` into the chat shape.
+   *   3. Fall back to whatever the UI `sessionStore` has on disk.
+   */
+  private async handleRequestScoopMessages(scoopJid: string): Promise<void> {
+    if (!this.orchestrator) return;
+    const scoop = this.orchestrator.getScoops().find((s) => s.jid === scoopJid);
+    if (!scoop) return;
+
+    const buffered = this.messageBuffers.get(scoopJid);
+    if (buffered && buffered.length > 0) {
+      this.emit({
+        type: 'scoop-messages-replaced',
+        scoopJid,
+        messages: buffered,
+      });
+      return;
+    }
+
+    // Translate from the agent's canonical conversation. Lazy-import the
+    // translator so it doesn't pull pi-ai types into the bridge's hot
+    // path until needed.
+    const context = this.orchestrator.getScoopContext(scoopJid);
+    if (context) {
+      const { agentMessagesToChatMessages } =
+        await import('../../../packages/webapp/src/scoops/agent-message-to-chat.js');
+      const agentMessages = context.getAgentMessages();
+      if (agentMessages.length > 0) {
+        const chatMessages = agentMessagesToChatMessages(agentMessages, {
+          source: scoop.isCone ? 'cone' : (scoop.name ?? scoop.folder),
+        });
+        // Hydrate the buffer so subsequent agent events extend the
+        // restored history instead of starting from empty (which
+        // would silently overwrite the UI store via persistScoop).
+        const buf: BufferedChatMessage[] = chatMessages.map((m) => ({
+          id: m.id,
+          role: m.role,
+          content: m.content,
+          attachments: m.attachments,
+          timestamp: m.timestamp,
+          source: m.source,
+          channel: m.channel,
+          toolCalls: m.toolCalls?.map((tc) => ({
+            id: tc.id,
+            name: tc.name,
+            input: tc.input,
+            result: tc.result,
+            isError: tc.isError,
+          })),
+          isStreaming: false,
+        }));
+        this.messageBuffers.set(scoopJid, buf);
+        this.emit({
+          type: 'scoop-messages-replaced',
+          scoopJid,
+          messages: buf,
+        });
+        return;
+      }
+    }
+
+    // Last resort: load from the UI session store.
+    if (this.sessionStore) {
+      const sessionId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
+      try {
+        const session = await this.sessionStore.load(sessionId);
+        const messages = session?.messages ?? [];
+        if (messages.length > 0) {
+          this.emit({
+            type: 'scoop-messages-replaced',
+            scoopJid,
+            messages: messages as unknown as BufferedChatMessage[],
+          });
+        }
+      } catch (err) {
+        console.warn('[offscreen-bridge] sessionStore load failed:', sessionId, err);
+      }
+    }
+  }
+
+  /**
    * Persist a scoop's message buffer to the shared UI session store.
    * Fire-and-forget — errors are swallowed to avoid blocking agent processing.
    */
@@ -747,6 +836,11 @@ export class OffscreenBridge implements KernelFacade {
 
       case 'request-state': {
         this.emit(this.buildStateSnapshot());
+        break;
+      }
+
+      case 'request-scoop-messages': {
+        await this.handleRequestScoopMessages(msg.scoopJid);
         break;
       }
 

--- a/packages/webapp/src/scoops/agent-message-to-chat.ts
+++ b/packages/webapp/src/scoops/agent-message-to-chat.ts
@@ -1,0 +1,152 @@
+/**
+ * Translate `AgentMessage[]` (the canonical agent conversation kept by
+ * each `ScoopContext`) into the `ChatMessage[]` shape the UI chat
+ * panel renders. Used by the kernel-host's request-scoop-messages
+ * handler so the panel can rebuild from the live agent state instead
+ * of the UI's own (potentially stale) `browser-coding-agent` IDB.
+ *
+ * The two shapes diverge in how they encode tool use:
+ *
+ *  - `AgentMessage` keeps `toolCall` blocks inside an `assistant`
+ *    message's `content` array, and pairs them with sibling
+ *    `role: 'toolResult'` messages.
+ *
+ *  - `ChatMessage` flattens this: a single `assistant` message owns a
+ *    `toolCalls: ToolCall[]` array where each entry already carries
+ *    its `result` and `isError`.
+ *
+ * The translator collapses the agent shape into the UI shape by
+ * walking the array left→right. Subsequent `toolResult` messages
+ * patch their result back onto the matching tool call inside the
+ * preceding assistant message.
+ *
+ * Image content is dropped from the textual content (the chat panel
+ * displays images via `attachments`, which the agent doesn't
+ * persist) — the goal is to recover the *conversation*, not pixel-
+ * perfect attachments. Thinking blocks are also omitted; reasoning
+ * is not rendered in the chat history view.
+ */
+
+import type { AgentMessage } from '@mariozechner/pi-agent-core';
+import type {
+  AssistantMessage,
+  Message,
+  TextContent,
+  ToolCall as AgentToolCall,
+  ToolResultMessage,
+  UserMessage,
+} from '@mariozechner/pi-ai';
+import type { ChatMessage, ToolCall as UiToolCall } from '../ui/types.js';
+
+/**
+ * Pure translator. `idSeed` lets callers inject a deterministic id
+ * source for tests; production calls fall through to a timestamp+random
+ * default that matches the chat panel's `uid()`.
+ */
+export function agentMessagesToChatMessages(
+  agentMessages: readonly AgentMessage[],
+  options: { source?: string; idSeed?: () => string } = {}
+): ChatMessage[] {
+  const { source = 'cone', idSeed = defaultUid } = options;
+  const out: ChatMessage[] = [];
+  let lastAssistant: ChatMessage | null = null;
+
+  for (const m of agentMessages) {
+    if (isUserMessage(m)) {
+      const text = textOf(m.content);
+      if (text.length === 0) continue;
+      out.push({
+        id: idSeed(),
+        role: 'user',
+        content: text,
+        timestamp: m.timestamp,
+      });
+      lastAssistant = null;
+      continue;
+    }
+
+    if (isAssistantMessage(m)) {
+      const text = textOf(m.content);
+      const toolCalls = collectToolCalls(m);
+      const msg: ChatMessage = {
+        id: idSeed(),
+        role: 'assistant',
+        content: text,
+        timestamp: m.timestamp,
+        source,
+      };
+      if (toolCalls.length > 0) msg.toolCalls = toolCalls;
+      out.push(msg);
+      lastAssistant = msg;
+      continue;
+    }
+
+    if (isToolResultMessage(m)) {
+      // Tool results land on the most recent assistant message's
+      // matching tool call. If we've drifted past that boundary
+      // (e.g. malformed history) we silently skip the result rather
+      // than fabricate an orphan.
+      const target = lastAssistant?.toolCalls?.find((tc) => tc.id === m.toolCallId);
+      if (!target) continue;
+      target.result = textOf(m.content);
+      target.isError = m.isError;
+      continue;
+    }
+  }
+
+  return out;
+}
+
+// ── Discriminators (AgentMessage is a custom-extensible union) ───────
+
+function isUserMessage(m: Message | AgentMessage): m is UserMessage {
+  return (m as { role?: string }).role === 'user';
+}
+
+function isAssistantMessage(m: Message | AgentMessage): m is AssistantMessage {
+  return (m as { role?: string }).role === 'assistant';
+}
+
+function isToolResultMessage(m: Message | AgentMessage): m is ToolResultMessage {
+  return (m as { role?: string }).role === 'toolResult';
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function textOf(
+  content: UserMessage['content'] | AssistantMessage['content'] | ToolResultMessage['content']
+): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (isTextBlock(block)) parts.push(block.text);
+  }
+  return parts.join('');
+}
+
+function isTextBlock(block: unknown): block is TextContent {
+  return (block as { type?: string }).type === 'text';
+}
+
+function isToolCallBlock(block: unknown): block is AgentToolCall {
+  return (block as { type?: string }).type === 'toolCall';
+}
+
+function collectToolCalls(m: AssistantMessage): UiToolCall[] {
+  if (!Array.isArray(m.content)) return [];
+  const out: UiToolCall[] = [];
+  for (const block of m.content) {
+    if (!isToolCallBlock(block)) continue;
+    out.push({
+      id: block.id,
+      name: block.name,
+      input: block.arguments,
+    });
+  }
+  return out;
+}
+
+function defaultUid(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}

--- a/packages/webapp/src/scoops/agent-message-to-chat.ts
+++ b/packages/webapp/src/scoops/agent-message-to-chat.ts
@@ -37,19 +37,36 @@ import type {
   UserMessage,
 } from '@mariozechner/pi-ai';
 import type { ChatMessage, ToolCall as UiToolCall } from '../ui/types.js';
+import { HIDDEN_TOOL_NAMES } from './hidden-tools.js';
 
 /**
  * Pure translator. `idSeed` lets callers inject a deterministic id
  * source for tests; production calls fall through to a timestamp+random
  * default that matches the chat panel's `uid()`.
+ *
+ * Internal orchestration tools (`HIDDEN_TOOL_NAMES`) are filtered out
+ * to match the live-streaming behavior in
+ * `OffscreenBridge.createCallbacks` — without this, a history rebuild
+ * would surface `send_message` / `list_scoops` / `list_tasks` rows
+ * that live agent activity intentionally hides.
  */
 export function agentMessagesToChatMessages(
   agentMessages: readonly AgentMessage[],
-  options: { source?: string; idSeed?: () => string } = {}
+  options: {
+    source?: string;
+    idSeed?: () => string;
+    hiddenToolNames?: ReadonlySet<string>;
+  } = {}
 ): ChatMessage[] {
-  const { source = 'cone', idSeed = defaultUid } = options;
+  const { source = 'cone', idSeed = defaultUid, hiddenToolNames = HIDDEN_TOOL_NAMES } = options;
   const out: ChatMessage[] = [];
   let lastAssistant: ChatMessage | null = null;
+  // Tool-call ids that we dropped from an assistant message because
+  // their tool name was on the hidden list. Their matching
+  // `toolResult` messages must also be skipped — otherwise the
+  // result-patcher below would either find no target (orphan, harmless)
+  // or worse, attach to a same-id call elsewhere if ids ever wrap.
+  const droppedToolCallIds = new Set<string>();
 
   for (const m of agentMessages) {
     if (isUserMessage(m)) {
@@ -67,7 +84,15 @@ export function agentMessagesToChatMessages(
 
     if (isAssistantMessage(m)) {
       const text = textOf(m.content);
-      const toolCalls = collectToolCalls(m);
+      const allToolCalls = collectToolCalls(m);
+      const visibleToolCalls: UiToolCall[] = [];
+      for (const tc of allToolCalls) {
+        if (hiddenToolNames.has(tc.name)) {
+          droppedToolCallIds.add(tc.id);
+        } else {
+          visibleToolCalls.push(tc);
+        }
+      }
       const msg: ChatMessage = {
         id: idSeed(),
         role: 'assistant',
@@ -75,13 +100,18 @@ export function agentMessagesToChatMessages(
         timestamp: m.timestamp,
         source,
       };
-      if (toolCalls.length > 0) msg.toolCalls = toolCalls;
+      if (visibleToolCalls.length > 0) msg.toolCalls = visibleToolCalls;
       out.push(msg);
       lastAssistant = msg;
       continue;
     }
 
     if (isToolResultMessage(m)) {
+      // Skip results for tool calls we filtered out above. Their
+      // assistant counterpart was hidden, so we'd otherwise have no
+      // target to attach to (and a future same-id collision could
+      // cross-attach to an unrelated call).
+      if (droppedToolCallIds.has(m.toolCallId)) continue;
       // Tool results land on the most recent assistant message's
       // matching tool call. If we've drifted past that boundary
       // (e.g. malformed history) we silently skip the result rather

--- a/packages/webapp/src/scoops/hidden-tools.ts
+++ b/packages/webapp/src/scoops/hidden-tools.ts
@@ -1,0 +1,25 @@
+/**
+ * Internal orchestration tools that should never appear in the chat
+ * UI. These are mechanics — `send_message` (cone↔scoop traffic),
+ * `list_scoops` (agent introspecting the scoop list), `list_tasks`
+ * (cron / webhook table introspection) — not user-visible work, so
+ * surfacing them as tool-call rows just adds noise.
+ *
+ * Single source of truth: every code path that translates agent
+ * activity into the chat surface should read this list. Imported by:
+ *
+ *  - `OffscreenBridge.createCallbacks.onToolStart / onToolEnd`
+ *    (live streaming path).
+ *  - `agentMessagesToChatMessages` (history rebuild path called by
+ *    `OffscreenBridge.handleRequestScoopMessages`).
+ *
+ * If those paths read different lists, history rebuilds will surface
+ * tool calls that live streaming hides — exactly the inconsistency
+ * the PR #614 review flagged.
+ */
+
+export const HIDDEN_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'send_message',
+  'list_scoops',
+  'list_tasks',
+]);

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1541,6 +1541,14 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
     const scoopName = scoop.isCone ? undefined : scoop.name;
     await layout.panels.chat.switchToContext(contextId, !scoop.isCone, scoopName);
 
+    // Ask the worker for the canonical chat history. The worker is the
+    // source of truth (it owns the live `AgentMessage[]`); the panel's
+    // own `browser-coding-agent` IDB can drift if the panel re-mounts
+    // mid-conversation (HMR, full reload). The reply lands as a
+    // `scoop-messages-replaced` event handled below and replaces the
+    // panel's view atomically.
+    client.requestScoopMessages(scoop.jid);
+
     if (client.isProcessing(scoop.jid)) {
       layout.panels.chat.setProcessing(true);
     }
@@ -1594,6 +1602,14 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
             new Date(message.timestamp).getTime()
           );
         }
+      },
+      onScoopMessagesReplaced: (scoopJid, messages) => {
+        if (selectedScoop?.jid !== scoopJid) return;
+        // Replace the panel's view of the scoop with the worker's
+        // canonical history. The worker has already updated the UI
+        // session store as part of its handler (sessionStore is a
+        // shared IDB), so the next reload starts from the same place.
+        layout.panels.chat.loadMessages(messages as unknown as ChatMessage[]);
       },
       onReady: () => {
         log.info('Kernel worker ready, scoop count:', client.getScoops().length);

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -640,10 +640,16 @@ async function mainExtension(app: HTMLElement): Promise<void> {
     layout.panels.scoops.setSelectedJid(scoop.jid);
 
     // switchToContext loads messages from the shared browser-coding-agent IndexedDB
-    // (written by the offscreen bridge). No buffer reconciliation needed.
+    // (written by the offscreen bridge). That snapshot can drift if the side panel
+    // re-mounts mid-stream (chrome.runtime reconnect, panel close/open) — its
+    // `persistSession` may overwrite the bridge's writes with a near-empty list.
+    // Match the standalone-worker path and ask the offscreen for the canonical
+    // history; the bridge replies via `scoop-messages-replaced` and the panel's
+    // `onScoopMessagesReplaced` handler swaps it in atomically.
     const contextId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
     const scoopName = scoop.isCone ? undefined : scoop.name;
     await layout.panels.chat.switchToContext(contextId, !scoop.isCone, scoopName);
+    client.requestScoopMessages(scoop.jid);
 
     if (client.isProcessing(scoop.jid)) {
       layout.panels.chat.setProcessing(true);
@@ -1606,9 +1612,15 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
       onScoopMessagesReplaced: (scoopJid, messages) => {
         if (selectedScoop?.jid !== scoopJid) return;
         // Replace the panel's view of the scoop with the worker's
-        // canonical history. The worker has already updated the UI
-        // session store as part of its handler (sessionStore is a
-        // shared IDB), so the next reload starts from the same place.
+        // canonical history. The worker's
+        // `handleRequestScoopMessages` persists the rebuilt buffer
+        // back to the shared `browser-coding-agent` IDB before
+        // emitting (when it rebuilds from agent messages or hydrates
+        // from the session-store fallback), so the next reload picks
+        // up the same view. The buffered-only path skips the persist
+        // because the buffer's content already came FROM the active
+        // streaming pipeline, which keeps writing through
+        // `persistScoop` on each agent event.
         layout.panels.chat.loadMessages(messages as unknown as ChatMessage[]);
       },
       onReady: () => {

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -249,6 +249,17 @@ export class OffscreenClient implements KernelClientFacade {
     this.send({ type: 'clear-filesystem' });
   }
 
+  /**
+   * Ask the worker for the canonical chat history of a scoop. The
+   * worker translates from the live `AgentMessage[]` and replies with
+   * a `scoop-messages-replaced` event the panel handler can swap in.
+   * Fire-and-forget — the worker may also no-op if the scoop is gone
+   * or has no history yet.
+   */
+  requestScoopMessages(scoopJid: string): void {
+    this.send({ type: 'request-scoop-messages', scoopJid } as PanelToOffscreenMessage);
+  }
+
   /** Request full state from offscreen. Retries until state arrives. */
   requestState(): void {
     this.send({ type: 'request-state' });

--- a/packages/webapp/tests/scoops/agent-message-to-chat.test.ts
+++ b/packages/webapp/tests/scoops/agent-message-to-chat.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentMessage } from '@mariozechner/pi-agent-core';
+import { agentMessagesToChatMessages } from '../../src/scoops/agent-message-to-chat.js';
+
+/**
+ * Build an AgentMessage with a content array. Cast to `AgentMessage`
+ * because the union also includes pi-agent-core's `CustomAgentMessages`
+ * extension point — the basic shape we test here matches the public
+ * pi-ai types.
+ */
+function userMsg(text: string, timestamp = 1): AgentMessage {
+  return {
+    role: 'user',
+    content: [{ type: 'text', text }],
+    timestamp,
+  } as AgentMessage;
+}
+
+function assistantMsg(
+  blocks: Array<
+    | { type: 'text'; text: string }
+    | { type: 'toolCall'; id: string; name: string; arguments: Record<string, unknown> }
+  >,
+  timestamp = 2
+): AgentMessage {
+  return {
+    role: 'assistant',
+    content: blocks,
+    api: 'anthropic-messages',
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'stop',
+    timestamp,
+  } as AgentMessage;
+}
+
+function toolResultMsg(
+  toolCallId: string,
+  text: string,
+  isError = false,
+  timestamp = 3
+): AgentMessage {
+  return {
+    role: 'toolResult',
+    toolCallId,
+    toolName: 'bash',
+    content: [{ type: 'text', text }],
+    isError,
+    timestamp,
+  } as AgentMessage;
+}
+
+let counter = 0;
+const seedId = (): string => `id-${++counter}`;
+
+describe('agentMessagesToChatMessages', () => {
+  it('returns an empty array for empty input', () => {
+    expect(agentMessagesToChatMessages([])).toEqual([]);
+  });
+
+  it('translates a plain user/assistant exchange', () => {
+    counter = 0;
+    const input: AgentMessage[] = [
+      userMsg('hello', 1),
+      assistantMsg([{ type: 'text', text: 'hi there' }], 2),
+    ];
+
+    const out = agentMessagesToChatMessages(input, { idSeed: seedId });
+    expect(out).toEqual([
+      { id: 'id-1', role: 'user', content: 'hello', timestamp: 1 },
+      {
+        id: 'id-2',
+        role: 'assistant',
+        content: 'hi there',
+        timestamp: 2,
+        source: 'cone',
+      },
+    ]);
+  });
+
+  it('joins multiple text blocks into a single content string', () => {
+    counter = 0;
+    const input: AgentMessage[] = [
+      assistantMsg(
+        [
+          { type: 'text', text: 'first ' },
+          { type: 'text', text: 'second' },
+        ],
+        2
+      ),
+    ];
+
+    const out = agentMessagesToChatMessages(input, { idSeed: seedId });
+    expect(out[0].content).toBe('first second');
+  });
+
+  it('collapses tool calls + tool results into the assistant message', () => {
+    counter = 0;
+    const input: AgentMessage[] = [
+      userMsg('list files', 1),
+      assistantMsg(
+        [
+          { type: 'text', text: 'Listing now.' },
+          {
+            type: 'toolCall',
+            id: 'tc-1',
+            name: 'bash',
+            arguments: { command: 'ls' },
+          },
+        ],
+        2
+      ),
+      toolResultMsg('tc-1', 'a.txt\nb.txt\n', false, 3),
+    ];
+
+    const out = agentMessagesToChatMessages(input, { idSeed: seedId });
+    expect(out).toHaveLength(2);
+    const assistant = out[1];
+    expect(assistant.role).toBe('assistant');
+    expect(assistant.content).toBe('Listing now.');
+    expect(assistant.toolCalls).toEqual([
+      {
+        id: 'tc-1',
+        name: 'bash',
+        input: { command: 'ls' },
+        result: 'a.txt\nb.txt\n',
+        isError: false,
+      },
+    ]);
+  });
+
+  it('attaches the error flag when a tool result is an error', () => {
+    counter = 0;
+    const input: AgentMessage[] = [
+      assistantMsg(
+        [
+          {
+            type: 'toolCall',
+            id: 'tc-fail',
+            name: 'bash',
+            arguments: { command: 'badcmd' },
+          },
+        ],
+        2
+      ),
+      toolResultMsg('tc-fail', 'bash: badcmd: command not found', true, 3),
+    ];
+
+    const out = agentMessagesToChatMessages(input, { idSeed: seedId });
+    expect(out[0].toolCalls?.[0].isError).toBe(true);
+    expect(out[0].toolCalls?.[0].result).toContain('command not found');
+  });
+
+  it('passes the source label through to assistant messages', () => {
+    counter = 0;
+    const input: AgentMessage[] = [assistantMsg([{ type: 'text', text: 'from a scoop' }], 2)];
+    const out = agentMessagesToChatMessages(input, { idSeed: seedId, source: 'todo-app' });
+    expect(out[0].source).toBe('todo-app');
+  });
+
+  it('skips empty user messages', () => {
+    counter = 0;
+    const input: AgentMessage[] = [userMsg('', 1), assistantMsg([{ type: 'text', text: 'hi' }], 2)];
+    const out = agentMessagesToChatMessages(input, { idSeed: seedId });
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe('assistant');
+  });
+
+  it('drops orphan tool results that have no preceding tool call', () => {
+    counter = 0;
+    const input: AgentMessage[] = [
+      userMsg('hi', 1),
+      toolResultMsg('tc-orphan', 'whatever', false, 2),
+    ];
+    const out = agentMessagesToChatMessages(input, { idSeed: seedId });
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe('user');
+  });
+
+  it('keeps multi-turn exchanges in order', () => {
+    counter = 0;
+    const input: AgentMessage[] = [
+      userMsg('first', 1),
+      assistantMsg([{ type: 'text', text: 'one' }], 2),
+      userMsg('second', 3),
+      assistantMsg([{ type: 'text', text: 'two' }], 4),
+    ];
+    const out = agentMessagesToChatMessages(input, { idSeed: seedId });
+    expect(out.map((m) => `${m.role}:${m.content}`)).toEqual([
+      'user:first',
+      'assistant:one',
+      'user:second',
+      'assistant:two',
+    ]);
+  });
+
+  it('omits the toolCalls field entirely when there are none', () => {
+    counter = 0;
+    const input: AgentMessage[] = [assistantMsg([{ type: 'text', text: 'just text' }], 2)];
+    const out = agentMessagesToChatMessages(input, { idSeed: seedId });
+    expect(out[0]).not.toHaveProperty('toolCalls');
+  });
+});

--- a/packages/webapp/tests/scoops/agent-message-to-chat.test.ts
+++ b/packages/webapp/tests/scoops/agent-message-to-chat.test.ts
@@ -208,4 +208,55 @@ describe('agentMessagesToChatMessages', () => {
     const out = agentMessagesToChatMessages(input, { idSeed: seedId });
     expect(out[0]).not.toHaveProperty('toolCalls');
   });
+
+  it('drops internal orchestration tools (send_message / list_scoops / list_tasks)', () => {
+    counter = 0;
+    const input: AgentMessage[] = [
+      assistantMsg(
+        [
+          { type: 'text', text: 'thinking…' },
+          { type: 'toolCall', id: 'tc-keep', name: 'bash', arguments: { command: 'ls' } },
+          {
+            type: 'toolCall',
+            id: 'tc-hidden-1',
+            name: 'send_message',
+            arguments: { to: 'cone' },
+          },
+          { type: 'toolCall', id: 'tc-hidden-2', name: 'list_scoops', arguments: {} },
+          { type: 'toolCall', id: 'tc-hidden-3', name: 'list_tasks', arguments: {} },
+        ],
+        2
+      ),
+      toolResultMsg('tc-keep', 'a.txt\n', false, 3),
+      // Results for the hidden tool calls must also be skipped — they
+      // have no visible target to attach to.
+      toolResultMsg('tc-hidden-1', 'sent', false, 4),
+      toolResultMsg('tc-hidden-2', '[]', false, 5),
+    ];
+
+    const out = agentMessagesToChatMessages(input, { idSeed: seedId });
+    expect(out).toHaveLength(1);
+    expect(out[0].toolCalls).toEqual([
+      { id: 'tc-keep', name: 'bash', input: { command: 'ls' }, result: 'a.txt\n', isError: false },
+    ]);
+  });
+
+  it('honors a custom hiddenToolNames override', () => {
+    counter = 0;
+    const input: AgentMessage[] = [
+      assistantMsg(
+        [
+          { type: 'toolCall', id: 'tc-bash', name: 'bash', arguments: { command: 'ls' } },
+          { type: 'toolCall', id: 'tc-x', name: 'experimental_thing', arguments: {} },
+        ],
+        2
+      ),
+    ];
+
+    const out = agentMessagesToChatMessages(input, {
+      idSeed: seedId,
+      hiddenToolNames: new Set(['experimental_thing']),
+    });
+    expect(out[0].toolCalls?.map((t) => t.name)).toEqual(['bash']);
+  });
 });


### PR DESCRIPTION
## Summary

After a panel re-mount (HMR or full reload) the chat panel was silently truncating its scoop history. The panel's in-memory \`this.messages\` resets to empty in the constructor; agent events arriving from the still-running worker then dribble in one at a time, and \`persistSession()\` writes that near-empty array back over the prior good UI-store snapshot.

CDP confirmed the divergence on a live page: 58 messages in the canonical core session store, only 2 left in the panel's \`browser-coding-agent\` IDB for the same scoop.

This makes the worker the single source of truth for "what is the chat history of this scoop" and rebuilds the panel from it on every scoop selection.

## What changes

- **New translator** \`packages/webapp/src/scoops/agent-message-to-chat.ts\`: pure function that walks the agent's \`AgentMessage[]\` and collapses \`assistant\` + \`toolResult\` pairs into a single \`ChatMessage\` with embedded \`toolCalls\` (matching what the chat panel expects). 10 unit tests cover plain exchanges, multi-text-block joins, tool-call/result merging, error flag, source label, empty-user skip, orphan-toolResult drop, multi-turn ordering, and the no-tool-call shape.

- **New wire envelope** \`RequestScoopMessagesMsg\` and a \`requestScoopMessages(jid)\` method on \`OffscreenClient\`.

- **Bridge handler** \`OffscreenBridge.handleRequestScoopMessages\`:
  1. Prefer the live in-memory \`messageBuffers\` (preserves a streaming tail).
  2. Else translate \`context.getAgentMessages()\` and **also rehydrate \`messageBuffers\`** so subsequent agent events extend the restored history instead of restarting from empty — that re-empty was the original race.
  3. Fall back to the UI session store as a last resort.
  Replies via the existing \`scoop-messages-replaced\` event the panel already knows how to consume.

- **Standalone worker boot** \`mainStandaloneWorker\`:
  - \`selectScoop\` now calls \`client.requestScoopMessages(jid)\` after switching context.
  - \`onScoopMessagesReplaced\` is now wired to \`chatPanel.loadMessages\` (extension mode already had this; standalone reaches parity).

## Test plan

- [x] 10 translator unit tests pass; structural coverage for empty, plain, joined-text, tool-call collapse, error flag, source label, empty-user skip, orphan-toolResult drop, ordering, no-toolCalls.
- [x] 828 tests across \`packages/webapp/tests/scoops/\` + \`packages/webapp/tests/kernel/\` pass (no regressions).
- [x] \`npm run typecheck\` clean (4 tsconfigs).
- [ ] Manual repro: open the worker dev server, send 5+ messages to the cone, edit \`chat-panel.ts\` to trigger HMR, confirm the chat repaints from the worker each time instead of dropping history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)