### PR TITLE
fix(oauth-token): read --from-file through the shell's primary VFS

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/oauth-token-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/oauth-token-command.ts
@@ -1,4 +1,4 @@
-import type { Command } from 'just-bash';
+import type { Command, CommandContext } from 'just-bash';
 import { defineCommand } from 'just-bash';
 
 function helpText(): string {
@@ -56,7 +56,7 @@ Examples:
 }
 
 export function createOAuthTokenCommand(): Command {
-  return defineCommand('oauth-token', async (args) => {
+  return defineCommand('oauth-token', async (args, ctx) => {
     // Lazy imports — same pattern as other supplemental commands that
     // import from browser modules.
     const { getOAuthAccountInfo, getSelectedProvider, getAccounts } = await import(
@@ -90,7 +90,7 @@ export function createOAuthTokenCommand(): Command {
     // print the captured redirect URL to stdout, and exit. No tokens are
     // persisted to the slicc account store — that's the provider's job.
     if (args.includes('--from-file') || args.includes('--intercept')) {
-      return runDeclarativeIntercept(args);
+      return runDeclarativeIntercept(args, ctx);
     }
 
     // Parse --scope flag
@@ -339,7 +339,8 @@ function describeAccount(
  * inspecting / testing OAuth flows without writing a provider module.
  */
 async function runDeclarativeIntercept(
-  args: string[]
+  args: string[],
+  ctx: CommandContext
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const { parseInterceptOAuthConfig } = await import('../../providers/intercepted-oauth.js');
   const { createInterceptingOAuthLauncherForCurrentRuntime } = await import(
@@ -352,13 +353,11 @@ async function runDeclarativeIntercept(
     const path = args[fromFileIdx + 1];
     if (!path) return errResult('oauth-token: --from-file requires a path');
     try {
-      // Slicc's VFS exposes file reads via the global filesystem proxy used
-      // by the rest of the shell. Lazy-import to avoid a hard dependency
-      // when this branch is unused.
-      const { VirtualFS } = await import('../../fs/index.js');
-      const { GLOBAL_FS_DB_NAME } = await import('../../fs/global-db.js');
-      const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
-      const raw = await fs.readFile(path);
+      // Read the intercept config from the shell's primary VFS (the same
+      // filesystem every other shell command sees via `ctx.fs`). Absolute
+      // paths pass through; relative paths resolve against `ctx.cwd`.
+      const resolved = ctx.fs.resolvePath(ctx.cwd, path);
+      const raw = await ctx.fs.readFile(resolved);
       rawConfig = JSON.parse(typeof raw === 'string' ? raw : new TextDecoder().decode(raw));
     } catch (err) {
       return errResult(

--- a/packages/webapp/tests/shell/supplemental-commands/oauth-token-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/oauth-token-command.test.ts
@@ -15,13 +15,17 @@ vi.mock('../../../src/providers/index.js', () => ({
 
 vi.mock('../../../src/providers/oauth-service.js', () => ({
   createOAuthLauncher: vi.fn(() => vi.fn()),
+  createInterceptingOAuthLauncherForCurrentRuntime: vi.fn(),
 }));
 
 import {
   getRegisteredProviderConfig,
   getRegisteredProviderIds,
 } from '../../../src/providers/index.js';
-import { createOAuthLauncher } from '../../../src/providers/oauth-service.js';
+import {
+  createInterceptingOAuthLauncherForCurrentRuntime,
+  createOAuthLauncher,
+} from '../../../src/providers/oauth-service.js';
 import { createOAuthTokenCommand } from '../../../src/shell/supplemental-commands/oauth-token-command.js';
 import {
   getAccounts,
@@ -35,6 +39,9 @@ const mockGetRegisteredProviderConfig = vi.mocked(getRegisteredProviderConfig);
 const mockGetRegisteredProviderIds = vi.mocked(getRegisteredProviderIds);
 const mockGetAccounts = vi.mocked(getAccounts);
 const mockCreateOAuthLauncher = vi.mocked(createOAuthLauncher);
+const mockCreateInterceptingOAuthLauncherForCurrentRuntime = vi.mocked(
+  createInterceptingOAuthLauncherForCurrentRuntime
+);
 
 function createMockCtx() {
   const fs: Partial<IFileSystem> = {
@@ -574,5 +581,78 @@ describe('oauth-token command', () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('no onSilentRenew hook');
+  });
+
+  it('--from-file reads JSON via ctx.fs and runs the intercept launcher', async () => {
+    const config = {
+      authorizeUrl: 'https://auth.example.com/authorize?client_id=abc',
+      redirectUriPattern: 'http://127.0.0.1:56121/*',
+    };
+    const launcher = vi.fn(async () => 'http://127.0.0.1:56121/?code=captured-code');
+    mockCreateInterceptingOAuthLauncherForCurrentRuntime.mockResolvedValue(launcher);
+
+    const ctx = createMockCtx();
+    const readFile = vi.fn(async () => JSON.stringify(config));
+    (ctx.fs as unknown as { readFile: typeof readFile }).readFile = readFile;
+
+    const cmd = createOAuthTokenCommand();
+    const result = await cmd.execute(
+      ['--from-file', 'oauth/xai.json'],
+      ctx as unknown as Parameters<typeof cmd.execute>[1]
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('http://127.0.0.1:56121/?code=captured-code\n');
+    // Relative path was resolved against cwd before reading.
+    expect(readFile).toHaveBeenCalledWith('/home/oauth/xai.json');
+    expect(launcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('--from-file passes absolute paths through unchanged', async () => {
+    const config = {
+      authorizeUrl: 'https://auth.example.com/authorize',
+      redirectUriPattern: 'http://127.0.0.1:56121/*',
+    };
+    const launcher = vi.fn(async () => 'http://127.0.0.1:56121/?code=abs');
+    mockCreateInterceptingOAuthLauncherForCurrentRuntime.mockResolvedValue(launcher);
+
+    const ctx = createMockCtx();
+    const readFile = vi.fn(async () => JSON.stringify(config));
+    (ctx.fs as unknown as { readFile: typeof readFile }).readFile = readFile;
+
+    const cmd = createOAuthTokenCommand();
+    const result = await cmd.execute(
+      ['--from-file', '/workspace/.slicc/oauth/xai.json'],
+      ctx as unknown as Parameters<typeof cmd.execute>[1]
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(readFile).toHaveBeenCalledWith('/workspace/.slicc/oauth/xai.json');
+  });
+
+  it('--from-file surfaces a read failure as a "failed to read" error', async () => {
+    const ctx = createMockCtx();
+    const readFile = vi.fn(async () => {
+      throw new Error('ENOENT: no such file');
+    });
+    (ctx.fs as unknown as { readFile: typeof readFile }).readFile = readFile;
+
+    const cmd = createOAuthTokenCommand();
+    const result = await cmd.execute(
+      ['--from-file', 'missing.json'],
+      ctx as unknown as Parameters<typeof cmd.execute>[1]
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('failed to read missing.json');
+    expect(result.stderr).toContain('ENOENT');
+    expect(mockCreateInterceptingOAuthLauncherForCurrentRuntime).not.toHaveBeenCalled();
+  });
+
+  it('--from-file requires a path', async () => {
+    const cmd = createOAuthTokenCommand();
+    const result = await cmd.execute(['--from-file'], createMockCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--from-file requires a path');
   });
 });


### PR DESCRIPTION
## Summary

`oauth-token --from-file <path>` read the intercept-config JSON from a fresh `VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME })` (the `slicc-fs-global` subtree) instead of the shell's **primary** VFS that every other command sees via `ctx.fs`. Now that OPFS is the default backend, the global and primary subtrees are fully disjoint, so a user passing the natural location (e.g. `/workspace/.slicc/oauth/xai.json`) read from a subtree where the file does not exist.

This routes the `--from-file` read through `ctx.fs` and removes the obsolete IDB-db-name dependency from the command.

## Changes

- Thread `CommandContext` through `runDeclarativeIntercept(args, ctx)`.
- Read `--from-file` via `ctx.fs.readFile(ctx.fs.resolvePath(ctx.cwd, path))` — absolute paths pass through, relative paths resolve against `ctx.cwd`.
- Remove the `VirtualFS` + `GLOBAL_FS_DB_NAME` lazy imports (no IDB-db-name dependency left in this file).
- Update the stale "global filesystem proxy" comment to reflect reading from the shell's primary VFS.
- Add 4 `--from-file` tests: cwd-resolution, absolute pass-through, read-failure error, missing-path error.

## Scope

Single file + its test only. No change to `--intercept` flag parsing, the OAuth launcher, provider modes, or `GLOBAL_FS_DB_NAME` usages elsewhere (those remain correct for credential/internal storage).

## Verification

- `npm run lint` → exit 0
- `npm run typecheck` → exit 0 (all 6 tsc passes)
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/oauth-token-command.test.ts` → 29/29 pass

Independently verified — APPROVED (high confidence).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author