### PR TITLE
fix(webapp): inline IDB stash in remote-terminal-view to avoid Vite export gap

### DIFF
--- a/packages/webapp/src/kernel/remote-terminal-view.ts
+++ b/packages/webapp/src/kernel/remote-terminal-view.ts
@@ -589,8 +589,7 @@ export class RemoteTerminalView {
         return;
       }
       try {
-        const { storePendingHandle } = await import('../fs/mount-picker-popup.js');
-        await storePendingHandle(localMountIdbKey(target), handle);
+        await stashMountHandle(localMountIdbKey(target), handle);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         this.terminal?.writeln(`mount: failed to stash handle: ${msg}`);
@@ -735,6 +734,37 @@ function parseLocalMountTarget(line: string): string | null {
  */
 export function localMountIdbKey(target: string): string {
   return `pendingMount:term:${target}`;
+}
+
+/**
+ * Write `handle` into the `slicc-pending-mount` IDB store under `idbKey`.
+ *
+ * Inlined here instead of delegating to `mount-picker-popup.ts` because
+ * Vite merges `mount-picker-popup` into the main index chunk but does NOT
+ * re-export `storePendingHandle` from that chunk.  A dynamic import of the
+ * merged chunk therefore resolves to `undefined`, causing "t is not a
+ * function" at the call site.  Inlining the three-line IDB write here keeps
+ * the logic inside the same chunk as its caller and avoids the export gap.
+ */
+async function stashMountHandle(idbKey: string, handle: FileSystemDirectoryHandle): Promise<void> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open('slicc-pending-mount', 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains('handles')) {
+        req.result.createObjectStore('handles');
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  const tx = db.transaction('handles', 'readwrite');
+  tx.objectStore('handles').put(handle, idbKey);
+  await new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error('IDB transaction failed'));
+    tx.onabort = () => reject(tx.error ?? new Error('IDB transaction aborted'));
+  });
+  db.close();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/src/kernel/remote-terminal-view.ts
+++ b/packages/webapp/src/kernel/remote-terminal-view.ts
@@ -42,6 +42,7 @@ import type { FitAddon } from '@xterm/addon-fit';
 import type { OffscreenClient } from '../ui/offscreen-client.js';
 import type { TerminalEventMsg, TerminalSessionId } from '../shell/terminal-protocol.js';
 import { TerminalSessionClient, type TerminalExecResult } from './terminal-session-client.js';
+import { storePendingHandle } from '../fs/mount-picker-popup.js';
 
 export interface RemoteTerminalViewOptions {
   client: OffscreenClient;
@@ -589,7 +590,7 @@ export class RemoteTerminalView {
         return;
       }
       try {
-        await stashMountHandle(localMountIdbKey(target), handle);
+        await storePendingHandle(localMountIdbKey(target), handle);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         this.terminal?.writeln(`mount: failed to stash handle: ${msg}`);
@@ -734,37 +735,6 @@ function parseLocalMountTarget(line: string): string | null {
  */
 export function localMountIdbKey(target: string): string {
   return `pendingMount:term:${target}`;
-}
-
-/**
- * Write `handle` into the `slicc-pending-mount` IDB store under `idbKey`.
- *
- * Inlined here instead of delegating to `mount-picker-popup.ts` because
- * Vite merges `mount-picker-popup` into the main index chunk but does NOT
- * re-export `storePendingHandle` from that chunk.  A dynamic import of the
- * merged chunk therefore resolves to `undefined`, causing "t is not a
- * function" at the call site.  Inlining the three-line IDB write here keeps
- * the logic inside the same chunk as its caller and avoids the export gap.
- */
-async function stashMountHandle(idbKey: string, handle: FileSystemDirectoryHandle): Promise<void> {
-  const db = await new Promise<IDBDatabase>((resolve, reject) => {
-    const req = indexedDB.open('slicc-pending-mount', 1);
-    req.onupgradeneeded = () => {
-      if (!req.result.objectStoreNames.contains('handles')) {
-        req.result.createObjectStore('handles');
-      }
-    };
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-  });
-  const tx = db.transaction('handles', 'readwrite');
-  tx.objectStore('handles').put(handle, idbKey);
-  await new Promise<void>((resolve, reject) => {
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error ?? new Error('IDB transaction failed'));
-    tx.onabort = () => reject(tx.error ?? new Error('IDB transaction aborted'));
-  });
-  db.close();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/tests/kernel/remote-terminal-mount.test.ts
+++ b/packages/webapp/tests/kernel/remote-terminal-mount.test.ts
@@ -8,7 +8,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { localMountIdbKey } from '../../src/kernel/remote-terminal-view.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // `parseLocalMountTarget` is module-internal; re-import via the
 // module's compiled namespace using a back-door eval-style import
@@ -99,5 +104,38 @@ describe('parseLocalMountTarget (spec)', () => {
   it('handles --no-probe and other flags between mount and target', () => {
     // `mount --no-probe /mnt/x` should still be a local-mount target.
     expect(parseLocalMountTarget('mount --no-probe /mnt/x')).toBe('/mnt/x');
+  });
+});
+
+// Regression guard for the `mount: failed to stash handle: t is not a function`
+// crash. Root cause: `remote-terminal-view.ts` used `await import('../fs/mount-picker-popup.js')`
+// to grab `storePendingHandle` at runtime. Vite merges `mount-picker-popup`
+// into the main index chunk because other modules statically import it, but
+// only re-exports the symbols those static importers asked for. Since no
+// static importer asked for `storePendingHandle`, the merged chunk did not
+// re-export it, and the dynamic import resolved the symbol to `undefined`.
+//
+// The fix is to statically import `storePendingHandle` from `mount-picker-popup.js`.
+// This forces Vite's used-exports analysis to keep the symbol on the chunk,
+// regardless of how the chunk gets merged. Don't reintroduce the dynamic
+// import — bundle-shape regressions like this one are invisible to typecheck
+// and to source-level unit tests.
+describe('regression: storePendingHandle import shape', () => {
+  const REMOTE_TERMINAL_VIEW = resolve(__dirname, '../../src/kernel/remote-terminal-view.ts');
+  const src = readFileSync(REMOTE_TERMINAL_VIEW, 'utf8');
+
+  it('imports storePendingHandle statically from mount-picker-popup', () => {
+    // The static import is required so Vite's chunk merger preserves the
+    // symbol's export entry on whichever chunk it lands in.
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bstorePendingHandle\b[^}]*\}\s*from\s*['"]\.\.\/fs\/mount-picker-popup\.js['"]/
+    );
+  });
+
+  it('does not dynamically import mount-picker-popup', () => {
+    // `await import('../fs/mount-picker-popup.js')` is the bug pattern. If a
+    // future caller needs another export from that module, add it to the
+    // static import above instead.
+    expect(src).not.toMatch(/import\s*\(\s*['"][^'"]*mount-picker-popup[^'"]*['"]\s*\)/);
   });
 });


### PR DESCRIPTION
> **EDIT (2026-05-22):** Switched from the inlined IDB helper (commit `5df13ad2`) to a one-line static import of `storePendingHandle` (commit `4eb8b57c`) on review feedback. Same root cause + same mechanism, but the static import forces Vite's used-exports analysis to keep the symbol exported on whichever chunk it lands in, so the IDB write doesn't have to be duplicated in `remote-terminal-view.ts`. Also adds a regression test.
>
> The original commit on this PR was authored with **Claude Sonnet 4.6**, which inlined a 30-line IDB helper and missed the simpler static-import alternative. Review of this PR with **Claude Opus 4.7** flagged the duplication and proposed the smaller fix; that change is in commit `4eb8b57c`. The history below is preserved as originally written.

---

## Summary

Fixes `mount: failed to stash handle: t is not a function` when running
`mount /path` in the panel terminal. The bug affects every installed `slicc`
build (verified in v3.4.2 and v3.5.0). Before this fix the command always
failed; after it the `FileSystemDirectoryHandle` is stashed in IDB and the
kernel worker picks it up normally.

## Why

Vite merges `mount-picker-popup.ts` into the main index chunk because
`main.ts` (and others) statically import it. The merged chunk's ES export list
does **not** include `storePendingHandle`, so
`await import('../fs/mount-picker-popup.js')` at the call site resolves the
symbol to `undefined` — producing `"t is not a function"` the instant the
function is called.

Reproducible in the browser console on any affected build:
```
> const mod = await import('/assets/index-Di6Yhobc.js')
> mod.storePendingHandle   // undefined
```
Vite logs `[INEFFECTIVE_DYNAMIC_IMPORT] src/fs/mount-picker-popup.ts is
dynamically imported … but also statically imported` — it just doesn't error.

## Approach / Implementation notes

- Replaced the two-line dynamic import + call with a call to a new
  module-private `stashMountHandle(idbKey, handle)` function added at the
  bottom of `remote-terminal-view.ts`
  (`packages/webapp/src/kernel/remote-terminal-view.ts:749`).
- The function is intentionally **not exported** — its purpose is to keep the
  IDB write in the same rolldown chunk as its caller, side-stepping the export
  gap.
- The IDB logic is duplicated from `storePendingHandle` in
  `mount-picker-popup.ts`. Both use the same DB name (`slicc-pending-mount`),
  store name (`handles`), and key format (`pendingMount:term:<path>`). If the
  schema ever changes, both sites need updating — the JSDoc calls this out.
- Alternative considered: removing the static imports of `mount-picker-popup.ts`
  from `main.ts` / `tool-ui-renderer.ts` so Vite can truly split the chunk.
  Rejected because those import sites use other exports from the module that are
  legitimately needed at startup, making that refactor larger in scope.

**Update (commit `4eb8b57c`):** the simpler alternative — making the import
*static* in `remote-terminal-view.ts` so Vite's used-exports analysis preserves
`storePendingHandle` on the merged chunk — was overlooked above. That two-line
change replaces the inlined helper. The original notes are kept above for
audit.

## Cross-cutting impact

- **Floats exercised:** CLI (panel terminal `mount` command). Extension float is
  unaffected — extension `mount` uses `chrome.runtime.sendMessage` to the popup
  via `openMountPickerPopup`, not the `RemoteTerminalView` path.
- **Other callers of the changed code:** `RemoteTerminalView.runRemoteWithLocalPicker()`
  is the only caller of the removed dynamic import.
- **IDB state:** same DB, store, key, and value shape. No migration needed. The
  kernel worker's `tryAdoptPrePickedHandle` in `mount-commands.ts` reads the
  handle under the same key and is untouched.

## Test plan

- [x] `npx prettier --write packages/webapp/src/kernel/remote-terminal-view.ts`
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 5161 passing, no new failures (was 5159 before regression test added)
- [x] `npm run build -w @slicc/webapp` — clean build; `INEFFECTIVE_DYNAMIC_IMPORT`
  warning for `mount-picker-popup.ts` is now gone (the dynamic import was the
  cause of that warning)
- [x] Existing unit tests pass:
  - `npx vitest run packages/webapp/tests/kernel/remote-terminal-mount.test.ts` — 13 tests including 2 new regression guards
  - `npx vitest run packages/webapp/tests/fs/mount-picker-popup.test.ts`
- [x] Regression test added: `remote-terminal-mount.test.ts` asserts the source
  file (a) statically imports `storePendingHandle` from `mount-picker-popup.js`
  and (b) does **not** dynamically import `mount-picker-popup`. Verified the
  test fails when reverted to the inlined approach (1 of 13 fails on commit
  `5df13ad2`'s source).
- [x] Manual smoke (CLI): loaded `localhost:5730` with the static-import build;
  confirmed `remote-terminal-view-5vXS6o6g.js` chunk imports
  `storePendingHandle` from `index-DIN09Wqb.js` and the symbol resolves to a
  real function (`typeof J === 'function'`)

**Pre-existing failures:** 20 failures in `lick-ws-bridge.test.ts` (6) and
`websocat-command.test.ts` (14) — `CloseEvent is not defined` in the Node test
environment. Reproduce on `main` at `777ffa94`, unrelated to this PR.

## Documentation

- [x] No documentation changes needed

## Risk & rollback

- Blast radius limited to `RemoteTerminalView` (CLI panel terminal `mount`
  command). Kernel worker and extension mount path are untouched.
- Clean revert — no IDB schema change, no persisted state migration.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths