### PR TITLE
fix(da-mount): Strip weak ETags before caching DA content

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -344,7 +344,6 @@
         "packages/webapp/src/core/tool-adapter.ts",
         "packages/webapp/src/fs/migration/migration-copy.ts",
         "packages/webapp/src/fs/mount-recovery.ts",
-        "packages/webapp/src/fs/mount/backend-da.ts",
         "packages/webapp/src/fs/mount/backend-local.ts",
         "packages/webapp/src/git/diff.ts",
         "packages/webapp/src/git/git-config.ts",

--- a/packages/webapp/src/fs/mount/backend-da.ts
+++ b/packages/webapp/src/fs/mount/backend-da.ts
@@ -202,7 +202,13 @@ export class DaMountBackend implements MountBackend {
     if (body.byteLength > this.maxBodyBytes) {
       throw new FsError('EFBIG', `body exceeds maxBodyBytes`, path);
     }
-    const etag = res.headers.get('etag') ?? '';
+    // Strip weak-ETag prefix (W/) before caching. Cloudflare compresses JSON
+    // responses and downgrades strong ETags to weak ones. If-Match requires a
+    // strong ETag, so caching the weak form causes a guaranteed 412 on every
+    // write. The underlying S3 ETag (content MD5) is the part after W/, which
+    // is what S3 actually validates against.
+    const rawEtag = res.headers.get('etag') ?? '';
+    const etag = rawEtag.startsWith('W/') ? rawEtag.slice(2) : rawEtag;
     await this.cache.putBody(rel, body, etag);
     return body;
   }
@@ -232,7 +238,10 @@ export class DaMountBackend implements MountBackend {
     // with empty etag, which is malformed. Treat empty etag as "we don't
     // know the version" and omit the conditional.
     if (cached?.etag) {
-      headers['if-match'] = cached.etag;
+      // Strip weak-ETag prefix defensively — cached entries written before the
+      // readFile fix may still carry W/"..." from Cloudflare compression.
+      const strongEtag = cached.etag.startsWith('W/') ? cached.etag.slice(2) : cached.etag;
+      headers['if-match'] = strongEtag;
     } else if (!cached) {
       headers['if-none-match'] = '*';
     }

--- a/packages/webapp/src/fs/mount/backend-da.ts
+++ b/packages/webapp/src/fs/mount/backend-da.ts
@@ -443,42 +443,7 @@ export class DaMountBackend implements MountBackend {
     while (stack.length > 0) {
       const dir = stack.pop()!;
       try {
-        const res = await this.transport({ method: 'GET', path: this.toListPath(dir) });
-        if (res.status >= 400) {
-          report.errors.push({ path: dir, message: `list failed: ${res.status}` });
-          continue;
-        }
-        const json = (await res.json()) as Array<{
-          name: string;
-          ext?: string;
-          etag?: string;
-          lastModified?: number;
-        }>;
-        const entries: MountDirEntry[] = [];
-        for (const item of json) {
-          if (item.ext) {
-            const filePath = dir ? `${dir}/${item.name}.${item.ext}` : `${item.name}.${item.ext}`;
-            entries.push({
-              name: `${item.name}.${item.ext}`,
-              kind: 'file',
-              etag: item.etag,
-              lastModified: item.lastModified,
-            });
-            const cached = await this.cache.getBody(filePath);
-            if (!cached) report.added.push(filePath);
-            else if (item.etag && cached.etag !== item.etag) {
-              await this.cache.invalidateBody(filePath);
-              report.changed.push(filePath);
-            } else {
-              report.unchanged++;
-            }
-          } else {
-            entries.push({ name: item.name, kind: 'directory' });
-            const subDir = dir ? `${dir}/${item.name}` : item.name;
-            stack.push(subDir);
-          }
-        }
-        await this.cache.putListing(dir, entries);
+        await this.refreshDir(dir, report, stack);
       } catch (err) {
         report.errors.push({
           path: dir,
@@ -486,20 +451,68 @@ export class DaMountBackend implements MountBackend {
         });
       }
     }
+    if (opts?.bodies) await this.refreshBodies(report);
+    return report;
+  }
 
-    if (opts?.bodies) {
-      for (const path of report.changed) {
-        try {
-          await this.readFile(path);
-        } catch (err) {
-          report.errors.push({
-            path,
-            message: err instanceof Error ? err.message : String(err),
-          });
-        }
+  private async classifyFile(
+    filePath: string,
+    remoteEtag: string | undefined,
+    report: RefreshReport
+  ): Promise<void> {
+    const cached = await this.cache.getBody(filePath);
+    if (!cached) {
+      report.added.push(filePath);
+    } else if (remoteEtag && cached.etag !== remoteEtag) {
+      await this.cache.invalidateBody(filePath);
+      report.changed.push(filePath);
+    } else {
+      report.unchanged++;
+    }
+  }
+
+  private async refreshDir(dir: string, report: RefreshReport, stack: string[]): Promise<void> {
+    const res = await this.transport({ method: 'GET', path: this.toListPath(dir) });
+    if (res.status >= 400) {
+      report.errors.push({ path: dir, message: `list failed: ${res.status}` });
+      return;
+    }
+    const json = (await res.json()) as Array<{
+      name: string;
+      ext?: string;
+      etag?: string;
+      lastModified?: number;
+    }>;
+    const entries: MountDirEntry[] = [];
+    for (const item of json) {
+      if (item.ext) {
+        const filePath = dir ? `${dir}/${item.name}.${item.ext}` : `${item.name}.${item.ext}`;
+        entries.push({
+          name: `${item.name}.${item.ext}`,
+          kind: 'file',
+          etag: item.etag,
+          lastModified: item.lastModified,
+        });
+        await this.classifyFile(filePath, item.etag, report);
+      } else {
+        entries.push({ name: item.name, kind: 'directory' });
+        stack.push(dir ? `${dir}/${item.name}` : item.name);
       }
     }
-    return report;
+    await this.cache.putListing(dir, entries);
+  }
+
+  private async refreshBodies(report: RefreshReport): Promise<void> {
+    for (const path of report.changed) {
+      try {
+        await this.readFile(path);
+      } catch (err) {
+        report.errors.push({
+          path,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 
   describe(): MountDescription {

--- a/packages/webapp/tests/fs/mount/backend-da.test.ts
+++ b/packages/webapp/tests/fs/mount/backend-da.test.ts
@@ -159,6 +159,48 @@ describe('DaMountBackend writeFile', () => {
     expect(bodyStr).toContain('filename="config.json"');
   });
 
+  it('strips W/ weak-ETag prefix from GET response before caching so If-Match uses the strong form', async () => {
+    // Repro for the Cloudflare compression bug: DA's CDN returns weak ETags
+    // (W/"...") for gzip-compressed JSON responses. If cached as-is and sent
+    // as If-Match, S3 always returns 412 because If-Match requires a strong
+    // ETag. The fix strips W/ in readFile before storing in the body cache.
+    mock.enqueue(
+      new Response('{"data":[]}', {
+        status: 200,
+        headers: { etag: 'W/"ed1fe6b5"', 'content-length': '11' },
+      })
+    );
+    const backend = new DaMountBackend({
+      source: 'da://my-org/my-repo',
+      profile: 'default',
+      signedFetch: createSignedFetchDaStub(TEST_DA_PROFILE),
+      cache: makeCache(),
+    });
+    await backend.readFile('data/staffing.json');
+    mock.enqueue(new Response('', { status: 200, headers: { etag: '"ed1fe6b5"' } }));
+    await backend.writeFile('data/staffing.json', new TextEncoder().encode('{"data":[]}'));
+    // Must send the strong form — no W/ prefix.
+    expect(mock.calls[1].headers['if-match']).toBe('"ed1fe6b5"');
+  });
+
+  it('strips W/ weak-ETag prefix from stale cache entries at write time', async () => {
+    // Defense-in-depth for cache entries written before the readFile fix:
+    // if the body cache holds W/"..." (the old weak form), writeFile should
+    // strip the prefix before sending If-Match rather than propagating it.
+    const cache = makeCache();
+    // Manually seed the cache with a weak ETag to simulate a stale entry.
+    await cache.putBody('data/staffing.json', new TextEncoder().encode('{"data":[]}'), 'W/"stale"');
+    const backend = new DaMountBackend({
+      source: 'da://my-org/my-repo',
+      profile: 'default',
+      signedFetch: createSignedFetchDaStub(TEST_DA_PROFILE),
+      cache,
+    });
+    mock.enqueue(new Response('', { status: 200, headers: { etag: '"stale"' } }));
+    await backend.writeFile('data/staffing.json', new TextEncoder().encode('{"data":[1]}'));
+    expect(mock.calls[0].headers['if-match']).toBe('"stale"');
+  });
+
   it('omits if-match (instead of sending empty value) when cached etag is empty', async () => {
     // Repro for a real production bug: if a prior write or a 200 GET landed
     // a body in cache with etag='' (DA omits ETag for some responses),


### PR DESCRIPTION
## Summary
  
  Fixes a bug where writing to DA-mounted JSON sheet files always failed with `EBUSY` ("remote modified since last read"). Cloudflare's CDN compresses JSON responses from `admin.da.live` and downgrades strong S3 ETags to weak form (`W/"..."`). `If-Match` requires a strong ETag, so the conditional write sent by the DA backend was guaranteed to 412. HTML pages were unaffected because Cloudflare does not compress `text/html` responses. The fix strips the `W/` prefix in `readFile` before caching and defensively in `writeFile` before sending, covering both new reads and stale IndexedDB entries written before this fix.

  ## Why
  
  Discovered during investigation of DA sheet writes failing with EBUSY errors. Root cause traced via a `console.warn` on `writeFile` revealing the cached ETag had a `W/` prefix. Confirmed empirically: two consecutive GETs to `admin.da.live` for the same `.json` file return identical ETags, ruling out server-side regeneration. The weak ETag comes from Cloudflare compressing JSON on the way out; S3 itself only issues strong ETags.

  **Repro (before fix):**
  1. Mount a DA repo: `mount /mnt/da da://org/repo`
  2. `cat /mnt/da/data/sheet.json` (reads and caches `W/"abc123"`)
  3. `write_file /mnt/da/data/sheet.json <updated-json>`

  Expected: write succeeds
  Actual: `EBUSY: remote modified since last read — re-read and retry` on every attempt

  ## Approach / Implementation notes

  - **`readFile`** (`backend-da.ts:205–208`): strips `W/` from the raw `etag` header value before passing to `cache.putBody`. All future reads cache the strong form.
  - **`writeFile`** (`backend-da.ts:234–238`): strips `W/` from `cached.etag` before setting `If-Match`. Defense-in-depth for IndexedDB entries written before this fix — these survive across sessions and would otherwise continue to cause 412s until the file is re-read.
  - No changes to `RemoteMountCache`, `signed-fetch.ts`, or the DA Admin API. The fix is entirely in the browser-side mount backend.
  - The `W/` prefix is per RFC 7232 and is stripped to recover the underlying S3 content MD5 that DA Admin passes to S3 for conditional writes.

  ## Cross-cutting impact

  - **Floats exercised**: all floats that use the DA mount (CLI, extension) are affected equally — the fix is in `DaMountBackend` which is float-agnostic.
  - **Other file types**: HTML and other non-JSON files served by DA are unaffected in practice (Cloudflare doesn't compress them), but the strip is applied unconditionally — harmless if the ETag was already strong.
  - **Persisted state**: `slicc-mount-cache` IndexedDB body entries written with `W/` ETags before this fix will be silently corrected at next write time via the `writeFile` defensive strip. No migration needed.
  - **S3MountBackend**: the same `If-Match` pattern exists in the S3 backend; S3 presigned URLs are not routed through Cloudflare so they return strong ETags directly — not affected.

  ## Test plan
  
  - [x] `npm run lint` — passed (150 pre-existing warnings, no errors)
  - [x] `npm run typecheck` — passed
  - [x] `npm run test packages/webapp/tests/fs/mount/backend-da.test.ts` — 18
        passed (16 pre-existing + 2 new)
  - [x] **New behavior covered by unit tests**: `strips W/ weak-ETag prefix from GET response before caching` and `strips W/ weak-ETag prefix from stale cache entries at write time` in packages/webapp/tests/fs/mount/backend-da.test.ts`
  - [x] Manual smoke (CLI): mounted DA repo, wrote to a `.json` sheet file — write succeeded; subsequent reads and writes use the strong ETag correctly
  - [x] `npm run build` / extension build — not run; change is pure logic in an existing module, no new imports or bundle impact

  **Pre-existing failures**: none in the DA test file; the 150 biome warnings are pre-existing across unrelated files.

  ## Documentation
  
  - [x] No documentation changes needed — this is an implementation fix, not a new surface

  ## Risk & rollback

  - **Blast radius**: DA mount writes only. HTML writes and S3 mounts are unaffected. If the strip were somehow wrong, the worst case is a 412 — the same failure mode as before this fix, with the same EBUSY recovery path.
  - **Rollback**: revert this PR cleanly; no persisted state migration involved.
  - **CI cannot catch**: the real Cloudflare compression behaviour — confirmed manually against `admin.da.live` by inspecting ETag headers on `.json` GET responses.

  ## Checklist

  - [x] Commits are focused and package-local where possible
  - [x] No hand-edited files under `dist/`
  - [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
  - [x] No public API / tool / shell-command changes
  - [x] The DA backend is used identically by CLI and extension floats — both corrected by this fix
