### PR TITLE
feat(webapp): render ANSI colors in bash tool output

### DIFF
--- a/packages/webapp/src/ui/ansi.ts
+++ b/packages/webapp/src/ui/ansi.ts
@@ -81,7 +81,9 @@ function extendedColor(params: number[], i: number): { color: string | null; con
     const b = clamp(params[i + 4] ?? 0);
     return { color: `rgb(${r},${g},${b})`, consumed: 5 };
   }
-  return { color: null, consumed: 1 };
+  // Unknown extended-color mode: skip the 38/48 and the mode byte together
+  // so the mode parameter is not re-interpreted as a standalone SGR code.
+  return { color: null, consumed: 2 };
 }
 
 function applyParams(prev: SgrState, params: number[]): SgrState {
@@ -150,7 +152,9 @@ const wrap = (chunk: string, state: SgrState): string => {
   return hasStyle(state) ? `<span style="${styleFor(state)}">${safe}</span>` : safe;
 };
 
-const ESC_PATTERN = /\x1b\[[?!#>]?[\d;]*[A-Za-z]|\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
+// CSI final byte per ECMA-48 is any 0x40-0x7E (`@` through `~`), which
+// covers letters plus `~` (bracketed paste, function keys), `@`, `` ` ``, etc.
+const ESC_PATTERN = /\x1b\[[?!#>]?[\d;]*[@-~]|\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
 const SGR_PATTERN = /^\x1b\[([\d;]*)m$/;
 
 /**

--- a/packages/webapp/src/ui/ansi.ts
+++ b/packages/webapp/src/ui/ansi.ts
@@ -150,10 +150,8 @@ const wrap = (chunk: string, state: SgrState): string => {
   return hasStyle(state) ? `<span style="${styleFor(state)}">${safe}</span>` : safe;
 };
 
- 
 const ESC_PATTERN = /\x1b\[[?!#>]?[\d;]*[A-Za-z]|\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
 const SGR_PATTERN = /^\x1b\[([\d;]*)m$/;
- 
 
 /**
  * Convert an ANSI-escaped string into a sanitized HTML fragment. The

--- a/packages/webapp/src/ui/ansi.ts
+++ b/packages/webapp/src/ui/ansi.ts
@@ -1,0 +1,183 @@
+/**
+ * ANSI escape-sequence renderer for bash tool output.
+ *
+ * Converts a string containing ANSI CSI/SGR sequences (colors, bold,
+ * underline, etc.) into a sanitized HTML fragment. Text content is
+ * HTML-escaped; styles are emitted as inline `style=` on `<span>` wrappers.
+ * Non-SGR CSI sequences (cursor movement, erase) and OSC sequences are
+ * stripped silently.
+ */
+
+import { escapeHtml } from './message-renderer.js';
+
+interface SgrState {
+  fg: string | null;
+  bg: string | null;
+  bold: boolean;
+  dim: boolean;
+  italic: boolean;
+  underline: boolean;
+  strike: boolean;
+  inverse: boolean;
+}
+
+const BASIC = [
+  '#000000',
+  '#cd3131',
+  '#0dbc79',
+  '#e5e510',
+  '#2472c8',
+  '#bc3fbc',
+  '#11a8cd',
+  '#e5e5e5',
+];
+const BRIGHT = [
+  '#666666',
+  '#f14c4c',
+  '#23d18b',
+  '#f5f543',
+  '#3b8eea',
+  '#d670d6',
+  '#29b8db',
+  '#ffffff',
+];
+
+const initial = (): SgrState => ({
+  fg: null,
+  bg: null,
+  bold: false,
+  dim: false,
+  italic: false,
+  underline: false,
+  strike: false,
+  inverse: false,
+});
+
+const clamp = (n: number): number => Math.max(0, Math.min(255, Math.floor(n) || 0));
+
+function xterm256(n: number): string {
+  if (n < 0 || n > 255) return '';
+  if (n < 8) return BASIC[n];
+  if (n < 16) return BRIGHT[n - 8];
+  if (n < 232) {
+    const k = n - 16;
+    const map = [0, 95, 135, 175, 215, 255];
+    return `rgb(${map[Math.floor(k / 36)]},${map[Math.floor((k % 36) / 6)]},${map[k % 6]})`;
+  }
+  const v = 8 + (n - 232) * 10;
+  return `rgb(${v},${v},${v})`;
+}
+
+/** Resolve an extended-color token starting at `params[i]` (38 or 48). */
+function extendedColor(params: number[], i: number): { color: string | null; consumed: number } {
+  const mode = params[i + 1];
+  if (mode === 5) {
+    const n = params[i + 2];
+    return { color: typeof n === 'number' ? xterm256(n) : null, consumed: 3 };
+  }
+  if (mode === 2) {
+    const r = clamp(params[i + 2] ?? 0);
+    const g = clamp(params[i + 3] ?? 0);
+    const b = clamp(params[i + 4] ?? 0);
+    return { color: `rgb(${r},${g},${b})`, consumed: 5 };
+  }
+  return { color: null, consumed: 1 };
+}
+
+function applyParams(prev: SgrState, params: number[]): SgrState {
+  const s = { ...prev };
+  const arr = params.length === 0 ? [0] : params;
+  for (let i = 0; i < arr.length; i++) {
+    const p = arr[i];
+    if (p === 0) Object.assign(s, initial());
+    else if (p === 1) s.bold = true;
+    else if (p === 2) s.dim = true;
+    else if (p === 3) s.italic = true;
+    else if (p === 4) s.underline = true;
+    else if (p === 7) s.inverse = true;
+    else if (p === 9) s.strike = true;
+    else if (p === 22) {
+      s.bold = false;
+      s.dim = false;
+    } else if (p === 23) s.italic = false;
+    else if (p === 24) s.underline = false;
+    else if (p === 27) s.inverse = false;
+    else if (p === 29) s.strike = false;
+    else if (p >= 30 && p <= 37) s.fg = BASIC[p - 30];
+    else if (p === 38) {
+      const r = extendedColor(arr, i);
+      if (r.color) s.fg = r.color;
+      i += r.consumed - 1;
+    } else if (p === 39) s.fg = null;
+    else if (p >= 40 && p <= 47) s.bg = BASIC[p - 40];
+    else if (p === 48) {
+      const r = extendedColor(arr, i);
+      if (r.color) s.bg = r.color;
+      i += r.consumed - 1;
+    } else if (p === 49) s.bg = null;
+    else if (p >= 90 && p <= 97) s.fg = BRIGHT[p - 90];
+    else if (p >= 100 && p <= 107) s.bg = BRIGHT[p - 100];
+  }
+  return s;
+}
+
+function styleFor(state: SgrState): string {
+  let fg = state.fg;
+  let bg = state.bg;
+  if (state.inverse) {
+    const swap = fg;
+    fg = bg ?? '#e6e6e6';
+    bg = swap ?? '#0d0d0f';
+  }
+  const parts: string[] = [];
+  if (fg) parts.push(`color:${fg}`);
+  if (bg) parts.push(`background-color:${bg}`);
+  if (state.bold) parts.push('font-weight:600');
+  if (state.dim) parts.push('opacity:.7');
+  if (state.italic) parts.push('font-style:italic');
+  const deco: string[] = [];
+  if (state.underline) deco.push('underline');
+  if (state.strike) deco.push('line-through');
+  if (deco.length) parts.push(`text-decoration:${deco.join(' ')}`);
+  return parts.join(';');
+}
+
+const hasStyle = (s: SgrState): boolean =>
+  !!(s.fg || s.bg || s.bold || s.dim || s.italic || s.underline || s.strike || s.inverse);
+
+const wrap = (chunk: string, state: SgrState): string => {
+  const safe = escapeHtml(chunk);
+  return hasStyle(state) ? `<span style="${styleFor(state)}">${safe}</span>` : safe;
+};
+
+ 
+const ESC_PATTERN = /\x1b\[[?!#>]?[\d;]*[A-Za-z]|\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
+const SGR_PATTERN = /^\x1b\[([\d;]*)m$/;
+ 
+
+/**
+ * Convert an ANSI-escaped string into a sanitized HTML fragment. The
+ * returned string is safe to assign to `innerHTML`: every text segment
+ * is HTML-escaped; only `<span>` wrappers with inline styles are added.
+ */
+export function ansiToHtml(text: string): string {
+  if (!text) return '';
+  let out = '';
+  let last = 0;
+  let state = initial();
+  ESC_PATTERN.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = ESC_PATTERN.exec(text)) !== null) {
+    const chunk = text.slice(last, m.index);
+    if (chunk) out += wrap(chunk, state);
+    const sgr = SGR_PATTERN.exec(m[0]);
+    if (sgr) {
+      const params = sgr[1] === '' ? [] : sgr[1].split(';').map((n) => Number(n) || 0);
+      state = applyParams(state, params);
+    }
+    last = m.index + m[0].length;
+  }
+  const tail = text.slice(last);
+  if (tail) out += wrap(tail, state);
+  return out;
+}

--- a/packages/webapp/src/ui/tool-call-view.ts
+++ b/packages/webapp/src/ui/tool-call-view.ts
@@ -32,6 +32,7 @@ import {
 import type { ToolCall } from './types.js';
 import { escapeHtml } from './message-renderer.js';
 import { maskSecrets } from './preview-masking.js';
+import { ansiToHtml } from './ansi.js';
 
 type IconNode = [tag: string, attrs: Record<string, string | number>][];
 
@@ -453,7 +454,7 @@ function renderBashBody(tc: ToolCall): HTMLElement {
   if (tc.result !== undefined) {
     const out = document.createElement('pre');
     out.className = `tool-call__terminal-output${tc.isError ? ' tool-call__terminal-output--error' : ''}`;
-    out.textContent = tc.result;
+    out.innerHTML = ansiToHtml(tc.result);
     body.appendChild(out);
   } else {
     const pending = document.createElement('div');

--- a/packages/webapp/tests/ui/ansi.test.ts
+++ b/packages/webapp/tests/ui/ansi.test.ts
@@ -57,9 +57,24 @@ describe('ansiToHtml', () => {
     expect(out).toBe('abcd');
   });
 
+  it('strips CSI sequences with non-letter final bytes (~, @, `)', () => {
+    // Bracketed paste markers (\x1b[200~ / \x1b[201~) and other final
+    // bytes in 0x40-0x7E must be stripped, not leaked into the output.
+    const out = ansiToHtml('a\x1b[200~paste\x1b[201~b\x1b[5@c\x1b[2`d');
+    expect(out).toBe('apastebcd');
+  });
+
   it('strips OSC sequences terminated by BEL', () => {
     const out = ansiToHtml('pre\x1b]0;title\x07post');
     expect(out).toBe('prepost');
+  });
+
+  it('ignores unknown 38/<mode> extended-color sequences without leaking the mode byte', () => {
+    // `\x1b[38;1m` is an unknown extended-color mode. The 1 must NOT be
+    // re-interpreted as the standalone "bold" SGR code after the 38 is
+    // skipped — the entire sequence should be a no-op style-wise.
+    expect(ansiToHtml('\x1b[38;1mx\x1b[0m')).toBe('x');
+    expect(ansiToHtml('\x1b[48;4mx\x1b[0m')).toBe('x');
   });
 
   it('escapes HTML inside a styled span', () => {

--- a/packages/webapp/tests/ui/ansi.test.ts
+++ b/packages/webapp/tests/ui/ansi.test.ts
@@ -92,4 +92,58 @@ describe('ansiToHtml', () => {
     expect(out).toContain('<span style="color:#cd3131;background-color:#2472c8">ab</span>');
     expect(out).toContain('<span style="background-color:#2472c8">c</span>');
   });
+
+  // Ampersand handling — these guard against two failure modes:
+  //   1) "swallowed": innerHTML parses an unescaped `&foo;` as an HTML entity.
+  //   2) "double-escaped": user sees literal `&amp;` on screen because the
+  //      renderer escapes an already-escaped string twice.
+  // The renderer's contract is "raw text in, escape exactly once" — so a
+  // literal `&amp;` in the source IS expected to render as `&amp;` on screen
+  // (the source said so). The cases below pin that contract.
+  describe('ampersand handling', () => {
+    it('escapes a bare & once between chunks', () => {
+      expect(ansiToHtml('foo & bar')).toBe('foo &amp; bar');
+    });
+
+    it('escapes & that opens an entity-shaped name (no swallowing)', () => {
+      expect(ansiToHtml('AT&T &copy; &#65;')).toBe('AT&amp;T &amp;copy; &amp;#65;');
+    });
+
+    it('escapes & in a URL query string', () => {
+      expect(ansiToHtml('curl http://x?a=1&b=2&c=3')).toBe('curl http://x?a=1&amp;b=2&amp;c=3');
+    });
+
+    it('escapes literal &amp; from source exactly once (no double-escape regression)', () => {
+      // The source bytes are literally `&amp;`. Escaping them once yields
+      // `&amp;amp;`, which the browser renders as the visible text `&amp;`
+      // — matching what the user typed. Escaping twice would surface
+      // `&amp;amp;` on screen, which is the bug we are guarding against.
+      expect(ansiToHtml('foo &amp; bar')).toBe('foo &amp;amp; bar');
+    });
+
+    it('escapes & at the boundary just before a CSI sequence', () => {
+      expect(ansiToHtml('foo &\x1b[31mbar\x1b[0m')).toBe(
+        'foo &amp;<span style="color:#cd3131">bar</span>'
+      );
+    });
+
+    it('escapes & at the boundary just after a CSI reset', () => {
+      expect(ansiToHtml('\x1b[31mfoo\x1b[0m& bar')).toBe(
+        '<span style="color:#cd3131">foo</span>&amp; bar'
+      );
+    });
+
+    it('escapes & sitting alone inside a styled span', () => {
+      expect(ansiToHtml('\x1b[33m&\x1b[0m')).toBe('<span style="color:#e5e510">&amp;</span>');
+    });
+
+    it('escapes & at the very start and very end of input', () => {
+      expect(ansiToHtml('& foo')).toBe('&amp; foo');
+      expect(ansiToHtml('foo &')).toBe('foo &amp;');
+    });
+
+    it('escapes adjacent &s without merging or dropping any', () => {
+      expect(ansiToHtml('A&&B&&&C')).toBe('A&amp;&amp;B&amp;&amp;&amp;C');
+    });
+  });
 });

--- a/packages/webapp/tests/ui/ansi.test.ts
+++ b/packages/webapp/tests/ui/ansi.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the ANSI-to-HTML renderer used by the bash tool body.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ansiToHtml } from '../../src/ui/ansi.js';
+
+describe('ansiToHtml', () => {
+  it('returns an empty string for empty input', () => {
+    expect(ansiToHtml('')).toBe('');
+  });
+
+  it('escapes HTML in plain text without ANSI codes', () => {
+    expect(ansiToHtml('a <b> & "c"')).toBe('a &lt;b&gt; &amp; &quot;c&quot;');
+  });
+
+  it('renders basic foreground colors as inline-styled spans', () => {
+    const out = ansiToHtml('\x1b[31mred\x1b[0m plain');
+    expect(out).toContain('<span style="color:#cd3131">red</span>');
+    expect(out).toContain(' plain');
+  });
+
+  it('resets state on \\x1b[0m so following text is unstyled', () => {
+    const out = ansiToHtml('\x1b[32mok\x1b[0mtail');
+    expect(out).toBe('<span style="color:#0dbc79">ok</span>tail');
+  });
+
+  it('treats an empty SGR sequence as a full reset', () => {
+    const out = ansiToHtml('\x1b[33mwarn\x1b[mtail');
+    expect(out).toBe('<span style="color:#e5e510">warn</span>tail');
+  });
+
+  it('combines bold and underline modifiers with color', () => {
+    const out = ansiToHtml('\x1b[1;4;34mhi\x1b[0m');
+    expect(out).toContain('color:#2472c8');
+    expect(out).toContain('font-weight:600');
+    expect(out).toContain('text-decoration:underline');
+  });
+
+  it('handles bright foreground colors (90-97)', () => {
+    const out = ansiToHtml('\x1b[91merr\x1b[0m');
+    expect(out).toContain('color:#f14c4c');
+  });
+
+  it('supports 256-color foreground via 38;5;n', () => {
+    const out = ansiToHtml('\x1b[38;5;9mx\x1b[0m');
+    expect(out).toContain('color:#f14c4c');
+  });
+
+  it('supports truecolor foreground via 38;2;r;g;b', () => {
+    const out = ansiToHtml('\x1b[38;2;10;20;30mx\x1b[0m');
+    expect(out).toContain('color:rgb(10,20,30)');
+  });
+
+  it('strips non-SGR CSI sequences like cursor moves and erase', () => {
+    const out = ansiToHtml('a\x1b[2Jb\x1b[Kc\x1b[10;5Hd');
+    expect(out).toBe('abcd');
+  });
+
+  it('strips OSC sequences terminated by BEL', () => {
+    const out = ansiToHtml('pre\x1b]0;title\x07post');
+    expect(out).toBe('prepost');
+  });
+
+  it('escapes HTML inside a styled span', () => {
+    const out = ansiToHtml('\x1b[31m<x>&\x1b[0m');
+    expect(out).toBe('<span style="color:#cd3131">&lt;x&gt;&amp;</span>');
+  });
+
+  it('keeps an unterminated style applied to trailing text', () => {
+    const out = ansiToHtml('\x1b[32mstill green');
+    expect(out).toBe('<span style="color:#0dbc79">still green</span>');
+  });
+
+  it('returns plain text unchanged when no style is active', () => {
+    expect(ansiToHtml('just text')).toBe('just text');
+  });
+
+  it('renders inverse video by swapping fg/bg', () => {
+    const out = ansiToHtml('\x1b[31;7minv\x1b[0m');
+    expect(out).toContain('background-color:#cd3131');
+    expect(out).toContain('color:#e6e6e6');
+  });
+
+  it('renders background colors (40-47)', () => {
+    const out = ansiToHtml('\x1b[44mbg\x1b[0m');
+    expect(out).toContain('background-color:#2472c8');
+  });
+
+  it('39 resets foreground without touching background', () => {
+    const out = ansiToHtml('\x1b[31;44mab\x1b[39mc\x1b[0m');
+    expect(out).toContain('<span style="color:#cd3131;background-color:#2472c8">ab</span>');
+    expect(out).toContain('<span style="background-color:#2472c8">c</span>');
+  });
+});


### PR DESCRIPTION
The bash tool's expanded body in chat history previously rendered its result via `pre.textContent`, which displayed ANSI escape sequences (`\x1b[31m...`) as literal characters instead of styling the text.

This PR adds a small ANSI-to-HTML renderer (`packages/webapp/src/ui/ansi.ts`) and wires it into `renderBashBody` so SGR sequences are translated into styled `<span>` wrappers.

### Supported
- Reset (`0`), bold (`1`), dim (`2`), italic (`3`), underline (`4`), inverse (`7`), strikethrough (`9`) and their reset codes
- Standard fg/bg colors (`30-37`, `40-47`) and bright variants (`90-97`, `100-107`)
- 256-color (`38;5;n`, `48;5;n`) including the 6×6×6 cube and grayscale ramp
- Truecolor (`38;2;r;g;b`, `48;2;r;g;b`)
- Default fg/bg restore (`39`, `49`)

### Stripped silently
- Non-SGR CSI sequences (cursor movement, erase, etc.)
- OSC sequences (`\x1b]...\x07` or `\x1b]...\x1b\\`)

Text segments are always HTML-escaped before composition, so the resulting fragment is safe to assign to `innerHTML`.

### Tests
Added `packages/webapp/tests/ui/ansi.test.ts` with 17 cases covering plain text, escaping, basic/bright/256/truecolor, modifier combinations, OSC + non-SGR stripping, inverse video, and partial state at end-of-input.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author