### PR TITLE
feat(mcp): add `mcp auth <name>` for OAuth token refresh

### DIFF
--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -68,7 +68,7 @@ Deep reference: `docs/kernel/process-model.md`.
 ### MCP Servers
 
 - Path: `packages/webapp/src/shell/mcp/`; command in `supplemental-commands/mcp-command.ts`.
-- Subcommands: `mcp add <url> [name]`, `mcp list`, `mcp delete <name>`, `mcp invoke <name> [tool] [--flag value]`, `mcp refresh <name>`, `mcp auth <name>` (re-authenticate via silent refresh-token renewal with an interactive popup fallback; `--silent` / `--interactive` to force one path).
+- Subcommands: `mcp add <url> <name>`, `mcp list`, `mcp delete <name>`, `mcp invoke <name> [tool] [--flag value]`, `mcp refresh <name>`, `mcp auth <name>` (re-authenticate via silent refresh-token renewal with an interactive popup fallback; `--silent` / `--interactive` to force one path).
 - Each registered server is exposed as an `mcp:<name>` OAuth provider (visible in `oauth-token --list`) when the server requires auth.
 - `mcp add` auto-writes an alias shim at `/workspace/.mcp/aliases/<name>.jsh` so `<name>` resolves as a top-level command and forwards to `mcp invoke <name>`.
 - MCP Apps declared by the server via `apps/list` are materialized as sprinkles under `/workspace/.mcp/sprinkles/<name>/`.

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -68,7 +68,7 @@ Deep reference: `docs/kernel/process-model.md`.
 ### MCP Servers
 
 - Path: `packages/webapp/src/shell/mcp/`; command in `supplemental-commands/mcp-command.ts`.
-- Subcommands: `mcp add <url> [name]`, `mcp list`, `mcp delete <name>`, `mcp invoke <name> [tool] [--flag value]`, `mcp refresh <name>`.
+- Subcommands: `mcp add <url> [name]`, `mcp list`, `mcp delete <name>`, `mcp invoke <name> [tool] [--flag value]`, `mcp refresh <name>`, `mcp auth <name>` (re-authenticate via silent refresh-token renewal with an interactive popup fallback; `--silent` / `--interactive` to force one path).
 - Each registered server is exposed as an `mcp:<name>` OAuth provider (visible in `oauth-token --list`) when the server requires auth.
 - `mcp add` auto-writes an alias shim at `/workspace/.mcp/aliases/<name>.jsh` so `<name>` resolves as a top-level command and forwards to `mcp invoke <name>`.
 - MCP Apps declared by the server via `apps/list` are materialized as sprinkles under `/workspace/.mcp/sprinkles/<name>/`.

--- a/packages/webapp/src/shell/supplemental-commands/mcp-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/mcp-command.ts
@@ -8,6 +8,7 @@
  *   invoke <name> [tool] …     Run a tool through the persisted server.
  *   search <query>             Find cached tools by name/description match.
  *   refresh <name>             Re-fetch tools/apps + AS discovery.
+ *   auth <name>                Re-authenticate (silent renewal → popup fallback).
  *
  * Library modules in `../mcp/` do the heavy lifting; this file only orchestrates
  * persistence, OAuth, and CLI ergonomics (help text, schema-driven flag
@@ -78,12 +79,18 @@ Commands:
   invoke <name> [tool] …     Call a tool through a configured server.
   search <query>             Find cached tools by name/description match.
   refresh <name>             Re-fetch tools/apps and AS metadata.
+  auth <name>                Re-authenticate an MCP server (silent renewal,
+                             with an interactive popup fallback). Use this
+                             when a token has expired; \`refresh\` only
+                             reloads the tool catalog and does not touch
+                             OAuth.
 
 Examples:
   mcp add https://mcp.example.com/sse weather
   mcp list
   mcp invoke weather get-forecast --lat 51.5 --lon -0.12
   mcp search forecast
+  mcp auth weather
   mcp delete weather
 `;
 }
@@ -111,6 +118,8 @@ export function createMcpCommand(deps: McpCommandDeps = {}): Command {
           return await cmdSearch(rest, deps);
         case 'refresh':
           return await cmdRefresh(rest, deps);
+        case 'auth':
+          return await cmdAuth(rest, deps);
         default:
           return err(`mcp: unknown subcommand "${sub}" (try \`mcp --help\`)`);
       }
@@ -789,7 +798,13 @@ async function cmdRefresh(args: string[], deps: McpCommandDeps): Promise<ExecRes
   if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     return args.length === 0
       ? err('mcp refresh: expected <name>')
-      : ok('usage: mcp refresh <name>\n');
+      : ok(
+          `usage: mcp refresh <name>
+
+Re-fetches the tool catalog and \`apps/list\` for <name>. Does NOT refresh
+OAuth tokens — for OAuth token refresh use \`mcp auth <name>\`.
+`
+        );
   }
   const name = args[0];
   const { ensureMcpProviderRegistered } = await import('../mcp/provider.js');
@@ -799,14 +814,23 @@ async function cmdRefresh(args: string[], deps: McpCommandDeps): Promise<ExecRes
   const entry = await getServer(name, deps.fs);
   if (!entry) return err(`mcp refresh: unknown server "${name}"`);
 
-  const { McpClient } = await import('../mcp/client.js');
+  const { McpClient, McpAuthRequiredError } = await import('../mcp/client.js');
   const client = new McpClient({
     url: entry.url,
     fetchImpl: deps.fetchImpl,
     headers: entry.headers,
     getAuthHeader: entry.auth ? () => getMcpBearerHeader(name) : undefined,
   });
-  await client.initialize();
+  try {
+    await client.initialize();
+  } catch (e) {
+    if (e instanceof McpAuthRequiredError) {
+      return err(
+        `mcp refresh: server "${name}" returned 401 — token may have expired. Run \`mcp auth ${name}\` to re-authenticate.`
+      );
+    }
+    throw e;
+  }
   const tools = await client.toolsList();
   const apps = await client.appsList();
   // Drop any previously persisted `sessionId` — it's per-process state on
@@ -825,6 +849,115 @@ async function cmdRefresh(args: string[], deps: McpCommandDeps): Promise<ExecRes
   return ok(
     `Refreshed "${name}" — tools: ${tools.length}, apps: ${apps.length} (${sprinkles} sprinkle${sprinkles === 1 ? '' : 's'})\n`
   );
+}
+
+// ── auth ────────────────────────────────────────────────────────────
+
+async function cmdAuth(args: string[], deps: McpCommandDeps): Promise<ExecResult> {
+  if (args.includes('--help') || args.includes('-h')) {
+    return ok(`usage: mcp auth <name> [--silent | --interactive]
+
+Re-authenticate an existing MCP server. By default, attempts a silent
+token renewal using the persisted refresh_token; if that returns no
+token, falls back to an interactive popup flow.
+
+Options:
+  -s, --silent        Only attempt silent renewal. Exit non-zero if it
+                      fails (no popup). Useful in scripts.
+  -i, --interactive   Skip silent renewal and open the OAuth popup
+                      directly. Use after revoking a refresh token or
+                      when the AS no longer accepts the cached one.
+`);
+  }
+  const positional = args.filter((a) => !a.startsWith('-'));
+  if (positional.length === 0) {
+    return err('mcp auth: expected <name>');
+  }
+  const name = positional[0];
+  const silent = args.includes('--silent') || args.includes('-s');
+  const interactive = args.includes('--interactive') || args.includes('-i');
+  if (silent && interactive) {
+    return err('mcp auth: --silent and --interactive are mutually exclusive');
+  }
+
+  const { ensureMcpProviderRegistered } = await import('../mcp/provider.js');
+  const registered = await ensureMcpProviderRegistered(name);
+
+  const { getServer } = await import('../mcp/store.js');
+  const entry = await getServer(name, deps.fs);
+  if (!entry) {
+    return err(`mcp auth: unknown server "${name}" (run \`mcp list\` to see configured servers)`);
+  }
+  if (!entry.auth) {
+    return err(`mcp auth: server "${name}" does not use OAuth`);
+  }
+  if (!registered) {
+    // ensureMcpProviderRegistered returned false despite an auth block;
+    // surface a clear error rather than silently failing on the next step.
+    return err(`mcp auth: failed to register provider for "${name}"`);
+  }
+
+  const providerId = `mcp:${name}`;
+  const { getRegisteredProviderConfig } = await import('../../providers/index.js');
+  const cfg = getRegisteredProviderConfig(providerId);
+  if (!cfg) {
+    return err(`mcp auth: provider "${providerId}" is not registered`);
+  }
+
+  if (interactive) {
+    return await runInteractiveAuth(name, cfg, deps);
+  }
+
+  // Default + --silent: try silent renewal first.
+  if (!cfg.onSilentRenew) {
+    if (silent) {
+      return err(
+        `mcp auth: provider "${providerId}" does not support silent renewal; retry without --silent`
+      );
+    }
+    return await runInteractiveAuth(name, cfg, deps);
+  }
+
+  let renewed: string | null = null;
+  try {
+    renewed = await cfg.onSilentRenew();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (silent) {
+      return err(
+        `mcp auth: silent renewal for "${name}" failed (${msg}); retry without --silent to run the interactive flow`
+      );
+    }
+    log.debug('mcp auth: silent renewal threw, falling back to interactive', { name, error: msg });
+  }
+  if (renewed) {
+    return ok(`Re-authenticated "${name}" via silent renewal (provider ${providerId})\n`);
+  }
+  if (silent) {
+    return err(
+      `mcp auth: silent renewal for "${name}" returned no token; retry without --silent to run the interactive flow`
+    );
+  }
+  return await runInteractiveAuth(name, cfg, deps);
+}
+
+async function runInteractiveAuth(
+  name: string,
+  cfg: import('../../providers/types.js').ProviderConfig,
+  deps: McpCommandDeps
+): Promise<ExecResult> {
+  if (!cfg.onOAuthLogin) {
+    return err(`mcp auth: provider "${cfg.id}" does not support interactive OAuth login`);
+  }
+  const launcher = deps.oauthLauncher ?? (await defaultLauncher());
+  let success = false;
+  await cfg.onOAuthLogin(launcher, () => {
+    success = true;
+  });
+  if (!success) {
+    return err(`mcp auth: interactive login for "${name}" did not complete`);
+  }
+  return ok(`Re-authenticated "${name}" via interactive login (provider ${cfg.id})\n`);
 }
 
 // ── helpers ─────────────────────────────────────────────────────────

--- a/packages/webapp/tests/shell/supplemental-commands/mcp-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/mcp-command.test.ts
@@ -44,7 +44,11 @@ import {
   readServersFile,
   setServer,
 } from '../../../src/shell/mcp/store.js';
-import { _testOnly_resetMcpProviderState, mcpProviderId } from '../../../src/shell/mcp/provider.js';
+import {
+  _testOnly_resetMcpProviderState,
+  mcpProviderId,
+  registerMcpProvider,
+} from '../../../src/shell/mcp/provider.js';
 import {
   unregisterProviderConfig,
   getRegisteredProviderConfig,
@@ -1490,5 +1494,252 @@ describe('mcp invoke --timeout flag (integration)', () => {
     });
     expect(r.exitCode).toBe(0);
     expect(r.stderr).toMatch(/invalid --timeout value "abc"/);
+  });
+});
+
+describe('mcp auth', () => {
+  beforeEach(async () => {
+    _testOnly_resetStoreCache();
+    _testOnly_resetMcpProviderState();
+    unregisterProviderConfig(mcpProviderId('demo'));
+    await wipeGlobalFs();
+    localStorage.clear();
+    mockGetOAuthPageOrigin.mockReset();
+    mockGetOAuthPageOrigin.mockResolvedValue({
+      origin: window.location.origin,
+      href: window.location.href,
+    });
+  });
+
+  afterEach(async () => {
+    _testOnly_resetMcpProviderState();
+    unregisterProviderConfig(mcpProviderId('demo'));
+    await new Promise((r) => setTimeout(r, 600));
+    _testOnly_resetStoreCache();
+  });
+
+  it('--help lists --silent and --interactive flags', async () => {
+    const r = await runCmd(['auth', '--help']);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('usage: mcp auth');
+    expect(r.stdout).toContain('--silent');
+    expect(r.stdout).toContain('--interactive');
+  });
+
+  it('top-level help mentions the auth subcommand', async () => {
+    const r = await runCmd(['--help']);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/\bauth\b/);
+  });
+
+  it('refresh --help mentions mcp auth for token refresh', async () => {
+    const r = await runCmd(['refresh', '--help']);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('mcp auth');
+  });
+
+  it('errors on missing <name>', async () => {
+    const r = await runCmd(['auth']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('mcp auth: expected <name>');
+  });
+
+  it('rejects --silent and --interactive together', async () => {
+    const r = await runCmd(['auth', 'demo', '--silent', '--interactive']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('mutually exclusive');
+  });
+
+  it('errors on unknown server with mcp list hint', async () => {
+    const r = await runCmd(['auth', 'ghost']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('unknown server "ghost"');
+    expect(r.stderr).toContain('mcp list');
+  });
+
+  it('errors on server without an auth block', async () => {
+    await setServer('demo', { url: 'https://server.test/sse' });
+    const r = await runCmd(['auth', 'demo']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('does not use OAuth');
+  });
+
+  it('silent renewal: rotates token via refresh_token grant', async () => {
+    await setServer('demo', {
+      url: 'https://server.test/sse',
+      auth: {
+        providerId: 'mcp:demo',
+        authorizationServer: 'https://auth.test',
+        clientId: 'cid',
+        scope: 'mcp:tools',
+      },
+    });
+    localStorage.setItem(
+      'slicc_accounts',
+      JSON.stringify([
+        {
+          providerId: 'mcp:demo',
+          apiKey: '',
+          accessToken: 'stale-token',
+          refreshToken: 'mcp-refresh-token',
+          tokenExpiresAt: Date.now() - 60_000,
+        },
+      ])
+    );
+    // Pre-register with the mock OAuth fetch so `onSilentRenew` uses it
+    // instead of the default `createProxiedFetch`. `ensureMcpProviderRegistered`
+    // short-circuits when the provider is already in the session set.
+    registerMcpProvider({
+      name: 'demo',
+      serverUrl: 'https://server.test/sse',
+      auth: {
+        providerId: 'mcp:demo',
+        authorizationServer: 'https://auth.test',
+        clientId: 'cid',
+        scope: 'mcp:tools',
+      },
+      fetchImpl: makeMockOAuthFetch(),
+    });
+
+    const r = await runCmd(['auth', 'demo']);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('Re-authenticated "demo"');
+    expect(r.stdout).toContain('silent renewal');
+
+    const accounts = JSON.parse(localStorage.getItem('slicc_accounts') || '[]');
+    const acc = accounts.find((a: { providerId: string }) => a.providerId === 'mcp:demo');
+    expect(acc?.accessToken).toBe('rotated-token');
+  });
+
+  it('--silent fails non-zero with retry hint when no refresh_token is stored', async () => {
+    await setServer('demo', {
+      url: 'https://server.test/sse',
+      auth: {
+        providerId: 'mcp:demo',
+        authorizationServer: 'https://auth.test',
+        clientId: 'cid',
+        scope: 'mcp:tools',
+      },
+    });
+    localStorage.setItem(
+      'slicc_accounts',
+      JSON.stringify([
+        {
+          providerId: 'mcp:demo',
+          apiKey: '',
+          accessToken: 'stale-token',
+          // No refreshToken -> onSilentRenew returns null.
+        },
+      ])
+    );
+    registerMcpProvider({
+      name: 'demo',
+      serverUrl: 'https://server.test/sse',
+      auth: {
+        providerId: 'mcp:demo',
+        authorizationServer: 'https://auth.test',
+        clientId: 'cid',
+        scope: 'mcp:tools',
+      },
+      fetchImpl: makeMockOAuthFetch(),
+    });
+
+    const r = await runCmd(['auth', 'demo', '--silent']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('silent renewal');
+    expect(r.stderr).toContain('retry without --silent');
+  });
+
+  it('falls back from silent to interactive when silent returns null', async () => {
+    await setServer('demo', {
+      url: 'https://server.test/sse',
+      auth: {
+        providerId: 'mcp:demo',
+        authorizationServer: 'https://auth.test',
+        clientId: 'cid',
+        scope: 'mcp:tools',
+      },
+    });
+    // No account at all -> getOAuthAccountInfo returns null -> silent
+    // renewal returns null without throwing. Default flow must then run
+    // the interactive popup path through the injected launcher.
+    registerMcpProvider({
+      name: 'demo',
+      serverUrl: 'https://server.test/sse',
+      auth: {
+        providerId: 'mcp:demo',
+        authorizationServer: 'https://auth.test',
+        clientId: 'cid',
+        scope: 'mcp:tools',
+      },
+      fetchImpl: makeMockOAuthFetch(),
+    });
+
+    const r = await runCmd(['auth', 'demo'], { oauthLauncher: stubLauncher });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('Re-authenticated "demo"');
+    expect(r.stdout).toContain('interactive login');
+
+    const accounts = JSON.parse(localStorage.getItem('slicc_accounts') || '[]');
+    const acc = accounts.find((a: { providerId: string }) => a.providerId === 'mcp:demo');
+    expect(acc?.accessToken).toBe('mcp-access-token');
+  });
+
+  it('--interactive skips silent renewal and runs the popup flow directly', async () => {
+    await setServer('demo', {
+      url: 'https://server.test/sse',
+      auth: {
+        providerId: 'mcp:demo',
+        authorizationServer: 'https://auth.test',
+        clientId: 'cid',
+        scope: 'mcp:tools',
+      },
+    });
+    // Seed a *valid* refresh token to prove --interactive bypasses it.
+    localStorage.setItem(
+      'slicc_accounts',
+      JSON.stringify([
+        {
+          providerId: 'mcp:demo',
+          apiKey: '',
+          accessToken: 'stale-token',
+          refreshToken: 'mcp-refresh-token',
+          tokenExpiresAt: Date.now() - 60_000,
+        },
+      ])
+    );
+    registerMcpProvider({
+      name: 'demo',
+      serverUrl: 'https://server.test/sse',
+      auth: {
+        providerId: 'mcp:demo',
+        authorizationServer: 'https://auth.test',
+        clientId: 'cid',
+        scope: 'mcp:tools',
+      },
+      fetchImpl: makeMockOAuthFetch(),
+    });
+
+    const r = await runCmd(['auth', 'demo', '--interactive'], { oauthLauncher: stubLauncher });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('interactive login');
+  });
+
+  it('mcp refresh: emits a hint to run `mcp auth <name>` on a 401', async () => {
+    await setServer('demo', {
+      url: 'https://server.test/sse',
+      auth: {
+        providerId: 'mcp:demo',
+        authorizationServer: 'https://auth.test',
+        clientId: 'cid',
+        scope: 'mcp:tools',
+      },
+    });
+    // Server requires auth + no account is stored -> initialize gets 401.
+    const { fetch } = makeMockMcpFetch({ authRequired: true });
+    const r = await runCmd(['refresh', 'demo'], { fetchImpl: fetch });
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('mcp auth demo');
+    expect(r.stderr).toContain('401');
   });
 });


### PR DESCRIPTION
## Summary

Adds `mcp auth <name>` so agents can refresh stale MCP OAuth tokens without the `mcp delete` + `mcp add` workaround (which discards the persisted dynamic-client-registration `clientId`).

## Problem

MCP OAuth tokens go stale. Agents intuitively try:
- `mcp auth <name>` — didn't exist
- `mcp refresh <name>` — existed, but only re-fetches tools/apps; doesn't touch the OAuth token

The current workaround is `mcp delete` + `mcp add`, which throws away the DCR `clientId` and forces a fresh OAuth registration.

## Changes

### New: `mcp auth <name>`
Re-authenticates an existing MCP server in place by delegating to the existing `mcp:<name>` provider's `onSilentRenew` and `onOAuthLogin` hooks.

- `mcp auth <name>` — silent renewal first, interactive popup fallback (default)
- `mcp auth <name> --silent` / `-s` — silent only, non-zero exit on failure with retry hint
- `mcp auth <name> --interactive` / `-i` — always opens the popup

Clear errors for unknown servers (points to `mcp list`) and non-OAuth servers.

### Clarified: `mcp refresh <name>`
- `mcp --help` and `mcp refresh --help` now distinguish "refresh tools/apps" from "refresh OAuth token"
- 401 failure path on `mcp refresh` now hints to try `mcp auth <name>`

### Docs
- `packages/webapp/CLAUDE.md` MCP Servers section lists the new subcommand

## Verification

- `npm run typecheck` — clean
- `npm run test -w @slicc/webapp -- mcp-command` — 74/74 pass (12 new tests for `auth` covering silent success, --silent failure, interactive fallback, --interactive direct, unknown server, non-OAuth server, --silent+--interactive mutex, help texts, refresh→auth pointer, and the 401 hint on `mcp refresh`)
- `npm run build -w @slicc/webapp` — clean

## Scope

Additive change to one command file plus test + doc updates. No changes to OAuth library, provider plumbing, or other providers. Touched only `packages/webapp/src/shell/supplemental-commands/mcp-command.ts`, its test file, and `packages/webapp/CLAUDE.md`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author