### PR TITLE
fix(node-server): validate DevToolsActivePort port via /json/version before trusting it

### DIFF
--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync } from 'fs';
 import { mkdir, readFile, unlink, writeFile } from 'fs/promises';
+import { request as httpRequest } from 'http';
 import { homedir } from 'os';
 import { dirname, join } from 'path';
 import type { ChildProcess } from 'child_process';
@@ -588,25 +589,109 @@ export async function clearStaleDevToolsActivePort(userDataDir: string): Promise
 }
 
 /**
+ * Single-shot HTTP probe of Chrome's `/json/version` endpoint. Resolves
+ * `true` only when the port answers with a 2xx response whose body is
+ * valid JSON with a non-empty `webSocketDebuggerUrl` (the CDP fingerprint
+ * — won't false-positive on some other HTTP service squatting on the
+ * port). All errors / timeouts collapse to `false` so the caller can
+ * retry without exception plumbing.
+ *
+ * Kept small and stdlib-only (`node:http`) to avoid pulling another
+ * fetch implementation into the launcher hot path.
+ */
+export function probeCdpAlive(port: number, timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const settle = (alive: boolean) => {
+      if (resolved) return;
+      resolved = true;
+      resolve(alive);
+    };
+    const req = httpRequest(
+      {
+        host: '127.0.0.1',
+        port,
+        path: '/json/version',
+        method: 'GET',
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const status = res.statusCode ?? 0;
+        if (status < 200 || status >= 300) {
+          res.resume();
+          settle(false);
+          return;
+        }
+        let body = '';
+        res.setEncoding('utf-8');
+        res.on('data', (chunk: string) => {
+          body += chunk;
+          // Cap the body size — the real /json/version payload is well
+          // under 1 KiB, so anything larger is junk from another service.
+          if (body.length > 16_384) {
+            res.destroy();
+            settle(false);
+          }
+        });
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(body) as { webSocketDebuggerUrl?: unknown };
+            settle(
+              typeof parsed.webSocketDebuggerUrl === 'string' &&
+                parsed.webSocketDebuggerUrl.length > 0
+            );
+          } catch {
+            settle(false);
+          }
+        });
+        res.on('error', () => settle(false));
+      }
+    );
+    req.on('error', () => settle(false));
+    req.on('timeout', () => {
+      req.destroy();
+      settle(false);
+    });
+    req.end();
+  });
+}
+
+/**
  * Poll `<userDataDir>/DevToolsActivePort` for the CDP port. Chrome writes
  * this file as soon as the DevTools listener is up — its first line is
  * the port, the second is the websocket path. This is the canonical way
  * Chromium itself recommends discovering the chosen port and is far more
  * reliable than scraping stderr.
  *
- * Resolves with the parsed port. Rejects on timeout or process exit.
+ * Validation: before resolving, probe `/json/version` on the discovered
+ * port. The file is written by Chrome but reused across runs in the same
+ * profile directory, and `clearStaleDevToolsActivePort` is a
+ * best-effort unlink that races our spawn. If the probe fails we treat
+ * the file content as stale and keep polling for either an updated file
+ * (the freshly-spawned Chrome about to overwrite it) or the eventual
+ * timeout. This belt-and-suspenders pairs with the pre-spawn deletion
+ * to make the discovery resilient to crashed previous runs that left
+ * the file pointing at a now-dead TCP port.
+ *
+ * Resolves with the parsed port once both the file content and the
+ * live CDP probe succeed. Rejects on timeout or process exit.
  *
  * @param userDataDir absolute path Chrome was launched with via `--user-data-dir=`
  * @param child       the Chrome child process (used to bail out on early exit)
  * @param timeoutMs   total budget before giving up
  * @param pollMs      polling cadence (default 50ms)
+ * @param options     test seam — inject a custom `verifyPort` to avoid
+ *                    real network probes in unit tests.
  */
 export function waitForCdpPortFromActivePortFile(
   userDataDir: string,
   child: ChildProcess,
   timeoutMs: number = getDefaultCdpLaunchTimeoutMs(),
-  pollMs = 50
+  pollMs = 50,
+  options: { verifyPort?: (port: number) => Promise<boolean> } = {}
 ): Promise<number> {
+  const verifyPort = options.verifyPort ?? ((port: number) => probeCdpAlive(port));
+
   return new Promise((resolve, reject) => {
     let settled = false;
     const path = join(userDataDir, 'DevToolsActivePort');
@@ -620,6 +705,7 @@ export function waitForCdpPortFromActivePortFile(
 
     const tick = async (): Promise<void> => {
       if (settled) return;
+      let candidatePort: number | null = null;
       try {
         const contents = await readFile(path, 'utf-8');
         // First line is the port; second is the WS path. Chrome writes both
@@ -630,8 +716,7 @@ export function waitForCdpPortFromActivePortFile(
         if (firstLine) {
           const port = Number.parseInt(firstLine, 10);
           if (Number.isFinite(port) && port > 0) {
-            finish(() => resolve(port));
-            return;
+            candidatePort = port;
           }
         }
       } catch (err) {
@@ -639,6 +724,19 @@ export function waitForCdpPortFromActivePortFile(
         // else is ignored too: we'd rather fall back to the stderr path
         // racing alongside this poller than reject early.
         void err;
+      }
+
+      if (candidatePort !== null) {
+        // Verify the file's port actually answers CDP. A stale file
+        // (e.g. from a previous run that crashed before
+        // `clearStaleDevToolsActivePort` could land) will fail this
+        // probe and fall through to the next tick.
+        const alive = await verifyPort(candidatePort);
+        if (settled) return; // child exited mid-probe — `child.on('exit')` already rejected.
+        if (alive) {
+          finish(() => resolve(candidatePort!));
+          return;
+        }
       }
 
       if (Date.now() - startedAt >= timeoutMs) {
@@ -670,12 +768,27 @@ export function waitForCdpPortFromActivePortFile(
  */
 export function waitForCdpPort(
   child: ChildProcess,
-  options: { userDataDir?: string; timeoutMs?: number } = {}
+  options: {
+    userDataDir?: string;
+    timeoutMs?: number;
+    /**
+     * Test seam — forwarded to `waitForCdpPortFromActivePortFile` so unit
+     * tests can simulate the "file says port X, but X isn't actually
+     * answering CDP" stale-port race without binding a real socket.
+     */
+    verifyPort?: (port: number) => Promise<boolean>;
+  } = {}
 ): Promise<number> {
   const timeoutMs = options.timeoutMs ?? getDefaultCdpLaunchTimeoutMs();
   const stderrPromise = waitForCdpPortFromStderr(child, timeoutMs);
   if (!options.userDataDir) return stderrPromise;
-  const filePromise = waitForCdpPortFromActivePortFile(options.userDataDir, child, timeoutMs);
+  const filePromise = waitForCdpPortFromActivePortFile(
+    options.userDataDir,
+    child,
+    timeoutMs,
+    undefined,
+    { verifyPort: options.verifyPort }
+  );
   // Suppress unhandled-rejection warnings on the loser.
   stderrPromise.catch(() => {});
   filePromise.catch(() => {});

--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -588,18 +588,43 @@ export async function clearStaleDevToolsActivePort(userDataDir: string): Promise
   }
 }
 
+export interface ProbeCdpAliveOptions {
+  /** Per-probe HTTP timeout in milliseconds. Default 500 ms. */
+  timeoutMs?: number;
+  /**
+   * When set, additionally require the returned
+   * `webSocketDebuggerUrl`'s pathname to equal this value. Used by the
+   * `DevToolsActivePort` poller to bind the probe to the *specific* CDP
+   * endpoint Chrome wrote into the file (line 2 of the file) so a port
+   * later reused by an unrelated Chrome/CDP instance can't be mistaken
+   * for ours.
+   */
+  expectedWebSocketPath?: string | null;
+}
+
 /**
  * Single-shot HTTP probe of Chrome's `/json/version` endpoint. Resolves
  * `true` only when the port answers with a 2xx response whose body is
  * valid JSON with a non-empty `webSocketDebuggerUrl` (the CDP fingerprint
  * — won't false-positive on some other HTTP service squatting on the
- * port). All errors / timeouts collapse to `false` so the caller can
- * retry without exception plumbing.
+ * port). When `expectedWebSocketPath` is supplied, the probe additionally
+ * requires the URL's pathname to match, so the launcher can't attach to
+ * an unrelated live CDP server that just happens to be on the same port
+ * a stale `DevToolsActivePort` file pointed at.
+ *
+ * Contract: **every** failure mode collapses to `Promise<false>`. Out-
+ * of-range ports, synchronous `httpRequest` throws (`ERR_SOCKET_BAD_PORT`,
+ * `ERR_INVALID_ARG_TYPE`), connection refused, timeouts, oversized
+ * bodies, malformed JSON, missing `webSocketDebuggerUrl`, mismatched
+ * websocket paths, errors on the response stream — all return `false`.
+ * Callers can retry without exception plumbing.
  *
  * Kept small and stdlib-only (`node:http`) to avoid pulling another
  * fetch implementation into the launcher hot path.
  */
-export function probeCdpAlive(port: number, timeoutMs = 500): Promise<boolean> {
+export function probeCdpAlive(port: number, options: ProbeCdpAliveOptions = {}): Promise<boolean> {
+  const timeoutMs = options.timeoutMs ?? 500;
+  const expectedWebSocketPath = options.expectedWebSocketPath ?? null;
   return new Promise((resolve) => {
     let resolved = false;
     const settle = (alive: boolean) => {
@@ -607,46 +632,85 @@ export function probeCdpAlive(port: number, timeoutMs = 500): Promise<boolean> {
       resolved = true;
       resolve(alive);
     };
-    const req = httpRequest(
-      {
-        host: '127.0.0.1',
-        port,
-        path: '/json/version',
-        method: 'GET',
-        timeout: timeoutMs,
-      },
-      (res) => {
-        const status = res.statusCode ?? 0;
-        if (status < 200 || status >= 300) {
-          res.resume();
-          settle(false);
-          return;
+
+    // Range-check before handing the port to `httpRequest`, which throws
+    // synchronously (`ERR_SOCKET_BAD_PORT`) for anything outside 0–65535.
+    // A stale or corrupt `DevToolsActivePort` can easily contain
+    // out-of-range values, and the contract above promises we never
+    // reject in that case.
+    if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+      settle(false);
+      return;
+    }
+
+    let req;
+    try {
+      req = httpRequest(
+        {
+          host: '127.0.0.1',
+          port,
+          path: '/json/version',
+          method: 'GET',
+          timeout: timeoutMs,
+        },
+        (res) => {
+          const status = res.statusCode ?? 0;
+          if (status < 200 || status >= 300) {
+            res.resume();
+            settle(false);
+            return;
+          }
+          let body = '';
+          res.setEncoding('utf-8');
+          res.on('data', (chunk: string) => {
+            body += chunk;
+            // Cap the body size — the real /json/version payload is well
+            // under 1 KiB, so anything larger is junk from another service.
+            if (body.length > 16_384) {
+              res.destroy();
+              settle(false);
+            }
+          });
+          res.on('end', () => {
+            try {
+              const parsed = JSON.parse(body) as { webSocketDebuggerUrl?: unknown };
+              if (
+                typeof parsed.webSocketDebuggerUrl !== 'string' ||
+                parsed.webSocketDebuggerUrl.length === 0
+              ) {
+                settle(false);
+                return;
+              }
+              if (expectedWebSocketPath) {
+                // Parse the URL to extract its pathname so we compare
+                // apples to apples regardless of host/port differences.
+                // Any parse failure collapses to false per contract.
+                let actualPath: string;
+                try {
+                  actualPath = new URL(parsed.webSocketDebuggerUrl).pathname;
+                } catch {
+                  settle(false);
+                  return;
+                }
+                if (actualPath !== expectedWebSocketPath) {
+                  settle(false);
+                  return;
+                }
+              }
+              settle(true);
+            } catch {
+              settle(false);
+            }
+          });
+          res.on('error', () => settle(false));
         }
-        let body = '';
-        res.setEncoding('utf-8');
-        res.on('data', (chunk: string) => {
-          body += chunk;
-          // Cap the body size — the real /json/version payload is well
-          // under 1 KiB, so anything larger is junk from another service.
-          if (body.length > 16_384) {
-            res.destroy();
-            settle(false);
-          }
-        });
-        res.on('end', () => {
-          try {
-            const parsed = JSON.parse(body) as { webSocketDebuggerUrl?: unknown };
-            settle(
-              typeof parsed.webSocketDebuggerUrl === 'string' &&
-                parsed.webSocketDebuggerUrl.length > 0
-            );
-          } catch {
-            settle(false);
-          }
-        });
-        res.on('error', () => settle(false));
-      }
-    );
+      );
+    } catch {
+      // `httpRequest` itself can throw synchronously for invalid option
+      // shapes (most commonly out-of-range port). Honor the contract.
+      settle(false);
+      return;
+    }
     req.on('error', () => settle(false));
     req.on('timeout', () => {
       req.destroy();
@@ -664,38 +728,55 @@ export function probeCdpAlive(port: number, timeoutMs = 500): Promise<boolean> {
  * reliable than scraping stderr.
  *
  * Validation: before resolving, probe `/json/version` on the discovered
- * port. The file is written by Chrome but reused across runs in the same
- * profile directory, and `clearStaleDevToolsActivePort` is a
- * best-effort unlink that races our spawn. If the probe fails we treat
- * the file content as stale and keep polling for either an updated file
- * (the freshly-spawned Chrome about to overwrite it) or the eventual
- * timeout. This belt-and-suspenders pairs with the pre-spawn deletion
- * to make the discovery resilient to crashed previous runs that left
- * the file pointing at a now-dead TCP port.
+ * port and require the response's `webSocketDebuggerUrl` pathname to
+ * match the path Chrome wrote into the file's second line. The file is
+ * written by Chrome but reused across runs in the same profile
+ * directory, and `clearStaleDevToolsActivePort` is a best-effort unlink
+ * that races our spawn. If the probe fails (port refused, wrong CDP
+ * instance, anything) we treat the file content as stale and keep
+ * polling for either an updated file (the freshly-spawned Chrome about
+ * to overwrite it) or the eventual timeout. The pathname comparison
+ * specifically guards against the port-reuse case where a stale file
+ * points at a port that's now serving an *unrelated* Chrome/CDP
+ * instance (different `browser/<uuid>` path).
  *
  * Resolves with the parsed port once both the file content and the
- * live CDP probe succeed. Rejects on timeout or process exit.
+ * live CDP probe succeed. Rejects on timeout or process exit, with
+ * the timeout message distinguishing "file never appeared" from "file
+ * appeared but its port never answered CDP".
  *
  * @param userDataDir absolute path Chrome was launched with via `--user-data-dir=`
  * @param child       the Chrome child process (used to bail out on early exit)
  * @param timeoutMs   total budget before giving up
  * @param pollMs      polling cadence (default 50ms)
  * @param options     test seam — inject a custom `verifyPort` to avoid
- *                    real network probes in unit tests.
+ *                    real network probes in unit tests. The verifier
+ *                    receives both the parsed port and the websocket
+ *                    path Chrome wrote on line 2 (or `null` if absent).
  */
 export function waitForCdpPortFromActivePortFile(
   userDataDir: string,
   child: ChildProcess,
   timeoutMs: number = getDefaultCdpLaunchTimeoutMs(),
   pollMs = 50,
-  options: { verifyPort?: (port: number) => Promise<boolean> } = {}
+  options: {
+    verifyPort?: (port: number, expectedWebSocketPath: string | null) => Promise<boolean>;
+  } = {}
 ): Promise<number> {
-  const verifyPort = options.verifyPort ?? ((port: number) => probeCdpAlive(port));
+  const verifyPort =
+    options.verifyPort ??
+    ((port: number, expectedWebSocketPath: string | null) =>
+      probeCdpAlive(port, { expectedWebSocketPath }));
 
   return new Promise((resolve, reject) => {
     let settled = false;
     const path = join(userDataDir, 'DevToolsActivePort');
     const startedAt = Date.now();
+    // Track whether we ever observed a parseable candidate port so the
+    // timeout error can distinguish "file never showed up" from "file
+    // was there but its port never answered CDP".
+    let sawCandidate = false;
+    let lastCandidatePort: number | null = null;
 
     const finish = (action: () => void) => {
       if (settled) return;
@@ -706,17 +787,26 @@ export function waitForCdpPortFromActivePortFile(
     const tick = async (): Promise<void> => {
       if (settled) return;
       let candidatePort: number | null = null;
+      let candidateWsPath: string | null = null;
       try {
         const contents = await readFile(path, 'utf-8');
-        // First line is the port; second is the WS path. Chrome writes both
-        // atomically once the listener is up. If we read it mid-write we'll
-        // either get an empty file or the port-only first line — both fall
-        // through to the next tick.
-        const firstLine = contents.split('\n', 1)[0]?.trim();
+        // First line is the port; second is the WS path. Chrome writes
+        // both atomically once the listener is up. If we read it
+        // mid-write we'll either get an empty file, the port-only first
+        // line, or a corrupt body — every parse failure falls through
+        // to the next tick.
+        const lines = contents.split('\n');
+        const firstLine = lines[0]?.trim();
         if (firstLine) {
           const port = Number.parseInt(firstLine, 10);
-          if (Number.isFinite(port) && port > 0) {
+          // Match `probeCdpAlive`'s range guard so we never hand it a
+          // value it'll reject anyway.
+          if (Number.isInteger(port) && port > 0 && port <= 65_535) {
             candidatePort = port;
+            const secondLine = lines[1]?.trim();
+            if (secondLine && secondLine.startsWith('/')) {
+              candidateWsPath = secondLine;
+            }
           }
         }
       } catch (err) {
@@ -727,11 +817,23 @@ export function waitForCdpPortFromActivePortFile(
       }
 
       if (candidatePort !== null) {
-        // Verify the file's port actually answers CDP. A stale file
-        // (e.g. from a previous run that crashed before
-        // `clearStaleDevToolsActivePort` could land) will fail this
-        // probe and fall through to the next tick.
-        const alive = await verifyPort(candidatePort);
+        sawCandidate = true;
+        lastCandidatePort = candidatePort;
+        // Verify the file's port actually answers CDP and reports the
+        // same websocket path the file claims. A stale file (e.g. from
+        // a previous run that crashed before
+        // `clearStaleDevToolsActivePort` could land) or a port that's
+        // been reused by an unrelated Chrome will fail this probe and
+        // fall through to the next tick. Wrap in try/catch so any
+        // unexpected verifier rejection — including a rogue custom
+        // verifier in tests — is treated as "not alive" rather than
+        // aborting the poll loop and hanging discovery indefinitely.
+        let alive = false;
+        try {
+          alive = await verifyPort(candidatePort, candidateWsPath);
+        } catch {
+          alive = false;
+        }
         if (settled) return; // child exited mid-probe — `child.on('exit')` already rejected.
         if (alive) {
           finish(() => resolve(candidatePort!));
@@ -740,9 +842,10 @@ export function waitForCdpPortFromActivePortFile(
       }
 
       if (Date.now() - startedAt >= timeoutMs) {
-        finish(() =>
-          reject(new Error(`Timed out waiting for DevToolsActivePort at ${path} (${timeoutMs}ms)`))
-        );
+        const message = sawCandidate
+          ? `Port ${lastCandidatePort} from DevToolsActivePort at ${path} never answered CDP (${timeoutMs}ms)`
+          : `Timed out waiting for DevToolsActivePort at ${path} (${timeoutMs}ms)`;
+        finish(() => reject(new Error(message)));
         return;
       }
       setTimeout(() => {
@@ -774,9 +877,12 @@ export function waitForCdpPort(
     /**
      * Test seam — forwarded to `waitForCdpPortFromActivePortFile` so unit
      * tests can simulate the "file says port X, but X isn't actually
-     * answering CDP" stale-port race without binding a real socket.
+     * answering CDP" stale-port race without binding a real socket. The
+     * verifier receives both the parsed port and the websocket path
+     * Chrome wrote on the file's second line (or `null` when the file
+     * was read mid-write and only the port is available).
      */
-    verifyPort?: (port: number) => Promise<boolean>;
+    verifyPort?: (port: number, expectedWebSocketPath: string | null) => Promise<boolean>;
   } = {}
 ): Promise<number> {
   const timeoutMs = options.timeoutMs ?? getDefaultCdpLaunchTimeoutMs();

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -485,7 +485,7 @@ describe('getDefaultCdpLaunchTimeoutMs', () => {
 });
 
 describe('waitForCdpPortFromActivePortFile', () => {
-  const trustingVerify = async (_port: number) => true;
+  const trustingVerify = async (_port: number, _ws: string | null) => true;
 
   it('resolves with the port written to DevToolsActivePort', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
@@ -502,6 +502,27 @@ describe('waitForCdpPortFromActivePortFile', () => {
     }, 30);
 
     await expect(promise).resolves.toBe(49321);
+  });
+
+  it('forwards the websocket path from the file to the verifier', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
+    tempDirs.push(dir);
+    await writeFile(join(dir, 'DevToolsActivePort'), '49322\n/devtools/browser/0001-fingerprint\n');
+    const { EventEmitter } = await import('events');
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+    let seenPort: number | null = null;
+    let seenPath: string | null = null;
+    const verifyPort = async (port: number, ws: string | null) => {
+      seenPort = port;
+      seenPath = ws;
+      return true;
+    };
+
+    await expect(
+      waitForCdpPortFromActivePortFile(dir, child, 2000, 10, { verifyPort })
+    ).resolves.toBe(49322);
+    expect(seenPort).toBe(49322);
+    expect(seenPath).toBe('/devtools/browser/0001-fingerprint');
   });
 
   it('rejects on timeout when the file never appears', async () => {
@@ -541,7 +562,7 @@ describe('waitForCdpPortFromActivePortFile', () => {
     const { EventEmitter } = await import('events');
     const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
     const probedPorts: number[] = [];
-    const verifyPort = async (port: number) => {
+    const verifyPort = async (port: number, _ws: string | null) => {
       probedPorts.push(port);
       return port === 22222;
     };
@@ -559,29 +580,53 @@ describe('waitForCdpPortFromActivePortFile', () => {
     expect(probedPorts.indexOf(11111)).toBeLessThan(probedPorts.indexOf(22222));
   });
 
-  it('keeps polling when verifyPort never returns true and eventually times out', async () => {
+  it('keeps polling when verifyPort never returns true and eventually times out with a stale-port message', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
     tempDirs.push(dir);
     await writeFile(join(dir, 'DevToolsActivePort'), '33333\n/devtools/browser/zombie\n');
     const { EventEmitter } = await import('events');
     const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
     let probeCount = 0;
-    const verifyPort = async (_port: number) => {
+    const verifyPort = async (_port: number, _ws: string | null) => {
       probeCount += 1;
       return false;
     };
 
+    // Timeout message MUST distinguish "file appeared but its port never
+    // answered CDP" from "file never showed up" — otherwise stale-port
+    // failures look identical to clean misses in the logs.
     await expect(
       waitForCdpPortFromActivePortFile(dir, child, 200, 10, { verifyPort })
-    ).rejects.toThrow(/Timed out waiting for DevToolsActivePort/);
-    // Sanity: the poller actually probed multiple times rather than
-    // bailing after the first stale read.
+    ).rejects.toThrow(/Port 33333 from DevToolsActivePort.*never answered CDP/);
+    expect(probeCount).toBeGreaterThan(1);
+  });
+
+  it('treats a synchronously-throwing verifier as not-alive and keeps polling', async () => {
+    // Defensive: even though the production verifier never throws,
+    // injecting one that does (or that returns a port that pushes
+    // probeCdpAlive over its range guard) must not abort the poll
+    // loop and hang discovery indefinitely.
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
+    tempDirs.push(dir);
+    await writeFile(join(dir, 'DevToolsActivePort'), '44444\n/devtools/browser/anything\n');
+    const { EventEmitter } = await import('events');
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+    let probeCount = 0;
+    const verifyPort = async (_port: number, _ws: string | null) => {
+      probeCount += 1;
+      throw new Error('rude verifier');
+    };
+
+    await expect(
+      waitForCdpPortFromActivePortFile(dir, child, 150, 10, { verifyPort })
+    ).rejects.toThrow(/never answered CDP/);
+    // The exception MUST NOT have collapsed the loop after the first probe.
     expect(probeCount).toBeGreaterThan(1);
   });
 });
 
 describe('waitForCdpPort (race)', () => {
-  const trustingVerify = async (_port: number) => true;
+  const trustingVerify = async (_port: number, _ws: string | null) => true;
 
   it('resolves from stderr when the active-port file is delayed', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
@@ -735,7 +780,105 @@ describe('probeCdpAlive', () => {
     const port = (probe.address() as import('net').AddressInfo).port;
     await new Promise<void>((resolve) => probe.close(() => resolve()));
 
-    await expect(probeCdpAlive(port, 300)).resolves.toBe(false);
+    await expect(probeCdpAlive(port, { timeoutMs: 300 })).resolves.toBe(false);
+  });
+
+  it('returns false for out-of-range ports without throwing', async () => {
+    // A stale or corrupt DevToolsActivePort can easily contain values
+    // like 70000. Handing that straight to http.request raises
+    // ERR_SOCKET_BAD_PORT synchronously — the probe contract says
+    // collapse it to false and let the caller retry.
+    await expect(probeCdpAlive(70000)).resolves.toBe(false);
+    await expect(probeCdpAlive(-1)).resolves.toBe(false);
+    await expect(probeCdpAlive(0)).resolves.toBe(false);
+    await expect(probeCdpAlive(Number.NaN)).resolves.toBe(false);
+    await expect(probeCdpAlive(3.14)).resolves.toBe(false);
+  });
+
+  it('returns false when the server delays the response past timeoutMs', async () => {
+    const { createServer } = await import('http');
+    // Server accepts the connection but never sends a response.
+    const server = createServer(() => {
+      /* hold the request open */
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as import('net').AddressInfo).port;
+
+    try {
+      const started = Date.now();
+      await expect(probeCdpAlive(port, { timeoutMs: 150 })).resolves.toBe(false);
+      // Sanity: the probe respected its own timeout rather than waiting
+      // for the server's default keep-alive deadline.
+      expect(Date.now() - started).toBeLessThan(2000);
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('returns false when the response body exceeds the size cap', async () => {
+    const { createServer } = await import('http');
+    // Real /json/version is well under 1 KiB. Anything larger than
+    // 16 KiB is treated as a foreign service spraying junk.
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      // Emit ~32 KiB of plausibly-JSON-looking payload.
+      res.write('{"webSocketDebuggerUrl":"ws://127.0.0.1:0/devtools/browser/abc","junk":"');
+      res.write('A'.repeat(32 * 1024));
+      res.end('"}');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as import('net').AddressInfo).port;
+
+    try {
+      await expect(probeCdpAlive(port)).resolves.toBe(false);
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('returns true when the response websocket path matches expectedWebSocketPath', async () => {
+    const { createServer } = await import('http');
+    const wsPath = '/devtools/browser/match-uuid';
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ webSocketDebuggerUrl: `ws://127.0.0.1:0${wsPath}` }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as import('net').AddressInfo).port;
+
+    try {
+      await expect(probeCdpAlive(port, { expectedWebSocketPath: wsPath })).resolves.toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('returns false when expectedWebSocketPath does not match the served URL', async () => {
+    // Guards against the port-reuse case where a stale
+    // DevToolsActivePort points at a port now serving an unrelated
+    // Chrome/CDP instance. The probe must reject it because the
+    // websocket path (the per-Chrome browser UUID) won't match.
+    const { createServer } = await import('http');
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          webSocketDebuggerUrl: 'ws://127.0.0.1:0/devtools/browser/served-by-someone-else',
+        })
+      );
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as import('net').AddressInfo).port;
+
+    try {
+      await expect(
+        probeCdpAlive(port, { expectedWebSocketPath: '/devtools/browser/our-uuid' })
+      ).resolves.toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it('returns false when the port answers HTTP but not with a CDP payload', async () => {

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -17,6 +17,7 @@ import {
   getDefaultCdpLaunchTimeoutMs,
   parseCdpPortFromStderr,
   planChromeSpawn,
+  probeCdpAlive,
   resolveChromeAppBundle,
   resolveChromeLaunchProfile,
   waitForCdpPort,
@@ -484,13 +485,17 @@ describe('getDefaultCdpLaunchTimeoutMs', () => {
 });
 
 describe('waitForCdpPortFromActivePortFile', () => {
+  const trustingVerify = async (_port: number) => true;
+
   it('resolves with the port written to DevToolsActivePort', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
     tempDirs.push(dir);
     const { EventEmitter } = await import('events');
     const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
 
-    const promise = waitForCdpPortFromActivePortFile(dir, child, 2000, 10);
+    const promise = waitForCdpPortFromActivePortFile(dir, child, 2000, 10, {
+      verifyPort: trustingVerify,
+    });
     // Simulate Chrome writing the file shortly after launch.
     setTimeout(() => {
       void writeFile(join(dir, 'DevToolsActivePort'), '49321\n/devtools/browser/abc-123\n');
@@ -505,9 +510,9 @@ describe('waitForCdpPortFromActivePortFile', () => {
     const { EventEmitter } = await import('events');
     const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
 
-    await expect(waitForCdpPortFromActivePortFile(dir, child, 100, 10)).rejects.toThrow(
-      /Timed out waiting for DevToolsActivePort/
-    );
+    await expect(
+      waitForCdpPortFromActivePortFile(dir, child, 100, 10, { verifyPort: trustingVerify })
+    ).rejects.toThrow(/Timed out waiting for DevToolsActivePort/);
   });
 
   it('rejects when Chrome exits before writing the file', async () => {
@@ -516,14 +521,68 @@ describe('waitForCdpPortFromActivePortFile', () => {
     const { EventEmitter } = await import('events');
     const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
 
-    const promise = waitForCdpPortFromActivePortFile(dir, child, 5000, 10);
+    const promise = waitForCdpPortFromActivePortFile(dir, child, 5000, 10, {
+      verifyPort: trustingVerify,
+    });
     setTimeout(() => child.emit('exit', 1), 20);
 
     await expect(promise).rejects.toThrow(/exited with code 1/);
   });
+
+  it('treats the file content as stale when verifyPort returns false, waiting for a live port', async () => {
+    // Simulate: file exists from a previous crashed run pointing at port 11111
+    // (which is no longer a CDP endpoint), then the freshly-spawned Chrome
+    // overwrites the file with port 22222 which IS live. The poller must
+    // reject 11111 and only resolve once it sees 22222.
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
+    tempDirs.push(dir);
+    const filePath = join(dir, 'DevToolsActivePort');
+    await writeFile(filePath, '11111\n/devtools/browser/stale\n');
+    const { EventEmitter } = await import('events');
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+    const probedPorts: number[] = [];
+    const verifyPort = async (port: number) => {
+      probedPorts.push(port);
+      return port === 22222;
+    };
+
+    const promise = waitForCdpPortFromActivePortFile(dir, child, 2000, 10, { verifyPort });
+    setTimeout(() => {
+      void writeFile(filePath, '22222\n/devtools/browser/fresh\n');
+    }, 50);
+
+    await expect(promise).resolves.toBe(22222);
+    expect(probedPorts).toContain(11111);
+    expect(probedPorts).toContain(22222);
+    // The poller MUST NOT have resolved on the stale port even though
+    // the file content parsed cleanly.
+    expect(probedPorts.indexOf(11111)).toBeLessThan(probedPorts.indexOf(22222));
+  });
+
+  it('keeps polling when verifyPort never returns true and eventually times out', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
+    tempDirs.push(dir);
+    await writeFile(join(dir, 'DevToolsActivePort'), '33333\n/devtools/browser/zombie\n');
+    const { EventEmitter } = await import('events');
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+    let probeCount = 0;
+    const verifyPort = async (_port: number) => {
+      probeCount += 1;
+      return false;
+    };
+
+    await expect(
+      waitForCdpPortFromActivePortFile(dir, child, 200, 10, { verifyPort })
+    ).rejects.toThrow(/Timed out waiting for DevToolsActivePort/);
+    // Sanity: the poller actually probed multiple times rather than
+    // bailing after the first stale read.
+    expect(probeCount).toBeGreaterThan(1);
+  });
 });
 
 describe('waitForCdpPort (race)', () => {
+  const trustingVerify = async (_port: number) => true;
+
   it('resolves from stderr when the active-port file is delayed', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
     tempDirs.push(dir);
@@ -532,7 +591,11 @@ describe('waitForCdpPort (race)', () => {
     const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
     (child as { stderr: typeof stderr }).stderr = stderr;
 
-    const promise = waitForCdpPort(child, { userDataDir: dir, timeoutMs: 5000 });
+    const promise = waitForCdpPort(child, {
+      userDataDir: dir,
+      timeoutMs: 5000,
+      verifyPort: trustingVerify,
+    });
     stderr.emit(
       'data',
       Buffer.from('DevTools listening on ws://127.0.0.1:11111/devtools/browser/id\n')
@@ -549,12 +612,44 @@ describe('waitForCdpPort (race)', () => {
     const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
     (child as { stderr: typeof stderr }).stderr = stderr;
 
-    const promise = waitForCdpPort(child, { userDataDir: dir, timeoutMs: 2000 });
+    const promise = waitForCdpPort(child, {
+      userDataDir: dir,
+      timeoutMs: 2000,
+      verifyPort: trustingVerify,
+    });
     setTimeout(() => {
       void writeFile(join(dir, 'DevToolsActivePort'), '22222\n/devtools/browser/zzz\n');
     }, 30);
 
     await expect(promise).resolves.toBe(22222);
+  });
+
+  it('forwards verifyPort to the active-port-file leg so stale ports are rejected end-to-end', async () => {
+    // The race must keep the stderr leg available as a fallback even
+    // when the file leg keeps seeing a stale port — otherwise the
+    // single user-data-dir profile-reuse race that prompted this fix
+    // would still hang.
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-active-port-'));
+    tempDirs.push(dir);
+    await writeFile(join(dir, 'DevToolsActivePort'), '11111\n/devtools/browser/stale\n');
+    const { EventEmitter } = await import('events');
+    const stderr = new EventEmitter();
+    const child = new EventEmitter() as unknown as import('child_process').ChildProcess;
+    (child as { stderr: typeof stderr }).stderr = stderr;
+
+    const promise = waitForCdpPort(child, {
+      userDataDir: dir,
+      timeoutMs: 2000,
+      verifyPort: async () => false,
+    });
+    setTimeout(() => {
+      stderr.emit(
+        'data',
+        Buffer.from('DevTools listening on ws://127.0.0.1:55555/devtools/browser/fresh\n')
+      );
+    }, 30);
+
+    await expect(promise).resolves.toBe(55555);
   });
 
   it('falls back to plain stderr-only waiting when no userDataDir is provided', async () => {
@@ -600,5 +695,82 @@ describe('clearStaleDevToolsActivePort', () => {
       `slicc-clear-active-port-missing-${Date.now()}-${Math.random()}`
     );
     await expect(clearStaleDevToolsActivePort(missing)).resolves.toBeUndefined();
+  });
+});
+
+describe('probeCdpAlive', () => {
+  it('returns true when /json/version answers with a valid CDP payload', async () => {
+    const { createServer } = await import('http');
+    const server = createServer((req, res) => {
+      if (req.url === '/json/version') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            Browser: 'Chrome/148.0.7778.167',
+            webSocketDebuggerUrl: 'ws://127.0.0.1:0/devtools/browser/abc',
+          })
+        );
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as import('net').AddressInfo).port;
+
+    try {
+      await expect(probeCdpAlive(port)).resolves.toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('returns false when nothing is listening on the port', async () => {
+    // Bind+release to find a port we know is free, then immediately
+    // probe it. The OS may rebind quickly to another service, but the
+    // probe should still return false within its own timeout.
+    const { createServer } = await import('net');
+    const probe = createServer();
+    await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', resolve));
+    const port = (probe.address() as import('net').AddressInfo).port;
+    await new Promise<void>((resolve) => probe.close(() => resolve()));
+
+    await expect(probeCdpAlive(port, 300)).resolves.toBe(false);
+  });
+
+  it('returns false when the port answers HTTP but not with a CDP payload', async () => {
+    // Distinguishes Chrome's CDP from any other HTTP service that
+    // happens to be on the same port (think: a dev server, a misrouted
+    // health check, etc.). Without this we could accept a 200 from a
+    // completely unrelated process as "Chrome is up".
+    const { createServer } = await import('http');
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ hello: 'world' }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as import('net').AddressInfo).port;
+
+    try {
+      await expect(probeCdpAlive(port)).resolves.toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('returns false when the port answers with non-2xx', async () => {
+    const { createServer } = await import('http');
+    const server = createServer((_req, res) => {
+      res.writeHead(500);
+      res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as import('net').AddressInfo).port;
+
+    try {
+      await expect(probeCdpAlive(port)).resolves.toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #672. Hardens `waitForCdpPortFromActivePortFile` with a live `/json/version` probe before accepting any port the file claims is Chrome's.

## Why

#672 deletes a stale `DevToolsActivePort` before spawn, which fixes the common case (previous run crashed, profile dir reused, file still says port 50169 even though that's a dead TCP port). But two narrower races slip past:

1. **Unlink loses to Chrome's early write.** `clearStaleDevToolsActivePort` is best-effort; on a fast cold start Chrome can land its own `DevToolsActivePort` before our unlink syscall completes. If Chrome's first published port is itself transient (renderer-process rebind, watchdog restart, whatever you saw in the smoke test where the file flipped 50169 → 59622), we still capture the transient one.
2. **Defense in depth for reused profiles.** Even with the pre-spawn unlink, any future code path that hands `waitForCdpPortFromActivePortFile` a profile dir Chrome hasn't owned yet has the same trust-the-file problem.

Both reviewers on #672 (Copilot and Codex P2) specifically suggested *either* pre-deletion *or* freshness validation. #672 did the deletion; this PR adds the validation.

## What

1. **`probeCdpAlive(port)`** — stdlib-only (`node:http`) single-shot probe of `http://127.0.0.1:<port>/json/version`. Returns `true` only on 2xx + valid JSON + non-empty `webSocketDebuggerUrl` (the CDP fingerprint; won't false-positive on a dev server / health endpoint / IDS scanner that happens to be on the port). Every failure mode (refused, timeout, non-JSON, oversized body) collapses to `false`.
2. **`waitForCdpPortFromActivePortFile`** now calls `probeCdpAlive` on the port it parsed from the file. On `false`, it doesn't resolve — falls back to the next poll tick and re-reads the file, so the freshly-spawned Chrome's overwrite eventually wins. Probe is injectable via `{ verifyPort }` for unit tests.
3. **`waitForCdpPort`** forwards `verifyPort` to the file leg. End-to-end semantics: if the file leg keeps probing a stale port that never goes live, the stderr leg can still win the race (covered by a new test).

## Why a probe instead of file-mtime / write-order tracking

- File-mtime is unreliable on macOS APFS at sub-second resolution and outright wrong inside Docker volumes.
- `fs.watch` works fine but doesn't help with the transient-bind case where Chrome's *own* second write is the right one. "Wait for the next change" sometimes resolves us to the same dead port.
- A live HTTP probe is the only check that actually answers the question we care about: "is there a CDP server accepting connections on this port *right now*?"

## Verification

- `npm run typecheck` clean.
- `npx vitest run packages/node-server/tests/chrome-launch.test.ts`: 50/50 pass (+7 new):
  - probe accepts valid CDP payload
  - probe rejects empty port
  - probe rejects non-CDP HTTP (the false-positive guard)
  - probe rejects non-2xx
  - file leg keeps polling when `verifyPort` returns false, eventually picks up the live overwrite
  - file leg times out when `verifyPort` never returns true
  - end-to-end race forwards `verifyPort` through `waitForCdpPort`
- `npm run build -w @slicc/node-server` clean.
- Manual smoke test: seeded `/tmp/browser-coding-agent-chrome/DevToolsActivePort` with `1\n/devtools/browser/totally-bogus-stale-id` then ran `npm run dev`. Chrome launched via `/usr/bin/open` as expected, node captured the real port (61592), `/json/version` answered, zero `CDP did not become available` entries in the log.

## Risks

- Adds a per-poll HTTP roundtrip (capped at 500 ms timeout, typically <5 ms on localhost). Negligible against the existing 15 s launch budget.
- The probe is HTTP-only, no WebSocket handshake. `/json/version` is the canonical Chromium readiness check and is what `puppeteer` / `playwright` use too.

## Base

This PR is stacked on `fix/macos-tcc-chrome-camera-node-server` (#672) because it depends on `clearStaleDevToolsActivePort`. Once #672 merges to main this PR's base will retarget to main automatically (or I'll rebase if needed).