### PR TITLE
ci: use staging GitHub OAuth secret for staging worker deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
             E2B_API_KEY
         env:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
-          GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET_STAGING }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
       - name: Wait before staging deploy retry 2
         if: steps.deploy_attempt_1.outcome == 'failure'
@@ -404,7 +404,7 @@ jobs:
             E2B_API_KEY
         env:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
-          GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET_STAGING }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
       - name: Wait before staging deploy retry 3
         if: steps.deploy_attempt_1.outcome == 'failure' && steps.deploy_attempt_2.outcome == 'failure'
@@ -426,7 +426,7 @@ jobs:
             E2B_API_KEY
         env:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
-          GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET_STAGING }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
       - name: Finalize staging deploy
         id: deploy


### PR DESCRIPTION
## Why

Every open PR's `cloudflare-worker` CI job has been failing at the **Smoke test staging** step, regardless of whether the PR touches the worker. Failure is consistent:

```
AssertionError: expected 'incorrect_client_credentials' to be 'bad_verification_code'
  at packages/cloudflare-worker/tests/deployed.test.ts:265
```

The test (`exchanges fake GitHub OAuth codes through valid worker credentials`) sends a fake `code` to the staging worker's `/oauth/token` and expects GitHub to reject the **code** (`bad_verification_code`), which would prove the worker's `(client_id, client_secret)` pair is valid. Instead GitHub rejects the **credentials** (`incorrect_client_credentials`).

### Root cause

`packages/cloudflare-worker/wrangler.jsonc` defines two different `GITHUB_CLIENT_ID`s — one for prod (top-level), one for staging (`env.staging.vars`). But `.github/workflows/ci.yml` was pushing the same repo secret `OAUTH_GITHUB_SECRET` as `GITHUB_CLIENT_SECRET` for both. That secret matches the prod OAuth app, not the staging one, so every staging deploy overwrote the staging worker's secret with a value GitHub then rejected.

Verified by curl against both live deployments:

| Env | URL | Result |
| --- | --- | --- |
| staging | `slicc-tray-hub-staging.minivelos.workers.dev/oauth/token` | `incorrect_client_credentials` ❌ |
| prod | `www.sliccy.ai/oauth/token` | `bad_verification_code` ✅ |

## What

Switch the three staging deploy attempt steps (`deploy_attempt_1/2/3`) in `.github/workflows/ci.yml` so `GITHUB_CLIENT_SECRET` is sourced from the existing `OAUTH_GITHUB_SECRET_STAGING` repo secret (confirmed already configured) instead of `OAUTH_GITHUB_SECRET`.

Prod deploy (`.github/workflows/worker.yml`) is untouched and keeps using `OAUTH_GITHUB_SECRET`.

## Diff

Three single-line replacements, nothing else:

```diff
-          GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET_STAGING }}
```

## Verification

- `npx prettier --check .github/workflows/ci.yml` ✅
- `git diff --stat` → `.github/workflows/ci.yml | 6 +++---` (3 replacements)
- Expected post-merge: `cloudflare-worker` job's smoke test passes on the first try; all currently-blocked PRs (#762, #770, #771, …) can re-run CI to go green.

## Rollback

Revert this commit — staging will be broken the way it is today, but no other regression.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author