### PR TITLE
fix(test): count-only concurrency barrier in workflow acceptance test (unblock main, take 2)

### DIFF
--- a/packages/webapp/tests/shell/supplemental-commands/workflow-acceptance.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/workflow-acceptance.test.ts
@@ -35,31 +35,32 @@ describe('workflow acceptance', () => {
     await fs.writeFile('/workspace/repo-audit.workflow.js', FIXTURE);
 
     const peak = { cur: 0, max: 0 };
-    // Deterministically observe concurrency without relying on event-loop timing.
-    // The pipeline issues both "Find bugs" agents together (cap 4 ≥ 2), so hold
-    // the first two spawns until both are in flight, then release — guaranteeing
-    // peak.max ≥ 2. A safety timeout prevents any deadlock if they never overlap.
-    // (Bare `await Promise.resolve()` flaked: under load the first spawn could
-    // resolve before the second was issued, leaving peak.max === 1.)
+    // Deterministically prove bounded-concurrent fan-out with NO wall-clock timing.
+    // The pipeline issues both "Find bugs" agents together (semaphore cap 4 ≥ 2) and
+    // the runtime dispatches both execs before either returns (the realm host answers
+    // exec RPCs fire-and-forget, so neither spawn is gated on the other completing).
+    // We therefore hold the first PROBE spawns until PROBE are concurrently in flight;
+    // the PROBE-th arrival releases the whole wave. This pins peak.max ≥ PROBE
+    // regardless of the realm factory (in-process vs Worker) or event-loop scheduling,
+    // and cannot deadlock because both execs are guaranteed in flight. vitest's own
+    // test timeout is the only backstop (we widen it below for starved CI runners).
+    //
+    // The previous version used `setTimeout(release, 2000)` as a safety escape; on a
+    // CPU-starved CI runner the timer fired BETWEEN the two spawns (real Worker-realm
+    // exec round-trips are macrotasks), releasing the first spawn alone → peak.max === 1.
+    // A count-only barrier removes that wall-clock dependency entirely.
     const PROBE = 2;
-    const firstWave: Array<() => void> = [];
-    let probed = false;
-    const releaseFirstWave = (): void => {
-      probed = true;
-      for (const r of firstWave.splice(0)) r();
-    };
+    let releaseWave!: () => void;
+    const waveReady = new Promise<void>((resolve) => {
+      releaseWave = resolve;
+    });
+    let arrived = 0;
     const spawn = async (a: string[]) => {
       peak.cur++;
       peak.max = Math.max(peak.max, peak.cur);
-      if (probed) {
-        await Promise.resolve();
-      } else {
-        await new Promise<void>((resolve) => {
-          firstWave.push(resolve);
-          if (firstWave.length >= PROBE) releaseFirstWave();
-          else setTimeout(releaseFirstWave, 2000);
-        });
-      }
+      const index = arrived++;
+      if (arrived >= PROBE) releaseWave(); // the PROBE-th concurrent spawn frees the wave
+      if (index < PROBE) await waveReady; // only the first wave blocks; later spawns flow
       const prompt = a[a.length - 1];
       const hasSchema = a.includes('--schema-b64');
       let stdout = '';
@@ -96,5 +97,8 @@ describe('workflow acceptance', () => {
     // Concurrency: max should be > 1 (parallel execution) but <= 4 (cap)
     expect(peak.max).toBeGreaterThan(1);
     expect(peak.max).toBeLessThanOrEqual(4);
-  });
+    // 30s timeout: the count-only barrier releases the instant both spawns are in
+    // flight, so this is just a generous backstop for a starved CI runner — never the
+    // normal path. (Default 5s could false-fail if the 2nd exec dispatch is delayed.)
+  }, 30000);
 });


### PR DESCRIPTION
## Problem

`main`'s **Release** workflow is still red after #929. The Release workflow runs the full `npm run test` on push-to-main (PR CI does not), and the same assertion keeps failing:

```
FAIL packages/webapp/tests/shell/supplemental-commands/workflow-acceptance.test.ts
  > runs a fan-out/verify workflow with schema and bounded concurrency
AssertionError: expected 1 to be greater than 1
  ❯ ...workflow-acceptance.test.ts:97:22  expect(peak.max).toBeGreaterThan(1)
```

It has failed on **every** push to main since #926 (#926, #928, #929) — PR CI was green each time because `Release` only runs on push.

## Root cause

#929 replaced the bare `await Promise.resolve()` with a barrier, but kept a wall-clock **`setTimeout(release, 2000)`** safety escape. That escape is the bug.

- The realm factory is chosen by `typeof Worker !== 'undefined' || typeof document !== 'undefined'` (`jsh-executor.ts:pickDefaultRealmFactory`). In a clean node env this is the **in-process** realm, where the exec bridge is `queueMicrotask`-based and the host answers exec RPCs fire-and-forget — so both "Find bugs" spawns are deterministically in flight together (`peak.max === 2`) and the timer is moot.
- On a CPU-starved CI runner, `Worker`/`document` leak across non-isolated vitest files, so the **real Worker realm** is selected. Exec round-trips then cross real macrotask boundaries. If the second spawn's dispatch is delayed past 2s, the timer fires **between** the two spawns, releasing the first alone → `peak.max === 1`.

In short: any wall-clock escape can fire in the gap between the two spawns under load.

## Fix

Replace the timer with a **count-only barrier**: hold the first `PROBE` (=2) spawns until `PROBE` are concurrently in flight; the `PROBE`-th arrival releases the wave.

- Deterministic `peak.max ≥ PROBE` regardless of realm factory or event-loop scheduling — no wall-clock dependency.
- Cannot deadlock: the pipeline issues both agents under the cap-4 semaphore, and the realm host answers exec RPCs fire-and-forget, so both execs are always in flight before either returns.
- `vitest`'s test timeout (widened to 30s) is the only backstop, so a genuinely broken runtime fails loudly instead of flaking.

## Verification

- 10/10 isolated runs green.
- A standalone model of both barriers under a starvation gap (gap > timer) reproduces the **old** `max=1` and shows the **new** barrier yields `max=2` — proving the fix addresses the exact failure condition.
- Full `npm test -w @slicc/webapp` green locally (the flake does not reproduce on a fast/unloaded machine — it is starvation-correlated, which is why it only bites the Release runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)