### PR TITLE
fix(ui/standalone): re-wire brain icon + thinking-level sync

### DIFF
--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1593,6 +1593,22 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
   let selectedScoop: RegisteredScoop | null = null;
   let client!: InstanceType<typeof OffscreenClient>;
 
+  // Sync the brain icon to the active scoop's resolved model + persisted
+  // thinking-level. Mirrors `syncThinkingButtonForExtensionScoop` in
+  // `mainExtension`. The legacy inline standalone path had an equivalent
+  // helper; it was lost in 07cdce16 ("remove legacy inline-orchestrator
+  // standalone path") and never re-wired here, so the brain icon stayed
+  // hidden in standalone-worker mode regardless of model capability.
+  const syncThinkingButtonForScoop = (scoop: RegisteredScoop): void => {
+    const modelId = scoop.config?.modelId;
+    const model = modelId ? resolveModelById(modelId) : resolveCurrentModel();
+    layout.panels.chat.setModelSupportsReasoning(
+      !!model.reasoning,
+      getSupportedThinkingLevels(model).includes('xhigh')
+    );
+    layout.panels.chat.setThinkingLevel(scoop.config?.thinkingLevel);
+  };
+
   const selectScoop = async (scoop: RegisteredScoop): Promise<void> => {
     selectedScoop = scoop;
     client.selectedScoopJid = scoop.jid;
@@ -1615,6 +1631,8 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
     if (client.isProcessing(scoop.jid)) {
       layout.panels.chat.setProcessing(true);
     }
+
+    syncThinkingButtonForScoop(scoop);
   };
 
   // Per-instance discriminator so same-origin RPC channels (sprinkle
@@ -1708,6 +1726,29 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
   layout.panels.memory.setOrchestrator(client as unknown as Orchestrator);
   layout.setScoopSwitcherOrchestrator?.(client as unknown as Orchestrator);
   layout.onScoopSelect = selectScoop;
+
+  // Brain-icon wiring (mirrors `mainExtension`).
+  // - `onModelChange`: persist the user's choice locally so the worker's
+  //   storage shim sees the same `selected-model` it would after reload,
+  //   ask the worker to refresh its resolved model, and re-sync the
+  //   thinking button (different models support different levels).
+  // - `onThinkingLevelChange`: persist the brain-icon cycle into the
+  //   active scoop's `config.thinkingLevel` over the wire.
+  // - `onModelsRefreshed`: provider-account add/remove can flip a model
+  //   from unavailable→available (or vice versa); re-sync so the brain
+  //   reflects the post-refresh capabilities.
+  layout.onModelChange = (modelId) => {
+    localStorage.setItem('selected-model', modelId);
+    client.updateModel();
+    if (selectedScoop) syncThinkingButtonForScoop(selectedScoop);
+  };
+  layout.onThinkingLevelChange = (level) => {
+    if (!selectedScoop) return;
+    client.setScoopThinkingLevel(selectedScoop.jid, level);
+  };
+  layout.onModelsRefreshed = () => {
+    if (selectedScoop) syncThinkingButtonForScoop(selectedScoop);
+  };
 
   // Wire chat agent handle. The handle's `sendMessage` posts a
   // `user-message` over the wire; the worker's bridge handles it.


### PR DESCRIPTION
## Summary

- Standalone-worker mode never showed the brain (thinking-level) icon — `.chat__thinking-btn` was always rendered with `hidden=""`, even with a reasoning-capable model like `adobe:claude-opus-4-6` selected.
- Root cause: commit `07cdce16` ("ui: remove legacy inline-orchestrator standalone path") deleted the inline-standalone entry point along with its `syncThinkingButtonForScoop` helper and the `layout.onModelChange` / `layout.onThinkingLevelChange` / `layout.onModelsRefreshed` handlers. `mainExtension` retained the equivalent wiring, but `mainStandaloneWorker` never got it ported.
- This PR restores the wiring inside `mainStandaloneWorker`, mirroring `mainExtension` exactly: a new `syncThinkingButtonForScoop` helper, a call at the tail of `selectScoop`, and the three `layout.on*` handlers that round-trip thinking-level changes through `OffscreenClient`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test -w @slicc/webapp` — 3679/3679 pass
- [x] `npm run build -w @slicc/webapp` — clean
- [ ] Manual: open standalone (`npm run dev`), confirm brain icon appears in the chat header when a reasoning-capable model is selected, cycles through levels on click, hides for non-reasoning models, and persists across scoop switches and reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)