### PR TITLE
chore: add CODEOWNERS, .env.example, gitignore .env, enable secret scanning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# SLICC does not require any environment variables to build or run locally.
+# `npm install && npm run dev` is sufficient on a fresh clone.
+#
+# This file exists as a discoverable hint for autonomous agents and new
+# contributors: if you ever do need a local override (for example, to point
+# at a different dev port), copy this file to `.env` and add the variable
+# below. The `.env` file is gitignored.
+#
+# Optional overrides (rarely needed):
+#
+#   PORT=5710             # UI port for `npm run dev` (auto-resolves on conflict)
+#
+# Production / CI secrets (Cloudflare Worker, OAuth, TestFlight signing,
+# Chrome Web Store publishing, etc.) live in GitHub Actions secrets and
+# wrangler secret storage — never in a local .env.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,30 +1,5 @@
-# Default owners — reviewed when no more specific rule matches.
-*                                       @trieloff @karlpauls @catalan-adobe
-
-# Workflow / release / repo-config changes need a maintainer review.
-/.github/                               @trieloff @karlpauls
-/.releaserc.json                        @trieloff @karlpauls
-/renovate.json                          @trieloff @karlpauls
-
-# Native macOS launcher + server.
-/packages/swift-launcher/               @trieloff @karlpauls
-/packages/swift-server/                 @trieloff @karlpauls
-
-# iOS follower app.
-/packages/ios-app/                      @trieloff @karlpauls
-
-# Cloudflare worker (tray hub / signaling / TURN).
-/packages/cloudflare-worker/            @trieloff @karlpauls
-
-# Browser app core + UI.
-/packages/webapp/                       @trieloff @karlpauls @catalan-adobe
+# Default owner.
+*                               @trieloff
 
 # Chrome extension.
-/packages/chrome-extension/             @trieloff @karlpauls @catalan-adobe
-
-# Node CLI / Electron server.
-/packages/node-server/                  @trieloff @karlpauls
-
-# Shared libs.
-/packages/shared-ts/                    @trieloff @karlpauls
-/packages/cloud-core/                   @trieloff @karlpauls
+/packages/chrome-extension/     @karlpauls

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+# Default owners — reviewed when no more specific rule matches.
+*                                       @trieloff @karlpauls @catalan-adobe
+
+# Workflow / release / repo-config changes need a maintainer review.
+/.github/                               @trieloff @karlpauls
+/.releaserc.json                        @trieloff @karlpauls
+/renovate.json                          @trieloff @karlpauls
+
+# Native macOS launcher + server.
+/packages/swift-launcher/               @trieloff @karlpauls
+/packages/swift-server/                 @trieloff @karlpauls
+
+# iOS follower app.
+/packages/ios-app/                      @trieloff @karlpauls
+
+# Cloudflare worker (tray hub / signaling / TURN).
+/packages/cloudflare-worker/            @trieloff @karlpauls
+
+# Browser app core + UI.
+/packages/webapp/                       @trieloff @karlpauls @catalan-adobe
+
+# Chrome extension.
+/packages/chrome-extension/             @trieloff @karlpauls @catalan-adobe
+
+# Node CLI / Electron server.
+/packages/node-server/                  @trieloff @karlpauls
+
+# Shared libs.
+/packages/shared-ts/                    @trieloff @karlpauls
+/packages/cloud-core/                   @trieloff @karlpauls

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules/
 dist/
 *.tsbuildinfo
 .DS_STORE
+.env
+.env.local
+.env.*.local
 /workspace/
 coverage/
 .worktrees/


### PR DESCRIPTION
<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in.
-->

## Summary

Three small, low-risk hygiene changes that close concrete gaps from the
agent-readiness audit, plus one out-of-band change applied via the GitHub API:

- **`.github/CODEOWNERS`** — default owners + per-package scoping so PRs
  auto-route to the right maintainers. Was previously missing.
- **`.env.example`** — explicit "no env vars required to build" hint, so
  agents and new contributors don't go hunting for one. Documents the one
  optional override (`PORT`) and points production secrets at GitHub
  Actions / Wrangler.
- **`.gitignore`** — adds `.env`, `.env.local`, `.env.*.local` so a
  developer copying `.env.example` -> `.env` can't accidentally commit
  secrets.
- **(out-of-band)** GitHub-native **secret scanning** and **push
  protection** enabled via `PATCH /repos/{owner}/{repo}` against
  `security_and_analysis`. This is a repo-settings change, not a file
  change, so it isn't visible in the diff — but it pairs with the
  `.env.example` work above.

## Why

These are the three lowest-cost, highest-leverage items the agent-readiness
report flagged as failing at the repo level (`codeowners`, `env_template`,
`secret_scanning`). Each is independent and reversible; together they move
the audit from Level 4 closer to Level 5 without changing any production
behavior.

## Test plan / Verification

- `git diff --stat`: 3 files changed, 48 insertions(+).
- No source code, build, or workflow files touched — CI lint/typecheck/test
  jobs should pass unchanged.
- CODEOWNERS validity: GitHub will surface any syntax error inline on the
  PR page (no @-mention should resolve to "Unknown user").
- Secret scanning: `gh api repos/ai-ecoverse/slicc | jq .security_and_analysis`
  now returns `{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}`.

## Three suggested follow-ups (not in this PR)

The audit also surfaced a handful of higher-effort items that are worth
queueing as separate PRs:

1. **Wire `tech_debt_tracking` into CI.** A single grep step that fails (or
   warns) when a `TODO`/`FIXME` lacks a linked issue (`TODO(#NNN)` style)
   would give the codebase a cheap, deterministic debt ledger. Pair with
   `eslint-plugin-no-warning-comments` (config-level) or a 10-line bash
   step in `ci.yml`'s `lint` job. ~30 min of work; closes the last
   "level 3 hygiene" gap.

2. **Add a `runbooks/` directory (or `docs/runbooks/`) with one entry
   per on-call surface.** Cloudflare-worker tray-hub outage, Chrome Web
   Store rejection, npm publish rollback, TestFlight signing failure,
   macOS notarization rejection — each gets a 1-page "symptom → check →
   fix → who to page" playbook. Currently the audit can't find any
   incident response documentation, and the failure modes already exist
   in `docs/pitfalls.md` but aren't organized as runbooks. ~2 hrs to
   draft the first four; closes `runbooks_documented` and starts to
   close `alerting_configured`.

3. **Adopt a structured issue-label taxonomy** (priority `P0`/`P1`/`P2`/`P3`,
   area `webapp`/`extension`/`worker`/`swift`/`ios`/`docs`, type
   `bug`/`feat`/`chore`/`docs`). Today issues only carry `bug`,
   `enhancement`, `skill issue` — which means agents can't filter by
   severity or surface area when picking up work. Pair the labels with
   the existing issue templates (drop `labels:` defaults into each YAML
   form) so new issues land pre-tagged. ~1 hr including label creation
   via `gh label create`; closes `issue_labeling_system` and meaningfully
   improves `backlog_health`.

Each of these is independent and could be picked up by an agent on its own.
