### PR TITLE
feat(jsh): expose piped stdin to .jsh, node, and node -e

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -257,7 +257,21 @@ process.cwd(): string         // Current working directory
 process.exit(code?: number)   // Exit with code (0 default)
 process.stdout.write(s)       // Write to stdout
 process.stderr.write(s)       // Write to stderr
+process.stdin.read(): string  // Buffered piped stdin (empty if none)
+process.stdin.isTTY: false    // Always false in this environment
+process.stdin[Symbol.asyncIterator]()  // Yields the buffered string once
 ```
+
+#### stdin (top-level parameter)
+
+The buffered piped stdin is also exposed as a top-level `stdin` string parameter — the most ergonomic form for scripts that just want to read the pipe:
+
+```typescript
+// echo "a,b,c" | parse-csv
+const cells = stdin.trim().split(',');
+```
+
+Stdin is **fully read-ahead** — there is no streaming. If no input is piped, `stdin` is `''` and `process.stdin.read()` returns `''`.
 
 #### console
 

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -251,27 +251,38 @@ Rule: First basename wins (no conflicts)
 #### process
 
 ```typescript
-process.argv: string[]        // ['node', 'script.jsh', ...args]
-process.env: object           // Environment variables
-process.cwd(): string         // Current working directory
-process.exit(code?: number)   // Exit with code (0 default)
-process.stdout.write(s)       // Write to stdout
-process.stderr.write(s)       // Write to stderr
-process.stdin.read(): string  // Buffered piped stdin (empty if none)
-process.stdin.isTTY: false    // Always false in this environment
-process.stdin[Symbol.asyncIterator]()  // Yields the buffered string once
+process.argv: string[]                       // ['node', 'script.jsh', ...args]
+process.env: object                          // Environment variables
+process.cwd(): string                        // Current working directory
+process.exit(code?: number)                  // Exit with code (0 default)
+process.stdout.write(s)                      // Write to stdout
+process.stderr.write(s)                      // Write to stderr
+process.stdin.read(): string | null          // Buffered piped stdin; null after EOF
+process.stdin.isTTY: false                   // Always false in this environment
+process.stdin[Symbol.asyncIterator]()        // Yields the buffered string once
+String(process.stdin)                        // Non-consuming view of the buffer
 ```
 
-#### stdin (top-level parameter)
+#### stdin (via `process.stdin`)
 
-The buffered piped stdin is also exposed as a top-level `stdin` string parameter — the most ergonomic form for scripts that just want to read the pipe:
+Stdin from upstream pipelines is buffered fully before the script runs — there is **no streaming**. `read()` drains the buffer with Node-like EOF semantics:
 
 ```typescript
 // echo "a,b,c" | parse-csv
-const cells = stdin.trim().split(',');
+const data = process.stdin.read(); // 'a,b,c\n'
+const again = process.stdin.read(); // null — buffer was drained
 ```
 
-Stdin is **fully read-ahead** — there is no streaming. If no input is piped, `stdin` is `''` and `process.stdin.read()` returns `''`.
+The async iterator shares that consumed state with `read()`, so re-iterating yields nothing after the first pass (and yields nothing at all if you called `read()` first):
+
+```typescript
+let total = '';
+for await (const chunk of process.stdin) total += chunk;
+```
+
+For a non-consuming view, use `String(process.stdin)` or `process.stdin.toString()`. If no input is piped, the first `read()` returns `''` and subsequent calls return `null`.
+
+Stdin is intentionally NOT exposed as a top-level identifier — user scripts are free to declare their own `const stdin = …` without colliding with the runtime.
 
 #### console
 

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -321,21 +321,25 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     error: (...a) => writeStderr(a.map(formatArg).join(' ') + '\n'),
   };
   const NODE_EXIT = Symbol('NODE_EXIT');
-  // Stdin surfaces — mirror of js-realm-shared.ts. Top-level `stdin`
-  // parameter for ergonomics, plus `process.stdin.read()` and async
-  // iteration for Node-like compatibility. See the shared module's
-  // comment for the full rationale.
-  const stdinBuffer = init.stdin || '';
+  // Stdin surface — mirror of js-realm-shared.ts. `process.stdin.read()`
+  // returns the buffer once then `null` (Node EOF semantics, shared with
+  // the async iterator); `toString()` is a non-consuming view. See the
+  // shared module for the full rationale.
+  const stdinBuffer = init.stdin ?? '';
+  let stdinConsumed = false;
   const stdinShim = {
     isTTY: false,
-    read() { return stdinBuffer; },
+    read() {
+      if (stdinConsumed) return null;
+      stdinConsumed = true;
+      return stdinBuffer;
+    },
     toString() { return stdinBuffer; },
     [Symbol.asyncIterator]() {
-      let yielded = false;
       return {
         async next() {
-          if (yielded) return { value: undefined, done: true };
-          yielded = true;
+          if (stdinConsumed) return { value: undefined, done: true };
+          stdinConsumed = true;
           return { value: stdinBuffer, done: false };
         },
       };
@@ -491,10 +495,10 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   try {
     const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
     const fn = new AsyncFunction(
-      'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch', 'stdin',
+      'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch',
       '"use strict";\n' + init.code
     );
-    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch, stdinBuffer);
+    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch);
   } catch (err) {
     if (err && typeof err === 'object' && NODE_EXIT in err) {
       exitCode = err[NODE_EXIT];

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -321,6 +321,26 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     error: (...a) => writeStderr(a.map(formatArg).join(' ') + '\n'),
   };
   const NODE_EXIT = Symbol('NODE_EXIT');
+  // Stdin surfaces — mirror of js-realm-shared.ts. Top-level `stdin`
+  // parameter for ergonomics, plus `process.stdin.read()` and async
+  // iteration for Node-like compatibility. See the shared module's
+  // comment for the full rationale.
+  const stdinBuffer = init.stdin || '';
+  const stdinShim = {
+    isTTY: false,
+    read() { return stdinBuffer; },
+    toString() { return stdinBuffer; },
+    [Symbol.asyncIterator]() {
+      let yielded = false;
+      return {
+        async next() {
+          if (yielded) return { value: undefined, done: true };
+          yielded = true;
+          return { value: stdinBuffer, done: false };
+        },
+      };
+    },
+  };
   const processShim = {
     argv: init.argv,
     env: init.env,
@@ -330,6 +350,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       e[NODE_EXIT] = Number.isFinite(code) ? Number(code) : 0;
       throw e;
     },
+    stdin: stdinShim,
     stdout: { write: writeStdout },
     stderr: { write: writeStderr },
   };
@@ -470,10 +491,10 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   try {
     const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
     const fn = new AsyncFunction(
-      'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch',
+      'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch', 'stdin',
       '"use strict";\n' + init.code
     );
-    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch);
+    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch, stdinBuffer);
   } catch (err) {
     if (err && typeof err === 'object' && NODE_EXIT in err) {
       exitCode = err[NODE_EXIT];

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -144,7 +144,7 @@ Deep reference: `docs/kernel/process-model.md`.
 - Command name is the basename without `.jsh`.
 - `packages/webapp/src/shell/script-catalog.ts` shares discovery across `WasmShell`, `which`, and other lookup paths. Raw scanning still comes from `jsh-discovery.ts`, which scans `/workspace/skills` first, then the wider VFS.
 - Scripts run in an async wrapper: prefer top-level `await` and always `await fs.*` operations.
-- Stdin from upstream pipelines is fully buffered (no streaming) and exposed two ways: a top-level `stdin` string parameter and `process.stdin.read()` / `process.stdin[Symbol.asyncIterator]()`. `process.stdin.isTTY` is always `false`. Empty when no input is piped. `node`'s read-from-stdin branch (when stdin is the script source) hands the inner script an empty stdin so it can't read its own source.
+- Stdin from upstream pipelines is fully buffered (no streaming) and exposed via `process.stdin`. `read()` drains the buffer with Node-like EOF semantics (returns the buffered string the first time, `null` thereafter) and shares that consumed state with `for await (const chunk of process.stdin)`. `String(process.stdin)` is a non-consuming view. `process.stdin.isTTY` is always `false`. `node`'s read-from-stdin branch (when stdin is the script source) hands the inner script an empty stdin so it can't read its own source. Stdin is intentionally NOT exposed as a top-level identifier so user scripts can keep declaring `const stdin = …` without colliding.
 
 ### `.bsh` browser scripts
 

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -144,6 +144,7 @@ Deep reference: `docs/kernel/process-model.md`.
 - Command name is the basename without `.jsh`.
 - `packages/webapp/src/shell/script-catalog.ts` shares discovery across `WasmShell`, `which`, and other lookup paths. Raw scanning still comes from `jsh-discovery.ts`, which scans `/workspace/skills` first, then the wider VFS.
 - Scripts run in an async wrapper: prefer top-level `await` and always `await fs.*` operations.
+- Stdin from upstream pipelines is fully buffered (no streaming) and exposed two ways: a top-level `stdin` string parameter and `process.stdin.read()` / `process.stdin[Symbol.asyncIterator]()`. `process.stdin.isTTY` is always `false`. Empty when no input is piped. `node`'s read-from-stdin branch (when stdin is the script source) hands the inner script an empty stdin so it can't read its own source.
 
 ### `.bsh` browser scripts
 

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -109,6 +109,41 @@ export async function runJsRealm(
     error: (...parts: unknown[]) => writeStderr(`${parts.map(formatConsoleArg).join(' ')}\n`),
   };
 
+  // `init.stdin` arrives as a buffered string from the kernel — pipelines
+  // upstream of the realm (the WasmShell exec pipeline, the registered
+  // `.jsh` command path, `node`/`node -e` via supplemental-commands) all
+  // populate it before posting `realm-init`. Stdin in the realm is
+  // therefore fully read-ahead; we don't model a streaming Readable.
+  // Surfaces:
+  //   • `stdin` — top-level AsyncFunction parameter; the ergonomic
+  //     "`const lines = stdin.split('\\n')`" path for `.jsh` scripts.
+  //   • `process.stdin.read()` — Node-like sync read returning the same
+  //     buffered string.
+  //   • `process.stdin[Symbol.asyncIterator]` — yields the buffered
+  //     string once, so `for await (const chunk of process.stdin)` works
+  //     for code copy-pasted from Node tutorials.
+  // `process.stdin.isTTY` is always `false`; there's no terminal.
+  const stdinBuffer = init.stdin ?? '';
+  const stdinShim = {
+    isTTY: false,
+    read(): string {
+      return stdinBuffer;
+    },
+    toString(): string {
+      return stdinBuffer;
+    },
+    [Symbol.asyncIterator](): AsyncIterator<string> {
+      let yielded = false;
+      return {
+        async next(): Promise<IteratorResult<string>> {
+          if (yielded) return { value: undefined, done: true };
+          yielded = true;
+          return { value: stdinBuffer, done: false };
+        },
+      };
+    },
+  };
+
   const processShim = {
     argv: init.argv,
     env: init.env,
@@ -117,6 +152,7 @@ export async function runJsRealm(
       const normalized = Number.isFinite(codeValue) ? Number(codeValue) : 0;
       throw new NodeExitError(normalized);
     },
+    stdin: stdinShim,
     stdout: { write: writeStdout },
     stderr: { write: writeStderr },
   };
@@ -267,7 +303,8 @@ export async function runJsRealm(
       module: typeof moduleShim,
       exports: Record<string, unknown>,
       exec: typeof execBridge,
-      fetch: typeof realmFetch
+      fetch: typeof realmFetch,
+      stdin: string
     ) => Promise<unknown>;
     const fn = new AsyncFn(
       'fs',
@@ -278,6 +315,7 @@ export async function runJsRealm(
       'exports',
       'exec',
       'fetch',
+      'stdin',
       `"use strict";\n${init.code}`
     );
     await fn(
@@ -288,7 +326,8 @@ export async function runJsRealm(
       moduleShim,
       moduleShim.exports,
       execBridge,
-      realmFetch
+      realmFetch,
+      stdinBuffer
     );
   } catch (err: unknown) {
     if (err instanceof NodeExitError) {

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -114,30 +114,40 @@ export async function runJsRealm(
   // `.jsh` command path, `node`/`node -e` via supplemental-commands) all
   // populate it before posting `realm-init`. Stdin in the realm is
   // therefore fully read-ahead; we don't model a streaming Readable.
-  // Surfaces:
-  //   • `stdin` — top-level AsyncFunction parameter; the ergonomic
-  //     "`const lines = stdin.split('\\n')`" path for `.jsh` scripts.
-  //   • `process.stdin.read()` — Node-like sync read returning the same
-  //     buffered string.
-  //   • `process.stdin[Symbol.asyncIterator]` — yields the buffered
-  //     string once, so `for await (const chunk of process.stdin)` works
-  //     for code copy-pasted from Node tutorials.
+  //
+  // Exposed exclusively via `process.stdin` to avoid burning a top-level
+  // identifier. Earlier drafts also injected `stdin` as an AsyncFunction
+  // parameter for ergonomics, but `stdin` is a common user variable name
+  // (more so than `fs` / `exec` / `fetch`); reserving it would have
+  // turned any pre-existing `let stdin = …` into a strict-mode
+  // SyntaxError. Scripts that want the short form can alias it
+  // themselves: `const { stdin } = process; const data = stdin.read();`.
+  //
+  // EOF semantics match Node's `Readable.read()`: the first `read()`
+  // returns the full buffer, subsequent calls return `null`. A single
+  // `consumed` flag is shared with the async iterator, so
+  // `for await (const c of process.stdin)` after a `read()` (or a
+  // second iteration) yields nothing — same as Node where `'end'`
+  // fires once. `toString()` always returns the original buffer
+  // because it's a view (`String(process.stdin)`), not a consumer.
   // `process.stdin.isTTY` is always `false`; there's no terminal.
   const stdinBuffer = init.stdin ?? '';
+  let stdinConsumed = false;
   const stdinShim = {
     isTTY: false,
-    read(): string {
+    read(): string | null {
+      if (stdinConsumed) return null;
+      stdinConsumed = true;
       return stdinBuffer;
     },
     toString(): string {
       return stdinBuffer;
     },
     [Symbol.asyncIterator](): AsyncIterator<string> {
-      let yielded = false;
       return {
         async next(): Promise<IteratorResult<string>> {
-          if (yielded) return { value: undefined, done: true };
-          yielded = true;
+          if (stdinConsumed) return { value: undefined, done: true };
+          stdinConsumed = true;
           return { value: stdinBuffer, done: false };
         },
       };
@@ -303,8 +313,7 @@ export async function runJsRealm(
       module: typeof moduleShim,
       exports: Record<string, unknown>,
       exec: typeof execBridge,
-      fetch: typeof realmFetch,
-      stdin: string
+      fetch: typeof realmFetch
     ) => Promise<unknown>;
     const fn = new AsyncFn(
       'fs',
@@ -315,7 +324,6 @@ export async function runJsRealm(
       'exports',
       'exec',
       'fetch',
-      'stdin',
       `"use strict";\n${init.code}`
     );
     await fn(
@@ -326,8 +334,7 @@ export async function runJsRealm(
       moduleShim,
       moduleShim.exports,
       execBridge,
-      realmFetch,
-      stdinBuffer
+      realmFetch
     );
   } catch (err: unknown) {
     if (err instanceof NodeExitError) {

--- a/packages/webapp/src/kernel/realm/realm-types.ts
+++ b/packages/webapp/src/kernel/realm/realm-types.ts
@@ -42,7 +42,14 @@ export interface RealmInitMsg {
   cwd: string;
   /** Filename surfaced to the user code (`<eval>`, `<stdin>`, or a path). */
   filename: string;
-  /** Optional initial stdin (string) — Pyodide reads it from `sys.stdin`. */
+  /**
+   * Optional initial stdin (string). Consumed by both realms:
+   *   • Python — surfaced as `sys.stdin`.
+   *   • JS — surfaced as `process.stdin.read()` / `for await ... of
+   *     process.stdin`, with Node-like EOF semantics (single read drains
+   *     the buffer). See `js-realm-shared.ts` for the full shim.
+   * The buffer is fully read-ahead; the realms don't model streaming.
+   */
   stdin?: string;
   /** `loadPyodide({indexURL})` for `kind:'py'`. */
   pyodideIndexURL?: string;

--- a/packages/webapp/src/shell/jsh-executor.ts
+++ b/packages/webapp/src/shell/jsh-executor.ts
@@ -111,6 +111,11 @@ export async function executeJsCode(
     env: Object.fromEntries(ctx.env.entries()),
     cwd: ctx.cwd,
     filename,
+    // Forward the upstream pipeline's stdin (just-bash exposes it as a
+    // string per `CommandContext.stdin`) so `.jsh` scripts and `node`/
+    // `node -e` invocations can read piped input via `process.stdin.read()`
+    // or the top-level `stdin` parameter.
+    stdin: ctx.stdin,
     ctx,
     ppid: pmConfig?.getParentPid?.(),
   });

--- a/packages/webapp/src/shell/supplemental-commands/node-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/node-command.ts
@@ -15,7 +15,7 @@
  */
 
 import { defineCommand } from 'just-bash';
-import type { Command } from 'just-bash';
+import type { Command, CommandContext } from 'just-bash';
 import { NODE_VERSION } from './shared.js';
 import { executeJsCode } from '../jsh-executor.js';
 
@@ -43,6 +43,12 @@ export function createNodeCommand(): Command {
     let code = '';
     let filename = '<stdin>';
     let argv: string[] = ['node'];
+    // `node`'s read-from-stdin branch consumes `ctx.stdin` AS THE CODE.
+    // The inner script must not also see that same buffer as its own
+    // stdin (it would be reading its own source) — we hand it an empty
+    // stdin via a context override. The `-e` and script-file branches
+    // keep the upstream pipeline's stdin intact.
+    let innerCtx: CommandContext = ctx;
 
     if (args.length > 0 && (args[0] === '-e' || args[0] === '--eval')) {
       if (!args[1]) {
@@ -72,6 +78,7 @@ export function createNodeCommand(): Command {
       code = ctx.stdin;
       filename = '<stdin>';
       argv = ['node'];
+      innerCtx = { ...ctx, stdin: '' };
     } else if (args.length > 0) {
       return {
         stdout: '',
@@ -86,6 +93,6 @@ export function createNodeCommand(): Command {
       };
     }
 
-    return executeJsCode(code, argv, ctx, undefined, { filename });
+    return executeJsCode(code, argv, innerCtx, undefined, { filename });
   });
 }

--- a/packages/webapp/tests/shell/jsh-executor.test.ts
+++ b/packages/webapp/tests/shell/jsh-executor.test.ts
@@ -559,9 +559,11 @@ describe('jsh-executor — process manager wiring', () => {
 });
 
 describe('stdin in .jsh scripts', () => {
-  it('exposes piped stdin as the top-level `stdin` parameter', async () => {
+  it('exposes piped stdin via process.stdin.read()', async () => {
     const ctx = createMockCtx(
-      { '/workspace/cat.jsh': 'process.stdout.write(stdin);' },
+      {
+        '/workspace/cat.jsh': 'const data = process.stdin.read(); process.stdout.write(data);',
+      },
       {},
       undefined,
       'hello from upstream\n'
@@ -571,7 +573,7 @@ describe('stdin in .jsh scripts', () => {
     expect(result.stdout).toBe('hello from upstream\n');
   });
 
-  it('exposes piped stdin via process.stdin.read()', async () => {
+  it('returns the byte length when stdin is read as a string', async () => {
     const ctx = createMockCtx(
       { '/workspace/read.jsh': 'console.log(process.stdin.read().length);' },
       {},
@@ -598,15 +600,86 @@ describe('stdin in .jsh scripts', () => {
     expect(result.stdout.trim()).toBe('HI');
   });
 
-  it('exposes empty string when no stdin is piped', async () => {
+  it('returns null on subsequent process.stdin.read() calls (Node EOF semantics)', async () => {
+    const ctx = createMockCtx(
+      {
+        '/workspace/eof.jsh':
+          'const a = process.stdin.read(); const b = process.stdin.read(); console.log(JSON.stringify({ a, b }));',
+      },
+      {},
+      undefined,
+      'data'
+    );
+    const result = await executeJshFile('/workspace/eof.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({ a: 'data', b: null });
+  });
+
+  it('shares EOF state between read() and the async iterator', async () => {
+    const ctx = createMockCtx(
+      {
+        '/workspace/shared-eof.jsh':
+          'process.stdin.read(); let n = 0; for await (const _ of process.stdin) n++; console.log(n);',
+      },
+      {},
+      undefined,
+      'data'
+    );
+    const result = await executeJshFile('/workspace/shared-eof.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('0');
+  });
+
+  it('async iterator yields once then ends', async () => {
+    const ctx = createMockCtx(
+      {
+        '/workspace/iter-twice.jsh': [
+          'let first = ""; for await (const c of process.stdin) first += c;',
+          'let second = ""; for await (const c of process.stdin) second += c;',
+          'console.log(JSON.stringify({ first, second }));',
+        ].join('\n'),
+      },
+      {},
+      undefined,
+      'once'
+    );
+    const result = await executeJshFile('/workspace/iter-twice.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({ first: 'once', second: '' });
+  });
+
+  it('process.stdin.toString() is a non-consuming view', async () => {
+    const ctx = createMockCtx(
+      {
+        '/workspace/view.jsh': [
+          'const view = String(process.stdin);',
+          'const read = process.stdin.read();',
+          'console.log(JSON.stringify({ view, read }));',
+        ].join('\n'),
+      },
+      {},
+      undefined,
+      'data'
+    );
+    const result = await executeJshFile('/workspace/view.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({ view: 'data', read: 'data' });
+  });
+
+  it('exposes null + empty defaults when no stdin is piped', async () => {
     const ctx = createMockCtx({
       '/workspace/empty.jsh':
-        'console.log(JSON.stringify({ top: stdin, viaProcess: process.stdin.read(), tty: process.stdin.isTTY }));',
+        'console.log(JSON.stringify({ first: process.stdin.read(), second: process.stdin.read(), tty: process.stdin.isTTY }));',
     });
     const result = await executeJshFile('/workspace/empty.jsh', [], ctx);
     expect(result.exitCode).toBe(0);
-    const parsed = JSON.parse(result.stdout.trim());
-    expect(parsed).toEqual({ top: '', viaProcess: '', tty: false });
+    // Even with no piped input, the first read drains the (empty) buffer
+    // and subsequent reads return null — same behavior as a real EOF stream.
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      first: '',
+      second: null,
+      tty: false,
+    });
   });
 
   it('preserves binary-shaped (latin1) stdin bytes verbatim', async () => {
@@ -616,7 +689,7 @@ describe('stdin in .jsh scripts', () => {
     const ctx = createMockCtx(
       {
         '/workspace/echo.jsh':
-          'const codes = []; for (const c of stdin) codes.push(c.charCodeAt(0)); console.log(codes.join(","));',
+          'const data = process.stdin.read(); const codes = []; for (const c of data) codes.push(c.charCodeAt(0)); console.log(codes.join(","));',
       },
       {},
       undefined,
@@ -627,8 +700,28 @@ describe('stdin in .jsh scripts', () => {
     expect(result.stdout.trim()).toBe('0,255,127,128,195,169');
   });
 
+  it('does not collide with scripts that declare their own `stdin` identifier', async () => {
+    // Earlier drafts of this feature injected `stdin` as a 9th
+    // AsyncFunction parameter. That would have made the line below a
+    // strict-mode SyntaxError (duplicate declaration). Surfacing only
+    // via `process.stdin` keeps the identifier free for user code.
+    const ctx = createMockCtx(
+      {
+        '/workspace/local-name.jsh': [
+          'const stdin = "user-owned name";',
+          'console.log(stdin);',
+        ].join('\n'),
+      },
+      {},
+      undefined,
+      'piped'
+    );
+    const result = await executeJshFile('/workspace/local-name.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('user-owned name');
+  });
+
   it('does not break scripts that ignore stdin', async () => {
-    // Regression guard for the additive AsyncFunction parameter.
     const ctx = createMockCtx(
       { '/workspace/quiet.jsh': 'console.log("ok");' },
       {},

--- a/packages/webapp/tests/shell/jsh-executor.test.ts
+++ b/packages/webapp/tests/shell/jsh-executor.test.ts
@@ -112,14 +112,15 @@ function createMockCtx(
   execFn?: (
     command: string,
     options: { cwd?: string }
-  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>,
+  stdin = ''
 ): CommandContext {
   const env = new Map<string, string>(Object.entries(envVars));
   const ctx: CommandContext = {
     fs: createMockFs(files),
     cwd: '/workspace',
     env,
-    stdin: '',
+    stdin,
   };
   if (execFn) {
     ctx.exec = execFn as CommandContext['exec'];
@@ -554,5 +555,88 @@ describe('jsh-executor — process manager wiring', () => {
     });
     const result = await executeJshFile('/workspace/hi.jsh', [], ctx);
     expect(result.exitCode).toBe(0);
+  });
+});
+
+describe('stdin in .jsh scripts', () => {
+  it('exposes piped stdin as the top-level `stdin` parameter', async () => {
+    const ctx = createMockCtx(
+      { '/workspace/cat.jsh': 'process.stdout.write(stdin);' },
+      {},
+      undefined,
+      'hello from upstream\n'
+    );
+    const result = await executeJshFile('/workspace/cat.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('hello from upstream\n');
+  });
+
+  it('exposes piped stdin via process.stdin.read()', async () => {
+    const ctx = createMockCtx(
+      { '/workspace/read.jsh': 'console.log(process.stdin.read().length);' },
+      {},
+      undefined,
+      'abcdef'
+    );
+    const result = await executeJshFile('/workspace/read.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('6');
+  });
+
+  it('supports `for await (const chunk of process.stdin)` iteration', async () => {
+    const ctx = createMockCtx(
+      {
+        '/workspace/iter.jsh':
+          'let total = ""; for await (const c of process.stdin) total += c; console.log(total.toUpperCase());',
+      },
+      {},
+      undefined,
+      'hi'
+    );
+    const result = await executeJshFile('/workspace/iter.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('HI');
+  });
+
+  it('exposes empty string when no stdin is piped', async () => {
+    const ctx = createMockCtx({
+      '/workspace/empty.jsh':
+        'console.log(JSON.stringify({ top: stdin, viaProcess: process.stdin.read(), tty: process.stdin.isTTY }));',
+    });
+    const result = await executeJshFile('/workspace/empty.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout.trim());
+    expect(parsed).toEqual({ top: '', viaProcess: '', tty: false });
+  });
+
+  it('preserves binary-shaped (latin1) stdin bytes verbatim', async () => {
+    // just-bash threads non-UTF-8 binary as a latin1 string (one JS char
+    // per byte). The realm must hand it back to user code byte-identical.
+    const bytes = String.fromCharCode(0x00, 0xff, 0x7f, 0x80, 0xc3, 0xa9);
+    const ctx = createMockCtx(
+      {
+        '/workspace/echo.jsh':
+          'const codes = []; for (const c of stdin) codes.push(c.charCodeAt(0)); console.log(codes.join(","));',
+      },
+      {},
+      undefined,
+      bytes
+    );
+    const result = await executeJshFile('/workspace/echo.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('0,255,127,128,195,169');
+  });
+
+  it('does not break scripts that ignore stdin', async () => {
+    // Regression guard for the additive AsyncFunction parameter.
+    const ctx = createMockCtx(
+      { '/workspace/quiet.jsh': 'console.log("ok");' },
+      {},
+      undefined,
+      'some piped input the script will never read'
+    );
+    const result = await executeJshFile('/workspace/quiet.jsh', [], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('ok\n');
   });
 });

--- a/packages/webapp/tests/shell/wasm-shell.test.ts
+++ b/packages/webapp/tests/shell/wasm-shell.test.ts
@@ -381,7 +381,7 @@ describe('WasmShell .jsh command registration', () => {
     // script would see an empty string regardless of the upstream pipe.
     await fs.writeFile(
       '/workspace/skills/test-cmd/scripts/upper.jsh',
-      'process.stdout.write(stdin.toUpperCase());'
+      'process.stdout.write(process.stdin.read().toUpperCase());'
     );
 
     const shell = new WasmShell({ fs });

--- a/packages/webapp/tests/shell/wasm-shell.test.ts
+++ b/packages/webapp/tests/shell/wasm-shell.test.ts
@@ -375,6 +375,37 @@ describe('WasmShell .jsh command registration', () => {
     expect(result.stdout).toContain('hello world');
   });
 
+  it('threads piped stdin into registered .jsh commands', async () => {
+    // The agent-facing path: a `.jsh` script registered as a bash command
+    // must be able to read piped input. Before stdin-in-jsh support, the
+    // script would see an empty string regardless of the upstream pipe.
+    await fs.writeFile(
+      '/workspace/skills/test-cmd/scripts/upper.jsh',
+      'process.stdout.write(stdin.toUpperCase());'
+    );
+
+    const shell = new WasmShell({ fs });
+    await shell.syncJshCommands();
+
+    const piped = await shell.executeCommand('echo -n hello | upper');
+    expect(piped.exitCode).toBe(0);
+    expect(piped.stdout).toBe('HELLO');
+  });
+
+  it('exposes process.stdin.read() inside registered .jsh commands', async () => {
+    await fs.writeFile(
+      '/workspace/skills/test-cmd/scripts/wc-bytes.jsh',
+      'console.log(process.stdin.read().length);'
+    );
+
+    const shell = new WasmShell({ fs });
+    await shell.syncJshCommands();
+
+    const piped = await shell.executeCommand('echo -n abcdef | wc-bytes');
+    expect(piped.exitCode).toBe(0);
+    expect(piped.stdout.trim()).toBe('6');
+  });
+
   it('does not shadow built-in commands with .jsh files of the same name', async () => {
     // Create a .jsh file named "echo" — should NOT override the built-in
     await fs.writeFile('/workspace/skills/test-cmd/scripts/echo.jsh', 'console.log("fake echo");');


### PR DESCRIPTION
## Summary

`.jsh` scripts and `node` / `node -e` invocations could not read piped input — pipelines like `echo foo | myscript.jsh` or `cat file | node -e '…'` were indistinguishable from no pipe at all. The JS realm's `processShim` never threaded `init.stdin` (already in the realm-init schema for the Python path) into user code, so the upstream pipeline's `ctx.stdin` reached the realm and was silently dropped.

This was the limitation flagged: \"jsh files can't read stdin\". This PR closes it.

## API

Two surfaces, mirroring Node where it's useful:

```javascript
// 1. Top-level `stdin` parameter — the ergonomic form
const cells = stdin.trim().split(',');

// 2. Node-like process.stdin
const buffer = process.stdin.read();              // sync, returns the buffered string
process.stdin.isTTY;                              // false (always)
for await (const chunk of process.stdin) { … }    // yields the buffered string once
```

Stdin is **fully read-ahead** — there is no streaming. If no input is piped, both surfaces return `''`. The buffer is byte-identical (latin1) end-to-end, so binary stdin survives.

## Implementation

- `packages/webapp/src/shell/jsh-executor.ts` — pass `ctx.stdin` to `runInRealm({ stdin })`. One-line wiring; the field was already in the schema, just unconsumed by the JS realm.
- `packages/webapp/src/kernel/realm/js-realm-shared.ts` — extend `processShim` with a `stdin` shim, and add `stdin` as the 9th `AsyncFunction` parameter so user code can reference it as a top-level binding. Additive — existing scripts that don't reference `stdin` are unchanged.
- `packages/chrome-extension/sandbox.html` — mirror the shim in the extension's CSP-exempt iframe (it runs its own bootstrap script outside the TS module graph; same dual-write rule that's already in place for the other realm shims).
- `packages/webapp/src/shell/supplemental-commands/node-command.ts` — when `node` consumes its own stdin as the script source (no `-e`, no script path), hand the inner script an empty stdin via a context override. Otherwise the script would see its own source as its piped input.

## Tests

`packages/webapp/tests/shell/jsh-executor.test.ts` (6 new):
- top-level `stdin` parameter
- `process.stdin.read()`
- `for await (const chunk of process.stdin)`
- empty-stdin defaults (`{ top: '', viaProcess: '', tty: false }`)
- binary (latin1) bytes preserved byte-identical: `\x00\xff\x7f\x80\xc3\xa9` round-trips intact
- regression guard: scripts that ignore stdin keep working

`packages/webapp/tests/shell/wasm-shell.test.ts` (2 new) — real end-to-end through `WasmShell` + just-bash pipeline:
- `echo -n hello | upper` → `HELLO`
- `echo -n abcdef | wc-bytes` → `6`

Results in touched suites:

```
Test Files  9 passed (9)
     Tests  156 passed (156)
```

## Docs

- `packages/webapp/CLAUDE.md` — one-line note under \`.jsh commands\` covering both surfaces, the fully-buffered (not streaming) caveat, and the `node`-reads-script-from-stdin edge case.
- `docs/shell-reference.md` — expanded \`process\` API table with the new fields, plus a new \`stdin (top-level parameter)\` subsection with example code.

## Verification

- `npx vitest run packages/webapp/tests/shell/jsh-executor.test.ts packages/webapp/tests/shell/wasm-shell.test.ts packages/webapp/tests/kernel/realm/` → 156/156 pass.
- `npx tsc --noEmit -p tsconfig.json` → zero errors in any touched file. (4 pre-existing baseline errors in `node-server/secrets/*` and `oauth-domain-command.ts` from an unrelated `@slicc/shared-ts` module-resolution issue, confirmed by stashing and re-running on `origin/main`.)
- `npx prettier --check` on every touched file → idempotent.

## Test plan

- [ ] `npm run typecheck`
- [ ] `npm run test`
- [ ] In the dev UI, drop `.jsh` files under `/workspace/skills/foo/scripts/` that read `stdin` and verify `echo -n bar | foo` works in both standalone and extension floats.