### PR TITLE
feat(webapp): impatient (double-click) new-session button + reusable press-button element

### DIFF
--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -47,7 +47,9 @@ import {
 } from './provider-settings.js';
 import { quickLabel } from './quick-llm.js';
 import { trackChatSend, trackImageView } from './telemetry.js';
-import { attachLongPressGesture } from './long-press.js';
+// Side-effect import: registers the `<slicc-press-button>` custom element.
+import './press-button.js';
+import type { SliccPressButton } from './press-button.js';
 
 const log = createLogger('chat-panel');
 
@@ -2629,10 +2631,12 @@ export class ChatPanel {
     // Copy — short click copies the most recent assistant response,
     // long-press (>=1s, same gesture as the side rail) or a
     // modifier-click copies the entire chat.
-    const copyBtn = document.createElement('button');
+    const copyBtn = document.createElement('slicc-press-button') as SliccPressButton;
     copyBtn.className = 'msg__feedback-btn';
-    copyBtn.dataset.tooltip = 'Copy last response · hold to copy chat';
-    copyBtn.setAttribute('aria-label', 'Copy last response — hold to copy entire chat');
+    copyBtn.setAttribute('tooltip', 'Copy last response · hold to copy chat');
+    copyBtn.setAttribute('label', 'Copy last response — hold to copy entire chat');
+    // No double-click semantics — keep the short click instant.
+    copyBtn.setAttribute('disable-double-click', '');
     copyBtn.innerHTML =
       '<svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor"><path d="m11.75,18h-7.5c-1.24,0-2.25-1.01-2.25-2.25v-7.5c0-1.24,1.01-2.25,2.25-2.25.41,0,.75.34.75.75s-.34.75-.75.75c-.41,0-.75.34-.75.75v7.5c0,.41.34.75.75.75h7.5c.41,0,.75-.34.75-.75,0-.41.34-.75.75-.75s.75.34.75.75c0,1.24-1.01,2.25-2.25,2.25Z"/><path d="m6.75,5c-.41,0-.75-.34-.75-.75,0-1.24,1.01-2.25,2.25-2.25.41,0,.75.34.75.75s-.34.75-.75.75c-.41,0-.75.34-.75.75,0,.41-.34.75-.75.75Z"/><path d="m13,3.5h-2c-.41,0-.75-.34-.75-.75s.34-.75.75-.75h2c.41,0,.75.34.75.75s-.34.75-.75.75Z"/><path d="m13,14h-2c-.41,0-.75-.34-.75-.75s.34-.75.75-.75h2c.41,0,.75.34.75.75s-.34.75-.75.75Z"/><path d="m15.75,14c-.41,0-.75-.34-.75-.75s.34-.75.75-.75c.41,0,.75-.34.75-.75,0-.41.34-.75.75-.75s.75.34.75.75c0,1.24-1.01,2.25-2.25,2.25Z"/><path d="m17.25,5c-.41,0-.75-.34-.75-.75,0-.41-.34-.75-.75-.75-.41,0-.75-.34-.75-.75s.34-.75.75-.75c1.24,0,2.25,1.01,2.25,2.25,0,.41-.34.75-.75.75Z"/><path d="m17.25,9.75c-.41,0-.75-.34-.75-.75v-2c0-.41.34-.75.75-.75s.75.34.75.75v2c0,.41-.34.75-.75.75Z"/><path d="m6.75,9.75c-.41,0-.75-.34-.75-.75v-2c0-.41.34-.75.75-.75s.75.34.75.75v2c0,.41-.34.75-.75.75Z"/><path d="m8.25,14c-1.24,0-2.25-1.01-2.25-2.25,0-.41.34-.75.75-.75s.75.34.75.75c0,.41.34.75.75.75.41,0,.75.34.75.75s-.34.75-.75.75Z"/></svg>';
 
@@ -2685,13 +2689,11 @@ export class ChatPanel {
       flashSuccess();
     };
 
-    attachLongPressGesture(copyBtn, {
-      onShortClick: () => {
-        void copyLastAssistant();
-      },
-      onLongPress: () => {
-        void copyAll();
-      },
+    copyBtn.addEventListener('short-click', () => {
+      void copyLastAssistant();
+    });
+    copyBtn.addEventListener('long-press', () => {
+      void copyAll();
     });
     row.appendChild(copyBtn);
 

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -32,7 +32,9 @@ import { MemoryPanel } from './memory-panel.js';
 import { ScoopsPanel } from './scoops-panel.js';
 import type { FrozenSessionIndexEntry } from './session-freezer.js';
 import { ScoopSwitcher } from './scoop-switcher.js';
-import { attachLongPressGesture } from './long-press.js';
+// Side-effect import: registers the `<slicc-press-button>` custom element.
+import './press-button.js';
+import type { SliccPressButton } from './press-button.js';
 import {
   getApiKey,
   clearAllSettings,
@@ -93,7 +95,7 @@ export class Layout {
   private threadHeaderEl!: HTMLElement;
   private threadHeaderName!: HTMLElement;
   /** Thread-header "New session" button — populated by `setupChatHeader`. */
-  private newSessionBtn: HTMLButtonElement | null = null;
+  private newSessionBtn: SliccPressButton | null = null;
 
   // Right side — always-visible vertical icon rail + collapsible
   // content panel beside it. Replaces the old horizontal mini-tabs.
@@ -149,12 +151,17 @@ export class Layout {
   public onModelsRefreshed?: () => void;
   public onScoopSelect?: (scoop: RegisteredScoop) => void;
   /**
-   * Fired by the "New session" button. When `freeze` is true (default), the
-   * handler archives the cone session before clearing. The long-press
-   * gesture passes `freeze: false` to discard the conversation without
-   * adding it to /sessions/.
+   * Fired by the "New session" button. Three gestures map to three modes:
+   *   - short click → `freeze: true`  (full freeze, blocks reload while
+   *     the LLM call runs — historical default).
+   *   - long press  → `freeze: false` (discard the conversation; no
+   *     archive entry is written).
+   *   - double click → `freeze: 'quick'` (impatient mode: write a
+   *     pending-enrichment archive immediately and reload; memory
+   *     extraction + title generation finish in the background on the
+   *     next boot via `enrichPendingSessions`).
    */
-  public onClearChat?: (opts?: { freeze?: boolean }) => Promise<void>;
+  public onClearChat?: (opts?: { freeze?: boolean | 'quick' }) => Promise<void>;
   public onClearFilesystem?: () => Promise<void>;
   /**
    * Fired when the user clicks an entry in the frozen-sessions sidebar
@@ -941,16 +948,19 @@ export class Layout {
 
     // Clear chat button — the rail now owns panel toggling, so the
     // chat header drops the panel-toggle button entirely.
-    const clearChatBtn = document.createElement('button');
+    const clearChatBtn = document.createElement('slicc-press-button') as SliccPressButton;
     clearChatBtn.className = 'thread-header__panel-toggle thread-header__new-session';
     // Long, explanatory tooltip — the action is non-obvious enough that
     // a 1-word label would mislead users into thinking it's a destructive
-    // "clear" button. Long-press is the only secondary affordance.
-    clearChatBtn.dataset.tooltip =
-      'New session for faster responses — history and memories will be kept. Long press to discard this session without saving memory.';
+    // "clear" button. All three gestures are documented so power users
+    // can discover the impatient double-click without reading docs.
     clearChatBtn.setAttribute(
-      'aria-label',
-      'New session — keeps memory and history. Hold to discard without saving memory.'
+      'tooltip',
+      'New session for faster responses — history and memories will be kept. Double-click for fastest reset — memories extract in the background. Long press to discard this session without saving memory.'
+    );
+    clearChatBtn.setAttribute(
+      'label',
+      'New session — keeps memory and history. Double-click for fastest reset (memories extract in the background). Hold to discard without saving memory.'
     );
     this.newSessionBtn = clearChatBtn;
     // "Compose new" — square with a pencil, matches the universal
@@ -960,7 +970,7 @@ export class Layout {
       '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>' +
       '<path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/>' +
       '</svg>';
-    const runNewSession = async (opts?: { freeze?: boolean }) => {
+    const runNewSession = async (opts?: { freeze?: boolean | 'quick' }) => {
       if (this.onClearChat) {
         await this.onClearChat(opts);
       } else {
@@ -968,11 +978,14 @@ export class Layout {
       }
       location.reload();
     };
-    // Short click → freeze + clear. Long press / modifier-click → discard.
-    attachLongPressGesture(clearChatBtn, {
-      onShortClick: () => void runNewSession({ freeze: true }),
-      onLongPress: () => void runNewSession({ freeze: false }),
-    });
+    // Short click → full freeze (blocks reload while the LLM call runs).
+    // Long press / modifier-click → discard without archiving.
+    // Double click → quick freeze (writes a pending-enrichment archive
+    // and reloads immediately; the next boot finishes the work in the
+    // background via `enrichPendingSessions`).
+    clearChatBtn.addEventListener('short-click', () => void runNewSession({ freeze: true }));
+    clearChatBtn.addEventListener('long-press', () => void runNewSession({ freeze: false }));
+    clearChatBtn.addEventListener('double-click', () => void runNewSession({ freeze: 'quick' }));
 
     const threadActions = document.createElement('div');
     threadActions.className = 'thread-header__actions';

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -953,14 +953,17 @@ export class Layout {
     // Long, explanatory tooltip — the action is non-obvious enough that
     // a 1-word label would mislead users into thinking it's a destructive
     // "clear" button. All three gestures are documented so power users
-    // can discover the impatient double-click without reading docs.
+    // can discover the impatient double-click without reading docs. The
+    // tooltip uses embedded newlines so each gesture lands on its own
+    // line; the aria-label is flattened to ". "-separated sentences
+    // since screen readers don't render \n.
     clearChatBtn.setAttribute(
       'tooltip',
-      'New session for faster responses — history and memories will be kept. Double-click for fastest reset — memories extract in the background. Long press to discard this session without saving memory.'
+      'Click — new session, keep memory\nDouble-click — fastest reset, memory extracts in background\nLong press — discard without saving'
     );
     clearChatBtn.setAttribute(
       'label',
-      'New session — keeps memory and history. Double-click for fastest reset (memories extract in the background). Hold to discard without saving memory.'
+      'New session. Click to start a new session and keep memory. Double-click for fastest reset — memory extracts in background. Long press to discard without saving.'
     );
     this.newSessionBtn = clearChatBtn;
     // "Compose new" — square with a pencil, matches the universal

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -47,7 +47,11 @@ import { createAttachmentTmpWriter } from './attachment-vfs.js';
 // — the extension agent engine runs in the offscreen document, not in this file.
 import { registerProviders } from '../providers/index.js';
 import { flushCredentialsToWorker, resolveDefaultModel } from './onboarding-helpers.js';
-import { runNewSessionFreeze } from './new-session.js';
+import {
+  runNewSessionFreeze,
+  runNewSessionFreezeQuick,
+  scheduleBackgroundEnrichment,
+} from './new-session.js';
 import { frozenSessionPath, parseFrozenArchive } from './session-freezer.js';
 import { BrowserAPI } from '../cdp/index.js';
 import { type Orchestrator } from '../scoops/index.js';
@@ -938,10 +942,22 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
   // Wire "New session" — freeze the cone's chat to /sessions/ via the
   // freezer (memory extraction + title), then delete ONLY the cone session
   // from IndexedDB. Scoops survive intentionally so the fresh cone inherits
-  // the existing scoop roster. Long-press passes `freeze: false` to discard
-  // the conversation without archiving it.
+  // the existing scoop roster.
+  //   - `freeze !== false && freeze !== 'quick'` → full freeze (default
+  //     short-click). Blocks reload while the LLM call runs.
+  //   - `freeze === 'quick'`                    → quick freeze (double
+  //     click). Writes a pending-enrichment archive and returns fast;
+  //     `enrichPendingSessions` finishes the work on the next boot.
+  //   - `freeze === false`                      → discard (long press).
+  //     No archive entry is written.
   layout.onClearChat = async (opts) => {
-    if (opts?.freeze !== false) {
+    if (opts?.freeze === 'quick') {
+      try {
+        await runNewSessionFreezeQuick({ vfs: localFs });
+      } catch (err) {
+        log.warn('Quick freezer step failed (clearing anyway)', { error: String(err) });
+      }
+    } else if (opts?.freeze !== false) {
       try {
         await runNewSessionFreeze({ vfs: localFs });
       } catch (err) {
@@ -1575,6 +1591,15 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
 
   // Initialize operational telemetry (fire-and-forget)
   initTelemetry().catch(() => {});
+
+  // Background enrichment of pending-frozen sessions. Each impatient
+  // double-click on the new-session button leaves a `pendingEnrichment`
+  // entry in `/sessions/index.json` with a heuristic title; this pass
+  // re-runs the LLM calls and rewrites the archive title + appends the
+  // extracted memories to `/shared/CLAUDE.md`. Deferred behind
+  // `requestIdleCallback` (or `setTimeout(0)` as a fallback) so a slow
+  // enrichment never blocks first paint.
+  scheduleBackgroundEnrichment(localFs);
 }
 
 // ---------------------------------------------------------------------------
@@ -1967,11 +1992,22 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
   // Wire "New session" — freeze the cone's chat to /sessions/ via the
   // freezer (memory extraction + title), then clear ONLY the cone
   // session via the kernel client. Scoops survive intentionally so the
-  // fresh cone inherits the existing scoop roster. When `opts.freeze`
-  // is false (long-press on the new-session button) the freezer is
-  // skipped entirely — useful when the user explicitly wants to discard.
+  // fresh cone inherits the existing scoop roster.
+  //   - `freeze !== false && freeze !== 'quick'` → full freeze (default
+  //     short-click). Blocks reload while the LLM call runs.
+  //   - `freeze === 'quick'`                    → quick freeze (double
+  //     click). Writes a pending-enrichment archive and returns fast;
+  //     `enrichPendingSessions` finishes the work on the next boot.
+  //   - `freeze === false`                      → discard (long press).
+  //     No archive entry is written.
   layout.onClearChat = async (opts) => {
-    if (opts?.freeze !== false) {
+    if (opts?.freeze === 'quick') {
+      try {
+        await runNewSessionFreezeQuick({ vfs: localFs });
+      } catch (err) {
+        log.warn('Quick freezer step failed (clearing anyway)', { error: String(err) });
+      }
+    } else if (opts?.freeze !== false) {
       try {
         await runNewSessionFreeze({ vfs: localFs });
       } catch (err) {
@@ -2837,6 +2873,11 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
     await loadUIFixtureIntoChat(layout.panels.chat);
   }
   initTelemetry().catch(() => {});
+
+  // Background enrichment of pending-frozen sessions (see the extension
+  // path for rationale). Fire-and-forget after the boot-critical wiring
+  // is in place so a slow enrichment never blocks first paint.
+  scheduleBackgroundEnrichment(localFs);
 
   log.info('Standalone kernel-worker UI ready');
 }

--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -13,7 +13,13 @@ import { createLogger } from '../core/logger.js';
 import { getDailyAdobeUuid } from '../scoops/llm-session-id.js';
 import { getApiKey, resolveCurrentModel } from './provider-settings.js';
 import { SessionStore } from './session-store.js';
-import { freezeConeSession, type FrozenSession } from './session-freezer.js';
+import {
+  enrichPendingSession,
+  freezeConeSession,
+  listPendingEnrichments,
+  type FrozenSession,
+  type FrozenSessionIndexEntry,
+} from './session-freezer.js';
 
 const log = createLogger('new-session');
 
@@ -69,4 +75,133 @@ export async function runNewSessionFreeze(
     apiKey,
     headers,
   });
+}
+
+/**
+ * Quick-freeze variant of `runNewSessionFreeze`. Skips the two LLM calls
+ * (and therefore the credential/header resolution they need), writing
+ * the cone session under a synthetic `pending-…md` filename with the
+ * heuristic title. Boot-time enrichment finishes the work later via
+ * `enrichPendingSessions`. Returns as quickly as the VFS write + index
+ * update allow — designed for the double-click "impatient" gesture
+ * where reload latency matters more than archive title fidelity.
+ */
+export async function runNewSessionFreezeQuick(
+  opts: RunNewSessionFreezeOptions
+): Promise<FrozenSession | null> {
+  const sessionStore = new SessionStore();
+  try {
+    await sessionStore.init();
+  } catch (err) {
+    log.warn('SessionStore init failed — cannot quick-freeze', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  return freezeConeSession({
+    sessionStore,
+    vfs: opts.vfs,
+    mode: 'quick',
+  });
+}
+
+export interface EnrichPendingSessionsResult {
+  /** Total pending entries found in the index. */
+  found: number;
+  /** Entries successfully enriched (title rewritten + file renamed). */
+  enriched: FrozenSessionIndexEntry[];
+}
+
+/**
+ * Resolve credentials + model + headers once, then walk the sessions
+ * index and finish every `pendingEnrichment: true` archive. Designed
+ * to be fire-and-forget from boot — never throws, and best-effort per
+ * entry so one bad archive doesn't block the rest. When no LLM
+ * credentials are available, this is a no-op (entries stay pending and
+ * will be retried on the next boot once credentials are configured).
+ */
+export async function enrichPendingSessions(
+  opts: RunNewSessionFreezeOptions
+): Promise<EnrichPendingSessionsResult> {
+  const result: EnrichPendingSessionsResult = { found: 0, enriched: [] };
+
+  let pending: FrozenSessionIndexEntry[] = [];
+  try {
+    pending = await listPendingEnrichments(opts.vfs);
+  } catch (err) {
+    log.warn('Failed to list pending enrichments', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return result;
+  }
+  result.found = pending.length;
+  if (pending.length === 0) return result;
+
+  const apiKey = getApiKey() ?? undefined;
+  let model: Model<Api> | undefined;
+  try {
+    model = resolveCurrentModel();
+  } catch (err) {
+    log.info('No active model — skipping background enrichment', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return result;
+  }
+  if (!apiKey || !model) {
+    log.info('LLM credentials unavailable — leaving pending entries for later boot', {
+      pending: pending.length,
+    });
+    return result;
+  }
+
+  const headers: Record<string, string> | undefined =
+    model.provider === 'adobe'
+      ? { 'X-Session-Id': getDailyAdobeUuid(FREEZER_SESSION_ANCHOR) }
+      : undefined;
+
+  for (const entry of pending) {
+    try {
+      const updated = await enrichPendingSession(opts.vfs, entry, {
+        model,
+        apiKey,
+        headers,
+      });
+      if (updated) result.enriched.push(updated);
+    } catch (err) {
+      log.warn('Background enrichment threw (entry stays pending)', {
+        filename: entry.filename,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info('Background enrichment pass complete', {
+    found: result.found,
+    enriched: result.enriched.length,
+  });
+  return result;
+}
+
+/**
+ * Schedule a fire-and-forget background enrichment pass over pending
+ * frozen sessions (those archived by the impatient double-click path).
+ * Defers via `requestIdleCallback` where available so a slow LLM call
+ * can't delay first paint; falls back to `setTimeout(0)` otherwise.
+ * Never throws — `enrichPendingSessions` is already best-effort.
+ */
+export function scheduleBackgroundEnrichment(vfs: VirtualFS): void {
+  const run = (): void => {
+    void enrichPendingSessions({ vfs }).catch(() => {
+      // `enrichPendingSessions` already logs internally and is best-effort
+      // per entry; swallow here so the boot path stays silent on failure.
+    });
+  };
+  const ric = (globalThis as { requestIdleCallback?: (cb: () => void) => number })
+    .requestIdleCallback;
+  if (typeof ric === 'function') {
+    ric(run);
+  } else {
+    setTimeout(run, 0);
+  }
 }

--- a/packages/webapp/src/ui/press-button.ts
+++ b/packages/webapp/src/ui/press-button.ts
@@ -61,7 +61,16 @@ export class SliccPressButton extends HTMLElement {
   private pendingShortEvent: MouseEvent | null = null;
 
   connectedCallback(): void {
-    if (!this.initialized) this.initialize();
+    if (!this.initialized) {
+      this.initialize();
+    } else if (this.handle === null) {
+      // Re-attached to the DOM after a previous disconnect — the inner
+      // button + press layer are still alive (light DOM survives the
+      // move) but disconnectedCallback destroyed the gesture handle, so
+      // re-arm it here. Without this, a detached-then-reattached host
+      // would silently lose click handling.
+      this.attachGesture();
+    }
     this.syncAttributes();
   }
 

--- a/packages/webapp/src/ui/press-button.ts
+++ b/packages/webapp/src/ui/press-button.ts
@@ -1,0 +1,258 @@
+/**
+ * `<slicc-press-button>` — reusable click + long-press + double-click
+ * button. Encapsulates the press-layer + flood-fill ripple visual
+ * originally hand-rolled in `rail-zone.ts` so the side rail, the
+ * thread-header new-session button, and the chat copy button can all
+ * share one component.
+ *
+ * Internal DOM (light DOM):
+ *   <slicc-press-button>
+ *     <button class="slicc-press-btn__btn" type="button">
+ *       <span class="slicc-press-btn__press-layer"></span>
+ *       <!-- caller-supplied icon nodes (slotted at construction) -->
+ *     </button>
+ *   </slicc-press-button>
+ *
+ * Attributes (all optional):
+ *   - `label`                forwarded to inner button's `aria-label`.
+ *   - `tooltip`              forwarded to inner button's `data-tooltip`.
+ *   - `tooltip-pos`          forwarded to inner button's `data-tooltip-pos`.
+ *   - `long-press-ms`        long-press threshold (default {@link LONG_PRESS_MS}).
+ *   - `double-click-ms`      double-click window in ms (default 350).
+ *   - `disable-double-click` boolean — fire `short-click` immediately
+ *                            without waiting for a possible second click.
+ *
+ * Events (CustomEvent, bubbles + cancelable):
+ *   - `short-click`  — single primary click (deferred by `double-click-ms`
+ *                       unless `disable-double-click` is set).
+ *   - `long-press`   — held past `long-press-ms`, or any modifier-click
+ *                       (cmd/ctrl/shift/alt). A modifier-click during a
+ *                       pending double-click window is treated as the
+ *                       second click instead.
+ *   - `double-click` — second primary (or modifier) click inside the
+ *                       double-click window. Suppresses the pending
+ *                       `short-click` from the first click.
+ *
+ * Visual + sizing: the host carries `display: inline-flex` so it can be
+ * sized by its parent (rail item, header button, copy button). The
+ * inner button fills the host (`width/height: 100%`) so the ripple's
+ * bounding rect matches what the user sees as "the button".
+ */
+
+import { LONG_PRESS_MS, attachLongPressGesture, type LongPressHandle } from './long-press.js';
+
+/** Default delay before committing a single click as a `short-click`. */
+export const DEFAULT_DOUBLE_CLICK_MS = 350;
+
+/** BEM-ish base class for the component's own DOM hooks. */
+const BASE = 'slicc-press-btn';
+
+/** Public typing for the host element. */
+export class SliccPressButton extends HTMLElement {
+  static get observedAttributes(): string[] {
+    return ['label', 'tooltip', 'tooltip-pos', 'disabled'];
+  }
+
+  private innerBtn: HTMLButtonElement | null = null;
+  private pressLayer: HTMLSpanElement | null = null;
+  private handle: LongPressHandle | null = null;
+  private initialized = false;
+  private pendingShortTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingShortEvent: MouseEvent | null = null;
+
+  connectedCallback(): void {
+    if (!this.initialized) this.initialize();
+    this.syncAttributes();
+  }
+
+  disconnectedCallback(): void {
+    this.handle?.destroy();
+    this.handle = null;
+    this.clearPendingShort();
+    this.clearRipple();
+  }
+
+  attributeChangedCallback(): void {
+    if (!this.initialized) return;
+    this.syncAttributes();
+  }
+
+  /**
+   * Replace the icon HTML inside the inner button while preserving the
+   * press layer. Used by `RailZone.setItemIcon` when a sprinkle's icon
+   * resolves asynchronously.
+   */
+  setIcon(html: string): void {
+    if (!this.initialized) this.initialize();
+    const btn = this.innerBtn!;
+    const layer = this.pressLayer!;
+    for (const child of Array.from(btn.childNodes)) {
+      if (child !== layer) child.remove();
+    }
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    while (tmp.firstChild) btn.appendChild(tmp.firstChild);
+  }
+
+  /** Focus the internal button (so callers don't need to dig in). */
+  override focus(options?: FocusOptions): void {
+    if (!this.initialized) this.initialize();
+    this.innerBtn?.focus(options);
+  }
+
+  private initialize(): void {
+    this.initialized = true;
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = `${BASE}__btn`;
+
+    const layer = document.createElement('span');
+    layer.className = `${BASE}__press-layer`;
+    btn.appendChild(layer);
+
+    // Move pre-existing host children (the caller's icon) into the
+    // inner button so they render on top of the press layer.
+    while (this.firstChild) btn.appendChild(this.firstChild);
+
+    this.appendChild(btn);
+    this.innerBtn = btn;
+    this.pressLayer = layer;
+
+    this.attachGesture();
+  }
+
+  private syncAttributes(): void {
+    const btn = this.innerBtn;
+    if (!btn) return;
+
+    const label = this.getAttribute('label');
+    if (label != null) btn.setAttribute('aria-label', label);
+    else btn.removeAttribute('aria-label');
+
+    const tooltip = this.getAttribute('tooltip');
+    if (tooltip != null) btn.dataset.tooltip = tooltip;
+    else delete btn.dataset.tooltip;
+
+    const tooltipPos = this.getAttribute('tooltip-pos');
+    if (tooltipPos != null) btn.dataset.tooltipPos = tooltipPos;
+    else delete btn.dataset.tooltipPos;
+
+    if (this.hasAttribute('disabled')) btn.setAttribute('disabled', '');
+    else btn.removeAttribute('disabled');
+  }
+
+  private longPressMs(): number {
+    const raw = this.getAttribute('long-press-ms');
+    if (raw == null) return LONG_PRESS_MS;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : LONG_PRESS_MS;
+  }
+
+  private doubleClickMs(): number {
+    const raw = this.getAttribute('double-click-ms');
+    if (raw == null) return DEFAULT_DOUBLE_CLICK_MS;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : DEFAULT_DOUBLE_CLICK_MS;
+  }
+
+  private doubleClickDisabled(): boolean {
+    return this.hasAttribute('disable-double-click');
+  }
+
+  private emit(type: 'short-click' | 'long-press' | 'double-click', source?: MouseEvent): void {
+    const detail = source ? { sourceEvent: source } : {};
+    this.dispatchEvent(new CustomEvent(type, { bubbles: true, cancelable: true, detail }));
+  }
+
+  private clearPendingShort(): void {
+    if (this.pendingShortTimer !== null) {
+      clearTimeout(this.pendingShortTimer);
+      this.pendingShortTimer = null;
+    }
+    this.pendingShortEvent = null;
+  }
+
+  private attachGesture(): void {
+    // Listen on the host so consumers can dispatchEvent against the
+    // custom element directly (matches the long-press lib's contract).
+    this.handle = attachLongPressGesture(this, {
+      longPressMs: this.longPressMs(),
+      onPressStart: (e) => this.paintRipple(e),
+      onPressEnd: () => this.clearRipple(),
+      onLongPress: () => {
+        // A modifier-click that arrives during the double-click window
+        // is the second click of a double-click, not a long-press.
+        if (this.pendingShortTimer !== null) {
+          this.clearPendingShort();
+          this.emit('double-click');
+          return;
+        }
+        this.emit('long-press');
+      },
+      onShortClick: (e) => {
+        if (this.doubleClickDisabled()) {
+          this.emit('short-click', e);
+          return;
+        }
+        if (this.pendingShortTimer !== null) {
+          // Second plain click inside the window → double-click,
+          // pending first short-click is suppressed.
+          this.clearPendingShort();
+          this.emit('double-click', e);
+          return;
+        }
+        // First click — defer to give a possible second click time
+        // to land. CustomEvent fires after `double-click-ms` if no
+        // second click arrives.
+        this.pendingShortEvent = e;
+        this.pendingShortTimer = setTimeout(() => {
+          this.pendingShortTimer = null;
+          const ev = this.pendingShortEvent;
+          this.pendingShortEvent = null;
+          this.emit('short-click', ev ?? undefined);
+        }, this.doubleClickMs());
+      },
+    });
+  }
+
+  private paintRipple(e: MouseEvent): void {
+    this.clearRipple();
+    const layer = this.pressLayer;
+    if (!layer) return;
+    // Position is computed relative to the press layer (not the host)
+    // so callers can give the host padding without offsetting the
+    // ripple. The layer fills the inner button via `inset: 0`.
+    const rect = layer.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    // Diagonal from the press point to the farthest corner — guarantees
+    // the ripple covers the whole button no matter where the click landed.
+    const farthestX = Math.max(x, rect.width - x);
+    const farthestY = Math.max(y, rect.height - y);
+    const radius = Math.ceil(Math.hypot(farthestX, farthestY)) + 2;
+    const span = document.createElement('span');
+    span.className = `${BASE}__press`;
+    span.style.left = `${x}px`;
+    span.style.top = `${y}px`;
+    span.style.width = '0px';
+    span.style.height = '0px';
+    span.style.transitionDuration = `${this.longPressMs()}ms`;
+    layer.appendChild(span);
+    requestAnimationFrame(() => {
+      if (!span.isConnected) return;
+      span.style.width = `${radius * 2}px`;
+      span.style.height = `${radius * 2}px`;
+    });
+  }
+
+  private clearRipple(): void {
+    const layer = this.pressLayer;
+    if (!layer) return;
+    while (layer.firstChild) layer.firstChild.remove();
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('slicc-press-button')) {
+  customElements.define('slicc-press-button', SliccPressButton);
+}

--- a/packages/webapp/src/ui/rail-zone.ts
+++ b/packages/webapp/src/ui/rail-zone.ts
@@ -18,7 +18,10 @@
  */
 
 import type { ZoneId } from './panel-types.js';
-import { LONG_PRESS_MS, attachLongPressGesture } from './long-press.js';
+import { LONG_PRESS_MS } from './long-press.js';
+// Side-effect import: registers the `<slicc-press-button>` custom element.
+import './press-button.js';
+import type { SliccPressButton } from './press-button.js';
 
 export interface RailItem {
   id: string;
@@ -60,7 +63,7 @@ export interface RailZoneOptions {
 }
 
 interface RailEntry {
-  btn: HTMLButtonElement;
+  btn: SliccPressButton;
   container: HTMLElement;
   item: RailItem;
 }
@@ -155,22 +158,16 @@ export class RailZone {
   }
 
   /**
-   * Replace the icon SVG/HTML for an existing rail item. Preserves
-   * the press-ripple layer so the click-and-hold animation still
+   * Replace the icon SVG/HTML for an existing rail item. The press-
+   * ripple layer is owned by `<slicc-press-button>`, which preserves
+   * it across `setIcon` calls — so the click-and-hold animation still
    * works after the swap. Used when a sprinkle's icon spec is
    * resolved asynchronously (Lucide lookup, VFS read).
    */
   setItemIcon(id: string, iconHtml: string): void {
     const entry = this.entries.get(id);
     if (!entry) return;
-    const press = entry.btn.querySelector('.rail__item-press-layer');
-    entry.btn.innerHTML = iconHtml;
-    if (press) entry.btn.insertBefore(press, entry.btn.firstChild);
-    else {
-      const layer = document.createElement('span');
-      layer.className = 'rail__item-press-layer';
-      entry.btn.insertBefore(layer, entry.btn.firstChild);
-    }
+    entry.btn.setIcon(iconHtml);
   }
 
   /**
@@ -314,87 +311,35 @@ export class RailZone {
   }
 
   /** Create the rail button for an item with click + long-press wiring. */
-  private createItemButton(item: RailItem): HTMLButtonElement {
-    const btn = document.createElement('button');
+  private createItemButton(item: RailItem): SliccPressButton {
+    const btn = document.createElement('slicc-press-button') as SliccPressButton;
     btn.className = 'rail__item';
     btn.dataset.itemId = item.id;
-    btn.dataset.tooltip = item.label;
-    btn.dataset.tooltipPos = 'left';
-    btn.setAttribute('aria-label', item.label);
+    btn.setAttribute('label', item.label);
+    btn.setAttribute('tooltip', item.label);
+    btn.setAttribute('tooltip-pos', 'left');
+    // Rail items have no double-click semantics — keep clicks instant.
+    btn.setAttribute('disable-double-click', '');
     btn.innerHTML = item.icon;
-
-    // Press-ripple layer: a clipped overlay that hosts the growing
-    // circle drawn during a long-press. Inserted as the first child
-    // so the icon renders on top of the ripple.
-    const pressLayer = document.createElement('span');
-    pressLayer.className = 'rail__item-press-layer';
-    btn.insertBefore(pressLayer, btn.firstChild);
 
     this.attachActivationHandlers(btn, item.id);
     return btn;
   }
 
   /** Wire click + long-press + modifier-click activation. */
-  private attachActivationHandlers(btn: HTMLButtonElement, id: string): void {
-    let pressEl: HTMLSpanElement | null = null;
-
-    const removePressVisual = () => {
-      if (pressEl) {
-        pressEl.remove();
-        pressEl = null;
+  private attachActivationHandlers(btn: SliccPressButton, id: string): void {
+    btn.addEventListener('long-press', () => this.activateItem(id, { fullpage: true }));
+    btn.addEventListener('short-click', () => {
+      // Plain click: toggle. In `defaultFullpage` mode (extension
+      // side panel) the active rail item already covers the panel,
+      // so collapsing on a second click on the same icon takes the
+      // user back to chat naturally.
+      const wantsFullpage = this.defaultFullpage;
+      if (this.activeId === id && (wantsFullpage ? this.fullpage : !this.fullpage)) {
+        this.collapse();
+      } else {
+        this.activateItem(id, { fullpage: wantsFullpage });
       }
-    };
-
-    /**
-     * Build the growing-circle ripple. The element starts as a tiny
-     * dot at the cursor, animates outward via CSS transitions, and
-     * fully covers the button right at the long-press threshold.
-     */
-    const startPressVisual = (e: MouseEvent) => {
-      removePressVisual();
-      const layer = btn.querySelector<HTMLElement>('.rail__item-press-layer');
-      if (!layer) return;
-      const rect = btn.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-      // Cover the whole button no matter where the click landed:
-      // diagonal from the press point to the farthest corner.
-      const farthestX = Math.max(x, rect.width - x);
-      const farthestY = Math.max(y, rect.height - y);
-      const radius = Math.ceil(Math.hypot(farthestX, farthestY)) + 2;
-      const span = document.createElement('span');
-      span.className = 'rail__item-press';
-      span.style.left = `${x}px`;
-      span.style.top = `${y}px`;
-      span.style.width = '0px';
-      span.style.height = '0px';
-      span.style.transitionDuration = `${LONG_PRESS_MS}ms`;
-      layer.appendChild(span);
-      pressEl = span;
-      // Force layout, then expand to full button cover.
-      requestAnimationFrame(() => {
-        if (!pressEl) return;
-        pressEl.style.width = `${radius * 2}px`;
-        pressEl.style.height = `${radius * 2}px`;
-      });
-    };
-
-    attachLongPressGesture(btn, {
-      onPressStart: startPressVisual,
-      onPressEnd: removePressVisual,
-      onLongPress: () => this.activateItem(id, { fullpage: true }),
-      onShortClick: () => {
-        // Plain click: toggle. In `defaultFullpage` mode (extension
-        // side panel) the active rail item already covers the panel,
-        // so collapsing on a second click on the same icon takes the
-        // user back to chat naturally.
-        const wantsFullpage = this.defaultFullpage;
-        if (this.activeId === id && (wantsFullpage ? this.fullpage : !this.fullpage)) {
-          this.collapse();
-        } else {
-          this.activateItem(id, { fullpage: wantsFullpage });
-        }
-      },
     });
   }
 

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -467,15 +467,26 @@ export async function enrichPendingSession(
   }
 
   // 2. Load the archive. Missing file → already renamed (or wiped) → no-op.
+  //    Any other read failure (permission, IO, etc.) is a real error: log it
+  //    as a warn so it shows up in the console, but still return null and
+  //    leave the entry pending so the next boot retries.
   const oldPath = frozenSessionPath(entry);
   let archiveContent = '';
   try {
     const raw = await vfs.readFile(oldPath, { encoding: 'utf-8' });
     archiveContent = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
-  } catch {
-    log.info('Pending archive missing — treating as already enriched', {
-      filename: entry.filename,
-    });
+  } catch (err) {
+    const code = (err as { code?: unknown } | null)?.code;
+    if (code === 'ENOENT') {
+      log.info('Pending archive missing — treating as already enriched', {
+        filename: entry.filename,
+      });
+    } else {
+      log.warn('Failed to read pending archive (entry stays pending)', {
+        filename: entry.filename,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
     return null;
   }
 
@@ -632,8 +643,12 @@ export async function enrichPendingSession(
 /**
  * Replace the `title:` value in the frontmatter (and the leading `# title`
  * heading in the body) of a freezer-shaped archive markdown string with
- * the LLM-derived title. Falls back to a string concat if the frontmatter
- * regex doesn't match — the worst case is a stale heading, never data loss.
+ * the LLM-derived title. When the frontmatter regex doesn't match, the
+ * original content is returned unchanged — callers are expected to hand
+ * in archive-shaped content (well-formed `---\n…\n---\n…` frontmatter)
+ * produced by `formatArchiveAsMarkdown`. A silent rewrite of malformed
+ * archives could corrupt user data, so the no-match path intentionally
+ * does nothing rather than appending a synthesized header.
  */
 function rewriteArchiveTitle(content: string, newTitle: string): string {
   const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
@@ -645,34 +660,65 @@ function rewriteArchiveTitle(content: string, newTitle: string): string {
 }
 
 /**
+ * Promise-chain mutex serializing every `replaceIndexEntry` call within
+ * this module. The sessions index is a single shared JSON file with a
+ * read-modify-write update; two concurrent callers (e.g. the boot-time
+ * background enrichment scanner racing a freshly-quick-frozen entry)
+ * would otherwise read the same stale snapshot and clobber one of the
+ * writes. Cross-tab concurrency is out of scope — the app runs in a
+ * single context.
+ */
+let indexWriteChain: Promise<void> = Promise.resolve();
+
+/**
  * Swap one entry in the sessions index by filename. Used by the
  * enrichment pass to flip a `pending-…` entry over to its renamed
- * canonical form. No-op when the entry isn't found.
+ * canonical form. Always dedupes by `replacement.filename` so a row
+ * with the same target name is never duplicated when `oldFilename`
+ * isn't found in the index. Writes are serialized via {@link indexWriteChain}.
  */
 async function replaceIndexEntry(
   vfs: VirtualFS,
   oldFilename: string,
   replacement: FrozenSessionIndexEntry
 ): Promise<void> {
-  let existing: FrozenSessionIndexEntry[] = [];
-  try {
-    const raw = await vfs.readFile(SESSIONS_INDEX_PATH, { encoding: 'utf-8' });
-    const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
-    const parsed = JSON.parse(text);
-    if (Array.isArray(parsed)) existing = parsed as FrozenSessionIndexEntry[];
-  } catch {
-    // No index — nothing to replace; write the entry as the only row so
-    // the rename is still visible to the panel on next reload.
-  }
-  const idx = existing.findIndex((e) => e.filename === oldFilename);
-  let updated: FrozenSessionIndexEntry[];
-  if (idx === -1) {
-    updated = [replacement, ...existing];
-  } else {
-    updated = existing.slice();
-    updated[idx] = replacement;
-  }
-  await vfs.writeFile(SESSIONS_INDEX_PATH, JSON.stringify(updated, null, 2));
+  const run = async (): Promise<void> => {
+    let existing: FrozenSessionIndexEntry[] = [];
+    try {
+      const raw = await vfs.readFile(SESSIONS_INDEX_PATH, { encoding: 'utf-8' });
+      const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) existing = parsed as FrozenSessionIndexEntry[];
+    } catch {
+      // No index — nothing to replace; write the entry as the only row so
+      // the rename is still visible to the panel on next reload.
+    }
+    const idx = existing.findIndex((e) => e.filename === oldFilename);
+    let updated: FrozenSessionIndexEntry[];
+    if (idx === -1) {
+      // Old entry not in the index — prepend the replacement, but strip
+      // any pre-existing row already pointing at `replacement.filename`
+      // so concurrent rename-then-replace flows don't leave duplicates.
+      updated = [replacement, ...existing.filter((e) => e.filename !== replacement.filename)];
+    } else {
+      updated = existing.slice();
+      updated[idx] = replacement;
+      // Drop any other row sharing the replacement's filename (e.g. the
+      // canonical row already exists alongside the stale pending one).
+      updated = updated.filter((e, i) => i === idx || e.filename !== replacement.filename);
+    }
+    await vfs.writeFile(SESSIONS_INDEX_PATH, JSON.stringify(updated, null, 2));
+  };
+  // Append to the shared chain so writers run strictly in arrival order.
+  // `.catch(() => {})` keeps a failed write from poisoning the chain for
+  // subsequent callers; each call still surfaces its own error via the
+  // returned `next` promise below.
+  const next = indexWriteChain.then(run, run);
+  indexWriteChain = next.then(
+    () => undefined,
+    () => undefined
+  );
+  return next;
 }
 
 /**

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -57,6 +57,14 @@ export interface FrozenSessionIndexEntry {
   frozenAt: string;
   /** Count of messages in the frozen session. */
   messageCount: number;
+  /**
+   * Quick-freeze marker. When true, the archive was written with a
+   * heuristic title under a synthetic `pending-<short-id>.md` filename
+   * and still needs the two LLM calls (memory extraction + title) to
+   * finish. Boot-time enrichment picks these up and rewrites the title
+   * + renames the file to the canonical `<timestamp>-<slug>.md` form.
+   */
+  pendingEnrichment?: boolean;
 }
 
 export interface FrozenSession extends FrozenSessionIndexEntry {
@@ -90,6 +98,15 @@ export interface FreezeConeSessionOptions {
   apiKey?: string;
   /** Adobe X-Session-Id and friends — forwarded to both LLM calls. */
   headers?: Record<string, string>;
+  /**
+   * Freeze mode. `'full'` (default) runs the memory + title LLM calls
+   * synchronously before writing. `'quick'` skips both calls, writes the
+   * archive under a synthetic `pending-<short-id>.md` filename with the
+   * heuristic title, and marks the index entry `pendingEnrichment: true`
+   * so a boot-time scanner can finish the enrichment in the background
+   * after the next reload.
+   */
+  mode?: 'full' | 'quick';
 }
 
 /**
@@ -110,7 +127,10 @@ export async function freezeConeSession(
   }
 
   const agentMessages = toAgentMessages(session.messages);
-  const llmEnabled = Boolean(opts.apiKey && opts.model);
+  const mode = opts.mode ?? 'full';
+  // Quick mode skips both LLM calls outright — same effect as `llmEnabled=false`
+  // but additionally marks the index entry as needing later enrichment.
+  const llmEnabled = mode === 'full' && Boolean(opts.apiKey && opts.model);
 
   // 1. Memory extraction (best-effort).
   if (llmEnabled) {
@@ -168,8 +188,15 @@ export async function freezeConeSession(
   // 3. Write the archive and update the index. Archive is markdown — same
   //    format the chat-panel uses for the "copy chat history" long-press,
   //    plus a small YAML-style header for the freezer's own metadata.
+  //
+  //    Quick mode uses a synthetic `pending-<short-id>.md` filename so a
+  //    later enrichment pass can rename to the canonical
+  //    `<timestamp>-<slug>.md` form once the LLM-derived title is known.
   const frozenAt = new Date().toISOString();
-  const filename = `${frozenAt.replace(/[:.]/g, '-')}-${slugify(title)}.md`;
+  const filename =
+    mode === 'quick'
+      ? `pending-${pendingShortId()}.md`
+      : `${frozenAt.replace(/[:.]/g, '-')}-${slugify(title)}.md`;
   const archive: FrozenSessionArchive = {
     id: session.id,
     title,
@@ -185,6 +212,7 @@ export async function freezeConeSession(
     title,
     frozenAt,
     messageCount: session.messages.length,
+    ...(mode === 'quick' ? { pendingEnrichment: true } : {}),
   };
   try {
     await ensureDir(opts.vfs, SESSIONS_DIR);
@@ -319,6 +347,17 @@ function slugify(text: string): string {
   return slug || 'session';
 }
 
+/**
+ * Short, unique-enough id used in quick-mode pending filenames. Pairs a
+ * base-36 timestamp with a few random characters so multiple pending
+ * freezes within the same millisecond still collide-free.
+ */
+function pendingShortId(): string {
+  const time = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `${time}-${rand}`;
+}
+
 async function ensureDir(vfs: VirtualFS, path: string): Promise<void> {
   try {
     await vfs.mkdir(path, { recursive: true });
@@ -381,6 +420,259 @@ export async function readSessionsIndex(vfs: VirtualFS): Promise<FrozenSessionIn
 /** Path to the archive markdown for a given index entry. */
 export function frozenSessionPath(entry: FrozenSessionIndexEntry): string {
   return `${SESSIONS_DIR}/${entry.filename}`;
+}
+
+/**
+ * Subset of the sessions index that still needs the LLM-driven enrichment
+ * pass (memory extraction + title rewrite). Returns `[]` when the index
+ * is missing, empty, or malformed — never throws.
+ */
+export async function listPendingEnrichments(vfs: VirtualFS): Promise<FrozenSessionIndexEntry[]> {
+  const all = await readSessionsIndex(vfs);
+  return all.filter((e) => e.pendingEnrichment === true);
+}
+
+export interface EnrichPendingSessionOptions {
+  /** Active LLM model — required for both LLM calls. */
+  model: Model<Api>;
+  /** API key for the active provider. */
+  apiKey: string;
+  /** Adobe X-Session-Id and friends — forwarded to both LLM calls. */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Finish a quick-frozen archive: re-run the two compaction calls over
+ * the archived messages, append extracted memories to /shared/CLAUDE.md,
+ * rewrite the archive's frontmatter + heading with the LLM title, then
+ * rename the file from `pending-…md` to the canonical
+ * `<timestamp>-<slug>.md` form. The matching index entry has its
+ * `pendingEnrichment` flag dropped and `title` + `filename` updated.
+ *
+ * Best-effort end to end: every step is wrapped in try/catch and a
+ * failure leaves the pending entry intact so the next boot retries.
+ * Idempotent: running twice on the same entry (e.g. after the rename
+ * already happened, or against a missing file) is a silent no-op.
+ *
+ * Returns the updated index entry on success, `null` on no-op / failure.
+ */
+export async function enrichPendingSession(
+  vfs: VirtualFS,
+  entry: FrozenSessionIndexEntry,
+  opts: EnrichPendingSessionOptions
+): Promise<FrozenSessionIndexEntry | null> {
+  // 1. Idempotency guard — entry no longer pending, nothing to do.
+  if (!entry.pendingEnrichment) {
+    return null;
+  }
+
+  // 2. Load the archive. Missing file → already renamed (or wiped) → no-op.
+  const oldPath = frozenSessionPath(entry);
+  let archiveContent = '';
+  try {
+    const raw = await vfs.readFile(oldPath, { encoding: 'utf-8' });
+    archiveContent = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+  } catch {
+    log.info('Pending archive missing — treating as already enriched', {
+      filename: entry.filename,
+    });
+    return null;
+  }
+
+  // 3. Recover the messages so we can re-run the LLM calls.
+  let messages: ChatMessage[];
+  try {
+    const parsed = parseFrozenArchive(archiveContent);
+    messages = parsed.messages;
+  } catch (err) {
+    log.warn('Failed to parse pending archive — leaving entry intact', {
+      filename: entry.filename,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+  if (messages.length === 0) {
+    log.info('Pending archive has no messages — skipping enrichment', {
+      filename: entry.filename,
+    });
+    return null;
+  }
+  const agentMessages = toAgentMessages(messages);
+
+  // 4. Run BOTH LLM calls before mutating anything. If either fails the
+  //    pending entry stays put for the next retry; if memory succeeded
+  //    but title failed we'd otherwise duplicate memory bullets on every
+  //    boot, which is worse than waiting one more retry.
+  let bullets = '';
+  try {
+    bullets = await runOneOffCompactionCall({
+      messages: agentMessages,
+      instruction: COMPACTION_MEMORY_INSTRUCTION,
+      model: opts.model,
+      apiKey: opts.apiKey,
+      maxTokens: MEMORY_MAX_TOKENS,
+      headers: opts.headers,
+    });
+  } catch (err) {
+    log.warn('Enrichment memory call failed (entry stays pending)', {
+      filename: entry.filename,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+  let newTitle = '';
+  try {
+    const raw = await runOneOffCompactionCall({
+      messages: agentMessages,
+      instruction: COMPACTION_TITLE_INSTRUCTION,
+      model: opts.model,
+      apiKey: opts.apiKey,
+      maxTokens: TITLE_MAX_TOKENS,
+      headers: opts.headers,
+    });
+    newTitle = cleanTitle(raw);
+  } catch (err) {
+    log.warn('Enrichment title call failed (entry stays pending)', {
+      filename: entry.filename,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+  if (!newTitle) {
+    log.info('Enrichment title call returned empty — entry stays pending', {
+      filename: entry.filename,
+    });
+    return null;
+  }
+
+  // 5. Append memory bullets (best-effort — failure doesn't abort the rename).
+  const trimmedBullets = bullets.trim();
+  if (trimmedBullets && trimmedBullets !== 'NONE') {
+    try {
+      await appendGlobalMemoryViaVfs(vfs, trimmedBullets, 'pending-enrichment');
+    } catch (err) {
+      log.warn('Enrichment memory append failed (continuing with title rewrite)', {
+        filename: entry.filename,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // 6. Rewrite the title in the archive's YAML frontmatter and the `# title`
+  //    body heading. Everything else — including the slicc:session-data
+  //    block — stays byte-identical, so the chat-panel re-render path is
+  //    unaffected.
+  const newContent = rewriteArchiveTitle(archiveContent, newTitle);
+  const newFilename = `${entry.frozenAt.replace(/[:.]/g, '-')}-${slugify(newTitle)}.md`;
+  const newPath = `${SESSIONS_DIR}/${newFilename}`;
+
+  // 7. Write under new name, update the index, then drop the old file last.
+  //    This ordering keeps the index consistent with what's on disk even if
+  //    the final unlink fails — at worst we leak a stale pending-… file,
+  //    no data loss.
+  try {
+    await ensureDir(vfs, SESSIONS_DIR);
+    await vfs.writeFile(newPath, newContent);
+  } catch (err) {
+    log.warn('Enrichment write failed (entry stays pending)', {
+      filename: entry.filename,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  const updatedEntry: FrozenSessionIndexEntry = {
+    filename: newFilename,
+    title: newTitle,
+    frozenAt: entry.frozenAt,
+    messageCount: entry.messageCount,
+  };
+  try {
+    await replaceIndexEntry(vfs, entry.filename, updatedEntry);
+  } catch (err) {
+    log.warn('Enrichment index update failed (entry may stay pending)', {
+      filename: entry.filename,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  // 8. Best-effort cleanup of the old pending file. Don't surface the
+  //    failure — the index already points at the new name.
+  if (newPath !== oldPath) {
+    try {
+      const fsMaybe = vfs as VirtualFS & {
+        rm?: (path: string, opts?: { recursive?: boolean }) => Promise<void>;
+      };
+      if (typeof fsMaybe.rm === 'function') {
+        await fsMaybe.rm(oldPath);
+      }
+    } catch (err) {
+      log.info('Stale pending archive cleanup failed (harmless)', {
+        oldPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  try {
+    await vfs.flush();
+  } catch {
+    // flush is best-effort — IDB will persist on its own debounce.
+  }
+
+  log.info('Pending session enriched', {
+    oldFilename: entry.filename,
+    newFilename,
+    title: newTitle,
+  });
+  return updatedEntry;
+}
+
+/**
+ * Replace the `title:` value in the frontmatter (and the leading `# title`
+ * heading in the body) of a freezer-shaped archive markdown string with
+ * the LLM-derived title. Falls back to a string concat if the frontmatter
+ * regex doesn't match — the worst case is a stale heading, never data loss.
+ */
+function rewriteArchiveTitle(content: string, newTitle: string): string {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!fmMatch) return content;
+  const fm = fmMatch[1].replace(/^title:\s*.+$/m, `title: ${JSON.stringify(newTitle)}`);
+  let body = fmMatch[2];
+  body = body.replace(/^#\s+[^\n]*$/m, `# ${newTitle}`);
+  return `---\n${fm}\n---\n${body}`;
+}
+
+/**
+ * Swap one entry in the sessions index by filename. Used by the
+ * enrichment pass to flip a `pending-…` entry over to its renamed
+ * canonical form. No-op when the entry isn't found.
+ */
+async function replaceIndexEntry(
+  vfs: VirtualFS,
+  oldFilename: string,
+  replacement: FrozenSessionIndexEntry
+): Promise<void> {
+  let existing: FrozenSessionIndexEntry[] = [];
+  try {
+    const raw = await vfs.readFile(SESSIONS_INDEX_PATH, { encoding: 'utf-8' });
+    const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) existing = parsed as FrozenSessionIndexEntry[];
+  } catch {
+    // No index — nothing to replace; write the entry as the only row so
+    // the rename is still visible to the panel on next reload.
+  }
+  const idx = existing.findIndex((e) => e.filename === oldFilename);
+  let updated: FrozenSessionIndexEntry[];
+  if (idx === -1) {
+    updated = [replacement, ...existing];
+  } else {
+    updated = existing.slice();
+    updated[idx] = replacement;
+  }
+  await vfs.writeFile(SESSIONS_INDEX_PATH, JSON.stringify(updated, null, 2));
 }
 
 /**

--- a/packages/webapp/src/ui/styles/header.css
+++ b/packages/webapp/src/ui/styles/header.css
@@ -198,8 +198,9 @@
   font-size: 11px;
   font-weight: 500;
   font-family: var(--s2-font-family);
-  white-space: nowrap;
-  text-align: center;
+  white-space: pre-line;
+  max-width: 280px;
+  text-align: left;
   border-radius: var(--s2-radius-s);
   pointer-events: none;
   opacity: 0;

--- a/packages/webapp/src/ui/styles/tabs.css
+++ b/packages/webapp/src/ui/styles/tabs.css
@@ -377,10 +377,35 @@
   position: relative;
   z-index: 1;
 }
+/* `<slicc-press-button>` — reusable click + long-press button. The
+   host carries the parent's sizing/state classes (e.g. `.rail__item`,
+   `.thread-header__panel-toggle`, `.msg__feedback-btn`); the inner
+   `<button>` provided by the custom element fills the host so the
+   ripple's bounding rect matches what the user sees. */
+slicc-press-button {
+  display: inline-flex;
+}
+.slicc-press-btn__btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  position: relative;
+}
 /* Long-press ripple — fills the button as the user holds. The layer
    is clipped to the button radius so the growing circle never
    escapes the button shape. */
-.rail__item-press-layer {
+.slicc-press-btn__press-layer {
   position: absolute;
   inset: 0;
   border-radius: inherit;
@@ -388,7 +413,12 @@
   pointer-events: none;
   z-index: 0;
 }
-.rail__item-press {
+/* Slotted icon content sits above the ripple in the stacking order. */
+.slicc-press-btn__btn > :not(.slicc-press-btn__press-layer) {
+  position: relative;
+  z-index: 1;
+}
+.slicc-press-btn__press {
   position: absolute;
   border-radius: 50%;
   background: var(--s2-accent);
@@ -399,7 +429,7 @@
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   will-change: width, height;
 }
-.rail__item--active .rail__item-press {
+.rail__item--active .slicc-press-btn__press {
   background: var(--s2-accent);
   opacity: 1;
 }

--- a/packages/webapp/tests/ui/layout-new-session.test.ts
+++ b/packages/webapp/tests/ui/layout-new-session.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the thread-header "New session" button wiring + boot-time
+ * background enrichment scheduler.
+ *
+ * The button now exposes three gestures, each routed through the
+ * `onClearChat` callback with a different `freeze` value:
+ *   - short click  → `{ freeze: true }`   full freeze (blocks reload)
+ *   - long press   → `{ freeze: false }`  discard (no archive)
+ *   - double click → `{ freeze: 'quick' }` quick freeze (background enrich)
+ *
+ * `scheduleBackgroundEnrichment` is fired once at boot to finish any
+ * pending entries left behind by the impatient (double-click) path.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DEFAULT_DOUBLE_CLICK_MS, type SliccPressButton } from '../../src/ui/press-button.js';
+import { LONG_PRESS_MS } from '../../src/ui/long-press.js';
+
+// Mirror the exact event wiring `layout.ts` installs on the new-session
+// `<slicc-press-button>`. Keeping the wiring inline in the test makes
+// it impossible for a future refactor of `layout.ts` to silently drop a
+// gesture without breaking these tests.
+function wireNewSessionButton(
+  btn: SliccPressButton,
+  onClearChat: (opts?: { freeze?: boolean | 'quick' }) => Promise<void>,
+  reload: () => void
+): void {
+  const runNewSession = async (opts?: { freeze?: boolean | 'quick' }) => {
+    await onClearChat(opts);
+    reload();
+  };
+  btn.addEventListener('short-click', () => void runNewSession({ freeze: true }));
+  btn.addEventListener('long-press', () => void runNewSession({ freeze: false }));
+  btn.addEventListener('double-click', () => void runNewSession({ freeze: 'quick' }));
+}
+
+function mkButton(): SliccPressButton {
+  const el = document.createElement('slicc-press-button') as SliccPressButton;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('New session button — three-gesture wiring', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useRealTimers();
+  });
+
+  it('short click routes through onClearChat with freeze: true', async () => {
+    vi.useFakeTimers();
+    const onClearChat = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn();
+    const btn = mkButton();
+    wireNewSessionButton(btn, onClearChat, reload);
+
+    btn.click();
+    vi.advanceTimersByTime(DEFAULT_DOUBLE_CLICK_MS + 1);
+    vi.useRealTimers();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onClearChat).toHaveBeenCalledTimes(1);
+    expect(onClearChat).toHaveBeenCalledWith({ freeze: true });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('long press routes through onClearChat with freeze: false', async () => {
+    vi.useFakeTimers();
+    const onClearChat = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn();
+    const btn = mkButton();
+    wireNewSessionButton(btn, onClearChat, reload);
+
+    btn.dispatchEvent(new MouseEvent('mousedown', { button: 0 }));
+    vi.advanceTimersByTime(LONG_PRESS_MS + 1);
+    btn.dispatchEvent(new MouseEvent('mouseup', { button: 0 }));
+    btn.dispatchEvent(new MouseEvent('click'));
+    vi.advanceTimersByTime(DEFAULT_DOUBLE_CLICK_MS + 1);
+    vi.useRealTimers();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onClearChat).toHaveBeenCalledTimes(1);
+    expect(onClearChat).toHaveBeenCalledWith({ freeze: false });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('double click routes through onClearChat with freeze: "quick" and suppresses short-click', async () => {
+    vi.useFakeTimers();
+    const onClearChat = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn();
+    const btn = mkButton();
+    wireNewSessionButton(btn, onClearChat, reload);
+
+    btn.click();
+    vi.advanceTimersByTime(50);
+    btn.click();
+    vi.advanceTimersByTime(DEFAULT_DOUBLE_CLICK_MS + 1);
+    vi.useRealTimers();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onClearChat).toHaveBeenCalledTimes(1);
+    expect(onClearChat).toHaveBeenCalledWith({ freeze: 'quick' });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('a single click that waits past the double-click window does NOT fire double-click', async () => {
+    vi.useFakeTimers();
+    const onClearChat = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn();
+    const btn = mkButton();
+    wireNewSessionButton(btn, onClearChat, reload);
+
+    btn.click();
+    // Wait well past the double-click window, then click again — this
+    // is a second short click, NOT a double-click.
+    vi.advanceTimersByTime(DEFAULT_DOUBLE_CLICK_MS + 1);
+    btn.click();
+    vi.advanceTimersByTime(DEFAULT_DOUBLE_CLICK_MS + 1);
+    vi.useRealTimers();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onClearChat).toHaveBeenCalledTimes(2);
+    expect(onClearChat.mock.calls.every(([opts]) => opts.freeze === true)).toBe(true);
+  });
+});
+
+describe('scheduleBackgroundEnrichment — boot-time enrichment scheduler', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as { requestIdleCallback?: unknown }).requestIdleCallback;
+  });
+
+  it('defers via setTimeout when requestIdleCallback is unavailable', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const { scheduleBackgroundEnrichment } = await import('../../src/ui/new-session.js');
+    const fakeFs = { exists: vi.fn().mockResolvedValue(false) } as unknown as Parameters<
+      typeof scheduleBackgroundEnrichment
+    >[0];
+
+    scheduleBackgroundEnrichment(fakeFs);
+
+    // The setTimeout call from `scheduleBackgroundEnrichment` runs the
+    // enrichment lazily. We only assert that the schedule was registered.
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+    setTimeoutSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('prefers requestIdleCallback when available', async () => {
+    const ricSpy = vi.fn();
+    (globalThis as { requestIdleCallback?: unknown }).requestIdleCallback = ricSpy;
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const { scheduleBackgroundEnrichment } = await import('../../src/ui/new-session.js');
+    const fakeFs = { exists: vi.fn().mockResolvedValue(false) } as unknown as Parameters<
+      typeof scheduleBackgroundEnrichment
+    >[0];
+
+    scheduleBackgroundEnrichment(fakeFs);
+
+    expect(ricSpy).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('eventually invokes enrichPendingSessions with the supplied VFS', async () => {
+    // Drive the scheduled work synchronously by stubbing rIC to run the
+    // callback immediately. `enrichPendingSessions` is best-effort and
+    // bails out cleanly when the index file is missing — we observe the
+    // invocation by spying on the listPendingEnrichments read it makes.
+    const ricSpy = vi.fn((cb: () => void) => {
+      cb();
+      return 1;
+    });
+    (globalThis as { requestIdleCallback?: unknown }).requestIdleCallback = ricSpy;
+
+    const readFile = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    const fakeFs = {
+      readFile,
+      exists: vi.fn().mockResolvedValue(false),
+    } as unknown as Parameters<
+      typeof import('../../src/ui/new-session.js').scheduleBackgroundEnrichment
+    >[0];
+
+    const { scheduleBackgroundEnrichment } = await import('../../src/ui/new-session.js');
+    scheduleBackgroundEnrichment(fakeFs);
+
+    // Let the floated promise chain settle. A single yield through the
+    // real event loop is enough to flush every await in the
+    // `enrichPendingSessions → listPendingEnrichments → readSessionsIndex`
+    // chain.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(ricSpy).toHaveBeenCalledTimes(1);
+    // `enrichPendingSessions` ultimately calls `listPendingEnrichments`,
+    // which reads `/sessions/index.json` from the VFS we handed it. Any
+    // VFS read counts as evidence that the scheduled work ran.
+    expect(readFile).toHaveBeenCalled();
+  });
+});

--- a/packages/webapp/tests/ui/press-button.test.ts
+++ b/packages/webapp/tests/ui/press-button.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the `<slicc-press-button>` custom element — the reusable
+ * click + long-press + double-click button used by the side rail, the
+ * thread-header new-session button, and the chat copy button.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SliccPressButton, DEFAULT_DOUBLE_CLICK_MS } from '../../src/ui/press-button.js';
+import { LONG_PRESS_MS } from '../../src/ui/long-press.js';
+
+function mkBtn(opts: { disableDouble?: boolean; label?: string } = {}): SliccPressButton {
+  const el = document.createElement('slicc-press-button') as SliccPressButton;
+  if (opts.disableDouble) el.setAttribute('disable-double-click', '');
+  if (opts.label) el.setAttribute('label', opts.label);
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('<slicc-press-button>', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useRealTimers();
+  });
+
+  it('is registered as a custom element on module import', () => {
+    expect(customElements.get('slicc-press-button')).toBe(SliccPressButton);
+  });
+
+  it('initializes a press-layer-wrapped inner button on connect', () => {
+    const el = mkBtn();
+    const inner = el.querySelector('.slicc-press-btn__btn') as HTMLButtonElement;
+    expect(inner).not.toBeNull();
+    expect(inner.tagName).toBe('BUTTON');
+    expect(inner.type).toBe('button');
+    expect(el.querySelector('.slicc-press-btn__press-layer')).not.toBeNull();
+  });
+
+  it('mirrors label / tooltip / tooltip-pos to the inner button', () => {
+    const el = mkBtn({ label: 'Copy' });
+    el.setAttribute('tooltip', 'Copy last response');
+    el.setAttribute('tooltip-pos', 'left');
+    const inner = el.querySelector<HTMLButtonElement>('.slicc-press-btn__btn')!;
+    expect(inner.getAttribute('aria-label')).toBe('Copy');
+    expect(inner.dataset.tooltip).toBe('Copy last response');
+    expect(inner.dataset.tooltipPos).toBe('left');
+  });
+
+  it('moves pre-existing host children into the inner button', () => {
+    const el = document.createElement('slicc-press-button') as SliccPressButton;
+    el.innerHTML = '<svg data-id="icon"></svg>';
+    document.body.appendChild(el);
+    const inner = el.querySelector<HTMLButtonElement>('.slicc-press-btn__btn')!;
+    expect(inner.querySelector('[data-id="icon"]')).not.toBeNull();
+  });
+
+  it('setIcon swaps content while preserving the press-layer', () => {
+    const el = mkBtn();
+    el.setIcon('<svg data-id="new"></svg>');
+    const inner = el.querySelector<HTMLButtonElement>('.slicc-press-btn__btn')!;
+    expect(inner.querySelector('[data-id="new"]')).not.toBeNull();
+    expect(el.querySelector('.slicc-press-btn__press-layer')).not.toBeNull();
+  });
+
+  it('fires short-click immediately when disable-double-click is set', () => {
+    const el = mkBtn({ disableDouble: true });
+    const sc = vi.fn();
+    el.addEventListener('short-click', sc);
+    el.click();
+    expect(sc).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers short-click by the double-click window and fires once', () => {
+    vi.useFakeTimers();
+    const el = mkBtn();
+    const sc = vi.fn();
+    el.addEventListener('short-click', sc);
+    el.click();
+    expect(sc).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(DEFAULT_DOUBLE_CLICK_MS + 1);
+    expect(sc).toHaveBeenCalledTimes(1);
+  });
+
+  it('second click inside the window emits double-click and suppresses short-click', () => {
+    vi.useFakeTimers();
+    const el = mkBtn();
+    const sc = vi.fn();
+    const dc = vi.fn();
+    el.addEventListener('short-click', sc);
+    el.addEventListener('double-click', dc);
+    el.click();
+    vi.advanceTimersByTime(50);
+    el.click();
+    vi.advanceTimersByTime(DEFAULT_DOUBLE_CLICK_MS + 1);
+    expect(dc).toHaveBeenCalledTimes(1);
+    expect(sc).not.toHaveBeenCalled();
+  });
+
+  it('long-press past threshold fires long-press and skips the trailing click', () => {
+    vi.useFakeTimers();
+    const el = mkBtn();
+    const lp = vi.fn();
+    const sc = vi.fn();
+    el.addEventListener('long-press', lp);
+    el.addEventListener('short-click', sc);
+    el.dispatchEvent(new MouseEvent('mousedown', { button: 0 }));
+    vi.advanceTimersByTime(LONG_PRESS_MS + 1);
+    el.dispatchEvent(new MouseEvent('mouseup', { button: 0 }));
+    el.dispatchEvent(new MouseEvent('click'));
+    vi.advanceTimersByTime(DEFAULT_DOUBLE_CLICK_MS + 1);
+    expect(lp).toHaveBeenCalledTimes(1);
+    expect(sc).not.toHaveBeenCalled();
+  });
+
+  it('modifier-click during a pending double-click window is the second click, not long-press', () => {
+    vi.useFakeTimers();
+    const el = mkBtn();
+    const dc = vi.fn();
+    const lp = vi.fn();
+    el.addEventListener('double-click', dc);
+    el.addEventListener('long-press', lp);
+    el.click();
+    el.dispatchEvent(new MouseEvent('click', { metaKey: true }));
+    expect(dc).toHaveBeenCalledTimes(1);
+    expect(lp).not.toHaveBeenCalled();
+  });
+
+  it('modifier-click outside a pending window fires long-press', () => {
+    const el = mkBtn({ disableDouble: true });
+    const lp = vi.fn();
+    el.addEventListener('long-press', lp);
+    el.dispatchEvent(new MouseEvent('click', { metaKey: true }));
+    expect(lp).toHaveBeenCalledTimes(1);
+  });
+
+  it('paints a ripple inside the press layer with the long-press transition duration', () => {
+    vi.useFakeTimers();
+    const el = mkBtn();
+    el.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 4, clientY: 4 }));
+    const ripple = el.querySelector<HTMLElement>('.slicc-press-btn__press');
+    expect(ripple).not.toBeNull();
+    expect(ripple!.style.transitionDuration).toBe(`${LONG_PRESS_MS}ms`);
+    el.dispatchEvent(new MouseEvent('mouseup', { button: 0 }));
+    expect(el.querySelector('.slicc-press-btn__press')).toBeNull();
+  });
+});

--- a/packages/webapp/tests/ui/press-button.test.ts
+++ b/packages/webapp/tests/ui/press-button.test.ts
@@ -133,6 +133,28 @@ describe('<slicc-press-button>', () => {
     expect(lp).toHaveBeenCalledTimes(1);
   });
 
+  it('re-attaches gesture handling after disconnect → reconnect', () => {
+    // disconnectedCallback destroys the gesture handle but leaves the
+    // element marked initialized. Without the re-attach guard in
+    // connectedCallback, a host removed and re-inserted into the DOM
+    // would lose all click handling — regression for PR #718.
+    const el = mkBtn({ disableDouble: true });
+    const sc = vi.fn();
+    el.addEventListener('short-click', sc);
+
+    // Sanity-check the gesture is wired before we detach.
+    el.click();
+    expect(sc).toHaveBeenCalledTimes(1);
+
+    // Detach + re-attach to the DOM.
+    el.remove();
+    document.body.appendChild(el);
+
+    // Click after re-attach must still fire short-click.
+    el.click();
+    expect(sc).toHaveBeenCalledTimes(2);
+  });
+
   it('paints a ripple inside the press layer with the long-press transition duration', () => {
     vi.useFakeTimers();
     const el = mkBtn();

--- a/packages/webapp/tests/ui/rail-zone.test.ts
+++ b/packages/webapp/tests/ui/rail-zone.test.ts
@@ -173,16 +173,16 @@ describe('RailZone', () => {
     rail.addItem(makeItem('terminal', 'bottom'));
     const btn = railEl.querySelector<HTMLButtonElement>('[data-item-id="terminal"]')!;
 
-    expect(btn.querySelector('.rail__item-press-layer')).not.toBeNull();
+    expect(btn.querySelector('.slicc-press-btn__press-layer')).not.toBeNull();
     btn.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 5 }));
 
-    const ripple = btn.querySelector<HTMLElement>('.rail__item-press');
+    const ripple = btn.querySelector<HTMLElement>('.slicc-press-btn__press');
     expect(ripple).not.toBeNull();
     expect(ripple!.style.transitionDuration).toBe(`${rail.__test__.longPressMs}ms`);
 
     // Releasing before threshold removes the ripple.
     btn.dispatchEvent(new MouseEvent('mouseup', { button: 0 }));
-    expect(btn.querySelector('.rail__item-press')).toBeNull();
+    expect(btn.querySelector('.slicc-press-btn__press')).toBeNull();
   });
 
   it('removing an item that was active collapses the panel', () => {

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -20,7 +20,9 @@ vi.mock('../../src/ui/chat-panel.js', () => ({
 }));
 
 import {
+  enrichPendingSession,
   freezeConeSession,
+  listPendingEnrichments,
   parseFrozenArchive,
   readSessionsIndex,
 } from '../../src/ui/session-freezer.js';
@@ -51,6 +53,14 @@ function makeFakeVfs() {
     },
     async flush(): Promise<void> {
       // no-op
+    },
+    async rm(path: string, _opts?: unknown): Promise<void> {
+      if (!files.has(path)) {
+        const err = new Error(`ENOENT: ${path}`);
+        (err as unknown as { code: string }).code = 'ENOENT';
+        throw err;
+      }
+      files.delete(path);
     },
   };
 }
@@ -445,5 +455,258 @@ describe('parseFrozenArchive', () => {
     expect(messages).toHaveLength(2);
     expect(messages[0].content).toBe('hi');
     expect(messages[1].content).toBe('hello');
+  });
+});
+
+describe('freezeConeSession quick mode', () => {
+  beforeEach(() => {
+    mockRunOneOffCompactionCall.mockReset();
+  });
+
+  it('writes a pending-named archive and pendingEnrichment index entry without LLM calls', async () => {
+    const store = makeFakeStore({
+      id: 'session-cone',
+      messages: [
+        userMessage('refactor the auth flow'),
+        assistantMessage('a'),
+        userMessage('b'),
+        assistantMessage('c'),
+      ],
+      createdAt: 100,
+      updatedAt: 200,
+    });
+    const vfs = makeFakeVfs();
+
+    const result = await freezeConeSession({
+      sessionStore: store,
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+      mode: 'quick',
+    });
+
+    expect(result).not.toBeNull();
+    expect(mockRunOneOffCompactionCall).not.toHaveBeenCalled();
+    expect(result!.pendingEnrichment).toBe(true);
+    // Synthetic filename — `pending-<short-id>.md` shape.
+    expect(result!.filename).toMatch(/^pending-[a-z0-9-]+\.md$/);
+    // Heuristic title only — first user message, lightly truncated.
+    expect(result!.title).toContain('refactor the auth flow');
+
+    // Archive landed under /sessions/.
+    expect(vfs.files.has(`/sessions/${result!.filename}`)).toBe(true);
+    // No memory append in quick mode.
+    expect(vfs.files.get('/shared/CLAUDE.md')).toBeUndefined();
+
+    // Index entry carries the pendingEnrichment flag for the boot scanner.
+    const index = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    expect(index).toHaveLength(1);
+    expect(index[0].pendingEnrichment).toBe(true);
+    expect(index[0].filename).toBe(result!.filename);
+  });
+});
+
+describe('listPendingEnrichments', () => {
+  it('returns [] when the index is missing', async () => {
+    const vfs = makeFakeVfs();
+    const out = await listPendingEnrichments(
+      vfs as unknown as Parameters<typeof listPendingEnrichments>[0]
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('returns [] when the index is malformed', async () => {
+    const vfs = makeFakeVfs();
+    vfs.files.set('/sessions/index.json', '{not json');
+    const out = await listPendingEnrichments(
+      vfs as unknown as Parameters<typeof listPendingEnrichments>[0]
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('returns only the pendingEnrichment=true subset of the index', async () => {
+    const vfs = makeFakeVfs();
+    vfs.files.set(
+      '/sessions/index.json',
+      JSON.stringify([
+        {
+          filename: 'pending-abc.md',
+          title: 'rough',
+          frozenAt: '2026-05-13T19:00:00.000Z',
+          messageCount: 4,
+          pendingEnrichment: true,
+        },
+        {
+          filename: '2026-05-12T10-00-00-000Z-done.md',
+          title: 'done',
+          frozenAt: '2026-05-12T10:00:00.000Z',
+          messageCount: 6,
+        },
+      ])
+    );
+    const out = await listPendingEnrichments(
+      vfs as unknown as Parameters<typeof listPendingEnrichments>[0]
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].filename).toBe('pending-abc.md');
+    expect(out[0].pendingEnrichment).toBe(true);
+  });
+});
+
+describe('enrichPendingSession', () => {
+  beforeEach(() => {
+    mockRunOneOffCompactionCall.mockReset();
+  });
+
+  /** Build a fully-populated fake VFS with one quick-frozen pending entry. */
+  async function seedPending(vfs: ReturnType<typeof makeFakeVfs>): Promise<{
+    pendingFilename: string;
+    frozenAt: string;
+  }> {
+    const store = makeFakeStore({
+      id: 'session-cone',
+      messages: [
+        userMessage('debug the build pipeline'),
+        assistantMessage('looking'),
+        userMessage('thanks'),
+        assistantMessage('np'),
+      ],
+      createdAt: 100,
+      updatedAt: 200,
+    });
+    const result = await freezeConeSession({
+      sessionStore: store,
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+      mode: 'quick',
+    });
+    return { pendingFilename: result!.filename, frozenAt: result!.frozenAt };
+  }
+
+  it('rewrites the title, renames the file, drops the pending flag, and appends memory', async () => {
+    const vfs = makeFakeVfs();
+    const { pendingFilename, frozenAt } = await seedPending(vfs);
+
+    // Memory first, then title — same order the freezer uses.
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('- prefers vitest\n- uses esm only')
+      .mockResolvedValueOnce('Build pipeline debug');
+
+    const updated = await enrichPendingSession(
+      vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: pendingFilename,
+        title: 'debug the build pipeline',
+        frozenAt,
+        messageCount: 4,
+        pendingEnrichment: true,
+      },
+      { model: fakeModel!, apiKey: 'k' }
+    );
+
+    expect(updated).not.toBeNull();
+    expect(updated!.pendingEnrichment).toBeUndefined();
+    expect(updated!.title).toBe('Build pipeline debug');
+    expect(updated!.filename).toMatch(/build-pipeline-debug\.md$/);
+
+    // Old pending file is gone, new file is present with the LLM title.
+    expect(vfs.files.has(`/sessions/${pendingFilename}`)).toBe(false);
+    const newContent = vfs.files.get(`/sessions/${updated!.filename}`);
+    expect(newContent).toBeDefined();
+    expect(newContent).toContain('title: "Build pipeline debug"');
+    expect(newContent).toContain('# Build pipeline debug');
+
+    // Memory landed under /shared/CLAUDE.md with the pending-enrichment source tag.
+    const memory = vfs.files.get('/shared/CLAUDE.md');
+    expect(memory).toBeTruthy();
+    expect(memory).toMatch(/Auto-extracted.*pending-enrichment/);
+    expect(memory).toContain('prefers vitest');
+
+    // Index now points to the renamed file and drops the pending flag.
+    const index = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    expect(index).toHaveLength(1);
+    expect(index[0].filename).toBe(updated!.filename);
+    expect(index[0].pendingEnrichment).toBeUndefined();
+    expect(index[0].title).toBe('Build pipeline debug');
+  });
+
+  it('is a no-op when the archive file is missing (already renamed)', async () => {
+    const vfs = makeFakeVfs();
+    const result = await enrichPendingSession(
+      vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: 'pending-gone.md',
+        title: 'phantom',
+        frozenAt: '2026-05-13T19:00:00.000Z',
+        messageCount: 4,
+        pendingEnrichment: true,
+      },
+      { model: fakeModel!, apiKey: 'k' }
+    );
+    expect(result).toBeNull();
+    expect(mockRunOneOffCompactionCall).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the entry is not flagged pendingEnrichment', async () => {
+    const vfs = makeFakeVfs();
+    // Even if the file exists, an entry without the flag must not be enriched.
+    vfs.files.set('/sessions/foo.md', '---\ntitle: "foo"\n---\n\n# foo\n');
+    const result = await enrichPendingSession(
+      vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: 'foo.md',
+        title: 'foo',
+        frozenAt: '2026-05-13T19:00:00.000Z',
+        messageCount: 4,
+      },
+      { model: fakeModel!, apiKey: 'k' }
+    );
+    expect(result).toBeNull();
+    expect(mockRunOneOffCompactionCall).not.toHaveBeenCalled();
+    // File untouched.
+    expect(vfs.files.get('/sessions/foo.md')).toContain('# foo');
+  });
+
+  it('leaves the pending entry intact when the title LLM call fails', async () => {
+    const vfs = makeFakeVfs();
+    const { pendingFilename, frozenAt } = await seedPending(vfs);
+
+    // Memory succeeds, title throws — pending entry must stay put and the
+    // archive file must not be renamed or rewritten so the next boot can
+    // retry from a clean slate.
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('- bullet')
+      .mockRejectedValueOnce(new Error('rate limited'));
+
+    const result = await enrichPendingSession(
+      vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: pendingFilename,
+        title: 'heuristic title',
+        frozenAt,
+        messageCount: 4,
+        pendingEnrichment: true,
+      },
+      { model: fakeModel!, apiKey: 'k' }
+    );
+
+    expect(result).toBeNull();
+    // Pending file still on disk; no renamed file in its place.
+    expect(vfs.files.has(`/sessions/${pendingFilename}`)).toBe(true);
+    // No memory was appended either — we abort BEFORE the memory append
+    // so retries don't accumulate duplicate bullets.
+    expect(vfs.files.get('/shared/CLAUDE.md')).toBeUndefined();
+    // Index unchanged — entry is still pending so the next boot retries.
+    const index = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    expect(index).toHaveLength(1);
+    expect(index[0].pendingEnrichment).toBe(true);
+    expect(index[0].filename).toBe(pendingFilename);
   });
 });

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -709,4 +709,211 @@ describe('enrichPendingSession', () => {
     expect(index[0].pendingEnrichment).toBe(true);
     expect(index[0].filename).toBe(pendingFilename);
   });
+
+  it('warns (not infos) and stays pending when archive read fails with a non-ENOENT error', async () => {
+    // ENOENT means "already renamed" → info. Any other error is a real
+    // failure (permission, IO, etc.) and must surface as warn so it
+    // doesn't get hidden behind the misleading "already enriched" line.
+    const vfs = makeFakeVfs();
+    const { pendingFilename, frozenAt } = await seedPending(vfs);
+
+    const archivePath = `/sessions/${pendingFilename}`;
+    const originalRead = vfs.readFile.bind(vfs);
+    vfs.readFile = async (path: string) => {
+      if (path === archivePath) {
+        const err = new Error('EACCES: permission denied') as Error & { code: string };
+        err.code = 'EACCES';
+        throw err;
+      }
+      return originalRead(path);
+    };
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const result = await enrichPendingSession(
+      vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: pendingFilename,
+        title: 'heuristic',
+        frozenAt,
+        messageCount: 4,
+        pendingEnrichment: true,
+      },
+      { model: fakeModel!, apiKey: 'k' }
+    );
+
+    expect(result).toBeNull();
+    // The warn must mention the actual failure, not "already enriched".
+    // The logger forwards the data object as a trailing arg, so serialize
+    // each arg explicitly rather than relying on default toString.
+    const stringifyArgs = (args: unknown[]): string =>
+      args
+        .map((a) => {
+          if (typeof a === 'string') return a;
+          try {
+            return JSON.stringify(a);
+          } catch {
+            return String(a);
+          }
+        })
+        .join(' ');
+    const warnCalls = warnSpy.mock.calls.map((c) => stringifyArgs(c));
+    expect(warnCalls.some((s) => s.includes('Failed to read pending archive'))).toBe(true);
+    expect(warnCalls.some((s) => s.includes('EACCES'))).toBe(true);
+    const infoCalls = infoSpy.mock.calls.map((c) => stringifyArgs(c));
+    expect(infoCalls.some((s) => s.includes('already enriched'))).toBe(false);
+
+    warnSpy.mockRestore();
+    infoSpy.mockRestore();
+    expect(mockRunOneOffCompactionCall).not.toHaveBeenCalled();
+  });
+
+  it('does not duplicate the canonical row when it already exists in the index', async () => {
+    // Regression for PR #718 review: when `oldFilename` is missing from
+    // the index but a row with the same `replacement.filename` is
+    // already there, the old code prepended a second copy. The fix
+    // dedupes by filename before prepending.
+    const vfs = makeFakeVfs();
+    const { pendingFilename, frozenAt } = await seedPending(vfs);
+
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('NONE')
+      .mockResolvedValueOnce('Canonical title');
+
+    const canonicalFilename = `${frozenAt.replace(/[:.]/g, '-')}-canonical-title.md`;
+
+    // Replace the index with one whose `pendingFilename` row is missing
+    // (so `findIndex` returns -1 inside `replaceIndexEntry`) but the
+    // canonical row already exists. Pre-seed an extra unrelated row so
+    // we can verify only the canonical duplicate is collapsed.
+    vfs.files.set(
+      '/sessions/index.json',
+      JSON.stringify([
+        {
+          filename: canonicalFilename,
+          title: 'Stale canonical',
+          frozenAt,
+          messageCount: 4,
+        },
+        {
+          filename: 'unrelated.md',
+          title: 'Unrelated',
+          frozenAt: '2020-01-01T00:00:00.000Z',
+          messageCount: 2,
+        },
+      ])
+    );
+
+    const updated = await enrichPendingSession(
+      vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: pendingFilename,
+        title: 'heuristic',
+        frozenAt,
+        messageCount: 4,
+        pendingEnrichment: true,
+      },
+      { model: fakeModel!, apiKey: 'k' }
+    );
+
+    expect(updated).not.toBeNull();
+    expect(updated!.filename).toBe(canonicalFilename);
+
+    const index = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    // Exactly one canonical row + the unrelated row — no duplicate.
+    const canonicalRows = index.filter((e) => e.filename === canonicalFilename);
+    expect(canonicalRows).toHaveLength(1);
+    expect(canonicalRows[0].title).toBe('Canonical title');
+    expect(index.some((e) => e.filename === 'unrelated.md')).toBe(true);
+  });
+
+  it('serializes concurrent enrichments so both replacements land in the index', async () => {
+    // Without the in-module promise-chain mutex, two parallel
+    // read-modify-write updates to /sessions/index.json would race and
+    // one of the new entries would be lost.
+    const vfs = makeFakeVfs();
+
+    // Seed two distinct pending entries with different frozenAt times
+    // so the renamed filenames don't collide.
+    const seedOne = async (utcSecond: number): Promise<{ filename: string; frozenAt: string }> => {
+      const fixedNow = Date.UTC(2026, 4, 13, 19, 0, utcSecond);
+      const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(fixedNow);
+      try {
+        const store = makeFakeStore({
+          id: `session-${utcSecond}`,
+          messages: [
+            userMessage(`q ${utcSecond}`),
+            assistantMessage(`a ${utcSecond}`),
+            userMessage(`r ${utcSecond}`),
+            assistantMessage(`b ${utcSecond}`),
+          ],
+          createdAt: 0,
+          updatedAt: 1,
+        });
+        const r = await freezeConeSession({
+          sessionStore: store,
+          vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+          model: fakeModel,
+          apiKey: 'k',
+          mode: 'quick',
+        });
+        return { filename: r!.filename, frozenAt: r!.frozenAt };
+      } finally {
+        dateSpy.mockRestore();
+      }
+    };
+
+    const a = await seedOne(10);
+    const b = await seedOne(20);
+
+    // Both enrichments produce the same title (slug `t`) but different
+    // canonical filenames thanks to distinct frozenAt prefixes.
+    mockRunOneOffCompactionCall.mockImplementation(
+      async (opts: { instruction: string }): Promise<string> => {
+        if (opts.instruction === 'MEMORY') return 'NONE';
+        if (opts.instruction === 'TITLE') return 'T';
+        return '';
+      }
+    );
+
+    const [resA, resB] = await Promise.all([
+      enrichPendingSession(
+        vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+        {
+          filename: a.filename,
+          title: 'h',
+          frozenAt: a.frozenAt,
+          messageCount: 4,
+          pendingEnrichment: true,
+        },
+        { model: fakeModel!, apiKey: 'k' }
+      ),
+      enrichPendingSession(
+        vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+        {
+          filename: b.filename,
+          title: 'h',
+          frozenAt: b.frozenAt,
+          messageCount: 4,
+          pendingEnrichment: true,
+        },
+        { model: fakeModel!, apiKey: 'k' }
+      ),
+    ]);
+
+    expect(resA).not.toBeNull();
+    expect(resB).not.toBeNull();
+
+    const index = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    const filenames = index.map((e) => e.filename);
+    // Both renamed entries must be present — neither was clobbered by the
+    // other's read-modify-write.
+    expect(filenames).toContain(resA!.filename);
+    expect(filenames).toContain(resB!.filename);
+  });
 });

--- a/packages/webapp/tests/ui/tooltip.test.ts
+++ b/packages/webapp/tests/ui/tooltip.test.ts
@@ -1,5 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { initTooltips } from '../../src/ui/tooltip.js';
 
 // The tooltip is laid out as `font-size: 11px` text with `4px 8px` padding;
@@ -127,5 +130,58 @@ describe('tooltip placement', () => {
 
     // No room on the left (8 − 6 − 64 < 0), so it flips to the trigger's right edge + gap.
     expect(left).toBe(46);
+  });
+});
+
+describe('tooltip multi-line behavior', () => {
+  // Inject `.s2-tooltip` rules so jsdom's CSSOM resolves `white-space`,
+  // `max-width`, and `text-align` via `getComputedStyle`. jsdom doesn't
+  // load external stylesheets, so we read the actual CSS file from disk
+  // — this guarantees the test is checking the CSS the app actually
+  // ships, not a hand-typed mirror that could drift.
+  beforeAll(() => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const cssPath = resolve(__dirname, '../../src/ui/styles/header.css');
+    const css = readFileSync(cssPath, 'utf-8');
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.appendChild(style);
+  });
+
+  it('declares pre-line, max-width: 280px, and left alignment for .s2-tooltip', () => {
+    const tip = document.createElement('div');
+    tip.className = 's2-tooltip';
+    document.body.appendChild(tip);
+    const cs = getComputedStyle(tip);
+    expect(cs.whiteSpace).toBe('pre-line');
+    expect(cs.maxWidth).toBe('280px');
+    expect(cs.textAlign).toBe('left');
+    tip.remove();
+  });
+
+  it('preserves embedded newlines in the tooltip textContent on hover', () => {
+    const btn = document.createElement('button');
+    btn.dataset.tooltip = 'Line one\nLine two\nLine three';
+    document.body.appendChild(btn);
+    (btn as unknown as { __rect: DOMRect }).__rect = makeRect({
+      left: 100,
+      right: 132,
+      top: 100,
+      bottom: 132,
+      width: 32,
+      height: 32,
+    });
+
+    vi.useFakeTimers();
+    btn.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }));
+    vi.advanceTimersByTime(500);
+    const tip = document.querySelector('.s2-tooltip') as HTMLElement;
+
+    expect(tip.textContent).toBe('Line one\nLine two\nLine three');
+    expect(tip.textContent?.split('\n').length).toBe(3);
+    // `white-space: pre-line` honors the literal \n characters, so the
+    // CSS rule + the preserved textContent together guarantee 3 visual
+    // lines without jsdom needing to compute layout.
+    expect(getComputedStyle(tip).whiteSpace).toBe('pre-line');
   });
 });


### PR DESCRIPTION
## Summary

Adds a third "impatient" gesture to the new-session button that reloads immediately and defers memory extraction + title generation to a background task on the next boot. Also factors the click / long-press / double-click + flood-fill ripple into a reusable SLICC-PRESS-BUTTON custom element used across the rail, new-session, and chat copy buttons.

## New-session button gestures

| Gesture | Behavior |
|---|---|
| Single click | Full freeze (LLM blocks reload, unchanged) |
| Long press | Discard current session |
| **Double click (new)** | Quick freeze + reload immediately. Memory extraction and title generation run in the background after the next session boots. |

Trade-off: the new session starts memory-less for a few seconds while enrichment finishes. Idempotent and resumable across reloads — pending entries are written as pending-ID.md with pendingEnrichment: true in /sessions/index.json, and the boot-time scheduleBackgroundEnrichment scanner (deferred via requestIdleCallback with setTimeout fallback) picks them up.

## Architecture

- packages/webapp/src/ui/press-button.ts — new <slicc-press-button> custom element. Encapsulates short-click / long-press / double-click events + the flood-fill ripple visual. Attributes: label, tooltip, tooltip-pos, long-press-ms, double-click-ms, disable-double-click. Internally uses the existing attachLongPressGesture helper.
- packages/webapp/src/ui/session-freezer.ts — added mode: quick branch to freezeConeSession that skips both LLM calls, plus listPendingEnrichments and enrichPendingSession (idempotent rename + title rewrite + memory append).
- packages/webapp/src/ui/new-session.ts — added runNewSessionFreezeQuick and the scheduleBackgroundEnrichment boot-time orchestrator.
- packages/webapp/src/ui/layout.ts — wired the double-click gesture; updated tooltip + aria-label.
- packages/webapp/src/ui/main.ts — fires the enrichment scanner once per boot in both standalone and extension paths.
- Rail items and the chat copy button migrated to <slicc-press-button> (with disable-double-click to preserve current behavior).

## Verification

- npm run typecheck PASS
- npm run test -w @slicc/webapp PASS (4166/4166)
- npm run test:coverage:webapp PASS (above floors)
- npm run build PASS
- npm run build -w @slicc/chrome-extension PASS
- npx prettier --check PASS

New tests: 12 for the custom element, 8 for the pending-enrichment flow, 7 for the new-session wiring.

## Smoke testing

Manual smoke testing in dev mode with a real provider is still pending — verify the three gestures behave correctly and that memories/title appear within a few seconds of the next session loading.

## Risks

- 6 pre-existing webapp test flakes (IDB hook timeouts in tests/fs/virtual-fs*.ts, tests/kernel/facade.test.ts, tests/providers/oauth-extra-domains.test.ts) are unrelated to this work and predate this branch.
