### PR TITLE
feat(providers): split GitHub auth from GitHub Copilot, add device-flow LLM provider

### DIFF
--- a/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
+++ b/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
@@ -166,6 +166,24 @@
         margin-top: 6px;
         line-height: 1.4;
       }
+
+      /* Device-code box — matches the settings dialog's inline code
+         box so the welcome flow and Add Account flow look identical. */
+      .device-code {
+        margin-top: 14px;
+        padding: 10px 12px;
+        border-radius: 8px;
+        background: var(--s2-bg-elevated, #161b22);
+        border: 1px solid var(--s2-border-default, #30363d);
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-weight: 600;
+        font-size: 22px;
+        letter-spacing: 2px;
+        text-align: center;
+        color: var(--s2-content-default, #e6edf3);
+        user-select: all;
+        cursor: text;
+      }
     </style>
   </head>
   <body>
@@ -210,6 +228,23 @@
         <button id="connectBtn" class="btn btn--primary" type="button">Connect</button>
       </div>
       <div class="meta" id="meta"></div>
+    </section>
+
+    <!-- Step 2.5: device-code prompt (GitHub Copilot, future device flows). -->
+    <section id="sDeviceCode" class="step">
+      <div class="step-heading" id="deviceCodeHeading">Verification code</div>
+      <div class="step-sub" id="deviceCodeSub">
+        Copy the code, then click Continue. We'll open the authorization page in a new tab —
+        paste the code there if it isn't pre-filled.
+      </div>
+      <div class="device-code" id="deviceCode">XXXX-XXXX</div>
+      <div class="actions">
+        <button id="deviceCancelBtn" class="btn" type="button">Cancel</button>
+        <span class="spacer"></span>
+        <button id="deviceContinueBtn" class="btn btn--primary" type="button">
+          Copy &amp; Continue
+        </button>
+      </div>
     </section>
 
     <!-- Step 3: success -->
@@ -292,10 +327,50 @@
       }
 
       function go(stepId) {
-        ['sProvider', 'sCreds', 'sDone'].forEach(function (id) {
+        ['sProvider', 'sCreds', 'sDeviceCode', 'sDone'].forEach(function (id) {
           document.getElementById(id).classList.toggle('active', id === stepId);
         });
       }
+
+      // Cache device-code DOM up front so the message handler can flip
+      // between steps without re-querying every time.
+      var deviceCodeEl = document.getElementById('deviceCode');
+      var deviceCancelBtn = document.getElementById('deviceCancelBtn');
+      var deviceContinueBtn = document.getElementById('deviceContinueBtn');
+      function emitDeviceDecision(decision) {
+        // Lock both buttons immediately so we never send two decisions
+        // for the same prompt (e.g. double-clicks).
+        deviceCancelBtn.disabled = true;
+        deviceContinueBtn.disabled = true;
+        slicc.lick({
+          action: 'device-code-decision',
+          data: { decision: decision },
+        });
+      }
+      deviceCancelBtn.onclick = function () {
+        emitDeviceDecision('cancel');
+        // Return to the credential step — the host will broadcast a
+        // `slicc-connect-result` shortly with the cancellation message,
+        // which the existing handler renders into the status row.
+        go('sCreds');
+      };
+      deviceContinueBtn.onclick = function () {
+        // Best-effort clipboard copy — the host's prompter will retry
+        // server-side too, but doing it here lets the user paste even
+        // if the host clipboard call gets blocked by the sandbox.
+        try {
+          var text = deviceCodeEl.textContent || '';
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text);
+          }
+        } catch (e) {
+          /* ignore — code is still visible on the box */
+        }
+        emitDeviceDecision('continue');
+        statusEl.className = 'status busy';
+        statusEl.textContent = 'Waiting for you to authorize in the new tab…';
+        go('sCreds');
+      };
 
       function selectProvider(p) {
         current.provider = p.id;
@@ -444,6 +519,16 @@
           // model dropdown; that responsibility now lives in the chat
           // header so we deliberately ignore the models map.
           renderProviders();
+        } else if (msg.type === 'slicc-device-code') {
+          // Host is asking us to render the device-flow verification
+          // code (GitHub Copilot today; future device-flow providers
+          // can reuse this same message). Show the code + Cancel /
+          // Copy & Continue and wait for the user's pick — the host
+          // won't open any auth tab until we emit `device-code-decision`.
+          deviceCodeEl.textContent = msg.userCode || 'XXXX-XXXX';
+          deviceCancelBtn.disabled = false;
+          deviceContinueBtn.disabled = false;
+          go('sDeviceCode');
         } else if (msg.type === 'slicc-already-connected') {
           // Reload of a chat that already finished onboarding —
           // skip the provider list entirely and show a finished card.

--- a/packages/webapp/providers/github-copilot.ts
+++ b/packages/webapp/providers/github-copilot.ts
@@ -1,0 +1,1049 @@
+/**
+ * GitHub Copilot Provider — device-flow login + Copilot-backed LLM access.
+ *
+ * Why this is separate from `github.ts`:
+ *   GitHub's `copilot_internal/v2/token` endpoint is gated on the OAuth
+ *   client ID itself. Slicc's general-purpose GitHub OAuth App is not on
+ *   the allowlist — all calls return 404 regardless of token scopes or
+ *   subscription tier. The only public way to get a Copilot-eligible
+ *   token is GitHub's device-code flow with the well-known VS Code
+ *   Copilot Chat client ID (`Iv1.b507a08c87ecfe98`). That's what every
+ *   third-party Copilot client (Aider, Continue, opencode, pi-mono, …)
+ *   does. This provider implements exactly that flow, then reuses pi-ai's
+ *   `github-copilot` provider machinery for streaming.
+ *
+ * Login UX:
+ *   We piggy-back on `onOAuthLoginIntercepted` / the controlled-browser
+ *   `InterceptingOAuthLauncher` (same pattern `oauth-token --intercept`
+ *   exposes to the shell). The flow:
+ *     1. POST `/login/device/code` to receive `device_code`, `user_code`,
+ *        `verification_uri`.
+ *     2. Open `https://github.com/login/device?user_code=XXXX-XXXX` in a
+ *        fresh controlled-browser tab via the launcher. The user just
+ *        clicks "Continue" → "Authorize <VS Code app>". The launcher
+ *        auto-closes the tab when the post-authorize success page loads.
+ *     3. Poll `/login/oauth/access_token` in parallel until GitHub issues
+ *        the access token (typically <1s after the user clicks Authorize).
+ *     4. Exchange that token for a short-lived Copilot token at
+ *        `api.github.com/copilot_internal/v2/token`, save under this
+ *        provider's account.
+ *
+ * Streaming:
+ *   Pi-mono's anthropic / openai-completions / openai-responses providers
+ *   already have built-in `model.provider === "github-copilot"` branches
+ *   that send the right Bearer auth + dynamic VS Code Chat headers. Our
+ *   wrappers just restore the underlying api / baseUrl / headers that
+ *   slicc's getModelIds branch overrides with the slicc custom api name,
+ *   then delegate.
+ */
+
+import type {
+  ProviderConfig,
+  InterceptingOAuthLauncher,
+  OAuthLoginOptions,
+  DeviceCodePrompter,
+  ModelMetadata,
+} from '../src/providers/types.js';
+import {
+  registerApiProvider,
+  streamAnthropic,
+  streamSimpleAnthropic,
+  streamOpenAICompletions,
+  streamSimpleOpenAICompletions,
+  streamOpenAIResponses,
+  streamSimpleOpenAIResponses,
+  createAssistantMessageEventStream,
+  getModel,
+  getModels,
+} from '@earendil-works/pi-ai';
+import type { Api, Model, Context } from '@earendil-works/pi-ai';
+import { saveOAuthAccount, getAccounts } from '../src/ui/provider-settings.js';
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const PROVIDER_ID = 'github-copilot';
+
+/**
+ * Public VS Code Copilot Chat OAuth App client ID. Hardcoded here (and in
+ * pi-mono and every other third-party Copilot client) because it's the only
+ * client GitHub authorizes to call `copilot_internal/v2/token`. Base64
+ * encoded to mirror pi-mono's convention — not a security measure, just to
+ * avoid trivial secret-scanner false positives in the public repo.
+ */
+const VSCODE_COPILOT_CLIENT_ID = atob('SXYxLmI1MDdhMDhjODdlY2ZlOTg=');
+
+const GITHUB_DEVICE_CODE_URL = 'https://github.com/login/device/code';
+const GITHUB_ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const COPILOT_TOKEN_URL = 'https://api.github.com/copilot_internal/v2/token';
+
+/** Mirrors the VS Code Copilot Chat extension's identifying headers. */
+const COPILOT_EXCHANGE_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'Editor-Version': 'vscode/1.107.0',
+  'Editor-Plugin-Version': 'copilot-chat/0.35.0',
+  'Copilot-Integration-Id': 'vscode-chat',
+};
+
+/** Headers GitHub expects on the device-code / token POSTs. */
+const DEVICE_FLOW_POST_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'Content-Type': 'application/x-www-form-urlencoded',
+};
+
+/**
+ * After the user clicks "Authorize" on the device flow, GitHub navigates the
+ * tab to `https://github.com/login/device/success` (with the user_code as a
+ * query param). Capturing that URL via the intercepting launcher gives us a
+ * clean tab-close signal — we don't need its body, just the navigation event.
+ */
+const DEVICE_SUCCESS_PATTERN = 'https://github.com/login/device/success*';
+
+// ── Types ──────────────────────────────────────────────────────────
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface AccessTokenResponse {
+  access_token?: string;
+  error?: string;
+  error_description?: string;
+  interval?: number;
+}
+
+interface CopilotTokenResponse {
+  token: string;
+  expires_at: number;
+  refresh_in?: number;
+  sku?: string;
+  copilot_plan?: string;
+  chat_enabled?: boolean;
+  endpoints?: { api?: string };
+}
+
+interface PersistedCopilot {
+  copilotToken: string;
+  expiresAtMs: number;
+  apiBaseUrl: string;
+  githubAccessToken: string;
+}
+
+// ── Account access ─────────────────────────────────────────────────
+
+function getCopilotAccount() {
+  return getAccounts().find((a) => a.providerId === PROVIDER_ID);
+}
+
+// ── Device flow ────────────────────────────────────────────────────
+
+async function startDeviceFlow(): Promise<DeviceCodeResponse> {
+  const res = await fetch(GITHUB_DEVICE_CODE_URL, {
+    method: 'POST',
+    headers: DEVICE_FLOW_POST_HEADERS,
+    body: new URLSearchParams({
+      client_id: VSCODE_COPILOT_CLIENT_ID,
+      scope: 'read:user',
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub device-code request failed: ${res.status} ${res.statusText} — ${await res.text().catch(() => '')}`
+    );
+  }
+  const data = (await res.json()) as DeviceCodeResponse;
+  if (
+    typeof data.device_code !== 'string' ||
+    typeof data.user_code !== 'string' ||
+    typeof data.verification_uri !== 'string' ||
+    typeof data.expires_in !== 'number' ||
+    typeof data.interval !== 'number'
+  ) {
+    throw new Error('GitHub device-code response had an unexpected shape');
+  }
+  return data;
+}
+
+/**
+ * Poll `/login/oauth/access_token` until GitHub issues a token or the device
+ * code expires. Returns the access token on success. Honors the `slow_down`
+ * error by backing off; cancels cleanly when `signal` aborts.
+ */
+async function pollForGitHubAccessToken(
+  device: DeviceCodeResponse,
+  signal: AbortSignal
+): Promise<string> {
+  const deadline = Date.now() + device.expires_in * 1000;
+  // Mirror pi-mono's pacing — the first wait gets a 1.2x buffer to stay
+  // safely above GitHub's stated interval.
+  let intervalMs = Math.max(1000, Math.floor(device.interval * 1000));
+  let multiplier = 1.2;
+
+  while (Date.now() < deadline) {
+    if (signal.aborted) throw new Error('Copilot login cancelled');
+    await abortableSleep(Math.ceil(intervalMs * multiplier), signal);
+
+    const res = await fetch(GITHUB_ACCESS_TOKEN_URL, {
+      method: 'POST',
+      headers: DEVICE_FLOW_POST_HEADERS,
+      body: new URLSearchParams({
+        client_id: VSCODE_COPILOT_CLIENT_ID,
+        device_code: device.device_code,
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `GitHub token poll failed: ${res.status} ${res.statusText} — ${await res.text().catch(() => '')}`
+      );
+    }
+    const data = (await res.json()) as AccessTokenResponse;
+    if (typeof data.access_token === 'string' && data.access_token.length > 0) {
+      return data.access_token;
+    }
+    if (data.error === 'authorization_pending') continue;
+    if (data.error === 'slow_down') {
+      intervalMs = typeof data.interval === 'number' ? data.interval * 1000 : intervalMs + 5000;
+      multiplier = 1.4;
+      continue;
+    }
+    if (data.error) {
+      const desc = data.error_description ? `: ${data.error_description}` : '';
+      throw new Error(`Device flow failed (${data.error})${desc}`);
+    }
+  }
+  throw new Error('Copilot device flow timed out (device code expired)');
+}
+
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error('Copilot login cancelled'));
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(new Error('Copilot login cancelled'));
+      },
+      { once: true }
+    );
+  });
+}
+
+// ── Copilot token exchange ─────────────────────────────────────────
+
+function extractCopilotApiBase(token: string): string | null {
+  const m = token.match(/proxy-ep=([^;]+)/);
+  if (!m) return null;
+  return `https://${m[1].replace(/^proxy\./, 'api.')}`;
+}
+
+async function exchangeForCopilotToken(githubAccessToken: string): Promise<PersistedCopilot> {
+  const res = await fetch(COPILOT_TOKEN_URL, {
+    headers: { ...COPILOT_EXCHANGE_HEADERS, Authorization: `Bearer ${githubAccessToken}` },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(
+      `Copilot token exchange failed: ${res.status} ${res.statusText} — ${body.slice(0, 300)}`
+    );
+  }
+  const data = (await res.json()) as CopilotTokenResponse;
+  if (typeof data.token !== 'string' || typeof data.expires_at !== 'number') {
+    throw new Error('Copilot token exchange returned an unexpected payload');
+  }
+  if (data.chat_enabled === false) {
+    throw new Error('GitHub Copilot Chat is disabled for this account (no chat features granted)');
+  }
+  return {
+    copilotToken: data.token,
+    // Mirror pi-mono's 5-minute safety buffer for refresh.
+    expiresAtMs: data.expires_at * 1000 - 5 * 60 * 1000,
+    apiBaseUrl: extractCopilotApiBase(data.token) ?? 'https://api.individual.githubcopilot.com',
+    githubAccessToken,
+  };
+}
+
+// ── Live catalog discovery (/models) ───────────────────────────────
+
+/**
+ * Subset of GitHub Copilot's `/models` response we actually consume.
+ * The endpoint returns far more fields (vision dimensions, tokenizer, etc.);
+ * we only persist what slicc needs for picker rendering, policy management,
+ * and stream dispatch.
+ */
+interface CopilotCatalogEntry {
+  id: string;
+  name: string;
+  vendor: string;
+  /** Pi-mono-style api shape, derived from supported_endpoints + vendor + id. */
+  api: 'anthropic-messages' | 'openai-completions' | 'openai-responses';
+  contextWindow: number;
+  maxTokens: number;
+  supportsTools: boolean;
+  supportsStreaming: boolean;
+  supportsVision: boolean;
+  supportsReasoning: boolean;
+  /** `enabled` / `disabled` / `unconfigured` — `disabled` requires a policy POST. */
+  policyState: 'enabled' | 'disabled' | 'unconfigured' | string;
+}
+
+const COPILOT_CATALOG_STORAGE_KEY = 'github-copilot.models.v1';
+
+interface RawCopilotModel {
+  id: string;
+  name?: string;
+  object?: string;
+  vendor?: string;
+  model_picker_enabled?: boolean;
+  preview?: boolean;
+  supported_endpoints?: string[];
+  policy?: { state?: string };
+  capabilities?: {
+    type?: string;
+    family?: string;
+    limits?: {
+      max_context_window_tokens?: number;
+      max_output_tokens?: number;
+      max_prompt_tokens?: number;
+    };
+    supports?: {
+      tool_calls?: boolean;
+      streaming?: boolean;
+      vision?: boolean;
+      adaptive_thinking?: boolean;
+      reasoning_effort?: unknown;
+    };
+  };
+}
+
+/**
+ * Pick the pi-mono `api` shape from GitHub's catalog entry. Order matters:
+ *   1) Anthropic vendors that advertise `/v1/messages` use Anthropic Messages
+ *      (better caching + tool semantics on Claude than the OpenAI shape).
+ *   2) OpenAI's GPT-5 / o-series / codex line speaks the `/responses` API.
+ *   3) Everything else (gpt-4.x, gemini, grok, …) speaks `/chat/completions`.
+ */
+function pickCopilotApi(raw: RawCopilotModel): CopilotCatalogEntry['api'] {
+  const endpoints = raw.supported_endpoints ?? [];
+  const vendor = (raw.vendor ?? '').toLowerCase();
+  const id = raw.id;
+  if (vendor === 'anthropic' && endpoints.includes('/v1/messages')) {
+    return 'anthropic-messages';
+  }
+  if (vendor === 'openai' && (/^gpt-5/i.test(id) || /codex/i.test(id) || /^o\d/i.test(id))) {
+    return 'openai-responses';
+  }
+  return 'openai-completions';
+}
+
+function parseCopilotCatalog(json: unknown): CopilotCatalogEntry[] {
+  if (!json || typeof json !== 'object') return [];
+  const data = (json as { data?: RawCopilotModel[] }).data;
+  if (!Array.isArray(data)) return [];
+  const out: CopilotCatalogEntry[] = [];
+  for (const raw of data) {
+    if (raw.capabilities?.type && raw.capabilities.type !== 'chat') continue;
+    if (raw.model_picker_enabled === false) continue;
+    if (!raw.id) continue;
+    out.push({
+      id: raw.id,
+      name: raw.name ?? raw.id,
+      vendor: raw.vendor ?? '',
+      api: pickCopilotApi(raw),
+      contextWindow:
+        raw.capabilities?.limits?.max_context_window_tokens ??
+        raw.capabilities?.limits?.max_prompt_tokens ??
+        128_000,
+      maxTokens: raw.capabilities?.limits?.max_output_tokens ?? 8192,
+      supportsTools: raw.capabilities?.supports?.tool_calls === true,
+      supportsStreaming: raw.capabilities?.supports?.streaming !== false,
+      supportsVision: raw.capabilities?.supports?.vision === true,
+      supportsReasoning:
+        raw.capabilities?.supports?.adaptive_thinking === true ||
+        Array.isArray(raw.capabilities?.supports?.reasoning_effort),
+      policyState: raw.policy?.state ?? 'enabled',
+    });
+  }
+  return out;
+}
+
+async function fetchCopilotCatalog(creds: PersistedCopilot): Promise<CopilotCatalogEntry[]> {
+  const res = await fetch(`${creds.apiBaseUrl}/models`, {
+    headers: {
+      ...COPILOT_EXCHANGE_HEADERS,
+      Authorization: `Bearer ${creds.copilotToken}`,
+      Accept: 'application/json',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Copilot /models returned ${res.status} ${res.statusText}`);
+  }
+  return parseCopilotCatalog(await res.json());
+}
+
+function loadCachedCopilotCatalog(): CopilotCatalogEntry[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(COPILOT_CATALOG_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as CopilotCatalogEntry[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function storeCachedCopilotCatalog(catalog: CopilotCatalogEntry[]): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(COPILOT_CATALOG_STORAGE_KEY, JSON.stringify(catalog));
+  } catch {
+    /* quota or denied — picker still works without persistence */
+  }
+}
+
+function findCachedCopilotModel(modelId: string): CopilotCatalogEntry | null {
+  const cache = loadCachedCopilotCatalog();
+  return cache.find((m) => m.id === modelId) ?? null;
+}
+
+/**
+ * Refresh the catalog AND accept per-model usage policies that gate premium
+ * models (Claude, GPT-5, Codex, Gemini, Grok). The /models response tells us
+ * which models actually need a `policy.state === 'disabled'` accept; we only
+ * POST for those, matching VS Code Copilot Chat's behavior.
+ *
+ * Best-effort and parallel: errors never block login or other models. The
+ * cache is updated even if individual policy accepts fail — the user can
+ * still pick non-gated models from the picker.
+ */
+async function refreshCopilotCatalogAndPolicies(creds: PersistedCopilot): Promise<void> {
+  let catalog: CopilotCatalogEntry[];
+  try {
+    catalog = await fetchCopilotCatalog(creds);
+  } catch (err) {
+    console.warn(
+      '[github-copilot] Catalog refresh failed; keeping previous cache.',
+      err instanceof Error ? err.message : String(err)
+    );
+    return;
+  }
+  storeCachedCopilotCatalog(catalog);
+  await Promise.all(
+    catalog
+      .filter((m) => m.policyState === 'disabled')
+      .map(async (m) => {
+        const url = `${creds.apiBaseUrl}/models/${encodeURIComponent(m.id)}/policy`;
+        try {
+          const res = await fetch(url, {
+            method: 'POST',
+            headers: {
+              ...COPILOT_EXCHANGE_HEADERS,
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${creds.copilotToken}`,
+              'openai-intent': 'chat-policy',
+              'x-interaction-type': 'chat-policy',
+            },
+            body: JSON.stringify({ state: 'enabled' }),
+          });
+          if (res.ok) {
+            m.policyState = 'enabled';
+          } else if (res.status !== 404 && res.status !== 400) {
+            console.warn(
+              `[github-copilot] enable policy for ${m.id} returned ${res.status} ${res.statusText}`
+            );
+          }
+        } catch (err) {
+          console.warn(
+            `[github-copilot] enable policy for ${m.id} failed:`,
+            err instanceof Error ? err.message : String(err)
+          );
+        }
+      })
+  );
+  storeCachedCopilotCatalog(catalog);
+}
+
+async function persistCopilot(creds: PersistedCopilot, userName?: string): Promise<void> {
+  await saveOAuthAccount({
+    providerId: PROVIDER_ID,
+    accessToken: creds.copilotToken,
+    refreshToken: creds.githubAccessToken,
+    tokenExpiresAt: creds.expiresAtMs,
+    baseUrl: creds.apiBaseUrl,
+    userName,
+  });
+}
+
+async function getValidCopilotToken(): Promise<string> {
+  const account = getCopilotAccount();
+  if (!account?.accessToken || !account.refreshToken) {
+    throw new Error('Not logged in to GitHub Copilot — click "Login" in the provider settings');
+  }
+  const expiresAt = account.tokenExpiresAt ?? 0;
+  if (Date.now() < expiresAt - 60_000) return account.accessToken;
+  const refreshed = await exchangeForCopilotToken(account.refreshToken);
+  await persistCopilot(refreshed, account.userName);
+  return refreshed.copilotToken;
+}
+
+// ── Models ─────────────────────────────────────────────────────────
+
+// Picker filter: keep only models powerful enough to drive the cone.
+//
+// Mirrors `isBedrockCampCompatible` in spirit — the cone needs strong
+// instruction-following, robust tool use, and resistance to prompt
+// injection. Mini/flash/haiku/nano variants reliably break the agent loop
+// (truncated tool calls, missed instructions, hallucinated args) even
+// when they're listed in GitHub Copilot's /models response.
+//
+// Excluded patterns (matched against both id and human-readable name,
+// after lowercasing + replacing separators with `-`):
+//   - `mini`        (gpt-4o-mini, gpt-5-mini, …)
+//   - `nano`        (any future *-nano tier)
+//   - `flash`       (gemini-*-flash)
+//   - `haiku`       (claude-haiku-*)
+//   - `lite`        (any future *-lite tier)
+//   - `embedding`   (text-embedding-*, not chat at all)
+//
+// Lowering this bar means the cone silently degrades; users who really
+// want a small model can still target it from feed_scoop or the agent
+// shell, where the failure mode is contained to a single sub-scoop.
+const COPILOT_CONE_EXCLUDE_PATTERNS = ['mini', 'nano', 'flash', 'haiku', 'lite', 'embedding'];
+
+export function isCopilotConeCompatible(model: { id: string; name?: string }): boolean {
+  const candidates = [model.id, model.name ?? ''].flatMap((v) => {
+    const lower = v.toLowerCase();
+    return [lower, lower.replace(/[\s_.:]+/g, '-')];
+  });
+  return !COPILOT_CONE_EXCLUDE_PATTERNS.some((needle) =>
+    candidates.some((s) => s.includes(needle))
+  );
+}
+
+function buildCopilotModelList(): Array<{ id: string; name: string } & ModelMetadata> {
+  const account = getCopilotAccount();
+  if (!account?.accessToken) return [];
+
+  // Prefer the live /models cache (refreshed on login + silent renew).
+  // Fall back to pi-mono's static catalog only when we have no cache yet
+  // — that keeps the picker non-empty on first paint after login when
+  // refreshCopilotCatalogAndPolicies is still in flight.
+  const cache = loadCachedCopilotCatalog();
+  if (cache.length > 0) {
+    return cache
+      .filter((m) => !m.policyState.startsWith('unavailable:'))
+      .filter((m) => isCopilotConeCompatible(m))
+      .map((m) => ({
+        id: m.id,
+        name: m.name,
+        api: m.api === 'anthropic-messages' ? ('anthropic' as const) : ('openai' as const),
+        context_window: m.contextWindow,
+        max_tokens: m.maxTokens,
+        reasoning: m.supportsReasoning,
+        input: m.supportsVision ? (['text', 'image'] as const) : (['text'] as const),
+      }));
+  }
+  let piModels: ReturnType<typeof getModels<'github-copilot'>>;
+  try {
+    piModels = getModels('github-copilot');
+  } catch {
+    return [];
+  }
+  return piModels
+    .filter((m) => isCopilotConeCompatible({ id: m.id, name: m.name }))
+    .map((m) => ({
+      id: m.id,
+      name: m.name ?? m.id,
+      api: m.api === 'anthropic-messages' ? ('anthropic' as const) : ('openai' as const),
+      context_window: m.contextWindow,
+      max_tokens: m.maxTokens,
+      reasoning: m.reasoning,
+      input: m.input,
+    }));
+}
+
+// ── Stream wrappers ────────────────────────────────────────────────
+
+function makeErrorOutput(model: Model<Api>, error: unknown) {
+  return {
+    type: 'error' as const,
+    reason: 'error' as const,
+    error: {
+      role: 'assistant' as const,
+      content: [],
+      api: model.api,
+      provider: PROVIDER_ID,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: 'error' as const,
+      errorMessage: error instanceof Error ? error.message : String(error),
+      timestamp: Date.now(),
+    },
+  };
+}
+
+/** Pi-mono-style headers VS Code Copilot Chat sends on every API call. */
+const COPILOT_API_HEADERS = {
+  'User-Agent': 'GitHubCopilotChat/0.35.0',
+  'Editor-Version': 'vscode/1.107.0',
+  'Editor-Plugin-Version': 'copilot-chat/0.35.0',
+  'Copilot-Integration-Id': 'vscode-chat',
+} as const;
+
+interface ResolvedCopilotModel {
+  api: CopilotCatalogEntry['api'];
+  baseUrl: string;
+  headers: Record<string, string>;
+}
+
+/**
+ * Find the right downstream API + baseUrl + headers for a Copilot model.
+ *
+ * Look-up order:
+ *   1) The live `/models` cache (authoritative — reflects what GitHub
+ *      actually serves right now, including models pi-mono doesn't know
+ *      about yet such as claude-opus-4.8).
+ *   2) Pi-mono's static catalog (legacy fallback for the brief window
+ *      before the first /models fetch completes after login).
+ *
+ * Returns null if neither source knows the model — caller will surface
+ * an error to the user explaining the picker is out of date.
+ */
+function resolveCopilotModel(modelId: string): ResolvedCopilotModel | null {
+  const account = getCopilotAccount();
+  const baseUrl = account?.baseUrl ?? 'https://api.individual.githubcopilot.com';
+
+  const cached = findCachedCopilotModel(modelId);
+  if (cached) {
+    return { api: cached.api, baseUrl, headers: { ...COPILOT_API_HEADERS } };
+  }
+  try {
+    const pi = getModel('github-copilot' as never, modelId as never) as unknown as Model<Api>;
+    return {
+      api: pi.api as CopilotCatalogEntry['api'],
+      baseUrl: account?.baseUrl ?? pi.baseUrl,
+      headers: { ...(pi.headers ?? {}), ...COPILOT_API_HEADERS },
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mark a model as unavailable on this account so the picker can hide it on
+ * the next render. Keyed by model id; the next catalog refresh wipes the
+ * flag, so users get a chance to retry after upgrading their plan.
+ */
+function markCopilotModelUnavailable(modelId: string, reason: string): void {
+  const cache = loadCachedCopilotCatalog();
+  const idx = cache.findIndex((m) => m.id === modelId);
+  if (idx < 0) return;
+  cache[idx] = { ...cache[idx], policyState: `unavailable:${reason}` };
+  storeCachedCopilotCatalog(cache);
+}
+
+/**
+ * Translate GitHub's terse `model_not_supported` error into something
+ * actionable. The same error code covers two very different cases:
+ *   1) The user's Copilot plan tier does not include the model (Free tier
+ *      can't use Opus, etc.) — even after a successful policy POST.
+ *   2) The model id is genuinely unknown to the backend.
+ *
+ * We can't tell which from the response alone, but mentioning the plan
+ * possibility gives the user a useful next step.
+ */
+function explainModelRejection(modelId: string, raw: string): string {
+  return (
+    `GitHub Copilot rejected "${modelId}" with model_not_supported. ` +
+    `This usually means the model isn't included in your Copilot plan ` +
+    `(Opus and other premium models require Copilot Pro / Pro+ / Business / Enterprise). ` +
+    `Try Claude Sonnet 4.6 or another model that appears in the picker after a fresh login. ` +
+    `Original error: ${raw}`
+  );
+}
+
+/**
+ * Read the human-readable message off a streaming `error` event. Pi-mono
+ * (and our own makeErrorOutput) put it on `event.error.errorMessage`, but
+ * some adapter paths surface it directly on `event.errorMessage` instead —
+ * try both so we don't miss a 400 just because the shape varies.
+ */
+function extractStreamErrorMessage(event: unknown): string | null {
+  if (!event || typeof event !== 'object') return null;
+  const e = event as { type?: unknown; error?: unknown; errorMessage?: unknown };
+  if (e.type !== 'error') return null;
+  if (e.error && typeof e.error === 'object') {
+    const inner = (e.error as { errorMessage?: unknown }).errorMessage;
+    if (typeof inner === 'string') return inner;
+  }
+  return typeof e.errorMessage === 'string' ? e.errorMessage : null;
+}
+
+function createCopilotStreamWrapper(simple: boolean) {
+  return (model: Model<Api>, context: Context, options: Record<string, unknown> = {}) => {
+    const stream = createAssistantMessageEventStream();
+    void (async () => {
+      try {
+        const apiKey = await getValidCopilotToken();
+        const resolved = resolveCopilotModel(model.id);
+        if (!resolved) {
+          throw new Error(
+            `GitHub Copilot does not recognize "${model.id}" — open the picker (the model list refreshes on login) and pick a current model.`
+          );
+        }
+        const inner: Model<Api> = {
+          ...model,
+          api: resolved.api as Api,
+          baseUrl: resolved.baseUrl,
+          headers: resolved.headers,
+          provider: 'github-copilot',
+        } as Model<Api>;
+
+        const opts = { ...options, apiKey };
+        let upstream: AsyncIterable<unknown>;
+        if (resolved.api === 'anthropic-messages') {
+          const fn = simple ? streamSimpleAnthropic : streamAnthropic;
+          upstream = fn(inner as never, context, opts as never) as AsyncIterable<unknown>;
+        } else if (resolved.api === 'openai-responses') {
+          const fn = simple ? streamSimpleOpenAIResponses : streamOpenAIResponses;
+          upstream = fn(inner as never, context, opts as never) as AsyncIterable<unknown>;
+        } else {
+          const fn = simple ? streamSimpleOpenAICompletions : streamOpenAICompletions;
+          upstream = fn(inner as never, context, opts as never) as AsyncIterable<unknown>;
+        }
+        for await (const event of upstream) {
+          // Pi-mono surfaces HTTP errors as in-stream `error` events rather
+          // than thrown exceptions, so the outer catch never sees them.
+          // Inspect each event and rewrite the misleading
+          // `model_not_supported` 400 into a plan-aware explanation; also
+          // mark the model unavailable so the picker hides it next render.
+          const errMsg = extractStreamErrorMessage(event);
+          if (errMsg && /model_not_supported/i.test(errMsg)) {
+            markCopilotModelUnavailable(model.id, 'model_not_supported');
+            const friendly = explainModelRejection(model.id, errMsg);
+            console.error('[github-copilot] Plan-gated model rejection:', friendly);
+            stream.push(makeErrorOutput(model, new Error(friendly)) as never);
+            stream.end();
+            return;
+          }
+          stream.push(event as never);
+        }
+        stream.end();
+      } catch (error) {
+        const raw = error instanceof Error ? error.message : String(error);
+        let surfaced: unknown = error;
+        // Belt-and-suspenders: the same rewrite for thrown errors, in case
+        // a future pi-mono adapter throws instead of emitting an error event.
+        if (/model_not_supported/i.test(raw)) {
+          markCopilotModelUnavailable(model.id, 'model_not_supported');
+          surfaced = new Error(explainModelRejection(model.id, raw));
+        }
+        console.error(
+          '[github-copilot] Stream error:',
+          surfaced instanceof Error ? surfaced.message : String(surfaced)
+        );
+        stream.push(makeErrorOutput(model, surfaced) as never);
+        stream.end();
+      }
+    })();
+    return stream;
+  };
+}
+
+const streamCopilot = createCopilotStreamWrapper(false);
+const streamSimpleCopilot = createCopilotStreamWrapper(true);
+
+// ── Default device-code prompter ───────────────────────────────────
+
+/**
+ * Fallback {@link DeviceCodePrompter} used when the caller (settings dialog,
+ * welcome sprinkle, …) does not provide its own UI surface.
+ *
+ * Renders a small floating overlay with the user code + copy / continue /
+ * cancel buttons, auto-copies the code to the clipboard, and resolves only
+ * after the user explicitly continues or cancels — so the auth tab is never
+ * opened behind the user's back.
+ *
+ * In contexts without a `document` (e.g. the kernel worker running
+ * `oauth-token github-copilot`), this logs the code to the dev console and
+ * resolves immediately with `'continue'` — that path has no UI to render to,
+ * and the existing CLI surface already prints stdout the user can read.
+ */
+const defaultDeviceCodePrompter: DeviceCodePrompter = ({ userCode, verificationUrl }) => {
+  if (typeof document === 'undefined') {
+    console.info(
+      `[github-copilot] Device verification code: ${userCode} — open ${verificationUrl} in a browser to authorize.`
+    );
+    return Promise.resolve('continue');
+  }
+
+  return new Promise((resolve) => {
+    const wrap = document.createElement('div');
+    wrap.setAttribute('data-slicc-overlay', 'github-copilot-device');
+    wrap.style.cssText = [
+      'position:fixed',
+      'top:24px',
+      'right:24px',
+      'z-index:2147483647',
+      'background:#0d1117',
+      'color:#e6edf3',
+      'border:1px solid #30363d',
+      'border-radius:10px',
+      'padding:16px 18px',
+      'box-shadow:0 8px 32px rgba(0,0,0,0.45)',
+      'font:13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      'min-width:260px',
+      'max-width:340px',
+    ].join(';');
+
+    const title = document.createElement('div');
+    title.textContent = 'GitHub Copilot — verification code';
+    title.style.cssText = 'font-weight:600;margin-bottom:8px;color:#7ee787';
+
+    const codeBox = document.createElement('div');
+    codeBox.textContent = userCode;
+    codeBox.style.cssText = [
+      'font:600 22px ui-monospace, SFMono-Regular, Menlo, monospace',
+      'letter-spacing:2px',
+      'background:#161b22',
+      'border:1px solid #30363d',
+      'border-radius:6px',
+      'padding:10px 12px',
+      'text-align:center',
+      'margin-bottom:10px',
+      'user-select:all',
+      'cursor:text',
+    ].join(';');
+
+    const hint = document.createElement('div');
+    hint.style.cssText = 'color:#8b949e;font-size:12px;line-height:1.5';
+    hint.textContent =
+      'Copy the code, then click Continue to open the GitHub authorization page in a new tab.';
+
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;gap:8px;margin-top:12px;justify-content:flex-end';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.style.cssText = [
+      'background:transparent',
+      'color:#e6edf3',
+      'border:1px solid #30363d',
+      'border-radius:6px',
+      'padding:6px 12px',
+      'font:600 12px inherit',
+      'cursor:pointer',
+    ].join(';');
+
+    const continueBtn = document.createElement('button');
+    continueBtn.type = 'button';
+    continueBtn.textContent = 'Copy & Continue';
+    continueBtn.style.cssText = [
+      'background:#238636',
+      'color:#fff',
+      'border:0',
+      'border-radius:6px',
+      'padding:6px 12px',
+      'font:600 12px inherit',
+      'cursor:pointer',
+    ].join(';');
+
+    const cleanup = () => {
+      try {
+        wrap.remove();
+      } catch {
+        /* already removed */
+      }
+    };
+
+    cancelBtn.addEventListener('click', () => {
+      cleanup();
+      resolve('cancel');
+    });
+    continueBtn.addEventListener('click', () => {
+      void (async () => {
+        try {
+          const { copyTextToClipboard } = await import('../src/ui/clipboard.js');
+          await copyTextToClipboard(userCode);
+        } catch {
+          /* user can still copy manually */
+        }
+        cleanup();
+        resolve('continue');
+      })();
+    });
+
+    row.appendChild(cancelBtn);
+    row.appendChild(continueBtn);
+
+    wrap.appendChild(title);
+    wrap.appendChild(codeBox);
+    wrap.appendChild(hint);
+    wrap.appendChild(row);
+    document.body.appendChild(wrap);
+  });
+};
+
+// ── Provider config ────────────────────────────────────────────────
+
+export const config: ProviderConfig = {
+  id: PROVIDER_ID,
+  name: 'GitHub Copilot',
+  description:
+    'Use your GitHub Copilot subscription to access Claude, GPT-5, Codex, Gemini, and Grok models. Sign in with the GitHub device-code flow.',
+  requiresApiKey: false,
+  requiresBaseUrl: false,
+  isOAuth: true,
+  defaultModelId: 'claude-sonnet-4.6',
+  oauthTokenDomains: [
+    '*.githubcopilot.com',
+    'api.individual.githubcopilot.com',
+    'api.business.githubcopilot.com',
+    'api.enterprise.githubcopilot.com',
+  ],
+
+  getModelIds: buildCopilotModelList,
+
+  onOAuthLoginIntercepted: async (
+    launcher: InterceptingOAuthLauncher,
+    onSuccess: () => void,
+    options?: OAuthLoginOptions
+  ) => {
+    // Step 1: ask GitHub for a fresh device code.
+    const device = await startDeviceFlow();
+
+    const verificationUrl = new URL(device.verification_uri);
+    verificationUrl.searchParams.set('user_code', device.user_code);
+
+    // Step 2: show the user the verification code via whatever UI surface
+    // the caller provided (settings dialog, sprinkle, …), or our default
+    // overlay. We do NOT open the auth tab until the user explicitly
+    // continues — they need to see and copy the code first so they can
+    // confirm it matches what GitHub shows on the authorize screen.
+    const prompter = options?.presentDeviceCode ?? defaultDeviceCodePrompter;
+    const decision = await prompter({
+      userCode: device.user_code,
+      verificationUrl: verificationUrl.toString(),
+      expiresInSeconds: device.expires_in,
+    });
+    if (decision === 'cancel') {
+      throw new Error('GitHub Copilot login cancelled');
+    }
+
+    // Step 3 + 4 run in parallel, AFTER the user confirmed:
+    //   - the controlled-browser tab opens to the pre-filled verification URL
+    //     and self-closes when the post-authorize success page loads;
+    //   - we poll the access-token endpoint until GitHub issues a token.
+    //
+    // The launcher's promise is allowed to settle independently (success page
+    // capture OR timeout); the polling promise is the source of truth for
+    // whether we actually got a token.
+    const pollAbort = new AbortController();
+    const tabPromise = launcher({
+      authorizeUrl: verificationUrl.toString(),
+      redirectUriPattern: DEVICE_SUCCESS_PATTERN,
+      onCapture: 'close',
+      timeoutMs: device.expires_in * 1000,
+    }).catch((err) => {
+      console.warn(
+        '[github-copilot] Launcher failed:',
+        err instanceof Error ? err.message : String(err)
+      );
+      return null;
+    });
+
+    let githubAccessToken: string;
+    try {
+      githubAccessToken = await pollForGitHubAccessToken(device, pollAbort.signal);
+    } catch (err) {
+      pollAbort.abort();
+      await tabPromise;
+      throw err;
+    }
+    // Let the launcher resolve/cleanup naturally so the tab gets closed.
+    await tabPromise;
+
+    // Step 5: trade the GitHub token for a short-lived Copilot session token.
+    const copilot = await exchangeForCopilotToken(githubAccessToken);
+    // Try to fetch a display name so the picker shows "logged in as <name>".
+    let userName: string | undefined;
+    try {
+      const userRes = await fetch('https://api.github.com/user', {
+        headers: { Authorization: `Bearer ${githubAccessToken}`, Accept: 'application/json' },
+      });
+      if (userRes.ok) {
+        const u = (await userRes.json()) as { name?: string; login?: string };
+        userName = u.name || u.login;
+      }
+    } catch {
+      /* best-effort */
+    }
+    await persistCopilot(copilot, userName);
+    // Discover the live model catalog and accept per-model usage policies
+    // GitHub gates premium models on (Claude, GPT-5, Codex, Gemini, Grok).
+    // The result is cached for buildCopilotModelList + resolveCopilotModel.
+    // Best-effort — never block login on it.
+    await refreshCopilotCatalogAndPolicies(copilot);
+    onSuccess();
+  },
+
+  onOAuthLogout: async () => {
+    await saveOAuthAccount({ providerId: PROVIDER_ID, accessToken: '' });
+  },
+
+  onSilentRenew: async () => {
+    const account = getCopilotAccount();
+    if (!account?.refreshToken) return null;
+    try {
+      const refreshed = await exchangeForCopilotToken(account.refreshToken);
+      await persistCopilot(refreshed, account.userName);
+      // Refresh catalog + re-accept policies on every silent renew so the
+      // picker reflects newly-released models (e.g. claude-opus-4.8) without
+      // forcing the user to log out and back in.
+      await refreshCopilotCatalogAndPolicies(refreshed);
+      return refreshed.copilotToken;
+    } catch (err) {
+      console.warn(
+        '[github-copilot] Silent renew failed:',
+        err instanceof Error ? err.message : String(err)
+      );
+      return null;
+    }
+  },
+};
+
+// ── Registration ───────────────────────────────────────────────────
+
+export function register(): void {
+  // Slicc's getModelIds branch in provider-settings.ts maps each model's
+  // metadata `api` field to a synthetic api name `${providerId}-${api}`,
+  // so we register stream functions under those exact names. Both delegate
+  // to the same dispatcher — it picks anthropic / responses / completions
+  // based on the underlying pi-mono model's real api.
+  registerApiProvider({
+    api: 'github-copilot-anthropic' as Api,
+    stream: streamCopilot as never,
+    streamSimple: streamSimpleCopilot as never,
+  });
+  registerApiProvider({
+    api: 'github-copilot-openai' as Api,
+    stream: streamCopilot as never,
+    streamSimple: streamSimpleCopilot as never,
+  });
+}

--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -1,40 +1,29 @@
 /**
- * GitHub Provider — OAuth login + GitHub Models LLM access.
+ * GitHub Provider — pure OAuth + git authentication.
+ *
+ * Scope:
+ *   This provider exists ONLY to give slicc a GitHub identity for
+ *   git push/pull/clone, the `oauth-token github` shell command, and
+ *   masking of `*.github.com` traffic through the fetch-proxy. It
+ *   intentionally exposes NO LLM models — slicc's previous attempt to
+ *   reach Copilot through this token never worked because GitHub's
+ *   `copilot_internal/v2/token` endpoint is restricted to specific
+ *   OAuth client IDs (notably the VS Code Copilot Chat client), and
+ *   slicc's OAuth App is not on that allowlist. The Copilot LLM
+ *   surface lives in the sibling `github-copilot.ts` provider, which
+ *   uses GitHub's device-code flow with the VS Code client ID.
  *
  * Authentication:
- *   Authorization code grant via the generic OAuth token broker.
- *   CLI mode:       popup → /auth/callback relay → code extracted → worker exchanges
- *   Extension mode: chrome.identity.launchWebAuthFlow → code extracted → worker exchanges
- *
- * LLM access:
- *   GitHub Models (models.inference.ai.azure.com) is an OpenAI-compatible API
- *   authenticated with the GitHub OAuth token. Routes through pi-ai's
- *   streamOpenAICompletions.
+ *   Authorization-code grant via the generic OAuth token broker.
+ *   CLI mode:       popup → /auth/callback relay → code → worker exchange
+ *   Extension mode: chrome.identity.launchWebAuthFlow → code → worker exchange
  *
  * Git integration:
- *   The OAuth token is written to /workspace/.git/github-token in the global VFS
- *   so isomorphic-git picks it up for push/pull/clone operations.
+ *   The OAuth token is written to /workspace/.git/github-token in the global
+ *   VFS so isomorphic-git picks it up for push / pull / clone.
  */
 
-import type {
-  ProviderConfig,
-  OAuthLauncher,
-  OAuthLoginOptions,
-  ModelMetadata,
-} from '../src/providers/types.js';
-import {
-  registerApiProvider,
-  streamOpenAICompletions,
-  streamSimpleOpenAICompletions,
-  createAssistantMessageEventStream,
-} from '@earendil-works/pi-ai';
-import type {
-  Api,
-  Model,
-  Context,
-  SimpleStreamOptions,
-  OpenAICompletionsOptions,
-} from '@earendil-works/pi-ai';
+import type { ProviderConfig, OAuthLauncher, OAuthLoginOptions } from '../src/providers/types.js';
 import { saveOAuthAccount, getAccounts, getOAuthAccountInfo } from '../src/ui/provider-settings.js';
 import {
   exchangeOAuthCode,
@@ -285,162 +274,19 @@ async function getValidAccessToken(): Promise<string> {
   return account.accessToken;
 }
 
-// ── GitHub Models ──────────────────────────────────────────────────
-
-// New unified GitHub Models endpoint (replaces the old Azure inference endpoint).
-// Model IDs use vendor-prefixed format: "openai/gpt-4.1"
-const GITHUB_MODELS_BASE = 'https://models.github.ai/inference';
-
-/**
- * Models available via GitHub Models free tier (no Copilot subscription required).
- * gpt-4o / gpt-4o-mini / o3-mini are deprecated; o4-mini requires a paid Copilot plan.
- * Model IDs use the vendor-prefixed format required by the models.github.ai endpoint.
- */
-const GITHUB_MODELS: Array<{ id: string; name: string } & ModelMetadata> = [
-  {
-    id: 'openai/gpt-4.1',
-    name: 'GPT-4.1',
-    api: 'openai',
-    context_window: 1047576,
-    max_tokens: 32768,
-    reasoning: false,
-    input: ['text', 'image'],
-  },
-  {
-    id: 'openai/gpt-4.1-mini',
-    name: 'GPT-4.1 mini',
-    api: 'openai',
-    context_window: 1047576,
-    max_tokens: 32768,
-    reasoning: false,
-    input: ['text', 'image'],
-  },
-];
-
-// ── Stream functions ───────────────────────────────────────────────
-
-function makeErrorOutput(model: Model<Api>, error: unknown) {
-  return {
-    type: 'error' as const,
-    reason: 'error' as const,
-    error: {
-      role: 'assistant' as const,
-      content: [],
-      api: 'github-openai' as Api,
-      provider: 'github',
-      model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: 'error' as const,
-      errorMessage: error instanceof Error ? error.message : String(error),
-      timestamp: Date.now(),
-    },
-  };
-}
-
-const streamGitHub = (
-  model: Model<Api>,
-  context: Context,
-  options: OpenAICompletionsOptions = {}
-) => {
-  const stream = createAssistantMessageEventStream();
-  (async () => {
-    try {
-      const accessToken = await getValidAccessToken();
-      const proxyModel = {
-        ...model,
-        baseUrl: GITHUB_MODELS_BASE,
-        api: 'openai-completions' as Api,
-        compat: {
-          ...(model as any).compat,
-          supportsStore: false,
-          supportsDeveloperRole: false,
-          // models.github.ai/inference does not support stream_options.include_usage
-          // (causes 500 after ~30s timeout) or max_completion_tokens (use max_tokens).
-          supportsUsageInStreaming: false,
-          maxTokensField: 'max_tokens',
-        },
-      };
-      const inner = streamOpenAICompletions(proxyModel as any, context, {
-        ...options,
-        apiKey: accessToken,
-      } as any);
-      for await (const event of inner) stream.push(event as any);
-      stream.end();
-    } catch (error) {
-      console.error(
-        '[github] Stream error:',
-        error instanceof Error ? error.message : String(error)
-      );
-      stream.push(makeErrorOutput(model, error) as any);
-      stream.end();
-    }
-  })();
-  return stream;
-};
-
-const streamSimpleGitHub = (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => {
-  const stream = createAssistantMessageEventStream();
-  (async () => {
-    try {
-      const accessToken = await getValidAccessToken();
-      const proxyModel = {
-        ...model,
-        baseUrl: GITHUB_MODELS_BASE,
-        api: 'openai-completions' as Api,
-        compat: {
-          ...(model as any).compat,
-          supportsStore: false,
-          supportsDeveloperRole: false,
-          // models.github.ai/inference does not support stream_options.include_usage
-          // (causes 500 after ~30s timeout) or max_completion_tokens (use max_tokens).
-          supportsUsageInStreaming: false,
-          maxTokensField: 'max_tokens',
-        },
-      };
-      const inner = streamSimpleOpenAICompletions(proxyModel as any, context, {
-        ...options,
-        apiKey: accessToken,
-      } as any);
-      for await (const event of inner) stream.push(event as any);
-      stream.end();
-    } catch (error) {
-      console.error(
-        '[github] Stream error:',
-        error instanceof Error ? error.message : String(error)
-      );
-      stream.push(makeErrorOutput(model, error) as any);
-      stream.end();
-    }
-  })();
-  return stream;
-};
-
-// ── Provider config ────────────────────────────────────────────────
-
 export const config: ProviderConfig = {
   id: 'github',
   name: 'GitHub',
-  description: 'GitHub Models + git authentication — login with your GitHub account',
+  description:
+    'Sign in with GitHub for git authentication (push/pull/clone) and the `oauth-token github` shell command. Does not expose LLM models — use the GitHub Copilot provider for those.',
   requiresApiKey: false,
   requiresBaseUrl: false,
   isOAuth: true,
-  defaultModelId: 'gpt-4.1', // substring-matched against openai/gpt-4.1
-  oauthTokenDomains: [
-    'github.com',
-    '*.github.com',
-    'api.github.com',
-    'raw.githubusercontent.com',
-    'models.github.ai',
-  ],
+  oauthTokenDomains: ['github.com', '*.github.com', 'api.github.com', 'raw.githubusercontent.com'],
 
-  getModelIds: () => GITHUB_MODELS,
+  // Pure git/auth provider — no LLM models exposed. Copilot lives in
+  // its own sibling provider (`github-copilot.ts`).
+  getModelIds: () => [],
 
   onOAuthLogin: async (
     launcher: OAuthLauncher,
@@ -564,19 +410,9 @@ export const config: ProviderConfig = {
     }
     // Clear git token from VFS
     await clearGitToken();
-    // Clear account
+    // Clear github account
     await saveOAuthAccount({ providerId: 'github', accessToken: '' });
   },
 };
-
-// ── Registration ───────────────────────────────────────────────────
-
-export function register(): void {
-  registerApiProvider({
-    api: 'github-openai' as Api,
-    stream: streamGitHub as any,
-    streamSimple: streamSimpleGitHub as any,
-  });
-}
 
 export { getValidAccessToken };

--- a/packages/webapp/src/providers/device-code-bridge.ts
+++ b/packages/webapp/src/providers/device-code-bridge.ts
@@ -1,0 +1,81 @@
+/**
+ * Bridge that lets the welcome-flow sprinkle ("connect-llm") render the
+ * GitHub Copilot device-code prompt inline, instead of falling back to
+ * the provider's default floating overlay.
+ *
+ * Wire-up:
+ *   1. `main.ts` calls `createSprinkleDeviceCodePrompter({ broadcastToDip })`
+ *      and passes the returned {@link DeviceCodePrompter} into
+ *      `onOAuthLoginIntercepted`'s options. The provider awaits it before
+ *      opening any auth tab.
+ *   2. The prompter broadcasts a `slicc-device-code` message into the
+ *      sprinkle iframe and stores its resolver in a module-local slot.
+ *   3. The sprinkle renders code + Cancel / Copy & Continue buttons and
+ *      emits a `device-code-decision` lick when the user picks one.
+ *   4. The welcome-lick interceptor in `main.ts` intercepts the lick and
+ *      calls {@link resolveDeviceCodeDecision}, which fires the stored
+ *      resolver.
+ *
+ * Only one device-code flow can be in flight per page; if a new
+ * prompter starts while a previous one is still pending, the previous
+ * one is cancelled defensively so the resolver chain stays sane.
+ */
+
+import type { DeviceCodePrompter, DeviceCodePromptInput } from './types.js';
+
+type Decision = 'continue' | 'cancel';
+
+/**
+ * Shape of host-side dip broadcasters. Matches `broadcastToDips` in
+ * `ui/dip.ts` — payload MUST carry a `type` field starting with `slicc-`
+ * (the runtime in dip.ts asserts this).
+ */
+export type DipBroadcaster = (payload: { type: string; [k: string]: unknown }) => void;
+
+let pendingResolver: ((decision: Decision) => void) | null = null;
+
+/**
+ * Build a {@link DeviceCodePrompter} that drives the welcome sprinkle.
+ *
+ * @param opts.broadcastToDip - The host's sprinkle-bridge broadcaster.
+ *                              Same signature as `broadcastToDips` in
+ *                              `main.ts`; called with a JSON-serializable
+ *                              payload that the sprinkle's
+ *                              `slicc-message` listener receives.
+ */
+export function createSprinkleDeviceCodePrompter(opts: {
+  broadcastToDip: DipBroadcaster;
+}): DeviceCodePrompter {
+  return (input: DeviceCodePromptInput) =>
+    new Promise<Decision>((resolve) => {
+      if (pendingResolver) {
+        const stale = pendingResolver;
+        pendingResolver = null;
+        stale('cancel');
+      }
+      pendingResolver = resolve;
+      opts.broadcastToDip({
+        type: 'slicc-device-code',
+        userCode: input.userCode,
+        verificationUrl: input.verificationUrl,
+        expiresInSeconds: input.expiresInSeconds,
+      });
+    });
+}
+
+/**
+ * Resolve the pending device-code prompter, if any. Returns true when a
+ * prompter was waiting (so the caller can mark the lick as intercepted).
+ */
+export function resolveDeviceCodeDecision(decision: Decision): boolean {
+  if (!pendingResolver) return false;
+  const resolver = pendingResolver;
+  pendingResolver = null;
+  resolver(decision);
+  return true;
+}
+
+/** Whether a sprinkle prompter is currently awaiting a decision. */
+export function isDeviceCodeFlowPending(): boolean {
+  return pendingResolver !== null;
+}

--- a/packages/webapp/src/providers/types.ts
+++ b/packages/webapp/src/providers/types.ts
@@ -71,6 +71,39 @@ export interface InterceptOAuthConfig {
  */
 export type InterceptingOAuthLauncher = (config: InterceptOAuthConfig) => Promise<string | null>;
 
+/**
+ * Input handed to a {@link DeviceCodePrompter}. Surfaces the user-friendly
+ * code (the part the user types/pastes on the verification page) plus the
+ * full verification URL with `?user_code=` pre-filled, so the prompter can
+ * offer both a copy action and an "open authorization tab" action.
+ */
+export interface DeviceCodePromptInput {
+  /** Human-readable code GitHub displays, e.g. `XXXX-XXXX`. */
+  userCode: string;
+  /** Verification URL with `user_code` already in the query string. */
+  verificationUrl: string;
+  /** Device-code lifetime as reported by the OAuth server, in seconds. */
+  expiresInSeconds: number;
+}
+
+/**
+ * Caller-supplied UI hook that displays the device-flow user code and waits
+ * for explicit user confirmation before the provider opens any auth tab.
+ *
+ * Why a caller-supplied hook: the device code MUST be visible to the user
+ * (it's their only way to verify the request is genuine), but where to render
+ * it depends on the surrounding UI surface — the settings dialog wants to
+ * inject into its own DOM, the welcome sprinkle would render into its own
+ * iframe, and the `oauth-token` shell command can only print to stdout.
+ *
+ * The prompter is responsible for its own DOM/teardown. It should resolve
+ * with `'continue'` when the user has acknowledged the code (typically via
+ * a "Copy & Continue" button — auto-copying to clipboard is a nice touch)
+ * and `'cancel'` if the user backed out before authorizing. Providers may
+ * fall back to a default in-page overlay when no prompter is supplied.
+ */
+export type DeviceCodePrompter = (input: DeviceCodePromptInput) => Promise<'continue' | 'cancel'>;
+
 /** Options passed to onOAuthLogin from the caller (e.g. oauth-token command). */
 export interface OAuthLoginOptions {
   /**
@@ -80,6 +113,14 @@ export interface OAuthLoginOptions {
    * space-separated). The provider is responsible for any normalization.
    */
   scopes?: string;
+  /**
+   * UI hook for device-code OAuth flows. When present, the provider MUST
+   * await its resolution before navigating any auth tab, so the user
+   * always sees (and can copy) the verification code first. See
+   * {@link DeviceCodePrompter}. Providers ignore this option for
+   * non-device-flow logins.
+   */
+  presentDeviceCode?: DeviceCodePrompter;
 }
 
 /**
@@ -158,6 +199,16 @@ export interface ProviderConfig {
   requiresBaseUrl: boolean;
   baseUrlPlaceholder?: string;
   baseUrlDescription?: string;
+  /**
+   * Internal-only providers hidden from the picker / settings dialog. The
+   * config still participates in the registry (so OAuth token storage,
+   * fetch-proxy unmasking, and any associated stream functions still work),
+   * but the provider does not appear as a user-selectable account.
+   *
+   * Use for storage-slot providers that piggy-back on another provider's
+   * login flow (e.g. the Copilot token slot bootstrapped by the GitHub login).
+   */
+  hidden?: boolean;
   /** OAuth providers show a login button instead of an API key input. */
   isOAuth?: boolean;
   /**

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1004,9 +1004,14 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
     setSelectedModelId: setSelectedModelIdExt,
     getAccounts: getAccountsExt,
     isModelHiddenFromPicker: isModelHiddenFromPickerExt,
+    providerOffersLlmModels: providerOffersLlmModelsExt,
   } = await import('./provider-settings.js');
+  const {
+    createSprinkleDeviceCodePrompter: createSprinkleDeviceCodePrompterExt,
+    resolveDeviceCodeDecision: resolveDeviceCodeDecisionExt,
+  } = await import('../providers/device-code-bridge.js');
   const buildExtProviderCatalogue = () => {
-    const ids = getAvailableProvidersExt();
+    const ids = getAvailableProvidersExt().filter((id) => providerOffersLlmModelsExt(id));
     const providers = ids
       .map((id) => {
         const cfg = getProviderConfigExt(id);
@@ -1097,7 +1102,11 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
                   'Intercepted OAuth requires the controlled-browser transport — open SLICC in standalone or extension mode.',
               };
             }
-            await cfg.onOAuthLoginIntercepted(launcher, () => undefined);
+            await cfg.onOAuthLoginIntercepted(launcher, () => undefined, {
+              presentDeviceCode: createSprinkleDeviceCodePrompterExt({
+                broadcastToDip: broadcastToDipsExt,
+              }),
+            });
           } else if (cfg.onOAuthLogin) {
             const { createOAuthLauncher } = await import('../providers/oauth-service.js');
             const launcher = createOAuthLauncher();
@@ -1161,12 +1170,22 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
       welcomeAction === 'connect-ready' ||
       welcomeAction === 'connect-attempt' ||
       welcomeAction === 'oauth-attempt' ||
+      welcomeAction === 'device-code-decision' ||
       welcomeAction === 'shortcut-migrate';
     if (!isWelcomeFlowAction) return false;
 
     const body = event.body as Record<string, unknown> | null;
     const action = welcomeAction;
 
+    if (action === 'device-code-decision') {
+      // Sprinkle relayed the user's Cancel / Copy & Continue click —
+      // resolve the pending DeviceCodePrompter so the provider's
+      // device-flow login proceeds or aborts. Always intercept the
+      // lick so it never reaches the cone.
+      const decision = (body?.data as { decision?: unknown } | undefined)?.decision;
+      resolveDeviceCodeDecisionExt(decision === 'cancel' ? 'cancel' : 'continue');
+      return true;
+    }
     if (action === 'first-run') {
       getExtOnboardingOrchestrator().handleFirstRun();
       return true;
@@ -2223,7 +2242,10 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
     getProviderModels,
     isModelHiddenFromPicker,
     setSelectedModelId,
+    providerOffersLlmModels,
   } = await import('./provider-settings.js');
+  const { createSprinkleDeviceCodePrompter, resolveDeviceCodeDecision } =
+    await import('../providers/device-code-bridge.js');
   let workerOnboardingOrchestrator: InstanceType<typeof OnboardingOrchestratorWorker> | null = null;
   // `sprinkleManager` is assigned just below; closures reference the
   // binding, not the value, so the orchestrator's lazy construction
@@ -2277,7 +2299,11 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
                   'Intercepted OAuth requires the controlled-browser transport — open SLICC in standalone or extension mode.',
               };
             }
-            await cfg.onOAuthLoginIntercepted(launcher, () => undefined);
+            await cfg.onOAuthLoginIntercepted(launcher, () => undefined, {
+              presentDeviceCode: createSprinkleDeviceCodePrompter({
+                broadcastToDip: (payload) => broadcastToDips(payload),
+              }),
+            });
           } else if (cfg.onOAuthLogin) {
             const { createOAuthLauncher } = await import('../providers/oauth-service.js');
             const launcher = createOAuthLauncher();
@@ -2322,12 +2348,21 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
       welcomeAction === 'connect-ready' ||
       welcomeAction === 'connect-attempt' ||
       welcomeAction === 'oauth-attempt' ||
+      welcomeAction === 'device-code-decision' ||
       welcomeAction === 'shortcut-migrate';
     if (!isWelcomeFlowAction) return false;
 
     const body = event.body as Record<string, unknown> | null;
     const action = welcomeAction;
 
+    if (action === 'device-code-decision') {
+      // See `mainExtension`'s mirror branch for the rationale — resolves
+      // the pending DeviceCodePrompter so the github-copilot device flow
+      // proceeds (Copy & Continue) or aborts (Cancel).
+      const decision = (body?.data as { decision?: unknown } | undefined)?.decision;
+      resolveDeviceCodeDecision(decision === 'cancel' ? 'cancel' : 'continue');
+      return true;
+    }
     if (action === 'first-run') {
       getOnboardingOrchestrator().handleFirstRun();
       return true;
@@ -3050,7 +3085,7 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
 
   // Worker-side provider catalogue (same shape as `buildExtProviderCatalogue`).
   function buildWorkerProviderCatalogue() {
-    const ids = getAvailableProviders();
+    const ids = getAvailableProviders().filter((id) => providerOffersLlmModels(id));
     const providers = ids
       .map((id) => {
         const cfg = getProviderConfig(id);

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -19,7 +19,8 @@ import {
   shouldIncludeProvider,
 } from '../providers/index.js';
 import type { ProviderConfig } from '../providers/index.js';
-import type { CompatOverrides } from '../providers/types.js';
+import type { CompatOverrides, DeviceCodePrompter } from '../providers/types.js';
+import { copyTextToClipboard } from './clipboard.js';
 import {
   isBedrockCampCompatible,
   bedrockCampRegionFromBaseUrl,
@@ -172,12 +173,52 @@ export const __test__ = { _resetLegacyCleanup };
 // Provider configs are now loaded dynamically from packages/webapp/src/providers/index.ts
 // (built-in providers in packages/webapp/src/providers/built-in/ + external providers in /packages/webapp/providers/)
 
-// Get all available providers — pi-ai providers (filtered by build config) + registered configs
+// Get all available providers — pi-ai providers (filtered by build config) + registered configs.
+// Hidden providers (config.hidden) are participants in the registry but never
+// surfaced to the user (see ProviderConfig.hidden — used by storage-slot
+// providers like the GitHub Copilot token cache).
 export function getAvailableProviders(): string[] {
   const piProviders = (getProviders() as string[]).filter(shouldIncludeProvider);
   const registeredIds = getRegisteredProviderIds(); // external + built-in extensions, already filtered
   const merged = new Set([...piProviders, ...registeredIds]);
-  return [...merged];
+  return [...merged].filter((id) => !getRegisteredProviderConfig(id)?.hidden);
+}
+
+/**
+ * Whether a provider exposes any LLM models the user could actually pick.
+ *
+ * Used to keep auth-only providers (e.g. plain `github`, which exists solely
+ * for git push/pull and the `oauth-token github` shell command) out of the
+ * "Add Account" picker. Login-gated LLM providers like `github-copilot`
+ * still pass because pi-ai's static registry advertises their catalog even
+ * before the user authenticates.
+ *
+ * Checked sources, in order:
+ *   1. `getProviderModels(id)` — covers providers that proxy another pi-ai
+ *      registry (bedrock-camp → amazon-bedrock) and providers whose
+ *      `getModelIds()` already resolves to a non-empty list.
+ *   2. Pi-ai's static `getModels(id)` — catches providers that advertise a
+ *      static catalog but resolve dynamic models only after login
+ *      (github-copilot pre-login).
+ *   3. The provider's `modelOverrides` declaration — explicit intent that
+ *      models will be offered, even if both look-ups above are empty in
+ *      the current state.
+ */
+export function providerOffersLlmModels(providerId: string): boolean {
+  try {
+    if (getProviderModels(providerId).length > 0) return true;
+  } catch {
+    /* fall through */
+  }
+  try {
+    const piModels = (getModels as (id: string) => unknown[])(providerId);
+    if (piModels.length > 0) return true;
+  } catch {
+    /* provider not registered with pi-ai */
+  }
+  const cfg = getRegisteredProviderConfig(providerId);
+  if (cfg?.modelOverrides && Object.keys(cfg.modelOverrides).length > 0) return true;
+  return false;
 }
 
 // Get provider config with fallback for unknown providers
@@ -431,9 +472,13 @@ export function getAllAvailableModels(): GroupedModels[] {
   const seen = new Map<string, GroupedModels>();
   for (const account of accounts) {
     if (seen.has(account.providerId)) continue;
+    const config = getProviderConfig(account.providerId);
+    // Hidden providers (e.g. internal Copilot token slot) participate in the
+    // registry for token storage but must not surface in the picker even when
+    // they have an active account.
+    if (config.hidden) continue;
     const models = pickerVisible(getProviderModels(account.providerId));
     if (models.length === 0) continue;
-    const config = getProviderConfig(account.providerId);
     const group: GroupedModels = {
       providerId: account.providerId,
       providerName: config.name,
@@ -1367,6 +1412,16 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
         providerSelect.disabled = true;
         providerSelect.style.opacity = '0.7';
       } else {
+        // Placeholder so nothing is silently pre-selected — users must
+        // explicitly pick a provider before any auth/key UI shows up.
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Select a provider…';
+        placeholder.disabled = true;
+        placeholder.selected = true;
+        placeholder.hidden = true;
+        providerSelect.appendChild(placeholder);
+
         const providers = getAvailableProviders();
         const existingProviders = new Set(getAccounts().map((a) => a.providerId));
         const sorted = [...providers].sort((a, b) => {
@@ -1376,6 +1431,10 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
         });
         for (const providerId of sorted) {
           if (existingProviders.has(providerId)) continue;
+          // Skip auth-only providers (no LLM models to expose) — they're
+          // useful as accounts the user might already have, but not as
+          // something to "add" from this dialog.
+          if (!providerOffersLlmModels(providerId)) continue;
           const config = getProviderConfig(providerId);
           const opt = document.createElement('option');
           opt.value = providerId;
@@ -1408,7 +1467,105 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
         'font-size: 12px; color: var(--s2-content-secondary); text-align: center;';
       oauthSection.appendChild(oauthStatus);
 
-      // OAuth login handler — calls the provider's onOAuthLogin callback with a generic launcher
+      // OAuth login handler — calls the provider's onOAuthLogin callback with a generic launcher.
+      // Device-flow providers (e.g. github-copilot) also receive a `presentDeviceCode` prompter
+      // that renders the verification code inline in this dialog instead of via a floating overlay.
+      const createDialogDeviceCodePrompter = (): DeviceCodePrompter => {
+        const host = oauthSection;
+        const status = oauthStatus;
+        const loginBtn = oauthLoginBtn;
+        return (input) =>
+          new Promise<'continue' | 'cancel'>((resolve) => {
+            // Hide the default login UI while the prompt is active so the
+            // dialog only shows the code + the continue/cancel pair. The
+            // original elements are restored on resolution.
+            const wasLoginHidden = loginBtn.style.display;
+            const wasStatusHidden = status.style.display;
+            loginBtn.style.display = 'none';
+            status.style.display = 'none';
+
+            const prompt = document.createElement('div');
+            prompt.setAttribute('data-slicc-device-code-prompt', '');
+            prompt.style.cssText = 'display:flex;flex-direction:column;gap:8px';
+
+            const label = document.createElement('div');
+            label.className = 'dialog__desc';
+            label.textContent = 'Verification code';
+            label.style.cssText = 'font-size: 11px; color: var(--s2-content-tertiary);';
+
+            const code = document.createElement('div');
+            code.textContent = input.userCode;
+            code.style.cssText = [
+              'font: 600 22px ui-monospace, SFMono-Regular, Menlo, monospace',
+              'letter-spacing: 2px',
+              'color: var(--s2-content-primary, #e6edf3)',
+              'background: var(--s2-bg-secondary, #161b22)',
+              'border: 1px solid var(--s2-border, #30363d)',
+              'border-radius: 6px',
+              'padding: 10px 12px',
+              'text-align: center',
+              'user-select: all',
+              'cursor: text',
+            ].join(';');
+
+            const hint = document.createElement('div');
+            hint.className = 'dialog__desc';
+            hint.style.cssText = 'font-size: 12px; color: var(--s2-content-secondary);';
+            hint.textContent =
+              'Click Copy & Continue — we will open the GitHub authorization page in a new tab. Paste this code there if it is not already filled in.';
+
+            const row = document.createElement('div');
+            row.style.cssText = 'display:flex;gap:8px;justify-content:flex-end;margin-top:4px';
+
+            const cancelBtn = document.createElement('button');
+            cancelBtn.type = 'button';
+            cancelBtn.className = 'dialog__btn';
+            cancelBtn.textContent = 'Cancel';
+
+            const continueBtn = document.createElement('button');
+            continueBtn.type = 'button';
+            continueBtn.className = 'dialog__btn dialog__btn--primary';
+            continueBtn.textContent = 'Copy & Continue';
+
+            const cleanup = () => {
+              try {
+                prompt.remove();
+              } catch {
+                /* already removed */
+              }
+              loginBtn.style.display = wasLoginHidden;
+              status.style.display = wasStatusHidden;
+            };
+
+            cancelBtn.addEventListener('click', () => {
+              cleanup();
+              resolve('cancel');
+            });
+            continueBtn.addEventListener('click', () => {
+              void (async () => {
+                try {
+                  await copyTextToClipboard(input.userCode);
+                } catch {
+                  /* user can still copy manually from the displayed code */
+                }
+                cleanup();
+                status.style.display = wasStatusHidden;
+                status.textContent = 'Waiting for you to authorize in the new tab…';
+                resolve('continue');
+              })();
+            });
+
+            row.appendChild(cancelBtn);
+            row.appendChild(continueBtn);
+
+            prompt.appendChild(label);
+            prompt.appendChild(code);
+            prompt.appendChild(hint);
+            prompt.appendChild(row);
+            host.appendChild(prompt);
+          });
+      };
+
       oauthLoginBtn.addEventListener('click', async () => {
         const pid = providerSelect.value;
         if (!pid) return;
@@ -1439,7 +1596,9 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
                 'No controlled-browser CDP transport available — open SLICC in standalone mode or the Chrome extension.'
               );
             }
-            await providerConfig.onOAuthLoginIntercepted(launcher, renderAccountsList);
+            await providerConfig.onOAuthLoginIntercepted(launcher, renderAccountsList, {
+              presentDeviceCode: createDialogDeviceCodePrompter(),
+            });
           } else if (providerConfig.onOAuthLogin) {
             const { createOAuthLauncher } = await import('../providers/oauth-service.js');
             const launcher = createOAuthLauncher();
@@ -1574,7 +1733,18 @@ export function showProviderSettings(options?: ShowProviderSettingsOptions): Pro
 
       function updateFormFields() {
         const pid = providerSelect.value;
-        if (!pid) return;
+        if (!pid) {
+          // Placeholder state — hide everything so the dialog only shows
+          // the dropdown until the user makes a choice.
+          providerDesc.textContent = '';
+          oauthSection.style.display = 'none';
+          apiKeySection.style.display = 'none';
+          baseUrlSection.style.display = 'none';
+          deploymentSection.style.display = 'none';
+          apiVersionSection.style.display = 'none';
+          saveBtn.style.display = 'none';
+          return;
+        }
         const providerConfig = getProviderConfig(pid);
 
         providerDesc.textContent = providerConfig.description;

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -133,6 +133,18 @@ const LEGACY_KEYS = [
   'bedrock_region',
 ] as const;
 
+// Provider ids that used to expose LLM models but no longer do — `selected-model`
+// entries pointing at any of these are stale after the upgrade and must be
+// cleared, otherwise `resolveCurrentModel()` falls through to its Anthropic
+// default while `getApiKey()` still returns the unrelated OAuth token (e.g.
+// GitHub PAT) and the next cone turn fails with an opaque auth error.
+//
+// We migrate eagerly on module load — `ensureModelSelected()` in layout.ts
+// also catches the broader "stored selection no longer resolves" case, but
+// it only runs on the page boot path; the worker context can `import` this
+// module first and call `resolveCurrentModel()` before layout has booted.
+const LEGACY_AUTH_ONLY_PROVIDERS = new Set(['github']);
+
 // Account entry in the slicc_accounts array
 export interface Account {
   providerId: string;
@@ -160,6 +172,33 @@ function cleanLegacyKeys(): void {
     } catch {
       /* noop */
     }
+  }
+  migrateLegacyAuthOnlySelection();
+}
+
+/**
+ * Clear `selected-model` when it points at a provider that used to expose
+ * LLM models but no longer does (currently: `github`, after the 3.13.0
+ * Copilot split). Idempotent; never throws.
+ *
+ * Exported only for tests — the production path runs this through
+ * `cleanLegacyKeys()` so the migration fires on the first call to
+ * `getAccounts()` in both the panel and worker contexts.
+ */
+export function migrateLegacyAuthOnlySelection(): void {
+  try {
+    const raw = localStorage.getItem(MODEL_KEY);
+    if (!raw) return;
+    const sep = raw.indexOf(':');
+    if (sep <= 0) return;
+    const provider = raw.slice(0, sep);
+    if (LEGACY_AUTH_ONLY_PROVIDERS.has(provider)) {
+      localStorage.removeItem(MODEL_KEY);
+    }
+  } catch {
+    /* localStorage may be unavailable in some contexts — leave the
+       selection alone; layout.ts:ensureModelSelected() will catch
+       the mismatch on the next boot. */
   }
 }
 

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -192,6 +192,7 @@ import {
   resolveModelById,
   saveOAuthAccount,
   getOAuthAccountInfo,
+  migrateLegacyAuthOnlySelection,
 } from '../../src/ui/provider-settings.js';
 import type { ProviderDefault } from '../../src/ui/provider-settings.js';
 
@@ -289,6 +290,51 @@ describe('selected model encodes provider', () => {
     storage.set('selected-model', 'anthropic:claude-sonnet-4-0');
     setSelectedProvider('openai');
     expect(storage.get('selected-model')).toBe('openai:claude-sonnet-4-0');
+  });
+});
+
+describe('migrateLegacyAuthOnlySelection — clears stale auth-only selections', () => {
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('clears selected-model when it points at github (auth-only after 3.13)', () => {
+    storage.set('selected-model', 'github:gpt-4.1');
+    migrateLegacyAuthOnlySelection();
+    expect(storage.get('selected-model')).toBeUndefined();
+  });
+
+  it('preserves selected-model for providers that still expose LLM models', () => {
+    storage.set('selected-model', 'anthropic:claude-sonnet-4-6');
+    migrateLegacyAuthOnlySelection();
+    expect(storage.get('selected-model')).toBe('anthropic:claude-sonnet-4-6');
+  });
+
+  it('preserves selected-model when prefix is github-copilot (LLM provider)', () => {
+    // github-copilot lives next to the legacy github prefix but still
+    // offers LLM models; the migration must not collateral-damage it.
+    storage.set('selected-model', 'github-copilot:claude-sonnet-4.6');
+    migrateLegacyAuthOnlySelection();
+    expect(storage.get('selected-model')).toBe('github-copilot:claude-sonnet-4.6');
+  });
+
+  it('is a no-op when selected-model is unset', () => {
+    migrateLegacyAuthOnlySelection();
+    expect(storage.get('selected-model')).toBeUndefined();
+  });
+
+  it('is a no-op when selected-model has no provider prefix', () => {
+    storage.set('selected-model', 'claude-sonnet-4-6');
+    migrateLegacyAuthOnlySelection();
+    expect(storage.get('selected-model')).toBe('claude-sonnet-4-6');
+  });
+
+  it('is idempotent', () => {
+    storage.set('selected-model', 'github:gpt-4.1');
+    migrateLegacyAuthOnlySelection();
+    migrateLegacyAuthOnlySelection();
+    expect(storage.get('selected-model')).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What

Splits GitHub identity from Copilot LLM access into two sibling providers, and threads a generic device-code prompting hook through the OAuth flow so the verification code is rendered inside whatever UI initiates the login instead of a floating overlay.

### Provider split

- **`github`** is now pure git/auth: OAuth code grant, writes the token to `/workspace/.git/github-token` for isomorphic-git, seeds `user.name` / `user.email` in global git config. `getModelIds: () => []`; no LLM streams.
- **`github-copilot`** (new): VS Code device-code flow, live `/models` catalog (refreshed on login + silent renew) cached in localStorage, per-model `POST /models/{id}/policy` accept for plan-gated models. Streams dispatch to `streamAnthropic` / `streamOpenAIResponses` / `streamOpenAICompletions` based on each model's `supported_endpoints` and vendor.

### Better failure UX

When the `/v1/messages` or `/chat/completions` upstream emits a `model_not_supported` event mid-stream, the wrapper:

1. marks the model unavailable in the cache so it's filtered from the picker on the next render,
2. rewrites the error event with a plan-aware explanation pointing the user at Claude Sonnet 4.6 or other models their tier includes.

### Cone-compat filter

New `isCopilotConeCompatible` predicate (mirroring `isBedrockCampCompatible`) hides Haiku / mini / flash / nano / lite / embedding variants from the picker — they reliably break the agent loop. Applied to both the live catalog and the pi-mono fallback.

### Generic device-code prompter

New `DeviceCodePrompter` type + `presentDeviceCode` option on `OAuthLoginOptions`. The provider awaits its resolution before opening any auth tab.

- **Settings dialog** renders the code inline in `oauthSection` via `createDialogDeviceCodePrompter`.
- **Welcome sprinkle** renders the code as a new `sDeviceCode` step in `connect-llm.shtml`, plumbed through a new `device-code-bridge.ts` module (`createSprinkleDeviceCodePrompter` + `resolveDeviceCodeDecision`) and a new `device-code-decision` welcome-flow lick action intercepted in both `mainExtension` and `mainStandaloneWorker`.
- **Fallback** (e.g. `oauth-token github-copilot` shell command) keeps the floating overlay, now also gated on a Copy & Continue click.

### Account picker hygiene

- New `providerOffersLlmModels(id)` predicate. Checks `getProviderModels`, pi-ai's `getModels`, and `modelOverrides`. Filters the settings Add Account dropdown, the extension welcome catalogue, and the standalone-worker welcome catalogue — so the auth-only `github` provider no longer appears in either surface.
- Add Account dropdown now opens with a disabled `Select a provider…` placeholder instead of auto-selecting Amazon Bedrock. All form sections stay hidden until the user picks something.

## Files

- `packages/webapp/providers/github.ts` — trimmed to pure git/auth.
- `packages/webapp/providers/github-copilot.ts` (new) — device-code flow, live catalog, stream wrappers, plan-aware error rewriting.
- `packages/webapp/src/providers/device-code-bridge.ts` (new) — sprinkle prompter helper.
- `packages/webapp/src/providers/types.ts` — `DeviceCodePrompter`, `DeviceCodePromptInput`, `presentDeviceCode` on `OAuthLoginOptions`.
- `packages/webapp/src/ui/provider-settings.ts` — `providerOffersLlmModels`, `createDialogDeviceCodePrompter`, dropdown placeholder + filter.
- `packages/webapp/src/ui/main.ts` — wire prompter into both `launchOAuth` paths, intercept `device-code-decision` lick in both welcome-flow interceptors, filter both catalogue builders.
- `packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml` — new `sDeviceCode` step.

## Verification

`npm run typecheck` clean across the five tsconfigs; 133/133 tests pass (`provider-settings`, `oauth-token-command`, `onboarding-orchestrator`); `npx prettier --check` clean on the touched files.

Live CDP probe confirmed: post-login, `claude-sonnet-4.6` returns 200 from `/v1/messages`; Opus variants return `model_not_supported` (Copilot Free tier limitation — surfaced to the user with a tier-aware message and auto-hidden from the picker).