### PR TITLE
Pyodide root-cause perf: warm worker pool + lazy FS

### DIFF
--- a/packages/webapp/src/kernel/realm/py-realm-pool.ts
+++ b/packages/webapp/src/kernel/realm/py-realm-pool.ts
@@ -1,0 +1,205 @@
+/**
+ * `py-realm-pool.ts` — a pool of warm, reusable Pyodide realms.
+ *
+ * Replaces the one-shot "spawn a DedicatedWorker per `python`
+ * invocation, then `worker.terminate()`" model: the interpreter and
+ * its FS survive between runs, so only the first call pays the
+ * ~1-2 s `loadPyodide` cold boot. Defaults: keep 1 warm idle worker,
+ * scale to 2 in parallel, queue (FIFO) beyond that.
+ *
+ * The pool is signal-agnostic — the runner (`runInPooledRealm`)
+ * owns the pid↔lease mapping and calls `lease.evict()` on SIGKILL /
+ * error. `evict()` terminates the worker and (if callers are waiting)
+ * lazily creates a replacement; `release()` returns the worker idle
+ * for reuse, applying the warm-idle / idle-TTL policy.
+ */
+
+import type { CommandContext } from 'just-bash';
+import type { Realm, RealmFactory, RealmLease, RealmPool } from './realm-runner.js';
+
+export interface PyRealmPoolOptions {
+  factory: RealmFactory;
+  /** Idle workers kept warm indefinitely. Default 1. */
+  warmIdle?: number;
+  /** Max workers checked out + creating at once. Default 2. */
+  maxConcurrent?: number;
+  /** Idle TTL (ms) for workers beyond `warmIdle`. Default 30 s; 0 disables. */
+  idleTtlMs?: number;
+}
+
+interface PooledWorker {
+  realm: Realm;
+  idleTimer?: ReturnType<typeof setTimeout>;
+}
+
+interface Waiter {
+  ctx: CommandContext;
+  resolve(lease: RealmLease): void;
+  reject(err: Error): void;
+}
+
+class PyRealmPool implements RealmPool {
+  private readonly factory: RealmFactory;
+  private readonly warmIdle: number;
+  private readonly maxConcurrent: number;
+  private readonly idleTtlMs: number;
+  private readonly idle: PooledWorker[] = [];
+  private readonly busy = new Set<PooledWorker>();
+  private readonly waiters: Waiter[] = [];
+  private creating = 0;
+  private disposed = false;
+
+  constructor(opts: PyRealmPoolOptions) {
+    this.factory = opts.factory;
+    this.warmIdle = opts.warmIdle ?? 1;
+    this.maxConcurrent = opts.maxConcurrent ?? 2;
+    this.idleTtlMs = opts.idleTtlMs ?? 30_000;
+  }
+
+  checkout(ctx: CommandContext): Promise<RealmLease> {
+    if (this.disposed) return Promise.reject(new Error('realm pool disposed'));
+    return new Promise<RealmLease>((resolve, reject) => {
+      this.waiters.push({ ctx, resolve, reject });
+      this.pump();
+    });
+  }
+
+  stats(): { idle: number; busy: number; waiting: number; creating: number } {
+    return {
+      idle: this.idle.length,
+      busy: this.busy.size,
+      waiting: this.waiters.length,
+      creating: this.creating,
+    };
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const w of this.idle) this.terminate(w);
+    this.idle.length = 0;
+    for (const w of this.busy) this.terminate(w);
+    this.busy.clear();
+    const err = new Error('realm pool disposed');
+    for (const waiter of this.waiters.splice(0)) waiter.reject(err);
+  }
+
+  /** Satisfy waiters from the idle pool, then create up to capacity. */
+  private pump(): void {
+    if (this.disposed) return;
+    while (this.waiters.length > 0 && this.idle.length > 0) {
+      const worker = this.idle.shift()!;
+      this.clearTimer(worker);
+      this.busy.add(worker);
+      this.waiters.shift()!.resolve(this.lease(worker));
+    }
+    while (
+      this.waiters.length > this.creating &&
+      this.busy.size + this.creating < this.maxConcurrent
+    ) {
+      const waiter = this.waiters.shift()!;
+      this.creating++;
+      this.factory({ kind: 'py', ctx: waiter.ctx }).then(
+        (realm) => {
+          this.creating--;
+          if (this.disposed) {
+            this.terminateRealm(realm);
+            waiter.reject(new Error('realm pool disposed'));
+            return;
+          }
+          const worker: PooledWorker = { realm };
+          this.busy.add(worker);
+          waiter.resolve(this.lease(worker));
+        },
+        (err: unknown) => {
+          this.creating--;
+          waiter.reject(err instanceof Error ? err : new Error(String(err)));
+          this.pump();
+        }
+      );
+    }
+  }
+
+  private lease(worker: PooledWorker): RealmLease {
+    let done = false;
+    return {
+      realm: worker.realm,
+      release: () => {
+        if (done) return;
+        done = true;
+        this.onRelease(worker);
+      },
+      evict: () => {
+        if (done) return;
+        done = true;
+        this.onEvict(worker);
+      },
+    };
+  }
+
+  private onRelease(worker: PooledWorker): void {
+    this.busy.delete(worker);
+    if (this.disposed) {
+      this.terminate(worker);
+      return;
+    }
+    this.idle.push(worker);
+    this.rebalanceIdle();
+    this.pump();
+  }
+
+  private onEvict(worker: PooledWorker): void {
+    this.busy.delete(worker);
+    this.terminate(worker);
+    // Lazy replacement: pump() creates a fresh worker for any waiter
+    // now that a concurrency slot has freed up.
+    if (!this.disposed) this.pump();
+  }
+
+  /** Keep `warmIdle` workers timer-free; expire the rest after TTL. */
+  private rebalanceIdle(): void {
+    this.idle.forEach((worker, i) => {
+      if (i < this.warmIdle || this.idleTtlMs <= 0) {
+        this.clearTimer(worker);
+        return;
+      }
+      if (worker.idleTimer) return;
+      worker.idleTimer = setTimeout(() => this.dropIdle(worker), this.idleTtlMs);
+      (worker.idleTimer as { unref?: () => void })?.unref?.();
+    });
+  }
+
+  private dropIdle(worker: PooledWorker): void {
+    const i = this.idle.indexOf(worker);
+    if (i < 0) return;
+    this.idle.splice(i, 1);
+    this.terminate(worker);
+  }
+
+  private clearTimer(worker: PooledWorker): void {
+    if (worker.idleTimer) {
+      clearTimeout(worker.idleTimer);
+      worker.idleTimer = undefined;
+    }
+  }
+
+  private terminate(worker: PooledWorker): void {
+    this.clearTimer(worker);
+    this.terminateRealm(worker.realm);
+  }
+
+  private terminateRealm(realm: Realm): void {
+    try {
+      realm.terminate();
+    } catch {
+      /* idempotent on real workers / iframes */
+    }
+  }
+}
+
+/** Construct a warm Pyodide realm pool. */
+export function createPyRealmPool(opts: PyRealmPoolOptions): PyRealmPool {
+  return new PyRealmPool(opts);
+}
+
+export type { PyRealmPool };

--- a/packages/webapp/src/kernel/realm/py-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/py-realm-shared.ts
@@ -56,114 +56,292 @@ except BaseException:
 `;
 
 // ---------------------------------------------------------------------------
+// Per-run state isolation (warm-pool reuse)
+// ---------------------------------------------------------------------------
+
+/**
+ * Captured ONCE right after `loadPyodide`, before any user code
+ * runs. Records the pristine `sys.modules` key set into a Python
+ * global so the per-run reset can prune anything user code imported
+ * back down to this baseline.
+ */
+export const PY_BASELINE_SNIPPET = `
+import sys as __slicc_sys
+__slicc_baseline_modules = frozenset(__slicc_sys.modules)
+del __slicc_sys
+`;
+
+/**
+ * Run BEFORE every reused run (never on the first). Prunes
+ * `sys.modules` back to the post-boot baseline so a module a
+ * previous run imported (and possibly monkeypatched) is re-imported
+ * fresh next time. The `__main__` namespace is already fresh every
+ * run — `PYTHON_RUNNER` `exec`s into a brand-new dict — so only the
+ * shared module cache needs explicit teardown here.
+ *
+ * Residual shared-state caveat: pruning `sys.modules` drops the
+ * Python-level module objects, but C-level singletons living in the
+ * WASM heap (a native extension's global state, an already-open file
+ * descriptor outside the synced scratch dirs, numpy's threadpool, …)
+ * are NOT reset. This is the accepted trade-off for skipping the
+ * ~1-2 s cold boot on warm reuse; code needing hermetic isolation
+ * gets a cold worker whenever the pool evicts (SIGKILL / error).
+ */
+export const PY_RESET_SNIPPET = `
+import sys as __slicc_sys
+for __slicc_name in list(__slicc_sys.modules):
+    if __slicc_name not in __slicc_baseline_modules:
+        __slicc_sys.modules.pop(__slicc_name, None)
+del __slicc_sys
+try:
+    del __slicc_name
+except NameError:
+    pass
+`;
+
+/**
+ * Pyodide/emscripten system directories that must never be cleared
+ * between runs — wiping them breaks the interpreter. The per-run
+ * scratch reset only touches the caller's `syncDirs` contents, and
+ * skips any entry that is itself one of these roots.
+ */
+const PROTECTED_PY_DIRS = new Set<string>([
+  '/',
+  '/bin',
+  '/sbin',
+  '/dev',
+  '/etc',
+  '/home',
+  '/home/pyodide',
+  '/lib',
+  '/lib64',
+  '/proc',
+  '/root',
+  '/usr',
+]);
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ---------------------------------------------------------------------------
 // Python realm execution engine
 // ---------------------------------------------------------------------------
 
 /**
- * Run a `kind:'py'` realm against `port`. Loads Pyodide via the
- * supplied `loaderImport` (default: dynamic `import('pyodide')`),
- * syncs VFS↔Pyodide-FS via the `vfs` RPC channel, runs the user
- * code, then posts `realm-done`. Used by both `py-realm-worker.ts`
- * (worker context) and the in-process test factory.
+ * A warm, reusable Pyodide realm. `create()` pays the one-time
+ * `loadPyodide` cost and snapshots the pristine module set; `run()`
+ * executes one `RealmInitMsg` and posts `realm-done`. The same
+ * session services many `run()` calls — the warm-pool reuse that
+ * skips cold boot. State carried by Pyodide between runs (imported
+ * modules, scratch files) is reset at the start of every run after
+ * the first; see `PY_RESET_SNIPPET` for the caveat.
+ */
+export class PyRealmSession {
+  private hasRun = false;
+
+  private constructor(private readonly pyodide: PyodideInterface) {}
+
+  /**
+   * Load Pyodide via `loaderImport` (default: dynamic
+   * `import('pyodide')`) and capture the module baseline. Throws on
+   * load failure — callers (the worker / in-process factory) post a
+   * `realm-error` with a `loadPyodide:` prefix.
+   */
+  static async create(
+    init: RealmInitMsg,
+    loaderImport: () => Promise<typeof import('pyodide')> = () => import('pyodide')
+  ): Promise<PyRealmSession> {
+    const mod = await loaderImport();
+    const pyodide = await mod.loadPyodide({
+      indexURL: init.pyodideIndexURL,
+      fullStdLib: false,
+    });
+    pyodide.runPython(PY_BASELINE_SNIPPET);
+    return new PyRealmSession(pyodide);
+  }
+
+  /**
+   * Execute one realm-init against `port`: reset state (reused runs
+   * only), sync VFS↔Pyodide-FS via the `vfs` RPC channel, run the
+   * user code, then post `realm-done`.
+   */
+  async run(init: RealmInitMsg, port: RealmPortLike): Promise<void> {
+    const pyodide = this.pyodide;
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+    const pushWarning = (msg: string): void => {
+      stderrChunks.push(`Warning: ${msg}\n`);
+    };
+
+    // Default `[cwd, '/tmp']` is deliberate: those are the two
+    // directories Python code almost always reads from (the working
+    // directory the user invoked from + the conventional scratch
+    // location). Adding `/workspace/` or `/shared/` to the default
+    // would mirror the entire workspace into Pyodide's FS on every
+    // invocation — minutes per `python3 -c "print(1)"` even with the
+    // bulk-RPC path. Callers that need wider visibility pass an
+    // explicit `pyodideSyncDirs`.
+    const syncDirs = init.pyodideSyncDirs ?? [init.cwd, '/tmp'];
+
+    // Reset carried state on every reused run. The first run on a
+    // freshly-booted session skips this — nothing to clean and the
+    // scratch dirs don't exist yet. `clearPyScratch` wipes the
+    // synced dirs so a file the previous run created (and that VFS
+    // has since deleted) doesn't leak in via pre-sync's add-only
+    // mirror; `PY_RESET_SNIPPET` prunes the module cache.
+    if (this.hasRun) {
+      try {
+        clearPyScratch(pyodide, syncDirs, pushWarning);
+      } catch (err) {
+        pushWarning(`reset scratch failed: ${errMessage(err)}`);
+      }
+      try {
+        pyodide.runPython(PY_RESET_SNIPPET);
+      } catch (err) {
+        pushWarning(`reset modules failed: ${errMessage(err)}`);
+      }
+    }
+    this.hasRun = true;
+
+    const rpc = new RealmRpcClient(port);
+
+    let preSyncSnapshot: PreSyncSnapshot = { files: new Map(), dirs: new Set() };
+    try {
+      preSyncSnapshot = await syncVfsToPyodide(rpc, pyodide, syncDirs, pushWarning);
+    } catch (err) {
+      pushWarning(`VFS→Pyodide sync failed: ${errMessage(err)}`);
+    }
+
+    try {
+      pyodide.FS.chdir(init.cwd);
+    } catch {
+      /* dir may not exist in Pyodide FS */
+    }
+
+    pyodide.setStdout({ batched: (msg: string) => stdoutChunks.push(msg + '\n') });
+    pyodide.setStderr({ batched: (msg: string) => stderrChunks.push(msg + '\n') });
+
+    let stdinConsumed = false;
+    pyodide.setStdin({
+      stdin: () => {
+        if (stdinConsumed || !init.stdin) return null;
+        stdinConsumed = true;
+        return init.stdin;
+      },
+    });
+    pyodide.globals.set('__slicc_code', init.code);
+    pyodide.globals.set('__slicc_filename', init.filename);
+    pyodide.globals.set('__slicc_argv', init.argv);
+
+    let exitCode: number;
+    try {
+      await pyodide.runPythonAsync(PYTHON_RUNNER);
+      const raw = pyodide.globals.get('__slicc_exit_code');
+      exitCode = typeof raw === 'number' ? raw : Number(raw ?? 1);
+    } catch (err) {
+      stderrChunks.push(`${errMessage(err)}\n`);
+      exitCode = 1;
+    }
+
+    try {
+      pyodide.runPython('del __slicc_code, __slicc_filename, __slicc_argv, __slicc_exit_code');
+    } catch {
+      /* best-effort cleanup */
+    }
+
+    try {
+      await syncPyodideToVfs(rpc, pyodide, syncDirs, preSyncSnapshot, pushWarning);
+    } catch (err) {
+      pushWarning(`Pyodide→VFS sync failed: ${errMessage(err)}`);
+    }
+
+    rpc.dispose();
+    const done: RealmDoneMsg = {
+      type: 'realm-done',
+      stdout: stdoutChunks.join(''),
+      stderr: stderrChunks.join(''),
+      exitCode,
+    };
+    port.postMessage(done);
+  }
+}
+
+/**
+ * Recursively delete the CONTENTS of each scratch dir (not the dir
+ * itself), skipping Pyodide/emscripten system roots. Used by
+ * `PyRealmSession.run` to drop stale in-memory files before a reused
+ * run re-mirrors VFS.
+ */
+function clearPyScratch(pyodide: PyodideInterface, dirs: string[], pushWarning: WarningSink): void {
+  const FS = pyodide.FS;
+  for (const dir of dirs) {
+    if (PROTECTED_PY_DIRS.has(dir)) continue;
+    let names: string[];
+    try {
+      names = (FS.readdir(dir) as string[]).filter((n) => n !== '.' && n !== '..');
+    } catch {
+      continue; // dir not present in Pyodide FS yet
+    }
+    for (const name of names) {
+      const full = dir === '/' ? `/${name}` : `${dir}/${name}`;
+      if (PROTECTED_PY_DIRS.has(full)) continue;
+      removePyPath(FS, full, pushWarning);
+    }
+  }
+}
+
+function removePyPath(Fs: PyodideInterface['FS'], path: string, pushWarning: WarningSink): void {
+  let st: { mode: number };
+  try {
+    st = Fs.stat(path) as { mode: number };
+  } catch {
+    return;
+  }
+  if (Fs.isDir(st.mode)) {
+    let names: string[];
+    try {
+      names = (Fs.readdir(path) as string[]).filter((n) => n !== '.' && n !== '..');
+    } catch {
+      names = [];
+    }
+    for (const name of names) removePyPath(Fs, `${path}/${name}`, pushWarning);
+    try {
+      Fs.rmdir(path);
+    } catch (err) {
+      pushWarning(`reset: rmdir '${path}' failed: ${errMessage(err)}`);
+    }
+  } else {
+    try {
+      Fs.unlink(path);
+    } catch (err) {
+      pushWarning(`reset: unlink '${path}' failed: ${errMessage(err)}`);
+    }
+  }
+}
+
+/**
+ * One-shot convenience wrapper retained for callers that don't reuse
+ * the realm. Creates a session, runs once, and posts `realm-error`
+ * (prefixed `loadPyodide:`) if the interpreter fails to boot.
  */
 export async function runPyRealm(
   init: RealmInitMsg,
   port: RealmPortLike,
   loaderImport: () => Promise<typeof import('pyodide')> = () => import('pyodide')
 ): Promise<void> {
-  const stdoutChunks: string[] = [];
-  const stderrChunks: string[] = [];
-
-  const rpc = new RealmRpcClient(port);
-
-  let pyodide: PyodideInterface;
+  let session: PyRealmSession;
   try {
-    const mod = await loaderImport();
-    pyodide = await mod.loadPyodide({
-      indexURL: init.pyodideIndexURL,
-      fullStdLib: false,
-    });
+    session = await PyRealmSession.create(init, loaderImport);
   } catch (err) {
-    rpc.dispose();
-    const message = err instanceof Error ? err.message : String(err);
-    const errMsg: RealmErrorMsg = { type: 'realm-error', message: `loadPyodide: ${message}` };
+    const errMsg: RealmErrorMsg = {
+      type: 'realm-error',
+      message: `loadPyodide: ${errMessage(err)}`,
+    };
     port.postMessage(errMsg);
     return;
   }
-
-  // Default `[cwd, '/tmp']` is deliberate: those are the two
-  // directories Python code almost always reads from (the working
-  // directory the user invoked from + the conventional scratch
-  // location). Adding `/workspace/` or `/shared/` to the default
-  // would mirror the entire workspace into Pyodide's FS on every
-  // invocation — minutes per `python3 -c "print(1)"` even with the
-  // bulk-RPC path. Callers that need wider visibility pass an
-  // explicit `pyodideSyncDirs`.
-  const syncDirs = init.pyodideSyncDirs ?? [init.cwd, '/tmp'];
-  const pushWarning = (msg: string): void => {
-    stderrChunks.push(`Warning: ${msg}\n`);
-  };
-  let preSyncSnapshot: PreSyncSnapshot = { files: new Map(), dirs: new Set() };
-  try {
-    preSyncSnapshot = await syncVfsToPyodide(rpc, pyodide, syncDirs, pushWarning);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    pushWarning(`VFS→Pyodide sync failed: ${message}`);
-  }
-
-  try {
-    pyodide.FS.chdir(init.cwd);
-  } catch {
-    /* dir may not exist in Pyodide FS */
-  }
-
-  pyodide.setStdout({ batched: (msg: string) => stdoutChunks.push(msg + '\n') });
-  pyodide.setStderr({ batched: (msg: string) => stderrChunks.push(msg + '\n') });
-
-  let stdinConsumed = false;
-  pyodide.setStdin({
-    stdin: () => {
-      if (stdinConsumed || !init.stdin) return null;
-      stdinConsumed = true;
-      return init.stdin;
-    },
-  });
-  pyodide.globals.set('__slicc_code', init.code);
-  pyodide.globals.set('__slicc_filename', init.filename);
-  pyodide.globals.set('__slicc_argv', init.argv);
-
-  let exitCode: number;
-  try {
-    await pyodide.runPythonAsync(PYTHON_RUNNER);
-    const raw = pyodide.globals.get('__slicc_exit_code');
-    exitCode = typeof raw === 'number' ? raw : Number(raw ?? 1);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    stderrChunks.push(`${message}\n`);
-    exitCode = 1;
-  }
-
-  try {
-    pyodide.runPython('del __slicc_code, __slicc_filename, __slicc_argv, __slicc_exit_code');
-  } catch {
-    /* best-effort cleanup */
-  }
-
-  try {
-    await syncPyodideToVfs(rpc, pyodide, syncDirs, preSyncSnapshot, pushWarning);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    pushWarning(`Pyodide→VFS sync failed: ${message}`);
-  }
-
-  rpc.dispose();
-  const done: RealmDoneMsg = {
-    type: 'realm-done',
-    stdout: stdoutChunks.join(''),
-    stderr: stderrChunks.join(''),
-    exitCode,
-  };
-  port.postMessage(done);
+  await session.run(init, port);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/src/kernel/realm/py-realm-worker.ts
+++ b/packages/webapp/src/kernel/realm/py-realm-worker.ts
@@ -8,19 +8,24 @@
  * `script-src 'self' 'wasm-unsafe-eval'` and we have to fall back
  * to a sandbox iframe.)
  *
- * Thin wrapper around `runPyRealm` (in `py-realm-shared.ts`) so an
- * in-process test factory can drive the same code path without a
- * real DedicatedWorker.
+ * Hosts a single warm `PyRealmSession` (in `py-realm-shared.ts`)
+ * that survives between runs: `loadPyodide` is paid once, then each
+ * `realm-init` drives one `session.run()`. The pool
+ * (`py-realm-pool.ts`) checks this worker out, posts an init, and on
+ * `realm-done` returns it idle for the next run — the warm-reuse
+ * that skips cold boot. An in-process test factory drives the same
+ * `PyRealmSession` path without a real DedicatedWorker.
  *
  * SIGKILL: a runaway `while True: pass` exits when the kernel
  * terminates the worker — Pyodide can't service interrupts inside
  * a tight loop because Python's bytecode interpreter has no yield
- * points there.
+ * points there. The pool evicts (terminates) the worker on SIGKILL
+ * and lazily replaces it.
  */
 
 /// <reference lib="webworker" />
 
-import { runPyRealm } from './py-realm-shared.js';
+import { PyRealmSession } from './py-realm-shared.js';
 import type { RealmPortLike } from './realm-rpc.js';
 import type { RealmErrorMsg, RealmInitMsg } from './realm-types.js';
 
@@ -33,14 +38,43 @@ const port: RealmPortLike = {
   removeEventListener: (type, handler) => self.removeEventListener(type, handler),
 };
 
+// The session is created lazily on the first init (it needs the
+// init's `pyodideIndexURL`) and reused for every subsequent run.
+// `busy` is defensive: the pool guarantees one in-flight run per
+// worker, but a stray concurrent init must not corrupt the shared
+// interpreter.
+let sessionPromise: Promise<PyRealmSession> | null = null;
+let busy = false;
+
 self.addEventListener('message', (event: MessageEvent) => {
   const data = event.data as { type?: string };
   if (data?.type !== 'realm-init') return;
   const init = event.data as RealmInitMsg;
   if (init.kind !== 'py') return;
-  void runPyRealm(init, port).catch((err: unknown) => {
-    const message = err instanceof Error ? err.message : String(err);
-    const errMsg: RealmErrorMsg = { type: 'realm-error', message };
-    self.postMessage(errMsg);
+  if (busy) return;
+  busy = true;
+  void (async () => {
+    let session: PyRealmSession;
+    try {
+      if (!sessionPromise) sessionPromise = PyRealmSession.create(init);
+      session = await sessionPromise;
+    } catch (err) {
+      // Reset so a later checkout retries the cold boot (the pool
+      // also evicts this worker on realm-error).
+      sessionPromise = null;
+      const message = err instanceof Error ? err.message : String(err);
+      const errMsg: RealmErrorMsg = { type: 'realm-error', message: `loadPyodide: ${message}` };
+      self.postMessage(errMsg);
+      return;
+    }
+    try {
+      await session.run(init, port);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const errMsg: RealmErrorMsg = { type: 'realm-error', message };
+      self.postMessage(errMsg);
+    }
+  })().finally(() => {
+    busy = false;
   });
 });

--- a/packages/webapp/src/kernel/realm/realm-inprocess.ts
+++ b/packages/webapp/src/kernel/realm/realm-inprocess.ts
@@ -16,7 +16,7 @@
  */
 
 import { runJsRealm } from './js-realm-shared.js';
-import { runPyRealm } from './py-realm-shared.js';
+import { PyRealmSession } from './py-realm-shared.js';
 import type { RealmPortLike } from './realm-rpc.js';
 import type { Realm, RealmFactory } from './realm-runner.js';
 import type { RealmErrorMsg, RealmInitMsg } from './realm-types.js';
@@ -101,29 +101,63 @@ export function createInProcessJsRealmFactory(): RealmFactory {
 }
 
 /**
- * In-process Python realm factory. Same pattern as the JS one but
- * dispatches to `runPyRealm`. Used when no DedicatedWorker is
- * available (vitest, headless tools that didn't import the
- * default factory). Cold-start cost is the same ~1-2 s — Pyodide
- * doesn't care that it's running in the same realm as the
- * kernel.
+ * In-process Python realm factory. Mirrors the warm-reuse worker
+ * (`py-realm-worker.ts`): the realm-side listener stays attached and
+ * hosts a single `PyRealmSession` across many `realm-init` messages,
+ * so the pool can check the same in-process realm out repeatedly
+ * (state reset between runs). Used when no DedicatedWorker is
+ * available (vitest, headless tools that didn't import the default
+ * factory).
+ *
+ * `loaderImport` lets tests inject a fake Pyodide instead of paying
+ * the real ~1-2 s cold boot; production callers omit it and the
+ * session dynamically imports `pyodide`.
+ *
+ * `terminate()` detaches the listener (there's no worker to kill in
+ * process). After eviction the pool creates a fresh in-process realm
+ * on the next checkout, which boots a new session.
  */
-export function createInProcessPyRealmFactory(): RealmFactory {
+export function createInProcessPyRealmFactory(
+  loaderImport?: () => Promise<typeof import('pyodide')>
+): RealmFactory {
   return async ({ kind }) => {
     if (kind !== 'py') {
       throw new Error('createInProcessPyRealmFactory: only kind:py is supported');
     }
     const { realmSide, hostSide } = makeInProcessPortPair();
+    let sessionPromise: Promise<PyRealmSession> | null = null;
+    let busy = false;
     const initHandler = (event: MessageEvent): void => {
       const data = event.data as { type?: string };
       if (data?.type !== 'realm-init') return;
-      realmSide.removeEventListener('message', initHandler);
       const init = event.data as RealmInitMsg;
       if (init.kind !== 'py') return;
-      void runPyRealm(init, realmSide).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        const errMsg: RealmErrorMsg = { type: 'realm-error', message };
-        realmSide.postMessage(errMsg);
+      if (busy) return;
+      busy = true;
+      void (async () => {
+        let session: PyRealmSession;
+        try {
+          if (!sessionPromise) sessionPromise = PyRealmSession.create(init, loaderImport);
+          session = await sessionPromise;
+        } catch (err) {
+          sessionPromise = null;
+          const message = err instanceof Error ? err.message : String(err);
+          const errMsg: RealmErrorMsg = {
+            type: 'realm-error',
+            message: `loadPyodide: ${message}`,
+          };
+          realmSide.postMessage(errMsg);
+          return;
+        }
+        try {
+          await session.run(init, realmSide);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          const errMsg: RealmErrorMsg = { type: 'realm-error', message };
+          realmSide.postMessage(errMsg);
+        }
+      })().finally(() => {
+        busy = false;
       });
     };
     realmSide.addEventListener('message', initHandler);

--- a/packages/webapp/src/kernel/realm/realm-runner.ts
+++ b/packages/webapp/src/kernel/realm/realm-runner.ts
@@ -66,6 +66,38 @@ export interface RealmFactoryArgs {
 export type RealmFactory = (args: RealmFactoryArgs) => Promise<Realm>;
 
 // ---------------------------------------------------------------------------
+// Realm pool abstraction (warm-reuse)
+// ---------------------------------------------------------------------------
+
+/**
+ * A checked-out realm. The runner drives one init/done cycle then
+ * either `release()`s it back to the pool for reuse (clean exit) or
+ * `evict()`s it (error / SIGKILL) so a broken or hard-killed worker
+ * is never handed out again. Both are idempotent and first-wins.
+ *
+ * Defined here (not in `py-realm-pool.ts`) so the runner depends only
+ * on this interface, not the concrete pool — keeps the import edge
+ * one-directional (pool → runner).
+ */
+export interface RealmLease {
+  readonly realm: Realm;
+  /** Return the realm to the pool for reuse. */
+  release(): void;
+  /** Terminate + drop the realm from the pool (broken / killed). */
+  evict(): void;
+}
+
+/**
+ * A pool of warm, reusable realms. `checkout` resolves a lease once
+ * capacity is available (reusing a warm idle realm, creating a new
+ * one under the concurrency limit, or queuing FIFO otherwise).
+ */
+export interface RealmPool {
+  checkout(ctx: CommandContext): Promise<RealmLease>;
+  dispose(): void;
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -209,6 +241,163 @@ export async function runInRealm(opts: RunInRealmOptions): Promise<RealmResult> 
     const init: RealmInitMsg = {
       type: 'realm-init',
       kind: opts.kind,
+      code: opts.code,
+      argv: opts.realmArgv ?? opts.argv,
+      env: opts.env,
+      cwd: opts.cwd,
+      filename: opts.filename,
+      stdin: opts.stdin,
+      pyodideIndexURL: opts.pyodideIndexURL,
+      pyodideSyncDirs: opts.pyodideSyncDirs,
+    };
+    realm.controlPort.postMessage(init);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pooled runner (warm-reuse)
+// ---------------------------------------------------------------------------
+
+export interface RunInPooledRealmOptions {
+  pm: ProcessManager;
+  /** Warm-realm pool to check the worker out of. */
+  pool: RealmPool;
+  owner: ProcessOwner;
+  /** Python source. */
+  code: string;
+  argv: string[];
+  env: Record<string, string>;
+  cwd: string;
+  filename: string;
+  ctx: CommandContext;
+  ppid?: number;
+  /** Override the argv exposed to user code as `sys.argv`. */
+  realmArgv?: string[];
+  /** Optional initial stdin exposed to the user code. */
+  stdin?: string;
+  /** Pyodide indexURL. */
+  pyodideIndexURL?: string;
+  /** Pyodide VFS sync directories. */
+  pyodideSyncDirs?: string[];
+  /** `ProcessKind` to register the process under. Defaults to `'py'`. */
+  procKind?: ProcessKind;
+}
+
+/**
+ * Run `code` in a warm realm checked out of `pool`, hooking the
+ * resulting process into `pm` so `ps` / `kill` see it. Mirrors
+ * `runInRealm` but:
+ *
+ *   - the realm comes from the pool (warm reuse skips cold boot)
+ *     rather than a fresh-per-call factory;
+ *   - the realm host is (re-)attached to THIS call's
+ *     `CommandContext` on every checkout and disposed on return, so
+ *     a reused worker dispatches `vfs`/`exec`/`fetch` against the
+ *     current caller's fs/cwd/secrets — never a previous run's;
+ *   - clean `realm-done` RELEASES the lease back to the pool for
+ *     reuse; `realm-error`, a realm `error` event, and SIGKILL all
+ *     EVICT it (terminate + drop) so a broken / hard-killed worker
+ *     is replaced lazily instead of reused.
+ *
+ * SIGKILL still exits 137 by terminating the underlying worker (via
+ * `lease.evict()` → `realm.terminate()`); the pool lazily spins a
+ * fresh worker on the next checkout.
+ */
+export async function runInPooledRealm(opts: RunInPooledRealmOptions): Promise<RealmResult> {
+  const procKind: ProcessKind = opts.procKind ?? 'py';
+  const proc = opts.pm.spawn({
+    kind: procKind,
+    argv: opts.argv,
+    cwd: opts.cwd,
+    env: opts.env,
+    owner: opts.owner,
+    ppid: opts.ppid,
+  });
+
+  let lease: RealmLease;
+  try {
+    lease = await opts.pool.checkout(opts.ctx);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    opts.pm.exit(proc.pid, 1);
+    return { stdout: '', stderr: `realm-runner: ${message}\n`, exitCode: 1 };
+  }
+
+  const realm = lease.realm;
+  // Re-attach the host to THIS checkout's context. Disposed on
+  // settle so the next checkout of a reused worker re-binds to its
+  // own caller's fs/cwd/secrets.
+  const host: RealmHostHandle = attachRealmHost(realm.controlPort, opts.ctx, {
+    ...(opts.owner.scoopJid !== undefined ? { scoopJid: opts.owner.scoopJid } : {}),
+  });
+
+  return new Promise<RealmResult>((resolve) => {
+    let settled = false;
+    let unsubSignal: (() => void) | null = null;
+    let messageHandler: ((event: MessageEvent) => void) | null = null;
+    let errorHandler: ((event: ErrorEvent) => void) | null = null;
+
+    const cleanup = (): void => {
+      if (messageHandler) realm.controlPort.removeEventListener('message', messageHandler);
+      if (errorHandler && realm.removeEventListener) {
+        realm.removeEventListener('error', errorHandler);
+      }
+      unsubSignal?.();
+      host.dispose();
+    };
+
+    const settle = (
+      result: RealmResult,
+      exitForPm: number | null,
+      disposition: 'release' | 'evict'
+    ): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      try {
+        if (disposition === 'evict') lease.evict();
+        else lease.release();
+      } catch {
+        /* idempotent on the lease */
+      }
+      opts.pm.exit(proc.pid, exitForPm);
+      resolve(result);
+    };
+
+    messageHandler = (event: MessageEvent): void => {
+      const data = event.data as { type?: string };
+      if (data?.type === 'realm-done') {
+        const done = event.data as RealmDoneMsg;
+        settle(
+          { stdout: done.stdout, stderr: done.stderr, exitCode: done.exitCode },
+          done.exitCode,
+          'release'
+        );
+      } else if (data?.type === 'realm-error') {
+        const err = event.data as RealmErrorMsg;
+        settle({ stdout: '', stderr: err.message + '\n', exitCode: 1 }, 1, 'evict');
+      }
+    };
+
+    errorHandler = (event: ErrorEvent): void => {
+      const message = event.message ?? 'realm error';
+      settle({ stdout: '', stderr: message + '\n', exitCode: 1 }, 1, 'evict');
+    };
+
+    // SIGKILL evicts: terminate the worker (137) and drop it from
+    // the pool so it's never reused. The pool lazily replaces it.
+    unsubSignal = opts.pm.onSignal((signaled, sig) => {
+      if (signaled.pid !== proc.pid) return;
+      if (sig !== 'SIGKILL') return;
+      settle({ stdout: '', stderr: '', exitCode: 137 }, 137, 'evict');
+    });
+
+    realm.controlPort.addEventListener('message', messageHandler);
+    if (realm.addEventListener) realm.addEventListener('error', errorHandler);
+
+    const init: RealmInitMsg = {
+      type: 'realm-init',
+      kind: 'py',
       code: opts.code,
       argv: opts.realmArgv ?? opts.argv,
       env: opts.env,

--- a/packages/webapp/src/shell/supplemental-commands/python-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/python-command.ts
@@ -18,22 +18,30 @@
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import type { ProcessManager, ProcessOwner } from '../../kernel/process-manager.js';
+import { createPyRealmPool } from '../../kernel/realm/py-realm-pool.js';
 import {
   createDefaultRealmFactory,
   resolvePyodideIndexURL,
 } from '../../kernel/realm/realm-factory.js';
-import type { RealmFactory } from '../../kernel/realm/realm-runner.js';
-import { runInRealm } from '../../kernel/realm/realm-runner.js';
+import type { RealmFactory, RealmPool } from '../../kernel/realm/realm-runner.js';
+import { runInPooledRealm, runInRealm } from '../../kernel/realm/realm-runner.js';
 import { stdinAsText } from '../just-bash-compat.js';
 
 export interface PythonCommandOptions {
   /**
-   * Override the realm factory. Default: `createDefaultRealmFactory()`
-   * — picks the Pyodide DedicatedWorker realm in both standalone
-   * and extension modes (Pyodide is WASM, only needs
-   * `wasm-unsafe-eval`). Tests can inject a mock.
+   * Override the realm factory. When set, the command runs the
+   * one-shot path (`runInRealm` — fresh realm per call, terminated
+   * after) instead of the warm pool. Tests inject a mock realm here;
+   * production leaves it unset so `python` reuses warm Pyodide
+   * workers from the pool.
    */
   realmFactory?: RealmFactory;
+  /**
+   * Override the warm realm pool. Default: a process-wide singleton
+   * built on `createDefaultRealmFactory()`. Tests inject a pool over
+   * a mock/in-process factory; ignored when `realmFactory` is set.
+   */
+  pool?: RealmPool;
   /** Override the indexURL used by `loadPyodide`. */
   pyodideIndexURL?: string;
 }
@@ -130,41 +138,48 @@ export function createPython3LikeCommand(
       if (!syncDirs.includes(scriptDir)) syncDirs.push(scriptDir);
     }
 
-    const pm = options ? lookupGlobalPm() : null;
     const owner: ProcessOwner = { kind: 'system' };
-    const realmFactory = options.realmFactory ?? createDefaultRealmFactory();
     const pyodideIndexURL = options.pyodideIndexURL ?? resolvePyodideIndexURL();
     // When the program source itself was read from piped stdin, the script
     // must not re-read its own code as input — mirror the `node` command's
     // empty-stdin behavior in that branch.
     const realmStdin = filename === '<stdin>' ? '' : stdinAsText(ctx.stdin);
+    const pm = await resolvePm();
+    const env = Object.fromEntries(ctx.env.entries());
 
-    if (!pm) {
-      return runWithEphemeralPm({
-        realmFactory,
+    // Injected factory → one-shot path (fresh realm per call,
+    // terminated after). Backward-compatible surface tests use to
+    // drive a mock realm. Otherwise route through the warm pool so
+    // the Pyodide interpreter + FS survive between invocations.
+    if (options.realmFactory) {
+      return runInRealm({
+        pm,
+        realmFactory: options.realmFactory,
         owner,
+        kind: 'py',
         code,
         argv: procArgv,
         realmArgv: sysArgv,
-        env: Object.fromEntries(ctx.env.entries()),
+        env,
         cwd: ctx.cwd,
         filename,
         ctx,
         stdin: realmStdin,
         pyodideIndexURL,
         pyodideSyncDirs: syncDirs,
+        procKind: 'py',
       });
     }
 
-    return runInRealm({
+    const pool = options.pool ?? getGlobalPyRealmPool();
+    return runInPooledRealm({
       pm,
-      realmFactory,
+      pool,
       owner,
-      kind: 'py',
       code,
       argv: procArgv,
       realmArgv: sysArgv,
-      env: Object.fromEntries(ctx.env.entries()),
+      env,
       cwd: ctx.cwd,
       filename,
       ctx,
@@ -194,40 +209,34 @@ function lookupGlobalPm(): ProcessManager | null {
   return null;
 }
 
+/**
+ * Resolve the `ProcessManager`: the kernel-host singleton when wired
+ * (`globalThis.__slicc_pm`), else a lazily-built ephemeral one for
+ * vitest / headless tooling so `ps` / `kill` still have a registry.
+ */
 let EphemeralPm: ProcessManager | null = null;
-async function runWithEphemeralPm(args: {
-  realmFactory: RealmFactory;
-  owner: ProcessOwner;
-  code: string;
-  argv: string[];
-  realmArgv?: string[];
-  env: Record<string, string>;
-  cwd: string;
-  filename: string;
-  ctx: Parameters<typeof runInRealm>[0]['ctx'];
-  stdin?: string;
-  pyodideIndexURL: string;
-  pyodideSyncDirs: string[];
-}) {
+async function resolvePm(): Promise<ProcessManager> {
+  const global = lookupGlobalPm();
+  if (global) return global;
   if (!EphemeralPm) {
     const { ProcessManager: PM } = await import('../../kernel/process-manager.js');
     EphemeralPm = new PM();
   }
-  return runInRealm({
-    pm: EphemeralPm,
-    realmFactory: args.realmFactory,
-    owner: args.owner,
-    kind: 'py',
-    code: args.code,
-    argv: args.argv,
-    realmArgv: args.realmArgv,
-    env: args.env,
-    cwd: args.cwd,
-    filename: args.filename,
-    ctx: args.ctx,
-    stdin: args.stdin,
-    pyodideIndexURL: args.pyodideIndexURL,
-    pyodideSyncDirs: args.pyodideSyncDirs,
-    procKind: 'py',
-  });
+  return EphemeralPm;
+}
+
+/**
+ * Process-wide warm Pyodide pool. One per JS context (each kernel
+ * worker / offscreen agent gets its own), stashed on `globalThis` so
+ * a single pool is shared across `WasmShell` instances within the
+ * context. Built on the default realm factory, which falls back to
+ * the reusable in-process Pyodide realm when no `Worker` is
+ * available (vitest / headless).
+ */
+function getGlobalPyRealmPool(): RealmPool {
+  const g = globalThis as { __slicc_py_pool?: RealmPool };
+  if (!g.__slicc_py_pool) {
+    g.__slicc_py_pool = createPyRealmPool({ factory: createDefaultRealmFactory() });
+  }
+  return g.__slicc_py_pool;
 }

--- a/packages/webapp/tests/kernel/realm/py-realm-pool.test.ts
+++ b/packages/webapp/tests/kernel/realm/py-realm-pool.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the warm Pyodide realm pool (`py-realm-pool.ts`).
+ *
+ * Fake realms: the pool only needs `controlPort` + `terminate()`, so
+ * these tests use no-op ports and spy on `terminate` to assert
+ * warm-reuse (factory called once), FIFO queueing past the
+ * concurrency limit, SIGKILL-style eviction + lazy replacement, and
+ * idle-TTL drop — without booting Pyodide.
+ */
+
+import type { CommandContext } from 'just-bash';
+import { describe, expect, it, vi } from 'vitest';
+import { createPyRealmPool } from '../../../src/kernel/realm/py-realm-pool.js';
+import type { RealmPortLike } from '../../../src/kernel/realm/realm-rpc.js';
+import type { Realm, RealmFactory } from '../../../src/kernel/realm/realm-runner.js';
+
+const ctx = {} as CommandContext;
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+function makeFakeRealm(): Realm {
+  const port: RealmPortLike = {
+    postMessage: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  return { controlPort: port, terminate: vi.fn() };
+}
+
+function trackingFactory(): RealmFactory {
+  return vi.fn(async ({ kind }) => {
+    if (kind !== 'py') throw new Error('only py');
+    return makeFakeRealm();
+  });
+}
+
+describe('PyRealmPool', () => {
+  it('reuses a warm idle worker across sequential checkouts (factory called once)', async () => {
+    const factory = trackingFactory();
+    const pool = createPyRealmPool({ factory, warmIdle: 1, maxConcurrent: 2, idleTtlMs: 0 });
+    const l1 = await pool.checkout(ctx);
+    l1.release();
+    const l2 = await pool.checkout(ctx);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(l2.realm).toBe(l1.realm);
+    pool.dispose();
+  });
+
+  it('creates up to maxConcurrent, queues the rest FIFO, and hands reused workers to waiters', async () => {
+    const factory = trackingFactory();
+    const pool = createPyRealmPool({ factory, warmIdle: 2, maxConcurrent: 2, idleTtlMs: 0 });
+    const l1 = await pool.checkout(ctx);
+    const l2 = await pool.checkout(ctx);
+    expect(factory).toHaveBeenCalledTimes(2);
+
+    const order: string[] = [];
+    let l3: Awaited<ReturnType<typeof pool.checkout>> | undefined;
+    let l4: Awaited<ReturnType<typeof pool.checkout>> | undefined;
+    void pool.checkout(ctx).then((l) => {
+      l3 = l;
+      order.push('c');
+    });
+    void pool.checkout(ctx).then((l) => {
+      l4 = l;
+      order.push('d');
+    });
+    await flush();
+    expect(pool.stats().waiting).toBe(2);
+    expect(l3).toBeUndefined();
+
+    l1.release();
+    await flush();
+    l2.release();
+    await flush();
+
+    expect(factory).toHaveBeenCalledTimes(2); // reused, not recreated
+    expect(l3?.realm).toBe(l1.realm);
+    expect(l4?.realm).toBe(l2.realm);
+    expect(order).toEqual(['c', 'd']); // FIFO
+    pool.dispose();
+  });
+
+  it('evicts a worker (terminate) and lazily creates a replacement for a queued waiter', async () => {
+    const factory = trackingFactory();
+    const pool = createPyRealmPool({ factory, warmIdle: 1, maxConcurrent: 1, idleTtlMs: 0 });
+    const l1 = await pool.checkout(ctx);
+    let l2: Awaited<ReturnType<typeof pool.checkout>> | undefined;
+    void pool.checkout(ctx).then((l) => {
+      l2 = l;
+    });
+    await flush();
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    l1.evict();
+    await flush();
+    expect(l1.realm.terminate).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2); // lazy replacement
+    expect(l2).toBeDefined();
+    expect(l2?.realm).not.toBe(l1.realm);
+    pool.dispose();
+  });
+
+  it('evict with no waiters drops the worker; the next checkout creates a fresh one', async () => {
+    const factory = trackingFactory();
+    const pool = createPyRealmPool({ factory, warmIdle: 1, maxConcurrent: 2, idleTtlMs: 0 });
+    const l1 = await pool.checkout(ctx);
+    l1.evict();
+    expect(l1.realm.terminate).toHaveBeenCalledTimes(1);
+    expect(pool.stats()).toMatchObject({ idle: 0, busy: 0 });
+    const l2 = await pool.checkout(ctx);
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(l2.realm).not.toBe(l1.realm);
+    pool.dispose();
+  });
+
+  it('keeps warmIdle workers warm and drops extras after the idle TTL', async () => {
+    vi.useFakeTimers();
+    try {
+      const factory = trackingFactory();
+      const pool = createPyRealmPool({ factory, warmIdle: 1, maxConcurrent: 3, idleTtlMs: 1000 });
+      const l1 = await pool.checkout(ctx);
+      const l2 = await pool.checkout(ctx);
+      l1.release();
+      l2.release();
+      expect(pool.stats().idle).toBe(2);
+
+      vi.advanceTimersByTime(1001);
+      expect(pool.stats().idle).toBe(1); // one warm survivor
+      expect(l2.realm.terminate).toHaveBeenCalledTimes(1); // extra dropped
+      expect(l1.realm.terminate).not.toHaveBeenCalled();
+      pool.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('dispose terminates idle + busy workers and rejects pending waiters', async () => {
+    const factory = trackingFactory();
+    const pool = createPyRealmPool({ factory, warmIdle: 1, maxConcurrent: 1, idleTtlMs: 0 });
+    const l1 = await pool.checkout(ctx);
+    let rejected = false;
+    void pool.checkout(ctx).catch(() => {
+      rejected = true;
+    });
+    await flush();
+    pool.dispose();
+    await flush();
+    expect(l1.realm.terminate).toHaveBeenCalledTimes(1);
+    expect(rejected).toBe(true);
+    await expect(pool.checkout(ctx)).rejects.toThrow(/disposed/);
+  });
+});

--- a/packages/webapp/tests/kernel/realm/py-realm-session.test.ts
+++ b/packages/webapp/tests/kernel/realm/py-realm-session.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for `PyRealmSession` warm reuse + per-run state reset.
+ *
+ * A fake Pyodide (loaded via an injected `loaderImport`) lets us
+ * assert that `loadPyodide` runs ONCE across many runs (warm reuse
+ * skips cold boot), the module baseline is captured once, the reset
+ * snippet runs only on reused runs, and stale scratch files are
+ * cleared before a reused run re-mirrors VFS. The
+ * `RealmRpcClient.walkTree` calls are answered by a responding port.
+ */
+
+import type { PyodideInterface } from 'pyodide';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  PY_BASELINE_SNIPPET,
+  PY_RESET_SNIPPET,
+  PyRealmSession,
+} from '../../../src/kernel/realm/py-realm-shared.js';
+import type { RealmPortLike } from '../../../src/kernel/realm/realm-rpc.js';
+import type { RealmInitMsg } from '../../../src/kernel/realm/realm-types.js';
+
+const DIR_MODE = 0o40000;
+const FILE_MODE = 0o100000;
+
+function makeFakePyodide(): {
+  pyodide: PyodideInterface;
+  files: Map<string, Uint8Array>;
+  runPython: ReturnType<typeof vi.fn>;
+} {
+  const dirs = new Set<string>(['/', '/workspace', '/tmp']);
+  const files = new Map<string, Uint8Array>();
+  const globals = new Map<string, unknown>();
+  const enc = new TextEncoder();
+  let stdoutCb: ((s: string) => void) | null = null;
+  const FS = {
+    stat: (p: string) => {
+      if (dirs.has(p)) return { mode: DIR_MODE, size: 0 };
+      const f = files.get(p);
+      if (f) return { mode: FILE_MODE, size: f.length };
+      throw new Error(`ENOENT: ${p}`);
+    },
+    mkdirTree: (p: string) => {
+      let c = '';
+      for (const part of p.split('/').filter(Boolean)) {
+        c += `/${part}`;
+        dirs.add(c);
+      }
+      dirs.add('/');
+    },
+    writeFile: (p: string, c: string | Uint8Array) =>
+      files.set(p, typeof c === 'string' ? enc.encode(c) : new Uint8Array(c)),
+    readFile: (p: string) => {
+      const f = files.get(p);
+      if (!f) throw new Error(`ENOENT: ${p}`);
+      return f;
+    },
+    readdir: (p: string) => {
+      if (!dirs.has(p)) throw new Error(`ENOENT: ${p}`);
+      const out = new Set<string>(['.', '..']);
+      const prefix = p === '/' ? '/' : `${p}/`;
+      for (const key of [...files.keys(), ...dirs]) {
+        if (!key.startsWith(prefix) || key === p) continue;
+        const rest = key.slice(prefix.length);
+        const slash = rest.indexOf('/');
+        out.add(slash === -1 ? rest : rest.slice(0, slash));
+      }
+      return [...out];
+    },
+    isDir: (m: number) => (m & 0o170000) === DIR_MODE,
+    isFile: (m: number) => (m & 0o170000) === FILE_MODE,
+    chdir: vi.fn(),
+    rmdir: (p: string) => void dirs.delete(p),
+    unlink: (p: string) => void files.delete(p),
+  };
+  const runPython = vi.fn((_code: string) => {});
+  const pyodide = {
+    FS,
+    runPython,
+    runPythonAsync: vi.fn(async (_code: string) => {
+      stdoutCb?.('hello');
+      globals.set('__slicc_exit_code', 0);
+    }),
+    setStdout: vi.fn((o: { batched: (s: string) => void }) => {
+      stdoutCb = o.batched;
+    }),
+    setStderr: vi.fn(),
+    setStdin: vi.fn(),
+    globals: {
+      set: (k: string, v: unknown) => globals.set(k, v),
+      get: (k: string) => globals.get(k),
+    },
+  } as unknown as PyodideInterface;
+  return { pyodide, files, runPython };
+}
+
+function makeRespondingPort(): { port: RealmPortLike; posted: unknown[] } {
+  const handlers = new Set<(e: MessageEvent) => void>();
+  const posted: unknown[] = [];
+  const port: RealmPortLike = {
+    postMessage: (msg) => {
+      posted.push(msg);
+      const m = msg as { type?: string; id?: number; op?: string };
+      if (m.type !== 'realm-rpc-req') return;
+      const result = m.op === 'writeBatch' ? { ok: true, failedMkdirs: [], failedFiles: [] } : [];
+      queueMicrotask(() => {
+        for (const h of [...handlers]) {
+          h({ data: { type: 'realm-rpc-res', id: m.id, result } } as MessageEvent);
+        }
+      });
+    },
+    addEventListener: (_t, h) => void handlers.add(h),
+    removeEventListener: (_t, h) => void handlers.delete(h),
+  };
+  return { port, posted };
+}
+
+const init: RealmInitMsg = {
+  type: 'realm-init',
+  kind: 'py',
+  code: 'print("hi")',
+  argv: ['-c'],
+  env: {},
+  cwd: '/workspace',
+  filename: '-c',
+  pyodideSyncDirs: ['/workspace', '/tmp'],
+};
+
+describe('PyRealmSession warm reuse + reset', () => {
+  it('loads Pyodide once, captures the baseline once, and resets only on reused runs', async () => {
+    const { pyodide, files, runPython } = makeFakePyodide();
+    const loadPyodide = vi.fn(async () => pyodide);
+    const loader = async () => ({ loadPyodide }) as unknown as typeof import('pyodide');
+
+    const session = await PyRealmSession.create(init, loader);
+    expect(loadPyodide).toHaveBeenCalledTimes(1);
+    const baselineCalls = () =>
+      runPython.mock.calls.filter((c) => c[0] === PY_BASELINE_SNIPPET).length;
+    const resetCalls = () => runPython.mock.calls.filter((c) => c[0] === PY_RESET_SNIPPET).length;
+    expect(baselineCalls()).toBe(1);
+    expect(resetCalls()).toBe(0);
+
+    // First run: no reset (nothing carried yet).
+    await session.run(init, makeRespondingPort().port);
+    expect(resetCalls()).toBe(0);
+
+    // A file the previous run left in cwd that VFS no longer has.
+    pyodide.FS.writeFile('/workspace/leak.txt', 'stale');
+    expect(files.has('/workspace/leak.txt')).toBe(true);
+
+    // Second run: warm reuse — no second load — and state reset.
+    const { port, posted } = makeRespondingPort();
+    await session.run(init, port);
+    expect(loadPyodide).toHaveBeenCalledTimes(1);
+    expect(baselineCalls()).toBe(1);
+    expect(resetCalls()).toBe(1);
+    expect(files.has('/workspace/leak.txt')).toBe(false); // scratch cleared
+    const done = posted.find((m) => (m as { type?: string }).type === 'realm-done') as {
+      stdout: string;
+      exitCode: number;
+    };
+    expect(done).toMatchObject({ exitCode: 0, stdout: 'hello\n' });
+  });
+});

--- a/packages/webapp/tests/kernel/realm/realm-runner-pooled.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-runner-pooled.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for `runInPooledRealm` — the warm-reuse runner.
+ *
+ * A fake pool hands out a lease wrapping an in-memory mock realm and
+ * records `release()` vs `evict()`. Pins: clean exit RELEASES the
+ * lease, errors / SIGKILL EVICT it (137 on kill), and the realm host
+ * is re-attached to the CURRENT checkout's `CommandContext` (the
+ * previous run's host is disposed on return).
+ */
+
+import type { CommandContext } from 'just-bash';
+import { describe, expect, it, vi } from 'vitest';
+import { ProcessManager } from '../../../src/kernel/process-manager.js';
+import type { RealmPortLike } from '../../../src/kernel/realm/realm-rpc.js';
+import type { Realm, RealmLease, RealmPool } from '../../../src/kernel/realm/realm-runner.js';
+import { runInPooledRealm } from '../../../src/kernel/realm/realm-runner.js';
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+interface MockRealm extends Realm {
+  fireMessage(data: unknown): void;
+  posted: unknown[];
+  lastPosted(): unknown;
+}
+
+function makeMockRealm(): MockRealm {
+  const handlers = new Set<(e: MessageEvent) => void>();
+  const posted: unknown[] = [];
+  const port: RealmPortLike = {
+    postMessage: (msg) => posted.push(msg),
+    addEventListener: (_t, h) => handlers.add(h),
+    removeEventListener: (_t, h) => handlers.delete(h),
+  };
+  return {
+    controlPort: port,
+    terminate: vi.fn(),
+    posted,
+    fireMessage: (data) => {
+      for (const h of [...handlers]) h({ data } as MessageEvent);
+    },
+    lastPosted: () => posted[posted.length - 1],
+  };
+}
+
+function makeReusingPool(realm: Realm): {
+  pool: RealmPool;
+  events: { releases: number; evicts: number; checkouts: CommandContext[] };
+} {
+  const events = { releases: 0, evicts: 0, checkouts: [] as CommandContext[] };
+  const pool: RealmPool = {
+    checkout: async (ctx) => {
+      events.checkouts.push(ctx);
+      let done = false;
+      const lease: RealmLease = {
+        realm,
+        release: () => {
+          if (done) return;
+          done = true;
+          events.releases++;
+        },
+        evict: () => {
+          if (done) return;
+          done = true;
+          events.evicts++;
+        },
+      };
+      return lease;
+    },
+    dispose: () => {},
+  };
+  return { pool, events };
+}
+
+const baseOpts = {
+  owner: { kind: 'cone' as const },
+  code: '',
+  argv: ['python3'],
+  env: {},
+  cwd: '/workspace',
+  filename: '-c',
+  ctx: {} as CommandContext,
+};
+
+describe('runInPooledRealm', () => {
+  it('posts realm-init, resolves on realm-done, and RELEASES the lease', async () => {
+    const pm = new ProcessManager();
+    const realm = makeMockRealm();
+    const { pool, events } = makeReusingPool(realm);
+    const promise = runInPooledRealm({ pm, pool, ...baseOpts, code: 'print(1)' });
+    await flush();
+    expect(realm.lastPosted()).toMatchObject({ type: 'realm-init', kind: 'py', code: 'print(1)' });
+    realm.fireMessage({ type: 'realm-done', stdout: '1\n', stderr: '', exitCode: 0 });
+    const result = await promise;
+    expect(result).toEqual({ stdout: '1\n', stderr: '', exitCode: 0 });
+    expect(events).toMatchObject({ releases: 1, evicts: 0 });
+    const proc = pm.list()[0];
+    expect(proc.kind).toBe('py');
+    expect(proc.exitCode).toBe(0);
+  });
+
+  it('EVICTS the lease on realm-error (exit 1)', async () => {
+    const pm = new ProcessManager();
+    const realm = makeMockRealm();
+    const { pool, events } = makeReusingPool(realm);
+    const promise = runInPooledRealm({ pm, pool, ...baseOpts });
+    await flush();
+    realm.fireMessage({ type: 'realm-error', message: 'boom' });
+    const result = await promise;
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('boom');
+    expect(events).toMatchObject({ releases: 0, evicts: 1 });
+  });
+
+  it('SIGKILL exits 137 and EVICTS the lease', async () => {
+    const pm = new ProcessManager();
+    const realm = makeMockRealm();
+    const { pool, events } = makeReusingPool(realm);
+    const promise = runInPooledRealm({ pm, pool, ...baseOpts, code: 'while True: pass' });
+    await flush();
+    const proc = pm.list()[0];
+    pm.signal(proc.pid, 'SIGKILL');
+    const result = await promise;
+    expect(result.exitCode).toBe(137);
+    expect(events).toMatchObject({ releases: 0, evicts: 1 });
+    expect(proc.status).toBe('killed');
+  });
+
+  it('fails fast (exit 1) when checkout rejects', async () => {
+    const pm = new ProcessManager();
+    const pool: RealmPool = {
+      checkout: async () => Promise.reject(new Error('no capacity')),
+      dispose: () => {},
+    };
+    const result = await runInPooledRealm({ pm, pool, ...baseOpts });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('no capacity');
+    expect(pm.list()[0].exitCode).toBe(1);
+  });
+
+  it('re-attaches the host to the current ctx on each checkout (old host disposed)', async () => {
+    const pm = new ProcessManager();
+    const realm = makeMockRealm();
+    const { pool } = makeReusingPool(realm);
+    const makeFsCtx = (marker: string): CommandContext =>
+      ({
+        cwd: '/workspace',
+        fs: { resolvePath: (b: string, p: string) => `${b}/${p}`, readFile: async () => marker },
+      }) as unknown as CommandContext;
+
+    const p1 = runInPooledRealm({ pm, pool, ...baseOpts, ctx: makeFsCtx('A') });
+    await flush();
+    realm.fireMessage({ type: 'realm-done', stdout: '', stderr: '', exitCode: 0 });
+    await p1;
+
+    const p2 = runInPooledRealm({ pm, pool, ...baseOpts, ctx: makeFsCtx('B') });
+    await flush();
+    realm.posted.length = 0;
+    realm.fireMessage({
+      type: 'realm-rpc-req',
+      id: 99,
+      channel: 'vfs',
+      op: 'readFile',
+      args: ['x.txt'],
+    });
+    await flush();
+    const results = realm.posted
+      .filter((m): m is { type: string; id: number; result: unknown } => {
+        const x = m as { type?: string; id?: number };
+        return x?.type === 'realm-rpc-res' && x.id === 99;
+      })
+      .map((m) => m.result);
+    expect(results).toEqual(['B']); // exactly one response, from ctxB → host A disposed
+    realm.fireMessage({ type: 'realm-done', stdout: '', stderr: '', exitCode: 0 });
+    await p2;
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the Pyodide performance problem at the root by eliminating the eager "copy the whole cwd + /tmp tree into MEMFS on every invocation" model. Tracked in the workspace spec.

This is a draft — multi-wave work in progress (opened overnight per request).

### Wave 1 — Warm, reusable Pyodide worker pool (committed)
Replaces the one-shot "spawn a fresh worker per python invocation, then terminate" model with a pool of warm, reusable Pyodide realms.
- New py-realm-pool.ts: 1 warm idle, up to 2 parallel, FIFO queue when saturated, SIGKILL eviction + lazy replacement, idle-TTL drop.
- Reusable-realm protocol: a worker accepts a new realm-init after realm-done instead of being terminated; per-run interpreter state reset (sys.modules baseline + clean __main__ + MEMFS scratch).
- Per-checkout host re-attach to the current CommandContext.
- Keeps the existing eager VFS-to-Pyodide sync (runs against the reused worker).

Gates: typecheck, lint, and the webapp realm test suite (229 tests) all green.

### Wave 2 — JSPI-backed lazy filesystem for Python (in progress)
Spike-first: confirm Pyodide 0.29.4 + Emscripten exposes a JSPI-suspendable custom-FS hook. If viable, mount the whole VFS tree lazily over the realm RPC channel (no cwd//tmp subset restriction — reads are on-demand). Capability-gated with an eager-copy fallback (scoped to cwd//tmp) for non-JSPI runtimes. If the spike fails, fall back to incremental delta-sync on the warm pool. No SharedArrayBuffer / cross-origin isolation.

### Wave 3 — Harden the eager-copy fallback path
Surface real FsError causes instead of the generic "unreadable from VFS" warning.

## Test plan
- npm run lint
- npm run typecheck
- npm run test -w @slicc/webapp -- realm
- npm run test
