### PR TITLE
fix(chat): fix markdown element contrast in user message bubbles

### DIFF
--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -99,6 +99,16 @@
 .msg.msg--user pre code {
   color: #e8e0ff;
 }
+.msg.msg--user .msg__content th {
+  background: rgba(0, 0, 0, 0.2);
+}
+.msg.msg--user .msg__content th,
+.msg.msg--user .msg__content td {
+  border-color: rgba(255, 255, 255, 0.25);
+}
+.msg.msg--user .msg__content blockquote {
+  color: rgba(255, 255, 255, 0.8);
+}
 .msg--user .msg__attachments {
   margin-bottom: 8px;
 }

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -92,11 +92,11 @@
   background: rgba(255, 255, 255, 0.18);
   color: #fff;
 }
-.msg--user pre {
+.msg.msg--user pre {
   background: rgba(0, 0, 0, 0.25);
   border-color: rgba(255, 255, 255, 0.1);
 }
-.msg--user pre code {
+.msg.msg--user pre code {
   color: #e8e0ff;
 }
 .msg--user .msg__attachments {

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -76,15 +76,15 @@
   line-height: 18px;
   letter-spacing: 0;
 }
-.msg--user .msg__content a,
-.msg--user .msg__content a:visited {
-  color: #c8bbff;
+.msg.msg--user .msg__content a,
+.msg.msg--user .msg__content a:visited {
+  color: #fff;
   text-decoration: underline;
 }
-.msg--user .msg__content a:hover {
+.msg.msg--user .msg__content a:hover {
   color: #fff;
 }
-.msg--user :not(pre) > code {
+.msg.msg--user :not(pre) > code {
   background: rgba(255, 255, 255, 0.18);
   color: #fff;
 }

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -80,9 +80,13 @@
 .msg.msg--user .msg__content a:visited {
   color: #fff;
   text-decoration: underline;
+  text-decoration-color: rgba(255, 255, 255, 0.6);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
 }
 .msg.msg--user .msg__content a:hover {
   color: #fff;
+  text-decoration-color: #fff;
 }
 .msg.msg--user :not(pre) > code {
   background: rgba(255, 255, 255, 0.18);


### PR DESCRIPTION
## Summary

Fixes #862. Multiple markdown elements were unreadable inside user message bubbles (`.msg--user`) due to CSS cascade conflicts: `markdown.css` is imported after `chat.css`, so at equal specificity its generic `.msg` / `.msg__content` rules won over the user-bubble overrides. (One offender was intra-file: `.theme-light .msg__content a` sits later in `chat.css` and beat the user-bubble link rule.)

The user bubble is purple (`#7155fa`) in **both** themes, but the losing cascade left it with light-theme backgrounds/text, producing catastrophic contrast.

## Elements fixed

| Element | Before | After |
|---|---|---|
| Inline `code` | white on light-gray (~1.3:1) | white on translucent-white overlay |
| Fenced `pre` block | lavender text on light-gray bg | lavender on dark overlay |
| Links | browser-default blue on purple (~1.04:1) | white + styled underline (4.79:1, WCAG AA) |
| Table `th` bg | white on light-gray (~1.1:1) | white on dark overlay |
| Table `th`/`td` borders | invisible light-gray | `rgba(255,255,255,0.25)` |
| Blockquote text | dark-gray on purple (~1.3:1) | `rgba(255,255,255,0.8)` |

## Approach

Raised the user-bubble overrides to `.msg.msg--user` (class-doubling specificity bump) so they win regardless of stylesheet load order, and added rules for table/blockquote which previously had none. All overrides are theme-independent, matching the always-purple bubble.

Note: chose white over the issue's suggested lavender `#c8bbff` for links — lavender only reaches 2.74:1 against the purple bubble (fails AA); white reaches 4.79:1.

## Test plan

- [x] `npm run build -w @slicc/webapp` — clean
- [x] Verified each element via `?ui-fixture=1` + injected probes (computed styles + screenshots)
- [ ] Light and dark theme spot-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
