### PR TITLE
ci(agentic-debt-triage): raise --max-turns from 40 to 200

### DIFF
--- a/.github/workflows/agentic-debt-triage.yml
+++ b/.github/workflows/agentic-debt-triage.yml
@@ -119,5 +119,5 @@ jobs:
           claude_args: |
             --model ${{ vars.SINS_BEDROCK_MODEL || vars.RUM_BEDROCK_MODEL || 'global.anthropic.claude-sonnet-4-6' }}
             --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*)"
-            --max-turns 40
+            --max-turns 200
           prompt: ${{ steps.sin.outputs.prompt }}


### PR DESCRIPTION
## What

Raise `--max-turns` for the **Agentic Debt Triage** nightly cron from `40` to `200`.

## Why

Run [27194757786](https://github.com/ai-ecoverse/slicc/actions/runs/27194757786) failed with:

```
"subtype": "error_max_turns",
error: Claude Code returned an error result: Reached maximum number of turns (40)
```

The triage scoop ran out of its turn budget before completing the hunt-and-file loop. Bumping the budget to 200 gives it enough room to finish within a single run.

## Change

`.github/workflows/agentic-debt-triage.yml` — `--max-turns 40` → `--max-turns 200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)