### PR TITLE
docs(skills): light/dark theming + dip auto-size rules

### DIFF
--- a/packages/vfs-root/workspace/skills/dips/SKILL.md
+++ b/packages/vfs-root/workspace/skills/dips/SKILL.md
@@ -59,13 +59,27 @@ Multiple cards in one message: each is a separate `.sprinkle-action-card`. The i
 Inside dips, bare HTML form elements are pre-styled to match S2:
 
 - `<input type="range">` — 4px track, 18px accent thumb.
-- `<input type="text">`, `<textarea>` — S2 layer-2 background, accent focus ring.
+- `<input type="text">`, `<textarea>` — S2 layer-2 background, accent focus ring. `rows` is fine as an initial size; never add `overflow:auto` or a fixed pixel height — the dip auto-sizes (see "Sizing").
 - `<select>` — S2 styled with focus ring.
 - `<button>` — pill-rounded, 28px height, hover state. Use `.sprinkle-btn--primary` class for the accent fill.
 - `<canvas>` — full-width, rounded corners.
 - `<mark>` — accent-tinted highlight.
 
 No custom CSS needed for basic widgets. Just write bare HTML.
+
+## Sizing
+
+The dip iframe auto-sizes to its content via `ResizeObserver` on `document.body`. **Your content's natural height becomes the iframe height. Don't fight it.**
+
+Never set `height`, `max-height`, `min-height`, `overflow: auto`, or `overflow: scroll` on dip containers. The outer iframe has `overflow: hidden`, so any internal scroller or fixed height clips content instead of growing the iframe. Let content flow and grow.
+
+The one exception is `<canvas>`: canvases need explicit pixel `width`/`height` for the drawing buffer. That's a drawing surface, not a scrollable container — set the pixel dimensions you need.
+
+If content is long enough that it would want to scroll, it belongs in a sprinkle.
+
+## Light & dark mode
+
+Dips inherit the parent's theme automatically. The parent injects its S2 tokens and toggles a `.theme-light` class on the iframe's `<html>` whenever the user flips themes; every `var(--s2-*)` token swaps in lockstep. **Never hard-code dark colors** — always use S2 tokens, or `light-dark()` for one-off custom colors (set `color-scheme: light dark` on an ancestor). **Do not use `@media (prefers-color-scheme: ...)`** — the parent toggle is class-based, so media queries desync. See `/workspace/skills/sprinkles/style-guide.md` for the full S2 token reference and a `light-dark()` example.
 
 ## Color palette for charts
 
@@ -118,7 +132,9 @@ result=$(agent /tmp "curl,jq" "Fetch <url>, return field 'price' as a number.")
 
 ## Don't
 
-- Don't hardcode hex colors — use S2 CSS variables.
+- Don't hardcode hex colors or theme-specific values — use S2 tokens or `light-dark()` (see "Light & dark mode").
+- Don't use `@media (prefers-color-scheme: ...)` to swap colors — the parent's theme toggle is class-based and the media query desyncs.
+- Don't set `height`, `max-height`, `min-height`, `overflow: auto`, or `overflow: scroll` on dip containers — the iframe auto-sizes to content; fixed heights and internal scrollers clip it. Canvases are the one exception (they need pixel dimensions for the drawing buffer). Long content belongs in a sprinkle.
 - Don't build custom progress bars — use `.sprinkle-progress-bar`.
 - Don't build custom status dots — use `.sprinkle-status-light`.
 - Don't use numbered headings (1. File Operations) inside cards — the `__header` IS the heading.

--- a/packages/vfs-root/workspace/skills/dips/patterns.md
+++ b/packages/vfs-root/workspace/skills/dips/patterns.md
@@ -2,6 +2,8 @@
 
 A gallery of 10 ready-to-adapt patterns for inline `shtml` widgets. Each pattern is a self-contained example you can copy and modify. See `SKILL.md` for the design rules, card structure, and pre-styled elements that apply to all of them.
 
+> **Two rules apply to every example below:** (1) use S2 tokens or `light-dark()` for color — never hard-code light/dark values; (2) never set `height`, `max-height`, `min-height`, or `overflow: auto|scroll` on dip containers (the iframe auto-sizes). Canvases are the documented exception — they need pixel dimensions for the drawing buffer.
+
 ## 1. Drag-on-canvas
 
 Drag control points on `<canvas>` — live computed output.
@@ -14,6 +16,8 @@ Drag control points on `<canvas>` — live computed output.
   const cv = document.getElementById('c');
   const ctx = cv.getContext('2d');
   const dpr = window.devicePixelRatio || 1;
+  // Canvas needs explicit pixel dimensions for its drawing buffer — this
+  // is the one allowed exception to the dip "no fixed heights" rule.
   const W = 640, H = 260;
   cv.width = W * dpr; cv.height = H * dpr;
   cv.style.height = H + 'px';
@@ -26,10 +30,10 @@ Drag control points on `<canvas>` — live computed output.
 
 ## 2. Animated step loop
 
-Async loop with speed slider — algorithm visualization.
+Async loop with speed slider — algorithm visualization. The bars container has no fixed height — the tallest bar drives the layout, and `align-items:flex-end` keeps them sitting on a common baseline.
 
 ```shtml
-<div id="bars" style="display:flex;align-items:flex-end;gap:3px;height:160px"></div>
+<div id="bars" style="display:flex;align-items:flex-end;gap:3px"></div>
 <div style="display:flex;gap:8px;align-items:center;margin-top:8px">
   <button onclick="run()">Run</button>
   <input type="range" id="speed" min="10" max="200" value="80">

--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -22,6 +22,14 @@ allowed-tools: bash, read_file, write_file, edit_file
 
 Pick full-document mode when you need custom CSS beyond `.sprinkle-*` classes, complex layouts (sidebar + main, split panes, tabs), or interactive canvas/SVG.
 
+## Light & dark mode
+
+Theming is **automatic**. The parent injects its S2 tokens into every sprinkle iframe and toggles a `.theme-light` class on the iframe's `<html>` whenever the user flips the parent theme. All `var(--s2-*)` tokens swap in lockstep. **Never hard-code colors for one theme.**
+
+- Use S2 tokens (`var(--s2-content-default)`, `var(--s2-bg-layer-2)`, etc.) for everything — see `style-guide.md` for the full reference.
+- For one-off colors not covered by an S2 token, use CSS `light-dark(<light>, <dark>)` and set `color-scheme: light dark` on an ancestor (the root in full-document mode, the outermost container in fragment mode). `light-dark()` returns the dark value only when `color-scheme` is set.
+- **Do NOT use `@media (prefers-color-scheme: ...)`** to swap colors. The parent's theme toggle is a class on `<html>`, not the OS preference, so media queries desync from the actual theme. Use S2 tokens or `light-dark()` instead.
+
 ## Layout & viewport
 
 Sprinkles open in **one of four viewport contexts**, and you must design for the narrowest:

--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -24,11 +24,11 @@ Pick full-document mode when you need custom CSS beyond `.sprinkle-*` classes, c
 
 ## Light & dark mode
 
-Theming is **automatic**. The parent injects its S2 tokens into every sprinkle iframe and toggles a `.theme-light` class on the iframe's `<html>` whenever the user flips the parent theme. All `var(--s2-*)` tokens swap in lockstep. **Never hard-code colors for one theme.**
+Theming is **automatic**. The parent injects its S2 tokens into every sprinkle and toggles a `.theme-light` class on the sprinkle root — the iframe's `<html>` in full-document mode, or the outermost container injected into the sidebar in fragment mode — whenever the user flips the parent theme. All `var(--s2-*)` tokens swap in lockstep. **Never hard-code colors for one theme.**
 
 - Use S2 tokens (`var(--s2-content-default)`, `var(--s2-bg-layer-2)`, etc.) for everything — see `style-guide.md` for the full reference.
-- For one-off colors not covered by an S2 token, use CSS `light-dark(<light>, <dark>)` and set `color-scheme: light dark` on an ancestor (the root in full-document mode, the outermost container in fragment mode). `light-dark()` returns the dark value only when `color-scheme` is set.
-- **Do NOT use `@media (prefers-color-scheme: ...)`** to swap colors. The parent's theme toggle is a class on `<html>`, not the OS preference, so media queries desync from the actual theme. Use S2 tokens or `light-dark()` instead.
+- For one-off colors not covered by an S2 token, use CSS `light-dark(<light>, <dark>)` and set `color-scheme: light dark` on an ancestor (the root in full-document mode, the outermost container in fragment mode). `light-dark()` returns the dark value only when `color-scheme` is set. This intentionally follows the user's OS `color-scheme` preference for one-off custom colors; S2 tokens still track the parent app's class-based theme toggle in lockstep.
+- **Do NOT use `@media (prefers-color-scheme: ...)`** to swap colors that should mirror the parent app's theme. The parent's theme toggle is a class on the sprinkle root, not the OS preference, so media queries desync from the actual app theme. Use S2 tokens (class-driven) or `light-dark()` (OS-driven, for one-off custom colors only) instead.
 
 ## Layout & viewport
 

--- a/packages/vfs-root/workspace/skills/sprinkles/style-guide.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/style-guide.md
@@ -733,7 +733,7 @@ slicc.on('update', function (data) {
 
 ## Light & dark mode
 
-All sprinkles inherit the parent's theme automatically. The parent injects its S2 tokens and toggles a `.theme-light` class on the iframe's `<html>` whenever the user flips themes — every `var(--s2-*)` token below swaps with it. **Never hard-code colors for one theme**, and **do not use `@media (prefers-color-scheme: ...)`** (it desyncs from the parent's class-based toggle).
+All sprinkles inherit the parent's theme automatically. The parent injects its S2 tokens and toggles a `.theme-light` class on the sprinkle root — the iframe's `<html>` in full-document mode, or the outermost container injected into the sidebar in fragment mode — whenever the user flips themes. Every `var(--s2-*)` token below swaps with it. **Never hard-code colors for one theme**, and **do not use `@media (prefers-color-scheme: ...)`** for colors that should mirror the app theme (it desyncs from the parent's class-based toggle).
 
 For one-off colors that aren't covered by an S2 token, use CSS `light-dark()`:
 
@@ -747,7 +747,7 @@ For one-off colors that aren't covered by an S2 token, use CSS `light-dark()`:
 }
 ```
 
-`light-dark()` only resolves the dark branch when `color-scheme` is set on an ancestor — set it on `:root` in full-document mode, or on your outermost container in fragment mode.
+`light-dark()` only resolves the dark branch when `color-scheme` is set on an ancestor — set it on `:root` in full-document mode, or on your outermost container in fragment mode. This intentionally follows the user's OS `color-scheme` preference for one-off custom colors; the S2 tokens above still track the parent app's class-based theme toggle in lockstep.
 
 ## Spectrum 2 Token Reference
 

--- a/packages/vfs-root/workspace/skills/sprinkles/style-guide.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/style-guide.md
@@ -523,7 +523,7 @@ Panels should look like professional tools, not chatbot output. Follow these rul
 
 **No emojis in headings or labels.** Use badges, status lights, and semantic color to convey meaning — not 🔍 ❌ ✅ ⚠️ 📊 icons.
 
-**No inline color styles.** Use the semantic variants (`--positive`, `--negative`, `--notice`, `--informative`) instead of hardcoded hex colors.
+**No inline color styles, and never hard-code light/dark values.** Use the semantic variants (`--positive`, `--negative`, `--notice`, `--informative`) and S2 tokens — they swap automatically when the parent theme flips. For one-off colors not covered by a token, use `light-dark()` (see "Light & dark mode" below).
 
 **Use tables for structured findings.** When presenting lists of issues, checks, or recommendations, use `.sprinkle-table` with severity badges in the first column — not bullet lists with emoji prefixes.
 
@@ -731,9 +731,27 @@ slicc.on('update', function (data) {
 
 ---
 
+## Light & dark mode
+
+All sprinkles inherit the parent's theme automatically. The parent injects its S2 tokens and toggles a `.theme-light` class on the iframe's `<html>` whenever the user flips themes — every `var(--s2-*)` token below swaps with it. **Never hard-code colors for one theme**, and **do not use `@media (prefers-color-scheme: ...)`** (it desyncs from the parent's class-based toggle).
+
+For one-off colors that aren't covered by an S2 token, use CSS `light-dark()`:
+
+```css
+:root {
+  color-scheme: light dark;
+}
+.my-tile {
+  background: light-dark(#fafafa, #1c1c1c);
+  color: light-dark(#222, #eee);
+}
+```
+
+`light-dark()` only resolves the dark branch when `color-scheme` is set on an ancestor — set it on `:root` in full-document mode, or on your outermost container in fragment mode.
+
 ## Spectrum 2 Token Reference
 
-Full-document sprinkles (`.shtml`) inherit S2 CSS custom properties from the parent page. Always use tokens — never hardcode hex values.
+Full-document sprinkles (`.shtml`) inherit S2 CSS custom properties from the parent page. Every token below is theme-aware: its value swaps when `.theme-light` is toggled on `<html>`, so you get correct light and dark colors for free. Always use tokens — never hardcode hex values.
 
 ### Border Radius
 


### PR DESCRIPTION
Docs-only update to the bundled VFS skills under `packages/vfs-root/workspace/skills/`.

## Sprinkles

- **`sprinkles/SKILL.md`**: new "Light & dark mode" section explaining that S2 tokens swap automatically when the parent flips themes (`.theme-light` class on the iframe `<html>`), how to use `light-dark()` with `color-scheme: light dark` for one-off custom colors, and an explicit warning against `@media (prefers-color-scheme: ...)` (it desyncs from the parent's class-based toggle).
- **`sprinkles/style-guide.md`**: extended the "No inline color styles" rule to cover hard-coded light/dark values; added a "Light & dark mode" section with a copyable `light-dark()` example; reaffirmed in the S2 token reference intro that every listed token is theme-aware.

## Dips

- **`dips/SKILL.md`**: cross-link to the sprinkles theming section, plus the same warning against hard-coded dark colors and `prefers-color-scheme`. New "Sizing" section documents the `ResizeObserver`-based auto-size contract. New rule in the "Don't" list bans `height`, `max-height`, `min-height`, `overflow: auto`, and `overflow: scroll` on dip containers — they clip content under the iframe's outer `overflow: hidden`. Canvases are noted as the one allowed exception (they need pixel dimensions for the drawing buffer). The `<textarea>` line under "Pre-styled form elements" now points authors at `rows` instead of fixed pixel heights.
- **`dips/patterns.md`**: top-of-file reminder of the two new rules, inline canvas-exception comment in Pattern 1, and Pattern 2's bars container switched from `height:160px` to content-driven sizing (`align-items:flex-end` keeps a common baseline as bar heights drive the row). Patterns 3–10 already comply.

## Verification

- `npx prettier --check packages/vfs-root/workspace/skills/sprinkles packages/vfs-root/workspace/skills/dips` ✅
- `npm run typecheck` ✅
- `npm run test` ✅ (5437 passed, sanity — docs-only change)

No runtime code, CSS, or non-doc files touched.
