### PR TITLE
feat(dev-tools): nightly RUM error-to-insight pipeline

### DIFF
--- a/.github/workflows/rum-error-triage.yml
+++ b/.github/workflows/rum-error-triage.yml
@@ -1,0 +1,121 @@
+name: RUM Error Triage
+
+# Error-to-insight pipeline. SLICC has no Sentry — operational errors land in
+# the helix RUM `cluster` table as `error` checkpoints (see
+# packages/webapp/src/ui/telemetry.ts). Each night this workflow:
+#   1. queries RUM for recent SLICC errors (filtering dev/Vite noise),
+#   2. deduplicates them against errors that already have an issue, and
+#   3. hands the new candidates to claude-code-action, which investigates each
+#      against the codebase and opens a GitHub issue (and, when the fix is
+#      clear, a draft PR) for the genuine bugs.
+#
+# Required repository secrets:
+#   RUM_BQ_SA_KEY    GCP service-account JSON with BigQuery Job User + Data
+#                    Viewer on project `helix-225321` (the RUM dataset).
+#                    (Workload Identity Federation can replace this — see
+#                    google-github-actions/auth — and is preferred long-term.)
+#   ANTHROPIC_API_KEY  API key for claude-code-action.
+# Until both secrets are set the scheduled run will fail fast at the auth /
+# classify steps; the query+dedup logic is covered by unit tests in
+# packages/dev-tools/rum-error-triage/lib.test.mjs.
+
+on:
+  schedule:
+    - cron: '0 3 * * *' # nightly at 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      since_days:
+        description: 'Look-back window in days'
+        required: false
+        default: '1'
+      dry_run:
+        description: 'Query + dedup only; do not open issues'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: rum-error-triage
+  cancel-in-progress: false
+
+permissions:
+  contents: write # claude-code-action may push a draft-fix branch
+  issues: write # file error issues
+  pull-requests: write # open draft fix PRs
+  id-token: write # for GCP Workload Identity Federation (if adopted)
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.RUM_BQ_SA_KEY }}
+
+      - name: Set up Cloud SDK (provides bq)
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Ensure triage labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create rum-error --color B60205 --description "Surfaced from RUM error telemetry" --force
+          gh label create bug --color D73A4A --description "Something isn't working" --force
+
+      - name: Query RUM and select new error candidates
+        id: query
+        env:
+          SINCE_DAYS: ${{ github.event.inputs.since_days || '1' }}
+          GH_TOKEN: ${{ github.token }}
+        run: node packages/dev-tools/rum-error-triage/triage-rum-errors.mjs
+
+      - name: Classify candidates and file issues
+        if: steps.query.outputs.has_candidates == 'true' && github.event.inputs.dry_run != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Edit,Write"
+            --max-turns 40
+          prompt: |
+            You are triaging production errors for the SLICC codebase. A nightly
+            job queried RUM (Real User Monitoring) telemetry and wrote the new,
+            already-deduplicated error candidates to `rum-error-candidates.json`
+            in the repo root.
+
+            For EACH candidate in that file:
+
+            1. Read the candidate's `signature`, `exampleSource`, `exampleTarget`,
+               `float` (cli/extension/electron), occurrence stats (`sampled`,
+               `estimated`), and `firstSeen`/`lastSeen`.
+            2. Investigate the codebase (Grep/Glob/Read) to locate where this
+               error originates and judge whether it is a REAL, ACTIONABLE SLICC
+               bug. Skip and explain (do not file) if it is: dev-server/tooling
+               noise, a transient/network blip with no code fix, or an
+               environmental/browser-policy condition the app cannot reasonably
+               handle.
+            3. Before filing, double-check it is not already tracked:
+               `gh issue list --search "rum-fp:<fingerprint> in:body" --state all`.
+            4. For each genuine bug, open an issue with `gh issue create`:
+               - Title: a concise description of the bug (not the raw stack frame).
+               - Body: what the error is, the suspected root cause with
+                 `file:line` references you found, the float it occurs on, the
+                 occurrence stats and first/last-seen window, and a proposed fix.
+                 You MUST include, on its own line, the exact marker:
+                 `<!-- rum-fp:<fingerprint> -->` using the candidate's
+                 `fingerprint` — this is how future runs avoid duplicates.
+               - Labels: `--label rum-error --label bug`.
+            5. If — and only if — the fix is small, clear, and low-risk, also
+               open a DRAFT pull request implementing it on a new branch and link
+               it to the issue. Otherwise leave the fix to a human.
+
+            Be conservative: a wrong or noisy issue is worse than no issue. End by
+            printing a short summary of what you filed and what you skipped (with
+            reasons).

--- a/.github/workflows/rum-error-triage.yml
+++ b/.github/workflows/rum-error-triage.yml
@@ -48,19 +48,21 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      # Third-party actions are pinned to immutable commit SHAs (matching
+      # .github/workflows/ci.yml) — this job has contents/issues/PR write access.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.RUM_BQ_SA_KEY }}
 
       - name: Set up Cloud SDK (provides bq)
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
 
       - name: Ensure triage labels exist
         env:
@@ -78,7 +80,7 @@ jobs:
 
       - name: Classify candidates and file issues
         if: steps.query.outputs.has_candidates == 'true' && github.event.inputs.dry_run != 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |

--- a/.github/workflows/rum-error-triage.yml
+++ b/.github/workflows/rum-error-triage.yml
@@ -81,9 +81,22 @@ jobs:
       - name: Classify candidates and file issues
         if: steps.query.outputs.has_candidates == 'true' && github.event.inputs.dry_run != 'true'
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        env:
+          # Bedrock path: authenticate with an Amazon Bedrock API key (the Adobe
+          # CAMP `ABSK...` bearer token). Set the AWS_BEARER_TOKEN_BEDROCK secret
+          # and, if needed, the RUM_AWS_REGION / RUM_BEDROCK_MODEL repo variables
+          # to match the region + inference profile your CAMP key can reach.
+          # (Bearer-token auth for Bedrock is newer in Claude Code — if a run
+          # fails on auth, fall back to `anthropic_api_key` below.)
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          AWS_REGION: ${{ vars.RUM_AWS_REGION || 'us-east-1' }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_bedrock: 'true'
+          # Anthropic-API fallback — uncomment and remove the Bedrock env above
+          # to use a direct Anthropic key instead:
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
+            --model ${{ vars.RUM_BEDROCK_MODEL || 'global.anthropic.claude-sonnet-4-6' }}
             --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Edit,Write"
             --max-turns 40
           prompt: |

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ packages/swift-launcher/.node-cache/
 .claude/settings.*
 .claude/worktrees/
 packages/cloudflare-worker/.dev.vars
+
+# RUM error-triage runtime artifact
+rum-error-candidates.json

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -93,7 +93,7 @@ export default tseslint.config(
       'packages/node-server/src/**/*.ts',
       'packages/node-server/scripts/**/*.{mjs,js,ts}',
       'packages/cloudflare-worker/src/**/*.ts',
-      'packages/dev-tools/tools/**/*.{mjs,js,ts}',
+      'packages/dev-tools/**/*.{mjs,js,ts}',
       'packages/swift-launcher/**/*.{mjs,js,ts}',
       'packages/swift-server/**/*.{mjs,js,ts}',
       'vite.config*.ts',

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -12,6 +12,7 @@ This file covers the repo's developer-tooling surface.
 - **Build configs**: `packages/webapp/vite.config.ts`, `packages/chrome-extension/vite.config.ts`, `eslint.config.js`
 - **QA setup**: `packages/node-server/src/qa-setup.ts` plus the root `npm run qa:*` scripts
 - **Visual/integration helpers**: `tests/test-dips.mjs` and related targeted test utilities
+- **RUM error triage** (error-to-insight pipeline): `packages/dev-tools/rum-error-triage/` — run `node packages/dev-tools/rum-error-triage/triage-rum-errors.mjs` to query RUM for new SLICC errors and write triage candidates; pure logic in `lib.mjs` (tested via the `dev-tools` vitest project). Driven nightly by `.github/workflows/rum-error-triage.yml`. See its `README.md`.
 
 ## What Lives Here Conceptually
 

--- a/packages/dev-tools/rum-error-triage/README.md
+++ b/packages/dev-tools/rum-error-triage/README.md
@@ -1,0 +1,77 @@
+# RUM Error Triage — the error-to-insight pipeline
+
+SLICC has no Sentry. Operational errors are reported through RUM (Real User
+Monitoring) as `error` checkpoints in the helix BigQuery `cluster` table (see
+`packages/webapp/src/ui/telemetry.ts`). This tool turns those errors into
+actionable GitHub issues, automatically, every night.
+
+## Flow
+
+```
+nightly cron ─▶ triage-rum-errors.mjs ─▶ rum-error-candidates.json ─▶ claude-code-action ─▶ issues (+ draft PRs)
+                  │                          ▲
+                  ├─ bq query (RUM errors)   │ deduped vs. existing rum-fp markers
+                  └─ gh issue list (dedup) ──┘
+```
+
+1. **Query** — `triage-rum-errors.mjs` runs a BigQuery query (`buildErrorQuery`
+   in `lib.mjs`) for `error` checkpoints in SLICC sessions over the look-back
+   window. SLICC sessions are identified by the telemetry fingerprint
+   (`generation LIKE 'slicc-%'` for the extension, or a `navigate` checkpoint
+   with `target IN ('cli','electron')` for the CLI/Electron floats). Vite HMR
+   dev-client noise is excluded.
+2. **Group + dedup** — raw rows are normalised into stable signatures and
+   fingerprinted (`md5`). Each fingerprint that already appears in an existing
+   issue (as a `<!-- rum-fp:... -->` marker) is dropped, so the same error is
+   filed only once.
+3. **Classify + file** — new candidates are written to
+   `rum-error-candidates.json`, and `anthropics/claude-code-action` reads them,
+   investigates each against the codebase, and opens an issue (and, when the fix
+   is clear and low-risk, a draft PR) for the genuine bugs — embedding the
+   `rum-fp` marker so the next run recognises it.
+
+The workflow lives in `.github/workflows/rum-error-triage.yml`.
+
+## Design notes
+
+- **Pure logic is isolated and tested.** `lib.mjs` contains all normalisation,
+  fingerprinting, noise filtering, dedup, and query building, with no I/O. It is
+  unit-tested in `lib.test.mjs` (run via the `dev-tools` vitest project in
+  `npm test`). `triage-rum-errors.mjs` only shells out to `bq` and `gh`.
+- **Dedup key.** The `rum-fp:<fingerprint>` marker embedded in each filed issue
+  body is the dedup contract — keep it intact when editing issue templates.
+- **Noise.** `isNoise()` drops Vite HMR frames and contentless errors. Extend
+  `NOISE_PATTERNS` as new dev-only noise appears.
+
+## Required secrets (GitHub Actions)
+
+| Secret              | Purpose                                                                                  |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| `RUM_BQ_SA_KEY`     | GCP service-account JSON with **BigQuery Job User** + **Data Viewer** on `helix-225321`. |
+| `ANTHROPIC_API_KEY` | Key for `claude-code-action` (classification + issue/PR authoring).                      |
+
+Workload Identity Federation is the preferred long-term replacement for the
+service-account key — see `google-github-actions/auth`.
+
+## Run it locally
+
+Requires the `bq` CLI (authenticated to `helix-225321`) and the `gh` CLI.
+
+```bash
+# Look back 7 days; write candidates to a temp file
+SINCE_DAYS=7 OUTPUT_PATH=/tmp/candidates.json \
+  node packages/dev-tools/rum-error-triage/triage-rum-errors.mjs
+
+# Unit tests
+npx vitest run --project dev-tools
+```
+
+### Environment variables
+
+| Var               | Default                                      | Meaning                          |
+| ----------------- | -------------------------------------------- | -------------------------------- |
+| `SINCE_DAYS`      | `1`                                          | Look-back window in days         |
+| `SLICC_RUM_HOSTS` | `localhost,akjjllgokmbgpbdbmafpiefnhidlmbgf` | Hostnames carrying SLICC traffic |
+| `RUM_BQ_PROJECT`  | `helix-225321`                               | BigQuery billing/project id      |
+| `TRIAGE_LABEL`    | `rum-error`                                  | Label used for dedup and filing  |
+| `OUTPUT_PATH`     | `rum-error-candidates.json`                  | Where to write the candidates    |

--- a/packages/dev-tools/rum-error-triage/README.md
+++ b/packages/dev-tools/rum-error-triage/README.md
@@ -43,15 +43,20 @@ The workflow lives in `.github/workflows/rum-error-triage.yml`.
 - **Noise.** `isNoise()` drops Vite HMR frames and contentless errors. Extend
   `NOISE_PATTERNS` as new dev-only noise appears.
 
-## Required secrets (GitHub Actions)
+## Required secrets / variables (GitHub Actions)
 
-| Secret              | Purpose                                                                                  |
-| ------------------- | ---------------------------------------------------------------------------------------- |
-| `RUM_BQ_SA_KEY`     | GCP service-account JSON with **BigQuery Job User** + **Data Viewer** on `helix-225321`. |
-| `ANTHROPIC_API_KEY` | Key for `claude-code-action` (classification + issue/PR authoring).                      |
+| Name                       | Kind     | Purpose                                                                                                                                                                                                                     |
+| -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RUM_BQ_SA_KEY`            | secret   | GCP service-account JSON for BigQuery. Provisioned: `rum-error-triage@helix-225321.iam.gserviceaccount.com` — `bigquery.jobUser` (project) + `bigquery.dataViewer` scoped by IAM condition to the `helix_rum` dataset only. |
+| `AWS_BEARER_TOKEN_BEDROCK` | secret   | Amazon Bedrock API key (the Adobe CAMP `ABSK...` bearer token) used by `claude-code-action` (`use_bedrock: true`).                                                                                                          |
+| `RUM_AWS_REGION`           | variable | Optional. Bedrock region for the CAMP key (default `us-east-1`).                                                                                                                                                            |
+| `RUM_BEDROCK_MODEL`        | variable | Optional. Bedrock model / inference profile (default `global.anthropic.claude-sonnet-4-6`).                                                                                                                                 |
+| `ANTHROPIC_API_KEY`        | secret   | Only if you switch off the Bedrock path (see the commented `anthropic_api_key` fallback in the workflow).                                                                                                                   |
 
-Workload Identity Federation is the preferred long-term replacement for the
-service-account key — see `google-github-actions/auth`.
+The BigQuery service account is intentionally minimal: read-only, single
+dataset (enforced by an IAM condition), single purpose. Workload Identity
+Federation is the preferred long-term replacement for the key — see
+`google-github-actions/auth`.
 
 ## Run it locally
 

--- a/packages/dev-tools/rum-error-triage/lib.mjs
+++ b/packages/dev-tools/rum-error-triage/lib.mjs
@@ -1,0 +1,173 @@
+/*
+ * RUM error-triage — pure logic.
+ *
+ * SLICC has no Sentry; its operational errors land in the helix RUM
+ * `cluster` table as `checkpoint='error'` rows (see
+ * `packages/webapp/src/ui/telemetry.ts`). This module turns raw error rows
+ * into deduplicated, actionable triage candidates. It is intentionally free
+ * of I/O so it can be unit-tested in isolation — the BigQuery and GitHub
+ * calls live in `triage-rum-errors.mjs`.
+ */
+import { createHash } from 'node:crypto';
+
+/** Default BigQuery location of the RUM data. */
+export const RUM_TABLE = 'helix-225321.helix_rum.cluster';
+
+/**
+ * Hostnames that carry SLICC traffic. The CLI/Electron floats report under
+ * the shared `localhost` bucket (the port is stripped server-side — see
+ * adobe/helix-rum-collector#634), and the published extension reports under
+ * its stable extension ID. Override via the `SLICC_RUM_HOSTS` env var.
+ */
+export const DEFAULT_HOSTS = ['localhost', 'akjjllgokmbgpbdbmafpiefnhidlmbgf'];
+
+/**
+ * Frames we never file: dev-server / tooling noise that is not a SLICC bug.
+ * The dominant example is the Vite HMR client, which only errors under
+ * `npm run dev` and accounts for ~99% of raw CLI `error` checkpoints.
+ */
+const NOISE_PATTERNS = [/@vite\/client/i, /vite\/dist\/client/i, /__vite_hmr/i];
+
+/**
+ * True if an error row is dev/tooling noise rather than an app error.
+ * @param {string|null|undefined} source the RUM error `source` (stack frame)
+ * @param {string|null|undefined} target the RUM error `target` (message)
+ */
+export function isNoise(source, target) {
+  const hay = `${source ?? ''} ${target ?? ''}`;
+  // An error with no alphanumeric content (empty source AND target) carries
+  // nothing to act on — drop it rather than filing a contentless issue.
+  if (!/[a-z0-9]/i.test(hay)) return true;
+  return NOISE_PATTERNS.some((re) => re.test(hay));
+}
+
+/**
+ * Collapse a raw (source, target) error pair into a stable signature, so
+ * that the "same" error across sessions groups together regardless of
+ * volatile detail (ports, line:col, ids, counts).
+ * @param {string|null|undefined} source
+ * @param {string|null|undefined} target
+ * @returns {string} the normalized signature
+ */
+export function normalizeSignature(source, target) {
+  return `${source ?? ''} | ${target ?? ''}`
+    .toLowerCase()
+    .replace(/https?:\/\/[^\s)]+/g, '') // strip URLs (host:port + path)
+    .replace(/[0-9a-f]{8}-[0-9a-f-]{20,}/g, '<uuid>') // collapse UUIDs
+    .replace(/0x[0-9a-f]+/g, '<hex>') // collapse hex addresses
+    .replace(/\d+/g, 'N') // collapse remaining numbers (line:col, counts)
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Stable short fingerprint for a signature. Used as the dedup key and
+ * embedded in filed issues as `rum-fp:<fingerprint>` so subsequent runs
+ * recognise an error that already has an issue.
+ * @param {string} signature
+ * @returns {string} hex md5 of the signature
+ */
+export function fingerprint(signature) {
+  return createHash('md5').update(signature).digest('hex');
+}
+
+/**
+ * Extract the `rum-fp:<fingerprint>` markers from a set of existing GitHub
+ * issues (as returned by `gh issue list --json body`).
+ * @param {Array<{body?: string}>} issues
+ * @returns {Set<string>} lowercased fingerprints already filed
+ */
+export function parseFingerprints(issues) {
+  const fps = new Set();
+  for (const issue of issues ?? []) {
+    for (const m of (issue?.body ?? '').matchAll(/rum-fp:\s*([0-9a-f]{6,64})/gi)) {
+      fps.add(m[1].toLowerCase());
+    }
+  }
+  return fps;
+}
+
+/**
+ * Group raw error rows by fingerprint into candidates, dropping noise.
+ * Each candidate carries occurrence stats and one concrete example.
+ * @param {Array<{float?: string, source?: string, target?: string, weight?: number|string, time?: string}>} rows
+ * @returns {Array<object>} candidates, most-frequent first
+ */
+export function aggregateCandidates(rows) {
+  /** @type {Map<string, any>} */
+  const byFp = new Map();
+  for (const r of rows ?? []) {
+    if (isNoise(r.source, r.target)) continue;
+    const signature = normalizeSignature(r.source, r.target);
+    const fp = fingerprint(signature);
+    const weight = Number(r.weight) || 0;
+    const existing = byFp.get(fp);
+    if (existing) {
+      existing.sampled += 1;
+      existing.estimated += weight;
+      if (r.time && r.time < existing.firstSeen) existing.firstSeen = r.time;
+      if (r.time && r.time > existing.lastSeen) existing.lastSeen = r.time;
+    } else {
+      byFp.set(fp, {
+        fingerprint: fp,
+        signature,
+        float: r.float ?? 'unknown',
+        sampled: 1,
+        estimated: weight,
+        firstSeen: r.time ?? null,
+        lastSeen: r.time ?? null,
+        exampleSource: r.source ?? '',
+        exampleTarget: r.target ?? '',
+      });
+    }
+  }
+  return [...byFp.values()].sort((a, b) => b.estimated - a.estimated || b.sampled - a.sampled);
+}
+
+/**
+ * Final triage selection: aggregate raw rows and drop any fingerprint that
+ * already has an issue.
+ * @param {Array<object>} rows raw error rows from BigQuery
+ * @param {Set<string>} existingFps fingerprints already filed (see parseFingerprints)
+ * @returns {Array<object>} new candidates needing an issue
+ */
+export function selectNewCandidates(rows, existingFps) {
+  const filed = existingFps ?? new Set();
+  return aggregateCandidates(rows).filter((c) => !filed.has(c.fingerprint));
+}
+
+/**
+ * Build the BigQuery SQL that extracts raw SLICC `error` rows over a window.
+ * Returns raw rows (not pre-aggregated) so all normalization/dedup stays in
+ * tested JS; only the cheap, clustered SLICC-session filter and a coarse
+ * Vite exclusion run server-side.
+ * @param {{sinceDays?: number, hosts?: string[], table?: string}} [opts]
+ * @returns {string} a standard-SQL query
+ */
+export function buildErrorQuery(opts = {}) {
+  const sinceDays = Number.isFinite(opts.sinceDays) ? Math.max(1, Math.floor(opts.sinceDays)) : 1;
+  const hosts = opts.hosts?.length ? opts.hosts : DEFAULT_HOSTS;
+  const table = opts.table ?? RUM_TABLE;
+  const hostList = hosts.map((h) => `"${String(h).replace(/[^\w.:-]/g, '')}"`).join(',');
+  return `
+DECLARE since TIMESTAMP DEFAULT TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL ${sinceDays} DAY);
+DECLARE hosts ARRAY<STRING> DEFAULT [${hostList}];
+WITH sess AS (
+  SELECT id,
+    CASE WHEN LOGICAL_OR(generation LIKE "slicc%") THEN "extension"
+         WHEN LOGICAL_OR(checkpoint="navigate" AND target="cli") THEN "cli"
+         WHEN LOGICAL_OR(checkpoint="navigate" AND target="electron") THEN "electron" END AS float
+  FROM \`${table}\`
+  WHERE time >= since AND hostname IN UNNEST(hosts)
+    AND (generation LIKE "slicc%" OR (checkpoint="navigate" AND target IN ("cli","electron")))
+  GROUP BY id
+  HAVING float IS NOT NULL
+)
+SELECT s.float AS float, e.source AS source, e.target AS target, e.weight AS weight,
+       FORMAT_TIMESTAMP("%Y-%m-%dT%H:%M:%SZ", e.time) AS time
+FROM \`${table}\` e JOIN sess s USING (id)
+WHERE e.time >= since AND e.hostname IN UNNEST(hosts) AND e.checkpoint = "error"
+  AND COALESCE(e.source, "") NOT LIKE "%@vite/client%"
+  AND COALESCE(e.target, "") NOT LIKE "%@vite/client%"
+`.trim();
+}

--- a/packages/dev-tools/rum-error-triage/lib.mjs
+++ b/packages/dev-tools/rum-error-triage/lib.mjs
@@ -154,12 +154,17 @@ DECLARE since TIMESTAMP DEFAULT TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL ${si
 DECLARE hosts ARRAY<STRING> DEFAULT [${hostList}];
 WITH sess AS (
   SELECT id,
-    CASE WHEN LOGICAL_OR(generation LIKE "slicc%") THEN "extension"
-         WHEN LOGICAL_OR(checkpoint="navigate" AND target="cli") THEN "cli"
-         WHEN LOGICAL_OR(checkpoint="navigate" AND target="electron") THEN "electron" END AS float
+    -- Navigate target wins. telemetry.ts sets RUM_GENERATION="slicc-\${mode}"
+    -- for every float, so a CLI/Electron session can carry a slicc-* generation
+    -- too; classify by the navigate target first and treat the generation
+    -- marker as the extension-only fallback. Match "slicc-%" (with hyphen) to
+    -- mirror the RUM_GENERATION format exactly.
+    CASE WHEN LOGICAL_OR(checkpoint="navigate" AND target="cli") THEN "cli"
+         WHEN LOGICAL_OR(checkpoint="navigate" AND target="electron") THEN "electron"
+         WHEN LOGICAL_OR(generation LIKE "slicc-%") THEN "extension" END AS float
   FROM \`${table}\`
   WHERE time >= since AND hostname IN UNNEST(hosts)
-    AND (generation LIKE "slicc%" OR (checkpoint="navigate" AND target IN ("cli","electron")))
+    AND (generation LIKE "slicc-%" OR (checkpoint="navigate" AND target IN ("cli","electron")))
   GROUP BY id
   HAVING float IS NOT NULL
 )

--- a/packages/dev-tools/rum-error-triage/lib.test.mjs
+++ b/packages/dev-tools/rum-error-triage/lib.test.mjs
@@ -178,8 +178,23 @@ describe('buildErrorQuery', () => {
     expect(sql).toContain('"localhost"');
     expect(sql).toContain('"extid"');
     expect(sql).toContain('checkpoint = "error"');
-    expect(sql).toContain('generation LIKE "slicc%"');
+    // Matches telemetry.ts RUM_GENERATION format exactly (hyphen), not a loose prefix.
+    expect(sql).toContain('generation LIKE "slicc-%"');
+    expect(sql).not.toContain('generation LIKE "slicc%"');
     expect(sql).toContain('NOT LIKE "%@vite/client%"');
+  });
+
+  it('classifies floats by navigate target before the generation marker', () => {
+    const sql = buildErrorQuery();
+    // CLI/Electron must be matched on their navigate target ahead of the
+    // generation fallback, so a slicc-* generation never mislabels them.
+    const cliIdx = sql.indexOf('target="cli"');
+    const electronIdx = sql.indexOf('target="electron"');
+    const genIdx = sql.indexOf('generation LIKE "slicc-%") THEN "extension"');
+    expect(cliIdx).toBeGreaterThan(-1);
+    expect(genIdx).toBeGreaterThan(-1);
+    expect(cliIdx).toBeLessThan(genIdx);
+    expect(electronIdx).toBeLessThan(genIdx);
   });
 
   it('defaults to a 1-day window over the default hosts', () => {

--- a/packages/dev-tools/rum-error-triage/lib.test.mjs
+++ b/packages/dev-tools/rum-error-triage/lib.test.mjs
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isNoise,
+  normalizeSignature,
+  fingerprint,
+  parseFingerprints,
+  aggregateCandidates,
+  selectNewCandidates,
+  buildErrorQuery,
+  DEFAULT_HOSTS,
+} from './lib.mjs';
+
+describe('isNoise', () => {
+  it('flags Vite HMR dev-client frames', () => {
+    expect(
+      isNoise(
+        'Object.send@http://localhost:5710/@vite/client:384:15',
+        'send was called before connect'
+      )
+    ).toBe(true);
+    expect(isNoise('foo', 'something in vite/dist/client/x')).toBe(true);
+  });
+  it('does not flag genuine app errors', () => {
+    expect(isNoise('notallowederror', "Failed to execute 'writeText' on 'Clipboard'")).toBe(false);
+  });
+  it('flags contentless errors (no alphanumerics in source or target)', () => {
+    expect(isNoise(null, undefined)).toBe(true);
+    expect(isNoise('', '')).toBe(true);
+    expect(isNoise(' | ', '')).toBe(true);
+  });
+});
+
+describe('normalizeSignature', () => {
+  it('collapses ports, line:col, and urls so the same error groups together', () => {
+    const a = normalizeSignature(
+      'Object.x@http://localhost:5710/app.js:384:15',
+      'TypeError: boom 12'
+    );
+    const b = normalizeSignature(
+      'Object.x@http://localhost:5720/app.js:991:3',
+      'TypeError: boom 87'
+    );
+    expect(a).toBe(b);
+  });
+  it('keeps distinct errors distinct', () => {
+    expect(normalizeSignature('a', 'clipboard write failed')).not.toBe(
+      normalizeSignature('a', 'network request failed')
+    );
+  });
+  it('collapses uuids and hex addresses', () => {
+    const sig = normalizeSignature('at 0xdeadbeef', 'lost 550e8400-e29b-41d4-a716-446655440000');
+    expect(sig).toContain('<hex>');
+    expect(sig).toContain('<uuid>');
+  });
+  it('tolerates null/undefined', () => {
+    expect(normalizeSignature(null, null)).toBe('|');
+  });
+});
+
+describe('fingerprint', () => {
+  it('is stable and deterministic for a signature', () => {
+    expect(fingerprint('abc')).toBe(fingerprint('abc'));
+    expect(fingerprint('abc')).toMatch(/^[0-9a-f]{32}$/);
+  });
+  it('differs for different signatures', () => {
+    expect(fingerprint('abc')).not.toBe(fingerprint('abd'));
+  });
+});
+
+describe('parseFingerprints', () => {
+  it('extracts rum-fp markers from issue bodies (case-insensitive)', () => {
+    const fps = parseFingerprints([
+      { body: 'Recurring error.\n<!-- rum-fp:abc123def456 -->' },
+      { body: 'Another\nRUM-FP: 0011223344AA' },
+      { body: 'no marker here' },
+    ]);
+    expect(fps.has('abc123def456')).toBe(true);
+    expect(fps.has('0011223344aa')).toBe(true);
+    expect(fps.size).toBe(2);
+  });
+  it('handles empty/missing input', () => {
+    expect(parseFingerprints([]).size).toBe(0);
+    expect(parseFingerprints(undefined).size).toBe(0);
+    expect(parseFingerprints([{}]).size).toBe(0);
+  });
+});
+
+describe('aggregateCandidates', () => {
+  const rows = [
+    {
+      float: 'cli',
+      source: 'x@http://localhost:5710/a.js:1:2',
+      target: 'boom 1',
+      weight: 10,
+      time: '2026-05-10T00:00:00Z',
+    },
+    {
+      float: 'cli',
+      source: 'x@http://localhost:5720/a.js:9:9',
+      target: 'boom 9',
+      weight: 10,
+      time: '2026-05-12T00:00:00Z',
+    },
+    {
+      float: 'cli',
+      source: 'q@http://localhost:5710/@vite/client:3:4',
+      target: 'send before connect',
+      weight: 10,
+      time: '2026-05-11T00:00:00Z',
+    },
+    {
+      float: 'extension',
+      source: 'notallowederror',
+      target: 'clipboard blocked',
+      weight: 5,
+      time: '2026-05-09T00:00:00Z',
+    },
+  ];
+
+  it('groups by normalized signature, sums weight, and drops noise', () => {
+    const out = aggregateCandidates(rows);
+    // two real groups: the boom* pair (collapsed) and the clipboard one. Vite dropped.
+    expect(out).toHaveLength(2);
+    const boom = out.find((c) => c.exampleTarget.startsWith('boom'));
+    expect(boom.sampled).toBe(2);
+    expect(boom.estimated).toBe(20);
+    expect(boom.firstSeen).toBe('2026-05-10T00:00:00Z');
+    expect(boom.lastSeen).toBe('2026-05-12T00:00:00Z');
+  });
+
+  it('sorts by estimated occurrences descending', () => {
+    const out = aggregateCandidates(rows);
+    expect(out[0].estimated).toBeGreaterThanOrEqual(out[1].estimated);
+  });
+
+  it('returns [] for empty/missing input', () => {
+    expect(aggregateCandidates([])).toEqual([]);
+    expect(aggregateCandidates(undefined)).toEqual([]);
+  });
+});
+
+describe('selectNewCandidates', () => {
+  const rows = [
+    {
+      float: 'cli',
+      source: 'notallowederror',
+      target: 'clipboard blocked',
+      weight: 5,
+      time: '2026-05-09T00:00:00Z',
+    },
+    {
+      float: 'cli',
+      source: 'typeerror',
+      target: 'undefined is not a function',
+      weight: 10,
+      time: '2026-05-09T00:00:00Z',
+    },
+  ];
+
+  it('omits fingerprints that already have an issue', () => {
+    const all = aggregateCandidates(rows);
+    const filed = new Set([all[0].fingerprint]);
+    const fresh = selectNewCandidates(rows, filed);
+    expect(fresh).toHaveLength(1);
+    expect(fresh[0].fingerprint).toBe(all[1].fingerprint);
+  });
+
+  it('returns all candidates when nothing has been filed', () => {
+    expect(selectNewCandidates(rows, new Set())).toHaveLength(2);
+    expect(selectNewCandidates(rows, undefined)).toHaveLength(2);
+  });
+});
+
+describe('buildErrorQuery', () => {
+  it('embeds the look-back window, hosts, and SLICC fingerprint filters', () => {
+    const sql = buildErrorQuery({ sinceDays: 3, hosts: ['localhost', 'extid'] });
+    expect(sql).toContain('INTERVAL 3 DAY');
+    expect(sql).toContain('"localhost"');
+    expect(sql).toContain('"extid"');
+    expect(sql).toContain('checkpoint = "error"');
+    expect(sql).toContain('generation LIKE "slicc%"');
+    expect(sql).toContain('NOT LIKE "%@vite/client%"');
+  });
+
+  it('defaults to a 1-day window over the default hosts', () => {
+    const sql = buildErrorQuery();
+    expect(sql).toContain('INTERVAL 1 DAY');
+    for (const h of DEFAULT_HOSTS) expect(sql).toContain(`"${h}"`);
+  });
+
+  it('clamps a sub-day window up to 1 and floors fractional days', () => {
+    expect(buildErrorQuery({ sinceDays: 0 })).toContain('INTERVAL 1 DAY');
+    expect(buildErrorQuery({ sinceDays: 2.9 })).toContain('INTERVAL 2 DAY');
+  });
+
+  it('sanitises host values to guard the interpolated SQL', () => {
+    const sql = buildErrorQuery({ hosts: ['localhost"; DROP TABLE x; --'] });
+    expect(sql).not.toContain('DROP TABLE');
+  });
+});

--- a/packages/dev-tools/rum-error-triage/triage-rum-errors.mjs
+++ b/packages/dev-tools/rum-error-triage/triage-rum-errors.mjs
@@ -23,10 +23,13 @@ import { writeFileSync, appendFileSync } from 'node:fs';
 import { DEFAULT_HOSTS, buildErrorQuery, parseFingerprints, selectNewCandidates } from './lib.mjs';
 
 const SINCE_DAYS = Number(process.env.SINCE_DAYS) || 1;
-const HOSTS =
-  process.env.SLICC_RUM_HOSTS?.split(',')
-    .map((h) => h.trim())
-    .filter(Boolean) ?? DEFAULT_HOSTS;
+// Parse the env override into a clean list; fall back to DEFAULT_HOSTS when it
+// is unset OR empty (an empty/whitespace value must not yield zero hosts).
+const envHosts = (process.env.SLICC_RUM_HOSTS ?? '')
+  .split(',')
+  .map((h) => h.trim())
+  .filter(Boolean);
+const HOSTS = envHosts.length ? envHosts : DEFAULT_HOSTS;
 const PROJECT = process.env.RUM_BQ_PROJECT || 'helix-225321';
 const LABEL = process.env.TRIAGE_LABEL || 'rum-error';
 const OUTPUT_PATH = process.env.OUTPUT_PATH || 'rum-error-candidates.json';

--- a/packages/dev-tools/rum-error-triage/triage-rum-errors.mjs
+++ b/packages/dev-tools/rum-error-triage/triage-rum-errors.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/*
+ * RUM error-triage — orchestrator (I/O).
+ *
+ * Queries the helix RUM `cluster` table for recent SLICC `error` checkpoints,
+ * deduplicates them against errors that already have a GitHub issue, and
+ * writes the remaining candidates to a JSON file for `claude-code-action` to
+ * classify and file. Pure logic lives in `lib.mjs` (unit-tested); this file
+ * only shells out to `bq` and `gh`.
+ *
+ * Env:
+ *   SINCE_DAYS         look-back window in days            (default 1)
+ *   SLICC_RUM_HOSTS    comma-separated hostnames           (default lib DEFAULT_HOSTS)
+ *   RUM_BQ_PROJECT     BigQuery billing/project id         (default helix-225321)
+ *   TRIAGE_LABEL       issue label used for dedup + filing (default rum-error)
+ *   OUTPUT_PATH        candidates JSON path                (default ./rum-error-candidates.json)
+ *   GH_TOKEN           token for `gh` (provided by Actions)
+ *
+ * Writes `count` and `has_candidates` to $GITHUB_OUTPUT when present.
+ */
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, appendFileSync } from 'node:fs';
+import { DEFAULT_HOSTS, buildErrorQuery, parseFingerprints, selectNewCandidates } from './lib.mjs';
+
+const SINCE_DAYS = Number(process.env.SINCE_DAYS) || 1;
+const HOSTS =
+  process.env.SLICC_RUM_HOSTS?.split(',')
+    .map((h) => h.trim())
+    .filter(Boolean) ?? DEFAULT_HOSTS;
+const PROJECT = process.env.RUM_BQ_PROJECT || 'helix-225321';
+const LABEL = process.env.TRIAGE_LABEL || 'rum-error';
+const OUTPUT_PATH = process.env.OUTPUT_PATH || 'rum-error-candidates.json';
+
+/** Run the error-extraction query and return raw rows. */
+function queryErrors() {
+  const sql = buildErrorQuery({ sinceDays: SINCE_DAYS, hosts: HOSTS });
+  const out = execFileSync(
+    'bq',
+    [
+      'query',
+      `--project_id=${PROJECT}`,
+      '--use_legacy_sql=false',
+      '--format=json',
+      '--max_rows=1000',
+      sql,
+    ],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+  );
+  const parsed = JSON.parse(out.trim() || '[]');
+  // The query is a multi-statement script (two DECLAREs + a SELECT), and
+  // `bq --format=json` returns scripts as an array of result sets — i.e.
+  // `[[...rows]]`. A single-statement query would return `[...rows]`. Flatten
+  // one level so both shapes yield a flat row list.
+  return Array.isArray(parsed) ? parsed.flatMap((x) => (Array.isArray(x) ? x : [x])) : [];
+}
+
+/** Fetch fingerprints of errors that already have an issue. Tolerant of a missing label. */
+function fetchExistingFingerprints() {
+  try {
+    const out = execFileSync(
+      'gh',
+      [
+        'issue',
+        'list',
+        '--label',
+        LABEL,
+        '--state',
+        'all',
+        '--limit',
+        '500',
+        '--json',
+        'number,body',
+      ],
+      { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }
+    );
+    return parseFingerprints(JSON.parse(out.trim() || '[]'));
+  } catch (err) {
+    console.warn(
+      `⚠️  Could not list existing "${LABEL}" issues (treating as none): ${err.message?.split('\n')[0]}`
+    );
+    return new Set();
+  }
+}
+
+function setOutput(key, value) {
+  if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+}
+
+function main() {
+  console.log(
+    `🔎 Querying RUM for SLICC errors over the last ${SINCE_DAYS} day(s) on [${HOSTS.join(', ')}]…`
+  );
+  const rows = queryErrors();
+  console.log(`   ${rows.length} raw error row(s) returned.`);
+
+  const existing = fetchExistingFingerprints();
+  console.log(`   ${existing.size} error fingerprint(s) already have an issue.`);
+
+  const candidates = selectNewCandidates(rows, existing);
+  writeFileSync(OUTPUT_PATH, JSON.stringify(candidates, null, 2));
+
+  setOutput('count', String(candidates.length));
+  setOutput('has_candidates', candidates.length > 0 ? 'true' : 'false');
+
+  if (candidates.length === 0) {
+    console.log('✅ No new actionable errors. Nothing to triage.');
+    return;
+  }
+  console.log(`\n🆕 ${candidates.length} new error candidate(s) → ${OUTPUT_PATH}:`);
+  for (const c of candidates) {
+    const detail = (c.exampleTarget || c.exampleSource || c.signature).slice(0, 90);
+    console.log(`   • [${c.float}] ${c.fingerprint.slice(0, 8)}  ×${c.estimated} (est)  ${detail}`);
+  }
+}
+
+main();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -139,6 +139,16 @@ export default defineConfig({
           include: ['packages/cloud-core/tests/**/*.test.ts'],
         },
       },
+      {
+        // Repo-level tooling under packages/dev-tools/ (plain .mjs, not a
+        // workspace). Co-located *.test.mjs so `npm test` covers the triage
+        // logic; no per-package coverage gate applies to this project.
+        extends: true,
+        test: {
+          name: 'dev-tools',
+          include: ['packages/dev-tools/**/*.test.mjs'],
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
## What & why

Fixes the **"Error to Insight Pipeline"** agent-readiness signal. SLICC has no Sentry — operational errors are reported through RUM as `error` checkpoints in the helix BigQuery `cluster` table (`packages/webapp/src/ui/telemetry.ts`). Today they sit unseen in BigQuery. This adds an automated **error → GitHub issue** pipeline, which is the RUM-native equivalent of the Sentry→GitHub integration the signal looks for.

## How it works

```
nightly cron ─▶ triage-rum-errors.mjs ─▶ rum-error-candidates.json ─▶ claude-code-action ─▶ issues (+ draft PRs)
```

1. **Query** (`lib.mjs` → `buildErrorQuery`): pulls `error` checkpoints from SLICC sessions (identified by the telemetry fingerprint — `generation LIKE 'slicc-%'` for the extension, `navigate target IN ('cli','electron')` for CLI/Electron), excluding Vite HMR dev-client noise.
2. **Group + dedup**: errors are normalized into stable signatures, fingerprinted (md5), stripped of noise/contentless rows, and deduplicated against `rum-fp:<fingerprint>` markers embedded in existing issues — so each distinct error is filed once.
3. **Classify + file**: `anthropics/claude-code-action@v1` reads the candidates, investigates each against the codebase, and opens an issue (and a draft PR when the fix is clear and low-risk) for the genuine bugs, embedding the `rum-fp` marker for future dedup.

## Files

- `packages/dev-tools/rum-error-triage/lib.mjs` — pure logic (no I/O).
- `packages/dev-tools/rum-error-triage/triage-rum-errors.mjs` — orchestrator (`bq` + `gh`).
- `packages/dev-tools/rum-error-triage/lib.test.mjs` — **20 unit tests**, wired via a new `dev-tools` vitest project so they run under `npm test`.
- `.github/workflows/rum-error-triage.yml` — nightly cron + manual `workflow_dispatch` (with `since_days` / `dry_run` inputs).
- `eslint.config.js` — Node globals for all of `packages/dev-tools/**`.
- README + `packages/dev-tools/CLAUDE.md` updates.

## Verification

- `npx vitest run --project dev-tools` → 20/20 pass.
- Ran the orchestrator against live BigQuery (31-day window): 7 raw error rows → **2 deduplicated candidates** (an `undefined error` and a genuine clipboard `NotAllowedError`), proving the query, noise filter, normalization, and dedup work end-to-end.
- Workflow YAML validated; Prettier + ESLint clean (enforced by the repo pre-commit hook).

## Required secrets (documented in the README)

- `RUM_BQ_SA_KEY` — GCP service account (BigQuery Job User + Data Viewer on `helix-225321`). WIF is the preferred long-term alternative.
- `ANTHROPIC_API_KEY` — for `claude-code-action`.

Until those are set, the scheduled job fails fast at the auth step; the query/dedup logic is fully covered by unit tests regardless.

> Note: the extension currently emits **zero** error checkpoints (see ai-ecoverse/slicc#795 — offscreen agent errors aren't captured), so until that's fixed this pipeline primarily surfaces CLI-float errors. The host/fingerprint filter already covers the extension for when #795 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)