### PR TITLE
fix: guard postinstall against global/npx installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,6 +557,32 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             CODE_SIGNING_ALLOWED=NO
 
+  global-install:
+    needs: changes
+    if: >-
+      needs.changes.outputs.node-server == 'true' ||
+      needs.changes.outputs.root-config == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Build @slicc/shared-ts
+        run: npm run build -w @slicc/shared-ts
+      - name: Build node-server
+        run: npm run build -w @slicc/node-server
+      - name: Pack
+        run: npm pack
+      - name: Test global install
+        run: |
+          npm install -g ./sliccy-*.tgz
+          slicc --version
+      - name: Test npx
+        run: npx --yes sliccy@file:./sliccy-*.tgz --version
+
   # Wait for any in-progress release before allowing merge queue to land.
   # Only runs on merge_group events; skipped (= passing) for PRs.
   release-gate:
@@ -593,6 +619,7 @@ jobs:
         node-server,
         chrome-extension,
         cloudflare-worker,
+        global-install,
         swift-launcher,
         swift-server,
         ios-app,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,7 +575,7 @@ jobs:
       - name: Build node-server
         run: npm run build -w @slicc/node-server
       - name: Pack
-        run: echo "tarball=$(npm pack)" >> "$GITHUB_OUTPUT"
+        run: echo "tarball=$(npm pack --quiet | tail -1)" >> "$GITHUB_OUTPUT"
         id: pack
       - name: Test global install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,13 +575,14 @@ jobs:
       - name: Build node-server
         run: npm run build -w @slicc/node-server
       - name: Pack
-        run: npm pack
+        run: echo "tarball=$(npm pack)" >> "$GITHUB_OUTPUT"
+        id: pack
       - name: Test global install
         run: |
-          npm install -g ./sliccy-*.tgz
+          npm install -g ./${{ steps.pack.outputs.tarball }}
           slicc --version
       - name: Test npx
-        run: npx --yes sliccy@file:./sliccy-*.tgz --version
+        run: npx --yes "sliccy@file:./${{ steps.pack.outputs.tarball }}" --version
 
   # Wait for any in-progress release before allowing merge queue to land.
   # Only runs on merge_group events; skipped (= passing) for PRs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4151,9 +4151,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4171,9 +4168,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4191,9 +4185,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4211,9 +4202,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4231,9 +4219,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4251,9 +4236,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4151,6 +4151,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4168,6 +4171,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4185,6 +4191,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4202,6 +4211,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4219,6 +4231,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4236,6 +4251,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "package:release": "node dist/node-server/release-package.js",
     "publish:chrome": "node dist/node-server/publish-chrome-web-store.js",
     "publish:worker": "echo \"$CLOUDFLARE_TURN_API_TOKEN\" | npx wrangler secret put CLOUDFLARE_TURN_API_TOKEN --config packages/cloudflare-worker/wrangler.jsonc && echo \"$GITHUB_CLIENT_SECRET\" | npx wrangler secret put GITHUB_CLIENT_SECRET --config packages/cloudflare-worker/wrangler.jsonc && npx wrangler deploy --config packages/cloudflare-worker/wrangler.jsonc && MAX_ATTEMPTS=6; for attempt in $(seq 1 \"$MAX_ATTEMPTS\"); do if npx vitest run --project cloudflare-worker packages/cloudflare-worker/tests/deployed.test.ts; then exit 0; fi; if [ \"$attempt\" -eq \"$MAX_ATTEMPTS\" ]; then echo \"Deployed smoke test failed after $MAX_ATTEMPTS attempts\"; exit 1; fi; echo \"Deployed smoke test failed on attempt $attempt; waiting for edge propagation before retrying...\"; sleep 15; done",
-    "postinstall": "npm run build -w @slicc/shared-ts",
+    "postinstall": "if [ -d packages/shared-ts ]; then npm run build -w @slicc/shared-ts; fi",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- `npm install -g sliccy` and `npx sliccy` were failing with `Workspaces not supported for global packages` because `postinstall` ran `npm run build -w @slicc/shared-ts` unconditionally
- Guard the script with a directory check: only builds `shared-ts` when `packages/shared-ts` exists (dev clone), skips silently for global/npx installs where `dist/` is already pre-built

## Test plan

- [x] `npm install -g sliccy` completes without error
- [x] `npx sliccy --version` works on a fresh install
- [x] `npm install` in dev clone still builds `shared-ts` automatically
- [x] `npm run dev` works after a fresh `npm install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)