### PR TITLE
fix(bedrock-camp): close drift gaps vs pi-ai amazon-bedrock 0.74.0

### DIFF
--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -6,6 +6,13 @@
  * transparently by `llm-proxy-sw.ts` (rewrites to /api/fetch-proxy at
  * the SW layer). Extension mode bypasses CORS via host_permissions.
  * Registers as api: "bedrock-camp-converse" via pi-ai's registerApiProvider().
+ *
+ * Tracks pi-ai's `amazon-bedrock` provider (currently 0.74.0) where the
+ * shapes overlap. The remaining intentional divergence is the transport:
+ * non-streaming `POST /converse` over `fetch` versus pi's
+ * `ConverseStreamCommand` over `@aws-sdk/client-bedrock-runtime`. Adopting
+ * streaming would require parsing the `vnd.amazon.eventstream` framing
+ * by hand; tracked as a follow-up.
  */
 
 import type { ProviderConfig } from '../types.js';
@@ -30,6 +37,8 @@ import type {
   AssistantMessage,
   ThinkingLevel,
   ThinkingBudgets,
+  CacheRetention,
+  ProviderResponse,
 } from '@earendil-works/pi-ai';
 
 export const config: ProviderConfig = {
@@ -59,11 +68,19 @@ export const config: ProviderConfig = {
 //    `global.*` works anywhere.
 const BEDROCK_CAMP_INFERENCE_PROFILE_RE = /^(us|eu|global|apac)\./;
 const BEDROCK_CAMP_CLAUDE_4_RE = /\.anthropic\.claude-(opus|sonnet|haiku)-4/;
-const BEDROCK_RUNTIME_HOST_RE = /bedrock-runtime\.([a-z0-9-]+)\.amazonaws\.com/i;
+// Matches standard (us-east-1), FIPS (us-east-1-fips) and China
+// (cn-north-1.amazonaws.com.cn) Bedrock runtime hosts.
+const BEDROCK_RUNTIME_HOST_RE =
+  /bedrock-runtime(?:-fips)?\.([a-z0-9-]+)\.amazonaws\.com(?:\.cn)?$/i;
 
 export function bedrockCampRegionFromBaseUrl(baseUrl: string | null | undefined): string | null {
   if (!baseUrl) return null;
-  return baseUrl.match(BEDROCK_RUNTIME_HOST_RE)?.[1] ?? null;
+  try {
+    const { hostname } = new URL(baseUrl);
+    return hostname.toLowerCase().match(BEDROCK_RUNTIME_HOST_RE)?.[1] ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function profileMatchesRegion(prefix: string, region: string): boolean {
@@ -82,58 +99,95 @@ export function isBedrockCampCompatible(model: { id: string }, region?: string |
   return profileMatchesRegion(prefix, region);
 }
 
-// Models not yet in pi-ai's amazon-bedrock registry that CAMP already serves.
-// Opus 4.7 shape mirrors 4.6 until pi-ai regenerates. Caller must dedupe
-// against the registry — once pi-ai ships these IDs, the dedup drops them
-// and this function becomes a no-op that can be removed.
-export function getBedrockCampExtraModels(): Model<Api>[] {
-  const shared: Omit<Model<Api>, 'id' | 'name'> = {
-    reasoning: true,
-    input: ['text', 'image'],
-    cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
-    contextWindow: 1_000_000,
-    maxTokens: 128_000,
-    baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
-    api: 'bedrock-converse-stream' as Api,
-    provider: 'amazon-bedrock' as Model<Api>['provider'],
-  };
-  return [
-    { ...shared, id: 'us.anthropic.claude-opus-4-7', name: 'Claude Opus 4.7 (US)' },
-    { ...shared, id: 'global.anthropic.claude-opus-4-7', name: 'Claude Opus 4.7 (Global)' },
-  ];
-}
-
 // Opus 4.7 returns 400 "temperature is deprecated for this model" when the
 // param is set. Keep temperature for every other model.
-function supportsTemperature(modelId: string): boolean {
-  return !modelId.includes('claude-opus-4-7');
+function supportsTemperature(modelId: string, modelName?: string): boolean {
+  return !matchesAny(modelId, modelName, ['claude-opus-4-7', 'opus-4-7']);
 }
 
-type BedrockCampOnPayload =
-  | ((payload: unknown) => void)
-  | ((payload: unknown, model: Model<Api>) => void);
+export type BedrockCampThinkingDisplay = 'summarized' | 'omitted';
 
-interface BedrockCampOptions extends Omit<StreamOptions, 'onPayload'> {
+type BedrockCampOnPayload = (
+  payload: unknown,
+  model: Model<Api>
+) => unknown | undefined | Promise<unknown | undefined>;
+
+type BedrockCampOnResponse = (
+  response: ProviderResponse,
+  model: Model<Api>
+) => void | Promise<void>;
+
+interface BedrockCampOptions extends Omit<StreamOptions, 'onPayload' | 'onResponse'> {
   onPayload?: BedrockCampOnPayload;
+  onResponse?: BedrockCampOnResponse;
   toolChoice?: 'auto' | 'any' | 'none' | { type: 'tool'; name: string };
   reasoning?: ThinkingLevel;
   thinkingBudgets?: ThinkingBudgets;
+  /**
+   * Controls how Claude's thinking content is returned (Opus 4.6+ / Mythos).
+   * Defaults to "summarized" for parity with pi-ai's `amazon-bedrock`.
+   */
+  thinkingDisplay?: BedrockCampThinkingDisplay;
+  /**
+   * Send `anthropic_beta: ["interleaved-thinking-2025-05-14"]` for
+   * non-adaptive Claude models that support extended thinking + tool use.
+   * Defaults to true (matches pi-ai).
+   */
+  interleavedThinking?: boolean;
+  /**
+   * Key-value pairs attached to the inference request for cost allocation.
+   * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html
+   */
+  requestMetadata?: Record<string, string>;
 }
 
-type BedrockCampSimpleOptions = Omit<SimpleStreamOptions, 'onPayload'> & {
+type BedrockCampSimpleOptions = Omit<SimpleStreamOptions, 'onPayload' | 'onResponse'> & {
   onPayload?: BedrockCampOnPayload;
+  onResponse?: BedrockCampOnResponse;
+  toolChoice?: BedrockCampOptions['toolChoice'];
+  thinkingDisplay?: BedrockCampThinkingDisplay;
+  interleavedThinking?: boolean;
+  requestMetadata?: Record<string, string>;
 };
 
-function notifyPayload(
-  onPayload: BedrockCampOnPayload | undefined,
-  payload: unknown,
-  model: Model<Api>
-): void {
-  if (!onPayload) return;
-  // Bedrock CAMP callers inspect both the serialized payload and the resolved
-  // model. Plain StreamOptions callbacks remain valid because extra arguments
-  // are ignored in JavaScript.
-  (onPayload as (payload: unknown, model: Model<Api>) => void)(payload, model);
+function pickCampExtras(
+  options: BedrockCampSimpleOptions
+): Pick<
+  BedrockCampOptions,
+  | 'onPayload'
+  | 'onResponse'
+  | 'toolChoice'
+  | 'thinkingDisplay'
+  | 'interleavedThinking'
+  | 'requestMetadata'
+> {
+  return {
+    onPayload: options.onPayload,
+    onResponse: options.onResponse,
+    toolChoice: options.toolChoice,
+    thinkingDisplay: options.thinkingDisplay,
+    interleavedThinking: options.interleavedThinking,
+    requestMetadata: options.requestMetadata,
+  };
+}
+
+// ── Model-name aware matching ───────────────────────────────────────
+// Application inference profiles use opaque ARNs whose id does not contain
+// the underlying model name. We check both `model.id` and `model.name`
+// (when present), normalizing separators so e.g. "Claude Opus 4.6" matches
+// "opus-4-6".
+
+function getModelMatchCandidates(modelId: string, modelName?: string): string[] {
+  const values = modelName ? [modelId, modelName] : [modelId];
+  return values.flatMap((value) => {
+    const lower = value.toLowerCase();
+    return [lower, lower.replace(/[\s_.:]+/g, '-')];
+  });
+}
+
+function matchesAny(modelId: string, modelName: string | undefined, needles: string[]): boolean {
+  const candidates = getModelMatchCandidates(modelId, modelName);
+  return candidates.some((s) => needles.some((n) => s.includes(n)));
 }
 
 // ── Message conversion ──────────────────────────────────────────────
@@ -151,7 +205,11 @@ function sanitize(text: string | undefined | null): string {
   );
 }
 
-function convertMessages(context: Context, model: Model<Api>): any[] {
+function convertMessages(
+  context: Context,
+  model: Model<Api>,
+  cacheRetention: CacheRetention
+): any[] {
   const result: any[] = [];
   const transformed = transformMessages(context.messages, model, normalizeToolCallId);
 
@@ -166,10 +224,7 @@ function convertMessages(context: Context, model: Model<Api>): any[] {
               ? [{ text: sanitize(m.content) }]
               : m.content.map((c: any) => {
                   if (c.type === 'text') return { text: sanitize(c.text) };
-                  if (c.type === 'image')
-                    return {
-                      image: { source: { bytes: c.data }, format: mimeToFormat(c.mimeType) },
-                    };
+                  if (c.type === 'image') return { image: createImageBlock(c.mimeType, c.data) };
                   throw new Error(`Unknown user content type: ${c.type}`);
                 }),
         });
@@ -190,11 +245,22 @@ function convertMessages(context: Context, model: Model<Api>): any[] {
             case 'thinking':
               if (c.thinking.trim().length === 0) continue;
               if (supportsThinkingSignature(model)) {
-                blocks.push({
-                  reasoningContent: {
-                    reasoningText: { text: sanitize(c.thinking), signature: c.thinkingSignature },
-                  },
-                });
+                // Signatures arrive after thinking deltas. If a partial or
+                // externally persisted message lacks a signature, Bedrock
+                // rejects the replayed reasoning block. Fall back to plain
+                // text — matches pi-ai's amazon-bedrock behavior.
+                if (!c.thinkingSignature || c.thinkingSignature.trim().length === 0) {
+                  blocks.push({ text: sanitize(c.thinking) });
+                } else {
+                  blocks.push({
+                    reasoningContent: {
+                      reasoningText: {
+                        text: sanitize(c.thinking),
+                        signature: c.thinkingSignature,
+                      },
+                    },
+                  });
+                }
               } else {
                 blocks.push({
                   reasoningContent: { reasoningText: { text: sanitize(c.thinking) } },
@@ -215,7 +281,7 @@ function convertMessages(context: Context, model: Model<Api>): any[] {
             toolUseId: m.toolCallId,
             content: m.content.map((c: any) =>
               c.type === 'image'
-                ? { image: { source: { bytes: c.data }, format: mimeToFormat(c.mimeType) } }
+                ? { image: createImageBlock(c.mimeType, c.data) }
                 : { text: sanitize(c.text ?? c.json ?? JSON.stringify(c)) }
             ),
             status: m.isError ? 'error' : 'success',
@@ -229,7 +295,7 @@ function convertMessages(context: Context, model: Model<Api>): any[] {
               toolUseId: next.toolCallId,
               content: next.content.map((c: any) =>
                 c.type === 'image'
-                  ? { image: { source: { bytes: c.data }, format: mimeToFormat(c.mimeType) } }
+                  ? { image: createImageBlock(c.mimeType, c.data) }
                   : { text: sanitize(c.text ?? c.json ?? JSON.stringify(c)) }
               ),
               status: next.isError ? 'error' : 'success',
@@ -244,14 +310,22 @@ function convertMessages(context: Context, model: Model<Api>): any[] {
     }
   }
   // Add cache point to the last user message for supported Claude models
-  if (supportsPromptCaching(model) && result.length > 0) {
+  // when caching is enabled.
+  if (cacheRetention !== 'none' && supportsPromptCaching(model) && result.length > 0) {
     const lastMessage = result[result.length - 1];
     if (lastMessage.role === 'user' && Array.isArray(lastMessage.content)) {
-      lastMessage.content.push({ cachePoint: { type: 'default' } });
+      lastMessage.content.push(buildCachePoint(cacheRetention));
     }
   }
 
   return result;
+}
+
+function createImageBlock(
+  mime: string,
+  data: string
+): { source: { bytes: string }; format: string } {
+  return { source: { bytes: data }, format: mimeToFormat(mime) };
 }
 
 function mimeToFormat(mime: string): string {
@@ -266,19 +340,30 @@ function mimeToFormat(mime: string): string {
     case 'image/webp':
       return 'webp';
     default:
-      return 'png';
+      throw new Error(`Unsupported image MIME type: ${mime}`);
   }
 }
 
 function supportsThinkingSignature(model: Model<Api>): boolean {
-  const id = model.id.toLowerCase();
-  return id.includes('anthropic.claude') || id.includes('anthropic/claude');
+  return isAnthropicClaudeModel(model);
 }
 
-const ADAPTIVE_THINKING_RE = /(?:opus|sonnet|haiku)-4[-.](?:[6-9]|\d{2,})/;
+// Adaptive thinking is currently supported by Claude Opus 4.6, Opus 4.7,
+// and Sonnet 4.6 only. Other Claude 4.x models stay on legacy
+// `thinking.type=enabled` with a token budget. This list is kept in lockstep
+// with pi-ai's amazon-bedrock provider.
+function supportsAdaptiveThinking(modelId: string, modelName?: string): boolean {
+  return matchesAny(modelId, modelName, ['opus-4-6', 'opus-4-7', 'sonnet-4-6']);
+}
 
-function supportsAdaptiveThinking(modelId: string): boolean {
-  return ADAPTIVE_THINKING_RE.test(modelId);
+// Opus 4.7 introduced a native `effort: "xhigh"` tier above `high`. Older
+// Opus 4.6 clamps xhigh to `"max"`. Anything else clamps to `"high"`.
+function supportsNativeXhighEffort(modelId: string, modelName?: string): boolean {
+  return matchesAny(modelId, modelName, ['opus-4-7']);
+}
+
+function supportsMaxEffort(modelId: string, modelName?: string): boolean {
+  return matchesAny(modelId, modelName, ['opus-4-6']);
 }
 
 // ── Tool config ─────────────────────────────────────────────────────
@@ -309,7 +394,12 @@ function convertToolConfig(
 
 // ── Thinking / reasoning fields ─────────────────────────────────────
 
-function mapThinkingLevelToEffort(level: ThinkingLevel | undefined, modelId: string): string {
+function mapThinkingLevelToEffort(
+  level: ThinkingLevel | undefined,
+  modelId: string,
+  modelName?: string
+): string {
+  if (level === 'xhigh' && supportsNativeXhighEffort(modelId, modelName)) return 'xhigh';
   switch (level) {
     case 'minimal':
     case 'low':
@@ -319,69 +409,104 @@ function mapThinkingLevelToEffort(level: ThinkingLevel | undefined, modelId: str
     case 'high':
       return 'high';
     case 'xhigh':
-      return /opus-4[-.](?:[6-9]|\d{2,})/.test(modelId) ? 'max' : 'high';
+      return supportsMaxEffort(modelId, modelName) ? 'max' : 'high';
     default:
       return 'high';
   }
 }
 
+// GovCloud Bedrock currently rejects the Claude `thinking.display` field
+// and is detected either by region (us-gov-*) or by model id prefix.
+function isGovCloudTarget(model: Model<Api>): boolean {
+  const region = bedrockCampRegionFromBaseUrl(model.baseUrl);
+  if (region?.toLowerCase().startsWith('us-gov-')) return true;
+  const id = model.id.toLowerCase();
+  return id.startsWith('us-gov.') || id.startsWith('arn:aws-us-gov:');
+}
+
 function buildAdditionalModelRequestFields(
   model: Model<Api>,
   options: BedrockCampOptions
-): any | undefined {
+): Record<string, unknown> | undefined {
   if (!options.reasoning || !model.reasoning) return undefined;
-  if (model.id.includes('anthropic.claude') || model.id.includes('anthropic/claude')) {
-    const result: any = supportsAdaptiveThinking(model.id)
-      ? {
-          thinking: { type: 'adaptive' },
-          output_config: { effort: mapThinkingLevelToEffort(options.reasoning, model.id) },
-        }
-      : (() => {
-          const defaults: Record<string, number> = {
-            minimal: 1024,
-            low: 2048,
-            medium: 8192,
-            high: 16384,
-            xhigh: 16384,
-          };
-          const level = options.reasoning === 'xhigh' ? 'high' : options.reasoning!;
-          const budget =
-            options.thinkingBudgets?.[level as keyof ThinkingBudgets] ??
-            defaults[options.reasoning!];
-          return { thinking: { type: 'enabled', budget_tokens: budget } };
-        })();
-    return result;
+  if (!isAnthropicClaudeModel(model)) return undefined;
+
+  const display = isGovCloudTarget(model) ? undefined : (options.thinkingDisplay ?? 'summarized');
+
+  if (supportsAdaptiveThinking(model.id, model.name)) {
+    const adaptive: Record<string, unknown> = {
+      thinking: { type: 'adaptive', ...(display !== undefined ? { display } : {}) },
+      output_config: { effort: mapThinkingLevelToEffort(options.reasoning, model.id, model.name) },
+    };
+    return adaptive;
   }
-  return undefined;
+
+  const defaults: Record<string, number> = {
+    minimal: 1024,
+    low: 2048,
+    medium: 8192,
+    high: 16384,
+    xhigh: 16384,
+  };
+  const level = options.reasoning === 'xhigh' ? 'high' : options.reasoning;
+  const budget =
+    options.thinkingBudgets?.[level as keyof ThinkingBudgets] ?? defaults[options.reasoning];
+  const legacy: Record<string, unknown> = {
+    thinking: {
+      type: 'enabled',
+      budget_tokens: budget,
+      ...(display !== undefined ? { display } : {}),
+    },
+  };
+  if (options.interleavedThinking ?? true) {
+    legacy.anthropic_beta = ['interleaved-thinking-2025-05-14'];
+  }
+  return legacy;
 }
 
 // ── Prompt caching ─────────────────────────────────────────────────
 
-/**
- * Check if the model supports prompt caching.
- * Matches pi-ai's built-in Bedrock provider logic.
- */
-function supportsPromptCaching(model: Model<Api>): boolean {
+function isAnthropicClaudeModel(model: Model<Api>): boolean {
   const id = model.id.toLowerCase();
-  if (!id.includes('claude')) {
-    return false;
-  }
-  // Claude 4.x models (opus-4, sonnet-4, haiku-4)
-  if (id.includes('-4-') || id.includes('-4.')) return true;
-  // Claude 3.7 Sonnet
-  if (id.includes('claude-3-7-sonnet')) return true;
-  // Claude 3.5 Haiku
-  if (id.includes('claude-3-5-haiku')) return true;
+  const name = model.name?.toLowerCase() ?? '';
+  return (
+    id.includes('anthropic.claude') ||
+    id.includes('anthropic/claude') ||
+    name.includes('anthropic.claude') ||
+    name.includes('anthropic/claude') ||
+    name.includes('claude')
+  );
+}
+
+function supportsPromptCaching(model: Model<Api>): boolean {
+  const candidates = getModelMatchCandidates(model.id, model.name);
+  if (!candidates.some((s) => s.includes('claude'))) return false;
+  if (candidates.some((s) => s.includes('-4-'))) return true;
+  if (candidates.some((s) => s.includes('claude-3-7-sonnet'))) return true;
+  if (candidates.some((s) => s.includes('claude-3-5-haiku'))) return true;
   return false;
+}
+
+function buildCachePoint(cacheRetention: CacheRetention): Record<string, unknown> {
+  return {
+    cachePoint: {
+      type: 'default',
+      ...(cacheRetention === 'long' ? { ttl: '1h' } : {}),
+    },
+  };
 }
 
 // ── System prompt ───────────────────────────────────────────────────
 
-function buildSystemPrompt(systemPrompt: string | undefined, model: Model<Api>): any[] | undefined {
+function buildSystemPrompt(
+  systemPrompt: string | undefined,
+  model: Model<Api>,
+  cacheRetention: CacheRetention
+): any[] | undefined {
   if (!systemPrompt) return undefined;
   const blocks: any[] = [{ text: sanitize(systemPrompt) }];
-  if (supportsPromptCaching(model)) {
-    blocks.push({ cachePoint: { type: 'default' } });
+  if (cacheRetention !== 'none' && supportsPromptCaching(model)) {
+    blocks.push(buildCachePoint(cacheRetention));
   }
   return blocks;
 }
@@ -401,6 +526,20 @@ function mapStopReason(reason: string): 'stop' | 'length' | 'toolUse' | 'error' 
     default:
       return 'error';
   }
+}
+
+// ── Error formatting ────────────────────────────────────────────────
+// Stable human-readable prefixes mirror pi-ai's BEDROCK_ERROR_PREFIXES so
+// downstream retry classification (`server.?error`, `service.?unavailable`,
+// `throttl(?:ing|e)`) keeps working over CAMP.
+function formatHttpError(status: number, body: string): string {
+  let prefix = `Bedrock CAMP API error (${status})`;
+  if (status === 429) prefix = `Throttling error: ${prefix}`;
+  else if (status === 503) prefix = `Service unavailable: ${prefix}`;
+  else if (status === 502 || status === 504) prefix = `Internal server error: ${prefix}`;
+  else if (status >= 500) prefix = `Internal server error: ${prefix}`;
+  else if (status === 400) prefix = `Validation error: ${prefix}`;
+  return `${prefix}: ${body}`;
 }
 
 // ── Response parsing (non-streaming /converse) ──────────────────────
@@ -479,6 +618,18 @@ function parseConverseResponse(
   output.stopReason = mapStopReason(body.stopReason || 'end_turn');
 }
 
+function resolveCacheRetention(cacheRetention?: CacheRetention): CacheRetention {
+  return cacheRetention ?? 'short';
+}
+
+function extractResponseHeaders(response: Response): Record<string, string> {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key.toLowerCase()] = value;
+  });
+  return headers;
+}
+
 // ── Stream function ─────────────────────────────────────────────────
 
 export const streamBedrockCamp = (
@@ -514,18 +665,24 @@ export const streamBedrockCamp = (
       const baseUrl = model.baseUrl;
       if (!baseUrl) throw new Error('Base URL is required for Bedrock CAMP');
 
+      const cacheRetention = resolveCacheRetention(options.cacheRetention);
+
       // Build request body (Converse API format)
-      const inferenceConfig: Record<string, unknown> = { maxTokens: options.maxTokens };
-      if (supportsTemperature(model.id)) {
+      const inferenceConfig: Record<string, unknown> = {};
+      if (options.maxTokens !== undefined) inferenceConfig.maxTokens = options.maxTokens;
+      if (options.temperature !== undefined && supportsTemperature(model.id, model.name)) {
         inferenceConfig.temperature = options.temperature;
       }
-      const body: any = {
+      let body: Record<string, unknown> = {
         modelId: model.id,
-        messages: convertMessages(context, model),
-        system: buildSystemPrompt(context.systemPrompt, model),
+        messages: convertMessages(context, model, cacheRetention),
+        system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
         inferenceConfig,
         toolConfig: convertToolConfig(context.tools, options.toolChoice),
         additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
+        ...(options.requestMetadata !== undefined
+          ? { requestMetadata: options.requestMetadata }
+          : {}),
       };
 
       // Remove undefined fields
@@ -533,7 +690,12 @@ export const streamBedrockCamp = (
       if (!body.toolConfig) delete body.toolConfig;
       if (!body.additionalModelRequestFields) delete body.additionalModelRequestFields;
 
-      notifyPayload(options.onPayload, body, model);
+      if (options.onPayload) {
+        const replacement = await options.onPayload(body, model);
+        if (replacement !== undefined) {
+          body = replacement as Record<string, unknown>;
+        }
+      }
 
       // Build URL: POST {baseUrl}/model/{modelId}/converse
       const targetUrl = `${baseUrl.replace(/\/$/, '')}/model/${model.id}/converse`;
@@ -545,19 +707,28 @@ export const streamBedrockCamp = (
       // and never registers the SW, so a direct fetch works there too.
       // Either way, this provider issues a plain fetch and lets the
       // platform handle transport.
+      const requestHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+        ...(options.headers ?? {}),
+      };
       const response = await fetch(targetUrl, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
+        headers: requestHeaders,
         body: JSON.stringify(body),
         signal: options.signal,
       });
 
+      if (options.onResponse) {
+        await options.onResponse(
+          { status: response.status, headers: extractResponseHeaders(response) },
+          model
+        );
+      }
+
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Bedrock CAMP API error (${response.status}): ${errorText}`);
+        throw new Error(formatHttpError(response.status, errorText));
       }
 
       const responseBody = await response.json();
@@ -590,23 +761,16 @@ export const streamSimpleBedrockCamp = (
   context: Context,
   options?: BedrockCampSimpleOptions
 ): AssistantMessageEventStream => {
-  const base = buildBaseOptions(
-    model,
-    options && {
-      ...options,
-      onPayload: options.onPayload
-        ? (payload) => notifyPayload(options.onPayload, payload, model)
-        : undefined,
-    },
-    undefined
-  );
+  const base = buildBaseOptions(model, options, undefined);
+  const extras = options ? pickCampExtras(options) : {};
   if (!options?.reasoning) {
-    return streamBedrockCamp(model, context, { ...base, reasoning: undefined });
+    return streamBedrockCamp(model, context, { ...base, ...extras, reasoning: undefined });
   }
-  if (model.id.includes('anthropic.claude') || model.id.includes('anthropic/claude')) {
-    if (supportsAdaptiveThinking(model.id)) {
+  if (isAnthropicClaudeModel(model)) {
+    if (supportsAdaptiveThinking(model.id, model.name)) {
       return streamBedrockCamp(model, context, {
         ...base,
+        ...extras,
         reasoning: options.reasoning,
         thinkingBudgets: options.thinkingBudgets,
       });
@@ -619,6 +783,7 @@ export const streamSimpleBedrockCamp = (
     );
     return streamBedrockCamp(model, context, {
       ...base,
+      ...extras,
       maxTokens: adjusted.maxTokens,
       reasoning: options.reasoning,
       thinkingBudgets: {
@@ -629,6 +794,7 @@ export const streamSimpleBedrockCamp = (
   }
   return streamBedrockCamp(model, context, {
     ...base,
+    ...extras,
     reasoning: options.reasoning,
     thinkingBudgets: options.thinkingBudgets,
   });

--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -275,13 +275,10 @@ function supportsThinkingSignature(model: Model<Api>): boolean {
   return id.includes('anthropic.claude') || id.includes('anthropic/claude');
 }
 
+const ADAPTIVE_THINKING_RE = /(?:opus|sonnet|haiku)-4[-.](?:[6-9]|\d{2,})/;
+
 function supportsAdaptiveThinking(modelId: string): boolean {
-  return (
-    modelId.includes('opus-4-6') ||
-    modelId.includes('opus-4.6') ||
-    modelId.includes('sonnet-4-6') ||
-    modelId.includes('sonnet-4.6')
-  );
+  return ADAPTIVE_THINKING_RE.test(modelId);
 }
 
 // ── Tool config ─────────────────────────────────────────────────────
@@ -322,7 +319,7 @@ function mapThinkingLevelToEffort(level: ThinkingLevel | undefined, modelId: str
     case 'high':
       return 'high';
     case 'xhigh':
-      return modelId.includes('opus-4-6') || modelId.includes('opus-4.6') ? 'max' : 'high';
+      return /opus-4[-.](?:[6-9]|\d{2,})/.test(modelId) ? 'max' : 'high';
     default:
       return 'high';
   }

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -22,7 +22,6 @@ import type { ProviderConfig } from '../providers/index.js';
 import type { CompatOverrides } from '../providers/types.js';
 import {
   isBedrockCampCompatible,
-  getBedrockCampExtraModels,
   bedrockCampRegionFromBaseUrl,
 } from '../providers/built-in/bedrock-camp.js';
 import { trackSettingsOpen } from './telemetry.js';
@@ -229,25 +228,20 @@ function applyModelMetadata(
 // Get models for a provider
 export function getProviderModels(providerId: string): Model<Api>[] {
   try {
-    // Bedrock CAMP uses Amazon Bedrock models with custom API.
-    // Filter to inference-profile-prefixed Claude 4.x whose region matches
-    // the configured endpoint (eu.* against us-* 400s "invalid model
-    // identifier"), and inject models missing from pi-ai's registry (e.g.
-    // opus-4.7). Dedupe by ID so extras auto-drop when pi-ai ships them.
+    // Bedrock CAMP uses Amazon Bedrock models with a custom API. Filter to
+    // inference-profile-prefixed Claude 4.x whose region matches the
+    // configured endpoint (eu.* against us-* 400s "invalid model
+    // identifier"). pi-ai's amazon-bedrock registry now ships every Opus 4.7
+    // profile variant; no manual extras list is needed.
     if (providerId === 'bedrock-camp') {
       const region = bedrockCampRegionFromBaseUrl(getBaseUrlForProvider('bedrock-camp'));
-      const bedrockModels = getModelsDynamic('amazon-bedrock').filter((m) =>
-        isBedrockCampCompatible(m, region)
-      );
-      const existingIds = new Set(bedrockModels.map((m) => m.id));
-      const extras = getBedrockCampExtraModels().filter(
-        (m) => isBedrockCampCompatible(m, region) && !existingIds.has(m.id)
-      );
-      return [...bedrockModels, ...extras].map((m) => ({
-        ...m,
-        api: 'bedrock-camp-converse' as Api,
-        provider: 'bedrock-camp',
-      }));
+      return getModelsDynamic('amazon-bedrock')
+        .filter((m) => isBedrockCampCompatible(m, region))
+        .map((m) => ({
+          ...m,
+          api: 'bedrock-camp-converse' as Api,
+          provider: 'bedrock-camp',
+        }));
     }
     // Providers that use Anthropic's model registry with custom API
     const providerConfig = getProviderConfig(providerId);

--- a/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
+++ b/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
@@ -120,4 +120,95 @@ describe('bedrock-camp built-in provider', () => {
       })
     );
   });
+
+  it.each([
+    ['us.anthropic.claude-opus-4-6', 'max'],
+    ['us.anthropic.claude-opus-4-7', 'max'],
+    ['global.anthropic.claude-opus-4-7', 'max'],
+    ['us.anthropic.claude-sonnet-4-6', 'high'],
+    ['us.anthropic.claude-sonnet-4-7', 'high'],
+    ['us.anthropic.claude-haiku-4-7', 'high'],
+  ])(
+    'uses adaptive thinking (not type.enabled) for Claude 4.6+ models (%s)',
+    async (modelId, expectedEffort) => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          output: { message: { content: [{ text: 'ok' }] } },
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          stopReason: 'end_turn',
+        }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      let captured: any;
+      const stream = streamSimpleBedrockCamp(
+        {
+          id: modelId,
+          provider: 'amazon-bedrock',
+          api: 'bedrock-camp-converse',
+          baseUrl: 'https://bedrock-runtime.us-west-2.amazonaws.com',
+          maxTokens: 128_000,
+          input: ['text'],
+          reasoning: true,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        } as any,
+        { messages: [{ role: 'user', content: 'hi' }] } as any,
+        {
+          apiKey: 'ABSK-test',
+          reasoning: 'xhigh',
+          onPayload(payload: unknown) {
+            captured = payload;
+          },
+        }
+      );
+
+      await stream.result();
+
+      expect(captured.additionalModelRequestFields).toEqual({
+        thinking: { type: 'adaptive' },
+        output_config: { effort: expectedEffort },
+      });
+      expect(captured.additionalModelRequestFields.thinking.type).not.toBe('enabled');
+    }
+  );
+
+  it('keeps legacy thinking.type=enabled for pre-4.6 Claude models', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        output: { message: { content: [{ text: 'ok' }] } },
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        stopReason: 'end_turn',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    let captured: any;
+    const stream = streamSimpleBedrockCamp(
+      {
+        id: 'us.anthropic.claude-sonnet-4-5',
+        provider: 'amazon-bedrock',
+        api: 'bedrock-camp-converse',
+        baseUrl: 'https://bedrock-runtime.us-west-2.amazonaws.com',
+        maxTokens: 64_000,
+        input: ['text'],
+        reasoning: true,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      } as any,
+      { messages: [{ role: 'user', content: 'hi' }] } as any,
+      {
+        apiKey: 'ABSK-test',
+        reasoning: 'medium',
+        onPayload(payload: unknown) {
+          captured = payload;
+        },
+      }
+    );
+
+    await stream.result();
+
+    expect(captured.additionalModelRequestFields.thinking.type).toBe('enabled');
+    expect(captured.additionalModelRequestFields.thinking.budget_tokens).toBeGreaterThan(0);
+  });
 });

--- a/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
+++ b/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
@@ -6,10 +6,60 @@ import {
   register,
   config,
   streamSimpleBedrockCamp,
+  streamBedrockCamp,
+  bedrockCampRegionFromBaseUrl,
+  isBedrockCampCompatible,
 } from '../../../src/providers/built-in/bedrock-camp.js';
 
 // Call register manually since built-in modules use explicit registration
 register();
+
+function mockOkResponse(body: any = { output: { message: { content: [{ text: 'ok' }] } } }) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'x-amzn-requestid': 'req-test-123' }),
+    json: async () => ({
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      stopReason: 'end_turn',
+      ...body,
+    }),
+  });
+}
+
+function baseModel(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'us.anthropic.claude-sonnet-4-6',
+    name: 'Claude Sonnet 4.6 (US)',
+    provider: 'amazon-bedrock',
+    api: 'bedrock-camp-converse',
+    baseUrl: 'https://bedrock-runtime.us-west-2.amazonaws.com',
+    maxTokens: 128_000,
+    input: ['text'],
+    reasoning: true,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    ...overrides,
+  } as any;
+}
+
+async function capturePayload(model: any, options: Record<string, unknown> = {}): Promise<any> {
+  const fetchMock = mockOkResponse();
+  vi.stubGlobal('fetch', fetchMock);
+  let captured: any;
+  const stream = streamSimpleBedrockCamp(
+    model,
+    { messages: [{ role: 'user', content: 'hi' }] } as any,
+    {
+      apiKey: 'ABSK-test',
+      ...options,
+      onPayload(payload: unknown) {
+        captured = payload;
+      },
+    } as any
+  );
+  await stream.result();
+  return captured;
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -37,60 +87,66 @@ describe('bedrock-camp built-in provider', () => {
     expect(typeof provider!.streamSimple).toBe('function');
   });
 
-  it('passes the request payload and resolved model to onPayload before sending the converse request', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        output: {
-          message: {
-            content: [{ text: 'hello from bedrock camp' }],
-          },
-        },
-        usage: { inputTokens: 12, outputTokens: 4, totalTokens: 16 },
-        stopReason: 'end_turn',
-      }),
+  it('parses the endpoint region for FIPS and China runtime hosts', () => {
+    expect(bedrockCampRegionFromBaseUrl('https://bedrock-runtime.us-west-2.amazonaws.com')).toBe(
+      'us-west-2'
+    );
+    expect(
+      bedrockCampRegionFromBaseUrl('https://bedrock-runtime-fips.us-east-1.amazonaws.com')
+    ).toBe('us-east-1');
+    expect(
+      bedrockCampRegionFromBaseUrl('https://bedrock-runtime.cn-north-1.amazonaws.com.cn')
+    ).toBe('cn-north-1');
+    expect(bedrockCampRegionFromBaseUrl('not a url')).toBeNull();
+    expect(bedrockCampRegionFromBaseUrl(null)).toBeNull();
+  });
+
+  it('filters CAMP-compatible models by region prefix', () => {
+    expect(isBedrockCampCompatible({ id: 'us.anthropic.claude-sonnet-4-6' }, 'us-west-2')).toBe(
+      true
+    );
+    expect(isBedrockCampCompatible({ id: 'eu.anthropic.claude-sonnet-4-6' }, 'us-west-2')).toBe(
+      false
+    );
+    expect(isBedrockCampCompatible({ id: 'global.anthropic.claude-opus-4-7' }, 'eu-west-1')).toBe(
+      true
+    );
+    expect(isBedrockCampCompatible({ id: 'anthropic.claude-sonnet-4-6' }, 'us-west-2')).toBe(false);
+    expect(isBedrockCampCompatible({ id: 'us.anthropic.claude-3-5-sonnet' }, 'us-west-2')).toBe(
+      false
+    );
+  });
+
+  it('sends the request payload and resolved model to onPayload before fetching', async () => {
+    const fetchMock = mockOkResponse({
+      output: { message: { content: [{ text: 'hello from bedrock camp' }] } },
+      usage: { inputTokens: 12, outputTokens: 4, totalTokens: 16 },
     });
     vi.stubGlobal('fetch', fetchMock);
 
     const payloads: unknown[] = [];
     const models: unknown[] = [];
-    const argCounts: number[] = [];
     const stream = streamSimpleBedrockCamp(
-      {
+      baseModel({
         id: 'anthropic.claude-sonnet-4-6',
-        provider: 'bedrock-camp',
-        api: 'bedrock-camp-converse',
-        baseUrl: 'https://bedrock-runtime.us-west-2.amazonaws.com',
-        maxTokens: 200000,
+        name: 'Claude Sonnet 4.6',
         input: ['text', 'image'],
-        cost: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-        },
-      } as any,
-      {
-        messages: [{ role: 'user', content: 'Say hello' }],
-      } as any,
+        maxTokens: 200_000,
+      }),
+      { messages: [{ role: 'user', content: 'Say hello' }] } as any,
       {
         apiKey: 'ABSK-test',
-        onPayload(...args: unknown[]) {
-          argCounts.push(args.length);
-          payloads.push(args[0]);
-          models.push(args[1]);
+        onPayload(payload: unknown, model: unknown) {
+          payloads.push(payload);
+          models.push(model);
         },
-      }
+      } as any
     );
 
     const result = await stream.result();
 
     expect(result.stopReason).toBe('stop');
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    // Provider now issues a plain cross-origin fetch — CLI mode's
-    // CORS routing is handled by `llm-proxy-sw.ts` which rewrites the
-    // request at the SW layer before it leaves the page. Extension mode
-    // bypasses CORS via host_permissions.
     expect(fetchMock).toHaveBeenCalledWith(
       'https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-sonnet-4-6/converse',
       expect.objectContaining({
@@ -102,8 +158,6 @@ describe('bedrock-camp built-in provider', () => {
       })
     );
     expect(payloads).toHaveLength(1);
-    expect(models).toHaveLength(1);
-    expect(argCounts).toEqual([2]);
     expect(models[0]).toMatchObject({
       id: 'anthropic.claude-sonnet-4-6',
       api: 'bedrock-camp-converse',
@@ -123,92 +177,286 @@ describe('bedrock-camp built-in provider', () => {
 
   it.each([
     ['us.anthropic.claude-opus-4-6', 'max'],
-    ['us.anthropic.claude-opus-4-7', 'max'],
-    ['global.anthropic.claude-opus-4-7', 'max'],
+    ['us.anthropic.claude-opus-4-7', 'xhigh'],
+    ['global.anthropic.claude-opus-4-7', 'xhigh'],
     ['us.anthropic.claude-sonnet-4-6', 'high'],
-    ['us.anthropic.claude-sonnet-4-7', 'high'],
-    ['us.anthropic.claude-haiku-4-7', 'high'],
   ])(
-    'uses adaptive thinking (not type.enabled) for Claude 4.6+ models (%s)',
+    'uses adaptive thinking for Claude 4.6 / Opus 4.7 (%s -> effort=%s)',
     async (modelId, expectedEffort) => {
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          output: { message: { content: [{ text: 'ok' }] } },
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          stopReason: 'end_turn',
-        }),
+      const payload = await capturePayload(baseModel({ id: modelId, name: modelId }), {
+        reasoning: 'xhigh',
       });
-      vi.stubGlobal('fetch', fetchMock);
-
-      let captured: any;
-      const stream = streamSimpleBedrockCamp(
-        {
-          id: modelId,
-          provider: 'amazon-bedrock',
-          api: 'bedrock-camp-converse',
-          baseUrl: 'https://bedrock-runtime.us-west-2.amazonaws.com',
-          maxTokens: 128_000,
-          input: ['text'],
-          reasoning: true,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        } as any,
-        { messages: [{ role: 'user', content: 'hi' }] } as any,
-        {
-          apiKey: 'ABSK-test',
-          reasoning: 'xhigh',
-          onPayload(payload: unknown) {
-            captured = payload;
-          },
-        }
-      );
-
-      await stream.result();
-
-      expect(captured.additionalModelRequestFields).toEqual({
-        thinking: { type: 'adaptive' },
+      expect(payload.additionalModelRequestFields).toEqual({
+        thinking: { type: 'adaptive', display: 'summarized' },
         output_config: { effort: expectedEffort },
       });
-      expect(captured.additionalModelRequestFields.thinking.type).not.toBe('enabled');
     }
   );
 
-  it('keeps legacy thinking.type=enabled for pre-4.6 Claude models', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        output: { message: { content: [{ text: 'ok' }] } },
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        stopReason: 'end_turn',
-      }),
-    });
-    vi.stubGlobal('fetch', fetchMock);
+  it('keeps non-adaptive Claude 4.x models on thinking.type=enabled with interleaved beta', async () => {
+    const payload = await capturePayload(
+      baseModel({ id: 'us.anthropic.claude-sonnet-4-5', name: 'Claude Sonnet 4.5' }),
+      { reasoning: 'medium' }
+    );
+    expect(payload.additionalModelRequestFields.thinking.type).toBe('enabled');
+    expect(payload.additionalModelRequestFields.thinking.budget_tokens).toBeGreaterThan(0);
+    expect(payload.additionalModelRequestFields.thinking.display).toBe('summarized');
+    expect(payload.additionalModelRequestFields.anthropic_beta).toEqual([
+      'interleaved-thinking-2025-05-14',
+    ]);
+  });
 
+  it('skips the interleaved-thinking beta when interleavedThinking=false', async () => {
+    const fetchMock = mockOkResponse();
+    vi.stubGlobal('fetch', fetchMock);
     let captured: any;
-    const stream = streamSimpleBedrockCamp(
-      {
-        id: 'us.anthropic.claude-sonnet-4-5',
-        provider: 'amazon-bedrock',
-        api: 'bedrock-camp-converse',
-        baseUrl: 'https://bedrock-runtime.us-west-2.amazonaws.com',
-        maxTokens: 64_000,
-        input: ['text'],
-        reasoning: true,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      } as any,
+    const stream = streamBedrockCamp(
+      baseModel({ id: 'us.anthropic.claude-sonnet-4-5', name: 'Claude Sonnet 4.5' }),
       { messages: [{ role: 'user', content: 'hi' }] } as any,
       {
         apiKey: 'ABSK-test',
         reasoning: 'medium',
-        onPayload(payload: unknown) {
+        interleavedThinking: false,
+        onPayload(payload) {
           captured = payload;
         },
       }
     );
-
     await stream.result();
-
     expect(captured.additionalModelRequestFields.thinking.type).toBe('enabled');
-    expect(captured.additionalModelRequestFields.thinking.budget_tokens).toBeGreaterThan(0);
+    expect(captured.additionalModelRequestFields.anthropic_beta).toBeUndefined();
+  });
+
+  it('omits thinking.display for GovCloud region endpoints', async () => {
+    const payload = await capturePayload(
+      baseModel({
+        id: 'us.anthropic.claude-opus-4-7',
+        baseUrl: 'https://bedrock-runtime.us-gov-west-1.amazonaws.com',
+      }),
+      { reasoning: 'high' }
+    );
+    expect(payload.additionalModelRequestFields.thinking).toEqual({ type: 'adaptive' });
+    expect(payload.additionalModelRequestFields.output_config).toEqual({ effort: 'high' });
+  });
+
+  it('omits thinking.display for us-gov.* GovCloud model ids', async () => {
+    const payload = await capturePayload(
+      baseModel({ id: 'us-gov.anthropic.claude-sonnet-4-5', name: 'Claude Sonnet 4.5 (GovCloud)' }),
+      { reasoning: 'high' }
+    );
+    expect(payload.additionalModelRequestFields.thinking.type).toBe('enabled');
+    expect(payload.additionalModelRequestFields.thinking.display).toBeUndefined();
+  });
+
+  it('matches the underlying model via model.name for application inference profiles', async () => {
+    const payload = await capturePayload(
+      baseModel({
+        id: 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile',
+        name: 'Claude Opus 4.6',
+      }),
+      { reasoning: 'high' }
+    );
+    expect(payload.additionalModelRequestFields.thinking).toEqual({
+      type: 'adaptive',
+      display: 'summarized',
+    });
+    expect(payload.additionalModelRequestFields.output_config).toEqual({ effort: 'high' });
+  });
+
+  it('adds cache points to system prompt and last user message when model.name identifies Claude', async () => {
+    const payload = await capturePayload(
+      baseModel({
+        id: 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile',
+        name: 'Claude Sonnet 4.6',
+      }),
+      {}
+    );
+    // System block + cachePoint
+    expect(payload.system).toBeUndefined(); // no system prompt
+    const lastMsg = payload.messages[payload.messages.length - 1];
+    const lastContent = lastMsg.content[lastMsg.content.length - 1];
+    expect(lastContent).toHaveProperty('cachePoint');
+  });
+
+  it('falls back to plain text for thinking blocks with empty signatures', async () => {
+    const fetchMock = mockOkResponse();
+    vi.stubGlobal('fetch', fetchMock);
+    let captured: any;
+    const stream = streamBedrockCamp(
+      baseModel(),
+      {
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'I should respond.', thinkingSignature: '' },
+              { type: 'text', text: 'Hi' },
+            ],
+          },
+          { role: 'user', content: 'Continue' },
+        ],
+      } as any,
+      {
+        apiKey: 'ABSK-test',
+        onPayload(payload) {
+          captured = payload;
+        },
+      }
+    );
+    await stream.result();
+    const assistantMsg = captured.messages.find((m: any) => m.role === 'assistant');
+    expect(assistantMsg.content[0]).toEqual({ text: 'I should respond.' });
+    expect(assistantMsg.content[0]).not.toHaveProperty('reasoningContent');
+  });
+
+  it('attaches a 1h TTL to cache points when cacheRetention=long', async () => {
+    const payload = await capturePayload(baseModel({ id: 'us.anthropic.claude-sonnet-4-6' }), {
+      cacheRetention: 'long',
+    });
+    const lastMsg = payload.messages[payload.messages.length - 1];
+    const cp = lastMsg.content.find((c: any) => c.cachePoint);
+    expect(cp.cachePoint).toEqual({ type: 'default', ttl: '1h' });
+  });
+
+  it('omits all cache points when cacheRetention=none', async () => {
+    const payload = await capturePayload(baseModel({ id: 'us.anthropic.claude-sonnet-4-6' }), {
+      cacheRetention: 'none',
+    });
+    const lastMsg = payload.messages[payload.messages.length - 1];
+    expect(lastMsg.content.some((c: any) => c.cachePoint)).toBe(false);
+  });
+
+  it('passes requestMetadata through verbatim', async () => {
+    const payload = await capturePayload(baseModel(), {
+      requestMetadata: { team: 'eng', cost_center: 'r-d' },
+    });
+    expect(payload.requestMetadata).toEqual({ team: 'eng', cost_center: 'r-d' });
+  });
+
+  it('omits temperature for Opus 4.7 (CAMP deprecates it)', async () => {
+    const payload = await capturePayload(
+      baseModel({ id: 'us.anthropic.claude-opus-4-7', name: 'Claude Opus 4.7 (US)' }),
+      { temperature: 0.5, reasoning: 'high' }
+    );
+    expect(payload.inferenceConfig.temperature).toBeUndefined();
+  });
+
+  it('keeps temperature for other models', async () => {
+    const fetchMock = mockOkResponse();
+    vi.stubGlobal('fetch', fetchMock);
+    let captured: any;
+    const stream = streamBedrockCamp(
+      baseModel({ id: 'us.anthropic.claude-sonnet-4-6' }),
+      { messages: [{ role: 'user', content: 'hi' }] } as any,
+      {
+        apiKey: 'ABSK-test',
+        temperature: 0.5,
+        onPayload(payload) {
+          captured = payload;
+        },
+      }
+    );
+    await stream.result();
+    expect(captured.inferenceConfig.temperature).toBe(0.5);
+  });
+
+  it('lets onPayload replace the request body when it returns a value', async () => {
+    const fetchMock = mockOkResponse();
+    vi.stubGlobal('fetch', fetchMock);
+    const stream = streamBedrockCamp(
+      baseModel(),
+      { messages: [{ role: 'user', content: 'hi' }] } as any,
+      {
+        apiKey: 'ABSK-test',
+        onPayload(payload: any) {
+          return { ...payload, modelId: 'rewritten-model-id' };
+        },
+      }
+    );
+    await stream.result();
+    const sentBody = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(sentBody.modelId).toBe('rewritten-model-id');
+  });
+
+  it('invokes onResponse with status and headers from the http response', async () => {
+    const fetchMock = mockOkResponse();
+    vi.stubGlobal('fetch', fetchMock);
+    let response: any;
+    const stream = streamBedrockCamp(
+      baseModel(),
+      { messages: [{ role: 'user', content: 'hi' }] } as any,
+      {
+        apiKey: 'ABSK-test',
+        onResponse(r) {
+          response = r;
+        },
+      }
+    );
+    await stream.result();
+    expect(response.status).toBe(200);
+    expect(response.headers['x-amzn-requestid']).toBe('req-test-123');
+  });
+
+  it('merges custom headers into the outgoing request', async () => {
+    const fetchMock = mockOkResponse();
+    vi.stubGlobal('fetch', fetchMock);
+    const stream = streamBedrockCamp(
+      baseModel(),
+      { messages: [{ role: 'user', content: 'hi' }] } as any,
+      { apiKey: 'ABSK-test', headers: { 'X-Custom-Header': 'value-1' } }
+    );
+    await stream.result();
+    const sentHeaders = (fetchMock.mock.calls[0][1] as any).headers;
+    expect(sentHeaders).toEqual(
+      expect.objectContaining({
+        'X-Custom-Header': 'value-1',
+        Authorization: 'Bearer ABSK-test',
+      })
+    );
+  });
+
+  it.each([
+    [429, 'Throttling error'],
+    [503, 'Service unavailable'],
+    [502, 'Internal server error'],
+    [500, 'Internal server error'],
+    [400, 'Validation error'],
+  ])('prefixes HTTP %s errors with %s', async (status, prefix) => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status,
+      headers: new Headers(),
+      text: async () => 'upstream message',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const stream = streamBedrockCamp(
+      baseModel(),
+      { messages: [{ role: 'user', content: 'hi' }] } as any,
+      { apiKey: 'ABSK-test' }
+    );
+    const result = await stream.result();
+    expect(result.stopReason).toBe('error');
+    expect(result.errorMessage).toContain(prefix);
+    expect(result.errorMessage).toContain('upstream message');
+  });
+
+  it('throws on unsupported image MIME types', async () => {
+    const fetchMock = mockOkResponse();
+    vi.stubGlobal('fetch', fetchMock);
+    const stream = streamBedrockCamp(
+      baseModel({ id: 'us.anthropic.claude-sonnet-4-6', input: ['text', 'image'] }),
+      {
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'image', mimeType: 'image/bmp', data: 'AAAA' }],
+          },
+        ],
+      } as any,
+      { apiKey: 'ABSK-test' }
+    );
+    const result = await stream.result();
+    expect(result.stopReason).toBe('error');
+    expect(result.errorMessage).toContain('Unsupported image MIME type');
   });
 });


### PR DESCRIPTION
## Problem

Cone scoops backed by Bedrock CAMP fail after 3 attempts with:

```
Bedrock CAMP API error (400): {"message":"The model returned the following errors: \"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}
```

Root cause was that `supportsAdaptiveThinking()` only matched `opus-4-6`/`sonnet-4-6` and the already-registered `claude-opus-4-7` models fell through to the legacy `thinking.type=enabled` shape that CAMP rejects.

A side audit against `packages/ai/src/providers/amazon-bedrock.ts` in `@earendil-works/pi-ai` 0.74.0 (`~/Developer/earendil-works/pi`) surfaced a sizeable backlog of drift since the CAMP fork was carved out. This PR closes every behavioral gap except the transport itself (streaming Converse). Pi exports a single 943-line provider; this fork started from a 645-line trimmed copy.

## Behavioral changes

Each item below is a port from `amazon-bedrock.ts`:

- **Opus 4.7 xhigh -> `effort: "xhigh"`** (native tier). Only Opus 4.6 still clamps xhigh to `"max"`. The earlier patch in this PR mapped both to `"max"`, which is the wrong tier for 4.7.
- **Adaptive-thinking model list matches pi exactly**: `opus-4-6`, `opus-4-7`, `sonnet-4-6`. No haiku-4-7 / sonnet-4-7 — those stay on legacy `enabled` until pi adds them.
- **`thinking.display` option** (`'summarized' | 'omitted'`), default `'summarized'`, applied to both adaptive and legacy thinking payloads.
- **GovCloud handling**: omit `thinking.display` when the endpoint region is `us-gov-*` or the model id is `us-gov.anthropic.*` / `arn:aws-us-gov:*`.
- **`interleavedThinking` option** + `anthropic_beta: ["interleaved-thinking-2025-05-14"]` for non-adaptive Claude 4.x, default `true`.
- **Application inference profile support**: every check (`isAnthropicClaudeModel`, `supportsAdaptiveThinking`, `supportsPromptCaching`, `supportsThinkingSignature`, `supportsNativeXhighEffort`, `supportsMaxEffort`, `supportsTemperature`) now consults `model.name` via `getModelMatchCandidates`, with separator normalization. Opaque ARNs no longer silently lose adaptive thinking or caching.
- **`cacheRetention: 'none' | 'short' | 'long'`** option. Defaults to `'short'`. `'long'` attaches `{ ttl: '1h' }` to cache points; `'none'` skips all cache points.
- **Thinking-signature replay safety**: assistant thinking blocks with missing/empty signatures fall back to plain text so Bedrock no longer rejects replayed turns (compaction, mid-stream abort, externally persisted sessions).
- **Async `onPayload` with replace semantics**: callback can mutate or wholly replace the request body via the return value (pi signature). Existing void callbacks keep working.
- **`onResponse(status, headers, model)` callback** for surfacing the upstream `x-amzn-requestid` and status.
- **HTTP error prefixes**: `Throttling error` (429), `Service unavailable` (503), `Internal server error` (>=500), `Validation error` (400). Matches pi's `BEDROCK_ERROR_PREFIXES` so the agent-session retry classifier (`server.?error`, `service.?unavailable`, `throttl(?:ing|e)`) keeps working over CAMP.
- **`requestMetadata` option** for AWS Cost Explorer cost-allocation tagging.
- **FIPS and China runtime endpoints**: `bedrock-runtime-fips.*.amazonaws.com` and `bedrock-runtime.*.amazonaws.com.cn` now resolve to a region. Hostname parsing goes through `new URL()` instead of a substring regex.
- **Strict image MIME validation**: unsupported MIME types throw instead of silently mapping to `png`.
- **Custom `headers` option** merges into the outgoing request.
- **Remove `getBedrockCampExtraModels()`**: pi-ai 0.74.0 already ships all four Opus 4.7 inference-profile variants (`us.`, `eu.`, `global.`, bare). The deduper made the extras dead code. Provider-settings consumer cleaned up accordingly.

## Remaining intentional divergence

- **Non-streaming `POST /converse`** instead of pi's `ConverseStreamCommand`. CAMP serves the non-streaming endpoint over Bearer auth via plain `fetch`; the streaming variant would require parsing `vnd.amazon.eventstream` framing by hand. Tracked as follow-up.
- **No AWS SDK** — no SigV4, no profile/region resolution from env, no NodeHttpHandler proxy agents. CAMP uses Bearer tokens.

## Tests

Coverage expanded from 11 to 31 tests in `packages/webapp/tests/providers/built-in/bedrock-camp.test.ts` — one or more tests per item above. Full `packages/webapp/tests/providers/` + provider-settings suite (283 tests) stays green.