### PR TITLE
feat(ui): add-menu — replace attachment button with searchable context picker

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -33,6 +33,7 @@
         "packages/webapp/src/shell/**",
         "packages/webapp/src/fs/**",
         "packages/webapp/src/core/proxy-error.ts",
+        "packages/webapp/src/ui/add-menu/**",
         "packages/node-server/src/**"
       ]
     },

--- a/packages/webapp/src/scoops/agent-message-to-chat.ts
+++ b/packages/webapp/src/scoops/agent-message-to-chat.ts
@@ -36,6 +36,7 @@ import type {
   ToolResultMessage,
   UserMessage,
 } from '@earendil-works/pi-ai';
+import { stripContextPreamble } from '../ui/add-menu/preamble.js';
 import { isLickChannel, LICK_CHANNELS, type LickChannel } from '../ui/lick-channels.js';
 import type { ChatMessage, ToolCall as UiToolCall } from '../ui/types.js';
 import { HIDDEN_TOOL_NAMES } from './hidden-tools.js';
@@ -99,7 +100,7 @@ export function agentMessagesToChatMessages(
         const msg: ChatMessage = {
           id: idSeed(),
           role: 'user',
-          content: env.body,
+          content: lickChannel ? env.body : stripContextPreamble(env.body),
           timestamp: m.timestamp,
         };
         if (lickChannel) {

--- a/packages/webapp/src/ui/add-menu/add-item.ts
+++ b/packages/webapp/src/ui/add-menu/add-item.ts
@@ -12,3 +12,18 @@ export interface AddItem {
    *  file,folder → VFS path; skill → name; session → /sessions/<file>; scoop → jid. */
   locator: string;
 }
+
+/** User-facing category label for a reference kind. "session" reads as
+ *  "conversation" to match the add-menu search placeholder; everything else
+ *  uses its own name. */
+const REFERENCE_KIND_LABELS: Record<AddItemKind, string> = {
+  file: 'file',
+  folder: 'folder',
+  skill: 'skill',
+  session: 'conversation',
+  scoop: 'scoop',
+};
+
+export function referenceKindLabel(kind: AddItemKind): string {
+  return REFERENCE_KIND_LABELS[kind];
+}

--- a/packages/webapp/src/ui/add-menu/add-item.ts
+++ b/packages/webapp/src/ui/add-menu/add-item.ts
@@ -1,0 +1,14 @@
+/** Kinds of thing the add-menu can reference. All are reachable via the
+ *  agent's tools, so they ride along as references (not inline content). */
+export type AddItemKind = 'file' | 'folder' | 'skill' | 'session' | 'scoop';
+
+export interface AddItem {
+  kind: AddItemKind;
+  /** Display name: filename / skill name / session title / scoop name. */
+  label: string;
+  /** Secondary line: path or context, e.g. "/workspace/src". */
+  sublabel?: string;
+  /** Resolvable reference for the preamble:
+   *  file,folder → VFS path; skill → name; session → /sessions/<file>; scoop → jid. */
+  locator: string;
+}

--- a/packages/webapp/src/ui/add-menu/add-menu.ts
+++ b/packages/webapp/src/ui/add-menu/add-menu.ts
@@ -1,5 +1,7 @@
+import { Monitor, Upload } from 'lucide';
 import { createLogger } from '../../core/logger.js';
-import type { AddItem } from './add-item.js';
+import { createLucideIcon, type IconNode } from '../create-lucide-icon.js';
+import { type AddItem, referenceKindLabel } from './add-item.js';
 import type { AddSearchAggregator } from './search-providers.js';
 
 const log = createLogger('add-menu');
@@ -12,7 +14,6 @@ export interface AddMenuOptions {
   aggregator: AddSearchAggregator;
   onAttachFiles(files: File[] | FileList): void;
   onAddReference(item: AddItem): void;
-  capturePhoto(): Promise<File | null>;
   captureScreenshot(): Promise<File | null>;
   onClose?(): void;
 }
@@ -34,6 +35,10 @@ export class AddMenu {
       this.opts.onAttachFiles(e.dataTransfer.files);
       this.close();
     }
+  };
+
+  private readonly onSearchKeydown = (e: KeyboardEvent): void => {
+    if (this.handleKey(e)) e.preventDefault();
   };
 
   private readonly onDocumentMousedown = (e: MouseEvent): void => {
@@ -65,6 +70,11 @@ export class AddMenu {
     this.opts.composer.appendChild(this.panel);
 
     this.search.addEventListener('input', () => this.scheduleSearch());
+    // `open()` focuses the search input, so Arrow/Enter/Escape land here —
+    // not on the composer textarea whose keydown handler also calls
+    // `handleKey`. Without this listener, result navigation and selection
+    // would be dead while the menu is open.
+    this.search.addEventListener('keydown', this.onSearchKeydown);
     this.opts.composer.addEventListener('dragover', this.onComposerDragOver);
     this.opts.composer.addEventListener('drop', this.onComposerDrop);
     document.addEventListener('mousedown', this.onDocumentMousedown);
@@ -116,6 +126,7 @@ export class AddMenu {
 
   dispose(): void {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.search.removeEventListener('keydown', this.onSearchKeydown);
     this.opts.composer.removeEventListener('dragover', this.onComposerDragOver);
     this.opts.composer.removeEventListener('drop', this.onComposerDrop);
     document.removeEventListener('mousedown', this.onDocumentMousedown);
@@ -171,23 +182,39 @@ export class AddMenu {
   private renderActionsAndDefault(): void {
     this.results = [];
     this.list.innerHTML = '';
-    const actions: { label: string; sub: string; run: () => void }[] = [
+    const actions: { icon: IconNode; label: string; sub?: string; run: () => void }[] = [
       {
+        icon: Upload as unknown as IconNode,
         label: 'Upload from this computer',
         sub: 'Drag & drop or click to browse',
         run: () => this.requestUpload(),
       },
-      { label: 'Take a photo', sub: '', run: () => void this.runCapture(this.opts.capturePhoto) },
       {
+        icon: Monitor as unknown as IconNode,
         label: 'Take a screenshot',
-        sub: '',
         run: () => void this.runCapture(this.opts.captureScreenshot),
       },
     ];
     for (const a of actions) {
       const el = document.createElement('div');
       el.className = 'add-menu__action';
-      el.textContent = a.sub ? `${a.label} — ${a.sub}` : a.label;
+
+      el.appendChild(createLucideIcon(a.icon, 18));
+
+      const text = document.createElement('span');
+      text.className = 'add-menu__action-text';
+      const label = document.createElement('span');
+      label.className = 'add-menu__action-label';
+      label.textContent = a.label;
+      text.appendChild(label);
+      if (a.sub) {
+        const sub = document.createElement('span');
+        sub.className = 'add-menu__action-sub';
+        sub.textContent = a.sub;
+        text.appendChild(sub);
+      }
+      el.appendChild(text);
+
       el.addEventListener('mousedown', (e) => {
         e.preventDefault();
         a.run();
@@ -232,7 +259,7 @@ export class AddMenu {
 
     const kind = document.createElement('span');
     kind.className = 'add-menu__item-kind';
-    kind.textContent = item.kind;
+    kind.textContent = referenceKindLabel(item.kind);
     el.appendChild(kind);
 
     if (item.sublabel) {

--- a/packages/webapp/src/ui/add-menu/add-menu.ts
+++ b/packages/webapp/src/ui/add-menu/add-menu.ts
@@ -15,6 +15,8 @@ export interface AddMenuOptions {
   onAttachFiles(files: File[] | FileList): void;
   onAddReference(item: AddItem): void;
   captureScreenshot(): Promise<File | null>;
+  /** Called when the user chooses "Upload from this computer". */
+  requestUpload?(): void;
   onClose?(): void;
 }
 
@@ -50,7 +52,10 @@ export class AddMenu {
 
   private results: AddItem[] = [];
   private highlight = 0;
+  private actionElems: { el: HTMLElement; run: () => void }[] = [];
+  private actionHighlight = -1;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly listId = `add-menu-list-${Math.random().toString(36).slice(2, 9)}`;
 
   constructor(private readonly opts: AddMenuOptions) {
     this.panel = document.createElement('div');
@@ -61,8 +66,11 @@ export class AddMenu {
     this.search.className = 'add-menu__search';
     this.search.type = 'text';
     this.search.placeholder = 'Search files, skills, conversations…';
+    this.search.setAttribute('aria-label', 'Search files, skills, conversations');
+    this.search.setAttribute('aria-controls', this.listId);
 
     this.list = document.createElement('div');
+    this.list.id = this.listId;
     this.list.className = 'add-menu__list';
     this.list.setAttribute('role', 'listbox');
 
@@ -100,6 +108,9 @@ export class AddMenu {
     this.opts.composer.classList.remove('composer--add-open');
     this.list.innerHTML = '';
     this.results = [];
+    this.actionElems = [];
+    this.actionHighlight = -1;
+    this.search.removeAttribute('aria-activedescendant');
     this.opts.onClose?.();
   }
 
@@ -118,6 +129,10 @@ export class AddMenu {
           this.pick(this.results[this.highlight]);
           return true;
         }
+        if (this.actionHighlight >= 0 && this.actionHighlight < this.actionElems.length) {
+          this.actionElems[this.actionHighlight].run();
+          return true;
+        }
         return false;
       default:
         return false;
@@ -130,17 +145,44 @@ export class AddMenu {
     this.opts.composer.removeEventListener('dragover', this.onComposerDragOver);
     this.opts.composer.removeEventListener('drop', this.onComposerDrop);
     document.removeEventListener('mousedown', this.onDocumentMousedown);
+    this.actionElems = [];
     this.panel.remove();
   }
 
-  /** Overridden by the host (ChatPanel) to click the hidden file input. */
-  requestUpload: () => void = () => {};
-
   private navigateResults(direction: 1 | -1): boolean {
-    if (!this.results.length) return true;
-    this.highlight = (this.highlight + direction + this.results.length) % this.results.length;
-    this.renderResults();
-    return true;
+    if (this.results.length > 0) {
+      this.highlight = (this.highlight + direction + this.results.length) % this.results.length;
+      this.renderResults();
+      return true;
+    }
+    if (this.actionElems.length > 0) {
+      const len = this.actionElems.length;
+      this.actionHighlight =
+        this.actionHighlight < 0
+          ? direction === 1
+            ? 0
+            : len - 1
+          : (this.actionHighlight + direction + len) % len;
+      this.applyActionHighlight();
+      return true;
+    }
+    return false;
+  }
+
+  private applyActionHighlight(): void {
+    for (let i = 0; i < this.actionElems.length; i++) {
+      this.actionElems[i].el.classList.toggle(
+        'add-menu__action--active',
+        i === this.actionHighlight
+      );
+    }
+    const active = this.actionElems[this.actionHighlight]?.el;
+    if (active?.id) {
+      this.search.setAttribute('aria-activedescendant', active.id);
+      active.scrollIntoView?.({ block: 'nearest' });
+    } else {
+      this.search.removeAttribute('aria-activedescendant');
+    }
   }
 
   private scheduleSearch(): void {
@@ -162,6 +204,8 @@ export class AddMenu {
     }
     log.debug('runSearch', { query, resultCount: items.length });
     if (this.search.value.trim() !== query) return;
+    this.actionElems = [];
+    this.actionHighlight = -1;
     this.results = items;
     this.highlight = 0;
     if (items.length === 0) {
@@ -181,13 +225,16 @@ export class AddMenu {
 
   private renderActionsAndDefault(): void {
     this.results = [];
+    this.actionElems = [];
+    this.actionHighlight = -1;
     this.list.innerHTML = '';
+    this.search.removeAttribute('aria-activedescendant');
     const actions: { icon: IconNode; label: string; sub?: string; run: () => void }[] = [
       {
         icon: Upload as unknown as IconNode,
         label: 'Upload from this computer',
         sub: 'Drag & drop or click to browse',
-        run: () => this.requestUpload(),
+        run: () => this.opts.requestUpload?.(),
       },
       {
         icon: Monitor as unknown as IconNode,
@@ -195,9 +242,11 @@ export class AddMenu {
         run: () => void this.runCapture(this.opts.captureScreenshot),
       },
     ];
-    for (const a of actions) {
+    actions.forEach((a, i) => {
       const el = document.createElement('div');
       el.className = 'add-menu__action';
+      el.id = `${this.listId}-act-${i}`;
+      el.setAttribute('role', 'option');
 
       el.appendChild(createLucideIcon(a.icon, 18));
 
@@ -219,12 +268,19 @@ export class AddMenu {
         e.preventDefault();
         a.run();
       });
+      this.actionElems.push({ el, run: a.run });
       this.list.appendChild(el);
-    }
+    });
   }
 
   private async runCapture(fn: () => Promise<File | null>): Promise<void> {
-    const file = await fn();
+    let file: File | null;
+    try {
+      file = await fn();
+    } catch (err) {
+      log.warn('Screenshot capture threw unexpectedly', { error: String(err) });
+      file = null;
+    }
     if (file) {
       this.opts.onAttachFiles([file]);
       this.close();
@@ -240,10 +296,16 @@ export class AddMenu {
     this.list.innerHTML = '';
     this.results.forEach((item, i) => {
       const el = this.buildResultItem(item, i === this.highlight);
+      el.id = `${this.listId}-opt-${i}`;
       this.list.appendChild(el);
     });
     const active = this.list.querySelector<HTMLElement>('.add-menu__item--active');
     active?.scrollIntoView?.({ block: 'nearest' });
+    if (active?.id) {
+      this.search.setAttribute('aria-activedescendant', active.id);
+    } else {
+      this.search.removeAttribute('aria-activedescendant');
+    }
   }
 
   private buildResultItem(item: AddItem, isActive: boolean): HTMLElement {

--- a/packages/webapp/src/ui/add-menu/add-menu.ts
+++ b/packages/webapp/src/ui/add-menu/add-menu.ts
@@ -21,6 +21,19 @@ export class AddMenu {
   private readonly search: HTMLInputElement;
   private readonly list: HTMLElement;
   private open_ = false;
+
+  private readonly onComposerDragOver = (e: DragEvent): void => {
+    if (this.open_) e.preventDefault();
+  };
+
+  private readonly onComposerDrop = (e: DragEvent): void => {
+    if (!this.open_) return;
+    e.preventDefault();
+    if (e.dataTransfer?.files?.length) {
+      this.opts.onAttachFiles(e.dataTransfer.files);
+      this.close();
+    }
+  };
   private results: AddItem[] = [];
   private highlight = 0;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -43,17 +56,8 @@ export class AddMenu {
     this.opts.composer.appendChild(this.panel);
 
     this.search.addEventListener('input', () => this.scheduleSearch());
-    this.opts.composer.addEventListener('dragover', (e) => {
-      if (this.open_) e.preventDefault();
-    });
-    this.opts.composer.addEventListener('drop', (e) => {
-      if (!this.open_) return;
-      e.preventDefault();
-      if (e.dataTransfer?.files?.length) {
-        this.opts.onAttachFiles(e.dataTransfer.files);
-        this.close();
-      }
-    });
+    this.opts.composer.addEventListener('dragover', this.onComposerDragOver);
+    this.opts.composer.addEventListener('drop', this.onComposerDrop);
   }
 
   isOpen(): boolean {
@@ -101,6 +105,8 @@ export class AddMenu {
 
   dispose(): void {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.opts.composer.removeEventListener('dragover', this.onComposerDragOver);
+    this.opts.composer.removeEventListener('drop', this.onComposerDrop);
     this.panel.remove();
   }
 

--- a/packages/webapp/src/ui/add-menu/add-menu.ts
+++ b/packages/webapp/src/ui/add-menu/add-menu.ts
@@ -1,0 +1,237 @@
+import { createLogger } from '../../core/logger.js';
+import type { AddItem } from './add-item.js';
+import type { AddSearchAggregator } from './search-providers.js';
+
+const log = createLogger('add-menu');
+const PER_KIND_LIMIT = 6;
+const DEBOUNCE_MS = 120;
+
+export interface AddMenuOptions {
+  composer: HTMLElement;
+  toggleButton: HTMLButtonElement;
+  aggregator: AddSearchAggregator;
+  onAttachFiles(files: File[] | FileList): void;
+  onAddReference(item: AddItem): void;
+  capturePhoto(): Promise<File | null>;
+  captureScreenshot(): Promise<File | null>;
+}
+
+export class AddMenu {
+  private readonly panel: HTMLElement;
+  private readonly search: HTMLInputElement;
+  private readonly list: HTMLElement;
+  private open_ = false;
+  private results: AddItem[] = [];
+  private highlight = 0;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly opts: AddMenuOptions) {
+    this.panel = document.createElement('div');
+    this.panel.className = 'add-menu';
+    this.panel.style.display = 'none';
+
+    this.search = document.createElement('input');
+    this.search.className = 'add-menu__search';
+    this.search.type = 'text';
+    this.search.placeholder = 'Search files, skills, conversations…';
+
+    this.list = document.createElement('div');
+    this.list.className = 'add-menu__list';
+    this.list.setAttribute('role', 'listbox');
+
+    this.panel.append(this.list, this.search);
+    this.opts.composer.appendChild(this.panel);
+
+    this.search.addEventListener('input', () => this.scheduleSearch());
+    this.opts.composer.addEventListener('dragover', (e) => {
+      if (this.open_) e.preventDefault();
+    });
+    this.opts.composer.addEventListener('drop', (e) => {
+      if (!this.open_) return;
+      e.preventDefault();
+      if (e.dataTransfer?.files?.length) {
+        this.opts.onAttachFiles(e.dataTransfer.files);
+        this.close();
+      }
+    });
+  }
+
+  isOpen(): boolean {
+    return this.open_;
+  }
+
+  open(): void {
+    this.open_ = true;
+    this.panel.style.display = 'block';
+    this.opts.composer.classList.add('composer--add-open');
+    this.search.value = '';
+    this.highlight = 0;
+    this.renderActionsAndDefault();
+    this.search.focus();
+  }
+
+  close(): void {
+    this.open_ = false;
+    this.panel.style.display = 'none';
+    this.opts.composer.classList.remove('composer--add-open');
+    this.list.innerHTML = '';
+    this.results = [];
+  }
+
+  handleKey(event: KeyboardEvent): boolean {
+    if (!this.open_) return false;
+    switch (event.key) {
+      case 'Escape':
+        this.close();
+        return true;
+      case 'ArrowDown':
+        return this.navigateResults(1);
+      case 'ArrowUp':
+        return this.navigateResults(-1);
+      case 'Enter':
+        if (this.results.length) {
+          this.pick(this.results[this.highlight]);
+          return true;
+        }
+        return false;
+      default:
+        return false;
+    }
+  }
+
+  dispose(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.panel.remove();
+  }
+
+  /** Overridden by the host (ChatPanel) to click the hidden file input. */
+  requestUpload: () => void = () => {};
+
+  private navigateResults(direction: 1 | -1): boolean {
+    if (!this.results.length) return true;
+    this.highlight = (this.highlight + direction + this.results.length) % this.results.length;
+    this.renderResults();
+    return true;
+  }
+
+  private scheduleSearch(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    const query = this.search.value.trim();
+    if (!query) {
+      this.renderActionsAndDefault();
+      return;
+    }
+    this.debounceTimer = setTimeout(() => void this.runSearch(query), DEBOUNCE_MS);
+  }
+
+  private async runSearch(query: string): Promise<void> {
+    let items: AddItem[] = [];
+    try {
+      items = await this.opts.aggregator.search(query, PER_KIND_LIMIT);
+    } catch (err) {
+      log.warn('Add-menu search failed', { error: String(err) });
+    }
+    if (this.search.value.trim() !== query) return;
+    this.results = items;
+    this.highlight = 0;
+    if (items.length === 0) {
+      this.renderEmpty(query);
+      return;
+    }
+    this.renderResults();
+  }
+
+  private renderEmpty(query: string): void {
+    this.list.innerHTML = '';
+    const empty = document.createElement('div');
+    empty.className = 'add-menu__empty';
+    empty.textContent = `No matches for "${query}".`;
+    this.list.appendChild(empty);
+  }
+
+  private renderActionsAndDefault(): void {
+    this.results = [];
+    this.list.innerHTML = '';
+    const actions: { label: string; sub: string; run: () => void }[] = [
+      {
+        label: 'Upload from this computer',
+        sub: 'Drag & drop or click to browse',
+        run: () => this.requestUpload(),
+      },
+      { label: 'Take a photo', sub: '', run: () => void this.runCapture(this.opts.capturePhoto) },
+      {
+        label: 'Take a screenshot',
+        sub: '',
+        run: () => void this.runCapture(this.opts.captureScreenshot),
+      },
+    ];
+    for (const a of actions) {
+      const el = document.createElement('div');
+      el.className = 'add-menu__action';
+      el.textContent = a.sub ? `${a.label} — ${a.sub}` : a.label;
+      el.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        a.run();
+      });
+      this.list.appendChild(el);
+    }
+  }
+
+  private async runCapture(fn: () => Promise<File | null>): Promise<void> {
+    const file = await fn();
+    if (file) {
+      this.opts.onAttachFiles([file]);
+      this.close();
+    } else {
+      const note = document.createElement('div');
+      note.className = 'add-menu__empty';
+      note.textContent = 'Capture cancelled.';
+      this.list.prepend(note);
+    }
+  }
+
+  private renderResults(): void {
+    this.list.innerHTML = '';
+    this.results.forEach((item, i) => {
+      const el = this.buildResultItem(item, i === this.highlight);
+      this.list.appendChild(el);
+    });
+    const active = this.list.querySelector<HTMLElement>('.add-menu__item--active');
+    active?.scrollIntoView?.({ block: 'nearest' });
+  }
+
+  private buildResultItem(item: AddItem, isActive: boolean): HTMLElement {
+    const el = document.createElement('div');
+    el.className = 'add-menu__item';
+    if (isActive) el.classList.add('add-menu__item--active');
+    el.setAttribute('role', 'option');
+
+    const label = document.createElement('span');
+    label.className = 'add-menu__item-label';
+    label.textContent = item.label;
+    el.appendChild(label);
+
+    const kind = document.createElement('span');
+    kind.className = 'add-menu__item-kind';
+    kind.textContent = item.kind;
+    el.appendChild(kind);
+
+    if (item.sublabel) {
+      const sub = document.createElement('span');
+      sub.className = 'add-menu__item-sub';
+      sub.textContent = item.sublabel;
+      el.appendChild(sub);
+    }
+
+    el.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      this.pick(item);
+    });
+    return el;
+  }
+
+  private pick(item: AddItem): void {
+    this.opts.onAddReference(item);
+    this.close();
+  }
+}

--- a/packages/webapp/src/ui/add-menu/add-menu.ts
+++ b/packages/webapp/src/ui/add-menu/add-menu.ts
@@ -14,6 +14,7 @@ export interface AddMenuOptions {
   onAddReference(item: AddItem): void;
   capturePhoto(): Promise<File | null>;
   captureScreenshot(): Promise<File | null>;
+  onClose?(): void;
 }
 
 export class AddMenu {
@@ -80,6 +81,7 @@ export class AddMenu {
     this.opts.composer.classList.remove('composer--add-open');
     this.list.innerHTML = '';
     this.results = [];
+    this.opts.onClose?.();
   }
 
   handleKey(event: KeyboardEvent): boolean {

--- a/packages/webapp/src/ui/add-menu/add-menu.ts
+++ b/packages/webapp/src/ui/add-menu/add-menu.ts
@@ -149,6 +149,7 @@ export class AddMenu {
     } catch (err) {
       log.warn('Add-menu search failed', { error: String(err) });
     }
+    log.debug('runSearch', { query, resultCount: items.length });
     if (this.search.value.trim() !== query) return;
     this.results = items;
     this.highlight = 0;

--- a/packages/webapp/src/ui/add-menu/add-menu.ts
+++ b/packages/webapp/src/ui/add-menu/add-menu.ts
@@ -35,6 +35,14 @@ export class AddMenu {
       this.close();
     }
   };
+
+  private readonly onDocumentMousedown = (e: MouseEvent): void => {
+    if (!this.open_) return;
+    const target = e.target as Node | null;
+    if (this.panel.contains(target) || this.opts.toggleButton.contains(target)) return;
+    this.close();
+  };
+
   private results: AddItem[] = [];
   private highlight = 0;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -59,6 +67,7 @@ export class AddMenu {
     this.search.addEventListener('input', () => this.scheduleSearch());
     this.opts.composer.addEventListener('dragover', this.onComposerDragOver);
     this.opts.composer.addEventListener('drop', this.onComposerDrop);
+    document.addEventListener('mousedown', this.onDocumentMousedown);
   }
 
   isOpen(): boolean {
@@ -109,6 +118,7 @@ export class AddMenu {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     this.opts.composer.removeEventListener('dragover', this.onComposerDragOver);
     this.opts.composer.removeEventListener('drop', this.onComposerDrop);
+    document.removeEventListener('mousedown', this.onDocumentMousedown);
     this.panel.remove();
   }
 
@@ -193,7 +203,7 @@ export class AddMenu {
     } else {
       const note = document.createElement('div');
       note.className = 'add-menu__empty';
-      note.textContent = 'Capture cancelled.';
+      note.textContent = 'Capture cancelled or unavailable.';
       this.list.prepend(note);
     }
   }

--- a/packages/webapp/src/ui/add-menu/capture.ts
+++ b/packages/webapp/src/ui/add-menu/capture.ts
@@ -20,7 +20,8 @@ export async function grabFrameToFile(
     canvas.width = w;
     canvas.height = h;
     const ctx = canvas.getContext('2d');
-    ctx?.drawImage(video, 0, 0, w, h);
+    if (!ctx) return null;
+    ctx.drawImage(video, 0, 0, w, h);
     const blob: Blob | null = await new Promise((resolve) =>
       canvas.toBlob((b) => resolve(b), 'image/png')
     );
@@ -35,7 +36,23 @@ async function streamToFile(stream: MediaStream): Promise<File | null> {
   const video = document.createElement('video');
   video.srcObject = stream;
   video.muted = true;
-  await video.play().catch(() => {});
+  // A failed play() can still yield a blank frame below, so surface it
+  // rather than swallowing silently — but don't abort the capture.
+  await video.play().catch((err) => {
+    log.warn('Screenshot video.play() failed; frame may be blank', { error: String(err) });
+  });
+  // Wait for the first decoded frame before grabbing. `loadeddata` fires once
+  // readyState reaches HAVE_CURRENT_DATA (≥ 2); fall back after 2 s so a
+  // stalled stream cannot hang the capture forever.
+  await new Promise<void>((resolve) => {
+    if (video.readyState >= 2) {
+      resolve();
+      return;
+    }
+    const done = (): void => resolve();
+    video.addEventListener('loadeddata', done, { once: true });
+    setTimeout(done, 2000);
+  });
   await new Promise((r) => requestAnimationFrame(() => r(null)));
   return grabFrameToFile(stream, video, 'screenshot');
 }
@@ -45,11 +62,7 @@ async function streamToFile(stream: MediaStream): Promise<File | null> {
 export async function captureScreenshot(): Promise<File | null> {
   let stream: MediaStream;
   try {
-    stream = await (
-      navigator.mediaDevices as MediaDevices & {
-        getDisplayMedia(c?: DisplayMediaStreamOptions): Promise<MediaStream>;
-      }
-    ).getDisplayMedia({ video: true });
+    stream = await navigator.mediaDevices.getDisplayMedia({ video: true });
   } catch (err) {
     log.info('Screenshot capture cancelled/denied', { error: String(err) });
     return null;

--- a/packages/webapp/src/ui/add-menu/capture.ts
+++ b/packages/webapp/src/ui/add-menu/capture.ts
@@ -11,7 +11,7 @@ function stopStream(stream: MediaStream): void {
 export async function grabFrameToFile(
   stream: MediaStream,
   video: HTMLVideoElement,
-  prefix: 'photo' | 'screenshot'
+  prefix: 'screenshot'
 ): Promise<File | null> {
   try {
     const w = video.videoWidth || 1280;
@@ -31,29 +31,13 @@ export async function grabFrameToFile(
   }
 }
 
-async function streamToFile(
-  stream: MediaStream,
-  prefix: 'photo' | 'screenshot'
-): Promise<File | null> {
+async function streamToFile(stream: MediaStream): Promise<File | null> {
   const video = document.createElement('video');
   video.srcObject = stream;
   video.muted = true;
   await video.play().catch(() => {});
   await new Promise((r) => requestAnimationFrame(() => r(null)));
-  return grabFrameToFile(stream, video, prefix);
-}
-
-/** Capture a still from the webcam. Returns null on denial/cancel. MUST be
- *  called synchronously from a user gesture. */
-export async function capturePhoto(): Promise<File | null> {
-  let stream: MediaStream;
-  try {
-    stream = await navigator.mediaDevices.getUserMedia({ video: true });
-  } catch (err) {
-    log.info('Photo capture cancelled/denied', { error: String(err) });
-    return null;
-  }
-  return streamToFile(stream, 'photo');
+  return grabFrameToFile(stream, video, 'screenshot');
 }
 
 /** Capture a still of the user's screen via the native picker. Returns null
@@ -70,5 +54,5 @@ export async function captureScreenshot(): Promise<File | null> {
     log.info('Screenshot capture cancelled/denied', { error: String(err) });
     return null;
   }
-  return streamToFile(stream, 'screenshot');
+  return streamToFile(stream);
 }

--- a/packages/webapp/src/ui/add-menu/capture.ts
+++ b/packages/webapp/src/ui/add-menu/capture.ts
@@ -1,0 +1,74 @@
+import { createLogger } from '../../core/logger.js';
+
+const log = createLogger('add-menu-capture');
+
+function stopStream(stream: MediaStream): void {
+  for (const track of stream.getTracks()) track.stop();
+}
+
+/** Draw the current video frame to a canvas and return it as a PNG File.
+ *  Always stops the stream's tracks. Exported for testing. */
+export async function grabFrameToFile(
+  stream: MediaStream,
+  video: HTMLVideoElement,
+  prefix: 'photo' | 'screenshot'
+): Promise<File | null> {
+  try {
+    const w = video.videoWidth || 1280;
+    const h = video.videoHeight || 720;
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    ctx?.drawImage(video, 0, 0, w, h);
+    const blob: Blob | null = await new Promise((resolve) =>
+      canvas.toBlob((b) => resolve(b), 'image/png')
+    );
+    if (!blob) return null;
+    return new File([blob], `${prefix}-${Date.now()}.png`, { type: 'image/png' });
+  } finally {
+    stopStream(stream);
+  }
+}
+
+async function streamToFile(
+  stream: MediaStream,
+  prefix: 'photo' | 'screenshot'
+): Promise<File | null> {
+  const video = document.createElement('video');
+  video.srcObject = stream;
+  video.muted = true;
+  await video.play().catch(() => {});
+  await new Promise((r) => requestAnimationFrame(() => r(null)));
+  return grabFrameToFile(stream, video, prefix);
+}
+
+/** Capture a still from the webcam. Returns null on denial/cancel. MUST be
+ *  called synchronously from a user gesture. */
+export async function capturePhoto(): Promise<File | null> {
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ video: true });
+  } catch (err) {
+    log.info('Photo capture cancelled/denied', { error: String(err) });
+    return null;
+  }
+  return streamToFile(stream, 'photo');
+}
+
+/** Capture a still of the user's screen via the native picker. Returns null
+ *  on denial/cancel. MUST be called synchronously from a user gesture. */
+export async function captureScreenshot(): Promise<File | null> {
+  let stream: MediaStream;
+  try {
+    stream = await (
+      navigator.mediaDevices as MediaDevices & {
+        getDisplayMedia(c?: DisplayMediaStreamOptions): Promise<MediaStream>;
+      }
+    ).getDisplayMedia({ video: true });
+  } catch (err) {
+    log.info('Screenshot capture cancelled/denied', { error: String(err) });
+    return null;
+  }
+  return streamToFile(stream, 'screenshot');
+}

--- a/packages/webapp/src/ui/add-menu/preamble.ts
+++ b/packages/webapp/src/ui/add-menu/preamble.ts
@@ -1,5 +1,11 @@
 import type { AddItem } from './add-item.js';
 
+/** Replace embedded newlines with spaces so a single reference never
+ *  spans multiple lines and corrupts the `[context]` block structure. */
+function collapseNewlines(s: string): string {
+  return s.replace(/[\n\r]/g, ' ');
+}
+
 /**
  * Compile reference chips into a `[context]` preamble prepended to the
  * user's prompt. The agent resolves each locator with its own tools
@@ -9,8 +15,10 @@ import type { AddItem } from './add-item.js';
 export function compileContextPreamble(references: AddItem[]): string {
   if (references.length === 0) return '';
   const lines = references.map((r) => {
-    const tail = r.label && r.label !== r.locator ? ` (${r.label})` : '';
-    return `- ${r.kind}: ${r.locator}${tail}`;
+    const locator = collapseNewlines(r.locator);
+    const label = collapseNewlines(r.label);
+    const tail = label && label !== locator ? ` (${label})` : '';
+    return `- ${r.kind}: ${locator}${tail}`;
   });
   return ['[context]', ...lines].join('\n');
 }
@@ -21,6 +29,11 @@ export function compileContextPreamble(references: AddItem[]): string {
  * from text reconstructed out of the agent's stored history, so the hidden
  * preamble never leaks into a rebuilt transcript. No-op when there's no
  * leading block.
+ *
+ * Display edge case: a user message that literally starts with `[context]\n`
+ * (without having gone through compileContextPreamble) will also have that
+ * prefix stripped from the displayed transcript. The full text is still
+ * forwarded to the agent correctly via `agentText` in chat-panel.ts.
  */
 export function stripContextPreamble(text: string): string {
   if (!text.startsWith('[context]\n')) return text;

--- a/packages/webapp/src/ui/add-menu/preamble.ts
+++ b/packages/webapp/src/ui/add-menu/preamble.ts
@@ -14,3 +14,16 @@ export function compileContextPreamble(references: AddItem[]): string {
   });
   return ['[context]', ...lines].join('\n');
 }
+
+/**
+ * Inverse of compileContextPreamble, for DISPLAY ONLY: strip a leading
+ * `[context]` block (header + `- ` lines, up to the blank-line separator)
+ * from text reconstructed out of the agent's stored history, so the hidden
+ * preamble never leaks into a rebuilt transcript. No-op when there's no
+ * leading block.
+ */
+export function stripContextPreamble(text: string): string {
+  if (!text.startsWith('[context]\n')) return text;
+  const sep = text.indexOf('\n\n');
+  return sep === -1 ? '' : text.slice(sep + 2);
+}

--- a/packages/webapp/src/ui/add-menu/preamble.ts
+++ b/packages/webapp/src/ui/add-menu/preamble.ts
@@ -1,0 +1,16 @@
+import type { AddItem } from './add-item.js';
+
+/**
+ * Compile reference chips into a `[context]` preamble prepended to the
+ * user's prompt. The agent resolves each locator with its own tools
+ * (cat the file/folder, use the skill, read the session, address the
+ * scoop). Returns '' when there are no references.
+ */
+export function compileContextPreamble(references: AddItem[]): string {
+  if (references.length === 0) return '';
+  const lines = references.map((r) => {
+    const tail = r.label && r.label !== r.locator ? ` (${r.label})` : '';
+    return `- ${r.kind}: ${r.locator}${tail}`;
+  });
+  return ['[context]', ...lines].join('\n');
+}

--- a/packages/webapp/src/ui/add-menu/preamble.ts
+++ b/packages/webapp/src/ui/add-menu/preamble.ts
@@ -25,18 +25,15 @@ export function compileContextPreamble(references: AddItem[]): string {
 
 /**
  * Inverse of compileContextPreamble, for DISPLAY ONLY: strip a leading
- * `[context]` block (header + `- ` lines, up to the blank-line separator)
- * from text reconstructed out of the agent's stored history, so the hidden
- * preamble never leaks into a rebuilt transcript. No-op when there's no
- * leading block.
+ * `[context]` block (header + `- ` lines + blank separator) from text
+ * reconstructed out of the agent's stored history, so the hidden preamble
+ * never leaks into a rebuilt transcript. No-op when there's no leading block.
  *
- * Display edge case: a user message that literally starts with `[context]\n`
- * (without having gone through compileContextPreamble) will also have that
- * prefix stripped from the displayed transcript. The full text is still
- * forwarded to the agent correctly via `agentText` in chat-panel.ts.
+ * The regex anchors to the exact structure compileContextPreamble emits, so
+ * user messages that happen to start with "[context]" are left untouched
+ * unless they also have the `- kind: locator` + blank-line shape.
  */
 export function stripContextPreamble(text: string): string {
-  if (!text.startsWith('[context]\n')) return text;
-  const sep = text.indexOf('\n\n');
-  return sep === -1 ? '' : text.slice(sep + 2);
+  const match = /^\[context\]\n(?:- [^\n]*\n)*\n/.exec(text);
+  return match ? text.slice(match[0].length) : text;
 }

--- a/packages/webapp/src/ui/add-menu/search-providers.ts
+++ b/packages/webapp/src/ui/add-menu/search-providers.ts
@@ -1,4 +1,7 @@
+import { createLogger } from '../../core/logger.js';
 import type { AddItem, AddItemKind } from './add-item.js';
+
+const log = createLogger('add-menu-search');
 
 export interface AddSearchProvider {
   kind: AddItemKind;
@@ -70,8 +73,8 @@ async function walkFilesAndDirs(
         collectAncestorDirs(filePath, root, seenDirs);
         if (fileItems.length >= 500) break;
       }
-    } catch {
-      // skip an unreadable root
+    } catch (err) {
+      log.warn('file/folder walk failed', { root, error: String(err) });
     }
     if (fileItems.length >= 500) break;
   }
@@ -112,7 +115,8 @@ export function createSkillProvider(vfs: VfsLike): AddSearchProvider {
       let entries: { name: string; type: string }[] = [];
       try {
         entries = await vfs.readDir('/workspace/skills');
-      } catch {
+      } catch (err) {
+        log.warn('skill provider failed', { error: String(err) });
         return [];
       }
       const skills = entries
@@ -138,7 +142,8 @@ export function createSessionProvider(readIndex: ReadSessionsIndex): AddSearchPr
       let index: Awaited<ReturnType<ReadSessionsIndex>> = [];
       try {
         index = await readIndex();
-      } catch {
+      } catch (err) {
+        log.warn('session provider failed', { error: String(err) });
         return [];
       }
       return index
@@ -184,8 +189,17 @@ export function createAggregator(providers: AddSearchProvider[]): AddSearchAggre
   return {
     async search(query, perKindLimit) {
       const groups = await Promise.all(
-        providers.map((p) => p.search(query, perKindLimit).catch(() => []))
+        providers.map((p) =>
+          p.search(query, perKindLimit).catch((err) => {
+            log.warn('provider threw in aggregator', { error: String(err) });
+            return [] as AddItem[];
+          })
+        )
       );
+      log.debug('aggregator results', {
+        query,
+        perKind: providers.map((p, i) => [p.kind, groups[i].length]),
+      });
       return groups.flat();
     },
   };

--- a/packages/webapp/src/ui/add-menu/search-providers.ts
+++ b/packages/webapp/src/ui/add-menu/search-providers.ts
@@ -85,7 +85,7 @@ function applyQueryRanking(items: AddItem[], query: string, limit: number): AddI
         .filter((x) => x.s >= 0)
         .sort((a, b) => b.s - a.s || a.it.locator.localeCompare(b.it.locator))
         .map((x) => x.it)
-    : items.sort((a, b) => a.locator.localeCompare(b.locator));
+    : [...items].sort((a, b) => a.locator.localeCompare(b.locator));
   return scored.slice(0, limit);
 }
 

--- a/packages/webapp/src/ui/add-menu/search-providers.ts
+++ b/packages/webapp/src/ui/add-menu/search-providers.ts
@@ -1,0 +1,158 @@
+import type { AddItem, AddItemKind } from './add-item.js';
+
+export interface AddSearchProvider {
+  kind: AddItemKind;
+  search(query: string, limit: number): Promise<AddItem[]>;
+}
+
+export interface AddSearchAggregator {
+  search(query: string, perKindLimit: number): Promise<AddItem[]>;
+}
+
+/** Minimal VFS surface the file/folder + skill providers need. */
+interface VfsLike {
+  readDir(path: string): Promise<{ name: string; type: string }[]>;
+  walk(path: string): AsyncGenerator<string>;
+}
+
+function rank(query: string, hay: string): number {
+  const q = query.toLowerCase();
+  const h = hay.toLowerCase();
+  if (!q) return 0;
+  if (h === q) return 3;
+  if (h.startsWith(q)) return 2;
+  if (h.includes(q)) return 1;
+  return -1;
+}
+
+function basename(path: string): string {
+  const parts = path.split('/').filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}
+
+function parentDir(path: string): string {
+  const idx = path.lastIndexOf('/');
+  return idx <= 0 ? '/' : path.slice(0, idx);
+}
+
+export function createFileFolderProvider(vfs: VfsLike, roots: string[]): AddSearchProvider {
+  return {
+    kind: 'file',
+    async search(query, limit) {
+      const items: AddItem[] = [];
+      const seen = new Set<string>();
+      for (const root of roots) {
+        try {
+          for await (const filePath of vfs.walk(root)) {
+            if (seen.has(filePath)) continue;
+            seen.add(filePath);
+            items.push({
+              kind: 'file',
+              label: basename(filePath),
+              sublabel: parentDir(filePath),
+              locator: filePath,
+            });
+            if (items.length >= 500) break;
+          }
+        } catch {
+          // skip an unreadable root
+        }
+        if (items.length >= 500) break;
+      }
+      const scored = query
+        ? items
+            .map((it) => ({ it, s: rank(query, it.locator) }))
+            .filter((x) => x.s >= 0)
+            .sort((a, b) => b.s - a.s || a.it.locator.localeCompare(b.it.locator))
+            .map((x) => x.it)
+        : items.sort((a, b) => a.locator.localeCompare(b.locator));
+      return scored.slice(0, limit);
+    },
+  };
+}
+
+export function createSkillProvider(vfs: VfsLike): AddSearchProvider {
+  return {
+    kind: 'skill',
+    async search(query, limit) {
+      let entries: { name: string; type: string }[] = [];
+      try {
+        entries = await vfs.readDir('/workspace/skills');
+      } catch {
+        return [];
+      }
+      const skills = entries
+        .filter((e) => e.type === 'directory')
+        .map<AddItem>((e) => ({ kind: 'skill', label: e.name, locator: e.name }))
+        .filter((it) => rank(query, it.label) >= 0)
+        .sort(
+          (a, b) => rank(query, b.label) - rank(query, a.label) || a.label.localeCompare(b.label)
+        );
+      return skills.slice(0, limit);
+    },
+  };
+}
+
+type ReadSessionsIndex = () => Promise<
+  { filename: string; title: string; frozenAt: string; messageCount: number }[]
+>;
+
+export function createSessionProvider(readIndex: ReadSessionsIndex): AddSearchProvider {
+  return {
+    kind: 'session',
+    async search(query, limit) {
+      let index: Awaited<ReturnType<ReadSessionsIndex>> = [];
+      try {
+        index = await readIndex();
+      } catch {
+        return [];
+      }
+      return index
+        .map<AddItem>((e) => ({
+          kind: 'session',
+          label: e.title,
+          sublabel: `${e.messageCount} messages`,
+          locator: `/sessions/${e.filename}`,
+        }))
+        .filter((it) => rank(query, it.label) >= 0 || rank(query, it.locator) >= 0)
+        .sort(
+          (a, b) => rank(query, b.label) - rank(query, a.label) || a.label.localeCompare(b.label)
+        )
+        .slice(0, limit);
+    },
+  };
+}
+
+type GetScoops = () => { jid: string; name: string; isCone: boolean }[];
+
+export function createScoopProvider(getScoops: GetScoops): AddSearchProvider {
+  return {
+    kind: 'scoop',
+    async search(query, limit) {
+      return getScoops()
+        .filter((s) => !s.isCone)
+        .map<AddItem>((s) => ({
+          kind: 'scoop',
+          label: s.name,
+          sublabel: undefined,
+          locator: s.jid,
+        }))
+        .filter((it) => rank(query, it.label) >= 0)
+        .sort(
+          (a, b) => rank(query, b.label) - rank(query, a.label) || a.label.localeCompare(b.label)
+        )
+        .slice(0, limit);
+    },
+  };
+}
+
+export function createAggregator(providers: AddSearchProvider[]): AddSearchAggregator {
+  return {
+    async search(query, perKindLimit) {
+      const groups = await Promise.all(
+        providers.map((p) => p.search(query, perKindLimit).catch(() => []))
+      );
+      return groups.flat();
+    },
+  };
+}

--- a/packages/webapp/src/ui/add-menu/search-providers.ts
+++ b/packages/webapp/src/ui/add-menu/search-providers.ts
@@ -35,38 +35,72 @@ function parentDir(path: string): string {
   return idx <= 0 ? '/' : path.slice(0, idx);
 }
 
+/*
+ * Walks upward from a file's immediate parent directory collecting distinct
+ * ancestor paths that fall strictly under the given root (i.e. longer than
+ * the root path). Stops as soon as a directory has already been seen.
+ */
+function collectAncestorDirs(filePath: string, root: string, seen: Set<string>): void {
+  let dir = parentDir(filePath);
+  while (dir.length > root.length) {
+    if (seen.has(dir)) break;
+    seen.add(dir);
+    dir = parentDir(dir);
+  }
+}
+
+async function walkFilesAndDirs(
+  vfs: VfsLike,
+  roots: string[]
+): Promise<{ fileItems: AddItem[]; seenDirs: Set<string> }> {
+  const fileItems: AddItem[] = [];
+  const seenFiles = new Set<string>();
+  const seenDirs = new Set<string>();
+  for (const root of roots) {
+    try {
+      for await (const filePath of vfs.walk(root)) {
+        if (seenFiles.has(filePath)) continue;
+        seenFiles.add(filePath);
+        fileItems.push({
+          kind: 'file',
+          label: basename(filePath),
+          sublabel: parentDir(filePath),
+          locator: filePath,
+        });
+        collectAncestorDirs(filePath, root, seenDirs);
+        if (fileItems.length >= 500) break;
+      }
+    } catch {
+      // skip an unreadable root
+    }
+    if (fileItems.length >= 500) break;
+  }
+  return { fileItems, seenDirs };
+}
+
+function applyQueryRanking(items: AddItem[], query: string, limit: number): AddItem[] {
+  const scored = query
+    ? items
+        .map((it) => ({ it, s: rank(query, it.locator) }))
+        .filter((x) => x.s >= 0)
+        .sort((a, b) => b.s - a.s || a.it.locator.localeCompare(b.it.locator))
+        .map((x) => x.it)
+    : items.sort((a, b) => a.locator.localeCompare(b.locator));
+  return scored.slice(0, limit);
+}
+
 export function createFileFolderProvider(vfs: VfsLike, roots: string[]): AddSearchProvider {
   return {
     kind: 'file',
     async search(query, limit) {
-      const items: AddItem[] = [];
-      const seen = new Set<string>();
-      for (const root of roots) {
-        try {
-          for await (const filePath of vfs.walk(root)) {
-            if (seen.has(filePath)) continue;
-            seen.add(filePath);
-            items.push({
-              kind: 'file',
-              label: basename(filePath),
-              sublabel: parentDir(filePath),
-              locator: filePath,
-            });
-            if (items.length >= 500) break;
-          }
-        } catch {
-          // skip an unreadable root
-        }
-        if (items.length >= 500) break;
-      }
-      const scored = query
-        ? items
-            .map((it) => ({ it, s: rank(query, it.locator) }))
-            .filter((x) => x.s >= 0)
-            .sort((a, b) => b.s - a.s || a.it.locator.localeCompare(b.it.locator))
-            .map((x) => x.it)
-        : items.sort((a, b) => a.locator.localeCompare(b.locator));
-      return scored.slice(0, limit);
+      const { fileItems, seenDirs } = await walkFilesAndDirs(vfs, roots);
+      const folderItems: AddItem[] = [...seenDirs].map((dir) => ({
+        kind: 'folder' as const,
+        label: basename(dir),
+        sublabel: parentDir(dir),
+        locator: dir,
+      }));
+      return applyQueryRanking([...folderItems, ...fileItems], query, limit);
     },
   };
 }

--- a/packages/webapp/src/ui/add-menu/search-providers.ts
+++ b/packages/webapp/src/ui/add-menu/search-providers.ts
@@ -12,11 +12,18 @@ export interface AddSearchAggregator {
   search(query: string, perKindLimit: number): Promise<AddItem[]>;
 }
 
-/** Minimal VFS surface the file/folder + skill providers need. */
+/**
+ * Minimal VFS surface the file/folder + skill providers need. Only
+ * `readDir` is required so the providers work against both the page-side
+ * `VirtualFS` (non-OPFS) and the worker-backed `RemoteVfsClient` (OPFS,
+ * the browser default) — the latter does not expose a `walk` generator.
+ */
 interface VfsLike {
   readDir(path: string): Promise<{ name: string; type: string }[]>;
-  walk(path: string): AsyncGenerator<string>;
 }
+
+const WALK_LIMIT = 500;
+const WALK_CACHE_TTL_MS = 3000;
 
 function rank(query: string, hay: string): number {
   const q = query.toLowerCase();
@@ -28,57 +35,54 @@ function rank(query: string, hay: string): number {
   return -1;
 }
 
-function basename(path: string): string {
-  const parts = path.split('/').filter(Boolean);
-  return parts[parts.length - 1] ?? path;
+function joinPath(dir: string, name: string): string {
+  return dir === '/' ? `/${name}` : `${dir}/${name}`;
 }
 
-function parentDir(path: string): string {
-  const idx = path.lastIndexOf('/');
-  return idx <= 0 ? '/' : path.slice(0, idx);
+function isExcluded(path: string, exclude: string[]): boolean {
+  return exclude.some((ex) => path === ex || path.startsWith(`${ex}/`));
 }
 
 /*
- * Walks upward from a file's immediate parent directory collecting distinct
- * ancestor paths that fall strictly under the given root (i.e. longer than
- * the root path). Stops as soon as a directory has already been seen.
+ * Breadth-first traversal of `roots` using only `readDir`, emitting a flat
+ * list of file and folder `AddItem`s (bounded by `WALK_LIMIT`). Each entry's
+ * parent directory is used as its `sublabel`. A failed `readDir` on any
+ * single directory is logged and skipped so one unreadable subtree does not
+ * abort the whole walk. Subtrees under any `exclude` prefix are skipped
+ * entirely (e.g. `/workspace/skills`, which the skill provider owns).
  */
-function collectAncestorDirs(filePath: string, root: string, seen: Set<string>): void {
-  let dir = parentDir(filePath);
-  while (dir.length > root.length) {
-    if (seen.has(dir)) break;
-    seen.add(dir);
-    dir = parentDir(dir);
-  }
-}
-
-async function walkFilesAndDirs(
+async function walkViaReadDir(
   vfs: VfsLike,
-  roots: string[]
-): Promise<{ fileItems: AddItem[]; seenDirs: Set<string> }> {
-  const fileItems: AddItem[] = [];
-  const seenFiles = new Set<string>();
-  const seenDirs = new Set<string>();
-  for (const root of roots) {
+  roots: string[],
+  exclude: string[]
+): Promise<AddItem[]> {
+  const items: AddItem[] = [];
+  const seen = new Set<string>();
+  const queue: string[] = roots.filter((r) => !isExcluded(r, exclude));
+  while (queue.length) {
+    if (items.length >= WALK_LIMIT) break;
+    const dir = queue.shift() as string;
+    let entries: { name: string; type: string }[];
     try {
-      for await (const filePath of vfs.walk(root)) {
-        if (seenFiles.has(filePath)) continue;
-        seenFiles.add(filePath);
-        fileItems.push({
-          kind: 'file',
-          label: basename(filePath),
-          sublabel: parentDir(filePath),
-          locator: filePath,
-        });
-        collectAncestorDirs(filePath, root, seenDirs);
-        if (fileItems.length >= 500) break;
-      }
+      entries = await vfs.readDir(dir);
     } catch (err) {
-      log.warn('file/folder walk failed', { root, error: String(err) });
+      log.warn('readDir failed during walk', { dir, error: String(err) });
+      continue;
     }
-    if (fileItems.length >= 500) break;
+    for (const entry of entries) {
+      const path = joinPath(dir, entry.name);
+      if (seen.has(path) || isExcluded(path, exclude)) continue;
+      seen.add(path);
+      if (entry.type === 'directory') {
+        items.push({ kind: 'folder', label: entry.name, sublabel: dir, locator: path });
+        queue.push(path);
+      } else if (entry.type === 'file') {
+        items.push({ kind: 'file', label: entry.name, sublabel: dir, locator: path });
+      }
+      if (items.length >= WALK_LIMIT) break;
+    }
   }
-  return { fileItems, seenDirs };
+  return items;
 }
 
 function applyQueryRanking(items: AddItem[], query: string, limit: number): AddItem[] {
@@ -92,18 +96,38 @@ function applyQueryRanking(items: AddItem[], query: string, limit: number): AddI
   return scored.slice(0, limit);
 }
 
-export function createFileFolderProvider(vfs: VfsLike, roots: string[]): AddSearchProvider {
+export function createFileFolderProvider(
+  vfs: VfsLike,
+  roots: string[],
+  exclude: string[] = []
+): AddSearchProvider {
+  /*
+   * The full tree is walked once and reused across keystrokes within a
+   * short TTL. Over the OPFS RPC path a fresh walk per keystroke would be
+   * dozens of round-trips; the cache keeps typeahead responsive while still
+   * picking up filesystem changes within `WALK_CACHE_TTL_MS`.
+   */
+  let cache: { at: number; items: AddItem[] } | null = null;
+  let inflight: Promise<AddItem[]> | null = null;
+
+  function loadItems(): Promise<AddItem[]> {
+    if (cache && Date.now() - cache.at < WALK_CACHE_TTL_MS) return Promise.resolve(cache.items);
+    if (inflight) return inflight;
+    inflight = walkViaReadDir(vfs, roots, exclude)
+      .then((items) => {
+        cache = { at: Date.now(), items };
+        return items;
+      })
+      .finally(() => {
+        inflight = null;
+      });
+    return inflight;
+  }
+
   return {
     kind: 'file',
     async search(query, limit) {
-      const { fileItems, seenDirs } = await walkFilesAndDirs(vfs, roots);
-      const folderItems: AddItem[] = [...seenDirs].map((dir) => ({
-        kind: 'folder' as const,
-        label: basename(dir),
-        sublabel: parentDir(dir),
-        locator: dir,
-      }));
-      return applyQueryRanking([...folderItems, ...fileItems], query, limit);
+      return applyQueryRanking(await loadItems(), query, limit);
     },
   };
 }

--- a/packages/webapp/src/ui/add-menu/search-providers.ts
+++ b/packages/webapp/src/ui/add-menu/search-providers.ts
@@ -27,6 +27,12 @@ interface VfsLike {
 const WALK_LIMIT = 500;
 const WALK_CACHE_TTL_MS = 3000;
 
+const NOISY_DIR_NAMES = new Set(['node_modules', 'dist', 'build', 'coverage', '__pycache__']);
+
+function isNoisyDir(name: string): boolean {
+  return name.startsWith('.') || NOISY_DIR_NAMES.has(name);
+}
+
 function rank(query: string, hay: string): number {
   const q = query.toLowerCase();
   const h = hay.toLowerCase();
@@ -76,6 +82,7 @@ async function walkViaReadDir(
       if (seen.has(path) || isExcluded(path, exclude)) continue;
       seen.add(path);
       if (entry.type === 'directory') {
+        if (isNoisyDir(entry.name)) continue;
         items.push({ kind: 'folder', label: entry.name, sublabel: dir, locator: path });
         queue.push(path);
       } else if (entry.type === 'file') {

--- a/packages/webapp/src/ui/add-menu/search-providers.ts
+++ b/packages/webapp/src/ui/add-menu/search-providers.ts
@@ -1,10 +1,12 @@
 import { createLogger } from '../../core/logger.js';
-import type { AddItem, AddItemKind } from './add-item.js';
+import type { AddItem } from './add-item.js';
 
 const log = createLogger('add-menu-search');
 
 export interface AddSearchProvider {
-  kind: AddItemKind;
+  /** Identifies the provider in debug logs; not constrained to AddItemKind
+   *  because a single provider can emit multiple kinds (e.g. 'file-folder'). */
+  kind: string;
   search(query: string, limit: number): Promise<AddItem[]>;
 }
 
@@ -125,7 +127,7 @@ export function createFileFolderProvider(
   }
 
   return {
-    kind: 'file',
+    kind: 'file-folder',
     async search(query, limit) {
       return applyQueryRanking(await loadItems(), query, limit);
     },
@@ -170,13 +172,25 @@ export function createSessionProvider(readIndex: ReadSessionsIndex): AddSearchPr
         log.warn('session provider failed', { error: String(err) });
         return [];
       }
+
+      const toItem = (e: (typeof index)[0]): AddItem => ({
+        kind: 'session',
+        label: e.title,
+        sublabel: `${e.messageCount} messages`,
+        locator: `/sessions/${e.filename}`,
+      });
+
+      if (!query) {
+        // No query: return sessions newest-first. frozenAt is ISO 8601, so
+        // lexicographic comparison gives correct chronological ordering.
+        return [...index]
+          .sort((a, b) => b.frozenAt.localeCompare(a.frozenAt))
+          .slice(0, limit)
+          .map(toItem);
+      }
+
       return index
-        .map<AddItem>((e) => ({
-          kind: 'session',
-          label: e.title,
-          sublabel: `${e.messageCount} messages`,
-          locator: `/sessions/${e.filename}`,
-        }))
+        .map(toItem)
         .filter((it) => rank(query, it.label) >= 0 || rank(query, it.locator) >= 0)
         .sort(
           (a, b) => rank(query, b.label) - rank(query, a.label) || a.label.localeCompare(b.label)

--- a/packages/webapp/src/ui/boot/setup-ui-fixture.ts
+++ b/packages/webapp/src/ui/boot/setup-ui-fixture.ts
@@ -33,10 +33,10 @@ export async function loadUIFixtureIntoChat(chatPanel: {
   switchToContext: (id: string, readOnly: boolean, scoopName?: string) => Promise<void>;
   loadMessages: (msgs: ChatMessage[]) => void;
   setCompactionState?: (state: 'summarizing' | 'extracting-memory' | 'idle') => void;
+  openAddMenuForFixture?(): void;
 }): Promise<void> {
-  const [{ createChatFixture, FIXTURE_SESSION_ID, FIXTURE_SCOOP_NAME }] = await Promise.all([
-    import('../chat-fixture.js'),
-  ]);
+  const [{ createChatFixture, FIXTURE_SESSION_ID, FIXTURE_SCOOP_NAME, applyAddMenuFixtureSeed }] =
+    await Promise.all([import('../chat-fixture.js')]);
   await chatPanel.switchToContext(FIXTURE_SESSION_ID, true, FIXTURE_SCOOP_NAME);
   chatPanel.loadMessages(createChatFixture());
   // Optional preview of the compaction ghost bubble for designers:
@@ -47,5 +47,11 @@ export async function loadUIFixtureIntoChat(chatPanel: {
   if (compacting === 'summarizing' || compacting === 'extracting-memory') {
     chatPanel.setCompactionState?.(compacting);
   }
+  // Open the add-menu so its search/results/actions UI is visible for CSS
+  // iteration. `wireAddMenu` (main.ts) runs before this finalize step in
+  // both the extension and standalone-worker boot paths, so `addMenu` is
+  // already wired when this fires. The `?.` guard makes it safe to call
+  // even from tests that pass a minimal stub.
+  applyAddMenuFixtureSeed(chatPanel);
   log.info('Loaded UI fixture session for design iteration');
 }

--- a/packages/webapp/src/ui/chat-fixture.ts
+++ b/packages/webapp/src/ui/chat-fixture.ts
@@ -55,6 +55,17 @@ export const FIXTURE_SESSION_ID = 'session-ui-fixture';
  *  render as `@ui-fixture` instead of `sliccy`. */
 export const FIXTURE_SCOOP_NAME = 'ui-fixture';
 
+/**
+ * Open the add-menu on the given panel so its search/results/actions UI
+ * renders during `?ui-fixture=1` design iteration.
+ *
+ * The panel parameter is typed structurally so this module does not need
+ * to import ChatPanel and avoids a potential import cycle.
+ */
+export function applyAddMenuFixtureSeed(panel: { openAddMenuForFixture?(): void }): void {
+  panel.openAddMenuForFixture?.();
+}
+
 /** Build the synthetic chat history. Pure function — no side effects.
  *  Each message has a stable id so the fixture is idempotent under
  *  re-renders and matches exact-id lookups in tests. */

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -374,6 +374,7 @@ export class ChatPanel {
       onAddReference: (item) => this.addReference(item),
       capturePhoto: opts.capturePhoto,
       captureScreenshot: opts.captureScreenshot,
+      onClose: () => this.updateAddToggleIcon(),
     });
     this.addMenu.requestUpload = () => this.fileInput.click();
   }
@@ -2331,7 +2332,9 @@ export class ChatPanel {
     for (const ref of this.pendingReferences) {
       const chip = document.createElement('span');
       chip.className = 'chat__ref-chip';
-      chip.textContent = `${ref.label} `;
+      const labelSpan = document.createElement('span');
+      labelSpan.textContent = ref.label;
+      chip.appendChild(labelSpan);
       const removeBtn = document.createElement('button');
       removeBtn.type = 'button';
       removeBtn.textContent = '×';
@@ -3308,6 +3311,8 @@ export class ChatPanel {
       document.removeEventListener('keydown', this.keydownListener);
       this.keydownListener = null;
     }
+    this.addMenu?.dispose();
+    this.addMenu = null;
     this.container.innerHTML = '';
   }
 }

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -17,10 +17,11 @@ import { createLogger } from '../core/logger.js';
 import { getMimeType } from '../core/mime-types.js';
 import { isThinkingLevel, THINKING_LEVEL_CYCLE, type ThinkingLevel } from '../scoops/types.js';
 import { toPreviewUrl } from '../shell/supplemental-commands/shared.js';
-import type { AddItem } from './add-menu/add-item.js';
+import { type AddItem, referenceKindLabel } from './add-menu/add-item.js';
 import { AddMenu } from './add-menu/add-menu.js';
 import { compileContextPreamble } from './add-menu/preamble.js';
 import type { AddSearchAggregator } from './add-menu/search-providers.js';
+import { createLucideIcon, type IconNode } from './create-lucide-icon.js';
 import {
   type DipInstance,
   type DraftDipInstance,
@@ -61,8 +62,6 @@ import './press-button.js';
 import type { SliccPressButton } from './press-button.js';
 
 const log = createLogger('chat-panel');
-
-type IconNode = [tag: string, attrs: Record<string, string | number>][];
 
 /**
  * Writes a dropped/picked file somewhere the agent can reach (typically
@@ -107,27 +106,6 @@ function readToolCallStatus(el: Element): 'running' | 'success' | 'error' {
   if (el.classList.contains('tool-call--success')) return 'success';
   if (el.classList.contains('tool-call--error')) return 'error';
   return 'running';
-}
-
-function createLucideIcon(node: IconNode, size = 18): SVGElement {
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-  svg.setAttribute('width', String(size));
-  svg.setAttribute('height', String(size));
-  svg.setAttribute('viewBox', '0 0 24 24');
-  svg.setAttribute('fill', 'none');
-  svg.setAttribute('stroke', 'currentColor');
-  svg.setAttribute('stroke-width', '2');
-  svg.setAttribute('stroke-linecap', 'round');
-  svg.setAttribute('stroke-linejoin', 'round');
-  for (const [tag, attrs] of node) {
-    const child = document.createElementNS('http://www.w3.org/2000/svg', tag);
-    for (const [key, value] of Object.entries(attrs)) {
-      child.setAttribute(key, String(value));
-    }
-    svg.appendChild(child);
-  }
-  return svg;
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
@@ -362,7 +340,6 @@ export class ChatPanel {
   /** Construct (or replace) the add-menu, wired to the composer's input wrapper. */
   setAddMenu(opts: {
     aggregator: AddSearchAggregator;
-    capturePhoto(): Promise<File | null>;
     captureScreenshot(): Promise<File | null>;
   }): void {
     this.addMenu?.dispose();
@@ -372,7 +349,6 @@ export class ChatPanel {
       aggregator: opts.aggregator,
       onAttachFiles: (files) => void this.addAttachmentsFromFiles(files),
       onAddReference: (item) => this.addReference(item),
-      capturePhoto: opts.capturePhoto,
       captureScreenshot: opts.captureScreenshot,
       onClose: () => this.updateAddToggleIcon(),
     });
@@ -2341,6 +2317,10 @@ export class ChatPanel {
     for (const ref of this.pendingReferences) {
       const chip = document.createElement('span');
       chip.className = 'chat__ref-chip';
+      const kindSpan = document.createElement('span');
+      kindSpan.className = 'chat__ref-chip-kind';
+      kindSpan.textContent = `${referenceKindLabel(ref.kind)}:`;
+      chip.appendChild(kindSpan);
       const labelSpan = document.createElement('span');
       labelSpan.textContent = ref.label;
       chip.appendChild(labelSpan);
@@ -2741,17 +2721,6 @@ export class ChatPanel {
         contentEl.appendChild(cursor);
       } else {
         this.hydrateDipsInEl(contentEl, msg.id);
-      }
-      if (msg.references?.length) {
-        const refsRow = document.createElement('div');
-        refsRow.className = 'chat__msg-refs';
-        for (const ref of msg.references) {
-          const chip = document.createElement('span');
-          chip.className = 'chat__ref-chip';
-          chip.textContent = ref.label;
-          refsRow.appendChild(chip);
-        }
-        contentEl.prepend(refsRow);
       }
       el.appendChild(contentEl);
     }

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -350,9 +350,9 @@ export class ChatPanel {
       onAttachFiles: (files) => void this.addAttachmentsFromFiles(files),
       onAddReference: (item) => this.addReference(item),
       captureScreenshot: opts.captureScreenshot,
+      requestUpload: () => this.fileInput.click(),
       onClose: () => this.updateAddToggleIcon(),
     });
-    this.addMenu.requestUpload = () => this.fileInput.click();
   }
 
   private addReference(item: AddItem): void {
@@ -1241,6 +1241,9 @@ export class ChatPanel {
         void this.addAttachmentsFromFiles(files);
       }
       this.fileInput.value = '';
+      // Mirror the drag/drop and screenshot paths: the add-menu's Upload
+      // action opens this picker, so dismiss the menu once it returns.
+      if (this.addMenu?.isOpen()) this.addMenu.close();
     });
     this.stopBtn.addEventListener('click', () => {
       this.agent?.stop();
@@ -2327,6 +2330,7 @@ export class ChatPanel {
       const removeBtn = document.createElement('button');
       removeBtn.type = 'button';
       removeBtn.textContent = '×';
+      removeBtn.setAttribute('aria-label', `Remove ${ref.label}`);
       removeBtn.addEventListener('click', () => {
         this.pendingReferences = this.pendingReferences.filter((r) => r !== ref);
         this.renderPendingAttachments();

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -392,6 +392,11 @@ export class ChatPanel {
     this.attachBtn.classList.toggle('chat__attach-btn--open', !!this.addMenu?.isOpen());
   }
 
+  /** Design-time only: open the add-menu so its UI renders for the ?ui-fixture harness. */
+  openAddMenuForFixture(): void {
+    this.addMenu?.open();
+  }
+
   /** @internal test hook */
   addReferenceForTest(item: AddItem): void {
     this.addReference(item);

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -17,6 +17,10 @@ import { createLogger } from '../core/logger.js';
 import { getMimeType } from '../core/mime-types.js';
 import { isThinkingLevel, THINKING_LEVEL_CYCLE, type ThinkingLevel } from '../scoops/types.js';
 import { toPreviewUrl } from '../shell/supplemental-commands/shared.js';
+import type { AddItem } from './add-menu/add-item.js';
+import { AddMenu } from './add-menu/add-menu.js';
+import { compileContextPreamble } from './add-menu/preamble.js';
+import type { AddSearchAggregator } from './add-menu/search-providers.js';
 import {
   type DipInstance,
   type DraftDipInstance,
@@ -217,7 +221,10 @@ export class ChatPanel {
   private attachBtn!: HTMLButtonElement;
   private fileInput!: HTMLInputElement;
   private attachmentsEl!: HTMLElement;
+  private inputWrapper!: HTMLElement;
   private pendingAttachments: MessageAttachment[] = [];
+  private pendingReferences: AddItem[] = [];
+  private addMenu: AddMenu | null = null;
   private attachmentReadInProgress = false;
   private attachmentWriter: AttachmentWriter | null = null;
   private voiceInput: VoiceInput | null = null;
@@ -350,6 +357,48 @@ export class ChatPanel {
     this.unsubscribe?.();
     this.agent = agent;
     this.unsubscribe = agent.onEvent((ev) => this.handleAgentEvent(ev));
+  }
+
+  /** Construct (or replace) the add-menu, wired to the composer's input wrapper. */
+  setAddMenu(opts: {
+    aggregator: AddSearchAggregator;
+    capturePhoto(): Promise<File | null>;
+    captureScreenshot(): Promise<File | null>;
+  }): void {
+    this.addMenu?.dispose();
+    this.addMenu = new AddMenu({
+      composer: this.inputWrapper,
+      toggleButton: this.attachBtn,
+      aggregator: opts.aggregator,
+      onAttachFiles: (files) => void this.addAttachmentsFromFiles(files),
+      onAddReference: (item) => this.addReference(item),
+      capturePhoto: opts.capturePhoto,
+      captureScreenshot: opts.captureScreenshot,
+    });
+    this.addMenu.requestUpload = () => this.fileInput.click();
+  }
+
+  private addReference(item: AddItem): void {
+    if (this.pendingReferences.some((r) => r.kind === item.kind && r.locator === item.locator)) {
+      return;
+    }
+    this.pendingReferences.push(item);
+    this.renderPendingAttachments();
+    this.updateAddToggleIcon();
+  }
+
+  private updateAddToggleIcon(): void {
+    this.attachBtn.classList.toggle('chat__attach-btn--open', !!this.addMenu?.isOpen());
+  }
+
+  /** @internal test hook */
+  addReferenceForTest(item: AddItem): void {
+    this.addReference(item);
+  }
+
+  /** @internal test hook */
+  getMessagesForTest(): ChatMessage[] {
+    return this.messages;
   }
 
   /**
@@ -1074,8 +1123,9 @@ export class ChatPanel {
     this.micBtn.dataset.tooltip = 'Voice (Ctrl+Shift+V)';
 
     // Input wrapper — two-row layout per Figma PromptBar
-    const inputWrapper = document.createElement('div');
-    inputWrapper.className = 'chat__input-wrapper';
+    this.inputWrapper = document.createElement('div');
+    this.inputWrapper.className = 'chat__input-wrapper';
+    const inputWrapper = this.inputWrapper;
 
     this.attachmentsEl = document.createElement('div');
     this.attachmentsEl.className = 'chat__attachments';
@@ -1137,6 +1187,10 @@ export class ChatPanel {
 
     // Event listeners
     this.textarea.addEventListener('keydown', (e) => {
+      if (this.addMenu?.handleKey(e)) {
+        e.preventDefault();
+        return;
+      }
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         this.sendMessage();
@@ -1187,7 +1241,14 @@ export class ChatPanel {
     });
 
     this.sendBtn.addEventListener('click', () => this.sendMessage());
-    this.attachBtn.addEventListener('click', () => this.fileInput.click());
+    this.attachBtn.addEventListener('click', () => {
+      if (this.addMenu) {
+        this.addMenu.isOpen() ? this.addMenu.close() : this.addMenu.open();
+        this.updateAddToggleIcon();
+      } else {
+        this.fileInput.click();
+      }
+    });
     this.fileInput.addEventListener('change', () => {
       const files = this.fileInput.files;
       if (files?.length) {
@@ -1317,12 +1378,17 @@ export class ChatPanel {
     this.autoScrollAttached = true;
     this.hideJumpPill();
 
+    const pendingRefs = this.pendingReferences.slice();
+    const preamble = compileContextPreamble(pendingRefs);
+    const agentText = preamble ? `${preamble}\n\n${text}` : text;
+
     const isQueued = this.isStreaming;
     const msg: ChatMessage = {
       id: uid(),
       role: 'user',
       content: text,
       attachments: attachments.length > 0 ? attachments : undefined,
+      references: pendingRefs.length > 0 ? pendingRefs : undefined,
       timestamp: Date.now(),
       queued: isQueued || undefined,
     };
@@ -1333,6 +1399,7 @@ export class ChatPanel {
     // Clear input and shrink back to a single row
     this.textarea.value = '';
     this.pendingAttachments = [];
+    this.pendingReferences = [];
     this.renderPendingAttachments();
     this.resetTextareaHeight();
     this.updateSendButtonState();
@@ -1343,7 +1410,7 @@ export class ChatPanel {
     }
 
     // Send to agent (orchestrator persists & queues if the cone is busy)
-    this.agent?.sendMessage(text, msg.id, attachments);
+    this.agent?.sendMessage(agentText, msg.id, attachments);
     // Notify the leader-tray broadcast hook so followers receive a
     // matching `user_message_echo` live. Exception isolation: a broken
     // broadcaster must not undo the local agent send.
@@ -2247,10 +2314,8 @@ export class ChatPanel {
   private renderPendingAttachments(): void {
     if (!this.attachmentsEl) return;
     this.attachmentsEl.innerHTML = '';
-    this.attachmentsEl.classList.toggle(
-      'chat__attachments--visible',
-      this.pendingAttachments.length > 0
-    );
+    const hasContent = this.pendingAttachments.length > 0 || this.pendingReferences.length > 0;
+    this.attachmentsEl.classList.toggle('chat__attachments--visible', hasContent);
     for (const attachment of this.pendingAttachments) {
       this.attachmentsEl.appendChild(
         this.createAttachmentChip(attachment, {
@@ -2262,6 +2327,20 @@ export class ChatPanel {
           },
         })
       );
+    }
+    for (const ref of this.pendingReferences) {
+      const chip = document.createElement('span');
+      chip.className = 'chat__ref-chip';
+      chip.textContent = `${ref.label} `;
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.textContent = '×';
+      removeBtn.addEventListener('click', () => {
+        this.pendingReferences = this.pendingReferences.filter((r) => r !== ref);
+        this.renderPendingAttachments();
+      });
+      chip.appendChild(removeBtn);
+      this.attachmentsEl.appendChild(chip);
     }
   }
 
@@ -2650,6 +2729,17 @@ export class ChatPanel {
         contentEl.appendChild(cursor);
       } else {
         this.hydrateDipsInEl(contentEl, msg.id);
+      }
+      if (msg.references?.length) {
+        const refsRow = document.createElement('div');
+        refsRow.className = 'chat__msg-refs';
+        for (const ref of msg.references) {
+          const chip = document.createElement('span');
+          chip.className = 'chat__ref-chip';
+          chip.textContent = ref.label;
+          refsRow.appendChild(chip);
+        }
+        contentEl.prepend(refsRow);
       }
       el.appendChild(contentEl);
     }

--- a/packages/webapp/src/ui/chat-panel.ts
+++ b/packages/webapp/src/ui/chat-panel.ts
@@ -5,7 +5,7 @@
  * Connects to an AgentHandle for sending messages and receiving events.
  */
 
-import { Brain, File as FileIcon, FileText, Image as ImageIcon, Paperclip, X } from 'lucide';
+import { Brain, File as FileIcon, FileText, Image as ImageIcon, Plus, X } from 'lucide';
 import type { MessageAttachment, MessageAttachmentKind } from '../core/attachments.js';
 import { formatAttachmentSize, formatAttachmentSummary } from '../core/attachments.js';
 import {
@@ -389,7 +389,11 @@ export class ChatPanel {
   }
 
   private updateAddToggleIcon(): void {
-    this.attachBtn.classList.toggle('chat__attach-btn--open', !!this.addMenu?.isOpen());
+    const isOpen = !!this.addMenu?.isOpen();
+    this.attachBtn.classList.toggle('chat__attach-btn--open', isOpen);
+    this.attachBtn.replaceChildren(
+      createLucideIcon((isOpen ? X : Plus) as unknown as IconNode, 18)
+    );
   }
 
   /** Design-time only: open the add-menu so its UI renders for the ?ui-fixture harness. */
@@ -1088,8 +1092,8 @@ export class ChatPanel {
     this.attachBtn = document.createElement('button');
     this.attachBtn.className = 'chat__attach-btn';
     this.attachBtn.type = 'button';
-    this.attachBtn.appendChild(createLucideIcon(Paperclip as unknown as IconNode, 18));
-    this.attachBtn.dataset.tooltip = 'Attach files';
+    this.attachBtn.dataset.tooltip = 'Add context';
+    this.updateAddToggleIcon();
 
     this.fileInput = document.createElement('input');
     this.fileInput.className = 'chat__file-input';

--- a/packages/webapp/src/ui/create-lucide-icon.ts
+++ b/packages/webapp/src/ui/create-lucide-icon.ts
@@ -1,0 +1,29 @@
+/**
+ * Build an SVG element from a lucide icon node. lucide ships each icon as a
+ * `[tag, attrs][]` array; this renders it into a styled `<svg>` that inherits
+ * `currentColor`. Shared by the composer and the add-menu so the SVG-builder
+ * isn't duplicated.
+ */
+
+export type IconNode = [tag: string, attrs: Record<string, string | number>][];
+
+export function createLucideIcon(node: IconNode, size = 18): SVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  svg.setAttribute('width', String(size));
+  svg.setAttribute('height', String(size));
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  for (const [tag, attrs] of node) {
+    const child = document.createElementNS('http://www.w3.org/2000/svg', tag);
+    for (const [key, value] of Object.entries(attrs)) {
+      child.setAttribute(key, String(value));
+    }
+    svg.appendChild(child);
+  }
+  return svg;
+}

--- a/packages/webapp/src/ui/lick-view.ts
+++ b/packages/webapp/src/ui/lick-view.ts
@@ -21,9 +21,8 @@ import {
   Webhook,
   Workflow,
 } from 'lucide';
+import { createLucideIcon, type IconNode } from './create-lucide-icon.js';
 import type { ChatMessage } from './types.js';
-
-type IconNode = [tag: string, attrs: Record<string, string | number>][];
 
 /** Per-channel metadata driving the compact row + expanded body. */
 export interface LickDescriptor {
@@ -180,26 +179,5 @@ export function parseLickContent(content: string): ParsedLick {
 /** Build the lucide SVG element for a channel. */
 export function createLickIcon(msg: ChatMessage): SVGElement {
   const desc = getLickDescriptor(msg);
-  return iconNodeToSvg(desc.icon);
-}
-
-function iconNodeToSvg(node: IconNode): SVGElement {
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-  svg.setAttribute('width', '14');
-  svg.setAttribute('height', '14');
-  svg.setAttribute('viewBox', '0 0 24 24');
-  svg.setAttribute('fill', 'none');
-  svg.setAttribute('stroke', 'currentColor');
-  svg.setAttribute('stroke-width', '2');
-  svg.setAttribute('stroke-linecap', 'round');
-  svg.setAttribute('stroke-linejoin', 'round');
-  for (const [tag, attrs] of node) {
-    const child = document.createElementNS('http://www.w3.org/2000/svg', tag);
-    for (const [k, v] of Object.entries(attrs)) {
-      child.setAttribute(k, String(v));
-    }
-    svg.appendChild(child);
-  }
-  return svg;
+  return createLucideIcon(desc.icon, 14);
 }

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -108,11 +108,7 @@ function wireAddMenu(
           mimeType: 'image/png',
           quality: 1.0,
         });
-        const ab =
-          result.bytes.buffer instanceof ArrayBuffer
-            ? result.bytes.buffer
-            : new Uint8Array(result.bytes).buffer;
-        return new File([ab], `screenshot-${Date.now()}.png`, { type: 'image/png' });
+        return new File([result.bytes], `screenshot-${Date.now()}.png`, { type: 'image/png' });
       } catch {
         return null;
       }

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -29,6 +29,10 @@ import type { VirtualFS } from '../fs/index.js';
 import { registerProviders } from '../providers/index.js';
 import { hasStoredTrayJoinUrl } from '../scoops/tray-runtime-config.js';
 import type { RegisteredScoop } from '../scoops/types.js';
+import {
+  captureViaPopup,
+  isExtensionFloat,
+} from '../shell/supplemental-commands/extension-media-capture.js';
 import { capturePhoto, captureScreenshot } from './add-menu/capture.js';
 import {
   createAggregator,
@@ -70,14 +74,71 @@ import { initTooltips } from './tooltip.js';
 
 const log = createLogger('main');
 
-function wireAddMenu(layout: Layout, vfs: VirtualFS, client: OffscreenClient): void {
+function wireAddMenu(
+  layout: Layout,
+  vfs: VirtualFS,
+  client: OffscreenClient,
+  isExtension: boolean
+): void {
   const aggregator = createAggregator([
     createFileFolderProvider(vfs, ['/workspace', '/shared']),
     createSkillProvider(vfs),
     createSessionProvider(() => readSessionsIndex(vfs)),
     createScoopProvider(() => client.getScoops()),
   ]);
-  layout.panels.chat.setAddMenu({ aggregator, capturePhoto, captureScreenshot });
+
+  let photo: () => Promise<File | null>;
+  let screenshot: () => Promise<File | null>;
+
+  if (isExtension && isExtensionFloat()) {
+    /**
+     * In the extension side-panel page, getUserMedia / getDisplayMedia can't
+     * prompt (no visible surface). Route both captures through the popup
+     * helper which opens a real Chrome window for the permission / picker UI.
+     * captureViaPopup returns PopupCaptureResult { bytes, mimeType, width, height };
+     * convert to File so the add-menu contract (File | null) is satisfied.
+     * On cancel / timeout the popup rejects — map to null.
+     */
+    photo = async (): Promise<File | null> => {
+      try {
+        const result = await captureViaPopup({
+          kind: 'camera',
+          mode: 'photo',
+          mimeType: 'image/png',
+          quality: 1.0,
+        });
+        const ab =
+          result.bytes.buffer instanceof ArrayBuffer
+            ? result.bytes.buffer
+            : new Uint8Array(result.bytes).buffer;
+        return new File([ab], `photo-${Date.now()}.png`, { type: 'image/png' });
+      } catch {
+        return null;
+      }
+    };
+
+    screenshot = async (): Promise<File | null> => {
+      try {
+        const result = await captureViaPopup({
+          kind: 'screen',
+          mimeType: 'image/png',
+          quality: 1.0,
+        });
+        const ab =
+          result.bytes.buffer instanceof ArrayBuffer
+            ? result.bytes.buffer
+            : new Uint8Array(result.bytes).buffer;
+        return new File([ab], `screenshot-${Date.now()}.png`, { type: 'image/png' });
+      } catch {
+        return null;
+      }
+    };
+  } else {
+    photo = capturePhoto;
+    screenshot = captureScreenshot;
+  }
+
+  layout.panels.chat.setAddMenu({ aggregator, capturePhoto: photo, captureScreenshot: screenshot });
 }
 
 /**
@@ -163,7 +224,7 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
     getSelectedScoop: () => selectedScoop,
     log,
   }).syncThinkingButtonForScoop;
-  wireAddMenu(layout, localFs, client);
+  wireAddMenu(layout, localFs, client, true);
 
   // Persistent dedup ledger of welcome-flow licks — shared between the
   // orchestrator's final-lick and the welcome lick interceptor.
@@ -322,7 +383,7 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
     log,
   });
   const { localFs, writableFs } = vfsHandle;
-  wireAddMenu(layout, localFs, client);
+  wireAddMenu(layout, localFs, client, false);
 
   // Post-panels runtime composite: host-ready join → onboarding →
   // dip-lick callback → sprinkle manager → leader-runtime + panel-RPC +

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -12,6 +12,7 @@ import './styles/dialog.css';
 import './styles/sprinkle-components.css';
 import './styles/feedback.css';
 import './styles/image-preview.css';
+import './styles/add-menu.css';
 /**
  * Main entry point for the Browser Coding Agent UI.
  *
@@ -21,12 +22,21 @@ import './styles/image-preview.css';
  */
 
 import { createLogger } from '../core/index.js';
+import type { VirtualFS } from '../fs/index.js';
 // Auto-discover and register all providers (built-in + external).
 // IMPORTANT: This import must also appear in packages/chrome-extension/src/offscreen.ts
 // — the extension agent engine runs in the offscreen document, not in this file.
 import { registerProviders } from '../providers/index.js';
 import { hasStoredTrayJoinUrl } from '../scoops/tray-runtime-config.js';
 import type { RegisteredScoop } from '../scoops/types.js';
+import { capturePhoto, captureScreenshot } from './add-menu/capture.js';
+import {
+  createAggregator,
+  createFileFolderProvider,
+  createScoopProvider,
+  createSessionProvider,
+  createSkillProvider,
+} from './add-menu/search-providers.js';
 import { setupElectronOverlay } from './boot/setup-electron-overlay.js';
 import { setupExtensionClient } from './boot/setup-extension-client.js';
 import { setupExtensionDetached } from './boot/setup-extension-detached.js';
@@ -51,12 +61,24 @@ import { setupSwRegistration } from './boot/setup-sw-registration.js';
 import { setupVfs } from './boot/setup-vfs.js';
 import { loadFiredWelcomeActions, persistFiredWelcomeActions } from './boot/setup-welcome-flow.js';
 import { Layout } from './layout.js';
+import type { OffscreenClient } from './offscreen-client.js';
 import { applyProviderDefaults, getApiKey } from './provider-settings.js';
 import { resolveUiRuntimeMode, type UiRuntimeMode } from './runtime-mode.js';
+import { readSessionsIndex } from './session-freezer.js';
 import { initTheme } from './theme.js';
 import { initTooltips } from './tooltip.js';
 
 const log = createLogger('main');
+
+function wireAddMenu(layout: Layout, vfs: VirtualFS, client: OffscreenClient): void {
+  const aggregator = createAggregator([
+    createFileFolderProvider(vfs, ['/workspace', '/shared']),
+    createSkillProvider(vfs),
+    createSessionProvider(() => readSessionsIndex(vfs)),
+    createScoopProvider(() => client.getScoops()),
+  ]);
+  layout.panels.chat.setAddMenu({ aggregator, capturePhoto, captureScreenshot });
+}
 
 /**
  * Sprinkle names whose `.shtml` file backs an inline dip rather than a
@@ -141,6 +163,7 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
     getSelectedScoop: () => selectedScoop,
     log,
   }).syncThinkingButtonForScoop;
+  wireAddMenu(layout, localFs, client);
 
   // Persistent dedup ledger of welcome-flow licks — shared between the
   // orchestrator's final-lick and the welcome lick interceptor.
@@ -298,7 +321,8 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
     syncThinkingButtonForScoop,
     log,
   });
-  const { writableFs } = vfsHandle;
+  const { localFs, writableFs } = vfsHandle;
+  wireAddMenu(layout, localFs, client);
 
   // Post-panels runtime composite: host-ready join → onboarding →
   // dip-lick callback → sprinkle manager → leader-runtime + panel-RPC +

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -108,7 +108,9 @@ function wireAddMenu(
           mimeType: 'image/png',
           quality: 1.0,
         });
-        return new File([result.bytes], `screenshot-${Date.now()}.png`, { type: 'image/png' });
+        return new File([result.bytes.buffer as ArrayBuffer], `screenshot-${Date.now()}.png`, {
+          type: 'image/png',
+        });
       } catch {
         return null;
       }

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -22,7 +22,7 @@ import './styles/add-menu.css';
  */
 
 import { createLogger } from '../core/index.js';
-import type { VirtualFS } from '../fs/index.js';
+import type { LocalVfsClient } from '../kernel/local-vfs-client.js';
 // Auto-discover and register all providers (built-in + external).
 // IMPORTANT: This import must also appear in packages/chrome-extension/src/offscreen.ts
 // — the extension agent engine runs in the offscreen document, not in this file.
@@ -33,7 +33,7 @@ import {
   captureViaPopup,
   isExtensionFloat,
 } from '../shell/supplemental-commands/extension-media-capture.js';
-import { capturePhoto, captureScreenshot } from './add-menu/capture.js';
+import { captureScreenshot } from './add-menu/capture.js';
 import {
   createAggregator,
   createFileFolderProvider,
@@ -76,47 +76,31 @@ const log = createLogger('main');
 
 function wireAddMenu(
   layout: Layout,
-  vfs: VirtualFS,
+  vfs: LocalVfsClient,
   client: OffscreenClient,
   isExtension: boolean
 ): void {
   const aggregator = createAggregator([
-    createFileFolderProvider(vfs, ['/workspace', '/shared']),
+    // Exclude the skills tree from file/folder results — skills surface as
+    // first-class, activatable SKILL entries via createSkillProvider, so
+    // listing their directories/files here would only duplicate them.
+    createFileFolderProvider(vfs, ['/workspace', '/shared'], ['/workspace/skills']),
     createSkillProvider(vfs),
     createSessionProvider(() => readSessionsIndex(vfs)),
     createScoopProvider(() => client.getScoops()),
   ]);
 
-  let photo: () => Promise<File | null>;
   let screenshot: () => Promise<File | null>;
 
   if (isExtension && isExtensionFloat()) {
     /**
-     * In the extension side-panel page, getUserMedia / getDisplayMedia can't
-     * prompt (no visible surface). Route both captures through the popup
-     * helper which opens a real Chrome window for the permission / picker UI.
+     * In the extension side-panel page, getDisplayMedia can't prompt (no
+     * visible surface). Route the screenshot capture through the popup helper
+     * which opens a real Chrome window for the permission / picker UI.
      * captureViaPopup returns PopupCaptureResult { bytes, mimeType, width, height };
      * convert to File so the add-menu contract (File | null) is satisfied.
      * On cancel / timeout the popup rejects — map to null.
      */
-    photo = async (): Promise<File | null> => {
-      try {
-        const result = await captureViaPopup({
-          kind: 'camera',
-          mode: 'photo',
-          mimeType: 'image/png',
-          quality: 1.0,
-        });
-        const ab =
-          result.bytes.buffer instanceof ArrayBuffer
-            ? result.bytes.buffer
-            : new Uint8Array(result.bytes).buffer;
-        return new File([ab], `photo-${Date.now()}.png`, { type: 'image/png' });
-      } catch {
-        return null;
-      }
-    };
-
     screenshot = async (): Promise<File | null> => {
       try {
         const result = await captureViaPopup({
@@ -134,11 +118,10 @@ function wireAddMenu(
       }
     };
   } else {
-    photo = capturePhoto;
     screenshot = captureScreenshot;
   }
 
-  layout.panels.chat.setAddMenu({ aggregator, capturePhoto: photo, captureScreenshot: screenshot });
+  layout.panels.chat.setAddMenu({ aggregator, captureScreenshot: screenshot });
 }
 
 /**
@@ -224,7 +207,11 @@ async function mainExtension(app: HTMLElement, options?: { detached?: boolean })
     getSelectedScoop: () => selectedScoop,
     log,
   }).syncThinkingButtonForScoop;
-  wireAddMenu(layout, localFs, client, true);
+  // Read through the file-browser's reader: under `slicc_opfs_vfs=opfs`
+  // (the browser default) `localFs` is an empty in-memory shadow and the
+  // canonical tree lives in the worker, reachable via the remote VFS client
+  // resolved into `previewVfsReaderBox.current` above.
+  wireAddMenu(layout, previewVfsReaderBox.current, client, true);
 
   // Persistent dedup ledger of welcome-flow licks — shared between the
   // orchestrator's final-lick and the welcome lick interceptor.
@@ -382,8 +369,11 @@ async function mainStandaloneWorker(app: HTMLElement, runtimeMode: UiRuntimeMode
     syncThinkingButtonForScoop,
     log,
   });
-  const { localFs, writableFs } = vfsHandle;
-  wireAddMenu(layout, localFs, client, false);
+  const { writableFs } = vfsHandle;
+  // `panelReadVfs` is what the file browser reads from — `localFs` when the
+  // OPFS flag is off, the worker-backed remote VFS client when it's on (the
+  // browser default). `localFs` alone would be an empty shadow under OPFS.
+  wireAddMenu(layout, vfsHandle.panelReadVfs, client, false);
 
   // Post-panels runtime composite: host-ready join → onboarding →
   // dip-lick callback → sprinkle manager → leader-runtime + panel-RPC +

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -302,6 +302,7 @@ function stripEphemeral(messages: ChatMessage[]): ChatMessage[] {
         ...(tc.isError ? { isError: tc.isError } : {}),
       }));
     }
+    if (m.references?.length) out.references = m.references;
     if (m.source) out.source = m.source;
     if (m.channel) out.channel = m.channel;
     return out;

--- a/packages/webapp/src/ui/styles/add-menu.css
+++ b/packages/webapp/src/ui/styles/add-menu.css
@@ -40,9 +40,33 @@
   cursor: pointer;
   user-select: none;
 }
+.add-menu__action {
+  align-items: center;
+}
+
+.add-menu__action:last-child {
+  margin-bottom: 12px;
+}
+
 .add-menu__action:hover,
 .add-menu__item:hover {
-  background: var(--surface-hover, rgba(0, 0, 0, 0.05));
+  background: var(--s2-bg-elevated);
+}
+.add-menu__action svg {
+  flex-shrink: 0;
+  color: var(--accent, #3c64dc);
+}
+.add-menu__action-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.add-menu__action-label {
+  font-weight: 600;
+}
+.add-menu__action-sub {
+  font-size: 12px;
+  color: var(--text-muted, #888);
 }
 .add-menu__item--active {
   background: var(--accent-soft, rgba(60, 100, 220, 0.12));

--- a/packages/webapp/src/ui/styles/add-menu.css
+++ b/packages/webapp/src/ui/styles/add-menu.css
@@ -68,6 +68,7 @@
   font-size: 12px;
   color: var(--text-muted, #888);
 }
+.add-menu__action--active,
 .add-menu__item--active {
   background: var(--accent-soft, rgba(60, 100, 220, 0.12));
 }

--- a/packages/webapp/src/ui/styles/add-menu.css
+++ b/packages/webapp/src/ui/styles/add-menu.css
@@ -1,18 +1,18 @@
 .add-menu {
   display: flex;
   flex-direction: column-reverse;
-  gap: 6px;
-  padding: 8px;
+  gap: 8px;
+  padding: 10px;
   border: 1px solid var(--s2-border-subtle, rgba(0, 0, 0, 0.12));
   border-radius: 10px;
   background: var(--surface-elevated, #fff);
   margin-bottom: 8px;
-  max-height: 320px;
+  max-height: 360px;
   overflow: hidden;
 }
 .add-menu__list {
   overflow-y: auto;
-  max-height: 260px;
+  max-height: 280px;
   display: flex;
   flex-direction: column;
 }
@@ -20,17 +20,22 @@
   width: 100%;
   border: 1px solid var(--s2-border-subtle, rgba(0, 0, 0, 0.12));
   border-radius: 8px;
-  padding: 8px 10px;
+  padding: 10px 12px;
   background: transparent;
   color: inherit;
   font: inherit;
+  margin-top: 2px;
+}
+.add-menu__search:focus {
+  outline: 2px solid var(--accent, #3c64dc);
+  outline-offset: -1px;
 }
 .add-menu__action,
 .add-menu__item {
   display: flex;
   align-items: baseline;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: 10px;
+  padding: 10px 12px;
   border-radius: 6px;
   cursor: pointer;
   user-select: none;
@@ -44,6 +49,10 @@
 }
 .add-menu__item-label {
   font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .add-menu__item-kind {
   font-size: 10px;
@@ -51,14 +60,19 @@
   letter-spacing: 0.04em;
   color: var(--text-muted, #888);
   margin-left: auto;
+  flex-shrink: 0;
 }
 .add-menu__item-sub,
 .add-menu__empty {
   font-size: 12px;
   color: var(--text-muted, #888);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .add-menu__empty {
-  padding: 12px 10px;
+  padding: 14px 12px;
   text-align: center;
 }
 @media (prefers-color-scheme: dark) {

--- a/packages/webapp/src/ui/styles/add-menu.css
+++ b/packages/webapp/src/ui/styles/add-menu.css
@@ -1,0 +1,69 @@
+.add-menu {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid var(--s2-border-subtle, rgba(0, 0, 0, 0.12));
+  border-radius: 10px;
+  background: var(--surface-elevated, #fff);
+  margin-bottom: 8px;
+  max-height: 320px;
+  overflow: hidden;
+}
+.add-menu__list {
+  overflow-y: auto;
+  max-height: 260px;
+  display: flex;
+  flex-direction: column;
+}
+.add-menu__search {
+  width: 100%;
+  border: 1px solid var(--s2-border-subtle, rgba(0, 0, 0, 0.12));
+  border-radius: 8px;
+  padding: 8px 10px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+.add-menu__action,
+.add-menu__item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  user-select: none;
+}
+.add-menu__action:hover,
+.add-menu__item:hover {
+  background: var(--surface-hover, rgba(0, 0, 0, 0.05));
+}
+.add-menu__item--active {
+  background: var(--accent-soft, rgba(60, 100, 220, 0.12));
+}
+.add-menu__item-label {
+  font-weight: 600;
+}
+.add-menu__item-kind {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #888);
+  margin-left: auto;
+}
+.add-menu__item-sub,
+.add-menu__empty {
+  font-size: 12px;
+  color: var(--text-muted, #888);
+}
+.add-menu__empty {
+  padding: 12px 10px;
+  text-align: center;
+}
+@media (prefers-color-scheme: dark) {
+  .add-menu {
+    background: var(--surface-elevated, #1e1e1e);
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+}

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -931,8 +931,44 @@
 .chat__attach-btn--busy {
   color: var(--s2-accent);
 }
+.chat__attach-btn--open {
+  color: var(--s2-accent);
+  background: var(--s2-bg-elevated);
+}
 .chat__file-input {
   display: none;
+}
+
+/* Reference chips — pending row and read-only message bubbles */
+.chat__msg-refs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+.chat__ref-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--s2-bg-elevated);
+  color: var(--s2-content-secondary);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+.chat__ref-chip button {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--s2-content-secondary);
+  font-size: 0.9rem;
+  line-height: 1;
+}
+.chat__ref-chip button:hover {
+  color: var(--s2-content-default);
 }
 .chat__mic-btn--active {
   color: var(--slicc-cone);

--- a/packages/webapp/src/ui/styles/chat.css
+++ b/packages/webapp/src/ui/styles/chat.css
@@ -470,6 +470,7 @@
     box-shadow var(--s2-transition-default);
   padding: 16px;
   min-height: 112px;
+  gap: 12px;
 }
 .chat__input-wrapper:focus-within {
   border-color: var(--s2-accent);
@@ -939,36 +940,38 @@
   display: none;
 }
 
-/* Reference chips — pending row and read-only message bubbles */
-.chat__msg-refs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-bottom: 6px;
-}
+/* Reference chips — pending composer row (not shown in sent message bubbles) */
 .chat__ref-chip {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 2px 8px;
+  padding: 3px 10px;
   border-radius: 999px;
-  background: var(--s2-bg-elevated);
-  color: var(--s2-content-secondary);
+  border: 1px solid color-mix(in srgb, var(--slicc-scoop-purple) 45%, transparent);
+  background: color-mix(in srgb, var(--slicc-scoop-purple) 14%, transparent);
+  color: var(--slicc-scoop-purple);
   font-size: 0.8rem;
+  font-weight: 600;
   line-height: 1.4;
   white-space: nowrap;
+}
+.chat__ref-chip-kind {
+  font-weight: 500;
+  opacity: 0.7;
+  text-transform: lowercase;
 }
 .chat__ref-chip button {
   border: none;
   background: none;
   padding: 0;
   cursor: pointer;
-  color: var(--s2-content-secondary);
+  color: var(--slicc-scoop-purple);
   font-size: 0.9rem;
   line-height: 1;
+  opacity: 0.8;
 }
 .chat__ref-chip button:hover {
-  color: var(--s2-content-default);
+  opacity: 1;
 }
 .chat__mic-btn--active {
   color: var(--slicc-cone);

--- a/packages/webapp/src/ui/tool-call-view.ts
+++ b/packages/webapp/src/ui/tool-call-view.ts
@@ -30,11 +30,10 @@ import {
   Wrench,
 } from 'lucide';
 import { ansiToHtml } from './ansi.js';
+import { createLucideIcon, type IconNode } from './create-lucide-icon.js';
 import { escapeHtml } from './message-renderer.js';
 import { maskSecrets } from './preview-masking.js';
 import type { ToolCall } from './types.js';
-
-type IconNode = [tag: string, attrs: Record<string, string | number>][];
 
 /** Per-tool metadata driving the compact row + expanded body. */
 interface ToolDescriptor {
@@ -192,12 +191,12 @@ export function toolStatus(tc: ToolCall): ToolStatus {
 /** Build the icon element for the collapsed row. */
 export function createToolIcon(name: string): SVGElement {
   const desc = getToolDescriptor(name);
-  return iconNodeToSvg(desc.icon);
+  return createLucideIcon(desc.icon, 14);
 }
 
 /** Cluster icon used in the collapsed "working" header. */
 export function createClusterIcon(): SVGElement {
-  return iconNodeToSvg(Cog as unknown as IconNode);
+  return createLucideIcon(Cog as unknown as IconNode, 14);
 }
 
 /** Threshold above which consecutive tool calls collapse into a cluster.
@@ -292,27 +291,6 @@ function formatScoopNames(input: unknown): string {
   if (!Array.isArray(names)) return '';
   const joined = names.filter((n) => typeof n === 'string').join(', ');
   return truncate(joined, 100);
-}
-
-function iconNodeToSvg(node: IconNode): SVGElement {
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-  svg.setAttribute('width', '14');
-  svg.setAttribute('height', '14');
-  svg.setAttribute('viewBox', '0 0 24 24');
-  svg.setAttribute('fill', 'none');
-  svg.setAttribute('stroke', 'currentColor');
-  svg.setAttribute('stroke-width', '2');
-  svg.setAttribute('stroke-linecap', 'round');
-  svg.setAttribute('stroke-linejoin', 'round');
-  for (const [tag, attrs] of node) {
-    const child = document.createElementNS('http://www.w3.org/2000/svg', tag);
-    for (const [k, v] of Object.entries(attrs)) {
-      child.setAttribute(k, String(v));
-    }
-    svg.appendChild(child);
-  }
-  return svg;
 }
 
 // ── body renderers ──────────────────────────────────────────────────

--- a/packages/webapp/src/ui/types.ts
+++ b/packages/webapp/src/ui/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { MessageAttachment } from '../core/attachments.js';
+import type { AddItem } from './add-menu/add-item.js';
 
 // ---------------------------------------------------------------------------
 // Agent interface — the UI's view of the agent core
@@ -49,6 +50,9 @@ export interface ChatMessage {
   content: string;
   timestamp: number;
   attachments?: MessageAttachment[];
+  /** Reference chips compiled into the hidden [context] preamble on send.
+   *  Persisted so the bubble re-renders chips on reload without the raw preamble. */
+  references?: AddItem[];
   toolCalls?: ToolCall[];
   isStreaming?: boolean;
   /** Source of the message: 'cone' for main agent, scoop name for sub-agents, 'lick' for async events */

--- a/packages/webapp/tests/ui/add-menu/add-menu.test.ts
+++ b/packages/webapp/tests/ui/add-menu/add-menu.test.ts
@@ -12,6 +12,7 @@ function setup(items: AddItem[] = []) {
   const onAddReference = vi.fn();
   const onClose = vi.fn();
   const captureScreenshot = vi.fn(async () => null);
+  const requestUpload = vi.fn();
   const aggregator = { search: vi.fn(async () => items) };
   const menu = new AddMenu({
     composer,
@@ -20,6 +21,7 @@ function setup(items: AddItem[] = []) {
     onAttachFiles,
     onAddReference,
     captureScreenshot,
+    requestUpload,
     onClose,
   });
   return {
@@ -30,6 +32,7 @@ function setup(items: AddItem[] = []) {
     onAddReference,
     onClose,
     captureScreenshot,
+    requestUpload,
     aggregator,
   };
 }
@@ -130,6 +133,87 @@ describe('AddMenu shell', () => {
   });
 });
 
+describe('AddMenu action keyboard navigation', () => {
+  beforeEach(() => {
+    (HTMLElement.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = () => {};
+  });
+
+  it('ArrowDown selects the first action', () => {
+    const { menu } = setup();
+    menu.open();
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    const actions = Array.from(document.querySelectorAll('.add-menu__action'));
+    expect(actions[0].classList.contains('add-menu__action--active')).toBe(true);
+    expect(actions[1].classList.contains('add-menu__action--active')).toBe(false);
+  });
+
+  it('ArrowDown twice selects the second action', () => {
+    const { menu } = setup();
+    menu.open();
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    const actions = Array.from(document.querySelectorAll('.add-menu__action'));
+    expect(actions[0].classList.contains('add-menu__action--active')).toBe(false);
+    expect(actions[1].classList.contains('add-menu__action--active')).toBe(true);
+  });
+
+  it('ArrowUp from nothing selects the last action', () => {
+    const { menu } = setup();
+    menu.open();
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    const actions = Array.from(document.querySelectorAll('.add-menu__action'));
+    expect(actions[actions.length - 1].classList.contains('add-menu__action--active')).toBe(true);
+  });
+
+  it('ArrowDown wraps from last action back to first', () => {
+    const { menu } = setup();
+    menu.open();
+    // Two actions: Down → [0], Down → [1], Down → wraps to [0]
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    const actions = Array.from(document.querySelectorAll('.add-menu__action'));
+    expect(actions[0].classList.contains('add-menu__action--active')).toBe(true);
+  });
+
+  it('Enter triggers the highlighted action and closes the menu', () => {
+    const { menu, captureScreenshot } = setup();
+    menu.open();
+    // ArrowDown → [0] Upload, ArrowDown → [1] Screenshot
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(captureScreenshot).toHaveBeenCalled();
+  });
+
+  it('Enter on the Upload action invokes requestUpload', () => {
+    const { menu, requestUpload } = setup();
+    menu.open();
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(requestUpload).toHaveBeenCalled();
+  });
+
+  it('Enter with no action highlighted does not consume the event', () => {
+    const { menu } = setup();
+    menu.open();
+    // No ArrowDown pressed — nothing highlighted
+    const consumed = menu.handleKey(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(consumed).toBe(false);
+  });
+
+  it('action highlight is cleared when the menu closes', () => {
+    const { menu } = setup();
+    menu.open();
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    menu.close();
+    menu.open();
+    // Highlight should be reset: no active class on any action
+    const active = document.querySelectorAll('.add-menu__action--active');
+    expect(active.length).toBe(0);
+  });
+});
+
 describe('AddMenu results', () => {
   beforeEach(() => {
     (HTMLElement.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = () => {};
@@ -187,5 +271,18 @@ describe('AddMenu results', () => {
     input.dispatchEvent(new Event('input'));
     await new Promise((r) => setTimeout(r, 150));
     expect(document.querySelector('.add-menu__empty')?.textContent).toContain('No matches');
+  });
+
+  it('ArrowDown/Up do not consume the keypress in the empty-results state', async () => {
+    const { menu } = setup([]);
+    menu.open();
+    const input = document.querySelector<HTMLInputElement>('.add-menu__search')!;
+    input.value = 'zzz';
+    input.dispatchEvent(new Event('input'));
+    await new Promise((r) => setTimeout(r, 150));
+    // Both arrays empty — navigateResults should return false so callers know
+    // not to preventDefault on Arrow keys.
+    expect(menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }))).toBe(false);
+    expect(menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowUp' }))).toBe(false);
   });
 });

--- a/packages/webapp/tests/ui/add-menu/add-menu.test.ts
+++ b/packages/webapp/tests/ui/add-menu/add-menu.test.ts
@@ -81,4 +81,17 @@ describe('AddMenu shell', () => {
     photo?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     expect(capturePhoto).toHaveBeenCalled();
   });
+
+  it('dispose() removes composer drag-drop listeners', () => {
+    const { menu, composer, onAttachFiles } = setup();
+    menu.open();
+    menu.dispose();
+    const evt = new Event('drop', { bubbles: true, cancelable: true }) as unknown as DragEvent;
+    Object.defineProperty(evt, 'dataTransfer', {
+      value: { files: [new File(['x'], 'x.txt')] },
+      configurable: true,
+    });
+    composer.dispatchEvent(evt);
+    expect(onAttachFiles).not.toHaveBeenCalled();
+  });
 });

--- a/packages/webapp/tests/ui/add-menu/add-menu.test.ts
+++ b/packages/webapp/tests/ui/add-menu/add-menu.test.ts
@@ -11,7 +11,6 @@ function setup(items: AddItem[] = []) {
   const onAttachFiles = vi.fn();
   const onAddReference = vi.fn();
   const onClose = vi.fn();
-  const capturePhoto = vi.fn(async () => null);
   const captureScreenshot = vi.fn(async () => null);
   const aggregator = { search: vi.fn(async () => items) };
   const menu = new AddMenu({
@@ -20,7 +19,6 @@ function setup(items: AddItem[] = []) {
     aggregator,
     onAttachFiles,
     onAddReference,
-    capturePhoto,
     captureScreenshot,
     onClose,
   });
@@ -31,7 +29,6 @@ function setup(items: AddItem[] = []) {
     onAttachFiles,
     onAddReference,
     onClose,
-    capturePhoto,
     captureScreenshot,
     aggregator,
   };
@@ -54,7 +51,7 @@ describe('AddMenu shell', () => {
     expect(menu.isOpen()).toBe(true);
     expect(composer.classList.contains('composer--add-open')).toBe(true);
     const actions = document.querySelectorAll('.add-menu__action');
-    expect(actions.length).toBe(3);
+    expect(actions.length).toBe(2);
     expect(document.querySelector('.add-menu__search')).not.toBeNull();
   });
 
@@ -74,15 +71,15 @@ describe('AddMenu shell', () => {
     expect(menu.isOpen()).toBe(false);
   });
 
-  it('clicking the photo action invokes capturePhoto', async () => {
-    const { menu, capturePhoto } = setup();
+  it('clicking the screenshot action invokes captureScreenshot', async () => {
+    const { menu, captureScreenshot } = setup();
     menu.open();
     await Promise.resolve();
-    const photo = Array.from(document.querySelectorAll<HTMLElement>('.add-menu__action')).find(
-      (el) => /photo/i.test(el.textContent ?? '')
+    const screenshot = Array.from(document.querySelectorAll<HTMLElement>('.add-menu__action')).find(
+      (el) => /screenshot/i.test(el.textContent ?? '')
     );
-    photo?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
-    expect(capturePhoto).toHaveBeenCalled();
+    screenshot?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(captureScreenshot).toHaveBeenCalled();
   });
 
   it('fires onClose when closed via close() and Escape', () => {
@@ -167,6 +164,19 @@ describe('AddMenu results', () => {
     menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
     menu.handleKey(new KeyboardEvent('keydown', { key: 'Enter' }));
     expect(onAddReference).toHaveBeenCalledWith(items[1]);
+  });
+
+  it('routes ArrowDown + Enter from the focused search input to result selection', async () => {
+    const { menu, onAddReference } = setup(items);
+    menu.open();
+    const input = document.querySelector<HTMLInputElement>('.add-menu__search')!;
+    input.value = 's';
+    input.dispatchEvent(new Event('input'));
+    await new Promise((r) => setTimeout(r, 150));
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(onAddReference).toHaveBeenCalledWith(items[1]);
+    expect(menu.isOpen()).toBe(false);
   });
 
   it('shows a no-matches note for an empty result set', async () => {

--- a/packages/webapp/tests/ui/add-menu/add-menu.test.ts
+++ b/packages/webapp/tests/ui/add-menu/add-menu.test.ts
@@ -95,3 +95,50 @@ describe('AddMenu shell', () => {
     expect(onAttachFiles).not.toHaveBeenCalled();
   });
 });
+
+describe('AddMenu results', () => {
+  beforeEach(() => {
+    (HTMLElement.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = () => {};
+  });
+
+  const items: AddItem[] = [
+    { kind: 'file', label: 'README.md', locator: '/workspace/README.md' },
+    { kind: 'skill', label: 'sprinkles', locator: 'sprinkles' },
+  ];
+
+  it('typing shows results from the aggregator; picking calls onAddReference and closes', async () => {
+    const { menu, onAddReference } = setup(items);
+    menu.open();
+    const input = document.querySelector<HTMLInputElement>('.add-menu__search')!;
+    input.value = 'r';
+    input.dispatchEvent(new Event('input'));
+    await new Promise((r) => setTimeout(r, 150));
+    const rows = document.querySelectorAll('.add-menu__item');
+    expect(rows.length).toBe(2);
+    (rows[0] as HTMLElement).dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(onAddReference).toHaveBeenCalledWith(items[0]);
+    expect(menu.isOpen()).toBe(false);
+  });
+
+  it('ArrowDown + Enter picks the highlighted result', async () => {
+    const { menu, onAddReference } = setup(items);
+    menu.open();
+    const input = document.querySelector<HTMLInputElement>('.add-menu__search')!;
+    input.value = 's';
+    input.dispatchEvent(new Event('input'));
+    await new Promise((r) => setTimeout(r, 150));
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(onAddReference).toHaveBeenCalledWith(items[1]);
+  });
+
+  it('shows a no-matches note for an empty result set', async () => {
+    const { menu } = setup([]);
+    menu.open();
+    const input = document.querySelector<HTMLInputElement>('.add-menu__search')!;
+    input.value = 'zzz';
+    input.dispatchEvent(new Event('input'));
+    await new Promise((r) => setTimeout(r, 150));
+    expect(document.querySelector('.add-menu__empty')?.textContent).toContain('No matches');
+  });
+});

--- a/packages/webapp/tests/ui/add-menu/add-menu.test.ts
+++ b/packages/webapp/tests/ui/add-menu/add-menu.test.ts
@@ -95,6 +95,30 @@ describe('AddMenu shell', () => {
     expect(onClose).toHaveBeenCalledTimes(2);
   });
 
+  it('mousedown outside the panel closes the menu and fires onClose', () => {
+    const { menu, onClose } = setup();
+    menu.open();
+    expect(menu.isOpen()).toBe(true);
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(menu.isOpen()).toBe(false);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('mousedown inside the panel does NOT close the menu', () => {
+    const { menu } = setup();
+    menu.open();
+    const panel = document.querySelector('.add-menu') as HTMLElement;
+    panel.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(menu.isOpen()).toBe(true);
+  });
+
+  it('mousedown on the toggle button does NOT close the menu', () => {
+    const { menu, toggle } = setup();
+    menu.open();
+    toggle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(menu.isOpen()).toBe(true);
+  });
+
   it('dispose() removes composer drag-drop listeners', () => {
     const { menu, composer, onAttachFiles } = setup();
     menu.open();

--- a/packages/webapp/tests/ui/add-menu/add-menu.test.ts
+++ b/packages/webapp/tests/ui/add-menu/add-menu.test.ts
@@ -10,6 +10,7 @@ function setup(items: AddItem[] = []) {
   document.body.append(composer, toggle);
   const onAttachFiles = vi.fn();
   const onAddReference = vi.fn();
+  const onClose = vi.fn();
   const capturePhoto = vi.fn(async () => null);
   const captureScreenshot = vi.fn(async () => null);
   const aggregator = { search: vi.fn(async () => items) };
@@ -21,6 +22,7 @@ function setup(items: AddItem[] = []) {
     onAddReference,
     capturePhoto,
     captureScreenshot,
+    onClose,
   });
   return {
     menu,
@@ -28,6 +30,7 @@ function setup(items: AddItem[] = []) {
     toggle,
     onAttachFiles,
     onAddReference,
+    onClose,
     capturePhoto,
     captureScreenshot,
     aggregator,
@@ -80,6 +83,16 @@ describe('AddMenu shell', () => {
     );
     photo?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     expect(capturePhoto).toHaveBeenCalled();
+  });
+
+  it('fires onClose when closed via close() and Escape', () => {
+    const { menu, onClose } = setup();
+    menu.open();
+    menu.close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    menu.open();
+    menu.handleKey(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(onClose).toHaveBeenCalledTimes(2);
   });
 
   it('dispose() removes composer drag-drop listeners', () => {

--- a/packages/webapp/tests/ui/add-menu/add-menu.test.ts
+++ b/packages/webapp/tests/ui/add-menu/add-menu.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AddItem } from '../../../src/ui/add-menu/add-item.js';
+import { AddMenu } from '../../../src/ui/add-menu/add-menu.js';
+
+function setup(items: AddItem[] = []) {
+  document.body.innerHTML = '';
+  const composer = document.createElement('div');
+  const toggle = document.createElement('button');
+  document.body.append(composer, toggle);
+  const onAttachFiles = vi.fn();
+  const onAddReference = vi.fn();
+  const capturePhoto = vi.fn(async () => null);
+  const captureScreenshot = vi.fn(async () => null);
+  const aggregator = { search: vi.fn(async () => items) };
+  const menu = new AddMenu({
+    composer,
+    toggleButton: toggle,
+    aggregator,
+    onAttachFiles,
+    onAddReference,
+    capturePhoto,
+    captureScreenshot,
+  });
+  return {
+    menu,
+    composer,
+    toggle,
+    onAttachFiles,
+    onAddReference,
+    capturePhoto,
+    captureScreenshot,
+    aggregator,
+  };
+}
+
+describe('AddMenu shell', () => {
+  beforeEach(() => {
+    (HTMLElement.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = () => {};
+  });
+
+  it('is closed by default', () => {
+    const { menu } = setup();
+    expect(menu.isOpen()).toBe(false);
+  });
+
+  it('open() shows the panel, grows the composer, and renders action items', async () => {
+    const { menu, composer } = setup();
+    menu.open();
+    await Promise.resolve();
+    expect(menu.isOpen()).toBe(true);
+    expect(composer.classList.contains('composer--add-open')).toBe(true);
+    const actions = document.querySelectorAll('.add-menu__action');
+    expect(actions.length).toBe(3);
+    expect(document.querySelector('.add-menu__search')).not.toBeNull();
+  });
+
+  it('close() hides the panel and ungrows', () => {
+    const { menu, composer } = setup();
+    menu.open();
+    menu.close();
+    expect(menu.isOpen()).toBe(false);
+    expect(composer.classList.contains('composer--add-open')).toBe(false);
+  });
+
+  it('Escape closes', () => {
+    const { menu } = setup();
+    menu.open();
+    const consumed = menu.handleKey(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(consumed).toBe(true);
+    expect(menu.isOpen()).toBe(false);
+  });
+
+  it('clicking the photo action invokes capturePhoto', async () => {
+    const { menu, capturePhoto } = setup();
+    menu.open();
+    await Promise.resolve();
+    const photo = Array.from(document.querySelectorAll<HTMLElement>('.add-menu__action')).find(
+      (el) => /photo/i.test(el.textContent ?? '')
+    );
+    photo?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(capturePhoto).toHaveBeenCalled();
+  });
+});

--- a/packages/webapp/tests/ui/add-menu/capture.test.ts
+++ b/packages/webapp/tests/ui/add-menu/capture.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { grabFrameToFile } from '../../../src/ui/add-menu/capture.js';
+
+function fakeStream() {
+  const track = { stop: vi.fn() };
+  return { getTracks: () => [track], _track: track } as never;
+}
+
+describe('grabFrameToFile', () => {
+  beforeEach(() => {
+    (HTMLCanvasElement.prototype as unknown as { toBlob: unknown }).toBlob = function (
+      cb: (b: Blob | null) => void
+    ) {
+      cb(new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' }));
+    };
+  });
+
+  it('draws the video frame, returns a File, and stops all tracks', async () => {
+    const stream = fakeStream();
+    const video = document.createElement('video');
+    Object.defineProperty(video, 'videoWidth', { value: 4, configurable: true });
+    Object.defineProperty(video, 'videoHeight', { value: 4, configurable: true });
+    const file = await grabFrameToFile(stream, video, 'screenshot');
+    expect(file).toBeInstanceOf(File);
+    expect(file?.type).toBe('image/png');
+    expect(file?.name).toMatch(/^screenshot-/);
+    expect(
+      (stream as unknown as { _track: { stop: ReturnType<typeof vi.fn> } })._track.stop
+    ).toHaveBeenCalled();
+  });
+});

--- a/packages/webapp/tests/ui/add-menu/capture.test.ts
+++ b/packages/webapp/tests/ui/add-menu/capture.test.ts
@@ -14,6 +14,11 @@ describe('grabFrameToFile', () => {
     ) {
       cb(new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' }));
     };
+    // jsdom does not implement getContext; provide a minimal stub so the
+    // null-context guard does not short-circuit the draw → toBlob path.
+    (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext = () => ({
+      drawImage: () => {},
+    });
   });
 
   it('draws the video frame, returns a File, and stops all tracks', async () => {
@@ -28,5 +33,21 @@ describe('grabFrameToFile', () => {
     expect(
       (stream as unknown as { _track: { stop: ReturnType<typeof vi.fn> } })._track.stop
     ).toHaveBeenCalled();
+  });
+
+  it('returns null and stops tracks when the canvas 2d context is unavailable', async () => {
+    const stream = fakeStream();
+    const video = document.createElement('video');
+    const origGetContext = HTMLCanvasElement.prototype.getContext;
+    (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext = () => null;
+    try {
+      const result = await grabFrameToFile(stream, video, 'screenshot');
+      expect(result).toBeNull();
+      expect(
+        (stream as unknown as { _track: { stop: ReturnType<typeof vi.fn> } })._track.stop
+      ).toHaveBeenCalled();
+    } finally {
+      HTMLCanvasElement.prototype.getContext = origGetContext;
+    }
   });
 });

--- a/packages/webapp/tests/ui/add-menu/chat-panel-add-integration.test.ts
+++ b/packages/webapp/tests/ui/add-menu/chat-panel-add-integration.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import type { AddItem } from '../../../src/ui/add-menu/add-item.js';
+import { ChatPanel } from '../../../src/ui/chat-panel.js';
+import type { AgentEvent, AgentHandle } from '../../../src/ui/types.js';
+
+vi.mock('../../../src/ui/voice-input.js', () => ({
+  VoiceInput: class {
+    destroy() {}
+    start() {}
+    stop() {}
+    setAutoSend() {}
+    setLang() {}
+    isListening() {
+      return false;
+    }
+  },
+  getVoiceAutoSend: () => false,
+  getVoiceLang: () => 'en-US',
+}));
+
+vi.mock('../../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => '',
+  showProviderSettings: () => {},
+  applyProviderDefaults: () => {},
+  getAllAvailableModels: () => [],
+  getSelectedModelId: () => '',
+  getSelectedProvider: () => null,
+  setSelectedModelId: () => {},
+  getProviderConfig: () => null,
+}));
+
+function makeAgent() {
+  const sent: { text: string; id: string }[] = [];
+  let cb: ((e: AgentEvent) => void) | null = null;
+  const handle: AgentHandle = {
+    sendMessage: (text: string, id: string) => sent.push({ text, id }),
+    onEvent: (handler: (e: AgentEvent) => void) => {
+      cb = handler;
+      return () => {
+        cb = null;
+      };
+    },
+    stop: () => {},
+  };
+  return { sent, cb, handle };
+}
+
+describe('ChatPanel add-menu integration', () => {
+  let container: HTMLElement;
+  let testCounter = 0;
+
+  beforeEach(() => {
+    testCounter += 1;
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    (HTMLElement.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = () => {};
+    const store: Record<string, string> = { 'selected-model': 'claude-sonnet' };
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+    });
+  });
+
+  it('compiles references into the preamble on send, keeps content plain, stores references, renders a chip', async () => {
+    const panel = new ChatPanel(container);
+    await panel.initSession(`test-add-integration-${testCounter}`);
+    const { sent, handle } = makeAgent();
+    panel.setAgent(handle);
+
+    const ref: AddItem = { kind: 'file', label: 'CLAUDE.md', locator: '/workspace/CLAUDE.md' };
+    panel.addReferenceForTest(ref);
+
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'explain this';
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await Promise.resolve();
+
+    expect(sent[0].text).toBe(
+      '[context]\n- file: /workspace/CLAUDE.md (CLAUDE.md)\n\nexplain this'
+    );
+    const stored = panel.getMessagesForTest().find((m) => m.role === 'user');
+    expect(stored?.content).toBe('explain this');
+    expect(stored?.references?.[0].locator).toBe('/workspace/CLAUDE.md');
+    expect(container.textContent).not.toContain('[context]');
+    expect(container.querySelector('.chat__ref-chip')?.textContent).toContain('CLAUDE.md');
+  });
+
+  it('dedupes references by kind+locator', () => {
+    const panel = new ChatPanel(container);
+    const ref: AddItem = { kind: 'file', label: 'CLAUDE.md', locator: '/workspace/CLAUDE.md' };
+    panel.addReferenceForTest(ref);
+    panel.addReferenceForTest(ref);
+    expect(panel.getMessagesForTest().length).toBe(0);
+    const chips = container.querySelectorAll('.chat__ref-chip');
+    expect(chips.length).toBe(1);
+  });
+
+  it('sends plain text when there are no references', async () => {
+    const panel = new ChatPanel(container);
+    await panel.initSession(`test-add-plain-${testCounter}`);
+    const { sent, handle } = makeAgent();
+    panel.setAgent(handle);
+
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'hello';
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await Promise.resolve();
+
+    expect(sent[0].text).toBe('hello');
+  });
+});

--- a/packages/webapp/tests/ui/add-menu/chat-panel-add-integration.test.ts
+++ b/packages/webapp/tests/ui/add-menu/chat-panel-add-integration.test.ts
@@ -69,7 +69,7 @@ describe('ChatPanel add-menu integration', () => {
     });
   });
 
-  it('compiles references into the preamble on send, keeps content plain, stores references, renders a chip', async () => {
+  it('compiles references into the preamble on send, keeps content plain, stores references, hides chips from the bubble', async () => {
     const panel = new ChatPanel(container);
     await panel.initSession(`test-add-integration-${testCounter}`);
     const { sent, handle } = makeAgent();
@@ -91,10 +91,9 @@ describe('ChatPanel add-menu integration', () => {
     expect(stored?.references?.[0].locator).toBe('/workspace/CLAUDE.md');
     expect(container.textContent).not.toContain('[context]');
 
-    // Bubble chip is still present in the message; composer pending chips are cleared.
-    const bubbleChips = container.querySelectorAll('.chat__msg-refs .chat__ref-chip');
-    expect(bubbleChips.length).toBe(1);
-    expect(bubbleChips[0].textContent).toContain('CLAUDE.md');
+    // References drive the hidden preamble but are not rendered in the bubble.
+    const bubbleChips = container.querySelectorAll('.chat__msg-refs');
+    expect(bubbleChips.length).toBe(0);
 
     const composerChips = container.querySelectorAll('.chat__attachments .chat__ref-chip');
     expect(composerChips.length).toBe(0);
@@ -108,6 +107,24 @@ describe('ChatPanel add-menu integration', () => {
     expect(panel.getMessagesForTest().length).toBe(0);
     const chips = container.querySelectorAll('.chat__ref-chip');
     expect(chips.length).toBe(1);
+  });
+
+  it('prefixes pending reference chips with their category, mapping session to conversation', () => {
+    const panel = new ChatPanel(container);
+    panel.addReferenceForTest({
+      kind: 'file',
+      label: 'CLAUDE.md',
+      locator: '/workspace/CLAUDE.md',
+    });
+    panel.addReferenceForTest({
+      kind: 'session',
+      label: 'Debugging the search bug',
+      locator: '/sessions/2026-06-09-debug.md',
+    });
+    const kinds = Array.from(
+      container.querySelectorAll('.chat__ref-chip .chat__ref-chip-kind')
+    ).map((el) => el.textContent);
+    expect(kinds).toEqual(['file:', 'conversation:']);
   });
 
   it('sends plain text when there are no references', async () => {

--- a/packages/webapp/tests/ui/add-menu/chat-panel-add-integration.test.ts
+++ b/packages/webapp/tests/ui/add-menu/chat-panel-add-integration.test.ts
@@ -140,4 +140,22 @@ describe('ChatPanel add-menu integration', () => {
 
     expect(sent[0].text).toBe('hello');
   });
+
+  it('closes the add-menu once the file picker returns from the Upload action', () => {
+    const panel = new ChatPanel(container);
+    panel.setAddMenu({
+      aggregator: { search: async () => [] },
+      captureScreenshot: async () => null,
+    });
+    panel.openAddMenuForFixture();
+    expect(document.querySelector('.add-menu')).not.toBeNull();
+    expect(getComputedStyle(document.querySelector('.add-menu') as HTMLElement).display).not.toBe(
+      'none'
+    );
+
+    const fileInput = container.querySelector<HTMLInputElement>('.chat__file-input')!;
+    fileInput.dispatchEvent(new Event('change'));
+
+    expect((document.querySelector('.add-menu') as HTMLElement).style.display).toBe('none');
+  });
 });

--- a/packages/webapp/tests/ui/add-menu/chat-panel-add-integration.test.ts
+++ b/packages/webapp/tests/ui/add-menu/chat-panel-add-integration.test.ts
@@ -90,7 +90,14 @@ describe('ChatPanel add-menu integration', () => {
     expect(stored?.content).toBe('explain this');
     expect(stored?.references?.[0].locator).toBe('/workspace/CLAUDE.md');
     expect(container.textContent).not.toContain('[context]');
-    expect(container.querySelector('.chat__ref-chip')?.textContent).toContain('CLAUDE.md');
+
+    // Bubble chip is still present in the message; composer pending chips are cleared.
+    const bubbleChips = container.querySelectorAll('.chat__msg-refs .chat__ref-chip');
+    expect(bubbleChips.length).toBe(1);
+    expect(bubbleChips[0].textContent).toContain('CLAUDE.md');
+
+    const composerChips = container.querySelectorAll('.chat__attachments .chat__ref-chip');
+    expect(composerChips.length).toBe(0);
   });
 
   it('dedupes references by kind+locator', () => {

--- a/packages/webapp/tests/ui/add-menu/preamble.test.ts
+++ b/packages/webapp/tests/ui/add-menu/preamble.test.ts
@@ -33,6 +33,16 @@ describe('compileContextPreamble', () => {
       '[context]\n- session: /sessions/2026-06-01-foo.md (Fix the build)'
     );
   });
+
+  it('collapses embedded newlines in locators and labels to prevent preamble corruption', () => {
+    const refs: AddItem[] = [
+      { kind: 'file', label: 'name\nwith\nnewline', locator: '/workspace/path\ninjected' },
+    ];
+    const result = compileContextPreamble(refs);
+    const lines = result.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toBe('- file: /workspace/path injected (name with newline)');
+  });
 });
 
 describe('stripContextPreamble', () => {

--- a/packages/webapp/tests/ui/add-menu/preamble.test.ts
+++ b/packages/webapp/tests/ui/add-menu/preamble.test.ts
@@ -54,7 +54,7 @@ describe('stripContextPreamble', () => {
     expect(stripContextPreamble('just a question')).toBe('just a question');
   });
   it('returns empty string when the text is only a preamble', () => {
-    expect(stripContextPreamble('[context]\n- skill: sprinkles')).toBe('');
+    expect(stripContextPreamble('[context]\n- skill: sprinkles\n\n')).toBe('');
   });
   it('only strips a [context] block at the very start', () => {
     const raw = 'hello [context]\n- skill: x\n\nworld';

--- a/packages/webapp/tests/ui/add-menu/preamble.test.ts
+++ b/packages/webapp/tests/ui/add-menu/preamble.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AddItem } from '../../../src/ui/add-menu/add-item.js';
-import { compileContextPreamble } from '../../../src/ui/add-menu/preamble.js';
+import { compileContextPreamble, stripContextPreamble } from '../../../src/ui/add-menu/preamble.js';
 
 describe('compileContextPreamble', () => {
   it('returns empty string for no references', () => {
@@ -32,5 +32,22 @@ describe('compileContextPreamble', () => {
     expect(compileContextPreamble(refs)).toBe(
       '[context]\n- session: /sessions/2026-06-01-foo.md (Fix the build)'
     );
+  });
+});
+
+describe('stripContextPreamble', () => {
+  it('removes a leading [context] block from agent-sourced user text', () => {
+    const raw = '[context]\n- file: /workspace/CLAUDE.md (CLAUDE.md)\n\nexplain this';
+    expect(stripContextPreamble(raw)).toBe('explain this');
+  });
+  it('leaves normal text untouched', () => {
+    expect(stripContextPreamble('just a question')).toBe('just a question');
+  });
+  it('returns empty string when the text is only a preamble', () => {
+    expect(stripContextPreamble('[context]\n- skill: sprinkles')).toBe('');
+  });
+  it('only strips a [context] block at the very start', () => {
+    const raw = 'hello [context]\n- skill: x\n\nworld';
+    expect(stripContextPreamble(raw)).toBe(raw);
   });
 });

--- a/packages/webapp/tests/ui/add-menu/preamble.test.ts
+++ b/packages/webapp/tests/ui/add-menu/preamble.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { AddItem } from '../../../src/ui/add-menu/add-item.js';
+import { compileContextPreamble } from '../../../src/ui/add-menu/preamble.js';
+
+describe('compileContextPreamble', () => {
+  it('returns empty string for no references', () => {
+    expect(compileContextPreamble([])).toBe('');
+  });
+
+  it('emits one line per reference under a [context] header', () => {
+    const refs: AddItem[] = [
+      { kind: 'file', label: 'CLAUDE.md', locator: '/workspace/CLAUDE.md' },
+      { kind: 'folder', label: 'src', locator: '/workspace/src' },
+      { kind: 'skill', label: 'sprinkles', locator: 'sprinkles' },
+      { kind: 'scoop', label: 'my-scoop', locator: 'jid-123' },
+    ];
+    expect(compileContextPreamble(refs)).toBe(
+      [
+        '[context]',
+        '- file: /workspace/CLAUDE.md (CLAUDE.md)',
+        '- folder: /workspace/src (src)',
+        '- skill: sprinkles',
+        '- scoop: jid-123 (my-scoop)',
+      ].join('\n')
+    );
+  });
+
+  it('appends label in parens when it differs from the locator', () => {
+    const refs: AddItem[] = [
+      { kind: 'session', label: 'Fix the build', locator: '/sessions/2026-06-01-foo.md' },
+    ];
+    expect(compileContextPreamble(refs)).toBe(
+      '[context]\n- session: /sessions/2026-06-01-foo.md (Fix the build)'
+    );
+  });
+});

--- a/packages/webapp/tests/ui/add-menu/search-providers.test.ts
+++ b/packages/webapp/tests/ui/add-menu/search-providers.test.ts
@@ -51,6 +51,20 @@ describe('createFileFolderProvider', () => {
     expect(srcRes.some((r) => r.kind === 'folder' && r.locator === '/workspace/src')).toBe(true);
   });
 
+  it('skips excluded subtrees so skills are not double-surfaced as files/folders', async () => {
+    const vfs = fakeVfs({
+      '/workspace/memory.md': 'file',
+      '/workspace/skills/aem': 'directory',
+      '/workspace/skills/aem/SKILL.md': 'file',
+      '/workspace/skills/aem/scripts/aem.jsh': 'file',
+    });
+    const p = createFileFolderProvider(vfs, ['/workspace'], ['/workspace/skills']);
+    const all = await p.search('', 50);
+    const locators = all.map((r) => r.locator);
+    expect(locators).toContain('/workspace/memory.md');
+    expect(locators.some((l) => l.startsWith('/workspace/skills'))).toBe(false);
+  });
+
   it('returns a default list for an empty query', async () => {
     const vfs = fakeVfs({ '/workspace/a.md': 'file', '/workspace/b.md': 'file' });
     const p = createFileFolderProvider(vfs, ['/workspace']);

--- a/packages/webapp/tests/ui/add-menu/search-providers.test.ts
+++ b/packages/webapp/tests/ui/add-menu/search-providers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createFileFolderProvider,
+  createScoopProvider,
+  createSessionProvider,
+  createSkillProvider,
+} from '../../../src/ui/add-menu/search-providers.js';
+
+function fakeVfs(tree: Record<string, 'file' | 'directory'>) {
+  return {
+    async readDir(path: string) {
+      const prefix = path.endsWith('/') ? path : `${path}/`;
+      const names = new Set<string>();
+      const out: { name: string; type: 'file' | 'directory' }[] = [];
+      for (const [p, type] of Object.entries(tree)) {
+        if (p.startsWith(prefix)) {
+          const rest = p.slice(prefix.length);
+          const seg = rest.split('/')[0];
+          if (!seg || names.has(seg)) continue;
+          names.add(seg);
+          const isDir = rest.includes('/') || type === 'directory';
+          out.push({ name: seg, type: isDir ? 'directory' : 'file' });
+        }
+      }
+      return out;
+    },
+    async *walk(path: string) {
+      const prefix = path.endsWith('/') ? path : `${path}/`;
+      for (const [p, type] of Object.entries(tree)) {
+        if (type === 'file' && p.startsWith(prefix)) yield p;
+      }
+    },
+  } as never;
+}
+
+describe('createFileFolderProvider', () => {
+  it('matches files and folders by path substring, prefix-ranked', async () => {
+    const vfs = fakeVfs({
+      '/workspace/CLAUDE.md': 'file',
+      '/workspace/README.md': 'file',
+      '/workspace/src': 'directory',
+      '/workspace/src/main.ts': 'file',
+    });
+    const p = createFileFolderProvider(vfs, ['/workspace']);
+    const res = await p.search('read', 10);
+    expect(res.map((r) => r.locator)).toContain('/workspace/README.md');
+    expect(res.every((r) => r.kind === 'file' || r.kind === 'folder')).toBe(true);
+  });
+
+  it('returns a default list for an empty query', async () => {
+    const vfs = fakeVfs({ '/workspace/a.md': 'file', '/workspace/b.md': 'file' });
+    const p = createFileFolderProvider(vfs, ['/workspace']);
+    const res = await p.search('', 10);
+    expect(res.length).toBeGreaterThan(0);
+  });
+});
+
+describe('createSkillProvider', () => {
+  it('lists /workspace/skills dirs, filtered by query', async () => {
+    const vfs = fakeVfs({
+      '/workspace/skills/sprinkles': 'directory',
+      '/workspace/skills/frontend-design': 'directory',
+    });
+    const p = createSkillProvider(vfs);
+    const all = await p.search('', 10);
+    expect(all.map((r) => r.label).sort()).toEqual(['frontend-design', 'sprinkles']);
+    const filtered = await p.search('spr', 10);
+    expect(filtered.map((r) => r.label)).toEqual(['sprinkles']);
+    expect(filtered[0].kind).toBe('skill');
+  });
+});
+
+describe('createSessionProvider', () => {
+  it('maps frozen-session entries to AddItems', async () => {
+    const readIndex = async () => [
+      { filename: '2026-06-01-foo.md', title: 'Fix the build', frozenAt: '', messageCount: 5 },
+    ];
+    const p = createSessionProvider(readIndex as never);
+    const res = await p.search('fix', 10);
+    expect(res[0]).toMatchObject({
+      kind: 'session',
+      label: 'Fix the build',
+      locator: '/sessions/2026-06-01-foo.md',
+    });
+  });
+});
+
+describe('createScoopProvider', () => {
+  it('lists non-cone scoops by name', async () => {
+    const getScoops = () => [
+      { jid: 'cone', name: 'sliccy', isCone: true },
+      { jid: 'jid-1', name: 'andy-scoop', isCone: false },
+    ];
+    const p = createScoopProvider(getScoops as never);
+    const res = await p.search('andy', 10);
+    expect(res).toEqual([
+      { kind: 'scoop', label: 'andy-scoop', sublabel: undefined, locator: 'jid-1' },
+    ]);
+  });
+});

--- a/packages/webapp/tests/ui/add-menu/search-providers.test.ts
+++ b/packages/webapp/tests/ui/add-menu/search-providers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  createAggregator,
   createFileFolderProvider,
   createScoopProvider,
   createSessionProvider,
@@ -45,6 +46,9 @@ describe('createFileFolderProvider', () => {
     const res = await p.search('read', 10);
     expect(res.map((r) => r.locator)).toContain('/workspace/README.md');
     expect(res.every((r) => r.kind === 'file' || r.kind === 'folder')).toBe(true);
+
+    const srcRes = await p.search('src', 10);
+    expect(srcRes.some((r) => r.kind === 'folder' && r.locator === '/workspace/src')).toBe(true);
   });
 
   it('returns a default list for an empty query', async () => {
@@ -96,5 +100,44 @@ describe('createScoopProvider', () => {
     expect(res).toEqual([
       { kind: 'scoop', label: 'andy-scoop', sublabel: undefined, locator: 'jid-1' },
     ]);
+  });
+});
+
+describe('createAggregator', () => {
+  it('queries all providers and flattens results into one array', async () => {
+    const itemA = {
+      kind: 'file' as const,
+      label: 'a.ts',
+      sublabel: '/workspace',
+      locator: '/workspace/a.ts',
+    };
+    const itemB = { kind: 'skill' as const, label: 'sprinkles', locator: 'sprinkles' };
+    const providerA = { kind: 'file' as const, search: async () => [itemA] };
+    const providerB = { kind: 'skill' as const, search: async () => [itemB] };
+    const aggregator = createAggregator([providerA, providerB]);
+    const results = await aggregator.search('', 10);
+    expect(results).toContainEqual(itemA);
+    expect(results).toContainEqual(itemB);
+    expect(results).toHaveLength(2);
+  });
+
+  it('isolates provider errors — a throwing provider contributes [] and does not break others', async () => {
+    const goodItem = {
+      kind: 'file' as const,
+      label: 'good.ts',
+      sublabel: '/workspace',
+      locator: '/workspace/good.ts',
+    };
+    const throwingProvider = {
+      kind: 'skill' as const,
+      search: async (): Promise<never> => {
+        throw new Error('provider exploded');
+      },
+    };
+    const goodProvider = { kind: 'file' as const, search: async () => [goodItem] };
+    const aggregator = createAggregator([throwingProvider, goodProvider]);
+    const results = await aggregator.search('', 10);
+    expect(results).toContainEqual(goodItem);
+    expect(results).toHaveLength(1);
   });
 });

--- a/packages/webapp/tests/ui/add-menu/search-providers.test.ts
+++ b/packages/webapp/tests/ui/add-menu/search-providers.test.ts
@@ -101,6 +101,36 @@ describe('createSessionProvider', () => {
       locator: '/sessions/2026-06-01-foo.md',
     });
   });
+
+  it('returns sessions newest-first when the query is empty', async () => {
+    const readIndex = async () => [
+      {
+        filename: 'old.md',
+        title: 'Old session',
+        frozenAt: '2026-01-01T00:00:00Z',
+        messageCount: 2,
+      },
+      {
+        filename: 'new.md',
+        title: 'New session',
+        frozenAt: '2026-06-01T00:00:00Z',
+        messageCount: 5,
+      },
+      {
+        filename: 'mid.md',
+        title: 'Mid session',
+        frozenAt: '2026-03-15T00:00:00Z',
+        messageCount: 3,
+      },
+    ];
+    const p = createSessionProvider(readIndex as never);
+    const res = await p.search('', 10);
+    expect(res.map((r) => r.locator)).toEqual([
+      '/sessions/new.md',
+      '/sessions/mid.md',
+      '/sessions/old.md',
+    ]);
+  });
 });
 
 describe('createScoopProvider', () => {

--- a/packages/webapp/tests/ui/chat-fixture.test.ts
+++ b/packages/webapp/tests/ui/chat-fixture.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  applyAddMenuFixtureSeed,
   createChatFixture,
   FIXTURE_SCOOP_NAME,
   FIXTURE_SESSION_ID,
@@ -113,5 +114,20 @@ describe('createChatFixture', () => {
   it('exports stable identifiers used by main.ts', () => {
     expect(FIXTURE_SESSION_ID).toBe('session-ui-fixture');
     expect(FIXTURE_SCOOP_NAME).toBe('ui-fixture');
+  });
+});
+
+describe('applyAddMenuFixtureSeed', () => {
+  it('exposes the add-menu fixture seed that opens the menu when present', () => {
+    expect(typeof applyAddMenuFixtureSeed).toBe('function');
+    let opened = false;
+    applyAddMenuFixtureSeed({
+      openAddMenuForFixture: () => {
+        opened = true;
+      },
+    });
+    expect(opened).toBe(true);
+    // no-op safe when the method is absent
+    expect(() => applyAddMenuFixtureSeed({})).not.toThrow();
   });
 });

--- a/packages/webapp/tests/ui/create-lucide-icon.test.ts
+++ b/packages/webapp/tests/ui/create-lucide-icon.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import { createLucideIcon, type IconNode } from '../../src/ui/create-lucide-icon.js';
+import { createLickIcon } from '../../src/ui/lick-view.js';
+import { createClusterIcon, createToolIcon } from '../../src/ui/tool-call-view.js';
+import type { ChatMessage } from '../../src/ui/types.js';
+
+const sampleNode: IconNode = [
+  ['path', { d: 'M5 12h14' }],
+  ['circle', { cx: 12, cy: 12, r: 3 }],
+];
+
+describe('createLucideIcon', () => {
+  it('builds an <svg> with the standard lucide attributes', () => {
+    const svg = createLucideIcon(sampleNode);
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+    expect(svg.getAttribute('viewBox')).toBe('0 0 24 24');
+    expect(svg.getAttribute('fill')).toBe('none');
+    expect(svg.getAttribute('stroke')).toBe('currentColor');
+    expect(svg.getAttribute('stroke-width')).toBe('2');
+    expect(svg.getAttribute('stroke-linecap')).toBe('round');
+    expect(svg.getAttribute('stroke-linejoin')).toBe('round');
+  });
+
+  it('defaults to size 18 and honors an explicit size', () => {
+    const def = createLucideIcon(sampleNode);
+    expect(def.getAttribute('width')).toBe('18');
+    expect(def.getAttribute('height')).toBe('18');
+
+    const sized = createLucideIcon(sampleNode, 14);
+    expect(sized.getAttribute('width')).toBe('14');
+    expect(sized.getAttribute('height')).toBe('14');
+  });
+
+  it('renders one child element per node entry with its attributes', () => {
+    const svg = createLucideIcon(sampleNode);
+    const children = Array.from(svg.children);
+    expect(children.map((c) => c.tagName.toLowerCase())).toEqual(['path', 'circle']);
+    expect(children[0].getAttribute('d')).toBe('M5 12h14');
+    expect(children[1].getAttribute('r')).toBe('3');
+  });
+
+  it('produces a childless <svg> for an empty node', () => {
+    expect(createLucideIcon([]).children.length).toBe(0);
+  });
+});
+
+describe('icon entry points route through the shared builder', () => {
+  function makeLick(channel: string, content: string): ChatMessage {
+    return { id: 'm1', role: 'user', content, timestamp: Date.now(), source: 'lick', channel };
+  }
+
+  it('createToolIcon renders a 14px svg with children', () => {
+    const svg = createToolIcon('read_file');
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+    expect(svg.getAttribute('width')).toBe('14');
+    expect(svg.children.length).toBeGreaterThan(0);
+  });
+
+  it('createClusterIcon renders a 14px svg', () => {
+    expect(createClusterIcon().getAttribute('width')).toBe('14');
+  });
+
+  it('createLickIcon renders a 14px svg', () => {
+    const svg = createLickIcon(makeLick('webhook', '[Webhook Event: x]'));
+    expect(svg.getAttribute('width')).toBe('14');
+    expect(svg.children.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
<!-- Linked issue: none -->

## Summary

Replaces the attachment-only Paperclip button on the chat composer with a `+` "Add context" button that opens a searchable menu. Users can attach files (upload or drag-and-drop), take a screenshot, and add **references** to VFS files/folders, skills, frozen sessions, and scoops. References render as dismissible chips in the composer and compile into a hidden `[context]` preamble prepended to the agent message on send. The preamble is stripped from the reconstructed transcript display so it never leaks into chat bubbles.

## Why

The attachment button was an all-or-nothing file picker. Agents can already resolve VFS paths, skill names, session files, and scoop JIDs with their own tools — this surfaces those as first-class, typeahead-searchable inputs from the composer, giving users a faster way to point the agent at context without pasting paths by hand.

## Approach / Implementation notes

**Layering:**

- `packages/webapp/src/ui/add-menu/` — five new modules: `add-item.ts` (type definitions), `add-menu.ts` (DOM component), `capture.ts` (screen capture via `getDisplayMedia`), `preamble.ts` (compile + strip `[context]` block), `search-providers.ts` (VFS walk, skill/session/scoop providers, aggregator).
- `packages/webapp/src/ui/create-lucide-icon.ts` — extracted shared SVG builder that was duplicated in `chat-panel.ts`, `lick-view.ts`, and `tool-call-view.ts`.
- `packages/webapp/src/ui/chat-panel.ts` — `setAddMenu()` wires the menu into the composer; `addReference()` manages pending refs; `sendMessage()` compiles the preamble before handing text to the agent.
- `packages/webapp/src/ui/main.ts` — `wireAddMenu()` constructs the aggregator for both extension and standalone-worker boot paths.

**Non-obvious choices:**

- *References ride as a hidden text preamble, not new tool parameters.* The agent resolves each locator with its own tools (`read_file`, `bash cat`, etc.) — no new tool surface needed.
- *VFS walk is cached for 3 s with in-flight dedup.* Over the OPFS RPC path a fresh walk per keystroke would be dozens of round-trips; the TTL keeps typeahead responsive while still picking up filesystem changes.
- *`[context]` block stripped in `agentMessagesToChatMessages`* so the hidden preamble never appears in the rebuilt transcript when messages are loaded from session storage.
- *`WALK_LIMIT = 500`* bounds the breadth-first walk on large VFS trees.

**Design choices rejected:**

- Embedding file content inline in the message was considered but abandoned — it would bloat the context window unpredictably. A path reference lets the agent fetch exactly what it needs.
- A dedicated `add_reference` tool was considered but rejected in favour of the preamble text convention, which works without any model-side changes.

**New data shape:**

- `ChatMessage.references?: AddItem[]` — persisted by the session freezer so chips re-render on reload without the raw preamble being present.

## Cross-cutting impact

**Floats exercised:**
- CLI (standalone-worker): `wireAddMenu` called from `mainStandaloneWorker`, screenshot via `captureScreenshot()` (direct `getDisplayMedia`).
- Chrome extension: `wireAddMenu` called from `mainExtension`, screenshot routed through `captureViaPopup` because `getDisplayMedia` cannot prompt from the side panel.
- Electron: reuses standalone-worker boot path, no separate change needed.
- Sliccstart / worker: N/A — UI feature only.

**Shell contexts (extension):** side-panel `WasmShell` and offscreen `WasmShell` are untouched. The add-menu is side-panel UI only.

**Other callers of changed code:**
- `agentMessagesToChatMessages` — the `stripContextPreamble` call is guarded by `!lickChannel`, so lick messages are unaffected.
- `renderPendingAttachments` — now also renders reference chips; attachment chip rendering is unchanged.
- `lick-view.ts` / `tool-call-view.ts` — `iconNodeToSvg` replaced with the shared `createLucideIcon`; pixel output is identical (same attributes, same size).

**Persisted state side-effects:**
- `ChatMessage.references` is a new optional field written by the session freezer. Old sessions without it load fine (field is absent → no chips rendered). No migration needed.

**Async lifecycle:**
- `AddMenu.dispose()` cancels the debounce timer and removes all listeners.
- `ChatPanel.destroy()` now calls `addMenu?.dispose()`.
- In-flight `aggregator.search()` after dispose modifies a detached DOM subtree — harmless.

**Security:** all label/locator text is set via `textContent` (not `innerHTML`). Newlines in locators/labels are collapsed in `collapseNewlines()` to prevent `[context]` block corruption.

**Bundle size:** `lucide` icons were already imported in `chat-panel.ts`. This PR adds `Plus`, `Monitor`, and `Upload` — negligible delta.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — all passing, no new failures
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] New modules covered by unit tests mirroring `src/` layout: `add-menu.test.ts`, `capture.test.ts`, `preamble.test.ts`, `search-providers.test.ts`, `create-lucide-icon.test.ts`, `chat-panel-add-integration.test.ts`
- [x] Manual smoke (CLI): `npm run dev` — `+` button opens menu, search filters VFS files/skills/sessions, chips appear and dismiss, Enter sends with preamble, transcript hides preamble on reload.
- [x] Manual smoke (extension): load unpacked `dist/extension/` — screenshot routes through popup, all other paths as above.
- [ ] Manual smoke (Electron): not verified; reuses standalone-worker path.

**Pre-existing failures:** none observed on `main`.

## Documentation

- [x] No documentation changes needed — this is a UI-only feature with no new shell commands, tools, or agent-facing contracts.

## Risk & rollback

- **Blast radius:** webapp UI only — CLI, extension, and Electron chat composer. No VFS, agent core, or protocol changes.
- **No feature flags.** `setAddMenu` is called unconditionally in both boot paths; rolling back means reverting this PR.
- **Rollback is clean** — revert restores the Paperclip button. The `references` field in frozen sessions is ignored by old code (optional field, no migration). `ChatMessage` shape is backwards-compatible.
- **CI cannot catch:** real `getDisplayMedia` picker UX and the extension popup capture path require manual verification with a loaded extension.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths