### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -37,10 +37,10 @@
       ]
     },
     "webapp": {
-      "lines": 71,
-      "statements": 69,
-      "functions": 71,
-      "branches": 60,
+      "lines": 74,
+      "statements": 72,
+      "functions": 73,
+      "branches": 62,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.