### PR TITLE
fix(offscreen-client): re-request state when offscreen restarts mid-session

### DIFF
--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -338,11 +338,16 @@ export class OffscreenClient implements KernelClientFacade {
   private handleOffscreenMessage(msg: OffscreenToPanelMessage | StateSnapshotMsg): void {
     switch (msg.type) {
       case 'offscreen-ready':
-        log.info('Offscreen engine ready');
-        if (!this.ready) {
-          // Request state now that offscreen is confirmed ready
-          this.send({ type: 'request-state' });
+        if (this.ready) {
+          // Offscreen restarted while panel was open (e.g. MV3 SW killed and
+          // recreated the offscreen doc). Reset so the state-snapshot handler
+          // treats the next snapshot as a first-ready and fires onReady again.
+          log.warn('Offscreen restarted — re-requesting state');
+          this.ready = false;
+        } else {
+          log.info('Offscreen engine ready');
         }
+        this.send({ type: 'request-state' });
         break;
 
       case 'agent-event':

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -346,6 +346,29 @@ describe('OffscreenClient', () => {
     expect(onReady).toHaveBeenCalled();
   });
 
+  it('resets ready and re-requests state when offscreen restarts mid-session', () => {
+    const onReady = vi.fn();
+    const c2 = new OffscreenClient({ ...callbacks, onReady });
+
+    // First boot: offscreen-ready → request-state → state-snapshot → ready
+    simulateMessage('offscreen', { type: 'offscreen-ready' });
+    simulateMessage('offscreen', { type: 'state-snapshot', scoops: [], activeScoopJid: null });
+    expect(c2.isReady()).toBe(true);
+    expect(onReady).toHaveBeenCalledTimes(1);
+    sentMessages.length = 0;
+
+    // Offscreen restarts: second offscreen-ready while already ready
+    simulateMessage('offscreen', { type: 'offscreen-ready' });
+    expect(c2.isReady()).toBe(false);
+    const requestStateMsg = (sentMessages[0] as { payload: any })?.payload;
+    expect(requestStateMsg?.type).toBe('request-state');
+
+    // New state-snapshot arrives → onReady fires again
+    simulateMessage('offscreen', { type: 'state-snapshot', scoops: [], activeScoopJid: null });
+    expect(c2.isReady()).toBe(true);
+    expect(onReady).toHaveBeenCalledTimes(2);
+  });
+
   it('handles tool_start and tool_end events', () => {
     client.selectedScoopJid = 'cone_123';
     const handle = client.createAgentHandle();


### PR DESCRIPTION
## Summary

Fix UI freeze in the Chrome extension when the MV3 service worker kills and recreates the offscreen document mid-session.

## Why

The MV3 service worker can be terminated at any time by Chrome, which destroys the offscreen document (the agent engine). When it restarts, it sends a new offscreen-ready message. Previously the side panel ignored this because this.ready was already true — leaving the UI connected to a dead offscreen instance with no way to recover short of a full page reload.

## Approach / Implementation notes

In OffscreenClient.handleOffscreenMessage, when offscreen-ready arrives while this.ready === true, reset ready to false before sending request-state. The existing state-snapshot handler already gates onReady() behind isFirstReady = !this.ready, so setting ready = false first causes onReady to fire again on the next snapshot — reloading chat history from the new offscreen instance cleanly.

The send({ type: 'request-state' }) call is now unconditional (moved outside the if/else) since fresh state is always wanted on offscreen-ready, whether it's first boot or a restart.

## Cross-cutting impact

Single file change in offscreen-client.ts, extension runtime only. No effect on standalone/CLI or Electron floats. No VFS, shell, or protocol changes.

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [x] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [x] `npm run typecheck`
- [x] `npm run test` — `<N>` passing, no new failures
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [x] Manual smoke (CLI): `npm run dev` + …
- [x] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [x] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
