### PR TITLE
fix(skills): stop kernel-worker OOM from monkeypatching the sudo-fs Proxy

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -395,7 +395,6 @@
         "packages/webapp/src/shell/supplemental-commands/webhook-command.ts",
         "packages/webapp/src/shell/supplemental-commands/websocat-command.ts",
         "packages/webapp/src/shell/wasm-shell.ts",
-        "packages/webapp/src/skills/catalog.ts",
         "packages/webapp/src/skills/install-from-drop.ts",
         "packages/webapp/src/tools/search-tools.ts",
         "packages/webapp/src/ui/ansi.ts",

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -161,6 +161,7 @@ Deep reference: `docs/kernel/process-model.md`.
 - Path: `packages/webapp/src/skills/`
 - Discovers install-managed native skills from `/workspace/skills/`.
 - Also discovers compatible read-only skill roots under `.agents/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md`.
+- **Never monkeypatch an fs method in place on a get/set-asymmetric Proxy.** `catalog.ts`'s compatibility-skill cache is invalidated by wrapping `writeFile`/`mkdir`/`rm`/… in place. The agent shell hands discovery the **sudo-fs `Proxy`** (`fs/sudo-fs.ts`), whose `get` returns a gating override while `set` writes through to the wrapped target — so reassigning a gated method clobbers the target's real method and leaves the override delegating to the new wrapper, whose captured `original` is that same override: an unbounded `override↔wrapper` async recursion that OOMs the kernel worker on the next gated write (stardust `upskill` → `playwright-cli` writing `/.playwright/session.md`). The sudo Proxy therefore advertises `MONKEYPATCH_UNSAFE_FS` (a `Symbol.for` registry marker) and `getCompatibilitySkillCandidates` skips both the hooks **and** the cache for it (always re-discovers). Boot-time `loadSkills` uses the unwrapped fs, so it is unaffected — which is why the crash only reproduced on first-time, in-shell skill installs.
 
 ### Sprinkle Rendering
 

--- a/packages/webapp/src/fs/sudo-fs.ts
+++ b/packages/webapp/src/fs/sudo-fs.ts
@@ -31,6 +31,22 @@ import { FsError } from './types.js';
 
 const log = createLogger('sudo:fs');
 
+/**
+ * Marker the sudo-fs `Proxy` advertises through its `get` trap so callers that
+ * monkeypatch fs methods *in place* (e.g. the skill-discovery cache-invalidation
+ * hooks in `skills/catalog.ts`) can detect this handle and refuse to touch it.
+ *
+ * The Proxy is get/set-asymmetric: `get` returns a gating override for a gated
+ * method, while `set` writes straight through to the wrapped target. Reassigning
+ * `fs.writeFile` on it therefore (a) clobbers the target's real method and
+ * (b) leaves the override delegating to the freshly-installed wrapper, whose
+ * captured `original` (read via `get`) is that same override — an infinite
+ * `override → wrapper → override …` recursion that OOMs the kernel worker on the
+ * next gated write. A well-known (registry) symbol lets the catalog skip it with
+ * no import cycle. See `skills/catalog.ts`.
+ */
+export const MONKEYPATCH_UNSAFE_FS: unique symbol = Symbol.for('slicc.fs.monkeypatchUnsafe');
+
 /** Drop-in file for persisted "Always" grants. */
 export const GRANTED_FILE = `${SUDOERS_D_DIR}/granted`;
 
@@ -183,6 +199,10 @@ export function createSudoFs<T extends object>(target: T, deps: SudoFsDeps): T {
 
   return new Proxy(target, {
     get(obj, prop, receiver) {
+      // Advertise the monkeypatch-unsafe marker so in-place fs-method patchers
+      // (skill-discovery cache hooks) skip this get/set-asymmetric Proxy instead
+      // of installing an infinite override↔wrapper recursion. See the symbol's doc.
+      if (prop === MONKEYPATCH_UNSAFE_FS) return true;
       if (typeof prop === 'string' && prop in overrides) return overrides[prop];
       const value = Reflect.get(obj, prop, receiver);
       return typeof value === 'function' ? value.bind(obj) : value;

--- a/packages/webapp/src/shell/vfs-adapter.ts
+++ b/packages/webapp/src/shell/vfs-adapter.ts
@@ -381,87 +381,48 @@ export class VfsAdapter implements IFileSystem {
       // the CacheFS internal isn't available.
       const fastEntries = this.vfs.readDirSync(normalized);
       if (fastEntries !== null) {
-        return this.mapFastEntriesToDirents(fastEntries, normalized);
+        return this.mapFastEntriesToDirents(fastEntries);
       }
 
       // Slow path: async VirtualFS readDir for mounted paths.
       const entries = await this.vfs.readDir(normalized);
-      return this.mapAsyncEntriesToDirents(entries, normalized);
+      return this.mapAsyncEntriesToDirents(entries);
     });
   }
 
-  /** Map synchronous CacheFS entries to DirentEntry[], resolving symlinks. */
-  private async mapFastEntriesToDirents(
-    fastEntries: { name: string; type: string }[],
-    normalized: string
-  ): Promise<DirentEntry[]> {
-    const result: DirentEntry[] = [];
-    for (const e of fastEntries) {
-      if (e.type !== 'symlink') {
-        result.push({
-          name: e.name,
-          isFile: e.type === 'file',
-          isDirectory: e.type === 'directory',
-          isSymbolicLink: false,
-        });
-        continue;
-      }
-      const childPath = normalized === '/' ? `/${e.name}` : `${normalized}/${e.name}`;
-      result.push(await this.resolveSymlinkDirent(e.name, childPath));
-    }
-    return result;
+  /** Map synchronous CacheFS entries to DirentEntry[]. */
+  private mapFastEntriesToDirents(fastEntries: { name: string; type: string }[]): DirentEntry[] {
+    return fastEntries.map((e) => this.entryToDirent(e));
   }
 
-  /** Map async VirtualFS entries to DirentEntry[], resolving symlinks. */
-  private async mapAsyncEntriesToDirents(
-    entries: { name: string; type: string }[],
-    normalized: string
-  ): Promise<DirentEntry[]> {
-    const result: DirentEntry[] = [];
-    for (const e of entries) {
-      if (e.type !== 'symlink') {
-        result.push({
-          name: e.name,
-          isFile: e.type === 'file',
-          isDirectory: e.type === 'directory',
-          isSymbolicLink: false,
-        });
-        continue;
-      }
-      const childPath = normalized === '/' ? `/${e.name}` : `${normalized}/${e.name}`;
-      result.push(await this.resolveSymlinkDirentAsync(e.name, childPath));
-    }
-    return result;
+  /** Map async VirtualFS entries to DirentEntry[]. */
+  private mapAsyncEntriesToDirents(entries: { name: string; type: string }[]): DirentEntry[] {
+    return entries.map((e) => this.entryToDirent(e));
   }
 
-  /** Resolve a symlink entry, trying sync stat first then falling back to async. */
-  private async resolveSymlinkDirent(name: string, childPath: string): Promise<DirentEntry> {
-    // Try synchronous stat first (follows symlinks via CacheFS)
-    const targetStat = this.vfs.statSync(childPath);
-    if (targetStat) {
-      return {
-        name,
-        isFile: targetStat.type === 'file',
-        isDirectory: targetStat.type === 'directory',
-        isSymbolicLink: true,
-      };
+  /**
+   * Convert a readdir entry to a `DirentEntry`. A `Dirent` reflects `lstat`
+   * (the link itself), NOT `stat` (the resolved target) — so a symlink is
+   * reported with `isSymbolicLink: true` and `isFile`/`isDirectory` BOTH false,
+   * exactly like Node's `fs.Dirent`. This is load-bearing: the shell's
+   * recursive walkers (`find`, `grep -r`, `ls -R`) decide whether to descend
+   * from `isDirectory`. Resolving the target here (the previous behavior) made
+   * a symlink-to-directory look like a plain directory, so the walkers followed
+   * it — and a symlink CYCLE recursed forever, allocating millions of path
+   * objects in the kernel worker until V8 OOM'd (~4GB). POSIX `find`/`grep -r`
+   * do not follow symlinks by default; not resolving the target here restores
+   * that contract and is also far cheaper (no per-entry stat).
+   */
+  private entryToDirent(e: { name: string; type: string }): DirentEntry {
+    if (e.type === 'symlink') {
+      return { name: e.name, isFile: false, isDirectory: false, isSymbolicLink: true };
     }
-    // Symlink target is in a mount or unresolvable — fall back to async
-    return this.resolveSymlinkDirentAsync(name, childPath);
-  }
-
-  /** Resolve a symlink entry using async stat. */
-  private async resolveSymlinkDirentAsync(name: string, childPath: string): Promise<DirentEntry> {
-    let isFile = false;
-    let isDir = false;
-    try {
-      const stat = await this.vfs.stat(childPath);
-      isFile = stat.type === 'file';
-      isDir = stat.type === 'directory';
-    } catch {
-      // Dangling symlink
-    }
-    return { name, isFile, isDirectory: isDir, isSymbolicLink: true };
+    return {
+      name: e.name,
+      isFile: e.type === 'file',
+      isDirectory: e.type === 'directory',
+      isSymbolicLink: false,
+    };
   }
 
   async rm(path: string, options?: RmOptions): Promise<void> {

--- a/packages/webapp/src/skills/catalog.ts
+++ b/packages/webapp/src/skills/catalog.ts
@@ -164,41 +164,47 @@ async function discoverCompatibilitySkillCandidates(
   for (let index = 0; index < queue.length; index += 1) {
     const currentPath = queue[index];
 
-    const entries = await readSortedDir(fs, currentPath);
-    for (const entry of entries) {
+    for (const entry of await readSortedDir(fs, currentPath)) {
       if (entry.type !== 'directory') continue;
 
       const childPath = currentPath === '/' ? `/${entry.name}` : `${currentPath}/${entry.name}`;
 
       const source = COMPATIBILITY_DIRECTORY_SOURCES.get(entry.name);
       if (source) {
-        const skillRoot = `${childPath}/skills`;
-        const skillEntries = await readSortedDir(fs, skillRoot);
-
-        for (const skillEntry of skillEntries) {
-          if (skillEntry.type !== 'directory') continue;
-
-          const skillPath = `${skillRoot}/${skillEntry.name}`;
-          const skillFilePath = `${skillPath}/${SKILL_FILE}`;
-          if (!(await pathExists(fs, skillFilePath)) || seenPaths.has(skillPath)) continue;
-
-          seenPaths.add(skillPath);
-          discovered.push({
-            source,
-            sourceRoot: skillRoot,
-            path: skillPath,
-            skillFilePath,
-          });
-        }
+        await collectCompatibilitySkills(fs, source, `${childPath}/skills`, seenPaths, discovered);
       }
 
-      if (PRUNED_COMPATIBILITY_DIRECTORY_NAMES.has(entry.name)) continue;
-
-      queue.push(childPath);
+      if (!PRUNED_COMPATIBILITY_DIRECTORY_NAMES.has(entry.name)) {
+        queue.push(childPath);
+      }
     }
   }
 
   return discovered;
+}
+
+/**
+ * Collect every `SKILL.md`-bearing subdirectory of a single `.agents`/`.claude`
+ * skills root into `discovered`, de-duped via `seenPaths`. Extracted from the
+ * BFS so the walker itself stays under the cognitive-complexity cap.
+ */
+async function collectCompatibilitySkills(
+  fs: VirtualFS,
+  source: Exclude<SkillDiscoverySource, 'native'>,
+  skillRoot: string,
+  seenPaths: Set<string>,
+  discovered: DiscoveredSkillCandidate[]
+): Promise<void> {
+  for (const skillEntry of await readSortedDir(fs, skillRoot)) {
+    if (skillEntry.type !== 'directory') continue;
+
+    const skillPath = `${skillRoot}/${skillEntry.name}`;
+    const skillFilePath = `${skillPath}/${SKILL_FILE}`;
+    if (seenPaths.has(skillPath) || !(await pathExists(fs, skillFilePath))) continue;
+
+    seenPaths.add(skillPath);
+    discovered.push({ source, sourceRoot: skillRoot, path: skillPath, skillFilePath });
+  }
 }
 
 function installCompatibilityCacheInvalidationHooks(fs: VirtualFS): void {

--- a/packages/webapp/src/skills/catalog.ts
+++ b/packages/webapp/src/skills/catalog.ts
@@ -1,4 +1,5 @@
 import type { VirtualFS } from '../fs/index.js';
+import { MONKEYPATCH_UNSAFE_FS } from '../fs/sudo-fs.js';
 import { SKILL_FILE, WORKSPACE_SKILLS_PATH } from './constants.js';
 
 export type SkillDiscoverySource = 'native' | 'agents' | 'claude';
@@ -57,6 +58,18 @@ export async function discoverSkillCandidates(
 }
 
 async function getCompatibilitySkillCandidates(fs: VirtualFS): Promise<DiscoveredSkillCandidate[]> {
+  // A get/set-asymmetric Proxy (the sudo-fs handle that backs the agent shell)
+  // cannot be monkeypatched for cache invalidation without creating an infinite
+  // override↔hook recursion (see installCompatibilityCacheInvalidationHooks), so
+  // we neither hook nor cache it — we always re-discover. This keeps the agent's
+  // skill view correct after an in-shell `upskill`/`skill list` install while
+  // eliminating the OOM cycle. The expense (a full-VFS walk per call) is bounded
+  // and off the hot path.
+  if (isMonkeypatchUnsafeFs(fs)) {
+    const fresh = await discoverCompatibilitySkillCandidates(fs);
+    return fresh.map((candidate) => ({ ...candidate }));
+  }
+
   installCompatibilityCacheInvalidationHooks(fs);
 
   const cacheKey = fs as object;
@@ -68,6 +81,21 @@ async function getCompatibilitySkillCandidates(fs: VirtualFS): Promise<Discovere
   const discovered = await discoverCompatibilitySkillCandidates(fs);
   compatibilityCandidatesCache.set(cacheKey, discovered);
   return discovered.map((candidate) => ({ ...candidate }));
+}
+
+/**
+ * True when `fs` is the sudo-fs Proxy (or any handle advertising
+ * {@link MONKEYPATCH_UNSAFE_FS}). Reassigning a gated method on such a Proxy
+ * clobbers the wrapped target and creates an infinite override↔wrapper
+ * recursion that OOMs the kernel worker, so the cache-invalidation hooks must
+ * never touch it.
+ */
+function isMonkeypatchUnsafeFs(fs: VirtualFS): boolean {
+  try {
+    return (fs as unknown as Record<symbol, unknown>)[MONKEYPATCH_UNSAFE_FS] === true;
+  } catch {
+    return false;
+  }
 }
 
 export function resolveSkillNameCollisions<T>(
@@ -174,6 +202,11 @@ async function discoverCompatibilitySkillCandidates(
 }
 
 function installCompatibilityCacheInvalidationHooks(fs: VirtualFS): void {
+  // Defense in depth: never monkeypatch a get/set-asymmetric Proxy (the sudo-fs
+  // handle) — see isMonkeypatchUnsafeFs. The sole caller already short-circuits
+  // such handles, but a future caller must be safe too.
+  if (isMonkeypatchUnsafeFs(fs)) return;
+
   const cacheKey = fs as object;
   if (compatibilityCacheHooksInstalled.has(cacheKey)) return;
   compatibilityCacheHooksInstalled.add(cacheKey);

--- a/packages/webapp/tests/shell/vfs-adapter.test.ts
+++ b/packages/webapp/tests/shell/vfs-adapter.test.ts
@@ -203,4 +203,68 @@ describe('VfsAdapter', () => {
       expect(await freshAdapter.exists('/usr/bin')).toBe(true);
     });
   });
+
+  describe('readdirWithFileTypes — symlink Dirent semantics (no-follow)', () => {
+    // A `Dirent` reflects `lstat` (the link itself), NOT `stat` (the target).
+    // Reporting a symlink-to-directory as `isDirectory: true` makes the shell's
+    // recursive walkers (`find`, `grep -r`, `ls -R`) descend into it, and a
+    // symlink CYCLE then recurses forever → millions of path objects → V8 OOM.
+    // POSIX `find`/`grep -r` do NOT follow symlinks by default; the Dirent must
+    // report `isDirectory: false, isSymbolicLink: true` so the walkers stop.
+
+    it('reports a symlink-to-directory as a symlink, not a directory', async () => {
+      await vfs.mkdir('/dir/sub', { recursive: true });
+      await vfs.symlink('/dir', '/dir/sub/loop'); // /dir/sub/loop -> /dir (a cycle)
+
+      const entries = await adapter.readdirWithFileTypes('/dir/sub');
+      const loop = entries.find((e) => e.name === 'loop');
+
+      expect(loop).toEqual({
+        name: 'loop',
+        isFile: false,
+        isDirectory: false,
+        isSymbolicLink: true,
+      });
+    });
+
+    it('reports a symlink-to-file as a symlink, not a file', async () => {
+      await vfs.mkdir('/d', { recursive: true });
+      await vfs.writeFile('/d/real.txt', 'hi');
+      await vfs.symlink('/d/real.txt', '/d/link.txt');
+
+      const entries = await adapter.readdirWithFileTypes('/d');
+      const link = entries.find((e) => e.name === 'link.txt');
+
+      expect(link).toEqual({
+        name: 'link.txt',
+        isFile: false,
+        isDirectory: false,
+        isSymbolicLink: true,
+      });
+    });
+
+    it('a recursive readdir walk over a symlink cycle terminates (no infinite descent)', async () => {
+      await vfs.mkdir('/root/a', { recursive: true });
+      await vfs.writeFile('/root/a/f.txt', 'x');
+      await vfs.symlink('/root', '/root/a/loop'); // cycle: /root/a/loop -> /root
+
+      // Mirror how just-bash's `find`/`grep -r` recurse: descend only into
+      // entries the Dirent marks as a real directory. With the no-follow fix
+      // the symlink is not a directory, so the walk is finite.
+      const visited: string[] = [];
+      const walk = async (path: string): Promise<void> => {
+        if (visited.length > 10_000) throw new Error('walk did not terminate — symlink followed');
+        for (const e of await adapter.readdirWithFileTypes(path)) {
+          const child = path === '/' ? `/${e.name}` : `${path}/${e.name}`;
+          visited.push(child);
+          if (e.isDirectory) await walk(child);
+        }
+      };
+
+      await expect(walk('/root')).resolves.toBeUndefined();
+      // /root/a, /root/a/f.txt, /root/a/loop — and crucially NOT /root/a/loop/a/...
+      expect(visited).toContain('/root/a/loop');
+      expect(visited.some((p) => p.includes('/loop/a'))).toBe(false);
+    });
+  });
 });

--- a/packages/webapp/tests/skills/catalog.test.ts
+++ b/packages/webapp/tests/skills/catalog.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import 'fake-indexeddb/auto';
 import { IDBFactory } from 'fake-indexeddb';
 import { VirtualFS } from '../../src/fs/index.js';
+import { createSudoFs, MONKEYPATCH_UNSAFE_FS } from '../../src/fs/sudo-fs.js';
+import { emptyPolicy } from '../../src/shell/sudo/sudoers.js';
 import { discoverSkillCandidates, resolveSkillNameCollisions } from '../../src/skills/catalog.js';
 
 describe('discoverSkillCandidates', () => {
@@ -114,6 +116,77 @@ describe('discoverSkillCandidates', () => {
     expect(candidates.map((candidate) => candidate.path)).toEqual([
       '/repo/.claude/skills/visible-skill',
     ]);
+  });
+});
+
+describe('discoverSkillCandidates over a sudo-fs Proxy (OOM regression)', () => {
+  let raw: VirtualFS;
+  let gated: VirtualFS;
+
+  const noopBroker = {
+    async requestApproval() {
+      return { decision: 'allow' as const };
+    },
+  };
+
+  beforeEach(async () => {
+    globalThis.indexedDB = new IDBFactory();
+    raw = await VirtualFS.create({ wipe: true });
+    // Empty policy => nothing is gated, so reads/writes pass straight through —
+    // isolating the discovery/monkeypatch interaction from approval prompts.
+    gated = createSudoFs(raw, { broker: noopBroker, getPolicy: () => emptyPolicy() });
+  });
+
+  it('advertises the monkeypatch-unsafe marker', () => {
+    expect((gated as unknown as Record<symbol, unknown>)[MONKEYPATCH_UNSAFE_FS]).toBe(true);
+    expect((raw as unknown as Record<symbol, unknown>)[MONKEYPATCH_UNSAFE_FS]).toBeUndefined();
+  });
+
+  it('does NOT monkeypatch the wrapped target (the override↔hook recursion that OOMed the worker)', async () => {
+    await raw.mkdir('/workspace/.claude/skills/foo', { recursive: true });
+    await raw.writeFile('/workspace/.claude/skills/foo/SKILL.md', '# foo');
+
+    // Capturing the wrapped target's gated methods BEFORE discovery: the bug
+    // reassigned `raw.writeFile`/`raw.mkdir`/etc. on the Proxy's target (the
+    // `set` writes through), leaving the sudo override delegating to the hook
+    // and the hook calling back into the override — an unbounded async cycle.
+    const before = {
+      writeFile: raw.writeFile,
+      mkdir: raw.mkdir,
+      rm: raw.rm,
+    };
+
+    const candidates = await discoverSkillCandidates(gated);
+
+    // Discovery still works through the gated handle...
+    expect(candidates.map((c) => c.path)).toContain('/workspace/.claude/skills/foo');
+    // ...without having clobbered the wrapped target's real methods.
+    expect(raw.writeFile).toBe(before.writeFile);
+    expect(raw.mkdir).toBe(before.mkdir);
+    expect(raw.rm).toBe(before.rm);
+
+    // A gated write reaches the real fs exactly once (no recursion) and persists.
+    let realWriteCalls = 0;
+    const realWrite = raw.writeFile.bind(raw);
+    raw.writeFile = (async (path: string, content: string | Uint8Array) => {
+      realWriteCalls += 1;
+      return realWrite(path, content);
+    }) as typeof raw.writeFile;
+    await gated.writeFile('/tmp/probe.txt', 'ok');
+    expect(realWriteCalls).toBe(1);
+    expect(await raw.readTextFile('/tmp/probe.txt')).toBe('ok');
+  });
+
+  it('returns the same candidates whether discovery runs over the raw fs or the gated Proxy', async () => {
+    await raw.mkdir('/repo/.agents/skills/agent-skill', { recursive: true });
+    await raw.writeFile('/repo/.agents/skills/agent-skill/SKILL.md', '# agent');
+    await raw.mkdir('/workspace/skills/native-skill', { recursive: true });
+    await raw.writeFile('/workspace/skills/native-skill/SKILL.md', '# native');
+
+    const overRaw = (await discoverSkillCandidates(raw)).map((c) => c.path);
+    const overGated = (await discoverSkillCandidates(gated)).map((c) => c.path);
+
+    expect(overGated).toEqual(overRaw);
   });
 });
 


### PR DESCRIPTION
## Problem

A fresh report (commit `e60b2620`): the prompt *"using stardust create a more contemporary version of the page in the current tab"* drives the kernel worker to ~4GB and crashes it with `Ineffective mark-compacts near heap limit` — within a minute. Reproduces in **both** standalone and the extension.

## Root cause

The skill-discovery compatibility cache (`skills/catalog.ts`) invalidates itself by **monkeypatching fs write methods in place** — `mutableFs.writeFile = async (...) => { await original.apply(fs, args); cache.delete(key); }` for `writeFile`/`mkdir`/`rm`/`rename`/`mount`/`unmount`.

The agent shell hands discovery the **sudo-fs `Proxy`** (`fs/sudo-fs.ts`, the gated handle backing both file tools and the shell). That Proxy is **get/set-asymmetric**:

- `get('writeFile')` → a *gating override* that delegates dynamically to `target.writeFile`.
- `set('writeFile', …)` → writes straight **through to the wrapped target** (no `set` trap).

So when discovery runs over the gated handle, reassigning `gatedFs.writeFile`:

1. captures `original = gatedFs.writeFile` (via `get`) = the **override**, then
2. writes the new wrapper onto the **target** (`rawFs.writeFile = wrapper`).

Now the override (which re-reads `target.writeFile` each call) calls the wrapper, whose captured `original` is the override → **unbounded `override ↔ wrapper` async recursion**. The next gated write — stardust `upskill` → `playwright-cli` writing `/.playwright/session.md` — triggers it and the worker balloons until V8 OOMs.

This is intermittent by nature: boot-time `loadSkills` uses the *unwrapped* fs, so it only fires on a **first-time, in-shell skill install** (when the agent runs `upskill`/`skill list` over the gated handle). Once the skill is installed, the path isn't re-run — which is exactly the reported "sometimes" behavior.

### Forensics

CDP heap sampling during the balloon showed the sudo write-override invoked **20,000×** while `VirtualFS.writeFile` was **never reached** — the hallmark of a wrapper cycle that never bottoms out. Stack capture confirmed the frames alternate `catalog-hook ↔ sudo-override`.

### Where it was introduced

This is a *collision* of two changes, latent until both were present:

- The **in-place fs-method monkeypatch** in `catalog.ts` (`installCompatibilityCacheInvalidationHooks`) is old and was harmless on its own — it predates the package split and traces back through #187 (the monorepo restructure).
- The cycle only became reachable when **#829 (`feat(sudo): explicit native approval for sensitive agent actions`, merged 2026-06-06)** introduced `createSudoFs` and wired the **get/set-asymmetric sudo-fs `Proxy`** in as the agent shell's fs handle (`scoops/scoop-context.ts` → `WasmShell`). From that point, an in-shell `upskill`/`skill list` handed skill discovery a Proxy whose methods cannot be safely reassigned, and the latent monkeypatch turned into the override↔wrapper recursion.

So this is **not a regression introduced just before the report** — it has been live since the sudo feature merged (~2026-06-06), which matches the "it could have been there before" observation. #829 is the change to anchor the fix against; the monkeypatch is the pre-existing fragility it collided with.

## Fix

- `fs/sudo-fs.ts`: the Proxy advertises a `MONKEYPATCH_UNSAFE_FS` marker (a `Symbol.for` registry symbol) through its `get` trap.
- `skills/catalog.ts`: `getCompatibilitySkillCandidates` detects the marker and **skips both the in-place hooks and the cache** for such a handle, always re-discovering instead. The agent's skill view stays correct after an in-shell install, with no cycle. `installCompatibilityCacheInvalidationHooks` keeps a defense-in-depth guard so any future caller is safe too.

### Bonus hardening (second OOM vector)

- `shell/vfs-adapter.ts`: `readdir` now reports symlinks per Node `Dirent`/`lstat` semantics (`isFile`/`isDirectory` both `false`, `isSymbolicLink: true`) instead of resolving the target. Previously a symlink-to-directory looked like a plain directory, so `find`/`grep -r`/`ls -R` followed it — and a symlink **cycle** recursed forever, allocating path objects until OOM. POSIX tools don't follow symlinks by default; this restores that and is cheaper (no per-entry stat). It also makes the discovery BFS correctly skip symlinks.

## Verification

Reset-flail reproduction on the exact reported prompt (skills removed + cone IDB cleared so the agent installs stardust fresh):

- **Before:** heap balloons 18MB → 1.6GB+ and the worker dies within ~20s.
- **After:** the agent installs the full stardust bundle (`extract`/`direct`/`prototype`) and runs **33 `playwright-cli` `session.md` writes** — the precise writes that crashed before — with a **35.6MB peak heap**; worker survives indefinitely. Zero `RangeError`/OOM in logs.

## Gates

- ✅ `lint` ✅ `typecheck` ✅ `test` (7593 passed) ✅ `test:coverage:webapp` ✅ `build` (webapp) ✅ `build` (chrome-extension)
- New regression tests in `tests/skills/catalog.test.ts`: discovery over a real `createSudoFs` Proxy must not clobber the wrapped target's methods, a gated write must reach the real fs exactly once, and results match the unwrapped path. Symlink-Dirent tests in `tests/shell/vfs-adapter.test.ts`.

## Cross-runtime parity

The crash and fix are in the shared `webapp` core (kernel worker), so both the standalone (DedicatedWorker) and extension (offscreen) floats are fixed by the same change. No float-specific code touched.
