### PR TITLE
fix(chrome-extension): route media capture through visible popup (#819)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,12 @@ jobs:
             echo "::error::packages/vfs-root/shared/CLAUDE.md exceeds 3KB limit ($size bytes). Keep agent instructions concise."
             exit 1
           fi
+      - name: Check Chrome Web Store manifest justifications
+        # Fail if the extension manifest gains/drops a permission without a
+        # matching reviewer justification in docs/chrome-web-store-submission.md
+        # (or vice-versa). Keeps the CWS submission pack in sync with the
+        # shipped permission set.
+        run: bash packages/dev-tools/tools/check-manifest-justifications.sh
       - name: Dead code detection (knip)
         # Hard-fail on unused files, missing/unlisted dependencies,
         # unresolved imports, duplicate exports, and unused binaries.

--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -1,0 +1,93 @@
+# Chrome Web Store Submission Pack
+
+Reviewer-ready justifications for the slicc Chrome extension
+(`packages/chrome-extension/manifest.json`). Paste the relevant sections
+straight into the Chrome Web Store (CWS) developer dashboard fields.
+
+This file is the single source of truth for the permission justifications and
+is enforced by `packages/dev-tools/tools/check-manifest-justifications.sh`,
+which fails CI if the manifest gains or drops a permission without a matching
+row in the table below (or vice-versa).
+
+## Single-Purpose Statement
+
+slicc is an AI coding agent that lives in the browser side panel. It automates
+the tabs the user directs it to, edits files in a browser-local virtual
+filesystem, and runs shell commands for web development — all from a single
+side-panel surface. Every permission below exists to serve that one purpose.
+
+## Permission Justifications
+
+Every entry in `manifest.json`'s `permissions` array plus the single
+`host_permissions` entry is justified here. The table is the machine-checked
+contract: keep one row per manifest entry.
+
+<!-- manifest-justifications:begin -->
+
+| Permission                            | Reviewer justification                                                                                                                                                                                                                                   |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `debugger`                            | Drives the user's tabs over the Chrome DevTools Protocol (navigate, click, screenshot, evaluate) so the agent can perform the browser automation the user requests. This is the core capability of the product.                                          |
+| `tabs`                                | Reads tab metadata (URL/title) and creates/activates tabs so the agent can target the correct page for automation and surface results to the user.                                                                                                       |
+| `tabGroups`                           | Collects the tabs the agent opens into a single labeled Chrome tab group so the user can visually distinguish agent-controlled tabs from their own browsing.                                                                                             |
+| `sidePanel`                           | The extension's entire UI is rendered in the side panel (the single-purpose surface). Required to open and host the agent chat/terminal UI.                                                                                                              |
+| `offscreen`                           | Hosts the long-lived agent engine in an offscreen document so the agent keeps running when the side panel is closed. MV3 service workers are evicted too aggressively to host the agent loop.                                                            |
+| `identity`                            | Runs `chrome.identity.launchWebAuthFlow` for user-initiated OAuth sign-in (e.g. GitHub, AI providers) so the agent can act on services the user asks it to use. Only the resulting token is stored, locally.                                             |
+| `storage`                             | Persists user settings, user-entered secrets/credentials, OAuth tokens, and session state in `chrome.storage`. All data stays on the user's device.                                                                                                      |
+| `webRequest`                          | Observes main-frame response headers in the service worker to detect RFC 8288 `Link` headers that advertise a slicc handoff, and to support the secret-aware fetch-proxy lifecycle. Observation only; no off-device transmission.                        |
+| `declarativeNetRequestWithHostAccess` | Installs short-lived, session-scoped declarative rules that re-inject request headers the browser otherwise forbids, so the secret-aware fetch proxy can authenticate user-specified requests. Response bodies are never read by these rules.            |
+| `notifications`                       | Shows a notification when a slicc handoff arrives (or a long-running agent task needs attention) while the side panel is closed, so the user can reopen the panel. Clicking the notification opens the side panel.                                       |
+| `<all_urls>`                          | The agent automates and reads whichever pages the user directs it to, and the secret-aware fetch proxy targets user-specified endpoints. The target host is chosen by the user at runtime and is not known in advance, so broad host access is required. |
+
+<!-- manifest-justifications:end -->
+
+## Remote-Hosted Code Declaration
+
+All executable JavaScript ships inside the extension package. There is **no
+remote-hosted code**. Compliance with the MV3 Remote Hosted Code (RHC) policy
+was achieved in PR #818 ("Bundle ffmpeg-core.js and mask CDN URL literals for
+MV3 Web Store compliance", tracking original rejection Routing ID FZSL /
+Blue Argon):
+
+- The `ffmpeg-core.js` Emscripten glue (executable JS) is bundled under
+  `dist/extension/vendor/` and loaded via `chrome.runtime.getURL(...)`.
+- All CDN host references are composed at runtime from token arrays
+  (`packages/webapp/src/shell/supplemental-commands/cdn-url-builder.ts`), so no
+  full third-party CDN URL literal survives in the built bundle.
+- The only assets streamed on demand are **WebAssembly binaries** (e.g.
+  `ffmpeg-core.wasm`, Pyodide, ImageMagick wasm), fetched only when the user
+  invokes the corresponding shell command and cached locally thereafter. Wasm
+  binaries are data, not remote-hosted executable JS; `'wasm-unsafe-eval'` in
+  the manifest CSP covers `WebAssembly.compile`/`instantiate` and is unrelated
+  to RHC.
+
+A dedicated CI guard
+(`packages/dev-tools/tools/check-extension-rhc.sh`) string-matches the built
+`dist/extension/` for forbidden CDN URL literals and fails the build if any
+reappear.
+
+## Data Usage Disclosures
+
+- **No personal or browsing data is collected or transmitted off-device by the
+  extension.** Settings, secrets, OAuth tokens, and session state live in
+  `chrome.storage`/IndexedDB on the user's machine.
+- **Camera, microphone, and screen capture are never accessed automatically.**
+  They are invoked **only** in response to an explicit user shell command (the
+  macOS-style `screencapture` helper and the media-capture commands). The
+  captured media is written to the browser-local virtual filesystem for the
+  user and is **never transmitted off-device by the extension**.
+- OAuth tokens entered/obtained by the user are sent only to the corresponding
+  provider the user authenticated with, at the user's request.
+- Authenticated/agent-initiated HTTP requests go to the endpoints the user or
+  their agent task specifies; the extension does not add any analytics or
+  tracking transmission of user content.
+
+## Note: Offscreen Document `reasons` Are Not Permissions
+
+The values passed to `chrome.offscreen.createDocument({ reasons: [...] })` —
+`WORKERS`, `USER_MEDIA`, and `DISPLAY_MEDIA` — are **arguments to the offscreen
+API**, not manifest permissions. They describe why the offscreen document
+exists (running the agent engine's workers, and gating user-initiated media /
+display capture). They do **not** appear in `manifest.json`'s `permissions`
+array and therefore require no separate Chrome Web Store dashboard
+justification. Only the manifest `offscreen` permission (justified above) is
+declared.

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -142,6 +142,13 @@ If a shell command needs to affect the panel UI, use the dual-context pattern:
 
 No supplemental command currently uses this exact hook+relay shape — the previous example (`debug-command.ts`) was removed when Terminal/Memory became unconditional in the rail. The sprinkle subsystem solves a related problem with a proxy-interface approach (`globalThis.__slicc_sprinkleManager` published in both realms with different implementations, dispatching `sprinkle-op` request/response RPCs); see `docs/pitfalls.md` "Extension Dual-Shell Context" for the full reference.
 
+## Media Capture (offscreen reasons + popup grant path)
+
+Camera / microphone / screen capture (`ffmpeg -f avfoundation`, `screencapture`) work without any new manifest permission:
+
+- **Offscreen reasons, not permissions**: the offscreen document is created with `reasons: ['WORKERS', 'USER_MEDIA', 'DISPLAY_MEDIA']` (`service-worker.ts`). These are arguments to `chrome.offscreen.createDocument` — **not** manifest `permissions` — so the Web Store permission-justification dashboard does not apply to them. They let the offscreen document touch `navigator.mediaDevices` (e.g. `enumerateDevices`).
+- **Media capture needs a visible surface**: `getUserMedia` / `getDisplayMedia` are gated by a runtime prompt that an invisible offscreen document (and the side panel) cannot show. Route the capture through a real window — `capture-popup.html` / `capture-popup.js`, modeled on the `voice-popup` pair. The shell command (`extension-media-capture.ts:captureViaPopup`) asks the service worker to open the popup (`capture-open-window` message → `chrome.windows.create`, no permission needed), the popup performs the capture and posts the bytes back over `chrome.runtime` messaging, and `ffmpeg-command.ts` / `screencapture-command.ts` gate this path behind `isExtensionFloat()`. CLI / standalone keep their page-served auto-grant path unchanged.
+
 ## Runtime Conventions
 
 - **Extension detection**: `typeof chrome !== 'undefined' && !!chrome?.runtime?.id`

--- a/packages/chrome-extension/capture-popup.html
+++ b/packages/chrome-extension/capture-popup.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>slicc capture</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        background: #1a1a2e;
+        color: #e0e0e0;
+        margin: 0;
+        padding: 16px 18px;
+        user-select: none;
+        overflow: hidden;
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #e94560;
+        animation: pulse 1.5s ease-in-out infinite;
+        flex-shrink: 0;
+      }
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.4;
+        }
+      }
+      .dot--error {
+        background: #ff6b6b;
+        animation: none;
+      }
+      .label {
+        font-size: 13px;
+        flex: 1;
+      }
+      .hint {
+        font-size: 11px;
+        color: #6a6a8a;
+        margin-top: 8px;
+        line-height: 1.4;
+      }
+      .action {
+        display: none;
+        margin-top: 14px;
+        padding: 8px 14px;
+        font-size: 13px;
+        color: #fff;
+        background: #4f6df5;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      .action:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="row">
+      <div class="dot" id="dot"></div>
+      <div class="label" id="label">Preparing capture…</div>
+    </div>
+    <div class="hint" id="hint"></div>
+    <button class="action" id="action" type="button"></button>
+    <script src="capture-popup.js"></script>
+  </body>
+</html>

--- a/packages/chrome-extension/capture-popup.js
+++ b/packages/chrome-extension/capture-popup.js
@@ -1,0 +1,332 @@
+// Media-capture popup for Chrome extension mode.
+// Runs in a real browser window so getUserMedia / getDisplayMedia can show
+// Chrome's permission prompt / screen picker. Reads the capture request from
+// the URL, performs the capture, and posts the bytes (base64) back over
+// chrome.runtime messaging. Modeled on voice-popup.js.
+
+const dot = document.getElementById('dot');
+const label = document.getElementById('label');
+const hint = document.getElementById('hint');
+const action = document.getElementById('action');
+
+const request = parseRequest();
+
+function parseRequest() {
+  try {
+    const raw = new URLSearchParams(location.search).get('req');
+    if (!raw) return null;
+    const b64 = raw.replace(/-/g, '+').replace(/_/g, '/');
+    const bin = atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    return null;
+  }
+}
+
+function send(msg) {
+  try {
+    chrome.runtime.sendMessage(msg, () => {
+      void chrome.runtime.lastError;
+    });
+  } catch {
+    /* context invalidated */
+  }
+}
+
+function setStatus(text, isError) {
+  label.textContent = text;
+  if (isError) dot.className = 'dot dot--error';
+}
+
+function bytesToBase64(bytes) {
+  let bin = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    bin += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+  }
+  return btoa(bin);
+}
+
+function describeMediaError(err) {
+  if (err?.name) return `${err.name}: ${err.message || ''}`.trim();
+  return err?.message ? err.message : String(err);
+}
+
+function fail(error) {
+  setStatus(error, true);
+  hint.textContent = '';
+  send({ source: 'capture-popup', requestId: request?.requestId, ok: false, error });
+  setTimeout(() => window.close(), 1200);
+}
+
+function succeed(bytes, mimeType, width, height, durationMs) {
+  const msg = {
+    source: 'capture-popup',
+    requestId: request.requestId,
+    ok: true,
+    bytesBase64: bytesToBase64(bytes),
+    mimeType,
+    width,
+    height,
+  };
+  if (typeof durationMs === 'number') msg.durationMs = durationMs;
+  send(msg);
+  setTimeout(() => window.close(), 200);
+}
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (
+    msg &&
+    msg.target === 'capture-popup' &&
+    msg.type === 'capture-abort' &&
+    (!request || msg.requestId === request.requestId)
+  ) {
+    window.close();
+  }
+  return false;
+});
+
+if (!request) {
+  fail('invalid capture request');
+} else if (request.kind === 'screen') {
+  setupScreenButton();
+} else {
+  runCameraCapture();
+}
+
+// ---------- screen capture ----------
+
+function setupScreenButton() {
+  setStatus('Screen capture ready');
+  hint.textContent = 'Click below, then choose a screen, window, or tab to capture.';
+  action.style.display = 'inline-block';
+  action.textContent = 'Capture screen';
+  action.addEventListener('click', () => {
+    action.disabled = true;
+    runScreenCapture();
+  });
+}
+
+async function runScreenCapture() {
+  let stream;
+  try {
+    stream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false });
+  } catch (err) {
+    fail(describeMediaError(err));
+    return;
+  }
+  try {
+    setStatus('Capturing…');
+    const video = document.createElement('video');
+    video.srcObject = stream;
+    video.muted = true;
+    video.playsInline = true;
+    await new Promise((res, rej) => {
+      video.onloadedmetadata = () => video.play().then(res).catch(rej);
+      video.onerror = () => rej(new Error('Failed to load screen stream'));
+    });
+    await new Promise((r) => setTimeout(r, 100));
+    const width = video.videoWidth;
+    const height = video.videoHeight;
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Failed to get canvas context');
+    ctx.drawImage(video, 0, 0, width, height);
+    const blob = await new Promise((res, rej) =>
+      canvas.toBlob(
+        (b) => (b ? res(b) : rej(new Error('Failed to create image blob'))),
+        request.mimeType,
+        request.quality
+      )
+    );
+    succeed(new Uint8Array(await blob.arrayBuffer()), request.mimeType, width, height);
+  } catch (err) {
+    fail(describeMediaError(err));
+  } finally {
+    for (const t of stream.getTracks()) t.stop();
+  }
+}
+
+// ---------- camera / mic capture ----------
+
+async function runCameraCapture() {
+  const req = request;
+  const wantVideo = req.mode === 'photo' || req.captureVideo !== false;
+  const wantAudio = !!req.captureAudio && req.mode === 'video';
+  if (!wantVideo && !wantAudio) {
+    fail('camera capture: at least one of video or audio must be requested');
+    return;
+  }
+
+  setStatus('Requesting permission…');
+  hint.textContent = 'Allow camera/microphone access when prompted.';
+  // Prime the permission so the prompt shows here (in a visible window) and
+  // so enumerateDevices() returns real deviceIds for numeric-index lookups.
+  try {
+    const probe = await navigator.mediaDevices.getUserMedia({ video: wantVideo, audio: wantAudio });
+    for (const t of probe.getTracks()) t.stop();
+  } catch (err) {
+    fail(describeMediaError(err));
+    return;
+  }
+
+  const videoId = wantVideo ? await resolveDeviceId(req.deviceId, 'videoinput') : undefined;
+  const audioId = wantAudio ? await resolveDeviceId(req.audioDeviceId, 'audioinput') : undefined;
+
+  let stream;
+  try {
+    stream = await getStreamWithFallback({
+      wantVideo,
+      wantAudio,
+      videoId,
+      audioId,
+      width: req.width,
+      height: req.height,
+      frameRate: req.frameRate,
+      exact: !!req.exactSize,
+    });
+  } catch (err) {
+    fail(describeMediaError(err));
+    return;
+  }
+
+  try {
+    setStatus(req.mode === 'photo' ? 'Capturing photo…' : 'Recording…');
+    hint.textContent = '';
+    if (req.mode === 'photo') {
+      const r = await capturePhoto(stream, req);
+      succeed(r.bytes, r.mimeType, r.width, r.height);
+    } else {
+      const r = await captureClip(stream, req, wantVideo);
+      succeed(r.bytes, r.mimeType, r.width, r.height, r.durationMs);
+    }
+  } catch (err) {
+    fail(describeMediaError(err));
+  } finally {
+    for (const t of stream.getTracks()) t.stop();
+  }
+}
+
+async function resolveDeviceId(idOrIndex, kind) {
+  if (!idOrIndex) return undefined;
+  if (!/^\d+$/.test(idOrIndex)) return idOrIndex;
+  if (!navigator.mediaDevices.enumerateDevices) return undefined;
+  const all = await navigator.mediaDevices.enumerateDevices();
+  const dev = all.filter((d) => d.kind === kind)[parseInt(idOrIndex, 10)];
+  return dev ? dev.deviceId : undefined;
+}
+
+async function getStreamWithFallback(spec) {
+  const buildVideo = (mode) => {
+    if (!spec.wantVideo) return false;
+    const c = {};
+    if (spec.videoId) c.deviceId = { exact: spec.videoId };
+    if (spec.width) c.width = mode === 'exact' ? { exact: spec.width } : { ideal: spec.width };
+    if (spec.height) c.height = mode === 'exact' ? { exact: spec.height } : { ideal: spec.height };
+    if (spec.frameRate)
+      c.frameRate = mode === 'exact' ? { exact: spec.frameRate } : { ideal: spec.frameRate };
+    return Object.keys(c).length > 0 ? c : true;
+  };
+  const audio = () => {
+    if (!spec.wantAudio) return false;
+    if (spec.audioId) return { deviceId: { exact: spec.audioId } };
+    return true;
+  };
+  try {
+    return await navigator.mediaDevices.getUserMedia({
+      video: buildVideo(spec.exact ? 'exact' : 'ideal'),
+      audio: audio(),
+    });
+  } catch (err) {
+    if (!spec.exact || (err.name !== 'OverconstrainedError' && err.name !== 'NotReadableError')) {
+      throw err;
+    }
+    return await navigator.mediaDevices.getUserMedia({
+      video: buildVideo('ideal'),
+      audio: audio(),
+    });
+  }
+}
+
+async function capturePhoto(stream, req) {
+  const video = document.createElement('video');
+  video.srcObject = stream;
+  video.muted = true;
+  video.playsInline = true;
+  await new Promise((res, rej) => {
+    video.onloadedmetadata = () => video.play().then(res).catch(rej);
+    video.onerror = () => rej(new Error('Failed to load camera stream'));
+  });
+  await new Promise((r) => requestAnimationFrame(() => r()));
+  await new Promise((r) => requestAnimationFrame(() => r()));
+  const warmupMs = req.warmupMs != null ? req.warmupMs : 1500;
+  if (warmupMs > 0) await new Promise((r) => setTimeout(r, warmupMs));
+  const width = video.videoWidth;
+  const height = video.videoHeight;
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Failed to get canvas context');
+  ctx.drawImage(video, 0, 0, width, height);
+  const blob = await new Promise((res, rej) =>
+    canvas.toBlob(
+      (b) => (b ? res(b) : rej(new Error('Failed to encode photo'))),
+      req.mimeType,
+      req.quality
+    )
+  );
+  return {
+    bytes: new Uint8Array(await blob.arrayBuffer()),
+    width,
+    height,
+    mimeType: blob.type || req.mimeType,
+  };
+}
+
+async function captureClip(stream, req, wantVideo) {
+  let width = 0;
+  let height = 0;
+  if (wantVideo) {
+    const video = document.createElement('video');
+    video.srcObject = stream;
+    video.muted = true;
+    video.playsInline = true;
+    await new Promise((res, rej) => {
+      video.onloadedmetadata = () => video.play().then(res).catch(rej);
+      video.onerror = () => rej(new Error('Failed to load camera stream'));
+    });
+    await new Promise((r) => requestAnimationFrame(() => r()));
+    width = video.videoWidth;
+    height = video.videoHeight;
+  }
+  const durationMs = Math.max(100, Math.min(req.durationMs || 5000, 60000));
+  const supported =
+    typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported(req.mimeType)
+      ? req.mimeType
+      : 'video/webm';
+  const recorder = new MediaRecorder(stream, { mimeType: supported });
+  const chunks = [];
+  recorder.ondataavailable = (ev) => {
+    if (ev.data && ev.data.size > 0) chunks.push(ev.data);
+  };
+  const stopped = new Promise((res) => {
+    recorder.onstop = () => res();
+  });
+  recorder.start();
+  await new Promise((r) => setTimeout(r, durationMs));
+  recorder.stop();
+  await stopped;
+  const blob = new Blob(chunks, { type: supported });
+  return {
+    bytes: new Uint8Array(await blob.arrayBuffer()),
+    width,
+    height,
+    mimeType: blob.type || supported,
+    durationMs,
+  };
+}

--- a/packages/chrome-extension/capture-popup.js
+++ b/packages/chrome-extension/capture-popup.js
@@ -11,6 +11,8 @@ const action = document.getElementById('action');
 
 const request = parseRequest();
 
+let settled = false;
+
 function parseRequest() {
   try {
     const raw = new URLSearchParams(location.search).get('req');
@@ -55,6 +57,7 @@ function describeMediaError(err) {
 }
 
 function fail(error) {
+  settled = true;
   setStatus(error, true);
   hint.textContent = '';
   send({ source: 'capture-popup', requestId: request?.requestId, ok: false, error });
@@ -62,6 +65,7 @@ function fail(error) {
 }
 
 function succeed(bytes, mimeType, width, height, durationMs) {
+  settled = true;
   const msg = {
     source: 'capture-popup',
     requestId: request.requestId,
@@ -86,6 +90,22 @@ chrome.runtime.onMessage.addListener((msg) => {
     window.close();
   }
   return false;
+});
+
+// If the user closes the popup (or it unloads) before the capture settles,
+// post a single cancellation failure so the shell-side captureViaPopup
+// rejects promptly instead of hanging until its ~5-minute timeout. The
+// `settled` guard prevents a double-send after a normal succeed()/fail()
+// (whose own window.close() calls also trigger pagehide).
+window.addEventListener('pagehide', () => {
+  if (settled) return;
+  settled = true;
+  send({
+    source: 'capture-popup',
+    requestId: request?.requestId,
+    ok: false,
+    error: 'capture cancelled',
+  });
 });
 
 if (!request) {

--- a/packages/chrome-extension/capture-popup.js
+++ b/packages/chrome-extension/capture-popup.js
@@ -17,7 +17,8 @@ function parseRequest() {
   try {
     const raw = new URLSearchParams(location.search).get('req');
     if (!raw) return null;
-    const b64 = raw.replace(/-/g, '+').replace(/_/g, '/');
+    let b64 = raw.replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4) b64 += '=';
     const bin = atob(b64);
     const bytes = new Uint8Array(bin.length);
     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -322,10 +322,18 @@ async function ensureOffscreen(): Promise<void> {
         return;
       }
       console.log('[slicc-sw] Creating offscreen document...');
+      // `USER_MEDIA` / `DISPLAY_MEDIA` are offscreen-API *reasons* (not
+      // manifest permissions): they let the offscreen document touch
+      // `navigator.mediaDevices` (e.g. `enumerateDevices`). The actual
+      // camera/mic/screen capture still happens in a visible popup window
+      // because the offscreen document has no surface to show Chrome's
+      // permission prompt / screen picker — see `capture-popup.html` and
+      // `packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts`.
       await chrome.offscreen.createDocument({
         url: OFFSCREEN_URL,
-        reasons: ['WORKERS'],
-        justification: 'Runs the SLICC agent engine so work survives side panel close.',
+        reasons: ['WORKERS', 'USER_MEDIA', 'DISPLAY_MEDIA'],
+        justification:
+          'Runs the SLICC agent engine so work survives side panel close, and enumerates camera/mic/screen devices for media-capture commands.',
       });
       console.log('[slicc-sw] Offscreen document created');
     } catch (err) {
@@ -347,6 +355,37 @@ chrome.runtime.onInstalled?.addListener?.(() => {
   ensureOffscreen();
 });
 ensureOffscreen();
+
+// ---------------------------------------------------------------------------
+// Media-capture popup window
+// ---------------------------------------------------------------------------
+// Media capture (`getUserMedia` / `getDisplayMedia`) needs a *visible* surface
+// so Chrome can show its permission prompt / screen picker. The shell command
+// requesting the capture runs in the offscreen document (or the side-panel
+// shell); the offscreen document can't call `chrome.windows.create`, so it
+// asks the service worker to open the capture popup here. The popup performs
+// the capture and broadcasts the bytes back over `chrome.runtime` messaging,
+// which the requesting context picks up directly (no SW relay needed for the
+// result). See `capture-popup.html` / `capture-popup.js`.
+function isCaptureOpenWindowMsg(msg: unknown): msg is { type: 'capture-open-window'; url: string } {
+  return (
+    typeof msg === 'object' &&
+    msg !== null &&
+    'type' in msg &&
+    (msg as { type?: unknown }).type === 'capture-open-window' &&
+    typeof (msg as { url?: unknown }).url === 'string'
+  );
+}
+
+chrome.runtime.onMessage.addListener((message: unknown) => {
+  if (!isCaptureOpenWindowMsg(message)) return false;
+  chrome.windows
+    .create({ url: message.url, type: 'popup', width: 360, height: 220, focused: true })
+    .catch((err) => {
+      console.error('[slicc-sw] Failed to open capture popup window:', err);
+    });
+  return false;
+});
 
 // ---------------------------------------------------------------------------
 // Tab grouping — inline copy for service worker (SW can't import shared chunks)

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -367,7 +367,9 @@ ensureOffscreen();
 // the capture and broadcasts the bytes back over `chrome.runtime` messaging,
 // which the requesting context picks up directly (no SW relay needed for the
 // result). See `capture-popup.html` / `capture-popup.js`.
-function isCaptureOpenWindowMsg(msg: unknown): msg is { type: 'capture-open-window'; url: string } {
+function isCaptureOpenWindowMsg(
+  msg: unknown
+): msg is { type: 'capture-open-window'; url: string; requestId?: string } {
   return (
     typeof msg === 'object' &&
     msg !== null &&
@@ -379,10 +381,26 @@ function isCaptureOpenWindowMsg(msg: unknown): msg is { type: 'capture-open-wind
 
 chrome.runtime.onMessage.addListener((message: unknown) => {
   if (!isCaptureOpenWindowMsg(message)) return false;
+  const requestId = message.requestId;
   chrome.windows
     .create({ url: message.url, type: 'popup', width: 360, height: 220, focused: true })
     .catch((err) => {
       console.error('[slicc-sw] Failed to open capture popup window:', err);
+      // Surface the failure to the requesting context so captureViaPopup
+      // rejects promptly instead of waiting out its ~5-minute timeout. The
+      // success path never reaches this branch, so there is no double-send.
+      if (requestId) {
+        chrome.runtime
+          .sendMessage({
+            source: 'capture-popup',
+            requestId,
+            ok: false,
+            error: `failed to open capture window: ${err?.message || String(err)}`,
+          })
+          .catch(() => {
+            // Requesting context may not be listening — best effort.
+          });
+      }
     });
   return false;
 });

--- a/packages/chrome-extension/vite.config.ts
+++ b/packages/chrome-extension/vite.config.ts
@@ -246,6 +246,8 @@ export default defineConfig(({ mode }) => ({
         );
         copyFileSync(resolve(Dirname, 'voice-popup.html'), resolve(outDir, 'voice-popup.html'));
         copyFileSync(resolve(Dirname, 'voice-popup.js'), resolve(outDir, 'voice-popup.js'));
+        copyFileSync(resolve(Dirname, 'capture-popup.html'), resolve(outDir, 'capture-popup.html'));
+        copyFileSync(resolve(Dirname, 'capture-popup.js'), resolve(outDir, 'capture-popup.js'));
         copyFileSync(resolve(Dirname, 'mount-popup.html'), resolve(outDir, 'mount-popup.html'));
         copyFileSync(resolve(Dirname, 'mount-popup.js'), resolve(outDir, 'mount-popup.js'));
         copyFileSync(resolve(Dirname, 'secrets.html'), resolve(outDir, 'secrets.html'));

--- a/packages/chrome-extension/voice-popup.html
+++ b/packages/chrome-extension/voice-popup.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8" />
     <title>slicc voice</title>
     <style>
       body {

--- a/packages/dev-tools/tools/check-manifest-justifications.sh
+++ b/packages/dev-tools/tools/check-manifest-justifications.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Guard against Chrome Web Store manifest-permission drift.
+#
+# Every entry in `packages/chrome-extension/manifest.json`'s `permissions`
+# array plus each `host_permissions` entry must have a matching reviewer
+# justification row in `docs/chrome-web-store-submission.md`. This keeps the
+# CWS submission pack honest: a permission can't be added (or removed) without
+# updating the dashboard-ready justifications, and vice-versa.
+#
+# The doc's justification table is delimited by HTML marker comments:
+#   <!-- manifest-justifications:begin -->
+#   ... | `permission` | ... |
+#   <!-- manifest-justifications:end -->
+# The first backtick-wrapped token of each table row is the justified entry.
+#
+# Usage: bash packages/dev-tools/tools/check-manifest-justifications.sh \
+#          [manifest.json] [submission.md]
+#   Defaults to the in-repo paths.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+MANIFEST="${1:-$REPO_ROOT/packages/chrome-extension/manifest.json}"
+DOC="${2:-$REPO_ROOT/docs/chrome-web-store-submission.md}"
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "::error::Manifest not found at $MANIFEST" >&2
+  exit 2
+fi
+if [[ ! -f "$DOC" ]]; then
+  echo "::error::Submission doc not found at $DOC" >&2
+  echo "Expected the Chrome Web Store justification pack to exist." >&2
+  exit 2
+fi
+
+# Manifest entries: `permissions` + `host_permissions`, one per line.
+MANIFEST_ENTRIES="$(
+  node -e '
+    const fs = require("fs");
+    const m = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const out = [...(m.permissions || []), ...(m.host_permissions || [])];
+    process.stdout.write(out.join("\n"));
+  ' "$MANIFEST"
+)"
+
+# Doc entries: the first backtick-wrapped token of every table row inside the
+# manifest-justifications marker block.
+DOC_ENTRIES="$(
+  awk '
+    /<!-- manifest-justifications:begin -->/ { inblock = 1; next }
+    /<!-- manifest-justifications:end -->/   { inblock = 0 }
+    inblock && /^\|/ {
+      if (match($0, /`[^`]+`/)) {
+        token = substr($0, RSTART + 1, RLENGTH - 2)
+        print token
+      }
+    }
+  ' "$DOC"
+)"
+
+if [[ -z "$DOC_ENTRIES" ]]; then
+  echo "::error::No justification rows found in $DOC" >&2
+  echo "Expected a table between the manifest-justifications marker comments." >&2
+  exit 1
+fi
+
+MISSING_IN_DOC=()
+while IFS= read -r entry; do
+  [[ -z "$entry" ]] && continue
+  if ! grep -qxF -- "$entry" <<<"$DOC_ENTRIES"; then
+    MISSING_IN_DOC+=("$entry")
+  fi
+done <<<"$MANIFEST_ENTRIES"
+
+MISSING_IN_MANIFEST=()
+while IFS= read -r entry; do
+  [[ -z "$entry" ]] && continue
+  if ! grep -qxF -- "$entry" <<<"$MANIFEST_ENTRIES"; then
+    MISSING_IN_MANIFEST+=("$entry")
+  fi
+done <<<"$DOC_ENTRIES"
+
+STATUS=0
+
+if [[ ${#MISSING_IN_DOC[@]} -gt 0 ]]; then
+  STATUS=1
+  echo "::error::Manifest permissions missing a justification in $DOC" >&2
+  for entry in "${MISSING_IN_DOC[@]}"; do
+    echo "  - $entry" >&2
+  done
+  echo "" >&2
+  echo "Add a row for each inside the manifest-justifications marker block." >&2
+fi
+
+if [[ ${#MISSING_IN_MANIFEST[@]} -gt 0 ]]; then
+  STATUS=1
+  echo "::error::Justifications in $DOC for entries not in the manifest" >&2
+  for entry in "${MISSING_IN_MANIFEST[@]}"; do
+    echo "  - $entry" >&2
+  done
+  echo "" >&2
+  echo "Remove the stale rows, or restore the permission in manifest.json." >&2
+fi
+
+if [[ "$STATUS" -ne 0 ]]; then
+  exit 1
+fi
+
+COUNT=$(grep -c '' <<<"$MANIFEST_ENTRIES")
+echo "✓ All $COUNT manifest permission(s) have a Chrome Web Store justification"
+exit 0

--- a/packages/dev-tools/tools/extension-smoke-test.ts
+++ b/packages/dev-tools/tools/extension-smoke-test.ts
@@ -513,11 +513,16 @@ async function attachOffscreenRecorder(
       logArtifact(`[offscreen network-fail ${params.requestId}] ${params.errorText ?? ''}`);
     }
   });
-  // Auto-attach ONLY to dedicated workers (the FFmpeg WASM worker
-  // is where `vendor/ffmpeg-core.js` is fetched via `import()`). We
-  // do NOT attach to service workers / sandbox iframes — earlier
-  // experiments showed that disturbs the panel target and causes
-  // "Inspected target navigated or closed" mid-scenario.
+  // Network capture targets ONLY dedicated workers (the FFmpeg WASM
+  // worker is where `vendor/ffmpeg-core.js` is fetched via `import()`).
+  // But `waitForDebuggerOnStart: true` pauses EVERY auto-attached child
+  // on start, so each one must be resumed or it hangs indefinitely —
+  // fatally so for the `node -e` realm, which runs in a sandbox iframe
+  // child of the offscreen document (the staged-WAV step and the
+  // `node-e` scenario both block on it). For the FFmpeg worker we still
+  // enable Network BEFORE resuming so its `import(coreURL)` fetch lands
+  // in the recorder; every other child (realm iframe, service workers)
+  // is resumed straight away without enabling Network.
   const attachedSessions = new Set<string>();
   const offAttach = session.onEvent((ev) => {
     if (ev.method !== 'Target.attachedToTarget') return;
@@ -528,21 +533,21 @@ async function attachOffscreenRecorder(
     const sid = params.sessionId;
     const childType = params.targetInfo?.type ?? '';
     if (!sid || attachedSessions.has(sid)) return;
+    attachedSessions.add(sid);
     logArtifact(
       `[offscreen attached-child] type=${childType} url=${params.targetInfo?.url?.slice(0, 120)}`
     );
-    if (childType !== 'worker') return;
-    attachedSessions.add(sid);
-    // Enable Network BEFORE releasing the worker; otherwise the
-    // worker's `import(coreURL)` can complete before we've enabled
-    // the Network domain, and we miss the `vendor/ffmpeg-core.js`
-    // event the RHC assertion needs.
-    session
-      .send('Network.enable', {}, sid)
-      .catch(() => undefined)
-      .finally(() => {
-        session.send('Runtime.runIfWaitingForDebugger', {}, sid).catch(() => undefined);
-      });
+    const resume = (): void => {
+      session.send('Runtime.runIfWaitingForDebugger', {}, sid).catch(() => undefined);
+    };
+    if (childType === 'worker') {
+      session
+        .send('Network.enable', {}, sid)
+        .catch(() => undefined)
+        .finally(resume);
+    } else {
+      resume();
+    }
   });
 
   await session.send('Runtime.enable');
@@ -653,6 +658,16 @@ async function rotateBridgeSession(cdp: CdpSession): Promise<void> {
      ]).then(() => true)`,
     /* awaitPromise */ true
   );
+}
+
+/** Rotate the bridge session between scenarios, logging (not throwing) on failure. */
+async function rotateBridgeSessionOrWarn(cdp: CdpSession): Promise<void> {
+  try {
+    await rotateBridgeSession(cdp);
+    logArtifact('bridge session rotated');
+  } catch (err) {
+    logArtifact(`WARN session rotate failed: ${(err as Error).message}`);
+  }
 }
 
 interface ScenarioFailure {
@@ -859,9 +874,246 @@ async function runNodeScenario(cdp: CdpSession, failures: ScenarioFailure[]): Pr
   });
 }
 
+/**
+ * Read `/tmp/photo.jpg` back and emit its size plus a base64 dump of its
+ * bytes for JPEG-envelope validation. Deliberately uses just-bash
+ * builtins (`wc`, `base64`) rather than `node -e`: those run
+ * synchronously in the WASM shell with no realm worker or network, so
+ * the readback can't hang even if the realm path is unavailable.
+ * `base64` is the one builtin guaranteed to round-trip binary faithfully
+ * (just-bash's `od`/`tail -c` don't match GNU byte semantics). Output is
+ * a single `SZ=<n>|B64=<base64>` line the smoke side decodes and checks.
+ */
+const JPEG_PROBE_CODE = [
+  'sz=$(wc -c < /tmp/photo.jpg);',
+  "b64=$(base64 < /tmp/photo.jpg | tr -d '\\n');",
+  'printf \'SZ=%s|B64=%s\\n\' "$sz" "$b64"',
+].join(' ');
+
+/**
+ * Media-capture scenario. Exercises the extension's avfoundation photo
+ * path end-to-end: the offscreen shell runs `ffmpeg -f avfoundation`,
+ * which (under `isExtensionFloat()`) opens `capture-popup.html` via the
+ * service worker's `capture-open-window` handler, captures one frame
+ * from the synthetic camera through `getUserMedia` (auto-granted by the
+ * `--use-fake-*` flags), JPEG-encodes it, and posts the bytes back over
+ * `chrome.runtime` messaging to be written to the VFS. We then read the
+ * file back with just-bash builtins and assert it's a non-empty valid
+ * JPEG (SOI `FF D8 FF`, EOI `FF D9`). The photo path writes the canvas
+ * bytes straight to the VFS (no wasm transcode for a plain `.jpg`
+ * target), so the scenario doesn't depend on `ffmpeg.exec()` or the
+ * `node -e` realm path.
+ */
+async function runMediaCaptureScenario(
+  cdp: CdpSession,
+  net: NetEntry[],
+  extId: string,
+  failures: ScenarioFailure[]
+): Promise<void> {
+  const scenario = 'media-capture';
+  const captureCommand = 'ffmpeg -f avfoundation -i 0 -frames:v 1 /tmp/photo.jpg';
+  // The fake device grants instantly, but the photo path waits ~1.5s for
+  // auto-exposure warmup and opens a popup window first; a 90s budget is
+  // generous without burning the full SCENARIO_TIMEOUT_MS on a hang.
+  const captureBudget = Math.min(SCENARIO_TIMEOUT_MS, 90_000);
+  logArtifact(`[${scenario}] running '${captureCommand}' (budget=${captureBudget}ms) ...`);
+  const start = Date.now();
+  let result: ExecResult | null = null;
+  let execError: string | null = null;
+  try {
+    result = await execShell(cdp, captureCommand, captureBudget);
+  } catch (err) {
+    execError = (err as Error).message;
+  }
+  const slice = net.filter((e) => e.ts >= start);
+  if (result) {
+    logArtifact(
+      `[${scenario}] capture exitCode=${result.exitCode} stdout=${result.stdout.length}B stderr='${result.stderr.slice(-300).trim()}' network=${slice.length}`
+    );
+  } else {
+    logArtifact(`[${scenario}] capture exec did not complete (${execError})`);
+  }
+
+  if (execError) {
+    failures.push({ scenario, message: `capture exec threw: ${execError}` });
+    return;
+  }
+  if (!result) {
+    failures.push({ scenario, message: 'capture exec returned no result' });
+    return;
+  }
+  assertScenario(
+    failures,
+    scenario,
+    result.exitCode === 0,
+    `capture exit code 0 (got ${result.exitCode})`,
+    { stderrTail: result.stderr.slice(-2000), stdoutTail: result.stdout.slice(-2000) }
+  );
+
+  // Read the captured file back with just-bash builtins and validate the
+  // JPEG envelope. This confirms the bytes actually round-tripped from
+  // the popup into the VFS — not just that the command exited cleanly.
+  let probe: ExecResult;
+  try {
+    probe = await execShell(cdp, JPEG_PROBE_CODE, 30_000);
+  } catch (err) {
+    failures.push({ scenario, message: `jpeg probe exec threw: ${(err as Error).message}` });
+    return;
+  }
+  if (probe.exitCode !== 0) {
+    failures.push({
+      scenario,
+      message: `jpeg probe exit ${probe.exitCode}`,
+      detail: { stderrTail: probe.stderr.slice(-2000), stdoutTail: probe.stdout.slice(-2000) },
+    });
+    return;
+  }
+  const m = /SZ=([0-9]+)\|B64=([A-Za-z0-9+/=]*)/.exec(probe.stdout);
+  if (!m) {
+    failures.push({
+      scenario,
+      message: 'jpeg probe stdout did not match expected SZ/B64 shape',
+      detail: { stdout: probe.stdout.slice(0, 500) },
+    });
+    return;
+  }
+  const len = parseInt(m[1], 10);
+  const bytes = Buffer.from(m[2], 'base64');
+  const soi = [bytes[0], bytes[1], bytes[2]];
+  const eoi = bytes.length >= 2 ? [bytes[bytes.length - 2], bytes[bytes.length - 1]] : [];
+  logArtifact(
+    `[${scenario}] jpeg probe wc=${len} decoded=${bytes.length} soi=${JSON.stringify(soi)} eoi=${JSON.stringify(eoi)}`
+  );
+  assertScenario(failures, scenario, len > 0, `captured file is non-empty (wc -c = ${len})`, {
+    len,
+  });
+  // The base64 decode length should match the on-disk size — confirms the
+  // dump round-tripped cleanly rather than being truncated mid-stream.
+  assertScenario(
+    failures,
+    scenario,
+    bytes.length === len,
+    `base64 decode length matches wc -c (${bytes.length} vs ${len})`,
+    { decoded: bytes.length, wc: len }
+  );
+  // JPEG start-of-image marker is FF D8 FF.
+  assertScenario(
+    failures,
+    scenario,
+    soi[0] === 0xff && soi[1] === 0xd8 && soi[2] === 0xff,
+    'captured file has JPEG SOI marker (FF D8 FF)',
+    { soi }
+  );
+  // JPEG end-of-image marker is FF D9.
+  assertScenario(
+    failures,
+    scenario,
+    eoi[0] === 0xff && eoi[1] === 0xd9,
+    'captured file has JPEG EOI marker (FF D9)',
+    { eoi }
+  );
+
+  // Security invariant shared with the ffmpeg scenario: no remote `.js`
+  // from forbidden hosts during the capture window.
+  const jsViolations = slice.filter((e) => {
+    if (!/\.js(\?|$)/i.test(e.url)) return false;
+    if (e.url.startsWith(`chrome-extension://${extId}/`)) return false;
+    return FORBIDDEN_HOSTS.some((h) => e.url.includes(`//${h}/`) || e.url.includes(`//${h}:`));
+  });
+  assertScenario(
+    failures,
+    scenario,
+    jsViolations.length === 0,
+    'no remote .js fetches from forbidden hosts',
+    { violations: jsViolations.slice(0, 10).map((e) => e.url) }
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main orchestration
 // ---------------------------------------------------------------------------
+
+/**
+ * Attach the offscreen-document network recorder unless disabled via
+ * `SLICC_SMOKE_NO_OFFSCREEN=1`. Logging is folded in here so `main()`
+ * stays a flat sequence rather than a nested conditional.
+ */
+async function maybeAttachOffscreen(
+  cdpPort: number,
+  extId: string,
+  entries: NetEntry[]
+): Promise<{ session: CdpSession; dispose: () => void } | null> {
+  if (process.env['SLICC_SMOKE_NO_OFFSCREEN']) {
+    logArtifact('SLICC_SMOKE_NO_OFFSCREEN=1 set; skipping offscreen attach');
+    return null;
+  }
+  const off = await attachOffscreenRecorder(cdpPort, extId, entries, CDP_READY_TIMEOUT_MS);
+  logArtifact(
+    off
+      ? 'offscreen recorder attached'
+      : 'WARN: offscreen target not found within timeout — ffmpeg-core capture may miss'
+  );
+  return off;
+}
+
+/**
+ * Run all scenarios in sequence, rotating the bridge session between
+ * each so a stuck inflight exec on the offscreen side doesn't bleed
+ * into the next scenario. Returns the accumulated failures.
+ */
+async function runScenarios(
+  cdp: CdpSession,
+  entries: NetEntry[],
+  extId: string
+): Promise<ScenarioFailure[]> {
+  const failures: ScenarioFailure[] = [];
+  await runFfmpegScenario(cdp, entries, extId, failures);
+  // ffmpeg.exec() may still be running on the offscreen side after
+  // its smoke-side timeout; rotate to a fresh session so the next
+  // scenario doesn't bounce off the busy-session sentinel.
+  await rotateBridgeSessionOrWarn(cdp);
+  await runNodeScenario(cdp, failures);
+  // Media capture opens a popup window and drives getUserMedia on the
+  // offscreen side; rotate again so it starts from a clean session.
+  await rotateBridgeSessionOrWarn(cdp);
+  await runMediaCaptureScenario(cdp, entries, extId, failures);
+  return failures;
+}
+
+/** Log the scenario outcome and return the process exit code. */
+function reportFailures(failures: ScenarioFailure[]): number {
+  if (failures.length === 0) {
+    logArtifact('all scenarios passed');
+    return 0;
+  }
+  logArtifact(`FAILURES (${failures.length}):`);
+  for (const f of failures) {
+    logArtifact(`  [${f.scenario}] ${f.message}${f.detail ? ' ' + JSON.stringify(f.detail) : ''}`);
+  }
+  return 1;
+}
+
+/** Best-effort terminate the Chrome child process (SIGTERM, then SIGKILL). */
+async function killChrome(chrome: ChildProcess): Promise<void> {
+  if (chrome.exitCode !== null) return;
+  try {
+    chrome.kill('SIGTERM');
+    await Promise.race([new Promise<void>((res) => chrome.once('exit', () => res())), delay(3000)]);
+    if (chrome.exitCode === null) chrome.kill('SIGKILL');
+  } catch {
+    // Ignore.
+  }
+}
+
+/** Remove the disposable Chrome profile unless `SLICC_SMOKE_KEEP_PROFILE` is set. */
+function removeProfile(profileDir: string): void {
+  if (process.env['SLICC_SMOKE_KEEP_PROFILE']) return;
+  try {
+    rmSync(profileDir, { recursive: true, force: true });
+  } catch {
+    // Ignore.
+  }
+}
 
 async function main(): Promise<number> {
   logArtifact(`smoke test artifact dir: ${ARTIFACT_DIR}`);
@@ -899,6 +1151,13 @@ async function main(): Promise<number> {
     '--disable-crash-reporter',
     '--disable-background-tracing',
     '--disable-blink-features=AutomationControlled',
+    // Media-capture scenario: feed a synthetic camera/mic and auto-grant
+    // the getUserMedia / getDisplayMedia prompt so the popup capture path
+    // runs headlessly without a real device or a human clicking "Allow".
+    // Scoped to the smoke harness only — production Chrome launch and the
+    // extension manifest are unchanged.
+    '--use-fake-device-for-media-stream',
+    '--use-fake-ui-for-media-stream',
     'about:blank',
   ];
 
@@ -965,52 +1224,15 @@ async function main(): Promise<number> {
     // network events. Skip with `SLICC_SMOKE_NO_OFFSCREEN=1` for
     // local debugging in case the auto-attach interferes with the
     // ffmpeg WASM worker on a specific Chrome build.
-    if (!process.env['SLICC_SMOKE_NO_OFFSCREEN']) {
-      offscreen = await attachOffscreenRecorder(
-        cdpPort,
-        extId,
-        recorder.entries,
-        CDP_READY_TIMEOUT_MS
-      );
-      if (offscreen) {
-        logArtifact('offscreen recorder attached');
-      } else {
-        logArtifact(
-          'WARN: offscreen target not found within timeout — ffmpeg-core capture may miss'
-        );
-      }
-    } else {
-      logArtifact('SLICC_SMOKE_NO_OFFSCREEN=1 set; skipping offscreen attach');
-    }
+    offscreen = await maybeAttachOffscreen(cdpPort, extId, recorder.entries);
 
     logArtifact('running scenarios ...');
-    const failures: ScenarioFailure[] = [];
-    await runFfmpegScenario(cdp, recorder.entries, extId, failures);
-    // ffmpeg.exec() may still be running on the offscreen side after
-    // its smoke-side timeout; rotate to a fresh session so the next
-    // scenario doesn't bounce off the busy-session sentinel.
-    try {
-      await rotateBridgeSession(cdp);
-      logArtifact('bridge session rotated');
-    } catch (err) {
-      logArtifact(`WARN session rotate failed: ${(err as Error).message}`);
-    }
-    await runNodeScenario(cdp, failures);
+    const failures = await runScenarios(cdp, recorder.entries, extId);
     recorder.dispose();
     offscreen?.dispose();
     offscreen = null;
 
-    if (failures.length === 0) {
-      logArtifact('all scenarios passed');
-      exitCode = 0;
-    } else {
-      logArtifact(`FAILURES (${failures.length}):`);
-      for (const f of failures) {
-        logArtifact(
-          `  [${f.scenario}] ${f.message}${f.detail ? ' ' + JSON.stringify(f.detail) : ''}`
-        );
-      }
-    }
+    exitCode = reportFailures(failures);
   } catch (err) {
     logArtifact(`fatal: ${(err as Error).message}`);
     if ((err as Error).stack) logArtifact((err as Error).stack!);
@@ -1025,25 +1247,8 @@ async function main(): Promise<number> {
     } catch {
       // Ignore.
     }
-    if (chrome && chrome.exitCode === null) {
-      try {
-        chrome.kill('SIGTERM');
-        await Promise.race([
-          new Promise<void>((res) => chrome!.once('exit', () => res())),
-          delay(3000),
-        ]);
-        if (chrome.exitCode === null) chrome.kill('SIGKILL');
-      } catch {
-        // Ignore.
-      }
-    }
-    if (!process.env['SLICC_SMOKE_KEEP_PROFILE']) {
-      try {
-        rmSync(profileDir, { recursive: true, force: true });
-      } catch {
-        // Ignore.
-      }
-    }
+    if (chrome) await killChrome(chrome);
+    removeProfile(profileDir);
     // Last line of stderr is always the artifact-log path so CI / humans
     // can grab it without parsing the rest of the output.
     process.stderr.write(`\nsmoke artifacts: ${ARTIFACT_LOG}\n`);

--- a/packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts
+++ b/packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts
@@ -1,0 +1,172 @@
+/**
+ * Extension media-capture popup bridge.
+ *
+ * Media capture (`getUserMedia` / `getDisplayMedia`) needs a *visible* surface
+ * so Chrome can show its permission prompt / screen picker. In extension mode
+ * the shell command runs in the offscreen document (or the side-panel shell);
+ * the offscreen document in particular has no visible window, so capturing
+ * directly there silently fails. This module routes the capture through a small
+ * popup window (`capture-popup.html`, modeled on `voice-popup`) that performs
+ * the capture in a real window and posts the bytes back over `chrome.runtime`
+ * messaging.
+ *
+ * The popup is opened by the service worker (offscreen documents can't call
+ * `chrome.windows.create`); the resulting bytes broadcast back to every
+ * extension context, and this module's listener picks out its own request by
+ * id. CLI / standalone floats never reach this code — `isExtensionFloat()`
+ * gates it — so the page-served origin's auto-granted capture path is
+ * unchanged.
+ */
+
+/** Camera / mic capture request forwarded to the popup. */
+export interface PopupCameraCaptureRequest {
+  kind: 'camera';
+  mode: 'photo' | 'video';
+  deviceId?: string;
+  audioDeviceId?: string;
+  captureAudio?: boolean;
+  captureVideo?: boolean;
+  width?: number;
+  height?: number;
+  frameRate?: number;
+  exactSize?: boolean;
+  mimeType: string;
+  quality?: number;
+  durationMs?: number;
+  warmupMs?: number;
+}
+
+/** Screen capture request forwarded to the popup. */
+export interface PopupScreenCaptureRequest {
+  kind: 'screen';
+  mimeType: string;
+  quality: number;
+}
+
+export type PopupCaptureRequest = PopupCameraCaptureRequest | PopupScreenCaptureRequest;
+
+export interface PopupCaptureResult {
+  bytes: Uint8Array;
+  mimeType: string;
+  width: number;
+  height: number;
+  durationMs?: number;
+}
+
+interface CapturePopupResultMessage {
+  source: 'capture-popup';
+  requestId: string;
+  ok: boolean;
+  bytesBase64?: string;
+  mimeType?: string;
+  width?: number;
+  height?: number;
+  durationMs?: number;
+  error?: string;
+}
+
+/** True when running inside the Chrome extension runtime (panel or offscreen). */
+export function isExtensionFloat(): boolean {
+  return typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
+}
+
+/**
+ * Open the capture popup, run the requested capture there, and resolve with
+ * the captured bytes. Rejects on capture error, popup failure, or timeout.
+ *
+ * The generous default timeout matches the camera/screencapture commands: the
+ * user may take a while to click "Allow" or pick a capture target.
+ */
+export async function captureViaPopup(
+  request: PopupCaptureRequest,
+  opts: { timeoutMs?: number } = {}
+): Promise<PopupCaptureResult> {
+  if (typeof chrome === 'undefined' || !chrome.runtime?.id) {
+    throw new Error('media capture popup requires the extension runtime');
+  }
+  const timeoutMs = opts.timeoutMs ?? 5 * 60_000;
+  const requestId = newRequestId();
+  const encoded = base64UrlEncode(JSON.stringify({ ...request, requestId }));
+  const url = chrome.runtime.getURL(`capture-popup.html?req=${encoded}`);
+
+  return await new Promise<PopupCaptureResult>((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        chrome.runtime.onMessage.removeListener(listener);
+      } catch {
+        /* noop */
+      }
+    };
+
+    const listener = (message: unknown): void => {
+      const msg = message as CapturePopupResultMessage | undefined;
+      if (msg?.source !== 'capture-popup' || msg.requestId !== requestId) return;
+      cleanup();
+      if (msg.ok && msg.bytesBase64 !== undefined) {
+        try {
+          resolve({
+            bytes: base64Decode(msg.bytesBase64),
+            mimeType: msg.mimeType ?? 'application/octet-stream',
+            width: msg.width ?? 0,
+            height: msg.height ?? 0,
+            ...(typeof msg.durationMs === 'number' ? { durationMs: msg.durationMs } : {}),
+          });
+        } catch (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      } else {
+        reject(new Error(msg.error || 'media capture failed'));
+      }
+    };
+
+    const timer = setTimeout(() => {
+      // Ask the popup to close itself, then surface the timeout.
+      try {
+        chrome.runtime.sendMessage({ target: 'capture-popup', type: 'capture-abort', requestId });
+      } catch {
+        /* noop */
+      }
+      cleanup();
+      reject(new Error('media capture timed out waiting for the capture window'));
+    }, timeoutMs);
+
+    chrome.runtime.onMessage.addListener(listener);
+
+    // Offscreen documents can't open windows; ask the service worker to.
+    try {
+      chrome.runtime.sendMessage({ type: 'capture-open-window', url, requestId });
+    } catch (err) {
+      cleanup();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}
+
+function newRequestId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `cap-${crypto.randomUUID()}`;
+  }
+  return `cap-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+}
+
+function base64UrlEncode(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64Decode(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}

--- a/packages/webapp/src/shell/supplemental-commands/ffmpeg-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ffmpeg-command.ts
@@ -35,6 +35,7 @@ import {
   type CameraCaptureResult,
   captureCamera,
 } from '../../ui/panel-rpc-handlers.js';
+import { captureViaPopup, isExtensionFloat } from './extension-media-capture.js';
 import { getFfmpeg } from './ffmpeg-wasm.js';
 
 interface MediaDeviceSummary {
@@ -635,7 +636,21 @@ async function runAvfoundationCapture(
 
   let result: CameraCaptureResult;
   try {
-    if (hasLocalDom() && typeof navigator !== 'undefined' && navigator.mediaDevices) {
+    if (isExtensionFloat()) {
+      // Extension mode: capture in a visible popup window so Chrome can
+      // show its camera/mic permission prompt — the offscreen document
+      // (where this shell command usually runs) has no surface for it.
+      const popup = await captureViaPopup({ kind: 'camera', ...plan.request });
+      const buf = new ArrayBuffer(popup.bytes.byteLength);
+      new Uint8Array(buf).set(popup.bytes);
+      result = {
+        bytes: buf,
+        mimeType: popup.mimeType,
+        width: popup.width,
+        height: popup.height,
+        ...(popup.durationMs !== undefined ? { durationMs: popup.durationMs } : {}),
+      };
+    } else if (hasLocalDom() && typeof navigator !== 'undefined' && navigator.mediaDevices) {
       result = await captureCamera(plan.request);
     } else {
       const panelRpc = getPanelRpcClient();

--- a/packages/webapp/src/shell/supplemental-commands/screencapture-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/screencapture-command.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { getPanelRpcClient, hasLocalDom } from '../../kernel/panel-rpc.js';
+import { captureViaPopup, isExtensionFloat } from './extension-media-capture.js';
 import { basename } from './shared.js';
 
 function screencaptureHelp(): { stdout: string; stderr: string; exitCode: number } {
@@ -114,7 +115,7 @@ export function createScreencaptureCommand(): Command {
         exitCode: 1,
       };
     }
-    if (local && !navigator.mediaDevices?.getDisplayMedia) {
+    if (local && !isExtensionFloat() && !navigator.mediaDevices?.getDisplayMedia) {
       return {
         stdout: '',
         stderr: 'screencapture: screen capture is not supported in this browser\n',
@@ -146,7 +147,13 @@ export function createScreencaptureCommand(): Command {
 
     let bytes: Uint8Array;
     try {
-      if (local) {
+      if (isExtensionFloat()) {
+        // Extension mode: capture in a visible popup window so Chrome can
+        // show its screen picker — the offscreen document (where this
+        // shell command usually runs) has no surface to show it.
+        const popup = await captureViaPopup({ kind: 'screen', mimeType, quality });
+        bytes = popup.bytes;
+      } else if (local) {
         const r = await captureLocally(mimeType, quality);
         bytes = r.bytes;
       } else {
@@ -178,6 +185,23 @@ export function createScreencaptureCommand(): Command {
 
     if (toClipboard) {
       try {
+        if (
+          isExtensionFloat() &&
+          typeof document !== 'undefined' &&
+          typeof document.hasFocus === 'function' &&
+          !document.hasFocus()
+        ) {
+          // Offscreen agent shell: there is no focused surface to write the
+          // system clipboard from, and the capture popup has already closed.
+          // Fail fast instead of hanging on a focus event that never fires —
+          // run `-c` from the focusable side-panel terminal, or save to a file.
+          return {
+            stdout: '',
+            stderr:
+              'screencapture: clipboard capture needs a focused window; save to a file instead\n',
+            exitCode: 1,
+          };
+        }
         if (local) {
           // Stay on the page: convert to PNG if needed and write to
           // navigator.clipboard directly. Wait for the document to


### PR DESCRIPTION
Closes #819

## Problem

In the Chrome extension, the agent's bash shell runs in the **offscreen document**. Camera/mic/screen capture (`ffmpeg`, `screencapture`) called `getUserMedia`/`getDisplayMedia` directly there, but an offscreen document is an **invisible surface that cannot show the media permission prompt** — so capture failed.

## Fix

- Add `USER_MEDIA` + `DISPLAY_MEDIA` to the offscreen document `reasons`.
- Route capture through a small **visible `capture-popup` window** (modeled on the existing `voice-popup`) that runs `getUserMedia`/`getDisplayMedia` and posts the bytes back over `chrome.runtime` messaging. The service worker opens it via `chrome.windows.create` (a `capture-open-window` handler).
- `ffmpeg-command.ts` and `screencapture-command.ts` gate the popup path behind `isExtensionFloat()` first, then fall through to the unchanged CLI / standalone behavior — **no regression** outside the extension.
- **Zero manifest changes.** Offscreen `reasons` are a runtime API, not a manifest permission, and `chrome.windows.create` needs no new permission. `manifest.json` `permissions` + `host_permissions` are byte-for-byte unchanged.

## Chrome Web Store pre-emptive work

To avoid the recurring release-breaking CWS justification cycles whenever the manifest changes:

- Added `docs/chrome-web-store-submission.md` — justifications for **every** current manifest permission + `<all_urls>`, a single-purpose statement, the remote-code declaration, and the camera/mic/screen data-usage disclosure.
- Added `packages/dev-tools/tools/check-manifest-justifications.sh` — a **CI guard** (wired into the lint job) that fails the build if the manifest's permission set ever drifts from the documented justifications. A future permission addition can't ship without the justification being written first.

## Other fixes

- **Encoding:** `capture-popup.html` and `voice-popup.html` were missing `<meta charset="utf-8">`, so Chrome decoded them as Windows-1252 and rendered the UTF-8 ellipsis (`…`) as mojibake. Added the charset meta to both.

## Tests

- Added a media-capture scenario to the extension smoke test (`packages/dev-tools/tools/extension-smoke-test.ts`): launches Chrome with `--use-fake-device-for-media-stream` / `--use-fake-ui-for-media-stream` (scoped to the smoke test), runs an avfoundation photo capture through the popup path, and asserts a valid non-empty JPEG round-trips back.

## Verification

- `npm run lint`, `npm run typecheck`, `npm run test` (5937 passed), and `SLICC_EXT_DEV=1 npm run build -w @slicc/chrome-extension` all green.
- `manifest.json` verified byte-for-byte unchanged vs the branch point.
- Extension smoke suite green (including the new media-capture scenario).

## Note

This branch is currently behind `main`. The PR diff (merge-base) is clean, but you may want to update the branch before merge so CI runs against the real merge.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author