### PR TITLE
feat(dev-tools): daily Cloudflare overspend monitor (issue over $3/day)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       extension: ${{ steps.filter.outputs.extension }}
       cloudflare-worker: ${{ steps.filter.outputs.cloudflare-worker }}
       cherry: ${{ steps.filter.outputs.cherry }}
+      dev-tools: ${{ steps.filter.outputs.dev-tools }}
       swift-server: ${{ steps.filter.outputs.swift-server }}
       swift-launcher: ${{ steps.filter.outputs.swift-launcher }}
       ios-app: ${{ steps.filter.outputs.ios-app }}
@@ -52,6 +53,8 @@ jobs:
               - 'packages/cloudflare-worker/**'
             cherry:
               - 'packages/cherry/**'
+            dev-tools:
+              - 'packages/dev-tools/**'
             swift-server:
               - 'packages/swift-server/**'
             swift-launcher:
@@ -134,6 +137,7 @@ jobs:
       needs.changes.outputs.extension == 'true' ||
       needs.changes.outputs.cloudflare-worker == 'true' ||
       needs.changes.outputs.cherry == 'true' ||
+      needs.changes.outputs.dev-tools == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/cloudflare-spend-monitor.yml
+++ b/.github/workflows/cloudflare-spend-monitor.yml
@@ -1,0 +1,104 @@
+name: Cloudflare Spend Monitor
+
+# Daily tripwire for Cloudflare overspend. Cloudflare has no per-day billing
+# API, so this estimates usage-based spend for the previous full UTC day from
+# the GraphQL Analytics API (Durable Objects duration & requests, Workers
+# requests) and opens/updates a GitHub issue when it exceeds the threshold
+# (default $3/day). It exists to catch cost regressions like the Durable
+# Objects duration blow-up fixed in packages/cloudflare-worker/src/session-tray.ts.
+#
+# Required:
+#   secrets.CLOUDFLARE_API_TOKEN   must include "Account Analytics: Read"
+#   vars.CLOUDFLARE_ACCOUNT_ID     already used by the worker deploy workflows
+# Optional:
+#   vars.CLOUDFLARE_SPEND_THRESHOLD_USD   override the $3/day default
+#
+# The estimate logic is pure and unit-tested in
+# packages/dev-tools/cloudflare-spend-monitor/lib.test.mjs.
+
+on:
+  schedule:
+    - cron: '30 6 * * *' # daily at 06:30 UTC (after the UTC day has fully closed)
+  workflow_dispatch:
+    inputs:
+      threshold_usd:
+        description: 'Alert threshold in USD/day'
+        required: false
+        default: '3'
+      dry_run:
+        description: 'Query + estimate only; do not open/close issues'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: cloudflare-spend-monitor
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Third-party actions pinned to immutable commit SHAs (matching the other
+      # workflows) — this job has issues:write.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Estimate Cloudflare daily spend
+        id: spend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          SPEND_THRESHOLD_USD: ${{ github.event.inputs.threshold_usd || vars.CLOUDFLARE_SPEND_THRESHOLD_USD || '3' }}
+          REPORT_FILE: cloudflare-spend-report.md
+        run: node packages/dev-tools/cloudflare-spend-monitor/check-spend.mjs
+
+      - name: Ensure label exists
+        if: github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh label create cloudflare-spend --color B60205 --description "Cloudflare overspend tripwire" --force
+
+      - name: Open or update the overspend issue
+        if: steps.spend.outputs.over_threshold == 'true' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DAY: ${{ steps.spend.outputs.day }}
+          USD: ${{ steps.spend.outputs.estimated_usd }}
+          REPORT_FILE: ${{ steps.spend.outputs.report_file }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label cloudflare-spend --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #$existing"
+            gh issue comment "$existing" --body-file "$REPORT_FILE"
+          else
+            echo "Creating new overspend issue"
+            gh issue create \
+              --title "Cloudflare daily spend over threshold (\$$USD on $DAY)" \
+              --label cloudflare-spend \
+              --body-file "$REPORT_FILE"
+          fi
+
+      - name: Resolve the issue when spend is back to normal
+        if: steps.spend.outputs.over_threshold == 'false' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DAY: ${{ steps.spend.outputs.day }}
+          USD: ${{ steps.spend.outputs.estimated_usd }}
+          THRESHOLD: ${{ steps.spend.outputs.threshold_usd }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label cloudflare-spend --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Estimated Cloudflare spend for **$DAY (UTC)** was **\$$USD**, back under the \$$THRESHOLD/day threshold. Auto-closing."
+            gh issue close "$existing"
+          fi

--- a/packages/dev-tools/cloudflare-spend-monitor/README.md
+++ b/packages/dev-tools/cloudflare-spend-monitor/README.md
@@ -12,9 +12,10 @@ fix).
 ```
 cron (daily) ─▶ check-spend.mjs ─▶ over_threshold? ─▶ create-or-update GitHub issue
                    │
-                   ├─ POST graphql  durableObjectsPeriodicGroups        (duration → GB-s)
-                   ├─ POST graphql  durableObjectsInvocationsAdaptive…  (DO requests)
-                   └─ POST graphql  workersInvocationsAdaptive          (Workers requests)
+                   └─ one GraphQL POST returning three meters:
+                        • durableObjectsPeriodicGroups            (duration → GB-s)
+                        • durableObjectsInvocationsAdaptiveGroups (DO requests)
+                        • workersInvocationsAdaptive              (Workers requests)
 ```
 
 1. **Window** — `previousUtcDay()` selects the last _complete_ UTC day (avoids

--- a/packages/dev-tools/cloudflare-spend-monitor/README.md
+++ b/packages/dev-tools/cloudflare-spend-monitor/README.md
@@ -1,0 +1,93 @@
+# Cloudflare Spend Monitor — daily overspend tripwire
+
+A nightly check that estimates the previous UTC day's usage-based Cloudflare
+spend from the GraphQL Analytics API and opens (or updates) a GitHub issue when
+it exceeds a threshold (default **$3/day**). It exists to catch cost regressions
+like the Durable Objects duration blow-up that was costing ~$12.50/day (see
+`packages/cloudflare-worker/src/session-tray.ts` and the WebSocket hibernation
+fix).
+
+## Flow
+
+```
+cron (daily) ─▶ check-spend.mjs ─▶ over_threshold? ─▶ create-or-update GitHub issue
+                   │
+                   ├─ POST graphql  durableObjectsPeriodicGroups        (duration → GB-s)
+                   ├─ POST graphql  durableObjectsInvocationsAdaptive…  (DO requests)
+                   └─ POST graphql  workersInvocationsAdaptive          (Workers requests)
+```
+
+1. **Window** — `previousUtcDay()` selects the last _complete_ UTC day (avoids
+   the partial-day undercount of a trailing-24h window).
+2. **Query** — `check-spend.mjs` runs one GraphQL query for the three meters
+   that drive cost on this account.
+3. **Estimate** — `estimateDailySpend(...)` (pure, in `lib.mjs`) prices each
+   meter using public Workers Paid rates, subtracting the monthly free
+   allocation prorated per day, and sums to a daily total.
+4. **Alert** — the workflow writes `over_threshold` / `estimated_usd` /
+   `day` to `$GITHUB_OUTPUT` and a Markdown report; when over threshold it
+   creates a single rolling issue (deduped by a marker) or comments on the
+   existing one. When spend returns below threshold it comments and closes it.
+
+## What "spend" means here
+
+Cloudflare exposes **no per-day billing API**, so this is a deliberate
+**estimate** from analytics, not the invoiced amount. It covers the meters that
+actually drive cost on this account:
+
+| Meter                    | Rate                  | Monthly free allocation |
+| ------------------------ | --------------------- | ----------------------- |
+| Durable Objects duration | $12.50 / million GB-s | 400,000 GB-s            |
+| Durable Objects requests | $0.15 / million       | 1,000,000               |
+| Workers requests         | $0.30 / million       | 10,000,000              |
+
+Free allocations are prorated by the number of days in the month. The Workers
+Paid base fee (~$5/month) is intentionally ignored — this is a _usage-spike_
+tripwire. Durable Objects duration (128 MB × wall-clock active time) is the
+meter behind past overspend; it is the first thing to inspect in an alert.
+
+## Design notes
+
+- **Pure logic is isolated and tested.** `lib.mjs` has all cost math
+  (`estimateDailySpend`, `estimateMeterCost`, `activeTimeMicrosToGbSeconds`,
+  `daysInUtcMonth`, `previousUtcDay`, `sumForDay`, `buildReport`) with no I/O,
+  unit-tested in `lib.test.mjs` (run via the `dev-tools` vitest project in
+  `npm test`). `check-spend.mjs` only talks to the Cloudflare GraphQL API and
+  `$GITHUB_OUTPUT`.
+
+The workflow lives in `.github/workflows/cloudflare-spend-monitor.yml`.
+
+## Required secrets / variables (GitHub Actions)
+
+Reuses the existing Cloudflare credentials — **no new secret is required**, but
+the token must carry one extra permission:
+
+| Name                    | Kind     | Purpose                                                                       |
+| ----------------------- | -------- | ----------------------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`  | secret   | Cloudflare API token. **Must include `Account Analytics: Read`** for GraphQL. |
+| `CLOUDFLARE_ACCOUNT_ID` | variable | Cloudflare account id (already used by the worker deploy workflows).          |
+
+> If the existing `CLOUDFLARE_API_TOKEN` lacks `Account Analytics: Read`, the
+> run fails fast with a clear message; add the permission to that token (or
+> swap in one that has it) in the Cloudflare dashboard.
+
+## Run it locally
+
+```bash
+CLOUDFLARE_API_TOKEN=<token-with-analytics-read> \
+CLOUDFLARE_ACCOUNT_ID=<account-id> \
+SPEND_THRESHOLD_USD=3 \
+  node packages/dev-tools/cloudflare-spend-monitor/check-spend.mjs
+
+# Unit tests
+npx vitest run --project dev-tools
+```
+
+### Environment variables
+
+| Var                     | Meaning                                            | Default                      |
+| ----------------------- | -------------------------------------------------- | ---------------------------- |
+| `CLOUDFLARE_API_TOKEN`  | Token with `Account Analytics: Read`               | — (required)                 |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account id                              | — (required)                 |
+| `SPEND_THRESHOLD_USD`   | Alert threshold, USD/day                           | `3`                          |
+| `REPORT_FILE`           | Path for the Markdown report the workflow comments | `cloudflare-spend-report.md` |

--- a/packages/dev-tools/cloudflare-spend-monitor/check-spend.mjs
+++ b/packages/dev-tools/cloudflare-spend-monitor/check-spend.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/*
+ * Cloudflare spend monitor — orchestrator (I/O).
+ *
+ * Queries the Cloudflare GraphQL Analytics API for the previous full UTC day,
+ * asks `estimateDailySpend` (pure, unit-tested in `lib.mjs`) for the estimated
+ * usage-based cost, and writes the result to $GITHUB_OUTPUT plus a Markdown
+ * report file. The workflow opens/updates a GitHub issue when over threshold.
+ * This file only does I/O.
+ *
+ * Env:
+ *   CLOUDFLARE_API_TOKEN   token with **Account Analytics: Read**   (required)
+ *   CLOUDFLARE_ACCOUNT_ID  Cloudflare account id                    (required)
+ *   SPEND_THRESHOLD_USD    alert threshold in USD/day               (default 3)
+ *   REPORT_FILE            path to write the Markdown report        (default cloudflare-spend-report.md)
+ *
+ * Exit 0 on a clean decision (over or under threshold); non-zero only on
+ * missing env or an unexpected API/network failure.
+ */
+import { appendFileSync, writeFileSync } from 'node:fs';
+import {
+  activeTimeMicrosToGbSeconds,
+  buildReport,
+  DEFAULT_THRESHOLD_USD,
+  daysInUtcMonth,
+  estimateDailySpend,
+  isOverThreshold,
+  previousUtcDay,
+  sumForDay,
+} from './lib.mjs';
+
+const GRAPHQL_ENDPOINT = 'https://api.cloudflare.com/client/v4/graphql';
+
+const QUERY = `query AccountSpend($account: String!, $start: Time!, $end: Time!) {
+  viewer {
+    accounts(filter: { accountTag: $account }) {
+      durableObjectsDuration: durableObjectsPeriodicGroups(
+        limit: 1000
+        filter: { datetime_geq: $start, datetime_lt: $end }
+        orderBy: [date_ASC]
+      ) { dimensions { date } sum { activeTime } }
+      durableObjectsRequests: durableObjectsInvocationsAdaptiveGroups(
+        limit: 1000
+        filter: { datetime_geq: $start, datetime_lt: $end }
+        orderBy: [date_ASC]
+      ) { dimensions { date } sum { requests } }
+      workersRequests: workersInvocationsAdaptive(
+        limit: 1000
+        filter: { datetime_geq: $start, datetime_lt: $end }
+        orderBy: [date_ASC]
+      ) { dimensions { date } sum { requests } }
+    }
+  }
+}`;
+
+function requireEnv(name) {
+  const value = (process.env[name] ?? '').trim();
+  if (!value) {
+    console.error(`❌ Missing required env var ${name}.`);
+    process.exit(2);
+  }
+  return value;
+}
+
+function setOutput(key, value) {
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+  }
+}
+
+async function fetchAccountUsage({ token, accountId, startISO, endISO }) {
+  const res = await fetch(GRAPHQL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'slicc-cloudflare-spend-monitor',
+    },
+    body: JSON.stringify({
+      query: QUERY,
+      variables: { account: accountId, start: startISO, end: endISO },
+    }),
+  });
+
+  const text = await res.text();
+  if (!res.ok) {
+    const hint =
+      res.status === 403 || res.status === 401
+        ? ' (the token likely needs the "Account Analytics: Read" permission)'
+        : '';
+    throw new Error(
+      `Cloudflare GraphQL → ${res.status} ${res.statusText}${hint}: ${text.slice(0, 300)}`
+    );
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(`Cloudflare GraphQL returned non-JSON: ${text.slice(0, 300)}`);
+  }
+  if (payload.errors?.length) {
+    throw new Error(`Cloudflare GraphQL errors: ${JSON.stringify(payload.errors).slice(0, 300)}`);
+  }
+  const account = payload.data?.viewer?.accounts?.[0];
+  if (!account) {
+    throw new Error(
+      'Cloudflare GraphQL returned no account data (check the account id and token).'
+    );
+  }
+  return account;
+}
+
+async function main() {
+  const token = requireEnv('CLOUDFLARE_API_TOKEN');
+  const accountId = requireEnv('CLOUDFLARE_ACCOUNT_ID');
+  const thresholdUsd = Number(process.env.SPEND_THRESHOLD_USD) || DEFAULT_THRESHOLD_USD;
+  const reportFile = (process.env.REPORT_FILE ?? '').trim() || 'cloudflare-spend-report.md';
+
+  const { startISO, endISO, day } = previousUtcDay();
+  const account = await fetchAccountUsage({ token, accountId, startISO, endISO });
+
+  const durationGbSeconds = activeTimeMicrosToGbSeconds(
+    sumForDay(account.durableObjectsDuration, day, 'activeTime')
+  );
+  const doRequests = sumForDay(account.durableObjectsRequests, day, 'requests');
+  const workersRequests = sumForDay(account.workersRequests, day, 'requests');
+
+  const estimate = estimateDailySpend(
+    { durationGbSeconds, doRequests, workersRequests },
+    { daysInMonth: daysInUtcMonth(day) }
+  );
+  const over = isOverThreshold(estimate.totalUsd, thresholdUsd);
+
+  const report = buildReport({ day, thresholdUsd, estimate, accountId });
+  writeFileSync(reportFile, `${report}\n`);
+
+  setOutput('day', day);
+  setOutput('estimated_usd', estimate.totalUsd.toFixed(2));
+  setOutput('threshold_usd', thresholdUsd.toFixed(2));
+  setOutput('over_threshold', over ? 'true' : 'false');
+  setOutput('report_file', reportFile);
+
+  console.log(
+    `Cloudflare estimated spend for ${day} (UTC): $${estimate.totalUsd.toFixed(2)} (threshold $${thresholdUsd.toFixed(2)})`
+  );
+  for (const meter of estimate.breakdown) {
+    console.log(
+      `  - ${meter.label}: $${meter.usd.toFixed(2)} (${Math.round(meter.units).toLocaleString('en-US')} ${meter.unit})`
+    );
+  }
+  console.log(over ? '⚠️  Over threshold — issue will be raised.' : '✅ Under threshold.');
+}
+
+main().catch((err) => {
+  console.error(`❌ Cloudflare spend monitor failed: ${err.message?.split('\n')[0] ?? err}`);
+  process.exit(1);
+});

--- a/packages/dev-tools/cloudflare-spend-monitor/lib.mjs
+++ b/packages/dev-tools/cloudflare-spend-monitor/lib.mjs
@@ -1,0 +1,197 @@
+/*
+ * Cloudflare spend monitor — pure logic.
+ *
+ * Estimates one UTC day of usage-based Cloudflare Workers Platform spend from
+ * the GraphQL Analytics API and decides whether it crosses an alert threshold.
+ * Cloudflare has no per-day billing API, so this is a deliberate *estimate*
+ * across the meters that actually drive cost on this account — the same
+ * Durable Objects duration meter behind the $12.50/day incident this monitor
+ * was created to catch (see packages/cloudflare-worker/src/session-tray.ts).
+ *
+ * This module is intentionally free of I/O so it can be unit-tested in
+ * isolation; the GraphQL/GitHub calls live in `check-spend.mjs`.
+ */
+
+const MICROS_PER_SECOND = 1_000_000;
+// Each Durable Object instance is billed at 128 MB of memory for the wall-clock
+// time it is active; duration is metered in GB-seconds.
+const DO_MEMORY_GB = 128 / 1024;
+
+/**
+ * Billable meters with public Workers Paid unit prices and the monthly free
+ * allocations included with the plan. Prices in USD. Keep this table in sync
+ * with https://developers.cloudflare.com/workers/platform/pricing/ and
+ * https://developers.cloudflare.com/durable-objects/platform/pricing/.
+ * @type {Record<string, {label: string, unit: string, usdPerMillion: number, freeUnitsPerMonth: number}>}
+ */
+export const METERS = {
+  durableObjectsDuration: {
+    label: 'Durable Objects duration',
+    unit: 'GB-s',
+    usdPerMillion: 12.5,
+    freeUnitsPerMonth: 400_000,
+  },
+  durableObjectsRequests: {
+    label: 'Durable Objects requests',
+    unit: 'requests',
+    usdPerMillion: 0.15,
+    freeUnitsPerMonth: 1_000_000,
+  },
+  workersRequests: {
+    label: 'Workers requests',
+    unit: 'requests',
+    usdPerMillion: 0.3,
+    freeUnitsPerMonth: 10_000_000,
+  },
+};
+
+export const DEFAULT_THRESHOLD_USD = 3;
+
+/**
+ * Convert the `activeTime` sum from `durableObjectsPeriodicGroups`
+ * (microseconds of wall-clock active time) into billable GB-seconds.
+ * @param {number} activeTimeMicros
+ * @returns {number}
+ */
+export function activeTimeMicrosToGbSeconds(activeTimeMicros) {
+  const micros = Number(activeTimeMicros) || 0;
+  return (micros / MICROS_PER_SECOND) * DO_MEMORY_GB;
+}
+
+/**
+ * Number of days in the UTC month of an ISO `YYYY-MM-DD` day. Used to prorate
+ * the monthly free allocations onto a single day.
+ * @param {string} day
+ * @returns {number}
+ */
+export function daysInUtcMonth(day) {
+  const [year, month] = String(day)
+    .split('-')
+    .map((part) => Number(part));
+  if (!Number.isInteger(year) || !Number.isInteger(month)) {
+    return 30;
+  }
+  // Date.UTC months are 0-based, so `month` (1-based) is next month; day 0 backs
+  // up to the last day of the intended month.
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+/**
+ * The previous complete UTC day relative to `now`. A complete day avoids the
+ * partial-day undercount you would get from a trailing-24h window mid-day.
+ * @param {Date} [now]
+ * @returns {{startISO: string, endISO: string, day: string}}
+ */
+export function previousUtcDay(now = new Date()) {
+  const end = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0, 0)
+  );
+  const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
+  return {
+    startISO: start.toISOString(),
+    endISO: end.toISOString(),
+    day: start.toISOString().slice(0, 10),
+  };
+}
+
+/**
+ * Sum a numeric `sum.<field>` across the rows of a GraphQL `*Groups` series
+ * that match `day`. Tolerant of null/missing shapes.
+ * @param {Array<{dimensions?: {date?: string}, sum?: Record<string, unknown>}>|null|undefined} groups
+ * @param {string} day
+ * @param {string} field
+ * @returns {number}
+ */
+export function sumForDay(groups, day, field) {
+  if (!Array.isArray(groups)) {
+    return 0;
+  }
+  return groups
+    .filter((group) => group?.dimensions?.date === day)
+    .reduce((total, group) => total + (Number(group?.sum?.[field]) || 0), 0);
+}
+
+/**
+ * Estimate the billable cost of a single meter for one day, prorating the
+ * monthly free allocation across the month.
+ * @param {number} units
+ * @param {{label: string, unit: string, usdPerMillion: number, freeUnitsPerMonth: number}} meter
+ * @param {number} daysInMonth
+ * @returns {{label: string, unit: string, units: number, freeUnitsPerDay: number, billableUnits: number, usd: number}}
+ */
+export function estimateMeterCost(units, meter, daysInMonth) {
+  const used = Math.max(0, Number(units) || 0);
+  const safeDays = Number(daysInMonth) > 0 ? Number(daysInMonth) : 30;
+  const freeUnitsPerDay = meter.freeUnitsPerMonth / safeDays;
+  const billableUnits = Math.max(0, used - freeUnitsPerDay);
+  const usd = (billableUnits / 1_000_000) * meter.usdPerMillion;
+  return {
+    label: meter.label,
+    unit: meter.unit,
+    units: used,
+    freeUnitsPerDay,
+    billableUnits,
+    usd,
+  };
+}
+
+/**
+ * Estimate total usage-based spend for one day across all tracked meters.
+ * @param {{durationGbSeconds?: number, doRequests?: number, workersRequests?: number}} usage
+ * @param {{daysInMonth?: number}} [options]
+ * @returns {{totalUsd: number, breakdown: ReturnType<typeof estimateMeterCost>[]}}
+ */
+export function estimateDailySpend(usage = {}, options = {}) {
+  const daysInMonth = options.daysInMonth ?? 30;
+  const breakdown = [
+    estimateMeterCost(usage.durationGbSeconds, METERS.durableObjectsDuration, daysInMonth),
+    estimateMeterCost(usage.doRequests, METERS.durableObjectsRequests, daysInMonth),
+    estimateMeterCost(usage.workersRequests, METERS.workersRequests, daysInMonth),
+  ];
+  const totalUsd = breakdown.reduce((total, meter) => total + meter.usd, 0);
+  return { totalUsd, breakdown };
+}
+
+/**
+ * Decide whether estimated spend crosses the threshold.
+ * @param {number} totalUsd
+ * @param {number} thresholdUsd
+ * @returns {boolean}
+ */
+export function isOverThreshold(totalUsd, thresholdUsd) {
+  return (Number(totalUsd) || 0) > (Number(thresholdUsd) || 0);
+}
+
+const USD = (value) => `$${(Number(value) || 0).toFixed(2)}`;
+const NUM = (value) => Math.round(Number(value) || 0).toLocaleString('en-US');
+
+/** Marker used to find this monitor's existing issue for deduplication. */
+export const ISSUE_MARKER = '<!-- cloudflare-spend-monitor -->';
+
+/**
+ * Render a Markdown report body for the alert issue / comment.
+ * @param {{day: string, thresholdUsd: number, estimate: ReturnType<typeof estimateDailySpend>, accountId?: string}} input
+ * @returns {string}
+ */
+export function buildReport({ day, thresholdUsd, estimate, accountId }) {
+  const rows = estimate.breakdown
+    .map(
+      (meter) =>
+        `| ${meter.label} | ${NUM(meter.units)} ${meter.unit} | ${NUM(meter.billableUnits)} ${meter.unit} | ${USD(meter.usd)} |`
+    )
+    .join('\n');
+  const account = accountId ? `\n- **Account:** \`${accountId}\`` : '';
+  return [
+    ISSUE_MARKER,
+    `## Cloudflare daily spend over ${USD(thresholdUsd)}`,
+    '',
+    `Estimated usage-based spend for **${day} (UTC)** was **${USD(estimate.totalUsd)}**, above the ${USD(thresholdUsd)}/day alert threshold.${account}`,
+    '',
+    '| Meter | Used | Billable (after prorated free tier) | Est. cost |',
+    '| ----- | ---- | ----------------------------------- | --------- |',
+    rows,
+    `| **Total** | | | **${USD(estimate.totalUsd)}** |`,
+    '',
+    '<sub>Estimated from the Cloudflare GraphQL Analytics API across the usage meters that drive cost on this account (Durable Objects duration & requests, Workers requests); monthly free allocations are prorated per day. This is an estimate, not the billed amount. Durable Objects duration is the meter behind past overspend — check for non-hibernating WebSockets or alarm loops first.</sub>',
+  ].join('\n');
+}

--- a/packages/dev-tools/cloudflare-spend-monitor/lib.test.mjs
+++ b/packages/dev-tools/cloudflare-spend-monitor/lib.test.mjs
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  activeTimeMicrosToGbSeconds,
+  buildReport,
+  daysInUtcMonth,
+  estimateDailySpend,
+  estimateMeterCost,
+  ISSUE_MARKER,
+  isOverThreshold,
+  METERS,
+  previousUtcDay,
+  sumForDay,
+} from './lib.mjs';
+
+describe('activeTimeMicrosToGbSeconds', () => {
+  it('converts microseconds of active time into 128 MB GB-seconds', () => {
+    // 1s of active time = 1_000_000 micros = 0.125 GB-s (128 MB).
+    expect(activeTimeMicrosToGbSeconds(1_000_000)).toBeCloseTo(0.125, 6);
+  });
+
+  it('treats missing/invalid input as zero', () => {
+    expect(activeTimeMicrosToGbSeconds(undefined)).toBe(0);
+    expect(activeTimeMicrosToGbSeconds('nope')).toBe(0);
+  });
+});
+
+describe('daysInUtcMonth', () => {
+  it('returns the correct day count per month', () => {
+    expect(daysInUtcMonth('2026-06-04')).toBe(30);
+    expect(daysInUtcMonth('2026-01-15')).toBe(31);
+    expect(daysInUtcMonth('2024-02-10')).toBe(29); // leap year
+    expect(daysInUtcMonth('2026-02-10')).toBe(28);
+  });
+
+  it('falls back to 30 for malformed input', () => {
+    expect(daysInUtcMonth('garbage')).toBe(30);
+  });
+});
+
+describe('previousUtcDay', () => {
+  it('returns the prior complete UTC day window', () => {
+    const range = previousUtcDay(new Date('2026-06-05T09:30:00Z'));
+    expect(range).toEqual({
+      startISO: '2026-06-04T00:00:00.000Z',
+      endISO: '2026-06-05T00:00:00.000Z',
+      day: '2026-06-04',
+    });
+  });
+});
+
+describe('sumForDay', () => {
+  const groups = [
+    { dimensions: { date: '2026-06-03' }, sum: { activeTime: 10 } },
+    { dimensions: { date: '2026-06-04' }, sum: { activeTime: 20 } },
+    { dimensions: { date: '2026-06-04' }, sum: { activeTime: 5 } },
+  ];
+
+  it('sums only the rows matching the requested day', () => {
+    expect(sumForDay(groups, '2026-06-04', 'activeTime')).toBe(25);
+  });
+
+  it('returns 0 for no match or non-array input', () => {
+    expect(sumForDay(groups, '2026-01-01', 'activeTime')).toBe(0);
+    expect(sumForDay(null, '2026-06-04', 'activeTime')).toBe(0);
+  });
+});
+
+describe('estimateMeterCost', () => {
+  it('prices billable units after subtracting the prorated daily free tier', () => {
+    // duration: free 400_000/month; in a 30-day month that is ~13_333/day.
+    const result = estimateMeterCost(913_333, METERS.durableObjectsDuration, 30);
+    expect(result.billableUnits).toBeCloseTo(900_000, 0);
+    expect(result.usd).toBeCloseTo(11.25, 2); // 900_000 / 1e6 * 12.5
+  });
+
+  it('never goes negative below the free allocation', () => {
+    const result = estimateMeterCost(1000, METERS.workersRequests, 30);
+    expect(result.billableUnits).toBe(0);
+    expect(result.usd).toBe(0);
+  });
+});
+
+describe('estimateDailySpend', () => {
+  it('reproduces the duration incident (~$11/day) and stays additive', () => {
+    const { totalUsd, breakdown } = estimateDailySpend(
+      { durationGbSeconds: 914_638, doRequests: 66_335, workersRequests: 80_373 },
+      { daysInMonth: 30 }
+    );
+    expect(totalUsd).toBeGreaterThan(11);
+    expect(totalUsd).toBeLessThan(12);
+    expect(breakdown).toHaveLength(3);
+    // Workers requests are well within the prorated free tier here.
+    expect(breakdown[2].usd).toBe(0);
+  });
+
+  it('returns ~$0 for a healthy (post-hibernation) day', () => {
+    const { totalUsd } = estimateDailySpend(
+      { durationGbSeconds: 9_000, doRequests: 60_000, workersRequests: 90_000 },
+      { daysInMonth: 30 }
+    );
+    expect(totalUsd).toBeLessThan(0.5);
+  });
+});
+
+describe('isOverThreshold', () => {
+  it('compares strictly greater than the threshold', () => {
+    expect(isOverThreshold(11.27, 3)).toBe(true);
+    expect(isOverThreshold(3, 3)).toBe(false);
+    expect(isOverThreshold(0.1, 3)).toBe(false);
+  });
+});
+
+describe('buildReport', () => {
+  it('includes the dedup marker, day, total and a meter table', () => {
+    const estimate = estimateDailySpend(
+      { durationGbSeconds: 914_638, doRequests: 66_335, workersRequests: 80_373 },
+      { daysInMonth: 30 }
+    );
+    const body = buildReport({
+      day: '2026-06-04',
+      thresholdUsd: 3,
+      estimate,
+      accountId: 'acct-123',
+    });
+    expect(body).toContain(ISSUE_MARKER);
+    expect(body).toContain('2026-06-04 (UTC)');
+    expect(body).toContain('Durable Objects duration');
+    expect(body).toContain('acct-123');
+    expect(body).toMatch(/\*\*Total\*\*/);
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to the Durable Objects hibernation fix (#880). That incident — `SessionTrayDurableObject` billing ~$12.50/day of DO **Duration** — went unnoticed for weeks because nothing watched Cloudflare spend. This adds a daily tripwire that files a GitHub issue when estimated spend exceeds **$3/day**.

## What

- **`packages/dev-tools/cloudflare-spend-monitor/`** — a small tool following the existing `pr-review-gate` pattern:
  - `lib.mjs` — pure, unit-tested cost math (GB-s conversion, per-meter pricing with prorated monthly free tiers, report rendering).
  - `check-spend.mjs` — I/O: one GraphQL query for the previous full UTC day, writes `over_threshold` / `estimated_usd` / `day` to `$GITHUB_OUTPUT` and a Markdown report.
  - `lib.test.mjs` — 13 tests (run via the existing `dev-tools` vitest project).
  - `README.md`.
- **`.github/workflows/cloudflare-spend-monitor.yml`** — runs daily at 06:30 UTC (+ manual dispatch). Over threshold → opens a single rolling issue (deduped by the `cloudflare-spend` label) or comments on the open one; back under → comments and auto-closes it.

## What "spend" means

Cloudflare has **no per-day billing API**, so this is a deliberate estimate from the GraphQL Analytics API across the meters that drive cost on this account, with monthly free allocations prorated per day:

| Meter | Rate | Free/month |
|---|---|---|
| Durable Objects duration | $12.50 / M GB-s | 400,000 GB-s |
| Durable Objects requests | $0.15 / M | 1,000,000 |
| Workers requests | $0.30 / M | 10,000,000 |

## Secrets

Reuses the existing `CLOUDFLARE_API_TOKEN` secret + `CLOUDFLARE_ACCOUNT_ID` var (already used by the worker deploy workflows). **The token must include `Account Analytics: Read`** — if it doesn't, the run fails fast with a clear message to add the permission. Optional `CLOUDFLARE_SPEND_THRESHOLD_USD` repo variable overrides the $3 default.

## Verification

Ran the script against the live account for 2026-06-04 (a pre-fix day):

```
Cloudflare estimated spend for 2026-06-04 (UTC): $11.27 (threshold $3.00)
  - Durable Objects duration: $11.27 (914,638 GB-s)
  - Durable Objects requests: $0.00 (66,335 requests)
  - Workers requests: $0.00 (80,373 requests)
⚠️  Over threshold — issue will be raised.
```

Correctly trips on the incident and reads ~$0 on healthy (post-hibernation) days. Tests + biome + prettier + doc-size lint all clean.
