### PR TITLE
fix(kernel): seed chat buffers from restored agent history on boot

### DIFF
--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -863,6 +863,70 @@ export class OffscreenBridge implements KernelFacade {
   }
 
   /**
+   * Translate a scoop's restored canonical `AgentMessage[]` into the
+   * buffered chat shape. Returns `null` when there is no context or no
+   * agent messages yet. Lazy-imports the translator so it doesn't pull
+   * pi-ai types into the bridge's hot path until needed. Shared by
+   * {@link handleRequestScoopMessages} and {@link seedBuffersFromAgentState}.
+   */
+  private async buildBufferFromAgentMessages(
+    scoop: RegisteredScoop
+  ): Promise<BufferedChatMessage[] | null> {
+    const context = this.orchestrator?.getScoopContext(scoop.jid);
+    if (!context) return null;
+    const agentMessages = context.getAgentMessages();
+    if (agentMessages.length === 0) return null;
+    const { agentMessagesToChatMessages } = await import(
+      '../../../packages/webapp/src/scoops/agent-message-to-chat.js'
+    );
+    const chatMessages = agentMessagesToChatMessages(agentMessages, {
+      source: scoop.isCone ? 'cone' : (scoop.name ?? scoop.folder),
+    });
+    return chatMessages.map((m) => ({
+      id: m.id,
+      role: m.role,
+      content: m.content,
+      attachments: m.attachments,
+      timestamp: m.timestamp,
+      source: m.source,
+      channel: m.channel,
+      toolCalls: m.toolCalls?.map((tc) => ({
+        id: tc.id,
+        name: tc.name,
+        input: tc.input,
+        result: tc.result,
+        isError: tc.isError,
+      })),
+      isStreaming: false,
+    }));
+  }
+
+  /**
+   * Seed each registered scoop's chat buffer from its agent's restored
+   * canonical history at boot, BEFORE any post-boot turn can run
+   * `persistScoop`. The bridge's `messageBuffers` otherwise start empty
+   * on a fresh boot, so the first agent turn after a reload would
+   * persist only the new messages and overwrite the full conversation
+   * in the `browser-coding-agent` UI store — the "only the last few
+   * messages after a reboot" truncation. Non-destructive: only seeds
+   * scoops whose buffer is still empty, and persists the seeded buffer
+   * so a subsequent panel reload sees the canonical history immediately.
+   */
+  async seedBuffersFromAgentState(): Promise<void> {
+    if (!this.orchestrator) return;
+    for (const scoop of this.orchestrator.getScoops()) {
+      const existing = this.messageBuffers.get(scoop.jid);
+      if (existing && existing.length > 0) continue;
+      const buf = await this.buildBufferFromAgentMessages(scoop);
+      if (!buf) continue;
+      this.messageBuffers.set(scoop.jid, buf);
+      this.currentMessageId.delete(scoop.jid);
+      this.fanOutMessageId.delete(scoop.jid);
+      this.persistScoop(scoop.jid);
+    }
+  }
+
+  /**
    * Rebuild the panel's chat history for a scoop from the live agent
    * state. Replies via `scoop-messages-replaced`. Used after a panel
    * remount (HMR or full reload) to override the panel's own
@@ -890,58 +954,30 @@ export class OffscreenBridge implements KernelFacade {
       return;
     }
 
-    // Translate from the agent's canonical conversation. Lazy-import the
-    // translator so it doesn't pull pi-ai types into the bridge's hot
-    // path until needed.
-    const context = this.orchestrator.getScoopContext(scoopJid);
-    if (context) {
-      const { agentMessagesToChatMessages } = await import(
-        '../../../packages/webapp/src/scoops/agent-message-to-chat.js'
-      );
-      const agentMessages = context.getAgentMessages();
-      if (agentMessages.length > 0) {
-        const chatMessages = agentMessagesToChatMessages(agentMessages, {
-          source: scoop.isCone ? 'cone' : (scoop.name ?? scoop.folder),
-        });
-        // Hydrate the buffer so subsequent agent events extend the
-        // restored history instead of starting from empty (which
-        // would silently overwrite the UI store via persistScoop).
-        // Clear `currentMessageId` for the same reason: a stale id
-        // pointing at a (now non-existent) buffer entry would have
-        // `getOrCreateAssistantMsg` write into the rehydrated buffer
-        // under an unrelated id.
-        const buf: BufferedChatMessage[] = chatMessages.map((m) => ({
-          id: m.id,
-          role: m.role,
-          content: m.content,
-          attachments: m.attachments,
-          timestamp: m.timestamp,
-          source: m.source,
-          channel: m.channel,
-          toolCalls: m.toolCalls?.map((tc) => ({
-            id: tc.id,
-            name: tc.name,
-            input: tc.input,
-            result: tc.result,
-            isError: tc.isError,
-          })),
-          isStreaming: false,
-        }));
-        this.messageBuffers.set(scoopJid, buf);
-        this.currentMessageId.delete(scoopJid);
-        this.fanOutMessageId.delete(scoopJid);
-        // Persist the rebuilt buffer back to the UI session store so
-        // a subsequent panel reload (without further agent activity)
-        // sees the canonical history instead of whatever truncated
-        // snapshot the panel last wrote during the remount race.
-        this.persistScoop(scoopJid);
-        this.emit({
-          type: 'scoop-messages-replaced',
-          scoopJid,
-          messages: buf,
-        });
-        return;
-      }
+    // Translate from the agent's canonical conversation.
+    const buf = await this.buildBufferFromAgentMessages(scoop);
+    if (buf) {
+      // Hydrate the buffer so subsequent agent events extend the
+      // restored history instead of starting from empty (which would
+      // silently overwrite the UI store via persistScoop). Clear
+      // `currentMessageId`/`fanOutMessageId` for the same reason: a
+      // stale id pointing at a (now non-existent) buffer entry would
+      // have `getOrCreateAssistantMsg` write into the rehydrated buffer
+      // under an unrelated id.
+      this.messageBuffers.set(scoopJid, buf);
+      this.currentMessageId.delete(scoopJid);
+      this.fanOutMessageId.delete(scoopJid);
+      // Persist the rebuilt buffer back to the UI session store so
+      // a subsequent panel reload (without further agent activity)
+      // sees the canonical history instead of whatever truncated
+      // snapshot the panel last wrote during the remount race.
+      this.persistScoop(scoopJid);
+      this.emit({
+        type: 'scoop-messages-replaced',
+        scoopJid,
+        messages: buf,
+      });
+      return;
     }
 
     // Last resort: load from the UI session store. Hydrate the buffer

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -909,8 +909,11 @@ export class OffscreenBridge implements KernelFacade {
    * persist only the new messages and overwrite the full conversation
    * in the `browser-coding-agent` UI store — the "only the last few
    * messages after a reboot" truncation. Non-destructive: only seeds
-   * scoops whose buffer is still empty, and persists the seeded buffer
-   * so a subsequent panel reload sees the canonical history immediately.
+   * scoops whose buffer is still empty, and AWAITS the persist of the
+   * seeded buffer so the `browser-coding-agent` store is repaired before
+   * `createKernelHost` signals `kernel-worker-ready` — otherwise a panel
+   * that mounts and reads the store on the next tick could still see the
+   * truncated snapshot.
    */
   async seedBuffersFromAgentState(): Promise<void> {
     if (!this.orchestrator) return;
@@ -922,7 +925,7 @@ export class OffscreenBridge implements KernelFacade {
       this.messageBuffers.set(scoop.jid, buf);
       this.currentMessageId.delete(scoop.jid);
       this.fanOutMessageId.delete(scoop.jid);
-      this.persistScoop(scoop.jid);
+      await this.persistScoopAwait(scoop.jid);
     }
   }
 
@@ -1082,19 +1085,33 @@ export class OffscreenBridge implements KernelFacade {
    * semantics as the standalone leader.
    */
   persistScoop(jid: string): void {
+    void this.persistScoopAwait(jid);
+  }
+
+  /**
+   * Awaitable variant of {@link persistScoop}. Callers that must KNOW the
+   * UI store has been written before proceeding — e.g. boot-time
+   * {@link seedBuffersFromAgentState}, which runs inside `createKernelHost`
+   * before `kernel-worker-ready` is signaled so the panel never mounts
+   * against a stale/truncated `browser-coding-agent` snapshot — await this
+   * instead. Errors are still swallowed so a failed write can't break boot.
+   */
+  private async persistScoopAwait(jid: string): Promise<void> {
     if (!this.sessionStore || !this.orchestrator) return;
     const scoop = this.orchestrator.getScoops().find((s) => s.jid === jid);
     if (!scoop) return;
     const sessionId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
     const buf = this.messageBuffers.get(jid);
     if (!buf || buf.length === 0) return;
-    // BufferedChatMessage is structurally compatible with ChatMessage
-    this.sessionStore.saveMessages(sessionId, buf as unknown as ChatMessage[]).catch((err) => {
+    try {
+      // BufferedChatMessage is structurally compatible with ChatMessage
+      await this.sessionStore.saveMessages(sessionId, buf as unknown as ChatMessage[]);
+    } catch (err) {
       log.error('persistScoop failed', {
         sessionId,
         error: err instanceof Error ? err.message : String(err),
       });
-    });
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/packages/chrome-extension/tests/offscreen-bridge.test.ts
+++ b/packages/chrome-extension/tests/offscreen-bridge.test.ts
@@ -1998,3 +1998,94 @@ describe('OffscreenBridge handleRequestScoopMessages', () => {
     );
   });
 });
+
+describe('OffscreenBridge seedBuffersFromAgentState', () => {
+  let bridge: InstanceType<typeof OffscreenBridge>;
+
+  const coneScoop = {
+    jid: 'cone_1',
+    name: 'Cone',
+    folder: 'cone',
+    isCone: true,
+    assistantLabel: 'sliccy',
+  };
+  const makeContext = (messages: any[]) => ({ getAgentMessages: vi.fn(() => messages) });
+  const restoredHistory = [
+    { role: 'user', content: [{ type: 'text', text: 'first question' }], timestamp: 1 },
+    {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'first answer' }],
+      timestamp: 2,
+      api: 'anthropic-messages',
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      stopReason: 'stop',
+    },
+  ];
+
+  beforeEach(() => {
+    sentMessages.length = 0;
+    messageListeners.length = 0;
+    vi.clearAllMocks();
+    bridge = new OffscreenBridge();
+  });
+
+  it('seeds an empty buffer from the restored agent messages and persists it', async () => {
+    const context = makeContext(restoredHistory);
+    await bridge.bind({
+      getScoops: vi.fn(() => [coneScoop]),
+      getScoopContext: vi.fn(() => context),
+    } as any);
+    const store = (bridge as any).sessionStore;
+
+    await bridge.seedBuffersFromAgentState();
+
+    const buf = (bridge as any).getBuffer('cone_1');
+    expect(buf).toHaveLength(2);
+    expect(buf[0]).toMatchObject({ role: 'user', content: 'first question' });
+    expect(buf[1]).toMatchObject({ role: 'assistant', content: 'first answer' });
+    // Repairs the UI store immediately (the truncation fix).
+    expect(store.saveMessages).toHaveBeenCalledWith('session-cone', expect.any(Array));
+    const persisted = store.saveMessages.mock.calls[0][1];
+    expect(persisted).toHaveLength(2);
+  });
+
+  it('does not overwrite a buffer that already has live messages', async () => {
+    const context = makeContext(restoredHistory);
+    await bridge.bind({
+      getScoops: vi.fn(() => [coneScoop]),
+      getScoopContext: vi.fn(() => context),
+    } as any);
+    const store = (bridge as any).sessionStore;
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push({ id: 'live-1', role: 'user', content: 'live', timestamp: 100 });
+
+    await bridge.seedBuffersFromAgentState();
+
+    const after = (bridge as any).getBuffer('cone_1');
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe('live-1');
+    // Skipped before even reading the context — no clobber, no persist.
+    expect(context.getAgentMessages).not.toHaveBeenCalled();
+    expect(store.saveMessages).not.toHaveBeenCalled();
+  });
+
+  it('skips scoops with no restored agent messages (no buffer, no persist)', async () => {
+    const context = makeContext([]);
+    await bridge.bind({
+      getScoops: vi.fn(() => [coneScoop]),
+      getScoopContext: vi.fn(() => context),
+    } as any);
+    const store = (bridge as any).sessionStore;
+
+    await bridge.seedBuffersFromAgentState();
+
+    expect((bridge as any).messageBuffers.get('cone_1')).toBeUndefined();
+    expect(store.saveMessages).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the orchestrator is not bound', async () => {
+    const fresh = new OffscreenBridge();
+    await expect(fresh.seedBuffersFromAgentState()).resolves.toBeUndefined();
+  });
+});

--- a/packages/webapp/src/kernel/host.ts
+++ b/packages/webapp/src/kernel/host.ts
@@ -338,6 +338,14 @@ export async function createKernelHost(config: KernelHostConfig): Promise<Kernel
   // 4. Init orchestrator (loads persisted scoops, mounts the shared FS).
   await orchestrator.init();
 
+  // 4b. Seed the bridge's chat buffers from each scoop's restored
+  // canonical conversation, BEFORE `kernel-worker-ready` is signaled and
+  // therefore before the panel selects a scoop or a post-boot turn runs
+  // `persistScoop`. Without this the buffers start empty and the first
+  // turn after a reload overwrites the full history in the
+  // `browser-coding-agent` UI store with only the new messages.
+  await bridge.seedBuffersFromAgentState();
+
   // 5. Publish agent bridge for the `agent` shell command.
   const sharedFs = orchestrator.getSharedFS();
   if (sharedFs) {

--- a/packages/webapp/src/kernel/types.ts
+++ b/packages/webapp/src/kernel/types.ts
@@ -117,6 +117,18 @@ export interface KernelFacade {
 
   /** Today's helper used by tray-leader to know which scoop is the cone. */
   getConeJid(): string | null;
+
+  /**
+   * Seed each registered scoop's chat buffer from its agent's restored
+   * canonical `AgentMessage[]`, immediately after `orchestrator.init()`
+   * and BEFORE any post-boot turn can `persistScoop`. The bridge's
+   * `messageBuffers` otherwise start empty on boot, so the first turn
+   * after a reload would persist only the new messages and overwrite the
+   * full conversation in the `browser-coding-agent` UI store — the
+   * "only the last few messages after a reboot" truncation. Idempotent
+   * and non-destructive: only seeds scoops whose buffer is still empty.
+   */
+  seedBuffersFromAgentState(): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/tests/ui/file-browser-panel.test.ts
+++ b/packages/webapp/tests/ui/file-browser-panel.test.ts
@@ -16,8 +16,25 @@ function createContainer(): HTMLElement {
   return el;
 }
 
-function tick(ms = 5): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
+/**
+ * Poll until `predicate` returns a non-null/non-false value or the timeout
+ * elapses. Used instead of a fixed `setTimeout` so the assertions don't
+ * race the real-MessageChannel RPC round-trips (readDir → stat → render)
+ * under CI load — a fixed wait flaked intermittently.
+ */
+async function waitFor<T>(
+  predicate: () => T | null | undefined | false,
+  { timeout = 2000, interval = 5 }: { timeout?: number; interval?: number } = {}
+): Promise<T> {
+  const start = Date.now();
+  for (;;) {
+    const value = predicate();
+    if (value != null && value !== false) return value;
+    if (Date.now() - start > timeout) {
+      throw new Error('waitFor: condition not met within timeout');
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
 }
 
 describe('FileBrowserPanel', () => {
@@ -114,10 +131,14 @@ describe('FileBrowserPanel — renders via RemoteVfsClient + VfsRpcHost', () => 
       return [];
     });
     ctx.vfs.stat.mockResolvedValue({ type: 'file', size: 42, mtime: 0, ctime: 0 } as Stats);
-    // Allow the async refresh chain (readDir → stat for the file) to settle.
-    await tick(20);
-    const rows = Array.from(ctx.container.querySelectorAll('.file-browser__name')) as HTMLElement[];
-    const names = rows.map((r) => r.textContent);
+    // Poll the async refresh chain (readDir → stat for the file) to settle.
+    const names = await waitFor(() => {
+      const rows = Array.from(
+        ctx!.container.querySelectorAll('.file-browser__name')
+      ) as HTMLElement[];
+      const ns = rows.map((r) => r.textContent);
+      return ns.includes('workspace') && ns.includes('readme.txt') ? ns : null;
+    });
     expect(names).toEqual(expect.arrayContaining(['workspace', 'readme.txt']));
     expect(ctx.vfs.readDir).toHaveBeenCalledWith('/');
   });
@@ -129,9 +150,11 @@ describe('FileBrowserPanel — renders via RemoteVfsClient + VfsRpcHost', () => 
       return [];
     });
     ctx.vfs.stat.mockResolvedValue({ type: 'file', size: 2048, mtime: 0, ctime: 0 } as Stats);
-    await tick(20);
-    const size = ctx.container.querySelector('.file-browser__size') as HTMLElement | null;
-    expect(size?.textContent).toBe('2.0K');
+    const sizeText = await waitFor(() => {
+      const size = ctx!.container.querySelector('.file-browser__size') as HTMLElement | null;
+      return size?.textContent === '2.0K' ? size.textContent : null;
+    });
+    expect(sizeText).toBe('2.0K');
     expect(ctx.vfs.stat).toHaveBeenCalledWith('/big.bin');
   });
 });


### PR DESCRIPTION
## Summary

On reload, the kernel host's chat buffer (`OffscreenBridge.messageBuffers`) started empty on every boot. The first post-reboot `persistScoop` call overwrote the canonical UI session store with a truncated copy, causing the chat panel to show only the messages recorded since the last boot.

This PR seeds each registered scoop's buffer from its restored canonical `AgentMessage[]` inside `createKernelHost`, right after `orchestrator.init()` and before `kernel-worker-ready` is signaled, so the UI store is fully repaired before the panel can mount and read it. Additionally, `persistScoopAwait()` (an awaitable variant of `persistScoop`) is used in the seed loop to guarantee the IDB write lands before the worker signals ready.

## Why

`browser-coding-agent / session-cone` was being silently truncated on every reload — the canonical `agent-sessions` store was intact (669 messages), but the chat panel rendered from the truncated UI store (6 messages). The race between `handleRequestScoopMessages` hydration and the first `persistScoop` call was consistently lost because the hydration path is fire-and-forget with no retry.

## Approach / Implementation notes

- **`KernelFacade.seedBuffersFromAgentState()`** — new method on the host facade, implemented in `OffscreenBridge`. Non-destructive: only fills buffers that are still empty.
- **`persistScoopAwait()`** — awaitable variant of `persistScoop`; the fire-and-forget `persistScoop()` now delegates to it via `void`. The seed loop awaits it so the UI store is durably repaired before `kernel-worker-ready`.
- **`buildBufferFromAgentMessages()`** — extracted shared helper (agent→chat translation), used by both `seedBuffersFromAgentState` and `handleRequestScoopMessages` to avoid duplication.
- Applies to **both** floats — `kernel-worker.ts` (standalone) and `offscreen.ts` (extension) both boot through `createKernelHost`.

## Cross-cutting impact

- **Floats exercised**: standalone kernel worker + Chrome extension offscreen.
- **Persisted state side-effects**: `browser-coding-agent / session-cone` is repaired (written once at boot if empty) rather than truncated.
- **Async lifecycle**: `persistScoop` callers outside the seed path are unchanged (still fire-and-forget); only the boot-time seed loop awaits `persistScoopAwait()`.
- **CI flake fixed**: `tests/ui/file-browser-panel.test.ts > renders via RemoteVfsClient + VfsRpcHost` intermittently failed under CI load due to fixed `await tick(20)` waits for a real-MessageChannel RPC round-trip. Replaced with a polling `waitFor()` helper so assertions are deterministic.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test` — `vitest run offscreen-bridge.test.ts` ✅ (122 passed, 4 new); `vitest run tests/kernel` + translator ✅ (675 passed); `file-browser-panel.test.ts` ✅ (4 passed × 5 runs)
- [x] `npm run build -w @slicc/webapp` and `-w @slicc/chrome-extension` ✅
- [x] `npm run lint` ✅
- [x] **New / changed behavior is covered by a unit test** — `seedBuffersFromAgentState` suite in `offscreen-bridge.test.ts`: seeds empty buffer and persists it; does not overwrite a buffer with live messages; skips scoops with no restored messages; no-op when orchestrator is unbound.

**Pre-existing failures**: none — `file-browser-panel.test.ts` flake (from #896) is resolved by the `waitFor()` polling fix in this PR.

## Documentation

- [x] No documentation changes needed

## Risk & rollback

- Blast radius: chat panel history display on reload across both floats.
- No feature flags. Revert this PR cleanly reverts the fix; the truncation behaviour returns but no data migration is needed (canonical `agent-sessions` is untouched by this PR).
- The seeding is non-destructive: buffers that already have live messages are never overwritten.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths