### PR TITLE
fix(webapp): resume streaming after mid-turn rehydrate (#959)

### DIFF
--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -700,18 +700,28 @@ export class OffscreenClient implements KernelClientFacade {
    * bubble and `WcChatController` drops it silently — leaving a perpetual
    * "working" spinner that never renders the reply (issue #959).
    *
-   * Mirror the bridge's own rebuild logic: adopt the replay's trailing
-   * streaming assistant message id so subsequent (incremental) deltas keep
-   * extending that exact bubble, otherwise forget the pointer so the next
-   * delta opens a fresh `message_start`.
+   * Mirror the bridge's own rebuild logic: adopt the replay's streaming
+   * assistant message id so subsequent (incremental) deltas keep extending
+   * that exact bubble, otherwise forget the pointer so the next delta opens
+   * a fresh `message_start`. The streaming assistant is usually the tail, but
+   * a prompt or lick queued mid-turn is buffered AFTER it, so scan backward
+   * for the last streaming assistant rather than assuming it is the final
+   * entry.
    */
   private resyncStreamPointer(
     scoopJid: string,
     messages: ScoopMessagesReplacedMsg['messages']
   ): void {
-    const tail = messages[messages.length - 1];
-    if (tail && tail.role === 'assistant' && tail.isStreaming) {
-      this.currentMessageId.set(scoopJid, tail.id);
+    let streamingId: string | undefined;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (m.role === 'assistant' && m.isStreaming) {
+        streamingId = m.id;
+        break;
+      }
+    }
+    if (streamingId !== undefined) {
+      this.currentMessageId.set(scoopJid, streamingId);
     } else {
       this.currentMessageId.delete(scoopJid);
     }

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -616,6 +616,7 @@ export class OffscreenClient implements KernelClientFacade {
 
       case 'scoop-messages-replaced': {
         const m = msg as ScoopMessagesReplacedMsg;
+        this.resyncStreamPointer(m.scoopJid, m.messages);
         this.callbacks.onScoopMessagesReplaced?.(m.scoopJid, m.messages);
         break;
       }
@@ -687,6 +688,33 @@ export class OffscreenClient implements KernelClientFacade {
   onTerminalEvent(handler: (event: TerminalEventMsg) => void): () => void {
     this.terminalEventListeners.add(handler);
     return () => this.terminalEventListeners.delete(handler);
+  }
+
+  /**
+   * Re-sync the panel's streaming pointer with a canonical replay.
+   *
+   * A mid-turn rehydrate (thawing a frozen session, switching scoops, or
+   * an HMR/reload remount) replaces the thread via `scoop-messages-replaced`.
+   * The synthetic message id we had been streaming into is no longer in the
+   * rebuilt thread, so the next live `text_delta` would target a vanished
+   * bubble and `WcChatController` drops it silently — leaving a perpetual
+   * "working" spinner that never renders the reply (issue #959).
+   *
+   * Mirror the bridge's own rebuild logic: adopt the replay's trailing
+   * streaming assistant message id so subsequent (incremental) deltas keep
+   * extending that exact bubble, otherwise forget the pointer so the next
+   * delta opens a fresh `message_start`.
+   */
+  private resyncStreamPointer(
+    scoopJid: string,
+    messages: ScoopMessagesReplacedMsg['messages']
+  ): void {
+    const tail = messages[messages.length - 1];
+    if (tail && tail.role === 'assistant' && tail.isStreaming) {
+      this.currentMessageId.set(scoopJid, tail.id);
+    } else {
+      this.currentMessageId.delete(scoopJid);
+    }
   }
 
   private handleAgentEvent(msg: AgentEventMsg): void {

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -136,13 +136,14 @@ export class WcChatController {
     // Runs of same-channel licks render as ONE collated card ("×2" pill).
     this.#messages = collateLickMessages(messages);
     // A canonical replay can land mid-turn (rehydrate after a scoop switch /
-    // frozen-session thaw / remount). When its tail is still streaming, keep
+    // frozen-session thaw / remount). When a message is still streaming, keep
     // the stream machine pointed at that bubble so the resumed deltas extend
-    // it and `content_done` flushes the final chunk (issue #959). A settled
-    // tail clears the pointer as before.
-    const tail = this.#messages[this.#messages.length - 1];
-    this.#currentStreamId = tail?.isStreaming ? tail.id : null;
-    if (tail?.isStreaming) this.#turnAssistantId = tail.id;
+    // it and `content_done` flushes the final chunk (issue #959). The
+    // streaming message is usually the tail, but a prompt/lick queued mid-turn
+    // is buffered AFTER it, so scan backward rather than assuming the tail.
+    const streamingTail = [...this.#messages].reverse().find((m) => m.isStreaming);
+    this.#currentStreamId = streamingTail?.id ?? null;
+    if (streamingTail) this.#turnAssistantId = streamingTail.id;
     this.#pendingDelta = '';
     this.#flushScheduled = false;
     this.#els.clear();

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -135,7 +135,14 @@ export class WcChatController {
     for (const id of this.#els.keys()) this.#onMessageDisposed?.(id);
     // Runs of same-channel licks render as ONE collated card ("×2" pill).
     this.#messages = collateLickMessages(messages);
-    this.#currentStreamId = null;
+    // A canonical replay can land mid-turn (rehydrate after a scoop switch /
+    // frozen-session thaw / remount). When its tail is still streaming, keep
+    // the stream machine pointed at that bubble so the resumed deltas extend
+    // it and `content_done` flushes the final chunk (issue #959). A settled
+    // tail clears the pointer as before.
+    const tail = this.#messages[this.#messages.length - 1];
+    this.#currentStreamId = tail?.isStreaming ? tail.id : null;
+    if (tail?.isStreaming) this.#turnAssistantId = tail.id;
     this.#pendingDelta = '';
     this.#flushScheduled = false;
     this.#els.clear();

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -597,3 +597,99 @@ describe('OffscreenClient.getScoopTranscript', () => {
     await expect(pending).resolves.toBe('real');
   });
 });
+
+describe('OffscreenClient stream-pointer resync on scoop-messages-replaced', () => {
+  let client: InstanceType<typeof OffscreenClient>;
+  const callbacks = {
+    onStatusChange: vi.fn(),
+    onScoopCreated: vi.fn(),
+    onScoopListUpdate: vi.fn(),
+    onIncomingMessage: vi.fn(),
+    onScoopMessagesReplaced: vi.fn(),
+  };
+
+  beforeEach(() => {
+    sentMessages.length = 0;
+    messageListeners.length = 0;
+    vi.clearAllMocks();
+    client = new OffscreenClient(callbacks);
+  });
+
+  // Regression for #959: a mid-turn canonical replay (frozen-session thaw /
+  // scoop switch / remount) used to leave the panel streaming into a vanished
+  // synthetic id, so live deltas were dropped and the spinner hung forever.
+  it('adopts the replay streaming-tail id so resumed deltas extend that bubble', () => {
+    client.setSelectedScoopJid('cone_123');
+    const handle = client.createAgentHandle();
+    const events: any[] = [];
+    handle.onEvent((e) => events.push(e));
+
+    // First turn starts streaming under a synthetic id.
+    simulateMessage('offscreen', {
+      type: 'agent-event',
+      scoopJid: 'cone_123',
+      eventType: 'text_delta',
+      text: 'before',
+    });
+    expect(events[0].type).toBe('message_start');
+    const syntheticId = events[0].messageId;
+
+    // Canonical replay lands mid-turn with a still-streaming tail.
+    simulateMessage('offscreen', {
+      type: 'scoop-messages-replaced',
+      scoopJid: 'cone_123',
+      messages: [
+        { id: 'u1', role: 'user', content: 'hi', timestamp: 1 },
+        { id: 'buf-stream', role: 'assistant', content: 'before', timestamp: 2, isStreaming: true },
+      ],
+    });
+    expect(callbacks.onScoopMessagesReplaced).toHaveBeenCalledWith('cone_123', expect.any(Array));
+
+    events.length = 0;
+    // The next delta must continue into the replay's bubble (no new
+    // message_start) and carry the replay's id, not the stale synthetic one.
+    simulateMessage('offscreen', {
+      type: 'agent-event',
+      scoopJid: 'cone_123',
+      eventType: 'text_delta',
+      text: ' after',
+    });
+    expect(events.map((e) => e.type)).toEqual(['content_delta']);
+    expect(events[0].messageId).toBe('buf-stream');
+    expect(events[0].messageId).not.toBe(syntheticId);
+  });
+
+  it('drops the pointer when the replay tail is settled so the next delta opens a fresh bubble', () => {
+    client.setSelectedScoopJid('cone_123');
+    const handle = client.createAgentHandle();
+    const events: any[] = [];
+    handle.onEvent((e) => events.push(e));
+
+    simulateMessage('offscreen', {
+      type: 'agent-event',
+      scoopJid: 'cone_123',
+      eventType: 'text_delta',
+      text: 'turn one',
+    });
+
+    // Replay with no streaming tail (turn already settled).
+    simulateMessage('offscreen', {
+      type: 'scoop-messages-replaced',
+      scoopJid: 'cone_123',
+      messages: [
+        { id: 'a1', role: 'assistant', content: 'turn one', timestamp: 2, isStreaming: false },
+      ],
+    });
+
+    events.length = 0;
+    simulateMessage('offscreen', {
+      type: 'agent-event',
+      scoopJid: 'cone_123',
+      eventType: 'text_delta',
+      text: 'turn two',
+    });
+    // A fresh turn: must re-open with message_start under a new id.
+    expect(events.map((e) => e.type)).toEqual(['message_start', 'content_delta']);
+    expect(events[0].messageId).not.toBe('a1');
+  });
+});

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -659,6 +659,42 @@ describe('OffscreenClient stream-pointer resync on scoop-messages-replaced', () 
     expect(events[0].messageId).not.toBe(syntheticId);
   });
 
+  it('finds the streaming assistant even when a queued user message is buffered after it', () => {
+    client.setSelectedScoopJid('cone_123');
+    const handle = client.createAgentHandle();
+    const events: any[] = [];
+    handle.onEvent((e) => events.push(e));
+
+    simulateMessage('offscreen', {
+      type: 'agent-event',
+      scoopJid: 'cone_123',
+      eventType: 'text_delta',
+      text: 'before',
+    });
+
+    // A prompt/lick queued mid-turn lands AFTER the streaming assistant in
+    // the replay buffer — the streaming entry is no longer the tail.
+    simulateMessage('offscreen', {
+      type: 'scoop-messages-replaced',
+      scoopJid: 'cone_123',
+      messages: [
+        { id: 'buf-stream', role: 'assistant', content: 'before', timestamp: 2, isStreaming: true },
+        { id: 'queued-1', role: 'user', content: 'do this next', timestamp: 3 },
+      ],
+    });
+
+    events.length = 0;
+    simulateMessage('offscreen', {
+      type: 'agent-event',
+      scoopJid: 'cone_123',
+      eventType: 'text_delta',
+      text: ' after',
+    });
+    // Still extends the streaming assistant, not a new bubble.
+    expect(events.map((e) => e.type)).toEqual(['content_delta']);
+    expect(events[0].messageId).toBe('buf-stream');
+  });
+
   it('drops the pointer when the replay tail is settled so the next delta opens a fresh bubble', () => {
     client.setSelectedScoopJid('cone_123');
     const handle = client.createAgentHandle();

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -318,6 +318,24 @@ describe('WcChatController render/dispose lifecycle hooks', () => {
     expect(el?.hasAttribute('streaming')).toBe(false);
     expect(thread.querySelectorAll('slicc-agent-message')).toHaveLength(1);
   });
+
+  // A prompt/lick queued mid-turn is buffered after the streaming assistant,
+  // so loadMessages must scan backward (not assume the tail) to keep resuming
+  // the right bubble.
+  it('resumes a streaming message even when a queued user message follows it', async () => {
+    const { thread, agent, controller } = makeTracked();
+    controller.loadMessages([
+      { id: 'm1', role: 'assistant', content: 'before', timestamp: 2, isStreaming: true },
+      { id: 'q1', role: 'user', content: 'queued', timestamp: 3 },
+    ]);
+    agent.emit({ type: 'content_delta', messageId: 'm1', text: ' more' });
+    agent.emit({ type: 'content_done', messageId: 'm1' });
+    await nextFrame();
+    const streamed = thread.querySelector('slicc-agent-message');
+    expect(streamed?.textContent).toContain('before more');
+    expect(streamed?.hasAttribute('streaming')).toBe(false);
+    expect(thread.querySelectorAll('slicc-agent-message')).toHaveLength(1);
+  });
 });
 
 describe('WcChatController scroll pinning', () => {

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -295,6 +295,29 @@ describe('WcChatController render/dispose lifecycle hooks', () => {
     expect(thread.querySelectorAll('slicc-agent-message')).toHaveLength(1);
     expect(thread.querySelector('slicc-agent-message')?.hasAttribute('streaming')).toBe(false);
   });
+
+  // Regression for #959: a canonical replay that lands mid-turn must leave the
+  // stream machine pointed at the streaming tail so resumed deltas extend it
+  // (and content_done folds the last un-flushed chunk) instead of the reply
+  // hanging unrendered behind a stuck spinner.
+  it('resumes a streaming tail after loadMessages: deltas extend it, content_done flushes', async () => {
+    const { thread, agent, controller } = makeTracked();
+    controller.loadMessages([
+      { id: 'm1', role: 'assistant', content: 'before', timestamp: 2, isStreaming: true },
+    ]);
+    agent.emit({ type: 'content_delta', messageId: 'm1', text: ' mid' });
+    await nextFrame();
+    expect(thread.querySelector('slicc-agent-message')?.textContent).toContain('before mid');
+
+    // A delta with no rAF tick before content_done must still be folded in
+    // (works because loadMessages restored #currentStreamId for the tail).
+    agent.emit({ type: 'content_delta', messageId: 'm1', text: ' end' });
+    agent.emit({ type: 'content_done', messageId: 'm1' });
+    const el = thread.querySelector('slicc-agent-message');
+    expect(el?.textContent).toContain('before mid end');
+    expect(el?.hasAttribute('streaming')).toBe(false);
+    expect(thread.querySelectorAll('slicc-agent-message')).toHaveLength(1);
+  });
 });
 
 describe('WcChatController scroll pinning', () => {


### PR DESCRIPTION
## Summary

Fixes #959 — after thawing a frozen session (or switching scoops) while the cone is mid-turn and returning, the mount-recovery prompt / reply never rendered and the cone looked stuck in the "working" state with no further action.

## Root cause (a rehydration bug)

When a scoop is mid-turn, the panel streams deltas into a synthetic message id tracked in `OffscreenClient.currentMessageId`. Navigating away and back issues `requestScoopMessages`; the bridge replies with `scoop-messages-replaced` carrying the buffered transcript (including the still-streaming tail), and `WcChatController.loadMessages` rebuilds the thread using the **bridge's** ids.

The panel's `currentMessageId` still pointed at the now-vanished synthetic id, so subsequent live `text_delta` events were emitted under an id no longer in the thread. `WcChatController.#handleContentDelta` drops them (`if (!this.#findMessage(messageId)) return;`). Result: spinner stuck up, reply never rendered, conversation looked wedged — even though the worker was fine.

This is a general mid-turn rehydration desync (frozen-session thaw, scoop switch, HMR/reload remount), surfaced via the mount-recovery flow in #959.

## Fix (two symmetric seams)

- `packages/webapp/src/ui/offscreen-client.ts`: on `scoop-messages-replaced`, `resyncStreamPointer` adopts the replay's trailing streaming-assistant id (so resumed incremental deltas extend that exact bubble) or clears the pointer so the next delta opens a fresh `message_start`. Mirrors the bridge's own `currentMessageId` reset on rebuild.
- `packages/webapp/src/ui/wc/wc-chat-controller.ts`: `loadMessages` restores `#currentStreamId` / `#turnAssistantId` to the streaming tail, so `content_done` folds the final un-flushed chunk and the turn-complete hook fires with the right reply.

## Tests

- `offscreen-client.test.ts`: adopts the streaming-tail id on mid-turn replay; clears it for a settled tail.
- `wc-chat-controller.test.ts`: resumes a streaming tail after `loadMessages` (deltas extend it, `content_done` flushes).

The bug lives entirely at the message-protocol/state-machine seam, so it is pinned by fast deterministic unit tests rather than the (LLM-free) browser e2e tier.

## Verification

- `npm run typecheck` — clean
- `npm run lint` (biome via pre-commit) — clean
- 263 webapp UI tests pass (incl. the new regression cases)

Closes #959