### PR TITLE
fix(context-compaction): strip orphaned toolResult blocks after compaction cut

### DIFF
--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -39,23 +39,25 @@ function hasRole(message: AgentMessage, role: string): boolean {
 }
 
 /**
- * Drop any `toolResult` messages at the HEAD of `messages` whose `toolCallId`
- * has no matching `toolCall` block in the immediately preceding assistant message.
+ * Drop any `toolResult` messages at the HEAD of `messages`.
  *
- * This happens after compaction slices away the assistant turn that contained
- * the matching `tool_use` blocks. Bedrock (and Claude in strict mode) rejects
- * such orphaned `tool_result` blocks with a 400 error.
+ * A leading `toolResult` is orphaned by definition: there is no preceding
+ * assistant message that contains its `toolCallId`. This arises in two
+ * call sites:
  *
- * The function is intentionally conservative: it only removes leading orphans
- * so the invariant "every toolResult follows an assistant message that contains
- * its toolCallId" holds for the messages the LLM will see after the summary
- * message is prepended.
+ *  1. **Session restore** (`scoop-context.ts`): IndexedDB can persist a
+ *     corrupt session whose first message is a `toolResult` (e.g. a browser
+ *     crash mid-save, or sessions written before the walk-back guard was
+ *     introduced). Without stripping it, Bedrock rejects the next prompt
+ *     with "unexpected tool_use_id found in tool_result blocks".
+ *
+ *  2. **After compaction** (defense-in-depth): the walk-back guard in both
+ *     `createCompactContext` and `compactContext` already ensures
+ *     `slice(cutIndex)` does not start with a `toolResult`, so the strip
+ *     is normally a no-op here. It is kept as a safety net against future
+ *     changes to the cut algebra.
  */
 export function stripOrphanedToolResults(messages: AgentMessage[]): AgentMessage[] {
-  // Collect toolCallIds from the first assistant message (if any).
-  // After compaction the summary message is prepended as a user message,
-  // so there is no preceding assistant message — any leading toolResults
-  // are orphaned by definition.
   let i = 0;
   while (i < messages.length && hasRole(messages[i], 'toolResult')) {
     const tr = messages[i] as { role: string; toolCallId?: string };

--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -38,6 +38,35 @@ function hasRole(message: AgentMessage, role: string): boolean {
   return (message as { role: string }).role === role;
 }
 
+/**
+ * Drop any `toolResult` messages at the HEAD of `messages` whose `toolCallId`
+ * has no matching `toolCall` block in the immediately preceding assistant message.
+ *
+ * This happens after compaction slices away the assistant turn that contained
+ * the matching `tool_use` blocks. Bedrock (and Claude in strict mode) rejects
+ * such orphaned `tool_result` blocks with a 400 error.
+ *
+ * The function is intentionally conservative: it only removes leading orphans
+ * so the invariant "every toolResult follows an assistant message that contains
+ * its toolCallId" holds for the messages the LLM will see after the summary
+ * message is prepended.
+ */
+export function stripOrphanedToolResults(messages: AgentMessage[]): AgentMessage[] {
+  // Collect toolCallIds from the first assistant message (if any).
+  // After compaction the summary message is prepended as a user message,
+  // so there is no preceding assistant message — any leading toolResults
+  // are orphaned by definition.
+  let i = 0;
+  while (i < messages.length && hasRole(messages[i], 'toolResult')) {
+    const tr = messages[i] as { role: string; toolCallId?: string };
+    log.warn('Dropping orphaned toolResult (no preceding assistant message)', {
+      toolCallId: tr.toolCallId,
+    });
+    i++;
+  }
+  return i > 0 ? messages.slice(i) : messages;
+}
+
 export interface CompactionConfig {
   model: Model<Api>;
   getApiKey: () => string | undefined;
@@ -118,7 +147,7 @@ export function createCompactContext(
     }
 
     const messagesToSummarize = messages.slice(0, cutIndex);
-    const messagesToKeep = messages.slice(cutIndex);
+    const messagesToKeep = stripOrphanedToolResults(messages.slice(cutIndex));
 
     log.info('Compaction cut point', {
       summarizing: messagesToSummarize.length,
@@ -233,7 +262,8 @@ export async function compactContext(messages: AgentMessage[]): Promise<AgentMes
     timestamp: Date.now(),
   };
 
-  const result = [compactedMsg, ...messages.slice(cutIndex)];
+  const kept = stripOrphanedToolResults(messages.slice(cutIndex));
+  const result = [compactedMsg, ...kept];
 
   log.info('Context compacted (legacy)', {
     originalMessages: messages.length,

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -15,7 +15,7 @@ import type { VirtualFS } from '../fs/index.js';
 import type { RestrictedFS } from '../fs/restricted-fs.js';
 import { WasmShell } from '../shell/index.js';
 import { Agent, adaptTools, createLogger } from '../core/index.js';
-import { createCompactContext } from '../core/context-compaction.js';
+import { createCompactContext, stripOrphanedToolResults } from '../core/context-compaction.js';
 import type {
   AgentEvent as CoreAgentEvent,
   AgentMessage,
@@ -423,11 +423,12 @@ export class ScoopContext {
         try {
           const saved = await this.sessionStore.load(this.sessionId);
           if (saved) {
-            restoredMessages = saved.messages;
+            restoredMessages = stripOrphanedToolResults(saved.messages);
             this.sessionCreatedAt = saved.createdAt;
             log.info('Restored agent session', {
               folder: this.scoop.folder,
               messageCount: restoredMessages.length,
+              droppedOrphans: saved.messages.length - restoredMessages.length,
             });
           }
         } catch (err) {

--- a/packages/webapp/tests/core/context-compaction.test.ts
+++ b/packages/webapp/tests/core/context-compaction.test.ts
@@ -474,21 +474,20 @@ describe('createCompactContext', () => {
     expect(mockGenerateSummary).not.toHaveBeenCalled();
   });
 
-  it('strips orphaned toolResults left at the head after compaction cut', async () => {
-    // Scenario: assistant+toolResult pair lands at the cut boundary such that
-    // the assistant is summarized away but the toolResult is kept. The resulting
-    // array would start with an orphaned toolResult that Bedrock rejects.
+  it('walk-back guard keeps assistant+toolResult pair together across the cut', async () => {
+    // Verifies the walk-back guard (lines 137-141 in context-compaction.ts):
+    // when the naive cut would land on a toolResult, cutIndex is walked back
+    // to include the preceding assistant, so the kept slice never starts with
+    // an orphaned toolResult. Note: `stripOrphanedToolResults` is a no-op
+    // here — the guard is what makes this pass.
     const compact = createCompactContext({ ...mockConfig, getApiKey: () => undefined });
     const baseMsg = 'x'.repeat(65000);
-    // Craft history so the cut lands right after an assistant-with-tool-call turn,
-    // leaving the matching toolResult as the first kept message.
     const messages: AgentMessage[] = [
       createMessage('user', baseMsg),
       createMessage('assistant', baseMsg),
       createMessage('user', baseMsg),
       createMessage('assistant', baseMsg),
       createMessage('user', baseMsg),
-      // This assistant+toolResult pair will straddle the cut point
       createAssistantWithToolCalls(baseMsg, ['orphan-id']),
       createToolResult('small result', 'orphan-id'),
       createMessage('user', 'follow up'),

--- a/packages/webapp/tests/core/context-compaction.test.ts
+++ b/packages/webapp/tests/core/context-compaction.test.ts
@@ -47,7 +47,11 @@ vi.mock('@earendil-works/pi-coding-agent/dist/core/compaction/compaction.js', ()
   },
 }));
 
-import { compactContext, createCompactContext } from '../../src/core/context-compaction.js';
+import {
+  compactContext,
+  createCompactContext,
+  stripOrphanedToolResults,
+} from '../../src/core/context-compaction.js';
 
 /** Cast helper used in assertions where a typed AgentMessage view of an array of content blocks is needed. */
 function asTestMessage(message: AgentMessage): TestMessage {
@@ -470,6 +474,54 @@ describe('createCompactContext', () => {
     expect(mockGenerateSummary).not.toHaveBeenCalled();
   });
 
+  it('strips orphaned toolResults left at the head after compaction cut', async () => {
+    // Scenario: assistant+toolResult pair lands at the cut boundary such that
+    // the assistant is summarized away but the toolResult is kept. The resulting
+    // array would start with an orphaned toolResult that Bedrock rejects.
+    const compact = createCompactContext({ ...mockConfig, getApiKey: () => undefined });
+    const baseMsg = 'x'.repeat(65000);
+    // Craft history so the cut lands right after an assistant-with-tool-call turn,
+    // leaving the matching toolResult as the first kept message.
+    const messages: AgentMessage[] = [
+      createMessage('user', baseMsg),
+      createMessage('assistant', baseMsg),
+      createMessage('user', baseMsg),
+      createMessage('assistant', baseMsg),
+      createMessage('user', baseMsg),
+      // This assistant+toolResult pair will straddle the cut point
+      createAssistantWithToolCalls(baseMsg, ['orphan-id']),
+      createToolResult('small result', 'orphan-id'),
+      createMessage('user', 'follow up'),
+    ];
+
+    const result = await compact(messages);
+
+    // The result must never start with a toolResult
+    expect(asTestMessage(result[0]).role).not.toBe('toolResult');
+
+    // No toolResult in the output should be orphaned
+    for (let i = 0; i < result.length; i++) {
+      const msg = asTestMessage(result[i]);
+      if (msg.role !== 'toolResult' || !msg.toolCallId) continue;
+      let found = false;
+      for (let j = i - 1; j >= 0; j--) {
+        const prev = asTestMessage(result[j]);
+        if (prev.role === 'assistant' && Array.isArray(prev.content)) {
+          if (
+            prev.content.some(
+              (c: TestContentBlock) => c.type === 'toolCall' && c.id === msg.toolCallId
+            )
+          ) {
+            found = true;
+            break;
+          }
+        }
+        if (prev.role !== 'toolResult') break;
+      }
+      expect(found).toBe(true);
+    }
+  });
+
   it('full-size tool results survive until compaction', async () => {
     const compact = createCompactContext(mockConfig);
     // Tool results pass through at full fidelity — overflow recovery handles sizing if needed
@@ -487,5 +539,61 @@ describe('createCompactContext', () => {
     expect(result).toEqual(messages);
     // Tool result preserved at full size
     expect(firstText(result[2])).toBe(largeResult);
+  });
+});
+
+describe('stripOrphanedToolResults', () => {
+  it('returns the array unchanged when it does not start with a toolResult', () => {
+    const messages: AgentMessage[] = [
+      createMessage('user', 'hello'),
+      createAssistantWithToolCalls('calling', ['t1']),
+      createToolResult('result', 't1'),
+    ];
+    const result = stripOrphanedToolResults(messages);
+    expect(result).toBe(messages); // same reference — no copy made
+  });
+
+  it('returns empty array unchanged', () => {
+    const result = stripOrphanedToolResults([]);
+    expect(result).toEqual([]);
+  });
+
+  it('drops a single orphaned toolResult at the head', () => {
+    const messages: AgentMessage[] = [
+      createToolResult('orphan', 'orphan-id'),
+      createMessage('user', 'follow up'),
+      createMessage('assistant', 'response'),
+    ];
+    const result = stripOrphanedToolResults(messages);
+    expect(result).toHaveLength(2);
+    expect(asTestMessage(result[0]).role).toBe('user');
+  });
+
+  it('drops multiple consecutive orphaned toolResults at the head', () => {
+    const messages: AgentMessage[] = [
+      createToolResult('orphan-1', 'id-1'),
+      createToolResult('orphan-2', 'id-2'),
+      createMessage('user', 'next turn'),
+    ];
+    const result = stripOrphanedToolResults(messages);
+    expect(result).toHaveLength(1);
+    expect(asTestMessage(result[0]).role).toBe('user');
+  });
+
+  it('does not drop toolResults that appear after an assistant message', () => {
+    const messages: AgentMessage[] = [
+      createMessage('user', 'hello'),
+      createAssistantWithToolCalls('calling', ['t1', 't2']),
+      createToolResult('result-1', 't1'),
+      createToolResult('result-2', 't2'),
+    ];
+    const result = stripOrphanedToolResults(messages);
+    expect(result).toHaveLength(4);
+  });
+
+  it('returns all-toolResult array as empty', () => {
+    const messages: AgentMessage[] = [createToolResult('a', 'id-a'), createToolResult('b', 'id-b')];
+    const result = stripOrphanedToolResults(messages);
+    expect(result).toEqual([]);
   });
 });

--- a/packages/webapp/tests/scoops/scoop-context.restore-orphans.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.restore-orphans.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Regression coverage for `ScoopContext.init()` healing of corrupted
+ * persisted sessions: orphaned `toolResult` messages at the head of
+ * `saved.messages` must be stripped before the Agent is constructed,
+ * otherwise Bedrock rejects the next turn with
+ * "unexpected tool_use_id found in tool_result blocks".
+ *
+ * Captures the `Agent` constructor args so we can assert the
+ * `initialState.messages` the Agent is built with — that's the
+ * load-bearing observation: removing the `stripOrphanedToolResults`
+ * call at `scoop-context.ts` session-restore site must make this fail.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RegisteredScoop } from '../../src/scoops/types.js';
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+
+type AgentCtorOptions = { initialState?: { messages?: AgentMessage[] } };
+
+const captures = vi.hoisted(() => ({
+  agentCtorCalls: [] as AgentCtorOptions[],
+}));
+
+vi.mock('../../src/core/index.js', () => {
+  class MockAgent {
+    constructor(options: AgentCtorOptions) {
+      captures.agentCtorCalls.push(options);
+    }
+
+    subscribe = vi.fn(() => () => {});
+    abort = vi.fn();
+  }
+  return {
+    Agent: MockAgent,
+    adaptTools: (tools: unknown[]) => tools,
+    createLogger: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() }),
+  };
+});
+
+// Keep real `stripOrphanedToolResults` so the wire-up is what's under test.
+// Replace `createCompactContext` with a no-op to avoid loading pi-coding-agent.
+vi.mock('../../src/core/context-compaction.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/core/context-compaction.js')>(
+    '../../src/core/context-compaction.js'
+  );
+  return {
+    ...actual,
+    createCompactContext: () => async (messages: AgentMessage[]) => messages,
+  };
+});
+
+vi.mock('@earendil-works/pi-ai', () => ({
+  isContextOverflow: () => false,
+  streamSimple: () => ({ result: () => Promise.resolve(null) }),
+  getSupportedThinkingLevels: () => ['off'],
+}));
+
+vi.mock('../../src/tools/index.js', () => ({
+  createFileTools: () => [],
+  createBashTool: () => ({ name: 'bash' }),
+}));
+
+vi.mock('../../src/shell/index.js', () => ({
+  WasmShell: vi.fn(function () {
+    return {};
+  }),
+}));
+
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => 'test-api-key',
+  getSelectedProvider: () => 'anthropic',
+  resolveCurrentModel: () => ({ id: 'test-model', provider: 'anthropic' }),
+  resolveModelById: () => ({ id: 'test-model', provider: 'anthropic' }),
+}));
+
+vi.mock('../../src/scoops/skills.js', () => ({
+  createDefaultSkills: async () => {},
+  loadSkills: async () => [],
+  formatSkillsForPrompt: () => '',
+}));
+
+vi.mock('../../src/scoops/scoop-management-tools.js', () => ({
+  createScoopManagementTools: () => [],
+}));
+
+vi.mock('../../src/core/secret-env.js', () => ({
+  fetchSecretEnvVars: async () => ({}),
+}));
+
+const { ScoopContext } = await import('../../src/scoops/scoop-context.js');
+
+const baseScoop: RegisteredScoop = {
+  jid: 'cone_test_1',
+  name: 'cone',
+  folder: '',
+  isCone: true,
+  type: 'cone',
+  requiresTrigger: false,
+  assistantLabel: 'sliccy',
+  addedAt: new Date().toISOString(),
+};
+
+function createMockCallbacks() {
+  return {
+    onResponse: vi.fn(),
+    onResponseDone: vi.fn(),
+    onError: vi.fn(),
+    onStatusChange: vi.fn(),
+    onSendMessage: vi.fn(),
+    getScoops: vi.fn(() => []),
+    getGlobalMemory: vi.fn(async () => ''),
+    getBrowserAPI: vi.fn(() => ({})),
+  };
+}
+
+function createMockFs() {
+  return {
+    mkdir: vi.fn(async () => {}),
+    readFile: vi.fn(async () => {
+      throw new Error('ENOENT');
+    }),
+    writeFile: vi.fn(async () => {}),
+  };
+}
+
+function orphanedToolResult(toolCallId = 'orphan-id'): AgentMessage {
+  return {
+    role: 'toolResult',
+    toolCallId,
+    toolName: 'test_tool',
+    content: [{ type: 'text', text: 'lost result' }],
+    isError: false,
+    timestamp: 0,
+  } as unknown as AgentMessage;
+}
+
+function userMessage(text: string): AgentMessage {
+  return {
+    role: 'user',
+    content: [{ type: 'text', text }],
+    timestamp: 0,
+  } as unknown as AgentMessage;
+}
+
+function assistantMessage(text: string): AgentMessage {
+  return {
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    provider: 'anthropic',
+    model: 'test-model',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'stop',
+    timestamp: 0,
+  } as unknown as AgentMessage;
+}
+
+describe('ScoopContext session restore — orphan healing', () => {
+  beforeEach(() => {
+    captures.agentCtorCalls.length = 0;
+  });
+
+  it('strips a leading orphaned toolResult from a corrupt persisted session', async () => {
+    // A session persisted in IndexedDB whose first message is a toolResult
+    // with no preceding assistant. Without the stripOrphanedToolResults call
+    // at the session-restore site, this message flows into the Agent's
+    // initialState and Bedrock rejects the next prompt with a 400.
+    const corrupt: AgentMessage[] = [orphanedToolResult(), userMessage('continue')];
+    const sessionStore = {
+      load: vi.fn().mockResolvedValue({ messages: corrupt, createdAt: 42 }),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const ctx = new ScoopContext(
+      baseScoop,
+      createMockCallbacks() as never,
+      createMockFs() as never,
+      sessionStore as never,
+      undefined,
+      'cone_test_1'
+    );
+    await ctx.init();
+
+    expect(captures.agentCtorCalls).toHaveLength(1);
+    const passed = captures.agentCtorCalls[0].initialState?.messages ?? [];
+    // The orphan must be gone before the Agent sees the history.
+    expect(passed).toHaveLength(1);
+    expect((passed[0] as { role: string }).role).toBe('user');
+  });
+
+  it('strips multiple consecutive leading orphaned toolResults', async () => {
+    const corrupt: AgentMessage[] = [
+      orphanedToolResult('id-1'),
+      orphanedToolResult('id-2'),
+      userMessage('continue'),
+    ];
+    const sessionStore = {
+      load: vi.fn().mockResolvedValue({ messages: corrupt, createdAt: 42 }),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const ctx = new ScoopContext(
+      baseScoop,
+      createMockCallbacks() as never,
+      createMockFs() as never,
+      sessionStore as never,
+      undefined,
+      'cone_test_1'
+    );
+    await ctx.init();
+
+    const passed = captures.agentCtorCalls[0].initialState?.messages ?? [];
+    expect(passed).toHaveLength(1);
+    expect((passed[0] as { role: string }).role).toBe('user');
+  });
+
+  it('passes already-clean sessions through unchanged', async () => {
+    const clean: AgentMessage[] = [userMessage('hello'), assistantMessage('hi')];
+    const sessionStore = {
+      load: vi.fn().mockResolvedValue({ messages: clean, createdAt: 42 }),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const ctx = new ScoopContext(
+      baseScoop,
+      createMockCallbacks() as never,
+      createMockFs() as never,
+      sessionStore as never,
+      undefined,
+      'cone_test_1'
+    );
+    await ctx.init();
+
+    expect(captures.agentCtorCalls).toHaveLength(1);
+    const passed = captures.agentCtorCalls[0].initialState?.messages ?? [];
+    expect(passed).toHaveLength(2);
+    expect((passed[0] as { role: string }).role).toBe('user');
+    expect((passed[1] as { role: string }).role).toBe('assistant');
+  });
+});


### PR DESCRIPTION
<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

Corrupt persisted sessions — where the first stored message is a `toolResult` with no preceding assistant turn — caused a permanent Bedrock 400 on the user's next prompt. This exports `stripOrphanedToolResults` and calls it at session restore so broken sessions self-heal silently on the next load.

## Why

Bedrock (and Claude in strict mode) rejects a conversation that opens with a `toolResult`:

  > messages.0.content.0: unexpected tool_use_id found in tool_result blocks

The orphan arises from a browser crash mid-save, or from sessions written before the walk-back guard was introduced. There was no recovery path; the session was permanently broken for the affected user.

## Approach / Implementation notes

`stripOrphanedToolResults` unconditionally drops any leading `toolResult` messages — no `toolCallId` matching needed, because a `toolResult` at the head is orphaned by definition (there is no preceding assistant turn).

It is called in two places:
  - **`scoop-context.ts` (load-bearing):** applied to `saved.messages` before the `Agent` is constructed. This is the fix that unblocks users. `droppedOrphans` is logged for field telemetry.
  - **`createCompactContext` / `compactContext` (defense-in-depth):** applied after the compaction cut. The walk-back guard already prevents a leading `toolResult` here by construction, so the strip is normally a no-op. It is kept as a safety net against future changes to the cut algebra and is documented as such in the docstring.

The integration test in `context-compaction.test.ts` was renamed from "strips orphaned toolResults left at the head after compaction cut" to "walk-back guard keeps assistant+toolResult pair together across the cut" — because the strip is a no-op on that fixture; it's the walk-back guard that makes the test pass.

## Cross-cutting impact

No behavior change outside the session-restore path. The compaction strips are no-ops under normal operation. No API surface changes. The new `stripOrphanedToolResults` export is the only public-facing addition.

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [x] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [x] `npm run typecheck`
- [x] `npm run test` — `<N>` passing, no new failures
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [x] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [x] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
