### PR TITLE
fix: dedupe repeated handoff/upskill navigate licks

### DIFF
--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -20,7 +20,10 @@ import {
   type SecretGetter,
   type SignAndForwardReply,
 } from '../../webapp/src/fs/mount/sign-and-forward-shared.js';
-import { extractHandoffFromWebRequest } from '../../webapp/src/net/handoff-link.js';
+import {
+  extractHandoffFromWebRequest,
+  handoffFingerprint,
+} from '../../webapp/src/net/handoff-link.js';
 import { handleFetchProxyConnectionAsync } from './fetch-proxy-shared.js';
 import type {
   CdpCommandMsg,
@@ -432,10 +435,33 @@ chrome.notifications.onClicked.addListener((notificationId: string) => {
 // document response advertises a SLICC handoff rel via RFC 8288 Link.
 // ---------------------------------------------------------------------------
 
+/**
+ * Payload fingerprints of handoffs whose OS notification has already been shown
+ * this service-worker lifetime. A site can advertise the same SLICC `Link` rel
+ * on every page response; without this guard each navigation re-shows the
+ * toast.
+ *
+ * IMPORTANT: this set gates ONLY the notification — never the forward. The
+ * durable cone-turn dedup lives in the long-lived offscreen `LickManager`,
+ * which records a fingerprint only at the instant it actually fires (in-process,
+ * no async delivery gap). The forward here (`chrome.runtime.sendMessage`) is
+ * best-effort and silently drops when the offscreen document isn't listening
+ * yet (e.g. cold start). If we suppressed the forward on "seen", a first
+ * delivery that was dropped before the offscreen came up would lose the handoff
+ * permanently. So we always forward and let the offscreen guard dedup the cone
+ * turn. MV3 may evict and respawn the worker, resetting this set — an accepted
+ * limitation of the in-memory design (a repeat toast can appear once after
+ * eviction). See {@link handoffFingerprint}.
+ */
+const notifiedHandoffFingerprints = new Set<string>();
+
 chrome.webRequest.onHeadersReceived.addListener(
   (details) => {
     const { match } = extractHandoffFromWebRequest(details.responseHeaders, details.url);
     if (!match) return;
+    const fingerprint = handoffFingerprint(match);
+    const alreadyNotified = notifiedHandoffFingerprints.has(fingerprint);
+    notifiedHandoffFingerprints.add(fingerprint);
     const payload: NavigateLickMsg = {
       type: 'navigate-lick',
       url: details.url,
@@ -457,15 +483,17 @@ chrome.webRequest.onHeadersReceived.addListener(
       chrome.tabs
         .get(tabId)
         .then((tab) => {
-          if (tab.windowId !== undefined) showHandoffNotification(tab.windowId);
+          if (!alreadyNotified && tab.windowId !== undefined) showHandoffNotification(tab.windowId);
           dispatch(tab.title);
         })
         .catch(() => dispatch());
     } else {
-      chrome.windows
-        .getCurrent()
-        .then((w) => showHandoffNotification(w.id!))
-        .catch(() => {});
+      if (!alreadyNotified) {
+        chrome.windows
+          .getCurrent()
+          .then((w) => showHandoffNotification(w.id!))
+          .catch(() => {});
+      }
       dispatch();
     }
   },

--- a/packages/webapp/src/net/handoff-link.ts
+++ b/packages/webapp/src/net/handoff-link.ts
@@ -162,6 +162,38 @@ export function extractHandoff(links: ParsedLink[]): HandoffMatch | null {
   return null;
 }
 
+/**
+ * Stable identity for a handoff/upskill payload, independent of the page URL
+ * that advertised it.
+ *
+ * A site can emit the same SLICC `Link` rel on every page response (e.g. a
+ * site-wide upskill pointing at one repo). Keying dedup on the page URL would
+ * never collapse those because the path changes on every navigation, while the
+ * payload (`verb` + `target` repo + `branch` + `path`, or for the prose
+ * `handoff` verb the page `target` + `instruction`) stays constant. Keying on
+ * this fingerprint lets callers process a given handoff once and silently drop
+ * repeat sightings of the same payload within a session.
+ *
+ * The NUL separator can't appear in any of the parts (URLs, git refs, paths,
+ * and the RFC 8187-decoded title are all NUL-free), so concatenation is
+ * collision-free without hashing.
+ */
+export function handoffFingerprint(input: {
+  verb: string;
+  target: string;
+  branch?: string;
+  path?: string;
+  instruction?: string;
+}): string {
+  return [
+    input.verb,
+    input.target,
+    input.branch ?? '',
+    input.path ?? '',
+    input.instruction ?? '',
+  ].join('\u0000');
+}
+
 /* ────────── header-shape adapters that go straight to a verb match ────────── */
 
 export function extractHandoffFromCdpHeaders(

--- a/packages/webapp/src/scoops/lick-manager.ts
+++ b/packages/webapp/src/scoops/lick-manager.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLogger } from '../core/logger.js';
+import { handoffFingerprint } from '../net/handoff-link.js';
 import * as db from './db.js';
 
 const log = createLogger('lick-manager');
@@ -56,6 +57,27 @@ export interface LickEvent {
 
 export type LickEventHandler = (event: LickEvent) => void;
 
+/**
+ * Derive a stable dedup key from a navigate lick's body, or `null` if the body
+ * lacks the structured handoff fields (in which case the event is let through
+ * undeduped). The body is built by every navigate source (CDP watcher,
+ * extension offscreen, lick-ws bridge) as `{ url, verb, target, branch?, path?,
+ * instruction?, title? }`; we key on the payload identity, never the page
+ * `url`. See {@link handoffFingerprint}.
+ */
+function navigateFingerprint(body: unknown): string | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const b = body as Record<string, unknown>;
+  if (typeof b.verb !== 'string' || typeof b.target !== 'string') return null;
+  return handoffFingerprint({
+    verb: b.verb,
+    target: b.target,
+    branch: typeof b.branch === 'string' ? b.branch : undefined,
+    path: typeof b.path === 'string' ? b.path : undefined,
+    instruction: typeof b.instruction === 'string' ? b.instruction : undefined,
+  });
+}
+
 // ─── Lick Manager ───────────────────────────────────────────────────────────
 
 export class LickManager {
@@ -63,6 +85,16 @@ export class LickManager {
   private crontasks = new Map<string, CronTaskEntry>();
   private cronInterval: ReturnType<typeof setInterval> | null = null;
   private eventHandler: LickEventHandler | null = null;
+  /**
+   * Payload fingerprints of navigate (handoff/upskill) licks already emitted
+   * this session. A site can advertise the same SLICC `Link` rel on every page
+   * response, so without this guard each navigation would wake the cone and
+   * (in the extension) re-show a notification. Scoped to the instance so it
+   * naturally re-arms on a fresh session / reset; `upskill`'s on-disk
+   * "already exists" check still prevents duplicate installs on that one
+   * re-fire. See {@link handoffFingerprint}.
+   */
+  private seenNavigateFingerprints = new Set<string>();
 
   /** Initialize - load from IndexedDB and start cron scheduler */
   async init(): Promise<void> {
@@ -103,6 +135,16 @@ export class LickManager {
 
   /** Emit an externally-generated lick event (e.g., from fswatch). */
   emitEvent(event: LickEvent): void {
+    if (event.type === 'navigate') {
+      const fingerprint = navigateFingerprint(event.body);
+      if (fingerprint !== null) {
+        if (this.seenNavigateFingerprints.has(fingerprint)) {
+          log.debug('Suppressing duplicate navigate lick', { fingerprint });
+          return;
+        }
+        this.seenNavigateFingerprints.add(fingerprint);
+      }
+    }
     log.info('External lick event', { type: event.type, target: event.targetScoop });
     this.eventHandler?.(event);
   }

--- a/packages/webapp/tests/net/handoff-link.test.ts
+++ b/packages/webapp/tests/net/handoff-link.test.ts
@@ -5,6 +5,7 @@ import {
   extractHandoffFromFetchHeaders,
   extractHandoffFromWebRequest,
   HANDOFF_REL,
+  handoffFingerprint,
   UPSKILL_REL,
 } from '../../src/net/handoff-link.js';
 import { parseLinkHeader } from '../../src/net/link-header.js';
@@ -336,5 +337,49 @@ describe('extractHandoffFrom* adapters', () => {
     const result = extractHandoffFromFetchHeaders(headers);
     expect(result.match?.verb).toBe('upskill');
     expect(result.match?.target).toBe('https://github.com/o/r');
+  });
+});
+
+describe('handoffFingerprint', () => {
+  it('is stable across different page URLs for the same upskill payload', () => {
+    // Same site-wide upskill rel, advertised on two different page URLs.
+    const a = handoffFingerprint({ verb: 'upskill', target: 'https://github.com/o/r' });
+    const b = handoffFingerprint({ verb: 'upskill', target: 'https://github.com/o/r' });
+    expect(a).toBe(b);
+  });
+
+  it('distinguishes branch and path', () => {
+    const base = handoffFingerprint({ verb: 'upskill', target: 'https://github.com/o/r' });
+    const branched = handoffFingerprint({
+      verb: 'upskill',
+      target: 'https://github.com/o/r',
+      branch: 'next',
+    });
+    const subpath = handoffFingerprint({
+      verb: 'upskill',
+      target: 'https://github.com/o/r',
+      path: 'skills/foo',
+    });
+    expect(new Set([base, branched, subpath]).size).toBe(3);
+  });
+
+  it('distinguishes verb and instruction', () => {
+    const handoffA = handoffFingerprint({
+      verb: 'handoff',
+      target: 'https://example.com/p',
+      instruction: 'do A',
+    });
+    const handoffB = handoffFingerprint({
+      verb: 'handoff',
+      target: 'https://example.com/p',
+      instruction: 'do B',
+    });
+    expect(handoffA).not.toBe(handoffB);
+  });
+
+  it('treats omitted and empty optional fields identically', () => {
+    expect(handoffFingerprint({ verb: 'upskill', target: 't' })).toBe(
+      handoffFingerprint({ verb: 'upskill', target: 't', branch: '', path: '', instruction: '' })
+    );
   });
 });

--- a/packages/webapp/tests/scoops/lick-manager-navigate-dedup.test.ts
+++ b/packages/webapp/tests/scoops/lick-manager-navigate-dedup.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type LickEvent, LickManager } from '../../src/scoops/lick-manager.js';
+
+function navigateEvent(body: Record<string, unknown>): LickEvent {
+  return {
+    type: 'navigate',
+    navigateUrl: typeof body.url === 'string' ? body.url : 'https://example.com/',
+    timestamp: new Date().toISOString(),
+    body,
+  };
+}
+
+describe('LickManager navigate-lick dedup', () => {
+  it('emits the first sighting of a handoff payload but drops repeats', () => {
+    const manager = new LickManager();
+    const handler = vi.fn();
+    manager.setEventHandler(handler);
+
+    const payload = { verb: 'upskill', target: 'https://github.com/o/r' };
+    // Same payload, advertised on three different page URLs across a site.
+    manager.emitEvent(navigateEvent({ ...payload, url: 'https://aem.live/' }));
+    manager.emitEvent(navigateEvent({ ...payload, url: 'https://aem.live/docs' }));
+    manager.emitEvent(navigateEvent({ ...payload, url: 'https://aem.live/tools' }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats different payloads as distinct even on the same URL', () => {
+    const manager = new LickManager();
+    const handler = vi.fn();
+    manager.setEventHandler(handler);
+
+    const url = 'https://aem.live/';
+    manager.emitEvent(navigateEvent({ verb: 'upskill', target: 'https://github.com/o/r', url }));
+    manager.emitEvent(
+      navigateEvent({ verb: 'upskill', target: 'https://github.com/o/r', branch: 'next', url })
+    );
+    manager.emitEvent(navigateEvent({ verb: 'handoff', target: url, instruction: 'sign in', url }));
+
+    expect(handler).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not dedup malformed navigate bodies lacking verb/target', () => {
+    const manager = new LickManager();
+    const handler = vi.fn();
+    manager.setEventHandler(handler);
+
+    manager.emitEvent(navigateEvent({ url: 'https://aem.live/' }));
+    manager.emitEvent(navigateEvent({ url: 'https://aem.live/' }));
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not dedup non-navigate events', () => {
+    const manager = new LickManager();
+    const handler = vi.fn();
+    manager.setEventHandler(handler);
+
+    const webhook: LickEvent = {
+      type: 'webhook',
+      webhookId: 'w1',
+      webhookName: 'hook',
+      timestamp: new Date().toISOString(),
+      body: { verb: 'upskill', target: 'https://github.com/o/r' },
+    };
+    manager.emitEvent(webhook);
+    manager.emitEvent(webhook);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

A site can advertise the same SLICC `Link` rel on **every** page response (e.g. `www.aem.live`'s site-wide upskill pointing at `github.com/adobe/skills`). Today every navigation re-fires a `navigate` lick — waking the cone and re-showing the extension's "Slicc handoff received" toast on each page load. The cone correctly notices it's "already processed," but that's avoidable noise.

This PR makes a handoff/upskill **process once per session, then stay quiet** on repeat visits — across all floats.

- **Payload fingerprint** (`handoffFingerprint`): a stable identity from `verb + target + branch + path + instruction`, deliberately **not** the page URL (the path changes on every in-site navigation while the upskill payload is constant — URL-keying could never collapse it).
- **Single dedup chokepoint** at `LickManager.emitEvent`, the one funnel all navigate sources converge on: standalone CLI (CDP `NavigationWatcher`), Electron, hosted/cloud, extension offscreen, and the `POST /api/handoff` bridge. First sighting fires; repeats are dropped silently. `upskill`'s on-disk "already exists" check still guards installs on a fresh-session re-fire.
- **Extension service worker**: gates **only the OS notification** on the fingerprint, and **always forwards** the lick. The forward (`chrome.runtime.sendMessage`) is best-effort and silently drops when the offscreen document isn't listening yet; recording "seen" before a dropped delivery would lose the handoff permanently. The durable cone-turn dedup therefore lives in the long-lived offscreen `LickManager`, which records a fingerprint only at the instant it actually fires (in-process, no delivery gap).

### Design notes
- **In-memory, session-scoped** by design: the dedup set lives on the `LickManager` instance, so a fresh session / browser restart / extension reload re-arms the first-fire (one re-fire, then quiet again). Persisting to IndexedDB would make it permanent if ever desired.
- MV3 may evict/respawn the service worker, resetting its notification set — an accepted limitation (a repeat toast can appear once after eviction; the offscreen guard still drops the duplicate cone turn).

## Test plan

- [x] `handoffFingerprint`: URL-independence, branch/path/verb/instruction distinctness, empty-vs-omitted equivalence
- [x] `LickManager` navigate dedup: first sighting emits, repeats drop, distinct payloads pass, malformed/non-navigate bodies untouched
- [x] `tsc --noEmit -p tsconfig.json` clean; prettier clean; lint clean
- [x] Manual: build (`npm run build -w @slicc/chrome-extension`) + reload at `chrome://extensions`, visit `www.aem.live` in a fresh tab → handoff fires once; subsequent aem.live pages stay silent

Made with [Cursor](https://cursor.com)