### PR TITLE
Fix shell rail icon to look like a command line

### DIFF
--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -1218,7 +1218,7 @@ export class Layout {
 
     // 16×16 lucide icons for built-in rail tools.
     this.terminalIconSvg =
-      '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>';
+      '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" x2="20" y1="19" y2="19"></line></svg>';
     const folderIcon =
       '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"></path></svg>';
     // Memory → BrainCircuit (lucide). Replaces the old gear icon.


### PR DESCRIPTION
## Summary

The Terminal/shell icon in the side rail used the Lucide **Code** glyph (the outward `</>` double-chevrons), which reads as markup rather than a command line. This swaps it for the Lucide **Terminal** glyph (prompt chevron + baseline cursor), so the rail icon reads as a command line and matches the bash tool-call icon already used in chat (`tool-call-view.ts`).

## Change

- `packages/webapp/src/ui/layout.ts`: `terminalIconSvg` now uses the Lucide Terminal paths (`<polyline points="4 17 10 11 4 5">` + `<line x1="12" x2="20" y1="19" y2="19">`), keeping identical `width`/`height`/`viewBox`/stroke attributes so it visually matches the folder and memory rail icons.

This single value drives the rail icon in both standalone and extension modes. Label, rail id (`terminal`), and all other icons are unchanged.

## Scope

- One-line SVG string swap. No type or API surface impact, no new dependencies or assets.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run build -w @slicc/webapp`
- Visual: open the app with `?ui-fixture=1` and confirm the rail Terminal icon shows a command-line glyph.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author