### PR TITLE
chore(coverage): add a coverage floor for the shared (@slicc/shared-ts) project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
       needs.changes.outputs.webapp == 'true' ||
       needs.changes.outputs.vfs-root == 'true' ||
       needs.changes.outputs.assets == 'true' ||
+      needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -254,6 +255,7 @@ jobs:
     if: >-
       needs.changes.outputs.cloud-core == 'true' ||
       needs.changes.outputs.node-server == 'true' ||
+      needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -286,6 +288,7 @@ jobs:
       needs.changes.outputs.webapp == 'true' ||
       needs.changes.outputs.vfs-root == 'true' ||
       needs.changes.outputs.assets == 'true' ||
+      needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -723,6 +726,7 @@ jobs:
     if: >-
       needs.changes.outputs.cloud-core == 'true' ||
       needs.changes.outputs.node-server == 'true' ||
+      needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       assets: ${{ steps.filter.outputs.assets }}
       cloud-core: ${{ steps.filter.outputs.cloud-core }}
       node-server: ${{ steps.filter.outputs.node-server }}
+      shared: ${{ steps.filter.outputs.shared }}
       extension: ${{ steps.filter.outputs.extension }}
       cloudflare-worker: ${{ steps.filter.outputs.cloudflare-worker }}
       cherry: ${{ steps.filter.outputs.cherry }}
@@ -47,6 +48,8 @@ jobs:
               - 'packages/cloud-core/**'
             node-server:
               - 'packages/node-server/**'
+            shared:
+              - 'packages/shared-ts/**'
             extension:
               - 'packages/chrome-extension/**'
             cloudflare-worker:
@@ -144,6 +147,7 @@ jobs:
       needs.changes.outputs.assets == 'true' ||
       needs.changes.outputs.cloud-core == 'true' ||
       needs.changes.outputs.node-server == 'true' ||
+      needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.extension == 'true' ||
       needs.changes.outputs.cloudflare-worker == 'true' ||
       needs.changes.outputs.cherry == 'true' ||
@@ -525,6 +529,33 @@ jobs:
       - name: Build
         run: npm run build -w @slicc/cloud-core
 
+  shared:
+    needs: changes
+    if: >-
+      needs.changes.outputs.shared == 'true' ||
+      needs.changes.outputs.root-config == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Typecheck
+        run: npm run typecheck -w @slicc/shared-ts
+      - name: Test (with coverage threshold gate)
+        run: npm run test:coverage:shared
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-shared
+          path: coverage/
+          if-no-files-found: ignore
+      - name: Build
+        run: npm run build -w @slicc/shared-ts
+
   cherry:
     needs: changes
     if: >-
@@ -752,6 +783,7 @@ jobs:
         chrome-extension,
         cloudflare-worker,
         cloud-core,
+        shared,
         global-install,
         swift-launcher,
         swift-server,

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -55,10 +55,10 @@
       "branches": 75
     },
     "shared": {
-      "lines": 93,
-      "statements": 91,
-      "functions": 89,
-      "branches": 86
+      "lines": 94,
+      "statements": 93,
+      "functions": 92,
+      "branches": 84
     }
   },
   "swift": {

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -53,6 +53,12 @@
       "statements": 78,
       "functions": 72,
       "branches": 75
+    },
+    "shared": {
+      "lines": 93,
+      "statements": 91,
+      "functions": 89,
+      "branches": 86
     }
   },
   "swift": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test:coverage:webapp": "node packages/dev-tools/tools/coverage-gate.mjs webapp",
     "test:coverage:cherry": "node packages/dev-tools/tools/coverage-gate.mjs cherry",
     "test:coverage:cloud-core": "node packages/dev-tools/tools/coverage-gate.mjs cloud-core",
+    "test:coverage:shared": "node packages/dev-tools/tools/coverage-gate.mjs shared",
     "coverage:ratchet": "node packages/dev-tools/tools/coverage-ratchet.mjs",
     "test:server-integration": "vitest run --config packages/node-server/tests/integration/server/vitest.config.ts",
     "test:e2e": "npx playwright test --config packages/webapp/tests/e2e/playwright.config.ts",

--- a/packages/shared-ts/tests/sign-and-forward.test.ts
+++ b/packages/shared-ts/tests/sign-and-forward.test.ts
@@ -311,7 +311,7 @@ describe('executeS3SignAndForward — successful sign + forward', () => {
     for (let i = 0; i < payload.length; i++) binary += String.fromCharCode(payload[i]);
     const bodyBase64 = btoa(binary);
 
-    const original = globalThis.Buffer;
+    const original = (globalThis as { Buffer?: unknown }).Buffer;
     (globalThis as { Buffer?: unknown }).Buffer = undefined;
     let reply: Awaited<ReturnType<typeof executeS3SignAndForward>>;
     try {


### PR DESCRIPTION
## What

The `shared` vitest project (`@slicc/shared-ts`) had no entry in `coverage-thresholds.json`. As a result the nightly coverage ratchet skipped it (the ratchet iterates the `typescript` keys) and CI never gated its coverage — a regression in shared-ts coverage would have gone unnoticed.

This introduces a coverage floor for the `shared` project and wires it into the ratchet and CI exactly like every other TypeScript package.

## Changes

- **`coverage-thresholds.json`**: new `shared` key under `typescript` with floors **lines 93 / statements 91 / functions 89 / branches 86**. These are `floor()` of the currently measured coverage (lines 93.95 / statements 91.96 / functions 89.83 / branches 86.92), matching the ratchet's `nextFloor` convention, so the gate passes today and the next nightly ratchet has nothing to raise.
- **`package.json`**: add `test:coverage:shared` → `coverage-gate.mjs shared`, mirroring the other `test:coverage:*` scripts.
- **`.github/workflows/ci.yml`**:
  - add a `shared` path filter (`packages/shared-ts/**`) and the matching `changes` output;
  - add a `shared` coverage job (typecheck → coverage gate → build), modeled on the `cloud-core`/`node-server` jobs;
  - include `shared` in the `node-matrix-tests` trigger so a shared-ts-only change still exercises the multi-Node test matrix;
  - add `shared` to the required `ci` summary job's `needs` so the new gate is part of branch protection.

No ratchet **code** change is needed — `coverage-ratchet.mjs` auto-discovers the new key, so the nightly job will now measure and (only ever) raise the `shared` floor going forward.

## Verification

- `npm run test:coverage:shared` — passes (6 files, 83 tests; measured coverage above all four floors).
- `npm run lint` — passes.
- `ci.yml` parses as valid YAML; `jobs.ci.needs` includes `shared`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KTF766FKW3R77FT8Q1DAZEMC&panel=chat)