### PR TITLE
fix(sprinkles): restore custom rail icons in standalone bootstrap

### DIFF
--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1948,6 +1948,7 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
   });
   await sprinkleManager.refresh();
   layout.onSprinkleClose = (name) => sprinkleManager.close(name);
+  layout.resolveSprinkleIcon = (spec) => resolveSprinkleIconHtml(spec, localFs);
   await sprinkleManager.restoreOpenSprinkles().catch((err) => {
     log.warn('Failed to restore open sprinkles', err);
   });

--- a/packages/webapp/tests/ui/sprinkle-manager.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-manager.test.ts
@@ -235,4 +235,30 @@ describe('SprinkleManager', () => {
 
     vfs.readFile = originalReadFile;
   });
+
+  it('open forwards the declared icon spec to the addSprinkle callback', async () => {
+    // Custom icon contract: a sprinkle declaring <link rel="icon">
+    // must surface the raw spec in the addSprinkle options so the
+    // layout can resolve it (Lucide / VFS path / inline SVG / data URL)
+    // and swap the rail glyph. Regression guard: if the manager stops
+    // forwarding `icon`, every per-sprinkle rail glyph reverts to the
+    // generic Sparkles default and the breakage is silent.
+    await vfs.writeFile(
+      '/shared/sprinkles/iconic/iconic.shtml',
+      '<title>Iconic</title><link rel="icon" href="music" /><div>hi</div>'
+    );
+    await mgr.refresh();
+    await mgr.open('iconic');
+
+    expect(addSprinkle).toHaveBeenCalledTimes(1);
+    const [name, , , , options] = addSprinkle.mock.calls[0] as [
+      string,
+      string,
+      unknown,
+      unknown,
+      { icon?: string } | undefined,
+    ];
+    expect(name).toBe('iconic');
+    expect(options?.icon).toBe('music');
+  });
 });


### PR DESCRIPTION
## Summary

- `mainStandaloneWorker` never wired `layout.resolveSprinkleIcon`, so sprinkles declaring `<link rel="icon">` or `data-sprinkle-icon` silently fell back to the default Sparkles glyph in CLI/Electron. The assignment was lost when [`07cdce16`](https://github.com/ai-ecoverse/slicc/commit/07cdce16) removed the legacy inline-orchestrator path; the kernel-worker bootstrap that replaced it never re-added it.
- Extension mode is unaffected — `mainExtension` still wires the resolver at `main.ts:1320`.
- The `Sprinkle.icon` field was already flowing correctly through `SprinkleManager.open()` → `addSprinkle({ ..., icon })` and across the BroadcastChannel bridge. Only the page-side resolver hook was missing, so the conditional `if (options?.icon && this.resolveSprinkleIcon)` in `Layout.addSprinkle` silently skipped icon resolution.
- Adds a regression test pinning the `SprinkleManager → addSprinkle` icon contract so future refactors of the manager can't break per-sprinkle rail icons silently.

## Test plan

- [x] `npx vitest run packages/webapp/tests/ui/sprinkle-manager.test.ts` — 13/13 pass (1 new)
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx prettier --check` on edited files — clean
- [x] Live verification on a built standalone instance: a sprinkle with `<link rel="icon" href="music">` resolves the Lucide `music` glyph in the rail instead of the default Sparkles fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)