### PR TITLE
fix(test): deterministic concurrency probe in workflow acceptance test (unblock main)

### DIFF
--- a/packages/webapp/tests/shell/supplemental-commands/workflow-acceptance.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/workflow-acceptance.test.ts
@@ -35,10 +35,31 @@ describe('workflow acceptance', () => {
     await fs.writeFile('/workspace/repo-audit.workflow.js', FIXTURE);
 
     const peak = { cur: 0, max: 0 };
+    // Deterministically observe concurrency without relying on event-loop timing.
+    // The pipeline issues both "Find bugs" agents together (cap 4 ≥ 2), so hold
+    // the first two spawns until both are in flight, then release — guaranteeing
+    // peak.max ≥ 2. A safety timeout prevents any deadlock if they never overlap.
+    // (Bare `await Promise.resolve()` flaked: under load the first spawn could
+    // resolve before the second was issued, leaving peak.max === 1.)
+    const PROBE = 2;
+    const firstWave: Array<() => void> = [];
+    let probed = false;
+    const releaseFirstWave = (): void => {
+      probed = true;
+      for (const r of firstWave.splice(0)) r();
+    };
     const spawn = async (a: string[]) => {
       peak.cur++;
       peak.max = Math.max(peak.max, peak.cur);
-      await Promise.resolve();
+      if (probed) {
+        await Promise.resolve();
+      } else {
+        await new Promise<void>((resolve) => {
+          firstWave.push(resolve);
+          if (firstWave.length >= PROBE) releaseFirstWave();
+          else setTimeout(releaseFirstWave, 2000);
+        });
+      }
       const prompt = a[a.length - 1];
       const hasSchema = a.includes('--schema-b64');
       let stdout = '';


### PR DESCRIPTION
## Summary

Unblocks `main`: the `Release` workflow's `npm run test` is failing on the SP1 workflow-acceptance test with `AssertionError: expected 1 to be greater than 1` (`workflow-acceptance.test.ts:76`).

## Root cause

The test asserts `peak.max > 1` (bounded concurrency) by counting overlapping mock `agent` spawns, but the mock used a bare `await Promise.resolve()` — a single-microtask yield. That's event-loop-timing dependent: under the full-suite load of the `Release` job, the first spawn could resolve before the pipeline issued the second, so `peak.max` stayed at `1`. It passed in the per-package PR CI (lighter load) but flakes in the full `npm run test`.

## Fix (test-only)

Replace the timing-based probe with a **barrier**: hold the first two spawns (the pipeline's two concurrent "Find bugs" agents — `cap 4 ≥ 2`) until both are in flight, then release. This guarantees `peak.max ≥ 2` deterministically regardless of load. A 2s safety timeout releases a lone waiter so it can never deadlock. No product code changes.

## Verification

- `workflow-acceptance.test.ts` — 10/10 isolated runs green.
- Full `npm test` — **7496 passed / 0 failed** (the condition that exposed the flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
