### PR TITLE
fix(adobe): allow AEM admin hostnames for Adobe OAuth tokens

### DIFF
--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -242,6 +242,10 @@ export const config: ProviderConfig = {
     '*.adobelogin.com',
     '*.adobe.io',
     'firefall.adobe.io',
+    'admin.hlx.page',
+    'admin.hlx.live',
+    'admin.aem.page',
+    'admin.aem.live',
   ],
 
   getModelIds: () => {

--- a/packages/webapp/tests/providers/oauth-config.test.ts
+++ b/packages/webapp/tests/providers/oauth-config.test.ts
@@ -10,5 +10,9 @@ describe('OAuth provider domain config', () => {
   });
   it('adobe provider has IMS hosts', () => {
     expect(adobeProvider.oauthTokenDomains?.length).toBeGreaterThan(0);
+    expect(adobeProvider.oauthTokenDomains).toContain('admin.hlx.page');
+    expect(adobeProvider.oauthTokenDomains).toContain('admin.hlx.live');
+    expect(adobeProvider.oauthTokenDomains).toContain('admin.aem.page');
+    expect(adobeProvider.oauthTokenDomains).toContain('admin.aem.live');
   });
 });


### PR DESCRIPTION
## Summary

Adds the four AEM Edge Delivery Services admin hostnames to the Adobe provider's default `oauthTokenDomains` so an Adobe IMS bearer token can be sent to the AEM admin API out of the box, without requiring a per-user `oauth-domain add`.

- `admin.hlx.page`
- `admin.hlx.live`
- `admin.aem.page`
- `admin.aem.live`

## Problem

Running `oauth-token adobe` and piping the token into `curl https://admin.hlx.page/...` failed with:

```
Secret oauth.adobe.token is not allowed for domain admin.hlx.page
```

The AEM admin API authenticates with Adobe IMS tokens, but the Adobe provider's hardcoded allowlist in `packages/webapp/providers/adobe.ts` only covered IMS (`*.adobelogin.com`), `*.adobe.io`, and `firefall.adobe.io`. The secrets pipeline (`packages/shared-ts/src/secrets-pipeline.ts` → `matchesDomains`) correctly rejected the unmask, surfaced by the CLI fetch-proxy at `packages/node-server/src/index.ts:1273` (and mirrored in the extension/Swift proxies).

Users can work around it with `oauth-domain add adobe admin.hlx.page` + reload, but for a first-party Adobe service this should be a default.

## Changes

- `packages/webapp/providers/adobe.ts` — append the four `admin.{hlx,aem}.{page,live}` hostnames to `config.oauthTokenDomains`. Original five entries unchanged.
- `packages/webapp/tests/providers/oauth-config.test.ts` — add four `.toContain` assertions matching the github-provider style so the new hostnames can't be silently dropped.

## Out of scope

- No broader wildcards (`*.hlx.page` etc.) — those are content URLs, not bearer-token endpoints.
- No `admin.da.live` — Document Authoring has its own auth path and remains the canonical example for the user-side `oauth-domain add` workflow.
- No changes to the secrets pipeline or `oauth-domain` command (working as designed).

## Verification

```
npx prettier --check packages/webapp/providers/adobe.ts packages/webapp/tests/providers/oauth-config.test.ts
npm run typecheck
npx vitest run packages/webapp/tests/providers/oauth-config.test.ts
```

All three pass locally (vitest: 2/2).

## Rollback

Revert this commit. The new entries are additive; reverting only re-tightens the default back to IMS/Firefall, and affected users can layer the hostnames back via `oauth-domain add`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author