### PR TITLE
fix(ci): authenticate gh in RUM triage + full output on dispatch

### DIFF
--- a/.github/workflows/rum-error-triage.yml
+++ b/.github/workflows/rum-error-triage.yml
@@ -90,8 +90,17 @@ jobs:
           # fails on auth, fall back to `anthropic_api_key` below.)
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           AWS_REGION: ${{ vars.RUM_AWS_REGION || 'us-east-1' }}
+          # claude-code-action does NOT expose a token to the Bash tool's `gh`,
+          # so set it explicitly or `gh issue create` / `gh pr create` fail.
+          # The job's top-level permissions (issues/pull-requests/contents:
+          # write) scope this token appropriately.
+          GH_TOKEN: ${{ github.token }}
         with:
           use_bedrock: 'true'
+          # Print Claude's full turn-by-turn output to the Actions log on manual
+          # dispatch (to inspect its reasoning); kept off for the nightly cron so
+          # routine runs don't log tool output that may contain sensitive data.
+          show_full_output: ${{ github.event_name == 'workflow_dispatch' }}
           # Anthropic-API fallback — uncomment and remove the Bedrock env above
           # to use a direct Anthropic key instead:
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Follow-up hardening for the RUM error-triage workflow (#802).

## 1. Give Claude's `gh` calls a token (correctness fix)

`anthropics/claude-code-action` does **not** expose a token to the Bash tool, so the prompt's `gh issue create` / `gh pr create` / `gh issue list` calls had no authentication — they would have failed on a real bug. The first full run only passed because opus-4.7 dismissed the synthetic test error and never reached issue creation.

Fix: set `GH_TOKEN: ${{ github.token }}` on the step. The job's existing `issues: write` / `pull-requests: write` / `contents: write` permissions scope this token correctly (verified sufficient for `gh issue create` and draft `gh pr create`). Note: PRs opened by the default `GITHUB_TOKEN` don't trigger downstream workflows — acceptable for triage issues/draft PRs.

## 2. `show_full_output` on manual dispatch only

```yaml
show_full_output: ${{ github.event_name == 'workflow_dispatch' }}
```

So a manual `workflow_dispatch` prints Claude's full turn-by-turn reasoning to the Actions log (useful for inspecting/debugging the triage), while the **nightly cron stays quiet** — the action warns that full output can include tool results with sensitive data, so we don't want that on every scheduled run.

Validated: YAML parses, Prettier clean.