### PR TITLE
fix(ci): skip e2b template build/verify in worker deploy workflows while account is out of credits

### DIFF
--- a/.github/workflows/worker-staging.yml
+++ b/.github/workflows/worker-staging.yml
@@ -40,11 +40,18 @@ jobs:
       - name: Build and push e2b template
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          # TEMPORARY: the Adobe e2b team account is out of build credits, so
+          # `Template.build` fails (403 team is blocked) and aborts this job.
+          # This flag makes build-template.sh no-op (exit 0). Remove once e2b
+          # credits are restored (see release.yml for the matching note).
+          SLICC_SKIP_E2B_TEMPLATE: '1'
         run: bash packages/dev-tools/e2b-template/scripts/build-template.sh
 
       - name: Verify template boots
         env:
           SLICC_TEST_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          # TEMPORARY: see above — skip e2b verification boot while out of credits.
+          SLICC_SKIP_E2B_TEMPLATE: '1'
         run: bash packages/dev-tools/e2b-template/scripts/verify-template.sh
 
       - name: Deploy staging worker (attempt 1)

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -39,11 +39,18 @@ jobs:
       - name: Build and push e2b template
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          # TEMPORARY: the Adobe e2b team account is out of build credits, so
+          # `Template.build` fails (403 team is blocked) and aborts this job.
+          # This flag makes build-template.sh no-op (exit 0). Remove once e2b
+          # credits are restored (see release.yml for the matching note).
+          SLICC_SKIP_E2B_TEMPLATE: '1'
         run: bash packages/dev-tools/e2b-template/scripts/build-template.sh
 
       - name: Verify template boots
         env:
           SLICC_TEST_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          # TEMPORARY: see above — skip e2b verification boot while out of credits.
+          SLICC_SKIP_E2B_TEMPLATE: '1'
         run: bash packages/dev-tools/e2b-template/scripts/verify-template.sh
 
       - name: Deploy production worker (attempt 1)


### PR DESCRIPTION
## Problem

The 'Build and push e2b template' step fails in `worker-staging.yml` ("Deploy staging + smoke test") and `worker.yml` with:

> 403: team is blocked: missing payment method

The Adobe e2b team account is out of build credits, so `Template.build` is rejected. This surfaces as a red deploy job on every PR/push.

## Root cause

Karl's `2face90a` added the `SLICC_SKIP_E2B_TEMPLATE` escape hatch (no-op `exit 0`) to `build-template.sh` and `verify-template.sh`, but only wired the env var into `release.yml`. The staging and production worker-deploy workflows run the same scripts and hit the same failure.

## Fix

Set `SLICC_SKIP_E2B_TEMPLATE: '1'` on both e2b steps in both `worker-staging.yml` and `worker.yml`, mirroring `release.yml`. The steps no-op and deploy against the already-published template.

## Temporary

Remove the `SLICC_SKIP_E2B_TEMPLATE` env from all three workflows once e2b credits are restored.