### PR TITLE
fix(ui/chat): keep cluster's LLM label stable and debounce refetches

### DIFF
--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -258,10 +258,19 @@ export class ChatPanel {
   /** Latest pending snapshot per anchor: the signature we'll request a
    *  label for, plus every preview element that should receive the
    *  result (including orphaned ones from intermediate reflows — those
-   *  are filtered with `isConnected` at settle time). */
+   *  are filtered with `isConnected` at settle time). `inFlight` flips
+   *  true once `fireClusterLabelRequest` has actually called the LLM
+   *  for this signature, so identical-signature reschedules (the same
+   *  cluster reflowing during streaming) can enroll their new
+   *  previewEl without starting a duplicate request. */
   private clusterLabelPending = new Map<
     string,
-    { signature: string; toolCalls: readonly ToolCall[]; elements: Set<HTMLElement> }
+    {
+      signature: string;
+      toolCalls: readonly ToolCall[];
+      elements: Set<HTMLElement>;
+      inFlight: boolean;
+    }
   >();
   /** Debounce window before a cluster-label request actually fires.
    *  Short enough that a finished cluster gets its label promptly, long
@@ -1442,19 +1451,35 @@ export class ChatPanel {
     const stickyLabel = this.clusterLabelByAnchor.get(anchor);
     if (stickyLabel) previewEl.textContent = stickyLabel;
 
-    // Enroll this previewEl in the pending entry for `anchor`. If the
-    // signature changed since the last schedule, replace the snapshot
-    // but carry over the element set — orphaned elements get filtered
-    // out by `isConnected` at settle time, and any still-connected one
-    // (a freshly rebuilt cluster body) should also receive the result.
+    // Enroll this previewEl in the pending entry for `anchor`. Three
+    // cases:
+    //
+    //   1. No pending entry — first schedule for this anchor; create one.
+    //   2. Same signature — cluster re-rendered with no new tool calls
+    //      (typical during streaming reflows). Just enroll the new
+    //      element. If a request is already in flight, that's the only
+    //      thing to do; do NOT reset the debounce timer or fire again
+    //      (would duplicate the LLM call for an identical signature).
+    //   3. Signature changed — newer snapshot supersedes the old one.
+    //      Carry over the element set (orphaned ones drop out at
+    //      settle via `isConnected`) and clear `inFlight` so the new
+    //      signature gets its own request once the debounce expires.
+    //      Any still-in-flight call for the old signature will drop
+    //      its result at settle time on the signature mismatch.
     const existing = this.clusterLabelPending.get(anchor);
-    const elements = existing?.elements ?? new Set<HTMLElement>();
-    elements.add(previewEl);
-    this.clusterLabelPending.set(anchor, {
-      signature,
-      toolCalls: [...toolCalls],
-      elements,
-    });
+    if (existing && existing.signature === signature) {
+      existing.elements.add(previewEl);
+      if (existing.inFlight) return;
+    } else {
+      const elements = existing?.elements ?? new Set<HTMLElement>();
+      elements.add(previewEl);
+      this.clusterLabelPending.set(anchor, {
+        signature,
+        toolCalls: [...toolCalls],
+        elements,
+        inFlight: false,
+      });
+    }
 
     // Debounce: reset the timer on every fresh call. A burst of tool
     // calls keeps pushing the firing time out so we only pay for one
@@ -1474,6 +1499,10 @@ export class ChatPanel {
   private fireClusterLabelRequest(anchor: string): void {
     const pending = this.clusterLabelPending.get(anchor);
     if (!pending) return;
+    // Mark in-flight so an identical-signature reschedule (e.g. a
+    // streaming-driven reflow that doesn't actually grow the cluster)
+    // enrolls its new previewEl instead of firing a duplicate request.
+    pending.inFlight = true;
     const { signature, toolCalls } = pending;
 
     const formatted = toolCalls

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -245,12 +245,28 @@ export class ChatPanel {
   private openClusterAnchors = new Set<string>();
   /** Cache of LLM-generated cluster labels keyed by sorted tool-call ids. */
   private clusterLabelCache = new Map<string, string>();
-  /** In-flight cluster-label requests, keyed by the same signature. The
-   *  value tracks every preview element awaiting that signature's label,
-   *  so a cluster rebuilt mid-flight (re-render during streaming) still
-   *  picks up the eventual response instead of being stuck on the
-   *  comma-joined fallback. */
-  private clusterLabelInflight = new Map<string, Set<HTMLElement>>();
+  /** Sticky label keyed by the cluster's *anchor* (first tool-call id).
+   *  The anchor stays the same as the cluster grows, so once an LLM label
+   *  has been shown we can re-display it on every subsequent rebuild —
+   *  instead of flickering back to the comma-joined fallback while the
+   *  new signature's label is being fetched. */
+  private clusterLabelByAnchor = new Map<string, string>();
+  /** Debounce timers keyed by anchor. A fresh tool call arriving inside
+   *  the debounce window resets the timer, so a fast burst fires one
+   *  LLM call for the whole cluster instead of one per call. */
+  private clusterLabelTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Latest pending snapshot per anchor: the signature we'll request a
+   *  label for, plus every preview element that should receive the
+   *  result (including orphaned ones from intermediate reflows — those
+   *  are filtered with `isConnected` at settle time). */
+  private clusterLabelPending = new Map<
+    string,
+    { signature: string; toolCalls: readonly ToolCall[]; elements: Set<HTMLElement> }
+  >();
+  /** Debounce window before a cluster-label request actually fires.
+   *  Short enough that a finished cluster gets its label promptly, long
+   *  enough to coalesce a fast burst of tool calls into one request. */
+  private static readonly CLUSTER_LABEL_DEBOUNCE_MS = 600;
   /** Default placeholder before any LLM-suggested replacement. */
   private static readonly DEFAULT_PLACEHOLDER = 'What shall we build?';
   /** AbortController for the most recent placeholder-suggestion request. */
@@ -371,7 +387,10 @@ export class ChatPanel {
    *  or applies a label resolved from a previous scoop's signatures. */
   private resetEphemeralLlmState(): void {
     this.clusterLabelCache.clear();
-    this.clusterLabelInflight.clear();
+    this.clusterLabelByAnchor.clear();
+    for (const t of this.clusterLabelTimers.values()) clearTimeout(t);
+    this.clusterLabelTimers.clear();
+    this.clusterLabelPending.clear();
     this.placeholderAbort?.abort();
     this.placeholderAbort = null;
     this.wasStreaming = false;
@@ -1387,36 +1406,75 @@ export class ChatPanel {
 
   /** Replace a cluster's comma-joined preview with an LLM-generated label
    *  describing what the tool calls accomplish together. Uses inputs only
-   *  (per-tool args), not return values. Cached by the sorted set of
-   *  tool-call ids so reflow re-renders reuse the prior label.
+   *  (per-tool args), not return values.
    *
-   *  Mid-flight rebuilds: when reflow rebuilds a cluster while its
-   *  label request is still in flight, the new previewEl joins the
-   *  same signature's pending set so the eventual response writes
-   *  into every still-connected element. Without this, the original
-   *  previewEl was the only one updated — and after reflow it has
-   *  been replaced by a fresh element, so the visible cluster stayed
-   *  on its comma-joined fallback. */
+   *  Two layers of caching keep the label visually stable as a cluster
+   *  grows: an exact-signature cache (sorted tool-call ids → label) for
+   *  re-renders of an unchanged cluster, and an anchor cache (first
+   *  tool-call id → most recent label) so a cluster that has grown by
+   *  one tool call keeps displaying its previous LLM label instead of
+   *  flickering back to the comma-joined "bash, bash, bash" fallback.
+   *
+   *  Requests are debounced per anchor so a fast burst of tool calls
+   *  fires a single LLM call once the burst settles rather than one
+   *  per call. Late-arriving previewEls from intermediate reflows
+   *  enroll in the pending entry and pick up the eventual response. */
   private scheduleClusterLabel(previewEl: HTMLElement, toolCalls: readonly ToolCall[]): void {
     if (toolCalls.length === 0) return;
+    const anchor = toolCalls[0].id;
     const signature = toolCalls
       .map((tc) => tc.id)
       .slice()
       .sort()
       .join('|');
 
+    // Exact-signature cache hit: this cluster has been labeled before.
     const cached = this.clusterLabelCache.get(signature);
     if (cached) {
       previewEl.textContent = cached;
+      this.clusterLabelByAnchor.set(anchor, cached);
       return;
     }
-    const inflight = this.clusterLabelInflight.get(signature);
-    if (inflight) {
-      inflight.add(previewEl);
-      return;
-    }
-    const pending = new Set<HTMLElement>([previewEl]);
-    this.clusterLabelInflight.set(signature, pending);
+
+    // The cluster has changed (or this is the first render). If we have
+    // ANY prior label for this anchor, paint it immediately so the user
+    // doesn't see the comma-joined fallback flash while we refresh.
+    const stickyLabel = this.clusterLabelByAnchor.get(anchor);
+    if (stickyLabel) previewEl.textContent = stickyLabel;
+
+    // Enroll this previewEl in the pending entry for `anchor`. If the
+    // signature changed since the last schedule, replace the snapshot
+    // but carry over the element set — orphaned elements get filtered
+    // out by `isConnected` at settle time, and any still-connected one
+    // (a freshly rebuilt cluster body) should also receive the result.
+    const existing = this.clusterLabelPending.get(anchor);
+    const elements = existing?.elements ?? new Set<HTMLElement>();
+    elements.add(previewEl);
+    this.clusterLabelPending.set(anchor, {
+      signature,
+      toolCalls: [...toolCalls],
+      elements,
+    });
+
+    // Debounce: reset the timer on every fresh call. A burst of tool
+    // calls keeps pushing the firing time out so we only pay for one
+    // label once the burst settles.
+    const existingTimer = this.clusterLabelTimers.get(anchor);
+    if (existingTimer) clearTimeout(existingTimer);
+    const timer = setTimeout(() => {
+      this.clusterLabelTimers.delete(anchor);
+      this.fireClusterLabelRequest(anchor);
+    }, ChatPanel.CLUSTER_LABEL_DEBOUNCE_MS);
+    this.clusterLabelTimers.set(anchor, timer);
+  }
+
+  /** Fire the actual LLM request for the anchor's latest pending
+   *  snapshot. Kept separate so `scheduleClusterLabel` only handles
+   *  caching/debounce bookkeeping. */
+  private fireClusterLabelRequest(anchor: string): void {
+    const pending = this.clusterLabelPending.get(anchor);
+    if (!pending) return;
+    const { signature, toolCalls } = pending;
 
     const formatted = toolCalls
       .map((tc, i) => {
@@ -1447,11 +1505,16 @@ export class ChatPanel {
       'Example output: Run a Python sanity check';
 
     const settle = (trimmed: string | null): void => {
-      const elements = this.clusterLabelInflight.get(signature);
-      this.clusterLabelInflight.delete(signature);
-      if (!trimmed || !elements) return;
+      // If a newer signature was scheduled while this request was in
+      // flight, drop our result — the newer timer will fire its own
+      // request and that one's response is the one that should land.
+      const latest = this.clusterLabelPending.get(anchor);
+      if (!latest || latest.signature !== signature) return;
+      this.clusterLabelPending.delete(anchor);
+      if (!trimmed) return;
       this.clusterLabelCache.set(signature, trimmed);
-      for (const el of elements) {
+      this.clusterLabelByAnchor.set(anchor, trimmed);
+      for (const el of latest.elements) {
         if (el.isConnected) el.textContent = trimmed;
       }
     };

--- a/packages/webapp/tests/ui/chat-panel-cluster-label.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-cluster-label.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the "Working" cluster's LLM-generated preview label.
+ *
+ * The preview row next to "Working" starts as a comma-joined fallback
+ * (e.g. `bash, bash, bash`) and is replaced asynchronously by a short
+ * LLM-suggested phrase. Two behaviors matter:
+ *
+ *   - The label must stay stable across re-renders. Once an LLM label
+ *     has been shown for a cluster, growing the cluster by one tool
+ *     call must not flicker back to the comma-joined fallback while
+ *     the new signature's label is being fetched.
+ *   - The LLM call must be debounced. A fast burst of tool calls
+ *     adding to the same cluster should result in a single label
+ *     request once the burst settles, not one per call.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import type { ChatMessage, ToolCall } from '../../src/ui/types.js';
+
+vi.mock('../../src/ui/voice-input.js', () => ({
+  VoiceInput: class {
+    destroy() {}
+    start() {}
+    stop() {}
+    setAutoSend() {}
+    setLang() {}
+  },
+  getVoiceAutoSend: () => false,
+  getVoiceLang: () => 'en-US',
+}));
+
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => '',
+  showProviderSettings: () => {},
+  applyProviderDefaults: () => {},
+  getAllAvailableModels: () => [],
+  getSelectedModelId: () => '',
+  getSelectedProvider: () => null,
+  setSelectedModelId: () => {},
+  getProviderConfig: () => null,
+}));
+
+const quickLabelMock = vi.hoisted(() => vi.fn());
+vi.mock('../../src/ui/quick-llm.js', () => ({
+  quickLabel: quickLabelMock,
+}));
+
+// Imported AFTER the mocks above so the chat panel binds the mocked
+// `quickLabel` rather than the real one.
+const { ChatPanel } = await import('../../src/ui/chat-panel.js');
+
+const tc = (overrides: Partial<ToolCall> & { name: string; id: string }): ToolCall => ({
+  id: overrides.id,
+  name: overrides.name,
+  input: overrides.input ?? { command: `echo ${overrides.id}` },
+  result: overrides.result,
+  isError: overrides.isError,
+});
+
+const assistantMsg = (id: string, toolCalls: ToolCall[], timestamp: number): ChatMessage => ({
+  id,
+  role: 'assistant',
+  content: '',
+  timestamp,
+  toolCalls,
+});
+
+/** Resolve the next microtask queue plus any pending then-handlers so
+ *  the `quickLabel` promise chain inside `fireClusterLabelRequest` has
+ *  a chance to call `settle()` before assertions run. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+const DEBOUNCE_MS = 600;
+
+let testCounter = 0;
+
+describe('ChatPanel cluster-label LLM behavior', () => {
+  let container: HTMLElement;
+  let panel: InstanceType<typeof ChatPanel>;
+
+  beforeEach(async () => {
+    testCounter += 1;
+    quickLabelMock.mockReset();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    panel = new ChatPanel(container);
+    await panel.initSession(`test-cluster-label-${testCounter}`);
+    // Install fake timers AFTER initSession — fake-indexeddb's setup
+    // path uses real setTimeout and would deadlock otherwise.
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  const previewEl = (): HTMLElement | null =>
+    container.querySelector('.tool-call-cluster .tool-call__preview');
+
+  it('debounces a burst of tool calls into a single LLM request', async () => {
+    quickLabelMock.mockResolvedValue('Run a burst of shell commands');
+
+    // First render: three calls, just enough to form a cluster.
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'bash' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'bash' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'bash' })], 2200),
+    ]);
+
+    // Inside the debounce window: keep growing the cluster.
+    vi.advanceTimersByTime(100);
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'bash' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'bash' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'bash' })], 2200),
+      assistantMsg('a4', [tc({ id: 'tc-4', name: 'bash' })], 2300),
+    ]);
+    vi.advanceTimersByTime(100);
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'bash' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'bash' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'bash' })], 2200),
+      assistantMsg('a4', [tc({ id: 'tc-4', name: 'bash' })], 2300),
+      assistantMsg('a5', [tc({ id: 'tc-5', name: 'bash' })], 2400),
+    ]);
+
+    // Nothing fires while we're still inside the debounce window.
+    expect(quickLabelMock).toHaveBeenCalledTimes(0);
+
+    // Let the burst settle.
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    // Exactly one LLM call for the whole burst.
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+
+    // And the prompt covered the LATEST snapshot (all five calls), not
+    // the original three.
+    const callArg = quickLabelMock.mock.calls[0][0] as { prompt: string };
+    expect(callArg.prompt).toMatch(/5\. bash:/);
+
+    expect(previewEl()?.textContent).toBe('Run a burst of shell commands');
+  });
+
+  it('keeps the sticky LLM label across re-renders instead of flickering back to the comma-joined fallback', async () => {
+    quickLabelMock.mockResolvedValue('Inspect repository files');
+
+    // First render: 3-call cluster. Fire the LLM label.
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'bash' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'bash' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'bash' })], 2200),
+    ]);
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    await flushMicrotasks();
+    expect(previewEl()?.textContent).toBe('Inspect repository files');
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+
+    // Now grow the cluster — new signature, no cache hit. The next
+    // `quickLabel` resolves with a different label, but we won't let
+    // it land yet; the assertion is about what the user sees in the
+    // *meantime*.
+    let resolveSecond: (v: string) => void = () => {};
+    quickLabelMock.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveSecond = resolve;
+        })
+    );
+
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'bash' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'bash' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'bash' })], 2200),
+      assistantMsg('a4', [tc({ id: 'tc-4', name: 'bash' })], 2300),
+    ]);
+
+    // Immediately after the re-render — before the debounce fires —
+    // the preview must show the previously-shown LLM label, NOT the
+    // comma-joined fallback "bash, bash, bash, bash".
+    expect(previewEl()?.textContent).toBe('Inspect repository files');
+    expect(previewEl()?.textContent ?? '').not.toMatch(/^bash, bash/);
+
+    // Even after the debounce timer fires and the new request is in
+    // flight, the sticky label still wins until the new label lands.
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    await flushMicrotasks();
+    expect(previewEl()?.textContent).toBe('Inspect repository files');
+
+    // Once the new request resolves, the preview updates.
+    resolveSecond('Inspect repository files and tests');
+    await flushMicrotasks();
+    expect(previewEl()?.textContent).toBe('Inspect repository files and tests');
+  });
+
+  it('reuses the cached label for an identical re-render without firing again', async () => {
+    quickLabelMock.mockResolvedValue('Compare drafts against published files');
+
+    const messages: ChatMessage[] = [
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'bash' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'bash' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'bash' })], 2200),
+    ];
+    panel.loadMessages(messages);
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    await flushMicrotasks();
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+    expect(previewEl()?.textContent).toBe('Compare drafts against published files');
+
+    // Re-render with the exact same tool calls — cache hit, no new
+    // request, label still shown.
+    panel.loadMessages(messages);
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    await flushMicrotasks();
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+    expect(previewEl()?.textContent).toBe('Compare drafts against published files');
+  });
+});

--- a/packages/webapp/tests/ui/chat-panel-cluster-label.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-cluster-label.test.ts
@@ -203,6 +203,51 @@ describe('ChatPanel cluster-label LLM behavior', () => {
     expect(previewEl()?.textContent).toBe('Inspect repository files and tests');
   });
 
+  it('does not fire a duplicate request when the same signature reschedules while a request is in flight', async () => {
+    // Hold the first quickLabel call open so we can re-trigger
+    // `scheduleClusterLabel` for the same signature while it's still
+    // pending. Without the in-flight guard, the second schedule would
+    // reset the debounce timer and fire a second identical request.
+    let resolveFirst: (v: string) => void = () => {};
+    quickLabelMock.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+
+    const messages: ChatMessage[] = [
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      assistantMsg('a1', [tc({ id: 'tc-1', name: 'bash' })], 2000),
+      assistantMsg('a2', [tc({ id: 'tc-2', name: 'bash' })], 2100),
+      assistantMsg('a3', [tc({ id: 'tc-3', name: 'bash' })], 2200),
+    ];
+    panel.loadMessages(messages);
+
+    // Drive the debounce past expiry — the LLM call is now in flight.
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    await flushMicrotasks();
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+
+    // Streaming-style reflow: same signature, no new tool calls. This
+    // happens whenever `updateMessageEl` rebuilds the cluster while
+    // results trickle in. We must NOT enqueue a second request.
+    panel.loadMessages(messages);
+    panel.loadMessages(messages);
+
+    // Even after another full debounce window, still no duplicate.
+    vi.advanceTimersByTime(DEBOUNCE_MS * 2);
+    await flushMicrotasks();
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+
+    // When the original request finally resolves, every still-
+    // connected previewEl (including the freshly rebuilt one) is
+    // updated.
+    resolveFirst('List repository contents');
+    await flushMicrotasks();
+    expect(previewEl()?.textContent).toBe('List repository contents');
+  });
+
   it('reuses the cached label for an identical re-render without firing again', async () => {
     quickLabelMock.mockResolvedValue('Compare drafts against published files');
 


### PR DESCRIPTION
Follow-up to #613.

## Summary

The "Working" cluster's preview row was flipping between an LLM-generated phrase and the comma-joined fallback (`bash, bash, bash, ...`) every time a fast burst of tool calls reflowed the cluster. Each new tool-call id extended the signature, missed the signature-keyed cache, and fired a fresh `quickLabel` request — the freshly rebuilt previewEl showed the fallback until the response landed.

## What changes

`packages/webapp/src/ui/chat-panel.ts` — `scheduleClusterLabel`:

- **Anchor-keyed sticky label** (`clusterLabelByAnchor`). The cluster's anchor (first tool-call id) stays stable as the cluster grows, so once an LLM label has been shown we re-paint it on every subsequent rebuild — no more flicker back to the comma-joined preview while the next signature's label is fetched.
- **Per-anchor debounce** (`clusterLabelTimers`, 600ms). A burst of tool calls keeps resetting one timer; only after the burst settles do we fire a single `quickLabel` for the latest snapshot. Late-arriving previewEls from intermediate reflows enroll in the same `clusterLabelPending` entry and receive the result; stale responses (newer signature scheduled mid-flight) drop themselves at settle time.
- `resetEphemeralLlmState` clears the new caches + timers on session switch so labels never leak across scoops.

## Test plan

`packages/webapp/tests/ui/chat-panel-cluster-label.test.ts` — three new tests with fake timers and a mocked `quickLabel`:

- [x] A 5-call burst inside the debounce window fires exactly 1 LLM request, and the request payload covers the LATEST snapshot (5 calls), not the original 3.
- [x] Growing a cluster after the first label has been shown keeps the sticky label visible across the reflow and until the new label resolves — never flips back to the `bash, bash, ...` fallback.
- [x] Re-rendering with an identical signature is a cache hit (no second request).
- [x] `npm run typecheck` clean.
- [x] `npm run test` — 3927 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)