### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
         run: npm run test
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
+          SLICC_CDP_LAUNCH_TIMEOUT_MS: '60000'
 
   webapp:
     needs: changes

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -10,13 +10,13 @@
     "node-server": {
       "lines": 74,
       "statements": 72,
-      "functions": 75,
+      "functions": 76,
       "branches": 64
     },
     "chrome-extension": {
       "lines": 73,
       "statements": 71,
-      "functions": 65,
+      "functions": 66,
       "branches": 60,
       "coverageExclude": [
         "**/node_modules/**",

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -3504,8 +3504,9 @@ const FRAME_HTML = `<!DOCTYPE html>
 
 const chromePath = findChromeExecutable();
 const describeIntegration = chromePath ? describe : describe.skip;
+const INTEGRATION_CDP_LAUNCH_TIMEOUT_MS = Math.max(getDefaultCdpLaunchTimeoutMs(), 60_000);
 
-describeIntegration('iframe integration', { timeout: 60_000 }, () => {
+describeIntegration('iframe integration', { timeout: 90_000 }, () => {
   let server: http.Server;
   let serverPort: number;
   let chromeProcess: ChildProcess;
@@ -3539,6 +3540,7 @@ describeIntegration('iframe integration', { timeout: 60_000 }, () => {
       '--no-first-run',
       '--no-default-browser-check',
       '--disable-gpu',
+      '--disable-dev-shm-usage',
       '--disable-crash-reporter',
       `--user-data-dir=${tmpDir}`,
       'about:blank',
@@ -3552,7 +3554,7 @@ describeIntegration('iframe integration', { timeout: 60_000 }, () => {
     // because GitHub runners commonly pay a 10+ second cold-start tax.
     const cdpPort = await waitForCdpPort(chromeProcess, {
       userDataDir: tmpDir,
-      timeoutMs: Math.max(getDefaultCdpLaunchTimeoutMs(), 25_000),
+      timeoutMs: INTEGRATION_CDP_LAUNCH_TIMEOUT_MS,
     });
 
     // 3. Fetch the browser WS URL from /json/version
@@ -3567,7 +3569,7 @@ describeIntegration('iframe integration', { timeout: 60_000 }, () => {
 
     // 5. Create a mock FS for the command
     mockFs = createMockFS();
-  }, 30_000);
+  }, INTEGRATION_CDP_LAUNCH_TIMEOUT_MS + 15_000);
 
   afterAll(async () => {
     try {


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.