### PR TITLE
fix(node-server): cache headers on built UI so post-update stale-bundle goes away

### DIFF
--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -1532,37 +1532,51 @@ async function main() {
     app.use(
       express.static(uiDir, {
         setHeaders: (res, path) => {
-          // Service workers must declare a maximum scope; without
-          // `Service-Worker-Allowed: /`, the browser refuses to register
-          // a root-scoped SW served from `/llm-proxy-sw.js`. Also force
-          // `no-store` on SWs so a fresh registration always picks up
-          // the new bundle hashes the SW preloads/intercepts.
-          if (path.endsWith('llm-proxy-sw.js')) {
-            res.setHeader('Service-Worker-Allowed', '/');
-            res.setHeader('Cache-Control', 'no-store');
-            return;
-          }
-          // Vite emits content-hashed filenames into `/assets/` — the
-          // hash changes when content changes, so the file at a given
-          // URL is byte-for-byte immutable. Tell the browser to cache
-          // forever to avoid revalidation round-trips. The `path`
-          // parameter is a filesystem path (uses `sep` on Windows,
-          // `/` elsewhere), hence the platform-aware match.
-          if (path.includes(`${sep}assets${sep}`)) {
-            res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-            return;
-          }
-          // Everything else (HTML, manifest, sprinkle-sandbox.html, etc.)
-          // is NOT content-hashed and references hashed asset URLs that
-          // change on rebuild. If the browser serves a stale `index.html`
-          // out of its heuristic cache, the referenced `/assets/*` chunks
-          // will 404 after an update — the user sees
+          // Default Cache-Control for anything not classified below:
+          // HTML, manifest, sprinkle-sandbox.html, publicDir fonts/logos,
+          // favicon, etc. None of these are content-hashed and they
+          // reference hashed asset URLs that change on rebuild. If the
+          // browser serves a stale `index.html` out of its heuristic
+          // cache, the referenced `/assets/*` chunks 404 after an update
+          // — the user sees
           //   "Failed to fetch dynamically imported module: …/assets/<old-hash>.js"
           // on every cone bootstrap until they hard-refresh.
           // `no-cache` forces a conditional revalidation on every load
-          // (cheap — `If-None-Match` returns 304 when unchanged) so the
-          // tab picks up a freshly-built `index.html` after `npm run build`.
-          res.setHeader('Cache-Control', 'no-cache');
+          // (cheap — `serve-static`'s default ETag yields a 304 when
+          // unchanged) so the tab picks up a freshly-built `index.html`
+          // after `npm run build`.
+          //
+          // The single `setHeader` at the end is intentional: each
+          // branch overrides the default by assigning to `cacheControl`.
+          // To add a fourth bucket, add an `else if` ABOVE the final
+          // assignment — never a separate `setHeader` after, or the
+          // catch-all silently wins.
+          let cacheControl = 'no-cache';
+          if (path.endsWith('llm-proxy-sw.js') || path.endsWith('preview-sw.js')) {
+            // Service workers need `Service-Worker-Allowed: /` for the
+            // root-scoped registration `llm-proxy-sw.js` does (the
+            // `preview-sw.js` SW registers at scope `/preview/`, which
+            // is narrower than `/` so the broader allowance is harmless).
+            //
+            // `no-store`, not `no-cache`: the browser only re-checks
+            // the SW script on navigation/registration, so the safest
+            // signal is "always pull the latest bytes." A stale SW
+            // pinned in cache would intercept fetch / dispatch
+            // `preview/*` with outdated logic (e.g. an old fetch-proxy
+            // domain list, missing a provider) — that's a worse
+            // failure mode than the `no-cache` revalidation cost.
+            res.setHeader('Service-Worker-Allowed', '/');
+            cacheControl = 'no-store';
+          } else if (path.includes(`${sep}assets${sep}`)) {
+            // Vite emits content-hashed filenames into `/assets/` —
+            // the hash changes when content changes, so the file at a
+            // given URL is byte-for-byte immutable. Cache forever to
+            // avoid revalidation round-trips. The `path` parameter is
+            // a filesystem path (uses `sep` on Windows, `/` elsewhere),
+            // hence the platform-aware match.
+            cacheControl = 'public, max-age=31536000, immutable';
+          }
+          res.setHeader('Cache-Control', cacheControl);
         },
       })
     );

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -3,7 +3,7 @@ import { createServer } from 'http';
 import { createServer as createNetServer } from 'net';
 import { spawn, type ChildProcess } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
-import { join, resolve, dirname } from 'path';
+import { join, resolve, dirname, sep } from 'path';
 import { homedir } from 'os';
 import { Readable, Transform } from 'stream';
 import { StringDecoder } from 'string_decoder';
@@ -1534,17 +1534,45 @@ async function main() {
         setHeaders: (res, path) => {
           // Service workers must declare a maximum scope; without
           // `Service-Worker-Allowed: /`, the browser refuses to register
-          // a root-scoped SW served from `/llm-proxy-sw.js`.
+          // a root-scoped SW served from `/llm-proxy-sw.js`. Also force
+          // `no-store` on SWs so a fresh registration always picks up
+          // the new bundle hashes the SW preloads/intercepts.
           if (path.endsWith('llm-proxy-sw.js')) {
             res.setHeader('Service-Worker-Allowed', '/');
             res.setHeader('Cache-Control', 'no-store');
+            return;
           }
+          // Vite emits content-hashed filenames into `/assets/` — the
+          // hash changes when content changes, so the file at a given
+          // URL is byte-for-byte immutable. Tell the browser to cache
+          // forever to avoid revalidation round-trips. The `path`
+          // parameter is a filesystem path (uses `sep` on Windows,
+          // `/` elsewhere), hence the platform-aware match.
+          if (path.includes(`${sep}assets${sep}`)) {
+            res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+            return;
+          }
+          // Everything else (HTML, manifest, sprinkle-sandbox.html, etc.)
+          // is NOT content-hashed and references hashed asset URLs that
+          // change on rebuild. If the browser serves a stale `index.html`
+          // out of its heuristic cache, the referenced `/assets/*` chunks
+          // will 404 after an update — the user sees
+          //   "Failed to fetch dynamically imported module: …/assets/<old-hash>.js"
+          // on every cone bootstrap until they hard-refresh.
+          // `no-cache` forces a conditional revalidation on every load
+          // (cheap — `If-None-Match` returns 304 when unchanged) so the
+          // tab picks up a freshly-built `index.html` after `npm run build`.
+          res.setHeader('Cache-Control', 'no-cache');
         },
       })
     );
 
-    // SPA fallback — serve index.html for all non-file routes
+    // SPA fallback — serve index.html for all non-file routes. Same
+    // `no-cache` reasoning as above: the served `index.html` carries
+    // references to the current asset hashes, and stale-cached HTML
+    // is the canonical post-update breakage.
     app.get('/{*path}', (_req, res) => {
+      res.setHeader('Cache-Control', 'no-cache');
       res.sendFile(join(uiDir, 'index.html'));
     });
   }

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -1562,9 +1562,11 @@ async function main() {
             // the SW script on navigation/registration, so the safest
             // signal is "always pull the latest bytes." A stale SW
             // pinned in cache would intercept fetch / dispatch
-            // `preview/*` with outdated logic (e.g. an old fetch-proxy
-            // domain list, missing a provider) — that's a worse
-            // failure mode than the `no-cache` revalidation cost.
+            // `preview/*` with outdated logic (e.g. an outdated
+            // forbidden-header encoding scheme that no longer matches
+            // the server-side restoration in `index.ts`, or a stale
+            // `preview-sw` VFS handler) — that's a worse failure mode
+            // than the `no-cache` revalidation cost.
             res.setHeader('Service-Worker-Allowed', '/');
             cacheControl = 'no-store';
           } else if (path.includes(`${sep}assets${sep}`)) {


### PR DESCRIPTION
## Symptom (user report)

After updating SLICC (e.g. \`npm i -g sliccy@latest\`) and starting the standalone server, the cone bootstrap loop fails with:

\`\`\`
Scoop "Cone" failed after 3 attempts:
Failed to fetch dynamically imported module:
http://localhost:5710/assets/anthropic-<oldhash>.js
\`\`\`

repeating constantly until the user hard-refreshes the tab.

## Root cause

\`packages/node-server/src/index.ts\` mounts \`express.static(uiDir, { setHeaders })\` but the \`setHeaders\` callback only handled \`llm-proxy-sw.js\`. \`index.html\` and the \`/assets/*\` chunks fell through to Express defaults — which sends NO \`Cache-Control\` header at all, so browsers apply heuristic freshness based on \`Last-Modified\`. A long-running tab keeps using its cached \`index.html\` after a server rebuild, but that cached HTML references the previous Vite hashes (e.g. \`anthropic-8dSWvEaO.js\`). The new build emits different hashes (e.g. \`anthropic-4ASJTRhO.js\`), so every dynamic-import 404s.

## Fix

Three header classes in the static middleware:

| File pattern | Cache-Control | Why |
|---|---|---|
| \`index.html\` and other non-hashed files (manifest, \`sprinkle-sandbox.html\`, ...) | \`no-cache\` | Conditional revalidation every load — cheap (304 on unchanged), guarantees tabs pick up new asset references after a rebuild |
| \`/assets/*\` (content-hashed chunks) | \`public, max-age=31536000, immutable\` | Safe forever — the hash in the URL changes when content changes |
| \`llm-proxy-sw.js\` | \`no-store\` + \`Service-Worker-Allowed: /\` | unchanged from existing handling |

Also applied \`no-cache\` to the SPA fallback (\`app.get('/{*path}', …)\`) since \`res.sendFile\` bypasses the static-middleware \`setHeaders\` callback.

Platform-aware path match (uses \`sep\` from \`path\` so Windows backslashes are recognised).

## Scope

- **Affected**: standalone CLI / Electron float served from \`packages/node-server/\` (the path the user hit).
- **Not affected**: Cloudflare worker static-assets binding (sliccy.ai) — Cloudflare Workers Static Assets sends ETag-based revalidation by default, which already handles this case correctly.

## Verification

- \`npm run typecheck\` clean.
- \`npm run build\` of the node-server succeeds.
- Manual test: build, refresh tab, observe \`index.html\` responds with \`Cache-Control: no-cache\` and \`/assets/anthropic-*.js\` responds with \`Cache-Control: public, max-age=31536000, immutable\` via the network panel.

## Test coverage

The static-middleware \`setHeaders\` callback is currently not unit-tested (Express middleware behavior is integration-level). Adding a test would need an HTTP-level fixture — out of scope for the minimal fix. The behavior is exercised by every standalone CLI smoke run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)