### PR TITLE
fix(welcome-dip): don't leak baseUrlPlaceholder as user-entered baseUrl

### DIFF
--- a/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
+++ b/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
@@ -318,8 +318,14 @@
         apiKeyIn.placeholder = p.apiKeyPlaceholder || 'sk-…';
 
         // ── Base URL field ────────────────────────────────────────
+        // `defaultBaseUrl` on the catalogue is the provider's
+        // `baseUrlPlaceholder` — a UI hint like
+        // `https://your-resource.cognitiveservices.azure.com/` or
+        // `https://your-proxy.example.com`. It is NOT a real default
+        // and must not be sent back as the user's value. Mirror the
+        // settings dialog and use it only as the HTML placeholder.
         baseUrlRow.hidden = !p.requiresBaseUrl;
-        baseUrlIn.value = p.defaultBaseUrl || '';
+        baseUrlIn.value = '';
         baseUrlIn.placeholder = p.defaultBaseUrl || 'https://…';
         setHelpText(baseUrlHelpEl, p.requiresBaseUrl ? p.baseUrlDescription || '' : '');
 


### PR DESCRIPTION
## Summary
- The welcome/connect-llm dip prefilled the Base URL input with the provider's `baseUrlPlaceholder` (a UI hint like `https://your-proxy.example.com`). When the user left the field untouched, that placeholder string was posted back as `baseUrl` in the `oauth-attempt` (and `connect-attempt`) lick.
- For OAuth providers with `requiresBaseUrl: true`, `launchOAuth` then persisted the placeholder as the account's real baseUrl in `slicc_accounts`, so subsequent provider calls resolved through the example URL.
- Mirror the settings-dialog pattern: use `baseUrlPlaceholder` only for the input's HTML `placeholder` attribute, never as the field's initial value.

Fixes #618

## Test plan
- [ ] Run `npm run typecheck`
- [ ] Run the welcome flow → pick an OAuth provider with `requiresBaseUrl: true` → leave Base URL blank → click Login → confirm the `oauth-attempt` lick payload now has `baseUrl: null`
- [ ] Confirm `localStorage['slicc_accounts']` is no longer seeded with the example URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)