### PR TITLE
feat(sprinkles): add slicc.minimize() to collapse rail panel from sprinkle

### DIFF
--- a/packages/chrome-extension/sprinkle-sandbox.html
+++ b/packages/chrome-extension/sprinkle-sandbox.html
@@ -226,6 +226,9 @@ window.slicc = {
   close: function() {
     parent.postMessage({ type: 'sprinkle-close' }, '*');
   },
+  minimize: function() {
+    parent.postMessage({ type: 'sprinkle-minimize' }, '*');
+  },
   stopCone: function() {
     parent.postMessage({ type: 'sprinkle-stop-cone' }, '*');
   },
@@ -333,6 +336,7 @@ function buildNestedBridgeScript(savedState, savedStorage, name, isLight) {
       'getState: function() { return window.__slicc_state; },' +
       'open: function(path, opts) { parent.postMessage({ type: "sprinkle-open", path: path, projectRoot: opts && opts.projectRoot || null }, "*"); },' +
       'close: function() { parent.postMessage({ type: "sprinkle-close" }, "*"); },' +
+      'minimize: function() { parent.postMessage({ type: "sprinkle-minimize" }, "*"); },' +
       'stopCone: function() { parent.postMessage({ type: "sprinkle-stop-cone" }, "*"); },' +
       'attachImage: function(base64, name, mimeType) { parent.postMessage({ type: "sprinkle-attach-image", base64: base64, name: name, mimeType: mimeType }, "*"); }' +
     '};' +
@@ -565,7 +569,7 @@ addEventListener('message', function(e) {
   // Relay bridge messages FROM the nested child iframe TO the extension page.
   if (window.__slicc_childIframe && e.source === window.__slicc_childIframe.contentWindow) {
     var bridgeTypes = [
-      'sprinkle-lick', 'sprinkle-set-state', 'sprinkle-close', 'sprinkle-stop-cone',
+      'sprinkle-lick', 'sprinkle-set-state', 'sprinkle-close', 'sprinkle-minimize', 'sprinkle-stop-cone',
       'sprinkle-attach-image', 'sprinkle-open', 'sprinkle-readfile',
       'sprinkle-writefile', 'sprinkle-readdir', 'sprinkle-exists',
       'sprinkle-stat', 'sprinkle-mkdir', 'sprinkle-rm',

--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -200,6 +200,7 @@ Available as `slicc` in `<script>` tags and `onclick` attributes:
 
 - `slicc.name` — the sprinkle's name.
 - `slicc.close()` — close the sprinkle.
+- `slicc.minimize()` — collapse the sprinkle panel (rail icon stays visible; user can click to reopen). Does not close or destroy the sprinkle.
 - `slicc.stopCone()` — stop the cone agent.
 - `slicc.readFile(path)` — read a VFS file (returns `Promise<string>`).
 - `slicc.writeFile(path, content)` — write text content to a VFS file.

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -1381,8 +1381,10 @@ export class Layout {
   }
 
   /** Collapse the rail content panel without removing the sprinkle. The rail icon stays visible. */
-  minimizeSprinkle(_name: string): void {
-    this.primaryRail?.collapse();
+  minimizeSprinkle(name: string): void {
+    if (this.primaryRail?.getActiveItemId() === `sprinkle-${name}`) {
+      this.primaryRail.collapse();
+    }
   }
 
   // The legacy switchPrimaryTab/switchDrawerTab helpers were removed

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -1380,6 +1380,11 @@ export class Layout {
     this.updateAddButtons();
   }
 
+  /** Collapse the rail content panel without removing the sprinkle. The rail icon stays visible. */
+  minimizeSprinkle(_name: string): void {
+    this.primaryRail?.collapse();
+  }
+
   // The legacy switchPrimaryTab/switchDrawerTab helpers were removed
   // when the tabbed layout was retired — see `setActiveTab` for the
   // current API surface.

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1351,6 +1351,7 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
       addSprinkle: (name, title, element, zone, options) =>
         layout.addSprinkle(name, title, element, zone as 'primary' | 'drawer' | undefined, options),
       removeSprinkle: (name) => layout.removeSprinkle(name),
+      minimizeSprinkle: (name) => layout.minimizeSprinkle(name),
     },
     () => {
       const cone = client.getScoops().find((s) => s.isCone);
@@ -2438,6 +2439,7 @@ async function mainStandaloneWorker(app: HTMLElement, isElectronOverlay: boolean
       addSprinkle: (name, title, element, zone, options) =>
         layout.addSprinkle(name, title, element, zone as 'primary' | 'drawer' | undefined, options),
       removeSprinkle: (name) => layout.removeSprinkle(name),
+      minimizeSprinkle: (name) => layout.minimizeSprinkle(name),
     },
     () => {
       const cone = client.getScoops().find((s) => s.isCone);

--- a/packages/webapp/src/ui/sprinkle-bridge.ts
+++ b/packages/webapp/src/ui/sprinkle-bridge.ts
@@ -40,6 +40,8 @@ export interface SprinkleBridgeAPI {
   open(path: string, opts?: { projectRoot?: string }): void;
   /** Close this sprinkle */
   close(): void;
+  /** Collapse the sprinkle panel (rail icon stays visible; user can click to reopen). Does not close or destroy the sprinkle. */
+  minimize(): void;
   /** Stop the cone agent */
   stopCone(): void;
   /** Push an image into the chat input as a pending attachment (no agent turn). */
@@ -55,6 +57,7 @@ export class SprinkleBridge {
   private lickHandler: (event: LickEvent) => void;
   private fs: VirtualFS;
   private closeHandler: (name: string) => void;
+  private minimizeHandler: (name: string) => void;
   private stopConeHandler: () => void;
   private attachImageHandler: (base64: string, name?: string, mimeType?: string) => void;
 
@@ -62,12 +65,14 @@ export class SprinkleBridge {
     fs: VirtualFS,
     lickHandler: (event: LickEvent) => void,
     closeHandler: (name: string) => void,
+    minimizeHandler: (name: string) => void,
     stopConeHandler: () => void,
     attachImageHandler: (base64: string, name?: string, mimeType?: string) => void
   ) {
     this.fs = fs;
     this.lickHandler = lickHandler;
     this.closeHandler = closeHandler;
+    this.minimizeHandler = minimizeHandler;
     this.stopConeHandler = stopConeHandler;
     this.attachImageHandler = attachImageHandler;
   }
@@ -168,6 +173,7 @@ export class SprinkleBridge {
         window.open(url, '_blank');
       },
       close: () => this.closeHandler(sprinkleName),
+      minimize: () => this.minimizeHandler(sprinkleName),
       stopCone: () => this.stopConeHandler(),
       attachImage: (base64: string, name?: string, mimeType?: string) =>
         this.attachImageHandler(base64, name, mimeType),

--- a/packages/webapp/src/ui/sprinkle-follower-controller.ts
+++ b/packages/webapp/src/ui/sprinkle-follower-controller.ts
@@ -426,6 +426,10 @@ export class SprinkleFollowerController {
         window.open(url, '_blank');
       },
       close: () => this.closeLocally(sprinkleName),
+      minimize: () => {
+        // Follower-rendered sprinkles don't have a managed rail — minimize
+        // is a local UI operation on the leader. No-op on the follower side.
+      },
       stopCone: () => {
         // Special-case action that the leader's lick router maps to "abort
         // the cone agent." Matches iOS `SprinkleWebView` `case "stopCone"`.

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -45,6 +45,8 @@ export interface SprinkleManagerCallbacks {
   ): void;
   /** Called to remove a sprinkle from the layout. */
   removeSprinkle(name: string): void;
+  /** Called to collapse the rail content panel without destroying the sprinkle. */
+  minimizeSprinkle(name: string): void;
 }
 
 const OPEN_SPRINKLES_KEY = 'slicc-open-sprinkles';
@@ -146,6 +148,7 @@ export class SprinkleManager {
       fs,
       lickHandler,
       (name) => this.close(name),
+      (name) => this.minimize(name),
       stopConeHandler,
       options.onAttachImage ?? (() => {})
     );
@@ -480,6 +483,17 @@ export class SprinkleManager {
     this.persistOpenSprinkles();
     log.info('Sprinkle closed', { name });
     this.notifyChange();
+  }
+
+  /**
+   * Minimize (collapse) a sprinkle by name. The rail icon stays visible and
+   * the sprinkle remains open/registered — the user can click the icon to
+   * reopen it. No-op if the sprinkle is not open.
+   */
+  minimize(name: string): void {
+    if (!this.openSprinkles.has(name)) return;
+    this.callbacks.minimizeSprinkle(name);
+    log.info('Sprinkle minimized', { name });
   }
 
   /** List available sprinkles. */

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -144,6 +144,8 @@ export class SprinkleRenderer {
         this.bridge.setState(msg.data);
       } else if (msg.type === 'sprinkle-close') {
         this.bridge.close();
+      } else if (msg.type === 'sprinkle-minimize') {
+        this.bridge.minimize();
       } else if (msg.type === 'sprinkle-stop-cone') {
         this.bridge.stopCone();
       } else if (msg.type === 'sprinkle-storage-set') {
@@ -487,6 +489,7 @@ export class SprinkleRenderer {
     setState: function(data) { _state = data; parent.postMessage({ type: 'sprinkle-set-state', data: data }, '*'); },
     getState: function() { return _state; },
     close: function() { parent.postMessage({ type: 'sprinkle-close' }, '*'); },
+    minimize: function() { parent.postMessage({ type: 'sprinkle-minimize' }, '*'); },
     stopCone: function() { parent.postMessage({ type: 'sprinkle-stop-cone' }, '*'); },
     attachImage: function(base64, name, mimeType) { parent.postMessage({ type: 'sprinkle-attach-image', base64: base64, name: name, mimeType: mimeType }, '*'); },
     name: ''
@@ -589,6 +592,8 @@ export class SprinkleRenderer {
         this.bridge.setState(msg.data);
       } else if (msg.type === 'sprinkle-close') {
         this.bridge.close();
+      } else if (msg.type === 'sprinkle-minimize') {
+        this.bridge.minimize();
       } else if (msg.type === 'sprinkle-stop-cone') {
         this.bridge.stopCone();
       } else if (msg.type === 'sprinkle-attach-image') {

--- a/packages/webapp/tests/ui/sprinkle-bridge.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-bridge.test.ts
@@ -9,6 +9,7 @@ describe('SprinkleBridge', () => {
   let lickHandlerMock: ReturnType<typeof vi.fn>;
   let closeHandler: (name: string) => void;
   let closeHandlerMock: ReturnType<typeof vi.fn>;
+  let minimizeHandlerMock: ReturnType<typeof vi.fn>;
   let stopConeHandlerMock: ReturnType<typeof vi.fn>;
   let attachImageHandlerMock: ReturnType<typeof vi.fn>;
   let mockFs: VirtualFS;
@@ -18,6 +19,7 @@ describe('SprinkleBridge', () => {
     lickHandler = lickHandlerMock as unknown as (event: LickEvent) => void;
     closeHandlerMock = vi.fn();
     closeHandler = closeHandlerMock as unknown as (name: string) => void;
+    minimizeHandlerMock = vi.fn();
     stopConeHandlerMock = vi.fn();
     attachImageHandlerMock = vi.fn();
     mockFs = {
@@ -36,6 +38,7 @@ describe('SprinkleBridge', () => {
       mockFs,
       lickHandler,
       closeHandler,
+      minimizeHandlerMock,
       stopConeHandlerMock,
       attachImageHandlerMock
     );
@@ -71,6 +74,12 @@ describe('SprinkleBridge', () => {
     const api = bridge.createAPI('test-sprinkle');
     api.close();
     expect(closeHandlerMock).toHaveBeenCalledWith('test-sprinkle');
+  });
+
+  it('minimize() calls the minimize handler with the sprinkle name', () => {
+    const api = bridge.createAPI('test-sprinkle');
+    api.minimize();
+    expect(minimizeHandlerMock).toHaveBeenCalledWith('test-sprinkle');
   });
 
   it('readFile() delegates to VFS', async () => {

--- a/packages/webapp/tests/ui/sprinkle-manager.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-manager.test.ts
@@ -61,6 +61,7 @@ describe('SprinkleManager', () => {
   let lickHandler: (event: LickEvent) => void;
   let addSprinkle: ReturnType<typeof vi.fn>;
   let removeSprinkle: ReturnType<typeof vi.fn>;
+  let minimizeSprinkle: ReturnType<typeof vi.fn>;
   let mgr: SprinkleManager;
 
   beforeEach(async () => {
@@ -73,6 +74,7 @@ describe('SprinkleManager', () => {
     lickHandler = vi.fn() as unknown as (event: LickEvent) => void;
     addSprinkle = vi.fn();
     removeSprinkle = vi.fn();
+    minimizeSprinkle = vi.fn();
     mgr = new SprinkleManager(
       vfs,
       lickHandler,
@@ -83,6 +85,7 @@ describe('SprinkleManager', () => {
           element: HTMLElement
         ) => void,
         removeSprinkle: removeSprinkle as unknown as (name: string) => void,
+        minimizeSprinkle: minimizeSprinkle as unknown as (name: string) => void,
       },
       vi.fn()
     );
@@ -122,6 +125,22 @@ describe('SprinkleManager', () => {
     expect(() => mgr.sendToSprinkle('unknown', {})).not.toThrow();
   });
 
+  it('minimize() calls the minimizeSprinkle callback when the sprinkle is open', async () => {
+    await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>D</title><div>hi</div>');
+    await mgr.refresh();
+    await mgr.open('dash');
+    minimizeSprinkle.mockClear();
+
+    mgr.minimize('dash');
+
+    expect(minimizeSprinkle).toHaveBeenCalledWith('dash');
+  });
+
+  it('minimize() is a no-op when the sprinkle is not open', () => {
+    mgr.minimize('not-open');
+    expect(minimizeSprinkle).not.toHaveBeenCalled();
+  });
+
   it('sendToSprinkle fires the onSendToSprinkle hook when sprinkle is open (leader broadcast wiring)', async () => {
     // The hook is what `ui/main.ts:mainStandaloneWorker` wires to
     // `pageLeaderTray.sync.broadcastSprinkleUpdate` so followers receive the
@@ -139,6 +158,7 @@ describe('SprinkleManager', () => {
           element: HTMLElement
         ) => void,
         removeSprinkle: removeSprinkle as unknown as (name: string) => void,
+        minimizeSprinkle: minimizeSprinkle as unknown as (name: string) => void,
       },
       vi.fn(),
       { onSendToSprinkle }
@@ -164,6 +184,7 @@ describe('SprinkleManager', () => {
           element: HTMLElement
         ) => void,
         removeSprinkle: removeSprinkle as unknown as (name: string) => void,
+        minimizeSprinkle: minimizeSprinkle as unknown as (name: string) => void,
       },
       vi.fn(),
       { onSendToSprinkle }
@@ -189,6 +210,7 @@ describe('SprinkleManager', () => {
           element: HTMLElement
         ) => void,
         removeSprinkle: removeSprinkle as unknown as (name: string) => void,
+        minimizeSprinkle: minimizeSprinkle as unknown as (name: string) => void,
       },
       vi.fn(),
       { onSendToSprinkle }
@@ -255,6 +277,7 @@ describe('SprinkleManager', () => {
           element: HTMLElement
         ) => void,
         removeSprinkle: removeSprinkle as unknown as (name: string) => void,
+        minimizeSprinkle: minimizeSprinkle as unknown as (name: string) => void,
       },
       vi.fn(),
       { onSendToSprinkle: constructorHook }


### PR DESCRIPTION
## Summary

- Adds `slicc.minimize()` to the sprinkle bridge API — collapses the rail content panel without closing or destroying the sprinkle
- Rail icon stays visible; user can click to reopen
- Non-destructive alternative to `slicc.close()`
- Wired through all rendering paths: inline CLI, full-doc CLI, and extension sandbox

## Changes

- `sprinkle-bridge.ts` — `minimize(): void` added to `SprinkleBridgeAPI` interface and `SprinkleBridge` class
- `sprinkle-manager.ts` — `minimize(name)` method + `minimizeSprinkle` callback in `SprinkleManagerCallbacks`
- `sprinkle-renderer.ts` — `sprinkle-minimize` postMessage handled in all three render paths (sandbox, full-doc, `generateBridgeScript`)
- `sprinkle-sandbox.html` — `window.slicc.minimize` shim, `buildNestedBridgeScript`, and `bridgeTypes` relay updated
- `sprinkle-follower-controller.ts` — no-op implementation (minimize is local leader UI state)
- `layout.ts` + `main.ts` — `minimizeSprinkle()` wired to `primaryRail.collapse()` in both extension and standalone paths
- `SKILL.md` — documented in Bridge API section

## Test plan

- [ ] `npx vitest run packages/webapp/tests/ui/sprinkle-bridge.test.ts packages/webapp/tests/ui/sprinkle-manager.test.ts` — 46 tests pass
- [ ] `npm run typecheck` — no errors
- [ ] Call `slicc.minimize()` from a sprinkle button — panel collapses, icon stays in rail, click icon reopens panel
- [ ] Works in both standalone (CLI) and extension side panel modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)