### PR TITLE
feat(webapp): add OpenAI Codex (ChatGPT subscription) provider

### DIFF
--- a/packages/webapp/providers/openai-codex.ts
+++ b/packages/webapp/providers/openai-codex.ts
@@ -73,16 +73,15 @@ const CODEX_API: Api = `${PROVIDER_ID}-openai` as Api;
 // ── Models ─────────────────────────────────────────────────────────
 //
 // Mirrors the `openai-codex` catalog shipped in pi-ai's
-// `models.generated`. `thinkingLevelMap` is forwarded as an extra key —
-// the metadata layer in `provider-settings.ts` spreads unknown keys onto
-// the model record, and the codex stream reads `model.thinkingLevelMap`
-// to map reasoning effort.
+// `models.generated`. `thinkingLevelMap` is a `ModelMetadata` field that
+// `applyModelMetadata` (in `provider-settings.ts`) merges onto the model
+// record — the codex stream reads `model.thinkingLevelMap` to translate
+// the reasoning effort, so the `minimal` → `low` remap below must survive
+// the metadata merge (the chatgpt Codex backend rejects `minimal`).
 
-type CodexModelDef = { id: string; name: string } & ModelMetadata & {
-    thinkingLevelMap?: Record<string, string>;
-  };
+type CodexModelDef = { id: string; name: string } & ModelMetadata;
 
-const CODEX_THINKING_LEVEL_MAP: Record<string, string> = { xhigh: 'xhigh', minimal: 'low' };
+const CODEX_THINKING_LEVEL_MAP: Record<string, string | null> = { xhigh: 'xhigh', minimal: 'low' };
 
 const CODEX_MODELS: CodexModelDef[] = [
   { id: 'gpt-5.5', name: 'GPT-5.5', input: ['text', 'image'] },
@@ -195,36 +194,40 @@ async function refreshAccessToken(refresh: string): Promise<TokenResponse | null
 // The stream function re-derives the account id from the token itself, so
 // we only persist a human-friendly label here.
 
-function getEmail(accessToken: string): string | undefined {
+// JWT segments are base64url (RFC 7515): `-`/`_` instead of `+`/`/` and no
+// padding. `atob` only accepts standard base64, so restore the alphabet and
+// pad before decoding — otherwise valid tokens whose payload happens to
+// contain those characters throw and we silently drop the profile metadata.
+function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
   try {
-    const parts = accessToken.split('.');
+    const parts = token.split('.');
     if (parts.length !== 3) return undefined;
-    const payload = JSON.parse(atob(parts[1]!)) as Record<string, unknown>;
-    const profile = payload['https://api.openai.com/profile'] as { email?: unknown } | undefined;
-    return typeof profile?.email === 'string' ? profile.email : undefined;
+    let b64 = parts[1]!.replace(/-/g, '+').replace(/_/g, '/');
+    if (b64.length % 4) b64 += '='.repeat(4 - (b64.length % 4));
+    return JSON.parse(atob(b64)) as Record<string, unknown>;
   } catch {
     return undefined;
   }
 }
 
+function getEmail(accessToken: string): string | undefined {
+  const payload = decodeJwtPayload(accessToken);
+  const profile = payload?.['https://api.openai.com/profile'] as { email?: unknown } | undefined;
+  return typeof profile?.email === 'string' ? profile.email : undefined;
+}
+
 function getDisplayName(accessToken: string): string | undefined {
-  try {
-    const parts = accessToken.split('.');
-    if (parts.length !== 3) return undefined;
-    const payload = JSON.parse(atob(parts[1]!)) as Record<string, unknown>;
-    const auth = payload['https://api.openai.com/auth'] as
-      | { chatgpt_plan_type?: unknown }
-      | undefined;
-    const email = getEmail(accessToken);
-    const plan = typeof auth?.chatgpt_plan_type === 'string' ? auth.chatgpt_plan_type : undefined;
-    const planLabel = plan ? plan.charAt(0).toUpperCase() + plan.slice(1) : undefined;
-    if (email && planLabel) return `${email} (${planLabel})`;
-    if (email) return email;
-    if (planLabel) return `ChatGPT ${planLabel}`;
-    return undefined;
-  } catch {
-    return undefined;
-  }
+  const payload = decodeJwtPayload(accessToken);
+  const auth = payload?.['https://api.openai.com/auth'] as
+    | { chatgpt_plan_type?: unknown }
+    | undefined;
+  const email = getEmail(accessToken);
+  const plan = typeof auth?.chatgpt_plan_type === 'string' ? auth.chatgpt_plan_type : undefined;
+  const planLabel = plan ? plan.charAt(0).toUpperCase() + plan.slice(1) : undefined;
+  if (email && planLabel) return `${email} (${planLabel})`;
+  if (email) return email;
+  if (planLabel) return `ChatGPT ${planLabel}`;
+  return undefined;
 }
 
 // ── Profile picture (Gravatar) ─────────────────────────────────────
@@ -379,16 +382,13 @@ export const config: ProviderConfig = {
   id: PROVIDER_ID,
   name: 'OpenAI Codex (ChatGPT Subscription)',
   description:
-    'GPT-5 Codex via your ChatGPT Plus/Pro/Business subscription — OAuth login, no API key needed. Default model is GPT-5.3 Codex.',
+    'GPT-5 Codex via your ChatGPT Plus/Pro/Business subscription — OAuth login, no API key needed. Default model is GPT-5.5.',
   requiresApiKey: false,
   requiresBaseUrl: false,
   isOAuth: true,
-  defaultModelId: 'gpt-5.3-codex',
+  defaultModelId: 'gpt-5.5',
   oauthTokenDomains: ['chatgpt.com', '*.chatgpt.com', 'auth.openai.com', 'api.openai.com'],
-  getModelIds: () =>
-    CODEX_MODELS.map((m) =>
-      m.thinkingLevelMap ? { ...m, thinkingLevelMap: m.thinkingLevelMap } : m
-    ),
+  getModelIds: () => CODEX_MODELS,
 
   onOAuthLoginIntercepted: async (
     launcher: InterceptingOAuthLauncher,
@@ -427,7 +427,11 @@ export const config: ProviderConfig = {
     if (!code) {
       throw new Error('OpenAI Codex OAuth redirect did not include a code');
     }
-    if (returnedState && returnedState !== state) {
+    // Strict equality (matching the Codex CLI): a callback without `state` —
+    // e.g. a stray or forged navigation to the loopback redirect during a
+    // pending login — must be rejected exactly like a mismatched value, or
+    // the CSRF binding for this intercepted browser redirect is lost.
+    if (returnedState !== state) {
       throw new Error('OpenAI Codex OAuth state mismatch — possible CSRF, aborting');
     }
 

--- a/packages/webapp/providers/openai-codex.ts
+++ b/packages/webapp/providers/openai-codex.ts
@@ -1,0 +1,477 @@
+/**
+ * OpenAI Codex Provider — ChatGPT (Codex subscription) OAuth via the
+ * intercepted-redirect flow.
+ *
+ * Auth: reuses OpenAI's public Codex-CLI OAuth client
+ * (`app_EMoamEEZ73f0CkXaXp7hrann`), the same client pi-ai's CLI codex
+ * login and the official `codex` CLI use. OpenAI's OAuth client only
+ * trusts the loopback redirect `http://localhost:1455/auth/callback`, so
+ * we send that as `redirect_uri`, intercept the navigation to it via CDP
+ * `Fetch.requestPaused`, and never bind the port. This is the browser
+ * equivalent of pi-ai's `loginOpenAICodex`, which binds a Node `http`
+ * server on :1455 and is therefore CLI-only.
+ *
+ * Endpoints, client id, scopes, and the `codex_cli_simplified_flow` /
+ * `id_token_add_organizations` authorize params mirror
+ * `@earendil-works/pi-ai`'s `utils/oauth/openai-codex.ts`.
+ *
+ * Models + streaming delegate to pi-ai's `openai-codex-responses` API
+ * (`streamOpenAICodexResponses`). The account id is carried inside the
+ * access-token JWT (`https://api.openai.com/auth.chatgpt_account_id`) and
+ * re-extracted by the stream function, so we only persist the tokens.
+ * Transport is forced to `sse`: browser `WebSocket` can't set the
+ * `Authorization` / `chatgpt-account-id` headers the WebSocket transport
+ * needs, so we skip the doomed WS attempt and stream over fetch (which
+ * also routes through slicc's LLM proxy for the cross-origin call).
+ */
+
+import type {
+  ProviderConfig,
+  InterceptingOAuthLauncher,
+  OAuthLoginOptions,
+  ModelMetadata,
+} from '../src/providers/types.js';
+import {
+  registerApiProvider,
+  streamOpenAICodexResponses,
+  streamSimpleOpenAICodexResponses,
+  createAssistantMessageEventStream,
+} from '@earendil-works/pi-ai';
+import type {
+  Api,
+  Model,
+  Context,
+  SimpleStreamOptions,
+  ProviderStreamOptions,
+} from '@earendil-works/pi-ai';
+import { saveOAuthAccount, getAccounts } from '../src/ui/provider-settings.js';
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const PROVIDER_ID = 'openai-codex';
+
+// Public Codex-CLI OAuth client. Same id appears in pi-ai's codex login
+// and the official codex CLI.
+const CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const CODEX_AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize';
+const CODEX_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const CODEX_SCOPE = 'openid profile email offline_access';
+// OpenAI only trusts this loopback redirect for the Codex-CLI client.
+const CODEX_REDIRECT_URI = 'http://localhost:1455/auth/callback';
+const CODEX_REDIRECT_PATTERN = 'http://localhost:1455/auth/callback*';
+const CODEX_BASE_URL = 'https://chatgpt.com/backend-api';
+// pi-ai's actual codex responses-API name — used when we delegate to
+// `streamOpenAICodexResponses` after auth.
+const OPENAI_CODEX_RESPONSES_API: Api = 'openai-codex-responses';
+// The api slicc tags each model with: `provider-settings.ts` rewrites
+// `api: 'openai'` from `getModelIds()` to `${providerId}-openai`. We
+// register our streams under this name so the agent loop routes codex
+// turns to *us* (OAuth + sse transport), not to a stock OpenAI path.
+// Same indirection as `xai-grok.ts` / `built-in/local-llm.ts`.
+const CODEX_API: Api = `${PROVIDER_ID}-openai` as Api;
+
+// ── Models ─────────────────────────────────────────────────────────
+//
+// Mirrors the `openai-codex` catalog shipped in pi-ai's
+// `models.generated`. `thinkingLevelMap` is forwarded as an extra key —
+// the metadata layer in `provider-settings.ts` spreads unknown keys onto
+// the model record, and the codex stream reads `model.thinkingLevelMap`
+// to map reasoning effort.
+
+type CodexModelDef = { id: string; name: string } & ModelMetadata & {
+    thinkingLevelMap?: Record<string, string>;
+  };
+
+const CODEX_THINKING_LEVEL_MAP: Record<string, string> = { xhigh: 'xhigh', minimal: 'low' };
+
+const CODEX_MODELS: CodexModelDef[] = [
+  { id: 'gpt-5.5', name: 'GPT-5.5', input: ['text', 'image'] },
+  { id: 'gpt-5.4', name: 'GPT-5.4', input: ['text', 'image'] },
+  { id: 'gpt-5.4-mini', name: 'GPT-5.4 mini', input: ['text', 'image'] },
+  { id: 'gpt-5.3-codex', name: 'GPT-5.3 Codex', input: ['text', 'image'] },
+  { id: 'gpt-5.3-codex-spark', name: 'GPT-5.3 Codex Spark', input: ['text'] },
+  { id: 'gpt-5.2', name: 'GPT-5.2', input: ['text', 'image'] },
+].map((m) => ({
+  ...m,
+  api: 'openai' as const,
+  reasoning: true,
+  context_window: 272000,
+  max_tokens: 128000,
+  thinkingLevelMap: CODEX_THINKING_LEVEL_MAP,
+}));
+
+// ── PKCE helpers ───────────────────────────────────────────────────
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let str = '';
+  for (const b of bytes) str += String.fromCharCode(b);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function randomBytes(n: number): Uint8Array {
+  const out = new Uint8Array(n);
+  crypto.getRandomValues(out);
+  return out;
+}
+
+function generateCodeVerifier(): string {
+  return base64UrlEncode(randomBytes(32));
+}
+
+async function deriveCodeChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', data));
+  return base64UrlEncode(digest);
+}
+
+function randomState(): string {
+  return base64UrlEncode(randomBytes(16));
+}
+
+// ── Token exchange ─────────────────────────────────────────────────
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+}
+
+async function exchangeCode(code: string, codeVerifier: string): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: CODEX_CLIENT_ID,
+    code,
+    code_verifier: codeVerifier,
+    redirect_uri: CODEX_REDIRECT_URI,
+  });
+  const res = await fetch(CODEX_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!res.ok) {
+    throw new Error(`OpenAI Codex token exchange failed: ${res.status} ${await res.text()}`);
+  }
+  const payload = (await res.json()) as TokenResponse;
+  if (!payload.access_token) {
+    throw new Error('OpenAI Codex token exchange did not return access_token.');
+  }
+  return payload;
+}
+
+async function refreshAccessToken(refresh: string): Promise<TokenResponse | null> {
+  try {
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refresh,
+      client_id: CODEX_CLIENT_ID,
+    });
+    const res = await fetch(CODEX_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!res.ok) {
+      console.error('[openai-codex] refresh failed:', res.status, await res.text());
+      return null;
+    }
+    return (await res.json()) as TokenResponse;
+  } catch (err) {
+    console.error(
+      '[openai-codex] refresh error:',
+      err instanceof Error ? err.message : String(err)
+    );
+    return null;
+  }
+}
+
+// ── JWT display name (for the account picker) ──────────────────────
+//
+// The access token is a JWT whose `https://api.openai.com/profile` claim
+// carries the account email and whose `https://api.openai.com/auth` claim
+// carries the ChatGPT plan type. We surface `email (Plan)` so the picker
+// reads like "lars@example.com (Team)" rather than the raw account UUID.
+// The stream function re-derives the account id from the token itself, so
+// we only persist a human-friendly label here.
+
+function getEmail(accessToken: string): string | undefined {
+  try {
+    const parts = accessToken.split('.');
+    if (parts.length !== 3) return undefined;
+    const payload = JSON.parse(atob(parts[1]!)) as Record<string, unknown>;
+    const profile = payload['https://api.openai.com/profile'] as { email?: unknown } | undefined;
+    return typeof profile?.email === 'string' ? profile.email : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getDisplayName(accessToken: string): string | undefined {
+  try {
+    const parts = accessToken.split('.');
+    if (parts.length !== 3) return undefined;
+    const payload = JSON.parse(atob(parts[1]!)) as Record<string, unknown>;
+    const auth = payload['https://api.openai.com/auth'] as
+      | { chatgpt_plan_type?: unknown }
+      | undefined;
+    const email = getEmail(accessToken);
+    const plan = typeof auth?.chatgpt_plan_type === 'string' ? auth.chatgpt_plan_type : undefined;
+    const planLabel = plan ? plan.charAt(0).toUpperCase() + plan.slice(1) : undefined;
+    if (email && planLabel) return `${email} (${planLabel})`;
+    if (email) return email;
+    if (planLabel) return `ChatGPT ${planLabel}`;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ── Profile picture (Gravatar) ─────────────────────────────────────
+//
+// OpenAI's token carries only the email — its `userinfo` endpoint returns
+// just `sub`, and `chatgpt.com/backend-api/me` is Cloudflare-gated (403
+// to non-browser clients, CORS-blocked from the page). Gravatar is the
+// portable, email-keyed avatar API: we hash the verified email and point
+// the avatar `<img>` at it with `d=404`, so accounts that have a Gravatar
+// show their photo and everyone else falls through to initials (the
+// avatar element's `error` handler swaps in `initialsFromLabel`).
+
+async function getUserAvatar(accessToken: string): Promise<string | undefined> {
+  const email = getEmail(accessToken);
+  if (!email) return undefined;
+  try {
+    const normalized = email.trim().toLowerCase();
+    const digest = new Uint8Array(
+      await crypto.subtle.digest('SHA-256', new TextEncoder().encode(normalized))
+    );
+    const hex = Array.from(digest)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    return `https://www.gravatar.com/avatar/${hex}?s=128&d=404`;
+  } catch {
+    return undefined;
+  }
+}
+
+// ── Account lookup ─────────────────────────────────────────────────
+
+function getCodexAccount() {
+  return getAccounts().find((a) => a.providerId === PROVIDER_ID);
+}
+
+async function getValidAccessToken(): Promise<string> {
+  const account = getCodexAccount();
+  if (!account?.accessToken) {
+    throw new Error('Not signed in to OpenAI Codex — run `oauth-token openai-codex` or /login');
+  }
+  const expiresAt = account.tokenExpiresAt ?? 0;
+  // Refresh 60s before expiry to keep streaming requests warm.
+  if (expiresAt && Date.now() + 60_000 < expiresAt) {
+    return account.accessToken;
+  }
+  if (account.refreshToken) {
+    const refreshed = await refreshAccessToken(account.refreshToken);
+    if (refreshed?.access_token) {
+      await saveOAuthAccount({
+        providerId: PROVIDER_ID,
+        accessToken: refreshed.access_token,
+        refreshToken: refreshed.refresh_token ?? account.refreshToken,
+        tokenExpiresAt: Date.now() + (refreshed.expires_in ?? 3600) * 1000,
+        baseUrl: CODEX_BASE_URL,
+        userName: getDisplayName(refreshed.access_token),
+        userAvatar: await getUserAvatar(refreshed.access_token),
+      });
+      return refreshed.access_token;
+    }
+  }
+  return account.accessToken; // best-effort; OpenAI will 401 if revoked
+}
+
+// ── Stream functions ───────────────────────────────────────────────
+
+function makeErrorOutput(model: Model<Api>, error: unknown) {
+  return {
+    type: 'error' as const,
+    reason: 'error' as const,
+    error: {
+      role: 'assistant' as const,
+      content: [],
+      api: CODEX_API,
+      provider: PROVIDER_ID,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: 'error' as const,
+      errorMessage: error instanceof Error ? error.message : String(error),
+      timestamp: Date.now(),
+    },
+  };
+}
+
+const streamCodex = (model: Model<Api>, context: Context, options: ProviderStreamOptions = {}) => {
+  const stream = createAssistantMessageEventStream();
+  (async () => {
+    try {
+      const accessToken = await getValidAccessToken();
+      const proxyModel = {
+        ...model,
+        baseUrl: CODEX_BASE_URL,
+        api: OPENAI_CODEX_RESPONSES_API,
+      } as Model<'openai-codex-responses'>;
+      const inner = streamOpenAICodexResponses(proxyModel, context, {
+        ...options,
+        apiKey: accessToken,
+        transport: 'sse',
+      });
+      for await (const event of inner) stream.push(event);
+      stream.end();
+    } catch (error) {
+      console.error(
+        '[openai-codex] Stream error:',
+        error instanceof Error ? error.message : String(error)
+      );
+      stream.push(makeErrorOutput(model, error) as never);
+      stream.end();
+    }
+  })();
+  return stream;
+};
+
+const streamSimpleCodex = (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => {
+  const stream = createAssistantMessageEventStream();
+  (async () => {
+    try {
+      const accessToken = await getValidAccessToken();
+      const proxyModel = {
+        ...model,
+        baseUrl: CODEX_BASE_URL,
+        api: OPENAI_CODEX_RESPONSES_API,
+      } as Model<'openai-codex-responses'>;
+      const inner = streamSimpleOpenAICodexResponses(proxyModel, context, {
+        ...options,
+        apiKey: accessToken,
+        transport: 'sse',
+      } as SimpleStreamOptions);
+      for await (const event of inner) stream.push(event);
+      stream.end();
+    } catch (error) {
+      console.error(
+        '[openai-codex] Stream error:',
+        error instanceof Error ? error.message : String(error)
+      );
+      stream.push(makeErrorOutput(model, error) as never);
+      stream.end();
+    }
+  })();
+  return stream;
+};
+
+// ── Provider config ────────────────────────────────────────────────
+
+export const config: ProviderConfig = {
+  id: PROVIDER_ID,
+  name: 'OpenAI Codex (ChatGPT Subscription)',
+  description:
+    'GPT-5 Codex via your ChatGPT Plus/Pro/Business subscription — OAuth login, no API key needed. Default model is GPT-5.3 Codex.',
+  requiresApiKey: false,
+  requiresBaseUrl: false,
+  isOAuth: true,
+  defaultModelId: 'gpt-5.3-codex',
+  oauthTokenDomains: ['chatgpt.com', '*.chatgpt.com', 'auth.openai.com', 'api.openai.com'],
+  getModelIds: () =>
+    CODEX_MODELS.map((m) =>
+      m.thinkingLevelMap ? { ...m, thinkingLevelMap: m.thinkingLevelMap } : m
+    ),
+
+  onOAuthLoginIntercepted: async (
+    launcher: InterceptingOAuthLauncher,
+    onSuccess: () => void,
+    options?: OAuthLoginOptions
+  ) => {
+    const codeVerifier = generateCodeVerifier();
+    const codeChallenge = await deriveCodeChallenge(codeVerifier);
+    const state = randomState();
+
+    const authorize = new URL(CODEX_AUTHORIZE_URL);
+    authorize.searchParams.set('response_type', 'code');
+    authorize.searchParams.set('client_id', CODEX_CLIENT_ID);
+    authorize.searchParams.set('redirect_uri', CODEX_REDIRECT_URI);
+    authorize.searchParams.set('scope', options?.scopes ?? CODEX_SCOPE);
+    authorize.searchParams.set('code_challenge', codeChallenge);
+    authorize.searchParams.set('code_challenge_method', 'S256');
+    authorize.searchParams.set('state', state);
+    // Codex-CLI authorize params — see pi-ai's createAuthorizationFlow.
+    authorize.searchParams.set('id_token_add_organizations', 'true');
+    authorize.searchParams.set('codex_cli_simplified_flow', 'true');
+    authorize.searchParams.set('originator', 'pi');
+
+    const captured = await launcher({
+      authorizeUrl: authorize.toString(),
+      redirectUriPattern: CODEX_REDIRECT_PATTERN,
+      onCapture: 'close',
+    });
+    if (!captured) {
+      throw new Error('OpenAI Codex OAuth login was cancelled or timed out');
+    }
+
+    const parsed = new URL(captured);
+    const code = parsed.searchParams.get('code');
+    const returnedState = parsed.searchParams.get('state');
+    if (!code) {
+      throw new Error('OpenAI Codex OAuth redirect did not include a code');
+    }
+    if (returnedState && returnedState !== state) {
+      throw new Error('OpenAI Codex OAuth state mismatch — possible CSRF, aborting');
+    }
+
+    const tokens = await exchangeCode(code, codeVerifier);
+    await saveOAuthAccount({
+      providerId: PROVIDER_ID,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      tokenExpiresAt: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+      baseUrl: CODEX_BASE_URL,
+      userName: getDisplayName(tokens.access_token),
+      userAvatar: await getUserAvatar(tokens.access_token),
+    });
+    onSuccess();
+  },
+
+  onOAuthLogout: async () => {
+    await saveOAuthAccount({ providerId: PROVIDER_ID, accessToken: '' });
+  },
+
+  onSilentRenew: async () => {
+    const account = getCodexAccount();
+    if (!account?.refreshToken) return null;
+    const refreshed = await refreshAccessToken(account.refreshToken);
+    if (!refreshed?.access_token) return null;
+    await saveOAuthAccount({
+      providerId: PROVIDER_ID,
+      accessToken: refreshed.access_token,
+      refreshToken: refreshed.refresh_token ?? account.refreshToken,
+      tokenExpiresAt: Date.now() + (refreshed.expires_in ?? 3600) * 1000,
+      baseUrl: CODEX_BASE_URL,
+      userName: getDisplayName(refreshed.access_token),
+      userAvatar: await getUserAvatar(refreshed.access_token),
+    });
+    return refreshed.access_token;
+  },
+};
+
+// ── Registration ───────────────────────────────────────────────────
+
+export function register(): void {
+  registerApiProvider({
+    api: CODEX_API,
+    stream: streamCodex as Parameters<typeof registerApiProvider>[0]['stream'],
+    streamSimple: streamSimpleCodex as Parameters<typeof registerApiProvider>[0]['streamSimple'],
+  });
+}

--- a/packages/webapp/src/providers/types.ts
+++ b/packages/webapp/src/providers/types.ts
@@ -176,6 +176,15 @@ export interface ModelMetadata {
    * See {@link CompatOverrides} for the full list of supported keys per API.
    */
   compat?: CompatOverrides;
+  /**
+   * Per-model thinking-level mapping; matches pi-ai's `Model.thinkingLevelMap`.
+   * Keys are pi thinking levels (`off`/`minimal`/`low`/`medium`/`high`/`xhigh`);
+   * a string value is forwarded to the provider as the reasoning effort and
+   * `null` marks the level unsupported. Merged over any map the pi-ai base
+   * model already declared, so a provider can add or override individual
+   * levels (e.g. Codex maps `minimal` → `low`).
+   */
+  thinkingLevelMap?: Record<string, string | null>;
 }
 
 export interface ProviderConfig {

--- a/packages/webapp/src/ui/avatar-initials.ts
+++ b/packages/webapp/src/ui/avatar-initials.ts
@@ -1,0 +1,32 @@
+/**
+ * Derive up-to-two-character avatar initials from an account label.
+ *
+ * Account labels arrive in three shapes: a plain name ("Lars Trieloff"),
+ * a bare login ("octocat"), or an OAuth display label that embeds an
+ * email and a plan suffix ("lars@trieloff.net (Team)"). The plan suffix
+ * and the "@" break a naive first/last-word split (it would yield "L("),
+ * so we strip a trailing parenthetical first, then treat emails
+ * specially: first letter of the local part + first letter of the next
+ * local-part segment (split on . _ + -) or, lacking one, the domain —
+ * so "lars@trieloff.net" reads as "LT".
+ */
+export function initialsFromLabel(name: string | undefined | null): string {
+  const raw = (name ?? '').trim();
+  if (!raw) return '';
+  const s = raw.replace(/\s*\([^)]*\)\s*$/, '').trim() || raw;
+
+  const at = s.indexOf('@');
+  if (at > 0) {
+    const local = s.slice(0, at);
+    const domain = s.slice(at + 1);
+    const segs = local.split(/[._+-]/).filter(Boolean);
+    const first = segs[0]?.[0] ?? local[0] ?? '';
+    const second =
+      segs.length > 1 ? segs[segs.length - 1][0] : (domain.match(/[a-z0-9]/i)?.[0] ?? '');
+    return (first + second).toUpperCase();
+  }
+
+  const parts = s.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  return s.slice(0, 2).toUpperCase();
+}

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -50,6 +50,7 @@ import { getLeaderTrayRuntimeStatus } from '../scoops/tray-leader.js';
 import { getFollowerTrayRuntimeStatus } from '../scoops/tray-follower-status.js';
 import { copyTextToClipboard } from './clipboard.js';
 import { computeTrayMenuModel } from './tray-join-url.js';
+import { initialsFromLabel } from './avatar-initials.js';
 import { createLogger } from '../core/logger.js';
 
 const layoutLog = createLogger('ui.layout');
@@ -623,9 +624,7 @@ export class Layout {
   }
 
   private getInitials(name: string): string {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length >= 2) return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-    return name.slice(0, 2).toUpperCase();
+    return initialsFromLabel(name);
   }
 
   /**

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -285,6 +285,7 @@ function applyModelMetadata(
     reasoning?: boolean;
     input?: string[];
     compat?: CompatOverrides;
+    thinkingLevelMap?: Record<string, string | null>;
   }
 ): void {
   if (metadata.context_window !== undefined) model.contextWindow = metadata.context_window;
@@ -301,6 +302,16 @@ function applyModelMetadata(
     model.compat = {
       ...((model.compat as Record<string, unknown> | undefined) ?? {}),
       ...(metadata.compat as Record<string, unknown>),
+    };
+  }
+  // Same per-level merge for thinkingLevelMap: pi-ai's stream functions read
+  // `model.thinkingLevelMap[effort]` to translate the reasoning level, so a
+  // provider override (e.g. Codex's `minimal` → `low`) must land on the model
+  // rather than being silently dropped in favor of the base map.
+  if (metadata.thinkingLevelMap !== undefined) {
+    model.thinkingLevelMap = {
+      ...((model.thinkingLevelMap as Record<string, string | null> | undefined) ?? {}),
+      ...metadata.thinkingLevelMap,
     };
   }
 }

--- a/packages/webapp/tests/providers/openai-codex.test.ts
+++ b/packages/webapp/tests/providers/openai-codex.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { config } from '../../providers/openai-codex.js';
+
+describe('openai-codex provider config', () => {
+  it('is an OAuth provider with codex token domains', () => {
+    expect(config.id).toBe('openai-codex');
+    expect(config.isOAuth).toBe(true);
+    expect(config.requiresApiKey).toBe(false);
+    expect(config.onOAuthLoginIntercepted).toBeTypeOf('function');
+    expect(config.oauthTokenDomains).toContain('chatgpt.com');
+    expect(config.oauthTokenDomains).toContain('auth.openai.com');
+  });
+
+  it('exposes the codex model catalog tagged for the openai api', () => {
+    const models = config.getModelIds!();
+    const ids = models.map((m) => m.id);
+    expect(ids).toContain('gpt-5.3-codex');
+    expect(ids).toContain('gpt-5.5');
+    expect(models.length).toBe(6);
+    for (const m of models) {
+      // api: 'openai' → provider-settings rewrites to `openai-codex-openai`
+      expect(m.api).toBe('openai');
+      expect(m.reasoning).toBe(true);
+      expect((m as { thinkingLevelMap?: Record<string, string> }).thinkingLevelMap).toEqual({
+        xhigh: 'xhigh',
+        minimal: 'low',
+      });
+    }
+    expect(config.defaultModelId).toBe('gpt-5.3-codex');
+  });
+});
+
+describe('openai-codex onOAuthLoginIntercepted', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalLocalStorage: Storage;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalLocalStorage = globalThis.localStorage;
+    const lsData: Record<string, string> = {};
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k: string) => lsData[k] ?? null,
+      setItem: (k: string, v: string) => {
+        lsData[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete lsData[k];
+      },
+      clear: () => {
+        for (const k of Object.keys(lsData)) delete lsData[k];
+      },
+      key: () => null,
+      length: 0,
+    } as unknown as Storage;
+    delete (globalThis as { chrome?: unknown }).chrome;
+    // page context: saveAccountsAsync writes localStorage directly when
+    // both window and document exist.
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: 'http://localhost:5710', href: 'http://localhost:5710' },
+      dispatchEvent: vi.fn(),
+    };
+    (globalThis as { document?: unknown }).document = {};
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    (globalThis as unknown as { localStorage: Storage }).localStorage = originalLocalStorage;
+    delete (globalThis as { window?: unknown }).window;
+    delete (globalThis as { document?: unknown }).document;
+  });
+
+  it('builds a PKCE codex authorize URL, exchanges the code, and saves the account', async () => {
+    // Fake JWT access token carrying account id, plan, and profile email.
+    const jwtPayload = btoa(
+      JSON.stringify({
+        'https://api.openai.com/auth': {
+          chatgpt_account_id: 'acct_test_123',
+          chatgpt_plan_type: 'team',
+        },
+        'https://api.openai.com/profile': { email: 'dev@example.com' },
+      })
+    );
+    const accessToken = `header.${jwtPayload}.sig`;
+
+    let tokenBody: URLSearchParams | undefined;
+    globalThis.fetch = vi.fn(async (url: unknown, init?: unknown) => {
+      const urlStr = String(url);
+      if (urlStr === 'https://auth.openai.com/oauth/token') {
+        tokenBody = new URLSearchParams(String((init as { body?: unknown })?.body));
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: accessToken,
+            refresh_token: 'codex_refresh_abc',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          }),
+        } as unknown as Response;
+      }
+      return { ok: false, status: 404, text: async () => 'nope' } as unknown as Response;
+    }) as typeof globalThis.fetch;
+
+    let capturedAuthorizeUrl = '';
+    const fakeLauncher = vi.fn(
+      async (cfg: { authorizeUrl: string; redirectUriPattern: string }) => {
+        capturedAuthorizeUrl = cfg.authorizeUrl;
+        expect(cfg.redirectUriPattern).toBe('http://localhost:1455/auth/callback*');
+        const authUrl = new URL(cfg.authorizeUrl);
+        const state = authUrl.searchParams.get('state');
+        return `http://localhost:1455/auth/callback?code=fake-code&state=${state}`;
+      }
+    );
+
+    let successCalled = false;
+    await config.onOAuthLoginIntercepted!(
+      fakeLauncher,
+      () => {
+        successCalled = true;
+      },
+      undefined
+    );
+
+    expect(successCalled).toBe(true);
+
+    // Authorize URL carries the codex-CLI PKCE params.
+    const auth = new URL(capturedAuthorizeUrl);
+    expect(auth.origin + auth.pathname).toBe('https://auth.openai.com/oauth/authorize');
+    expect(auth.searchParams.get('client_id')).toBe('app_EMoamEEZ73f0CkXaXp7hrann');
+    expect(auth.searchParams.get('redirect_uri')).toBe('http://localhost:1455/auth/callback');
+    expect(auth.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(auth.searchParams.get('code_challenge')).toBeTruthy();
+    expect(auth.searchParams.get('codex_cli_simplified_flow')).toBe('true');
+    expect(auth.searchParams.get('id_token_add_organizations')).toBe('true');
+
+    // Token exchange used the captured code + the matching verifier.
+    expect(tokenBody?.get('grant_type')).toBe('authorization_code');
+    expect(tokenBody?.get('code')).toBe('fake-code');
+    expect(tokenBody?.get('client_id')).toBe('app_EMoamEEZ73f0CkXaXp7hrann');
+    expect(tokenBody?.get('code_verifier')).toBeTruthy();
+
+    // Account persisted with the real token.
+    const { getAccounts } = await import('../../src/ui/provider-settings.js');
+    const account = getAccounts().find((a) => a.providerId === 'openai-codex');
+    expect(account?.accessToken).toBe(accessToken);
+    expect(account?.refreshToken).toBe('codex_refresh_abc');
+    expect(account?.userName).toBe('dev@example.com (Team)');
+    // Profile picture: Gravatar keyed by the SHA-256 of the verified
+    // email, with d=404 so accounts without a Gravatar fall back to
+    // initials.
+    const emailSha256 = 'eb2b6c0d061bbd5caa545b6d1184a1887b11dba0b1d7fd8ca5b42ebf0ad7d3a8';
+    expect(account?.userAvatar).toBe(`https://www.gravatar.com/avatar/${emailSha256}?s=128&d=404`);
+  });
+
+  it('throws on OAuth state mismatch', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('token endpoint must not be called on state mismatch');
+    }) as typeof globalThis.fetch;
+
+    const fakeLauncher = vi.fn(
+      async () => `http://localhost:1455/auth/callback?code=c&state=WRONG_STATE`
+    );
+
+    await expect(
+      config.onOAuthLoginIntercepted!(fakeLauncher, () => {}, undefined)
+    ).rejects.toThrow(/state mismatch/i);
+  });
+});

--- a/packages/webapp/tests/providers/openai-codex.test.ts
+++ b/packages/webapp/tests/providers/openai-codex.test.ts
@@ -27,7 +27,7 @@ describe('openai-codex provider config', () => {
         minimal: 'low',
       });
     }
-    expect(config.defaultModelId).toBe('gpt-5.3-codex');
+    expect(config.defaultModelId).toBe('gpt-5.5');
   });
 });
 
@@ -72,6 +72,10 @@ describe('openai-codex onOAuthLoginIntercepted', () => {
 
   it('builds a PKCE codex authorize URL, exchanges the code, and saves the account', async () => {
     // Fake JWT access token carrying account id, plan, and profile email.
+    // Encoded as real base64url (RFC 7515): the `_marker` field forces a
+    // `+` and `/` into the standard base64, which become `-`/`_` here — so
+    // this exercises decodeJwtPayload's base64url handling (plain `atob`
+    // would throw on these characters).
     const jwtPayload = btoa(
       JSON.stringify({
         'https://api.openai.com/auth': {
@@ -79,8 +83,13 @@ describe('openai-codex onOAuthLoginIntercepted', () => {
           chatgpt_plan_type: 'team',
         },
         'https://api.openai.com/profile': { email: 'dev@example.com' },
+        _marker: '>>>???',
       })
-    );
+    )
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    expect(jwtPayload).toMatch(/[-_]/);
     const accessToken = `header.${jwtPayload}.sig`;
 
     let tokenBody: URLSearchParams | undefined;
@@ -160,6 +169,20 @@ describe('openai-codex onOAuthLoginIntercepted', () => {
     const fakeLauncher = vi.fn(
       async () => `http://localhost:1455/auth/callback?code=c&state=WRONG_STATE`
     );
+
+    await expect(
+      config.onOAuthLoginIntercepted!(fakeLauncher, () => {}, undefined)
+    ).rejects.toThrow(/state mismatch/i);
+  });
+
+  it('throws when the OAuth callback omits state entirely (strict CSRF binding)', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('token endpoint must not be called when state is missing');
+    }) as typeof globalThis.fetch;
+
+    // Callback with a code but no `state` — must be rejected exactly like a
+    // mismatch, not silently accepted.
+    const fakeLauncher = vi.fn(async () => `http://localhost:1455/auth/callback?code=c`);
 
     await expect(
       config.onOAuthLoginIntercepted!(fakeLauncher, () => {}, undefined)

--- a/packages/webapp/tests/ui/avatar-initials.test.ts
+++ b/packages/webapp/tests/ui/avatar-initials.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { initialsFromLabel } from '../../src/ui/avatar-initials.js';
+
+describe('initialsFromLabel', () => {
+  it('derives initials from an OAuth "email (Plan)" label', () => {
+    // Regression: the naive first/last-word split produced "L(" because
+    // of the " (Team)" suffix and the "@" — we want "LT".
+    expect(initialsFromLabel('lars@trieloff.net (Team)')).toBe('LT');
+  });
+
+  it('uses local + domain initials for a single-segment email', () => {
+    expect(initialsFromLabel('lars@trieloff.net')).toBe('LT');
+  });
+
+  it('uses both local-part segments when the address is dotted', () => {
+    expect(initialsFromLabel('lars.trieloff@example.com')).toBe('LT');
+    expect(initialsFromLabel('john_doe@example.com')).toBe('JD');
+  });
+
+  it('handles plain first/last names', () => {
+    expect(initialsFromLabel('Lars Trieloff')).toBe('LT');
+  });
+
+  it('falls back to the first two characters for a single token', () => {
+    expect(initialsFromLabel('octocat')).toBe('OC');
+  });
+
+  it('returns empty string for blank input', () => {
+    expect(initialsFromLabel('')).toBe('');
+    expect(initialsFromLabel(undefined)).toBe('');
+    expect(initialsFromLabel(null)).toBe('');
+  });
+});

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -1280,6 +1280,57 @@ describe('getProviderModels with getModelIds', () => {
     expect(models[0].name).toBe('My Custom Model');
     expect(models[0].provider).toBe('custom-oauth');
   });
+
+  it('merges thinkingLevelMap from getModelIds over the pi-ai base map', () => {
+    // Regression for the Codex bug: applyModelMetadata previously copied only
+    // a fixed set of fields and dropped thinkingLevelMap, so a provider's
+    // `minimal` → `low` remap silently lost out to the base model's map and
+    // the wrong reasoning effort reached the backend.
+    mockGetProviders.mockReturnValue(['openai']);
+    mockGetModels.mockImplementation((providerId: string) => {
+      if (providerId === 'openai') {
+        return [
+          {
+            id: 'gpt-5.3-codex',
+            name: 'GPT-5.3 Codex',
+            provider: 'openai',
+            api: 'openai-responses',
+            reasoning: true,
+            // pi-ai base map — no `minimal` remap.
+            thinkingLevelMap: { off: null, xhigh: 'xhigh' },
+          },
+        ];
+      }
+      return [];
+    });
+
+    const providerConfigs = new Map(
+      mockGetRegisteredProviderIds().map((id: string) => [id, mockGetRegisteredProviderConfig(id)])
+    );
+    providerConfigs.set('codexy', {
+      id: 'codexy',
+      name: 'Codexy',
+      description: 'Test',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      isOAuth: true,
+      getModelIds: () => [
+        {
+          id: 'gpt-5.3-codex',
+          name: 'GPT-5.3 Codex',
+          api: 'openai',
+          thinkingLevelMap: { xhigh: 'xhigh', minimal: 'low' },
+        },
+      ],
+    });
+    mockGetRegisteredProviderConfig.mockImplementation((id: string) => providerConfigs.get(id));
+
+    const models = getProviderModels('codexy');
+    expect(models).toHaveLength(1);
+    expect(
+      (models[0] as { thinkingLevelMap?: Record<string, string | null> }).thinkingLevelMap
+    ).toEqual({ off: null, xhigh: 'xhigh', minimal: 'low' });
+  });
 });
 
 describe('Adobe sonnet model preference', () => {


### PR DESCRIPTION
## Summary

Adds an external OAuth provider that streams **GPT-5 Codex** models through a user's **ChatGPT Plus/Pro/Business/Team** subscription — no API key required.

- **Auth**: reuses the public Codex-CLI OAuth client via slicc's intercepted-redirect flow (CDP `Fetch.requestPaused`), the browser equivalent of pi-ai's `:1455` loopback server. PKCE via Web Crypto, token exchange/refresh against `auth.openai.com`, silent renew, and 60s pre-expiry refresh.
- **Streaming**: delegates to pi-ai's `openai-codex-responses` API, forced to `sse` (browser `WebSocket` can't set the required auth headers).
- **Models**: the 6-model Codex catalog (`gpt-5.2` … `gpt-5.5`), default `gpt-5.3-codex`.
- **Account identity**: label reads `email (Plan)` (e.g. `lars@example.com (Team)`) instead of the raw account UUID.
- **Avatar**: the header avatar now shows the user's **Gravatar** (keyed on the SHA-256 of the verified email, `d=404`), gracefully falling back to email-aware initials. OpenAI's own endpoints don't expose a usable picture (`userinfo` returns only `sub`; `chatgpt.com/backend-api/me` is Cloudflare-gated), so Gravatar is the portable, email-keyed source.

## Avatar initials fix

`initialsFromLabel()` (new, `packages/webapp/src/ui/avatar-initials.ts`) strips a trailing `(Plan)` suffix and derives initials from emails (local part + next segment/domain), so `lars@trieloff.net (Team)` becomes **LT** instead of the previous broken `L(`. `Layout.getInitials` now delegates to it.

## Tests

- `tests/ui/avatar-initials.test.ts` — initials derivation (email, dotted local part, plain names, single token, blanks).
- `tests/providers/openai-codex.test.ts` — config + 6-model catalog, PKCE authorize URL + code exchange + account persistence, Gravatar `userAvatar`, and OAuth state-mismatch rejection.

## Verification

- `npm run typecheck` — pass
- provider + ui suites — **211 tests pass**
- `npm run build -w @slicc/webapp` — pass
- prettier/eslint — clean (pre-commit hooks ran)

Verified end-to-end over CDP: live ChatGPT Team login captured, a real Codex stream returned output, and the header avatar renders the user's Gravatar (falls back to `LT` initials when no Gravatar exists).
