### PR TITLE
fix(kernel): install page-storage-sync overrides as non-enumerable

### DIFF
--- a/packages/webapp/src/kernel/page-storage-sync.ts
+++ b/packages/webapp/src/kernel/page-storage-sync.ts
@@ -72,26 +72,43 @@ export function installPageStorageSync(sink: PageStorageSyncSink): () => void {
   const origRemoveItem = ls.removeItem.bind(ls);
   const origClear = ls.clear.bind(ls);
 
-  ls.setItem = (key: string, value: string): void => {
+  // Native Storage methods live on `Storage.prototype` and are
+  // non-enumerable. A direct assignment (`ls.setItem = …`) would
+  // create an enumerable own-property, so `Object.keys(localStorage)`
+  // and `for…in` would return phantom keys `"setItem"`/`"removeItem"`/
+  // `"clear"` mixed with the user's actual stored keys. Use
+  // `Object.defineProperty` to install non-enumerable own-properties
+  // that shadow the prototype methods without breaking enumeration.
+  // `dispose()` uses the same shape to restore.
+  const define = (name: 'setItem' | 'removeItem' | 'clear', value: unknown): void => {
+    Object.defineProperty(ls, name, {
+      value,
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
+  };
+
+  define('setItem', (key: string, value: string): void => {
     origSetItem(key, value);
     if (!isForwardableKey(key)) {
       console.warn('[page-storage-sync] dropping localStorage write with NUL in key', key);
       return;
     }
     sink.send({ type: 'local-storage-set', key, value } satisfies LocalStorageSetMsg);
-  };
-  ls.removeItem = (key: string): void => {
+  });
+  define('removeItem', (key: string): void => {
     origRemoveItem(key);
     if (!isForwardableKey(key)) {
       console.warn('[page-storage-sync] dropping localStorage remove with NUL in key', key);
       return;
     }
     sink.send({ type: 'local-storage-remove', key } satisfies LocalStorageRemoveMsg);
-  };
-  ls.clear = (): void => {
+  });
+  define('clear', (): void => {
     origClear();
     sink.send({ type: 'local-storage-clear' } satisfies LocalStorageClearMsg);
-  };
+  });
 
   // Cross-tab writes: when another tab calls localStorage.setItem(),
   // a `storage` event fires here. The browser already updated this
@@ -120,9 +137,9 @@ export function installPageStorageSync(sink: PageStorageSyncSink): () => void {
   window.addEventListener('storage', onStorage);
 
   return () => {
-    ls.setItem = origSetItem;
-    ls.removeItem = origRemoveItem;
-    ls.clear = origClear;
+    define('setItem', origSetItem);
+    define('removeItem', origRemoveItem);
+    define('clear', origClear);
     window.removeEventListener('storage', onStorage);
   };
 }

--- a/packages/webapp/tests/kernel/page-storage-sync.test.ts
+++ b/packages/webapp/tests/kernel/page-storage-sync.test.ts
@@ -208,6 +208,34 @@ describe('installPageStorageSync', () => {
     dispose();
   });
 
+  it('installs the override methods as non-enumerable own-properties', () => {
+    // Regression for #619: assigning `ls.setItem = …` directly on the
+    // Storage instance creates an enumerable own-property, so
+    // `Object.keys(localStorage)` returns phantom keys `"setItem"`,
+    // `"removeItem"`, `"clear"` mixed with the user's stored keys.
+    // The fake storage in this test is a plain object literal (its
+    // methods are own-enumerable from the start), so we can't compare
+    // `Object.keys` directly — assert the property descriptors instead.
+    const sent: PanelToOffscreenMessage[] = [];
+    const dispose = installPageStorageSync({ send: (m) => sent.push(m) });
+
+    for (const name of ['setItem', 'removeItem', 'clear'] as const) {
+      const desc = Object.getOwnPropertyDescriptor(fakeWindow.localStorage, name);
+      expect(desc, `expected ${name} descriptor`).toBeDefined();
+      expect(desc!.enumerable, `${name} should be non-enumerable`).toBe(false);
+      expect(desc!.writable, `${name} should remain writable`).toBe(true);
+      expect(desc!.configurable, `${name} should remain configurable`).toBe(true);
+    }
+
+    // dispose() restores originals via the same defineProperty shape,
+    // so the property stays non-enumerable.
+    dispose();
+    for (const name of ['setItem', 'removeItem', 'clear'] as const) {
+      const desc = Object.getOwnPropertyDescriptor(fakeWindow.localStorage, name);
+      expect(desc!.enumerable, `${name} should remain non-enumerable after dispose`).toBe(false);
+    }
+  });
+
   it('drops cross-tab storage events with NUL in the key', () => {
     const sent: PanelToOffscreenMessage[] = [];
     const dispose = installPageStorageSync({ send: (m) => sent.push(m) });


### PR DESCRIPTION
## Summary
- `installPageStorageSync` overrode `localStorage.setItem`/`removeItem`/`clear` via direct assignment on the Storage instance. Native Storage methods live on `Storage.prototype` and are non-enumerable, but a plain assignment creates an enumerable own-property — so `Object.keys(localStorage)` and `for…in` returned phantom keys `"setItem"`, `"removeItem"`, `"clear"` whose values were the override functions.
- Install (and restore on dispose) via `Object.defineProperty` with `{ enumerable: false, writable: true, configurable: true }` so the overrides shadow the prototype without leaking into enumeration.
- Added a regression test asserting the property descriptors are non-enumerable after install and after dispose.

Fixes #619

## Test plan
- [ ] `npm run typecheck`
- [ ] `npx vitest run packages/webapp/tests/kernel/page-storage-sync.test.ts`
- [ ] In a running standalone kernel-worker float, confirm `Object.keys(window.localStorage).filter(k => ['setItem','removeItem','clear'].includes(k))` returns `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)