### PR TITLE
fix(upksill): Update upskill to fallback when zip repo cannot be found.

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -1047,7 +1047,6 @@ async function resolveTesslRef(
 
 type ZipResult =
   | { status: 'ok'; files: Record<string, Uint8Array> }
-  | { status: 'not_found' }
   | { status: 'error'; message: string };
 
 /**
@@ -1068,7 +1067,7 @@ async function fetchRepoZip(
     if (branch === 'main') {
       return fetchRepoZip(owner, repo, fetch, 'master');
     }
-    return { status: 'not_found' };
+    return { status: 'error', message: 'codeload returned HTTP 404' };
   }
   if (response.status !== 200) {
     return { status: 'error', message: `codeload returned HTTP ${response.status}` };
@@ -1133,12 +1132,6 @@ async function listGitHubSkills(
         }
       }
       return { skills };
-    }
-    if (zip.status === 'not_found') {
-      const target = branch
-        ? `branch "${branch}" in ${owner}/${repo}`
-        : `repository ${owner}/${repo}`;
-      return { skills: [], error: `${target} not found` };
     }
     // zip.status === 'error' — fall through to API
   }
@@ -1214,16 +1207,6 @@ async function installFromGitHub(
     // Try ZIP-based install first (no rate limit)
     if (fetch) {
       const zip = await fetchRepoZip(owner, repo, fetch, branch);
-      if (zip.status === 'not_found') {
-        const target = branch
-          ? `branch "${branch}" in ${owner}/${repo}`
-          : `repository ${owner}/${repo}`;
-        return {
-          stdout: '',
-          stderr: `upskill: ${target} not found\n`,
-          exitCode: 1,
-        };
-      }
       if (zip.status === 'ok') {
         const files = stripZipPrefix(zip.files);
         const prefix = skillPath.replace(/^\/|\/$/g, '') + '/';
@@ -1623,26 +1606,68 @@ export async function installRecommendedSkills(
     Array.from(repoGroups.entries()).map(async ([repoKey, recs]) => {
       const [owner, repo] = repoKey.split('/');
       const zip = await fetchRepoZip(owner, repo, fetchFn);
-      if (zip.status === 'not_found' || zip.status === 'error') {
-        const errMsg =
-          zip.status === 'not_found'
-            ? `upskill: repository ${repoKey} not found`
-            : `upskill: failed to fetch ${repoKey}: ${zip.message}`;
+      if (zip.status === 'error') {
+        // ZIP unavailable — fall back to Contents API per skill/bundle
+        const github = await createGitHubRequestContext(fetchFn);
         const results: Array<{ ok: boolean; name: string; error?: string }> = [];
         for (const rec of recs) {
+          const src = rec.entry.source;
           completedSkills++;
           const eta =
             completedSkills < totalSkills
               ? ` (~${Math.round(((totalSkills - completedSkills) * (Date.now() - startTime)) / completedSkills / 1000)}s remaining)`
               : '';
-          output += `[${completedSkills}/${totalSkills}] Failed "${rec.entry.name}" from ${repoKey}: repo fetch failed${eta}\n`;
-          results.push({
-            ok: false,
-            name: rec.entry.name,
-            error: `repo fetch failed for ${repoKey}`,
-          });
+          if (src.installAll && src.path) {
+            const listResult = await listGitHubSkills(owner, repo, github, src.path);
+            if (listResult.error) {
+              results.push({ ok: false, name: rec.entry.name, error: listResult.error });
+              output += `[${completedSkills}/${totalSkills}] Failed "${rec.entry.name}" bundle from ${repoKey}: ${listResult.error}${eta}\n`;
+              continue;
+            }
+            const bundleStart = Date.now();
+            let bundleSuccess = 0;
+            let bundleFailed = 0;
+            for (const skill of listResult.skills) {
+              if (installed.has(skill.name)) continue;
+              const r = await installFromGitHub(
+                owner,
+                repo,
+                skill.path,
+                skill.name,
+                fs,
+                github,
+                false
+              );
+              if (r.exitCode === 0) {
+                results.push({ ok: true, name: skill.name });
+                bundleSuccess++;
+              } else {
+                results.push({ ok: false, name: skill.name, error: r.stderr.trim() });
+                bundleFailed++;
+              }
+            }
+            const bundleDuration = ((Date.now() - bundleStart) / 1000).toFixed(1);
+            if (bundleSuccess === 0 && bundleFailed === 0) {
+              output += `[${completedSkills}/${totalSkills}] Skipped "${rec.entry.name}" bundle from ${repoKey}: all sub-skills already installed${eta}\n`;
+            } else if (bundleFailed === 0) {
+              output += `[${completedSkills}/${totalSkills}] Installed "${rec.entry.name}" bundle (${bundleSuccess} skill(s)) from ${repoKey} (${bundleDuration}s)${eta}\n`;
+            } else {
+              output += `[${completedSkills}/${totalSkills}] Installed "${rec.entry.name}" bundle (${bundleSuccess}/${bundleSuccess + bundleFailed} skill(s)) from ${repoKey} (${bundleDuration}s)${eta}\n`;
+            }
+            continue;
+          }
+          const skillPath = src.path ? src.path.replace(/^\/|\/$/g, '') : rec.entry.name;
+          const skillName = src.skill || rec.entry.name;
+          const r = await installFromGitHub(owner, repo, skillPath, skillName, fs, github, false);
+          if (r.exitCode === 0) {
+            output += `[${completedSkills}/${totalSkills}] Installed "${skillName}" from ${repoKey}${eta}\n`;
+            results.push({ ok: true, name: skillName });
+          } else {
+            output += `[${completedSkills}/${totalSkills}] Failed "${skillName}" from ${repoKey}: ${r.stderr.trim()}${eta}\n`;
+            results.push({ ok: false, name: skillName, error: r.stderr.trim() });
+          }
         }
-        return { errors: [errMsg], results };
+        return { errors: [], results };
       }
 
       const files = stripZipPrefix(zip.files);
@@ -2464,37 +2489,54 @@ export function createUpskillCommand(
       // For batch installs (--all or multiple --skill), use ZIP and skip per-skill hooks
       if (totalSkills > 1) {
         const zip = await fetchRepoZip(owner, repo, fetchFn, effectiveBranch);
-        if (zip.status === 'not_found') {
-          const target = effectiveBranch
-            ? `branch "${effectiveBranch}" in ${owner}/${repo}`
-            : `repository ${owner}/${repo}`;
-          return { stdout: '', stderr: `upskill: ${target} not found\n`, exitCode: 1 };
-        }
-        if (zip.status === 'error') {
-          return {
-            stdout: '',
-            stderr: `upskill: failed to fetch ${owner}/${repo}: ${zip.message}\n`,
-            exitCode: 1,
-          };
-        }
+        if (zip.status === 'ok') {
+          const files = stripZipPrefix(zip.files);
 
-        const files = stripZipPrefix(zip.files);
+          for (let si = 0; si < skillsToInstall.length; si++) {
+            const skill = skillsToInstall[si];
+            const result = await installSkillFromZip(skill.path, skill.name, files, fs, force);
+            const idx = si + 1;
+            const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+            const avgTime = (Date.now() - startTime) / idx;
+            const remaining = Math.round(((totalSkills - idx) * avgTime) / 1000);
+            const eta = idx < totalSkills ? ` (~${remaining}s remaining)` : '';
 
-        for (let si = 0; si < skillsToInstall.length; si++) {
-          const skill = skillsToInstall[si];
-          const result = await installSkillFromZip(skill.path, skill.name, files, fs, force);
-          const idx = si + 1;
-          const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-          const avgTime = (Date.now() - startTime) / idx;
-          const remaining = Math.round(((totalSkills - idx) * avgTime) / 1000);
-          const eta = idx < totalSkills ? ` (~${remaining}s remaining)` : '';
+            if (result.ok) {
+              output += `[${idx}/${totalSkills}] Installed "${skill.name}" from ${owner}/${repo} (${elapsed}s)${eta}\n`;
+              successCount++;
+            } else {
+              output += `[${idx}/${totalSkills}] Failed "${skill.name}": ${result.error}${eta}\n`;
+              errors += `upskill: ${result.error}\n`;
+            }
+          }
+        } else {
+          // ZIP unavailable — fall back to Contents API per skill
+          for (let si = 0; si < skillsToInstall.length; si++) {
+            const skill = skillsToInstall[si];
+            const installResult = await installFromGitHub(
+              owner,
+              repo,
+              skill.path,
+              skill.name,
+              fs,
+              github,
+              force,
+              undefined,
+              effectiveBranch
+            );
+            const idx = si + 1;
+            const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+            const avgTime = (Date.now() - startTime) / idx;
+            const remaining = Math.round(((totalSkills - idx) * avgTime) / 1000);
+            const eta = idx < totalSkills ? ` (~${remaining}s remaining)` : '';
 
-          if (result.ok) {
-            output += `[${idx}/${totalSkills}] Installed "${skill.name}" from ${owner}/${repo} (${elapsed}s)${eta}\n`;
-            successCount++;
-          } else {
-            output += `[${idx}/${totalSkills}] Failed "${skill.name}": ${result.error}${eta}\n`;
-            errors += `upskill: ${result.error}\n`;
+            if (installResult.exitCode === 0) {
+              output += `[${idx}/${totalSkills}] Installed "${skill.name}" from ${owner}/${repo} (${elapsed}s)${eta}\n`;
+              successCount++;
+            } else {
+              output += `[${idx}/${totalSkills}] Failed "${skill.name}": ${installResult.stderr.trim()}${eta}\n`;
+              errors += installResult.stderr;
+            }
           }
         }
       } else {

--- a/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
@@ -680,6 +680,138 @@ describe('upskill Tessl registry integration', () => {
 
     delete (globalThis as Record<string, unknown>).__slicc_reloadSkills;
   });
+
+  it('falls back to Contents API when codeload returns 404 on --list', async () => {
+    const globalFs = await VirtualFS.create({ dbName: 'slicc-fs-global' });
+    await globalFs.writeFile('/workspace/.git/github-token', 'ghp_test_token');
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('codeload.github.com')) return response(404, '', {}, 'Not Found');
+      if (url.endsWith('/contents/'))
+        return response(
+          200,
+          JSON.stringify([{ name: 'private-skill', path: 'private-skill', type: 'dir' }])
+        );
+      if (url.includes('/contents/private-skill'))
+        return response(
+          200,
+          JSON.stringify([
+            {
+              name: 'SKILL.md',
+              path: 'private-skill/SKILL.md',
+              type: 'file',
+              download_url:
+                'https://raw.githubusercontent.com/org/private-repo/main/private-skill/SKILL.md',
+            },
+          ])
+        );
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['org/private-repo', '--list'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('private-skill');
+  });
+
+  it('falls back to Contents API when codeload returns 404 for a single skill install', async () => {
+    const globalFs = await VirtualFS.create({ dbName: 'slicc-fs-global' });
+    await globalFs.writeFile('/workspace/.git/github-token', 'ghp_test_token');
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('codeload.github.com')) return response(404, '', {}, 'Not Found');
+      if (url.endsWith('/contents/'))
+        return response(
+          200,
+          JSON.stringify([{ name: 'private-skill', path: 'private-skill', type: 'dir' }])
+        );
+      if (url.includes('/contents/private-skill'))
+        return response(
+          200,
+          JSON.stringify([
+            {
+              name: 'SKILL.md',
+              path: 'private-skill/SKILL.md',
+              type: 'file',
+              download_url:
+                'https://raw.githubusercontent.com/org/private-repo/main/private-skill/SKILL.md',
+            },
+          ])
+        );
+      if (url.endsWith('/private-skill/SKILL.md')) return response(200, '# Private Skill\n');
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(
+      ['org/private-repo', '--skill', 'private-skill'],
+      createMockCtx() as any
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Installed skill "private-skill"');
+    await expect(fs.readTextFile('/workspace/skills/private-skill/SKILL.md')).resolves.toContain(
+      '# Private Skill'
+    );
+  });
+
+  it('falls back to Contents API when codeload returns 404 for --all multi-skill install', async () => {
+    const globalFs = await VirtualFS.create({ dbName: 'slicc-fs-global' });
+    await globalFs.writeFile('/workspace/.git/github-token', 'ghp_test_token');
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('codeload.github.com')) return response(404, '', {}, 'Not Found');
+      if (url.endsWith('/contents/'))
+        return response(
+          200,
+          JSON.stringify([
+            { name: 'skill-a', path: 'skill-a', type: 'dir' },
+            { name: 'skill-b', path: 'skill-b', type: 'dir' },
+          ])
+        );
+      if (url.includes('/contents/skill-a'))
+        return response(
+          200,
+          JSON.stringify([
+            {
+              name: 'SKILL.md',
+              path: 'skill-a/SKILL.md',
+              type: 'file',
+              download_url:
+                'https://raw.githubusercontent.com/org/private-repo/main/skill-a/SKILL.md',
+            },
+          ])
+        );
+      if (url.includes('/contents/skill-b'))
+        return response(
+          200,
+          JSON.stringify([
+            {
+              name: 'SKILL.md',
+              path: 'skill-b/SKILL.md',
+              type: 'file',
+              download_url:
+                'https://raw.githubusercontent.com/org/private-repo/main/skill-b/SKILL.md',
+            },
+          ])
+        );
+      if (url.endsWith('/skill-a/SKILL.md')) return response(200, '# Skill A\n');
+      if (url.endsWith('/skill-b/SKILL.md')) return response(200, '# Skill B\n');
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['org/private-repo', '--all'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    await expect(fs.readTextFile('/workspace/skills/skill-a/SKILL.md')).resolves.toContain(
+      '# Skill A'
+    );
+    await expect(fs.readTextFile('/workspace/skills/skill-b/SKILL.md')).resolves.toContain(
+      '# Skill B'
+    );
+  });
 });
 
 describe('scoreSkills', () => {
@@ -1311,6 +1443,166 @@ describe('installRecommendedSkills helper (no-shell entry point)', () => {
     // The pre-existing companion was left untouched.
     await expect(fs.readTextFile('/workspace/skills/migrate-block/SKILL.md')).resolves.toContain(
       'pre-existing'
+    );
+  });
+
+  it('falls back to Contents API when codeload returns 404 for a recommended skill', async () => {
+    await fs.mkdir('/home/test', { recursive: true });
+    await fs.writeFile(
+      '/home/test/.welcome.json',
+      JSON.stringify({
+        purpose: 'work',
+        role: 'developer',
+        tasks: ['build-websites'],
+        apps: ['aem'],
+        name: 'Test',
+      })
+    );
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/skills/catalog.json')) {
+        return response(
+          200,
+          JSON.stringify({
+            data: [
+              {
+                name: 'aem',
+                displayName: 'AEM',
+                description: 'AEM skill',
+                repo: 'adobe/skills',
+                path: 'skills/aem',
+                skill: 'aem',
+                apps: 'aem',
+                tasks: 'build-websites',
+                role: 'developer',
+                purpose: 'work',
+                boost: '',
+              },
+            ],
+          })
+        );
+      }
+      if (url.includes('codeload.github.com')) return response(404, '', {}, 'Not Found');
+      if (url.includes('/repos/adobe/skills/contents/skills/aem')) {
+        return response(
+          200,
+          JSON.stringify([
+            {
+              name: 'SKILL.md',
+              path: 'skills/aem/SKILL.md',
+              type: 'file',
+              download_url:
+                'https://raw.githubusercontent.com/adobe/skills/main/skills/aem/SKILL.md',
+            },
+          ])
+        );
+      }
+      if (url.endsWith('/skills/aem/SKILL.md')) {
+        return response(200, '---\nname: aem\n---\n# AEM\n');
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const result = await installRecommendedSkills(fs, fetchMock as unknown as SecureFetch);
+    expect(result.skipped).toBeNull();
+    expect(result.errors).toEqual([]);
+    expect(result.installedNames).toEqual(['aem']);
+    await expect(fs.readTextFile('/workspace/skills/aem/SKILL.md')).resolves.toContain('# AEM');
+  });
+
+  it('falls back to Contents API when codeload returns 404 for a recommended installAll bundle', async () => {
+    await fs.mkdir('/home/test', { recursive: true });
+    await fs.writeFile(
+      '/home/test/.welcome.json',
+      JSON.stringify({
+        purpose: 'work',
+        role: 'developer',
+        tasks: ['build-websites'],
+        apps: ['aem'],
+        name: 'Test',
+      })
+    );
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/skills/catalog.json')) {
+        return response(
+          200,
+          JSON.stringify({
+            data: [
+              {
+                name: 'migrate-page',
+                displayName: 'AEM Page Import',
+                description: 'Migration bundle',
+                repo: 'aemcoder/skills',
+                path: 'skills/migration/',
+                skill: 'migrate-page',
+                apps: 'aem',
+                tasks: 'build-websites',
+                role: 'developer',
+                purpose: 'work',
+                boost: '',
+                installAll: 'true',
+              },
+            ],
+          })
+        );
+      }
+      if (url.includes('codeload.github.com')) return response(404, '', {}, 'Not Found');
+      if (url.includes('/repos/aemcoder/skills/contents/skills/migration/migrate-page')) {
+        return response(
+          200,
+          JSON.stringify([
+            {
+              name: 'SKILL.md',
+              path: 'skills/migration/migrate-page/SKILL.md',
+              type: 'file',
+              download_url:
+                'https://raw.githubusercontent.com/aemcoder/skills/main/skills/migration/migrate-page/SKILL.md',
+            },
+          ])
+        );
+      }
+      if (url.includes('/repos/aemcoder/skills/contents/skills/migration/migrate-header')) {
+        return response(
+          200,
+          JSON.stringify([
+            {
+              name: 'SKILL.md',
+              path: 'skills/migration/migrate-header/SKILL.md',
+              type: 'file',
+              download_url:
+                'https://raw.githubusercontent.com/aemcoder/skills/main/skills/migration/migrate-header/SKILL.md',
+            },
+          ])
+        );
+      }
+      if (url.includes('/repos/aemcoder/skills/contents/skills/migration')) {
+        return response(
+          200,
+          JSON.stringify([
+            { name: 'migrate-page', path: 'skills/migration/migrate-page', type: 'dir' },
+            { name: 'migrate-header', path: 'skills/migration/migrate-header', type: 'dir' },
+          ])
+        );
+      }
+      if (url.endsWith('/skills/migration/migrate-page/SKILL.md')) {
+        return response(200, '---\nname: migrate-page\n---\n# Migrate Page\n');
+      }
+      if (url.endsWith('/skills/migration/migrate-header/SKILL.md')) {
+        return response(200, '---\nname: migrate-header\n---\n# Migrate Header\n');
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const result = await installRecommendedSkills(fs, fetchMock as unknown as SecureFetch);
+    expect(result.skipped).toBeNull();
+    expect(result.errors).toEqual([]);
+    expect(result.installedNames.sort()).toEqual(['migrate-header', 'migrate-page']);
+    await expect(fs.readTextFile('/workspace/skills/migrate-page/SKILL.md')).resolves.toContain(
+      '# Migrate Page'
+    );
+    await expect(fs.readTextFile('/workspace/skills/migrate-header/SKILL.md')).resolves.toContain(
+      '# Migrate Header'
     );
   });
 });


### PR DESCRIPTION
Fixes: #745 

## Summary
  
  `upskill <org>/<repo>` silently failed for private GitHub repos and GHEC instances. Before this PR, users saw no skill installed and no useful error — the command just returned nothing. After this PR, `upskill` falls back to the authenticated GitHub Contents API (same path already used for rate-limited anonymous requests) and installs the skill normally.

## Why

`codeload.github.com` serves ZIP archives for public github.com repos only. For private repos and GHEC, it returns HTTP 404; not because the repo doesn't exist, but because codeload simply can't serve it. The code treated that 404 as definitive "repo not found" and returned early, never reaching the Contents API fallback already wired for other failure modes.
  
**Repro:**

  1. `upskill org/private-repo` (private repo, PAT configured via `git config github.token`)
  2. Expected: skill installed from Contents API
  3. Actual: silent failure, exit 0, no skill written to disk

## Approach / Implementation notes

The fix is conceptually small: codeload 404 and codeload error are the same signal ("can't get a ZIP, try the API"). Collapsing `not_found` into `error` in `ZipResult` makes that explicit and lets the existing Contents API fallbacks handle both cases without new branching.

The two batch paths (`--all` and `installRecommendedSkills`) needed separate attention because they download one ZIP for N skills. The single-skill path already had a working fallback; the batch paths were bailing out before reaching it. The new fallback in each calls `installFromGitHub` with no `fetch` argument to skip a redundant codeload attempt that would just fail again.
  
One decision worth flagging: the `installRecommendedSkills` fallback for `installAll` bundles calls `listGitHubSkills` to discover skills before installing them. This is an extra round-trip compared to the ZIP path, but it's the only way to enumerate bundle contents via the Contents API. The alternative (caching the discovery result from the earlier `listGitHubSkills` call) would require threading state across the two phases and isn't worth the complexity for what should be an uncommon fallback.
  
Auth to codeload was not added intentionally; I did not want to change the that API call to include authentication. Additionally, GHEC repos do not support codeload, so they still would result in a 404 response.

## Cross-cutting impact
  
  - **Floats exercised:** applies equally to CLI, extension, and Electron. No float-specific code paths changed.
  - **Shell contexts:** `upskill` runs in the agent's `WasmShell` only. Side-panel shell untouched.
  - **Other callers of `ZipResult`:** the type is module-private. All consumers are in the same file and updated.
  - **Auth / rate limits:** the new fallback paths call `createGitHubRequestContext` identically to the existing single-skill path. No new token handling.
  - **Persisted state:** no IndexedDB, localStorage, or ledger writes. Skills land in VFS under `/workspace/skills/` same as before.

  ## Test plan

  - [x] `npx prettier --write packages/webapp/src/shell/supplemental-commands/upskill-command.ts packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts`
  - [x] `npm run typecheck` — clean
  - [x] `npm run test` — 5208 passing, 3 skipped (pre-existing), no new failures
  - [x] **New behavior covered by unit tests** — 5 new tests in `packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts`, written red-first before any production
   changes:

    | # | Test |
    |---|------|
    | 1 | `--list` falls back to Contents API when codeload returns 404 |
    | 2 | Single skill install falls back to Contents API when codeload returns 404 |
    | 3 | `--all` multi-skill install falls back to Contents API when codeload returns 404 |
    | 4 | `installRecommendedSkills` single skill falls back when codeload returns 404 |
    | 5 | `installRecommendedSkills` `installAll` bundle falls back when codeload returns 404 |

  - [ ] `npm run build` / `npm run build -w @slicc/chrome-extension` — N/A, no build output depends on this module's types at runtime
  - [ ] Manual smoke — N/A; requires a private repo. Covered by unit tests which mock the full codeload 404 + Contents API round-trip.

  **Pre-existing failures:** none known against `main`.

  ## Documentation
  
  - [x] No documentation changes needed — silent bug fix, documented behavior unchanged.

  ## Risk & rollback

  - **Blast radius:** `upskill` only. No other command or subsystem calls `fetchRepoZip` or `installFromGitHub`.
  - **Rollback:** clean revert, no persisted state migration.
  - **What CI can't catch:** a real private repo or GHEC instance. The new tests mock codeload and the Contents API; a real-repo smoke test against a private repo would confirm end-to-end.

  ## Checklist
  
  - [x] Commits are focused and package-local where possible
  - [x] No hand-edited files under `dist/`
  - [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
  - [x] No public API / tool / shell-command / lick-channel changes
  - [x] No contracts used by other floats changed