### PR TITLE
fix(extension): route OAuth token storage (mask + delete) through the SW (#847)

### DIFF
--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -348,7 +348,7 @@ Each provider's hardcoded `oauthTokenDomains` is the immutable default safelist.
 - the **OAuth domains** tab on the options page (`secrets.html`)
 - direct `localStorage` edit of `slicc_oauth_extra_domains` at the extension origin
 
-The extras are read by `saveOAuthAccount` in `provider-settings.ts` and merged with provider defaults (deduped case-insensitively) before being pushed to `chrome.storage.local`'s `oauth.<id>.token_DOMAINS`. Page-side `oauth-bootstrap` re-pushes the merged list on every page load, so newly-added extras apply on next side-panel reload.
+The extras are read by `saveOAuthAccount` in `provider-settings.ts` and merged with provider defaults (deduped case-insensitively), then sent in the `secrets.mask-oauth-token` SW message — the service worker (which owns `chrome.storage`; `oauth-token` runs in the offscreen document, which has none — #847) writes `oauth.<id>.token` + `oauth.<id>.token_DOMAINS`. Page-side `oauth-bootstrap` re-pushes the merged list on every page load, so newly-added extras apply on next side-panel reload.
 
 ## Automated CDP Smoke Test
 

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -1212,8 +1212,27 @@ chrome.runtime.onMessage.addListener(
       typeof msg.providerId === 'string'
     ) {
       const providerId = msg.providerId;
+      const accessToken =
+        'accessToken' in msg && typeof (msg as { accessToken?: unknown }).accessToken === 'string'
+          ? (msg as { accessToken: string }).accessToken
+          : undefined;
+      const domains =
+        'domains' in msg && typeof (msg as { domains?: unknown }).domains === 'string'
+          ? (msg as { domains: string }).domains
+          : undefined;
       (async () => {
         try {
+          // #847: the caller may be the offscreen document, which has
+          // `chrome.runtime` but NOT `chrome.storage` (MV3 quirk — same reason
+          // `secrets.set` proxies through the SW). Write the secret here, where
+          // the SW owns `chrome.storage`, before building the pipeline that
+          // masks it. `domains` is the comma-joined `_DOMAINS` companion.
+          if (accessToken && domains) {
+            await chrome.storage.local.set({
+              [`oauth.${providerId}.token`]: accessToken,
+              [`oauth.${providerId}.token_DOMAINS`]: domains,
+            });
+          }
           const pipeline = await buildSecretsPipeline();
           await pipeline.reload();
           const name = `oauth.${providerId}.token`;

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -1242,7 +1242,11 @@ chrome.runtime.onMessage.addListener(
           // pipeline stopped emitting it). Surface it so the page side can
           // distinguish "not warm yet" from "wrote it and still missing".
           if (accessToken && domains && !found) {
+            // Real fault (not a cold miss): surface a reason so the page can
+            // distinguish it and the give-up log isn't reason-less (#847).
             console.warn('[sw] secrets.mask-oauth-token: entry missing after write', { name });
+            sendResponse({ maskedValue: undefined, error: 'entry missing after write' });
+            return;
           }
           sendResponse({ maskedValue: found?.maskedValue });
         } catch (err) {

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -1237,6 +1237,13 @@ chrome.runtime.onMessage.addListener(
           await pipeline.reload();
           const name = `oauth.${providerId}.token`;
           const found = pipeline.getMaskedEntries().find((e) => e.name === name);
+          // We just wrote the secret above, so a missing entry here is NOT a
+          // cold-start miss — it's a real fault (write didn't land, or the
+          // pipeline stopped emitting it). Surface it so the page side can
+          // distinguish "not warm yet" from "wrote it and still missing".
+          if (accessToken && domains && !found) {
+            console.warn('[sw] secrets.mask-oauth-token: entry missing after write', { name });
+          }
           sendResponse({ maskedValue: found?.maskedValue });
         } catch (err) {
           console.error('[sw] secrets.mask-oauth-token failed', err);

--- a/packages/chrome-extension/tests/service-worker-secrets.test.ts
+++ b/packages/chrome-extension/tests/service-worker-secrets.test.ts
@@ -328,4 +328,30 @@ describe('service-worker fetch-proxy.fetch + secrets handlers', () => {
     expect(response.maskedValue).toBeUndefined();
     expect(typeof response.error).toBe('string');
   });
+
+  it('returns { error: "entry missing after write" } when the entry is absent post-write (real fault, not cold miss)', async () => {
+    await import('../src/service-worker.js');
+    // No-op the write so the entry is genuinely missing after "writing" — the
+    // page must be able to tell this from a cold-start miss, so it gets an error.
+    (globalThis as any).chrome.storage.local.set = vi.fn(async () => {});
+    let response: any;
+    for (const l of messageListeners) {
+      const result = l(
+        {
+          type: 'secrets.mask-oauth-token',
+          providerId: 'ghost',
+          accessToken: 't',
+          domains: 'x.com',
+        },
+        {},
+        (r: any) => {
+          response = r;
+        }
+      );
+      if (result === true) break;
+    }
+    await new Promise((r) => setTimeout(r, 30));
+    expect(response.maskedValue).toBeUndefined();
+    expect(response.error).toBe('entry missing after write');
+  });
 });

--- a/packages/chrome-extension/tests/service-worker-secrets.test.ts
+++ b/packages/chrome-extension/tests/service-worker-secrets.test.ts
@@ -248,4 +248,84 @@ describe('service-worker fetch-proxy.fetch + secrets handlers', () => {
     expect(typeof response.maskedValue).toBe('string');
     expect(response.maskedValue.length).toBeGreaterThan(0);
   });
+
+  // #847: the offscreen caller (where oauth-token runs) has no chrome.storage,
+  // so the SW must do the write from the message. This is the line that
+  // actually fixes the bug.
+  it('secrets.mask-oauth-token writes oauth.<id>.token + _DOMAINS from the message, then masks', async () => {
+    await import('../src/service-worker.js');
+    // `testprov` is NOT pre-seeded — the SW-side write is load-bearing here.
+    expect(storageMap['oauth.testprov.token']).toBeUndefined();
+    let response: any;
+    for (const l of messageListeners) {
+      const result = l(
+        {
+          type: 'secrets.mask-oauth-token',
+          providerId: 'testprov',
+          accessToken: 'tok_real',
+          domains: 'example.com,api.example.com',
+        },
+        {},
+        (r: any) => {
+          response = r;
+        }
+      );
+      if (result === true) break;
+    }
+    await new Promise((r) => setTimeout(r, 30));
+    expect(storageMap['oauth.testprov.token']).toBe('tok_real');
+    expect(storageMap['oauth.testprov.token_DOMAINS']).toBe('example.com,api.example.com');
+    expect(typeof response.maskedValue).toBe('string');
+    expect(response.maskedValue.length).toBeGreaterThan(0);
+  });
+
+  it('secrets.mask-oauth-token skips the OAuth-token write when accessToken/domains are absent (back-compat)', async () => {
+    await import('../src/service-worker.js');
+    const setSpy = (globalThis as any).chrome.storage.local.set;
+    setSpy.mockClear();
+    let response: any;
+    for (const l of messageListeners) {
+      const result = l({ type: 'secrets.mask-oauth-token', providerId: 'github' }, {}, (r: any) => {
+        response = r;
+      });
+      if (result === true) break;
+    }
+    await new Promise((r) => setTimeout(r, 30));
+    // Old-shape message must NOT write the OAuth token keys (an unrelated
+    // session-id write may occur — assert specifically, not "never called").
+    const wroteOAuthKey = setSpy.mock.calls.some(
+      (call: any[]) => call[0] && 'oauth.github.token' in call[0]
+    );
+    expect(wroteOAuthKey).toBe(false);
+    // The pre-seeded oauth.github.token still masks.
+    expect(typeof response.maskedValue).toBe('string');
+  });
+
+  it('secrets.mask-oauth-token returns { error } (not a throw) when the storage write fails', async () => {
+    await import('../src/service-worker.js');
+    (globalThis as any).chrome.storage.local.set = vi.fn(async () => {
+      throw new Error('quota exceeded');
+    });
+    let response: any;
+    for (const l of messageListeners) {
+      const result = l(
+        {
+          type: 'secrets.mask-oauth-token',
+          providerId: 'failprov',
+          accessToken: 't',
+          domains: 'x.com',
+        },
+        {},
+        (r: any) => {
+          response = r;
+        }
+      );
+      if (result === true) break;
+    }
+    await new Promise((r) => setTimeout(r, 30));
+    // The page-side retry/give-up logic depends on the SW surfacing { error },
+    // not throwing across the message boundary.
+    expect(response.maskedValue).toBeUndefined();
+    expect(typeof response.error).toBe('string');
+  });
 });

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -923,6 +923,45 @@ export async function maskOAuthTokenWithRetry(
   return undefined;
 }
 
+/**
+ * Register an OAuth token's masked replica via the service worker and persist
+ * the masked value on the account.
+ *
+ * #847: `oauth-token` runs in the offscreen document, which has `chrome.runtime`
+ * but NOT `chrome.storage`. So the token + domains must travel IN the SW message
+ * — the SW (which owns `chrome.storage`) writes them and returns the masked
+ * value. The caller must never touch `chrome.storage` directly (it throws
+ * "Cannot read properties of undefined (reading 'local')" in offscreen). Pure +
+ * injectable so it is unit-testable without `chrome`.
+ */
+export async function persistOAuthMaskViaServiceWorker(
+  opts: { providerId: string; accessToken: string; domains: string[] },
+  deps: {
+    sendMaskRequest: (payload: {
+      providerId: string;
+      accessToken: string;
+      domains: string;
+    }) => Promise<{ maskedValue?: string; error?: string }>;
+    getAccounts: () => Account[];
+    saveAccounts: (accounts: Account[]) => Promise<void>;
+  },
+  maskOpts?: { attempts?: number; delayMs?: number; sleep?: (ms: number) => Promise<void> }
+): Promise<void> {
+  const payload = {
+    providerId: opts.providerId,
+    accessToken: opts.accessToken,
+    domains: opts.domains.join(','),
+  };
+  const maskedValue = await maskOAuthTokenWithRetry(() => deps.sendMaskRequest(payload), maskOpts);
+  if (!maskedValue) return;
+  const accounts = deps.getAccounts();
+  const acct = accounts.find((a) => a.providerId === opts.providerId);
+  if (acct) {
+    acct.maskedValue = maskedValue;
+    await deps.saveAccounts(accounts);
+  }
+}
+
 /** Save an OAuth account (used by external providers after token exchange). */
 export async function saveOAuthAccount(opts: {
   providerId: string;
@@ -969,51 +1008,47 @@ export async function saveOAuthAccount(opts: {
   const isExtension = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
   try {
     if (isExtension) {
-      await chrome.storage.local.set({
-        [`oauth.${opts.providerId}.token`]: opts.accessToken,
-        [`oauth.${opts.providerId}.token_DOMAINS`]: domains.join(','),
-      });
-      const sendMaskRequest = () =>
+      // #847: `oauth-token` runs in the offscreen document, which has
+      // `chrome.runtime` but NOT `chrome.storage` — a direct
+      // `chrome.storage.local.set` here throws "Cannot read properties of
+      // undefined (reading 'local')", the catch swallows it, and the account is
+      // left unmasked. Send the token + domains IN the message so the service
+      // worker (which owns `chrome.storage`) writes them, then masks. The retry
+      // also covers a genuinely cold SW that isn't ready on the first round-trip.
+      const sendMaskRequest = (payload: {
+        providerId: string;
+        accessToken: string;
+        domains: string;
+      }) =>
         new Promise<{ maskedValue?: string; error?: string }>((resolve) => {
-          chrome.runtime.sendMessage(
-            { type: 'secrets.mask-oauth-token', providerId: opts.providerId },
-            (r: any) => {
-              // Chrome sets `lastError` AND invokes the callback with
-              // `undefined` when the SW is unreachable / message port closed /
-              // listener crashed. Without explicit handling the empty
-              // resolve looks identical to "SW returned no maskedValue".
-              if (chrome.runtime.lastError) {
-                log.error('SW mask-oauth-token transport failed', {
-                  providerId: opts.providerId,
-                  error: chrome.runtime.lastError.message,
-                });
-              }
-              // The SW handler returns `{ maskedValue: undefined, error: '<msg>' }`
-              // on pipeline-build failure (see service-worker.ts secrets.mask-oauth-token
-              // catch). Surface that — matching the CLI branch's "OAuth replica POST
-              // non-ok" logging — so a failure isn't invisible from the page side.
-              if (r?.error) {
-                log.warn('SW mask-oauth-token returned error', {
-                  providerId: opts.providerId,
-                  error: r.error,
-                });
-              }
-              resolve(r ?? {});
+          chrome.runtime.sendMessage({ type: 'secrets.mask-oauth-token', ...payload }, (r: any) => {
+            // Chrome sets `lastError` AND invokes the callback with
+            // `undefined` when the SW is unreachable / message port closed /
+            // listener crashed. Without explicit handling the empty
+            // resolve looks identical to "SW returned no maskedValue".
+            if (chrome.runtime.lastError) {
+              log.error('SW mask-oauth-token transport failed', {
+                providerId: opts.providerId,
+                error: chrome.runtime.lastError.message,
+              });
             }
-          );
+            // The SW handler returns `{ maskedValue: undefined, error: '<msg>' }`
+            // on storage-write / pipeline-build failure (see service-worker.ts
+            // secrets.mask-oauth-token catch). Surface that — matching the CLI
+            // branch's "OAuth replica POST non-ok" logging.
+            if (r?.error) {
+              log.warn('SW mask-oauth-token returned error', {
+                providerId: opts.providerId,
+                error: r.error,
+              });
+            }
+            resolve(r ?? {});
+          });
         });
-      // Cold-SW retry (#847): a freshly-opened panel's service worker can return
-      // no maskedValue on the first round-trip before its secrets pipeline is
-      // warm. Retry briefly instead of silently leaving the account unmasked.
-      const maskedValue = await maskOAuthTokenWithRetry(sendMaskRequest);
-      if (maskedValue) {
-        const accounts = getAccounts();
-        const acct = accounts.find((a) => a.providerId === opts.providerId);
-        if (acct) {
-          acct.maskedValue = maskedValue;
-          await saveAccountsAsync(accounts);
-        }
-      }
+      await persistOAuthMaskViaServiceWorker(
+        { providerId: opts.providerId, accessToken: opts.accessToken, domains },
+        { sendMaskRequest, getAccounts, saveAccounts: saveAccountsAsync }
+      );
     } else if (!(globalThis as Record<string, unknown>).__slicc_connect_mode) {
       const r = await fetch('/api/secrets/oauth-update', {
         method: 'POST',

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -765,30 +765,42 @@ export function addAccount(
   saveAccounts(accounts);
 }
 
-export async function removeAccount(providerId: string): Promise<void> {
-  // For OAuth providers, run the full logout sequence first (token revocation,
-  // IdP session clear, and replica removal). removeAccount then finishes by
-  // deleting the account entry entirely.
-  const accountToRemove = getAccounts().find((a) => a.providerId === providerId);
-  const configToRemove = getProviderConfig(providerId);
-  if (accountToRemove && configToRemove?.isOAuth) {
-    await logoutOAuthAccount(providerId);
-  }
-
-  // Clear the replica BEFORE wiping the local Account
+/**
+ * Remove an OAuth token's replica (the `oauth.<id>.token` + `_DOMAINS` pair).
+ *
+ * #847 (remove-path twin): `removeAccount`/`logoutOAuthAccount` are reachable
+ * from the offscreen shell (`mcp delete`, provider logout), which has
+ * `chrome.runtime` but NOT `chrome.storage` — a direct
+ * `chrome.storage.local.remove` throws there. Route the delete through the SW
+ * `secrets.delete` message (whose `deleteSecret` removes both keys), mirroring
+ * the write path. CLI deletes the node-server replica. Fail-open with a logged
+ * breadcrumb (the local Account is wiped by the caller regardless).
+ */
+async function deleteOAuthReplica(providerId: string): Promise<void> {
   const isExtension = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
   try {
     if (isExtension) {
-      await chrome.storage.local.remove([
-        `oauth.${providerId}.token`,
-        `oauth.${providerId}.token_DOMAINS`,
-      ]);
+      const resp = await new Promise<{ ok?: boolean; error?: string }>((resolve) => {
+        chrome.runtime.sendMessage(
+          { type: 'secrets.delete', name: `oauth.${providerId}.token` },
+          (r: unknown) => {
+            if (chrome.runtime.lastError) {
+              log.error('SW secrets.delete transport failed', {
+                providerId,
+                error: chrome.runtime.lastError.message,
+              });
+            }
+            resolve((r as { ok?: boolean; error?: string } | undefined) ?? {});
+          }
+        );
+      });
+      if (resp.error) {
+        log.error('SW secrets.delete returned error', { providerId, error: resp.error });
+      }
     } else {
       const r = await fetch(`/api/secrets/oauth/${providerId}`, { method: 'DELETE' });
-      // 404 is benign (already deleted). Anything else non-2xx means the
-      // server still has the OAuth token in its OauthSecretStore — surface
-      // for operational visibility so the user knows local clear ≠ server
-      // clear in that path.
+      // 404 is benign (already deleted). Anything else non-2xx means the server
+      // still has the OAuth token — surface so local clear ≠ server clear is visible.
       if (!r.ok && r.status !== 404) {
         log.warn('OAuth replica DELETE non-ok', { providerId, status: r.status });
       }
@@ -800,6 +812,21 @@ export async function removeAccount(providerId: string): Promise<void> {
       error: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+export async function removeAccount(providerId: string): Promise<void> {
+  // For OAuth providers, run the full logout sequence first (token revocation,
+  // IdP session clear, and replica removal). removeAccount then finishes by
+  // deleting the account entry entirely.
+  const accountToRemove = getAccounts().find((a) => a.providerId === providerId);
+  const configToRemove = getProviderConfig(providerId);
+  if (accountToRemove && configToRemove?.isOAuth) {
+    await logoutOAuthAccount(providerId);
+  }
+
+  // Clear the replica BEFORE wiping the local Account (SW-proxied in the
+  // extension so it works from the offscreen shell — see deleteOAuthReplica).
+  await deleteOAuthReplica(providerId);
 
   // Use the worker-safe async variant so `mcp delete` (which runs in
   // the kernel worker) writes through panel-rpc to real page
@@ -875,38 +902,25 @@ export async function logoutOAuthAccount(providerId: string): Promise<void> {
   });
   await saveAccountsAsync(updated);
 
-  // 4. Remove token replica from node-server / extension storage
-  const isExt = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
-  try {
-    if (isExt) {
-      await chrome.storage.local.remove([
-        `oauth.${providerId}.token`,
-        `oauth.${providerId}.token_DOMAINS`,
-      ]);
-    } else {
-      const r = await fetch(`/api/secrets/oauth/${providerId}`, { method: 'DELETE' });
-      if (!r.ok && r.status !== 404) {
-        log.warn('OAuth replica DELETE non-ok during logout', { providerId, status: r.status });
-      }
-    }
-  } catch (err) {
-    log.error('OAuth replica removal failed during logout', {
-      providerId,
-      isExtension: isExt,
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
+  // 4. Remove token replica from node-server / extension storage (SW-proxied
+  //    in the extension so it works from the offscreen shell — see #847).
+  await deleteOAuthReplica(providerId);
 }
 
 /**
  * Run the service-worker `secrets.mask-oauth-token` round-trip with a small
- * bounded retry. A freshly-opened side panel can hit a cold SW whose secrets
- * pipeline isn't warm yet, so the FIRST round-trip returns no `maskedValue`
- * (issue #847). Without a retry, `saveOAuthAccount` gave up and `oauth-token`
- * reported "no masked value" until the panel was reopened (the boot-time
- * oauth-bootstrap re-push happened to warm the SW). Retry a few times with a
- * short backoff. Pure + injectable (`send`/`sleep`) so it is unit-testable
- * without `chrome`.
+ * bounded retry. Opening a fresh side panel can cold-start the SW whose secrets
+ * pipeline isn't warm yet, so the first round-trip (issued from the offscreen
+ * shell, where `oauth-token` runs) can come back with no `maskedValue`
+ * (issue #847). Retry a few times with a short backoff. Defense-in-depth: the
+ * primary #847 cause was the offscreen `chrome.storage` gap, fixed by moving the
+ * write into the SW (see `persistOAuthMaskViaServiceWorker`).
+ *
+ * @param send Issues one round-trip, resolving `{ maskedValue?, error? }`.
+ * @param opts `attempts` (floored to >=1, default 3), `delayMs` (default 150),
+ *   and an injectable `sleep`; no sleep after the final attempt.
+ * @returns the masked value, or `undefined` if every attempt was empty (never
+ *   throws — the caller decides how to surface the give-up). Pure + injectable.
  */
 export async function maskOAuthTokenWithRetry(
   send: () => Promise<{ maskedValue?: string; error?: string }>,
@@ -928,11 +942,12 @@ export async function maskOAuthTokenWithRetry(
  * the masked value on the account.
  *
  * #847: `oauth-token` runs in the offscreen document, which has `chrome.runtime`
- * but NOT `chrome.storage`. So the token + domains must travel IN the SW message
- * — the SW (which owns `chrome.storage`) writes them and returns the masked
- * value. The caller must never touch `chrome.storage` directly (it throws
- * "Cannot read properties of undefined (reading 'local')" in offscreen). Pure +
- * injectable so it is unit-testable without `chrome`.
+ * but NOT `chrome.storage`. So the token + domains travel IN the SW message —
+ * the SW (which owns `chrome.storage`) writes them and returns the masked value.
+ * This helper deliberately keeps `chrome.storage` out of the offscreen caller;
+ * the remove path does the same via `deleteOAuthReplica`. Returns silently
+ * (after a `log.error` breadcrumb) if masking never succeeds, and no-ops if the
+ * account row is gone. Pure + injectable so it is unit-testable without `chrome`.
  */
 export async function persistOAuthMaskViaServiceWorker(
   opts: { providerId: string; accessToken: string; domains: string[] },
@@ -953,7 +968,15 @@ export async function persistOAuthMaskViaServiceWorker(
     domains: opts.domains.join(','),
   };
   const maskedValue = await maskOAuthTokenWithRetry(() => deps.sendMaskRequest(payload), maskOpts);
-  if (!maskedValue) return;
+  if (!maskedValue) {
+    // Don't fail silently: the account stays unmasked and `oauth-token` will
+    // report "no masked value". log.warn is dropped at the prod ERROR level, so
+    // this give-up breadcrumb must be log.error to be visible at all (#847).
+    log.error('OAuth mask give-up: no masked value after retries', {
+      providerId: opts.providerId,
+    });
+    return;
+  }
   const accounts = deps.getAccounts();
   const acct = accounts.find((a) => a.providerId === opts.providerId);
   if (acct) {
@@ -990,7 +1013,8 @@ export async function saveOAuthAccount(opts: {
   // worker writes through `panel-rpc` to real page localStorage.
   await saveAccountsAsync(accounts);
 
-  // Sync to replica (CLI: node-server /api/secrets/oauth-update; Extension: SW via chrome.storage.local + runtime.sendMessage)
+  // Sync to replica (CLI: node-server /api/secrets/oauth-update; Extension: SW
+  // message — the SW owns the chrome.storage write, see persistOAuthMaskViaServiceWorker)
   const cfg = getProviderConfig(opts.providerId);
   const defaults = cfg?.oauthTokenDomains ?? [];
   const extras = getExtraOAuthDomains(opts.providerId);

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -919,35 +919,39 @@ export async function logoutOAuthAccount(providerId: string): Promise<void> {
  * @param send Issues one round-trip, resolving `{ maskedValue?, error? }`.
  * @param opts `attempts` (floored to >=1, default 3), `delayMs` (default 150),
  *   and an injectable `sleep`; no sleep after the final attempt.
- * @returns the masked value, or `undefined` if every attempt was empty (never
- *   throws — the caller decides how to surface the give-up). Pure + injectable.
+ * @returns `{ maskedValue }` on success, else `{ lastError }` carrying the last
+ *   SW-reported error (so the caller can log a non-empty give-up reason; may be
+ *   undefined for a genuinely empty/cold reply). Never throws. Pure + injectable.
  */
 export async function maskOAuthTokenWithRetry(
   send: () => Promise<{ maskedValue?: string; error?: string }>,
   opts: { attempts?: number; delayMs?: number; sleep?: (ms: number) => Promise<void> } = {}
-): Promise<string | undefined> {
+): Promise<{ maskedValue?: string; lastError?: string }> {
   const attempts = Math.max(1, opts.attempts ?? 3);
   const delayMs = opts.delayMs ?? 150;
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  let lastError: string | undefined;
   for (let i = 0; i < attempts; i++) {
     const resp = await send();
-    if (resp.maskedValue) return resp.maskedValue;
+    if (resp.maskedValue) return { maskedValue: resp.maskedValue };
+    if (resp.error) lastError = resp.error;
     if (i < attempts - 1) await sleep(delayMs);
   }
-  return undefined;
+  return { lastError };
 }
 
 /**
  * Register an OAuth token's masked replica via the service worker and persist
  * the masked value on the account.
  *
- * #847: `oauth-token` runs in the offscreen document, which has `chrome.runtime`
- * but NOT `chrome.storage`. So the token + domains travel IN the SW message —
- * the SW (which owns `chrome.storage`) writes them and returns the masked value.
- * This helper deliberately keeps `chrome.storage` out of the offscreen caller;
- * the remove path does the same via `deleteOAuthReplica`. Returns silently
- * (after a `log.error` breadcrumb) if masking never succeeds, and no-ops if the
- * account row is gone. Pure + injectable so it is unit-testable without `chrome`.
+ * #847: `saveOAuthAccount` is reachable from the offscreen `oauth-token` shell
+ * (which has `chrome.runtime` but NOT `chrome.storage`) as well as the page-side
+ * login button (which does have `chrome.storage`). Routing the write through the
+ * SW — which owns `chrome.storage` — is the single path that works from BOTH, so
+ * the token + domains travel IN the SW message and the SW does the write. The
+ * remove path does the same via `deleteOAuthReplica`. Returns (after a
+ * `log.error` breadcrumb with the SW reason) if masking never succeeds, and
+ * no-ops if the account row is gone. Pure + injectable; unit-testable sans `chrome`.
  */
 export async function persistOAuthMaskViaServiceWorker(
   opts: { providerId: string; accessToken: string; domains: string[] },
@@ -967,13 +971,19 @@ export async function persistOAuthMaskViaServiceWorker(
     accessToken: opts.accessToken,
     domains: opts.domains.join(','),
   };
-  const maskedValue = await maskOAuthTokenWithRetry(() => deps.sendMaskRequest(payload), maskOpts);
+  const { maskedValue, lastError } = await maskOAuthTokenWithRetry(
+    () => deps.sendMaskRequest(payload),
+    maskOpts
+  );
   if (!maskedValue) {
     // Don't fail silently: the account stays unmasked and `oauth-token` will
     // report "no masked value". log.warn is dropped at the prod ERROR level, so
     // this give-up breadcrumb must be log.error to be visible at all (#847).
+    // Carry the SW reason so the operator can tell a cold/empty reply apart from
+    // a write failure or "entry missing after write" pipeline fault.
     log.error('OAuth mask give-up: no masked value after retries', {
       providerId: opts.providerId,
+      reason: lastError ?? 'no error reported (cold SW or empty reply)',
     });
     return;
   }

--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -898,6 +898,31 @@ export async function logoutOAuthAccount(providerId: string): Promise<void> {
   }
 }
 
+/**
+ * Run the service-worker `secrets.mask-oauth-token` round-trip with a small
+ * bounded retry. A freshly-opened side panel can hit a cold SW whose secrets
+ * pipeline isn't warm yet, so the FIRST round-trip returns no `maskedValue`
+ * (issue #847). Without a retry, `saveOAuthAccount` gave up and `oauth-token`
+ * reported "no masked value" until the panel was reopened (the boot-time
+ * oauth-bootstrap re-push happened to warm the SW). Retry a few times with a
+ * short backoff. Pure + injectable (`send`/`sleep`) so it is unit-testable
+ * without `chrome`.
+ */
+export async function maskOAuthTokenWithRetry(
+  send: () => Promise<{ maskedValue?: string; error?: string }>,
+  opts: { attempts?: number; delayMs?: number; sleep?: (ms: number) => Promise<void> } = {}
+): Promise<string | undefined> {
+  const attempts = Math.max(1, opts.attempts ?? 3);
+  const delayMs = opts.delayMs ?? 150;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  for (let i = 0; i < attempts; i++) {
+    const resp = await send();
+    if (resp.maskedValue) return resp.maskedValue;
+    if (i < attempts - 1) await sleep(delayMs);
+  }
+  return undefined;
+}
+
 /** Save an OAuth account (used by external providers after token exchange). */
 export async function saveOAuthAccount(opts: {
   providerId: string;
@@ -948,39 +973,44 @@ export async function saveOAuthAccount(opts: {
         [`oauth.${opts.providerId}.token`]: opts.accessToken,
         [`oauth.${opts.providerId}.token_DOMAINS`]: domains.join(','),
       });
-      const resp = await new Promise<{ maskedValue?: string; error?: string }>((resolve) => {
-        chrome.runtime.sendMessage(
-          { type: 'secrets.mask-oauth-token', providerId: opts.providerId },
-          (r: any) => {
-            // Chrome sets `lastError` AND invokes the callback with
-            // `undefined` when the SW is unreachable / message port closed /
-            // listener crashed. Without explicit handling the empty
-            // resolve looks identical to "SW returned no maskedValue".
-            if (chrome.runtime.lastError) {
-              log.error('SW mask-oauth-token transport failed', {
-                providerId: opts.providerId,
-                error: chrome.runtime.lastError.message,
-              });
+      const sendMaskRequest = () =>
+        new Promise<{ maskedValue?: string; error?: string }>((resolve) => {
+          chrome.runtime.sendMessage(
+            { type: 'secrets.mask-oauth-token', providerId: opts.providerId },
+            (r: any) => {
+              // Chrome sets `lastError` AND invokes the callback with
+              // `undefined` when the SW is unreachable / message port closed /
+              // listener crashed. Without explicit handling the empty
+              // resolve looks identical to "SW returned no maskedValue".
+              if (chrome.runtime.lastError) {
+                log.error('SW mask-oauth-token transport failed', {
+                  providerId: opts.providerId,
+                  error: chrome.runtime.lastError.message,
+                });
+              }
+              // The SW handler returns `{ maskedValue: undefined, error: '<msg>' }`
+              // on pipeline-build failure (see service-worker.ts secrets.mask-oauth-token
+              // catch). Surface that — matching the CLI branch's "OAuth replica POST
+              // non-ok" logging — so a failure isn't invisible from the page side.
+              if (r?.error) {
+                log.warn('SW mask-oauth-token returned error', {
+                  providerId: opts.providerId,
+                  error: r.error,
+                });
+              }
+              resolve(r ?? {});
             }
-            resolve(r ?? {});
-          }
-        );
-      });
-      // The SW handler returns `{ maskedValue: undefined, error: '<msg>' }`
-      // on pipeline-build failure (see service-worker.ts secrets.mask-oauth-token
-      // catch). Surface that — matching the CLI branch's "OAuth replica POST
-      // non-ok" logging — so a failure isn't invisible from the page side.
-      if (resp.error) {
-        log.warn('SW mask-oauth-token returned error', {
-          providerId: opts.providerId,
-          error: resp.error,
+          );
         });
-      }
-      if (resp.maskedValue) {
+      // Cold-SW retry (#847): a freshly-opened panel's service worker can return
+      // no maskedValue on the first round-trip before its secrets pipeline is
+      // warm. Retry briefly instead of silently leaving the account unmasked.
+      const maskedValue = await maskOAuthTokenWithRetry(sendMaskRequest);
+      if (maskedValue) {
         const accounts = getAccounts();
         const acct = accounts.find((a) => a.providerId === opts.providerId);
         if (acct) {
-          acct.maskedValue = resp.maskedValue;
+          acct.maskedValue = maskedValue;
           await saveAccountsAsync(accounts);
         }
       }

--- a/packages/webapp/tests/providers/oauth-sync.test.ts
+++ b/packages/webapp/tests/providers/oauth-sync.test.ts
@@ -85,7 +85,6 @@ describe('saveOAuthAccount — CLI sync to /api/secrets/oauth-update', () => {
     expect(fetchCalled).toBe(true);
     const accounts = getAccounts();
     const info = accounts.find((a) => a.providerId === 'github');
-    console.log('Account:', info);
     expect(info?.maskedValue).toBe('ghp_masked_sentinel');
   });
 
@@ -100,6 +99,28 @@ describe('saveOAuthAccount — CLI sync to /api/secrets/oauth-update', () => {
         accessToken: 'ghp_x',
       })
     ).resolves.toBeUndefined();
+  });
+
+  it('logoutOAuthAccount DELETEs the CLI replica at /api/secrets/oauth/<id>', async () => {
+    const calls: { url: string; method?: string }[] = [];
+    globalThis.fetch = vi.fn(async (url: any, init: any) => {
+      calls.push({ url: String(url), method: init?.method });
+      return { ok: true, status: 200 } as any;
+    });
+    (globalThis as any).localStorage.setItem(
+      'slicc_accounts',
+      JSON.stringify([{ providerId: 'github', apiKey: '', accessToken: 'ghp_x' }])
+    );
+
+    const { logoutOAuthAccount } = await import('../../src/ui/provider-settings.js');
+    await expect(logoutOAuthAccount('github')).resolves.toBeUndefined();
+
+    // The CLI branch of deleteOAuthReplica must issue the replica DELETE so the
+    // node-server OauthSecretStore is cleared (local clear ≠ server clear hazard).
+    const del = calls.find(
+      (c) => c.url.includes('/api/secrets/oauth/github') && c.method === 'DELETE'
+    );
+    expect(del).toBeDefined();
   });
 });
 

--- a/packages/webapp/tests/providers/oauth-sync.test.ts
+++ b/packages/webapp/tests/providers/oauth-sync.test.ts
@@ -103,7 +103,7 @@ describe('saveOAuthAccount — CLI sync to /api/secrets/oauth-update', () => {
   });
 });
 
-describe('saveOAuthAccount — extension sync via chrome.storage.local + SW message', () => {
+describe('saveOAuthAccount — extension sync via SW message (SW owns chrome.storage, #847)', () => {
   let originalChrome: unknown;
   let originalLocalStorage: Storage;
 
@@ -134,9 +134,9 @@ describe('saveOAuthAccount — extension sync via chrome.storage.local + SW mess
     (globalThis as any).localStorage = originalLocalStorage;
   });
 
-  it('writes to chrome.storage.local + dispatches secrets.mask-oauth-token and caches maskedValue', async () => {
+  it('dispatches secrets.mask-oauth-token WITH the token + domains (SW owns the write) and caches maskedValue', async () => {
     const storageWrites: Record<string, unknown> = {};
-    const sentMessages: { msg: unknown }[] = [];
+    const sentMessages: { msg: any }[] = [];
     (globalThis as any).chrome = {
       runtime: {
         id: 'test-ext-id',
@@ -150,6 +150,9 @@ describe('saveOAuthAccount — extension sync via chrome.storage.local + SW mess
           }
         }),
       },
+      // Present here, but #847: saveOAuthAccount must NOT use it — oauth-token
+      // runs in the offscreen document, which has no chrome.storage. The token
+      // travels in the SW message and the SW does the write.
       storage: {
         local: {
           set: vi.fn(async (obj: Record<string, unknown>) => {
@@ -166,18 +169,15 @@ describe('saveOAuthAccount — extension sync via chrome.storage.local + SW mess
       accessToken: 'ghp_real_extension',
     });
 
-    // chrome.storage.local got the OAuth replica + DOMAINS pair
-    expect(storageWrites['oauth.github.token']).toBe('ghp_real_extension');
-    expect(storageWrites['oauth.github.token_DOMAINS']).toBe('github.com');
+    // saveOAuthAccount must NOT write chrome.storage itself (offscreen has none).
+    expect(storageWrites['oauth.github.token']).toBeUndefined();
 
-    // SW received the mask-oauth-token round-trip
-    const askMask = sentMessages.find(
-      (m) =>
-        typeof m.msg === 'object' &&
-        m.msg != null &&
-        (m.msg as any).type === 'secrets.mask-oauth-token'
-    );
+    // The SW round-trip carries the token + comma-joined domains so the SW can
+    // write them.
+    const askMask = sentMessages.find((m) => m.msg?.type === 'secrets.mask-oauth-token');
     expect(askMask).toBeDefined();
+    expect(askMask?.msg.accessToken).toBe('ghp_real_extension');
+    expect(askMask?.msg.domains).toBe('github.com');
 
     // maskedValue from the SW reply was cached in the Account
     const acct = getAccounts().find((a) => a.providerId === 'github');

--- a/packages/webapp/tests/providers/oauth-sync.test.ts
+++ b/packages/webapp/tests/providers/oauth-sync.test.ts
@@ -184,6 +184,65 @@ describe('saveOAuthAccount — extension sync via SW message (SW owns chrome.sto
     expect(acct?.maskedValue).toBe('ghp_masked_extension');
   });
 
+  it('works from an offscreen-like context with NO chrome.storage (the actual #847 env)', async () => {
+    const sent: any[] = [];
+    (globalThis as any).chrome = {
+      runtime: {
+        id: 'test-ext-id',
+        lastError: undefined,
+        sendMessage: vi.fn((msg: any, cb: (r: any) => void) => {
+          sent.push(msg);
+          cb(
+            msg?.type === 'secrets.mask-oauth-token' ? { maskedValue: 'ghp_masked_offscreen' } : {}
+          );
+        }),
+      },
+      // NO `storage` at all — the real offscreen shape that threw before the fix.
+    };
+
+    const { saveOAuthAccount, getAccounts } = await import('../../src/ui/provider-settings.js');
+    await expect(
+      saveOAuthAccount({ providerId: 'github', accessToken: 'ghp_off' })
+    ).resolves.toBeUndefined();
+
+    const askMask = sent.find((m) => m?.type === 'secrets.mask-oauth-token');
+    expect(askMask?.accessToken).toBe('ghp_off');
+    expect(getAccounts().find((a) => a.providerId === 'github')?.maskedValue).toBe(
+      'ghp_masked_offscreen'
+    );
+  });
+
+  it('removeAccount routes the replica delete through the SW (offscreen has no chrome.storage, #847)', async () => {
+    const sent: any[] = [];
+    (globalThis as any).chrome = {
+      runtime: {
+        id: 'test-ext-id',
+        lastError: undefined,
+        sendMessage: vi.fn((msg: any, cb: (r: any) => void) => {
+          sent.push(msg);
+          cb({ ok: true });
+        }),
+      },
+      // NO `storage` — the real offscreen shape. A direct
+      // chrome.storage.local.remove would throw here (the twin of the
+      // masking bug, reachable via `mcp delete`).
+    };
+    (globalThis as any).localStorage.setItem(
+      'slicc_accounts',
+      JSON.stringify([{ providerId: 'github', apiKey: '', accessToken: 'ghp_x' }])
+    );
+
+    const { removeAccount, getAccounts } = await import('../../src/ui/provider-settings.js');
+    await expect(removeAccount('github')).resolves.toBeUndefined();
+
+    // Replica removal went through the SW secrets.delete message (deleteSecret
+    // removes both `oauth.<id>.token` and its `_DOMAINS` companion).
+    const del = sent.find((m) => m?.type === 'secrets.delete' && m.name === 'oauth.github.token');
+    expect(del).toBeDefined();
+    // The account row is gone afterward.
+    expect(getAccounts().find((a) => a.providerId === 'github')).toBeUndefined();
+  });
+
   it('still resolves when chrome.runtime.lastError is set (SW unreachable)', async () => {
     (globalThis as any).chrome = {
       runtime: {

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -1944,8 +1944,9 @@ describe('persistOAuthMaskViaServiceWorker (#847 — offscreen has no chrome.sto
     expect((accounts[0] as { maskedValue?: string }).maskedValue).toBe('MASK');
   });
 
-  it('leaves the account unmasked when the SW returns no maskedValue (bounded, no throw)', async () => {
+  it('leaves the account unmasked AND logs a prod-visible error when masking never succeeds', async () => {
     const accounts = [{ providerId: 'github', apiKey: '', accessToken: 'tok' }] as never[];
+    mockLog.error.mockClear();
     await persistOAuthMaskViaServiceWorker(
       { providerId: 'github', accessToken: 'tok', domains: ['github.com'] },
       {
@@ -1956,5 +1957,9 @@ describe('persistOAuthMaskViaServiceWorker (#847 — offscreen has no chrome.sto
       { attempts: 2, sleep: noSleep }
     );
     expect((accounts[0] as { maskedValue?: string }).maskedValue).toBeUndefined();
+    // #847: the give-up must NOT be silent. log.warn is dropped in prod
+    // (level=ERROR), so the breadcrumb must be log.error or the "no masked
+    // value" symptom recurs with no diagnostic.
+    expect(mockLog.error).toHaveBeenCalled();
   });
 });

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -199,6 +199,7 @@ import {
   logoutOAuthAccount,
   maskOAuthTokenWithRetry,
   migrateLegacyAuthOnlySelection,
+  persistOAuthMaskViaServiceWorker,
   removeAccount,
   resolveCurrentModel,
   resolveModelById,
@@ -1910,5 +1911,50 @@ describe('maskOAuthTokenWithRetry (cold service worker — issue #847)', () => {
     let i = 0;
     const send = async () => responses[i++];
     expect(await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep })).toBe('MASK2');
+  });
+});
+
+describe('persistOAuthMaskViaServiceWorker (#847 — offscreen has no chrome.storage)', () => {
+  // oauth-token runs in the offscreen document, which has chrome.runtime but
+  // NOT chrome.storage. The token+domains must travel IN the SW message so the
+  // SW (which owns chrome.storage) writes them — the caller must never touch
+  // chrome.storage. This helper does exactly that and persists the mask.
+  const noSleep = async () => {};
+
+  it('sends accessToken + comma-joined domains to the SW (so the SW can write storage) and persists the mask', async () => {
+    let payload: { providerId: string; accessToken: string; domains: string } | undefined;
+    const accounts = [{ providerId: 'github', apiKey: '', accessToken: 'tok' }] as never[];
+    await persistOAuthMaskViaServiceWorker(
+      { providerId: 'github', accessToken: 'tok', domains: ['github.com', 'api.github.com'] },
+      {
+        sendMaskRequest: async (p) => {
+          payload = p;
+          return { maskedValue: 'MASK' };
+        },
+        getAccounts: () => accounts,
+        saveAccounts: async () => {},
+      }
+    );
+    // The whole point: the token leaves via the message, not via chrome.storage.
+    expect(payload).toEqual({
+      providerId: 'github',
+      accessToken: 'tok',
+      domains: 'github.com,api.github.com',
+    });
+    expect((accounts[0] as { maskedValue?: string }).maskedValue).toBe('MASK');
+  });
+
+  it('leaves the account unmasked when the SW returns no maskedValue (bounded, no throw)', async () => {
+    const accounts = [{ providerId: 'github', apiKey: '', accessToken: 'tok' }] as never[];
+    await persistOAuthMaskViaServiceWorker(
+      { providerId: 'github', accessToken: 'tok', domains: ['github.com'] },
+      {
+        sendMaskRequest: async () => ({}),
+        getAccounts: () => accounts,
+        saveAccounts: async () => {},
+      },
+      { attempts: 2, sleep: noSleep }
+    );
+    expect((accounts[0] as { maskedValue?: string }).maskedValue).toBeUndefined();
   });
 });

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -1882,7 +1882,7 @@ describe('maskOAuthTokenWithRetry (cold service worker — issue #847)', () => {
     let i = 0;
     const send = async () => responses[i++];
     const result = await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep });
-    expect(result).toBe('MASK');
+    expect(result.maskedValue).toBe('MASK');
     expect(i).toBe(3); // retried past the two empty responses
   });
 
@@ -1892,17 +1892,20 @@ describe('maskOAuthTokenWithRetry (cold service worker — issue #847)', () => {
       calls++;
       return { maskedValue: 'M' };
     };
-    expect(await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep })).toBe('M');
+    expect((await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep })).maskedValue).toBe(
+      'M'
+    );
     expect(calls).toBe(1);
   });
 
-  it('gives up with undefined after exhausting attempts', async () => {
+  it('gives up with no maskedValue after exhausting attempts', async () => {
     let calls = 0;
     const send = async () => {
       calls++;
       return {};
     };
-    expect(await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep })).toBeUndefined();
+    const result = await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep });
+    expect(result.maskedValue).toBeUndefined();
     expect(calls).toBe(3); // bounded — does not loop forever
   });
 
@@ -1910,7 +1913,16 @@ describe('maskOAuthTokenWithRetry (cold service worker — issue #847)', () => {
     const responses = [{ error: 'pipeline build failed' }, { maskedValue: 'MASK2' }];
     let i = 0;
     const send = async () => responses[i++];
-    expect(await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep })).toBe('MASK2');
+    expect((await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep })).maskedValue).toBe(
+      'MASK2'
+    );
+  });
+
+  it('propagates the last SW error reason on give-up (for a prod-visible diagnostic)', async () => {
+    const send = async () => ({ error: 'entry missing after write' });
+    const result = await maskOAuthTokenWithRetry(send, { attempts: 2, sleep: noSleep });
+    expect(result.maskedValue).toBeUndefined();
+    expect(result.lastError).toBe('entry missing after write');
   });
 });
 
@@ -1944,22 +1956,25 @@ describe('persistOAuthMaskViaServiceWorker (#847 — offscreen has no chrome.sto
     expect((accounts[0] as { maskedValue?: string }).maskedValue).toBe('MASK');
   });
 
-  it('leaves the account unmasked AND logs a prod-visible error when masking never succeeds', async () => {
+  it('leaves the account unmasked AND logs a prod-visible error WITH the SW reason', async () => {
     const accounts = [{ providerId: 'github', apiKey: '', accessToken: 'tok' }] as never[];
     mockLog.error.mockClear();
     await persistOAuthMaskViaServiceWorker(
       { providerId: 'github', accessToken: 'tok', domains: ['github.com'] },
       {
-        sendMaskRequest: async () => ({}),
+        // SW reports WHY it couldn't mask — the reason must reach the give-up log.
+        sendMaskRequest: async () => ({ error: 'entry missing after write' }),
         getAccounts: () => accounts,
         saveAccounts: async () => {},
       },
       { attempts: 2, sleep: noSleep }
     );
     expect((accounts[0] as { maskedValue?: string }).maskedValue).toBeUndefined();
-    // #847: the give-up must NOT be silent. log.warn is dropped in prod
-    // (level=ERROR), so the breadcrumb must be log.error or the "no masked
-    // value" symptom recurs with no diagnostic.
-    expect(mockLog.error).toHaveBeenCalled();
+    // #847: the give-up must NOT be silent (log.warn is dropped at prod ERROR
+    // level) AND must carry the reason so cold-SW vs write-fault is diagnosable.
+    expect(mockLog.error).toHaveBeenCalledWith(
+      expect.stringContaining('give-up'),
+      expect.objectContaining({ providerId: 'github', reason: 'entry missing after write' })
+    );
   });
 });

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -197,6 +197,7 @@ import {
   getSelectedModelId,
   getSelectedProvider,
   logoutOAuthAccount,
+  maskOAuthTokenWithRetry,
   migrateLegacyAuthOnlySelection,
   removeAccount,
   resolveCurrentModel,
@@ -1865,5 +1866,49 @@ describe('logoutOAuthAccount', () => {
     // This is the exact finder used in showAvatarPopover — must return undefined after logout.
     const found = accounts.find((a) => !a.loggedOut && (a.userName || a.accessToken || a.apiKey));
     expect(found).toBeUndefined();
+  });
+});
+
+describe('maskOAuthTokenWithRetry (cold service worker — issue #847)', () => {
+  // A freshly-opened side panel can have a cold SW whose secrets pipeline isn't
+  // warm yet, so the first secrets.mask-oauth-token round-trip comes back with
+  // no maskedValue. Without a retry, saveOAuthAccount gave up and oauth-token
+  // reported "no masked value" until the panel was reopened. Retry briefly.
+  const noSleep = async () => {};
+
+  it('returns the masked value once the SW warms up (empty, empty, then value)', async () => {
+    const responses = [{}, {}, { maskedValue: 'MASK' }];
+    let i = 0;
+    const send = async () => responses[i++];
+    const result = await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep });
+    expect(result).toBe('MASK');
+    expect(i).toBe(3); // retried past the two empty responses
+  });
+
+  it('returns immediately on first success without extra round-trips', async () => {
+    let calls = 0;
+    const send = async () => {
+      calls++;
+      return { maskedValue: 'M' };
+    };
+    expect(await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep })).toBe('M');
+    expect(calls).toBe(1);
+  });
+
+  it('gives up with undefined after exhausting attempts', async () => {
+    let calls = 0;
+    const send = async () => {
+      calls++;
+      return {};
+    };
+    expect(await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep })).toBeUndefined();
+    expect(calls).toBe(3); // bounded — does not loop forever
+  });
+
+  it('keeps retrying through a transient SW error (resp.error then value)', async () => {
+    const responses = [{ error: 'pipeline build failed' }, { maskedValue: 'MASK2' }];
+    let i = 0;
+    const send = async () => responses[i++];
+    expect(await maskOAuthTokenWithRetry(send, { attempts: 3, sleep: noSleep })).toBe('MASK2');
   });
 });


### PR DESCRIPTION
## Summary

Fixes two related Chrome-extension bugs where OAuth token storage operations crashed in the **offscreen document** (which has `chrome.runtime` but not `chrome.storage`):

1. **Masking (login):** the first `oauth-token <provider>` after opening the side panel saved the token but not its masked value → `no masked value for <provider> (try logging in again)`, self-healing only on panel reopen. (#847)
2. **Removal (twin bug):** `removeAccount` / `logoutOAuthAccount` (reachable via `mcp delete` / provider logout, which run in the offscreen shell) crashed the same way on the replica delete, silently leaving the secret behind.

After: both work from the offscreen document, on the first try.

## Why

Closes #847. **Root cause (confirmed from a runtime console error — `Cannot read properties of undefined (reading 'local')`):** `oauth-token` / `mcp delete` / logout run in the **offscreen document**, which has `chrome.runtime` but **not** `chrome.storage` (the MV3 quirk that already makes `secrets.set`/`secrets.delete` proxy through the SW). `saveOAuthAccount`'s direct `chrome.storage.local.set(...)` (and `removeAccount`/`logoutOAuthAccount`'s `chrome.storage.local.remove(...)`) therefore threw, the `try/catch` swallowed it, and the secret was never written/removed for the service worker. (The boot-time `oauth-bootstrap` re-push, which runs in the side panel where `chrome.storage` exists, is what "fixed" masking on reopen.)

## Approach / Implementation notes

- **Storage ops moved into the service worker** (which owns `chrome.storage`), matching the existing `secrets.set`/`secrets.delete` proxy pattern. `saveOAuthAccount` sends `{ providerId, accessToken, domains }` in the `secrets.mask-oauth-token` message; the SW writes `oauth.<id>.token` + `oauth.<id>.token_DOMAINS`, then masks. The new shared `deleteOAuthReplica` routes the remove through the SW `secrets.delete` message (`deleteSecret` removes both keys), used by `removeAccount` **and** `logoutOAuthAccount`. The page helpers no longer touch `chrome.storage`, so they work from offscreen.
- **New helpers** (pure + injectable, unit-tested without `chrome`): `persistOAuthMaskViaServiceWorker` and `maskOAuthTokenWithRetry`. The retry (3×150 ms) is **defense-in-depth** for a genuinely cold SW — it was the first (insufficient) fix attempt; the offscreen `chrome.storage` gap is the real cause.
- **Observability (so failures aren't silent in prod, where `log.warn` is dropped at ERROR level):** the masking give-up is logged at `log.error` **with the SW reason** (`maskOAuthTokenWithRetry` now returns `{ maskedValue?, lastError? }`); the SW returns `{ error: 'entry missing after write' }` when it wrote the token but the pipeline didn't surface it (a real fault, distinct from a cold-start miss).

## Cross-cutting impact

- **Float:** Chrome extension only. The CLI/connect branches (`/api/secrets/oauth-update`, `/api/secrets/oauth/<id>` DELETE) are unchanged.
- **Shell contexts:** `oauth-token`/`mcp delete`/logout run in the offscreen document; the SW remains the sole `chrome.storage` authority. `saveOAuthAccount` is also reachable from the page login button (which has `chrome.storage`) — SW-routing is the single path that works from both.
- **Contract change:** `secrets.mask-oauth-token` optionally accepts `accessToken`+`domains`; its only caller is `saveOAuthAccount`. No storage schema change.

## Test plan

- [x] `npm run typecheck` — clean (all 6 tsconfigs)
- [x] `npm run test` — **6219 passing / 14 skipped / 0 failed**
- [x] `biome check` / `prettier --check` clean
- [x] `npm run build -w @slicc/webapp` and `npm run build -w @slicc/chrome-extension`
- [x] Unit coverage: `maskOAuthTokenWithRetry` (retry/immediate/give-up/transient-error/`lastError` propagation), `persistOAuthMaskViaServiceWorker` (sends token+domains; give-up logs reason), SW write-branch (writes-from-message/back-compat-skip/write-failure/entry-missing-returns-error), offscreen-condition (`chrome` present, `chrome.storage` absent) for both `saveOAuthAccount` and `removeAccount`, CLI `deleteOAuthReplica` DELETE via `logoutOAuthAccount`.
- [ ] **Manual smoke (extension) — pending live verification.** Rebuild, **hard reinstall** (Remove + Load unpacked, to force a fresh SW), open the side panel, `oauth-token github --scope "repo,read:user"` → returns the token on the first try. The give-up `log.error` now carries a `reason`, so any remaining failure is diagnosable (cold SW vs write failure vs `entry missing after write`).

## Documentation

- [x] `packages/chrome-extension/CLAUDE.md` updated — the SW owns the `chrome.storage` write for OAuth tokens.

## Risk & rollback

- Low blast radius: extension-only; the SW now performs storage writes/removes the caller previously did. Reverts cleanly. Failures are now logged at ERROR (prod-visible) with a reason rather than silently swallowed.
- CI can't drive the real extension OAuth round-trip — verify by hand via the manual smoke above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
