### PR TITLE
feat: scoop scope-label tooltips (rail + extension dropdown)

### DIFF
--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -145,6 +145,31 @@ export interface RequestScoopMessagesMsg {
   scoopJid: string;
 }
 
+/**
+ * Side-effect-free transcript fetch for a scoop. Distinct from
+ * `request-scoop-messages` (which triggers the chat panel to
+ * wholesale-replace its render via `scoop-messages-replaced`): this
+ * one is a pure read used by the scoop-switcher's scope-label
+ * tooltip. The worker resolves the most recent transcript it has
+ * (in-flight buffer, then live agent state) and flattens it into a
+ * single string. The `requestId` correlates the reply.
+ */
+export interface RequestScoopTranscriptMsg {
+  type: 'request-scoop-transcript';
+  requestId: string;
+  scoopJid: string;
+}
+
+/** Reply to {@link RequestScoopTranscriptMsg}. `transcript` is the
+ *  flattened text the labeler hands to `quickLabel`; empty string if
+ *  the scoop is unknown or has no history yet. */
+export interface ScoopTranscriptMsg {
+  type: 'scoop-transcript';
+  requestId: string;
+  scoopJid: string;
+  transcript: string;
+}
+
 export interface ClearChatMsg {
   type: 'clear-chat';
   /** Correlation id so the panel can await the bridge's ack and avoid
@@ -510,6 +535,7 @@ export type PanelToOffscreenMessage =
   | SetModelMsg
   | RequestStateMsg
   | RequestScoopMessagesMsg
+  | RequestScoopTranscriptMsg
   | ClearChatMsg
   | ClearFilesystemMsg
   | RefreshModelMsg
@@ -845,6 +871,7 @@ export type OffscreenToPanelMessage =
   | ScoopCreatedMsg
   | IncomingMessageMsg
   | ScoopMessagesReplacedMsg
+  | ScoopTranscriptMsg
   | PanelCdpResponseMsg
   | OAuthResultMsg
   | TrayRuntimeStatusMsg

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -975,6 +975,69 @@ export class OffscreenBridge implements KernelFacade {
   }
 
   /**
+   * Side-effect-free transcript fetch for the scoop-switcher's scope
+   * label tooltip. Distinct from {@link handleRequestScoopMessages},
+   * which emits a `scoop-messages-replaced` that the chat panel
+   * wholesale-applies. Replies with a `scoop-transcript` envelope
+   * (correlated by `requestId`) carrying a flattened `user: …` /
+   * `assistant: …` transcript string — empty on unknown scoop or no
+   * history yet.
+   *
+   * Resolution order mirrors the message-replace path:
+   *   1. In-flight `messageBuffers` (current session, including
+   *      streaming tail).
+   *   2. Live `ScoopContext.getAgentMessages()` translated to the
+   *      chat shape so tool-use blocks become readable text.
+   */
+  private async handleRequestScoopTranscript(requestId: string, scoopJid: string): Promise<void> {
+    const empty = (): void => {
+      this.emit({ type: 'scoop-transcript', requestId, scoopJid, transcript: '' });
+    };
+    if (!this.orchestrator) {
+      empty();
+      return;
+    }
+    const scoop = this.orchestrator.getScoops().find((s) => s.jid === scoopJid);
+    if (!scoop) {
+      empty();
+      return;
+    }
+
+    const buffered = this.messageBuffers.get(scoopJid);
+    if (buffered && buffered.length > 0) {
+      this.emit({
+        type: 'scoop-transcript',
+        requestId,
+        scoopJid,
+        transcript: formatTranscript(buffered),
+      });
+      return;
+    }
+
+    const context = this.orchestrator.getScoopContext(scoopJid);
+    if (context) {
+      const { agentMessagesToChatMessages } = await import(
+        '../../../packages/webapp/src/scoops/agent-message-to-chat.js'
+      );
+      const agentMessages = context.getAgentMessages();
+      if (agentMessages.length > 0) {
+        const chatMessages = agentMessagesToChatMessages(agentMessages, {
+          source: scoop.isCone ? 'cone' : (scoop.name ?? scoop.folder),
+        });
+        this.emit({
+          type: 'scoop-transcript',
+          requestId,
+          scoopJid,
+          transcript: formatTranscript(chatMessages),
+        });
+        return;
+      }
+    }
+
+    empty();
+  }
+
+  /**
    * Persist a scoop's message buffer to the shared UI session store.
    * Fire-and-forget — errors are swallowed to avoid blocking agent processing.
    *
@@ -1191,6 +1254,11 @@ export class OffscreenBridge implements KernelFacade {
 
       case 'request-scoop-messages': {
         await this.handleRequestScoopMessages(msg.scoopJid);
+        break;
+      }
+
+      case 'request-scoop-transcript': {
+        await this.handleRequestScoopTranscript(msg.requestId, msg.scoopJid);
         break;
       }
 
@@ -1454,4 +1522,20 @@ export class OffscreenBridge implements KernelFacade {
 
 function uid(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+/**
+ * Flatten a list of chat-shaped messages into a single `role: content`
+ * transcript string suitable for the scope-label LLM call. Empty
+ * `content` entries are skipped so a streaming-only assistant message
+ * with no text yet doesn't insert blank lines.
+ */
+function formatTranscript(messages: ReadonlyArray<{ role: string; content: string }>): string {
+  const lines: string[] = [];
+  for (const m of messages) {
+    const text = (m.content ?? '').trim();
+    if (text.length === 0) continue;
+    lines.push(`${m.role}: ${text}`);
+  }
+  return lines.join('\n');
 }

--- a/packages/chrome-extension/tests/offscreen-bridge.test.ts
+++ b/packages/chrome-extension/tests/offscreen-bridge.test.ts
@@ -1538,3 +1538,71 @@ describe('OffscreenBridge follower-forwarding bridge', () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe('OffscreenBridge request-scoop-transcript', () => {
+  let bridge: InstanceType<typeof OffscreenBridge>;
+
+  beforeEach(async () => {
+    sentMessages.length = 0;
+    messageListeners.length = 0;
+    vi.clearAllMocks();
+    bridge = new OffscreenBridge();
+    await bridge.bind({
+      getScoops: vi.fn(() => [
+        { jid: 'cone_1', name: 'Cone', folder: 'cone', isCone: true, assistantLabel: 'sliccy' },
+      ]),
+      handleMessage: vi.fn().mockResolvedValue(undefined),
+      getScoopContext: vi.fn(() => undefined),
+    } as any);
+  });
+
+  it('flattens buffered messages and replies with correlated requestId', async () => {
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push(
+      { id: 'u1', role: 'user', content: 'help me refactor auth', timestamp: 100 },
+      { id: 'a1', role: 'assistant', content: 'starting now', timestamp: 200 },
+      { id: 'a2', role: 'assistant', content: '   ', timestamp: 300 } // empty after trim — skip
+    );
+
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-transcript',
+      requestId: 'tr-test-1',
+      scoopJid: 'cone_1',
+    });
+
+    const reply = sentMessages.find((m: any) => m.payload?.type === 'scoop-transcript') as any;
+    expect(reply).toBeDefined();
+    expect(reply.payload.requestId).toBe('tr-test-1');
+    expect(reply.payload.scoopJid).toBe('cone_1');
+    expect(reply.payload.transcript).toBe('user: help me refactor auth\nassistant: starting now');
+  });
+
+  it('returns empty transcript for an unknown scoop', async () => {
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-transcript',
+      requestId: 'tr-test-2',
+      scoopJid: 'does-not-exist',
+    });
+
+    const reply = sentMessages.find((m: any) => m.payload?.type === 'scoop-transcript') as any;
+    expect(reply).toBeDefined();
+    expect(reply.payload.requestId).toBe('tr-test-2');
+    expect(reply.payload.transcript).toBe('');
+  });
+
+  it('does NOT emit scoop-messages-replaced (side-effect-free vs request-scoop-messages)', async () => {
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push({ id: 'u1', role: 'user', content: 'hi', timestamp: 100 });
+
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-transcript',
+      requestId: 'tr-test-3',
+      scoopJid: 'cone_1',
+    });
+
+    const replacedReply = sentMessages.find(
+      (m: any) => m.payload?.type === 'scoop-messages-replaced'
+    );
+    expect(replacedReply).toBeUndefined();
+  });
+});

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -28,6 +28,7 @@
 import { ChatPanel } from './chat-panel.js';
 import { FileBrowserPanel } from './file-browser-panel.js';
 import { MemoryPanel } from './memory-panel.js';
+import { ScoopScopeLabeler } from './scoop-scope-label.js';
 import { ScoopSwitcher } from './scoop-switcher.js';
 import { ScoopsPanel } from './scoops-panel.js';
 import type { FrozenSessionIndexEntry } from './session-freezer.js';
@@ -211,6 +212,19 @@ export class Layout {
     orchestrator: import('../scoops/orchestrator.js').Orchestrator
   ): void {
     this.scoopSwitcher?.setOrchestrator(orchestrator);
+  }
+
+  /**
+   * Wire the extension scoop-switcher with a scope-label generator
+   * backed by the side-effect-free transcript accessor on
+   * `OffscreenClient`. Same shape as the standalone rail's labeler;
+   * the only difference is the transcript source (panel→offscreen
+   * round-trip vs. direct `Orchestrator.getMessagesForScoop`).
+   */
+  setScoopSwitcherTranscriptSource?(fetchTranscript: (jid: string) => Promise<string>): void {
+    if (!this.scoopSwitcher) return;
+    const labeler = new ScoopScopeLabeler(fetchTranscript);
+    this.scoopSwitcher.setLabeler(labeler, fetchTranscript);
   }
 
   /** Update scoop switcher status (extension mode). */

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -227,6 +227,17 @@ export class Layout {
     this.scoopSwitcher.setLabeler(labeler, fetchTranscript);
   }
 
+  /**
+   * Wire the standalone scoops rail with the same side-effect-free
+   * transcript source. Required because the standalone rail is wired
+   * with the `OffscreenClient` shim, which does not implement
+   * `Orchestrator.getMessagesForScoop` — without this hook the rail
+   * tooltip's scope line never populates.
+   */
+  setScoopsRailTranscriptSource?(fetchTranscript: (jid: string) => Promise<string>): void {
+    this.panels.scoops?.setScopeTranscriptSource(fetchTranscript);
+  }
+
   /** Update scoop switcher status (extension mode). */
   updateScoopSwitcherStatus?(scoopJid: string, status: ScoopTabState['status']): void {
     this.scoopSwitcher?.updateStatus(scoopJid, status);

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -898,6 +898,11 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
   // routed through a dedicated `request-scoop-transcript` round-trip
   // so the chat panel is never repainted.
   layout.setScoopSwitcherTranscriptSource?.((jid) => client.getScoopTranscript(jid));
+  // Symmetric wiring for the standalone scoops rail tooltip — the
+  // `OffscreenClient` shim doesn't implement `getMessagesForScoop`, so
+  // the rail's scope-label fetcher must route through the same
+  // side-effect-free transcript round-trip.
+  layout.setScoopsRailTranscriptSource?.((jid) => client.getScoopTranscript(jid));
 
   layout.onScoopSelect = selectScoop;
 
@@ -2027,6 +2032,11 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
   // non-overlay standalone uses the scoops rail instead). No-op when
   // the switcher isn't constructed.
   layout.setScoopSwitcherTranscriptSource?.((jid) => client.getScoopTranscript(jid));
+  // Symmetric wiring for the standalone scoops rail tooltip — the
+  // `OffscreenClient` shim doesn't implement `getMessagesForScoop`, so
+  // the rail's scope-label fetcher must route through the same
+  // side-effect-free transcript round-trip.
+  layout.setScoopsRailTranscriptSource?.((jid) => client.getScoopTranscript(jid));
   layout.onScoopSelect = selectScoop;
 
   // Wire clear chat — must drive the IDB clears from the PAGE in

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -892,6 +892,12 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
   layout.panels.scoops.setOrchestrator(client as unknown as Orchestrator);
   layout.panels.memory.setOrchestrator(client as unknown as Orchestrator);
   layout.setScoopSwitcherOrchestrator?.(client as unknown as Orchestrator);
+  // Scope-label tooltip on dropdown items uses the side-effect-free
+  // transcript accessor on `OffscreenClient` — same role as
+  // `Orchestrator.getMessagesForScoop` in the standalone rail, but
+  // routed through a dedicated `request-scoop-transcript` round-trip
+  // so the chat panel is never repainted.
+  layout.setScoopSwitcherTranscriptSource?.((jid) => client.getScoopTranscript(jid));
 
   layout.onScoopSelect = selectScoop;
 
@@ -2016,6 +2022,11 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
   layout.panels.scoops.setOrchestrator(client as unknown as Orchestrator);
   layout.panels.memory.setOrchestrator(client as unknown as Orchestrator);
   layout.setScoopSwitcherOrchestrator?.(client as unknown as Orchestrator);
+  // Scope-label tooltip for the scoop-switcher in electron-overlay
+  // (the only standalone-worker path that mounts the switcher today —
+  // non-overlay standalone uses the scoops rail instead). No-op when
+  // the switcher isn't constructed.
+  layout.setScoopSwitcherTranscriptSource?.((jid) => client.getScoopTranscript(jid));
   layout.onScoopSelect = selectScoop;
 
   // Wire clear chat — must drive the IDB clears from the PAGE in

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -20,6 +20,7 @@ import type {
   ScoopListMsg,
   ScoopMessagesReplacedMsg,
   ScoopStatusMsg,
+  ScoopTranscriptMsg,
   StateSnapshotMsg,
   TrayFollowerStatusSnapshot,
   TrayLeaderStatusSnapshot,
@@ -94,6 +95,12 @@ export class OffscreenClient implements KernelClientFacade {
    * `requestId`; resolved when a `clear-chat-ack` envelope arrives.
    */
   private pendingClearAcks = new Map<string, () => void>();
+  /**
+   * Pending `request-scoop-transcript` requests awaiting the bridge's
+   * reply. Keyed by `requestId`; resolved with the transcript string
+   * (or `''` on timeout) when a `scoop-transcript` envelope arrives.
+   */
+  private pendingTranscriptRequests = new Map<string, (transcript: string) => void>();
   /**
    * KernelTransport — defaults to the chrome.runtime adapter.
    * A `MessageChannel`-backed transport can be passed via the
@@ -353,6 +360,33 @@ export class OffscreenClient implements KernelClientFacade {
     this.send({ type: 'request-scoop-messages', scoopJid } as PanelToOffscreenMessage);
   }
 
+  /**
+   * Side-effect-free transcript accessor. Distinct from
+   * {@link requestScoopMessages}, which mutates the chat panel via
+   * `scoop-messages-replaced`. The worker replies with a
+   * `scoop-transcript` envelope carrying the same `requestId` so this
+   * Promise can resolve cleanly without touching panel state. Used by
+   * the scoop-switcher's scope-label tooltip. Resolves to an empty
+   * string on timeout or unknown scoop.
+   */
+  async getScoopTranscript(scoopJid: string): Promise<string> {
+    const requestId = `tr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const reply = new Promise<string>((resolve) => {
+      this.pendingTranscriptRequests.set(requestId, resolve);
+    });
+    this.send({
+      type: 'request-scoop-transcript',
+      requestId,
+      scoopJid,
+    } as PanelToOffscreenMessage);
+    const result = await Promise.race([
+      reply,
+      new Promise<string>((resolve) => setTimeout(() => resolve(''), 5000)),
+    ]);
+    this.pendingTranscriptRequests.delete(requestId);
+    return result;
+  }
+
   /** Request full state from offscreen. Retries until state arrives. */
   requestState(): void {
     this.send({ type: 'request-state' });
@@ -536,6 +570,16 @@ export class OffscreenClient implements KernelClientFacade {
       case 'scoop-messages-replaced': {
         const m = msg as ScoopMessagesReplacedMsg;
         this.callbacks.onScoopMessagesReplaced?.(m.scoopJid, m.messages);
+        break;
+      }
+
+      case 'scoop-transcript': {
+        const m = msg as ScoopTranscriptMsg;
+        const resolve = this.pendingTranscriptRequests.get(m.requestId);
+        if (resolve) {
+          this.pendingTranscriptRequests.delete(m.requestId);
+          resolve(m.transcript);
+        }
         break;
       }
 

--- a/packages/webapp/src/ui/scoop-scope-label.ts
+++ b/packages/webapp/src/ui/scoop-scope-label.ts
@@ -1,0 +1,213 @@
+/**
+ * Per-scoop "working scope" label cache.
+ *
+ * Wraps `quickLabel` so the scoops rail / switcher can show a short
+ * LLM-summarized phrase describing what each scoop is currently
+ * working on. Float-agnostic: callers inject `fetchTranscript(jid)`
+ * which yields a flattened recent-transcript string (whatever shape
+ * the float can produce — orchestrator-side or stored sessions).
+ *
+ * Pattern mirrors `chat-panel.ts`'s `refreshSuggestedPlaceholder`
+ * and cluster-label cache: AbortController per in-flight call, cache
+ * keyed by jid, and signature-based skip so a hover/dropdown-open
+ * refresh against an unchanged transcript doesn't burn an LLM call.
+ *
+ * Never throws to callers; returns `null`/no-ops on any failure or
+ * empty input.
+ */
+
+import { createLogger } from '../core/logger.js';
+import { quickLabel } from './quick-llm.js';
+
+const log = createLogger('scoop-scope-label');
+
+export type FetchTranscript = (jid: string) => Promise<string>;
+export type OnResolved = (jid: string, label: string) => void;
+
+interface CacheEntry {
+  label: string;
+  /** Transcript signature that produced `label`. Cleared by
+   *  `invalidate` to force the next `request` to regenerate even
+   *  when the transcript is unchanged. */
+  signature: string | null;
+}
+
+interface InFlight {
+  signature: string;
+  controller: AbortController;
+}
+
+const SYSTEM_PROMPT =
+  'You label what an AI coding agent is currently working on with a short noun phrase ' +
+  '(<= 6 words) describing the working scope — e.g. "refactoring auth flow" or ' +
+  '"writing scope-label tests". Reply with just the phrase. No quotes, no preamble, ' +
+  'no trailing period, no list, no code result. If nothing useful comes to mind, ' +
+  'reply exactly: idle.';
+
+const MAX_TRANSCRIPT_CHARS = 4000;
+const MAX_LABEL_TOKENS = 24;
+
+/** Trim a transcript to the trailing window we'll send to the LLM. */
+function clipTranscript(transcript: string): string {
+  const trimmed = transcript.trim();
+  if (trimmed.length <= MAX_TRANSCRIPT_CHARS) return trimmed;
+  return '…' + trimmed.slice(trimmed.length - MAX_TRANSCRIPT_CHARS);
+}
+
+/** Strip wrapping quotes / trailing period; reject "idle" / empty. */
+function normalizeLabel(raw: string): string | null {
+  let cleaned = raw.trim();
+  // Repeatedly peel wrapping quotes / trailing period until stable, so
+  // models that wrap the phrase AND end it with a period (e.g.
+  // `"writing the docs."`) collapse cleanly instead of leaving a
+  // stray period after the closing quote is removed.
+  while (true) {
+    const stripped = cleaned.replace(/^["']|["']$|\.$/g, '').trim();
+    if (stripped === cleaned) break;
+    cleaned = stripped;
+  }
+  if (cleaned.length === 0) return null;
+  if (/^idle$/i.test(cleaned)) return null;
+  return cleaned;
+}
+
+export class ScoopScopeLabeler {
+  private readonly fetchTranscript: FetchTranscript;
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly inFlight = new Map<string, InFlight>();
+
+  constructor(fetchTranscript: FetchTranscript) {
+    this.fetchTranscript = fetchTranscript;
+  }
+
+  /** Synchronous cache lookup. Returns the last successful label or
+   *  `null` if nothing has been generated yet (or the most recent
+   *  attempt yielded no usable label). */
+  getCached(jid: string): string | null {
+    return this.cache.get(jid)?.label ?? null;
+  }
+
+  /** Force the next `request(jid, …)` to regenerate even if the
+   *  transcript hasn't changed. Leaves the previously-cached label
+   *  in place so `getCached` keeps returning a stable value while
+   *  the regenerate is in flight. */
+  invalidate(jid: string): void {
+    const entry = this.cache.get(jid);
+    if (entry) entry.signature = null;
+    // Also abort any in-flight call so the next request truly
+    // regenerates from the current transcript, not whatever was in
+    // flight when invalidate fired.
+    const current = this.inFlight.get(jid);
+    if (current) {
+      current.controller.abort();
+      this.inFlight.delete(jid);
+    }
+  }
+
+  /** Generate-or-refresh the label for `jid`. Dedupes in-flight
+   *  calls (same jid + same transcript signature), skips when the
+   *  transcript signature is unchanged since the last successful
+   *  label, and never throws. */
+  request(jid: string, onResolved: OnResolved): void {
+    void this.runRequest(jid, onResolved).catch((err) => {
+      log.debug('Unexpected error in request', {
+        jid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
+  private async runRequest(jid: string, onResolved: OnResolved): Promise<void> {
+    let transcript: string;
+    try {
+      transcript = await this.fetchTranscript(jid);
+    } catch (err) {
+      log.debug('fetchTranscript threw', {
+        jid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    const clipped = clipTranscript(transcript);
+    if (clipped.length === 0) {
+      log.debug('Empty transcript — skipping', { jid });
+      return;
+    }
+
+    const signature = clipped;
+
+    const cached = this.cache.get(jid);
+    if (cached?.signature === signature) {
+      // Transcript unchanged since the last successful label. Skip
+      // the LLM call; the caller already has the right value via
+      // `getCached`.
+      return;
+    }
+
+    const current = this.inFlight.get(jid);
+    if (current && current.signature === signature) {
+      // Identical-signature call already in flight. Let it land.
+      return;
+    }
+    if (current) {
+      current.controller.abort();
+      this.inFlight.delete(jid);
+    }
+
+    const controller = new AbortController();
+    this.inFlight.set(jid, { signature, controller });
+
+    let label: string | null = null;
+    try {
+      label = await quickLabel({
+        system: SYSTEM_PROMPT,
+        prompt: `Recent agent transcript:\n${clipped}`,
+        maxTokens: MAX_LABEL_TOKENS,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      log.debug('quickLabel threw', {
+        jid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      label = null;
+    }
+
+    // The owning in-flight slot may have been replaced or aborted
+    // while we awaited. Drop our result if so.
+    const stillOwns = this.inFlight.get(jid);
+    if (!stillOwns || stillOwns.controller !== controller) return;
+    this.inFlight.delete(jid);
+    if (controller.signal.aborted) return;
+
+    if (label === null) {
+      log.debug('No label from quickLabel', { jid });
+      return;
+    }
+
+    const normalized = normalizeLabel(label);
+    if (!normalized) {
+      log.debug('Label rejected after normalization', { jid });
+      return;
+    }
+
+    this.cache.set(jid, { label: normalized, signature });
+    try {
+      onResolved(jid, normalized);
+    } catch (err) {
+      log.debug('onResolved threw', {
+        jid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/** Test-only hooks. */
+export const __test__ = {
+  clipTranscript,
+  normalizeLabel,
+  SYSTEM_PROMPT,
+  MAX_TRANSCRIPT_CHARS,
+};

--- a/packages/webapp/src/ui/scoop-scope-label.ts
+++ b/packages/webapp/src/ui/scoop-scope-label.ts
@@ -204,6 +204,20 @@ export class ScoopScopeLabeler {
   }
 }
 
+/** Pull the last `user: …` block (case-insensitive, lenient on
+ *  whitespace) from a flat `role: text` transcript string. Returns an
+ *  empty string when no user line is present. Shared by the rail
+ *  (`scoops-panel.ts`) and the dropdown switcher (`scoop-switcher.ts`)
+ *  so the fallback tooltip line stays consistent across floats. */
+export function extractLatestUserPrompt(transcript: string): string {
+  const lines = transcript.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const m = /^user:\s*(.*)$/i.exec(lines[i] ?? '');
+    if (m && m[1].length > 0) return m[1];
+  }
+  return '';
+}
+
 /** Test-only hooks. */
 export const __test__ = {
   clipTranscript,

--- a/packages/webapp/src/ui/scoop-switcher.ts
+++ b/packages/webapp/src/ui/scoop-switcher.ts
@@ -5,7 +5,7 @@
 
 import type { Orchestrator } from '../scoops/orchestrator.js';
 import type { RegisteredScoop, ScoopTabState } from '../scoops/types.js';
-import type { ScoopScopeLabeler } from './scoop-scope-label.js';
+import { extractLatestUserPrompt, type ScoopScopeLabeler } from './scoop-scope-label.js';
 
 export interface ScoopSwitcherCallbacks {
   onScoopSelect: (scoop: RegisteredScoop) => void;
@@ -555,18 +555,6 @@ export class ScoopSwitcher {
     `;
     document.head.appendChild(style);
   }
-}
-
-/** Pull the last `user: …` block (case-insensitive, lenient on
- *  whitespace) from the flat transcript shape `formatTranscript`
- *  emits. Returns an empty string when no user line is present. */
-function extractLatestUserPrompt(transcript: string): string {
-  const lines = transcript.split('\n');
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const m = /^user:\s*(.*)$/i.exec(lines[i] ?? '');
-    if (m && m[1].length > 0) return m[1];
-  }
-  return '';
 }
 
 function truncate(text: string, max: number): string {

--- a/packages/webapp/src/ui/scoop-switcher.ts
+++ b/packages/webapp/src/ui/scoop-switcher.ts
@@ -5,6 +5,7 @@
 
 import type { Orchestrator } from '../scoops/orchestrator.js';
 import type { RegisteredScoop, ScoopTabState } from '../scoops/types.js';
+import type { ScoopScopeLabeler } from './scoop-scope-label.js';
 
 export interface ScoopSwitcherCallbacks {
   onScoopSelect: (scoop: RegisteredScoop) => void;
@@ -19,6 +20,19 @@ export class ScoopSwitcher {
   private statuses: Map<string, ScoopTabState['status']> = new Map();
   private dropdownOpen = false;
   private lastBadgeCount = 0;
+  /** Scope-label cache + LLM driver. When unset, the tooltip still
+   *  renders with the name only — same fallback as the standalone
+   *  rail's no-API-key path. */
+  private labeler: ScoopScopeLabeler | null = null;
+  /** Fallback transcript source used to populate the tooltip while
+   *  the LLM label is still resolving (or when no API key is
+   *  available). Yields the same flat-text shape `labeler` expects. */
+  private fetchFallbackTranscript: ((jid: string) => Promise<string>) | null = null;
+  /** Per-jid pending fallback line — last user prompt extracted from
+   *  the transcript for the no-scope-label branch. Populated lazily on
+   *  hover so we don't fan-out transcript fetches before the user
+   *  actually opens the dropdown. */
+  private fallbackLines = new Map<string, string>();
 
   constructor(container: HTMLElement, callbacks: ScoopSwitcherCallbacks) {
     this.container = container;
@@ -34,6 +48,19 @@ export class ScoopSwitcher {
     });
   }
 
+  /** Wire the scope-label generator + fallback transcript source.
+   *  `fetchFallbackTranscript` is the SAME accessor the labeler uses;
+   *  the switcher needs a direct hook so it can extract the latest
+   *  user prompt for the no-LLM fallback line without re-implementing
+   *  the round-trip. Safe to call once after construction. */
+  setLabeler(
+    labeler: ScoopScopeLabeler,
+    fetchFallbackTranscript: (jid: string) => Promise<string>
+  ): void {
+    this.labeler = labeler;
+    this.fetchFallbackTranscript = fetchFallbackTranscript;
+  }
+
   setOrchestrator(orchestrator: Orchestrator): void {
     this.orchestrator = orchestrator;
     this.render();
@@ -45,7 +72,15 @@ export class ScoopSwitcher {
   }
 
   updateStatus(jid: string, status: ScoopTabState['status']): void {
+    const prev = this.statuses.get(jid);
     this.statuses.set(jid, status);
+    // Pre-warm the scope label whenever a scoop transitions INTO
+    // 'processing' — that's the same edge `ChatPanel` produces when
+    // the user sends input. Mirrors the standalone rail's pre-warm
+    // hook on `Orchestrator.updateScoopStatus`.
+    if (status === 'processing' && prev !== 'processing') {
+      this.requestLabel(jid);
+    }
     this.render();
   }
 
@@ -91,6 +126,12 @@ export class ScoopSwitcher {
     trigger.addEventListener('click', (e) => {
       e.stopPropagation();
       this.dropdownOpen = !this.dropdownOpen;
+      // Refresh labels for every listed scoop when the dropdown
+      // opens. `request` dedupes against the cached signature, so a
+      // rapid open/close doesn't burn extra LLM calls.
+      if (this.dropdownOpen) {
+        for (const s of scoops) this.requestLabel(s.jid);
+      }
       this.render();
     });
 
@@ -150,9 +191,12 @@ export class ScoopSwitcher {
         item.addEventListener('click', () => {
           this.selectedJid = scoop.jid;
           this.dropdownOpen = false;
+          this.hideTooltip(item);
           this.render();
           this.callbacks.onScoopSelect(scoop);
         });
+
+        this.attachItemTooltip(item, scoop);
 
         menu.appendChild(item);
       }
@@ -174,6 +218,125 @@ export class ScoopSwitcher {
       icon.style.background = SCOOP_COLORS[scoopIndex % SCOOP_COLORS.length];
     }
     return icon;
+  }
+
+  /** Wire hover-tooltip listeners on a dropdown item. Extracted from
+   *  `render` so the dropdown-item assembly stays readable and the
+   *  function complexity stays bounded as new affordances land. */
+  private attachItemTooltip(item: HTMLElement, scoop: RegisteredScoop): void {
+    const displayName = scoop.isCone ? 'cone' : scoop.assistantLabel;
+    item.addEventListener('mouseenter', () => {
+      this.showTooltip(item, scoop, displayName);
+    });
+    item.addEventListener('mouseleave', () => {
+      this.hideTooltip(item);
+    });
+  }
+
+  /** Trigger a scope-label refresh for `jid`. The labeler dedupes
+   *  against the cached transcript signature, so this is safe to call
+   *  on every `processing` transition and every dropdown open. */
+  private requestLabel(jid: string): void {
+    if (!this.labeler) return;
+    this.labeler.request(jid, (resolvedJid) => {
+      const tip = this.activeTooltip;
+      if (tip && tip.dataset.jid === resolvedJid) {
+        this.applyTooltipContent(tip, resolvedJid);
+      }
+    });
+  }
+
+  /** Currently-mounted hover tooltip element, if any. Tracked so the
+   *  labeler's async resolution can update the open tooltip in place
+   *  without searching the DOM. */
+  private activeTooltip: HTMLDivElement | null = null;
+
+  private showTooltip(item: HTMLElement, scoop: RegisteredScoop, displayName: string): void {
+    // Clear any stale tooltip (e.g. dropdown was just opened by
+    // hovering one item and then moving to another without leaving
+    // the menu).
+    document.querySelectorAll('.scoop-switcher-tooltip').forEach((t) => {
+      t.remove();
+    });
+
+    const tip = document.createElement('div');
+    tip.className = 'scoop-switcher-tooltip';
+    tip.dataset.jid = scoop.jid;
+    tip.dataset.name = displayName;
+    document.body.appendChild(tip);
+
+    const rect = item.getBoundingClientRect();
+    tip.style.top = `${rect.top + rect.height / 2}px`;
+    tip.style.left = `${rect.right + 8}px`;
+
+    this.activeTooltip = tip;
+    (item as HTMLElement & { __tip?: HTMLDivElement }).__tip = tip;
+
+    // Initial paint with whatever is currently cached. The labeler
+    // request below may resolve in the same tick (cache hit) or later;
+    // either way `requestLabel`'s onResolved patches the tooltip in
+    // place via `activeTooltip`.
+    this.applyTooltipContent(tip, scoop.jid);
+    this.requestLabel(scoop.jid);
+    void this.warmFallbackLine(scoop.jid);
+  }
+
+  private hideTooltip(item: HTMLElement): void {
+    const owned = (item as HTMLElement & { __tip?: HTMLDivElement }).__tip;
+    if (owned) {
+      owned.remove();
+      (item as HTMLElement & { __tip?: HTMLDivElement }).__tip = undefined;
+    }
+    if (this.activeTooltip && !document.body.contains(this.activeTooltip)) {
+      this.activeTooltip = null;
+    } else if (this.activeTooltip === owned) {
+      this.activeTooltip = null;
+    }
+  }
+
+  /** Render the tooltip content. Always starts with the scoop name on
+   *  its own line; appends the LLM scope label when available, else
+   *  the latest user prompt (truncated). Never shows "null" or an
+   *  empty body. */
+  private applyTooltipContent(tip: HTMLDivElement, jid: string): void {
+    while (tip.firstChild) tip.removeChild(tip.firstChild);
+    const name = tip.dataset.name ?? '';
+    const nameEl = document.createElement('div');
+    nameEl.className = 'scoop-switcher-tooltip__name';
+    nameEl.textContent = name;
+    tip.appendChild(nameEl);
+
+    const scope = this.labeler?.getCached(jid) ?? null;
+    const fallback = this.fallbackLines.get(jid) ?? '';
+    const line = scope ?? truncate(fallback, 80);
+    if (line.length > 0) {
+      const scopeEl = document.createElement('div');
+      scopeEl.className = 'scoop-switcher-tooltip__scope';
+      scopeEl.textContent = line;
+      tip.appendChild(scopeEl);
+    }
+  }
+
+  /** Extract the most recent `user: …` line from the transcript so
+   *  the tooltip has something to show before the labeler resolves
+   *  (or when no API key is configured). Cached per jid. */
+  private async warmFallbackLine(jid: string): Promise<void> {
+    if (!this.fetchFallbackTranscript) return;
+    let transcript = '';
+    try {
+      transcript = await this.fetchFallbackTranscript(jid);
+    } catch {
+      return;
+    }
+    const latestUser = extractLatestUserPrompt(transcript);
+    if (latestUser.length === 0) return;
+    const previous = this.fallbackLines.get(jid);
+    if (previous === latestUser) return;
+    this.fallbackLines.set(jid, latestUser);
+    const tip = this.activeTooltip;
+    if (tip && tip.dataset.jid === jid) {
+      this.applyTooltipContent(tip, jid);
+    }
   }
 
   private addStyles(): void {
@@ -359,7 +522,55 @@ export class ScoopSwitcher {
         50% { transform: scale(1.3); }
         100% { transform: scale(1); }
       }
+
+      /* Hover tooltip for dropdown items — same fixed-position
+         pattern as the standalone rail's .scoop-fixed-tooltip. */
+      .scoop-switcher-tooltip {
+        position: fixed;
+        transform: translateY(-50%);
+        max-width: 240px;
+        padding: 6px 10px;
+        background: var(--s2-gray-900);
+        color: var(--s2-gray-25);
+        font-size: 12px;
+        font-family: var(--s2-font-family);
+        border-radius: var(--s2-radius-default);
+        box-shadow: var(--s2-shadow-elevated);
+        z-index: 1100;
+        pointer-events: none;
+        line-height: 1.3;
+      }
+
+      .scoop-switcher-tooltip__name {
+        font-weight: 600;
+      }
+
+      .scoop-switcher-tooltip__scope {
+        margin-top: 2px;
+        opacity: 0.85;
+        font-weight: 400;
+        white-space: normal;
+        overflow-wrap: anywhere;
+      }
     `;
     document.head.appendChild(style);
   }
+}
+
+/** Pull the last `user: …` block (case-insensitive, lenient on
+ *  whitespace) from the flat transcript shape `formatTranscript`
+ *  emits. Returns an empty string when no user line is present. */
+function extractLatestUserPrompt(transcript: string): string {
+  const lines = transcript.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const m = /^user:\s*(.*)$/i.exec(lines[i] ?? '');
+    if (m && m[1].length > 0) return m[1];
+  }
+  return '';
+}
+
+function truncate(text: string, max: number): string {
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= max) return cleaned;
+  return `${cleaned.slice(0, max - 1)}\u2026`;
 }

--- a/packages/webapp/src/ui/scoops-panel.ts
+++ b/packages/webapp/src/ui/scoops-panel.ts
@@ -323,8 +323,8 @@ export class ScoopsPanel {
           });
           return '';
         }
-        const latest = extractLatestUserPrompt(transcript);
-        if (latest.length > 0) this.lastUserPrompts.set(jid, latest);
+        const trimmed = truncateFallbackPrompt(extractLatestUserPrompt(transcript));
+        if (trimmed.length > 0) this.lastUserPrompts.set(jid, trimmed);
         return transcript;
       });
       return;
@@ -344,8 +344,11 @@ export class ScoopsPanel {
         for (let i = messages.length - 1; i >= 0; i--) {
           const m = messages[i];
           if (!m.fromAssistant && m.content && m.content.trim().length > 0) {
-            this.lastUserPrompts.set(jid, m.content);
-            break;
+            const trimmed = truncateFallbackPrompt(m.content);
+            if (trimmed.length > 0) {
+              this.lastUserPrompts.set(jid, trimmed);
+              break;
+            }
           }
         }
         return flattenScoopTranscript(messages);

--- a/packages/webapp/src/ui/scoops-panel.ts
+++ b/packages/webapp/src/ui/scoops-panel.ts
@@ -11,10 +11,45 @@
 import { createLogger } from '../core/logger.js';
 import type { VirtualFS } from '../fs/index.js';
 import type { Orchestrator } from '../scoops/orchestrator.js';
-import type { RegisteredScoop, ScoopTabState } from '../scoops/types.js';
+import type { ChannelMessage, RegisteredScoop, ScoopTabState } from '../scoops/types.js';
+import { ScoopScopeLabeler } from './scoop-scope-label.js';
 import { type FrozenSessionIndexEntry, readSessionsIndex } from './session-freezer.js';
 
 const log = createLogger('scoops-panel');
+
+/** Tail of recent ChannelMessages we hand to the scope labeler. */
+const SCOPE_TRANSCRIPT_TAIL = 12;
+/** Per-message clip — keeps the LLM prompt small without dropping context. */
+const SCOPE_MESSAGE_MAX_CHARS = 600;
+/** Fallback prompt line shown until / unless an LLM label is available. */
+const SCOPE_FALLBACK_MAX_CHARS = 80;
+
+/** Flatten the tail of a scoop's ChannelMessage history into the short
+ *  `role: text` transcript shape the labeler feeds to `quickLabel`. */
+function flattenScoopTranscript(messages: ChannelMessage[]): string {
+  if (messages.length === 0) return '';
+  const tail = messages.slice(-SCOPE_TRANSCRIPT_TAIL);
+  const lines: string[] = [];
+  for (const m of tail) {
+    const role = m.fromAssistant ? 'assistant' : m.senderName || 'user';
+    const content = (m.content ?? '').replace(/\s+/g, ' ').trim();
+    if (content.length === 0) continue;
+    const clipped =
+      content.length > SCOPE_MESSAGE_MAX_CHARS
+        ? `${content.slice(0, SCOPE_MESSAGE_MAX_CHARS)}…`
+        : content;
+    lines.push(`${role}: ${clipped}`);
+  }
+  return lines.join('\n');
+}
+
+/** Truncate the latest user prompt for the fallback tooltip line. */
+function truncateFallbackPrompt(text: string): string {
+  const cleaned = (text ?? '').replace(/\s+/g, ' ').trim();
+  if (cleaned.length === 0) return '';
+  if (cleaned.length <= SCOPE_FALLBACK_MAX_CHARS) return cleaned;
+  return `${cleaned.slice(0, SCOPE_FALLBACK_MAX_CHARS - 1)}…`;
+}
 
 export interface ScoopsPanelCallbacks {
   /** Called when user selects a scoop */
@@ -52,6 +87,16 @@ export class ScoopsPanel {
   private eyesSvg: SVGSVGElement | null = null;
   private mouseMoveBound: ((e: MouseEvent) => void) | null = null;
 
+  // Scope-label state (rail hover tooltip line 2)
+  private scopeLabeler: ScoopScopeLabeler | null = null;
+  /** Latest user prompt per scoop, used as the immediate fallback line
+   *  until an LLM label is available. Populated as a side-effect of the
+   *  labeler's transcript fetch. */
+  private readonly lastUserPrompts = new Map<string, string>();
+  /** Currently-visible rail tooltip; updated when the labeler resolves
+   *  a new label while the user is still hovering the same item. */
+  private activeTooltip: { jid: string; scopeEl: HTMLElement } | null = null;
+
   constructor(container: HTMLElement, callbacks: ScoopsPanelCallbacks) {
     this.container = container;
     this.callbacks = callbacks;
@@ -72,6 +117,9 @@ export class ScoopsPanel {
     document.querySelectorAll('.scoop-fixed-tooltip').forEach((t) => {
       t.remove();
     });
+    this.activeTooltip = null;
+    this.lastUserPrompts.clear();
+    this.scopeLabeler = null;
   }
 
   /** Toggle the nav rail expanded/collapsed state */
@@ -234,6 +282,28 @@ export class ScoopsPanel {
   /** Set the orchestrator instance */
   setOrchestrator(orchestrator: Orchestrator): void {
     this.orchestrator = orchestrator;
+    // Build the scope labeler against this orchestrator. The transcript
+    // fetcher also caches the latest user prompt so the tooltip has an
+    // immediate fallback line before the LLM label resolves.
+    this.scopeLabeler = new ScoopScopeLabeler(async (jid) => {
+      try {
+        const messages = await orchestrator.getMessagesForScoop(jid);
+        for (let i = messages.length - 1; i >= 0; i--) {
+          const m = messages[i];
+          if (!m.fromAssistant && m.content && m.content.trim().length > 0) {
+            this.lastUserPrompts.set(jid, m.content);
+            break;
+          }
+        }
+        return flattenScoopTranscript(messages);
+      } catch (err) {
+        log.debug('Transcript fetch failed for scope label', {
+          jid,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return '';
+      }
+    });
     this.refreshScoops();
   }
 
@@ -269,8 +339,72 @@ export class ScoopsPanel {
     this.scoopStatuses.set(jid, status);
     if (status === 'processing') {
       this.lastProcessingJid = jid;
+      // Pre-warm the scope label so it is likely ready before the user
+      // hovers. The labeler dedupes / skips when the transcript signature
+      // is unchanged, so repeated processing transitions are cheap.
+      this.requestScopeLabel(jid);
     }
     this.refreshScoops();
+  }
+
+  /** Kick the labeler for `jid` and route the resolved label to the
+   *  active rail tooltip if the user is still hovering that item. */
+  private requestScopeLabel(jid: string): void {
+    if (!this.scopeLabeler) return;
+    this.scopeLabeler.request(jid, (resolvedJid, label) => {
+      if (this.activeTooltip?.jid !== resolvedJid) return;
+      const { scopeEl } = this.activeTooltip;
+      scopeEl.textContent = label;
+      scopeEl.style.display = '';
+    });
+  }
+
+  /** Build the two-line rail tooltip. Line 1 is the scoop/cone name;
+   *  line 2 is the cached scope label, falling back to the latest user
+   *  prompt (truncated), and hidden entirely when neither is available
+   *  so a name-only tooltip never carries an empty second row. */
+  private attachRailTooltip(item: HTMLElement, jid: string, name: string): void {
+    item.addEventListener('mouseenter', () => {
+      if (this.expanded) return;
+      const tip = document.createElement('div');
+      tip.className = 'scoop-fixed-tooltip scoop-fixed-tooltip--multiline';
+
+      const nameEl = document.createElement('div');
+      nameEl.className = 'scoop-fixed-tooltip__name';
+      nameEl.textContent = name;
+      tip.appendChild(nameEl);
+
+      const scopeEl = document.createElement('div');
+      scopeEl.className = 'scoop-fixed-tooltip__scope';
+      const cached = this.scopeLabeler?.getCached(jid) ?? null;
+      const fallback = cached ?? truncateFallbackPrompt(this.lastUserPrompts.get(jid) ?? '');
+      if (fallback.length > 0) {
+        scopeEl.textContent = fallback;
+      } else {
+        scopeEl.style.display = 'none';
+      }
+      tip.appendChild(scopeEl);
+
+      document.body.appendChild(tip);
+      const rect = item.getBoundingClientRect();
+      tip.style.top = `${rect.top + rect.height / 2}px`;
+      tip.style.left = `${rect.right + 8}px`;
+      (item as any).__tip = tip;
+      this.activeTooltip = { jid, scopeEl };
+
+      // Refresh on hover so the label keeps up with new activity.
+      this.requestScopeLabel(jid);
+    });
+    item.addEventListener('mouseleave', () => {
+      const tip = (item as any).__tip;
+      if (tip) {
+        tip.remove();
+        (item as any).__tip = null;
+      }
+      if (this.activeTooltip?.jid === jid) {
+        this.activeTooltip = null;
+      }
+    });
   }
 
   /** Refresh the scoop list */
@@ -409,26 +543,8 @@ export class ScoopsPanel {
           this.moveEyes();
         });
 
-        // Collapsed-mode tooltip
-        const label = cone.assistantLabel;
-        coneItem.addEventListener('mouseenter', () => {
-          if (this.expanded) return;
-          const tip = document.createElement('div');
-          tip.className = 'scoop-fixed-tooltip';
-          tip.textContent = label;
-          document.body.appendChild(tip);
-          const rect = coneItem.getBoundingClientRect();
-          tip.style.top = `${rect.top + rect.height / 2}px`;
-          tip.style.left = `${rect.right + 8}px`;
-          (coneItem as any).__tip = tip;
-        });
-        coneItem.addEventListener('mouseleave', () => {
-          const tip = (coneItem as any).__tip;
-          if (tip) {
-            tip.remove();
-            (coneItem as any).__tip = null;
-          }
-        });
+        // Collapsed-mode tooltip: name + working-scope line
+        this.attachRailTooltip(coneItem, cone.jid, cone.assistantLabel);
 
         coneHeaderEl.appendChild(coneItem);
       }
@@ -545,25 +661,8 @@ export class ScoopsPanel {
         this.moveEyes();
       });
 
-      // Collapsed-mode tooltip
-      item.addEventListener('mouseenter', () => {
-        if (this.expanded) return;
-        const tip = document.createElement('div');
-        tip.className = 'scoop-fixed-tooltip';
-        tip.textContent = displayName;
-        document.body.appendChild(tip);
-        const rect = item.getBoundingClientRect();
-        tip.style.top = `${rect.top + rect.height / 2}px`;
-        tip.style.left = `${rect.right + 8}px`;
-        (item as any).__tip = tip;
-      });
-      item.addEventListener('mouseleave', () => {
-        const tip = (item as any).__tip;
-        if (tip) {
-          tip.remove();
-          (item as any).__tip = null;
-        }
-      });
+      // Collapsed-mode tooltip: name + working-scope line
+      this.attachRailTooltip(item, scoop.jid, displayName);
 
       listEl.appendChild(item);
     }
@@ -1183,6 +1282,29 @@ export class ScoopsPanel {
         pointer-events: none;
         z-index: 10000;
         line-height: 1.3;
+      }
+      /* Two-line variant: per-line nowrap + ellipsis keeps the
+         single-line frozen-session tooltip behavior intact while
+         capping each rail line to a readable width. */
+      .scoop-fixed-tooltip--multiline {
+        white-space: normal;
+        max-width: 280px;
+        padding: 6px 10px;
+      }
+      .scoop-fixed-tooltip__name {
+        font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .scoop-fixed-tooltip__scope {
+        margin-top: 2px;
+        font-size: 11px;
+        font-weight: 400;
+        color: var(--s2-gray-100, rgba(255, 255, 255, 0.75));
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
 `;

--- a/packages/webapp/src/ui/scoops-panel.ts
+++ b/packages/webapp/src/ui/scoops-panel.ts
@@ -12,7 +12,7 @@ import { createLogger } from '../core/logger.js';
 import type { VirtualFS } from '../fs/index.js';
 import type { Orchestrator } from '../scoops/orchestrator.js';
 import type { ChannelMessage, RegisteredScoop, ScoopTabState } from '../scoops/types.js';
-import { ScoopScopeLabeler } from './scoop-scope-label.js';
+import { extractLatestUserPrompt, ScoopScopeLabeler } from './scoop-scope-label.js';
 import { type FrozenSessionIndexEntry, readSessionsIndex } from './session-freezer.js';
 
 const log = createLogger('scoops-panel');
@@ -96,6 +96,12 @@ export class ScoopsPanel {
   /** Currently-visible rail tooltip; updated when the labeler resolves
    *  a new label while the user is still hovering the same item. */
   private activeTooltip: { jid: string; scopeEl: HTMLElement } | null = null;
+  /** Optional side-effect-free transcript fetcher. When wired (e.g.
+   *  standalone mode injecting `OffscreenClient.getScoopTranscript`),
+   *  the rail labeler routes through this instead of the orchestrator's
+   *  `getMessagesForScoop`, which the standalone shim doesn't implement.
+   *  Falls back to the orchestrator-backed path when null. */
+  private transcriptSource: ((jid: string) => Promise<string>) | null = null;
 
   constructor(container: HTMLElement, callbacks: ScoopsPanelCallbacks) {
     this.container = container;
@@ -282,6 +288,53 @@ export class ScoopsPanel {
   /** Set the orchestrator instance */
   setOrchestrator(orchestrator: Orchestrator): void {
     this.orchestrator = orchestrator;
+    this.rebuildScopeLabeler();
+    this.refreshScoops();
+  }
+
+  /**
+   * Wire a side-effect-free transcript source for the rail's scope
+   * labeler. When set, the labeler routes through this fetcher (e.g.
+   * `OffscreenClient.getScoopTranscript` in standalone mode) and
+   * derives the fallback "latest user prompt" line from the flat
+   * transcript string via `extractLatestUserPrompt` — symmetric to the
+   * extension scoop-switcher. When NOT set, the labeler falls back to
+   * `Orchestrator.getMessagesForScoop` so any real-Orchestrator caller
+   * (and existing unit tests) keeps working unchanged.
+   */
+  setScopeTranscriptSource(fetchTranscript: (jid: string) => Promise<string>): void {
+    this.transcriptSource = fetchTranscript;
+    this.rebuildScopeLabeler();
+  }
+
+  /** (Re)build `scopeLabeler` against whichever source is currently
+   *  wired — transcript source wins over orchestrator. */
+  private rebuildScopeLabeler(): void {
+    if (this.transcriptSource) {
+      const fetch = this.transcriptSource;
+      this.scopeLabeler = new ScoopScopeLabeler(async (jid) => {
+        let transcript = '';
+        try {
+          transcript = await fetch(jid);
+        } catch (err) {
+          log.debug('Transcript source threw for scope label', {
+            jid,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return '';
+        }
+        const latest = extractLatestUserPrompt(transcript);
+        if (latest.length > 0) this.lastUserPrompts.set(jid, latest);
+        return transcript;
+      });
+      return;
+    }
+
+    const orchestrator = this.orchestrator;
+    if (!orchestrator) {
+      this.scopeLabeler = null;
+      return;
+    }
     // Build the scope labeler against this orchestrator. The transcript
     // fetcher also caches the latest user prompt so the tooltip has an
     // immediate fallback line before the LLM label resolves.
@@ -304,7 +357,6 @@ export class ScoopsPanel {
         return '';
       }
     });
-    this.refreshScoops();
   }
 
   /**

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -537,3 +537,63 @@ describe('OffscreenClient.setSelectedScoopJid + onScoopSelected', () => {
     expect(calls).toEqual(['scoop-2']);
   });
 });
+
+describe('OffscreenClient.getScoopTranscript', () => {
+  let client: InstanceType<typeof OffscreenClient>;
+  const callbacks = {
+    onStatusChange: vi.fn(),
+    onScoopCreated: vi.fn(),
+    onScoopListUpdate: vi.fn(),
+    onIncomingMessage: vi.fn(),
+  };
+
+  beforeEach(() => {
+    sentMessages.length = 0;
+    messageListeners.length = 0;
+    vi.clearAllMocks();
+    client = new OffscreenClient(callbacks);
+  });
+
+  it('sends request-scoop-transcript and resolves on matching reply', async () => {
+    const pending = client.getScoopTranscript('cone_1');
+    expect(sentMessages.length).toBe(1);
+    const envelope = sentMessages[0] as { source: string; payload: any };
+    expect(envelope.source).toBe('panel');
+    expect(envelope.payload.type).toBe('request-scoop-transcript');
+    expect(envelope.payload.scoopJid).toBe('cone_1');
+    const requestId = envelope.payload.requestId;
+    expect(typeof requestId).toBe('string');
+
+    simulateMessage('offscreen', {
+      type: 'scoop-transcript',
+      requestId,
+      scoopJid: 'cone_1',
+      transcript: 'user: hi\nassistant: hello',
+    });
+
+    await expect(pending).resolves.toBe('user: hi\nassistant: hello');
+  });
+
+  it('ignores replies for unrelated requestIds', async () => {
+    const pending = client.getScoopTranscript('cone_1');
+    const envelope = sentMessages[0] as { source: string; payload: any };
+    const requestId = envelope.payload.requestId;
+
+    // Unrelated reply — must not resolve the pending promise.
+    simulateMessage('offscreen', {
+      type: 'scoop-transcript',
+      requestId: 'tr-other',
+      scoopJid: 'cone_1',
+      transcript: 'spurious',
+    });
+
+    // Correct reply
+    simulateMessage('offscreen', {
+      type: 'scoop-transcript',
+      requestId,
+      scoopJid: 'cone_1',
+      transcript: 'real',
+    });
+    await expect(pending).resolves.toBe('real');
+  });
+});

--- a/packages/webapp/tests/ui/scoop-scope-label.test.ts
+++ b/packages/webapp/tests/ui/scoop-scope-label.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for the float-agnostic scoop scope-label cache.
+ *
+ * Covers cache hit (unchanged signature is skipped), in-flight
+ * dedupe (concurrent same-jid calls coalesce), `invalidate` (forces
+ * regeneration even when transcript is unchanged), `null` from
+ * `quickLabel` (no-op, no `onResolved`), empty transcript (no-op,
+ * no `quickLabel` call), and the never-throws contract.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const quickLabelMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<string | null>>());
+vi.mock('../../src/ui/quick-llm.js', () => ({
+  quickLabel: quickLabelMock,
+}));
+
+const { ScoopScopeLabeler } = await import('../../src/ui/scoop-scope-label.js');
+
+/** Promise + manual resolver. Lets us coordinate the
+ *  fetchTranscript / quickLabel timing with test assertions. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/** Drain any pending microtasks. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+  quickLabelMock.mockReset();
+});
+
+describe('ScoopScopeLabeler', () => {
+  it('caches the resolved label and skips regeneration for an unchanged transcript', async () => {
+    quickLabelMock.mockResolvedValue('refactoring auth flow');
+    const fetchTranscript = vi.fn(async () => 'user: refactor auth\nassistant: starting');
+    const onResolved = vi.fn();
+
+    const labeler = new ScoopScopeLabeler(fetchTranscript);
+    labeler.request('jid-a', onResolved);
+    await flush();
+    await flush();
+
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+    expect(onResolved).toHaveBeenCalledWith('jid-a', 'refactoring auth flow');
+    expect(labeler.getCached('jid-a')).toBe('refactoring auth flow');
+
+    labeler.request('jid-a', onResolved);
+    await flush();
+    await flush();
+
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+    expect(onResolved).toHaveBeenCalledTimes(1);
+    expect(labeler.getCached('jid-a')).toBe('refactoring auth flow');
+  });
+
+  it('dedupes concurrent in-flight calls for the same jid + signature', async () => {
+    const labelDeferred = deferred<string | null>();
+    quickLabelMock.mockReturnValue(labelDeferred.promise);
+    const fetchTranscript = vi.fn(async () => 'doing the work');
+    const onResolved = vi.fn();
+
+    const labeler = new ScoopScopeLabeler(fetchTranscript);
+    labeler.request('jid-b', onResolved);
+    labeler.request('jid-b', onResolved);
+    labeler.request('jid-b', onResolved);
+    await flush();
+
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+
+    labelDeferred.resolve('writing tests');
+    await flush();
+    await flush();
+
+    expect(onResolved).toHaveBeenCalledTimes(1);
+    expect(onResolved).toHaveBeenCalledWith('jid-b', 'writing tests');
+    expect(labeler.getCached('jid-b')).toBe('writing tests');
+  });
+
+  it('invalidate() forces the next request to regenerate even with an unchanged transcript', async () => {
+    quickLabelMock.mockResolvedValueOnce('first label');
+    quickLabelMock.mockResolvedValueOnce('second label');
+    const fetchTranscript = vi.fn(async () => 'stable transcript');
+    const onResolved = vi.fn();
+
+    const labeler = new ScoopScopeLabeler(fetchTranscript);
+    labeler.request('jid-c', onResolved);
+    await flush();
+    await flush();
+    expect(labeler.getCached('jid-c')).toBe('first label');
+
+    labeler.request('jid-c', onResolved);
+    await flush();
+    await flush();
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+
+    labeler.invalidate('jid-c');
+    expect(labeler.getCached('jid-c')).toBe('first label');
+
+    labeler.request('jid-c', onResolved);
+    await flush();
+    await flush();
+
+    expect(quickLabelMock).toHaveBeenCalledTimes(2);
+    expect(labeler.getCached('jid-c')).toBe('second label');
+    expect(onResolved).toHaveBeenLastCalledWith('jid-c', 'second label');
+  });
+
+  it('no-ops when quickLabel returns null (no onResolved, no cache write)', async () => {
+    quickLabelMock.mockResolvedValue(null);
+    const fetchTranscript = vi.fn(async () => 'something to label');
+    const onResolved = vi.fn();
+
+    const labeler = new ScoopScopeLabeler(fetchTranscript);
+    labeler.request('jid-d', onResolved);
+    await flush();
+    await flush();
+
+    expect(quickLabelMock).toHaveBeenCalledTimes(1);
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(labeler.getCached('jid-d')).toBeNull();
+  });
+
+  it('no-ops on empty transcript (does not call quickLabel)', async () => {
+    const fetchTranscript = vi.fn(async () => '   \n   ');
+    const onResolved = vi.fn();
+
+    const labeler = new ScoopScopeLabeler(fetchTranscript);
+    labeler.request('jid-e', onResolved);
+    await flush();
+    await flush();
+
+    expect(quickLabelMock).not.toHaveBeenCalled();
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(labeler.getCached('jid-e')).toBeNull();
+  });
+
+  it('never throws when fetchTranscript or quickLabel reject', async () => {
+    const fetchTranscript = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const labeler = new ScoopScopeLabeler(fetchTranscript);
+    expect(() => labeler.request('jid-f', () => {})).not.toThrow();
+    await flush();
+    await flush();
+
+    expect(quickLabelMock).not.toHaveBeenCalled();
+    expect(labeler.getCached('jid-f')).toBeNull();
+
+    const ok = vi.fn(async () => 'fresh transcript');
+    quickLabelMock.mockRejectedValueOnce(new Error('llm down'));
+    const labeler2 = new ScoopScopeLabeler(ok);
+    const onResolved = vi.fn();
+    expect(() => labeler2.request('jid-g', onResolved)).not.toThrow();
+    await flush();
+    await flush();
+
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(labeler2.getCached('jid-g')).toBeNull();
+  });
+
+  it('rejects "idle" sentinel and normalizes wrapping quotes / trailing period', async () => {
+    quickLabelMock.mockResolvedValueOnce('idle');
+    const fetchTranscript = vi.fn(async () => 'transcript v1');
+    const onResolved = vi.fn();
+
+    const labeler = new ScoopScopeLabeler(fetchTranscript);
+    labeler.request('jid-h', onResolved);
+    await flush();
+    await flush();
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(labeler.getCached('jid-h')).toBeNull();
+
+    quickLabelMock.mockResolvedValueOnce('"writing the docs."');
+    fetchTranscript.mockResolvedValueOnce('transcript v2');
+    labeler.request('jid-h', onResolved);
+    await flush();
+    await flush();
+    expect(onResolved).toHaveBeenCalledWith('jid-h', 'writing the docs');
+    expect(labeler.getCached('jid-h')).toBe('writing the docs');
+  });
+
+  it('regenerates when the transcript signature changes', async () => {
+    quickLabelMock.mockResolvedValueOnce('label one');
+    quickLabelMock.mockResolvedValueOnce('label two');
+    const fetchTranscript = vi.fn();
+    fetchTranscript.mockResolvedValueOnce('transcript A');
+    fetchTranscript.mockResolvedValueOnce('transcript B');
+    const onResolved = vi.fn();
+
+    const labeler = new ScoopScopeLabeler(fetchTranscript);
+    labeler.request('jid-i', onResolved);
+    await flush();
+    await flush();
+    expect(labeler.getCached('jid-i')).toBe('label one');
+
+    labeler.request('jid-i', onResolved);
+    await flush();
+    await flush();
+    expect(quickLabelMock).toHaveBeenCalledTimes(2);
+    expect(labeler.getCached('jid-i')).toBe('label two');
+    expect(onResolved).toHaveBeenLastCalledWith('jid-i', 'label two');
+  });
+});

--- a/packages/webapp/tests/ui/scoops-panel.test.ts
+++ b/packages/webapp/tests/ui/scoops-panel.test.ts
@@ -125,6 +125,69 @@ describe('ScoopsPanel scope tooltip', () => {
     expect(scope?.style.display).not.toBe('none');
   });
 
+  it('stores the cached fallback prompt truncated (injected source path)', async () => {
+    quickLabelMock.mockResolvedValue(null);
+    const cone = makeCone('cone-1');
+    const orch = makeOrchestrator([cone]);
+    const longPrompt = `please ${'really '.repeat(40)}summarize the recent diff`;
+    expect(longPrompt.length).toBeGreaterThan(80);
+    const fetchTranscript = vi.fn(async () => `user: ${longPrompt}\nassistant: ok`);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new ScoopsPanel(container, { onScoopSelect: () => {}, onSendMessage: () => {} });
+    panel.setScopeTranscriptSource(fetchTranscript);
+    // biome-ignore lint/suspicious/noExplicitAny: fake orchestrator covers only the surface the panel touches
+    panel.setOrchestrator(orch as any);
+
+    const item = container.querySelector<HTMLElement>('.scoop-item[data-jid="cone-1"]')!;
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+    await flush();
+    await flush();
+    item.dispatchEvent(new MouseEvent('mouseleave'));
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+
+    const scope = document.querySelector<HTMLElement>('.scoop-fixed-tooltip__scope');
+    const text = scope?.textContent ?? '';
+    expect(text.length).toBeGreaterThan(0);
+    expect(text.length).toBeLessThanOrEqual(80);
+    expect(text.endsWith('…')).toBe(true);
+  });
+
+  it('stores the cached fallback prompt truncated (orchestrator path)', async () => {
+    quickLabelMock.mockResolvedValue(null);
+    const cone = makeCone('cone-1');
+    const longContent = `please ${'really '.repeat(40)}summarize the recent diff`;
+    expect(longContent.length).toBeGreaterThan(80);
+    const orch = {
+      getScoops: vi.fn(() => [cone]),
+      getMessagesForScoop: vi.fn(async () => [
+        { fromAssistant: false, senderName: 'user', content: longContent },
+      ]),
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new ScoopsPanel(container, { onScoopSelect: () => {}, onSendMessage: () => {} });
+    // No transcript source: orchestrator branch must run.
+    // biome-ignore lint/suspicious/noExplicitAny: fake orchestrator covers only the surface the panel touches
+    panel.setOrchestrator(orch as any);
+
+    const item = container.querySelector<HTMLElement>('.scoop-item[data-jid="cone-1"]')!;
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+    await flush();
+    await flush();
+    expect(orch.getMessagesForScoop).toHaveBeenCalledWith('cone-1');
+    item.dispatchEvent(new MouseEvent('mouseleave'));
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+
+    const scope = document.querySelector<HTMLElement>('.scoop-fixed-tooltip__scope');
+    const text = scope?.textContent ?? '';
+    expect(text.length).toBeGreaterThan(0);
+    expect(text.length).toBeLessThanOrEqual(80);
+    expect(text.endsWith('…')).toBe(true);
+  });
+
   it('hides the scope line when the transcript yields no user prompt and no label', async () => {
     quickLabelMock.mockResolvedValue(null);
     const cone = makeCone('cone-1');

--- a/packages/webapp/tests/ui/scoops-panel.test.ts
+++ b/packages/webapp/tests/ui/scoops-panel.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the standalone scoops-rail tooltip's scope-label wiring.
+ *
+ * Covers the gap that let `OffscreenClient`-as-Orchestrator slip through
+ * unit tests: when a side-effect-free transcript source is injected via
+ * `setScopeTranscriptSource`, the rail labeler MUST route through it
+ * instead of `Orchestrator.getMessagesForScoop` (which the standalone
+ * worker shim does not implement). Also asserts the fallback tooltip
+ * line is extracted from the transcript string via
+ * `extractLatestUserPrompt`, matching the dropdown switcher.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const quickLabelMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<string | null>>());
+vi.mock('../../src/ui/quick-llm.js', () => ({
+  quickLabel: quickLabelMock,
+}));
+
+// jsdom doesn't expose `CSS.escape`; the panel uses it to safely quote
+// jid values in DOM selectors. A minimal alphanumeric/dash passthrough is
+// enough for the synthetic jids we use here.
+if (typeof (globalThis as any).CSS === 'undefined') {
+  (globalThis as any).CSS = { escape: (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, '\\$&') };
+}
+
+const { ScoopsPanel } = await import('../../src/ui/scoops-panel.js');
+
+import type { RegisteredScoop } from '../../src/scoops/types.js';
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+}
+
+function makeCone(jid = 'cone-1'): RegisteredScoop {
+  return {
+    jid,
+    name: 'sliccy',
+    folder: 'sliccy',
+    isCone: true,
+    type: 'cone',
+    requiresTrigger: false,
+    assistantLabel: 'sliccy',
+    addedAt: new Date().toISOString(),
+  };
+}
+
+function makeOrchestrator(scoops: RegisteredScoop[]) {
+  return {
+    getScoops: vi.fn(() => scoops),
+    // Spy that must NOT be called when a transcript source is wired.
+    // Returns a rejected promise so any accidental call also fails fast.
+    getMessagesForScoop: vi.fn(async () => {
+      throw new Error('getMessagesForScoop must not be called when transcript source is wired');
+    }),
+  };
+}
+
+beforeEach(() => {
+  quickLabelMock.mockReset();
+  document.body.innerHTML = '';
+});
+
+describe('ScoopsPanel scope tooltip', () => {
+  it('routes the rail labeler through the injected transcript source (not getMessagesForScoop)', async () => {
+    quickLabelMock.mockResolvedValue('refactoring auth flow');
+    const cone = makeCone('cone-1');
+    const orch = makeOrchestrator([cone]);
+    const fetchTranscript = vi.fn(async () => 'user: refactor auth\nassistant: starting');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new ScoopsPanel(container, { onScoopSelect: () => {}, onSendMessage: () => {} });
+    panel.setScopeTranscriptSource(fetchTranscript);
+    // biome-ignore lint/suspicious/noExplicitAny: fake orchestrator covers only the surface the panel touches
+    panel.setOrchestrator(orch as any);
+
+    const item = container.querySelector<HTMLElement>('.scoop-item[data-jid="cone-1"]')!;
+    expect(item).toBeTruthy();
+
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+    await flush();
+    await flush();
+
+    expect(fetchTranscript).toHaveBeenCalledWith('cone-1');
+    expect(orch.getMessagesForScoop).not.toHaveBeenCalled();
+    // Once the labeler resolves, it updates the active tooltip in place.
+    const scope = document.querySelector<HTMLElement>('.scoop-fixed-tooltip__scope');
+    expect(scope?.textContent).toBe('refactoring auth flow');
+  });
+
+  it('falls back to extractLatestUserPrompt of the transcript string when no LLM label is cached', async () => {
+    // quickLabel returns null → no cached label → tooltip falls back to
+    // the latest-user-prompt line populated from the transcript string.
+    quickLabelMock.mockResolvedValue(null);
+    const cone = makeCone('cone-1');
+    const orch = makeOrchestrator([cone]);
+    const fetchTranscript = vi.fn(
+      async () => 'assistant: ok\nuser: please summarize the recent diff\nassistant: sure'
+    );
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new ScoopsPanel(container, { onScoopSelect: () => {}, onSendMessage: () => {} });
+    panel.setScopeTranscriptSource(fetchTranscript);
+    // biome-ignore lint/suspicious/noExplicitAny: fake orchestrator covers only the surface the panel touches
+    panel.setOrchestrator(orch as any);
+
+    const item = container.querySelector<HTMLElement>('.scoop-item[data-jid="cone-1"]')!;
+
+    // First hover: tooltip renders with no fallback yet (cache empty),
+    // then the labeler resolves and populates `lastUserPrompts`.
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+    await flush();
+    await flush();
+    expect(fetchTranscript).toHaveBeenCalledTimes(1);
+    expect(orch.getMessagesForScoop).not.toHaveBeenCalled();
+
+    // Re-hover so the tooltip rebuilds and now reads the populated cache.
+    item.dispatchEvent(new MouseEvent('mouseleave'));
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+    const scope = document.querySelector<HTMLElement>('.scoop-fixed-tooltip__scope');
+    expect(scope?.textContent).toBe('please summarize the recent diff');
+    expect(scope?.style.display).not.toBe('none');
+  });
+
+  it('hides the scope line when the transcript yields no user prompt and no label', async () => {
+    quickLabelMock.mockResolvedValue(null);
+    const cone = makeCone('cone-1');
+    const orch = makeOrchestrator([cone]);
+    const fetchTranscript = vi.fn(async () => 'assistant: just thinking');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new ScoopsPanel(container, { onScoopSelect: () => {}, onSendMessage: () => {} });
+    panel.setScopeTranscriptSource(fetchTranscript);
+    // biome-ignore lint/suspicious/noExplicitAny: fake orchestrator covers only the surface the panel touches
+    panel.setOrchestrator(orch as any);
+
+    const item = container.querySelector<HTMLElement>('.scoop-item[data-jid="cone-1"]')!;
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+    await flush();
+    await flush();
+    item.dispatchEvent(new MouseEvent('mouseleave'));
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+
+    const scope = document.querySelector<HTMLElement>('.scoop-fixed-tooltip__scope');
+    expect(scope?.style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary

Shows each scoop's **current working scope** as a hover tooltip in both the standalone webapp scoops rail and the extension scoop-switcher dropdown, so users get a sense of activity / current scope without opening each scoop. Scope summaries are generated from the scoop's recent activity via the existing `quickLabel` cheap-model helper.

## What changed

- **`ScoopScopeLabeler`** (`packages/webapp/src/ui/scoop-scope-label.ts`) — float-agnostic helper that turns a scoop's recent transcript into a short cached scope phrase. In-flight dedupe + signature-skip (no re-call when the transcript is unchanged) + `invalidate`. Constructed with an injected `fetchTranscript(jid)` so each float supplies its own source.
- **Standalone rail** (`packages/webapp/src/ui/scoops-panel.ts`) — two-line hover tooltip (name + scope) via an opt-in `.scoop-fixed-tooltip--multiline` modifier (frozen-session single-line tooltips unchanged). Transcript is sourced from the side-effect-free `OffscreenClient.getScoopTranscript(jid)` round-trip via `ScoopsPanel.setScopeTranscriptSource` (wired in `main.ts`), so it works under the standalone worker shim; falls back to `Orchestrator.getMessagesForScoop` when no source is injected (real-`Orchestrator` callers).
- **Extension dropdown** (`packages/webapp/src/ui/scoop-switcher.ts`) — same tooltip behavior, plus a new **side-effect-free** `request-scoop-transcript` / `scoop-transcript` round-trip (`offscreen-bridge.ts`, `OffscreenClient.getScoopTranscript`, wired via `layout.ts` / `main.ts`) so reading a scoop's messages does not disturb the chat panel.
- **Shared fallback** — the truncated latest-user-prompt fallback is derived from the flat transcript string via the shared `extractLatestUserPrompt` (exported from `scoop-switcher.ts`), used by both surfaces (no duplicated logic).

## Refresh model

- **Pre-warm on input** — a label is generated immediately when a scoop receives new work (the `→ processing` transition), so it is likely cached by the time the user looks.
- **Refresh on hover (rail) / dropdown open (extension)** — re-requests, but the cache + skip-if-unchanged check avoids redundant LLM calls.
- Fallback line uses the truncated latest user prompt while the label loads or when no API key is configured (never shows empty / `null`).

## Tests & verification

- New unit tests for `ScoopScopeLabeler` (8) plus tooltip / transcript tests, including 3 `scoops-panel` tests asserting the rail labeler uses the injected transcript source (not `getMessagesForScoop`) and that the fallback is extracted from the transcript string; a dedicated switcher test asserts the transcript round-trip emits no `scoop-messages-replaced` (no chat-panel mutation).
- Gates green: `npm run lint`, `npm run typecheck`, `npm run test` (6305 pass), `npm run build -w @slicc/webapp`, `npm run build -w @slicc/chrome-extension`.

## Notes

- Rail and switcher use independent labeler instances; they are never visible simultaneously (rail is hidden in extension mode), so no redundant LLM calls in practice.
- Additive change — no schema/storage changes; in-memory cache only (no persistence across reloads).

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author