### PR TITLE
feat(shell): add minimal websocat client supplemental command

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -33,6 +33,7 @@ Custom commands implemented in TypeScript and registered in just-bash.
 | **node**                                    | `node-command.ts`          | Execute JavaScript code                                                                                                                                                                                                                      | `-e "console.log(1+1)"` with fs bridge                                                                                                      |
 | **python3 / python**                        | `python-command.ts`        | Execute Python code                                                                                                                                                                                                                          | `-c "print([i**2 for i in range(5)])"` with Pyodide                                                                                         |
 | **webhook**                                 | `webhook-command.ts`       | Manage webhooks for event-driven licks                                                                                                                                                                                                       | `webhook create <endpoint>`, `webhook list`, `webhook delete <id>`                                                                          |
+| **websocat**                                | `websocat-command.ts`      | Minimal WebSocket client (netcat/curl for ws://). Sends stdin lines as messages, prints received messages. Client-only — server mode and advanced specifiers (`exec:`, `tcp:`, `broadcast:`, `ws-l:`) are not supported.                     | `websocat ws://URL`, `-1` one-shot, `-b` binary, `--jsonrpc`/`--jsonrpc-omit-jsonrpc`, `--base64`, `--protocol`, `--max-messages`           |
 | **crontask**                                | `crontask-command.ts`      | Schedule cron jobs that dispatch licks                                                                                                                                                                                                       | `crontask add <name> "0 9 * * *" scoop-name "instructions..."`                                                                              |
 | **pdftk / pdf**                             | `pdftk-command.ts`         | PDF manipulation                                                                                                                                                                                                                             | `pdf burst input.pdf`, `pdf cat input.pdf output output.pdf`                                                                                |
 | **convert / magick**                        | `convert-command.ts`       | Image conversion (ImageMagick style)                                                                                                                                                                                                         | `convert -resize 800x600 input.jpg output.jpg`                                                                                              |
@@ -645,6 +646,14 @@ rg "TODO" /src --type js
 
 # Process JSON
 curl https://api.example.com/data | jq '.items[] | select(.status == "active")'
+
+# Probe a WebSocket echo server (send one message, receive one, exit)
+echo hello | websocat -1 wss://ws.vi-server.org/mirror
+
+# Drive a Chrome DevTools target via JSON-RPC over WebSocket
+echo 'Page.navigate {"url":"https://example.com"}' \
+  | websocat -1 --jsonrpc --jsonrpc-omit-jsonrpc \
+      ws://127.0.0.1:9222/devtools/page/<id>
 
 # Batch rename
 for file in *.txt; do mv "$file" "${file%.txt}.md"; done

--- a/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
+++ b/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
@@ -238,3 +238,18 @@ playwright-cli stop-recording <recordingId>        # Stop and save HAR
 - The SLICC app tab and Chrome internal UI tabs are automatically excluded from `tab-list`.
 - `fill` clears and types into regular inputs, textareas, and `contenteditable` elements.
 - Screenshots default to `/tmp/screenshot-<timestamp>.png`. Use `--filename=path` to save elsewhere.
+
+## Low-level CDP escape hatch
+
+For raw Chrome DevTools Protocol calls that `playwright-cli` doesn't wrap, send JSON-RPC directly over WebSocket with `websocat`:
+
+```bash
+# Discover the page's debug socket URL via the CDP HTTP endpoint
+curl -s http://127.0.0.1:9222/json | jq -r '.[0].webSocketDebuggerUrl'
+
+# Send a single CDP method, receive the response, exit
+echo 'Page.navigate {"url":"https://example.com"}' \
+  | websocat -1 --jsonrpc --jsonrpc-omit-jsonrpc ws://127.0.0.1:9222/devtools/page/<id>
+```
+
+Run `websocat --help` for the full flag list. Use this only when `playwright-cli` has no wrapper for the CDP method you need.

--- a/packages/webapp/src/shell/supplemental-commands/help-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/help-command.ts
@@ -58,7 +58,7 @@ const COMMAND_CATEGORIES = new Map<string, string[]>([
     ],
   ],
   ['Data processing', ['xargs', 'jq', 'base64', 'date']],
-  ['Network', ['curl', 'wget', 'html-to-markdown']],
+  ['Network', ['curl', 'wget', 'websocat', 'html-to-markdown']],
   ['Version control', ['git']],
   ['Languages', ['node', 'python', 'python3', 'sqlite3']],
   ['Skills', ['skill', 'upskill']],

--- a/packages/webapp/src/shell/supplemental-commands/index.ts
+++ b/packages/webapp/src/shell/supplemental-commands/index.ts
@@ -16,6 +16,7 @@ import { createUnameCommand } from './uname-command.js';
 import { createManCommand } from './man-command.js';
 import { createUnzipCommand } from './unzip-command.js';
 import { createWebhookCommand } from './webhook-command.js';
+import { createWebsocatCommand } from './websocat-command.js';
 import { createCrontaskCommand } from './crontask-command.js';
 import { createFsWatchCommand } from './fswatch-command.js';
 import { createSprinkleCommand } from './sprinkle-command.js';
@@ -89,6 +90,7 @@ export function createSupplementalCommands(options: SupplementalCommandsConfig =
     createPython3LikeCommand('python3'),
     createPython3LikeCommand('python'),
     createWebhookCommand(),
+    createWebsocatCommand(),
     createCrontaskCommand(),
     createFsWatchCommand(),
     createSprinkleCommand(),

--- a/packages/webapp/src/shell/supplemental-commands/websocat-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/websocat-command.ts
@@ -154,6 +154,13 @@ function parseArgs(args: string[]): ParsedArgs {
       out.text = false;
       continue;
     }
+    // Handle combined short flags before the bare single-letter cases so that
+    // e.g. `-1n` and `-n1` are not swallowed by the `-1`/`-n` branches.
+    if (a === '-1n' || a === '-n1') {
+      out.oneMessage = true;
+      out.noClose = true;
+      continue;
+    }
     if (a === '-1' || a === '--one-message') {
       out.oneMessage = true;
       continue;
@@ -207,17 +214,6 @@ function parseArgs(args: string[]): ParsedArgs {
       out.jsonrpc = true;
       continue;
     }
-    if (a === '-1' || a.startsWith('-1')) {
-      out.oneMessage = true;
-      continue;
-    }
-
-    if (a === '-n1' || a === '-1n') {
-      out.noClose = true;
-      out.oneMessage = true;
-      continue;
-    }
-
     if (a === '--close-status-code' || a.startsWith('--close-status-code=')) {
       const r = consumeValue(i, '--close-status-code');
       if (!r) return out;
@@ -305,6 +301,11 @@ function parseArgs(args: string[]): ParsedArgs {
       return out;
     }
     out.url = a;
+  }
+
+  if (out.closeReason !== undefined && out.closeStatus === undefined) {
+    out.error =
+      'websocat: --close-reason requires --close-status-code (the WebSocket close frame cannot carry a reason without a status code)\n';
   }
 
   return out;
@@ -464,52 +465,57 @@ export async function runWebsocat(
 
   let finishing = false;
   ws.onmessage = (ev: MessageEvent) => {
-    if (parsed.unidirectional) return; // -u suppresses receive output
     if (finishing) return;
-    let bytes: Uint8Array;
-    let isBinary = false;
-    if (typeof ev.data === 'string') {
-      bytes = new TextEncoder().encode(ev.data);
-    } else if (ev.data instanceof ArrayBuffer) {
-      bytes = new Uint8Array(ev.data);
-      isBinary = true;
-    } else if (ArrayBuffer.isView(ev.data)) {
-      bytes = new Uint8Array(
-        (ev.data as ArrayBufferView).buffer,
-        (ev.data as ArrayBufferView).byteOffset,
-        (ev.data as ArrayBufferView).byteLength
-      );
-      isBinary = true;
-    } else {
-      bytes = new TextEncoder().encode(String(ev.data));
-    }
-    if (bytes.length > parsed.bufferSize) {
-      note(
-        `inbound message of ${bytes.length} bytes exceeds --buffer-size ${parsed.bufferSize}; truncating`
-      );
-      bytes = bytes.slice(0, parsed.bufferSize);
-    }
-    const line = isBinary && parsed.base64 ? bytesToBase64(bytes) : bytesToTextSafe(bytes);
-    if (outLines.length < MAX_OUT_LINES) {
-      outLines.push(line);
-    } else if (droppedForOverflow === 0) {
-      note(
-        `output buffer reached ${MAX_OUT_LINES} messages; dropping further inbound messages — use -1, --max-messages, or pipe to a file with a different tool for long-running streams`
-      );
-      droppedForOverflow += 1;
-    } else {
-      droppedForOverflow += 1;
+    // `-u/--unidirectional` suppresses *output* of received messages, but we
+    // still count them so `--max-messages` and `-1` can terminate. Skipping
+    // counting here previously caused `-u -1` and `-u --max-messages N` to
+    // hang until the peer closed.
+    if (!parsed.unidirectional) {
+      let bytes: Uint8Array;
+      let isBinary = false;
+      if (typeof ev.data === 'string') {
+        bytes = new TextEncoder().encode(ev.data);
+      } else if (ev.data instanceof ArrayBuffer) {
+        bytes = new Uint8Array(ev.data);
+        isBinary = true;
+      } else if (ArrayBuffer.isView(ev.data)) {
+        bytes = new Uint8Array(
+          (ev.data as ArrayBufferView).buffer,
+          (ev.data as ArrayBufferView).byteOffset,
+          (ev.data as ArrayBufferView).byteLength
+        );
+        isBinary = true;
+      } else {
+        bytes = new TextEncoder().encode(String(ev.data));
+      }
+      if (bytes.length > parsed.bufferSize) {
+        note(
+          `inbound message of ${bytes.length} bytes exceeds --buffer-size ${parsed.bufferSize}; truncating`
+        );
+        bytes = bytes.slice(0, parsed.bufferSize);
+      }
+      const line = isBinary && parsed.base64 ? bytesToBase64(bytes) : bytesToTextSafe(bytes);
+      if (outLines.length < MAX_OUT_LINES) {
+        outLines.push(line);
+      } else if (droppedForOverflow === 0) {
+        note(
+          `output buffer reached ${MAX_OUT_LINES} messages; dropping further inbound messages — use -1, --max-messages, or pipe to a file with a different tool for long-running streams`
+        );
+        droppedForOverflow += 1;
+      } else {
+        droppedForOverflow += 1;
+      }
     }
     received += 1;
 
     if (parsed.maxMessages !== undefined && received >= parsed.maxMessages) {
       finishing = true;
-      closeAndFinish(parsed.closeStatus ?? 1000, parsed.closeReason);
+      terminate();
       return;
     }
     if (parsed.oneMessage) {
       finishing = true;
-      closeAndFinish(parsed.closeStatus ?? 1000, parsed.closeReason);
+      terminate();
     }
   };
 
@@ -552,6 +558,20 @@ export async function runWebsocat(
     }
   }
 
+  /**
+   * Reach the "we're done" state. Honors `-n/--no-close`: when set, resolve the
+   * done promise directly instead of sending a Close frame to the peer.
+   * Otherwise emit a clean Close(1000) (or `--close-status-code`) and let the
+   * resulting onclose drive doneResolve.
+   */
+  function terminate() {
+    if (parsed.noClose) {
+      doneResolve(exitCode);
+      return;
+    }
+    closeAndFinish(parsed.closeStatus ?? 1000, parsed.closeReason);
+  }
+
   try {
     await openedPromise;
   } catch (err) {
@@ -559,7 +579,7 @@ export async function runWebsocat(
     const m = err instanceof Error ? err.message : String(err);
     return {
       stdout: outLines.join(outSep) + (outLines.length ? outSep : ''),
-      stderr: diagnostics.concat([`websocat: ${m}`]).join('\n') + (diagnostics.length ? '\n' : ''),
+      stderr: diagnostics.concat([`websocat: ${m}`]).join('\n') + '\n',
       exitCode: m === 'connect timeout' ? 124 : 1,
     };
   }

--- a/packages/webapp/src/shell/supplemental-commands/websocat-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/websocat-command.ts
@@ -1,0 +1,580 @@
+import { defineCommand } from 'just-bash';
+import type { Command } from 'just-bash';
+
+interface ParsedArgs {
+  url?: string;
+  text: boolean;
+  binary: boolean;
+  oneMessage: boolean;
+  noClose: boolean;
+  exitOnEof: boolean;
+  unidirectional: boolean;
+  unidirectionalReverse: boolean;
+  insecure: boolean;
+  quiet: boolean;
+  verbose: number;
+  nullTerminated: boolean;
+  base64: boolean;
+  jsonrpc: boolean;
+  jsonrpcOmit: boolean;
+  closeStatus?: number;
+  closeReason?: string;
+  bufferSize: number;
+  maxMessages?: number;
+  protocol?: string;
+  pingInterval?: number;
+  connTimeoutMs: number;
+  customHeaders: string[];
+  showHelp: boolean;
+  error?: string;
+}
+
+function websocatHelp(): { stdout: string; stderr: string; exitCode: number } {
+  return {
+    stdout: `usage: websocat [FLAGS] [OPTIONS] <ws://URL | wss://URL>
+
+Minimal websocat client. Sends stdin lines as WebSocket messages and prints
+received messages to stdout. Server mode and advanced specifiers (exec:, tcp:,
+broadcast:, ws-l:, etc.) are NOT supported — slicc's websocat is client-only.
+
+FLAGS:
+  -t, --text                 Send stdin as text messages (default)
+  -b, --binary               Send stdin as binary messages
+  -1, --one-message          Send and/or receive exactly one message, then exit
+  -n, --no-close             Do not send a Close frame on stdin EOF
+  -E, --exit-on-eof          Exit once peer closes its half
+  -u, --unidirectional       Only send (do not print received messages)
+  -U, --unidirectional-rev   Only receive (do not send anything from stdin)
+  -k, --insecure             No-op in browsers (cert validation is fixed)
+  -q                         Suppress diagnostic messages
+  -v                         Verbose (repeat for more)
+  -0, --null-terminated      Split stdin / output on \\0 instead of \\n
+      --base64               Encode binary messages as base64 on output
+      --jsonrpc              Wrap stdin lines as JSON-RPC 2.0 method calls
+      --jsonrpc-omit-jsonrpc Omit the "jsonrpc":"2.0" field (CDP-style)
+  -h, --help                 Show this help
+
+OPTIONS:
+      --close-status-code N  Send Close with status code N (default 1000)
+      --close-reason TEXT    Close reason string (requires --close-status-code)
+  -B, --buffer-size N        Max inbound message size in bytes (default 65536)
+      --max-messages N       Exit after N inbound messages
+      --protocol NAME        WebSocket subprotocol (Sec-WebSocket-Protocol)
+      --ping-interval SEC    Accepted for parity; browsers expose no ping API
+      --conn-timeout SEC     Abort connect after SEC seconds (default 30)
+  -H, --header "K: V"        Accepted for parity; browsers reject arbitrary
+                             headers — only --protocol is honored
+
+EXAMPLES:
+  # Echo round-trip
+  echo hello | websocat -1 wss://ws.vi-server.org/mirror
+
+  # Send a CDP command to a Chrome target
+  echo 'Page.navigate {"url":"https://example.com"}' \\
+    | websocat -1 --jsonrpc --jsonrpc-omit-jsonrpc \\
+        ws://127.0.0.1:9222/devtools/page/<id>
+`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+const UNSUPPORTED_FLAGS = new Set([
+  '-s',
+  '--server-mode',
+  '--oneshot',
+  '--socks5',
+  '--basic-auth',
+  '--basic-auth-file',
+  '--header-to-env',
+  '--server-header',
+  '--exec',
+  '--ws-c-uri',
+  '--restrict-uri',
+  '--unlink',
+  '--strict',
+  '-S',
+]);
+
+function parseArgs(args: string[]): ParsedArgs {
+  const out: ParsedArgs = {
+    text: true,
+    binary: false,
+    oneMessage: false,
+    noClose: false,
+    exitOnEof: false,
+    unidirectional: false,
+    unidirectionalReverse: false,
+    insecure: false,
+    quiet: false,
+    verbose: 0,
+    nullTerminated: false,
+    base64: false,
+    jsonrpc: false,
+    jsonrpcOmit: false,
+    bufferSize: 65536,
+    connTimeoutMs: 30000,
+    customHeaders: [],
+    showHelp: false,
+  };
+
+  const consumeValue = (i: number, flag: string): { value: string; next: number } | null => {
+    const eq = args[i].indexOf('=');
+    if (eq !== -1 && args[i].startsWith(flag)) {
+      return { value: args[i].slice(eq + 1), next: i };
+    }
+    const next = args[i + 1];
+    if (next === undefined) {
+      out.error = `websocat: missing value for ${flag}\n`;
+      return null;
+    }
+    return { value: next, next: i + 1 };
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+
+    if (a === '-h' || a === '--help') {
+      out.showHelp = true;
+      return out;
+    }
+
+    if (UNSUPPORTED_FLAGS.has(a) || UNSUPPORTED_FLAGS.has(a.split('=')[0])) {
+      out.error = `websocat: flag '${a}' is not supported in slicc's minimal client\n`;
+      return out;
+    }
+
+    if (a === '-t' || a === '--text') {
+      out.text = true;
+      out.binary = false;
+      continue;
+    }
+    if (a === '-b' || a === '--binary') {
+      out.binary = true;
+      out.text = false;
+      continue;
+    }
+    if (a === '-1' || a === '--one-message') {
+      out.oneMessage = true;
+      continue;
+    }
+    if (a === '-n' || a === '--no-close') {
+      out.noClose = true;
+      continue;
+    }
+    if (a === '-E' || a === '--exit-on-eof') {
+      out.exitOnEof = true;
+      continue;
+    }
+    if (a === '-u' || a === '--unidirectional') {
+      out.unidirectional = true;
+      continue;
+    }
+    if (a === '-U' || a === '--unidirectional-reverse') {
+      out.unidirectionalReverse = true;
+      continue;
+    }
+    if (a === '-k' || a === '--insecure') {
+      out.insecure = true;
+      continue;
+    }
+    if (a === '-q') {
+      out.quiet = true;
+      continue;
+    }
+    if (a === '-v') {
+      out.verbose += 1;
+      continue;
+    }
+    if (a === '-vv') {
+      out.verbose += 2;
+      continue;
+    }
+    if (a === '-0' || a === '--null-terminated') {
+      out.nullTerminated = true;
+      continue;
+    }
+    if (a === '--base64') {
+      out.base64 = true;
+      continue;
+    }
+    if (a === '--jsonrpc') {
+      out.jsonrpc = true;
+      continue;
+    }
+    if (a === '--jsonrpc-omit-jsonrpc') {
+      out.jsonrpcOmit = true;
+      out.jsonrpc = true;
+      continue;
+    }
+    if (a === '-1' || a.startsWith('-1')) {
+      out.oneMessage = true;
+      continue;
+    }
+
+    if (a === '-n1' || a === '-1n') {
+      out.noClose = true;
+      out.oneMessage = true;
+      continue;
+    }
+
+    if (a === '--close-status-code' || a.startsWith('--close-status-code=')) {
+      const r = consumeValue(i, '--close-status-code');
+      if (!r) return out;
+      const n = Number(r.value);
+      if (!Number.isFinite(n) || n < 1000 || n > 4999) {
+        out.error = `websocat: --close-status-code expects 1000..4999, got '${r.value}'\n`;
+        return out;
+      }
+      out.closeStatus = n;
+      i = r.next;
+      continue;
+    }
+    if (a === '--close-reason' || a.startsWith('--close-reason=')) {
+      const r = consumeValue(i, '--close-reason');
+      if (!r) return out;
+      out.closeReason = r.value;
+      i = r.next;
+      continue;
+    }
+    if (a === '-B' || a === '--buffer-size' || a.startsWith('--buffer-size=')) {
+      const r = consumeValue(i, a === '-B' ? '-B' : '--buffer-size');
+      if (!r) return out;
+      const n = Number(r.value);
+      if (!Number.isFinite(n) || n <= 0) {
+        out.error = `websocat: --buffer-size expects positive integer\n`;
+        return out;
+      }
+      out.bufferSize = n;
+      i = r.next;
+      continue;
+    }
+    if (a === '--max-messages' || a.startsWith('--max-messages=')) {
+      const r = consumeValue(i, '--max-messages');
+      if (!r) return out;
+      const n = Number(r.value);
+      if (!Number.isFinite(n) || n <= 0) {
+        out.error = `websocat: --max-messages expects positive integer\n`;
+        return out;
+      }
+      out.maxMessages = n;
+      i = r.next;
+      continue;
+    }
+    if (a === '--protocol' || a.startsWith('--protocol=')) {
+      const r = consumeValue(i, '--protocol');
+      if (!r) return out;
+      out.protocol = r.value;
+      i = r.next;
+      continue;
+    }
+    if (a === '--ping-interval' || a.startsWith('--ping-interval=')) {
+      const r = consumeValue(i, '--ping-interval');
+      if (!r) return out;
+      out.pingInterval = Number(r.value);
+      i = r.next;
+      continue;
+    }
+    if (a === '--conn-timeout' || a.startsWith('--conn-timeout=')) {
+      const r = consumeValue(i, '--conn-timeout');
+      if (!r) return out;
+      const n = Number(r.value);
+      if (!Number.isFinite(n) || n <= 0) {
+        out.error = `websocat: --conn-timeout expects positive seconds\n`;
+        return out;
+      }
+      out.connTimeoutMs = Math.round(n * 1000);
+      i = r.next;
+      continue;
+    }
+    if (a === '-H' || a === '--header' || a.startsWith('--header=')) {
+      const r = consumeValue(i, a === '-H' ? '-H' : '--header');
+      if (!r) return out;
+      out.customHeaders.push(r.value);
+      i = r.next;
+      continue;
+    }
+
+    if (a.startsWith('-')) {
+      out.error = `websocat: unknown flag '${a}'\n`;
+      return out;
+    }
+
+    if (out.url) {
+      out.error = `websocat: extra positional argument '${a}' — advanced mode is not supported\n`;
+      return out;
+    }
+    out.url = a;
+  }
+
+  return out;
+}
+
+function splitStdin(stdin: string, nullTerm: boolean): string[] {
+  if (!stdin) return [];
+  const sep = nullTerm ? '\0' : '\n';
+  const parts = stdin.split(sep);
+  // Drop the trailing empty fragment when input ended with the separator.
+  if (parts.length > 0 && parts[parts.length - 1] === '') parts.pop();
+  return parts;
+}
+
+function buildJsonRpc(line: string, id: number, omit: boolean): string {
+  const trimmed = line.trim();
+  if (!trimmed) return line;
+  const spaceIdx = trimmed.search(/\s/);
+  const method = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
+  const rest = spaceIdx === -1 ? '' : trimmed.slice(spaceIdx + 1).trim();
+  let params: unknown = [];
+  if (rest) {
+    try {
+      params = JSON.parse(rest);
+    } catch {
+      params = [rest];
+    }
+  }
+  const payload: Record<string, unknown> = { id, method, params };
+  if (!omit) payload.jsonrpc = '2.0';
+  return JSON.stringify(payload);
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i += 1) bin += String.fromCharCode(bytes[i]);
+  // btoa exists in browsers + Node 16+
+  return btoa(bin);
+}
+
+function bytesToTextSafe(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+  } catch {
+    return bytesToBase64(bytes);
+  }
+}
+
+interface WebsocatRunDeps {
+  WebSocketCtor?: typeof WebSocket;
+}
+
+export async function runWebsocat(
+  args: string[],
+  ctx: { stdin: string },
+  deps: WebsocatRunDeps = {}
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const parsed = parseArgs(args);
+  if (parsed.showHelp) return websocatHelp();
+  if (parsed.error) return { stdout: '', stderr: parsed.error, exitCode: 2 };
+  if (!parsed.url) {
+    return {
+      stdout: '',
+      stderr: 'websocat: missing ws:// or wss:// URL (use --help for usage)\n',
+      exitCode: 2,
+    };
+  }
+  if (!/^wss?:\/\//i.test(parsed.url)) {
+    return {
+      stdout: '',
+      stderr: `websocat: URL must start with ws:// or wss://, got '${parsed.url}'\n`,
+      exitCode: 2,
+    };
+  }
+
+  const WS = deps.WebSocketCtor ?? (typeof WebSocket !== 'undefined' ? WebSocket : undefined);
+  if (!WS) {
+    return {
+      stdout: '',
+      stderr: 'websocat: no WebSocket implementation available in this runtime\n',
+      exitCode: 1,
+    };
+  }
+
+  const diagnostics: string[] = [];
+  const note = (msg: string) => {
+    if (!parsed.quiet) diagnostics.push(`websocat: ${msg}`);
+  };
+  if (parsed.verbose >= 1) {
+    if (parsed.customHeaders.length > 0) {
+      note(
+        '-H/--header is accepted for parity but browsers do not allow setting WebSocket request headers; only --protocol is honored'
+      );
+    }
+    if (parsed.pingInterval !== undefined) {
+      note('--ping-interval has no effect in browsers (no ping API exposed)');
+    }
+    if (parsed.insecure) {
+      note('-k/--insecure has no effect in browsers');
+    }
+  }
+
+  const outLines: string[] = [];
+  const outSep = parsed.nullTerminated ? '\0' : '\n';
+
+  let ws: WebSocket;
+  try {
+    ws = parsed.protocol ? new WS(parsed.url, parsed.protocol) : new WS(parsed.url);
+  } catch (err) {
+    const m = err instanceof Error ? err.message : String(err);
+    return { stdout: '', stderr: `websocat: connect failed: ${m}\n`, exitCode: 1 };
+  }
+  ws.binaryType = 'arraybuffer';
+
+  let received = 0;
+  let openedResolve!: () => void;
+  let openedReject!: (e: Error) => void;
+  const opened = new Promise<void>((res, rej) => {
+    openedResolve = res;
+    openedReject = rej;
+  });
+
+  let doneResolve!: (code: number) => void;
+  const done = new Promise<number>((res) => {
+    doneResolve = res;
+  });
+
+  let exitCode = 0;
+  let timedOut = false;
+  const connTimer = setTimeout(() => {
+    timedOut = true;
+    try {
+      ws.close();
+    } catch {
+      /* noop */
+    }
+    openedReject(new Error('connect timeout'));
+  }, parsed.connTimeoutMs);
+
+  ws.onopen = () => {
+    clearTimeout(connTimer);
+    openedResolve();
+  };
+
+  let finishing = false;
+  ws.onmessage = (ev: MessageEvent) => {
+    if (parsed.unidirectional) return; // -u suppresses receive output
+    if (finishing) return;
+    let bytes: Uint8Array;
+    let isBinary = false;
+    if (typeof ev.data === 'string') {
+      bytes = new TextEncoder().encode(ev.data);
+    } else if (ev.data instanceof ArrayBuffer) {
+      bytes = new Uint8Array(ev.data);
+      isBinary = true;
+    } else if (ArrayBuffer.isView(ev.data)) {
+      bytes = new Uint8Array(
+        (ev.data as ArrayBufferView).buffer,
+        (ev.data as ArrayBufferView).byteOffset,
+        (ev.data as ArrayBufferView).byteLength
+      );
+      isBinary = true;
+    } else {
+      bytes = new TextEncoder().encode(String(ev.data));
+    }
+    if (bytes.length > parsed.bufferSize) {
+      note(
+        `inbound message of ${bytes.length} bytes exceeds --buffer-size ${parsed.bufferSize}; truncating`
+      );
+      bytes = bytes.slice(0, parsed.bufferSize);
+    }
+    const line = isBinary && parsed.base64 ? bytesToBase64(bytes) : bytesToTextSafe(bytes);
+    outLines.push(line);
+    received += 1;
+
+    if (parsed.maxMessages !== undefined && received >= parsed.maxMessages) {
+      finishing = true;
+      closeAndFinish(parsed.closeStatus ?? 1000, parsed.closeReason);
+      return;
+    }
+    if (parsed.oneMessage) {
+      finishing = true;
+      closeAndFinish(parsed.closeStatus ?? 1000, parsed.closeReason);
+    }
+  };
+
+  ws.onerror = () => {
+    // Browsers do not expose a useful error payload here; surface generic.
+    if (timedOut) return;
+    note('websocket error');
+    exitCode = 1;
+  };
+
+  ws.onclose = (ev: CloseEvent) => {
+    clearTimeout(connTimer);
+    if (timedOut) {
+      doneResolve(124);
+      return;
+    }
+    if (parsed.verbose >= 1) {
+      note(`closed code=${ev.code} reason=${JSON.stringify(ev.reason || '')}`);
+    }
+    if (exitCode === 0 && ev.code !== 1000 && ev.code !== 1005 && ev.code !== 1001) {
+      // Non-normal close → non-zero exit
+      exitCode = 1;
+    }
+    doneResolve(exitCode);
+  };
+
+  function closeAndFinish(code: number, reason?: string) {
+    try {
+      if (reason !== undefined) ws.close(code, reason);
+      else ws.close(code);
+    } catch {
+      /* noop */
+    }
+  }
+
+  try {
+    await opened;
+  } catch (err) {
+    clearTimeout(connTimer);
+    const m = err instanceof Error ? err.message : String(err);
+    return {
+      stdout: outLines.join(outSep) + (outLines.length ? outSep : ''),
+      stderr: diagnostics.concat([`websocat: ${m}`]).join('\n') + (diagnostics.length ? '\n' : ''),
+      exitCode: m === 'connect timeout' ? 124 : 1,
+    };
+  }
+
+  // Send stdin lines (unless -U).
+  if (!parsed.unidirectionalReverse) {
+    const lines = splitStdin(ctx.stdin, parsed.nullTerminated);
+    let id = 1;
+    let sent = 0;
+    const toSend = parsed.oneMessage ? lines.slice(0, 1) : lines;
+    for (const raw of toSend) {
+      let payload: string | ArrayBuffer = raw;
+      if (parsed.jsonrpc) {
+        payload = buildJsonRpc(raw, id, parsed.jsonrpcOmit);
+        id += 1;
+      }
+      if (parsed.binary) {
+        ws.send(new TextEncoder().encode(payload as string).buffer as ArrayBuffer);
+      } else {
+        ws.send(payload as string);
+      }
+      sent += 1;
+    }
+
+    if (!parsed.oneMessage && !parsed.noClose && (parsed.exitOnEof || sent === 0)) {
+      // EOF on stdin + close requested → send close after a tick to drain
+      setTimeout(() => {
+        closeAndFinish(parsed.closeStatus ?? 1000, parsed.closeReason);
+      }, 0);
+    }
+  } else if (!parsed.noClose && parsed.exitOnEof && !parsed.oneMessage) {
+    setTimeout(() => {
+      closeAndFinish(parsed.closeStatus ?? 1000, parsed.closeReason);
+    }, 0);
+  }
+
+  const code = await done;
+  const stdout = outLines.length ? outLines.join(outSep) + outSep : '';
+  const stderr = diagnostics.length ? diagnostics.join('\n') + '\n' : '';
+  return { stdout, stderr, exitCode: code };
+}
+
+export function createWebsocatCommand(): Command {
+  return defineCommand('websocat', async (args, ctx) => {
+    return runWebsocat(args, { stdin: ctx.stdin });
+  });
+}

--- a/packages/webapp/src/shell/supplemental-commands/websocat-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/websocat-command.ts
@@ -420,16 +420,28 @@ export async function runWebsocat(
   ws.binaryType = 'arraybuffer';
 
   let received = 0;
+  // Cap the in-memory output buffer to bound RSS for long-running sessions.
+  // Inbound messages beyond this drop with a single diagnostic warning so the
+  // command can't OOM the host page on a chatty server when neither -1 nor
+  // --max-messages is set.
+  const MAX_OUT_LINES = 10000;
+  let droppedForOverflow = 0;
+  let opened = false;
   let openedResolve!: () => void;
   let openedReject!: (e: Error) => void;
-  const opened = new Promise<void>((res, rej) => {
+  const openedPromise = new Promise<void>((res, rej) => {
     openedResolve = res;
     openedReject = rej;
   });
 
   let doneResolve!: (code: number) => void;
+  let doneSettled = false;
   const done = new Promise<number>((res) => {
-    doneResolve = res;
+    doneResolve = (code: number) => {
+      if (doneSettled) return;
+      doneSettled = true;
+      res(code);
+    };
   });
 
   let exitCode = 0;
@@ -441,11 +453,12 @@ export async function runWebsocat(
     } catch {
       /* noop */
     }
-    openedReject(new Error('connect timeout'));
+    if (!opened) openedReject(new Error('connect timeout'));
   }, parsed.connTimeoutMs);
 
   ws.onopen = () => {
     clearTimeout(connTimer);
+    opened = true;
     openedResolve();
   };
 
@@ -477,7 +490,16 @@ export async function runWebsocat(
       bytes = bytes.slice(0, parsed.bufferSize);
     }
     const line = isBinary && parsed.base64 ? bytesToBase64(bytes) : bytesToTextSafe(bytes);
-    outLines.push(line);
+    if (outLines.length < MAX_OUT_LINES) {
+      outLines.push(line);
+    } else if (droppedForOverflow === 0) {
+      note(
+        `output buffer reached ${MAX_OUT_LINES} messages; dropping further inbound messages — use -1, --max-messages, or pipe to a file with a different tool for long-running streams`
+      );
+      droppedForOverflow += 1;
+    } else {
+      droppedForOverflow += 1;
+    }
     received += 1;
 
     if (parsed.maxMessages !== undefined && received >= parsed.maxMessages) {
@@ -496,6 +518,10 @@ export async function runWebsocat(
     if (timedOut) return;
     note('websocket error');
     exitCode = 1;
+    // If the error fires before onopen, no future open event is coming —
+    // reject the opened promise so the outer await doesn't hang. The follow-up
+    // onclose still drives the final exit code.
+    if (!opened) openedReject(new Error('connect failed'));
   };
 
   ws.onclose = (ev: CloseEvent) => {
@@ -511,6 +537,9 @@ export async function runWebsocat(
       // Non-normal close → non-zero exit
       exitCode = 1;
     }
+    // Same defensive rejection as in onerror: if the socket closes before
+    // open, the outer `await opened` must unblock.
+    if (!opened) openedReject(new Error(`connect closed (code ${ev.code})`));
     doneResolve(exitCode);
   };
 
@@ -524,7 +553,7 @@ export async function runWebsocat(
   }
 
   try {
-    await opened;
+    await openedPromise;
   } catch (err) {
     clearTimeout(connTimer);
     const m = err instanceof Error ? err.message : String(err);
@@ -568,6 +597,9 @@ export async function runWebsocat(
   }
 
   const code = await done;
+  if (droppedForOverflow > 0) {
+    note(`dropped ${droppedForOverflow} inbound message(s) due to output buffer cap`);
+  }
   const stdout = outLines.length ? outLines.join(outSep) + outSep : '';
   const stderr = diagnostics.length ? diagnostics.join('\n') + '\n' : '';
   return { stdout, stderr, exitCode: code };

--- a/packages/webapp/tests/shell/supplemental-commands/websocat-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/websocat-command.test.ts
@@ -247,6 +247,77 @@ describe('websocat command', () => {
     expect(r.exitCode).toBe(1);
   });
 
+  it('parses -1n and -n1 as one-message + no-close (regression for prefix swallow)', async () => {
+    for (const combined of ['-1n', '-n1']) {
+      const Ctor = makeCtor();
+      const promise = runWebsocat([combined, 'ws://x'], { stdin: 'hi\n' }, { WebSocketCtor: Ctor });
+      await new Promise((r) => setTimeout(r, 0));
+      const sock = MockWebSocket.instances[0];
+      sock.fireOpen();
+      await new Promise((r) => setTimeout(r, 0));
+      // -1n sends one message…
+      expect(sock.sent).toHaveLength(1);
+      sock.fireText('ack');
+      const r = await promise;
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toBe('ack\n');
+      // …and -n means: do not send a Close frame ourselves.
+      expect(sock.closeCalls).toHaveLength(0);
+    }
+  });
+
+  it('terminates -u --max-messages by counting inbound messages without emitting them', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(
+      ['-u', '--max-messages', '2', 'ws://x'],
+      { stdin: '' },
+      { WebSocketCtor: Ctor }
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    sock.fireOpen();
+    sock.fireText('hidden-one');
+    sock.fireText('hidden-two');
+    const r = await promise;
+    expect(r.exitCode).toBe(0);
+    // -u suppresses output but message count drove termination.
+    expect(r.stdout).toBe('');
+    expect(sock.closeCalls).toHaveLength(1);
+  });
+
+  it('terminates -u -1 after one inbound message (counted but not emitted)', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(['-u', '-1', 'ws://x'], { stdin: 'hi\n' }, { WebSocketCtor: Ctor });
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    sock.fireOpen();
+    await new Promise((r) => setTimeout(r, 0));
+    sock.fireText('reply-not-printed');
+    const r = await promise;
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(sock.closeCalls).toHaveLength(1);
+  });
+
+  it('rejects --close-reason without --close-status-code', async () => {
+    const r = await runWebsocat(['--close-reason', 'goodbye', 'ws://x'], { stdin: '' });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('--close-reason requires --close-status-code');
+  });
+
+  it('always terminates stderr with a newline on connect failure', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(['ws://refused'], { stdin: '' }, { WebSocketCtor: Ctor });
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    sock.fireError();
+    sock.fireClose(1006, '');
+    const r = await promise;
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).not.toBe('');
+    expect(r.stderr.endsWith('\n')).toBe(true);
+  });
+
   it('warns under -v that custom headers are not honored', async () => {
     const Ctor = makeCtor();
     const promise = runWebsocat(

--- a/packages/webapp/tests/shell/supplemental-commands/websocat-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/websocat-command.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createWebsocatCommand,
+  runWebsocat,
+} from '../../../src/shell/supplemental-commands/websocat-command.js';
+
+interface SentFrame {
+  data: string | ArrayBuffer;
+}
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  protocols: string | string[] | undefined;
+  binaryType: BinaryType = 'blob';
+  readyState = 0;
+  sent: SentFrame[] = [];
+
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+
+  constructor(url: string, protocols?: string | string[]) {
+    this.url = url;
+    this.protocols = protocols;
+    MockWebSocket.instances.push(this);
+  }
+
+  fireOpen() {
+    this.readyState = 1;
+    this.onopen?.(new Event('open'));
+  }
+  fireText(text: string) {
+    this.onmessage?.(new MessageEvent('message', { data: text }));
+  }
+  fireBinary(bytes: Uint8Array) {
+    const buf = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    this.onmessage?.(new MessageEvent('message', { data: buf }));
+  }
+  fireClose(code = 1000, reason = '') {
+    this.readyState = 3;
+    this.onclose?.(new CloseEvent('close', { code, reason, wasClean: code === 1000 }));
+  }
+  fireError() {
+    this.onerror?.(new Event('error'));
+  }
+  send(data: string | ArrayBuffer) {
+    this.sent.push({ data });
+  }
+  close(code?: number, reason?: string) {
+    this.closeCalls.push({ code, reason });
+    // Simulate the browser firing close after we call close().
+    setTimeout(() => this.fireClose(code ?? 1000, reason ?? ''), 0);
+  }
+}
+
+function makeCtor() {
+  MockWebSocket.instances = [];
+  return MockWebSocket as unknown as typeof WebSocket;
+}
+
+describe('websocat command', () => {
+  it('exposes the correct name', () => {
+    expect(createWebsocatCommand().name).toBe('websocat');
+  });
+
+  it('prints help with -h', async () => {
+    const r = await runWebsocat(['-h'], { stdin: '' });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('Minimal websocat client');
+    expect(r.stdout).toContain('Server mode and advanced specifiers');
+  });
+
+  it('errors when URL is missing', async () => {
+    const r = await runWebsocat([], { stdin: '' });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('missing ws:// or wss:// URL');
+  });
+
+  it('rejects non-ws URLs', async () => {
+    const r = await runWebsocat(['https://example.com'], { stdin: '' });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('must start with ws:// or wss://');
+  });
+
+  it('rejects server mode and other unsupported flags', async () => {
+    const r1 = await runWebsocat(['-s', '1234'], { stdin: '' });
+    expect(r1.exitCode).toBe(2);
+    expect(r1.stderr).toContain("flag '-s' is not supported");
+
+    const r2 = await runWebsocat(['--socks5', '127.0.0.1:9050', 'ws://x'], { stdin: '' });
+    expect(r2.exitCode).toBe(2);
+    expect(r2.stderr).toContain('--socks5');
+  });
+
+  it('rejects extra positional args (no advanced mode)', async () => {
+    const r = await runWebsocat(['ws://a', 'tcp:1.2.3.4:5'], { stdin: '' });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('advanced mode is not supported');
+  });
+
+  it('does a one-shot send/receive round trip', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(
+      ['-1', 'ws://test/echo'],
+      { stdin: 'hello\n' },
+      { WebSocketCtor: Ctor }
+    );
+
+    // Let the constructor and listeners attach.
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.fireOpen();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sock.sent).toHaveLength(1);
+    expect(sock.sent[0].data).toBe('hello');
+    sock.fireText('world');
+    // -1 triggers close after first message; mock fires close on next tick.
+    const r = await promise;
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe('world\n');
+  });
+
+  it('formats JSON-RPC with --jsonrpc-omit-jsonrpc', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(
+      ['-1', '--jsonrpc-omit-jsonrpc', 'ws://cdp'],
+      { stdin: 'Page.navigate {"url":"https://example.com"}\n' },
+      { WebSocketCtor: Ctor }
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    sock.fireOpen();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sock.sent).toHaveLength(1);
+    const payload = JSON.parse(sock.sent[0].data as string);
+    expect(payload.method).toBe('Page.navigate');
+    expect(payload.params).toEqual({ url: 'https://example.com' });
+    expect(payload.id).toBe(1);
+    expect(payload.jsonrpc).toBeUndefined();
+    sock.fireText('{"id":1,"result":{}}');
+    await promise;
+  });
+
+  it('base64-encodes binary frames when --base64 is set', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(
+      ['-1', '--base64', '-U', 'ws://bin'],
+      { stdin: '' },
+      { WebSocketCtor: Ctor }
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    sock.fireOpen();
+    await new Promise((r) => setTimeout(r, 0));
+    sock.fireBinary(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+    const r = await promise;
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('3q2+7w==');
+  });
+
+  it('honors --max-messages', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(
+      ['--max-messages', '2', '-U', 'ws://x'],
+      { stdin: '' },
+      { WebSocketCtor: Ctor }
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    sock.fireOpen();
+    sock.fireText('one');
+    sock.fireText('two');
+    sock.fireText('three');
+    const r = await promise;
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe('one\ntwo\n');
+  });
+
+  it('sends each stdin line as a separate message in multi-message mode', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(['-E', 'ws://x'], { stdin: 'a\nb\nc\n' }, { WebSocketCtor: Ctor });
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    sock.fireOpen();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sock.sent.map((f) => f.data)).toEqual(['a', 'b', 'c']);
+    await promise;
+  });
+
+  it('passes --protocol as the WebSocket subprotocol', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(
+      ['-1', '--protocol', 'chat.v1', 'ws://x'],
+      { stdin: 'hi\n' },
+      { WebSocketCtor: Ctor }
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    expect(sock.protocols).toBe('chat.v1');
+    sock.fireOpen();
+    await new Promise((r) => setTimeout(r, 0));
+    sock.fireText('ack');
+    await promise;
+  });
+
+  it('reports connect timeout as exit 124', async () => {
+    vi.useFakeTimers();
+    const Ctor = makeCtor();
+    const promise = runWebsocat(
+      ['--conn-timeout', '1', 'ws://slow'],
+      { stdin: '' },
+      { WebSocketCtor: Ctor }
+    );
+    await vi.advanceTimersByTimeAsync(1001);
+    // The mock close() schedules an onclose tick.
+    await vi.advanceTimersByTimeAsync(10);
+    const r = await promise;
+    expect(r.exitCode).toBe(124);
+    vi.useRealTimers();
+  });
+
+  it('warns under -v that custom headers are not honored', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(
+      ['-1', '-v', '-H', 'X-Test: 1', 'ws://x'],
+      { stdin: 'hi\n' },
+      { WebSocketCtor: Ctor }
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    sock.fireOpen();
+    await new Promise((r) => setTimeout(r, 0));
+    sock.fireText('ack');
+    const r = await promise;
+    expect(r.stderr).toContain('browsers do not allow setting WebSocket request headers');
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/websocat-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/websocat-command.test.ts
@@ -225,6 +225,28 @@ describe('websocat command', () => {
     vi.useRealTimers();
   });
 
+  it('does not hang when the socket fires error before open (refused)', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(['ws://refused'], { stdin: '' }, { WebSocketCtor: Ctor });
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    sock.fireError();
+    sock.fireClose(1006, 'refused');
+    const r = await promise;
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('connect');
+  });
+
+  it('does not hang when the socket closes before open (no error event)', async () => {
+    const Ctor = makeCtor();
+    const promise = runWebsocat(['ws://aborted'], { stdin: '' }, { WebSocketCtor: Ctor });
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = MockWebSocket.instances[0];
+    sock.fireClose(1006, '');
+    const r = await promise;
+    expect(r.exitCode).toBe(1);
+  });
+
   it('warns under -v that custom headers are not honored', async () => {
     const Ctor = makeCtor();
     const promise = runWebsocat(


### PR DESCRIPTION
## Summary

- Adds a client-only `websocat` shell command (netcat for `ws://` / `wss://`) implemented in TypeScript and registered as a supplemental command. One implementation covers all three floats (extension, node-server, swift-server) because it uses the native browser `WebSocket` API that the WasmShell host always has access to.
- Stdin lines become outgoing messages; inbound messages stream to stdout. `--jsonrpc` framing makes direct Chrome DevTools Protocol calls a one-liner. Unsupported features (server mode, `exec:`, `tcp:`, `broadcast:`, `ws-l:`, SOCKS5, etc.) fail fast with a clear error rather than silently no-op'ing.
- Discoverable for agents: registered in the `commands` Network category, added to `docs/shell-reference.md`, and cross-referenced from the `playwright-cli` SKILL as a low-level CDP escape hatch.

### Supported flags
`-t/-b`, `-1`, `-n`, `-E`, `-u/-U`, `-k`, `-q`, `-v`, `-0`, `-h`, `--base64`, `--jsonrpc`/`--jsonrpc-omit-jsonrpc`, `--close-status-code`/`--close-reason`, `-B/--buffer-size`, `--max-messages`, `--protocol`, `--ping-interval` (parity no-op), `--conn-timeout`, `-H/--header` (parity, warns under `-v` since browsers do not let you set arbitrary WS request headers).

### Example
```bash
# Echo round-trip
echo hello | websocat -1 wss://ws.vi-server.org/mirror

# Drive a Chrome DevTools target via JSON-RPC over WebSocket
echo 'Page.navigate {"url":"https://example.com"}' \
  | websocat -1 --jsonrpc --jsonrpc-omit-jsonrpc \
      ws://127.0.0.1:9222/devtools/page/<id>
```

## Test plan

- [x] `npx prettier --check` clean on all touched files
- [x] `npm run typecheck` passes
- [x] `npm run test -w @slicc/webapp` — 3487 tests pass, including 14 new websocat tests
- [x] `npm run test:coverage:webapp` — Statements 66.53% / Branches 57.31% / Functions 68.86% / Lines 68.2% (all above floors)
- [x] `npm run build` — full production build succeeds
- [x] `npm run build -w @slicc/chrome-extension` — extension build succeeds
- [ ] Manual smoke test in a running float (echo round-trip and CDP call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)