### PR TITLE
fix(llm-session-id): provider-level X-Session-Id fallback

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -774,18 +774,31 @@ without going through the agent loop or the compaction transformer
 will silently bypass it — and the resulting events can't be re-grouped
 after the fact.
 
-**The Two Enforcement Points**
+**The Enforcement Points**
 
 | Code path                                     | Wiring                                           | Where                                                               |
 | --------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------- |
 | Agent loop (cone, scoops, tool turns)         | `streamFn` wrapper passed to `Agent` constructor | `packages/webapp/src/scoops/scoop-context.ts` `streamWithSessionId` |
 | Compaction summaries (Pi packed-conversation) | `headers` config on `createCompactContext`       | `packages/webapp/src/scoops/scoop-context.ts` `compactionHeaders`   |
+| Ad-hoc UI quick-LLM calls                     | Inline `getQuickLlmAdobeSessionId()` header set  | `packages/webapp/src/ui/quick-llm.ts`                               |
+| Session freezer (new-session flow)            | Inline `getDailyAdobeUuid(...)` header set       | `packages/webapp/src/ui/new-session.ts`                             |
+| Provider-level fallback (defense-in-depth)    | `ensureSessionIdHeader` in Adobe stream funcs    | `packages/webapp/providers/adobe.ts`                                |
 
-Both paths attach the same identifier from `getAdobeSessionId(scoop,
-coneJid)` in `packages/webapp/src/scoops/llm-session-id.ts` (a
-daily-rotating UUID for the cone, `<uuid>/<hash(folder, uuid)>` for
-scoops), gated on `model.provider === 'adobe'`. Other providers
-receive no header.
+The first four paths attach a meaningful identifier from
+`getAdobeSessionId(scoop, coneJid)` in
+`packages/webapp/src/scoops/llm-session-id.ts` (a daily-rotating UUID
+for the cone, `<uuid>/<hash(folder, uuid)>` for scoops) or a
+purpose-anchored variant. Other providers receive no header.
+
+The last row is the defense-in-depth net: `streamAdobe` and
+`streamSimpleAdobe` both run `ensureSessionIdHeader` before forwarding
+to pi-ai, so any future call site that forgets to attach a header
+still gets a daily-rotated fallback UUID anchored on the sentinel
+`'adobe-provider-fallback'`. The fallback collides across all unwrapped
+paths within a browser-day — that is intentional. It tells the proxy
+"the dev forgot the wrapper" rather than legitimizing the call.
+`ensureSessionIdHeader` also emits a deduped `console.warn` per call
+site identifier so the missing wrapper surfaces in development.
 
 **Adding a New LLM Call Site**
 
@@ -796,7 +809,10 @@ attach `X-Session-Id` for the Adobe provider. The cleanest pattern is
 to take a `headers: Record<string, string>` parameter and let the
 caller inject it the same way `createCompactContext` does. Don't
 replicate the Adobe-provider check at every site — push it up to
-whoever owns the call.
+whoever owns the call. If you skip the wiring, the provider-level
+fallback prevents the proxy from falling back to content hashing, but
+your call site will land in a generic "unwrapped" bucket rather than
+the cone's session.
 
 **The pi-coding-agent Stub Tripwire**
 
@@ -841,11 +857,13 @@ that touched LLM call paths, a new code path is bypassing the wiring.
 **Related**
 
 - Bug fix: PR #600 attached `X-Session-Id` to compaction; PR #378
-  attached it to the agent loop.
+  attached it to the agent loop. Provider-level fallback added after
+  the 2026-05-19 cron/standalone-Pi-chat residual report.
 - Tripwire: PR #600 added the positional contract.
 - Coverage: `tests/scoops/scoop-context.session-id.test.ts` asserts
   both wiring points use the same identifier; gates against future
-  reverts.
+  reverts. `tests/providers/adobe-provider.test.ts` covers the
+  provider-level `ensureSessionIdHeader` fallback behavior.
 
 ## Detached popout: boot is the lock event
 

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -136,7 +136,7 @@ Deep reference: `docs/kernel/process-model.md`.
 - **Dual-mode compatibility**: browser features must work in both standalone/CLI and extension runtimes.
 - **Model IDs**: use pi-ai aliases such as `claude-opus-4-6`, not dated snapshot names.
 - **Provider composition**: providers are auto-discovered from pi-ai plus `packages/webapp/src/providers/built-in/`; external provider configs live in `packages/webapp/providers/`, and build-time filtering lives in `packages/dev-tools/providers.build.json`.
-- **Adobe `X-Session-Id` invariant**: every LLM call to the Adobe proxy must attach the `X-Session-Id` header (`scoops/scoop-context.ts` wires it for both the agent `streamFn` and compaction `headers`). New LLM call sites — direct `streamSimple` / `completeSimple` callers, or pi-coding-agent helpers like `generateSummary` — must attach it explicitly or the proxy session-id grouping breaks. See `docs/pitfalls.md` for the full contract, tripwire, and verification SQL.
+- **Adobe `X-Session-Id` invariant**: every LLM call to the Adobe proxy must attach the `X-Session-Id` header (`scoops/scoop-context.ts` wires it for both the agent `streamFn` and compaction `headers`). New LLM call sites — direct `streamSimple` / `completeSimple` callers, or pi-coding-agent helpers like `generateSummary` — must attach it explicitly or the proxy session-id grouping breaks. `providers/adobe.ts`'s `ensureSessionIdHeader` is a defense-in-depth net that injects a daily-rotated sentinel UUID and warns when a caller didn't attach one — fix the call site rather than relying on the fallback. See `docs/pitfalls.md` for the full contract, tripwire, and verification SQL.
 
 ## VFS API Patterns
 

--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -43,6 +43,7 @@ import {
   getBaseUrlForProvider,
 } from '../src/ui/provider-settings.js';
 import { getOAuthPageOrigin } from '../src/providers/oauth-service.js';
+import { getDailyAdobeUuid } from '../src/scoops/llm-session-id.js';
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -626,6 +627,63 @@ function withSliccVersionHeader<T extends { headers?: Record<string, string> }>(
   return { ...options, headers: merged };
 }
 
+// ── X-Session-Id defense-in-depth ───────────────────────────────────
+
+/**
+ * Sentinel anchor for the daily-rotated UUID used when a caller didn't
+ * attach `X-Session-Id`. Shared with the other purpose-anchored
+ * fallbacks (`'ui-quick-llm'`, `'ui-new-session'`) — same shape, same
+ * rotation cadence, no per-user info encoded.
+ */
+const ADOBE_PROVIDER_FALLBACK_ANCHOR = 'adobe-provider-fallback';
+
+/** Dedup developer warnings per call site so hot paths don't spam the console. */
+const warnedCallSites = new Set<string>();
+
+/**
+ * Defense-in-depth: every Adobe-bound LLM call MUST carry `X-Session-Id`.
+ * The intended wiring attaches an anchor-specific id at the call site —
+ * `scoop-context.ts` for cone/scoop traffic, `quick-llm.ts` for ad-hoc UI
+ * labels, `new-session.ts` for the freezer, etc. If a new call site
+ * slips through without one, fall back to a daily-rotated sentinel UUID
+ * so the proxy can still group requests, rather than letting it hash
+ * the content into an opaque hex id. The fallback intentionally collides
+ * across all unwrapped paths within a browser-day — the value is "the
+ * dev forgot the wrapper, fix it" not "this is a legitimate session."
+ *
+ * Caller-supplied values (any case variant) are always preserved.
+ */
+function ensureSessionIdHeader<T extends { headers?: Record<string, string> }>(
+  options: T,
+  callSite: string
+): T {
+  if (options.headers) {
+    for (const key of Object.keys(options.headers)) {
+      if (key.toLowerCase() === 'x-session-id') return options;
+    }
+  }
+  if (!warnedCallSites.has(callSite)) {
+    warnedCallSites.add(callSite);
+    console.warn(
+      `[adobe] Missing X-Session-Id from ${callSite} — using daily fallback. ` +
+        `Attach an X-Session-Id header at the call site (see scoop-context.ts ` +
+        `streamWithSessionId or docs/pitfalls.md).`
+    );
+  }
+  return {
+    ...options,
+    headers: {
+      ...(options.headers ?? {}),
+      'X-Session-Id': getDailyAdobeUuid(ADOBE_PROVIDER_FALLBACK_ANCHOR),
+    },
+  };
+}
+
+/** Test-only: clear the dedup set so warning-emission tests stay independent. */
+export function __resetAdobeSessionIdWarningCacheForTests(): void {
+  warnedCallSites.clear();
+}
+
 // ── Stream functions (reuse pi-ai's Anthropic provider) ─────────────
 
 function makeErrorOutput(model: Model<Api>, error: unknown) {
@@ -678,7 +736,9 @@ const streamAdobe = (
         const inner = streamOpenAICompletions(
           proxyModel as any,
           context,
-          withSliccVersionHeader({ ...options, apiKey: accessToken }) as any
+          withSliccVersionHeader(
+            ensureSessionIdHeader({ ...options, apiKey: accessToken }, 'streamAdobe[openai]')
+          ) as any
         );
         for await (const event of inner) stream.push(event as any);
       } else {
@@ -691,7 +751,9 @@ const streamAdobe = (
         const inner = streamAnthropic(
           proxyModel as any,
           context,
-          withSliccVersionHeader({ ...options, apiKey: accessToken })
+          withSliccVersionHeader(
+            ensureSessionIdHeader({ ...options, apiKey: accessToken }, 'streamAdobe[anthropic]')
+          )
         );
         for await (const event of inner) stream.push(event as any);
       }
@@ -725,7 +787,9 @@ const streamSimpleAdobe = (model: Model<Api>, context: Context, options?: Simple
         const inner = streamSimpleOpenAICompletions(
           proxyModel as any,
           context,
-          withSliccVersionHeader({ ...options, apiKey: accessToken }) as any
+          withSliccVersionHeader(
+            ensureSessionIdHeader({ ...options, apiKey: accessToken }, 'streamSimpleAdobe[openai]')
+          ) as any
         );
         for await (const event of inner) stream.push(event as any);
       } else {
@@ -738,7 +802,12 @@ const streamSimpleAdobe = (model: Model<Api>, context: Context, options?: Simple
         const inner = streamSimpleAnthropic(
           proxyModel as any,
           context,
-          withSliccVersionHeader({ ...options, apiKey: accessToken }) as any
+          withSliccVersionHeader(
+            ensureSessionIdHeader(
+              { ...options, apiKey: accessToken },
+              'streamSimpleAdobe[anthropic]'
+            )
+          ) as any
         );
         for await (const event of inner) stream.push(event as any);
       }

--- a/packages/webapp/tests/providers/adobe-provider.test.ts
+++ b/packages/webapp/tests/providers/adobe-provider.test.ts
@@ -430,3 +430,164 @@ describe('SLICC version header injection', () => {
     expect(headers[SLICC_VERSION_HEADER]).toBe(sliccVersion);
   });
 });
+
+describe('X-Session-Id fallback enforcement', () => {
+  // Mirrors ensureSessionIdHeader in adobe.ts. Same mirror-rather-than-import
+  // pattern as withSliccVersionHeader above (adobe.ts pulls in import.meta.glob
+  // and chrome globals that aren't available under vitest/node).
+  //
+  // The real helper anchors its fallback on a daily-rotated UUID via
+  // getDailyAdobeUuid; the mirror substitutes a fixed string so the assertion
+  // is deterministic. The behavior under test is the merge logic — header
+  // preservation, case-insensitive detection, dev-warning dedup — not the
+  // UUID generator itself (covered by tests/scoops/llm-session-id.test.ts).
+  const FALLBACK_UUID = 'fallback-uuid-for-test';
+  const SLICC_VERSION_HEADER = 'X-Slicc-Version';
+  const sliccVersion = '9.9.9-test';
+  const warned: string[] = [];
+
+  function ensureSessionIdHeader<T extends { headers?: Record<string, string> }>(
+    options: T,
+    callSite: string,
+    warnedSet: Set<string>
+  ): T {
+    if (options.headers) {
+      for (const key of Object.keys(options.headers)) {
+        if (key.toLowerCase() === 'x-session-id') return options;
+      }
+    }
+    if (!warnedSet.has(callSite)) {
+      warnedSet.add(callSite);
+      warned.push(callSite);
+    }
+    return {
+      ...options,
+      headers: {
+        ...(options.headers ?? {}),
+        'X-Session-Id': FALLBACK_UUID,
+      },
+    };
+  }
+
+  function withSliccVersionHeader<T extends { headers?: Record<string, string> }>(options: T): T {
+    const merged: Record<string, string> = {};
+    const versionKeyLower = SLICC_VERSION_HEADER.toLowerCase();
+    if (options.headers) {
+      for (const [key, value] of Object.entries(options.headers)) {
+        if (key.toLowerCase() !== versionKeyLower) merged[key] = value;
+      }
+    }
+    merged[SLICC_VERSION_HEADER] = sliccVersion;
+    return { ...options, headers: merged };
+  }
+
+  beforeEach(() => {
+    warned.length = 0;
+  });
+
+  it('preserves caller-supplied X-Session-Id (the wrapped, intended path)', () => {
+    const warnedSet = new Set<string>();
+    const result = ensureSessionIdHeader(
+      { apiKey: 'tok', headers: { 'X-Session-Id': 'cone-uuid-abc' } },
+      'streamAdobe[anthropic]',
+      warnedSet
+    );
+    expect(result.headers).toEqual({ 'X-Session-Id': 'cone-uuid-abc' });
+    expect(warned).toEqual([]);
+  });
+
+  it('detects lowercase x-session-id and treats it as caller-supplied', () => {
+    // HTTP headers are case-insensitive — a caller writing 'x-session-id'
+    // already discharged the wrapper duty; do not overwrite with the fallback.
+    const warnedSet = new Set<string>();
+    const result = ensureSessionIdHeader(
+      { headers: { 'x-session-id': 'lower-cased-id' } },
+      'streamAdobe[anthropic]',
+      warnedSet
+    );
+    expect(result.headers).toEqual({ 'x-session-id': 'lower-cased-id' });
+    expect(warned).toEqual([]);
+  });
+
+  it('injects fallback when caller has no headers at all', () => {
+    const warnedSet = new Set<string>();
+    const result = ensureSessionIdHeader({ apiKey: 'tok' }, 'streamSimpleAdobe[openai]', warnedSet);
+    expect(result.headers?.['X-Session-Id']).toBe(FALLBACK_UUID);
+    expect(warned).toEqual(['streamSimpleAdobe[openai]']);
+  });
+
+  it('injects fallback when caller has headers but no session id', () => {
+    const warnedSet = new Set<string>();
+    const result = ensureSessionIdHeader(
+      { headers: { 'X-Other-Header': 'keep-me' } },
+      'streamAdobe[openai]',
+      warnedSet
+    );
+    expect(result.headers).toEqual({
+      'X-Other-Header': 'keep-me',
+      'X-Session-Id': FALLBACK_UUID,
+    });
+    expect(warned).toEqual(['streamAdobe[openai]']);
+  });
+
+  it('preserves non-header options (apiKey, maxTokens, signal) through the merge', () => {
+    const signal = new AbortController().signal;
+    const warnedSet = new Set<string>();
+    const result = ensureSessionIdHeader(
+      { apiKey: 'tok', maxTokens: 100, signal },
+      'streamAdobe[anthropic]',
+      warnedSet
+    );
+    expect(result.apiKey).toBe('tok');
+    expect(result.maxTokens).toBe(100);
+    expect(result.signal).toBe(signal);
+    expect(result.headers?.['X-Session-Id']).toBe(FALLBACK_UUID);
+  });
+
+  it('dedups the dev warning per call site across repeated misses', () => {
+    // A hot path (e.g. a cron firing every 3h) should not spam the console.
+    const warnedSet = new Set<string>();
+    ensureSessionIdHeader({}, 'streamAdobe[anthropic]', warnedSet);
+    ensureSessionIdHeader({}, 'streamAdobe[anthropic]', warnedSet);
+    ensureSessionIdHeader({}, 'streamAdobe[anthropic]', warnedSet);
+    expect(warned).toEqual(['streamAdobe[anthropic]']);
+  });
+
+  it('warns once per distinct call site', () => {
+    // A new unwrapped surface should still surface a warning even if a
+    // different call site was already warned about.
+    const warnedSet = new Set<string>();
+    ensureSessionIdHeader({}, 'streamAdobe[anthropic]', warnedSet);
+    ensureSessionIdHeader({}, 'streamAdobe[openai]', warnedSet);
+    ensureSessionIdHeader({}, 'streamSimpleAdobe[anthropic]', warnedSet);
+    expect(warned).toEqual([
+      'streamAdobe[anthropic]',
+      'streamAdobe[openai]',
+      'streamSimpleAdobe[anthropic]',
+    ]);
+  });
+
+  it('composes with withSliccVersionHeader: fallback id + version both attached', () => {
+    // Production order: ensureSessionIdHeader runs first, then
+    // withSliccVersionHeader. The composition must end with both headers
+    // present on the outgoing options.
+    const warnedSet = new Set<string>();
+    const withSession = ensureSessionIdHeader({}, 'streamAdobe[anthropic]', warnedSet);
+    const withSessionAndVersion = withSliccVersionHeader(withSession);
+    expect(withSessionAndVersion.headers?.['X-Session-Id']).toBe(FALLBACK_UUID);
+    expect(withSessionAndVersion.headers?.[SLICC_VERSION_HEADER]).toBe(sliccVersion);
+  });
+
+  it('composes with withSliccVersionHeader: caller id preserved when supplied', () => {
+    const warnedSet = new Set<string>();
+    const withSession = ensureSessionIdHeader(
+      { headers: { 'X-Session-Id': 'real-cone-uuid' } },
+      'streamAdobe[anthropic]',
+      warnedSet
+    );
+    const withSessionAndVersion = withSliccVersionHeader(withSession);
+    expect(withSessionAndVersion.headers?.['X-Session-Id']).toBe('real-cone-uuid');
+    expect(withSessionAndVersion.headers?.[SLICC_VERSION_HEADER]).toBe(sliccVersion);
+    expect(warned).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `ensureSessionIdHeader` to `providers/adobe.ts` — `streamAdobe` and `streamSimpleAdobe` now inject a daily-rotated sentinel UUID when the caller didn't attach `X-Session-Id`, instead of letting the proxy fall back to a content hash.
- Caller-supplied ids (any case variant) are preserved; the helper only fills in a missing header.
- A deduped `console.warn` per call-site identifier surfaces missing wrappers in development without spamming hot paths.

## Context

Filed as a follow-up to the bug report covering cron-triggered Pi calls and standalone Pi-chat events still landing in the proxy's hex-fallback bucket. The intended fix shape — wrap each call site in `streamWithSessionId` — has been applied four times now (PR #378, PR #600, and the 2026-05-12 follow-ups). The wrapper-at-call-site pattern is fragile because new call sites keep being added without it.

This change implements the "broader prevention" option from the bug report: enforce `X-Session-Id` one level lower, inside the Adobe stream functions themselves, so an unwrapped call still attaches a valid id and surfaces a developer warning rather than failing silently into the hex bucket.

The four intended call sites (`scoop-context.ts`, `context-compaction.ts`, `quick-llm.ts`, `new-session.ts`) continue to attach their own anchor-specific ids for proper session grouping. Only unwrapped slip-throughs land in the shared `'adobe-provider-fallback'` daily bucket.

## Test plan

- [x] `npx prettier --write` on changed files — clean
- [x] `npm run typecheck` — clean
- [x] `npx vitest run packages/webapp/tests/providers/ packages/webapp/tests/scoops/` — 823 pass, 9 new
- [x] `npm run test` — pre-existing `CloseEvent is not defined` failures in `websocat-command.test.ts` only, unrelated to this change
- [x] `npm run build` — clean
- [x] `npm run build -w @slicc/chrome-extension` — clean
- [ ] After deploy, the `cron` + `standalone_pi_chat` columns of the verification SQL in the bug report should drop to ~0 for new days

🤖 Generated with [Claude Code](https://claude.com/claude-code)