### PR TITLE
Pass WebDAV/CalDAV verbs through fetch-proxy (all three floats)

### DIFF
--- a/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
+++ b/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
@@ -585,3 +585,133 @@ describe('handleFetchProxyConnection — DNR forbidden-header rule', () => {
     expect(headersOnFetch.cookie).toBe('sid=abc');
   });
 });
+
+// Regression: WebDAV / CalDAV verbs (PROPFIND, REPORT, MKCALENDAR, LOCK,
+// etc.) must pass through `msg.method` straight to upstream `fetch()` —
+// browser fetch only forbids CONNECT/TRACE/TRACK. The DNR forbidden-header
+// installer only acts on Cookie/Origin/Referer/Proxy-*, so DAV-only headers
+// like `Depth` and `Timeout` are forwarded as ordinary request headers and
+// must survive the round-trip untouched.
+describe('handleFetchProxyConnection — WebDAV/CalDAV verb pass-through', () => {
+  let pipeline: SecretsPipeline;
+
+  beforeEach(async () => {
+    pipeline = new SecretsPipeline({
+      sessionId: 'session-fixed',
+      source: { get: async () => undefined, listAll: async () => [] },
+    });
+    await pipeline.reload();
+  });
+
+  function encodeBase64(s: string): string {
+    let bin = '';
+    const bytes = new TextEncoder().encode(s);
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+    return btoa(bin);
+  }
+
+  async function dispatchDav(req: {
+    method: string;
+    url?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  }): Promise<{
+    method: string | undefined;
+    headers: Record<string, string> | undefined;
+    bodyBytes: Uint8Array | undefined;
+    posts: any[];
+  }> {
+    let capturedMethod: string | undefined;
+    let capturedHeaders: Record<string, string> | undefined;
+    let capturedBody: Uint8Array | undefined;
+    (globalThis as any).fetch = vi.fn(async (_url: string, init: any) => {
+      capturedMethod = init.method;
+      capturedHeaders = init.headers;
+      capturedBody = init.body instanceof Uint8Array ? init.body : undefined;
+      return new Response('<multistatus/>', {
+        status: 207,
+        statusText: 'Multi-Status',
+        headers: { 'content-type': 'application/xml' },
+      });
+    });
+    const posts: any[] = [];
+    const port = makePort((m) => posts.push(m));
+    handleFetchProxyConnection(port, pipeline);
+    port.fireMessage({
+      type: 'request',
+      url: req.url ?? 'https://dav.example.com/calendars/user/',
+      method: req.method,
+      headers: req.headers ?? {},
+      bodyBase64: req.body !== undefined ? encodeBase64(req.body) : undefined,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    return {
+      method: capturedMethod,
+      headers: capturedHeaders,
+      bodyBytes: capturedBody,
+      posts,
+    };
+  }
+
+  it('PROPFIND passes verb, XML body, and Depth: 1 header through; 207 reaches the port', async () => {
+    const xml =
+      '<?xml version="1.0"?><propfind xmlns="DAV:"><prop><displayname/></prop></propfind>';
+    const { method, headers, bodyBytes, posts } = await dispatchDav({
+      method: 'PROPFIND',
+      headers: { Depth: '1', 'Content-Type': 'application/xml' },
+      body: xml,
+    });
+
+    expect(method).toBe('PROPFIND');
+    expect(headers?.Depth).toBe('1');
+    expect(headers?.['Content-Type']).toBe('application/xml');
+    expect(bodyBytes).toBeDefined();
+    expect(new TextDecoder().decode(bodyBytes!)).toBe(xml);
+
+    const head = posts.find((p) => p.type === 'response-head');
+    expect(head).toMatchObject({ type: 'response-head', status: 207, statusText: 'Multi-Status' });
+    expect(posts.some((p) => p.type === 'response-end')).toBe(true);
+  });
+
+  it('REPORT passes verb and XML body through; 207 reaches the port', async () => {
+    const xml = '<?xml version="1.0"?><c:calendar-query xmlns:c="urn:ietf:params:xml:ns:caldav"/>';
+    const { method, headers, bodyBytes, posts } = await dispatchDav({
+      method: 'REPORT',
+      headers: { Depth: '1', 'Content-Type': 'application/xml' },
+      body: xml,
+    });
+
+    expect(method).toBe('REPORT');
+    expect(headers?.Depth).toBe('1');
+    expect(new TextDecoder().decode(bodyBytes!)).toBe(xml);
+
+    const head = posts.find((p) => p.type === 'response-head');
+    expect(head).toMatchObject({ status: 207 });
+  });
+
+  it('MKCALENDAR with no body passes verb through; body is undefined', async () => {
+    const { method, bodyBytes, posts } = await dispatchDav({
+      method: 'MKCALENDAR',
+      headers: { 'Content-Type': 'application/xml' },
+    });
+
+    expect(method).toBe('MKCALENDAR');
+    expect(bodyBytes).toBeUndefined();
+    expect(posts.some((p) => p.type === 'response-head')).toBe(true);
+    expect(posts.some((p) => p.type === 'response-end')).toBe(true);
+  });
+
+  it('LOCK passes verb, body, and Timeout: Second-300 header through', async () => {
+    const xml =
+      '<?xml version="1.0"?><lockinfo xmlns="DAV:"><lockscope><exclusive/></lockscope></lockinfo>';
+    const { method, headers, bodyBytes } = await dispatchDav({
+      method: 'LOCK',
+      headers: { Timeout: 'Second-300', 'Content-Type': 'application/xml' },
+      body: xml,
+    });
+
+    expect(method).toBe('LOCK');
+    expect(headers?.Timeout).toBe('Second-300');
+    expect(new TextDecoder().decode(bodyBytes!)).toBe(xml);
+  });
+});

--- a/packages/node-server/tests/fetch-proxy-dav.test.ts
+++ b/packages/node-server/tests/fetch-proxy-dav.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express, { type Express } from 'express';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { FETCH_PROXY_SKIP_HEADERS } from '../src/fetch-proxy-headers.js';
+
+/**
+ * Regression coverage for WebDAV / CalDAV verbs (PROPFIND, REPORT,
+ * MKCALENDAR, LOCK) traversing the Node `/api/fetch-proxy` route.
+ *
+ * The production handler at `packages/node-server/src/index.ts`
+ * (`app.all('/api/fetch-proxy', ...)`) is inline and tightly coupled
+ * to `secretProxy`. Per the task scope, it is NOT extracted into a
+ * separate module. Instead — following the pattern in
+ * `fetch-proxy-raw-body.test.ts` — this test mirrors the slice of
+ * the handler responsible for verb / body / header pass-through.
+ * Keep this mirror in sync with `index.ts` if the proxy changes.
+ */
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  headers: http.IncomingHttpHeaders;
+  body: Buffer;
+}
+
+function buildUpstream(): {
+  server: http.Server;
+  baseUrl: () => string;
+  captured: CapturedRequest[];
+} {
+  const captured: CapturedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(Buffer.from(c)));
+    req.on('end', () => {
+      captured.push({
+        method: req.method ?? '',
+        url: req.url ?? '',
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      });
+      res.statusCode = 207;
+      res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+      res.end('<?xml version="1.0"?><d:multistatus xmlns:d="DAV:"/>');
+    });
+  });
+  return {
+    server,
+    baseUrl: () => `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    captured,
+  };
+}
+
+function buildProxyApp(): Express {
+  const app = express();
+  app.use(
+    express.json({
+      limit: '50mb',
+      type: (req) =>
+        req.headers['x-slicc-raw-body'] !== '1' &&
+        (req.headers['content-type'] ?? '').includes('application/json'),
+    })
+  );
+  app.all('/api/fetch-proxy', async (req, res) => {
+    let rawBody: Buffer;
+    if (req.body && typeof req.body === 'object' && Object.keys(req.body).length > 0) {
+      rawBody = Buffer.from(JSON.stringify(req.body), 'utf-8');
+    } else {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(Buffer.from(chunk));
+      rawBody = Buffer.concat(chunks);
+    }
+    const targetUrl = req.headers['x-target-url'] as string;
+    if (!targetUrl) {
+      res.status(400).json({ error: 'Missing X-Target-URL header' });
+      return;
+    }
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (!FETCH_PROXY_SKIP_HEADERS.has(key) && typeof value === 'string') {
+        headers[key] = value;
+      }
+    }
+    const fetchInit: RequestInit = { method: req.method, redirect: 'follow' };
+    if (Object.keys(headers).length > 0) fetchInit.headers = headers;
+    if (rawBody.length > 0 && !['GET', 'HEAD'].includes(req.method)) {
+      fetchInit.body = rawBody as unknown as RequestInit['body'];
+    }
+    const upstream = await fetch(targetUrl, fetchInit);
+    res.status(upstream.status);
+    upstream.headers.forEach((v, k) => {
+      const lower = k.toLowerCase();
+      if (
+        lower !== 'transfer-encoding' &&
+        lower !== 'content-encoding' &&
+        lower !== 'content-length'
+      ) {
+        res.setHeader(k, v);
+      }
+    });
+    const buf = Buffer.from(await upstream.arrayBuffer());
+    res.end(buf);
+  });
+  return app;
+}
+
+describe('fetch-proxy WebDAV / CalDAV verb pass-through', () => {
+  let proxyServer: http.Server;
+  let proxyUrl: string;
+  let upstream: ReturnType<typeof buildUpstream>;
+
+  beforeEach(async () => {
+    upstream = buildUpstream();
+    await new Promise<void>((resolve) => upstream.server.listen(0, resolve));
+    proxyServer = http.createServer(buildProxyApp());
+    await new Promise<void>((resolve) => proxyServer.listen(0, resolve));
+    proxyUrl = `http://127.0.0.1:${(proxyServer.address() as AddressInfo).port}/api/fetch-proxy`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+    await new Promise<void>((resolve) => upstream.server.close(() => resolve()));
+  });
+
+  it('forwards PROPFIND with XML body and Depth header (207 round-trip)', async () => {
+    const body =
+      '<?xml version="1.0" encoding="utf-8"?>' +
+      '<d:propfind xmlns:d="DAV:"><d:prop><d:displayname/></d:prop></d:propfind>';
+    const res = await fetch(proxyUrl, {
+      method: 'PROPFIND',
+      headers: {
+        'X-Target-URL': `${upstream.baseUrl()}/calendars/user/`,
+        'Content-Type': 'application/xml; charset=utf-8',
+        Depth: '1',
+      },
+      body,
+    });
+    expect(res.status).toBe(207);
+    expect(upstream.captured).toHaveLength(1);
+    const cap = upstream.captured[0]!;
+    expect(cap.method).toBe('PROPFIND');
+    expect(cap.headers['depth']).toBe('1');
+    expect(cap.headers['content-type']).toBe('application/xml; charset=utf-8');
+    expect(cap.body.toString('utf-8')).toBe(body);
+  });
+
+  it('forwards REPORT with a CalDAV calendar-query XML body', async () => {
+    const body =
+      '<?xml version="1.0" encoding="utf-8"?>' +
+      '<c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">' +
+      '<d:prop><d:getetag/><c:calendar-data/></d:prop>' +
+      '<c:filter><c:comp-filter name="VCALENDAR"/></c:filter>' +
+      '</c:calendar-query>';
+    const res = await fetch(proxyUrl, {
+      method: 'REPORT',
+      headers: {
+        'X-Target-URL': `${upstream.baseUrl()}/calendars/user/default/`,
+        'Content-Type': 'application/xml; charset=utf-8',
+        Depth: '1',
+      },
+      body,
+    });
+    expect(res.status).toBe(207);
+    expect(upstream.captured).toHaveLength(1);
+    const cap = upstream.captured[0]!;
+    expect(cap.method).toBe('REPORT');
+    expect(cap.headers['depth']).toBe('1');
+    expect(cap.body.toString('utf-8')).toBe(body);
+  });
+
+  it('forwards MKCALENDAR with no body and preserves the verb', async () => {
+    const res = await fetch(proxyUrl, {
+      method: 'MKCALENDAR',
+      headers: {
+        'X-Target-URL': `${upstream.baseUrl()}/calendars/user/new/`,
+      },
+    });
+    expect(res.status).toBe(207);
+    expect(upstream.captured).toHaveLength(1);
+    const cap = upstream.captured[0]!;
+    expect(cap.method).toBe('MKCALENDAR');
+    expect(cap.body.length).toBe(0);
+  });
+
+  it('forwards LOCK with a body and Timeout: Second-300 header', async () => {
+    const body =
+      '<?xml version="1.0" encoding="utf-8"?>' +
+      '<d:lockinfo xmlns:d="DAV:">' +
+      '<d:lockscope><d:exclusive/></d:lockscope>' +
+      '<d:locktype><d:write/></d:locktype>' +
+      '<d:owner><d:href>mailto:user@example.com</d:href></d:owner>' +
+      '</d:lockinfo>';
+    const res = await fetch(proxyUrl, {
+      method: 'LOCK',
+      headers: {
+        'X-Target-URL': `${upstream.baseUrl()}/files/doc.txt`,
+        'Content-Type': 'application/xml; charset=utf-8',
+        Timeout: 'Second-300',
+      },
+      body,
+    });
+    expect(res.status).toBe(207);
+    expect(upstream.captured).toHaveLength(1);
+    const cap = upstream.captured[0]!;
+    expect(cap.method).toBe('LOCK');
+    expect(cap.headers['timeout']).toBe('Second-300');
+    expect(cap.body.toString('utf-8')).toBe(body);
+  });
+});
+
+describe('FETCH_PROXY_SKIP_HEADERS does not strip DAV headers', () => {
+  it('forwards Depth, Timeout, If, Lock-Token, Destination, Overwrite', () => {
+    for (const header of ['depth', 'timeout', 'if', 'lock-token', 'destination', 'overwrite']) {
+      expect(FETCH_PROXY_SKIP_HEADERS.has(header)).toBe(false);
+    }
+  });
+});

--- a/packages/swift-server/CLAUDE.md
+++ b/packages/swift-server/CLAUDE.md
@@ -44,7 +44,7 @@ swift run slicc-server --help
 - `GET|POST /api/oauth-result`
 - `GET /api/secrets`, `GET /api/secrets/masked`
 - `POST /api/s3-sign-and-forward`, `POST /api/da-sign-and-forward` — server-side request signing for S3 and Adobe da.live mounts. Mirrors `packages/node-server/src/secrets/sign-and-forward.ts`; resolves S3 credentials from the Keychain (`SecretStore`) and accepts a transient IMS bearer for DA. See `Sources/Server/SignAndForward.swift`.
-- `ALL /api/fetch-proxy`
+- `ALL /api/fetch-proxy` — accepts standard verbs (`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`) plus the WebDAV (RFC 4918) and CalDAV (RFC 4791) verbs `PROPFIND`, `PROPPATCH`, `MKCOL`, `MKCALENDAR`, `REPORT`, `COPY`, `MOVE`, `LOCK`, `UNLOCK`. Unknown verbs are forwarded to AsyncHTTPClient via `HTTPMethod.RAW(value:)`.
 
 WebSocket routes are installed separately for CDP proxying and the lick system.
 

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -22,7 +22,23 @@ private let proxyBlockedResponseHeaders: Set<String> = [
     "transfer-encoding", "content-encoding", "www-authenticate",
     "set-cookie",
 ]
-private let fetchProxyMethods: [HTTPRequest.Method] = [.get, .head, .post, .put, .patch, .delete, .options]
+private let fetchProxyMethods: [HTTPRequest.Method] = [
+    .get, .head, .post, .put, .patch, .delete, .options,
+    // WebDAV (RFC 4918) + CalDAV (RFC 4791) + WebDAV extensions. These verbs
+    // are not in HTTPTypes' built-in `Method` statics, but `Method(rawValue:)`
+    // accepts any valid RFC 9110 method token. Upstream forwarding works
+    // because the `HTTPMethod.init(_:)` mapping at the bottom of this file
+    // falls back to `.RAW(value:)` for any method not enumerated here.
+    HTTPRequest.Method(rawValue: "PROPFIND")!,
+    HTTPRequest.Method(rawValue: "PROPPATCH")!,
+    HTTPRequest.Method(rawValue: "MKCOL")!,
+    HTTPRequest.Method(rawValue: "MKCALENDAR")!,
+    HTTPRequest.Method(rawValue: "REPORT")!,
+    HTTPRequest.Method(rawValue: "COPY")!,
+    HTTPRequest.Method(rawValue: "MOVE")!,
+    HTTPRequest.Method(rawValue: "LOCK")!,
+    HTTPRequest.Method(rawValue: "UNLOCK")!,
+]
 
 private actor OAuthResultStore {
     struct PendingResult: Codable, Sendable, Equatable {

--- a/packages/swift-server/Tests/APIRoutesTests.swift
+++ b/packages/swift-server/Tests/APIRoutesTests.swift
@@ -195,15 +195,14 @@ final class APIRoutesTests: XCTestCase {
 
     // The fetch proxy must accept WebDAV (RFC 4918) and CalDAV (RFC 4791)
     // verbs in addition to the standard HTTP methods so the agent can
-    // talk to CalDAV / WebDAV servers from the Sliccstart float. These two
-    // round-trip tests cover the new method set by exercising PROPFIND and
-    // REPORT end-to-end: the proxy must register the route, forward the
-    // verb / body / DAV-specific request header unchanged, and let the
-    // upstream's 207 Multi-Status response flow back to the client.
-    //
-    // The remaining seven verbs (PROPPATCH, MKCOL, MKCALENDAR, COPY, MOVE,
-    // LOCK, UNLOCK) share the exact same code path, so two tests are
-    // sufficient.
+    // talk to CalDAV / WebDAV servers from the Sliccstart float. The four
+    // round-trip tests below cover the new method set end-to-end against
+    // the representative verbs called out in the spec's Acceptance
+    // Criterion #3 (PROPFIND, REPORT, MKCALENDAR, LOCK): the proxy must
+    // register the route, forward the verb / body / DAV-specific request
+    // header unchanged, and let the upstream's response flow back to the
+    // client. The remaining five verbs (PROPPATCH, MKCOL, COPY, MOVE,
+    // UNLOCK) share the exact same code path.
 
     func testFetchProxyForwardsPropfindWithBodyAndDavHeaders() async throws {
         try await self.runDavRoundTripTest(
@@ -232,6 +231,40 @@ final class APIRoutesTests: XCTestCase {
         )
     }
 
+    func testFetchProxyForwardsMkcalendarWithoutBody() async throws {
+        // MKCALENDAR (RFC 4791 § 5.3.1) is the CalDAV verb for creating a
+        // calendar collection; the request body is optional and frequently
+        // omitted. This test exercises the no-body path and asserts the
+        // verb passes through to the upstream and the upstream's response
+        // status flows back unchanged.
+        try await self.runDavRoundTripTest(
+            method: "MKCALENDAR",
+            davHeaderName: nil,
+            davHeaderValue: nil,
+            requestBody: ""
+        )
+    }
+
+    func testFetchProxyForwardsLockWithBodyAndTimeoutHeader() async throws {
+        // LOCK (RFC 4918 § 9.10) carries both an XML body (lockinfo) and
+        // the WebDAV-specific `Timeout` request header. This test asserts
+        // that the verb, body, and `Timeout: Second-300` header all reach
+        // the upstream unchanged.
+        try await self.runDavRoundTripTest(
+            method: "LOCK",
+            davHeaderName: "Timeout",
+            davHeaderValue: "Second-300",
+            requestBody: """
+                <?xml version="1.0" encoding="utf-8"?>
+                <D:lockinfo xmlns:D="DAV:">
+                  <D:lockscope><D:exclusive/></D:lockscope>
+                  <D:locktype><D:write/></D:locktype>
+                  <D:owner><D:href>mailto:agent@example.com</D:href></D:owner>
+                </D:lockinfo>
+                """
+        )
+    }
+
     /// Round-trip helper: stands up a live Hummingbird server hosting an
     /// upstream stub route, registers the API routes (including
     /// `/api/fetch-proxy`) on a separate router used in `.router` (in-memory)
@@ -252,12 +285,15 @@ final class APIRoutesTests: XCTestCase {
     ///   proxy handler directly without depending on a second listener.
     private func runDavRoundTripTest(
         method: String,
-        davHeaderName: String,
-        davHeaderValue: String,
+        davHeaderName: String?,
+        davHeaderValue: String?,
         requestBody: String
     ) async throws {
         let httpMethod = try XCTUnwrap(HTTPRequest.Method(rawValue: method))
-        let davHeader = try XCTUnwrap(HTTPField.Name(davHeaderName))
+        let davHeader: HTTPField.Name? = try {
+            guard let davHeaderName else { return nil }
+            return try XCTUnwrap(HTTPField.Name(davHeaderName))
+        }()
         let captured = CapturedRequestBox()
 
         // Build the upstream stub on its own router/app.
@@ -266,7 +302,7 @@ final class APIRoutesTests: XCTestCase {
             let body = try await request.body.collect(upTo: 1 * 1024 * 1024)
             await captured.record(
                 method: request.method.rawValue,
-                davHeader: request.headers[davHeader],
+                davHeader: davHeader.flatMap { request.headers[$0] },
                 body: String(buffer: body)
             )
             return Response(
@@ -306,14 +342,20 @@ final class APIRoutesTests: XCTestCase {
 
         let snapshot = await captured.snapshot()
         XCTAssertEqual(snapshot.method, method, "\(method) verb must reach upstream unchanged")
-        XCTAssertEqual(snapshot.davHeader, davHeaderValue, "\(davHeaderName) header must reach upstream unchanged")
+        if let davHeaderName, let davHeaderValue {
+            XCTAssertEqual(
+                snapshot.davHeader,
+                davHeaderValue,
+                "\(davHeaderName) header must reach upstream unchanged"
+            )
+        }
         XCTAssertEqual(snapshot.body, requestBody, "request body must reach upstream byte-for-byte")
     }
 
     private func executeDavRoundTrip(
         httpMethod: HTTPRequest.Method,
-        davHeader: HTTPField.Name,
-        davHeaderValue: String,
+        davHeader: HTTPField.Name?,
+        davHeaderValue: String?,
         requestBody: String,
         upstreamPort: Int,
         httpClient: HTTPClient
@@ -327,15 +369,19 @@ final class APIRoutesTests: XCTestCase {
         )
         let proxyApp = Application(responder: proxyRouter.buildResponder())
 
+        var headers: HTTPFields = [
+            HTTPField.Name("X-Target-URL")!: "http://localhost:\(upstreamPort)/upstream",
+            .contentType: "application/xml; charset=utf-8",
+        ]
+        if let davHeader, let davHeaderValue {
+            headers[davHeader] = davHeaderValue
+        }
+
         try await proxyApp.test(.router) { proxyClient in
             try await proxyClient.execute(
                 uri: "/api/fetch-proxy",
                 method: httpMethod,
-                headers: [
-                    HTTPField.Name("X-Target-URL")!: "http://localhost:\(upstreamPort)/upstream",
-                    davHeader: davHeaderValue,
-                    .contentType: "application/xml; charset=utf-8",
-                ],
+                headers: headers,
                 body: ByteBuffer(string: requestBody)
             ) { response in
                 XCTAssertEqual(response.status.code, 207, "207 Multi-Status must flow back to the client")

--- a/packages/swift-server/Tests/APIRoutesTests.swift
+++ b/packages/swift-server/Tests/APIRoutesTests.swift
@@ -3,6 +3,8 @@ import Foundation
 import Hummingbird
 import HummingbirdTesting
 import HTTPTypes
+import NIOCore
+import NIOPosix
 import XCTest
 @testable import slicc_server
 
@@ -191,6 +193,157 @@ final class APIRoutesTests: XCTestCase {
         }
     }
 
+    // The fetch proxy must accept WebDAV (RFC 4918) and CalDAV (RFC 4791)
+    // verbs in addition to the standard HTTP methods so the agent can
+    // talk to CalDAV / WebDAV servers from the Sliccstart float. These two
+    // round-trip tests cover the new method set by exercising PROPFIND and
+    // REPORT end-to-end: the proxy must register the route, forward the
+    // verb / body / DAV-specific request header unchanged, and let the
+    // upstream's 207 Multi-Status response flow back to the client.
+    //
+    // The remaining seven verbs (PROPPATCH, MKCOL, MKCALENDAR, COPY, MOVE,
+    // LOCK, UNLOCK) share the exact same code path, so two tests are
+    // sufficient.
+
+    func testFetchProxyForwardsPropfindWithBodyAndDavHeaders() async throws {
+        try await self.runDavRoundTripTest(
+            method: "PROPFIND",
+            davHeaderName: "Depth",
+            davHeaderValue: "1",
+            requestBody: """
+                <?xml version="1.0" encoding="utf-8"?>
+                <D:propfind xmlns:D="DAV:"><D:prop><D:displayname/></D:prop></D:propfind>
+                """
+        )
+    }
+
+    func testFetchProxyForwardsReportWithCalDAVBody() async throws {
+        try await self.runDavRoundTripTest(
+            method: "REPORT",
+            davHeaderName: "Depth",
+            davHeaderValue: "1",
+            requestBody: """
+                <?xml version="1.0" encoding="utf-8"?>
+                <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+                  <D:prop><D:getetag/><C:calendar-data/></D:prop>
+                  <C:filter><C:comp-filter name="VCALENDAR"/></C:filter>
+                </C:calendar-query>
+                """
+        )
+    }
+
+    /// Round-trip helper: stands up a live Hummingbird server hosting an
+    /// upstream stub route, registers the API routes (including
+    /// `/api/fetch-proxy`) on a separate router used in `.router` (in-memory)
+    /// mode, then routes a DAV request through the proxy and asserts the
+    /// verb, body, and DAV header reached the upstream unchanged and that
+    /// the upstream's 207 Multi-Status response flowed back.
+    ///
+    /// Two implementation notes:
+    ///
+    /// - We use an MTELG-backed `HTTPClient` (NIO-Posix sockets) for the
+    ///   proxy's outbound call instead of the singleton, which on macOS
+    ///   resolves to NIOTransportServices (Network.framework). Network.framework
+    ///   has been observed to refuse local-loopback connections with
+    ///   `NWPOSIXError 1` in unit-test environments; raw Posix sockets work
+    ///   reliably.
+    /// - The upstream stub is its own live `Application`; the proxy itself is
+    ///   exercised through `.router` mode so the test client invokes the
+    ///   proxy handler directly without depending on a second listener.
+    private func runDavRoundTripTest(
+        method: String,
+        davHeaderName: String,
+        davHeaderValue: String,
+        requestBody: String
+    ) async throws {
+        let httpMethod = try XCTUnwrap(HTTPRequest.Method(rawValue: method))
+        let davHeader = try XCTUnwrap(HTTPField.Name(davHeaderName))
+        let captured = CapturedRequestBox()
+
+        // Build the upstream stub on its own router/app.
+        let upstreamRouter = Router()
+        upstreamRouter.on("/upstream", method: httpMethod) { request, _ in
+            let body = try await request.body.collect(upTo: 1 * 1024 * 1024)
+            await captured.record(
+                method: request.method.rawValue,
+                davHeader: request.headers[davHeader],
+                body: String(buffer: body)
+            )
+            return Response(
+                status: HTTPResponse.Status(code: 207, reasonPhrase: "Multi-Status"),
+                headers: [.contentType: "application/xml; charset=utf-8"],
+                body: .init(byteBuffer: ByteBuffer(string: "<multistatus/>"))
+            )
+        }
+        let upstreamApp = Application(responder: upstreamRouter.buildResponder())
+
+        // Dedicated MTELG-backed HTTPClient for the proxy's outbound call.
+        // On macOS, AsyncHTTPClient's singleton ELG resolves to
+        // NIOTransportServices (Network.framework) which has been observed
+        // to refuse local-loopback connections with `NWPOSIXError 1` in
+        // unit-test environments; raw Posix sockets work reliably.
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
+
+        do {
+            try await upstreamApp.test(.live) { upstreamClient in
+                try await self.executeDavRoundTrip(
+                    httpMethod: httpMethod,
+                    davHeader: davHeader,
+                    davHeaderValue: davHeaderValue,
+                    requestBody: requestBody,
+                    upstreamPort: try XCTUnwrap(upstreamClient.port, "live test framework must expose a port"),
+                    httpClient: httpClient
+                )
+            }
+        } catch {
+            try? await httpClient.shutdown()
+            try? await eventLoopGroup.shutdownGracefully()
+            throw error
+        }
+        try await httpClient.shutdown()
+        try await eventLoopGroup.shutdownGracefully()
+
+        let snapshot = await captured.snapshot()
+        XCTAssertEqual(snapshot.method, method, "\(method) verb must reach upstream unchanged")
+        XCTAssertEqual(snapshot.davHeader, davHeaderValue, "\(davHeaderName) header must reach upstream unchanged")
+        XCTAssertEqual(snapshot.body, requestBody, "request body must reach upstream byte-for-byte")
+    }
+
+    private func executeDavRoundTrip(
+        httpMethod: HTTPRequest.Method,
+        davHeader: HTTPField.Name,
+        davHeaderValue: String,
+        requestBody: String,
+        upstreamPort: Int,
+        httpClient: HTTPClient
+    ) async throws {
+        let proxyRouter = Router()
+        registerAPIRoutes(
+            router: proxyRouter,
+            lickSystem: LickSystem(),
+            config: self.makeConfig(),
+            httpClient: httpClient
+        )
+        let proxyApp = Application(responder: proxyRouter.buildResponder())
+
+        try await proxyApp.test(.router) { proxyClient in
+            try await proxyClient.execute(
+                uri: "/api/fetch-proxy",
+                method: httpMethod,
+                headers: [
+                    HTTPField.Name("X-Target-URL")!: "http://localhost:\(upstreamPort)/upstream",
+                    davHeader: davHeaderValue,
+                    .contentType: "application/xml; charset=utf-8",
+                ],
+                body: ByteBuffer(string: requestBody)
+            ) { response in
+                XCTAssertEqual(response.status.code, 207, "207 Multi-Status must flow back to the client")
+                XCTAssertEqual(String(buffer: response.body), "<multistatus/>")
+            }
+        }
+    }
+
     func testOAuthResultRoundTripsAndClears() async throws {
         try await self.withHTTPClient { httpClient in
             let router = Router()
@@ -289,5 +442,31 @@ final class APIRoutesTests: XCTestCase {
             await lickSystem.handleMessage(text: payload)
         }
         await lickSystem.addClient(client)
+    }
+}
+
+/// Thread-safe holder for upstream-side request observations captured by
+/// the DAV round-trip tests. The stub upstream route runs on the live
+/// server's task; the test assertions run on the test task — so a plain
+/// `var` would trip the Sendable checker.
+private actor CapturedRequestBox {
+    struct Snapshot {
+        let method: String?
+        let davHeader: String?
+        let body: String?
+    }
+
+    private var method: String?
+    private var davHeader: String?
+    private var body: String?
+
+    func record(method: String, davHeader: String?, body: String) {
+        self.method = method
+        self.davHeader = davHeader
+        self.body = body
+    }
+
+    func snapshot() -> Snapshot {
+        .init(method: self.method, davHeader: self.davHeader, body: self.body)
     }
 }

--- a/packages/webapp/tests/shell/proxied-fetch-cli-dav.test.ts
+++ b/packages/webapp/tests/shell/proxied-fetch-cli-dav.test.ts
@@ -1,0 +1,115 @@
+/**
+ * CLI branch of `createProxiedFetch` must forward arbitrary WebDAV/CalDAV
+ * verbs (PROPFIND, REPORT, MKCALENDAR, LOCK) verbatim into the outer
+ * `fetch('/api/fetch-proxy', init)` call along with any caller-supplied
+ * body. Regression guard for the verb plumbing — if an intermediate adapter
+ * tightens the method allowlist, these tests fail.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const DAV_VERBS = ['PROPFIND', 'REPORT', 'MKCALENDAR', 'LOCK'] as const;
+
+describe('createProxiedFetch — CLI branch DAV verb pass-through', () => {
+  let originalChrome: unknown;
+  let originalFetch: typeof globalThis.fetch | undefined;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalChrome = (globalThis as { chrome?: unknown }).chrome;
+    originalFetch = globalThis.fetch;
+    // CLI mode — no chrome runtime.
+    (globalThis as { chrome?: unknown }).chrome = undefined;
+    mockFetch = vi.fn().mockImplementation(async () => {
+      return new Response('<multistatus/>', {
+        status: 207,
+        statusText: 'Multi-Status',
+        headers: { 'content-type': 'application/xml' },
+      });
+    });
+    (globalThis as { fetch: typeof globalThis.fetch }).fetch =
+      mockFetch as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    (globalThis as { chrome?: unknown }).chrome = originalChrome;
+    if (originalFetch) {
+      (globalThis as { fetch: typeof globalThis.fetch }).fetch = originalFetch;
+    }
+    vi.restoreAllMocks();
+  });
+
+  for (const verb of DAV_VERBS) {
+    it(`forwards ${verb} as the outer init.method`, async () => {
+      const { createProxiedFetch } = await import('../../src/shell/proxied-fetch.js');
+      const proxiedFetch = createProxiedFetch();
+
+      await proxiedFetch('https://caldav.example.com/cal/', {
+        method: verb,
+        headers: { 'Content-Type': 'application/xml', Depth: '1' },
+        body: '<propfind xmlns="DAV:"><prop><displayname/></prop></propfind>',
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('/api/fetch-proxy');
+      expect((init as RequestInit).method).toBe(verb);
+    });
+
+    it(`forwards ${verb} body verbatim into init.body`, async () => {
+      const { createProxiedFetch } = await import('../../src/shell/proxied-fetch.js');
+      const proxiedFetch = createProxiedFetch();
+
+      const body = `<request verb="${verb}"/>`;
+      await proxiedFetch('https://caldav.example.com/cal/', {
+        method: verb,
+        headers: { 'Content-Type': 'application/xml' },
+        body,
+      });
+
+      const init = mockFetch.mock.calls[0][1] as RequestInit;
+      // Text content-type → body is forwarded as the same string the
+      // caller passed in (prepareRequestBody returns it unchanged).
+      expect(init.body).toBe(body);
+    });
+
+    it(`encodes forbidden request headers (Cookie/Origin/Referer) for ${verb}`, async () => {
+      const { createProxiedFetch } = await import('../../src/shell/proxied-fetch.js');
+      const proxiedFetch = createProxiedFetch();
+
+      await proxiedFetch('https://caldav.example.com/cal/', {
+        method: verb,
+        headers: {
+          Cookie: 'sid=abc',
+          Origin: 'https://caldav.example.com',
+          Referer: 'https://caldav.example.com/principals/',
+          Depth: '1',
+        },
+        body: '<x/>',
+      });
+
+      const init = mockFetch.mock.calls[0][1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers['X-Proxy-Cookie']).toBe('sid=abc');
+      expect(headers['X-Proxy-Origin']).toBe('https://caldav.example.com');
+      expect(headers['X-Proxy-Referer']).toBe('https://caldav.example.com/principals/');
+      // Non-forbidden DAV headers pass through unchanged.
+      expect(headers['Depth']).toBe('1');
+      // Target URL header always present.
+      expect(headers['X-Target-URL']).toBe('https://caldav.example.com/cal/');
+    });
+  }
+
+  it('omits body for GET (sanity check that the DAV-body guard is method-aware)', async () => {
+    const { createProxiedFetch } = await import('../../src/shell/proxied-fetch.js');
+    const proxiedFetch = createProxiedFetch();
+
+    await proxiedFetch('https://caldav.example.com/cal/', {
+      method: 'GET',
+      body: 'should-not-be-sent',
+    });
+
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.body).toBeUndefined();
+  });
+});

--- a/packages/webapp/tests/shell/wasm-shell-curl-dav.test.ts
+++ b/packages/webapp/tests/shell/wasm-shell-curl-dav.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `curl -X <DAV-VERB>` round-trip through `WasmShell` → just-bash curl shim →
+ * `SecureFetch` (our `createProxiedFetch()` CLI branch) → mocked
+ * `globalThis.fetch('/api/fetch-proxy', init)`.
+ *
+ * Verifies the agent can issue WebDAV/CalDAV requests with arbitrary verbs
+ * from the bash tool. If just-bash's curl shim drops `-X PROPFIND` (or the
+ * supplied body) on the floor, the corresponding test fails — that finding
+ * is then a spec-level follow-up (per task definition of done), not a fix
+ * inside this package.
+ */
+
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../src/fs/index.js';
+import { WasmShell } from '../../src/shell/wasm-shell.js';
+
+const DAV_VERBS = ['PROPFIND', 'REPORT', 'MKCALENDAR', 'LOCK'] as const;
+
+let dbCounter = 0;
+
+describe('WasmShell curl shim — DAV verb pass-through', () => {
+  let fs: VirtualFS;
+  let originalChrome: unknown;
+  let originalFetch: typeof globalThis.fetch | undefined;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    fs = await VirtualFS.create({ dbName: `test-curl-dav-${dbCounter++}`, wipe: true });
+    originalChrome = (globalThis as { chrome?: unknown }).chrome;
+    originalFetch = globalThis.fetch;
+    // CLI mode — createProxiedFetch() routes through globalThis.fetch('/api/fetch-proxy', …).
+    (globalThis as { chrome?: unknown }).chrome = undefined;
+    mockFetch = vi.fn().mockImplementation(async () => {
+      return new Response('<multistatus xmlns="DAV:"/>', {
+        status: 207,
+        statusText: 'Multi-Status',
+        headers: { 'content-type': 'application/xml; charset=utf-8' },
+      });
+    });
+    (globalThis as { fetch: typeof globalThis.fetch }).fetch =
+      mockFetch as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    (globalThis as { chrome?: unknown }).chrome = originalChrome;
+    if (originalFetch) {
+      (globalThis as { fetch: typeof globalThis.fetch }).fetch = originalFetch;
+    }
+    vi.restoreAllMocks();
+    await fs.dispose();
+  });
+
+  for (const verb of DAV_VERBS) {
+    it(`propagates curl -X ${verb} -d '<xml/>' through SecureFetch as method=${verb}`, async () => {
+      const shell = new WasmShell({ fs });
+      const body = `<request verb="${verb}"/>`;
+
+      const result = await shell.executeCommand(
+        `curl -s -X ${verb} -H 'Content-Type: application/xml' -d '${body}' https://caldav.example.com/cal/`
+      );
+
+      if (mockFetch.mock.calls.length === 0) {
+        // Treat as documented follow-up: just-bash's curl shim did NOT
+        // reach `SecureFetch` at all (e.g. rejected the verb pre-fetch).
+        // Surface enough context for the spec follow-up note rather than
+        // a silent skip.
+        throw new Error(
+          `curl shim did not call SecureFetch for verb ${verb}; ` +
+            `exit=${result.exitCode}, stderr=${JSON.stringify(result.stderr)}`
+        );
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('/api/fetch-proxy');
+      expect((init as RequestInit).method).toBe(verb);
+      const fwdHeaders = (init as RequestInit).headers as Record<string, string>;
+      expect(fwdHeaders['X-Target-URL']).toBe('https://caldav.example.com/cal/');
+
+      // Body survives the curl-shim → SecureFetch → proxiedFetch hop.
+      // prepareRequestBody passes text bodies through verbatim (string).
+      expect(init.body).toBe(body);
+    });
+  }
+
+  it('still allows GET as a baseline (sanity check the harness)', async () => {
+    const shell = new WasmShell({ fs });
+    await shell.executeCommand('curl -s -X GET https://caldav.example.com/cal/');
+    expect(mockFetch).toHaveBeenCalled();
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe('GET');
+  });
+});


### PR DESCRIPTION
## Goal

Let the agent make outbound WebDAV/CalDAV requests through SLICC's fetch-proxy on all three floats (node-server CLI, swift-server, chrome-extension). Plumbing only — no skill, no DAV-server-side support, no DAV-aware client.

Verbs covered: `PROPFIND, PROPPATCH, MKCOL, MKCALENDAR, REPORT, COPY, MOVE, LOCK, UNLOCK`.

## What changed

| Package | Production change | Tests added |
|---|---|---|
| **swift-server** | Extended `fetchProxyMethods` in `APIRoutes.swift` to register all 9 WebDAV+CalDAV verbs via `HTTPRequest.Method(rawValue:)`. The existing `HTTPMethod.init(_:)` fallback to `.RAW(value:)` covers outbound forwarding to AsyncHTTPClient without further changes. CLAUDE.md route table updated. | Round-trip tests for `PROPFIND`, `REPORT`, `MKCALENDAR`, `LOCK` against a Hummingbird live upstream stub, asserting verb + body + DAV header (`Depth` / `Timeout`) reach upstream unchanged and `207 Multi-Status` flows back. |
| **node-server** | None — `app.all('/api/fetch-proxy', ...)` + undici `fetch` already pass arbitrary verbs through. | New `tests/fetch-proxy-dav.test.ts` with PROPFIND / REPORT / MKCALENDAR / LOCK round-trips. |
| **chrome-extension** | None — service-worker `fetch-proxy.fetch` port handler is verb-transparent. Verified `installForbiddenHeaderRule` does not touch DAV headers. | New describe block in `tests/fetch-proxy-shared.test.ts` covering the same four verbs. |
| **webapp** | None — `createProxiedFetch()` CLI branch is verb-transparent; just-bash 2.14.5's `curl -X <ANY>` shim propagates arbitrary verbs to `SecureFetch`. | New `proxied-fetch-cli-dav.test.ts` (13 tests) and `wasm-shell-curl-dav.test.ts` (5 tests). |

## Verification

All CI gates pass locally:

- `npx prettier --check .` — clean
- `npm run typecheck` — clean
- `npm run test` — 5464 passing
- `npm run build` + `npm run build -w @slicc/chrome-extension` — clean
- `cd packages/swift-server && swift build && swift test` — 226/226 passing
- Coverage above floor in all four packages:
  - webapp: 67/58/68/69
  - node-server: 70.48/62.23/75.13/72.36
  - chrome-extension: 67.9/55/65.22/69.44
  - swift-server: 53.91% lines / 53.72% functions / 48.58% regions (floors 40/40/35)

A verifier agent reviewed the combined result against the spec's acceptance criteria; one tests-only gap (Swift was missing MKCALENDAR + LOCK cases) was flagged and fixed in `cedee275`.

## Non-goals

- Hosting a WebDAV/CalDAV server inside SLICC.
- DAV-specific response parsing, XML helpers, or 207-status interpretation.
- CalDAV client skill or sample.
- Touching the S3/DA `sign-and-forward` allowlists.

## Manual smoke (post-merge, optional)

From a dev SLICC instance:

```
curl -X PROPFIND -H 'Depth: 0' -u user:pass https://caldav.icloud.com/
```

should return a `207 Multi-Status`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author