### PR TITLE
ci: grant id-token: write to agentic-debt-triage

### DIFF
--- a/.github/workflows/agentic-debt-triage.yml
+++ b/.github/workflows/agentic-debt-triage.yml
@@ -51,6 +51,7 @@ permissions:
   contents: read # read-only investigation of the codebase
   issues: write # file the agentic-debt issue
   pull-requests: read # so Claude can `gh pr list` to avoid covered areas
+  id-token: write # claude-code-action fetches an OIDC token during GitHub token setup
 
 jobs:
   triage:


### PR DESCRIPTION
## Why

A manual `workflow_dispatch` of `agentic-debt-triage` (run [26866894434](https://github.com/ai-ecoverse/slicc/actions/runs/26866894434)) failed at the **Hunt the sin and file an issue** step:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

`claude-code-action` v1 fetches an OIDC token during its GitHub token setup, which requires `id-token: write`. This workflow only granted `contents: read`, `issues: write`, `pull-requests: read`.

## Change

Add `id-token: write` to the job permissions, matching the existing `rum-error-triage.yml` workflow.