### PR TITLE
feat(upskill): Support claude marketplace repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Virtual Filesystem (packages/webapp/src/fs/) → RestrictedFS → Shell (package
 
 **Dips** (`packages/webapp/src/ui/dip.ts`): Agent ` ```shtml ` code blocks in chat messages are hydrated into sandboxed iframes after streaming completes. Minimal bridge (lick-only, no state) via postMessage. Auto-height via ResizeObserver. CLI mode: direct srcdoc iframe. Extension mode: routes through `sprinkle-sandbox.html` (same CSP-exempt sandbox as panel sprinkles). Lick events route to the cone via `routeLickToScoop` (CLI) or `client.sendSprinkleLick` (extension). CSS: `.msg__dip` container, `.sprinkle-action-card` component.
 
-**Skills** (`packages/webapp/src/skills/`, `packages/webapp/src/scoops/skills.ts`): native `/workspace/skills/` packages auto-load into the system prompt alongside accessible compatibility skills discovered from `.agents/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md` anywhere in the reachable VFS. Only native `/workspace/skills/` entries are install-managed; compatibility roots stay read-only.
+**Skills** (`packages/webapp/src/skills/`, `packages/webapp/src/scoops/skills.ts`): native `/workspace/skills/` packages auto-load into the system prompt alongside accessible compatibility skills discovered from `.agents/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md` anywhere in the reachable VFS, and marketplace skills discovered from any `.claude-plugin/marketplace.json` manifest (skills at `<plugin-source>/skills/<name>/SKILL.md`). Only native `/workspace/skills/` entries are install-managed; compatibility and marketplace roots stay read-only. Precedence: native → agents → claude → marketplace.
 
 ### Data Flow
 

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -323,11 +323,24 @@ Use the skill doc at `packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
 
 Skill package manager. Installs into `/workspace/skills/<name>/` from three registries:
 
-| Install ref                        | Registry                                                                                                                                                                                     |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `upskill <owner>/<repo>[@branch]`  | GitHub. Supports `--skill <name>` (repeatable), `--all`, `--path <subfolder>`, `--branch/-b`, `--list`, `--force`.                                                                           |
-| `upskill tessl:<name>`             | Tessl registry (resolves to a GitHub source under the hood).                                                                                                                                 |
-| `upskill browse:<hostname>/<task>` | [browse.sh](https://browse.sh) site-specific skills. Equivalent URL form: `upskill https://browse.sh/skills/<hostname>/<task>`. Installs into `/workspace/skills/browse-<hostname>-<name>/`. |
+| Install ref                        | Registry                                                                                                                                                                                                             |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `upskill <owner>/<repo>[@branch]`  | GitHub. Supports `--skill <name>` (repeatable), `--all`, `--path <subfolder>`, `--branch/-b`, `--list`, `--force`. If the repo contains `.claude-plugin/marketplace.json`, switches to marketplace mode — see below. |
+| `upskill tessl:<name>`             | Tessl registry (resolves to a GitHub source under the hood).                                                                                                                                                         |
+| `upskill browse:<hostname>/<task>` | [browse.sh](https://browse.sh) site-specific skills. Equivalent URL form: `upskill https://browse.sh/skills/<hostname>/<task>`. Installs into `/workspace/skills/browse-<hostname>-<name>/`.                         |
+
+### Marketplace repos (`.claude-plugin/marketplace.json`)
+
+When a GitHub repo contains `.claude-plugin/marketplace.json` at its root, `upskill` enters marketplace mode. Skills are organised into named plugin collections; the listing is grouped by collection rather than flat.
+
+```
+upskill owner/repo                    # grouped listing by plugin collection
+upskill owner/repo --plugin <name>    # install all skills in a collection
+upskill owner/repo --skill <name>     # install a specific skill (unchanged)
+upskill owner/repo --all              # install everything (skips git-subdir plugins)
+```
+
+`--plugin` and `--skill` are mutually exclusive. Plugin collections whose `source` is a `git-subdir` object (external repos not in the ZIP) are skipped with a `⚠` warning. Repos without a manifest fall back to the existing flat SKILL.md discovery unchanged.
 
 `upskill search "<query>"` round-robin interleaves results from Tessl and the browse.sh catalog (first hit from each source, then second from each, …) so both registries get visibility in the top page. `upskill recommendations` matches your profile; add `--install` to write the matches.
 

--- a/packages/vfs-root/workspace/skills/skill-authoring/SKILL.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/SKILL.md
@@ -16,15 +16,18 @@ A skill is a folder with a `SKILL.md` (and optional companion files) that loads 
 
 ## Discovery
 
-SLICC discovers three kinds of skill roots:
+SLICC discovers four kinds of skill roots:
 
-| Root                                        | Source                               | Mutability                          |
-| ------------------------------------------- | ------------------------------------ | ----------------------------------- |
-| `/workspace/skills/<name>/SKILL.md`         | Bundled or installed via `upskill`   | Install-managed; you can edit them  |
-| `.agents/skills/<name>/SKILL.md` (anywhere) | Compatibility (Cursor / SuperClaude) | Read-only (discovered, not managed) |
-| `.claude/skills/<name>/SKILL.md` (anywhere) | Compatibility (Claude Code)          | Read-only (discovered, not managed) |
+| Root                                                         | Source                                  | Mutability                          |
+| ------------------------------------------------------------ | --------------------------------------- | ----------------------------------- |
+| `/workspace/skills/<name>/SKILL.md`                          | Bundled or installed via `upskill`      | Install-managed; you can edit them  |
+| `.agents/skills/<name>/SKILL.md` (anywhere)                  | Compatibility (Cursor / SuperClaude)    | Read-only (discovered, not managed) |
+| `.claude/skills/<name>/SKILL.md` (anywhere)                  | Compatibility (Claude Code)             | Read-only (discovered, not managed) |
+| `<mount>/.claude-plugin/marketplace.json` → plugin `skills/` | Claude Code marketplace (mounted repos) | Read-only (discovered, not managed) |
 
-When you create a new skill **for SLICC**, put it in `/workspace/skills/<name>/`. The `.agents/` and `.claude/` paths exist so SLICC can pick up skills authored for other agents without modification — don't create new skills there.
+The marketplace root is auto-discovered: when a mounted directory contains `.claude-plugin/marketplace.json`, SLICC reads the manifest, resolves each plugin's `source` path, and discovers skills at `<plugin-source>/skills/<name>/SKILL.md`. No install step needed — mount the repo and the skills are live immediately. Precedence: native > agents > claude > marketplace.
+
+When you create a new skill **for SLICC**, put it in `/workspace/skills/<name>/`. The `.agents/`, `.claude/`, and marketplace paths exist so SLICC can pick up skills authored for other agents without modification — don't create new skills there.
 
 ## SKILL.md structure
 

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -158,7 +158,7 @@ Deep reference: `docs/kernel/process-model.md`.
 
 - Path: `packages/webapp/src/skills/`
 - Discovers install-managed native skills from `/workspace/skills/`.
-- Also discovers compatible read-only skill roots under `.agents/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md`.
+- Also discovers compatible read-only skill roots under `.agents/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md`, and marketplace skills from any `.claude-plugin/marketplace.json` manifest found in the VFS (skills at `<plugin-source>/skills/<name>/SKILL.md`). Precedence: native → agents → claude → marketplace.
 
 ### Sprinkle Rendering
 

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -488,14 +488,20 @@ function formatSkillSource(source: DiscoveredSkill['source']): string {
 }
 
 function formatDiscoveredSkills(discovered: DiscoveredSkill[], heading: string): string {
+  const nameWidth = Math.max(4, ...discovered.map((s) => s.name.length));
+  const sourceWidth = 11; // 'marketplace'.length
+
+  const header = 'NAME'.padEnd(nameWidth);
+  const divider = '─'.repeat(nameWidth + sourceWidth + 2 + 60);
+
   let output = `${heading}:\n\n`;
-  output += '  NAME                 SOURCE    DESCRIPTION\n';
-  output += '  ─────────────────────────────────────────────────────────────\n';
+  output += `  ${header}  SOURCE      DESCRIPTION\n`;
+  output += `  ${divider}\n`;
 
   for (const skill of discovered) {
     const raw = skill.description || '';
     const description = raw.length > 60 ? raw.slice(0, 59) + '…' : raw;
-    output += `  ${skill.name.padEnd(20)} ${formatSkillSource(skill.source).padEnd(9)} ${description}\n`;
+    output += `  ${skill.name.padEnd(nameWidth)}  ${formatSkillSource(skill.source).padEnd(sourceWidth)} ${description}\n`;
   }
 
   output += `\n${formatDiscoveryScope()}`;

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -490,17 +490,19 @@ function formatSkillSource(source: DiscoveredSkill['source']): string {
 function formatDiscoveredSkills(discovered: DiscoveredSkill[], heading: string): string {
   const nameWidth = Math.max(4, ...discovered.map((s) => s.name.length));
   const sourceWidth = 11; // 'marketplace'.length
+  // 2 indent + nameWidth + 2 sep + sourceWidth + 1 sep = fixed overhead
+  const descWidth = Math.max(20, 120 - 2 - nameWidth - 2 - sourceWidth - 1);
 
   const header = 'NAME'.padEnd(nameWidth);
-  const divider = '─'.repeat(nameWidth + sourceWidth + 2 + 60);
+  const divider = '─'.repeat(2 + nameWidth + 2 + sourceWidth + 1 + descWidth);
 
   let output = `${heading}:\n\n`;
   output += `  ${header}  SOURCE      DESCRIPTION\n`;
-  output += `  ${divider}\n`;
+  output += `${divider}\n`;
 
   for (const skill of discovered) {
     const raw = skill.description || '';
-    const description = raw.length > 60 ? raw.slice(0, 59) + '…' : raw;
+    const description = raw.length > descWidth ? raw.slice(0, descWidth - 1) + '…' : raw;
     output += `  ${skill.name.padEnd(nameWidth)}  ${formatSkillSource(skill.source).padEnd(sourceWidth)} ${description}\n`;
   }
 

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -471,7 +471,7 @@ function formatGitHubFailure(
 }
 
 function formatDiscoveryScope(): string {
-  return 'Discovery roots: /workspace/skills plus accessible **/.agents/skills/* and **/.claude/skills/* anywhere in the VFS.\n';
+  return 'Discovery roots: /workspace/skills plus accessible **/.agents/skills/*, **/.claude/skills/*, and **/.claude-plugin/marketplace.json skill collections anywhere in the VFS.\n';
 }
 
 function formatSkillSource(source: DiscoveredSkill['source']): string {

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -1184,9 +1184,17 @@ function detectMarketplaceManifest(files: Record<string, Uint8Array>): ResolvedM
       continue;
     }
 
-    const normalizedSource = plugin.source.replace(/^\.\//, '');
-    const pluginDir = `${manifestDir}${normalizedSource}`;
-    const skillsPrefix = `${pluginDir}/skills/`;
+    // Strip leading "./" and trailing "/" so source "." and "./" both resolve
+    // to the manifest root rather than producing a leading "/" or "./" prefix
+    // that won't match ZIP entry paths.
+    const normalizedSource = plugin.source
+      .replace(/^\.\//, '')
+      .replace(/\/$/, '')
+      .replace(/^\.$/, '');
+    const pluginDir = normalizedSource
+      ? `${manifestDir}${normalizedSource}`
+      : manifestDir.replace(/\/$/, '');
+    const skillsPrefix = pluginDir ? `${pluginDir}/skills/` : 'skills/';
 
     const skills: Array<{ name: string; path: string }> = [];
     for (const filePath of Object.keys(files)) {
@@ -1195,7 +1203,7 @@ function detectMarketplaceManifest(files: Record<string, Uint8Array>): ResolvedM
       const parts = rest.split('/');
       if (parts.length >= 2 && parts[1] === 'SKILL.md') {
         const skillName = parts[0];
-        const skillPath = `${pluginDir}/skills/${skillName}`;
+        const skillPath = pluginDir ? `${pluginDir}/skills/${skillName}` : `skills/${skillName}`;
         if (!skills.find((s) => s.name === skillName)) {
           skills.push({ name: skillName, path: skillPath });
         }

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -493,7 +493,8 @@ function formatDiscoveredSkills(discovered: DiscoveredSkill[], heading: string):
   output += '  ─────────────────────────────────────────────────────────────\n';
 
   for (const skill of discovered) {
-    const description = skill.description || '';
+    const raw = skill.description || '';
+    const description = raw.length > 60 ? raw.slice(0, 59) + '…' : raw;
     output += `  ${skill.name.padEnd(20)} ${formatSkillSource(skill.source).padEnd(9)} ${description}\n`;
   }
 

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -134,6 +134,40 @@ interface UserProfile {
   company?: string;
 }
 
+// ── Marketplace manifest types ──
+
+interface MarketplacePluginSourceGitSubdir {
+  source: 'git-subdir';
+  url: string;
+  path: string;
+  sha: string;
+}
+
+interface MarketplacePlugin {
+  name: string;
+  description?: string;
+  source: string | MarketplacePluginSourceGitSubdir;
+  strict?: boolean;
+}
+
+interface MarketplaceManifest {
+  name: string;
+  metadata?: { version?: string };
+  plugins: MarketplacePlugin[];
+}
+
+interface ResolvedMarketplacePlugin {
+  name: string;
+  skills: Array<{ name: string; path: string }>;
+}
+
+interface ResolvedMarketplace {
+  manifestName: string;
+  version: string;
+  plugins: ResolvedMarketplacePlugin[];
+  skippedGitSubdir: Array<{ name: string; url: string }>;
+}
+
 interface RemoteCatalogRow {
   name: string;
   displayName: string;
@@ -511,6 +545,7 @@ GitHub Installation:
   upskill owner/repo --path subdir       Restrict to subfolder
   upskill owner/repo@branch              Install from a specific branch
   upskill owner/repo --branch name       Same, using flag syntax
+  upskill owner/repo --plugin name       Install all skills in a plugin collection
 
 Recommendations:
   upskill recommendations                Show skills matching your profile
@@ -526,6 +561,7 @@ Registry Search:
 
 Options:
   --skill <name>           Install specific skill (repeatable)
+  --plugin <name>          Install all skills in a plugin collection (marketplace repos)
   --all                    Install all skills from source
   --path <subfolder>       Only discover skills under this subfolder
   --branch, -b <name>      Install from a specific branch (default: main)
@@ -1103,6 +1139,102 @@ function stripZipPrefix(files: Record<string, Uint8Array>): Record<string, Uint8
     if (stripped) result[stripped] = content;
   }
   return result;
+}
+
+/**
+ * Detect and resolve a .claude-plugin/marketplace.json from an already-stripped
+ * ZIP file map. Returns null when no manifest is present.
+ *
+ * Skills are discovered at <plugin-source>/skills/<name>/SKILL.md within the ZIP.
+ * git-subdir sources are skipped and surfaced in `skippedGitSubdir`.
+ */
+function detectMarketplaceManifest(files: Record<string, Uint8Array>): ResolvedMarketplace | null {
+  const manifestKey = Object.keys(files).find(
+    (k) => k === '.claude-plugin/marketplace.json' || k.endsWith('/.claude-plugin/marketplace.json')
+  );
+  if (!manifestKey) return null;
+
+  let manifest: MarketplaceManifest;
+  try {
+    manifest = JSON.parse(new TextDecoder().decode(files[manifestKey])) as MarketplaceManifest;
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(manifest.plugins)) return null;
+
+  const manifestDir = manifestKey.replace(/\.claude-plugin\/marketplace\.json$/, '');
+
+  const plugins: ResolvedMarketplacePlugin[] = [];
+  const skippedGitSubdir: Array<{ name: string; url: string }> = [];
+
+  for (const plugin of manifest.plugins) {
+    if (typeof plugin.source !== 'string') {
+      const gitSub = plugin.source as MarketplacePluginSourceGitSubdir;
+      skippedGitSubdir.push({ name: plugin.name, url: gitSub.url ?? '' });
+      continue;
+    }
+
+    const normalizedSource = plugin.source.replace(/^\.\//, '');
+    const pluginDir = `${manifestDir}${normalizedSource}`;
+    const skillsPrefix = `${pluginDir}/skills/`;
+
+    const skills: Array<{ name: string; path: string }> = [];
+    for (const filePath of Object.keys(files)) {
+      if (!filePath.startsWith(skillsPrefix)) continue;
+      const rest = filePath.slice(skillsPrefix.length);
+      const parts = rest.split('/');
+      if (parts.length >= 2 && parts[1] === 'SKILL.md') {
+        const skillName = parts[0];
+        const skillPath = `${pluginDir}/skills/${skillName}`;
+        if (!skills.find((s) => s.name === skillName)) {
+          skills.push({ name: skillName, path: skillPath });
+        }
+      }
+    }
+
+    plugins.push({ name: plugin.name, skills });
+  }
+
+  return {
+    manifestName: manifest.name ?? 'marketplace',
+    version: manifest.metadata?.version ?? '',
+    plugins,
+    skippedGitSubdir,
+  };
+}
+
+/**
+ * Format a grouped marketplace skill listing for display.
+ * Mirrors the style of the existing flat listing but groups by plugin collection.
+ */
+function formatMarketplaceListing(marketplace: ResolvedMarketplace, sourceRef: string): string {
+  const versionSuffix = marketplace.version ? ` v${marketplace.version}` : '';
+  const totalSkills = marketplace.plugins.reduce((n, p) => n + p.skills.length, 0);
+  const totalPlugins = marketplace.plugins.length + marketplace.skippedGitSubdir.length;
+
+  let output = `Available skills in ${sourceRef} (marketplace: ${marketplace.manifestName}${versionSuffix}):\n\n`;
+
+  for (const plugin of marketplace.plugins) {
+    output += `  ${plugin.name}\n`;
+    for (const skill of plugin.skills) {
+      output += `    ${skill.name}\n`;
+    }
+    output += '\n';
+  }
+
+  for (const skipped of marketplace.skippedGitSubdir) {
+    output += `  ⚠  ${skipped.name}: skipped (external git-subdir${skipped.url ? ` — ${skipped.url}` : ''})\n`;
+  }
+
+  if (marketplace.skippedGitSubdir.length > 0) output += '\n';
+
+  output += `Found ${totalSkills} skill(s) in ${totalPlugins} plugin(s)\n`;
+  output += `\nTo install a collection: upskill ${sourceRef} --plugin <collection-name>\n`;
+  output += `To install a skill:      upskill ${sourceRef} --skill <skill-name>\n`;
+  output += `To install all:          upskill ${sourceRef} --all\n`;
+
+  return output;
 }
 
 /**
@@ -2299,6 +2431,7 @@ export function createUpskillCommand(
 
     // Parse arguments
     const selectedSkills: string[] = [];
+    const selectedPlugins: string[] = [];
     let subPath: string | undefined;
     let listOnly = false;
     let installAll = false;
@@ -2379,6 +2512,8 @@ export function createUpskillCommand(
         }
       } else if (arg === '--skill') {
         selectedSkills.push(args[++i]);
+      } else if (arg === '--plugin') {
+        selectedPlugins.push(args[++i]);
       } else if (arg === '--path' || arg === '-p') {
         const val = args[++i];
         // Defense-in-depth: even though `handoff-link.ts` already drops
@@ -2472,6 +2607,125 @@ export function createUpskillCommand(
       // --path/-p takes precedence over implicit subpath from URL /tree/<branch>/<path>
       const effectiveSubPath = subPath ?? githubRef.path;
       const github = await createGitHubRequestContext(fetchFn);
+
+      // ── Marketplace detection (early return if manifest found) ──
+      // Try downloading the ZIP to detect a marketplace manifest. If the ZIP
+      // succeeds and contains .claude-plugin/marketplace.json, handle in
+      // marketplace mode and return. On ZIP failure or no manifest, fall
+      // through to the existing flat-discovery path below unchanged.
+      {
+        const marketplaceZip = await fetchRepoZip(owner, repo, fetchFn, effectiveBranch);
+        if (marketplaceZip.status === 'ok') {
+          const marketplaceFiles = stripZipPrefix(marketplaceZip.files);
+          const marketplace = detectMarketplaceManifest(marketplaceFiles);
+
+          if (marketplace) {
+            // Show grouped listing when no action flags given
+            if (
+              listOnly ||
+              (selectedSkills.length === 0 && selectedPlugins.length === 0 && !installAll)
+            ) {
+              return {
+                stdout: formatMarketplaceListing(marketplace, sourceRef),
+                stderr: '',
+                exitCode: 0,
+              };
+            }
+
+            // --plugin and --skill are mutually exclusive
+            if (selectedPlugins.length > 0 && selectedSkills.length > 0) {
+              return {
+                stdout: '',
+                stderr: 'upskill: --plugin and --skill are mutually exclusive\n',
+                exitCode: 1,
+              };
+            }
+
+            // Resolve which skills to install
+            let skillsToInstall: Array<{ name: string; path: string }> = [];
+
+            if (selectedPlugins.length > 0) {
+              for (const pluginName of selectedPlugins) {
+                const plugin = marketplace.plugins.find((p) => p.name === pluginName);
+                if (!plugin) {
+                  return {
+                    stdout: '',
+                    stderr: `upskill: plugin collection "${pluginName}" not found in ${owner}/${repo}\n`,
+                    exitCode: 1,
+                  };
+                }
+                skillsToInstall.push(...plugin.skills);
+              }
+            } else if (selectedSkills.length > 0) {
+              for (const skillName of selectedSkills) {
+                const found = marketplace.plugins
+                  .flatMap((p) => p.skills)
+                  .find((s) => s.name === skillName);
+                if (!found) {
+                  return {
+                    stdout: '',
+                    stderr: `upskill: skill "${skillName}" not found in ${owner}/${repo}\n`,
+                    exitCode: 1,
+                  };
+                }
+                skillsToInstall.push(found);
+              }
+            } else {
+              // --all: every skill from every local-source plugin
+              skillsToInstall = marketplace.plugins.flatMap((p) => p.skills);
+            }
+
+            if (skillsToInstall.length === 0) {
+              return { stdout: 'No skills to install.\n', stderr: '', exitCode: 0 };
+            }
+
+            let output = '';
+            let errors = '';
+            let successCount = 0;
+            const totalSkills = skillsToInstall.length;
+            const startTime = Date.now();
+
+            for (let si = 0; si < skillsToInstall.length; si++) {
+              const skill = skillsToInstall[si];
+              const installResult = await installSkillFromZip(
+                skill.path,
+                skill.name,
+                marketplaceFiles,
+                fs,
+                force
+              );
+              const idx = si + 1;
+              const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+              const avgTime = (Date.now() - startTime) / idx;
+              const remaining = Math.round(((totalSkills - idx) * avgTime) / 1000);
+              const eta = idx < totalSkills ? ` (~${remaining}s remaining)` : '';
+
+              if (installResult.ok) {
+                output += `[${idx}/${totalSkills}] Installed "${skill.name}" from ${owner}/${repo} (${elapsed}s)${eta}\n`;
+                successCount++;
+              } else {
+                output += `[${idx}/${totalSkills}] Failed "${skill.name}": ${installResult.error}${eta}\n`;
+                errors += `upskill: ${installResult.error}\n`;
+              }
+            }
+
+            if (installAll) {
+              for (const skipped of marketplace.skippedGitSubdir) {
+                errors += `upskill: skipped plugin "${skipped.name}" (external git-subdir${skipped.url ? `: ${skipped.url}` : ''})\n`;
+              }
+            }
+
+            const totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+            if (successCount > 0) {
+              output += `\nInstalled ${successCount} skill(s)${totalSkills > 1 ? ` in ${totalElapsed}s` : ''}\n`;
+              await runPostInstallHooks();
+            }
+
+            return { stdout: output, stderr: errors, exitCode: errors ? 1 : 0 };
+          }
+        }
+      }
+      // ── end marketplace detection ──
 
       // List skills in the repository
       const result = await listGitHubSkills(

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -448,6 +448,8 @@ function formatSkillSource(source: DiscoveredSkill['source']): string {
       return '.agents';
     case 'claude':
       return '.claude';
+    case 'marketplace':
+      return 'marketplace';
   }
 }
 

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -384,7 +384,7 @@ function buildGitHubHeaders(
     'User-Agent': 'slicc-upskill',
   };
   if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
+    headers.Authorization = `Bearer ${token}`;
   }
   return headers;
 }
@@ -502,7 +502,7 @@ function formatDiscoveredSkills(discovered: DiscoveredSkill[], heading: string):
 
   for (const skill of discovered) {
     const raw = skill.description || '';
-    const description = raw.length > descWidth ? raw.slice(0, descWidth - 1) + '…' : raw;
+    const description = raw.length > descWidth ? `${raw.slice(0, descWidth - 1)}…` : raw;
     output += `  ${skill.name.padEnd(nameWidth)}  ${formatSkillSource(skill.source).padEnd(sourceWidth)} ${description}\n`;
   }
 
@@ -2428,6 +2428,115 @@ async function handleRecommendations(
  *   omitted (e.g. headless tests or pre-CDP boot), `upskill tabs` exits
  *   non-zero with a clear "browser APIs unavailable" message.
  */
+/**
+ * Try to handle a GitHub repo install in marketplace mode.
+ * Returns a result if the repo has a marketplace manifest, null otherwise.
+ */
+async function handleMarketplaceGitHubInstall(
+  owner: string,
+  repo: string,
+  sourceRef: string,
+  fetchFn: SecureFetch,
+  fs: VirtualFS,
+  branch: string | undefined,
+  selectedSkills: string[],
+  selectedPlugins: string[],
+  installAll: boolean,
+  listOnly: boolean,
+  force: boolean
+): Promise<{ stdout: string; stderr: string; exitCode: number } | null> {
+  const zipResult = await fetchRepoZip(owner, repo, fetchFn, branch);
+  if (zipResult.status !== 'ok') return null;
+
+  const files = stripZipPrefix(zipResult.files);
+  const marketplace = detectMarketplaceManifest(files);
+  if (!marketplace) return null;
+
+  if (listOnly || (selectedSkills.length === 0 && selectedPlugins.length === 0 && !installAll)) {
+    return { stdout: formatMarketplaceListing(marketplace, sourceRef), stderr: '', exitCode: 0 };
+  }
+
+  if (selectedPlugins.length > 0 && selectedSkills.length > 0) {
+    return {
+      stdout: '',
+      stderr: 'upskill: --plugin and --skill are mutually exclusive\n',
+      exitCode: 1,
+    };
+  }
+
+  let skillsToInstall: Array<{ name: string; path: string }> = [];
+
+  if (selectedPlugins.length > 0) {
+    for (const pluginName of selectedPlugins) {
+      const plugin = marketplace.plugins.find((p) => p.name === pluginName);
+      if (!plugin) {
+        return {
+          stdout: '',
+          stderr: `upskill: plugin collection "${pluginName}" not found in ${owner}/${repo}\n`,
+          exitCode: 1,
+        };
+      }
+      skillsToInstall.push(...plugin.skills);
+    }
+  } else if (selectedSkills.length > 0) {
+    for (const skillName of selectedSkills) {
+      const found = marketplace.plugins.flatMap((p) => p.skills).find((s) => s.name === skillName);
+      if (!found) {
+        return {
+          stdout: '',
+          stderr: `upskill: skill "${skillName}" not found in ${owner}/${repo}\n`,
+          exitCode: 1,
+        };
+      }
+      skillsToInstall.push(found);
+    }
+  } else {
+    skillsToInstall = marketplace.plugins.flatMap((p) => p.skills);
+  }
+
+  if (skillsToInstall.length === 0) {
+    return { stdout: 'No skills to install.\n', stderr: '', exitCode: 0 };
+  }
+
+  let output = '';
+  let errors = '';
+  let successCount = 0;
+  const totalSkills = skillsToInstall.length;
+  const startTime = Date.now();
+
+  for (let si = 0; si < skillsToInstall.length; si++) {
+    const skill = skillsToInstall[si];
+    const result = await installSkillFromZip(skill.path, skill.name, files, fs, force);
+    const idx = si + 1;
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    const avgTime = (Date.now() - startTime) / idx;
+    const remaining = Math.round(((totalSkills - idx) * avgTime) / 1000);
+    const eta = idx < totalSkills ? ` (~${remaining}s remaining)` : '';
+
+    if (result.ok) {
+      output += `[${idx}/${totalSkills}] Installed "${skill.name}" from ${owner}/${repo} (${elapsed}s)${eta}\n`;
+      successCount++;
+    } else {
+      output += `[${idx}/${totalSkills}] Failed "${skill.name}": ${result.error}${eta}\n`;
+      errors += `upskill: ${result.error}\n`;
+    }
+  }
+
+  if (installAll) {
+    for (const skipped of marketplace.skippedGitSubdir) {
+      errors += `upskill: skipped plugin "${skipped.name}" (external git-subdir${skipped.url ? `: ${skipped.url}` : ''})\n`;
+    }
+  }
+
+  const totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  if (successCount > 0) {
+    output += `\nInstalled ${successCount} skill(s)${totalSkills > 1 ? ` in ${totalElapsed}s` : ''}\n`;
+    await runPostInstallHooks();
+  }
+
+  return { stdout: output, stderr: errors, exitCode: errors ? 1 : 0 };
+}
+
 export function createUpskillCommand(
   fs: VirtualFS,
   fetchFn: SecureFetch,
@@ -2625,124 +2734,20 @@ export function createUpskillCommand(
       const effectiveSubPath = subPath ?? githubRef.path;
       const github = await createGitHubRequestContext(fetchFn);
 
-      // ── Marketplace detection (early return if manifest found) ──
-      // Try downloading the ZIP to detect a marketplace manifest. If the ZIP
-      // succeeds and contains .claude-plugin/marketplace.json, handle in
-      // marketplace mode and return. On ZIP failure or no manifest, fall
-      // through to the existing flat-discovery path below unchanged.
-      {
-        const marketplaceZip = await fetchRepoZip(owner, repo, fetchFn, effectiveBranch);
-        if (marketplaceZip.status === 'ok') {
-          const marketplaceFiles = stripZipPrefix(marketplaceZip.files);
-          const marketplace = detectMarketplaceManifest(marketplaceFiles);
-
-          if (marketplace) {
-            // Show grouped listing when no action flags given
-            if (
-              listOnly ||
-              (selectedSkills.length === 0 && selectedPlugins.length === 0 && !installAll)
-            ) {
-              return {
-                stdout: formatMarketplaceListing(marketplace, sourceRef),
-                stderr: '',
-                exitCode: 0,
-              };
-            }
-
-            // --plugin and --skill are mutually exclusive
-            if (selectedPlugins.length > 0 && selectedSkills.length > 0) {
-              return {
-                stdout: '',
-                stderr: 'upskill: --plugin and --skill are mutually exclusive\n',
-                exitCode: 1,
-              };
-            }
-
-            // Resolve which skills to install
-            let skillsToInstall: Array<{ name: string; path: string }> = [];
-
-            if (selectedPlugins.length > 0) {
-              for (const pluginName of selectedPlugins) {
-                const plugin = marketplace.plugins.find((p) => p.name === pluginName);
-                if (!plugin) {
-                  return {
-                    stdout: '',
-                    stderr: `upskill: plugin collection "${pluginName}" not found in ${owner}/${repo}\n`,
-                    exitCode: 1,
-                  };
-                }
-                skillsToInstall.push(...plugin.skills);
-              }
-            } else if (selectedSkills.length > 0) {
-              for (const skillName of selectedSkills) {
-                const found = marketplace.plugins
-                  .flatMap((p) => p.skills)
-                  .find((s) => s.name === skillName);
-                if (!found) {
-                  return {
-                    stdout: '',
-                    stderr: `upskill: skill "${skillName}" not found in ${owner}/${repo}\n`,
-                    exitCode: 1,
-                  };
-                }
-                skillsToInstall.push(found);
-              }
-            } else {
-              // --all: every skill from every local-source plugin
-              skillsToInstall = marketplace.plugins.flatMap((p) => p.skills);
-            }
-
-            if (skillsToInstall.length === 0) {
-              return { stdout: 'No skills to install.\n', stderr: '', exitCode: 0 };
-            }
-
-            let output = '';
-            let errors = '';
-            let successCount = 0;
-            const totalSkills = skillsToInstall.length;
-            const startTime = Date.now();
-
-            for (let si = 0; si < skillsToInstall.length; si++) {
-              const skill = skillsToInstall[si];
-              const installResult = await installSkillFromZip(
-                skill.path,
-                skill.name,
-                marketplaceFiles,
-                fs,
-                force
-              );
-              const idx = si + 1;
-              const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-              const avgTime = (Date.now() - startTime) / idx;
-              const remaining = Math.round(((totalSkills - idx) * avgTime) / 1000);
-              const eta = idx < totalSkills ? ` (~${remaining}s remaining)` : '';
-
-              if (installResult.ok) {
-                output += `[${idx}/${totalSkills}] Installed "${skill.name}" from ${owner}/${repo} (${elapsed}s)${eta}\n`;
-                successCount++;
-              } else {
-                output += `[${idx}/${totalSkills}] Failed "${skill.name}": ${installResult.error}${eta}\n`;
-                errors += `upskill: ${installResult.error}\n`;
-              }
-            }
-
-            if (installAll) {
-              for (const skipped of marketplace.skippedGitSubdir) {
-                errors += `upskill: skipped plugin "${skipped.name}" (external git-subdir${skipped.url ? `: ${skipped.url}` : ''})\n`;
-              }
-            }
-
-            const totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-            if (successCount > 0) {
-              output += `\nInstalled ${successCount} skill(s)${totalSkills > 1 ? ` in ${totalElapsed}s` : ''}\n`;
-              await runPostInstallHooks();
-            }
-
-            return { stdout: output, stderr: errors, exitCode: errors ? 1 : 0 };
-          }
-        }
-      }
-      // ── end marketplace detection ──
+      const marketplaceResult = await handleMarketplaceGitHubInstall(
+        owner,
+        repo,
+        sourceRef,
+        fetchFn,
+        fs,
+        effectiveBranch,
+        selectedSkills,
+        selectedPlugins,
+        installAll,
+        listOnly,
+        force
+      );
+      if (marketplaceResult) return marketplaceResult;
 
       // List skills in the repository
       const result = await listGitHubSkills(

--- a/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill-command.ts
@@ -491,7 +491,7 @@ function formatDiscoveredSkills(discovered: DiscoveredSkill[], heading: string):
   const nameWidth = Math.max(4, ...discovered.map((s) => s.name.length));
   const sourceWidth = 11; // 'marketplace'.length
   // 2 indent + nameWidth + 2 sep + sourceWidth + 1 sep = fixed overhead
-  const descWidth = Math.max(20, 120 - 2 - nameWidth - 2 - sourceWidth - 1);
+  const descWidth = Math.max(20, 99 - 2 - nameWidth - 2 - sourceWidth - 1);
 
   const header = 'NAME'.padEnd(nameWidth);
   const divider = '─'.repeat(2 + nameWidth + 2 + sourceWidth + 1 + descWidth);

--- a/packages/webapp/src/skills/catalog.ts
+++ b/packages/webapp/src/skills/catalog.ts
@@ -1,7 +1,7 @@
 import type { VirtualFS } from '../fs/index.js';
 import { SKILL_FILE, WORKSPACE_SKILLS_PATH } from './constants.js';
 
-export type SkillDiscoverySource = 'native' | 'agents' | 'claude';
+export type SkillDiscoverySource = 'native' | 'agents' | 'claude' | 'marketplace';
 
 export interface DiscoveredSkillCandidate {
   /** Discovery source bucket used for precedence. */
@@ -20,7 +20,7 @@ export interface SkillNameCollision<T> {
   shadowed: T[];
 }
 
-const DISCOVERY_ORDER: SkillDiscoverySource[] = ['native', 'agents', 'claude'];
+const DISCOVERY_ORDER: SkillDiscoverySource[] = ['native', 'agents', 'claude', 'marketplace'];
 const COMPATIBILITY_DIRECTORY_SOURCES = new Map<string, Exclude<SkillDiscoverySource, 'native'>>([
   ['.agents', 'agents'],
   ['.claude', 'claude'],
@@ -126,6 +126,56 @@ async function discoverNativeSkillCandidates(
   return discovered;
 }
 
+/**
+ * Parse a .claude-plugin/marketplace.json and return the list of plugin
+ * source paths (relative to the manifest's parent directory). Entries whose
+ * source is a git-subdir object are silently skipped — they reference
+ * external repos not present in the local tree.
+ */
+async function resolveMarketplacePluginPaths(
+  fs: VirtualFS,
+  manifestPath: string
+): Promise<string[]> {
+  let raw: string;
+  try {
+    raw = await fs.readTextFile(manifestPath);
+  } catch {
+    return [];
+  }
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  if (
+    typeof manifest !== 'object' ||
+    manifest === null ||
+    !Array.isArray((manifest as Record<string, unknown>).plugins)
+  ) {
+    return [];
+  }
+
+  const parentDir = manifestPath.replace(/\/[^/]+$/, '').replace(/\/.claude-plugin$/, '');
+  const paths: string[] = [];
+
+  for (const plugin of (manifest as { plugins: unknown[] }).plugins) {
+    if (typeof plugin !== 'object' || plugin === null) continue;
+    const source = (plugin as Record<string, unknown>).source;
+    // Skip git-subdir objects — they require a separate git clone
+    if (typeof source !== 'string') continue;
+    // Reject absolute paths and traversal attempts
+    if (source.startsWith('/') || source.split('/').includes('..')) continue;
+    // Resolve relative path (e.g. "./plugins/my-tools" -> "/mnt/repo/plugins/my-tools")
+    const normalized = source.replace(/^\.\//, '');
+    paths.push(`${parentDir}/${normalized}`);
+  }
+
+  return paths;
+}
+
 async function discoverCompatibilitySkillCandidates(
   fs: VirtualFS
 ): Promise<DiscoveredSkillCandidate[]> {
@@ -162,6 +212,33 @@ async function discoverCompatibilitySkillCandidates(
             skillFilePath,
           });
         }
+      }
+
+      if (entry.name === '.claude-plugin') {
+        const manifestPath = `${childPath}/marketplace.json`;
+        const pluginDirs = await resolveMarketplacePluginPaths(fs, manifestPath);
+
+        for (const pluginDir of pluginDirs) {
+          const skillRoot = `${pluginDir}/skills`;
+          const skillEntries = await readSortedDir(fs, skillRoot);
+
+          for (const skillEntry of skillEntries) {
+            if (skillEntry.type !== 'directory') continue;
+
+            const skillPath = `${skillRoot}/${skillEntry.name}`;
+            const skillFilePath = `${skillPath}/${SKILL_FILE}`;
+            if (!(await pathExists(fs, skillFilePath)) || seenPaths.has(skillPath)) continue;
+
+            seenPaths.add(skillPath);
+            discovered.push({
+              source: 'marketplace',
+              sourceRoot: skillRoot,
+              path: skillPath,
+              skillFilePath,
+            });
+          }
+        }
+        continue;
       }
 
       if (PRUNED_COMPATIBILITY_DIRECTORY_NAMES.has(entry.name)) continue;

--- a/packages/webapp/src/skills/catalog.ts
+++ b/packages/webapp/src/skills/catalog.ts
@@ -168,9 +168,9 @@ async function resolveMarketplacePluginPaths(
     if (typeof source !== 'string') continue;
     // Reject absolute paths and traversal attempts
     if (source.startsWith('/') || source.split('/').includes('..')) continue;
-    // Resolve relative path (e.g. "./plugins/my-tools" -> "/mnt/repo/plugins/my-tools")
-    const normalized = source.replace(/^\.\//, '');
-    paths.push(`${parentDir}/${normalized}`);
+    // Resolve relative path. "." and "./" both mean the repo root (parentDir itself).
+    const normalized = source.replace(/^\.\//, '').replace(/\/$/, '').replace(/^\.$/, '');
+    paths.push(normalized ? `${parentDir}/${normalized}` : parentDir);
   }
 
   return paths;

--- a/packages/webapp/src/skills/catalog.ts
+++ b/packages/webapp/src/skills/catalog.ts
@@ -176,6 +176,39 @@ async function resolveMarketplacePluginPaths(
   return paths;
 }
 
+async function discoverMarketplaceSkillCandidates(
+  fs: VirtualFS,
+  claudePluginPath: string,
+  seenPaths: Set<string>
+): Promise<DiscoveredSkillCandidate[]> {
+  const manifestPath = `${claudePluginPath}/marketplace.json`;
+  const pluginDirs = await resolveMarketplacePluginPaths(fs, manifestPath);
+  const discovered: DiscoveredSkillCandidate[] = [];
+
+  for (const pluginDir of pluginDirs) {
+    const skillRoot = `${pluginDir}/skills`;
+    const skillEntries = await readSortedDir(fs, skillRoot);
+
+    for (const skillEntry of skillEntries) {
+      if (skillEntry.type !== 'directory') continue;
+
+      const skillPath = `${skillRoot}/${skillEntry.name}`;
+      const skillFilePath = `${skillPath}/${SKILL_FILE}`;
+      if (!(await pathExists(fs, skillFilePath)) || seenPaths.has(skillPath)) continue;
+
+      seenPaths.add(skillPath);
+      discovered.push({
+        source: 'marketplace',
+        sourceRoot: skillRoot,
+        path: skillPath,
+        skillFilePath,
+      });
+    }
+  }
+
+  return discovered;
+}
+
 async function discoverCompatibilitySkillCandidates(
   fs: VirtualFS
 ): Promise<DiscoveredSkillCandidate[]> {
@@ -215,29 +248,12 @@ async function discoverCompatibilitySkillCandidates(
       }
 
       if (entry.name === '.claude-plugin') {
-        const manifestPath = `${childPath}/marketplace.json`;
-        const pluginDirs = await resolveMarketplacePluginPaths(fs, manifestPath);
-
-        for (const pluginDir of pluginDirs) {
-          const skillRoot = `${pluginDir}/skills`;
-          const skillEntries = await readSortedDir(fs, skillRoot);
-
-          for (const skillEntry of skillEntries) {
-            if (skillEntry.type !== 'directory') continue;
-
-            const skillPath = `${skillRoot}/${skillEntry.name}`;
-            const skillFilePath = `${skillPath}/${SKILL_FILE}`;
-            if (!(await pathExists(fs, skillFilePath)) || seenPaths.has(skillPath)) continue;
-
-            seenPaths.add(skillPath);
-            discovered.push({
-              source: 'marketplace',
-              sourceRoot: skillRoot,
-              path: skillPath,
-              skillFilePath,
-            });
-          }
-        }
+        const marketplaceCandidates = await discoverMarketplaceSkillCandidates(
+          fs,
+          childPath,
+          seenPaths
+        );
+        discovered.push(...marketplaceCandidates);
         continue;
       }
 

--- a/packages/webapp/src/skills/types.ts
+++ b/packages/webapp/src/skills/types.ts
@@ -12,7 +12,7 @@ export interface DiscoveredSkill {
   /** Skill name (directory name) */
   name: string;
   /** Discovery source bucket */
-  source: 'native' | 'agents' | 'claude';
+  source: 'native' | 'agents' | 'claude' | 'marketplace';
   /** Root directory that yielded this skill */
   sourceRoot: string;
   /** Path to skill directory */

--- a/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
@@ -222,6 +222,50 @@ describe('skill/upskill command compatibility discovery', () => {
     expect(result.stdout).toContain('local-agent-skill');
     expect(result.stdout).toContain('.agents');
   });
+
+  it('skill list shows marketplace as source for marketplace skills', async () => {
+    // Set up a marketplace plugin: a .claude-plugin/marketplace.json that points
+    // to a local plugin directory containing a skills sub-tree.
+    await fs.mkdir('/repo/.claude-plugin', { recursive: true });
+    await fs.writeFile(
+      '/repo/.claude-plugin/marketplace.json',
+      JSON.stringify({ plugins: [{ source: './plugins/market-tools' }] })
+    );
+    await fs.mkdir('/repo/plugins/market-tools/skills/my-market-skill', { recursive: true });
+    await fs.writeFile(
+      '/repo/plugins/market-tools/skills/my-market-skill/SKILL.md',
+      '---\nname: my-market-skill\ndescription: A marketplace skill\n---\n# My Market Skill\n'
+    );
+
+    const result = await createSkillCommand(fs).execute(['list'], createMockCtx() as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('my-market-skill');
+    expect(result.stdout).toContain('marketplace');
+  });
+
+  it('skill info shows Source: marketplace for marketplace skill', async () => {
+    // Same marketplace layout: .claude-plugin/marketplace.json points to a local plugin dir.
+    await fs.mkdir('/repo/.claude-plugin', { recursive: true });
+    await fs.writeFile(
+      '/repo/.claude-plugin/marketplace.json',
+      JSON.stringify({ plugins: [{ source: './plugins/market-tools' }] })
+    );
+    await fs.mkdir('/repo/plugins/market-tools/skills/my-market-skill', { recursive: true });
+    await fs.writeFile(
+      '/repo/plugins/market-tools/skills/my-market-skill/SKILL.md',
+      '---\nname: my-market-skill\ndescription: A marketplace skill\n---\n# My Market Skill\n'
+    );
+
+    const result = await createSkillCommand(fs).execute(
+      ['info', 'my-market-skill'],
+      createMockCtx() as never
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Skill: my-market-skill');
+    expect(result.stdout).toContain('Source: marketplace');
+  });
 });
 
 describe('upskill command GitHub flows', () => {

--- a/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts
@@ -2613,3 +2613,213 @@ describe('upskill tabs', () => {
     expect(result.stdout).toContain('upskill https://github.com/acme/skills');
   });
 });
+
+describe('upskill command — marketplace manifest flows', () => {
+  let fs: VirtualFS;
+  let createdFileSystems: VirtualFS[];
+  let dbCounter = 700;
+
+  beforeEach(async () => {
+    createdFileSystems = [];
+    const originalCreate = VirtualFS.create.bind(VirtualFS);
+    vi.spyOn(VirtualFS, 'create').mockImplementation(async (options) => {
+      const instance = await originalCreate(options);
+      createdFileSystems.push(instance);
+      return instance;
+    });
+    fs = await VirtualFS.create({ dbName: `upskill-marketplace-${dbCounter++}`, wipe: true });
+    await VirtualFS.create({ dbName: 'slicc-fs-global', wipe: true });
+  });
+
+  afterEach(async () => {
+    _resetGlobalFsCache();
+    await Promise.allSettled(createdFileSystems.map((instance) => instance.dispose()));
+    vi.restoreAllMocks();
+  });
+
+  function makeMarketplaceZip(opts: {
+    marketplaceName?: string;
+    version?: string;
+    plugins: Array<{
+      name: string;
+      source: string | Record<string, unknown>;
+      skills?: string[];
+    }>;
+  }): Uint8Array {
+    const encoder = new TextEncoder();
+    const manifest = {
+      name: opts.marketplaceName ?? 'test-marketplace',
+      metadata: { version: opts.version ?? '1.0.0' },
+      plugins: opts.plugins.map((p) => ({
+        name: p.name,
+        description: `${p.name} plugin`,
+        source: p.source,
+        strict: false,
+      })),
+    };
+    const entries: Record<string, Uint8Array> = {
+      'repo-main/.claude-plugin/marketplace.json': encoder.encode(JSON.stringify(manifest)),
+    };
+    for (const plugin of opts.plugins) {
+      if (typeof plugin.source !== 'string') continue;
+      const pluginPath = plugin.source.replace(/^\.\//, '');
+      for (const skillName of plugin.skills ?? []) {
+        entries[`repo-main/${pluginPath}/skills/${skillName}/SKILL.md`] = encoder.encode(
+          `---\nname: ${skillName}\n---\n# ${skillName}\n`
+        );
+      }
+    }
+    return zipSync(entries);
+  }
+
+  it('shows grouped marketplace listing when manifest is present', async () => {
+    const zipBytes = makeMarketplaceZip({
+      marketplaceName: 'my-marketplace',
+      version: '2.0.0',
+      plugins: [
+        {
+          name: 'tool-set-a',
+          source: './plugins/tool-set-a',
+          skills: ['skill-alpha', 'skill-beta'],
+        },
+        { name: 'tool-set-b', source: './plugins/tool-set-b', skills: ['skill-gamma'] },
+      ],
+    });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('codeload.github.com')) return response(200, zipBytes);
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['owner/repo'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('my-marketplace');
+    expect(result.stdout).toContain('2.0.0');
+    expect(result.stdout).toContain('tool-set-a');
+    expect(result.stdout).toContain('skill-alpha');
+    expect(result.stdout).toContain('skill-beta');
+    expect(result.stdout).toContain('tool-set-b');
+    expect(result.stdout).toContain('skill-gamma');
+    expect(result.stdout).toContain('--plugin');
+    expect(result.stdout).toContain('--skill');
+    expect(result.stdout).toContain('--all');
+  });
+
+  it('--plugin installs all skills in a named collection', async () => {
+    const zipBytes = makeMarketplaceZip({
+      plugins: [
+        {
+          name: 'tool-set-a',
+          source: './plugins/tool-set-a',
+          skills: ['skill-alpha', 'skill-beta'],
+        },
+        { name: 'tool-set-b', source: './plugins/tool-set-b', skills: ['skill-gamma'] },
+      ],
+    });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('codeload.github.com')) return response(200, zipBytes);
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(
+      ['owner/repo', '--plugin', 'tool-set-a'],
+      createMockCtx() as any
+    );
+
+    expect(result.exitCode).toBe(0);
+    await expect(fs.stat('/workspace/skills/skill-alpha')).resolves.toBeDefined();
+    await expect(fs.stat('/workspace/skills/skill-beta')).resolves.toBeDefined();
+    await expect(fs.stat('/workspace/skills/skill-gamma')).rejects.toThrow();
+  });
+
+  it('--all installs skills from all local-source plugins and warns about git-subdir', async () => {
+    const zipBytes = makeMarketplaceZip({
+      plugins: [
+        { name: 'tool-set-a', source: './plugins/tool-set-a', skills: ['skill-alpha'] },
+        { name: 'tool-set-b', source: './plugins/tool-set-b', skills: ['skill-beta'] },
+        {
+          name: 'external',
+          source: {
+            source: 'git-subdir',
+            url: 'https://github.com/org/repo',
+            path: '.',
+            sha: 'abc',
+          },
+        },
+      ],
+    });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('codeload.github.com')) return response(200, zipBytes);
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['owner/repo', '--all'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(1); // non-zero because git-subdir produces stderr
+    await expect(fs.stat('/workspace/skills/skill-alpha')).resolves.toBeDefined();
+    await expect(fs.stat('/workspace/skills/skill-beta')).resolves.toBeDefined();
+    expect(result.stderr).toContain('external');
+    expect(result.stderr).toContain('git-subdir');
+  });
+
+  it('--plugin and --skill together return a mutual exclusion error', async () => {
+    const zipBytes = makeMarketplaceZip({
+      plugins: [{ name: 'tool-set-a', source: './plugins/tool-set-a', skills: ['skill-alpha'] }],
+    });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('codeload.github.com')) return response(200, zipBytes);
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(
+      ['owner/repo', '--plugin', 'tool-set-a', '--skill', 'skill-alpha'],
+      createMockCtx() as any
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('mutually exclusive');
+  });
+
+  it('unknown --plugin name returns a clear error', async () => {
+    const zipBytes = makeMarketplaceZip({
+      plugins: [{ name: 'tool-set-a', source: './plugins/tool-set-a', skills: ['skill-alpha'] }],
+    });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('codeload.github.com')) return response(200, zipBytes);
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(
+      ['owner/repo', '--plugin', 'does-not-exist'],
+      createMockCtx() as any
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('"does-not-exist"');
+    expect(result.stderr).toContain('not found');
+  });
+
+  it('repos without a manifest fall back to existing flat listing', async () => {
+    const encoder = new TextEncoder();
+    const zipBytes = zipSync({
+      'repo-main/plain-skill/SKILL.md': encoder.encode('---\nname: plain-skill\n---\n# Plain\n'),
+    });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('codeload.github.com')) return response(200, zipBytes);
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['owner/repo'], createMockCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('plain-skill');
+    expect(result.stdout).not.toContain('marketplace');
+    expect(result.stdout).toContain('upskill owner/repo --skill');
+  });
+});

--- a/packages/webapp/tests/skills/catalog.test.ts
+++ b/packages/webapp/tests/skills/catalog.test.ts
@@ -115,6 +115,138 @@ describe('discoverSkillCandidates', () => {
       '/repo/.claude/skills/visible-skill',
     ]);
   });
+
+  it('discovers marketplace skills from a .claude-plugin/marketplace.json', async () => {
+    const manifest = JSON.stringify({
+      name: 'test-marketplace',
+      metadata: { version: '1.0.0' },
+      plugins: [
+        { name: 'my-tools', description: 'My tools', source: './plugins/my-tools', strict: false },
+      ],
+    });
+
+    await fs.mkdir('/mnt/repo/.claude-plugin', { recursive: true });
+    await fs.writeFile('/mnt/repo/.claude-plugin/marketplace.json', manifest);
+    await fs.mkdir('/mnt/repo/plugins/my-tools/skills/my-skill', { recursive: true });
+    await fs.writeFile(
+      '/mnt/repo/plugins/my-tools/skills/my-skill/SKILL.md',
+      '---\nname: my-skill\n---\n'
+    );
+
+    const candidates = await discoverSkillCandidates(fs);
+
+    expect(candidates).toContainEqual(
+      expect.objectContaining({
+        source: 'marketplace',
+        path: '/mnt/repo/plugins/my-tools/skills/my-skill',
+      })
+    );
+  });
+
+  it('skips marketplace plugins whose source is a git-subdir object', async () => {
+    const manifest = JSON.stringify({
+      name: 'test-marketplace',
+      metadata: { version: '1.0.0' },
+      plugins: [
+        { name: 'local-plugin', source: './plugins/local', strict: false },
+        {
+          name: 'external-plugin',
+          source: {
+            source: 'git-subdir',
+            url: 'https://github.com/org/repo',
+            path: '.',
+            sha: 'abc',
+          },
+          strict: false,
+        },
+      ],
+    });
+
+    await fs.mkdir('/mnt/repo/.claude-plugin', { recursive: true });
+    await fs.writeFile('/mnt/repo/.claude-plugin/marketplace.json', manifest);
+    await fs.mkdir('/mnt/repo/plugins/local/skills/local-skill', { recursive: true });
+    await fs.writeFile(
+      '/mnt/repo/plugins/local/skills/local-skill/SKILL.md',
+      '---\nname: local-skill\n---\n'
+    );
+
+    const candidates = await discoverSkillCandidates(fs);
+    const names = candidates.map((c) => c.path.split('/').pop());
+
+    expect(names).toContain('local-skill');
+    expect(candidates.filter((c) => c.source === 'marketplace')).toHaveLength(1);
+  });
+
+  it('discovers skills across multiple plugins in one manifest', async () => {
+    const manifest = JSON.stringify({
+      name: 'multi-marketplace',
+      metadata: { version: '1.0.0' },
+      plugins: [
+        { name: 'plugin-a', source: './plugins/a', strict: false },
+        { name: 'plugin-b', source: './plugins/b', strict: false },
+      ],
+    });
+
+    await fs.mkdir('/mnt/repo/.claude-plugin', { recursive: true });
+    await fs.writeFile('/mnt/repo/.claude-plugin/marketplace.json', manifest);
+    await fs.mkdir('/mnt/repo/plugins/a/skills/skill-one', { recursive: true });
+    await fs.writeFile(
+      '/mnt/repo/plugins/a/skills/skill-one/SKILL.md',
+      '---\nname: skill-one\n---\n'
+    );
+    await fs.mkdir('/mnt/repo/plugins/b/skills/skill-two', { recursive: true });
+    await fs.writeFile(
+      '/mnt/repo/plugins/b/skills/skill-two/SKILL.md',
+      '---\nname: skill-two\n---\n'
+    );
+
+    const candidates = await discoverSkillCandidates(fs);
+    const marketplaceCandidates = candidates.filter((c) => c.source === 'marketplace');
+
+    expect(marketplaceCandidates.map((c) => c.path.split('/').pop()).sort()).toEqual([
+      'skill-one',
+      'skill-two',
+    ]);
+  });
+
+  it('native skill shadows marketplace skill with the same name', async () => {
+    const manifest = JSON.stringify({
+      name: 'test-marketplace',
+      metadata: { version: '1.0.0' },
+      plugins: [{ name: 'my-tools', source: './plugins/my-tools', strict: false }],
+    });
+
+    await fs.mkdir('/workspace/skills/shared-name', { recursive: true });
+    await fs.writeFile(
+      '/workspace/skills/shared-name/SKILL.md',
+      '---\nname: shared-name\n---\n# native'
+    );
+
+    await fs.mkdir('/mnt/repo/.claude-plugin', { recursive: true });
+    await fs.writeFile('/mnt/repo/.claude-plugin/marketplace.json', manifest);
+    await fs.mkdir('/mnt/repo/plugins/my-tools/skills/shared-name', { recursive: true });
+    await fs.writeFile(
+      '/mnt/repo/plugins/my-tools/skills/shared-name/SKILL.md',
+      '---\nname: shared-name\n---\n# marketplace'
+    );
+
+    const candidates = await discoverSkillCandidates(fs);
+    const { winners } = resolveSkillNameCollisions(
+      candidates,
+      (c) => c.path.split('/').pop() ?? ''
+    );
+    const winner = winners.find((w) => w.path.split('/').pop() === 'shared-name');
+
+    expect(winner?.source).toBe('native');
+  });
+
+  it('ignores malformed marketplace.json without throwing', async () => {
+    await fs.mkdir('/mnt/repo/.claude-plugin', { recursive: true });
+    await fs.writeFile('/mnt/repo/.claude-plugin/marketplace.json', 'not valid json {{{');
+
+    const candidates = await discoverSkillCandidates(fs);
+    expect(candidates.filter((c) => c.source === 'marketplace')).toHaveLength(0);
+  });
 });
 
 describe('resolveSkillNameCollisions', () => {


### PR DESCRIPTION
## Summary

Adds support for the Claude Code plugin marketplace format (`.claude-plugin/marketplace.json`) in two ways: mounted marketplace repos are now auto-discovered by the VFS skill  engine with no install step, and `upskill owner/repo` against a marketplace repo shows a grouped plugin/skill listing and a new `--plugin <name>` flag to install an entire  collection.
  
  ## Why

SLICC's skill discovery engine knew about three path conventions (`/workspace/skills/`, `**/.agents/skills/`, `**/.claude/skills/`) but not the Claude Code marketplace layout, where skills live at `<plugin-source>/skills/<name>/SKILL.md` inside named plugin collections declared in `.claude-plugin/marketplace.json`. Mounting a marketplace repo produced no discoverable skills; running `upskill` against one produced a flat unstructured listing that ignored collection grouping.
  
Design spec: `docs/superpowers/specs/2026-06-09-claude-marketplace-upskill-design.md` (branch-local, not committed to main per project convention).

  ## Approach / Implementation notes

  **Layering:**
  - `catalog.ts` owns discovery (Commit 1). The existing BFS already walks the full VFS; the change adds a new trigger: when the BFS encounters a directory named `.claude-plugin`, it reads `marketplace.json`, resolves each plugin's `source` path, and registers skills at `<plugin-source>/skills/<name>/SKILL.md` as `'marketplace'`-sourced candidates. A `continue` after the block prevents the BFS from recursing into `.claude-plugin/` itself.
  - `upskill-command.ts` owns remote install (Commit 2). After downloading the repo ZIP (existing path), `detectMarketplaceManifest` checks the stripped file map for `.claude-plugin/marketplace.json`. If found, all GitHub dispatch returns early through the marketplace path; if not found or if the ZIP download failed, execution falls through to the existing flat-discovery + Contents API fallback byte-for-byte unchanged.

  **Non-obvious choices:**
  - Marketplace discovery is an early-return block inserted *before* `listGitHubSkills`, not a replacement. This preserves the Contents API fallback for non-marketplace repos and avoids touching the existing listing/install code paths.
  - `git-subdir` plugin sources (external repos not in the ZIP or mount) are silently skipped during BFS discovery; a warning is emitted to stderr during `upskill --all` only.  Warnings at discovery time would fire on every agent turn.
  - Path traversal in manifest `source` fields (absolute paths, `..` components) is rejected in `resolveMarketplacePluginPaths` the same way non-string sources are silently skipped.
  - `--plugin` and `--skill` are mutually exclusive — combining them returns an error rather than attempting a union, which would be surprising behaviour.
  - Precedence order: `native → agents → claude → marketplace`. Marketplace is lowest so installed skills always shadow discovered-but-not-installed ones.

  ## Cross-cutting impact

  - **Floats exercised**: CLI and Chrome extension both use the same `catalog.ts` BFS and `upskill-command.ts` dispatch — no float-specific branches were added. Electron and Sliccstart unaffected.
  - **Shell contexts**: The skill discovery runs in the offscreen agent shell (extension) and the kernel-worker shell (standalone). Both call `discoverSkills` → `discoverSkillCandidates` → the same BFS. No side-panel-only paths touched.
  - **Other callers of `discoverSkillCandidates`**: `discover.ts` (`discoverSkills`, `getSkillInfo`, `readSkillInstructions`), `upskill-command.ts` (`upskill list`, `skill list`, `skill info`). All callers receive the new `'marketplace'` source in results; `formatSkillSource` updated accordingly.
  - **Persisted state**: No IndexedDB schema changes. Marketplace skills are discovered at runtime from the VFS; nothing is written to `slicc-fs` or any ledger.
  - **Security**: Plugin `source` paths from untrusted manifests are validated to reject absolute paths and `..` traversal before being resolved against the manifest's parent directory.
  - **Bundle size**: No new dependencies. `TextDecoder` (used in `detectMarketplaceManifest`) is a browser built-in already used elsewhere in the file.

  ## Test plan

  - [x] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate                                              
  - [x] `npm run typecheck` — clean across all 6 tsconfig targets
  - [x] `npm run test` — 6,243 passing, 0 new failures
  - [x] `npm run build`
  - [x] `npm run build -w @slicc/chrome-extension`
  - [x] **New behavior covered by unit tests**:
    - `packages/webapp/tests/skills/catalog.test.ts` — 5 new tests: manifest discovery, git-subdir skip, multi-plugin, native shadowing, malformed JSON
    - `packages/webapp/tests/shell/supplemental-commands/upskill-command.test.ts` — 8 new tests: grouped listing, `--plugin` install, `--all` with git-subdir warning, mutual exclusion error, unknown plugin name, non-marketplace fallback, `skill list` marketplace label, `skill info` marketplace source
  - [x] Manual smoke: mount a repo containing `.claude-plugin/marketplace.json` and verify skills appear in `skill list`; 
  - [x] Manual smoke: run `upskill owner/repo` against a marketplace repo and verify grouped output.

  **Pre-existing failures**: none known on `main`.

  ## Documentation

  - [ ] `README.md` (user-facing behavior)
  - [x] Relevant `CLAUDE.md` (developer / package architecture)
  - [x] `docs/shell-reference.md` — added `--plugin` flag and a "Marketplace repos" subsection to the `upskill` entry
  - [x] `packages/vfs-root/workspace/skills/skill-authoring/SKILL.md` — expanded discovery table from 3 to 4 roots; added explanation of marketplace auto-discovery and precedence

  ## Risk & rollback
  
  - **Blast radius**: skill discovery and `upskill` GitHub flow. Non-marketplace repos are unaffected — the new code paths are gated behind manifest detection and fall through to existing logic on any failure. The `'marketplace'` source type is additive to the union; no existing callers break.
  - **Rollback**: revert this PR cleanly — no persisted state migration, no new IndexedDB schemas, no localStorage keys.
  - **CI cannot catch**: actual mount behaviour with a real marketplace repo on disk. The unit tests cover the BFS with a fake VFS; verify manually that `mount` + `skill list` surfaces marketplace skills in a live session.

  ## Checklist

  - [x] Commits are focused and package-local where possible
  - [x] No hand-edited files under `dist/`
  - [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
  - [x] Public API / tool / shell-command changes reflected in docs (`--plugin` flag, marketplace listing format)
  - [x] Contract used by both CLI and extension floats checked — `catalog.ts` and `upskill-command.ts` are shared; no float-specific divergence introduced