### PR TITLE
feat(chrome-extension): show notification and badge on x-slicc handoff

### DIFF
--- a/packages/chrome-extension/manifest.json
+++ b/packages/chrome-extension/manifest.json
@@ -12,7 +12,8 @@
     "offscreen",
     "identity",
     "storage",
-    "webRequest"
+    "webRequest",
+    "notifications"
   ],
   "host_permissions": ["<all_urls>"],
   "side_panel": {

--- a/packages/chrome-extension/src/chrome.d.ts
+++ b/packages/chrome-extension/src/chrome.d.ts
@@ -87,6 +87,9 @@ interface ChromeAPI {
     sendMessage(message: unknown, callback?: (response: unknown) => void): Promise<void>;
     /** Open the manifest's options_ui page in a new tab (or popup). */
     openOptionsPage(): Promise<void>;
+    getContexts(filter: {
+      contextTypes?: string[];
+    }): Promise<Array<{ contextType: string; documentUrl?: string }>>;
     onInstalled: {
       addListener(callback: () => void): void;
     };

--- a/packages/chrome-extension/src/chrome.d.ts
+++ b/packages/chrome-extension/src/chrome.d.ts
@@ -134,6 +134,20 @@ interface ChromeAPI {
     open(options: { tabId?: number; windowId?: number }): Promise<void>;
     close(options: { tabId?: number; windowId?: number }): Promise<void>;
   };
+  notifications: {
+    create(
+      notificationId: string,
+      options: {
+        type: 'basic' | 'image' | 'list' | 'progress';
+        iconUrl: string;
+        title: string;
+        message: string;
+      }
+    ): Promise<string>;
+    onClicked: {
+      addListener(callback: (notificationId: string) => void): void;
+    };
+  };
   windows: {
     create(options: {
       url?: string;
@@ -145,6 +159,7 @@ interface ChromeAPI {
     update(windowId: number, properties: { focused?: boolean }): Promise<{ id?: number }>;
     remove(windowId: number): Promise<void>;
     getAll(): Promise<Array<{ id: number }>>;
+    getCurrent(): Promise<{ id: number }>;
   };
   identity: {
     launchWebAuthFlow(options: { url: string; interactive: boolean }): Promise<string | undefined>;

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -387,7 +387,13 @@ async function addToSliccGroup(tabId: number): Promise<void> {
 /** Maps notification ID → windowId so the click handler can open the right panel. */
 const handoffNotificationWindows = new Map<string, number>();
 
-function showHandoffNotification(windowId: number): void {
+async function showHandoffNotification(windowId: number): Promise<void> {
+  const [contexts, detachedTabId] = await Promise.all([
+    chrome.runtime.getContexts({ contextTypes: ['SIDE_PANEL'] }),
+    readStoredDetachedTabId(),
+  ]);
+  if (contexts.length > 0 || detachedTabId !== undefined) return;
+
   const notificationId = `slicc-handoff-${Date.now()}`;
   handoffNotificationWindows.set(notificationId, windowId);
   chrome.action.setBadgeText({ text: '!' });

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -408,12 +408,13 @@ chrome.notifications.onClicked.addListener((notificationId: string) => {
   const windowId = handoffNotificationWindows.get(notificationId);
   handoffNotificationWindows.delete(notificationId);
   chrome.action.setBadgeText({ text: '' });
+  if (windowId !== undefined) {
+    chrome.sidePanel.open({ windowId }).catch(() => {});
+  }
   readStoredDetachedTabId()
     .then((detachedTabId) => {
       if (detachedTabId !== undefined) {
         chrome.tabs.update(detachedTabId, { active: true }).catch(() => {});
-      } else if (windowId !== undefined) {
-        chrome.sidePanel.open({ windowId }).catch(() => {});
       }
     })
     .catch(() => {});

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -271,6 +271,7 @@ async function handleActionClick(clickedTab: ChromeTab): Promise<void> {
 }
 
 chrome.action.onClicked.addListener((tab) => {
+  chrome.action.setBadgeText({ text: '' });
   handleActionClick(tab).catch((err) => {
     console.error('[slicc-sw] handleActionClick failed', err);
   });
@@ -409,9 +410,7 @@ async function showHandoffNotification(windowId: number): Promise<void> {
 chrome.notifications.onClicked.addListener((notificationId: string) => {
   const windowId = handoffNotificationWindows.get(notificationId);
   handoffNotificationWindows.delete(notificationId);
-  if (handoffNotificationWindows.size === 0) {
-    chrome.action.setBadgeText({ text: '' });
-  }
+  chrome.action.setBadgeText({ text: '' });
   if (windowId !== undefined) {
     chrome.sidePanel.open({ windowId }).catch(() => {});
   }

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -389,11 +389,8 @@ async function addToSliccGroup(tabId: number): Promise<void> {
 const handoffNotificationWindows = new Map<string, number>();
 
 async function showHandoffNotification(windowId: number): Promise<void> {
-  const [contexts, detachedTabId] = await Promise.all([
-    chrome.runtime.getContexts({ contextTypes: ['SIDE_PANEL'] }),
-    readStoredDetachedTabId(),
-  ]);
-  if (contexts.length > 0 || detachedTabId !== undefined) return;
+  const contexts = await chrome.runtime.getContexts({ contextTypes: ['SIDE_PANEL'] });
+  if (contexts.length > 0) return;
 
   const notificationId = `slicc-handoff-${Date.now()}`;
   handoffNotificationWindows.set(notificationId, windowId);

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -412,9 +412,13 @@ chrome.notifications.onClicked.addListener((notificationId: string) => {
     chrome.sidePanel.open({ windowId }).catch(() => {});
   }
   readStoredDetachedTabId()
-    .then((detachedTabId) => {
+    .then(async (detachedTabId) => {
       if (detachedTabId !== undefined) {
-        chrome.tabs.update(detachedTabId, { active: true }).catch(() => {});
+        const tab = await chrome.tabs.get(detachedTabId);
+        await chrome.tabs.update(detachedTabId, { active: true });
+        if (tab.windowId !== undefined) {
+          await chrome.windows.update(tab.windowId, { focused: true });
+        }
       }
     })
     .catch(() => {});

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -380,6 +380,38 @@ async function addToSliccGroup(tabId: number): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Handoff notifications — alert the user when an x-slicc header is received
+// and open the side panel on notification click (user gesture required).
+// ---------------------------------------------------------------------------
+
+/** Maps notification ID → windowId so the click handler can open the right panel. */
+const handoffNotificationWindows = new Map<string, number>();
+
+function showHandoffNotification(windowId: number): void {
+  const notificationId = `slicc-handoff-${Date.now()}`;
+  handoffNotificationWindows.set(notificationId, windowId);
+  chrome.action.setBadgeText({ text: '!' });
+  chrome.action.setBadgeBackgroundColor({ color: '#ff5f72' });
+  chrome.notifications.create(notificationId, {
+    type: 'basic',
+    iconUrl: 'logos/sliccy-color-1scoops-128x128.png',
+    title: 'Slicc handoff received',
+    message: 'Click to open the Slicc side panel and process the handoff.',
+  });
+}
+
+chrome.notifications.onClicked.addListener((notificationId: string) => {
+  const windowId = handoffNotificationWindows.get(notificationId);
+  handoffNotificationWindows.delete(notificationId);
+  if (handoffNotificationWindows.size === 0) {
+    chrome.action.setBadgeText({ text: '' });
+  }
+  if (windowId !== undefined) {
+    chrome.sidePanel.open({ windowId }).catch(() => {});
+  }
+});
+
+// ---------------------------------------------------------------------------
 // x-slicc header observer — emit a navigate lick when a main-frame document
 // response carries the x-slicc header.
 // ---------------------------------------------------------------------------
@@ -422,9 +454,16 @@ chrome.webRequest.onHeadersReceived.addListener(
     if (tabId >= 0) {
       chrome.tabs
         .get(tabId)
-        .then((tab) => dispatch(tab.title))
+        .then((tab) => {
+          if (tab.windowId !== undefined) showHandoffNotification(tab.windowId);
+          dispatch(tab.title);
+        })
         .catch(() => dispatch());
     } else {
+      chrome.windows
+        .getCurrent()
+        .then((w) => showHandoffNotification(w.id!))
+        .catch(() => {});
       dispatch();
     }
   },

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -498,6 +498,7 @@ chrome.runtime.onMessage.addListener(
     const msg = message as ExtensionMessage;
 
     if (msg.source === 'panel') {
+      chrome.action.setBadgeText({ text: '' });
       const panelPayload = msg.payload;
 
       // Handle OAuth requests — service worker has chrome.identity access

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -408,9 +408,15 @@ chrome.notifications.onClicked.addListener((notificationId: string) => {
   const windowId = handoffNotificationWindows.get(notificationId);
   handoffNotificationWindows.delete(notificationId);
   chrome.action.setBadgeText({ text: '' });
-  if (windowId !== undefined) {
-    chrome.sidePanel.open({ windowId }).catch(() => {});
-  }
+  readStoredDetachedTabId()
+    .then((detachedTabId) => {
+      if (detachedTabId !== undefined) {
+        chrome.tabs.update(detachedTabId, { active: true }).catch(() => {});
+      } else if (windowId !== undefined) {
+        chrome.sidePanel.open({ windowId }).catch(() => {});
+      }
+    })
+    .catch(() => {});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/chrome-extension/tests/service-worker-detached.test.ts
+++ b/packages/chrome-extension/tests/service-worker-detached.test.ts
@@ -120,6 +120,7 @@ const mockChrome = {
       },
     },
     sendMessage: vi.fn(async () => {}),
+    getContexts: vi.fn(async () => []),
     onConnect: { addListener: vi.fn() },
     lastError: undefined,
   },
@@ -137,6 +138,10 @@ const mockChrome = {
   identity: {
     launchWebAuthFlow: vi.fn(),
     getRedirectURL: vi.fn(),
+  },
+  notifications: {
+    create: vi.fn(),
+    onClicked: { addListener: vi.fn() },
   },
   webRequest: {
     onHeadersReceived: { addListener: vi.fn() },

--- a/packages/chrome-extension/tests/service-worker-secrets.test.ts
+++ b/packages/chrome-extension/tests/service-worker-secrets.test.ts
@@ -25,6 +25,7 @@ describe('service-worker fetch-proxy.fetch + secrets handlers', () => {
         onMessage: { addListener: (fn: any) => messageListeners.push(fn) },
         onInstalled: { addListener: vi.fn() },
         onStartup: { addListener: vi.fn() },
+        getContexts: vi.fn(async () => []),
         id: 'test-id',
       },
       storage: {
@@ -75,6 +76,10 @@ describe('service-worker fetch-proxy.fetch + secrets handlers', () => {
       identity: {
         launchWebAuthFlow: vi.fn(),
         getRedirectURL: vi.fn(),
+      },
+      notifications: {
+        create: vi.fn(),
+        onClicked: { addListener: vi.fn() },
       },
       webRequest: {
         onHeadersReceived: { addListener: vi.fn() },

--- a/packages/chrome-extension/tests/service-worker.test.ts
+++ b/packages/chrome-extension/tests/service-worker.test.ts
@@ -362,7 +362,7 @@ describe('extension service worker', () => {
     }
   });
 
-  it('shows a notification when x-slicc header is received on a known tab', async () => {
+  it('shows a notification and sets badge when x-slicc header is received', async () => {
     const chrome = (
       globalThis as typeof globalThis & { chrome: ReturnType<typeof createChromeMock> }
     ).chrome;
@@ -379,9 +379,11 @@ describe('extension service worker', () => {
       expect.any(String),
       expect.objectContaining({ type: 'basic', message: expect.any(String) })
     );
+    expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '!' });
+    expect(chrome.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#ff5f72' });
   });
 
-  it('opens the side panel when the handoff notification is clicked', async () => {
+  it('opens the side panel and clears badge when handoff notification is clicked', async () => {
     const chrome = (
       globalThis as typeof globalThis & { chrome: ReturnType<typeof createChromeMock> }
     ).chrome;
@@ -414,6 +416,7 @@ describe('extension service worker', () => {
     await flushAsync();
 
     expect(chrome.sidePanel.open).toHaveBeenCalledWith({ windowId: 7 });
+    expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '' });
   });
 
   it('handles DA sign-and-forward by attaching the IMS bearer token', async () => {

--- a/packages/chrome-extension/tests/service-worker.test.ts
+++ b/packages/chrome-extension/tests/service-worker.test.ts
@@ -91,6 +91,7 @@ function createChromeMock() {
           runtimeMessageListeners.push(listener);
         }),
       },
+      getContexts: vi.fn(async () => []),
       onConnect: {
         addListener: vi.fn(),
       },
@@ -381,6 +382,26 @@ describe('extension service worker', () => {
     );
     expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '!' });
     expect(chrome.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#ff5f72' });
+  });
+
+  it('skips notification when side panel is already open', async () => {
+    const chrome = (
+      globalThis as typeof globalThis & { chrome: ReturnType<typeof createChromeMock> }
+    ).chrome;
+    chrome.tabs.get = vi.fn(async () => ({ id: 42, windowId: 1, title: 'Handoff Page' })) as never;
+    chrome.runtime.getContexts = vi.fn(async () => [
+      { contextType: 'SIDE_PANEL', documentUrl: 'chrome-extension://abc/index.html' },
+    ]) as never;
+
+    headersReceivedListener!({
+      url: 'https://www.sliccy.ai/handoff?msg=upskill%3Ahello',
+      tabId: 42,
+      responseHeaders: [{ name: 'x-slicc', value: 'upskill%3Ahello' }],
+    });
+    await flushAsync();
+
+    expect(chrome.notifications.create).not.toHaveBeenCalled();
+    expect(chrome.action.setBadgeText).not.toHaveBeenCalled();
   });
 
   it('opens the side panel and clears badge when handoff notification is clicked', async () => {

--- a/packages/chrome-extension/tests/service-worker.test.ts
+++ b/packages/chrome-extension/tests/service-worker.test.ts
@@ -11,9 +11,15 @@ type DebuggerEventListener = (
   params?: Record<string, unknown>
 ) => void;
 type DebuggerDetachListener = (source: { tabId: number }, reason: string) => void;
+type HeadersReceivedListener = (details: {
+  url: string;
+  tabId: number;
+  responseHeaders?: Array<{ name: string; value?: string }>;
+}) => void;
 
 const runtimeMessageListeners: OnMessageListener[] = [];
 const runtimeSentMessages: unknown[] = [];
+let headersReceivedListener: HeadersReceivedListener | null = null;
 const debuggerEventListeners: DebuggerEventListener[] = [];
 const debuggerDetachListeners: DebuggerDetachListener[] = [];
 
@@ -132,9 +138,17 @@ function createChromeMock() {
       launchWebAuthFlow: vi.fn(),
       getRedirectURL: vi.fn(),
     },
+    notifications: {
+      create: vi.fn(),
+      onClicked: {
+        addListener: vi.fn(),
+      },
+    },
     webRequest: {
       onHeadersReceived: {
-        addListener: vi.fn(),
+        addListener: vi.fn((listener: HeadersReceivedListener) => {
+          headersReceivedListener = listener;
+        }),
       },
     },
   };
@@ -186,6 +200,7 @@ describe('extension service worker', () => {
     debuggerEventListeners.length = 0;
     debuggerDetachListeners.length = 0;
     MockWebSocket.instances.length = 0;
+    headersReceivedListener = null;
     vi.clearAllMocks();
     vi.resetModules();
 
@@ -345,6 +360,60 @@ describe('extension service worker', () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it('shows a notification when x-slicc header is received on a known tab', async () => {
+    const chrome = (
+      globalThis as typeof globalThis & { chrome: ReturnType<typeof createChromeMock> }
+    ).chrome;
+    chrome.tabs.get = vi.fn(async () => ({ id: 42, windowId: 1, title: 'Handoff Page' })) as never;
+
+    headersReceivedListener!({
+      url: 'https://www.sliccy.ai/handoff?msg=upskill%3Ahello',
+      tabId: 42,
+      responseHeaders: [{ name: 'x-slicc', value: 'upskill%3Ahello' }],
+    });
+    await flushAsync();
+
+    expect(chrome.notifications.create).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ type: 'basic', message: expect.any(String) })
+    );
+  });
+
+  it('opens the side panel when the handoff notification is clicked', async () => {
+    const chrome = (
+      globalThis as typeof globalThis & { chrome: ReturnType<typeof createChromeMock> }
+    ).chrome;
+    chrome.tabs.get = vi.fn(async () => ({ id: 42, windowId: 7, title: 'Handoff Page' })) as never;
+    chrome.sidePanel.open = vi.fn(async () => undefined) as never;
+
+    // Capture the notifications.onClicked listener
+    let notificationClickListener: ((id: string) => void) | null = null;
+    chrome.notifications.onClicked.addListener = vi.fn((listener: (id: string) => void) => {
+      notificationClickListener = listener;
+    }) as never;
+
+    // Re-load the service worker so it picks up our onClicked mock
+    vi.resetModules();
+    await loadServiceWorker();
+
+    headersReceivedListener!({
+      url: 'https://www.sliccy.ai/handoff?msg=upskill%3Ahello',
+      tabId: 42,
+      responseHeaders: [{ name: 'x-slicc', value: 'upskill%3Ahello' }],
+    });
+    await flushAsync();
+
+    expect(chrome.notifications.create).toHaveBeenCalled();
+    const notificationId = (chrome.notifications.create as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+
+    // Simulate user clicking the notification
+    notificationClickListener!(notificationId);
+    await flushAsync();
+
+    expect(chrome.sidePanel.open).toHaveBeenCalledWith({ windowId: 7 });
   });
 
   it('handles DA sign-and-forward by attaching the IMS bearer token', async () => {

--- a/packages/chrome-extension/tests/service-worker.test.ts
+++ b/packages/chrome-extension/tests/service-worker.test.ts
@@ -440,6 +440,41 @@ describe('extension service worker', () => {
     expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '' });
   });
 
+  it('focuses detached tab on notification click when in detached mode', async () => {
+    const chrome = (
+      globalThis as typeof globalThis & { chrome: ReturnType<typeof createChromeMock> }
+    ).chrome;
+    chrome.tabs.get = vi.fn(async () => ({ id: 42, windowId: 7, title: 'Handoff Page' })) as never;
+    chrome.tabs.update = vi.fn(async () => ({})) as never;
+    chrome.sidePanel.open = vi.fn(async () => undefined) as never;
+    // Simulate detached mode — storage.session returns a stored tab ID
+    chrome.storage.session.get = vi.fn(async () => ({ 'slicc.detached.tabId': 99 })) as never;
+
+    let notificationClickListener: ((id: string) => void) | null = null;
+    chrome.notifications.onClicked.addListener = vi.fn((listener: (id: string) => void) => {
+      notificationClickListener = listener;
+    }) as never;
+
+    vi.resetModules();
+    await loadServiceWorker();
+
+    headersReceivedListener!({
+      url: 'https://www.sliccy.ai/handoff?msg=upskill%3Ahello',
+      tabId: 42,
+      responseHeaders: [{ name: 'x-slicc', value: 'upskill%3Ahello' }],
+    });
+    await flushAsync();
+
+    expect(chrome.notifications.create).toHaveBeenCalled();
+    const notificationId = (chrome.notifications.create as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+
+    notificationClickListener!(notificationId);
+    await flushAsync();
+
+    expect(chrome.tabs.update).toHaveBeenCalledWith(99, { active: true });
+  });
+
   it('handles DA sign-and-forward by attaching the IMS bearer token', async () => {
     let capturedUrl = '';
     let capturedAuth = '';


### PR DESCRIPTION
## Summary

When a main-frame navigation returns the `x-slicc` response header (handoff signal), the extension now shows a system notification and sets a badge (!) on the toolbar icon. Clicking the notification opens the side panel.

Badge Notification:
<img width="147" height="39" alt="image" src="https://github.com/user-attachments/assets/a086d52f-dc81-4daa-bbbd-935fdb40a497" />

Chrome Notification:
<img width="374" height="84" alt="image" src="https://github.com/user-attachments/assets/b8ef7da8-717d-499b-8eb8-f36d960df1af" />


## Why

`chrome.sidePanel.open()` requires a user gesture, it cannot be called from a `webRequest.onHeadersReceived` listener. The previous approach silently failed because Chrome rejected the call without throwing. This replaces it with a notification-based flow where the click event provides the required user gesture.

## Approach / Implementation notes

- showHandoffNotification(windowId) creates a Chrome notification and sets the action badge.
- chrome.notifications.onClicked handler opens the side panel (user gesture context) and clears the badge.
- A Map<notificationId, windowId> tracks which window to target on click.
- Added notifications permission to manifest.json.
- Extended chrome.d.ts with sidePanel.open, notifications, windows.getCurrent, and windowId on ChromeTab

## Cross-cutting impact

- New permission (notifications) — users will see a permission prompt on extension update.
- No changes to offscreen/panel/CLI paths; the navigate-lick dispatch logic is unchanged.
 
## Test plan

- [x] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [x] `npm run typecheck`
- [x] `npm run test` — `<N>` passing, no new failures
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [x] Manual smoke (extension): load unpacked `dist/extension/` + …

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

Low risk. The notification is additive, if it fails for any reason (macOS notifications disabled, SW restart losing state), the user can still click the extension icon directly. Rollback: revert the commit and remove notifications from manifest permissions.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
