### PR TITLE
fix(ui/standalone): clear all chat-state IDBs from the page on clear chat

### DIFF
--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -50,6 +50,8 @@ import { flushCredentialsToWorker, resolveDefaultModel } from './onboarding-help
 import { BrowserAPI, NavigationWatcher } from '../cdp/index.js';
 import { type Orchestrator } from '../scoops/index.js';
 import { publishAgentBridge } from '../scoops/agent-bridge.js';
+import { clearAllMessages as clearOrchestratorMessages } from '../scoops/db.js';
+import { SessionStore as AgentSessionStore } from '../core/session.js';
 import type { RegisteredScoop, ChannelMessage } from '../scoops/types.js';
 import type { LickEvent } from '../scoops/lick-manager.js';
 import {
@@ -1726,6 +1728,34 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
   layout.panels.memory.setOrchestrator(client as unknown as Orchestrator);
   layout.setScoopSwitcherOrchestrator?.(client as unknown as Orchestrator);
   layout.onScoopSelect = selectScoop;
+
+  // Wire clear chat — must drive the IDB clears from the PAGE in
+  // standalone, because the kernel worker is a DedicatedWorker that
+  // `location.reload()` tears down moments after this handler returns —
+  // possibly before its own `clear-chat` handler has finished persisting.
+  // Mirrors what `orchestrator.clearAllMessages` does, minus the
+  // in-memory bits that the soon-to-respawn worker doesn't carry across
+  // the reload. Three same-origin IDBs to clear:
+  //  - `slicc-groups.messages` — inter-scoop ChannelMessage history
+  //  - `agent-sessions`        — per-scoop AgentMessage[] (the actual
+  //                              conversation memory the LLM resumes from)
+  //  - `browser-coding-agent`  — the panel's view cache
+  // The extension path doesn't need this — its offscreen document
+  // survives the side-panel reload, so its `clear-chat` handler has time
+  // to complete.
+  layout.onClearChat = async () => {
+    await clearOrchestratorMessages().catch(() => {});
+    await new AgentSessionStore().clearAll().catch(() => {});
+    const scoops = client.getScoops();
+    for (const scoop of scoops) {
+      const sessionId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
+      await layout.panels.chat.deleteSessionById(sessionId);
+    }
+    // Fire-and-forget; the page-side IDB writes above are what survive
+    // the reload. This just keeps the worker's in-memory buffers tidy
+    // in case the reload races us.
+    client.clearAllMessages();
+  };
 
   // Brain-icon wiring (mirrors `mainExtension`).
   // - `onModelChange`: persist the user's choice locally so the worker's


### PR DESCRIPTION
## Summary

Clicking **Clear chat** in standalone didn't actually clear the conversation — the chat would visibly empty for a fraction of a second, then `location.reload()` would happen and the entire history would come right back.

The extension path was unaffected.

## Fix

Drive the IDB clears from the page side *before* the reload. All three stores are same-origin from the page — no worker round-trip needed.

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [x] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [x] `npm run typecheck`
- [x] `npm run test` — `<N>` passing, no new failures
- [x] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
