### PR TITLE
ci: gated Claude Code PR review for unreviewed PRs

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -10,6 +10,16 @@ name: Claude PR Review
 #      needs a review (open, not draft, zero inline review comments), and
 #   3. only then hands it to claude-code-action for a focused review.
 #
+# Triggers on `opened` and `ready_for_review`: PRs opened as drafts are skipped
+# by the gate (Codex/Copilot don't review drafts either), so they must be
+# reconsidered when marked ready. Single-review behaviour is preserved because
+# the gate counts Claude's own prior inline comments — once Claude has reviewed,
+# later triggers skip automatically.
+#
+# Security: the gate decides whether the privileged review runs, so it must NOT
+# execute PR-authored code. The gate runs from a TRUSTED checkout of the PR base
+# revision; the PR head is only checked out (conditionally) for the review step.
+#
 # Required repository secret (already present — shared with rum-error-triage):
 #   AWS_BEARER_TOKEN_BEDROCK  Amazon Bedrock API key (Adobe CAMP `ABSK...`
 #                             bearer token) used by claude-code-action
@@ -20,7 +30,7 @@ name: Claude PR Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 concurrency:
   group: claude-pr-review-${{ github.event.pull_request.number }}
@@ -42,9 +52,12 @@ jobs:
       - name: Wait 5 minutes for personal/human reviewers
         run: sleep 300
 
+      # Trusted checkout: the PR BASE revision contains the gate script. The gate
+      # must not run PR-authored code (it gates a privileged job), so we never
+      # check out the PR head before the gate decides.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 1
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -58,6 +71,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
         run: node packages/dev-tools/pr-review-gate/check-pr-review-gate.mjs
+
+      # Only now (and only if the gate approved) check out the PR head so the
+      # review step sees the proposed changes.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: steps.gate.outputs.should_review == 'true'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
 
       - name: Claude PR review
         if: steps.gate.outputs.should_review == 'true'

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,111 @@
+name: Claude PR Review
+
+# Gated automated PR review. Codex/Copilot reviews are *personal* reviewers:
+# they only run on PRs opened by the account owner, so PRs opened by anyone
+# else get no automated review. This workflow fills that gap WITHOUT
+# double-reviewing the author's own PRs:
+#   1. waits 5 minutes after a PR is opened to let personal/human reviewers
+#      leave their inline comments first,
+#   2. asks the gate (packages/dev-tools/pr-review-gate) whether the PR still
+#      needs a review (open, not draft, zero inline review comments), and
+#   3. only then hands it to claude-code-action for a focused review.
+#
+# Required repository secret (already present — shared with rum-error-triage):
+#   AWS_BEARER_TOKEN_BEDROCK  Amazon Bedrock API key (Adobe CAMP `ABSK...`
+#                             bearer token) used by claude-code-action
+#                             (`use_bedrock: true`). No new secrets needed.
+#
+# Third-party actions are pinned to immutable commit SHAs (the exact same SHAs
+# as .github/workflows/rum-error-triage.yml) — this job has pull-requests:write.
+
+on:
+  pull_request:
+    types: [opened]
+
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # check out the PR head to review it
+  pull-requests: write # post inline comments + a summary
+  id-token: write # OIDC, mirrors rum-error-triage.yml
+
+jobs:
+  gated-review:
+    runs-on: ubuntu-latest
+    # Skip fork PRs: secrets are unavailable on `pull_request` from forks, and
+    # reviewing them safely would require `pull_request_target` + a security
+    # review (out of scope). Only run when the PR head lives in this repo.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Wait 5 minutes for personal/human reviewers
+        run: sleep 300
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Check PR-review gate
+        id: gate
+        env:
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: node packages/dev-tools/pr-review-gate/check-pr-review-gate.mjs
+
+      - name: Claude PR review
+        if: steps.gate.outputs.should_review == 'true'
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        env:
+          # Bedrock path: authenticate with an Amazon Bedrock API key (the Adobe
+          # CAMP `ABSK...` bearer token). Mirrors rum-error-triage.yml — the
+          # AWS_BEARER_TOKEN_BEDROCK secret and RUM_AWS_REGION variable are
+          # already provisioned, so no new configuration is required here.
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          AWS_REGION: ${{ vars.RUM_AWS_REGION || 'us-east-1' }}
+          # claude-code-action does NOT expose a token to the Bash tool's `gh`,
+          # so set it explicitly or `gh pr comment` fails. The job's
+          # pull-requests:write permission scopes this token appropriately.
+          GH_TOKEN: ${{ github.token }}
+        with:
+          use_bedrock: 'true'
+          # Needed by the action for the inline-comment MCP tool.
+          github_token: ${{ github.token }}
+          claude_args: |
+            --model ${{ vars.PR_REVIEW_BEDROCK_MODEL || vars.RUM_BEDROCK_MODEL || 'global.anthropic.claude-sonnet-4-6' }}
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            --max-turns 40
+          prompt: |
+            You are performing an automated code review for the SLICC codebase.
+
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review the pull request above. Use `gh pr view` and `gh pr diff` to
+            read the PR description and the changed code. Focus your review on:
+
+            - Correctness and bugs: logic errors, edge cases, broken behaviour,
+              incorrect error handling.
+            - Security: injection, secret leakage, unsafe input handling,
+              privilege/permission mistakes.
+            - Performance: needless work, obvious inefficiencies, leaks.
+            - Repo conventions: follow the guidance in the nearest CLAUDE.md
+              (shell-first, browser-first, dual-mode CLI/extension, SHA-pinned
+              actions, tests + docs for behaviour changes, etc.).
+
+            Post specific, actionable feedback as INLINE comments on the exact
+            changed lines using the
+            `mcp__github_inline_comment__create_inline_comment` tool. Then post
+            ONE concise top-level summary (a few sentences on overall quality
+            and the most important findings) with `gh pr comment`.
+
+            Be focused and high-signal: only flag things that genuinely matter,
+            and prefer no comment over a noisy or speculative one. Do NOT submit
+            your review as raw chat/output text — all feedback must go through
+            the inline-comment tool and `gh pr comment`.

--- a/packages/dev-tools/pr-review-gate/README.md
+++ b/packages/dev-tools/pr-review-gate/README.md
@@ -1,0 +1,72 @@
+# PR Review Gate — the "does this PR still need a review?" check
+
+Codex/Copilot reviews are _personal_ reviewers: they only run on PRs opened by
+the account owner. PRs opened by anyone else get no automated review. This gate
+lets a Claude Code review fill that gap without double-reviewing the author's
+own PRs.
+
+## Flow
+
+```
+PR opened ─▶ sleep 300 ─▶ check-pr-review-gate.mjs ─▶ should_review? ─▶ claude-code-action (inline comments + summary)
+                            │
+                            ├─ GET /pulls/{n}            (state, draft)
+                            └─ GET /pulls/{n}/comments   (inline review comments)
+```
+
+1. **Wait** — the workflow sleeps 5 minutes after the PR is opened, giving
+   personal/human reviewers time to leave inline comments first.
+2. **Gate** — `check-pr-review-gate.mjs` reads the PR state/draft flag and the
+   PR's inline review comments from the GitHub REST API, then calls the pure
+   `decideReview(...)` logic in `lib.mjs`. It writes `should_review=<bool>` and
+   `reason=<text>` to `$GITHUB_OUTPUT`.
+3. **Review** — only when `should_review == 'true'` does
+   `anthropics/claude-code-action` run, posting inline comments via
+   `mcp__github_inline_comment__create_inline_comment` plus a top-level summary
+   via `gh pr comment`.
+
+This produces the desired split: on the author's own PR, Codex/Copilot leave
+inline comments within 5 minutes → Claude skips; on someone else's PR, no
+personal review exists → Claude reviews.
+
+The workflow lives in `.github/workflows/claude-pr-review.yml`.
+
+## Design notes
+
+- **Pure logic is isolated and tested.** `lib.mjs` contains the decision logic
+  (`decideReview`, `countInlineReviewComments`) with no I/O, unit-tested in
+  `lib.test.mjs` (run via the `dev-tools` vitest project in `npm test`).
+  `check-pr-review-gate.mjs` only talks to the GitHub REST API and
+  `$GITHUB_OUTPUT`.
+- **Skip rules.** The gate skips when the PR is not `open`, is a draft, or
+  already has any inline review comment. Otherwise it reviews.
+
+## Required secrets / variables (GitHub Actions)
+
+These are shared with `rum-error-triage` — no new secrets are required.
+
+| Name                       | Kind     | Purpose                                                                                                            |
+| -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `AWS_BEARER_TOKEN_BEDROCK` | secret   | Amazon Bedrock API key (Adobe CAMP `ABSK...` bearer token) used by `claude-code-action` (`use_bedrock`).           |
+| `RUM_AWS_REGION`           | variable | Optional. Bedrock region for the CAMP key (default `us-east-1`).                                                   |
+| `PR_REVIEW_BEDROCK_MODEL`  | variable | Optional. Bedrock model for reviews; falls back to `RUM_BEDROCK_MODEL`, then `global.anthropic.claude-sonnet-4-6`. |
+
+## Run it locally
+
+Requires a `GH_TOKEN` with read access to the repo.
+
+```bash
+REPO=owner/repo PR_NUMBER=123 GH_TOKEN=$(gh auth token) \
+  node packages/dev-tools/pr-review-gate/check-pr-review-gate.mjs
+
+# Unit tests
+npx vitest run --project dev-tools
+```
+
+### Environment variables
+
+| Var         | Meaning                                  |
+| ----------- | ---------------------------------------- |
+| `REPO`      | `owner/repo` of the pull request         |
+| `PR_NUMBER` | The pull request number to gate          |
+| `GH_TOKEN`  | Token used for the GitHub REST API reads |

--- a/packages/dev-tools/pr-review-gate/check-pr-review-gate.mjs
+++ b/packages/dev-tools/pr-review-gate/check-pr-review-gate.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/*
+ * PR-review gate — orchestrator (I/O).
+ *
+ * Reads a PR's state and its inline review comments from the GitHub REST API,
+ * then asks `decideReview` (pure, unit-tested in `lib.mjs`) whether the
+ * automated Claude review should run. Writes `should_review` and `reason` to
+ * $GITHUB_OUTPUT for the workflow to gate on. This file only does I/O.
+ *
+ * Env:
+ *   REPO        owner/repo                          (required)
+ *   PR_NUMBER   pull request number                 (required)
+ *   GH_TOKEN    token for the GitHub API            (required)
+ *
+ * Exit 0 on a clean decision (review or skip); non-zero only on missing env
+ * or an unexpected API/network failure.
+ */
+import { appendFileSync } from 'node:fs';
+import { countInlineReviewComments, decideReview } from './lib.mjs';
+
+const API = 'https://api.github.com';
+
+function requireEnv(name) {
+  const value = (process.env[name] ?? '').trim();
+  if (!value) {
+    console.error(`❌ Missing required env var ${name}.`);
+    process.exit(2);
+  }
+  return value;
+}
+
+/** GitHub REST GET returning parsed JSON. Throws on a non-OK response. */
+async function ghGet(path, token) {
+  const res = await fetch(`${API}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'slicc-pr-review-gate',
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`GET ${path} → ${res.status} ${res.statusText} ${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+/** Fetch every inline review comment, following pagination (per_page=100). */
+async function fetchInlineComments(repo, prNumber, token) {
+  const all = [];
+  for (let page = 1; ; page += 1) {
+    const batch = await ghGet(
+      `/repos/${repo}/pulls/${prNumber}/comments?per_page=100&page=${page}`,
+      token
+    );
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    all.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return all;
+}
+
+function setOutput(key, value) {
+  if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+}
+
+async function main() {
+  const repo = requireEnv('REPO');
+  const prNumber = requireEnv('PR_NUMBER');
+  const token = requireEnv('GH_TOKEN');
+
+  const pr = await ghGet(`/repos/${repo}/pulls/${prNumber}`, token);
+  const comments = await fetchInlineComments(repo, prNumber, token);
+
+  const decision = decideReview({
+    state: pr.state,
+    isDraft: Boolean(pr.draft),
+    inlineReviewCommentCount: countInlineReviewComments(comments),
+  });
+
+  setOutput('should_review', decision.shouldReview ? 'true' : 'false');
+  setOutput('reason', decision.reason);
+  console.log(decision.reason);
+}
+
+main().catch((err) => {
+  console.error(`❌ PR-review gate failed: ${err.message?.split('\n')[0] ?? err}`);
+  process.exit(1);
+});

--- a/packages/dev-tools/pr-review-gate/lib.mjs
+++ b/packages/dev-tools/pr-review-gate/lib.mjs
@@ -1,0 +1,48 @@
+/*
+ * PR-review gate — pure logic.
+ *
+ * Decides whether the automated Claude Code review should run on a pull
+ * request. The rule: review only when the PR is still open, not a draft, and
+ * carries zero inline review comments (so PRs that personal reviewers like
+ * Codex/Copilot already covered are skipped). This module is intentionally
+ * free of I/O so it can be unit-tested in isolation — the GitHub API calls
+ * live in `check-pr-review-gate.mjs`.
+ */
+
+/**
+ * Count the inline review comments returned by
+ * `GET /repos/{owner}/{repo}/pulls/{n}/comments`. Tolerates null/undefined
+ * and non-array input by treating them as zero comments.
+ * @param {Array<unknown>|null|undefined} comments
+ * @returns {number}
+ */
+export function countInlineReviewComments(comments) {
+  return Array.isArray(comments) ? comments.length : 0;
+}
+
+/**
+ * Decide whether Claude should review the PR. Each branch returns a clear,
+ * human-readable `reason` so the workflow log and `$GITHUB_OUTPUT` explain
+ * the decision.
+ * @param {{state?: string, isDraft?: boolean, inlineReviewCommentCount?: number}} input
+ * @returns {{shouldReview: boolean, reason: string}}
+ */
+export function decideReview({ state, isDraft, inlineReviewCommentCount } = {}) {
+  if (state !== 'open') {
+    return { shouldReview: false, reason: `PR is not open (state="${state ?? 'unknown'}").` };
+  }
+  if (isDraft) {
+    return { shouldReview: false, reason: 'PR is a draft.' };
+  }
+  const count = Number(inlineReviewCommentCount) || 0;
+  if (count > 0) {
+    return {
+      shouldReview: false,
+      reason: `PR already has ${count} inline review comment(s); a reviewer has it covered.`,
+    };
+  }
+  return {
+    shouldReview: true,
+    reason: 'PR is open, not a draft, and has no inline review comments — reviewing.',
+  };
+}

--- a/packages/dev-tools/pr-review-gate/lib.test.mjs
+++ b/packages/dev-tools/pr-review-gate/lib.test.mjs
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { countInlineReviewComments, decideReview } from './lib.mjs';
+
+describe('decideReview', () => {
+  it('reviews an open PR with zero inline comments', () => {
+    const out = decideReview({ state: 'open', isDraft: false, inlineReviewCommentCount: 0 });
+    expect(out.shouldReview).toBe(true);
+    expect(out.reason).toMatch(/reviewing/i);
+  });
+
+  it('skips an open PR that already has inline comments', () => {
+    const out = decideReview({ state: 'open', isDraft: false, inlineReviewCommentCount: 3 });
+    expect(out.shouldReview).toBe(false);
+    expect(out.reason).toContain('3');
+  });
+
+  it('skips a draft PR', () => {
+    const out = decideReview({ state: 'open', isDraft: true, inlineReviewCommentCount: 0 });
+    expect(out.shouldReview).toBe(false);
+    expect(out.reason).toMatch(/draft/i);
+  });
+
+  it('skips a closed PR', () => {
+    const out = decideReview({ state: 'closed', isDraft: false, inlineReviewCommentCount: 0 });
+    expect(out.shouldReview).toBe(false);
+    expect(out.reason).toMatch(/not open/i);
+  });
+
+  it('skips when state is missing', () => {
+    expect(decideReview({}).shouldReview).toBe(false);
+    expect(decideReview().shouldReview).toBe(false);
+  });
+});
+
+describe('countInlineReviewComments', () => {
+  it('returns the length of an array', () => {
+    expect(countInlineReviewComments([{ id: 1 }, { id: 2 }])).toBe(2);
+  });
+
+  it('returns 0 for an empty array', () => {
+    expect(countInlineReviewComments([])).toBe(0);
+  });
+
+  it('tolerates null/undefined and non-array input', () => {
+    expect(countInlineReviewComments(null)).toBe(0);
+    expect(countInlineReviewComments(undefined)).toBe(0);
+    expect(countInlineReviewComments({})).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Adds an automated Claude Code PR review that runs **only when a PR isn't already being reviewed** — filling the gap for PRs opened by people other than the repo owner (Codex/Copilot are *personal* reviewers and only run on the author's own PRs).

## How the gate works

1. Triggers on `pull_request: [opened]`.
2. Waits 5 minutes (`sleep 300`) to give personal/human reviewers time to comment.
3. Checks the PR's inline review comments (`GET /pulls/{n}/comments`).
4. Runs `claude-code-action` **only if** the PR is still open, not a draft, and has **zero** inline review comments.

Result: on the author's own PRs, Codex/Copilot leave inline comments within 5 min so Claude stays out of the way; on PRs from others, no personal review exists so Claude reviews.

## Changes

- **`packages/dev-tools/pr-review-gate/`** — pure, unit-tested gate logic (`lib.mjs`: `decideReview` + `countInlineReviewComments`), a `check-pr-review-gate.mjs` CLI that reads PR state + paginated inline comments and writes `should_review`/`reason` to `$GITHUB_OUTPUT`, `lib.test.mjs` (8 tests), and a README.
- **`.github/workflows/claude-pr-review.yml`** — the gated workflow. Skips fork PRs (no secret access), pins all three third-party actions to the **same SHAs** as `rum-error-triage.yml`, and uses the existing Amazon Bedrock auth (`AWS_BEARER_TOKEN_BEDROCK`). **No new secrets required.**

## Defaults / decisions

- Gate counts **inline review comments only** (not top-level PR conversation comments or review summaries without inline comments).
- 5-minute wait is an in-job `sleep 300`.
- Draft PRs and fork PRs are skipped.

## Verification

- `npm run test` — 29 pass (8 new) via the `dev-tools` vitest project.
- `npm run lint:ci` — clean.
- `actionlint .github/workflows/claude-pr-review.yml` — clean.

## Rollback

Delete `.github/workflows/claude-pr-review.yml` and `packages/dev-tools/pr-review-gate/`. No other workflows depend on them.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author