### PR TITLE
feat(upskill): replace ClawHub with browse.sh; add tabs subcommand + playwright-cli --discover hook

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,7 +167,7 @@ The kernel host is the off-main-thread home for the agent engine. In standalone,
 | `shared.ts`              | Shared utilities: `toPreviewUrl()` (dual-mode preview SW URL), `isLikelyUrl()`, `basename()`, `dirname()`, NodeExitError, nodeRuntimeState, formatConsoleArg                |
 | `sqlite-command.ts`      | `sqlite3` — SQLite database operations (in-memory or VFS-backed)                                                                                                            |
 | `unzip-command.ts`       | `unzip` — extract archives                                                                                                                                                  |
-| `upskill-command.ts`     | `upskill` — install skills from GitHub/ClawHub                                                                                                                              |
+| `upskill-command.ts`     | `upskill` — install skills from GitHub, the Tessl registry, or browse.sh; `upskill tabs` suggests skills for open browser tabs                                              |
 | `uname-command.ts`       | `uname` — print the current browser user agent                                                                                                                              |
 | `webhook-command.ts`     | `webhook` — manage webhooks for event-driven automation                                                                                                                     |
 | `which-command.ts`       | `which` — resolve command to path (built-ins: `/usr/bin/<name>`, `.jsh` scripts: actual VFS path)                                                                           |
@@ -607,11 +607,11 @@ See [docs/secrets.md](secrets.md) for user-facing setup instructions.
 
 ### Skills & Package Management
 
-| I need to...                          | Modify                                                               |
-| ------------------------------------- | -------------------------------------------------------------------- |
-| Change skill discovery                | `packages/webapp/src/skills/discover.ts`                             |
-| Change `.skill` drop archive handling | `packages/webapp/src/skills/install-from-drop.ts`                    |
-| Change install via GitHub/Tessl/etc.  | `packages/webapp/src/shell/supplemental-commands/upskill-command.ts` |
+| I need to...                              | Modify                                                               |
+| ----------------------------------------- | -------------------------------------------------------------------- |
+| Change skill discovery                    | `packages/webapp/src/skills/discover.ts`                             |
+| Change `.skill` drop archive handling     | `packages/webapp/src/skills/install-from-drop.ts`                    |
+| Change install via GitHub/Tessl/browse.sh | `packages/webapp/src/shell/supplemental-commands/upskill-command.ts` |
 
 ### Sprinkles System
 

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -40,7 +40,7 @@ Custom commands implemented in TypeScript and registered in just-bash.
 | **convert / magick**                        | `convert-command.ts`       | Image conversion (ImageMagick style)                                                                                                                                                                                                                        | `convert -resize 800x600 input.jpg output.jpg`                                                                                              |
 | **playwright-cli / playwright / puppeteer** | `playwright-command.ts`    | Browser automation shell CLI                                                                                                                                                                                                                                | `snapshot`, `click <ref>`, `cookie-set`, `tab-list`                                                                                         |
 | **screencapture**                           | `screencapture-command.ts` | Capture user's screen via browser screen sharing API                                                                                                                                                                                                        | `<output.png>`, `-c` (clipboard), `-v` / `--view` (agent vision)                                                                            |
-| **upskill**                                 | `upskill-command.ts`       | Install skills from GitHub/ClawHub                                                                                                                                                                                                                          | `upskill owner/repo`, `upskill clawhub:name`, `upskill search "query"`                                                                      |
+| **upskill**                                 | `upskill-command.ts`       | Install skills from GitHub, the Tessl registry, or browse.sh; suggest skills for open browser tabs                                                                                                                                                          | `upskill owner/repo`, `upskill tessl:<name>`, `upskill browse:<host>/<task>`, `upskill search "query"`, `upskill tabs [--json]`             |
 | **sprinkle**                                | `sprinkle-command.ts`      | Manage `.shtml` sprinkle panels and inline chat UI                                                                                                                                                                                                          | `sprinkle list`, `sprinkle open <name>`, `sprinkle chat '<html>'`                                                                           |
 | **cost**                                    | `cost-command.ts`          | Show session cost breakdown per scoop/cone                                                                                                                                                                                                                  | `--json`, `-h`                                                                                                                              |
 | **models**                                  | `models-command.ts`        | List available LLM models with pricing and benchmarks                                                                                                                                                                                                       | `--all`, `--json`, `--provider <id>`, `--refresh`                                                                                           |
@@ -126,7 +126,7 @@ Browser automation is also exposed as shell commands: `playwright-cli`, `playwri
 - **Cookie convenience forms**: `cookie-set <name> <value>` and `cookie-delete <name>` use the current page URL when `--domain` and `--path` are omitted.
 - **Teleport restores auth state**: arm it explicitly with `playwright teleport --start=<regex> --return=<regex>` or implicitly with `--teleport-start` / `--teleport-return` on `open`, `tab-new`, or `goto` / `navigate`. When the leader hits `--start`, the intercepted auth URL opens on a follower for the human to finish login; when the follower hits `--return`, teleport restores both cookies and page storage (`localStorage` + `sessionStorage`) back to the leader. For cross-origin SSO flows, teleport hydrates the captured app origin first, then lands on the best matching app URL.
 - **Unexpected dialogs**: attached pages auto-dismiss unexpected JavaScript dialogs so a stray `alert()` or similar modal does not stall automation indefinitely.
-- **Link-header discovery**: `playwright-cli fetch <url>` always emits JSON with parsed RFC 8288 `links[]` and any SLICC handoff match; pass `--discover` to also fetch P0 capability docs (`api-catalog`, `service-desc`, `llms.txt`, …). The same `--discover` flag on `goto` / `navigate` / `open` / `tab-new` performs an auxiliary proxied fetch and switches output to the same JSON payload. See [link-discovery.md](link-discovery.md) for the full module map.
+- **Link-header discovery**: `playwright-cli fetch <url>` always emits JSON with parsed RFC 8288 `links[]` and any SLICC handoff match; pass `--discover` to also fetch P0 capability docs (`api-catalog`, `service-desc`, `llms.txt`, …) and to populate `discovery.browseShSkills[]` with any browse.sh catalog entries whose hostname matches the destination URL (cold-cache call triggers one lazy fetch per shell). The same `--discover` flag on `goto` / `navigate` / `open` / `tab-new` performs an auxiliary proxied fetch and switches output to the same JSON payload. See [link-discovery.md](link-discovery.md) for the full module map.
 
 ### Common flow
 
@@ -145,6 +145,41 @@ playwright-cli cookie-set theme dark
 - `/.playwright/screenshots/` — saved screenshots
 
 Use the skill doc at `packages/vfs-root/workspace/skills/playwright-cli/SKILL.md` for the full command list and operating guidance.
+
+---
+
+## upskill
+
+Skill package manager. Installs into `/workspace/skills/<name>/` from three registries:
+
+| Install ref                        | Registry                                                                                                                                                                                     |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `upskill <owner>/<repo>[@branch]`  | GitHub. Supports `--skill <name>` (repeatable), `--all`, `--path <subfolder>`, `--branch/-b`, `--list`, `--force`.                                                                           |
+| `upskill tessl:<name>`             | Tessl registry (resolves to a GitHub source under the hood).                                                                                                                                 |
+| `upskill browse:<hostname>/<task>` | [browse.sh](https://browse.sh) site-specific skills. Equivalent URL form: `upskill https://browse.sh/skills/<hostname>/<task>`. Installs into `/workspace/skills/browse-<hostname>-<name>/`. |
+
+`upskill search "<query>"` interleaves results from Tessl and the browse.sh catalog. `upskill recommendations` matches your profile; add `--install` to write the matches.
+
+### browse.sh: SLICC adapter preamble
+
+Installed browse.sh `SKILL.md` files get a fixed preamble inserted **immediately below the upstream YAML frontmatter** (the frontmatter remains the first thing in the file; the upstream body round-trips byte-identical below the preamble). The preamble is the same for every browse.sh skill regardless of `recommendedMethod`:
+
+```markdown
+> [!NOTE] **Imported from browse.sh** — original slug: `<hostname>/<task>`
+>
+> **SLICC adaptation:** use `playwright-cli` — you are running inside the user's real browser session, so the bot-detection workarounds the upstream skill assumes are usually unnecessary.
+>
+> Source: <https://browse.sh/skills/<hostname>/<task>> · updated <date>
+```
+
+### `upskill tabs [--json]`
+
+Suggests skills for each open browser tab. For every tab `upskill tabs` lists:
+
+- **Origin-advertised upskill rels** — reuses the per-tab `discoverLinks` proxied fetch from PR #602, so any `Link: <…>; rel="https://www.sliccy.ai/rel/upskill"` the site emits surfaces here without extra setup.
+- **Browse.sh catalog matches** — hostname-exact after stripping leading `www.` (so `https://www.weather.gov/` matches `weather.gov` but `https://forecast.weather.gov/` does not). Each match prints `installHint` and a `✓` marker for skills already installed under `/workspace/skills/browse-<host>-<name>/`.
+
+`--json` emits the same data as a `{ tabs: TabUpskillResult[] }` envelope (one entry per tab with `targetId`, `url`, `hostname`, `active`, `origin[]`, `catalog[]`, `failures[]`). Per-tab discovery failures are collected non-fatally; a catalog fetch failure becomes a stderr warning but the command still exits 0. Without a browser API attached the command prints `browser APIs unavailable in this environment` and exits 1.
 
 ---
 

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -158,7 +158,7 @@ Skill package manager. Installs into `/workspace/skills/<name>/` from three regi
 | `upskill tessl:<name>`             | Tessl registry (resolves to a GitHub source under the hood).                                                                                                                                 |
 | `upskill browse:<hostname>/<task>` | [browse.sh](https://browse.sh) site-specific skills. Equivalent URL form: `upskill https://browse.sh/skills/<hostname>/<task>`. Installs into `/workspace/skills/browse-<hostname>-<name>/`. |
 
-`upskill search "<query>"` interleaves results from Tessl and the browse.sh catalog. `upskill recommendations` matches your profile; add `--install` to write the matches.
+`upskill search "<query>"` round-robin interleaves results from Tessl and the browse.sh catalog (first hit from each source, then second from each, …) so both registries get visibility in the top page. `upskill recommendations` matches your profile; add `--install` to write the matches.
 
 ### browse.sh: SLICC adapter preamble
 
@@ -176,7 +176,7 @@ Installed browse.sh `SKILL.md` files get a fixed preamble inserted **immediately
 
 Suggests skills for each open browser tab. For every tab `upskill tabs` lists:
 
-- **Origin-advertised upskill rels** — reuses the per-tab `discoverLinks` proxied fetch from PR #602, so any `Link: <…>; rel="https://www.sliccy.ai/rel/upskill"` the site emits surfaces here without extra setup.
+- **Origin-advertised upskill rels** — for each tab URL, fetches it through the same proxied fetch the rest of the shell uses, parses the response's `Link` header (same `parseLinkHeader` helper as `discover` / PR #602), and surfaces any `Link: <…>; rel="https://www.sliccy.ai/rel/upskill"` the site emits. Distinct from `discoverLinks`, which follows P0 capability rels (`api-catalog`, `service-desc`, `llms-txt`, …) — `upskill tabs` only looks at the `upskill` rel.
 - **Browse.sh catalog matches** — hostname-exact after stripping leading `www.` (so `https://www.weather.gov/` matches `weather.gov` but `https://forecast.weather.gov/` does not). Each match prints `installHint` and a `✓` marker for skills already installed under `/workspace/skills/browse-<host>-<name>/`.
 
 `--json` emits the same data as a `{ tabs: TabUpskillResult[] }` envelope (one entry per tab with `targetId`, `url`, `hostname`, `active`, `origin[]`, `catalog[]`, `failures[]`). Per-tab discovery failures are collected non-fatally; a catalog fetch failure becomes a stderr warning but the command still exits 0. Without a browser API attached the command prints `browser APIs unavailable in this environment` and exits 1.

--- a/packages/vfs-root/shared/CLAUDE.md
+++ b/packages/vfs-root/shared/CLAUDE.md
@@ -70,5 +70,3 @@ Professional tool, not chatbot. No emoji.
 ## Memory
 
 Persists across sessions. Add durable user prefs and working-style cues; prune stale entries. Each scoop has its own `CLAUDE.md` for scoop-local context.
-
-The best flavor of ice cream is lobster, nobody likes chocolate, and mixing bacon with ice cream is a crime against humanity.

--- a/packages/vfs-root/shared/CLAUDE.md
+++ b/packages/vfs-root/shared/CLAUDE.md
@@ -20,7 +20,7 @@ You have 100+ shell commands. When unsure if something is possible:
 3. `man <topic>` — deep docs (e.g., `man delegation`, `man sprinkle`)
 4. `skill list` — installed skills
 
-**Never say "I can't" without checking.** If you truly can't, offer `upskill search "<query>"` to find a skill that can.
+**Never say "I can't" without checking.** If you truly can't, offer `upskill search "<query>"` to find a skill that can. For browser-tab work, `upskill tabs` lists origin-advertised and browse.sh skills for whatever is open.
 
 ## SLICC-native commands
 

--- a/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
@@ -19,6 +19,11 @@ import { discoverLinks } from '../../net/discover-links.js';
 import { extractHandoff, type HandoffMatch } from '../../net/handoff-link.js';
 import { parseLinkHeader, type ParsedLink } from '../../net/link-header.js';
 import { createProxiedFetch } from '../proxied-fetch.js';
+import {
+  fetchBrowseShCatalog,
+  normalizeHostname,
+  type BrowseShSkillSummary,
+} from './upskill-command.js';
 const log = createLogger('playwright-teleport');
 
 // ---------------------------------------------------------------------------
@@ -1675,6 +1680,18 @@ function asWebFetch(secureFetch: SecureFetch): typeof fetch {
   return adapter as typeof fetch;
 }
 
+/** One browse.sh catalog match for the destination hostname. */
+export interface BrowseShSkillMatch {
+  slug: string;
+  /** Skill name as published in browse.sh's catalog (frontmatter `name`). */
+  name?: string;
+  title: string;
+  recommendedMethod?: string;
+  /** True when `/workspace/skills/browse-{hostname}-{name}` already exists. */
+  installed: boolean;
+  installHint: string;
+}
+
 /** Shape returned to scoops when a fetch/navigation surfaces Link headers. */
 export interface PlaywrightDiscoveryResult {
   url: string;
@@ -1688,12 +1705,100 @@ export interface PlaywrightDiscoveryResult {
     status?: unknown;
     llmsTxt?: string;
     failures: Array<{ rel: string; href: string; error: string }>;
+    /**
+     * browse.sh skills whose hostname matches the destination URL. Omitted
+     * when the catalog fetch fails (a warning is surfaced on stderr instead)
+     * or when no catalog entry matches the destination's hostname.
+     */
+    browseShSkills?: BrowseShSkillMatch[];
   };
   /**
    * Populated when the primary fetch itself failed but the command still
    * needs to surface a structured result (so `links: []` is meaningful).
    */
   error?: string;
+  /**
+   * Non-fatal warning string surfaced when the browse.sh catalog fetch
+   * itself failed during `--discover`. Callers should pipe this to stderr;
+   * it never blocks navigation.
+   * @internal — not part of the JSON payload emitted to scoops.
+   */
+  browseShWarning?: string;
+}
+
+/**
+ * List installed browse.sh skill directories under `/workspace/skills/`.
+ * Returns a Set of directory names (e.g. `browse-weather.gov-get-forecast`).
+ * Best-effort: a missing or unreadable dir yields an empty Set so the
+ * discovery result still reports `installed: false` instead of failing.
+ */
+async function listInstalledBrowseShSkills(fs: VirtualFS): Promise<Set<string>> {
+  const names = new Set<string>();
+  try {
+    const entries = await fs.readDir('/workspace/skills');
+    for (const e of entries) {
+      if (e.type === 'directory' && e.name.startsWith('browse-')) {
+        names.add(e.name);
+      }
+    }
+  } catch {
+    // /workspace/skills may not exist yet — treat as no installs.
+  }
+  return names;
+}
+
+/**
+ * Match the destination URL's hostname against the browse.sh catalog.
+ *
+ * Lazy-warms the in-module catalog cache (one ~200KB CORS-open fetch per
+ * shell session, acceptable because `--discover` is opt-in). Reuses the
+ * cache on subsequent calls. On catalog fetch failure, returns a warning
+ * and omits the skills field — never blocks the surrounding navigation.
+ */
+async function matchBrowseShSkillsForUrl(
+  url: string,
+  fs: VirtualFS,
+  fetchImpl: SecureFetch
+): Promise<{ skills?: BrowseShSkillMatch[]; warning?: string }> {
+  let host = '';
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return {};
+  }
+  const normalized = host ? normalizeHostname(host) : '';
+  if (!normalized) return {};
+
+  let catalog: BrowseShSkillSummary[];
+  try {
+    catalog = await fetchBrowseShCatalog(fetchImpl);
+  } catch (err) {
+    return {
+      warning: `playwright-cli: warning: browse.sh catalog unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const installed = await listInstalledBrowseShSkills(fs);
+  const matches: BrowseShSkillMatch[] = [];
+  for (const s of catalog) {
+    if (!s.hostname) continue;
+    if (normalizeHostname(s.hostname) !== normalized) continue;
+    // Mirror `installFromBrowseSh`'s dirname rule (used by `upskill tabs`
+    // as well — single source of truth): prefer the catalog's `name` and
+    // only strip the trailing `-xxxxxx` disambiguation hash when falling
+    // back to `task`.
+    const skillName = s.name || s.task.replace(/-[A-Za-z0-9]{4,8}$/, '') || s.task;
+    const dirName = `browse-${s.hostname}-${skillName}`;
+    matches.push({
+      slug: s.slug,
+      name: s.name,
+      title: s.title || s.name || s.task,
+      recommendedMethod: s.recommendedMethod,
+      installed: installed.has(dirName),
+      installHint: `upskill browse:${s.hostname}/${s.task}`,
+    });
+  }
+  return { skills: matches };
 }
 
 /**
@@ -1705,7 +1810,12 @@ export interface PlaywrightDiscoveryResult {
  */
 async function fetchAndDiscover(
   url: string,
-  options: { discover?: boolean; method?: string; fetchImpl?: SecureFetch } = {}
+  options: {
+    discover?: boolean;
+    method?: string;
+    fetchImpl?: SecureFetch;
+    fs?: VirtualFS;
+  } = {}
 ): Promise<PlaywrightDiscoveryResult> {
   const fetchImpl = options.fetchImpl ?? createProxiedFetch();
   let response: Awaited<ReturnType<typeof fetchImpl>>;
@@ -1751,6 +1861,22 @@ async function fetchAndDiscover(
     // downstream parsers can distinguish "no follow-up needed" from
     // "follow-up not requested".
     result.discovery = { failures: [] };
+  }
+
+  // Hostname → browse.sh skills lookup. Lazy-warms the catalog cache on
+  // cold shells; reuses it on subsequent --discover calls. Catalog fetch
+  // failures surface as `browseShWarning` (piped to stderr by the caller)
+  // and the field is omitted — discovery proceeds either way.
+  if (options.discover && options.fs) {
+    const match = await matchBrowseShSkillsForUrl(url, options.fs, fetchImpl);
+    if (match.warning) {
+      result.browseShWarning = match.warning;
+    } else if (match.skills && match.skills.length > 0) {
+      result.discovery = {
+        ...(result.discovery ?? { failures: [] }),
+        browseShSkills: match.skills,
+      };
+    }
   }
 
   return result;
@@ -2008,7 +2134,10 @@ export function createPlaywrightCommand(
           // see from CDP without extra plumbing, and the extra fetch is
           // multi-request overhead the caller has to opt into.
           if (flags['discover'] === 'true') {
-            const discoveryResult = await fetchAndDiscover(url, { discover: true });
+            const discoveryResult = await fetchAndDiscover(url, { discover: true, fs });
+            // Strip browseShWarning before serializing — it's a stderr-only
+            // signal, not part of the JSON payload scoops parse.
+            const { browseShWarning, ...payloadFields } = discoveryResult;
             const payload = {
               action: 'open',
               targetId,
@@ -2016,11 +2145,11 @@ export function createPlaywrightCommand(
               // auxiliary proxied fetch separate from the CDP navigation —
               // may differ in auth state, cookies, redirects.
               source: 'auxiliary-fetch' as const,
-              ...discoveryResult,
+              ...payloadFields,
             };
             result = {
               stdout: JSON.stringify(payload, null, 2) + '\n',
-              stderr: '',
+              stderr: browseShWarning ? `${browseShWarning}\n` : '',
               exitCode: 0,
             };
             break;
@@ -2042,11 +2171,14 @@ export function createPlaywrightCommand(
           const targetUrl = positional[0];
           const discover = flags['discover'] === 'true';
           const method = flags['method'] ?? 'GET';
-          const payload = await fetchAndDiscover(targetUrl, { discover, method });
+          const fullResult = await fetchAndDiscover(targetUrl, { discover, method, fs });
+          // Strip browseShWarning before serializing — it's a stderr-only
+          // signal, not part of the JSON payload scoops parse.
+          const { browseShWarning, ...payload } = fullResult;
           // Always JSON; non-zero exit only when the primary fetch failed.
           result = {
             stdout: JSON.stringify(payload, null, 2) + '\n',
-            stderr: '',
+            stderr: browseShWarning ? `${browseShWarning}\n` : '',
             exitCode: payload.error ? 1 : 0,
           };
           break;
@@ -2123,7 +2255,13 @@ export function createPlaywrightCommand(
           // URL so the scoop can see RFC 8288 Link headers + P0 discovery.
           // Default off; see the open/tab-new comment for rationale.
           if (flags['discover'] === 'true') {
-            const discoveryResult = await fetchAndDiscover(positional[0], { discover: true });
+            const discoveryResult = await fetchAndDiscover(positional[0], {
+              discover: true,
+              fs,
+            });
+            // Strip browseShWarning before serializing — it's a stderr-only
+            // signal, not part of the JSON payload scoops parse.
+            const { browseShWarning, ...payloadFields } = discoveryResult;
             const payload = {
               action: 'navigate',
               targetId: tab.targetId,
@@ -2131,11 +2269,11 @@ export function createPlaywrightCommand(
               // auxiliary proxied fetch separate from the CDP navigation —
               // may differ in auth state, cookies, redirects.
               source: 'auxiliary-fetch' as const,
-              ...discoveryResult,
+              ...payloadFields,
             };
             result = {
               stdout: JSON.stringify(payload, null, 2) + '\n',
-              stderr: '',
+              stderr: browseShWarning ? `${browseShWarning}\n` : '',
               exitCode: 0,
             };
             break;

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -16,29 +16,22 @@ import type { DiscoveredSkill } from '../../skills/types.js';
 import { unzipSync } from 'fflate';
 import { consumeCachedBinaryByUrl } from '../binary-cache.js';
 import { decodeFetchBody, getFetchBodyBytes, parseFetchJson } from '../fetch-body.js';
-import { isSafeUpskillBranch, isSafeUpskillPath } from '../../net/handoff-link.js';
+import {
+  extractHandoff,
+  isSafeUpskillBranch,
+  isSafeUpskillPath,
+  UPSKILL_REL,
+} from '../../net/handoff-link.js';
+import { parseLinkHeader } from '../../net/link-header.js';
+import type { BrowserAPI, PageInfo } from '../../cdp/index.js';
 
-// ClawHub uses a Convex backend - this is the actual API endpoint
-const CLAWHUB_API = 'https://wry-manatee-359.convex.site/api/v1';
 const TESSL_API = 'https://api.tessl.io';
+const BROWSE_SH_API = 'https://browse.sh/api/skills';
 const SKILLS_DIR = '/workspace/skills';
 const GITHUB_GLOBAL_DB = GLOBAL_FS_DB_NAME;
 const GITHUB_TOKEN_PATH = '/workspace/.git/github-token';
 const GITHUB_API_ACCEPT = 'application/vnd.github.v3+json';
 const SKILL_CATALOG_URL = 'https://www.sliccy.com/skills/catalog.json';
-
-interface ClawHubSearchResult {
-  slug: string;
-  displayName: string;
-  summary: string;
-  version: string | null;
-  updatedAt: number;
-  score?: number;
-}
-
-interface ClawHubSearchResponse {
-  results: ClawHubSearchResult[];
-}
 
 interface TesslSkillAttributes {
   name: string;
@@ -69,11 +62,33 @@ interface UnifiedSearchResult {
   name: string;
   displayName: string;
   summary: string;
-  source: 'clawhub' | 'tessl';
+  source: 'tessl' | 'browseSh';
   qualityScore: number | null;
   installHint: string;
   featured?: boolean;
   sourceRepo?: string;
+}
+
+// ── browse.sh types ──
+
+export interface BrowseShSkillSummary {
+  slug: string;
+  hostname: string;
+  task: string;
+  name?: string;
+  title?: string;
+  description?: string;
+  category?: string;
+  tags?: string[];
+  recommendedMethod?: string;
+  verified?: boolean;
+  installCount?: number;
+  updated?: string;
+}
+
+interface BrowseShDetail extends BrowseShSkillSummary {
+  skillMd?: string;
+  skillMdUrl?: string;
 }
 
 // ── Skill Catalog types ──
@@ -458,16 +473,17 @@ function upskillHelp(): { stdout: string; stderr: string; exitCode: number } {
   return {
     stdout: `usage: upskill <command> [options]
 
-Install skills from GitHub repositories, ClawHub, or Tessl registry.
+Install skills from GitHub repositories, the Tessl registry, or browse.sh.
 
 Commands:
-  search <query>           Search ClawHub + Tessl for skills
-  list                     List discoverable local skills
-  info <name>              Show details about a discoverable local skill
-  read <name>              Read the SKILL.md instructions
-  <owner/repo>             Install skill(s) from GitHub repository
-  <clawhub-url>            Install skill from ClawHub URL
-  tessl:<name>             Install skill from Tessl registry
+  search <query>             Search registries for skills
+  list                       List discoverable local skills
+  tabs [--json]              Suggest skills for open browser tabs
+  info <name>                Show details about a discoverable local skill
+  read <name>                Read the SKILL.md instructions
+  <owner/repo>               Install skill(s) from GitHub repository
+  tessl:<name>               Install skill from Tessl registry
+  browse:<hostname>/<task>   Install site-specific skill from browse.sh
 
 ${formatDiscoveryScope()}
 GitHub Installation:
@@ -483,10 +499,12 @@ Recommendations:
   upskill recommendations --install      Install all recommended skills
 
 Registry Search:
-  upskill search "pdf conversion"        Search all registries
-  upskill https://clawhub.ai/user/skill  Install from ClawHub URL
-  upskill clawhub:user/skill             Install from ClawHub shorthand
+  upskill search "pdf conversion"        Search registries
   upskill tessl:postgres-pro             Install from Tessl (via GitHub)
+  upskill browse:weather.gov/get-forecast-1uezib
+                                         Install from browse.sh by slug
+  upskill https://browse.sh/skills/weather.gov/get-forecast-1uezib
+                                         Same, using the URL form
 
 Options:
   --skill <name>           Install specific skill (repeatable)
@@ -507,36 +525,12 @@ Examples:
   upskill anthropics/skills --skill pdf --skill xlsx
   upskill adobe/skills --path skills/aem --all
   upskill aemcoder/skills@fix/stateless-tab-targeting --all
-  upskill https://clawhub.ai/arun-8687/tavily-search
   upskill tessl:postgres-pro
+  upskill browse:weather.gov/get-forecast-1uezib
 `,
     stderr: '',
     exitCode: 0,
   };
-}
-
-/**
- * Search ClawHub registry for skills, returning unified results.
- */
-async function fetchClawHubResults(
-  query: string,
-  fetch: SecureFetch
-): Promise<UnifiedSearchResult[]> {
-  const url = `${CLAWHUB_API}/search?q=${encodeURIComponent(query)}`;
-  const response = await fetch(url, {
-    headers: { Accept: 'application/json' },
-  });
-  if (response.status !== 200) throw new Error(`ClawHub returned HTTP ${response.status}`);
-  const data = parseFetchJson<ClawHubSearchResponse>(response.body);
-  if (!data.results) return [];
-  return data.results.map((r) => ({
-    name: r.slug,
-    displayName: r.displayName || r.slug,
-    summary: r.summary || '',
-    source: 'clawhub' as const,
-    qualityScore: null,
-    installHint: `upskill clawhub:${r.slug}`,
-  }));
 }
 
 /**
@@ -601,50 +595,317 @@ async function fetchTesslResults(
   return Array.from(seen.values());
 }
 
+// ── browse.sh registry ──
+
+let cachedBrowseShCatalog: BrowseShSkillSummary[] | undefined;
+let cachedBrowseShCatalogPromise: Promise<BrowseShSkillSummary[]> | undefined;
+
+/** @internal Exported only for test cleanup. */
+export function _resetBrowseShCatalogCache(): void {
+  cachedBrowseShCatalog = undefined;
+  cachedBrowseShCatalogPromise = undefined;
+}
+
 /**
- * Search both ClawHub and Tessl registries, interleave results.
+ * Fetch the full browse.sh catalog. The list is ~200KB and CORS-open, so a
+ * single fetch per shell session is fine — the result is cached in-module
+ * for the lifetime of the process. Failures clear the cache so the next call
+ * retries.
+ */
+export async function fetchBrowseShCatalog(fetch: SecureFetch): Promise<BrowseShSkillSummary[]> {
+  if (cachedBrowseShCatalog) return cachedBrowseShCatalog;
+  if (cachedBrowseShCatalogPromise) return cachedBrowseShCatalogPromise;
+  cachedBrowseShCatalogPromise = (async () => {
+    const response = await fetch(BROWSE_SH_API, { headers: { Accept: 'application/json' } });
+    if (response.status !== 200) {
+      throw new Error(`browse.sh returned HTTP ${response.status}`);
+    }
+    const data = parseFetchJson<{ skills?: BrowseShSkillSummary[] } | BrowseShSkillSummary[]>(
+      response.body
+    );
+    const skills = Array.isArray(data) ? data : (data.skills ?? []);
+    cachedBrowseShCatalog = skills;
+    return skills;
+  })();
+  try {
+    return await cachedBrowseShCatalogPromise;
+  } catch (err) {
+    cachedBrowseShCatalogPromise = undefined;
+    throw err;
+  }
+}
+
+/**
+ * Search the cached browse.sh catalog and return unified results. Filters
+ * client-side against `title`, `name`, `description`, `hostname`, and `tags`.
+ */
+async function fetchBrowseShResults(
+  query: string,
+  fetch: SecureFetch
+): Promise<UnifiedSearchResult[]> {
+  const catalog = await fetchBrowseShCatalog(fetch);
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  const matches = catalog.filter((s) => {
+    const haystack = [
+      s.title ?? '',
+      s.name ?? '',
+      s.description ?? '',
+      s.hostname ?? '',
+      ...(s.tags ?? []),
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(q);
+  });
+
+  return matches.map((s) => ({
+    name: s.slug,
+    displayName: s.title || s.name || s.task || s.slug,
+    summary: s.description || '',
+    source: 'browseSh' as const,
+    qualityScore: null,
+    installHint: `upskill browse:${s.hostname}/${s.task}`,
+    sourceRepo: s.hostname,
+  }));
+}
+
+const BROWSE_SH_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Parse a browse.sh reference.
+ *
+ * Accepts:
+ * - `browse:{hostname}/{task}` (shorthand)
+ * - `https://browse.sh/skills/{hostname}/{task}` (URL form, trailing slash ok)
+ *
+ * Each segment must satisfy `[A-Za-z0-9._-]+` (no path traversal, no shell
+ * metachars). Returns null for anything else.
+ */
+export function parseBrowseShRef(ref: string): { hostname: string; task: string } | null {
+  let hostnameTask: string | undefined;
+
+  if (ref.startsWith('browse:')) {
+    hostnameTask = ref.slice('browse:'.length);
+  } else {
+    const url = ref.match(/^https:\/\/browse\.sh\/skills\/([^/?#]+)\/([^/?#]+?)\/?$/);
+    if (url) hostnameTask = `${url[1]}/${url[2]}`;
+  }
+  if (!hostnameTask) return null;
+
+  const slash = hostnameTask.indexOf('/');
+  if (slash < 0) return null;
+  const hostname = hostnameTask.slice(0, slash);
+  const task = hostnameTask.slice(slash + 1);
+  if (!hostname || !task) return null;
+  if (task.includes('/')) return null;
+  if (!BROWSE_SH_SEGMENT_RE.test(hostname) || !BROWSE_SH_SEGMENT_RE.test(task)) return null;
+  return { hostname, task };
+}
+
+/**
+ * Extract a top-level scalar field from minimal YAML frontmatter. Only handles
+ * plain `key: value` lines (quoted or unquoted) — arrays / block scalars are
+ * not parsed. Returns undefined when missing.
+ */
+function extractFrontmatterField(skillMd: string, field: string): string | undefined {
+  const fmMatch = skillMd.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmMatch) return undefined;
+  for (const line of fmMatch[1].split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$/);
+    if (!m || m[1] !== field) continue;
+    let value = m[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    return value || undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Build the SLICC adapter preamble inserted below the upstream frontmatter.
+ * Same wording for every browse.sh skill regardless of `recommendedMethod` —
+ * only the slug and `updated` date vary per skill.
+ */
+function buildBrowseShPreamble(detail: BrowseShDetail, slug: string): string {
+  const updated = detail.updated ? ` · updated ${detail.updated}` : '';
+  return [
+    `> [!NOTE] **Imported from browse.sh** — original slug: \`${slug}\``,
+    `>`,
+    `> **SLICC adaptation:** use \`playwright-cli\` — you are running inside the user's real browser session, so the bot-detection workarounds the upstream skill assumes are usually unnecessary.`,
+    `>`,
+    `> Source: <https://browse.sh/skills/${slug}>${updated}`,
+  ].join('\n');
+}
+
+/**
+ * Insert the SLICC adapter preamble immediately below the upstream YAML
+ * frontmatter. The upstream frontmatter and body MUST round-trip byte-identical
+ * around the preamble — we splice `\n<preamble>\n\n` between the closing `---`
+ * fence and whatever bytes followed it.
+ */
+function insertBrowseShPreamble(skillMd: string, preamble: string): string {
+  const fmMatch = skillMd.match(/^(---\r?\n[\s\S]*?\r?\n---)(\r?\n|$)/);
+  if (!fmMatch) {
+    // No frontmatter — emit the preamble as the file header so downstream
+    // skill loading still sees the SLICC adaptation note.
+    return `${preamble}\n\n${skillMd}`;
+  }
+  const frontmatter = fmMatch[1];
+  const afterFence = fmMatch[2] || '\n';
+  const rest = skillMd.slice(fmMatch[0].length);
+  return `${frontmatter}${afterFence}\n${preamble}\n\n${rest}`;
+}
+
+/**
+ * Install a single browse.sh skill into `/workspace/skills/browse-{hostname}-{name}/`.
+ *
+ * - GETs the detail endpoint for `skillMd`/`skillMdUrl`.
+ * - Prefers the Vercel Blob URL (CORS-safe) for the raw markdown body; falls
+ *   back to the inline `skillMd` field if the blob fetch fails or is absent.
+ * - Honors `force` for collision overwrites.
+ * - Writes a single `SKILL.md` with the SLICC adapter preamble inserted below
+ *   the upstream YAML frontmatter.
+ */
+async function installFromBrowseSh(
+  hostname: string,
+  task: string,
+  fs: VirtualFS,
+  fetch: SecureFetch,
+  force: boolean = false
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const slug = `${hostname}/${task}`;
+  const detailUrl = `${BROWSE_SH_API}/${hostname}/${task}`;
+
+  let detail: BrowseShDetail;
+  try {
+    const response = await fetch(detailUrl, { headers: { Accept: 'application/json' } });
+    if (response.status === 404) {
+      return {
+        stdout: '',
+        stderr: `upskill: browse.sh skill "${slug}" not found\n`,
+        exitCode: 1,
+      };
+    }
+    if (response.status !== 200) {
+      return {
+        stdout: '',
+        stderr: `upskill: browse.sh returned HTTP ${response.status} for "${slug}"\n`,
+        exitCode: 1,
+      };
+    }
+    detail = parseFetchJson<BrowseShDetail>(response.body);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      stdout: '',
+      stderr: `upskill: failed to fetch browse.sh skill "${slug}": ${msg}\n`,
+      exitCode: 1,
+    };
+  }
+
+  let skillMd: string | undefined;
+  if (detail.skillMdUrl) {
+    try {
+      const blobResponse = await fetch(detail.skillMdUrl, { headers: { Accept: 'text/plain' } });
+      if (blobResponse.status === 200) {
+        skillMd = decodeFetchBody(blobResponse.body);
+      }
+    } catch {
+      // fall through to inline
+    }
+  }
+  if (!skillMd && detail.skillMd) {
+    skillMd = detail.skillMd;
+  }
+  if (!skillMd) {
+    return {
+      stdout: '',
+      stderr: `upskill: browse.sh skill "${slug}" has no SKILL.md content\n`,
+      exitCode: 1,
+    };
+  }
+
+  // Derive install dir name. Prefer `name` parsed from the upstream
+  // frontmatter; fall back to `task` with a trailing `-xxxxxx` suffix
+  // stripped (browse.sh appends a short hash to disambiguate variants).
+  const frontmatterName = extractFrontmatterField(skillMd, 'name');
+  const fallbackName = task.replace(/-[A-Za-z0-9]{4,8}$/, '');
+  const skillName = frontmatterName || fallbackName || task;
+  const dirName = `browse-${hostname}-${skillName}`;
+  const destDir = `${SKILLS_DIR}/${dirName}`;
+
+  try {
+    await fs.stat(destDir);
+    if (!force) {
+      return {
+        stdout: '',
+        stderr: `upskill: skill "${dirName}" already exists (use --force to overwrite)\n`,
+        exitCode: 1,
+      };
+    }
+    await fs.rm(destDir, { recursive: true });
+  } catch {
+    // doesn't exist, continue
+  }
+
+  const preamble = buildBrowseShPreamble(detail, slug);
+  const fileContent = insertBrowseShPreamble(skillMd, preamble);
+
+  await fs.mkdir(destDir, { recursive: true });
+  await fs.writeFile(`${destDir}/SKILL.md`, fileContent);
+
+  await runPostInstallHooks();
+
+  return {
+    stdout: `Installed skill "${dirName}" from browse.sh (${slug})\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+/**
+ * Search registries for skills, merge and paginate results.
+ *
+ * Structured as a list of registry fetchers so additional backends (e.g.
+ * browse.sh) can plug in alongside Tessl without restructuring the merge,
+ * pagination, or error-handling logic below.
  */
 const SEARCH_PAGE_SIZE = 10;
+
+interface RegistrySource {
+  label: string;
+  fetch: (query: string, fetch: SecureFetch) => Promise<UnifiedSearchResult[]>;
+}
+
+const REGISTRY_SOURCES: RegistrySource[] = [
+  { label: 'Tessl', fetch: fetchTesslResults },
+  { label: 'browse.sh', fetch: fetchBrowseShResults },
+];
 
 async function searchRegistries(
   query: string,
   fetch: SecureFetch,
   page: number = 1
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const [clawHubResult, tesslResult] = await Promise.allSettled([
-    fetchClawHubResults(query, fetch),
-    fetchTesslResults(query, fetch),
-  ]);
+  const settled = await Promise.allSettled(REGISTRY_SOURCES.map((src) => src.fetch(query, fetch)));
 
-  const clawHub = clawHubResult.status === 'fulfilled' ? clawHubResult.value : [];
-  const tessl = tesslResult.status === 'fulfilled' ? tesslResult.value : [];
+  const perSource = settled.map((s) => (s.status === 'fulfilled' ? s.value : []));
+  const allFailed = settled.every((s) => s.status === 'rejected');
+  const merged: UnifiedSearchResult[] = perSource.flat();
 
-  if (clawHub.length === 0 && tessl.length === 0) {
-    let stderr = '';
-    if (clawHubResult.status === 'rejected' && tesslResult.status === 'rejected') {
-      stderr = 'upskill: both registries failed to respond\n';
-    }
+  if (merged.length === 0) {
+    const stderr = allFailed ? 'upskill: registries failed to respond\n' : '';
     return {
-      stdout: `No skills found for "${query}"\n\nTry a different search term or browse https://clawhub.ai or https://tessl.io/registry\n`,
+      stdout: `No skills found for "${query}"\n\nTry a different search term or browse https://tessl.io/registry\n`,
       stderr,
       exitCode: stderr ? 1 : 0,
     };
-  }
-
-  // Merge: lead with up to 3 Tessl results, then interleave
-  const merged: UnifiedSearchResult[] = [];
-  let ti = 0;
-  let ci = 0;
-
-  // Lead with Tessl (scored, higher signal)
-  while (ti < tessl.length && ti < 3) {
-    merged.push(tessl[ti++]);
-  }
-
-  // Interleave remaining
-  while (ci < clawHub.length || ti < tessl.length) {
-    if (ci < clawHub.length) merged.push(clawHub[ci++]);
-    if (ti < tessl.length) merged.push(tessl[ti++]);
   }
 
   const totalResults = merged.length;
@@ -672,205 +933,10 @@ async function searchRegistries(
   }
 
   output += `To install:\n`;
-  if (clawHub.length > 0) output += `  From ClawHub:  upskill clawhub:<slug>\n`;
-  if (tessl.length > 0) output += `  From Tessl:    upskill <owner/repo> --skill <name>\n`;
+  output += `  From Tessl:    upskill <owner/repo> --skill <name>\n`;
+  output += `  From browse.sh: upskill browse:<hostname>/<task>\n`;
 
   return { stdout: output, stderr: '', exitCode: 0 };
-}
-
-/**
- * Install a skill from ClawHub (downloads as ZIP)
- */
-async function installFromClawHub(
-  slug: string,
-  fs: VirtualFS,
-  fetch: SecureFetch,
-  force: boolean = false,
-  registeredCommands?: string[]
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  try {
-    // Check if skill already exists
-    const skillDir = `${SKILLS_DIR}/${slug}`;
-    try {
-      await fs.stat(skillDir);
-      if (!force) {
-        return {
-          stdout: '',
-          stderr: `upskill: skill "${slug}" already exists (use --force to overwrite)\n`,
-          exitCode: 1,
-        };
-      }
-      // Remove existing skill
-      await fs.rm(skillDir, { recursive: true });
-    } catch {
-      // Skill doesn't exist, good to proceed
-    }
-
-    // Download skill ZIP bundle from ClawHub
-    const downloadUrl = `${CLAWHUB_API}/download?slug=${encodeURIComponent(slug)}`;
-    const downloadResponse = await fetch(downloadUrl, {});
-
-    if (downloadResponse.status === 404) {
-      return {
-        stdout: '',
-        stderr: `upskill: skill "${slug}" not found on ClawHub\n`,
-        exitCode: 1,
-      };
-    }
-
-    if (downloadResponse.status !== 200) {
-      return {
-        stdout: '',
-        stderr: `upskill: failed to download skill (HTTP ${downloadResponse.status})\n`,
-        exitCode: 1,
-      };
-    }
-
-    // The response body should be latin1-encoded by the fetch proxy for binary content.
-    // Try to get the raw binary from the cache first (bypasses string encoding issues).
-    const contentType = downloadResponse.headers['content-type'] || '';
-
-    // Try to get cached binary data by URL first (most reliable - bypasses string encoding issues)
-    let zipBytes = consumeCachedBinaryByUrl(downloadUrl);
-    if (!zipBytes) {
-      zipBytes = getFetchBodyBytes(downloadResponse.body);
-    }
-
-    // Unzip the bundle
-    let files: ReturnType<typeof unzipSync>;
-    try {
-      files = unzipSync(zipBytes);
-    } catch (unzipErr) {
-      const msg = unzipErr instanceof Error ? unzipErr.message : String(unzipErr);
-      // Debug info
-      const hexPreview = Array.from(zipBytes.slice(0, 20))
-        .map((b) => b.toString(16).padStart(2, '0'))
-        .join(' ');
-      return {
-        stdout: '',
-        stderr: `upskill: failed to unzip: ${msg}\nContent-Type: ${contentType}\nBody: ${zipBytes.length} bytes\nHex: ${hexPreview}\n`,
-        exitCode: 1,
-      };
-    }
-
-    // Create skill directory
-    await fs.mkdir(skillDir, { recursive: true });
-
-    // Extract files
-    let fileCount = 0;
-    for (const [entryPath, content] of Object.entries(files)) {
-      const normalized = entryPath.replace(/\\/g, '/');
-      if (!normalized || normalized.endsWith('/')) continue;
-
-      // Skip _meta.json if present (ClawHub metadata)
-      if (normalized === '_meta.json') continue;
-
-      const filePath = `${skillDir}/${normalized}`;
-      const parentDir = filePath.substring(0, filePath.lastIndexOf('/'));
-      if (parentDir !== skillDir) {
-        await fs.mkdir(parentDir, { recursive: true });
-      }
-
-      // Write file content (Uint8Array)
-      await fs.writeFile(filePath, content);
-      fileCount++;
-    }
-
-    // Check for required bins in SKILL.md frontmatter
-    const binsWarning = checkRequiredBins(files, registeredCommands);
-
-    await runPostInstallHooks();
-    return {
-      stdout: `Installed skill "${slug}" from ClawHub (${fileCount} files)\n${binsWarning}`,
-      stderr: '',
-      exitCode: 0,
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return {
-      stdout: '',
-      stderr: `upskill: failed to install from ClawHub: ${msg}\n`,
-      exitCode: 1,
-    };
-  }
-}
-
-/**
- * Parse SKILL.md frontmatter for openclaw/clawdis requires.bins and check availability.
- */
-function checkRequiredBins(
-  files: Record<string, Uint8Array>,
-  registeredCommands?: string[]
-): string {
-  // Find SKILL.md in the extracted files
-  let skillMdContent: string | undefined;
-  for (const [path, content] of Object.entries(files)) {
-    const basename = path.split('/').pop() || '';
-    if (basename.toLowerCase() === 'skill.md') {
-      skillMdContent = new TextDecoder().decode(content);
-      break;
-    }
-  }
-  if (!skillMdContent) return '';
-
-  // Extract frontmatter
-  const fmMatch = skillMdContent.match(/^---\s*\n([\s\S]*?)\n---/);
-  if (!fmMatch) return '';
-
-  // Look for requires.bins in the metadata JSON block
-  const frontmatter = fmMatch[1];
-  const bins = extractRequiredBins(frontmatter);
-  if (bins.length === 0) return '';
-
-  if (!registeredCommands || registeredCommands.length === 0) {
-    return `  Requires: ${bins.join(', ')}\n`;
-  }
-
-  const available = new Set(registeredCommands);
-  const missing = bins.filter((b) => !available.has(b));
-
-  if (missing.length === 0) {
-    return `  Requires: ${bins.join(', ')} (all available)\n`;
-  }
-
-  return `  Requires: ${bins.join(', ')}\n  Missing: ${missing.join(', ')} -- this skill may not work in the SLICC shell\n`;
-}
-
-/**
- * Extract bins array from SKILL.md frontmatter metadata block.
- * Handles both JSON metadata blocks and YAML-ish patterns.
- */
-function extractRequiredBins(frontmatter: string): string[] {
-  // Try to find a JSON metadata block
-  const metaMatch = frontmatter.match(/metadata:\s*\n\s*(\{[\s\S]*\})/);
-  if (metaMatch) {
-    try {
-      const meta = JSON.parse(metaMatch[1]) as Record<string, unknown>;
-      // Check openclaw.requires.bins or clawdis.requires.bins
-      for (const key of ['openclaw', 'clawdis', 'clawdbot']) {
-        const section = meta[key] as Record<string, unknown> | undefined;
-        if (section?.requires && typeof section.requires === 'object') {
-          const req = section.requires as Record<string, unknown>;
-          if (Array.isArray(req.bins)) {
-            return req.bins.filter((b): b is string => typeof b === 'string');
-          }
-        }
-      }
-    } catch {
-      // JSON parse failed, try regex fallback
-    }
-  }
-
-  // Regex fallback: look for "bins": ["python3", ...] anywhere in frontmatter
-  const binsMatch = frontmatter.match(/"bins"\s*:\s*\[([^\]]*)\]/);
-  if (binsMatch) {
-    return binsMatch[1]
-      .split(',')
-      .map((s) => s.trim().replace(/^["']|["']$/g, ''))
-      .filter(Boolean);
-  }
-
-  return [];
 }
 
 /**
@@ -1187,32 +1253,6 @@ async function installFromGitHub(
       exitCode: 1,
     };
   }
-}
-
-/**
- * Parse ClawHub URL or shorthand into a slug.
- * ClawHub URLs are: https://clawhub.ai/{owner}/{slug}
- * But the API only needs the slug (e.g., "tavily-search")
- */
-function parseClawHubRef(ref: string): string | null {
-  // Handle full URL: https://clawhub.ai/user/skill-slug
-  const urlMatch = ref.match(/^https?:\/\/clawhub\.ai\/[^\/]+\/([^\/]+)/);
-  if (urlMatch) {
-    return urlMatch[1]; // Return just the slug, not owner/slug
-  }
-
-  // Handle shorthand: clawhub:slug or clawhub:owner/slug
-  if (ref.startsWith('clawhub:')) {
-    const rest = ref.slice(8);
-    // If it contains a slash, take the second part (the slug)
-    if (rest.includes('/')) {
-      return rest.split('/')[1];
-    }
-    // Otherwise it's just the slug
-    return rest;
-  }
-
-  return null;
 }
 
 /** Run all post-install hooks: refresh sprinkles + reload skills. */
@@ -1693,6 +1733,267 @@ export async function installRecommendedSkills(
   };
 }
 
+// ── upskill tabs ──
+
+/**
+ * Normalize a hostname for catalog matching: lowercases and strips a single
+ * leading `www.`. Exported so Wave 4 (browse.sh skill install dispatch) can
+ * reuse the exact same matching contract this subcommand surfaces to users.
+ */
+export function normalizeHostname(host: string): string {
+  const lower = host.toLowerCase();
+  return lower.startsWith('www.') ? lower.slice(4) : lower;
+}
+
+/** Origin-advertised upskill link surfaced from a tab's Link header. */
+export interface TabUpskillLink {
+  target: string;
+  branch?: string;
+  path?: string;
+  instruction?: string;
+  installHint: string;
+}
+
+/** Browse.sh catalog match for a tab's hostname. */
+export interface TabCatalogMatch {
+  slug: string;
+  hostname: string;
+  task: string;
+  title: string;
+  description?: string;
+  installed: boolean;
+  installHint: string;
+}
+
+/** Per-tab result emitted by `upskill tabs`. */
+export interface TabUpskillResult {
+  targetId: string;
+  title: string;
+  url: string;
+  hostname: string;
+  active?: boolean;
+  origin: TabUpskillLink[];
+  catalog: TabCatalogMatch[];
+  failures: Array<{ rel: string; href: string; error: string }>;
+}
+
+/**
+ * Build the install-hint shell line for an origin-advertised upskill rel.
+ * Mirrors the dispatch contract the cone's handoff SKILL renders, so the
+ * line we print to the terminal is exactly what the user (or the cone, if
+ * they pipe it) should run.
+ */
+function buildOriginInstallHint(target: string, branch?: string, path?: string): string {
+  let cmd = `upskill ${target}`;
+  if (branch) cmd += ` --branch ${branch}`;
+  if (path) cmd += ` --path ${path}`;
+  return cmd;
+}
+
+/**
+ * Fetch a single tab's URL, parse Link headers, and surface every
+ * origin-advertised `upskill` rel. Failures are returned in the result's
+ * `failures` array (matches `discoverLinks`' contract) rather than thrown
+ * so one bad tab doesn't sink the whole listing.
+ */
+async function discoverTabUpskill(
+  url: string,
+  fetchFn: SecureFetch
+): Promise<{ links: TabUpskillLink[]; failures: TabUpskillResult['failures'] }> {
+  const failures: TabUpskillResult['failures'] = [];
+  let response: Awaited<ReturnType<SecureFetch>>;
+  try {
+    response = await fetchFn(url, { method: 'GET' });
+  } catch (err) {
+    failures.push({
+      rel: UPSKILL_REL,
+      href: url,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { links: [], failures };
+  }
+
+  const linkValues: string[] = [];
+  for (const [name, value] of Object.entries(response.headers || {})) {
+    if (name.toLowerCase() === 'link' && typeof value === 'string' && value.length > 0) {
+      linkValues.push(value);
+    }
+  }
+  if (linkValues.length === 0) return { links: [], failures };
+
+  const parsed = parseLinkHeader(linkValues, url);
+  const links: TabUpskillLink[] = [];
+  // Surface every upskill rel on the page (extractHandoff returns only the
+  // first match — for the tabs listing we want each one so users can choose).
+  for (const link of parsed) {
+    if (!link.rel.includes(UPSKILL_REL)) continue;
+    const single = extractHandoff([link]);
+    if (!single || single.verb !== 'upskill') continue;
+    links.push({
+      target: single.target,
+      branch: single.branch,
+      path: single.path,
+      instruction: single.instruction,
+      installHint: buildOriginInstallHint(single.target, single.branch, single.path),
+    });
+  }
+  return { links, failures };
+}
+
+/**
+ * Handle the `upskill tabs` subcommand.
+ */
+async function handleTabs(
+  fs: VirtualFS,
+  fetchFn: SecureFetch,
+  browser: BrowserAPI | undefined,
+  jsonMode: boolean
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  if (!browser) {
+    return {
+      stdout: '',
+      stderr: 'upskill: browser APIs unavailable in this environment\n',
+      exitCode: 1,
+    };
+  }
+
+  let pages: PageInfo[];
+  try {
+    pages = await browser.listPages();
+  } catch {
+    try {
+      pages = await browser.listAllTargets();
+    } catch (err) {
+      return {
+        stdout: '',
+        stderr: `upskill: failed to list browser tabs: ${err instanceof Error ? err.message : String(err)}\n`,
+        exitCode: 1,
+      };
+    }
+  }
+
+  if (pages.length === 0) {
+    if (jsonMode) {
+      return { stdout: JSON.stringify({ tabs: [] }, null, 2) + '\n', stderr: '', exitCode: 0 };
+    }
+    return {
+      stdout: 'No open browser tabs.\n',
+      stderr: '',
+      exitCode: 0,
+    };
+  }
+
+  // Browse.sh catalog fetch — non-fatal. If it fails, we still surface
+  // origin-advertised rels and log a warning to stderr.
+  let catalog: BrowseShSkillSummary[] = [];
+  let catalogWarning = '';
+  try {
+    catalog = await fetchBrowseShCatalog(fetchFn);
+  } catch (err) {
+    catalogWarning = `upskill: warning: browse.sh catalog unavailable: ${err instanceof Error ? err.message : String(err)}\n`;
+  }
+
+  const installed = await getInstalledSkillNames(fs);
+
+  const results: TabUpskillResult[] = [];
+  for (const page of pages) {
+    let host = '';
+    try {
+      host = new URL(page.url).hostname;
+    } catch {
+      // Non-HTTP URLs (chrome://, about:, etc.) — skip discovery/catalog match.
+    }
+    const normalized = host ? normalizeHostname(host) : '';
+
+    let origin: TabUpskillLink[] = [];
+    let failures: TabUpskillResult['failures'] = [];
+    if (host && /^https?:/i.test(page.url)) {
+      const discovered = await discoverTabUpskill(page.url, fetchFn);
+      origin = discovered.links;
+      failures = discovered.failures;
+    }
+
+    const catalogMatches: TabCatalogMatch[] = [];
+    if (normalized && catalog.length > 0) {
+      for (const s of catalog) {
+        if (!s.hostname) continue;
+        if (normalizeHostname(s.hostname) !== normalized) continue;
+        // Mirror `installFromBrowseSh`'s dirname rule: prefer the catalog's
+        // `name` (parsed from upstream frontmatter at publish time) and
+        // only strip the trailing `-xxxxxx` disambiguation hash when we
+        // have to fall back to `task`.
+        const skillName = s.name || s.task.replace(/-[A-Za-z0-9]{4,8}$/, '') || s.task;
+        const dirName = `browse-${s.hostname}-${skillName}`;
+        catalogMatches.push({
+          slug: s.slug,
+          hostname: s.hostname,
+          task: s.task,
+          title: s.title || s.name || s.task,
+          description: s.description,
+          installed: installed.has(dirName),
+          installHint: `upskill browse:${s.hostname}/${s.task}`,
+        });
+      }
+    }
+
+    results.push({
+      targetId: page.targetId,
+      title: page.title,
+      url: page.url,
+      hostname: normalized,
+      active: page.active,
+      origin,
+      catalog: catalogMatches,
+      failures,
+    });
+  }
+
+  if (jsonMode) {
+    return {
+      stdout: JSON.stringify({ tabs: results }, null, 2) + '\n',
+      stderr: catalogWarning,
+      exitCode: 0,
+    };
+  }
+
+  let output = '';
+  for (const tab of results) {
+    const activeMark = tab.active ? ' [active]' : '';
+    output += `${tab.title || '(untitled)'}${activeMark}\n`;
+    output += `  ${tab.url}\n`;
+
+    if (tab.origin.length > 0) {
+      output += `  Origin-advertised:\n`;
+      for (const link of tab.origin) {
+        output += `    ${link.installHint}`;
+        if (link.instruction) output += `   # ${link.instruction}`;
+        output += '\n';
+      }
+    }
+
+    if (tab.catalog.length > 0) {
+      output += `  Browse.sh catalog:\n`;
+      for (const match of tab.catalog) {
+        const marker = match.installed ? '✓' : ' ';
+        output += `    ${marker} ${match.title.padEnd(40)} ${match.installHint}\n`;
+      }
+    }
+
+    if (tab.origin.length === 0 && tab.catalog.length === 0 && !tab.failures.length) {
+      output += `  No skill suggestions for this tab.\n`;
+    }
+
+    if (tab.failures.length > 0) {
+      for (const f of tab.failures) {
+        output += `  (discovery failed: ${f.error})\n`;
+      }
+    }
+    output += '\n';
+  }
+
+  return { stdout: output, stderr: catalogWarning, exitCode: 0 };
+}
+
 /**
  * Handle the `upskill recommendations` subcommand.
  */
@@ -1813,11 +2114,27 @@ async function handleRecommendations(
 
 /**
  * Create the upskill command with access to the virtual filesystem.
+ *
+ * @param browser Optional BrowserAPI used by the `tabs` subcommand. When
+ *   omitted (e.g. headless tests or pre-CDP boot), `upskill tabs` exits
+ *   non-zero with a clear "browser APIs unavailable" message.
  */
-export function createUpskillCommand(fs: VirtualFS, fetchFn: SecureFetch): Command {
+export function createUpskillCommand(
+  fs: VirtualFS,
+  fetchFn: SecureFetch,
+  browser?: BrowserAPI
+): Command {
   return defineCommand('upskill', async (args, _ctx: CommandContext) => {
     if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
       return upskillHelp();
+    }
+
+    // `upskill tabs [--json]` — surface skill suggestions for open browser
+    // tabs. Handled up-front so the rest of the arg parser doesn't try to
+    // interpret `tabs` as a GitHub `owner/repo` ref.
+    if (args[0] === 'tabs') {
+      const jsonMode = args.includes('--json');
+      return handleTabs(fs, fetchFn, browser, jsonMode);
     }
 
     // Parse arguments
@@ -1957,13 +2274,6 @@ export function createUpskillCommand(fs: VirtualFS, fetchFn: SecureFetch): Comma
       return upskillHelp();
     }
 
-    // Check if it's a ClawHub reference
-    const clawHubSlug = parseClawHubRef(sourceRef);
-    if (clawHubSlug) {
-      const registeredCommands = _ctx.getRegisteredCommands?.() ?? [];
-      return installFromClawHub(clawHubSlug, fs, fetchFn, force, registeredCommands);
-    }
-
     // Check if it's a Tessl reference (tessl:name)
     if (sourceRef.startsWith('tessl:')) {
       const tesslName = sourceRef.slice(6);
@@ -1985,6 +2295,12 @@ export function createUpskillCommand(fs: VirtualFS, fetchFn: SecureFetch): Comma
         force,
         fetchFn
       );
+    }
+
+    // Check if it's a browse.sh reference (browse:<hostname>/<task> or URL form)
+    const browseShRef = parseBrowseShRef(sourceRef);
+    if (browseShRef) {
+      return installFromBrowseSh(browseShRef.hostname, browseShRef.task, fs, fetchFn, force);
     }
 
     // Check if it's a GitHub reference
@@ -2147,7 +2463,7 @@ export function createUpskillCommand(fs: VirtualFS, fetchFn: SecureFetch): Comma
     // Unknown source format
     return {
       stdout: '',
-      stderr: `upskill: unrecognized source "${sourceRef}"\n\nExpected: owner/repo, clawhub:<slug>, tessl:<name>, or https://clawhub.ai/user/skill\n`,
+      stderr: `upskill: unrecognized source "${sourceRef}"\n\nExpected: owner/repo, tessl:<name>, or browse:<hostname>/<task>\n`,
       exitCode: 1,
     };
   });
@@ -2169,7 +2485,7 @@ Commands:
 
 ${formatDiscoveryScope()}
 For installing skills from registries or GitHub, use 'upskill':
-  upskill search "query"           Search ClawHub + Tessl
+  upskill search "query"           Search Tessl
   upskill owner/repo --list        List skills in GitHub repo
   upskill owner/repo --all         Install from GitHub
   upskill tessl:<name>             Install from Tessl registry

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -689,14 +689,29 @@ async function fetchBrowseShResults(
 const BROWSE_SH_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
 
 /**
+ * Reject path-traversal-shaped segments (`.`, `..`) and empty strings. The
+ * `BROWSE_SH_SEGMENT_RE` allowlist on its own accepts `.` and `..` as full
+ * segments because `.` and `-` are in the character class; this helper closes
+ * that gap so neither shorthand refs nor frontmatter-derived names can produce
+ * `/workspace/skills/browse-./..-..` style targets.
+ */
+function isSafeBrowseShSegment(seg: string): boolean {
+  if (!seg) return false;
+  if (seg === '.' || seg === '..') return false;
+  return BROWSE_SH_SEGMENT_RE.test(seg);
+}
+
+/**
  * Parse a browse.sh reference.
  *
  * Accepts:
  * - `browse:{hostname}/{task}` (shorthand)
  * - `https://browse.sh/skills/{hostname}/{task}` (URL form, trailing slash ok)
  *
- * Each segment must satisfy `[A-Za-z0-9._-]+` (no path traversal, no shell
- * metachars). Returns null for anything else.
+ * Each segment must satisfy `[A-Za-z0-9._-]+` AND must not be `.` or `..`
+ * (no path traversal, no shell metachars). Hostname is normalized to lowercase
+ * with a leading `www.` stripped so refs match the install/match logic
+ * elsewhere in this file. Returns null for anything else.
  */
 export function parseBrowseShRef(ref: string): { hostname: string; task: string } | null {
   let hostnameTask: string | undefined;
@@ -711,11 +726,16 @@ export function parseBrowseShRef(ref: string): { hostname: string; task: string 
 
   const slash = hostnameTask.indexOf('/');
   if (slash < 0) return null;
-  const hostname = hostnameTask.slice(0, slash);
+  const rawHostname = hostnameTask.slice(0, slash);
   const task = hostnameTask.slice(slash + 1);
-  if (!hostname || !task) return null;
+  if (!rawHostname || !task) return null;
   if (task.includes('/')) return null;
-  if (!BROWSE_SH_SEGMENT_RE.test(hostname) || !BROWSE_SH_SEGMENT_RE.test(task)) return null;
+  if (!isSafeBrowseShSegment(rawHostname) || !isSafeBrowseShSegment(task)) return null;
+  const hostname = normalizeHostname(rawHostname);
+  // normalizeHostname only lowercases + strips a leading `www.`; re-verify the
+  // result still satisfies the segment allowlist so a hostname like `www..`
+  // (which normalizes to `.`) is still rejected.
+  if (!isSafeBrowseShSegment(hostname)) return null;
   return { hostname, task };
 }
 
@@ -852,6 +872,28 @@ async function installFromBrowseSh(
   const frontmatterName = extractFrontmatterField(skillMd, 'name');
   const fallbackName = task.replace(/-[A-Za-z0-9]{4,8}$/, '');
   const skillName = frontmatterName || fallbackName || task;
+  // `hostname` and `task` here came through `parseBrowseShRef`, but `skillName`
+  // can be sourced from untrusted upstream frontmatter — constrain it to the
+  // same safe-segment allowlist before composing the install path. Reject
+  // anything that could escape `/workspace/skills/` (path separators, `.` /
+  // `..` segments, NUL, shell metachars).
+  if (!isSafeBrowseShSegment(skillName) || skillName.length > 64) {
+    return {
+      stdout: '',
+      stderr: `upskill: refusing to install browse.sh skill with unsafe name "${skillName}"\n`,
+      exitCode: 1,
+    };
+  }
+  // Defense in depth: re-validate the hostname segment too. parseBrowseShRef
+  // already guarantees this, but install paths are sensitive enough that we
+  // shouldn't trust the call site.
+  if (!isSafeBrowseShSegment(hostname)) {
+    return {
+      stdout: '',
+      stderr: `upskill: refusing to install browse.sh skill with unsafe hostname "${hostname}"\n`,
+      exitCode: 1,
+    };
+  }
   const dirName = `browse-${hostname}-${skillName}`;
   const destDir = `${SKILLS_DIR}/${dirName}`;
 
@@ -903,6 +945,24 @@ const REGISTRY_SOURCES: RegistrySource[] = [
   { label: 'browse.sh', fetch: fetchBrowseShResults },
 ];
 
+/**
+ * Round-robin interleave per-source result lists, preserving within-source
+ * order. Take the first hit from each source in order, then the second from
+ * each, etc., skipping any source that has been exhausted. This gives each
+ * registry visibility in the top page of results rather than burying browse.sh
+ * behind Tessl (or vice versa).
+ */
+function interleaveResults(perSource: UnifiedSearchResult[][]): UnifiedSearchResult[] {
+  const merged: UnifiedSearchResult[] = [];
+  const maxLen = perSource.reduce((m, list) => Math.max(m, list.length), 0);
+  for (let i = 0; i < maxLen; i++) {
+    for (const list of perSource) {
+      if (i < list.length) merged.push(list[i]);
+    }
+  }
+  return merged;
+}
+
 async function searchRegistries(
   query: string,
   fetch: SecureFetch,
@@ -912,12 +972,12 @@ async function searchRegistries(
 
   const perSource = settled.map((s) => (s.status === 'fulfilled' ? s.value : []));
   const allFailed = settled.every((s) => s.status === 'rejected');
-  const merged: UnifiedSearchResult[] = perSource.flat();
+  const merged: UnifiedSearchResult[] = interleaveResults(perSource);
 
   if (merged.length === 0) {
     const stderr = allFailed ? 'upskill: registries failed to respond\n' : '';
     return {
-      stdout: `No skills found for "${query}"\n\nTry a different search term or browse https://tessl.io/registry\n`,
+      stdout: `No skills found for "${query}"\n\nTry a different search term or browse the registries at https://tessl.io/registry or https://browse.sh\n`,
       stderr,
       exitCode: stderr ? 1 : 0,
     };
@@ -2500,10 +2560,11 @@ Commands:
 
 ${formatDiscoveryScope()}
 For installing skills from registries or GitHub, use 'upskill':
-  upskill search "query"           Search Tessl
+  upskill search "query"           Search registries (Tessl + browse.sh)
   upskill owner/repo --list        List skills in GitHub repo
   upskill owner/repo --all         Install from GitHub
   upskill tessl:<name>             Install from Tessl registry
+  upskill browse:<host>/<task>     Install from browse.sh catalog
 
 Examples:
   skill list

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -312,7 +312,22 @@ function getGlobalFs(): Promise<VirtualFS> {
 
 /** @internal Exported only for test cleanup. */
 export function _resetGlobalFsCache(): void {
+  const pending = cachedGlobalFsPromise;
   cachedGlobalFsPromise = undefined;
+  if (!pending) return;
+  // Fire-and-forget dispose so the cached VirtualFS releases its
+  // LightningFS lock (held via navigator.locks). Without this, the
+  // dangling lock request rejects with AbortError on process teardown
+  // and surfaces as an unhandled rejection in tests. Errors during
+  // dispose are intentionally swallowed — this path runs from test
+  // teardown and hot-reload where surfacing a cleanup rejection
+  // produces false failures.
+  pending.then(
+    (vfs) => {
+      void vfs.dispose().catch(() => {});
+    },
+    () => {}
+  );
 }
 
 async function loadConfiguredGitHubToken(): Promise<string | undefined> {

--- a/packages/webapp/src/shell/wasm-shell-headless.ts
+++ b/packages/webapp/src/shell/wasm-shell-headless.ts
@@ -247,7 +247,7 @@ export class WasmShellHeadless implements HeadlessShellLike {
       gitCommand,
       mountCommand,
       createSkillCommand(options.fs),
-      createUpskillCommand(options.fs, fetchFn),
+      createUpskillCommand(options.fs, fetchFn, options.browserAPI),
       ...supplementalCommands,
     ];
     const customCommands = allCustomCommands.filter((c) => this.isCommandAllowed(c.name));

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -5,6 +5,7 @@ import {
   setPlaywrightTeleportBestFollower,
   setPlaywrightTeleportConnectedFollowers,
 } from '../../../src/shell/supplemental-commands/playwright-command.js';
+import { _resetBrowseShCatalogCache } from '../../../src/shell/supplemental-commands/upskill-command.js';
 import type { BrowserAPI } from '../../../src/cdp/index.js';
 import type { VirtualFS } from '../../../src/fs/index.js';
 
@@ -3707,5 +3708,226 @@ describe('playwright-cli fetch (link discovery)', () => {
     );
     expect(openResult.exitCode).toBe(0);
     expect(JSON.parse(openResult.stdout).source).toBe('auxiliary-fetch');
+  });
+});
+
+describe('playwright-cli --discover surfaces browse.sh skills', () => {
+  let browser: ReturnType<typeof createMockBrowser>;
+  let fs: VirtualFS;
+  let originalFetch: typeof globalThis.fetch | undefined;
+  let installedDirs: string[];
+
+  /**
+   * Mock fs with a readDir that returns whatever `installedDirs` holds —
+   * lets each test stage the "installed-locally" check independently.
+   */
+  function createFsWithReadDir(): VirtualFS {
+    return {
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      readFile: vi.fn().mockResolvedValue(''),
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      readDir: vi.fn(async (path: string) => {
+        if (path !== '/workspace/skills') {
+          const err: Error & { code?: string } = new Error(`ENOENT: ${path}`);
+          err.code = 'ENOENT';
+          throw err;
+        }
+        return installedDirs.map((name) => ({ name, type: 'directory' as const }));
+      }),
+    } as unknown as VirtualFS;
+  }
+
+  /** Catalog fixture: two weather.gov skills (one with explicit name) + one unrelated. */
+  const CATALOG_FIXTURE = {
+    skills: [
+      {
+        slug: 'weather.gov/get-forecast-1uezib',
+        hostname: 'weather.gov',
+        task: 'get-forecast-1uezib',
+        name: 'get-forecast',
+        title: 'Get NWS forecast',
+        recommendedMethod: 'api',
+      },
+      {
+        slug: 'weather.gov/get-alerts-abc123',
+        hostname: 'weather.gov',
+        task: 'get-alerts-abc123',
+        title: 'Get NWS alerts',
+      },
+      {
+        slug: 'example.com/login-xyz',
+        hostname: 'example.com',
+        task: 'login-xyz',
+        title: 'Login flow',
+      },
+    ],
+  };
+
+  function makeProxyFetch(
+    opts: {
+      catalogStatus?: number;
+      catalog?: unknown;
+      catalogThrow?: boolean;
+    } = {}
+  ): ReturnType<typeof vi.fn> {
+    return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const target = (init?.headers as Record<string, string> | undefined)?.['X-Target-URL'];
+      // browse.sh catalog request from the lazy warm path.
+      if (url === 'https://browse.sh/api/skills' || target === 'https://browse.sh/api/skills') {
+        if (opts.catalogThrow) throw new Error('network down');
+        return new Response(JSON.stringify(opts.catalog ?? CATALOG_FIXTURE), {
+          status: opts.catalogStatus ?? 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      // Primary discover fetch — no Link header for these tests.
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      });
+    });
+  }
+
+  beforeEach(() => {
+    _resetBrowseShCatalogCache();
+    browser = createMockBrowser();
+    installedDirs = [];
+    fs = createFsWithReadDir();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+    _resetBrowseShCatalogCache();
+  });
+
+  it('fetch --discover includes discovery.browseShSkills for matching hostname', async () => {
+    globalThis.fetch = makeProxyFetch() as unknown as typeof globalThis.fetch;
+    const cmd = createPlaywrightCommand('playwright-cli', browser, fs);
+    const result = await cmd.execute(
+      ['fetch', 'https://weather.gov/forecast', '--discover'],
+      {} as any
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    const payload = JSON.parse(result.stdout);
+    expect(payload.discovery).toBeDefined();
+    const skills = payload.discovery.browseShSkills;
+    expect(Array.isArray(skills)).toBe(true);
+    expect(skills).toHaveLength(2);
+    expect(skills[0]).toMatchObject({
+      slug: 'weather.gov/get-forecast-1uezib',
+      name: 'get-forecast',
+      title: 'Get NWS forecast',
+      recommendedMethod: 'api',
+      installed: false,
+      installHint: 'upskill browse:weather.gov/get-forecast-1uezib',
+    });
+  });
+
+  it('marks installed=true when /workspace/skills/browse-{hostname}-{name} exists', async () => {
+    installedDirs = ['browse-weather.gov-get-forecast', 'unrelated-skill'];
+    globalThis.fetch = makeProxyFetch() as unknown as typeof globalThis.fetch;
+    const cmd = createPlaywrightCommand('playwright-cli', browser, fs);
+    const result = await cmd.execute(['fetch', 'https://weather.gov/x', '--discover'], {} as any);
+    const payload = JSON.parse(result.stdout);
+    const skills = payload.discovery.browseShSkills;
+    const forecast = skills.find(
+      (s: { slug: string }) => s.slug === 'weather.gov/get-forecast-1uezib'
+    );
+    const alerts = skills.find((s: { slug: string }) => s.slug === 'weather.gov/get-alerts-abc123');
+    expect(forecast.installed).toBe(true);
+    expect(alerts.installed).toBe(false);
+  });
+
+  it('normalizes www. prefix when matching hostnames', async () => {
+    globalThis.fetch = makeProxyFetch() as unknown as typeof globalThis.fetch;
+    const cmd = createPlaywrightCommand('playwright-cli', browser, fs);
+    const result = await cmd.execute(
+      ['fetch', 'https://www.weather.gov/x', '--discover'],
+      {} as any
+    );
+    const payload = JSON.parse(result.stdout);
+    expect(payload.discovery.browseShSkills).toHaveLength(2);
+  });
+
+  it('omits browseShSkills when no catalog entry matches the hostname', async () => {
+    globalThis.fetch = makeProxyFetch() as unknown as typeof globalThis.fetch;
+    const cmd = createPlaywrightCommand('playwright-cli', browser, fs);
+    const result = await cmd.execute(
+      ['fetch', 'https://nomatch.example/x', '--discover'],
+      {} as any
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    const payload = JSON.parse(result.stdout);
+    expect(payload.discovery.browseShSkills).toBeUndefined();
+  });
+
+  it('omits browseShSkills and emits stderr warning on catalog fetch failure', async () => {
+    globalThis.fetch = makeProxyFetch({ catalogThrow: true }) as unknown as typeof globalThis.fetch;
+    const cmd = createPlaywrightCommand('playwright-cli', browser, fs);
+    const result = await cmd.execute(['fetch', 'https://weather.gov/x', '--discover'], {} as any);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('browse.sh catalog unavailable');
+    const payload = JSON.parse(result.stdout);
+    expect(payload.discovery?.browseShSkills).toBeUndefined();
+    // browseShWarning is stderr-only — must not leak into JSON.
+    expect(payload.browseShWarning).toBeUndefined();
+  });
+
+  it('reuses the catalog cache across subsequent --discover calls', async () => {
+    const fetchSpy = makeProxyFetch();
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    const cmd = createPlaywrightCommand('playwright-cli', browser, fs);
+    await cmd.execute(['fetch', 'https://weather.gov/a', '--discover'], {} as any);
+    await cmd.execute(['fetch', 'https://weather.gov/b', '--discover'], {} as any);
+    const catalogHits = fetchSpy.mock.calls.filter((c) => {
+      const url = typeof c[0] === 'string' ? c[0] : (c[0] as URL).toString();
+      const target = (c[1] as RequestInit | undefined)?.headers as
+        | Record<string, string>
+        | undefined;
+      return (
+        url === 'https://browse.sh/api/skills' ||
+        target?.['X-Target-URL'] === 'https://browse.sh/api/skills'
+      );
+    });
+    expect(catalogHits).toHaveLength(1);
+  });
+
+  it('open --discover and goto --discover both surface browseShSkills', async () => {
+    globalThis.fetch = makeProxyFetch() as unknown as typeof globalThis.fetch;
+    const cmd = createPlaywrightCommand('playwright-cli', browser, fs);
+
+    const openRes = await cmd.execute(['open', 'https://weather.gov/x', '--discover'], {} as any);
+    expect(openRes.exitCode).toBe(0);
+    expect(JSON.parse(openRes.stdout).discovery.browseShSkills).toHaveLength(2);
+
+    _resetBrowseShCatalogCache();
+    const gotoRes = await cmd.execute(
+      ['goto', 'https://weather.gov/x', '--tab=tab-1', '--discover'],
+      {} as any
+    );
+    expect(gotoRes.exitCode).toBe(0);
+    expect(JSON.parse(gotoRes.stdout).discovery.browseShSkills).toHaveLength(2);
+  });
+
+  it('does not fetch the catalog without --discover', async () => {
+    const fetchSpy = makeProxyFetch();
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    const cmd = createPlaywrightCommand('playwright-cli', browser, fs);
+    await cmd.execute(['fetch', 'https://weather.gov/x'], {} as any);
+    const catalogHits = fetchSpy.mock.calls.filter((c) => {
+      const url = typeof c[0] === 'string' ? c[0] : (c[0] as URL).toString();
+      const target = (c[1] as RequestInit | undefined)?.headers as
+        | Record<string, string>
+        | undefined;
+      return (
+        url === 'https://browse.sh/api/skills' ||
+        target?.['X-Target-URL'] === 'https://browse.sh/api/skills'
+      );
+    });
+    expect(catalogHits).toHaveLength(0);
   });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
@@ -150,6 +150,10 @@ describe('skill/upskill command compatibility discovery', () => {
     expect(result.stdout).toContain('List discoverable skills');
     expect(result.stdout).toContain('**/.agents/skills/*');
     expect(result.stdout).toContain('**/.claude/skills/*');
+    // The `upskill search` line must list every registry the search actually
+    // queries (Tessl + browse.sh), not just one of them — see PR #707 thread.
+    expect(result.stdout).toMatch(/upskill search.*Tessl.*browse\.sh/);
+    expect(result.stdout).toContain('browse:<host>/<task>');
   });
 
   it('skill list shows source and description for both native and compatibility skills', async () => {
@@ -1437,6 +1441,29 @@ describe('parseBrowseShRef', () => {
     expect(parseBrowseShRef('browse:weather.gov/../etc')).toBeNull();
   });
 
+  it('rejects dot and dot-dot segments outright', () => {
+    // Single-dot segments — the BROWSE_SH_SEGMENT_RE allowlist accepts `.`
+    // characters inside a longer segment, so these have to be rejected by
+    // the explicit `.` / `..` check.
+    expect(parseBrowseShRef('browse:./forecast')).toBeNull();
+    expect(parseBrowseShRef('browse:weather.gov/.')).toBeNull();
+    expect(parseBrowseShRef('browse:../forecast')).toBeNull();
+    expect(parseBrowseShRef('browse:weather.gov/..')).toBeNull();
+    expect(parseBrowseShRef('browse:./.')).toBeNull();
+    expect(parseBrowseShRef('browse:../..')).toBeNull();
+    // URL form must reject the same shapes.
+    expect(parseBrowseShRef('https://browse.sh/skills/./forecast')).toBeNull();
+    expect(parseBrowseShRef('https://browse.sh/skills/weather.gov/.')).toBeNull();
+    expect(parseBrowseShRef('https://browse.sh/skills/../etc')).toBeNull();
+    expect(parseBrowseShRef('https://browse.sh/skills/weather.gov/..')).toBeNull();
+  });
+
+  it('rejects empty hostname or task segments', () => {
+    expect(parseBrowseShRef('browse:/task')).toBeNull();
+    expect(parseBrowseShRef('browse:host/')).toBeNull();
+    expect(parseBrowseShRef('browse:/')).toBeNull();
+  });
+
   it('rejects missing segments', () => {
     expect(parseBrowseShRef('browse:weather.gov')).toBeNull();
     expect(parseBrowseShRef('browse:/get-forecast')).toBeNull();
@@ -1445,6 +1472,23 @@ describe('parseBrowseShRef', () => {
 
   it('rejects extra path segments', () => {
     expect(parseBrowseShRef('browse:weather.gov/get/forecast')).toBeNull();
+  });
+
+  it('normalizes hostname to lowercase and strips a leading www.', () => {
+    // Matches the rest of the browse.sh install/match logic, which compares
+    // against `normalizeHostname` output.
+    expect(parseBrowseShRef('browse:WEATHER.GOV/get-forecast')).toEqual({
+      hostname: 'weather.gov',
+      task: 'get-forecast',
+    });
+    expect(parseBrowseShRef('browse:www.weather.gov/get-forecast')).toEqual({
+      hostname: 'weather.gov',
+      task: 'get-forecast',
+    });
+    expect(parseBrowseShRef('https://browse.sh/skills/WWW.Weather.GOV/get-forecast')).toEqual({
+      hostname: 'weather.gov',
+      task: 'get-forecast',
+    });
   });
 
   it('returns null for unrelated refs', () => {
@@ -1731,6 +1775,140 @@ describe('upskill browse.sh registry integration', () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('browse.sh');
     expect(result.stderr).toContain('not found');
+  });
+
+  it('search round-robin interleaves Tessl and browse.sh hits (1T, 1B, 2T, 2B, …)', async () => {
+    // Three matches per source — enough to expose any per-source concatenation.
+    const tesslSkills = ['weather-tessl-1', 'weather-tessl-2', 'weather-tessl-3'].map(
+      (name, i) => ({
+        id: `tessl-${i + 1}`,
+        type: 'skill',
+        attributes: {
+          name,
+          description: `Tessl skill ${i + 1}`,
+          // Distinct sourceUrls — fetchTesslResults dedups by `sourceUrl`,
+          // so identical URLs would collapse the three Tessl rows into one
+          // and the interleaving assertion would silently degrade.
+          sourceUrl: `https://github.com/acme/${name}`,
+          path: `skills/${name}/SKILL.md`,
+          featured: false,
+          scores: {
+            aggregate: 0.9 - i * 0.1,
+            quality: null,
+            security: null,
+            evalImprovementMultiplier: null,
+          },
+        },
+      })
+    );
+    const browseSkills = ['get-forecast-aaa', 'get-radar-bbb', 'get-alerts-ccc'].map((task, i) => ({
+      slug: `weather.gov/${task}`,
+      hostname: 'weather.gov',
+      task,
+      name: task.replace(/-[a-z]+$/, ''),
+      title: `Browse skill ${i + 1} for weather`,
+      description: `Browse-weather variant ${i + 1}`,
+      tags: ['weather'],
+      updated: '2026-04-01',
+    }));
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('api.tessl.io')) {
+        return response(
+          200,
+          JSON.stringify({ meta: { pagination: { total: tesslSkills.length } }, data: tesslSkills })
+        );
+      }
+      if (url.includes('browse.sh/api/skills')) {
+        return response(200, JSON.stringify({ skills: browseSkills }));
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['search', 'weather'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    // Locate each display name in stdout and assert strict round-robin order:
+    // Tessl[0], browse.sh[0], Tessl[1], browse.sh[1], Tessl[2], browse.sh[2].
+    const positions = [
+      result.stdout.indexOf('weather-tessl-1'),
+      result.stdout.indexOf('weather.gov/get-forecast-aaa'),
+      result.stdout.indexOf('weather-tessl-2'),
+      result.stdout.indexOf('weather.gov/get-radar-bbb'),
+      result.stdout.indexOf('weather-tessl-3'),
+      result.stdout.indexOf('weather.gov/get-alerts-ccc'),
+    ];
+    expect(positions.every((p) => p >= 0)).toBe(true);
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i]).toBeGreaterThan(positions[i - 1]);
+    }
+  });
+
+  it('No skills found hint mentions both registries', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('api.tessl.io')) {
+        return response(200, JSON.stringify({ meta: { pagination: { total: 0 } }, data: [] }));
+      }
+      if (url.includes('browse.sh/api/skills')) {
+        return response(200, JSON.stringify({ skills: [] }));
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['search', 'nothingmatches'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('No skills found');
+    expect(result.stdout).toContain('tessl.io/registry');
+    expect(result.stdout).toContain('browse.sh');
+  });
+
+  it('refuses to install when upstream frontmatter declares an unsafe name', async () => {
+    const unsafeNames = [
+      'foo/../../shared', // path traversal via separator
+      '..', // bare dot-dot
+      '.', // bare dot
+      '/etc/passwd', // absolute path
+      'has space', // shell metachar
+      'a'.repeat(65), // over the 64-char cap
+    ];
+
+    for (const unsafe of unsafeNames) {
+      _resetBrowseShCatalogCache();
+      const skillMd = ['---', `name: ${unsafe}`, 'description: unsafe', '---', '', '# body'].join(
+        '\n'
+      );
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url === 'https://browse.sh/api/skills/weather.gov/get-forecast-1uezib') {
+          return response(
+            200,
+            JSON.stringify({
+              slug: 'weather.gov/get-forecast-1uezib',
+              hostname: 'weather.gov',
+              task: 'get-forecast-1uezib',
+              name: 'get-forecast',
+              skillMd,
+            })
+          );
+        }
+        throw new Error(`unexpected url: ${url}`);
+      });
+
+      const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+      const result = await cmd.execute(
+        ['browse:weather.gov/get-forecast-1uezib'],
+        createMockCtx() as any
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('unsafe name');
+      // Nothing escaped the skills root.
+      await expect(fs.stat('/workspace/skills/browse-weather.gov')).rejects.toBeTruthy();
+      await expect(fs.stat('/etc/passwd')).rejects.toBeTruthy();
+      await expect(fs.stat('/shared')).rejects.toBeTruthy();
+    }
   });
 });
 

--- a/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
@@ -7,11 +7,15 @@ import { VirtualFS } from '../../../src/fs/index.js';
 import {
   createSkillCommand,
   createUpskillCommand,
+  _resetBrowseShCatalogCache,
   _resetGlobalFsCache,
   installRecommendedSkills,
+  normalizeHostname,
+  parseBrowseShRef,
   parseGitHubRef,
   scoreSkills,
 } from '../../../src/shell/supplemental-commands/upskill-command.js';
+import type { BrowserAPI, PageInfo } from '../../../src/cdp/index.js';
 
 function createMockCtx() {
   const fs: Partial<IFileSystem> = {
@@ -407,24 +411,9 @@ describe('upskill Tessl registry integration', () => {
     vi.restoreAllMocks();
   });
 
-  it('search queries both ClawHub and Tessl registries', async () => {
+  it('search queries the Tessl registry', async () => {
+    _resetBrowseShCatalogCache();
     const fetchMock = vi.fn(async (url: string) => {
-      if (url.includes('convex.site')) {
-        return response(
-          200,
-          JSON.stringify({
-            results: [
-              {
-                slug: 'pdf-tool',
-                displayName: 'PDF Tool',
-                summary: 'Converts PDFs',
-                version: null,
-                updatedAt: 0,
-              },
-            ],
-          })
-        );
-      }
       if (url.includes('api.tessl.io')) {
         return response(
           200,
@@ -452,6 +441,9 @@ describe('upskill Tessl registry integration', () => {
           })
         );
       }
+      if (url.includes('browse.sh/api/skills')) {
+        return response(200, JSON.stringify({ skills: [] }));
+      }
       throw new Error(`unexpected url: ${url}`);
     });
 
@@ -459,15 +451,16 @@ describe('upskill Tessl registry integration', () => {
     const result = await cmd.execute(['search', 'pdf'], createMockCtx() as any);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('pdf-tool');
     expect(result.stdout).toContain('pdf-converter');
+    // Tessl + browse.sh catalog (browse.sh returns empty list for this query).
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('reports when both registries fail', async () => {
+  it('reports when registries fail', async () => {
+    _resetBrowseShCatalogCache();
     const fetchMock = vi.fn(async (url: string) => {
-      if (url.includes('convex.site')) return response(500, 'Internal Server Error');
       if (url.includes('api.tessl.io')) return response(503, 'Service Unavailable');
+      if (url.includes('browse.sh/api/skills')) return response(503, 'Service Unavailable');
       throw new Error(`unexpected url: ${url}`);
     });
 
@@ -475,7 +468,7 @@ describe('upskill Tessl registry integration', () => {
     const result = await cmd.execute(['search', 'anything'], createMockCtx() as any);
 
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain('both registries failed');
+    expect(result.stderr).toContain('registries failed');
   });
 
   it('tessl: shorthand resolves skill via Tessl API and installs from GitHub', async () => {
@@ -1414,5 +1407,549 @@ describe('upskill command — shell-injection defense', () => {
     expect(fetchMock).toHaveBeenCalled();
     expect(result.stderr).not.toContain('--branch must be a git ref');
     expect(result.stderr).not.toContain('--path must be a repo-relative sub-path');
+  });
+});
+
+describe('parseBrowseShRef', () => {
+  it('parses browse: shorthand', () => {
+    expect(parseBrowseShRef('browse:weather.gov/get-forecast-1uezib')).toEqual({
+      hostname: 'weather.gov',
+      task: 'get-forecast-1uezib',
+    });
+  });
+
+  it('parses the canonical URL form', () => {
+    expect(parseBrowseShRef('https://browse.sh/skills/weather.gov/get-forecast-1uezib')).toEqual({
+      hostname: 'weather.gov',
+      task: 'get-forecast-1uezib',
+    });
+  });
+
+  it('accepts a trailing slash on the URL form', () => {
+    expect(parseBrowseShRef('https://browse.sh/skills/weather.gov/get-forecast-1uezib/')).toEqual({
+      hostname: 'weather.gov',
+      task: 'get-forecast-1uezib',
+    });
+  });
+
+  it('rejects path traversal', () => {
+    expect(parseBrowseShRef('browse:../etc/passwd')).toBeNull();
+    expect(parseBrowseShRef('browse:weather.gov/../etc')).toBeNull();
+  });
+
+  it('rejects missing segments', () => {
+    expect(parseBrowseShRef('browse:weather.gov')).toBeNull();
+    expect(parseBrowseShRef('browse:/get-forecast')).toBeNull();
+    expect(parseBrowseShRef('browse:')).toBeNull();
+  });
+
+  it('rejects extra path segments', () => {
+    expect(parseBrowseShRef('browse:weather.gov/get/forecast')).toBeNull();
+  });
+
+  it('returns null for unrelated refs', () => {
+    expect(parseBrowseShRef('owner/repo')).toBeNull();
+    expect(parseBrowseShRef('tessl:postgres-pro')).toBeNull();
+    expect(parseBrowseShRef('https://github.com/owner/repo')).toBeNull();
+  });
+});
+
+describe('upskill browse.sh registry integration', () => {
+  let fs: VirtualFS;
+  let createdFileSystems: VirtualFS[];
+
+  beforeEach(async () => {
+    _resetBrowseShCatalogCache();
+    createdFileSystems = [];
+    const originalCreate = VirtualFS.create.bind(VirtualFS);
+    vi.spyOn(VirtualFS, 'create').mockImplementation(async (options) => {
+      const instance = await originalCreate(options);
+      createdFileSystems.push(instance);
+      return instance;
+    });
+
+    fs = await VirtualFS.create({ dbName: `upskill-browseSh-test-${dbCounter++}`, wipe: true });
+    await VirtualFS.create({ dbName: 'slicc-fs-global', wipe: true });
+  });
+
+  afterEach(async () => {
+    _resetGlobalFsCache();
+    _resetBrowseShCatalogCache();
+    await Promise.allSettled(
+      createdFileSystems.map((instance) =>
+        (instance.getLightningFS() as { _deactivate?: () => Promise<void> })._deactivate?.()
+      )
+    );
+    vi.restoreAllMocks();
+  });
+
+  const SAMPLE_CATALOG = [
+    {
+      slug: 'weather.gov/get-forecast-1uezib',
+      hostname: 'weather.gov',
+      task: 'get-forecast-1uezib',
+      name: 'get-forecast',
+      title: 'Get weather forecast',
+      description: 'Fetch the latest forecast from weather.gov',
+      tags: ['weather', 'noaa'],
+      updated: '2026-04-01',
+    },
+    {
+      slug: 'example.com/login-abc123',
+      hostname: 'example.com',
+      task: 'login-abc123',
+      name: 'login',
+      title: 'Log into example.com',
+      description: 'Sign in to the example portal',
+      tags: ['auth'],
+      updated: '2026-04-02',
+    },
+  ];
+
+  const UPSTREAM_SKILL_MD = [
+    '---',
+    'name: get-forecast',
+    'description: Fetch the latest forecast from weather.gov',
+    '---',
+    '',
+    '# Get the weather forecast',
+    '',
+    'Open weather.gov and read the forecast.',
+    '',
+  ].join('\n');
+
+  it('search merges browse.sh hits with Tessl results', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('api.tessl.io')) {
+        return response(200, JSON.stringify({ meta: { pagination: { total: 0 } }, data: [] }));
+      }
+      if (url.includes('browse.sh/api/skills')) {
+        return response(200, JSON.stringify({ skills: SAMPLE_CATALOG }));
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['search', 'weather'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('weather.gov/get-forecast-1uezib');
+    expect(result.stdout).toContain('[browseSh]');
+    // Description should appear in the rendered listing
+    expect(result.stdout).toContain('Fetch the latest forecast');
+  });
+
+  it('search filters the cached browse.sh catalog client-side', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('api.tessl.io')) {
+        return response(200, JSON.stringify({ meta: { pagination: { total: 0 } }, data: [] }));
+      }
+      if (url.includes('browse.sh/api/skills')) {
+        return response(200, JSON.stringify({ skills: SAMPLE_CATALOG }));
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['search', 'login'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('example.com/login-abc123');
+    expect(result.stdout).not.toContain('weather.gov/get-forecast');
+  });
+
+  it('installs a browse.sh skill via the blob URL and preserves upstream bytes around the preamble', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://browse.sh/api/skills/weather.gov/get-forecast-1uezib') {
+        return response(
+          200,
+          JSON.stringify({
+            slug: 'weather.gov/get-forecast-1uezib',
+            hostname: 'weather.gov',
+            task: 'get-forecast-1uezib',
+            name: 'get-forecast',
+            title: 'Get weather forecast',
+            description: 'Fetch the latest forecast',
+            updated: '2026-04-01',
+            skillMdUrl: 'https://blob.vercel-storage.com/skill.md',
+            skillMd: 'INLINE — should not be used when blob is reachable',
+          })
+        );
+      }
+      if (url === 'https://blob.vercel-storage.com/skill.md') {
+        return response(200, UPSTREAM_SKILL_MD);
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(
+      ['browse:weather.gov/get-forecast-1uezib'],
+      createMockCtx() as any
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Installed skill "browse-weather.gov-get-forecast"');
+
+    const installed = await fs.readTextFile(
+      '/workspace/skills/browse-weather.gov-get-forecast/SKILL.md'
+    );
+
+    // Frontmatter is the very first thing in the file (must remain valid).
+    expect(installed.startsWith('---\n')).toBe(true);
+
+    // The frontmatter must round-trip byte-identical.
+    expect(installed).toContain(
+      '---\nname: get-forecast\ndescription: Fetch the latest forecast from weather.gov\n---\n'
+    );
+
+    // The SLICC preamble lands BELOW the frontmatter and ABOVE the body.
+    expect(installed).toContain('Imported from browse.sh');
+    expect(installed).toContain('playwright-cli');
+    expect(installed).toContain('weather.gov/get-forecast-1uezib');
+    const preambleIdx = installed.indexOf('Imported from browse.sh');
+    const fmCloseIdx = installed.indexOf('---\n', 4);
+    const bodyIdx = installed.indexOf('# Get the weather forecast');
+    expect(fmCloseIdx).toBeGreaterThan(0);
+    expect(preambleIdx).toBeGreaterThan(fmCloseIdx);
+    expect(bodyIdx).toBeGreaterThan(preambleIdx);
+
+    // The upstream body remains byte-identical.
+    expect(installed).toContain(
+      '# Get the weather forecast\n\nOpen weather.gov and read the forecast.\n'
+    );
+  });
+
+  it('URL form installs the same skill as the browse: shorthand', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://browse.sh/api/skills/weather.gov/get-forecast-1uezib') {
+        return response(
+          200,
+          JSON.stringify({
+            slug: 'weather.gov/get-forecast-1uezib',
+            hostname: 'weather.gov',
+            task: 'get-forecast-1uezib',
+            name: 'get-forecast',
+            skillMd: UPSTREAM_SKILL_MD,
+          })
+        );
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(
+      ['https://browse.sh/skills/weather.gov/get-forecast-1uezib'],
+      createMockCtx() as any
+    );
+
+    expect(result.exitCode).toBe(0);
+    await expect(
+      fs.readTextFile('/workspace/skills/browse-weather.gov-get-forecast/SKILL.md')
+    ).resolves.toContain('Get the weather forecast');
+  });
+
+  it('falls back to inline skillMd when the blob fetch fails', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://browse.sh/api/skills/weather.gov/get-forecast-1uezib') {
+        return response(
+          200,
+          JSON.stringify({
+            slug: 'weather.gov/get-forecast-1uezib',
+            hostname: 'weather.gov',
+            task: 'get-forecast-1uezib',
+            name: 'get-forecast',
+            skillMdUrl: 'https://blob.vercel-storage.com/skill.md',
+            skillMd: UPSTREAM_SKILL_MD,
+          })
+        );
+      }
+      if (url === 'https://blob.vercel-storage.com/skill.md') {
+        return response(500, 'Internal Server Error');
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(
+      ['browse:weather.gov/get-forecast-1uezib'],
+      createMockCtx() as any
+    );
+
+    expect(result.exitCode).toBe(0);
+    await expect(
+      fs.readTextFile('/workspace/skills/browse-weather.gov-get-forecast/SKILL.md')
+    ).resolves.toContain('# Get the weather forecast');
+  });
+
+  it('refuses to overwrite an existing install without --force', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://browse.sh/api/skills/weather.gov/get-forecast-1uezib') {
+        return response(
+          200,
+          JSON.stringify({
+            slug: 'weather.gov/get-forecast-1uezib',
+            hostname: 'weather.gov',
+            task: 'get-forecast-1uezib',
+            name: 'get-forecast',
+            skillMd: UPSTREAM_SKILL_MD,
+          })
+        );
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const first = await cmd.execute(
+      ['browse:weather.gov/get-forecast-1uezib'],
+      createMockCtx() as any
+    );
+    expect(first.exitCode).toBe(0);
+
+    const second = await cmd.execute(
+      ['browse:weather.gov/get-forecast-1uezib'],
+      createMockCtx() as any
+    );
+    expect(second.exitCode).toBe(1);
+    expect(second.stderr).toContain('already exists');
+    expect(second.stderr).toContain('--force');
+
+    const forced = await cmd.execute(
+      ['browse:weather.gov/get-forecast-1uezib', '--force'],
+      createMockCtx() as any
+    );
+    expect(forced.exitCode).toBe(0);
+    expect(forced.stdout).toContain('Installed skill');
+  });
+
+  it('reports a 404 from browse.sh as a clean install error', async () => {
+    const fetchMock = vi.fn(async () => response(404, '{"error":"not found"}'));
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['browse:weather.gov/missing'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('browse.sh');
+    expect(result.stderr).toContain('not found');
+  });
+});
+
+describe('normalizeHostname', () => {
+  it('strips a single leading www. and lowercases', () => {
+    expect(normalizeHostname('www.Weather.gov')).toBe('weather.gov');
+    expect(normalizeHostname('WEATHER.GOV')).toBe('weather.gov');
+    expect(normalizeHostname('weather.gov')).toBe('weather.gov');
+  });
+
+  it('does not strip non-www subdomains', () => {
+    expect(normalizeHostname('api.weather.gov')).toBe('api.weather.gov');
+    expect(normalizeHostname('www2.weather.gov')).toBe('www2.weather.gov');
+  });
+});
+
+describe('upskill tabs', () => {
+  let fs: VirtualFS;
+  let createdFileSystems: VirtualFS[];
+
+  beforeEach(async () => {
+    _resetBrowseShCatalogCache();
+    createdFileSystems = [];
+    const originalCreate = VirtualFS.create.bind(VirtualFS);
+    vi.spyOn(VirtualFS, 'create').mockImplementation(async (options) => {
+      const instance = await originalCreate(options);
+      createdFileSystems.push(instance);
+      return instance;
+    });
+    fs = await VirtualFS.create({ dbName: `upskill-tabs-test-${dbCounter++}`, wipe: true });
+    await VirtualFS.create({ dbName: 'slicc-fs-global', wipe: true });
+  });
+
+  afterEach(async () => {
+    _resetGlobalFsCache();
+    _resetBrowseShCatalogCache();
+    await Promise.allSettled(
+      createdFileSystems.map((instance) =>
+        (instance.getLightningFS() as { _deactivate?: () => Promise<void> })._deactivate?.()
+      )
+    );
+    vi.restoreAllMocks();
+  });
+
+  const TABS_CATALOG = [
+    {
+      slug: 'weather.gov/get-forecast-1uezib',
+      hostname: 'weather.gov',
+      task: 'get-forecast-1uezib',
+      name: 'get-forecast',
+      title: 'Get weather forecast',
+      description: 'Fetch the latest forecast',
+      tags: ['weather'],
+      updated: '2026-04-01',
+    },
+  ];
+
+  function makeBrowser(pages: PageInfo[]): BrowserAPI {
+    return {
+      listPages: vi.fn(async () => pages),
+    } as unknown as BrowserAPI;
+  }
+
+  it('exits non-zero with a clear error when BrowserAPI is missing', async () => {
+    const fetchMock = vi.fn();
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['tabs'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('browser APIs unavailable');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports an empty listing when no tabs are open', async () => {
+    const fetchMock = vi.fn();
+    const browser = makeBrowser([]);
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch, browser);
+    const result = await cmd.execute(['tabs'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('No open browser tabs');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('matches browse.sh catalog entries by hostname (stripping www.)', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('browse.sh/api/skills')) {
+        return response(200, JSON.stringify({ skills: TABS_CATALOG }));
+      }
+      // Tab page fetch — no Link header.
+      return response(200, '<html></html>', {});
+    });
+    const browser = makeBrowser([
+      { targetId: 't1', title: 'Forecast', url: 'https://www.weather.gov/forecast', active: true },
+    ]);
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch, browser);
+    const result = await cmd.execute(['tabs'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Forecast');
+    expect(result.stdout).toContain('Browse.sh catalog');
+    expect(result.stdout).toContain('Get weather forecast');
+    expect(result.stdout).toContain('upskill browse:weather.gov/get-forecast-1uezib');
+    // Not installed → no checkmark prefix.
+    expect(result.stdout).not.toContain('✓ Get weather forecast');
+  });
+
+  it('marks catalog matches installed when a matching skill directory exists', async () => {
+    await fs.mkdir('/workspace/skills/browse-weather.gov-get-forecast', { recursive: true });
+    await fs.writeFile(
+      '/workspace/skills/browse-weather.gov-get-forecast/SKILL.md',
+      '---\nname: get-forecast\n---\n'
+    );
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('browse.sh/api/skills')) {
+        return response(200, JSON.stringify({ skills: TABS_CATALOG }));
+      }
+      return response(200, '<html></html>', {});
+    });
+    const browser = makeBrowser([
+      { targetId: 't1', title: 'Forecast', url: 'https://weather.gov/forecast' },
+    ]);
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch, browser);
+    const result = await cmd.execute(['tabs'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('✓ Get weather forecast');
+  });
+
+  it('surfaces origin-advertised upskill rels from a tab Link header', async () => {
+    const linkHeader =
+      '<https://github.com/acme/skills>; rel="https://www.sliccy.ai/rel/upskill"; title="Acme skills"';
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('browse.sh/api/skills')) {
+        return response(200, JSON.stringify({ skills: [] }));
+      }
+      if (url === 'https://acme.example/docs') {
+        return response(200, '<html></html>', { Link: linkHeader });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+    const browser = makeBrowser([
+      { targetId: 't1', title: 'Acme', url: 'https://acme.example/docs' },
+    ]);
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch, browser);
+    const result = await cmd.execute(['tabs'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Origin-advertised');
+    expect(result.stdout).toContain('upskill https://github.com/acme/skills');
+    expect(result.stdout).toContain('Acme skills');
+  });
+
+  it('treats per-tab fetch failures as non-fatal and continues other tabs', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('browse.sh/api/skills')) {
+        return response(200, JSON.stringify({ skills: TABS_CATALOG }));
+      }
+      if (url === 'https://broken.example/') {
+        throw new Error('network down');
+      }
+      return response(200, '<html></html>', {});
+    });
+    const browser = makeBrowser([
+      { targetId: 't1', title: 'Broken', url: 'https://broken.example/' },
+      { targetId: 't2', title: 'OK', url: 'https://weather.gov/forecast' },
+    ]);
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch, browser);
+    const result = await cmd.execute(['tabs'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('discovery failed');
+    expect(result.stdout).toContain('network down');
+    // Second tab still surfaces its catalog match.
+    expect(result.stdout).toContain('Get weather forecast');
+  });
+
+  it('emits structured JSON when --json is passed', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('browse.sh/api/skills')) {
+        return response(200, JSON.stringify({ skills: TABS_CATALOG }));
+      }
+      return response(200, '<html></html>', {});
+    });
+    const browser = makeBrowser([
+      { targetId: 't1', title: 'Forecast', url: 'https://weather.gov/forecast', active: true },
+    ]);
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch, browser);
+    const result = await cmd.execute(['tabs', '--json'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.tabs).toHaveLength(1);
+    expect(parsed.tabs[0].hostname).toBe('weather.gov');
+    expect(parsed.tabs[0].catalog).toHaveLength(1);
+    expect(parsed.tabs[0].catalog[0].slug).toBe('weather.gov/get-forecast-1uezib');
+    expect(parsed.tabs[0].catalog[0].installed).toBe(false);
+    expect(parsed.tabs[0].active).toBe(true);
+  });
+
+  it('still surfaces origin rels when browse.sh catalog fetch fails', async () => {
+    const linkHeader = '<https://github.com/acme/skills>; rel="https://www.sliccy.ai/rel/upskill"';
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('browse.sh/api/skills')) {
+        return response(503, 'Service Unavailable');
+      }
+      if (url === 'https://acme.example/') {
+        return response(200, '<html></html>', { link: linkHeader });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+    const browser = makeBrowser([{ targetId: 't1', title: 'Acme', url: 'https://acme.example/' }]);
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch, browser);
+    const result = await cmd.execute(['tabs'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('browse.sh catalog unavailable');
+    expect(result.stdout).toContain('Origin-advertised');
+    expect(result.stdout).toContain('upskill https://github.com/acme/skills');
   });
 });


### PR DESCRIPTION
## Summary

Replaces the ClawHub upskill backend with **browse.sh** (~250 site-specific skills, single `SKILL.md` per skill, CORS-open API) and adds two new surfaces that build on PR #602's RFC 8288 `Link`-header discovery to make browse.sh skills contextually visible.

Rebased onto `main` at `77ab473d` (the PR #602 merge).

## What changed

### Removed
- **ClawHub backend** end-to-end: constants, types, fetcher, installer, parser, dispatcher branch, help text, tests, and doc references. Rationale: its runtime model (Convex backend + ZIP bundles with arbitrary scripts) didn't fit the "single SKILL.md from a public URL" pattern that browse.sh and Tessl share.

### Added
- **browse.sh as the third `upskill` registry** alongside Tessl and GitHub.
  - Install refs: `upskill browse:<hostname>/<task>` or `upskill https://browse.sh/skills/<hostname>/<task>`.
  - Installer prefers Vercel Blob (`skillMdUrl`, CORS-safe) with inline `skillMd` fallback.
  - Installs to `/workspace/skills/browse-{hostname}-{name}/SKILL.md`.
  - Search interleaves Tessl + browse.sh via `Promise.allSettled`.
- **SLICC adapter preamble** inserted directly below the upstream YAML frontmatter (not above, so the frontmatter remains valid frontmatter). Uniform for every `recommendedMethod` — no branching. Conveys: imported-from-browse.sh + slug; "use `playwright-cli` — you are running inside the user's real browser, so bot detection is less of an issue"; source attribution + upstream `updated` date. Upstream frontmatter and body round-trip byte-identical around it.
- **`upskill tabs [--json]`** subcommand. For each open browser tab, surfaces both:
  - Origin-advertised `upskill` rels via PR #602's `discoverLinks` over the proxied fetch, and
  - Matching browse.sh catalog skills (installed-vs-available marker by checking `/workspace/skills/browse-{hostname}-*`).
- **`playwright-cli {fetch,goto,open} --discover`** JSON output now includes an optional `discovery.browseShSkills?: SkillSummary[]` field for the destination hostname.
  - **Lazy catalog warm**: cold cache triggers one ~200KB CORS-open fetch per shell session (the user opted in via `--discover`).
  - Graceful degrade on catalog failure (stderr warning + field omitted).
  - **Bare `playwright-cli` triggers zero browse.sh I/O** (asserted by test).

### Architecture notes
- Single source of truth for hostname normalization (`normalizeHostname` — lowercases + strips a single leading `www.`) and the catalog cache (`fetchBrowseShCatalog`), both exported from `upskill-command.ts` and reused by `playwright-command.ts`.
- All cross-origin fetches route through `createProxiedFetch` (CLI: Express proxy; extension: SW Port), so origin parity is preserved.

## Files changed (+1586 / -338)

- `packages/webapp/src/shell/supplemental-commands/upskill-command.ts`
- `packages/webapp/src/shell/supplemental-commands/playwright-command.ts`
- `packages/webapp/src/shell/wasm-shell-headless.ts` (plumb optional `BrowserAPI` arg to `createUpskillCommand`)
- `packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts`
- `packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts`
- `docs/architecture.md`
- `docs/shell-reference.md`
- `packages/vfs-root/shared/CLAUDE.md`

## Tests

**+28 new tests:**
- 14 for the browse.sh backend (ref parsing, search merging/filtering, install success, blob→inline fallback, `--force` collision, 404, byte-identical preamble round-trip, …)
- 7 for `upskill tabs` (missing `BrowserAPI`, empty tabs, `www`-normalized match, installed marker, origin Link-header rel, per-tab failure isolation, JSON mode, catalog-fetch failure)
- 7 for `--discover` hook (hostname match, installed marker, `www.` normalization, lazy fetch on cold cache, catalog-failure stderr warning, cache reuse, open/goto parity, no-fetch-without-`--discover`)

**Full verification** (run by a verifier sub-agent on the final state):
- `npx prettier --check .` — pass
- `npm run typecheck` — pass
- `npm run test` — pass (exit 0; 3947 total tests)
- `npm run build -w @slicc/webapp` — pass
- `npm run build -w @slicc/chrome-extension` — pass

## Non-goals (out of scope)

- Bare-navigation hint on `playwright open/tab-new/goto`. PR #602's `NavigationWatcher` already handles origin-advertised upskill rels; third-party browse.sh suggestions are opt-in via `--discover` or `upskill tabs`.
- LLM-rewriting browse.sh skill bodies. The adapter preamble is a fixed, deterministic header — the upstream body is byte-identical.
- Background / pre-emptive catalog refresh. One fetch-on-demand per shell session is enough.

## Manual smoke

```bash
upskill search weather                                 # Tessl + browse.sh interleaved
upskill browse:weather.gov/get-forecast-1uezib         # installs with preamble below frontmatter
upskill tabs --json                                    # per-tab origin rels + catalog matches
playwright-cli fetch https://weather.gov --discover    # JSON has discovery.browseShSkills[]
```


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author