### PR TITLE
chore(ci): drop redundant --merge flag from cleanup auto-merge

### DIFF
--- a/.github/workflows/planning-artifact-cleanup.yml
+++ b/.github/workflows/planning-artifact-cleanup.yml
@@ -87,4 +87,4 @@ jobs:
           PR_URL: ${{ steps.pr.outputs.url }}
         run: |
           set -euo pipefail
-          gh pr merge "$PR_URL" --auto --merge
+          gh pr merge "$PR_URL" --auto


### PR DESCRIPTION
Tiny follow-up to #695. The merge-queue ruleset dictates the merge method, and `gh pr merge --merge --auto` warns "The merge strategy for main is set by the merge queue" on every cleanup run. Drop the redundant flag.