### PR TITLE
feat(ui): simplify Electron overlay — drop shell header/tabs, move close button into iframe

### DIFF
--- a/packages/webapp/src/ui/electron-overlay.ts
+++ b/packages/webapp/src/ui/electron-overlay.ts
@@ -19,8 +19,11 @@ import {
   shouldSnapElectronOverlayLauncher,
   toggleElectronOverlay,
 } from './overlay-shell-state.js';
-import { ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE } from './runtime-mode.js';
-import { EXTENSION_TAB_SPECS, type ExtensionTabId, normalizeExtensionTabId } from './tabbed-ui.js';
+import {
+  ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE,
+  ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE,
+} from './runtime-mode.js';
+import { type ExtensionTabId, normalizeExtensionTabId } from './tabbed-ui.js';
 
 export const ELECTRON_OVERLAY_HOST_ID = 'slicc-electron-overlay-root';
 export const ELECTRON_OVERLAY_TAG_NAME = 'slicc-electron-overlay';
@@ -434,7 +437,6 @@ class SliccElectronLauncherElement extends HTMLElement {
 class SliccElectronSidebarElement extends HTMLElement {
   static observedAttributes = ['open', 'active-tab', 'app-url', 'corner'];
 
-  private tabButtons = new Map<ExtensionTabId, HTMLButtonElement>();
   private iframe: HTMLIFrameElement | null = null;
   private emptyState: HTMLElement | null = null;
   private currentAppUrl = DEFAULT_APP_URL;
@@ -453,7 +455,6 @@ class SliccElectronSidebarElement extends HTMLElement {
   private render(): void {
     const root = this.attachShadow({ mode: 'open' });
     const doc = this.ownerDocument;
-    const activeTab = normalizeExtensionTabId(this.getAttribute('active-tab'));
 
     // Create style
     root.appendChild(
@@ -499,14 +500,6 @@ class SliccElectronSidebarElement extends HTMLElement {
         transform: translateY(calc(100% + 28px));
       }
       :host([open][corner="bottom"]) .sidebar { transform: translateY(0); }
-      .header { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 14px 16px 12px; border-bottom: 1px solid var(--s2-border-subtle); background: color-mix(in srgb, var(--s2-bg-layer-1) 92%, transparent); }
-      .header__brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
-      .header__title { font-size: 15px; font-weight: 700; letter-spacing: 0.01em; }
-      .header__subtitle { font-size: 11px; color: var(--s2-content-secondary); }
-      .header__close { appearance: none; border: 1px solid var(--s2-border-subtle); background: var(--s2-bg-layer-2); color: var(--s2-content-default); width: 32px; height: 32px; border-radius: 50%; cursor: pointer; font-size: 18px; line-height: 1; }
-      .tab-bar { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; padding: 12px 16px; border-bottom: 1px solid var(--s2-border-subtle); background: color-mix(in srgb, var(--s2-bg-layer-1) 96%, transparent); }
-      .tab-bar__tab { appearance: none; border: 1px solid var(--s2-border-subtle); border-radius: var(--s2-radius-default); background: var(--s2-bg-layer-2); color: var(--s2-content-secondary); padding: 9px 8px; font-size: 12px; font-weight: 600; cursor: pointer; transition: background var(--s2-transition-default), color var(--s2-transition-default), border-color var(--s2-transition-default); }
-      .tab-bar__tab--active { background: color-mix(in srgb, var(--s2-accent) 18%, var(--s2-bg-layer-2)); color: var(--s2-content-default); border-color: color-mix(in srgb, var(--s2-accent) 45%, var(--s2-border-default)); }
       .viewport { position: relative; flex: 1; min-height: 0; background: var(--s2-bg-sunken); }
       iframe { border: 0; width: 100%; height: 100%; display: block; background: var(--s2-bg-base); }
       .empty-state { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; padding: 24px; text-align: center; color: var(--s2-content-secondary); font-size: 13px; line-height: 1.5; }
@@ -524,69 +517,15 @@ class SliccElectronSidebarElement extends HTMLElement {
     });
     root.appendChild(backdrop);
 
-    // Create sidebar
+    // Create sidebar — the outer shell now renders only the iframe
+    // viewport. The header (brand + close) and tab-bar were removed
+    // when the inner app's thread header absorbed the close affordance
+    // (in electron-overlay mode it shows a close button left of the
+    // scoop switcher) and the right-side rail covers tab switching.
     const aside = doc.createElement('aside');
     aside.className = 'sidebar';
     aside.setAttribute('part', 'sidebar');
     aside.setAttribute('aria-label', 'SLICC overlay sidebar');
-
-    // Header
-    const header = doc.createElement('header');
-    header.className = 'header';
-
-    const brand = doc.createElement('div');
-    brand.className = 'header__brand';
-
-    const titleContainer = doc.createElement('div');
-    const title = doc.createElement('div');
-    title.className = 'header__title';
-    title.textContent = 'slicc';
-    const subtitle = doc.createElement('div');
-    subtitle.className = 'header__subtitle';
-    subtitle.textContent = 'electron float';
-    titleContainer.appendChild(title);
-    titleContainer.appendChild(subtitle);
-    brand.appendChild(titleContainer);
-    header.appendChild(brand);
-
-    const closeBtn = doc.createElement('button');
-    closeBtn.type = 'button';
-    closeBtn.className = 'header__close';
-    closeBtn.setAttribute('aria-label', 'Close SLICC overlay');
-    closeBtn.textContent = '×';
-    closeBtn.addEventListener('click', () => {
-      this.dispatchEvent(new CustomEvent('slicc-overlay-close', { bubbles: true, composed: true }));
-    });
-    header.appendChild(closeBtn);
-    aside.appendChild(header);
-
-    // Tab bar
-    const tabBar = doc.createElement('div');
-    tabBar.className = 'tab-bar';
-    tabBar.setAttribute('role', 'tablist');
-    tabBar.setAttribute('aria-label', 'SLICC overlay tabs');
-
-    for (const { id, label } of EXTENSION_TAB_SPECS) {
-      const tabBtn = doc.createElement('button');
-      tabBtn.type = 'button';
-      tabBtn.className = 'tab-bar__tab' + (id === activeTab ? ' tab-bar__tab--active' : '');
-      tabBtn.setAttribute('role', 'tab');
-      tabBtn.setAttribute('aria-selected', String(id === activeTab));
-      tabBtn.dataset.tab = id;
-      tabBtn.textContent = label;
-      this.tabButtons.set(id, tabBtn);
-      tabBtn.addEventListener('click', () => {
-        this.dispatchEvent(
-          new CustomEvent('slicc-overlay-select-tab', {
-            bubbles: true,
-            composed: true,
-            detail: { tab: id },
-          })
-        );
-      });
-      tabBar.appendChild(tabBtn);
-    }
-    aside.appendChild(tabBar);
 
     // Viewport
     const viewport = doc.createElement('div');
@@ -609,21 +548,11 @@ class SliccElectronSidebarElement extends HTMLElement {
 
     aside.appendChild(viewport);
     root.appendChild(aside);
-    this.iframe?.addEventListener('load', () => {
-      this.frameLoaded = true;
-      this.postActiveTab();
-    });
   }
 
   private sync(): void {
     const activeTab = normalizeExtensionTabId(this.getAttribute('active-tab'));
     const appUrl = this.getAttribute('app-url')?.trim() ?? DEFAULT_APP_URL;
-
-    for (const [tabId, button] of this.tabButtons) {
-      const active = tabId === activeTab;
-      button.classList.toggle('tab-bar__tab--active', active);
-      button.setAttribute('aria-selected', String(active));
-    }
 
     this.emptyState?.toggleAttribute('hidden', Boolean(appUrl));
     this.syncFrameUrl(appUrl, activeTab);
@@ -805,13 +734,14 @@ export class SliccElectronOverlayElement extends HTMLElement {
   };
 
   private onMessage = (event: MessageEvent): void => {
-    if (
-      event.data &&
-      typeof event.data === 'object' &&
-      'type' in event.data &&
-      (event.data as Record<string, unknown>).type === ELECTRON_OVERLAY_TOGGLE_MESSAGE_TYPE
-    ) {
+    if (!event.data || typeof event.data !== 'object' || !('type' in event.data)) return;
+    const type = (event.data as Record<string, unknown>).type;
+    if (type === ELECTRON_OVERLAY_TOGGLE_MESSAGE_TYPE) {
       this.toggle();
+      return;
+    }
+    if (type === ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE) {
+      this.hideSidebar();
     }
   };
 
@@ -849,15 +779,14 @@ export class SliccElectronOverlayElement extends HTMLElement {
     });
     root.appendChild(launcher);
 
-    // Create sidebar
+    // Create sidebar — the sidebar element no longer fires
+    // `slicc-overlay-select-tab` (the in-shell tab bar was removed
+    // when the inner app's rail absorbed tab switching) so only the
+    // `slicc-overlay-close` event (from the backdrop click) is wired.
     const sidebar = doc.createElement(
       ELECTRON_OVERLAY_SIDEBAR_TAG_NAME
     ) as SliccElectronSidebarElement;
     sidebar.addEventListener('slicc-overlay-close', () => this.hideSidebar());
-    sidebar.addEventListener('slicc-overlay-select-tab', (event: Event) => {
-      const tab = (event as CustomEvent<{ tab?: string }>).detail?.tab;
-      this.applyState(setElectronOverlayTab(this.state, tab));
-    });
     root.appendChild(sidebar);
   }
 

--- a/packages/webapp/src/ui/electron-overlay.ts
+++ b/packages/webapp/src/ui/electron-overlay.ts
@@ -735,6 +735,15 @@ export class SliccElectronOverlayElement extends HTMLElement {
 
   private onMessage = (event: MessageEvent): void => {
     if (!event.data || typeof event.data !== 'object' || !('type' in event.data)) return;
+    // Reject messages from the host window itself — only the embedded app
+    // iframe (or another foreign window) may drive toggle/close, never the
+    // page that hosts this overlay.
+    if (event.source === this.ownerDocument.defaultView) return;
+    // When appUrl is a valid absolute URL, require event.origin to match its
+    // origin. Empty / relative appUrl skips this check (no origin to compare
+    // against), but the source guard above still applies.
+    const expectedOrigin = this.parseAppOrigin();
+    if (expectedOrigin !== null && event.origin !== expectedOrigin) return;
     const type = (event.data as Record<string, unknown>).type;
     if (type === ELECTRON_OVERLAY_TOGGLE_MESSAGE_TYPE) {
       this.toggle();
@@ -744,6 +753,15 @@ export class SliccElectronOverlayElement extends HTMLElement {
       this.hideSidebar();
     }
   };
+
+  private parseAppOrigin(): string | null {
+    if (!this.appUrlValue) return null;
+    try {
+      return new URL(this.appUrlValue).origin;
+    } catch {
+      return null;
+    }
+  }
 
   private render(): void {
     const root = this.attachShadow({ mode: 'open' });

--- a/packages/webapp/src/ui/layout.ts
+++ b/packages/webapp/src/ui/layout.ts
@@ -131,6 +131,9 @@ export class Layout {
   private popoutClickHandler?: () => void;
   private detachedActiveOverlayEl?: HTMLDivElement;
 
+  // Electron-overlay close button (electron-overlay mode only)
+  private electronOverlayCloseBtnEl?: HTMLButtonElement;
+
   // User avatar element
   private avatarEl!: HTMLElement;
 
@@ -306,6 +309,40 @@ export class Layout {
     if (this.popoutButtonEl) {
       this.popoutButtonEl.disabled = false;
     }
+  }
+
+  /**
+   * Show/hide a close button in the thread header, positioned to the LEFT
+   * of the scoop switcher. Used ONLY in electron-overlay mode — clicking
+   * it posts a close message to the parent overlay shell which collapses
+   * the drawer to the launcher pill. Standalone and extension thread
+   * headers must not get this button.
+   */
+  setShowElectronOverlayClose(handler: (() => void) | null): void {
+    if (!handler) {
+      this.electronOverlayCloseBtnEl?.remove();
+      this.electronOverlayCloseBtnEl = undefined;
+      return;
+    }
+    if (this.electronOverlayCloseBtnEl) return;
+
+    const titleEl = this.threadHeaderEl?.querySelector(
+      '.thread-header__title'
+    ) as HTMLElement | null;
+    if (!titleEl) return;
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'thread-header__electron-overlay-close';
+    btn.title = 'Close SLICC';
+    btn.setAttribute('aria-label', 'Close SLICC');
+    btn.innerHTML =
+      '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>';
+    btn.addEventListener('click', () => handler());
+    // Insert at the very start of the title slot so the button lands to
+    // the LEFT of the scoop-switcher dropdown.
+    titleEl.insertBefore(btn, titleEl.firstChild);
+    this.electronOverlayCloseBtnEl = btn;
   }
 
   /**

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -112,6 +112,7 @@ import {
 import { createRemoteCdpPageBridge } from './remote-cdp-page-bridge.js';
 import { canonicalRuntimeId } from './runtime-identity.js';
 import {
+  ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE,
   getElectronOverlayInitialTab,
   isElectronOverlaySetTabMessage,
   resolveUiRuntimeMode,
@@ -1902,12 +1903,18 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
   if (isElectronOverlay) {
     // Electron-overlay specifics: hide the tab-bar (Electron's chrome
     // has its own), set the initial tab from the URL hash, listen for
-    // parent-frame `set-tab` messages, and bind ⌘; (Cmd-+-Semicolon)
-    // to toggle the overlay window. Ported from the legacy inline
-    // path so the worker mode handles overlay correctly when it's
-    // the only standalone path.
+    // parent-frame `set-tab` messages, mount a close button in the
+    // inner thread header (left of the scoop switcher) that posts a
+    // close message to the parent overlay shell, and bind ⌘;
+    // (Cmd-+-Semicolon) to toggle the overlay window. Ported from the
+    // legacy inline path so the worker mode handles overlay correctly
+    // when it's the only standalone path.
     const initialTab = getElectronOverlayInitialTab(window.location.href);
     layout.setActiveTab(initialTab);
+
+    layout.setShowElectronOverlayClose(() => {
+      window.parent.postMessage({ type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE }, '*');
+    });
 
     const runtimeStyle = document.createElement('style');
     runtimeStyle.id = 'slicc-electron-overlay-runtime-style';

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -1912,9 +1912,17 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
     const initialTab = getElectronOverlayInitialTab(window.location.href);
     layout.setActiveTab(initialTab);
 
-    layout.setShowElectronOverlayClose(() => {
-      window.parent.postMessage({ type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE }, '*');
-    });
+    // Only mount the close button when actually embedded in a parent frame
+    // (the overlay shell). When `/electron` is opened top-level, posting a
+    // close message to `window.parent` would target the page itself and
+    // close nothing — render no button instead of a dead control.
+    if (window.parent !== window) {
+      layout.setShowElectronOverlayClose(() => {
+        window.parent.postMessage({ type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE }, '*');
+      });
+    } else {
+      layout.setShowElectronOverlayClose(null);
+    }
 
     const runtimeStyle = document.createElement('style');
     runtimeStyle.id = 'slicc-electron-overlay-runtime-style';

--- a/packages/webapp/src/ui/runtime-mode.ts
+++ b/packages/webapp/src/ui/runtime-mode.ts
@@ -21,6 +21,7 @@ export const ELECTRON_OVERLAY_RUNTIME_QUERY_VALUE = 'electron-overlay';
 export const HOSTED_LEADER_RUNTIME_QUERY_VALUE = 'hosted-leader';
 export const ELECTRON_OVERLAY_RUNTIME_PATH = '/electron';
 export const ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE = 'slicc-electron-overlay:set-tab';
+export const ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE = 'slicc-electron-overlay:close';
 // Re-export shared detached-runtime constants from chrome-extension/messages.ts
 // so panel-side code (resolveUiRuntimeMode) and SW-side code share the same
 // source of truth.
@@ -32,6 +33,10 @@ export {
 export interface ElectronOverlaySetTabMessage {
   type: typeof ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE;
   tab?: string;
+}
+
+export interface ElectronOverlayCloseMessage {
+  type: typeof ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE;
 }
 
 export function resolveUiRuntimeMode(locationHref: string, isExtension: boolean): UiRuntimeMode {
@@ -120,5 +125,16 @@ export function isElectronOverlaySetTabMessage(
     value !== null &&
     'type' in value &&
     (value as Record<string, unknown>).type === ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE
+  );
+}
+
+export function isElectronOverlayCloseMessage(
+  value: unknown
+): value is ElectronOverlayCloseMessage {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    (value as Record<string, unknown>).type === ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE
   );
 }

--- a/packages/webapp/src/ui/styles/layout.css
+++ b/packages/webapp/src/ui/styles/layout.css
@@ -148,6 +148,34 @@
   flex-shrink: 0;
 }
 
+/* Close-overlay button (electron-overlay mode only) — sits at the
+   leftmost edge of the thread header's title slot, to the LEFT of the
+   scoop-switcher dropdown. Posts a close message to the parent shell
+   which collapses the overlay drawer to the launcher pill. */
+.thread-header__electron-overlay-close {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  margin-right: 4px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--s2-content-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background var(--s2-transition-default),
+    color var(--s2-transition-default);
+}
+.thread-header__electron-overlay-close:hover {
+  background: var(--s2-bg-layer-2);
+  color: var(--s2-content-default);
+}
+
 /* Extension mode: the thread header hosts the scoop-switcher
    dropdown in place of the static chat icon + scoop name. The
    dropdown sets its own internal styles so we just need to make

--- a/packages/webapp/tests/ui/electron-overlay-element.test.ts
+++ b/packages/webapp/tests/ui/electron-overlay-element.test.ts
@@ -1,0 +1,933 @@
+// @vitest-environment jsdom
+/**
+ * Comprehensive coverage tests for `electron-overlay.ts` — exercises the
+ * three custom elements (launcher, sidebar, overlay shell) plus the
+ * inject/remove/persist helpers. Pure DOM / jsdom; no network or fetch.
+ *
+ * The element registrations are global to `customElements`, so each test
+ * relies on `registerElectronOverlayElements` being idempotent.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ELECTRON_OVERLAY_HOST_ID,
+  ELECTRON_OVERLAY_TAG_NAME,
+  ELECTRON_OVERLAY_TOGGLE_MESSAGE_TYPE,
+  ELECTRON_OVERLAY_TOGGLE_SHORTCUT_CODE,
+  injectElectronOverlayShell,
+  registerElectronOverlayElements,
+  removeElectronOverlayShell,
+  type SliccElectronOverlayElement,
+} from '../../src/ui/electron-overlay.js';
+import {
+  ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE,
+  ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE,
+} from '../../src/ui/runtime-mode.js';
+
+const LAUNCHER_TAG = 'slicc-electron-launcher';
+const SIDEBAR_TAG = 'slicc-electron-sidebar';
+const STORAGE_KEY = 'slicc-electron-overlay-launcher-corner';
+
+// Map-backed localStorage stub. The webapp vitest project does not provide
+// a writable jsdom localStorage out of the box (see api-key-dialog.test.ts
+// for the same pattern); install one before every test so the persisted-
+// corner branches in `electron-overlay.ts` get exercised.
+const storage = new Map<string, string>();
+const mockStorage = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storage.set(key, value);
+  },
+  removeItem: (key: string) => {
+    storage.delete(key);
+  },
+  clear: () => storage.clear(),
+  get length() {
+    return storage.size;
+  },
+  key: (_i: number) => null,
+};
+
+function installMockStorage(): void {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: mockStorage,
+  });
+}
+
+function dispatchMessage(detail: {
+  data: unknown;
+  source?: MessageEventSource | null;
+  origin?: string;
+}): void {
+  const event = new MessageEvent('message', {
+    data: detail.data,
+    source: detail.source ?? null,
+    origin: detail.origin ?? '',
+  });
+  window.dispatchEvent(event);
+}
+
+function makePointerEvent(
+  type: string,
+  init: {
+    pointerId?: number;
+    clientX?: number;
+    clientY?: number;
+    button?: number;
+    isPrimary?: boolean;
+    timeStamp?: number;
+  } = {}
+): PointerEvent {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as PointerEvent;
+  Object.defineProperty(event, 'pointerId', { value: init.pointerId ?? 1, configurable: true });
+  Object.defineProperty(event, 'clientX', { value: init.clientX ?? 0, configurable: true });
+  Object.defineProperty(event, 'clientY', { value: init.clientY ?? 0, configurable: true });
+  Object.defineProperty(event, 'button', { value: init.button ?? 0, configurable: true });
+  Object.defineProperty(event, 'isPrimary', {
+    value: init.isPrimary ?? true,
+    configurable: true,
+  });
+  if (init.timeStamp !== undefined) {
+    Object.defineProperty(event, 'timeStamp', { value: init.timeStamp, configurable: true });
+  }
+  return event;
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  installMockStorage();
+  storage.clear();
+  registerElectronOverlayElements();
+});
+
+describe('registerElectronOverlayElements', () => {
+  it('is idempotent — re-registering does not throw', () => {
+    expect(() => registerElectronOverlayElements()).not.toThrow();
+    expect(() => registerElectronOverlayElements()).not.toThrow();
+    expect(customElements.get(ELECTRON_OVERLAY_TAG_NAME)).toBeDefined();
+    expect(customElements.get(LAUNCHER_TAG)).toBeDefined();
+    expect(customElements.get(SIDEBAR_TAG)).toBeDefined();
+  });
+});
+
+describe('injectElectronOverlayShell', () => {
+  it('creates and mounts a fresh overlay element under document.body', () => {
+    const overlay = injectElectronOverlayShell();
+    expect(overlay.tagName.toLowerCase()).toBe(ELECTRON_OVERLAY_TAG_NAME);
+    expect(overlay.id).toBe(ELECTRON_OVERLAY_HOST_ID);
+    expect(document.body.contains(overlay)).toBe(true);
+  });
+
+  it('reuses an existing overlay element with the same id', () => {
+    const a = injectElectronOverlayShell();
+    const b = injectElectronOverlayShell();
+    expect(b).toBe(a);
+    expect(document.querySelectorAll(`#${ELECTRON_OVERLAY_HOST_ID}`)).toHaveLength(1);
+  });
+
+  it('replaces a non-overlay element that already owns the host id', () => {
+    const stale = document.createElement('div');
+    stale.id = ELECTRON_OVERLAY_HOST_ID;
+    document.body.appendChild(stale);
+
+    const overlay = injectElectronOverlayShell();
+    expect(overlay).not.toBe(stale as unknown);
+    expect(document.body.contains(stale)).toBe(false);
+    expect(document.body.contains(overlay)).toBe(true);
+  });
+
+  it('applies all options atomically on first inject', () => {
+    const overlay = injectElectronOverlayShell(document, {
+      open: true,
+      activeTab: 'files',
+      appUrl: 'https://app.example.com/electron',
+      corner: 'bottom-left',
+    });
+    expect(overlay.open).toBe(true);
+    expect(overlay.activeTab).toBe('files');
+    expect(overlay.appUrl).toBe('https://app.example.com/electron');
+    expect(overlay.corner).toBe('bottom-left');
+  });
+
+  it('honours boolean false for `open` and clears appUrl when given null', () => {
+    const overlay = injectElectronOverlayShell(document, {
+      open: true,
+      appUrl: 'https://app.example.com/electron',
+    });
+    expect(overlay.open).toBe(true);
+    injectElectronOverlayShell(document, { open: false, appUrl: null });
+    expect(overlay.open).toBe(false);
+    expect(overlay.appUrl).toBe('');
+  });
+
+  it('falls back to the persisted corner when `corner: null` is supplied', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'bottom-right');
+    const overlay = injectElectronOverlayShell(document, { corner: null });
+    expect(overlay.corner).toBe('bottom-right');
+  });
+
+  it('skips options it was not given (no over-eager attribute writes)', () => {
+    const overlay = injectElectronOverlayShell(document, { open: true });
+    expect(overlay.open).toBe(true);
+    // No activeTab / appUrl / corner option → defaults stay in place.
+    expect(overlay.activeTab).toBe('chat');
+    expect(overlay.appUrl).toBe('');
+  });
+
+  it('falls back to documentElement when body is missing', () => {
+    const doc = document.implementation.createHTMLDocument('headless');
+    doc.body.remove();
+    expect(doc.body).toBeNull();
+    const overlay = injectElectronOverlayShell(doc);
+    expect(doc.documentElement.contains(overlay)).toBe(true);
+  });
+});
+
+describe('removeElectronOverlayShell', () => {
+  it('removes a mounted overlay', () => {
+    injectElectronOverlayShell();
+    expect(document.getElementById(ELECTRON_OVERLAY_HOST_ID)).not.toBeNull();
+    removeElectronOverlayShell();
+    expect(document.getElementById(ELECTRON_OVERLAY_HOST_ID)).toBeNull();
+  });
+
+  it('is a no-op when no overlay exists', () => {
+    expect(() => removeElectronOverlayShell()).not.toThrow();
+  });
+});
+
+describe('SliccElectronOverlayElement — lifecycle + setters', () => {
+  function mount(attrs: Record<string, string> = {}): SliccElectronOverlayElement {
+    const overlay = document.createElement(
+      ELECTRON_OVERLAY_TAG_NAME
+    ) as SliccElectronOverlayElement;
+    for (const [k, v] of Object.entries(attrs)) overlay.setAttribute(k, v);
+    document.body.appendChild(overlay);
+    return overlay;
+  }
+
+  it('reads initial state from attributes on connect', () => {
+    const overlay = mount({
+      open: '',
+      'active-tab': 'memory',
+      'app-url': 'https://app.example.com/x',
+      corner: 'top-left',
+    });
+    expect(overlay.open).toBe(true);
+    expect(overlay.activeTab).toBe('memory');
+    expect(overlay.appUrl).toBe('https://app.example.com/x');
+    expect(overlay.corner).toBe('top-left');
+  });
+
+  it('persists the corner on connect and on every state change', () => {
+    const overlay = mount({ corner: 'bottom-right' });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('bottom-right');
+    overlay.corner = 'top-left';
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('top-left');
+  });
+
+  it('open/showSidebar/hideSidebar/toggle update state and DOM attribute', () => {
+    const overlay = mount();
+    expect(overlay.open).toBe(false);
+    overlay.toggle();
+    expect(overlay.open).toBe(true);
+    expect(overlay.hasAttribute('open')).toBe(true);
+    overlay.hideSidebar();
+    expect(overlay.open).toBe(false);
+    overlay.showSidebar();
+    expect(overlay.open).toBe(true);
+    overlay.open = false;
+    expect(overlay.open).toBe(false);
+  });
+
+  it('activeTab setter is a no-op when value is unchanged', () => {
+    const overlay = mount({ 'active-tab': 'files' });
+    overlay.activeTab = 'files';
+    expect(overlay.activeTab).toBe('files');
+    overlay.activeTab = 'memory';
+    expect(overlay.activeTab).toBe('memory');
+    expect(overlay.getAttribute('active-tab')).toBe('memory');
+  });
+
+  it('corner setter updates state + DOM and persists', () => {
+    const overlay = mount();
+    overlay.corner = 'bottom-left';
+    expect(overlay.corner).toBe('bottom-left');
+    expect(overlay.getAttribute('corner')).toBe('bottom-left');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('bottom-left');
+  });
+
+  it('appUrl setter writes attribute, clears it when emptied, and is no-op on no-change', () => {
+    const overlay = mount();
+    overlay.appUrl = 'https://app.example.com/electron';
+    expect(overlay.appUrl).toBe('https://app.example.com/electron');
+    expect(overlay.getAttribute('app-url')).toBe('https://app.example.com/electron');
+    // Same value → setter returns early (must not throw or duplicate attribute writes).
+    overlay.appUrl = 'https://app.example.com/electron';
+    expect(overlay.getAttribute('app-url')).toBe('https://app.example.com/electron');
+    overlay.appUrl = '';
+    expect(overlay.appUrl).toBe('');
+    expect(overlay.hasAttribute('app-url')).toBe(false);
+  });
+
+  it('attributeChangedCallback re-derives state from attributes', () => {
+    const overlay = mount();
+    overlay.setAttribute('open', '');
+    overlay.setAttribute('active-tab', 'terminal');
+    overlay.setAttribute('corner', 'top-left');
+    overlay.setAttribute('app-url', 'https://app.example.com/y');
+    expect(overlay.open).toBe(true);
+    expect(overlay.activeTab).toBe('terminal');
+    expect(overlay.corner).toBe('top-left');
+    expect(overlay.appUrl).toBe('https://app.example.com/y');
+  });
+
+  it('disconnectedCallback removes keydown and message listeners', () => {
+    const overlay = mount();
+    overlay.remove();
+    // After disconnect, posting a close message must NOT change the saved state
+    // (state remains whatever it was; we just prove there is no throw).
+    expect(() => {
+      window.postMessage({ type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE }, '*');
+    }).not.toThrow();
+  });
+});
+
+describe('SliccElectronOverlayElement — keyboard shortcuts', () => {
+  function mount(open = false): SliccElectronOverlayElement {
+    const overlay = document.createElement(
+      ELECTRON_OVERLAY_TAG_NAME
+    ) as SliccElectronOverlayElement;
+    if (open) overlay.setAttribute('open', '');
+    document.body.appendChild(overlay);
+    return overlay;
+  }
+
+  it('toggles when meta+; is pressed', () => {
+    const overlay = mount();
+    const event = new KeyboardEvent('keydown', {
+      key: ';',
+      code: ELECTRON_OVERLAY_TOGGLE_SHORTCUT_CODE,
+      metaKey: true,
+      bubbles: true,
+    });
+    document.dispatchEvent(event);
+    expect(overlay.open).toBe(true);
+  });
+
+  it('toggles when ctrl+; is pressed (non-mac browsers)', () => {
+    const overlay = mount();
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: ';',
+        code: ELECTRON_OVERLAY_TOGGLE_SHORTCUT_CODE,
+        ctrlKey: true,
+        bubbles: true,
+      })
+    );
+    expect(overlay.open).toBe(true);
+  });
+
+  it('does NOT toggle when the modifier is missing', () => {
+    const overlay = mount();
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: ';',
+        code: ELECTRON_OVERLAY_TOGGLE_SHORTCUT_CODE,
+        bubbles: true,
+      })
+    );
+    expect(overlay.open).toBe(false);
+  });
+
+  it('does NOT toggle when shift or alt is pressed alongside the shortcut', () => {
+    const overlay = mount();
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: ';',
+        code: ELECTRON_OVERLAY_TOGGLE_SHORTCUT_CODE,
+        metaKey: true,
+        shiftKey: true,
+        bubbles: true,
+      })
+    );
+    expect(overlay.open).toBe(false);
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: ';',
+        code: ELECTRON_OVERLAY_TOGGLE_SHORTCUT_CODE,
+        metaKey: true,
+        altKey: true,
+        bubbles: true,
+      })
+    );
+    expect(overlay.open).toBe(false);
+  });
+
+  it('ignores repeated keydown events (autorepeat is filtered out)', () => {
+    const overlay = mount();
+    const event = new KeyboardEvent('keydown', {
+      key: ';',
+      code: ELECTRON_OVERLAY_TOGGLE_SHORTCUT_CODE,
+      metaKey: true,
+      repeat: true,
+      bubbles: true,
+    });
+    document.dispatchEvent(event);
+    expect(overlay.open).toBe(false);
+  });
+
+  it('closes the sidebar on Escape when open, and is a no-op when closed', () => {
+    const overlay = mount(true);
+    expect(overlay.open).toBe(true);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(overlay.open).toBe(false);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(overlay.open).toBe(false);
+  });
+});
+
+describe('SliccElectronOverlayElement — message handling', () => {
+  function mount(opts: { open?: boolean; appUrl?: string } = {}): SliccElectronOverlayElement {
+    const overlay = document.createElement(
+      ELECTRON_OVERLAY_TAG_NAME
+    ) as SliccElectronOverlayElement;
+    if (opts.open) overlay.setAttribute('open', '');
+    if (opts.appUrl !== undefined) overlay.setAttribute('app-url', opts.appUrl);
+    document.body.appendChild(overlay);
+    return overlay;
+  }
+
+  const foreignSource = { postMessage: () => {} } as unknown as MessageEventSource;
+
+  it('toggles on a valid toggle message from a foreign source', () => {
+    const overlay = mount();
+    dispatchMessage({
+      data: { type: ELECTRON_OVERLAY_TOGGLE_MESSAGE_TYPE },
+      source: foreignSource,
+      origin: 'https://anywhere.example.com',
+    });
+    expect(overlay.open).toBe(true);
+  });
+
+  it('closes on a valid close message from a foreign source', () => {
+    const overlay = mount({ open: true });
+    dispatchMessage({
+      data: { type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE },
+      source: foreignSource,
+      origin: 'anywhere',
+    });
+    expect(overlay.open).toBe(false);
+  });
+
+  it('rejects malformed payloads (non-object, missing type)', () => {
+    const overlay = mount({ open: true });
+    dispatchMessage({ data: null, source: foreignSource });
+    dispatchMessage({ data: 'string', source: foreignSource });
+    dispatchMessage({ data: {}, source: foreignSource });
+    expect(overlay.open).toBe(true);
+  });
+
+  it('ignores unknown message types', () => {
+    const overlay = mount({ open: true });
+    dispatchMessage({
+      data: { type: 'something-unrelated' },
+      source: foreignSource,
+      origin: 'x',
+    });
+    expect(overlay.open).toBe(true);
+  });
+
+  it('rejects messages with mismatched origin when appUrl is absolute', () => {
+    const overlay = mount({ open: true, appUrl: 'https://app.example.com/electron' });
+    dispatchMessage({
+      data: { type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE },
+      source: foreignSource,
+      origin: 'https://evil.example.com',
+    });
+    expect(overlay.open).toBe(true);
+  });
+
+  it('accepts messages with matching origin when appUrl is absolute', () => {
+    const overlay = mount({ open: true, appUrl: 'https://app.example.com/electron' });
+    dispatchMessage({
+      data: { type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE },
+      source: foreignSource,
+      origin: 'https://app.example.com',
+    });
+    expect(overlay.open).toBe(false);
+  });
+
+  it('skips origin validation when appUrl is unparseable (relative)', () => {
+    const overlay = mount({ open: true, appUrl: '/electron' });
+    dispatchMessage({
+      data: { type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE },
+      source: foreignSource,
+      origin: 'https://anywhere.example.com',
+    });
+    expect(overlay.open).toBe(false);
+  });
+});
+
+describe('SliccElectronOverlayElement — children + slot wiring', () => {
+  it('renders a launcher and a sidebar in the shadow root', () => {
+    const overlay = injectElectronOverlayShell(document, {
+      appUrl: 'https://app.example.com/electron',
+      open: true,
+      corner: 'top-right',
+      activeTab: 'memory',
+    });
+    const root = overlay.shadowRoot!;
+    const launcher = root.querySelector(LAUNCHER_TAG)!;
+    const sidebar = root.querySelector(SIDEBAR_TAG)!;
+    expect(launcher).not.toBeNull();
+    expect(sidebar).not.toBeNull();
+    expect(launcher.hasAttribute('open')).toBe(true);
+    expect(launcher.getAttribute('corner')).toBe('top-right');
+    expect(sidebar.hasAttribute('open')).toBe(true);
+    expect(sidebar.getAttribute('corner')).toBe('top-right');
+    expect(sidebar.getAttribute('active-tab')).toBe('memory');
+    expect(sidebar.getAttribute('app-url')).toBe('https://app.example.com/electron');
+  });
+
+  it('clears the sidebar app-url attribute when appUrl is empty', () => {
+    const overlay = injectElectronOverlayShell(document, {
+      appUrl: 'https://app.example.com/electron',
+    });
+    overlay.appUrl = '';
+    const sidebar = overlay.shadowRoot!.querySelector(SIDEBAR_TAG)!;
+    expect(sidebar.hasAttribute('app-url')).toBe(false);
+  });
+
+  it('toggles via the launcher click event', () => {
+    const overlay = injectElectronOverlayShell(document);
+    expect(overlay.open).toBe(false);
+    const launcher = overlay.shadowRoot!.querySelector(LAUNCHER_TAG) as HTMLElement;
+    launcher.dispatchEvent(
+      new CustomEvent('slicc-overlay-toggle', { bubbles: true, composed: true })
+    );
+    expect(overlay.open).toBe(true);
+  });
+
+  it('updates corner via the launcher move event', () => {
+    const overlay = injectElectronOverlayShell(document, { corner: 'top-right' });
+    const launcher = overlay.shadowRoot!.querySelector(LAUNCHER_TAG) as HTMLElement;
+    launcher.dispatchEvent(
+      new CustomEvent<{ corner: string }>('slicc-overlay-move', {
+        bubbles: true,
+        composed: true,
+        detail: { corner: 'bottom-left' },
+      })
+    );
+    expect(overlay.corner).toBe('bottom-left');
+  });
+
+  it('closes when the sidebar fires its close event', () => {
+    const overlay = injectElectronOverlayShell(document, { open: true });
+    const sidebar = overlay.shadowRoot!.querySelector(SIDEBAR_TAG) as HTMLElement;
+    sidebar.dispatchEvent(
+      new CustomEvent('slicc-overlay-close', { bubbles: true, composed: true })
+    );
+    expect(overlay.open).toBe(false);
+  });
+});
+
+describe('SliccElectronSidebarElement — iframe wiring', () => {
+  it('renders an iframe with no src when appUrl is empty', () => {
+    const overlay = injectElectronOverlayShell();
+    const sidebar = overlay.shadowRoot!.querySelector(SIDEBAR_TAG)!;
+    const iframe = sidebar.shadowRoot!.querySelector('iframe')!;
+    expect(iframe).not.toBeNull();
+    expect(iframe.hasAttribute('src')).toBe(false);
+  });
+
+  it('points the iframe at appUrl with the active tab query parameter', () => {
+    const overlay = injectElectronOverlayShell(document, {
+      appUrl: 'https://app.example.com/electron',
+      activeTab: 'files',
+    });
+    const sidebar = overlay.shadowRoot!.querySelector(SIDEBAR_TAG)!;
+    const iframe = sidebar.shadowRoot!.querySelector('iframe')!;
+    const src = iframe.getAttribute('src') ?? '';
+    expect(src.startsWith('https://app.example.com/electron')).toBe(true);
+    expect(src).toContain('tab=files');
+  });
+
+  it('clears the iframe src when appUrl is removed', () => {
+    const overlay = injectElectronOverlayShell(document, {
+      appUrl: 'https://app.example.com/electron',
+    });
+    const sidebar = overlay.shadowRoot!.querySelector(SIDEBAR_TAG)!;
+    const iframe = sidebar.shadowRoot!.querySelector('iframe')!;
+    expect(iframe.hasAttribute('src')).toBe(true);
+    overlay.appUrl = '';
+    expect(iframe.hasAttribute('src')).toBe(false);
+  });
+
+  it('hides the empty-state when appUrl is non-empty', () => {
+    const overlay = injectElectronOverlayShell(document, {
+      appUrl: 'https://app.example.com/electron',
+    });
+    const sidebar = overlay.shadowRoot!.querySelector(SIDEBAR_TAG)!;
+    const empty = sidebar.shadowRoot!.querySelector('.empty-state')!;
+    expect(empty.hasAttribute('hidden')).toBe(true);
+  });
+
+  it('shows the empty-state when appUrl is empty', () => {
+    const overlay = injectElectronOverlayShell();
+    const sidebar = overlay.shadowRoot!.querySelector(SIDEBAR_TAG)!;
+    const empty = sidebar.shadowRoot!.querySelector('.empty-state')!;
+    expect(empty.hasAttribute('hidden')).toBe(false);
+  });
+
+  it('posts the active tab to the iframe on load and dedupes repeat posts', () => {
+    const overlay = injectElectronOverlayShell(document, {
+      appUrl: 'https://app.example.com/electron',
+      activeTab: 'files',
+    });
+    const sidebar = overlay.shadowRoot!.querySelector(SIDEBAR_TAG)!;
+    const iframe = sidebar.shadowRoot!.querySelector('iframe')!;
+    // Stub contentWindow.postMessage; jsdom does not actually navigate iframes.
+    const postMessage = vi.fn();
+    Object.defineProperty(iframe, 'contentWindow', {
+      configurable: true,
+      get: () => ({ postMessage }),
+    });
+    // Fire the load event the production code listens for.
+    iframe.dispatchEvent(new Event('load'));
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE, tab: 'files' }),
+      '*'
+    );
+    // sync() re-runs on attributeChangedCallback. Same tab → no extra post.
+    postMessage.mockClear();
+    sidebar.setAttribute('active-tab', 'files');
+    expect(postMessage).not.toHaveBeenCalled();
+    // Different tab → posts the new tab.
+    sidebar.setAttribute('active-tab', 'memory');
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE, tab: 'memory' }),
+      '*'
+    );
+  });
+
+  it('routes backdrop clicks to slicc-overlay-close', () => {
+    const overlay = injectElectronOverlayShell(document, { open: true });
+    const sidebar = overlay.shadowRoot!.querySelector(SIDEBAR_TAG)!;
+    const backdrop = sidebar.shadowRoot!.querySelector('.backdrop') as HTMLElement;
+    backdrop.click();
+    expect(overlay.open).toBe(false);
+  });
+});
+
+describe('SliccElectronLauncherElement — render + click flows', () => {
+  it('renders a button with shortcut hint in the title and aria-pressed reflects open state', () => {
+    const overlay = injectElectronOverlayShell(document, { open: true });
+    const launcher = overlay.shadowRoot!.querySelector(LAUNCHER_TAG)!;
+    const button = launcher.shadowRoot!.querySelector('button')!;
+    expect(button).not.toBeNull();
+    expect(button.title).toMatch(/Toggle SLICC/);
+    expect(button.title).toContain(';');
+    expect(button.getAttribute('aria-pressed')).toBe('true');
+    expect(button.getAttribute('aria-label')).toBe('Toggle SLICC overlay');
+    // Both monochrome logo variants are embedded so CSS can pick.
+    expect(launcher.shadowRoot!.querySelectorAll('.logo-icon')).toHaveLength(2);
+  });
+
+  it('emits slicc-overlay-toggle on a normal button click', () => {
+    const overlay = injectElectronOverlayShell();
+    const launcher = overlay.shadowRoot!.querySelector(LAUNCHER_TAG)!;
+    const button = launcher.shadowRoot!.querySelector('button')!;
+    const listener = vi.fn();
+    launcher.addEventListener('slicc-overlay-toggle', listener);
+    button.click();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SliccElectronLauncherElement — pointer drag + snap', () => {
+  function mountLauncher(): {
+    overlay: SliccElectronOverlayElement;
+    launcher: HTMLElement;
+    button: HTMLButtonElement;
+  } {
+    const overlay = injectElectronOverlayShell();
+    const launcher = overlay.shadowRoot!.querySelector(LAUNCHER_TAG) as HTMLElement;
+    const button = launcher.shadowRoot!.querySelector('button') as HTMLButtonElement;
+    // jsdom does not implement setPointerCapture / releasePointerCapture / hasPointerCapture;
+    // stub them so the production code can call through without throwing.
+    const captured = new Set<number>();
+    button.setPointerCapture = (id: number) => {
+      captured.add(id);
+    };
+    button.releasePointerCapture = (id: number) => {
+      captured.delete(id);
+    };
+    button.hasPointerCapture = (id: number) => captured.has(id);
+    Object.defineProperty(launcher, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        left: 100,
+        top: 100,
+        right: 144,
+        bottom: 144,
+        width: 44,
+        height: 44,
+        x: 100,
+        y: 100,
+        toJSON: () => ({}),
+      }),
+    });
+    return { overlay, launcher, button };
+  }
+
+  it('ignores secondary-button and non-primary pointerdowns', () => {
+    const { launcher, button } = mountLauncher();
+    button.dispatchEvent(
+      makePointerEvent('pointerdown', { pointerId: 5, button: 2, isPrimary: true })
+    );
+    button.dispatchEvent(
+      makePointerEvent('pointerdown', { pointerId: 5, button: 0, isPrimary: false })
+    );
+    // No drag attribute should land.
+    expect(launcher.hasAttribute('dragging')).toBe(false);
+  });
+
+  it('starts dragging after the threshold is exceeded and updates inline position', () => {
+    const { launcher, button } = mountLauncher();
+    button.dispatchEvent(
+      makePointerEvent('pointerdown', {
+        pointerId: 7,
+        clientX: 100,
+        clientY: 100,
+        timeStamp: 0,
+      })
+    );
+    // Below threshold first.
+    button.dispatchEvent(
+      makePointerEvent('pointermove', {
+        pointerId: 7,
+        clientX: 102,
+        clientY: 101,
+        timeStamp: 16,
+      })
+    );
+    expect(launcher.hasAttribute('dragging')).toBe(false);
+
+    // Above threshold (snap threshold is 8px).
+    button.dispatchEvent(
+      makePointerEvent('pointermove', {
+        pointerId: 7,
+        clientX: 200,
+        clientY: 240,
+        timeStamp: 64,
+      })
+    );
+    expect(launcher.hasAttribute('dragging')).toBe(true);
+    // The launcher's left/top inline styles should have been updated.
+    expect(launcher.style.left).not.toBe('');
+    expect(launcher.style.top).not.toBe('');
+  });
+
+  it('drops drag-state and emits slicc-overlay-move on pointerup past threshold', () => {
+    const { overlay, launcher, button } = mountLauncher();
+    const cornerListener = vi.fn();
+    launcher.addEventListener('slicc-overlay-move', cornerListener);
+    button.dispatchEvent(
+      makePointerEvent('pointerdown', {
+        pointerId: 9,
+        clientX: 100,
+        clientY: 100,
+        timeStamp: 0,
+      })
+    );
+    button.dispatchEvent(
+      makePointerEvent('pointermove', {
+        pointerId: 9,
+        clientX: 400,
+        clientY: 500,
+        timeStamp: 50,
+      })
+    );
+    button.dispatchEvent(
+      makePointerEvent('pointerup', {
+        pointerId: 9,
+        clientX: 400,
+        clientY: 500,
+        timeStamp: 60,
+      })
+    );
+    expect(launcher.hasAttribute('dragging')).toBe(false);
+    expect(cornerListener).toHaveBeenCalledTimes(1);
+    // applyState should have run with the new corner. Just check that the
+    // overlay corner is now one of the resolved corner values.
+    expect([
+      'top-left',
+      'top-right',
+      'bottom-left',
+      'bottom-right',
+      'top',
+      'bottom',
+      'left',
+      'right',
+    ]).toContain(overlay.corner);
+  });
+
+  it('suppresses the immediately-following click when a drag occurred', () => {
+    const { launcher, button } = mountLauncher();
+    const toggleListener = vi.fn();
+    launcher.addEventListener('slicc-overlay-toggle', toggleListener);
+    button.dispatchEvent(
+      makePointerEvent('pointerdown', {
+        pointerId: 11,
+        clientX: 100,
+        clientY: 100,
+        timeStamp: 0,
+      })
+    );
+    button.dispatchEvent(
+      makePointerEvent('pointermove', {
+        pointerId: 11,
+        clientX: 400,
+        clientY: 500,
+        timeStamp: 50,
+      })
+    );
+    button.dispatchEvent(
+      makePointerEvent('pointerup', {
+        pointerId: 11,
+        clientX: 400,
+        clientY: 500,
+        timeStamp: 60,
+      })
+    );
+    button.click();
+    expect(toggleListener).not.toHaveBeenCalled();
+    // A subsequent normal click should pass through.
+    button.click();
+    expect(toggleListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('pointercancel resets drag state without snapping', () => {
+    const { launcher, button } = mountLauncher();
+    const moveListener = vi.fn();
+    launcher.addEventListener('slicc-overlay-move', moveListener);
+    button.dispatchEvent(
+      makePointerEvent('pointerdown', {
+        pointerId: 13,
+        clientX: 100,
+        clientY: 100,
+        timeStamp: 0,
+      })
+    );
+    button.dispatchEvent(
+      makePointerEvent('pointermove', {
+        pointerId: 13,
+        clientX: 400,
+        clientY: 500,
+        timeStamp: 50,
+      })
+    );
+    button.dispatchEvent(
+      makePointerEvent('pointercancel', {
+        pointerId: 13,
+        clientX: 400,
+        clientY: 500,
+        timeStamp: 60,
+      })
+    );
+    expect(launcher.hasAttribute('dragging')).toBe(false);
+    expect(moveListener).not.toHaveBeenCalled();
+  });
+
+  it('ignores pointer events with mismatched pointerId', () => {
+    const { launcher, button } = mountLauncher();
+    button.dispatchEvent(
+      makePointerEvent('pointerdown', {
+        pointerId: 15,
+        clientX: 100,
+        clientY: 100,
+        timeStamp: 0,
+      })
+    );
+    // Different pointerId — must be ignored.
+    button.dispatchEvent(
+      makePointerEvent('pointermove', {
+        pointerId: 99,
+        clientX: 400,
+        clientY: 500,
+        timeStamp: 50,
+      })
+    );
+    button.dispatchEvent(
+      makePointerEvent('pointerup', {
+        pointerId: 99,
+        clientX: 400,
+        clientY: 500,
+        timeStamp: 60,
+      })
+    );
+    expect(launcher.hasAttribute('dragging')).toBe(false);
+  });
+});
+
+describe('localStorage persistence helpers', () => {
+  it('roundtrips the corner through localStorage on connect/disconnect', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'bottom-left');
+    const overlay = document.createElement(
+      ELECTRON_OVERLAY_TAG_NAME
+    ) as SliccElectronOverlayElement;
+    document.body.appendChild(overlay);
+    expect(overlay.corner).toBe('bottom-left');
+  });
+
+  it('falls back gracefully when localStorage throws on read', () => {
+    const original = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new Error('blocked');
+      },
+    });
+    try {
+      const overlay = document.createElement(
+        ELECTRON_OVERLAY_TAG_NAME
+      ) as SliccElectronOverlayElement;
+      document.body.appendChild(overlay);
+      // Default corner kicks in when localStorage throws.
+      expect(overlay.corner).toBe('top-right');
+    } finally {
+      if (original) Object.defineProperty(window, 'localStorage', original);
+    }
+  });
+
+  it('falls back gracefully when localStorage throws on write', () => {
+    const overlay = document.createElement(
+      ELECTRON_OVERLAY_TAG_NAME
+    ) as SliccElectronOverlayElement;
+    document.body.appendChild(overlay);
+    const original = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('quota');
+        },
+        removeItem: () => {},
+        clear: () => {},
+        key: () => null,
+        length: 0,
+      },
+    });
+    try {
+      expect(() => {
+        overlay.corner = 'bottom-right';
+      }).not.toThrow();
+    } finally {
+      if (original) Object.defineProperty(window, 'localStorage', original);
+    }
+  });
+});

--- a/packages/webapp/tests/ui/layout-electron-overlay-close.test.ts
+++ b/packages/webapp/tests/ui/layout-electron-overlay-close.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the electron-overlay close button mounted in the inner
+ * webapp's thread header (`Layout.setShowElectronOverlayClose`) and
+ * for the close-message round-trip on `SliccElectronOverlayElement`.
+ *
+ * The button is mounted only in electron-overlay mode (see `main.ts`),
+ * sits to the LEFT of the scoop switcher in the thread header, and
+ * posts `ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE` to `window.parent`. The
+ * outer overlay shell forwards that message to
+ * `SliccElectronOverlayElement.hideSidebar()`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ELECTRON_OVERLAY_TAG_NAME,
+  registerElectronOverlayElements,
+  type SliccElectronOverlayElement,
+} from '../../src/ui/electron-overlay.js';
+import { Layout } from '../../src/ui/layout.js';
+import { ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE } from '../../src/ui/runtime-mode.js';
+
+/**
+ * Build a Layout shell stub that bypasses the heavy constructor.
+ * `setShowElectronOverlayClose` only reads `this.threadHeaderEl` and
+ * writes `this.electronOverlayCloseBtnEl`; both are TS `private` (not
+ * `#private`), so prototype-attached methods operate on a hand-rolled
+ * fixture without booting ChatPanel/TerminalPanel/RailZone.
+ */
+function makeLayoutFixture(): {
+  layout: Layout;
+  threadHeaderEl: HTMLElement;
+  titleEl: HTMLElement;
+  switcherEl: HTMLElement;
+} {
+  const layout = Object.create(Layout.prototype) as Layout;
+  const threadHeaderEl = document.createElement('div');
+  threadHeaderEl.className = 'thread-header';
+  const titleEl = document.createElement('div');
+  titleEl.className = 'thread-header__title';
+  // Stand-in for the scoop-switcher dropdown so we can prove the new
+  // close button lands to the LEFT of it (first child of the title).
+  const switcherEl = document.createElement('div');
+  switcherEl.className = 'scoop-switcher';
+  titleEl.appendChild(switcherEl);
+  threadHeaderEl.appendChild(titleEl);
+  document.body.appendChild(threadHeaderEl);
+  (layout as unknown as { threadHeaderEl: HTMLElement }).threadHeaderEl = threadHeaderEl;
+  return { layout, threadHeaderEl, titleEl, switcherEl };
+}
+
+const BTN_SEL = 'button.thread-header__electron-overlay-close';
+
+describe('Layout.setShowElectronOverlayClose — DOM mount/unmount', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('mounts a button with the expected attributes when given a handler', () => {
+    const { layout, titleEl } = makeLayoutFixture();
+    layout.setShowElectronOverlayClose(() => {});
+
+    const btn = titleEl.querySelector<HTMLButtonElement>(BTN_SEL);
+    expect(btn).not.toBeNull();
+    expect(btn!.type).toBe('button');
+    expect(btn!.title).toBe('Close SLICC');
+    expect(btn!.getAttribute('aria-label')).toBe('Close SLICC');
+    // Inlined ✕ glyph — assert the svg renders so a future icon change
+    // doesn't silently ship an empty button.
+    expect(btn!.querySelector('svg')).not.toBeNull();
+  });
+
+  it('inserts the button as the first child of the title (left of the switcher)', () => {
+    const { layout, titleEl, switcherEl } = makeLayoutFixture();
+    layout.setShowElectronOverlayClose(() => {});
+
+    expect(
+      titleEl.firstElementChild?.classList.contains('thread-header__electron-overlay-close')
+    ).toBe(true);
+    expect(titleEl.children).toHaveLength(2);
+    expect(titleEl.children[1]).toBe(switcherEl);
+  });
+
+  it('routes click events to the provided handler', () => {
+    const { layout, titleEl } = makeLayoutFixture();
+    const handler = vi.fn();
+    layout.setShowElectronOverlayClose(handler);
+
+    const btn = titleEl.querySelector<HTMLButtonElement>(BTN_SEL)!;
+    btn.click();
+    btn.click();
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('is idempotent — repeat calls with a handler do not duplicate the button', () => {
+    const { layout, titleEl } = makeLayoutFixture();
+    layout.setShowElectronOverlayClose(() => {});
+    layout.setShowElectronOverlayClose(() => {});
+
+    expect(titleEl.querySelectorAll(BTN_SEL)).toHaveLength(1);
+  });
+
+  it('is absent by default — no button until setShowElectronOverlayClose runs', () => {
+    const { titleEl } = makeLayoutFixture();
+    expect(titleEl.querySelector(BTN_SEL)).toBeNull();
+  });
+
+  it('removes the button when called with null', () => {
+    const { layout, titleEl } = makeLayoutFixture();
+    layout.setShowElectronOverlayClose(() => {});
+    expect(titleEl.querySelector(BTN_SEL)).not.toBeNull();
+
+    layout.setShowElectronOverlayClose(null);
+    expect(titleEl.querySelector(BTN_SEL)).toBeNull();
+  });
+
+  it('is a no-op when the thread header has no `.thread-header__title`', () => {
+    const layout = Object.create(Layout.prototype) as Layout;
+    const threadHeaderEl = document.createElement('div');
+    threadHeaderEl.className = 'thread-header';
+    document.body.appendChild(threadHeaderEl);
+    (layout as unknown as { threadHeaderEl: HTMLElement }).threadHeaderEl = threadHeaderEl;
+
+    expect(() => layout.setShowElectronOverlayClose(() => {})).not.toThrow();
+    expect(threadHeaderEl.querySelector(BTN_SEL)).toBeNull();
+  });
+});
+
+describe('SliccElectronOverlayElement — close-message round-trip', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    registerElectronOverlayElements();
+  });
+
+  it('hides the sidebar when ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE is posted', async () => {
+    const overlay = document.createElement(
+      ELECTRON_OVERLAY_TAG_NAME
+    ) as SliccElectronOverlayElement;
+    overlay.setAttribute('open', '');
+    document.body.appendChild(overlay);
+    expect(overlay.open).toBe(true);
+
+    window.postMessage({ type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE }, '*');
+    await vi.waitFor(() => expect(overlay.open).toBe(false));
+  });
+
+  it('ignores foreign message types', async () => {
+    const overlay = document.createElement(
+      ELECTRON_OVERLAY_TAG_NAME
+    ) as SliccElectronOverlayElement;
+    overlay.setAttribute('open', '');
+    document.body.appendChild(overlay);
+
+    window.postMessage({ type: 'slicc-electron-overlay:other' }, '*');
+    await new Promise((r) => setTimeout(r, 10));
+    expect(overlay.open).toBe(true);
+  });
+});

--- a/packages/webapp/tests/ui/layout-electron-overlay-close.test.ts
+++ b/packages/webapp/tests/ui/layout-electron-overlay-close.test.ts
@@ -133,12 +133,37 @@ describe('SliccElectronOverlayElement — close-message round-trip', () => {
     registerElectronOverlayElements();
   });
 
-  it('hides the sidebar when ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE is posted', async () => {
+  function mountOverlay(appUrl?: string): SliccElectronOverlayElement {
     const overlay = document.createElement(
       ELECTRON_OVERLAY_TAG_NAME
     ) as SliccElectronOverlayElement;
     overlay.setAttribute('open', '');
+    if (appUrl !== undefined) overlay.setAttribute('app-url', appUrl);
     document.body.appendChild(overlay);
+    return overlay;
+  }
+
+  /**
+   * Synthesize a MessageEvent with caller-controlled `source` and `origin`
+   * so we can prove the source/origin guards reject hostile cases. The
+   * `window.postMessage` self-post path in jsdom leaves `source` null, so
+   * we dispatch the event directly to exercise the source==window branch.
+   */
+  function dispatchMessage(detail: {
+    data: unknown;
+    source?: MessageEventSource | null;
+    origin?: string;
+  }): void {
+    const event = new MessageEvent('message', {
+      data: detail.data,
+      source: detail.source ?? null,
+      origin: detail.origin ?? '',
+    });
+    window.dispatchEvent(event);
+  }
+
+  it('hides the sidebar when ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE is posted', async () => {
+    const overlay = mountOverlay();
     expect(overlay.open).toBe(true);
 
     window.postMessage({ type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE }, '*');
@@ -146,14 +171,106 @@ describe('SliccElectronOverlayElement — close-message round-trip', () => {
   });
 
   it('ignores foreign message types', async () => {
-    const overlay = document.createElement(
-      ELECTRON_OVERLAY_TAG_NAME
-    ) as SliccElectronOverlayElement;
-    overlay.setAttribute('open', '');
-    document.body.appendChild(overlay);
+    const overlay = mountOverlay();
 
     window.postMessage({ type: 'slicc-electron-overlay:other' }, '*');
     await new Promise((r) => setTimeout(r, 10));
     expect(overlay.open).toBe(true);
+  });
+
+  it('rejects messages whose source is the host window itself', () => {
+    const overlay = mountOverlay();
+
+    dispatchMessage({
+      data: { type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE },
+      source: window,
+      origin: window.location.origin,
+    });
+    expect(overlay.open).toBe(true);
+
+    dispatchMessage({
+      data: { type: 'slicc-electron-overlay:toggle' },
+      source: window,
+      origin: window.location.origin,
+    });
+    expect(overlay.open).toBe(true);
+  });
+
+  it('rejects messages whose origin does not match the iframe app origin', () => {
+    const overlay = mountOverlay('https://app.example.com/electron');
+
+    dispatchMessage({
+      data: { type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE },
+      source: { postMessage: () => {} } as unknown as MessageEventSource,
+      origin: 'https://evil.example.com',
+    });
+    expect(overlay.open).toBe(true);
+  });
+
+  it('accepts messages whose origin matches the iframe app origin', () => {
+    const overlay = mountOverlay('https://app.example.com/electron');
+
+    dispatchMessage({
+      data: { type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE },
+      source: { postMessage: () => {} } as unknown as MessageEventSource,
+      origin: 'https://app.example.com',
+    });
+    expect(overlay.open).toBe(false);
+  });
+
+  it('skips origin validation when appUrl is empty (relies on source guard alone)', () => {
+    const overlay = mountOverlay();
+
+    dispatchMessage({
+      data: { type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE },
+      source: { postMessage: () => {} } as unknown as MessageEventSource,
+      origin: 'https://anywhere.example.com',
+    });
+    expect(overlay.open).toBe(false);
+  });
+});
+
+describe('main.ts electron-overlay close-button gating — embedded vs top-level', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  /**
+   * Mirrors the gating in `main.ts`: when `/electron` is opened top-level,
+   * `window.parent === window`, so `setShowElectronOverlayClose(null)` is
+   * called and no button must be mounted — otherwise the button would post
+   * a close message to itself and close nothing.
+   */
+  it('top-level frame branch (null) does not mount a close button', () => {
+    const { layout, titleEl } = makeLayoutFixture();
+    const isEmbedded = window.parent !== window;
+    // jsdom default: `window.parent === window`, so we exercise the same
+    // branch main.ts takes for top-level `/electron`.
+    expect(isEmbedded).toBe(false);
+    if (isEmbedded) {
+      layout.setShowElectronOverlayClose(() => {});
+    } else {
+      layout.setShowElectronOverlayClose(null);
+    }
+    expect(titleEl.querySelector(BTN_SEL)).toBeNull();
+  });
+
+  /**
+   * Mirrors the gating in `main.ts`: when actually embedded in the overlay
+   * shell, `window.parent !== window`, so a handler is passed and the
+   * button IS mounted. We cannot make jsdom satisfy that predicate without
+   * a real iframe, so we exercise the embedded branch directly.
+   */
+  it('embedded frame branch (handler) mounts a close button that posts to parent', () => {
+    const { layout, titleEl } = makeLayoutFixture();
+    const postSpy = vi.fn();
+    // Same closure shape as the production code path.
+    layout.setShowElectronOverlayClose(() => {
+      postSpy({ type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE });
+    });
+    const btn = titleEl.querySelector<HTMLButtonElement>(BTN_SEL);
+    expect(btn).not.toBeNull();
+    btn!.click();
+    expect(postSpy).toHaveBeenCalledWith({ type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE });
   });
 });

--- a/packages/webapp/tests/ui/layout-setters.test.ts
+++ b/packages/webapp/tests/ui/layout-setters.test.ts
@@ -1,0 +1,243 @@
+// @vitest-environment jsdom
+/**
+ * Targeted tests for the small public setters on `Layout` that can be
+ * exercised via a hand-rolled prototype fixture, mirroring the pattern
+ * established by `layout-electron-overlay-close.test.ts`. We bypass
+ * the heavy `Layout` constructor entirely because these setters only
+ * read a few private fields each — booting the full layout would drag
+ * in ChatPanel, RailZone, scoop-switcher, model lists, etc.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Layout } from '../../src/ui/layout.js';
+
+type LayoutPrivates = {
+  root: HTMLElement;
+  isExtension: boolean;
+  threadHeaderEl?: HTMLElement;
+  threadHeaderName?: HTMLElement;
+  newSessionBtn: { classList: DOMTokenList } | null;
+  primaryRail?: {
+    collapse: ReturnType<typeof vi.fn>;
+    activateItem: ReturnType<typeof vi.fn>;
+    getActiveItemId: ReturnType<typeof vi.fn>;
+  };
+  activeTab: string;
+  popoutButtonEl?: HTMLButtonElement;
+  popoutClickHandler?: () => void;
+  detachedActiveOverlayEl?: HTMLDivElement;
+};
+
+function makeLayout(
+  opts: { isExtension?: boolean; withRailHeader?: boolean; withThreadHeader?: boolean } = {}
+): { layout: Layout; root: HTMLElement; privates: LayoutPrivates } {
+  const layout = Object.create(Layout.prototype) as Layout;
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+
+  // Standalone mode hosts the popout button on `.header`; extension mode
+  // hosts it on `.thread-header`. Render both up-front and let the test
+  // toggle `isExtension` to drive the branch.
+  if (opts.withRailHeader !== false) {
+    const header = document.createElement('div');
+    header.className = 'header';
+    root.appendChild(header);
+  }
+
+  const threadHeaderEl = document.createElement('div');
+  threadHeaderEl.className = 'thread-header';
+  if (opts.withThreadHeader !== false) root.appendChild(threadHeaderEl);
+
+  const threadHeaderName = document.createElement('span');
+  threadHeaderName.className = 'thread-header__name';
+  threadHeaderEl.appendChild(threadHeaderName);
+
+  const privates: LayoutPrivates = {
+    root,
+    isExtension: opts.isExtension ?? false,
+    threadHeaderEl,
+    threadHeaderName,
+    newSessionBtn: { classList: document.createElement('button').classList },
+    primaryRail: {
+      collapse: vi.fn(),
+      activateItem: vi.fn(),
+      getActiveItemId: vi.fn(() => 'chat'),
+    },
+    activeTab: 'chat',
+  };
+  Object.assign(layout as unknown as Record<string, unknown>, privates);
+  return { layout, root, privates };
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('Layout.setShowPopoutButton', () => {
+  it('mounts a popout button under `.header` in standalone mode and routes clicks to the handler', () => {
+    const { layout, root } = makeLayout();
+    const handler = vi.fn();
+    layout.setPopoutClickHandler(handler);
+    layout.setShowPopoutButton(true);
+    const btn = root.querySelector('.header__popout-btn') as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    expect(btn.type).toBe('button');
+    expect(btn.title).toBe('Open in a new tab');
+    expect(btn.getAttribute('aria-label')).toBe('Pop out to a new tab');
+    btn.click();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('mounts the popout button under `.thread-header` in extension mode', () => {
+    const { layout, root } = makeLayout({ isExtension: true });
+    layout.setPopoutClickHandler(() => {});
+    layout.setShowPopoutButton(true);
+    const headerBtn = root.querySelector('.header .header__popout-btn');
+    const threadBtn = root.querySelector('.thread-header .header__popout-btn');
+    expect(headerBtn).toBeNull();
+    expect(threadBtn).not.toBeNull();
+  });
+
+  it('is idempotent — repeat true calls do not duplicate the button', () => {
+    const { layout, root } = makeLayout();
+    layout.setShowPopoutButton(true);
+    layout.setShowPopoutButton(true);
+    expect(root.querySelectorAll('.header__popout-btn')).toHaveLength(1);
+  });
+
+  it('removes the popout button when called with false', () => {
+    const { layout, root } = makeLayout();
+    layout.setShowPopoutButton(true);
+    expect(root.querySelector('.header__popout-btn')).not.toBeNull();
+    layout.setShowPopoutButton(false);
+    expect(root.querySelector('.header__popout-btn')).toBeNull();
+  });
+
+  it('is a no-op when no container element exists', () => {
+    const { layout, root, privates } = makeLayout({ withRailHeader: false });
+    privates.isExtension = false;
+    // Remove the thread-header too so neither container resolves.
+    root.querySelector('.thread-header')?.remove();
+    expect(() => layout.setShowPopoutButton(true)).not.toThrow();
+    expect(root.querySelector('.header__popout-btn')).toBeNull();
+  });
+
+  it('resetPopoutButton re-enables a disabled button and is safe with no button', () => {
+    const { layout, root } = makeLayout();
+    // Safe before any button is mounted.
+    expect(() => layout.resetPopoutButton()).not.toThrow();
+    layout.setPopoutClickHandler(() => {});
+    layout.setShowPopoutButton(true);
+    const btn = root.querySelector('.header__popout-btn') as HTMLButtonElement;
+    btn.disabled = true;
+    layout.resetPopoutButton();
+    expect(btn.disabled).toBe(false);
+  });
+});
+
+describe('Layout.setThreadHeaderName', () => {
+  it('updates the thread-header name text when connected', () => {
+    const { layout, privates } = makeLayout();
+    layout.setThreadHeaderName('Frozen archive');
+    expect(privates.threadHeaderName!.textContent).toBe('Frozen archive');
+  });
+
+  it('is a no-op when the thread-header name is detached', () => {
+    const { layout, privates } = makeLayout();
+    privates.threadHeaderName!.remove();
+    expect(() => layout.setThreadHeaderName('whatever')).not.toThrow();
+    expect(privates.threadHeaderName!.textContent).toBe('');
+  });
+});
+
+describe('Layout.setNewSessionGlow', () => {
+  it('toggles `glow` / `glow--hot` classes based on the fill ratio', () => {
+    const { layout, privates } = makeLayout();
+    const cl = privates.newSessionBtn!.classList;
+    layout.setNewSessionGlow(0.1);
+    expect(cl.contains('glow')).toBe(false);
+    expect(cl.contains('glow--hot')).toBe(false);
+    layout.setNewSessionGlow(0.6);
+    expect(cl.contains('glow')).toBe(true);
+    expect(cl.contains('glow--hot')).toBe(false);
+    layout.setNewSessionGlow(0.9);
+    expect(cl.contains('glow')).toBe(true);
+    expect(cl.contains('glow--hot')).toBe(true);
+    layout.setNewSessionGlow(0.0);
+    expect(cl.contains('glow')).toBe(false);
+    expect(cl.contains('glow--hot')).toBe(false);
+  });
+
+  it('is a no-op when the new-session button has not been mounted', () => {
+    const { layout, privates } = makeLayout();
+    privates.newSessionBtn = null;
+    expect(() => layout.setNewSessionGlow(0.9)).not.toThrow();
+  });
+});
+
+describe('Layout.setActiveTab / getActiveTab', () => {
+  it('collapses the rail for the chat tab', () => {
+    const { layout, privates } = makeLayout();
+    layout.setActiveTab('chat');
+    expect(privates.primaryRail!.collapse).toHaveBeenCalledTimes(1);
+    expect(privates.primaryRail!.activateItem).not.toHaveBeenCalled();
+    expect(layout.getActiveTab()).toBe('chat');
+  });
+
+  it('activates the matching rail item for non-chat tabs', () => {
+    const { layout, privates } = makeLayout();
+    layout.setActiveTab('terminal');
+    expect(privates.primaryRail!.activateItem).toHaveBeenCalledWith('terminal');
+    expect(layout.getActiveTab()).toBe('terminal');
+  });
+});
+
+describe('Layout.isTerminalOpen / openTerminal', () => {
+  it('reports terminal-open when the rail has the terminal item active', () => {
+    const { layout, privates } = makeLayout();
+    privates.primaryRail!.getActiveItemId.mockReturnValue('terminal');
+    expect(layout.isTerminalOpen()).toBe(true);
+    privates.primaryRail!.getActiveItemId.mockReturnValue('memory');
+    expect(layout.isTerminalOpen()).toBe(false);
+  });
+
+  it('openTerminal activates the terminal rail item', () => {
+    const { layout, privates } = makeLayout();
+    privates.primaryRail!.getActiveItemId.mockReturnValue('chat');
+    layout.openTerminal();
+    expect(privates.primaryRail!.activateItem).toHaveBeenCalledWith('terminal');
+  });
+
+  it('openTerminal does not steal focus from an active sprinkle', () => {
+    const { layout, privates } = makeLayout();
+    privates.primaryRail!.getActiveItemId.mockReturnValue('sprinkle-github');
+    layout.openTerminal();
+    expect(privates.primaryRail!.activateItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('Layout.setAgentProcessing', () => {
+  it('toggles `.thread-header--processing` on the thread-header', () => {
+    const { layout, privates } = makeLayout();
+    layout.setAgentProcessing(true);
+    expect(privates.threadHeaderEl!.classList.contains('thread-header--processing')).toBe(true);
+    layout.setAgentProcessing(false);
+    expect(privates.threadHeaderEl!.classList.contains('thread-header--processing')).toBe(false);
+  });
+});
+
+describe('Layout.showDetachedActiveOverlay', () => {
+  it('renders the alertdialog overlay and is idempotent', () => {
+    const { layout, root } = makeLayout();
+    layout.showDetachedActiveOverlay();
+    layout.showDetachedActiveOverlay();
+    const overlays = root.querySelectorAll('.layout-detached-overlay');
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0].getAttribute('role')).toBe('alertdialog');
+    expect(overlays[0].getAttribute('aria-modal')).toBe('true');
+    expect(overlays[0].querySelector('p')?.textContent).toMatch(/Detached in another tab/);
+    expect(overlays[0].querySelector('.layout-detached-overlay-close')).not.toBeNull();
+  });
+});

--- a/packages/webapp/tests/ui/memory-panel.test.ts
+++ b/packages/webapp/tests/ui/memory-panel.test.ts
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+/**
+ * Tests for `MemoryPanel` — the panel-side viewer that surfaces the
+ * `/shared/CLAUDE.md` global memory plus the active scoop/cone memory
+ * file. The orchestrator dependency is mocked with the minimum surface
+ * `MemoryPanel` actually calls.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MemoryPanel } from '../../src/ui/memory-panel.js';
+
+type OrchestratorMock = {
+  getGlobalMemory: ReturnType<typeof vi.fn>;
+  getScoopContext: ReturnType<typeof vi.fn>;
+  getScoop: ReturnType<typeof vi.fn>;
+};
+
+function makeOrchestrator(overrides: Partial<OrchestratorMock> = {}): OrchestratorMock {
+  return {
+    getGlobalMemory: vi.fn(async () => '# Shared memory body'),
+    getScoopContext: vi.fn(() => null),
+    getScoop: vi.fn(() => null),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document.body.replaceChildren();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('MemoryPanel — initial render', () => {
+  it('mounts `.memory-panel__body` inside the container and clears prior content', () => {
+    const container = document.createElement('div');
+    container.appendChild(document.createElement('span'));
+    document.body.appendChild(container);
+    // biome-ignore lint/correctness/noUnusedVariables: ctor side-effects under test
+    const panel = new MemoryPanel(container);
+    expect(container.classList.contains('memory-panel')).toBe(true);
+    expect(container.querySelector('.memory-panel__body')).not.toBeNull();
+    expect(container.querySelector('span')).toBeNull();
+    void panel;
+  });
+});
+
+describe('MemoryPanel — refresh()', () => {
+  it('returns early when no orchestrator is set', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    await panel.refresh();
+    expect(container.querySelector('.memory-panel__section')).toBeNull();
+  });
+
+  it('renders the global memory section when present', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const orch = makeOrchestrator();
+    panel.setOrchestrator(orch as unknown as never);
+    await vi.waitFor(() => {
+      expect(container.querySelector('.memory-panel__section')).not.toBeNull();
+    });
+    const sections = container.querySelectorAll('.memory-panel__section');
+    expect(sections).toHaveLength(1);
+    expect(sections[0].textContent).toContain('Global Memory (/shared/CLAUDE.md)');
+    expect(sections[0].textContent).toContain('# Shared memory body');
+  });
+
+  it('renders `(empty)` when global memory is the empty string', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const orch = makeOrchestrator({ getGlobalMemory: vi.fn(async () => '') });
+    panel.setOrchestrator(orch as unknown as never);
+    await vi.waitFor(() => {
+      expect(container.querySelector('.memory-panel__memory-content')).not.toBeNull();
+    });
+    expect(container.querySelector('.memory-panel__memory-content')!.textContent).toBe('(empty)');
+  });
+
+  it('renders `(not available)` when getGlobalMemory throws', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const orch = makeOrchestrator({
+      getGlobalMemory: vi.fn(async () => {
+        throw new Error('nope');
+      }),
+    });
+    panel.setOrchestrator(orch as unknown as never);
+    await vi.waitFor(() => {
+      expect(container.querySelector('.memory-panel__memory-content')).not.toBeNull();
+    });
+    expect(container.querySelector('.memory-panel__memory-content')!.textContent).toBe(
+      '(not available)'
+    );
+  });
+
+  it('renders a cone memory section pointing at /workspace/CLAUDE.md', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const fs = {
+      readFile: vi.fn(async () => '## Cone CLAUDE body'),
+    };
+    const orch = makeOrchestrator({
+      getScoopContext: vi.fn(() => ({ getFS: () => fs })),
+      getScoop: vi.fn(() => ({ isCone: true, folder: 'cone', assistantLabel: 'Sliccy' })),
+    });
+    panel.setOrchestrator(orch as unknown as never);
+    panel.setSelectedScoop('cone-jid');
+    await vi.waitFor(() => {
+      const sections = container.querySelectorAll('.memory-panel__section');
+      expect(sections.length).toBeGreaterThanOrEqual(2);
+    });
+    const headers = Array.from(container.querySelectorAll('.memory-panel__section-header'));
+    const coneHeader = headers.find((h) => h.textContent?.includes('Cone'));
+    expect(coneHeader?.textContent).toContain('/workspace/CLAUDE.md');
+    expect(coneHeader?.textContent).toContain('Sliccy');
+    expect(container.textContent).toContain('## Cone CLAUDE body');
+  });
+
+  it('renders a scoop memory section pointing at /scoops/<folder>/CLAUDE.md', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const fs = {
+      readFile: vi.fn(async () => '## Scoop CLAUDE body'),
+    };
+    const orch = makeOrchestrator({
+      getScoopContext: vi.fn(() => ({ getFS: () => fs })),
+      getScoop: vi.fn(() => ({ isCone: false, folder: 'researcher', assistantLabel: 'Cherry' })),
+    });
+    panel.setOrchestrator(orch as unknown as never);
+    panel.setSelectedScoop('scoop-jid');
+    await vi.waitFor(() => {
+      expect(container.querySelectorAll('.memory-panel__section').length).toBeGreaterThanOrEqual(2);
+    });
+    const headers = Array.from(container.querySelectorAll('.memory-panel__section-header'));
+    const scoopHeader = headers.find((h) => h.textContent?.includes('Scoop'));
+    expect(scoopHeader?.textContent).toContain('/scoops/researcher/CLAUDE.md');
+    expect(scoopHeader?.textContent).toContain('Cherry');
+  });
+
+  it('decodes a Uint8Array file body via TextDecoder', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const bytes = new TextEncoder().encode('## binary-body');
+    const fs = {
+      readFile: vi.fn(async () => bytes),
+    };
+    const orch = makeOrchestrator({
+      getScoopContext: vi.fn(() => ({ getFS: () => fs })),
+      getScoop: vi.fn(() => ({ isCone: true, folder: 'cone', assistantLabel: 'C' })),
+    });
+    panel.setOrchestrator(orch as unknown as never);
+    panel.setSelectedScoop('cone-jid');
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('## binary-body');
+    });
+  });
+
+  it('shows `(filesystem not ready)` when getFS returns null', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const orch = makeOrchestrator({
+      getScoopContext: vi.fn(() => ({ getFS: () => null })),
+      getScoop: vi.fn(() => ({ isCone: true, folder: 'cone', assistantLabel: 'C' })),
+    });
+    panel.setOrchestrator(orch as unknown as never);
+    panel.setSelectedScoop('cone-jid');
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('(filesystem not ready)');
+    });
+  });
+
+  it('shows `(no memory file yet)` when readFile throws', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const fs = {
+      readFile: vi.fn(async () => {
+        throw new Error('ENOENT');
+      }),
+    };
+    const orch = makeOrchestrator({
+      getScoopContext: vi.fn(() => ({ getFS: () => fs })),
+      getScoop: vi.fn(() => ({ isCone: false, folder: 'x', assistantLabel: 'X' })),
+    });
+    panel.setOrchestrator(orch as unknown as never);
+    panel.setSelectedScoop('jid');
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('(no memory file yet)');
+    });
+  });
+
+  it('does not render a scoop section when getScoopContext returns null', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const orch = makeOrchestrator();
+    panel.setOrchestrator(orch as unknown as never);
+    panel.setSelectedScoop('jid');
+    await vi.waitFor(() => {
+      expect(container.querySelector('.memory-panel__section')).not.toBeNull();
+    });
+    expect(container.querySelectorAll('.memory-panel__section')).toHaveLength(1);
+  });
+
+  it('does not re-render identical content (innerHTML guard)', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const orch = makeOrchestrator();
+    panel.setOrchestrator(orch as unknown as never);
+    await vi.waitFor(() => {
+      expect(container.querySelector('.memory-panel__section')).not.toBeNull();
+    });
+    const firstSection = container.querySelector('.memory-panel__section');
+    await panel.refresh();
+    expect(container.querySelector('.memory-panel__section')).toBe(firstSection);
+  });
+});
+
+describe('MemoryPanel — setOrchestrator / dispose', () => {
+  it('schedules a 5 s refresh timer that dispose() clears', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    const orch = makeOrchestrator();
+    panel.setOrchestrator(orch as unknown as never);
+    await vi.waitFor(() => {
+      expect(orch.getGlobalMemory).toHaveBeenCalledTimes(1);
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(orch.getGlobalMemory).toHaveBeenCalledTimes(2);
+    panel.dispose();
+    await vi.advanceTimersByTimeAsync(20000);
+    expect(orch.getGlobalMemory).toHaveBeenCalledTimes(2);
+  });
+
+  it('dispose() is safe to call before setOrchestrator()', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new MemoryPanel(container);
+    expect(() => panel.dispose()).not.toThrow();
+  });
+});

--- a/packages/webapp/tests/ui/runtime-mode.test.ts
+++ b/packages/webapp/tests/ui/runtime-mode.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE,
   ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE,
   getElectronOverlayInitialTab,
   getLickWebSocketUrl,
   getTrayWebhookUrl,
   getWebhookUrl,
+  isElectronOverlayCloseMessage,
   isElectronOverlaySetTabMessage,
   resolveUiRuntimeMode,
   shouldUseRuntimeModeTrayDefaults,
@@ -93,6 +95,24 @@ describe('runtime-mode', () => {
     ).toBe(true);
     expect(isElectronOverlaySetTabMessage({ type: 'something-else' })).toBe(false);
     expect(isElectronOverlaySetTabMessage(null)).toBe(false);
+  });
+
+  it('exposes the dedicated overlay close message type', () => {
+    expect(ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE).toBe('slicc-electron-overlay:close');
+    // The close message must NOT be confused with the toggle or set-tab
+    // messages — the parent shell routes each to a different action.
+    expect(ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE).not.toBe(ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE);
+  });
+
+  it('recognizes overlay close messages', () => {
+    expect(isElectronOverlayCloseMessage({ type: ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE })).toBe(true);
+    expect(isElectronOverlayCloseMessage({ type: ELECTRON_OVERLAY_SET_TAB_MESSAGE_TYPE })).toBe(
+      false
+    );
+    expect(isElectronOverlayCloseMessage({ type: 'something-else' })).toBe(false);
+    expect(isElectronOverlayCloseMessage(null)).toBe(false);
+    expect(isElectronOverlayCloseMessage(undefined)).toBe(false);
+    expect(isElectronOverlayCloseMessage({})).toBe(false);
   });
 });
 

--- a/packages/webapp/tests/ui/sprinkle-picker.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-picker.test.ts
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+/**
+ * Tests for `showSprinklePicker` — the popup menu launched by [+] zone
+ * buttons. Covers the toggle, separator, dismissal (outside click / Esc),
+ * empty-state, and item selection callbacks.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PanelRegistry } from '../../src/ui/panel-registry.js';
+import type { PanelDescriptor, ZoneId } from '../../src/ui/panel-types.js';
+import { showSprinklePicker } from '../../src/ui/sprinkle-picker.js';
+
+function makeAnchor(): HTMLElement {
+  const anchor = document.createElement('button');
+  // jsdom returns zeros from getBoundingClientRect; that's fine — the picker
+  // only reads the rect to set `top`/`left` and does not branch on values.
+  document.body.appendChild(anchor);
+  return anchor;
+}
+
+function makeRegistry(
+  descriptors: Array<{ id: string; label: string; zone: ZoneId | null }>
+): PanelRegistry {
+  const registry = new PanelRegistry();
+  for (const d of descriptors) {
+    const desc: PanelDescriptor = {
+      id: d.id,
+      label: d.label,
+      zone: d.zone,
+    } as PanelDescriptor;
+    registry.register(desc);
+  }
+  return registry;
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+afterEach(() => {
+  document.querySelector('.sprinkle-picker')?.remove();
+});
+
+describe('showSprinklePicker', () => {
+  it('is a no-op when there are no closed panels and no available sprinkles', () => {
+    const registry = makeRegistry([]);
+    showSprinklePicker(makeAnchor(), 'rail', {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle: vi.fn() },
+      getAvailableSprinkles: () => [],
+    });
+    expect(document.querySelector('.sprinkle-picker')).toBeNull();
+  });
+
+  it('renders only closed panels when no sprinkles are available', () => {
+    const registry = makeRegistry([
+      { id: 'terminal', label: 'Terminal', zone: null },
+      { id: 'files', label: 'Files', zone: 'rail' },
+      { id: 'memory', label: 'Memory', zone: null },
+    ]);
+    showSprinklePicker(makeAnchor(), 'rail', {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle: vi.fn() },
+    });
+    const picker = document.querySelector('.sprinkle-picker')!;
+    const items = picker.querySelectorAll('.sprinkle-picker__item');
+    expect(items).toHaveLength(2);
+    const labels = Array.from(items).map((el) => el.textContent);
+    expect(labels).toContain('Terminal');
+    expect(labels).toContain('Memory');
+    expect(labels).not.toContain('Files');
+  });
+
+  it('renders only sprinkles when no panels are closed', () => {
+    const registry = makeRegistry([]);
+    showSprinklePicker(makeAnchor(), 'rail', {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle: vi.fn() },
+      getAvailableSprinkles: () => [
+        { name: 'github', title: 'GitHub' },
+        { name: 'jira', title: 'Jira' },
+      ],
+    });
+    const picker = document.querySelector('.sprinkle-picker')!;
+    const items = picker.querySelectorAll('.sprinkle-picker__item');
+    expect(items).toHaveLength(2);
+    expect(Array.from(items).map((el) => el.textContent)).toEqual(['GitHub', 'Jira']);
+  });
+
+  it('inserts a separator between closed panels and available sprinkles', () => {
+    const registry = makeRegistry([{ id: 'terminal', label: 'Terminal', zone: null }]);
+    showSprinklePicker(makeAnchor(), 'rail', {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle: vi.fn() },
+      getAvailableSprinkles: () => [{ name: 'github', title: 'GitHub' }],
+    });
+    const picker = document.querySelector('.sprinkle-picker')!;
+    expect(picker.children).toHaveLength(3);
+    expect(picker.children[0].textContent).toBe('Terminal');
+    // The separator has no `.sprinkle-picker__item` class.
+    expect(picker.children[1].classList.contains('sprinkle-picker__item')).toBe(false);
+    expect(picker.children[2].textContent).toBe('GitHub');
+  });
+
+  it('toggles closed when the picker is already open', () => {
+    const registry = makeRegistry([{ id: 'terminal', label: 'Terminal', zone: null }]);
+    const opts = {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle: vi.fn() },
+    };
+    showSprinklePicker(makeAnchor(), 'rail', opts);
+    expect(document.querySelector('.sprinkle-picker')).not.toBeNull();
+    showSprinklePicker(makeAnchor(), 'rail', opts);
+    expect(document.querySelector('.sprinkle-picker')).toBeNull();
+  });
+
+  it('selecting a panel item invokes onSelectPanel with the triggering zone', () => {
+    const registry = makeRegistry([{ id: 'terminal', label: 'Terminal', zone: null }]);
+    const onSelectPanel = vi.fn();
+    showSprinklePicker(makeAnchor(), 'rail', {
+      registry,
+      callbacks: { onSelectPanel, onSelectSprinkle: vi.fn() },
+    });
+    const item = document.querySelector('.sprinkle-picker__item') as HTMLElement;
+    item.click();
+    expect(onSelectPanel).toHaveBeenCalledWith('terminal', 'rail');
+    expect(document.querySelector('.sprinkle-picker')).toBeNull();
+  });
+
+  it('selecting a sprinkle item invokes onSelectSprinkle and dismisses', () => {
+    const registry = makeRegistry([]);
+    const onSelectSprinkle = vi.fn();
+    showSprinklePicker(makeAnchor(), 'rail', {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle },
+      getAvailableSprinkles: () => [{ name: 'github', title: 'GitHub' }],
+    });
+    const item = document.querySelector('.sprinkle-picker__item') as HTMLElement;
+    item.click();
+    expect(onSelectSprinkle).toHaveBeenCalledWith('github', 'rail');
+    expect(document.querySelector('.sprinkle-picker')).toBeNull();
+  });
+
+  it('hover styling toggles background on enter/leave', () => {
+    const registry = makeRegistry([{ id: 'terminal', label: 'Terminal', zone: null }]);
+    showSprinklePicker(makeAnchor(), 'rail', {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle: vi.fn() },
+    });
+    const item = document.querySelector('.sprinkle-picker__item') as HTMLElement;
+    item.dispatchEvent(new Event('mouseenter'));
+    expect(item.style.background).not.toBe('');
+    item.dispatchEvent(new Event('mouseleave'));
+    expect(item.style.background).toBe('');
+  });
+
+  it('dismisses on Escape', async () => {
+    const registry = makeRegistry([{ id: 'terminal', label: 'Terminal', zone: null }]);
+    showSprinklePicker(makeAnchor(), 'rail', {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle: vi.fn() },
+    });
+    // The picker installs its document listeners on the next animation
+    // frame, so wait one frame before dispatching the Escape.
+    await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(document.querySelector('.sprinkle-picker')).toBeNull();
+  });
+
+  it('dismisses on outside click', async () => {
+    const registry = makeRegistry([{ id: 'terminal', label: 'Terminal', zone: null }]);
+    showSprinklePicker(makeAnchor(), 'rail', {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle: vi.fn() },
+    });
+    await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    expect(document.querySelector('.sprinkle-picker')).toBeNull();
+  });
+
+  it('does not dismiss on a click inside the picker', async () => {
+    const registry = makeRegistry([{ id: 'terminal', label: 'Terminal', zone: null }]);
+    showSprinklePicker(makeAnchor(), 'rail', {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle: vi.fn() },
+    });
+    await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    const picker = document.querySelector('.sprinkle-picker') as HTMLElement;
+    picker.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    // Picker should still be present.
+    expect(document.querySelector('.sprinkle-picker')).not.toBeNull();
+  });
+
+  it('uses anchor.getBoundingClientRect() to position the menu', () => {
+    const registry = makeRegistry([{ id: 'terminal', label: 'Terminal', zone: null }]);
+    const anchor = makeAnchor();
+    Object.defineProperty(anchor, 'getBoundingClientRect', {
+      configurable: true,
+      value: () =>
+        ({ left: 50, top: 100, right: 150, bottom: 200, width: 100, height: 100 }) as DOMRect,
+    });
+    showSprinklePicker(anchor, 'rail', {
+      registry,
+      callbacks: { onSelectPanel: vi.fn(), onSelectSprinkle: vi.fn() },
+    });
+    const picker = document.querySelector('.sprinkle-picker') as HTMLElement;
+    expect(picker.style.left).toBe('50px');
+    expect(picker.style.top).toBe('204px');
+  });
+});

--- a/packages/webapp/tests/ui/sync-dialog.test.ts
+++ b/packages/webapp/tests/ui/sync-dialog.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+/**
+ * DOM-only tests for `showSyncEnabledDialog` — the avatar-popover dialog
+ * that surfaces the leader's join URL after a `host enable` succeeds.
+ * Stubs the optional clipboard module so the copy-back button can be
+ * exercised without depending on the browser's real clipboard API.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/ui/clipboard.js', () => ({
+  copyTextToClipboard: vi.fn(async () => true),
+}));
+
+import { copyTextToClipboard } from '../../src/ui/clipboard.js';
+import { showSyncEnabledDialog } from '../../src/ui/sync-dialog.js';
+
+const mockedCopy = vi.mocked(copyTextToClipboard);
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  mockedCopy.mockReset();
+  mockedCopy.mockResolvedValue(true);
+});
+
+describe('showSyncEnabledDialog', () => {
+  it('mounts an overlay with the join URL and the copied-state status line', () => {
+    showSyncEnabledDialog({
+      joinUrl: 'https://slicc.example.com/join#abc',
+      copied: true,
+    });
+    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]');
+    expect(overlay).not.toBeNull();
+    expect(overlay!.querySelector('.dialog__title')!.textContent).toMatch(/sync is on/i);
+    expect(overlay!.textContent).toContain('https://slicc.example.com/join#abc');
+    expect(overlay!.textContent).toContain('URL copied to clipboard');
+  });
+
+  it('renders the not-copied desc and label when `copied: false`', () => {
+    showSyncEnabledDialog({
+      joinUrl: 'https://slicc.example.com/join#xyz',
+      copied: false,
+    });
+    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
+    const desc = overlay.querySelector('.dialog__desc')!;
+    expect(desc.textContent).toMatch(/Couldn[\u2019']t copy automatically/);
+    // The action button reads "Copy URL" instead of "Copy again".
+    const buttons = Array.from(overlay.querySelectorAll('button'));
+    const copyBtn = buttons.find((b) => /Copy URL/.test(b.textContent ?? ''));
+    expect(copyBtn).toBeDefined();
+  });
+
+  it('removes any pre-existing instance before mounting (idempotent)', () => {
+    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true });
+    showSyncEnabledDialog({ joinUrl: 'https://b', copied: true });
+    const overlays = document.querySelectorAll('.dialog-overlay[data-sync-dialog]');
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0].textContent).toContain('https://b');
+  });
+
+  it('removes the overlay when Done is clicked', () => {
+    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true });
+    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
+    const buttons = Array.from(overlay.querySelectorAll('button')) as HTMLButtonElement[];
+    const done = buttons.find((b) => b.textContent === 'Done')!;
+    done.click();
+    expect(document.querySelector('.dialog-overlay[data-sync-dialog]')).toBeNull();
+  });
+
+  it('removes the overlay on backdrop click', () => {
+    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true });
+    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]') as HTMLElement;
+    overlay.click();
+    expect(document.querySelector('.dialog-overlay[data-sync-dialog]')).toBeNull();
+  });
+
+  it('does not remove the overlay on inner click', () => {
+    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true });
+    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
+    const dialog = overlay.querySelector('.dialog')! as HTMLElement;
+    dialog.click();
+    expect(document.querySelector('.dialog-overlay[data-sync-dialog]')).not.toBeNull();
+  });
+
+  it('copy-again button writes the join URL and updates the status', async () => {
+    showSyncEnabledDialog({ joinUrl: 'https://slicc.example.com/join#abc', copied: true });
+    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
+    const copyBtn = Array.from(overlay.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Copy again'
+    ) as HTMLButtonElement;
+    copyBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedCopy).toHaveBeenCalledWith('https://slicc.example.com/join#abc');
+    expect(overlay.textContent).toContain('URL copied to clipboard');
+  });
+
+  it('copy failure surfaces a manual-copy hint', async () => {
+    mockedCopy.mockResolvedValueOnce(false);
+    showSyncEnabledDialog({ joinUrl: 'https://a', copied: false });
+    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
+    const copyBtn = Array.from(overlay.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Copy URL'
+    ) as HTMLButtonElement;
+    copyBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(overlay.textContent).toMatch(/Select and copy manually/);
+  });
+
+  it('renders a Reset button only when `onReset` is supplied', () => {
+    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true });
+    let overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
+    expect(
+      Array.from(overlay.querySelectorAll('button')).some((b) =>
+        /Reset URL/.test(b.textContent ?? '')
+      )
+    ).toBe(false);
+
+    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true, onReset: async () => {} });
+    overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
+    expect(
+      Array.from(overlay.querySelectorAll('button')).some((b) =>
+        /Reset URL/.test(b.textContent ?? '')
+      )
+    ).toBe(true);
+  });
+
+  it('Reset button success path clears the URL display and disables buttons', async () => {
+    const onReset = vi.fn(async () => {});
+    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true, onReset });
+    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
+    const buttons = Array.from(overlay.querySelectorAll('button')) as HTMLButtonElement[];
+    const resetBtn = buttons.find((b) => /Reset URL/.test(b.textContent ?? ''))!;
+    resetBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onReset).toHaveBeenCalled();
+    expect(resetBtn.disabled).toBe(true);
+    expect(overlay.textContent).toMatch(/Sync URL reset/);
+  });
+
+  it('Reset button failure path re-enables buttons and shows the error', async () => {
+    const onReset = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true, onReset });
+    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
+    const buttons = Array.from(overlay.querySelectorAll('button')) as HTMLButtonElement[];
+    const resetBtn = buttons.find((b) => /Reset URL/.test(b.textContent ?? ''))!;
+    const doneBtn = buttons.find((b) => b.textContent === 'Done')!;
+    resetBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(overlay.textContent).toMatch(/Reset failed: boom/);
+    expect(resetBtn.disabled).toBe(false);
+    expect(doneBtn.disabled).toBe(false);
+  });
+
+  it('Reset failure with non-Error rejection still surfaces a string', async () => {
+    const onReset = vi.fn(async () => {
+      throw 'string-reason';
+    });
+    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true, onReset });
+    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
+    const resetBtn = Array.from(overlay.querySelectorAll('button')).find((b) =>
+      /Reset URL/.test(b.textContent ?? '')
+    ) as HTMLButtonElement;
+    resetBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(overlay.textContent).toMatch(/Reset failed: string-reason/);
+  });
+});

--- a/packages/webapp/tests/ui/terminal-panel.test.ts
+++ b/packages/webapp/tests/ui/terminal-panel.test.ts
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+/**
+ * DOM tests for `TerminalPanel` — the embedded panel that hosts an
+ * xterm.js terminal and a preview pane. The `WasmShell` /
+ * `RemoteTerminalView` dependencies are stubbed via the structural
+ * `MountedTerminalShell` interface the panel already exposes for
+ * dual-mode hosting.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TerminalPanel } from '../../src/ui/terminal-panel.js';
+
+function makeMountStub(opts: { withPreview?: boolean } = {}): {
+  shell: {
+    mount: ReturnType<typeof vi.fn>;
+    refit: ReturnType<typeof vi.fn>;
+    clearTerminal: ReturnType<typeof vi.fn>;
+    executeCommandInTerminal: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+    setPreviewStateListener: ReturnType<typeof vi.fn>;
+  };
+  previewListener: { current: ((hasPreview: boolean) => void) | null };
+} {
+  const previewListener = { current: null as ((hasPreview: boolean) => void) | null };
+  const shell = {
+    mount: vi.fn(async (mountEl: HTMLElement) => {
+      const terminalHost = document.createElement('div');
+      terminalHost.className = 'terminal-panel__terminal-host';
+      mountEl.appendChild(terminalHost);
+      if (opts.withPreview !== false) {
+        const previewHost = document.createElement('div');
+        previewHost.className = 'terminal-panel__preview';
+        mountEl.appendChild(previewHost);
+      }
+    }),
+    refit: vi.fn(),
+    clearTerminal: vi.fn(),
+    executeCommandInTerminal: vi.fn(async () => ({
+      stdout: 'ok',
+      stderr: '',
+      exitCode: 0,
+    })),
+    dispose: vi.fn(),
+    setPreviewStateListener: vi.fn((listener: ((hasPreview: boolean) => void) | null) => {
+      previewListener.current = listener;
+    }),
+  };
+  return { shell, previewListener };
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('TerminalPanel — initial render', () => {
+  it('renders the header, preview button, and terminal/preview views', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    // biome-ignore lint/correctness/noUnusedVariables: side-effect render under test
+    const panel = new TerminalPanel(container);
+    expect(container.classList.contains('terminal-panel')).toBe(true);
+    expect(container.querySelector('.file-browser__header')).not.toBeNull();
+    expect(container.querySelectorAll('.terminal-panel__view')).toHaveLength(2);
+    expect(container.querySelector('.terminal-panel__empty-state')).not.toBeNull();
+    const previewBtn = container.querySelector(
+      'button[aria-label="Toggle preview"]'
+    ) as HTMLButtonElement;
+    expect(previewBtn).not.toBeNull();
+    expect(previewBtn.disabled).toBe(true);
+    void panel;
+  });
+
+  it('mounts a Clear-Terminal button only when onClearTerminal is provided', () => {
+    const c1 = document.createElement('div');
+    document.body.appendChild(c1);
+    new TerminalPanel(c1);
+    expect(c1.querySelector('button[aria-label="Clear Terminal"]')).toBeNull();
+    const c2 = document.createElement('div');
+    document.body.appendChild(c2);
+    const onClearTerminal = vi.fn();
+    new TerminalPanel(c2, { onClearTerminal });
+    const clearBtn = c2.querySelector('button[aria-label="Clear Terminal"]') as HTMLButtonElement;
+    expect(clearBtn).not.toBeNull();
+    clearBtn.click();
+    clearBtn.click();
+    expect(onClearTerminal).toHaveBeenCalledTimes(2);
+  });
+
+  it('getBodyElement() returns the panel container', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    expect(panel.getBodyElement()).toBe(container);
+  });
+
+  it('runCommand without a mounted shell returns exit code 1 + stderr message', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const result = await panel.runCommand('echo hi');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/unavailable/);
+  });
+
+  it('clearTerminal / refit / dispose are safe before a shell is mounted', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    expect(() => panel.clearTerminal()).not.toThrow();
+    expect(() => panel.refit()).not.toThrow();
+    expect(() => panel.dispose()).not.toThrow();
+    // dispose() empties the container.
+    expect(container.innerHTML).toBe('');
+  });
+});
+
+describe('TerminalPanel — mountShell (WasmShell)', () => {
+  it('relocates the terminal/preview hosts and registers a preview listener', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const { shell, previewListener } = makeMountStub();
+    await panel.mountShell(shell as unknown as never);
+    expect(shell.mount).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('.terminal-panel__terminal-host')).not.toBeNull();
+    expect(container.querySelector('.terminal-panel__preview')).not.toBeNull();
+    expect(typeof previewListener.current).toBe('function');
+  });
+
+  it('throws when the shell does not produce both expected host elements', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const { shell } = makeMountStub({ withPreview: false });
+    await expect(panel.mountShell(shell as unknown as never)).rejects.toThrow(
+      /did not create expected hosts/
+    );
+  });
+
+  it('routes clearTerminal/refit/runCommand to the mounted shell', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const { shell } = makeMountStub();
+    await panel.mountShell(shell as unknown as never);
+    panel.clearTerminal();
+    panel.refit();
+    const result = await panel.runCommand('echo hi');
+    expect(shell.clearTerminal).toHaveBeenCalledTimes(1);
+    expect(shell.refit).toHaveBeenCalled();
+    expect(shell.executeCommandInTerminal).toHaveBeenCalledWith('echo hi');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('preview-toggle button is wired to switch views once enabled', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const { shell, previewListener } = makeMountStub();
+    await panel.mountShell(shell as unknown as never);
+    previewListener.current?.(true); // turns the button on AND switches to preview
+    const previewBtn = container.querySelector(
+      'button[aria-label="Toggle preview"]'
+    ) as HTMLButtonElement;
+    expect(previewBtn.disabled).toBe(false);
+    expect(previewBtn.classList.contains('file-browser__header-btn--active')).toBe(true);
+    // Toggling it back goes to terminal.
+    previewBtn.click();
+    expect(previewBtn.classList.contains('file-browser__header-btn--active')).toBe(false);
+    // Toggling it again goes back to preview.
+    previewBtn.click();
+    expect(previewBtn.classList.contains('file-browser__header-btn--active')).toBe(true);
+  });
+
+  it('preview-toggle button does nothing when disabled', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const { shell } = makeMountStub();
+    await panel.mountShell(shell as unknown as never);
+    const previewBtn = container.querySelector(
+      'button[aria-label="Toggle preview"]'
+    ) as HTMLButtonElement;
+    expect(previewBtn.disabled).toBe(true);
+    previewBtn.click();
+    expect(previewBtn.classList.contains('file-browser__header-btn--active')).toBe(false);
+  });
+
+  it('handlePreviewStateChange(false) flips back to the terminal view', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const { shell, previewListener } = makeMountStub();
+    await panel.mountShell(shell as unknown as never);
+    previewListener.current?.(true);
+    previewListener.current?.(false);
+    const previewBtn = container.querySelector(
+      'button[aria-label="Toggle preview"]'
+    ) as HTMLButtonElement;
+    expect(previewBtn.disabled).toBe(true);
+    expect(previewBtn.classList.contains('file-browser__header-btn--active')).toBe(false);
+  });
+
+  it('runCommand for an imgcat command does NOT force back to the terminal view', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const { shell, previewListener } = makeMountStub();
+    await panel.mountShell(shell as unknown as never);
+    previewListener.current?.(true);
+    const previewBtn = container.querySelector(
+      'button[aria-label="Toggle preview"]'
+    ) as HTMLButtonElement;
+    expect(previewBtn.classList.contains('file-browser__header-btn--active')).toBe(true);
+    await panel.runCommand('imgcat /tmp/x.png');
+    // Still on the preview view.
+    expect(previewBtn.classList.contains('file-browser__header-btn--active')).toBe(true);
+  });
+
+  it('mountShell twice unhooks the prior preview listener', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const first = makeMountStub();
+    await panel.mountShell(first.shell as unknown as never);
+    const second = makeMountStub();
+    await panel.mountShell(second.shell as unknown as never);
+    // The first stub's listener was cleared before reassignment.
+    expect(first.shell.setPreviewStateListener).toHaveBeenLastCalledWith(null);
+  });
+
+  it('dispose() unhooks the preview listener and clears the container', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const { shell } = makeMountStub();
+    await panel.mountShell(shell as unknown as never);
+    panel.dispose();
+    expect(shell.setPreviewStateListener).toHaveBeenLastCalledWith(null);
+    expect(shell.dispose).toHaveBeenCalled();
+    expect(container.innerHTML).toBe('');
+  });
+});
+
+describe('TerminalPanel — mountRemoteShell', () => {
+  it('mounts a remote view that may not provide a preview host', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const { shell: view, previewListener } = makeMountStub();
+    await panel.mountRemoteShell(view as unknown as never);
+    expect(view.mount).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('.terminal-panel__terminal-host')).not.toBeNull();
+    expect(typeof previewListener.current).toBe('function');
+  });
+
+  it('throws when the remote mount produces no terminal host', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const panel = new TerminalPanel(container);
+    const view = {
+      mount: vi.fn(async (_el: HTMLElement) => {}),
+      refit: vi.fn(),
+      clearTerminal: vi.fn(),
+      executeCommandInTerminal: vi.fn(),
+      dispose: vi.fn(),
+      setPreviewStateListener: vi.fn(),
+    };
+    await expect(panel.mountRemoteShell(view as unknown as never)).rejects.toThrow(
+      /did not create expected host/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Simplifies the Electron overlay (`/electron`) shell UI by removing chrome that is now redundant with the inner app's right rail, and relocating the close affordance into the iframe.

- **Removed** the outer-shell header (`slicc` / `electron float` brand line + its close button) and the duplicate `Chat / Terminal / Files / Memory` tab bar from `SliccElectronSidebarElement`. The iframe now fills the full sidebar height.
- **Moved** the close button **inside the iframe**, into the inner thread header to the **left of the cone/scoops dropdown**, with `title="Close SLICC"`.
- **Added** a dedicated `slicc-electron-overlay:close` message protocol: the inner close button posts to `window.parent`, and the outer shell's `onMessage` handles it by collapsing to the launcher pill (`hideSidebar()`).
- Gated to **electron-overlay mode only** — standalone and extension thread headers are unchanged.
- The floating launcher pill, its toggle message, drag/corner-snap, Escape-to-close, and backdrop-click-to-close are all **left untouched**.

### Background

This work grew out of diagnosing a report of an "empty" SLICC iframe in the Electron float. The diagnosis (node+AEM, node+Slack, swift+Slack) confirmed **no server-side regression** — the "empty" appearance was simply the closed-drawer default state (only the launcher pill shows until opened). With that closed out, the follow-on request was to simplify the now-confirmed-working overlay UI.

## Files changed

- `packages/webapp/src/ui/runtime-mode.ts` — added `ELECTRON_OVERLAY_CLOSE_MESSAGE_TYPE`, `ElectronOverlayCloseMessage`, and `isElectronOverlayCloseMessage()` guard (mirrors the set-tab pattern).
- `packages/webapp/src/ui/electron-overlay.ts` — sidebar render no longer emits header/tab-bar; removed dead `.header*`/`.tab-bar*` CSS, the `tabButtons` map, and the `EXTENSION_TAB_SPECS` import; `onMessage` now handles the close message.
- `packages/webapp/src/ui/layout.ts` — added `setShowElectronOverlayClose(handler)` that mounts a 24px X button at the start of the thread header (left of the scoop switcher).
- `packages/webapp/src/ui/styles/layout.css` — `.thread-header__electron-overlay-close` styles.
- `packages/webapp/src/ui/main.ts` — wires the close button in the `isElectronOverlay` boot branch only.
- `packages/webapp/tests/ui/runtime-mode.test.ts` — cases for the new close message type + guard.

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅ (6 tsconfig projects)
- `npm run test -w @slicc/webapp` ✅ 5942 passed / 10 skipped (1 pre-existing Chrome-launch flake unrelated to this change, fails on `HEAD~1` too)
- `npm run build -w @slicc/webapp` ✅
- **Visual confirmation**: verified live via swift-server injecting the fresh overlay into Slack — close button renders left of the cone dropdown, iframe fills the drawer from the top, launcher pill intact.

## Follow-ups (non-blocking)

- DOM-level integration test for the click→postMessage→`hideSidebar()` round-trip.
- Layout-level assertion that the close button is gated to electron-overlay mode.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author