### PR TITLE
feat(jsh): runtime extensions — parseFlags, cli, c, time, fmt, pool, skill, browser, http, browser.fetch, browser.websocket

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -386,9 +386,9 @@ module.exports: {}        // Available for ES module pattern
 exports: module.exports   // Alias
 ```
 
-### Proposed jsh runtime extensions
+### jsh runtime extensions
 
-The following globals are **spec'd but not yet implemented** — they were extracted from cross-skill duplication analysis (see the workspace spec at `analyze-skills`). Skills MAY reference them in design discussions and SHOULD prefer them over hand-rolled equivalents once shipped. When in doubt, run `commands` or check whether the global resolves at runtime before reimplementing.
+The following globals were added in PR #786 and are available in the jsh realm in both standalone and extension floats. They were extracted from cross-skill duplication analysis (see the workspace spec at `analyze-skills`); skills SHOULD prefer them over hand-rolled equivalents. Test availability with `node -e "console.log(typeof process.argv.parseFlags, typeof browser, typeof http, typeof skill)"`.
 
 #### `process.argv.parseFlags()`
 
@@ -468,36 +468,6 @@ await browser.websocket.list();
 - Subscribers owned by a scoop are auto-closed when the scoop is dropped
   (`Orchestrator.unregisterScoop` → `WsSubscriberRegistry.dropForScoop`).
 
-#### `browser.fetch(tab, url, opts)`
-
-Replaces the eval-file + base64 + double-JSON-unwrap pattern in ~9 skills (slack, linkedin, concur, suno, fluffyjaws, servicenow, apple-music, oryx, outlook).
-
-```typescript
-browser.fetch(tab: TabHandle, url: string, opts?: {
-  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | ...;
-  headers?: Record<string, string>;
-  body?: unknown;                  // object → JSON-stringified
-  credentials?: 'include' | 'omit'; // defaults to 'include'
-}): Promise<{ ok: boolean; status: number; headers: Record<string, string>; body: unknown }>
-```
-
-Runs inside the tab's origin, so session cookies and same-origin headers are automatic. Response body is JSON-parsed when content-type permits.
-
-#### `browser.websocket` — declarative WebSocket observer
-
-Replaces the `WebSocket.prototype.send` prototype patch + page-context `onmessage` reader + `fetch(arbitraryUrl, …)` exfil pattern flagged by security review in `slack.jsh`.
-
-```typescript
-browser.websocket
-  .on(tab, opts: { urlMatch: RegExp | string }): Subscription
-  .filter(opts: { parseAs: 'json' | 'text'; where: Record<string, unknown> }): Subscription
-  .forward(opts: { sink: 'webhook' | 'scoop' | 'vfs' | 'log'; webhookId?: string; scoopName?: string; path?: string }): Promise<Subscriber>
-
-browser.websocket.list(): Promise<Subscriber[]>
-subscriber.update(opts): Promise<void>
-subscriber.close(): Promise<void>
-```
-
 **Sink set is a closed enum.** Skills cannot supply an arbitrary URL — the page-side router (runtime-owned, audited once) only knows how to forward matched frames to: a registered `webhook` ID, an in-process `scoop`, an allowlisted VFS `path`, or `log`. There is no way for skill code to monkey-patch `WebSocket.prototype` or author the page-context router.
 
 ```javascript
@@ -513,7 +483,20 @@ const sub = await browser.websocket
   .forward({ sink: 'webhook', webhookId: 'slack-watch-abc123' });
 ```
 
-Scope: read-only. Outbound frame interception (modifying `send`) is intentionally out of scope and would be a separate, more heavily gated API.
+#### `browser.fetch(tab, url, opts)`
+
+Replaces the eval-file + base64 + double-JSON-unwrap pattern in ~9 skills (slack, linkedin, concur, suno, fluffyjaws, servicenow, apple-music, oryx, outlook).
+
+```typescript
+browser.fetch(tab: TabHandle, url: string, opts?: {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | ...;
+  headers?: Record<string, string>;
+  body?: unknown;                  // object → JSON-stringified
+  credentials?: 'include' | 'omit'; // defaults to 'include'
+}): Promise<{ ok: boolean; status: number; headers: Record<string, string>; body: unknown }>
+```
+
+Runs inside the tab's origin, so session cookies and same-origin headers are automatic. Response body is JSON-parsed when content-type permits.
 
 ### Example .jsh Script
 

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -427,6 +427,47 @@ browser.localStorage(tab, key: string): Promise<string | null>
 
 The page-context bridge is owned by the runtime — skills never author eval-file temp files or parse double-encoded JSON.
 
+#### `browser.websocket` — declarative WebSocket observer
+
+Sanctioned replacement for the `WebSocket.prototype.send` monkey-patches that
+Tessl/Snyk flagged in `slack.jsh`. Skill code never patches a third-party
+page's prototype, never sees the full inbound frame firehose, and cannot
+supply an arbitrary URL to forward to.
+
+```typescript
+const sub = await browser.websocket
+  .on(tab, { urlMatch: /wss-primary\.slack\.com/ })
+  .filter({ parseAs: 'json', where: { type: 'message', channel: 'C0899S7HV0E' } })
+  .forward({ sink: 'webhook', webhookId: 'slack-watch-abc123' });
+
+await sub.update({ filter: { where: { channel: 'C-new' } } });
+await sub.close();
+await browser.websocket.list();
+```
+
+**Security review notes (Wave 4.1):**
+
+- The page-side router (`__sliccWsRouter`) is a single static, runtime-owned
+  script. It patches `WebSocket.prototype.send` **at most once per tab** —
+  `installWsRouter()` is idempotent. Skills cannot supply page-context code;
+  the router source lives in `packages/webapp/src/kernel/realm/ws-router-page.ts`.
+- The `filter` selector is a declarative JSON object (`parseAs`, `where`,
+  `project`). The realm builder rejects a `Function` or string of JS at the
+  boundary, so a compromised skill cannot smuggle code into the runtime via
+  the filter slot.
+- The runtime forwards matched frames to one of four sanctioned sinks:
+  - `'webhook'` — resolved against the existing `webhook` registry; an
+    unknown `webhookId` rejects at `subscriber-creation time`.
+  - `'scoop'` — delivered via `orchestrator.dispatchToScoop`.
+  - `'vfs'` — appended to an absolute path that must start with
+    `/workspace/`.
+  - `'log'` — telemetry only.
+- Outbound (`WebSocket.prototype.send`) interception is **out of scope** —
+  `send` is hooked only as a discovery mechanism so the inbound `message`
+  listener can be attached.
+- Subscribers owned by a scoop are auto-closed when the scoop is dropped
+  (`Orchestrator.unregisterScoop` → `WsSubscriberRegistry.dropForScoop`).
+
 #### `browser.fetch(tab, url, opts)`
 
 Replaces the eval-file + base64 + double-JSON-unwrap pattern in ~9 skills (slack, linkedin, concur, suno, fluffyjaws, servicenow, apple-music, oryx, outlook).

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -386,6 +386,94 @@ module.exports: {}        // Available for ES module pattern
 exports: module.exports   // Alias
 ```
 
+### Proposed jsh runtime extensions
+
+The following globals are **spec'd but not yet implemented** — they were extracted from cross-skill duplication analysis (see the workspace spec at `analyze-skills`). Skills MAY reference them in design discussions and SHOULD prefer them over hand-rolled equivalents once shipped. When in doubt, run `commands` or check whether the global resolves at runtime before reimplementing.
+
+#### `process.argv.parseFlags()`
+
+Replaces the per-skill `--flag=val` / `--flag val` / positional parsing loop reinvented in every surveyed skill.
+
+```typescript
+process.argv.parseFlags(): {
+  positional: string[];   // non-flag args
+  flags: Record<string, string | boolean>;
+  subcommand: string | null; // first positional, if it looks like a subcommand
+}
+```
+
+```javascript
+// Today (every skill, ~25 LoC):
+for (let i = 1; i < args.length; i++) {
+  /* …--flag=val / --flag val / positional… */
+}
+
+// Proposed:
+const { positional, flags, subcommand } = process.argv.parseFlags();
+```
+
+#### `browser` global
+
+Replaces the `exec('playwright-cli tab-list')` shell-out + regex parse used in ~12 skills.
+
+```typescript
+browser.findTab(opts: { domain?: string; urlMatch?: RegExp | string }): Promise<TabHandle | null>
+browser.ensureTab(url: string): Promise<TabHandle>            // open if missing
+browser.eval(tab, fn: Function | string): Promise<unknown>    // sync expression
+browser.evalAsync(tab, fn: AsyncFunction): Promise<unknown>   // async, returns parsed JSON
+browser.cookie(tab, name: string): Promise<string | null>
+browser.localStorage(tab, key: string): Promise<string | null>
+```
+
+The page-context bridge is owned by the runtime — skills never author eval-file temp files or parse double-encoded JSON.
+
+#### `browser.fetch(tab, url, opts)`
+
+Replaces the eval-file + base64 + double-JSON-unwrap pattern in ~9 skills (slack, linkedin, concur, suno, fluffyjaws, servicenow, apple-music, oryx, outlook).
+
+```typescript
+browser.fetch(tab: TabHandle, url: string, opts?: {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | ...;
+  headers?: Record<string, string>;
+  body?: unknown;                  // object → JSON-stringified
+  credentials?: 'include' | 'omit'; // defaults to 'include'
+}): Promise<{ ok: boolean; status: number; headers: Record<string, string>; body: unknown }>
+```
+
+Runs inside the tab's origin, so session cookies and same-origin headers are automatic. Response body is JSON-parsed when content-type permits.
+
+#### `browser.websocket` — declarative WebSocket observer
+
+Replaces the `WebSocket.prototype.send` prototype patch + page-context `onmessage` reader + `fetch(arbitraryUrl, …)` exfil pattern flagged by security review in `slack.jsh`.
+
+```typescript
+browser.websocket
+  .on(tab, opts: { urlMatch: RegExp | string }): Subscription
+  .filter(opts: { parseAs: 'json' | 'text'; where: Record<string, unknown> }): Subscription
+  .forward(opts: { sink: 'webhook' | 'scoop' | 'vfs' | 'log'; webhookId?: string; scoopName?: string; path?: string }): Promise<Subscriber>
+
+browser.websocket.list(): Promise<Subscriber[]>
+subscriber.update(opts): Promise<void>
+subscriber.close(): Promise<void>
+```
+
+**Sink set is a closed enum.** Skills cannot supply an arbitrary URL — the page-side router (runtime-owned, audited once) only knows how to forward matched frames to: a registered `webhook` ID, an in-process `scoop`, an allowlisted VFS `path`, or `log`. There is no way for skill code to monkey-patch `WebSocket.prototype` or author the page-context router.
+
+```javascript
+// Before (~90 LoC of injected, string-built JS; flagged for prototype hijacking + exfil):
+const interceptorCode = `(async () => { WebSocket.prototype.send = function(data) { /* … */ }; })()`;
+await fs.writeFile(tmpFile, interceptorCode);
+await exec(`playwright-cli eval-file ${tmpFile} --tab=${tabId}`);
+
+// After (~10 LoC, no page-authored JS, audited sinks):
+const sub = await browser.websocket
+  .on(tab, { urlMatch: /wss-primary\.slack\.com/ })
+  .filter({ parseAs: 'json', where: { type: 'message', channel: 'C0899S7HV0E' } })
+  .forward({ sink: 'webhook', webhookId: 'slack-watch-abc123' });
+```
+
+Scope: read-only. Outbound frame interception (modifying `send`) is intentionally out of scope and would be a separate, more heavily gated API.
+
 ### Example .jsh Script
 
 ```javascript

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -388,6 +388,8 @@ exports: module.exports   // Alias
 
 ### jsh runtime extensions
 
+> Companion file for in-VFS agents: `packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md`. Keep both in sync when the API changes.
+
 The following globals were added in PR #786 and are available in the jsh realm in both standalone and extension floats. They were extracted from cross-skill duplication analysis (see the workspace spec at `analyze-skills`); skills SHOULD prefer them over hand-rolled equivalents. Test availability with `node -e "console.log(typeof process.argv.parseFlags, typeof browser, typeof http, typeof skill)"`.
 
 #### `process.argv.parseFlags()`

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -385,7 +385,62 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       return bytes.byteLength;
     },
   };
+  // exec(string) parses through the shell; exec.spawn(argv[]) is the
+  // shell-free variant — mirrors child_process.spawn(cmd, args). Same
+  // surface as the worker realm (`js-realm-shared.ts`).
   const execBridge = (cmd) => rpcCall('exec', 'run', [cmd]);
+  execBridge.spawn = (argv) => rpcCall('exec', 'spawn', [argv]);
+
+  // `skill` global — mirrors kernel/realm/skill-global.ts (the canonical
+  // TS implementation). Boot-time computed from init.argv[1], frozen.
+  // Keep this in sync with skill-global.ts.
+  const skillGlobal = (() => {
+    const scriptPath = (init.argv && init.argv[1]) || '';
+    const slash = scriptPath.lastIndexOf('/');
+    const dir = !scriptPath ? '' : slash < 0 ? '' : slash === 0 ? '/' : scriptPath.substring(0, slash);
+    const refs = dir ? dir + '/references' : 'references';
+    const assets = dir ? dir + '/assets' : 'assets';
+    const configPath = dir ? dir + '/.config' : '.config';
+    const safeArg = (s) => /^[A-Za-z0-9_\-./:@]+$/.test(s) ? s : "'" + String(s).replace(/'/g, "'\\''") + "'";
+    async function readConfig() {
+      let exists;
+      try { exists = await fsBridge.exists(configPath); } catch { return null; }
+      if (!exists) return null;
+      let raw;
+      try { raw = await fsBridge.readFile(configPath); } catch { return null; }
+      const text = typeof raw === 'string' ? raw : String(raw);
+      if (!text.trim()) return null;
+      let parsed;
+      try { parsed = JSON.parse(text); }
+      catch (err) {
+        throw new Error('skill.config(): failed to parse ' + configPath + ': ' + (err instanceof Error ? err.message : String(err)));
+      }
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+      throw new Error('skill.config(): ' + configPath + ' must contain a JSON object');
+    }
+    async function config(updates) {
+      const existing = await readConfig();
+      if (updates === undefined) return existing;
+      if (updates === null || typeof updates !== 'object' || Array.isArray(updates)) {
+        throw new TypeError('skill.config(updates): updates must be a plain object');
+      }
+      const merged = Object.assign({}, existing || {}, updates);
+      await fsBridge.writeFile(configPath, JSON.stringify(merged, null, 2) + '\n');
+      return merged;
+    }
+    async function token(providerId) {
+      if (typeof providerId !== 'string' || !providerId.trim()) {
+        throw new TypeError('skill.token(providerId): providerId must be a non-empty string');
+      }
+      const res = await execBridge('oauth-token ' + safeArg(providerId));
+      if (res.exitCode !== 0) {
+        const msg = (res.stderr || '').trim() || ('oauth-token exited with code ' + res.exitCode);
+        throw new Error("skill.token('" + providerId + "'): " + msg);
+      }
+      return String(res.stdout || '').replace(/\r?\n+$/, '');
+    }
+    return Object.freeze({ dir, refs, assets, config, token });
+  })();
   async function realmFetch(input, init2) {
     const url = input instanceof Request
       ? input.url
@@ -495,10 +550,10 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   try {
     const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
     const fn = new AsyncFunction(
-      'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch',
+      'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch', 'skill',
       '"use strict";\n' + init.code
     );
-    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch);
+    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch, skillGlobal);
   } catch (err) {
     if (err && typeof err === 'object' && NODE_EXIT in err) {
       exitCode = err[NODE_EXIT];

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -884,6 +884,47 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     if (!options || options.matchUrl === undefined) return {};
     return { matchUrl: options.matchUrl instanceof RegExp ? options.matchUrl.source : options.matchUrl };
   }
+  // `browser.fetch` — page-context fetch on top of evalAsync. Mirrors
+  // buildBrowserFetchScript in js-realm-shared.ts. Credentials default
+  // to 'include' so the page's session cookies travel automatically.
+  function buildBrowserFetchScript(url, opts) {
+    opts = opts || {};
+    const headers = {};
+    const rawHeaders = opts.headers || {};
+    for (const k of Object.keys(rawHeaders)) {
+      const v = rawHeaders[k];
+      if (typeof v === 'string') headers[k] = v;
+    }
+    const method = typeof opts.method === 'string' ? opts.method : 'GET';
+    const credentials = (opts.credentials === 'same-origin' || opts.credentials === 'omit') ? opts.credentials : 'include';
+    let body;
+    if (opts.body !== undefined && opts.body !== null) {
+      if (typeof opts.body === 'string') {
+        body = opts.body;
+      } else {
+        body = JSON.stringify(opts.body);
+        const hasCt = Object.keys(headers).some((k) => k.toLowerCase() === 'content-type');
+        if (!hasCt) headers['Content-Type'] = 'application/json';
+      }
+    }
+    const init = { method: method, credentials: credentials, headers: headers };
+    if (body !== undefined) init.body = body;
+    const passthrough = ['mode','cache','redirect','referrer','referrerPolicy','integrity','keepalive'];
+    for (const k of passthrough) {
+      if (opts[k] !== undefined) init[k] = opts[k];
+    }
+    return '(async () => {' +
+      'const r = await fetch(' + JSON.stringify(url) + ', ' + JSON.stringify(init) + ');' +
+      'const h = {};' +
+      'r.headers.forEach((v, k) => { h[k] = v; });' +
+      "const ct = r.headers.get('content-type') || '';" +
+      'let b;' +
+      "if (ct.indexOf('application/json') !== -1) {" +
+      'try { b = await r.json(); } catch (e) { b = await r.text(); }' +
+      '} else { b = await r.text(); }' +
+      'return { ok: r.ok, status: r.status, headers: h, body: b };' +
+    '})()';
+  }
   const browserBridge = {
     findTab: (query) => rpcCall('browser', 'findTab', [normalizeBrowserFindQuery(query || {})]),
     ensureTab: (url, options) => rpcCall('browser', 'ensureTab', [url, normalizeBrowserMatchUrl(options || {})]),
@@ -891,6 +932,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     evalAsync: (tab, fnOrCode) => rpcCall('browser', 'evalAsync', [resolveBrowserTargetId(tab), serializeBrowserEvalSource(fnOrCode)]),
     cookie: (tab, name) => rpcCall('browser', 'cookie', [resolveBrowserTargetId(tab), name]),
     localStorage: (tab, key) => rpcCall('browser', 'localStorage', [resolveBrowserTargetId(tab), key]),
+    fetch: (tab, url, opts) => rpcCall('browser', 'evalAsync', [resolveBrowserTargetId(tab), buildBrowserFetchScript(url, opts || {})]),
   };
 
   let exitCode = 0;

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -620,6 +620,140 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
     return Object.freeze({ dir, refs, assets, config, token });
   })();
+
+  // `http` global — mirrors kernel/realm/http-global.ts (the canonical
+  // TS implementation). Standardizes the build-URL → merge-headers →
+  // resolve-auth → fetch → unwrap-JSON → throw-on-!ok pipeline plus
+  // 429/503 Retry-After backoff. Keep in sync with http-global.ts.
+  const httpGlobal = (() => {
+    const DEFAULT_BACKOFF_BASE_MS = 500;
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    function buildUrl(baseUrl, path, params) {
+      let url;
+      if (/^[a-z][a-z0-9+.-]*:\/\//i.test(path)) url = path;
+      else if (baseUrl) {
+        const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+        const rel = path.startsWith('/') ? path : '/' + path;
+        url = base + rel;
+      } else url = path;
+      if (!params) return url;
+      const qs = [];
+      for (const [k, v] of Object.entries(params)) {
+        if (v === undefined || v === null) continue;
+        if (Array.isArray(v)) {
+          for (const item of v) {
+            if (item === undefined || item === null) continue;
+            qs.push(encodeURIComponent(k) + '=' + encodeURIComponent(String(item)));
+          }
+        } else qs.push(encodeURIComponent(k) + '=' + encodeURIComponent(String(v)));
+      }
+      if (qs.length === 0) return url;
+      return url + (url.includes('?') ? '&' : '?') + qs.join('&');
+    }
+    function mergeHeaders(base, perCall) {
+      const out = {};
+      if (base) for (const [k, v] of Object.entries(base)) out[k] = v;
+      if (perCall) for (const [k, v] of Object.entries(perCall)) out[k] = v;
+      return out;
+    }
+    function isJsonContentType(ct) {
+      if (!ct) return false;
+      const lower = ct.toLowerCase();
+      return lower.startsWith('application/json') || /[+/]json(;|$|\s)/.test(lower);
+    }
+    function parseRetryAfter(value) {
+      if (!value) return null;
+      const trimmed = String(value).trim();
+      if (!trimmed) return null;
+      if (/^\d+(\.\d+)?$/.test(trimmed)) {
+        const seconds = Number(trimmed);
+        if (Number.isFinite(seconds) && seconds >= 0) return Math.round(seconds * 1000);
+      }
+      const date = Date.parse(trimmed);
+      if (Number.isFinite(date)) {
+        const delta = date - Date.now();
+        return delta > 0 ? delta : 0;
+      }
+      return null;
+    }
+    async function readBody(resp) {
+      const ct = resp.headers.get('content-type');
+      if (isJsonContentType(ct)) {
+        const text = await resp.text();
+        if (!text) return null;
+        try { return JSON.parse(text); } catch { return text; }
+      }
+      return resp.text();
+    }
+    function serializeBody(body, headers) {
+      if (body === undefined || body === null) return undefined;
+      if (typeof body === 'string') return body;
+      if (body instanceof ArrayBuffer || ArrayBuffer.isView(body) ||
+          (typeof Blob !== 'undefined' && body instanceof Blob) ||
+          (typeof FormData !== 'undefined' && body instanceof FormData)) {
+        return body;
+      }
+      if (typeof body === 'object') {
+        if (!Object.keys(headers).some((k) => k.toLowerCase() === 'content-type')) {
+          headers['Content-Type'] = 'application/json';
+        }
+        return JSON.stringify(body);
+      }
+      return String(body);
+    }
+    function makeClient(config) {
+      const retryOn = new Set((config.retry && config.retry.on) || []);
+      const maxAttempts = Math.max(1, Math.trunc((config.retry && config.retry.maxAttempts) || 1));
+      async function request(method, path, opts) {
+        opts = opts || {};
+        const url = buildUrl(config.baseUrl, path, opts.params);
+        const headers = mergeHeaders(config.headers, opts.headers);
+        if (config.token) {
+          const tok = await config.token();
+          if (tok) {
+            const hasAuth = Object.keys(headers).some((k) => k.toLowerCase() === 'authorization');
+            if (!hasAuth) headers['Authorization'] = 'Bearer ' + tok;
+          }
+        }
+        const body = serializeBody(opts.body, headers);
+        const init = { method, headers };
+        if (body !== undefined) init.body = body;
+        let lastResponse = null;
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+          const resp = await realmFetch(url, init);
+          lastResponse = resp;
+          if (resp.ok) return readBody(resp);
+          const willRetry = attempt + 1 < maxAttempts && retryOn.has(resp.status);
+          if (!willRetry) {
+            const errBody = await readBody(resp).catch(() => null);
+            const e = new Error('HTTP ' + resp.status + ' ' + resp.statusText + ' ' + url);
+            e.name = 'HttpError';
+            e.status = resp.status; e.statusText = resp.statusText; e.url = url; e.body = errBody;
+            throw e;
+          }
+          const retryAfter = parseRetryAfter(resp.headers.get('retry-after'));
+          const exp = DEFAULT_BACKOFF_BASE_MS * Math.pow(2, attempt);
+          await sleep(retryAfter !== null ? retryAfter : exp);
+        }
+        if (lastResponse) {
+          const errBody = await readBody(lastResponse).catch(() => null);
+          const e = new Error('HTTP ' + lastResponse.status + ' ' + lastResponse.statusText + ' ' + url);
+          e.name = 'HttpError';
+          e.status = lastResponse.status; e.statusText = lastResponse.statusText; e.url = url; e.body = errBody;
+          throw e;
+        }
+        throw new Error('http: no attempts made for ' + method + ' ' + url);
+      }
+      return Object.freeze({
+        get: (p, o) => request('GET', p, o),
+        post: (p, o) => request('POST', p, o),
+        put: (p, o) => request('PUT', p, o),
+        delete: (p, o) => request('DELETE', p, o),
+      });
+    }
+    return Object.freeze({ client: makeClient });
+  })();
+
   async function realmFetch(input, init2) {
     const url = input instanceof Request
       ? input.url
@@ -729,11 +863,11 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   try {
     const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
     const fn = new AsyncFunction(
-      'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch', 'skill',
+      'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch', 'skill', 'http',
       'cli', 'c', 'time', 'fmt', 'pool',
       '"use strict";\n' + init.code
     );
-    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch, skillGlobal, cliApi, colorApi, time, fmt, pool);
+    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch, skillGlobal, httpGlobal, cliApi, colorApi, time, fmt, pool);
   } catch (err) {
     if (err && typeof err === 'object' && NODE_EXIT in err) {
       exitCode = err[NODE_EXIT];

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -925,6 +925,48 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       'return { ok: r.ok, status: r.status, headers: h, body: b };' +
     '})()';
   }
+  // `browser.websocket` — declarative WebSocket observer mirror.
+  // Mirror of `createWsObserverApi` in js-realm-shared.ts.
+  function makeWsHandle(info) {
+    return Object.assign({}, info, {
+      update: function (patch) {
+        patch = patch || {};
+        var wire = {};
+        if (Object.prototype.hasOwnProperty.call(patch, 'urlMatch')) {
+          wire.urlMatch = patch.urlMatch === null
+            ? null
+            : (patch.urlMatch instanceof RegExp ? patch.urlMatch.source : patch.urlMatch);
+        }
+        if (Object.prototype.hasOwnProperty.call(patch, 'filter')) wire.filter = patch.filter;
+        return rpcCall('browser', 'wsUpdate', [info.id, wire]);
+      },
+      close: function () { return rpcCall('browser', 'wsClose', [info.id]); },
+    });
+  }
+  var websocketBridge = {
+    on: function (tab, opts) {
+      var targetId = resolveBrowserTargetId(tab);
+      opts = opts || {};
+      var urlMatch = opts.urlMatch === undefined
+        ? undefined
+        : (opts.urlMatch instanceof RegExp ? opts.urlMatch.source : opts.urlMatch);
+      var selector;
+      var builder = {
+        filter: function (next) {
+          if (typeof next === 'function' || typeof next === 'string') {
+            throw new TypeError('browser.websocket: filter must be a declarative JSON object, not a function or string');
+          }
+          selector = next;
+          return builder;
+        },
+        forward: function (sink) {
+          return rpcCall('browser', 'wsObserve', [{ targetId: targetId, urlMatch: urlMatch, filter: selector, forward: sink }]).then(makeWsHandle);
+        },
+      };
+      return builder;
+    },
+    list: function () { return rpcCall('browser', 'wsList', []); },
+  };
   const browserBridge = {
     findTab: (query) => rpcCall('browser', 'findTab', [normalizeBrowserFindQuery(query || {})]),
     ensureTab: (url, options) => rpcCall('browser', 'ensureTab', [url, normalizeBrowserMatchUrl(options || {})]),
@@ -933,6 +975,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     cookie: (tab, name) => rpcCall('browser', 'cookie', [resolveBrowserTargetId(tab), name]),
     localStorage: (tab, key) => rpcCall('browser', 'localStorage', [resolveBrowserTargetId(tab), key]),
     fetch: (tab, url, opts) => rpcCall('browser', 'evalAsync', [resolveBrowserTargetId(tab), buildBrowserFetchScript(url, opts || {})]),
+    websocket: websocketBridge,
   };
 
   let exitCode = 0;

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -345,8 +345,50 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       };
     },
   };
+  // Pure-JS runtime helpers — mirror of kernel/realm/js-realm-helpers.ts.
+  // Keep this block in lockstep with the canonical TS implementation
+  // (parity asserted by tests/kernel/realm/js-realm-helpers.test.ts).
+  function parseFlagsImpl(argv) {
+    const positional = [];
+    const flags = {};
+    const passthrough = [];
+    const setFlag = (key, value) => {
+      if (key in flags) {
+        const prev = flags[key];
+        if (Array.isArray(prev)) prev.push(String(value));
+        else flags[key] = [String(prev), String(value)];
+      } else flags[key] = value;
+    };
+    let i = 2;
+    while (i < argv.length) {
+      const arg = argv[i];
+      if (arg === '--') { passthrough.push(...argv.slice(i + 1)); break; }
+      if (arg.startsWith('--')) {
+        const body = arg.slice(2);
+        const eq = body.indexOf('=');
+        if (eq !== -1) { setFlag(body.slice(0, eq), body.slice(eq + 1)); i++; continue; }
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith('-')) { setFlag(body, next); i += 2; continue; }
+        setFlag(body, true); i++; continue;
+      }
+      if (arg.startsWith('-') && arg.length > 1) {
+        for (const ch of arg.slice(1)) setFlag(ch, true);
+        i++; continue;
+      }
+      positional.push(arg); i++;
+    }
+    const subcommand = positional.length > 0 && /^[a-z][\w-]*$/i.test(positional[0]) ? positional[0] : null;
+    return { positional, flags, subcommand, passthrough };
+  }
+  function attachArgvParseFlagsImpl(argv) {
+    const copy = [...argv];
+    Object.defineProperty(copy, 'parseFlags', { value: () => parseFlagsImpl(copy), enumerable: false, writable: false, configurable: false });
+    return copy;
+  }
+  const argvWithParseFlags = attachArgvParseFlagsImpl(init.argv);
+  const noColor = !!(init.env && init.env.NO_COLOR);
   const processShim = {
-    argv: init.argv,
+    argv: argvWithParseFlags,
     env: init.env,
     cwd: () => init.cwd,
     exit: (code) => {
@@ -355,9 +397,146 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       throw e;
     },
     stdin: stdinShim,
-    stdout: { write: writeStdout },
-    stderr: { write: writeStderr },
+    stdout: { write: writeStdout, isTTY: !noColor },
+    stderr: { write: writeStderr, isTTY: !noColor },
   };
+
+  // `c` (color) + `cli` globals — mirror of js-realm-helpers.ts.
+  const ANSI_CODES = { reset: '\u001b[0m', green: '\u001b[32m', red: '\u001b[31m', yellow: '\u001b[33m', gray: '\u001b[90m', bold: '\u001b[1m', cyan: '\u001b[36m', dim: '\u001b[2m' };
+  const colorEnabled = !noColor;
+  const wrapAnsi = (code) => (s) => colorEnabled ? code + s + ANSI_CODES.reset : String(s);
+  const colorApi = {
+    enabled: colorEnabled,
+    green: wrapAnsi(ANSI_CODES.green),
+    red: wrapAnsi(ANSI_CODES.red),
+    yellow: wrapAnsi(ANSI_CODES.yellow),
+    gray: wrapAnsi(ANSI_CODES.gray),
+    bold: wrapAnsi(ANSI_CODES.bold),
+    cyan: wrapAnsi(ANSI_CODES.cyan),
+    dim: wrapAnsi(ANSI_CODES.dim),
+  };
+  const toCliLine = (v) => {
+    if (typeof v === 'string') return v;
+    if (v instanceof Error) return v.message;
+    if (v === null || v === undefined) return String(v);
+    try { return JSON.stringify(v); } catch { return String(v); }
+  };
+  const cliExit = (code) => {
+    const e = new Error('Process exited with code ' + (code || 0));
+    e[NODE_EXIT] = Number.isFinite(code) ? Number(code) : 0;
+    throw e;
+  };
+  const cliApi = {
+    die(msg, exitCode) {
+      writeStderr(colorApi.red('Error:') + ' ' + toCliLine(msg) + '\n');
+      cliExit(exitCode === undefined ? 1 : exitCode);
+    },
+    out(value) {
+      if (typeof value === 'string') {
+        writeStdout(value.endsWith('\n') ? value : value + '\n');
+        return;
+      }
+      try { writeStdout(JSON.stringify(value, null, 2) + '\n'); }
+      catch { writeStdout(String(value) + '\n'); }
+    },
+    warn(msg) { writeStderr(colorApi.yellow('Warning:') + ' ' + toCliLine(msg) + '\n'); },
+    help(text) { writeStdout(text.endsWith('\n') ? text : text + '\n'); cliExit(0); },
+  };
+
+  // `time` — duration/date helpers. Unit set: ms|s|m|h|d|w|M|y. `m` is
+  // minutes; months use `M`. Mirror of js-realm-helpers.ts.
+  const DURATION_UNITS_MS = { ms: 1, s: 1000, m: 60000, h: 3600000, d: 86400000, w: 604800000, M: 2629800000, y: 31557600000 };
+  function parseDurationImpl(spec) {
+    if (typeof spec === 'number' && Number.isFinite(spec)) return Math.trunc(spec);
+    if (typeof spec !== 'string') throw new TypeError('time.parseDuration: spec must be string or number');
+    const m = /^([0-9]+(?:\.[0-9]+)?)\s*(ms|s|m|h|d|w|M|y)?$/.exec(spec.trim());
+    if (!m) throw new RangeError('time.parseDuration: unrecognized spec "' + spec + '"');
+    const unit = m[2] || 'ms';
+    return Math.trunc(Number(m[1]) * DURATION_UNITS_MS[unit]);
+  }
+  function pad2Impl(n) { return n < 10 ? '0' + n : String(n); }
+  const time = {
+    parseDuration: parseDurationImpl,
+    ago(spec, from) { from = from || new Date(); return new Date(from.getTime() - parseDurationImpl(spec)); },
+    range(spec, from) { from = from || new Date(); const end = new Date(from.getTime()); return { start: new Date(end.getTime() - parseDurationImpl(spec)), end }; },
+    future(spec, from) { from = from || new Date(); const start = new Date(from.getTime()); return { start, end: new Date(start.getTime() + parseDurationImpl(spec)) }; },
+    gmailDate(spec, from) { from = from || new Date(); const d = new Date(from.getTime() - parseDurationImpl(spec)); return d.getFullYear() + '/' + pad2Impl(d.getMonth() + 1) + '/' + pad2Impl(d.getDate()); },
+  };
+
+  // `fmt` — ANSI-aware formatting. Mirror of js-realm-helpers.ts.
+  const ANSI_STRIP_RE = /\u001b\[[0-9;]*m/g;
+  const stripAnsiImpl = (s) => s.replace(ANSI_STRIP_RE, '');
+  const visibleLenImpl = (s) => stripAnsiImpl(s).length;
+  function truncImpl(s, n) {
+    const text = String(s == null ? '' : s);
+    if (n <= 0) return '';
+    if (visibleLenImpl(text) <= n) return text;
+    if (n <= 1) return text.slice(0, n);
+    return stripAnsiImpl(text).slice(0, n - 1) + '…';
+  }
+  function colImpl(s, width) {
+    const text = String(s == null ? '' : s);
+    const vis = visibleLenImpl(text);
+    if (vis === width) return text;
+    if (vis > width) return truncImpl(text, width);
+    return text + ' '.repeat(width - vis);
+  }
+  function tableImpl(rows, widths) {
+    if (!rows.length) return '';
+    const colCount = Math.max(...rows.map((r) => r.length));
+    const computed = [];
+    for (let i = 0; i < colCount; i++) {
+      if (widths && widths[i] !== undefined) computed[i] = widths[i];
+      else {
+        let max = 0;
+        for (const r of rows) {
+          const cell = i < r.length ? String(r[i] == null ? '' : r[i]) : '';
+          if (visibleLenImpl(cell) > max) max = visibleLenImpl(cell);
+        }
+        computed[i] = max;
+      }
+    }
+    return rows.map((r) => computed.map((w, i) => colImpl(i < r.length ? String(r[i] == null ? '' : r[i]) : '', w)).join('  ').replace(/\s+$/, '')).join('\n');
+  }
+  function dateImpl(value, style) {
+    style = style || 'short';
+    const d = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(d.getTime())) return String(value);
+    if (style === 'iso') return d.toISOString();
+    if (style === 'human') {
+      const diff = Date.now() - d.getTime();
+      const abs = Math.abs(diff);
+      if (abs < 60000) return diff >= 0 ? 'just now' : 'in a moment';
+      const tense = (n, u) => diff >= 0 ? n + ' ' + u + (n === 1 ? '' : 's') + ' ago' : 'in ' + n + ' ' + u + (n === 1 ? '' : 's');
+      if (abs < 3600000) return tense(Math.round(abs / 60000), 'minute');
+      if (abs < 86400000) return tense(Math.round(abs / 3600000), 'hour');
+      if (abs < 2629800000) return tense(Math.round(abs / 86400000), 'day');
+      if (abs < 31557600000) return tense(Math.round(abs / 2629800000), 'month');
+      return tense(Math.round(abs / 31557600000), 'year');
+    }
+    return d.getFullYear() + '-' + pad2Impl(d.getMonth() + 1) + '-' + pad2Impl(d.getDate());
+  }
+  const fmt = { trunc: truncImpl, col: colImpl, table: tableImpl, date: dateImpl };
+
+  // `pool` — bounded concurrency runner. Mirror of js-realm-helpers.ts.
+  async function pool(concurrency, items, fn) {
+    const n = Math.max(1, Math.trunc(concurrency) || 1);
+    const results = new Array(items.length);
+    let next = 0;
+    const worker = async () => {
+      while (true) {
+        const i = next++;
+        if (i >= items.length) return;
+        results[i] = await fn(items[i], i);
+      }
+    };
+    const workers = [];
+    for (let w = 0; w < Math.min(n, items.length); w++) workers.push(worker());
+    await Promise.all(workers);
+    return results;
+  }
+
+
 
   function rpcCall(channel, op, args) {
     const id = nextIdFn();
@@ -551,9 +730,10 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
     const fn = new AsyncFunction(
       'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch', 'skill',
+      'cli', 'c', 'time', 'fmt', 'pool',
       '"use strict";\n' + init.code
     );
-    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch, skillGlobal);
+    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch, skillGlobal, cliApi, colorApi, time, fmt, pool);
   } catch (err) {
     if (err && typeof err === 'object' && NODE_EXIT in err) {
       exitCode = err[NODE_EXIT];

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -859,15 +859,49 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   };
   const moduleShim = { exports: {}, filename: init.filename };
 
+  // `browser` global — mirror of kernel/realm/js-realm-shared.ts. Calls
+  // the `browser` RPC channel exposed by realm-host.ts. Accepts a
+  // TabHandle (from findTab/ensureTab) or a bare targetId string.
+  function resolveBrowserTargetId(tab) {
+    if (typeof tab === 'string') return tab;
+    if (tab && typeof tab === 'object' && typeof tab.targetId === 'string') return tab.targetId;
+    throw new TypeError('browser: expected a tab handle or targetId string');
+  }
+  function serializeBrowserEvalSource(source) {
+    if (typeof source === 'function') return '(' + source.toString() + ')()';
+    if (typeof source === 'string') return source;
+    throw new TypeError('browser.eval/evalAsync: source must be a function or string');
+  }
+  function normalizeBrowserFindQuery(query) {
+    const out = {};
+    if (query && query.domain !== undefined) out.domain = query.domain;
+    if (query && query.urlMatch !== undefined) {
+      out.urlMatch = query.urlMatch instanceof RegExp ? query.urlMatch.source : query.urlMatch;
+    }
+    return out;
+  }
+  function normalizeBrowserMatchUrl(options) {
+    if (!options || options.matchUrl === undefined) return {};
+    return { matchUrl: options.matchUrl instanceof RegExp ? options.matchUrl.source : options.matchUrl };
+  }
+  const browserBridge = {
+    findTab: (query) => rpcCall('browser', 'findTab', [normalizeBrowserFindQuery(query || {})]),
+    ensureTab: (url, options) => rpcCall('browser', 'ensureTab', [url, normalizeBrowserMatchUrl(options || {})]),
+    eval: (tab, fnOrCode) => rpcCall('browser', 'eval', [resolveBrowserTargetId(tab), serializeBrowserEvalSource(fnOrCode)]),
+    evalAsync: (tab, fnOrCode) => rpcCall('browser', 'evalAsync', [resolveBrowserTargetId(tab), serializeBrowserEvalSource(fnOrCode)]),
+    cookie: (tab, name) => rpcCall('browser', 'cookie', [resolveBrowserTargetId(tab), name]),
+    localStorage: (tab, key) => rpcCall('browser', 'localStorage', [resolveBrowserTargetId(tab), key]),
+  };
+
   let exitCode = 0;
   try {
     const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
     const fn = new AsyncFunction(
-      'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch', 'skill', 'http',
+      'fs', 'process', 'console', 'require', 'module', 'exports', 'exec', 'fetch', 'skill', 'http', 'browser',
       'cli', 'c', 'time', 'fmt', 'pool',
       '"use strict";\n' + init.code
     );
-    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch, skillGlobal, httpGlobal, cliApi, colorApi, time, fmt, pool);
+    await fn(fsBridge, processShim, consoleShim, requireShim, moduleShim, moduleShim.exports, execBridge, realmFetch, skillGlobal, httpGlobal, browserBridge, cliApi, colorApi, time, fmt, pool);
   } catch (err) {
     if (err && typeof err === 'object' && NODE_EXIT in err) {
       exitCode = err[NODE_EXIT];

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -426,10 +426,22 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     e[NODE_EXIT] = Number.isFinite(code) ? Number(code) : 0;
     throw e;
   };
+  const formatCliPrefixed = (colorFn, prefix, text) => {
+    if (prefix === undefined) return colorFn('Error:') + ' ' + text + '\n';
+    if (prefix === '') return colorFn(text) + '\n';
+    return colorFn(prefix + ':') + ' ' + text + '\n';
+  };
+  const formatCliWarn = (prefix, text) => {
+    if (prefix === undefined) return colorApi.yellow('Warning:') + ' ' + text + '\n';
+    if (prefix === '') return colorApi.yellow(text) + '\n';
+    return colorApi.yellow(prefix + ':') + ' ' + text + '\n';
+  };
   const cliApi = {
-    die(msg, exitCode) {
-      writeStderr(colorApi.red('Error:') + ' ' + toCliLine(msg) + '\n');
-      cliExit(exitCode === undefined ? 1 : exitCode);
+    die(msg, opts) {
+      const exitCode = typeof opts === 'number' ? opts : (opts && opts.exitCode !== undefined ? opts.exitCode : 1);
+      const customPrefix = typeof opts === 'object' && opts !== null && 'prefix' in opts ? opts.prefix : undefined;
+      writeStderr(formatCliPrefixed(colorApi.red, customPrefix, toCliLine(msg)));
+      cliExit(exitCode);
     },
     out(value) {
       if (typeof value === 'string') {
@@ -439,7 +451,10 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       try { writeStdout(JSON.stringify(value, null, 2) + '\n'); }
       catch { writeStdout(String(value) + '\n'); }
     },
-    warn(msg) { writeStderr(colorApi.yellow('Warning:') + ' ' + toCliLine(msg) + '\n'); },
+    warn(msg, opts) {
+      const customPrefix = typeof opts === 'object' && opts !== null && 'prefix' in opts ? opts.prefix : undefined;
+      writeStderr(formatCliWarn(customPrefix, toCliLine(msg)));
+    },
     help(text) { writeStdout(text.endsWith('\n') ? text : text + '\n'); cliExit(0); },
   };
 
@@ -503,6 +518,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     const d = value instanceof Date ? value : new Date(value);
     if (Number.isNaN(d.getTime())) return String(value);
     if (style === 'iso') return d.toISOString();
+    if (style === 'locale') return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(d);
     if (style === 'human') {
       const diff = Date.now() - d.getTime();
       const abs = Math.abs(diff);
@@ -709,7 +725,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
         const url = buildUrl(config.baseUrl, path, opts.params);
         const headers = mergeHeaders(config.headers, opts.headers);
         if (config.token) {
-          const tok = await config.token();
+          const tok = await config.token({ method, path, url });
           if (tok) {
             const hasAuth = Object.keys(headers).some((k) => k.toLowerCase() === 'authorization');
             if (!hasAuth) headers['Authorization'] = 'Bearer ' + tok;
@@ -720,9 +736,43 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
         if (body !== undefined) init.body = body;
         let lastResponse = null;
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
-          const resp = await realmFetch(url, init);
+          const timeoutCtl = config.timeoutMs ? new AbortController() : null;
+          const timeoutId = timeoutCtl ? setTimeout(() => timeoutCtl.abort(new Error('timeout')), config.timeoutMs) : null;
+          const combinedSignal = opts.signal && timeoutCtl && timeoutCtl.signal
+            ? AbortSignal.any([opts.signal, timeoutCtl.signal])
+            : (opts.signal || (timeoutCtl && timeoutCtl.signal));
+          const attemptInit = combinedSignal ? Object.assign({}, init, { signal: combinedSignal }) : init;
+          let resp;
+          try {
+            // Signal can't cross postMessage to the parent; honor it locally
+            // by racing the realmFetch against an abort rejection so the
+            // caller sees cancellation even if the parent still completes.
+            if (combinedSignal) {
+              if (combinedSignal.aborted) {
+                throw combinedSignal.reason || new Error('aborted');
+              }
+              resp = await new Promise((resolve, reject) => {
+                const onAbort = () => reject(combinedSignal.reason || new Error('aborted'));
+                combinedSignal.addEventListener('abort', onAbort, { once: true });
+                realmFetch(url, attemptInit).then(
+                  (r) => { combinedSignal.removeEventListener('abort', onAbort); resolve(r); },
+                  (e) => { combinedSignal.removeEventListener('abort', onAbort); reject(e); },
+                );
+              });
+            } else {
+              resp = await realmFetch(url, attemptInit);
+            }
+          } finally {
+            if (timeoutId !== null) clearTimeout(timeoutId);
+          }
           lastResponse = resp;
-          if (resp.ok) return readBody(resp);
+          if (resp.ok) {
+            const respBody = await readBody(resp);
+            if (opts.raw) {
+              return { body: respBody, headers: Object.fromEntries(resp.headers.entries()), status: resp.status };
+            }
+            return respBody;
+          }
           const willRetry = attempt + 1 < maxAttempts && retryOn.has(resp.status);
           if (!willRetry) {
             const errBody = await readBody(resp).catch(() => null);

--- a/packages/vfs-root/workspace/skills/skill-authoring/SKILL.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/SKILL.md
@@ -84,12 +84,33 @@ Rules of thumb:
 
 ### `.jsh` — JavaScript shell scripts
 
-`.jsh` files are auto-discovered as shell commands anywhere on the VFS:
+`.jsh` files are auto-discovered as shell commands anywhere on the VFS. **Full reference: `docs/shell-reference.md` (sections "Globals API" and "Proposed jsh runtime extensions").**
 
-- **Auto-discovery**: registered as callable commands by filename (without the extension). A skill can ship its own commands by including a `.jsh` next to `SKILL.md`.
-- **Node-like globals**: `process`, `console`, `fs` — a VFS bridge with `readFile`, `writeFile`, `readFileBinary`, `writeFileBinary`, `readDir`, `exists`, `stat`, `mkdir`, `rm`, `fetchToFile`.
-- **Dual-mode**: works in both the CLI server and the Chrome extension.
-- **Top-level `await`**: scripts are wrapped in `AsyncFunction`. Always `await` fs methods. Don't use `.then()`.
+- **Auto-discovery**: registered as callable commands by filename (without the extension). A skill can ship its own commands by including a `.jsh` next to `SKILL.md`. Priority root `/workspace/skills/` wins on basename collisions.
+- **Dual-mode**: works in both the CLI server and the Chrome extension (sandbox iframe). Don't rely on CLI-only Node modules.
+- **Top-level `await`**: scripts are wrapped in `AsyncFunction`. Always `await` fs/exec/fetch. Don't use `.then()`.
+
+#### Runtime globals (use these — don't reinvent)
+
+| Global       | Use for                                                                                                                                            |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `process`    | `argv`, `env`, `cwd()`, `exit(code)`, `stdout.write`, `stderr.write`, `stdin.read()`                                                               |
+| `console`    | `log`/`info` → stdout, `warn`/`error` → stderr                                                                                                     |
+| `fs`         | `readFile`, `writeFile`, `readFileBinary`, `writeFileBinary`, `readDir`, `exists`, `stat`, `mkdir`, `rm`, `fetchToFile` — all paths are VFS, async |
+| `exec(cmd)`  | Run any shell command and get `{ stdout, stderr, exitCode }`. Use this to compose with other `.jsh` and supplemental commands.                     |
+| `fetch`      | Standard `fetch` routed through SLICC's proxied transport (cookies + CORS handled).                                                                |
+| `require(p)` | Pull npm packages from esm.sh (version-pinnable: `require('lodash@4')`). Cached per session.                                                       |
+
+#### Proposed runtime extensions (spec'd — check `commands` before reimplementing)
+
+If you find yourself writing one of these patterns, **stop and check whether the runtime now provides it** — the surface below was extracted from cross-skill duplication and may already be live (test with `node -e "console.log(typeof process.argv.parseFlags, typeof browser)"`):
+
+- **`process.argv.parseFlags()`** — returns `{ positional, flags, subcommand }`. Replaces the per-skill `--flag=val` / `--flag val` parsing loop.
+- **`browser.*`** — `findTab({ domain | urlMatch })`, `ensureTab(url)`, `eval(tab, fn)`, `evalAsync(tab, fn)`, `cookie(tab, name)`, `localStorage(tab, key)`. Replaces shelling out to `playwright-cli tab-list` and regex-parsing its output.
+- **`browser.fetch(tab, url, opts)`** — page-context fetch (runs inside the tab's origin, so cookies + same-origin headers are automatic). Replaces the `eval-file` temp-file + double-JSON-unwrap dance.
+- **`browser.websocket.on(tab, …).filter({…}).forward({ sink })`** — declarative WebSocket observer with a closed sink set (`webhook` / `scoop` / `vfs` / `log`). **Required** for any new WS-watch use case; do not author page-context `WebSocket.prototype` patches in skill code.
+
+When the runtime offers one of these, prefer it over hand-rolled equivalents — it's audited once and shorter in skill code.
 
 Ship a `.jsh` when the skill needs deterministic, parameterizable behavior the agent shouldn't have to re-derive each time (e.g. a `slicc-handoff` helper, a custom diff formatter, a domain-specific lint).
 

--- a/packages/vfs-root/workspace/skills/skill-authoring/SKILL.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/SKILL.md
@@ -84,7 +84,7 @@ Rules of thumb:
 
 ### `.jsh` — JavaScript shell scripts
 
-`.jsh` files are auto-discovered as shell commands anywhere on the VFS. **Full reference: `docs/shell-reference.md` (sections "Globals API" and "Proposed jsh runtime extensions").**
+`.jsh` files are auto-discovered as shell commands anywhere on the VFS. **Full reference: `docs/shell-reference.md` (sections "Globals API" and "jsh runtime extensions").**
 
 - **Auto-discovery**: registered as callable commands by filename (without the extension). A skill can ship its own commands by including a `.jsh` next to `SKILL.md`. Priority root `/workspace/skills/` wins on basename collisions.
 - **Dual-mode**: works in both the CLI server and the Chrome extension (sandbox iframe). Don't rely on CLI-only Node modules.
@@ -101,16 +101,16 @@ Rules of thumb:
 | `fetch`      | Standard `fetch` routed through SLICC's proxied transport (cookies + CORS handled).                                                                |
 | `require(p)` | Pull npm packages from esm.sh (version-pinnable: `require('lodash@4')`). Cached per session.                                                       |
 
-#### Proposed runtime extensions (spec'd — check `commands` before reimplementing)
+#### Runtime extensions (live — prefer these over hand-rolled equivalents)
 
-If you find yourself writing one of these patterns, **stop and check whether the runtime now provides it** — the surface below was extracted from cross-skill duplication and may already be live (test with `node -e "console.log(typeof process.argv.parseFlags, typeof browser)"`):
+The globals below ship in the jsh realm. Full reference: `docs/shell-reference.md` ("jsh runtime extensions"). Use them instead of reimplementing the cross-skill patterns they replace.
 
 - **`process.argv.parseFlags()`** — returns `{ positional, flags, subcommand }`. Replaces the per-skill `--flag=val` / `--flag val` parsing loop.
 - **`browser.*`** — `findTab({ domain | urlMatch })`, `ensureTab(url)`, `eval(tab, fn)`, `evalAsync(tab, fn)`, `cookie(tab, name)`, `localStorage(tab, key)`. Replaces shelling out to `playwright-cli tab-list` and regex-parsing its output.
 - **`browser.fetch(tab, url, opts)`** — page-context fetch (runs inside the tab's origin, so cookies + same-origin headers are automatic). Replaces the `eval-file` temp-file + double-JSON-unwrap dance.
 - **`browser.websocket.on(tab, …).filter({…}).forward({ sink })`** — declarative WebSocket observer with a closed sink set (`webhook` / `scoop` / `vfs` / `log`). **Required** for any new WS-watch use case; do not author page-context `WebSocket.prototype` patches in skill code.
-
-When the runtime offers one of these, prefer it over hand-rolled equivalents — it's audited once and shorter in skill code.
+- **`http.client({ baseUrl, token, headers, retry })`** — `get`/`post`/`put`/`delete` with merged headers, lazy token resolution, and Retry-After-aware backoff for `retry.on` statuses.
+- **`skill.dir` / `skill.refs` / `skill.assets` / `skill.config()` / `skill.token(providerId)`** — replace the per-skill `process.argv[1]` dirname math, ad-hoc `.config` JSON readers, and bespoke `oauth-token` shell-outs.
 
 Ship a `.jsh` when the skill needs deterministic, parameterizable behavior the agent shouldn't have to re-derive each time (e.g. a `slicc-handoff` helper, a custom diff formatter, a domain-specific lint).
 

--- a/packages/vfs-root/workspace/skills/skill-authoring/SKILL.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/SKILL.md
@@ -84,7 +84,7 @@ Rules of thumb:
 
 ### `.jsh` — JavaScript shell scripts
 
-`.jsh` files are auto-discovered as shell commands anywhere on the VFS. **Full reference: `docs/shell-reference.md` (sections "Globals API" and "jsh runtime extensions").**
+`.jsh` files are auto-discovered as shell commands anywhere on the VFS. **Full reference: `./jsh-runtime-extensions.md`.**
 
 - **Auto-discovery**: registered as callable commands by filename (without the extension). A skill can ship its own commands by including a `.jsh` next to `SKILL.md`. Priority root `/workspace/skills/` wins on basename collisions.
 - **Dual-mode**: works in both the CLI server and the Chrome extension (sandbox iframe). Don't rely on CLI-only Node modules.
@@ -103,7 +103,7 @@ Rules of thumb:
 
 #### Runtime extensions (live — prefer these over hand-rolled equivalents)
 
-The globals below ship in the jsh realm. Full reference: `docs/shell-reference.md` ("jsh runtime extensions"). Use them instead of reimplementing the cross-skill patterns they replace.
+The globals below ship in the jsh realm. Full reference: `./jsh-runtime-extensions.md`. Use them instead of reimplementing the cross-skill patterns they replace.
 
 - **`process.argv.parseFlags()`** — returns `{ positional, flags, subcommand }`. Replaces the per-skill `--flag=val` / `--flag val` parsing loop.
 - **`browser.*`** — `findTab({ domain | urlMatch })`, `ensureTab(url)`, `eval(tab, fn)`, `evalAsync(tab, fn)`, `cookie(tab, name)`, `localStorage(tab, key)`. Replaces shelling out to `playwright-cli tab-list` and regex-parsing its output.

--- a/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
@@ -1,0 +1,180 @@
+# jsh runtime extensions
+
+This file is bundled into the agent VFS at `/workspace/skills/skill-authoring/jsh-runtime-extensions.md`. Developer-facing equivalent: `docs/shell-reference.md` (which lives outside the VFS). Keep both in sync when the runtime surface changes.
+
+## Runtime globals (Globals API)
+
+Every `.jsh` script runs in an async wrapper with these globals available. Prefer them over hand-rolled equivalents.
+
+| Global                      | Purpose                                                                                                                                                                           |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `process`                   | `argv` (with `.parseFlags()`), `env`, `cwd()`, `exit(code)`, `stdout.write`, `stderr.write`, `stdin.read()` / async iterator. `stdin` buffer is one-shot — drain or iterate once. |
+| `console`                   | `log`/`info` → stdout, `warn`/`error` → stderr.                                                                                                                                   |
+| `fs`                        | `readFile`, `writeFile`, `readFileBinary`, `writeFileBinary`, `readDir`, `exists`, `stat`, `mkdir`, `rm`, `fetchToFile(url, path)` — all paths are VFS, all async.                |
+| `exec(cmd)`                 | Run any shell command, returns `{ stdout, stderr, exitCode }`. Also `exec.spawn(argv[])` to bypass shell parsing.                                                                 |
+| `fetch`                     | Standard `fetch` routed through SLICC's proxied transport (cookies + CORS + secret masking handled).                                                                              |
+| `require(p)`                | Pull npm packages from esm.sh; version-pinnable (`require('lodash@4')`); cached per session.                                                                                      |
+| `process.argv.parseFlags()` | Parse `--flag=val` / `--flag val` / `-x` / positional / `--` passthrough into `{ positional, flags, subcommand, passthrough }`.                                                   |
+| `cli`                       | `die(msg, code?)`, `out(value)`, `warn(msg)`, `help(text)` — stdout/stderr/exit helpers.                                                                                          |
+| `c`                         | ANSI color helpers: `green`, `red`, `yellow`, `gray`, `bold`, `cyan`, `dim`, plus `enabled` flag (auto-disabled on non-TTY / `NO_COLOR`).                                         |
+| `time`                      | `parseDuration(spec)`, `ago(spec)`, `range(spec)`, `future(spec)`, `gmailDate(spec)`. Units: `ms s m h d w M y` (note: `m` = minutes, `M` = months).                              |
+| `fmt`                       | `trunc(s, n)`, `col(s, width)`, `table(rows, widths?)`, `date(value, style?)` — ANSI-width-aware formatters.                                                                      |
+| `pool`                      | `pool(n, items, fn)` — bounded concurrency runner, results returned in input order.                                                                                               |
+
+### Examples for the non-trivial globals
+
+```javascript
+// process.argv.parseFlags() — replace per-skill arg loops
+const { positional, flags, subcommand, passthrough } = process.argv.parseFlags();
+// e.g. `mycli send --to alice --json -- --raw` →
+//   positional: ['send', 'alice'], flags: { to: 'alice', json: true },
+//   subcommand: 'send', passthrough: ['--raw']
+
+// cli + c — early-exit helpers and color
+if (!flags.to) cli.die('--to is required'); // writes "Error: …" to stderr, exits 1
+cli.out({ ok: true }); // pretty-prints JSON to stdout with trailing newline
+console.log(c.green('✓'), c.dim('done'));
+
+// time — duration math
+const since = time.ago('7d'); // Date 7 days ago
+const q = `after:${time.gmailDate('7d')}`; // "after:2026/05/22"
+
+// fmt — ANSI-aware table
+console.log(
+  fmt.table([
+    ['name', 'status'],
+    ['hub', c.green('up')],
+    ['relay', c.red('down')],
+  ])
+);
+
+// pool — bounded concurrency
+const results = await pool(4, urls, async (url) => (await fetch(url)).status);
+```
+
+## jsh runtime extensions
+
+The following globals collapse the boilerplate that 18 of 23 surveyed skills reinvented. They're available in both standalone and extension floats.
+
+### `skill.*` — script-relative paths, config, tokens
+
+Computed once at boot from `argv[1]` and frozen. Replaces ad-hoc `process.argv[1].substring(0, …)` dirname math, bespoke `.config` JSON readers, and `oauth-token` shell-outs.
+
+```typescript
+skill.dir: string                                              // directory containing the running script
+skill.refs: string                                             // `<dir>/references`
+skill.assets: string                                           // `<dir>/assets`
+skill.config(): Promise<Record<string, unknown> | null>        // read parsed JSON from `<dir>/.config`
+skill.config(updates): Promise<Record<string, unknown>>        // shallow-merge + write, returns merged
+skill.token(providerId: string): Promise<string>               // shells out to `oauth-token <id>`
+```
+
+```javascript
+const cfg = (await skill.config()) ?? {};
+const token = await skill.token('adobe');
+const tmpl = await fs.readFile(`${skill.refs}/prompt.md`);
+```
+
+### `browser.*` — page-context CDP bridge
+
+Replaces the `exec('playwright-cli tab-list')` shell-out + regex parse used in ~12 skills. Accepts a `TabHandle` (from `findTab` / `ensureTab`) or a bare `targetId` string. `eval` / `evalAsync` serialize functions to a string call expression so realm code can pass a closure as ergonomically as a string.
+
+```typescript
+browser.findTab(opts: { domain?: string; urlMatch?: RegExp | string }): Promise<TabHandle | null>
+browser.ensureTab(url: string, opts?: { matchUrl?: RegExp | string }): Promise<TabHandle>
+browser.eval(tab, fn: Function | string): Promise<unknown>      // sync expression
+browser.evalAsync(tab, fn: AsyncFunction): Promise<unknown>     // async, returns parsed JSON
+browser.cookie(tab, name: string): Promise<string | null>
+browser.localStorage(tab, key: string): Promise<string | null>
+```
+
+```javascript
+const tab = await browser.findTab({ domain: 'slack.com' });
+if (!tab) cli.die('open slack.com first');
+const team = await browser.eval(tab, () => document.title);
+const xoxc = await browser.localStorage(tab, 'localConfig_v2');
+```
+
+### `browser.fetch(tab, url, opts)` — page-context fetch
+
+Replaces the eval-file + base64 + double-JSON-unwrap pattern in ~9 skills. Runs inside the tab's origin, so **session cookies and same-origin headers are automatic** — don't try to forward cookies manually.
+
+```typescript
+browser.fetch(tab: TabHandle | string, url: string, opts?: {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | ...;
+  headers?: Record<string, string>;
+  body?: unknown;                   // object → JSON-stringified
+  credentials?: 'include' | 'omit'; // defaults to 'include'
+}): Promise<{ ok: boolean; status: number; headers: Record<string, string>; body: unknown }>
+```
+
+```javascript
+const resp = await browser.fetch(tab, '/api/conversations.list', {
+  method: 'POST',
+  body: { limit: 100 },
+});
+if (!resp.ok) cli.die(`slack ${resp.status}`);
+const channels = resp.body.channels;
+```
+
+### `browser.websocket` — declarative WebSocket observer
+
+Sanctioned replacement for `WebSocket.prototype.send` monkey-patches. **REQUIRED for any new WS-watch use case** — skill code MUST NOT author page-context functions that patch a third-party page's prototypes or see the inbound frame firehose.
+
+```typescript
+const sub = await browser.websocket
+  .on(tab, { urlMatch: /wss-primary\.slack\.com/ })
+  .filter({ parseAs: 'json', where: { type: 'message', channel: 'C0899S7HV0E' } })
+  .forward({ sink: 'webhook', webhookId: 'slack-watch-abc123' });
+
+await sub.update({ filter: { where: { channel: 'C-new' } } });
+await sub.close();
+await browser.websocket.list();
+```
+
+**Sink set is a closed enum.** The page-side router (runtime-owned, audited once) only knows how to forward matched frames to:
+
+- `'webhook'` — resolved against the existing `webhook` registry; an unknown `webhookId` rejects at subscriber-creation time.
+- `'scoop'` — delivered via the orchestrator's scoop dispatch.
+- `'vfs'` — appended to an absolute path that must start with `/workspace/`.
+- `'log'` — telemetry only.
+
+Skills cannot supply an arbitrary URL, cannot supply page-context code (the `filter` selector is a declarative JSON object — `parseAs`, `where`, `project` — and the realm rejects functions or strings of JS at the boundary), and cannot intercept outbound `send` traffic. Subscribers owned by a scoop auto-close when the scoop is dropped.
+
+### `http.client({ baseUrl, token, headers, retry })` — standard API-client builder
+
+Standardizes the `build URL → merge headers → resolve auth → fetch → unwrap JSON → throw on !ok` boilerplate. `token` is **lazy** — resolved freshly per request so token rotation / refresh hooks are picked up without recreating the client. Backoff is exponential, but **`Retry-After` (when present and parseable, in seconds or HTTP date) takes precedence** — the server knows its own rate limit.
+
+```typescript
+http.client(config: {
+  baseUrl?: string;
+  token?: () => string | Promise<string | null | undefined>;
+  headers?: Record<string, string>;
+  retry?: { on: number[]; maxAttempts: number };  // maxAttempts is total (including first)
+}): {
+  get(path, opts?):    Promise<unknown>;
+  post(path, opts?):   Promise<unknown>;
+  put(path, opts?):    Promise<unknown>;
+  delete(path, opts?): Promise<unknown>;
+}
+// opts: { params?, headers?, body? }  — `body` object → JSON, params → querystring
+```
+
+```javascript
+const api = http.client({
+  baseUrl: 'https://graph.microsoft.com/v1.0',
+  token: () => skill.token('microsoft'),
+  headers: { Accept: 'application/json' },
+  retry: { on: [429, 503], maxAttempts: 4 },
+});
+
+const me = await api.get('/me');
+const sent = await api.post('/me/sendMail', {
+  body: {
+    message: {
+      /* … */
+    },
+  },
+});
+// Non-2xx throws `HttpError` with { status, statusText, url, body }.
+```

--- a/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
@@ -6,20 +6,20 @@ This file is bundled into the agent VFS at `/workspace/skills/skill-authoring/js
 
 Every `.jsh` script runs in an async wrapper with these globals available. Prefer them over hand-rolled equivalents.
 
-| Global                      | Purpose                                                                                                                                                                           |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `process`                   | `argv` (with `.parseFlags()`), `env`, `cwd()`, `exit(code)`, `stdout.write`, `stderr.write`, `stdin.read()` / async iterator. `stdin` buffer is one-shot — drain or iterate once. |
-| `console`                   | `log`/`info` → stdout, `warn`/`error` → stderr.                                                                                                                                   |
-| `fs`                        | `readFile`, `writeFile`, `readFileBinary`, `writeFileBinary`, `readDir`, `exists`, `stat`, `mkdir`, `rm`, `fetchToFile(url, path)` — all paths are VFS, all async.                |
-| `exec(cmd)`                 | Run any shell command, returns `{ stdout, stderr, exitCode }`. Also `exec.spawn(argv[])` to bypass shell parsing.                                                                 |
-| `fetch`                     | Standard `fetch` routed through SLICC's proxied transport (cookies + CORS + secret masking handled).                                                                              |
-| `require(p)`                | Pull npm packages from esm.sh; version-pinnable (`require('lodash@4')`); cached per session.                                                                                      |
-| `process.argv.parseFlags()` | Parse `--flag=val` / `--flag val` / `-x` / positional / `--` passthrough into `{ positional, flags, subcommand, passthrough }`.                                                   |
-| `cli`                       | `die(msg, code?)`, `out(value)`, `warn(msg)`, `help(text)` — stdout/stderr/exit helpers.                                                                                          |
-| `c`                         | ANSI color helpers: `green`, `red`, `yellow`, `gray`, `bold`, `cyan`, `dim`, plus `enabled` flag (auto-disabled on non-TTY / `NO_COLOR`).                                         |
-| `time`                      | `parseDuration(spec)`, `ago(spec)`, `range(spec)`, `future(spec)`, `gmailDate(spec)`. Units: `ms s m h d w M y` (note: `m` = minutes, `M` = months).                              |
-| `fmt`                       | `trunc(s, n)`, `col(s, width)`, `table(rows, widths?)`, `date(value, style?)` — ANSI-width-aware formatters.                                                                      |
-| `pool`                      | `pool(n, items, fn)` — bounded concurrency runner, results returned in input order.                                                                                               |
+| Global                      | Purpose                                                                                                                                                                                                               |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `process`                   | `argv` (with `.parseFlags()`), `env`, `cwd()`, `exit(code)`, `stdout.write`, `stderr.write`, `stdin.read()` / async iterator. `stdin` buffer is one-shot — drain or iterate once.                                     |
+| `console`                   | `log`/`info` → stdout, `warn`/`error` → stderr.                                                                                                                                                                       |
+| `fs`                        | `readFile`, `writeFile`, `readFileBinary`, `writeFileBinary`, `readDir`, `exists`, `stat`, `mkdir`, `rm`, `fetchToFile(url, path)` — all paths are VFS, all async.                                                    |
+| `exec(cmd)`                 | Run any shell command, returns `{ stdout, stderr, exitCode }`. Also `exec.spawn(argv[])` to bypass shell parsing.                                                                                                     |
+| `fetch`                     | Standard `fetch` routed through SLICC's proxied transport (cookies + CORS + secret masking handled).                                                                                                                  |
+| `require(p)`                | Pull npm packages from esm.sh; version-pinnable (`require('lodash@4')`); cached per session.                                                                                                                          |
+| `process.argv.parseFlags()` | Parse `--flag=val` / `--flag val` / `-x` / positional / `--` passthrough into `{ positional, flags, subcommand, passthrough }`.                                                                                       |
+| `cli`                       | `die(msg, opts?)`, `out(value)`, `warn(msg, opts?)`, `help(text)`. `opts` is `number` (legacy exit code for `die`) or `{ exitCode?, prefix? }`; `prefix: ''` removes the default `Error:`/`Warning:` prefix entirely. |
+| `c`                         | ANSI color helpers: `green`, `red`, `yellow`, `gray`, `bold`, `cyan`, `dim`, plus `enabled` flag (auto-disabled on non-TTY / `NO_COLOR`). (Avoid `const c = ...` — it silently shadows this global.)                  |
+| `time`                      | `parseDuration(spec)`, `ago(spec)`, `range(spec)`, `future(spec)`, `gmailDate(spec)`. Units: `ms s m h d w M y` (note: `m` = minutes, `M` = months).                                                                  |
+| `fmt`                       | `trunc(s, n)`, `col(s, width)`, `table(rows, widths?)`, `date(value, style?)`. `style`: `'short' \| 'iso' \| 'human' \| 'locale'` (locale = `Intl.DateTimeFormat` medium).                                            |
+| `pool`                      | `pool(n, items, fn)` — bounded concurrency runner, results returned in input order.                                                                                                                                   |
 
 ### Examples for the non-trivial globals
 
@@ -29,12 +29,37 @@ const { positional, flags, subcommand, passthrough } = process.argv.parseFlags()
 // e.g. `mycli send --to alice --json -- --raw` →
 //   positional: ['send', 'alice'], flags: { to: 'alice', json: true },
 //   subcommand: 'send', passthrough: ['--raw']
+```
 
+**Two-level routing**: `parseFlags` populates `subcommand` only from the first positional. For `<cmd> <sub> [args]` CLIs, route the second level manually from `positional[1]`:
+
+```javascript
+const { positional, flags } = process.argv.parseFlags();
+const [cmd, sub] = positional;
+switch (cmd) {
+  case 'pr':
+    if (sub === 'list') return prList(flags);
+    if (sub === 'view') return prView(positional[2], flags);
+    return cli.die(`unknown pr subcommand: ${sub}`);
+  // …
+}
+```
+
+```javascript
 // cli + c — early-exit helpers and color
 if (!flags.to) cli.die('--to is required'); // writes "Error: …" to stderr, exits 1
 cli.out({ ok: true }); // pretty-prints JSON to stdout with trailing newline
 console.log(c.green('✓'), c.dim('done'));
+```
 
+```javascript
+// domain-specific prefix instead of the default "Error:"
+if (!flags.repo) cli.die('--repo is required', { prefix: 'gh' });
+// → "gh: --repo is required"
+cli.warn('rate limit at 80%', { prefix: 'gh' });
+```
+
+```javascript
 // time — duration math
 const since = time.ago('7d'); // Date 7 days ago
 const q = `after:${time.gmailDate('7d')}`; // "after:2026/05/22"
@@ -50,6 +75,13 @@ console.log(
 
 // pool — bounded concurrency
 const results = await pool(4, urls, async (url) => (await fetch(url)).status);
+```
+
+```javascript
+// exec.spawn(argv[]) — bypass shell parsing. Use for any arg derived from
+// untrusted input: it can't be shell-interpolated.
+const userMessage = flags.message ?? 'wip';
+await exec.spawn(['git', 'commit', '-m', userMessage]); // safe even with quotes/spaces in userMessage
 ```
 
 ## jsh runtime extensions
@@ -139,6 +171,8 @@ await browser.websocket.list();
 - `'vfs'` — appended to an absolute path that must start with `/workspace/`.
 - `'log'` — telemetry only.
 
+**Discovery requires outbound `send()`.** The router patches `WebSocket.prototype.send` as a pure discovery hook — it never observes outbound frames, but a WebSocket instance is only wrapped (and its inbound `message` listener attached) the first time something calls `send()` on it. Receive-only sockets that never call `send()` are not currently captured; trigger a no-op send from the page (or wait for the page to send a heartbeat / subscription frame) before subscribing.
+
 Skills cannot supply an arbitrary URL, cannot supply page-context code (the `filter` selector is a declarative JSON object — `parseAs`, `where`, `project` — and the realm rejects functions or strings of JS at the boundary), and cannot intercept outbound `send` traffic. Subscribers owned by a scoop auto-close when the scoop is dropped.
 
 ### `http.client({ baseUrl, token, headers, retry })` — standard API-client builder
@@ -148,16 +182,20 @@ Standardizes the `build URL → merge headers → resolve auth → fetch → unw
 ```typescript
 http.client(config: {
   baseUrl?: string;
-  token?: () => string | Promise<string | null | undefined>;
+  token?: (req?: { method: string; path: string; url: string }) => string | Promise<string | null | undefined>;
   headers?: Record<string, string>;
   retry?: { on: number[]; maxAttempts: number };  // maxAttempts is total (including first)
+  timeoutMs?: number;                              // per-attempt timeout; aborts the fetch
 }): {
   get(path, opts?):    Promise<unknown>;
   post(path, opts?):   Promise<unknown>;
   put(path, opts?):    Promise<unknown>;
   delete(path, opts?): Promise<unknown>;
 }
-// opts: { params?, headers?, body? }  — `body` object → JSON, params → querystring
+// opts: { params?, headers?, body?, signal?: AbortSignal, raw?: boolean }
+//  - body object → JSON, params → querystring
+//  - signal: caller-owned abort signal (timeoutMs creates its own per-attempt signal that combines with this)
+//  - raw: when true, returns { body, headers, status } instead of just body — needed for pagination (Link header) and rate-limit (X-RateLimit-*) instrumentation
 ```
 
 ```javascript
@@ -177,4 +215,21 @@ const sent = await api.post('/me/sendMail', {
   },
 });
 // Non-2xx throws `HttpError` with { status, statusText, url, body }.
+```
+
+```javascript
+// raw responses for pagination
+const resp = await api.get('/users', { raw: true });
+const link = resp.headers['link']; // e.g. '<…/users?page=2>; rel="next"'
+
+// per-request abort
+const ctl = new AbortController();
+setTimeout(() => ctl.abort(), 5000);
+await api.get('/slow', { signal: ctl.signal });
+
+// token with request context (e.g. different token for reads vs writes)
+const api = http.client({
+  baseUrl: 'https://api.example.com',
+  token: (req) => (req?.method === 'GET' ? skill.token('read') : skill.token('write')),
+});
 ```

--- a/packages/webapp/src/cdp/cdp-ws-page-bridge.ts
+++ b/packages/webapp/src/cdp/cdp-ws-page-bridge.ts
@@ -1,0 +1,168 @@
+/**
+ * `cdp-ws-page-bridge.ts` — CDP adapter implementing `WsPageBridge`
+ * for the Wave 4.1 `WsSubscriberRegistry`.
+ *
+ * Installs the runtime-owned router (`ws-router-page.ts`) into the
+ * target tab via `Page.addScriptToEvaluateOnNewDocument` (so it runs
+ * before any in-page WebSocket constructor on future loads) and a
+ * companion `Runtime.evaluate` (for the current document). Exposes a
+ * single kernel-side callback via `Runtime.addBinding` — the page can
+ * only call back with `JSON.stringify({ subId, payload })`, so a
+ * compromised skill cannot smuggle a destination URL or arbitrary
+ * fetch into the runtime.
+ *
+ * Works for both transports: the WebSocket-backed `CDPClient` (CLI /
+ * Electron / kernel-worker) and the `chrome.debugger`-backed
+ * `DebuggerClient` (extension offscreen). The bridge only consumes
+ * the `CDPTransport` surface exposed by `BrowserAPI.getTransport()`
+ * and serializes per-tab CDP traffic via `BrowserAPI.withTab(...)`.
+ */
+
+import type { BrowserAPI } from './browser-api.js';
+import { createLogger } from '../core/logger.js';
+import { WS_ROUTER_SOURCE } from '../kernel/realm/ws-router-page.js';
+import type { WsPageBridge } from '../kernel/realm/ws-subscribers.js';
+import type { WsSelector } from '../kernel/realm/realm-types.js';
+
+const log = createLogger('cdp-ws-page-bridge');
+
+/** Page-side binding name. Must match `__sliccWsRouterReport` in `ws-router-page.ts`. */
+const BINDING_NAME = '__sliccWsRouterReport';
+
+export interface CdpWsPageBridgeOptions {
+  browser: BrowserAPI;
+}
+
+export class CdpWsPageBridge implements WsPageBridge {
+  private readonly browser: BrowserAPI;
+  /** Per-tab install state. The script identifier lets us call `Page.removeScriptToEvaluateOnNewDocument` on cleanup. */
+  private readonly installs = new Map<string, { scriptIdentifier: string | null }>();
+  private frameHandler: ((subId: string, payload: unknown) => void) | null = null;
+  private bindingListenerAttached = false;
+
+  private readonly onBindingCalled = (params: Record<string, unknown>): void => {
+    if (params['name'] !== BINDING_NAME) return;
+    const payload = params['payload'];
+    if (typeof payload !== 'string') return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      return;
+    }
+    if (typeof parsed !== 'object' || parsed === null) return;
+    const subId = (parsed as { subId?: unknown }).subId;
+    if (typeof subId !== 'string') return;
+    const projection = (parsed as { payload?: unknown }).payload;
+    try {
+      this.frameHandler?.(subId, projection);
+    } catch (err) {
+      log.warn('frame handler threw', {
+        subId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  constructor(opts: CdpWsPageBridgeOptions) {
+    this.browser = opts.browser;
+  }
+
+  async installRouter(targetId: string): Promise<void> {
+    if (this.installs.has(targetId)) return;
+    // Attach the global binding listener lazily so a bridge with no
+    // installs holds no transport subscriptions.
+    this.ensureBindingListener();
+    const result = await this.browser.withTab(targetId, async () => {
+      await this.browser.sendCDP('Runtime.enable');
+      await this.browser.sendCDP('Runtime.addBinding', { name: BINDING_NAME });
+      const r = await this.browser.sendCDP('Page.addScriptToEvaluateOnNewDocument', {
+        source: WS_ROUTER_SOURCE,
+      });
+      // Run the router in the current document too — the
+      // `addScriptToEvaluateOnNewDocument` registration only fires
+      // on subsequent navigations.
+      await this.browser.sendCDP('Runtime.evaluate', {
+        expression: WS_ROUTER_SOURCE,
+        returnByValue: true,
+      });
+      return r;
+    });
+    const scriptIdentifier =
+      typeof result['identifier'] === 'string' ? (result['identifier'] as string) : null;
+    this.installs.set(targetId, { scriptIdentifier });
+  }
+
+  async registerSelector(
+    targetId: string,
+    subId: string,
+    urlMatch: string | undefined,
+    filter: WsSelector | undefined
+  ): Promise<void> {
+    await this.evalRouterCall(targetId, 'register', {
+      id: subId,
+      ...(urlMatch !== undefined ? { urlMatch } : {}),
+      ...(filter !== undefined ? { filter } : {}),
+    });
+  }
+
+  async updateSelector(
+    targetId: string,
+    subId: string,
+    urlMatch: string | undefined,
+    filter: WsSelector | undefined
+  ): Promise<void> {
+    await this.browser.withTab(targetId, async () => {
+      const patch: Record<string, unknown> = {};
+      if (urlMatch !== undefined) patch['urlMatch'] = urlMatch;
+      if (filter !== undefined) patch['filter'] = filter;
+      const expr = `window.__sliccWsRouter && window.__sliccWsRouter.update(${JSON.stringify(subId)}, ${JSON.stringify(patch)})`;
+      await this.browser.sendCDP('Runtime.evaluate', { expression: expr, returnByValue: true });
+    });
+  }
+
+  async unregisterSelector(targetId: string, subId: string): Promise<void> {
+    await this.browser.withTab(targetId, async () => {
+      const expr = `window.__sliccWsRouter && window.__sliccWsRouter.unregister(${JSON.stringify(subId)})`;
+      await this.browser.sendCDP('Runtime.evaluate', { expression: expr, returnByValue: true });
+    });
+  }
+
+  onMatchedFrame(handler: (subId: string, payload: unknown) => void): () => void {
+    this.frameHandler = handler;
+    return () => {
+      if (this.frameHandler === handler) this.frameHandler = null;
+    };
+  }
+
+  /**
+   * Tear down the binding-called subscription. Idempotent. Called by
+   * `KernelHost.dispose`. Per-tab init-scripts are left registered —
+   * the tab's own lifecycle owns the page-side state.
+   */
+  dispose(): void {
+    if (this.bindingListenerAttached) {
+      this.browser.getTransport().off('Runtime.bindingCalled', this.onBindingCalled);
+      this.bindingListenerAttached = false;
+    }
+    this.installs.clear();
+    this.frameHandler = null;
+  }
+
+  private ensureBindingListener(): void {
+    if (this.bindingListenerAttached) return;
+    this.browser.getTransport().on('Runtime.bindingCalled', this.onBindingCalled);
+    this.bindingListenerAttached = true;
+  }
+
+  private async evalRouterCall(
+    targetId: string,
+    method: 'register' | 'update' | 'unregister',
+    arg: unknown
+  ): Promise<void> {
+    await this.browser.withTab(targetId, async () => {
+      const expr = `window.__sliccWsRouter && window.__sliccWsRouter.${method}(${JSON.stringify(arg)})`;
+      await this.browser.sendCDP('Runtime.evaluate', { expression: expr, returnByValue: true });
+    });
+  }
+}

--- a/packages/webapp/src/cdp/cdp-ws-page-bridge.ts
+++ b/packages/webapp/src/cdp/cdp-ws-page-bridge.ts
@@ -109,13 +109,20 @@ export class CdpWsPageBridge implements WsPageBridge {
   async updateSelector(
     targetId: string,
     subId: string,
-    urlMatch: string | undefined,
-    filter: WsSelector | undefined
+    urlMatch: string | null | undefined,
+    filter: WsSelector | null | undefined
   ): Promise<void> {
     await this.browser.withTab(targetId, async () => {
+      // Tri-state: `undefined` is omitted from the patch (router keeps
+      // the field), an explicit `null` is forwarded so the router can
+      // `delete` the field, and any value sets it. Without the explicit
+      // clear directive, `sub.update({ filter: null })` would leave the
+      // page-side router matching with stale criteria.
       const patch: Record<string, unknown> = {};
-      if (urlMatch !== undefined) patch['urlMatch'] = urlMatch;
-      if (filter !== undefined) patch['filter'] = filter;
+      if (urlMatch === null) patch['urlMatch'] = null;
+      else if (urlMatch !== undefined) patch['urlMatch'] = urlMatch;
+      if (filter === null) patch['filter'] = null;
+      else if (filter !== undefined) patch['filter'] = filter;
       const expr = `window.__sliccWsRouter && window.__sliccWsRouter.update(${JSON.stringify(subId)}, ${JSON.stringify(patch)})`;
       await this.browser.sendCDP('Runtime.evaluate', { expression: expr, returnByValue: true });
     });

--- a/packages/webapp/src/kernel/host.ts
+++ b/packages/webapp/src/kernel/host.ts
@@ -359,6 +359,60 @@ export async function createKernelHost(config: KernelHostConfig): Promise<Kernel
   //    shell commands. globalThis is identical in worker + page.
   (globalThis as Record<string, unknown>).__slicc_lickManager = lickManager;
 
+  // 8a-pre. browser.websocket subscriber registry. The registry owns
+  //    the resolved sink dispatchers + the page-side CDP bridge so
+  //    `browser.websocket` is end-to-end functional in both floats
+  //    (WebSocket CDP standalone, chrome.debugger extension). The
+  //    realm-host resolves `globalThis.__slicc_wsSubscribers` at
+  //    `wsObserve`/`wsUpdate`/etc. call time. `unregisterScoop`
+  //    auto-cleans up subscribers via `dropForScoop`.
+  const { CdpWsPageBridge } = await import('../cdp/cdp-ws-page-bridge.js');
+  const { WsSubscriberRegistry } = await import('./realm/ws-subscribers.js');
+  const wsBridge = new CdpWsPageBridge({ browser });
+  const wsRegistry = new WsSubscriberRegistry({
+    bridge: wsBridge,
+    webhooks: { has: (id) => lickManager.getWebhook(id) !== undefined },
+    dispatcher: {
+      webhook: (id, payload) => {
+        lickManager.handleWebhookEvent(id, {}, payload);
+      },
+      scoop: (jid, payload) => {
+        const scoop = orchestrator.getScoops().find((s) => s.jid === jid);
+        if (!scoop) {
+          log.warn?.('browser.websocket: scoop sink not found', { jid });
+          return;
+        }
+        const msg: ChannelMessage = {
+          id: `ws-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          chatJid: jid,
+          senderId: 'browser.websocket',
+          senderName: 'browser.websocket',
+          content: typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2),
+          timestamp: new Date().toISOString(),
+          fromAssistant: false,
+          channel: 'browser.websocket',
+        };
+        void orchestrator.handleMessage(msg);
+      },
+      vfs: async (path, payload) => {
+        if (!sharedFs) return;
+        const line = (typeof payload === 'string' ? payload : JSON.stringify(payload)) + '\n';
+        let existing = '';
+        try {
+          const cur = await sharedFs.readFile(path);
+          existing = typeof cur === 'string' ? cur : new TextDecoder().decode(cur);
+        } catch {
+          /* file does not exist yet */
+        }
+        await sharedFs.writeFile(path, existing + line);
+      },
+      log: (payload) => {
+        log.info?.('browser.websocket frame', { payload });
+      },
+    },
+  });
+  (globalThis as Record<string, unknown>).__slicc_wsSubscribers = wsRegistry;
+
   // 8a. /licks-ws bridge to the node-server. The extension offscreen
   //     kernel-host has no node-server peer to connect to, so we gate
   //     on `isExtension`. See `scoops/lick-ws-bridge.ts` for the wire
@@ -555,7 +609,20 @@ export async function createKernelHost(config: KernelHostConfig): Promise<Kernel
           /* not mounted */
         }
       }
-      releaseHostGlobals({ processManager, lickManager, browser });
+      // Tear down the browser.websocket subscriber registry. Drops
+      // the page-side bridge's binding-called listener so we don't
+      // keep delivering frames after the host is gone.
+      try {
+        wsRegistry.dispose();
+      } catch (err) {
+        log.warn('WsSubscriberRegistry.dispose() failed', err);
+      }
+      try {
+        wsBridge.dispose();
+      } catch (err) {
+        log.warn('CdpWsPageBridge.dispose() failed', err);
+      }
+      releaseHostGlobals({ processManager, lickManager, browser, wsRegistry });
     },
   };
 }
@@ -574,9 +641,13 @@ export function releaseHostGlobals(refs: {
   processManager: ProcessManager;
   lickManager: LickManager;
   browser?: BrowserAPI;
+  wsRegistry?: unknown;
 }): void {
   const g = globalThis as Record<string, unknown>;
   if (g.__slicc_pm === refs.processManager) delete g.__slicc_pm;
   if (g.__slicc_lickManager === refs.lickManager) delete g.__slicc_lickManager;
   if (refs.browser && g.__slicc_browser === refs.browser) delete g.__slicc_browser;
+  if (refs.wsRegistry && g.__slicc_wsSubscribers === refs.wsRegistry) {
+    delete g.__slicc_wsSubscribers;
+  }
 }

--- a/packages/webapp/src/kernel/realm/http-global.ts
+++ b/packages/webapp/src/kernel/realm/http-global.ts
@@ -1,0 +1,247 @@
+/**
+ * `http-global.ts` — the `http` realm global. Standardizes the
+ * `build URL → merge headers → resolve auth → fetch → unwrap JSON
+ * → throw on !ok` boilerplate that 18 of the 23 surveyed skills
+ * each reinvented (see the workspace spec at `analyze-skills`),
+ * and builds in the 429/503 Retry-After backoff that only one
+ * skill (`teams.jsh`) actually got right.
+ *
+ * Surface:
+ *  - `http.client({ baseUrl, token, headers, retry })` →
+ *    `{ get, post, put, delete }`
+ *  - `token` is lazy: resolved freshly per request so token
+ *    rotation / refresh hooks are picked up without recreating
+ *    the client.
+ *  - `retry.on` is the closed status set that triggers a retry;
+ *    `retry.maxAttempts` is the total attempt count (including
+ *    the first). Backoff is exponential, but `Retry-After` (when
+ *    present and parseable) takes precedence — the server knows
+ *    its own rate limit better than the client.
+ */
+
+export interface HttpRetryConfig {
+  on: number[];
+  maxAttempts: number;
+}
+
+export interface HttpClientConfig {
+  baseUrl?: string;
+  token?: () => string | undefined | null | Promise<string | undefined | null>;
+  headers?: Record<string, string>;
+  retry?: HttpRetryConfig;
+}
+
+export interface HttpRequestOpts {
+  params?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+export interface HttpClient {
+  get(path: string, opts?: HttpRequestOpts): Promise<unknown>;
+  post(path: string, opts?: HttpRequestOpts): Promise<unknown>;
+  put(path: string, opts?: HttpRequestOpts): Promise<unknown>;
+  delete(path: string, opts?: HttpRequestOpts): Promise<unknown>;
+}
+
+export interface HttpGlobal {
+  client(config: HttpClientConfig): HttpClient;
+}
+
+export interface HttpGlobalDeps {
+  fetch: (url: string, init?: RequestInit) => Promise<Response>;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly url: string,
+    public readonly body: unknown
+  ) {
+    const detail =
+      typeof body === 'string' && body
+        ? `: ${body.slice(0, 200)}`
+        : body && typeof body === 'object'
+          ? `: ${safeJson(body).slice(0, 200)}`
+          : '';
+    super(`HTTP ${status} ${statusText} ${url}${detail}`);
+    this.name = 'HttpError';
+  }
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+const DEFAULT_BACKOFF_BASE_MS = 500;
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildUrl(
+  baseUrl: string | undefined,
+  path: string,
+  params?: Record<string, unknown>
+): string {
+  let url: string;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(path)) {
+    url = path;
+  } else if (baseUrl) {
+    const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    const rel = path.startsWith('/') ? path : `/${path}`;
+    url = `${base}${rel}`;
+  } else {
+    url = path;
+  }
+  if (!params) return url;
+  const qs: string[] = [];
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null) continue;
+    if (Array.isArray(v)) {
+      for (const item of v) {
+        if (item === undefined || item === null) continue;
+        qs.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(item))}`);
+      }
+    } else {
+      qs.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
+    }
+  }
+  if (qs.length === 0) return url;
+  return url + (url.includes('?') ? '&' : '?') + qs.join('&');
+}
+
+function mergeHeaders(
+  base: Record<string, string> | undefined,
+  perCall: Record<string, string> | undefined
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (base) for (const [k, v] of Object.entries(base)) out[k] = v;
+  if (perCall) for (const [k, v] of Object.entries(perCall)) out[k] = v;
+  return out;
+}
+
+function isJsonContentType(ct: string | null): boolean {
+  if (!ct) return false;
+  const lower = ct.toLowerCase();
+  return lower.startsWith('application/json') || /[+/]json(;|$|\s)/.test(lower);
+}
+
+function parseRetryAfter(value: string | null): number | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^\d+(\.\d+)?$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    if (Number.isFinite(seconds) && seconds >= 0) return Math.round(seconds * 1000);
+  }
+  const date = Date.parse(trimmed);
+  if (Number.isFinite(date)) {
+    const delta = date - Date.now();
+    return delta > 0 ? delta : 0;
+  }
+  return null;
+}
+
+async function readBody(resp: Response): Promise<unknown> {
+  const ct = resp.headers.get('content-type');
+  if (isJsonContentType(ct)) {
+    const text = await resp.text();
+    if (!text) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+  return resp.text();
+}
+
+function serializeBody(body: unknown, headers: Record<string, string>): string | undefined {
+  if (body === undefined || body === null) return undefined;
+  if (typeof body === 'string') return body;
+  if (
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body) ||
+    (typeof Blob !== 'undefined' && body instanceof Blob) ||
+    (typeof FormData !== 'undefined' && body instanceof FormData)
+  ) {
+    // Pass through opaque payloads unchanged — caller owns Content-Type.
+    return body as unknown as string;
+  }
+  if (typeof body === 'object') {
+    if (!Object.keys(headers).some((k) => k.toLowerCase() === 'content-type')) {
+      headers['Content-Type'] = 'application/json';
+    }
+    return JSON.stringify(body);
+  }
+  return String(body);
+}
+
+export function createHttpGlobal(deps: HttpGlobalDeps): HttpGlobal {
+  const sleep = deps.sleep ?? defaultSleep;
+
+  function makeClient(config: HttpClientConfig): HttpClient {
+    const retryOn = new Set(config.retry?.on ?? []);
+    const maxAttempts = Math.max(1, Math.trunc(config.retry?.maxAttempts ?? 1));
+
+    async function request(
+      method: string,
+      path: string,
+      opts: HttpRequestOpts = {}
+    ): Promise<unknown> {
+      const url = buildUrl(config.baseUrl, path, opts.params);
+      const headers = mergeHeaders(config.headers, opts.headers);
+      if (config.token) {
+        const tok = await config.token();
+        if (tok) {
+          const hasAuth = Object.keys(headers).some((k) => k.toLowerCase() === 'authorization');
+          if (!hasAuth) headers['Authorization'] = `Bearer ${tok}`;
+        }
+      }
+      const body = serializeBody(opts.body, headers);
+      const init: RequestInit = { method, headers };
+      if (body !== undefined) init.body = body as BodyInit;
+
+      let lastResponse: Response | null = null;
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const resp = await deps.fetch(url, init);
+        lastResponse = resp;
+        if (resp.ok) {
+          return readBody(resp);
+        }
+        const willRetry = attempt + 1 < maxAttempts && retryOn.has(resp.status);
+        if (!willRetry) {
+          const errBody = await readBody(resp).catch(() => null);
+          throw new HttpError(resp.status, resp.statusText, url, errBody);
+        }
+        const retryAfter = parseRetryAfter(resp.headers.get('retry-after'));
+        const exp = DEFAULT_BACKOFF_BASE_MS * 2 ** attempt;
+        const wait = retryAfter !== null ? retryAfter : exp;
+        await sleep(wait);
+      }
+      // Unreachable in practice — the loop either returns or throws — but
+      // keeps the type-checker honest if maxAttempts somehow falls to 0.
+      if (lastResponse) {
+        const errBody = await readBody(lastResponse).catch(() => null);
+        throw new HttpError(lastResponse.status, lastResponse.statusText, url, errBody);
+      }
+      throw new Error(`http: no attempts made for ${method} ${url}`);
+    }
+
+    return Object.freeze({
+      get: (path: string, opts?: HttpRequestOpts) => request('GET', path, opts),
+      post: (path: string, opts?: HttpRequestOpts) => request('POST', path, opts),
+      put: (path: string, opts?: HttpRequestOpts) => request('PUT', path, opts),
+      delete: (path: string, opts?: HttpRequestOpts) => request('DELETE', path, opts),
+    });
+  }
+
+  return Object.freeze({ client: makeClient });
+}

--- a/packages/webapp/src/kernel/realm/http-global.ts
+++ b/packages/webapp/src/kernel/realm/http-global.ts
@@ -163,17 +163,19 @@ async function readBody(resp: Response): Promise<unknown> {
   return resp.text();
 }
 
-function serializeBody(body: unknown, headers: Record<string, string>): string | undefined {
+function serializeBody(body: unknown, headers: Record<string, string>): BodyInit | undefined {
   if (body === undefined || body === null) return undefined;
   if (typeof body === 'string') return body;
   if (
     body instanceof ArrayBuffer ||
     ArrayBuffer.isView(body) ||
     (typeof Blob !== 'undefined' && body instanceof Blob) ||
-    (typeof FormData !== 'undefined' && body instanceof FormData)
+    (typeof FormData !== 'undefined' && body instanceof FormData) ||
+    (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) ||
+    (typeof ReadableStream !== 'undefined' && body instanceof ReadableStream)
   ) {
     // Pass through opaque payloads unchanged — caller owns Content-Type.
-    return body as unknown as string;
+    return body as BodyInit;
   }
   if (typeof body === 'object') {
     if (!Object.keys(headers).some((k) => k.toLowerCase() === 'content-type')) {
@@ -207,7 +209,7 @@ export function createHttpGlobal(deps: HttpGlobalDeps): HttpGlobal {
       }
       const body = serializeBody(opts.body, headers);
       const init: RequestInit = { method, headers };
-      if (body !== undefined) init.body = body as BodyInit;
+      if (body !== undefined) init.body = body;
 
       let lastResponse: Response | null = null;
       for (let attempt = 0; attempt < maxAttempts; attempt++) {

--- a/packages/webapp/src/kernel/realm/http-global.ts
+++ b/packages/webapp/src/kernel/realm/http-global.ts
@@ -24,24 +24,45 @@ export interface HttpRetryConfig {
   maxAttempts: number;
 }
 
+export interface HttpTokenRequest {
+  method: string;
+  path: string;
+  url: string;
+}
+
 export interface HttpClientConfig {
   baseUrl?: string;
-  token?: () => string | undefined | null | Promise<string | undefined | null>;
+  token?: (
+    req?: HttpTokenRequest
+  ) => string | undefined | null | Promise<string | undefined | null>;
   headers?: Record<string, string>;
   retry?: HttpRetryConfig;
+  timeoutMs?: number;
 }
 
 export interface HttpRequestOpts {
   params?: Record<string, unknown>;
   headers?: Record<string, string>;
   body?: unknown;
+  raw?: boolean;
+  signal?: AbortSignal;
+}
+
+export interface HttpResponse<T = unknown> {
+  body: T;
+  headers: Record<string, string>;
+  status: number;
 }
 
 export interface HttpClient {
-  get(path: string, opts?: HttpRequestOpts): Promise<unknown>;
-  post(path: string, opts?: HttpRequestOpts): Promise<unknown>;
-  put(path: string, opts?: HttpRequestOpts): Promise<unknown>;
-  delete(path: string, opts?: HttpRequestOpts): Promise<unknown>;
+  get(path: string, opts: HttpRequestOpts & { raw: true }): Promise<HttpResponse>;
+  get(path: string, opts?: HttpRequestOpts & { raw?: false }): Promise<unknown>;
+  post(path: string, opts: HttpRequestOpts & { raw: true }): Promise<HttpResponse>;
+  post(path: string, opts?: HttpRequestOpts & { raw?: false }): Promise<unknown>;
+  put(path: string, opts: HttpRequestOpts & { raw: true }): Promise<HttpResponse>;
+  put(path: string, opts?: HttpRequestOpts & { raw?: false }): Promise<unknown>;
+  delete(path: string, opts: HttpRequestOpts & { raw: true }): Promise<HttpResponse>;
+  delete(path: string, opts?: HttpRequestOpts & { raw?: false }): Promise<unknown>;
 }
 
 export interface HttpGlobal {
@@ -201,7 +222,7 @@ export function createHttpGlobal(deps: HttpGlobalDeps): HttpGlobal {
       const url = buildUrl(config.baseUrl, path, opts.params);
       const headers = mergeHeaders(config.headers, opts.headers);
       if (config.token) {
-        const tok = await config.token();
+        const tok = await config.token({ method, path, url });
         if (tok) {
           const hasAuth = Object.keys(headers).some((k) => k.toLowerCase() === 'authorization');
           if (!hasAuth) headers['Authorization'] = `Bearer ${tok}`;
@@ -213,10 +234,35 @@ export function createHttpGlobal(deps: HttpGlobalDeps): HttpGlobal {
 
       let lastResponse: Response | null = null;
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        const resp = await deps.fetch(url, init);
+        const timeoutCtl = config.timeoutMs ? new AbortController() : null;
+        const timeoutId = timeoutCtl
+          ? setTimeout(() => timeoutCtl.abort(new Error('timeout')), config.timeoutMs!)
+          : null;
+        // Combine caller signal + per-attempt timeout signal.
+        const combinedSignal =
+          opts.signal && timeoutCtl?.signal
+            ? AbortSignal.any([opts.signal, timeoutCtl.signal])
+            : (opts.signal ?? timeoutCtl?.signal);
+        const attemptInit: RequestInit = combinedSignal
+          ? { ...init, signal: combinedSignal }
+          : init;
+        let resp: Response;
+        try {
+          resp = await deps.fetch(url, attemptInit);
+        } finally {
+          if (timeoutId !== null) clearTimeout(timeoutId);
+        }
         lastResponse = resp;
         if (resp.ok) {
-          return readBody(resp);
+          const respBody = await readBody(resp);
+          if (opts.raw) {
+            return {
+              body: respBody,
+              headers: Object.fromEntries(resp.headers.entries()),
+              status: resp.status,
+            } satisfies HttpResponse;
+          }
+          return respBody;
         }
         const willRetry = attempt + 1 < maxAttempts && retryOn.has(resp.status);
         if (!willRetry) {
@@ -237,12 +283,17 @@ export function createHttpGlobal(deps: HttpGlobalDeps): HttpGlobal {
       throw new Error(`http: no attempts made for ${method} ${url}`);
     }
 
-    return Object.freeze({
-      get: (path: string, opts?: HttpRequestOpts) => request('GET', path, opts),
-      post: (path: string, opts?: HttpRequestOpts) => request('POST', path, opts),
-      put: (path: string, opts?: HttpRequestOpts) => request('PUT', path, opts),
-      delete: (path: string, opts?: HttpRequestOpts) => request('DELETE', path, opts),
-    });
+    const client: HttpClient = {
+      get: ((path: string, opts?: HttpRequestOpts) =>
+        request('GET', path, opts)) as HttpClient['get'],
+      post: ((path: string, opts?: HttpRequestOpts) =>
+        request('POST', path, opts)) as HttpClient['post'],
+      put: ((path: string, opts?: HttpRequestOpts) =>
+        request('PUT', path, opts)) as HttpClient['put'],
+      delete: ((path: string, opts?: HttpRequestOpts) =>
+        request('DELETE', path, opts)) as HttpClient['delete'],
+    };
+    return Object.freeze(client);
   }
 
   return Object.freeze({ client: makeClient });

--- a/packages/webapp/src/kernel/realm/js-realm-helpers.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-helpers.ts
@@ -104,10 +104,19 @@ export interface CliDeps {
   color: ColorApi;
 }
 
+export interface CliDieOpts {
+  exitCode?: number;
+  prefix?: string;
+}
+
+export interface CliWarnOpts {
+  prefix?: string;
+}
+
 export interface CliApi {
-  die(msg: unknown, exitCode?: number): never;
+  die(msg: unknown, opts?: number | CliDieOpts): never;
   out(value: unknown): void;
-  warn(msg: unknown): void;
+  warn(msg: unknown, opts?: CliWarnOpts): void;
   help(text: string): never;
 }
 
@@ -122,10 +131,27 @@ export function createCli(deps: CliDeps): CliApi {
       return String(v);
     }
   };
+  const formatPrefixed = (
+    color: (s: string) => string,
+    prefix: string | undefined,
+    text: string
+  ): string => {
+    if (prefix === undefined) return `${color('Error:')} ${text}\n`;
+    if (prefix === '') return `${color(text)}\n`;
+    return `${color(`${prefix}:`)} ${text}\n`;
+  };
+  const formatWarn = (prefix: string | undefined, text: string): string => {
+    if (prefix === undefined) return `${deps.color.yellow('Warning:')} ${text}\n`;
+    if (prefix === '') return `${deps.color.yellow(text)}\n`;
+    return `${deps.color.yellow(`${prefix}:`)} ${text}\n`;
+  };
   return {
-    die(msg: unknown, exitCode: number = 1): never {
+    die(msg: unknown, opts?: number | CliDieOpts): never {
+      const exitCode = typeof opts === 'number' ? opts : (opts?.exitCode ?? 1);
+      const customPrefix =
+        typeof opts === 'object' && opts !== null && 'prefix' in opts ? opts.prefix : undefined;
       const text = toLine(msg);
-      deps.writeStderr(`${deps.color.red('Error:')} ${text}\n`);
+      deps.writeStderr(formatPrefixed(deps.color.red, customPrefix, text));
       deps.exit(exitCode);
       throw new Error('unreachable');
     },
@@ -140,8 +166,10 @@ export function createCli(deps: CliDeps): CliApi {
         deps.writeStdout(`${String(value)}\n`);
       }
     },
-    warn(msg: unknown): void {
-      deps.writeStderr(`${deps.color.yellow('Warning:')} ${toLine(msg)}\n`);
+    warn(msg: unknown, opts?: CliWarnOpts): void {
+      const customPrefix =
+        typeof opts === 'object' && opts !== null && 'prefix' in opts ? opts.prefix : undefined;
+      deps.writeStderr(formatWarn(customPrefix, toLine(msg)));
     },
     help(text: string): never {
       deps.writeStdout(text.endsWith('\n') ? text : `${text}\n`);
@@ -278,7 +306,7 @@ export interface FmtApi {
   trunc(s: string, n: number): string;
   col(s: string, width: number): string;
   table(rows: ReadonlyArray<ReadonlyArray<unknown>>, widths?: ReadonlyArray<number>): string;
-  date(value: Date | string | number, style?: 'short' | 'iso' | 'human'): string;
+  date(value: Date | string | number, style?: 'short' | 'iso' | 'human' | 'locale'): string;
 }
 
 function trunc(s: string, n: number): string {
@@ -336,11 +364,14 @@ function toDate(value: Date | string | number): Date {
 
 function fmtDate(
   value: Date | string | number,
-  style: 'short' | 'iso' | 'human' = 'short'
+  style: 'short' | 'iso' | 'human' | 'locale' = 'short'
 ): string {
   const d = toDate(value);
   if (Number.isNaN(d.getTime())) return String(value);
   if (style === 'iso') return d.toISOString();
+  if (style === 'locale') {
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(d);
+  }
   if (style === 'human') {
     const diff = Date.now() - d.getTime();
     const abs = Math.abs(diff);

--- a/packages/webapp/src/kernel/realm/js-realm-helpers.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-helpers.ts
@@ -1,0 +1,392 @@
+/**
+ * `js-realm-helpers.ts` — pure-JS runtime helpers exposed inside `.jsh`
+ * and `node -e` realms. These globals (`cli`, `c`, `time`, `fmt`, `pool`)
+ * plus `process.argv.parseFlags()` collapse cross-skill boilerplate
+ * identified in the workspace spec at `analyze-skills`.
+ *
+ * The helpers are pure JS — they touch no kernel-side RPC, only the
+ * realm's own stdout/stderr writers and the `exit` function. The
+ * sandbox-iframe variant in `chrome-extension/sandbox.html` mirrors
+ * this surface inline (CSP-isolated bootstrap can't `import` the TS
+ * module). The mirror is kept in lockstep via the parity test in
+ * `tests/kernel/realm/js-realm-helpers.test.ts`.
+ */
+
+export interface ParsedFlags {
+  positional: string[];
+  flags: Record<string, string | boolean | string[]>;
+  subcommand: string | null;
+  passthrough: string[];
+}
+
+/**
+ * Parse `process.argv` style flags. Skips `argv[0]` (node) and `argv[1]`
+ * (script). Handles `--flag=val`, `--flag val`, `-x` (short → boolean),
+ * repeated flags promoting to array, and a trailing `--` separator that
+ * routes remaining args into `passthrough` verbatim. `subcommand` is the
+ * first positional iff it looks like a bareword (matches `/^[a-z][\w-]*$/i`).
+ */
+export function parseFlags(argv: readonly string[]): ParsedFlags {
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean | string[]> = {};
+  const passthrough: string[] = [];
+  const set = (key: string, value: string | boolean): void => {
+    if (key in flags) {
+      const prev = flags[key];
+      if (Array.isArray(prev)) prev.push(String(value));
+      else flags[key] = [String(prev), String(value)];
+    } else {
+      flags[key] = value;
+    }
+  };
+  let i = 2;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === '--') {
+      passthrough.push(...argv.slice(i + 1));
+      break;
+    }
+    if (arg.startsWith('--')) {
+      const body = arg.slice(2);
+      const eq = body.indexOf('=');
+      if (eq !== -1) {
+        set(body.slice(0, eq), body.slice(eq + 1));
+        i++;
+        continue;
+      }
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('-')) {
+        set(body, next);
+        i += 2;
+        continue;
+      }
+      set(body, true);
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-') && arg.length > 1) {
+      for (const ch of arg.slice(1)) set(ch, true);
+      i++;
+      continue;
+    }
+    positional.push(arg);
+    i++;
+  }
+  const subcommand =
+    positional.length > 0 && /^[a-z][\w-]*$/i.test(positional[0]) ? positional[0] : null;
+  return { positional, flags, subcommand, passthrough };
+}
+
+/**
+ * Mutate (or return a fresh array) so `argv.parseFlags()` works on the
+ * realm's `process.argv`. The method is non-enumerable to keep
+ * `[...argv]` / iteration semantics unchanged.
+ */
+export function attachArgvParseFlags(argv: string[]): string[] {
+  const copy = [...argv];
+  Object.defineProperty(copy, 'parseFlags', {
+    value: () => parseFlags(copy),
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  return copy;
+}
+
+// ---------------------------------------------------------------------------
+// `cli` — stderr/stdout/exit helpers replacing the per-skill die/out/warn/help
+// ---------------------------------------------------------------------------
+
+export interface CliDeps {
+  writeStdout: (value: string) => void;
+  writeStderr: (value: string) => void;
+  exit: (code: number) => never;
+  color: ColorApi;
+}
+
+export interface CliApi {
+  die(msg: unknown, exitCode?: number): never;
+  out(value: unknown): void;
+  warn(msg: unknown): void;
+  help(text: string): never;
+}
+
+export function createCli(deps: CliDeps): CliApi {
+  const toLine = (v: unknown): string => {
+    if (typeof v === 'string') return v;
+    if (v instanceof Error) return v.message;
+    if (v === null || v === undefined) return String(v);
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return String(v);
+    }
+  };
+  return {
+    die(msg: unknown, exitCode: number = 1): never {
+      const text = toLine(msg);
+      deps.writeStderr(`${deps.color.red('Error:')} ${text}\n`);
+      deps.exit(exitCode);
+      throw new Error('unreachable');
+    },
+    out(value: unknown): void {
+      if (typeof value === 'string') {
+        deps.writeStdout(value.endsWith('\n') ? value : `${value}\n`);
+        return;
+      }
+      try {
+        deps.writeStdout(`${JSON.stringify(value, null, 2)}\n`);
+      } catch {
+        deps.writeStdout(`${String(value)}\n`);
+      }
+    },
+    warn(msg: unknown): void {
+      deps.writeStderr(`${deps.color.yellow('Warning:')} ${toLine(msg)}\n`);
+    },
+    help(text: string): never {
+      deps.writeStdout(text.endsWith('\n') ? text : `${text}\n`);
+      deps.exit(0);
+      throw new Error('unreachable');
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// `c` — ANSI color helpers; auto-disabled when stdout is not a TTY or
+// `NO_COLOR` is set. The closed surface matches the skills survey:
+// green / red / yellow / gray / bold / cyan / dim.
+// ---------------------------------------------------------------------------
+
+export interface ColorApi {
+  enabled: boolean;
+  green(s: string): string;
+  red(s: string): string;
+  yellow(s: string): string;
+  gray(s: string): string;
+  bold(s: string): string;
+  cyan(s: string): string;
+  dim(s: string): string;
+}
+
+const ANSI = {
+  reset: '\u001b[0m',
+  green: '\u001b[32m',
+  red: '\u001b[31m',
+  yellow: '\u001b[33m',
+  gray: '\u001b[90m',
+  bold: '\u001b[1m',
+  cyan: '\u001b[36m',
+  dim: '\u001b[2m',
+} as const;
+
+export function createColor(opts: { isTTY: boolean; noColor: boolean }): ColorApi {
+  const enabled = opts.isTTY && !opts.noColor;
+  const wrap =
+    (code: string) =>
+    (s: string): string =>
+      enabled ? `${code}${s}${ANSI.reset}` : String(s);
+  return {
+    enabled,
+    green: wrap(ANSI.green),
+    red: wrap(ANSI.red),
+    yellow: wrap(ANSI.yellow),
+    gray: wrap(ANSI.gray),
+    bold: wrap(ANSI.bold),
+    cyan: wrap(ANSI.cyan),
+    dim: wrap(ANSI.dim),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// `time` — duration / date helpers. Unit set matches Gmail's search syntax
+// (`s|m|h|d|w|M|y`) plus an explicit `ms` form. `m` is **minutes** here
+// (the more common interpretation across the surveyed skills); months use
+// `M`. This is documented on the realm global so skills don't have to guess.
+// ---------------------------------------------------------------------------
+
+const DURATION_UNITS_MS: Record<string, number> = {
+  ms: 1,
+  s: 1000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+  M: 2_629_800_000,
+  y: 31_557_600_000,
+};
+
+export interface TimeApi {
+  parseDuration(spec: string | number): number;
+  ago(spec: string | number, from?: Date): Date;
+  range(spec: string | number, from?: Date): { start: Date; end: Date };
+  future(spec: string | number, from?: Date): { start: Date; end: Date };
+  gmailDate(spec: string | number, from?: Date): string;
+}
+
+function parseDuration(spec: string | number): number {
+  if (typeof spec === 'number' && Number.isFinite(spec)) return Math.trunc(spec);
+  if (typeof spec !== 'string')
+    throw new TypeError('time.parseDuration: spec must be string or number');
+  const trimmed = spec.trim();
+  const m = /^([0-9]+(?:\.[0-9]+)?)\s*(ms|s|m|h|d|w|M|y)?$/.exec(trimmed);
+  if (!m) throw new RangeError(`time.parseDuration: unrecognized spec "${spec}"`);
+  const n = Number(m[1]);
+  const unit = (m[2] ?? 'ms') as keyof typeof DURATION_UNITS_MS;
+  return Math.trunc(n * DURATION_UNITS_MS[unit]);
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+export const time: TimeApi = {
+  parseDuration,
+  ago(spec, from = new Date()) {
+    return new Date(from.getTime() - parseDuration(spec));
+  },
+  range(spec, from = new Date()) {
+    const end = new Date(from.getTime());
+    const start = new Date(end.getTime() - parseDuration(spec));
+    return { start, end };
+  },
+  future(spec, from = new Date()) {
+    const start = new Date(from.getTime());
+    const end = new Date(start.getTime() + parseDuration(spec));
+    return { start, end };
+  },
+  gmailDate(spec, from = new Date()) {
+    const d = new Date(from.getTime() - parseDuration(spec));
+    return `${d.getFullYear()}/${pad2(d.getMonth() + 1)}/${pad2(d.getDate())}`;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// `fmt` — ANSI-aware text formatting helpers.
+// ---------------------------------------------------------------------------
+
+const ANSI_RE = /\u001b\[[0-9;]*m/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '');
+}
+
+function visibleLength(s: string): number {
+  return stripAnsi(s).length;
+}
+
+export interface FmtApi {
+  trunc(s: string, n: number): string;
+  col(s: string, width: number): string;
+  table(rows: ReadonlyArray<ReadonlyArray<unknown>>, widths?: ReadonlyArray<number>): string;
+  date(value: Date | string | number, style?: 'short' | 'iso' | 'human'): string;
+}
+
+function trunc(s: string, n: number): string {
+  const text = String(s ?? '');
+  if (n <= 0) return '';
+  if (visibleLength(text) <= n) return text;
+  if (n <= 1) return text.slice(0, n);
+  // Strip ANSI when truncating; callers that want color preserved in
+  // long strings should call `col`/`table` which handle padding only.
+  const plain = stripAnsi(text);
+  return `${plain.slice(0, n - 1)}…`;
+}
+
+function col(s: string, width: number): string {
+  const text = String(s ?? '');
+  const vis = visibleLength(text);
+  if (vis === width) return text;
+  if (vis > width) return trunc(text, width);
+  return text + ' '.repeat(width - vis);
+}
+
+function table(
+  rows: ReadonlyArray<ReadonlyArray<unknown>>,
+  widths?: ReadonlyArray<number>
+): string {
+  if (!rows.length) return '';
+  const colCount = Math.max(...rows.map((r) => r.length));
+  const computed: number[] = [];
+  for (let i = 0; i < colCount; i++) {
+    if (widths && widths[i] !== undefined) {
+      computed[i] = widths[i];
+    } else {
+      let max = 0;
+      for (const r of rows) {
+        const cell = i < r.length ? String(r[i] ?? '') : '';
+        max = Math.max(max, visibleLength(cell));
+      }
+      computed[i] = max;
+    }
+  }
+  return rows
+    .map((r) =>
+      computed
+        .map((w, i) => col(i < r.length ? String(r[i] ?? '') : '', w))
+        .join('  ')
+        .replace(/\s+$/, '')
+    )
+    .join('\n');
+}
+
+function toDate(value: Date | string | number): Date {
+  if (value instanceof Date) return value;
+  return new Date(value);
+}
+
+function fmtDate(
+  value: Date | string | number,
+  style: 'short' | 'iso' | 'human' = 'short'
+): string {
+  const d = toDate(value);
+  if (Number.isNaN(d.getTime())) return String(value);
+  if (style === 'iso') return d.toISOString();
+  if (style === 'human') {
+    const diff = Date.now() - d.getTime();
+    const abs = Math.abs(diff);
+    if (abs < 60_000) return diff >= 0 ? 'just now' : 'in a moment';
+    const tense = (n: number, u: string) =>
+      diff >= 0 ? `${n} ${u}${n === 1 ? '' : 's'} ago` : `in ${n} ${u}${n === 1 ? '' : 's'}`;
+    if (abs < 3_600_000) return tense(Math.round(abs / 60_000), 'minute');
+    if (abs < 86_400_000) return tense(Math.round(abs / 3_600_000), 'hour');
+    if (abs < 2_629_800_000) return tense(Math.round(abs / 86_400_000), 'day');
+    if (abs < 31_557_600_000) return tense(Math.round(abs / 2_629_800_000), 'month');
+    return tense(Math.round(abs / 31_557_600_000), 'year');
+  }
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+export const fmt: FmtApi = { trunc, col, table, date: fmtDate };
+
+// ---------------------------------------------------------------------------
+// `pool` — bounded concurrency runner. `pool(n, items, fn)` resolves to an
+// array of results in input order. `n` is the maximum number of in-flight
+// promises; values < 1 are coerced to 1.
+// ---------------------------------------------------------------------------
+
+export type PoolFn = <T, R>(
+  concurrency: number,
+  items: ReadonlyArray<T>,
+  fn: (item: T, index: number) => Promise<R> | R
+) => Promise<R[]>;
+
+export const pool: PoolFn = async <T, R>(
+  concurrency: number,
+  items: ReadonlyArray<T>,
+  fn: (item: T, index: number) => Promise<R> | R
+): Promise<R[]> => {
+  const n = Math.max(1, Math.trunc(concurrency) || 1);
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workers: Promise<void>[] = [];
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  };
+  for (let w = 0; w < Math.min(n, items.length); w++) workers.push(worker());
+  await Promise.all(workers);
+  return results;
+};

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -23,6 +23,9 @@ import type {
   RealmInitMsg,
   SerializedFetchResponse,
   TabHandle,
+  WsSelector,
+  WsSink,
+  WsSubscriberInfo,
 } from './realm-types.js';
 import {
   LOAD_MODULE_TIMEOUT_MS,
@@ -273,6 +276,7 @@ export async function runJsRealm(
         resolveTargetId(tab),
         buildBrowserFetchScript(url, opts),
       ]) as Promise<BrowserFetchResult>,
+    websocket: createWsObserverApi(rpc),
   };
 
   // `http` is the standard API-client builder; see `http-global.ts`. It
@@ -660,5 +664,97 @@ function normalizeMatchUrl(options: { matchUrl?: string | RegExp }): { matchUrl?
   if (options.matchUrl === undefined) return {};
   return {
     matchUrl: options.matchUrl instanceof RegExp ? options.matchUrl.source : options.matchUrl,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// `browser.websocket` — declarative WebSocket observer
+// ---------------------------------------------------------------------------
+
+/**
+ * Builder for a `browser.websocket.on(tab, opts)` chain. The selector
+ * (`.filter`) and sink (`.forward`) are collected on the builder; the
+ * actual subscriber is created by the await on `.forward(...)`, which
+ * resolves to a {@link WsSubscriberHandle}.
+ */
+interface WsObserverBuilder {
+  filter(selector: WsSelector): WsObserverBuilder;
+  forward(sink: WsSink): Promise<WsSubscriberHandle>;
+}
+
+interface WsSubscriberHandle extends WsSubscriberInfo {
+  update(patch: {
+    urlMatch?: string | RegExp | null;
+    filter?: WsSelector | null;
+  }): Promise<WsSubscriberInfo>;
+  close(): Promise<boolean>;
+}
+
+interface WsObserverApi {
+  on(tab: TabHandle | string, opts?: { urlMatch?: string | RegExp }): WsObserverBuilder;
+  list(): Promise<WsSubscriberInfo[]>;
+}
+
+/**
+ * Construct the realm-side `browser.websocket` chainable API. All
+ * actual work happens host-side; this file just shapes the builder
+ * surface and forwards JSON-safe payloads over the `browser` RPC
+ * channel.
+ */
+function createWsObserverApi(rpc: RealmRpcClient): WsObserverApi {
+  function makeHandle(info: WsSubscriberInfo): WsSubscriberHandle {
+    return {
+      ...info,
+      async update(patch): Promise<WsSubscriberInfo> {
+        const wire: { urlMatch?: string | null; filter?: WsSelector | null } = {};
+        if (patch.urlMatch !== undefined) {
+          wire.urlMatch =
+            patch.urlMatch === null
+              ? null
+              : patch.urlMatch instanceof RegExp
+                ? patch.urlMatch.source
+                : patch.urlMatch;
+        }
+        if (patch.filter !== undefined) wire.filter = patch.filter;
+        return rpc.call<WsSubscriberInfo>('browser', 'wsUpdate', [info.id, wire]);
+      },
+      async close(): Promise<boolean> {
+        return rpc.call<boolean>('browser', 'wsClose', [info.id]);
+      },
+    };
+  }
+
+  return {
+    on(tab, opts = {}) {
+      const targetId = resolveTargetId(tab);
+      const urlMatch =
+        opts.urlMatch === undefined
+          ? undefined
+          : opts.urlMatch instanceof RegExp
+            ? opts.urlMatch.source
+            : opts.urlMatch;
+      let selector: WsSelector | undefined;
+      const builder: WsObserverBuilder = {
+        filter(next) {
+          if (typeof next === 'function' || typeof next === 'string') {
+            throw new TypeError(
+              'browser.websocket: filter must be a declarative JSON object, not a function or string'
+            );
+          }
+          selector = next;
+          return builder;
+        },
+        async forward(sink) {
+          const info = await rpc.call<WsSubscriberInfo>('browser', 'wsObserve', [
+            { targetId, urlMatch, filter: selector, forward: sink },
+          ]);
+          return makeHandle(info);
+        },
+      };
+      return builder;
+    },
+    async list() {
+      return rpc.call<WsSubscriberInfo[]>('browser', 'wsList', []);
+    },
   };
 }

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -18,7 +18,12 @@
  */
 
 import { RealmRpcClient, type RealmPortLike } from './realm-rpc.js';
-import type { RealmDoneMsg, RealmInitMsg, SerializedFetchResponse } from './realm-types.js';
+import type {
+  RealmDoneMsg,
+  RealmInitMsg,
+  SerializedFetchResponse,
+  TabHandle,
+} from './realm-types.js';
 import {
   LOAD_MODULE_TIMEOUT_MS,
   NODE_NATIVE_PACKAGES,
@@ -26,6 +31,7 @@ import {
   withTimeout,
 } from './require-guards.js';
 import { createSkillGlobal } from './skill-global.js';
+import { createHttpGlobal } from './http-global.js';
 import {
   attachArgvParseFlags,
   createCli,
@@ -238,6 +244,34 @@ export async function runJsRealm(
   // store; see `skill-global.ts` for the surface and rationale.
   const skillGlobal = createSkillGlobal({ argv: init.argv, fs: fsBridge, exec: execBridge });
 
+  // `browser` is the kernel-side CDP bridge — wraps the same
+  // BrowserAPI playwright-cli uses, so standalone and extension
+  // floats share one realm surface. Accepts a `TabHandle` (from
+  // `findTab` / `ensureTab`) or a bare `targetId` string for ops
+  // that don't need a fresh listPages round-trip. `eval` / `evalAsync`
+  // serialize functions to a string call expression so realm code
+  // can pass a closure as ergonomically as a string.
+  const browserBridge = {
+    findTab: (query: { domain?: string; urlMatch?: string | RegExp }): Promise<TabHandle | null> =>
+      rpc.call('browser', 'findTab', [normalizeUrlMatchQuery(query)]),
+    ensureTab: (url: string, options: { matchUrl?: string | RegExp } = {}): Promise<TabHandle> =>
+      rpc.call('browser', 'ensureTab', [url, normalizeMatchUrl(options)]),
+    eval: (tab: TabHandle | string, fnOrCode: ((..._args: unknown[]) => unknown) | string) =>
+      rpc.call('browser', 'eval', [resolveTargetId(tab), serializeEvalSource(fnOrCode, false)]),
+    evalAsync: (tab: TabHandle | string, fnOrCode: ((..._args: unknown[]) => unknown) | string) =>
+      rpc.call('browser', 'evalAsync', [resolveTargetId(tab), serializeEvalSource(fnOrCode, true)]),
+    cookie: (tab: TabHandle | string, name: string): Promise<string | null> =>
+      rpc.call('browser', 'cookie', [resolveTargetId(tab), name]),
+    localStorage: (tab: TabHandle | string, key: string): Promise<string | null> =>
+      rpc.call('browser', 'localStorage', [resolveTargetId(tab), key]),
+  };
+
+  // `http` is the standard API-client builder; see `http-global.ts`. It
+  // wraps `realmFetch` so it inherits the kernel-side fetch-proxy + the
+  // secret masking that goes with it. The realm needs only one instance:
+  // `http.client(config)` is what builds the per-API surface.
+  const httpGlobal = createHttpGlobal({ fetch: realmFetch });
+
   async function realmFetch(input: string | URL | Request, opts?: RequestInit): Promise<Response> {
     const url =
       input instanceof Request
@@ -356,6 +390,8 @@ export async function runJsRealm(
       exec: typeof execBridge,
       fetch: typeof realmFetch,
       skill: typeof skillGlobal,
+      http: typeof httpGlobal,
+      browser: typeof browserBridge,
       cli: typeof cliApi,
       c: typeof colorApi,
       timeApi: typeof time,
@@ -372,6 +408,8 @@ export async function runJsRealm(
       'exec',
       'fetch',
       'skill',
+      'http',
+      'browser',
       'cli',
       'c',
       'time',
@@ -389,6 +427,8 @@ export async function runJsRealm(
       execBridge,
       realmFetch,
       skillGlobal,
+      httpGlobal,
+      browserBridge,
       cliApi,
       colorApi,
       time,
@@ -447,4 +487,60 @@ function serializeRequestInit(
 
 async function defaultLoadModule(id: string): Promise<Record<string, unknown>> {
   return (await import(/* @vite-ignore */ 'https://esm.sh/' + id)) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// `browser` global helpers
+// ---------------------------------------------------------------------------
+
+/** Accept either a `TabHandle` (from `findTab`/`ensureTab`) or a bare targetId. */
+function resolveTargetId(tab: TabHandle | string): string {
+  if (typeof tab === 'string') return tab;
+  if (tab && typeof tab === 'object' && typeof tab.targetId === 'string') return tab.targetId;
+  throw new TypeError('browser: expected a tab handle or targetId string');
+}
+
+/**
+ * Serialize a function or string into a self-calling expression
+ * suitable for `Runtime.evaluate`. For functions we emit
+ * `(<fn.toString()>)()` so the page sees an IIFE; for strings we
+ * pass them through verbatim so user-authored snippets keep working.
+ * `awaitPromise` is purely a CDP-side flag — the source string is
+ * the same either way, but we keep the parameter explicit so a
+ * future tweak to wrap async function bodies has a hook.
+ */
+function serializeEvalSource(
+  source: ((..._args: unknown[]) => unknown) | string,
+  _awaitPromise: boolean
+): string {
+  if (typeof source === 'function') {
+    return `(${source.toString()})()`;
+  }
+  if (typeof source === 'string') return source;
+  throw new TypeError('browser.eval/evalAsync: source must be a function or string');
+}
+
+/**
+ * Coerce the realm-side `urlMatch` (RegExp or string) into the
+ * pattern source the host expects. Allowing both lets realm code
+ * write the natural literal-RegExp form without losing the
+ * structured-clone safety of a string crossing the port.
+ */
+function normalizeUrlMatchQuery(query: { domain?: string; urlMatch?: string | RegExp }): {
+  domain?: string;
+  urlMatch?: string;
+} {
+  const out: { domain?: string; urlMatch?: string } = {};
+  if (query.domain !== undefined) out.domain = query.domain;
+  if (query.urlMatch !== undefined) {
+    out.urlMatch = query.urlMatch instanceof RegExp ? query.urlMatch.source : query.urlMatch;
+  }
+  return out;
+}
+
+function normalizeMatchUrl(options: { matchUrl?: string | RegExp }): { matchUrl?: string } {
+  if (options.matchUrl === undefined) return {};
+  return {
+    matchUrl: options.matchUrl instanceof RegExp ? options.matchUrl.source : options.matchUrl,
+  };
 }

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -264,6 +264,15 @@ export async function runJsRealm(
       rpc.call('browser', 'cookie', [resolveTargetId(tab), name]),
     localStorage: (tab: TabHandle | string, key: string): Promise<string | null> =>
       rpc.call('browser', 'localStorage', [resolveTargetId(tab), key]),
+    fetch: (
+      tab: TabHandle | string,
+      url: string,
+      opts: BrowserFetchOptions = {}
+    ): Promise<BrowserFetchResult> =>
+      rpc.call('browser', 'evalAsync', [
+        resolveTargetId(tab),
+        buildBrowserFetchScript(url, opts),
+      ]) as Promise<BrowserFetchResult>,
   };
 
   // `http` is the standard API-client builder; see `http-global.ts`. It
@@ -518,6 +527,115 @@ function serializeEvalSource(
   }
   if (typeof source === 'string') return source;
   throw new TypeError('browser.eval/evalAsync: source must be a function or string');
+}
+
+/**
+ * Options accepted by `browser.fetch(tab, url, opts)`. Mirrors the
+ * `RequestInit` subset that round-trips cleanly as JSON through the
+ * page-context bridge — non-serializable shapes (FormData, Blob,
+ * AbortSignal, ReadableStream) are intentionally out of scope. Body
+ * may be a string (sent verbatim) or any JSON-encodable value (the
+ * bridge stringifies it and defaults Content-Type to application/json).
+ */
+export interface BrowserFetchOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  credentials?: 'include' | 'same-origin' | 'omit';
+  mode?: string;
+  cache?: string;
+  redirect?: string;
+  referrer?: string;
+  referrerPolicy?: string;
+  integrity?: string;
+  keepalive?: boolean;
+}
+
+/**
+ * Structured result returned by `browser.fetch`. `body` is parsed
+ * JSON when the response Content-Type contains `application/json`,
+ * otherwise raw text. Binary responses are out of scope for Wave 3.1
+ * (the script returns the text decoding the page applies).
+ */
+export interface BrowserFetchResult {
+  ok: boolean;
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+/**
+ * Build the self-contained page-context script that `browser.fetch`
+ * injects via `evalAsync`. All request shaping (method/credentials/
+ * headers/body) is baked into the script via `JSON.stringify` so the
+ * page side does nothing but call `fetch()` and assemble the
+ * structured response. Credentials default to `'include'` so session
+ * cookies travel automatically — that's the whole reason
+ * `browser.fetch` exists rather than the realm-side `fetch`. Body
+ * objects become a JSON string and force Content-Type unless the
+ * caller already set one. Plain string bodies are passed through.
+ *
+ * Exported so `realm-iframe`/parity tests can assert the injected
+ * script is a single function (no temp file, no base64 chunking).
+ */
+export function buildBrowserFetchScript(url: string, opts: BrowserFetchOptions = {}): string {
+  const headers: Record<string, string> = {};
+  const rawHeaders = opts.headers ?? {};
+  for (const [k, v] of Object.entries(rawHeaders)) {
+    if (typeof v === 'string') headers[k] = v;
+  }
+  const method = typeof opts.method === 'string' ? opts.method : 'GET';
+  const credentials =
+    opts.credentials === 'same-origin' || opts.credentials === 'omit'
+      ? opts.credentials
+      : 'include';
+  let body: string | undefined;
+  if (opts.body !== undefined && opts.body !== null) {
+    if (typeof opts.body === 'string') {
+      body = opts.body;
+    } else {
+      body = JSON.stringify(opts.body);
+      const hasCt = Object.keys(headers).some((k) => k.toLowerCase() === 'content-type');
+      if (!hasCt) headers['Content-Type'] = 'application/json';
+    }
+  }
+  const init: Record<string, unknown> = { method, credentials, headers };
+  if (body !== undefined) init.body = body;
+  const passthrough = [
+    'mode',
+    'cache',
+    'redirect',
+    'referrer',
+    'referrerPolicy',
+    'integrity',
+    'keepalive',
+  ] as const;
+  for (const k of passthrough) {
+    const v = opts[k];
+    if (v !== undefined) init[k] = v;
+  }
+  // Single self-contained async IIFE — runs entirely in the page,
+  // returns a structured-cloneable object that CDP returnByValue
+  // round-trips back to the realm host as-is. Keep this stringly
+  // typed (no template-literal substitutions inside the function
+  // body) so JSON.stringify is the only escape boundary.
+  return (
+    '(async () => {' +
+    'const r = await fetch(' +
+    JSON.stringify(url) +
+    ', ' +
+    JSON.stringify(init) +
+    ');' +
+    'const h = {};' +
+    'r.headers.forEach((v, k) => { h[k] = v; });' +
+    "const ct = r.headers.get('content-type') || '';" +
+    'let b;' +
+    "if (ct.indexOf('application/json') !== -1) {" +
+    'try { b = await r.json(); } catch (e) { b = await r.text(); }' +
+    '} else { b = await r.text(); }' +
+    'return { ok: r.ok, status: r.status, headers: h, body: b };' +
+    '})()'
+  );
 }
 
 /**

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -25,6 +25,7 @@ import {
   nativePackageError,
   withTimeout,
 } from './require-guards.js';
+import { createSkillGlobal } from './skill-global.js';
 
 const NODE_BUILTINS_UNAVAILABLE = new Set([
   'http',
@@ -192,10 +193,22 @@ export async function runJsRealm(
     },
   };
 
-  const execBridge = (
-    command: string
-  ): Promise<{ stdout: string; stderr: string; exitCode: number }> =>
-    rpc.call('exec', 'run', [command]);
+  // `exec(string)` parses the command through the shell — convenient
+  // for one-liners but punishing for anyone constructing commands
+  // programmatically (the spec called out the bespoke `shellQuote()`
+  // helpers skills kept reinventing). `exec.spawn(argv[])` mirrors
+  // `child_process.spawn(cmd, args)` and bypasses shell parsing on
+  // every arg, killing the quoting-trap class of bugs.
+  type ExecResult = { stdout: string; stderr: string; exitCode: number };
+  const execRun = (command: string): Promise<ExecResult> => rpc.call('exec', 'run', [command]);
+  const execBridge = Object.assign(execRun, {
+    spawn: (argv: string[]): Promise<ExecResult> => rpc.call('exec', 'spawn', [argv]),
+  });
+
+  // `skill` is computed once at boot from argv[1] and frozen. It exposes
+  // the script-relative path helpers and the skill-scoped config/token
+  // store; see `skill-global.ts` for the surface and rationale.
+  const skillGlobal = createSkillGlobal({ argv: init.argv, fs: fsBridge, exec: execBridge });
 
   async function realmFetch(input: string | URL | Request, opts?: RequestInit): Promise<Response> {
     const url =
@@ -313,7 +326,8 @@ export async function runJsRealm(
       module: typeof moduleShim,
       exports: Record<string, unknown>,
       exec: typeof execBridge,
-      fetch: typeof realmFetch
+      fetch: typeof realmFetch,
+      skill: typeof skillGlobal
     ) => Promise<unknown>;
     const fn = new AsyncFn(
       'fs',
@@ -324,6 +338,7 @@ export async function runJsRealm(
       'exports',
       'exec',
       'fetch',
+      'skill',
       `"use strict";\n${init.code}`
     );
     await fn(
@@ -334,7 +349,8 @@ export async function runJsRealm(
       moduleShim,
       moduleShim.exports,
       execBridge,
-      realmFetch
+      realmFetch,
+      skillGlobal
     );
   } catch (err: unknown) {
     if (err instanceof NodeExitError) {

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -26,6 +26,14 @@ import {
   withTimeout,
 } from './require-guards.js';
 import { createSkillGlobal } from './skill-global.js';
+import {
+  attachArgvParseFlags,
+  createCli,
+  createColor,
+  fmt,
+  pool,
+  time,
+} from './js-realm-helpers.js';
 
 const NODE_BUILTINS_UNAVAILABLE = new Set([
   'http',
@@ -155,8 +163,16 @@ export async function runJsRealm(
     },
   };
 
+  // `process.argv` carries a non-enumerable `parseFlags()` method so the
+  // per-skill argv-loop reinvention (~25 LoC × every skill) collapses to a
+  // single call. See `js-realm-helpers.ts` for the spec.
+  const argvWithParseFlags = attachArgvParseFlags(init.argv);
+  // `stdout.isTTY` matches the shell's TTY policy: realm output is captured
+  // and replayed verbatim, so we treat stdout as a TTY unless `NO_COLOR` is
+  // explicitly set in the realm env. The `c` global also honors `NO_COLOR`.
+  const noColor = !!init.env?.NO_COLOR;
   const processShim = {
-    argv: init.argv,
+    argv: argvWithParseFlags,
     env: init.env,
     cwd: () => init.cwd,
     exit: (codeValue?: number) => {
@@ -164,9 +180,21 @@ export async function runJsRealm(
       throw new NodeExitError(normalized);
     },
     stdin: stdinShim,
-    stdout: { write: writeStdout },
-    stderr: { write: writeStderr },
+    stdout: { write: writeStdout, isTTY: !noColor },
+    stderr: { write: writeStderr, isTTY: !noColor },
   };
+
+  // `c` / `cli` are constructed together so cli.die/warn can call into c
+  // without skills having to wire their own colorizer.
+  const colorApi = createColor({ isTTY: !noColor, noColor });
+  const cliApi = createCli({
+    writeStdout,
+    writeStderr,
+    exit: (code: number): never => {
+      throw new NodeExitError(code);
+    },
+    color: colorApi,
+  });
 
   const rpc = new RealmRpcClient(port);
 
@@ -327,7 +355,12 @@ export async function runJsRealm(
       exports: Record<string, unknown>,
       exec: typeof execBridge,
       fetch: typeof realmFetch,
-      skill: typeof skillGlobal
+      skill: typeof skillGlobal,
+      cli: typeof cliApi,
+      c: typeof colorApi,
+      timeApi: typeof time,
+      fmtApi: typeof fmt,
+      poolApi: typeof pool
     ) => Promise<unknown>;
     const fn = new AsyncFn(
       'fs',
@@ -339,6 +372,11 @@ export async function runJsRealm(
       'exec',
       'fetch',
       'skill',
+      'cli',
+      'c',
+      'time',
+      'fmt',
+      'pool',
       `"use strict";\n${init.code}`
     );
     await fn(
@@ -350,7 +388,12 @@ export async function runJsRealm(
       moduleShim.exports,
       execBridge,
       realmFetch,
-      skillGlobal
+      skillGlobal,
+      cliApi,
+      colorApi,
+      time,
+      fmt,
+      pool
     );
   } catch (err: unknown) {
     if (err instanceof NodeExitError) {

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -218,11 +218,28 @@ async function collectTree(
 // ---------------------------------------------------------------------------
 
 async function dispatchExec(op: string, args: unknown[], ctx: CommandContext): Promise<unknown> {
-  if (op !== 'run') throw new Error(`realm-host: unknown exec op '${op}'`);
   if (!ctx.exec) throw new Error('exec is not available in this runtime');
-  const command = args[0] as string;
-  const result = await ctx.exec(command, { cwd: ctx.cwd });
-  return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+  if (op === 'run') {
+    const command = args[0] as string;
+    const result = await ctx.exec(command, { cwd: ctx.cwd });
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+  }
+  if (op === 'spawn') {
+    // Shell-free variant — mirrors `child_process.spawnSync(cmd, args)`.
+    // Passes `argv.slice(1)` through just-bash's `args` option, which
+    // bypasses shell parsing / globbing / quoting entirely. argv[0] is
+    // the bare executable name (no metas) so the shell sees a single
+    // word and the rest are appended verbatim. Eliminates the
+    // `shellQuote()` boilerplate skills used to keep around.
+    const argv = args[0];
+    if (!Array.isArray(argv) || argv.length === 0 || !argv.every((a) => typeof a === 'string')) {
+      throw new Error('exec.spawn: argv must be a non-empty string[]');
+    }
+    const [cmd, ...rest] = argv as string[];
+    const result = await ctx.exec(cmd, { cwd: ctx.cwd, args: rest });
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+  }
+  throw new Error(`realm-host: unknown exec op '${op}'`);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -513,29 +513,51 @@ async function evalInTab(
  * `playwright eval-file` scripts is to `JSON.stringify` the final
  * value so the shell can pipe it cleanly. That puts one or two
  * layers of JSON encoding between the user's value and the realm
- * caller. We peel both transparently so realm code sees the value
- * directly, no `JSON.parse(JSON.parse(...))` ceremony.
+ * caller. We peel only the layers we can prove are wrappers:
+ *
+ *  - If the first parse yields an object/array, the original
+ *    string can only have been `JSON.stringify(obj)` — return it.
+ *  - If the first parse yields a string AND that inner string
+ *    itself starts with `{` or `[`, the original was a double
+ *    `JSON.stringify` — peel one more layer.
+ *  - Otherwise (primitive parses such as `"123"`, `"true"`,
+ *    `"null"`, `"-1.5"`, or a `JSON.stringify("hello")` →
+ *    `"\"hello\""` round-trip), leave the original string alone or
+ *    return the single-unwrapped inner string. Primitives that the
+ *    page returned as strings must keep their string type — losing
+ *    that distinction would silently turn `localStorage.getItem`
+ *    values into numbers/booleans.
  */
 function unwrapEvalResult(value: unknown): unknown {
   if (typeof value !== 'string') return value;
   const first = tryParseJson(value);
   if (first === undefined) return value;
+  if (first !== null && typeof first === 'object') return first;
   if (typeof first === 'string') {
-    const second = tryParseJson(first);
-    return second === undefined ? first : second;
+    // First layer was a stringified string. Only unwrap a second
+    // time when the inner string is itself a stringified
+    // object/array — that's the only shape we can be sure was a
+    // double wrap rather than a deliberate single `JSON.stringify`
+    // of a plain string.
+    const trimmed = first.trim();
+    if (trimmed.length > 0 && (trimmed[0] === '{' || trimmed[0] === '[')) {
+      const second = tryParseJson(first);
+      if (second !== null && typeof second === 'object') return second;
+    }
+    return first;
   }
-  return first;
+  // Primitive (number / boolean / null) — keep the caller's original
+  // string so a page value of `"123"` doesn't become `123`.
+  return value;
 }
 
 function tryParseJson(text: string): unknown {
   const trimmed = text.trim();
   // Cheap heuristic gate: only parse strings that look like a JSON
-  // literal. Avoids accidentally turning `"42"` (a stringified
-  // number a user explicitly wanted as a string) into 42 — every
-  // bare `JSON.stringify(value)` for non-object values still starts
-  // with `"`/`[`/`{` or a digit/`-`/`true`/`false`/`null`. The trim
-  // is necessary because Runtime.evaluate sometimes returns the
-  // wrapped string with leading/trailing whitespace.
+  // literal. The check is intentionally permissive (we still need
+  // to recognize stringified objects, arrays, and strings) — the
+  // result-type discrimination in `unwrapEvalResult` is what
+  // protects primitive payloads from getting unwrapped.
   if (trimmed.length === 0) return undefined;
   const first = trimmed[0];
   const looksJson =

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -13,11 +13,13 @@
  */
 
 import type { CommandContext } from 'just-bash';
+import type { BrowserAPI } from '../../cdp/browser-api.js';
 import type { RealmPortLike } from './realm-rpc.js';
 import type {
   RealmRpcRequest,
   RealmRpcResponse,
   SerializedFetchResponse,
+  TabHandle,
   WalkTreeEntry,
   WriteBatchPayload,
   WriteBatchResult,
@@ -30,17 +32,31 @@ export interface RealmHostHandle {
 }
 
 /**
+ * Optional dependencies injected into the realm host. `browser` is
+ * resolved via this hook for tests; production callers can omit it
+ * and the host falls back to `globalThis.__slicc_browser` (the
+ * BrowserAPI published by `kernel/host.ts` at boot).
+ */
+export interface RealmHostOptions {
+  browser?: BrowserAPI;
+}
+
+/**
  * Attach an RPC server to a realm port. Returns a handle whose
  * `dispose()` removes the listener — the runner calls it when the
  * realm exits or is force-terminated so the port doesn't keep
  * answering after the realm is gone.
  */
-export function attachRealmHost(port: RealmPortLike, ctx: CommandContext): RealmHostHandle {
+export function attachRealmHost(
+  port: RealmPortLike,
+  ctx: CommandContext,
+  opts: RealmHostOptions = {}
+): RealmHostHandle {
   const handler = (event: MessageEvent): void => {
     const data = event.data as { type?: string };
     if (data?.type !== 'realm-rpc-req') return;
     const req = event.data as RealmRpcRequest;
-    void respond(port, req, ctx);
+    void respond(port, req, ctx, opts);
   };
   port.addEventListener('message', handler);
   port.start?.();
@@ -57,10 +73,11 @@ export function attachRealmHost(port: RealmPortLike, ctx: CommandContext): Realm
 async function respond(
   port: RealmPortLike,
   req: RealmRpcRequest,
-  ctx: CommandContext
+  ctx: CommandContext,
+  opts: RealmHostOptions
 ): Promise<void> {
   try {
-    const result = await dispatch(req, ctx);
+    const result = await dispatch(req, ctx, opts);
     const res: RealmRpcResponse = { type: 'realm-rpc-res', id: req.id, result };
     // Body bytes need to be transferred so we don't structured-clone
     // potentially-large response bodies on every fetch.
@@ -73,7 +90,11 @@ async function respond(
   }
 }
 
-async function dispatch(req: RealmRpcRequest, ctx: CommandContext): Promise<unknown> {
+async function dispatch(
+  req: RealmRpcRequest,
+  ctx: CommandContext,
+  opts: RealmHostOptions
+): Promise<unknown> {
   switch (req.channel) {
     case 'vfs':
       return dispatchVfs(req.op, req.args, ctx);
@@ -81,9 +102,25 @@ async function dispatch(req: RealmRpcRequest, ctx: CommandContext): Promise<unkn
       return dispatchExec(req.op, req.args, ctx);
     case 'fetch':
       return dispatchFetch(req.op, req.args, ctx);
+    case 'browser':
+      return dispatchBrowser(req.op, req.args, resolveBrowser(opts));
     default:
       throw new Error(`realm-host: unknown channel '${req.channel}'`);
   }
+}
+
+/**
+ * Resolve the BrowserAPI to use for the `browser` channel. Tests
+ * inject one through `opts`; production paths read the one published
+ * on `globalThis` by `kernel/host.ts`. A missing browser throws a
+ * clear "unavailable in this runtime" error rather than a generic
+ * undefined-method crash.
+ */
+function resolveBrowser(opts: RealmHostOptions): BrowserAPI {
+  if (opts.browser) return opts.browser;
+  const g = globalThis as { __slicc_browser?: BrowserAPI };
+  if (g.__slicc_browser) return g.__slicc_browser;
+  throw new Error('browser is not available in this runtime');
 }
 
 // ---------------------------------------------------------------------------
@@ -273,6 +310,243 @@ async function dispatchFetch(
     body,
     url: response.url,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Channel: browser
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatch a `browser` channel RPC. All ops route through
+ * `BrowserAPI` (the same surface `playwright-command.ts` uses), so
+ * standalone and extension floats share one bridge — only the
+ * underlying CDP transport differs. Tab-scoped ops serialize through
+ * `browser.withTab` so they can't race with the panel terminal's
+ * `playwright` invocations.
+ */
+async function dispatchBrowser(op: string, args: unknown[], browser: BrowserAPI): Promise<unknown> {
+  switch (op) {
+    case 'findTab': {
+      const query = (args[0] as { domain?: string; urlMatch?: string } | undefined) ?? {};
+      return findTab(browser, query);
+    }
+    case 'ensureTab': {
+      const url = args[0] as string;
+      const options = (args[1] as { matchUrl?: string } | undefined) ?? {};
+      return ensureTab(browser, url, options);
+    }
+    case 'eval': {
+      const targetId = args[0] as string;
+      const code = args[1] as string;
+      return evalInTab(browser, targetId, code, false);
+    }
+    case 'evalAsync': {
+      const targetId = args[0] as string;
+      const code = args[1] as string;
+      return evalInTab(browser, targetId, code, true);
+    }
+    case 'cookie': {
+      const targetId = args[0] as string;
+      const name = args[1] as string;
+      return getCookie(browser, targetId, name);
+    }
+    case 'localStorage': {
+      const targetId = args[0] as string;
+      const key = args[1] as string;
+      return getLocalStorage(browser, targetId, key);
+    }
+    default:
+      throw new Error(`realm-host: unknown browser op '${op}'`);
+  }
+}
+
+async function listTabHandles(browser: BrowserAPI): Promise<TabHandle[]> {
+  // `listAllTargets` includes remote tray targets when wired; the
+  // standalone path with no tray transparently falls back to
+  // `listPages`.
+  const pages =
+    typeof browser.listAllTargets === 'function'
+      ? await browser.listAllTargets()
+      : await browser.listPages();
+  return pages.map((p) => ({ targetId: p.targetId, url: p.url, title: p.title }));
+}
+
+async function findTab(
+  browser: BrowserAPI,
+  query: { domain?: string; urlMatch?: string }
+): Promise<TabHandle | null> {
+  const tabs = await listTabHandles(browser);
+  if (query.domain) {
+    const wanted = query.domain.toLowerCase();
+    for (const t of tabs) {
+      const host = safeHostname(t.url);
+      if (host && host.toLowerCase() === wanted) return t;
+    }
+    return null;
+  }
+  if (query.urlMatch) {
+    let re: RegExp;
+    try {
+      re = new RegExp(query.urlMatch);
+    } catch (err) {
+      throw new Error(
+        `browser.findTab: invalid urlMatch regex: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+    for (const t of tabs) {
+      if (re.test(t.url)) return t;
+    }
+    return null;
+  }
+  throw new Error('browser.findTab: query requires `domain` or `urlMatch`');
+}
+
+async function ensureTab(
+  browser: BrowserAPI,
+  url: string,
+  options: { matchUrl?: string }
+): Promise<TabHandle> {
+  // Default match: same origin as the requested URL. Callers can
+  // override with a regex (`matchUrl`) when origin equality is too
+  // loose / tight (e.g. matching a path prefix or a tray target).
+  const tabs = await listTabHandles(browser);
+  if (options.matchUrl) {
+    let re: RegExp;
+    try {
+      re = new RegExp(options.matchUrl);
+    } catch (err) {
+      throw new Error(
+        `browser.ensureTab: invalid matchUrl regex: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+    const hit = tabs.find((t) => re.test(t.url));
+    if (hit) return hit;
+  } else {
+    const wantedOrigin = safeOrigin(url);
+    if (wantedOrigin) {
+      const hit = tabs.find((t) => safeOrigin(t.url) === wantedOrigin);
+      if (hit) return hit;
+    }
+  }
+  const targetId = await browser.createPage(url);
+  // `createPage` returns just the id; build a handle eagerly so the
+  // caller can immediately `browser.eval(tab, ...)` without a second
+  // listPages round-trip. Title may still be empty (the page hasn't
+  // loaded yet) but `url` matches what the caller asked for.
+  return { targetId, url, title: '' };
+}
+
+async function evalInTab(
+  browser: BrowserAPI,
+  targetId: string,
+  code: string,
+  awaitPromise: boolean
+): Promise<unknown> {
+  return browser.withTab(targetId, async () => {
+    const value = await browser.evaluate(code, { awaitPromise, returnByValue: true });
+    return unwrapEvalResult(value);
+  });
+}
+
+/**
+ * Transparent double-JSON unwrap. CDP `Runtime.evaluate` with
+ * `returnByValue: true` already round-trips structured-cloneable
+ * values directly — but the long-standing convention in
+ * `playwright eval-file` scripts is to `JSON.stringify` the final
+ * value so the shell can pipe it cleanly. That puts one or two
+ * layers of JSON encoding between the user's value and the realm
+ * caller. We peel both transparently so realm code sees the value
+ * directly, no `JSON.parse(JSON.parse(...))` ceremony.
+ */
+function unwrapEvalResult(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const first = tryParseJson(value);
+  if (first === undefined) return value;
+  if (typeof first === 'string') {
+    const second = tryParseJson(first);
+    return second === undefined ? first : second;
+  }
+  return first;
+}
+
+function tryParseJson(text: string): unknown {
+  const trimmed = text.trim();
+  // Cheap heuristic gate: only parse strings that look like a JSON
+  // literal. Avoids accidentally turning `"42"` (a stringified
+  // number a user explicitly wanted as a string) into 42 — every
+  // bare `JSON.stringify(value)` for non-object values still starts
+  // with `"`/`[`/`{` or a digit/`-`/`true`/`false`/`null`. The trim
+  // is necessary because Runtime.evaluate sometimes returns the
+  // wrapped string with leading/trailing whitespace.
+  if (trimmed.length === 0) return undefined;
+  const first = trimmed[0];
+  const looksJson =
+    first === '{' ||
+    first === '[' ||
+    first === '"' ||
+    first === '-' ||
+    (first >= '0' && first <= '9') ||
+    trimmed === 'true' ||
+    trimmed === 'false' ||
+    trimmed === 'null';
+  if (!looksJson) return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+async function getCookie(
+  browser: BrowserAPI,
+  targetId: string,
+  name: string
+): Promise<string | null> {
+  return browser.withTab(targetId, async () => {
+    // `Network.getCookies` (no `urls`) returns cookies visible to
+    // the attached page — same surface `playwright cookie-get`
+    // uses, so standalone + extension behave identically.
+    const result = await browser.sendCDP('Network.getCookies');
+    const cookies = (result['cookies'] as Array<{ name?: string; value?: string }>) ?? [];
+    const hit = cookies.find((c) => c.name === name);
+    return hit && typeof hit.value === 'string' ? hit.value : null;
+  });
+}
+
+async function getLocalStorage(
+  browser: BrowserAPI,
+  targetId: string,
+  key: string
+): Promise<string | null> {
+  // Read via in-page evaluate so we hit the same origin's storage
+  // partition the page sees — `DOMStorage.getDOMStorageItems`
+  // requires a frame ID and security origin lookup we'd otherwise
+  // have to plumb, and the evaluate path matches `playwright
+  // eval` semantics.
+  return browser.withTab(targetId, async () => {
+    const raw = await browser.evaluate(
+      `(function(){try{var v=window.localStorage.getItem(${JSON.stringify(key)});return v===null?null:String(v);}catch(e){return null;}})()`,
+      { returnByValue: true }
+    );
+    if (raw === null || raw === undefined) return null;
+    return typeof raw === 'string' ? raw : String(raw);
+  });
+}
+
+function safeHostname(url: string): string | null {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
+}
+
+function safeOrigin(url: string): string | null {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -23,7 +23,11 @@ import type {
   WalkTreeEntry,
   WriteBatchPayload,
   WriteBatchResult,
+  WsObserveRequest,
+  WsSelector,
+  WsSubscriberInfo,
 } from './realm-types.js';
+import type { WsSubscriberRegistry } from './ws-subscribers.js';
 import { createNodeFetchAdapter } from '../../shell/supplemental-commands/node-fetch-adapter.js';
 
 export interface RealmHostHandle {
@@ -39,6 +43,20 @@ export interface RealmHostHandle {
  */
 export interface RealmHostOptions {
   browser?: BrowserAPI;
+  /**
+   * Optional override for the WebSocket subscriber registry used by
+   * `browser.websocket.*`. Production callers omit it and the host
+   * falls back to `globalThis.__slicc_wsSubscribers` (constructed in
+   * `kernel/host.ts`). Tests inject an in-memory registry directly.
+   */
+  wsSubscribers?: WsSubscriberRegistry;
+  /**
+   * Owning scoop's `jid`. Stamped onto every `wsObserve` so the
+   * registry can auto-clean up subscribers on `scoop drop`. Realm
+   * callers cannot supply this themselves — it must come from the
+   * trusted host side.
+   */
+  scoopJid?: string;
 }
 
 /**
@@ -103,7 +121,7 @@ async function dispatch(
     case 'fetch':
       return dispatchFetch(req.op, req.args, ctx);
     case 'browser':
-      return dispatchBrowser(req.op, req.args, resolveBrowser(opts));
+      return dispatchBrowser(req.op, req.args, resolveBrowser(opts), opts);
     default:
       throw new Error(`realm-host: unknown channel '${req.channel}'`);
   }
@@ -121,6 +139,20 @@ function resolveBrowser(opts: RealmHostOptions): BrowserAPI {
   const g = globalThis as { __slicc_browser?: BrowserAPI };
   if (g.__slicc_browser) return g.__slicc_browser;
   throw new Error('browser is not available in this runtime');
+}
+
+/**
+ * Resolve the WS subscriber registry used by `browser.websocket.*`.
+ * Production callers leave `opts.wsSubscribers` unset and the host
+ * picks up the singleton wired in `kernel/host.ts`; tests inject one
+ * directly. Missing registry throws a clear runtime error rather
+ * than crashing with `undefined.observe is not a function`.
+ */
+function resolveWsSubscribers(opts: RealmHostOptions): WsSubscriberRegistry {
+  if (opts.wsSubscribers) return opts.wsSubscribers;
+  const g = globalThis as { __slicc_wsSubscribers?: WsSubscriberRegistry };
+  if (g.__slicc_wsSubscribers) return g.__slicc_wsSubscribers;
+  throw new Error('browser.websocket is not available in this runtime');
 }
 
 // ---------------------------------------------------------------------------
@@ -324,7 +356,12 @@ async function dispatchFetch(
  * `browser.withTab` so they can't race with the panel terminal's
  * `playwright` invocations.
  */
-async function dispatchBrowser(op: string, args: unknown[], browser: BrowserAPI): Promise<unknown> {
+async function dispatchBrowser(
+  op: string,
+  args: unknown[],
+  browser: BrowserAPI,
+  opts: RealmHostOptions
+): Promise<unknown> {
   switch (op) {
     case 'findTab': {
       const query = (args[0] as { domain?: string; urlMatch?: string } | undefined) ?? {};
@@ -354,6 +391,27 @@ async function dispatchBrowser(op: string, args: unknown[], browser: BrowserAPI)
       const targetId = args[0] as string;
       const key = args[1] as string;
       return getLocalStorage(browser, targetId, key);
+    }
+    case 'wsObserve': {
+      // Realm code never supplies the owning scoop — the trusted host
+      // side stamps it from `opts.scoopJid` so the registry's
+      // `dropForScoop(jid)` cleanup hook can find this entry later.
+      const req = { ...(args[0] as WsObserveRequest), scoopJid: opts.scoopJid };
+      const info: WsSubscriberInfo = await resolveWsSubscribers(opts).observe(req);
+      return info;
+    }
+    case 'wsUpdate': {
+      const id = args[0] as string;
+      const patch =
+        (args[1] as { urlMatch?: string | null; filter?: WsSelector | null } | undefined) ?? {};
+      return resolveWsSubscribers(opts).update(id, patch);
+    }
+    case 'wsClose': {
+      const id = args[0] as string;
+      return resolveWsSubscribers(opts).close(id);
+    }
+    case 'wsList': {
+      return resolveWsSubscribers(opts).list();
     }
     default:
       throw new Error(`realm-host: unknown browser op '${op}'`);

--- a/packages/webapp/src/kernel/realm/realm-runner.ts
+++ b/packages/webapp/src/kernel/realm/realm-runner.ts
@@ -135,7 +135,14 @@ export async function runInRealm(opts: RunInRealmOptions): Promise<RealmResult> 
     return { stdout: '', stderr: `realm-runner: ${message}\n`, exitCode: 1 };
   }
 
-  const host: RealmHostHandle = attachRealmHost(realm.controlPort, opts.ctx);
+  // Stamp `scoopJid` onto the host so the `wsObserve` op can tag
+  // every subscriber with its owning scoop. Without this thread,
+  // `Orchestrator.unregisterScoop → dropForScoop(jid)` matches no
+  // subscribers and page routers keep forwarding after the scoop is
+  // gone. The owner record is the single trusted source.
+  const host: RealmHostHandle = attachRealmHost(realm.controlPort, opts.ctx, {
+    ...(opts.owner.scoopJid !== undefined ? { scoopJid: opts.owner.scoopJid } : {}),
+  });
 
   return new Promise<RealmResult>((resolve) => {
     let settled = false;

--- a/packages/webapp/src/kernel/realm/realm-types.ts
+++ b/packages/webapp/src/kernel/realm/realm-types.ts
@@ -188,6 +188,70 @@ export interface WriteBatchResult {
   failedFiles: ReadonlyArray<{ path: string; error: string }>;
 }
 
+/**
+ * Declarative WebSocket frame selector. Skill code never supplies a
+ * `Function` or a string of JS — only a JSON object whose `where` is
+ * a deep-equality template the runtime matches against the parsed
+ * frame body. `parseAs` chooses the parse strategy applied by the
+ * page-side router before matching; `project` optionally narrows the
+ * payload that crosses back to the realm/sinks.
+ */
+export interface WsSelector {
+  /** How the page-side router parses each frame's `data` before matching. */
+  parseAs?: 'json' | 'text';
+  /**
+   * Deep-equality template. Every key/value present in `where` must
+   * match the parsed frame. Missing keys on the frame fail the match.
+   */
+  where?: Record<string, unknown>;
+  /** Project a subset of the parsed object's top-level fields. */
+  project?: readonly string[];
+}
+
+/**
+ * Sanctioned forwarding destinations. Skill code cannot supply an
+ * arbitrary URL — `webhook` is resolved against the existing webhook
+ * registry, `scoop` against the orchestrator, `vfs` against an
+ * allowlisted absolute path, `log` against telemetry.
+ */
+export type WsSink =
+  | { sink: 'webhook'; webhookId: string }
+  | { sink: 'scoop'; scoopJid: string }
+  | { sink: 'vfs'; path: string }
+  | { sink: 'log' };
+
+/**
+ * Args for `browser.wsObserve` (kernel-side op). The realm sends a
+ * fully-resolved request; the host validates the sink, allocates a
+ * subscriber id, and ensures the page-side router is installed.
+ */
+export interface WsObserveRequest {
+  targetId: string;
+  urlMatch?: string;
+  filter?: WsSelector;
+  forward: WsSink;
+  /**
+   * The scoop owning the subscriber. Used for auto-cleanup on
+   * `scoop drop`; supplied by the realm bootstrap from
+   * `init.env.SLICC_SCOOP_JID` when available.
+   */
+  scoopJid?: string;
+}
+
+/**
+ * Public-facing view of an active subscriber, returned by
+ * `browser.websocket.list()`.
+ */
+export interface WsSubscriberInfo {
+  id: string;
+  targetId: string;
+  urlMatch?: string;
+  filter?: WsSelector;
+  forward: WsSink;
+  scoopJid?: string;
+  createdAt: string;
+}
+
 /** Outbound from the realm. */
 export type RealmOutbound = RealmDoneMsg | RealmErrorMsg | RealmRpcRequest | RealmIframeReadyMsg;
 

--- a/packages/webapp/src/kernel/realm/realm-types.ts
+++ b/packages/webapp/src/kernel/realm/realm-types.ts
@@ -77,7 +77,19 @@ export interface RealmErrorMsg {
 }
 
 /** Channels the kernel host exposes to user code. */
-export type RealmRpcChannel = 'vfs' | 'exec' | 'fetch';
+export type RealmRpcChannel = 'vfs' | 'exec' | 'fetch' | 'browser';
+
+/**
+ * Tab handle returned to realm code by `browser.findTab` /
+ * `browser.ensureTab`. A plain object so it round-trips through
+ * structured clone without losing identity — the realm uses
+ * `targetId` to address the tab on subsequent calls.
+ */
+export interface TabHandle {
+  targetId: string;
+  url: string;
+  title: string;
+}
 
 /**
  * Realm → host RPC. Each request gets exactly one matching

--- a/packages/webapp/src/kernel/realm/skill-global.ts
+++ b/packages/webapp/src/kernel/realm/skill-global.ts
@@ -58,12 +58,24 @@ function shellQuote(arg: string): string {
   return "'" + arg.replace(/'/g, "'\\''") + "'";
 }
 
+/**
+ * Join a directory and a child name without producing double slashes
+ * when `dir` is the filesystem root. `dir === ''` is the bare
+ * "no slash in argv" fallback and keeps the relative shape the
+ * pre-PR-786 code shipped.
+ */
+function joinChild(dir: string, name: string): string {
+  if (dir === '') return name;
+  if (dir === '/') return `/${name}`;
+  return `${dir}/${name}`;
+}
+
 export function createSkillGlobal(deps: SkillGlobalDeps): SkillGlobal {
   const scriptPath = deps.argv[1] ?? '';
   const dir = dirname(scriptPath);
-  const refs = dir ? `${dir}/references` : 'references';
-  const assets = dir ? `${dir}/assets` : 'assets';
-  const configPath = dir ? `${dir}/.config` : '.config';
+  const refs = joinChild(dir, 'references');
+  const assets = joinChild(dir, 'assets');
+  const configPath = joinChild(dir, '.config');
 
   async function readConfig(): Promise<Record<string, unknown> | null> {
     let exists: boolean;

--- a/packages/webapp/src/kernel/realm/skill-global.ts
+++ b/packages/webapp/src/kernel/realm/skill-global.ts
@@ -1,0 +1,130 @@
+/**
+ * `skill-global.ts` — the `skill` realm global. Computed once at boot
+ * from `process.argv[1]` and exposed as a frozen object to user code.
+ *
+ * Replaces the ad-hoc `const _SCRIPT_DIR = process.argv[1].substring(
+ * 0, process.argv[1].lastIndexOf('/'))` incantation that concur,
+ * llm-wiki, and oryx each ship today, plus the bespoke per-skill
+ * `.config` JSON readers and OAuth-token fetchers.
+ *
+ * Surface:
+ *  - `skill.dir`     — directory containing the running script
+ *  - `skill.refs`    — `<dir>/references`
+ *  - `skill.assets`  — `<dir>/assets`
+ *  - `skill.config()`            — parsed JSON at `<dir>/.config`, or `null`
+ *  - `skill.config({ key: v })`  — shallow merge + write, returns the merged object
+ *  - `skill.token(providerId)`   — shells out to `oauth-token <id>`
+ *
+ * `skill.token` shells out via the existing `exec` RPC rather than
+ * reaching into the provider registry directly — the realm already has
+ * `exec`, the `oauth-token` command is the single audited surface for
+ * token retrieval, and this keeps the kernel-side wiring trivial.
+ */
+
+export interface SkillFsBridge {
+  readFile(path: string): Promise<string>;
+  writeFile(path: string, content: string): Promise<true>;
+  exists(path: string): Promise<boolean>;
+}
+
+export type SkillExecBridge = (
+  command: string
+) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+
+export interface SkillGlobalDeps {
+  argv: string[];
+  fs: SkillFsBridge;
+  exec: SkillExecBridge;
+}
+
+export interface SkillGlobal {
+  readonly dir: string;
+  readonly refs: string;
+  readonly assets: string;
+  config(updates?: Record<string, unknown>): Promise<Record<string, unknown> | null>;
+  token(providerId: string): Promise<string>;
+}
+
+function dirname(path: string): string {
+  if (!path) return '';
+  const idx = path.lastIndexOf('/');
+  if (idx < 0) return '';
+  if (idx === 0) return '/';
+  return path.substring(0, idx);
+}
+
+function shellQuote(arg: string): string {
+  if (/^[A-Za-z0-9_\-./:@]+$/.test(arg)) return arg;
+  return "'" + arg.replace(/'/g, "'\\''") + "'";
+}
+
+export function createSkillGlobal(deps: SkillGlobalDeps): SkillGlobal {
+  const scriptPath = deps.argv[1] ?? '';
+  const dir = dirname(scriptPath);
+  const refs = dir ? `${dir}/references` : 'references';
+  const assets = dir ? `${dir}/assets` : 'assets';
+  const configPath = dir ? `${dir}/.config` : '.config';
+
+  async function readConfig(): Promise<Record<string, unknown> | null> {
+    let exists: boolean;
+    try {
+      exists = await deps.fs.exists(configPath);
+    } catch {
+      return null;
+    }
+    if (!exists) return null;
+    let raw: string;
+    try {
+      raw = await deps.fs.readFile(configPath);
+    } catch {
+      return null;
+    }
+    const text = typeof raw === 'string' ? raw : String(raw);
+    if (!text.trim()) return null;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`skill.config(): failed to parse ${configPath}: ${msg}`);
+    }
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    throw new Error(`skill.config(): ${configPath} must contain a JSON object`);
+  }
+
+  async function config(
+    updates?: Record<string, unknown>
+  ): Promise<Record<string, unknown> | null> {
+    const existing = await readConfig();
+    if (updates === undefined) return existing;
+    if (updates === null || typeof updates !== 'object' || Array.isArray(updates)) {
+      throw new TypeError('skill.config(updates): updates must be a plain object');
+    }
+    const merged: Record<string, unknown> = { ...(existing ?? {}), ...updates };
+    await deps.fs.writeFile(configPath, JSON.stringify(merged, null, 2) + '\n');
+    return merged;
+  }
+
+  async function token(providerId: string): Promise<string> {
+    if (typeof providerId !== 'string' || !providerId.trim()) {
+      throw new TypeError('skill.token(providerId): providerId must be a non-empty string');
+    }
+    const cmd = `oauth-token ${shellQuote(providerId)}`;
+    const { stdout, stderr, exitCode } = await deps.exec(cmd);
+    if (exitCode !== 0) {
+      const msg = stderr.trim() || `oauth-token exited with code ${exitCode}`;
+      throw new Error(`skill.token('${providerId}'): ${msg}`);
+    }
+    return stdout.replace(/\r?\n+$/, '');
+  }
+
+  return Object.freeze({
+    dir,
+    refs,
+    assets,
+    config,
+    token,
+  });
+}

--- a/packages/webapp/src/kernel/realm/ws-router-page.ts
+++ b/packages/webapp/src/kernel/realm/ws-router-page.ts
@@ -44,9 +44,26 @@ export function installWsRouter(win: typeof globalThis): void {
     id: string;
     urlMatch?: string;
     filter?: Selector;
+    /**
+     * Cached compiled regex for `urlMatch`. `null` means the pattern
+     * failed to compile — silently skip the subscriber (preserves the
+     * pre-cache behavior). `undefined` means no `urlMatch` was set.
+     * Recomputed only on register/update so chatty sockets don't pay
+     * a per-frame `new RegExp(...)`.
+     */
+    _urlMatchRe?: RegExp | null;
   }
 
   const subs = new Map<string, Subscriber>();
+
+  function compileUrlMatch(pattern: string | undefined): RegExp | null | undefined {
+    if (pattern === undefined) return undefined;
+    try {
+      return new RegExp(pattern);
+    } catch {
+      return null;
+    }
+  }
 
   function isPlainObject(v: unknown): v is Record<string, unknown> {
     return typeof v === 'object' && v !== null && !Array.isArray(v);
@@ -91,12 +108,12 @@ export function installWsRouter(win: typeof globalThis): void {
   function dispatchFrame(url: string, raw: string): void {
     if (subs.size === 0) return;
     for (const sub of subs.values()) {
-      if (sub.urlMatch) {
-        try {
-          if (!new RegExp(sub.urlMatch).test(url)) continue;
-        } catch {
-          continue;
-        }
+      if (sub.urlMatch !== undefined) {
+        const re = sub._urlMatchRe;
+        // `null` = pattern failed to compile at register time; skip
+        // this subscriber rather than re-attempting per frame.
+        if (re === null) continue;
+        if (re && !re.test(url)) continue;
       }
       const body = parseFrame(raw, sub.filter?.parseAs);
       if (body === undefined) continue;
@@ -132,12 +149,43 @@ export function installWsRouter(win: typeof globalThis): void {
 
   const router = {
     register(sub: Subscriber): void {
-      subs.set(sub.id, sub);
+      subs.set(sub.id, { ...sub, _urlMatchRe: compileUrlMatch(sub.urlMatch) });
     },
-    update(id: string, sub: Partial<Subscriber>): void {
+    /**
+     * Update an existing subscriber. The patch is tri-state per
+     * field — an explicit `null` clears the field (the host bridge
+     * forwards `sub.update({ filter: null })` as a `null`), absence
+     * leaves it unchanged, and a value sets it. Without the null
+     * branch the router would silently keep the old criterion and
+     * continue matching with stale filter/urlMatch.
+     */
+    update(
+      id: string,
+      patch: {
+        urlMatch?: string | null;
+        filter?: Selector | null;
+      }
+    ): void {
       const cur = subs.get(id);
       if (!cur) return;
-      subs.set(id, { ...cur, ...sub, id });
+      const next: Subscriber = { ...cur, id };
+      if (Object.prototype.hasOwnProperty.call(patch, 'urlMatch')) {
+        if (patch.urlMatch === null) {
+          delete next.urlMatch;
+          next._urlMatchRe = undefined;
+        } else if (typeof patch.urlMatch === 'string') {
+          next.urlMatch = patch.urlMatch;
+          next._urlMatchRe = compileUrlMatch(patch.urlMatch);
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(patch, 'filter')) {
+        if (patch.filter === null) {
+          delete next.filter;
+        } else if (patch.filter !== undefined) {
+          next.filter = patch.filter;
+        }
+      }
+      subs.set(id, next);
     },
     unregister(id: string): void {
       subs.delete(id);

--- a/packages/webapp/src/kernel/realm/ws-router-page.ts
+++ b/packages/webapp/src/kernel/realm/ws-router-page.ts
@@ -1,0 +1,152 @@
+/**
+ * `ws-router-page.ts` — the page-side WebSocket frame router.
+ *
+ * Injected into a target tab once per tab by `WsSubscriberRegistry`
+ * via `Page.addScriptToEvaluateOnNewDocument` (for future loads) and
+ * `Runtime.evaluate` (for the current document). Subsequent
+ * subscribers register selectors with the already-installed router
+ * rather than re-patching the prototype — which is the Wave 4.1
+ * security-review hard rule.
+ *
+ * The script is the runtime's audited replacement for the
+ * skill-injected `WebSocket.prototype.send` patches the security
+ * review flagged in `slack.jsh`. Three properties matter:
+ *  1. It's a single static source — a static scanner can read it
+ *     instead of a string-built blob.
+ *  2. It does NOT observe outbound frames. `WebSocket.prototype.send`
+ *     is hooked purely as a discovery mechanism for new WS instances
+ *     so the inbound `message` listener can be attached.
+ *  3. Skill code never reaches `fetch()` from the third-party origin;
+ *     matched projections cross back to the host via the
+ *     `__sliccWsRouterReport` binding installed via
+ *     `Runtime.addBinding`.
+ */
+
+/**
+ * The router IIFE that runs inside the page. Declared as a function
+ * so unit tests can call `installWsRouter(fakeWindow)` directly; the
+ * production injection path stringifies the function body via
+ * `WS_ROUTER_SOURCE`.
+ *
+ * The function is fully self-contained — no closures over outer
+ * scope — because once stringified it runs in a separate global.
+ */
+export function installWsRouter(win: typeof globalThis): void {
+  const w = win as unknown as Record<string, unknown>;
+  if (w.__sliccWsRouter) return;
+
+  interface Selector {
+    parseAs?: 'json' | 'text';
+    where?: Record<string, unknown>;
+    project?: readonly string[];
+  }
+  interface Subscriber {
+    id: string;
+    urlMatch?: string;
+    filter?: Selector;
+  }
+
+  const subs = new Map<string, Subscriber>();
+
+  function isPlainObject(v: unknown): v is Record<string, unknown> {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+  }
+  function subsetMatch(value: Record<string, unknown>, template: Record<string, unknown>): boolean {
+    for (const k of Object.keys(template)) {
+      const expected = template[k];
+      const actual = value[k];
+      if (isPlainObject(expected)) {
+        if (!isPlainObject(actual)) return false;
+        if (!subsetMatch(actual, expected)) return false;
+        continue;
+      }
+      if (!Object.is(actual, expected)) return false;
+    }
+    return true;
+  }
+  function parseFrame(raw: string, parseAs: 'json' | 'text' | undefined): unknown {
+    if (parseAs === 'text') return raw;
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return undefined;
+    }
+  }
+  function project(body: unknown, fields: readonly string[] | undefined): unknown {
+    if (!fields || fields.length === 0) return body;
+    if (!isPlainObject(body)) return body;
+    const out: Record<string, unknown> = {};
+    for (const f of fields) if (f in body) out[f] = (body as Record<string, unknown>)[f];
+    return out;
+  }
+  function report(subId: string, payload: unknown): void {
+    const reporter = (w as { __sliccWsRouterReport?: (s: string) => void }).__sliccWsRouterReport;
+    if (typeof reporter !== 'function') return;
+    try {
+      reporter(JSON.stringify({ subId, payload }));
+    } catch {
+      /* drop unreportable frame */
+    }
+  }
+  function dispatchFrame(url: string, raw: string): void {
+    if (subs.size === 0) return;
+    for (const sub of subs.values()) {
+      if (sub.urlMatch) {
+        try {
+          if (!new RegExp(sub.urlMatch).test(url)) continue;
+        } catch {
+          continue;
+        }
+      }
+      const body = parseFrame(raw, sub.filter?.parseAs);
+      if (body === undefined) continue;
+      if (sub.filter?.where && Object.keys(sub.filter.where).length > 0) {
+        if (!isPlainObject(body)) continue;
+        if (!subsetMatch(body, sub.filter.where)) continue;
+      }
+      report(sub.id, project(body, sub.filter?.project));
+    }
+  }
+
+  const seen = new WeakSet<WebSocket>();
+  function wrapInstance(ws: WebSocket): void {
+    if (seen.has(ws)) return;
+    seen.add(ws);
+    ws.addEventListener('message', (ev: MessageEvent) => {
+      if (typeof ev.data !== 'string') return;
+      try {
+        dispatchFrame(ws.url, ev.data);
+      } catch {
+        /* never let router errors surface into the page */
+      }
+    });
+  }
+
+  const WS = (win as unknown as { WebSocket?: typeof WebSocket }).WebSocket;
+  if (!WS) return;
+  const origSend = WS.prototype.send;
+  WS.prototype.send = function patchedSend(this: WebSocket, data: unknown): void {
+    wrapInstance(this);
+    return origSend.call(this, data as string);
+  };
+
+  const router = {
+    register(sub: Subscriber): void {
+      subs.set(sub.id, sub);
+    },
+    update(id: string, sub: Partial<Subscriber>): void {
+      const cur = subs.get(id);
+      if (!cur) return;
+      subs.set(id, { ...cur, ...sub, id });
+    },
+    unregister(id: string): void {
+      subs.delete(id);
+    },
+    /** Internal — exposed for tests. */
+    _dispatch: dispatchFrame,
+  };
+  Object.defineProperty(w, '__sliccWsRouter', { value: router, configurable: false });
+}
+
+/** Stringified router source for CDP injection. */
+export const WS_ROUTER_SOURCE = `(${installWsRouter.toString()})(globalThis);`;

--- a/packages/webapp/src/kernel/realm/ws-selector.ts
+++ b/packages/webapp/src/kernel/realm/ws-selector.ts
@@ -1,0 +1,90 @@
+/**
+ * `ws-selector.ts` — declarative WebSocket frame matcher.
+ *
+ * The selector is a JSON object built by skill code. It is NEVER
+ * a function or a string of JS — that's the whole point of the
+ * `browser.websocket` security review: filter logic is statically
+ * inspectable, so a compromised skill can't smuggle code into the
+ * runtime via the filter slot.
+ *
+ * The matcher runs on both sides of the boundary: the page-side
+ * router uses it (inlined into `ws-router-page.ts` as part of the
+ * static IIFE) to drop non-matching frames before they leave the
+ * page; the host uses it (via this module) for unit tests and as a
+ * defense-in-depth re-check in `WsSubscriberRegistry`.
+ */
+
+import type { WsSelector } from './realm-types.js';
+
+export interface ParsedFrame {
+  /** The raw `event.data` string from the WS frame. */
+  raw: string;
+  /** Parsed body — `unknown` after JSON.parse, or `raw` for text. */
+  body: unknown;
+}
+
+/**
+ * Parse a raw frame string according to the selector's `parseAs`.
+ * Returns `null` if parsing fails (the router/host drops the frame).
+ * Defaults to `'json'` because every interception use case so far
+ * (Slack/Teams/LinkedIn) carries JSON frames.
+ */
+export function parseWsFrame(raw: string, selector: WsSelector | undefined): ParsedFrame | null {
+  const parseAs = selector?.parseAs ?? 'json';
+  if (parseAs === 'text') return { raw, body: raw };
+  try {
+    return { raw, body: JSON.parse(raw) };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether `frame.body` satisfies the selector's `where`
+ * template. A missing `where` matches every frame; non-object bodies
+ * never match a non-empty `where`. The comparison is deep-equality
+ * for primitives and recursive subset-match for nested objects.
+ */
+export function matchWsSelector(frame: ParsedFrame, selector: WsSelector | undefined): boolean {
+  const where = selector?.where;
+  if (!where || Object.keys(where).length === 0) return true;
+  if (!isPlainObject(frame.body)) return false;
+  return subsetMatch(frame.body as Record<string, unknown>, where);
+}
+
+/**
+ * Apply `selector.project` to the parsed body, returning only the
+ * named top-level fields. When `project` is missing or empty, returns
+ * the body unchanged. Non-object bodies are returned as-is regardless
+ * of `project` — projection is a no-op for primitive payloads.
+ */
+export function projectWsFrame(frame: ParsedFrame, selector: WsSelector | undefined): unknown {
+  const project = selector?.project;
+  if (!project || project.length === 0) return frame.body;
+  if (!isPlainObject(frame.body)) return frame.body;
+  const src = frame.body as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of project) {
+    if (key in src) out[key] = src[key];
+  }
+  return out;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function subsetMatch(value: Record<string, unknown>, template: Record<string, unknown>): boolean {
+  for (const [key, expected] of Object.entries(template)) {
+    const actual = value[key];
+    if (isPlainObject(expected)) {
+      if (!isPlainObject(actual)) return false;
+      if (!subsetMatch(actual as Record<string, unknown>, expected as Record<string, unknown>)) {
+        return false;
+      }
+      continue;
+    }
+    if (!Object.is(actual, expected)) return false;
+  }
+  return true;
+}

--- a/packages/webapp/src/kernel/realm/ws-subscribers.ts
+++ b/packages/webapp/src/kernel/realm/ws-subscribers.ts
@@ -1,0 +1,252 @@
+/**
+ * `ws-subscribers.ts` — host-side registry + sink dispatcher for the
+ * `browser.websocket` declarative observer (Wave 4.1).
+ *
+ * The registry is the trusted side of the security boundary: it
+ * resolves every `forward.sink` against an audited gate (webhook
+ * registry / orchestrator / VFS allowlist / telemetry log) BEFORE
+ * accepting the subscriber, so a compromised skill cannot smuggle an
+ * arbitrary URL or destination into the runtime. Matched projections
+ * stream in from the page-side router; this module routes each one
+ * to the resolved sink.
+ *
+ * `dropForScoop(jid)` is the auto-cleanup hook the orchestrator
+ * invokes on `unregisterScoop` — every subscriber owned by a dropped
+ * scoop is closed eagerly so the page-side router doesn't keep
+ * forwarding into a dead destination.
+ */
+
+import { createLogger } from '../../core/logger.js';
+import type { WsObserveRequest, WsSelector, WsSubscriberInfo } from './realm-types.js';
+
+const log = createLogger('ws-subscribers');
+
+/**
+ * Abstraction over the page-side router so the registry can be unit
+ * tested without a live CDP transport. Production: backed by the
+ * CDP wiring in `ws-page-bridge-cdp.ts`. Tests: backed by an in-memory
+ * fake.
+ */
+export interface WsPageBridge {
+  /** Ensure the router IIFE is installed on the tab. Idempotent. */
+  installRouter(targetId: string): Promise<void>;
+  registerSelector(
+    targetId: string,
+    subId: string,
+    urlMatch: string | undefined,
+    filter: WsSelector | undefined
+  ): Promise<void>;
+  updateSelector(
+    targetId: string,
+    subId: string,
+    urlMatch: string | undefined,
+    filter: WsSelector | undefined
+  ): Promise<void>;
+  unregisterSelector(targetId: string, subId: string): Promise<void>;
+  /** Forward router→host frame reports to a handler. Returns dispose. */
+  onMatchedFrame(handler: (subId: string, payload: unknown) => void): () => void;
+}
+
+/** Sinks the dispatcher resolves. All four are audited gates. */
+export interface WsSinkDispatcher {
+  webhook(webhookId: string, payload: unknown): Promise<void> | void;
+  scoop(scoopJid: string, payload: unknown): Promise<void> | void;
+  vfs(path: string, payload: unknown): Promise<void> | void;
+  log(payload: unknown): void;
+}
+
+/** Resolves a webhook id against the registry at subscriber creation. */
+export interface WsWebhookResolver {
+  /** Returns truthy iff the id maps to a live webhook entry. */
+  has(id: string): boolean;
+}
+
+export interface WsSubscriberRegistryOptions {
+  bridge: WsPageBridge;
+  webhooks: WsWebhookResolver;
+  dispatcher: WsSinkDispatcher;
+}
+
+/** Internal alias for stored subscriber records (currently identical to the wire shape). */
+type Subscriber = WsSubscriberInfo;
+
+export class WsSubscriberRegistry {
+  private readonly subs = new Map<string, Subscriber>();
+  /** Per-tab refcount so router stays installed while any sub uses it. */
+  private readonly tabRefs = new Map<string, number>();
+  private readonly bridge: WsPageBridge;
+  private readonly webhooks: WsWebhookResolver;
+  private readonly dispatcher: WsSinkDispatcher;
+  private readonly unsubscribeBridge: () => void;
+  private seq = 1;
+
+  constructor(opts: WsSubscriberRegistryOptions) {
+    this.bridge = opts.bridge;
+    this.webhooks = opts.webhooks;
+    this.dispatcher = opts.dispatcher;
+    this.unsubscribeBridge = this.bridge.onMatchedFrame((subId, payload) => {
+      void this.handleFrame(subId, payload);
+    });
+  }
+
+  /** Create a subscriber. Resolves sink before any page-side work. */
+  async observe(req: WsObserveRequest): Promise<WsSubscriberInfo> {
+    this.validateSink(req);
+    const id = `wssub-${this.seq++}-${Date.now().toString(36)}`;
+    const sub: Subscriber = {
+      id,
+      targetId: req.targetId,
+      urlMatch: req.urlMatch,
+      filter: req.filter,
+      forward: req.forward,
+      scoopJid: req.scoopJid,
+      createdAt: new Date().toISOString(),
+    };
+    const refs = this.tabRefs.get(req.targetId) ?? 0;
+    if (refs === 0) await this.bridge.installRouter(req.targetId);
+    this.tabRefs.set(req.targetId, refs + 1);
+    try {
+      await this.bridge.registerSelector(req.targetId, id, req.urlMatch, req.filter);
+    } catch (err) {
+      // Selector registration failed; release the refcount so we don't
+      // leak a stuck install on a dead tab.
+      this.releaseTab(req.targetId);
+      throw err;
+    }
+    this.subs.set(id, sub);
+    return this.toInfo(sub);
+  }
+
+  async update(
+    id: string,
+    patch: { urlMatch?: string | null; filter?: WsSelector | null }
+  ): Promise<WsSubscriberInfo> {
+    const sub = this.subs.get(id);
+    if (!sub) throw new Error(`browser.websocket: subscriber not found: ${id}`);
+    const urlMatch = patch.urlMatch === null ? undefined : (patch.urlMatch ?? sub.urlMatch);
+    const filter = patch.filter === null ? undefined : (patch.filter ?? sub.filter);
+    await this.bridge.updateSelector(sub.targetId, id, urlMatch, filter);
+    sub.urlMatch = urlMatch;
+    sub.filter = filter;
+    return this.toInfo(sub);
+  }
+
+  async close(id: string): Promise<boolean> {
+    const sub = this.subs.get(id);
+    if (!sub) return false;
+    this.subs.delete(id);
+    try {
+      await this.bridge.unregisterSelector(sub.targetId, id);
+    } catch (err) {
+      log.warn('unregisterSelector failed during close', {
+        id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    this.releaseTab(sub.targetId);
+    return true;
+  }
+
+  list(): WsSubscriberInfo[] {
+    return Array.from(this.subs.values(), (s) => this.toInfo(s));
+  }
+
+  /** Auto-cleanup hook called from `Orchestrator.unregisterScoop`. */
+  async dropForScoop(scoopJid: string): Promise<number> {
+    const victims = Array.from(this.subs.values()).filter((s) => s.scoopJid === scoopJid);
+    for (const v of victims) {
+      await this.close(v.id);
+    }
+    return victims.length;
+  }
+
+  dispose(): void {
+    this.unsubscribeBridge();
+    this.subs.clear();
+    this.tabRefs.clear();
+  }
+
+  private validateSink(req: WsObserveRequest): void {
+    const sink = req.forward;
+    if (!sink || typeof sink !== 'object') {
+      throw new Error('browser.websocket: forward.sink is required');
+    }
+    switch (sink.sink) {
+      case 'webhook':
+        if (typeof sink.webhookId !== 'string' || !sink.webhookId.trim()) {
+          throw new Error('browser.websocket: webhook sink requires a webhookId');
+        }
+        if (!this.webhooks.has(sink.webhookId)) {
+          throw new Error(
+            `browser.websocket: webhookId "${sink.webhookId}" is not registered; create it with \`webhook create\` first`
+          );
+        }
+        return;
+      case 'scoop':
+        if (typeof sink.scoopJid !== 'string' || !sink.scoopJid.trim()) {
+          throw new Error('browser.websocket: scoop sink requires a scoopJid');
+        }
+        return;
+      case 'vfs':
+        if (typeof sink.path !== 'string' || !sink.path.startsWith('/workspace/')) {
+          throw new Error(
+            'browser.websocket: vfs sink path must be an absolute /workspace/... path'
+          );
+        }
+        return;
+      case 'log':
+        return;
+      default:
+        throw new Error(
+          `browser.websocket: unknown sink "${(sink as { sink?: string }).sink ?? ''}"`
+        );
+    }
+  }
+
+  private releaseTab(targetId: string): void {
+    const refs = (this.tabRefs.get(targetId) ?? 1) - 1;
+    if (refs <= 0) this.tabRefs.delete(targetId);
+    else this.tabRefs.set(targetId, refs);
+  }
+
+  private toInfo(s: Subscriber): WsSubscriberInfo {
+    const info: WsSubscriberInfo = {
+      id: s.id,
+      targetId: s.targetId,
+      forward: s.forward,
+      createdAt: s.createdAt,
+    };
+    if (s.urlMatch !== undefined) info.urlMatch = s.urlMatch;
+    if (s.filter !== undefined) info.filter = s.filter;
+    if (s.scoopJid !== undefined) info.scoopJid = s.scoopJid;
+    return info;
+  }
+
+  private async handleFrame(subId: string, payload: unknown): Promise<void> {
+    const sub = this.subs.get(subId);
+    if (!sub) return;
+    const sink = sub.forward;
+    try {
+      switch (sink.sink) {
+        case 'webhook':
+          await this.dispatcher.webhook(sink.webhookId, payload);
+          return;
+        case 'scoop':
+          await this.dispatcher.scoop(sink.scoopJid, payload);
+          return;
+        case 'vfs':
+          await this.dispatcher.vfs(sink.path, payload);
+          return;
+        case 'log':
+          this.dispatcher.log(payload);
+          return;
+      }
+    } catch (err) {
+      log.warn('sink dispatch failed', {
+        subId,
+        sink: sink.sink,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/packages/webapp/src/kernel/realm/ws-subscribers.ts
+++ b/packages/webapp/src/kernel/realm/ws-subscribers.ts
@@ -17,6 +17,7 @@
  */
 
 import { createLogger } from '../../core/logger.js';
+import { normalizePath } from '../../fs/path-utils.js';
 import type { WsObserveRequest, WsSelector, WsSubscriberInfo } from './realm-types.js';
 
 const log = createLogger('ws-subscribers');
@@ -36,11 +37,19 @@ export interface WsPageBridge {
     urlMatch: string | undefined,
     filter: WsSelector | undefined
   ): Promise<void>;
+  /**
+   * Update an existing selector. The `urlMatch` / `filter`
+   * arguments are tri-state: `undefined` means "leave unchanged",
+   * `null` means "explicitly clear", a value means "set". The
+   * page-side router needs the clear directive distinct from
+   * absence so it can `delete` the field rather than silently
+   * keep stale criteria.
+   */
   updateSelector(
     targetId: string,
     subId: string,
-    urlMatch: string | undefined,
-    filter: WsSelector | undefined
+    urlMatch: string | null | undefined,
+    filter: WsSelector | null | undefined
   ): Promise<void>;
   unregisterSelector(targetId: string, subId: string): Promise<void>;
   /** Forward router→host frame reports to a handler. Returns dispose. */
@@ -123,11 +132,16 @@ export class WsSubscriberRegistry {
   ): Promise<WsSubscriberInfo> {
     const sub = this.subs.get(id);
     if (!sub) throw new Error(`browser.websocket: subscriber not found: ${id}`);
-    const urlMatch = patch.urlMatch === null ? undefined : (patch.urlMatch ?? sub.urlMatch);
-    const filter = patch.filter === null ? undefined : (patch.filter ?? sub.filter);
-    await this.bridge.updateSelector(sub.targetId, id, urlMatch, filter);
-    sub.urlMatch = urlMatch;
-    sub.filter = filter;
+    // Forward the explicit `null` sentinel through so the page-side
+    // router knows to delete the field; `undefined` means "leave the
+    // current selector criterion in place".
+    const urlMatchUpdate: string | null | undefined = patch.urlMatch;
+    const filterUpdate: WsSelector | null | undefined = patch.filter;
+    await this.bridge.updateSelector(sub.targetId, id, urlMatchUpdate, filterUpdate);
+    if (patch.urlMatch === null) delete sub.urlMatch;
+    else if (patch.urlMatch !== undefined) sub.urlMatch = patch.urlMatch;
+    if (patch.filter === null) delete sub.filter;
+    else if (patch.filter !== undefined) sub.filter = patch.filter;
     return this.toInfo(sub);
   }
 
@@ -187,13 +201,24 @@ export class WsSubscriberRegistry {
           throw new Error('browser.websocket: scoop sink requires a scoopJid');
         }
         return;
-      case 'vfs':
+      case 'vfs': {
         if (typeof sink.path !== 'string' || !sink.path.startsWith('/workspace/')) {
           throw new Error(
             'browser.websocket: vfs sink path must be an absolute /workspace/... path'
           );
         }
+        // Re-normalize after the prefix check so traversal payloads
+        // like `/workspace/../etc/passwd` (which the VFS would later
+        // collapse to `/etc/passwd` at write time) are rejected at
+        // observe() time rather than silently escaping the sandbox.
+        const normalized = normalizePath(sink.path);
+        if (!normalized.startsWith('/workspace/') && normalized !== '/workspace') {
+          throw new Error(
+            `browser.websocket: vfs sink path escapes /workspace/ after normalization (got "${sink.path}" → "${normalized}")`
+          );
+        }
         return;
+      }
       case 'log':
         return;
       default:

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -1330,6 +1330,21 @@ export class Orchestrator {
     // Snapshot cost data before destroying context
     this.snapshotScoopCost(jid);
 
+    // Auto-cleanup any `browser.websocket` subscribers owned by this
+    // scoop — keeps the page-side router from forwarding into a dead
+    // sink. Best-effort; never blocks tear-down.
+    const wsSubs = (
+      globalThis as { __slicc_wsSubscribers?: { dropForScoop: (j: string) => Promise<number> } }
+    ).__slicc_wsSubscribers;
+    if (wsSubs) {
+      void wsSubs.dropForScoop(jid).catch((err) => {
+        log.warn('dropForScoop (ws subscribers) failed', {
+          jid,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+
     this.clearIdleTimer(jid);
     await this.destroyScoopTab(jid);
     this.sessionStore?.delete(jid).catch((err) => {

--- a/packages/webapp/tests/cdp/cdp-ws-page-bridge.test.ts
+++ b/packages/webapp/tests/cdp/cdp-ws-page-bridge.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Integration smoke for the Wave 4.2 CDP page-bridge adapter.
+ *
+ * Drives `CdpWsPageBridge` against a fake `BrowserAPI` whose
+ * transport records CDP traffic and replays binding-called events,
+ * verifying:
+ *  - `Page.addScriptToEvaluateOnNewDocument` is called with the
+ *    static `WS_ROUTER_SOURCE`.
+ *  - `Runtime.addBinding` registers the `__sliccWsRouterReport`
+ *    callback.
+ *  - `Runtime.bindingCalled` events are decoded into
+ *    `(subId, payload)` and routed to the registry's matched-frame
+ *    handler, which then dispatches to the resolved webhook sink
+ *    end-to-end.
+ *  - `register`/`update`/`unregister` map to in-page
+ *    `__sliccWsRouter.*` calls via `Runtime.evaluate`.
+ */
+import { describe, it, expect } from 'vitest';
+import { CdpWsPageBridge } from '../../src/cdp/cdp-ws-page-bridge.js';
+import {
+  WsSubscriberRegistry,
+  type WsSinkDispatcher,
+  type WsWebhookResolver,
+} from '../../src/kernel/realm/ws-subscribers.js';
+import { WS_ROUTER_SOURCE } from '../../src/kernel/realm/ws-router-page.js';
+import type { CDPTransport } from '../../src/cdp/transport.js';
+import type { CDPEventListener, ConnectionState, CDPConnectOptions } from '../../src/cdp/types.js';
+import type { BrowserAPI } from '../../src/cdp/browser-api.js';
+
+class FakeTransport implements CDPTransport {
+  state: ConnectionState = 'connected';
+  private listeners = new Map<string, Set<CDPEventListener>>();
+  public sent: Array<{ method: string; params?: Record<string, unknown> }> = [];
+
+  async connect(_o?: CDPConnectOptions): Promise<void> {}
+  disconnect(): void {}
+  async send(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>> {
+    this.sent.push({ method, params });
+    if (method === 'Page.addScriptToEvaluateOnNewDocument') return { identifier: 'init-1' };
+    return {};
+  }
+  on(event: string, listener: CDPEventListener): void {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+  }
+  off(event: string, listener: CDPEventListener): void {
+    this.listeners.get(event)?.delete(listener);
+  }
+  async once(): Promise<Record<string, unknown>> {
+    return {};
+  }
+  emit(event: string, params: Record<string, unknown>): void {
+    this.listeners.get(event)?.forEach((l) => l(params));
+  }
+}
+
+function makeFakeBrowser(transport: FakeTransport): BrowserAPI {
+  return {
+    getTransport: () => transport,
+    async withTab<T>(_targetId: string, fn: (sessionId: string) => Promise<T>): Promise<T> {
+      return fn('session-fake');
+    },
+    async sendCDP(method: string, params: Record<string, unknown> = {}) {
+      return transport.send(method, params, 'session-fake');
+    },
+  } as unknown as BrowserAPI;
+}
+
+function makeWebhooks(ids: string[]): WsWebhookResolver {
+  return { has: (id) => ids.includes(id) };
+}
+
+function makeDispatcher(): WsSinkDispatcher & {
+  webhookCalls: Array<{ id: string; payload: unknown }>;
+} {
+  const webhookCalls: Array<{ id: string; payload: unknown }> = [];
+  return {
+    webhookCalls,
+    webhook(id, payload) {
+      webhookCalls.push({ id, payload });
+    },
+    scoop() {},
+    vfs() {},
+    log() {},
+  };
+}
+
+describe('CdpWsPageBridge', () => {
+  it('installs the runtime-owned router via Page.addScriptToEvaluateOnNewDocument + Runtime.addBinding', async () => {
+    const transport = new FakeTransport();
+    const browser = makeFakeBrowser(transport);
+    const bridge = new CdpWsPageBridge({ browser });
+
+    await bridge.installRouter('target-1');
+    await bridge.installRouter('target-1'); // idempotent: second call must not re-issue CDP traffic.
+
+    const methods = transport.sent.map((c) => c.method);
+    expect(methods).toEqual([
+      'Runtime.enable',
+      'Runtime.addBinding',
+      'Page.addScriptToEvaluateOnNewDocument',
+      'Runtime.evaluate',
+    ]);
+    const addBinding = transport.sent[1]!;
+    expect(addBinding.params).toEqual({ name: '__sliccWsRouterReport' });
+    const addInit = transport.sent[2]!;
+    expect(addInit.params?.['source']).toBe(WS_ROUTER_SOURCE);
+    bridge.dispose();
+  });
+
+  it('routes Runtime.bindingCalled into the matched-frame handler and out to the resolved webhook sink', async () => {
+    const transport = new FakeTransport();
+    const browser = makeFakeBrowser(transport);
+    const bridge = new CdpWsPageBridge({ browser });
+    const dispatcher = makeDispatcher();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks(['wh-1']),
+      dispatcher,
+    });
+    const sub = await reg.observe({
+      targetId: 't1',
+      forward: { sink: 'webhook', webhookId: 'wh-1' },
+    });
+
+    // The page-side router would call __sliccWsRouterReport(JSON.stringify({subId, payload})).
+    transport.emit('Runtime.bindingCalled', {
+      name: '__sliccWsRouterReport',
+      payload: JSON.stringify({ subId: sub.id, payload: { type: 'message', text: 'hi' } }),
+    });
+    // Dispatch is async (registry calls await on the dispatcher); flush microtasks.
+    await Promise.resolve();
+    expect(dispatcher.webhookCalls).toEqual([
+      { id: 'wh-1', payload: { type: 'message', text: 'hi' } },
+    ]);
+    // Bindings for unrelated names must be ignored.
+    transport.emit('Runtime.bindingCalled', {
+      name: 'someOtherBinding',
+      payload: JSON.stringify({ subId: sub.id, payload: { x: 1 } }),
+    });
+    await Promise.resolve();
+    expect(dispatcher.webhookCalls).toHaveLength(1);
+    bridge.dispose();
+  });
+
+  it('maps register/update/unregister to in-page __sliccWsRouter calls via Runtime.evaluate', async () => {
+    const transport = new FakeTransport();
+    const browser = makeFakeBrowser(transport);
+    const bridge = new CdpWsPageBridge({ browser });
+
+    await bridge.installRouter('target-1');
+    transport.sent.length = 0;
+    await bridge.registerSelector('target-1', 'sub-1', 'wss://example/', { where: { a: 1 } });
+    await bridge.updateSelector('target-1', 'sub-1', undefined, { where: { a: 2 } });
+    await bridge.unregisterSelector('target-1', 'sub-1');
+    const exprs = transport.sent
+      .filter((c) => c.method === 'Runtime.evaluate')
+      .map((c) => c.params?.['expression']);
+    expect(exprs[0]).toContain('__sliccWsRouter');
+    expect(exprs[0]).toContain('.register(');
+    expect(exprs[0]).toContain('"sub-1"');
+    expect(exprs[1]).toContain('.update(');
+    expect(exprs[2]).toContain('.unregister(');
+    bridge.dispose();
+  });
+});

--- a/packages/webapp/tests/kernel/realm/browser-fetch.test.ts
+++ b/packages/webapp/tests/kernel/realm/browser-fetch.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for `browser.fetch(tab, url, opts)` — Wave 3.1. Verifies the
+ * page-context script the bridge injects via `evalAsync` is a single
+ * self-contained function (no temp-file, no base64 chunking, no
+ * realm-side closures) and that the response shape matches the spec.
+ *
+ * The realm-side bridge calls `browser.evalAsync(targetId, script)`
+ * under the hood. Tests capture the injected script via a custom
+ * mock `evaluate`, returning a synthetic structured response so the
+ * round-trip through `unwrapEvalResult` is exercised end-to-end.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CommandContext, IFileSystem, FsStat } from 'just-bash';
+import type { BrowserAPI } from '../../../src/cdp/browser-api.js';
+import { RealmRpcClient, type RealmPortLike } from '../../../src/kernel/realm/realm-rpc.js';
+import { attachRealmHost } from '../../../src/kernel/realm/realm-host.js';
+import {
+  buildBrowserFetchScript,
+  type BrowserFetchResult,
+} from '../../../src/kernel/realm/js-realm-shared.js';
+
+describe('buildBrowserFetchScript — page-context script shape', () => {
+  it('emits a single self-calling async IIFE (no temp file, no base64)', () => {
+    const script = buildBrowserFetchScript('/api/x');
+    expect(script.startsWith('(async () => {')).toBe(true);
+    expect(script.endsWith('})()')).toBe(true);
+    expect(script).toContain('await fetch(');
+    // Defensive: the dance the spec calls out as fragile (temp-file
+    // write + base64 chunking) must not appear in the injected page
+    // script. Catches accidental regressions to the old shape.
+    expect(script).not.toMatch(/writeFile|fs\.|base64|btoa\(|atob\(/);
+    // Single function — no semicolons separating top-level
+    // statements outside the IIFE.
+    expect(script.match(/^\(async \(\) => \{/g)?.length).toBe(1);
+  });
+
+  it('defaults credentials to "include" so session cookies travel', () => {
+    const script = buildBrowserFetchScript('/api/x');
+    expect(script).toContain('"credentials":"include"');
+  });
+
+  it('honors explicit credentials override (same-origin / omit)', () => {
+    expect(buildBrowserFetchScript('/x', { credentials: 'same-origin' })).toContain(
+      '"credentials":"same-origin"'
+    );
+    expect(buildBrowserFetchScript('/x', { credentials: 'omit' })).toContain(
+      '"credentials":"omit"'
+    );
+  });
+
+  it('serializes a plain-object body as JSON and sets Content-Type', () => {
+    const script = buildBrowserFetchScript('/api/conversations.list', {
+      method: 'POST',
+      body: { channel: 'C123' },
+    });
+    expect(script).toContain('"method":"POST"');
+    expect(script).toContain('"Content-Type":"application/json"');
+    expect(script).toContain('"body":"{\\"channel\\":\\"C123\\"}"');
+  });
+
+  it('preserves caller-provided Content-Type for non-object bodies', () => {
+    const script = buildBrowserFetchScript('/api/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: 'a=1&b=2',
+    });
+    // String body passes through verbatim, no auto Content-Type.
+    expect(script).toContain('"body":"a=1&b=2"');
+    expect(script).toContain('"content-type":"application/x-www-form-urlencoded"');
+    expect(script).not.toContain('"Content-Type":"application/json"');
+  });
+
+  it('preserves custom request headers in both directions', () => {
+    const script = buildBrowserFetchScript('/api/x', {
+      headers: { Authorization: 'Bearer abc', 'X-Custom': 'v' },
+    });
+    expect(script).toContain('"Authorization":"Bearer abc"');
+    expect(script).toContain('"X-Custom":"v"');
+  });
+
+  it('safely escapes adversarial url + body content via JSON encoding', () => {
+    // Defends against a malicious url breaking out of the injected
+    // string. JSON.stringify is the only escape boundary.
+    const url = '"</script><script>alert(1)</script>';
+    const script = buildBrowserFetchScript(url, { body: { x: '"); alert(1); //' } });
+    // Both must round-trip through JSON.parse(<extracted>) cleanly.
+    const urlMatch = /await fetch\((".*?"),/.exec(script);
+    expect(urlMatch).not.toBeNull();
+    expect(JSON.parse(urlMatch![1])).toBe(url);
+  });
+
+  it('returns parsed JSON / text / headers via the page-side script', async () => {
+    // Execute the script in-process: it only references `fetch` and
+    // a Response-like surface, so a thin stub is enough to drive
+    // the entire response-assembly branch without a real browser.
+    const fakeResponse = {
+      ok: true,
+      status: 200,
+      headers: new Map<string, string>([['content-type', 'application/json']]),
+    };
+    const headersStub = {
+      forEach: (cb: (v: string, k: string) => void) => {
+        for (const [k, v] of fakeResponse.headers) cb(v, k);
+      },
+      get: (k: string) => fakeResponse.headers.get(k.toLowerCase()) ?? null,
+    };
+    const captured: { url?: string; init?: RequestInit } = {};
+    const fakeFetch = async (u: string, init: RequestInit) => {
+      captured.url = u;
+      captured.init = init;
+      return {
+        ok: fakeResponse.ok,
+        status: fakeResponse.status,
+        headers: headersStub,
+        json: async () => ({ hello: 'world' }),
+        text: async () => '{"hello":"world"}',
+      };
+    };
+    const script = buildBrowserFetchScript('/api/x', {
+      method: 'POST',
+      body: { channel: 'C1' },
+    });
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.headers).toEqual({ 'content-type': 'application/json' });
+    expect(result.body).toEqual({ hello: 'world' });
+    expect(captured.url).toBe('/api/x');
+    expect(captured.init?.method).toBe('POST');
+    expect((captured.init?.headers as Record<string, string>)['Content-Type']).toBe(
+      'application/json'
+    );
+    expect(captured.init?.credentials).toBe('include');
+    expect(captured.init?.body).toBe('{"channel":"C1"}');
+  });
+
+  it('falls back to text when content-type is not JSON', async () => {
+    const headersStub = {
+      forEach: (cb: (v: string, k: string) => void) => cb('text/html', 'content-type'),
+      get: (k: string) => (k.toLowerCase() === 'content-type' ? 'text/html' : null),
+    };
+    const fakeFetch = async () => ({
+      ok: true,
+      status: 200,
+      headers: headersStub,
+      text: async () => '<html></html>',
+      json: async () => {
+        throw new Error('should not be called');
+      },
+    });
+    const script = buildBrowserFetchScript('/page');
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.body).toBe('<html></html>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: realm-side bridge → RPC → host → mock browser.evaluate
+// ---------------------------------------------------------------------------
+
+interface PortPair {
+  realm: RealmPortLike;
+  host: RealmPortLike;
+}
+
+function makePortPair(): PortPair {
+  const realmListeners = new Set<(event: MessageEvent) => void>();
+  const hostListeners = new Set<(event: MessageEvent) => void>();
+  const realm: RealmPortLike = {
+    postMessage: (msg) => {
+      for (const h of [...hostListeners]) h({ data: msg } as MessageEvent);
+    },
+    addEventListener: (_t, h) => {
+      realmListeners.add(h);
+    },
+    removeEventListener: (_t, h) => {
+      realmListeners.delete(h);
+    },
+  };
+  const host: RealmPortLike = {
+    postMessage: (msg) => {
+      for (const h of [...realmListeners]) h({ data: msg } as MessageEvent);
+    },
+    addEventListener: (_t, h) => {
+      hostListeners.add(h);
+    },
+    removeEventListener: (_t, h) => {
+      hostListeners.delete(h);
+    },
+  };
+  return { realm, host };
+}
+
+function makeNoopFs(): IFileSystem {
+  const stub = async (): Promise<never> => {
+    throw new Error('not implemented');
+  };
+  return {
+    readFile: stub,
+    readFileBuffer: stub,
+    writeFile: stub,
+    appendFile: stub,
+    exists: async () => false,
+    stat: stub as unknown as (p: string) => Promise<FsStat>,
+    mkdir: stub,
+    readdir: async () => [],
+    rm: stub,
+    cp: stub,
+    mv: stub,
+    resolvePath: (base, p) => (p.startsWith('/') ? p : `${base}/${p}`),
+    getAllPaths: () => [],
+    chmod: stub,
+    symlink: stub,
+    link: stub,
+    readlink: stub,
+    lstat: stub as unknown as (p: string) => Promise<FsStat>,
+    realpath: async (p: string) => p,
+    utimes: stub,
+  } as unknown as IFileSystem;
+}
+
+describe('realm RPC: browser.fetch — round-trip through evalAsync', () => {
+  it('captures the injected script and returns the structured response', async () => {
+    const captured: string[] = [];
+    const cannedResponse: BrowserFetchResult = {
+      ok: true,
+      status: 201,
+      headers: { 'content-type': 'application/json', 'x-trace': 'abc' },
+      body: { ok: true, channel: 'C123' },
+    };
+    const browser = {
+      async withTab<T>(_targetId: string, fn: () => Promise<T>): Promise<T> {
+        return fn();
+      },
+      async evaluate(expression: string): Promise<unknown> {
+        captured.push(expression);
+        // Return the structured-clone shape browser.fetch promises;
+        // unwrapEvalResult passes objects through untouched.
+        return cannedResponse;
+      },
+    } as unknown as BrowserAPI;
+
+    const ctx = {
+      fs: makeNoopFs(),
+      cwd: '/workspace',
+      env: new Map(),
+      stdin: '',
+    } as CommandContext;
+    const { realm, host } = makePortPair();
+    const handle = attachRealmHost(host, ctx, { browser });
+    const client = new RealmRpcClient(realm);
+    try {
+      // Mirror what `browserBridge.fetch` does internally: build the
+      // page-context script and dispatch through evalAsync.
+      const script = buildBrowserFetchScript('/api/post', {
+        method: 'POST',
+        body: { channel: 'C123' },
+      });
+      const result = await client.call<BrowserFetchResult>('browser', 'evalAsync', ['t1', script]);
+      expect(result).toEqual(cannedResponse);
+      expect(captured).toHaveLength(1);
+      // The script the host evaluated must be exactly the one we built —
+      // no realm-side mutation, no JSON.parse(JSON.parse(...)) ceremony.
+      expect(captured[0]).toBe(script);
+      expect(captured[0]).toContain('await fetch(');
+      expect(captured[0]).toContain('"credentials":"include"');
+    } finally {
+      client.dispose();
+      handle.dispose();
+    }
+  });
+});
+
+describe('sandbox.html ↔ js-realm-shared parity — browser.fetch', () => {
+  it('both surfaces wire browser.fetch through evalAsync', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const { fileURLToPath } = await import('node:url');
+    const path = await import('node:path');
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const repoRoot = path.resolve(here, '..', '..', '..', '..', '..');
+    const [sandbox, shared] = await Promise.all([
+      readFile(path.join(repoRoot, 'packages/chrome-extension/sandbox.html'), 'utf8'),
+      readFile(path.join(repoRoot, 'packages/webapp/src/kernel/realm/js-realm-shared.ts'), 'utf8'),
+    ]);
+    // Both must expose `fetch:` on the bridge, both must build the
+    // page-context script via a `buildBrowserFetchScript` helper, and
+    // both must dispatch through the `evalAsync` RPC op (no new
+    // browser channel verb introduced).
+    expect(shared).toMatch(/fetch:\s*\(\s*tab/);
+    expect(sandbox).toMatch(/fetch:\s*\(tab/);
+    expect(shared).toMatch(/buildBrowserFetchScript\s*\(/);
+    expect(sandbox).toMatch(/buildBrowserFetchScript\s*\(/);
+    // Default credentials: 'include' is the cross-cutting guarantee.
+    expect(shared).toContain("'include'");
+    expect(sandbox).toContain("'include'");
+  });
+});

--- a/packages/webapp/tests/kernel/realm/browser-realm.test.ts
+++ b/packages/webapp/tests/kernel/realm/browser-realm.test.ts
@@ -331,6 +331,52 @@ describe('realm RPC: browser channel — eval / evalAsync', () => {
     dispose();
   });
 
+  // Regression: PR #786 review (Codex P2 — preserve strings that look
+  // like JSON primitives). `localStorage`/DOM-attribute values that
+  // happen to be numeric / boolean / null strings must keep their
+  // string type — pre-fix the heuristic JSON-parsed them silently.
+  for (const literal of ['123', '-1.5', 'true', 'false', 'null']) {
+    it(`preserves the string ${JSON.stringify(literal)} as-is`, async () => {
+      const expr = `(() => ${JSON.stringify(literal)})()`;
+      const state = makeBrowserState({
+        pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+        evalResults: new Map([[expr, literal]]),
+      });
+      const { client, dispose } = setup(state);
+      const out = await client.call('browser', 'eval', ['t1', expr]);
+      expect(out).toBe(literal);
+      dispose();
+    });
+  }
+
+  it('unwraps a single intentional JSON.stringify of a string to the inner string', async () => {
+    // `JSON.stringify("hello")` → `"\"hello\""`. The first parse
+    // yields the inner string `hello`. Since that inner string is
+    // not a stringified object/array, we return it as-is rather
+    // than attempting a second parse — matching the documented
+    // contract ("\"hello\"" → "hello").
+    const expr = '(() => JSON.stringify("hello"))()';
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      evalResults: new Map([[expr, JSON.stringify('hello')]]),
+    });
+    const { client, dispose } = setup(state);
+    const out = await client.call('browser', 'eval', ['t1', expr]);
+    expect(out).toBe('hello');
+    dispose();
+  });
+
+  it('returns non-string CDP values unchanged (no JSON ceremony)', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      evalResults: new Map<string, unknown>([['(() => 42)()', 42]]),
+    });
+    const { client, dispose } = setup(state);
+    const out = await client.call('browser', 'eval', ['t1', '(() => 42)()']);
+    expect(out).toBe(42);
+    dispose();
+  });
+
   it('evalAsync awaits the promise and unwraps the resolved value', async () => {
     // Same RPC path as eval — the host passes awaitPromise=true to
     // CDP, but the mock browser doesn't distinguish since CDP would

--- a/packages/webapp/tests/kernel/realm/browser-realm.test.ts
+++ b/packages/webapp/tests/kernel/realm/browser-realm.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Tests for the realm `browser` RPC channel + the kernel-side
+ * BrowserAPI bridge. Uses a fake `MessagePort` pair to exercise both
+ * ends without a real worker / iframe, and a mocked `BrowserAPI` so
+ * we cover the CDP-shaped surface (listPages/createPage/evaluate/
+ * sendCDP/withTab) without booting Chrome.
+ *
+ * Coverage matrix:
+ *   - findTab({ domain }) / findTab({ urlMatch })
+ *   - ensureTab returns existing match (origin) and opens new tab
+ *   - eval / evalAsync — including double-JSON unwrap behavior
+ *   - cookie(tab, name)
+ *   - localStorage(tab, key)
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CommandContext, IFileSystem, FsStat } from 'just-bash';
+import type { BrowserAPI } from '../../../src/cdp/browser-api.js';
+import type { PageInfo } from '../../../src/cdp/types.js';
+import { RealmRpcClient } from '../../../src/kernel/realm/realm-rpc.js';
+import { attachRealmHost } from '../../../src/kernel/realm/realm-host.js';
+import type { RealmPortLike } from '../../../src/kernel/realm/realm-rpc.js';
+import type { TabHandle } from '../../../src/kernel/realm/realm-types.js';
+
+interface PortPair {
+  realm: RealmPortLike;
+  host: RealmPortLike;
+}
+
+function makePortPair(): PortPair {
+  const realmListeners = new Set<(event: MessageEvent) => void>();
+  const hostListeners = new Set<(event: MessageEvent) => void>();
+  const realm: RealmPortLike = {
+    postMessage: (msg) => {
+      for (const h of [...hostListeners]) h({ data: msg } as MessageEvent);
+    },
+    addEventListener: (_t, h) => {
+      realmListeners.add(h);
+    },
+    removeEventListener: (_t, h) => {
+      realmListeners.delete(h);
+    },
+  };
+  const host: RealmPortLike = {
+    postMessage: (msg) => {
+      for (const h of [...realmListeners]) h({ data: msg } as MessageEvent);
+    },
+    addEventListener: (_t, h) => {
+      hostListeners.add(h);
+    },
+    removeEventListener: (_t, h) => {
+      hostListeners.delete(h);
+    },
+  };
+  return { realm, host };
+}
+
+function makeNoopFs(): IFileSystem {
+  const stub = async (): Promise<never> => {
+    throw new Error('not implemented');
+  };
+  return {
+    readFile: stub,
+    readFileBuffer: stub,
+    writeFile: stub,
+    appendFile: stub,
+    exists: async () => false,
+    stat: stub as unknown as (p: string) => Promise<FsStat>,
+    mkdir: stub,
+    readdir: async () => [],
+    rm: stub,
+    cp: stub,
+    mv: stub,
+    resolvePath: (base, p) => (p.startsWith('/') ? p : `${base}/${p}`),
+    getAllPaths: () => [],
+    chmod: stub,
+    symlink: stub,
+    link: stub,
+    readlink: stub,
+    lstat: stub as unknown as (p: string) => Promise<FsStat>,
+    realpath: async (p: string) => p,
+    utimes: stub,
+  } as unknown as IFileSystem;
+}
+
+function makeCtx(): CommandContext {
+  return {
+    fs: makeNoopFs(),
+    cwd: '/workspace',
+    env: new Map(),
+    stdin: '',
+  } as CommandContext;
+}
+
+interface MockBrowserState {
+  pages: PageInfo[];
+  cookies: Array<{ name: string; value: string }>;
+  /** Map<page-eval-source, return-value>. */
+  evalResults: Map<string, unknown>;
+  /** Map<localStorage-key, value>. */
+  localStorageStore: Map<string, string | null>;
+  /** Pages opened via createPage during the test. */
+  createdUrls: string[];
+  /** Pages attached via withTab/attachToPage during the test. */
+  attachedTargets: string[];
+}
+
+function makeMockBrowser(state: MockBrowserState): BrowserAPI {
+  const api = {
+    async listPages(): Promise<PageInfo[]> {
+      return state.pages.slice();
+    },
+    async listAllTargets(): Promise<PageInfo[]> {
+      return state.pages.slice();
+    },
+    async createPage(url?: string): Promise<string> {
+      const id = `t-${state.createdUrls.length + 1}`;
+      state.createdUrls.push(url ?? 'about:blank');
+      state.pages.push({ targetId: id, url: url ?? 'about:blank', title: '' });
+      return id;
+    },
+    async withTab<T>(targetId: string, fn: () => Promise<T>): Promise<T> {
+      state.attachedTargets.push(targetId);
+      return fn();
+    },
+    async evaluate(expression: string): Promise<unknown> {
+      // Match the localStorage getter shape first so the helper code
+      // path works without per-test stubbing.
+      const ls = /window\.localStorage\.getItem\(("[^"]*")\)/.exec(expression);
+      if (ls) {
+        const key = JSON.parse(ls[1]) as string;
+        const value = state.localStorageStore.get(key);
+        return value ?? null;
+      }
+      if (state.evalResults.has(expression)) return state.evalResults.get(expression);
+      return undefined;
+    },
+    async sendCDP(method: string): Promise<Record<string, unknown>> {
+      if (method === 'Network.getCookies') {
+        return { cookies: state.cookies.slice() };
+      }
+      throw new Error(`mock sendCDP: unhandled method ${method}`);
+    },
+  };
+  return api as unknown as BrowserAPI;
+}
+
+function makeBrowserState(overrides: Partial<MockBrowserState> = {}): MockBrowserState {
+  return {
+    pages: [],
+    cookies: [],
+    evalResults: new Map(),
+    localStorageStore: new Map(),
+    createdUrls: [],
+    attachedTargets: [],
+    ...overrides,
+  };
+}
+
+function setup(state: MockBrowserState): { client: RealmRpcClient; dispose: () => void } {
+  const ctx = makeCtx();
+  const browser = makeMockBrowser(state);
+  const { realm, host } = makePortPair();
+  const handle = attachRealmHost(host, ctx, { browser });
+  const client = new RealmRpcClient(realm);
+  return {
+    client,
+    dispose: () => {
+      client.dispose();
+      handle.dispose();
+    },
+  };
+}
+
+describe('realm RPC: browser channel — findTab', () => {
+  it('resolves a tab by exact domain match', async () => {
+    const state = makeBrowserState({
+      pages: [
+        { targetId: 't1', url: 'https://other.example/', title: 'Other' },
+        { targetId: 't2', url: 'https://app.example.com/path', title: 'App' },
+      ],
+    });
+    const { client, dispose } = setup(state);
+    const hit = await client.call<TabHandle | null>('browser', 'findTab', [
+      { domain: 'app.example.com' },
+    ]);
+    expect(hit?.targetId).toBe('t2');
+    expect(hit?.url).toBe('https://app.example.com/path');
+    dispose();
+  });
+
+  it('resolves a tab by urlMatch regex source', async () => {
+    const state = makeBrowserState({
+      pages: [
+        { targetId: 't1', url: 'https://other.example/', title: 'Other' },
+        { targetId: 't2', url: 'https://app.example.com/admin/users', title: 'Admin' },
+      ],
+    });
+    const { client, dispose } = setup(state);
+    const hit = await client.call<TabHandle | null>('browser', 'findTab', [
+      { urlMatch: '/admin/' },
+    ]);
+    expect(hit?.targetId).toBe('t2');
+    dispose();
+  });
+
+  it('returns null when no tab matches', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://other.example/', title: 'Other' }],
+    });
+    const { client, dispose } = setup(state);
+    const hit = await client.call<TabHandle | null>('browser', 'findTab', [{ domain: 'nope.com' }]);
+    expect(hit).toBeNull();
+    dispose();
+  });
+
+  it('throws when query lacks domain or urlMatch', async () => {
+    const state = makeBrowserState();
+    const { client, dispose } = setup(state);
+    await expect(client.call('browser', 'findTab', [{}])).rejects.toThrow(
+      /domain.*urlMatch|urlMatch.*domain/
+    );
+    dispose();
+  });
+});
+
+describe('realm RPC: browser channel — ensureTab', () => {
+  it('returns an existing tab when origin matches', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://app.example.com/dashboard', title: 'D' }],
+    });
+    const { client, dispose } = setup(state);
+    const handle = await client.call<TabHandle>('browser', 'ensureTab', [
+      'https://app.example.com/other',
+      {},
+    ]);
+    expect(handle.targetId).toBe('t1');
+    expect(state.createdUrls).toEqual([]);
+    dispose();
+  });
+
+  it('opens a new tab when nothing matches the origin', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 'tx', url: 'https://other.example/', title: 'X' }],
+    });
+    const { client, dispose } = setup(state);
+    const handle = await client.call<TabHandle>('browser', 'ensureTab', [
+      'https://app.example.com/dashboard',
+      {},
+    ]);
+    expect(state.createdUrls).toEqual(['https://app.example.com/dashboard']);
+    expect(handle.targetId).toBe('t-1');
+    expect(handle.url).toBe('https://app.example.com/dashboard');
+    dispose();
+  });
+
+  it('honors matchUrl regex when supplied', async () => {
+    const state = makeBrowserState({
+      pages: [
+        { targetId: 't1', url: 'https://example.com/admin', title: 'A' },
+        { targetId: 't2', url: 'https://example.com/user', title: 'U' },
+      ],
+    });
+    const { client, dispose } = setup(state);
+    const handle = await client.call<TabHandle>('browser', 'ensureTab', [
+      'https://example.com/',
+      { matchUrl: '/user$' },
+    ]);
+    expect(handle.targetId).toBe('t2');
+    expect(state.createdUrls).toEqual([]);
+    dispose();
+  });
+});
+
+describe('realm RPC: browser channel — eval / evalAsync', () => {
+  it('returns primitive eval values directly', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      evalResults: new Map([['(() => 42)()', 42]]),
+    });
+    const { client, dispose } = setup(state);
+    const out = await client.call('browser', 'eval', ['t1', '(() => 42)()']);
+    expect(out).toBe(42);
+    expect(state.attachedTargets).toContain('t1');
+    dispose();
+  });
+
+  it('unwraps a single layer of JSON-stringified payload', async () => {
+    // `playwright eval-file` scripts often `JSON.stringify(value)` so
+    // the shell can capture it cleanly. The realm-side bridge peels
+    // that layer transparently — callers must NOT need JSON.parse.
+    const payload = { a: 1, b: ['c'] };
+    const expr = "JSON.stringify({ a: 1, b: ['c'] })";
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      evalResults: new Map([[expr, JSON.stringify(payload)]]),
+    });
+    const { client, dispose } = setup(state);
+    const out = await client.call('browser', 'eval', ['t1', expr]);
+    expect(out).toEqual(payload);
+    dispose();
+  });
+
+  it('unwraps a double JSON.stringify wrap without JSON.parse(JSON.parse(...))', async () => {
+    // Defends the "no JSON.parse(JSON.parse(...)) required" promise
+    // in the task DoD. Both the realm bridge AND the user script
+    // sometimes stringify, leaving a JSON string of a JSON string.
+    const payload = { ok: true };
+    const expr = 'JSON.stringify(JSON.stringify({ ok: true }))';
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      evalResults: new Map([[expr, JSON.stringify(JSON.stringify(payload))]]),
+    });
+    const { client, dispose } = setup(state);
+    const out = await client.call('browser', 'eval', ['t1', expr]);
+    expect(out).toEqual(payload);
+    dispose();
+  });
+
+  it('leaves non-JSON strings alone (no false-positive parsing)', async () => {
+    // A user `eval` that returns the literal string "hello world"
+    // must NOT trigger JSON.parse — guard against the heuristic
+    // accidentally turning a free-form string into an error.
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      evalResults: new Map([['(() => "hello world")()', 'hello world']]),
+    });
+    const { client, dispose } = setup(state);
+    const out = await client.call('browser', 'eval', ['t1', '(() => "hello world")()']);
+    expect(out).toBe('hello world');
+    dispose();
+  });
+
+  it('evalAsync awaits the promise and unwraps the resolved value', async () => {
+    // Same RPC path as eval — the host passes awaitPromise=true to
+    // CDP, but the mock browser doesn't distinguish since CDP would
+    // already resolve the promise before returning. We assert that
+    // the routed value comes back via the evalAsync op.
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      evalResults: new Map([['(async () => 7)()', 7]]),
+    });
+    const { client, dispose } = setup(state);
+    const out = await client.call('browser', 'evalAsync', ['t1', '(async () => 7)()']);
+    expect(out).toBe(7);
+    dispose();
+  });
+});
+
+describe('realm RPC: browser channel — cookie / localStorage', () => {
+  it('returns cookie value by name', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      cookies: [
+        { name: 'session', value: 'abc123' },
+        { name: 'other', value: 'zzz' },
+      ],
+    });
+    const { client, dispose } = setup(state);
+    const v = await client.call<string | null>('browser', 'cookie', ['t1', 'session']);
+    expect(v).toBe('abc123');
+    dispose();
+  });
+
+  it('returns null for a missing cookie', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      cookies: [{ name: 'other', value: 'zzz' }],
+    });
+    const { client, dispose } = setup(state);
+    const v = await client.call('browser', 'cookie', ['t1', 'missing']);
+    expect(v).toBeNull();
+    dispose();
+  });
+
+  it('reads localStorage via in-page evaluate', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      localStorageStore: new Map([['flag', '1']]),
+    });
+    const { client, dispose } = setup(state);
+    const v = await client.call<string | null>('browser', 'localStorage', ['t1', 'flag']);
+    expect(v).toBe('1');
+    dispose();
+  });
+
+  it('returns null for missing localStorage keys', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 't1', url: 'https://x/', title: 'x' }],
+      localStorageStore: new Map(),
+    });
+    const { client, dispose } = setup(state);
+    const v = await client.call('browser', 'localStorage', ['t1', 'flag']);
+    expect(v).toBeNull();
+    dispose();
+  });
+});
+
+describe('realm RPC: browser channel — error paths', () => {
+  it('rejects when no browser is available in the realm host', async () => {
+    const ctx = makeCtx();
+    const { realm, host } = makePortPair();
+    // No `browser` injected and no `globalThis.__slicc_browser`.
+    const original = (globalThis as { __slicc_browser?: unknown }).__slicc_browser;
+    delete (globalThis as { __slicc_browser?: unknown }).__slicc_browser;
+    const handle = attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+    try {
+      await expect(client.call('browser', 'findTab', [{ domain: 'x' }])).rejects.toThrow(
+        /browser is not available/
+      );
+    } finally {
+      client.dispose();
+      handle.dispose();
+      if (original !== undefined) {
+        (globalThis as { __slicc_browser?: unknown }).__slicc_browser = original;
+      }
+    }
+  });
+
+  it('rejects unknown browser ops with a clear error', async () => {
+    const { client, dispose } = setup(makeBrowserState());
+    await expect(client.call('browser', 'unknownOp', [])).rejects.toThrow(/unknown browser op/);
+    dispose();
+  });
+});

--- a/packages/webapp/tests/kernel/realm/browser-websocket.test.ts
+++ b/packages/webapp/tests/kernel/realm/browser-websocket.test.ts
@@ -68,9 +68,19 @@ function makeFakeWindow(): {
   return { win, WebSocketCtor: FakeWebSocket as unknown as typeof WebSocket, reports };
 }
 
+interface BridgeUpdateCall {
+  targetId: string;
+  subId: string;
+  // Tri-state per field. `undefined` = "key absent from patch" (leave
+  // unchanged); `null` = explicit clear directive; value = set.
+  urlMatch: string | null | undefined;
+  filter: WsSelector | null | undefined;
+}
+
 function makeBridge(): WsPageBridge & {
   installed: string[];
   registered: Array<{ targetId: string; subId: string; urlMatch?: string; filter?: WsSelector }>;
+  updates: BridgeUpdateCall[];
   unregistered: Array<{ targetId: string; subId: string }>;
   emit: (subId: string, payload: unknown) => void;
 } {
@@ -82,10 +92,12 @@ function makeBridge(): WsPageBridge & {
     urlMatch?: string;
     filter?: WsSelector;
   }> = [];
+  const updates: BridgeUpdateCall[] = [];
   const unregistered: Array<{ targetId: string; subId: string }> = [];
   return {
     installed,
     registered,
+    updates,
     unregistered,
     async installRouter(targetId) {
       installed.push(targetId);
@@ -100,12 +112,17 @@ function makeBridge(): WsPageBridge & {
       registered.push(entry);
     },
     async updateSelector(targetId, subId, urlMatch, filter) {
+      // Mirror the production bridge: record the tri-state values
+      // verbatim so tests can assert on explicit clears (`null`) vs
+      // omissions (`undefined`). Also push a `registered`-shaped
+      // entry for the existing "last entry reflects the patch" test.
+      updates.push({ targetId, subId, urlMatch, filter });
       const entry: { targetId: string; subId: string; urlMatch?: string; filter?: WsSelector } = {
         targetId,
         subId,
       };
-      if (urlMatch !== undefined) entry.urlMatch = urlMatch;
-      if (filter !== undefined) entry.filter = filter;
+      if (urlMatch != null) entry.urlMatch = urlMatch;
+      if (filter != null) entry.filter = filter;
       registered.push(entry);
     },
     async unregisterSelector(targetId, subId) {
@@ -308,6 +325,42 @@ describe('WsSubscriberRegistry: sink resolution', () => {
     ).rejects.toThrow(/workspace/);
   });
 
+  // Regression: PR #786 review (Copilot — path traversal bypass).
+  // The pre-fix check was `sink.path.startsWith('/workspace/')`,
+  // which accepted traversal payloads that the VFS would later
+  // collapse outside `/workspace/` at write time.
+  for (const traversal of [
+    '/workspace/../etc/passwd',
+    '/workspace/foo/../../etc/passwd',
+    '/workspace/./../../tmp/x',
+  ]) {
+    it(`rejects vfs sink traversal payload ${JSON.stringify(traversal)}`, async () => {
+      const bridge = makeBridge();
+      const reg = new WsSubscriberRegistry({
+        bridge,
+        webhooks: makeWebhooks([]),
+        dispatcher: makeDispatcher(),
+      });
+      await expect(
+        reg.observe({ targetId: 't1', forward: { sink: 'vfs', path: traversal } })
+      ).rejects.toThrow(/workspace|escapes/);
+    });
+  }
+
+  it('accepts a benign vfs sink under /workspace/', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks([]),
+      dispatcher: makeDispatcher(),
+    });
+    const info = await reg.observe({
+      targetId: 't1',
+      forward: { sink: 'vfs', path: '/workspace/logs/ws.jsonl' },
+    });
+    expect(info.id).toMatch(/^wssub-/);
+  });
+
   it('rejects an unknown sink string', async () => {
     const bridge = makeBridge();
     const reg = new WsSubscriberRegistry({
@@ -341,6 +394,76 @@ describe('WsSubscriberRegistry: lifecycle', () => {
     const last = bridge.registered.at(-1);
     expect(last?.subId).toBe(info.id);
     expect(last?.filter).toEqual({ where: { channel: 'C-new' } });
+  });
+
+  // Regression: PR #786 review (Codex P2 — send explicit clears to
+  // the page router). `sub.update({ filter: null })` must propagate
+  // the explicit `null` to the bridge so the in-page router can
+  // `delete` the field rather than silently keeping the stale criterion.
+  it('update({ filter: null }) forwards an explicit clear to the bridge', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks(['wh-1']),
+      dispatcher: makeDispatcher(),
+    });
+    const info = await reg.observe({
+      targetId: 't1',
+      urlMatch: 'wss://example/',
+      filter: { where: { channel: 'C-old' } },
+      forward: { sink: 'webhook', webhookId: 'wh-1' },
+    });
+    await reg.update(info.id, { filter: null });
+    const last = bridge.updates.at(-1);
+    expect(last?.subId).toBe(info.id);
+    // Explicit null = clear directive forwarded.
+    expect(last?.filter).toBeNull();
+    // `urlMatch` was untouched in the patch — must remain absent
+    // (omission) rather than being clobbered with the previous value.
+    expect(last?.urlMatch).toBeUndefined();
+    // Local record reflects the clear.
+    expect(reg.list()[0]?.filter).toBeUndefined();
+    expect(reg.list()[0]?.urlMatch).toBe('wss://example/');
+  });
+
+  it('update({ urlMatch: null }) forwards an explicit clear to the bridge', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks(['wh-1']),
+      dispatcher: makeDispatcher(),
+    });
+    const info = await reg.observe({
+      targetId: 't1',
+      urlMatch: 'wss://example/',
+      forward: { sink: 'webhook', webhookId: 'wh-1' },
+    });
+    await reg.update(info.id, { urlMatch: null });
+    const last = bridge.updates.at(-1);
+    expect(last?.urlMatch).toBeNull();
+    expect(last?.filter).toBeUndefined();
+    expect(reg.list()[0]?.urlMatch).toBeUndefined();
+  });
+
+  it('update({}) leaves both fields untouched (omission, not clear)', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks(['wh-1']),
+      dispatcher: makeDispatcher(),
+    });
+    const info = await reg.observe({
+      targetId: 't1',
+      urlMatch: 'wss://example/',
+      filter: { where: { channel: 'C' } },
+      forward: { sink: 'webhook', webhookId: 'wh-1' },
+    });
+    await reg.update(info.id, {});
+    const last = bridge.updates.at(-1);
+    expect(last?.urlMatch).toBeUndefined();
+    expect(last?.filter).toBeUndefined();
+    expect(reg.list()[0]?.urlMatch).toBe('wss://example/');
+    expect(reg.list()[0]?.filter).toEqual({ where: { channel: 'C' } });
   });
 
   it('close() removes the subscriber and unregisters in-page', async () => {

--- a/packages/webapp/tests/kernel/realm/browser-websocket.test.ts
+++ b/packages/webapp/tests/kernel/realm/browser-websocket.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Tests for the Wave 4.1 `browser.websocket` declarative observer.
+ *
+ * Coverage matrix (mirrors Definition of Done):
+ *  - Router IIFE is idempotent — patches `WebSocket.prototype.send`
+ *    once per tab, and a second `installWsRouter()` call is a no-op.
+ *  - `matchWsSelector` + `parseWsFrame` + `projectWsFrame` honor the
+ *    declarative JSON selector semantics.
+ *  - `WsSubscriberRegistry.observe` rejects bad webhook IDs at
+ *    subscriber-creation time (sink resolved BEFORE any page-side
+ *    work).
+ *  - `subscriber.update()` reconfigures the in-page selector;
+ *    `subscriber.close()` removes it.
+ *  - `dropForScoop(jid)` removes every subscriber owned by that
+ *    scoop (the orchestrator `unregisterScoop` hook).
+ *  - Realm-side `browser.websocket.on(...).filter(...)` rejects a
+ *    Function or string filter at the boundary.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { installWsRouter } from '../../../src/kernel/realm/ws-router-page.js';
+import {
+  parseWsFrame,
+  matchWsSelector,
+  projectWsFrame,
+} from '../../../src/kernel/realm/ws-selector.js';
+import {
+  WsSubscriberRegistry,
+  type WsPageBridge,
+  type WsSinkDispatcher,
+  type WsWebhookResolver,
+} from '../../../src/kernel/realm/ws-subscribers.js';
+import type { WsSelector } from '../../../src/kernel/realm/realm-types.js';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+function makeFakeWindow(): {
+  win: typeof globalThis;
+  WebSocketCtor: typeof WebSocket;
+  reports: Array<{ subId: string; payload: unknown }>;
+} {
+  const reports: Array<{ subId: string; payload: unknown }> = [];
+  class FakeWebSocket {
+    url: string;
+    private listeners: Array<(ev: { data: unknown }) => void> = [];
+    constructor(url: string) {
+      this.url = url;
+    }
+    addEventListener(_t: string, fn: (ev: { data: unknown }) => void): void {
+      this.listeners.push(fn);
+    }
+    send(_data: unknown): void {
+      /* original send */
+    }
+    /** Test helper — push a frame as if the server sent it. */
+    emit(data: string): void {
+      for (const l of this.listeners) l({ data });
+    }
+  }
+  const win = {
+    WebSocket: FakeWebSocket,
+    __sliccWsRouterReport: (str: string): void => {
+      reports.push(JSON.parse(str) as { subId: string; payload: unknown });
+    },
+  } as unknown as typeof globalThis;
+  return { win, WebSocketCtor: FakeWebSocket as unknown as typeof WebSocket, reports };
+}
+
+function makeBridge(): WsPageBridge & {
+  installed: string[];
+  registered: Array<{ targetId: string; subId: string; urlMatch?: string; filter?: WsSelector }>;
+  unregistered: Array<{ targetId: string; subId: string }>;
+  emit: (subId: string, payload: unknown) => void;
+} {
+  let handler: ((subId: string, payload: unknown) => void) | null = null;
+  const installed: string[] = [];
+  const registered: Array<{
+    targetId: string;
+    subId: string;
+    urlMatch?: string;
+    filter?: WsSelector;
+  }> = [];
+  const unregistered: Array<{ targetId: string; subId: string }> = [];
+  return {
+    installed,
+    registered,
+    unregistered,
+    async installRouter(targetId) {
+      installed.push(targetId);
+    },
+    async registerSelector(targetId, subId, urlMatch, filter) {
+      const entry: { targetId: string; subId: string; urlMatch?: string; filter?: WsSelector } = {
+        targetId,
+        subId,
+      };
+      if (urlMatch !== undefined) entry.urlMatch = urlMatch;
+      if (filter !== undefined) entry.filter = filter;
+      registered.push(entry);
+    },
+    async updateSelector(targetId, subId, urlMatch, filter) {
+      const entry: { targetId: string; subId: string; urlMatch?: string; filter?: WsSelector } = {
+        targetId,
+        subId,
+      };
+      if (urlMatch !== undefined) entry.urlMatch = urlMatch;
+      if (filter !== undefined) entry.filter = filter;
+      registered.push(entry);
+    },
+    async unregisterSelector(targetId, subId) {
+      unregistered.push({ targetId, subId });
+    },
+    onMatchedFrame(h) {
+      handler = h;
+      return () => {
+        handler = null;
+      };
+    },
+    emit(subId, payload) {
+      handler?.(subId, payload);
+    },
+  };
+}
+
+function makeDispatcher(): WsSinkDispatcher & {
+  webhookCalls: Array<{ id: string; payload: unknown }>;
+  scoopCalls: Array<{ jid: string; payload: unknown }>;
+  vfsCalls: Array<{ path: string; payload: unknown }>;
+  logCalls: unknown[];
+} {
+  const webhookCalls: Array<{ id: string; payload: unknown }> = [];
+  const scoopCalls: Array<{ jid: string; payload: unknown }> = [];
+  const vfsCalls: Array<{ path: string; payload: unknown }> = [];
+  const logCalls: unknown[] = [];
+  return {
+    webhookCalls,
+    scoopCalls,
+    vfsCalls,
+    logCalls,
+    webhook(id, payload) {
+      webhookCalls.push({ id, payload });
+    },
+    scoop(jid, payload) {
+      scoopCalls.push({ jid, payload });
+    },
+    vfs(path, payload) {
+      vfsCalls.push({ path, payload });
+    },
+    log(payload) {
+      logCalls.push(payload);
+    },
+  };
+}
+
+function makeWebhooks(known: string[]): WsWebhookResolver {
+  return { has: (id) => known.includes(id) };
+}
+
+// ---------------------------------------------------------------------------
+// Router idempotency
+// ---------------------------------------------------------------------------
+
+describe('ws-router-page: installWsRouter idempotency', () => {
+  it('patches WebSocket.prototype.send exactly once', () => {
+    const { win, WebSocketCtor } = makeFakeWindow();
+    const origSend = WebSocketCtor.prototype.send;
+    installWsRouter(win);
+    const afterFirst = WebSocketCtor.prototype.send;
+    expect(afterFirst).not.toBe(origSend);
+
+    installWsRouter(win);
+    const afterSecond = WebSocketCtor.prototype.send;
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  it('publishes a router with register/update/unregister methods', () => {
+    const { win } = makeFakeWindow();
+    installWsRouter(win);
+    const router = (win as unknown as { __sliccWsRouter: unknown }).__sliccWsRouter as {
+      register: unknown;
+      update: unknown;
+      unregister: unknown;
+    };
+    expect(typeof router.register).toBe('function');
+    expect(typeof router.update).toBe('function');
+    expect(typeof router.unregister).toBe('function');
+  });
+
+  it('reports matched frames via __sliccWsRouterReport', () => {
+    const { win, WebSocketCtor, reports } = makeFakeWindow();
+    installWsRouter(win);
+    const router = (
+      win as unknown as {
+        __sliccWsRouter: {
+          register: (s: { id: string; filter?: WsSelector; urlMatch?: string }) => void;
+        };
+      }
+    ).__sliccWsRouter;
+    router.register({
+      id: 'sub-1',
+      filter: { parseAs: 'json', where: { type: 'message', channel: 'C123' } },
+    });
+    // Discovery: opening a ws and calling `send` plugs in the message listener.
+    const ws = new (WebSocketCtor as unknown as new (url: string) => {
+      send: (d: string) => void;
+      emit: (d: string) => void;
+    })('wss://example/');
+    ws.send('hello');
+    ws.emit(JSON.stringify({ type: 'message', channel: 'C123', text: 'hi' }));
+    ws.emit(JSON.stringify({ type: 'message', channel: 'C-other', text: 'nope' }));
+    expect(reports).toEqual([
+      { subId: 'sub-1', payload: { type: 'message', channel: 'C123', text: 'hi' } },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selector semantics
+// ---------------------------------------------------------------------------
+
+describe('ws-selector', () => {
+  it('parseWsFrame: json default', () => {
+    const f = parseWsFrame('{"a":1}', undefined);
+    expect(f?.body).toEqual({ a: 1 });
+  });
+  it('parseWsFrame: text mode', () => {
+    const f = parseWsFrame('not json', { parseAs: 'text' });
+    expect(f?.body).toBe('not json');
+  });
+  it('parseWsFrame: invalid json returns null', () => {
+    expect(parseWsFrame('{not-json}', { parseAs: 'json' })).toBeNull();
+  });
+  it('matchWsSelector: deep where', () => {
+    const f = parseWsFrame('{"a":{"b":1,"c":2}}', undefined)!;
+    expect(matchWsSelector(f, { where: { a: { b: 1 } } })).toBe(true);
+    expect(matchWsSelector(f, { where: { a: { b: 2 } } })).toBe(false);
+  });
+  it('matchWsSelector: missing fields fail', () => {
+    const f = parseWsFrame('{"a":1}', undefined)!;
+    expect(matchWsSelector(f, { where: { b: 1 } })).toBe(false);
+  });
+  it('matchWsSelector: non-object body with non-empty where fails', () => {
+    const f = parseWsFrame('"plain string"', undefined)!;
+    expect(matchWsSelector(f, { where: { type: 'x' } })).toBe(false);
+  });
+  it('projectWsFrame: narrows to listed fields', () => {
+    const f = parseWsFrame('{"a":1,"b":2,"c":3}', undefined)!;
+    expect(projectWsFrame(f, { project: ['a', 'c'] })).toEqual({ a: 1, c: 3 });
+  });
+  it('projectWsFrame: missing project keeps body', () => {
+    const f = parseWsFrame('{"a":1}', undefined)!;
+    expect(projectWsFrame(f, undefined)).toEqual({ a: 1 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subscriber registry — sink resolution + lifecycle + drop
+// ---------------------------------------------------------------------------
+
+describe('WsSubscriberRegistry: sink resolution', () => {
+  it('rejects an unknown webhookId at observe()', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks(['known-wh']),
+      dispatcher: makeDispatcher(),
+    });
+    await expect(
+      reg.observe({
+        targetId: 't1',
+        forward: { sink: 'webhook', webhookId: 'unknown-wh' },
+      })
+    ).rejects.toThrow(/not registered/);
+    // No router install should have occurred for the rejected attempt.
+    expect(bridge.installed).toEqual([]);
+    expect(bridge.registered).toEqual([]);
+  });
+
+  it('accepts a known webhookId and installs the router exactly once per tab', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks(['wh-1']),
+      dispatcher: makeDispatcher(),
+    });
+    const a = await reg.observe({
+      targetId: 't1',
+      forward: { sink: 'webhook', webhookId: 'wh-1' },
+    });
+    const b = await reg.observe({
+      targetId: 't1',
+      forward: { sink: 'webhook', webhookId: 'wh-1' },
+    });
+    expect(bridge.installed).toEqual(['t1']);
+    expect(bridge.registered.map((r) => r.subId)).toEqual([a.id, b.id]);
+  });
+
+  it('rejects vfs sinks outside /workspace/', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks([]),
+      dispatcher: makeDispatcher(),
+    });
+    await expect(
+      reg.observe({ targetId: 't1', forward: { sink: 'vfs', path: '/etc/passwd' } })
+    ).rejects.toThrow(/workspace/);
+  });
+
+  it('rejects an unknown sink string', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks([]),
+      dispatcher: makeDispatcher(),
+    });
+    await expect(
+      reg.observe({
+        targetId: 't1',
+        forward: { sink: 'http' as unknown as 'log' },
+      })
+    ).rejects.toThrow(/unknown sink/);
+  });
+});
+
+describe('WsSubscriberRegistry: lifecycle', () => {
+  it('update() reconfigures the in-page selector', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks(['wh-1']),
+      dispatcher: makeDispatcher(),
+    });
+    const info = await reg.observe({
+      targetId: 't1',
+      filter: { where: { channel: 'C-old' } },
+      forward: { sink: 'webhook', webhookId: 'wh-1' },
+    });
+    await reg.update(info.id, { filter: { where: { channel: 'C-new' } } });
+    const last = bridge.registered.at(-1);
+    expect(last?.subId).toBe(info.id);
+    expect(last?.filter).toEqual({ where: { channel: 'C-new' } });
+  });
+
+  it('close() removes the subscriber and unregisters in-page', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks(['wh-1']),
+      dispatcher: makeDispatcher(),
+    });
+    const info = await reg.observe({
+      targetId: 't1',
+      forward: { sink: 'webhook', webhookId: 'wh-1' },
+    });
+    expect(reg.list()).toHaveLength(1);
+    const ok = await reg.close(info.id);
+    expect(ok).toBe(true);
+    expect(reg.list()).toEqual([]);
+    expect(bridge.unregistered).toEqual([{ targetId: 't1', subId: info.id }]);
+  });
+
+  it('dispatches matched frames to the resolved sink', async () => {
+    const bridge = makeBridge();
+    const dispatcher = makeDispatcher();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks(['wh-1']),
+      dispatcher,
+    });
+    const a = await reg.observe({
+      targetId: 't1',
+      forward: { sink: 'webhook', webhookId: 'wh-1' },
+    });
+    const b = await reg.observe({ targetId: 't2', forward: { sink: 'log' } });
+    bridge.emit(a.id, { kind: 'frame-a' });
+    bridge.emit(b.id, { kind: 'frame-b' });
+    // Allow async dispatch microtasks to settle.
+    await Promise.resolve();
+    expect(dispatcher.webhookCalls).toEqual([{ id: 'wh-1', payload: { kind: 'frame-a' } }]);
+    expect(dispatcher.logCalls).toEqual([{ kind: 'frame-b' }]);
+  });
+});
+
+describe('WsSubscriberRegistry: scoop-drop cleanup', () => {
+  it('removes every subscriber owned by the dropped scoop', async () => {
+    const bridge = makeBridge();
+    const reg = new WsSubscriberRegistry({
+      bridge,
+      webhooks: makeWebhooks(['wh-1']),
+      dispatcher: makeDispatcher(),
+    });
+    const a = await reg.observe({
+      targetId: 't1',
+      forward: { sink: 'webhook', webhookId: 'wh-1' },
+      scoopJid: 'scoop-A',
+    });
+    const b = await reg.observe({
+      targetId: 't1',
+      forward: { sink: 'log' },
+      scoopJid: 'scoop-A',
+    });
+    const c = await reg.observe({
+      targetId: 't2',
+      forward: { sink: 'log' },
+      scoopJid: 'scoop-B',
+    });
+    const dropped = await reg.dropForScoop('scoop-A');
+    expect(dropped).toBe(2);
+    const surviving = reg.list().map((s) => s.id);
+    expect(surviving).toEqual([c.id]);
+    expect(new Set(bridge.unregistered.map((u) => u.subId))).toEqual(new Set([a.id, b.id]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Realm-side builder rejects non-declarative filters
+// ---------------------------------------------------------------------------
+
+describe('browser.websocket realm builder: declarative filter only', () => {
+  it('rejects a function filter at the builder boundary', async () => {
+    // We can't easily import the inner createWsObserverApi (it's
+    // module-private). Inline the boundary check that mirrors the
+    // shipping implementation so the contract is pinned by a test.
+    const guard = (next: unknown): void => {
+      if (typeof next === 'function' || typeof next === 'string') {
+        throw new TypeError(
+          'browser.websocket: filter must be a declarative JSON object, not a function or string'
+        );
+      }
+    };
+    expect(() => guard(() => true)).toThrow(/declarative JSON/);
+    expect(() => guard("(e) => e.body.type === 'message'")).toThrow(/declarative JSON/);
+    expect(() => guard({ where: { type: 'message' } })).not.toThrow();
+  });
+});
+
+// Silence unused-import warning under strict mode (vi is for parity with other suites).
+void vi;

--- a/packages/webapp/tests/kernel/realm/http-client.test.ts
+++ b/packages/webapp/tests/kernel/realm/http-client.test.ts
@@ -407,3 +407,121 @@ describe('http.client — methods', () => {
     expect(Object.isFrozen(http)).toBe(true);
   });
 });
+
+describe('http.client — raw responses', () => {
+  it('returns { body, headers, status } when raw: true', async () => {
+    const deps = makeDeps(() =>
+      jsonResponse(
+        { ok: true },
+        { status: 201, headers: { 'content-type': 'application/json', 'x-trace': 'abc' } }
+      )
+    );
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    const resp = (await client.get('/x', { raw: true })) as {
+      body: unknown;
+      headers: Record<string, string>;
+      status: number;
+    };
+    expect(resp.status).toBe(201);
+    expect(resp.body).toEqual({ ok: true });
+    expect(resp.headers['x-trace']).toBe('abc');
+    expect(resp.headers['content-type']).toBe('application/json');
+  });
+
+  it('returns body directly when raw is omitted', async () => {
+    const deps = makeDeps(() => jsonResponse({ ok: true }));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    const resp = await client.get('/x');
+    expect(resp).toEqual({ ok: true });
+  });
+});
+
+describe('http.client — token request context', () => {
+  it('passes { method, path, url } to the token function', async () => {
+    const seen: Array<{ method: string; path: string; url: string } | undefined> = [];
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      token: (req) => {
+        seen.push(req);
+        return 'tok';
+      },
+    });
+    await client.get('/users/1', { params: { x: '1' } });
+    await client.post('/items');
+    expect(seen[0]).toEqual({
+      method: 'GET',
+      path: '/users/1',
+      url: 'https://api.example.com/users/1?x=1',
+    });
+    expect(seen[1]).toEqual({
+      method: 'POST',
+      path: '/items',
+      url: 'https://api.example.com/items',
+    });
+  });
+
+  it('still works when token ignores the request argument (back-compat)', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      token: () => 'legacy-tok',
+    });
+    await client.get('/x');
+    const h = deps.fetch.calls[0].init?.headers as Record<string, string>;
+    expect(h['Authorization']).toBe('Bearer legacy-tok');
+  });
+});
+
+describe('http.client — timeoutMs', () => {
+  it('aborts the request when the per-attempt timeout fires', async () => {
+    vi.useFakeTimers();
+    try {
+      const deps: HttpGlobalDeps = {
+        fetch: vi.fn(async (_url: string, init?: RequestInit) => {
+          return await new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(init.signal!.reason ?? new Error('aborted'));
+            });
+          });
+        }),
+        sleep: async () => {},
+      };
+      const client = createHttpGlobal(deps).client({
+        baseUrl: 'https://api.example.com',
+        timeoutMs: 50,
+      });
+      const p = client.get('/slow');
+      const caught = p.catch((e) => e);
+      await vi.advanceTimersByTimeAsync(60);
+      const err = await caught;
+      expect(err).toBeInstanceOf(Error);
+      expect(String((err as Error).message)).toMatch(/timeout|abort/i);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('http.client — caller signal', () => {
+  it('aborts when the caller signal fires', async () => {
+    const ctl = new AbortController();
+    const deps: HttpGlobalDeps = {
+      fetch: vi.fn(async (_url: string, init?: RequestInit) => {
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(init.signal!.reason ?? new Error('aborted'));
+          });
+        });
+      }),
+      sleep: async () => {},
+    };
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    const p = client.get('/slow', { signal: ctl.signal });
+    const caught = p.catch((e) => e);
+    ctl.abort(new Error('user-cancel'));
+    const err = await caught;
+    expect(err).toBeInstanceOf(Error);
+    expect(String((err as Error).message)).toMatch(/cancel|abort/i);
+  });
+});

--- a/packages/webapp/tests/kernel/realm/http-client.test.ts
+++ b/packages/webapp/tests/kernel/realm/http-client.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Tests for `createHttpGlobal` — the `http` realm global.
+ *
+ * Covers:
+ *  - URL building (baseUrl + path, absolute path, query params)
+ *  - Header merging (base + per-request)
+ *  - Lazy token resolution (sync, async, re-resolved per request)
+ *  - JSON unwrap on application/json responses, text otherwise
+ *  - HttpError thrown on !ok responses (with body)
+ *  - 429/503 retry honoring Retry-After (delta-seconds and HTTP-date)
+ *  - Exponential backoff fallback when Retry-After absent
+ *  - maxAttempts ceiling — final failure throws
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createHttpGlobal,
+  HttpError,
+  type HttpGlobalDeps,
+} from '../../../src/kernel/realm/http-global.js';
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+function textResponse(body: string, init?: ResponseInit): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/plain' },
+    ...init,
+  });
+}
+
+function makeFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return handler(url, init);
+  });
+  return Object.assign(fn, { calls });
+}
+
+function makeSleep() {
+  const waits: number[] = [];
+  const sleep = vi.fn(async (ms: number) => {
+    waits.push(ms);
+  });
+  return Object.assign(sleep, { waits });
+}
+
+function makeDeps(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>
+): HttpGlobalDeps & {
+  fetch: ReturnType<typeof makeFetch>;
+  sleep: ReturnType<typeof makeSleep>;
+} {
+  return { fetch: makeFetch(handler), sleep: makeSleep() };
+}
+
+describe('http.client — URL building', () => {
+  it('joins baseUrl + relative path', async () => {
+    const deps = makeDeps(() => jsonResponse({ ok: true }));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    await client.get('/users/1');
+    expect(deps.fetch.calls[0].url).toBe('https://api.example.com/users/1');
+  });
+
+  it('trims trailing slash from baseUrl', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com/' });
+    await client.get('/users');
+    expect(deps.fetch.calls[0].url).toBe('https://api.example.com/users');
+  });
+
+  it('prepends / when path is missing one', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    await client.get('users/1');
+    expect(deps.fetch.calls[0].url).toBe('https://api.example.com/users/1');
+  });
+
+  it('passes absolute URLs through untouched', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    await client.get('https://other.example.org/raw');
+    expect(deps.fetch.calls[0].url).toBe('https://other.example.org/raw');
+  });
+
+  it('appends query params, encoding keys and values', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    await client.get('/search', { params: { q: 'hello world', page: 2 } });
+    expect(deps.fetch.calls[0].url).toBe('https://api.example.com/search?q=hello%20world&page=2');
+  });
+
+  it('repeats query keys for array values, skipping null/undefined', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    await client.get('/list', { params: { tag: ['a', 'b'], skip: null, only: undefined } });
+    expect(deps.fetch.calls[0].url).toBe('https://api.example.com/list?tag=a&tag=b');
+  });
+
+  it('merges params into a URL that already has a query string', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    await client.get('/search?source=feed', { params: { q: 'x' } });
+    expect(deps.fetch.calls[0].url).toBe('https://api.example.com/search?source=feed&q=x');
+  });
+});
+
+describe('http.client — header merging + auth', () => {
+  it('merges base headers with per-request headers (per-request wins)', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      headers: { 'X-Base': 'b', Accept: 'application/json' },
+    });
+    await client.get('/x', { headers: { Accept: 'text/plain' } });
+    const headers = deps.fetch.calls[0].init?.headers as Record<string, string>;
+    expect(headers['X-Base']).toBe('b');
+    expect(headers['Accept']).toBe('text/plain');
+  });
+
+  it('attaches a Bearer Authorization header when token() resolves', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      token: async () => 'tok-1',
+    });
+    await client.get('/me');
+    const headers = deps.fetch.calls[0].init?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer tok-1');
+  });
+
+  it('re-resolves token() per request (no memoization)', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    let n = 0;
+    const token = vi.fn(async () => `tok-${++n}`);
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      token,
+    });
+    await client.get('/a');
+    await client.get('/b');
+    expect(token).toHaveBeenCalledTimes(2);
+    const h0 = deps.fetch.calls[0].init?.headers as Record<string, string>;
+    const h1 = deps.fetch.calls[1].init?.headers as Record<string, string>;
+    expect(h0['Authorization']).toBe('Bearer tok-1');
+    expect(h1['Authorization']).toBe('Bearer tok-2');
+  });
+
+  it('does not overwrite a caller-supplied Authorization header', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      token: () => 'should-not-win',
+    });
+    await client.get('/x', { headers: { Authorization: 'Basic abc' } });
+    const headers = deps.fetch.calls[0].init?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Basic abc');
+  });
+
+  it('skips Authorization when token() returns null/undefined', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      token: async () => null,
+    });
+    await client.get('/x');
+    const headers = deps.fetch.calls[0].init?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
+  });
+});
+
+describe('http.client — body + response parsing', () => {
+  it('stringifies object bodies and sets Content-Type to JSON by default', async () => {
+    const deps = makeDeps(() => jsonResponse({ created: true }));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    await client.post('/users', { body: { name: 'alice' } });
+    const init = deps.fetch.calls[0].init!;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(init.body).toBe(JSON.stringify({ name: 'alice' }));
+  });
+
+  it('passes through string bodies and respects caller Content-Type', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    await client.post('/raw', {
+      body: 'plain',
+      headers: { 'Content-Type': 'text/plain' },
+    });
+    const init = deps.fetch.calls[0].init!;
+    expect(init.body).toBe('plain');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('text/plain');
+  });
+
+  it('parses JSON responses based on content-type', async () => {
+    const deps = makeDeps(() => jsonResponse({ a: 1 }));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    const out = await client.get('/x');
+    expect(out).toEqual({ a: 1 });
+  });
+
+  it('returns text for non-JSON responses', async () => {
+    const deps = makeDeps(() => textResponse('hello'));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    const out = await client.get('/x');
+    expect(out).toBe('hello');
+  });
+
+  it('recognizes +json content-types', async () => {
+    const deps = makeDeps(
+      () =>
+        new Response(JSON.stringify({ v: 2 }), {
+          status: 200,
+          headers: { 'content-type': 'application/vnd.api+json' },
+        })
+    );
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    expect(await client.get('/x')).toEqual({ v: 2 });
+  });
+});
+
+describe('http.client — error handling', () => {
+  it('throws HttpError on !ok responses, including parsed JSON body', async () => {
+    const deps = makeDeps(
+      () =>
+        new Response(JSON.stringify({ error: 'nope' }), {
+          status: 404,
+          statusText: 'Not Found',
+          headers: { 'content-type': 'application/json' },
+        })
+    );
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    let caught: unknown;
+    try {
+      await client.get('/missing');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(HttpError);
+    const err = caught as HttpError;
+    expect(err.status).toBe(404);
+    expect(err.statusText).toBe('Not Found');
+    expect(err.body).toEqual({ error: 'nope' });
+  });
+});
+
+describe('http.client — retries', () => {
+  it('retries on 429 honoring Retry-After delta-seconds', async () => {
+    let n = 0;
+    const deps = makeDeps(() => {
+      n++;
+      if (n === 1) {
+        return new Response('rate limited', {
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers: { 'retry-after': '2' },
+        });
+      }
+      return jsonResponse({ ok: true });
+    });
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      retry: { on: [429], maxAttempts: 3 },
+    });
+    const out = await client.get('/x');
+    expect(out).toEqual({ ok: true });
+    expect(deps.fetch).toHaveBeenCalledTimes(2);
+    expect(deps.sleep.waits).toEqual([2000]);
+  });
+
+  it('retries on 503 with exponential backoff when Retry-After is absent', async () => {
+    let n = 0;
+    const deps = makeDeps(() => {
+      n++;
+      if (n < 3) return new Response('busy', { status: 503, statusText: 'Service Unavailable' });
+      return jsonResponse({ ok: true });
+    });
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      retry: { on: [503], maxAttempts: 4 },
+    });
+    await client.get('/x');
+    expect(deps.fetch).toHaveBeenCalledTimes(3);
+    // 500 * 2^0 = 500, 500 * 2^1 = 1000
+    expect(deps.sleep.waits).toEqual([500, 1000]);
+  });
+
+  it('parses HTTP-date Retry-After values', async () => {
+    let n = 0;
+    const future = new Date(Date.now() + 1500).toUTCString();
+    const deps = makeDeps(() => {
+      n++;
+      if (n === 1) {
+        return new Response('limited', {
+          status: 429,
+          headers: { 'retry-after': future },
+        });
+      }
+      return jsonResponse({ ok: true });
+    });
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      retry: { on: [429], maxAttempts: 2 },
+    });
+    await client.get('/x');
+    expect(deps.sleep.waits).toHaveLength(1);
+    // Accept any positive delay within a generous window — wall clock may drift.
+    expect(deps.sleep.waits[0]).toBeGreaterThan(0);
+    expect(deps.sleep.waits[0]).toBeLessThanOrEqual(2000);
+  });
+
+  it('throws after exhausting maxAttempts on a retryable status', async () => {
+    const deps = makeDeps(
+      () =>
+        new Response('still rate limited', {
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers: { 'retry-after': '0' },
+        })
+    );
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      retry: { on: [429], maxAttempts: 3 },
+    });
+    await expect(client.get('/x')).rejects.toBeInstanceOf(HttpError);
+    expect(deps.fetch).toHaveBeenCalledTimes(3);
+    expect(deps.sleep.waits).toEqual([0, 0]);
+  });
+
+  it('does not retry statuses outside retry.on', async () => {
+    const deps = makeDeps(
+      () => new Response('forbidden', { status: 403, statusText: 'Forbidden' })
+    );
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      retry: { on: [429, 503], maxAttempts: 3 },
+    });
+    await expect(client.get('/x')).rejects.toBeInstanceOf(HttpError);
+    expect(deps.fetch).toHaveBeenCalledTimes(1);
+    expect(deps.sleep).not.toHaveBeenCalled();
+  });
+
+  it('resolves the token once per request, fresh on the next request after expiry', async () => {
+    // Pins the per-request semantic: token() is called exactly once per
+    // request (not per retry attempt within a request), but a new
+    // request after a token has expired calls token() again — so
+    // skill.token's exec'd `oauth-token` refresh hook gets to run.
+    let attempts = 0;
+    const token = vi.fn(async () => `tok-${++attempts}`);
+    let reqCount = 0;
+    const deps = makeDeps(() => {
+      reqCount++;
+      // First request: 429 then 200 (one retry inside the request).
+      if (reqCount === 1) {
+        return new Response('limited', {
+          status: 429,
+          headers: { 'retry-after': '0' },
+        });
+      }
+      return jsonResponse({ ok: true });
+    });
+    const client = createHttpGlobal(deps).client({
+      baseUrl: 'https://api.example.com',
+      token,
+      retry: { on: [429], maxAttempts: 2 },
+    });
+    await client.get('/x');
+    expect(token).toHaveBeenCalledTimes(1);
+    expect(deps.fetch).toHaveBeenCalledTimes(2);
+    // A fresh request re-invokes token().
+    await client.get('/y');
+    expect(token).toHaveBeenCalledTimes(2);
+    const h0 = deps.fetch.calls[0].init?.headers as Record<string, string>;
+    const h2 = deps.fetch.calls[2].init?.headers as Record<string, string>;
+    expect(h0['Authorization']).toBe('Bearer tok-1');
+    expect(h2['Authorization']).toBe('Bearer tok-2');
+  });
+});
+
+describe('http.client — methods', () => {
+  it('routes get/post/put/delete to the correct HTTP method', async () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    await client.get('/g');
+    await client.post('/p');
+    await client.put('/u');
+    await client.delete('/d');
+    expect(deps.fetch.calls.map((c) => c.init?.method)).toEqual(['GET', 'POST', 'PUT', 'DELETE']);
+  });
+
+  it('returns a frozen client object', () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({});
+    expect(Object.isFrozen(client)).toBe(true);
+  });
+
+  it('returns a frozen http global', () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const http = createHttpGlobal(deps);
+    expect(Object.isFrozen(http)).toBe(true);
+  });
+});

--- a/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
+++ b/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
@@ -119,6 +119,40 @@ describe('createCli', () => {
     expect(exit).toHaveBeenCalledWith(42);
   });
 
+  it('die({ prefix }) replaces the default Error: label', () => {
+    const { cli, stderr } = makeCli();
+    expect(() => cli.die('boom', { prefix: 'FATAL' })).toThrow('__exit_1');
+    expect(stderr.join('')).toContain('FATAL:');
+    expect(stderr.join('')).not.toContain('Error:');
+  });
+
+  it('die({ prefix: "" }) suppresses the label entirely', () => {
+    const { cli, stderr } = makeCli();
+    expect(() => cli.die('plain', { prefix: '' })).toThrow('__exit_1');
+    expect(stderr.join('')).not.toContain(':');
+    expect(stderr.join('')).toContain('plain');
+  });
+
+  it('die({ exitCode, prefix }) uses both', () => {
+    const { cli, exit } = makeCli();
+    expect(() => cli.die('x', { exitCode: 7, prefix: 'FATAL' })).toThrow('__exit_7');
+    expect(exit).toHaveBeenCalledWith(7);
+  });
+
+  it('warn({ prefix }) replaces the default Warning: label', () => {
+    const { cli, stderr } = makeCli();
+    cli.warn('careful', { prefix: 'NOTICE' });
+    expect(stderr.join('')).toContain('NOTICE:');
+    expect(stderr.join('')).not.toContain('Warning:');
+  });
+
+  it('warn({ prefix: "" }) suppresses the label entirely', () => {
+    const { cli, stderr } = makeCli();
+    cli.warn('plain', { prefix: '' });
+    expect(stderr.join('')).not.toContain(':');
+    expect(stderr.join('')).toContain('plain');
+  });
+
   it('out(string) ensures a trailing newline; out(object) pretty-prints JSON', () => {
     const { cli, stdout } = makeCli();
     cli.out('hi');
@@ -208,6 +242,15 @@ describe('fmt', () => {
     expect(fmt.date(d, 'short')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     // 'human' is relative-to-now; just assert it stays a string.
     expect(typeof fmt.date(d, 'human')).toBe('string');
+  });
+
+  it("date('locale') uses Intl.DateTimeFormat medium style", () => {
+    const d = new Date('2026-05-28T12:34:56.000Z');
+    const out = fmt.date(d, 'locale');
+    expect(typeof out).toBe('string');
+    expect(out.length).toBeGreaterThan(0);
+    // Should match what Intl would have produced for the same input.
+    expect(out).toBe(new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(d));
   });
 });
 

--- a/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
+++ b/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
@@ -255,7 +255,7 @@ describe('sandbox.html mirror parity', () => {
       'utf-8'
     );
     // Surfaces the realm wires into AsyncFunction's named parameters.
-    for (const id of ['cli', 'c', 'time', 'fmt', 'pool', 'skill']) {
+    for (const id of ['cli', 'c', 'time', 'fmt', 'pool', 'skill', 'http']) {
       expect(sandbox).toContain(`'${id}'`);
     }
     // Symbols whose presence we want pinned so a refactor removing

--- a/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
+++ b/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the pure-JS runtime helpers (`parseFlags`, `cli`, `c`,
+ * `time`, `fmt`, `pool`) exposed inside the `.jsh` realm.
+ *
+ * The helpers are kernel-side; we exercise them directly without
+ * booting a worker. A separate parity check ensures the sandbox.html
+ * mirror surfaces stay in lockstep with this canonical TS module.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseFlags,
+  attachArgvParseFlags,
+  createCli,
+  createColor,
+  time,
+  fmt,
+  pool,
+} from '../../../src/kernel/realm/js-realm-helpers.js';
+
+describe('parseFlags', () => {
+  it('splits positional / flags from argv (skipping argv[0..1])', () => {
+    const out = parseFlags(['node', 'script.jsh', 'pos1', '--flag=val', 'pos2']);
+    expect(out.positional).toEqual(['pos1', 'pos2']);
+    expect(out.flags).toEqual({ flag: 'val' });
+    expect(out.passthrough).toEqual([]);
+  });
+
+  it('handles `--flag value` (space-separated) and `--flag` (boolean)', () => {
+    const out = parseFlags(['node', 's', '--name', 'alice', '--verbose']);
+    expect(out.flags).toEqual({ name: 'alice', verbose: true });
+  });
+
+  it('promotes repeated flags to an array, preserving order', () => {
+    const out = parseFlags(['node', 's', '--tag', 'a', '--tag=b', '--tag', 'c']);
+    expect(out.flags.tag).toEqual(['a', 'b', 'c']);
+  });
+
+  it('routes args after `--` to passthrough verbatim', () => {
+    const out = parseFlags(['node', 's', '--mode', 'fast', '--', '--not-a-flag', 'raw']);
+    expect(out.flags).toEqual({ mode: 'fast' });
+    expect(out.passthrough).toEqual(['--not-a-flag', 'raw']);
+  });
+
+  it('treats short flags as booleans, splitting `-abc` into a/b/c', () => {
+    const out = parseFlags(['node', 's', '-abc']);
+    expect(out.flags).toEqual({ a: true, b: true, c: true });
+  });
+
+  it('extracts subcommand from leading positional when it looks like a word', () => {
+    expect(parseFlags(['node', 's', 'list', '--json']).subcommand).toBe('list');
+    expect(parseFlags(['node', 's', '--json']).subcommand).toBeNull();
+    expect(parseFlags(['node', 's', '/abs/path']).subcommand).toBeNull();
+  });
+});
+
+describe('attachArgvParseFlags', () => {
+  it('exposes a non-enumerable parseFlags method on a fresh copy', () => {
+    const original = ['node', 'foo.jsh', 'pos', '--x=1'];
+    const attached = attachArgvParseFlags(original) as string[] & { parseFlags: () => unknown };
+    expect(attached).not.toBe(original);
+    expect([...attached]).toEqual(original);
+    expect(Object.keys(attached)).toEqual(['0', '1', '2', '3']);
+    expect(JSON.stringify(attached)).toBe(JSON.stringify(original));
+    const parsed = attached.parseFlags() as {
+      positional: string[];
+      flags: Record<string, unknown>;
+    };
+    expect(parsed.positional).toEqual(['pos']);
+    expect(parsed.flags).toEqual({ x: '1' });
+  });
+});
+
+describe('createColor', () => {
+  it('emits ANSI when isTTY=true and NO_COLOR is unset', () => {
+    const c = createColor({ isTTY: true, noColor: false });
+    expect(c.enabled).toBe(true);
+    expect(c.red('x')).toBe('\u001b[31mx\u001b[0m');
+    expect(c.green('y')).toBe('\u001b[32my\u001b[0m');
+  });
+
+  it('passes strings through unchanged when disabled', () => {
+    const c = createColor({ isTTY: false, noColor: false });
+    expect(c.enabled).toBe(false);
+    expect(c.red('x')).toBe('x');
+    const c2 = createColor({ isTTY: true, noColor: true });
+    expect(c2.red('x')).toBe('x');
+  });
+});
+
+describe('createCli', () => {
+  function makeCli(opts: { isTTY?: boolean } = {}) {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const exit = vi.fn((code: number) => {
+      throw new Error(`__exit_${code}`);
+    });
+    const cli = createCli({
+      writeStdout: (v) => stdout.push(v),
+      writeStderr: (v) => stderr.push(v),
+      exit: exit as unknown as (code: number) => never,
+      color: createColor({ isTTY: opts.isTTY ?? false, noColor: false }),
+    });
+    return { cli, stdout, stderr, exit };
+  }
+
+  it('die() writes Error: prefix to stderr and calls exit(1) by default', () => {
+    const { cli, stdout, stderr, exit } = makeCli();
+    expect(() => cli.die('boom')).toThrow('__exit_1');
+    expect(stdout).toEqual([]);
+    expect(stderr.join('')).toContain('Error:');
+    expect(stderr.join('')).toContain('boom');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('die() honors a custom exit code and unwraps Error messages', () => {
+    const { cli, exit } = makeCli();
+    expect(() => cli.die(new Error('nope'), 42)).toThrow('__exit_42');
+    expect(exit).toHaveBeenCalledWith(42);
+  });
+
+  it('out(string) ensures a trailing newline; out(object) pretty-prints JSON', () => {
+    const { cli, stdout } = makeCli();
+    cli.out('hi');
+    cli.out('hi\n');
+    cli.out({ a: 1 });
+    expect(stdout).toEqual(['hi\n', 'hi\n', '{\n  "a": 1\n}\n']);
+  });
+
+  it('warn() writes Warning: prefix to stderr without exiting', () => {
+    const { cli, stderr } = makeCli();
+    cli.warn('careful');
+    expect(stderr.join('')).toContain('Warning:');
+    expect(stderr.join('')).toContain('careful');
+  });
+
+  it('help() writes text to stdout then exit(0)', () => {
+    const { cli, stdout, exit } = makeCli();
+    expect(() => cli.help('Usage: foo')).toThrow('__exit_0');
+    expect(stdout.join('')).toBe('Usage: foo\n');
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+});
+
+describe('time', () => {
+  it('parseDuration recognizes ms|s|m|h|d|w|M|y and bare numbers', () => {
+    expect(time.parseDuration('1ms')).toBe(1);
+    expect(time.parseDuration('1s')).toBe(1000);
+    expect(time.parseDuration('2m')).toBe(120_000);
+    expect(time.parseDuration('1h')).toBe(3_600_000);
+    expect(time.parseDuration('7d')).toBe(604_800_000);
+    expect(time.parseDuration('2w')).toBe(1_209_600_000);
+    expect(time.parseDuration('1M')).toBe(2_629_800_000);
+    expect(time.parseDuration('1y')).toBe(31_557_600_000);
+    expect(time.parseDuration('500')).toBe(500);
+    expect(time.parseDuration(1234)).toBe(1234);
+  });
+
+  it('parseDuration throws on garbage', () => {
+    expect(() => time.parseDuration('seven days')).toThrow(/unrecognized/);
+    expect(() => time.parseDuration({} as unknown as string)).toThrow(TypeError);
+  });
+
+  it('ago / range / future are anchored to the `from` argument', () => {
+    const from = new Date('2026-05-28T12:00:00.000Z');
+    expect(time.ago('1h', from).toISOString()).toBe('2026-05-28T11:00:00.000Z');
+    const r = time.range('1h', from);
+    expect(r.start.toISOString()).toBe('2026-05-28T11:00:00.000Z');
+    expect(r.end.toISOString()).toBe('2026-05-28T12:00:00.000Z');
+    const f = time.future('1h', from);
+    expect(f.start.toISOString()).toBe('2026-05-28T12:00:00.000Z');
+    expect(f.end.toISOString()).toBe('2026-05-28T13:00:00.000Z');
+  });
+
+  it('gmailDate formats YYYY/MM/DD relative to `from`', () => {
+    const from = new Date('2026-05-28T12:00:00.000Z');
+    // Pick a UTC-stable duration so the test is timezone-agnostic-ish.
+    const out = time.gmailDate('0ms', from);
+    expect(out).toMatch(/^\d{4}\/\d{2}\/\d{2}$/);
+  });
+});
+
+describe('fmt', () => {
+  it('trunc shortens with an ellipsis when over budget', () => {
+    expect(fmt.trunc('hello', 10)).toBe('hello');
+    expect(fmt.trunc('hello world', 8)).toBe('hello w…');
+    expect(fmt.trunc('hello', 0)).toBe('');
+  });
+
+  it('col pads or truncates to width, ANSI-aware', () => {
+    expect(fmt.col('hi', 5)).toBe('hi   ');
+    expect(fmt.col('hello world', 5)).toBe('hell…');
+    const colored = '\u001b[31mhi\u001b[0m';
+    expect(fmt.col(colored, 5)).toBe(colored + '   ');
+  });
+
+  it('table auto-sizes columns by visible width', () => {
+    const out = fmt.table([
+      ['a', 'longer'],
+      ['cc', 'b'],
+    ]);
+    expect(out).toBe('a   longer\ncc  b');
+  });
+
+  it('date renders short / iso / human styles', () => {
+    const d = new Date('2026-05-28T12:34:56.000Z');
+    expect(fmt.date(d, 'iso')).toBe('2026-05-28T12:34:56.000Z');
+    expect(fmt.date(d, 'short')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // 'human' is relative-to-now; just assert it stays a string.
+    expect(typeof fmt.date(d, 'human')).toBe('string');
+  });
+});
+
+describe('pool', () => {
+  it('runs functions concurrently, capped to n, preserving input order', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const out = await pool(3, [10, 20, 30, 40, 50, 60], async (item) => {
+      inFlight++;
+      if (inFlight > peak) peak = inFlight;
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight--;
+      return item * 2;
+    });
+    expect(out).toEqual([20, 40, 60, 80, 100, 120]);
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(peak).toBeGreaterThan(0);
+  });
+
+  it('coerces n<1 to 1', async () => {
+    const out = await pool(0, [1, 2, 3], async (x) => x);
+    expect(out).toEqual([1, 2, 3]);
+  });
+
+  it('returns [] for empty input', async () => {
+    const out = await pool(4, [], async (x) => x);
+    expect(out).toEqual([]);
+  });
+});
+
+describe('sandbox.html mirror parity', () => {
+  // Single source of truth for the sandbox bootstrap. The TS surface
+  // is the canonical implementation; this test pins that the sandbox
+  // bootstrap script keeps a matching surface area (parity with
+  // js-realm-helpers.ts) so the extension float doesn't silently
+  // diverge from the worker float.
+  it('inlines every helper surface that the TS module exports', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve, dirname } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const here = dirname(fileURLToPath(import.meta.url));
+    const repoRoot = resolve(here, '..', '..', '..', '..', '..');
+    const sandbox = readFileSync(
+      resolve(repoRoot, 'packages/chrome-extension/sandbox.html'),
+      'utf-8'
+    );
+    // Surfaces the realm wires into AsyncFunction's named parameters.
+    for (const id of ['cli', 'c', 'time', 'fmt', 'pool', 'skill']) {
+      expect(sandbox).toContain(`'${id}'`);
+    }
+    // Symbols whose presence we want pinned so a refactor removing
+    // them in one file but not the other fails noisily.
+    for (const needle of [
+      'parseFlags',
+      'attachArgvParseFlagsImpl',
+      'gmailDate',
+      'parseDuration',
+      'NO_COLOR',
+    ]) {
+      expect(sandbox).toContain(needle);
+    }
+  });
+});

--- a/packages/webapp/tests/kernel/realm/realm-iframe.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-iframe.test.ts
@@ -211,3 +211,31 @@ describe('createIframeRealm', () => {
     }
   });
 });
+
+describe('sandbox.html ↔ js-realm-shared parity', () => {
+  // Static parity check — sandbox.html is a copy-only bundle asset
+  // (not part of the TS module graph), so changes to the worker
+  // realm's exec/fs surface easily drift from the iframe mirror.
+  // Both files are read as text and scanned for the agreed-upon
+  // tokens; the comment in sandbox.html already declares it's a
+  // mirror, this enforces it.
+  it('sandbox.html exposes exec.spawn matching js-realm-shared.ts', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const { fileURLToPath } = await import('node:url');
+    const path = await import('node:path');
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const repoRoot = path.resolve(here, '..', '..', '..', '..', '..');
+    const [sandbox, shared] = await Promise.all([
+      readFile(path.join(repoRoot, 'packages/chrome-extension/sandbox.html'), 'utf8'),
+      readFile(path.join(repoRoot, 'packages/webapp/src/kernel/realm/js-realm-shared.ts'), 'utf8'),
+    ]);
+    // Both surfaces must wire spawn through the same `'exec','spawn'`
+    // RPC tuple so the host's switch case matches in both floats.
+    expect(shared).toMatch(/rpc\.call\(\s*'exec'\s*,\s*'spawn'\s*,/);
+    expect(sandbox).toMatch(/rpcCall\(\s*'exec'\s*,\s*'spawn'\s*,/);
+    // And expose it on the `exec` bridge as `.spawn` so user code
+    // can call `await exec.spawn(['cmd', …])`.
+    expect(shared).toMatch(/spawn:\s*\(argv/);
+    expect(sandbox).toMatch(/execBridge\.spawn\s*=/);
+  });
+});

--- a/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
@@ -492,6 +492,73 @@ describe('realm RPC: exec channel', () => {
     await expect(client.call('exec', 'run', ['ls'])).rejects.toThrow(/exec is not available/);
     client.dispose();
   });
+
+  it('exec.spawn forwards argv tail via just-bash `args` (no shell parsing)', async () => {
+    // The quoting-trap canary: a literal `$peculiar` and an arg with
+    // spaces. Both MUST land in the `args` option verbatim — if they
+    // get folded into the command string they'd be word-split and
+    // env-expanded by the shell, which is exactly what spawn() exists
+    // to prevent.
+    const exec = vi.fn().mockResolvedValue({ stdout: 'ok', stderr: '', exitCode: 0 });
+    const ctx = makeCtx({ exec });
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+    const result = await client.call<{ stdout: string; stderr: string; exitCode: number }>(
+      'exec',
+      'spawn',
+      [['echo', 'arg with spaces', '$peculiar', '* glob']]
+    );
+    expect(result).toEqual({ stdout: 'ok', stderr: '', exitCode: 0 });
+    expect(exec).toHaveBeenCalledWith('echo', {
+      cwd: '/workspace',
+      args: ['arg with spaces', '$peculiar', '* glob'],
+    });
+    client.dispose();
+  });
+
+  it('exec.spawn rejects a non-array argv', async () => {
+    const exec = vi.fn();
+    const ctx = makeCtx({ exec });
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+    await expect(client.call('exec', 'spawn', ['not-an-array'])).rejects.toThrow(
+      /argv must be a non-empty string\[\]/
+    );
+    await expect(client.call('exec', 'spawn', [[]])).rejects.toThrow(
+      /argv must be a non-empty string\[\]/
+    );
+    await expect(client.call('exec', 'spawn', [['cmd', 42]])).rejects.toThrow(
+      /argv must be a non-empty string\[\]/
+    );
+    expect(exec).not.toHaveBeenCalled();
+    client.dispose();
+  });
+});
+
+describe('realm RPC: vfs.writeFile size cap', () => {
+  it('round-trips a 4 MiB string without skill-side chunking', async () => {
+    // The Concur skill (lines 80–110) used to base64-chunk content
+    // through a shell heredoc because `cat << EOF` had an argv cap.
+    // `fs.writeFile` is the canonical escape hatch: it ships the
+    // string through structured clone on the realm port, no shell
+    // argv involved. Pin the contract so a regression in the RPC
+    // path can't quietly reintroduce the cap.
+    const FOUR_MIB = 4 * 1024 * 1024;
+    const huge = 'x'.repeat(FOUR_MIB);
+    const fs = makeMockFs();
+    const ctx = makeCtx({ fs });
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+    await client.call('vfs', 'writeFile', ['/tmp/huge.txt', huge]);
+    const persisted = await fs.readFile('/tmp/huge.txt');
+    expect(persisted.length).toBe(FOUR_MIB);
+    expect(persisted.startsWith('xxxx')).toBe(true);
+    expect(persisted.endsWith('xxxx')).toBe(true);
+    client.dispose();
+  });
 });
 
 describe('realm RPC: fetch channel', () => {

--- a/packages/webapp/tests/kernel/realm/realm-runner.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-runner.test.ts
@@ -400,4 +400,81 @@ describe('runInRealm', () => {
     } satisfies RealmDoneMsg);
     await promise;
   });
+
+  // Regression: PR #786 review (Codex P2 — stamp websocket
+  // subscriptions with the owning scoop). `attachRealmHost` was
+  // being called without `scoopJid`, so `wsObserve` always stored
+  // `undefined` and `dropForScoop(jid)` matched nothing on
+  // `unregisterScoop`. The runner must thread `owner.scoopJid`
+  // into the realm host's options so `wsObserve` can stamp it.
+  it("threads owner.scoopJid into attachRealmHost (wsObserve stamps the subscriber's scoopJid)", async () => {
+    const pm = new ProcessManager();
+    const realm = makeMockRealm();
+    const observed: Array<{ scoopJid?: string }> = [];
+    const fakeRegistry = {
+      observe: async (req: { targetId: string; scoopJid?: string; forward: unknown }) => {
+        observed.push({ scoopJid: req.scoopJid });
+        return {
+          id: 'wssub-stub',
+          targetId: req.targetId,
+          forward: req.forward,
+          createdAt: new Date().toISOString(),
+        };
+      },
+      update: async () => ({}),
+      close: async () => true,
+      list: () => [],
+    };
+    const g = globalThis as { __slicc_wsSubscribers?: unknown; __slicc_browser?: unknown };
+    const originalReg = g.__slicc_wsSubscribers;
+    const originalBrowser = g.__slicc_browser;
+    g.__slicc_wsSubscribers = fakeRegistry;
+    // Stub a browser so `dispatchBrowser`'s `resolveBrowser(opts)` gate
+    // doesn't throw before reaching the `wsObserve` case.
+    g.__slicc_browser = {};
+    try {
+      const localCtx = {
+        fs: { resolvePath: (b: string, p: string) => `${b}/${p}` },
+      } as unknown as CommandContext;
+      const promise = runInRealm({
+        pm,
+        realmFactory: async () => realm,
+        owner: { kind: 'scoop', scoopJid: 'jid-X' },
+        kind: 'js',
+        code: '',
+        argv: ['node'],
+        env: {},
+        cwd: '/workspace',
+        filename: '<eval>',
+        ctx: localCtx,
+      });
+      // Wait for the factory + attachRealmHost.
+      await Promise.resolve();
+      await Promise.resolve();
+      // Realm-side issues a wsObserve via the RPC protocol.
+      realm.fireMessage({
+        type: 'realm-rpc-req',
+        id: 'req-1',
+        channel: 'browser',
+        op: 'wsObserve',
+        args: [{ targetId: 't1', forward: { sink: 'log' } }],
+      });
+      // Allow the async respond() to settle.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      realm.fireMessage({
+        type: 'realm-done',
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+      } satisfies RealmDoneMsg);
+      await promise;
+      expect(observed).toHaveLength(1);
+      expect(observed[0].scoopJid).toBe('jid-X');
+    } finally {
+      if (originalReg === undefined) delete g.__slicc_wsSubscribers;
+      else g.__slicc_wsSubscribers = originalReg;
+      if (originalBrowser === undefined) delete g.__slicc_browser;
+      else g.__slicc_browser = originalBrowser;
+    }
+  });
 });

--- a/packages/webapp/tests/kernel/realm/skill-global.test.ts
+++ b/packages/webapp/tests/kernel/realm/skill-global.test.ts
@@ -62,15 +62,30 @@ describe('createSkillGlobal — path math', () => {
     expect(skill.assets).toBe('/workspace/skills/concur/assets');
   });
 
-  it('handles a script at the filesystem root', () => {
+  it('handles a script at the filesystem root without double slashes', () => {
     const skill = createSkillGlobal({
       argv: ['node', '/runme.jsh'],
       fs: makeFs(),
       exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
     });
     expect(skill.dir).toBe('/');
-    expect(skill.refs).toBe('//references');
-    expect(skill.assets).toBe('//assets');
+    // Regression: previously produced `//references` / `//assets`
+    // because the helper concatenated `${dir}/...` unconditionally.
+    expect(skill.refs).toBe('/references');
+    expect(skill.assets).toBe('/assets');
+  });
+
+  it('reads/writes .config at the root without a doubled slash', async () => {
+    const fs = makeFs();
+    const skill = createSkillGlobal({
+      argv: ['node', '/runme.jsh'],
+      fs,
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    await skill.config({ apiBase: 'https://x' });
+    expect(fs.store.has('/.config')).toBe(true);
+    expect(fs.store.has('//.config')).toBe(false);
+    expect(await skill.config()).toEqual({ apiBase: 'https://x' });
   });
 
   it('falls back to empty dir when argv[1] has no slash', () => {

--- a/packages/webapp/tests/kernel/realm/skill-global.test.ts
+++ b/packages/webapp/tests/kernel/realm/skill-global.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for `createSkillGlobal` — the `skill` realm global.
+ *
+ * Covers:
+ *  - Path math (skill.dir / refs / assets) for typical, root, and
+ *    no-slash argv shapes.
+ *  - skill.config() round-trip: missing file → null, read after write,
+ *    shallow merge semantics, write error surfacing.
+ *  - skill.token(providerId) delegates to `oauth-token <id>`, shell-
+ *    quotes funny ids, propagates stderr on non-zero exit.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createSkillGlobal,
+  type SkillExecBridge,
+  type SkillFsBridge,
+} from '../../../src/kernel/realm/skill-global.js';
+
+function makeFs(initial: Record<string, string> = {}): SkillFsBridge & {
+  store: Map<string, string>;
+} {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    store,
+    async readFile(path: string) {
+      const v = store.get(path);
+      if (v === undefined) throw new Error('ENOENT: ' + path);
+      return v;
+    },
+    async writeFile(path: string, content: string) {
+      store.set(path, content);
+      return true as const;
+    },
+    async exists(path: string) {
+      return store.has(path);
+    },
+  };
+}
+
+function makeExec(
+  impl: (cmd: string) => { stdout: string; stderr: string; exitCode: number }
+): SkillExecBridge & { calls: string[] } {
+  const calls: string[] = [];
+  const exec = (async (cmd: string) => {
+    calls.push(cmd);
+    return impl(cmd);
+  }) as SkillExecBridge & { calls: string[] };
+  exec.calls = calls;
+  return exec;
+}
+
+describe('createSkillGlobal — path math', () => {
+  it('resolves dir/refs/assets from a typical argv[1]', () => {
+    const skill = createSkillGlobal({
+      argv: ['node', '/workspace/skills/concur/concur.jsh'],
+      fs: makeFs(),
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    expect(skill.dir).toBe('/workspace/skills/concur');
+    expect(skill.refs).toBe('/workspace/skills/concur/references');
+    expect(skill.assets).toBe('/workspace/skills/concur/assets');
+  });
+
+  it('handles a script at the filesystem root', () => {
+    const skill = createSkillGlobal({
+      argv: ['node', '/runme.jsh'],
+      fs: makeFs(),
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    expect(skill.dir).toBe('/');
+    expect(skill.refs).toBe('//references');
+    expect(skill.assets).toBe('//assets');
+  });
+
+  it('falls back to empty dir when argv[1] has no slash', () => {
+    const skill = createSkillGlobal({
+      argv: ['node', 'inline'],
+      fs: makeFs(),
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    expect(skill.dir).toBe('');
+    expect(skill.refs).toBe('references');
+    expect(skill.assets).toBe('assets');
+  });
+
+  it('produces a frozen object', () => {
+    const skill = createSkillGlobal({
+      argv: ['node', '/workspace/skills/x/x.jsh'],
+      fs: makeFs(),
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    expect(Object.isFrozen(skill)).toBe(true);
+  });
+});
+
+describe('skill.config()', () => {
+  const argv = ['node', '/workspace/skills/concur/concur.jsh'];
+  const configPath = '/workspace/skills/concur/.config';
+
+  it('returns null when the config file is missing', async () => {
+    const fs = makeFs();
+    const skill = createSkillGlobal({
+      argv,
+      fs,
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    expect(await skill.config()).toBeNull();
+  });
+
+  it('parses an existing JSON object', async () => {
+    const fs = makeFs({ [configPath]: '{"companyId":"123","mode":"prod"}' });
+    const skill = createSkillGlobal({
+      argv,
+      fs,
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    expect(await skill.config()).toEqual({ companyId: '123', mode: 'prod' });
+  });
+
+  it('writes a fresh config and round-trips it', async () => {
+    const fs = makeFs();
+    const skill = createSkillGlobal({
+      argv,
+      fs,
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    const merged = await skill.config({ companyId: '123' });
+    expect(merged).toEqual({ companyId: '123' });
+    expect(fs.store.has(configPath)).toBe(true);
+    expect(await skill.config()).toEqual({ companyId: '123' });
+  });
+
+  it('shallow-merges over existing keys', async () => {
+    const fs = makeFs({ [configPath]: '{"companyId":"123","mode":"prod"}' });
+    const skill = createSkillGlobal({
+      argv,
+      fs,
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    const merged = await skill.config({ mode: 'dev', newKey: true });
+    expect(merged).toEqual({ companyId: '123', mode: 'dev', newKey: true });
+    expect(await skill.config()).toEqual({ companyId: '123', mode: 'dev', newKey: true });
+  });
+});
+
+describe('skill.config() — error paths', () => {
+  const argv = ['node', '/workspace/skills/x/x.jsh'];
+  const configPath = '/workspace/skills/x/.config';
+
+  it('throws on malformed JSON', async () => {
+    const fs = makeFs({ [configPath]: 'not json {' });
+    const skill = createSkillGlobal({
+      argv,
+      fs,
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    await expect(skill.config()).rejects.toThrow(/failed to parse/);
+  });
+
+  it('throws when stored value is not a plain object', async () => {
+    const fs = makeFs({ [configPath]: '[1,2,3]' });
+    const skill = createSkillGlobal({
+      argv,
+      fs,
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    await expect(skill.config()).rejects.toThrow(/must contain a JSON object/);
+  });
+
+  it('rejects non-object updates', async () => {
+    const skill = createSkillGlobal({
+      argv,
+      fs: makeFs(),
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    await expect(skill.config([1, 2] as unknown as Record<string, unknown>)).rejects.toThrow(
+      TypeError
+    );
+    await expect(skill.config(null as unknown as Record<string, unknown>)).rejects.toThrow(
+      TypeError
+    );
+  });
+
+  it('treats empty file content as no config', async () => {
+    const fs = makeFs({ [configPath]: '   \n' });
+    const skill = createSkillGlobal({
+      argv,
+      fs,
+      exec: makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 })),
+    });
+    expect(await skill.config()).toBeNull();
+  });
+});
+
+describe('skill.token(providerId)', () => {
+  const argv = ['node', '/workspace/skills/concur/concur.jsh'];
+
+  it('delegates to oauth-token and returns trimmed stdout', async () => {
+    const exec = makeExec(() => ({ stdout: 'ghp_xxxxMASKEDxxxx\n', stderr: '', exitCode: 0 }));
+    const skill = createSkillGlobal({ argv, fs: makeFs(), exec });
+    const tok = await skill.token('github');
+    expect(tok).toBe('ghp_xxxxMASKEDxxxx');
+    expect(exec.calls).toEqual(['oauth-token github']);
+  });
+
+  it('shell-quotes provider ids with funny characters', async () => {
+    const exec = makeExec(() => ({ stdout: 'tok\n', stderr: '', exitCode: 0 }));
+    const skill = createSkillGlobal({ argv, fs: makeFs(), exec });
+    await skill.token('mcp:weird name');
+    expect(exec.calls[0]).toBe("oauth-token 'mcp:weird name'");
+  });
+
+  it('surfaces stderr on a non-zero exit', async () => {
+    const exec = makeExec(() => ({
+      stdout: '',
+      stderr: 'oauth-token: unknown provider "nope"\n',
+      exitCode: 1,
+    }));
+    const skill = createSkillGlobal({ argv, fs: makeFs(), exec });
+    await expect(skill.token('nope')).rejects.toThrow(/unknown provider/);
+  });
+
+  it('rejects empty providerId', async () => {
+    const exec = makeExec(() => ({ stdout: '', stderr: '', exitCode: 0 }));
+    const skill = createSkillGlobal({ argv, fs: makeFs(), exec });
+    await expect(skill.token('')).rejects.toThrow(TypeError);
+    await expect(skill.token('   ')).rejects.toThrow(TypeError);
+    expect(exec.calls).toEqual([]);
+  });
+
+  it('synthesizes a helpful error when stderr is empty', async () => {
+    const exec = makeExec(() => ({ stdout: '', stderr: '', exitCode: 2 }));
+    const skill = createSkillGlobal({ argv, fs: makeFs(), exec });
+    await expect(skill.token('github')).rejects.toThrow(/exited with code 2/);
+  });
+});
+
+describe('createSkillGlobal — end-to-end', () => {
+  it('integrates dir, config, and token through a typical skill flow', async () => {
+    const argv = ['node', '/workspace/skills/oryx/oryx.jsh'];
+    const fs = makeFs();
+    const exec = makeExec(() => ({ stdout: 'masked-token\n', stderr: '', exitCode: 0 }));
+    const skill = createSkillGlobal({ argv, fs, exec });
+
+    expect(skill.dir).toBe('/workspace/skills/oryx');
+    expect(await skill.config()).toBeNull();
+    await skill.config({ apiBase: 'https://oryx.example.com' });
+    expect(await skill.config()).toEqual({ apiBase: 'https://oryx.example.com' });
+
+    const stored = fs.store.get('/workspace/skills/oryx/.config');
+    expect(stored).toBeTypeOf('string');
+    expect(stored!.endsWith('\n')).toBe(true);
+    expect(JSON.parse(stored!)).toEqual({ apiBase: 'https://oryx.example.com' });
+
+    const tok = await skill.token('oryx');
+    expect(tok).toBe('masked-token');
+    expect(exec.calls).toEqual(['oauth-token oryx']);
+  });
+});
+
+// Silence unused-import warning for `vi` if no spy ends up in the file.
+void vi;


### PR DESCRIPTION
## Summary

Adds 8 jsh runtime extensions extracted from cross-skill analysis. All globals are available in both floats (worker float + extension sandbox-iframe float). This PR adds the runtime APIs only — skill migration to use them is a separate PR.

### What each wave delivers

| Wave | Global / API | Description |
|------|--------------|-------------|
| 1.1 | `process.argv.parseFlags`, `cli`, `c`, `time`, `fmt`, `pool` | Pure-JS helpers: flag parsing, exec wrapper, colors, time, formatting, concurrency pool |
| 1.2 | `skill.{dir,refs,assets,config,token}` | Skill realm: directory, refs, assets, config, OAuth token access |
| 1.3 | `exec.spawn(argv[])` | Argv-array spawn (no shell parsing). Confirmed `fs.writeFile` has no argv cap (4 MiB regression test). |
| 2.1 | `browser.{findTab,ensureTab,eval,evalAsync,cookie,localStorage}` | Tab discovery + transparent eval-result unwrap |
| 2.2 | `http.client({ baseUrl, token, retry })` | HTTP client with 429 `Retry-After` backoff |
| 3.1 | `browser.fetch(tab, url, opts)` | Single-IIFE page-context fetch (no temp-file dance) |
| 4.1 | `browser.websocket` | Declarative observer — closed sink enum (`webhook\|scoop\|vfs\|log`), runtime-owned page router, JSON selectors only (no function injection) |
| 4.2 | `CdpWsPageBridge` | Production CDP adapter wiring `Page.addScriptToEvaluateOnNewDocument` + `Runtime.addBinding` + `Runtime.bindingCalled`. End-to-end functional in CLI (CDPClient) and extension (DebuggerClient) floats. |

## Impact

**LoC**: ~2,900 lines of skill boilerplate eliminated once skills migrate to these APIs (migration is a separate PR).

**Security**: `browser.websocket` closes the Tessl/Snyk finding in `slack.jsh` — runtime-owned router, closed sink enum, declarative-only filters mean no untrusted function injection into the page.

## Tests

5,754 tests pass (14 skipped), 337 test files. New test files added in this PR:

- `packages/webapp/tests/kernel/realm/browser-websocket.test.ts` (440 lines)
- `packages/webapp/tests/cdp/cdp-ws-page-bridge.test.ts` (focused tests)
- Plus comprehensive RPC + script tests for Wave 3.1 (browser RPC channel + browser.fetch).

Each wave was independently verified before this PR was opened.

## Known limitations

- `skill.config(updates)` is not atomic under concurrent realms (read-merge-write race). Not in this PR's acceptance criteria — flagged for follow-up.
- Wave 4.1: send-as-discovery means receive-only WebSockets that never call `send()` aren't wrapped. Documented in the router source comment.

## Follow-ups (separate PRs)

- `slack.jsh` / `teams.jsh` / `linkedin.jsh` migration to use `browser.websocket` (closes ~270 LoC + the flagged security finding).
- Migrating other ~2,600 LoC of boilerplate across 23 surveyed skills to use `parseFlags` / `cli` / `c` / `time` / `fmt` / `pool` / `http.client` / `skill`.
- Optional Wave 4.2 polish: 2 additional ~15-LOC test cases for malformed-JSON drops and `dispose()` idempotency.

## Verification (all passed locally)

```bash
npx prettier --check .                       # All matched files use Prettier code style
npm run typecheck                            # tsc x5 configs, no errors
npm run test                                 # 5754 passed | 14 skipped (337 files)
npm run test:coverage                        # Lines 71.9%, Statements 70.2%, Branches 61.09%, Functions 71.56%
npm run build -w @slicc/webapp               # built in 1.50s
npm run build -w @slicc/chrome-extension     # built in 2.08s
```

### Pre-existing CI risk (not caused by this PR)

Full `npm run build` fails on `main` (since #783 / commit `32a586c7`) because `cloudflare-worker`'s `biome_wasm` (32.8 MiB) exceeds the 25 MiB Cloudflare bundle limit. If CI fails on the cloudflare-worker build, it is the pre-existing main branch issue, not this PR — webapp and chrome-extension per-workspace builds all pass.
