### PR TITLE
fix(workflow): enqueue cleanup PR into the merge queue

### DIFF
--- a/.github/workflows/planning-artifact-cleanup.yml
+++ b/.github/workflows/planning-artifact-cleanup.yml
@@ -105,15 +105,27 @@ jobs:
               exit 0
             fi
 
+            # mergeStateStatus reference:
+            #   CLEAN / HAS_HOOKS  -> green, ready to enqueue
+            #   UNSTABLE           -> required checks pending or failing; keep waiting
+            #   BLOCKED            -> usually transient while CI is still running on a
+            #                         fresh push (queue + required checks not yet green);
+            #                         keep waiting until the polling timeout
+            #   UNKNOWN            -> GitHub still computing; keep waiting
+            #   DIRTY / BEHIND     -> needs human attention (conflict or rebase)
+            #   DRAFT              -> shouldn't happen for this workflow, but treat as terminal
             case "$merge_state" in
-              CLEAN|UNSTABLE|HAS_HOOKS)
+              CLEAN | HAS_HOOKS)
                 if [ "$mergeable" = "MERGEABLE" ]; then
                   break
                 fi
                 ;;
-              DIRTY|BLOCKED)
+              DIRTY | BEHIND | DRAFT)
                 echo "PR is $merge_state; cannot enqueue. Exiting."
                 exit 0
+                ;;
+              *)
+                # UNSTABLE, BLOCKED, UNKNOWN, anything else -> keep polling.
                 ;;
             esac
 

--- a/.github/workflows/planning-artifact-cleanup.yml
+++ b/.github/workflows/planning-artifact-cleanup.yml
@@ -68,8 +68,62 @@ jobs:
           fi
           echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
 
-      - name: Enable auto-merge for cleanup PR
+      - name: Add cleanup PR to merge queue
         if: steps.cleanup.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr merge --auto "${{ steps.pr.outputs.url }}"
+          PR_URL: ${{ steps.pr.outputs.url }}
+        # `gh pr merge --auto` only enables auto-merge, which does NOT add
+        # the PR to a required merge queue. We poll until the PR is
+        # mergeable (CI green) and then explicitly enqueue via the
+        # `enqueuePullRequest` GraphQL mutation, which is what the
+        # "Merge when ready" button calls.
+        run: |
+          set -euo pipefail
+          PR_ID=$(gh pr view "$PR_URL" --json id --jq '.id')
+
+          already_queued=$(gh pr view "$PR_URL" --json isInMergeQueue --jq '.isInMergeQueue')
+          if [ "$already_queued" = "true" ]; then
+            echo "PR already in merge queue; nothing to do."
+            exit 0
+          fi
+
+          attempts=60
+          sleep_seconds=30
+          for i in $(seq 1 "$attempts"); do
+            state=$(gh pr view "$PR_URL" \
+              --json mergeable,mergeStateStatus,isInMergeQueue \
+              --jq '"\(.mergeable)|\(.mergeStateStatus)|\(.isInMergeQueue)"')
+            mergeable=${state%%|*}
+            rest=${state#*|}
+            merge_state=${rest%%|*}
+            queued=${rest#*|}
+            echo "attempt $i/$attempts mergeable=$mergeable mergeStateStatus=$merge_state isInMergeQueue=$queued"
+
+            if [ "$queued" = "true" ]; then
+              echo "PR entered queue out-of-band; done."
+              exit 0
+            fi
+
+            case "$merge_state" in
+              CLEAN|UNSTABLE|HAS_HOOKS)
+                if [ "$mergeable" = "MERGEABLE" ]; then
+                  break
+                fi
+                ;;
+              DIRTY|BLOCKED)
+                echo "PR is $merge_state; cannot enqueue. Exiting."
+                exit 0
+                ;;
+            esac
+
+            if [ "$i" -eq "$attempts" ]; then
+              echo "Timed out waiting for PR to become mergeable."
+              exit 1
+            fi
+            sleep "$sleep_seconds"
+          done
+
+          gh api graphql \
+            -f query='mutation($id:ID!){ enqueuePullRequest(input:{pullRequestId:$id}){ mergeQueueEntry{ position } } }' \
+            -F id="$PR_ID"


### PR DESCRIPTION
## Why

The `Planning Artifact Cleanup` workflow opens a PR (most recently #652) to remove `docs/superpowers/**` planning artifacts from `main`, then runs `gh pr merge --auto` on it. With a required merge queue on `main`, that command **does not** add the PR to the queue — it only flips the GitHub "Auto-merge" toggle, which then attempts a direct merge and is silently blocked by the `merge_queue` ruleset.

Result: PR #652 has been sitting `MERGEABLE` / `CLEAN`, all checks green, auto-merge on, but never enters the queue. Every subsequent push to `main` opens a new identical cleanup branch that never lands either.

## What

Replace the `gh pr merge --auto` step with one that:

1. Reads the PR's GraphQL node id.
2. Polls `mergeable` + `mergeStateStatus` + `isInMergeQueue` (up to 30 minutes) so we wait for CI to finish on the cleanup branch.
3. Calls the `enqueuePullRequest` GraphQL mutation explicitly — the same operation the "Merge when ready" UI button triggers.

Handles the obvious edge cases:

- already in the queue from a prior run → exit 0
- `DIRTY` / `BLOCKED` merge state → exit 0 (the cleanup PR has a real problem; surface it via the unmerged PR rather than spinning)
- polling timeout → exit 1 so the workflow surfaces the failure

## Verification

- `npx prettier --write` ran clean on the file.
- The change is workflow-only; no app code paths touched.
- After this merges, the next push to `main` that produces planning-artifact changes will exercise the new step end-to-end. PR #652 itself can be unstuck manually once by clicking "Merge when ready" (or by triggering the workflow via `workflow_dispatch` once this is on `main`).
