### PR TITLE
fix(test): pin core count in workflow acceptance test (the actual root cause)

### DIFF
--- a/packages/webapp/tests/shell/supplemental-commands/workflow-acceptance.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/workflow-acceptance.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import 'fake-indexeddb/auto';
 import { VirtualFS } from '../../../src/fs/index.js';
 import { createWorkflowCommand } from '../../../src/shell/supplemental-commands/workflow-command.js';
@@ -29,26 +29,32 @@ async function ctxWith(
 }
 
 describe('workflow acceptance', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   it('runs a fan-out/verify workflow with schema and bounded concurrency', async () => {
+    // ROOT CAUSE of the prior CI failures (#929/#930): the effective concurrency cap is
+    // `min(--concurrency, resolveMaxCap())` and `resolveMaxCap() = min(16, max(1, cores-2))`
+    // reads `navigator.hardwareConcurrency` (workflow-command.ts). On a 2-core CI runner
+    // that is `max(1, 0) = 1`, so `--concurrency 4` is CLAMPED TO 1 → agents run serially →
+    // the two "Find bugs" spawns never overlap (peak.max===1), and a concurrency barrier
+    // would deadlock (agent B can't acquire the cap-1 semaphore until A finishes, but A
+    // waits for B). Locally (many cores) the cap is 4 and it passes — hence "green local,
+    // red Release". Pin the core count so the cap is a deterministic 4
+    // (min(4, min(16, max(1, 8-2))) = 4) regardless of the runner. Reproduced + verified
+    // locally by stubbing navigator to 2 cores (deadlock) vs 8 (pass).
+    vi.stubGlobal('navigator', { hardwareConcurrency: 8 });
+
     const fs = await VirtualFS.create({ dbName: `wf-${Math.random()}`, wipe: true });
     await fs.mkdir('/workspace', { recursive: true });
     await fs.writeFile('/workspace/repo-audit.workflow.js', FIXTURE);
 
     const peak = { cur: 0, max: 0 };
-    // Deterministically prove bounded-concurrent fan-out with NO wall-clock timing.
-    // The pipeline issues both "Find bugs" agents together (semaphore cap 4 ≥ 2) and
-    // the runtime dispatches both execs before either returns (the realm host answers
-    // exec RPCs fire-and-forget, so neither spawn is gated on the other completing).
-    // We therefore hold the first PROBE spawns until PROBE are concurrently in flight;
-    // the PROBE-th arrival releases the whole wave. This pins peak.max ≥ PROBE
-    // regardless of the realm factory (in-process vs Worker) or event-loop scheduling,
-    // and cannot deadlock because both execs are guaranteed in flight. vitest's own
-    // test timeout is the only backstop (we widen it below for starved CI runners).
-    //
-    // The previous version used `setTimeout(release, 2000)` as a safety escape; on a
-    // CPU-starved CI runner the timer fired BETWEEN the two spawns (real Worker-realm
-    // exec round-trips are macrotasks), releasing the first spawn alone → peak.max === 1.
-    // A count-only barrier removes that wall-clock dependency entirely.
+    // With the cap pinned to 4 (above), the pipeline issues both "Find bugs" agents
+    // together and both acquire the semaphore before either spawn returns. Hold the first
+    // PROBE spawns until PROBE are concurrently in flight; the PROBE-th arrival releases
+    // the wave — a count-only barrier (no wall-clock) that deterministically yields
+    // peak.max ≥ PROBE. This is safe (no deadlock) precisely BECAUSE the cap is ≥ PROBE;
+    // the prior failures came from the cap collapsing to 1 on CI, not from this barrier.
     const PROBE = 2;
     let releaseWave!: () => void;
     const waveReady = new Promise<void>((resolve) => {
@@ -94,11 +100,11 @@ describe('workflow acceptance', () => {
     expect(Array.isArray(parsed.confirmed)).toBe(true);
     // Only "x" verifies as real
     expect(parsed.confirmed.every((c: any) => c.bug === 'x')).toBe(true);
-    // Concurrency: max should be > 1 (parallel execution) but <= 4 (cap)
+    // Concurrency: with the cap pinned to 4, the two "Find bugs" agents overlap, so
+    // peak.max is > 1 (parallel) and <= 4 (cap).
     expect(peak.max).toBeGreaterThan(1);
     expect(peak.max).toBeLessThanOrEqual(4);
-    // 30s timeout: the count-only barrier releases the instant both spawns are in
-    // flight, so this is just a generous backstop for a starved CI runner — never the
-    // normal path. (Default 5s could false-fail if the 2nd exec dispatch is delayed.)
-  }, 30000);
+    // 10s timeout: a backstop only. The cap is pinned to 4 so the barrier can't deadlock;
+    // this guards against unforeseen hangs without masking them behind a huge window.
+  }, 10000);
 });


### PR DESCRIPTION
## TL;DR

The real reason main's **Release** workflow kept failing through #929 and #930 is **not** event-loop timing or the realm factory — it's the **concurrency cap collapsing to 1 on a 2-core CI runner**. This pins the core count so the cap is deterministic.

## Root cause (reproduced locally)

The effective cap is `min(--concurrency, resolveMaxCap())`, and:

```ts
// workflow-command.ts
function resolveMaxCap() {
  const cores = globalThis.navigator?.hardwareConcurrency ?? 8;
  return Math.min(16, Math.max(1, cores - 2)); // spec cap
}
```

GitHub's Release runner is **2 cores** → `max(1, 2 - 2) = 1` → `maxCap = 1` → `--concurrency 4` is **clamped to 1**. With cap 1 the two "Find bugs" agents run **serially** (semaphore cap 1), so their mock spawns never overlap:

- **Original test** → `peak.max === 1` → `expect(peak.max).toBeGreaterThan(1)` fails.
- **#930's count-only barrier** → **deadlock**: agent B can't acquire the cap-1 semaphore until agent A's spawn returns, but A's spawn waits for B to arrive → `Error: Test timed out in 30000ms`.

Locally the machine reports many cores → cap 4 → agents overlap → pass. That is the complete "green local / red Release" story, and it's **realm-independent** (the earlier timer-between-spawns and Worker-realm-serialization theories were both wrong).

**Reproduced locally** by stubbing `navigator.hardwareConcurrency`: 2 cores → deadlock; 8/16 cores → pass.

## Fix

```ts
vi.stubGlobal('navigator', { hardwareConcurrency: 8 }); // → maxCap 6 → cap min(4,6) = 4
```

Pin the core count so the cap is a deterministic **4** on every runner. The count-only barrier stays (now safe, since the cap is ≥ the probe size) and the timeout drops from 30s to a 10s backstop. `afterEach(() => vi.unstubAllGlobals())` restores the global.

## Verification

- Reproduced the failure locally (navigator → 2 cores ⇒ deadlock) and confirmed the fix (navigator → 8 ⇒ pass).
- Fixed test: **10/10 green, ~50ms each** (no deadlock).

## Note (not fixed here)

`resolveMaxCap()` clamps real workflows to cap 1 on 2-core machines (e.g. small cloud cones), making them fully serial. That's a product/design question for the workflow cap policy, separate from this test-determinism fix — flagging it for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)