### PR TITLE
fix(swift-server): set SO_REUSEADDR on port probe to survive TIME_WAIT

### DIFF
--- a/packages/swift-server/Sources/Utilities/PortResolver.swift
+++ b/packages/swift-server/Sources/Utilities/PortResolver.swift
@@ -115,6 +115,21 @@ private func tryListenOnPort(_ port: Int, host: LoopbackAddress) throws -> Int {
     }
     defer { _ = close(fd) }
 
+    // Match Hummingbird's real listen socket, which sets SO_REUSEADDR by
+    // default (`ServerConfiguration.reuseAddress = true`). Without this,
+    // the probe bind fails with EADDRINUSE while TIME_WAIT entries from a
+    // previous slicc-server's client connections are still draining on
+    // 127.0.0.1:<port>, even though the actual Hummingbird bind that
+    // follows would have succeeded. This is the smooth-update path:
+    // SIGUSR1 → old server exits → ~1s later new server probes 5710
+    // → TIME_WAIT residue from the now-dead HTTP connections trips the
+    // probe and the new server bails before Hummingbird even gets a
+    // chance to bind.
+    var enableReuseAddr: Int32 = 1
+    _ = withUnsafePointer(to: &enableReuseAddr) {
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, $0, socklen_t(MemoryLayout<Int32>.size))
+    }
+
     if host.family == AF_INET6 {
         var enableV6Only: Int32 = 1
         _ = withUnsafePointer(to: &enableV6Only) {

--- a/packages/swift-server/Sources/Utilities/PortResolver.swift
+++ b/packages/swift-server/Sources/Utilities/PortResolver.swift
@@ -126,8 +126,11 @@ private func tryListenOnPort(_ port: Int, host: LoopbackAddress) throws -> Int {
     // probe and the new server bails before Hummingbird even gets a
     // chance to bind.
     var enableReuseAddr: Int32 = 1
-    _ = withUnsafePointer(to: &enableReuseAddr) {
+    let reuseAddrResult = withUnsafePointer(to: &enableReuseAddr) {
         setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, $0, socklen_t(MemoryLayout<Int32>.size))
+    }
+    guard reuseAddrResult == 0 else {
+        throw socketFailure(host: host.host, port: port)
     }
 
     if host.family == AF_INET6 {

--- a/packages/swift-server/Tests/PortResolverTests.swift
+++ b/packages/swift-server/Tests/PortResolverTests.swift
@@ -75,9 +75,10 @@ final class PortResolverTests: XCTestCase {
         clientAddr.sin_len = UInt8(MemoryLayout<sockaddr_in>.stride)
         clientAddr.sin_family = sa_family_t(AF_INET)
         clientAddr.sin_port = in_port_t(UInt16(port).bigEndian)
-        _ = withUnsafeMutablePointer(to: &clientAddr.sin_addr) {
+        let clientConversion = withUnsafeMutablePointer(to: &clientAddr.sin_addr) {
             inet_pton(AF_INET, "127.0.0.1", $0)
         }
+        XCTAssertEqual(clientConversion, 1)
         let connectResult = withUnsafePointer(to: &clientAddr) {
             $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
                 Darwin.connect(client, $0, socklen_t(MemoryLayout<sockaddr_in>.stride))
@@ -92,7 +93,11 @@ final class PortResolverTests: XCTestCase {
                 Darwin.accept(listener.fd, $0, &acceptedLen)
             }
         }
-        XCTAssertGreaterThanOrEqual(accepted, 0)
+        guard accepted >= 0 else {
+            close(listener.fd)
+            XCTFail("accept() failed: errno=\(errno)")
+            return
+        }
 
         // Close the active (server) side first so it ends up in TIME_WAIT.
         close(accepted)

--- a/packages/swift-server/Tests/PortResolverTests.swift
+++ b/packages/swift-server/Tests/PortResolverTests.swift
@@ -57,6 +57,54 @@ final class PortResolverTests: XCTestCase {
         XCTAssertEqual(resolvedPort, ipv6Reserved.port)
     }
 
+    func testStrictModeSucceedsAcrossTimeWaitResidueFromPreviousListener() async throws {
+        // Regression for the 3.0.0 → 3.0.1 smooth-update bug. The old
+        // slicc-server detaches on SIGUSR1 and the new one tries to bind
+        // 127.0.0.1:5710 ~1s later. Any HTTP/WebSocket connections the
+        // old server had to its clients linger in TIME_WAIT and trip the
+        // probe with EADDRINUSE unless SO_REUSEADDR is set. Hummingbird's
+        // real listen socket sets it; the probe must too.
+        let listener = try makeListeningSocket(port: 0)
+        let port = listener.port
+
+        let client = socket(AF_INET, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(client, 0)
+        defer { close(client) }
+
+        var clientAddr = sockaddr_in()
+        clientAddr.sin_len = UInt8(MemoryLayout<sockaddr_in>.stride)
+        clientAddr.sin_family = sa_family_t(AF_INET)
+        clientAddr.sin_port = in_port_t(UInt16(port).bigEndian)
+        _ = withUnsafeMutablePointer(to: &clientAddr.sin_addr) {
+            inet_pton(AF_INET, "127.0.0.1", $0)
+        }
+        let connectResult = withUnsafePointer(to: &clientAddr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(client, $0, socklen_t(MemoryLayout<sockaddr_in>.stride))
+            }
+        }
+        XCTAssertEqual(connectResult, 0)
+
+        var acceptedAddr = sockaddr_storage()
+        var acceptedLen = socklen_t(MemoryLayout<sockaddr_storage>.stride)
+        let accepted = withUnsafeMutablePointer(to: &acceptedAddr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.accept(listener.fd, $0, &acceptedLen)
+            }
+        }
+        XCTAssertGreaterThanOrEqual(accepted, 0)
+
+        // Close the active (server) side first so it ends up in TIME_WAIT.
+        close(accepted)
+        close(listener.fd)
+
+        // Give the kernel a beat to move the socket into TIME_WAIT.
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let resolved = try await findAvailablePort(startingFrom: port, strict: true)
+        XCTAssertEqual(resolved, port)
+    }
+
     func testPreferredPortUnavailableErrorSurfacesAsHelpfulDescription() {
         let error = PortResolverError.preferredPortUnavailable(port: 5710)
         let description = error.localizedDescription


### PR DESCRIPTION
## Symptom

Updating Sliccstart from 3.0.0 → 3.0.1 leaves the Swift server dead: nothing listening on port 5710 and the previously running browser orphaned without a backend. The status row shows **Start failed**.

## Root cause (from system logs)

```
11:59:00.948  [server/Google Chrome] Detaching (browser stays open)...
11:59:00.955  process exited: Google Chrome code=0
11:59:01.555  new Sliccstart (3.0.1) starts
11:59:01.573  spawn: slicc-server --serve-only --cdp-port=9222  (re-attach)
11:59:01.925  [server/Google Chrome] Error: Port 5710 is already in use.
11:59:01.926  process exited: Google Chrome code=1
```

After SIGUSR1, the old slicc-server cleanly exits but its HTTP/WebSocket connections to its clients linger in **TIME_WAIT** on `127.0.0.1:5710`. `PortResolver.tryListenOnPort` pre-binds with **no `SO_REUSEADDR`**, so the probe fails with `EADDRINUSE` and strict mode bubbles up `preferredPortUnavailable`. Hummingbird's real listener — which would have succeeded — never gets a chance to bind, because the new slicc-server already exited code=1.

The launcher's `isPortInUse` is a `connect()` check, so it correctly sees the port as free and proceeds with re-attach; only the spawned child crashes. That's why the UI shows "Start failed" even though the launcher thought everything was fine.

Hummingbird itself sets `SO_REUSEADDR` on the real listener (`ServerConfiguration.reuseAddress = true` by default), so the probe is strictly more pessimistic than the actual bind — wrong by construction.

## Fix

Set `SO_REUSEADDR` on the probe socket in `tryListenOnPort` before `bind()`, matching the real Hummingbird listener.

## Regression test

`testStrictModeSucceedsAcrossTimeWaitResidueFromPreviousListener` drives a real TCP handshake against a listener bound to an ephemeral port, closes the active (server) side first to seed a real TIME_WAIT entry, then asserts the strict probe still succeeds. Without the fix it raises `preferredPortUnavailable(port: …)` — the exact production error. With the fix, all 7 PortResolver tests pass.

Verified locally:
- Without fix: `Test Case '…testStrictModeSucceedsAcrossTimeWaitResidueFromPreviousListener' failed (0.398s)` — `caught error: "preferredPortUnavailable(port: 56213)"`
- With fix: all 7 PortResolver tests pass (`Executed 7 tests, with 0 failures`)