### PR TITLE
fix(extension-sw): filter tabs without numeric id in cdpGetTargets

### DIFF
--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -756,14 +756,19 @@ async function cdpGetTargets(): Promise<Record<string, unknown>> {
     chrome.tabs.query({ active: true, currentWindow: true }),
   ]);
   const activeTabIds = new Set(activeTabs.map((t) => t.id));
-  const targetInfos = tabs.map((tab) => ({
-    targetId: String(tab.id),
-    type: 'page',
-    title: tab.title ?? '',
-    url: tab.url ?? '',
-    attached: attachedTabs.has(tab.id!),
-    active: activeTabIds.has(tab.id!),
-  }));
+  // Skip tabs without a numeric id (devtools, anonymous pages). They
+  // can't be CDP-attached targets — without this filter, String(undefined)
+  // would surface "undefined" as a targetId and tab.id! would crash.
+  const targetInfos = tabs
+    .filter((tab): tab is typeof tab & { id: number } => typeof tab.id === 'number')
+    .map((tab) => ({
+      targetId: String(tab.id),
+      type: 'page',
+      title: tab.title ?? '',
+      url: tab.url ?? '',
+      attached: attachedTabs.has(tab.id),
+      active: activeTabIds.has(tab.id),
+    }));
   return { targetInfos };
 }
 


### PR DESCRIPTION
## Summary

After PR #650 widened `ChromeTab.id` to `number | undefined` (matching Chrome's actual contract for devtools/anonymous tabs), `cdpGetTargets` was left with two latent bugs:

1. `String(tab.id)` — would yield the literal string `"undefined"` as a `targetId` for any tab without a numeric id.
2. `tab.id!` non-null assertion — would crash at runtime if Chrome ever passed an id-less tab through.

This filters tabs to those with a numeric id before building `targetInfos`. CDP can't attach to id-less tabs anyway, so dropping them is semantically correct, not just defensive.

## Why this PR exists

`fix:` commit to trigger a semantic-release patch bump (v2.49.0 → v2.49.1) and re-attempt the Chrome Web Store publish that was skipped on v2.48.0 (pending review) and failed at the npm step on v2.49.0 (OIDC token expiry during long prepareCmd).

## Test plan

- [x] `npm run typecheck` PASS
- [x] `npx vitest run packages/chrome-extension/` — 12 files / 194 tests pass
- [ ] CWS publish step runs successfully on the merge → main release

🤖 Generated with [Claude Code](https://claude.com/claude-code)