### PR TITLE
fix(swift-server): cache headers on built UI so post-update stale-bundle goes away

### DIFF
--- a/packages/swift-server/Sources/Server/StaticFileMiddleware.swift
+++ b/packages/swift-server/Sources/Server/StaticFileMiddleware.swift
@@ -78,10 +78,13 @@ extension StaticFileMiddleware {
     ///
     /// Three buckets:
     /// - `/llm-proxy-sw.js`, `/preview-sw.js`: `no-store` so the browser
-    ///   always pulls the latest SW bytes on navigation/registration.
-    ///   `llm-proxy-sw.js` additionally needs `Service-Worker-Allowed: /`
-    ///   for its root-scope registration; `preview-sw.js` registers at
-    ///   `/preview/` (narrower) so the broader allowance is unnecessary.
+    ///   always pulls the latest SW bytes on navigation/registration,
+    ///   plus `Service-Worker-Allowed: /` so the SW can claim a wider
+    ///   scope than its serve path. `llm-proxy-sw.js` actually needs
+    ///   the root scope; `preview-sw.js` registers at `/preview/`
+    ///   (narrower), but Node sends the header for both — matching here
+    ///   keeps the two implementations byte-for-byte identical and the
+    ///   broader allowance is harmless.
     /// - `/assets/*`: Vite emits content-hashed filenames here, so each
     ///   URL is byte-for-byte immutable — cache forever to avoid
     ///   revalidation round-trips.
@@ -90,7 +93,7 @@ extension StaticFileMiddleware {
     ///   on every load. Cheap (304 on unchanged) and guarantees tabs pick
     ///   up the new asset references after a rebuild.
     static func applyCacheHeaders(path: String, response: inout Response) {
-        if path == "/llm-proxy-sw.js" {
+        if path == "/llm-proxy-sw.js" || path == "/preview-sw.js" {
             response.headers[HTTPField.Name("Service-Worker-Allowed")!] = "/"
         }
         response.headers[HTTPField.Name.cacheControl] = cacheControlValue(forPath: path)

--- a/packages/swift-server/Sources/Server/StaticFileMiddleware.swift
+++ b/packages/swift-server/Sources/Server/StaticFileMiddleware.swift
@@ -37,7 +37,7 @@ struct StaticFileMiddleware<Context: RequestContext>: RouterMiddleware {
 
         do {
             var response = try await self.fileMiddleware.handle(request, context: context, next: next)
-            Self.applyServiceWorkerHeaders(path: request.uri.path, response: &response)
+            Self.applyCacheHeaders(path: request.uri.path, response: &response)
             return response
         } catch {
             guard Self.shouldServeSPAFallback(method: request.method, path: request.uri.path, error: error) else {
@@ -45,9 +45,11 @@ struct StaticFileMiddleware<Context: RequestContext>: RouterMiddleware {
             }
 
             let fallbackRequest = self.rewritingRequestPath(request, to: self.fallbackFilePath)
-            return try await self.fileMiddleware.handle(fallbackRequest, context: context) { _, _ in
+            var fallbackResponse = try await self.fileMiddleware.handle(fallbackRequest, context: context) { _, _ in
                 throw HTTPError(.notFound)
             }
+            Self.applyCacheHeaders(path: self.fallbackFilePath, response: &fallbackResponse)
+            return fallbackResponse
         }
     }
 
@@ -67,14 +69,41 @@ extension StaticFileMiddleware {
         return responseError.status == .notFound
     }
 
-    /// The root-scope LLM-proxy SW must declare its maximum scope via the
-    /// `Service-Worker-Allowed: /` response header; without it the browser
-    /// refuses to register a SW with a wider scope than its serve path.
-    /// Also disable caching so dev rebuilds always reach the page.
-    static func applyServiceWorkerHeaders(path: String, response: inout Response) {
-        guard path == "/llm-proxy-sw.js" else { return }
-        response.headers[HTTPField.Name("Service-Worker-Allowed")!] = "/"
-        response.headers[HTTPField.Name.cacheControl] = "no-store"
+    /// Mirrors the Express middleware in `packages/node-server/src/index.ts`
+    /// (PR #710). Without these headers, browsers apply heuristic freshness
+    /// to `index.html` and the unhashed shells based on `Last-Modified`, so
+    /// a long-running tab keeps using cached HTML after a server rebuild
+    /// and every dynamic `import()` of `/assets/<old-hash>.js` 404s until
+    /// the user hard-refreshes.
+    ///
+    /// Three buckets:
+    /// - `/llm-proxy-sw.js`, `/preview-sw.js`: `no-store` so the browser
+    ///   always pulls the latest SW bytes on navigation/registration.
+    ///   `llm-proxy-sw.js` additionally needs `Service-Worker-Allowed: /`
+    ///   for its root-scope registration; `preview-sw.js` registers at
+    ///   `/preview/` (narrower) so the broader allowance is unnecessary.
+    /// - `/assets/*`: Vite emits content-hashed filenames here, so each
+    ///   URL is byte-for-byte immutable — cache forever to avoid
+    ///   revalidation round-trips.
+    /// - Everything else (`index.html`, manifest, `sprinkle-sandbox.html`,
+    ///   favicon, fonts, ...): `no-cache` forces a conditional revalidation
+    ///   on every load. Cheap (304 on unchanged) and guarantees tabs pick
+    ///   up the new asset references after a rebuild.
+    static func applyCacheHeaders(path: String, response: inout Response) {
+        if path == "/llm-proxy-sw.js" {
+            response.headers[HTTPField.Name("Service-Worker-Allowed")!] = "/"
+        }
+        response.headers[HTTPField.Name.cacheControl] = cacheControlValue(forPath: path)
+    }
+
+    static func cacheControlValue(forPath path: String) -> String {
+        if path == "/llm-proxy-sw.js" || path == "/preview-sw.js" {
+            return "no-store"
+        }
+        if path.hasPrefix("/assets/") {
+            return "public, max-age=31536000, immutable"
+        }
+        return "no-cache"
     }
 
     static func isReservedPath(_ path: String) -> Bool {

--- a/packages/swift-server/Tests/StaticFileMiddlewareTests.swift
+++ b/packages/swift-server/Tests/StaticFileMiddlewareTests.swift
@@ -78,7 +78,7 @@ final class StaticFileMiddlewareTests: XCTestCase {
         )
     }
 
-    func testApplyCacheHeadersServiceWorkerAllowedOnlyOnLlmProxy() {
+    func testApplyCacheHeadersServiceWorkerAllowedOnBothSWPaths() {
         var response = Response(status: .ok)
         StaticFileMiddleware<BasicRequestContext>.applyCacheHeaders(path: "/llm-proxy-sw.js", response: &response)
         XCTAssertEqual(response.headers[HTTPField.Name.cacheControl], "no-store")
@@ -87,7 +87,7 @@ final class StaticFileMiddlewareTests: XCTestCase {
         var previewResponse = Response(status: .ok)
         StaticFileMiddleware<BasicRequestContext>.applyCacheHeaders(path: "/preview-sw.js", response: &previewResponse)
         XCTAssertEqual(previewResponse.headers[HTTPField.Name.cacheControl], "no-store")
-        XCTAssertNil(previewResponse.headers[HTTPField.Name("Service-Worker-Allowed")!])
+        XCTAssertEqual(previewResponse.headers[HTTPField.Name("Service-Worker-Allowed")!], "/")
 
         var assetResponse = Response(status: .ok)
         StaticFileMiddleware<BasicRequestContext>.applyCacheHeaders(path: "/assets/x.js", response: &assetResponse)

--- a/packages/swift-server/Tests/StaticFileMiddlewareTests.swift
+++ b/packages/swift-server/Tests/StaticFileMiddlewareTests.swift
@@ -1,4 +1,5 @@
 import Hummingbird
+import HTTPTypes
 import XCTest
 @testable import slicc_server
 
@@ -34,5 +35,68 @@ final class StaticFileMiddlewareTests: XCTestCase {
             path: "/dashboard",
             error: HTTPError(.internalServerError)
         ))
+    }
+
+    func testCacheControlValueForServiceWorkers() {
+        XCTAssertEqual(
+            StaticFileMiddleware<BasicRequestContext>.cacheControlValue(forPath: "/llm-proxy-sw.js"),
+            "no-store"
+        )
+        XCTAssertEqual(
+            StaticFileMiddleware<BasicRequestContext>.cacheControlValue(forPath: "/preview-sw.js"),
+            "no-store"
+        )
+    }
+
+    func testCacheControlValueForHashedAssets() {
+        XCTAssertEqual(
+            StaticFileMiddleware<BasicRequestContext>.cacheControlValue(forPath: "/assets/anthropic-4ASJTRhO.js"),
+            "public, max-age=31536000, immutable"
+        )
+        XCTAssertEqual(
+            StaticFileMiddleware<BasicRequestContext>.cacheControlValue(forPath: "/assets/nested/chunk.css"),
+            "public, max-age=31536000, immutable"
+        )
+    }
+
+    func testCacheControlValueForUnhashedShells() {
+        XCTAssertEqual(
+            StaticFileMiddleware<BasicRequestContext>.cacheControlValue(forPath: "/index.html"),
+            "no-cache"
+        )
+        XCTAssertEqual(
+            StaticFileMiddleware<BasicRequestContext>.cacheControlValue(forPath: "/sprinkle-sandbox.html"),
+            "no-cache"
+        )
+        XCTAssertEqual(
+            StaticFileMiddleware<BasicRequestContext>.cacheControlValue(forPath: "/manifest.webmanifest"),
+            "no-cache"
+        )
+        XCTAssertEqual(
+            StaticFileMiddleware<BasicRequestContext>.cacheControlValue(forPath: "/favicon.ico"),
+            "no-cache"
+        )
+    }
+
+    func testApplyCacheHeadersServiceWorkerAllowedOnlyOnLlmProxy() {
+        var response = Response(status: .ok)
+        StaticFileMiddleware<BasicRequestContext>.applyCacheHeaders(path: "/llm-proxy-sw.js", response: &response)
+        XCTAssertEqual(response.headers[HTTPField.Name.cacheControl], "no-store")
+        XCTAssertEqual(response.headers[HTTPField.Name("Service-Worker-Allowed")!], "/")
+
+        var previewResponse = Response(status: .ok)
+        StaticFileMiddleware<BasicRequestContext>.applyCacheHeaders(path: "/preview-sw.js", response: &previewResponse)
+        XCTAssertEqual(previewResponse.headers[HTTPField.Name.cacheControl], "no-store")
+        XCTAssertNil(previewResponse.headers[HTTPField.Name("Service-Worker-Allowed")!])
+
+        var assetResponse = Response(status: .ok)
+        StaticFileMiddleware<BasicRequestContext>.applyCacheHeaders(path: "/assets/x.js", response: &assetResponse)
+        XCTAssertEqual(assetResponse.headers[HTTPField.Name.cacheControl], "public, max-age=31536000, immutable")
+        XCTAssertNil(assetResponse.headers[HTTPField.Name("Service-Worker-Allowed")!])
+
+        var indexResponse = Response(status: .ok)
+        StaticFileMiddleware<BasicRequestContext>.applyCacheHeaders(path: "/index.html", response: &indexResponse)
+        XCTAssertEqual(indexResponse.headers[HTTPField.Name.cacheControl], "no-cache")
+        XCTAssertNil(indexResponse.headers[HTTPField.Name("Service-Worker-Allowed")!])
     }
 }


### PR DESCRIPTION
## Context

Follow-up to #710, which fixed the same class of bug in the Express static middleware in `packages/node-server/src/index.ts`. The Hummingbird port in `packages/swift-server/Sources/Server/StaticFileMiddleware.swift` had the same gap: it only set `Service-Worker-Allowed` + `no-store` on `/llm-proxy-sw.js` and let everything else fall through to `FileMiddleware`, which doesn't emit a `Cache-Control` header at all.

## Symptom (matches #710)

After updating SLICC and starting the swift-server, a long-running tab can keep serving its cached `index.html` (browser heuristic freshness based on `Last-Modified`), but that cached HTML references the previous Vite hashes. The new build emits different hashes, so every dynamic-import 404s:

```
Scoop "Cone" failed after 3 attempts:
Failed to fetch dynamically imported module:
http://localhost:5710/assets/anthropic-<oldhash>.js
```

…repeating until the user hard-refreshes.

## Fix

Same three-bucket header policy as #710, in `applyCacheHeaders` (renamed from `applyServiceWorkerHeaders`):

| Path | Cache-Control | Why |
|---|---|---|
| `/llm-proxy-sw.js`, `/preview-sw.js` | `no-store` | Browser only re-checks SW scripts on registration; safest signal is "always pull the latest bytes". `llm-proxy-sw.js` also gets `Service-Worker-Allowed: /` (unchanged). |
| `/assets/*` | `public, max-age=31536000, immutable` | Vite emits content-hashed filenames — each URL is byte-for-byte immutable. |
| Everything else (`index.html`, manifest, `sprinkle-sandbox.html`, favicon, ...) | `no-cache` | Forces a conditional revalidation on every load — cheap (304 on unchanged) and guarantees tabs pick up new asset references after a rebuild. |

The SPA fallback branch (`rewritingRequestPath` → `fileMiddleware.handle`) previously bypassed the header callback entirely; it now runs through `applyCacheHeaders` against the fallback path (`/index.html`), which yields the same `no-cache` from the default branch.

## Tests

`StaticFileMiddlewareTests` gains four assertions covering the three buckets and the `Service-Worker-Allowed`-only-on-`llm-proxy-sw.js` constraint, so the Swift port can't silently regress relative to the Node implementation:

```
Test Suite 'StaticFileMiddlewareTests' passed
  Executed 6 tests, with 0 failures
```

## Scope

- Affects: native macOS server in `packages/swift-server/` (Hummingbird path).
- Mirrors: `packages/node-server/src/index.ts` per #710.
- No JS / shared-ts changes.

Refs: #710