### PR TITLE
feat(upskill): support company-specific skill catalogs

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -32,6 +32,7 @@ const GITHUB_GLOBAL_DB = GLOBAL_FS_DB_NAME;
 const GITHUB_TOKEN_PATH = '/workspace/.git/github-token';
 const GITHUB_API_ACCEPT = 'application/vnd.github.v3+json';
 const SKILL_CATALOG_URL = 'https://www.sliccy.com/skills/catalog.json';
+const SKILL_CATALOG_BASE_URL = 'https://www.sliccy.com/skills/';
 
 interface TesslSkillAttributes {
   name: string;
@@ -131,6 +132,10 @@ interface UserProfile {
   tasks: string[];
   apps: string[];
   name: string;
+  /** Optional company / organization, collected by the welcome sprinkle. When
+   *  set, recommendations also pull `/skills/<slug>.json` so company-specific
+   *  skills can be pushed alongside the global catalog. */
+  company?: string;
 }
 
 interface RemoteCatalogRow {
@@ -1468,7 +1473,57 @@ function normalizeProfile(profile: Partial<UserProfile>): UserProfile {
     tasks: Array.isArray(profile.tasks) ? profile.tasks : [],
     apps: Array.isArray(profile.apps) ? profile.apps : [],
     name: profile.name ?? '',
+    company: typeof profile.company === 'string' ? profile.company : undefined,
   };
+}
+
+/**
+ * Slugify a company name for use as a catalog filename component, e.g.
+ * `"Adobe"` → `"adobe"`, `"Acme Inc."` → `"acme-inc"`. Returns `null` when
+ * the input slugs to an empty string so callers can skip the fetch.
+ */
+function slugifyCompany(company: string | undefined | null): string | null {
+  if (!company) return null;
+  const slug = company
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-+|-+$)/g, '');
+  return slug || null;
+}
+
+/**
+ * Fetch the per-company skill catalog (`/skills/<slug>.json`). Returns `[]`
+ * on any failure — a missing or broken company catalog must not block the
+ * primary recommendation flow.
+ */
+async function fetchCompanyCatalog(
+  fetchFn: SecureFetch,
+  company: string | undefined | null
+): Promise<CatalogSkill[]> {
+  const slug = slugifyCompany(company);
+  if (!slug) return [];
+  try {
+    const response = await fetchFn(`${SKILL_CATALOG_BASE_URL}${slug}.json`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (response.status !== 200) return [];
+    const data = parseFetchJson<{ data: RemoteCatalogRow[] }>(response.body);
+    return parseRemoteCatalog(data.data);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Merge a base catalog with a company-specific catalog, deduping by skill
+ * name. Company-specific entries take precedence so a company can override
+ * affinity / priority of a globally-listed skill.
+ */
+function mergeCatalogs(base: CatalogSkill[], company: CatalogSkill[]): CatalogSkill[] {
+  if (company.length === 0) return base;
+  const companyNames = new Set(company.map((s) => s.name));
+  return [...base.filter((s) => !companyNames.has(s.name)), ...company];
 }
 
 /**
@@ -1556,11 +1611,14 @@ export async function installRecommendedSkills(
 
   if (!profile) return empty('no-profile');
 
-  // Fetch catalog and installed names in parallel
+  // Fetch catalog, optional company catalog, and installed names in parallel.
+  // The company catalog (when profile.company is set) is best-effort — its
+  // failure is silently ignored so an unrecognized company never blocks
+  // recommendations from the global catalog.
   let catalogSkills: CatalogSkill[];
   let installed: Set<string>;
   try {
-    const [catalogResult, installedResult] = await Promise.all([
+    const [catalogResult, companyResult, installedResult] = await Promise.all([
       (async () => {
         const response = await fetchFn(SKILL_CATALOG_URL, {
           headers: { Accept: 'application/json' },
@@ -1571,9 +1629,10 @@ export async function installRecommendedSkills(
         const data = parseFetchJson<{ data: RemoteCatalogRow[] }>(response.body);
         return parseRemoteCatalog(data.data);
       })(),
+      fetchCompanyCatalog(fetchFn, profile.company),
       getInstalledSkillNames(fs),
     ]);
-    catalogSkills = catalogResult;
+    catalogSkills = mergeCatalogs(catalogResult, companyResult);
     installed = installedResult;
   } catch (err) {
     return empty('catalog-fetch', [
@@ -2163,7 +2222,7 @@ async function handleRecommendations(
   let catalogSkills: CatalogSkill[];
   let installed: Set<string>;
   try {
-    const [catalogResult, installedResult] = await Promise.all([
+    const [catalogResult, companyResult, installedResult] = await Promise.all([
       (async () => {
         const response = await fetchFn(SKILL_CATALOG_URL, {
           headers: { Accept: 'application/json' },
@@ -2174,9 +2233,10 @@ async function handleRecommendations(
         const data = parseFetchJson<{ data: RemoteCatalogRow[] }>(response.body);
         return parseRemoteCatalog(data.data);
       })(),
+      fetchCompanyCatalog(fetchFn, profile.company),
       getInstalledSkillNames(fs),
     ]);
-    catalogSkills = catalogResult;
+    catalogSkills = mergeCatalogs(catalogResult, companyResult);
     installed = installedResult;
   } catch (err) {
     return {

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -31,8 +31,8 @@ const SKILLS_DIR = '/workspace/skills';
 const GITHUB_GLOBAL_DB = GLOBAL_FS_DB_NAME;
 const GITHUB_TOKEN_PATH = '/workspace/.git/github-token';
 const GITHUB_API_ACCEPT = 'application/vnd.github.v3+json';
-const SKILL_CATALOG_URL = 'https://www.sliccy.com/skills/catalog.json';
 const SKILL_CATALOG_BASE_URL = 'https://www.sliccy.com/skills/';
+const SKILL_CATALOG_URL = `${SKILL_CATALOG_BASE_URL}catalog.json`;
 
 interface TesslSkillAttributes {
   name: string;
@@ -1479,11 +1479,13 @@ function normalizeProfile(profile: Partial<UserProfile>): UserProfile {
 
 /**
  * Slugify a company name for use as a catalog filename component, e.g.
- * `"Adobe"` → `"adobe"`, `"Acme Inc."` → `"acme-inc"`. Returns `null` when
- * the input slugs to an empty string so callers can skip the fetch.
+ * `"Adobe"` → `"adobe"`, `"Acme Inc."` → `"acme-inc"`. Accepts `unknown`
+ * so a corrupted/manually-edited `/home/<user>/.welcome.json` (e.g.
+ * `company: 42`) can never throw — returns `null` for non-strings or
+ * anything that slugs to an empty string.
  */
-function slugifyCompany(company: string | undefined | null): string | null {
-  if (!company) return null;
+function slugifyCompany(company: unknown): string | null {
+  if (typeof company !== 'string' || !company) return null;
   const slug = company
     .toLowerCase()
     .trim()
@@ -1499,11 +1501,11 @@ function slugifyCompany(company: string | undefined | null): string | null {
  */
 async function fetchCompanyCatalog(
   fetchFn: SecureFetch,
-  company: string | undefined | null
+  company: unknown
 ): Promise<CatalogSkill[]> {
-  const slug = slugifyCompany(company);
-  if (!slug) return [];
   try {
+    const slug = slugifyCompany(company);
+    if (!slug) return [];
     const response = await fetchFn(`${SKILL_CATALOG_BASE_URL}${slug}.json`, {
       headers: { Accept: 'application/json' },
     });

--- a/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
@@ -1001,6 +1001,176 @@ describe('upskill recommendations subcommand', () => {
     expect(result.stdout).toContain('upskill recommendations --install');
   });
 
+  it('fetches the company-specific catalog when profile.company is set', async () => {
+    await fs.mkdir('/home/test', { recursive: true });
+    await fs.writeFile(
+      '/home/test/.welcome.json',
+      JSON.stringify({
+        purpose: 'work',
+        role: 'developer',
+        tasks: ['build-websites'],
+        apps: ['aem'],
+        name: 'Test',
+        company: 'Adobe',
+      })
+    );
+
+    const seen: string[] = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      seen.push(url);
+      if (url.endsWith('/skills/catalog.json')) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            data: [
+              {
+                name: 'aem',
+                displayName: 'AEM',
+                description: 'AEM skill',
+                repo: 'adobe/skills',
+                path: 'skills/aem',
+                skill: 'aem',
+                apps: 'aem',
+                tasks: 'build-websites',
+                role: 'developer',
+                purpose: 'work',
+                boost: '',
+              },
+            ],
+          }),
+          headers: {},
+        };
+      }
+      if (url.endsWith('/skills/adobe.json')) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            data: [
+              {
+                name: 'adobe-internal-tool',
+                displayName: 'Adobe Internal Tool',
+                description: 'Internal-only skill',
+                repo: 'adobe/internal-skills',
+                path: 'skills/internal',
+                skill: 'internal',
+                apps: 'aem',
+                tasks: 'build-websites',
+                role: 'developer',
+                purpose: 'work',
+                boost: '',
+              },
+            ],
+          }),
+          headers: {},
+        };
+      }
+      return { status: 404, body: '', headers: {} };
+    });
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['recommendations'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(seen.some((u) => u.endsWith('/skills/adobe.json'))).toBe(true);
+    expect(result.stdout).toContain('AEM');
+    expect(result.stdout).toContain('Adobe Internal Tool');
+  });
+
+  it('falls back to base catalog when company catalog 404s', async () => {
+    await fs.mkdir('/home/test', { recursive: true });
+    await fs.writeFile(
+      '/home/test/.welcome.json',
+      JSON.stringify({
+        purpose: 'work',
+        role: 'developer',
+        tasks: ['build-websites'],
+        apps: ['aem'],
+        name: 'Test',
+        company: 'Unknown Co',
+      })
+    );
+
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.endsWith('/skills/catalog.json')) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            data: [
+              {
+                name: 'aem',
+                displayName: 'AEM',
+                description: 'AEM skill',
+                repo: 'adobe/skills',
+                path: 'skills/aem',
+                skill: 'aem',
+                apps: 'aem',
+                tasks: 'build-websites',
+                role: 'developer',
+                purpose: 'work',
+                boost: '',
+              },
+            ],
+          }),
+          headers: {},
+        };
+      }
+      return { status: 404, body: '', headers: {} };
+    });
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['recommendations'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('AEM');
+  });
+
+  it('skips company catalog fetch when company is empty', async () => {
+    await fs.mkdir('/home/test', { recursive: true });
+    await fs.writeFile(
+      '/home/test/.welcome.json',
+      JSON.stringify({
+        purpose: 'work',
+        role: 'developer',
+        tasks: ['build-websites'],
+        apps: ['aem'],
+        name: 'Test',
+        company: '',
+      })
+    );
+
+    const seen: string[] = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      seen.push(url);
+      if (url.endsWith('/skills/catalog.json')) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            data: [
+              {
+                name: 'aem',
+                displayName: 'AEM',
+                description: 'AEM skill',
+                repo: 'adobe/skills',
+                path: 'skills/aem',
+                skill: 'aem',
+                apps: 'aem',
+                tasks: 'build-websites',
+                role: 'developer',
+                purpose: 'work',
+                boost: '',
+              },
+            ],
+          }),
+          headers: {},
+        };
+      }
+      return { status: 404, body: '', headers: {} };
+    });
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['recommendations'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(seen.some((u) => u.includes('/skills/') && !u.endsWith('/catalog.json'))).toBe(false);
+  });
+
   it('returns error when catalog fetch fails', async () => {
     // Write profile so we get past profile check
     await fs.mkdir('/home/test', { recursive: true });


### PR DESCRIPTION
## Summary

`upskill recommendations` now consumes the `company` field collected by the welcome sprinkle. When a profile has e.g. `company: "Adobe"`, the command fetches both `https://www.sliccy.com/skills/catalog.json` and `https://www.sliccy.com/skills/adobe.json` in parallel and merges them before scoring. This lets us push company-specific skills without polluting the global catalog.

## Changes

- `packages/webapp/src/shell/supplemental-commands/upskill-command.ts`
  - Added `SKILL_CATALOG_BASE_URL` constant.
  - Added optional `company?: string` to `UserProfile` and propagated it through `normalizeProfile`.
  - New helpers: `slugifyCompany`, `fetchCompanyCatalog` (best-effort, returns `[]` on any failure), `mergeCatalogs` (dedupes by skill name; company entries win on collision).
  - Both catalog-fetch sites (`installRecommendedSkills` and `handleRecommendations`) now fetch the global + company catalogs in parallel and merge.
- `packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts`
  - Three new tests: company catalog is fetched and merged, fallback on 404, skipped when company is empty.

## Behavior

- Empty/missing `company` → no extra fetch; behavior unchanged.
- Company catalog 404 / 5xx / network error → silently ignored; never blocks the primary flow.
- Same-named skills in both catalogs → company entry overrides (so a company can tune affinity/priority).

## Verification

- `npm run typecheck` — clean.
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts` — **98 passed** (95 existing + 3 new).
- `npx prettier --write` on touched files.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author