### PR TITLE
fix(playwright-cli): bridge follower tabs into tab-list via panel-RPC

### DIFF
--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -172,6 +172,16 @@ export type PanelRpcRequest =
       // mirror it into its shim immediately. See issue #701.
       op: 'save-oauth-accounts';
       payload: { accountsJson: string };
+    }
+  | {
+      // Fetch remote (follower) browser targets from the page-side
+      // BrowserAPI. The tray provider is set on the page-side instance
+      // only — the worker's BrowserAPI has no reference to it, so
+      // listAllTargets() in the worker falls back to local CDP tabs.
+      // This op bridges the gap: the page fetches its full target list
+      // and returns only entries with composite targetIds (remote ones).
+      op: 'list-remote-targets';
+      payload?: undefined;
     };
 
 export interface PanelRpcResults {
@@ -201,6 +211,9 @@ export interface PanelRpcResults {
   'tray-leave': TrayLeaveResult;
   'oauth-extras-set': { storeAfter: OAuthExtraDomainsStore };
   'save-oauth-accounts': { storedJson: string };
+  'list-remote-targets': {
+    targets: Array<{ targetId: string; title: string; url: string }>;
+  };
 }
 
 export type PanelRpcOp = PanelRpcRequest['op'];

--- a/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
@@ -555,6 +555,7 @@ async function getActionablePages(
         const seen = new Set(pages.map((p) => p.targetId));
         for (const t of targets) {
           if (!seen.has(t.targetId)) {
+            seen.add(t.targetId);
             pages.push({ targetId: t.targetId, title: t.title, url: t.url });
           }
         }

--- a/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
@@ -518,11 +518,31 @@ async function getActionablePages(
   state: PlaywrightState
 ): Promise<PageInfo[]> {
   await resolveAppTabId(browser, state);
-  // Use listAllTargets when available (includes remote tray targets)
-  const pages =
-    typeof browser.listAllTargets === 'function'
-      ? await browser.listAllTargets()
-      : await browser.listPages();
+  // Use listAllTargets when available (includes remote tray targets).
+  // In standalone mode the worker-side BrowserAPI has no trayTargetProvider, so
+  // listAllTargets() returns local-only. Always supplement via panel-RPC from the
+  // page-side BrowserAPI (fully wired), then dedupe by targetId — idempotent whether
+  // or not the worker instance is also wired.
+  let pages: PageInfo[];
+  if (typeof browser.listAllTargets === 'function') {
+    pages = await browser.listAllTargets();
+    const rpc = getPanelRpcClient();
+    if (rpc) {
+      try {
+        const { targets } = await rpc.call('list-remote-targets', undefined, { timeoutMs: 3000 });
+        const seen = new Set(pages.map((p) => p.targetId));
+        for (const t of targets) {
+          if (!seen.has(t.targetId)) {
+            pages.push({ targetId: t.targetId, title: t.title, url: t.url });
+          }
+        }
+      } catch (err) {
+        log.debug('panel-rpc list-remote-targets failed', { err: String(err) });
+      }
+    }
+  } else {
+    pages = await browser.listPages();
+  }
   return pages.filter((page) => isActionablePage(state, page));
 }
 

--- a/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
@@ -18,6 +18,10 @@ import { discoverLinks } from '../../net/discover-links.js';
 import { extractHandoff, type HandoffMatch } from '../../net/handoff-link.js';
 import { type ParsedLink, parseLinkHeader } from '../../net/link-header.js';
 import type { FloatType } from '../../scoops/tray-leader-sync.js';
+import {
+  TRAY_JOIN_STORAGE_KEY,
+  TRAY_WORKER_STORAGE_KEY,
+} from '../../scoops/tray-runtime-config.js';
 import { createProxiedFetch } from '../proxied-fetch.js';
 import { normalizeHeadersInit } from '../proxy-headers.js';
 import {
@@ -513,6 +517,23 @@ function isActionablePage(state: PlaywrightState, page: PageInfo): boolean {
   return !isAppTab(state, page.targetId) && !isChromeInternalUiTarget(page);
 }
 
+/**
+ * Cheap, synchronous check for whether a multi-browser tray is configured
+ * (leader worker URL or follower join URL present). Reads `globalThis.localStorage`
+ * — the real Storage on the page, or the page-seeded shim in the kernel worker.
+ * Used to skip the `list-remote-targets` panel-RPC round-trip entirely when no
+ * tray exists, so plain (non-tray) playwright commands stay at one local call.
+ */
+function isTrayConfigured(): boolean {
+  try {
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (!ls) return false;
+    return !!(ls.getItem(TRAY_WORKER_STORAGE_KEY) || ls.getItem(TRAY_JOIN_STORAGE_KEY));
+  } catch {
+    return false;
+  }
+}
+
 async function getActionablePages(
   browser: BrowserAPI,
   state: PlaywrightState
@@ -520,13 +541,14 @@ async function getActionablePages(
   await resolveAppTabId(browser, state);
   // Use listAllTargets when available (includes remote tray targets).
   // In standalone mode the worker-side BrowserAPI has no trayTargetProvider, so
-  // listAllTargets() returns local-only. Always supplement via panel-RPC from the
-  // page-side BrowserAPI (fully wired), then dedupe by targetId — idempotent whether
-  // or not the worker instance is also wired.
+  // listAllTargets() returns local-only. When a tray is configured, supplement via
+  // panel-RPC from the page-side BrowserAPI (fully wired) and dedupe by targetId.
+  // The tray-configured gate keeps the no-tray common case to a single local call
+  // (no per-command BroadcastChannel round-trip, no 3s-timeout exposure).
   let pages: PageInfo[];
   if (typeof browser.listAllTargets === 'function') {
     pages = await browser.listAllTargets();
-    const rpc = getPanelRpcClient();
+    const rpc = isTrayConfigured() ? getPanelRpcClient() : null;
     if (rpc) {
       try {
         const { targets } = await rpc.call('list-remote-targets', undefined, { timeoutMs: 3000 });

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -2678,6 +2678,11 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
       // non-transferable WebRTC resources and live on the page.
       leaveTray: async ({ workerBaseUrl, requestId }) =>
         await performTrayLeaveLocally({ workerBaseUrl, requestId }),
+      // Bridge remote (follower) browser targets to the worker-side
+      // playwright-cli. The worker's BrowserAPI has no trayTargetProvider
+      // so listAllTargets() falls back to local CDP only; this callback
+      // fetches from the page-side BrowserAPI which is fully wired.
+      listRemoteTargets: () => browser.listAllTargets(),
     }),
   });
   // Tear down on session reload so the handler doesn't outlive its

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -10,6 +10,7 @@
  * offscreen document already has a DOM.
  */
 
+import type { PageInfo } from '../cdp/types.js';
 import type { PanelRpcHandlers, PanelRpcResults } from '../kernel/panel-rpc.js';
 import type { LeaderTrayRuntimeStatus } from '../scoops/tray-leader.js';
 import { getAllExtraOAuthDomains, setExtraOAuthDomains } from './provider-settings.js';
@@ -38,6 +39,13 @@ export interface StandalonePanelRpcHandlerOptions {
     workerBaseUrl: string | null;
     requestId?: string;
   }) => Promise<PanelRpcResults['tray-leave']> | PanelRpcResults['tray-leave'];
+  /**
+   * Return the remote (follower) browser targets known to the page-side
+   * BrowserAPI. Only set when a leader tray is active. The worker's
+   * BrowserAPI has no trayTargetProvider, so it can't call
+   * listAllTargets() itself — this bridges the gap.
+   */
+  listRemoteTargets?: () => Promise<PageInfo[]> | PageInfo[];
 }
 
 /**
@@ -301,6 +309,16 @@ export function createStandalonePanelRpcHandlers(
       localStorage.setItem('slicc_accounts', accountsJson);
       const storedJson = localStorage.getItem('slicc_accounts') ?? accountsJson;
       return { storedJson };
+    },
+
+    'list-remote-targets': async () => {
+      if (!options.listRemoteTargets) return { targets: [] };
+      const all = await options.listRemoteTargets();
+      // Only return remote entries (composite targetId = "runtimeId:localId")
+      const remote = all.filter((p) => p.targetId.includes(':'));
+      return {
+        targets: remote.map((p) => ({ targetId: p.targetId, title: p.title, url: p.url })),
+      };
     },
   };
 }

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -41,9 +41,12 @@ export interface StandalonePanelRpcHandlerOptions {
   }) => Promise<PanelRpcResults['tray-leave']> | PanelRpcResults['tray-leave'];
   /**
    * Return the remote (follower) browser targets known to the page-side
-   * BrowserAPI. Only set when a leader tray is active. The worker's
-   * BrowserAPI has no trayTargetProvider, so it can't call
-   * listAllTargets() itself — this bridges the gap.
+   * BrowserAPI. `mainStandaloneWorker` wires this unconditionally to
+   * `browser.listAllTargets()`; it returns local-only (no composite
+   * targetIds) until a leader tray is active, and the `list-remote-targets`
+   * handler filters to composite ids. The worker's BrowserAPI has no
+   * trayTargetProvider, so it can't call listAllTargets() itself — this
+   * bridges the gap. Optional so other host wirings (tests) may omit it.
    */
   listRemoteTargets?: () => Promise<PageInfo[]> | PageInfo[];
 }

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -849,6 +849,36 @@ describe('playwright-cli tab management', () => {
     }
   });
 
+  it('tab-list deduplicates repeated targetIds within the RPC response itself', async () => {
+    (browser as { listAllTargets?: unknown }).listAllTargets = vi
+      .fn()
+      .mockResolvedValue([
+        { targetId: 'local-1', title: 'Local Tab', url: 'https://local.example.com' },
+      ]);
+    // RPC response contains the same composite targetId twice
+    (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = {
+      call: vi.fn().mockResolvedValue({
+        targets: [
+          { targetId: 'f:dup', title: 'Follower Tab', url: 'https://follower.example.com' },
+          { targetId: 'f:dup', title: 'Follower Tab', url: 'https://follower.example.com' },
+        ],
+      }),
+      dispose: vi.fn(),
+    };
+    const restoreTray = withTrayConfigured();
+
+    try {
+      const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+      const result = await cmd.execute(['tab-list'], {} as any);
+      expect(result.exitCode).toBe(0);
+      const matches = (result.stdout.match(/Follower Tab/g) ?? []).length;
+      expect(matches).toBe(1);
+    } finally {
+      (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = undefined;
+      restoreTray();
+    }
+  });
+
   it('tab-list skips the panel-RPC supplement when no tray is configured', async () => {
     (browser as { listAllTargets?: unknown }).listAllTargets = vi
       .fn()

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -2,6 +2,7 @@ import type { SecureFetch } from 'just-bash';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BrowserAPI } from '../../../src/cdp/index.js';
 import type { VirtualFS } from '../../../src/fs/index.js';
+import { TRAY_WORKER_STORAGE_KEY } from '../../../src/scoops/tray-runtime-config.js';
 import { asWebFetch as asWebFetchDiscover } from '../../../src/shell/supplemental-commands/discover-command.js';
 import {
   asWebFetch as asWebFetchPlaywright,
@@ -11,6 +12,22 @@ import {
   setPlaywrightTeleportConnectedFollowers,
 } from '../../../src/shell/supplemental-commands/playwright-command.js';
 import { _resetBrowseShCatalogCache } from '../../../src/shell/supplemental-commands/upskill-command.js';
+
+/**
+ * Install a minimal `globalThis.localStorage` reporting a configured leader
+ * tray, so `getActionablePages`'s tray-configured gate lets the panel-RPC
+ * supplement run. Returns a cleanup fn that restores the prior value.
+ */
+function withTrayConfigured(): () => void {
+  const g = globalThis as { localStorage?: unknown };
+  const prev = g.localStorage;
+  g.localStorage = {
+    getItem: (key: string) => (key === TRAY_WORKER_STORAGE_KEY ? 'https://tray.example.com' : null),
+  };
+  return () => {
+    g.localStorage = prev;
+  };
+}
 
 /** Minimal mock BrowserAPI. */
 function createMockBrowser(overrides: Partial<BrowserAPI> = {}): BrowserAPI {
@@ -783,6 +800,7 @@ describe('playwright-cli tab management', () => {
       }),
       dispose: vi.fn(),
     };
+    const restoreTray = withTrayConfigured();
 
     try {
       const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
@@ -792,6 +810,7 @@ describe('playwright-cli tab management', () => {
       expect(result.stdout).toContain('Follower Tab');
     } finally {
       (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = undefined;
+      restoreTray();
     }
   });
 
@@ -815,6 +834,7 @@ describe('playwright-cli tab management', () => {
       }),
       dispose: vi.fn(),
     };
+    const restoreTray = withTrayConfigured();
 
     try {
       const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
@@ -823,6 +843,32 @@ describe('playwright-cli tab management', () => {
       // Should appear exactly once despite being in both local and RPC results
       const matches = (result.stdout.match(/Follower Tab/g) ?? []).length;
       expect(matches).toBe(1);
+    } finally {
+      (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = undefined;
+      restoreTray();
+    }
+  });
+
+  it('tab-list skips the panel-RPC supplement when no tray is configured', async () => {
+    (browser as { listAllTargets?: unknown }).listAllTargets = vi
+      .fn()
+      .mockResolvedValue([
+        { targetId: 'local-1', title: 'Local Tab', url: 'https://local.example.com' },
+      ]);
+    // RPC client is present but no tray is configured (no localStorage tray keys).
+    // The client may still be used for unrelated ops (e.g. page-info origin
+    // resolution); the gate must specifically suppress `list-remote-targets`.
+    const call = vi.fn().mockResolvedValue({});
+    (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = { call, dispose: vi.fn() };
+
+    try {
+      const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+      const result = await cmd.execute(['tab-list'], {} as any);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Local Tab');
+      // Gate must short-circuit before any list-remote-targets round-trip
+      const calledOps = call.mock.calls.map((args) => args[0]);
+      expect(calledOps).not.toContain('list-remote-targets');
     } finally {
       (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = undefined;
     }

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -763,6 +763,71 @@ describe('playwright-cli tab management', () => {
     expect(result.stdout).toContain('No tabs open');
   });
 
+  it('tab-list merges follower remote targets from panel-RPC when RPC client available', async () => {
+    // Worker listAllTargets returns only local tabs
+    (browser as { listAllTargets?: unknown }).listAllTargets = vi
+      .fn()
+      .mockResolvedValue([
+        { targetId: 'local-1', title: 'Local Tab', url: 'https://local.example.com' },
+      ]);
+    // RPC returns a remote follower tab
+    (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = {
+      call: vi.fn().mockResolvedValue({
+        targets: [
+          {
+            targetId: 'f-runtime:remote-tab',
+            title: 'Follower Tab',
+            url: 'https://follower.example.com',
+          },
+        ],
+      }),
+      dispose: vi.fn(),
+    };
+
+    try {
+      const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+      const result = await cmd.execute(['tab-list'], {} as any);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Local Tab');
+      expect(result.stdout).toContain('Follower Tab');
+    } finally {
+      (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = undefined;
+    }
+  });
+
+  it('tab-list deduplicates when RPC returns a target already in local results', async () => {
+    (browser as { listAllTargets?: unknown }).listAllTargets = vi.fn().mockResolvedValue([
+      {
+        targetId: 'f-runtime:remote-tab',
+        title: 'Follower Tab',
+        url: 'https://follower.example.com',
+      },
+    ]);
+    (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = {
+      call: vi.fn().mockResolvedValue({
+        targets: [
+          {
+            targetId: 'f-runtime:remote-tab',
+            title: 'Follower Tab',
+            url: 'https://follower.example.com',
+          },
+        ],
+      }),
+      dispose: vi.fn(),
+    };
+
+    try {
+      const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+      const result = await cmd.execute(['tab-list'], {} as any);
+      expect(result.exitCode).toBe(0);
+      // Should appear exactly once despite being in both local and RPC results
+      const matches = (result.stdout.match(/Follower Tab/g) ?? []).length;
+      expect(matches).toBe(1);
+    } finally {
+      (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = undefined;
+    }
+  });
+
   it('tab-list shows → for current target and * for active tab', async () => {
     (browser.listPages as ReturnType<typeof vi.fn>).mockResolvedValue([
       { targetId: 'tab-new', title: 'Page A', url: 'https://a.com', active: false },

--- a/packages/webapp/tests/ui/panel-rpc-handlers.test.ts
+++ b/packages/webapp/tests/ui/panel-rpc-handlers.test.ts
@@ -270,3 +270,27 @@ describe('createStandalonePanelRpcHandlers — save-oauth-accounts', () => {
     expect(lsData.slicc_accounts).toBe(next);
   });
 });
+
+describe('createStandalonePanelRpcHandlers — list-remote-targets', () => {
+  it('returns empty targets when no listRemoteTargets callback wired', async () => {
+    const handlers = createStandalonePanelRpcHandlers({});
+    const result = await handlers['list-remote-targets']!(undefined);
+    expect(result).toEqual({ targets: [] });
+  });
+
+  it('filters to composite targetIds only', async () => {
+    const handlers = createStandalonePanelRpcHandlers({
+      listRemoteTargets: () => [
+        { targetId: 'local-1', title: 'Local Tab', url: 'https://local.example.com' },
+        {
+          targetId: 'runtime-abc:tab-1',
+          title: 'Follower Tab',
+          url: 'https://follower.example.com',
+        },
+      ],
+    });
+    const result = await handlers['list-remote-targets']!(undefined);
+    expect(result.targets).toHaveLength(1);
+    expect(result.targets[0].targetId).toBe('runtime-abc:tab-1');
+  });
+});


### PR DESCRIPTION
## Summary

`playwright-cli tab-list` silently returned only the leader's local CDP tabs when a multi-browser tray was connected — follower tabs from other browsers were invisible to the agent. Now `tab-list` (and every command that enumerates targets) also surfaces follower tabs, fetched from the page-side `BrowserAPI` over panel-RPC.

## Why

In standalone mode the agent's shell runs in a `DedicatedWorker` whose `BrowserAPI` has **no** `trayTargetProvider` — that provider lives only on the page-side `BrowserAPI` (forced there by `RTCDataChannel` non-transferability). So the worker's `listAllTargets()` returns local-only and follower tabs never reached the agent.

**Repro:**
1. `npm run dev`, start a tray (`host`), connect a second browser as a follower.
2. Open a tab in the follower.
3. `playwright-cli tab-list` → follower tab missing.

## Approach / Implementation notes

- New `list-remote-targets` panel-RPC op, following the existing `tray-reset` / `tray-leave` worker→page bridge pattern. The page-side handler calls `listAllTargets()` on the fully-wired page `BrowserAPI`, filters to composite targetIds (`runtimeId:localTargetId` = remote), and returns them — `packages/webapp/src/ui/panel-rpc-handlers.ts`.
- `getActionablePages()` supplements its local result with the RPC targets and dedups by `targetId` — `packages/webapp/src/shell/supplemental-commands/playwright-command.ts`.
- **Tray-configured gate:** the panel-RPC client is published at worker boot regardless of tray state, so a naive supplement would fire a round-trip on *every* playwright command even with no tray. `isTrayConfigured()` (a cheap synchronous read of the leader/follower tray keys from `globalThis.localStorage` — real Storage on the page, page-seeded shim in the worker) short-circuits the supplement entirely when no tray exists.
- **Teleport's follower-selection shares this same worker/page split but is intentionally NOT in scope here** — separate concern, separate change. This PR is tab-list only.

## Cross-cutting impact

- **Floats exercised:** standalone CLI only. **Extension is a deliberate no-op** — in the offscreen document `getPanelRpcClient()` returns `null` (offscreen has a DOM, no panel-RPC bridge) and its `BrowserAPI` already carries the tray provider, so `listAllTargets()` includes follower targets natively. No extension/offscreen file is touched.
- **Per-command cost:** with **no tray**, `getActionablePages()` is back to a single local `listAllTargets()` — the gate skips `getPanelRpcClient()` before any BroadcastChannel traffic. With a **tray configured**, each target-enumerating command (`tab-list`, `click`, `navigate`, screenshot, …) adds one BroadcastChannel round-trip + a page-side `listAllTargets()`; the page returns `[]` fast when no followers are connected.
- **3s timeout exposure** is now scoped to the tray-configured case only: if the page is unresponsive (mid-navigation/reload) while a tray is set up, a command can stall up to 3000 ms before falling through. The failure is swallowed (`log.debug`) and degrades to local-only — it never throws.
- **Persisted state:** none — the op and handler are pure reads of in-memory state; the gate only *reads* existing tray keys.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — browser bundle typecheck clean
- [x] `npx vitest run` on the two affected files — **203 passing** (`playwright-command.test.ts`: tab-list merge, dedup, and a new "skips list-remote-targets when no tray configured" gate test; `panel-rpc-handlers.test.ts`: list-remote-targets empty + composite-filter)
- [x] `npm run build -w @slicc/chrome-extension` — succeeds; offscreen bundle gains no new eager imports
- [ ] `npm run test` (full) / `npm run build` (webapp) — not run locally; relying on CI
- [x] Manual smoke (CLI tray + follower) — not yet done; recommend before merge

## Risk & rollback

- **Blast radius:** standalone playwright commands only. Steady-state with no tray is identical to `main` (single local call). With a tray, worst realistic case is the 3 s per-command stall on an unresponsive page.
- **Rollback:** clean `git revert` — code-only, no migration, no persisted-state change.
- **CI can't catch:** the real tray/follower round-trip needs two live browsers; unit tests mock the RPC client and stub the tray-configured localStorage.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Public contract change (new panel-RPC op) is intentional
- [x] Checked the worker/page (leader / offscreen) paths for the changed contract