### PR TITLE
fix(kernel): don't let a slow OPFS migration trip the boot ready timeout

### DIFF
--- a/packages/webapp/src/kernel/spawn.ts
+++ b/packages/webapp/src/kernel/spawn.ts
@@ -66,14 +66,16 @@ export interface KernelWorkerSpawnOptions {
   readyTimeoutMs?: number;
   /**
    * Stall watchdog for an in-progress legacy→OPFS migration, in ms.
-   * Default 60s. While the worker is migrating, the {@link readyTimeoutMs}
-   * boot clock is SUSPENDED — a one-time data migration can legitimately
-   * run far longer than the boot timeout, so it must never trip it.
-   * This watchdog replaces the boot clock for the duration of the
-   * migration and is re-armed on every `kernel-migration-progress`
-   * heartbeat, so a steadily-advancing (legitimately slow) migration is
-   * never stopped. It only rejects if the migration makes NO progress
-   * for this long, which indicates a genuinely hung worker.
+   * Default 60s. On `kernel-migration-started` the {@link readyTimeoutMs}
+   * boot clock is SUSPENDED with no replacement timer — the worker's
+   * unbounded pre-copy work (dynamic import, legacy-IDB manifest walk,
+   * directory creation) emits no progress, so any timeout during that
+   * phase could wrongly reject a legitimate large-workspace migration.
+   * The watchdog is armed on the FIRST `kernel-migration-progress`
+   * heartbeat and re-armed on every subsequent one, so a steadily-
+   * advancing (legitimately slow) copy is never stopped regardless of
+   * total duration. It only rejects if the copy, once started, makes NO
+   * progress for this long — a genuinely hung worker.
    */
   migrationStallTimeoutMs?: number;
   /**
@@ -214,10 +216,16 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
         reject(new Error(`Kernel worker did not signal ready within ${readyTimeoutMs}ms`));
       }, readyTimeoutMs);
     };
-    // Arm the migration stall watchdog. Re-armed on every progress
-    // heartbeat so a legitimately slow but steadily-advancing migration
-    // is NEVER stopped. Only a migration that makes no progress for
-    // `migrationStallTimeoutMs` (a genuinely hung worker) rejects.
+    // Arm the migration stall watchdog. Armed on the FIRST progress
+    // heartbeat and re-armed on every subsequent one, so a legitimately
+    // slow but steadily-advancing copy is NEVER stopped. Only a copy
+    // that makes no progress for `migrationStallTimeoutMs` (a genuinely
+    // hung worker) rejects. It is intentionally NOT armed at
+    // `kernel-migration-started`: the worker does unbounded pre-copy
+    // work (dynamic import, legacy-IDB manifest walk, directory
+    // creation) before the first heartbeat, and that phase emits no
+    // progress — arming here would let the watchdog reject a legitimate
+    // large-workspace migration mid-walk.
     const armMigrationWatchdog = (): void => {
       clearTimer();
       timeoutId = setTimeout(() => {
@@ -251,12 +259,14 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
       // after a migration signal arrives so the worker can still
       // post `kernel-worker-ready` when it eventually finishes.
       if (data?.type === 'kernel-migration-started') {
-        // SUSPEND the boot clock and hand over to the stall watchdog.
-        // A one-time legacy→OPFS data copy can run far longer than
-        // `readyTimeoutMs`; letting the boot timeout fire here was the
-        // bug that stranded the page behind a frozen, input-blocking
-        // migration splash while the worker quietly finished the copy.
-        armMigrationWatchdog();
+        // SUSPEND the boot clock entirely — but do NOT arm the stall
+        // watchdog yet. The worker's pre-copy phase (dynamic import,
+        // legacy-IDB manifest walk, directory creation) emits no
+        // progress and is unbounded for a large workspace; any timeout
+        // armed here could reject a legitimate slow migration mid-walk,
+        // recreating the very fatal boot path this change fixes. The
+        // watchdog starts on the first progress heartbeat below.
+        clearTimer();
         try {
           options.onMigrationStart?.();
         } catch {
@@ -265,8 +275,9 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
         return;
       }
       if (data?.type === 'kernel-migration-progress') {
-        // Heartbeat — reset the stall watchdog so a slow-but-advancing
-        // migration is never aborted, regardless of total duration.
+        // First heartbeat arms the stall watchdog; subsequent ones reset
+        // it, so a slow-but-advancing copy is never aborted regardless
+        // of total duration.
         armMigrationWatchdog();
         try {
           const progress = data as Partial<KernelMigrationProgressMsg>;

--- a/packages/webapp/src/kernel/spawn.ts
+++ b/packages/webapp/src/kernel/spawn.ts
@@ -65,6 +65,18 @@ export interface KernelWorkerSpawnOptions {
   /** Boot timeout in ms. Default 30s. */
   readyTimeoutMs?: number;
   /**
+   * Stall watchdog for an in-progress legacy→OPFS migration, in ms.
+   * Default 60s. While the worker is migrating, the {@link readyTimeoutMs}
+   * boot clock is SUSPENDED — a one-time data migration can legitimately
+   * run far longer than the boot timeout, so it must never trip it.
+   * This watchdog replaces the boot clock for the duration of the
+   * migration and is re-armed on every `kernel-migration-progress`
+   * heartbeat, so a steadily-advancing (legitimately slow) migration is
+   * never stopped. It only rejects if the migration makes NO progress
+   * for this long, which indicates a genuinely hung worker.
+   */
+  migrationStallTimeoutMs?: number;
+  /**
    * Optional snapshot of `window.localStorage` for the worker's shim.
    * Workers don't have a real `localStorage`; we seed a read-only
    * shim from the page's snapshot so `provider-settings.getApiKey()`
@@ -98,6 +110,8 @@ export interface KernelWorkerBootstrapOptions {
   realCdpTransport: CDPTransport;
   callbacks: OffscreenClientCallbacks;
   readyTimeoutMs?: number;
+  /** See `KernelWorkerSpawnOptions.migrationStallTimeoutMs`. */
+  migrationStallTimeoutMs?: number;
   localStorageSeed?: Record<string, string>;
   /**
    * Per-instance discriminator forwarded to the worker so same-origin
@@ -156,6 +170,7 @@ export interface SpawnedKernelHost {
 export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): SpawnedKernelHost {
   const { worker, realCdpTransport, callbacks } = options;
   const readyTimeoutMs = options.readyTimeoutMs ?? 30_000;
+  const migrationStallTimeoutMs = options.migrationStallTimeoutMs ?? 60_000;
   const localStorageSeed = options.localStorageSeed ?? {};
 
   const kernelChannel = new MessageChannel();
@@ -175,22 +190,52 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
   // a second listener that resolves on the boot signal.
   //
   // Single cleanup path: `cleanupReady()` removes the listener AND clears
-  // the timeout. Called from the success branch, the timeout branch, AND
-  // from `dispose()` so a caller that disposes before the worker replies
-  // doesn't leave the listener attached for the worker's lifetime.
+  // whichever timer is armed. Called from the success branch, the timeout
+  // branch, AND from `dispose()` so a caller that disposes before the
+  // worker replies doesn't leave the listener attached for the worker's
+  // lifetime.
   let cleanupReady: (() => void) | null = null;
   const ready = new Promise<void>((resolve, reject) => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     let listener: ((event: MessageEvent) => void) | null = null;
+
+    const clearTimer = (): void => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    };
+    // Arm the boot-ready clock. Used for the initial boot wait and
+    // re-armed once a migration finishes (the rest of boot is quick).
+    const armReadyTimeout = (): void => {
+      clearTimer();
+      timeoutId = setTimeout(() => {
+        cleanupReady?.();
+        reject(new Error(`Kernel worker did not signal ready within ${readyTimeoutMs}ms`));
+      }, readyTimeoutMs);
+    };
+    // Arm the migration stall watchdog. Re-armed on every progress
+    // heartbeat so a legitimately slow but steadily-advancing migration
+    // is NEVER stopped. Only a migration that makes no progress for
+    // `migrationStallTimeoutMs` (a genuinely hung worker) rejects.
+    const armMigrationWatchdog = (): void => {
+      clearTimer();
+      timeoutId = setTimeout(() => {
+        cleanupReady?.();
+        reject(
+          new Error(
+            `Kernel worker migration stalled — no progress within ${migrationStallTimeoutMs}ms`
+          )
+        );
+      }, migrationStallTimeoutMs);
+    };
+
     cleanupReady = (): void => {
       if (listener !== null) {
         kernelChannel.port1.removeEventListener('message', listener as EventListener);
         listener = null;
       }
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
+      clearTimer();
     };
     listener = (event: MessageEvent): void => {
       const data = event.data as
@@ -206,6 +251,12 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
       // after a migration signal arrives so the worker can still
       // post `kernel-worker-ready` when it eventually finishes.
       if (data?.type === 'kernel-migration-started') {
+        // SUSPEND the boot clock and hand over to the stall watchdog.
+        // A one-time legacy→OPFS data copy can run far longer than
+        // `readyTimeoutMs`; letting the boot timeout fire here was the
+        // bug that stranded the page behind a frozen, input-blocking
+        // migration splash while the worker quietly finished the copy.
+        armMigrationWatchdog();
         try {
           options.onMigrationStart?.();
         } catch {
@@ -214,6 +265,9 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
         return;
       }
       if (data?.type === 'kernel-migration-progress') {
+        // Heartbeat — reset the stall watchdog so a slow-but-advancing
+        // migration is never aborted, regardless of total duration.
+        armMigrationWatchdog();
         try {
           const progress = data as Partial<KernelMigrationProgressMsg>;
           options.onMigrationProgress?.({
@@ -226,6 +280,9 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
         return;
       }
       if (data?.type === 'kernel-migration-finished') {
+        // Migration done — restore the normal boot-ready clock for the
+        // remainder of boot (which should complete promptly).
+        armReadyTimeout();
         try {
           options.onMigrationFinish?.();
         } catch {
@@ -238,10 +295,7 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
       resolve();
     };
     kernelChannel.port1.addEventListener('message', listener as EventListener);
-    timeoutId = setTimeout(() => {
-      cleanupReady?.();
-      reject(new Error(`Kernel worker did not signal ready within ${readyTimeoutMs}ms`));
-    }, readyTimeoutMs);
+    armReadyTimeout();
   });
 
   // Hand the worker its ports. After `postMessage` with a transferable
@@ -317,6 +371,7 @@ export function spawnKernelWorker(options: KernelWorkerSpawnOptions): SpawnedKer
     realCdpTransport: options.realCdpTransport,
     callbacks: options.callbacks,
     readyTimeoutMs: options.readyTimeoutMs,
+    migrationStallTimeoutMs: options.migrationStallTimeoutMs,
     localStorageSeed: options.localStorageSeed ?? collectLocalStorageSeed(),
     instanceId: options.instanceId,
     onMigrationStart: options.onMigrationStart,

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -2143,6 +2143,12 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
   // on first `onMigrationStart` so flag-off boots never touch
   // `document.body`.
   let migrationSplash: ReturnType<typeof createMigrationSplash> | null = null;
+  // Tear down the blocking splash. Wrapped so the boot-failure path can
+  // reuse it without tripping control-flow narrowing of the closure-
+  // assigned `migrationSplash` binding.
+  const disarmMigrationSplash = (): void => {
+    migrationSplash?.disarm();
+  };
 
   const host = spawnKernelWorker({
     realCdpTransport,
@@ -2164,7 +2170,7 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
       migrationSplash.updateProgress(progress);
     },
     onMigrationFinish: () => {
-      migrationSplash?.disarm();
+      disarmMigrationSplash();
     },
     callbacks: {
       onStatusChange: (scoopJid, status) => {
@@ -2458,6 +2464,12 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
     log.info('Worker boot handshake complete');
   } catch (err) {
     log.error('Worker failed to signal ready', err);
+    // Tear down the blocking migration splash on any boot failure so a
+    // failed/timed-out boot never strands the user behind a frozen,
+    // input-blocking scrim. With the migration-aware ready timeout a
+    // legitimately slow migration no longer reaches this path, but a
+    // genuine boot failure must still release the modal.
+    disarmMigrationSplash();
     throw err;
   }
   client.requestState();

--- a/packages/webapp/tests/kernel/spawn.test.ts
+++ b/packages/webapp/tests/kernel/spawn.test.ts
@@ -74,6 +74,45 @@ function makeMockWorker(opts?: { autoReady?: boolean; readyDelay?: number }): Mo
   return worker;
 }
 
+/**
+ * Worker mock that stashes the transferred kernel port so a test can
+ * post raw migration / ready signals back to the page-side listener.
+ */
+function makeStashingWorker(): { worker: WorkerLike; getPort: () => MessagePort } {
+  let port: MessagePort | null = null;
+  const worker: WorkerLike = {
+    postMessage: (message: unknown) => {
+      const data = message as { type?: string; kernelPort?: MessagePort };
+      if (data?.type === 'kernel-worker-init' && data.kernelPort) {
+        port = data.kernelPort;
+        port.start();
+      }
+    },
+    terminate: () => undefined,
+  };
+  return {
+    worker,
+    getPort: () => {
+      if (!port) throw new Error('kernel port not yet transferred');
+      return port;
+    },
+  };
+}
+
+/**
+ * Flush enough real macrotasks for a `MessagePort` message posted in a
+ * test to be delivered to the bootstrap listener. The migration-timing
+ * tests fake ONLY `setTimeout`/`clearTimeout`, so `setImmediate` stays
+ * real; a single tick can race the port's native delivery, so we cycle
+ * the event loop a few times to make delivery deterministic before any
+ * faked-timer advance.
+ */
+async function flushPortMessages(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+}
+
 describe('bootstrapKernelWorker', () => {
   it('returns a client immediately and posts kernel-worker-init with transferables', () => {
     const worker = makeMockWorker();
@@ -234,144 +273,190 @@ describe('bootstrapKernelWorker', () => {
     host.dispose();
   });
 
+  // The migration-timing tests below fake ONLY `setTimeout`/`clearTimeout`
+  // so the assertions are deterministic (no real-clock jitter), while
+  // `setImmediate` stays real for `flushPortMessages()` to deliver the
+  // posted kernel-port signals.
+
   it('suspends the boot timeout while a migration is in progress', async () => {
     // A migration that runs longer than `readyTimeoutMs` must NOT trip
     // the boot timeout — this is the exact bug that stranded the page
     // behind a frozen migration splash. With the boot clock suspended
     // on `kernel-migration-started`, the worker can copy for as long as
     // it keeps posting progress and still resolve `ready` afterwards.
-    let port: MessagePort | null = null;
-    const worker: WorkerLike = {
-      postMessage: (message: unknown) => {
-        const data = message as { type?: string; kernelPort?: MessagePort };
-        if (data?.type === 'kernel-worker-init' && data.kernelPort) {
-          port = data.kernelPort;
-          port.start();
-        }
-      },
-      terminate: () => undefined,
-    };
-    const host = bootstrapKernelWorker({
-      worker,
-      realCdpTransport: makeStubCdpTransport(),
-      callbacks: makeStubCallbacks(),
-      // Tiny boot timeout — the old code would reject ~30ms in.
-      readyTimeoutMs: 30,
-      migrationStallTimeoutMs: 500,
-    });
-    expect(port).not.toBeNull();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const { worker, getPort } = makeStashingWorker();
+      const host = bootstrapKernelWorker({
+        worker,
+        realCdpTransport: makeStubCdpTransport(),
+        callbacks: makeStubCallbacks(),
+        // Tiny boot timeout — the old code would reject ~30ms in.
+        readyTimeoutMs: 30,
+        migrationStallTimeoutMs: 500,
+      });
+      const port = getPort();
 
-    port!.postMessage({ type: 'kernel-migration-started' });
-    // Idle well past `readyTimeoutMs` while migrating.
-    await new Promise((r) => setTimeout(r, 80));
-    port!.postMessage({ type: 'kernel-migration-progress', copied: 1, total: 2 });
-    await new Promise((r) => setTimeout(r, 80));
-    // Finish + ready back-to-back so the re-armed boot clock can't fire.
-    port!.postMessage({ type: 'kernel-migration-finished' });
-    port!.postMessage({ type: 'kernel-worker-ready' });
+      port.postMessage({ type: 'kernel-migration-started' });
+      await flushPortMessages();
+      // Boot clock (30ms) is suspended and the watchdog isn't armed yet —
+      // advancing far past it must not reject.
+      vi.advanceTimersByTime(10_000);
+      await flushPortMessages();
+      port.postMessage({ type: 'kernel-migration-progress', copied: 1, total: 2 });
+      await flushPortMessages();
+      vi.advanceTimersByTime(400); // < 500ms watchdog — still alive
+      await flushPortMessages();
+      // Finish + ready back-to-back so the re-armed boot clock can't fire.
+      port.postMessage({ type: 'kernel-migration-finished' });
+      port.postMessage({ type: 'kernel-worker-ready' });
+      await flushPortMessages();
 
-    await expect(host.ready).resolves.toBeUndefined();
-    host.dispose();
+      await expect(host.ready).resolves.toBeUndefined();
+      host.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('progress heartbeats keep resetting the stall watchdog', async () => {
     // Total migration time exceeds both timeouts, but each gap between
     // progress ticks stays under `migrationStallTimeoutMs`, so the
     // watchdog never fires.
-    let port: MessagePort | null = null;
-    const worker: WorkerLike = {
-      postMessage: (message: unknown) => {
-        const data = message as { type?: string; kernelPort?: MessagePort };
-        if (data?.type === 'kernel-worker-init' && data.kernelPort) {
-          port = data.kernelPort;
-          port.start();
-        }
-      },
-      terminate: () => undefined,
-    };
-    const onMigrationProgress = vi.fn();
-    const host = bootstrapKernelWorker({
-      worker,
-      realCdpTransport: makeStubCdpTransport(),
-      callbacks: makeStubCallbacks(),
-      readyTimeoutMs: 40,
-      migrationStallTimeoutMs: 60,
-      onMigrationProgress,
-    });
-    expect(port).not.toBeNull();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const { worker, getPort } = makeStashingWorker();
+      const onMigrationProgress = vi.fn();
+      const host = bootstrapKernelWorker({
+        worker,
+        realCdpTransport: makeStubCdpTransport(),
+        callbacks: makeStubCallbacks(),
+        readyTimeoutMs: 40,
+        migrationStallTimeoutMs: 60,
+        onMigrationProgress,
+      });
+      const port = getPort();
 
-    port!.postMessage({ type: 'kernel-migration-started' });
-    for (let i = 1; i <= 5; i++) {
-      await new Promise((r) => setTimeout(r, 30)); // < 60ms watchdog each
-      port!.postMessage({ type: 'kernel-migration-progress', copied: i, total: 5 });
+      port.postMessage({ type: 'kernel-migration-started' });
+      await flushPortMessages();
+      for (let i = 1; i <= 5; i++) {
+        port.postMessage({ type: 'kernel-migration-progress', copied: i, total: 5 });
+        await flushPortMessages();
+        vi.advanceTimersByTime(50); // < 60ms watchdog, reset on each tick
+        await flushPortMessages();
+      }
+      port.postMessage({ type: 'kernel-migration-finished' });
+      port.postMessage({ type: 'kernel-worker-ready' });
+      await flushPortMessages();
+
+      await expect(host.ready).resolves.toBeUndefined();
+      expect(onMigrationProgress).toHaveBeenCalledTimes(5);
+      host.dispose();
+    } finally {
+      vi.useRealTimers();
     }
-    port!.postMessage({ type: 'kernel-migration-finished' });
-    port!.postMessage({ type: 'kernel-worker-ready' });
-
-    await expect(host.ready).resolves.toBeUndefined();
-    expect(onMigrationProgress).toHaveBeenCalledTimes(5);
-    host.dispose();
   });
 
-  it('rejects when a migration starts but makes no progress (hung worker)', async () => {
-    // The watchdog is the safety net: if `kernel-migration-started`
-    // arrives but no progress follows within `migrationStallTimeoutMs`,
+  it('does not arm the stall watchdog until the first progress heartbeat', async () => {
+    // Regression guard for the worker's pre-copy phase (dynamic import,
+    // legacy-IDB manifest walk, directory creation): it emits no
+    // progress and is unbounded for a large workspace, so NEITHER the
+    // suspended boot timeout nor the not-yet-armed watchdog may reject
+    // during it. Arming the watchdog at `kernel-migration-started` would
+    // recreate the fatal boot path this change fixes.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const { worker, getPort } = makeStashingWorker();
+      const host = bootstrapKernelWorker({
+        worker,
+        realCdpTransport: makeStubCdpTransport(),
+        callbacks: makeStubCallbacks(),
+        readyTimeoutMs: 30,
+        migrationStallTimeoutMs: 40,
+      });
+      const port = getPort();
+
+      port.postMessage({ type: 'kernel-migration-started' });
+      await flushPortMessages();
+      // Long pre-copy phase with no heartbeat — must not reject even
+      // though it dwarfs both the boot timeout and the watchdog window.
+      vi.advanceTimersByTime(10_000);
+      await flushPortMessages();
+      // The copy then begins emitting progress and completes normally.
+      port.postMessage({ type: 'kernel-migration-progress', copied: 0, total: 3 });
+      await flushPortMessages();
+      port.postMessage({ type: 'kernel-migration-progress', copied: 3, total: 3 });
+      await flushPortMessages();
+      port.postMessage({ type: 'kernel-migration-finished' });
+      port.postMessage({ type: 'kernel-worker-ready' });
+      await flushPortMessages();
+
+      await expect(host.ready).resolves.toBeUndefined();
+      host.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects when the copy stalls after it has started (hung worker)', async () => {
+    // Once progress has begun, the watchdog is the safety net: if the
+    // copy then makes no further progress within `migrationStallTimeoutMs`
     // the worker is genuinely hung and `ready` must reject rather than
     // hang forever.
-    let port: MessagePort | null = null;
-    const worker: WorkerLike = {
-      postMessage: (message: unknown) => {
-        const data = message as { type?: string; kernelPort?: MessagePort };
-        if (data?.type === 'kernel-worker-init' && data.kernelPort) {
-          port = data.kernelPort;
-          port.start();
-        }
-      },
-      terminate: () => undefined,
-    };
-    const host = bootstrapKernelWorker({
-      worker,
-      realCdpTransport: makeStubCdpTransport(),
-      callbacks: makeStubCallbacks(),
-      readyTimeoutMs: 1_000,
-      migrationStallTimeoutMs: 40,
-    });
-    expect(port).not.toBeNull();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const { worker, getPort } = makeStashingWorker();
+      const host = bootstrapKernelWorker({
+        worker,
+        realCdpTransport: makeStubCdpTransport(),
+        callbacks: makeStubCallbacks(),
+        readyTimeoutMs: 1_000,
+        migrationStallTimeoutMs: 40,
+      });
+      const port = getPort();
 
-    port!.postMessage({ type: 'kernel-migration-started' });
-    await expect(host.ready).rejects.toThrow(/migration stalled/);
-    host.dispose();
+      port.postMessage({ type: 'kernel-migration-started' });
+      await flushPortMessages();
+      port.postMessage({ type: 'kernel-migration-progress', copied: 1, total: 10 });
+      await flushPortMessages();
+      // No further progress — advance past the watchdog window.
+      const rejection = expect(host.ready).rejects.toThrow(/migration stalled/);
+      vi.advanceTimersByTime(50);
+      await rejection;
+      host.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('restores the boot timeout after a migration finishes', async () => {
     // Once migration finishes, the rest of boot should complete
     // promptly; a worker that finishes the copy but then hangs must
     // still trip the normal boot-ready timeout.
-    let port: MessagePort | null = null;
-    const worker: WorkerLike = {
-      postMessage: (message: unknown) => {
-        const data = message as { type?: string; kernelPort?: MessagePort };
-        if (data?.type === 'kernel-worker-init' && data.kernelPort) {
-          port = data.kernelPort;
-          port.start();
-        }
-      },
-      terminate: () => undefined,
-    };
-    const host = bootstrapKernelWorker({
-      worker,
-      realCdpTransport: makeStubCdpTransport(),
-      callbacks: makeStubCallbacks(),
-      readyTimeoutMs: 40,
-      migrationStallTimeoutMs: 1_000,
-    });
-    expect(port).not.toBeNull();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const { worker, getPort } = makeStashingWorker();
+      const host = bootstrapKernelWorker({
+        worker,
+        realCdpTransport: makeStubCdpTransport(),
+        callbacks: makeStubCallbacks(),
+        readyTimeoutMs: 40,
+        migrationStallTimeoutMs: 1_000,
+      });
+      const port = getPort();
 
-    port!.postMessage({ type: 'kernel-migration-started' });
-    port!.postMessage({ type: 'kernel-migration-finished' });
-    // No `kernel-worker-ready` follows — the re-armed boot clock fires.
-    await expect(host.ready).rejects.toThrow(/did not signal ready/);
-    host.dispose();
+      port.postMessage({ type: 'kernel-migration-started' });
+      await flushPortMessages();
+      port.postMessage({ type: 'kernel-migration-finished' });
+      await flushPortMessages();
+      // No `kernel-worker-ready` follows — the re-armed boot clock fires.
+      const rejection = expect(host.ready).rejects.toThrow(/did not signal ready/);
+      vi.advanceTimersByTime(50);
+      await rejection;
+      host.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('a stale kernel-worker-ready arriving after timeout does not resolve ready', async () => {

--- a/packages/webapp/tests/kernel/spawn.test.ts
+++ b/packages/webapp/tests/kernel/spawn.test.ts
@@ -234,6 +234,146 @@ describe('bootstrapKernelWorker', () => {
     host.dispose();
   });
 
+  it('suspends the boot timeout while a migration is in progress', async () => {
+    // A migration that runs longer than `readyTimeoutMs` must NOT trip
+    // the boot timeout — this is the exact bug that stranded the page
+    // behind a frozen migration splash. With the boot clock suspended
+    // on `kernel-migration-started`, the worker can copy for as long as
+    // it keeps posting progress and still resolve `ready` afterwards.
+    let port: MessagePort | null = null;
+    const worker: WorkerLike = {
+      postMessage: (message: unknown) => {
+        const data = message as { type?: string; kernelPort?: MessagePort };
+        if (data?.type === 'kernel-worker-init' && data.kernelPort) {
+          port = data.kernelPort;
+          port.start();
+        }
+      },
+      terminate: () => undefined,
+    };
+    const host = bootstrapKernelWorker({
+      worker,
+      realCdpTransport: makeStubCdpTransport(),
+      callbacks: makeStubCallbacks(),
+      // Tiny boot timeout — the old code would reject ~30ms in.
+      readyTimeoutMs: 30,
+      migrationStallTimeoutMs: 500,
+    });
+    expect(port).not.toBeNull();
+
+    port!.postMessage({ type: 'kernel-migration-started' });
+    // Idle well past `readyTimeoutMs` while migrating.
+    await new Promise((r) => setTimeout(r, 80));
+    port!.postMessage({ type: 'kernel-migration-progress', copied: 1, total: 2 });
+    await new Promise((r) => setTimeout(r, 80));
+    // Finish + ready back-to-back so the re-armed boot clock can't fire.
+    port!.postMessage({ type: 'kernel-migration-finished' });
+    port!.postMessage({ type: 'kernel-worker-ready' });
+
+    await expect(host.ready).resolves.toBeUndefined();
+    host.dispose();
+  });
+
+  it('progress heartbeats keep resetting the stall watchdog', async () => {
+    // Total migration time exceeds both timeouts, but each gap between
+    // progress ticks stays under `migrationStallTimeoutMs`, so the
+    // watchdog never fires.
+    let port: MessagePort | null = null;
+    const worker: WorkerLike = {
+      postMessage: (message: unknown) => {
+        const data = message as { type?: string; kernelPort?: MessagePort };
+        if (data?.type === 'kernel-worker-init' && data.kernelPort) {
+          port = data.kernelPort;
+          port.start();
+        }
+      },
+      terminate: () => undefined,
+    };
+    const onMigrationProgress = vi.fn();
+    const host = bootstrapKernelWorker({
+      worker,
+      realCdpTransport: makeStubCdpTransport(),
+      callbacks: makeStubCallbacks(),
+      readyTimeoutMs: 40,
+      migrationStallTimeoutMs: 60,
+      onMigrationProgress,
+    });
+    expect(port).not.toBeNull();
+
+    port!.postMessage({ type: 'kernel-migration-started' });
+    for (let i = 1; i <= 5; i++) {
+      await new Promise((r) => setTimeout(r, 30)); // < 60ms watchdog each
+      port!.postMessage({ type: 'kernel-migration-progress', copied: i, total: 5 });
+    }
+    port!.postMessage({ type: 'kernel-migration-finished' });
+    port!.postMessage({ type: 'kernel-worker-ready' });
+
+    await expect(host.ready).resolves.toBeUndefined();
+    expect(onMigrationProgress).toHaveBeenCalledTimes(5);
+    host.dispose();
+  });
+
+  it('rejects when a migration starts but makes no progress (hung worker)', async () => {
+    // The watchdog is the safety net: if `kernel-migration-started`
+    // arrives but no progress follows within `migrationStallTimeoutMs`,
+    // the worker is genuinely hung and `ready` must reject rather than
+    // hang forever.
+    let port: MessagePort | null = null;
+    const worker: WorkerLike = {
+      postMessage: (message: unknown) => {
+        const data = message as { type?: string; kernelPort?: MessagePort };
+        if (data?.type === 'kernel-worker-init' && data.kernelPort) {
+          port = data.kernelPort;
+          port.start();
+        }
+      },
+      terminate: () => undefined,
+    };
+    const host = bootstrapKernelWorker({
+      worker,
+      realCdpTransport: makeStubCdpTransport(),
+      callbacks: makeStubCallbacks(),
+      readyTimeoutMs: 1_000,
+      migrationStallTimeoutMs: 40,
+    });
+    expect(port).not.toBeNull();
+
+    port!.postMessage({ type: 'kernel-migration-started' });
+    await expect(host.ready).rejects.toThrow(/migration stalled/);
+    host.dispose();
+  });
+
+  it('restores the boot timeout after a migration finishes', async () => {
+    // Once migration finishes, the rest of boot should complete
+    // promptly; a worker that finishes the copy but then hangs must
+    // still trip the normal boot-ready timeout.
+    let port: MessagePort | null = null;
+    const worker: WorkerLike = {
+      postMessage: (message: unknown) => {
+        const data = message as { type?: string; kernelPort?: MessagePort };
+        if (data?.type === 'kernel-worker-init' && data.kernelPort) {
+          port = data.kernelPort;
+          port.start();
+        }
+      },
+      terminate: () => undefined,
+    };
+    const host = bootstrapKernelWorker({
+      worker,
+      realCdpTransport: makeStubCdpTransport(),
+      callbacks: makeStubCallbacks(),
+      readyTimeoutMs: 40,
+      migrationStallTimeoutMs: 1_000,
+    });
+    expect(port).not.toBeNull();
+
+    port!.postMessage({ type: 'kernel-migration-started' });
+    port!.postMessage({ type: 'kernel-migration-finished' });
+    // No `kernel-worker-ready` follows — the re-armed boot clock fires.
+    await expect(host.ready).rejects.toThrow(/did not signal ready/);
+    host.dispose();
+  });
+
   it('a stale kernel-worker-ready arriving after timeout does not resolve ready', async () => {
     // Catches the original leak: if the timeout path forgot to remove
     // the listener, a later `kernel-worker-ready` posted on the port


### PR DESCRIPTION
## Summary

This updates the kernel-worker boot timeout fix to handle the migration pre-copy phase safely and make timing tests deterministic. During migration, boot timeout is still suspended, but the stall watchdog is now armed only after the first `kernel-migration-progress` heartbeat (not at `kernel-migration-started`), then reset on each heartbeat.  
Tests were converted to Vitest fake timers and expanded with a regression test for the no-progress pre-copy window.

## Why

Large legacy→OPFS migrations can spend significant time in pre-copy setup (import/manifest walk/directory creation) without emitting progress events. Arming the stall watchdog before progress exists could still fail boot during that phase, which conflicts with this PR’s core goal (avoid false fatal boot timeouts during legitimate slow migration).

## Approach / Implementation notes

- `bootstrapKernelWorker` now treats `kernel-migration-started` as “suspend boot timeout only.”
- Stall watchdog (`migrationStallTimeoutMs`) is armed on first `kernel-migration-progress` and re-armed on subsequent progress heartbeats.
- On `kernel-migration-finished`, normal boot timeout behavior is restored for the remaining handshake.
- Migration timing tests now use fake timers for deterministic timeout assertions while keeping message delivery behavior intact.

## Cross-cutting impact

- **Floats exercised**: webapp standalone kernel-worker boot path.
- **Other callers of changed contract**: no API/contract expansion beyond kernel spawn/boot sequencing.
- **Async lifecycle**: timer behavior is now explicitly phase-aware (pre-progress vs progress-active migration), reducing false timeout failures in long pre-copy phases.
- **Security**: no new secret handling, auth surface, or sandbox boundary changes.

## Test plan

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [x] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [x] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [x] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

- N/A for targeted verification; ran focused checks for changed area:
  - `npm run lint` ✅
  - `npm run typecheck` ✅
  - `npx vitest run packages/webapp/tests/kernel/spawn.test.ts` ✅ (13 passed)

## Documentation

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [x] No documentation changes needed

## Risk & rollback

Blast radius is limited to kernel worker boot/migration timing in webapp startup.  
If regression occurs, rollback is clean by reverting this PR (no persisted schema/data shape change introduced by this update).  
Main residual risk is timer sequencing under unusual runtime scheduling; mitigated by deterministic fake-timer unit coverage including pre-progress and post-finish phases.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths