### PR TITLE
chore(e2b-template): raise hosted-cone sandbox memory to 8GB

### DIFF
--- a/packages/dev-tools/e2b-template/template.ts
+++ b/packages/dev-tools/e2b-template/template.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
 
   console.log('Template definition built, starting Template.build…');
   const buildInfo = await Template.build(template, 'slicc', {
-    memoryMB: 2048,
+    memoryMB: 8192,
     onBuildLogs: defaultBuildLogger({ minLevel: 'debug' }),
   });
   console.log('Published template slicc:', buildInfo);


### PR DESCRIPTION
## What

Raise the e2b template build memory from **2048 MB → 8192 MB** (8 GB) so hosted cloud cones get more RAM.

Single change: the `memoryMB` option passed to `Template.build(template, 'slicc', …)` in `packages/dev-tools/e2b-template/template.ts`.

## How it takes effect

This is the **only** source-level memory knob — memory is baked into the e2b template snapshot at build time, not set per-cone at `Sandbox.create()` (`packages/cloud-core/src/substrates/e2b.ts` passes no memory option). The change does nothing in production until the `slicc` template is rebuilt and **republished** (`Template.build` builds + publishes in one shot):

```bash
npm run build
export E2B_API_KEY=...   # team that owns the 'slicc' template
bash packages/dev-tools/e2b-template/scripts/build-template.sh
```

## Caveats

- **Plan tier cap**: e2b gates memory/cpu by plan; `requestBuild` will reject 8192 MB if the team's plan doesn't allow it. `cpuCount` stays at the SDK default (2) — may need bumping if e2b requires paired cpu/mem.
- **Existing cones unaffected**: running and paused cones resume from their old 2 GB snapshot; only cones created after the republish get 8 GB.
- **No tests/docs touched**: no doc references the memory figure (verified via grep), and a build-script constant isn't covered by — or suitable for — a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)