### PR TITLE
fix(cdp): attach NavigationWatcher to target=_blank tabs

### DIFF
--- a/packages/webapp/src/cdp/navigation-watcher.ts
+++ b/packages/webapp/src/cdp/navigation-watcher.ts
@@ -175,10 +175,13 @@ export class NavigationWatcher {
 
     try {
       // Use target discovery + manual attach instead of setAutoAttach.
-      // Auto-attach causes Chrome to pause the opener tab's JS when a
-      // window.open() popup is created, showing "debugger paused in another
-      // tab" and freezing OAuth flows. Manual attach via targetCreated lets
-      // us skip popup targets (those with openerId) entirely.
+      // Auto-attach with `waitForDebuggerOnStart` causes Chrome to pause
+      // both the new target's JS and surface a "debugger paused in
+      // another tab" banner on the opener, which freezes OAuth flows
+      // mid-redirect. Manual `Target.attachToTarget` (without enabling
+      // the `Debugger` domain — we only enable `Page` and `Network`)
+      // does NOT pause anything, so we can safely attach to every
+      // page target regardless of whether it has an `openerId`.
       await this.transport.send('Target.setDiscoverTargets', { discover: true });
     } catch (err) {
       log.error('Failed to enable target discovery', {
@@ -250,9 +253,17 @@ export class NavigationWatcher {
   }
 
   /**
-   * Handle a newly discovered target. Manually attach to non-popup page
-   * targets. Popup targets (those with openerId) are skipped — attaching
-   * to them causes Chrome to pause the opener tab.
+   * Handle a newly discovered target. Manually attach to every page
+   * target — including those with an `openerId` (i.e. tabs opened via
+   * `target="_blank"` link clicks or `window.open()`). The pause-the-
+   * opener pathology that prompted the earlier blanket skip was
+   * specific to `Target.setAutoAttach`; manual attach without
+   * enabling the `Debugger` domain is side-effect-free.
+   *
+   * Skipping every `openerId`-bearing target meant that any new tab
+   * spawned from a link click would never have `Page`/`Network`
+   * enabled on it, so its main-frame `Link` headers (and therefore
+   * the resulting `navigate` lick) were silently dropped.
    */
   private async handleTargetCreated(params: Record<string, unknown>): Promise<void> {
     const info = params['targetInfo'] as
@@ -260,13 +271,6 @@ export class NavigationWatcher {
       | undefined;
     if (!info || info.type !== 'page' || typeof info.targetId !== 'string') return;
     if (info.attached) return; // already attached
-    if (info.openerId) {
-      log.debug('Skipping popup target to avoid debugger pause', {
-        targetId: info.targetId,
-        openerId: info.openerId,
-      });
-      return;
-    }
 
     try {
       await this.transport.send('Target.attachToTarget', {

--- a/packages/webapp/tests/cdp/navigation-watcher.test.ts
+++ b/packages/webapp/tests/cdp/navigation-watcher.test.ts
@@ -192,6 +192,23 @@ describe('NavigationWatcher', () => {
         openerId: 'tab-parent',
       },
     });
+    transport.emit('Target.targetCreated', {
+      targetInfo: {
+        targetId: 'iframe-1',
+        type: 'iframe',
+        attached: false,
+        openerId: 'tab-parent',
+        url: 'https://ex.com/embed',
+      },
+    });
+    transport.emit('Target.targetCreated', {
+      targetInfo: {
+        targetId: 'worker-1',
+        type: 'worker',
+        attached: false,
+        openerId: 'tab-parent',
+      },
+    });
     await new Promise((r) => setTimeout(r, 0));
 
     const attachCalls = transport.sentCommands.filter((c) => c.method === 'Target.attachToTarget');

--- a/packages/webapp/tests/cdp/navigation-watcher.test.ts
+++ b/packages/webapp/tests/cdp/navigation-watcher.test.ts
@@ -124,6 +124,80 @@ describe('NavigationWatcher', () => {
     expect(methods).not.toContain('Target.setAutoAttach');
   });
 
+  it('attaches to targets opened with an openerId (target="_blank" / window.open())', async () => {
+    // Regression: NavigationWatcher previously skipped every target
+    // with `openerId`, which meant `<a target="_blank">` clicks
+    // never got Page/Network enabled and their main-frame Link
+    // headers were silently dropped. Manual attach (without enabling
+    // the Debugger domain) does not pause anything, so we attach to
+    // all page targets including link-click children.
+    await watcher.start();
+    transport.sentCommands.length = 0;
+
+    transport.emit('Target.targetCreated', {
+      targetInfo: {
+        targetId: 'tab-child',
+        type: 'page',
+        attached: false,
+        openerId: 'tab-parent',
+        url: 'https://ex.com/landing',
+      },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const attachCalls = transport.sentCommands.filter((c) => c.method === 'Target.attachToTarget');
+    expect(attachCalls).toHaveLength(1);
+    expect(attachCalls[0].params).toMatchObject({ targetId: 'tab-child', flatten: true });
+
+    // And the watcher must subsequently emit the navigate event for
+    // that tab's main-frame Document response, end-to-end.
+    transport.emit('Target.attachedToTarget', {
+      sessionId: 'sess-child',
+      targetInfo: {
+        targetId: 'tab-child',
+        type: 'page',
+        url: 'https://ex.com/landing',
+        openerId: 'tab-parent',
+      },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    transport.emit('Network.responseReceived', {
+      sessionId: 'sess-child',
+      type: 'Document',
+      frameId: 'root-sess-child',
+      response: {
+        url: 'https://ex.com/landing',
+        headers: { link: `<https://github.com/o/r>; rel="${UPSKILL_REL}"` },
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      verb: 'upskill',
+      target: 'https://github.com/o/r',
+      targetId: 'tab-child',
+    });
+  });
+
+  it('still skips non-page target types (workers, iframes) regardless of openerId', async () => {
+    await watcher.start();
+    transport.sentCommands.length = 0;
+
+    transport.emit('Target.targetCreated', {
+      targetInfo: {
+        targetId: 'sw-1',
+        type: 'service_worker',
+        attached: false,
+        openerId: 'tab-parent',
+      },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const attachCalls = transport.sentCommands.filter((c) => c.method === 'Target.attachToTarget');
+    expect(attachCalls).toHaveLength(0);
+  });
+
   it('emits an event when a main-frame Document response advertises a handoff Link', async () => {
     await watcher.start();
 


### PR DESCRIPTION
## Symptom

Visiting `https://www.aem.live/` (or any other page that advertises a SLICC handoff/upskill `Link` header) did **not** result in a `navigate` lick in the standalone / Electron float, despite the header being correctly emitted by the origin:

\`\`\`
link: <https://github.com/adobe/skills>; rel=\"https://www.sliccy.ai/rel/upskill\"; branch=main; path=\"plugins/aem/edge-delivery-services\"
\`\`\`

## Root cause

\`NavigationWatcher.handleTargetCreated\` previously skipped **every** new page target with an \`openerId\`:

\`\`\`ts
if (info.openerId) {
  log.debug('Skipping popup target to avoid debugger pause', { ... });
  return;
}
\`\`\`

Chrome stamps \`openerId\` on every target spawned from another tab — not just \`window.open()\` popups but also \`<a target=\"_blank\">\` link clicks. As a result, any tab a user opened in the background by clicking a link never had \`Page\`/\`Network\` enabled on its CDP session, the main-frame \`Network.responseReceived\` event never fired in the watcher, and the \`navigate\` lick was silently dropped.

Verified live against the CLI float on port 9222: of seven open tabs, the four that looked like link-click navigations (gradial, github SKILL.md, developer.apple.com, aem.live) all had \`attached: false\`, while two typed-URL tabs (sliccy.com, foursquare) were attached. Reloading aem.live via a fresh CDP session reproduced the full \`Link\` header in \`Network.responseReceived\` with \`frameId === targetId\`, confirming the extractor would have matched if attach had happened.

## Fix

Drop the blanket \`openerId\` skip. The pause-the-opener pathology that motivated the original guard is specific to \`Target.setAutoAttach\` with \`waitForDebuggerOnStart\`, which the watcher already does not use. Manual \`Target.attachToTarget\` without enabling the \`Debugger\` domain (we only enable \`Page\` and \`Network\`) is side-effect-free and safe for OAuth popups as well as normal new tabs.

## Tests

- New: \`attaches to targets opened with an openerId (target=\"_blank\" / window.open())\` — locks in that opener-bearing page targets get \`Target.attachToTarget\` called AND end-to-end emit a \`navigate\` event when their main-frame Document response carries the upskill rel.
- New: \`still skips non-page target types (workers, iframes) regardless of openerId\` — guards the narrow remaining filter.
- All existing 19 \`navigation-watcher\` tests pass; full webapp suite (4141 tests) green.

## Verification

\`\`\`
npx prettier --check packages/webapp/src/cdp/navigation-watcher.ts packages/webapp/tests/cdp/navigation-watcher.test.ts
npm run typecheck
npm run test -w @slicc/webapp
\`\`\`