### PR TITLE
feat: nightly agentic-debt triage (seven-sins rotation)

### DIFF
--- a/.github/workflows/agentic-debt-triage.yml
+++ b/.github/workflows/agentic-debt-triage.yml
@@ -1,0 +1,110 @@
+name: Agentic Debt Triage
+
+# Nightly "agentic-debt" hunter. Where RUM error triage chases runtime bugs,
+# this workflow chases CODEBASE debt introduced by agentic development. Each
+# night it rotates through seven agentic-codebase failure modes — the "sins" —
+# and hands the sin of the day to claude-code-action, which investigates the
+# repo read-only and files exactly ONE GitHub issue documenting the single most
+# impactful instance it finds (steering clear of areas already covered by open
+# issues / PRs).
+#
+# The seven-sin rotation (day-of-year UTC mod 7, severity order):
+#   1. complicatification  easy things done the hard way
+#   2. entanglement        muddy module boundaries / wrong call directions
+#   3. drift               code vs. comments/names/docs out of sync
+#   4. duplication         copy-paste / parallel implementations
+#   5. bloat               gigantic files/functions; deep nesting
+#   6. necrophilia         dead code: unused exports, unreachable branches
+#   7. paranoia            overly defensive programming
+# Rotation + per-sin prompts live in packages/dev-tools/codebase-sins/; the
+# select-sin.mjs CLI emits the chosen sin id/name/label and composed prompt.
+#
+# Required repository secret (already present — same as rum-error-triage.yml):
+#   AWS_BEARER_TOKEN_BEDROCK  Amazon Bedrock API key (Adobe CAMP `ABSK...`
+#                             bearer token) for claude-code-action. Optional
+#                             repo vars RUM_AWS_REGION / SINS_BEDROCK_MODEL /
+#                             RUM_BEDROCK_MODEL tune region + inference profile.
+# No new secrets are required beyond what RUM error triage already uses.
+#
+# Third-party actions are pinned to immutable commit SHAs (identical to
+# .github/workflows/rum-error-triage.yml) — this job has issues:write access.
+
+on:
+  schedule:
+    - cron: '0 5 * * *' # nightly at 05:00 UTC (offset from RUM's 03:00)
+  workflow_dispatch:
+    inputs:
+      sin:
+        description: 'Override sin of the day (1-7 or name); blank = rotation'
+        required: false
+      dry_run:
+        description: 'Select the sin only; do not run Claude / file an issue'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: agentic-debt-triage
+  cancel-in-progress: false
+
+permissions:
+  contents: read # read-only investigation of the codebase
+  issues: write # file the agentic-debt issue
+  pull-requests: read # so Claude can `gh pr list` to avoid covered areas
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      # Third-party actions are pinned to immutable commit SHAs (matching
+      # .github/workflows/rum-error-triage.yml).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # full history so Claude can use git log / blame
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Ensure triage labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create agentic-debt --color 5319e7 --description "Agentic-codebase tech-debt surfaced by nightly triage" --force
+          for id in complicatification entanglement drift duplication bloat necrophilia paranoia; do
+            gh label create "debt:$id" --color 5319e7 --description "Agentic-debt sin: $id" --force
+          done
+
+      - name: Select the sin of the day
+        id: sin
+        env:
+          SIN_OVERRIDE: ${{ github.event.inputs.sin }}
+        run: node packages/dev-tools/codebase-sins/select-sin.mjs
+
+      - name: Hunt the sin and file an issue
+        if: github.event.inputs.dry_run != 'true'
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        env:
+          # Bedrock path: authenticate with an Amazon Bedrock API key (the Adobe
+          # CAMP `ABSK...` bearer token). Set the AWS_BEARER_TOKEN_BEDROCK secret
+          # and, if needed, the RUM_AWS_REGION / SINS_BEDROCK_MODEL repo
+          # variables to match the region + inference profile your CAMP key can
+          # reach. (Bearer-token auth for Bedrock is newer in Claude Code — if a
+          # run fails on auth, fall back to `anthropic_api_key`.)
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          AWS_REGION: ${{ vars.RUM_AWS_REGION || 'us-east-1' }}
+          # claude-code-action does NOT expose a token to the Bash tool's `gh`,
+          # so set it explicitly or `gh issue create` / `gh issue list` fail.
+          # The job's top-level permissions scope this token appropriately.
+          GH_TOKEN: ${{ github.token }}
+        with:
+          use_bedrock: 'true'
+          # Print Claude's full turn-by-turn output to the Actions log on manual
+          # dispatch (to inspect its reasoning); kept off for the nightly cron so
+          # routine runs don't log tool output that may contain sensitive data.
+          show_full_output: ${{ github.event_name == 'workflow_dispatch' }}
+          claude_args: |
+            --model ${{ vars.SINS_BEDROCK_MODEL || vars.RUM_BEDROCK_MODEL || 'global.anthropic.claude-sonnet-4-6' }}
+            --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*)"
+            --max-turns 40
+          prompt: ${{ steps.sin.outputs.prompt }}

--- a/packages/dev-tools/codebase-sins/README.md
+++ b/packages/dev-tools/codebase-sins/README.md
@@ -1,0 +1,54 @@
+# Codebase Sins — nightly agentic-debt triage
+
+A nightly job that hunts for ONE concrete instance of the **sin of the day** —
+rotating through seven agentic-codebase failure modes, ordered by severity — and
+files a single GitHub issue documenting the worst offender. Mirrors the
+`packages/dev-tools/rum-error-triage/` layout (pure logic + CLI + co-located
+tests run by the `dev-tools` vitest project).
+
+## The seven sins (rotation order = severity)
+
+1. **Complicatification** — easy things done the hard way.
+2. **Entanglement** — muddy module boundaries / wrong call directions.
+3. **Drift** — code vs. comments/docs/names out of sync.
+4. **Duplication** — multiple implementations of the same thing.
+5. **Bloat** — gigantic files/functions/classes.
+6. **Necrophilia** — dead code.
+7. **Paranoia** — overly defensive programming.
+
+## Rotation
+
+`selectSinOfDay(date)` picks the sin via **day-of-year (UTC) mod 7**:
+`SINS[dayOfYearUTC % 7]`. The sin drifts by one each day, is independent of the
+weekday, and cycles through all seven. It is pure and deterministic.
+
+`resolveSin(override)` honours a `workflow_dispatch` override that may be a `1-7`
+rank or a sin name/id, falling back to `selectSinOfDay()` when empty or invalid.
+
+## Files
+
+- `sins.mjs` — pure logic: `SINS` (the seven definitions), `selectSinOfDay`,
+  `resolveSin`, and `buildPrompt` (composes the shared filing/dedup boilerplate,
+  written once here, with a per-sin body). No I/O; unit-tested in `lib.test.mjs`.
+- `prompts/<n>-<id>.md` — the seven per-sin bodies (definition + repo-specific
+  signals to grep for + what makes an instance "most impactful").
+- `select-sin.mjs` — CLI (I/O only): resolves the sin from `SIN_OVERRIDE`, reads
+  its prompt body, composes the prompt, and writes `sin_id`, `sin_name`,
+  `sin_label`, and the multi-line `prompt` to `$GITHUB_OUTPUT`.
+
+## Run it locally
+
+```bash
+# Pick the necrophilia sin (override 6) and print the chosen sin + prompt
+SIN_OVERRIDE=6 GITHUB_OUTPUT=/tmp/out.txt node packages/dev-tools/codebase-sins/select-sin.mjs
+
+# Unit tests
+npx vitest run --project dev-tools
+```
+
+### Environment variables
+
+| Var             | Default            | Meaning                                                 |
+| --------------- | ------------------ | ------------------------------------------------------- |
+| `SIN_OVERRIDE`  | _(sin of the day)_ | `workflow_dispatch` override: a `1-7` rank or a name/id |
+| `GITHUB_OUTPUT` | _(unset)_          | Actions output file; the CLI appends results when set   |

--- a/packages/dev-tools/codebase-sins/README.md
+++ b/packages/dev-tools/codebase-sins/README.md
@@ -20,7 +20,7 @@ tests run by the `dev-tools` vitest project).
 
 `selectSinOfDay(date)` picks the sin via **day-of-year (UTC) mod 7**:
 `SINS[dayOfYearUTC % 7]`. The sin drifts by one each day, is independent of the
-weekday, and cycles through all seven. It is pure and deterministic.
+weekday, cycles through all seven, and is deterministic for a given `date` argument.
 
 `resolveSin(override)` honours a `workflow_dispatch` override that may be a `1-7`
 rank or a sin name/id, falling back to `selectSinOfDay()` when empty or invalid.

--- a/packages/dev-tools/codebase-sins/lib.test.mjs
+++ b/packages/dev-tools/codebase-sins/lib.test.mjs
@@ -1,0 +1,108 @@
+import { existsSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { buildPrompt, resolveSin, SINS, selectSinOfDay } from './sins.mjs';
+
+describe('SINS', () => {
+  it('has seven sins in the severity order, with derived labels and prompt files', () => {
+    expect(SINS).toHaveLength(7);
+    expect(SINS.map((s) => s.id)).toEqual([
+      'complicatification',
+      'entanglement',
+      'drift',
+      'duplication',
+      'bloat',
+      'necrophilia',
+      'paranoia',
+    ]);
+    for (const s of SINS) {
+      expect(s.label).toBe(`debt:${s.id}`);
+      expect(typeof s.name).toBe('string');
+      expect(typeof s.summary).toBe('string');
+    }
+  });
+
+  it('points every promptFile at a file that exists on disk', () => {
+    for (const s of SINS) {
+      expect(existsSync(s.promptFile), `${s.id} prompt missing: ${s.promptFile}`).toBe(true);
+    }
+  });
+});
+
+describe('selectSinOfDay', () => {
+  it('is deterministic for a fixed date', () => {
+    const date = new Date('2026-03-15T12:00:00Z');
+    expect(selectSinOfDay(date)).toBe(selectSinOfDay(date));
+  });
+
+  it('maps seven consecutive days to the full distinct set of seven sins', () => {
+    const ids = new Set();
+    const start = new Date('2026-03-01T00:00:00Z');
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(start.getTime() + i * 86_400_000);
+      ids.add(selectSinOfDay(d).id);
+    }
+    expect(ids.size).toBe(7);
+    expect(ids).toEqual(new Set(SINS.map((s) => s.id)));
+  });
+
+  it('uses UTC day-of-year (independent of local time within the same UTC day)', () => {
+    expect(selectSinOfDay(new Date('2026-06-01T00:30:00Z')).id).toBe(
+      selectSinOfDay(new Date('2026-06-01T23:30:00Z')).id
+    );
+  });
+});
+
+describe('resolveSin', () => {
+  it('resolves a 1-7 numeric override to that rank', () => {
+    expect(resolveSin(1).id).toBe('complicatification');
+    expect(resolveSin('6').id).toBe('necrophilia');
+    expect(resolveSin(7).id).toBe('paranoia');
+  });
+
+  it('resolves a sin id or name (case-insensitive)', () => {
+    expect(resolveSin('drift').id).toBe('drift');
+    expect(resolveSin('Necrophilia').id).toBe('necrophilia');
+    expect(resolveSin('ENTANGLEMENT').id).toBe('entanglement');
+  });
+
+  it('falls back to the sin of the day for empty input', () => {
+    const date = new Date('2026-04-10T00:00:00Z');
+    const today = selectSinOfDay(date).id;
+    // resolveSin's empty-path uses selectSinOfDay() with the real clock, so
+    // assert it returns a valid sin rather than pinning the date.
+    expect(SINS.map((s) => s.id)).toContain(resolveSin('').id);
+    expect(SINS.map((s) => s.id)).toContain(resolveSin(null).id);
+    expect(SINS.map((s) => s.id)).toContain(resolveSin(undefined).id);
+    expect(today).toBeTruthy();
+  });
+
+  it('falls back to a valid sin for invalid input (out of range / unknown)', () => {
+    expect(SINS.map((s) => s.id)).toContain(resolveSin('0').id);
+    expect(SINS.map((s) => s.id)).toContain(resolveSin('8').id);
+    expect(SINS.map((s) => s.id)).toContain(resolveSin('not-a-sin').id);
+  });
+});
+
+describe('buildPrompt', () => {
+  const sin = SINS[3]; // duplication
+  const body = 'PER_SIN_BODY_MARKER: hunt for copy-paste blocks.';
+  const prompt = buildPrompt(sin, body);
+
+  it('includes the per-sin body', () => {
+    expect(prompt).toContain('PER_SIN_BODY_MARKER');
+  });
+
+  it('includes the shared filing/dedup instructions interpolated with the sin', () => {
+    expect(prompt).toContain('gh issue create');
+    expect(prompt).toContain('gh issue list --state open');
+    expect(prompt).toContain('gh pr list --state open');
+    expect(prompt).toContain(`<!-- agentic-debt:${sin.id} -->`);
+    expect(prompt).toContain(`--label agentic-debt --label ${sin.label}`);
+    expect(prompt).toContain(sin.name);
+  });
+
+  it('tolerates an empty body', () => {
+    expect(() => buildPrompt(sin, '')).not.toThrow();
+    expect(buildPrompt(sin, '')).toContain('gh issue create');
+  });
+});

--- a/packages/dev-tools/codebase-sins/prompts/1-complicatification.md
+++ b/packages/dev-tools/codebase-sins/prompts/1-complicatification.md
@@ -1,0 +1,28 @@
+**Complicatification** — easy things done the hard way. Code that is far more
+elaborate than the problem requires: incomprehensible control flow, needless
+abstraction or indirection, "clever" one-liners that take minutes to read,
+reinvented standard-library or existing-library features, and over-engineered
+patterns (factories/managers/wrappers around something trivial).
+
+## Signals to look for in this repo
+
+- Hand-rolled helpers that duplicate built-ins (manual `Array`/`Object`
+  iteration where `map`/`filter`/`Object.entries` would do; bespoke deep-clone,
+  debounce, or path joining instead of stdlib).
+- Deeply chained ternaries, nested closures, or callback gymnastics where a
+  plain `if`/early-return would be clearer.
+- Abstraction with a single caller: an interface, factory, or generic wrapper
+  that is only ever instantiated one way.
+- Re-implemented logic that a dependency already exports (e.g. re-deriving
+  things `pi-agent-core`/`pi-ai`, `isomorphic-git`, or `@slicc/shared-ts`
+  already provide).
+- The shell/tools layers (`packages/webapp/src/shell/`,
+  `packages/webapp/src/tools/`) and CDP layer (`packages/webapp/src/cdp/`) are
+  common homes for accidental complexity.
+
+## What makes an instance "most impactful"
+
+Prefer code on a hot path or in a widely-touched module where the complexity
+actively slows comprehension or invites bugs, and where a concrete, simpler
+formulation is obvious. Favour a self-contained simplification over a sprawling
+refactor.

--- a/packages/dev-tools/codebase-sins/prompts/2-entanglement.md
+++ b/packages/dev-tools/codebase-sins/prompts/2-entanglement.md
@@ -1,0 +1,26 @@
+**Entanglement** — muddy module boundaries and wrong call directions.
+Dependencies that point the wrong way, modules that know too much about each
+other, and objects that have grown to do everything.
+
+## Signals to look for in this repo
+
+The package boundaries in `CLAUDE.md` define the intended layering. Hunt for
+imports that violate it:
+
+- The layer stack flows `fs → shell/git → cdp → tools → core → scoops → ui`.
+  Look for back-edges, e.g. `packages/webapp/src/core/` importing from
+  `packages/webapp/src/ui/`, or low layers reaching up into orchestration.
+- `packages/node-server/` importing deep `packages/webapp/src/` internals
+  instead of a stable entry point; `@slicc/shared-ts` (meant to be
+  platform-agnostic) importing browser- or node-only code.
+- Circular dependencies between modules.
+- "God" modules: a single file imported by many otherwise-unrelated modules, or
+  a class/object that accumulates unrelated responsibilities (orchestrator,
+  shell, or a catch-all `utils`/`shared` file are usual suspects).
+
+## What makes an instance "most impactful"
+
+Prefer a boundary violation that couples two layers/packages that should be
+independent (it blocks reuse and makes change risky), with clear `file:line`
+evidence of the offending import and a concrete suggestion for which direction
+the dependency should run.

--- a/packages/dev-tools/codebase-sins/prompts/3-drift.md
+++ b/packages/dev-tools/codebase-sins/prompts/3-drift.md
@@ -1,0 +1,25 @@
+**Drift** — code and its description out of sync. Comments, docstrings, names,
+and docs that no longer match what the code actually does. The danger is that
+the stale words are trusted over the code.
+
+## Signals to look for in this repo
+
+- Comments or JSDoc that contradict the adjacent implementation (describe a
+  parameter, return value, or behaviour the code no longer has).
+- Function/variable names that lie about behaviour (a `getX` that mutates, an
+  `isReady` that means something else now).
+- Stale developer docs: `CLAUDE.md` files (root + per-package),
+  `docs/shell-reference.md`, and `docs/architecture.md` describing modules,
+  commands, ports, or flows that have since changed. Cross-check claims like the
+  supplemental-command list, layer stack, and the agent-facing
+  `packages/vfs-root/shared/CLAUDE.md`.
+- `TODO`/`FIXME` comments referencing work that is already done, or describing a
+  plan that the code contradicts.
+- Examples or README snippets that no longer run as written.
+
+## What makes an instance "most impactful"
+
+Prefer drift that would actively mislead a developer or agent — e.g. a
+documented invariant or command that is now false — over cosmetic typos. Cite
+the contradicting `file:line` on both sides (the claim and the code) so the fix
+is unambiguous.

--- a/packages/dev-tools/codebase-sins/prompts/4-duplication.md
+++ b/packages/dev-tools/codebase-sins/prompts/4-duplication.md
@@ -1,0 +1,24 @@
+**Duplication** — multiple implementations of the same thing. Copy-pasted
+blocks, parallel implementations of one concept across packages, and repeated
+logic or constants that should live in one place.
+
+## Signals to look for in this repo
+
+- Near-identical functions or blocks that have drifted slightly (the classic
+  copy-paste-then-tweak), especially across the three floats
+  (`packages/webapp/`, `packages/node-server/`, `packages/chrome-extension/`)
+  which must stay dual-mode compatible.
+- Logic or constants repeated in more than one package that belong in
+  `@slicc/shared-ts` (the home for platform-agnostic primitives) — e.g.
+  duplicated secret-masking, parsing, or formatting helpers.
+- Two code paths doing the "same" thing for CLI vs. extension where a shared
+  helper already exists or could.
+- Repeated magic strings/constants (action SHAs, model id aliases, env-var
+  names, paths) defined independently in several spots.
+
+## What makes an instance "most impactful"
+
+Prefer duplication that has already started to diverge or sits in code that
+changes often, where a single shared definition would prevent the copies from
+falling out of sync. Quantify it (how many copies, which files) and name the
+single place the logic should live.

--- a/packages/dev-tools/codebase-sins/prompts/5-bloat.md
+++ b/packages/dev-tools/codebase-sins/prompts/5-bloat.md
@@ -1,0 +1,24 @@
+**Bloat** — things that have grown too big. Gigantic files, sprawling functions
+or classes, deep nesting, and modules that have accreted far too many
+responsibilities.
+
+## Signals to look for in this repo
+
+- Outsized files — quantify with line counts (e.g. `wc -l`). The orchestrator
+  (`packages/webapp/src/scoops/orchestrator.ts`), the shell
+  (`packages/webapp/src/shell/`), and the UI layer
+  (`packages/webapp/src/ui/`) are common places for files to balloon.
+- Single functions that are hundreds of lines long, or with deep nesting
+  (many levels of `if`/`for`/`try`), where the cyclomatic complexity makes them
+  hard to follow.
+- Classes/modules doing too much: a file exporting a grab-bag of unrelated
+  helpers, or one object owning many distinct concerns.
+- Supplemental-command files in `packages/webapp/src/shell/supplemental-commands/`
+  that mix many commands' logic into one oversized module.
+
+## What makes an instance "most impactful"
+
+Prefer the single biggest offender by a concrete measure (line count, function
+length, nesting depth) that also sits in frequently-edited code, where a clear
+split along responsibility lines would help. Include the measured numbers and a
+suggested decomposition.

--- a/packages/dev-tools/codebase-sins/prompts/6-necrophilia.md
+++ b/packages/dev-tools/codebase-sins/prompts/6-necrophilia.md
@@ -1,0 +1,25 @@
+**Necrophilia** — dead code kept alive. Unused or unexported functions,
+unreferenced files, commented-out blocks, unreachable branches, and exports
+that nobody imports.
+
+## Signals to look for in this repo
+
+- Run the repo's dead-code tooling if available: `npm run deadcode` (knip) is a
+  strong starting point — corroborate its findings with Grep before trusting
+  them.
+- Exported symbols with zero importers; internal functions defined but never
+  called. Search across `packages/*/src/` for the symbol name.
+- Whole files that nothing imports (orphaned modules left behind after a
+  refactor).
+- Large commented-out blocks of code (as opposed to explanatory comments).
+- Unreachable branches: conditions that can never be true, code after an
+  unconditional `return`/`throw`, dead `switch` cases.
+- Stale build/config entries pointing at files or scripts that no longer exist.
+
+## What makes an instance "most impactful"
+
+Prefer a clearly dead, self-contained unit (an unimported file or an unused
+exported function) where removal is obviously safe — verify there are genuinely
+no references (including dynamic `*.jsh`/`*.bsh` discovery and string-based
+lookups) before claiming it. Cite the symbol, its definition `file:line`, and
+the evidence of zero references.

--- a/packages/dev-tools/codebase-sins/prompts/7-paranoia.md
+++ b/packages/dev-tools/codebase-sins/prompts/7-paranoia.md
@@ -1,0 +1,26 @@
+**Paranoia** — overly defensive programming. Guard code for situations that
+cannot actually occur: redundant null checks on values that are always present,
+catch-all `try/catch` that swallows or masks real errors, and validation of
+impossible internal states. It adds noise, hides bugs, and inflates complexity.
+
+## Signals to look for in this repo
+
+- Null/undefined checks on values a type or invariant already guarantees are
+  present (e.g. re-checking a non-optional field right after constructing it).
+- Broad `try { … } catch { /* ignore */ }` blocks that swallow errors instead
+  of letting genuine failures surface — especially around tool calls, shell
+  execution, and CDP/transport code.
+- Defaulting/fallback branches for cases the caller can never produce, where the
+  fallback silently hides a real contract violation.
+- Validation of internal state that is fully controlled by the same module
+  (defensive checks aimed at "impossible" inputs from trusted internal callers).
+- Repeated belt-and-braces guards layered at multiple levels for the same
+  condition.
+
+## What makes an instance "most impactful"
+
+Prefer defensive code that actively hides failures — e.g. a catch-all that turns
+a real error into a silent no-op on a hot path — over harmless redundancy.
+Explain why the guarded condition cannot occur (or why the swallow is harmful)
+and cite the `file:line`, with a concrete tightening (remove the guard, narrow
+the catch, or surface the error).

--- a/packages/dev-tools/codebase-sins/select-sin.mjs
+++ b/packages/dev-tools/codebase-sins/select-sin.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/*
+ * Codebase "seven sins" rotation — CLI (I/O).
+ *
+ * Resolves the sin of the day (honouring an optional workflow_dispatch
+ * override), reads its per-sin prompt body, composes the final prompt with the
+ * shared filing boilerplate, and writes `sin_id`, `sin_name`, `sin_label`, and
+ * the multi-line `prompt` to `$GITHUB_OUTPUT`. Pure logic lives in `sins.mjs`
+ * (unit-tested); this file only does I/O. Mirrors
+ * `packages/dev-tools/rum-error-triage/triage-rum-errors.mjs`.
+ *
+ * Env:
+ *   SIN_OVERRIDE   optional workflow_dispatch override (1-7, or a sin name/id)
+ *   GITHUB_OUTPUT  Actions output file (when present)
+ */
+import { randomUUID } from 'node:crypto';
+import { appendFileSync, readFileSync } from 'node:fs';
+import { buildPrompt, resolveSin } from './sins.mjs';
+
+/** Append `key=value` to $GITHUB_OUTPUT, using the heredoc form for multi-line values. */
+function setOutput(key, value) {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file) return;
+  if (value.includes('\n')) {
+    const delim = `EOF_${randomUUID().replace(/-/g, '')}`;
+    appendFileSync(file, `${key}<<${delim}\n${value}\n${delim}\n`);
+  } else {
+    appendFileSync(file, `${key}=${value}\n`);
+  }
+}
+
+function main() {
+  const sin = resolveSin(process.env.SIN_OVERRIDE);
+  const body = readFileSync(sin.promptFile, 'utf8');
+  const prompt = buildPrompt(sin, body);
+
+  setOutput('sin_id', sin.id);
+  setOutput('sin_name', sin.name);
+  setOutput('sin_label', sin.label);
+  setOutput('prompt', prompt);
+
+  console.log(`🎯 Sin of the day: ${sin.name} (${sin.label})`);
+  console.log(`   ${sin.summary}`);
+}
+
+main();

--- a/packages/dev-tools/codebase-sins/sins.mjs
+++ b/packages/dev-tools/codebase-sins/sins.mjs
@@ -100,7 +100,7 @@ export function selectSinOfDay(date = new Date()) {
 
 /**
  * Resolve a workflow_dispatch override that may be a 1-7 rank or a sin
- * name/id. Falls back to `selectSinOfDay()` when empty or invalid. Pure.
+ * name/id. Falls back to `selectSinOfDay()` when empty or invalid. No I/O.
  * @param {string|number|null|undefined} override
  * @returns {(typeof SINS)[number]}
  */

--- a/packages/dev-tools/codebase-sins/sins.mjs
+++ b/packages/dev-tools/codebase-sins/sins.mjs
@@ -87,9 +87,9 @@ function dayOfYearUTC(d) {
 }
 
 /**
- * The sin of the given day via day-of-year (UTC) mod 7. Deterministic, pure,
- * no I/O. Drifts by one each day, independent of weekday, and cycles through
- * all seven.
+ * The sin of the given day via day-of-year (UTC) mod 7. Deterministic for a
+ * given `date` argument (defaults to the current date). Drifts by one each day,
+ * independent of weekday, and cycles through all seven.
  * @param {Date} [date]
  * @returns {(typeof SINS)[number]}
  */

--- a/packages/dev-tools/codebase-sins/sins.mjs
+++ b/packages/dev-tools/codebase-sins/sins.mjs
@@ -1,0 +1,172 @@
+/*
+ * Codebase "seven sins" rotation — pure logic.
+ *
+ * A nightly job hunts for ONE concrete instance of the "sin of the day",
+ * rotating through seven agentic-codebase failure modes (ordered by severity).
+ * This module is intentionally free of I/O so it can be unit-tested in
+ * isolation — the `gh` calls and `$GITHUB_OUTPUT` writes live in
+ * `select-sin.mjs`. Mirrors `packages/dev-tools/rum-error-triage/lib.mjs`.
+ */
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PROMPTS_DIR = join(HERE, 'prompts');
+
+/** Build one sin record. `n` is the 1-based rank used in the prompt filename. */
+function sin(n, id, name, summary) {
+  return {
+    id,
+    name,
+    label: `debt:${id}`,
+    promptFile: join(PROMPTS_DIR, `${n}-${id}.md`),
+    summary,
+  };
+}
+
+/**
+ * The seven sins, ordered by the severity ranking. The rotation maps
+ * `dayOfYearUTC % 7` onto this array, so the sin drifts by one each day and
+ * cycles through the full set independently of the weekday.
+ * @type {ReadonlyArray<{id: string, name: string, label: string, promptFile: string, summary: string}>}
+ */
+export const SINS = [
+  sin(
+    1,
+    'complicatification',
+    'Complicatification',
+    'Easy things done the hard way: needless abstraction, clever one-liners, reinvented stdlib, over-engineered patterns.'
+  ),
+  sin(
+    2,
+    'entanglement',
+    'Entanglement',
+    'Muddy module boundaries and wrong call directions: layering violations, circular deps, god objects.'
+  ),
+  sin(
+    3,
+    'drift',
+    'Drift',
+    'Code vs. comments/docs/names out of sync: contradicting comments, stale docs, lying TODOs.'
+  ),
+  sin(
+    4,
+    'duplication',
+    'Duplication',
+    'Multiple implementations of the same thing: copy-paste, parallel implementations, repeated constants.'
+  ),
+  sin(
+    5,
+    'bloat',
+    'Bloat',
+    'Gigantic files/functions/classes, deep nesting, modules doing too much.'
+  ),
+  sin(
+    6,
+    'necrophilia',
+    'Necrophilia',
+    'Dead code: unused functions, unreferenced files, commented-out code, exports nobody imports.'
+  ),
+  sin(
+    7,
+    'paranoia',
+    'Paranoia',
+    'Overly defensive programming: redundant null checks, catch-all try/catch, validation of impossible states.'
+  ),
+];
+
+/**
+ * The 1-based UTC day-of-year for a date (Jan 1 → 1).
+ * @param {Date} d
+ * @returns {number}
+ */
+function dayOfYearUTC(d) {
+  const startOfYear = Date.UTC(d.getUTCFullYear(), 0, 1);
+  const today = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  return Math.floor((today - startOfYear) / 86_400_000) + 1;
+}
+
+/**
+ * The sin of the given day via day-of-year (UTC) mod 7. Deterministic, pure,
+ * no I/O. Drifts by one each day, independent of weekday, and cycles through
+ * all seven.
+ * @param {Date} [date]
+ * @returns {(typeof SINS)[number]}
+ */
+export function selectSinOfDay(date = new Date()) {
+  const d = date instanceof Date ? date : new Date(date);
+  return SINS[dayOfYearUTC(d) % SINS.length];
+}
+
+/**
+ * Resolve a workflow_dispatch override that may be a 1-7 rank or a sin
+ * name/id. Falls back to `selectSinOfDay()` when empty or invalid. Pure.
+ * @param {string|number|null|undefined} override
+ * @returns {(typeof SINS)[number]}
+ */
+export function resolveSin(override) {
+  if (override === null || override === undefined) return selectSinOfDay();
+  const raw = String(override).trim();
+  if (raw === '') return selectSinOfDay();
+  if (/^[0-9]+$/.test(raw)) {
+    const n = Number(raw);
+    if (n >= 1 && n <= SINS.length) return SINS[n - 1];
+    return selectSinOfDay();
+  }
+  const key = raw.toLowerCase();
+  const match = SINS.find((s) => s.id === key || s.name.toLowerCase() === key);
+  return match ?? selectSinOfDay();
+}
+
+/**
+ * The shared filing/dedup/header boilerplate, written ONCE here so the seven
+ * prompt files only carry their per-sin body. Interpolates the day's sin id,
+ * name, and label into the instructions Claude follows.
+ * @param {(typeof SINS)[number]} s
+ * @returns {string}
+ */
+function filingInstructions(s) {
+  return `## How to investigate and file
+
+You are auditing THIS repository for a single, concrete instance of the sin
+above. Work **read-only**: use Read, Grep, Glob, and \`git\` to gather evidence;
+do not edit code.
+
+1. Find the **single most impactful** instance of this sin. One issue per run —
+   pick the worst offender, not a list. A noisy or wrong issue is worse than
+   none, so be conservative.
+2. **Before filing, steer clear of work already in flight.** Run:
+   - \`gh issue list --state open\`
+   - \`gh pr list --state open\`
+   - \`gh issue list --search "agentic-debt:${s.id} in:body" --state all\`
+   If the file or area is already covered by an open issue or open PR, or a
+   prior issue already documents this exact instance, **skip and file nothing**.
+3. If — and only if — you found a solid, un-covered instance, file **exactly
+   one** issue with \`gh issue create\`:
+   - a concise, specific title;
+   - a body containing: the \`file:line\` evidence, why it exemplifies
+     **${s.name}**, the occurrence/scope, and a concrete suggested remediation;
+   - the exact marker line on its own: \`<!-- agentic-debt:${s.id} -->\`;
+   - \`--label agentic-debt --label ${s.label}\`.
+4. If nothing solid is found, **file nothing** and print a one-line reason why.`;
+}
+
+/**
+ * Compose the final prompt = shared filing/dedup/header boilerplate + the
+ * per-sin body. Pure; `promptBody` is the file content read by the CLI.
+ * @param {(typeof SINS)[number]} s the day's sin
+ * @param {string} promptBody the per-sin body loaded from `s.promptFile`
+ * @returns {string}
+ */
+export function buildPrompt(s, promptBody) {
+  return `# Agentic-debt triage — Sin of the day: ${s.name}
+
+> ${s.summary}
+
+## What to hunt for
+
+${String(promptBody ?? '').trim()}
+
+${filingInstructions(s)}
+`;
+}


### PR DESCRIPTION
## Summary

Adds a nightly GitHub Actions job that uses `claude-code-action` (Bedrock) to hunt for ONE concrete instance of the **sin of the day** — rotating through seven agentic-codebase failure modes — and files a single GitHub issue with the finding. Mirrors the existing RUM→issue pipeline (`.github/workflows/rum-error-triage.yml`).

## The seven sins (rotation = day-of-year UTC mod 7)

| idx | Sin | What Claude hunts for |
|---|---|---|
| 0 | Complicatification | Easy things done the hard way; incomprehensible control flow, needless abstraction, over-engineering. |
| 1 | Entanglement | Muddy module boundaries / wrong call directions, circular deps, god objects. |
| 2 | Drift | Code vs. comments/docstrings/names/docs out of sync. |
| 3 | Duplication | Multiple implementations of the same thing / copy-paste across packages. |
| 4 | Bloat | Gigantic files/functions/classes; deep nesting. |
| 5 | Necrophilia | Dead code: unused exports, unreferenced files, commented-out code. |
| 6 | Paranoia | Overly defensive programming: redundant null checks, catch-all try/catch. |

The sin index is `dayOfYearUTC % 7`, so it drifts by one each day, is independent of weekday, and cycles through all seven.

## What's included

**`packages/dev-tools/codebase-sins/`** (plain ESM, no new deps)
- `sins.mjs` — `SINS` (7 ordered defs), pure `selectSinOfDay(date)` (day-of-year UTC mod 7), `resolveSin(override)`, and `buildPrompt(sin, body)` (shared filing/dedup boilerplate written ONCE + per-sin body).
- `prompts/<n>-<id>.md` — seven per-sin bodies (no boilerplate).
- `select-sin.mjs` — CLI that resolves the sin (honors `SIN_OVERRIDE`) and writes `sin_id`/`sin_name`/`sin_label`/multi-line `prompt` to `$GITHUB_OUTPUT`.
- `lib.test.mjs` — unit tests (rotation coverage, determinism, override parsing, prompt composition, prompt files exist).
- `README.md`.

**`.github/workflows/agentic-debt-triage.yml`**
- `schedule` cron `0 5 * * *` (offset from RUM's 03:00) + `workflow_dispatch` (`sin` override 1-7/name, `dry_run` boolean).
- Ensures `agentic-debt` + seven `debt:<id>` labels.
- Runs `select-sin.mjs`, then `claude-code-action` via Bedrock (skipped when `dry_run`).
- The composed prompt instructs Claude to investigate read-only, check open issues/PRs and SKIP already-covered areas, dedup via a `<!-- agentic-debt:<id> -->` marker, and file exactly ONE issue (file:line evidence + rationale + remediation), being conservative.

## Auth & security
- Reuses existing Bedrock secrets/vars — **no new secrets** (`AWS_BEARER_TOKEN_BEDROCK`, region from `RUM_AWS_REGION`, model `SINS_BEDROCK_MODEL || RUM_BEDROCK_MODEL` fallback).
- All three third-party action SHAs are **identical** to `rum-error-triage.yml`.
- Permissions scoped to `contents: read`, `issues: write`, `pull-requests: read`.
- `rum-error-triage.yml` is unchanged.

## Verification
- `npm run test` — dev-tools vitest project passes.
- `npm run lint:ci` clean; `actionlint` on the new workflow clean.
- CLI smoke: `SIN_OVERRIDE=6 node packages/dev-tools/codebase-sins/select-sin.mjs` prints Necrophilia + composed prompt.
- Independently reviewed by a verifier agent: APPROVED (high confidence) against every acceptance criterion.

## How to try it
`workflow_dispatch` with `sin=6` + `dry_run=true` to preview selection without filing an issue.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author