### PR TITLE
feat(kernel): panel-RPC bridge for DOM-bound shell commands in standalone

### DIFF
--- a/packages/webapp/src/kernel/kernel-worker.ts
+++ b/packages/webapp/src/kernel/kernel-worker.ts
@@ -167,6 +167,7 @@ function installLocalStorageShim(seed: Record<string, string>): void {
 
 let host: KernelHost | null = null;
 let stopTerminalHost: (() => void) | null = null;
+let panelRpcClient: { dispose: () => void } | null = null;
 
 /**
  * Wire the init listener using a double-init guard. Exported via
@@ -245,13 +246,14 @@ async function boot(init: KernelWorkerInitMsg): Promise<void> {
 
   // Publish the panel-RPC bridge client. DOM-bound shell supplemental
   // commands (`screencapture`, `say`, `afplay`, `pbcopy`/`pbpaste`,
-  // `imgcat`, `open`, plus `playwright`'s appOrigin lookup) detect this
-  // global and route their DOM calls to the page handler installed by
-  // `mainStandaloneWorker`. See `kernel/panel-rpc.ts` for the op surface.
+  // `open`, plus `playwright`'s appOrigin lookup) detect this global
+  // and route their DOM calls to the page handler installed by
+  // `mainStandaloneWorker`. See `kernel/panel-rpc.ts` for the op
+  // surface. `imgcat` is intentionally NOT bridged — it's terminal-only
+  // and the panel WasmShell renders the preview locally.
   const { createPanelRpcClient } = await import('./panel-rpc.js');
-  (globalThis as Record<string, unknown>).__slicc_panelRpc = createPanelRpcClient({
-    instanceId: init.instanceId,
-  });
+  panelRpcClient = createPanelRpcClient({ instanceId: init.instanceId });
+  (globalThis as Record<string, unknown>).__slicc_panelRpc = panelRpcClient;
 
   // Take the process manager from the kernel host so scoop-turns
   // (registered by `ScoopContext`) and shell execs (registered by
@@ -295,5 +297,7 @@ self.addEventListener('message', (event: MessageEvent) => {
   if (data?.type !== 'kernel-worker-shutdown') return;
   stopTerminalHost?.();
   stopTerminalHost = null;
+  panelRpcClient?.dispose();
+  panelRpcClient = null;
   void host?.dispose();
 });

--- a/packages/webapp/src/kernel/kernel-worker.ts
+++ b/packages/webapp/src/kernel/kernel-worker.ts
@@ -243,6 +243,16 @@ async function boot(init: KernelWorkerInitMsg): Promise<void> {
   (globalThis as Record<string, unknown>).__slicc_sprinkleManager =
     createSprinkleManagerProxyOverChannel({ instanceId: init.instanceId });
 
+  // Publish the panel-RPC bridge client. DOM-bound shell supplemental
+  // commands (`screencapture`, `say`, `afplay`, `pbcopy`/`pbpaste`,
+  // `imgcat`, `open`, plus `playwright`'s appOrigin lookup) detect this
+  // global and route their DOM calls to the page handler installed by
+  // `mainStandaloneWorker`. See `kernel/panel-rpc.ts` for the op surface.
+  const { createPanelRpcClient } = await import('./panel-rpc.js');
+  (globalThis as Record<string, unknown>).__slicc_panelRpc = createPanelRpcClient({
+    instanceId: init.instanceId,
+  });
+
   // Take the process manager from the kernel host so scoop-turns
   // (registered by `ScoopContext`) and shell execs (registered by
   // `TerminalSessionHost`) land in the same table. `createKernelHost`

--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -1,0 +1,305 @@
+/**
+ * Panel-RPC: a typed BroadcastChannel bridge that lets DOM-bound shell
+ * supplemental commands run from the kernel worker.
+ *
+ * ## Why
+ *
+ * In standalone mode the agent's bash tool runs inside a
+ * `DedicatedWorker` (`kernel-worker.ts`). Worker globals expose neither
+ * `window`/`document` nor the DOM-only halves of `navigator` —
+ * `mediaDevices`, `clipboard`, `speechSynthesis`, `AudioContext`. Any
+ * supplemental command that touches those APIs directly currently
+ * fails with "browser APIs are unavailable" when invoked from the
+ * agent.
+ *
+ * The fix is to keep the DOM operations on the page (which always has
+ * a DOM in every float that hosts the webapp) and route requests from
+ * the worker over a single channel. This module is the channel.
+ *
+ * ## Shape
+ *
+ * - Worker side calls `createPanelRpcClient({ instanceId })` and gets
+ *   a thin `{ call(op, payload, opts?) }` surface. Each `call` posts a
+ *   request on the BroadcastChannel and resolves with the page-side
+ *   result (or rejects with the page-side error / timeout).
+ *
+ * - Page side calls `installPanelRpcHandler({ handlers, instanceId })`
+ *   with a record of per-op handlers, and gets back a disposer. The
+ *   handler dispatches incoming requests and posts responses on the
+ *   same channel. Unknown ops resolve with a clear error rather than
+ *   hanging the worker.
+ *
+ * Mirrors `sprinkle-bridge-channel.ts` (instance-scoped channel name,
+ * UUID request ids, default 8s timeout). Extension mode does not use
+ * this bridge — the offscreen document already has a DOM, so DOM-bound
+ * commands run directly there.
+ */
+
+const PANEL_RPC_CHANNEL = 'slicc-panel-rpc';
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export function panelRpcChannelName(instanceId?: string): string {
+  return instanceId ? `${PANEL_RPC_CHANNEL}:${instanceId}` : PANEL_RPC_CHANNEL;
+}
+
+// ── Op surface ──────────────────────────────────────────────────────
+
+/**
+ * The closed set of operations the worker can ask the page to perform.
+ * Each branch documents the payload it takes and the result shape.
+ */
+export type PanelRpcRequest =
+  | { op: 'page-info'; payload?: undefined }
+  | {
+      op: 'screencapture';
+      payload: { mimeType: string; quality: number };
+    }
+  | {
+      op: 'speak-text';
+      payload: { text: string; voice?: string; rate?: number; pitch?: number; volume?: number };
+    }
+  | {
+      op: 'list-voices';
+      payload?: undefined;
+    }
+  | {
+      op: 'play-audio';
+      payload: { bytes: ArrayBuffer; mimeType?: string; volume?: number };
+    }
+  | {
+      op: 'play-chime';
+      payload: { tone?: 'success' | 'error' | 'notify' };
+    }
+  | { op: 'clipboard-read-text'; payload?: undefined }
+  | { op: 'clipboard-write-text'; payload: { text: string } }
+  | {
+      op: 'clipboard-write-image';
+      payload: { bytes: ArrayBuffer; mimeType: string };
+    }
+  | {
+      op: 'window-open';
+      payload: { url: string; target?: string; features?: string };
+    };
+
+export interface PanelRpcResults {
+  'page-info': { origin: string; href: string; title: string };
+  screencapture: { bytes: ArrayBuffer; width: number; height: number; mimeType: string };
+  'speak-text': { done: true };
+  'list-voices': { voices: Array<{ name: string; lang: string; default: boolean }> };
+  'play-audio': { done: true };
+  'play-chime': { done: true };
+  'clipboard-read-text': { text: string };
+  'clipboard-write-text': { done: true };
+  'clipboard-write-image': { done: true };
+  'window-open': { opened: boolean };
+}
+
+export type PanelRpcOp = PanelRpcRequest['op'];
+export type PanelRpcPayloadFor<O extends PanelRpcOp> = Extract<
+  PanelRpcRequest,
+  { op: O }
+>['payload'];
+export type PanelRpcResultFor<O extends PanelRpcOp> = PanelRpcResults[O];
+
+// ── Wire envelopes ──────────────────────────────────────────────────
+
+interface PanelRpcRequestMsg {
+  type: 'panel-rpc-request';
+  id: string;
+  op: PanelRpcOp;
+  payload: unknown;
+}
+
+interface PanelRpcResponseMsg {
+  type: 'panel-rpc-response';
+  id: string;
+  result?: unknown;
+  error?: string;
+}
+
+// ── Worker-side client ──────────────────────────────────────────────
+
+export interface PanelRpcClient {
+  call<O extends PanelRpcOp>(
+    op: O,
+    payload: PanelRpcPayloadFor<O>,
+    opts?: { timeoutMs?: number }
+  ): Promise<PanelRpcResultFor<O>>;
+  /** Close the BroadcastChannel and reject any in-flight requests. */
+  dispose(): void;
+}
+
+/**
+ * Build the worker-side proxy. Returns a `call(op, payload)` helper
+ * and a `dispose()`. The client may be constructed in environments
+ * without `BroadcastChannel` (older test runners, isolated test
+ * harnesses); in that case every call rejects with a clear "bridge
+ * unavailable" error.
+ */
+export function createPanelRpcClient(options: { instanceId?: string } = {}): PanelRpcClient {
+  if (typeof BroadcastChannel !== 'function') {
+    return {
+      call: () => Promise.reject(new Error('panel-rpc: BroadcastChannel is unavailable')),
+      dispose: () => {},
+    };
+  }
+
+  const channelName = panelRpcChannelName(options.instanceId);
+  const channel = new BroadcastChannel(channelName);
+  const pending = new Map<
+    string,
+    {
+      resolve: (value: unknown) => void;
+      reject: (err: Error) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
+
+  channel.addEventListener('message', (event: MessageEvent) => {
+    const msg = event.data as PanelRpcResponseMsg | undefined;
+    if (!msg || msg.type !== 'panel-rpc-response') return;
+    const slot = pending.get(msg.id);
+    if (!slot) return;
+    pending.delete(msg.id);
+    clearTimeout(slot.timer);
+    if (typeof msg.error === 'string') slot.reject(new Error(msg.error));
+    else slot.resolve(msg.result);
+  });
+
+  function call<O extends PanelRpcOp>(
+    op: O,
+    payload: PanelRpcPayloadFor<O>,
+    opts: { timeoutMs?: number } = {}
+  ): Promise<PanelRpcResultFor<O>> {
+    const id = newRequestId();
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    return new Promise<PanelRpcResultFor<O>>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`panel-rpc: op '${op}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      pending.set(id, {
+        resolve: resolve as (v: unknown) => void,
+        reject,
+        timer,
+      });
+      const req: PanelRpcRequestMsg = { type: 'panel-rpc-request', id, op, payload };
+      channel.postMessage(req);
+    });
+  }
+
+  function dispose(): void {
+    for (const [, slot] of pending) {
+      clearTimeout(slot.timer);
+      slot.reject(new Error('panel-rpc: client disposed'));
+    }
+    pending.clear();
+    try {
+      channel.close();
+    } catch {
+      /* noop */
+    }
+  }
+
+  return { call, dispose };
+}
+
+// ── Page-side handler ───────────────────────────────────────────────
+
+export type PanelRpcHandlers = {
+  [O in PanelRpcOp]?: (
+    payload: PanelRpcPayloadFor<O>
+  ) => Promise<PanelRpcResultFor<O>> | PanelRpcResultFor<O>;
+};
+
+/**
+ * Install a page-side handler that listens for `panel-rpc-request`
+ * messages on the bridge channel and dispatches them. Unknown ops are
+ * answered with an error so the worker's `call` rejects cleanly
+ * instead of hanging until the timeout. Errors raised inside a handler
+ * are forwarded as `error` strings on the response.
+ *
+ * Returns a disposer that removes the listener and closes the channel.
+ */
+export function installPanelRpcHandler(options: {
+  handlers: PanelRpcHandlers;
+  instanceId?: string;
+}): () => void {
+  if (typeof BroadcastChannel !== 'function') return () => {};
+  const channel = new BroadcastChannel(panelRpcChannelName(options.instanceId));
+
+  const respond = (id: string, result?: unknown, error?: string): void => {
+    const msg: PanelRpcResponseMsg = { type: 'panel-rpc-response', id };
+    if (error !== undefined) msg.error = error;
+    else msg.result = result;
+    try {
+      channel.postMessage(msg);
+    } catch (err) {
+      // Posting can fail if the channel was closed while we were
+      // resolving — there's no useful recovery beyond logging.
+      const reason = err instanceof Error ? err.message : String(err);
+       
+      console.warn(`panel-rpc: failed to post response for id=${id}: ${reason}`);
+    }
+  };
+
+  const listener = async (event: MessageEvent): Promise<void> => {
+    const msg = event.data as PanelRpcRequestMsg | undefined;
+    if (!msg || msg.type !== 'panel-rpc-request') return;
+    const handler = (options.handlers as Record<string, ((p: unknown) => unknown) | undefined>)[
+      msg.op
+    ];
+    if (!handler) {
+      respond(msg.id, undefined, `panel-rpc: no handler for op '${msg.op}'`);
+      return;
+    }
+    try {
+      const result = await handler(msg.payload);
+      respond(msg.id, result);
+    } catch (err) {
+      respond(msg.id, undefined, err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  channel.addEventListener('message', listener as (ev: MessageEvent) => void);
+
+  return () => {
+    channel.removeEventListener('message', listener as (ev: MessageEvent) => void);
+    try {
+      channel.close();
+    } catch {
+      /* noop */
+    }
+  };
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function newRequestId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `prpc-${crypto.randomUUID()}`;
+  }
+  return `prpc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+}
+
+// ── Worker-shell consumer helper ────────────────────────────────────
+
+/**
+ * Returns the bridge client published on `globalThis.__slicc_panelRpc`
+ * by `kernel-worker.ts`, or null when the current realm has a real
+ * DOM and should run DOM operations directly. Commands use this to
+ * pick between local-DOM and bridged execution.
+ */
+export function getPanelRpcClient(): PanelRpcClient | null {
+  const g = globalThis as unknown as { __slicc_panelRpc?: PanelRpcClient };
+  return g.__slicc_panelRpc ?? null;
+}
+
+/**
+ * `true` when the current realm has a real DOM. False inside a
+ * DedicatedWorker, irrespective of whether the bridge client is
+ * published.
+ */
+export function hasLocalDom(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}

--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -30,7 +30,10 @@
  *   hanging the worker.
  *
  * Mirrors `sprinkle-bridge-channel.ts` (instance-scoped channel name,
- * UUID request ids, default 8s timeout). Extension mode does not use
+ * UUID request ids). Default timeout is 15s — long enough that the
+ * page handler has plenty of room to do real DOM work (capture
+ * pipelines, audio decode) without spurious timeouts, but short enough
+ * that a hung handler still surfaces. Extension mode does not use
  * this bridge — the offscreen document already has a DOM, so DOM-bound
  * commands run directly there.
  */
@@ -56,7 +59,14 @@ export type PanelRpcRequest =
     }
   | {
       op: 'speak-text';
-      payload: { text: string; voice?: string; rate?: number; pitch?: number; volume?: number };
+      payload: {
+        text: string;
+        lang?: string;
+        voice?: string;
+        rate?: number;
+        pitch?: number;
+        volume?: number;
+      };
     }
   | {
       op: 'list-voices';
@@ -238,7 +248,6 @@ export function installPanelRpcHandler(options: {
       // Posting can fail if the channel was closed while we were
       // resolving — there's no useful recovery beyond logging.
       const reason = err instanceof Error ? err.message : String(err);
-
       console.warn(`panel-rpc: failed to post response for id=${id}: ${reason}`);
     }
   };

--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -238,7 +238,7 @@ export function installPanelRpcHandler(options: {
       // Posting can fail if the channel was closed while we were
       // resolving — there's no useful recovery beyond logging.
       const reason = err instanceof Error ? err.message : String(err);
-       
+
       console.warn(`panel-rpc: failed to post response for id=${id}: ${reason}`);
     }
   };

--- a/packages/webapp/src/shell/supplemental-commands/afplay-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/afplay-command.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'just-bash';
 import type { Command } from 'just-bash';
 import { detectMimeType } from './shared.js';
+import { getPanelRpcClient, hasLocalDom } from '../../kernel/panel-rpc.js';
 
 type CommandContext = Parameters<Parameters<typeof defineCommand>[1]>[1];
 type CommandResult = { stdout: string; stderr: string; exitCode: number };
@@ -32,7 +33,9 @@ async function playAudioFile(
   rate: number,
   ctx: CommandContext
 ): Promise<CommandResult> {
-  if (typeof window === 'undefined' || typeof AudioContext === 'undefined') {
+  const local = hasLocalDom() && typeof AudioContext !== 'undefined';
+  const panelRpc = getPanelRpcClient();
+  if (!local && !panelRpc) {
     return {
       stdout: '',
       stderr: 'afplay: Web Audio API unavailable in this environment\n',
@@ -60,6 +63,29 @@ async function playAudioFile(
       stderr: `afplay: ${filePath} is not an audio file\n`,
       exitCode: 1,
     };
+  }
+
+  if (!local) {
+    // Worker context: send the bytes to the page via panel-RPC.
+    // `rate` is dropped on this path (the bridge plays at native rate)
+    // — almost no callers use `-r` and supporting it would mean
+    // building the BufferSource graph on the page side too.
+    try {
+      const buf = new ArrayBuffer(bytes.byteLength);
+      new Uint8Array(buf).set(bytes);
+      await panelRpc!.call(
+        'play-audio',
+        { bytes: buf, mimeType, volume },
+        { timeoutMs: 5 * 60_000 }
+      );
+      return { stdout: '', stderr: '', exitCode: 0 };
+    } catch (err) {
+      return {
+        stdout: '',
+        stderr: `afplay: failed to play ${filePath}: ${err instanceof Error ? err.message : String(err)}\n`,
+        exitCode: 1,
+      };
+    }
   }
 
   try {

--- a/packages/webapp/src/shell/supplemental-commands/clipboard-commands.ts
+++ b/packages/webapp/src/shell/supplemental-commands/clipboard-commands.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from 'just-bash';
 import type { Command } from 'just-bash';
+import { getPanelRpcClient } from '../../kernel/panel-rpc.js';
 
 function formatError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -39,7 +40,9 @@ async function copyToClipboard(
   stdin: string,
   cmdName: string
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  if (!globalThis.navigator?.clipboard) {
+  const hasLocal = !!globalThis.navigator?.clipboard;
+  const panelRpc = !hasLocal ? getPanelRpcClient() : null;
+  if (!hasLocal && !panelRpc) {
     return {
       stdout: '',
       stderr: `${cmdName}: clipboard API is unavailable\n`,
@@ -48,7 +51,11 @@ async function copyToClipboard(
   }
 
   try {
-    await navigator.clipboard.writeText(stdin);
+    if (hasLocal) {
+      await navigator.clipboard.writeText(stdin);
+    } else {
+      await panelRpc!.call('clipboard-write-text', { text: stdin });
+    }
     return { stdout: '', stderr: '', exitCode: 0 };
   } catch (err) {
     return {
@@ -62,7 +69,9 @@ async function copyToClipboard(
 async function pasteFromClipboard(
   cmdName: string
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  if (!globalThis.navigator?.clipboard) {
+  const hasLocal = !!globalThis.navigator?.clipboard;
+  const panelRpc = !hasLocal ? getPanelRpcClient() : null;
+  if (!hasLocal && !panelRpc) {
     return {
       stdout: '',
       stderr: `${cmdName}: clipboard API is unavailable\n`,
@@ -71,7 +80,9 @@ async function pasteFromClipboard(
   }
 
   try {
-    const text = await navigator.clipboard.readText();
+    const text = hasLocal
+      ? await navigator.clipboard.readText()
+      : (await panelRpc!.call('clipboard-read-text', undefined)).text;
     // Return verbatim clipboard content without appending newline
     return { stdout: text, stderr: '', exitCode: 0 };
   } catch (err) {

--- a/packages/webapp/src/shell/supplemental-commands/open-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/open-command.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'just-bash';
 import type { Command } from 'just-bash';
 import { basename, detectMimeType, isLikelyUrl, toPreviewUrl } from './shared.js';
+import { getPanelRpcClient } from '../../kernel/panel-rpc.js';
 
 const FLAGS = ['--download', '-d', '--view', '-v'] as const;
 
@@ -53,6 +54,22 @@ export function createOpenCommand(): Command {
       | import('../../ui/sprinkle-manager.js').SprinkleManager
       | undefined;
     const hasDom = typeof window !== 'undefined' && typeof document !== 'undefined';
+    const panelRpc = !hasDom ? getPanelRpcClient() : null;
+    const canOpenWindow = hasDom || !!panelRpc;
+    const openExternal = async (url: string): Promise<void> => {
+      if (hasDom) {
+        // window.open() returns null in extension contexts (offscreen/
+        // side panel) even when the tab opens successfully — don't
+        // treat null as failure.
+        window.open(url, '_blank', 'noopener,noreferrer');
+        return;
+      }
+      await panelRpc!.call('window-open', {
+        url,
+        target: '_blank',
+        features: 'noopener,noreferrer',
+      });
+    };
 
     const results: string[] = [];
 
@@ -76,9 +93,9 @@ export function createOpenCommand(): Command {
               exitCode: 1,
             };
           }
-        } else if (hasDom) {
+        } else if (canOpenWindow) {
           const previewUrl = toPreviewUrl(fullPath);
-          window.open(previewUrl, '_blank', 'noopener,noreferrer');
+          await openExternal(previewUrl);
           results.push(`opened ${fullPath} → ${previewUrl}`);
         } else {
           return {
@@ -90,9 +107,10 @@ export function createOpenCommand(): Command {
         continue;
       }
 
-      // Every remaining branch needs a DOM (window.open / document.body
-      // / Blob href download). Bail out here for the worker-shell case.
-      if (!hasDom) {
+      // `--view` only needs file I/O + base64 (no DOM); every other
+      // mode needs either a DOM (anchor-click download) or a way to
+      // open a tab (`canOpenWindow`). Bail early when no mode applies.
+      if (!view && !canOpenWindow) {
         return {
           stdout: '',
           stderr: 'open: browser APIs are unavailable in this environment\n',
@@ -101,9 +119,14 @@ export function createOpenCommand(): Command {
       }
 
       if (isLikelyUrl(target)) {
-        // window.open() returns null in extension contexts (offscreen/side panel)
-        // even when the tab opens successfully — don't treat null as failure
-        window.open(target, '_blank', 'noopener,noreferrer');
+        if (!canOpenWindow) {
+          return {
+            stdout: '',
+            stderr: 'open: browser APIs are unavailable in this environment\n',
+            exitCode: 1,
+          };
+        }
+        await openExternal(target);
         results.push(`opened ${target}`);
         continue;
       }
@@ -145,6 +168,18 @@ export function createOpenCommand(): Command {
           `${path} (${Math.round(bytes.byteLength / 1024)} KB)\n<img:data:${mimeType};base64,${base64}>`
         );
       } else if (download) {
+        if (!hasDom) {
+          // Anchor-click download requires DOM; the bridge can't fake
+          // a browser download trigger from the page without surfacing
+          // the bytes through a transient blob URL on its own, which
+          // would still need the user to be on the page. Surface a
+          // clear error rather than silently failing.
+          return {
+            stdout: '',
+            stderr: 'open: --download requires the in-panel terminal (DOM-only)\n',
+            exitCode: 1,
+          };
+        }
         let stat;
         try {
           stat = await ctx.fs.stat(path);
@@ -187,10 +222,15 @@ export function createOpenCommand(): Command {
         setTimeout(() => URL.revokeObjectURL(url), 0);
         results.push(`downloaded ${path}`);
       } else {
+        if (!canOpenWindow) {
+          return {
+            stdout: '',
+            stderr: 'open: browser APIs are unavailable in this environment\n',
+            exitCode: 1,
+          };
+        }
         const previewUrl = toPreviewUrl(path);
-        // window.open() returns null in extension contexts (offscreen/side panel)
-        // even when the tab opens successfully — don't treat null as failure
-        window.open(previewUrl, '_blank', 'noopener,noreferrer');
+        await openExternal(previewUrl);
         results.push(`opened ${path} → ${previewUrl}`);
       }
     }

--- a/packages/webapp/src/shell/supplemental-commands/open-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/open-command.ts
@@ -56,6 +56,14 @@ export function createOpenCommand(): Command {
     const hasDom = typeof window !== 'undefined' && typeof document !== 'undefined';
     const panelRpc = !hasDom ? getPanelRpcClient() : null;
     const canOpenWindow = hasDom || !!panelRpc;
+    /**
+     * Open a URL in a new tab. Throws an Error with a stable `open:`
+     * prefix on the bridged path so callers can rely on a consistent
+     * error shape (panel-RPC rejections — handler not installed,
+     * timeout — would otherwise bubble as raw `panel-rpc: …` strings).
+     * Callers wrap this in try/catch to map to a `{ stderr, exitCode }`
+     * result.
+     */
     const openExternal = async (url: string): Promise<void> => {
       if (hasDom) {
         // window.open() returns null in extension contexts (offscreen/
@@ -64,11 +72,15 @@ export function createOpenCommand(): Command {
         window.open(url, '_blank', 'noopener,noreferrer');
         return;
       }
-      await panelRpc!.call('window-open', {
-        url,
-        target: '_blank',
-        features: 'noopener,noreferrer',
-      });
+      try {
+        await panelRpc!.call('window-open', {
+          url,
+          target: '_blank',
+          features: 'noopener,noreferrer',
+        });
+      } catch (err) {
+        throw new Error(`open: ${err instanceof Error ? err.message : String(err)}`);
+      }
     };
 
     const results: string[] = [];
@@ -95,7 +107,15 @@ export function createOpenCommand(): Command {
           }
         } else if (canOpenWindow) {
           const previewUrl = toPreviewUrl(fullPath);
-          await openExternal(previewUrl);
+          try {
+            await openExternal(previewUrl);
+          } catch (err) {
+            return {
+              stdout: '',
+              stderr: `${err instanceof Error ? err.message : String(err)}\n`,
+              exitCode: 1,
+            };
+          }
           results.push(`opened ${fullPath} → ${previewUrl}`);
         } else {
           return {
@@ -126,7 +146,15 @@ export function createOpenCommand(): Command {
             exitCode: 1,
           };
         }
-        await openExternal(target);
+        try {
+          await openExternal(target);
+        } catch (err) {
+          return {
+            stdout: '',
+            stderr: `${err instanceof Error ? err.message : String(err)}\n`,
+            exitCode: 1,
+          };
+        }
         results.push(`opened ${target}`);
         continue;
       }
@@ -230,7 +258,15 @@ export function createOpenCommand(): Command {
           };
         }
         const previewUrl = toPreviewUrl(path);
-        await openExternal(previewUrl);
+        try {
+          await openExternal(previewUrl);
+        } catch (err) {
+          return {
+            stdout: '',
+            stderr: `${err instanceof Error ? err.message : String(err)}\n`,
+            exitCode: 1,
+          };
+        }
         results.push(`opened ${path} → ${previewUrl}`);
       }
     }

--- a/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
@@ -14,6 +14,7 @@ import type { AccessibilityNode } from '../../cdp/types.js';
 import { createLogger } from '../../core/logger.js';
 import { FsError, type VirtualFS } from '../../fs/index.js';
 import type { FloatType } from '../../scoops/tray-leader-sync.js';
+import { getPanelRpcClient } from '../../kernel/panel-rpc.js';
 const log = createLogger('playwright-teleport');
 
 // ---------------------------------------------------------------------------
@@ -447,11 +448,36 @@ function renderNode(
 async function resolveAppTabId(browser: BrowserAPI, state: PlaywrightState): Promise<void> {
   if (state.appTabId) return;
   const pages = await browser.listPages();
-  // Use current origin when in browser, fall back to default port for tests/Node
-  const appOrigin =
-    typeof window !== 'undefined' ? window.location.origin : 'http://localhost:5710';
+  const appOrigin = await resolveAppOrigin();
   const appTab = pages.find((p) => p.url.startsWith(appOrigin) && !p.url.includes('/preview/'));
   if (appTab) state.appTabId = appTab.targetId;
+}
+
+/**
+ * Resolve the origin where the SLICC webapp is served.
+ *
+ *   - Page context: use `window.location.origin`.
+ *   - Kernel worker (standalone agent shell): bridge to the page via
+ *     panel-RPC `page-info`. Without this the worker was falling back
+ *     to a hardcoded `http://localhost:5710`, which silently broke
+ *     `playwright-cli` for any user running on a non-default port
+ *     (e.g. parallel instances with `PORT=5720 npm run dev`).
+ *   - Tests / Node fallback: keep the hardcoded default.
+ */
+async function resolveAppOrigin(): Promise<string> {
+  if (typeof window !== 'undefined') return window.location.origin;
+  const rpc = getPanelRpcClient();
+  if (rpc) {
+    try {
+      const info = await rpc.call('page-info', undefined, { timeoutMs: 2000 });
+      if (info.origin) return info.origin;
+    } catch {
+      // Fall through to the hardcoded default rather than failing the
+      // whole command; the agent will still try to locate the app tab
+      // and surface a clearer error if it can't.
+    }
+  }
+  return 'http://localhost:5710';
 }
 
 function isAppTab(state: PlaywrightState, targetId: string): boolean {

--- a/packages/webapp/src/shell/supplemental-commands/say-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/say-command.ts
@@ -173,12 +173,13 @@ export function createSayCommand(): Command {
       });
     }
 
-    // Worker context: bridge via panel-RPC. We pass `lang` through too
-    // even though the bridge currently ignores it — surface as a TODO
-    // when we extend the speak-text payload.
+    // Worker context: bridge via panel-RPC. `lang` is required for the
+    // command contract and must reach the page so the utterance uses
+    // the correct locale (regression flagged on PR #626 review).
     try {
       await panelRpc!.call('speak-text', {
         text,
+        lang,
         voice: resolvedVoice,
         rate,
       });

--- a/packages/webapp/src/shell/supplemental-commands/say-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/say-command.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from 'just-bash';
 import type { Command } from 'just-bash';
+import { getPanelRpcClient } from '../../kernel/panel-rpc.js';
 
 function sayHelp(): { stdout: string; stderr: string; exitCode: number } {
   return {
@@ -53,7 +54,14 @@ export function createSayCommand(): Command {
       return sayHelp();
     }
 
-    if (typeof window === 'undefined' || typeof speechSynthesis === 'undefined') {
+    // `say` only needs Web Speech, not the full DOM — using a finer
+    // gate than `hasLocalDom()` here keeps existing tests (which stub
+    // `window` + `speechSynthesis` only) working under jsdom-free
+    // environments while still bridging to the page in the kernel
+    // worker where neither global exists.
+    const local = typeof window !== 'undefined' && typeof speechSynthesis !== 'undefined';
+    const panelRpc = getPanelRpcClient();
+    if (!local && !panelRpc) {
       return {
         stdout: '',
         stderr: 'say: Web Speech API unavailable in this environment\n',
@@ -63,13 +71,22 @@ export function createSayCommand(): Command {
 
     // Handle --list early (needs voices)
     if (args.includes('--list')) {
-      const voices = await getVoices();
-      const lines = voices.map((v) => `${v.name} (${v.lang})${v.default ? ' [default]' : ''}`);
-      return {
-        stdout: lines.join('\n') + '\n',
-        stderr: '',
-        exitCode: 0,
-      };
+      if (local) {
+        const voices = await getVoices();
+        const lines = voices.map((v) => `${v.name} (${v.lang})${v.default ? ' [default]' : ''}`);
+        return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
+      }
+      try {
+        const r = await panelRpc!.call('list-voices', undefined);
+        const lines = r.voices.map((v) => `${v.name} (${v.lang})${v.default ? ' [default]' : ''}`);
+        return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
+      } catch (err) {
+        return {
+          stdout: '',
+          stderr: `say: ${err instanceof Error ? err.message : String(err)}\n`,
+          exitCode: 1,
+        };
+      }
     }
 
     // Parse args (no voice loading needed)
@@ -115,38 +132,63 @@ export function createSayCommand(): Command {
       return { stdout: '', stderr: 'say: -l language tag is required\n', exitCode: 1 };
     }
 
-    // Create utterance
-    const utterance = new SpeechSynthesisUtterance(text);
-    utterance.rate = rate;
-    utterance.lang = lang;
-
-    // Voice matching (only loads voices if -v was specified)
+    // Voice matching for worker context: the page-side handler does the
+    // exact-name match on `voice`, so we pre-resolve the partial here.
+    let resolvedVoice: string | undefined = undefined;
     if (voiceName) {
-      const voices = await getVoices();
+      const voices = local
+        ? await getVoices().then((vs) =>
+            vs.map((v) => ({ name: v.name, lang: v.lang, default: v.default }))
+          )
+        : (await panelRpc!.call('list-voices', undefined)).voices;
       const match = voices.find((v) => v.name.toLowerCase().includes(voiceName!.toLowerCase()));
-      if (match) {
-        utterance.voice = match;
-      } else {
+      if (!match) {
         return {
           stdout: '',
           stderr: `say: voice "${voiceName}" not found. Use --list to see available voices.\n`,
           exitCode: 1,
         };
       }
+      resolvedVoice = match.name;
     }
 
-    return new Promise((resolve) => {
-      utterance.onend = () => {
-        resolve({ stdout: '', stderr: '', exitCode: 0 });
+    if (local) {
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.rate = rate;
+      utterance.lang = lang;
+      if (resolvedVoice) {
+        const all = await getVoices();
+        const match = all.find((v) => v.name === resolvedVoice);
+        if (match) utterance.voice = match;
+      }
+      return new Promise((resolve) => {
+        utterance.onend = () => resolve({ stdout: '', stderr: '', exitCode: 0 });
+        utterance.onerror = (event) =>
+          resolve({
+            stdout: '',
+            stderr: `say: speech synthesis error: ${event.error}\n`,
+            exitCode: 1,
+          });
+        speechSynthesis.speak(utterance);
+      });
+    }
+
+    // Worker context: bridge via panel-RPC. We pass `lang` through too
+    // even though the bridge currently ignores it — surface as a TODO
+    // when we extend the speak-text payload.
+    try {
+      await panelRpc!.call('speak-text', {
+        text,
+        voice: resolvedVoice,
+        rate,
+      });
+      return { stdout: '', stderr: '', exitCode: 0 };
+    } catch (err) {
+      return {
+        stdout: '',
+        stderr: `say: ${err instanceof Error ? err.message : String(err)}\n`,
+        exitCode: 1,
       };
-      utterance.onerror = (event) => {
-        resolve({
-          stdout: '',
-          stderr: `say: speech synthesis error: ${event.error}\n`,
-          exitCode: 1,
-        });
-      };
-      speechSynthesis.speak(utterance);
-    });
+    }
   });
 }

--- a/packages/webapp/src/shell/supplemental-commands/screencapture-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/screencapture-command.ts
@@ -178,24 +178,35 @@ export function createScreencaptureCommand(): Command {
       try {
         if (local) {
           // Stay on the page: convert to PNG if needed and write to
-          // navigator.clipboard directly.
+          // navigator.clipboard directly. Wait for the document to
+          // regain focus first — after a full-screen / window capture
+          // through the OS-level `getDisplayMedia` picker the SLICC
+          // tab is no longer focused, and `clipboard.write` rejects
+          // with "Document is not focused".
           const pngBytes = await ensurePngBytes(bytes, mimeType);
           const pngBuffer = new ArrayBuffer(pngBytes.byteLength);
           new Uint8Array(pngBuffer).set(pngBytes);
           const pngBlob = new Blob([pngBuffer], { type: 'image/png' });
+          await whenDocumentFocused();
           await navigator.clipboard.write([new ClipboardItem({ 'image/png': pngBlob })]);
           const sizeKB = Math.round(pngBlob.size / 1024);
           return { stdout: `captured ${sizeKB} KB to clipboard\n`, stderr: '', exitCode: 0 };
         }
         // Worker: bridge the clipboard write too — navigator.clipboard
-        // doesn't exist on WorkerNavigator.
-        await panelRpc!.call('clipboard-write-image', {
-          bytes: bytes.buffer.slice(
-            bytes.byteOffset,
-            bytes.byteOffset + bytes.byteLength
-          ) as ArrayBuffer,
-          mimeType,
-        });
+        // doesn't exist on WorkerNavigator. The page-side handler does
+        // its own focus wait, so we just need a generous bridge timeout
+        // in case the user takes a while to refocus the tab.
+        await panelRpc!.call(
+          'clipboard-write-image',
+          {
+            bytes: bytes.buffer.slice(
+              bytes.byteOffset,
+              bytes.byteOffset + bytes.byteLength
+            ) as ArrayBuffer,
+            mimeType,
+          },
+          { timeoutMs: 5 * 60_000 }
+        );
         const sizeKB = Math.round(bytes.byteLength / 1024);
         return { stdout: `captured ${sizeKB} KB to clipboard\n`, stderr: '', exitCode: 0 };
       } catch (err) {
@@ -272,4 +283,45 @@ async function ensurePngBytes(bytes: Uint8Array, mimeType: string): Promise<Uint
   } finally {
     URL.revokeObjectURL(url);
   }
+}
+
+/**
+ * Resolve once `document.hasFocus()` is true so a follow-up
+ * `navigator.clipboard.write` call doesn't reject with "Document is
+ * not focused". Mirrors the helper used on the panel-RPC handler side;
+ * kept local to keep this file callable from worker-importable code
+ * paths without dragging UI deps along (the function is only ever
+ * called on the local-DOM branch).
+ */
+async function whenDocumentFocused(timeoutMs = 5 * 60_000): Promise<void> {
+  if (typeof document === 'undefined') return;
+  // Treat a missing `hasFocus` (lightweight test stubs) as already
+  // focused so we don't wedge tests that don't bother mocking it.
+  if (typeof document.hasFocus !== 'function') return;
+  if (document.hasFocus()) return;
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
+      clearTimeout(timer);
+    };
+    const onFocus = () => {
+      if (document.hasFocus()) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible' && document.hasFocus()) {
+        cleanup();
+        resolve();
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('timed out waiting for window focus'));
+    }, timeoutMs);
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+  });
 }

--- a/packages/webapp/src/shell/supplemental-commands/screencapture-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/screencapture-command.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'just-bash';
 import type { Command } from 'just-bash';
 import { basename } from './shared.js';
+import { getPanelRpcClient, hasLocalDom } from '../../kernel/panel-rpc.js';
 
 function screencaptureHelp(): { stdout: string; stderr: string; exitCode: number } {
   return {
@@ -49,60 +50,50 @@ function getMimeTypeForExtension(filename: string): string {
   }
 }
 
-async function captureScreen(mimeType: string, quality: number): Promise<Blob> {
-  const stream = await navigator.mediaDevices.getDisplayMedia({
-    video: true,
-    audio: false,
-  });
-
+/**
+ * Capture pixels via the DOM directly. Only callable from a context
+ * that has `navigator.mediaDevices` and `document` (panel terminal,
+ * extension offscreen). The kernel worker reaches the same code path
+ * by going through the panel-RPC bridge instead.
+ */
+async function captureLocally(
+  mimeType: string,
+  quality: number
+): Promise<{ bytes: Uint8Array; mimeType: string }> {
+  const stream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false });
   try {
     const video = document.createElement('video');
     video.srcObject = stream;
     video.muted = true;
     video.playsInline = true;
-
     await new Promise<void>((resolve, reject) => {
-      video.onloadedmetadata = () => {
+      video.onloadedmetadata = () =>
         video
           .play()
           .then(() => resolve())
           .catch(reject);
-      };
       video.onerror = () => reject(new Error('Failed to load video stream'));
     });
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
 
-    // Wait a frame to ensure video is rendered
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-
-    // Use actual video dimensions from the loaded stream
     const width = video.videoWidth;
     const height = video.videoHeight;
-
     const canvas = document.createElement('canvas');
     canvas.width = width;
     canvas.height = height;
     const ctx = canvas.getContext('2d');
-    if (!ctx) {
-      throw new Error('Failed to get canvas context');
-    }
-
+    if (!ctx) throw new Error('Failed to get canvas context');
     ctx.drawImage(video, 0, 0, width, height);
-
-    return new Promise<Blob>((resolve, reject) => {
+    const blob = await new Promise<Blob>((resolve, reject) => {
       canvas.toBlob(
-        (blob) => {
-          if (blob) {
-            resolve(blob);
-          } else {
-            reject(new Error('Failed to create image blob'));
-          }
-        },
+        (b) => (b ? resolve(b) : reject(new Error('Failed to create image blob'))),
         mimeType,
         quality
       );
     });
+    return { bytes: new Uint8Array(await blob.arrayBuffer()), mimeType };
   } finally {
-    stream.getTracks().forEach((track) => track.stop());
+    stream.getTracks().forEach((t) => t.stop());
   }
 }
 
@@ -112,19 +103,16 @@ export function createScreencaptureCommand(): Command {
       return screencaptureHelp();
     }
 
-    if (
-      typeof window === 'undefined' ||
-      typeof navigator === 'undefined' ||
-      typeof document === 'undefined'
-    ) {
+    const local = hasLocalDom();
+    const panelRpc = getPanelRpcClient();
+    if (!local && !panelRpc) {
       return {
         stdout: '',
         stderr: 'screencapture: browser APIs are unavailable in this environment\n',
         exitCode: 1,
       };
     }
-
-    if (!navigator.mediaDevices?.getDisplayMedia) {
+    if (local && !navigator.mediaDevices?.getDisplayMedia) {
       return {
         stdout: '',
         stderr: 'screencapture: screen capture is not supported in this browser\n',
@@ -154,9 +142,22 @@ export function createScreencaptureCommand(): Command {
     const mimeType = getMimeTypeForExtension(filename);
     const quality = mimeType === 'image/png' ? 1.0 : 0.92;
 
-    let blob: Blob;
+    let bytes: Uint8Array;
     try {
-      blob = await captureScreen(mimeType, quality);
+      if (local) {
+        const r = await captureLocally(mimeType, quality);
+        bytes = r.bytes;
+      } else {
+        // Worker context: round-trip via the page. The bridge timeout
+        // is generous because the user has to pick a target in the
+        // OS-level capture picker, which may take many seconds.
+        const r = await panelRpc!.call(
+          'screencapture',
+          { mimeType, quality },
+          { timeoutMs: 5 * 60_000 }
+        );
+        bytes = new Uint8Array(r.bytes);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (message.includes('Permission denied') || message.includes('NotAllowedError')) {
@@ -173,51 +174,30 @@ export function createScreencaptureCommand(): Command {
       };
     }
 
-    const arrayBuffer = await blob.arrayBuffer();
-    const bytes = new Uint8Array(arrayBuffer);
-
     if (toClipboard) {
       try {
-        let pngBlob: Blob;
-        if (mimeType === 'image/png') {
-          pngBlob = blob;
-        } else {
-          // Clipboard API requires PNG, convert if necessary
-          const img = new Image();
-          const url = URL.createObjectURL(blob);
-          try {
-            await new Promise<void>((resolve, reject) => {
-              img.onload = () => resolve();
-              img.onerror = () => reject(new Error('Failed to load image for conversion'));
-              img.src = url;
-            });
-          } finally {
-            URL.revokeObjectURL(url);
-          }
-
-          const canvas = document.createElement('canvas');
-          canvas.width = img.width;
-          canvas.height = img.height;
-          const ctx = canvas.getContext('2d');
-          if (!ctx) throw new Error('Failed to get canvas context');
-          ctx.drawImage(img, 0, 0);
-
-          pngBlob = await new Promise<Blob>((resolve, reject) => {
-            canvas.toBlob((b) => {
-              if (b) resolve(b);
-              else reject(new Error('Failed to create PNG blob'));
-            }, 'image/png');
-          });
+        if (local) {
+          // Stay on the page: convert to PNG if needed and write to
+          // navigator.clipboard directly.
+          const pngBytes = await ensurePngBytes(bytes, mimeType);
+          const pngBuffer = new ArrayBuffer(pngBytes.byteLength);
+          new Uint8Array(pngBuffer).set(pngBytes);
+          const pngBlob = new Blob([pngBuffer], { type: 'image/png' });
+          await navigator.clipboard.write([new ClipboardItem({ 'image/png': pngBlob })]);
+          const sizeKB = Math.round(pngBlob.size / 1024);
+          return { stdout: `captured ${sizeKB} KB to clipboard\n`, stderr: '', exitCode: 0 };
         }
-
-        await navigator.clipboard.write([new ClipboardItem({ 'image/png': pngBlob })]);
-
-        const sizeKB = Math.round(pngBlob.size / 1024);
-        return {
-          stdout: `captured ${sizeKB} KB to clipboard\n`,
-          stderr: '',
-          exitCode: 0,
-        };
+        // Worker: bridge the clipboard write too — navigator.clipboard
+        // doesn't exist on WorkerNavigator.
+        await panelRpc!.call('clipboard-write-image', {
+          bytes: bytes.buffer.slice(
+            bytes.byteOffset,
+            bytes.byteOffset + bytes.byteLength
+          ) as ArrayBuffer,
+          mimeType,
+        });
+        const sizeKB = Math.round(bytes.byteLength / 1024);
+        return { stdout: `captured ${sizeKB} KB to clipboard\n`, stderr: '', exitCode: 0 };
       } catch (err) {
         return {
           stdout: '',
@@ -256,4 +236,40 @@ export function createScreencaptureCommand(): Command {
       exitCode: 0,
     };
   });
+}
+
+/**
+ * Convert raw image bytes to PNG bytes when the source isn't already
+ * PNG. Only used on the local DOM path — the bridge path defers PNG
+ * conversion to the page-side `clipboard-write-image` handler.
+ */
+async function ensurePngBytes(bytes: Uint8Array, mimeType: string): Promise<Uint8Array> {
+  if (mimeType === 'image/png') return bytes;
+  const safeBuffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(safeBuffer).set(bytes);
+  const blob = new Blob([safeBuffer], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = new Image();
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error('Failed to load image for conversion'));
+      img.src = url;
+    });
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Failed to get canvas context');
+    ctx.drawImage(img, 0, 0);
+    const png = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (b) => (b ? resolve(b) : reject(new Error('Failed to create PNG blob'))),
+        'image/png'
+      );
+    });
+    return new Uint8Array(await png.arrayBuffer());
+  } finally {
+    URL.revokeObjectURL(url);
+  }
 }

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1946,6 +1946,23 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
   const stopSprinkleHandler = installSprinkleManagerHandlerOverChannel(sprinkleManager, {
     instanceId,
   });
+
+  // Install the panel-RPC handler so DOM-bound shell commands run by
+  // the kernel worker (screencapture / say / afplay / clipboard /
+  // open, plus the playwright app-origin lookup) can reach the page.
+  // `imgcat` is intentionally terminal-only and stays out of the
+  // bridge — it's meant for the in-panel terminal, not the agent.
+  const { installPanelRpcHandler } = await import('../kernel/panel-rpc.js');
+  const { createStandalonePanelRpcHandlers } = await import('./panel-rpc-handlers.js');
+  const stopPanelRpcHandler = installPanelRpcHandler({
+    instanceId,
+    handlers: createStandalonePanelRpcHandlers(),
+  });
+  // Tear down on session reload so the handler doesn't outlive its
+  // page (the channel would still receive requests and try to call
+  // into a torn-down DOM).
+  window.addEventListener('beforeunload', () => stopPanelRpcHandler(), { once: true });
+
   await sprinkleManager.refresh();
   layout.onSprinkleClose = (name) => sprinkleManager.close(name);
   await sprinkleManager.restoreOpenSprinkles().catch((err) => {

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1536,9 +1536,25 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
   };
 
   // Real CDP transport. The worker's `BrowserAPI` proxies CDP commands
-  // back here through the kernel transport.
+  // back here through the kernel transport. We must connect the
+  // underlying `CDPClient` proactively: the worker-side `BrowserAPI`
+  // has its own `ensureConnected()` (which flips its `CdpTransportBridge`
+  // state to 'connected' inside the worker, decoupled from the wire),
+  // but every `cdp-cmd` envelope it forwards ultimately lands in
+  // `startPageCdpForwarder` → `realTransport.send(...)`. If this
+  // `CDPClient` is still in `disconnected` state at that moment, the
+  // send throws "CDP client is not connected" and the agent sees
+  // confusing errors for `playwright`, `open`, etc.
   const browser = new BrowserAPI();
   const realCdpTransport = browser.getTransport();
+  try {
+    await browser.connect();
+  } catch (err) {
+    log.warn(
+      'Initial CDP connect failed; worker-forwarded commands will retry on demand',
+      err instanceof Error ? err.message : String(err)
+    );
+  }
 
   let selectedScoop: RegisteredScoop | null = null;
   let client!: InstanceType<typeof OffscreenClient>;

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -39,12 +39,13 @@ export function createStandalonePanelRpcHandlers(): PanelRpcHandlers {
       };
     },
 
-    'speak-text': async ({ text, voice, rate, pitch, volume }) => {
+    'speak-text': async ({ text, lang, voice, rate, pitch, volume }) => {
       if (typeof speechSynthesis === 'undefined') {
         throw new Error('speechSynthesis is unavailable in this page');
       }
       await new Promise<void>((resolve, reject) => {
         const u = new SpeechSynthesisUtterance(text);
+        if (lang !== undefined) u.lang = lang;
         if (rate !== undefined) u.rate = rate;
         if (pitch !== undefined) u.pitch = pitch;
         if (volume !== undefined) u.volume = volume;
@@ -86,6 +87,9 @@ export function createStandalonePanelRpcHandlers(): PanelRpcHandlers {
     },
 
     'play-audio': async ({ bytes, volume }) => {
+      if (typeof AudioContext === 'undefined') {
+        throw new Error('Web Audio API is unavailable in this page');
+      }
       const ctx = new AudioContext();
       try {
         const buffer = await ctx.decodeAudioData(bytes.slice(0));
@@ -122,6 +126,9 @@ export function createStandalonePanelRpcHandlers(): PanelRpcHandlers {
         notify: [660, 660],
       };
       const [f1, f2] = freqs[tone ?? 'notify'] ?? freqs.notify;
+      if (typeof AudioContext === 'undefined') {
+        throw new Error('Web Audio API is unavailable in this page');
+      }
       const ctx = new AudioContext();
       try {
         const start = ctx.currentTime;
@@ -206,6 +213,9 @@ function toVoiceInfo(v: SpeechSynthesisVoice): { name: string; lang: string; def
 }
 
 async function captureScreen(mimeType: string, quality: number): Promise<Blob> {
+  if (!navigator.mediaDevices?.getDisplayMedia) {
+    throw new Error('screen capture is not supported in this browser');
+  }
   const stream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false });
   try {
     const video = document.createElement('video');

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -1,0 +1,274 @@
+/**
+ * Page-side handlers for the panel-RPC bridge defined in
+ * `kernel/panel-rpc.ts`. The kernel worker has no DOM, no
+ * `mediaDevices`, no `clipboard`, and no `speechSynthesis`/`AudioContext`
+ * — these handlers run in the page context and execute the actual
+ * browser-API calls on behalf of worker-side supplemental commands.
+ *
+ * Wired from `mainStandaloneWorker` after the orchestrator boot
+ * handshake; the extension float doesn't use this module because its
+ * offscreen document already has a DOM.
+ */
+
+import type { PanelRpcHandlers } from '../kernel/panel-rpc.js';
+
+/**
+ * Build a record of handlers suitable for `installPanelRpcHandler`.
+ * Pure factory so the handler set is easy to test under JSDOM.
+ */
+export function createStandalonePanelRpcHandlers(): PanelRpcHandlers {
+  return {
+    'page-info': () => ({
+      origin: window.location.origin,
+      href: window.location.href,
+      title: document.title || '',
+    }),
+
+    screencapture: async ({ mimeType, quality }) => {
+      const blob = await captureScreen(mimeType, quality);
+      const buffer = await blob.arrayBuffer();
+      // Recover dimensions for the agent's reference. Decoding to an
+      // <img> just to read its natural size is the cheapest path that
+      // works for every blob type the browser emits via toBlob().
+      const dims = await readBlobDimensions(blob);
+      return {
+        bytes: buffer,
+        width: dims.width,
+        height: dims.height,
+        mimeType,
+      };
+    },
+
+    'speak-text': async ({ text, voice, rate, pitch, volume }) => {
+      if (typeof speechSynthesis === 'undefined') {
+        throw new Error('speechSynthesis is unavailable in this page');
+      }
+      await new Promise<void>((resolve, reject) => {
+        const u = new SpeechSynthesisUtterance(text);
+        if (rate !== undefined) u.rate = rate;
+        if (pitch !== undefined) u.pitch = pitch;
+        if (volume !== undefined) u.volume = volume;
+        if (voice) {
+          const match = speechSynthesis.getVoices().find((v) => v.name === voice);
+          if (match) u.voice = match;
+        }
+        u.onend = () => resolve();
+        u.onerror = (ev) => reject(new Error(`speak: ${ev.error || 'utterance failed'}`));
+        speechSynthesis.speak(u);
+      });
+      return { done: true };
+    },
+
+    'list-voices': async () => {
+      if (typeof speechSynthesis === 'undefined') {
+        throw new Error('speechSynthesis is unavailable in this page');
+      }
+      const ready = speechSynthesis.getVoices();
+      if (ready.length > 0) return { voices: ready.map(toVoiceInfo) };
+      // Voices load asynchronously on first read in many browsers —
+      // wait once for `voiceschanged` so the worker side doesn't get
+      // an empty list on a cold session.
+      const voices = await new Promise<SpeechSynthesisVoice[]>((resolve) => {
+        const onChange = () => {
+          speechSynthesis.removeEventListener('voiceschanged', onChange);
+          resolve(speechSynthesis.getVoices());
+        };
+        speechSynthesis.addEventListener('voiceschanged', onChange);
+        // Belt-and-braces: bail out after 1s so a browser that never
+        // fires the event doesn't hang the call until the bridge
+        // timeout (which would surface as a confusing op error).
+        setTimeout(() => {
+          speechSynthesis.removeEventListener('voiceschanged', onChange);
+          resolve(speechSynthesis.getVoices());
+        }, 1000);
+      });
+      return { voices: voices.map(toVoiceInfo) };
+    },
+
+    'play-audio': async ({ bytes, volume }) => {
+      const ctx = new AudioContext();
+      try {
+        const buffer = await ctx.decodeAudioData(bytes.slice(0));
+        const src = ctx.createBufferSource();
+        src.buffer = buffer;
+        if (volume !== undefined) {
+          const gain = ctx.createGain();
+          gain.gain.value = Math.max(0, Math.min(1, volume));
+          src.connect(gain);
+          gain.connect(ctx.destination);
+        } else {
+          src.connect(ctx.destination);
+        }
+        await new Promise<void>((resolve) => {
+          src.onended = () => resolve();
+          src.start();
+        });
+      } finally {
+        try {
+          await ctx.close();
+        } catch {
+          /* noop */
+        }
+      }
+      return { done: true };
+    },
+
+    'play-chime': async ({ tone }) => {
+      // Simple synthesized chime so chime/notify works without a VFS
+      // file. Tone-coded for variants.
+      const freqs: Record<string, [number, number]> = {
+        success: [880, 1320],
+        error: [440, 220],
+        notify: [660, 660],
+      };
+      const [f1, f2] = freqs[tone ?? 'notify'] ?? freqs.notify;
+      const ctx = new AudioContext();
+      try {
+        const start = ctx.currentTime;
+        for (const [i, f] of [f1, f2].entries()) {
+          const osc = ctx.createOscillator();
+          osc.type = 'sine';
+          osc.frequency.value = f;
+          const gain = ctx.createGain();
+          gain.gain.setValueAtTime(0.0001, start + i * 0.18);
+          gain.gain.exponentialRampToValueAtTime(0.2, start + i * 0.18 + 0.02);
+          gain.gain.exponentialRampToValueAtTime(0.0001, start + i * 0.18 + 0.18);
+          osc.connect(gain);
+          gain.connect(ctx.destination);
+          osc.start(start + i * 0.18);
+          osc.stop(start + i * 0.18 + 0.2);
+        }
+        await new Promise((r) => setTimeout(r, 450));
+      } finally {
+        try {
+          await ctx.close();
+        } catch {
+          /* noop */
+        }
+      }
+      return { done: true };
+    },
+
+    'clipboard-read-text': async () => {
+      if (!navigator.clipboard?.readText) {
+        throw new Error('clipboard API unavailable');
+      }
+      return { text: await navigator.clipboard.readText() };
+    },
+
+    'clipboard-write-text': async ({ text }) => {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error('clipboard API unavailable');
+      }
+      await navigator.clipboard.writeText(text);
+      return { done: true };
+    },
+
+    'clipboard-write-image': async ({ bytes, mimeType }) => {
+      if (!navigator.clipboard?.write || typeof ClipboardItem === 'undefined') {
+        throw new Error('clipboard image API unavailable');
+      }
+      let pngBlob: Blob;
+      const src = new Blob([bytes], { type: mimeType });
+      if (mimeType === 'image/png') {
+        pngBlob = src;
+      } else {
+        pngBlob = await reencodeAsPng(src);
+      }
+      await navigator.clipboard.write([new ClipboardItem({ 'image/png': pngBlob })]);
+      return { done: true };
+    },
+
+    'window-open': async ({ url, target, features }) => {
+      // `window.open` may return null in some contexts (extension
+      // offscreen has been seen to do this for `_blank`). For
+      // standalone the call succeeds; report what we observed so the
+      // caller can decide how to handle it.
+      const win = window.open(url, target ?? '_blank', features ?? 'noopener,noreferrer');
+      return { opened: win !== null };
+    },
+  };
+}
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+function toVoiceInfo(v: SpeechSynthesisVoice): { name: string; lang: string; default: boolean } {
+  return { name: v.name, lang: v.lang, default: v.default };
+}
+
+async function captureScreen(mimeType: string, quality: number): Promise<Blob> {
+  const stream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false });
+  try {
+    const video = document.createElement('video');
+    video.srcObject = stream;
+    video.muted = true;
+    video.playsInline = true;
+    await new Promise<void>((resolve, reject) => {
+      video.onloadedmetadata = () =>
+        video
+          .play()
+          .then(() => resolve())
+          .catch(reject);
+      video.onerror = () => reject(new Error('Failed to load video stream'));
+    });
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+    const width = video.videoWidth;
+    const height = video.videoHeight;
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Failed to get canvas context');
+    ctx.drawImage(video, 0, 0, width, height);
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error('Failed to create image blob'))),
+        mimeType,
+        quality
+      );
+    });
+  } finally {
+    stream.getTracks().forEach((t) => t.stop());
+  }
+}
+
+async function readBlobDimensions(blob: Blob): Promise<{ width: number; height: number }> {
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = new Image();
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error('Failed to decode capture'));
+      img.src = url;
+    });
+    return { width: img.naturalWidth, height: img.naturalHeight };
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+async function reencodeAsPng(blob: Blob): Promise<Blob> {
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = new Image();
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error('Failed to load image for clipboard conversion'));
+      img.src = url;
+    });
+    const canvas = document.createElement('canvas');
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Failed to get canvas context');
+    ctx.drawImage(img, 0, 0);
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (b) => (b ? resolve(b) : reject(new Error('PNG re-encode failed'))),
+        'image/png'
+      );
+    });
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -160,6 +160,7 @@ export function createStandalonePanelRpcHandlers(): PanelRpcHandlers {
       if (!navigator.clipboard?.writeText) {
         throw new Error('clipboard API unavailable');
       }
+      await whenDocumentFocused();
       await navigator.clipboard.writeText(text);
       return { done: true };
     },
@@ -175,6 +176,14 @@ export function createStandalonePanelRpcHandlers(): PanelRpcHandlers {
       } else {
         pngBlob = await reencodeAsPng(src);
       }
+      // The browser rejects `clipboard.write` with "Document is not
+      // focused" when invoked while the page is in the background —
+      // which is exactly what happens after the user picks a target
+      // in the OS-level `getDisplayMedia` picker (focus stays on the
+      // target window / screen). Defer the write until the page
+      // regains focus so `screencapture -c` finishes silently when
+      // the user comes back instead of failing right at the finish line.
+      await whenDocumentFocused();
       await navigator.clipboard.write([new ClipboardItem({ 'image/png': pngBlob })]);
       return { done: true };
     },
@@ -271,4 +280,53 @@ async function reencodeAsPng(blob: Blob): Promise<Blob> {
   } finally {
     URL.revokeObjectURL(url);
   }
+}
+
+/**
+ * Resolve when the document is focused so a follow-up `navigator.clipboard.*`
+ * call doesn't reject with "Document is not focused". Common trigger: the
+ * `getDisplayMedia` OS picker hands focus to the selected target window /
+ * screen, leaving the SLICC tab in the background while the agent tries to
+ * finish the capture pipeline.
+ *
+ * - Resolves immediately when the page is already focused.
+ * - Otherwise listens for the next `focus` event on `window` and resolves
+ *   then. A `visibilitychange` listener covers the case where the tab is
+ *   reactivated without firing a window focus event (e.g. switching back
+ *   from another tab via Cmd-Tab).
+ * - Bails out after `timeoutMs` so a forgotten capture doesn't hang the
+ *   command forever; the caller surfaces the timeout as a clipboard error
+ *   the user can act on.
+ */
+async function whenDocumentFocused(timeoutMs = 5 * 60_000): Promise<void> {
+  if (typeof document === 'undefined') return;
+  // Treat a missing `hasFocus` (lightweight test stubs) as already
+  // focused so we don't wedge tests that don't bother mocking it.
+  if (typeof document.hasFocus !== 'function') return;
+  if (document.hasFocus()) return;
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
+      clearTimeout(timer);
+    };
+    const onFocus = () => {
+      if (document.hasFocus()) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible' && document.hasFocus()) {
+        cleanup();
+        resolve();
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('timed out waiting for window focus'));
+    }, timeoutMs);
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+  });
 }

--- a/packages/webapp/tests/kernel/panel-rpc.test.ts
+++ b/packages/webapp/tests/kernel/panel-rpc.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  createPanelRpcClient,
+  installPanelRpcHandler,
+  panelRpcChannelName,
+} from '../../src/kernel/panel-rpc.js';
+
+/**
+ * Tiny in-memory BroadcastChannel polyfill so this test runs under the
+ * Node-environment vitest setup the rest of the kernel suite uses. The
+ * real BroadcastChannel is async on the same channel name but
+ * delivers synchronously through the JS task queue; this polyfill
+ * mirrors that with queueMicrotask.
+ */
+class FakeChannel {
+  private static buses = new Map<string, Set<FakeChannel>>();
+  private listeners = new Set<(ev: MessageEvent) => void>();
+  private closed = false;
+
+  constructor(public readonly name: string) {
+    let bus = FakeChannel.buses.get(name);
+    if (!bus) {
+      bus = new Set();
+      FakeChannel.buses.set(name, bus);
+    }
+    bus.add(this);
+  }
+  postMessage(data: unknown): void {
+    if (this.closed) return;
+    const bus = FakeChannel.buses.get(this.name);
+    if (!bus) return;
+    for (const peer of bus) {
+      if (peer === this || peer.closed) continue;
+      queueMicrotask(() => {
+        for (const l of peer.listeners) l(new MessageEvent('message', { data }));
+      });
+    }
+  }
+  addEventListener(_type: 'message', listener: (ev: MessageEvent) => void): void {
+    this.listeners.add(listener);
+  }
+  removeEventListener(_type: 'message', listener: (ev: MessageEvent) => void): void {
+    this.listeners.delete(listener);
+  }
+  close(): void {
+    this.closed = true;
+    const bus = FakeChannel.buses.get(this.name);
+    bus?.delete(this);
+    this.listeners.clear();
+  }
+}
+
+let originalBroadcastChannel: typeof BroadcastChannel | undefined;
+
+beforeEach(() => {
+  originalBroadcastChannel = (globalThis as { BroadcastChannel?: typeof BroadcastChannel })
+    .BroadcastChannel;
+  (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel =
+    FakeChannel as unknown as typeof BroadcastChannel;
+});
+
+afterEach(() => {
+  (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = originalBroadcastChannel;
+});
+
+describe('panel-rpc', () => {
+  it('panelRpcChannelName scopes by instanceId', () => {
+    expect(panelRpcChannelName()).toBe('slicc-panel-rpc');
+    expect(panelRpcChannelName('abc')).toBe('slicc-panel-rpc:abc');
+  });
+
+  it('round-trips a request/response through the handler', async () => {
+    const stop = installPanelRpcHandler({
+      instanceId: 't1',
+      handlers: {
+        'page-info': () => ({
+          origin: 'http://localhost:5720',
+          href: 'http://localhost:5720/',
+          title: 'slicc',
+        }),
+      },
+    });
+    const client = createPanelRpcClient({ instanceId: 't1' });
+    const info = await client.call('page-info', undefined);
+    expect(info.origin).toBe('http://localhost:5720');
+    expect(info.title).toBe('slicc');
+    client.dispose();
+    stop();
+  });
+
+  it('forwards handler errors as rejected promises', async () => {
+    const stop = installPanelRpcHandler({
+      instanceId: 't2',
+      handlers: {
+        'clipboard-read-text': () => {
+          throw new Error('clipboard blocked');
+        },
+      },
+    });
+    const client = createPanelRpcClient({ instanceId: 't2' });
+    await expect(client.call('clipboard-read-text', undefined)).rejects.toThrow(
+      /clipboard blocked/
+    );
+    client.dispose();
+    stop();
+  });
+
+  it('responds with an error for an unregistered op rather than hanging', async () => {
+    const stop = installPanelRpcHandler({ instanceId: 't3', handlers: {} });
+    const client = createPanelRpcClient({ instanceId: 't3' });
+    await expect(client.call('page-info', undefined, { timeoutMs: 200 })).rejects.toThrow(
+      /no handler for op 'page-info'/
+    );
+    client.dispose();
+    stop();
+  });
+
+  it('times out when no handler is listening on the channel', async () => {
+    vi.useFakeTimers();
+    const client = createPanelRpcClient({ instanceId: 'lonely' });
+    const promise = client.call('page-info', undefined, { timeoutMs: 50 });
+    // Attach the expectation handler before advancing fake timers so
+    // the rejection is observed instead of surfacing as an
+    // unhandled-rejection warning.
+    const expectation = expect(promise).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(60);
+    await expectation;
+    client.dispose();
+    vi.useRealTimers();
+  });
+
+  it('does not cross-talk between instanceIds', async () => {
+    const stopA = installPanelRpcHandler({
+      instanceId: 'A',
+      handlers: { 'clipboard-read-text': () => ({ text: 'from-A' }) },
+    });
+    const stopB = installPanelRpcHandler({
+      instanceId: 'B',
+      handlers: { 'clipboard-read-text': () => ({ text: 'from-B' }) },
+    });
+    const clientA = createPanelRpcClient({ instanceId: 'A' });
+    const clientB = createPanelRpcClient({ instanceId: 'B' });
+    expect((await clientA.call('clipboard-read-text', undefined)).text).toBe('from-A');
+    expect((await clientB.call('clipboard-read-text', undefined)).text).toBe('from-B');
+    clientA.dispose();
+    clientB.dispose();
+    stopA();
+    stopB();
+  });
+
+  it('dispose rejects in-flight calls', async () => {
+    // No handler installed, so the call won't complete on its own.
+    const client = createPanelRpcClient({ instanceId: 'dispose-test' });
+    const promise = client.call('page-info', undefined, { timeoutMs: 5000 });
+    client.dispose();
+    await expect(promise).rejects.toThrow(/client disposed/);
+  });
+
+  it('returns a fail-fast proxy when BroadcastChannel is unavailable', async () => {
+    (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = undefined;
+    const client = createPanelRpcClient({ instanceId: 'no-bc' });
+    await expect(client.call('page-info', undefined)).rejects.toThrow(
+      /BroadcastChannel is unavailable/
+    );
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/screencapture-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/screencapture-command.test.ts
@@ -316,6 +316,40 @@ describe('screencapture command', () => {
       expect(result.stderr).toContain('failed to copy to clipboard');
     });
 
+    it('defers the clipboard write until the document regains focus', async () => {
+      // Simulate the OS-picker stealing focus: hasFocus() starts false
+      // and flips to true once we dispatch a window `focus` event.
+      let focused = false;
+      const focusListeners = new Set<() => void>();
+      (globalThis as any).document.hasFocus = () => focused;
+      (globalThis as any).document.addEventListener = vi.fn();
+      (globalThis as any).document.removeEventListener = vi.fn();
+      (globalThis as any).window.addEventListener = vi.fn((type: string, fn: () => void) => {
+        if (type === 'focus') focusListeners.add(fn);
+      });
+      (globalThis as any).window.removeEventListener = vi.fn((type: string, fn: () => void) => {
+        if (type === 'focus') focusListeners.delete(fn);
+      });
+
+      const cmd = createScreencaptureCommand();
+      const ctx = createMockCtx();
+      const promise = cmd.execute(['-c'], ctx as any);
+
+      // Yield so screencapture's capture pipeline reaches the focus wait.
+      await new Promise((r) => setTimeout(r, 10));
+      expect((globalThis as any).navigator.clipboard.write).not.toHaveBeenCalled();
+      expect(focusListeners.size).toBe(1);
+
+      // Refocus and re-fire — the helper checks hasFocus() inside the
+      // handler, so flip it first.
+      focused = true;
+      for (const fn of focusListeners) fn();
+
+      const result = await promise;
+      expect(result.exitCode).toBe(0);
+      expect((globalThis as any).navigator.clipboard.write).toHaveBeenCalled();
+    });
+
     it('uses correct mime type for jpg extension', async () => {
       const cmd = createScreencaptureCommand();
       const ctx = createMockCtx();


### PR DESCRIPTION
## Why

In standalone mode the agent's `bash` tool runs in a `DedicatedWorker` (`kernel-worker.ts`). `WorkerNavigator` has **no** `mediaDevices`, **no** `clipboard`, **no** `speechSynthesis`, **no** `AudioContext`, **no** `window`, **no** `document` — so every supplemental command that touched those APIs directly failed for the agent, even though the same command worked fine from the in-panel terminal (which has a real DOM).

The user surfaced this while looking at `screencapture` and asked to broaden the wiring: \"same problem with say and afplay and a few more commands… and also playwright.\"

## What this PR does

Adds a single typed BroadcastChannel bridge (`packages/webapp/src/kernel/panel-rpc.ts`) that the worker shell can call into and that the page services. Each affected command now picks between a **direct DOM path** (untouched for the terminal and for the extension offscreen document) and a **bridged path** (used by the worker), so behaviour stays identical where it already worked and is finally usable where it didn't.

### Commands fixed

| Command | Was broken because | Now |
|---|---|---|
| `screencapture` | `navigator.mediaDevices` + DOM canvas + clipboard write | bridges all three to the page |
| `say` | `speechSynthesis` utterance + voice listing | bridges `speak-text` + `list-voices` |
| `afplay` / `chime` | `AudioContext` decode + playback | bridges `play-audio` |
| `pbcopy` / `pbpaste` (+ `xclip` / `xsel`) | `navigator.clipboard` read/write | bridges `clipboard-read-text` / `clipboard-write-text` |
| `open` | `window.open` for URLs and previews | bridges `window-open`; `--view` works in the worker directly (file I/O + base64 only, no DOM needed); `--download` stays panel-only with a clear error |
| `playwright` | hardcoded `http://localhost:5710` when `window` was undefined — silently broke any non-default port | bridges `page-info` to read the real origin |

The playwright bug was extra subtle: on parallel-instance ports (`PORT=5720 npm run dev`) the agent's `playwright-cli` couldn't locate the SLICC tab because it was probing for the wrong origin.

### Architecture

Mirrors `sprinkle-bridge-channel.ts` (the existing worker→page bridge for sprinkles): instance-scoped channel name, UUID request ids, default 15s timeout, fail-fast when `BroadcastChannel` is absent. Worker side publishes `globalThis.__slicc_panelRpc`; page side installs the handler in `mainStandaloneWorker` right next to the sprinkle handler.

\"Has local DOM\" detection is intentionally per-command (each command knows its own API requirement) rather than a single global gate — that keeps the existing test suites untouched (e.g. `say` tests stub `window: {}` + `speechSynthesis` without `document`, and still pass).

The **extension float does not use this bridge** — its offscreen document has a real DOM, so the local-DOM path runs directly there. Zero behaviour change for the extension.

## Test plan

- [x] 8 panel-rpc unit tests: round trip, error forwarding, unknown op, timeout, instance-id isolation, dispose, no-BroadcastChannel fail-fast.
- [x] All 3517 webapp tests pass (was 3509, +8).
- [x] `npm run typecheck` clean across all 4 tsconfigs.
- [x] `npm run build -w @slicc/webapp` + `npm run build -w @slicc/chrome-extension` succeed.
- [x] Live CDP verification on the running dev server (port 5720): round-tripped `page-info` over the bridge and got back `origin: \"http://localhost:5720\"` — the exact case the old `playwright` hardcode missed.
- [ ] Manual smoke: in a worker-hosted agent, run `screencapture /tmp/x.png`, `say -l en-US hello`, `echo hi | pbcopy`, `open https://example.com`, and a playwright command on a non-default port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)