### PR TITLE
fix(chat-panel): eliminate blank gaps injected by empty msg-group wrappers

### DIFF
--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -2174,8 +2174,13 @@ export class ChatPanel {
         .forEach((el) => el.classList.add('tool-call--stale'));
     }
     const el = this.createMessageEl(msg, showLabel, isLastAssistant);
-    this.messagesInner.appendChild(el);
-    this.reflowToolClusters();
+    // Don't inject an empty wrapper into the flex container — the gap: 16px
+    // between msg-groups would create a visible blank line. updateMessageEl
+    // will append it once the message has actual content or tool calls.
+    if (el.childElementCount > 0) {
+      this.messagesInner.appendChild(el);
+      this.reflowToolClusters();
+    }
     this.scrollToBottom();
   }
 
@@ -2198,6 +2203,22 @@ export class ChatPanel {
     const msg = this.findMessage(messageId);
     if (!msg) return;
     const existing = this.messagesEl.querySelector(`.msg-group[data-msg-id="${messageId}"]`);
+    const idx = this.messages.indexOf(msg);
+    const prev = idx > 0 ? this.messages[idx - 1] : null;
+    const showLabel = this.shouldShowLabel(msg, prev?.role ?? null, prev?.timestamp ?? 0);
+    let isLastAssistant = false;
+    if (msg.role === 'assistant') {
+      let lastIdx = -1;
+      for (let i = this.messages.length - 1; i >= 0; i--) {
+        if (this.messages[i].role === 'assistant') {
+          lastIdx = i;
+          break;
+        }
+      }
+      isLastAssistant = idx === lastIdx;
+    }
+    const stale = this.findLastRealUserIdx() > idx;
+    const newEl = this.createMessageEl(msg, showLabel, isLastAssistant, stale);
     if (existing) {
       this.disposeDipsForMessage(messageId);
       // Tool calls for sibling messages in this chain may be inside a
@@ -2207,25 +2228,20 @@ export class ChatPanel {
       // the stale clustered ones would coexist briefly until the next
       // reflow re-collected them.
       this.unwrapToolClusters();
-      // Determine showLabel based on previous message in the list
-      const idx = this.messages.indexOf(msg);
-      const prev = idx > 0 ? this.messages[idx - 1] : null;
-      const showLabel = this.shouldShowLabel(msg, prev?.role ?? null, prev?.timestamp ?? 0);
-      // Only show feedback on the last assistant message
-      let isLastAssistant = false;
-      if (msg.role === 'assistant') {
-        let lastIdx = -1;
-        for (let i = this.messages.length - 1; i >= 0; i--) {
-          if (this.messages[i].role === 'assistant') {
-            lastIdx = i;
-            break;
-          }
-        }
-        isLastAssistant = idx === lastIdx;
-      }
-      const stale = this.findLastRealUserIdx() > idx;
-      const newEl = this.createMessageEl(msg, showLabel, isLastAssistant, stale);
       existing.replaceWith(newEl);
+      this.reflowToolClusters();
+    } else if (newEl.childElementCount > 0) {
+      // Element was skipped in appendMessageEl because it was empty at the
+      // time — now that it has content, insert it at the correct position.
+      const nextMsg = this.messages[idx + 1];
+      const nextEl = nextMsg
+        ? this.messagesEl.querySelector(`.msg-group[data-msg-id="${nextMsg.id}"]`)
+        : null;
+      if (nextEl) {
+        this.messagesInner.insertBefore(newEl, nextEl);
+      } else {
+        this.messagesInner.appendChild(newEl);
+      }
       this.reflowToolClusters();
     }
     this.scrollToBottom();

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -2817,6 +2817,17 @@ export class ChatPanel {
     // Drop any anchors that didn't map to a rebuilt cluster — chain may
     // have shrunk below the threshold or been broken by a user turn.
     this.openClusterAnchors.clear();
+
+    // Mark empty msg-groups so CSS can suppress them from the flex gap.
+    // We use a data attribute rather than relying solely on :empty because
+    // browsers may disagree on whether a whitespace-only text node counts.
+    this.messagesInner.querySelectorAll<HTMLElement>(':scope > .msg-group').forEach((g) => {
+      if (g.childElementCount === 0) {
+        g.dataset.empty = '';
+      } else {
+        delete g.dataset.empty;
+      }
+    });
   }
 
   /** Build a "Working" cluster around an existing list of `.tool-call`

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -2817,17 +2817,6 @@ export class ChatPanel {
     // Drop any anchors that didn't map to a rebuilt cluster — chain may
     // have shrunk below the threshold or been broken by a user turn.
     this.openClusterAnchors.clear();
-
-    // Mark empty msg-groups so CSS can suppress them from the flex gap.
-    // We use a data attribute rather than relying solely on :empty because
-    // browsers may disagree on whether a whitespace-only text node counts.
-    this.messagesInner.querySelectorAll<HTMLElement>(':scope > .msg-group').forEach((g) => {
-      if (g.childElementCount === 0) {
-        g.dataset.empty = '';
-      } else {
-        delete g.dataset.empty;
-      }
-    });
   }
 
   /** Build a "Working" cluster around an existing list of `.tool-call`

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -266,6 +266,12 @@
   gap: 8px;
 }
 
+/* Empty groups left behind after tool-call clustering must not contribute
+   to the parent container's gap: 16px. */
+.msg-group:empty {
+  display: none;
+}
+
 /* Queued messages — dimmed to distinguish from sent messages */
 .msg--queued {
   opacity: 0.55;

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -267,8 +267,10 @@
 }
 
 /* Empty groups left behind after tool-call clustering must not contribute
-   to the parent container's gap: 16px. */
-.msg-group:empty {
+   to the parent container's gap: 16px. Use both :empty (no child nodes)
+   and a data attribute set explicitly by JS for groups with text nodes. */
+.msg-group:empty,
+.msg-group[data-empty] {
   display: none;
 }
 

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -267,10 +267,8 @@
 }
 
 /* Empty groups left behind after tool-call clustering must not contribute
-   to the parent container's gap: 16px. Use both :empty (no child nodes)
-   and a data attribute set explicitly by JS for groups with text nodes. */
-.msg-group:empty,
-.msg-group[data-empty] {
+   to the parent container's gap: 16px. */
+.msg-group:empty {
   display: none;
 }
 

--- a/packages/webapp/tests/ui/chat-panel-empty-group.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-empty-group.test.ts
@@ -190,12 +190,14 @@ describe('ChatPanel empty msg-group gap fix', () => {
     // All three tool calls should be clustered.
     expect(container.querySelectorAll('.tool-call-cluster').length).toBe(1);
 
-    // Continuation groups that lost their tool calls to the cluster are empty.
+    // Continuation groups that lost their tool calls to the cluster are empty
+    // and must be marked data-empty so CSS suppresses them from the flex gap.
     const emptyGroups = [...container.querySelectorAll('.msg-group')].filter(
       (g) => g.childElementCount === 0
     );
-    // They exist in the DOM (load-bearing for chain detection) but are empty.
+    // They exist in the DOM (load-bearing for chain detection) but are hidden.
     expect(emptyGroups.length).toBeGreaterThan(0);
+    emptyGroups.forEach((g) => expect((g as HTMLElement).dataset.empty).toBeDefined());
   });
 
   it('does not produce duplicate msg-groups when updateMessageEl is called on an existing element', () => {

--- a/packages/webapp/tests/ui/chat-panel-empty-group.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-empty-group.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+/**
+ * Regression tests for the empty msg-group gap bug.
+ *
+ * When a new assistant message starts streaming (message_start) but has no
+ * text content yet, appendMessageEl used to inject an empty div.msg-group
+ * into the flex container. Because the container uses gap: 16px, each empty
+ * wrapper created a visible blank line that shifted earlier tool calls upward
+ * on every new tool_use_start event.
+ *
+ * Fix: appendMessageEl skips the DOM append when the wrapper has no children,
+ * and updateMessageEl inserts it at the correct position once content arrives.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { ChatPanel } from '../../src/ui/chat-panel.js';
+import type { ChatMessage } from '../../src/ui/types.js';
+
+vi.mock('../../src/ui/voice-input.js', () => ({
+  VoiceInput: class {
+    destroy() {}
+    start() {}
+    stop() {}
+    setAutoSend() {}
+    setLang() {}
+  },
+  getVoiceAutoSend: () => false,
+  getVoiceLang: () => 'en-US',
+}));
+
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => '',
+  showProviderSettings: () => {},
+  applyProviderDefaults: () => {},
+  getAllAvailableModels: () => [],
+  getSelectedModelId: () => '',
+  getSelectedProvider: () => null,
+  setSelectedModelId: () => {},
+  getProviderConfig: () => null,
+}));
+
+type ChatPanelInternals = {
+  messages: ChatMessage[];
+  appendMessageEl: (msg: ChatMessage) => void;
+  updateMessageEl: (messageId: string) => void;
+  messagesInner: HTMLElement;
+};
+const internals = (p: ChatPanel): ChatPanelInternals => p as unknown as ChatPanelInternals;
+
+let testCounter = 0;
+
+describe('ChatPanel empty msg-group gap fix', () => {
+  let container: HTMLElement;
+  let panel: ChatPanel;
+
+  beforeEach(async () => {
+    testCounter += 1;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    panel = new ChatPanel(container);
+    await panel.initSession(`test-empty-group-${testCounter}`);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('does not inject an empty msg-group when message has no content or tool calls', () => {
+    const msg: ChatMessage = {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      timestamp: 1000,
+      isStreaming: true,
+      toolCalls: [],
+    };
+    internals(panel).messages.push(msg);
+    internals(panel).appendMessageEl(msg);
+
+    const groups = container.querySelectorAll('.msg-group[data-msg-id="a1"]');
+    expect(groups.length).toBe(0);
+  });
+
+  it('inserts the msg-group once a tool call arrives via updateMessageEl', () => {
+    const msg: ChatMessage = {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      timestamp: 1000,
+      isStreaming: true,
+      toolCalls: [],
+    };
+    internals(panel).messages.push(msg);
+    internals(panel).appendMessageEl(msg);
+    expect(container.querySelectorAll('.msg-group[data-msg-id="a1"]').length).toBe(0);
+
+    msg.toolCalls = [{ id: 'tc-1', name: 'bash', input: { command: 'ls' } }];
+    internals(panel).updateMessageEl('a1');
+
+    expect(container.querySelectorAll('.msg-group[data-msg-id="a1"]').length).toBe(1);
+    expect(container.querySelectorAll('.tool-call').length).toBe(1);
+  });
+
+  it('inserts the msg-group once text content arrives via updateMessageEl', () => {
+    const msg: ChatMessage = {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      timestamp: 1000,
+      isStreaming: true,
+      toolCalls: [],
+    };
+    internals(panel).messages.push(msg);
+    internals(panel).appendMessageEl(msg);
+    expect(container.querySelectorAll('.msg-group[data-msg-id="a1"]').length).toBe(0);
+
+    msg.content = 'Hello world';
+    internals(panel).updateMessageEl('a1');
+
+    expect(container.querySelectorAll('.msg-group[data-msg-id="a1"]').length).toBe(1);
+    expect(container.querySelector('.msg__content')?.textContent).toContain('Hello world');
+  });
+
+  it('inserts the late msg-group before the next message in the list', () => {
+    const a1: ChatMessage = {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      timestamp: 1000,
+      isStreaming: true,
+      toolCalls: [],
+    };
+    const u2: ChatMessage = {
+      id: 'u2',
+      role: 'user',
+      content: 'follow-up',
+      timestamp: 2000,
+    };
+    const p = internals(panel);
+    p.messages.push(a1);
+    p.appendMessageEl(a1);
+    p.messages.push(u2);
+    p.appendMessageEl(u2);
+
+    // a1 was empty — only u2 should be in the DOM
+    expect(container.querySelectorAll('.msg-group').length).toBe(1);
+
+    a1.content = 'Done';
+    p.updateMessageEl('a1');
+
+    const groups = container.querySelectorAll<HTMLElement>('.msg-group');
+    expect(groups.length).toBe(2);
+    // a1 must appear before u2
+    expect(groups[0].dataset.msgId).toBe('a1');
+    expect(groups[1].dataset.msgId).toBe('u2');
+  });
+
+  it('does not produce duplicate msg-groups when updateMessageEl is called on an existing element', () => {
+    const msg: ChatMessage = {
+      id: 'a1',
+      role: 'assistant',
+      content: 'initial',
+      timestamp: 1000,
+      toolCalls: [],
+    };
+    internals(panel).messages.push(msg);
+    internals(panel).appendMessageEl(msg);
+    expect(container.querySelectorAll('.msg-group[data-msg-id="a1"]').length).toBe(1);
+
+    msg.content = 'updated';
+    internals(panel).updateMessageEl('a1');
+
+    expect(container.querySelectorAll('.msg-group[data-msg-id="a1"]').length).toBe(1);
+  });
+});

--- a/packages/webapp/tests/ui/chat-panel-empty-group.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-empty-group.test.ts
@@ -190,14 +190,13 @@ describe('ChatPanel empty msg-group gap fix', () => {
     // All three tool calls should be clustered.
     expect(container.querySelectorAll('.tool-call-cluster').length).toBe(1);
 
-    // Continuation groups that lost their tool calls to the cluster are empty
-    // and must be marked data-empty so CSS suppresses them from the flex gap.
+    // Continuation groups that lost their tool calls to the cluster are empty.
+    // They stay in the DOM (load-bearing for chain detection) but are hidden
+    // by the .msg-group:empty { display: none } CSS rule.
     const emptyGroups = [...container.querySelectorAll('.msg-group')].filter(
       (g) => g.childElementCount === 0
     );
-    // They exist in the DOM (load-bearing for chain detection) but are hidden.
     expect(emptyGroups.length).toBeGreaterThan(0);
-    emptyGroups.forEach((g) => expect((g as HTMLElement).dataset.empty).toBeDefined());
   });
 
   it('does not produce duplicate msg-groups when updateMessageEl is called on an existing element', () => {

--- a/packages/webapp/tests/ui/chat-panel-empty-group.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-empty-group.test.ts
@@ -156,6 +156,48 @@ describe('ChatPanel empty msg-group gap fix', () => {
     expect(groups[1].dataset.msgId).toBe('u2');
   });
 
+  it('vacated msg-groups left after clustering have no visible size (display:none via CSS :empty)', () => {
+    // After reflowToolClusters, continuation groups that had their tool calls
+    // moved into a cluster become empty. They must not contribute to the
+    // parent flex container gap. jsdom does not compute CSS, so we assert the
+    // element is empty — the :empty { display:none } rule in chat.css handles
+    // the visual suppression.
+    panel.loadMessages([
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1000 },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: '',
+        timestamp: 2000,
+        toolCalls: [{ id: 'tc-1', name: 'bash', input: {}, result: 'ok' }],
+      },
+      {
+        id: 'a2',
+        role: 'assistant',
+        content: '',
+        timestamp: 2100,
+        toolCalls: [{ id: 'tc-2', name: 'bash', input: {}, result: 'ok' }],
+      },
+      {
+        id: 'a3',
+        role: 'assistant',
+        content: '',
+        timestamp: 2200,
+        toolCalls: [{ id: 'tc-3', name: 'bash', input: {}, result: 'ok' }],
+      },
+    ]);
+
+    // All three tool calls should be clustered.
+    expect(container.querySelectorAll('.tool-call-cluster').length).toBe(1);
+
+    // Continuation groups that lost their tool calls to the cluster are empty.
+    const emptyGroups = [...container.querySelectorAll('.msg-group')].filter(
+      (g) => g.childElementCount === 0
+    );
+    // They exist in the DOM (load-bearing for chain detection) but are empty.
+    expect(emptyGroups.length).toBeGreaterThan(0);
+  });
+
   it('does not produce duplicate msg-groups when updateMessageEl is called on an existing element', () => {
     const msg: ChatMessage = {
       id: 'a1',


### PR DESCRIPTION
## Summary

Fix two related blank-line bugs in the chat panel that caused visible gaps to grow proportionally with the number of agent commands run.

Before:
<img width="775" height="858" alt="image" src="https://github.com/user-attachments/assets/57800296-75f4-424b-b7e2-ca7b2cd4fbe4" />

After:
<img width="886" height="906" alt="image" src="https://github.com/user-attachments/assets/67d3416a-1489-4e94-b52b-520a5c4e0d82" />

## Why

  Bug 1 — blank line per new command (streaming): appendMessageEl always injected a div.msg-group into the flex container immediately on message_start, before any content or tool calls arrived. The container uses gap: 16px, so each empty wrapper added a blank slot. On every tool_use_start the wrapper was replaced, but a new empty one was injected for the next message.

  Bug 2 — gap scales with command count (clustering): After reflowToolClusters moves tool-call elements from continuation groups into a cluster, those groups become empty but stay in the DOM as chain anchors for the next reflow pass. With gap: 16px on the flex container, each vacated group contributed a blank line — so 10 commands produced ~160px of blank space between the cluster bar and the final text response.

## Approach / Implementation notes

- appendMessageEl: skip messagesInner.appendChild when el.childElementCount === 0. updateMessageEl handles the first real render once content or tool calls arrive.
  - updateMessageEl: when no existing element is found (was deferred), build and insert at the correct DOM position using the next message as an insertBefore anchor, falling back to appendChild.
  - CSS: .msg-group:empty { display: none } — one rule suppresses vacated continuation groups from the flex layout while leaving them in the DOM for chain detection.

## Cross-cutting impact

chat-panel.ts and chat.css only. No VFS, shell, extension protocol, or agent changes. Both standalone and extension modes use the same ChatPanel. The cluster/reflow logic is unchanged — :empty groups stay in the DOM and are still found by reflowToolClusters.

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [x] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [x] `npm run typecheck`
- [x] `npm run test` — `<N>` passing, no new failures
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [ x] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ x] Manual smoke (CLI): `npm run dev` + …
- [x ] Manual smoke (extension): load unpacked `dist/extension/` + …

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [x] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
