### PR TITLE
ci: allow bot actor so nightly claude triage cron can run

### DIFF
--- a/.github/workflows/agentic-debt-triage.yml
+++ b/.github/workflows/agentic-debt-triage.yml
@@ -106,6 +106,12 @@ jobs:
           # GitHub App is not installed on this repo). Job permissions above
           # (issues: write) scope this token appropriately.
           github_token: ${{ github.token }}
+          # On `schedule` events GitHub sets the actor to the last actor on the
+          # default branch, which in this merge-queue repo is `github-merge-queue`
+          # (a bot). claude-code-action's human-actor gate otherwise rejects the
+          # nightly run with "Workflow initiated by non-human actor". Allow all
+          # bots so the cron can run unattended.
+          allowed_bots: '*'
           # Print Claude's full turn-by-turn output to the Actions log on manual
           # dispatch (to inspect its reasoning); kept off for the nightly cron so
           # routine runs don't log tool output that may contain sensitive data.

--- a/.github/workflows/rum-error-triage.yml
+++ b/.github/workflows/rum-error-triage.yml
@@ -103,6 +103,12 @@ jobs:
           # GitHub App is not installed on this repo). Job permissions above
           # (contents/issues/pull-requests: write) scope this token appropriately.
           github_token: ${{ github.token }}
+          # On `schedule` events GitHub sets the actor to the last actor on the
+          # default branch, which in this merge-queue repo is `github-merge-queue`
+          # (a bot). claude-code-action's human-actor gate otherwise rejects the
+          # nightly run with "Workflow initiated by non-human actor". Allow all
+          # bots so the cron can run unattended.
+          allowed_bots: '*'
           # Print Claude's full turn-by-turn output to the Actions log on manual
           # dispatch (to inspect its reasoning); kept off for the nightly cron so
           # routine runs don't log tool output that may contain sensitive data.


### PR DESCRIPTION
## Problem

`agentic-debt-triage` and `rum-error-triage` are nightly cron workflows that hand work to `claude-code-action`. Their **scheduled** runs have been failing within ~30s, so they never file issues. Manual `workflow_dispatch` runs succeed, which masked the issue.

Root cause: on `schedule` events GitHub sets the actor to the last actor on the default branch — in this **merge-queue** repo that is `github-merge-queue[bot]`. `claude-code-action@v1` has a human-actor gate that rejects bot actors unless they're listed in `allowed_bots`:

```
##[error]Action failed with error: Workflow initiated by non-human actor:
github-merge-queue (actor not found on GitHub).
Add bot to allowed_bots list or use '*' to allow all bots.
```

Confirmed via the API on the 06-05 scheduled run `#27005577130`: `actor=github-merge-queue[bot]  triggering=github-merge-queue[bot]  event=schedule`. A human `workflow_dispatch` passes the gate, which is why manual runs work.

(An earlier scheduled failure — "User does not have write access" — was a separate OIDC->GitHub-App auth issue already fixed in `08a1cf58`.)

## Fix

Set `allowed_bots: '*'` on the `claude-code-action` step in both nightly workflows so the cron can run unattended — exactly what the action's error message recommends.

## Notes
- Only affects unattended cron behavior; manual dispatch already worked.
- GitHub's scheduled triggers remain best-effort (these runs landed ~3h after the 05:33/03:00 cron times and occasional nights are dropped) — that's independent of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)