### PR TITLE
fix(ui): place left-anchored tooltips on the correct side

### DIFF
--- a/packages/webapp/src/ui/tooltip.ts
+++ b/packages/webapp/src/ui/tooltip.ts
@@ -3,8 +3,9 @@
  * Uses a single fixed-position element appended to <body>,
  * so tooltips are never clipped by overflow:hidden ancestors.
  *
- * Placement auto-detects: prefers below, flips above if near bottom,
- * shifts horizontally to stay within viewport.
+ * Placement honors `data-tooltip-pos` ('top' | 'bottom' | 'left' | 'right',
+ * default 'bottom'), flips to the opposite side when the preferred side is
+ * clipped, then clamps to the viewport on both axes.
  */
 
 const DELAY = 100; // ms before showing
@@ -58,23 +59,35 @@ function show(target: HTMLElement): void {
   } else if (pos === 'right') {
     top = rect.top + rect.height / 2 - tipRect.height / 2;
     left = rect.right + GAP;
+  } else if (pos === 'left') {
+    top = rect.top + rect.height / 2 - tipRect.height / 2;
+    left = rect.left - tipRect.width - GAP;
   } else {
     // bottom (default)
     top = rect.bottom + GAP;
     left = rect.left + rect.width / 2 - tipRect.width / 2;
   }
 
-  // Auto-flip vertical if clipped
+  // Auto-flip to the opposite side when the preferred side is clipped.
   if (pos === 'bottom' && top + tipRect.height > window.innerHeight - 4) {
     top = rect.top - tipRect.height - GAP;
   } else if (pos === 'top' && top < 4) {
     top = rect.bottom + GAP;
+  } else if (pos === 'left' && left < 4) {
+    left = rect.right + GAP;
+  } else if (pos === 'right' && left + tipRect.width > window.innerWidth - 4) {
+    left = rect.left - tipRect.width - GAP;
   }
 
-  // Clamp horizontal to viewport
+  // Clamp to the viewport on both axes (covers diagonal overflow and the
+  // along-axis spread of left/right placements near a corner).
   if (left < 4) left = 4;
   if (left + tipRect.width > window.innerWidth - 4) {
     left = window.innerWidth - tipRect.width - 4;
+  }
+  if (top < 4) top = 4;
+  if (top + tipRect.height > window.innerHeight - 4) {
+    top = window.innerHeight - tipRect.height - 4;
   }
 
   tip.style.top = `${top}px`;

--- a/packages/webapp/tests/ui/tooltip.test.ts
+++ b/packages/webapp/tests/ui/tooltip.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { initTooltips } from '../../src/ui/tooltip.js';
+
+// The tooltip is laid out as `font-size: 11px` text with `4px 8px` padding;
+// pick stable dimensions so the placement math is deterministic in jsdom
+// (which never computes layout — getBoundingClientRect returns zeros).
+const TIP_WIDTH = 64;
+const TIP_HEIGHT = 22;
+
+function makeRect(r: Partial<DOMRect>): DOMRect {
+  const merged = {
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    width: 0,
+    height: 0,
+    ...r,
+  };
+  return { ...merged, toJSON: () => merged } as DOMRect;
+}
+
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+beforeAll(() => {
+  // jsdom doesn't lay out elements, so stub getBoundingClientRect: the
+  // singleton tooltip element reports a fixed size, and every other element
+  // reports whatever rect the test pinned on it via `__rect`.
+  Element.prototype.getBoundingClientRect = function (this: Element): DOMRect {
+    if (this instanceof HTMLElement && this.classList.contains('s2-tooltip')) {
+      return makeRect({
+        width: TIP_WIDTH,
+        height: TIP_HEIGHT,
+        right: TIP_WIDTH,
+        bottom: TIP_HEIGHT,
+      });
+    }
+    const pinned = (this as unknown as { __rect?: DOMRect }).__rect;
+    return pinned ?? makeRect({});
+  };
+  initTooltips();
+});
+
+afterAll(() => {
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const trigger of Array.from(document.querySelectorAll('[data-tooltip]'))) {
+    trigger.remove();
+  }
+});
+
+function makeTrigger(pos: string, rect: Partial<DOMRect>): HTMLElement {
+  const btn = document.createElement('button');
+  btn.dataset.tooltip = 'Memory';
+  btn.dataset.tooltipPos = pos;
+  document.body.appendChild(btn);
+  (btn as unknown as { __rect: DOMRect }).__rect = makeRect(rect);
+  return btn;
+}
+
+function hoverAndReadTooltip(trigger: HTMLElement): { top: number; left: number } {
+  vi.useFakeTimers();
+  trigger.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }));
+  vi.advanceTimersByTime(500); // past the show-delay
+  const tip = document.querySelector('.s2-tooltip') as HTMLElement;
+  return { top: parseFloat(tip.style.top), left: parseFloat(tip.style.left) };
+}
+
+describe('tooltip placement', () => {
+  it('keeps a left-positioned tooltip on screen for the bottom-most rail button', () => {
+    // The "Memory" button is the bottom icon of the right-side rail, so its
+    // tooltip sits near the bottom-right corner (jsdom viewport is 1024x768).
+    const trigger = makeTrigger('left', {
+      left: 984,
+      right: 1016,
+      top: 720,
+      bottom: 752,
+      width: 32,
+      height: 32,
+    });
+
+    const { top, left } = hoverAndReadTooltip(trigger);
+
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(top + TIP_HEIGHT).toBeLessThanOrEqual(window.innerHeight);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(left + TIP_WIDTH).toBeLessThanOrEqual(window.innerWidth);
+    // ...and it actually renders to the LEFT of the trigger, not over it.
+    expect(left + TIP_WIDTH).toBeLessThanOrEqual(984);
+  });
+
+  it('renders a left-positioned tooltip beside the trigger, vertically centered', () => {
+    const trigger = makeTrigger('left', {
+      left: 500,
+      right: 532,
+      top: 300,
+      bottom: 332,
+      width: 32,
+      height: 32,
+    });
+
+    const { top, left } = hoverAndReadTooltip(trigger);
+
+    // Trigger left edge (500) − gap (6) − tooltip width (64) = 430.
+    expect(left).toBe(430);
+    // Centered on the 32px-tall trigger: 300 + 16 − 11 = 305.
+    expect(top).toBe(305);
+  });
+
+  it('flips a left-positioned tooltip to the right when the left side would clip it', () => {
+    const trigger = makeTrigger('left', {
+      left: 8,
+      right: 40,
+      top: 300,
+      bottom: 332,
+      width: 32,
+      height: 32,
+    });
+
+    const { left } = hoverAndReadTooltip(trigger);
+
+    // No room on the left (8 − 6 − 64 < 0), so it flips to the trigger's right edge + gap.
+    expect(left).toBe(46);
+  });
+});


### PR DESCRIPTION
## Summary
The global tooltip engine handled `data-tooltip-pos` 'top', 'right' and the 'bottom' default but had no `left` case, so every rail button (which sets `data-tooltip-pos="left"`) fell through to the `bottom` branch and rendered its tooltip below the button. For the bottom-most rail icon ("Memory") that put the tooltip off the bottom edge of the viewport, and the vertical auto-flip never fired because the position wasn't 'bottom'.

Add the `left` branch (mirror of `right`), flip left/right tooltips to the opposite side when the preferred side is clipped, and clamp the final position to the viewport on both axes.

Adds tooltip placement tests.

Fixes #605

## Screenshots
Before:
<img width="1058" height="230" alt="image" src="https://github.com/user-attachments/assets/0573b5a4-e336-4244-848c-ab48080cdb87" />

After:
<img width="860" height="165" alt="image" src="https://github.com/user-attachments/assets/86d5e0a8-f482-4d7f-9353-df00cc14652f" />


## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [x] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [x] `npm run typecheck`
- [x] `npm run test` — `<N>` passing, no new failures
- [x] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [x] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
