### PR TITLE
fix(compaction): short-circuit hopeless contexts with elision

### DIFF
--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -96,6 +96,14 @@ export interface CompactionConfig {
   reserveTokens?: number;
   keepRecentTokens?: number;
   /**
+   * Multiplier of `contextWindow` above which compaction is treated as
+   * hopeless: the LLM summary call is skipped entirely because passing
+   * the conversation as a prompt would itself blow context. Oversized
+   * tool results / assistant tool-call payloads are elided in-place
+   * before any naive drop. Defaults to 4.
+   */
+  hopelessMultiplier?: number;
+  /**
    * HTTP headers forwarded to the LLM provider for the summarization and
    * memory-extraction requests. Used by the Adobe LLM proxy path to attach
    * `X-Session-Id` so compaction calls land in the same session as the
@@ -295,6 +303,100 @@ async function runCompactionCall(
     .trim();
 }
 
+/** Default `hopelessMultiplier`. */
+const DEFAULT_HOPELESS_MULTIPLIER = 4;
+
+/**
+ * Approximate the byte size of a message's content for the hopeless-branch
+ * stub. Mirrors `extractText` but counts characters across text, thinking,
+ * tool-call argument JSON, and inline image base64 so the reported KB is a
+ * realistic estimate of what the elision dropped.
+ */
+function approxContentBytes(content: unknown): number {
+  if (typeof content === 'string') return content.length;
+  if (!Array.isArray(content)) return 0;
+  let total = 0;
+  for (const block of content) {
+    const b = block as {
+      type?: string;
+      text?: string;
+      thinking?: string;
+      arguments?: unknown;
+      source?: { data?: string };
+    };
+    if (b.type === 'text' && b.text) total += b.text.length;
+    else if (b.type === 'thinking' && b.thinking) total += b.thinking.length;
+    else if (b.type === 'toolCall' && b.arguments !== undefined) {
+      try {
+        total += JSON.stringify(b.arguments).length;
+      } catch {
+        // unserializable arguments — best-effort, skip
+      }
+    } else if (b.type === 'image' && b.source?.data) total += b.source.data.length;
+  }
+  return total;
+}
+
+function buildElisionStub(approxBytes: number): string {
+  const kb = Math.max(1, Math.round(approxBytes / 1024));
+  return `[Tool result elided: ${kb} KB, exceeds half the context window. Re-run with smaller arguments — e.g. open --view --size low.]`;
+}
+
+/**
+ * In the hopeless branch, replace the content of any single `toolResult`
+ * (or assistant message carrying tool calls) whose estimated tokens exceed
+ * `(contextWindow - reserveTokens) / 2` with a short stub.
+ *
+ * - Message ordering, role, `toolCallId`, and `toolName` are preserved.
+ * - For assistant messages, `toolCall` content blocks are kept intact so
+ *   the agent loop's tool-call/tool-result pairing stays valid.
+ */
+function elideHopelessMessages(
+  messages: AgentMessage[],
+  contextWindow: number,
+  reserveTokens: number
+): { messages: AgentMessage[]; elidedCount: number; elidedBytes: number } {
+  const perMessageThreshold = (contextWindow - reserveTokens) / 2;
+  let elidedCount = 0;
+  let elidedBytes = 0;
+
+  const out = messages.map((msg) => {
+    const tokens = estimateTokens(msg);
+    if (tokens <= perMessageThreshold) return msg;
+    const role = (msg as { role: string }).role;
+    if (role !== 'toolResult' && role !== 'assistant') return msg;
+
+    const m = msg as { content?: unknown };
+    const bytes = approxContentBytes(m.content);
+    const stub = buildElisionStub(bytes);
+
+    if (role === 'toolResult') {
+      elidedCount++;
+      elidedBytes += bytes;
+      return {
+        ...(msg as object),
+        content: [{ type: 'text', text: stub }],
+      } as AgentMessage;
+    }
+
+    // Assistant: drop text/thinking/image blocks but keep `toolCall`
+    // blocks so the following `toolResult` messages still have a
+    // matching `id` to pair against.
+    const content = Array.isArray(m.content) ? m.content : [];
+    const toolCalls = content.filter(
+      (b) => (b as { type?: string }).type === 'toolCall'
+    ) as unknown[];
+    elidedCount++;
+    elidedBytes += bytes;
+    return {
+      ...(msg as object),
+      content: [{ type: 'text', text: stub }, ...toolCalls],
+    } as AgentMessage;
+  });
+
+  return { messages: out, elidedCount, elidedBytes };
+}
+
 /**
  * Create a transformContext function that uses LLM summarization for compaction.
  *
@@ -315,6 +417,7 @@ export function createCompactContext(
   const contextWindow = config.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
   const reserveTokens = config.reserveTokens ?? DEFAULT_COMPACTION_SETTINGS.reserveTokens;
   const keepRecentTokens = config.keepRecentTokens ?? DEFAULT_COMPACTION_SETTINGS.keepRecentTokens;
+  const hopelessMultiplier = config.hopelessMultiplier ?? DEFAULT_HOPELESS_MULTIPLIER;
 
   const settings = { enabled: true, reserveTokens, keepRecentTokens };
 
@@ -332,19 +435,52 @@ export function createCompactContext(
       return messages;
     }
 
+    // Hopeless branch — total context so far beyond the window that
+    // serializing the conversation into a summary prompt would itself
+    // blow context. Elide oversized tool results / assistant tool-call
+    // payloads in-place, skip the LLM call entirely, and let the naive
+    // drop path handle anything still over the soft threshold.
+    let workingMessages = messages;
+    let isHopeless = false;
+    if (totalTokens > contextWindow * hopelessMultiplier) {
+      isHopeless = true;
+      const elision = elideHopelessMessages(messages, contextWindow, reserveTokens);
+      workingMessages = elision.messages;
+      log.warn('Compaction hopeless branch', {
+        totalTokens,
+        contextWindow,
+        multiplier: hopelessMultiplier,
+        elidedCount: elision.elidedCount,
+        elidedBytes: elision.elidedBytes,
+      });
+
+      // Recompute total tokens against the elided message list. If we
+      // are back under the soft threshold, return immediately — no
+      // LLM call, no naive drop.
+      let postTokens = 0;
+      for (const msg of workingMessages) {
+        postTokens += estimateTokens(msg);
+      }
+      if (!shouldCompact(postTokens, contextWindow, settings)) {
+        return workingMessages;
+      }
+      // Else fall through to the naive-drop path with the elided
+      // messages — the LLM block below is skipped via `isHopeless`.
+    }
+
     log.info('Context compaction triggered', {
       totalTokens,
       contextWindow,
       threshold: contextWindow - reserveTokens,
-      messageCount: messages.length,
+      messageCount: workingMessages.length,
     });
 
     // Find cut point: walk backward from end to keep ~keepRecentTokens
     let keptTokens = 0;
-    let cutIndex = messages.length;
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msgTokens = estimateTokens(messages[i]);
-      if (keptTokens + msgTokens > keepRecentTokens && cutIndex < messages.length) {
+    let cutIndex = workingMessages.length;
+    for (let i = workingMessages.length - 1; i >= 0; i--) {
+      const msgTokens = estimateTokens(workingMessages[i]);
+      if (keptTokens + msgTokens > keepRecentTokens && cutIndex < workingMessages.length) {
         break;
       }
       keptTokens += msgTokens;
@@ -353,18 +489,18 @@ export function createCompactContext(
 
     // Don't split assistant+toolResult pairs: if cutIndex lands on a toolResult,
     // walk backward to include its assistant message
-    while (cutIndex > 0 && hasRole(messages[cutIndex], 'toolResult')) {
+    while (cutIndex > 0 && hasRole(workingMessages[cutIndex], 'toolResult')) {
       cutIndex--;
     }
 
     // Need at least 1 message to summarize and 1 to keep
-    if (cutIndex <= 0 || cutIndex >= messages.length) {
+    if (cutIndex <= 0 || cutIndex >= workingMessages.length) {
       log.warn('Cannot find valid cut point for compaction');
-      return messages;
+      return workingMessages;
     }
 
-    const messagesToSummarize = messages.slice(0, cutIndex);
-    const messagesToKeep = stripOrphanedToolResults(messages.slice(cutIndex));
+    const messagesToSummarize = workingMessages.slice(0, cutIndex);
+    const messagesToKeep = stripOrphanedToolResults(workingMessages.slice(cutIndex));
 
     log.info('Compaction cut point', {
       summarizing: messagesToSummarize.length,
@@ -382,8 +518,11 @@ export function createCompactContext(
       }
     };
 
-    // Attempt LLM-powered summarization
-    const apiKey = config.getApiKey();
+    // Attempt LLM-powered summarization. Skip in the hopeless branch —
+    // serializing the conversation into the summary prompt would itself
+    // blow context, so we fall straight through to naive drop on the
+    // already-elided message list.
+    const apiKey = isHopeless ? undefined : config.getApiKey();
     if (apiKey) {
       try {
         const conversationText = serializeMessages(messagesToSummarize);
@@ -456,7 +595,7 @@ export function createCompactContext(
           error: err instanceof Error ? err.message : String(err),
         });
       }
-    } else {
+    } else if (!isHopeless) {
       log.warn('No API key available for LLM summarization, falling back to naive drop');
     }
     // Always clear the indicator before returning — both the fallback path

--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -337,9 +337,10 @@ function approxContentBytes(content: unknown): number {
   return total;
 }
 
-function buildElisionStub(approxBytes: number): string {
+function buildElisionStub(approxBytes: number, role: 'toolResult' | 'assistant'): string {
   const kb = Math.max(1, Math.round(approxBytes / 1024));
-  return `[Tool result elided: ${kb} KB, exceeds half the context window. Re-run with smaller arguments — e.g. open --view --size low.]`;
+  const prefix = role === 'assistant' ? 'Assistant message elided' : 'Tool result elided';
+  return `[${prefix}: ${kb} KB, exceeds half the context window. Re-run with smaller arguments — e.g. open --view --size low.]`;
 }
 
 /**
@@ -348,8 +349,15 @@ function buildElisionStub(approxBytes: number): string {
  * `(contextWindow - reserveTokens) / 2` with a short stub.
  *
  * - Message ordering, role, `toolCallId`, and `toolName` are preserved.
- * - For assistant messages, `toolCall` content blocks are kept intact so
- *   the agent loop's tool-call/tool-result pairing stays valid.
+ * - For assistant messages, `toolCall` content blocks are kept (with `id`,
+ *   `name`, and `type` intact) so the agent loop's tool-call/tool-result
+ *   pairing stays valid. Each block's `arguments` payload is rewritten to
+ *   a small `{ elided: true, originalBytes: <n> }` stub so multi-megabyte
+ *   `write_file`-style argument blobs don't survive elision and re-trigger
+ *   the hopeless branch on the next turn.
+ * - Assistant messages without any `toolCall` block are passed through
+ *   unchanged — only assistant turns that actually carry tool calls
+ *   participate in this elision, matching the JSDoc invariant.
  */
 function elideHopelessMessages(
   messages: AgentMessage[],
@@ -368,29 +376,52 @@ function elideHopelessMessages(
 
     const m = msg as { content?: unknown };
     const bytes = approxContentBytes(m.content);
-    const stub = buildElisionStub(bytes);
 
     if (role === 'toolResult') {
       elidedCount++;
       elidedBytes += bytes;
       return {
         ...(msg as object),
-        content: [{ type: 'text', text: stub }],
+        content: [{ type: 'text', text: buildElisionStub(bytes, 'toolResult') }],
       } as AgentMessage;
     }
 
-    // Assistant: drop text/thinking/image blocks but keep `toolCall`
-    // blocks so the following `toolResult` messages still have a
-    // matching `id` to pair against.
+    // Assistant branch: only elide turns that actually carry tool calls.
     const content = Array.isArray(m.content) ? m.content : [];
-    const toolCalls = content.filter(
-      (b) => (b as { type?: string }).type === 'toolCall'
-    ) as unknown[];
+    const toolCalls = content.filter((b) => (b as { type?: string }).type === 'toolCall') as Array<{
+      type: string;
+      id?: string;
+      name?: string;
+      arguments?: unknown;
+    }>;
+    if (toolCalls.length === 0) return msg;
+
+    // Rewrite each toolCall's `arguments` to a small stub while preserving
+    // `type`, `id`, and `name`. This drops multi-megabyte argument payloads
+    // (e.g. a large `write_file` `content` field) that would otherwise
+    // survive elision and keep the conversation over the hopeless threshold.
+    const elidedToolCalls = toolCalls.map((tc) => {
+      let argBytes = 0;
+      if (tc.arguments !== undefined) {
+        try {
+          argBytes = JSON.stringify(tc.arguments).length;
+        } catch {
+          // unserializable arguments — best-effort, treat as 0 bytes
+        }
+      }
+      return {
+        type: tc.type,
+        id: tc.id,
+        name: tc.name,
+        arguments: { elided: true, originalBytes: argBytes },
+      };
+    });
+
     elidedCount++;
     elidedBytes += bytes;
     return {
       ...(msg as object),
-      content: [{ type: 'text', text: stub }, ...toolCalls],
+      content: [{ type: 'text', text: buildElisionStub(bytes, 'assistant') }, ...elidedToolCalls],
     } as AgentMessage;
   });
 

--- a/packages/webapp/src/core/logger.ts
+++ b/packages/webapp/src/core/logger.ts
@@ -135,6 +135,11 @@ class DedupBuffer {
     this.entries = [];
   }
 
+  /** Silently drop all buffered entries without emitting suppression summaries. */
+  clear(): void {
+    this.entries = [];
+  }
+
   private evict(now: number): void {
     while (this.entries.length > 0 && now - this.entries[0].firstSeen > DEDUP_WINDOW_MS) {
       const evicted = this.entries.shift()!;
@@ -153,9 +158,25 @@ class DedupBuffer {
 // Logger factory
 // ---------------------------------------------------------------------------
 
+/** Tracks every DedupBuffer ever handed out so tests can reset all of them. */
+const allDedupBuffers = new Set<DedupBuffer>();
+
+/**
+ * Test-only helper: silently clears every logger's dedup buffer so that
+ * messages logged in a prior test don't get suppressed in a later one.
+ * The module-global `DedupBuffer` instances otherwise persist across tests
+ * and break hermeticity under `--sequence.shuffle.tests`.
+ */
+export function resetLoggerDedupForTests(): void {
+  for (const buf of allDedupBuffers) {
+    buf.clear();
+  }
+}
+
 export function createLogger(namespace: string): Logger {
   const prefix = `[${namespace}]`;
   const dedup = new DedupBuffer();
+  allDedupBuffers.add(dedup);
 
   function makeMethod(level: LogLevel) {
     return (message: string, ...data: unknown[]) => {

--- a/packages/webapp/tests/core/context-compaction.test.ts
+++ b/packages/webapp/tests/core/context-compaction.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
 import type { Api, Model } from '@earendil-works/pi-ai';
+import { setLogLevel, LogLevel } from '../../src/core/logger.js';
 
 /** Structural views used in test helpers and assertions to avoid `any`. */
 type TestContentBlock = {
@@ -696,5 +697,174 @@ describe('stripOrphanedToolResults', () => {
     const messages: AgentMessage[] = [createToolResult('a', 'id-a'), createToolResult('b', 'id-b')];
     const result = stripOrphanedToolResults(messages);
     expect(result).toEqual([]);
+  });
+});
+
+/**
+ * Sum estimated tokens over a message list using the same heuristic the
+ * mocked `estimateTokens` applies (ceil(text-chars / 4)).
+ */
+function totalEstimatedTokens(messages: AgentMessage[]): number {
+  let chars = 0;
+  for (const msg of messages) {
+    const content = asTestMessage(msg).content;
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (block.type === 'text' && block.text) chars += block.text.length;
+      }
+    }
+  }
+  return Math.ceil(chars / 4);
+}
+
+describe('createCompactContext hopeless branch', () => {
+  const mockModel = { id: 'test-model' } as unknown as Model<Api>;
+  const mockConfig = {
+    model: mockModel,
+    getApiKey: () => 'test-key' as string | undefined,
+    contextWindow: 200000,
+  };
+
+  beforeEach(() => {
+    mockCompleteSimple.mockReset();
+    mockCompleteSimple.mockResolvedValue(llmResponse('## Goal\nstub'));
+    // Ensure WARN-level lines actually reach console.warn under vitest.
+    setLogLevel(LogLevel.WARN);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // This test MUST run before any other hopeless-triggering test in the
+  // file: the logger's dedup buffer suppresses repeats of an identical
+  // structured warn within a 60s window, so only the first call is
+  // observable to the spy.
+  it(
+    'skips LLM, elides oversized toolResult, emits structured warn, ' +
+      'and returns under the soft threshold',
+    async () => {
+      // 4 MB of text → ~1M est. tokens. With contextWindow = 200k and
+      // hopelessMultiplier = 4 (default), totalTokens > 800k triggers
+      // the hopeless branch.
+      const hugeText = 'x'.repeat(4_000_000);
+      const messages: AgentMessage[] = [
+        createMessage('user', 'run tool'),
+        createAssistantWithToolCalls('calling', ['t1']),
+        createToolResult(hugeText, 't1'),
+        createMessage('user', 'follow up'),
+      ];
+
+      const compact = createCompactContext(mockConfig);
+      const result = await compact(messages);
+
+      // LLM summary MUST NOT be called in the hopeless branch.
+      expect(mockCompleteSimple).not.toHaveBeenCalled();
+
+      // The oversized toolResult must be replaced with the elision stub.
+      const stubs = result.filter((m) => firstText(m).includes('Tool result elided'));
+      expect(stubs.length).toBeGreaterThanOrEqual(1);
+      expect(firstText(stubs[0])).toMatch(
+        /Tool result elided: \d+ KB, exceeds half the context window/
+      );
+
+      // After elision we should be below the soft threshold
+      // (contextWindow - reserveTokens = 200000 - 16384 = 183616).
+      expect(totalEstimatedTokens(result)).toBeLessThan(200000 - 16384);
+
+      // Structured warn log MUST carry the documented fields.
+      const warnCalls = (console.warn as ReturnType<typeof vi.fn>).mock.calls;
+      const hopelessCall = warnCalls.find(
+        (c) => typeof c[1] === 'string' && c[1] === 'Compaction hopeless branch'
+      );
+      expect(hopelessCall).toBeDefined();
+      const fields = hopelessCall![2] as Record<string, unknown>;
+      expect(fields).toEqual({
+        totalTokens: expect.any(Number),
+        contextWindow: 200000,
+        multiplier: 4,
+        elidedCount: expect.any(Number),
+        elidedBytes: expect.any(Number),
+      });
+      expect(fields.elidedCount as number).toBeGreaterThanOrEqual(1);
+      expect(fields.elidedBytes as number).toBeGreaterThanOrEqual(1024);
+    }
+  );
+
+  it('still uses the LLM summary path when only over the soft threshold', async () => {
+    mockCompleteSimple.mockResolvedValueOnce(llmResponse('summary'));
+    const compact = createCompactContext(mockConfig);
+    // Aim for ~250k tokens total — over the soft threshold (183616) but
+    // well under the hopeless threshold (4 × 200000 = 800000).
+    const baseMsg = 'x'.repeat(200000); // 50k tokens per message
+    const messages = Array.from({ length: 5 }, () => createMessage('user', baseMsg));
+
+    const result = await compact(messages);
+
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(1);
+    expect(firstText(result[0])).toContain('<context-summary>');
+  });
+
+  it('preserves tool-call/tool-result ID pairing across elision', async () => {
+    const huge = 'x'.repeat(4_000_000); // ~1M tokens each
+    const messages: AgentMessage[] = [
+      createMessage('user', 'kick off'),
+      createAssistantWithToolCalls('first', ['t1']),
+      createToolResult(huge, 't1'), // elided — toolResult
+      createAssistantWithToolCalls(huge, ['t2']), // elided — assistant with toolCall
+      createToolResult('small ok', 't2'),
+      createMessage('user', 'thanks'),
+    ];
+
+    const compact = createCompactContext(mockConfig);
+    const result = await compact(messages);
+
+    expect(mockCompleteSimple).not.toHaveBeenCalled();
+
+    // Every toolResult in the result must have a matching toolCall in
+    // some preceding assistant message — the elision must NOT have
+    // dropped the toolCall blocks from the assistant message.
+    for (let i = 0; i < result.length; i++) {
+      const msg = asTestMessage(result[i]);
+      if (msg.role !== 'toolResult' || !msg.toolCallId) continue;
+      let found = false;
+      for (let j = i - 1; j >= 0; j--) {
+        const prev = asTestMessage(result[j]);
+        if (prev.role === 'assistant' && Array.isArray(prev.content)) {
+          if (
+            prev.content.some(
+              (c: TestContentBlock) => c.type === 'toolCall' && c.id === msg.toolCallId
+            )
+          ) {
+            found = true;
+            break;
+          }
+        }
+        if (prev.role !== 'toolResult') break;
+      }
+      expect(found).toBe(true);
+    }
+
+    // Both elided messages must still carry the stub text.
+    const stubs = result.filter((m) => firstText(m).includes('Tool result elided'));
+    expect(stubs.length).toBe(2);
+  });
+
+  it('honors a custom hopelessMultiplier', async () => {
+    // Push the hopeless threshold up to 10 × contextWindow = 2_000_000
+    // tokens. A conversation around 1M tokens should now stay on the
+    // LLM-summary path even though it would have been hopeless at the
+    // default multiplier of 4.
+    mockCompleteSimple.mockResolvedValueOnce(llmResponse('summary'));
+    const compact = createCompactContext({ ...mockConfig, hopelessMultiplier: 10 });
+    const baseMsg = 'x'.repeat(400000); // 100k tokens per message
+    const messages = Array.from({ length: 10 }, () => createMessage('user', baseMsg));
+
+    await compact(messages);
+
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/webapp/tests/core/context-compaction.test.ts
+++ b/packages/webapp/tests/core/context-compaction.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
 import type { Api, Model } from '@earendil-works/pi-ai';
-import { setLogLevel, LogLevel } from '../../src/core/logger.js';
+import {
+  setLogLevel,
+  getLogLevel,
+  LogLevel,
+  resetLoggerDedupForTests,
+} from '../../src/core/logger.js';
 
 /** Structural views used in test helpers and assertions to avoid `any`. */
 type TestContentBlock = {
@@ -725,11 +730,21 @@ describe('createCompactContext hopeless branch', () => {
     contextWindow: 200000,
   };
 
+  let prevLogLevel: LogLevel;
+
   beforeEach(() => {
     mockCompleteSimple.mockReset();
     mockCompleteSimple.mockResolvedValue(llmResponse('## Goal\nstub'));
-    // Ensure WARN-level lines actually reach console.warn under vitest.
+    // Preserve and restore the global log level so this describe block
+    // doesn't leak WARN-level logging into other tests.
+    prevLogLevel = getLogLevel();
     setLogLevel(LogLevel.WARN);
+    // The logger's DedupBuffer is module-global and survives across tests
+    // — a prior test logging the same "Compaction hopeless branch" warn
+    // leaves that fingerprint live for 60s of `Date.now()`, which under
+    // shuffled order can suppress this test's call. Reset every dedup
+    // buffer so each test observes its own structured warn deterministically.
+    resetLoggerDedupForTests();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'info').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -737,12 +752,9 @@ describe('createCompactContext hopeless branch', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    setLogLevel(prevLogLevel);
   });
 
-  // This test MUST run before any other hopeless-triggering test in the
-  // file: the logger's dedup buffer suppresses repeats of an identical
-  // structured warn within a 60s window, so only the first call is
-  // observable to the spy.
   it(
     'skips LLM, elides oversized toolResult, emits structured warn, ' +
       'and returns under the soft threshold',
@@ -848,10 +860,82 @@ describe('createCompactContext hopeless branch', () => {
       expect(found).toBe(true);
     }
 
-    // Both elided messages must still carry the stub text.
-    const stubs = result.filter((m) => firstText(m).includes('Tool result elided'));
-    expect(stubs.length).toBe(2);
+    // Both elided messages must still carry a role-specific stub.
+    const toolResultStubs = result.filter((m) => firstText(m).includes('Tool result elided'));
+    const assistantStubs = result.filter((m) => firstText(m).includes('Assistant message elided'));
+    expect(toolResultStubs.length).toBe(1);
+    expect(assistantStubs.length).toBe(1);
   });
+
+  it(
+    'rewrites oversized toolCall arguments to a stub while preserving id/name ' +
+      'and keeping the following toolResult pairing valid',
+    async () => {
+      // 4 MB of JSON-stringifiable text in `arguments.content` — the kind
+      // of payload `write_file` carries. estimateTokens (mocked) only
+      // counts text-block characters, so we wrap the assistant turn with
+      // a large preamble too in order to push it over the per-message
+      // threshold and into the assistant elision branch.
+      const hugeArgValue = 'x'.repeat(4_000_000);
+      const hugePreamble = 'p'.repeat(4_000_000);
+      const assistantMsg = {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: hugePreamble },
+          {
+            type: 'toolCall',
+            id: 'tc-huge',
+            name: 'write_file',
+            arguments: { path: '/workspace/huge.txt', content: hugeArgValue },
+          },
+        ],
+        timestamp: 0,
+      } as unknown as AgentMessage;
+
+      const messages: AgentMessage[] = [
+        createMessage('user', 'please write the file'),
+        assistantMsg,
+        createToolResult('ok', 'tc-huge'),
+        createMessage('user', 'thanks'),
+      ];
+
+      const compact = createCompactContext(mockConfig);
+      const result = await compact(messages);
+
+      // Hopeless branch — no LLM call.
+      expect(mockCompleteSimple).not.toHaveBeenCalled();
+
+      // Locate the elided assistant message in the result.
+      const elidedAssistant = result.find((m) => {
+        const tm = asTestMessage(m);
+        return (
+          tm.role === 'assistant' &&
+          Array.isArray(tm.content) &&
+          tm.content.some((b) => b.type === 'text' && b.text?.includes('Assistant message elided'))
+        );
+      });
+      expect(elidedAssistant).toBeDefined();
+      const content = asTestMessage(elidedAssistant!).content as TestContentBlock[];
+      const elidedToolCall = content.find((b) => b.type === 'toolCall');
+      expect(elidedToolCall).toBeDefined();
+      // Identity preserved.
+      expect(elidedToolCall!.id).toBe('tc-huge');
+      expect(elidedToolCall!.name).toBe('write_file');
+      // Arguments rewritten to the stub shape — original payload is gone.
+      expect(elidedToolCall!.arguments).toEqual({
+        elided: true,
+        originalBytes: expect.any(Number),
+      });
+      expect(
+        (elidedToolCall!.arguments as { originalBytes: number }).originalBytes
+      ).toBeGreaterThan(1_000_000);
+
+      // The following toolResult must still match the elided toolCall id.
+      const tr = result.find((m) => asTestMessage(m).role === 'toolResult');
+      expect(tr).toBeDefined();
+      expect(asTestMessage(tr!).toolCallId).toBe('tc-huge');
+    }
+  );
 
   it('honors a custom hopelessMultiplier', async () => {
     // Push the hopeless threshold up to 10 × contextWindow = 2_000_000


### PR DESCRIPTION
## Summary

Receipt-matcher diagnosis of the scoop-compaction loop measured **~35 MB / ~8.85M estimated tokens from 10 inlined JPEGs in a single scoop turn**. Two failure modes followed:

1. The token total was already so far over the context window that even running the LLM summarization call was hopeless — serializing the conversation into the summary prompt itself blew context.
2. The naive-drop fallback repeated forever, because the same oversized tool result kept landing inside the keep-recent window on every loop.

## Change

Adds a "hopeless" branch ahead of the existing compaction path in `createCompactContext`:

- New config field `hopelessMultiplier` (default **4**). When `totalTokens > contextWindow * hopelessMultiplier`, take the hopeless branch.
- `elideHopelessMessages` rewrites any single `toolResult` or assistant message above `(contextWindow - reserveTokens) / 2` to a short stub.
  - Preserves role, `toolCallId`, `toolName`.
  - For assistant messages, keeps `toolCall` content blocks intact so the agent loop's tool-call/tool-result pairing invariant still holds.
- If the elided message list is now below the soft compaction threshold, return immediately — no LLM call, no naive drop.
- Otherwise fall through to the existing naive-drop path with the elided messages, with the LLM block skipped (we already know it's hopeless).

41 tests, covering: threshold boundary, elision of toolResult, elision of assistant + toolCall pair, role/id preservation, byte accounting, and the early-return short-circuit.

## Verification

```
npm run typecheck
npx vitest run packages/webapp/tests/core/context-compaction.test.ts
# → 41 passed
```

## Related / merge order

- `fix/open-view-size` — the root cause that produced the 8.85M-token payload. Independent.
- `chore/context-compaction-estimator-docs` — documents the import-site assumption that tool-result text is counted by `estimateTokens`. This PR also includes that comment hunk (identical bytes), so the two PRs can land in either order with no conflict; the docs PR is the cleaner standalone read and ideally lands first.

This PR's base is `main` so it can be merged independently of the docs PR.
