### PR TITLE
fix(fetch-proxy): correct Origin header handling in CLI and extension floats

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -366,6 +366,52 @@ Host the real leader tray `WebSocket` in `packages/chrome-extension/src/service-
 
 **Git CORS**: Same rules apply to isomorphic-git HTTP requests (clone, push, pull). Both modes now route through `createProxiedFetch()`.
 
+## Origin Contract: Forbidden Headers & Default-Origin Fallback
+
+**The Problem**
+
+Browsers silently strip a small set of "forbidden" request headers — `Origin`, `Referer`, `Cookie`, `Proxy-*` — from any `fetch()` call made in page or Service Worker contexts. A skill author writing `fetch(url, { headers: { Origin: 'https://foo.com' } })` will see that header vanish before it reaches the network. Upstream CORS-protected APIs that key on `Origin` then either reject the request or fall back to a content-derived bucket.
+
+**The Contract**
+
+`createProxiedFetch()` and every `SecureFetch`-backed shell call (curl, `node -e "fetch(...)"`, `upskill`, `mcp invoke`, git, etc.) preserve forbidden headers in both floats via the same `X-Proxy-*` wire transport, and both proxies synthesize a default `Origin` when none survives.
+
+| Step                                                                   | CLI                                                       | Extension                                                                    |
+| ---------------------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Client encodes `Origin`/`Referer`/`Cookie`/`Proxy-*` as `X-Proxy-*`    | `createProxiedFetch` → `encodeForbiddenRequestHeaders`    | `extensionPortFetch` → `encodeForbiddenRequestHeaders` over `chrome.runtime` |
+| Proxy decodes `X-Proxy-*` back to real header names before upstream    | `/api/fetch-proxy` handler in `node-server/src/index.ts`  | SW `handleFetchProxyConnectionAsync` in `fetch-proxy-shared.ts`              |
+| If no caller `Origin` survived, synthesize `<scheme>://<host>` of URL  | Yes — `new URL(targetUrl).origin`                         | Yes — `new URL(cleanedUrl).origin`                                           |
+| Caller-supplied `Origin` always wins                                   | Decode runs before fallback                               | Decode runs before fallback                                                  |
+| Browser-injected `localhost` `Origin`/`Referer` stripped before refill | `isLocalhostOrigin` deletes it, fallback then synthesizes | (n/a — extension `Origin` is the extension ID, not localhost)                |
+
+**Overriding the Origin**
+
+To force a specific `Origin` upstream, pass one explicitly — it survives end-to-end because the encode step runs in your runtime before the browser can strip it:
+
+```bash
+# curl in the agent shell
+curl -H "Origin: https://example.com" https://api.example.com/data
+
+# node -e using SecureFetch (wired into the shell `fetch` binding)
+node -e 'fetch("https://api.example.com/data", { headers: { Origin: "https://example.com" } })'
+
+# upskill / mcp invoke / any other SecureFetch caller — same shape
+upskill some-org/some-skill   # propagates Origin if the skill sets one
+```
+
+Leave `Origin` unset to get the default — the proxy will use the target URL's origin (e.g., a request to `https://api.example.com/v1/foo` gets `Origin: https://api.example.com`). This is intentionally permissive: most upstream APIs accept their own origin, and skill authors don't need to think about CORS unless they want a specific value.
+
+**Why both floats need the encode/decode dance**
+
+The extension float also runs `fetch()` from a page-context (the side panel or offscreen document), so the same browser-strip behavior applies — extension `host_permissions` bypass CORS at the network layer but do **not** restore stripped request headers. The `extensionPortFetch` branch was changed in Wave 1 to match the CLI branch exactly; before that, extension-mode `curl -H "Origin: ..."` silently dropped the header even though CLI-mode worked. The default-origin fallback in the extension SW closes the matching gap for callers that don't set an Origin at all.
+
+**Related Files**
+
+- `packages/webapp/src/shell/proxy-headers.ts` — `encodeForbiddenRequestHeaders` / `decodeForbiddenRequestHeaders` (shared by both floats)
+- `packages/webapp/src/shell/proxied-fetch.ts` — `createProxiedFetch` factory; CLI and extension branches both encode
+- `packages/node-server/src/index.ts` — `/api/fetch-proxy` handler; decode + localhost-strip + default-origin synth
+- `packages/chrome-extension/src/fetch-proxy-shared.ts` — SW `handleFetchProxyConnectionAsync`; same decode + default-origin synth
+
 ## Kernel-Worker Fetch Bypass: Same-Origin Only
 
 `packages/webapp/src/kernel/kernel-worker.ts` wraps `globalThis.fetch` to

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -372,21 +372,38 @@ Host the real leader tray `WebSocket` in `packages/chrome-extension/src/service-
 
 Browsers silently strip a small set of "forbidden" request headers — `Origin`, `Referer`, `Cookie`, `Proxy-*` — from any `fetch()` call made in page or Service Worker contexts. A skill author writing `fetch(url, { headers: { Origin: 'https://foo.com' } })` will see that header vanish before it reaches the network. Upstream CORS-protected APIs that key on `Origin` then either reject the request or fall back to a content-derived bucket.
 
+The extension float makes this worse: Chrome MV3 strips `Cookie`/`Referer`/`Proxy-*` from extension-SW `fetch()` regardless of the `init.headers` dict or `host_permissions`, **and** rewrites `Origin` to `chrome-extension://<id>` on the wire. So the obvious "decode `X-Proxy-*` back into the headers dict and call `fetch(url, { headers })`" approach is **not** sufficient in the SW — the headers are visible to JS but never reach the network.
+
 **The Contract**
 
-`createProxiedFetch()` and every `SecureFetch`-backed shell call (curl, `node -e "fetch(...)"`, `upskill`, `mcp invoke`, git, etc.) preserve forbidden headers in both floats via the same `X-Proxy-*` wire transport, and both proxies synthesize a default `Origin` when none survives.
+`createProxiedFetch()` and every `SecureFetch`-backed shell call (curl, `node -e "fetch(...)"`, `upskill`, `mcp invoke`, git, etc.) preserve forbidden headers in both floats via the same `X-Proxy-*` wire transport, but the two proxies use different mechanisms to actually land them on the upstream request, and both synthesize a default `Origin` when none survives.
 
-| Step                                                                   | CLI                                                       | Extension                                                                    |
-| ---------------------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Client encodes `Origin`/`Referer`/`Cookie`/`Proxy-*` as `X-Proxy-*`    | `createProxiedFetch` → `encodeForbiddenRequestHeaders`    | `extensionPortFetch` → `encodeForbiddenRequestHeaders` over `chrome.runtime` |
-| Proxy decodes `X-Proxy-*` back to real header names before upstream    | `/api/fetch-proxy` handler in `node-server/src/index.ts`  | SW `handleFetchProxyConnectionAsync` in `fetch-proxy-shared.ts`              |
-| If no caller `Origin` survived, synthesize `<scheme>://<host>` of URL  | Yes — `new URL(targetUrl).origin`                         | Yes — `new URL(cleanedUrl).origin`                                           |
-| Caller-supplied `Origin` always wins                                   | Decode runs before fallback                               | Decode runs before fallback                                                  |
-| Browser-injected `localhost` `Origin`/`Referer` stripped before refill | `isLocalhostOrigin` deletes it, fallback then synthesizes | (n/a — extension `Origin` is the extension ID, not localhost)                |
+| Step                                                                   | CLI                                                       | Extension                                                                                                                                                                       |
+| ---------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Client encodes `Origin`/`Referer`/`Cookie`/`Proxy-*` as `X-Proxy-*`    | `createProxiedFetch` → `encodeForbiddenRequestHeaders`    | `extensionPortFetch` → `encodeForbiddenRequestHeaders` over `chrome.runtime`                                                                                                    |
+| Proxy decodes `X-Proxy-*` back to real header names before upstream    | `/api/fetch-proxy` handler in `node-server/src/index.ts`  | SW `handleFetchProxyConnectionAsync` in `fetch-proxy-shared.ts`                                                                                                                 |
+| Forbidden headers actually reach upstream                              | Yes — Node `fetch()` honors the init dict for every name  | **DNR rule required** — `installForbiddenHeaderRule` installs a per-request `chrome.declarativeNetRequest.updateSessionRules` `modifyHeaders` rule that rewrites them on egress |
+| If no caller `Origin` survived, synthesize `<scheme>://<host>` of URL  | Yes — `new URL(targetUrl).origin`                         | Yes — `new URL(cleanedUrl).origin`                                                                                                                                              |
+| Caller-supplied `Origin` always wins                                   | Decode runs before fallback                               | Decode runs before fallback; DNR `set` operation overrides the Chrome-injected extension Origin                                                                                 |
+| Browser-injected `localhost` `Origin`/`Referer` stripped before refill | `isLocalhostOrigin` deletes it, fallback then synthesizes | (n/a — extension `Origin` is the extension ID, replaced by DNR or fallback)                                                                                                     |
+
+**The DNR mechanism (extension SW only)**
+
+`installForbiddenHeaderRule` in `packages/chrome-extension/src/fetch-proxy-shared.ts`:
+
+1. Scans the decoded `headers` dict for forbidden names (`cookie`, `origin`, `referer`, anything `proxy-*`).
+2. Mints a unique URL fragment token (`#slicc-req-<uuid>`) and appends it to the cleaned upstream URL, stripping any caller-supplied fragment so the DNR `urlFilter` matches exactly one in-flight request. The fragment never reaches the upstream server but DNR `urlFilter` sees it (empirically verified against Chrome for Testing 146).
+3. Installs a `chrome.declarativeNetRequest.updateSessionRules` `modifyHeaders` rule keyed to that fragment URL, with one `{ operation: 'set' }` entry per forbidden header.
+4. The SW then calls `fetch(fetchUrl, { method, headers, body, signal })`. Chrome strips/rewrites the forbidden headers in the init dict as usual, then the DNR rule rewrites them back on the way out.
+5. A `finally` block calls `cleanup()`, which removes the session rule via `removeRuleIds`. Each rule has a unique monotonic id so concurrent in-flight requests don't collide even if cleanup is delayed; any leaked rule expires when the SW unloads.
+
+**Graceful no-op fallback**
+
+When `chrome.declarativeNetRequest` is unavailable (vitest, non-extension runtimes, older Chrome), `installForbiddenHeaderRule` returns the original URL and a no-op `cleanup`. The forbidden headers are still passed to `fetch()` under their real names — useful for unit tests that mock `fetch` and assert on the headers dict — but in a real Chrome SW they would not survive. The synthesized default-`Origin` still lands in `init.headers` and is observable to mocks, but caller-supplied forbidden headers from a real extension SW require DNR to reach the network.
 
 **Overriding the Origin**
 
-To force a specific `Origin` upstream, pass one explicitly — it survives end-to-end because the encode step runs in your runtime before the browser can strip it:
+To force a specific `Origin` upstream, pass one explicitly — it survives end-to-end because the encode step runs in your runtime before the browser can strip it, and in the extension SW the DNR rule rewrites it on the wire:
 
 ```bash
 # curl in the agent shell
@@ -401,16 +418,16 @@ upskill some-org/some-skill   # propagates Origin if the skill sets one
 
 Leave `Origin` unset to get the default — the proxy will use the target URL's origin (e.g., a request to `https://api.example.com/v1/foo` gets `Origin: https://api.example.com`). This is intentionally permissive: most upstream APIs accept their own origin, and skill authors don't need to think about CORS unless they want a specific value.
 
-**Why both floats need the encode/decode dance**
+**Why decode alone isn't enough in the extension**
 
-The extension float also runs `fetch()` from a page-context (the side panel or offscreen document), so the same browser-strip behavior applies — extension `host_permissions` bypass CORS at the network layer but do **not** restore stripped request headers. The `extensionPortFetch` branch was changed in Wave 1 to match the CLI branch exactly; before that, extension-mode `curl -H "Origin: ..."` silently dropped the header even though CLI-mode worked. The default-origin fallback in the extension SW closes the matching gap for callers that don't set an Origin at all.
+The extension SW runs `fetch()` in a Service Worker context, so the same browser-strip behavior applies — extension `host_permissions` bypass CORS at the network layer but do **not** restore stripped request headers, and Chrome rewrites `Origin` to `chrome-extension://<id>` independently of what the init dict contains. An earlier iteration of the extension branch decoded `X-Proxy-*` back into the headers dict and stopped there; that made the headers visible to the SW but they never reached the upstream. The DNR session-rule shim closes that gap. The default-origin fallback in the SW handles the orthogonal case where no caller `Origin` is set at all.
 
 **Related Files**
 
 - `packages/webapp/src/shell/proxy-headers.ts` — `encodeForbiddenRequestHeaders` / `decodeForbiddenRequestHeaders` (shared by both floats)
 - `packages/webapp/src/shell/proxied-fetch.ts` — `createProxiedFetch` factory; CLI and extension branches both encode
 - `packages/node-server/src/index.ts` — `/api/fetch-proxy` handler; decode + localhost-strip + default-origin synth
-- `packages/chrome-extension/src/fetch-proxy-shared.ts` — SW `handleFetchProxyConnectionAsync`; same decode + default-origin synth
+- `packages/chrome-extension/src/fetch-proxy-shared.ts` — SW `handleFetchProxyConnectionAsync`; decode + default-origin synth + `installForbiddenHeaderRule` (DNR session-rule shim, fragment-keyed, cleanup in `finally`)
 
 ## Kernel-Worker Fetch Bypass: Same-Origin Only
 

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -564,7 +564,7 @@ curl -X POST /api/fetch-proxy \
 
 All `fetch()` and `curl` calls route through proxy (CLI: `/api/fetch-proxy`, extension: `fetch-proxy.fetch` SW Port handler). Both modes now provide full secret-injection coverage.
 
-Browsers strip `Origin`, `Referer`, `Cookie`, and `Proxy-*` from page-context `fetch()` calls, so the proxy restores them via an `X-Proxy-*` transport and synthesizes a default `Origin` from the target URL when no caller value survives. Override with `curl -H "Origin: ..."` (or pass an `Origin` header to any `SecureFetch`-backed call). See [Origin Contract: Forbidden Headers & Default-Origin Fallback](./pitfalls.md#origin-contract-forbidden-headers--default-origin-fallback) in `docs/pitfalls.md` for the full contract.
+Browsers strip `Origin`, `Referer`, `Cookie`, and `Proxy-*` from page-context `fetch()` calls, so the proxy restores them via an `X-Proxy-*` transport and synthesizes a default `Origin` from the target URL when no caller value survives. In CLI mode the Express handler decodes the headers and Node `fetch()` carries them through; in the extension SW, decoding alone is not sufficient because Chrome strips/rewrites forbidden headers regardless of the init dict, so the SW additionally installs a per-request `chrome.declarativeNetRequest` session rule (keyed to a unique URL fragment) that rewrites them on egress. Override with `curl -H "Origin: ..."` (or pass an `Origin` header to any `SecureFetch`-backed call). See [Origin Contract: Forbidden Headers & Default-Origin Fallback](./pitfalls.md#origin-contract-forbidden-headers--default-origin-fallback) in `docs/pitfalls.md` for the full contract.
 
 ### Extension Mode
 

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -564,6 +564,8 @@ curl -X POST /api/fetch-proxy \
 
 All `fetch()` and `curl` calls route through proxy (CLI: `/api/fetch-proxy`, extension: `fetch-proxy.fetch` SW Port handler). Both modes now provide full secret-injection coverage.
 
+Browsers strip `Origin`, `Referer`, `Cookie`, and `Proxy-*` from page-context `fetch()` calls, so the proxy restores them via an `X-Proxy-*` transport and synthesizes a default `Origin` from the target URL when no caller value survives. Override with `curl -H "Origin: ..."` (or pass an `Origin` header to any `SecureFetch`-backed call). See [Origin Contract: Forbidden Headers & Default-Origin Fallback](./pitfalls.md#origin-contract-forbidden-headers--default-origin-fallback) in `docs/pitfalls.md` for the full contract.
+
 ### Extension Mode
 
 Extension mode routes through the service worker `fetch-proxy.fetch` Port handler. The handler unmasks secrets at the network boundary and uses `host_permissions` for CORS bypass:

--- a/packages/chrome-extension/manifest.json
+++ b/packages/chrome-extension/manifest.json
@@ -13,6 +13,7 @@
     "identity",
     "storage",
     "webRequest",
+    "declarativeNetRequestWithHostAccess",
     "notifications"
   ],
   "host_permissions": ["<all_urls>"],

--- a/packages/chrome-extension/src/fetch-proxy-shared.ts
+++ b/packages/chrome-extension/src/fetch-proxy-shared.ts
@@ -6,7 +6,7 @@ export const REQUEST_BODY_CAP = 32 * 1024 * 1024;
 /**
  * Extract `Set-Cookie` values from upstream response headers as a list.
  * `Headers.forEach` joins multi-value `set-cookie` entries with a comma
- * (per WHATWG fetch — undef behavior for set-cookie), so use the dedicated
+ * (per WHATWG fetch — undefined behavior for set-cookie), so use the dedicated
  * `getSetCookie()` accessor when available. Falls back to a single
  * comma-joined string for older runtimes that don't implement it.
  */

--- a/packages/chrome-extension/src/fetch-proxy-shared.ts
+++ b/packages/chrome-extension/src/fetch-proxy-shared.ts
@@ -167,6 +167,19 @@ export function handleFetchProxyConnectionAsync(
         headers.authorization = credsResult.syntheticAuthorization;
       }
 
+      // Default-Origin fallback: when no caller Origin survives the
+      // X-Proxy-Origin decode step above, synthesize one from the target URL
+      // so upstream CORS-protected APIs see a real Origin instead of nothing.
+      // Caller-supplied Origin (decoded from X-Proxy-Origin) still wins
+      // because the decode step ran first. Matches CLI server behavior.
+      if (!headers.origin) {
+        try {
+          headers.origin = new URL(cleanedUrl).origin;
+        } catch {
+          // Malformed cleanedUrl — leave origin unset; upstream fetch will fail anyway.
+        }
+      }
+
       let body: Uint8Array | undefined;
       if (msg.bodyBase64) {
         const raw = decodeBase64Bytes(msg.bodyBase64);
@@ -255,6 +268,19 @@ export function handleFetchProxyConnection(port: PortLike, pipeline: SecretsPipe
       }
       if (credsResult.syntheticAuthorization && !('authorization' in headers)) {
         headers.authorization = credsResult.syntheticAuthorization;
+      }
+
+      // Default-Origin fallback: when no caller Origin survives the
+      // X-Proxy-Origin decode step above, synthesize one from the target URL
+      // so upstream CORS-protected APIs see a real Origin instead of nothing.
+      // Caller-supplied Origin (decoded from X-Proxy-Origin) still wins
+      // because the decode step ran first. Matches CLI server behavior.
+      if (!headers.origin) {
+        try {
+          headers.origin = new URL(cleanedUrl).origin;
+        } catch {
+          // Malformed cleanedUrl — leave origin unset; upstream fetch will fail anyway.
+        }
       }
 
       let body: Uint8Array | undefined;

--- a/packages/chrome-extension/src/fetch-proxy-shared.ts
+++ b/packages/chrome-extension/src/fetch-proxy-shared.ts
@@ -1,6 +1,48 @@
 import { type SecretsPipeline } from '@slicc/shared-ts';
+import { decodeForbiddenRequestHeaders } from '../../webapp/src/shell/proxy-headers.js';
 
 export const REQUEST_BODY_CAP = 32 * 1024 * 1024;
+
+/**
+ * Extract `Set-Cookie` values from upstream response headers as a list.
+ * `Headers.forEach` joins multi-value `set-cookie` entries with a comma
+ * (per WHATWG fetch — undef behavior for set-cookie), so use the dedicated
+ * `getSetCookie()` accessor when available. Falls back to a single
+ * comma-joined string for older runtimes that don't implement it.
+ */
+function extractSetCookies(headers: Headers): string[] {
+  const get = (headers as unknown as { getSetCookie?: () => string[] }).getSetCookie;
+  if (typeof get === 'function') {
+    return get.call(headers);
+  }
+  const joined = headers.get('set-cookie');
+  return joined ? [joined] : [];
+}
+
+/**
+ * Build the response-head headers map the way the CLI proxy does:
+ *   - drop `set-cookie` and any `x-proxy-*` from the scrubbed map
+ *   - if there were any `set-cookie` values, repack them as a JSON array
+ *     under `X-Proxy-Set-Cookie` so the page side can recover them via
+ *     `decodeForbiddenResponseHeaders`.
+ */
+function buildResponseHeaders(
+  scrubbed: Record<string, string>,
+  upstream: Headers,
+  pipeline: SecretsPipeline
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(scrubbed)) {
+    const lower = k.toLowerCase();
+    if (lower === 'set-cookie' || lower.startsWith('x-proxy-')) continue;
+    out[k] = v;
+  }
+  const setCookies = extractSetCookies(upstream);
+  if (setCookies.length > 0) {
+    out['X-Proxy-Set-Cookie'] = pipeline.scrubResponse(JSON.stringify(setCookies));
+  }
+  return out;
+}
 
 export interface PortLike {
   onMessage: { addListener: (fn: (msg: unknown) => void) => void };
@@ -110,7 +152,9 @@ export function handleFetchProxyConnectionAsync(
       const cleanedUrl = credsResult.url;
       const host = new URL(cleanedUrl).host;
 
-      const headers: Record<string, string> = { ...msg.headers };
+      // Decode X-Proxy-* forbidden-header transport BEFORE unmask so the
+      // pipeline sees real header names. Matches CLI server behavior.
+      const headers: Record<string, string> = decodeForbiddenRequestHeaders(msg.headers);
       const headersResult = pipeline.unmaskHeaders(headers, host);
       if (headersResult.forbidden) {
         send(port, {
@@ -135,7 +179,8 @@ export function handleFetchProxyConnectionAsync(
         body: body as BodyInit | undefined,
         signal: ac.signal,
       });
-      const respHeaders = pipeline.scrubHeaders(upstream.headers);
+      const scrubbed = pipeline.scrubHeaders(upstream.headers);
+      const respHeaders = buildResponseHeaders(scrubbed, upstream.headers, pipeline);
       send(port, {
         type: 'response-head',
         status: upstream.status,
@@ -148,8 +193,8 @@ export function handleFetchProxyConnectionAsync(
         while (true) {
           const { value, done } = await reader.read();
           if (done) break;
-          const scrubbed = pipeline.scrubResponseBytes(value);
-          send(port, { type: 'response-chunk', dataBase64: encodeBase64Bytes(scrubbed) });
+          const bodyScrubbed = pipeline.scrubResponseBytes(value);
+          send(port, { type: 'response-chunk', dataBase64: encodeBase64Bytes(bodyScrubbed) });
         }
       }
       send(port, { type: 'response-end' });
@@ -197,7 +242,9 @@ export function handleFetchProxyConnection(port: PortLike, pipeline: SecretsPipe
       const cleanedUrl = credsResult.url;
       const host = new URL(cleanedUrl).host;
 
-      const headers: Record<string, string> = { ...msg.headers };
+      // Decode X-Proxy-* forbidden-header transport BEFORE unmask so the
+      // pipeline sees real header names. Matches CLI server behavior.
+      const headers: Record<string, string> = decodeForbiddenRequestHeaders(msg.headers);
       const headersResult = pipeline.unmaskHeaders(headers, host);
       if (headersResult.forbidden) {
         send(port, {
@@ -222,7 +269,8 @@ export function handleFetchProxyConnection(port: PortLike, pipeline: SecretsPipe
         body: body as BodyInit | undefined,
         signal: ac.signal,
       });
-      const respHeaders = pipeline.scrubHeaders(upstream.headers);
+      const scrubbed = pipeline.scrubHeaders(upstream.headers);
+      const respHeaders = buildResponseHeaders(scrubbed, upstream.headers, pipeline);
       send(port, {
         type: 'response-head',
         status: upstream.status,
@@ -239,8 +287,8 @@ export function handleFetchProxyConnection(port: PortLike, pipeline: SecretsPipe
           // (git packfiles, ZIPs, images) survive intact. Chunk-boundary
           // scrub limitation matches CLI behavior: a coincidental real-value
           // straddling a chunk boundary leaks through. v2: carry-over window.
-          const scrubbed = pipeline.scrubResponseBytes(value);
-          send(port, { type: 'response-chunk', dataBase64: encodeBase64Bytes(scrubbed) });
+          const bodyScrubbed = pipeline.scrubResponseBytes(value);
+          send(port, { type: 'response-chunk', dataBase64: encodeBase64Bytes(bodyScrubbed) });
         }
       }
       send(port, { type: 'response-end' });

--- a/packages/chrome-extension/src/fetch-proxy-shared.ts
+++ b/packages/chrome-extension/src/fetch-proxy-shared.ts
@@ -96,6 +96,108 @@ function encodeBase64Bytes(bytes: Uint8Array): string {
 }
 
 /**
+ * Headers that Chrome silently strips or overrides on any `fetch()` call —
+ * including from an extension service worker. The decode-from-`X-Proxy-*`
+ * step writes them under their real names, but Chrome then erases them on
+ * the wire (Cookie/Referer/Proxy-* dropped; Origin rewritten to the
+ * extension's chrome-extension:// origin). The DNR shim below restores them.
+ */
+function isForbiddenRequestHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  return (
+    lower === 'cookie' || lower === 'origin' || lower === 'referer' || lower.startsWith('proxy-')
+  );
+}
+
+interface DnrRule {
+  id: number;
+  priority: number;
+  condition: { urlFilter: string; resourceTypes?: string[] };
+  action: {
+    type: 'modifyHeaders';
+    requestHeaders: Array<{ header: string; operation: 'set'; value: string }>;
+  };
+}
+interface DnrLike {
+  updateSessionRules: (opts: { addRules?: DnrRule[]; removeRuleIds?: number[] }) => Promise<void>;
+}
+
+function getDnr(): DnrLike | null {
+  const c = (globalThis as { chrome?: { declarativeNetRequest?: DnrLike } }).chrome;
+  const dnr = c?.declarativeNetRequest;
+  if (!dnr || typeof dnr.updateSessionRules !== 'function') return null;
+  return dnr;
+}
+
+// Monotonic counter for DNR session-rule IDs. Session rules live for the
+// SW's lifetime; we always remove the rule before the response resolves,
+// but a unique id per request prevents collisions if cleanup is delayed
+// for any reason (concurrent in-flight requests, retried install).
+let nextDnrRuleId = 1_000_000;
+
+function randomFragmentToken(): string {
+  const c = (globalThis as { crypto?: Crypto }).crypto;
+  if (c && typeof c.randomUUID === 'function') return c.randomUUID();
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Forbidden request headers (Cookie/Origin/Referer/Proxy-*) are stripped or
+ * overridden by Chrome on any extension-SW `fetch()` — even when the
+ * `headers` init dict lists them under their real names. Restore them on
+ * the wire by installing a one-shot `chrome.declarativeNetRequest` session
+ * rule keyed to a unique URL fragment, then removing the rule after the
+ * fetch settles.
+ *
+ * URL fragments are never sent to the upstream server but DNR `urlFilter`
+ * DOES see them (empirically verified against Chrome for Testing 146), so
+ * the keying is leak-free for concurrent requests.
+ *
+ * Falls back to a no-op when `chrome.declarativeNetRequest` is unavailable
+ * (vitest / non-extension runtimes / older Chrome). In that case the
+ * forbidden headers are still passed to `fetch()` under their real names,
+ * matching the pre-DNR behavior — useful for unit tests that mock `fetch`.
+ */
+export async function installForbiddenHeaderRule(
+  url: string,
+  headers: Record<string, string>
+): Promise<{ fetchUrl: string; cleanup: () => Promise<void> }> {
+  const dnr = getDnr();
+  const requestHeaders: Array<{ header: string; operation: 'set'; value: string }> = [];
+  for (const [k, v] of Object.entries(headers)) {
+    if (isForbiddenRequestHeader(k)) {
+      requestHeaders.push({ header: k.toLowerCase(), operation: 'set', value: v });
+    }
+  }
+  if (!dnr || requestHeaders.length === 0) {
+    return { fetchUrl: url, cleanup: async () => {} };
+  }
+  const id = nextDnrRuleId++;
+  const fragment = `slicc-req-${randomFragmentToken()}`;
+  // Strip any caller-supplied fragment so the DNR urlFilter matches exactly
+  // one in-flight request. The upstream never sees either fragment.
+  const fetchUrl = `${url.split('#')[0]}#${fragment}`;
+  const rule: DnrRule = {
+    id,
+    priority: 100,
+    condition: { urlFilter: fetchUrl, resourceTypes: ['xmlhttprequest'] },
+    action: { type: 'modifyHeaders', requestHeaders },
+  };
+  await dnr.updateSessionRules({ addRules: [rule] });
+  let removed = false;
+  const cleanup = async (): Promise<void> => {
+    if (removed) return;
+    removed = true;
+    try {
+      await dnr.updateSessionRules({ removeRuleIds: [id] });
+    } catch {
+      // Best-effort — a leaked session rule expires when the SW unloads.
+    }
+  };
+  return { fetchUrl, cleanup };
+}
+
+/**
  * Variant that accepts a Promise for the pipeline so the caller can attach
  * the onMessage listener SYNCHRONOUSLY in the onConnect callback — Chrome
  * drops port messages that arrive before any listener exists, and the
@@ -186,31 +288,38 @@ export function handleFetchProxyConnectionAsync(
         body = pipeline.unmaskBodyBytes(raw, host).bytes;
       }
 
-      const upstream = await fetch(cleanedUrl, {
-        method: msg.method,
-        headers,
-        body: body as BodyInit | undefined,
-        signal: ac.signal,
-      });
-      const scrubbed = pipeline.scrubHeaders(upstream.headers);
-      const respHeaders = buildResponseHeaders(scrubbed, upstream.headers, pipeline);
-      send(port, {
-        type: 'response-head',
-        status: upstream.status,
-        statusText: upstream.statusText,
-        headers: respHeaders,
-      });
+      // Re-inject forbidden request headers via declarativeNetRequest because
+      // Chrome strips/overrides them on extension-SW fetch() — see the helper.
+      const dnrRule = await installForbiddenHeaderRule(cleanedUrl, headers);
+      try {
+        const upstream = await fetch(dnrRule.fetchUrl, {
+          method: msg.method,
+          headers,
+          body: body as BodyInit | undefined,
+          signal: ac.signal,
+        });
+        const scrubbed = pipeline.scrubHeaders(upstream.headers);
+        const respHeaders = buildResponseHeaders(scrubbed, upstream.headers, pipeline);
+        send(port, {
+          type: 'response-head',
+          status: upstream.status,
+          statusText: upstream.statusText,
+          headers: respHeaders,
+        });
 
-      if (upstream.body) {
-        const reader = upstream.body.getReader();
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          const bodyScrubbed = pipeline.scrubResponseBytes(value);
-          send(port, { type: 'response-chunk', dataBase64: encodeBase64Bytes(bodyScrubbed) });
+        if (upstream.body) {
+          const reader = upstream.body.getReader();
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            const bodyScrubbed = pipeline.scrubResponseBytes(value);
+            send(port, { type: 'response-chunk', dataBase64: encodeBase64Bytes(bodyScrubbed) });
+          }
         }
+        send(port, { type: 'response-end' });
+      } finally {
+        await dnrRule.cleanup();
       }
-      send(port, { type: 'response-end' });
     } catch (err) {
       send(port, {
         type: 'response-error',
@@ -289,35 +398,42 @@ export function handleFetchProxyConnection(port: PortLike, pipeline: SecretsPipe
         body = pipeline.unmaskBodyBytes(raw, host).bytes;
       }
 
-      const upstream = await fetch(cleanedUrl, {
-        method: msg.method,
-        headers,
-        body: body as BodyInit | undefined,
-        signal: ac.signal,
-      });
-      const scrubbed = pipeline.scrubHeaders(upstream.headers);
-      const respHeaders = buildResponseHeaders(scrubbed, upstream.headers, pipeline);
-      send(port, {
-        type: 'response-head',
-        status: upstream.status,
-        statusText: upstream.statusText,
-        headers: respHeaders,
-      });
+      // Re-inject forbidden request headers via declarativeNetRequest because
+      // Chrome strips/overrides them on extension-SW fetch() — see the helper.
+      const dnrRule = await installForbiddenHeaderRule(cleanedUrl, headers);
+      try {
+        const upstream = await fetch(dnrRule.fetchUrl, {
+          method: msg.method,
+          headers,
+          body: body as BodyInit | undefined,
+          signal: ac.signal,
+        });
+        const scrubbed = pipeline.scrubHeaders(upstream.headers);
+        const respHeaders = buildResponseHeaders(scrubbed, upstream.headers, pipeline);
+        send(port, {
+          type: 'response-head',
+          status: upstream.status,
+          statusText: upstream.statusText,
+          headers: respHeaders,
+        });
 
-      if (upstream.body) {
-        const reader = upstream.body.getReader();
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          // Byte-safe scrub — no TextDecoder round-trip, so binary chunks
-          // (git packfiles, ZIPs, images) survive intact. Chunk-boundary
-          // scrub limitation matches CLI behavior: a coincidental real-value
-          // straddling a chunk boundary leaks through. v2: carry-over window.
-          const bodyScrubbed = pipeline.scrubResponseBytes(value);
-          send(port, { type: 'response-chunk', dataBase64: encodeBase64Bytes(bodyScrubbed) });
+        if (upstream.body) {
+          const reader = upstream.body.getReader();
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            // Byte-safe scrub — no TextDecoder round-trip, so binary chunks
+            // (git packfiles, ZIPs, images) survive intact. Chunk-boundary
+            // scrub limitation matches CLI behavior: a coincidental real-value
+            // straddling a chunk boundary leaks through. v2: carry-over window.
+            const bodyScrubbed = pipeline.scrubResponseBytes(value);
+            send(port, { type: 'response-chunk', dataBase64: encodeBase64Bytes(bodyScrubbed) });
+          }
         }
+        send(port, { type: 'response-end' });
+      } finally {
+        await dnrRule.cleanup();
       }
-      send(port, { type: 'response-end' });
     } catch (err) {
       send(port, {
         type: 'response-error',

--- a/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
+++ b/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
@@ -298,3 +298,131 @@ describe('handleFetchProxyConnectionAsync — synchronous listener attach', () =
     ]);
   });
 });
+
+// X-Proxy-* forbidden-header transport parity with CLI. Browser `fetch()`
+// silently strips Cookie/Origin/Referer/Proxy-* request headers AND the
+// `Set-Cookie` response header, so both the page→SW request and the
+// SW→page response are encoded under `X-Proxy-*` names.
+describe('handleFetchProxyConnection — X-Proxy-* request decode', () => {
+  let pipeline: SecretsPipeline;
+
+  beforeEach(async () => {
+    pipeline = new SecretsPipeline({
+      sessionId: 'session-fixed',
+      source: { get: async () => undefined, listAll: async () => [] },
+    });
+    await pipeline.reload();
+  });
+
+  async function dispatch(headers: Record<string, string>): Promise<Record<string, string>> {
+    let captured: Record<string, string> | undefined;
+    (globalThis as any).fetch = vi.fn(async (_url: string, init: { headers: any }) => {
+      captured = init.headers as Record<string, string>;
+      return new Response('ok', { status: 200, statusText: 'OK' });
+    });
+    const port = makePort(() => {});
+    handleFetchProxyConnection(port, pipeline);
+    port.fireMessage({
+      type: 'request',
+      url: 'https://api.example.com/path',
+      method: 'GET',
+      headers,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    if (!captured) throw new Error('fetch was not called');
+    return captured;
+  }
+
+  it('decodes X-Proxy-Origin → origin', async () => {
+    const h = await dispatch({ 'X-Proxy-Origin': 'https://example.com' });
+    expect(h.origin).toBe('https://example.com');
+    expect('X-Proxy-Origin' in h).toBe(false);
+  });
+
+  it('decodes X-Proxy-Referer → referer', async () => {
+    const h = await dispatch({ 'X-Proxy-Referer': 'https://example.com/page' });
+    expect(h.referer).toBe('https://example.com/page');
+    expect('X-Proxy-Referer' in h).toBe(false);
+  });
+
+  it('decodes X-Proxy-Cookie → cookie', async () => {
+    const h = await dispatch({ 'X-Proxy-Cookie': 'sid=abc; theme=dark' });
+    expect(h.cookie).toBe('sid=abc; theme=dark');
+    expect('X-Proxy-Cookie' in h).toBe(false);
+  });
+
+  it('decodes X-Proxy-Proxy-* → proxy-* (preserves original suffix)', async () => {
+    const h = await dispatch({ 'X-Proxy-Proxy-Authorization': 'Basic dXNlcjpwYXNz' });
+    expect(h['proxy-authorization']).toBe('Basic dXNlcjpwYXNz');
+    expect('X-Proxy-Proxy-Authorization' in h).toBe(false);
+  });
+
+  it('leaves non-forbidden headers untouched', async () => {
+    const h = await dispatch({ 'User-Agent': 'curl/8', Accept: '*/*' });
+    expect(h['User-Agent']).toBe('curl/8');
+    expect(h['Accept']).toBe('*/*');
+  });
+});
+
+describe('handleFetchProxyConnection — Set-Cookie encode on response', () => {
+  let pipeline: SecretsPipeline;
+
+  beforeEach(async () => {
+    pipeline = new SecretsPipeline({
+      sessionId: 'session-fixed',
+      source: { get: async () => undefined, listAll: async () => [] },
+    });
+    await pipeline.reload();
+  });
+
+  it('packs upstream Set-Cookie values into X-Proxy-Set-Cookie JSON array', async () => {
+    const upstreamHeaders = new Headers([
+      ['content-type', 'text/plain'],
+      ['set-cookie', 'sid=abc; Path=/'],
+      ['set-cookie', 'theme=dark; Path=/'],
+    ]);
+    (globalThis as any).fetch = vi.fn(
+      async () => new Response('ok', { status: 200, statusText: 'OK', headers: upstreamHeaders })
+    );
+
+    const posts: any[] = [];
+    const port = makePort((m) => posts.push(m));
+    handleFetchProxyConnection(port, pipeline);
+    port.fireMessage({
+      type: 'request',
+      url: 'https://api.example.com/login',
+      method: 'GET',
+      headers: {},
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const head = posts.find((p) => p.type === 'response-head');
+    expect(head).toBeDefined();
+    expect(head.headers['X-Proxy-Set-Cookie']).toBeDefined();
+    const parsed = JSON.parse(head.headers['X-Proxy-Set-Cookie']);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toContain('sid=abc; Path=/');
+    expect(parsed).toContain('theme=dark; Path=/');
+    // The raw `set-cookie` is dropped from the page-visible map (browsers
+    // strip it anyway; X-Proxy-Set-Cookie is the recoverable transport).
+    expect(head.headers['set-cookie']).toBeUndefined();
+  });
+
+  it('omits X-Proxy-Set-Cookie when upstream sets no cookies', async () => {
+    (globalThis as any).fetch = vi.fn(
+      async () => new Response('ok', { status: 200, statusText: 'OK' })
+    );
+    const posts: any[] = [];
+    const port = makePort((m) => posts.push(m));
+    handleFetchProxyConnection(port, pipeline);
+    port.fireMessage({
+      type: 'request',
+      url: 'https://api.example.com/x',
+      method: 'GET',
+      headers: {},
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    const head = posts.find((p) => p.type === 'response-head');
+    expect(head.headers['X-Proxy-Set-Cookie']).toBeUndefined();
+  });
+});

--- a/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
+++ b/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
@@ -362,6 +362,21 @@ describe('handleFetchProxyConnection — X-Proxy-* request decode', () => {
     expect(h['User-Agent']).toBe('curl/8');
     expect(h['Accept']).toBe('*/*');
   });
+
+  // Default-Origin fallback parity with CLI `/api/fetch-proxy`. When no
+  // caller-supplied Origin reaches the SW (page-side strips Origin on the
+  // forbidden-headers boundary), synthesize one from the target URL so
+  // CORS-protected upstreams see a real Origin instead of nothing.
+  it('synthesizes Origin from target URL when no Origin given', async () => {
+    const h = await dispatch({});
+    expect(h.origin).toBe('https://api.example.com');
+  });
+
+  it('caller-supplied X-Proxy-Origin wins over default-Origin fallback', async () => {
+    const h = await dispatch({ 'X-Proxy-Origin': 'https://my.app' });
+    expect(h.origin).toBe('https://my.app');
+    expect('X-Proxy-Origin' in h).toBe(false);
+  });
 });
 
 describe('handleFetchProxyConnection — Set-Cookie encode on response', () => {

--- a/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
+++ b/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   handleFetchProxyConnection,
   handleFetchProxyConnectionAsync,
@@ -439,5 +439,149 @@ describe('handleFetchProxyConnection — Set-Cookie encode on response', () => {
     await new Promise((r) => setTimeout(r, 10));
     const head = posts.find((p) => p.type === 'response-head');
     expect(head.headers['X-Proxy-Set-Cookie']).toBeUndefined();
+  });
+});
+
+// Chrome strips Cookie/Referer/Proxy-* and overrides Origin on extension-SW
+// `fetch()` even when those headers are listed in the init dict — empirically
+// verified against Chrome for Testing 146 with the fetch-proxy SW (see
+// `/tmp/slicc-empirical/echo-server.js` + `dnr-test.js`). The SW now installs
+// a one-shot `chrome.declarativeNetRequest.updateSessionRules` rule that
+// `set`s those headers on the wire and removes the rule when the response
+// settles. These tests pin the rule shape and lifecycle.
+describe('handleFetchProxyConnection — DNR forbidden-header rule', () => {
+  let pipeline: SecretsPipeline;
+  let dnrCalls: Array<{ addRules?: any[]; removeRuleIds?: number[] }>;
+
+  beforeEach(async () => {
+    pipeline = new SecretsPipeline({
+      sessionId: 'session-fixed',
+      source: { get: async () => undefined, listAll: async () => [] },
+    });
+    await pipeline.reload();
+    dnrCalls = [];
+    (globalThis as any).chrome = {
+      declarativeNetRequest: {
+        updateSessionRules: vi.fn(async (opts: any) => {
+          dnrCalls.push(opts);
+        }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).chrome;
+  });
+
+  async function dispatch(
+    requestHeaders: Record<string, string>,
+    url = 'https://api.example.com/path'
+  ): Promise<{ fetchUrl: string; headersOnFetch: Record<string, string> }> {
+    let fetchUrl: string | undefined;
+    let headersOnFetch: Record<string, string> | undefined;
+    (globalThis as any).fetch = vi.fn(async (u: string, init: any) => {
+      fetchUrl = u;
+      headersOnFetch = init.headers;
+      return new Response('ok', { status: 200, statusText: 'OK' });
+    });
+    const port = makePort(() => {});
+    handleFetchProxyConnection(port, pipeline);
+    port.fireMessage({ type: 'request', url, method: 'GET', headers: requestHeaders });
+    await new Promise((r) => setTimeout(r, 10));
+    if (!fetchUrl || !headersOnFetch) throw new Error('fetch was not called');
+    return { fetchUrl, headersOnFetch };
+  }
+
+  it('installs a session rule that sets origin/cookie/referer/proxy-* on the wire', async () => {
+    await dispatch({
+      'X-Proxy-Origin': 'https://my.app',
+      'X-Proxy-Cookie': 'sid=abc',
+      'X-Proxy-Referer': 'https://my.ref/page',
+      'X-Proxy-Proxy-Authorization': 'Basic dXNlcjpwYXNz',
+    });
+    const installs = dnrCalls.filter((c) => c.addRules);
+    expect(installs).toHaveLength(1);
+    const rule = installs[0].addRules![0];
+    expect(rule.action.type).toBe('modifyHeaders');
+    const headerMap = new Map<string, string>(
+      rule.action.requestHeaders.map((h: any) => [h.header, h.value])
+    );
+    expect(headerMap.get('origin')).toBe('https://my.app');
+    expect(headerMap.get('cookie')).toBe('sid=abc');
+    expect(headerMap.get('referer')).toBe('https://my.ref/page');
+    expect(headerMap.get('proxy-authorization')).toBe('Basic dXNlcjpwYXNz');
+    for (const h of rule.action.requestHeaders) {
+      expect(h.operation).toBe('set');
+    }
+  });
+
+  it('keys the rule via a unique URL fragment that survives to the fetch call', async () => {
+    const { fetchUrl } = await dispatch({ 'X-Proxy-Origin': 'https://a.example' });
+    expect(fetchUrl).toMatch(/^https:\/\/api\.example\.com\/path#slicc-req-/);
+    const rule = dnrCalls.find((c) => c.addRules)!.addRules![0];
+    expect(rule.condition.urlFilter).toBe(fetchUrl);
+  });
+
+  it('removes the session rule after the response settles', async () => {
+    await dispatch({ 'X-Proxy-Origin': 'https://my.app' });
+    const installs = dnrCalls.filter((c) => c.addRules);
+    const removes = dnrCalls.filter((c) => c.removeRuleIds);
+    expect(installs).toHaveLength(1);
+    expect(removes).toHaveLength(1);
+    expect(removes[0].removeRuleIds).toEqual([installs[0].addRules![0].id]);
+  });
+
+  it('removes the session rule even when fetch rejects', async () => {
+    (globalThis as any).fetch = vi.fn(async () => {
+      throw new Error('network');
+    });
+    const port = makePort(() => {});
+    handleFetchProxyConnection(port, pipeline);
+    port.fireMessage({
+      type: 'request',
+      url: 'https://api.example.com/x',
+      method: 'GET',
+      headers: { 'X-Proxy-Origin': 'https://my.app' },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(dnrCalls.filter((c) => c.removeRuleIds)).toHaveLength(1);
+  });
+
+  it('does not install a rule when no forbidden header is present', async () => {
+    // No X-Proxy-* headers AND a target URL that won't trigger the
+    // default-origin fallback path? It always does — default-Origin
+    // fallback synthesizes `origin` from the target URL, so DNR is
+    // always invoked once the SW reaches fetch. Verify the rule has
+    // ONLY `origin` (the fallback), not cookie/referer/proxy-*.
+    await dispatch({});
+    const installs = dnrCalls.filter((c) => c.addRules);
+    expect(installs).toHaveLength(1);
+    const rule = installs[0].addRules![0];
+    const headerNames = rule.action.requestHeaders.map((h: any) => h.header);
+    expect(headerNames).toEqual(['origin']);
+  });
+
+  it('strips a caller-supplied URL fragment from the wire URL', async () => {
+    const { fetchUrl } = await dispatch(
+      { 'X-Proxy-Origin': 'https://my.app' },
+      'https://api.example.com/path#caller-supplied'
+    );
+    expect(fetchUrl).not.toContain('caller-supplied');
+    expect(fetchUrl).toMatch(/^https:\/\/api\.example\.com\/path#slicc-req-/);
+  });
+
+  it('falls back to a no-op when chrome.declarativeNetRequest is unavailable', async () => {
+    delete (globalThis as any).chrome;
+    const { fetchUrl, headersOnFetch } = await dispatch({
+      'X-Proxy-Origin': 'https://my.app',
+      'X-Proxy-Cookie': 'sid=abc',
+    });
+    // No fragment appended — fetch sees the original URL.
+    expect(fetchUrl).toBe('https://api.example.com/path');
+    // Forbidden headers still passed under their real names so unit tests
+    // that mock `fetch` can capture them. Real Chrome strips them; that's
+    // the fallback-no-fix mode the helper documents.
+    expect(headersOnFetch.origin).toBe('https://my.app');
+    expect(headersOnFetch.cookie).toBe('sid=abc');
   });
 });

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -1233,6 +1233,16 @@ async function main() {
         // Only strip browser's auto-added localhost origin, preserve legitimate origins
         delete headers['origin'];
       }
+      // Default-Origin fallback: when no explicit caller Origin survives, synthesize
+      // one from the target URL so upstream CORS-protected APIs see a real Origin
+      // instead of nothing. Caller-supplied X-Proxy-Origin (handled above) still wins.
+      if (!headers['origin']) {
+        try {
+          headers['origin'] = new URL(targetUrl).origin;
+        } catch {
+          // Malformed targetUrl — leave origin unset; the upstream fetch will fail anyway.
+        }
+      }
 
       // Forbidden-header transport: restore X-Proxy-Referer → Referer
       const proxyReferer = req.headers['x-proxy-referer'];

--- a/packages/node-server/tests/integration/server/server-api.test.ts
+++ b/packages/node-server/tests/integration/server/server-api.test.ts
@@ -362,6 +362,123 @@ describe('shared server API conformance', () => {
     }
   });
 
+  it('synthesizes a default Origin from the target URL when none is supplied', async () => {
+    const { createServer } = await import('node:http');
+    const upstream = createServer((req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ origin: req.headers['origin'] || null }));
+    });
+
+    await new Promise<void>((resolve) => upstream.listen(0, resolve));
+    const port = (upstream.address() as import('node:net').AddressInfo).port;
+
+    try {
+      const res = await fetchFromServer('/api/fetch-proxy', {
+        method: 'GET',
+        headers: { 'x-target-url': `http://127.0.0.1:${port}/path` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.origin).toBe(`http://127.0.0.1:${port}`);
+    } finally {
+      upstream.close();
+    }
+  });
+
+  it('explicit X-Proxy-Origin wins over the default-Origin fallback', async () => {
+    const { createServer } = await import('node:http');
+    const upstream = createServer((req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ origin: req.headers['origin'] || null }));
+    });
+
+    await new Promise<void>((resolve) => upstream.listen(0, resolve));
+    const port = (upstream.address() as import('node:net').AddressInfo).port;
+
+    try {
+      const res = await fetchFromServer('/api/fetch-proxy', {
+        method: 'GET',
+        headers: {
+          'x-target-url': `http://127.0.0.1:${port}/path`,
+          'x-proxy-origin': 'https://example.com',
+        },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.origin).toBe('https://example.com');
+    } finally {
+      upstream.close();
+    }
+  });
+
+  it('strips localhost Origin then refills with default-Origin fallback', async () => {
+    const { createServer } = await import('node:http');
+    const upstream = createServer((req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ origin: req.headers['origin'] || null }));
+    });
+
+    await new Promise<void>((resolve) => upstream.listen(0, resolve));
+    const port = (upstream.address() as import('node:net').AddressInfo).port;
+
+    try {
+      const res = await fetchFromServer('/api/fetch-proxy', {
+        method: 'GET',
+        headers: {
+          'x-target-url': `http://127.0.0.1:${port}/path`,
+          origin: 'http://localhost:5710',
+        },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // The page's localhost Origin should be stripped, then the fallback fires
+      // and substitutes the target URL's origin — not the page Origin.
+      expect(body.origin).toBe(`http://127.0.0.1:${port}`);
+    } finally {
+      upstream.close();
+    }
+  });
+
+  it('derives default Origin for unusual ports and IPv6 hosts', async () => {
+    const { createServer } = await import('node:http');
+    const upstream = createServer((req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ origin: req.headers['origin'] || null }));
+    });
+
+    // Try IPv6 loopback first to exercise the [::1] origin shape end-to-end;
+    // fall back to IPv4 if the runner has IPv6 disabled (some CI sandboxes do).
+    const ipv6Ok = await new Promise<boolean>((resolve) => {
+      const onError = () => {
+        upstream.removeAllListeners('error');
+        resolve(false);
+      };
+      upstream.once('error', onError);
+      upstream.listen(0, '::1', () => {
+        upstream.off('error', onError);
+        resolve(true);
+      });
+    });
+    if (!ipv6Ok) {
+      await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+    }
+    const port = (upstream.address() as import('node:net').AddressInfo).port;
+    const host = ipv6Ok ? '[::1]' : '127.0.0.1';
+
+    try {
+      const res = await fetchFromServer('/api/fetch-proxy', {
+        method: 'GET',
+        headers: { 'x-target-url': `http://${host}:${port}/path` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // WHATWG URL preserves the bracketed IPv6 host and the explicit port.
+      expect(body.origin).toBe(`http://${host}:${port}`);
+    } finally {
+      upstream.close();
+    }
+  });
+
   it('returns webhook CORS headers for preflight requests', async () => {
     const response = await fetchFromServer('/webhooks/test-id', { method: 'OPTIONS' });
     expect(response.status).toBe(204);

--- a/packages/swift-server/Package.resolved
+++ b/packages/swift-server/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c810138d92c8a86434268bba08432ad72190a650fdbb52045657acd9476de26d",
+  "originHash" : "87de4887195cd19325dd95f3f2b4ce936181ab441d8bcc1e5c8c373432b4b103",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "b31565862a8f39866af50bc6676160d8dda7de35",
-        "version" : "2.96.0"
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
       }
     },
     {

--- a/packages/webapp/src/shell/proxied-fetch.ts
+++ b/packages/webapp/src/shell/proxied-fetch.ts
@@ -117,6 +117,11 @@ async function extensionPortFetch(
   const plainHeaders = headersToRecord(options?.headers);
   const method = options?.method ?? 'GET';
   const preparedBody = options?.body ? prepareRequestBody(options.body, plainHeaders) : undefined;
+  // Encode forbidden headers (Cookie/Origin/Referer/Proxy-*) under X-Proxy-*
+  // transport so the SW can restore them before calling upstream `fetch()` —
+  // same wire format the CLI proxy uses. Without this the SW silently
+  // strips them at the browser fetch boundary.
+  const transportHeaders = encodeForbiddenRequestHeaders(plainHeaders);
 
   let bodyBase64: string | undefined;
   let requestBodyTooLarge = false;
@@ -173,10 +178,14 @@ async function extensionPortFetch(
         });
         readResponseBody(synth, url)
           .then((body) => {
+            // Decode `X-Proxy-Set-Cookie` → `set-cookie` JSON-array string so
+            // callers can recover Set-Cookie values the browser would otherwise
+            // strip — matches CLI client decoding.
+            const decodedHeaders = decodeForbiddenResponseHeaders(headInfo!.headers);
             resolve({
               status: headInfo!.status,
               statusText: headInfo!.statusText,
-              headers: headInfo!.headers,
+              headers: decodedHeaders,
               body,
               url,
             });
@@ -211,7 +220,7 @@ async function extensionPortFetch(
       type: 'request',
       url,
       method,
-      headers: plainHeaders,
+      headers: transportHeaders,
       bodyBase64,
       requestBodyTooLarge,
     });

--- a/packages/webapp/src/shell/proxy-headers.ts
+++ b/packages/webapp/src/shell/proxy-headers.ts
@@ -41,6 +41,35 @@ export function encodeForbiddenRequestHeaders(
 }
 
 /**
+ * Decode request headers from the X-Proxy-* transport back to their real names.
+ * X-Proxy-Cookie → cookie, X-Proxy-Origin → origin, X-Proxy-Referer → referer,
+ * X-Proxy-Proxy-* → proxy-*. Inverse of `encodeForbiddenRequestHeaders` —
+ * used by the proxy server side (CLI Express handler, extension SW) before
+ * calling upstream `fetch()`. Match is case-insensitive on the `X-Proxy-`
+ * prefix; the decoded key is always lowercase.
+ */
+export function decodeForbiddenRequestHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    if (lower === 'x-proxy-cookie') {
+      result['cookie'] = value;
+    } else if (lower === 'x-proxy-origin') {
+      result['origin'] = value;
+    } else if (lower === 'x-proxy-referer') {
+      result['referer'] = value;
+    } else if (lower.startsWith('x-proxy-proxy-')) {
+      result[lower.replace(/^x-proxy-/, '')] = value;
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
  * Decode response headers that the proxy transported under non-forbidden names.
  * X-Proxy-Set-Cookie (JSON array) → set-cookie (JSON array string)
  */

--- a/packages/webapp/src/shell/proxy-headers.ts
+++ b/packages/webapp/src/shell/proxy-headers.ts
@@ -104,3 +104,31 @@ export function headersToRecord(
   }
   return headers;
 }
+
+/**
+ * Coerce any `HeadersInit` shape (Headers / record / [k,v][] array) to a
+ * plain record so it can ride on `SecureFetchOptions.headers`. Returns
+ * `undefined` when no headers are present (or the result would be empty)
+ * so callers can omit the field entirely — preserving the "no empty
+ * object leak" contract verified by the `asWebFetch` Origin-propagation
+ * tests.
+ */
+export function normalizeHeadersInit(
+  headers: HeadersInit | undefined
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) {
+    const rec: Record<string, string> = {};
+    headers.forEach((v, k) => {
+      rec[k] = v;
+    });
+    return Object.keys(rec).length === 0 ? undefined : rec;
+  }
+  if (Array.isArray(headers)) {
+    const rec: Record<string, string> = {};
+    for (const [k, v] of headers) rec[k] = v;
+    return Object.keys(rec).length === 0 ? undefined : rec;
+  }
+  const rec = { ...(headers as Record<string, string>) };
+  return Object.keys(rec).length === 0 ? undefined : rec;
+}

--- a/packages/webapp/src/shell/supplemental-commands/discover-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/discover-command.ts
@@ -31,6 +31,7 @@ import { discoverLinks } from '../../net/discover-links.js';
 import { extractHandoff } from '../../net/handoff-link.js';
 import { parseLinkHeader } from '../../net/link-header.js';
 import { createProxiedFetch } from '../proxied-fetch.js';
+import { normalizeHeadersInit } from '../proxy-headers.js';
 
 /**
  * Wrap a `SecureFetch` so it can stand in for the Web Fetch API. Used to
@@ -50,7 +51,7 @@ export function asWebFetch(secureFetch: SecureFetch): typeof fetch {
   const adapter = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url =
       typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-    const headers = normalizeHeaders(init?.headers);
+    const headers = normalizeHeadersInit(init?.headers);
     const result = await secureFetch(url, {
       method: init?.method ?? 'GET',
       ...(headers ? { headers } : {}),
@@ -62,29 +63,6 @@ export function asWebFetch(secureFetch: SecureFetch): typeof fetch {
     });
   };
   return adapter as typeof fetch;
-}
-
-/**
- * Convert any `HeadersInit` shape to a plain `Record<string, string>` so the
- * forbidden-header encoder in `proxied-fetch` can read it. Returns `undefined`
- * when no headers are present so the adapter can omit the field entirely.
- */
-function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> | undefined {
-  if (!headers) return undefined;
-  if (headers instanceof Headers) {
-    const rec: Record<string, string> = {};
-    headers.forEach((v, k) => {
-      rec[k] = v;
-    });
-    return Object.keys(rec).length === 0 ? undefined : rec;
-  }
-  if (Array.isArray(headers)) {
-    const rec: Record<string, string> = {};
-    for (const [k, v] of headers) rec[k] = v;
-    return Object.keys(rec).length === 0 ? undefined : rec;
-  }
-  const rec = { ...(headers as Record<string, string>) };
-  return Object.keys(rec).length === 0 ? undefined : rec;
 }
 
 function helpText(): string {

--- a/packages/webapp/src/shell/supplemental-commands/discover-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/discover-command.ts
@@ -37,6 +37,11 @@ import { createProxiedFetch } from '../proxied-fetch.js';
  * give `discoverLinks` (which speaks Web Fetch) the same CORS bypass /
  * forbidden-header bridging the rest of the shell enjoys.
  *
+ * Forwards caller-supplied `init.headers` (including forbidden headers like
+ * `Origin` / `Cookie` / `Referer`) so the underlying `SecureFetch` can run
+ * them through `encodeForbiddenRequestHeaders` and the proxy preserves them
+ * end-to-end.
+ *
  * The adapter doesn't thread `AbortSignal` into the underlying secure fetch
  * (the SecureFetch contract has no signal slot) — `discoverLinks` already
  * caps each call with its own timeout and tolerates non-aborting fetches.
@@ -45,7 +50,11 @@ function asWebFetch(secureFetch: SecureFetch): typeof fetch {
   const adapter = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url =
       typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-    const result = await secureFetch(url, { method: init?.method ?? 'GET' });
+    const headers = normalizeHeaders(init?.headers);
+    const result = await secureFetch(url, {
+      method: init?.method ?? 'GET',
+      ...(headers ? { headers } : {}),
+    });
     return new Response(result.body as BodyInit, {
       status: result.status,
       statusText: result.statusText,
@@ -53,6 +62,29 @@ function asWebFetch(secureFetch: SecureFetch): typeof fetch {
     });
   };
   return adapter as typeof fetch;
+}
+
+/**
+ * Convert any `HeadersInit` shape to a plain `Record<string, string>` so the
+ * forbidden-header encoder in `proxied-fetch` can read it. Returns `undefined`
+ * when no headers are present so the adapter can omit the field entirely.
+ */
+function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) {
+    const rec: Record<string, string> = {};
+    headers.forEach((v, k) => {
+      rec[k] = v;
+    });
+    return Object.keys(rec).length === 0 ? undefined : rec;
+  }
+  if (Array.isArray(headers)) {
+    const rec: Record<string, string> = {};
+    for (const [k, v] of headers) rec[k] = v;
+    return Object.keys(rec).length === 0 ? undefined : rec;
+  }
+  const rec = { ...(headers as Record<string, string>) };
+  return Object.keys(rec).length === 0 ? undefined : rec;
 }
 
 function helpText(): string {

--- a/packages/webapp/src/shell/supplemental-commands/discover-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/discover-command.ts
@@ -46,7 +46,7 @@ import { createProxiedFetch } from '../proxied-fetch.js';
  * (the SecureFetch contract has no signal slot) — `discoverLinks` already
  * caps each call with its own timeout and tolerates non-aborting fetches.
  */
-function asWebFetch(secureFetch: SecureFetch): typeof fetch {
+export function asWebFetch(secureFetch: SecureFetch): typeof fetch {
   const adapter = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url =
       typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;

--- a/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
@@ -1668,7 +1668,7 @@ function requireTab(flags: Record<string, string>): { targetId: string } | { err
  * forwards `init.headers` so caller-supplied forbidden headers
  * (`Origin`, `Cookie`, `Referer`) survive end-to-end.
  */
-function asWebFetch(secureFetch: SecureFetch): typeof fetch {
+export function asWebFetch(secureFetch: SecureFetch): typeof fetch {
   const adapter = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url =
       typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;

--- a/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
@@ -19,6 +19,7 @@ import { discoverLinks } from '../../net/discover-links.js';
 import { extractHandoff, type HandoffMatch } from '../../net/handoff-link.js';
 import { parseLinkHeader, type ParsedLink } from '../../net/link-header.js';
 import { createProxiedFetch } from '../proxied-fetch.js';
+import { normalizeHeadersInit } from '../proxy-headers.js';
 import {
   fetchBrowseShCatalog,
   normalizeHostname,
@@ -1684,31 +1685,6 @@ export function asWebFetch(secureFetch: SecureFetch): typeof fetch {
     });
   };
   return adapter as typeof fetch;
-}
-
-/**
- * Coerce any `HeadersInit` shape to a plain record so it can ride on
- * `SecureFetchOptions.headers`. Returns `undefined` when empty so the
- * adapter can omit the field entirely.
- */
-function normalizeHeadersInit(
-  headers: HeadersInit | undefined
-): Record<string, string> | undefined {
-  if (!headers) return undefined;
-  if (headers instanceof Headers) {
-    const rec: Record<string, string> = {};
-    headers.forEach((v, k) => {
-      rec[k] = v;
-    });
-    return Object.keys(rec).length === 0 ? undefined : rec;
-  }
-  if (Array.isArray(headers)) {
-    const rec: Record<string, string> = {};
-    for (const [k, v] of headers) rec[k] = v;
-    return Object.keys(rec).length === 0 ? undefined : rec;
-  }
-  const rec = { ...(headers as Record<string, string>) };
-  return Object.keys(rec).length === 0 ? undefined : rec;
 }
 
 /** One browse.sh catalog match for the destination hostname. */

--- a/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
@@ -1664,13 +1664,19 @@ function requireTab(flags: Record<string, string>): { targetId: string } | { err
 /**
  * Adapter that lets `discoverLinks` (Web Fetch shape) ride on our
  * `SecureFetch`, inheriting CORS bypass and forbidden-header bridging.
- * Mirrors the helper used by the standalone `discover` command.
+ * Mirrors the helper used by the standalone `discover` command — also
+ * forwards `init.headers` so caller-supplied forbidden headers
+ * (`Origin`, `Cookie`, `Referer`) survive end-to-end.
  */
 function asWebFetch(secureFetch: SecureFetch): typeof fetch {
   const adapter = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url =
       typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-    const result = await secureFetch(url, { method: init?.method ?? 'GET' });
+    const headers = normalizeHeadersInit(init?.headers);
+    const result = await secureFetch(url, {
+      method: init?.method ?? 'GET',
+      ...(headers ? { headers } : {}),
+    });
     return new Response(result.body as BodyInit, {
       status: result.status,
       statusText: result.statusText,
@@ -1678,6 +1684,31 @@ function asWebFetch(secureFetch: SecureFetch): typeof fetch {
     });
   };
   return adapter as typeof fetch;
+}
+
+/**
+ * Coerce any `HeadersInit` shape to a plain record so it can ride on
+ * `SecureFetchOptions.headers`. Returns `undefined` when empty so the
+ * adapter can omit the field entirely.
+ */
+function normalizeHeadersInit(
+  headers: HeadersInit | undefined
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) {
+    const rec: Record<string, string> = {};
+    headers.forEach((v, k) => {
+      rec[k] = v;
+    });
+    return Object.keys(rec).length === 0 ? undefined : rec;
+  }
+  if (Array.isArray(headers)) {
+    const rec: Record<string, string> = {};
+    for (const [k, v] of headers) rec[k] = v;
+    return Object.keys(rec).length === 0 ? undefined : rec;
+  }
+  const rec = { ...(headers as Record<string, string>) };
+  return Object.keys(rec).length === 0 ? undefined : rec;
 }
 
 /** One browse.sh catalog match for the destination hostname. */

--- a/packages/webapp/tests/shell/node-fetch-adapter.test.ts
+++ b/packages/webapp/tests/shell/node-fetch-adapter.test.ts
@@ -357,4 +357,54 @@ describe('createNodeFetchAdapter', () => {
       })
     ).rejects.toThrow(/unsupported request body type/);
   });
+
+  it('propagates Origin from init.headers (Record) to SecureFetch', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    await fetch('https://api.example.com/x', {
+      method: 'GET',
+      headers: { Origin: 'https://my.app', Cookie: 'sid=abc' },
+    });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    expect(opts.headers['Origin']).toBe('https://my.app');
+    expect(opts.headers['Cookie']).toBe('sid=abc');
+  });
+
+  it('propagates Origin from init.headers (Headers instance) to SecureFetch', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const h = new Headers();
+    h.set('Origin', 'https://my.app');
+    await fetch('https://api.example.com/x', { method: 'GET', headers: h });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    // Headers normalizes keys to lowercase, but the value must survive.
+    expect(opts.headers['origin']).toBe('https://my.app');
+  });
+
+  it('lets init.headers Origin override a Request.headers Origin', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    const request = new Request('https://api.example.com/x', {
+      method: 'GET',
+      headers: { Origin: 'https://from-request' },
+    });
+    await fetch(request, { headers: { Origin: 'https://from-init' } });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    // init wins on conflicts; case may differ depending on Headers
+    // normalization, so check both candidate slots.
+    const origin = opts.headers['Origin'] ?? opts.headers['origin'];
+    expect(origin).toBe('https://from-init');
+  });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import {
+  asWebFetch as asWebFetchPlaywright,
   createPlaywrightCommand,
   getSharedState,
   setPlaywrightTeleportBestFollower,
   setPlaywrightTeleportConnectedFollowers,
 } from '../../../src/shell/supplemental-commands/playwright-command.js';
+import { asWebFetch as asWebFetchDiscover } from '../../../src/shell/supplemental-commands/discover-command.js';
+import type { SecureFetch } from 'just-bash';
 import { _resetBrowseShCatalogCache } from '../../../src/shell/supplemental-commands/upskill-command.js';
 import type { BrowserAPI } from '../../../src/cdp/index.js';
 import type { VirtualFS } from '../../../src/fs/index.js';
@@ -3930,4 +3933,61 @@ describe('playwright-cli --discover surfaces browse.sh skills', () => {
     });
     expect(catalogHits).toHaveLength(0);
   });
+});
+
+// Origin-propagation contract for the two `asWebFetch` shims.
+// `discoverLinks` (and similar Web-Fetch-shaped consumers) speak the
+// browser Fetch API; the shims wrap a `SecureFetch` so those callers
+// inherit our CORS bypass + forbidden-header bridging. If the shim
+// drops `init.headers`, a caller-supplied `Origin` is silently lost on
+// the way to the proxy — breaking the Wave 1 Origin contract.
+describe('asWebFetch — Origin propagation through SecureFetch shim', () => {
+  function makeOkFetchResult() {
+    return {
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'text/plain' },
+      body: new TextEncoder().encode('ok'),
+      url: 'https://api.example.com/x',
+    };
+  }
+
+  for (const [label, asWebFetch] of [
+    ['discover-command.asWebFetch', asWebFetchDiscover],
+    ['playwright-command.asWebFetch', asWebFetchPlaywright],
+  ] as const) {
+    describe(label, () => {
+      it('forwards init.headers.Origin (record) to the underlying SecureFetch', async () => {
+        const secureFetch = vi.fn(async () => makeOkFetchResult()) as unknown as SecureFetch;
+        const fetchAdapter = asWebFetch(secureFetch);
+        await fetchAdapter('https://api.example.com/x', {
+          headers: { Origin: 'https://my.app' },
+        });
+        expect(secureFetch).toHaveBeenCalledTimes(1);
+        const [, opts] = (secureFetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(opts?.headers).toMatchObject({ Origin: 'https://my.app' });
+      });
+
+      it('forwards init.headers.Origin (Headers instance) to the underlying SecureFetch', async () => {
+        const secureFetch = vi.fn(async () => makeOkFetchResult()) as unknown as SecureFetch;
+        const fetchAdapter = asWebFetch(secureFetch);
+        const h = new Headers();
+        h.set('Origin', 'https://my.app');
+        await fetchAdapter('https://api.example.com/x', { headers: h });
+        const [, opts] = (secureFetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+        const got = opts?.headers as Record<string, string>;
+        // Headers lowercase keys when iterated via forEach.
+        const originVal = got['origin'] ?? got['Origin'];
+        expect(originVal).toBe('https://my.app');
+      });
+
+      it('omits headers when no init.headers given (no empty object leak)', async () => {
+        const secureFetch = vi.fn(async () => makeOkFetchResult()) as unknown as SecureFetch;
+        const fetchAdapter = asWebFetch(secureFetch);
+        await fetchAdapter('https://api.example.com/x');
+        const [, opts] = (secureFetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(opts?.headers).toBeUndefined();
+      });
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Fixes silent dropping of the `Origin` request header on agent-initiated HTTP calls in both CLI and extension floats. Upstream APIs that require a real `Origin` (CORS-protected endpoints, OAuth issuers, WAF-protected backends) were rejecting slicc requests because the proxy either passed the page's `localhost` origin or no origin at all.

## Background

Three browser realities collide in slicc's fetch path:

1. `Origin` is a **forbidden request header** — the browser silently strips it on `fetch()` calls from page and service-worker contexts.
2. **CLI mode** had a workaround: page-side `createProxiedFetch()` smuggled it as `X-Proxy-Origin`, and `/api/fetch-proxy` decoded it back. But if no caller explicitly set one, the proxy also stripped the browser's auto-added `localhost` Origin, so upstream received nothing.
3. **Extension mode** had no smuggling at all: `extensionPortFetch` posted raw headers to the SW, whose `fetch()` also strips forbidden headers. Any explicit `Origin` passed by the caller was lost.

## Changes

Six commits across five areas:

### Extension SW X-Proxy-* transport parity with CLI
- `packages/webapp/src/shell/proxy-headers.ts` — added `decodeForbiddenRequestHeaders` and `encodeForbiddenResponseHeaders`
- `packages/webapp/src/shell/proxied-fetch.ts` — `extensionPortFetch` now encodes forbidden request headers; response decode wired through `decodeForbiddenResponseHeaders` to recover `Set-Cookie`
- `packages/chrome-extension/src/fetch-proxy-shared.ts` — both sync and async SW handlers decode `X-Proxy-Origin`/`X-Proxy-Referer`/`X-Proxy-Cookie`/`X-Proxy-Proxy-*` before the upstream `fetch()`, and repack upstream `Set-Cookie` into `X-Proxy-Set-Cookie`

### Default-Origin synthesis (CLI + extension)
- `packages/node-server/src/index.ts` — `/api/fetch-proxy` synthesizes `Origin: <scheme>://<host>` from the target URL when no caller-supplied Origin reaches the proxy. Caller's `X-Proxy-Origin` still wins; localhost Origins get stripped then refilled.
- `packages/chrome-extension/src/fetch-proxy-shared.ts` — same fallback in both SW handlers, applied after the X-Proxy-Origin decode step.

### Extension SW: DNR-based wire-level header restoration (Codex P1 follow-up)
Decoding `X-Proxy-*` back to real header names is necessary but not sufficient — empirically verified that Chrome's extension-SW `fetch()` still strips `Cookie` / `Referer` / `Proxy-*` and overrides `Origin` to `chrome-extension://<id>`, no matter what the init dict contains. The SW now installs a per-request `chrome.declarativeNetRequest.updateSessionRules` rule that `set`s those headers on the outbound wire, keyed to a unique `#slicc-req-<uuid>` URL fragment so concurrent requests don't collide. The rule is removed in a `finally` block once the response settles. Falls back to a no-op when `chrome.declarativeNetRequest` is unavailable.
- `packages/chrome-extension/src/fetch-proxy-shared.ts` — new `installForbiddenHeaderRule` helper, wired into both handlers
- `packages/chrome-extension/manifest.json` — `declarativeNetRequestWithHostAccess` permission already present

### SecureFetch caller audit
- `packages/webapp/src/shell/supplemental-commands/discover-command.ts` and `playwright-command.ts` — `asWebFetch` shims were silently dropping `init.headers`. Now forward caller-supplied headers (Origin/Cookie/Referer) all the way through to `SecureFetch`.
- New tests in `node-fetch-adapter` covering Origin propagation (record + `Headers` + init-wins-over-Request semantics).

### Documentation
- `docs/pitfalls.md` — new "Origin Contract: Forbidden Headers & Default-Origin Fallback" section covering browser stripping, `X-Proxy-*` transport in both floats, default-Origin synthesis, and override examples for `curl`/`node -e`/`upskill`/`mcp invoke`.
- `docs/shell-reference.md` — cross-linked from the Proxied Fetch section.

## Tests

- 7 new fetch-proxy unit tests in `packages/chrome-extension/tests/fetch-proxy-shared.test.ts` (origin decode, referer decode, cookie decode, proxy-* decode, Set-Cookie encode, default-Origin fallback fills when missing, explicit Origin wins).
- **7 new DNR unit tests** (Wave 2): rule shape, fragment keying, cleanup on success, cleanup on fetch-reject, default-Origin-only rule when no forbidden caller headers, caller-fragment-strip, DNR-unavailable fallback.
- 4 new integration tests in `packages/node-server/tests/integration/server/server-api.test.ts` covering the CLI default-Origin fallback.
- 6 new `asWebFetch` Origin propagation tests across `discover-command` and `playwright-command`.
- 3 new `node-fetch-adapter` Origin tests.
- **End-to-end live drive** against the built extension under Chrome for Testing 146: `X-Proxy-Origin`/`X-Proxy-Cookie`/`X-Proxy-Referer`/`X-Proxy-Proxy-Authorization` set on the page→SW message all reach the upstream verbatim. See the [Codex thread reply](https://github.com/ai-ecoverse/slicc/pull/768#issuecomment-4556367288) for the log.

Full CI gate passes locally: typecheck ✅, 5235 tests passing (0 failed, 3 skipped), `npm run build` ✅, `npm run build -w @slicc/chrome-extension` ✅.

## Acceptance criteria (all met)

- ✅ An agent calling `curl https://api.example.com/foo` results in upstream receiving `Origin: https://api.example.com` (synthesized fallback), in both CLI and extension floats.
- ✅ An agent calling `curl -H "Origin: https://my.app" https://api.example.com/foo` results in upstream receiving `Origin: https://my.app` (explicit override), in both floats.
- ✅ No upstream request reaches the wire with `Origin: http://localhost:5710` (or any other slicc page Origin) leaked from the page.
- ✅ `Set-Cookie` round-trips back to the agent in extension mode (parity with CLI).
- ✅ Existing CLI fetch-proxy behavior unchanged for callers that already set `X-Proxy-Origin` explicitly.

## Non-goals

- No CORS/credentials semantics changes.
- No per-host Origin policy or allow-lists.
- No `SecureFetch` type-signature changes.
- LLM SSE proxy, mount-backend signing, and OAuth-domain allow-list are untouched.
- Did NOT auto-synthesize `Referer` (only `Origin`) — Referer leaks the source page in ways Origin does not.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author