### PR TITLE
fix(shell): remove ui/ back-edge from worker-safe shell base (#869)

### DIFF
--- a/packages/webapp/src/shell/telemetry-hook.ts
+++ b/packages/webapp/src/shell/telemetry-hook.ts
@@ -1,0 +1,29 @@
+/**
+ * Worker-safe telemetry hook for the shell layer.
+ *
+ * The shell (a low layer in the stack) must not import the UI's
+ * `ui/telemetry.ts`, which reaches `window`, `localStorage`, and
+ * `@adobe/helix-rum-js` — a back-edge against the layer stack that
+ * also keeps the worker-resident shell out of the no-DOM typecheck
+ * guard (`tsconfig.webapp-worker.json`).
+ *
+ * Instead, the shell emits through this dependency-inversion sink:
+ * the UI registers `trackShellCommand` via `setShellTelemetrySink`
+ * during `initTelemetry()`, and the shell calls `emitShellCommand`
+ * with no knowledge of the UI. When no sink is registered (worker
+ * float without a page-side telemetry init), emits are dropped.
+ */
+
+type ShellTelemetrySink = (commandName: string) => void;
+
+let sink: ShellTelemetrySink | null = null;
+
+/** Register (or clear with `null`) the shell telemetry sink. */
+export function setShellTelemetrySink(fn: ShellTelemetrySink | null): void {
+  sink = fn;
+}
+
+/** Emit a shell-command telemetry event through the registered sink. */
+export function emitShellCommand(commandName: string): void {
+  sink?.(commandName);
+}

--- a/packages/webapp/src/shell/wasm-shell-headless.ts
+++ b/packages/webapp/src/shell/wasm-shell-headless.ts
@@ -4,11 +4,15 @@
  * The agent's `bash` tool calls run here. Owns just-bash,
  * the VFS adapter, custom commands (git, mount, supplemental), the
  * `.jsh` discovery + sync loop, and the `executeCommand` /
- * `executeScriptFile` primitives. Zero DOM — the file lives outside
- * `tsconfig.webapp-worker.json`'s include list today only because of
- * its transitive imports, but every line of this class is worker-
- * safe in principle (`setInterval`, `IndexedDB`-backed VFS, no
- * `window`/`document`).
+ * `executeScriptFile` primitives. Zero DOM in this class's own code
+ * (`setInterval`, `IndexedDB`-backed VFS only). Shell-command
+ * telemetry is emitted through the dependency-inverted
+ * `telemetry-hook.ts` sink (the UI registers `trackShellCommand`)
+ * rather than importing `ui/telemetry.ts` directly, so the shell no
+ * longer carries a back-edge into the `ui/` layer. The file still
+ * lives outside `tsconfig.webapp-worker.json`'s no-DOM include
+ * because its remaining (type-only) `cdp/` imports transitively reach
+ * the DOM-bound CDP transports.
  *
  * The view layer — `WasmShell` in `wasm-shell.ts` — extends this
  * class and adds xterm mounting, the line editor, history, and
@@ -32,7 +36,6 @@ import type { FsWatcher, VirtualFS } from '../fs/index.js';
 import { MountCommands } from '../fs/mount-commands.js';
 import { GitCommands } from '../git/git-commands.js';
 import type { ProcessManager, ProcessOwner } from '../kernel/process-manager.js';
-import { trackShellCommand } from '../ui/telemetry.js';
 import type { BshDiscoveryFS } from './bsh-discovery.js';
 import type { JshDiscoveryFS } from './jsh-discovery.js';
 import type { JshProcessConfig } from './jsh-executor.js';
@@ -47,6 +50,7 @@ import {
 } from './supplemental-commands/upskill-command.js';
 import type { MediaPreviewItem } from './supplemental-commands.js';
 import { createSupplementalCommands } from './supplemental-commands.js';
+import { emitShellCommand } from './telemetry-hook.js';
 import { VfsAdapter } from './vfs-adapter.js';
 
 // ---------------------------------------------------------------------------
@@ -414,7 +418,7 @@ export class WasmShellHeadless implements HeadlessShellLike {
    */
   protected async runCommand(command: string, signal?: AbortSignal): Promise<BashExecResult> {
     const commandName = command.trim().split(/\s+/)[0] || 'unknown';
-    trackShellCommand(commandName);
+    emitShellCommand(commandName);
 
     // just-bash's published ExecOptions type does not yet expose
     // AbortSignal, but we still forward it so external callers and

--- a/packages/webapp/src/ui/telemetry.ts
+++ b/packages/webapp/src/ui/telemetry.ts
@@ -12,6 +12,8 @@
  * - navigate: page load with deployment mode
  */
 
+import { setShellTelemetrySink } from '../shell/telemetry-hook.js';
+
 type SampleRUM = (checkpoint: string, data?: { source?: string; target?: string }) => void;
 
 let sampleRUM: SampleRUM | null = null;
@@ -43,6 +45,11 @@ export async function initTelemetry(): Promise<void> {
   if (initialized) return;
   if (typeof localStorage !== 'undefined' && localStorage.getItem('telemetry-disabled') === 'true')
     return;
+
+  // Register the shell telemetry sink so the worker-resident shell can emit
+  // command beacons without importing this DOM-bound module (dependency
+  // inversion — keeps the shell layer free of a back-edge into ui/).
+  setShellTelemetrySink(trackShellCommand);
 
   try {
     const mode = getModeLabel();

--- a/packages/webapp/tests/shell/telemetry-hook.test.ts
+++ b/packages/webapp/tests/shell/telemetry-hook.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { emitShellCommand, setShellTelemetrySink } from '../../src/shell/telemetry-hook.js';
+
+describe('shell telemetry-hook', () => {
+  beforeEach(() => {
+    setShellTelemetrySink(null);
+  });
+
+  afterEach(() => {
+    setShellTelemetrySink(null);
+  });
+
+  it('drops emits when no sink is registered', () => {
+    expect(() => emitShellCommand('git')).not.toThrow();
+  });
+
+  it('routes emits to the registered sink', () => {
+    const sink = vi.fn();
+    setShellTelemetrySink(sink);
+
+    emitShellCommand('git');
+    emitShellCommand('ls');
+
+    expect(sink).toHaveBeenCalledTimes(2);
+    expect(sink).toHaveBeenNthCalledWith(1, 'git');
+    expect(sink).toHaveBeenNthCalledWith(2, 'ls');
+  });
+
+  it('stops emitting after the sink is cleared', () => {
+    const sink = vi.fn();
+    setShellTelemetrySink(sink);
+    emitShellCommand('git');
+    setShellTelemetrySink(null);
+    emitShellCommand('ls');
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledWith('git');
+  });
+
+  it('replaces a previously registered sink', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    setShellTelemetrySink(first);
+    setShellTelemetrySink(second);
+
+    emitShellCommand('node');
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith('node');
+  });
+});

--- a/packages/webapp/tests/ui/telemetry.test.ts
+++ b/packages/webapp/tests/ui/telemetry.test.ts
@@ -91,6 +91,16 @@ describe('telemetry', () => {
     expect(mockSampleRUM).toHaveBeenCalledWith('fill', { source: 'git' });
   });
 
+  it('initTelemetry registers the shell telemetry sink so emitShellCommand reaches RUM', async () => {
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    const { emitShellCommand } = await import('../../src/shell/telemetry-hook.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    emitShellCommand('node');
+    expect(mockSampleRUM).toHaveBeenCalledWith('fill', { source: 'node' });
+  });
+
   it('trackSprinkleView emits viewblock', async () => {
     const { initTelemetry, trackSprinkleView } = await import('../../src/ui/telemetry.js');
     await initTelemetry();


### PR DESCRIPTION
Closes #869.

## Problem

`packages/webapp/src/shell/wasm-shell-headless.ts` — explicitly documented as the **worker-safe shell base class** (the second-lowest layer in the `fs → shell → … → ui` stack) — imported `trackShellCommand` from `../ui/telemetry.js` (the **highest** layer) for a single shell-command beacon.

`ui/telemetry.ts` reaches `window`, `localStorage`, and `import('@adobe/helix-rum-js')` — DOM/page-only surface with no business on the shell's call graph. This is a textbook Entanglement boundary violation: it couples the two furthest-apart layers and keeps the worker-resident shell out of the no-DOM typecheck guard (`tsconfig.webapp-worker.json`).

## Fix

Invert the dependency so the shell never knows about the UI:

- New leaf module `packages/webapp/src/shell/telemetry-hook.ts` exposes `setShellTelemetrySink(fn | null)` and `emitShellCommand(cmd)`. It imports nothing, so there is no cycle.
- `wasm-shell-headless.ts` calls `emitShellCommand(commandName)` instead of `trackShellCommand(commandName)`.
- `ui/telemetry.ts` registers `trackShellCommand` as the sink inside `initTelemetry()` via `setShellTelemetrySink`.

### Behavior is preserved in every float

The sink is per-realm and is registered exactly where `initTelemetry()` runs:

- **Extension panel**: registers the sink + runs the terminal shell — both in the panel realm → user shell commands still captured.
- **Extension offscreen**: registers the sink + runs the agent's bash shell — both in offscreen → agent bash calls still captured.
- **Standalone**: `initTelemetry()` runs on the page; the shell runs in the kernel worker. As before, worker-side shell beacons are not captured (previously `sampleRUM` was `null` in the worker; now the sink is simply unregistered there). No regression.

## Scope note on the no-DOM guard

The issue also suggested adding `wasm-shell-headless.ts` to `tsconfig.webapp-worker.json`'s `include`. I verified empirically that its transitive closure is still DOM-bound via the (type-only) `cdp/` imports — `cdp/browser-api.ts` and `cdp/debugger-client.ts` legitimately reference `window`/`chrome`. Expanding the guard would require refactoring the CDP transport layer, which is out of scope here. The file docstring is updated to state this honestly. This PR removes the `ui/` back-edge that the issue identified as the highest-impact instance.

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅ (all 6 tsc projects, including the no-DOM `tsconfig.webapp-worker.json`)
- `npx vitest run packages/webapp/tests/shell packages/webapp/tests/kernel` ✅ (1937 passed)
- telemetry + offscreen-telemetry suites ✅ (35 passed, incl. new `telemetry-hook.test.ts` and an `initTelemetry → emitShellCommand → RUM` integration test)
- `npm run build -w @slicc/webapp` ✅
