### PR TITLE
fix(webapp): wipe OPFS on nuke to clear post-ZenFS-migration state

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/nuke-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/nuke-command.ts
@@ -115,6 +115,30 @@ export function createNukeCommand(): Command {
           /* indexedDB.databases unsupported on some browsers — fall through */
         }
 
+        // Wipe the OPFS-backed VFS tree. Since the ZenFS/OPFS migration
+        // the bulk of local state (workspace files, scoops, mounts) lives
+        // in OPFS, not IndexedDB, so a nuke that only wipes IDB would
+        // leave the user's prior workspace on disk. Guard on
+        // `navigator.storage.getDirectory` (mirrors
+        // `resolveVfsBackendFromEnv`) so contexts without OPFS — older
+        // browsers, some test envs — fall through cleanly.
+        try {
+          const storage = (navigator as unknown as { storage?: StorageManager }).storage;
+          if (typeof storage?.getDirectory === 'function') {
+            const root = (await storage.getDirectory()) as unknown as {
+              keys: () => AsyncIterableIterator<string>;
+              removeEntry: (name: string, options?: { recursive: boolean }) => Promise<void>;
+            };
+            const names: string[] = [];
+            for await (const name of root.keys()) names.push(name);
+            await Promise.all(
+              names.map((name) => root.removeEntry(name, { recursive: true }).catch(() => {}))
+            );
+          }
+        } catch {
+          /* OPFS unavailable / blocked — best effort, never block reload */
+        }
+
         triggerReload(NUKE_LOCAL_STORAGE_KEYS);
       })();
       return { stdout: 'Nuking everything…\n', stderr: '', exitCode: 0 };

--- a/packages/webapp/tests/shell/supplemental-commands/nuke-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/nuke-command.test.ts
@@ -85,7 +85,14 @@ describe('nuke command', () => {
         onblocked: null,
       }),
     });
-    vi.stubGlobal('navigator', { serviceWorker: { getRegistrations: async () => [] } });
+    vi.stubGlobal('navigator', {
+      serviceWorker: { getRegistrations: async () => [] },
+      storage: {
+        // Default to "no OPFS in this env": tests that exercise the
+        // OPFS-wipe path install their own stub via vi.stubGlobal.
+        getDirectory: undefined,
+      },
+    });
     vi.stubGlobal('localStorage', {
       removeItem: vi.fn(),
       getItem: () => null,
@@ -170,6 +177,56 @@ describe('nuke command', () => {
     expect(NUKE_LOCAL_STORAGE_KEYS).toContain('slicc:welcome-flow-fired');
     expect(NUKE_LOCAL_STORAGE_KEYS).toContain('slicc.trayJoinUrl');
     expect(NUKE_LOCAL_STORAGE_KEYS).toContain('slicc.trayWorkerBaseUrl');
+  });
+
+  it('recursively removes every OPFS root entry on the launch-code path', async () => {
+    // Post-ZenFS/OPFS migration the bulk of local state lives in OPFS
+    // (workspace files, scoops, mounts). Without this wipe a nuke
+    // would leave the prior workspace on disk and the user would
+    // boot back into stale state.
+    const removeEntry = vi.fn(async (_name: string, _opts?: { recursive: boolean }) => undefined);
+    const entries = ['slicc-fs', 'slicc-fs-global', 'leftover-mount'];
+    async function* keys(): AsyncIterableIterator<string> {
+      for (const name of entries) yield name;
+    }
+    vi.stubGlobal('navigator', {
+      serviceWorker: { getRegistrations: async () => [] },
+      storage: {
+        getDirectory: async () => ({ keys, removeEntry }),
+      },
+    });
+
+    const dispose = installNukeReloadListener(() => {});
+    const cmd = createNukeCommand();
+    await cmd.execute(['1234'], createMockCtx());
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(removeEntry).toHaveBeenCalledTimes(entries.length);
+    for (const name of entries) {
+      expect(removeEntry).toHaveBeenCalledWith(name, { recursive: true });
+    }
+    dispose();
+  });
+
+  it('still reloads cleanly when OPFS is unavailable', async () => {
+    // No `navigator.storage.getDirectory` (older browsers / some test
+    // envs). The wipe block must be best-effort and never block the
+    // reload broadcast — otherwise the user is stranded on a half-
+    // nuked instance.
+    vi.stubGlobal('navigator', {
+      serviceWorker: { getRegistrations: async () => [] },
+      storage: {},
+    });
+
+    const onReload = vi.fn();
+    const dispose = installNukeReloadListener(onReload);
+    const cmd = createNukeCommand();
+    const result = await cmd.execute(['1234'], createMockCtx());
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(result.exitCode).toBe(0);
+    expect(onReload).toHaveBeenCalledTimes(1);
+    dispose();
   });
 });
 


### PR DESCRIPTION
## Problem

The recent VFS refactor migrated the filesystem off IndexedDB-backed LightningFS onto **ZenFS over OPFS** (`13dd7d78`, `0df56c98 — always default to OPFS backend`). The filesystem now lives in OPFS subdirectories (`slicc-fs`, `slicc-fs-global`, `browser-fs`, mounts), no longer in IndexedDB.

The `nuke` command was never updated. It only unregistered service workers, deleted all IndexedDB databases, and cleared a few `localStorage` keys before reloading. Because it never touched OPFS, the **entire filesystem survived the reload** — `/workspace`, mounts, and global git/MCP/OAuth state all came back. Chat/scoops (still IDB) were wiped, but the file system was not, so `nuke` appeared broken.

## Fix

In `packages/webapp/src/shell/supplemental-commands/nuke-command.ts`, on the valid launch-code path — after the IDB deletes and before `triggerReload(...)` — enumerate `navigator.storage.getDirectory()` and recursively `removeEntry(name, { recursive: true })` every root entry. The wipe is:

- **Awaited** before reload (same "finish before reload" rationale as the existing IDB deletes),
- **Best-effort**: an unsupported `navigator.storage.getDirectory`, or a rejected `removeEntry`, is swallowed and never blocks the reload (guarded like `resolveVfsBackendFromEnv()`),
- Works in both standalone (kernel worker) and extension (offscreen) contexts where nuke runs.

No change to the launch-code gate, SW-unregister, IDB deletes, `localStorage` clears, or the BroadcastChannel reload listener.

## Tests

Extended `packages/webapp/tests/shell/supplemental-commands/nuke-command.test.ts`:
- recursively removes every OPFS root entry on the `nuke 1234` path (asserts `removeEntry` with `{ recursive: true }`),
- still reloads cleanly when OPFS is unavailable.

Existing nuke tests untouched.

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅ (all 6 tsc projects)
- `npm run test -- nuke-command` ✅ (11/11)

Independently reviewed and approved.

## Out of scope

Cache Storage (cached esbuild/biome/ffmpeg wasm binaries) is intentionally **not** cleared — those are harmless, re-fetchable caches, consistent with nuke being "wipe local state," not a binary-cache purge.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author