### PR TITLE
feat(git): seamless GitHub auth via GH_TOKEN/GITHUB_TOKEN env vars

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -45,6 +45,13 @@ oauth-domain clear adobe
 
 Extras are stored in `localStorage` under `slicc_oauth_extra_domains` (`{providerId: [domain, ...]}`). The merged list (defaults + extras, deduped case-insensitively) is what gets sent to the fetch-proxy / SW the next time the token is saved. To apply newly-added extras to an existing token immediately, run `oauth-token <providerId>` (re-saves) or reload the page (`oauth-bootstrap` re-pushes).
 
+### Cloning a private GitHub repo
+
+Two clone shapes are supported. Prefer the first — the second is an escape hatch for tools that only know how to pass auth via the URL.
+
+- **Preferred (env / file-based auth):** `git clone https://github.com/owner/repo` — the fetch-proxy attaches the GitHub PAT it already has on file (`/workspace/.git/github-token`, then `GH_TOKEN` / `GITHUB_TOKEN` from the shell env) to the request at the wire boundary.
+- **Escape hatch (URL-embedded masked credential):** `git clone https://x-access-token:$(oauth-token github)@github.com/owner/repo.git` — the masked value in the URL's userinfo segment is unmasked into a synthetic `Authorization: Basic` header by the fetch-proxy (`/api/fetch-proxy` in node-server / swift-server, the `fetch-proxy.fetch` Port handler in the extension SW). The agent never sees the real PAT in either form.
+
 ### Shell-env naming convention
 
 Only secrets whose names are valid POSIX env identifiers — `[A-Za-z_][A-Za-z0-9_]*` — are exposed as `$NAME` in the agent shell. Names containing dots, hyphens, or starting with a digit (e.g. `s3.r2.access_key_id`, `oauth.adobe.token`, `db.prod.password`) are still loaded into the fetch-proxy for header unmasking, but they do not leak into `printenv` or `$VAR` resolution. Use this to keep subsystem secrets (mount backends, OAuth replicas) out of the agent's environment while still letting the proxy substitute them when an HTTP request happens to carry the masked value.

--- a/packages/webapp/src/core/secret-env.ts
+++ b/packages/webapp/src/core/secret-env.ts
@@ -42,6 +42,39 @@ function isValidShellEnvName(name: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
 }
 
+/**
+ * Build the shell env map from a list of masked secret entries.
+ *
+ * Applies the POSIX-identifier filter so dot-namespaced internal secrets
+ * (`s3.<profile>.*`, `oauth.<id>.token`, `db.<name>.password`) stay out of
+ * `printenv` while still being available to the fetch-proxy for unmasking.
+ *
+ * Narrow GitHub-only bridge: when the masked `oauth.github.token` is
+ * present, also surface it under the conventional `GITHUB_TOKEN` and
+ * `GH_TOKEN` aliases so `git push` Just Works after a single OAuth login.
+ * Any user-provided `GITHUB_TOKEN` / `GH_TOKEN` secret takes precedence
+ * over the alias (we do not overwrite an existing entry). A user `export`
+ * inside the live shell session still wins via bash's own env semantics.
+ */
+function buildEnvFromMaskedEntries(entries: MaskedSecretEntry[]): Record<string, string> {
+  const env: Record<string, string> = {};
+  let githubOAuthMasked: string | undefined;
+  for (const entry of entries) {
+    if (!entry?.name || !entry?.maskedValue) continue;
+    if (entry.name === 'oauth.github.token') {
+      githubOAuthMasked = entry.maskedValue;
+    }
+    if (isValidShellEnvName(entry.name)) {
+      env[entry.name] = entry.maskedValue;
+    }
+  }
+  if (githubOAuthMasked) {
+    if (env.GITHUB_TOKEN === undefined) env.GITHUB_TOKEN = githubOAuthMasked;
+    if (env.GH_TOKEN === undefined) env.GH_TOKEN = githubOAuthMasked;
+  }
+  return env;
+}
+
 export async function fetchSecretEnvVars(): Promise<Record<string, string>> {
   const isExtension = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
 
@@ -50,12 +83,7 @@ export async function fetchSecretEnvVars(): Promise<Record<string, string>> {
     return new Promise((resolve) => {
       chrome.runtime.sendMessage({ type: 'secrets.list-masked-entries' }, (response: unknown) => {
         const resp = response as { entries?: MaskedSecretEntry[] };
-        const env: Record<string, string> = {};
-        for (const entry of resp?.entries ?? []) {
-          if (entry.name && entry.maskedValue && isValidShellEnvName(entry.name)) {
-            env[entry.name] = entry.maskedValue;
-          }
-        }
+        const env = buildEnvFromMaskedEntries(resp?.entries ?? []);
 
         if (Object.keys(env).length > 0) {
           log.info('Loaded masked secrets into shell env from SW', {
@@ -80,12 +108,7 @@ export async function fetchSecretEnvVars(): Promise<Record<string, string>> {
       return {};
     }
 
-    const env: Record<string, string> = {};
-    for (const entry of entries) {
-      if (entry.name && entry.maskedValue && isValidShellEnvName(entry.name)) {
-        env[entry.name] = entry.maskedValue;
-      }
-    }
+    const env = buildEnvFromMaskedEntries(entries);
 
     if (Object.keys(env).length > 0) {
       log.info('Loaded masked secrets into shell env', { count: Object.keys(env).length });

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -39,6 +39,19 @@ export interface GitCommandsOptions {
   globalDbName?: string;
 }
 
+/** Read an env var from either a Map (shell ctx.env) or a plain Record. */
+function readEnvVar(
+  env: ReadonlyMap<string, string> | Readonly<Record<string, string>>,
+  name: string
+): string | undefined {
+  if (env instanceof Map) {
+    const v = env.get(name);
+    return v && v.length > 0 ? v : undefined;
+  }
+  const v = (env as Record<string, string>)[name];
+  return v && v.length > 0 ? v : undefined;
+}
+
 /**
  * Git commands handler that provides CLI-like git functionality.
  * Uses the shared VirtualFS instance (backed by LightningFS).
@@ -53,6 +66,13 @@ export class GitCommands {
   private globalDbName: string;
   /** GitHub token for authentication (avoids rate limits on public repos, required for private). */
   private githubToken?: string;
+  /**
+   * Shell env vars threaded in from the current `execute()` call. Used as an
+   * ambient fallback by `resolveAuthToken()` when no explicit `github.token`
+   * file is set. Cleared at the end of every `execute()` invocation so a
+   * subsequent call without env doesn't accidentally inherit it.
+   */
+  private currentEnv?: ReadonlyMap<string, string> | Readonly<Record<string, string>>;
 
   constructor(private options: GitCommandsOptions) {
     // Route through a VirtualFS-backed adapter so isomorphic-git sees mount
@@ -67,15 +87,34 @@ export class GitCommands {
 
   /**
    * Get onAuth callback for isomorphic-git operations.
-   * Returns credentials if a GitHub token is configured.
+   * Returns credentials if a GitHub token is configured (via file or env).
    */
   private getOnAuth(): (() => { username: string; password: string }) | undefined {
-    if (!this.githubToken) return undefined;
-    const token = this.githubToken;
+    const token = this.resolveAuthToken();
+    if (!token) return undefined;
     return () => ({
       username: 'x-access-token',
       password: token,
     });
+  }
+
+  /**
+   * Resolve the effective GitHub auth token, in priority order:
+   *   1. `git config github.token` (the `/workspace/.git/github-token` file,
+   *      loaded into `this.githubToken` at the start of every `execute()`)
+   *   2. `$GH_TOKEN` from the shell env (matches the `gh` CLI convention)
+   *   3. `$GITHUB_TOKEN` from the shell env
+   * Returns undefined when none is set.
+   */
+  private resolveAuthToken(): string | undefined {
+    if (this.githubToken) return this.githubToken;
+    const env = this.currentEnv;
+    if (!env) return undefined;
+    const gh = readEnvVar(env, 'GH_TOKEN');
+    if (gh) return gh;
+    const gt = readEnvVar(env, 'GITHUB_TOKEN');
+    if (gt) return gt;
+    return undefined;
   }
 
   /** Get or create the shared Global VirtualFS instance for config persistence. */
@@ -151,14 +190,22 @@ export class GitCommands {
    * Execute a git command.
    * @param args Command arguments (e.g., ['init'], ['commit', '-m', 'message'])
    * @param cwd Current working directory
+   * @param env Optional shell env vars used as an ambient auth fallback
+   *   (`$GH_TOKEN`, `$GITHUB_TOKEN`) when no explicit `github.token` file is
+   *   set. Matches the `gh` CLI convention.
    */
-  async execute(args: string[], cwd: string): Promise<GitCommandResult> {
+  async execute(
+    args: string[],
+    cwd: string,
+    env?: ReadonlyMap<string, string> | Readonly<Record<string, string>>
+  ): Promise<GitCommandResult> {
     if (args.length === 0) {
       return this.help();
     }
 
     const [command, ...rest] = args;
 
+    this.currentEnv = env;
     try {
       await this.loadGithubToken();
       switch (command) {
@@ -231,6 +278,8 @@ export class GitCommands {
         stderr: `fatal: ${message}\n`,
         exitCode: 128,
       };
+    } finally {
+      this.currentEnv = undefined;
     }
   }
 

--- a/packages/webapp/src/shell/wasm-shell-headless.ts
+++ b/packages/webapp/src/shell/wasm-shell-headless.ts
@@ -530,7 +530,7 @@ export class WasmShellHeadless implements HeadlessShellLike {
     const gitCommands = this.gitCommands;
     return defineCommand('git', async (args, ctx) => {
       const cwd = ctx.cwd;
-      const result = await gitCommands.execute(args, cwd);
+      const result = await gitCommands.execute(args, cwd, ctx.env);
       return {
         stdout: result.stdout,
         stderr: result.stderr,

--- a/packages/webapp/tests/core/secret-env.test.ts
+++ b/packages/webapp/tests/core/secret-env.test.ts
@@ -118,6 +118,85 @@ describe('fetchSecretEnvVars', () => {
       expect(result['0LEADING_DIGIT']).toBeUndefined();
       expect(result['WITH-HYPHEN']).toBeUndefined();
     });
+
+    // GitHub OAuth env-alias bridge: when oauth.github.token is present
+    // in the masked secrets feed, surface it as GITHUB_TOKEN / GH_TOKEN
+    // so `git push` works after a single OAuth login (no manual export).
+    describe('GitHub OAuth env-alias bridge', () => {
+      it('exposes GITHUB_TOKEN and GH_TOKEN when oauth.github.token is present', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+          ok: true,
+          json: async () => [
+            {
+              name: 'oauth.github.token',
+              maskedValue: 'ghp_masked_oauth',
+              domains: ['github.com'],
+            },
+          ],
+        } as Response);
+
+        const result = await fetchSecretEnvVars();
+        expect(result.GITHUB_TOKEN).toBe('ghp_masked_oauth');
+        expect(result.GH_TOKEN).toBe('ghp_masked_oauth');
+        // The dot-form must NOT leak into printenv — only the aliases do.
+        expect(result['oauth.github.token']).toBeUndefined();
+      });
+
+      it('does not expose GITHUB_TOKEN/GH_TOKEN when oauth.github.token is absent', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+          ok: true,
+          json: async () => [
+            { name: 'NPM_TOKEN', maskedValue: 'npm_masked', domains: ['npmjs.org'] },
+            { name: 'oauth.adobe.token', maskedValue: 'eyJmasked', domains: ['*.adobe.io'] },
+          ],
+        } as Response);
+
+        const result = await fetchSecretEnvVars();
+        expect(result).toEqual({ NPM_TOKEN: 'npm_masked' });
+        expect(result.GITHUB_TOKEN).toBeUndefined();
+        expect(result.GH_TOKEN).toBeUndefined();
+      });
+
+      it('user-set GITHUB_TOKEN wins over the OAuth alias', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+          ok: true,
+          json: async () => [
+            { name: 'GITHUB_TOKEN', maskedValue: 'user_masked_github', domains: ['github.com'] },
+            {
+              name: 'oauth.github.token',
+              maskedValue: 'ghp_masked_oauth',
+              domains: ['github.com'],
+            },
+          ],
+        } as Response);
+
+        const result = await fetchSecretEnvVars();
+        expect(result.GITHUB_TOKEN).toBe('user_masked_github');
+        // GH_TOKEN was not user-set, so the OAuth alias still fills it.
+        expect(result.GH_TOKEN).toBe('ghp_masked_oauth');
+        expect(result['oauth.github.token']).toBeUndefined();
+      });
+
+      it('user-set GH_TOKEN wins over the OAuth alias', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+          ok: true,
+          json: async () => [
+            { name: 'GH_TOKEN', maskedValue: 'user_masked_gh', domains: ['github.com'] },
+            {
+              name: 'oauth.github.token',
+              maskedValue: 'ghp_masked_oauth',
+              domains: ['github.com'],
+            },
+          ],
+        } as Response);
+
+        const result = await fetchSecretEnvVars();
+        expect(result.GH_TOKEN).toBe('user_masked_gh');
+        // GITHUB_TOKEN was not user-set, so the OAuth alias still fills it.
+        expect(result.GITHUB_TOKEN).toBe('ghp_masked_oauth');
+        expect(result['oauth.github.token']).toBeUndefined();
+      });
+    });
   });
 
   describe('Extension mode', () => {
@@ -210,6 +289,103 @@ describe('fetchSecretEnvVars', () => {
 
       const result = await fetchSecretEnvVars();
       expect(result).toEqual({ GITHUB_TOKEN: 'ghp_masked' });
+    });
+
+    // GitHub OAuth env-alias bridge — extension mode mirror of the CLI suite.
+    describe('GitHub OAuth env-alias bridge', () => {
+      it('exposes GITHUB_TOKEN and GH_TOKEN when oauth.github.token is present', async () => {
+        vi.mocked((globalThis as any).chrome.runtime.sendMessage).mockImplementation(
+          (_msg: any, callback?: (resp: any) => void) => {
+            if (callback) {
+              callback({
+                entries: [
+                  {
+                    name: 'oauth.github.token',
+                    maskedValue: 'ghp_masked_oauth',
+                    domains: ['github.com'],
+                  },
+                ],
+              });
+            }
+            return Promise.resolve();
+          }
+        );
+
+        const result = await fetchSecretEnvVars();
+        expect(result.GITHUB_TOKEN).toBe('ghp_masked_oauth');
+        expect(result.GH_TOKEN).toBe('ghp_masked_oauth');
+        expect(result['oauth.github.token']).toBeUndefined();
+      });
+
+      it('does not expose GITHUB_TOKEN/GH_TOKEN when oauth.github.token is absent', async () => {
+        vi.mocked((globalThis as any).chrome.runtime.sendMessage).mockImplementation(
+          (_msg: any, callback?: (resp: any) => void) => {
+            if (callback) {
+              callback({
+                entries: [{ name: 'NPM_TOKEN', maskedValue: 'npm_masked', domains: ['npmjs.org'] }],
+              });
+            }
+            return Promise.resolve();
+          }
+        );
+
+        const result = await fetchSecretEnvVars();
+        expect(result).toEqual({ NPM_TOKEN: 'npm_masked' });
+        expect(result.GITHUB_TOKEN).toBeUndefined();
+        expect(result.GH_TOKEN).toBeUndefined();
+      });
+
+      it('user-set GITHUB_TOKEN wins over the OAuth alias', async () => {
+        vi.mocked((globalThis as any).chrome.runtime.sendMessage).mockImplementation(
+          (_msg: any, callback?: (resp: any) => void) => {
+            if (callback) {
+              callback({
+                entries: [
+                  {
+                    name: 'GITHUB_TOKEN',
+                    maskedValue: 'user_masked_github',
+                    domains: ['github.com'],
+                  },
+                  {
+                    name: 'oauth.github.token',
+                    maskedValue: 'ghp_masked_oauth',
+                    domains: ['github.com'],
+                  },
+                ],
+              });
+            }
+            return Promise.resolve();
+          }
+        );
+
+        const result = await fetchSecretEnvVars();
+        expect(result.GITHUB_TOKEN).toBe('user_masked_github');
+        expect(result.GH_TOKEN).toBe('ghp_masked_oauth');
+      });
+
+      it('user-set GH_TOKEN wins over the OAuth alias', async () => {
+        vi.mocked((globalThis as any).chrome.runtime.sendMessage).mockImplementation(
+          (_msg: any, callback?: (resp: any) => void) => {
+            if (callback) {
+              callback({
+                entries: [
+                  { name: 'GH_TOKEN', maskedValue: 'user_masked_gh', domains: ['github.com'] },
+                  {
+                    name: 'oauth.github.token',
+                    maskedValue: 'ghp_masked_oauth',
+                    domains: ['github.com'],
+                  },
+                ],
+              });
+            }
+            return Promise.resolve();
+          }
+        );
+
+        const result = await fetchSecretEnvVars();
+        expect(result.GH_TOKEN).toBe('user_masked_gh');
+        expect(result.GITHUB_TOKEN).toBe('ghp_masked_oauth');
+      });
     });
   });
 });

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -213,6 +213,100 @@ describe('GitCommands', () => {
     expect(getResult.stdout.trim()).toBe('ghp_via_shared_const');
   });
 
+  describe('GH_TOKEN / GITHUB_TOKEN env fallback', () => {
+    // Pull the onAuth callback that GitCommands hands to isomorphic-git for a
+    // clone invocation. Works for both Map<string,string> and Record<string,string>
+    // env shapes since execute() accepts either.
+    async function captureOnAuth(
+      env?: ReadonlyMap<string, string> | Record<string, string>
+    ): Promise<(() => { username: string; password: string }) | undefined> {
+      const cloneSpy = vi.spyOn(isoGit, 'clone').mockResolvedValue();
+      const listFilesSpy = vi.spyOn(isoGit, 'listFiles').mockResolvedValue([]);
+      try {
+        const result = await git.execute(
+          ['clone', 'https://github.com/example/repo.git', 'repo'],
+          '/workspace',
+          env
+        );
+        expect(result.exitCode).toBe(0);
+        const call = cloneSpy.mock.calls[0]?.[0] as
+          | { onAuth?: () => { username: string; password: string } }
+          | undefined;
+        return call?.onAuth;
+      } finally {
+        cloneSpy.mockRestore();
+        listFilesSpy.mockRestore();
+      }
+    }
+
+    it('uses $GH_TOKEN when only GH_TOKEN is set (no file)', async () => {
+      const onAuth = await captureOnAuth({ GH_TOKEN: 'ghp_from_gh_token' });
+      expect(onAuth).toBeDefined();
+      expect(onAuth?.()).toEqual({ username: 'x-access-token', password: 'ghp_from_gh_token' });
+    });
+
+    it('uses $GITHUB_TOKEN when only GITHUB_TOKEN is set (no file)', async () => {
+      const onAuth = await captureOnAuth({ GITHUB_TOKEN: 'ghp_from_github_token' });
+      expect(onAuth).toBeDefined();
+      expect(onAuth?.()).toEqual({
+        username: 'x-access-token',
+        password: 'ghp_from_github_token',
+      });
+    });
+
+    it('prefers $GH_TOKEN over $GITHUB_TOKEN when both are set', async () => {
+      const onAuth = await captureOnAuth({
+        GH_TOKEN: 'ghp_gh_wins',
+        GITHUB_TOKEN: 'ghp_github_loses',
+      });
+      expect(onAuth?.()).toEqual({ username: 'x-access-token', password: 'ghp_gh_wins' });
+    });
+
+    it('file token wins over both env vars (file is the explicit override)', async () => {
+      await git.execute(['config', 'github.token', 'ghp_from_file'], '/project');
+      const onAuth = await captureOnAuth({
+        GH_TOKEN: 'ghp_gh_ignored',
+        GITHUB_TOKEN: 'ghp_github_ignored',
+      });
+      expect(onAuth?.()).toEqual({ username: 'x-access-token', password: 'ghp_from_file' });
+    });
+
+    it('returns no onAuth when neither file nor env vars are set', async () => {
+      const onAuth = await captureOnAuth();
+      expect(onAuth).toBeUndefined();
+    });
+
+    it('accepts a Map env (matches shell ctx.env shape) for GH_TOKEN', async () => {
+      const env = new Map<string, string>([['GH_TOKEN', 'ghp_from_map']]);
+      const onAuth = await captureOnAuth(env);
+      expect(onAuth?.()).toEqual({ username: 'x-access-token', password: 'ghp_from_map' });
+    });
+
+    it('ignores empty-string env values (treats them as unset)', async () => {
+      const onAuth = await captureOnAuth({ GH_TOKEN: '', GITHUB_TOKEN: '' });
+      expect(onAuth).toBeUndefined();
+    });
+
+    it('does not retain env from a previous execute() call', async () => {
+      // First call sets GH_TOKEN; second call passes no env. The second call
+      // must NOT inherit the first call's token.
+      await captureOnAuth({ GH_TOKEN: 'ghp_first_call' });
+      const onAuth = await captureOnAuth();
+      expect(onAuth).toBeUndefined();
+    });
+
+    it('does not expose env tokens via `git config github.token` reads', async () => {
+      // The file is the explicit override; env vars are an ambient fallback
+      // only for auth-using operations. `git config github.token` should
+      // continue to reflect the file state.
+      const result = await git.execute(['config', 'github.token'], '/project', {
+        GH_TOKEN: 'ghp_env_should_not_leak',
+      });
+      expect(result.stdout.trim()).toBe('');
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
   it('supports --no-single-branch for clone', async () => {
     const cloneSpy = vi.spyOn(isoGit, 'clone').mockResolvedValue();
     const listFilesSpy = vi.spyOn(isoGit, 'listFiles').mockResolvedValue([]);

--- a/packages/webapp/tests/git/git-http-token-url-clone.test.ts
+++ b/packages/webapp/tests/git/git-http-token-url-clone.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Token-in-URL clone regression — end-to-end through `createGitHttpClient` /
+ * proxied-fetch.
+ *
+ * Locks in that `git clone https://x-access-token:<masked>@github.com/owner/repo`
+ * reaches the fetch-proxy layer with the masked-credential URL intact, so the
+ * existing URL-credentials unmask path in node-server / swift-server / the
+ * extension SW is the one that runs. Mirrors the
+ * `packages/chrome-extension/tests/fetch-proxy-shared.test.ts` "URL with
+ * masked cred" pattern, adapted to the isomorphic-git http surface.
+ */
+
+import type { GitHttpRequest } from 'isomorphic-git';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Synthetic masked sentinel — the real value is opaque to the http client;
+// it just has to survive the round-trip from the caller into the fetch-proxy
+// layer untouched so the proxy can unmask it.
+const MASKED = 'MASK_abc123def456abc123def456';
+const CLONE_URL = `https://x-access-token:${MASKED}@github.com/owner/repo.git/info/refs?service=git-upload-pack`;
+
+describe('git-http — token-in-URL clone reaches the fetch-proxy unmask path', () => {
+  let originalChrome: unknown;
+  let originalFetch: typeof globalThis.fetch | undefined;
+
+  beforeEach(() => {
+    originalChrome = (globalThis as { chrome?: unknown }).chrome;
+    originalFetch = globalThis.fetch;
+    // `git-http.ts` caches a module-scoped `proxiedFetch` singleton on first
+    // call. Reset the module graph so each test picks up a fresh
+    // `createProxiedFetch()` against the per-test `chrome` global.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    (globalThis as { chrome?: unknown }).chrome = originalChrome;
+    if (originalFetch) {
+      (globalThis as { fetch: typeof globalThis.fetch }).fetch = originalFetch;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('CLI mode: masked-cred URL is forwarded to /api/fetch-proxy via X-Target-URL', async () => {
+    // CLI mode — no chrome runtime.
+    (globalThis as { chrome?: unknown }).chrome = undefined;
+
+    const mockFetch = vi.fn(
+      async () =>
+        new Response('refs response', {
+          status: 200,
+          statusText: 'OK',
+          headers: { 'content-type': 'application/x-git-upload-pack-advertisement' },
+        })
+    );
+    (globalThis as { fetch: typeof globalThis.fetch }).fetch =
+      mockFetch as unknown as typeof globalThis.fetch;
+
+    const { createGitHttpClient } = await import('../../src/git/git-http.js');
+    const client = createGitHttpClient();
+    const req: GitHttpRequest = {
+      url: CLONE_URL,
+      method: 'GET',
+      headers: { 'user-agent': 'git/isomorphic-git' },
+    };
+
+    const resp = await client.request(req);
+
+    // The proxy endpoint is the one that runs — not a direct fetch of the
+    // upstream URL.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [proxyUrl, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(proxyUrl).toBe('/api/fetch-proxy');
+
+    // The full masked-cred URL — userinfo segment and all — survives intact
+    // on `X-Target-URL` so the proxy's `extractAndUnmaskUrlCredentials` path
+    // can strip the userinfo and synthesize a Basic Authorization with the
+    // real PAT.
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-Target-URL']).toBe(CLONE_URL);
+    expect(headers['X-Target-URL']).toContain(`x-access-token:${MASKED}@`);
+    expect(headers['X-Target-URL']).toMatch(/^https:\/\/x-access-token:/);
+
+    expect(resp.statusCode).toBe(200);
+  });
+
+  it('Extension mode: masked-cred URL is posted to the fetch-proxy.fetch Port', async () => {
+    // Extension mode — a chrome.runtime with `connect` and an `id` triggers
+    // the Port-based branch in `createProxiedFetch`.
+    const postedMessages: unknown[] = [];
+    const msgListeners: ((m: unknown) => void)[] = [];
+    const port = {
+      postMessage: (msg: unknown) => {
+        postedMessages.push(msg);
+      },
+      disconnect: vi.fn(),
+      onMessage: { addListener: (fn: (m: unknown) => void) => msgListeners.push(fn) },
+      onDisconnect: { addListener: vi.fn() },
+    };
+    const connect = vi.fn(() => port);
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: { connect, id: 'test-extension-id' },
+    };
+
+    const { createGitHttpClient } = await import('../../src/git/git-http.js');
+    const client = createGitHttpClient();
+    const req: GitHttpRequest = {
+      url: CLONE_URL,
+      method: 'GET',
+      headers: { 'user-agent': 'git/isomorphic-git' },
+    };
+
+    const requestPromise = client.request(req);
+
+    // Allow `extensionPortFetch` to install its listeners and post the request.
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Drive the response so the promise resolves and the test exits cleanly.
+    for (const l of msgListeners) {
+      l({
+        type: 'response-head',
+        status: 200,
+        statusText: 'OK',
+        headers: { 'content-type': 'application/x-git-upload-pack-advertisement' },
+      });
+    }
+    for (const l of msgListeners) {
+      l({ type: 'response-chunk', dataBase64: btoa('refs response') });
+    }
+    for (const l of msgListeners) {
+      l({ type: 'response-end' });
+    }
+
+    const resp = await requestPromise;
+
+    // The SW Port — and only the SW Port — sees the request. The SW-side
+    // `extractAndUnmaskUrlCredentials` path is the one that runs.
+    expect(connect).toHaveBeenCalledWith({ name: 'fetch-proxy.fetch' });
+    expect(postedMessages).toHaveLength(1);
+    const request = postedMessages[0] as { type: string; url: string };
+    expect(request.type).toBe('request');
+    expect(request.url).toBe(CLONE_URL);
+    expect(request.url).toContain(`x-access-token:${MASKED}@`);
+
+    expect(resp.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

After a single GitHub OAuth login, `git` operations now authenticate transparently. Agents no longer need to plumb tokens through `oauth-token github` + `git config` manually — the standard `gh` CLI conventions (`GH_TOKEN` / `GITHUB_TOKEN`) Just Work.

## Changes

**Wave 1 — Make `git` consume env-var credentials**

- `packages/webapp/src/git/git-commands.ts`: `getOnAuth()` honors environment credentials with resolution order: `/workspace/.git/github-token` (file) → `$GH_TOKEN` → `$GITHUB_TOKEN` → no auth. Env never leaks into `git config github.token` reads.
- `packages/webapp/src/shell/wasm-shell-headless.ts`: threads `ctx.env` into `GitCommands.execute()`.
- New tests: 9 vitests covering precedence + config isolation.

**Wave 1 — Lock in token-in-URL clones**

- New regression test: `packages/webapp/tests/git/git-http-token-url-clone.test.ts` covering CLI (`/api/fetch-proxy` + `X-Target-URL`) and Extension (`fetch-proxy.fetch` Port) modes.
- `docs/secrets.md`: new "Cloning a private GitHub repo" section documenting both preferred and escape-hatch clone shapes.

**Wave 2 — Auto-populate the env from the OAuth account**

- `packages/webapp/src/core/secret-env.ts`: narrow GitHub-only bridge — when `oauth.github.token` resolves to a non-empty masked value, expose it as `GITHUB_TOKEN` and `GH_TOKEN`. User-set values for either alias win independently. The dot-form `oauth.github.token` is still filtered out by the POSIX-identifier check.
- New tests: full alias matrix (present / absent / user-overrides / dot-form-filtered) in both CLI and Extension modes.

## End-user effect

Before: agent had to run `export GITHUB_TOKEN=$(oauth-token github)` in every fresh shell before `git clone https://github.com/owner/private-repo`.

After: a single OAuth login is enough — `git clone https://github.com/owner/private-repo` just works.

## Security

- Only the **masked** token value is exposed; the raw secret never reaches `printenv`.
- Existing fetch-proxy unmask path (CLI / Swift / extension SW) is untouched.
- Dot-form `oauth.github.token` continues to be filtered out of the env (POSIX-identifier check intact).
- Per-alias precedence: user-set `GITHUB_TOKEN` or `GH_TOKEN` is never overwritten.
- Only the github OAuth provider is bridged — Codex, Copilot, Adobe stay out of `printenv`.

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅ (5 tsconfigs)
- `npm run test -w @slicc/webapp` ✅ 4962/4962
- `npm run test -w @slicc/node-server` ✅ 339/339
- `npm run test:coverage:webapp` ✅ 67.87 / 59.23 / 69.07 / 69.67 (floor 50/40/50/50)
- Both waves verified by a Verifier specialist before merge.

## Rollback

All three commits are independently revertable. Reverting Wave 2 alone leaves Wave 1's env fallback in place (works after manual `export`). Reverting Wave 1 alone makes Wave 2 inert.

## Out of scope

- Generic per-provider env-alias map (one-shot for GitHub; revisit if pattern repeats)
- Refresh-token / silent-renew for GitHub
- Touching `github-copilot.ts`
- Removing or changing the `/workspace/.git/github-token` file path (stays as the highest-precedence explicit override)