### PR TITLE
fix(ci): query merge-queue state via GraphQL in cleanup workflow

### DIFF
--- a/.github/workflows/planning-artifact-cleanup.yml
+++ b/.github/workflows/planning-artifact-cleanup.yml
@@ -78,11 +78,25 @@ jobs:
         # mergeable (CI green) and then explicitly enqueue via the
         # `enqueuePullRequest` GraphQL mutation, which is what the
         # "Merge when ready" button calls.
+        #
+        # NOTE: `gh pr view --json isInMergeQueue` is not supported by the
+        # gh CLI shipped on ubuntu-latest runners — the field is missing
+        # from its known set and the command exits non-zero. Query the
+        # GraphQL API directly instead so this step does not regress with
+        # CLI version drift.
         run: |
           set -euo pipefail
           PR_ID=$(gh pr view "$PR_URL" --json id --jq '.id')
 
-          already_queued=$(gh pr view "$PR_URL" --json isInMergeQueue --jq '.isInMergeQueue')
+          pr_state() {
+            gh api graphql \
+              -f query='query($id:ID!){ node(id:$id){ ... on PullRequest { mergeable mergeStateStatus isInMergeQueue } } }' \
+              -F id="$PR_ID" \
+              --jq '"\(.data.node.mergeable)|\(.data.node.mergeStateStatus)|\(.data.node.isInMergeQueue)"'
+          }
+
+          initial=$(pr_state)
+          already_queued=${initial##*|}
           if [ "$already_queued" = "true" ]; then
             echo "PR already in merge queue; nothing to do."
             exit 0
@@ -91,9 +105,7 @@ jobs:
           attempts=60
           sleep_seconds=30
           for i in $(seq 1 "$attempts"); do
-            state=$(gh pr view "$PR_URL" \
-              --json mergeable,mergeStateStatus,isInMergeQueue \
-              --jq '"\(.mergeable)|\(.mergeStateStatus)|\(.isInMergeQueue)"')
+            state=$(pr_state)
             mergeable=${state%%|*}
             rest=${state#*|}
             merge_state=${rest%%|*}

--- a/docs/superpowers/specs/2026-05-19-planning-artifact-cleanup-graphql.md
+++ b/docs/superpowers/specs/2026-05-19-planning-artifact-cleanup-graphql.md
@@ -1,0 +1,60 @@
+# Planning Artifact Cleanup — GraphQL merge-queue probe
+
+**Status:** Proposed
+**Date:** 2026-05-19
+**Branch:** `fix/planning-artifact-cleanup-graphql`
+
+## 1. Why
+
+The `planning-artifact-cleanup` workflow opens a follow-up PR after each
+landing on `main` and is supposed to enqueue that PR into the merge queue
+without human intervention. In practice the `Add cleanup PR to merge
+queue` step has been failing on every push that actually produces a
+cleanup branch — leaving the bot PR to be added to the queue by hand.
+
+The failure is reproducible in CI logs (e.g. run `26102979698` for PR
+#684): the very first probe `gh pr view "$PR_URL" --json isInMergeQueue`
+exits non-zero with
+
+```
+Unknown JSON field: "isInMergeQueue"
+```
+
+The `gh` CLI shipped on `ubuntu-latest` does not expose
+`isInMergeQueue` as a `--json` field on `pr view`. With
+`set -euo pipefail`, the step terminates before the polling loop or the
+`enqueuePullRequest` GraphQL mutation can run.
+
+## 2. Fix
+
+Replace both `gh pr view --json ...,isInMergeQueue ...` invocations with
+a direct GraphQL query that selects the same three fields. The GraphQL
+schema has always exposed `isInMergeQueue`, so this side-steps CLI
+version drift entirely.
+
+```bash
+pr_state() {
+  gh api graphql \
+    -f query='query($id:ID!){ node(id:$id){ ... on PullRequest { mergeable mergeStateStatus isInMergeQueue } } }' \
+    -F id="$PR_ID" \
+    --jq '"\(.data.node.mergeable)|\(.data.node.mergeStateStatus)|\(.data.node.isInMergeQueue)"'
+}
+```
+
+The composite `mergeable|mergeStateStatus|isInMergeQueue` string format
+is preserved so the surrounding shell parsing stays identical.
+
+## 3. Why a planning artifact
+
+This document exists solely so that landing this PR demonstrably exercises
+the cleanup workflow end-to-end: after merge, the bot must detect this
+file under `docs/superpowers/`, open a follow-up cleanup PR removing it,
+poll the GraphQL query introduced by this fix, and enqueue itself into
+the merge queue without a human pressing "Merge when ready". If the
+follow-up PR lands automatically, the fix is verified in production.
+
+## 4. Out of scope
+
+- Changes to the `Remove tracked planning artifacts` step itself.
+- Restructuring of `docs/superpowers/` or `.superpowers/` layout.
+- Any change to the merge-queue configuration or branch protection rules.


### PR DESCRIPTION
## Why

The `planning-artifact-cleanup` workflow's "Add cleanup PR to merge queue" step has been failing on every push that actually produces a cleanup branch, leaving the bot PR for a human to enqueue. Example: [run 26102979698](https://github.com/ai-ecoverse/slicc/actions/runs/26102979698) for #684 failed with:

```
Unknown JSON field: "isInMergeQueue"
```

`gh pr view --json isInMergeQueue` is rejected by the `gh` CLI shipped on `ubuntu-latest` — the field is not in its known set. With `set -euo pipefail`, the step terminates before the polling loop or the `enqueuePullRequest` mutation can run.

## What

Replace both `gh pr view --json mergeable,mergeStateStatus,isInMergeQueue` probes with a single `gh api graphql` query against the PR node. GraphQL has always exposed `isInMergeQueue`, so this side-steps CLI version drift. The composite `mergeable|mergeStateStatus|isInMergeQueue` parsing format is preserved unchanged.

## Verification

This PR intentionally ships a planning artifact at `docs/superpowers/specs/2026-05-19-planning-artifact-cleanup-graphql.md`. After this PR lands, the cleanup workflow must:

1. Detect the artifact and `git rm` it.
2. Open a follow-up cleanup PR.
3. Poll PR state via the new GraphQL query.
4. Self-enqueue into the merge queue without a human pressing "Merge when ready".

If the follow-up cleanup PR lands automatically, the fix is verified end-to-end in production.