### PR TITLE
fix(cloud-core): bump e2b requestTimeoutMs to survive CF subrequest cap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4212,9 +4212,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4232,9 +4229,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4252,9 +4246,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4272,9 +4263,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4292,9 +4280,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4312,9 +4297,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/cloud-core/src/substrates/e2b.ts
+++ b/packages/cloud-core/src/substrates/e2b.ts
@@ -15,6 +15,12 @@ export function createE2bSubstrate(cfg: SubstrateConfig): SandboxSubstrate {
   // Capture apiKey locally to pass explicitly to every SDK call (worker-safe).
   const apiKey = cfg.apiKey;
 
+  // CF Workers' default subrequest timeout aborts fetches around 30s. e2b's
+  // Sandbox.create resolves once the VM is restored from the paused template
+  // snapshot, which can take 20-40s on a cold edge. Bump requestTimeoutMs so
+  // CF doesn't abort the fetch under our feet. Same for connect (resume path).
+  const REQUEST_TIMEOUT_MS = 120_000;
+
   return {
     id: 'e2b',
     async create(opts: CreateOpts): Promise<SandboxHandle> {
@@ -23,12 +29,16 @@ export function createE2bSubstrate(cfg: SubstrateConfig): SandboxSubstrate {
         envs: opts.envVars,
         metadata: opts.metadata,
         timeoutMs: DEFAULT_TTL_MS,
+        requestTimeoutMs: REQUEST_TIMEOUT_MS,
         ...(opts.autoPauseOnCap ? { lifecycle: { onTimeout: 'pause' } } : {}),
       });
       return wrap(sbx);
     },
     async connect(sandboxId: string): Promise<SandboxHandle> {
-      const sbx = await Sandbox.connect(sandboxId, { apiKey });
+      const sbx = await Sandbox.connect(sandboxId, {
+        apiKey,
+        requestTimeoutMs: REQUEST_TIMEOUT_MS,
+      });
       return wrap(sbx);
     },
     async list(opts?: import('../substrate.js').ListOpts): Promise<SandboxSummary[]> {

--- a/packages/dev-tools/e2b-template/start.sh
+++ b/packages/dev-tools/e2b-template/start.sh
@@ -5,8 +5,14 @@ set -e
 # would default to ~/.slicc/secrets.env (the laptop CLI path) inside the
 # sandbox, where nothing exists. CHROME_USER_DATA_DIR matches the --hosted
 # default and is belt-and-suspenders.
+#
+# SLICC_CDP_LAUNCH_TIMEOUT_MS: chromium cold-starts on every new sandbox
+# (template snapshot has no running processes — see template.ts setStartCmd
+# waitForFile). 15s default is too tight for a cold microVM; 60s gives
+# generous headroom without making real failures wait too long.
 export SLICC_SECRETS_FILE=/slicc/secrets.env
 export CHROME_USER_DATA_DIR=/data/profile
+export SLICC_CDP_LAUNCH_TIMEOUT_MS=60000
 
 # Bootstrap secrets.env from sandbox env vars when present. Both the laptop CLI
 # (Plan B) and the Cloudflare worker (Plan D) inject ADOBE_IMS_TOKEN via


### PR DESCRIPTION
## Symptom

Production `POST /api/cloud/start` returns `500 INTERNAL: The operation was aborted due to timeout` after ~30s.

## Root cause

The e2b SDK's `Sandbox.create` (and `Sandbox.connect` for resume) call e2b's API and wait for the sandbox to be restored from the paused template snapshot. That restore can take 20-40s on a cold edge.

The e2b SDK uses `AbortSignal.timeout(requestTimeoutMs)` on each HTTP call. Our code never sets `requestTimeoutMs`, so it falls back to the SDK default (~30s). When the snapshot restore takes longer than that, the SDK aborts with `TimeoutError`: "The operation was aborted due to timeout" — the exact error we saw in prod.

(This was predicted in Plan C's PASS-WITH-CAVEATS verdict: "Production Workers CPU + subrequest limits not yet measured.")

## Fix

Pass `requestTimeoutMs: 120_000` to `Sandbox.create` and `Sandbox.connect`. Same magnitude as the cap on most non-trivial CF Workers plans. e2b's snapshot restore should always fit well under 2 minutes in practice.

If CF Workers' own subrequest budget still aborts before 120s, we'd see a different error class (CF returns its own abort, not jose-style "operation aborted"). In that case we'd need the async pattern (DO alarm to do `substrate.create` outside the request lifecycle). This fix is the surgical first attempt.

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run build -w @slicc/cloud-core` ✓
- [ ] Deploy via staging workflow + retry `POST /api/cloud/start` against staging
- [ ] If staging passes, merge → prod release path picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)