### PR TITLE
chore(hooks): enforce linear history locally via pre-push + pre-merge-commit

### DIFF
--- a/.husky/pre-merge-commit
+++ b/.husky/pre-merge-commit
@@ -1,0 +1,28 @@
+set -e
+
+# Fail fast when a merge would create a merge commit on a feature branch.
+# The merge queue requires a linear history (CI job: linear-history), so
+# feature branches must rebase onto the base instead of merging it in.
+#
+# This hook only fires for merges that create a commit — fast-forward and
+# squash merges keep history linear and pass through untouched.
+# Escape hatch: `git merge --no-verify`.
+
+branch="$(git symbolic-ref --short -q HEAD || echo)"
+if [ "$branch" = "main" ] || [ -z "$branch" ]; then
+  exit 0
+fi
+
+echo "✗ Refusing to create a merge commit on '$branch'." >&2
+echo "" >&2
+echo "The merge queue requires a linear history (CI job: linear-history)." >&2
+echo "Rebase onto the base branch instead of merging it in:" >&2
+echo "" >&2
+echo "  git merge --abort        # undo this in-progress merge" >&2
+echo "  git fetch origin" >&2
+echo "  git rebase origin/main" >&2
+echo "  git push --force-with-lease" >&2
+echo "" >&2
+echo "Tip: 'git config pull.rebase true' makes 'git pull' rebase by default." >&2
+echo "If you really need this merge commit, re-run with --no-verify." >&2
+exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,37 @@
+set -e
+
+# Enforce a linear PR history locally — the merge queue rejects branches that
+# carry merge commits, and the CI `linear-history` job fails them at PR time.
+# This mirrors that gate before the push leaves your machine. It reuses the
+# same script CI runs: packages/dev-tools/tools/check-linear-history.sh.
+#
+# A pre-push hook (not pre-commit) is the right place: git skips pre-commit on
+# merge commits, so a clean `git merge`/`git pull` would slip past it.
+#
+# stdin lines: <local ref> <local oid> <remote ref> <remote oid>
+# Escape hatch: `git push --no-verify`.
+
+DEFAULT_BRANCH="main"
+BASE_REF="origin/$DEFAULT_BRANCH"
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null 2>&1; then
+  # Fresh clone without an origin/main ref — fall back to the local branch.
+  BASE_REF="$DEFAULT_BRANCH"
+fi
+
+status=0
+while read -r local_ref local_oid remote_ref remote_oid; do
+  # Skip branch deletions (local oid is all zeros).
+  case "$local_oid" in
+    *[!0]*) ;;
+    *) continue ;;
+  esac
+  # Never gate the base branch itself.
+  case "$remote_ref" in
+    */"$DEFAULT_BRANCH") continue ;;
+  esac
+  if ! bash packages/dev-tools/tools/check-linear-history.sh "$BASE_REF" "$local_oid"; then
+    status=1
+  fi
+done
+
+exit "$status"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -25,10 +25,11 @@ while read -r local_ref local_oid remote_ref remote_oid; do
     *[!0]*) ;;
     *) continue ;;
   esac
-  # Never gate the base branch itself.
-  case "$remote_ref" in
-    */"$DEFAULT_BRANCH") continue ;;
-  esac
+  # Never gate the base branch itself. Match the exact heads ref so branches
+  # like `feature/main` aren't mistaken for the base and skipped.
+  if [ "$remote_ref" = "refs/heads/$DEFAULT_BRANCH" ]; then
+    continue
+  fi
   if ! bash packages/dev-tools/tools/check-linear-history.sh "$BASE_REF" "$local_oid"; then
     status=1
   fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ Use the ice cream terms in code review comments and docs when they match the dom
 ## Git Conventions
 
 - Keep commits focused and package-local when possible.
+- **Linear history**: the merge queue and CI `linear-history` job reject branches with merge commits. Rebase onto the base (`git rebase origin/main`) instead of merging it in (`git config pull.rebase true` helps). Husky enforces this locally via `.husky/pre-merge-commit` and `.husky/pre-push` (reusing `packages/dev-tools/tools/check-linear-history.sh`).
 - Do not hand-edit generated output in `dist/`.
 - Webapp git behavior is implemented with `isomorphic-git` over the OPFS-backed VirtualFS.
 - Auth uses `git config github.token <PAT>`.


### PR DESCRIPTION
## Why

The merge queue (and the CI `linear-history` job) reject branches that carry merge commits, but only **after** a PR has already gone green and burned a full CI run. This was hit on #981: a `git merge origin/main` to resolve a conflict produced a merge commit that the gate rejected. These hooks catch it on the developer's machine first.

## What

- **`.husky/pre-push`** mirrors the CI gate before the push leaves your machine, reusing `packages/dev-tools/tools/check-linear-history.sh` against `origin/main`. It walks the pushed refs, skips branch deletions and pushes of the base branch itself, and rejects any branch carrying merge commits.
- **`.husky/pre-merge-commit`** fails fast the moment a merge would create a merge commit on a feature branch, pointing at `git rebase` instead. Fast-forward and squash merges keep history linear and pass through untouched.
- Documents the workflow in the root `CLAUDE.md` Git Conventions section.

## Why pre-push, not pre-commit

Git does **not** run `pre-commit` when a `git merge` / `git pull` creates a merge commit (it only fires on the manual conflict-resolution `git commit`). A `pre-commit` hook would therefore miss the most common case — a clean auto-merge. `pre-push` is the faithful local mirror of the CI check; `pre-merge-commit` adds earlier feedback at merge time.

Both hooks honor `--no-verify` as an escape hatch.

## Testing

Smoke-tested both hooks in a throwaway git repo:

| Case | Result |
| --- | --- |
| pre-push, linear feature branch | exit 0 (pass) |
| pre-push, branch with a real merge commit | exit 1 (rejected, with rebase guidance) |
| pre-push, pushing `main` itself | exit 0 (skipped) |
| pre-push, branch deletion (zero oid) | exit 0 (skipped) |
| pre-merge-commit on a feature branch | exit 1 (rejected) |
| pre-merge-commit on `main` | exit 0 (pass) |

`npm run lint:ci` and the doc-size budget check pass.
