### PR TITLE
feat(shell): add readline keyboard shortcuts to terminal

### DIFF
--- a/packages/webapp/src/kernel/remote-terminal-view.ts
+++ b/packages/webapp/src/kernel/remote-terminal-view.ts
@@ -160,6 +160,7 @@ export class RemoteTerminalView {
       fontFamily: "'Source Code Pro', 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
       theme: isDark ? DARK_THEME : LIGHT_THEME,
       convertEol: true,
+      macOptionIsMeta: true,
     });
 
     this.themeObserver = new MutationObserver(() => {
@@ -259,8 +260,8 @@ export class RemoteTerminalView {
         return;
       }
 
-      // Escape sequences first (arrows, Home, End, Delete).
-      if (data.startsWith('\x1b[') || data.startsWith('\x1bO')) {
+      // Escape sequences first (arrows, Home, End, Delete, Alt+key).
+      if (data.startsWith('\x1b')) {
         switch (data) {
           case '\x1b[A':
             this.handleHistoryUp();
@@ -287,6 +288,12 @@ export class RemoteTerminalView {
           case '\x1b[3~':
             this.handleDelete();
             return;
+          case '\x1bb':
+            this.handleWordBack();
+            return;
+          case '\x1bf':
+            this.handleWordForward();
+            return;
         }
         return;
       }
@@ -305,6 +312,21 @@ export class RemoteTerminalView {
             this.currentLine = '';
             this.cursorPos = 0;
             this.showPrompt();
+            break;
+          case '\x01':
+            this.handleHome();
+            break;
+          case '\x05':
+            this.handleEnd();
+            break;
+          case '\x0b':
+            this.handleKillToEnd();
+            break;
+          case '\x15':
+            this.handleKillToStart();
+            break;
+          case '\x17':
+            this.handleKillWordBack();
             break;
           case '\t':
             // Tab completion via a silent `compgen` round-trip through
@@ -377,6 +399,61 @@ export class RemoteTerminalView {
     if (delta <= 0) return;
     this.terminal?.write(`\x1b[${delta}C`);
     this.cursorPos = this.currentLine.length;
+  }
+
+  private handleKillToEnd(): void {
+    if (this.cursorPos >= this.currentLine.length) return;
+    this.currentLine = this.currentLine.slice(0, this.cursorPos);
+    this.terminal?.write('\x1b[K');
+  }
+
+  private handleKillToStart(): void {
+    if (this.cursorPos <= 0) return;
+    const after = this.currentLine.slice(this.cursorPos);
+    this.currentLine = after;
+    this.cursorPos = 0;
+    this.terminal?.write('\r\x1b[K');
+    this.showPrompt();
+    this.terminal?.write(after);
+    if (after.length > 0) {
+      this.terminal?.write(`\x1b[${after.length}D`);
+    }
+  }
+
+  private handleKillWordBack(): void {
+    if (this.cursorPos <= 0) return;
+    let i = this.cursorPos - 1;
+    while (i > 0 && this.currentLine[i - 1] === ' ') i--;
+    while (i > 0 && this.currentLine[i - 1] !== ' ') i--;
+    const deleted = this.cursorPos - i;
+    const after = this.currentLine.slice(this.cursorPos);
+    this.currentLine = this.currentLine.slice(0, i) + after;
+    this.cursorPos = i;
+    this.terminal?.write(`\x1b[${deleted}D\x1b[K`);
+    if (after.length > 0) {
+      this.terminal?.write(after);
+      this.terminal?.write(`\x1b[${after.length}D`);
+    }
+  }
+
+  private handleWordBack(): void {
+    if (this.cursorPos <= 0) return;
+    let i = this.cursorPos - 1;
+    while (i > 0 && this.currentLine[i - 1] === ' ') i--;
+    while (i > 0 && this.currentLine[i - 1] !== ' ') i--;
+    const moved = this.cursorPos - i;
+    this.cursorPos = i;
+    this.terminal?.write(`\x1b[${moved}D`);
+  }
+
+  private handleWordForward(): void {
+    if (this.cursorPos >= this.currentLine.length) return;
+    let i = this.cursorPos;
+    while (i < this.currentLine.length && this.currentLine[i] === ' ') i++;
+    while (i < this.currentLine.length && this.currentLine[i] !== ' ') i++;
+    const moved = i - this.cursorPos;
+    this.cursorPos = i;
+    this.terminal?.write(`\x1b[${moved}C`);
   }
 
   private handleHistoryUp(): void {

--- a/packages/webapp/src/shell/wasm-shell.ts
+++ b/packages/webapp/src/shell/wasm-shell.ts
@@ -163,6 +163,7 @@ export class WasmShell extends WasmShellHeadless {
       fontFamily: "'Source Code Pro', 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
       theme: isDark ? darkTheme : lightTheme,
       convertEol: true,
+      macOptionIsMeta: true,
     });
 
     this.themeObserver?.disconnect();
@@ -324,8 +325,8 @@ export class WasmShell extends WasmShellHeadless {
         return;
       }
 
-      // Handle escape sequences as a whole (arrow keys, Home, End, Delete)
-      if (data.startsWith('\x1b[') || data.startsWith('\x1bO')) {
+      // Handle escape sequences as a whole (arrow keys, Home, End, Delete, Alt+key)
+      if (data.startsWith('\x1b')) {
         switch (data) {
           case '\x1b[A':
             this.handleHistoryUp();
@@ -352,6 +353,12 @@ export class WasmShell extends WasmShellHeadless {
           case '\x1b[3~':
             this.handleDelete();
             return;
+          case '\x1bb':
+            this.handleWordBack();
+            return;
+          case '\x1bf':
+            this.handleWordForward();
+            return;
         }
         return; // Ignore unknown escape sequences
       }
@@ -367,6 +374,21 @@ export class WasmShell extends WasmShellHeadless {
             break;
           case '\x03':
             this.handleCtrlC();
+            break;
+          case '\x01':
+            this.handleHome();
+            break;
+          case '\x05':
+            this.handleEnd();
+            break;
+          case '\x0b':
+            this.handleKillToEnd();
+            break;
+          case '\x15':
+            this.handleKillToStart();
+            break;
+          case '\x17':
+            this.handleKillWordBack();
             break;
           case '\t':
             this.handleTab();
@@ -515,6 +537,78 @@ export class WasmShell extends WasmShellHeadless {
     if (this.cursorPos === lineEnd) return;
     const moved = lineEnd - this.cursorPos;
     this.cursorPos = lineEnd;
+    this.terminal?.write(`\x1b[${moved}C`);
+  }
+
+  private handleKillToEnd(): void {
+    if (this.cursorPos >= this.currentLine.length) return;
+    const multiLine = this.currentLine.includes('\n');
+    const oldLine = multiLine ? this.getCursorVisualLine() : 0;
+    this.currentLine = this.currentLine.slice(0, this.cursorPos);
+    if (multiLine) {
+      this.redrawInput(oldLine);
+    } else {
+      this.terminal?.write('\x1b[K');
+    }
+  }
+
+  private handleKillToStart(): void {
+    if (this.cursorPos <= 0) return;
+    const multiLine = this.currentLine.includes('\n');
+    const oldLine = multiLine ? this.getCursorVisualLine() : 0;
+    this.currentLine = this.currentLine.slice(this.cursorPos);
+    this.cursorPos = 0;
+    if (multiLine) {
+      this.redrawInput(oldLine);
+    } else {
+      this.terminal?.write('\r\x1b[K');
+      this.showPrompt();
+      this.terminal?.write(this.currentLine);
+      if (this.currentLine.length > 0) {
+        this.terminal?.write(`\x1b[${this.currentLine.length}D`);
+      }
+    }
+  }
+
+  private handleKillWordBack(): void {
+    if (this.cursorPos <= 0) return;
+    const multiLine = this.currentLine.includes('\n');
+    const oldLine = multiLine ? this.getCursorVisualLine() : 0;
+    let i = this.cursorPos - 1;
+    while (i > 0 && this.currentLine[i - 1] === ' ') i--;
+    while (i > 0 && this.currentLine[i - 1] !== ' ') i--;
+    const deleted = this.cursorPos - i;
+    this.currentLine = this.currentLine.slice(0, i) + this.currentLine.slice(this.cursorPos);
+    this.cursorPos = i;
+    if (multiLine) {
+      this.redrawInput(oldLine);
+    } else {
+      const after = this.currentLine.slice(this.cursorPos);
+      this.terminal?.write(`\x1b[${deleted}D\x1b[K`);
+      if (after.length > 0) {
+        this.terminal?.write(after);
+        this.terminal?.write(`\x1b[${after.length}D`);
+      }
+    }
+  }
+
+  private handleWordBack(): void {
+    if (this.cursorPos <= 0) return;
+    let i = this.cursorPos - 1;
+    while (i > 0 && this.currentLine[i - 1] === ' ') i--;
+    while (i > 0 && this.currentLine[i - 1] !== ' ') i--;
+    const moved = this.cursorPos - i;
+    this.cursorPos = i;
+    this.terminal?.write(`\x1b[${moved}D`);
+  }
+
+  private handleWordForward(): void {
+    if (this.cursorPos >= this.currentLine.length) return;
+    let i = this.cursorPos;
+    while (i < this.currentLine.length && this.currentLine[i] === ' ') i++;
+    while (i < this.currentLine.length && this.currentLine[i] !== ' ') i++;
+    const moved = i - this.cursorPos;
+    this.cursorPos = i;
     this.terminal?.write(`\x1b[${moved}C`);
   }
 


### PR DESCRIPTION
## Summary

- Add standard GNU readline shortcuts to both terminal implementations (`wasm-shell.ts` and `remote-terminal-view.ts`)
- Ctrl+A/E (beginning/end of line), Ctrl+U/K (kill before/after cursor), Ctrl+W (kill word back), Alt+B/F (word navigation)
- Set `macOptionIsMeta: true` on xterm.js so Alt+key emits proper escape sequences on macOS

## Test plan

- [x] Typecheck passes
- [x] Existing tests pass (44/45, 1 unrelated sandbox failure)
- [x] Manually verified Alt+B/F work in Chrome on macOS after adding macOptionIsMeta
- [ ] Verify shortcuts work in extension mode (side panel terminal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)