### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -16,7 +16,7 @@
     "chrome-extension": {
       "lines": 73,
       "statements": 71,
-      "functions": 66,
+      "functions": 67,
       "branches": 60,
       "coverageExclude": [
         "**/node_modules/**",


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.