### PR TITLE
fix(node-server): launch Chrome via LaunchServices on macOS to unbreak camera/mic

### DIFF
--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -174,6 +174,76 @@ export function buildChromeLaunchArgs(options: {
   return args;
 }
 
+/**
+ * Walk up from a Chrome executable path
+ * (`…/Foo.app/Contents/MacOS/Foo`) to its enclosing `.app` bundle so we
+ * can hand it to `/usr/bin/open -a`. Returns `null` on non-darwin
+ * platforms or bare-binary paths so the caller falls back to a direct
+ * exec (Linux/Windows have no LaunchServices equivalent).
+ */
+export function resolveChromeAppBundle(
+  executablePath: string,
+  platform: NodeJS.Platform = process.platform
+): string | null {
+  if (platform !== 'darwin') return null;
+  const parts = executablePath.split('/');
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (parts[i]?.toLowerCase().endsWith('.app')) {
+      return parts.slice(0, i + 1).join('/');
+    }
+  }
+  return null;
+}
+
+export interface ChromeSpawnPlan {
+  command: string;
+  args: string[];
+  /**
+   * `true` when the spawn is routed through `/usr/bin/open` so
+   * LaunchServices owns the new Chrome process. The caller should rely
+   * on `DevToolsActivePort` for CDP port discovery in this mode because
+   * `open`'s stderr never carries Chrome's `DevTools listening on …`
+   * banner.
+   */
+  usesLaunchServices: boolean;
+}
+
+/**
+ * Decide how to spawn Chrome so macOS TCC attributes camera/microphone
+ * requests to Chrome itself rather than to whatever terminal launched
+ * `node`. On darwin, when we can resolve an enclosing `.app` bundle for
+ * the Chrome executable, route the spawn through
+ * `/usr/bin/open -n -a <bundle> -W --args …` so LaunchServices becomes
+ * Chrome's parent and TCC responsible process. Without this hop,
+ * `getUserMedia()` calls in Google Meet, Zoom, etc. hang forever on
+ * machines where the terminal app has never been granted camera/mic
+ * access (or has no `NS{Camera,Microphone}UsageDescription`).
+ *
+ * On Linux / Windows, fall back to a direct exec — neither platform has
+ * a LaunchServices equivalent, and they don't suffer the same TCC
+ * inheritance problem.
+ */
+export function planChromeSpawn(options: {
+  executablePath: string;
+  chromeArgs: string[];
+  platform?: NodeJS.Platform;
+}): ChromeSpawnPlan {
+  const platform = options.platform ?? process.platform;
+  const bundle = resolveChromeAppBundle(options.executablePath, platform);
+  if (bundle) {
+    return {
+      command: '/usr/bin/open',
+      args: ['-n', '-a', bundle, '-W', '--args', ...options.chromeArgs],
+      usesLaunchServices: true,
+    };
+  }
+  return {
+    command: options.executablePath,
+    args: options.chromeArgs,
+    usesLaunchServices: false,
+  };
+}
+
 function findPuppeteerChromeForTesting(
   options: Required<
     Pick<FindChromeExecutableOptions, 'platform' | 'homeDir' | 'existsSyncImpl' | 'readdirSyncImpl'>

--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync } from 'fs';
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { mkdir, readFile, unlink, writeFile } from 'fs/promises';
 import { homedir } from 'os';
 import { dirname, join } from 'path';
 import type { ChildProcess } from 'child_process';
@@ -561,6 +561,30 @@ export function waitForCdpPortFromStderr(
       }
     });
   });
+}
+
+/**
+ * Delete a stale `<userDataDir>/DevToolsActivePort` left behind by a
+ * previous Chrome run before we spawn a new one. Otherwise
+ * `waitForCdpPortFromActivePortFile` can win the race instantly with the
+ * old port from a crashed / SIGKILL'd previous launch — Chrome only
+ * writes the file when its listener comes up, and never proactively
+ * clears it on shutdown. The file lives inside a profile directory that
+ * is reused across runs (both the dev `/tmp/browser-coding-agent-chrome`
+ * profile and the persistent `.qa/chrome/<profile>` QA profiles), so the
+ * stale-port window is real.
+ *
+ * ENOENT is fine (no previous run); other errors are swallowed too
+ * because a failure to unlink shouldn't block a launch — the worst case
+ * is the pre-existing stale-port behavior, which is what we want to
+ * avoid but is not worth crashing over.
+ */
+export async function clearStaleDevToolsActivePort(userDataDir: string): Promise<void> {
+  try {
+    await unlink(join(userDataDir, 'DevToolsActivePort'));
+  } catch {
+    // Intentionally ignored — see docstring.
+  }
 }
 
 /**

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -18,6 +18,7 @@ import {
 import { getElectronAppPorts } from './electron-runtime.js';
 import {
   buildChromeLaunchArgs,
+  clearStaleDevToolsActivePort,
   ensureQaProfileScaffold,
   findChromeExecutable,
   planChromeSpawn,
@@ -571,6 +572,14 @@ async function main() {
       launchUrl: browserLaunchUrl,
       profile: chromeProfile,
     });
+
+    // Profile directories are reused across runs (both the dev
+    // `/tmp/browser-coding-agent-chrome` profile and the persistent
+    // `.qa/chrome/<profile>` QA profiles). Chrome never proactively
+    // clears `DevToolsActivePort` on shutdown, so a stale file from a
+    // previous crash/SIGKILL would let our active-port-file poller win
+    // the race instantly with the wrong port. Clear it before spawn.
+    await clearStaleDevToolsActivePort(chromeProfile.userDataDir);
 
     // On macOS, route through `/usr/bin/open` so LaunchServices owns the
     // new Chrome process. Without this hop the terminal that started

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -20,8 +20,9 @@ import {
   buildChromeLaunchArgs,
   ensureQaProfileScaffold,
   findChromeExecutable,
+  planChromeSpawn,
   resolveChromeLaunchProfile,
-  waitForCdpPortFromStderr,
+  waitForCdpPort,
 } from './chrome-launch.js';
 import { resolveCliBrowserLaunchUrl } from './launch-url.js';
 import { parseCliRuntimeFlags } from './runtime-flags.js';
@@ -571,16 +572,31 @@ async function main() {
       profile: chromeProfile,
     });
 
-    launchedBrowserProcess = spawn(chromePath, chromeArgs, {
+    // On macOS, route through `/usr/bin/open` so LaunchServices owns the
+    // new Chrome process. Without this hop the terminal that started
+    // `node` stays in Chrome's TCC responsibility chain, which silently
+    // breaks `getUserMedia()` (camera/mic in Google Meet, Zoom, etc.)
+    // whenever the terminal hasn't already been granted camera/microphone
+    // access. With LaunchServices in the loop, Chrome becomes its own
+    // TCC responsible process and the user's
+    // `/Applications/Google Chrome.app` privacy grant applies as expected.
+    const spawnPlan = planChromeSpawn({ executablePath: chromePath, chromeArgs });
+
+    launchedBrowserProcess = spawn(spawnPlan.command, spawnPlan.args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: false,
       env: { ...process.env, GOOGLE_CRASHPAD_DISABLE: '1' },
     });
     launchedBrowserLabel = chromeProfile.displayName;
 
-    // Parse the actual CDP port from Chrome's stderr before piping output.
-    // Chrome prints "DevTools listening on ws://HOST:PORT/..." to stderr.
-    const actualCdpPort = await waitForCdpPortFromStderr(launchedBrowserProcess);
+    // Use the stderr-vs-DevToolsActivePort race so we work in both
+    // direct-exec mode (Linux/Windows, or bare-binary fallbacks where
+    // stderr carries Chrome's banner) and LaunchServices mode (macOS,
+    // where stderr belongs to `open` and only the active-port file
+    // surfaces the real CDP port).
+    const actualCdpPort = await waitForCdpPort(launchedBrowserProcess, {
+      userDataDir: chromeProfile.userDataDir,
+    });
     CDP_PORT = actualCdpPort;
     console.log(`Chrome CDP listening on port ${CDP_PORT}`);
 

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -5,8 +5,12 @@ import { join } from 'path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { existsSync as fsExistsSync } from 'fs';
+import { stat } from 'fs/promises';
+
 import {
   buildChromeLaunchArgs,
+  clearStaleDevToolsActivePort,
   DEFAULT_CDP_LAUNCH_TIMEOUT_MS,
   ensureQaProfileScaffold,
   findChromeExecutable,
@@ -566,5 +570,35 @@ describe('waitForCdpPort (race)', () => {
     );
 
     await expect(promise).resolves.toBe(33333);
+  });
+});
+
+describe('clearStaleDevToolsActivePort', () => {
+  it('deletes an existing DevToolsActivePort file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-clear-active-port-'));
+    tempDirs.push(dir);
+    const filePath = join(dir, 'DevToolsActivePort');
+    await writeFile(filePath, '49321\n/devtools/browser/abc-123\n');
+    expect(fsExistsSync(filePath)).toBe(true);
+
+    await clearStaleDevToolsActivePort(dir);
+
+    expect(fsExistsSync(filePath)).toBe(false);
+    // Profile dir itself is untouched.
+    await expect(stat(dir)).resolves.toBeDefined();
+  });
+
+  it('is a no-op when no file exists (ENOENT swallowed)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-clear-active-port-'));
+    tempDirs.push(dir);
+    await expect(clearStaleDevToolsActivePort(dir)).resolves.toBeUndefined();
+  });
+
+  it('does not throw when the directory itself is missing', async () => {
+    const missing = join(
+      tmpdir(),
+      `slicc-clear-active-port-missing-${Date.now()}-${Math.random()}`
+    );
+    await expect(clearStaleDevToolsActivePort(missing)).resolves.toBeUndefined();
   });
 });

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -12,6 +12,8 @@ import {
   findChromeExecutable,
   getDefaultCdpLaunchTimeoutMs,
   parseCdpPortFromStderr,
+  planChromeSpawn,
+  resolveChromeAppBundle,
   resolveChromeLaunchProfile,
   waitForCdpPort,
   waitForCdpPortFromActivePortFile,
@@ -105,6 +107,100 @@ describe('chrome-launch', () => {
       '--load-extension=/repo/dist/extension',
       'http://localhost:3000',
     ]);
+  });
+
+  describe('resolveChromeAppBundle', () => {
+    it('walks up to the canonical Chrome .app bundle on darwin', () => {
+      expect(
+        resolveChromeAppBundle(
+          '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+          'darwin'
+        )
+      ).toBe('/Applications/Google Chrome.app');
+    });
+
+    it('walks up to a Chrome for Testing bundle on darwin', () => {
+      const exe =
+        '/Users/test/.cache/puppeteer/chrome/mac-123/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing';
+      expect(resolveChromeAppBundle(exe, 'darwin')).toBe(
+        '/Users/test/.cache/puppeteer/chrome/mac-123/chrome-mac-arm64/Google Chrome for Testing.app'
+      );
+    });
+
+    it('returns null on non-darwin platforms even when given a .app-style path', () => {
+      const exe = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+      expect(resolveChromeAppBundle(exe, 'linux')).toBeNull();
+      expect(resolveChromeAppBundle(exe, 'win32')).toBeNull();
+    });
+
+    it('returns null for bare-binary paths on darwin', () => {
+      expect(resolveChromeAppBundle('/usr/local/bin/chromium', 'darwin')).toBeNull();
+      expect(resolveChromeAppBundle('/tmp/just-a-binary', 'darwin')).toBeNull();
+    });
+  });
+
+  describe('planChromeSpawn', () => {
+    const baseArgs = [
+      '--remote-debugging-port=9222',
+      '--user-data-dir=/tmp/profile',
+      'about:blank',
+    ];
+
+    it('routes darwin Chrome through /usr/bin/open with -n -a <bundle> -W --args …', () => {
+      // The exact prefix shape matters: dropping `--args` would let `open`
+      // swallow Chrome's flags into its own option parser; reordering
+      // before `--args` would do the same. Pin the full prefix so a
+      // refactor that breaks LaunchServices delegation breaks the build.
+      const plan = planChromeSpawn({
+        executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        chromeArgs: baseArgs,
+        platform: 'darwin',
+      });
+      expect(plan.command).toBe('/usr/bin/open');
+      expect(plan.args.slice(0, 5)).toEqual([
+        '-n',
+        '-a',
+        '/Applications/Google Chrome.app',
+        '-W',
+        '--args',
+      ]);
+      expect(plan.args.slice(5)).toEqual(baseArgs);
+      expect(plan.usesLaunchServices).toBe(true);
+    });
+
+    it('uses a direct exec on linux and windows', () => {
+      const linuxPlan = planChromeSpawn({
+        executablePath: '/usr/bin/google-chrome',
+        chromeArgs: baseArgs,
+        platform: 'linux',
+      });
+      expect(linuxPlan).toEqual({
+        command: '/usr/bin/google-chrome',
+        args: baseArgs,
+        usesLaunchServices: false,
+      });
+
+      const winPlan = planChromeSpawn({
+        executablePath: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+        chromeArgs: baseArgs,
+        platform: 'win32',
+      });
+      expect(winPlan.command).toBe('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe');
+      expect(winPlan.usesLaunchServices).toBe(false);
+    });
+
+    it('falls back to direct exec for bare-binary paths on darwin', () => {
+      const plan = planChromeSpawn({
+        executablePath: '/opt/chromium/chromium-bin',
+        chromeArgs: baseArgs,
+        platform: 'darwin',
+      });
+      expect(plan).toEqual({
+        command: '/opt/chromium/chromium-bin',
+        args: baseArgs,
+        usesLaunchServices: false,
+      });
+    });
   });
 
   it('prefers CHROME_PATH over discovered installations', () => {


### PR DESCRIPTION
## Why

Follow-up to #671. PR #671 fixed the Sliccstart-launched Chrome path; this PR applies the same fix to the Node CLI runtime (`npm run dev`, the packaged Electron float, anywhere `packages/node-server` launches Chrome).

`packages/node-server/src/index.ts` spawned Chrome with `child_process.spawn` (a thin `posix_spawn` wrapper). That left whichever terminal launched `node` — `Terminal.app`, `iTerm2.app`, `Code.app`, `Warp.app`, etc. — sitting in Chrome's macOS TCC responsibility chain. On machines where the terminal app had no prior camera/microphone grant (or, for some terminals, no `NS{Camera,Microphone}UsageDescription` at all), `navigator.mediaDevices.getUserMedia()` in Google Meet / Zoom / etc. silently hangs.

Most developers don't hit this because their terminal already has the grants from earlier dev work, but fresh dev machines and CI smoke runs are exposed, and the underlying architecture issue is the same one #671 fixed for Sliccstart. Symptom and macOS `tccd` log shape are identical: `promptType: 1, DB Action: None`, plus a `code_sign_clone` of Chrome under `/var/folders/…/com.google.Chrome.code_sign_clone/…` that doesn't match the user's TCC entry for canonical `/Applications/Google Chrome.app`.

## What

1. **Add `planChromeSpawn()` and `resolveChromeAppBundle()`** in `packages/node-server/src/chrome-launch.ts`. On darwin, when the Chrome executable resolves to a `.app` bundle (both canonical Chrome and Chrome-for-Testing do), return a plan that runs:
   ```
   /usr/bin/open -n -a <Chrome.app> -W --args <existing Chromium flags>
   ```
   LaunchServices owns the new process, Chrome becomes its own TCC responsible process, and the canonical Chrome privacy grant applies.
2. **Keep a direct-exec fallback** on Linux and Windows (no LaunchServices equivalent, no TCC inheritance problem) and for bare-binary paths on darwin.
3. **Switch `index.ts` from `waitForCdpPortFromStderr` to `waitForCdpPort`** so CDP port discovery works in both modes. `waitForCdpPort` already races stderr scraping and `DevToolsActivePort` polling — direct-exec wins via stderr, LaunchServices wins via the active-port file (because `open`, not Chrome, owns our stderr pipe).
4. **Unit tests** pin the `-n -a <bundle> -W --args …` prefix shape so a refactor that drops `--args` (which would swallow Chrome's flags into `open`'s own option parser) fails the build, and cover the Linux / Windows / bare-binary fallback paths.

## Verification

- `npm run typecheck` ✅
- `npx vitest run packages/node-server/tests/chrome-launch.test.ts` ✅ (40/40 pass, +8 new)
- `npm run build -w @slicc/node-server` ✅
- `npx prettier --write` on touched files: clean
- `npx eslint` on touched files: 0 errors (12 pre-existing warnings in the test file, unrelated)
- Manual repro on darwin: `npm run dev` against a Sliccstart-style fresh-terminal-without-camera-grant scenario now shows the standard macOS Camera/Microphone prompt attributed to Google Chrome instead of hanging in `getUserMedia`.

## Risks / Limitations

- Same `open -W` caveat #671 inherited from the existing `ElectronLauncher` flow: SIGTERM/SIGKILL of the `launchedBrowserProcess` targets `open`, not Chrome. The primary shutdown path is CDP `Browser.close` (unchanged), and `open -W` does keep `launchedBrowserProcess.isAlive`/`on('exit')` tracking accurate because it stays alive as long as Chrome stays alive.
- The stderr-vs-active-port-file race is unchanged on Linux/Windows; we just stopped restricting it to stderr-only on macOS.