### PR TITLE
refactor(ci): use BOT_PAT for cleanup PR open + auto-merge

### DIFF
--- a/.github/workflows/planning-artifact-cleanup.yml
+++ b/.github/workflows/planning-artifact-cleanup.yml
@@ -49,7 +49,14 @@ jobs:
         if: steps.cleanup.outputs.has_changes == 'true'
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          # BOT_PAT is a fine-grained PAT scoped to this repo with contents
+          # and pull-requests write. Using a non-GITHUB_TOKEN identity here
+          # is load-bearing: when GITHUB_TOKEN opens a PR or enqueues it,
+          # the resulting `pull_request` and `merge_group` events do not
+          # trigger workflow runs (GitHub anti-recursion safeguard), so
+          # CI never reports against the cleanup PR or its merge-queue
+          # ref and the queue parks in AWAITING_CHECKS indefinitely.
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
           CLEANUP_BRANCH: automation/planning-artifact-cleanup
         run: |
           set -euo pipefail
@@ -64,114 +71,20 @@ jobs:
               --base main \
               --head "$CLEANUP_BRANCH" \
               --title "chore: remove planning artifacts from main" \
-              --body "Automated follow-up after a merge-queue landing to remove planning artifacts that should stay visible in the original PR but not remain on \`main\`. The cleanup branch is pushed with the repo deploy key so the normal CI workflow still runs before this PR is re-queued.")
-            echo "created=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "created=false" >> "$GITHUB_OUTPUT"
+              --body "Automated follow-up after a merge-queue landing to remove planning artifacts that should stay visible in the original PR but not remain on \`main\`.")
           fi
           echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
 
-      - name: Kick required pull_request checks
-        if: steps.cleanup.outputs.has_changes == 'true' && steps.pr.outputs.created == 'true'
-        env:
-          CLEANUP_BRANCH: automation/planning-artifact-cleanup
-        # `gh pr create` above authenticates with GITHUB_TOKEN. GitHub's
-        # anti-recursion safeguard suppresses every workflow run that a
-        # `pull_request` event would otherwise trigger when the PR is
-        # opened by GITHUB_TOKEN, so required checks like CodeQL never
-        # run and the merge queue parks the PR in AWAITING_CHECKS forever.
-        #
-        # Push an empty commit using the deploy-key-authenticated remote
-        # so `pull_request: synchronize` fires under a real identity and
-        # all required workflows run on the cleanup PR. On subsequent
-        # workflow runs the PR already exists and the force-push of the
-        # cleanup commit itself fires synchronize, so this step is only
-        # needed on first creation.
-        run: |
-          set -euo pipefail
-          git commit --allow-empty -m "chore(ci): trigger required pull_request checks"
-          git push origin "HEAD:$CLEANUP_BRANCH"
-
-      - name: Add cleanup PR to merge queue
+      - name: Enable auto-merge on cleanup PR
         if: steps.cleanup.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Same identity requirement as the PR-create step. When the
+          # repo's merge-queue ruleset is active, `gh pr merge --auto`
+          # adds the PR to the queue as soon as required checks pass —
+          # and because the request originates from BOT_PAT, the
+          # `merge_group` event on the queue ref dispatches CI normally.
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
           PR_URL: ${{ steps.pr.outputs.url }}
-        # `gh pr merge --auto` only enables auto-merge, which does NOT add
-        # the PR to a required merge queue. We poll until the PR is
-        # mergeable (CI green) and then explicitly enqueue via the
-        # `enqueuePullRequest` GraphQL mutation, which is what the
-        # "Merge when ready" button calls.
-        #
-        # NOTE: `gh pr view --json isInMergeQueue` is not supported by the
-        # gh CLI shipped on ubuntu-latest runners — the field is missing
-        # from its known set and the command exits non-zero. Query the
-        # GraphQL API directly instead so this step does not regress with
-        # CLI version drift.
         run: |
           set -euo pipefail
-          PR_ID=$(gh pr view "$PR_URL" --json id --jq '.id')
-
-          pr_state() {
-            gh api graphql \
-              -f query='query($id:ID!){ node(id:$id){ ... on PullRequest { mergeable mergeStateStatus isInMergeQueue } } }' \
-              -F id="$PR_ID" \
-              --jq '"\(.data.node.mergeable)|\(.data.node.mergeStateStatus)|\(.data.node.isInMergeQueue)"'
-          }
-
-          initial=$(pr_state)
-          already_queued=${initial##*|}
-          if [ "$already_queued" = "true" ]; then
-            echo "PR already in merge queue; nothing to do."
-            exit 0
-          fi
-
-          attempts=60
-          sleep_seconds=30
-          for i in $(seq 1 "$attempts"); do
-            state=$(pr_state)
-            mergeable=${state%%|*}
-            rest=${state#*|}
-            merge_state=${rest%%|*}
-            queued=${rest#*|}
-            echo "attempt $i/$attempts mergeable=$mergeable mergeStateStatus=$merge_state isInMergeQueue=$queued"
-
-            if [ "$queued" = "true" ]; then
-              echo "PR entered queue out-of-band; done."
-              exit 0
-            fi
-
-            # mergeStateStatus reference:
-            #   CLEAN / HAS_HOOKS  -> green, ready to enqueue
-            #   UNSTABLE           -> required checks pending or failing; keep waiting
-            #   BLOCKED            -> usually transient while CI is still running on a
-            #                         fresh push (queue + required checks not yet green);
-            #                         keep waiting until the polling timeout
-            #   UNKNOWN            -> GitHub still computing; keep waiting
-            #   DIRTY / BEHIND     -> needs human attention (conflict or rebase)
-            #   DRAFT              -> shouldn't happen for this workflow, but treat as terminal
-            case "$merge_state" in
-              CLEAN | HAS_HOOKS)
-                if [ "$mergeable" = "MERGEABLE" ]; then
-                  break
-                fi
-                ;;
-              DIRTY | BEHIND | DRAFT)
-                echo "PR is $merge_state; cannot enqueue. Exiting."
-                exit 0
-                ;;
-              *)
-                # UNSTABLE, BLOCKED, UNKNOWN, anything else -> keep polling.
-                ;;
-            esac
-
-            if [ "$i" -eq "$attempts" ]; then
-              echo "Timed out waiting for PR to become mergeable."
-              exit 1
-            fi
-            sleep "$sleep_seconds"
-          done
-
-          gh api graphql \
-            -f query='mutation($id:ID!){ enqueuePullRequest(input:{pullRequestId:$id}){ mergeQueueEntry{ position } } }' \
-            -F id="$PR_ID"
+          gh pr merge "$PR_URL" --auto --merge


### PR DESCRIPTION
## Why

The cleanup workflow has been failing in two compounding GitHub anti-recursion ways:

1. **#690** found that `gh pr create` with `GITHUB_TOKEN` suppresses `pull_request` workflow runs on the new PR — fixed with a deploy-key kick commit.
2. Today's e2e tests (#691→#692 and #693→#694) found that **the same suppression also blocks `merge_group` workflow runs** when `enqueuePullRequest` is called with `GITHUB_TOKEN`. The merge-queue ref is created but CI never runs against it, so the queue parks indefinitely. Both #692 and #694 needed a manual dequeue/re-enqueue to land.

A watchdog inside the same workflow cannot self-heal this because the re-enqueue would still come from `GITHUB_TOKEN` and trip the same safeguard. The only fix is a non-`GITHUB_TOKEN` identity.

## What

Replace `GITHUB_TOKEN` with the new `BOT_PAT` secret (fine-grained PAT scoped to this repo) for both `gh pr create` and `gh pr merge --auto --merge`. With a non-Actions identity:

- `pull_request: opened` fires CI on the cleanup PR (no kick commit needed).
- `gh pr merge --auto` adds the PR to the queue once required checks pass (no explicit `enqueuePullRequest` mutation needed).
- The `merge_group` event fires CI on the queue ref (the actual blocker today).

Drops the previously-needed kick-commit step (#690) and the poll-then-enqueue loop (#688). The workflow shrinks by ~100 lines.

## Verification

After this lands, the next planning artifact merged to `main` should trigger a cleanup PR that lands without any manual queue intervention. Demonstrated in a follow-up PR.