### PR TITLE
bug(welcome-prompt): Fix dupe Welcome message

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -359,7 +359,6 @@
         "packages/webapp/src/net/link-header.ts",
         "packages/webapp/src/providers/built-in/azure-openai.ts",
         "packages/webapp/src/scoops/db.ts",
-        "packages/webapp/src/scoops/onboarding-orchestrator.ts",
         "packages/webapp/src/scoops/scoop-management-tools.ts",
         "packages/webapp/src/scoops/tray-leader-sync.ts",
         "packages/webapp/src/scoops/tray-webrtc.ts",

--- a/packages/webapp/src/scoops/onboarding-orchestrator.ts
+++ b/packages/webapp/src/scoops/onboarding-orchestrator.ts
@@ -270,29 +270,13 @@ export class OnboardingOrchestrator {
     // accounts. Without this, picking azure-openai from the welcome
     // dip used to write an account missing deployment + api-version
     // and break at the first chat request.
-    const providerEntry = (() => {
-      try {
-        return this.deps.getProviderCatalogue().providers.find((p) => p.id === provider);
-      } catch {
-        return undefined;
-      }
-    })();
-    if (providerEntry?.requiresDeployment && !deployment?.trim()) {
+    const requiredFieldError = this.validateProviderRequiredFields(provider, baseUrl, deployment);
+    if (requiredFieldError) {
       this.deps.broadcastToDip({
         type: 'slicc-connect-result',
         ok: false,
         kind: 'failed',
-        message: `${providerEntry.name} requires a deployment name.`,
-      });
-      this.stage = 'awaiting-connect';
-      return;
-    }
-    if (providerEntry?.requiresBaseUrl && !baseUrl?.trim()) {
-      this.deps.broadcastToDip({
-        type: 'slicc-connect-result',
-        ok: false,
-        kind: 'failed',
-        message: `${providerEntry.name} requires a base URL.`,
+        message: requiredFieldError,
       });
       this.stage = 'awaiting-connect';
       return;
@@ -478,6 +462,33 @@ export class OnboardingOrchestrator {
         validation: 'oauth',
       },
     });
+  }
+
+  /**
+   * Internal — validate provider required fields (deployment, base URL) against
+   * the live catalogue. Returns an error message string when a required field is
+   * missing, or `null` when all required fields are present. Mirrors the
+   * Settings → Add Account dialog's required-field gate so the welcome dip
+   * can't silently save a half-configured Azure-style account.
+   */
+  private validateProviderRequiredFields(
+    provider: string,
+    baseUrl: string | null | undefined,
+    deployment: string | null | undefined
+  ): string | null {
+    let providerEntry: ProviderEntry | undefined;
+    try {
+      providerEntry = this.deps.getProviderCatalogue().providers.find((p) => p.id === provider);
+    } catch {
+      return null;
+    }
+    if (providerEntry?.requiresDeployment && !deployment?.trim()) {
+      return `${providerEntry.name} requires a deployment name.`;
+    }
+    if (providerEntry?.requiresBaseUrl && !baseUrl?.trim()) {
+      return `${providerEntry.name} requires a base URL.`;
+    }
+    return null;
   }
 
   /** Internal — write the user's profile to /home/<name>/.welcome.json. */

--- a/packages/webapp/src/scoops/onboarding-orchestrator.ts
+++ b/packages/webapp/src/scoops/onboarding-orchestrator.ts
@@ -150,7 +150,7 @@ export interface OrchestratorDeps {
   rand?: RandomFn;
 }
 
-type Stage = 'idle' | 'awaiting-connect' | 'connecting' | 'complete';
+type Stage = 'idle' | 'collect-profile' | 'awaiting-connect' | 'connecting' | 'complete';
 
 export class OnboardingOrchestrator {
   private deps: OrchestratorDeps;
@@ -179,6 +179,7 @@ export class OnboardingOrchestrator {
    */
   handleFirstRun(): void {
     if (this.stage !== 'idle') return;
+    this.stage = 'collect-profile';
     this.deps.postDipReference("Welcome to SLICC — let's get you set up.");
     this.deps.postDipReference('![Welcome](/shared/sprinkles/welcome/welcome.shtml)');
   }

--- a/packages/webapp/src/scoops/onboarding-orchestrator.ts
+++ b/packages/webapp/src/scoops/onboarding-orchestrator.ts
@@ -192,7 +192,7 @@ export class OnboardingOrchestrator {
    * fall back to the legacy path.
    */
   async handleOnboardingComplete(profile: OnboardingProfile): Promise<boolean> {
-    if (this.stage !== 'idle') {
+    if (this.stage !== 'idle' && this.stage !== 'collect-profile') {
       log.debug('Ignoring duplicate onboarding-complete', { stage: this.stage });
       return true;
     }

--- a/packages/webapp/src/ui/boot/setup-onboarding.ts
+++ b/packages/webapp/src/ui/boot/setup-onboarding.ts
@@ -24,8 +24,7 @@ import type { OnboardingSetupDeps } from './types.js';
  * orchestrator owns the welcome dip + intro lines until the user
  * configures a provider — handing it to the cone would fatal with
  * "No API key configured for provider …" before the wizard even
- * appears. The persistent dedup ledger guards against reload
- * double-fires (see `DEDUPED_WELCOME_ACTIONS` in `main.ts`).
+ * appears.
  *
  * No-op when a tray-join URL is stored: a follower instance is
  * driven by its leader's chat history and should never re-render

--- a/packages/webapp/src/ui/boot/setup-onboarding.ts
+++ b/packages/webapp/src/ui/boot/setup-onboarding.ts
@@ -31,17 +31,9 @@ import type { OnboardingSetupDeps } from './types.js';
  * driven by its leader's chat history and should never re-render
  * the welcome flow.
  *
- * Mirrors the standalone and extension caller bodies exactly: when
- * detection insists this is genuinely a fresh boot (no
- * `/shared/.welcomed` marker AND no welcome lick in chat history)
- * but the in-memory ledger has a stale `first-run` entry from a
- * previous install whose state was wiped (clear-site-data, IndexedDB
- * nuke, manual VFS reset), suppressing here would leave the user
- * with no welcome and no deterministic onboarding path. Trust the
- * install state over the ledger and clear the stale entry. The
- * ledger still protects against intra-session double-fires (the
- * detection promise can resolve twice during a noisy boot), because
- * we re-add it before handing off.
+ * The persistent dedup ledger guards against both intra-session double-fires
+ * and cross-restart re-welcomes: if `'first-run'` is already in the ledger,
+ * detection exits early without calling `handleFirstRun()`.
  */
 export function runFirstRunDetection(deps: OnboardingSetupDeps): void {
   const { vfs, storage, firedWelcomeActions, persistFiredWelcomeActions, getOrchestrator, log } =
@@ -53,9 +45,8 @@ export function runFirstRunDetection(deps: OnboardingSetupDeps): void {
     .then((result) => {
       if (!result.isFirstRun) return;
       if (firedWelcomeActions.has('first-run')) {
-        log.info('Clearing stale welcome dedup entry — install state is fresh');
-        firedWelcomeActions.delete('first-run');
-        persistFiredWelcomeActions(firedWelcomeActions);
+        log.debug('Suppressing welcome re-fire: first-run already in dedup ledger');
+        return;
       }
       firedWelcomeActions.add('first-run');
       persistFiredWelcomeActions(firedWelcomeActions);

--- a/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
@@ -165,6 +165,17 @@ describe('OnboardingOrchestrator', () => {
     });
   });
 
+  describe('handleFirstRun', () => {
+    it('posts the welcome message and dip reference exactly once even when called twice', () => {
+      const h = makeHarness();
+      h.orchestrator.handleFirstRun();
+      h.orchestrator.handleFirstRun(); // second call must be a no-op
+      expect(h.dipRefs).toHaveLength(2); // "Welcome…" text + dip image markdown
+      expect(h.dipRefs[0]).toContain("let's get you set up");
+      expect(h.dipRefs[1]).toContain('welcome.shtml');
+    });
+  });
+
   describe('handleConnectReady', () => {
     it('responds to ready by broadcasting the provider catalogue to the dip', async () => {
       const h = makeHarness();

--- a/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
@@ -173,6 +173,17 @@ describe('OnboardingOrchestrator', () => {
       expect(h.dipRefs).toHaveLength(2); // "Welcome…" text + dip image markdown
       expect(h.dipRefs[0]).toContain("let's get you set up");
       expect(h.dipRefs[1]).toContain('welcome.shtml');
+      expect(h.orchestrator.getStage()).toBe('collect-profile');
+    });
+
+    it('allows handleOnboardingComplete to proceed after handleFirstRun has run', async () => {
+      const h = makeHarness();
+      h.orchestrator.handleFirstRun();
+      expect(h.orchestrator.getStage()).toBe('collect-profile');
+      const handled = await h.orchestrator.handleOnboardingComplete({ name: 'Test' });
+      expect(handled).toBe(true);
+      expect(h.orchestrator.getStage()).toBe('awaiting-connect');
+      expect(h.systemMessages).toHaveLength(3); // three deterministic intro lines
     });
   });
 

--- a/packages/webapp/tests/ui/boot/setup-onboarding.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-onboarding.test.ts
@@ -138,9 +138,10 @@ describe('runFirstRunDetection', () => {
     expect(handleFirstRun).toHaveBeenCalledTimes(1);
   });
 
-  it('clears a stale ledger entry before re-adding it on a fresh boot', async () => {
+  it('suppresses re-fire when first-run is already in the dedup ledger', async () => {
     const handleFirstRun = vi.fn();
     const persist = vi.fn();
+    // Simulate a restart: localStorage already has 'first-run' from the previous boot.
     const set = new Set<string>(['first-run']);
 
     runFirstRunDetection({
@@ -153,9 +154,10 @@ describe('runFirstRunDetection', () => {
     });
 
     await new Promise((r) => setTimeout(r, 30));
-    // Persist called twice: once on the stale-clear, once on the re-add.
-    expect(persist).toHaveBeenCalledTimes(2);
-    expect(handleFirstRun).toHaveBeenCalledTimes(1);
+    // The ledger entry was already present — no re-fire, no persist mutation.
+    expect(handleFirstRun).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
+    expect(set.has('first-run')).toBe(true); // entry untouched
   });
 
   it('no-ops the orchestrator + ledger when the welcomed marker exists', async () => {

--- a/packages/webapp/tests/ui/boot/setup-onboarding.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-onboarding.test.ts
@@ -8,9 +8,8 @@
  *   - No-op when a tray-join URL is stored (follower instance).
  *   - On first-run, the dedup ledger is mutated AND persisted AND
  *     the orchestrator's `handleFirstRun()` is invoked.
- *   - A stale `first-run` entry on a genuine fresh boot is cleared
- *     (trust install-state over ledger), then re-added before
- *     `handleFirstRun()` is invoked.
+ *   - A `'first-run'` entry already in the dedup ledger suppresses re-fire
+ *     (trust the ledger over install-state — prevents restart re-welcomes).
  *   - A non-first-run detection result is a no-op against the
  *     orchestrator and the ledger.
  */


### PR DESCRIPTION
## Summary

Closes: #601 

  Fixes two related welcome-flow bugs: (1) the "let's get you set up" prompt appeared twice on a fresh install, and (2) the prompt re-appeared on every restart when the user had not yet completed the profile form. After this PR, the welcome shows exactly once and a restart does not re-trigger it.

  ## Why

  **Repro (Bug 1 — double fire):**
  1. Run `npx sliccy`, start your default profile,
  2. Run `npx sliccy`, to start a new profile
  3. Expected: welcome dip appears once on the new profile
     Actual: welcome dip appears twice (stacked), one from the initial boot and one from the SW-registration page reload.

  **Repro (Bug 2 — restart re-welcome):**
  1. Run `npx sliccy` on a fresh profile → welcome appears, do **not** submit the profile form
  2. Quit and restart `npx sliccy`
  3. Expected: previous session restored, no second welcome.
     Actual: welcome re-appears on every restart.

  ## Approach / Implementation notes

  Two independent defects, both in the onboarding boot path:
  
  **Defect 1 — `handleFirstRun()` stage not advanced**
  `OnboardingOrchestrator.handleFirstRun()` had a guard `if (this.stage !== 'idle') return` but never set `this.stage` after posting, so any second call found stage still `'idle'` and re-posted the welcome. Fix: set `this.stage = 'collect-profile'` before the first `postDipReference` call.

  Side-effect fix: `handleOnboardingComplete()`'s entry guard also checked `!== 'idle'` and would have silently no-oped when stage was `'collect-profile'`. Widened to `!== 'idle' && !== 'collect-profile'` so the normal flow `handleFirstRun() → handleOnboardingComplete()` still works. The `'idle'` entry path is retained for the reload case where the dedup ledger suppressed `handleFirstRun()` but the user reaches `handleOnboardingComplete()` via the persisted connect-llm dip.

  **Defect 2 — stale-clearing block in `runFirstRunDetection`**
  The block intended to handle "user wiped VFS but not localStorage" would fire whenever `detectWelcomeFirstRun` returned `isFirstRun: true` AND `'first-run'` was already in the localStorage ledger — which is exactly the state after any page-reload or process restart mid-onboarding. The block cleared the dedup entry and called `handleFirstRun()` again.

  Fix: replace clear+refire with an early `return`. If `'first-run'` is already in the ledger, the welcome was shown in a prior session — do nothing.

  Known limitation: a user who manually clears only IndexedDB (not localStorage) will not see the welcome again without also clearing `localStorage['slicc:welcome-flow-fired']`. This is a very narrow edge case and preferable to the common-case regression.

  ## Cross-cutting impact

  - **Floats exercised**: CLI (`npx sliccy` / `npm run dev`) and Chrome extension (`mainExtension`). Both boot paths call `runFirstRunDetection` via
    `setup-standalone-trailers.ts` and `main.ts:181` respectively — both are fixed.
    Electron / Sliccstart / worker floats all reach `runFirstRunDetection` through
    the same boot chain; no float-specific code changed.
  - **Shell contexts**: no shell contexts touched.
  - **Other callers of changed functions**: `handleOnboardingComplete` is only called from `setup-welcome-flow.ts:dispatchWelcomeBranch`. The widened guard  (`'idle' || 'collect-profile'`) has no effect on that caller's behavior because both stages are now valid entries and the caller never passes stage as an argument.
    `handleConnectReady` and `handleConnectAttempt` accept `stage !== 'complete'` —  unchanged.
  - **Persisted state side-effects**: no changes to IndexedDB stores. The `slicc:welcome-flow-fired` localStorage key is now never cleared mid-session by the boot path; it is only written (added) when the welcome fires for the first time.
  - **`/shared/.welcomed` marker**: unaffected. Written by `handleOnboardingComplete` as before. The marker-based fast-path in `detectWelcomeFirstRun` is unchanged.
  - **`hasWelcomeLickInHistory` history check**: unaffected — still present as defence-in-depth for returning users whose marker was written.

  ## Test plan

    - [x] `npm run lint` — clean
  - [x] `npm run typecheck` — clean
  - [x] `npm run test` — 6333 passing, 10 pre-existing skips, no new failures
  - [x] `npm run build` — clean (Swift deprecation warnings are pre-existing on `main`)
  - [x] `npm run build -w @slicc/chrome-extension` — clean
  - [x] **New unit tests** in `packages/webapp/tests/scoops/onboarding-orchestrator.test.ts`
        (`describe('handleFirstRun')`) and
        `packages/webapp/tests/ui/boot/setup-onboarding.test.ts`
        (`'suppresses re-fire when first-run is already in the dedup ledger'`)
  - [x] Manual smoke (CLI):
    1. `rm -rf "$HOME/Library/Application Support/Slicc/profiles/default"`
    2. `npx sliccy` — welcome appears **once**
    3. Close without submitting profile form; restart — welcome does **not** reappear
    4. Complete full onboarding; restart — opens to existing session, no welcome
  - [ ] Manual smoke (extension): load unpacked `dist/extension/`, open side panel on


  **Pre-existing failures**: none observed on `main`.

  ## Documentation

  - [ ] No documentation changes needed

  ## Risk & rollback

  - **Blast radius**: welcome flow only. No LLM calls, no account storage, no CDP
    involved. Regression would mean new users don't see the welcome on first install
    (detectable immediately).
  - **Rollback**: clean revert with no persisted-state migration needed. The
    `slicc:welcome-flow-fired` localStorage key exists in both old and new code;
    reverting leaves the key in place but the old code would clear and refire on it,
    which is the pre-fix behavior.
  - **CI cannot catch**: the double-fire requires a page reload between the first
    `handleFirstRun()` call and the dedup check — covered by the manual smoke steps
    above.

  ## Checklist
  
  - [x] Commits are focused and package-local where possible
  - [x] No hand-edited files under `dist/`
  - [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
  - [x] No public API / tool / shell-command / lick-channel changes
  - [x] Contract change (`handleOnboardingComplete` guard widened) is internal to
        `OnboardingOrchestrator`; checked all callers (one: `dispatchWelcomeBranch`)
