### PR TITLE
chore: build @slicc/shared-ts on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "package:release": "node dist/node-server/release-package.js",
     "publish:chrome": "node dist/node-server/publish-chrome-web-store.js",
     "publish:worker": "echo \"$CLOUDFLARE_TURN_API_TOKEN\" | npx wrangler secret put CLOUDFLARE_TURN_API_TOKEN --config packages/cloudflare-worker/wrangler.jsonc && echo \"$GITHUB_CLIENT_SECRET\" | npx wrangler secret put GITHUB_CLIENT_SECRET --config packages/cloudflare-worker/wrangler.jsonc && npx wrangler deploy --config packages/cloudflare-worker/wrangler.jsonc && MAX_ATTEMPTS=6; for attempt in $(seq 1 \"$MAX_ATTEMPTS\"); do if npx vitest run --project cloudflare-worker packages/cloudflare-worker/tests/deployed.test.ts; then exit 0; fi; if [ \"$attempt\" -eq \"$MAX_ATTEMPTS\" ]; then echo \"Deployed smoke test failed after $MAX_ATTEMPTS attempts\"; exit 1; fi; echo \"Deployed smoke test failed on attempt $attempt; waiting for edge propagation before retrying...\"; sleep 15; done",
+    "postinstall": "npm run build -w @slicc/shared-ts",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- `@slicc/shared-ts` is a workspace dep that `node-server` imports through its compiled `dist/index.js`. `npm i` symlinks the package but does not build it, so on a fresh clone `npm run dev` immediately fails with `ERR_MODULE_NOT_FOUND` for `shared-ts/dist/index.js`.
- Add a root `postinstall` script that builds `@slicc/shared-ts`, so `npm i && npm run dev` works out of the box.

## Test plan
- [x] Delete `packages/shared-ts/dist/`, run `npm i`, verify `dist/index.js` is rebuilt.
- [x] Run `npm run dev` and confirm the server boots and serves the UI on http://localhost:5710.