### PR TITLE
fix(standalone): resolve trayWorkerBaseUrl from /api/runtime-config at boot

### DIFF
--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1438,6 +1438,29 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
   const { VirtualFS } = await import('../fs/index.js');
   const { BrowserAPI } = await import('../cdp/index.js');
 
+  // Resolve the tray worker base URL from /api/runtime-config so consumers
+  // like oauth-code-exchange's `getWorkerBaseUrl` read a value that matches
+  // the float the user actually launched (staging under `--dev`, production
+  // otherwise). Without this, a stale localStorage value from an older
+  // session keeps surfacing — the prior inline standalone path did this
+  // before it was removed in 07cdce16.
+  const runtimeConfig = await fetchRuntimeConfig();
+  const runtimeDefaultWorkerBaseUrl = shouldUseRuntimeModeTrayDefaults(
+    isElectronOverlay ? 'electron-overlay' : 'standalone',
+    runtimeConfig !== null
+  )
+    ? __DEV__
+      ? DEFAULT_STAGING_TRAY_WORKER_BASE_URL
+      : DEFAULT_PRODUCTION_TRAY_WORKER_BASE_URL
+    : null;
+  await resolveTrayRuntimeConfig({
+    locationHref: window.location.href,
+    storage: window.localStorage,
+    envBaseUrl: import.meta.env.VITE_WORKER_BASE_URL ?? null,
+    defaultWorkerBaseUrl: runtimeDefaultWorkerBaseUrl,
+    runtimeConfigFetcher: async () => runtimeConfig,
+  });
+
   const layout = new Layout(app, isElectronOverlay);
   if (isElectronOverlay) {
     // Electron-overlay specifics: hide the tab-bar (Electron's chrome


### PR DESCRIPTION
## Summary

- `mainStandaloneWorker` now calls `resolveTrayRuntimeConfig` at boot, restoring behavior lost in 07cdce16 when the inline standalone path was removed.
- Without this, `slicc.trayWorkerBaseUrl` in `localStorage` is whatever was last persisted by an older session — typically `https://www.sliccy.ai` — so `npm run dev` (which passes `--dev` and has the node-server's `/api/runtime-config` reporting the staging URL) silently keeps targeting prod through consumers like `oauth-code-exchange.ts`'s `getWorkerBaseUrl`.
- `resolveTrayRuntimeConfig` priority-orders `serverBaseUrl > storedBaseUrl > envBaseUrl > default` (`packages/webapp/src/scoops/tray-runtime-config.ts:188`), so the dev server's response overwrites the stale entry on next boot.

## Test plan

- [x] `tsc --noEmit -p tsconfig.json` clean
- [x] `prettier --write packages/webapp/src/ui/main.ts` (no changes)
- [x] `vitest packages/webapp/tests/scoops/tray-runtime-config.test.ts` — 21/21 pass
- [ ] Manual: clear `slicc.trayWorkerBaseUrl` in localStorage, run `npm run dev`, confirm value is rewritten to `https://slicc-tray-hub-staging.minivelos.workers.dev`
- [ ] Manual: `npm run dev` against an existing profile with a stale prod value — confirm it gets overwritten to staging

## Out of scope

- The follower-sync / `slicc:tray-join` wiring also deleted in 07cdce16 (Settings dialog's "Join tray" is a silent no-op in standalone). Separable issue, may belong in the kernel-worker layer rather than the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)