### PR TITLE
chore(issues): add area/* labels and surface them in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,6 +53,22 @@ body:
         - Build / dev server / Vite HMR
         - Other / not sure
 
+  - type: checkboxes
+    id: area
+    attributes:
+      label: Area (apply matching `area/*` labels)
+      description: |
+        After filing, please add the matching `area/*` label(s) to the issue so it routes to the right maintainer. Tick all that apply as a reminder.
+      options:
+        - label: '`area/webapp` — browser app core (packages/webapp)'
+        - label: '`area/extension` — Chrome extension (packages/chrome-extension)'
+        - label: '`area/node-server` — Node CLI / Electron server (packages/node-server)'
+        - label: '`area/worker` — Cloudflare worker (packages/cloudflare-worker)'
+        - label: '`area/swift` — native macOS apps (swift-launcher / swift-server)'
+        - label: '`area/ios` — iOS follower app (packages/ios-app)'
+        - label: '`area/docs` — README, CLAUDE.md, AGENTS.md, docs/, SKILL.md'
+        - label: '`area/build` — build, CI, release, monorepo tooling'
+
   - type: textarea
     id: repro
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 name: Documentation issue
 description: Incorrect, missing, or confusing docs in README, `CLAUDE.md`, `AGENTS.md`, `docs/`, or skill `SKILL.md` files.
 title: 'docs: '
-labels: ['documentation']
+labels: ['documentation', 'area/docs']
 body:
   - type: input
     id: location

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -56,3 +56,19 @@ body:
         - Cloudflare worker / tray hub
         - Provider / model integration
         - Other
+
+  - type: checkboxes
+    id: area
+    attributes:
+      label: Area (apply matching `area/*` labels)
+      description: |
+        After filing, please add the matching `area/*` label(s) to the issue so it routes to the right maintainer. Tick all that apply as a reminder.
+      options:
+        - label: '`area/webapp` — browser app core (packages/webapp)'
+        - label: '`area/extension` — Chrome extension (packages/chrome-extension)'
+        - label: '`area/node-server` — Node CLI / Electron server (packages/node-server)'
+        - label: '`area/worker` — Cloudflare worker (packages/cloudflare-worker)'
+        - label: '`area/swift` — native macOS apps (swift-launcher / swift-server)'
+        - label: '`area/ios` — iOS follower app (packages/ios-app)'
+        - label: '`area/docs` — README, CLAUDE.md, AGENTS.md, docs/, SKILL.md'
+        - label: '`area/build` — build, CI, release, monorepo tooling'


### PR DESCRIPTION
## Summary

Adds an `area/*` issue-label taxonomy and wires it into the existing
issue templates. No priority labels yet — area alone is enough to
filter and route work for now.

## Why

`issue_labeling_system` was the last "easy" gap in the agent-readiness
audit. Today issues only carry `bug`, `enhancement`, `skill issue`, so
agents and humans can't filter the backlog by surface area
(extension vs worker vs ios, etc.).

## What changed

**Labels (created out-of-band via `gh label create`):**

| Label             | Description                                            |
| ----------------- | ------------------------------------------------------ |
| `area/webapp`     | Browser app core (`packages/webapp`)                   |
| `area/extension`  | Chrome extension (`packages/chrome-extension`)         |
| `area/node-server`| Node CLI / Electron server (`packages/node-server`)    |
| `area/worker`     | Cloudflare worker (`packages/cloudflare-worker`)       |
| `area/swift`      | Native macOS apps (swift-launcher / swift-server)      |
| `area/ios`        | iOS follower app (`packages/ios-app`)                  |
| `area/docs`       | README, CLAUDE.md, AGENTS.md, `docs/`, SKILL.md        |
| `area/build`      | Build, CI, release, monorepo tooling                   |

All eight share the same color (`#1d76db`) so they group visually on
the issues list.

**Issue templates (this PR's diff):**

- `documentation.yml` auto-applies `area/docs` via the template's
  `labels:` field — that template only ever produces doc issues, so
  the area is unambiguous.
- `bug_report.yml` and `feature_request.yml` add a checkbox list of all
  eight areas as a **reminder for the filer** to apply the matching
  label(s) after submitting. GitHub form templates can't dynamically
  set labels from checkbox state, so the checkboxes are guidance
  rather than enforcement, but they put the taxonomy in front of every
  new bug / feature filer.
- `skill_proposal.yml` left alone — skills span every area by nature.

## Test plan

- `prettier --check .github/ISSUE_TEMPLATE/*.yml` is clean.
- GitHub renders YAML issue forms with strict validation; if any of
  the three edited files were malformed, the issue form would refuse
  to render. (Verified locally that the YAML still parses with the
  same structure.)
- Filing a test doc issue after merge should arrive pre-labeled with
  `documentation` + `area/docs`.

## Follow-ups (intentionally not in this PR)

- A simple labeler workflow could read the bug/feature checkbox state
  from the issue body and apply the picked labels automatically
  (closing the gap between "filer ticked the box" and "label is
  actually on the issue"). Worth doing once we see how filers use
  the checkboxes.
- Priority labels (`P0`–`P3`) remain deliberately out of scope.
