### PR TITLE
fix(swift-launcher): refresh Electron app state when Sliccstart regains focus

### DIFF
--- a/packages/swift-launcher/README.md
+++ b/packages/swift-launcher/README.md
@@ -68,7 +68,9 @@ and build the native server: `cd packages/swift-server && swift build`
   If the app is already running without a known SLICC debug port, Sliccstart
   offers to restart it with remote debugging enabled. If a previously launched
   Electron app exits, Sliccstart clears the stale running state on the next
-  refresh/click so it can be started again.
+  refresh/click so it can be started again. Status dots are refreshed
+  periodically while Sliccstart is open and again whenever Sliccstart regains
+  focus, so quitting an Electron app externally updates the row promptly.
 - **Get extension**: Opens the Chrome Web Store listing to install the
   SLICC extension directly — no Developer Mode required.
 - **Update**: Pulls latest SLICC changes and rebuilds with one click.

--- a/packages/swift-launcher/Sliccstart/SliccstartApp.swift
+++ b/packages/swift-launcher/Sliccstart/SliccstartApp.swift
@@ -107,6 +107,10 @@ struct SliccstartApp: App {
                 guard isReady else { return }
                 sliccProcess.refreshRuntimeStates(for: targets)
             }
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+                guard isReady else { return }
+                sliccProcess.refreshRuntimeStates(for: targets)
+            }
             .onChange(of: appManagementPermission.isGranted) {
                 // Re-scan when permission is granted so Electron apps appear
                 if isReady {


### PR DESCRIPTION
## Summary

Follow-up to #686.

Without this, quitting an Electron app externally (e.g., closing Slack via Cmd-Q) and switching back to Sliccstart would leave the row showing a stale running state until the next 2s timer tick. Observe `NSApplication.didBecomeActiveNotification` to refresh runtime state immediately on focus return.

## Changes

- `SliccstartApp.swift`: add `.onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))` that calls `sliccProcess.refreshRuntimeStates(for: targets)` when `isReady`.
- `README.md`: document the focus-driven refresh behavior.

## Verification

- `swift build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` (46 tests passed)
- `npx prettier --check packages/swift-launcher/README.md`
