### PR TITLE
feat(composer): Tab accepts the suggested follow-up instead of moving focus

### DIFF
--- a/packages/webapp/src/ui/wc/wc-placeholder.ts
+++ b/packages/webapp/src/ui/wc/wc-placeholder.ts
@@ -2,9 +2,11 @@
  * Suggested composer placeholder — the legacy ChatPanel's
  * `refreshSuggestedPlaceholder` ported to the WC shell. After each finished
  * turn, a cheap one-shot LLM call (`quickLabel`) proposes the user's likely
- * next prompt from the recent conversation; it lands as the textarea
- * placeholder. Fails soft to the static default on every edge (no provider,
- * no conversation yet, user already typing, call failure).
+ * next prompt from the recent conversation; it lands on the input card's
+ * `suggestion` attribute, which `<slicc-input-card>` shows as the textarea
+ * placeholder and lets Tab accept into the textarea for submission. Fails
+ * soft to the static default placeholder on every edge (no provider, no
+ * conversation yet, user already typing, call failure).
  */
 
 import type { ChatMessage } from '../types.js';
@@ -78,6 +80,26 @@ export interface WirePlaceholderDeps {
 }
 
 /**
+ * Land a refreshed placeholder on the input card. A real suggestion goes to
+ * the `suggestion` attribute — `<slicc-input-card>` shows it as the
+ * placeholder and lets Tab accept it into the textarea — while the static
+ * default clears any stale suggestion and restores the plain placeholder
+ * (which Tab must NOT fill; it keeps native focus navigation).
+ */
+export function applySuggestedPlaceholder(
+  inputCard: HTMLElement,
+  text: string,
+  defaultPlaceholder: string
+): void {
+  if (text === defaultPlaceholder) {
+    inputCard.removeAttribute('suggestion');
+    inputCard.setAttribute('placeholder', text);
+  } else {
+    inputCard.setAttribute('suggestion', text);
+  }
+}
+
+/**
  * Returns the trigger the boot wires to "turn finished" moments: aborts any
  * in-flight suggestion, then regenerates from the current conversation.
  */
@@ -91,7 +113,8 @@ export function createPlaceholderRefresher(deps: WirePlaceholderDeps): () => voi
     void refreshSuggestedPlaceholder({
       messages: deps.getMessages(),
       currentValue: deps.inputCard.value ?? '',
-      setPlaceholder: (text) => deps.inputCard.setAttribute('placeholder', text),
+      setPlaceholder: (text) =>
+        applySuggestedPlaceholder(deps.inputCard, text, deps.defaultPlaceholder),
       defaultPlaceholder: deps.defaultPlaceholder,
       signal: abort.signal,
     }).catch(() => undefined);

--- a/packages/webapp/tests/ui/wc/wc-placeholder.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-placeholder.test.ts
@@ -11,6 +11,7 @@ installWcDomStubs();
 
 import type { ChatMessage } from '../../../src/ui/types.js';
 import {
+  applySuggestedPlaceholder,
   createPlaceholderRefresher,
   placeholderTranscript,
   refreshSuggestedPlaceholder,
@@ -108,8 +109,27 @@ describe('refreshSuggestedPlaceholder', () => {
   });
 });
 
+describe('applySuggestedPlaceholder', () => {
+  it('lands a real suggestion on the suggestion attribute (Tab-to-accept)', () => {
+    const inputCard = document.createElement('slicc-input-card');
+    inputCard.setAttribute('placeholder', 'default');
+    applySuggestedPlaceholder(inputCard, 'Now add dark mode?', 'default');
+    expect(inputCard.getAttribute('suggestion')).toBe('Now add dark mode?');
+    // The static placeholder stays in place beneath the suggestion.
+    expect(inputCard.getAttribute('placeholder')).toBe('default');
+  });
+
+  it('restores the plain placeholder and clears a stale suggestion on the default', () => {
+    const inputCard = document.createElement('slicc-input-card');
+    inputCard.setAttribute('suggestion', 'stale suggestion');
+    applySuggestedPlaceholder(inputCard, 'default', 'default');
+    expect(inputCard.hasAttribute('suggestion')).toBe(false);
+    expect(inputCard.getAttribute('placeholder')).toBe('default');
+  });
+});
+
 describe('createPlaceholderRefresher', () => {
-  it('writes the suggestion onto the input card placeholder, skipping disabled (frozen) views', async () => {
+  it('writes the refreshed placeholder onto the input card, skipping disabled (frozen) views', async () => {
     const inputCard = document.createElement('slicc-input-card') as HTMLElement & {
       value?: string;
     };
@@ -127,9 +147,11 @@ describe('createPlaceholderRefresher', () => {
     inputCard.removeAttribute('disabled');
     refresh();
     // The real quick-llm path resolves null in tests (no provider/key) —
-    // fail-soft means the default lands.
+    // fail-soft means the default lands as the plain placeholder, with no
+    // Tab-acceptable suggestion left behind.
     await vi.waitFor(() => {
       expect(inputCard.getAttribute('placeholder')).toBe('default');
     });
+    expect(inputCard.hasAttribute('suggestion')).toBe(false);
   });
 });

--- a/packages/webcomponents/src/composer/slicc-input-card.stories.ts
+++ b/packages/webcomponents/src/composer/slicc-input-card.stories.ts
@@ -6,6 +6,7 @@ import './slicc-input-card.js';
 interface InputCardArgs {
   value?: string;
   placeholder?: string;
+  suggestion?: string;
   disabled?: boolean;
 }
 
@@ -25,10 +26,11 @@ function inComposer(card: HTMLElement): HTMLElement {
   return band;
 }
 
-function buildCard({ value, placeholder, disabled }: InputCardArgs): HTMLElement {
+function buildCard({ value, placeholder, suggestion, disabled }: InputCardArgs): HTMLElement {
   const el = document.createElement('slicc-input-card');
   if (value != null) el.setAttribute('value', value);
   if (placeholder != null) el.setAttribute('placeholder', placeholder);
+  if (suggestion != null) el.setAttribute('suggestion', suggestion);
   if (disabled) el.setAttribute('disabled', '');
   return el;
 }
@@ -40,6 +42,10 @@ const meta: Meta<InputCardArgs> = {
   argTypes: {
     value: { control: 'text', description: 'Textarea contents' },
     placeholder: { control: 'text', description: 'Textarea placeholder' },
+    suggestion: {
+      control: 'text',
+      description: 'Suggested follow-up shown as the placeholder; Tab accepts it',
+    },
     disabled: { control: 'boolean', description: 'Disable the textarea' },
   },
   render: (args) => inComposer(buildCard(args)),
@@ -87,6 +93,16 @@ export const MultiLine: Story = {
 /** Custom placeholder copy. */
 export const CustomPlaceholder: Story = {
   args: { placeholder: 'Describe the change you want…' },
+};
+
+/**
+ * Suggested follow-up — an LLM-proposed next prompt on the `suggestion`
+ * attribute: shown as the placeholder of the empty composer, and Tab accepts
+ * it into the textarea (instead of tabbing focus to the + menu) so Enter can
+ * submit it. Focus the textarea and press Tab to try it.
+ */
+export const SuggestedFollowUp: Story = {
+  args: { suggestion: 'Now add dark mode to the hero?' },
 };
 
 /** Disabled — textarea is non-interactive (e.g. while a turn is streaming). */

--- a/packages/webcomponents/src/composer/slicc-input-card.ts
+++ b/packages/webcomponents/src/composer/slicc-input-card.ts
@@ -122,12 +122,15 @@ const DEFAULT_PLACEHOLDER = 'Ask sliccy, or describe a change…';
  * composer and Tab accepts it into the textarea — instead of tabbing focus
  * away to the toolbar — so the very next Enter can submit it. Tab keeps its
  * native focus-navigation whenever text is present, no suggestion is set, or
- * Shift/a modifier is held.
+ * Shift/a modifier is held. The suggestion is single-use: accepting it (Tab)
+ * or submitting anything drops the attribute, so a stale prompt is never
+ * re-offered on the cleared composer mid-turn (hosts refresh it on turn end).
  *
  * @attr value - the textarea contents (reflected to/from the property)
  * @attr placeholder - textarea placeholder (defaults to the prototype copy)
  * @attr suggestion - a suggested follow-up prompt; shown as the placeholder
- *   when the composer is empty, accepted into the textarea on Tab
+ *   when the composer is empty, accepted into the textarea on Tab; consumed
+ *   by acceptance and by any submit
  * @attr disabled - boolean; disables the textarea
  * @csspart card - the rounded white card surface (carries the focus ring)
  * @csspart textarea - the borderless autosizing `<textarea>`
@@ -316,6 +319,10 @@ export class SliccInputCard extends HTMLElement {
       const suggestion = this.suggestion;
       if (suggestion && this.#textarea.value === '') {
         e.preventDefault();
+        // Consume the suggestion: once accepted it must not stay Tab-fillable,
+        // or the post-submit clear() would re-offer it and a second Tab+Enter
+        // could enqueue a duplicate prompt mid-turn.
+        this.removeAttribute('suggestion');
         const ta = this.#textarea;
         ta.value = suggestion;
         ta.setSelectionRange(suggestion.length, suggestion.length);
@@ -361,6 +368,10 @@ export class SliccInputCard extends HTMLElement {
     if (this.disabled) return;
     const value = this.#textarea.value;
     if (value.trim() === '') return;
+    // Any submission invalidates the conversational context the suggestion
+    // was generated from — drop it so the post-submit empty composer doesn't
+    // re-offer a stale Tab-fillable prompt (the host refreshes it on turn end).
+    this.removeAttribute('suggestion');
     this.dispatchEvent(
       new CustomEvent('submit', { bubbles: true, composed: true, detail: { value } })
     );

--- a/packages/webcomponents/src/composer/slicc-input-card.ts
+++ b/packages/webcomponents/src/composer/slicc-input-card.ts
@@ -117,10 +117,17 @@ const DEFAULT_PLACEHOLDER = 'Ask sliccy, or describe a change…';
  *
  * Behavior: the textarea autosizes from a 28px min-height up to a 140px max
  * (then scrolls). Enter sends (emits `submit`); Shift+Enter inserts a newline.
- * Every keystroke emits `input`.
+ * Every keystroke emits `input`. When a `suggestion` is set (e.g. the host's
+ * LLM-proposed follow-up prompt), it is shown as the placeholder of an empty
+ * composer and Tab accepts it into the textarea — instead of tabbing focus
+ * away to the toolbar — so the very next Enter can submit it. Tab keeps its
+ * native focus-navigation whenever text is present, no suggestion is set, or
+ * Shift/a modifier is held.
  *
  * @attr value - the textarea contents (reflected to/from the property)
  * @attr placeholder - textarea placeholder (defaults to the prototype copy)
+ * @attr suggestion - a suggested follow-up prompt; shown as the placeholder
+ *   when the composer is empty, accepted into the textarea on Tab
  * @attr disabled - boolean; disables the textarea
  * @csspart card - the rounded white card surface (carries the focus ring)
  * @csspart textarea - the borderless autosizing `<textarea>`
@@ -136,7 +143,7 @@ const DEFAULT_PLACEHOLDER = 'Ask sliccy, or describe a change…';
  *   carries the submitted text (suppressed when the textarea is empty/disabled)
  */
 export class SliccInputCard extends HTMLElement {
-  static readonly observedAttributes = ['value', 'placeholder', 'disabled'];
+  static readonly observedAttributes = ['value', 'placeholder', 'suggestion', 'disabled'];
 
   #card!: HTMLDivElement;
   #textarea!: HTMLTextAreaElement;
@@ -180,6 +187,20 @@ export class SliccInputCard extends HTMLElement {
   set placeholder(value: string | null) {
     if (value == null) this.removeAttribute('placeholder');
     else this.setAttribute('placeholder', value);
+  }
+
+  /**
+   * A suggested follow-up prompt (e.g. the host's LLM-proposed next message).
+   * Shown as the placeholder while the composer is empty; Tab accepts it into
+   * the textarea so it can be submitted with Enter.
+   */
+  get suggestion(): string | null {
+    return this.getAttribute('suggestion');
+  }
+
+  set suggestion(value: string | null) {
+    if (value == null || value === '') this.removeAttribute('suggestion');
+    else this.setAttribute('suggestion', value);
   }
 
   /** Whether the textarea is disabled. */
@@ -254,7 +275,9 @@ export class SliccInputCard extends HTMLElement {
   #syncAttributes(): void {
     if (!this.#built) return;
     const ta = this.#textarea;
-    ta.placeholder = this.placeholder;
+    // A pending suggestion takes the placeholder slot — it only shows while
+    // the textarea is empty, which is exactly when Tab can accept it.
+    ta.placeholder = this.suggestion ?? this.placeholder;
     ta.disabled = this.disabled;
     const value = this.getAttribute('value') ?? '';
     if (ta.value !== value) ta.value = value;
@@ -282,6 +305,25 @@ export class SliccInputCard extends HTMLElement {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       this.#emitSubmit();
+      return;
+    }
+    // Tab-to-accept: an empty composer showing a suggested follow-up fills the
+    // textarea with the suggestion instead of moving focus to the toolbar's
+    // + menu, so the very next Enter can submit it. Any other Tab (text
+    // present, no suggestion, Shift or a modifier held) keeps native focus
+    // navigation for keyboard accessibility.
+    if (e.key === 'Tab' && !e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey) {
+      const suggestion = this.suggestion;
+      if (suggestion && this.#textarea.value === '') {
+        e.preventDefault();
+        const ta = this.#textarea;
+        ta.value = suggestion;
+        ta.setSelectionRange(suggestion.length, suggestion.length);
+        // Route through the input pipeline so the reflected attribute, the
+        // autosize pass, and the host-facing CustomEvent('input') all fire
+        // exactly as if the text had been typed.
+        ta.dispatchEvent(new Event('input', { bubbles: true }));
+      }
       return;
     }
     // History walking: ArrowUp with the caret ALREADY at the very start

--- a/packages/webcomponents/tests/composer/slicc-input-card.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-input-card.test.ts
@@ -165,6 +165,34 @@ describe('slicc-input-card', () => {
       expect(document.activeElement).toBe(ta);
       expect(ta.selectionStart).toBe('Now add dark mode?'.length);
       expect(ta.selectionEnd).toBe('Now add dark mode?'.length);
+      // Acceptance consumes the suggestion — clearing the draft must not
+      // re-offer it, or a second Tab+Enter could enqueue a duplicate prompt.
+      expect(el.hasAttribute('suggestion')).toBe(false);
+      el.clear();
+      expect(ta.placeholder).toBe('Ask sliccy, or describe a change…');
+      expect(tab(el).defaultPrevented).toBe(false);
+    });
+
+    it('any submit drops a pending suggestion (stale context)', () => {
+      const el = mount((e) => {
+        e.suggestion = 'suggested follow-up';
+        e.value = 'manually typed instead';
+      });
+      enter(el);
+      expect(el.hasAttribute('suggestion')).toBe(false);
+      expect(textarea(el).placeholder).toBe('Ask sliccy, or describe a change…');
+    });
+
+    it('a suppressed submit (empty or disabled) keeps the suggestion', () => {
+      const el = mount((e) => {
+        e.suggestion = 'still pending';
+      });
+      enter(el); // empty — suppressed
+      expect(el.getAttribute('suggestion')).toBe('still pending');
+      el.value = 'ready';
+      el.disabled = true;
+      enter(el); // disabled — suppressed
+      expect(el.getAttribute('suggestion')).toBe('still pending');
     });
 
     it('submits the accepted suggestion on the next Enter', () => {

--- a/packages/webcomponents/tests/composer/slicc-input-card.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-input-card.test.ts
@@ -123,6 +123,88 @@ describe('slicc-input-card', () => {
       expect(el.hasAttribute('disabled')).toBe(true);
       expect(textarea(el).disabled).toBe(true);
     });
+
+    it('reflects suggestion and shows it as the textarea placeholder', () => {
+      const el = mount((e) => {
+        e.suggestion = 'Now add dark mode?';
+      });
+      expect(el.getAttribute('suggestion')).toBe('Now add dark mode?');
+      expect(textarea(el).placeholder).toBe('Now add dark mode?');
+      el.suggestion = null;
+      expect(el.hasAttribute('suggestion')).toBe(false);
+      expect(textarea(el).placeholder).toBe('Ask sliccy, or describe a change…');
+    });
+  });
+
+  describe('suggestion Tab-to-accept', () => {
+    function tab(el: SliccInputCard, init: KeyboardEventInit = {}): KeyboardEvent {
+      const ev = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      });
+      textarea(el).dispatchEvent(ev);
+      return ev;
+    }
+
+    it('Tab on an empty composer accepts the suggestion instead of moving focus', () => {
+      const el = mount((e) => {
+        e.suggestion = 'Now add dark mode?';
+      });
+      const seen: string[] = [];
+      el.addEventListener('input', (e) => seen.push((e as Event as CustomEvent).detail.value));
+      textarea(el).focus();
+      const ev = tab(el);
+      expect(ev.defaultPrevented).toBe(true);
+      expect(el.value).toBe('Now add dark mode?');
+      expect(el.getAttribute('value')).toBe('Now add dark mode?');
+      expect(seen).toEqual(['Now add dark mode?']);
+      // Focus stays in the textarea with the caret at the end, ready to edit.
+      const ta = textarea(el);
+      expect(document.activeElement).toBe(ta);
+      expect(ta.selectionStart).toBe('Now add dark mode?'.length);
+      expect(ta.selectionEnd).toBe('Now add dark mode?'.length);
+    });
+
+    it('submits the accepted suggestion on the next Enter', () => {
+      const el = mount((e) => {
+        e.suggestion = 'Now add dark mode?';
+      });
+      const submit = vi.fn();
+      el.addEventListener('submit', (e) => submit((e as Event as CustomEvent).detail.value));
+      tab(el);
+      enter(el);
+      expect(submit).toHaveBeenCalledWith('Now add dark mode?');
+    });
+
+    it('keeps native Tab focus-nav when text is present', () => {
+      const el = mount((e) => {
+        e.suggestion = 'suggested';
+        e.value = 'typed draft';
+      });
+      const ev = tab(el);
+      expect(ev.defaultPrevented).toBe(false);
+      expect(el.value).toBe('typed draft');
+    });
+
+    it('keeps native Tab focus-nav when no suggestion is set (default placeholder)', () => {
+      const el = mount();
+      const ev = tab(el);
+      expect(ev.defaultPrevented).toBe(false);
+      expect(el.value).toBe('');
+    });
+
+    it('keeps native Shift+Tab and modified-Tab focus-nav even with a suggestion', () => {
+      const el = mount((e) => {
+        e.suggestion = 'suggested';
+      });
+      expect(tab(el, { shiftKey: true }).defaultPrevented).toBe(false);
+      expect(tab(el, { ctrlKey: true }).defaultPrevented).toBe(false);
+      expect(tab(el, { altKey: true }).defaultPrevented).toBe(false);
+      expect(tab(el, { metaKey: true }).defaultPrevented).toBe(false);
+      expect(el.value).toBe('');
+    });
   });
 
   describe('idle vs focus-within state', () => {


### PR DESCRIPTION
## Problem

After each finished turn the composer auto-suggests a likely follow-up prompt (a quick LLM call lands it as the textarea placeholder). The suggestion was display-only: pressing Tab on the empty composer jumped focus to the next control (the + add-menu), so the suggested text could not be taken without retyping it by hand.

## Change

- **`<slicc-input-card>`** (`@slicc/webcomponents`) gains a `suggestion` attribute (reflected property, documented, story added):
  - While the composer is empty, the suggestion shows as the textarea placeholder (the static `placeholder` stays underneath).
  - **Tab fills the textarea with the suggestion** — routed through the normal input pipeline (reflected `value` attribute, autosize, host-facing `CustomEvent('input')`) with focus kept on the textarea and the caret at the end, so the very next Enter submits it.
  - Tab keeps **native focus navigation** whenever text is present, no suggestion is set, or Shift/any modifier is held — keyboard accessibility is unchanged in all non-suggestion states.
- **`wc-placeholder.ts`** (webapp): the turn-finished refresher now lands real suggestions on the `suggestion` attribute via the exported `applySuggestedPlaceholder` helper; the fail-soft default still lands on the plain `placeholder` and clears any stale suggestion, so the static copy ("Ask sliccy, or describe a change…") is never Tab-fillable.

## Cross-runtime parity

Both floats share this wiring — standalone and extension boots route through `wireWcComposer` in `wc-live.ts` (`wc-extension.ts` reuses `attachWcClient`). node-server / swift / iOS: N/A (composer is webapp-shell UI).

## Tests

- `packages/webcomponents/tests/composer/slicc-input-card.test.ts` (real Chromium): attribute↔property reflection, placeholder takeover/restore, Tab fill + `input` event + caret/focus assertions, accepted-suggestion submit on Enter, and native-Tab preservation for draft / no-suggestion / Shift+Tab / Ctrl / Alt / Meta.
- `packages/webapp/tests/ui/wc/wc-placeholder.test.ts`: `applySuggestedPlaceholder` suggestion vs. default routing; refresher fail-soft leaves no stale suggestion.

## Verification

- `npm run lint`, `npm run typecheck` (all seven targets), `npm run test` (7597 passed), `npm run test:coverage:webcomponents` + `:webapp` (above floors), `npm run build -w @slicc/webcomponents` — all green.
- **Live check** against `npm run dev` with trusted CDP `Input.dispatchKeyEvent` Tab keystrokes on the real shell:
  - suggestion + empty composer → Tab fills `"Now add dark mode to the hero?"`, focus stays on the textarea, caret at end;
  - no suggestion → Tab moves focus to `slicc-add-menu` (unchanged native behavior);
  - typed draft → Tab never disturbs the draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)