### PR TITLE
fix(webapp): route oauth-domain writes through panel-rpc (#701)

### DIFF
--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -190,9 +190,10 @@ The webapp consumes `@slicc/shared-ts` for secret masking primitives. `createPro
 Provider `oauthTokenDomains` is an immutable safe default; users can layer additional allowed domains per-provider:
 
 - Storage: `localStorage["slicc_oauth_extra_domains"]` → `{[providerId]: [domain, ...]}`
-- Helpers: `getExtraOAuthDomains(id)` / `setExtraOAuthDomains(id, domains)` / `getAllExtraOAuthDomains()` in `provider-settings.ts`
-- Surfaces: panel terminal `oauth-domain` command, extension options page "OAuth domains" tab
+- Helpers: `getExtraOAuthDomains(id)` / `setExtraOAuthDomains(id, domains)` / `getAllExtraOAuthDomains()` (sync, page-only) and `setExtraOAuthDomainsAsync(id, domains)` (worker-safe — routes through `panel-rpc` when no DOM, then mirrors the post-write store into the worker shim so same-session reads stay consistent) in `provider-settings.ts`
+- Surfaces: panel terminal `oauth-domain` command (worker float — uses the async setter), extension options page "OAuth domains" tab (page float — uses the sync helpers directly)
 - Merge: `saveOAuthAccount` concatenates defaults + extras, dedupes case-insensitively (defaults-first order), then pushes the merged list to the fetch-proxy / SW.
+- Worker-side write path: the kernel-worker shim's `localStorage.setItem` is page→worker only (no echo-back). Writes from the worker MUST go via `setExtraOAuthDomainsAsync` / the `oauth-extras-set` panel-rpc op, otherwise they're swallowed by the shim Map and lost on reload — see issue #701.
 
 ### Shell-env masked secret population
 

--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -171,7 +171,7 @@ export interface PanelRpcResults {
     audioinputs: Array<{ deviceId: string; label: string; groupId?: string }>;
   };
   'tray-reset': LeaderTrayRuntimeStatus;
-  'oauth-extras-set': { store: OAuthExtraDomainsStore };
+  'oauth-extras-set': { storeAfter: OAuthExtraDomainsStore };
 }
 
 export type PanelRpcOp = PanelRpcRequest['op'];

--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -38,6 +38,7 @@
  * commands run directly there.
  */
 
+import type { OAuthExtraDomainsStore } from '@slicc/shared-ts';
 import type { LeaderTrayRuntimeStatus } from '../scoops/tray-leader.js';
 
 const PANEL_RPC_CHANNEL = 'slicc-panel-rpc';
@@ -132,6 +133,18 @@ export type PanelRpcRequest =
       // Handler throws when no leader tray is active.
       op: 'tray-reset';
       payload?: undefined;
+    }
+  | {
+      // Write the user-configured extra-OAuth-domains store for a
+      // single provider. Worker writes can't reach page localStorage
+      // directly (the kernel-worker shim is page→worker only — see
+      // `kernel-worker.ts:installLocalStorageShim`), so the
+      // `oauth-domain` command routes writes through the page handler
+      // which mutates real `localStorage`. Response carries the full
+      // post-write store so the worker can mirror it into its shim
+      // before resolving, avoiding the page→worker forward race.
+      op: 'oauth-extras-set';
+      payload: { providerId: string; domains: string[] };
     };
 
 export interface PanelRpcResults {
@@ -158,6 +171,7 @@ export interface PanelRpcResults {
     audioinputs: Array<{ deviceId: string; label: string; groupId?: string }>;
   };
   'tray-reset': LeaderTrayRuntimeStatus;
+  'oauth-extras-set': { store: OAuthExtraDomainsStore };
 }
 
 export type PanelRpcOp = PanelRpcRequest['op'];

--- a/packages/webapp/src/shell/supplemental-commands/oauth-domain-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/oauth-domain-command.ts
@@ -36,7 +36,7 @@ export function createOAuthDomainCommand(): Command {
       return { stdout: helpText(), stderr: '', exitCode: 0 };
     }
 
-    const { getExtraOAuthDomains, setExtraOAuthDomains, getAllExtraOAuthDomains } =
+    const { getExtraOAuthDomains, setExtraOAuthDomainsAsync, getAllExtraOAuthDomains } =
       await import('../../ui/provider-settings.js');
 
     const [subcommand, providerId, domain] = args;
@@ -81,7 +81,7 @@ export function createOAuthDomainCommand(): Command {
               exitCode: 0,
             };
           }
-          setExtraOAuthDomains(providerId, [...current, domain]);
+          await setExtraOAuthDomainsAsync(providerId, [...current, domain]);
           return {
             stdout: `Added ${domain} to ${providerId}. Reload the page to apply.\n`,
             stderr: '',
@@ -107,7 +107,7 @@ export function createOAuthDomainCommand(): Command {
               exitCode: 0,
             };
           }
-          setExtraOAuthDomains(providerId, next);
+          await setExtraOAuthDomainsAsync(providerId, next);
           return {
             stdout: `Removed ${domain} from ${providerId}. Reload the page to apply.\n`,
             stderr: '',
@@ -123,7 +123,7 @@ export function createOAuthDomainCommand(): Command {
               exitCode: 1,
             };
           }
-          setExtraOAuthDomains(providerId, []);
+          await setExtraOAuthDomainsAsync(providerId, []);
           return {
             stdout: `Cleared extra domains for ${providerId}. Reload the page to apply.\n`,
             stderr: '',

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -262,12 +262,12 @@ export function createStandalonePanelRpcHandlers(
       // `installPageStorageSync` patches `Storage.prototype.setItem`
       // so this write also fans out to the worker shim — but on a
       // different channel than the panel-rpc response, with no
-      // ordering guarantee. Returning the full store lets the worker
-      // mirror it into its shim before resolving so a follow-up
-      // `oauth-domain list` in the same session sees the new value
-      // without waiting for the cross-channel forward.
+      // ordering guarantee. Returning the full post-write store lets
+      // the worker mirror it into its shim before resolving so a
+      // follow-up `oauth-domain list` in the same session sees the
+      // new value without waiting for the cross-channel forward.
       setExtraOAuthDomains(providerId, domains);
-      return { store: getAllExtraOAuthDomains() };
+      return { storeAfter: getAllExtraOAuthDomains() };
     },
   };
 }

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -12,6 +12,7 @@
 
 import type { PanelRpcHandlers } from '../kernel/panel-rpc.js';
 import type { LeaderTrayRuntimeStatus } from '../scoops/tray-leader.js';
+import { getAllExtraOAuthDomains, setExtraOAuthDomains } from './provider-settings.js';
 
 /**
  * Options threaded into the handler factory. Each callback is optional
@@ -253,6 +254,20 @@ export function createStandalonePanelRpcHandlers(
         throw new Error('host reset: no active tray session to reset');
       }
       return await options.resetTray();
+    },
+
+    'oauth-extras-set': ({ providerId, domains }) => {
+      // Page-side write to real `window.localStorage` for the
+      // `oauth-domain` shell command running in the kernel worker.
+      // `installPageStorageSync` patches `Storage.prototype.setItem`
+      // so this write also fans out to the worker shim — but on a
+      // different channel than the panel-rpc response, with no
+      // ordering guarantee. Returning the full store lets the worker
+      // mirror it into its shim before resolving so a follow-up
+      // `oauth-domain list` in the same session sees the new value
+      // without waiting for the cross-channel forward.
+      setExtraOAuthDomains(providerId, domains);
+      return { store: getAllExtraOAuthDomains() };
     },
   };
 }

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -520,6 +520,13 @@ export function setExtraOAuthDomains(providerId: string, domains: string[]): voi
  * resolving so a same-session `getExtraOAuthDomains` read sees the
  * new value without waiting for the cross-channel
  * `local-storage-set` forward to land.
+ *
+ * If the mirror-back itself throws (e.g., a future shim variant
+ * rejecting writes), the durable page-side write has ALREADY
+ * succeeded — degrade to a logged warning rather than propagating
+ * up. Surfacing the throw would inverted truth: the user would see
+ * "oauth-domain add failed" while the persistent state actually
+ * holds the new value, recoverable on reload.
  */
 export async function setExtraOAuthDomainsAsync(
   providerId: string,
@@ -535,8 +542,15 @@ export async function setExtraOAuthDomainsAsync(
       'setExtraOAuthDomainsAsync: no DOM and no panel-rpc client — cannot persist to page localStorage'
     );
   }
-  const { store } = await rpc.call('oauth-extras-set', { providerId, domains });
-  sharedWriteOAuthExtras(localStorage, store);
+  const { storeAfter } = await rpc.call('oauth-extras-set', { providerId, domains });
+  try {
+    sharedWriteOAuthExtras(localStorage, storeAfter);
+  } catch (err) {
+    log.warn('worker-shim mirror failed after successful page write — reload to refresh', {
+      providerId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 export function getAllExtraOAuthDomains(): OAuthExtraDomainsStore {

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -524,9 +524,10 @@ export function setExtraOAuthDomains(providerId: string, domains: string[]): voi
  * If the mirror-back itself throws (e.g., a future shim variant
  * rejecting writes), the durable page-side write has ALREADY
  * succeeded — degrade to a logged warning rather than propagating
- * up. Surfacing the throw would inverted truth: the user would see
- * "oauth-domain add failed" while the persistent state actually
- * holds the new value, recoverable on reload.
+ * up. The persistent state already holds the new value; surfacing
+ * the throw would make `oauth-domain add` report failure on a write
+ * that actually succeeded, with reload as the recovery path the
+ * help text already promises.
  */
 export async function setExtraOAuthDomainsAsync(
   providerId: string,

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -492,6 +492,7 @@ import {
   writeOAuthExtras as sharedWriteOAuthExtras,
   type OAuthExtraDomainsStore,
 } from '@slicc/shared-ts';
+import { getPanelRpcClient, hasLocalDom } from '../kernel/panel-rpc.js';
 
 export function getExtraOAuthDomains(providerId: string): string[] {
   return sharedReadOAuthExtras(localStorage)[providerId] ?? [];
@@ -505,6 +506,36 @@ export function setExtraOAuthDomains(providerId: string, domains: string[]): voi
   } else {
     store[providerId] = cleaned;
   }
+  sharedWriteOAuthExtras(localStorage, store);
+}
+
+/**
+ * Worker-safe variant of `setExtraOAuthDomains`. In page context it
+ * just calls the sync helper. In the kernel worker (no DOM, only a
+ * Map-backed `localStorage` shim that doesn't echo back to the page —
+ * see `kernel-worker.ts:installLocalStorageShim`) it routes the write
+ * through `panel-rpc` so the page handler can mutate real
+ * `window.localStorage`. The bridge response carries the full
+ * post-write store; we mirror it into the worker shim before
+ * resolving so a same-session `getExtraOAuthDomains` read sees the
+ * new value without waiting for the cross-channel
+ * `local-storage-set` forward to land.
+ */
+export async function setExtraOAuthDomainsAsync(
+  providerId: string,
+  domains: string[]
+): Promise<void> {
+  if (hasLocalDom()) {
+    setExtraOAuthDomains(providerId, domains);
+    return;
+  }
+  const rpc = getPanelRpcClient();
+  if (!rpc) {
+    throw new Error(
+      'setExtraOAuthDomainsAsync: no DOM and no panel-rpc client — cannot persist to page localStorage'
+    );
+  }
+  const { store } = await rpc.call('oauth-extras-set', { providerId, domains });
   sharedWriteOAuthExtras(localStorage, store);
 }
 

--- a/packages/webapp/tests/kernel/panel-rpc.test.ts
+++ b/packages/webapp/tests/kernel/panel-rpc.test.ts
@@ -219,4 +219,79 @@ describe('panel-rpc', () => {
     client.dispose();
     stop();
   });
+
+  /**
+   * `oauth-extras-set` is the op that fixes issue #701: worker-side
+   * `oauth-domain` writes route through here to reach real page
+   * localStorage. Unit tests cover each side in isolation; this case
+   * locks the wire contract by exercising the REAL page handler from
+   * `panel-rpc-handlers.ts` against the REAL worker client. If the
+   * variant's name, payload shape, or `storeAfter` field is renamed
+   * on only one side, this assertion fails.
+   */
+  it('oauth-extras-set: real page handler ↔ worker client round-trip', async () => {
+    const { createStandalonePanelRpcHandlers } = await import('../../src/ui/panel-rpc-handlers.js');
+    const originalLocalStorage = globalThis.localStorage;
+    const lsData: Record<string, string> = {};
+    (globalThis as { localStorage: Storage }).localStorage = {
+      get length(): number {
+        return Object.keys(lsData).length;
+      },
+      key: (i: number) => Object.keys(lsData)[i] ?? null,
+      getItem: (k: string) => lsData[k] ?? null,
+      setItem: (k: string, v: string) => {
+        lsData[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete lsData[k];
+      },
+      clear: () => {
+        for (const k of Object.keys(lsData)) delete lsData[k];
+      },
+    };
+    try {
+      const stop = installPanelRpcHandler({
+        instanceId: 'oauth-rt',
+        handlers: createStandalonePanelRpcHandlers({}),
+      });
+      const client = createPanelRpcClient({ instanceId: 'oauth-rt' });
+
+      // 1. First write.
+      const r1 = await client.call('oauth-extras-set', {
+        providerId: 'adobe',
+        domains: ['admin.hlx.page', '*.aem.page'],
+      });
+      expect(r1).toEqual({ storeAfter: { adobe: ['admin.hlx.page', '*.aem.page'] } });
+      expect(lsData.slicc_oauth_extra_domains).toBe(
+        JSON.stringify({ adobe: ['admin.hlx.page', '*.aem.page'] })
+      );
+
+      // 2. Second write on a different provider — the response carries
+      // the FULL post-write store so the worker can mirror correctly,
+      // not just the touched provider's slice.
+      const r2 = await client.call('oauth-extras-set', {
+        providerId: 'github',
+        domains: ['hub.example.com'],
+      });
+      expect(r2.storeAfter).toEqual({
+        adobe: ['admin.hlx.page', '*.aem.page'],
+        github: ['hub.example.com'],
+      });
+
+      // 3. Empty domains drops the provider entry.
+      const r3 = await client.call('oauth-extras-set', {
+        providerId: 'adobe',
+        domains: [],
+      });
+      expect(r3.storeAfter).toEqual({ github: ['hub.example.com'] });
+      expect(lsData.slicc_oauth_extra_domains).toBe(
+        JSON.stringify({ github: ['hub.example.com'] })
+      );
+
+      client.dispose();
+      stop();
+    } finally {
+      (globalThis as { localStorage: Storage }).localStorage = originalLocalStorage;
+    }
+  });
 });

--- a/packages/webapp/tests/providers/oauth-extra-domains.test.ts
+++ b/packages/webapp/tests/providers/oauth-extra-domains.test.ts
@@ -213,36 +213,60 @@ describe('setExtraOAuthDomainsAsync — DOM vs worker path', () => {
   it('worker-shim mirror failure does NOT propagate — page write is durable', async () => {
     // The page-side write succeeded (bridge returned a storeAfter
     // snapshot). If the worker-shim mirror then throws, surfacing
-    // that would inverted-truth the user: command exits non-zero
-    // even though the persistent state correctly holds the new
-    // value. Verify we degrade to a warning + return success.
+    // that would make the command exit non-zero even though the
+    // persistent state correctly holds the new value. Verify we
+    // degrade to a warning + return success.
     (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = {
       call: async () => ({ storeAfter: { adobe: ['mirrored.example.com'] } }),
       dispose: () => {},
     };
-    // Wrap the shim's setItem so the mirror-back write throws while
-    // the durable page side already succeeded (modeled by the
-    // bridge's resolved response above).
-    const originalSetItem = globalThis.localStorage.setItem.bind(globalThis.localStorage);
-    Object.defineProperty(globalThis.localStorage, 'setItem', {
-      configurable: true,
-      writable: true,
-      value: () => {
-        throw new Error('simulated worker-shim quota');
-      },
-    });
+    // `bind` is inside the try so a (theoretical) throw doesn't leak
+    // an undefined `originalSetItem` past the finally. The outer
+    // afterEach swaps the whole localStorage stub back, so this
+    // restoration is defense-in-depth — but keeping the swap atomic
+    // costs nothing.
+    let originalSetItem: ((k: string, v: string) => void) | null = null;
+    // Log the warn through `console.warn` (createLogger's transport
+    // for WARN level). Bump the runtime level so the message isn't
+    // filtered out by the test-env default (ERROR).
+    const { setLogLevel, getLogLevel, LogLevel } = await import('../../src/core/logger.js');
+    const priorLevel = getLogLevel();
+    setLogLevel(LogLevel.WARN);
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     try {
+      originalSetItem = globalThis.localStorage.setItem.bind(globalThis.localStorage);
+      Object.defineProperty(globalThis.localStorage, 'setItem', {
+        configurable: true,
+        writable: true,
+        value: () => {
+          throw new Error('simulated worker-shim quota');
+        },
+      });
       const { setExtraOAuthDomainsAsync } = await import('../../src/ui/provider-settings.js');
       // Must NOT reject; the failure is recoverable on reload.
       await expect(
         setExtraOAuthDomainsAsync('adobe', ['mirrored.example.com'])
       ).resolves.toBeUndefined();
+      // Operator visibility — locks the log-message contract so a
+      // future refactor can't silently demote the level (warn →
+      // debug) without test signal.
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      const call = consoleWarnSpy.mock.calls[0]!;
+      // createLogger emits as: console.warn(prefix, message, ...data)
+      expect(call[0]).toBe('[provider-settings]');
+      expect(call[1]).toMatch(/worker-shim mirror failed/i);
+      expect(call[1]).toMatch(/reload to refresh/i);
+      expect(call[2]).toMatchObject({ providerId: 'adobe' });
     } finally {
-      Object.defineProperty(globalThis.localStorage, 'setItem', {
-        configurable: true,
-        writable: true,
-        value: originalSetItem,
-      });
+      if (originalSetItem) {
+        Object.defineProperty(globalThis.localStorage, 'setItem', {
+          configurable: true,
+          writable: true,
+          value: originalSetItem,
+        });
+      }
+      consoleWarnSpy.mockRestore();
+      setLogLevel(priorLevel);
     }
   });
 });

--- a/packages/webapp/tests/providers/oauth-extra-domains.test.ts
+++ b/packages/webapp/tests/providers/oauth-extra-domains.test.ts
@@ -88,6 +88,129 @@ describe('OAuth extra-domains store', () => {
   });
 });
 
+/**
+ * `setExtraOAuthDomainsAsync` is the worker-safe writer that fixes
+ * issue #701. In a page context (has `window`) it forwards to the
+ * sync helper; in a worker (no DOM) it routes the write through
+ * `panel-rpc.oauth-extras-set` so the page handler can mutate real
+ * `window.localStorage`, then mirrors the returned post-write store
+ * into the worker shim. Without the mirror-back, a same-session
+ * `getExtraOAuthDomains` read could race the cross-channel
+ * `local-storage-set` forward and see stale data.
+ */
+describe('setExtraOAuthDomainsAsync — DOM vs worker path', () => {
+  let lsData: Record<string, string>;
+  let originalLocalStorage: Storage;
+  let originalWindow: unknown;
+  let originalDocument: unknown;
+  let originalPanelRpc: unknown;
+
+  beforeEach(() => {
+    originalLocalStorage = globalThis.localStorage;
+    originalWindow = (globalThis as { window?: unknown }).window;
+    originalDocument = (globalThis as { document?: unknown }).document;
+    originalPanelRpc = (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc;
+    lsData = {};
+    (globalThis as { localStorage: Storage }).localStorage = {
+      get length(): number {
+        return Object.keys(lsData).length;
+      },
+      key: (i: number) => Object.keys(lsData)[i] ?? null,
+      getItem: (k: string) => lsData[k] ?? null,
+      setItem: (k: string, v: string) => {
+        lsData[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete lsData[k];
+      },
+      clear: () => {
+        for (const k of Object.keys(lsData)) delete lsData[k];
+      },
+    };
+    delete (globalThis as { chrome?: unknown }).chrome;
+  });
+
+  afterEach(() => {
+    (globalThis as { localStorage: Storage }).localStorage = originalLocalStorage;
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window: unknown }).window = originalWindow;
+    }
+    if (originalDocument === undefined) {
+      delete (globalThis as { document?: unknown }).document;
+    } else {
+      (globalThis as { document: unknown }).document = originalDocument;
+    }
+    if (originalPanelRpc === undefined) {
+      delete (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc;
+    } else {
+      (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = originalPanelRpc;
+    }
+    vi.resetModules();
+  });
+
+  it('page context (has DOM): writes directly to localStorage, no bridge call', async () => {
+    // `hasLocalDom()` checks for `window` AND `document`. JSDOM tests
+    // would set both; node-env tests don't. Force the page branch by
+    // stubbing both globals here.
+    (globalThis as { window: unknown }).window = {};
+    (globalThis as { document: unknown }).document = {};
+    const calls: Array<{ op: string; payload: unknown }> = [];
+    (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = {
+      call: async (op: string, payload: unknown) => {
+        calls.push({ op, payload });
+        throw new Error('bridge must not be called in page context');
+      },
+      dispose: () => {},
+    };
+    const { setExtraOAuthDomainsAsync, getExtraOAuthDomains } =
+      await import('../../src/ui/provider-settings.js');
+    await setExtraOAuthDomainsAsync('adobe', ['admin.hlx.page', '*.aem.page']);
+    expect(getExtraOAuthDomains('adobe')).toEqual(['admin.hlx.page', '*.aem.page']);
+    expect(calls).toEqual([]);
+  });
+
+  it('worker context (no DOM): routes through panel-rpc and mirrors store into shim', async () => {
+    // Stay in node-env with no window/document so `hasLocalDom()` is false.
+    const calls: Array<{ op: string; payload: unknown }> = [];
+    let bridgeStore: Record<string, string[]> = {};
+    (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = {
+      call: async (op: string, payload: unknown) => {
+        calls.push({ op, payload });
+        const { providerId, domains } = payload as { providerId: string; domains: string[] };
+        // Simulate the page handler updating the page-side store.
+        if (domains.length === 0) {
+          delete bridgeStore[providerId];
+        } else {
+          bridgeStore = { ...bridgeStore, [providerId]: domains };
+        }
+        return { store: bridgeStore };
+      },
+      dispose: () => {},
+    };
+    const { setExtraOAuthDomainsAsync, getExtraOAuthDomains } =
+      await import('../../src/ui/provider-settings.js');
+    await setExtraOAuthDomainsAsync('adobe', ['admin.hlx.page']);
+    expect(calls).toEqual([
+      { op: 'oauth-extras-set', payload: { providerId: 'adobe', domains: ['admin.hlx.page'] } },
+    ]);
+    // The mirror-back into the worker shim is the critical assertion:
+    // without it, the next read could race the cross-channel forward
+    // and return stale data.
+    expect(lsData.slicc_oauth_extra_domains).toBe(JSON.stringify({ adobe: ['admin.hlx.page'] }));
+    expect(getExtraOAuthDomains('adobe')).toEqual(['admin.hlx.page']);
+  });
+
+  it('worker context with no bridge available throws a clear error', async () => {
+    delete (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc;
+    const { setExtraOAuthDomainsAsync } = await import('../../src/ui/provider-settings.js');
+    await expect(setExtraOAuthDomainsAsync('adobe', ['x.example.com'])).rejects.toThrow(
+      /no DOM and no panel-rpc client/i
+    );
+  });
+});
+
 describe('saveOAuthAccount — merges provider defaults + extras', () => {
   let originalFetch: typeof globalThis.fetch;
   let lsData: Record<string, string>;

--- a/packages/webapp/tests/providers/oauth-extra-domains.test.ts
+++ b/packages/webapp/tests/providers/oauth-extra-domains.test.ts
@@ -185,7 +185,7 @@ describe('setExtraOAuthDomainsAsync — DOM vs worker path', () => {
         } else {
           bridgeStore = { ...bridgeStore, [providerId]: domains };
         }
-        return { store: bridgeStore };
+        return { storeAfter: bridgeStore };
       },
       dispose: () => {},
     };
@@ -208,6 +208,42 @@ describe('setExtraOAuthDomainsAsync — DOM vs worker path', () => {
     await expect(setExtraOAuthDomainsAsync('adobe', ['x.example.com'])).rejects.toThrow(
       /no DOM and no panel-rpc client/i
     );
+  });
+
+  it('worker-shim mirror failure does NOT propagate — page write is durable', async () => {
+    // The page-side write succeeded (bridge returned a storeAfter
+    // snapshot). If the worker-shim mirror then throws, surfacing
+    // that would inverted-truth the user: command exits non-zero
+    // even though the persistent state correctly holds the new
+    // value. Verify we degrade to a warning + return success.
+    (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = {
+      call: async () => ({ storeAfter: { adobe: ['mirrored.example.com'] } }),
+      dispose: () => {},
+    };
+    // Wrap the shim's setItem so the mirror-back write throws while
+    // the durable page side already succeeded (modeled by the
+    // bridge's resolved response above).
+    const originalSetItem = globalThis.localStorage.setItem.bind(globalThis.localStorage);
+    Object.defineProperty(globalThis.localStorage, 'setItem', {
+      configurable: true,
+      writable: true,
+      value: () => {
+        throw new Error('simulated worker-shim quota');
+      },
+    });
+    try {
+      const { setExtraOAuthDomainsAsync } = await import('../../src/ui/provider-settings.js');
+      // Must NOT reject; the failure is recoverable on reload.
+      await expect(
+        setExtraOAuthDomainsAsync('adobe', ['mirrored.example.com'])
+      ).resolves.toBeUndefined();
+    } finally {
+      Object.defineProperty(globalThis.localStorage, 'setItem', {
+        configurable: true,
+        writable: true,
+        value: originalSetItem,
+      });
+    }
   });
 });
 

--- a/packages/webapp/tests/shell/supplemental-commands/oauth-domain-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/oauth-domain-command.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { IFileSystem } from 'just-bash';
+
+// Mock the provider-settings module so the command exercises its
+// public surface (getExtraOAuthDomains / setExtraOAuthDomainsAsync /
+// getAllExtraOAuthDomains) without touching real localStorage. This
+// is the layer that issue #701 broke: the command was calling the
+// sync `setExtraOAuthDomains` from the kernel worker and the writes
+// disappeared. Locking the command-level call shape to the async
+// setter prevents a future refactor from dropping the `await` and
+// re-introducing the same bug silently.
+vi.mock('../../../src/ui/provider-settings.js', () => ({
+  getExtraOAuthDomains: vi.fn(),
+  setExtraOAuthDomainsAsync: vi.fn(),
+  getAllExtraOAuthDomains: vi.fn(),
+}));
+
+import { createOAuthDomainCommand } from '../../../src/shell/supplemental-commands/oauth-domain-command.js';
+import {
+  getExtraOAuthDomains,
+  setExtraOAuthDomainsAsync,
+  getAllExtraOAuthDomains,
+} from '../../../src/ui/provider-settings.js';
+
+const mockGetExtraOAuthDomains = vi.mocked(getExtraOAuthDomains);
+const mockSetExtraOAuthDomainsAsync = vi.mocked(setExtraOAuthDomainsAsync);
+const mockGetAllExtraOAuthDomains = vi.mocked(getAllExtraOAuthDomains);
+
+function createMockCtx() {
+  const fs: Partial<IFileSystem> = {
+    resolvePath: (base: string, path: string) => (path.startsWith('/') ? path : `${base}/${path}`),
+  };
+  return {
+    fs: fs as IFileSystem,
+    cwd: '/home',
+    env: new Map<string, string>(),
+    stdin: '',
+  };
+}
+
+describe('oauth-domain command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetExtraOAuthDomains.mockReturnValue([]);
+    mockGetAllExtraOAuthDomains.mockReturnValue({});
+    mockSetExtraOAuthDomainsAsync.mockResolvedValue(undefined);
+  });
+
+  it('has correct name', () => {
+    expect(createOAuthDomainCommand().name).toBe('oauth-domain');
+  });
+
+  it('--help and no-args both print help', async () => {
+    const cmd = createOAuthDomainCommand();
+    const help = await cmd.execute(['--help'], createMockCtx());
+    expect(help.exitCode).toBe(0);
+    expect(help.stdout).toContain('oauth-domain');
+    const noArgs = await cmd.execute([], createMockCtx());
+    expect(noArgs.stdout).toContain('oauth-domain');
+  });
+
+  describe('list', () => {
+    it('list <provider> returns the domains', async () => {
+      mockGetExtraOAuthDomains.mockReturnValue(['admin.hlx.page', '*.aem.page']);
+      const result = await createOAuthDomainCommand().execute(['list', 'adobe'], createMockCtx());
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('admin.hlx.page\n*.aem.page\n');
+      expect(mockGetExtraOAuthDomains).toHaveBeenCalledWith('adobe');
+    });
+
+    it('list <provider> says no extras when empty', async () => {
+      const result = await createOAuthDomainCommand().execute(['list', 'adobe'], createMockCtx());
+      expect(result.stdout).toBe('(no extra domains configured for adobe)\n');
+    });
+
+    it('list (no provider) shows all configured providers', async () => {
+      mockGetAllExtraOAuthDomains.mockReturnValue({
+        adobe: ['admin.hlx.page'],
+        github: ['hub.example.com'],
+      });
+      const result = await createOAuthDomainCommand().execute(['list'], createMockCtx());
+      expect(result.stdout).toBe('adobe: admin.hlx.page\ngithub: hub.example.com\n');
+    });
+  });
+
+  describe('add — routes through the async setter (issue #701)', () => {
+    it('add <provider> <domain> appends and awaits the async setter', async () => {
+      mockGetExtraOAuthDomains.mockReturnValue(['existing.example.com']);
+      const result = await createOAuthDomainCommand().execute(
+        ['add', 'adobe', 'admin.hlx.page'],
+        createMockCtx()
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Added admin.hlx.page');
+      // Key assertion: the command MUST call setExtraOAuthDomainsAsync,
+      // not the sync setExtraOAuthDomains. The bug at issue #701 was a
+      // sync call from the worker that silently no-op'd because the
+      // worker-shim doesn't echo back to the page.
+      expect(mockSetExtraOAuthDomainsAsync).toHaveBeenCalledWith('adobe', [
+        'existing.example.com',
+        'admin.hlx.page',
+      ]);
+    });
+
+    it('add is idempotent on duplicate (case-insensitive)', async () => {
+      mockGetExtraOAuthDomains.mockReturnValue(['ADMIN.HLX.PAGE']);
+      const result = await createOAuthDomainCommand().execute(
+        ['add', 'adobe', 'admin.hlx.page'],
+        createMockCtx()
+      );
+      expect(result.stdout).toContain('already in adobe extras');
+      expect(mockSetExtraOAuthDomainsAsync).not.toHaveBeenCalled();
+    });
+
+    it('add propagates async-setter failure to stderr + exit 1', async () => {
+      mockSetExtraOAuthDomainsAsync.mockRejectedValue(new Error('panel-rpc unreachable'));
+      const result = await createOAuthDomainCommand().execute(
+        ['add', 'adobe', 'admin.hlx.page'],
+        createMockCtx()
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('panel-rpc unreachable');
+    });
+
+    it('add requires both provider and domain', async () => {
+      const result = await createOAuthDomainCommand().execute(['add', 'adobe'], createMockCtx());
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('requires');
+      expect(mockSetExtraOAuthDomainsAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove — routes through the async setter (issue #701)', () => {
+    it('remove drops the matching domain and awaits the async setter', async () => {
+      mockGetExtraOAuthDomains.mockReturnValue(['admin.hlx.page', '*.aem.page']);
+      const result = await createOAuthDomainCommand().execute(
+        ['remove', 'adobe', 'admin.hlx.page'],
+        createMockCtx()
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Removed admin.hlx.page');
+      expect(mockSetExtraOAuthDomainsAsync).toHaveBeenCalledWith('adobe', ['*.aem.page']);
+    });
+
+    it("remove is a no-op when the domain isn't present", async () => {
+      mockGetExtraOAuthDomains.mockReturnValue(['other.example.com']);
+      const result = await createOAuthDomainCommand().execute(
+        ['remove', 'adobe', 'admin.hlx.page'],
+        createMockCtx()
+      );
+      expect(result.stdout).toContain('not found');
+      expect(mockSetExtraOAuthDomainsAsync).not.toHaveBeenCalled();
+    });
+
+    it('remove requires both provider and domain', async () => {
+      const result = await createOAuthDomainCommand().execute(['remove', 'adobe'], createMockCtx());
+      expect(result.exitCode).toBe(1);
+      expect(mockSetExtraOAuthDomainsAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clear — routes through the async setter (issue #701)', () => {
+    it('clear empties the extras for the provider via the async setter', async () => {
+      const result = await createOAuthDomainCommand().execute(['clear', 'adobe'], createMockCtx());
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Cleared');
+      expect(mockSetExtraOAuthDomainsAsync).toHaveBeenCalledWith('adobe', []);
+    });
+
+    it('clear requires a provider', async () => {
+      const result = await createOAuthDomainCommand().execute(['clear'], createMockCtx());
+      expect(result.exitCode).toBe(1);
+      expect(mockSetExtraOAuthDomainsAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects unknown subcommands', async () => {
+    const result = await createOAuthDomainCommand().execute(['frobnicate'], createMockCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unknown subcommand');
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/oauth-domain-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/oauth-domain-command.test.ts
@@ -152,6 +152,20 @@ describe('oauth-domain command', () => {
       expect(mockSetExtraOAuthDomainsAsync).not.toHaveBeenCalled();
     });
 
+    it('remove propagates async-setter failure to stderr + exit 1', async () => {
+      // Dropped-`await` regression guard: without `await`, the
+      // rejection becomes an unhandled promise and the command
+      // returns exitCode: 0 — this assertion would then fail.
+      mockGetExtraOAuthDomains.mockReturnValue(['admin.hlx.page']);
+      mockSetExtraOAuthDomainsAsync.mockRejectedValue(new Error('panel-rpc unreachable'));
+      const result = await createOAuthDomainCommand().execute(
+        ['remove', 'adobe', 'admin.hlx.page'],
+        createMockCtx()
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('panel-rpc unreachable');
+    });
+
     it('remove requires both provider and domain', async () => {
       const result = await createOAuthDomainCommand().execute(['remove', 'adobe'], createMockCtx());
       expect(result.exitCode).toBe(1);
@@ -165,6 +179,15 @@ describe('oauth-domain command', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Cleared');
       expect(mockSetExtraOAuthDomainsAsync).toHaveBeenCalledWith('adobe', []);
+    });
+
+    it('clear propagates async-setter failure to stderr + exit 1', async () => {
+      // Dropped-`await` regression guard — see the `remove` variant
+      // above for rationale.
+      mockSetExtraOAuthDomainsAsync.mockRejectedValue(new Error('panel-rpc unreachable'));
+      const result = await createOAuthDomainCommand().execute(['clear', 'adobe'], createMockCtx());
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('panel-rpc unreachable');
     });
 
     it('clear requires a provider', async () => {

--- a/packages/webapp/tests/ui/panel-rpc-handlers.test.ts
+++ b/packages/webapp/tests/ui/panel-rpc-handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { createStandalonePanelRpcHandlers } from '../../src/ui/panel-rpc-handlers.js';
 import type { LeaderTrayRuntimeStatus } from '../../src/scoops/tray-leader.js';
@@ -61,5 +61,90 @@ describe('createStandalonePanelRpcHandlers — tray-reset', () => {
       },
     });
     await expect(handlers['tray-reset']!(undefined)).rejects.toThrow(/tray worker unreachable/);
+  });
+});
+
+/**
+ * `oauth-extras-set` is the panel-RPC op that lets a worker-side
+ * `oauth-domain` write reach real page `localStorage`. The handler
+ * delegates to `setExtraOAuthDomains` (which writes through
+ * `sharedWriteOAuthExtras`) and echoes the post-write store back so
+ * the worker can mirror it into its shim before resolving — the
+ * page→worker storage forward runs on a different channel and offers
+ * no ordering guarantee against the panel-rpc response.
+ */
+describe('createStandalonePanelRpcHandlers — oauth-extras-set', () => {
+  let lsData: Record<string, string>;
+  let originalLocalStorage: Storage;
+
+  beforeEach(() => {
+    originalLocalStorage = globalThis.localStorage;
+    lsData = {};
+    (globalThis as { localStorage: Storage }).localStorage = {
+      get length(): number {
+        return Object.keys(lsData).length;
+      },
+      key: (i: number) => Object.keys(lsData)[i] ?? null,
+      getItem: (k: string) => lsData[k] ?? null,
+      setItem: (k: string, v: string) => {
+        lsData[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete lsData[k];
+      },
+      clear: () => {
+        for (const k of Object.keys(lsData)) delete lsData[k];
+      },
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as { localStorage: Storage }).localStorage = originalLocalStorage;
+  });
+
+  it('writes the extras through to localStorage and returns the merged store', async () => {
+    const handlers = createStandalonePanelRpcHandlers({});
+    const handler = handlers['oauth-extras-set'];
+    expect(handler).toBeTypeOf('function');
+    const result = await handler!({
+      providerId: 'adobe',
+      domains: ['admin.hlx.page', '*.aem.page'],
+    });
+    expect(result).toEqual({ store: { adobe: ['admin.hlx.page', '*.aem.page'] } });
+    // Real-localStorage write fired through to the underlying map —
+    // this is the assertion that the bug at issue #701 (writes
+    // never leaving the worker's shim) is fixed.
+    expect(lsData.slicc_oauth_extra_domains).toBe(
+      JSON.stringify({ adobe: ['admin.hlx.page', '*.aem.page'] })
+    );
+  });
+
+  it('preserves other providers and overwrites the targeted one', async () => {
+    lsData.slicc_oauth_extra_domains = JSON.stringify({
+      adobe: ['old.example.com'],
+      github: ['hub.example.com'],
+    });
+    const handlers = createStandalonePanelRpcHandlers({});
+    const result = await handlers['oauth-extras-set']!({
+      providerId: 'adobe',
+      domains: ['new.example.com'],
+    });
+    expect(result.store).toEqual({
+      adobe: ['new.example.com'],
+      github: ['hub.example.com'],
+    });
+  });
+
+  it('empty domains array drops the provider entry', async () => {
+    lsData.slicc_oauth_extra_domains = JSON.stringify({
+      adobe: ['admin.hlx.page'],
+      github: ['hub.example.com'],
+    });
+    const handlers = createStandalonePanelRpcHandlers({});
+    const result = await handlers['oauth-extras-set']!({
+      providerId: 'adobe',
+      domains: [],
+    });
+    expect(result.store).toEqual({ github: ['hub.example.com'] });
   });
 });

--- a/packages/webapp/tests/ui/panel-rpc-handlers.test.ts
+++ b/packages/webapp/tests/ui/panel-rpc-handlers.test.ts
@@ -110,7 +110,7 @@ describe('createStandalonePanelRpcHandlers — oauth-extras-set', () => {
       providerId: 'adobe',
       domains: ['admin.hlx.page', '*.aem.page'],
     });
-    expect(result).toEqual({ store: { adobe: ['admin.hlx.page', '*.aem.page'] } });
+    expect(result).toEqual({ storeAfter: { adobe: ['admin.hlx.page', '*.aem.page'] } });
     // Real-localStorage write fired through to the underlying map —
     // this is the assertion that the bug at issue #701 (writes
     // never leaving the worker's shim) is fixed.
@@ -129,7 +129,7 @@ describe('createStandalonePanelRpcHandlers — oauth-extras-set', () => {
       providerId: 'adobe',
       domains: ['new.example.com'],
     });
-    expect(result.store).toEqual({
+    expect(result.storeAfter).toEqual({
       adobe: ['new.example.com'],
       github: ['hub.example.com'],
     });
@@ -145,6 +145,6 @@ describe('createStandalonePanelRpcHandlers — oauth-extras-set', () => {
       providerId: 'adobe',
       domains: [],
     });
-    expect(result.store).toEqual({ github: ['hub.example.com'] });
+    expect(result.storeAfter).toEqual({ github: ['hub.example.com'] });
   });
 });


### PR DESCRIPTION
## Summary

- Worker-side `oauth-domain` writes now reach real page `localStorage` via a new `oauth-extras-set` panel-rpc op — they were silently swallowed by the kernel-worker's Map shim and lost on reload (issue #701).
- New `setExtraOAuthDomainsAsync` in `provider-settings.ts` picks page-direct vs bridge based on `hasLocalDom()` and mirrors the page-side store back into the worker shim before resolving, so same-session `oauth-domain list` stays consistent without racing the cross-channel `local-storage-set` forward.
- Sync helpers (`setExtraOAuthDomains`, `getExtraOAuthDomains`, `getAllExtraOAuthDomains`) are unchanged — the chrome-extension options page still uses them directly because it writes from real page context.

Closes #701.

## Root cause

`packages/webapp/src/kernel/page-storage-sync.ts` and `kernel-worker.ts:113-117` are explicit that the shim is page→worker only:

> *Writes from the worker only stay in the worker's Map and don't propagate back to the page (changes to model/provider come FROM the page, so the worker just needs to read).*

`oauth-domain add` ran in the kernel-worker shell, calling the sync `setExtraOAuthDomains`, which wrote `slicc_oauth_extra_domains` to the worker shim. Page `localStorage` never saw the write; on reload the worker was re-seeded from the (still-empty) page snapshot and `oauth-bootstrap` POSTed only the immutable provider defaults to `/api/secrets/oauth-update`. User-added hosts (e.g. `admin.hlx.page`) never reached the fetch-proxy and the next masked-Bearer request hit a `403 Secret oauth.adobe.token is not allowed for domain <host>`.

## Why the mirror-back

`page-storage-sync` forwards the page-side `setItem` to the worker via a different transport than the panel-rpc response. Without an explicit mirror in `setExtraOAuthDomainsAsync`, a `oauth-domain add X && oauth-domain list X` sequence could race the two channels and surface stale data. The page handler returns the post-write store; the worker `writeOAuthExtras` against its own shim before resolving so reads after the await are always consistent. The duplicate forward that arrives later from `installPageStorageSync` is idempotent.

## Test plan

- [x] `npm run typecheck` (all 4 tsconfigs)
- [x] `npm run test` — 4677 passed, 3 skipped, 0 failed
- [x] `npm run test:coverage:webapp` — 65–67% all metrics, well above 50/40/50/50 floors
- [x] `npx prettier --check .`
- [x] Builds: `@slicc/webapp`, `@slicc/node-server`, `@slicc/chrome-extension`, `@slicc/cloudflare-worker`
- [ ] `@slicc/swift-server` build skipped locally — environmental `swift-log 1.12.0` needs Swift tools ≥6.2.0; CI has a current toolchain
- [x] 6 new unit tests — covers handler write-through, multi-provider preservation, empty-list-deletes-entry, DOM-path passthrough, no-DOM bridge round-trip with mirror-back, no-bridge error

## Manual verification path (post-merge)

In CLI float (`npm run dev`), from the panel terminal:

```
> oauth-domain add adobe admin.hlx.page
Added admin.hlx.page to adobe. Reload the page to apply.

> oauth-domain list adobe
admin.hlx.page

# Without reload — confirm page localStorage was updated:
# Page devtools console:
# > localStorage.getItem('slicc_oauth_extra_domains')
# '{"adobe":["admin.hlx.page"]}'

# After reload:
> oauth-domain list adobe
admin.hlx.page          # was returning "(no extra domains…)" before the fix

> curl -s http://localhost:5710/api/secrets/masked | jq '.[] | select(.name=="oauth.adobe.token") | .domains'
[ "ims-na1.adobelogin.com", … , "admin.hlx.page" ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)