### PR TITLE
fix(ui): render frozen sessions from OPFS by reading after the worker is ready

### DIFF
--- a/packages/webapp/src/kernel/remote-vfs-client.ts
+++ b/packages/webapp/src/kernel/remote-vfs-client.ts
@@ -55,6 +55,16 @@ export interface RemoteVfsClientOptions {
    */
   generateRequestId?: () => string;
   /**
+   * Per-request timeout in ms. Defaults to 30s. A request that gets no
+   * matching response within this window rejects with `FsError('EIO',
+   * …)` instead of hanging forever. This matters because the worker's
+   * `VfsRpcHost` only attaches its listener at the tail of boot — a
+   * read issued before the host is live (or a response otherwise lost
+   * on the shared wire) would never be answered, silently stranding
+   * the caller. Pass `0` (or negative) to disable the timeout.
+   */
+  requestTimeoutMs?: number;
+  /**
    * Optional logger — defaults to `console`. Override in tests to
    * silence expected warnings.
    */
@@ -91,12 +101,18 @@ interface PendingRequest {
   expect: ResultMsg['type'];
   /** Path argument, echoed onto a synthesised error if the responder dies. */
   path: string;
+  /** Timeout handle, cleared when the response lands (or on dispose). */
+  timer: ReturnType<typeof setTimeout> | null;
 }
+
+/** Default per-request timeout (ms). */
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
 class RemoteVfsClient implements RemoteVfsClientHandle {
   private readonly transport: KernelTransport<ExtensionMessage, PanelToOffscreenMessage>;
   private readonly log: NonNullable<RemoteVfsClientOptions['logger']>;
   private readonly genId: () => string;
+  private readonly requestTimeoutMs: number;
   private readonly pending = new Map<string, PendingRequest>();
   private unsubscribe: (() => void) | null = null;
   private counter = 0;
@@ -104,6 +120,7 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
   constructor(opts: RemoteVfsClientOptions) {
     this.transport = opts.transport;
     this.log = opts.logger ?? console;
+    this.requestTimeoutMs = opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     this.genId =
       opts.generateRequestId ??
       (() => {
@@ -149,6 +166,7 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
     // Reject any in-flight requests so callers don't hang forever after
     // teardown (e.g. panel-detach mid-readDir refresh).
     for (const [, p] of this.pending) {
+      if (p.timer !== null) clearTimeout(p.timer);
       p.reject(new FsError('EBADF', 'RemoteVfsClient disposed', p.path));
     }
     this.pending.clear();
@@ -165,16 +183,34 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
     payload: VfsReadDirRequestMsg | VfsReadFileRequestMsg | VfsStatRequestMsg
   ): Promise<T> {
     return new Promise<T>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      if (this.requestTimeoutMs > 0) {
+        timer = setTimeout(() => {
+          // No matching response arrived in time — the responder is
+          // either not up yet or the reply was lost on the shared wire.
+          // Reject so the caller fails fast instead of hanging forever.
+          if (!this.pending.delete(requestId)) return;
+          reject(
+            new FsError(
+              'EIO',
+              `vfs-rpc request timed out after ${this.requestTimeoutMs}ms (${expect})`,
+              path
+            )
+          );
+        }, this.requestTimeoutMs);
+      }
       this.pending.set(requestId, {
         resolve: resolve as (value: unknown) => void,
         reject,
         expect,
         path,
+        timer,
       });
       try {
         this.transport.send(payload as PanelToOffscreenMessage);
       } catch (err) {
         this.pending.delete(requestId);
+        if (timer !== null) clearTimeout(timer);
         reject(err);
       }
     });
@@ -191,6 +227,8 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
       });
       return;
     }
+    // A response landed — cancel the timeout before settling.
+    if (pending.timer !== null) clearTimeout(pending.timer);
     if (pending.expect !== msg.type) {
       // Type-discriminator mismatch — shouldn't happen with the typed
       // host, but guard against a future cross-route bug.

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -2399,7 +2399,14 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
   // displays it in the chat panel read-only — matching the affordance
   // of clicking a live scoop (which also opens the chat view rather
   // than a file).
-  layout.panels.scoops.setVfs(panelReadVfs);
+  //
+  // NOTE: `setVfs()` eagerly reads `/sessions/index.json`, but under
+  // `slicc_opfs_vfs=opfs` `panelReadVfs` is a worker-RPC client and the
+  // worker's `VfsRpcHost` only starts listening at the tail of boot.
+  // Wiring it is therefore deferred until after `await host.ready`
+  // below — otherwise the read fires before any responder exists, the
+  // request is dropped, and the frozen-sessions list renders empty even
+  // though the archives are present on OPFS.
   layout.onFrozenSessionOpen = (entry) => {
     void (async () => {
       try {
@@ -2461,6 +2468,14 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
     throw err;
   }
   client.requestState();
+
+  // Wire the frozen-sessions sidebar now that the worker's `VfsRpcHost`
+  // is live (it starts at the tail of `boot()`, just before the
+  // ready signal). `setVfs` eagerly reads `/sessions/index.json` through
+  // `panelReadVfs`; doing it pre-ready under `slicc_opfs_vfs=opfs` would
+  // drop the read against a not-yet-listening worker and leave the list
+  // empty. Flag off (`panelReadVfs === localFs`) this is equally correct.
+  layout.panels.scoops.setVfs(panelReadVfs);
 
   // Install localStorage sync interceptor immediately — before any
   // onboarding or provider-settings writes can happen. Placing this

--- a/packages/webapp/tests/kernel/remote-vfs-client.test.ts
+++ b/packages/webapp/tests/kernel/remote-vfs-client.test.ts
@@ -252,6 +252,79 @@ describe('RemoteVfsClient — envelope filtering', () => {
   });
 });
 
+describe('RemoteVfsClient — request timeout', () => {
+  it('rejects with EIO when no response arrives within requestTimeoutMs', async () => {
+    // Transport that never replies — mirrors a read issued before the
+    // worker's VfsRpcHost is listening (the frozen-sessions bug).
+    const transport: KernelTransport<ExtensionMessage, PanelToOffscreenMessage> = {
+      onMessage: () => () => {},
+      send: () => {},
+    };
+    const client = createRemoteVfsClient({
+      transport,
+      requestTimeoutMs: 20,
+      logger: { warn: vi.fn(), debug: vi.fn() },
+    });
+    await expect(client.readFile('/sessions/index.json')).rejects.toMatchObject({
+      name: 'FsError',
+      code: 'EIO',
+      path: '/sessions/index.json',
+    });
+    client.dispose();
+  });
+
+  it('requestTimeoutMs <= 0 disables the timeout (stays pending until dispose)', async () => {
+    const transport: KernelTransport<ExtensionMessage, PanelToOffscreenMessage> = {
+      onMessage: () => () => {},
+      send: () => {},
+    };
+    const client = createRemoteVfsClient({
+      transport,
+      requestTimeoutMs: 0,
+      logger: { warn: vi.fn(), debug: vi.fn() },
+    });
+    const p = client.readDir('/hang');
+    // Well past any plausible timer — the request must still be pending.
+    await tick(40);
+    client.dispose();
+    await expect(p).rejects.toMatchObject({ name: 'FsError', code: 'EBADF' });
+  });
+
+  it('a response received before the timeout cancels it (resolves, no late rejection)', async () => {
+    let handler: ((m: ExtensionMessage) => void) | null = null;
+    const transport: KernelTransport<ExtensionMessage, PanelToOffscreenMessage> = {
+      onMessage(h) {
+        handler = h;
+        return () => {
+          handler = null;
+        };
+      },
+      send(payload) {
+        const req = payload as { type: string; requestId: string };
+        handler?.({
+          source: 'offscreen',
+          payload: {
+            type: 'vfs-read-dir-result',
+            requestId: req.requestId,
+            ok: true,
+            entries: [],
+          } as VfsReadDirResultMsg,
+        } as ExtensionMessage);
+      },
+    };
+    const client = createRemoteVfsClient({
+      transport,
+      requestTimeoutMs: 20,
+      logger: { warn: vi.fn(), debug: vi.fn() },
+    });
+    await expect(client.readDir('/x')).resolves.toEqual([]);
+    // Idle past the timeout window — a leaked timer would have fired by
+    // now; the already-settled promise must not flip to a rejection.
+    await tick(40);
+    client.dispose();
+  });
+});
+
 describe('RemoteVfsClient — dispose semantics', () => {
   it('rejects pending requests on dispose', async () => {
     // Transport that never replies, so the pending request stays open


### PR DESCRIPTION
## Problem

The freezer UI (frozen-sessions sidebar) shows past cone sessions, but after the move to the OPFS-backed VFS the sessions stopped appearing — even though the archives are present on OPFS.

### Diagnosis (observed live via CDP)

OPFS confirmed to contain the data — `slicc-fs/sessions/index.json` holds 14 archived sessions:

```
slicc-fs/sessions/
  index.json
  2026-05-30T16-25-47-...-garmin-skill-pr-and-ci-fixes.md
  2026-05-30T03-57-51-...-slicc-upgrade-skills-patching-and-fitness.md
  ...
```

…yet the panel's `.frozen-sessions-list` rendered **0** items.

The panel is wired in `mainStandaloneWorker` via `scoops-panel.setVfs(panelReadVfs)`. Under `slicc_opfs_vfs=opfs`, `panelReadVfs` is a worker-RPC `RemoteVfsClient`, and `setVfs()` **eagerly** reads `/sessions/index.json`. But that wiring ran **before** `await host.ready`, while the worker's `VfsRpcHost` only starts listening at the **tail** of `boot()` (right before it signals ready).

So the eager read was sent to a not-yet-listening worker and **dropped**. And because `RemoteVfsClient.request()` had **no timeout**, the read promise hung forever — `refreshFrozenSessions()` never settled, and the list stayed empty. (The UI was reading the *correct* OPFS store, just before anything could answer.)

## Fix

1. **Defer the wiring** — move `layout.panels.scoops.setVfs(panelReadVfs)` to **after** `await host.ready` so the index read targets a live `VfsRpcHost`.
2. **Add a per-request timeout to `RemoteVfsClient`** (default 30s, `requestTimeoutMs`, pass `0` to disable). A dropped/lost response now rejects with `FsError('EIO', …)` instead of hanging a caller forever — defense-in-depth against this whole class of bug (file browser, preview, etc.). The timer is cleared when the response lands and on `dispose()`.

## Tests

Added 3 tests to `remote-vfs-client.test.ts`:
- a request with no response rejects with `EIO` after `requestTimeoutMs`,
- `requestTimeoutMs <= 0` disables the timeout (stays pending until `dispose()`),
- a timely response cancels the timer (resolves; no late rejection).

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npx vitest run packages/webapp/tests/kernel/remote-vfs-client.test.ts` ✅ (14 passed)
- Related suites (`tests/kernel`, `scoops-panel`, `session-freezer`) ✅ (593 passed)
- `npm run build -w @slicc/webapp` ✅

Note: the running dev instance serves a different checkout than this worktree, so the live reload re-confirmed the bug (0 sessions on the old build) rather than the fix; the fix is verified by the unit tests and the boot-ordering analysis above.