### PR TITLE
feat(compaction): extract memory on compact + freeze cone session

### DIFF
--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -245,6 +245,18 @@ export interface ScoopStatusMsg {
 }
 
 /**
+ * Fired by the offscreen agent's compaction transformer as it enters
+ * and leaves the summarize / memory-extract LLM phases. The panel
+ * renders a ghost-bubble affordance while the state is non-idle so the
+ * user knows why the agent is silent. `'idle'` clears the affordance.
+ */
+export interface CompactionStateMsg {
+  type: 'compaction-state';
+  scoopJid: string;
+  state: 'summarizing' | 'extracting-memory' | 'idle';
+}
+
+/**
  * Subset of `ScoopConfig` (see `packages/webapp/src/scoops/types.ts`)
  * carried across the offscreen → panel boundary. The panel only needs
  * the persisted-per-scoop bits that drive the UI affordances (model
@@ -440,6 +452,7 @@ export type OffscreenToPanelMessage =
   | OffscreenReadyMsg
   | AgentEventMsg
   | ScoopStatusMsg
+  | CompactionStateMsg
   | ScoopListMsg
   | StateSnapshotMsg
   | ErrorMsg

--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -78,12 +78,16 @@ export interface RequestScoopMessagesMsg {
 
 export interface ClearChatMsg {
   type: 'clear-chat';
-  /**
-   * Which sessions to clear. `'cone'` (default) wipes only the cone — used
-   * by the "New session" button so scoops survive. `'all'` wipes every
-   * scoop's session as well; reserved for future "reset everything" flows.
-   */
-  target?: 'cone' | 'all';
+  /** Correlation id so the panel can await the bridge's ack and avoid
+   *  reloading before the live cone context has actually been cleared
+   *  (the offscreen document survives panel reload in extension mode,
+   *  so a missed clear would leave the old agent state running). */
+  requestId: string;
+}
+
+export interface ClearChatAckMsg {
+  type: 'clear-chat-ack';
+  requestId: string;
 }
 
 export interface ClearFilesystemMsg {
@@ -462,6 +466,7 @@ export type OffscreenToPanelMessage =
   | PanelCdpResponseMsg
   | OAuthResultMsg
   | TrayRuntimeStatusMsg
+  | ClearChatAckMsg
   // Terminal session events emitted by the worker's `TerminalSessionHost`.
   // Consumed by the panel's `TerminalSessionClient`.
   | TerminalEventMsg;

--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -78,6 +78,12 @@ export interface RequestScoopMessagesMsg {
 
 export interface ClearChatMsg {
   type: 'clear-chat';
+  /**
+   * Which sessions to clear. `'cone'` (default) wipes only the cone — used
+   * by the "New session" button so scoops survive. `'all'` wipes every
+   * scoop's session as well; reserved for future "reset everything" flows.
+   */
+  target?: 'cone' | 'all';
 }
 
 export interface ClearFilesystemMsg {

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -861,20 +861,37 @@ export class OffscreenBridge implements KernelFacade {
       }
 
       case 'clear-chat': {
-        await this.orchestrator.clearAllMessages();
-        // Clear session store for all known scoops — must await so deletions
-        // complete before the panel reloads and re-reads from IndexedDB
-        if (this.sessionStore) {
-          const scoops = this.orchestrator.getScoops();
-          await Promise.all(
-            scoops.map((scoop) => {
-              const sessionId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
-              return this.sessionStore!.delete(sessionId);
-            })
-          );
+        const target = msg.target ?? 'cone';
+        if (target === 'cone') {
+          // Cone-only clear (the "New session" path). Scoops keep their
+          // conversations and continue to run; the fresh cone inherits
+          // the existing roster.
+          const coneJid = this.orchestrator.getScoops().find((s) => s.isCone)?.jid;
+          if (coneJid) {
+            await this.orchestrator.clearScoopMessages(coneJid);
+          }
+          if (this.sessionStore) {
+            await this.sessionStore.delete('session-cone');
+          }
+          if (coneJid) {
+            this.messageBuffers.delete(coneJid);
+            this.currentMessageId.delete(coneJid);
+          }
+        } else {
+          // Legacy 'all' path — used internally for resets.
+          await this.orchestrator.clearAllMessages();
+          if (this.sessionStore) {
+            const scoops = this.orchestrator.getScoops();
+            await Promise.all(
+              scoops.map((scoop) => {
+                const sessionId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
+                return this.sessionStore!.delete(sessionId);
+              })
+            );
+          }
+          this.messageBuffers.clear();
+          this.currentMessageId.clear();
         }
-        this.messageBuffers.clear();
-        this.currentMessageId.clear();
         break;
       }
 

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -869,37 +869,24 @@ export class OffscreenBridge implements KernelFacade {
       }
 
       case 'clear-chat': {
-        const target = msg.target ?? 'cone';
-        if (target === 'cone') {
-          // Cone-only clear (the "New session" path). Scoops keep their
-          // conversations and continue to run; the fresh cone inherits
-          // the existing roster.
-          const coneJid = this.orchestrator.getScoops().find((s) => s.isCone)?.jid;
-          if (coneJid) {
-            await this.orchestrator.clearScoopMessages(coneJid);
-          }
-          if (this.sessionStore) {
-            await this.sessionStore.delete('session-cone');
-          }
-          if (coneJid) {
-            this.messageBuffers.delete(coneJid);
-            this.currentMessageId.delete(coneJid);
-          }
-        } else {
-          // Legacy 'all' path — used internally for resets.
-          await this.orchestrator.clearAllMessages();
-          if (this.sessionStore) {
-            const scoops = this.orchestrator.getScoops();
-            await Promise.all(
-              scoops.map((scoop) => {
-                const sessionId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
-                return this.sessionStore!.delete(sessionId);
-              })
-            );
-          }
-          this.messageBuffers.clear();
-          this.currentMessageId.clear();
+        // Cone-only clear (the "New session" path). Scoops keep their
+        // conversations and continue to run; the fresh cone inherits
+        // the existing roster.
+        const coneJid = this.orchestrator.getScoops().find((s) => s.isCone)?.jid;
+        if (coneJid) {
+          await this.orchestrator.clearScoopMessages(coneJid);
         }
+        if (this.sessionStore) {
+          await this.sessionStore.delete('session-cone');
+        }
+        if (coneJid) {
+          this.messageBuffers.delete(coneJid);
+          this.currentMessageId.delete(coneJid);
+        }
+        // Acknowledge so the panel knows the clear completed before it
+        // calls `location.reload()` — important in extension mode where
+        // the offscreen document survives a panel reload.
+        this.emit({ type: 'clear-chat-ack', requestId: msg.requestId });
         break;
       }
 

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -218,6 +218,14 @@ export class OffscreenBridge implements KernelFacade {
         bridge.emitScoopList();
       },
 
+      onCompactionStateChange: (scoopJid, state) => {
+        bridge.emit({
+          type: 'compaction-state',
+          scoopJid,
+          state,
+        });
+      },
+
       onError: (scoopJid, error) => {
         bridge.emit({
           type: 'error',

--- a/packages/chrome-extension/tests/offscreen-bridge.test.ts
+++ b/packages/chrome-extension/tests/offscreen-bridge.test.ts
@@ -711,29 +711,25 @@ describe('OffscreenBridge handlePanelMessage', () => {
     expect(store.delete).toHaveBeenCalledWith('session-test-scoop');
   });
 
-  it('dispatches clear-chat (default target=cone) and clears only the cone session', async () => {
-    simulatePanelMessage({ type: 'clear-chat' });
+  it('dispatches clear-chat: clears only the cone session and emits an ack', async () => {
+    sentMessages.length = 0;
+    simulatePanelMessage({ type: 'clear-chat', requestId: 'req-123' });
 
     await new Promise((r) => setTimeout(r, 10));
 
-    // Default target is 'cone' — clear only the cone, leave scoops alive.
+    // Cone-only: scoops keep their sessions; clearScoopMessages does the
+    // per-scoop wipe (including the channel-history rows in the agent DB).
     expect(mockOrchestrator.clearScoopMessages).toHaveBeenCalledWith('cone_1');
     expect(mockOrchestrator.clearAllMessages).not.toHaveBeenCalled();
     const store = (bridge as any).sessionStore;
     expect(store.delete).toHaveBeenCalledWith('session-cone');
     expect(store.delete).not.toHaveBeenCalledWith('session-test-scoop');
-  });
 
-  it('dispatches clear-chat target=all and clears every scoop session', async () => {
-    simulatePanelMessage({ type: 'clear-chat', target: 'all' });
-
-    await new Promise((r) => setTimeout(r, 10));
-
-    expect(mockOrchestrator.clearAllMessages).toHaveBeenCalled();
-    expect(mockOrchestrator.clearScoopMessages).not.toHaveBeenCalled();
-    const store = (bridge as any).sessionStore;
-    expect(store.delete).toHaveBeenCalledWith('session-cone');
-    expect(store.delete).toHaveBeenCalledWith('session-test-scoop');
+    // Ack must carry the same requestId so the panel can match it.
+    const ack = sentMessages.find((m: any) => m?.payload?.type === 'clear-chat-ack') as
+      | { payload: { type: string; requestId: string } }
+      | undefined;
+    expect(ack?.payload.requestId).toBe('req-123');
   });
 
   it('dispatches abort to orchestrator.stopScoop', async () => {

--- a/packages/chrome-extension/tests/offscreen-bridge.test.ts
+++ b/packages/chrome-extension/tests/offscreen-bridge.test.ts
@@ -661,6 +661,7 @@ describe('OffscreenBridge handlePanelMessage', () => {
       stopScoop: vi.fn(),
       clearQueuedMessages: vi.fn().mockResolvedValue(undefined),
       clearAllMessages: vi.fn().mockResolvedValue(undefined),
+      clearScoopMessages: vi.fn().mockResolvedValue(undefined),
       delegateToScoop: vi.fn().mockResolvedValue(undefined),
       updateModel: vi.fn(),
     };
@@ -710,14 +711,27 @@ describe('OffscreenBridge handlePanelMessage', () => {
     expect(store.delete).toHaveBeenCalledWith('session-test-scoop');
   });
 
-  it('dispatches clear-chat and clears all sessions', async () => {
+  it('dispatches clear-chat (default target=cone) and clears only the cone session', async () => {
     simulatePanelMessage({ type: 'clear-chat' });
 
     await new Promise((r) => setTimeout(r, 10));
 
-    expect(mockOrchestrator.clearAllMessages).toHaveBeenCalled();
+    // Default target is 'cone' — clear only the cone, leave scoops alive.
+    expect(mockOrchestrator.clearScoopMessages).toHaveBeenCalledWith('cone_1');
+    expect(mockOrchestrator.clearAllMessages).not.toHaveBeenCalled();
     const store = (bridge as any).sessionStore;
-    // Should delete sessions for both cone and scoop
+    expect(store.delete).toHaveBeenCalledWith('session-cone');
+    expect(store.delete).not.toHaveBeenCalledWith('session-test-scoop');
+  });
+
+  it('dispatches clear-chat target=all and clears every scoop session', async () => {
+    simulatePanelMessage({ type: 'clear-chat', target: 'all' });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockOrchestrator.clearAllMessages).toHaveBeenCalled();
+    expect(mockOrchestrator.clearScoopMessages).not.toHaveBeenCalled();
+    const store = (bridge as any).sessionStore;
     expect(store.delete).toHaveBeenCalledWith('session-cone');
     expect(store.delete).toHaveBeenCalledWith('session-test-scoop');
   });

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -95,9 +95,9 @@ Deep reference: `docs/kernel/process-model.md`.
 ### Frozen Sessions ("New session" flow)
 
 - Path: `packages/webapp/src/ui/session-freezer.ts`, `packages/webapp/src/ui/new-session.ts`
-- The avatar-popover "New session" entry and thread-header refresh button both run the freezer over the cone session, then clear only the cone (scoops survive). The freezer writes `/sessions/<timestamp>-<slug>.json` and prepends an entry to `/sessions/index.json`.
-- `scoops-panel.ts` renders the index as a frozen-sessions section below the live scoops list (standalone only — extension hides the rail). Clicking an entry switches to the Files tab and reveals the archive via `FileBrowserPanel.revealPath`.
-- Clearing semantics: `OffscreenClient.clearAllMessages({ target: 'cone' \| 'all' })` defaults to `'cone'`. The `'all'` path is preserved for internal reset flows and is not currently exposed in the UI.
+- The avatar-popover "New session" entry and thread-header refresh button both run the freezer over the cone session, then clear only the cone (scoops survive). The freezer writes `/sessions/<timestamp>-<slug>.md` (YAML frontmatter + an HTML-commented `slicc:session-data` block carrying the structured `ChatMessage[]` + a human-readable markdown body) and prepends an entry to `/sessions/index.json`.
+- `scoops-panel.ts` renders the index as a frozen-sessions section below the live scoops list (standalone only — extension hides the rail). Clicking an entry reads the archive, parses it via `parseFrozenArchive`, and hands the messages to `ChatPanel.displayFrozenSession` for a read-only render — same affordance as clicking a live scoop.
+- Clearing semantics: `OffscreenClient.clearAllMessages()` is cone-only. It awaits the bridge's `clear-chat-ack` before resolving so the panel can `location.reload()` without racing the offscreen agent context (which survives the panel reload in extension mode).
 
 ### UI
 

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -89,6 +89,15 @@ Deep reference: `docs/kernel/process-model.md`.
 
 - Path: `packages/webapp/src/core/context-compaction.ts`
 - Handles large-context summarization, image resizing, and overflow recovery.
+- When `onMemoryUpdates` is wired on `CompactionConfig` (cone only — see `scoop-context.ts` wiring), compaction makes a second LLM call that shares the same system prompt to extract durable memories. The system prompt embeds the serialized conversation so Anthropic prompt caching hits on the prefix and the memory call is near-free. Memory bullets land in `/shared/CLAUDE.md` via `orchestrator.appendGlobalMemory`. Memory extraction is best-effort and never blocks compaction.
+- `runOneOffCompactionCall` is the reusable primitive — same shared-system-prompt shape, single call. Used by the "New session" freezer to generate a title and extract memories over the live cone session.
+
+### Frozen Sessions ("New session" flow)
+
+- Path: `packages/webapp/src/ui/session-freezer.ts`, `packages/webapp/src/ui/new-session.ts`
+- The avatar-popover "New session" entry and thread-header refresh button both run the freezer over the cone session, then clear only the cone (scoops survive). The freezer writes `/sessions/<timestamp>-<slug>.json` and prepends an entry to `/sessions/index.json`.
+- `scoops-panel.ts` renders the index as a frozen-sessions section below the live scoops list (standalone only — extension hides the rail). Clicking an entry switches to the Files tab and reveals the archive via `FileBrowserPanel.revealPath`.
+- Clearing semantics: `OffscreenClient.clearAllMessages({ target: 'cone' \| 'all' })` defaults to `'cone'`. The `'all'` path is preserved for internal reset flows and is not currently exposed in the UI.
 
 ### UI
 

--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -1,23 +1,28 @@
 /**
- * Context compaction — LLM-summarized context replacement.
+ * Context compaction — LLM-summarized context replacement, plus optional
+ * memory extraction over the same conversation prefix.
  *
- * Aligned with pi-mono's compaction strategy: when context approaches the limit,
- * an LLM call generates a structured summary of older messages, which replaces them
- * as a single user message. This preserves the conversation prefix (cache-friendly)
- * and keeps recent messages intact.
+ * When compaction triggers, two LLM calls share an identical system prompt
+ * (which embeds the serialized conversation). Anthropic's prompt cache hits
+ * on the system-prompt breakpoint, so the second call is near-free on input
+ * tokens. Other providers see two independent calls — correctness preserved,
+ * no cache savings.
  *
- * Uses generateSummary(), estimateTokens(), shouldCompact(), and DEFAULT_COMPACTION_SETTINGS
- * from @earendil-works/pi-coding-agent.
+ * Token-accounting helpers (`estimateTokens`, `shouldCompact`,
+ * `DEFAULT_COMPACTION_SETTINGS`) are still imported from pi-coding-agent —
+ * they are pure heuristics with no LLM coupling. The LLM call itself now
+ * goes through pi-ai's `completeSimple` directly so we control the message
+ * shape and can place the conversation in the system prompt.
  */
 
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
 import type { Api, Model, UserMessage } from '@earendil-works/pi-ai';
+import { completeSimple } from '@earendil-works/pi-ai';
 // Deep import to the compaction submodule — the main entry re-exports 113 Node-only
 // modules that would break Vite's browser bundle. The compaction submodule itself
 // only depends on @earendil-works/pi-ai (already a browser-safe dependency).
 // Types are declared in packages/webapp/src/types/pi-coding-agent-compaction.d.ts.
 import {
-  generateSummary,
   estimateTokens,
   shouldCompact,
   DEFAULT_COMPACTION_SETTINGS,
@@ -76,12 +81,183 @@ export interface CompactionConfig {
   reserveTokens?: number;
   keepRecentTokens?: number;
   /**
-   * HTTP headers forwarded to the LLM provider for the summarization
-   * request. Used by the Adobe LLM proxy path to attach `X-Session-Id`
-   * so compaction calls land in the same session as the agent's tool
-   * turns. Other providers ignore unknown headers.
+   * HTTP headers forwarded to the LLM provider for the summarization and
+   * memory-extraction requests. Used by the Adobe LLM proxy path to attach
+   * `X-Session-Id` so compaction calls land in the same session as the
+   * agent's tool turns. Other providers ignore unknown headers.
    */
   headers?: Record<string, string>;
+  /**
+   * Optional callback invoked when the memory-extraction LLM call produces
+   * durable bullets worth persisting. Receives the LLM's raw output (a
+   * markdown bullet block). The implementation is expected to append it to
+   * a memory store (e.g. `/shared/CLAUDE.md`).
+   *
+   * Best-effort: failures in the LLM call or the callback are logged but do
+   * not block compaction. When omitted, no memory call is made.
+   */
+  onMemoryUpdates?: (bullets: string) => Promise<void> | void;
+}
+
+/**
+ * Lightweight serializer that renders an AgentMessage array as a text block
+ * suitable for embedding inside a system prompt. We do not need the full
+ * structured fidelity pi-coding-agent provides for its own session manager —
+ * the summarizing LLM only needs to read the conversation.
+ */
+function serializeMessages(messages: AgentMessage[]): string {
+  const lines: string[] = [];
+  for (const msg of messages) {
+    const m = msg as {
+      role: string;
+      content?: unknown;
+      command?: string;
+      output?: string;
+      summary?: string;
+      toolName?: string;
+    };
+    switch (m.role) {
+      case 'user': {
+        lines.push(`<user>\n${extractText(m.content)}\n</user>`);
+        break;
+      }
+      case 'assistant': {
+        lines.push(`<assistant>\n${extractText(m.content)}\n</assistant>`);
+        break;
+      }
+      case 'toolResult': {
+        const name = m.toolName ?? 'tool';
+        lines.push(`<tool-result name="${name}">\n${extractText(m.content)}\n</tool-result>`);
+        break;
+      }
+      case 'bashExecution': {
+        lines.push(`<bash>\n$ ${m.command ?? ''}\n${m.output ?? ''}\n</bash>`);
+        break;
+      }
+      case 'branchSummary':
+      case 'compactionSummary': {
+        lines.push(`<prior-summary>\n${m.summary ?? ''}\n</prior-summary>`);
+        break;
+      }
+      default: {
+        // Unknown role — fall back to JSON-ish dump of text content.
+        lines.push(`<${m.role}>\n${extractText(m.content)}\n</${m.role}>`);
+      }
+    }
+  }
+  return lines.join('\n\n');
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const out: string[] = [];
+  for (const block of content) {
+    const b = block as {
+      type?: string;
+      text?: string;
+      name?: string;
+      arguments?: unknown;
+      thinking?: string;
+    };
+    if (b.type === 'text' && b.text) out.push(b.text);
+    else if (b.type === 'thinking' && b.thinking) out.push(`[thinking] ${b.thinking}`);
+    else if (b.type === 'toolCall')
+      out.push(`[tool-call ${b.name ?? '?'}] ${JSON.stringify(b.arguments ?? {})}`);
+    else if (b.type === 'image') out.push('[image]');
+  }
+  return out.join('\n');
+}
+
+const SUMMARY_INSTRUCTION = `Produce a structured context checkpoint summary of the conversation above that another LLM can use to continue the work.
+
+Use this EXACT format:
+
+## Goal
+[What is the user trying to accomplish? Can be multiple items if the session covers different tasks.]
+
+## Constraints & Preferences
+- [Any constraints, preferences, or requirements mentioned by user]
+- [Or "(none)" if none were mentioned]
+
+## Progress
+### Done
+- [x] [Completed tasks/changes]
+
+### In Progress
+- [ ] [Current work]
+
+### Blocked
+- [Issues preventing progress, if any]
+
+## Key Decisions
+- **[Decision]**: [Brief rationale]
+
+## Next Steps
+1. [Ordered list of what should happen next]
+
+## Critical Context
+- [Any data, examples, or references needed to continue]
+- [Or "(none)" if not applicable]
+
+Keep each section concise. Preserve exact file paths, function names, and error messages. Output ONLY the summary, with no preamble or follow-up.`;
+
+const MEMORY_INSTRUCTION = `From the conversation above, extract durable memories worth persisting to a global memory file shared across future sessions.
+
+Focus on:
+- User preferences, working style, opinions stated explicitly.
+- Stable project facts (architecture decisions, conventions, constraints).
+- Validated approaches the user accepted ("yes, exactly", "perfect"), not just corrections.
+- External resources/links the user named.
+
+DO NOT include:
+- Ephemeral state (current task, in-progress work).
+- Information already obvious from the codebase (file paths, function names, framework conventions).
+- Generic restatements of what the conversation was about.
+
+If nothing in the conversation is worth persisting, return exactly the single line:
+NONE
+
+Otherwise, output ONLY a markdown bullet list (one bullet per memory), no headers, no preamble, no follow-up. Each bullet is one line. Be specific. Prefer one fact per bullet over multi-clause sentences.`;
+
+/** Build a system prompt that embeds the conversation, identical across calls. */
+function buildSharedSystemPrompt(conversationText: string): string {
+  return `You are a context compaction assistant. You are shown the prefix of a conversation between a user and an AI coding assistant, and asked to produce either a structured summary, durable memory bullets, or a short title — depending on the user's instruction.
+
+Do NOT continue the conversation. Do NOT answer questions inside the conversation. Output ONLY what the user asks for in the format specified.
+
+<conversation>
+${conversationText}
+</conversation>`;
+}
+
+async function runCompactionCall(
+  model: Model<Api>,
+  apiKey: string,
+  systemPrompt: string,
+  userInstruction: string,
+  maxTokens: number,
+  headers: Record<string, string> | undefined,
+  signal: AbortSignal | undefined
+): Promise<string> {
+  const userMessage: UserMessage = {
+    role: 'user',
+    content: [{ type: 'text', text: userInstruction }],
+    timestamp: Date.now(),
+  };
+  const response = await completeSimple(
+    model,
+    { systemPrompt, messages: [userMessage] },
+    { maxTokens, apiKey, headers, signal }
+  );
+  if (response.stopReason === 'error') {
+    throw new Error(`Compaction call failed: ${response.errorMessage || 'Unknown error'}`);
+  }
+  return response.content
+    .filter((c) => c.type === 'text')
+    .map((c) => (c as { text: string }).text)
+    .join('\n')
+    .trim();
 }
 
 /**
@@ -90,9 +266,13 @@ export interface CompactionConfig {
  * The returned function:
  * 1. Checks if total tokens exceed (contextWindow - reserveTokens)
  * 2. If so, finds a cut point that keeps ~keepRecentTokens of recent messages
- * 3. Calls generateSummary() to produce a structured summary of older messages
- * 4. Replaces the older messages with a single summary user message
- * 5. Falls back to naive drop if the LLM call fails
+ * 3. Calls the LLM to summarize the older messages — conversation embedded in
+ *    the system prompt so a follow-up call can cache-hit the prefix.
+ * 4. Replaces the older messages with a single summary user message.
+ * 5. If `onMemoryUpdates` is configured, makes a second LLM call (same system
+ *    prompt, different instruction) to extract durable memories; this is
+ *    best-effort and never blocks compaction.
+ * 6. Falls back to naive drop if the summary call fails.
  */
 export function createCompactContext(
   config: CompactionConfig
@@ -160,11 +340,17 @@ export function createCompactContext(
     const apiKey = config.getApiKey();
     if (apiKey) {
       try {
-        const summary = await generateSummary(
-          messagesToSummarize,
+        const conversationText = serializeMessages(messagesToSummarize);
+        const systemPrompt = buildSharedSystemPrompt(conversationText);
+        // Summary uses ~80% of the reserve budget for output, mirroring the
+        // pi-coding-agent default.
+        const summaryMaxTokens = Math.floor(0.8 * reserveTokens);
+        const summary = await runCompactionCall(
           config.model,
-          reserveTokens,
           apiKey,
+          systemPrompt,
+          SUMMARY_INSTRUCTION,
+          summaryMaxTokens,
           config.headers,
           signal
         );
@@ -180,6 +366,40 @@ export function createCompactContext(
           compactedMessages: 1 + messagesToKeep.length,
           summaryLength: summary.length,
         });
+
+        // Best-effort memory extraction. Same system prompt → cache hit on
+        // the conversation block for Anthropic-style providers.
+        if (config.onMemoryUpdates) {
+          // Memory budget is much smaller — bullets, not a structured doc.
+          const memoryMaxTokens = 2048;
+          try {
+            const bullets = await runCompactionCall(
+              config.model,
+              apiKey,
+              systemPrompt,
+              MEMORY_INSTRUCTION,
+              memoryMaxTokens,
+              config.headers,
+              signal
+            );
+            if (bullets && bullets.trim() && bullets.trim() !== 'NONE') {
+              try {
+                await config.onMemoryUpdates(bullets.trim());
+                log.info('Memory extraction applied', { bulletsLength: bullets.length });
+              } catch (cbErr) {
+                log.warn('onMemoryUpdates callback threw', {
+                  error: cbErr instanceof Error ? cbErr.message : String(cbErr),
+                });
+              }
+            } else {
+              log.info('Memory extraction returned no durable memories');
+            }
+          } catch (memErr) {
+            log.warn('Memory extraction call failed (compaction still applied)', {
+              error: memErr instanceof Error ? memErr.message : String(memErr),
+            });
+          }
+        }
 
         return [summaryMessage, ...messagesToKeep];
       } catch (err) {
@@ -211,6 +431,40 @@ export function createCompactContext(
     return [compactedMsg, ...messagesToKeep];
   };
 }
+
+/**
+ * Build a shared system prompt and run a single user-instruction call against
+ * a serialized conversation. Used by the "New session" freezer to extract
+ * memories and produce a title over the live cone session — two calls that
+ * share this same system prompt for prefix-cache reuse.
+ *
+ * Returns the raw text response, or throws.
+ */
+export async function runOneOffCompactionCall(args: {
+  messages: AgentMessage[];
+  instruction: string;
+  model: Model<Api>;
+  apiKey: string;
+  maxTokens: number;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}): Promise<string> {
+  const conversationText = serializeMessages(args.messages);
+  const systemPrompt = buildSharedSystemPrompt(conversationText);
+  return runCompactionCall(
+    args.model,
+    args.apiKey,
+    systemPrompt,
+    args.instruction,
+    args.maxTokens,
+    args.headers,
+    args.signal
+  );
+}
+
+/** Instruction strings exported for reuse by the freezer flow. */
+export const COMPACTION_MEMORY_INSTRUCTION = MEMORY_INSTRUCTION;
+export const COMPACTION_TITLE_INSTRUCTION = `Generate a short title (3 to 6 words) summarizing what this conversation was about. Output ONLY the title text — no quotes, no punctuation other than what belongs in the title, no preamble.`;
 
 /**
  * Legacy compactContext — naive drop strategy without LLM summarization.

--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -97,7 +97,27 @@ export interface CompactionConfig {
    * not block compaction. When omitted, no memory call is made.
    */
   onMemoryUpdates?: (bullets: string) => Promise<void> | void;
+  /**
+   * Optional lifecycle hook for the UI. Fired around the compaction LLM
+   * calls so the chat panel can render a ghost-bubble affordance instead
+   * of leaving the user wondering why the agent is silent.
+   *
+   * Sequence on a typical compaction:
+   *   'summarizing'        → before the summary call
+   *   'extracting-memory'  → before the memory call (only when
+   *                          `onMemoryUpdates` is also wired)
+   *   'idle'               → in `finally`, always fires last
+   *
+   * No-op when omitted.
+   */
+  onCompactionStateChange?: (state: CompactionState) => void;
 }
+
+/**
+ * Phases of an in-flight compaction. `idle` is the resting state; the UI
+ * should clear any compaction-specific affordance when it sees it.
+ */
+export type CompactionState = 'summarizing' | 'extracting-memory' | 'idle';
 
 /**
  * Lightweight serializer that renders an AgentMessage array as a text block
@@ -336,6 +356,17 @@ export function createCompactContext(
       keeping: messagesToKeep.length,
     });
 
+    // Emit lifecycle hook safely — listener bugs must never abort compaction.
+    const emit = (state: CompactionState): void => {
+      try {
+        config.onCompactionStateChange?.(state);
+      } catch (e) {
+        log.warn('onCompactionStateChange listener threw', {
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    };
+
     // Attempt LLM-powered summarization
     const apiKey = config.getApiKey();
     if (apiKey) {
@@ -345,6 +376,7 @@ export function createCompactContext(
         // Summary uses ~80% of the reserve budget for output, mirroring the
         // pi-coding-agent default.
         const summaryMaxTokens = Math.floor(0.8 * reserveTokens);
+        emit('summarizing');
         const summary = await runCompactionCall(
           config.model,
           apiKey,
@@ -373,6 +405,7 @@ export function createCompactContext(
           // Memory budget is much smaller — bullets, not a structured doc.
           const memoryMaxTokens = 2048;
           try {
+            emit('extracting-memory');
             const bullets = await runCompactionCall(
               config.model,
               apiKey,
@@ -401,6 +434,7 @@ export function createCompactContext(
           }
         }
 
+        emit('idle');
         return [summaryMessage, ...messagesToKeep];
       } catch (err) {
         log.warn('LLM summarization failed, falling back to naive drop', {
@@ -410,6 +444,9 @@ export function createCompactContext(
     } else {
       log.warn('No API key available for LLM summarization, falling back to naive drop');
     }
+    // Always clear the indicator before returning — both the fallback path
+    // and any successful early-return must leave the UI in the resting state.
+    emit('idle');
 
     // Fallback: naive drop (same as old behavior but without eager truncation)
     const compactedMsg: UserMessage = {

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -138,6 +138,32 @@ export class VirtualFS {
   }
 
   /**
+   * Force the LightningFS superblock to commit to IndexedDB immediately.
+   *
+   * LightningFS debounces directory-metadata saves: a `mkdir` or `writeFile`
+   * that creates new inodes returns once the in-memory cache is updated,
+   * but the superblock IDB write is deferred. If the page is reloaded
+   * before the debounce timer fires, those new directories and files
+   * appear orphaned on next boot (their inode blocks are present but
+   * not linked from the root metadata).
+   *
+   * Call this before any operation that may kill the page (`location.reload`,
+   * navigation away, tab close) when newly-created paths must survive.
+   * No-op if the backend doesn't expose flush.
+   */
+  async flush(): Promise<void> {
+    const pfs = this.lfs as unknown as {
+      _backend?: { flush?: () => Promise<void>; saveSuperblock?: { cancel?: () => void } };
+    };
+    // Cancel the debounced saver — otherwise it might fire AFTER our flush,
+    // with stale superblock data captured at debounce-schedule time.
+    pfs._backend?.saveSuperblock?.cancel?.();
+    if (pfs._backend?.flush) {
+      await pfs._backend.flush();
+    }
+  }
+
+  /**
    * Writability predicate — the unrestricted VirtualFS has no ACL, so every
    * path is writable. Exists to mirror {@link RestrictedFS.canWrite} so
    * callers (e.g., the `agent` shell command) can duck-type across both

--- a/packages/webapp/src/kernel/types.ts
+++ b/packages/webapp/src/kernel/types.ts
@@ -191,7 +191,7 @@ export interface KernelClientFacade {
   // -------------------------------------------------------------------------
   updateModel(): void;
   setScoopThinkingLevel(jid: string, level: ThinkingLevel | undefined): void;
-  clearAllMessages(): Promise<void>;
+  clearAllMessages(opts?: { target?: 'cone' | 'all' }): Promise<void>;
   clearFilesystem(): void;
   requestState(): void;
   sendSprinkleLick(sprinkleName: string, body: unknown, targetScoop?: string): void;

--- a/packages/webapp/src/kernel/types.ts
+++ b/packages/webapp/src/kernel/types.ts
@@ -191,7 +191,13 @@ export interface KernelClientFacade {
   // -------------------------------------------------------------------------
   updateModel(): void;
   setScoopThinkingLevel(jid: string, level: ThinkingLevel | undefined): void;
-  clearAllMessages(opts?: { target?: 'cone' | 'all' }): Promise<void>;
+  /**
+   * Cone-only chat clear, used by the "New session" flow. Resolves only
+   * after the host has acknowledged the clear so the panel can safely
+   * `location.reload()` without racing the offscreen agent context (in
+   * extension mode the offscreen document survives the panel reload).
+   */
+  clearAllMessages(): Promise<void>;
   clearFilesystem(): void;
   requestState(): void;
   sendSprinkleLick(sprinkleName: string, body: unknown, targetScoop?: string): void;

--- a/packages/webapp/src/scoops/db.ts
+++ b/packages/webapp/src/scoops/db.ts
@@ -193,6 +193,32 @@ export async function clearAllMessages(): Promise<void> {
   });
 }
 
+/**
+ * Delete every persisted ChannelMessage for one chat jid. Used by the
+ * "New session" flow to wipe the cone's history from the agent DB —
+ * without this, `processScoopQueue` walks back over old `getMessagesSince`
+ * rows on the next prompt and re-injects pre-reset turns into the
+ * fresh session.
+ */
+export async function clearMessagesForScoop(chatJid: string): Promise<void> {
+  const store = await getStore(STORES.MESSAGES, 'readwrite');
+  const index = store.index('chatJid_timestamp');
+  const range = IDBKeyRange.bound([chatJid, ''], [chatJid, '￿'], false, false);
+  return new Promise((resolve, reject) => {
+    const req = index.openCursor(range);
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (!cursor) {
+        resolve();
+        return;
+      }
+      cursor.delete();
+      cursor.continue();
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
 export async function saveMessage(msg: ChannelMessage): Promise<void> {
   const store = await getStore(STORES.MESSAGES, 'readwrite');
   return new Promise((resolve, reject) => {

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -368,6 +368,29 @@ export class Orchestrator {
     log.info('Global memory updated');
   }
 
+  /**
+   * Append a block of auto-extracted memory bullets to /shared/CLAUDE.md.
+   * Used by the compaction memory-extraction pass and by the "New session"
+   * freezer flow.
+   *
+   * Inserts a dated heading so auto-extracted memories are attributable and
+   * easy to prune by hand. The `source` field is included in the heading
+   * (e.g., "compaction", "new-session") so the user can see why a block
+   * was added.
+   */
+  async appendGlobalMemory(bullets: string, meta: { source: string }): Promise<void> {
+    if (!this.sharedFs) return;
+    const trimmed = bullets.trim();
+    if (!trimmed) return;
+    const current = await this.getGlobalMemory();
+    const date = new Date().toISOString().slice(0, 10);
+    const heading = `## Auto-extracted (${date}, ${meta.source})`;
+    const separator = current.length === 0 || current.endsWith('\n') ? '' : '\n';
+    const block = `${separator}\n${heading}\n\n${trimmed}\n`;
+    await this.setGlobalMemory(current + block);
+    log.info('Global memory appended', { source: meta.source, length: trimmed.length });
+  }
+
   /** Get the shared VirtualFS */
   getSharedFS(): VirtualFS | null {
     return this.sharedFs;
@@ -1170,6 +1193,32 @@ export class Orchestrator {
     log.info('Filesystem reset and defaults re-seeded');
   }
 
+  /**
+   * Clear messages for a single scoop (live agent + persisted agent session
+   * + queued messages + timestamp tracking). Used by the "New session"
+   * flow to reset the cone while leaving every other scoop's runtime state
+   * untouched. The orchestrator-level `clearAllMessages` keeps its
+   * existing all-scoops semantics.
+   */
+  async clearScoopMessages(jid: string): Promise<void> {
+    const ctx = this.contexts.get(jid);
+    if (ctx) {
+      ctx.clearMessages();
+      if (this.sessionStore) {
+        const sessionId = ctx.getSessionId();
+        await this.sessionStore.delete(sessionId).catch((err) => {
+          log.warn('Failed to clear agent session for scoop', {
+            jid,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
+    }
+    this.lastAgentTimestamp.delete(jid);
+    this.messageQueues.set(jid, []);
+    log.info('Scoop messages cleared', { jid });
+  }
+
   /** Clear all messages from the orchestrator DB, agent sessions, and live agent contexts. */
   async clearAllMessages(): Promise<void> {
     await db.clearAllMessages();
@@ -1528,6 +1577,9 @@ export class Orchestrator {
         : undefined,
       getGlobalMemory: () => this.getGlobalMemory(),
       setGlobalMemory: scoop.isCone ? (content) => this.setGlobalMemory(content) : undefined,
+      appendGlobalMemory: scoop.isCone
+        ? (bullets, meta) => this.appendGlobalMemory(bullets, meta)
+        : undefined,
       getBrowserAPI: () => this.callbacks.getBrowserAPI(),
     };
 

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -1205,10 +1205,16 @@ export class Orchestrator {
 
   /**
    * Clear messages for a single scoop (live agent + persisted agent session
-   * + queued messages + timestamp tracking). Used by the "New session"
-   * flow to reset the cone while leaving every other scoop's runtime state
-   * untouched. The orchestrator-level `clearAllMessages` keeps its
-   * existing all-scoops semantics.
+   * + queued messages + timestamp tracking + per-scoop ChannelMessage
+   * history). Used by the "New session" flow to reset the cone while
+   * leaving every other scoop's runtime state untouched. The
+   * orchestrator-level `clearAllMessages` keeps its existing all-scoops
+   * semantics.
+   *
+   * The per-scoop channel-history wipe is load-bearing: without it,
+   * `processScoopQueue` calls `db.getMessagesSince(chatJid, '')` on the
+   * next prompt (because `lastAgentTimestamp` was just deleted) and
+   * replays every pre-reset turn back into the live agent.
    */
   async clearScoopMessages(jid: string): Promise<void> {
     const ctx = this.contexts.get(jid);
@@ -1224,6 +1230,12 @@ export class Orchestrator {
         });
       }
     }
+    await db.clearMessagesForScoop(jid).catch((err) => {
+      log.warn('Failed to clear persisted channel history for scoop', {
+        jid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
     this.lastAgentTimestamp.delete(jid);
     this.messageQueues.set(jid, []);
     log.info('Scoop messages cleared', { jid });

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -63,6 +63,16 @@ export interface OrchestratorCallbacks {
   onSendMessage: (targetJid: string, text: string) => void;
   /** Called when scoop status changes */
   onStatusChange: (scoopJid: string, status: ScoopTabState['status']) => void;
+  /**
+   * Called when the scoop's compaction pass enters / leaves a phase. The
+   * UI uses this to render a ghost-bubble affordance while the agent is
+   * silent during the summarize + memory-extract round-trips. `'idle'`
+   * clears the affordance.
+   */
+  onCompactionStateChange?: (
+    scoopJid: string,
+    state: 'summarizing' | 'extracting-memory' | 'idle'
+  ) => void;
   /** Called on error */
   onError: (scoopJid: string, error: string) => void;
   /** Get the BrowserAPI used by browser automation commands */
@@ -1528,6 +1538,9 @@ export class Orchestrator {
         if (status === 'ready' && !scoop.isCone) {
           void this.maybeNotifyConeOnScoopComplete(jid);
         }
+      },
+      onCompactionStateChange: (state) => {
+        this.callbacks.onCompactionStateChange?.(jid, state);
       },
       onToolStart: (toolName, toolInput) => {
         this.callbacks.onToolStart?.(jid, toolName, toolInput);

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -214,6 +214,13 @@ export interface ScoopContextCallbacks {
    * compaction pass skips its second LLM call entirely.
    */
   appendGlobalMemory?: (bullets: string, meta: { source: string }) => Promise<void>;
+  /**
+   * Optional lifecycle hook for compaction. Emitted by the compaction
+   * `transformContext` before and after each LLM call so the panel can
+   * render a ghost-bubble affordance while the agent is silent.
+   * `state === 'idle'` clears the affordance.
+   */
+  onCompactionStateChange?: (state: 'summarizing' | 'extracting-memory' | 'idle') => void;
   /** BrowserAPI provider for browser automation commands */
   getBrowserAPI: () => BrowserAPI;
 }
@@ -479,6 +486,7 @@ export class ScoopContext {
         getApiKey: () => getApiKey() ?? undefined,
         headers: compactionHeaders,
         onMemoryUpdates,
+        onCompactionStateChange: this.callbacks.onCompactionStateChange,
       });
 
       // Guard: dispose() may have run while init() was awaiting above.

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -208,6 +208,12 @@ export interface ScoopContextCallbacks {
   getGlobalMemory: () => Promise<string>;
   /** Update global CLAUDE.md (cone only) */
   setGlobalMemory?: (content: string) => Promise<void>;
+  /**
+   * Append auto-extracted memory bullets to /shared/CLAUDE.md (cone only).
+   * Called by the compaction memory-extraction pass. When omitted the
+   * compaction pass skips its second LLM call entirely.
+   */
+  appendGlobalMemory?: (bullets: string, meta: { source: string }) => Promise<void>;
   /** BrowserAPI provider for browser automation commands */
   getBrowserAPI: () => BrowserAPI;
 }
@@ -460,10 +466,19 @@ export class ScoopContext {
       // join the same session as the agent's tool turns.
       const compactionHeaders =
         model.provider === 'adobe' ? { 'X-Session-Id': adobeSessionId } : undefined;
+      // Auto-extracted memory is cone-only — scoops keep their own local
+      // memory files curated by the user. Wiring the callback only for the
+      // cone also skips the second compaction LLM call entirely for scoops.
+      const onMemoryUpdates =
+        this.scoop.isCone && this.callbacks.appendGlobalMemory
+          ? (bullets: string) =>
+              this.callbacks.appendGlobalMemory!(bullets, { source: 'compaction' })
+          : undefined;
       const compactFn = createCompactContext({
         model,
         getApiKey: () => getApiKey() ?? undefined,
         headers: compactionHeaders,
+        onMemoryUpdates,
       });
 
       // Guard: dispose() may have run while init() was awaiting above.

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -244,6 +244,15 @@ export class ChatPanel {
    */
   private drafts = new Map<string, Array<DraftDipInstance | null>>();
   public onDipLick?: (action: string, data: unknown) => void;
+  /**
+   * Fired whenever the displayed message list changes (new message,
+   * streaming update, switch to a new context). The estimated token
+   * count is a coarse chars/4 heuristic over message content + tool
+   * call JSON — same family of estimate the compaction pass uses,
+   * accurate enough to drive UI affordances like the "context getting
+   * full" glow on the New Session button.
+   */
+  public onMessagesChanged?: (estimatedTokens: number) => void;
   private modelSelectorEl!: HTMLElement;
   public onModelChange?: (modelId: string) => void;
   private thinkingBtn!: HTMLButtonElement;
@@ -382,6 +391,36 @@ export class ChatPanel {
   }
 
   /** Switch to a different scoop's chat context. */
+  /**
+   * Render a frozen-session archive as a read-only chat view. Bypasses
+   * `SessionStore` (the archive lives on the VFS, not in IndexedDB) and
+   * does NOT persist on the way out — the contextId is namespaced so a
+   * subsequent `persistSessionAsync()` would no-op rather than poison
+   * the live cone session.
+   */
+  async displayFrozenSession(opts: {
+    /** Unique id for this view; prefixed with `frozen:` so it can't collide with a real session. */
+    contextId: string;
+    /** Pre-parsed messages from the archive. */
+    messages: ChatMessage[];
+    /** Title to show in the thread header. */
+    title: string;
+  }): Promise<void> {
+    await this.persistSessionAsync();
+    this.setStreamingState(false);
+    this.currentStreamId = null;
+    this.cancelPendingDelta();
+    this.resetEphemeralLlmState();
+    if (this.textarea) this.textarea.placeholder = ChatPanel.DEFAULT_PLACEHOLDER;
+    this.sessionId = opts.contextId;
+    // The current-scoop label is a free-form string in this code path —
+    // re-use it as a "frozen indicator" so the thread header reads naturally.
+    this.currentScoopName = `❄ ${opts.title}`;
+    this.setReadOnly(true);
+    this.messages = opts.messages.map((m) => ({ ...m, isStreaming: false }));
+    this.renderMessages();
+  }
+
   async switchToContext(contextId: string, readOnly: boolean, scoopName?: string): Promise<void> {
     // Save current session first
     await this.persistSessionAsync();
@@ -2155,6 +2194,42 @@ export class ChatPanel {
     this.autoScrollAttached = true;
     this.hideJumpPill();
     this.scrollToBottom(true);
+    this.notifyMessagesChanged();
+  }
+
+  /**
+   * Rough chars/4 estimator over the current message list. Same family
+   * of heuristic the compaction pass uses (pi-coding-agent's
+   * `estimateTokens`), just over the UI's `ChatMessage` shape rather
+   * than the structured `AgentMessage`. Folds tool-call I/O into the
+   * count so long tool-result transcripts move the gauge appropriately.
+   */
+  private estimateChatTokens(): number {
+    let chars = 0;
+    for (const m of this.messages) {
+      chars += m.content?.length ?? 0;
+      if (m.toolCalls) {
+        for (const tc of m.toolCalls) {
+          chars += tc.name.length;
+          try {
+            chars += JSON.stringify(tc.input ?? {}).length;
+          } catch {
+            /* circular / non-serializable — ignore */
+          }
+          if (tc.result) chars += tc.result.length;
+        }
+      }
+    }
+    return Math.ceil(chars / 4);
+  }
+
+  private notifyMessagesChanged(): void {
+    if (!this.onMessagesChanged) return;
+    try {
+      this.onMessagesChanged(this.estimateChatTokens());
+    } catch {
+      /* listener bug must not break rendering */
+    }
   }
 
   private appendMessageEl(msg: ChatMessage): void {
@@ -2182,6 +2257,7 @@ export class ChatPanel {
       this.reflowToolClusters();
     }
     this.scrollToBottom();
+    this.notifyMessagesChanged();
   }
 
   /** Determine whether to show the sender label for a message */

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -642,6 +642,65 @@ export class ChatPanel {
     this.renderModelSelector();
   }
 
+  /**
+   * Toggle the in-flight compaction ghost bubble. Called by the kernel
+   * client when the active scoop's compaction transformer enters or
+   * leaves a phase. The bubble lives outside `this.messages` (it's not
+   * a persisted ChatMessage) — it's a sibling `.msg-group--ghost` node
+   * appended to the messages container that we tear down on idle.
+   *
+   * `'idle'` removes the bubble. The other states show different
+   * labels so the user knows whether we're crunching the conversation
+   * (summarizing) or persisting learnings (extracting-memory).
+   */
+  setCompactionState(state: 'summarizing' | 'extracting-memory' | 'idle'): void {
+    const existing = this.messagesInner?.querySelector(':scope > .msg-group--compaction');
+    if (state === 'idle') {
+      existing?.remove();
+      return;
+    }
+    const label =
+      state === 'extracting-memory'
+        ? 'Saving memories from this session…'
+        : 'Compacting earlier messages to save context…';
+    if (existing) {
+      const labelEl = existing.querySelector('.msg-group--compaction__label');
+      if (labelEl) labelEl.textContent = label;
+      return;
+    }
+    const ghost = this.createCompactionGhostBubble(label);
+    this.messagesInner.appendChild(ghost);
+    this.scrollToBottom();
+  }
+
+  /**
+   * Build the ghost-bubble DOM. Lucide `archive` icon (a box with a
+   * slot, suggesting "filing away") + animated dots after the label so
+   * the bubble visibly pulses while the LLM call is in flight.
+   */
+  private createCompactionGhostBubble(label: string): HTMLElement {
+    const group = document.createElement('div');
+    group.className = 'msg-group msg-group--compaction';
+    const bubble = document.createElement('div');
+    bubble.className = 'msg-group--compaction__bubble';
+    // Lucide `archive` — keep paths inline so we don't have to load the
+    // sprite bundle for one icon.
+    bubble.innerHTML =
+      '<svg class="msg-group--compaction__icon" xmlns="http://www.w3.org/2000/svg" ' +
+      'width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+      'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<rect width="20" height="5" x="2" y="3" rx="1"/>' +
+      '<path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/>' +
+      '<path d="M10 12h4"/>' +
+      '</svg>' +
+      '<span class="msg-group--compaction__label"></span>' +
+      '<span class="msg-group--compaction__dots" aria-hidden="true"><span></span><span></span><span></span></span>';
+    const labelEl = bubble.querySelector('.msg-group--compaction__label');
+    if (labelEl) labelEl.textContent = label;
+    group.appendChild(bubble);
+    return group;
+  }
+
   /** Clear all messages from the display (doesn't affect session store). */
   clear(): void {
     this.messages = [];

--- a/packages/webapp/src/ui/file-browser-panel.ts
+++ b/packages/webapp/src/ui/file-browser-panel.ts
@@ -116,32 +116,6 @@ export class FileBrowserPanel {
     this.refreshTimer = setInterval(() => this.refresh(), 3000);
   }
 
-  /**
-   * Expand every ancestor directory of `path` so a deeply-nested file is
-   * visible after a programmatic reveal. Always includes the root.
-   */
-  private expandAncestors(path: string): void {
-    this.expandedDirs.add('/');
-    const parts = path.split('/').filter(Boolean);
-    let cursor = '';
-    // Last segment is the file itself; we only expand the directories.
-    for (let i = 0; i < parts.length - 1; i++) {
-      cursor += `/${parts[i]}`;
-      this.expandedDirs.add(cursor);
-    }
-  }
-
-  /**
-   * Reveal a file in the tree: expand its parent directories, mark it as
-   * selected, and refresh. Used by the frozen-sessions sidebar to jump
-   * to an archive JSON.
-   */
-  async revealPath(path: string): Promise<void> {
-    this.expandAncestors(path);
-    this.selectedPath = path;
-    await this.refresh();
-  }
-
   /** Re-read the VFS and update the tree display (only if content changed). */
   async refresh(): Promise<void> {
     if (!this.fs) return;

--- a/packages/webapp/src/ui/file-browser-panel.ts
+++ b/packages/webapp/src/ui/file-browser-panel.ts
@@ -116,6 +116,32 @@ export class FileBrowserPanel {
     this.refreshTimer = setInterval(() => this.refresh(), 3000);
   }
 
+  /**
+   * Expand every ancestor directory of `path` so a deeply-nested file is
+   * visible after a programmatic reveal. Always includes the root.
+   */
+  private expandAncestors(path: string): void {
+    this.expandedDirs.add('/');
+    const parts = path.split('/').filter(Boolean);
+    let cursor = '';
+    // Last segment is the file itself; we only expand the directories.
+    for (let i = 0; i < parts.length - 1; i++) {
+      cursor += `/${parts[i]}`;
+      this.expandedDirs.add(cursor);
+    }
+  }
+
+  /**
+   * Reveal a file in the tree: expand its parent directories, mark it as
+   * selected, and refresh. Used by the frozen-sessions sidebar to jump
+   * to an archive JSON.
+   */
+  async revealPath(path: string): Promise<void> {
+    this.expandAncestors(path);
+    this.selectedPath = path;
+    await this.refresh();
+  }
+
   /** Re-read the VFS and update the tree display (only if content changed). */
   async refresh(): Promise<void> {
     if (!this.fs) return;

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -25,6 +25,7 @@ import { TerminalPanel } from './terminal-panel.js';
 import { FileBrowserPanel } from './file-browser-panel.js';
 import { MemoryPanel } from './memory-panel.js';
 import { ScoopsPanel } from './scoops-panel.js';
+import type { FrozenSessionIndexEntry } from './session-freezer.js';
 import { ScoopSwitcher } from './scoop-switcher.js';
 import { attachLongPressGesture } from './long-press.js';
 import {
@@ -86,6 +87,8 @@ export class Layout {
   // Thread header (sub-header with scoop name)
   private threadHeaderEl!: HTMLElement;
   private threadHeaderName!: HTMLElement;
+  /** Thread-header "New session" button — populated by `setupChatHeader`. */
+  private newSessionBtn: HTMLButtonElement | null = null;
 
   // Right side — always-visible vertical icon rail + collapsible
   // content panel beside it. Replaces the old horizontal mini-tabs.
@@ -151,10 +154,11 @@ export class Layout {
   public onClearFilesystem?: () => Promise<void>;
   /**
    * Fired when the user clicks an entry in the frozen-sessions sidebar
-   * section. Receives the VFS path of the archive JSON. Standalone-only;
-   * the extension build skips this section entirely.
+   * section. Receives the full index entry; the standalone wiring reads
+   * the archive markdown and displays it in the chat panel read-only.
+   * Standalone-only — the extension build hides the rail entirely.
    */
-  public onFrozenSessionOpen?: (vfsPath: string) => void;
+  public onFrozenSessionOpen?: (entry: FrozenSessionIndexEntry) => void;
   public onSprinkleClose?: (name: string) => void;
   /**
    * Fired when the user clicks a sprinkle's rail icon. Lets the
@@ -216,6 +220,37 @@ export class Layout {
    * content and the rest are rail items, so we collapse the rail for
    * `chat` and activate the matching rail item otherwise.
    */
+  /**
+   * Toggle the "context getting full" glow on the New Session button.
+   * Receives the current context-fill ratio (estimated tokens divided
+   * by the active model's context window). Two-tier visual:
+   *
+   *   - ≥ 0.5  → soft glow (`glow`)        — "consider freezing"
+   *   - ≥ 0.85 → strong glow (`glow--hot`) — "compaction is imminent"
+   *
+   * Below 0.5 the button is plain. No-op when the button hasn't been
+   * mounted (extension mode hides the thread-header entry).
+   */
+  /**
+   * Set the thread-header title text. Used by frozen-session display
+   * (so the header reads "❄ <archive title>") without going through
+   * the scoop-select code path. No-op in extension mode where the
+   * header is a detached node.
+   */
+  setThreadHeaderName(text: string): void {
+    if (this.threadHeaderName && this.threadHeaderName.isConnected) {
+      this.threadHeaderName.textContent = text;
+    }
+  }
+
+  setNewSessionGlow(ratio: number): void {
+    if (!this.newSessionBtn) return;
+    const hot = ratio >= 0.85;
+    const warm = ratio >= 0.5;
+    this.newSessionBtn.classList.toggle('glow', warm);
+    this.newSessionBtn.classList.toggle('glow--hot', hot);
+  }
+
   setActiveTab(id: TabId): void {
     this.activeTab = id;
     if (id === 'chat') {
@@ -870,9 +905,17 @@ export class Layout {
     // Clear chat button — the rail now owns panel toggling, so the
     // chat header drops the panel-toggle button entirely.
     const clearChatBtn = document.createElement('button');
-    clearChatBtn.className = 'thread-header__panel-toggle';
-    clearChatBtn.dataset.tooltip = 'New session · hold to discard';
-    clearChatBtn.setAttribute('aria-label', 'New session — hold to discard without freezing');
+    clearChatBtn.className = 'thread-header__panel-toggle thread-header__new-session';
+    // Long, explanatory tooltip — the action is non-obvious enough that
+    // a 1-word label would mislead users into thinking it's a destructive
+    // "clear" button. Long-press is the only secondary affordance.
+    clearChatBtn.dataset.tooltip =
+      'New session for faster responses — history and memories will be kept. Long press to discard this session without saving memory.';
+    clearChatBtn.setAttribute(
+      'aria-label',
+      'New session — keeps memory and history. Hold to discard without saving memory.'
+    );
+    this.newSessionBtn = clearChatBtn;
     // "Compose new" — square with a pencil, matches the universal
     // "start a new thread" pattern (Slack, Discord, modern chat apps).
     clearChatBtn.innerHTML =

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -26,6 +26,7 @@ import { FileBrowserPanel } from './file-browser-panel.js';
 import { MemoryPanel } from './memory-panel.js';
 import { ScoopsPanel } from './scoops-panel.js';
 import { ScoopSwitcher } from './scoop-switcher.js';
+import { attachLongPressGesture } from './long-press.js';
 import {
   getApiKey,
   clearAllSettings,
@@ -140,7 +141,13 @@ export class Layout {
    */
   public onModelsRefreshed?: () => void;
   public onScoopSelect?: (scoop: RegisteredScoop) => void;
-  public onClearChat?: () => Promise<void>;
+  /**
+   * Fired by the "New session" button. When `freeze` is true (default), the
+   * handler archives the cone session before clearing. The long-press
+   * gesture passes `freeze: false` to discard the conversation without
+   * adding it to /sessions/.
+   */
+  public onClearChat?: (opts?: { freeze?: boolean }) => Promise<void>;
   public onClearFilesystem?: () => Promise<void>;
   /**
    * Fired when the user clicks an entry in the frozen-sessions sidebar
@@ -742,7 +749,7 @@ export class Layout {
       // (the normal case) it handles the cone clear itself; only fall back
       // to clearing the panel-local view if no handler is registered.
       if (this.onClearChat) {
-        await this.onClearChat();
+        await this.onClearChat({ freeze: true });
       } else {
         await this.panels?.chat?.clearSession();
       }
@@ -864,21 +871,27 @@ export class Layout {
     // chat header drops the panel-toggle button entirely.
     const clearChatBtn = document.createElement('button');
     clearChatBtn.className = 'thread-header__panel-toggle';
-    clearChatBtn.dataset.tooltip = 'New session';
-    clearChatBtn.setAttribute('aria-label', 'New session');
+    clearChatBtn.dataset.tooltip = 'New session · hold to discard';
+    clearChatBtn.setAttribute('aria-label', 'New session — hold to discard without freezing');
+    // "Compose new" — square with a pencil, matches the universal
+    // "start a new thread" pattern (Slack, Discord, modern chat apps).
     clearChatBtn.innerHTML =
-      '<svg width="16" height="16" viewBox="0 0 20 20" fill="none"><path d="m8.249,15.021c-.4,0-.733-.317-.748-.72l-.25-6.5c-.017-.414.307-.763.72-.778.01-.001.021-.001.03-.001.4,0,.733.317.748.72l.25,6.5c.017.414-.307.763-.72.778-.01.001-.021.001-.03.001Z" fill="currentColor"/><path d="m11.751,15.021c-.01,0-.02,0-.03-.001-.413-.016-.736-.364-.72-.778l.25-6.5c.015-.403.348-.72.748-.72.01,0,.02,0,.03.001.413.016.736.364.72.778l-.25,6.5c-.015.403-.348.72-.748.72Z" fill="currentColor"/><path d="m17,4h-3.5v-.75c0-1.24-1.01-2.25-2.25-2.25h-2.5c-1.24,0-2.25,1.01-2.25,2.25v.75h-3.5c-.414,0-.75.336-.75.75s.336.75.75.75h.52l.422,10.342c.048,1.21,1.036,2.158,2.248,2.158h7.619c1.212,0,2.2-.948,2.248-2.158l.422-10.342h.52c.414,0,.75-.336.75-.75s-.336-.75-.75-.75Zm-9-.75c0-.413.337-.75.75-.75h2.5c.413,0,.75.337.75.75v.75h-4v-.75Zm6.56,12.531c-.017.403-.346.719-.75.719h-7.619c-.404,0-.733-.316-.75-.719l-.42-10.281h9.959l-.42,10.281Z" fill="currentColor"/></svg>';
-    clearChatBtn.addEventListener('click', async () => {
-      // Same freezer contract as the avatar-popover entry: when onClearChat
-      // is wired it handles the cone clear (after running the freezer). We
-      // only fall back to the panel-local clearSession when no handler is
-      // registered, so the freezer is never starved of the message list.
+      '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+      '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>' +
+      '<path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/>' +
+      '</svg>';
+    const runNewSession = async (opts?: { freeze?: boolean }) => {
       if (this.onClearChat) {
-        await this.onClearChat();
+        await this.onClearChat(opts);
       } else {
         await this.panels.chat.clearSession();
       }
       location.reload();
+    };
+    // Short click → freeze + clear. Long press / modifier-click → discard.
+    attachLongPressGesture(clearChatBtn, {
+      onShortClick: () => void runNewSession({ freeze: true }),
+      onLongPress: () => void runNewSession({ freeze: false }),
     });
 
     const threadActions = document.createElement('div');

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -142,6 +142,12 @@ export class Layout {
   public onScoopSelect?: (scoop: RegisteredScoop) => void;
   public onClearChat?: () => Promise<void>;
   public onClearFilesystem?: () => Promise<void>;
+  /**
+   * Fired when the user clicks an entry in the frozen-sessions sidebar
+   * section. Receives the VFS path of the archive JSON. Standalone-only;
+   * the extension build skips this section entirely.
+   */
+  public onFrozenSessionOpen?: (vfsPath: string) => void;
   public onSprinkleClose?: (name: string) => void;
   /**
    * Fired when the user clicks a sprinkle's rail icon. Lets the
@@ -726,12 +732,20 @@ export class Layout {
     popover.appendChild(sepChat);
 
     const clearChatBtn = document.createElement('button');
-    clearChatBtn.className = 'avatar-popover__item avatar-popover__item--danger';
-    clearChatBtn.textContent = 'Clear chat';
+    clearChatBtn.className = 'avatar-popover__item';
+    clearChatBtn.textContent = 'New session';
     clearChatBtn.addEventListener('click', async () => {
       popover.remove();
-      await this.panels?.chat?.clearSession();
-      await this.onClearChat?.();
+      // The freezer runs inside onClearChat and reads the cone's session
+      // from IndexedDB. We must NOT delete the panel's session before that
+      // happens (the freezer would see nothing). When onClearChat is wired
+      // (the normal case) it handles the cone clear itself; only fall back
+      // to clearing the panel-local view if no handler is registered.
+      if (this.onClearChat) {
+        await this.onClearChat();
+      } else {
+        await this.panels?.chat?.clearSession();
+      }
       location.reload();
     });
     popover.appendChild(clearChatBtn);
@@ -850,13 +864,20 @@ export class Layout {
     // chat header drops the panel-toggle button entirely.
     const clearChatBtn = document.createElement('button');
     clearChatBtn.className = 'thread-header__panel-toggle';
-    clearChatBtn.dataset.tooltip = 'Clear Chat';
-    clearChatBtn.setAttribute('aria-label', 'Clear Chat');
+    clearChatBtn.dataset.tooltip = 'New session';
+    clearChatBtn.setAttribute('aria-label', 'New session');
     clearChatBtn.innerHTML =
       '<svg width="16" height="16" viewBox="0 0 20 20" fill="none"><path d="m8.249,15.021c-.4,0-.733-.317-.748-.72l-.25-6.5c-.017-.414.307-.763.72-.778.01-.001.021-.001.03-.001.4,0,.733.317.748.72l.25,6.5c.017.414-.307.763-.72.778-.01.001-.021.001-.03.001Z" fill="currentColor"/><path d="m11.751,15.021c-.01,0-.02,0-.03-.001-.413-.016-.736-.364-.72-.778l.25-6.5c.015-.403.348-.72.748-.72.01,0,.02,0,.03.001.413.016.736.364.72.778l-.25,6.5c-.015.403-.348.72-.748.72Z" fill="currentColor"/><path d="m17,4h-3.5v-.75c0-1.24-1.01-2.25-2.25-2.25h-2.5c-1.24,0-2.25,1.01-2.25,2.25v.75h-3.5c-.414,0-.75.336-.75.75s.336.75.75.75h.52l.422,10.342c.048,1.21,1.036,2.158,2.248,2.158h7.619c1.212,0,2.2-.948,2.248-2.158l.422-10.342h.52c.414,0,.75-.336.75-.75s-.336-.75-.75-.75Zm-9-.75c0-.413.337-.75.75-.75h2.5c.413,0,.75.337.75.75v.75h-4v-.75Zm6.56,12.531c-.017.403-.346.719-.75.719h-7.619c-.404,0-.733-.316-.75-.719l-.42-10.281h9.959l-.42,10.281Z" fill="currentColor"/></svg>';
     clearChatBtn.addEventListener('click', async () => {
-      await this.panels.chat.clearSession();
-      await this.onClearChat?.();
+      // Same freezer contract as the avatar-popover entry: when onClearChat
+      // is wired it handles the cone clear (after running the freezer). We
+      // only fall back to the panel-local clearSession when no handler is
+      // registered, so the freezer is never starved of the message list.
+      if (this.onClearChat) {
+        await this.onClearChat();
+      } else {
+        await this.panels.chat.clearSession();
+      }
       location.reload();
     });
 
@@ -1025,6 +1046,7 @@ export class Layout {
         },
         onSendMessage: () => {},
         onScoopsChanged: (scoops) => this.updateLogoScoops(scoops),
+        onFrozenSessionOpen: (vfsPath) => this.onFrozenSessionOpen?.(vfsPath),
       }),
     };
 

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -48,6 +48,7 @@ import { createAttachmentTmpWriter } from './attachment-vfs.js';
 import { registerProviders } from '../providers/index.js';
 import { flushCredentialsToWorker, resolveDefaultModel } from './onboarding-helpers.js';
 import { runNewSessionFreeze } from './new-session.js';
+import { frozenSessionPath, parseFrozenArchive } from './session-freezer.js';
 import { BrowserAPI, NavigationWatcher } from '../cdp/index.js';
 import { type Orchestrator } from '../scoops/index.js';
 import { publishAgentBridge } from '../scoops/agent-bridge.js';
@@ -1788,12 +1789,47 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
 
   // Frozen sessions sidebar (standalone only). The panel reads
   // /sessions/index.json from the page-side VFS that already shares
-  // IndexedDB with the worker. Clicking an entry switches to the Files
-  // tab and reveals the archive markdown file.
+  // IndexedDB with the worker. Clicking an entry reads the archive
+  // markdown, parses it back into messages, and displays it in the
+  // chat panel read-only — matching the affordance of clicking a
+  // live scoop (which also opens the chat view rather than a file).
   layout.panels.scoops.setVfs(localFs);
-  layout.onFrozenSessionOpen = (vfsPath) => {
-    layout.setActiveTab('files');
-    void layout.panels.fileBrowser.revealPath(vfsPath);
+  layout.onFrozenSessionOpen = (entry) => {
+    void (async () => {
+      try {
+        const raw = await localFs.readFile(frozenSessionPath(entry), { encoding: 'utf-8' });
+        const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+        const parsed = parseFrozenArchive(text);
+        const title = parsed.title || entry.title;
+        await layout.panels.chat.displayFrozenSession({
+          contextId: `frozen:${entry.filename}`,
+          messages: parsed.messages,
+          title,
+        });
+        layout.setThreadHeaderName(`❄ ${title}`);
+        layout.setActiveTab('chat');
+      } catch (err) {
+        log.warn('Failed to open frozen session', {
+          filename: entry.filename,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+  };
+
+  // Glow the New Session button as the live cone session grows past
+  // half the active model's context window. Coarse chars/4 estimate
+  // is enough — the goal is an affordance, not a billing meter.
+  layout.panels.chat.onMessagesChanged = (estimatedTokens) => {
+    let contextWindow = 200000;
+    try {
+      const model = resolveCurrentModel();
+      contextWindow = model.contextWindow ?? contextWindow;
+    } catch {
+      /* no active model — keep the default and the gauge stays cold */
+    }
+    const ratio = estimatedTokens / contextWindow;
+    layout.setNewSessionGlow(ratio);
   };
 
   // Wire chat agent handle. The handle's `sendMessage` posts a

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -898,9 +898,9 @@ async function mainExtension(app: HTMLElement): Promise<void> {
       log.info('New session: freezer skipped (long-press)');
     }
     await layout.panels.chat.deleteSessionById('session-cone');
-    // Bridge-side cone-only clear. The legacy clearAllMessages remains as a
-    // fallback inside the bridge for future "Reset everything" flows.
-    client.clearAllMessages({ target: 'cone' });
+    // Bridge-side cone-only clear. Awaits the bridge's ack so we don't
+    // reload while the offscreen agent context is still running.
+    await client.clearAllMessages();
   };
 
   layout.onClearFilesystem = async () => {
@@ -1807,7 +1807,7 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
       log.info('New session: freezer skipped (long-press)');
     }
     await layout.panels.chat.deleteSessionById('session-cone');
-    await client.clearAllMessages({ target: 'cone' });
+    await client.clearAllMessages();
   };
 
   // Frozen sessions sidebar (standalone only). The panel reads

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -867,12 +867,17 @@ async function mainExtension(app: HTMLElement): Promise<void> {
   // Wire "New session" — freeze the cone's chat to /sessions/ via the
   // freezer (memory extraction + title), then delete ONLY the cone session
   // from IndexedDB. Scoops survive intentionally so the fresh cone inherits
-  // the existing scoop roster.
-  layout.onClearChat = async () => {
-    try {
-      await runNewSessionFreeze({ vfs: localFs });
-    } catch (err) {
-      log.warn('Freezer step failed (clearing anyway)', { error: String(err) });
+  // the existing scoop roster. Long-press passes `freeze: false` to discard
+  // the conversation without archiving it.
+  layout.onClearChat = async (opts) => {
+    if (opts?.freeze !== false) {
+      try {
+        await runNewSessionFreeze({ vfs: localFs });
+      } catch (err) {
+        log.warn('Freezer step failed (clearing anyway)', { error: String(err) });
+      }
+    } else {
+      log.info('New session: freezer skipped (long-press)');
     }
     await layout.panels.chat.deleteSessionById('session-cone');
     // Bridge-side cone-only clear. The legacy clearAllMessages remains as a
@@ -1755,15 +1760,27 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
     if (selectedScoop) syncThinkingButtonForScoop(selectedScoop);
   };
 
+  // Wire local VFS to client so the memory panel (which reads
+  // /shared/CLAUDE.md via `client.getGlobalMemory()`) sees the actual
+  // file system. Without this the panel reads empty in standalone-worker
+  // mode — only the extension path was calling setLocalFS before.
+  client.setLocalFS(localFs);
+
   // Wire "New session" — freeze the cone's chat to /sessions/ via the
   // freezer (memory extraction + title), then clear ONLY the cone
   // session via the kernel client. Scoops survive intentionally so the
-  // fresh cone inherits the existing scoop roster.
-  layout.onClearChat = async () => {
-    try {
-      await runNewSessionFreeze({ vfs: localFs });
-    } catch (err) {
-      log.warn('Freezer step failed (clearing anyway)', { error: String(err) });
+  // fresh cone inherits the existing scoop roster. When `opts.freeze`
+  // is false (long-press on the new-session button) the freezer is
+  // skipped entirely — useful when the user explicitly wants to discard.
+  layout.onClearChat = async (opts) => {
+    if (opts?.freeze !== false) {
+      try {
+        await runNewSessionFreeze({ vfs: localFs });
+      } catch (err) {
+        log.warn('Freezer step failed (clearing anyway)', { error: String(err) });
+      }
+    } else {
+      log.info('New session: freezer skipped (long-press)');
     }
     await layout.panels.chat.deleteSessionById('session-cone');
     await client.clearAllMessages({ target: 'cone' });
@@ -1772,7 +1789,7 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
   // Frozen sessions sidebar (standalone only). The panel reads
   // /sessions/index.json from the page-side VFS that already shares
   // IndexedDB with the worker. Clicking an entry switches to the Files
-  // tab and reveals the archive JSON.
+  // tab and reveals the archive markdown file.
   layout.panels.scoops.setVfs(localFs);
   layout.onFrozenSessionOpen = (vfsPath) => {
     layout.setActiveTab('files');

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -47,6 +47,7 @@ import { createAttachmentTmpWriter } from './attachment-vfs.js';
 // — the extension agent engine runs in the offscreen document, not in this file.
 import { registerProviders } from '../providers/index.js';
 import { flushCredentialsToWorker, resolveDefaultModel } from './onboarding-helpers.js';
+import { runNewSessionFreeze } from './new-session.js';
 import { BrowserAPI, NavigationWatcher } from '../cdp/index.js';
 import { type Orchestrator } from '../scoops/index.js';
 import { publishAgentBridge } from '../scoops/agent-bridge.js';
@@ -863,16 +864,20 @@ async function mainExtension(app: HTMLElement): Promise<void> {
     if (selectedScoop) syncThinkingButtonForExtensionScoop(selectedScoop);
   };
 
-  // Wire clear chat — delete all scoop sessions from the shared IndexedDB
-  // synchronously (from the panel's perspective) before the reload happens.
-  // The bridge also clears its in-memory buffers via the clear-chat message.
+  // Wire "New session" — freeze the cone's chat to /sessions/ via the
+  // freezer (memory extraction + title), then delete ONLY the cone session
+  // from IndexedDB. Scoops survive intentionally so the fresh cone inherits
+  // the existing scoop roster.
   layout.onClearChat = async () => {
-    const scoops = client.getScoops();
-    for (const scoop of scoops) {
-      const sessionId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
-      await layout.panels.chat.deleteSessionById(sessionId);
+    try {
+      await runNewSessionFreeze({ vfs: localFs });
+    } catch (err) {
+      log.warn('Freezer step failed (clearing anyway)', { error: String(err) });
     }
-    client.clearAllMessages();
+    await layout.panels.chat.deleteSessionById('session-cone');
+    // Bridge-side cone-only clear. The legacy clearAllMessages remains as a
+    // fallback inside the bridge for future "Reset everything" flows.
+    client.clearAllMessages({ target: 'cone' });
   };
 
   layout.onClearFilesystem = async () => {
@@ -1748,6 +1753,30 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
   };
   layout.onModelsRefreshed = () => {
     if (selectedScoop) syncThinkingButtonForScoop(selectedScoop);
+  };
+
+  // Wire "New session" — freeze the cone's chat to /sessions/ via the
+  // freezer (memory extraction + title), then clear ONLY the cone
+  // session via the kernel client. Scoops survive intentionally so the
+  // fresh cone inherits the existing scoop roster.
+  layout.onClearChat = async () => {
+    try {
+      await runNewSessionFreeze({ vfs: localFs });
+    } catch (err) {
+      log.warn('Freezer step failed (clearing anyway)', { error: String(err) });
+    }
+    await layout.panels.chat.deleteSessionById('session-cone');
+    await client.clearAllMessages({ target: 'cone' });
+  };
+
+  // Frozen sessions sidebar (standalone only). The panel reads
+  // /sessions/index.json from the page-side VFS that already shares
+  // IndexedDB with the worker. Clicking an entry switches to the Files
+  // tab and reveals the archive JSON.
+  layout.panels.scoops.setVfs(localFs);
+  layout.onFrozenSessionOpen = (vfsPath) => {
+    layout.setActiveTab('files');
+    void layout.panels.fileBrowser.revealPath(vfsPath);
   };
 
   // Wire chat agent handle. The handle's `sendMessage` posts a

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -225,12 +225,22 @@ function isUIFixtureRequested(): boolean {
 async function loadUIFixtureIntoChat(chatPanel: {
   switchToContext: (id: string, readOnly: boolean, scoopName?: string) => Promise<void>;
   loadMessages: (msgs: ChatMessage[]) => void;
+  setCompactionState?: (state: 'summarizing' | 'extracting-memory' | 'idle') => void;
 }): Promise<void> {
   const [{ createChatFixture, FIXTURE_SESSION_ID, FIXTURE_SCOOP_NAME }] = await Promise.all([
     import('./chat-fixture.js'),
   ]);
   await chatPanel.switchToContext(FIXTURE_SESSION_ID, true, FIXTURE_SCOOP_NAME);
   chatPanel.loadMessages(createChatFixture());
+  // Optional preview of the compaction ghost bubble for designers:
+  //   ?ui-fixture=1&compacting=summarizing
+  //   ?ui-fixture=1&compacting=extracting-memory
+  // (Anything else leaves the bubble off.)
+  const params = new URLSearchParams(window.location.search);
+  const compacting = params.get('compacting');
+  if (compacting === 'summarizing' || compacting === 'extracting-memory') {
+    chatPanel.setCompactionState?.(compacting);
+  }
   log.info('Loaded UI fixture session for design iteration');
 }
 
@@ -748,6 +758,13 @@ async function mainExtension(app: HTMLElement): Promise<void> {
       // The offscreen has already persisted the messages to IndexedDB,
       // so a panel reload would pick them up. Repaint the open chat.
       layout.panels.chat.loadMessages(messages as unknown as ChatMessage[]);
+    },
+    onCompactionStateChange: (scoopJid, state) => {
+      // Only render the ghost bubble in the scoop the user is looking at —
+      // a different scoop compacting in the background shouldn't poke the
+      // foreground chat.
+      if (selectedScoop?.jid !== scoopJid) return;
+      layout.panels.chat.setCompactionState(state);
     },
     onReady: async () => {
       try {
@@ -1720,6 +1737,12 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
         // streaming pipeline, which keeps writing through
         // `persistScoop` on each agent event.
         layout.panels.chat.loadMessages(messages as unknown as ChatMessage[]);
+      },
+      onCompactionStateChange: (scoopJid, state) => {
+        // Render the ghost bubble only in the scoop the user is viewing —
+        // a background scoop's compaction shouldn't perturb the foreground.
+        if (selectedScoop?.jid !== scoopJid) return;
+        layout.panels.chat.setCompactionState(state);
       },
       onReady: () => {
         log.info('Kernel worker ready, scoop count:', client.getScoops().length);

--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -1,0 +1,72 @@
+/**
+ * "New session" orchestration — UI-side glue that resolves model/api-key
+ * and invokes the freezer over the cone's current chat session.
+ *
+ * Both the extension and standalone (kernel-worker) paths wire their
+ * `onClearChat` to call `runNewSessionFreeze`, so the freezer behavior
+ * stays in one place.
+ */
+
+import type { Api, Model } from '@earendil-works/pi-ai';
+import type { VirtualFS } from '../fs/index.js';
+import { createLogger } from '../core/logger.js';
+import { getDailyAdobeUuid } from '../scoops/llm-session-id.js';
+import { getApiKey, resolveCurrentModel } from './provider-settings.js';
+import { SessionStore } from './session-store.js';
+import { freezeConeSession, type FrozenSession } from './session-freezer.js';
+
+const log = createLogger('new-session');
+
+/**
+ * Freezer-specific Adobe `X-Session-Id` anchor. Grouping freezer traffic
+ * under its own anchor keeps it visible-but-distinct from ad-hoc UI label
+ * calls in proxy monitoring, while still rotating daily and never leaking
+ * scoop/folder identifiers.
+ */
+const FREEZER_SESSION_ANCHOR = 'ui-new-session';
+
+export interface RunNewSessionFreezeOptions {
+  vfs: VirtualFS;
+}
+
+/**
+ * Resolve credentials + model + headers, then run the freezer. Returns the
+ * frozen entry on success, `null` when nothing was archived (short session,
+ * missing creds, or write failure). Never throws.
+ */
+export async function runNewSessionFreeze(
+  opts: RunNewSessionFreezeOptions
+): Promise<FrozenSession | null> {
+  const apiKey = getApiKey() ?? undefined;
+  let model: Model<Api> | undefined;
+  try {
+    model = resolveCurrentModel();
+  } catch (err) {
+    log.info('No active model — freezing without LLM enrichment', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  const headers: Record<string, string> | undefined =
+    model?.provider === 'adobe'
+      ? { 'X-Session-Id': getDailyAdobeUuid(FREEZER_SESSION_ANCHOR) }
+      : undefined;
+
+  const sessionStore = new SessionStore();
+  try {
+    await sessionStore.init();
+  } catch (err) {
+    log.warn('SessionStore init failed — cannot freeze', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  return freezeConeSession({
+    sessionStore,
+    vfs: opts.vfs,
+    model,
+    apiKey,
+    headers,
+  });
+}

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -241,8 +241,8 @@ export class OffscreenClient implements KernelClientFacade {
     this.send({ type: 'set-thinking-level', scoopJid: jid, level });
   }
 
-  async clearAllMessages(): Promise<void> {
-    this.send({ type: 'clear-chat' });
+  async clearAllMessages(opts: { target?: 'cone' | 'all' } = {}): Promise<void> {
+    this.send({ type: 'clear-chat', target: opts.target ?? 'cone' });
   }
 
   clearFilesystem(): void {

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -76,6 +76,11 @@ export class OffscreenClient implements KernelClientFacade {
   private stateRetryTimer: ReturnType<typeof setInterval> | null = null;
   private localFs: VirtualFS | null = null;
   /**
+   * Pending `clear-chat` requests awaiting the bridge's ack. Keyed by
+   * `requestId`; resolved when a `clear-chat-ack` envelope arrives.
+   */
+  private pendingClearAcks = new Map<string, () => void>();
+  /**
    * KernelTransport — defaults to the chrome.runtime adapter.
    * A `MessageChannel`-backed transport can be passed via the
    * constructor so the standalone panel can drive the same client
@@ -251,8 +256,22 @@ export class OffscreenClient implements KernelClientFacade {
     this.send({ type: 'set-thinking-level', scoopJid: jid, level });
   }
 
-  async clearAllMessages(opts: { target?: 'cone' | 'all' } = {}): Promise<void> {
-    this.send({ type: 'clear-chat', target: opts.target ?? 'cone' });
+  /**
+   * Cone-only chat clear. Sends a `clear-chat` envelope to the bridge
+   * and resolves only after the bridge's `clear-chat-ack` lands — so
+   * callers can `await` this before `location.reload()` without
+   * racing the offscreen document (which survives the panel reload in
+   * extension mode). A 5-second timeout backs out cleanly in the rare
+   * case the bridge is wedged; reload still proceeds.
+   */
+  async clearAllMessages(): Promise<void> {
+    const requestId = `clear-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ack = new Promise<void>((resolve) => {
+      this.pendingClearAcks.set(requestId, resolve);
+    });
+    this.send({ type: 'clear-chat', requestId });
+    await Promise.race([ack, new Promise<void>((resolve) => setTimeout(resolve, 5000))]);
+    this.pendingClearAcks.delete(requestId);
   }
 
   clearFilesystem(): void {
@@ -371,6 +390,15 @@ export class OffscreenClient implements KernelClientFacade {
       case 'compaction-state':
         this.callbacks.onCompactionStateChange?.(msg.scoopJid, msg.state);
         break;
+
+      case 'clear-chat-ack': {
+        const resolve = this.pendingClearAcks.get(msg.requestId);
+        if (resolve) {
+          this.pendingClearAcks.delete(msg.requestId);
+          resolve();
+        }
+        break;
+      }
 
       case 'scoop-created':
         this.handleScoopCreated(msg as ScoopCreatedMsg);

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -54,6 +54,16 @@ export interface OffscreenClientCallbacks {
   ) => void;
   /** Called when the offscreen engine is ready and state has been received. */
   onReady?: () => void;
+  /**
+   * Fired when a scoop's compaction transformer enters or leaves a
+   * phase. The panel uses this to render a ghost-bubble affordance
+   * while the agent is silent on summarize / memory-extract calls;
+   * `'idle'` clears the affordance.
+   */
+  onCompactionStateChange?: (
+    scoopJid: string,
+    state: 'summarizing' | 'extracting-memory' | 'idle'
+  ) => void;
 }
 
 export class OffscreenClient implements KernelClientFacade {
@@ -356,6 +366,10 @@ export class OffscreenClient implements KernelClientFacade {
 
       case 'scoop-status':
         this.handleScoopStatus(msg as ScoopStatusMsg);
+        break;
+
+      case 'compaction-state':
+        this.callbacks.onCompactionStateChange?.(msg.scoopJid, msg.state);
         break;
 
       case 'scoop-created':

--- a/packages/webapp/src/ui/scoops-panel.ts
+++ b/packages/webapp/src/ui/scoops-panel.ts
@@ -573,9 +573,9 @@ export class ScoopsPanel {
 
   /**
    * Render the frozen-sessions section below the live scoops list. One row
-   * per archived session, newest first. Click reveals the archive JSON in
-   * the Files tab via `onFrozenSessionOpen`. Read-only chat playback can
-   * land in a follow-up — this PR ships discovery only.
+   * per archived session, newest first. Click opens the archive in the
+   * chat panel as a read-only view via `onFrozenSessionOpen` — the same
+   * affordance as clicking a live scoop.
    */
   private renderFrozenSessions(): void {
     const frozenEl = this.container.querySelector('.frozen-sessions-list');

--- a/packages/webapp/src/ui/scoops-panel.ts
+++ b/packages/webapp/src/ui/scoops-panel.ts
@@ -622,6 +622,21 @@ export class ScoopsPanel {
       iconWrap.appendChild(svg);
       item.appendChild(iconWrap);
 
+      // Title + relative time — visible only when the rail is expanded
+      // (`.layout__scoops--expanded` rules give .scoop-info its size and
+      // hide it in the collapsed icon-only view).
+      const infoEl = document.createElement('div');
+      infoEl.className = 'scoop-info';
+      const nameEl = document.createElement('div');
+      nameEl.className = 'scoop-name';
+      nameEl.textContent = entry.title;
+      infoEl.appendChild(nameEl);
+      const subtitleEl = document.createElement('div');
+      subtitleEl.className = 'scoop-subtitle';
+      subtitleEl.textContent = formatRelativeTime(entry.frozenAt);
+      infoEl.appendChild(subtitleEl);
+      item.appendChild(infoEl);
+
       // Click: open the archive in the Files tab.
       const vfsPath = frozenSessionPath(entry);
       item.addEventListener('click', () => {
@@ -854,6 +869,51 @@ export class ScoopsPanel {
         opacity: 1;
         color: var(--s2-content-default);
         background: rgba(0, 0, 0, 0.04);
+      }
+      /* Hide the inline title in the collapsed icon-only rail. */
+      .frozen-session-item .scoop-info { display: none; }
+
+      /* Expanded rail: match scoop-item layout so the title fits beside the icon. */
+      .layout__scoops--expanded .frozen-session-item {
+        width: 100%;
+        height: auto;
+        justify-content: flex-start;
+        padding: 8px 5px;
+        margin-left: 0;
+        gap: 8px;
+        opacity: 1;
+      }
+      .layout__scoops--expanded .frozen-session-item .scoop-info {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        flex: 1;
+        min-width: 0;
+        justify-content: center;
+      }
+      .layout__scoops--expanded .frozen-session-item .scoop-name {
+        font-size: 13px;
+        font-weight: 500;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: var(--s2-content-secondary);
+        line-height: 16px;
+      }
+      .layout__scoops--expanded .frozen-session-item .scoop-subtitle {
+        font-size: 11px;
+        font-weight: 400;
+        color: var(--s2-content-disabled);
+        line-height: 1.4;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .frozen-session-icon-wrap {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
       }
 
       .scoops-empty {

--- a/packages/webapp/src/ui/scoops-panel.ts
+++ b/packages/webapp/src/ui/scoops-panel.ts
@@ -12,11 +12,7 @@ import type { RegisteredScoop, ScoopTabState } from '../scoops/types.js';
 import { type Orchestrator } from '../scoops/orchestrator.js';
 import { createLogger } from '../core/logger.js';
 import type { VirtualFS } from '../fs/index.js';
-import {
-  readSessionsIndex,
-  frozenSessionPath,
-  type FrozenSessionIndexEntry,
-} from './session-freezer.js';
+import { readSessionsIndex, type FrozenSessionIndexEntry } from './session-freezer.js';
 
 const log = createLogger('scoops-panel');
 
@@ -29,10 +25,11 @@ export interface ScoopsPanelCallbacks {
   onScoopsChanged?: (scoops: RegisteredScoop[]) => void;
   /**
    * Called when the user clicks a frozen-session entry in the sidebar.
-   * Receives the VFS path of the archive JSON. The standalone wiring uses
-   * this to reveal the file in the Files tab.
+   * Receives the full index entry so the wiring can read the archive
+   * file from the VFS, parse it, and hand it to the chat panel for
+   * read-only display.
    */
-  onFrozenSessionOpen?: (vfsPath: string) => void;
+  onFrozenSessionOpen?: (entry: FrozenSessionIndexEntry) => void;
 }
 
 export class ScoopsPanel {
@@ -637,10 +634,10 @@ export class ScoopsPanel {
       infoEl.appendChild(subtitleEl);
       item.appendChild(infoEl);
 
-      // Click: open the archive in the Files tab.
-      const vfsPath = frozenSessionPath(entry);
+      // Click: hand the entry off to the layout, which reads the archive
+      // and displays it in the chat panel like a scoop selection would.
       item.addEventListener('click', () => {
-        this.callbacks.onFrozenSessionOpen?.(vfsPath);
+        this.callbacks.onFrozenSessionOpen?.(entry);
       });
 
       // Hover tooltip: title + relative time. Same fixed-position tooltip

--- a/packages/webapp/src/ui/scoops-panel.ts
+++ b/packages/webapp/src/ui/scoops-panel.ts
@@ -11,6 +11,12 @@
 import type { RegisteredScoop, ScoopTabState } from '../scoops/types.js';
 import { type Orchestrator } from '../scoops/orchestrator.js';
 import { createLogger } from '../core/logger.js';
+import type { VirtualFS } from '../fs/index.js';
+import {
+  readSessionsIndex,
+  frozenSessionPath,
+  type FrozenSessionIndexEntry,
+} from './session-freezer.js';
 
 const log = createLogger('scoops-panel');
 
@@ -21,6 +27,12 @@ export interface ScoopsPanelCallbacks {
   onSendMessage: (scoopJid: string, text: string) => void;
   /** Called when the scoop list changes (for logo updates, etc.) */
   onScoopsChanged?: (scoops: RegisteredScoop[]) => void;
+  /**
+   * Called when the user clicks a frozen-session entry in the sidebar.
+   * Receives the VFS path of the archive JSON. The standalone wiring uses
+   * this to reveal the file in the Files tab.
+   */
+  onFrozenSessionOpen?: (vfsPath: string) => void;
 }
 
 export class ScoopsPanel {
@@ -30,6 +42,8 @@ export class ScoopsPanel {
   private selectedScoopJid: string | null = null;
   private scoopStatuses: Map<string, ScoopTabState['status']> = new Map();
   private expanded = false;
+  private vfs: VirtualFS | null = null;
+  private frozenSessions: FrozenSessionIndexEntry[] = [];
 
   // Roaming eyes state
   private eyesEl: HTMLElement | null = null;
@@ -222,6 +236,33 @@ export class ScoopsPanel {
   setOrchestrator(orchestrator: Orchestrator): void {
     this.orchestrator = orchestrator;
     this.refreshScoops();
+  }
+
+  /**
+   * Wire the VFS so the panel can render the "Frozen sessions" section
+   * from `/sessions/index.json`. Standalone-only — extension mode hides
+   * the scoops panel entirely.
+   */
+  setVfs(vfs: VirtualFS): void {
+    this.vfs = vfs;
+    void this.refreshFrozenSessions();
+  }
+
+  /**
+   * Re-read `/sessions/index.json` and re-render the frozen-sessions
+   * section. Cheap (one VFS read) and safe to call on demand.
+   */
+  async refreshFrozenSessions(): Promise<void> {
+    if (!this.vfs) return;
+    try {
+      this.frozenSessions = await readSessionsIndex(this.vfs);
+    } catch (err) {
+      log.warn('Failed to read sessions index', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      this.frozenSessions = [];
+    }
+    this.renderFrozenSessions();
   }
 
   /** Update scoop status */
@@ -533,6 +574,84 @@ export class ScoopsPanel {
     this.moveEyes();
   }
 
+  /**
+   * Render the frozen-sessions section below the live scoops list. One row
+   * per archived session, newest first. Click reveals the archive JSON in
+   * the Files tab via `onFrozenSessionOpen`. Read-only chat playback can
+   * land in a follow-up — this PR ships discovery only.
+   */
+  private renderFrozenSessions(): void {
+    const frozenEl = this.container.querySelector('.frozen-sessions-list');
+    if (!frozenEl) return;
+
+    while (frozenEl.firstChild) frozenEl.removeChild(frozenEl.firstChild);
+
+    if (this.frozenSessions.length === 0) return;
+
+    // Section divider — keeps the icon rail readable when frozen sessions
+    // sit directly below live scoops.
+    const divider = document.createElement('div');
+    divider.className = 'frozen-sessions-divider';
+    frozenEl.appendChild(divider);
+
+    for (const entry of this.frozenSessions) {
+      const item = document.createElement('div');
+      item.className = 'frozen-session-item';
+      item.setAttribute('aria-label', entry.title);
+
+      // Snowflake glyph — distinguishes frozen entries from the colorful
+      // live-scoop blobs.
+      const iconWrap = document.createElement('div');
+      iconWrap.className = 'frozen-session-icon-wrap';
+      const ns = 'http://www.w3.org/2000/svg';
+      const svg = document.createElementNS(ns, 'svg');
+      svg.setAttribute('width', '16');
+      svg.setAttribute('height', '16');
+      svg.setAttribute('viewBox', '0 0 24 24');
+      svg.setAttribute('fill', 'none');
+      svg.setAttribute('stroke', 'currentColor');
+      svg.setAttribute('stroke-width', '2');
+      svg.setAttribute('stroke-linecap', 'round');
+      svg.setAttribute('stroke-linejoin', 'round');
+      const paths = ['M12 2v20', 'M2 12h20', 'M19.07 4.93l-14.14 14.14', 'M4.93 4.93l14.14 14.14'];
+      for (const d of paths) {
+        const p = document.createElementNS(ns, 'path');
+        p.setAttribute('d', d);
+        svg.appendChild(p);
+      }
+      iconWrap.appendChild(svg);
+      item.appendChild(iconWrap);
+
+      // Click: open the archive in the Files tab.
+      const vfsPath = frozenSessionPath(entry);
+      item.addEventListener('click', () => {
+        this.callbacks.onFrozenSessionOpen?.(vfsPath);
+      });
+
+      // Hover tooltip: title + relative time. Same fixed-position tooltip
+      // mechanism the live scoops use.
+      item.addEventListener('mouseenter', () => {
+        const tip = document.createElement('div');
+        tip.className = 'scoop-fixed-tooltip';
+        tip.textContent = `${entry.title} · ${formatRelativeTime(entry.frozenAt)}`;
+        document.body.appendChild(tip);
+        const rect = item.getBoundingClientRect();
+        tip.style.top = `${rect.top + rect.height / 2}px`;
+        tip.style.left = `${rect.right + 8}px`;
+        (item as any).__tip = tip;
+      });
+      item.addEventListener('mouseleave', () => {
+        const tip = (item as any).__tip;
+        if (tip) {
+          tip.remove();
+          (item as any).__tip = null;
+        }
+      });
+
+      frozenEl.appendChild(item);
+    }
+  }
+
   /** Select a scoop */
   private selectScoop(scoop: RegisteredScoop): void {
     this.selectedScoopJid = scoop.jid;
@@ -647,6 +766,12 @@ export class ScoopsPanel {
     list.className = 'scoops-list';
     panel.appendChild(list);
 
+    // Frozen sessions — populated by `refreshFrozenSessions()` when a VFS
+    // is attached. Empty (and visually hidden via :empty CSS) until then.
+    const frozenList = document.createElement('div');
+    frozenList.className = 'frozen-sessions-list';
+    panel.appendChild(frozenList);
+
     this.container.appendChild(panel);
 
     // Add styles — UXC icon rail mode
@@ -690,6 +815,45 @@ export class ScoopsPanel {
       }
       .scoops-list::-webkit-scrollbar {
         display: none;
+      }
+
+      /* Frozen sessions section — past cone conversations archived
+         by the "New session" button. Sits below the live scoops list. */
+      .frozen-sessions-list {
+        width: 100%;
+        flex-shrink: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2px;
+        padding-top: 4px;
+      }
+      .frozen-sessions-list:empty {
+        display: none;
+      }
+      .frozen-sessions-divider {
+        width: 24px;
+        height: 1px;
+        background: rgba(0, 0, 0, 0.08);
+        margin: 4px 0 4px 9px;
+      }
+      .frozen-session-item {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 32px;
+        height: 32px;
+        margin-left: 5px;
+        border-radius: 8px;
+        cursor: pointer;
+        color: var(--s2-content-disabled);
+        opacity: 0.7;
+        transition: opacity 120ms, color 120ms, background 120ms;
+      }
+      .frozen-session-item:hover {
+        opacity: 1;
+        color: var(--s2-content-default);
+        background: rgba(0, 0, 0, 0.04);
       }
 
       .scoops-empty {
@@ -963,4 +1127,20 @@ export class ScoopsPanel {
 `;
     this.container.appendChild(style);
   }
+}
+
+/**
+ * Render a frozen-session `frozenAt` ISO timestamp as a short relative
+ * label ("3m ago", "2d ago"). Falls back to the literal string on
+ * parse failure so the tooltip never reads "NaN ago".
+ */
+function formatRelativeTime(iso: string): string {
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return iso;
+  const diffSec = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+  if (diffSec < 60) return 'just now';
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+  if (diffSec < 604800) return `${Math.floor(diffSec / 86400)}d ago`;
+  return new Date(ts).toLocaleDateString();
 }

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -186,6 +186,11 @@ export async function freezeConeSession(
     await ensureDir(opts.vfs, SESSIONS_DIR);
     await opts.vfs.writeFile(`${SESSIONS_DIR}/${filename}`, JSON.stringify(archive, null, 2));
     await updateSessionsIndex(opts.vfs, indexEntry);
+    // LightningFS debounces superblock saves — `location.reload()` after
+    // this returns would race the debounce timer and orphan the new
+    // /sessions/ directory inode. Force a flush so the writes are
+    // durable on IDB before the caller reloads.
+    await opts.vfs.flush();
     log.info('Cone session frozen', { filename, title, messageCount: session.messages.length });
     return { ...indexEntry, archive };
   } catch (err) {

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -1,0 +1,316 @@
+/**
+ * Freezer — archive the cone's chat session to the VFS before a "New session"
+ * reset clears it from IndexedDB.
+ *
+ * Flow (all best-effort, never throws past the caller):
+ *   1. Load `session-cone` from the UI SessionStore.
+ *   2. If the session is short (< MIN_MESSAGES_TO_FREEZE), skip everything
+ *      and return null — nothing meaningful to extract or archive.
+ *   3. Run two LLM calls over the message list with a shared system prompt
+ *      (Anthropic prompt cache hits on the prefix for the second call):
+ *        - Memory extraction → append bullets to /shared/CLAUDE.md.
+ *        - Title generation → 3-6 word label used to name the archive.
+ *      Either call may fail independently; failures fall through to safe
+ *      defaults (no memory append, heuristic title).
+ *   4. Write the session JSON to `/sessions/<timestamp>-<slug>.json` and
+ *      prepend the entry to `/sessions/index.json`.
+ *
+ * Scoops are intentionally untouched — they survive a "New session" reset
+ * so the fresh cone inherits the existing scoop roster and decides what
+ * to do with them.
+ */
+
+import type { Api, Model } from '@earendil-works/pi-ai';
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import type { VirtualFS } from '../fs/index.js';
+import { createLogger } from '../core/logger.js';
+import type { ChatMessage, Session } from './types.js';
+import type { SessionStore } from './session-store.js';
+import {
+  runOneOffCompactionCall,
+  COMPACTION_MEMORY_INSTRUCTION,
+  COMPACTION_TITLE_INSTRUCTION,
+} from '../core/context-compaction.js';
+
+const log = createLogger('session-freezer');
+
+/** Minimum cone message count before we bother freezing or extracting memory. */
+const MIN_MESSAGES_TO_FREEZE = 4;
+
+/** Max output tokens for the memory call — bullets, not a structured doc. */
+const MEMORY_MAX_TOKENS = 2048;
+
+/** Max output tokens for the title call — a short label. */
+const TITLE_MAX_TOKENS = 40;
+
+/** Where session archives and the index live. */
+const SESSIONS_DIR = '/sessions';
+const SESSIONS_INDEX_PATH = '/sessions/index.json';
+
+export interface FrozenSessionIndexEntry {
+  /** Filename within /sessions/, e.g. "2026-05-13T19-30-00Z-fix-build.json". */
+  filename: string;
+  /** Human-readable title from the LLM, or a heuristic fallback. */
+  title: string;
+  /** ISO timestamp when the freeze happened. */
+  frozenAt: string;
+  /** Count of messages in the frozen session. */
+  messageCount: number;
+}
+
+export interface FrozenSession extends FrozenSessionIndexEntry {
+  /** The full archive document written to disk. */
+  archive: FrozenSessionArchive;
+}
+
+export interface FrozenSessionArchive {
+  id: string;
+  title: string;
+  frozenAt: string;
+  createdAt: number;
+  updatedAt: number;
+  messageCount: number;
+  messages: ChatMessage[];
+}
+
+export interface FreezeConeSessionOptions {
+  sessionStore: SessionStore;
+  vfs: VirtualFS;
+  /**
+   * Active LLM model. When omitted (e.g. no provider configured) the
+   * freezer still archives the session but skips the memory and title
+   * LLM calls — a heuristic title is used in their place.
+   */
+  model?: Model<Api>;
+  /**
+   * API key for the active provider. Same fallback semantics as `model` —
+   * when empty/missing, LLM calls are skipped.
+   */
+  apiKey?: string;
+  /** Adobe X-Session-Id and friends — forwarded to both LLM calls. */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Run the freezer over the cone session. Returns the entry written (or null
+ * if nothing was frozen). Never throws past the caller — every step is
+ * wrapped in try/catch so the New Session flow can always proceed to the
+ * clear+reload step.
+ */
+export async function freezeConeSession(
+  opts: FreezeConeSessionOptions
+): Promise<FrozenSession | null> {
+  const session = await loadSessionSafely(opts.sessionStore);
+  if (!session || session.messages.length < MIN_MESSAGES_TO_FREEZE) {
+    log.info('Skipping freeze: session below threshold or missing', {
+      messageCount: session?.messages.length ?? 0,
+    });
+    return null;
+  }
+
+  const agentMessages = toAgentMessages(session.messages);
+  const llmEnabled = Boolean(opts.apiKey && opts.model);
+
+  // 1. Memory extraction (best-effort).
+  if (llmEnabled) {
+    try {
+      const bullets = await runOneOffCompactionCall({
+        messages: agentMessages,
+        instruction: COMPACTION_MEMORY_INSTRUCTION,
+        model: opts.model!,
+        apiKey: opts.apiKey!,
+        maxTokens: MEMORY_MAX_TOKENS,
+        headers: opts.headers,
+      });
+      if (bullets.trim() && bullets.trim() !== 'NONE') {
+        try {
+          await appendGlobalMemoryViaVfs(opts.vfs, bullets.trim(), 'new-session');
+          log.info('Memory extracted and appended on new-session');
+        } catch (err) {
+          log.warn('Memory append failed', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      } else {
+        log.info('Memory extraction returned no durable memories');
+      }
+    } catch (err) {
+      log.warn('Memory extraction call failed (freeze still proceeds)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  } else {
+    log.info('LLM unavailable — skipping memory extraction; freezing anyway');
+  }
+
+  // 2. Title generation (best-effort).
+  let title = '';
+  if (llmEnabled) {
+    try {
+      const raw = await runOneOffCompactionCall({
+        messages: agentMessages,
+        instruction: COMPACTION_TITLE_INSTRUCTION,
+        model: opts.model!,
+        apiKey: opts.apiKey!,
+        maxTokens: TITLE_MAX_TOKENS,
+        headers: opts.headers,
+      });
+      title = cleanTitle(raw);
+    } catch (err) {
+      log.warn('Title generation call failed (using heuristic)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  if (!title) title = heuristicTitle(session.messages);
+
+  // 3. Write the archive and update the index.
+  const frozenAt = new Date().toISOString();
+  const filename = `${frozenAt.replace(/[:.]/g, '-')}-${slugify(title)}.json`;
+  const archive: FrozenSessionArchive = {
+    id: session.id,
+    title,
+    frozenAt,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    messageCount: session.messages.length,
+    messages: session.messages,
+  };
+  const indexEntry: FrozenSessionIndexEntry = {
+    filename,
+    title,
+    frozenAt,
+    messageCount: session.messages.length,
+  };
+  try {
+    await ensureDir(opts.vfs, SESSIONS_DIR);
+    await opts.vfs.writeFile(`${SESSIONS_DIR}/${filename}`, JSON.stringify(archive, null, 2));
+    await updateSessionsIndex(opts.vfs, indexEntry);
+    log.info('Cone session frozen', { filename, title, messageCount: session.messages.length });
+    return { ...indexEntry, archive };
+  } catch (err) {
+    log.warn('Failed to write frozen session to VFS', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+async function loadSessionSafely(store: SessionStore): Promise<Session | null> {
+  try {
+    return await store.load('session-cone');
+  } catch (err) {
+    log.warn('Failed to load session-cone', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Lift ChatMessage[] (UI shape) into a minimal AgentMessage[] suitable for
+ * `runOneOffCompactionCall`'s serializer. We drop tool-call detail and
+ * attachments — for memory extraction and titling, the plain conversation
+ * text is what matters.
+ */
+function toAgentMessages(messages: ChatMessage[]): AgentMessage[] {
+  return messages.map(
+    (m) =>
+      ({
+        role: m.role,
+        content: [{ type: 'text', text: m.content }],
+        timestamp: m.timestamp,
+      }) as unknown as AgentMessage
+  );
+}
+
+function cleanTitle(raw: string): string {
+  let t = raw.trim();
+  // Strip surrounding quotes if the model added any
+  t = t.replace(/^["'`]+|["'`]+$/g, '').trim();
+  // Collapse whitespace, drop newlines (titles should be one line)
+  t = t.replace(/\s+/g, ' ');
+  // Hard cap so very chatty models don't blow out the filename
+  if (t.length > 80) t = t.slice(0, 80).trimEnd();
+  return t;
+}
+
+function heuristicTitle(messages: ChatMessage[]): string {
+  const firstUser = messages.find((m) => m.role === 'user');
+  if (!firstUser || !firstUser.content) return 'untitled-session';
+  const head = firstUser.content.trim().replace(/\s+/g, ' ');
+  return head.length > 60 ? `${head.slice(0, 60)}…` : head || 'untitled-session';
+}
+
+function slugify(text: string): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+  return slug || 'session';
+}
+
+async function ensureDir(vfs: VirtualFS, path: string): Promise<void> {
+  try {
+    await vfs.mkdir(path, { recursive: true });
+  } catch {
+    // Already exists or unsupported — writeFile will surface the real error.
+  }
+}
+
+async function appendGlobalMemoryViaVfs(
+  vfs: VirtualFS,
+  bullets: string,
+  source: string
+): Promise<void> {
+  const path = '/shared/CLAUDE.md';
+  let current = '';
+  try {
+    const raw = await vfs.readFile(path, { encoding: 'utf-8' });
+    current = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+  } catch {
+    // File doesn't exist yet — we'll create it via writeFile below.
+    await ensureDir(vfs, '/shared');
+  }
+  const date = new Date().toISOString().slice(0, 10);
+  const heading = `## Auto-extracted (${date}, ${source})`;
+  const separator = current.length === 0 || current.endsWith('\n') ? '' : '\n';
+  const block = `${separator}\n${heading}\n\n${bullets}\n`;
+  await vfs.writeFile(path, current + block);
+}
+
+async function updateSessionsIndex(
+  vfs: VirtualFS,
+  newEntry: FrozenSessionIndexEntry
+): Promise<void> {
+  let existing: FrozenSessionIndexEntry[] = [];
+  try {
+    const raw = await vfs.readFile(SESSIONS_INDEX_PATH, { encoding: 'utf-8' });
+    const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) existing = parsed as FrozenSessionIndexEntry[];
+  } catch {
+    // No index yet, or malformed — start fresh.
+  }
+  // Newest first.
+  const updated = [newEntry, ...existing.filter((e) => e.filename !== newEntry.filename)];
+  await vfs.writeFile(SESSIONS_INDEX_PATH, JSON.stringify(updated, null, 2));
+}
+
+/** Read the sessions index (or empty array if missing/malformed). */
+export async function readSessionsIndex(vfs: VirtualFS): Promise<FrozenSessionIndexEntry[]> {
+  try {
+    const raw = await vfs.readFile(SESSIONS_INDEX_PATH, { encoding: 'utf-8' });
+    const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed) ? (parsed as FrozenSessionIndexEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Path to the archive JSON for a given index entry. Useful for "open in Files" actions. */
+export function frozenSessionPath(entry: FrozenSessionIndexEntry): string {
+  return `${SESSIONS_DIR}/${entry.filename}`;
+}

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -233,12 +233,47 @@ function toAgentMessages(messages: ChatMessage[]): AgentMessage[] {
   );
 }
 
+/** Markers for the embedded structured-data block. */
+const SESSION_DATA_START = '<!-- slicc:session-data\n';
+const SESSION_DATA_END = '\n-->';
+
 /**
- * Render the archive as markdown. Header is a small YAML-style block carrying
- * the metadata that used to live in the JSON envelope (so a future "thaw"
- * action can rehydrate timestamps without parsing the body); the body itself
- * is the same markdown the chat-panel produces for the "copy chat history"
- * long-press gesture.
+ * Strip ephemeral fields that should never survive into a frozen archive
+ * (transient pointers held only for the live render). What's left is a
+ * pure data shape suitable for JSON round-trip and re-render.
+ */
+function stripEphemeral(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map((m) => {
+    const out: ChatMessage = {
+      id: m.id,
+      role: m.role,
+      content: m.content,
+      timestamp: m.timestamp,
+    };
+    if (m.attachments?.length) out.attachments = m.attachments;
+    if (m.toolCalls?.length) {
+      out.toolCalls = m.toolCalls.map((tc) => ({
+        id: tc.id,
+        name: tc.name,
+        input: tc.input,
+        ...(tc.result !== undefined ? { result: tc.result } : {}),
+        ...(tc.isError ? { isError: tc.isError } : {}),
+      }));
+    }
+    if (m.source) out.source = m.source;
+    if (m.channel) out.channel = m.channel;
+    return out;
+  });
+}
+
+/**
+ * Render the archive as markdown. The frontmatter carries scalar
+ * metadata; an HTML-commented JSON block carries the full structured
+ * message list (toolCalls, attachments, source, channel, timestamps)
+ * so the read-only chat-panel view can render with the same fidelity
+ * as a live scoop. The visible markdown body below is what the chat
+ * panel's "copy chat history" long-press produces — that part stays
+ * human-readable.
  */
 function formatArchiveAsMarkdown(archive: FrozenSessionArchive): string {
   const header =
@@ -249,9 +284,12 @@ function formatArchiveAsMarkdown(archive: FrozenSessionArchive): string {
     `createdAt: ${archive.createdAt}\n` +
     `updatedAt: ${archive.updatedAt}\n` +
     `messageCount: ${archive.messageCount}\n` +
-    `---\n\n` +
-    `# ${archive.title}\n\n`;
-  return header + formatChatForClipboard(archive.messages);
+    `---\n\n`;
+  // Escape the only sequence that would prematurely close an HTML comment.
+  const dataJson = JSON.stringify(stripEphemeral(archive.messages)).replace(/-->/g, '-- >');
+  const dataBlock = `${SESSION_DATA_START}${dataJson}${SESSION_DATA_END}\n\n`;
+  const title = `# ${archive.title}\n\n`;
+  return header + dataBlock + title + formatChatForClipboard(archive.messages);
 }
 
 function cleanTitle(raw: string): string {
@@ -347,12 +385,17 @@ export function frozenSessionPath(entry: FrozenSessionIndexEntry): string {
 
 /**
  * Parse a frozen-session markdown archive (produced by `formatArchiveAsMarkdown`)
- * back into a structured form the chat-panel can render read-only.
+ * back into the structured shape the chat-panel renders.
  *
- * Tool calls embedded under `### Tool: ...` are folded into the owning
- * assistant message's content — read-only display doesn't need the
- * structured `toolCalls[]` form (no clusters to re-label, no re-runs).
- * Lossless rehydration is left to a future "thaw" feature.
+ * Modern archives carry a `<!-- slicc:session-data ... -->` block right
+ * after the frontmatter — that JSON contains the original `ChatMessage[]`
+ * with `toolCalls`, `attachments`, `source`, `channel`, and timestamps
+ * intact, so read-only display matches a live scoop. The visible
+ * markdown body below the data block is preserved for human readers.
+ *
+ * Archives without the data block (older runs, or imports from elsewhere)
+ * fall back to a heading-based text parser that recovers user/assistant
+ * roles only — tool calls become flat text under the assistant message.
  */
 export function parseFrozenArchive(markdown: string): {
   title: string;
@@ -369,12 +412,29 @@ export function parseFrozenArchive(markdown: string): {
     if (titleMatch) title = titleMatch[1].trim();
   }
 
-  // 2. Drop the leading `# title` heading if present.
+  // 2. Prefer the embedded structured-data block when present —
+  //    round-trip-rich rendering for tool calls, attachments, etc.
+  const dataMatch = body.match(/<!-- slicc:session-data\n([\s\S]*?)\n-->\n*/);
+  if (dataMatch) {
+    try {
+      const restored = dataMatch[1].replace(/-- >/g, '-->');
+      const parsed = JSON.parse(restored);
+      if (Array.isArray(parsed)) {
+        return { title, messages: parsed as ChatMessage[] };
+      }
+    } catch {
+      // Malformed block — fall through to text parser.
+    }
+    // Strip the block before the text parser sees it.
+    body = body.replace(/<!-- slicc:session-data\n[\s\S]*?\n-->\n*/, '');
+  }
+
+  // 3. Drop the leading `# title` heading if present.
   body = body.replace(/^#\s+[^\n]*\n+/, '');
 
-  // 3. Split on `## User` / `## Assistant` boundaries. Anything between two
-  //    headings (including nested `### Tool:` blocks) lands in the prior
-  //    message's content verbatim.
+  // 4. Heading-based fallback. Splits on `## User` / `## Assistant`
+  //    boundaries; nested `### Tool:` blocks land in the prior message's
+  //    content verbatim.
   const messages: ChatMessage[] = [];
   const headingRe = /^## (User|Assistant)\s*\n/gm;
   const heads: { role: 'user' | 'assistant'; start: number; bodyStart: number }[] = [];

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -340,7 +340,61 @@ export async function readSessionsIndex(vfs: VirtualFS): Promise<FrozenSessionIn
   }
 }
 
-/** Path to the archive JSON for a given index entry. Useful for "open in Files" actions. */
+/** Path to the archive markdown for a given index entry. */
 export function frozenSessionPath(entry: FrozenSessionIndexEntry): string {
   return `${SESSIONS_DIR}/${entry.filename}`;
+}
+
+/**
+ * Parse a frozen-session markdown archive (produced by `formatArchiveAsMarkdown`)
+ * back into a structured form the chat-panel can render read-only.
+ *
+ * Tool calls embedded under `### Tool: ...` are folded into the owning
+ * assistant message's content — read-only display doesn't need the
+ * structured `toolCalls[]` form (no clusters to re-label, no re-runs).
+ * Lossless rehydration is left to a future "thaw" feature.
+ */
+export function parseFrozenArchive(markdown: string): {
+  title: string;
+  messages: ChatMessage[];
+} {
+  let body = markdown;
+  let title = 'Untitled';
+
+  // 1. Strip YAML-style frontmatter and pull out the title.
+  const fmMatch = body.match(/^---\n([\s\S]*?)\n---\n+/);
+  if (fmMatch) {
+    body = body.slice(fmMatch[0].length);
+    const titleMatch = fmMatch[1].match(/^title:\s*"?([^"\n]*)"?\s*$/m);
+    if (titleMatch) title = titleMatch[1].trim();
+  }
+
+  // 2. Drop the leading `# title` heading if present.
+  body = body.replace(/^#\s+[^\n]*\n+/, '');
+
+  // 3. Split on `## User` / `## Assistant` boundaries. Anything between two
+  //    headings (including nested `### Tool:` blocks) lands in the prior
+  //    message's content verbatim.
+  const messages: ChatMessage[] = [];
+  const headingRe = /^## (User|Assistant)\s*\n/gm;
+  const heads: { role: 'user' | 'assistant'; start: number; bodyStart: number }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = headingRe.exec(body)) !== null) {
+    heads.push({
+      role: m[1] === 'User' ? 'user' : 'assistant',
+      start: m.index,
+      bodyStart: m.index + m[0].length,
+    });
+  }
+  for (let i = 0; i < heads.length; i++) {
+    const end = i + 1 < heads.length ? heads[i + 1].start : body.length;
+    const content = body.slice(heads[i].bodyStart, end).trim();
+    messages.push({
+      id: `frozen-${i}`,
+      role: heads[i].role,
+      content,
+      timestamp: 0,
+    });
+  }
+  return { title, messages };
 }

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -31,6 +31,7 @@ import {
   COMPACTION_MEMORY_INSTRUCTION,
   COMPACTION_TITLE_INSTRUCTION,
 } from '../core/context-compaction.js';
+import { formatChatForClipboard } from './chat-panel.js';
 
 const log = createLogger('session-freezer');
 
@@ -164,9 +165,11 @@ export async function freezeConeSession(
   }
   if (!title) title = heuristicTitle(session.messages);
 
-  // 3. Write the archive and update the index.
+  // 3. Write the archive and update the index. Archive is markdown — same
+  //    format the chat-panel uses for the "copy chat history" long-press,
+  //    plus a small YAML-style header for the freezer's own metadata.
   const frozenAt = new Date().toISOString();
-  const filename = `${frozenAt.replace(/[:.]/g, '-')}-${slugify(title)}.json`;
+  const filename = `${frozenAt.replace(/[:.]/g, '-')}-${slugify(title)}.md`;
   const archive: FrozenSessionArchive = {
     id: session.id,
     title,
@@ -176,6 +179,7 @@ export async function freezeConeSession(
     messageCount: session.messages.length,
     messages: session.messages,
   };
+  const archiveMarkdown = formatArchiveAsMarkdown(archive);
   const indexEntry: FrozenSessionIndexEntry = {
     filename,
     title,
@@ -184,7 +188,7 @@ export async function freezeConeSession(
   };
   try {
     await ensureDir(opts.vfs, SESSIONS_DIR);
-    await opts.vfs.writeFile(`${SESSIONS_DIR}/${filename}`, JSON.stringify(archive, null, 2));
+    await opts.vfs.writeFile(`${SESSIONS_DIR}/${filename}`, archiveMarkdown);
     await updateSessionsIndex(opts.vfs, indexEntry);
     // LightningFS debounces superblock saves — `location.reload()` after
     // this returns would race the debounce timer and orphan the new
@@ -227,6 +231,27 @@ function toAgentMessages(messages: ChatMessage[]): AgentMessage[] {
         timestamp: m.timestamp,
       }) as unknown as AgentMessage
   );
+}
+
+/**
+ * Render the archive as markdown. Header is a small YAML-style block carrying
+ * the metadata that used to live in the JSON envelope (so a future "thaw"
+ * action can rehydrate timestamps without parsing the body); the body itself
+ * is the same markdown the chat-panel produces for the "copy chat history"
+ * long-press gesture.
+ */
+function formatArchiveAsMarkdown(archive: FrozenSessionArchive): string {
+  const header =
+    `---\n` +
+    `id: ${archive.id}\n` +
+    `title: ${JSON.stringify(archive.title)}\n` +
+    `frozenAt: ${archive.frozenAt}\n` +
+    `createdAt: ${archive.createdAt}\n` +
+    `updatedAt: ${archive.updatedAt}\n` +
+    `messageCount: ${archive.messageCount}\n` +
+    `---\n\n` +
+    `# ${archive.title}\n\n`;
+  return header + formatChatForClipboard(archive.messages);
 }
 
 function cleanTitle(raw: string): string {

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -405,11 +405,31 @@ export function parseFrozenArchive(markdown: string): {
   let title = 'Untitled';
 
   // 1. Strip YAML-style frontmatter and pull out the title.
+  //    The writer emits `title: ${JSON.stringify(value)}`, which means
+  //    quoted titles can contain `\"` and `\\` escapes (e.g. a title
+  //    like `Debug "Auth" bug`). Parse the value as JSON when it starts
+  //    with a quote so embedded escapes round-trip cleanly; fall back
+  //    to a raw read for unquoted scalars.
   const fmMatch = body.match(/^---\n([\s\S]*?)\n---\n+/);
   if (fmMatch) {
     body = body.slice(fmMatch[0].length);
-    const titleMatch = fmMatch[1].match(/^title:\s*"?([^"\n]*)"?\s*$/m);
-    if (titleMatch) title = titleMatch[1].trim();
+    const titleLine = fmMatch[1].match(/^title:\s*(.+?)\s*$/m);
+    if (titleLine) {
+      const raw = titleLine[1].trim();
+      if (raw.startsWith('"')) {
+        try {
+          // JSON.parse handles \", \\, \n, \uXXXX, etc. — same escapes
+          // JSON.stringify produced on the way in.
+          const decoded = JSON.parse(raw);
+          if (typeof decoded === 'string') title = decoded;
+        } catch {
+          // Malformed quoted value — strip surrounding quotes as a last resort.
+          title = raw.replace(/^"|"$/g, '');
+        }
+      } else {
+        title = raw;
+      }
+    }
   }
 
   // 2. Prefer the embedded structured-data block when present —

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -272,6 +272,75 @@
   display: none;
 }
 
+/* Ghost bubble shown while compaction is in flight. Not a persisted
+   ChatMessage — appended directly to .chat__messages-inner by
+   ChatPanel.setCompactionState and removed on `'idle'`. Pulses to
+   signal that the agent is busy, not stuck. */
+.msg-group--compaction {
+  align-self: flex-start;
+  max-width: 70%;
+}
+.msg-group--compaction__bubble {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: var(--s2-radius-l, 14px);
+  background: var(--s2-bg-elevated, rgba(0, 0, 0, 0.04));
+  color: var(--s2-content-secondary);
+  font-size: 13px;
+  font-style: italic;
+  border: 1px dashed var(--s2-border-subtle, rgba(0, 0, 0, 0.12));
+  animation: msg-compaction-pulse 2s ease-in-out infinite;
+}
+.msg-group--compaction__icon {
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+.msg-group--compaction__label {
+  white-space: pre-wrap;
+}
+.msg-group--compaction__dots {
+  display: inline-flex;
+  gap: 2px;
+  margin-left: 2px;
+}
+.msg-group--compaction__dots span {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.4;
+  animation: msg-compaction-dot 1.2s ease-in-out infinite;
+}
+.msg-group--compaction__dots span:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.msg-group--compaction__dots span:nth-child(3) {
+  animation-delay: 0.3s;
+}
+@keyframes msg-compaction-pulse {
+  0%,
+  100% {
+    background: var(--s2-bg-elevated, rgba(0, 0, 0, 0.04));
+  }
+  50% {
+    background: rgba(0, 0, 0, 0.07);
+  }
+}
+@keyframes msg-compaction-dot {
+  0%,
+  80%,
+  100% {
+    opacity: 0.25;
+    transform: translateY(0);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-2px);
+  }
+}
+
 /* Queued messages — dimmed to distinguish from sent messages */
 .msg--queued {
   opacity: 0.55;

--- a/packages/webapp/src/ui/styles/layout.css
+++ b/packages/webapp/src/ui/styles/layout.css
@@ -218,6 +218,39 @@
   height: 16px;
 }
 
+/* "Context getting full" affordance on the New Session button. Two
+   tiers — warm glow at ~50% of the active model's context window,
+   stronger glow + slow pulse past ~85% (compaction imminent). The
+   button keeps its hover/click affordances on top of the glow. */
+.thread-header__new-session.glow {
+  color: var(--s2-notice, #c97a00);
+  box-shadow:
+    0 0 0 1px rgba(201, 122, 0, 0.25),
+    0 0 12px rgba(201, 122, 0, 0.45);
+  background: rgba(201, 122, 0, 0.08);
+}
+.thread-header__new-session.glow--hot {
+  color: var(--s2-negative, #d73220);
+  box-shadow:
+    0 0 0 1px rgba(215, 50, 32, 0.35),
+    0 0 16px rgba(215, 50, 32, 0.55);
+  background: rgba(215, 50, 32, 0.1);
+  animation: new-session-pulse 2.4s ease-in-out infinite;
+}
+@keyframes new-session-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 1px rgba(215, 50, 32, 0.35),
+      0 0 16px rgba(215, 50, 32, 0.55);
+  }
+  50% {
+    box-shadow:
+      0 0 0 1px rgba(215, 50, 32, 0.55),
+      0 0 22px rgba(215, 50, 32, 0.85);
+  }
+}
+
 /* UXC: Chat gradient overlay at top */
 .chat__gradient-top {
   position: absolute;

--- a/packages/webapp/tests/core/context-compaction.test.ts
+++ b/packages/webapp/tests/core/context-compaction.test.ts
@@ -327,6 +327,49 @@ describe('createCompactContext', () => {
     expect(onMemoryUpdates.mock.calls[0][0]).toContain('user prefers vim');
   });
 
+  it('emits compaction lifecycle states in order, ending with idle', async () => {
+    const onMemoryUpdates = vi.fn();
+    const onCompactionStateChange = vi.fn();
+    mockCompleteSimple
+      .mockResolvedValueOnce(llmResponse('summary'))
+      .mockResolvedValueOnce(llmResponse('- a memory'));
+
+    const compact = createCompactContext({
+      ...mockConfig,
+      onMemoryUpdates,
+      onCompactionStateChange,
+    });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+    await compact(messages);
+
+    const states = onCompactionStateChange.mock.calls.map((c) => c[0]);
+    expect(states).toEqual(['summarizing', 'extracting-memory', 'idle']);
+  });
+
+  it('skips the extracting-memory state when onMemoryUpdates is not wired', async () => {
+    const onCompactionStateChange = vi.fn();
+    mockCompleteSimple.mockResolvedValueOnce(llmResponse('summary'));
+    const compact = createCompactContext({ ...mockConfig, onCompactionStateChange });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+    await compact(messages);
+    expect(onCompactionStateChange.mock.calls.map((c) => c[0])).toEqual(['summarizing', 'idle']);
+  });
+
+  it('emits idle even when the summary call fails (fallback path)', async () => {
+    const onCompactionStateChange = vi.fn();
+    mockCompleteSimple.mockRejectedValueOnce(new Error('boom'));
+    const compact = createCompactContext({ ...mockConfig, onCompactionStateChange });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+    await compact(messages);
+    // Whatever else fired, the LAST emission must be 'idle' so the UI
+    // never gets stuck showing the ghost bubble.
+    const states = onCompactionStateChange.mock.calls.map((c) => c[0]);
+    expect(states[states.length - 1]).toBe('idle');
+  });
+
   it('summary and memory calls share an identical system prompt (prefix-cache invariant)', async () => {
     const onMemoryUpdates = vi.fn();
     mockCompleteSimple

--- a/packages/webapp/tests/core/context-compaction.test.ts
+++ b/packages/webapp/tests/core/context-compaction.test.ts
@@ -17,12 +17,28 @@ type TestMessage = {
 };
 type CompactionSettingsArg = { enabled: boolean; reserveTokens: number; keepRecentTokens: number };
 
-const mockGenerateSummary = vi.fn().mockResolvedValue('## Summary\nGoal: testing\nProgress: done');
+/**
+ * The compaction module now drives both LLM calls through pi-ai's
+ * `completeSimple` directly (so the conversation can be embedded in the
+ * system prompt and Anthropic prompt caching can hit the prefix on the
+ * second call). Each test controls per-call responses via `mockResponses`.
+ */
+type CompleteSimpleArgs = {
+  systemPrompt?: string;
+  messages: { content: { type: string; text: string }[] }[];
+};
+const mockCompleteSimple = vi.fn();
 
-// Mock the pi-coding-agent compaction submodule (deep import path used in context-compaction.ts)
+vi.mock('@earendil-works/pi-ai', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    completeSimple: (...args: unknown[]) => mockCompleteSimple(...args),
+  };
+});
+
 vi.mock('@earendil-works/pi-coding-agent/dist/core/compaction/compaction.js', () => ({
   estimateTokens: (msg: TestMessage) => {
-    // Simple chars/4 heuristic matching the real implementation
     let chars = 0;
     if (Array.isArray(msg.content)) {
       for (const block of msg.content) {
@@ -39,7 +55,6 @@ vi.mock('@earendil-works/pi-coding-agent/dist/core/compaction/compaction.js', ()
     if (!settings.enabled) return false;
     return contextTokens > contextWindow - settings.reserveTokens;
   },
-  generateSummary: (...args: unknown[]) => mockGenerateSummary(...args),
   DEFAULT_COMPACTION_SETTINGS: {
     enabled: true,
     reserveTokens: 16384,
@@ -51,6 +66,9 @@ import {
   compactContext,
   createCompactContext,
   stripOrphanedToolResults,
+  runOneOffCompactionCall,
+  COMPACTION_MEMORY_INSTRUCTION,
+  COMPACTION_TITLE_INSTRUCTION,
 } from '../../src/core/context-compaction.js';
 
 /** Cast helper used in assertions where a typed AgentMessage view of an array of content blocks is needed. */
@@ -103,6 +121,17 @@ function createAssistantWithToolCalls(text: string, toolCallIds: string[]): Agen
   } as unknown as AgentMessage;
 }
 
+/** Build a `completeSimple` response shape with a single text content block. */
+function llmResponse(text: string) {
+  return {
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    stopReason: 'stop',
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: {} },
+    timestamp: 0,
+  };
+}
+
 describe('compactContext (legacy)', () => {
   it('returns empty array for empty input', async () => {
     const result = await compactContext([]);
@@ -121,15 +150,12 @@ describe('compactContext (legacy)', () => {
   });
 
   it('drops older messages when total exceeds threshold', async () => {
-    // Each message ~65K chars => ~16250 tokens. 12 messages => ~195000 tokens, exceeds 200000-16384=183616
     const baseMsg = 'x'.repeat(65000);
-    const messages = Array.from({ length: 12 }, (_, i) => createMessage('user', baseMsg));
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
 
     const result = await compactContext(messages);
 
-    // Should be smaller than original
     expect(result.length).toBeLessThan(messages.length);
-    // First message should be the compaction marker
     expect(firstText(result[0])).toContain('Earlier conversation');
   });
 
@@ -165,7 +191,6 @@ describe('compactContext (legacy)', () => {
 
     const result = await compactContext(messages);
 
-    // Every toolResult must have a preceding assistant with matching toolCall
     for (let i = 0; i < result.length; i++) {
       const msg = asTestMessage(result[i]);
       if (msg.role === 'toolResult' && msg.toolCallId) {
@@ -196,7 +221,6 @@ describe('compactContext (legacy)', () => {
   });
 
   it('returns messages unchanged when all messages form one large block (no valid cut point)', async () => {
-    // Single huge message: cutIndex would be 0 which is <= 0, so no compaction
     const hugeMsg = 'x'.repeat(800000);
     const messages = [createMessage('user', hugeMsg)];
     const result = await compactContext(messages);
@@ -222,7 +246,6 @@ describe('compactContext (legacy)', () => {
 
     const result = await compactContext(messages);
 
-    // If toolResult t1 is in the result, its assistant must also be present
     for (let i = 0; i < result.length; i++) {
       const msg = asTestMessage(result[i]);
       if (msg.role === 'toolResult' && msg.toolCallId) {
@@ -255,8 +278,8 @@ describe('createCompactContext', () => {
   };
 
   beforeEach(() => {
-    mockGenerateSummary.mockClear();
-    mockGenerateSummary.mockResolvedValue('## Summary\nGoal: testing\nProgress: done');
+    mockCompleteSimple.mockReset();
+    mockCompleteSimple.mockResolvedValue(llmResponse('## Goal\ntesting\n\n## Progress\ndone'));
   });
 
   it('returns messages unchanged when under threshold', async () => {
@@ -265,7 +288,7 @@ describe('createCompactContext', () => {
 
     const result = await compact(messages);
     expect(result).toEqual(messages);
-    expect(mockGenerateSummary).not.toHaveBeenCalled();
+    expect(mockCompleteSimple).not.toHaveBeenCalled();
   });
 
   it('returns empty array for empty input', async () => {
@@ -274,19 +297,102 @@ describe('createCompactContext', () => {
     expect(result).toEqual([]);
   });
 
-  it('calls generateSummary when threshold exceeded', async () => {
+  it('calls completeSimple once when threshold exceeded (no memory callback)', async () => {
     const compact = createCompactContext(mockConfig);
-    // ~16250 tokens each, 12 messages = ~195K tokens, exceeds 200000-16384
     const baseMsg = 'x'.repeat(65000);
     const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
 
     const result = await compact(messages);
 
-    expect(mockGenerateSummary).toHaveBeenCalledOnce();
-    // Result should contain the summary + kept recent messages
+    // One call: summary only. No memory callback was wired.
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(1);
     expect(result.length).toBeLessThan(messages.length);
     expect(firstText(result[0])).toContain('<context-summary>');
-    expect(firstText(result[0])).toContain('Summary');
+  });
+
+  it('calls completeSimple twice when onMemoryUpdates wired', async () => {
+    const onMemoryUpdates = vi.fn();
+    mockCompleteSimple
+      .mockResolvedValueOnce(llmResponse('## Goal\ndo a thing'))
+      .mockResolvedValueOnce(llmResponse('- user prefers vim\n- project uses ESM'));
+
+    const compact = createCompactContext({ ...mockConfig, onMemoryUpdates });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+
+    await compact(messages);
+
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(2);
+    expect(onMemoryUpdates).toHaveBeenCalledOnce();
+    expect(onMemoryUpdates.mock.calls[0][0]).toContain('user prefers vim');
+  });
+
+  it('summary and memory calls share an identical system prompt (prefix-cache invariant)', async () => {
+    const onMemoryUpdates = vi.fn();
+    mockCompleteSimple
+      .mockResolvedValueOnce(llmResponse('summary text'))
+      .mockResolvedValueOnce(llmResponse('- a memory'));
+
+    const compact = createCompactContext({ ...mockConfig, onMemoryUpdates });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+
+    await compact(messages);
+
+    const [, ctx1] = mockCompleteSimple.mock.calls[0] as [unknown, CompleteSimpleArgs];
+    const [, ctx2] = mockCompleteSimple.mock.calls[1] as [unknown, CompleteSimpleArgs];
+    expect(ctx1.systemPrompt).toBeTruthy();
+    expect(ctx2.systemPrompt).toBe(ctx1.systemPrompt);
+    // Sanity: instructions differ between the two calls.
+    expect(ctx1.messages[0].content[0].text).not.toBe(ctx2.messages[0].content[0].text);
+    expect(ctx2.messages[0].content[0].text).toBe(COMPACTION_MEMORY_INSTRUCTION);
+  });
+
+  it('skips memory callback when LLM returns NONE', async () => {
+    const onMemoryUpdates = vi.fn();
+    mockCompleteSimple
+      .mockResolvedValueOnce(llmResponse('summary'))
+      .mockResolvedValueOnce(llmResponse('NONE'));
+
+    const compact = createCompactContext({ ...mockConfig, onMemoryUpdates });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+
+    await compact(messages);
+
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(2);
+    expect(onMemoryUpdates).not.toHaveBeenCalled();
+  });
+
+  it('memory call failure does not block compaction', async () => {
+    const onMemoryUpdates = vi.fn();
+    mockCompleteSimple
+      .mockResolvedValueOnce(llmResponse('summary'))
+      .mockRejectedValueOnce(new Error('memory call exploded'));
+
+    const compact = createCompactContext({ ...mockConfig, onMemoryUpdates });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+
+    const result = await compact(messages);
+
+    // Summary still applied — first message is the context-summary wrapper.
+    expect(firstText(result[0])).toContain('<context-summary>');
+    expect(onMemoryUpdates).not.toHaveBeenCalled();
+  });
+
+  it('memory callback throwing does not break compaction', async () => {
+    const onMemoryUpdates = vi.fn().mockRejectedValue(new Error('vfs write failed'));
+    mockCompleteSimple
+      .mockResolvedValueOnce(llmResponse('summary'))
+      .mockResolvedValueOnce(llmResponse('- a memory'));
+
+    const compact = createCompactContext({ ...mockConfig, onMemoryUpdates });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+
+    const result = await compact(messages);
+    expect(firstText(result[0])).toContain('<context-summary>');
   });
 
   it('preserves recent messages after summarization', async () => {
@@ -299,22 +405,18 @@ describe('createCompactContext', () => {
     ];
 
     const result = await compact(messages);
-
-    // Last messages should be preserved
     const lastMsg = result[result.length - 1];
     expect(firstText(lastMsg)).toBe('recent-2');
   });
 
-  it('falls back to naive drop when generateSummary fails', async () => {
-    mockGenerateSummary.mockRejectedValueOnce(new Error('API error'));
+  it('falls back to naive drop when summary call fails', async () => {
+    mockCompleteSimple.mockRejectedValueOnce(new Error('API error'));
 
     const compact = createCompactContext(mockConfig);
     const baseMsg = 'x'.repeat(65000);
     const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
 
     const result = await compact(messages);
-
-    // Should still compact, just without summary
     expect(result.length).toBeLessThan(messages.length);
     expect(firstText(result[0])).toContain('Earlier conversation');
   });
@@ -328,115 +430,12 @@ describe('createCompactContext', () => {
     const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
 
     const result = await compact(messages);
-
-    expect(mockGenerateSummary).not.toHaveBeenCalled();
+    expect(mockCompleteSimple).not.toHaveBeenCalled();
     expect(result.length).toBeLessThan(messages.length);
     expect(firstText(result[0])).toContain('Earlier conversation');
   });
 
-  it('does not split assistant+toolResult pairs', async () => {
-    const compact = createCompactContext(mockConfig);
-    const baseMsg = 'x'.repeat(65000);
-    const messages: AgentMessage[] = [
-      createMessage('user', baseMsg),
-      createMessage('assistant', baseMsg),
-      createMessage('user', baseMsg),
-      createAssistantWithToolCalls(baseMsg, ['t1']),
-      createToolResult(baseMsg, 't1'),
-      createMessage('user', 'last'),
-      createMessage('assistant', 'done'),
-    ];
-
-    const result = await compact(messages);
-
-    // Every toolResult must have its assistant
-    for (let i = 0; i < result.length; i++) {
-      const msg = asTestMessage(result[i]);
-      if (msg.role === 'toolResult' && msg.toolCallId) {
-        let found = false;
-        for (let j = i - 1; j >= 0; j--) {
-          const prev = asTestMessage(result[j]);
-          if (prev.role === 'assistant' && Array.isArray(prev.content)) {
-            const hasToolCall = prev.content.some(
-              (c: TestContentBlock) => c.type === 'toolCall' && c.id === msg.toolCallId
-            );
-            if (hasToolCall) {
-              found = true;
-              break;
-            }
-          }
-          if (prev.role !== 'toolResult') break;
-        }
-        expect(found).toBe(true);
-      }
-    }
-  });
-
-  it('respects custom contextWindow and reserveTokens', async () => {
-    const compact = createCompactContext({
-      ...mockConfig,
-      contextWindow: 100000,
-      reserveTokens: 10000,
-    });
-    // At 100K window with 10K reserve, threshold is 90K tokens
-    // 6 messages at ~16250 tokens each = ~97500, exceeds 90K
-    const baseMsg = 'x'.repeat(65000);
-    const messages = Array.from({ length: 6 }, () => createMessage('user', baseMsg));
-
-    const result = await compact(messages);
-    expect(result.length).toBeLessThan(messages.length);
-  });
-
-  it('wraps summary in context-summary tags', async () => {
-    const compact = createCompactContext(mockConfig);
-    const baseMsg = 'x'.repeat(65000);
-    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
-
-    const result = await compact(messages);
-
-    const summaryText = firstText(result[0]);
-    expect(summaryText).toMatch(/^<context-summary>\n/);
-    expect(summaryText).toMatch(/\n<\/context-summary>$/);
-  });
-
-  it('passes signal to generateSummary', async () => {
-    const compact = createCompactContext(mockConfig);
-    const baseMsg = 'x'.repeat(65000);
-    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
-    const controller = new AbortController();
-
-    await compact(messages, controller.signal);
-
-    expect(mockGenerateSummary).toHaveBeenCalledOnce();
-    // pi-coding-agent generateSummary positional signature is
-    //   (messages, model, reserveTokens, apiKey, headers, signal, ...)
-    // signal lands at index 5; index 4 is reserved for headers.
-    const callArgs = mockGenerateSummary.mock.calls[0];
-    expect(callArgs[5]).toBe(controller.signal);
-  });
-
-  it('passes model and reserveTokens to generateSummary', async () => {
-    const compact = createCompactContext({
-      ...mockConfig,
-      reserveTokens: 8000,
-    });
-    const baseMsg = 'x'.repeat(65000);
-    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
-
-    await compact(messages);
-
-    const callArgs = mockGenerateSummary.mock.calls[0];
-    // generateSummary(messages, model, reserveTokens, apiKey, headers, signal, ...)
-    expect(callArgs[1]).toBe(mockConfig.model); // model
-    expect(callArgs[2]).toBe(8000); // reserveTokens
-    expect(callArgs[3]).toBe('test-key'); // apiKey
-  });
-
-  it('forwards configured headers to generateSummary', async () => {
-    // Regression test: SLICC's Adobe LLM proxy needs the X-Session-Id header
-    // on compaction calls. Without this wiring the header lands as undefined
-    // and the proxy falls back to its content-derived hash, fragmenting
-    // sessions across multiple ids.
+  it('forwards configured headers to completeSimple', async () => {
     const compact = createCompactContext({
       ...mockConfig,
       headers: { 'X-Session-Id': 'cone_42/abcd1234' },
@@ -446,40 +445,38 @@ describe('createCompactContext', () => {
 
     await compact(messages);
 
-    expect(mockGenerateSummary).toHaveBeenCalledOnce();
-    const callArgs = mockGenerateSummary.mock.calls[0];
-    // headers lands at index 4 (between apiKey and signal).
-    expect(callArgs[4]).toEqual({ 'X-Session-Id': 'cone_42/abcd1234' });
+    const opts = mockCompleteSimple.mock.calls[0][2] as { headers?: Record<string, string> };
+    expect(opts.headers).toEqual({ 'X-Session-Id': 'cone_42/abcd1234' });
   });
 
-  it('passes undefined headers when not configured', async () => {
+  it('wraps summary in context-summary tags', async () => {
     const compact = createCompactContext(mockConfig);
+    mockCompleteSimple.mockResolvedValueOnce(llmResponse('## Goal\nsome work'));
     const baseMsg = 'x'.repeat(65000);
     const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
 
-    await compact(messages);
-
-    const callArgs = mockGenerateSummary.mock.calls[0];
-    expect(callArgs[4]).toBeUndefined();
+    const result = await compact(messages);
+    const summaryText = firstText(result[0]);
+    expect(summaryText).toMatch(/^<context-summary>\n/);
+    expect(summaryText).toMatch(/\n<\/context-summary>$/);
   });
 
   it('returns messages unchanged when single message exceeds window (no valid cut)', async () => {
     const compact = createCompactContext(mockConfig);
-    // Single 800K char message (~200K tokens), exceeds window but can't be split
     const hugeMsg = 'x'.repeat(800000);
     const messages = [createMessage('user', hugeMsg)];
 
     const result = await compact(messages);
     expect(result).toEqual(messages);
-    expect(mockGenerateSummary).not.toHaveBeenCalled();
+    expect(mockCompleteSimple).not.toHaveBeenCalled();
   });
 
   it('walk-back guard keeps assistant+toolResult pair together across the cut', async () => {
-    // Verifies the walk-back guard (lines 137-141 in context-compaction.ts):
-    // when the naive cut would land on a toolResult, cutIndex is walked back
-    // to include the preceding assistant, so the kept slice never starts with
-    // an orphaned toolResult. Note: `stripOrphanedToolResults` is a no-op
-    // here — the guard is what makes this pass.
+    // Verifies the walk-back guard: when the naive cut would land on a
+    // toolResult, cutIndex is walked back to include the preceding
+    // assistant, so the kept slice never starts with an orphaned
+    // toolResult. `stripOrphanedToolResults` is a no-op here — the
+    // guard is what makes this pass.
     const compact = createCompactContext({ ...mockConfig, getApiKey: () => undefined });
     const baseMsg = 'x'.repeat(65000);
     const messages: AgentMessage[] = [
@@ -495,10 +492,7 @@ describe('createCompactContext', () => {
 
     const result = await compact(messages);
 
-    // The result must never start with a toolResult
     expect(asTestMessage(result[0]).role).not.toBe('toolResult');
-
-    // No toolResult in the output should be orphaned
     for (let i = 0; i < result.length; i++) {
       const msg = asTestMessage(result[i]);
       if (msg.role !== 'toolResult' || !msg.toolCallId) continue;
@@ -523,7 +517,6 @@ describe('createCompactContext', () => {
 
   it('full-size tool results survive until compaction', async () => {
     const compact = createCompactContext(mockConfig);
-    // Tool results pass through at full fidelity — overflow recovery handles sizing if needed
     const largeResult = 'x'.repeat(40000);
     const messages = [
       createMessage('user', 'run tool'),
@@ -533,11 +526,77 @@ describe('createCompactContext', () => {
     ];
 
     const result = await compact(messages);
-
-    // Under threshold, messages pass through unchanged
     expect(result).toEqual(messages);
-    // Tool result preserved at full size
     expect(firstText(result[2])).toBe(largeResult);
+  });
+
+  it('passes abort signal to completeSimple', async () => {
+    const compact = createCompactContext(mockConfig);
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+    const controller = new AbortController();
+
+    await compact(messages, controller.signal);
+
+    const opts = mockCompleteSimple.mock.calls[0][2] as { signal?: AbortSignal };
+    expect(opts.signal).toBe(controller.signal);
+  });
+});
+
+describe('runOneOffCompactionCall', () => {
+  const mockModel = { id: 'test-model' } as unknown as Model<Api>;
+
+  beforeEach(() => {
+    mockCompleteSimple.mockReset();
+  });
+
+  it('returns the LLM response trimmed', async () => {
+    mockCompleteSimple.mockResolvedValueOnce(llmResponse('  My Session Title  '));
+    const result = await runOneOffCompactionCall({
+      messages: [createMessage('user', 'hello'), createMessage('assistant', 'hi')],
+      instruction: COMPACTION_TITLE_INSTRUCTION,
+      model: mockModel,
+      apiKey: 'k',
+      maxTokens: 20,
+    });
+    expect(result).toBe('My Session Title');
+  });
+
+  it('forwards headers and signal', async () => {
+    mockCompleteSimple.mockResolvedValueOnce(llmResponse('title'));
+    const controller = new AbortController();
+    await runOneOffCompactionCall({
+      messages: [createMessage('user', 'hello')],
+      instruction: 'title please',
+      model: mockModel,
+      apiKey: 'k',
+      maxTokens: 20,
+      headers: { 'X-Session-Id': 'abc' },
+      signal: controller.signal,
+    });
+    const opts = mockCompleteSimple.mock.calls[0][2] as {
+      headers?: Record<string, string>;
+      signal?: AbortSignal;
+    };
+    expect(opts.headers).toEqual({ 'X-Session-Id': 'abc' });
+    expect(opts.signal).toBe(controller.signal);
+  });
+
+  it('throws when stopReason is error', async () => {
+    mockCompleteSimple.mockResolvedValueOnce({
+      ...llmResponse(''),
+      stopReason: 'error',
+      errorMessage: 'rate limited',
+    });
+    await expect(
+      runOneOffCompactionCall({
+        messages: [createMessage('user', 'hi')],
+        instruction: 'do',
+        model: mockModel,
+        apiKey: 'k',
+        maxTokens: 20,
+      })
+    ).rejects.toThrow(/rate limited/);
   });
 });
 

--- a/packages/webapp/tests/kernel/facade.test.ts
+++ b/packages/webapp/tests/kernel/facade.test.ts
@@ -137,6 +137,7 @@ function makeOrchestratorMock() {
     stopScoop: vi.fn(),
     clearQueuedMessages: vi.fn().mockResolvedValue(undefined),
     clearAllMessages: vi.fn().mockResolvedValue(undefined),
+    clearScoopMessages: vi.fn().mockResolvedValue(undefined),
     delegateToScoop: vi.fn().mockResolvedValue(undefined),
     updateModel: vi.fn(),
     setScoopThinkingLevel: vi.fn().mockResolvedValue(undefined),
@@ -232,9 +233,22 @@ describe('Kernel facade parity', () => {
     expect(orchestrator.unregisterScoop).toHaveBeenCalledWith('scoop_test');
   });
 
-  // 3. clear-chat deletes every scoop's session id
-  it('client.clearAllMessages → SessionStore.delete called for every scoop session', async () => {
+  // 3. clear-chat default (target=cone) deletes only the cone session
+  it('client.clearAllMessages() → SessionStore.delete called only for the cone session', async () => {
     await client.clearAllMessages();
+    await tick();
+
+    const sessionStore = (facade as unknown as { sessionStore: { delete: Mock } }).sessionStore;
+    expect(sessionStore.delete).toHaveBeenCalledWith('session-cone');
+    expect(sessionStore.delete).not.toHaveBeenCalledWith('session-test-scoop');
+    // Cone-only path uses clearScoopMessages, not clearAllMessages.
+    expect(orchestrator.clearScoopMessages).toHaveBeenCalledWith('cone_1');
+    expect(orchestrator.clearAllMessages).not.toHaveBeenCalled();
+  });
+
+  // 3b. explicit target='all' still wipes every scoop's session
+  it('client.clearAllMessages({target: "all"}) → SessionStore.delete called for every scoop session', async () => {
+    await client.clearAllMessages({ target: 'all' });
     await tick();
 
     const sessionStore = (facade as unknown as { sessionStore: { delete: Mock } }).sessionStore;

--- a/packages/webapp/tests/kernel/facade.test.ts
+++ b/packages/webapp/tests/kernel/facade.test.ts
@@ -233,28 +233,18 @@ describe('Kernel facade parity', () => {
     expect(orchestrator.unregisterScoop).toHaveBeenCalledWith('scoop_test');
   });
 
-  // 3. clear-chat default (target=cone) deletes only the cone session
+  // 3. clear-chat is cone-only by design: only the cone's session row
+  //    is deleted from the SessionStore and only the cone's runtime
+  //    state is reset via clearScoopMessages. Scoops survive.
   it('client.clearAllMessages() → SessionStore.delete called only for the cone session', async () => {
-    await client.clearAllMessages();
+    void client.clearAllMessages();
     await tick();
 
     const sessionStore = (facade as unknown as { sessionStore: { delete: Mock } }).sessionStore;
     expect(sessionStore.delete).toHaveBeenCalledWith('session-cone');
     expect(sessionStore.delete).not.toHaveBeenCalledWith('session-test-scoop');
-    // Cone-only path uses clearScoopMessages, not clearAllMessages.
     expect(orchestrator.clearScoopMessages).toHaveBeenCalledWith('cone_1');
     expect(orchestrator.clearAllMessages).not.toHaveBeenCalled();
-  });
-
-  // 3b. explicit target='all' still wipes every scoop's session
-  it('client.clearAllMessages({target: "all"}) → SessionStore.delete called for every scoop session', async () => {
-    await client.clearAllMessages({ target: 'all' });
-    await tick();
-
-    const sessionStore = (facade as unknown as { sessionStore: { delete: Mock } }).sessionStore;
-    expect(sessionStore.delete).toHaveBeenCalledWith('session-cone');
-    expect(sessionStore.delete).toHaveBeenCalledWith('session-test-scoop');
-    expect(orchestrator.clearAllMessages).toHaveBeenCalled();
   });
 
   // 4. panel-cdp-command round-trip

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -227,11 +227,32 @@ describe('OffscreenClient', () => {
     expect(envelope.payload.type).toBe('request-state');
   });
 
-  it('sends clear-chat', () => {
-    client.clearAllMessages();
+  it('sends clear-chat with a requestId and resolves once the ack arrives', async () => {
+    const pending = client.clearAllMessages();
 
     const envelope = sentMessages[0] as { source: string; payload: any };
     expect(envelope.payload.type).toBe('clear-chat');
+    expect(typeof envelope.payload.requestId).toBe('string');
+    expect(envelope.payload.requestId.length).toBeGreaterThan(0);
+
+    // Mirror the bridge's ack so the awaited Promise resolves.
+    simulateMessage('offscreen', {
+      type: 'clear-chat-ack',
+      requestId: envelope.payload.requestId,
+    });
+    await pending;
+  });
+
+  it('clear-chat resolves on timeout if no ack arrives', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = client.clearAllMessages();
+      // 5s timeout backs out cleanly so the panel can reload anyway.
+      vi.advanceTimersByTime(5000);
+      await pending;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('ignores messages from non-offscreen sources', () => {

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -402,6 +402,27 @@ describe('parseFrozenArchive', () => {
     });
   });
 
+  it('preserves embedded quotes in the title via JSON-encoded frontmatter', () => {
+    // The writer emits `title: ${JSON.stringify(value)}`, so a title like
+    // `Debug "Auth" bug` round-trips as `title: "Debug \"Auth\" bug"`.
+    // The reader must parse the value as JSON when it starts with a
+    // quote so internal escapes survive — otherwise the regex stops at
+    // the first `"` and reopens the session with a truncated header.
+    const md = [
+      '---',
+      'id: session-cone',
+      `title: ${JSON.stringify('Debug "Auth" bug — with backslash \\ too')}`,
+      'frozenAt: 2026-05-13T19:00:00.000Z',
+      '---',
+      '',
+      '## User',
+      'hello',
+      '',
+    ].join('\n');
+    const { title } = parseFrozenArchive(md);
+    expect(title).toBe('Debug "Auth" bug — with backslash \\ too');
+  });
+
   it('falls back to text parsing when the data block is malformed', () => {
     const md = [
       '---',

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Session, ChatMessage } from '../../src/ui/types.js';
+
+const mockRunOneOffCompactionCall = vi.fn();
+vi.mock('../../src/core/context-compaction.js', () => ({
+  COMPACTION_MEMORY_INSTRUCTION: 'MEMORY',
+  COMPACTION_TITLE_INSTRUCTION: 'TITLE',
+  runOneOffCompactionCall: (...args: unknown[]) => mockRunOneOffCompactionCall(...args),
+}));
+
+import { freezeConeSession, readSessionsIndex } from '../../src/ui/session-freezer.js';
+import type { SessionStore } from '../../src/ui/session-store.js';
+
+/**
+ * Minimal VirtualFS double — just the subset the freezer touches. Backed by
+ * a Map so we can introspect what was written without spinning up an
+ * indexed-DB harness.
+ */
+function makeFakeVfs() {
+  const files = new Map<string, string>();
+  return {
+    files,
+    async readFile(path: string): Promise<string> {
+      if (!files.has(path)) {
+        const err = new Error(`ENOENT: ${path}`);
+        (err as unknown as { code: string }).code = 'ENOENT';
+        throw err;
+      }
+      return files.get(path)!;
+    },
+    async writeFile(path: string, content: string | Uint8Array): Promise<void> {
+      files.set(path, typeof content === 'string' ? content : new TextDecoder().decode(content));
+    },
+    async mkdir(_path: string, _opts?: unknown): Promise<void> {
+      // no-op
+    },
+  };
+}
+
+function makeFakeStore(session: Session | null) {
+  return {
+    async load(): Promise<Session | null> {
+      return session;
+    },
+  } as unknown as SessionStore;
+}
+
+function userMessage(content: string): ChatMessage {
+  return { id: crypto.randomUUID(), role: 'user', content, timestamp: 1 };
+}
+function assistantMessage(content: string): ChatMessage {
+  return { id: crypto.randomUUID(), role: 'assistant', content, timestamp: 2 };
+}
+
+const fakeModel = { id: 'test-model', provider: 'anthropic' } as unknown as Parameters<
+  typeof freezeConeSession
+>[0]['model'];
+
+describe('freezeConeSession', () => {
+  beforeEach(() => {
+    mockRunOneOffCompactionCall.mockReset();
+  });
+
+  it('skips when session is below MIN_MESSAGES_TO_FREEZE', async () => {
+    const store = makeFakeStore({
+      id: 'session-cone',
+      messages: [userMessage('hi'), assistantMessage('hello')],
+      createdAt: 0,
+      updatedAt: 1,
+    });
+    const vfs = makeFakeVfs();
+    const result = await freezeConeSession({
+      sessionStore: store,
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+    });
+    expect(result).toBeNull();
+    expect(mockRunOneOffCompactionCall).not.toHaveBeenCalled();
+    expect(vfs.files.size).toBe(0);
+  });
+
+  it('writes archive + index and appends memory on a long session', async () => {
+    // Two LLM calls in order: memory bullets, then title.
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('- user prefers vim\n- project uses ESM')
+      .mockResolvedValueOnce('Fixing the auth bug');
+
+    const messages: ChatMessage[] = [
+      userMessage('q1'),
+      assistantMessage('a1'),
+      userMessage('q2'),
+      assistantMessage('a2'),
+    ];
+    const store = makeFakeStore({
+      id: 'session-cone',
+      messages,
+      createdAt: 100,
+      updatedAt: 200,
+    });
+    const vfs = makeFakeVfs();
+
+    const result = await freezeConeSession({
+      sessionStore: store,
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Fixing the auth bug');
+    expect(result!.messageCount).toBe(4);
+
+    // Archive file landed under /sessions/, named with the slugified title.
+    const archivePath = `/sessions/${result!.filename}`;
+    expect(vfs.files.has(archivePath)).toBe(true);
+    expect(result!.filename).toMatch(/fixing-the-auth-bug\.json$/);
+
+    // Index updated with the new entry first.
+    const index = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    expect(index).toHaveLength(1);
+    expect(index[0].title).toBe('Fixing the auth bug');
+
+    // Memory append landed in /shared/CLAUDE.md with a dated heading.
+    const memoryDoc = vfs.files.get('/shared/CLAUDE.md');
+    expect(memoryDoc).toBeTruthy();
+    expect(memoryDoc).toMatch(/Auto-extracted.*new-session/);
+    expect(memoryDoc).toContain('user prefers vim');
+  });
+
+  it('skips memory append when LLM returns NONE', async () => {
+    mockRunOneOffCompactionCall.mockResolvedValueOnce('NONE').mockResolvedValueOnce('Quick chat');
+
+    const store = makeFakeStore({
+      id: 'session-cone',
+      messages: [userMessage('a'), assistantMessage('b'), userMessage('c'), assistantMessage('d')],
+      createdAt: 0,
+      updatedAt: 1,
+    });
+    const vfs = makeFakeVfs();
+
+    await freezeConeSession({
+      sessionStore: store,
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+    });
+
+    expect(vfs.files.get('/shared/CLAUDE.md')).toBeUndefined();
+  });
+
+  it('uses heuristic title when title LLM call fails', async () => {
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('- memory bullet')
+      .mockRejectedValueOnce(new Error('rate limited'));
+
+    const store = makeFakeStore({
+      id: 'session-cone',
+      messages: [
+        userMessage('help me debug the build pipeline'),
+        assistantMessage('sure'),
+        userMessage('here is the error'),
+        assistantMessage('looking now'),
+      ],
+      createdAt: 0,
+      updatedAt: 1,
+    });
+    const vfs = makeFakeVfs();
+
+    const result = await freezeConeSession({
+      sessionStore: store,
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+    });
+
+    expect(result).not.toBeNull();
+    // Heuristic title falls back to first user message, truncated.
+    expect(result!.title).toContain('help me debug');
+  });
+
+  it('still archives without an API key (no LLM calls, heuristic title)', async () => {
+    const store = makeFakeStore({
+      id: 'session-cone',
+      messages: [
+        userMessage('plan the migration'),
+        assistantMessage('ok'),
+        userMessage('go'),
+        assistantMessage('done'),
+      ],
+      createdAt: 0,
+      updatedAt: 1,
+    });
+    const vfs = makeFakeVfs();
+
+    const result = await freezeConeSession({
+      sessionStore: store,
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: undefined,
+    });
+
+    expect(mockRunOneOffCompactionCall).not.toHaveBeenCalled();
+    expect(result).not.toBeNull();
+    expect(result!.title).toContain('plan the migration');
+    // Archive still landed.
+    const archivePath = `/sessions/${result!.filename}`;
+    expect(vfs.files.has(archivePath)).toBe(true);
+  });
+
+  it('prepends new entry to existing /sessions/index.json', async () => {
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('NONE')
+      .mockResolvedValueOnce('Second session');
+
+    const vfs = makeFakeVfs();
+    vfs.files.set(
+      '/sessions/index.json',
+      JSON.stringify([
+        {
+          filename: 'older.json',
+          title: 'First session',
+          frozenAt: '2026-01-01T00:00:00Z',
+          messageCount: 4,
+        },
+      ])
+    );
+    const store = makeFakeStore({
+      id: 'session-cone',
+      messages: [userMessage('q'), assistantMessage('a'), userMessage('r'), assistantMessage('b')],
+      createdAt: 0,
+      updatedAt: 1,
+    });
+
+    await freezeConeSession({
+      sessionStore: store,
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+    });
+
+    const index = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    expect(index).toHaveLength(2);
+    expect(index[0].title).toBe('Second session');
+    expect(index[1].title).toBe('First session');
+  });
+});

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -347,4 +347,82 @@ describe('parseFrozenArchive', () => {
       messages: [],
     });
   });
+
+  it('prefers the embedded structured-data block over the markdown body', () => {
+    // The data block carries the truth (toolCalls, timestamps, source);
+    // the visible body below is just human-readable garnish and may be
+    // less detailed. Parser must trust the data block when present.
+    const data = JSON.stringify([
+      {
+        id: 'm1',
+        role: 'user',
+        content: 'run ls',
+        timestamp: 100,
+      },
+      {
+        id: 'm2',
+        role: 'assistant',
+        content: 'sure',
+        timestamp: 200,
+        toolCalls: [{ id: 't1', name: 'bash', input: { command: 'ls' }, result: 'file1\nfile2' }],
+      },
+    ]);
+    const md = [
+      '---',
+      'title: "tool run"',
+      '---',
+      '',
+      '<!-- slicc:session-data',
+      data,
+      '-->',
+      '',
+      '# tool run',
+      '',
+      '## User',
+      'run ls',
+      '',
+      '## Assistant',
+      'sure',
+      '',
+      '### Tool: bash',
+      'Input: { "command": "ls" }',
+      'Result: file1\nfile2',
+      '',
+    ].join('\n');
+    const { title, messages } = parseFrozenArchive(md);
+    expect(title).toBe('tool run');
+    expect(messages).toHaveLength(2);
+    expect(messages[0].timestamp).toBe(100);
+    expect(messages[1].toolCalls).toHaveLength(1);
+    expect(messages[1].toolCalls![0]).toMatchObject({
+      id: 't1',
+      name: 'bash',
+      input: { command: 'ls' },
+      result: 'file1\nfile2',
+    });
+  });
+
+  it('falls back to text parsing when the data block is malformed', () => {
+    const md = [
+      '---',
+      'title: "broken"',
+      '---',
+      '',
+      '<!-- slicc:session-data',
+      '{not valid json',
+      '-->',
+      '',
+      '## User',
+      'hi',
+      '',
+      '## Assistant',
+      'hello',
+      '',
+    ].join('\n');
+    const { title, messages } = parseFrozenArchive(md);
+    expect(title).toBe('broken');
+    expect(messages).toHaveLength(2);
+    expect(messages[0].content).toBe('hi');
+    expect(messages[1].content).toBe('hello');
+  });
 });

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -8,6 +8,17 @@ vi.mock('../../src/core/context-compaction.js', () => ({
   runOneOffCompactionCall: (...args: unknown[]) => mockRunOneOffCompactionCall(...args),
 }));
 
+// chat-panel imports a wide chunk (incl. SessionStore via indexeddb shims) at
+// module load — the freezer only needs `formatChatForClipboard`. Stub it to a
+// minimal markdown renderer so the freezer's `.md` output is testable without
+// pulling the entire chat-panel surface into the test environment.
+vi.mock('../../src/ui/chat-panel.js', () => ({
+  formatChatForClipboard: (messages: { role: string; content: string }[]) =>
+    messages
+      .map((m) => `## ${m.role === 'user' ? 'User' : 'Assistant'}\n${m.content}\n\n`)
+      .join(''),
+}));
+
 import { freezeConeSession, readSessionsIndex } from '../../src/ui/session-freezer.js';
 import type { SessionStore } from '../../src/ui/session-store.js';
 
@@ -115,9 +126,17 @@ describe('freezeConeSession', () => {
     expect(result!.messageCount).toBe(4);
 
     // Archive file landed under /sessions/, named with the slugified title.
+    // Format: markdown with a YAML-style header.
     const archivePath = `/sessions/${result!.filename}`;
     expect(vfs.files.has(archivePath)).toBe(true);
-    expect(result!.filename).toMatch(/fixing-the-auth-bug\.json$/);
+    expect(result!.filename).toMatch(/fixing-the-auth-bug\.md$/);
+    const archiveContent = vfs.files.get(archivePath)!;
+    expect(archiveContent).toMatch(/^---\n/);
+    expect(archiveContent).toContain('title: "Fixing the auth bug"');
+    expect(archiveContent).toContain('messageCount: 4');
+    expect(archiveContent).toContain('# Fixing the auth bug');
+    expect(archiveContent).toContain('## User');
+    expect(archiveContent).toContain('## Assistant');
 
     // Index updated with the new entry first.
     const index = await readSessionsIndex(

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -34,6 +34,9 @@ function makeFakeVfs() {
     async mkdir(_path: string, _opts?: unknown): Promise<void> {
       // no-op
     },
+    async flush(): Promise<void> {
+      // no-op
+    },
   };
 }
 

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -19,7 +19,11 @@ vi.mock('../../src/ui/chat-panel.js', () => ({
       .join(''),
 }));
 
-import { freezeConeSession, readSessionsIndex } from '../../src/ui/session-freezer.js';
+import {
+  freezeConeSession,
+  parseFrozenArchive,
+  readSessionsIndex,
+} from '../../src/ui/session-freezer.js';
 import type { SessionStore } from '../../src/ui/session-store.js';
 
 /**
@@ -269,5 +273,78 @@ describe('freezeConeSession', () => {
     expect(index).toHaveLength(2);
     expect(index[0].title).toBe('Second session');
     expect(index[1].title).toBe('First session');
+  });
+});
+
+describe('parseFrozenArchive', () => {
+  it('round-trips title + user/assistant messages from a freezer-shaped archive', () => {
+    const md = [
+      '---',
+      'id: session-cone',
+      'title: "Auth bug investigation"',
+      'frozenAt: 2026-05-13T19:00:00.000Z',
+      'createdAt: 100',
+      'updatedAt: 200',
+      'messageCount: 3',
+      '---',
+      '',
+      '# Auth bug investigation',
+      '',
+      '## User',
+      'why is the token rotating every minute',
+      '',
+      '## Assistant',
+      'checking the refresh window now',
+      '',
+      '## User',
+      'thanks',
+      '',
+    ].join('\n');
+    const { title, messages } = parseFrozenArchive(md);
+    expect(title).toBe('Auth bug investigation');
+    expect(messages).toHaveLength(3);
+    expect(messages[0]).toMatchObject({
+      role: 'user',
+      content: 'why is the token rotating every minute',
+    });
+    expect(messages[1]).toMatchObject({
+      role: 'assistant',
+      content: 'checking the refresh window now',
+    });
+    expect(messages[2]).toMatchObject({ role: 'user', content: 'thanks' });
+  });
+
+  it('folds nested ### Tool: blocks into the owning assistant message', () => {
+    const md = [
+      '---',
+      'title: "tool run"',
+      '---',
+      '',
+      '# tool run',
+      '',
+      '## User',
+      'run ls',
+      '',
+      '## Assistant',
+      'sure',
+      '',
+      '### Tool: bash',
+      'Input: { "command": "ls" }',
+      'Result: file1\nfile2',
+      '',
+    ].join('\n');
+    const { messages } = parseFrozenArchive(md);
+    expect(messages).toHaveLength(2);
+    // The tool block is folded into the assistant's content verbatim.
+    expect(messages[1].role).toBe('assistant');
+    expect(messages[1].content).toContain('### Tool: bash');
+    expect(messages[1].content).toContain('"command": "ls"');
+  });
+
+  it('returns empty messages and Untitled when nothing matches', () => {
+    expect(parseFrozenArchive('no headings here at all')).toEqual({
+      title: 'Untitled',
+      messages: [],
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Compaction → memory extraction.** When the agent compacts older messages, run a second LLM call sharing the same conversation prefix (embedded in the system prompt so Anthropic's prompt cache hits). Bullets are appended to `/shared/CLAUDE.md` under a dated heading. Cone-only — scoops keep their own user-curated memory. Best-effort: memory failure never blocks compaction.
- **"Clear chat" → "New session".** Before clearing, freeze the cone's chat to `/sessions/<timestamp>-<slug>.json` with an LLM-generated title and prepend an entry to `/sessions/index.json`. Scoops intentionally survive a "New session" so the fresh cone inherits the existing roster. `clear-chat` message now carries `target: 'cone' | 'all'`; the UI button uses `'cone'`.
- **Frozen sessions sidebar (standalone).** New section in the scoops rail rendering the index newest-first with snowflake glyphs. Click → Files tab + `FileBrowserPanel.revealPath` expands ancestors and selects the archive JSON. Extension UX deferred (rail is hidden there).

Inspired by @kpauls' compaction UI brainstorming.

## Test plan

- [ ] `npm run typecheck` ✅
- [ ] `npm run test` ✅ (4249 passing — including new `session-freezer.test.ts` and rewritten `context-compaction.test.ts`)
- [ ] `npm run build` ✅
- [ ] `npm run build -w @slicc/chrome-extension` ✅
- [ ] Manual: stuff context past 200K threshold; confirm `/shared/CLAUDE.md` gains a dated `## Auto-extracted (…, compaction)` block and conversation is summarized.
- [ ] Manual: click "New session" on a non-trivial cone chat; confirm `/sessions/<ts>-<slug>.json` and `/sessions/index.json` appear after reload, scoops are still present and runnable, and sidebar shows the new entry.
- [ ] Manual on Adobe path: both LLM calls carry `X-Session-Id` (check compaction logs / network).
- [ ] Manual on a non-Anthropic provider: both calls complete (no cache hit, but correct).
- [ ] Memory call mocked to throw → compaction still applies summary.

## Out of scope

- Resuming / thawing frozen sessions (the freezer is write-only from the UI).
- Extension-mode sidebar surface.
- Per-scoop auto-memory writes.
- Freezing scoop sessions on "New session" (scoops survive by design).
- Pruning / GC of `/sessions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)