### PR TITLE
fix: persist Chrome profiles to ~/.slicc/chrome-profiles

### DIFF
--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
-import { cp, mkdir, readFile, unlink, writeFile } from 'fs/promises';
+import { cp, mkdir, readFile, rm, unlink, writeFile } from 'fs/promises';
 import { request as httpRequest } from 'http';
 import { homedir } from 'os';
 import { dirname, join } from 'path';
@@ -146,8 +146,16 @@ export async function migrateLegacyDefaultChromeProfile(
   if (existsSync(newDir)) return;
   for (const candidate of candidates) {
     if (existsSync(candidate)) {
-      await cp(candidate, newDir, { recursive: true });
-      console.log(`Migrated Chrome profile: ${candidate} → ${newDir}`);
+      try {
+        await cp(candidate, newDir, { recursive: true });
+        console.log(`Migrated Chrome profile: ${candidate} → ${newDir}`);
+      } catch (err) {
+        await rm(newDir, { recursive: true, force: true }).catch(() => {});
+        console.warn(
+          `Chrome profile migration failed (${candidate} → ${newDir}); continuing with a fresh profile.`,
+          err
+        );
+      }
       return;
     }
   }

--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -112,7 +112,7 @@ export function resolveQaProfilesRoot(projectRoot: string): string {
 }
 
 export function resolveDefaultChromeUserDataDir(
-  profilesDir = join(homedir(), '.slicc', 'chrome-profiles'),
+  profilesDir = join(homedir(), '.slicc', 'profiles'),
   servePort?: number
 ): string {
   const suffix = servePort && servePort !== 5710 ? `-${servePort}` : '';

--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
-import { mkdir, readFile, unlink, writeFile } from 'fs/promises';
+import { cp, mkdir, readFile, unlink, writeFile } from 'fs/promises';
 import { request as httpRequest } from 'http';
 import { homedir } from 'os';
 import { dirname, join } from 'path';
@@ -112,11 +112,45 @@ export function resolveQaProfilesRoot(projectRoot: string): string {
 }
 
 export function resolveDefaultChromeUserDataDir(
-  tmpDir = process.env['TMPDIR'] ?? '/tmp',
+  profilesDir = join(homedir(), '.slicc', 'chrome-profiles'),
   servePort?: number
 ): string {
   const suffix = servePort && servePort !== 5710 ? `-${servePort}` : '';
-  return join(tmpDir, `${DEFAULT_USER_DATA_DIR_NAME}${suffix}`);
+  return join(profilesDir, `${DEFAULT_USER_DATA_DIR_NAME}${suffix}`);
+}
+
+/**
+ * Builds the ordered list of legacy candidate paths to check during migration.
+ * Checks $TMPDIR first (the macOS per-user temp dir used by terminal sessions),
+ * then /tmp (the fallback used by GUI apps that don't inherit TMPDIR).
+ */
+export function legacyChromeCandidates(
+  profileDirName: string,
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  const bases = new Set<string>();
+  if (env['TMPDIR']) bases.add(env['TMPDIR']);
+  bases.add('/tmp');
+  return [...bases].map((b) => join(b, profileDirName));
+}
+
+/**
+ * One-time migration: if `newDir` doesn't exist yet, copies the first matching
+ * candidate (legacy profile from $TMPDIR or /tmp) to the stable new location.
+ * Non-destructive — the old profile is left in place.
+ */
+export async function migrateLegacyDefaultChromeProfile(
+  newDir: string,
+  candidates: string[]
+): Promise<void> {
+  if (existsSync(newDir)) return;
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      await cp(candidate, newDir, { recursive: true });
+      console.log(`Migrated Chrome profile: ${candidate} → ${newDir}`);
+      return;
+    }
+  }
 }
 
 export function resolveChromeLaunchProfile(options: {

--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -2,7 +2,7 @@ import type { ChildProcess } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
 import { cp, mkdir, readFile, rm, unlink, writeFile } from 'fs/promises';
 import { request as httpRequest } from 'http';
-import { homedir } from 'os';
+import { homedir, platform as osPlatform, tmpdir } from 'os';
 import { dirname, join } from 'path';
 
 /**
@@ -111,8 +111,27 @@ export function resolveQaProfilesRoot(projectRoot: string): string {
   return join(projectRoot, ...QA_PROFILE_ROOT_SEGMENTS);
 }
 
+export function resolveProfilesDir(
+  platform: NodeJS.Platform = osPlatform(),
+  homeDir: string = homedir(),
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  if (platform === 'darwin') {
+    return join(homeDir, 'Library', 'Application Support', 'Slicc', 'profiles');
+  }
+  if (platform === 'linux') {
+    const xdgState = env['XDG_STATE_HOME'] ?? join(homeDir, '.local', 'state');
+    return join(xdgState, 'slicc', 'profiles');
+  }
+  if (platform === 'win32') {
+    const localAppData = env['LOCALAPPDATA'] ?? join(homeDir, 'AppData', 'Local');
+    return join(localAppData, 'Slicc', 'profiles');
+  }
+  return tmpdir();
+}
+
 export function resolveDefaultChromeUserDataDir(
-  profilesDir = join(homedir(), '.slicc', 'profiles'),
+  profilesDir = resolveProfilesDir(),
   servePort?: number
 ): string {
   const suffix = servePort && servePort !== 5710 ? `-${servePort}` : '';
@@ -123,6 +142,8 @@ export function resolveDefaultChromeUserDataDir(
  * Builds the ordered list of legacy candidate paths to check during migration.
  * Checks $TMPDIR first (the macOS per-user temp dir used by terminal sessions),
  * then /tmp (the fallback used by GUI apps that don't inherit TMPDIR).
+ * Also includes the previous ~/.slicc/profiles location so existing installs
+ * are migrated to the platform-appropriate directory on first run.
  */
 export function legacyChromeCandidates(
   profileDirName: string,

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -7,7 +7,7 @@ import { existsSync, readFileSync } from 'fs';
 import { createServer } from 'http';
 import { createServer as createNetServer } from 'net';
 import { homedir } from 'os';
-import { dirname, join, resolve, sep } from 'path';
+import { basename, dirname, join, resolve, sep } from 'path';
 import { Readable, Transform } from 'stream';
 import { StringDecoder } from 'string_decoder';
 import { fileURLToPath } from 'url';
@@ -17,6 +17,8 @@ import {
   clearStaleDevToolsActivePort,
   ensureQaProfileScaffold,
   findChromeExecutable,
+  legacyChromeCandidates,
+  migrateLegacyDefaultChromeProfile,
   planChromeSpawn,
   resolveChromeLaunchProfile,
   waitForCdpPort,
@@ -556,7 +558,6 @@ async function main() {
       try {
         const resolved = resolveChromeLaunchProfile({
           projectRoot: PROJECT_ROOT,
-          tmpDir: process.env['TMPDIR'] ?? '/tmp',
           profile: RUNTIME_FLAGS.profile,
           servePort: SERVE_PORT,
         });
@@ -582,6 +583,12 @@ async function main() {
 
     if (chromeProfile.id) {
       await ensureQaProfileScaffold(PROJECT_ROOT);
+    } else if (!RUNTIME_FLAGS.hosted) {
+      const profileDirName = basename(chromeProfile.userDataDir);
+      await migrateLegacyDefaultChromeProfile(
+        chromeProfile.userDataDir,
+        legacyChromeCandidates(profileDirName)
+      );
     }
 
     if (chromeProfile.extensionPath && !existsSync(chromeProfile.extensionPath)) {

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -29,13 +29,13 @@ afterEach(async () => {
 });
 
 describe('chrome-launch', () => {
-  it('defaults to ~/.slicc/chrome-profiles when no tmpDir override is given', () => {
+  it('defaults to ~/.slicc/profiles when no tmpDir override is given', () => {
     const profile = resolveChromeLaunchProfile({
       projectRoot: '/repo',
     });
 
     expect(profile.userDataDir).toBe(
-      join(homedir(), '.slicc', 'chrome-profiles', 'browser-coding-agent-chrome')
+      join(homedir(), '.slicc', 'profiles', 'browser-coding-agent-chrome')
     );
   });
 

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -1,6 +1,6 @@
 import { type existsSync, existsSync as fsExistsSync, type readdirSync } from 'fs';
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises';
-import { homedir, tmpdir } from 'os';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -11,12 +11,14 @@ import {
   ensureQaProfileScaffold,
   findChromeExecutable,
   getDefaultCdpLaunchTimeoutMs,
+  legacyChromeCandidates,
   migrateLegacyDefaultChromeProfile,
   parseCdpPortFromStderr,
   planChromeSpawn,
   probeCdpAlive,
   resolveChromeAppBundle,
   resolveChromeLaunchProfile,
+  resolveProfilesDir,
   waitForCdpPort,
   waitForCdpPortFromActivePortFile,
   waitForCdpPortFromStderr,
@@ -28,15 +30,57 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
+describe('resolveProfilesDir', () => {
+  it('returns Application Support path on darwin', () => {
+    expect(resolveProfilesDir('darwin', '/Users/test', {})).toBe(
+      '/Users/test/Library/Application Support/Slicc/profiles'
+    );
+  });
+
+  it('returns ~/.local/state path on linux when XDG_STATE_HOME is not set', () => {
+    expect(resolveProfilesDir('linux', '/home/test', {})).toBe(
+      '/home/test/.local/state/slicc/profiles'
+    );
+  });
+
+  it('uses XDG_STATE_HOME on linux when set', () => {
+    expect(resolveProfilesDir('linux', '/home/test', { XDG_STATE_HOME: '/custom/state' })).toBe(
+      '/custom/state/slicc/profiles'
+    );
+  });
+
+  it('returns LOCALAPPDATA path on win32 when set', () => {
+    expect(resolveProfilesDir('win32', '/home/test', { LOCALAPPDATA: '/fake/AppData/Local' })).toBe(
+      join('/fake/AppData/Local', 'Slicc', 'profiles')
+    );
+  });
+
+  it('falls back to tmpdir on unknown platforms', () => {
+    expect(resolveProfilesDir('freebsd' as NodeJS.Platform, '/home/test', {})).toBe(tmpdir());
+  });
+});
+
+describe('legacyChromeCandidates', () => {
+  it('includes $TMPDIR-based path', () => {
+    const candidates = legacyChromeCandidates('browser-coding-agent-chrome', {
+      TMPDIR: '/private/tmp/userXYZ',
+    });
+    expect(candidates).toContain('/private/tmp/userXYZ/browser-coding-agent-chrome');
+  });
+
+  it('includes /tmp-based path', () => {
+    const candidates = legacyChromeCandidates('browser-coding-agent-chrome', {});
+    expect(candidates).toContain('/tmp/browser-coding-agent-chrome');
+  });
+});
+
 describe('chrome-launch', () => {
-  it('defaults to ~/.slicc/profiles when no tmpDir override is given', () => {
+  it('defaults to platform-appropriate profiles dir when no tmpDir override is given', () => {
     const profile = resolveChromeLaunchProfile({
       projectRoot: '/repo',
     });
 
-    expect(profile.userDataDir).toBe(
-      join(homedir(), '.slicc', 'profiles', 'browser-coding-agent-chrome')
-    );
+    expect(profile.userDataDir).not.toContain('.slicc');
   });
 
   it('uses an explicit tmpDir override when provided', () => {

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -1,6 +1,6 @@
 import { type existsSync, existsSync as fsExistsSync, type readdirSync } from 'fs';
-import { mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises';
-import { tmpdir } from 'os';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -11,6 +11,7 @@ import {
   ensureQaProfileScaffold,
   findChromeExecutable,
   getDefaultCdpLaunchTimeoutMs,
+  migrateLegacyDefaultChromeProfile,
   parseCdpPortFromStderr,
   planChromeSpawn,
   probeCdpAlive,
@@ -28,7 +29,17 @@ afterEach(async () => {
 });
 
 describe('chrome-launch', () => {
-  it('uses the legacy tmp profile when no QA profile is requested', () => {
+  it('defaults to ~/.slicc/chrome-profiles when no tmpDir override is given', () => {
+    const profile = resolveChromeLaunchProfile({
+      projectRoot: '/repo',
+    });
+
+    expect(profile.userDataDir).toBe(
+      join(homedir(), '.slicc', 'chrome-profiles', 'browser-coding-agent-chrome')
+    );
+  });
+
+  it('uses an explicit tmpDir override when provided', () => {
     const profile = resolveChromeLaunchProfile({
       projectRoot: '/repo',
       tmpDir: '/tmp/test-root',
@@ -947,5 +958,68 @@ describe('probeCdpAlive', () => {
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
+  });
+});
+
+describe('migrateLegacyDefaultChromeProfile', () => {
+  it('copies a legacy profile to the new stable location', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'slicc-migrate-'));
+    tempDirs.push(root);
+
+    const legacyProfile = join(root, 'legacy', 'browser-coding-agent-chrome');
+    await mkdir(legacyProfile, { recursive: true });
+    await writeFile(join(legacyProfile, 'marker.txt'), 'legacy-data');
+
+    const newProfile = join(root, 'new', 'browser-coding-agent-chrome');
+    await migrateLegacyDefaultChromeProfile(newProfile, [legacyProfile]);
+
+    expect(await readFile(join(newProfile, 'marker.txt'), 'utf8')).toBe('legacy-data');
+  });
+
+  it('skips migration when the new profile already exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'slicc-migrate-'));
+    tempDirs.push(root);
+
+    const newProfile = join(root, 'new', 'browser-coding-agent-chrome');
+    await mkdir(newProfile, { recursive: true });
+    await writeFile(join(newProfile, 'marker.txt'), 'existing-data');
+
+    const legacyProfile = join(root, 'legacy', 'browser-coding-agent-chrome');
+    await mkdir(legacyProfile, { recursive: true });
+    await writeFile(join(legacyProfile, 'marker.txt'), 'legacy-data');
+
+    await migrateLegacyDefaultChromeProfile(newProfile, [legacyProfile]);
+
+    expect(await readFile(join(newProfile, 'marker.txt'), 'utf8')).toBe('existing-data');
+  });
+
+  it('is a no-op when no legacy profile exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'slicc-migrate-'));
+    tempDirs.push(root);
+
+    const newProfile = join(root, 'new', 'browser-coding-agent-chrome');
+    const missingLegacy = join(root, 'legacy', 'browser-coding-agent-chrome');
+
+    await expect(
+      migrateLegacyDefaultChromeProfile(newProfile, [missingLegacy])
+    ).resolves.not.toThrow();
+    expect(fsExistsSync(newProfile)).toBe(false);
+  });
+
+  it('tries candidates in order and stops at the first match', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'slicc-migrate-'));
+    tempDirs.push(root);
+
+    const first = join(root, 'first', 'browser-coding-agent-chrome');
+    const second = join(root, 'second', 'browser-coding-agent-chrome');
+    await mkdir(first, { recursive: true });
+    await writeFile(join(first, 'marker.txt'), 'first-data');
+    await mkdir(second, { recursive: true });
+    await writeFile(join(second, 'marker.txt'), 'second-data');
+
+    const newProfile = join(root, 'new', 'browser-coding-agent-chrome');
+    await migrateLegacyDefaultChromeProfile(newProfile, [first, second]);
+
+    expect(await readFile(join(newProfile, 'marker.txt'), 'utf8')).toBe('first-data');
   });
 });

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -993,6 +993,26 @@ describe('migrateLegacyDefaultChromeProfile', () => {
     expect(await readFile(join(newProfile, 'marker.txt'), 'utf8')).toBe('existing-data');
   });
 
+  it('does not throw and leaves no partial copy when cp fails', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'slicc-migrate-'));
+    tempDirs.push(root);
+
+    const legacyProfile = join(root, 'legacy', 'browser-coding-agent-chrome');
+    await mkdir(legacyProfile, { recursive: true });
+    await writeFile(join(legacyProfile, 'marker.txt'), 'legacy-data');
+
+    // Make newDir's parent a file so cp fails with ENOTDIR — newDir itself does not exist,
+    // so the existsSync guard doesn't short-circuit.
+    const newParent = join(root, 'new');
+    await writeFile(newParent, 'i-am-a-file-not-a-dir');
+    const newProfile = join(newParent, 'browser-coding-agent-chrome');
+
+    await expect(
+      migrateLegacyDefaultChromeProfile(newProfile, [legacyProfile])
+    ).resolves.not.toThrow();
+    expect(fsExistsSync(newProfile)).toBe(false);
+  });
+
   it('is a no-op when no legacy profile exists', async () => {
     const root = await mkdtemp(join(tmpdir(), 'slicc-migrate-'));
     tempDirs.push(root);

--- a/packages/swift-server/Package.resolved
+++ b/packages/swift-server/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "87de4887195cd19325dd95f3f2b4ce936181ab441d8bcc1e5c8c373432b4b103",
+  "originHash" : "30c586523f0a62fb6acb4d7c54456e6d18310f6f12d7fac0dc96b2a0c2d14681",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "abcf5312eb8ed2fb11916078aef7c46b06f20813",
-        "version" : "1.33.0"
+        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
+        "version" : "1.34.1"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "9019b76fa858564a27e0aab13c01987d6e2869fa",
-        "version" : "1.41.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/swift-websocket.git",
       "state" : {
-        "revision" : "ca48d46c25f8fa948d37eaa480c73172182cf90f",
-        "version" : "1.5.0"
+        "revision" : "126df9655565068bd97838c072c1db11f9fd42ee",
+        "version" : "1.6.1"
       }
     },
     {

--- a/packages/swift-server/Package.resolved
+++ b/packages/swift-server/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "30c586523f0a62fb6acb4d7c54456e6d18310f6f12d7fac0dc96b2a0c2d14681",
+  "originHash" : "87de4887195cd19325dd95f3f2b4ce936181ab441d8bcc1e5c8c373432b4b103",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
-        "version" : "1.34.1"
+        "revision" : "abcf5312eb8ed2fb11916078aef7c46b06f20813",
+        "version" : "1.33.0"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
+        "revision" : "9019b76fa858564a27e0aab13c01987d6e2869fa",
+        "version" : "1.41.0"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/swift-websocket.git",
       "state" : {
-        "revision" : "126df9655565068bd97838c072c1db11f9fd42ee",
-        "version" : "1.6.1"
+        "revision" : "ca48d46c25f8fa948d37eaa480c73172182cf90f",
+        "version" : "1.5.0"
       }
     },
     {

--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -236,16 +236,53 @@ struct ChromeLauncher: Sendable {
     }
 
     func resolveUserDataDir(tmpDir: String? = nil, servePort: Int? = nil) -> String {
-        let baseTmpDir = normalizedPath(tmpDir)
-            ?? normalizedPath(environmentProvider()["TMPDIR"])
-            ?? "/tmp"
+        let baseDir = normalizedPath(tmpDir)
+            ?? URL(fileURLWithPath: homeDirectoryProvider(), isDirectory: true)
+                .appendingPathComponent(".slicc/chrome-profiles", isDirectory: true)
+                .path
         let suffix = (servePort != nil && servePort != defaultServePort) ? "-\(servePort!)" : ""
-        return URL(fileURLWithPath: baseTmpDir, isDirectory: true)
+        return URL(fileURLWithPath: baseDir, isDirectory: true)
             .appendingPathComponent("\(defaultChromeUserDataDirName)\(suffix)", isDirectory: true)
             .path
     }
 
+    /// One-time migration: if `newDir` doesn't exist yet, copies the first matching
+    /// candidate (legacy profile from $TMPDIR or /tmp) to the stable new location.
+    /// Non-destructive — the old profile is left in place.
+    func migrateLegacyDefaultChromeProfile(newDir: String, candidates: [String]) throws {
+        guard !FileManager.default.fileExists(atPath: newDir) else { return }
+        for candidate in candidates {
+            if FileManager.default.fileExists(atPath: candidate) {
+                let destParent = URL(fileURLWithPath: newDir).deletingLastPathComponent()
+                try FileManager.default.createDirectory(at: destParent, withIntermediateDirectories: true)
+                try FileManager.default.copyItem(atPath: candidate, toPath: newDir)
+                logger.info("Migrated Chrome profile: \(candidate) → \(newDir)")
+                return
+            }
+        }
+    }
+
+    /// Builds the ordered list of legacy candidate paths for a given profile dir name.
+    /// Checks $TMPDIR first, then /tmp, deduplicating when they are the same.
+    func legacyChromeCandidates(profileDirName: String) -> [String] {
+        var bases: [String] = []
+        let env = environmentProvider()
+        if let tmpDir = env["TMPDIR"] {
+            bases.append(tmpDir)
+        }
+        if !bases.contains("/tmp") {
+            bases.append("/tmp")
+        }
+        return bases.map { URL(fileURLWithPath: $0).appendingPathComponent(profileDirName).path }
+    }
+
     func launch(config: ChromeLaunchConfig) async throws -> ChromeProcess {
+        let profileDirName = URL(fileURLWithPath: config.userDataDir).lastPathComponent
+        try migrateLegacyDefaultChromeProfile(
+            newDir: config.userDataDir,
+            candidates: legacyChromeCandidates(profileDirName: profileDirName)
+        )
+
         let executable = config.executablePath ?? findChromeExecutable(
             projectRoot: config.projectRoot,
             environment: config.environment,

--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -238,7 +238,7 @@ struct ChromeLauncher: Sendable {
     func resolveUserDataDir(tmpDir: String? = nil, servePort: Int? = nil) -> String {
         let baseDir = normalizedPath(tmpDir)
             ?? URL(fileURLWithPath: homeDirectoryProvider(), isDirectory: true)
-                .appendingPathComponent(".slicc/chrome-profiles", isDirectory: true)
+                .appendingPathComponent(".slicc/profiles", isDirectory: true)
                 .path
         let suffix = (servePort != nil && servePort != defaultServePort) ? "-\(servePort!)" : ""
         return URL(fileURLWithPath: baseDir, isDirectory: true)

--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -249,14 +249,19 @@ struct ChromeLauncher: Sendable {
     /// One-time migration: if `newDir` doesn't exist yet, copies the first matching
     /// candidate (legacy profile from $TMPDIR or /tmp) to the stable new location.
     /// Non-destructive — the old profile is left in place.
-    func migrateLegacyDefaultChromeProfile(newDir: String, candidates: [String]) throws {
+    func migrateLegacyDefaultChromeProfile(newDir: String, candidates: [String]) {
         guard !FileManager.default.fileExists(atPath: newDir) else { return }
         for candidate in candidates {
             if FileManager.default.fileExists(atPath: candidate) {
-                let destParent = URL(fileURLWithPath: newDir).deletingLastPathComponent()
-                try FileManager.default.createDirectory(at: destParent, withIntermediateDirectories: true)
-                try FileManager.default.copyItem(atPath: candidate, toPath: newDir)
-                logger.info("Migrated Chrome profile: \(candidate) → \(newDir)")
+                do {
+                    let destParent = URL(fileURLWithPath: newDir).deletingLastPathComponent()
+                    try FileManager.default.createDirectory(at: destParent, withIntermediateDirectories: true)
+                    try FileManager.default.copyItem(atPath: candidate, toPath: newDir)
+                    logger.info("Migrated Chrome profile: \(candidate) → \(newDir)")
+                } catch {
+                    try? FileManager.default.removeItem(atPath: newDir)
+                    logger.warning("Chrome profile migration failed (\(candidate) → \(newDir)): \(error.localizedDescription); continuing with a fresh profile.")
+                }
                 return
             }
         }
@@ -278,7 +283,7 @@ struct ChromeLauncher: Sendable {
 
     func launch(config: ChromeLaunchConfig) async throws -> ChromeProcess {
         let profileDirName = URL(fileURLWithPath: config.userDataDir).lastPathComponent
-        try migrateLegacyDefaultChromeProfile(
+        migrateLegacyDefaultChromeProfile(
             newDir: config.userDataDir,
             candidates: legacyChromeCandidates(profileDirName: profileDirName)
         )

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -147,7 +147,7 @@ final class ChromeLauncherTests: XCTestCase {
 
         let newProfile = root.appendingPathComponent("new/browser-coding-agent-chrome")
         let launcher = makeLauncher()
-        try launcher.migrateLegacyDefaultChromeProfile(newDir: newProfile.path, candidates: [legacyProfile.path])
+        launcher.migrateLegacyDefaultChromeProfile(newDir: newProfile.path, candidates: [legacyProfile.path])
 
         let content = try String(contentsOfFile: newProfile.appendingPathComponent("marker.txt").path, encoding: .utf8)
         XCTAssertEqual(content, "legacy-data")
@@ -167,7 +167,7 @@ final class ChromeLauncherTests: XCTestCase {
         fm.createFile(atPath: legacyProfile.appendingPathComponent("marker.txt").path, contents: Data("legacy-data".utf8))
 
         let launcher = makeLauncher()
-        try launcher.migrateLegacyDefaultChromeProfile(newDir: newProfile.path, candidates: [legacyProfile.path])
+        launcher.migrateLegacyDefaultChromeProfile(newDir: newProfile.path, candidates: [legacyProfile.path])
 
         let content = try String(contentsOfFile: newProfile.appendingPathComponent("marker.txt").path, encoding: .utf8)
         XCTAssertEqual(content, "existing-data")
@@ -182,7 +182,7 @@ final class ChromeLauncherTests: XCTestCase {
         let missingLegacy = root.appendingPathComponent("legacy/browser-coding-agent-chrome")
         let launcher = makeLauncher()
 
-        XCTAssertNoThrow(try launcher.migrateLegacyDefaultChromeProfile(newDir: newProfile.path, candidates: [missingLegacy.path]))
+        launcher.migrateLegacyDefaultChromeProfile(newDir: newProfile.path, candidates: [missingLegacy.path])
         XCTAssertFalse(fm.fileExists(atPath: newProfile.path))
     }
 

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -105,17 +105,85 @@ final class ChromeLauncherTests: XCTestCase {
         XCTAssertEqual(Array(args.suffix(chromeArgs.count)), chromeArgs)
     }
 
+    func testResolveUserDataDirDefaultsToSliccProfilesInHomeDir() {
+        let launcher = makeLauncher(homeDirectory: "/Users/test")
+
+        XCTAssertEqual(
+            launcher.resolveUserDataDir(),
+            "/Users/test/.slicc/chrome-profiles/browser-coding-agent-chrome"
+        )
+    }
+
     func testResolveUserDataDirAddsSuffixForNonDefaultServePort() {
-        let launcher = makeLauncher(environment: ["TMPDIR": "/tmp/runtime"])
+        let launcher = makeLauncher(homeDirectory: "/Users/test")
 
         XCTAssertEqual(
             launcher.resolveUserDataDir(servePort: 5720),
-            "/tmp/runtime/browser-coding-agent-chrome-5720"
+            "/Users/test/.slicc/chrome-profiles/browser-coding-agent-chrome-5720"
         )
         XCTAssertEqual(
             launcher.resolveUserDataDir(servePort: 5710),
-            "/tmp/runtime/browser-coding-agent-chrome"
+            "/Users/test/.slicc/chrome-profiles/browser-coding-agent-chrome"
         )
+    }
+
+    func testResolveUserDataDirHonorsExplicitTmpDirOverride() {
+        let launcher = makeLauncher(homeDirectory: "/Users/test")
+
+        XCTAssertEqual(
+            launcher.resolveUserDataDir(tmpDir: "/custom/profiles", servePort: 5720),
+            "/custom/profiles/browser-coding-agent-chrome-5720"
+        )
+    }
+
+    func testMigrateLegacyProfileCopiesFromOldLocationToNew() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fm.removeItem(at: root) }
+
+        let legacyProfile = root.appendingPathComponent("legacy/browser-coding-agent-chrome")
+        try fm.createDirectory(at: legacyProfile, withIntermediateDirectories: true)
+        fm.createFile(atPath: legacyProfile.appendingPathComponent("marker.txt").path, contents: Data("legacy-data".utf8))
+
+        let newProfile = root.appendingPathComponent("new/browser-coding-agent-chrome")
+        let launcher = makeLauncher()
+        try launcher.migrateLegacyDefaultChromeProfile(newDir: newProfile.path, candidates: [legacyProfile.path])
+
+        let content = try String(contentsOfFile: newProfile.appendingPathComponent("marker.txt").path, encoding: .utf8)
+        XCTAssertEqual(content, "legacy-data")
+    }
+
+    func testMigrateLegacyProfileSkipsWhenNewProfileExists() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fm.removeItem(at: root) }
+
+        let newProfile = root.appendingPathComponent("new/browser-coding-agent-chrome")
+        try fm.createDirectory(at: newProfile, withIntermediateDirectories: true)
+        fm.createFile(atPath: newProfile.appendingPathComponent("marker.txt").path, contents: Data("existing-data".utf8))
+
+        let legacyProfile = root.appendingPathComponent("legacy/browser-coding-agent-chrome")
+        try fm.createDirectory(at: legacyProfile, withIntermediateDirectories: true)
+        fm.createFile(atPath: legacyProfile.appendingPathComponent("marker.txt").path, contents: Data("legacy-data".utf8))
+
+        let launcher = makeLauncher()
+        try launcher.migrateLegacyDefaultChromeProfile(newDir: newProfile.path, candidates: [legacyProfile.path])
+
+        let content = try String(contentsOfFile: newProfile.appendingPathComponent("marker.txt").path, encoding: .utf8)
+        XCTAssertEqual(content, "existing-data")
+    }
+
+    func testMigrateLegacyProfileIsNoOpWhenNoLegacyExists() {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fm.removeItem(at: root) }
+
+        let newProfile = root.appendingPathComponent("new/browser-coding-agent-chrome")
+        let missingLegacy = root.appendingPathComponent("legacy/browser-coding-agent-chrome")
+        let launcher = makeLauncher()
+
+        XCTAssertNoThrow(try launcher.migrateLegacyDefaultChromeProfile(newDir: newProfile.path, candidates: [missingLegacy.path]))
+        XCTAssertFalse(fm.fileExists(atPath: newProfile.path))
     }
 
     func testParseCdpPortFromStderrExtractsPort() {

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -110,7 +110,7 @@ final class ChromeLauncherTests: XCTestCase {
 
         XCTAssertEqual(
             launcher.resolveUserDataDir(),
-            "/Users/test/.slicc/chrome-profiles/browser-coding-agent-chrome"
+            "/Users/test/.slicc/profiles/browser-coding-agent-chrome"
         )
     }
 
@@ -119,11 +119,11 @@ final class ChromeLauncherTests: XCTestCase {
 
         XCTAssertEqual(
             launcher.resolveUserDataDir(servePort: 5720),
-            "/Users/test/.slicc/chrome-profiles/browser-coding-agent-chrome-5720"
+            "/Users/test/.slicc/profiles/browser-coding-agent-chrome-5720"
         )
         XCTAssertEqual(
             launcher.resolveUserDataDir(servePort: 5710),
-            "/Users/test/.slicc/chrome-profiles/browser-coding-agent-chrome"
+            "/Users/test/.slicc/profiles/browser-coding-agent-chrome"
         )
     }
 


### PR DESCRIPTION
## Summary

Chrome profiles were written to `$TMPDIR` (falling back to `/tmp`), which macOS clears on reboot, silently wiping all session history. Both `node-server` and `swift-server` now write profiles to `~/.slicc/chrome-profiles/`, a stable user-owned directory that survives reboots. A one-time migration copies any existing legacy profile to the new location on first launch after upgrade.

## Why

After running two SLICC instances simultaneously (e.g. sliccstart + `npx sliccy`), the default cone would lose all session history after a reboot. Root cause: sliccstart's swift-server launches as a GUI app and may not inherit the shell's `$TMPDIR`, causing it to fall back to `/tmp` — which macOS purges on restart.

**Repro:**
1. Open sliccstart, do some work (sessions created)
2. Run `npx sliccy` for a second cone
3. Reboot
4. Reopen sliccstart

Expected: previous sessions are present
Actual: session list is empty

## Approach / Implementation notes

- `resolveDefaultChromeUserDataDir()` (`chrome-launch.ts`) and `resolveUserDataDir()` (`ChromeLauncher.swift`) now default to `~/.slicc/chrome-profiles/` via `homedir()` / `homeDirectoryProvider()` instead of `$TMPDIR ?? /tmp`. The per-port suffix logic (`-<N>` for non-5710 ports) is unchanged.
- `index.ts` no longer passes `tmpDir: process.env['TMPDIR']` to `resolveChromeLaunchProfile` — that env-var pass-through was the production path that kept profiles in temp.
- The `tmpDir` override parameter is kept on both functions as a test escape hatch (existing tests pass explicit paths; none touch the real home directory).
- `migrateLegacyDefaultChromeProfile(newDir, candidates)` copies the first found legacy candidate to `newDir` if `newDir` doesn't exist yet. Non-destructive — old profile is left in place. Handles all port variants because the caller derives `candidates` from `basename(userDataDir)`, which already includes any port suffix.
- `legacyChromeCandidates(profileDirName)` builds the ordered candidate list: `$TMPDIR` first, then `/tmp`, deduplicating when they're the same path.
- Migration is skipped for hosted mode (`--hosted`) and QA profiles (`leader`/`follower`/`extension`) — hosted has its own `CHROME_USER_DATA_DIR`, and QA profiles never lived in tmp.

## Cross-cutting impact

- **Floats exercised**: CLI (`node-server`) and Sliccstart (`swift-server`). Chrome extension float is unaffected (no Chrome profile management). Electron float is unaffected (uses separate CDP attach path).
- **Other callers**: `resolveChromeLaunchProfile` is called in one place in `index.ts`; `ChromeLaunchConfig.userDataDir` is set at the call site in `ServerCommand.swift` (swift-server CLI entry) — that call site already uses `resolveUserDataDir()` so picks up the new default automatically.
- **Persisted state side-effects**: IndexedDB (`browser-coding-agent`, `slicc-fs`, etc.) lives inside the Chrome profile directory and moves with it. No schema changes; the data is copied verbatim.
- **Migration rollback**: if a user downgrades, the old code will create a fresh profile in `$TMPDIR` — sessions accumulated in `~/.slicc/chrome-profiles/` won't be visible. No automated undo.

## Test plan

- [ ] `npm run typecheck` — passes (pre-existing `just-bash ByteString` error on `main`, unrelated)
- [ ] `npm run test` — 6285 passing, 3 pre-existing failures in `packages/cherry/` (reproduce on `main`)
- [ ] `npm run lint` — clean
- [ ] **New behavior covered by unit tests** in `packages/node-server/tests/chrome-launch.test.ts`:
  - `defaults to ~/.slicc/chrome-profiles when no tmpDir override is given`
  - `uses an explicit tmpDir override when provided`
  - `migrateLegacyDefaultChromeProfile > copies a legacy profile to the new stable location`
  - `migrateLegacyDefaultChromeProfile > skips migration when the new profile already exists`
  - `migrateLegacyDefaultChromeProfile > is a no-op when no legacy profile exists`
  - `migrateLegacyDefaultChromeProfile > tries candidates in order and stops at the first match`
  - Swift equivalents in `ChromeLauncherTests.swift` (build blocked by pre-existing `swift-nio-ssl` C++ header issue on macOS 15, unrelated to this PR)
- [ ] Manual smoke (CLI): `npm run dev` — confirmed Chrome launches, profile appears at `~/.slicc/chrome-profiles/browser-coding-agent-chrome`
- [ ] Manual smoke (Sliccstart): relevant — swift-server change means sliccstart profiles now survive reboot

**Pre-existing failures:**
- 3 failures in `packages/cherry/tests/` reproduce on `main` (Vite transform error, unrelated)
- Swift test suite fails to compile on macOS 15 due to `swift-nio-ssl` missing `<memory>` C++ header — pre-existing, reproduces on `main`

## Documentation

- [x] No documentation changes needed — profile location is an implementation detail not referenced in user-facing docs or agent skills

## Risk & rollback

- **Blast radius**: all floats that use a default Chrome profile (CLI + Sliccstart). QA profiles, hosted mode, and extension float are unaffected.
- **Rollback**: revert this PR. Users who already launched after upgrade will have a profile at `~/.slicc/chrome-profiles/` that a reverted build won't find — they'd get a fresh profile in `$TMPDIR`. The `~/.slicc/chrome-profiles/` directory would need manual cleanup to fully undo.
- **CI cannot catch**: actual Chrome profile persistence across reboot; migration behavior with a real legacy profile in `/tmp`.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] No public API / tool / shell-command changes
- [x] Checked CLI and Sliccstart paths; extension and Electron floats unaffected
