### PR TITLE
ci: fix Claude Code action workflows (auth, bot PRs, turn budget)

### DIFF
--- a/.github/workflows/agentic-debt-triage.yml
+++ b/.github/workflows/agentic-debt-triage.yml
@@ -100,6 +100,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           use_bedrock: 'true'
+          # Pass the workflow's GITHUB_TOKEN explicitly so the action uses it
+          # directly instead of attempting an OIDC -> GitHub App token exchange
+          # (which fails with "User does not have write access" when the Claude
+          # GitHub App is not installed on this repo). Job permissions above
+          # (issues: write) scope this token appropriately.
+          github_token: ${{ github.token }}
           # Print Claude's full turn-by-turn output to the Actions log on manual
           # dispatch (to inspect its reasoning); kept off for the nightly cron so
           # routine runs don't log tool output that may contain sensitive data.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -47,7 +47,13 @@ jobs:
     # Skip fork PRs: secrets are unavailable on `pull_request` from forks, and
     # reviewing them safely would require `pull_request_target` + a security
     # review (out of scope). Only run when the PR head lives in this repo.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Also skip bot-authored PRs (e.g. Renovate dependency bumps): they don't
+    # need an AI review, and claude-code-action rejects bot-initiated runs by
+    # default ("Workflow initiated by non-human actor"), which only produced
+    # noisy failed runs.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.type != 'Bot'
     steps:
       - name: Wait 5 minutes for personal/human reviewers
         run: sleep 300
@@ -101,7 +107,7 @@ jobs:
           claude_args: |
             --model ${{ vars.PR_REVIEW_BEDROCK_MODEL || vars.RUM_BEDROCK_MODEL || 'global.anthropic.claude-sonnet-4-6' }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
-            --max-turns 40
+            --max-turns 200
           prompt: |
             You are performing an automated code review for the SLICC codebase.
 

--- a/.github/workflows/rum-error-triage.yml
+++ b/.github/workflows/rum-error-triage.yml
@@ -97,6 +97,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           use_bedrock: 'true'
+          # Pass the workflow's GITHUB_TOKEN explicitly so the action uses it
+          # directly instead of attempting an OIDC -> GitHub App token exchange
+          # (which fails with "User does not have write access" when the Claude
+          # GitHub App is not installed on this repo). Job permissions above
+          # (contents/issues/pull-requests: write) scope this token appropriately.
+          github_token: ${{ github.token }}
           # Print Claude's full turn-by-turn output to the Actions log on manual
           # dispatch (to inspect its reasoning); kept off for the nightly cron so
           # routine runs don't log tool output that may contain sensitive data.


### PR DESCRIPTION
## Summary

Diagnosed recent failures across the three `anthropics/claude-code-action` workflows and fixed three distinct root causes.

| Workflow | Symptom | Root cause | Fix |
|---|---|---|---|
| RUM Error Triage | `401 User does not have write access` on runs with candidates (green runs just skip Claude) | No `github_token` input -> action attempts an OIDC->GitHub App token exchange that fails (Claude App not installed) | Pass `github_token` |
| Agentic Debt Triage | Fails every run | Same as above | Pass `github_token` |
| Claude PR Review | Fails on Renovate PRs (`Workflow initiated by non-human actor`) | Bot-initiated runs blocked by default | Skip bot-authored PRs via job `if:` |
| Claude PR Review | Fails on large PRs (`error_max_turns`) | `--max-turns 40` too low (Opus burns turns exploring) | Raise to `--max-turns 200` |

## Notes
- `claude-pr-review.yml` already passed `github_token`, which is why it never hit the 401 - the other two now match it.
- Bot PRs (Renovate) are skipped rather than allowed: dependency bumps do not need an AI review, and this removes the noisy failed runs.
- Prettier-clean; only workflow YAML touched.