### PR TITLE
fix(extension): emit RUM beacons from offscreen realm

### DIFF
--- a/docs/operational-telemetry.md
+++ b/docs/operational-telemetry.md
@@ -52,9 +52,12 @@ The flag is read by `rum.js` on first call and cached in `window.hlx.rum`. CLI/E
 ### Where init happens
 
 - **CLI / Electron**: `packages/webapp/src/ui/main.ts:main()` calls `initTelemetry().catch(() => {})` near the end of bootstrap.
-- **Extension**: `packages/webapp/src/ui/main.ts:mainExtension()` calls `initTelemetry().catch(() => {})` after the panel is connected to the offscreen agent engine. Only the side panel realm initializes; the offscreen document and the service worker never call `initTelemetry`.
+- **Extension side panel**: `packages/webapp/src/ui/main.ts:mainExtension()` calls `initTelemetry().catch(() => {})` after the panel is connected to the offscreen agent engine.
+- **Extension offscreen document**: `packages/chrome-extension/src/offscreen.ts:init()` calls `initTelemetry().catch(() => {})` at the top of bootstrap. Without this, `trackShellCommand` calls from the offscreen `WasmShell` (which runs the agent's bash tool — including `agent` scoop delegations from the cone) silently no-op because `sampleRUM` is module-level singleton state and is per-realm. The service worker still never calls `initTelemetry`.
 
-`navigator.sendBeacon` is available in all three contexts where telemetry initializes. Side-panel close/reopen produces a fresh `initTelemetry` run with a new pageview id — fine because each call generates an independent sampling decision and an independent id.
+The side panel and offscreen are independent realms — each makes its own sampling decision and emits its own `navigate` beacon. Both beacons carry `target: 'extension'`; the `referer` field in the beacon body (`window.location.href`) distinguishes them — `chrome-extension://<id>/index.html` vs `chrome-extension://<id>/offscreen.html`. Side-panel close/reopen produces a fresh init in that realm; offscreen survives panel close, so its sampling decision persists for the lifetime of the offscreen document.
+
+`navigator.sendBeacon` is available in all four contexts where telemetry initializes.
 
 ## Checkpoints
 
@@ -94,9 +97,9 @@ These work out of the box in CLI/Electron with no custom code. They do NOT fire 
 `fill` beacons fire from `wasm-shell.ts:679`, which runs in two contexts in the extension: the panel terminal and the offscreen agent shell.
 
 - **CLI / Electron:** both contexts are the same realm; every shell command produces a beacon.
-- **Extension:** only the panel-terminal `WasmShell` initializes telemetry. The offscreen agent shell's `trackShellCommand` calls silently no-op. Extension `fill` beacons therefore represent commands the user typed in the panel terminal — not commands the agent ran via its bash tool.
+- **Extension:** both realms now initialize telemetry independently — the panel-terminal `WasmShell` and the offscreen agent `WasmShell`. User-typed commands fire `fill` from the panel realm; agent-initiated bash calls (including `agent` scoop delegations from the cone) fire `fill` from the offscreen realm. Distinguish in the data via the `referer` field on the beacon body: `index.html` vs `offscreen.html`.
 
-Dashboard readers comparing extension and CLI shell volume should expect this gap.
+Historical note: before 2026-05-29, the offscreen realm did not initialize telemetry, so extension `fill` beacons represented only panel-terminal commands. Cone delegation activity (visible as `agent ...` bash calls) was therefore invisible in RUM despite running thousands of times per day. Dashboards that bucket on the older period should account for this gap.
 
 ### `viewmedia` wiring
 
@@ -104,8 +107,8 @@ Dashboard readers comparing extension and CLI shell volume should expect this ga
 
 ### Not instrumented in this iteration
 
-- The offscreen document (`packages/chrome-extension/src/offscreen.ts`). Agent-loop events — turn end, tool-call durations, scoop create/delegate/drop — would require offscreen-side init.
 - The extension service worker (`packages/chrome-extension/src/service-worker.ts`). CDP attach/detach, OAuth completion, navigate-licks, tray-socket lifecycle.
+- Custom agent-loop events from the offscreen realm — turn end, tool-call durations, explicit scoop create/delegate/drop. The offscreen `WasmShell` now emits `fill` beacons for every bash call (so the cone-side `agent ...` invocations and `feed_scoop` tool calls show up indirectly), but there are no dedicated `agent-spawn` or `scoop-delegate` checkpoints yet.
 - Core Web Vitals in the extension. The helix enhancer that captures CWV cannot run under the extension's CSP, and we do not self-host it here.
 
 These are tracked as future work in `docs/superpowers/specs/2026-04-28-extension-telemetry-design.md`.

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -156,7 +156,7 @@ Pure logic lives in `src/secrets-storage.ts` (testable; `tests/secrets-storage.t
 
 ## Telemetry
 
-The side panel emits Helix RUM beacons via the inlined `packages/webapp/src/ui/rum.js` (extension-only). CLI/Electron use `@adobe/helix-rum-js` instead; the choice is made by `telemetry.ts:initTelemetry()` based on `getModeLabel()`. Offscreen and the service worker are not instrumented. Force 100% sampling for debugging by setting `localStorage.setItem('slicc-rum-debug', '1')` in the side panel's DevTools and reloading. See `docs/operational-telemetry.md`.
+Both the side panel AND the offscreen document emit Helix RUM beacons via the inlined `packages/webapp/src/ui/rum.js` (extension-only). CLI/Electron use `@adobe/helix-rum-js` instead; the choice is made by `telemetry.ts:initTelemetry()` based on `getModeLabel()`. The two extension realms are independent — the panel captures user-typed shell commands and chat sends; the offscreen realm captures the agent's bash tool calls (including `agent` scoop delegations from the cone, which is why this realm needs telemetry to track delegation activity). The service worker is not instrumented. Force 100% sampling for debugging by setting `localStorage.setItem('slicc-rum-debug', '1')` in DevTools for the realm you want to debug (side panel inspect, or right-click → Inspect on `chrome-extension://<id>/offscreen.html`) and reloading. See `docs/operational-telemetry.md`.
 
 ## Build Notes
 

--- a/packages/chrome-extension/src/offscreen.ts
+++ b/packages/chrome-extension/src/offscreen.ts
@@ -56,6 +56,7 @@ import { OFFSCREEN_SET_TRAY_RUNTIME_HOOK } from '../../../packages/webapp/src/sc
 import { createLogger } from '../../../packages/webapp/src/core/index.js';
 import type { ExtensionMessage } from './messages.js';
 import { getApiKey } from '../../../packages/webapp/src/ui/provider-settings.js';
+import { initTelemetry } from '../../../packages/webapp/src/ui/telemetry.js';
 
 // Auto-discover and register all providers (built-in + external).
 // IMPORTANT: Keep in sync with packages/webapp/src/ui/main.ts — both
@@ -78,6 +79,15 @@ console.log('[slicc-offscreen] Script loaded');
 
 async function init(): Promise<void> {
   console.log('[slicc-offscreen] init() starting...');
+
+  // Initialize RUM telemetry so beacons fire from the offscreen WasmShell
+  // — `trackShellCommand` and friends silently no-op until `sampleRUM` is
+  // bound here. Without this, agent-initiated `bash` invocations from the
+  // extension (including `agent ...` scoop delegations from the cone)
+  // never reach RUM, which is why extension users showed cone-prompt
+  // beacons but zero shell-command beacons in the data. Fire-and-forget
+  // — telemetry init must never block the boot.
+  initTelemetry().catch(() => {});
 
   // Register providers BEFORE the kernel host — the host's
   // construction reaches into the provider registry via

--- a/packages/chrome-extension/tests/offscreen-telemetry.test.ts
+++ b/packages/chrome-extension/tests/offscreen-telemetry.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression guard: the offscreen document MUST call `initTelemetry()` so
+ * RUM beacons fire from the agent's bash tool (which runs in the offscreen
+ * realm). Without this, `trackShellCommand` calls are silent no-ops because
+ * `sampleRUM` is module-level singleton state that's per-realm.
+ *
+ * This is a static-text guard, not a behavior test — offscreen.ts has a long
+ * side-effect-driven boot sequence (CDP proxy, kernel host, provider
+ * registration) that's expensive to mock in isolation. Behavior of
+ * initTelemetry itself is covered by webapp/tests/ui/telemetry.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const offscreenPath = join(here, '..', 'src', 'offscreen.ts');
+const source = readFileSync(offscreenPath, 'utf8');
+
+describe('offscreen.ts telemetry wiring', () => {
+  it('imports initTelemetry from the webapp telemetry module', () => {
+    expect(source).toMatch(
+      /import\s+\{\s*initTelemetry\s*\}\s+from\s+['"][^'"]*\/ui\/telemetry\.js['"]/
+    );
+  });
+
+  it('calls initTelemetry() inside init() with a swallowed catch', () => {
+    expect(source).toMatch(/initTelemetry\(\)\s*\.catch\(/);
+  });
+
+  it('calls initTelemetry before the heavy boot (registerProviders)', () => {
+    const initIdx = source.indexOf('initTelemetry()');
+    const providersIdx = source.indexOf('await registerProviders');
+    expect(initIdx).toBeGreaterThan(-1);
+    expect(providersIdx).toBeGreaterThan(-1);
+    expect(initIdx).toBeLessThan(providersIdx);
+  });
+});


### PR DESCRIPTION
## Summary

- Offscreen document never called `initTelemetry`, so `trackShellCommand` and other track\* helpers silently no-oped from the offscreen realm (`sampleRUM` is module-level singleton state, per-realm).
- This blinded RUM to the agent's bash tool calls — including `agent ...` scoop delegations from the cone. Production data shows ~6k cone prompts from extension users but **zero** scoop-delegation / shell-command beacons, which is impossible: cone prompts that produce no delegations would mean every extension user has been told to do nothing.
- Wire `initTelemetry().catch(() => {})` into `offscreen.ts:init()` (mirroring the panel-side call in `main.ts:mainExtension()`).

## Evidence

Both realms now make independent sampling decisions. The beacon body's `referer` field distinguishes them:

- Panel beacons → `chrome-extension://<id>/index.html`
- Offscreen beacons → `chrome-extension://<id>/offscreen.html`

Verified locally in Chrome for Testing:

- Offscreen boot sets `RUM_GENERATION=slicc-extension`
- `window.hlx.rum` populated with a sampling decision
- Forced `sampleRUM('fill', ...)` produced a real `navigator.sendBeacon` call to `https://rum.hlx.page/.rum/1` with `referer: offscreen.html`
- No errors in offscreen console; kernel host + agent engine boot completed cleanly

## Test plan

- [x] `npx prettier --check .` clean (lint-staged ran on commit)
- [x] `npm run typecheck`
- [x] `npm run test` — 5844 passed, 14 skipped (no regressions)
- [x] `npm run build -w @slicc/webapp`
- [x] `npm run build -w @slicc/chrome-extension` (with and without `SLICC_EXT_DEV=1`)
- [x] Manual: load unpacked extension in Chrome for Testing, verify offscreen telemetry state via CDP
- [x] Manual: verify `navigator.sendBeacon` to `rum.hlx.page` fires from offscreen realm
- [ ] CI green
- [ ] Production verification post-merge: confirm `fill` beacons with `referer: offscreen.html` appear in RUM data

🤖 Generated with [Claude Code](https://claude.com/claude-code)