### PR TITLE
fix(ci): kick pull_request checks on newly created cleanup PR

### DIFF
--- a/.github/workflows/planning-artifact-cleanup.yml
+++ b/.github/workflows/planning-artifact-cleanup.yml
@@ -65,8 +65,32 @@ jobs:
               --head "$CLEANUP_BRANCH" \
               --title "chore: remove planning artifacts from main" \
               --body "Automated follow-up after a merge-queue landing to remove planning artifacts that should stay visible in the original PR but not remain on \`main\`. The cleanup branch is pushed with the repo deploy key so the normal CI workflow still runs before this PR is re-queued.")
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "created=false" >> "$GITHUB_OUTPUT"
           fi
           echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Kick required pull_request checks
+        if: steps.cleanup.outputs.has_changes == 'true' && steps.pr.outputs.created == 'true'
+        env:
+          CLEANUP_BRANCH: automation/planning-artifact-cleanup
+        # `gh pr create` above authenticates with GITHUB_TOKEN. GitHub's
+        # anti-recursion safeguard suppresses every workflow run that a
+        # `pull_request` event would otherwise trigger when the PR is
+        # opened by GITHUB_TOKEN, so required checks like CodeQL never
+        # run and the merge queue parks the PR in AWAITING_CHECKS forever.
+        #
+        # Push an empty commit using the deploy-key-authenticated remote
+        # so `pull_request: synchronize` fires under a real identity and
+        # all required workflows run on the cleanup PR. On subsequent
+        # workflow runs the PR already exists and the force-push of the
+        # cleanup commit itself fires synchronize, so this step is only
+        # needed on first creation.
+        run: |
+          set -euo pipefail
+          git commit --allow-empty -m "chore(ci): trigger required pull_request checks"
+          git push origin "HEAD:$CLEANUP_BRANCH"
 
       - name: Add cleanup PR to merge queue
         if: steps.cleanup.outputs.has_changes == 'true'


### PR DESCRIPTION
## Why

Follow-up to #688. After that fix landed, PR #689 still parked in the merge queue for 22 minutes in `AWAITING_CHECKS` until I manually intervened.

Root cause: `gh pr create` in this workflow runs under `GITHUB_TOKEN`. GitHub's [anti-recursion safeguard](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) suppresses every workflow run that a `pull_request` event would trigger when the PR is opened by `GITHUB_TOKEN`. CodeQL ("Code Quality: PR #N") is a required status check that only listens to `pull_request`, so it never runs on the cleanup PR and the merge queue refuses to dequeue.

PR #684 only landed in the past by accident: a later push to `main` re-ran the cleanup workflow, which force-pushed the cleanup branch via the deploy key and fired `pull_request: synchronize` under a real identity, unblocking CodeQL. If nothing else lands on `main` between two cleanup workflow runs, the cleanup PR is stuck forever.

## What

After `gh pr create` succeeds, push an empty commit through the deploy-key-authenticated remote configured by `actions/checkout` so `pull_request: synchronize` fires under a real identity and required workflows run. Gated on `created == 'true'` so we only do this on initial creation; subsequent workflow runs already force-push real cleanup commits via the deploy key.

## Verification

The next cleanup PR opened by this workflow should enter the merge queue and dequeue without a human poke. Trivially testable by landing this PR with an intentional planning artifact — same protocol as #688.