### PR TITLE
Improve Sliccstart Electron app state

### DIFF
--- a/packages/swift-launcher/README.md
+++ b/packages/swift-launcher/README.md
@@ -65,6 +65,10 @@ and build the native server: `cd packages/swift-server && swift build`
   Arc, Dia, ChatGPT Atlas, Opera, and Chromium.
 - **Launch Electron app**: Click any Electron app to attach SLICC as a
   side panel overlay. Multiple apps can run simultaneously on separate ports.
+  If the app is already running without a known SLICC debug port, Sliccstart
+  offers to restart it with remote debugging enabled. If a previously launched
+  Electron app exits, Sliccstart clears the stale running state on the next
+  refresh/click so it can be started again.
 - **Get extension**: Opens the Chrome Web Store listing to install the
   SLICC extension directly — no Developer Mode required.
 - **Update**: Pulls latest SLICC changes and rebuilds with one click.

--- a/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
@@ -1,8 +1,60 @@
 import Foundation
 import AppKit
+import Darwin
 import os
 
 private let log = Logger(subsystem: "com.slicc.sliccstart", category: "SliccProcess")
+
+enum AppStartBlocker: Equatable {
+    case needsPermission
+    case needsDebugBuild
+}
+
+enum AppRuntimeState: Equatable {
+    case notRunning
+    case runningWithoutDebug
+    case runningWithDebug(cdpPort: UInt16?)
+    case startFailed(message: String)
+    case cannotStart(AppStartBlocker)
+
+    var isRunning: Bool {
+        switch self {
+        case .runningWithoutDebug, .runningWithDebug:
+            return true
+        case .notRunning, .startFailed, .cannotStart:
+            return false
+        }
+    }
+
+    static func resolve(
+        targetType: AppTargetType,
+        debugSupport: ElectronDebugSupport = .supported,
+        hasAppManagementPermission: Bool = true,
+        debugPort: UInt16? = nil,
+        launchFailure: String? = nil,
+        appIsRunning: Bool = false
+    ) -> AppRuntimeState {
+        if targetType == .electronApp {
+            if !hasAppManagementPermission {
+                return .cannotStart(.needsPermission)
+            }
+            if debugSupport == .disabled {
+                return .cannotStart(.needsDebugBuild)
+            }
+        }
+
+        if debugPort != nil {
+            return .runningWithDebug(cdpPort: debugPort)
+        }
+        if targetType == .electronApp && appIsRunning {
+            return .runningWithoutDebug
+        }
+        if let launchFailure {
+            return .startFailed(message: launchFailure)
+        }
+        return .notRunning
+    }
+}
 
 @Observable
 final class SliccProcess {
@@ -12,11 +64,19 @@ final class SliccProcess {
         let logLabel: String
     }
 
-    /// All running instances keyed by AppTarget.id
-    private var processes: [String: Process] = [:]
-    /// App paths launched via --electron, keyed by AppTarget.id
-    private var launchedAppPaths: [String: String] = [:]
-    private(set) var runningTargets: Set<String> = []
+    private struct LaunchRecord {
+        let process: Process
+        let targetType: AppTargetType
+        let launchedAppPaths: [String]
+        let cdpPort: UInt16
+        let startedAt: Date
+        var observedAppPID: pid_t?
+    }
+
+    /// SLICC helper/server processes keyed by AppTarget.id.
+    private var launchRecords: [String: LaunchRecord] = [:]
+    private var startFailures: [String: String] = [:]
+    private var intentionallyStoppingTargets: Set<String> = []
 
     var resolvedSliccDir: String { sliccDir }
     private var sliccDir: String {
@@ -51,47 +111,98 @@ final class SliccProcess {
     private static let browserCdpPort: UInt16 = 9222
     private static let electronBasePort: UInt16 = 5711
     private static let electronBaseCdpPort: UInt16 = 9223
+    private static let electronLaunchStaleTimeout: TimeInterval = 30
 
     func isRunning(_ target: AppTarget) -> Bool {
-        runningTargets.contains(target.id)
+        runtimeState(for: target).isRunning
+    }
+
+    func runtimeState(
+        for target: AppTarget,
+        hasAppManagementPermission: Bool = true
+    ) -> AppRuntimeState {
+        let debugPort = activeDebugPort(for: target)
+        let appIsRunning = target.type == .electronApp && isElectronAppRunning(target)
+        return AppRuntimeState.resolve(
+            targetType: target.type,
+            debugSupport: target.debugSupport,
+            hasAppManagementPermission: hasAppManagementPermission,
+            debugPort: debugPort,
+            launchFailure: startFailures[target.id],
+            appIsRunning: appIsRunning
+        )
+    }
+
+    func refreshRuntimeStates(for targets: [AppTarget]) {
+        for target in targets {
+            refreshRuntimeState(for: target)
+        }
     }
 
     // MARK: - Browser mode
 
     func launchStandalone(_ browser: AppTarget) throws {
+        refreshRuntimeState(for: browser)
         if isRunning(browser) {
             log.info("launchStandalone: \(browser.name) already running")
             return
         }
+        startFailures.removeValue(forKey: browser.id)
         guard !Self.isPortInUse(Self.browserPort) else { throw LaunchError.portInUse(Self.browserPort) }
         log.info("launchStandalone: \(browser.name, privacy: .public) on port \(Self.browserPort)")
-        try spawn(target: browser, extraArgs: ["--cdp-port=\(Self.browserCdpPort)"], env: [
-            "CHROME_PATH": browser.executablePath,
-            "PORT": "\(Self.browserPort)",
-        ])
+        do {
+            try spawn(
+                target: browser,
+                extraArgs: ["--cdp-port=\(Self.browserCdpPort)"],
+                env: [
+                    "CHROME_PATH": browser.executablePath,
+                    "PORT": "\(Self.browserPort)",
+                ],
+                cdpPort: Self.browserCdpPort
+            )
+        } catch {
+            recordStartFailure(for: browser, message: error.localizedDescription)
+            throw error
+        }
     }
 
     // MARK: - Electron mode (each app gets its own port)
 
-    func launchWithElectronApp(_ app: AppTarget) throws {
+    func launchWithElectronApp(_ app: AppTarget, forceRestartExistingApp: Bool = false) throws {
+        refreshRuntimeState(for: app)
         if isRunning(app) {
-            log.info("launchWithElectronApp: \(app.name) already running")
-            return
+            if case .runningWithDebug = runtimeState(for: app) {
+                log.info("launchWithElectronApp: \(app.name) already running with SLICC")
+                return
+            }
         }
+        if forceRestartExistingApp {
+            terminateElectronApplications(atAppPaths: Self.relatedAppPaths(for: app))
+        }
+        startFailures.removeValue(forKey: app.id)
         let (port, cdpPort) = nextElectronPorts()
         guard !Self.isPortInUse(port) else { throw LaunchError.portInUse(port) }
         log.info("launchWithElectronApp: \(app.name, privacy: .public) on port \(port), cdp \(cdpPort)")
-        launchedAppPaths[app.id] = app.path
-        try spawn(target: app, extraArgs: [
-            "--electron-app=\(app.path)",
-            "--kill",
-            "--cdp-port=\(cdpPort)",
-        ], env: ["PORT": "\(port)"])
+        do {
+            try spawn(
+                target: app,
+                extraArgs: [
+                    "--electron-app=\(app.path)",
+                    "--kill",
+                    "--cdp-port=\(cdpPort)",
+                ],
+                env: ["PORT": "\(port)"],
+                cdpPort: cdpPort
+            )
+        } catch {
+            recordStartFailure(for: app, message: error.localizedDescription)
+            throw error
+        }
     }
 
     /// Find the next available port pair for an Electron app.
     private func nextElectronPorts() -> (port: UInt16, cdpPort: UInt16) {
-        let electronCount = UInt16(processes.count) // offset from base
+        let electronCount = UInt16(launchRecords.count) // offset from base
         for i: UInt16 in 0...20 {
             let port = Self.electronBasePort + electronCount + i
             let cdpPort = Self.electronBaseCdpPort + electronCount + i
@@ -123,31 +234,16 @@ final class SliccProcess {
 
     func stop(_ target: AppTarget) {
         log.info("stop: \(target.name)")
-        processes[target.id]?.terminate()
-        processes.removeValue(forKey: target.id)
-        terminateLaunchedApp(id: target.id)
-        runningTargets.remove(target.id)
+        stopLaunchRecord(id: target.id, terminateApps: true)
+        startFailures.removeValue(forKey: target.id)
     }
 
     func stopAll() {
-        log.info("stopAll: terminating \(self.processes.count) processes")
-        for (_, proc) in processes { proc.terminate() }
-        processes.removeAll()
-        for (id, _) in launchedAppPaths {
-            terminateLaunchedApp(id: id)
+        log.info("stopAll: terminating \(self.launchRecords.count) processes")
+        for id in Array(launchRecords.keys) {
+            stopLaunchRecord(id: id, terminateApps: true)
         }
-        runningTargets.removeAll()
-    }
-
-    /// Terminate a launched Electron/WebView2 app by its bundle path.
-    private func terminateLaunchedApp(id: String) {
-        guard let appPath = launchedAppPaths.removeValue(forKey: id) else { return }
-        let appURL = URL(fileURLWithPath: appPath)
-        let running = NSWorkspace.shared.runningApplications.filter { $0.bundleURL == appURL }
-        for app in running {
-            log.info("terminating app: \(app.localizedName ?? appPath, privacy: .public)")
-            app.terminate()
-        }
+        startFailures.removeAll()
     }
 
     // MARK: - Private
@@ -172,7 +268,12 @@ final class SliccProcess {
         throw LaunchError.serverBinaryNotFound
     }
 
-    private func spawn(target: AppTarget, extraArgs: [String], env: [String: String]) throws {
+    private func spawn(
+        target: AppTarget,
+        extraArgs: [String],
+        env: [String: String],
+        cdpPort: UInt16
+    ) throws {
         let launchConfig = try Self.resolveLaunchConfiguration(sliccDir: sliccDir, extraArgs: extraArgs)
         log.info("spawn: \(launchConfig.executablePath, privacy: .public) \(launchConfig.arguments.joined(separator: " "), privacy: .public)")
         log.info("spawn: cwd = \(self.sliccDir, privacy: .public)")
@@ -210,14 +311,160 @@ final class SliccProcess {
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
             DispatchQueue.main.async {
-                self?.processes.removeValue(forKey: target.id)
-                self?.runningTargets.remove(target.id)
+                guard let self else { return }
+                let wasIntentional = self.intentionallyStoppingTargets.remove(target.id) != nil
+                let isCurrentRecord = self.launchRecords[target.id]?.process === p
+                if isCurrentRecord {
+                    self.launchRecords.removeValue(forKey: target.id)
+                }
+                if !wasIntentional && p.terminationStatus != 0 && isCurrentRecord {
+                    self.recordStartFailure(
+                        for: target,
+                        message: "SLICC exited with code \(p.terminationStatus)."
+                    )
+                }
             }
         }
         try proc.run()
         log.info("spawn: pid=\(proc.processIdentifier) for \(target.name, privacy: .public)")
-        processes[target.id] = proc
-        runningTargets.insert(target.id)
+        launchRecords[target.id] = LaunchRecord(
+            process: proc,
+            targetType: target.type,
+            launchedAppPaths: target.type == .electronApp ? Self.launchedAppPaths(for: target) : [],
+            cdpPort: cdpPort,
+            startedAt: Date(),
+            observedAppPID: nil
+        )
+    }
+
+    private func refreshRuntimeState(for target: AppTarget) {
+        guard var record = launchRecords[target.id] else { return }
+        guard record.process.isRunning else {
+            launchRecords.removeValue(forKey: target.id)
+            return
+        }
+
+        guard record.targetType == .electronApp else {
+            return
+        }
+
+        let runningApps = runningElectronApplications(for: target)
+        if let app = runningApps.first {
+            record.observedAppPID = app.processIdentifier
+            launchRecords[target.id] = record
+            return
+        }
+
+        guard let observedAppPID = record.observedAppPID else {
+            if Date().timeIntervalSince(record.startedAt) > Self.electronLaunchStaleTimeout,
+               !Self.isPortInUse(record.cdpPort) {
+                log.info("refreshRuntimeState: \(target.name, privacy: .public) has no app pid or CDP listener; stopping stale helper")
+                stopLaunchRecord(id: target.id, terminateApps: false)
+                return
+            }
+            return
+        }
+
+        if !Self.isPIDRunning(observedAppPID) {
+            log.info("refreshRuntimeState: \(target.name, privacy: .public) app pid \(observedAppPID) exited; stopping helper")
+            stopLaunchRecord(id: target.id, terminateApps: false)
+        }
+    }
+
+    private func activeDebugPort(for target: AppTarget) -> UInt16? {
+        guard let record = launchRecords[target.id], record.process.isRunning else {
+            return nil
+        }
+        if record.targetType == .electronApp,
+           !Self.isPortInUse(record.cdpPort) {
+            return nil
+        }
+        if record.targetType == .electronApp,
+           let observedAppPID = record.observedAppPID,
+           !Self.isPIDRunning(observedAppPID),
+           !isElectronAppRunning(target) {
+            return nil
+        }
+        return record.cdpPort
+    }
+
+    private func stopLaunchRecord(id: String, terminateApps: Bool) {
+        guard let record = launchRecords.removeValue(forKey: id) else {
+            intentionallyStoppingTargets.remove(id)
+            return
+        }
+
+        intentionallyStoppingTargets.insert(id)
+        if terminateApps {
+            terminateElectronApplications(atAppPaths: record.launchedAppPaths)
+        }
+        if record.process.isRunning {
+            record.process.terminate()
+        } else {
+            intentionallyStoppingTargets.remove(id)
+        }
+    }
+
+    private func recordStartFailure(for target: AppTarget, message: String) {
+        startFailures[target.id] = message
+    }
+
+    private func isElectronAppRunning(_ target: AppTarget) -> Bool {
+        !runningElectronApplications(for: target).isEmpty
+    }
+
+    private func runningElectronApplications(for target: AppTarget) -> [NSRunningApplication] {
+        Self.runningElectronApplications(atAppPaths: Self.relatedAppPaths(for: target))
+    }
+
+    private func terminateElectronApplications(atAppPaths appPaths: [String]) {
+        for app in Self.runningElectronApplications(atAppPaths: appPaths) {
+            log.info("terminating app: \(app.localizedName ?? app.bundleURL?.path ?? "unknown", privacy: .public)")
+            app.terminate()
+        }
+    }
+
+    static func launchedAppPaths(for target: AppTarget) -> [String] {
+        [target.path]
+    }
+
+    static func relatedAppPaths(for target: AppTarget) -> [String] {
+        var paths = [target.path]
+        if let originalAppPath = target.originalAppPath, originalAppPath != target.path {
+            paths.append(originalAppPath)
+        }
+        return paths
+    }
+
+    private static func runningElectronApplications(atAppPaths appPaths: [String]) -> [NSRunningApplication] {
+        let appURLs = Set(appPaths.map { standardizedFileURL(path: $0) })
+        return NSWorkspace.shared.runningApplications.filter { app in
+            guard !app.isTerminated else { return false }
+            if let bundleURL = app.bundleURL.map({ standardizedFileURL(path: $0.path) }),
+               appURLs.contains(bundleURL) {
+                return true
+            }
+            if let executableURL = app.executableURL?.standardizedFileURL.resolvingSymlinksInPath() {
+                return appURLs.contains { appURL in
+                    executableURL.path.hasPrefix(appURL.appendingPathComponent("Contents/MacOS").path)
+                }
+            }
+            return false
+        }
+    }
+
+    private static func standardizedFileURL(path: String) -> URL {
+        URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+    }
+
+    private static func isPIDRunning(_ pid: pid_t) -> Bool {
+        guard pid > 0 else { return false }
+        if kill(pid, 0) == 0 {
+            return true
+        }
+        return errno == EPERM
     }
 
     private static func isPortInUse(_ port: UInt16) -> Bool {

--- a/packages/swift-launcher/Sliccstart/SliccstartApp.swift
+++ b/packages/swift-launcher/Sliccstart/SliccstartApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import Combine
 import os
 import AppUpdater
 
@@ -27,9 +28,12 @@ struct SliccstartApp: App {
     @State private var showAlert = false
     @State private var showDebugBuildDialog = false
     @State private var debugBuildTarget: AppTarget?
+    @State private var showElectronRestartDialog = false
+    @State private var electronRestartTarget: AppTarget?
     @State private var isCreatingDebugBuild = false
     @State private var debugBuildProgress: String = ""
     @StateObject private var appUpdater = AppUpdater(owner: "ai-ecoverse", repo: "slicc", releasePrefix: "Sliccstart", provider: TolerantGithubReleaseProvider())
+    private let runtimeRefreshTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
 
     init() {
         NSApplication.shared.setActivationPolicy(.regular)
@@ -72,12 +76,7 @@ struct SliccstartApp: App {
                         },
                         onLaunchElectron: { target in
                             log.info("onLaunchElectron: \(target.name, privacy: .public)")
-                            do {
-                                try sliccProcess.launchWithElectronApp(target)
-                            } catch {
-                                log.error("onLaunchElectron failed: \(error.localizedDescription, privacy: .public)")
-                                showError(error.localizedDescription)
-                            }
+                            handleElectronLaunch(target)
                         },
                         onCreateDebugBuild: { target in
                             debugBuildTarget = target
@@ -104,6 +103,10 @@ struct SliccstartApp: App {
             .task { await initialize() }
             .onAppear { appManagementPermission.startWatchingForGrant() }
             .onDisappear { appManagementPermission.stopWatchingForGrant() }
+            .onReceive(runtimeRefreshTimer) { _ in
+                guard isReady else { return }
+                sliccProcess.refreshRuntimeStates(for: targets)
+            }
             .onChange(of: appManagementPermission.isGranted) {
                 // Re-scan when permission is granted so Electron apps appear
                 if isReady {
@@ -129,6 +132,21 @@ struct SliccstartApp: App {
             } message: {
                 if let target = debugBuildTarget {
                     Text("\(target.name) has remote debugging disabled.\n\nCreate a debug build in ~/Applications that enables SLICC to connect?\n\nThis will:\n• Copy the app to ~/Applications/\(target.name) Debug.app\n• Patch Electron fuses\n• Bypass CDP auth checks\n• Ad-hoc sign the result")
+                }
+            }
+            .alert("Restart App for SLICC?", isPresented: $showElectronRestartDialog) {
+                Button("Cancel", role: .cancel) {
+                    electronRestartTarget = nil
+                }
+                Button("Restart") {
+                    if let target = electronRestartTarget {
+                        launchElectron(target, forceRestartExistingApp: true)
+                    }
+                    electronRestartTarget = nil
+                }
+            } message: {
+                if let target = electronRestartTarget {
+                    Text("\(target.name) is already running without a known SLICC debug port.\n\nSliccstart can quit and reopen it with remote debugging enabled.")
                 }
             }
         }
@@ -208,6 +226,41 @@ struct SliccstartApp: App {
 
         isCreatingDebugBuild = false
         debugBuildTarget = nil
+    }
+
+    private func handleElectronLaunch(_ target: AppTarget) {
+        sliccProcess.refreshRuntimeStates(for: [target])
+        let state = sliccProcess.runtimeState(
+            for: target,
+            hasAppManagementPermission: appManagementPermission.isGranted
+        )
+
+        switch state {
+        case .runningWithDebug:
+            return
+        case .runningWithoutDebug:
+            electronRestartTarget = target
+            showElectronRestartDialog = true
+        case .cannotStart(.needsDebugBuild):
+            debugBuildTarget = target
+            showDebugBuildDialog = true
+        case .cannotStart(.needsPermission):
+            appManagementPermission.openSystemSettings()
+        case .notRunning, .startFailed:
+            launchElectron(target)
+        }
+    }
+
+    private func launchElectron(_ target: AppTarget, forceRestartExistingApp: Bool = false) {
+        do {
+            try sliccProcess.launchWithElectronApp(
+                target,
+                forceRestartExistingApp: forceRestartExistingApp
+            )
+        } catch {
+            log.error("onLaunchElectron failed: \(error.localizedDescription, privacy: .public)")
+            showError(error.localizedDescription)
+        }
     }
 
     private func showError(_ message: String) {

--- a/packages/swift-launcher/Sliccstart/Views/AppListView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/AppListView.swift
@@ -22,8 +22,7 @@ struct AppListView: View {
                 ForEach(browsers) { target in
                     AppRow(
                         target: target,
-                        isRunning: sliccProcess.isRunning(target),
-                        statusDot: .running,
+                        runtimeState: sliccProcess.runtimeState(for: target),
                         onLaunch: { onLaunchStandalone(target) },
                         onCreateDebugBuild: nil
                     )
@@ -33,26 +32,21 @@ struct AppListView: View {
             if !electronApps.isEmpty {
                 SectionHeader("Desktop Apps")
                 ForEach(electronApps) { target in
-                    let statusDot: AppRowStatusDot = {
-                        if target.debugSupport == .disabled {
-                            return .needsDebugBuild
-                        } else if !appManagementPermission.isGranted {
-                            return .needsPermission
-                        }
-                        return .running
-                    }()
+                    let runtimeState = sliccProcess.runtimeState(
+                        for: target,
+                        hasAppManagementPermission: appManagementPermission.isGranted
+                    )
 
                     AppRow(
                         target: target,
-                        isRunning: sliccProcess.isRunning(target),
-                        statusDot: statusDot,
+                        runtimeState: runtimeState,
                         onLaunch: {
-                            if target.debugSupport == .disabled {
+                            if runtimeState == .cannotStart(.needsDebugBuild) {
                                 onCreateDebugBuild(target)
-                            } else if appManagementPermission.isGranted {
-                                onLaunchElectron(target)
-                            } else {
+                            } else if runtimeState == .cannotStart(.needsPermission) {
                                 appManagementPermission.openSystemSettings()
+                            } else {
+                                onLaunchElectron(target)
                             }
                         },
                         onCreateDebugBuild: target.debugSupport == .disabled ? { onCreateDebugBuild(target) } : nil
@@ -141,15 +135,16 @@ struct SectionHeader: View {
 }
 
 enum AppRowStatusDot {
-    case running
+    case runningWithDebug
+    case runningWithoutDebug
     case needsPermission
     case needsDebugBuild
+    case failed
 }
 
 struct AppRow: View {
     let target: AppTarget
-    let isRunning: Bool
-    let statusDot: AppRowStatusDot
+    let runtimeState: AppRuntimeState
     let onLaunch: () -> Void
     let onCreateDebugBuild: (() -> Void)?
 
@@ -171,21 +166,16 @@ struct AppRow: View {
                 VStack(alignment: .leading, spacing: 1) {
                     Text(target.name)
                         .font(.system(size: 13))
-                    if target.isDebugBuild {
-                        Text("Debug Build")
+                    if let subtitle {
+                        Text(subtitle)
                             .font(.system(size: 9))
                             .foregroundStyle(.secondary)
                     }
                 }
                 Spacer()
-                if isRunning {
-                    Circle().fill(.green).frame(width: 7, height: 7)
-                } else if statusDot == .needsDebugBuild {
-                    Circle().fill(.red).frame(width: 7, height: 7)
-                        .help("Remote debugging disabled. Click to create a debug build.")
-                } else if statusDot == .needsPermission {
-                    Circle().fill(.yellow).frame(width: 7, height: 7)
-                        .help("App Management permission required. Click to open System Settings.")
+                if let dot = statusDot {
+                    Circle().fill(dot.color).frame(width: 7, height: 7)
+                        .help(dot.help)
                 }
             }
             .padding(.horizontal, 12)
@@ -199,6 +189,71 @@ struct AppRow: View {
             } else {
                 NSCursor.pop()
             }
+        }
+    }
+
+    private var statusDot: AppRowStatusDot? {
+        switch runtimeState {
+        case .notRunning:
+            return nil
+        case .runningWithoutDebug:
+            return .runningWithoutDebug
+        case .runningWithDebug:
+            return .runningWithDebug
+        case .startFailed:
+            return .failed
+        case .cannotStart(.needsDebugBuild):
+            return .needsDebugBuild
+        case .cannotStart(.needsPermission):
+            return .needsPermission
+        }
+    }
+
+    private var subtitle: String? {
+        switch runtimeState {
+        case .notRunning:
+            return target.isDebugBuild ? "Debug Build" : nil
+        case .runningWithoutDebug:
+            return "Running without SLICC"
+        case .runningWithDebug(let cdpPort):
+            if let cdpPort {
+                return "Running with SLICC on \(cdpPort)"
+            }
+            return "Running with SLICC"
+        case .startFailed:
+            return "Start failed"
+        case .cannotStart(.needsDebugBuild):
+            return "Needs Debug Build"
+        case .cannotStart(.needsPermission):
+            return "Needs Permission"
+        }
+    }
+}
+
+private extension AppRowStatusDot {
+    var color: Color {
+        switch self {
+        case .runningWithDebug:
+            return .green
+        case .runningWithoutDebug, .needsPermission:
+            return .yellow
+        case .needsDebugBuild, .failed:
+            return .red
+        }
+    }
+
+    var help: String {
+        switch self {
+        case .runningWithDebug:
+            return "Running with SLICC."
+        case .runningWithoutDebug:
+            return "Running without a known SLICC debug port. Click to restart."
+        case .needsDebugBuild:
+            return "Remote debugging disabled. Click to create a debug build."
+        case .needsPermission:
+            return "App Management permission required. Click to open System Settings."
+        case .failed:
+            return "The last start attempt failed. Click to retry."
         }
     }
 }

--- a/packages/swift-launcher/SliccstartTests/AppRuntimeStateTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppRuntimeStateTests.swift
@@ -1,0 +1,106 @@
+import AppKit
+import XCTest
+@testable import Sliccstart
+
+final class AppRuntimeStateTests: XCTestCase {
+    func testElectronAppDefaultsToNotRunning() {
+        XCTAssertEqual(
+            AppRuntimeState.resolve(targetType: .electronApp),
+            .notRunning
+        )
+    }
+
+    func testElectronAppRunningWithoutKnownDebugPortOffersRestartState() {
+        XCTAssertEqual(
+            AppRuntimeState.resolve(
+                targetType: .electronApp,
+                appIsRunning: true
+            ),
+            .runningWithoutDebug
+        )
+    }
+
+    func testKnownDebugPortWinsOverExternalRunningState() {
+        XCTAssertEqual(
+            AppRuntimeState.resolve(
+                targetType: .electronApp,
+                debugPort: 9227,
+                appIsRunning: true
+            ),
+            .runningWithDebug(cdpPort: 9227)
+        )
+    }
+
+    func testStartFailureIsShownWhenAppIsNotRunning() {
+        XCTAssertEqual(
+            AppRuntimeState.resolve(
+                targetType: .electronApp,
+                launchFailure: "SLICC exited with code 1."
+            ),
+            .startFailed(message: "SLICC exited with code 1.")
+        )
+    }
+
+    func testRunningAppSupersedesPreviousStartFailure() {
+        XCTAssertEqual(
+            AppRuntimeState.resolve(
+                targetType: .electronApp,
+                launchFailure: "SLICC exited with code 1.",
+                appIsRunning: true
+            ),
+            .runningWithoutDebug
+        )
+    }
+
+    func testCannotStartWhenPermissionIsMissing() {
+        XCTAssertEqual(
+            AppRuntimeState.resolve(
+                targetType: .electronApp,
+                hasAppManagementPermission: false,
+                appIsRunning: true
+            ),
+            .cannotStart(.needsPermission)
+        )
+    }
+
+    func testCannotStartWhenDebugBuildIsRequired() {
+        XCTAssertEqual(
+            AppRuntimeState.resolve(
+                targetType: .electronApp,
+                debugSupport: .disabled,
+                appIsRunning: true
+            ),
+            .cannotStart(.needsDebugBuild)
+        )
+    }
+
+    func testDebugBuildLaunchRecordOnlyTerminatesDebugCopy() {
+        let target = makeElectronTarget(
+            path: "/Users/test/Applications/Slack Debug.app",
+            originalAppPath: "/Applications/Slack.app"
+        )
+
+        XCTAssertEqual(
+            SliccProcess.launchedAppPaths(for: target),
+            ["/Users/test/Applications/Slack Debug.app"]
+        )
+        XCTAssertEqual(
+            SliccProcess.relatedAppPaths(for: target),
+            ["/Users/test/Applications/Slack Debug.app", "/Applications/Slack.app"]
+        )
+    }
+
+    private func makeElectronTarget(path: String, originalAppPath: String?) -> AppTarget {
+        AppTarget(
+            id: path,
+            name: "Slack",
+            path: path,
+            executablePath: "\(path)/Contents/MacOS/Slack",
+            type: .electronApp,
+            icon: NSImage(size: NSSize(width: 1, height: 1)),
+            debugSupport: .supported,
+            isDebugBuild: originalAppPath != nil,
+            originalAppPath: originalAppPath
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit Sliccstart runtime states for Electron apps: not running, running without debug, running with debug, failed, and cannot start
- track observed Electron app PIDs and refresh state so stale helper sessions are cleared after the app exits
- prompt to restart apps that are already running without a known SLICC debug port
- update launcher row state text/dots, README docs, and runtime-state tests
- address review feedback by gating Electron debug state on an active CDP port, removing redundant running state, and only terminating the debug app copy that Sliccstart launched

## Verification
- `swift build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` (46 tests passed)
- `npx prettier --check packages/swift-launcher/README.md`
- `git diff --check`

Note: commit was created with GPG signing disabled for this command because the configured signing key is not available in this worktree.