### PR TITLE
fix(chat-history): unwrap orchestrator envelope when rebuilding chat from agent messages

### DIFF
--- a/packages/webapp/src/scoops/agent-message-to-chat.ts
+++ b/packages/webapp/src/scoops/agent-message-to-chat.ts
@@ -38,6 +38,7 @@ import type {
 } from '@earendil-works/pi-ai';
 import type { ChatMessage, ToolCall as UiToolCall } from '../ui/types.js';
 import { HIDDEN_TOOL_NAMES } from './hidden-tools.js';
+import { isLickChannel, type LickChannel } from '../ui/lick-channels.js';
 
 /**
  * Pure translator. `idSeed` lets callers inject a deterministic id
@@ -70,14 +71,30 @@ export function agentMessagesToChatMessages(
 
   for (const m of agentMessages) {
     if (isUserMessage(m)) {
-      const text = textOf(m.content);
-      if (text.length === 0) continue;
-      out.push({
+      const rawText = textOf(m.content);
+      if (rawText.length === 0) continue;
+      // The orchestrator wraps every queued channel message in a
+      // `[<time>] <senderName>: <body>` envelope before handing it to
+      // the agent (see `orchestrator.processScoopQueue`). When we
+      // rebuild the chat from the agent's persisted history we have to
+      // unwrap that envelope — otherwise plain user input renders with
+      // a leading `[May 11, 6:50 AM] User:` and lick events render as
+      // doubly-prefixed user messages instead of as lick widgets.
+      const envelope = unwrapMessageEnvelope(rawText);
+      const text = envelope ? envelope.body : rawText;
+      const lickChannel = envelope ? lickChannelFromSenderName(envelope.sender) : null;
+
+      const msg: ChatMessage = {
         id: idSeed(),
         role: 'user',
         content: text,
         timestamp: m.timestamp,
-      });
+      };
+      if (lickChannel) {
+        msg.source = 'lick';
+        msg.channel = lickChannel;
+      }
+      out.push(msg);
       lastAssistant = null;
       continue;
     }
@@ -179,4 +196,51 @@ function collectToolCalls(m: AssistantMessage): UiToolCall[] {
 
 function defaultUid(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+/**
+ * Parse the `[<time>] <senderName>: <body>` envelope that
+ * `orchestrator.processScoopQueue` prepends to every queued
+ * `ChannelMessage` before sending it to the agent. The envelope is
+ * applied uniformly to user-typed input (senderName `User`), lick
+ * events (senderName `<channel>:<event-name>`), and scoop-lifecycle
+ * notifications (senderName `<channel>:<event-name>` or assistant
+ * label). Returns null if the text doesn't match the envelope shape so
+ * pre-envelope history and forward-quoted content fall through
+ * unchanged.
+ *
+ * The shape is intentionally not pinned to a specific date format: we
+ * accept any `[...]` opener as long as it's followed by ` <sender>: `
+ * where `<sender>` lives on a single line and contains no `]`. This
+ * keeps the parser stable if the orchestrator ever switches locale or
+ * adds seconds.
+ */
+export function unwrapMessageEnvelope(text: string): { sender: string; body: string } | null {
+  if (!text.startsWith('[')) return null;
+  const closeBracket = text.indexOf('] ');
+  if (closeBracket <= 0) return null;
+  // The bracketed prefix must not span newlines — otherwise we'd
+  // happily strip a leading `[foo`-style label off a multi-line body.
+  if (text.lastIndexOf('\n', closeBracket) !== -1) return null;
+  const afterBracket = text.slice(closeBracket + 2);
+  const senderEnd = afterBracket.indexOf(': ');
+  if (senderEnd <= 0) return null;
+  const sender = afterBracket.slice(0, senderEnd);
+  if (sender.includes('\n')) return null;
+  const body = afterBracket.slice(senderEnd + 2);
+  return { sender, body };
+}
+
+/**
+ * Map an envelope sender name back to its `LickChannel`. Lick senders
+ * are formatted by `host.ts` as `<channel>:<eventName>`; the channel
+ * portion is the segment before the first colon and must be one of
+ * the registered `LICK_CHANNELS`. Plain user input (`User`) and other
+ * non-lick senders return null.
+ */
+export function lickChannelFromSenderName(sender: string): LickChannel | null {
+  const colon = sender.indexOf(':');
+  if (colon <= 0) return null;
+  const channel = sender.slice(0, colon);
+  return isLickChannel(channel) ? channel : null;
 }

--- a/packages/webapp/src/scoops/agent-message-to-chat.ts
+++ b/packages/webapp/src/scoops/agent-message-to-chat.ts
@@ -38,7 +38,7 @@ import type {
 } from '@earendil-works/pi-ai';
 import type { ChatMessage, ToolCall as UiToolCall } from '../ui/types.js';
 import { HIDDEN_TOOL_NAMES } from './hidden-tools.js';
-import { isLickChannel, type LickChannel } from '../ui/lick-channels.js';
+import { isLickChannel, LICK_CHANNELS, type LickChannel } from '../ui/lick-channels.js';
 
 /**
  * Pure translator. `idSeed` lets callers inject a deterministic id
@@ -75,26 +75,39 @@ export function agentMessagesToChatMessages(
       if (rawText.length === 0) continue;
       // The orchestrator wraps every queued channel message in a
       // `[<time>] <senderName>: <body>` envelope before handing it to
-      // the agent (see `orchestrator.processScoopQueue`). When we
-      // rebuild the chat from the agent's persisted history we have to
-      // unwrap that envelope — otherwise plain user input renders with
-      // a leading `[May 11, 6:50 AM] User:` and lick events render as
-      // doubly-prefixed user messages instead of as lick widgets.
-      const envelope = unwrapMessageEnvelope(rawText);
-      const text = envelope ? envelope.body : rawText;
-      const lickChannel = envelope ? lickChannelFromSenderName(envelope.sender) : null;
-
-      const msg: ChatMessage = {
-        id: idSeed(),
-        role: 'user',
-        content: text,
-        timestamp: m.timestamp,
-      };
-      if (lickChannel) {
-        msg.source = 'lick';
-        msg.channel = lickChannel;
+      // the agent (see `orchestrator.processScoopQueue`). Two extra
+      // wrinkles:
+      //
+      //   1) `processScoopQueue` batches multiple `ChannelMessage`s
+      //      into a single prompt by joining the formatted lines with
+      //      `\n`, so one persisted user `AgentMessage` can carry
+      //      several envelopes — each one its own ChatMessage in the
+      //      live UI. We split them back apart on rebuild so a quick
+      //      burst of licks renders as N widgets, not one big bubble.
+      //
+      //   2) The senderName for licks is `<channel>:<eventName>` and
+      //      both halves are free-form (webhook/cron/sprinkle/upgrade
+      //      names), so the naive "first `: `" split corrupts senders
+      //      that contain `: ` themselves. The parser anchors on the
+      //      closed set of known senders (`User` or a `LICK_CHANNELS`
+      //      prefix) and only falls through to a generic split for
+      //      unknown senders we don't ship today.
+      const envelopes = splitEnvelopes(rawText);
+      for (const env of envelopes) {
+        if (env.body.length === 0 && env.sender == null) continue;
+        const lickChannel = env.sender ? lickChannelFromSenderName(env.sender) : null;
+        const msg: ChatMessage = {
+          id: idSeed(),
+          role: 'user',
+          content: env.body,
+          timestamp: m.timestamp,
+        };
+        if (lickChannel) {
+          msg.source = 'lick';
+          msg.channel = lickChannel;
+        }
+        out.push(msg);
       }
-      out.push(msg);
       lastAssistant = null;
       continue;
     }
@@ -199,21 +212,29 @@ function defaultUid(): string {
 }
 
 /**
- * Parse the `[<time>] <senderName>: <body>` envelope that
- * `orchestrator.processScoopQueue` prepends to every queued
- * `ChannelMessage` before sending it to the agent. The envelope is
- * applied uniformly to user-typed input (senderName `User`), lick
- * events (senderName `<channel>:<event-name>`), and scoop-lifecycle
- * notifications (senderName `<channel>:<event-name>` or assistant
- * label). Returns null if the text doesn't match the envelope shape so
- * pre-envelope history and forward-quoted content fall through
- * unchanged.
+ * Parse a *single* `[<time>] <senderName>: <body>` envelope —
+ * intentionally non-greedy about the body so multi-envelope content
+ * can be sliced apart by `splitEnvelopes`. Returns null when the text
+ * doesn't open with `[` + a single-line bracketed prefix.
  *
- * The shape is intentionally not pinned to a specific date format: we
- * accept any `[...]` opener as long as it's followed by ` <sender>: `
- * where `<sender>` lives on a single line and contains no `]`. This
- * keeps the parser stable if the orchestrator ever switches locale or
- * adds seconds.
+ * Sender parsing anchors on the closed set of senders the orchestrator
+ * actually emits today:
+ *
+ *   - `User`              — plain panel input
+ *   - `<LICK_CHANNELS>:…` — lick events; eventName may contain spaces,
+ *                           arrows, version numbers, etc.
+ *   - anything else       — best-effort split at the first `: ` (used
+ *                           for assistant-label scoop notifications,
+ *                           tray peers, and any future sender we add)
+ *
+ * The first two anchors make the parser robust against senders whose
+ * `eventName` contains `: ` (e.g. a webhook named `deploy: prod`)
+ * because we know exactly where the channel prefix ends. Only fully
+ * unknown senders fall back to the naive split.
+ *
+ * The shape is intentionally not pinned to a specific date format: any
+ * `[...]` opener on a single line is accepted, so changes to the
+ * orchestrator's `toLocaleString` arguments don't break the parser.
  */
 export function unwrapMessageEnvelope(text: string): { sender: string; body: string } | null {
   if (!text.startsWith('[')) return null;
@@ -223,12 +244,127 @@ export function unwrapMessageEnvelope(text: string): { sender: string; body: str
   // happily strip a leading `[foo`-style label off a multi-line body.
   if (text.lastIndexOf('\n', closeBracket) !== -1) return null;
   const afterBracket = text.slice(closeBracket + 2);
+
+  // Known-sender anchors. We try them in order; the first match wins.
+  // `User: ` is exact; lick channels match `<channel>:` followed by
+  // any eventName up to the next `: ` on the same line.
+  const userPrefix = 'User: ';
+  if (afterBracket.startsWith(userPrefix)) {
+    return { sender: 'User', body: afterBracket.slice(userPrefix.length) };
+  }
+  for (const channel of LICK_CHANNELS) {
+    const channelPrefix = `${channel}:`;
+    if (!afterBracket.startsWith(channelPrefix)) continue;
+    // Find the envelope `: ` *after* the channel prefix.
+    //
+    // The naive "first `: `" cuts senders like `webhook:deploy: prod`
+    // in half. The structural anchor we lean on instead: lick bodies
+    // formatted by `lick-formatting.ts` open with `[<Label>: <name>]`
+    // — i.e. the body's first character is `[`. So when the body
+    // starts on the same line, the envelope separator is the *last*
+    // `: ` that appears before that `[`. When the body starts on a
+    // new line (or doesn't open with `[`, e.g. session-reload's
+    // mount-recovery prompt), fall back to the first `: ` after the
+    // channel prefix.
+    const nl = afterBracket.indexOf('\n');
+    const firstLineEnd = nl === -1 ? afterBracket.length : nl;
+    const firstLine = afterBracket.slice(0, firstLineEnd);
+
+    let sepIdx = -1;
+    // Look for a `[` after the channel prefix, on the first line —
+    // that's the start of the lick body framing.
+    const bracketIdx = firstLine.indexOf('[', channelPrefix.length);
+    if (bracketIdx > channelPrefix.length) {
+      // Walk back from the `[` to the most recent `: `.
+      sepIdx = firstLine.lastIndexOf(': ', bracketIdx);
+    }
+    if (sepIdx < channelPrefix.length) {
+      // No `[` body opener on the first line (e.g. session-reload
+      // mount-recovery prompt). Use the first `: ` after the channel
+      // prefix as the boundary — eventNames for these cases don't
+      // contain `: ` in practice.
+      sepIdx = afterBracket.indexOf(': ', channelPrefix.length);
+    }
+    if (sepIdx < 0 || sepIdx >= firstLineEnd) continue; // malformed — fall through
+    const sender = afterBracket.slice(0, sepIdx);
+    const body = afterBracket.slice(sepIdx + 2);
+    return { sender, body };
+  }
+
+  // Unknown sender (e.g. an assistant label for a scoop notification
+  // not routed through host.ts). Best-effort: first `: ` on the first
+  // line wins. Any new sender shape that needs lossless replay should
+  // be added to the anchor set above.
+  const nl = afterBracket.indexOf('\n');
+  const firstLineEnd = nl === -1 ? afterBracket.length : nl;
   const senderEnd = afterBracket.indexOf(': ');
-  if (senderEnd <= 0) return null;
+  if (senderEnd <= 0 || senderEnd >= firstLineEnd) return null;
   const sender = afterBracket.slice(0, senderEnd);
   if (sender.includes('\n')) return null;
-  const body = afterBracket.slice(senderEnd + 2);
-  return { sender, body };
+  return { sender, body: afterBracket.slice(senderEnd + 2) };
+}
+
+/**
+ * Split a possibly-batched user-message body into its constituent
+ * envelopes. The orchestrator joins multiple queued `ChannelMessage`s
+ * with `\n` before sending to the agent, so one stored `AgentMessage`
+ * can carry several `[<time>] <sender>: <body>` segments back-to-back.
+ *
+ * The splitter walks the lines and starts a new segment every time a
+ * line both begins with `[` and successfully parses through
+ * `unwrapMessageEnvelope`. Content that doesn't open with a bracketed
+ * envelope is returned as a single segment with `sender: null` so the
+ * caller renders it as a plain user bubble unchanged — this also
+ * covers pre-envelope history that predates the orchestrator wrapper.
+ */
+export function splitEnvelopes(text: string): Array<{ sender: string | null; body: string }> {
+  if (text.length === 0) return [];
+  const lines = text.split('\n');
+
+  // Trivial single-segment fast path: input doesn't look like an
+  // envelope-prefixed batch.
+  if (!lines[0].startsWith('[')) return [{ sender: null, body: text }];
+
+  type Pending = { firstLine: string; rest: string[] } | null;
+  const segments: Array<{ sender: string | null; body: string }> = [];
+  let cur: Pending = null;
+
+  const flush = () => {
+    if (!cur) return;
+    const joined = cur.rest.length > 0 ? `${cur.firstLine}\n${cur.rest.join('\n')}` : cur.firstLine;
+    const env = unwrapMessageEnvelope(joined);
+    if (env) {
+      segments.push({ sender: env.sender, body: env.body });
+    } else {
+      // Bracket-shaped but doesn't unwrap (unknown sender, malformed):
+      // emit as a plain segment so we never lose content.
+      segments.push({ sender: null, body: joined });
+    }
+    cur = null;
+  };
+
+  for (const ln of lines) {
+    if (ln.startsWith('[') && /^\[[^\]\n]+\] /.test(ln) && ln.includes(': ')) {
+      // Possible envelope opener. Only commit to splitting if the line
+      // actually parses — otherwise treat it as body of the current
+      // segment (e.g. an inner `[Sprinkle Event: x]` line shouldn't
+      // start a new envelope).
+      const provisional = unwrapMessageEnvelope(ln);
+      if (provisional) {
+        flush();
+        cur = { firstLine: ln, rest: [] };
+        continue;
+      }
+    }
+    if (cur) cur.rest.push(ln);
+    else cur = { firstLine: ln, rest: [] };
+  }
+  flush();
+
+  // If nothing parsed, fall back to the whole text as a single
+  // unenveloped segment so callers don't drop data.
+  if (segments.length === 0) return [{ sender: null, body: text }];
+  return segments;
 }
 
 /**

--- a/packages/webapp/tests/scoops/agent-message-to-chat.test.ts
+++ b/packages/webapp/tests/scoops/agent-message-to-chat.test.ts
@@ -241,6 +241,91 @@ describe('agentMessagesToChatMessages', () => {
     ]);
   });
 
+  it('strips the orchestrator envelope from plain user messages', () => {
+    counter = 0;
+    const out = agentMessagesToChatMessages([userMsg('[May 11, 6:50 AM] User: hi', 100)], {
+      idSeed: seedId,
+    });
+    expect(out).toEqual([
+      {
+        id: 'id-1',
+        role: 'user',
+        content: 'hi',
+        timestamp: 100,
+      },
+    ]);
+  });
+
+  it('tags sprinkle lick messages with source=lick and channel=sprinkle', () => {
+    counter = 0;
+    const raw =
+      '[May 11, 8:15 AM] sprinkle:welcome: [Sprinkle Event: welcome]\n```json\n{"foo":1}\n```';
+    const out = agentMessagesToChatMessages([userMsg(raw, 200)], { idSeed: seedId });
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe('user');
+    expect(out[0].source).toBe('lick');
+    expect(out[0].channel).toBe('sprinkle');
+    // The inner lick body (the [Sprinkle Event: …] framing) is what
+    // the chat panel feeds to the lick widget — preserve it intact.
+    expect(out[0].content.startsWith('[Sprinkle Event: welcome]')).toBe(true);
+  });
+
+  it('handles upgrade lick senders with arrow-containing event names', () => {
+    counter = 0;
+    const raw =
+      '[May 11, 9:12 AM] upgrade:2.37.0→2.38.1: [Upgrade Event: 2.37.0→2.38.1]\n\nSLICC was upgraded.';
+    const out = agentMessagesToChatMessages([userMsg(raw, 300)], { idSeed: seedId });
+    expect(out[0].source).toBe('lick');
+    expect(out[0].channel).toBe('upgrade');
+    expect(out[0].content).toBe('[Upgrade Event: 2.37.0→2.38.1]\n\nSLICC was upgraded.');
+  });
+
+  it('recognizes scoop-lifecycle channels (scoop-notify / scoop-wait)', () => {
+    counter = 0;
+    const out = agentMessagesToChatMessages(
+      [
+        userMsg('[May 11, 10:00 AM] scoop-notify:done: [@scout completed]', 400),
+        userMsg('[May 11, 10:00 AM] scoop-wait:settle: [scoop_wait completed]', 401),
+      ],
+      { idSeed: seedId }
+    );
+    expect(out[0].channel).toBe('scoop-notify');
+    expect(out[0].source).toBe('lick');
+    expect(out[1].channel).toBe('scoop-wait');
+    expect(out[1].source).toBe('lick');
+  });
+
+  it('leaves pre-envelope or unbracketed content unchanged', () => {
+    counter = 0;
+    const out = agentMessagesToChatMessages([userMsg('just text, no envelope', 500)], {
+      idSeed: seedId,
+    });
+    expect(out[0].content).toBe('just text, no envelope');
+    expect(out[0].source).toBeUndefined();
+    expect(out[0].channel).toBeUndefined();
+  });
+
+  it('leaves an unknown sender as a plain user message (no lick tagging)', () => {
+    counter = 0;
+    // Bracketed envelope shape but sender is not a known lick channel.
+    const out = agentMessagesToChatMessages(
+      [userMsg('[May 11, 7:00 AM] cone: forwarded note', 600)],
+      { idSeed: seedId }
+    );
+    expect(out[0].content).toBe('forwarded note');
+    expect(out[0].source).toBeUndefined();
+    expect(out[0].channel).toBeUndefined();
+  });
+
+  it('does not unwrap when the bracket spans a newline', () => {
+    counter = 0;
+    const out = agentMessagesToChatMessages(
+      [userMsg('[opens here\nbut keeps going] User: bogus', 700)],
+      { idSeed: seedId }
+    );
+    expect(out[0].content).toBe('[opens here\nbut keeps going] User: bogus');
+  });
+
   it('honors a custom hiddenToolNames override', () => {
     counter = 0;
     const input: AgentMessage[] = [

--- a/packages/webapp/tests/scoops/agent-message-to-chat.test.ts
+++ b/packages/webapp/tests/scoops/agent-message-to-chat.test.ts
@@ -326,6 +326,60 @@ describe('agentMessagesToChatMessages', () => {
     expect(out[0].content).toBe('[opens here\nbut keeps going] User: bogus');
   });
 
+  it('parses a sender containing ": " by anchoring on the known channel prefix', () => {
+    counter = 0;
+    // Webhook with a user-defined name that contains ": " — this was
+    // the Codex P1 / Copilot finding on PR #625: a naive
+    // `indexOf(": ")` would split at the first colon-space inside the
+    // eventName and corrupt the body.
+    const raw =
+      '[May 11, 10:00 AM] webhook:deploy: prod: [Webhook Event: deploy: prod]\n```json\n{"ok":true}\n```';
+    const out = agentMessagesToChatMessages([userMsg(raw, 1000)], { idSeed: seedId });
+    expect(out).toHaveLength(1);
+    expect(out[0].source).toBe('lick');
+    expect(out[0].channel).toBe('webhook');
+    expect(out[0].content.startsWith('[Webhook Event: deploy: prod]')).toBe(true);
+  });
+
+  it('splits a batched user message with multiple envelopes into separate ChatMessages', () => {
+    counter = 0;
+    // `processScoopQueue` joins queued ChannelMessages with `\n` before
+    // calling sendPrompt, so two licks arriving between agent turns
+    // end up in one AgentMessage. The chat panel must replay each
+    // lick as its own widget.
+    const raw =
+      '[May 11, 8:15 AM] sprinkle:welcome: [Sprinkle Event: welcome]\n' +
+      '```json\n{"x":1}\n```\n' +
+      '[May 11, 8:16 AM] User: typed input\n' +
+      '[May 11, 8:17 AM] cron:daily: [Cron Event: daily]\n' +
+      '```json\n{"y":2}\n```';
+    const out = agentMessagesToChatMessages([userMsg(raw, 8000)], { idSeed: seedId });
+    expect(out).toHaveLength(3);
+    expect(out[0].source).toBe('lick');
+    expect(out[0].channel).toBe('sprinkle');
+    expect(out[0].content.startsWith('[Sprinkle Event: welcome]')).toBe(true);
+    expect(out[1].source).toBeUndefined();
+    expect(out[1].content).toBe('typed input');
+    expect(out[2].source).toBe('lick');
+    expect(out[2].channel).toBe('cron');
+    expect(out[2].content.startsWith('[Cron Event: daily]')).toBe(true);
+    // All split parts inherit the AgentMessage's timestamp.
+    expect(out.every((m) => m.timestamp === 8000)).toBe(true);
+  });
+
+  it('does not start a new envelope on an inner [Sprinkle Event: x] body line', () => {
+    counter = 0;
+    // The line `[Sprinkle Event: welcome]` looks bracket-shaped but is
+    // not an envelope opener (it doesn't match `[…] <sender>: …`). It
+    // must stay part of the previous segment's body.
+    const raw = '[May 11, 8:15 AM] sprinkle:welcome: header\n[Sprinkle Event: welcome]\nmore body';
+    const out = agentMessagesToChatMessages([userMsg(raw, 1)], { idSeed: seedId });
+    expect(out).toHaveLength(1);
+    expect(out[0].source).toBe('lick');
+    expect(out[0].channel).toBe('sprinkle');
+    expect(out[0].content).toBe('header\n[Sprinkle Event: welcome]\nmore body');
+  });
+
   it('honors a custom hiddenToolNames override', () => {
     counter = 0;
     const input: AgentMessage[] = [


### PR DESCRIPTION
## Summary

PR #614 made the chat panel rebuild its history from the worker's `AgentMessage[]` on scoop select, but the translator was never taught to unwrap the `[<time>] <senderName>: <body>` envelope that `orchestrator.processScoopQueue` prepends to every queued channel message before handing it to the agent.

That made the restored DOM diverge from the live UI: a Sprinkle event rendered as a user bubble with literal content like

```
[May 11, 8:15 AM] sprinkle:welcome: [Sprinkle Event: welcome]
```json
{…}
```
```

and plain input rendered as `[May 11, 6:50 AM] User: hi` instead of just `hi`.

## Root cause

Two bits of metadata travel on the envelope, and the translator was dropping both:

- The leading `[<time>] <senderName>:` is purely a cache-friendly hint to the LLM — it should never reach the UI.
- The `<senderName>` for licks is formatted by `kernel/host.ts` as `<channel>:<eventName>` (e.g. `sprinkle:welcome`, `upgrade:2.37.0→2.38.1`). That's the *only* place the channel survives once the message is in the agent's history — the inner `[Sprinkle Event: …]` text framing is for the agent to read, not for the chat panel to dispatch on.

Without unwrapping we lose both: cosmetic prefix in the bubble, lick widgets demoted to user messages.

## Changes

- New `unwrapMessageEnvelope(text)` and `lickChannelFromSenderName(sender)` helpers in `agent-message-to-chat.ts` (exported for tests).
- In the user-role branch of `agentMessagesToChatMessages`, run the envelope through the unwrapper. If the sender is `<LickChannel>:…`, mark the resulting `ChatMessage` with `source: 'lick'` and `channel: <channel>`. Otherwise just strip the prefix.
- Pre-envelope history and bracket-shaped content that doesn't fit the envelope (e.g. spans newlines, missing `: `) fall through unchanged.
- 9 new regression tests covering plain-user unwrap, sprinkle/upgrade/scoop-lifecycle channel detection, arrow chars in event names, pre-envelope fall-through, unknown-sender behavior, and the multi-line bracket edge case.

## Test plan

- [x] 19 translator tests pass (10 existing + 9 new).
- [x] `npm run typecheck` clean.
- [x] Verified via CDP eval against a real live page: the user's actual `agent-sessions` IDB now translates to the expected sequence — plain user `hi`, three lick events (`sprinkle`, `upgrade`, `sprinkle`) with `source: 'lick'` and the right `channel`, two more plain user messages.
- [ ] Manual smoke: reload the page in a session that has lick history; confirm the rebuilt DOM matches the live-streaming rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)