### PR TITLE
feat(ui): Quick Look image preview for attachments

### DIFF
--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -26,6 +26,7 @@ import {
 } from './dip.js';
 import { createToolUIRenderer, disposeToolUIRenderer } from './tool-ui-renderer.js';
 import { showImagePreview } from './image-preview.js';
+import { toPreviewUrl } from '../shell/supplemental-commands/shared.js';
 import {
   getToolDescriptor,
   createToolIcon,
@@ -2282,10 +2283,13 @@ export class ChatPanel {
       chip.appendChild(remove);
     }
 
-    if (attachment.kind === 'image' && attachment.data) {
+    if (attachment.kind === 'image' && (attachment.data || attachment.path)) {
       chip.style.cursor = 'pointer';
       chip.addEventListener('click', () => {
-        showImagePreview(`data:${attachment.mimeType};base64,${attachment.data}`, visual);
+        const src = attachment.data
+          ? `data:${attachment.mimeType};base64,${attachment.data}`
+          : toPreviewUrl(attachment.path!);
+        showImagePreview(src, visual);
       });
     }
 

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -25,6 +25,7 @@ import {
   type DraftDipInstance,
 } from './dip.js';
 import { createToolUIRenderer, disposeToolUIRenderer } from './tool-ui-renderer.js';
+import { showImagePreview } from './image-preview.js';
 import {
   getToolDescriptor,
   createToolIcon,
@@ -2279,6 +2280,13 @@ export class ChatPanel {
         options.onRemove?.();
       });
       chip.appendChild(remove);
+    }
+
+    if (attachment.kind === 'image' && attachment.data) {
+      chip.style.cursor = 'pointer';
+      chip.addEventListener('click', () => {
+        showImagePreview(`data:${attachment.mimeType};base64,${attachment.data}`, visual);
+      });
     }
 
     return chip;

--- a/packages/webapp/src/ui/image-preview.ts
+++ b/packages/webapp/src/ui/image-preview.ts
@@ -23,12 +23,6 @@ export function showImagePreview(src: string, originEl: HTMLElement): () => void
   activeOverlay = overlay;
 
   const originRect = originEl.getBoundingClientRect();
-  img.style.position = 'absolute';
-  img.style.top = `${originRect.top}px`;
-  img.style.left = `${originRect.left}px`;
-  img.style.width = `${originRect.width}px`;
-  img.style.height = `${originRect.height}px`;
-  img.style.borderRadius = `${Math.min(originRect.width, originRect.height) * 0.15}px`;
 
   const animateOpen = () => {
     const vw = window.innerWidth;
@@ -45,10 +39,31 @@ export function showImagePreview(src: string, originEl: HTMLElement): () => void
     const finalLeft = (vw - finalW) / 2;
     const finalTop = (vh - finalH) / 2;
 
-    img.style.top = `${finalTop}px`;
-    img.style.left = `${finalLeft}px`;
+    // Position image at final size and location using CSS positioning
+    img.style.position = 'absolute';
     img.style.width = `${finalW}px`;
     img.style.height = `${finalH}px`;
+    img.style.left = `${finalLeft}px`;
+    img.style.top = `${finalTop}px`;
+    img.style.borderRadius = '6px';
+
+    // Calculate transform to start from the origin thumbnail
+    const scaleX = originRect.width / finalW;
+    const scaleY = originRect.height / finalH;
+    const originCenterX = originRect.left + originRect.width / 2;
+    const originCenterY = originRect.top + originRect.height / 2;
+    const finalCenterX = finalLeft + finalW / 2;
+    const finalCenterY = finalTop + finalH / 2;
+    const translateX = originCenterX - finalCenterX;
+    const translateY = originCenterY - finalCenterY;
+
+    // Start at thumbnail position/size
+    img.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scaleX}, ${scaleY})`;
+    img.style.borderRadius = `${6 / Math.min(scaleX, scaleY)}px`;
+
+    // Trigger reflow then animate to final position
+    img.offsetHeight; // eslint-disable-line @typescript-eslint/no-unused-expressions
+    img.style.transform = 'translate(0, 0) scale(1, 1)';
     img.style.borderRadius = '6px';
 
     overlay.classList.add('image-preview-overlay--visible');
@@ -64,19 +79,30 @@ export function showImagePreview(src: string, originEl: HTMLElement): () => void
     };
   }
 
+  let dismissed = false;
+
   const dismiss = () => {
-    if (!activeOverlay || overlay !== activeOverlay) return;
+    if (dismissed || !activeOverlay || overlay !== activeOverlay) return;
+    dismissed = true;
 
     overlay.classList.add('image-preview-overlay--closing');
     overlay.classList.remove('image-preview-overlay--visible');
 
+    // Animate back to origin if it's still in the DOM
     const currentOriginRect = originEl.getBoundingClientRect();
     if (currentOriginRect.width > 0 && currentOriginRect.height > 0) {
-      img.style.top = `${currentOriginRect.top}px`;
-      img.style.left = `${currentOriginRect.left}px`;
-      img.style.width = `${currentOriginRect.width}px`;
-      img.style.height = `${currentOriginRect.height}px`;
-      img.style.borderRadius = `${Math.min(currentOriginRect.width, currentOriginRect.height) * 0.15}px`;
+      const imgRect = img.getBoundingClientRect();
+      const scaleX = currentOriginRect.width / imgRect.width;
+      const scaleY = currentOriginRect.height / imgRect.height;
+      const originCenterX = currentOriginRect.left + currentOriginRect.width / 2;
+      const originCenterY = currentOriginRect.top + currentOriginRect.height / 2;
+      const imgCenterX = imgRect.left + imgRect.width / 2;
+      const imgCenterY = imgRect.top + imgRect.height / 2;
+      const translateX = originCenterX - imgCenterX;
+      const translateY = originCenterY - imgCenterY;
+
+      img.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scaleX}, ${scaleY})`;
+      img.style.borderRadius = `${6 / Math.min(scaleX, scaleY)}px`;
     }
 
     const cleanup = () => {
@@ -89,8 +115,15 @@ export function showImagePreview(src: string, originEl: HTMLElement): () => void
         activeCleanup = null;
       }
     };
-    overlay.addEventListener('transitionend', cleanup, { once: true });
-    setTimeout(cleanup, 300);
+    const timeout = setTimeout(cleanup, 300);
+    overlay.addEventListener(
+      'transitionend',
+      () => {
+        clearTimeout(timeout);
+        cleanup();
+      },
+      { once: true }
+    );
   };
 
   const onKey = (e: KeyboardEvent) => {

--- a/packages/webapp/src/ui/image-preview.ts
+++ b/packages/webapp/src/ui/image-preview.ts
@@ -115,7 +115,7 @@ export function showImagePreview(src: string, originEl: HTMLElement): () => void
         activeCleanup = null;
       }
     };
-    const timeout = setTimeout(cleanup, 300);
+    const timeout = setTimeout(cleanup, 400);
     overlay.addEventListener(
       'transitionend',
       () => {

--- a/packages/webapp/src/ui/image-preview.ts
+++ b/packages/webapp/src/ui/image-preview.ts
@@ -114,14 +114,11 @@ export function showImagePreview(src: string, originEl: HTMLElement): () => void
       }
     };
     const timeout = setTimeout(cleanup, 400);
-    overlay.addEventListener(
-      'transitionend',
-      () => {
-        clearTimeout(timeout);
-        cleanup();
-      },
-      { once: true }
-    );
+    overlay.addEventListener('transitionend', (e) => {
+      if (e.propertyName !== 'transform') return;
+      clearTimeout(timeout);
+      cleanup();
+    });
   };
 
   const onKey = (e: KeyboardEvent) => {

--- a/packages/webapp/src/ui/image-preview.ts
+++ b/packages/webapp/src/ui/image-preview.ts
@@ -24,7 +24,7 @@ export function showImagePreview(src: string, originEl: HTMLElement): () => void
 
   const originRect = originEl.getBoundingClientRect();
 
-  const animateOpen = () => {
+  const setupAndAnimate = () => {
     const vw = window.innerWidth;
     const vh = window.innerHeight;
     const maxW = vw * 0.9;
@@ -39,15 +39,6 @@ export function showImagePreview(src: string, originEl: HTMLElement): () => void
     const finalLeft = (vw - finalW) / 2;
     const finalTop = (vh - finalH) / 2;
 
-    // Position image at final size and location using CSS positioning
-    img.style.position = 'absolute';
-    img.style.width = `${finalW}px`;
-    img.style.height = `${finalH}px`;
-    img.style.left = `${finalLeft}px`;
-    img.style.top = `${finalTop}px`;
-    img.style.borderRadius = '6px';
-
-    // Calculate transform to start from the origin thumbnail
     const scaleX = originRect.width / finalW;
     const scaleY = originRect.height / finalH;
     const originCenterX = originRect.left + originRect.width / 2;
@@ -57,22 +48,29 @@ export function showImagePreview(src: string, originEl: HTMLElement): () => void
     const translateX = originCenterX - finalCenterX;
     const translateY = originCenterY - finalCenterY;
 
-    // Start at thumbnail position/size
+    // Place image at final layout position but visually at thumbnail via transform
+    img.style.position = 'absolute';
+    img.style.width = `${finalW}px`;
+    img.style.height = `${finalH}px`;
+    img.style.left = `${finalLeft}px`;
+    img.style.top = `${finalTop}px`;
     img.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scaleX}, ${scaleY})`;
     img.style.borderRadius = `${6 / Math.min(scaleX, scaleY)}px`;
 
-    // Trigger reflow then animate to final position
-    img.offsetHeight; // eslint-disable-line @typescript-eslint/no-unused-expressions
-    img.style.transform = 'translate(0, 0) scale(1, 1)';
-    img.style.borderRadius = '6px';
-
-    overlay.classList.add('image-preview-overlay--visible');
+    // Double-rAF ensures the browser paints the initial state before we animate
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        img.style.transform = 'translate(0, 0) scale(1, 1)';
+        img.style.borderRadius = '6px';
+        overlay.classList.add('image-preview-overlay--visible');
+      });
+    });
   };
 
   if (img.complete && img.naturalWidth > 0) {
-    requestAnimationFrame(animateOpen);
+    setupAndAnimate();
   } else {
-    img.onload = () => requestAnimationFrame(animateOpen);
+    img.onload = () => setupAndAnimate();
     img.onerror = () => {
       overlay.remove();
       activeOverlay = null;

--- a/packages/webapp/src/ui/image-preview.ts
+++ b/packages/webapp/src/ui/image-preview.ts
@@ -1,0 +1,118 @@
+let activeOverlay: HTMLElement | null = null;
+let activeCleanup: (() => void) | null = null;
+
+export function showImagePreview(src: string, originEl: HTMLElement): () => void {
+  if (activeOverlay) {
+    dismissImmediate();
+  }
+
+  const overlay = document.createElement('div');
+  overlay.className = 'image-preview-overlay';
+
+  const backdrop = document.createElement('div');
+  backdrop.className = 'image-preview-backdrop';
+  overlay.appendChild(backdrop);
+
+  const img = document.createElement('img');
+  img.className = 'image-preview-image';
+  img.src = src;
+  img.alt = 'Image preview';
+  overlay.appendChild(img);
+
+  document.body.appendChild(overlay);
+  activeOverlay = overlay;
+
+  const originRect = originEl.getBoundingClientRect();
+  img.style.position = 'absolute';
+  img.style.top = `${originRect.top}px`;
+  img.style.left = `${originRect.left}px`;
+  img.style.width = `${originRect.width}px`;
+  img.style.height = `${originRect.height}px`;
+  img.style.borderRadius = `${Math.min(originRect.width, originRect.height) * 0.15}px`;
+
+  const animateOpen = () => {
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const maxW = vw * 0.9;
+    const maxH = vh * 0.9;
+
+    const natW = img.naturalWidth || originRect.width * 4;
+    const natH = img.naturalHeight || originRect.height * 4;
+    const scale = Math.min(maxW / natW, maxH / natH, 1);
+    const finalW = natW * scale;
+    const finalH = natH * scale;
+
+    const finalLeft = (vw - finalW) / 2;
+    const finalTop = (vh - finalH) / 2;
+
+    img.style.top = `${finalTop}px`;
+    img.style.left = `${finalLeft}px`;
+    img.style.width = `${finalW}px`;
+    img.style.height = `${finalH}px`;
+    img.style.borderRadius = '6px';
+
+    overlay.classList.add('image-preview-overlay--visible');
+  };
+
+  if (img.complete && img.naturalWidth > 0) {
+    requestAnimationFrame(animateOpen);
+  } else {
+    img.onload = () => requestAnimationFrame(animateOpen);
+    img.onerror = () => {
+      overlay.remove();
+      activeOverlay = null;
+    };
+  }
+
+  const dismiss = () => {
+    if (!activeOverlay || overlay !== activeOverlay) return;
+
+    overlay.classList.add('image-preview-overlay--closing');
+    overlay.classList.remove('image-preview-overlay--visible');
+
+    const currentOriginRect = originEl.getBoundingClientRect();
+    if (currentOriginRect.width > 0 && currentOriginRect.height > 0) {
+      img.style.top = `${currentOriginRect.top}px`;
+      img.style.left = `${currentOriginRect.left}px`;
+      img.style.width = `${currentOriginRect.width}px`;
+      img.style.height = `${currentOriginRect.height}px`;
+      img.style.borderRadius = `${Math.min(currentOriginRect.width, currentOriginRect.height) * 0.15}px`;
+    }
+
+    const cleanup = () => {
+      overlay.remove();
+      if (activeOverlay === overlay) {
+        activeOverlay = null;
+      }
+      if (activeCleanup) {
+        activeCleanup();
+        activeCleanup = null;
+      }
+    };
+    overlay.addEventListener('transitionend', cleanup, { once: true });
+    setTimeout(cleanup, 300);
+  };
+
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') dismiss();
+  };
+  overlay.addEventListener('click', dismiss);
+  document.addEventListener('keydown', onKey);
+
+  activeCleanup = () => {
+    document.removeEventListener('keydown', onKey);
+  };
+
+  return dismiss;
+}
+
+function dismissImmediate(): void {
+  if (activeOverlay) {
+    activeOverlay.remove();
+    activeOverlay = null;
+  }
+  if (activeCleanup) {
+    activeCleanup();
+    activeCleanup = null;
+  }
+}

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -11,6 +11,7 @@ import './styles/tabs.css';
 import './styles/dialog.css';
 import './styles/sprinkle-components.css';
 import './styles/feedback.css';
+import './styles/image-preview.css';
 
 /**
  * Main entry point for the Browser Coding Agent UI.

--- a/packages/webapp/src/ui/styles/image-preview.css
+++ b/packages/webapp/src/ui/styles/image-preview.css
@@ -29,7 +29,9 @@
 .image-preview-image {
   position: absolute;
   border-radius: 6px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4), 0 8px 20px rgba(0, 0, 0, 0.3);
+  box-shadow:
+    0 20px 60px rgba(0, 0, 0, 0.4),
+    0 8px 20px rgba(0, 0, 0, 0.3);
   max-width: 90vw;
   max-height: 90vh;
   object-fit: contain;

--- a/packages/webapp/src/ui/styles/image-preview.css
+++ b/packages/webapp/src/ui/styles/image-preview.css
@@ -1,0 +1,42 @@
+.image-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.image-preview-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(8px);
+  opacity: 0;
+  transition: opacity 0.3s cubic-bezier(0.2, 0, 0.13, 1);
+}
+
+.image-preview-overlay--visible .image-preview-backdrop {
+  opacity: 1;
+}
+
+.image-preview-overlay--closing .image-preview-backdrop {
+  opacity: 0;
+  transition-duration: 0.25s;
+}
+
+.image-preview-image {
+  position: absolute;
+  border-radius: 6px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4), 0 8px 20px rgba(0, 0, 0, 0.3);
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  will-change: transform, width, height, top, left;
+  transition: all 0.3s cubic-bezier(0.2, 0, 0.13, 1);
+}
+
+.image-preview-overlay--closing .image-preview-image {
+  transition-duration: 0.25s;
+}

--- a/packages/webapp/src/ui/styles/image-preview.css
+++ b/packages/webapp/src/ui/styles/image-preview.css
@@ -35,8 +35,12 @@
   max-width: 90vw;
   max-height: 90vh;
   object-fit: contain;
-  will-change: transform, width, height, top, left;
-  transition: all 0.3s cubic-bezier(0.2, 0, 0.13, 1);
+  transform-origin: center center;
+  will-change: transform, opacity;
+  transition:
+    transform 0.3s cubic-bezier(0.2, 0, 0.13, 1),
+    opacity 0.3s cubic-bezier(0.2, 0, 0.13, 1),
+    border-radius 0.3s cubic-bezier(0.2, 0, 0.13, 1);
 }
 
 .image-preview-overlay--closing .image-preview-image {

--- a/packages/webapp/src/ui/styles/image-preview.css
+++ b/packages/webapp/src/ui/styles/image-preview.css
@@ -14,7 +14,7 @@
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(8px);
   opacity: 0;
-  transition: opacity 0.3s cubic-bezier(0.2, 0, 0.13, 1);
+  transition: opacity 0.35s cubic-bezier(0.2, 0, 0.13, 1);
 }
 
 .image-preview-overlay--visible .image-preview-backdrop {
@@ -23,7 +23,6 @@
 
 .image-preview-overlay--closing .image-preview-backdrop {
   opacity: 0;
-  transition-duration: 0.25s;
 }
 
 .image-preview-image {
@@ -38,11 +37,11 @@
   transform-origin: center center;
   will-change: transform, opacity;
   transition:
-    transform 0.3s cubic-bezier(0.2, 0, 0.13, 1),
-    opacity 0.3s cubic-bezier(0.2, 0, 0.13, 1),
-    border-radius 0.3s cubic-bezier(0.2, 0, 0.13, 1);
+    transform 0.35s cubic-bezier(0.2, 0, 0.13, 1),
+    opacity 0.35s cubic-bezier(0.2, 0, 0.13, 1),
+    border-radius 0.35s cubic-bezier(0.2, 0, 0.13, 1);
 }
 
 .image-preview-overlay--closing .image-preview-image {
-  transition-duration: 0.25s;
+  transition-duration: 0.35s;
 }

--- a/packages/webapp/src/ui/styles/image-preview.css
+++ b/packages/webapp/src/ui/styles/image-preview.css
@@ -35,13 +35,8 @@
   max-height: 90vh;
   object-fit: contain;
   transform-origin: center center;
-  will-change: transform, opacity;
+  will-change: transform;
   transition:
     transform 0.35s cubic-bezier(0.2, 0, 0.13, 1),
-    opacity 0.35s cubic-bezier(0.2, 0, 0.13, 1),
     border-radius 0.35s cubic-bezier(0.2, 0, 0.13, 1);
-}
-
-.image-preview-overlay--closing .image-preview-image {
-  transition-duration: 0.35s;
 }

--- a/packages/webapp/tests/ui/image-preview-integration.test.ts
+++ b/packages/webapp/tests/ui/image-preview-integration.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { ChatPanel } from '../../src/ui/chat-panel.js';
+import type { AgentHandle, AgentEvent } from '../../src/ui/types.js';
+
+vi.mock('../../src/ui/voice-input.js', () => ({
+  VoiceInput: class {
+    destroy() {}
+    start() {}
+    stop() {}
+    setAutoSend() {}
+    setLang() {}
+    isListening() {
+      return false;
+    }
+  },
+  getVoiceAutoSend: () => false,
+  getVoiceLang: () => 'en-US',
+}));
+
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => '',
+  showProviderSettings: () => {},
+  applyProviderDefaults: () => {},
+  getAllAvailableModels: () => [],
+  getSelectedModelId: () => '',
+  getSelectedProvider: () => null,
+  setSelectedModelId: () => {},
+  getProviderConfig: () => null,
+}));
+
+describe('ChatPanel image preview integration', () => {
+  let container: HTMLElement;
+  let panel: ChatPanel;
+  let testCounter = 0;
+
+  beforeEach(async () => {
+    testCounter += 1;
+    const store: Record<string, string> = { 'selected-model': 'claude-sonnet' };
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    panel = new ChatPanel(container);
+    await panel.initSession(`test-preview-${testCounter}`);
+    const handle: AgentHandle = {
+      sendMessage: vi.fn(),
+      onEvent(_cb: (event: AgentEvent) => void) {
+        return () => {};
+      },
+      stop() {},
+    };
+    panel.setAgent(handle);
+  });
+
+  afterEach(() => {
+    container.remove();
+    document.querySelectorAll('.image-preview-overlay').forEach((el) => el.remove());
+    vi.unstubAllGlobals();
+  });
+
+  it('opens image preview when clicking an image attachment chip', async () => {
+    const pngBytes = Uint8Array.from(
+      atob(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+      ),
+      (c) => c.charCodeAt(0)
+    );
+    const file = new File([pngBytes], 'screenshot.png', { type: 'image/png' });
+    await panel.addAttachmentsFromFiles([file]);
+
+    const chip = container.querySelector('.attachment-chip--image');
+    expect(chip).toBeTruthy();
+
+    chip!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const overlay = document.querySelector('.image-preview-overlay');
+    expect(overlay).toBeTruthy();
+  });
+
+  it('does not open preview when clicking the remove button', async () => {
+    const pngBytes = Uint8Array.from(
+      atob(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+      ),
+      (c) => c.charCodeAt(0)
+    );
+    const file = new File([pngBytes], 'screenshot.png', { type: 'image/png' });
+    await panel.addAttachmentsFromFiles([file]);
+
+    const removeBtn = container.querySelector('.attachment-chip__remove');
+    expect(removeBtn).toBeTruthy();
+
+    removeBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const overlay = document.querySelector('.image-preview-overlay');
+    expect(overlay).toBeFalsy();
+  });
+});

--- a/packages/webapp/tests/ui/image-preview.test.ts
+++ b/packages/webapp/tests/ui/image-preview.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { showImagePreview } from '../../src/ui/image-preview.js';
+
+describe('showImagePreview', () => {
+  let originEl: HTMLElement;
+  const testSrc =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+  beforeEach(() => {
+    originEl = document.createElement('div');
+    originEl.style.width = '26px';
+    originEl.style.height = '26px';
+    originEl.style.position = 'absolute';
+    originEl.style.top = '100px';
+    originEl.style.left = '50px';
+    document.body.appendChild(originEl);
+  });
+
+  afterEach(() => {
+    originEl.remove();
+    document.querySelectorAll('.image-preview-overlay').forEach((el) => el.remove());
+  });
+
+  it('creates an overlay element in the DOM', () => {
+    showImagePreview(testSrc, originEl);
+    const overlay = document.querySelector('.image-preview-overlay');
+    expect(overlay).toBeTruthy();
+  });
+
+  it('contains a backdrop and an image element', () => {
+    showImagePreview(testSrc, originEl);
+    const overlay = document.querySelector('.image-preview-overlay')!;
+    expect(overlay.querySelector('.image-preview-backdrop')).toBeTruthy();
+    expect(overlay.querySelector('.image-preview-image')).toBeTruthy();
+  });
+
+  it('sets the image src correctly', () => {
+    showImagePreview(testSrc, originEl);
+    const img = document.querySelector('.image-preview-image') as HTMLImageElement;
+    expect(img.src).toBe(testSrc);
+  });
+
+  it('removes overlay on click', () => {
+    showImagePreview(testSrc, originEl);
+    const overlay = document.querySelector('.image-preview-overlay')!;
+    overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(overlay.classList.contains('image-preview-overlay--closing')).toBe(true);
+  });
+
+  it('removes overlay on Escape key', () => {
+    showImagePreview(testSrc, originEl);
+    const overlay = document.querySelector('.image-preview-overlay')!;
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(overlay.classList.contains('image-preview-overlay--closing')).toBe(true);
+  });
+
+  it('returns a dismiss function', () => {
+    const dismiss = showImagePreview(testSrc, originEl);
+    expect(typeof dismiss).toBe('function');
+    dismiss();
+    const overlay = document.querySelector('.image-preview-overlay')!;
+    expect(overlay.classList.contains('image-preview-overlay--closing')).toBe(true);
+  });
+
+  it('only allows one preview at a time', () => {
+    showImagePreview(testSrc, originEl);
+    showImagePreview(testSrc, originEl);
+    const overlays = document.querySelectorAll('.image-preview-overlay');
+    expect(overlays.length).toBe(1);
+  });
+});

--- a/packages/webapp/tests/ui/image-preview.test.ts
+++ b/packages/webapp/tests/ui/image-preview.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { showImagePreview } from '../../src/ui/image-preview.js';
 
 describe('showImagePreview', () => {


### PR DESCRIPTION
## Summary

- Adds a macOS Quick Look-style image preview overlay that opens when clicking image attachment chips
- Preview scales from the thumbnail position to center-screen with backdrop blur
- Works on both pending attachments in the input bar and sent message attachments
- Dismiss via click anywhere, Escape key, or programmatic dismiss function
- Delete button on input chips still works without triggering preview

## Test plan

- [ ] Paste an image (Cmd+V), click the attachment chip — verify preview opens with scale animation from thumbnail
- [ ] Click anywhere on the overlay — verify it animates back to the thumbnail position
- [ ] Paste an image, press Escape — verify dismiss works
- [ ] Paste an image, click the X (remove) button — verify attachment is removed without opening preview
- [ ] Send a message with an image, click the attachment in the sent message — verify preview opens from history
- [ ] 9 new unit/integration tests pass (`npx vitest run packages/webapp/tests/ui/image-preview*.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)