### PR TITLE
fix(oauth): make oauth-token work from the panel terminal

### DIFF
--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -42,6 +42,7 @@ import {
   getAccounts,
   getBaseUrlForProvider,
 } from '../src/ui/provider-settings.js';
+import { getOAuthPageOrigin } from '../src/providers/oauth-service.js';
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -307,16 +308,20 @@ export const config: ProviderConfig = {
     const scopes = resolveScopes(proxyConfig);
     const imsEnv = resolveImsEnvironment(proxyConfig);
 
+    // Resolve the page origin via panel-RPC when invoked from the kernel
+    // `DedicatedWorker` (no `window`); the page-context login path still
+    // reads `window.location.*` directly through the helper.
+    const pageInfo = isExtension ? null : await getOAuthPageOrigin();
     const redirectUri = isExtension
       ? (adobeConfig.extensionRedirectUri ??
         `https://${(chrome as any).runtime.id}.chromiumapp.org/`)
-      : (adobeConfig.redirectUri ?? `${window.location.origin}/auth/callback`);
+      : (adobeConfig.redirectUri ?? `${pageInfo!.origin}/auth/callback`);
 
     // Build OAuth state with port and CSRF nonce for the sliccy.ai relay (CLI only)
     const oauthState = !isExtension
       ? btoa(
           JSON.stringify({
-            port: parseInt(new URL(window.location.href).port || '5710', 10),
+            port: parseInt(new URL(pageInfo!.href).port || '5710', 10),
             path: '/auth/callback',
             nonce: crypto.randomUUID(),
           })

--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -41,6 +41,7 @@ import {
   revokeOAuthToken,
   getWorkerBaseUrl,
 } from '../src/providers/oauth-code-exchange.js';
+import { getOAuthPageOrigin } from '../src/providers/oauth-service.js';
 import { GLOBAL_FS_DB_NAME } from '../src/fs/global-db.js';
 
 // ── Config ─────────────────────────────────────────────────────────
@@ -457,9 +458,14 @@ export const config: ProviderConfig = {
     // reads the `state` param (source=local|extension) and forwards to the
     // correct final destination. Using one registered URL per OAuth App lets
     // GitHub OAuth Apps (single-callback) work for both CLI and extension.
+    //
+    // The CLI branch resolves `origin` / `href` via `getOAuthPageOrigin()` so
+    // the same code works when `onOAuthLogin` is invoked from a shell command
+    // running inside the kernel `DedicatedWorker` (which has no `window`).
+    const pageInfo = isExtension ? null : await getOAuthPageOrigin();
     const redirectUri = isExtension
       ? `${getWorkerBaseUrl()}/auth/callback`
-      : `${runtimeWorkerBaseUrl ?? window.location.origin}/auth/callback`;
+      : `${runtimeWorkerBaseUrl ?? pageInfo!.origin}/auth/callback`;
 
     const nonce = crypto.randomUUID();
     const extensionId = isExtension
@@ -468,7 +474,7 @@ export const config: ProviderConfig = {
     const stateData = isExtension
       ? { source: 'extension', extensionId, path: '/github', nonce }
       : {
-          port: parseInt(new URL(window.location.href).port || '5710', 10),
+          port: parseInt(new URL(pageInfo!.href).port || '5710', 10),
           path: '/auth/callback',
           nonce,
         };

--- a/packages/webapp/src/providers/oauth-service.ts
+++ b/packages/webapp/src/providers/oauth-service.ts
@@ -24,6 +24,32 @@ export function createOAuthLauncher(): OAuthLauncher {
 }
 
 /**
+ * Worker-aware page origin lookup. Provider `onOAuthLogin` implementations
+ * construct redirect URIs and OAuth `state` payloads from
+ * `window.location.origin` / `window.location.href`, but when the shell
+ * command `oauth-token <provider>` invokes them they run inside the kernel
+ * `DedicatedWorker` where `window` is undefined. This helper returns the page
+ * origin directly when called in the page (or extension offscreen DOM), and
+ * routes through panel-RPC `page-info` when called from the worker.
+ *
+ * Throws when neither path is available so callers surface a clear error
+ * instead of `ReferenceError: window is not defined`.
+ */
+export async function getOAuthPageOrigin(): Promise<{ origin: string; href: string }> {
+  if (typeof window !== 'undefined') {
+    return { origin: window.location.origin, href: window.location.href };
+  }
+  const rpc = getPanelRpcClient();
+  if (!rpc) {
+    throw new Error(
+      'OAuth from worker context requires the panel-RPC bridge (no page-info available)'
+    );
+  }
+  const info = await rpc.call('page-info', undefined);
+  return { origin: info.origin, href: info.href };
+}
+
+/**
  * Worker-context OAuth launcher. Delegates to the page via panel-RPC so the
  * page can open a real popup window (workers have no `window.open`).
  */

--- a/packages/webapp/tests/providers/github-oauth-login.test.ts
+++ b/packages/webapp/tests/providers/github-oauth-login.test.ts
@@ -225,3 +225,122 @@ describe('github.ts onOAuthLogin writes masked token to VFS', () => {
     expect(vfsToken).not.toContain('ghp_REAL_token_123');
   });
 });
+
+describe('github.ts onOAuthLogin in worker context (no window)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalLocalStorage: Storage;
+  let originalWindow: any;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalLocalStorage = globalThis.localStorage;
+    originalWindow = (globalThis as any).window;
+
+    const lsData: Record<string, string> = {};
+    (globalThis as any).localStorage = {
+      getItem: (k: string) => lsData[k] ?? null,
+      setItem: (k: string, v: string) => {
+        lsData[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete lsData[k];
+      },
+      clear: () => {
+        for (const k of Object.keys(lsData)) delete lsData[k];
+      },
+    };
+    delete (globalThis as any).chrome;
+    // Worker realm: explicitly remove the window global so the github
+    // provider must resolve page origin via panel-RPC.
+    delete (globalThis as any).window;
+
+    // Stand-in panel-RPC bridge that answers page-info from the simulated page.
+    (globalThis as any).__slicc_panelRpc = {
+      call: vi.fn(async (op: string) => {
+        if (op !== 'page-info') throw new Error(`unexpected op ${op}`);
+        return {
+          origin: 'http://localhost:5711',
+          href: 'http://localhost:5711/?cone=1',
+          title: '',
+        };
+      }),
+      dispose: () => {},
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    (globalThis as any).localStorage = originalLocalStorage;
+    if (originalWindow === undefined) {
+      delete (globalThis as any).window;
+    } else {
+      (globalThis as any).window = originalWindow;
+    }
+    delete (globalThis as any).__slicc_panelRpc;
+  });
+
+  it('resolves redirectUri and state port via panel-RPC instead of throwing "window is not defined"', async () => {
+    let observedAuthorizeUrl = '';
+    globalThis.fetch = vi.fn(async (url: any) => {
+      const urlStr = String(url);
+      if (urlStr.includes('/api/runtime-config')) {
+        return {
+          ok: true,
+          json: async () => ({ oauth: { github: 'worker-client-id' } }),
+        } as any;
+      }
+      if (urlStr.includes('/oauth/token')) {
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: 'ghp_worker_token',
+            token_type: 'Bearer',
+            scope: 'repo',
+          }),
+        } as any;
+      }
+      if (urlStr.includes('api.github.com/user')) {
+        return {
+          ok: true,
+          json: async () => ({ login: 'worker-user', id: 7 }),
+        } as any;
+      }
+      if (urlStr.includes('/api/secrets/oauth-update')) {
+        return {
+          ok: true,
+          json: async () => ({
+            providerId: 'github',
+            name: 'oauth.github.token',
+            maskedValue: 'ghp_masked_worker',
+            domains: ['github.com'],
+          }),
+        } as any;
+      }
+      return { ok: false, status: 404 } as any;
+    });
+
+    const { config } = await import('../../providers/github.js');
+
+    const fakeLauncher = vi.fn(async (url: string) => {
+      observedAuthorizeUrl = url;
+      const authUrl = new URL(url);
+      const state = authUrl.searchParams.get('state');
+      const stateData = state ? JSON.parse(atob(state)) : null;
+      return `https://x.com/callback?code=worker-code&nonce=${stateData?.nonce ?? ''}`;
+    });
+
+    // Must NOT throw "window is not defined"
+    await expect(config.onOAuthLogin!(fakeLauncher, () => {}, undefined)).resolves.toBeUndefined();
+
+    // Authorize URL must carry a state with the page port (5711) reconstructed
+    // from the panel-RPC page-info response, not the default 5710.
+    const auth = new URL(observedAuthorizeUrl);
+    const stateRaw = auth.searchParams.get('state');
+    expect(stateRaw).toBeTruthy();
+    const stateData = JSON.parse(atob(stateRaw!));
+    expect(stateData.port).toBe(5711);
+
+    // redirect_uri must point at the page origin returned by panel-RPC
+    expect(auth.searchParams.get('redirect_uri')).toBe('http://localhost:5711/auth/callback');
+  });
+});

--- a/packages/webapp/tests/providers/oauth-service.test.ts
+++ b/packages/webapp/tests/providers/oauth-service.test.ts
@@ -46,7 +46,7 @@ function fireMessage(data: unknown, opts: { origin?: string; source?: object | n
 }
 
 // Import AFTER stubs are in place (module reads `window` at call time)
-import { createOAuthLauncher } from '../../src/providers/oauth-service.js';
+import { createOAuthLauncher, getOAuthPageOrigin } from '../../src/providers/oauth-service.js';
 
 describe('createOAuthLauncher', () => {
   beforeEach(() => {
@@ -266,5 +266,47 @@ describe('createOAuthLauncher', () => {
 
     const result = await promise;
     expect(result).toBe('http://localhost:5710/auth/callback#token=first');
+  });
+});
+
+describe('getOAuthPageOrigin', () => {
+  const originalWindow = (globalThis as any).window;
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as any).window;
+    } else {
+      (globalThis as any).window = originalWindow;
+    }
+    delete (globalThis as any).__slicc_panelRpc;
+  });
+
+  it('reads origin and href from window when available', async () => {
+    (globalThis as any).window = {
+      location: { origin: 'http://localhost:5711', href: 'http://localhost:5711/?x=1' },
+    };
+    const info = await getOAuthPageOrigin();
+    expect(info.origin).toBe('http://localhost:5711');
+    expect(info.href).toBe('http://localhost:5711/?x=1');
+  });
+
+  it('routes through panel-RPC when window is undefined (worker context)', async () => {
+    delete (globalThis as any).window;
+    const callSpy = vi.fn(async (op: string) => {
+      expect(op).toBe('page-info');
+      return { origin: 'http://localhost:5731', href: 'http://localhost:5731/foo', title: 't' };
+    });
+    (globalThis as any).__slicc_panelRpc = { call: callSpy, dispose: () => {} };
+
+    const info = await getOAuthPageOrigin();
+    expect(callSpy).toHaveBeenCalled();
+    expect(info.origin).toBe('http://localhost:5731');
+    expect(info.href).toBe('http://localhost:5731/foo');
+  });
+
+  it('throws with a clear message when no window and no panel-RPC bridge', async () => {
+    delete (globalThis as any).window;
+    delete (globalThis as any).__slicc_panelRpc;
+    await expect(getOAuthPageOrigin()).rejects.toThrow(/panel-RPC bridge/);
   });
 });


### PR DESCRIPTION
## Summary

`oauth-token github` from the panel terminal fails with
`oauth-token: login failed: window is not defined`. The shell command runs
inside the standalone kernel `DedicatedWorker` where `window` is undefined.
`oauth-service.ts` already routes the popup through panel-RPC for that case
(see \`launchOAuthViaPanel\`), but the GitHub and Adobe \`onOAuthLogin\`
implementations still reach for \`window.location.origin\` / \`window.location.href\`
to build the \`redirect_uri\` and OAuth \`state.port\` — that throws before the
launcher is ever called.

## Fix

- Add \`getOAuthPageOrigin()\` in \`packages/webapp/src/providers/oauth-service.ts\`. When invoked from a DOM-bearing realm it returns \`window.location.{origin,href}\` directly; from the kernel worker it routes through the panel-RPC \`page-info\` op (already wired in \`panel-rpc-handlers.ts\`) and throws a clear error when no bridge is available.
- Update \`packages/webapp/providers/github.ts\` and \`packages/webapp/providers/adobe.ts\` interactive login paths to use the helper instead of touching \`window\` directly.
- Leave \`silentRenewToken\` in adobe.ts alone — its existing worker short-circuit (\`if (typeof window === 'undefined') return null\`) correctly defers silent renewal to the page-side oauth-bootstrap, which is the documented contract.

## Why this is the right shape

- Page-context flows (avatar \"Log in with…\" buttons) keep their direct \`window\` path.
- Worker-context flows (\`oauth-token\` shell command from the panel terminal) get the actual page origin/port from panel-RPC, so the OAuth \`state\` round-trip still resolves back to the correct port.
- Extension mode is untouched: \`isExtension\` branch never reads \`window.location\` for redirect URI construction.

## Tests

- \`tests/providers/oauth-service.test.ts\` — three new cases covering page, worker-with-RPC, and worker-without-RPC code paths of \`getOAuthPageOrigin\`.
- \`tests/providers/github-oauth-login.test.ts\` — new \"worker context\" describe block that deletes \`globalThis.window\`, stands up a fake panel-RPC bridge, and asserts \`onOAuthLogin\` resolves without throwing and embeds the panel-RPC-reported port (5711) into the OAuth state.

## Verification

\`\`\`
npx prettier --check (changed files)   # clean
npm run typecheck                       # clean
npm run test                            # 4291 passed, 3 skipped
\`\`\`

Repro before fix:
\`\`\`
/ \$ oauth-token github
oauth-token: login failed: window is not defined
\`\`\`