### PR TITLE
fix(swift-server): launch Chrome via LaunchServices so macOS TCC grants camera/mic access

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -94,6 +94,8 @@ export default tseslint.config(
       'packages/node-server/scripts/**/*.{mjs,js,ts}',
       'packages/cloudflare-worker/src/**/*.ts',
       'packages/dev-tools/tools/**/*.{mjs,js,ts}',
+      'packages/swift-launcher/**/*.{mjs,js,ts}',
+      'packages/swift-server/**/*.{mjs,js,ts}',
       'vite.config*.ts',
     ],
     languageOptions: {

--- a/packages/swift-launcher/assemble-app.mjs
+++ b/packages/swift-launcher/assemble-app.mjs
@@ -128,6 +128,10 @@ const infoPlist = `<?xml version="1.0" encoding="UTF-8"?>
     <false/>
     <key>NSSupportsSuddenTermination</key>
     <false/>
+    <key>NSCameraUsageDescription</key>
+    <string>Slicc launches Google Chrome to host the assistant UI. Chrome — not Slicc — uses the camera for sites you visit (Google Meet, Zoom, etc.). Grant access if you want camera-enabled sites to work inside Slicc.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Slicc launches Google Chrome to host the assistant UI. Chrome — not Slicc — uses the microphone for sites you visit (Google Meet, Zoom, etc.). Grant access if you want microphone-enabled sites to work inside Slicc.</string>
 </dict>
 </plist>
 `;

--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -54,6 +54,14 @@ enum ChromeLauncherError: LocalizedError, Sendable {
     case chromeExitedBeforeReportingPort(Int32)
     case timedOutWaitingForPort(TimeInterval)
     case cdpUnavailable(Int)
+    /// `/usr/bin/open` returned a non-zero exit code while trying to start
+    /// Chrome via LaunchServices. We use `open` so that LaunchServices —
+    /// not slicc-server / Sliccstart — becomes Chrome's parent and TCC
+    /// responsible process; this matters for camera/microphone access on
+    /// macOS, where TCC otherwise blames the closest GUI ancestor for the
+    /// hardware request and silently drops it if the ancestor has no
+    /// `NS{Camera,Microphone}UsageDescription`.
+    case openLaunchFailed(exitCode: Int32, executable: String)
     /// A Chrome instance was already listening on the requested CDP port
     /// when we tried to launch our own. Spawning a second Chrome with the
     /// same user-data-dir would have made the new process hand its URL
@@ -78,6 +86,8 @@ enum ChromeLauncherError: LocalizedError, Sendable {
         case .chromeAlreadyRunning(let port, let browser):
             let tail = browser.map { " (\($0))" } ?? ""
             return "A Chrome instance is already running on CDP port \(port)\(tail). Quit it before starting slicc-server again."
+        case .openLaunchFailed(let exitCode, let executable):
+            return "/usr/bin/open exited with code \(exitCode) while launching \(executable)."
         }
     }
 }
@@ -160,6 +170,36 @@ struct ChromeLauncher: Sendable {
         return args
     }
 
+    /// Compose the argument vector for `/usr/bin/open` that launches the
+    /// resolved Chrome `.app` bundle with our Chromium flags. The exact
+    /// `-n -a <bundle> -W --args …` shape mirrors `ElectronLauncher`, so
+    /// LaunchServices owns the spawned process and Chrome — not
+    /// slicc-server — becomes its own TCC responsible process for camera
+    /// and microphone access.
+    func buildOpenLaunchArgs(
+        appBundlePath: String,
+        chromeArgs: [String]
+    ) -> [String] {
+        return ["-n", "-a", appBundlePath, "-W", "--args"] + chromeArgs
+    }
+
+    /// Walk up from a Chrome executable path (`…/Foo.app/Contents/MacOS/Foo`)
+    /// to its enclosing `.app` bundle. Returns `nil` for bare-binary paths
+    /// (which falls back to the direct-exec launch path used in tests).
+    func resolveAppBundle(forExecutable executablePath: String) -> String? {
+        let url = URL(fileURLWithPath: executablePath)
+        let pathComponents = url.pathComponents
+        // Look for the deepest path component ending in ".app". Both
+        // canonical Chrome ("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+        // and Chrome for Testing
+        // ("~/.cache/puppeteer/chrome/mac-X/chrome-mac-arm64/Google Chrome for Testing.app/…")
+        // sit inside a `.app` bundle that LaunchServices can open.
+        guard let appIndex = pathComponents.lastIndex(where: { $0.lowercased().hasSuffix(".app") }) else {
+            return nil
+        }
+        return NSString.path(withComponents: Array(pathComponents.prefix(appIndex + 1)))
+    }
+
     func resolveUserDataDir(tmpDir: String? = nil, servePort: Int? = nil) -> String {
         let baseTmpDir = normalizedPath(tmpDir)
             ?? normalizedPath(environmentProvider()["TMPDIR"])
@@ -196,8 +236,7 @@ struct ChromeLauncher: Sendable {
         }
 
         let process = processFactory()
-        process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = buildLaunchArgs(
+        let chromeArgs = buildLaunchArgs(
             cdpPort: config.cdpPort,
             launchUrl: config.launchUrl,
             userDataDir: config.userDataDir,
@@ -213,20 +252,92 @@ struct ChromeLauncher: Sendable {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        let outputMonitor = ChromeOutputMonitor(
-            process: process,
-            stdout: stdoutPipe.fileHandleForReading,
-            stderr: stderrPipe.fileHandleForReading,
-            logger: logger
-        )
+        let usesLaunchServices: Bool
+        if let appBundlePath = resolveAppBundle(forExecutable: executable) {
+            // Route the spawn through `/usr/bin/open` so LaunchServices owns
+            // the new Chrome process. Without this, slicc-server (and
+            // therefore Sliccstart) stays in Chrome's TCC responsibility
+            // chain; macOS then blames our launcher bundle for any
+            // camera/microphone access Chrome makes — and silently denies
+            // it because the launcher has no NS*UsageDescription. With
+            // LaunchServices in the loop, Chrome becomes its own TCC
+            // responsible process and the canonical
+            // "/Applications/Google Chrome.app" privacy grant applies as
+            // users expect.
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            process.arguments = buildOpenLaunchArgs(
+                appBundlePath: appBundlePath,
+                chromeArgs: chromeArgs
+            )
+            usesLaunchServices = true
+        } else {
+            // Fallback for bare-binary paths (largely a test affordance):
+            // exec the binary directly and scrape its stderr for the CDP
+            // port the way we used to.
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = chromeArgs
+            usesLaunchServices = false
+        }
 
         try process.run()
         logger.info("Launched Chrome at \(executable)")
 
-        let actualPort = try await outputMonitor.awaitPort(timeout: config.launchTimeout)
-        _ = try await waitForCDP(port: actualPort)
+        let actualPort: Int
+        if usesLaunchServices {
+            actualPort = config.cdpPort
+            try await waitForCDPReady(port: actualPort, timeout: config.launchTimeout, process: process)
+        } else {
+            let outputMonitor = ChromeOutputMonitor(
+                process: process,
+                stdout: stdoutPipe.fileHandleForReading,
+                stderr: stderrPipe.fileHandleForReading,
+                logger: logger
+            )
+            actualPort = try await outputMonitor.awaitPort(timeout: config.launchTimeout)
+            _ = try await waitForCDP(port: actualPort)
+        }
         logger.info("Chrome CDP listening on port \(actualPort)")
         return ChromeProcess(process: process, cdpPort: actualPort)
+    }
+
+    /// Poll Chrome's `/json/version` endpoint until it answers with a CDP
+    /// payload or the launch budget runs out. This is the LaunchServices
+    /// counterpart to `ChromeOutputMonitor.awaitPort()`: when we spawn
+    /// Chrome through `/usr/bin/open`, the open helper is the only thing
+    /// connected to our stderr pipe and the CDP `DevTools listening on`
+    /// banner never reaches us. We also watch the `open` process so a
+    /// non-zero LaunchServices exit fails fast instead of waiting out the
+    /// full timeout.
+    private func waitForCDPReady(port: Int, timeout: TimeInterval, process: Process) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + UInt64(max(timeout, 0) * 1_000_000_000)
+        let pollIntervalNanos: UInt64 = 100_000_000
+        let versionURL = URL(string: "http://127.0.0.1:\(port)/json/version")!
+
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if !process.isRunning {
+                let exitCode = process.terminationStatus
+                if exitCode != 0 {
+                    throw ChromeLauncherError.openLaunchFailed(exitCode: exitCode, executable: "/usr/bin/open")
+                }
+                // `open` exits 0 once LaunchServices has handed off; keep polling.
+            }
+
+            do {
+                let (data, response) = try await fetchData(versionURL)
+                if let httpResponse = response as? HTTPURLResponse,
+                   (200..<300).contains(httpResponse.statusCode),
+                   Self.extractWebSocketDebuggerURL(from: data) != nil {
+                    return
+                }
+            } catch {
+                // Keep polling — transient connection refused is expected
+                // while Chrome boots.
+            }
+
+            try await Task.sleep(nanoseconds: pollIntervalNanos)
+        }
+
+        throw ChromeLauncherError.timedOutWaitingForPort(timeout)
     }
 
     func waitForCDP(port: Int, retries: Int = 50, delay: TimeInterval = 0.1) async throws -> String {

--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -1,9 +1,12 @@
+import AppKit
 import Foundation
 import Logging
 
 private let defaultChromeUserDataDirName = "browser-coding-agent-chrome"
 private let defaultServePort = 5710
 private let defaultChromeLaunchTimeout: TimeInterval = 15
+private let chromePidDiscoveryTimeout: TimeInterval = 5
+private let chromePidDiscoveryPollIntervalNanos: UInt64 = 100_000_000
 private let cdpPortRegex = try! NSRegularExpression(
     pattern: #"DevTools listening on ws://[^:]+:(\d+)/"#,
     options: []
@@ -12,6 +15,21 @@ private let cdpPortRegex = try! NSRegularExpression(
 struct ChromeProcess: @unchecked Sendable {
     let process: Process
     let cdpPort: Int
+    /// Real Chrome browser-process PID when the spawn went through
+    /// `/usr/bin/open` (LaunchServices), `nil` for the direct-exec
+    /// fallback (where `process.processIdentifier` is already Chrome's
+    /// PID). The graceful-shutdown handler needs this because in the
+    /// LaunchServices path `process` wraps `open`, so SIGKILL'ing
+    /// `process.processIdentifier` would only kill the `open` helper and
+    /// leave Chrome running — which then holds the CDP port and user
+    /// data dir, blocking the next launch.
+    let chromePid: pid_t?
+
+    init(process: Process, cdpPort: Int, chromePid: pid_t? = nil) {
+        self.process = process
+        self.cdpPort = cdpPort
+        self.chromePid = chromePid
+    }
 }
 
 struct ChromeLaunchConfig: Sendable {
@@ -101,6 +119,11 @@ struct ChromeLauncher: Sendable {
     private let homeDirectoryProvider: @Sendable () -> String
     private let processFactory: @Sendable () -> Process
     private let fetchData: @Sendable (URL) async throws -> (Data, URLResponse)
+    /// Snapshot the PIDs of every running app whose bundle URL matches
+    /// `bundleURL` (canonical Chrome.app, Chrome for Testing.app, etc.).
+    /// Injected so tests can simulate "new Chrome process appeared after
+    /// launch" without actually spawning Chrome.
+    private let runningPidsForBundle: @Sendable (URL) -> Set<pid_t>
 
     init(
         logger: Logger = Logger(label: "slicc.chrome-launcher"),
@@ -125,6 +148,17 @@ struct ChromeLauncher: Sendable {
             request.timeoutInterval = 2
             request.cachePolicy = .reloadIgnoringLocalCacheData
             return try await URLSession.shared.data(for: request)
+        },
+        runningPidsForBundle: @escaping @Sendable (URL) -> Set<pid_t> = { bundleURL in
+            let canonical = bundleURL.standardizedFileURL
+            return Set(NSWorkspace.shared.runningApplications.compactMap { app -> pid_t? in
+                guard let appBundleURL = app.bundleURL?.standardizedFileURL,
+                      appBundleURL == canonical,
+                      app.processIdentifier > 0 else {
+                    return nil
+                }
+                return app.processIdentifier
+            })
         }
     ) {
         self.logger = logger
@@ -135,6 +169,7 @@ struct ChromeLauncher: Sendable {
         self.homeDirectoryProvider = homeDirectoryProvider
         self.processFactory = processFactory
         self.fetchData = fetchData
+        self.runningPidsForBundle = runningPidsForBundle
     }
 
     func findChromeExecutable() -> String? {
@@ -253,6 +288,8 @@ struct ChromeLauncher: Sendable {
         process.standardError = stderrPipe
 
         let usesLaunchServices: Bool
+        let chromeBundleURL: URL?
+        let preexistingChromePids: Set<pid_t>
         if let appBundlePath = resolveAppBundle(forExecutable: executable) {
             // Route the spawn through `/usr/bin/open` so LaunchServices owns
             // the new Chrome process. Without this, slicc-server (and
@@ -270,6 +307,14 @@ struct ChromeLauncher: Sendable {
                 chromeArgs: chromeArgs
             )
             usesLaunchServices = true
+            // Snapshot every running Chrome instance for this bundle *before*
+            // spawning so we can identify the new process by set-difference
+            // after `open` returns. `-n` in `buildOpenLaunchArgs` always
+            // forces a fresh instance, so the new PID is guaranteed to be
+            // outside this set.
+            let bundleURL = URL(fileURLWithPath: appBundlePath)
+            chromeBundleURL = bundleURL
+            preexistingChromePids = runningPidsForBundle(bundleURL)
         } else {
             // Fallback for bare-binary paths (largely a test affordance):
             // exec the binary directly and scrape its stderr for the CDP
@@ -277,15 +322,42 @@ struct ChromeLauncher: Sendable {
             process.executableURL = URL(fileURLWithPath: executable)
             process.arguments = chromeArgs
             usesLaunchServices = false
+            chromeBundleURL = nil
+            preexistingChromePids = []
         }
 
         try process.run()
         logger.info("Launched Chrome at \(executable)")
 
         let actualPort: Int
+        let chromePid: pid_t?
         if usesLaunchServices {
             actualPort = config.cdpPort
             try await waitForCDPReady(port: actualPort, timeout: config.launchTimeout, process: process)
+            // CDP is up, so Chrome must be running — discover its real PID
+            // via NSWorkspace so the SIGKILL fallback in
+            // GracefulShutdownHandler.closeBrowser can target Chrome
+            // itself rather than the `open` helper that started it. The
+            // discovery has its own short budget; missing the PID is
+            // logged but non-fatal (`Browser.close` via CDP still works
+            // for normal shutdowns, and the registry will just no-op the
+            // last-resort SIGKILL).
+            if let bundleURL = chromeBundleURL {
+                chromePid = await discoverLaunchedChromePid(
+                    bundleURL: bundleURL,
+                    existingPids: preexistingChromePids,
+                    timeout: chromePidDiscoveryTimeout
+                )
+                if let chromePid {
+                    logger.info("Resolved Chrome PID via LaunchServices: \(chromePid)")
+                } else {
+                    logger.warning(
+                        "Could not resolve Chrome PID after \(chromePidDiscoveryTimeout)s; SIGKILL fallback will be a no-op"
+                    )
+                }
+            } else {
+                chromePid = nil
+            }
         } else {
             let outputMonitor = ChromeOutputMonitor(
                 process: process,
@@ -295,9 +367,31 @@ struct ChromeLauncher: Sendable {
             )
             actualPort = try await outputMonitor.awaitPort(timeout: config.launchTimeout)
             _ = try await waitForCDP(port: actualPort)
+            chromePid = nil
         }
         logger.info("Chrome CDP listening on port \(actualPort)")
-        return ChromeProcess(process: process, cdpPort: actualPort)
+        return ChromeProcess(process: process, cdpPort: actualPort, chromePid: chromePid)
+    }
+
+    /// Poll `runningPidsForBundle` for a new PID that wasn't present in
+    /// `existingPids`. Returns the first new PID or `nil` if the timeout
+    /// elapses (e.g. the user terminated Chrome from the Dock before we
+    /// could observe it). Exposed at `internal` visibility so unit tests
+    /// can drive it directly with a stubbed `runningPidsForBundle`.
+    func discoverLaunchedChromePid(
+        bundleURL: URL,
+        existingPids: Set<pid_t>,
+        timeout: TimeInterval
+    ) async -> pid_t? {
+        let deadline = DispatchTime.now().uptimeNanoseconds + UInt64(max(timeout, 0) * 1_000_000_000)
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            let candidates = runningPidsForBundle(bundleURL).subtracting(existingPids)
+            if let pid = candidates.min() {
+                return pid
+            }
+            try? await Task.sleep(nanoseconds: chromePidDiscoveryPollIntervalNanos)
+        }
+        return runningPidsForBundle(bundleURL).subtracting(existingPids).min()
     }
 
     /// Poll Chrome's `/json/version` endpoint until it answers with a CDP

--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -87,6 +87,11 @@ struct ServerCommand: AsyncParsableCommand {
         let serveOrigin = "http://localhost:\(servePort)"
 
         var browserProcess: Process?
+        // Real Chrome PID when we routed the spawn through `/usr/bin/open`
+        // (LaunchServices) for TCC attribution. `browserProcess` then wraps
+        // `open`, so the graceful-shutdown SIGKILL fallback needs this
+        // separate handle to actually target Chrome.
+        var browserKillPid: pid_t?
         var browserLabel = config.electron ? "Electron" : "Chrome"
         var overlayInjector: ElectronOverlayInjector?
 
@@ -175,6 +180,7 @@ struct ServerCommand: AsyncParsableCommand {
                 )
             )
             browserProcess = launchedChrome.process
+            browserKillPid = launchedChrome.chromePid
             browserLabel = "Chrome"
             cdpPort = launchedChrome.cdpPort
         }
@@ -280,6 +286,7 @@ struct ServerCommand: AsyncParsableCommand {
             await shutdownHandler.install(
                 context: ShutdownContext(
                     browserProcess: browserProcess,
+                    browserKillPid: browserKillPid,
                     browserLabel: browserLabel,
                     cdpPort: cdpPort,
                     fileLogger: fileLogger,

--- a/packages/swift-server/Sources/Server/GracefulShutdown.swift
+++ b/packages/swift-server/Sources/Server/GracefulShutdown.swift
@@ -24,6 +24,13 @@ extension LickSystem: GracefulShutdownClientSocketControlling {}
 
 struct ShutdownContext: @unchecked Sendable {
     var browserProcess: Process?
+    /// Real Chrome browser-process PID when `browserProcess` wraps
+    /// `/usr/bin/open` instead of Chrome itself (the LaunchServices spawn
+    /// path used to make macOS TCC attribute camera/mic requests to Chrome
+    /// rather than the launcher). `nil` for the direct-exec path, where
+    /// `browserProcess.processIdentifier` is already Chrome's PID and the
+    /// SIGKILL fallback can use it directly.
+    var browserKillPid: pid_t?
     var browserLabel: String
     var cdpPort: Int
     var fileLogger: FileLogger?
@@ -34,6 +41,7 @@ struct ShutdownContext: @unchecked Sendable {
 
     init(
         browserProcess: Process? = nil,
+        browserKillPid: pid_t? = nil,
         browserLabel: String,
         cdpPort: Int,
         fileLogger: FileLogger? = nil,
@@ -43,6 +51,7 @@ struct ShutdownContext: @unchecked Sendable {
         server: (any GracefulShutdownServer)? = nil
     ) {
         self.browserProcess = browserProcess
+        self.browserKillPid = browserKillPid
         self.browserLabel = browserLabel
         self.cdpPort = cdpPort
         self.fileLogger = fileLogger
@@ -92,7 +101,10 @@ actor GracefulShutdownHandler {
 
     func install(context: ShutdownContext) {
         self.context = context
-        GracefulShutdownLastResortRegistry.register(browserProcess: context.browserProcess)
+        GracefulShutdownLastResortRegistry.register(
+            browserProcess: context.browserProcess,
+            browserKillPid: context.browserKillPid
+        )
 
         guard !installed else { return }
         installed = true
@@ -141,14 +153,24 @@ actor GracefulShutdownHandler {
         }
 
         if let browserProcess = context.browserProcess {
-            await closeBrowser(process: browserProcess, browserLabel: context.browserLabel, cdpPort: context.cdpPort)
+            await closeBrowser(
+                process: browserProcess,
+                browserKillPid: context.browserKillPid,
+                browserLabel: context.browserLabel,
+                cdpPort: context.cdpPort
+            )
         }
 
         GracefulShutdownLastResortRegistry.clearBrowserProcess()
         exitHandler(0)
     }
 
-    private func closeBrowser(process: Process, browserLabel: String, cdpPort: Int) async {
+    private func closeBrowser(
+        process: Process,
+        browserKillPid: pid_t?,
+        browserLabel: String,
+        cdpPort: Int
+    ) async {
         if process.isRunning {
             do {
                 let browserWebSocketURL = try await fetchBrowserWebSocketURL(cdpPort)
@@ -159,8 +181,20 @@ actor GracefulShutdownHandler {
 
             await waitForBrowserExit(process)
 
-            if process.isRunning, process.processIdentifier > 0 {
-                _ = killProcess(process.processIdentifier, SIGKILL)
+            if process.isRunning {
+                // SIGKILL Chrome itself when we know its real PID, not the
+                // `/usr/bin/open` helper wrapped by `process`. Without
+                // this, the fallback only killed `open` (which had
+                // already exited 0 in most cases anyway) and left a
+                // hung Chrome holding the user-data-dir and CDP port,
+                // breaking the next launch. Fall back to
+                // `process.processIdentifier` for the direct-exec path
+                // (Linux/Windows-equivalent test runs, bare-binary
+                // CHROME_PATH) where it really is Chrome's PID.
+                let killPid = (browserKillPid ?? process.processIdentifier)
+                if killPid > 0 {
+                    _ = killProcess(killPid, SIGKILL)
+                }
             }
         }
 
@@ -200,12 +234,16 @@ private struct BrowserVersionPayload: Decodable {
 enum GracefulShutdownLastResortRegistry {
     private static let lock = NSLock()
     private static var browserProcess: Process?
+    /// Real Chrome PID when `browserProcess` wraps `/usr/bin/open` —
+    /// see `ShutdownContext.browserKillPid` for the full rationale.
+    private static var browserKillPid: pid_t?
     private static var gracefulShutdownStarted = false
     private static var didRegisterExitHandler = false
 
-    static func register(browserProcess: Process?) {
+    static func register(browserProcess: Process?, browserKillPid: pid_t? = nil) {
         lock.lock()
         self.browserProcess = browserProcess
+        self.browserKillPid = browserKillPid
         if !didRegisterExitHandler {
             didRegisterExitHandler = true
             atexit(gracefulShutdownLastResortCleanup)
@@ -222,32 +260,37 @@ enum GracefulShutdownLastResortRegistry {
     static func clearBrowserProcess() {
         lock.lock()
         browserProcess = nil
+        browserKillPid = nil
         lock.unlock()
     }
 
     static func performCleanup() {
         let process: Process?
+        let killPid: pid_t?
         let shouldCleanup: Bool
 
         lock.lock()
         process = browserProcess
+        killPid = browserKillPid
         shouldCleanup = !gracefulShutdownStarted
         browserProcess = nil
+        browserKillPid = nil
         lock.unlock()
 
-        guard shouldCleanup,
-              let process,
-              process.isRunning,
-              process.processIdentifier > 0 else {
-            return
-        }
+        guard shouldCleanup, let process, process.isRunning else { return }
 
-        _ = Darwin.kill(process.processIdentifier, SIGKILL)
+        // Prefer Chrome's real PID (LaunchServices spawn path); fall back
+        // to the Process PID for the direct-exec path where they're the
+        // same thing.
+        let targetPid = killPid ?? process.processIdentifier
+        guard targetPid > 0 else { return }
+        _ = Darwin.kill(targetPid, SIGKILL)
     }
 
     static func resetForTesting() {
         lock.lock()
         browserProcess = nil
+        browserKillPid = nil
         gracefulShutdownStarted = false
         lock.unlock()
     }

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -243,6 +243,61 @@ final class ChromeLauncherTests: XCTestCase {
         XCTAssertEqual(spawns.count, 0, "processFactory must not be invoked when a Chrome is already on the CDP port")
     }
 
+    func testDiscoverLaunchedChromePidReturnsSetDifferenceImmediately() async {
+        // Pre-existing Chrome instances: PIDs 100 and 200. The
+        // LaunchServices spawn adds PID 300; `discoverLaunchedChromePid`
+        // should return 300 without waiting out the full budget.
+        let bundleURL = URL(fileURLWithPath: "/Applications/Google Chrome.app")
+        let launcher = ChromeLauncher(
+            runningPidsForBundle: { url in
+                XCTAssertEqual(url.standardizedFileURL, bundleURL.standardizedFileURL)
+                return [100, 200, 300]
+            }
+        )
+
+        let pid = await launcher.discoverLaunchedChromePid(
+            bundleURL: bundleURL,
+            existingPids: [100, 200],
+            timeout: 1.0
+        )
+
+        XCTAssertEqual(pid, 300)
+    }
+
+    func testDiscoverLaunchedChromePidWaitsForNewPidToAppear() async {
+        // First poll returns only pre-existing PIDs; second poll returns
+        // the new one. Verifies the loop actually polls instead of
+        // resolving on the first read.
+        let bundleURL = URL(fileURLWithPath: "/Applications/Google Chrome.app")
+        let snapshots = AtomicSnapshotBox(values: [[100, 200], [100, 200, 555]])
+        let launcher = ChromeLauncher(
+            runningPidsForBundle: { _ in snapshots.next() }
+        )
+
+        let pid = await launcher.discoverLaunchedChromePid(
+            bundleURL: bundleURL,
+            existingPids: [100, 200],
+            timeout: 1.0
+        )
+
+        XCTAssertEqual(pid, 555)
+    }
+
+    func testDiscoverLaunchedChromePidReturnsNilOnTimeout() async {
+        let bundleURL = URL(fileURLWithPath: "/Applications/Google Chrome.app")
+        let launcher = ChromeLauncher(
+            runningPidsForBundle: { _ in [100, 200] }
+        )
+
+        let pid = await launcher.discoverLaunchedChromePid(
+            bundleURL: bundleURL,
+            existingPids: [100, 200],
+            timeout: 0.2
+        )
+
+        XCTAssertNil(pid)
+    }
+
     private func makeLauncher(
         existingPaths: Set<String> = [],
         directoryListings: [String: [String]] = [:],
@@ -257,5 +312,23 @@ final class ChromeLauncherTests: XCTestCase {
             currentDirectoryProvider: { currentDirectory },
             homeDirectoryProvider: { homeDirectory }
         )
+    }
+}
+
+private final class AtomicSnapshotBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var queue: [Set<pid_t>]
+
+    init(values: [Set<pid_t>]) {
+        self.queue = values
+    }
+
+    func next() -> Set<pid_t> {
+        lock.lock()
+        defer { lock.unlock() }
+        if queue.count > 1 {
+            return queue.removeFirst()
+        }
+        return queue.first ?? []
     }
 }

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -52,6 +52,59 @@ final class ChromeLauncherTests: XCTestCase {
         XCTAssertEqual(args.last, "http://127.0.0.1:5710")
     }
 
+    func testResolveAppBundleWalksUpFromCanonicalChromeExecutable() {
+        let launcher = makeLauncher()
+
+        XCTAssertEqual(
+            launcher.resolveAppBundle(
+                forExecutable: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+            ),
+            "/Applications/Google Chrome.app"
+        )
+    }
+
+    func testResolveAppBundleHandlesChromeForTestingPath() {
+        let launcher = makeLauncher()
+        let cached = "/Users/test/.cache/puppeteer/chrome/mac-123/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+
+        XCTAssertEqual(
+            launcher.resolveAppBundle(forExecutable: cached),
+            "/Users/test/.cache/puppeteer/chrome/mac-123/chrome-mac-arm64/Google Chrome for Testing.app"
+        )
+    }
+
+    func testResolveAppBundleReturnsNilForBareBinary() {
+        let launcher = makeLauncher()
+
+        XCTAssertNil(launcher.resolveAppBundle(forExecutable: "/usr/local/bin/chromium"))
+        XCTAssertNil(launcher.resolveAppBundle(forExecutable: "/tmp/just-a-binary"))
+    }
+
+    func testBuildOpenLaunchArgsRoutesThroughLaunchServicesWithChromeArgs() {
+        let launcher = makeLauncher()
+        let chromeArgs = launcher.buildLaunchArgs(
+            cdpPort: 9333,
+            launchUrl: "http://127.0.0.1:5710",
+            userDataDir: "/tmp/profile",
+            extensionPath: nil
+        )
+        let args = launcher.buildOpenLaunchArgs(
+            appBundlePath: "/Applications/Google Chrome.app",
+            chromeArgs: chromeArgs
+        )
+
+        // The `-n -a <bundle> -W --args …` shape is what frees Chrome from
+        // slicc-server's TCC responsibility chain. Pin the prefix so a
+        // refactor that drops `--args` (which would swallow the Chrome
+        // flags into `open`'s own option parser) breaks the build.
+        XCTAssertEqual(args[0], "-n")
+        XCTAssertEqual(args[1], "-a")
+        XCTAssertEqual(args[2], "/Applications/Google Chrome.app")
+        XCTAssertEqual(args[3], "-W")
+        XCTAssertEqual(args[4], "--args")
+        XCTAssertEqual(Array(args.suffix(chromeArgs.count)), chromeArgs)
+    }
+
     func testResolveUserDataDirAddsSuffixForNonDefaultServePort() {
         let launcher = makeLauncher(environment: ["TMPDIR": "/tmp/runtime"])
 

--- a/packages/swift-server/Tests/GracefulShutdownHandlerTests.swift
+++ b/packages/swift-server/Tests/GracefulShutdownHandlerTests.swift
@@ -108,6 +108,95 @@ final class GracefulShutdownHandlerTests: XCTestCase {
 
         XCTAssertFalse(process.isRunning)
     }
+
+    func testRunShutdownSequencePrefersBrowserKillPidOverProcessIdentifierWhenForcingKill() async throws {
+        // Mirror the LaunchServices spawn path: `process` is the long-lived
+        // `open -W` helper whose PID is NOT Chrome's. The SIGKILL fallback
+        // must target `browserKillPid` (the real Chrome PID) so we don't
+        // leave Chrome holding the user-data-dir and CDP port.
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "sleep 30"]
+        try process.run()
+        XCTAssertTrue(process.isRunning)
+        defer {
+            if process.isRunning {
+                _ = Darwin.kill(process.processIdentifier, SIGKILL)
+            }
+        }
+
+        let openPid = process.processIdentifier
+        let fakeChromePid: pid_t = 424242
+        let killTargets = PidRecorder()
+        let exitRecorder = ExitRecorder()
+
+        let handler = GracefulShutdownHandler(
+            fetchBrowserWebSocketURL: { _ in throw GracefulShutdownError.cdpUnavailable(9555) },
+            sendBrowserCloseCommand: { _ in
+                XCTFail("CDP path should not run when fetchBrowserWebSocketURL throws")
+            },
+            killProcess: { pid, _ in
+                killTargets.record(pid)
+                return 0
+            },
+            exitHandler: { code in exitRecorder.record(code) },
+            browserExitTimeoutNanoseconds: 50_000_000,
+            browserExitPollNanoseconds: 10_000_000
+        )
+
+        await handler.runShutdownSequence(context: ShutdownContext(
+            browserProcess: process,
+            browserKillPid: fakeChromePid,
+            browserLabel: "Chrome",
+            cdpPort: 9555
+        ))
+
+        XCTAssertEqual(killTargets.snapshot(), [fakeChromePid])
+        XCTAssertNotEqual(killTargets.snapshot(), [openPid])
+        XCTAssertEqual(exitRecorder.codeSnapshot(), 0)
+    }
+
+    func testRunShutdownSequenceFallsBackToProcessIdentifierWhenBrowserKillPidIsNil() async throws {
+        // Direct-exec path: `process.processIdentifier` IS Chrome's PID,
+        // and we should still SIGKILL it when Browser.close can't be
+        // delivered. Verifies the LaunchServices change didn't regress
+        // the legacy code path.
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "sleep 30"]
+        try process.run()
+        XCTAssertTrue(process.isRunning)
+        defer {
+            if process.isRunning {
+                _ = Darwin.kill(process.processIdentifier, SIGKILL)
+            }
+        }
+        let chromePid = process.processIdentifier
+
+        let killTargets = PidRecorder()
+        let exitRecorder = ExitRecorder()
+
+        let handler = GracefulShutdownHandler(
+            fetchBrowserWebSocketURL: { _ in throw GracefulShutdownError.cdpUnavailable(9556) },
+            sendBrowserCloseCommand: { _ in XCTFail("should not reach close") },
+            killProcess: { pid, _ in
+                killTargets.record(pid)
+                return 0
+            },
+            exitHandler: { code in exitRecorder.record(code) },
+            browserExitTimeoutNanoseconds: 50_000_000,
+            browserExitPollNanoseconds: 10_000_000
+        )
+
+        await handler.runShutdownSequence(context: ShutdownContext(
+            browserProcess: process,
+            browserLabel: "Chrome",
+            cdpPort: 9556
+        ))
+
+        XCTAssertEqual(killTargets.snapshot(), [chromePid])
+        XCTAssertEqual(exitRecorder.codeSnapshot(), 0)
+    }
 }
 
 private final class OverlayControllerSpy: @unchecked Sendable, GracefulShutdownOverlayControlling {
@@ -194,5 +283,22 @@ private final class EventRecorder: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return events
+    }
+}
+
+private final class PidRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var pids: [pid_t] = []
+
+    func record(_ pid: pid_t) {
+        lock.lock()
+        pids.append(pid)
+        lock.unlock()
+    }
+
+    func snapshot() -> [pid_t] {
+        lock.lock()
+        defer { lock.unlock() }
+        return pids
     }
 }


### PR DESCRIPTION
## Why

Camera and microphone access were silently broken in Slicc-launched Chrome — for example, joining a Google Meet would render the camera permission UI, but the actual `navigator.mediaDevices.getUserMedia()` call hung forever.

The root cause was macOS TCC. `packages/swift-server/Sources/Browser/ChromeLauncher.swift` spawned Chrome with Foundation `Process` (raw `posix_spawn`), which left `slicc-server` — and therefore its GUI parent `com.slicc.sliccstart` — in Chrome's TCC responsibility chain. `log show --predicate 'subsystem == "com.apple.TCC"'` against a running Slicc made the smoking gun obvious:

```
tccd: Handling access request to kTCCServiceCamera,
  from Sub:{com.slicc.sliccstart}
  Resp:{TCCDProcess: identifier=com.slicc.sliccstart, pid=27009,
    binary_path=/private/var/folders/.../X/com.google.Chrome.code_sign_clone/.../Google Chrome}
  ReqResult(Auth Right: Unknown (None), promptType: 1, DB Action: None, …)
```

The launcher bundle has no `NS{Camera,Microphone}UsageDescription`, so TCC could neither prompt nor persist a decision, and the request returned `Unknown (None)` with no DB action. Direct spawn also caused macOS to use a `code_sign_clone` of Chrome — distinct from the canonical `/Applications/Google Chrome.app` — so any prior TCC grant the user had for Google Chrome did not apply.

## What

1. **Route Chrome through LaunchServices.** When the resolved executable lives inside a `.app` bundle (the canonical Chrome and Chrome-for-Testing paths both do), launch via:
   ```
   /usr/bin/open -n -a <Google Chrome.app> -W --args <existing Chromium flags>
   ```
   This is the same pattern `ElectronLauncher` already uses. LaunchServices owns the new process, Chrome becomes its own TCC responsible process, and the user's `/Applications/Google Chrome.app` privacy grant applies normally.
2. **Keep a direct-exec fallback** for bare-binary paths so existing tests still cover the path.
3. **Replace stderr CDP-port scraping with HTTP polling** on the LaunchServices path (stderr now belongs to `open`, not Chrome). `waitForCDPReady()` watches the requested port and the `open` exit code so LaunchServices failures fail fast.
4. **Add `NS{Camera,Microphone}UsageDescription` to Sliccstart's Info.plist** so the bundle can legally prompt if/when TCC still attributes work to the launcher (e.g., direct invocations or future code paths).
5. **Extend the eslint Node-globals scope** to `packages/swift-launcher/**` and `packages/swift-server/**` helper scripts so the existing `assemble-app.mjs` no longer fails lint when touched.

## Verification

- `swift build -c debug` on `packages/swift-server` succeeds.
- New unit tests cover `resolveAppBundle(forExecutable:)` and `buildOpenLaunchArgs()`, pinning the `-n -a <bundle> -W --args …` prefix so future refactors cannot accidentally drop `--args` (which would silently swallow Chrome's flags into `open`'s own option parser).
- Existing `ChromeLauncherTests` still pass; `testLaunchFailsFastWhenCdpPortIsAlreadyServingChrome` still exercises the pre-flight probe and never spawns Chrome.
- `npx eslint packages/swift-launcher/assemble-app.mjs` is clean after the config scope extension.
- Local manual repro: with this branch, joining Google Meet in a Sliccstart-launched Chrome no longer hangs in `getUserMedia`; first-run users see the standard macOS Camera/Microphone prompt attributed to Google Chrome.

## Risks / Limitations

- Slicc's existing graceful-shutdown path already kills the `open` parent rather than Chrome itself when CDP `Browser.close` fails (this matches the long-standing Electron path), so killing the launcher does not force-kill Chrome. Out of scope for this PR; the primary CDP-driven shutdown path is unchanged.
- We rely on a fixed CDP port handed off by the existing port-resolution code, which already calls `findAvailablePort()` before launch; we no longer recover from Chrome picking a different port via stderr (it should not, because the port is free). If that ever regresses, `waitForCDPReady` will time out on the wrong port rather than silently succeed.