### PR TITLE
fix(onboarding): flush credentials to worker before final welcome lick

### DIFF
--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -46,6 +46,7 @@ import { createAttachmentTmpWriter } from './attachment-vfs.js';
 // IMPORTANT: This import must also appear in packages/chrome-extension/src/offscreen.ts
 // — the extension agent engine runs in the offscreen document, not in this file.
 import { registerProviders } from '../providers/index.js';
+import { flushCredentialsToWorker, resolveDefaultModel } from './onboarding-helpers.js';
 import { BrowserAPI, NavigationWatcher } from '../cdp/index.js';
 import { type Orchestrator } from '../scoops/index.js';
 import { publishAgentBridge } from '../scoops/agent-bridge.js';
@@ -953,22 +954,7 @@ async function mainExtension(app: HTMLElement): Promise<void> {
       },
       broadcastToDip: (payload) => broadcastToDipsExt(payload),
       fireFinalLick: (data) => {
-        // Flush provider credentials to the worker before the lick.
-        const accountsVal = localStorage.getItem('slicc_accounts');
-        const modelVal = localStorage.getItem('selected-model');
-        if (accountsVal)
-          client.sendRaw({
-            type: 'local-storage-set',
-            key: 'slicc_accounts',
-            value: accountsVal,
-          } as any);
-        if (modelVal)
-          client.sendRaw({
-            type: 'local-storage-set',
-            key: 'selected-model',
-            value: modelVal,
-          } as any);
-
+        flushCredentialsToWorker(client);
         const action = String((data as { action?: unknown })?.action ?? '');
         dispatchWelcomeLickOnce(
           action,
@@ -987,14 +973,15 @@ async function mainExtension(app: HTMLElement): Promise<void> {
           const { createOAuthLauncher } = await import('../providers/oauth-service.js');
           const launcher = createOAuthLauncher();
           await cfg.onOAuthLogin(launcher, () => undefined);
-          const models = getProviderModelsExt(providerId).filter(
-            (m) => !isModelHiddenFromPickerExt(m.id)
-          );
-          const preferred = cfg.defaultModelId
-            ? models.find((m) => m.id.toLowerCase().includes(cfg.defaultModelId!.toLowerCase()))
-            : undefined;
-          const model = preferred ?? models[0];
-          return { ok: true, model: model ? `${providerId}:${model.id}` : undefined };
+          return {
+            ok: true,
+            model: resolveDefaultModel(
+              providerId,
+              cfg,
+              getProviderModelsExt,
+              isModelHiddenFromPickerExt
+            ),
+          };
         } catch (err) {
           return {
             ok: false,
@@ -1778,25 +1765,7 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
       },
       broadcastToDip: (payload) => broadcastToDips(payload),
       fireFinalLick: (data) => {
-        // Flush provider credentials to the worker before the lick.
-        // page-storage-sync may not have forwarded yet (e.g. if the
-        // OAuth callback ran before the sync was installed, or if
-        // setItem was called on an unpatched reference).
-        const accountsVal = localStorage.getItem('slicc_accounts');
-        const modelVal = localStorage.getItem('selected-model');
-        if (accountsVal)
-          client.sendRaw({
-            type: 'local-storage-set',
-            key: 'slicc_accounts',
-            value: accountsVal,
-          } as any);
-        if (modelVal)
-          client.sendRaw({
-            type: 'local-storage-set',
-            key: 'selected-model',
-            value: modelVal,
-          } as any);
-
+        flushCredentialsToWorker(client);
         const action = String((data as { action?: unknown })?.action ?? '');
         dispatchWelcomeLickOnce(
           action,
@@ -1815,14 +1784,10 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
           const { createOAuthLauncher } = await import('../providers/oauth-service.js');
           const launcher = createOAuthLauncher();
           await cfg.onOAuthLogin(launcher, () => undefined);
-          const models = getProviderModels(providerId).filter(
-            (m) => !isModelHiddenFromPicker(m.id)
-          );
-          const preferred = cfg.defaultModelId
-            ? models.find((m) => m.id.toLowerCase().includes(cfg.defaultModelId!.toLowerCase()))
-            : undefined;
-          const model = preferred ?? models[0];
-          return { ok: true, model: model ? `${providerId}:${model.id}` : undefined };
+          return {
+            ok: true,
+            model: resolveDefaultModel(providerId, cfg, getProviderModels, isModelHiddenFromPicker),
+          };
         } catch (err) {
           return {
             ok: false,

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -953,11 +953,22 @@ async function mainExtension(app: HTMLElement): Promise<void> {
       },
       broadcastToDip: (payload) => broadcastToDipsExt(payload),
       fireFinalLick: (data) => {
-        // Forward the synthetic completion event through the same
-        // relay any other sprinkle lick would use, so the offscreen
-        // cone receives it as a regular `[Sprinkle Event: welcome]`.
-        // Dedup-gated so a stray re-fire (HMR, double-mount) can't
-        // double the cone's greeting.
+        // Flush provider credentials to the worker before the lick.
+        const accountsVal = localStorage.getItem('slicc_accounts');
+        const modelVal = localStorage.getItem('selected-model');
+        if (accountsVal)
+          client.sendRaw({
+            type: 'local-storage-set',
+            key: 'slicc_accounts',
+            value: accountsVal,
+          } as any);
+        if (modelVal)
+          client.sendRaw({
+            type: 'local-storage-set',
+            key: 'selected-model',
+            value: modelVal,
+          } as any);
+
         const action = String((data as { action?: unknown })?.action ?? '');
         dispatchWelcomeLickOnce(
           action,
@@ -976,7 +987,14 @@ async function mainExtension(app: HTMLElement): Promise<void> {
           const { createOAuthLauncher } = await import('../providers/oauth-service.js');
           const launcher = createOAuthLauncher();
           await cfg.onOAuthLogin(launcher, () => undefined);
-          return { ok: true };
+          const models = getProviderModelsExt(providerId).filter(
+            (m) => !isModelHiddenFromPickerExt(m.id)
+          );
+          const preferred = cfg.defaultModelId
+            ? models.find((m) => m.id.toLowerCase().includes(cfg.defaultModelId!.toLowerCase()))
+            : undefined;
+          const model = preferred ?? models[0];
+          return { ok: true, model: model ? `${providerId}:${model.id}` : undefined };
         } catch (err) {
           return {
             ok: false,
@@ -1760,9 +1778,25 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
       },
       broadcastToDip: (payload) => broadcastToDips(payload),
       fireFinalLick: (data) => {
-        // Forward through the same relay any sprinkle lick would use,
-        // gated by the persistent ledger so HMR / double-mount can't
-        // double the cone's greeting.
+        // Flush provider credentials to the worker before the lick.
+        // page-storage-sync may not have forwarded yet (e.g. if the
+        // OAuth callback ran before the sync was installed, or if
+        // setItem was called on an unpatched reference).
+        const accountsVal = localStorage.getItem('slicc_accounts');
+        const modelVal = localStorage.getItem('selected-model');
+        if (accountsVal)
+          client.sendRaw({
+            type: 'local-storage-set',
+            key: 'slicc_accounts',
+            value: accountsVal,
+          } as any);
+        if (modelVal)
+          client.sendRaw({
+            type: 'local-storage-set',
+            key: 'selected-model',
+            value: modelVal,
+          } as any);
+
         const action = String((data as { action?: unknown })?.action ?? '');
         dispatchWelcomeLickOnce(
           action,
@@ -1781,7 +1815,14 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
           const { createOAuthLauncher } = await import('../providers/oauth-service.js');
           const launcher = createOAuthLauncher();
           await cfg.onOAuthLogin(launcher, () => undefined);
-          return { ok: true };
+          const models = getProviderModels(providerId).filter(
+            (m) => !isModelHiddenFromPicker(m.id)
+          );
+          const preferred = cfg.defaultModelId
+            ? models.find((m) => m.id.toLowerCase().includes(cfg.defaultModelId!.toLowerCase()))
+            : undefined;
+          const model = preferred ?? models[0];
+          return { ok: true, model: model ? `${providerId}:${model.id}` : undefined };
         } catch (err) {
           return {
             ok: false,

--- a/packages/webapp/src/ui/onboarding-helpers.ts
+++ b/packages/webapp/src/ui/onboarding-helpers.ts
@@ -1,0 +1,51 @@
+import type { LocalStorageSetMsg } from '../../../chrome-extension/src/messages.js';
+import type { ProviderConfig } from '../providers/index.js';
+
+/**
+ * Flush the two localStorage keys the kernel worker reads at lick time
+ * (`slicc_accounts` and `selected-model`) directly over the transport.
+ *
+ * These are the only keys getSelectedProvider() / prompt() reads on the
+ * worker side when the onboarding-complete-with-provider lick arrives,
+ * so flushing just these two is sufficient.
+ *
+ * Why this is needed: the OAuth flow opens a popup window. That popup has
+ * its own window.localStorage that installPageStorageSync never patched
+ * (the patch only covers the opener's window). The saveAccounts() write
+ * therefore never reaches the worker's shim via the normal sync path.
+ * Explicitly flushing here, on the same OffscreenClient channel as the
+ * lick, guarantees ordering — the postMessage queue preserves FIFO.
+ */
+export function flushCredentialsToWorker(client: {
+  sendRaw: (m: LocalStorageSetMsg) => void;
+}): void {
+  for (const key of ['slicc_accounts', 'selected-model'] as const) {
+    const value = localStorage.getItem(key);
+    if (value != null) client.sendRaw({ type: 'local-storage-set', key, value });
+  }
+}
+
+/**
+ * Pick the best model id to activate after OAuth completes.
+ *
+ * Resolution order:
+ *   1. Exact match on cfg.defaultModelId
+ *   2. Substring match on cfg.defaultModelId (handles partial prefixes like "sonnet")
+ *   3. First visible model in the catalogue
+ *
+ * Returns `undefined` when the catalogue has no visible models for the provider.
+ */
+export function resolveDefaultModel(
+  providerId: string,
+  cfg: ProviderConfig,
+  getModels: (id: string) => Array<{ id: string }>,
+  isHidden: (modelId: string) => boolean
+): string | undefined {
+  const visible = getModels(providerId).filter((m) => !isHidden(m.id));
+  const exact = cfg.defaultModelId ? visible.find((m) => m.id === cfg.defaultModelId) : undefined;
+  const fuzzy = cfg.defaultModelId
+    ? visible.find((m) => m.id.toLowerCase().includes(cfg.defaultModelId!.toLowerCase()))
+    : undefined;
+  const model = exact ?? fuzzy ?? visible[0];
+  return model ? `${providerId}:${model.id}` : undefined;
+}

--- a/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
@@ -419,4 +419,160 @@ describe('OnboardingOrchestrator', () => {
       expect(reject.ok).toBe(false);
     });
   });
+
+  describe('handleOAuthAttempt', () => {
+    it('sets the model and fires the final lick on successful OAuth with a model', async () => {
+      const fs = new VirtualFS('oauth-ok-' + Math.random());
+      const selectedModels: string[] = [];
+      const finalLicks: FinalLickPayload[] = [];
+      const dipInbox: DipMessage[] = [];
+      const launchOAuth = vi.fn(async () => ({ ok: true, model: 'adobe:claude-sonnet-4-6' }));
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: () => {},
+        setSelectedModel: (id) => selectedModels.push(id),
+        resolveModelLabel: (_p, m) => m.toUpperCase(),
+        broadcastToDip: (msg) => dipInbox.push(msg),
+        fireFinalLick: (data) => finalLicks.push(data),
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        launchOAuth,
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleOAuthAttempt({ provider: 'adobe' });
+      expect(launchOAuth).toHaveBeenCalledWith('adobe', null);
+      expect(selectedModels).toEqual(['adobe:claude-sonnet-4-6']);
+      expect(finalLicks).toHaveLength(1);
+      expect(finalLicks[0].action).toBe('onboarding-complete-with-provider');
+      expect(finalLicks[0].data.provider).toBe('adobe');
+      expect(finalLicks[0].data.model).toBe('adobe:claude-sonnet-4-6');
+      expect(finalLicks[0].data.validation).toBe('oauth');
+      expect(orch.getStage()).toBe('complete');
+    });
+
+    it('fires the final lick but does not call setSelectedModel when OAuth returns no model', async () => {
+      const fs = new VirtualFS('oauth-nomodel-' + Math.random());
+      const selectedModels: string[] = [];
+      const finalLicks: FinalLickPayload[] = [];
+      const dipInbox: DipMessage[] = [];
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: () => {},
+        setSelectedModel: (id) => selectedModels.push(id),
+        broadcastToDip: (msg) => dipInbox.push(msg),
+        fireFinalLick: (data) => finalLicks.push(data),
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        launchOAuth: async () => ({ ok: true, model: null }),
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleOAuthAttempt({ provider: 'adobe' });
+      expect(selectedModels).toEqual([]);
+      expect(finalLicks).toHaveLength(1);
+      expect(finalLicks[0].data.model).toBeNull();
+      const okMsg = dipInbox.find((m) => m.type === 'slicc-connect-result' && m.ok);
+      expect(okMsg).toBeTruthy();
+    });
+
+    it('broadcasts an error and keeps stage at awaiting-connect when OAuth fails', async () => {
+      const fs = new VirtualFS('oauth-fail-' + Math.random());
+      const finalLicks: FinalLickPayload[] = [];
+      const dipInbox: DipMessage[] = [];
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: () => {},
+        setSelectedModel: () => {},
+        broadcastToDip: (msg) => dipInbox.push(msg),
+        fireFinalLick: (data) => finalLicks.push(data),
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        launchOAuth: async () => ({ ok: false, message: 'Login cancelled.' }),
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleOAuthAttempt({ provider: 'adobe' });
+      expect(finalLicks).toEqual([]);
+      const reject = dipInbox.find((m) => m.type === 'slicc-connect-result');
+      expect(reject.ok).toBe(false);
+      expect(reject.kind).toBe('failed');
+      expect(orch.getStage()).toBe('awaiting-connect');
+    });
+
+    it('broadcasts an error and keeps stage at awaiting-connect when launchOAuth throws', async () => {
+      const fs = new VirtualFS('oauth-throw-' + Math.random());
+      const finalLicks: FinalLickPayload[] = [];
+      const dipInbox: DipMessage[] = [];
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: () => {},
+        setSelectedModel: () => {},
+        broadcastToDip: (msg) => dipInbox.push(msg),
+        fireFinalLick: (data) => finalLicks.push(data),
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        launchOAuth: async () => {
+          throw new Error('popup closed');
+        },
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleOAuthAttempt({ provider: 'adobe' });
+      expect(finalLicks).toEqual([]);
+      const reject = dipInbox.find((m) => m.type === 'slicc-connect-result');
+      expect(reject.ok).toBe(false);
+      expect(reject.message).toContain('popup closed');
+      expect(orch.getStage()).toBe('awaiting-connect');
+    });
+
+    it('is a no-op when launchOAuth is not provided by the runtime', async () => {
+      const fs = new VirtualFS('oauth-noop-' + Math.random());
+      const finalLicks: FinalLickPayload[] = [];
+      const dipInbox: DipMessage[] = [];
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: () => {},
+        setSelectedModel: () => {},
+        broadcastToDip: (msg) => dipInbox.push(msg),
+        fireFinalLick: (data) => finalLicks.push(data),
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        // launchOAuth intentionally omitted
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleOAuthAttempt({ provider: 'adobe' });
+      expect(finalLicks).toEqual([]);
+      const reject = dipInbox.find((m) => m.type === 'slicc-connect-result');
+      expect(reject.ok).toBe(false);
+      expect(reject.message).toContain('not available');
+    });
+
+    it('ignores OAuth attempt when stage is already complete', async () => {
+      const h = makeHarness();
+      await h.orchestrator.handleOnboardingComplete({});
+      await h.orchestrator.handleConnectAttempt({
+        provider: 'openai',
+        apiKey: 'sk-good',
+        model: 'gpt-4o',
+      });
+      expect(h.orchestrator.getStage()).toBe('complete');
+      h.finalLicks.length = 0;
+      h.dipInbox.length = 0;
+      await h.orchestrator.handleOAuthAttempt({ provider: 'adobe' });
+      expect(h.finalLicks).toEqual([]);
+      expect(h.dipInbox).toEqual([]);
+    });
+  });
 });

--- a/packages/webapp/tests/ui/onboarding-helpers.test.ts
+++ b/packages/webapp/tests/ui/onboarding-helpers.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { flushCredentialsToWorker, resolveDefaultModel } from '../../src/ui/onboarding-helpers.js';
+import type { ProviderConfig } from '../../src/providers/index.js';
+
+// ---------------------------------------------------------------------------
+// flushCredentialsToWorker
+// ---------------------------------------------------------------------------
+
+function withLocalStorage(store: Record<string, string>, fn: () => void): void {
+  const mock = { getItem: (key: string) => store[key] ?? null };
+  (globalThis as Record<string, unknown>).localStorage = mock;
+  try {
+    fn();
+  } finally {
+    delete (globalThis as Record<string, unknown>).localStorage;
+  }
+}
+
+describe('flushCredentialsToWorker', () => {
+  it('sends both keys when both are present in localStorage', () => {
+    withLocalStorage(
+      { slicc_accounts: '{"accounts":[]}', 'selected-model': 'anthropic:claude-sonnet-4-6' },
+      () => {
+        const sent: unknown[] = [];
+        flushCredentialsToWorker({ sendRaw: (m) => sent.push(m) });
+        expect(sent).toEqual([
+          { type: 'local-storage-set', key: 'slicc_accounts', value: '{"accounts":[]}' },
+          {
+            type: 'local-storage-set',
+            key: 'selected-model',
+            value: 'anthropic:claude-sonnet-4-6',
+          },
+        ]);
+      }
+    );
+  });
+
+  it('skips a key that is null in localStorage', () => {
+    withLocalStorage({ slicc_accounts: '{"accounts":[]}' }, () => {
+      const sent: unknown[] = [];
+      flushCredentialsToWorker({ sendRaw: (m) => sent.push(m) });
+      expect(sent).toHaveLength(1);
+      expect((sent[0] as { key: string }).key).toBe('slicc_accounts');
+    });
+  });
+
+  it('sends nothing when both keys are absent', () => {
+    withLocalStorage({}, () => {
+      const sent: unknown[] = [];
+      flushCredentialsToWorker({ sendRaw: (m) => sent.push(m) });
+      expect(sent).toHaveLength(0);
+    });
+  });
+
+  it('uses the exact LocalStorageSetMsg envelope shape', () => {
+    withLocalStorage({ 'selected-model': 'adobe:claude-sonnet-4-6' }, () => {
+      const sent: unknown[] = [];
+      flushCredentialsToWorker({ sendRaw: (m) => sent.push(m) });
+      expect(sent[0]).toStrictEqual({
+        type: 'local-storage-set',
+        key: 'selected-model',
+        value: 'adobe:claude-sonnet-4-6',
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDefaultModel
+// ---------------------------------------------------------------------------
+
+const makeModels = (ids: string[]) => ids.map((id) => ({ id }));
+const noHidden = () => false;
+const getModels = (id: string) => {
+  const catalogue: Record<string, Array<{ id: string }>> = {
+    adobe: makeModels(['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5']),
+    empty: [],
+  };
+  return catalogue[id] ?? [];
+};
+
+const baseCfg: ProviderConfig = {
+  id: 'adobe',
+  name: 'Adobe',
+  isOAuth: true,
+};
+
+describe('resolveDefaultModel', () => {
+  it('returns exact match when defaultModelId is set and matches exactly', () => {
+    const cfg: ProviderConfig = { ...baseCfg, defaultModelId: 'claude-sonnet-4-6' };
+    expect(resolveDefaultModel('adobe', cfg, getModels, noHidden)).toBe('adobe:claude-sonnet-4-6');
+  });
+
+  it('prefers exact match over fuzzy when both would match', () => {
+    // 'sonnet' is a substring of 'claude-sonnet-4-6', but 'claude-sonnet-4-6' is an exact match
+    const cfg: ProviderConfig = { ...baseCfg, defaultModelId: 'claude-sonnet-4-6' };
+    expect(resolveDefaultModel('adobe', cfg, getModels, noHidden)).toBe('adobe:claude-sonnet-4-6');
+  });
+
+  it('falls back to fuzzy substring match when there is no exact match', () => {
+    const cfg: ProviderConfig = { ...baseCfg, defaultModelId: 'sonnet' };
+    expect(resolveDefaultModel('adobe', cfg, getModels, noHidden)).toBe('adobe:claude-sonnet-4-6');
+  });
+
+  it('falls back to first visible model when defaultModelId is absent', () => {
+    const cfg: ProviderConfig = { ...baseCfg };
+    expect(resolveDefaultModel('adobe', cfg, getModels, noHidden)).toBe('adobe:claude-opus-4-7');
+  });
+
+  it('skips hidden models and still resolves the first visible one', () => {
+    const cfg: ProviderConfig = { ...baseCfg };
+    const isHidden = (id: string) => id === 'claude-opus-4-7';
+    expect(resolveDefaultModel('adobe', cfg, getModels, isHidden)).toBe('adobe:claude-sonnet-4-6');
+  });
+
+  it('returns undefined when the catalogue has no visible models', () => {
+    const cfg: ProviderConfig = { ...baseCfg };
+    expect(resolveDefaultModel('empty', cfg, getModels, noHidden)).toBeUndefined();
+  });
+
+  it('returns undefined when all models are hidden', () => {
+    const cfg: ProviderConfig = { ...baseCfg };
+    expect(resolveDefaultModel('adobe', cfg, getModels, () => true)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
After Adobe OAuth, saveOAuthAccount writes to the page's localStorage but page-storage-sync was not reliably forwarding these writes to the kernel worker's shim. When the onboarding-complete-with-provider lick reached the cone, the worker still had no accounts/model, causing getSelectedProvider() to fall back to 'anthropic' with no API key.

Before:
Was always showing this error message about no API key for Anthrophic
<img width="936" height="769" alt="image" src="https://github.com/user-attachments/assets/7f742852-9a32-407c-b74a-858d33863a3b" />

After:
No error message and it actually upskills based on what I chose from the Welcome Page
<img width="1753" height="1125" alt="Screenshot 2026-05-12 at 11 49 39" src="https://github.com/user-attachments/assets/83fba094-a39c-4c0b-87f8-b48e9ad7fb2b" />

Two fixes:
- launchOAuth now resolves and returns the provider's default model after OAuth so the orchestrator calls setSelectedModel correctly
- fireFinalLick explicitly flushes slicc_accounts and selected-model to the worker via sendRaw before dispatching the sprinkle lick, guaranteeing the cone has credentials when prompt() runs

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `WasmShell`, offscreen
  `WasmShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [x] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [x] `npm run typecheck`
- [x] `npm run test` — `<N>` passing, no new failures
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [x] Manual smoke (CLI): `npm run dev` + …
- [x] Manual smoke (extension): load unpacked `dist/extension/` + …

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [x] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
