### PR TITLE
fix(cloudflare-worker): hibernate tray leader WebSocket to stop runaway DO duration cost

### DIFF
--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -178,26 +178,44 @@ export class SessionTrayDurableObject {
   }
 
   async webSocketClose(ws: TrayWebSocketLike): Promise<void> {
-    this.leaderSocket = ws;
-    if (!this.tray) {
-      await this.loadTray();
-    }
-    await this.markLeaderDisconnected(ws);
+    await this.handleLeaderSocketGone(ws);
   }
 
   async webSocketError(ws: TrayWebSocketLike): Promise<void> {
-    this.leaderSocket = ws;
+    await this.handleLeaderSocketGone(ws);
+  }
+
+  // A close/error for the leader socket may be delivered after a newer leader
+  // socket has already reconnected (the runtime can deliver these late, and we
+  // may be a freshly re-created instance after hibernation). Treat the runtime's
+  // getWebSockets(LEADER_WS_TAG) as the source of truth: if another leader
+  // socket is still live, the gone socket is stale and must not tear down the
+  // tray; otherwise mark the leader disconnected.
+  private async handleLeaderSocketGone(ws: TrayWebSocketLike): Promise<void> {
     if (!this.tray) {
       await this.loadTray();
     }
+    const liveSockets = this.currentLeaderSockets().filter((socket) => socket !== ws);
+    if (liveSockets.length > 0) {
+      this.leaderSocket = liveSockets[0] ?? null;
+      return;
+    }
+    this.leaderSocket = ws;
     await this.markLeaderDisconnected(ws);
   }
 
+  private currentLeaderSockets(): TrayWebSocketLike[] {
+    if (typeof this.state.getWebSockets !== 'function') {
+      return this.leaderSocket ? [this.leaderSocket] : [];
+    }
+    return this.state.getWebSockets(LEADER_WS_TAG) as TrayWebSocketLike[];
+  }
+
   private restoreLeaderSocket(): void {
-    if (this.leaderSocket || typeof this.state.getWebSockets !== 'function') {
+    if (this.leaderSocket) {
       return;
     }
-    const [socket] = this.state.getWebSockets(LEADER_WS_TAG) as TrayWebSocketLike[];
+    const [socket] = this.currentLeaderSockets();
     if (socket) {
       this.leaderSocket = socket;
     }

--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -42,13 +42,8 @@ type TrayBootstrapEventInput =
   | { type: 'bootstrap.failed'; failure: TrayBootstrapFailure };
 
 interface TrayWebSocketLike {
-  accept?: () => void;
   send(data: string): void;
   close(code?: number, reason?: string): void;
-  addEventListener(
-    type: 'message' | 'close' | 'error',
-    listener: (event: { data?: string }) => void
-  ): void;
 }
 
 export interface SessionTrayEnv {
@@ -64,6 +59,7 @@ interface SessionTrayOptions {
 
 const TRAY_STORAGE_KEY = 'tray';
 const TURN_CREDENTIAL_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+const LEADER_WS_TAG = 'leader';
 
 interface CachedIceServers {
   iceServers: TurnIceServer[];
@@ -114,6 +110,7 @@ export class SessionTrayDurableObject {
     }
 
     await this.loadTray();
+    this.restoreLeaderSocket();
     if (!this.tray) {
       return jsonResponse({ error: 'Tray not initialized', code: 'TRAY_NOT_INITIALIZED' }, 500);
     }
@@ -169,6 +166,41 @@ export class SessionTrayDurableObject {
     }
 
     return jsonResponse({ error: 'Not found', code: 'NOT_FOUND' }, 404);
+  }
+
+  async webSocketMessage(ws: TrayWebSocketLike, message: string | ArrayBuffer): Promise<void> {
+    this.leaderSocket = ws;
+    if (!this.tray) {
+      await this.loadTray();
+    }
+    const data = typeof message === 'string' ? message : new TextDecoder().decode(message);
+    await this.handleLeaderMessage(ws, data);
+  }
+
+  async webSocketClose(ws: TrayWebSocketLike): Promise<void> {
+    this.leaderSocket = ws;
+    if (!this.tray) {
+      await this.loadTray();
+    }
+    await this.markLeaderDisconnected(ws);
+  }
+
+  async webSocketError(ws: TrayWebSocketLike): Promise<void> {
+    this.leaderSocket = ws;
+    if (!this.tray) {
+      await this.loadTray();
+    }
+    await this.markLeaderDisconnected(ws);
+  }
+
+  private restoreLeaderSocket(): void {
+    if (this.leaderSocket || typeof this.state.getWebSockets !== 'function') {
+      return;
+    }
+    const [socket] = this.state.getWebSockets(LEADER_WS_TAG) as TrayWebSocketLike[];
+    if (socket) {
+      this.leaderSocket = socket;
+    }
   }
 
   private async handleCreate(request: Request): Promise<Response> {
@@ -476,21 +508,18 @@ export class SessionTrayDurableObject {
     }
 
     const { client, server } = this.webSocketPairFactory();
-    server.accept?.();
+    if (typeof this.state.acceptWebSocket !== 'function') {
+      throw new Error('Durable Object runtime does not support WebSocket hibernation');
+    }
+    // Hibernation API: the runtime evicts the object from memory between
+    // messages and delivers them via webSocketMessage/Close/Error, so we are
+    // not billed for idle connection time. The leader socket is recovered after
+    // eviction via getWebSockets(LEADER_WS_TAG).
+    this.state.acceptWebSocket(server, [LEADER_WS_TAG]);
     this.leaderSocket = server;
     tray.leader.connected = true;
     tray.leader.lastSeenAt = this.isoNow();
     tray.leader.disconnectedAt = undefined;
-
-    server.addEventListener('message', (event) => {
-      void this.handleLeaderMessage(server, event.data ?? '');
-    });
-    server.addEventListener('close', () => {
-      void this.markLeaderDisconnected(server);
-    });
-    server.addEventListener('error', () => {
-      void this.markLeaderDisconnected(server);
-    });
 
     await this.persistTray();
     server.send(

--- a/packages/cloudflare-worker/src/shared.ts
+++ b/packages/cloudflare-worker/src/shared.ts
@@ -35,6 +35,8 @@ export interface DurableObjectStorageLike {
 
 export interface DurableObjectStateLike {
   storage: DurableObjectStorageLike;
+  acceptWebSocket?(ws: unknown, tags?: string[]): void;
+  getWebSockets?(tag?: string): unknown[];
 }
 
 export interface ControllerRecord {

--- a/packages/cloudflare-worker/tests/deployed.test.ts
+++ b/packages/cloudflare-worker/tests/deployed.test.ts
@@ -293,6 +293,139 @@ describeIfConfigured('deployed tray worker', () => {
     expect(body.capabilities.controller.url).toBeTruthy();
     expect(body.capabilities.webhook.url).toBeTruthy();
   }, 15_000);
+
+  // Hibernation regression guard. With the WebSocket Hibernation API the runtime
+  // can evict the Durable Object from memory while the leader socket stays open,
+  // so a webhook POST arrives on a *separate* invocation that must recover the
+  // socket via getWebSockets() rather than an in-memory field. This is the exact
+  // path that the duration-cost fix changed, and it is otherwise unexercised
+  // live (the existing webhook checks only hit the WEBHOOK_ID_REQUIRED branch).
+  it('forwards a webhook to a hibernatable leader socket on a separate request', async () => {
+    const baseUrl = new URL(workerBaseUrl!);
+    const createResponse = await fetch(new URL('/tray', baseUrl), { method: 'POST' });
+    expect(createResponse.status).toBe(201);
+    const created = (await createResponse.json()) as CreateTrayResponse;
+
+    const attachResponse = await fetch(created.capabilities.controller.url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ controllerId: 'ci-webhook-leader', runtime: 'github-actions' }),
+    });
+    expect(attachResponse.status).toBe(200);
+    const controller = (await attachResponse.json()) as ControllerAttachResponse;
+    expect(controller.websocket?.url).toBeTruthy();
+
+    const { socket, nextMessage } = await openWebSocket(controller.websocket!.url);
+    try {
+      const connected = await nextMessage();
+      expect(connected).toMatchObject({ type: 'leader.connected', trayId: created.trayId });
+
+      const webhookResponse = await fetch(`${created.capabilities.webhook.url}/ci-hook-1`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action: 'opened', repo: 'ci/repo' }),
+      });
+      expect(webhookResponse.status).toBe(202);
+      await expect(webhookResponse.json()).resolves.toMatchObject({ ok: true, accepted: true });
+
+      const forwarded = await nextMessage();
+      expect(forwarded).toMatchObject({
+        type: 'webhook.event',
+        webhookId: 'ci-hook-1',
+        body: { action: 'opened', repo: 'ci/repo' },
+      });
+    } finally {
+      socket.close();
+    }
+  }, 30_000);
+
+  // Idle gap long enough for the runtime to potentially hibernate the object.
+  // The test passes whether or not eviction actually happens, but if the leader
+  // socket were pinned in an in-memory field (the pre-fix behavior) a rehydration
+  // bug would only ever surface here, after the object has been reclaimed.
+  it('still delivers webhooks to the leader after an idle gap that may trigger hibernation', async () => {
+    const baseUrl = new URL(workerBaseUrl!);
+    const created = (await (
+      await fetch(new URL('/tray', baseUrl), { method: 'POST' })
+    ).json()) as CreateTrayResponse;
+    const controller = (await (
+      await fetch(created.capabilities.controller.url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ controllerId: 'ci-idle-leader', runtime: 'github-actions' }),
+      })
+    ).json()) as ControllerAttachResponse;
+    expect(controller.websocket?.url).toBeTruthy();
+
+    const { socket, nextMessage } = await openWebSocket(controller.websocket!.url);
+    try {
+      await nextMessage(); // leader.connected
+
+      await new Promise((resolve) => setTimeout(resolve, 10_000));
+
+      const webhookResponse = await fetch(
+        `${created.capabilities.webhook.url}/ci-hook-after-idle`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ phase: 'after-idle' }),
+        }
+      );
+      expect(webhookResponse.status).toBe(202);
+
+      const forwarded = await nextMessage();
+      expect(forwarded).toMatchObject({
+        type: 'webhook.event',
+        webhookId: 'ci-hook-after-idle',
+        body: { phase: 'after-idle' },
+      });
+    } finally {
+      socket.close();
+    }
+  }, 30_000);
+
+  // After the leader socket closes, the runtime delivers webSocketClose on a
+  // possibly-fresh instance. Liveness must drop so webhooks are rejected with
+  // NO_LIVE_LEADER instead of being silently dropped against a dead socket.
+  it('drops leader liveness after the socket closes so webhooks are rejected', async () => {
+    const baseUrl = new URL(workerBaseUrl!);
+    const created = (await (
+      await fetch(new URL('/tray', baseUrl), { method: 'POST' })
+    ).json()) as CreateTrayResponse;
+    const controller = (await (
+      await fetch(created.capabilities.controller.url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ controllerId: 'ci-close-leader', runtime: 'github-actions' }),
+      })
+    ).json()) as ControllerAttachResponse;
+    expect(controller.websocket?.url).toBeTruthy();
+
+    const { socket, nextMessage } = await openWebSocket(controller.websocket!.url);
+    await nextMessage(); // leader.connected
+    await new Promise<void>((resolve) => {
+      socket.once('close', () => resolve());
+      socket.close();
+    });
+
+    // webSocketClose is processed asynchronously by the runtime; poll until the
+    // tray no longer reports a live leader.
+    let rejected = false;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const webhookResponse = await fetch(`${created.capabilities.webhook.url}/ci-hook-closed`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ phase: 'after-close' }),
+      });
+      if (webhookResponse.status === 410) {
+        await expect(webhookResponse.json()).resolves.toMatchObject({ code: 'NO_LIVE_LEADER' });
+        rejected = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+    expect(rejected).toBe(true);
+  }, 30_000);
 });
 
 describe('cloud routes smoke', () => {

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -29,6 +29,31 @@ class FakeStorage {
 
 class FakeDurableObjectState implements DurableObjectStateLike {
   readonly storage = new FakeStorage();
+  instance: SessionTrayDurableObject | null = null;
+  private readonly sockets: Array<{ ws: FakeWebSocket; tags: string[] }> = [];
+
+  acceptWebSocket(ws: FakeWebSocket, tags: string[] = []): void {
+    this.sockets.push({ ws, tags });
+    ws.addEventListener('message', (event) => {
+      void this.instance?.webSocketMessage(ws, event.data ?? '');
+    });
+    ws.addEventListener('close', () => {
+      const index = this.sockets.findIndex((entry) => entry.ws === ws);
+      if (index >= 0) {
+        this.sockets.splice(index, 1);
+      }
+      void this.instance?.webSocketClose(ws);
+    });
+    ws.addEventListener('error', () => {
+      void this.instance?.webSocketError(ws);
+    });
+  }
+
+  getWebSockets(tag?: string): FakeWebSocket[] {
+    return this.sockets
+      .filter((entry) => tag === undefined || entry.tags.includes(tag))
+      .map((entry) => entry.ws);
+  }
 }
 
 class FakeWebSocket {
@@ -110,6 +135,7 @@ class FakeNamespace {
         {},
         { now: this.now, webSocketPairFactory: createFakeWebSocketPair }
       );
+      state.instance = instance;
       this.instances.set(key, instance);
     }
 
@@ -2107,6 +2133,71 @@ describe('SessionTrayDurableObject — kind persistence', () => {
     const stored = (await state.storage.get('tray')) as TrayRecord;
     expect(stored.kind ?? 'desktop').toBe('desktop');
     expect(reclaimMsForTray(stored)).toBe(TRAY_RECLAIM_TTL_MS);
+  });
+});
+
+describe('SessionTrayDurableObject — hibernation', () => {
+  it('recovers the leader socket from getWebSockets after the object is evicted from memory', async () => {
+    const now = Date.parse('2026-03-11T00:00:00.000Z');
+    const state = new FakeDurableObjectState();
+    const first = new SessionTrayDurableObject(
+      state,
+      {},
+      { now: () => now, webSocketPairFactory: createFakeWebSocketPair }
+    );
+    state.instance = first;
+
+    await first.fetch(
+      new Request('https://tray.test/internal/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          trayId: 't-hib',
+          createdAt: new Date(now).toISOString(),
+          joinToken: 'j',
+          controllerToken: 'c',
+          webhookToken: 'w',
+        }),
+      })
+    );
+
+    const attach = await first.fetch(
+      new Request('https://tray.test/controller/c', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ controllerId: 'lead-1' }),
+      })
+    );
+    const leader = (await attach.json()) as { websocket: { url: string } };
+    const wsResponse = await first.fetch(
+      new Request(leader.websocket.url, { headers: { Upgrade: 'websocket' } })
+    );
+    const clientSocket = (wsResponse as unknown as { webSocket: FakeWebSocket }).webSocket;
+    expect(clientSocket.received[0]).toContain('leader.connected');
+
+    // Simulate a hibernation eviction: a fresh instance over the same state and
+    // the same accepted sockets, with no in-memory leaderSocket reference.
+    const revived = new SessionTrayDurableObject(
+      state,
+      {},
+      { now: () => now, webSocketPairFactory: createFakeWebSocketPair }
+    );
+    state.instance = revived;
+
+    const webhook = await revived.fetch(
+      new Request('https://tray.test/webhook/w/hook-1', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action: 'opened' }),
+      })
+    );
+
+    expect(webhook.status).toBe(202);
+    const forwarded = clientSocket.received
+      .map((raw) => JSON.parse(raw) as { type: string; webhookId?: string })
+      .filter((message) => message.type === 'webhook.event');
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0]?.webhookId).toBe('hook-1');
   });
 });
 

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -2199,6 +2199,52 @@ describe('SessionTrayDurableObject — hibernation', () => {
     expect(forwarded).toHaveLength(1);
     expect(forwarded[0]?.webhookId).toBe('hook-1');
   });
+
+  it('ignores a stale leader close when a newer leader socket is already live', async () => {
+    const now = Date.parse('2026-03-11T00:00:00.000Z');
+    const state = new FakeDurableObjectState();
+    const instance = new SessionTrayDurableObject(
+      state,
+      {},
+      { now: () => now, webSocketPairFactory: createFakeWebSocketPair }
+    );
+    state.instance = instance;
+
+    await instance.fetch(
+      new Request('https://tray.test/internal/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          trayId: 't-race',
+          createdAt: new Date(now).toISOString(),
+          joinToken: 'j',
+          controllerToken: 'c',
+          webhookToken: 'w',
+        }),
+      })
+    );
+    const attach = await instance.fetch(
+      new Request('https://tray.test/controller/c', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ controllerId: 'lead-1' }),
+      })
+    );
+    const leader = (await attach.json()) as { websocket: { url: string } };
+    await instance.fetch(new Request(leader.websocket.url, { headers: { Upgrade: 'websocket' } }));
+
+    const staleSocket = state.getWebSockets('leader')[0]!;
+
+    // The runtime accepts a replacement leader socket (reconnect) before it
+    // delivers the stale socket's webSocketClose.
+    const { server: newServer } = createFakeWebSocketPair();
+    state.acceptWebSocket(newServer, ['leader']);
+
+    await instance.webSocketClose(staleSocket);
+
+    const stored = (await state.storage.get('tray')) as TrayRecord;
+    expect(stored.leader?.connected).toBe(true);
+  });
 });
 
 describe('cherry framing policy', () => {


### PR DESCRIPTION
## Why

The `slicc-tray-hub` Cloudflare account was accruing ~$12/day (and climbing) of **Durable Objects Duration** charges ($12.50 per 1M GB-seconds). Analytics for the `SessionTrayDurableObject` namespace showed the smoking gun:

| date | active (s/day) | CPU (s/day) | CPU% |
|---|---|---|---|
| 06-03 | 8,060,854 | 127 | **0.00%** |
| 06-04 | 7,232,696 | 103 | 0.00% |

~7-8M active (in-memory) seconds/day at **~0% CPU** = ~80 DO instances pinned in memory 24/7. Cause: the leader control socket used `server.accept()` + `addEventListener`, which keeps the object resident in memory for the entire WebSocket lifetime, so every connected desktop session bills duration continuously even while idle.

## What

- Switch the leader socket to the **WebSocket Hibernation API**: `state.acceptWebSocket(server, ['leader'])` plus `webSocketMessage` / `webSocketClose` / `webSocketError` handlers, so the runtime evicts the object between messages and stops billing idle time.
- Add `restoreLeaderSocket()` (via `getWebSockets('leader')`) so cross-invocation paths — webhook forwarding, follower signaling, liveness checks — recover the socket after eviction instead of relying on an in-memory field.
- `webSocketClose`/`Error` only `await loadTray()` when the tray isn't already resident, preserving synchronous disconnect marking (and the reclaim-TTL semantics).

Since CPU is ~0%, this should cut that namespace's duration bill by roughly 99%. No migration or `wrangler.jsonc` change is needed (hibernation is an API-level switch on the existing SQLite-backed class).

## Tests

- **Unit:** made the fake DO state hibernation-aware (`acceptWebSocket`/`getWebSockets`, routes messages to the DO handlers) and added a test proving leader-socket recovery after a simulated eviction. Full suite: 193 passing.
- **Post-deploy (`deployed.test.ts`), targeting these edge-runtime edge cases:**
  - webhook forwarded to a hibernatable leader socket on a **separate** HTTP invocation (the exact rehydration path the fix changed — previously unexercised live; the old webhook checks only hit `WEBHOOK_ID_REQUIRED`).
  - webhook delivery after a ~10s idle gap that may trigger hibernation (correct whether or not eviction happens).
  - leader liveness drops after the socket closes so webhooks are rejected with `NO_LIVE_LEADER`.

## Verification

`tsc -p tsconfig.worker.json` clean; `biome check` clean; `vitest --project cloudflare-worker` 193 passing (new live tests skip without `WORKER_BASE_URL`).
