### PR TITLE
feat(http): add PATCH method to http.client jsh runtime

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -523,7 +523,11 @@ Standard API-client builder for the jsh realm. `token` is lazy (resolved freshly
 ```typescript
 http.client(config: {
   baseUrl?: string;
-  token?: (req?: { method: string; path: string; url: string }) => string | Promise<string | null | undefined>;
+  token?: (req?: { method: string; path: string; url: string }) =>
+    | string
+    | null
+    | undefined
+    | Promise<string | null | undefined>;
   headers?: Record<string, string>;
   retry?: { on: number[]; maxAttempts: number };
   timeoutMs?: number;

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -516,6 +516,29 @@ browser.fetch(tab: TabHandle, url: string, opts?: {
 
 Runs inside the tab's origin, so session cookies and same-origin headers are automatic. Response body is JSON-parsed when content-type permits.
 
+#### `http.client({ baseUrl, token, headers, retry, timeoutMs })`
+
+Standard API-client builder for the jsh realm. `token` is lazy (resolved freshly per request); `Retry-After` (seconds or HTTP date) takes precedence over exponential backoff.
+
+```typescript
+http.client(config: {
+  baseUrl?: string;
+  token?: (req?: { method: string; path: string; url: string }) => string | Promise<string | null | undefined>;
+  headers?: Record<string, string>;
+  retry?: { on: number[]; maxAttempts: number };
+  timeoutMs?: number;
+}): {
+  get(path, opts?):    Promise<unknown>;
+  post(path, opts?):   Promise<unknown>;
+  put(path, opts?):    Promise<unknown>;
+  patch(path, opts?):  Promise<unknown>;
+  delete(path, opts?): Promise<unknown>;
+}
+// opts: { params?, headers?, body?, signal?: AbortSignal, raw?: boolean }
+//  - body object → JSON, params → querystring
+//  - raw: when true, returns { body, headers, status } instead of just body
+```
+
 ### Example .jsh Script
 
 ```javascript

--- a/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
@@ -190,6 +190,7 @@ http.client(config: {
   get(path, opts?):    Promise<unknown>;
   post(path, opts?):   Promise<unknown>;
   put(path, opts?):    Promise<unknown>;
+  patch(path, opts?):  Promise<unknown>;
   delete(path, opts?): Promise<unknown>;
 }
 // opts: { params?, headers?, body?, signal?: AbortSignal, raw?: boolean }

--- a/packages/webapp/src/kernel/realm/http-global.ts
+++ b/packages/webapp/src/kernel/realm/http-global.ts
@@ -61,6 +61,8 @@ export interface HttpClient {
   post(path: string, opts?: HttpRequestOpts & { raw?: false }): Promise<unknown>;
   put(path: string, opts: HttpRequestOpts & { raw: true }): Promise<HttpResponse>;
   put(path: string, opts?: HttpRequestOpts & { raw?: false }): Promise<unknown>;
+  patch(path: string, opts: HttpRequestOpts & { raw: true }): Promise<HttpResponse>;
+  patch(path: string, opts?: HttpRequestOpts & { raw?: false }): Promise<unknown>;
   delete(path: string, opts: HttpRequestOpts & { raw: true }): Promise<HttpResponse>;
   delete(path: string, opts?: HttpRequestOpts & { raw?: false }): Promise<unknown>;
 }
@@ -290,6 +292,8 @@ export function createHttpGlobal(deps: HttpGlobalDeps): HttpGlobal {
         request('POST', path, opts)) as HttpClient['post'],
       put: ((path: string, opts?: HttpRequestOpts) =>
         request('PUT', path, opts)) as HttpClient['put'],
+      patch: ((path: string, opts?: HttpRequestOpts) =>
+        request('PATCH', path, opts)) as HttpClient['patch'],
       delete: ((path: string, opts?: HttpRequestOpts) =>
         request('DELETE', path, opts)) as HttpClient['delete'],
     };

--- a/packages/webapp/tests/kernel/realm/http-client.test.ts
+++ b/packages/webapp/tests/kernel/realm/http-client.test.ts
@@ -385,14 +385,39 @@ describe('http.client — retries', () => {
 });
 
 describe('http.client — methods', () => {
-  it('routes get/post/put/delete to the correct HTTP method', async () => {
+  it('routes get/post/put/patch/delete to the correct HTTP method', async () => {
     const deps = makeDeps(() => jsonResponse({}));
     const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
     await client.get('/g');
     await client.post('/p');
     await client.put('/u');
+    await client.patch('/pa');
     await client.delete('/d');
-    expect(deps.fetch.calls.map((c) => c.init?.method)).toEqual(['GET', 'POST', 'PUT', 'DELETE']);
+    expect(deps.fetch.calls.map((c) => c.init?.method)).toEqual([
+      'GET',
+      'POST',
+      'PUT',
+      'PATCH',
+      'DELETE',
+    ]);
+  });
+
+  it('serializes object bodies as JSON on PATCH with Content-Type application/json', async () => {
+    const deps = makeDeps(() => jsonResponse({ ok: true }));
+    const client = createHttpGlobal(deps).client({ baseUrl: 'https://api.example.com' });
+    await client.patch('/items/1', { body: { name: 'alice' } });
+    const init = deps.fetch.calls[0].init!;
+    const headers = init.headers as Record<string, string>;
+    expect(init.method).toBe('PATCH');
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(init.body).toBe(JSON.stringify({ name: 'alice' }));
+  });
+
+  it('exposes patch as an enumerable own property of the client', () => {
+    const deps = makeDeps(() => jsonResponse({}));
+    const client = createHttpGlobal(deps).client({});
+    const keys = Object.keys(client);
+    expect(keys).toContain('patch');
   });
 
   it('returns a frozen client object', () => {


### PR DESCRIPTION
## What

Adds a `patch()` method to the jsh `http.client()` runtime surface.

## Why

The `http.client()` factory in `packages/webapp/src/kernel/realm/http-global.ts` only exposed `get`/`post`/`put`/`delete` and froze the returned object with no generic `request()` escape hatch. As a result, `api.patch(...)` was `undefined`, so any jsh skill that issues an HTTP PATCH failed with `api.patch is not a function`.

This surfaced via ai-ecoverse/skills `gh.jsh` (PR #117), which reasonably assumed `.patch()` existed (the symmetric sibling of `put`/`delete`, and GitHub's API leans heavily on PATCH). It broke `gh pr edit`, `gh issue edit`, the PATCH-based close path, and `gh api … -X PATCH` passthrough.

The root cause is the runtime, not the consuming skill. With this change, `gh.jsh` works **unchanged** — no PR is needed against the skills repo. (`.delete()` was already exposed and was never affected.)

## Changes

- `http-global.ts`: add `patch` to the `HttpClient` interface (both `raw: true` and default overloads, mirroring `put`/`delete`) and wire `patch -> request('PATCH', path, opts)` in `makeClient`. Client object stays frozen.
- `http-client.test.ts`: extend coverage — PATCH method routing + object-body JSON serialization with `Content-Type: application/json`.
- Docs synced: `packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md` and `docs/shell-reference.md` now list `patch`.

The shared internal `request()` helper already handled any verb (body/params/headers/retry/token), so this is a small additive surface + type change.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npx vitest run packages/webapp/tests/kernel/realm/http-client.test.ts` — 35/35 pass
- `npm run test:coverage:webapp` — pass, above floor

Independently verified by a second agent against the diff.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author