### PR TITLE
fix(release): skip e2b template build/verify while account is out of credits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,13 @@ jobs:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          # TEMPORARY: the Adobe e2b team account is out of build credits, so
+          # `Template.build` fails and blocks the release at publish:worker
+          # (build-template.sh runs first under `set -e`). This flag makes
+          # build-template.sh / verify-template.sh no-op (exit 0) so the release
+          # can still deploy the worker against the already-published template.
+          # Remove this line once e2b credits are restored.
+          SLICC_SKIP_E2B_TEMPLATE: '1'
           WORKER_BASE_URL: https://www.sliccy.ai
           CHROME_WEB_STORE_PUBLISHER_ID: ${{ vars.CHROME_WEB_STORE_PUBLISHER_ID }}
           CHROME_WEB_STORE_ITEM_ID: ${{ vars.CHROME_WEB_STORE_ITEM_ID }}

--- a/packages/dev-tools/e2b-template/README.md
+++ b/packages/dev-tools/e2b-template/README.md
@@ -19,6 +19,16 @@ The script tags the published template with the SLICC version from the root
 
 Creates one sandbox, polls `/tmp/slicc-join.json`, kills the sandbox.
 
+## Skipping the build (temporary)
+
+Set `SLICC_SKIP_E2B_TEMPLATE=1` to make both `build-template.sh` and
+`verify-template.sh` no-op (print a notice and `exit 0`). This is a temporary
+escape hatch for the release pipeline while the e2b team account is out of build
+credits: it lets a release deploy the worker against the already-published
+template instead of failing on `Template.build`. Remove the
+`SLICC_SKIP_E2B_TEMPLATE` env from `.github/workflows/release.yml` (and this
+note) once credits are restored.
+
 ## Notes
 
 - Not an npm workspace. Invoke the scripts directly.

--- a/packages/dev-tools/e2b-template/scripts/build-template.sh
+++ b/packages/dev-tools/e2b-template/scripts/build-template.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
+# TEMPORARY (e2b out of credits): when SLICC_SKIP_E2B_TEMPLATE=1, skip the
+# template build entirely and exit 0. publish-worker.sh runs this first under
+# `set -e`, so a failed `Template.build` (which is what an out-of-credits
+# account returns) blocks the whole release. Skipping lets the release deploy
+# the worker against the already-published template. Remove the env var (set in
+# .github/workflows/release.yml) once e2b credits are restored.
+if [ "${SLICC_SKIP_E2B_TEMPLATE:-}" = "1" ]; then
+  echo "[build-template] SLICC_SKIP_E2B_TEMPLATE=1 set — skipping e2b template build (account out of credits)."
+  exit 0
+fi
+
 # E2B v2 template build for the SLICC hosted leader.
 #
 # Requires:

--- a/packages/dev-tools/e2b-template/scripts/verify-template.sh
+++ b/packages/dev-tools/e2b-template/scripts/verify-template.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+# TEMPORARY (e2b out of credits): mirror build-template.sh — when
+# SLICC_SKIP_E2B_TEMPLATE=1, skip booting a verification sandbox (which also
+# consumes credits) and exit 0. Remove once e2b credits are restored.
+if [ "${SLICC_SKIP_E2B_TEMPLATE:-}" = "1" ]; then
+  echo "[verify-template] SLICC_SKIP_E2B_TEMPLATE=1 set — skipping e2b template boot verification (account out of credits)."
+  exit 0
+fi
+
 if [ -z "${SLICC_TEST_E2B_API_KEY:-}" ]; then
   echo "SLICC_TEST_E2B_API_KEY env var required" >&2
   exit 1


### PR DESCRIPTION
## Problem

The **Release** workflow has failed on every push to `main` since `3.47.0` (runs #934, #938, #939, #941, #942). All steps up to **Publish release** pass; `npx semantic-release` then fails at the very first action of `publish:worker` → `packages/cloudflare-worker/scripts/publish-worker.sh`:

```
[publish-worker] Building and pushing e2b template...
E2B_API_KEY set: true
=== template build failed ===
    at handleApiError (.../e2b/src/api/index.ts:61:10)
    at requestBuild (.../e2b/src/template/buildApi.ts:65:17)
    at async main (.../packages/dev-tools/e2b-template/template.ts:60:21)
```

The **Adobe e2b team account is out of build credits**, so `Template.build` returns an API error. Because `publish-worker.sh` builds + verifies the template *first* under `set -euo pipefail`, that failure aborts the worker publish and fails the whole release — the **worker deploy, Chrome Web Store publish, and GitHub release never run**. (npm publish + the `chore(release)` git tag/commit already succeed earlier in semantic-release's prepare phase, which is why `main`/npm/tags sit at `3.47.0` while the rest of the release is incomplete.)

## Fix (temporary)

Gate the two credit-consuming scripts on a new env flag and set it in the release step:

- `packages/dev-tools/e2b-template/scripts/build-template.sh` and `verify-template.sh` early-exit `0` (with a clear notice) when `SLICC_SKIP_E2B_TEMPLATE` is exactly `"1"`.
- `.github/workflows/release.yml` sets `SLICC_SKIP_E2B_TEMPLATE: '1'` in the **Publish release** step.

The release then proceeds and deploys the worker against the **already-published** template (only a *rebuild* is blocked, not the existing image). Behavior is unchanged whenever the flag is unset. As a `fix:`, this cuts `3.47.1` — no version collision (npm + tags are at `3.47.0`).

## Scope

- `worker.yml` (manual `workflow_dispatch`) and `worker-staging.yml` (runs only on PRs touching `cloudflare-worker`/`cloud-core`/providers) call the same scripts and would also fail on rebuild, but neither blocks releases and neither auto-triggers here. The shared-script guard means a one-line env addition can skip them too if needed.
- `ci.yml` does **not** build the e2b template, so this PR's own CI is unaffected.

## Verification

- `bash -n` clean on both scripts.
- `SLICC_SKIP_E2B_TEMPLATE=1` → prints skip notice, `exit 0`, never calls e2b.
- Unset / `=0` → guard not taken; existing `dist`/API-key checks run exactly as before.
- `prettier --check` clean on the changed YAML + Markdown.

## Revert plan

Remove the `SLICC_SKIP_E2B_TEMPLATE` env from `release.yml` (and optionally the script guards + README note) once e2b credits are restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)