### PR TITLE
docs(skills): correct slicc.lick payload shape examples

### DIFF
--- a/packages/vfs-root/shared/CLAUDE.md
+++ b/packages/vfs-root/shared/CLAUDE.md
@@ -47,7 +47,7 @@ One scoop per sprinkle, named identically. Cone MUST NOT write `.shtml` or run `
 Inline `shtml` code blocks in chat that hydrate into sandboxed widgets. Ephemeral, lick-only (no state). Cone may write these directly. Use for pickers, calculators, quick charts:
 
 ```shtml
-<button onclick="slicc.lick('choose', { value: 42 })">Pick 42</button>
+<button onclick="slicc.lick({ action: 'choose', data: { value: 42 } })">Pick 42</button>
 ```
 
 For persistent UI, use Sprinkles instead. See `/workspace/skills/dips/SKILL.md`.

--- a/packages/vfs-root/shared/CLAUDE.md
+++ b/packages/vfs-root/shared/CLAUDE.md
@@ -44,10 +44,10 @@ One scoop per sprinkle, named identically. Cone MUST NOT write `.shtml` or run `
 
 ## Dips
 
-Inline `shtml` code blocks in chat that hydrate into sandboxed widgets. Ephemeral, lick-only (no state). Cone may write these directly. Use for pickers, calculators, quick charts:
+Inline `shtml` blocks in chat that hydrate into sandboxed widgets. Ephemeral, lick-only (no state). Cone may write these directly:
 
 ```shtml
-<button onclick="slicc.lick({ action: 'choose', data: { value: 42 } })">Pick 42</button>
+<button onclick="slicc.lick({action:'choose',data:{value:42}})">Pick 42</button>
 ```
 
 For persistent UI, use Sprinkles instead. See `/workspace/skills/dips/SKILL.md`.

--- a/packages/vfs-root/workspace/skills/dips/SKILL.md
+++ b/packages/vfs-root/workspace/skills/dips/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: bash
 
 # Dips
 
-Dips are inline `shtml` code blocks in chat that hydrate into sandboxed interactive widgets. **Ephemeral** — no state persistence, no `readFile`. Only `slicc.lick()` is available for agent communication.
+Dips are inline `shtml` code blocks in chat that hydrate into sandboxed interactive widgets. **Ephemeral** — no state persistence, no `readFile`. Only `slicc.lick(event)` is available for agent communication; pack payloads as `{ action, data: { ... } }` (extra top-level fields are silently dropped).
 
 **Use them generously.** A dip is the right answer any time a response could benefit from visualization, interaction, or a moment of delight. Don't reserve them for "complex" tasks — a slider that lets the user feel a number, a chart that beats a paragraph of stats, a button that's faster than typing "yes" all earn their keep.
 
@@ -93,7 +93,7 @@ When a dip's lick handler needs to do real work (lookup, transformation, generat
 
 The flow:
 
-1. Dip emits a lick: `slicc.lick({action: 'compute', input: ...})`.
+1. Dip emits a lick: `slicc.lick({action: 'compute', data: {input: ...}})`.
 2. The lick reaches the cone (or scoop) as a message.
 3. Instead of replying conversationally, the receiver shells out to `agent` with a tight allow-list and a self-contained prompt.
 4. `agent` returns the answer on stdout. The receiver writes the result back to the dip via a follow-up dip or via `sprinkle send` (if the dip was the entry point to a sprinkle flow).
@@ -128,15 +128,22 @@ result=$(agent /tmp "curl,jq" "Fetch <url>, return field 'price' as a number.")
 
 ```javascript
 // Explicit "send to agent" button.
-slicc.lick({ action: 'use-config', config: getCurrentConfig() });
+slicc.lick({ action: 'use-config', data: { config: getCurrentConfig() } });
 
 // Lick on threshold crossing.
 if (total > budget) {
-  slicc.lick({ action: 'over-budget', total, budget, breakdown });
+  slicc.lick({ action: 'over-budget', data: { total, budget, breakdown } });
 }
 
 // Lick on completion.
-slicc.lick({ action: 'sort-complete', algorithm: algo, comparisons: n });
+slicc.lick({ action: 'sort-complete', data: { algorithm: algo, comparisons: n } });
 ```
+
+> **Payload shape:** `slicc.lick(eventOrAction)` accepts either a plain
+> action string (`slicc.lick('cancel')`) or an `{ action, data? }`
+> object. **Only `action` and `data` survive** the iframe → host
+> postMessage hop — any other top-level fields are silently dropped.
+> Pack all extra fields inside `data: { ... }` so the cone receives
+> them.
 
 The agent receives the lick as a structured message and can respond with prose, another dip, or spawn a scoop.

--- a/packages/vfs-root/workspace/skills/dips/SKILL.md
+++ b/packages/vfs-root/workspace/skills/dips/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: bash
 
 # Dips
 
-Dips are inline `shtml` code blocks in chat that hydrate into sandboxed interactive widgets. **Ephemeral** — no state persistence, no `readFile`. Only `slicc.lick(event)` is available for agent communication; pack payloads as `{ action, data: { ... } }` (extra top-level fields are silently dropped).
+Dips are inline `shtml` code blocks in chat that hydrate into sandboxed interactive widgets. **Ephemeral** — no state persistence, no `readFile`. Only `slicc.lick(event)` is available for agent communication; always pack payloads as `{ action, data: { ... } }` for a predictable shape on the cone side.
 
 **Use them generously.** A dip is the right answer any time a response could benefit from visualization, interaction, or a moment of delight. Don't reserve them for "complex" tasks — a slider that lets the user feel a number, a chart that beats a paragraph of stats, a button that's faster than typing "yes" all earn their keep.
 
@@ -141,9 +141,10 @@ slicc.lick({ action: 'sort-complete', data: { algorithm: algo, comparisons: n } 
 
 > **Payload shape:** `slicc.lick(eventOrAction)` accepts either a plain
 > action string (`slicc.lick('cancel')`) or an `{ action, data? }`
-> object. **Only `action` and `data` survive** the iframe → host
-> postMessage hop — any other top-level fields are silently dropped.
-> Pack all extra fields inside `data: { ... }` so the cone receives
-> them.
+> object. **Always pack extra fields inside `data: { ... }`** — the
+> cone reads `event.data` as the payload, so top-level extras either
+> get dropped (sprinkle bridge) or folded into `data` as the whole
+> event object (dip bridge), neither of which gives the cone a
+> predictable shape. The canonical form works identically in both.
 
 The agent receives the lick as a structured message and can respond with prose, another dip, or spawn a scoop.

--- a/packages/vfs-root/workspace/skills/dips/patterns.md
+++ b/packages/vfs-root/workspace/skills/dips/patterns.md
@@ -9,7 +9,7 @@ Drag control points on `<canvas>` — live computed output.
 ```shtml
 <canvas id="c"></canvas>
 <div id="output" style="font-family:var(--s2-font-mono);font-size:12px;margin-top:8px"></div>
-<button class="sprinkle-btn sprinkle-btn--primary" onclick="slicc.lick({action:'use-value',value:currentValue})">Use this value</button>
+<button class="sprinkle-btn sprinkle-btn--primary" onclick="slicc.lick({action:'use-value',data:{value:currentValue}})">Use this value</button>
 <script>
   const cv = document.getElementById('c');
   const ctx = cv.getContext('2d');

--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -156,7 +156,7 @@ When a sprinkle button needs to do real work but the owning scoop should NOT be 
 
 Pattern:
 
-1. User clicks → `slicc.lick({action: 'lookup', q: 'foo'})`.
+1. User clicks → `slicc.lick({action: 'lookup', data: {q: 'foo'}})`.
 2. Cone sees the lick, forwards to the owning scoop with `feed_scoop`.
 3. The scoop's reply runs `agent` against a tight allow-list and writes the result back via `sprinkle send`.
 
@@ -184,7 +184,7 @@ sprinkle chat '<div class="sprinkle-action-card">
   <div class="sprinkle-action-card__header">Deploy to production?</div>
   <div class="sprinkle-action-card__actions">
     <button class="sprinkle-btn sprinkle-btn--secondary" onclick="slicc.lick({action:\"cancel\"})">Cancel</button>
-    <button class="sprinkle-btn sprinkle-btn--primary" onclick="slicc.lick({action:\"deploy\",env:\"prod\"})">Deploy</button>
+    <button class="sprinkle-btn sprinkle-btn--primary" onclick="slicc.lick({action:\"deploy\",data:{env:\"prod\"}})">Deploy</button>
   </div>
 </div>'
 ```
@@ -193,7 +193,7 @@ sprinkle chat '<div class="sprinkle-action-card">
 
 Available as `slicc` in `<script>` tags and `onclick` attributes:
 
-- `slicc.lick({action: 'refresh', data: {...}})` — send a lick event to the cone (cone routes to the right scoop).
+- `slicc.lick(event)` — send a lick event to the cone (cone routes to the right scoop). **Only `action` and `data` survive** the iframe → host postMessage hop; pack any extra payload inside `data: { ... }`. Accepts either a string shortcut (`slicc.lick('cancel')` → `{ action: 'cancel' }`) or `{ action, data? }`. **Do not** put extra fields at the top level — `slicc.lick({ action: 'deploy', env: 'prod' })` silently drops `env`; use `slicc.lick({ action: 'deploy', data: { env: 'prod' } })` instead.
 - `slicc.on('update', function(data) {...})` — receive data sent via `sprinkle send`.
 - `slicc.name` — the sprinkle's name.
 - `slicc.close()` — close the sprinkle.

--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -193,8 +193,10 @@ sprinkle chat '<div class="sprinkle-action-card">
 
 Available as `slicc` in `<script>` tags and `onclick` attributes:
 
-- `slicc.lick(event)` — send a lick event to the cone (cone routes to the right scoop). **Only `action` and `data` survive** the iframe → host postMessage hop; pack any extra payload inside `data: { ... }`. Accepts either a string shortcut (`slicc.lick('cancel')` → `{ action: 'cancel' }`) or `{ action, data? }`. **Do not** put extra fields at the top level — `slicc.lick({ action: 'deploy', env: 'prod' })` silently drops `env`; use `slicc.lick({ action: 'deploy', data: { env: 'prod' } })` instead.
+- `slicc.lick(event)` — send a lick event to the cone (cone routes to the right scoop). Accepts a string shortcut (`slicc.lick('cancel')` → `{ action: 'cancel' }`) or `{ action, data? }`. See payload-shape note below.
 - `slicc.on('update', function(data) {...})` — receive data sent via `sprinkle send`.
+
+> **Payload shape:** the cone reads `event.data` as the payload — top-level extras outside `action` and `data` are silently dropped by the sprinkle bridge. Always use `slicc.lick({ action: 'deploy', data: { env: 'prod' } })`, not `slicc.lick({ action: 'deploy', env: 'prod' })`.
 - `slicc.name` — the sprinkle's name.
 - `slicc.close()` — close the sprinkle.
 - `slicc.stopCone()` — stop the cone agent.

--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -197,6 +197,7 @@ Available as `slicc` in `<script>` tags and `onclick` attributes:
 - `slicc.on('update', function(data) {...})` — receive data sent via `sprinkle send`.
 
 > **Payload shape:** the cone reads `event.data` as the payload — top-level extras outside `action` and `data` are silently dropped by the sprinkle bridge. Always use `slicc.lick({ action: 'deploy', data: { env: 'prod' } })`, not `slicc.lick({ action: 'deploy', env: 'prod' })`.
+
 - `slicc.name` — the sprinkle's name.
 - `slicc.close()` — close the sprinkle.
 - `slicc.stopCone()` — stop the cone agent.

--- a/packages/vfs-root/workspace/skills/sprinkles/icon-example.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/icon-example.md
@@ -32,7 +32,7 @@ This shows how to use Lucide icons in inline sprinkles instead of emojis.
   <div class="sprinkle-action-card__header">Select Status</div>
   <div class="sprinkle-action-card__body">
     <div class="sprinkle-stack">
-      <button class="sprinkle-btn" onclick="slicc.lick({action:'status',value:'success'})">
+      <button class="sprinkle-btn" onclick="slicc.lick({action:'status',data:{value:'success'}})">
         <i
           data-lucide="check-circle"
           class="sprinkle-icon"
@@ -40,7 +40,7 @@ This shows how to use Lucide icons in inline sprinkles instead of emojis.
         ></i>
         Success
       </button>
-      <button class="sprinkle-btn" onclick="slicc.lick({action:'status',value:'warning'})">
+      <button class="sprinkle-btn" onclick="slicc.lick({action:'status',data:{value:'warning'}})">
         <i
           data-lucide="alert-triangle"
           class="sprinkle-icon"
@@ -48,7 +48,7 @@ This shows how to use Lucide icons in inline sprinkles instead of emojis.
         ></i>
         Warning
       </button>
-      <button class="sprinkle-btn" onclick="slicc.lick({action:'status',value:'error'})">
+      <button class="sprinkle-btn" onclick="slicc.lick({action:'status',data:{value:'error'}})">
         <i
           data-lucide="x-circle"
           class="sprinkle-icon"
@@ -56,7 +56,7 @@ This shows how to use Lucide icons in inline sprinkles instead of emojis.
         ></i>
         Error
       </button>
-      <button class="sprinkle-btn" onclick="slicc.lick({action:'status',value:'info'})">
+      <button class="sprinkle-btn" onclick="slicc.lick({action:'status',data:{value:'info'}})">
         <i data-lucide="info" class="sprinkle-icon" style="color: var(--uxc-accent-text)"></i> Info
       </button>
     </div>


### PR DESCRIPTION
## Summary

Closes #700 via Option A — fix the docs to match the `slicc.lick()` helper's actual contract (`{ action, data: { ... } }`) rather than changing the API.

The bridge helper at `packages/webapp/src/ui/sprinkle-renderer.ts:430-433` extracts only `action` and `data` from the caller's event object. Skill docs widely showed the broken pattern (top-level extra fields), so sprinkle authors who followed the examples silently lost their payload (`name`, `value`, `config`, `total`, `env`, …).

## Files changed

Doc-only:

- \`packages/vfs-root/shared/CLAUDE.md\` — the two-arg form \`slicc.lick('choose', { value })\` doesn't match the single-arg API; rewrote as the canonical \`{ action, data }\` shape.
- \`packages/vfs-root/workspace/skills/sprinkles/icon-example.md\` — 4 status buttons wrapping \`value\` at the top level.
- \`packages/vfs-root/workspace/skills/sprinkles/SKILL.md\` — \`{ action, q }\` and \`{ action, env }\` examples + Bridge API entry now has an explicit "extra top-level fields are dropped" warning with a wrong-vs-right snippet.
- \`packages/vfs-root/workspace/skills/dips/SKILL.md\` — \`input\`, \`config\`, \`total + budget + breakdown\`, \`algorithm + comparisons\` examples + a payload-shape callout under the Lick patterns section and a one-line reminder in the intro.
- \`packages/vfs-root/workspace/skills/dips/patterns.md\` — \`value: currentValue\` on a drag-on-canvas button.

Welcome sprinkles (\`shared/sprinkles/welcome/*.shtml\`) were already using the correct shape — verified, no changes.

## Verification

- \`grep -rn 'slicc\\.lick({[^}]*action[^}]*,[^}]*[a-z]' --include='*.md' --include='*.shtml' packages/vfs-root | grep -v 'data:'\` returns zero results.
- \`npx prettier --write packages/vfs-root/**/*.md\` clean.
- No code changed, so no test impact.

## Out of scope

Two protocol-level gaps surfaced during the same testing session as #700:

- #702 — followers don't reload an open sprinkle when the leader does close+reopen (no \`contentVersion\` in \`SprinkleSummary\`)
- #703 — \`SprinkleSummary\` is missing \`icon\` → follower rail shows default sparkle for every sprinkle

Both require iOS protocol-mirror coordination and stay deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)