### PR TITLE
fix(swift-server): drop redundant reload() at startup to fix 2.43.0 crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,6 +515,12 @@ jobs:
           if-no-files-found: ignore
       - name: Build
         run: npm run build -w @slicc/swift-launcher
+      - name: Upload Sliccstart.app artifact (unsigned, for PR verification)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: Sliccstart-${{ github.event.pull_request.number || github.run_id }}-unsigned
+          path: packages/swift-launcher/build/Sliccstart.app
+          if-no-files-found: error
       - name: Install Periphery
         run: brew install peripheryapp/periphery/periphery
       - name: Dead code detection (Periphery)

--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -126,9 +126,14 @@ struct ServerCommand: AsyncParsableCommand {
             envFileSecrets: envFileSecrets,
             oauthStore: oauthStore
         )
-        // Pick up any OAuth replicas that may exist (none at startup, but
-        // future tests / re-entry paths might pre-populate the store).
-        await secretInjector.reload()
+        // Do NOT call `await secretInjector.reload()` here: at startup the
+        // OAuth store is empty, so reload() is a state no-op — but the
+        // redundant Keychain re-read + async actor hop + second
+        // setSecretsAndScrubber cycle on a just-init'd injector has been
+        // observed to corrupt the libsystem_malloc nano zone, crashing the
+        // process shortly after Hummingbird binds with "freed pointer was
+        // not the last allocation". reload() is fine to call once OAuth
+        // replicas actually arrive (see /api/secrets/oauth-update).
 
         if config.electron, !config.serveOnly {
             guard let electronApp = config.electronApp else {


### PR DESCRIPTION
## Summary

- **Hotfix for 2.43.0 crash on Sliccstart users.** The release immediately aborts shortly after Hummingbird binds 127.0.0.1:5710, with `freed pointer was not the last allocation`. Removes `await secretInjector.reload()` from `ServerCommand.run()` — a state no-op (the just-created `OAuthSecretStore` is empty at startup) — that triggers the abort.
- **Diagnosis (lldb against the published Sliccstart-6.app):** the crash is NOT a libsystem_malloc nano-zone error; it's `libswift_Concurrency.dylib`swift_task_dealloc + 128` failing the task-allocator's LIFO invariant. The aborting thread's stack:
  ```
  frame #2: libsystem_c`abort + 180
  frame #5: libswift_Concurrency`swift_task_dealloc + 128
  frame #6: AsyncHTTPClient.HTTPClient.executeCancellable  (suspend resume #4)
  ...
  frame #23: slicc_server.CDPProxy.defaultDiscoverCDPURL(port:)
  frame #29: slicc_server.ServerCommand.run()
  ```
  Inside `ServerCommand.run()`'s single async task, `await secretInjector.reload()` is the only new await between task start and AsyncHTTPClient's first HTTP call (the CDP URL discover). Removing it eliminates the leftover task-local allocation that broke LIFO order on AsyncHTTPClient's 4th await-resume.
- **CI:** adds an upload-artifact step to the existing swift-launcher job so the assembled (unsigned) `Sliccstart.app` is downloadable from any PR run — lets us avoid burning another bad release on production users.

## Test plan

- [ ] Wait for CI swift-launcher job to upload `Sliccstart-<run_id>-unsigned` artifact
- [ ] Download the .app, `xattr -dr com.apple.quarantine Sliccstart.app`, right-click → Open
- [ ] Confirm slicc-server stays alive past bind (>10s) — no `freed pointer...` abort
- [ ] Confirm Chrome launches and webapp loads
- [ ] Confirm GitHub OAuth + a push to /workspace/test still works (the secrets pipeline that 2.43.0 added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)