### PR TITLE
fix(scoops): replace hand-rolled cron parser with croner (#948)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1945,7 +1945,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -8935,6 +8935,25 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -21406,6 +21425,7 @@
         "@zenfs/core": "2.5.6",
         "@zenfs/dom": "1.2.9",
         "buffer": "6.0.3",
+        "croner": "^10.0.1",
         "esbuild-wasm": "0.28.0",
         "esptool-js": "^0.6.0",
         "fflate": "^0.8.2",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -36,6 +36,7 @@
     "@zenfs/core": "2.5.6",
     "@zenfs/dom": "1.2.9",
     "buffer": "6.0.3",
+    "croner": "^10.0.1",
     "esbuild-wasm": "0.28.0",
     "esptool-js": "^0.6.0",
     "fflate": "^0.8.2",

--- a/packages/webapp/src/scoops/cron.ts
+++ b/packages/webapp/src/scoops/cron.ts
@@ -11,10 +11,15 @@ import { Cron } from 'croner';
 /**
  * Return the next time `expr` fires strictly after `from`, or `null` when the
  * expression is invalid or never fires again.
+ *
+ * `domAndDow: true` keeps the legacy AND semantics for schedules that
+ * constrain both day-of-month and day-of-week (e.g. `0 9 1 * 1` fires only
+ * when the 1st is a Monday), matching the bespoke parser this replaced rather
+ * than croner's default POSIX OR semantics.
  */
 export function getNextCronTime(expr: string, from: Date): Date | null {
   try {
-    return new Cron(expr.trim()).nextRun(from) ?? null;
+    return new Cron(expr.trim(), { domAndDow: true }).nextRun(from) ?? null;
   } catch {
     return null;
   }

--- a/packages/webapp/src/scoops/cron.ts
+++ b/packages/webapp/src/scoops/cron.ts
@@ -1,0 +1,21 @@
+/**
+ * Cron scheduling helper shared by LickManager and TaskScheduler.
+ *
+ * Wraps `croner`, which computes the next firing in closed form and validates
+ * field bounds, replacing the bespoke minute-by-minute search both schedulers
+ * used to carry.
+ */
+
+import { Cron } from 'croner';
+
+/**
+ * Return the next time `expr` fires strictly after `from`, or `null` when the
+ * expression is invalid or never fires again.
+ */
+export function getNextCronTime(expr: string, from: Date): Date | null {
+  try {
+    return new Cron(expr.trim()).nextRun(from) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/webapp/src/scoops/lick-manager.ts
+++ b/packages/webapp/src/scoops/lick-manager.ts
@@ -7,6 +7,7 @@
 
 import { createLogger } from '../core/logger.js';
 import { handoffFingerprint } from '../net/handoff-link.js';
+import { getNextCronTime } from './cron.js';
 import * as db from './db.js';
 
 const log = createLogger('lick-manager');
@@ -312,7 +313,7 @@ export class LickManager {
     filter?: string
   ): Promise<CronTaskEntry> {
     // Validate cron expression
-    const nextRun = this.getNextCronTime(cron, new Date());
+    const nextRun = getNextCronTime(cron, new Date());
     if (!nextRun) {
       throw new Error('Invalid cron expression');
     }
@@ -398,7 +399,7 @@ export class LickManager {
           if (result === false) {
             log.debug('Cron task skipped by filter', { id: task.id, name: task.name });
             // Update next run time even if skipped
-            const next = this.getNextCronTime(task.cron, now);
+            const next = getNextCronTime(task.cron, now);
             task.nextRun = next?.toISOString() ?? null;
             task.lastRun = now.toISOString();
             await db.saveCronTask(task);
@@ -429,7 +430,7 @@ export class LickManager {
       this.dispatch(event);
 
       // Update times
-      const next = this.getNextCronTime(task.cron, now);
+      const next = getNextCronTime(task.cron, now);
       task.nextRun = next?.toISOString() ?? null;
       task.lastRun = now.toISOString();
       await db.saveCronTask(task);
@@ -471,52 +472,6 @@ export class LickManager {
         `Invalid filter function: ${err instanceof Error ? err.message : String(err)}`
       );
     }
-  }
-
-  /** Calculate next cron run time */
-  private getNextCronTime(cron: string, from: Date): Date | null {
-    const parts = cron.trim().split(/\s+/);
-    if (parts.length !== 5) return null;
-
-    const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
-    const next = new Date(from);
-    next.setSeconds(0);
-    next.setMilliseconds(0);
-    next.setMinutes(next.getMinutes() + 1);
-
-    const cronFieldMatches = (value: number, field: string): boolean => {
-      if (field === '*') return true;
-      if (field.includes(',')) {
-        return field.split(',').some((f) => cronFieldMatches(value, f.trim()));
-      }
-      if (field.includes('-')) {
-        const [start, end] = field.split('-').map((n) => parseInt(n, 10));
-        return value >= start && value <= end;
-      }
-      if (field.includes('/')) {
-        const [base, step] = field.split('/');
-        const stepNum = parseInt(step, 10);
-        if (base === '*') return value % stepNum === 0;
-        const baseNum = parseInt(base, 10);
-        return value >= baseNum && (value - baseNum) % stepNum === 0;
-      }
-      return parseInt(field, 10) === value;
-    };
-
-    // Search up to 1 year
-    for (let i = 0; i < 527040; i++) {
-      if (
-        cronFieldMatches(next.getMinutes(), minute) &&
-        cronFieldMatches(next.getHours(), hour) &&
-        cronFieldMatches(next.getDate(), dayOfMonth) &&
-        cronFieldMatches(next.getMonth() + 1, month) &&
-        cronFieldMatches(next.getDay(), dayOfWeek)
-      ) {
-        return next;
-      }
-      next.setMinutes(next.getMinutes() + 1);
-    }
-    return null;
   }
 }
 

--- a/packages/webapp/src/scoops/scheduler.ts
+++ b/packages/webapp/src/scoops/scheduler.ts
@@ -8,6 +8,7 @@
  */
 
 import { createLogger } from '../core/logger.js';
+import { getNextCronTime } from './cron.js';
 import * as db from './db.js';
 import type { RegisteredScoop, ScheduledTask } from './types.js';
 
@@ -204,7 +205,7 @@ export class TaskScheduler {
 
     switch (scheduleType) {
       case 'cron': {
-        const next = this.getNextCronTime(scheduleValue, now);
+        const next = getNextCronTime(scheduleValue, now);
         return next?.toISOString() ?? null;
       }
 
@@ -222,71 +223,5 @@ export class TaskScheduler {
       default:
         return null;
     }
-  }
-
-  /** Parse a cron expression and get the next run time */
-  private getNextCronTime(cron: string, from: Date): Date | null {
-    const parts = cron.trim().split(/\s+/);
-    if (parts.length !== 5) return null;
-
-    const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
-
-    const next = new Date(from);
-    next.setSeconds(0);
-    next.setMilliseconds(0);
-    next.setMinutes(next.getMinutes() + 1);
-
-    for (let i = 0; i < 527040; i++) {
-      if (this.cronMatches(next, minute, hour, dayOfMonth, month, dayOfWeek)) {
-        return next;
-      }
-      next.setMinutes(next.getMinutes() + 1);
-    }
-
-    return null;
-  }
-
-  /** Check if a date matches cron fields */
-  private cronMatches(
-    date: Date,
-    minute: string,
-    hour: string,
-    dayOfMonth: string,
-    month: string,
-    dayOfWeek: string
-  ): boolean {
-    return (
-      this.cronFieldMatches(date.getMinutes(), minute) &&
-      this.cronFieldMatches(date.getHours(), hour) &&
-      this.cronFieldMatches(date.getDate(), dayOfMonth) &&
-      this.cronFieldMatches(date.getMonth() + 1, month) &&
-      this.cronFieldMatches(date.getDay(), dayOfWeek)
-    );
-  }
-
-  /** Check if a value matches a cron field */
-  private cronFieldMatches(value: number, field: string): boolean {
-    if (field === '*') return true;
-
-    if (field.includes(',')) {
-      return field.split(',').some((f) => this.cronFieldMatches(value, f.trim()));
-    }
-
-    if (field.includes('-')) {
-      const [start, end] = field.split('-').map((n) => parseInt(n, 10));
-      return value >= start && value <= end;
-    }
-
-    if (field.includes('/')) {
-      const [base, step] = field.split('/');
-      const stepNum = parseInt(step, 10);
-      if (base === '*') {
-        return value % stepNum === 0;
-      }
-      const baseNum = parseInt(base, 10);
-      return value >= baseNum && (value - baseNum) % stepNum === 0;
-    }
-
-    return parseInt(field, 10) === value;
   }
 }

--- a/packages/webapp/tests/scoops/cron.test.ts
+++ b/packages/webapp/tests/scoops/cron.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the shared cron helper used by LickManager and TaskScheduler.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getNextCronTime } from '../../src/scoops/cron.js';
+
+describe('getNextCronTime', () => {
+  it('returns the next minute for "* * * * *"', () => {
+    const from = new Date('2026-06-14T10:00:30');
+    const next = getNextCronTime('* * * * *', from);
+    expect(next).not.toBeNull();
+    expect(next!.getTime()).toBeGreaterThan(from.getTime());
+    expect(next!.getSeconds()).toBe(0);
+    expect((next!.getTime() - from.getTime()) / 1000).toBeLessThanOrEqual(60);
+  });
+
+  it('fires strictly after the given time', () => {
+    const from = new Date('2026-06-14T10:00:00');
+    const next = getNextCronTime('* * * * *', from);
+    expect(next!.getTime()).toBeGreaterThan(from.getTime());
+  });
+
+  it('computes daily "0 9 * * *" at 09:00', () => {
+    const next = getNextCronTime('0 9 * * *', new Date('2026-06-14T10:00:00'));
+    expect(next!.getHours()).toBe(9);
+    expect(next!.getMinutes()).toBe(0);
+    expect(next!.getSeconds()).toBe(0);
+  });
+
+  it('handles step fields "*/5 * * * *"', () => {
+    const next = getNextCronTime('*/5 * * * *', new Date('2026-06-14T10:02:00'));
+    expect(next!.getMinutes() % 5).toBe(0);
+  });
+
+  it('handles list fields "0 9,17 * * *"', () => {
+    const next = getNextCronTime('0 9,17 * * *', new Date('2026-06-14T10:00:00'));
+    expect([9, 17]).toContain(next!.getHours());
+    expect(next!.getMinutes()).toBe(0);
+  });
+
+  it('handles range fields "0 9-17 * * *"', () => {
+    const next = getNextCronTime('0 9-17 * * *', new Date('2026-06-14T08:00:00'));
+    expect(next!.getHours()).toBeGreaterThanOrEqual(9);
+    expect(next!.getHours()).toBeLessThanOrEqual(17);
+  });
+
+  it('returns far-future January 1st without iterating minute-by-minute', () => {
+    const next = getNextCronTime('0 9 1 1 *', new Date('2026-06-14T10:00:00'));
+    expect(next!.getMonth()).toBe(0);
+    expect(next!.getDate()).toBe(1);
+    expect(next!.getHours()).toBe(9);
+  });
+
+  it('returns null for wrong field count', () => {
+    expect(getNextCronTime('* * * *', new Date())).toBeNull();
+  });
+
+  it('returns null for out-of-range fields', () => {
+    expect(getNextCronTime('61 25 32 13 8', new Date())).toBeNull();
+  });
+
+  it('returns null for garbage input', () => {
+    expect(getNextCronTime('not a cron', new Date())).toBeNull();
+  });
+
+  it('supports @daily shortcut', () => {
+    const next = getNextCronTime('@daily', new Date('2026-06-14T10:00:00'));
+    expect(next!.getHours()).toBe(0);
+    expect(next!.getMinutes()).toBe(0);
+  });
+});

--- a/packages/webapp/tests/scoops/cron.test.ts
+++ b/packages/webapp/tests/scoops/cron.test.ts
@@ -64,6 +64,15 @@ describe('getNextCronTime', () => {
     expect(getNextCronTime('not a cron', new Date())).toBeNull();
   });
 
+  it('uses AND semantics when both day-of-month and day-of-week are constrained', () => {
+    // "0 9 1 * 1" fires only when the 1st of the month is also a Monday.
+    const next = getNextCronTime('0 9 1 * 1', new Date('2026-06-14T10:00:00'));
+    expect(next).not.toBeNull();
+    expect(next!.getDate()).toBe(1);
+    expect(next!.getDay()).toBe(1);
+    expect(next!.getHours()).toBe(9);
+  });
+
   it('supports @daily shortcut', () => {
     const next = getNextCronTime('@daily', new Date('2026-06-14T10:00:00'));
     expect(next!.getHours()).toBe(0);


### PR DESCRIPTION
## Summary

Closes #948.

`LickManager` and `TaskScheduler` each shipped a near-identical hand-rolled cron parser plus a brute-force loop that walked the calendar one minute at a time, up to **527,040 iterations** (a full year of minutes), to find the next firing. This replaces both with a single shared helper backed by [`croner`](https://www.npmjs.com/package/croner) (0 deps, ~10 kB, browser-safe), which computes the next run in closed form.

## Changes

- New `packages/webapp/src/scoops/cron.ts` — thin `getNextCronTime(expr, from)` wrapper over `croner`.
- `lick-manager.ts` — deleted private `getNextCronTime` + inline `cronFieldMatches`; callers now use the shared helper.
- `scheduler.ts` — deleted `getNextCronTime` + `cronMatches` + `cronFieldMatches`; uses the shared helper.
- Added `croner@^10.0.1` to `@slicc/webapp` dependencies.

## Why

- **Reinvented library code / brute force where arithmetic suffices.** The minute-walker is the canonical "easy thing done the hard way"; `croner` returns the answer in microseconds.
- **Duplicated complexity.** ~110 lines of bespoke parser/search removed from two near-identical implementations.
- **Correctness wins.** Now rejects out-of-range fields (e.g. `61 25 32 13 8`) and garbage instead of silently looping a year, and supports `@daily`/`@hourly` shortcuts.

## Tests

- New `tests/scoops/cron.test.ts` covering `*`, step, list, range, far-future, wrong-field-count, out-of-range rejection, garbage rejection, and `@daily`.
- Existing `scheduler.test.ts` / `lick-manager.test.ts` suites still pass unchanged.

## Verification

`npm run lint`, `npm run typecheck`, `npm run test:coverage:webapp`, `npm run build -w @slicc/webapp`, and `npm run build -w @slicc/chrome-extension` all pass locally.

## Cross-runtime parity

Cron scheduling lives only in the webapp bundle (shared by CLI + extension floats via the same code). No `node-server`/`swift-server`/`ios-app` cron logic exists, so no peer updates are needed.