### PR TITLE
feat: add slicc.attachImage() sprinkle bridge method

### DIFF
--- a/packages/chrome-extension/sprinkle-sandbox.html
+++ b/packages/chrome-extension/sprinkle-sandbox.html
@@ -230,7 +230,7 @@ window.slicc = {
     parent.postMessage({ type: 'sprinkle-stop-cone' }, '*');
   },
   attachImage: function(base64, name, mimeType) {
-    parent.postMessage({ type: 'sprinkle-attach-image', base64: base64, name: name || 'screenshot.jpg', mimeType: mimeType || 'image/jpeg' }, '*');
+    parent.postMessage({ type: 'sprinkle-attach-image', base64: base64, name: name, mimeType: mimeType }, '*');
   },
 };
 window.bridge = window.slicc;
@@ -334,7 +334,7 @@ function buildNestedBridgeScript(savedState, savedStorage, name, isLight) {
       'open: function(path, opts) { parent.postMessage({ type: "sprinkle-open", path: path, projectRoot: opts && opts.projectRoot || null }, "*"); },' +
       'close: function() { parent.postMessage({ type: "sprinkle-close" }, "*"); },' +
       'stopCone: function() { parent.postMessage({ type: "sprinkle-stop-cone" }, "*"); },' +
-      'attachImage: function(base64, name, mimeType) { parent.postMessage({ type: "sprinkle-attach-image", base64: base64, name: name || "screenshot.jpg", mimeType: mimeType || "image/jpeg" }, "*"); }' +
+      'attachImage: function(base64, name, mimeType) { parent.postMessage({ type: "sprinkle-attach-image", base64: base64, name: name, mimeType: mimeType }, "*"); }' +
     '};' +
     'window.bridge = window.slicc;' +
     'addEventListener("message", function(e) {' +

--- a/packages/chrome-extension/sprinkle-sandbox.html
+++ b/packages/chrome-extension/sprinkle-sandbox.html
@@ -229,6 +229,9 @@ window.slicc = {
   stopCone: function() {
     parent.postMessage({ type: 'sprinkle-stop-cone' }, '*');
   },
+  attachImage: function(base64, name, mimeType) {
+    parent.postMessage({ type: 'sprinkle-attach-image', base64: base64, name: name || 'screenshot.jpg', mimeType: mimeType || 'image/jpeg' }, '*');
+  },
 };
 window.bridge = window.slicc;
 
@@ -330,7 +333,8 @@ function buildNestedBridgeScript(savedState, savedStorage, name, isLight) {
       'getState: function() { return window.__slicc_state; },' +
       'open: function(path, opts) { parent.postMessage({ type: "sprinkle-open", path: path, projectRoot: opts && opts.projectRoot || null }, "*"); },' +
       'close: function() { parent.postMessage({ type: "sprinkle-close" }, "*"); },' +
-      'stopCone: function() { parent.postMessage({ type: "sprinkle-stop-cone" }, "*"); }' +
+      'stopCone: function() { parent.postMessage({ type: "sprinkle-stop-cone" }, "*"); },' +
+      'attachImage: function(base64, name, mimeType) { parent.postMessage({ type: "sprinkle-attach-image", base64: base64, name: name || "screenshot.jpg", mimeType: mimeType || "image/jpeg" }, "*"); }' +
     '};' +
     'window.bridge = window.slicc;' +
     'addEventListener("message", function(e) {' +
@@ -562,7 +566,7 @@ addEventListener('message', function(e) {
   if (window.__slicc_childIframe && e.source === window.__slicc_childIframe.contentWindow) {
     var bridgeTypes = [
       'sprinkle-lick', 'sprinkle-set-state', 'sprinkle-close', 'sprinkle-stop-cone',
-      'sprinkle-open', 'sprinkle-readfile',
+      'sprinkle-attach-image', 'sprinkle-open', 'sprinkle-readfile',
       'sprinkle-writefile', 'sprinkle-readdir', 'sprinkle-exists',
       'sprinkle-stat', 'sprinkle-mkdir', 'sprinkle-rm',
       'sprinkle-storage-set', 'sprinkle-storage-remove', 'sprinkle-storage-clear',

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -769,6 +769,8 @@ export class ChatPanel {
 
   /** Add a base64-encoded image directly to the pending composer attachments. */
   addImageAttachment(base64: string, name?: string, mimeType?: string): void {
+    if (!base64 || typeof base64 !== 'string') return;
+
     let data = base64;
     let mime = mimeType || 'image/jpeg';
     if (base64.startsWith('data:')) {
@@ -776,10 +778,24 @@ export class ChatPanel {
       if (match) {
         mime = match[1];
         data = match[2];
+      } else {
+        const commaIdx = base64.indexOf(',');
+        if (commaIdx !== -1) data = base64.slice(commaIdx + 1);
       }
     }
-    const fileName = name || (mime === 'image/png' ? 'screenshot.png' : 'screenshot.jpg');
+
+    // Validate mime is an image type
+    if (!/^image\/[a-z0-9.+\-]+$/i.test(mime)) mime = 'image/jpeg';
+
+    // Sanitize name: strip control chars, cap at 200 chars
+    let fileName = name || (mime === 'image/png' ? 'screenshot.png' : 'screenshot.jpg');
+    fileName = fileName.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
+    if (!fileName) fileName = 'screenshot.jpg';
+
+    // Estimate decoded size from base64 length; reject if over 10MB
     const size = Math.ceil((data.length * 3) / 4);
+    if (size > 10 * 1024 * 1024) return;
+
     this.pendingAttachments.push({
       id: uid(),
       name: fileName,

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -14,7 +14,11 @@ import { createLogger } from '../core/logger.js';
 import type { MessageAttachment, MessageAttachmentKind } from '../core/attachments.js';
 import { formatAttachmentSize, formatAttachmentSummary } from '../core/attachments.js';
 import { getMimeType } from '../core/mime-types.js';
-import { processImageContent, isSupportedImageFormat } from '../core/image-processor.js';
+import {
+  processImageContent,
+  isSupportedImageFormat,
+  getImageByteSize,
+} from '../core/image-processor.js';
 import { VoiceInput, getVoiceAutoSend, getVoiceLang } from './voice-input.js';
 import {
   hydrateDips,
@@ -768,7 +772,7 @@ export class ChatPanel {
   }
 
   /** Add a base64-encoded image directly to the pending composer attachments. */
-  addImageAttachment(base64: string, name?: string, mimeType?: string): void {
+  async addImageAttachment(base64: string, name?: string, mimeType?: string): Promise<void> {
     if (!base64 || typeof base64 !== 'string') return;
 
     let data = base64;
@@ -792,17 +796,22 @@ export class ChatPanel {
     fileName = fileName.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
     if (!fileName) fileName = 'screenshot.jpg';
 
-    // Estimate decoded size from base64 length; reject if over 10MB
-    const size = Math.ceil((data.length * 3) / 4);
-    if (size > 10 * 1024 * 1024) return;
+    // Reject images over 10MB raw (no point processing truly massive payloads)
+    const rawSize = getImageByteSize(data);
+    if (rawSize > 10 * 1024 * 1024) return;
+
+    // Run through the same resize pipeline as pasted images so oversized
+    // screenshots (e.g. Retina PNGs) are downsized to fit the 5MB API limit.
+    const processed = await processImageContent({ type: 'image', mimeType: mime, data });
+    if (processed.type !== 'image') return;
 
     this.pendingAttachments.push({
       id: uid(),
       name: fileName,
-      mimeType: mime,
-      size,
+      mimeType: processed.mimeType,
+      size: getImageByteSize(processed.data),
       kind: 'image',
-      data,
+      data: processed.data,
     });
     this.renderPendingAttachments();
     this.updateSendButtonState();

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -767,6 +767,31 @@ export class ChatPanel {
     this.appendMessageEl(msg);
   }
 
+  /** Add a base64-encoded image directly to the pending composer attachments. */
+  addImageAttachment(base64: string, name?: string, mimeType?: string): void {
+    let data = base64;
+    let mime = mimeType || 'image/jpeg';
+    if (base64.startsWith('data:')) {
+      const match = base64.match(/^data:(image\/[^;]+);base64,(.*)$/);
+      if (match) {
+        mime = match[1];
+        data = match[2];
+      }
+    }
+    const fileName = name || (mime === 'image/png' ? 'screenshot.png' : 'screenshot.jpg');
+    const size = Math.ceil((data.length * 3) / 4);
+    this.pendingAttachments.push({
+      id: uid(),
+      name: fileName,
+      mimeType: mime,
+      size,
+      kind: 'image',
+      data,
+    });
+    this.renderPendingAttachments();
+    this.updateSendButtonState();
+  }
+
   /** Add files to the pending composer attachments. */
   async addAttachmentsFromFiles(files: Iterable<File> | ArrayLike<File>): Promise<void> {
     const dropped = Array.from(files).filter((file) => file instanceof File);

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -787,6 +787,7 @@ export class ChatPanel {
         if (commaIdx !== -1) data = base64.slice(commaIdx + 1);
       }
     }
+    if (!data) return;
 
     // Validate against the app's supported image format allowlist (rejects SVG etc.)
     if (!isSupportedImageFormat(mime)) mime = 'image/jpeg';

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -784,8 +784,8 @@ export class ChatPanel {
       }
     }
 
-    // Validate mime is an image type
-    if (!/^image\/[a-z0-9.+\-]+$/i.test(mime)) mime = 'image/jpeg';
+    // Validate against the app's supported image format allowlist (rejects SVG etc.)
+    if (!isSupportedImageFormat(mime)) mime = 'image/jpeg';
 
     // Sanitize name: strip control chars, cap at 200 chars
     let fileName = name || (mime === 'image/png' ? 'screenshot.png' : 'screenshot.jpg');

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1363,7 +1363,8 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
       // open over chat (covers the welcome flow mid-flight). The
       // rail icon pulses to invite the user to click when ready.
       autoOpenBehavior: 'attention',
-    }
+    },
+    (base64, name, mimeType) => layout.panels.chat.addImageAttachment(base64, name, mimeType)
   );
   (window as unknown as Record<string, unknown>).__slicc_sprinkleManager = sprinkleManager;
   (window as unknown as Record<string, unknown>).__slicc_reloadSkills = () => {
@@ -2440,7 +2441,9 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
     () => {
       const cone = client.getScoops().find((s) => s.isCone);
       if (cone) client.stopScoop(cone.jid);
-    }
+    },
+    {},
+    (base64, name, mimeType) => layout.panels.chat.addImageAttachment(base64, name, mimeType)
   );
   (window as unknown as Record<string, unknown>).__slicc_sprinkleManager = sprinkleManager;
   const stopSprinkleHandler = installSprinkleManagerHandlerOverChannel(sprinkleManager, {

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1363,8 +1363,9 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
       // open over chat (covers the welcome flow mid-flight). The
       // rail icon pulses to invite the user to click when ready.
       autoOpenBehavior: 'attention',
-    },
-    (base64, name, mimeType) => layout.panels.chat.addImageAttachment(base64, name, mimeType)
+      onAttachImage: (base64, name, mimeType) =>
+        layout.panels.chat.addImageAttachment(base64, name, mimeType),
+    }
   );
   (window as unknown as Record<string, unknown>).__slicc_sprinkleManager = sprinkleManager;
   (window as unknown as Record<string, unknown>).__slicc_reloadSkills = () => {
@@ -2442,8 +2443,10 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
       const cone = client.getScoops().find((s) => s.isCone);
       if (cone) client.stopScoop(cone.jid);
     },
-    {},
-    (base64, name, mimeType) => layout.panels.chat.addImageAttachment(base64, name, mimeType)
+    {
+      onAttachImage: (base64, name, mimeType) =>
+        layout.panels.chat.addImageAttachment(base64, name, mimeType),
+    }
   );
   (window as unknown as Record<string, unknown>).__slicc_sprinkleManager = sprinkleManager;
   const stopSprinkleHandler = installSprinkleManagerHandlerOverChannel(sprinkleManager, {

--- a/packages/webapp/src/ui/sprinkle-bridge.ts
+++ b/packages/webapp/src/ui/sprinkle-bridge.ts
@@ -42,6 +42,8 @@ export interface SprinkleBridgeAPI {
   close(): void;
   /** Stop the cone agent */
   stopCone(): void;
+  /** Push an image into the chat input as a pending attachment (no agent turn). */
+  attachImage(base64: string, name?: string, mimeType?: string): void;
   /** Sprinkle name */
   readonly name: string;
 }
@@ -54,17 +56,20 @@ export class SprinkleBridge {
   private fs: VirtualFS;
   private closeHandler: (name: string) => void;
   private stopConeHandler: () => void;
+  private attachImageHandler: (base64: string, name?: string, mimeType?: string) => void;
 
   constructor(
     fs: VirtualFS,
     lickHandler: (event: LickEvent) => void,
     closeHandler: (name: string) => void,
-    stopConeHandler: () => void
+    stopConeHandler: () => void,
+    attachImageHandler: (base64: string, name?: string, mimeType?: string) => void
   ) {
     this.fs = fs;
     this.lickHandler = lickHandler;
     this.closeHandler = closeHandler;
     this.stopConeHandler = stopConeHandler;
+    this.attachImageHandler = attachImageHandler;
   }
 
   /** Create a bridge API for a specific sprinkle. */
@@ -164,6 +169,8 @@ export class SprinkleBridge {
       },
       close: () => this.closeHandler(sprinkleName),
       stopCone: () => this.stopConeHandler(),
+      attachImage: (base64: string, name?: string, mimeType?: string) =>
+        this.attachImageHandler(base64, name, mimeType),
     };
     return api;
   }

--- a/packages/webapp/src/ui/sprinkle-follower-controller.ts
+++ b/packages/webapp/src/ui/sprinkle-follower-controller.ts
@@ -431,6 +431,9 @@ export class SprinkleFollowerController {
         // the cone agent." Matches iOS `SprinkleWebView` `case "stopCone"`.
         this.sync.sendSprinkleLick(sprinkleName, { action: '__stopCone__' });
       },
+      attachImage: () => {
+        // No-op on follower — the follower doesn't own the chat input.
+      },
     };
     return api;
   }

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -86,6 +86,8 @@ export interface SprinkleManagerOptions {
    * must not skip the local renderer push or break the sprinkle.
    */
   onSendToSprinkle?: (name: string, data: unknown) => void;
+  /** Called when a sprinkle pushes an image into the chat input via slicc.attachImage(). */
+  onAttachImage?: (base64: string, name?: string, mimeType?: string) => void;
 }
 
 /**
@@ -137,8 +139,7 @@ export class SprinkleManager {
     lickHandler: (event: LickEvent) => void,
     callbacks: SprinkleManagerCallbacks,
     stopConeHandler: () => void,
-    options: SprinkleManagerOptions = {},
-    attachImageHandler: (base64: string, name?: string, mimeType?: string) => void = () => {}
+    options: SprinkleManagerOptions = {}
   ) {
     this.fs = fs;
     this.bridge = new SprinkleBridge(
@@ -146,7 +147,7 @@ export class SprinkleManager {
       lickHandler,
       (name) => this.close(name),
       stopConeHandler,
-      attachImageHandler
+      options.onAttachImage ?? (() => {})
     );
     this.callbacks = callbacks;
     this.autoOpenBehavior = options.autoOpenBehavior ?? 'activate';

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -137,10 +137,17 @@ export class SprinkleManager {
     lickHandler: (event: LickEvent) => void,
     callbacks: SprinkleManagerCallbacks,
     stopConeHandler: () => void,
-    options: SprinkleManagerOptions = {}
+    options: SprinkleManagerOptions = {},
+    attachImageHandler: (base64: string, name?: string, mimeType?: string) => void = () => {}
   ) {
     this.fs = fs;
-    this.bridge = new SprinkleBridge(fs, lickHandler, (name) => this.close(name), stopConeHandler);
+    this.bridge = new SprinkleBridge(
+      fs,
+      lickHandler,
+      (name) => this.close(name),
+      stopConeHandler,
+      attachImageHandler
+    );
     this.callbacks = callbacks;
     this.autoOpenBehavior = options.autoOpenBehavior ?? 'activate';
     this.onSendToSprinkle = options.onSendToSprinkle;

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -164,6 +164,8 @@ export class SprinkleRenderer {
           const k = localStorage.key(i);
           if (k?.startsWith(prefix)) localStorage.removeItem(k);
         }
+      } else if (msg.type === 'sprinkle-attach-image') {
+        this.bridge.attachImage(msg.base64, msg.name, msg.mimeType);
       } else if (msg.type === 'sprinkle-open') {
         this.bridge.open(msg.path, msg.projectRoot ? { projectRoot: msg.projectRoot } : undefined);
       } else if (msg.type === 'sprinkle-readfile') {
@@ -486,6 +488,7 @@ export class SprinkleRenderer {
     getState: function() { return _state; },
     close: function() { parent.postMessage({ type: 'sprinkle-close' }, '*'); },
     stopCone: function() { parent.postMessage({ type: 'sprinkle-stop-cone' }, '*'); },
+    attachImage: function(base64, name, mimeType) { parent.postMessage({ type: 'sprinkle-attach-image', base64: base64, name: name || 'screenshot.jpg', mimeType: mimeType || 'image/jpeg' }, '*'); },
     name: ''
   };
   window.slicc = api;
@@ -588,6 +591,8 @@ export class SprinkleRenderer {
         this.bridge.close();
       } else if (msg.type === 'sprinkle-stop-cone') {
         this.bridge.stopCone();
+      } else if (msg.type === 'sprinkle-attach-image') {
+        this.bridge.attachImage(msg.base64, msg.name, msg.mimeType);
       } else if (msg.type === 'sprinkle-readfile') {
         this.bridge.readFile(msg.path).then(
           (fileContent) =>

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -488,7 +488,7 @@ export class SprinkleRenderer {
     getState: function() { return _state; },
     close: function() { parent.postMessage({ type: 'sprinkle-close' }, '*'); },
     stopCone: function() { parent.postMessage({ type: 'sprinkle-stop-cone' }, '*'); },
-    attachImage: function(base64, name, mimeType) { parent.postMessage({ type: 'sprinkle-attach-image', base64: base64, name: name || 'screenshot.jpg', mimeType: mimeType || 'image/jpeg' }, '*'); },
+    attachImage: function(base64, name, mimeType) { parent.postMessage({ type: 'sprinkle-attach-image', base64: base64, name: name, mimeType: mimeType }, '*'); },
     name: ''
   };
   window.slicc = api;

--- a/packages/webapp/tests/ui/chat-panel-image-attachment.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-image-attachment.test.ts
@@ -163,6 +163,18 @@ describe('ChatPanel.addImageAttachment', () => {
     expect(attachments[0].mimeType).toBe('image/jpeg');
   });
 
+  it('rejects image/svg+xml and falls back to image/jpeg', () => {
+    panel.addImageAttachment('abc123', 'icon.svg', 'image/svg+xml');
+
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'go';
+    textarea.dispatchEvent(new Event('input'));
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+
+    const [, , attachments] = sendMessage.mock.calls[0];
+    expect(attachments[0].mimeType).toBe('image/jpeg');
+  });
+
   it('accepts valid image mime types', () => {
     panel.addImageAttachment('abc123', 'test.webp', 'image/webp');
 

--- a/packages/webapp/tests/ui/chat-panel-image-attachment.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-image-attachment.test.ts
@@ -31,6 +31,17 @@ vi.mock('../../src/ui/provider-settings.js', () => ({
   getProviderConfig: () => null,
 }));
 
+// Mock image-processor: passthrough processImageContent, real isSupportedImageFormat/getImageByteSize
+vi.mock('../../src/core/image-processor.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    processImageContent: vi.fn(async (image: { type: string; mimeType: string; data: string }) => {
+      return image;
+    }),
+  };
+});
+
 describe('ChatPanel.addImageAttachment', () => {
   let container: HTMLElement;
   let panel: ChatPanel;
@@ -69,25 +80,24 @@ describe('ChatPanel.addImageAttachment', () => {
     vi.unstubAllGlobals();
   });
 
-  it('adds a raw base64 image attachment with defaults', () => {
-    panel.addImageAttachment('abc123');
+  it('adds a raw base64 image attachment with defaults', async () => {
+    await panel.addImageAttachment('abc123');
 
     const chip = container.querySelector('.attachment-chip__name');
     expect(chip?.textContent).toBe('screenshot.jpg');
     expect(container.querySelector('.chat__attachments--visible')).not.toBeNull();
   });
 
-  it('adds an attachment with custom name and mimeType', () => {
-    panel.addImageAttachment('abc123', 'photo.png', 'image/png');
+  it('adds an attachment with custom name and mimeType', async () => {
+    await panel.addImageAttachment('abc123', 'photo.png', 'image/png');
 
     const chip = container.querySelector('.attachment-chip__name');
     expect(chip?.textContent).toBe('photo.png');
   });
 
-  it('extracts mime and data from a full data URL', () => {
-    panel.addImageAttachment('data:image/png;base64,iVBORw==', 'snap.png');
+  it('extracts mime and data from a full data URL', async () => {
+    await panel.addImageAttachment('data:image/png;base64,iVBORw==', 'snap.png');
 
-    // Sends the extracted base64 data, not the full URL
     const textarea = container.querySelector('textarea')!;
     textarea.value = 'check this';
     textarea.dispatchEvent(new Event('input'));
@@ -103,8 +113,8 @@ describe('ChatPanel.addImageAttachment', () => {
     });
   });
 
-  it('handles malformed data URL by stripping prefix at comma', () => {
-    panel.addImageAttachment('data:weird;base64,QUJD');
+  it('handles malformed data URL by stripping prefix at comma', async () => {
+    await panel.addImageAttachment('data:weird;base64,QUJD');
 
     const textarea = container.querySelector('textarea')!;
     textarea.value = 'go';
@@ -115,44 +125,44 @@ describe('ChatPanel.addImageAttachment', () => {
     expect(attachments[0].data).toBe('QUJD');
   });
 
-  it('rejects empty base64 input', () => {
-    panel.addImageAttachment('');
+  it('rejects empty base64 input', async () => {
+    await panel.addImageAttachment('');
 
     expect(container.querySelector('.chat__attachments--visible')).toBeNull();
   });
 
-  it('rejects oversized images (>10MB decoded)', () => {
+  it('rejects oversized images (>10MB decoded)', async () => {
     // ~14MB of base64 data (decodes to ~10.5MB)
     const huge = 'A'.repeat(14 * 1024 * 1024);
-    panel.addImageAttachment(huge);
+    await panel.addImageAttachment(huge);
 
     expect(container.querySelector('.chat__attachments--visible')).toBeNull();
   });
 
-  it('sanitizes name: strips control characters', () => {
-    panel.addImageAttachment('abc123', 'evil\x00\x1f\x7fname.png');
+  it('sanitizes name: strips control characters', async () => {
+    await panel.addImageAttachment('abc123', 'evil\x00\x1f\x7fname.png');
 
     const chip = container.querySelector('.attachment-chip__name');
     expect(chip?.textContent).toBe('evilname.png');
   });
 
-  it('sanitizes name: truncates at 200 characters', () => {
+  it('sanitizes name: truncates at 200 characters', async () => {
     const longName = 'a'.repeat(250) + '.png';
-    panel.addImageAttachment('abc123', longName);
+    await panel.addImageAttachment('abc123', longName);
 
     const chip = container.querySelector('.attachment-chip__name');
     expect(chip?.textContent?.length).toBeLessThanOrEqual(200);
   });
 
-  it('falls back to default name when sanitized name is empty', () => {
-    panel.addImageAttachment('abc123', '\x00\x01\x02');
+  it('falls back to default name when sanitized name is empty', async () => {
+    await panel.addImageAttachment('abc123', '\x00\x01\x02');
 
     const chip = container.querySelector('.attachment-chip__name');
     expect(chip?.textContent).toBe('screenshot.jpg');
   });
 
-  it('rejects invalid mimeType and falls back to image/jpeg', () => {
-    panel.addImageAttachment('abc123', 'test.jpg', 'text/html');
+  it('rejects invalid mimeType and falls back to image/jpeg', async () => {
+    await panel.addImageAttachment('abc123', 'test.jpg', 'text/html');
 
     const textarea = container.querySelector('textarea')!;
     textarea.value = 'go';
@@ -163,8 +173,8 @@ describe('ChatPanel.addImageAttachment', () => {
     expect(attachments[0].mimeType).toBe('image/jpeg');
   });
 
-  it('rejects image/svg+xml and falls back to image/jpeg', () => {
-    panel.addImageAttachment('abc123', 'icon.svg', 'image/svg+xml');
+  it('rejects image/svg+xml and falls back to image/jpeg', async () => {
+    await panel.addImageAttachment('abc123', 'icon.svg', 'image/svg+xml');
 
     const textarea = container.querySelector('textarea')!;
     textarea.value = 'go';
@@ -175,8 +185,8 @@ describe('ChatPanel.addImageAttachment', () => {
     expect(attachments[0].mimeType).toBe('image/jpeg');
   });
 
-  it('accepts valid image mime types', () => {
-    panel.addImageAttachment('abc123', 'test.webp', 'image/webp');
+  it('accepts valid image mime types', async () => {
+    await panel.addImageAttachment('abc123', 'test.webp', 'image/webp');
 
     const textarea = container.querySelector('textarea')!;
     textarea.value = 'go';
@@ -187,9 +197,9 @@ describe('ChatPanel.addImageAttachment', () => {
     expect(attachments[0].mimeType).toBe('image/webp');
   });
 
-  it('multiple calls add separate attachment chips', () => {
-    panel.addImageAttachment('abc', 'first.png', 'image/png');
-    panel.addImageAttachment('def', 'second.jpg', 'image/jpeg');
+  it('multiple calls add separate attachment chips', async () => {
+    await panel.addImageAttachment('abc', 'first.png', 'image/png');
+    await panel.addImageAttachment('def', 'second.jpg', 'image/jpeg');
 
     const chips = container.querySelectorAll('.attachment-chip__name');
     expect(chips).toHaveLength(2);
@@ -197,9 +207,9 @@ describe('ChatPanel.addImageAttachment', () => {
     expect(chips[1].textContent).toBe('second.jpg');
   });
 
-  it('estimates size from base64 length', () => {
-    // 12 base64 chars = 9 decoded bytes
-    panel.addImageAttachment('YWJjZGVmZ2hp');
+  it('uses getImageByteSize for accurate size estimation', async () => {
+    // 12 base64 chars = 9 decoded bytes (no padding)
+    await panel.addImageAttachment('YWJjZGVmZ2hp');
 
     const textarea = container.querySelector('textarea')!;
     textarea.value = 'go';
@@ -208,5 +218,15 @@ describe('ChatPanel.addImageAttachment', () => {
 
     const [, , attachments] = sendMessage.mock.calls[0];
     expect(attachments[0].size).toBe(9);
+  });
+
+  it('drops attachment when processImageContent returns text (unsupported)', async () => {
+    const { processImageContent } = await import('../../src/core/image-processor.js');
+    const mock = processImageContent as ReturnType<typeof vi.fn>;
+    mock.mockResolvedValueOnce({ type: 'text', text: '[Image removed]' });
+
+    await panel.addImageAttachment('abc123', 'huge.png', 'image/png');
+
+    expect(container.querySelector('.chat__attachments--visible')).toBeNull();
   });
 });

--- a/packages/webapp/tests/ui/chat-panel-image-attachment.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-image-attachment.test.ts
@@ -131,6 +131,12 @@ describe('ChatPanel.addImageAttachment', () => {
     expect(container.querySelector('.chat__attachments--visible')).toBeNull();
   });
 
+  it('rejects data URL with empty payload', async () => {
+    await panel.addImageAttachment('data:image/png;base64,');
+
+    expect(container.querySelector('.chat__attachments--visible')).toBeNull();
+  });
+
   it('rejects oversized images (>10MB decoded)', async () => {
     // ~14MB of base64 data (decodes to ~10.5MB)
     const huge = 'A'.repeat(14 * 1024 * 1024);

--- a/packages/webapp/tests/ui/chat-panel-image-attachment.test.ts
+++ b/packages/webapp/tests/ui/chat-panel-image-attachment.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { ChatPanel } from '../../src/ui/chat-panel.js';
+import type { AgentHandle, AgentEvent } from '../../src/ui/types.js';
+
+vi.mock('../../src/ui/voice-input.js', () => ({
+  VoiceInput: class {
+    destroy() {}
+    start() {}
+    stop() {}
+    setAutoSend() {}
+    setLang() {}
+    isListening() {
+      return false;
+    }
+  },
+  getVoiceAutoSend: () => false,
+  getVoiceLang: () => 'en-US',
+}));
+
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => '',
+  showProviderSettings: () => {},
+  applyProviderDefaults: () => {},
+  getAllAvailableModels: () => [],
+  getSelectedModelId: () => '',
+  getSelectedProvider: () => null,
+  setSelectedModelId: () => {},
+  getProviderConfig: () => null,
+}));
+
+describe('ChatPanel.addImageAttachment', () => {
+  let container: HTMLElement;
+  let panel: ChatPanel;
+  let sendMessage: ReturnType<typeof vi.fn>;
+  let testCounter = 0;
+
+  beforeEach(async () => {
+    testCounter += 1;
+    const store: Record<string, string> = { 'selected-model': 'claude-sonnet' };
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    panel = new ChatPanel(container);
+    await panel.initSession(`test-image-attach-${testCounter}`);
+    sendMessage = vi.fn();
+    const handle: AgentHandle = {
+      sendMessage,
+      onEvent(_cb: (event: AgentEvent) => void) {
+        return () => {};
+      },
+      stop() {},
+    };
+    panel.setAgent(handle);
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('adds a raw base64 image attachment with defaults', () => {
+    panel.addImageAttachment('abc123');
+
+    const chip = container.querySelector('.attachment-chip__name');
+    expect(chip?.textContent).toBe('screenshot.jpg');
+    expect(container.querySelector('.chat__attachments--visible')).not.toBeNull();
+  });
+
+  it('adds an attachment with custom name and mimeType', () => {
+    panel.addImageAttachment('abc123', 'photo.png', 'image/png');
+
+    const chip = container.querySelector('.attachment-chip__name');
+    expect(chip?.textContent).toBe('photo.png');
+  });
+
+  it('extracts mime and data from a full data URL', () => {
+    panel.addImageAttachment('data:image/png;base64,iVBORw==', 'snap.png');
+
+    // Sends the extracted base64 data, not the full URL
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'check this';
+    textarea.dispatchEvent(new Event('input'));
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const [, , attachments] = sendMessage.mock.calls[0];
+    expect(attachments[0]).toMatchObject({
+      name: 'snap.png',
+      mimeType: 'image/png',
+      data: 'iVBORw==',
+      kind: 'image',
+    });
+  });
+
+  it('handles malformed data URL by stripping prefix at comma', () => {
+    panel.addImageAttachment('data:weird;base64,QUJD');
+
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'go';
+    textarea.dispatchEvent(new Event('input'));
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+
+    const [, , attachments] = sendMessage.mock.calls[0];
+    expect(attachments[0].data).toBe('QUJD');
+  });
+
+  it('rejects empty base64 input', () => {
+    panel.addImageAttachment('');
+
+    expect(container.querySelector('.chat__attachments--visible')).toBeNull();
+  });
+
+  it('rejects oversized images (>10MB decoded)', () => {
+    // ~14MB of base64 data (decodes to ~10.5MB)
+    const huge = 'A'.repeat(14 * 1024 * 1024);
+    panel.addImageAttachment(huge);
+
+    expect(container.querySelector('.chat__attachments--visible')).toBeNull();
+  });
+
+  it('sanitizes name: strips control characters', () => {
+    panel.addImageAttachment('abc123', 'evil\x00\x1f\x7fname.png');
+
+    const chip = container.querySelector('.attachment-chip__name');
+    expect(chip?.textContent).toBe('evilname.png');
+  });
+
+  it('sanitizes name: truncates at 200 characters', () => {
+    const longName = 'a'.repeat(250) + '.png';
+    panel.addImageAttachment('abc123', longName);
+
+    const chip = container.querySelector('.attachment-chip__name');
+    expect(chip?.textContent?.length).toBeLessThanOrEqual(200);
+  });
+
+  it('falls back to default name when sanitized name is empty', () => {
+    panel.addImageAttachment('abc123', '\x00\x01\x02');
+
+    const chip = container.querySelector('.attachment-chip__name');
+    expect(chip?.textContent).toBe('screenshot.jpg');
+  });
+
+  it('rejects invalid mimeType and falls back to image/jpeg', () => {
+    panel.addImageAttachment('abc123', 'test.jpg', 'text/html');
+
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'go';
+    textarea.dispatchEvent(new Event('input'));
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+
+    const [, , attachments] = sendMessage.mock.calls[0];
+    expect(attachments[0].mimeType).toBe('image/jpeg');
+  });
+
+  it('accepts valid image mime types', () => {
+    panel.addImageAttachment('abc123', 'test.webp', 'image/webp');
+
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'go';
+    textarea.dispatchEvent(new Event('input'));
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+
+    const [, , attachments] = sendMessage.mock.calls[0];
+    expect(attachments[0].mimeType).toBe('image/webp');
+  });
+
+  it('multiple calls add separate attachment chips', () => {
+    panel.addImageAttachment('abc', 'first.png', 'image/png');
+    panel.addImageAttachment('def', 'second.jpg', 'image/jpeg');
+
+    const chips = container.querySelectorAll('.attachment-chip__name');
+    expect(chips).toHaveLength(2);
+    expect(chips[0].textContent).toBe('first.png');
+    expect(chips[1].textContent).toBe('second.jpg');
+  });
+
+  it('estimates size from base64 length', () => {
+    // 12 base64 chars = 9 decoded bytes
+    panel.addImageAttachment('YWJjZGVmZ2hp');
+
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'go';
+    textarea.dispatchEvent(new Event('input'));
+    (container.querySelector('.chat__send-btn') as HTMLButtonElement).click();
+
+    const [, , attachments] = sendMessage.mock.calls[0];
+    expect(attachments[0].size).toBe(9);
+  });
+});

--- a/packages/webapp/tests/ui/sprinkle-bridge.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-bridge.test.ts
@@ -10,6 +10,7 @@ describe('SprinkleBridge', () => {
   let closeHandler: (name: string) => void;
   let closeHandlerMock: ReturnType<typeof vi.fn>;
   let stopConeHandlerMock: ReturnType<typeof vi.fn>;
+  let attachImageHandlerMock: ReturnType<typeof vi.fn>;
   let mockFs: VirtualFS;
 
   beforeEach(() => {
@@ -18,6 +19,7 @@ describe('SprinkleBridge', () => {
     closeHandlerMock = vi.fn();
     closeHandler = closeHandlerMock as unknown as (name: string) => void;
     stopConeHandlerMock = vi.fn();
+    attachImageHandlerMock = vi.fn();
     mockFs = {
       readFile: vi.fn().mockResolvedValue('file content'),
       writeFile: vi.fn().mockResolvedValue(undefined),
@@ -30,7 +32,13 @@ describe('SprinkleBridge', () => {
       mkdir: vi.fn().mockResolvedValue(undefined),
       rm: vi.fn().mockResolvedValue(undefined),
     } as unknown as VirtualFS;
-    bridge = new SprinkleBridge(mockFs, lickHandler, closeHandler, stopConeHandlerMock);
+    bridge = new SprinkleBridge(
+      mockFs,
+      lickHandler,
+      closeHandler,
+      stopConeHandlerMock,
+      attachImageHandlerMock
+    );
   });
 
   it('creates an API with the sprinkle name', () => {
@@ -190,5 +198,17 @@ describe('SprinkleBridge', () => {
     const api = bridge.createAPI('test-sprinkle');
     api.stopCone();
     expect(stopConeHandlerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('attachImage() calls the attach-image handler with all args', () => {
+    const api = bridge.createAPI('test-sprinkle');
+    api.attachImage('abc123', 'test.png', 'image/png');
+    expect(attachImageHandlerMock).toHaveBeenCalledWith('abc123', 'test.png', 'image/png');
+  });
+
+  it('attachImage() calls the handler with optional args undefined', () => {
+    const api = bridge.createAPI('test-sprinkle');
+    api.attachImage('abc123');
+    expect(attachImageHandlerMock).toHaveBeenCalledWith('abc123', undefined, undefined);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `slicc.attachImage(base64, name?, mimeType?)` bridge method for sprinkles to push images directly into the chat panel's pending attachments without triggering an agent turn
- Works across all rendering modes: CLI inline, CLI full-doc iframe, extension sandbox, and extension nested full-doc
- Follows the existing fire-and-forget UI action pattern (like `sprinkle-close`, `sprinkle-stop-cone`)

## Motivation

The annotation sprinkle (and future image-producing sprinkles) needs to deliver images into the chat input so users can reference them in their next message. Currently `slicc.lick()` always triggers an agent turn — this provides a pure UI-to-UI action.

## Files changed

| File | Change |
|------|--------|
| `packages/webapp/src/ui/sprinkle-bridge.ts` | Added `attachImage` to interface + class |
| `packages/webapp/src/ui/sprinkle-renderer.ts` | Added `sprinkle-attach-image` handler in both sandbox and fullDoc modes + bridge script injection |
| `packages/webapp/src/ui/sprinkle-manager.ts` | Pass-through `attachImageHandler` callback |
| `packages/webapp/src/ui/chat-panel.ts` | New public `addImageAttachment()` method |
| `packages/webapp/src/ui/main.ts` | Wired handler in both extension and standalone boot paths |
| `packages/webapp/src/ui/sprinkle-follower-controller.ts` | No-op implementation (follower doesn't own chat input) |
| `packages/chrome-extension/sprinkle-sandbox.html` | Added to top-level API, nested bridge script, and relay allowlist |
| `packages/webapp/tests/ui/sprinkle-bridge.test.ts` | Added tests for attachImage |

## Test plan

- [x] Typecheck passes (`tsc --noEmit` for browser, worker, webapp-worker)
- [x] All sprinkle-related tests pass (bridge, manager, renderer, follower-controller, sandbox)
- [x] Full webapp test suite passes (234/235, 1 unrelated sandbox EPERM)
- [ ] Manual: load a sprinkle that calls `slicc.attachImage(canvas.toDataURL())` and verify attachment chip appears in chat input
- [ ] Manual: verify multiple calls add separate chips
- [ ] Manual: verify in extension mode (sandbox path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)