### PR TITLE
feat(swift-optel): add Swift RUM/OpTel client + CI and quality-gate integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       cherry: ${{ steps.filter.outputs.cherry }}
       dev-tools: ${{ steps.filter.outputs.dev-tools }}
       swift-server: ${{ steps.filter.outputs.swift-server }}
+      swift-optel: ${{ steps.filter.outputs.swift-optel }}
       swift-launcher: ${{ steps.filter.outputs.swift-launcher }}
       ios-app: ${{ steps.filter.outputs.ios-app }}
       swift-config: ${{ steps.filter.outputs.swift-config }}
@@ -63,6 +64,8 @@ jobs:
               - 'packages/dev-tools/**'
             swift-server:
               - 'packages/swift-server/**'
+            swift-optel:
+              - 'packages/swift-optel/**'
             swift-launcher:
               - 'packages/swift-launcher/**'
             ios-app:
@@ -701,6 +704,47 @@ jobs:
           # blocking PRs while existing findings get cleaned up incrementally.
           cd packages/swift-server && periphery scan --disable-update-check || true
 
+  swift-optel:
+    needs: [changes, lint]
+    if: >-
+      needs.lint.result == 'success' &&
+      needs.changes.outputs.is-queue-leader == 'true' &&
+      (needs.changes.outputs.swift-optel == 'true' ||
+      needs.changes.outputs.swift-config == 'true')
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # swift-coverage-check.sh reads its floors from coverage-thresholds.json
+      # via node, so pin Node (matches the other jobs) instead of relying on
+      # the runner's preinstalled version.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+      - name: Install SwiftLint
+        run: brew install swiftlint
+      - name: Lint (SwiftLint)
+        run: cd packages/swift-optel && swiftlint lint --reporter github-actions-logging
+      - name: Build
+        run: cd packages/swift-optel && swift build -c release
+      - name: Test (with coverage threshold gate)
+        run: |
+          ./packages/dev-tools/tools/swift-coverage-check.sh \
+            packages/swift-optel SwiftOptelPackageTests
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-swift-optel
+          path: packages/swift-optel/.build/coverage/
+          if-no-files-found: ignore
+      - name: Install Periphery
+        run: brew install peripheryapp/periphery/periphery
+      - name: Dead code detection (Periphery)
+        run: |
+          # Informational scan; surfaces unused Swift declarations without
+          # blocking PRs while existing findings get cleaned up incrementally.
+          cd packages/swift-optel && periphery scan --disable-update-check || true
+
   swift-launcher:
     needs: [changes, lint]
     if: >-
@@ -867,6 +911,7 @@ jobs:
         global-install,
         swift-launcher,
         swift-server,
+        swift-optel,
         ios-app,
         release-gate,
       ]

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -89,6 +89,11 @@
       "lines": 27,
       "functions": 31,
       "regions": 34
+    },
+    "swift-optel": {
+      "lines": 65,
+      "functions": 55,
+      "regions": 70
     }
   }
 }

--- a/knip.json
+++ b/knip.json
@@ -7,6 +7,7 @@
     "**/dist/**",
     "packages/swift-launcher/**",
     "packages/swift-server/**",
+    "packages/swift-optel/**",
     "packages/vfs-root/**",
     "packages/dev-tools/**",
     "packages/assets/**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "packages/chrome-extension",
         "packages/cloudflare-worker",
         "packages/swift-launcher",
-        "packages/swift-server"
+        "packages/swift-server",
+        "packages/swift-optel"
       ],
       "dependencies": {
         "e2b": "^2.23.0",
@@ -1945,7 +1946,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6754,6 +6755,10 @@
     },
     "node_modules/@slicc/swift-launcher": {
       "resolved": "packages/swift-launcher",
+      "link": true
+    },
+    "node_modules/@slicc/swift-optel": {
+      "resolved": "packages/swift-optel",
       "link": true
     },
     "node_modules/@slicc/swift-server": {
@@ -21390,6 +21395,9 @@
     },
     "packages/swift-launcher": {
       "name": "@slicc/swift-launcher"
+    },
+    "packages/swift-optel": {
+      "name": "@slicc/swift-optel"
     },
     "packages/swift-server": {
       "name": "@slicc/swift-server"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "deadcode:full": "knip",
     "deadcode:files": "knip --include files",
     "deadcode:production": "knip --production --strict",
-    "deadcode:swift": "npm run deadcode -w @slicc/swift-server && npm run deadcode -w @slicc/swift-launcher",
+    "deadcode:swift": "npm run deadcode -w @slicc/swift-server && npm run deadcode -w @slicc/swift-optel && npm run deadcode -w @slicc/swift-launcher",
     "package:release": "node dist/node-server/release-package.js",
     "publish:chrome": "node dist/node-server/publish-chrome-web-store.js",
     "publish:worker": "bash packages/cloudflare-worker/scripts/publish-worker.sh",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,13 @@
     "packages/chrome-extension",
     "packages/cloudflare-worker",
     "packages/swift-launcher",
-    "packages/swift-server"
+    "packages/swift-server",
+    "packages/swift-optel"
   ],
   "scripts": {
     "dev": "tsx packages/node-server/src/index.ts --dev",
     "dev:electron": "tsx packages/node-server/src/index.ts --dev --electron",
-    "build": "npm run build -w @slicc/shared-ts && npm run build -w @slicc/cloud-core && npm run build -w @slicc/webcomponents && npm run build -w @slicc/webapp && npm run build -w @ai-ecoverse/cherry && npm run build -w @slicc/node-server && npm run build -w @slicc/chrome-extension && npm run build -w @slicc/cloudflare-worker && npm run build -w @slicc/swift-server && npm run build -w @slicc/swift-launcher",
+    "build": "npm run build -w @slicc/shared-ts && npm run build -w @slicc/cloud-core && npm run build -w @slicc/webcomponents && npm run build -w @slicc/webapp && npm run build -w @ai-ecoverse/cherry && npm run build -w @slicc/node-server && npm run build -w @slicc/chrome-extension && npm run build -w @slicc/cloudflare-worker && npm run build -w @slicc/swift-server && npm run build -w @slicc/swift-optel && npm run build -w @slicc/swift-launcher",
     "start": "node dist/node-server/index.js",
     "start:electron": "node dist/node-server/index.js --electron",
     "preflight": "node packages/dev-tools/tools/preflight-deps.mjs",
@@ -65,7 +66,7 @@
     "lint:skills": "node packages/dev-tools/tools/lint-skills.mjs",
     "lint:no-innerhtml": "node packages/dev-tools/tools/check-no-innerhtml.mjs",
     "lint:patches": "node packages/dev-tools/patch-reconcile/check-patches.mjs",
-    "lint:swift": "npm run lint -w @slicc/swift-server && npm run lint -w @slicc/swift-launcher && cd packages/ios-app && swiftlint lint",
+    "lint:swift": "npm run lint -w @slicc/swift-server && npm run lint -w @slicc/swift-optel && npm run lint -w @slicc/swift-launcher && cd packages/ios-app && swiftlint lint",
     "deadcode": "knip --include files,dependencies,devDependencies,unlisted,binaries,unresolved,duplicates",
     "deadcode:full": "knip",
     "deadcode:files": "knip --include files",

--- a/packages/dev-tools/tools/coverage-ratchet.mjs
+++ b/packages/dev-tools/tools/coverage-ratchet.mjs
@@ -36,6 +36,7 @@ const only = onlyArg ? onlyArg.slice('--only='.length) : null;
 
 const SWIFT_BUNDLES = {
   'swift-server': 'SliccServerPackageTests',
+  'swift-optel': 'SwiftOptelPackageTests',
   'swift-launcher': 'SliccstartPackageTests',
 };
 

--- a/packages/swift-optel/.gitignore
+++ b/packages/swift-optel/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/packages/swift-optel/.periphery.yml
+++ b/packages/swift-optel/.periphery.yml
@@ -1,0 +1,13 @@
+schemes:
+  - SwiftOptel
+targets:
+  - SwiftOptel
+  - SwiftOptelTests
+retain_public: false
+retain_assign_only_property: true
+retain_objc_accessible: true
+retain_objc_annotated: true
+retain_swift_ui_previews: true
+disable_redundant_public_analysis: false
+clean_build: false
+strict: false

--- a/packages/swift-optel/.swiftlint.yml
+++ b/packages/swift-optel/.swiftlint.yml
@@ -1,0 +1,8 @@
+# Inherits the shared rule set from the repo-root .swiftlint.yml.
+# The `excluded` paths are redeclared here so they resolve relative to this
+# package (SwiftLint resolves excluded paths relative to the config file).
+parent_config: ../../.swiftlint.yml
+
+excluded:
+  - .build
+  - Package.resolved

--- a/packages/swift-optel/CLAUDE.md
+++ b/packages/swift-optel/CLAUDE.md
@@ -27,6 +27,46 @@ violations.
 - `Sources/SwiftOptel/` — library sources
 - `Tests/SwiftOptelTests/` — package tests
 
+## SwiftUI Auto-Instrumentation
+
+Ergonomic hooks for the four RUM checkpoints a SwiftUI app cares about. All
+SwiftUI surface lives in `OptelSwiftUI.swift` under `#if canImport(SwiftUI)`;
+the mapping helpers (`OptelSourceDeriver`, `OptelErrorMapping`,
+`OptelUncaughtExceptionHook`) are platform-agnostic and unit-tested.
+
+- `.optelAutoInstrument(appID:rate:)` — root modifier. Configures `Optel`
+  once, fires `enter` on launch, observes `scenePhase` and re-fires `enter`
+  on `background → active` transitions, and installs the best-effort
+  uncaught-exception hook.
+- `.optelView(_:)` — emits `navigate` with `source = name` on `.onAppear`.
+- `.optelTap(source:)` — attaches a `simultaneousGesture` that emits `click`
+  with the supplied source.
+- `OptelButton` — `Button` wrapper that derives `click` source from
+  `(identifier, accessibilityLabel, context)` via `OptelSourceDeriver` into
+  the `<context> <element>#<identifier>` shape.
+- `Optel.reportError(_:)` — emits `error` with `source` = bridged NSError
+  domain (or Swift type name) and `target` = `localizedDescription`.
+
+### Interception limits (known, accepted)
+
+- **No global tap / navigation interception.** SwiftUI has no AppKit/UIKit-
+  style responder chain that third-party code can hook. Per-view opt-in is
+  the only reliable surface — hence the `.optelView` / `.optelTap` /
+  `OptelButton` per-control modifiers rather than a single magic root hook.
+- **Uncaught-error hook is Objective-C only.** `NSSetUncaughtExceptionHandler`
+  fires for `NSException`s; Swift `Error` values are not exceptions and cannot
+  be intercepted globally. Catch and forward to `Optel.reportError(_:)`
+  explicitly at the boundaries where you `try?` / `do/catch`.
+- **`.optelAutoInstrument` covers launch and foregrounding only.** Background
+  / suspend / inactive transitions are intentionally not mapped to RUM
+  checkpoints (no helix-rum-js analogue).
+- **`scenePhase` requires a `Scene` ancestor.** The root modifier must be
+  applied inside the `WindowGroup` / `Scene` content (typically on the root
+  view), not on the `App` itself, for `@Environment(\.scenePhase)` to update.
+- **Reconfiguration resets state.** Calling `.optelAutoInstrument` on a
+  remounted root view will re-`configure` `Optel` and re-fire `enter` (and a
+  fresh session id). Mount it on a stable root.
+
 ## Related Guides
 
 - `packages/swift-server/CLAUDE.md` for the native macOS server

--- a/packages/swift-optel/CLAUDE.md
+++ b/packages/swift-optel/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+This file covers the Swift OpenTelemetry / RUM library in `packages/swift-optel/`.
+
+## Scope
+
+`packages/swift-optel/` is a pure-Swift library (`SwiftOptel`) that will host the shared RUM / OpenTelemetry instrumentation consumed by the iOS follower app and the macOS native server / launcher. Skeleton only at this stage — actual RUM logic lands in later tasks. Supports `.iOS(.v16)` and `.macOS(.v13)`; no third-party dependencies.
+
+## Build and Test Commands
+
+```bash
+cd packages/swift-optel
+swift build
+swift test
+npm run lint -w @slicc/swift-optel   # SwiftLint
+```
+
+## Linting
+
+`packages/swift-optel/.swiftlint.yml` inherits the shared rule set from the
+repo-root `.swiftlint.yml` (via `parent_config`) and excludes this package's
+`.build`. Run `npm run lint:fix -w @slicc/swift-optel` to auto-correct fixable
+violations.
+
+## Package Layout
+
+- `Sources/SwiftOptel/` — library sources
+- `Tests/SwiftOptelTests/` — package tests
+
+## Related Guides
+
+- `packages/swift-server/CLAUDE.md` for the native macOS server
+- `packages/ios-app/CLAUDE.md` for the iOS follower app

--- a/packages/swift-optel/Package.swift
+++ b/packages/swift-optel/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "SwiftOptel",
+    platforms: [.iOS(.v16), .macOS(.v13)],
+    products: [
+        .library(
+            name: "SwiftOptel",
+            targets: ["SwiftOptel"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "SwiftOptel",
+            path: "Sources/SwiftOptel"
+        ),
+        .testTarget(
+            name: "SwiftOptelTests",
+            dependencies: ["SwiftOptel"],
+            path: "Tests/SwiftOptelTests"
+        ),
+    ]
+)

--- a/packages/swift-optel/README.md
+++ b/packages/swift-optel/README.md
@@ -1,3 +1,73 @@
 # swift-optel
 
-Swift OpenTelemetry / RUM library for the SLICC iOS and macOS apps. Skeleton only — actual RUM logic lands in later tasks.
+Swift OpenTelemetry / RUM library for the SLICC iOS and macOS apps. Emits the same checkpoints and JSON wire format as Adobe's [`helix-rum-js`](https://github.com/adobe/helix-rum-js), using the configured app ID as the `referer` hostname.
+
+## SwiftUI auto-instrumentation
+
+Apply the root modifier once on the top-level view of each `Scene`:
+
+```swift
+import SwiftUI
+import SwiftOptel
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .optelAutoInstrument(appID: "com.example.myapp", rate: "high")
+        }
+    }
+}
+```
+
+Then opt in per view / control:
+
+```swift
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            OptelButton("Sign in", identifier: "sign-in", context: "Auth") {
+                signIn()
+            }
+
+            NavigationLink("Profile") { ProfileView() }
+                .optelTap(source: "ContentView nav#profile")
+        }
+        .optelView("Home")
+    }
+}
+
+func signIn() {
+    do {
+        try authenticate()
+    } catch {
+        Optel.reportError(error)
+    }
+}
+```
+
+| Modifier / API                       | Checkpoint   | Source                                                          |
+| ------------------------------------ | ------------ | --------------------------------------------------------------- |
+| `.optelAutoInstrument(appID:rate:)`  | `enter`      | — (also on `background → active`)                               |
+| `.optelView(_:)`                     | `navigate`   | view name                                                       |
+| `.optelTap(source:)`                 | `click`      | caller-supplied                                                 |
+| `OptelButton(...)`                   | `click`      | derived `<context> <element>#<identifier>` via accessibility id |
+| `Optel.reportError(_:)`              | `error`      | bridged `NSError.domain` + `localizedDescription`               |
+
+### Known interception limits
+
+- **Per-view opt-in only.** SwiftUI exposes no global tap / navigation
+  interception hook, so each tracked view / control must apply a modifier
+  (`.optelView`, `.optelTap`, or use `OptelButton`).
+- **Uncaught-error hook is Objective-C only.** Swift `Error` values are not
+  exceptions; only `NSException`s reach `NSSetUncaughtExceptionHandler`. Use
+  `Optel.reportError(_:)` from your own `catch` blocks for Swift errors.
+- **Foregrounding only.** `enter` re-fires on `background → active`;
+  background / suspend / inactive transitions are not mapped to a RUM
+  checkpoint.
+- **`scenePhase` requires a `Scene` ancestor.** Apply
+  `.optelAutoInstrument` inside `WindowGroup` content, not on the `App`.
+- **Reconfiguration resets the session.** Mount `.optelAutoInstrument` on
+  a stable root view; remounting re-`configure`s `Optel` and starts a fresh
+  session.

--- a/packages/swift-optel/README.md
+++ b/packages/swift-optel/README.md
@@ -47,13 +47,13 @@ func signIn() {
 }
 ```
 
-| Modifier / API                       | Checkpoint   | Source                                                          |
-| ------------------------------------ | ------------ | --------------------------------------------------------------- |
-| `.optelAutoInstrument(appID:rate:)`  | `enter`      | — (also on `background → active`)                               |
-| `.optelView(_:)`                     | `navigate`   | view name                                                       |
-| `.optelTap(source:)`                 | `click`      | caller-supplied                                                 |
-| `OptelButton(...)`                   | `click`      | derived `<context> <element>#<identifier>` via accessibility id |
-| `Optel.reportError(_:)`              | `error`      | bridged `NSError.domain` + `localizedDescription`               |
+| Modifier / API                      | Checkpoint | Source                                                          |
+| ----------------------------------- | ---------- | --------------------------------------------------------------- |
+| `.optelAutoInstrument(appID:rate:)` | `enter`    | — (also on `background → active`)                               |
+| `.optelView(_:)`                    | `navigate` | view name                                                       |
+| `.optelTap(source:)`                | `click`    | caller-supplied                                                 |
+| `OptelButton(...)`                  | `click`    | derived `<context> <element>#<identifier>` via accessibility id |
+| `Optel.reportError(_:)`             | `error`    | bridged `NSError.domain` + `localizedDescription`               |
 
 ### Known interception limits
 

--- a/packages/swift-optel/README.md
+++ b/packages/swift-optel/README.md
@@ -1,0 +1,3 @@
+# swift-optel
+
+Swift OpenTelemetry / RUM library for the SLICC iOS and macOS apps. Skeleton only — actual RUM logic lands in later tasks.

--- a/packages/swift-optel/Sources/SwiftOptel/Optel.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/Optel.swift
@@ -34,8 +34,9 @@ public final class Optel: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - appID: Identifier used as the `referer` hostname (e.g. bundle id).
-    ///   - rate: Sampling rate string (`on`/`off`/`high`/`low` or a numeric
-    ///     weight). `nil` falls back to the helix-rum-js default of `100`.
+    ///   - rate: Sampling rate string. Only the `on`/`off`/`high`/`low`
+    ///     aliases are recognized; `nil` and every other value (including
+    ///     numeric strings) fall back to the helix-rum-js default of `100`.
     ///   - collectBaseURL: Collector base URL. Defaults to `rum.hlx.page`.
     ///   - transport: Override the default ``URLSessionOptelTransport``
     ///     (tests inject a mock here).
@@ -82,9 +83,13 @@ public final class Optel: @unchecked Sendable {
         target: String? = nil,
         value: Double? = nil
     ) {
+        // Hold the lock across both `enqueue` calls so concurrent first-callers
+        // cannot interleave between flipping `hasEmittedTop` and enqueuing the
+        // auto-`top` beacon. `OptelCollector.enqueue` takes its own independent
+        // lock and never re-enters `Optel`, so this cannot deadlock.
         lock.lock()
+        defer { lock.unlock() }
         guard let session = session, let collector = collector else {
-            lock.unlock()
             return
         }
         let weight = session.weight
@@ -93,7 +98,6 @@ public final class Optel: @unchecked Sendable {
         let timeShift = max(0, Int(Date().timeIntervalSince(sessionStart) * 1000))
         let isFirst = !hasEmittedTop
         if isFirst { hasEmittedTop = true }
-        lock.unlock()
 
         let isTopRequest = checkpoint == .top
         if isFirst && !isTopRequest {

--- a/packages/swift-optel/Sources/SwiftOptel/Optel.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/Optel.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Configured entry point for the SwiftOptel client, mirroring the
+/// `sampleRUM(checkpoint, data)` surface from `helix-rum-js`.
+///
+/// Lifecycle:
+/// 1. Call ``configure(appID:rate:collectBaseURL:transport:randomSource:)`` once
+///    at app launch. This resolves a ``SamplingConfig`` from `rate`, derives a
+///    fresh session id, computes the once-per-session selection decision, and
+///    attaches an ``OptelCollector`` to the chosen ``OptelTransport``.
+/// 2. Call ``sample(_:source:target:value:)`` from anywhere; the first call
+///    automatically emits a `top` ping (matching helix-rum-js
+///    `sampleRUM.sendPing('top', 0)`), then the caller's checkpoint.
+///
+/// All mutating state is guarded by an `NSLock` so concurrent producers are
+/// safe. Re-calling ``configure`` resets the session, sampling decision,
+/// `top` flag, and start time.
+public final class Optel: @unchecked Sendable {
+    /// Shared singleton used by the static convenience methods. Callers may
+    /// instantiate their own ``Optel`` if they need isolated state (tests).
+    public static let shared = Optel()
+
+    private let lock = NSLock()
+    private var appID: String = ""
+    private var collectBaseURL: URL = RUMReferer.defaultCollectBaseURL
+    private var session: SamplingSession?
+    private var collector: OptelCollector?
+    private var sessionStart: Date = Date()
+    private var hasEmittedTop: Bool = false
+
+    public init() {}
+
+    /// Configure (or reconfigure) the client.
+    ///
+    /// - Parameters:
+    ///   - appID: Identifier used as the `referer` hostname (e.g. bundle id).
+    ///   - rate: Sampling rate string (`on`/`off`/`high`/`low` or a numeric
+    ///     weight). `nil` falls back to the helix-rum-js default of `100`.
+    ///   - collectBaseURL: Collector base URL. Defaults to `rum.hlx.page`.
+    ///   - transport: Override the default ``URLSessionOptelTransport``
+    ///     (tests inject a mock here).
+    ///   - randomSource: Override the system RNG used to compute
+    ///     `isSelected` (tests pin this for determinism).
+    public func configure(
+        appID: String,
+        rate: String? = nil,
+        collectBaseURL: URL = RUMReferer.defaultCollectBaseURL,
+        transport: OptelTransport? = nil,
+        randomSource: RandomSource? = nil
+    ) {
+        let config = SamplingConfig(rate: rate)
+        let id = RUMSessionID.generate()
+        let resolvedRandom = randomSource ?? SystemRandomSource()
+        let newSession = SamplingSession(id: id, config: config, random: resolvedRandom)
+        let resolvedTransport = transport ?? URLSessionOptelTransport()
+        let newCollector = OptelCollector(
+            transport: resolvedTransport,
+            collectBaseURL: collectBaseURL
+        )
+        newCollector.attach(session: newSession)
+
+        lock.lock()
+        self.appID = appID
+        self.collectBaseURL = collectBaseURL
+        self.session = newSession
+        self.collector = newCollector
+        self.sessionStart = Date()
+        self.hasEmittedTop = false
+        lock.unlock()
+    }
+
+    /// Sample a checkpoint. Mirrors `sampleRUM(checkpoint, { source, target, value })`.
+    ///
+    /// The first invocation after ``configure(appID:rate:collectBaseURL:transport:randomSource:)``
+    /// emits an auto-`top` beacon with `t=0`, then the caller's checkpoint.
+    /// If the caller's checkpoint is itself `.top`, the two are folded into a
+    /// single beacon so the user's payload still reaches the wire and the
+    /// `top` is not duplicated.
+    public func sample(
+        _ checkpoint: RUMCheckpoint,
+        source: String? = nil,
+        target: String? = nil,
+        value: Double? = nil
+    ) {
+        lock.lock()
+        guard let session = session, let collector = collector else {
+            lock.unlock()
+            return
+        }
+        let weight = session.weight
+        let id = session.id
+        let referer = RUMReferer.build(appID: appID, viewPath: "/")
+        let timeShift = max(0, Int(Date().timeIntervalSince(sessionStart) * 1000))
+        let isFirst = !hasEmittedTop
+        if isFirst { hasEmittedTop = true }
+        lock.unlock()
+
+        let isTopRequest = checkpoint == .top
+        if isFirst && !isTopRequest {
+            collector.enqueue(
+                RUMEvent(
+                    weight: weight,
+                    id: id,
+                    referer: referer,
+                    checkpoint: .top,
+                    t: 0
+                )
+            )
+        }
+        let pingData = RUMPingData(source: source, target: target, value: value)
+        collector.enqueue(
+            RUMEvent(
+                weight: weight,
+                id: id,
+                referer: referer,
+                checkpoint: checkpoint,
+                t: isFirst && isTopRequest ? 0 : timeShift,
+                pingData: pingData
+            )
+        )
+    }
+
+    /// Static convenience: configure the shared singleton.
+    public static func configure(
+        appID: String,
+        rate: String? = nil,
+        collectBaseURL: URL = RUMReferer.defaultCollectBaseURL
+    ) {
+        shared.configure(appID: appID, rate: rate, collectBaseURL: collectBaseURL)
+    }
+
+    /// Static convenience: sample on the shared singleton.
+    public static func sample(
+        _ checkpoint: RUMCheckpoint,
+        source: String? = nil,
+        target: String? = nil,
+        value: Double? = nil
+    ) {
+        shared.sample(checkpoint, source: source, target: target, value: value)
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/OptelCollector.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelCollector.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Session-aware buffer that holds RUM events until the sampling decision is
+/// known, then either flushes them through the configured transport or drops
+/// them entirely.
+///
+/// Behavior matches helix-rum-js: events generated before sampling has been
+/// resolved are queued; once a ``SamplingSession`` is attached, selected
+/// sessions flush the backlog and forward new events, while unselected
+/// sessions discard everything.
+public final class OptelCollector: @unchecked Sendable {
+    private let transport: OptelTransport
+    private let collectBaseURL: URL
+    private let queueLimit: Int
+    private let lock = NSLock()
+    private var buffered: [RUMEvent] = []
+    private var session: SamplingSession?
+
+    /// Construct a collector.
+    ///
+    /// - Parameters:
+    ///   - transport: Beacon sender. Defaults to ``URLSessionOptelTransport``.
+    ///   - collectBaseURL: Collector base URL.
+    ///     Defaults to `https://rum.hlx.page/`.
+    ///   - queueLimit: Maximum number of events to buffer while waiting for
+    ///     the sampling decision. Older events are dropped on overflow so a
+    ///     stuck session cannot grow unbounded.
+    public init(
+        transport: OptelTransport = URLSessionOptelTransport(),
+        collectBaseURL: URL = RUMReferer.defaultCollectBaseURL,
+        queueLimit: Int = 256
+    ) {
+        self.transport = transport
+        self.collectBaseURL = collectBaseURL
+        self.queueLimit = max(0, queueLimit)
+    }
+
+    /// Snapshot of currently buffered events. Test/debug aid.
+    public var bufferedCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return buffered.count
+    }
+
+    /// Whether a sampling session has been attached.
+    public var hasSession: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return session != nil
+    }
+
+    /// Enqueue an event. Forwarded immediately if the session is selected,
+    /// dropped if the session is unselected, otherwise buffered until
+    /// ``attach(session:)`` is called.
+    public func enqueue(_ event: RUMEvent) {
+        lock.lock()
+        if let current = session {
+            lock.unlock()
+            if current.isSelected {
+                transport.send(event, collectBaseURL: collectBaseURL)
+            }
+            return
+        }
+        buffered.append(event)
+        if buffered.count > queueLimit {
+            // Drop the oldest entries to bound memory while waiting for the
+            // sampling decision. Matches the "best-effort" nature of beacons.
+            buffered.removeFirst(buffered.count - queueLimit)
+        }
+        lock.unlock()
+    }
+
+    /// Attach the resolved sampling session and flush the backlog.
+    ///
+    /// Calling this more than once is a no-op after the first call so the
+    /// queue cannot be double-flushed.
+    public func attach(session newSession: SamplingSession) {
+        lock.lock()
+        guard session == nil else {
+            lock.unlock()
+            return
+        }
+        session = newSession
+        let pending = buffered
+        buffered.removeAll(keepingCapacity: false)
+        lock.unlock()
+
+        guard newSession.isSelected else { return }
+        for event in pending {
+            transport.send(event, collectBaseURL: collectBaseURL)
+        }
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/OptelErrorReporting.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelErrorReporting.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Resolved `source` / `target` pair for an `error` checkpoint.
+///
+/// Mapping is bridge-based so it works uniformly for Swift `Error` values
+/// (bridged to `NSError`) and Objective-C `NSException` instances surfaced by
+/// the uncaught-exception hook.
+public struct OptelErrorMapping: Hashable, Sendable {
+    /// The grouping key (error domain or exception name).
+    public let source: String
+    /// The free-form detail (localized description, reason, or code).
+    public let target: String
+
+    public init(source: String, target: String) {
+        self.source = source
+        self.target = target
+    }
+
+    /// Map a Swift `Error`. Uses the bridged `NSError.domain` as `source`
+    /// (which yields `<Module>.<TypeName>` for plain Swift error enums) and
+    /// `localizedDescription` as `target`.
+    public static func from(error: Error) -> OptelErrorMapping {
+        let nsError = error as NSError
+        let domain = nsError.domain.trimmingCharacters(in: .whitespacesAndNewlines)
+        let source = domain.isEmpty ? String(describing: type(of: error)) : domain
+        let description = nsError.localizedDescription
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let target = description.isEmpty ? String(nsError.code) : description
+        return OptelErrorMapping(source: source, target: target)
+    }
+
+    /// Map an Objective-C `NSException`. Uses `name.rawValue` as `source` and
+    /// `reason` (or `description`) as `target`.
+    public static func from(exception: NSException) -> OptelErrorMapping {
+        let rawName = exception.name.rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let source = rawName.isEmpty ? "NSException" : rawName
+        let reason = (exception.reason ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let target = reason.isEmpty ? exception.description : reason
+        return OptelErrorMapping(source: source, target: target)
+    }
+}
+
+extension Optel {
+    /// Report a Swift `Error` as an `error` checkpoint. `source` and `target`
+    /// are derived from the error's bridged `NSError` representation.
+    public func reportError(_ error: Error) {
+        let mapping = OptelErrorMapping.from(error: error)
+        sample(.error, source: mapping.source, target: mapping.target)
+    }
+
+    /// Static convenience: report an error on the shared singleton.
+    public static func reportError(_ error: Error) {
+        shared.reportError(error)
+    }
+}
+
+/// Module-private holder for the handler that was installed before
+/// ``OptelUncaughtExceptionHook/installIfNeeded()`` ran. `NSSetUncaughtExceptionHandler`
+/// takes a C function pointer, so the trampoline below cannot capture the
+/// previous handler in a closure and must reach it via this file-scope `var`.
+private var optelPreviousUncaughtExceptionHandler: (@convention(c) (NSException) -> Void)?
+
+/// File-scope C trampoline registered with `NSSetUncaughtExceptionHandler`.
+/// Emits an `error` checkpoint on the shared ``Optel`` and then chains to the
+/// previously-installed handler so crash reporters keep working.
+private func optelUncaughtExceptionTrampoline(_ exception: NSException) {
+    let mapping = OptelErrorMapping.from(exception: exception)
+    Optel.shared.sample(.error, source: mapping.source, target: mapping.target)
+    optelPreviousUncaughtExceptionHandler?(exception)
+}
+
+/// Install / inspect the best-effort uncaught-exception hook used by the
+/// SwiftUI auto-instrument modifier.
+///
+/// The hook catches Objective-C `NSException`s only — Swift errors are values,
+/// not exceptions, and cannot be intercepted globally. The previously-installed
+/// handler (if any) is chained so this plays nicely with crash reporters that
+/// also hook `NSSetUncaughtExceptionHandler`.
+public enum OptelUncaughtExceptionHook {
+    private static let lock = NSLock()
+    private static var installed = false
+
+    /// `true` once the hook has been installed for this process.
+    public static var isInstalled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return installed
+    }
+
+    /// Install the hook if it has not been installed yet. Safe to call from
+    /// any thread; subsequent calls are no-ops.
+    public static func installIfNeeded() {
+        lock.lock()
+        guard !installed else {
+            lock.unlock()
+            return
+        }
+        installed = true
+        optelPreviousUncaughtExceptionHandler = NSGetUncaughtExceptionHandler()
+        lock.unlock()
+        NSSetUncaughtExceptionHandler(optelUncaughtExceptionTrampoline)
+    }
+
+    /// Test-only reset of the install latch. Does **not** uninstall the
+    /// handler from the runtime (the system API only allows replacement).
+    internal static func _testing_reset() {
+        lock.lock()
+        installed = false
+        lock.unlock()
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/OptelSourceDeriver.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelSourceDeriver.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Builds the `source` selector string carried on RUM beacons.
+///
+/// Mirrors the helix-rum-enhancer convention of `<context> <element>#<identifier>`
+/// (e.g. `"main button#submit"`), adapted for native UI hierarchies where the
+/// only signals available are accessibility identifier / label and an optional
+/// parent context (typically the view name).
+///
+/// Pure value type with no SwiftUI dependency so it can be unit-tested on every
+/// platform.
+public enum OptelSourceDeriver {
+    /// Compose a source selector from the parts a native UI control can supply.
+    ///
+    /// - Parameters:
+    ///   - element: The element class (e.g. `"button"`, `"view"`). Required —
+    ///     anchors the selector even when nothing else is known.
+    ///   - identifier: Accessibility identifier. Rendered as `#identifier`.
+    ///   - label: Accessibility / visible label. Rendered as `"label"` when no
+    ///     identifier is available.
+    ///   - context: Optional parent context (e.g. owning view name). Rendered
+    ///     as a leading token separated by a space.
+    public static func source(
+        element: String,
+        identifier: String? = nil,
+        label: String? = nil,
+        context: String? = nil
+    ) -> String {
+        let trimmedElement = trimmed(element) ?? "view"
+        let trimmedIdentifier = trimmed(identifier)
+        let trimmedLabel = trimmed(label)
+        let trimmedContext = trimmed(context)
+
+        let core: String
+        if let identifier = trimmedIdentifier {
+            core = "\(trimmedElement)#\(identifier)"
+        } else if let label = trimmedLabel {
+            core = "\(trimmedElement) \"\(label)\""
+        } else {
+            core = trimmedElement
+        }
+
+        if let context = trimmedContext {
+            return "\(context) \(core)"
+        }
+        return core
+    }
+
+    /// Trim whitespace and return `nil` for empty / whitespace-only inputs.
+    private static func trimmed(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let result = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return result.isEmpty ? nil : result
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/OptelSwiftUI.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelSwiftUI.swift
@@ -36,7 +36,11 @@ public struct OptelAutoInstrumentModifier: ViewModifier {
     let appID: String
     let rate: String?
     @State private var configured = false
-    @State private var lastPhase: ScenePhase = .inactive
+    // Sticky "has been backgrounded" flag. SwiftUI scene transitions go
+    // `.background → .inactive → .active`, so we cannot infer "was just
+    // backgrounded" from only the immediately previous phase: `.inactive`
+    // would otherwise overwrite that signal before `.active` arrives.
+    @State private var wasBackgrounded = false
 
     public func body(content: Content) -> some View {
         content
@@ -45,16 +49,34 @@ public struct OptelAutoInstrumentModifier: ViewModifier {
                 Optel.configure(appID: appID, rate: rate)
                 OptelUncaughtExceptionHook.installIfNeeded()
                 Optel.sample(.enter)
-                lastPhase = scenePhase
                 configured = true
             }
             .onChange(of: scenePhase) { newPhase in
-                let wasBackground = lastPhase == .background
-                lastPhase = newPhase
-                if newPhase == .active && wasBackground {
+                let next = OptelAutoInstrumentModifier.nextState(
+                    forNewPhase: newPhase,
+                    wasBackgrounded: wasBackgrounded
+                )
+                wasBackgrounded = next.wasBackgrounded
+                if next.shouldFireEnter {
                     Optel.sample(.enter)
                 }
             }
+    }
+
+    /// Pure state-transition for the scene-phase tracker. Exposed for tests
+    /// so the `.background → .inactive → .active` re-fire can be locked in
+    /// without driving a live SwiftUI scene.
+    static func nextState(
+        forNewPhase newPhase: ScenePhase,
+        wasBackgrounded: Bool
+    ) -> (shouldFireEnter: Bool, wasBackgrounded: Bool) {
+        if newPhase == .background {
+            return (false, true)
+        }
+        if newPhase == .active && wasBackgrounded {
+            return (true, false)
+        }
+        return (false, wasBackgrounded)
     }
 }
 

--- a/packages/swift-optel/Sources/SwiftOptel/OptelSwiftUI.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelSwiftUI.swift
@@ -1,0 +1,148 @@
+#if canImport(SwiftUI)
+import Foundation
+import SwiftUI
+
+// MARK: - View extensions
+
+@available(iOS 16.0, macOS 13.0, *)
+extension View {
+    /// Root-level auto-instrumentation. Configures ``Optel`` once, fires an
+    /// `enter` checkpoint on launch, re-fires `enter` whenever the scene
+    /// returns to `.active` from `.background`, and installs the best-effort
+    /// uncaught Objective-C exception hook.
+    public func optelAutoInstrument(appID: String, rate: String? = nil) -> some View {
+        modifier(OptelAutoInstrumentModifier(appID: appID, rate: rate))
+    }
+
+    /// Per-view instrumentation. Emits a `navigate` checkpoint with `source`
+    /// set to `name` whenever the view appears.
+    public func optelView(_ name: String) -> some View {
+        modifier(OptelViewModifier(name: name))
+    }
+
+    /// Per-control click instrumentation. Attaches a `simultaneousGesture`
+    /// that emits a `click` checkpoint with the supplied `source`. The
+    /// underlying view's own tap handling is preserved.
+    public func optelTap(source: String) -> some View {
+        modifier(OptelTapModifier(source: source))
+    }
+}
+
+// MARK: - Modifiers
+
+@available(iOS 16.0, macOS 13.0, *)
+public struct OptelAutoInstrumentModifier: ViewModifier {
+    @Environment(\.scenePhase) private var scenePhase
+    let appID: String
+    let rate: String?
+    @State private var configured = false
+    @State private var lastPhase: ScenePhase = .inactive
+
+    public func body(content: Content) -> some View {
+        content
+            .task {
+                guard !configured else { return }
+                Optel.configure(appID: appID, rate: rate)
+                OptelUncaughtExceptionHook.installIfNeeded()
+                Optel.sample(.enter)
+                lastPhase = scenePhase
+                configured = true
+            }
+            .onChange(of: scenePhase) { newPhase in
+                let wasBackground = lastPhase == .background
+                lastPhase = newPhase
+                if newPhase == .active && wasBackground {
+                    Optel.sample(.enter)
+                }
+            }
+    }
+}
+
+@available(iOS 16.0, macOS 13.0, *)
+public struct OptelViewModifier: ViewModifier {
+    let name: String
+
+    public func body(content: Content) -> some View {
+        content.onAppear {
+            Optel.sample(.navigate, source: name)
+        }
+    }
+}
+
+@available(iOS 16.0, macOS 13.0, *)
+public struct OptelTapModifier: ViewModifier {
+    let source: String
+
+    public func body(content: Content) -> some View {
+        content.simultaneousGesture(TapGesture().onEnded {
+            Optel.sample(.click, source: source)
+        })
+    }
+}
+
+// MARK: - OptelButton
+
+/// `Button` wrapper that emits a `click` checkpoint with a source derived from
+/// the supplied accessibility identifier / label / context, then runs the
+/// caller's action.
+///
+/// Two initializers are provided: a free-form one taking a custom label view,
+/// and a convenience one mirroring `Button(_:action:)` that uses the title as
+/// both the visible label and the accessibility label.
+@available(iOS 16.0, macOS 13.0, *)
+public struct OptelButton<Label: View>: View {
+    private let identifier: String?
+    private let accessibilityLabel: String?
+    private let context: String?
+    private let action: () -> Void
+    private let labelBuilder: () -> Label
+
+    public init(
+        identifier: String? = nil,
+        accessibilityLabel: String? = nil,
+        context: String? = nil,
+        action: @escaping () -> Void,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        self.identifier = identifier
+        self.accessibilityLabel = accessibilityLabel
+        self.context = context
+        self.action = action
+        self.labelBuilder = label
+    }
+
+    public var body: some View {
+        Button(action: {
+            let derived = OptelSourceDeriver.source(
+                element: "button",
+                identifier: identifier,
+                label: accessibilityLabel,
+                context: context
+            )
+            Optel.sample(.click, source: derived)
+            action()
+        }, label: labelBuilder)
+    }
+}
+
+@available(iOS 16.0, macOS 13.0, *)
+extension OptelButton where Label == Text {
+    /// Convenience initializer that uses `title` as both the visible label
+    /// and the derived accessibility label.
+    public init(
+        _ title: String,
+        identifier: String? = nil,
+        context: String? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.init(
+            identifier: identifier,
+            accessibilityLabel: title,
+            context: context,
+            action: action,
+            label: { Text(title) }
+        )
+    }
+}
+
+#endif

--- a/packages/swift-optel/Sources/SwiftOptel/OptelTransport.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelTransport.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Fire-and-forget beacon transport. Implementations send a single
+/// ``RUMEvent`` to the collector identified by `collectBaseURL` and must
+/// never block the caller or surface network errors.
+public protocol OptelTransport: Sendable {
+    /// Send an event. Errors are swallowed; the call returns immediately.
+    func send(_ event: RUMEvent, collectBaseURL: URL)
+}
+
+/// Default ``OptelTransport`` backed by `URLSession`.
+///
+/// Mirrors `navigator.sendBeacon` semantics from `helix-rum-js`:
+/// - `POST {collectBaseURL}/.rum/{weight}` with `Content-Type: application/json`.
+/// - Body is the JSON-encoded ``RUMEvent`` (with `pingData` flattened).
+/// - Uses an ephemeral, non-caching `URLSession` and a finite per-request
+///   timeout so a stuck collector cannot retain memory indefinitely.
+/// - The returned `URLSessionDataTask` is resumed and discarded; any
+///   transport / decode error from the completion handler is silently
+///   dropped.
+public final class URLSessionOptelTransport: OptelTransport {
+    /// Default per-request timeout. Beacons are best-effort, so a short
+    /// window is preferable to letting requests pile up.
+    public static let defaultTimeout: TimeInterval = 10
+
+    private let session: URLSession
+    private let timeout: TimeInterval
+    private let encoder: JSONEncoder
+
+    /// Construct a transport.
+    ///
+    /// - Parameters:
+    ///   - session: Override for testing; defaults to an ephemeral session.
+    ///   - timeout: Per-request timeout in seconds.
+    public init(
+        session: URLSession = URLSessionOptelTransport.makeDefaultSession(),
+        timeout: TimeInterval = URLSessionOptelTransport.defaultTimeout
+    ) {
+        self.session = session
+        self.timeout = timeout
+        self.encoder = JSONEncoder()
+    }
+
+    public func send(_ event: RUMEvent, collectBaseURL: URL) {
+        guard let request = Self.makeRequest(
+            event: event,
+            collectBaseURL: collectBaseURL,
+            timeout: timeout,
+            encoder: encoder
+        ) else {
+            return
+        }
+        let task = session.dataTask(with: request) { _, _, _ in
+            // Fire-and-forget: beacon failures are non-actionable; never
+            // propagate them back to the caller. This is the Swift analogue
+            // of the JS `.catch(() => {})` swallow.
+        }
+        task.resume()
+    }
+
+    /// Default ephemeral session: no on-disk cache, no cookie persistence,
+    /// short request timeout suitable for beacon traffic.
+    public static func makeDefaultSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = defaultTimeout
+        config.timeoutIntervalForResource = defaultTimeout
+        config.waitsForConnectivity = false
+        config.urlCache = nil
+        return URLSession(configuration: config)
+    }
+
+    /// Build the `URLRequest` for a single beacon. Exposed `internal` so the
+    /// test suite can assert URL / method / headers / body without exercising
+    /// the network. Returns `nil` if URL composition fails.
+    static func makeRequest(
+        event: RUMEvent,
+        collectBaseURL: URL,
+        timeout: TimeInterval,
+        encoder: JSONEncoder = JSONEncoder()
+    ) -> URLRequest? {
+        // `URL(string: ".rum/\(weight)", relativeTo: base)` matches the
+        // `new URL('.rum/' + weight, collectBaseURL)` construction used by
+        // helix-rum-js: relative to the base path, with the trailing slash
+        // on `https://rum.hlx.page/` producing `…/.rum/{weight}`.
+        guard let url = URL(string: ".rum/\(event.weight)", relativeTo: collectBaseURL) else {
+            return nil
+        }
+        guard let body = try? encoder.encode(event) else {
+            return nil
+        }
+        var request = URLRequest(url: url.absoluteURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = timeout
+        request.httpBody = body
+        return request
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/RUMEvent.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/RUMEvent.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// On-the-wire checkpoint name for a RUM event. Mirrors the helix-rum-js
+/// enumeration; `raw` carries any future/unknown checkpoint string through
+/// without modification.
+public enum RUMCheckpoint: Hashable, Sendable {
+    case top
+    case enter
+    case navigate
+    case reload
+    case cwv
+    case pagesviewed
+    case click
+    case viewblock
+    case viewmedia
+    case formsubmit
+    case error
+    case raw(String)
+
+    /// Wire-format string for the checkpoint.
+    public var rawValue: String {
+        switch self {
+        case .top: return "top"
+        case .enter: return "enter"
+        case .navigate: return "navigate"
+        case .reload: return "reload"
+        case .cwv: return "cwv"
+        case .pagesviewed: return "pagesviewed"
+        case .click: return "click"
+        case .viewblock: return "viewblock"
+        case .viewmedia: return "viewmedia"
+        case .formsubmit: return "formsubmit"
+        case .error: return "error"
+        case .raw(let value): return value
+        }
+    }
+}
+
+/// Optional `source` / `target` / `value` payload for a RUM event. Flattened
+/// into the top-level JSON envelope at encode time rather than nested, to
+/// match the helix-rum-js wire format (`{ ...pingData }`).
+public struct RUMPingData: Hashable, Sendable {
+    public var source: String?
+    public var target: String?
+    public var value: Double?
+
+    public init(source: String? = nil, target: String? = nil, value: Double? = nil) {
+        self.source = source
+        self.target = target
+        self.value = value
+    }
+
+    /// `true` when none of `source` / `target` / `value` are set.
+    public var isEmpty: Bool {
+        source == nil && target == nil && value == nil
+    }
+}
+
+/// One RUM event ready to be POSTed to the collector. The JSON encoding is
+/// byte-compatible with helix-rum-js `sampleRUM.sendPing`:
+///
+/// ```json
+/// { "weight": 100, "id": "abc123def", "referer": "...", "checkpoint": "click",
+///   "t": 1234, "source": "...", "target": "...", "value": 42 }
+/// ```
+///
+/// `pingData` is flattened onto the top-level object; absent fields are
+/// omitted entirely (not encoded as `null`).
+public struct RUMEvent: Hashable, Sendable {
+    public var weight: Int
+    public var id: String
+    public var referer: String
+    public var checkpoint: RUMCheckpoint
+    public var t: Int
+    public var pingData: RUMPingData
+
+    public init(
+        weight: Int,
+        id: String,
+        referer: String,
+        checkpoint: RUMCheckpoint,
+        t: Int,
+        pingData: RUMPingData = RUMPingData()
+    ) {
+        self.weight = weight
+        self.id = id
+        self.referer = referer
+        self.checkpoint = checkpoint
+        self.t = t
+        self.pingData = pingData
+    }
+}
+
+extension RUMEvent: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case weight, id, referer, checkpoint, t, source, target, value
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(weight, forKey: .weight)
+        try container.encode(id, forKey: .id)
+        try container.encode(referer, forKey: .referer)
+        try container.encode(checkpoint.rawValue, forKey: .checkpoint)
+        try container.encode(t, forKey: .t)
+        try container.encodeIfPresent(pingData.source, forKey: .source)
+        try container.encodeIfPresent(pingData.target, forKey: .target)
+        try container.encodeIfPresent(pingData.value, forKey: .value)
+    }
+}
+
+/// Generator for the 9-character session id used by helix-rum-js
+/// (`crypto.randomUUID().slice(-9)`). The JS implementation lowercases UUIDs,
+/// so we lowercase the Swift `UUID().uuidString` (which is uppercase by
+/// default) before slicing.
+public enum RUMSessionID {
+    /// Returns a fresh 9-character session id derived from a v4 UUID.
+    public static func generate() -> String {
+        let uuid = UUID().uuidString.lowercased()
+        return String(uuid.suffix(9))
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/RUMReferer.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/RUMReferer.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Builds the helix-rum-js `referer` string from a configured app id and the
+/// current view path.
+///
+/// In `helix-rum-js`, `referer = window.location.origin + window.location.pathname`.
+/// Native apps have no URL, so we substitute the app id (typically a bundle
+/// identifier such as `com.example.app`) as the hostname:
+///
+/// ```
+/// https://{appID}{viewPath}
+/// ```
+///
+/// `viewPath` is normalized to always begin with `/` so the result mirrors a
+/// browser `origin + pathname` value even when callers pass an empty or
+/// relative path.
+public enum RUMReferer {
+    /// Default collector base URL, matching `helix-rum-js` (`https://rum.hlx.page/`).
+    public static let defaultCollectBaseURL = URL(string: "https://rum.hlx.page/")!
+
+    /// Construct a `referer` string from an app id and view path.
+    ///
+    /// - Parameters:
+    ///   - appID: Application identifier used as the URL hostname.
+    ///   - viewPath: Path component for the current view. May be empty,
+    ///     leading-slash-prefixed, or relative; the result always has a
+    ///     leading slash after the host.
+    public static func build(appID: String, viewPath: String = "/") -> String {
+        let normalized: String
+        if viewPath.isEmpty {
+            normalized = "/"
+        } else if viewPath.hasPrefix("/") {
+            normalized = viewPath
+        } else {
+            normalized = "/" + viewPath
+        }
+        return "https://\(appID)\(normalized)"
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/RandomSource.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/RandomSource.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Source of uniformly distributed `Double` values in `[0, 1)`.
+///
+/// Abstracted so sampling decisions can be made deterministic in tests by
+/// injecting a fixed/stubbed RNG. Mirrors the JS `Math.random()` contract.
+public protocol RandomSource {
+    /// Returns a `Double` in `[0, 1)`.
+    func nextUnitDouble() -> Double
+}
+
+/// Default ``RandomSource`` backed by the standard library's system RNG.
+public struct SystemRandomSource: RandomSource {
+    public init() {}
+
+    public func nextUnitDouble() -> Double {
+        Double.random(in: 0..<1)
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/SamplingConfig.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/SamplingConfig.swift
@@ -3,9 +3,9 @@ import Foundation
 /// Resolved sampling configuration: the integer weight that drives the
 /// per-session selection coin flip.
 ///
-/// Mirrors helix-rum-js: rate aliases (`on`, `off`, `high`, `low`) map to
-/// specific weights; numeric strings parse as the literal weight; anything
-/// else (including `nil`) falls back to the default weight of `100`.
+/// Mirrors helix-rum-js exactly: only the rate aliases (`on`, `off`, `high`,
+/// `low`) map to specific weights; anything else — including numeric strings
+/// and `nil` — falls back to the default weight of `100`.
 public struct SamplingConfig: Equatable {
     /// Sampling weight. `0` disables sampling; higher values reduce the
     /// probability of selection (`1 / weight`).
@@ -21,14 +21,15 @@ public struct SamplingConfig: Equatable {
         self.weight = weight
     }
 
-    /// Build a config from a rate string (alias or numeric). `nil` / unknown
-    /// values fall back to ``SamplingConfig/defaultWeight``.
+    /// Build a config from a rate string. Only the `on`/`off`/`high`/`low`
+    /// aliases are recognized; `nil` and every other value (including numeric
+    /// strings) fall back to ``SamplingConfig/defaultWeight``.
     public init(rate: String?) {
         self.weight = SamplingConfig.parseWeight(from: rate)
     }
 
     /// Resolve a rate string to its integer weight, matching the helix-rum-js
-    /// `rateValue` table plus numeric-string passthrough.
+    /// `rateValue` table.
     public static func parseWeight(from rate: String?) -> Int {
         guard let rate else { return defaultWeight }
         switch rate {
@@ -36,9 +37,7 @@ public struct SamplingConfig: Equatable {
         case "off": return 0
         case "high": return 10
         case "low": return 1000
-        default:
-            if let parsed = Int(rate) { return parsed }
-            return defaultWeight
+        default: return defaultWeight
         }
     }
 }

--- a/packages/swift-optel/Sources/SwiftOptel/SamplingConfig.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/SamplingConfig.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Resolved sampling configuration: the integer weight that drives the
+/// per-session selection coin flip.
+///
+/// Mirrors helix-rum-js: rate aliases (`on`, `off`, `high`, `low`) map to
+/// specific weights; numeric strings parse as the literal weight; anything
+/// else (including `nil`) falls back to the default weight of `100`.
+public struct SamplingConfig: Equatable {
+    /// Sampling weight. `0` disables sampling; higher values reduce the
+    /// probability of selection (`1 / weight`).
+    public let weight: Int
+
+    /// Default helix-rum-js weight used when no rate was supplied.
+    public static let defaultWeight: Int = 100
+
+    /// Default configuration (`weight = 100`).
+    public static let `default` = SamplingConfig(weight: defaultWeight)
+
+    public init(weight: Int) {
+        self.weight = weight
+    }
+
+    /// Build a config from a rate string (alias or numeric). `nil` / unknown
+    /// values fall back to ``SamplingConfig/defaultWeight``.
+    public init(rate: String?) {
+        self.weight = SamplingConfig.parseWeight(from: rate)
+    }
+
+    /// Resolve a rate string to its integer weight, matching the helix-rum-js
+    /// `rateValue` table plus numeric-string passthrough.
+    public static func parseWeight(from rate: String?) -> Int {
+        guard let rate else { return defaultWeight }
+        switch rate {
+        case "on": return 1
+        case "off": return 0
+        case "high": return 10
+        case "low": return 1000
+        default:
+            if let parsed = Int(rate) { return parsed }
+            return defaultWeight
+        }
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/SamplingSession.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/SamplingSession.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Per-session sampling state: the stable session id, the resolved weight,
+/// and the cached selection decision.
+///
+/// Mirrors helix-rum-js: `isSelected` is computed once from
+/// `weight > 0 && random * weight < 1` and reused for the lifetime of the
+/// session. Construct one instance per process/session and share it.
+public struct SamplingSession {
+    /// Stable 9-char session id (sourced externally; this type does not
+    /// generate it).
+    public let id: String
+
+    /// Sampling weight in effect for this session.
+    public let weight: Int
+
+    /// Cached selection decision. `true` means pings should be emitted.
+    public let isSelected: Bool
+
+    /// Construct a session, computing ``isSelected`` exactly once from the
+    /// supplied ``RandomSource``.
+    public init(
+        id: String,
+        config: SamplingConfig,
+        random: RandomSource = SystemRandomSource()
+    ) {
+        self.id = id
+        self.weight = config.weight
+        self.isSelected = SamplingSession.computeIsSelected(
+            weight: config.weight,
+            random: random
+        )
+    }
+
+    /// Pure selection predicate matching helix-rum-js:
+    /// `weight > 0 && random * weight < 1`.
+    public static func computeIsSelected(weight: Int, random: RandomSource) -> Bool {
+        guard weight > 0 else { return false }
+        return random.nextUnitDouble() * Double(weight) < 1.0
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/SwiftOptel.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/SwiftOptel.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Placeholder entry point for the SwiftOptel library.
+///
+/// The real RUM / OpenTelemetry surface is implemented in later tasks; this
+/// type only exists so the package has something to build and test against.
+public enum SwiftOptel {
+    /// Package version string. Bumped manually when the surface stabilizes.
+    public static let version = "0.0.0"
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/CrossImplementationTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/CrossImplementationTests.swift
@@ -1,0 +1,247 @@
+import XCTest
+@testable import SwiftOptel
+
+/// Pinned cross-implementation wire-format vectors.
+///
+/// Locks the encoded JSON body + collector URL emitted by
+/// ``URLSessionOptelTransport`` against fixtures derived from
+/// `helix-rum-js` `sampleRUM.sendPing`
+/// (https://github.com/adobe/helix-rum-js, `src/index.js`):
+///
+///     const rumData = JSON.stringify({
+///       weight, id,
+///       referer: window.location.origin + window.location.pathname,
+///       checkpoint: ck, t: time, ...pingData,
+///     });
+///     const { href: url } = new URL(`.rum/${weight}`, sampleRUM.collectBaseURL);
+///     navigator.sendBeacon(url, new Blob([rumData], { type: 'application/json' }));
+///
+/// The Swift port substitutes the app id as the URL host of `referer` (native
+/// apps have no `window.location`); the rest of the envelope is byte-compatible.
+///
+/// JSON-object key ordering is NOT part of the wire contract — comparison is
+/// done against the parsed object (`NSDictionary`) so this suite is robust to
+/// `JSONEncoder` key-ordering changes across Swift toolchains while still
+/// pinning every value and the absence of any extra fields.
+///
+/// Parallels `packages/swift-server/Tests/CrossImplementationTests.swift`,
+/// which pins the secret-masking wire format against the JS reference.
+final class CrossImplementationTests: XCTestCase {
+    private struct Vector {
+        let name: String
+        let event: RUMEvent
+        let collectBaseURL: URL
+        let expectedURL: String
+        /// Reference JSON body string as `helix-rum-js` `sampleRUM.sendPing`
+        /// would emit it. Compared as a parsed object, not byte-for-byte.
+        let expectedBody: String
+    }
+
+    private static let defaultBase = URL(string: "https://rum.hlx.page/")!
+
+    private static let vectors: [Vector] = [
+        // Default weight (100), first `top` ping on session start, no pingData.
+        Vector(
+            name: "top-default-weight",
+            event: RUMEvent(
+                weight: 100,
+                id: "abc123def",
+                referer: "https://com.example.app/",
+                checkpoint: .top,
+                t: 0
+            ),
+            collectBaseURL: defaultBase,
+            expectedURL: "https://rum.hlx.page/.rum/100",
+            expectedBody: """
+            {"weight":100,"id":"abc123def","referer":"https://com.example.app/",\
+            "checkpoint":"top","t":0}
+            """
+        ),
+        // `click` checkpoint with full pingData (source + target + value).
+        Vector(
+            name: "click-full-pingdata",
+            event: RUMEvent(
+                weight: 100,
+                id: "abc123def",
+                referer: "https://com.example.app/home",
+                checkpoint: .click,
+                t: 1234,
+                pingData: RUMPingData(
+                    source: ".button#submit",
+                    target: "/api/checkout",
+                    value: 42
+                )
+            ),
+            collectBaseURL: defaultBase,
+            expectedURL: "https://rum.hlx.page/.rum/100",
+            expectedBody: """
+            {"weight":100,"id":"abc123def","referer":"https://com.example.app/home",\
+            "checkpoint":"click","t":1234,"source":".button#submit",\
+            "target":"/api/checkout","value":42}
+            """
+        ),
+        // `rate=on` → weight 1; URL path carries the weight verbatim.
+        Vector(
+            name: "rate-on-weight-1",
+            event: RUMEvent(
+                weight: 1,
+                id: "000000001",
+                referer: "https://com.example.app/settings",
+                checkpoint: .navigate,
+                t: 500,
+                pingData: RUMPingData(source: "SettingsView")
+            ),
+            collectBaseURL: defaultBase,
+            expectedURL: "https://rum.hlx.page/.rum/1",
+            expectedBody: """
+            {"weight":1,"id":"000000001","referer":"https://com.example.app/settings",\
+            "checkpoint":"navigate","t":500,"source":"SettingsView"}
+            """
+        ),
+        // `rate=high` → weight 10.
+        Vector(
+            name: "rate-high-weight-10",
+            event: RUMEvent(
+                weight: 10,
+                id: "deadbeef0",
+                referer: "https://com.example.app/",
+                checkpoint: .enter,
+                t: 0
+            ),
+            collectBaseURL: defaultBase,
+            expectedURL: "https://rum.hlx.page/.rum/10",
+            expectedBody: """
+            {"weight":10,"id":"deadbeef0","referer":"https://com.example.app/",\
+            "checkpoint":"enter","t":0}
+            """
+        ),
+        // `rate=low` → weight 1000.
+        Vector(
+            name: "rate-low-weight-1000",
+            event: RUMEvent(
+                weight: 1000,
+                id: "feedface1",
+                referer: "https://com.example.app/error",
+                checkpoint: .error,
+                t: 9999,
+                pingData: RUMPingData(
+                    source: "NSCocoaErrorDomain",
+                    target: "File not found"
+                )
+            ),
+            collectBaseURL: defaultBase,
+            expectedURL: "https://rum.hlx.page/.rum/1000",
+            expectedBody: """
+            {"weight":1000,"id":"feedface1","referer":"https://com.example.app/error",\
+            "checkpoint":"error","t":9999,"source":"NSCocoaErrorDomain",\
+            "target":"File not found"}
+            """
+        ),
+        // Custom `collectBaseURL` with a non-root path. Mirrors the JS
+        // `new URL('.rum/' + weight, collectBaseURL)` relative-resolution
+        // semantics: the trailing slash on the base preserves the path prefix.
+        Vector(
+            name: "custom-collector-base",
+            event: RUMEvent(
+                weight: 100,
+                id: "cafebabe0",
+                referer: "https://com.example.app/",
+                checkpoint: .top,
+                t: 0
+            ),
+            collectBaseURL: URL(string: "https://custom.example.com/path/")!,
+            expectedURL: "https://custom.example.com/path/.rum/100",
+            expectedBody: """
+            {"weight":100,"id":"cafebabe0","referer":"https://com.example.app/",\
+            "checkpoint":"top","t":0}
+            """
+        ),
+    ]
+
+    func testCollectorURLMatchesHelixRumJsForAllVectors() throws {
+        for v in Self.vectors {
+            let request = try XCTUnwrap(
+                URLSessionOptelTransport.makeRequest(
+                    event: v.event,
+                    collectBaseURL: v.collectBaseURL,
+                    timeout: 10
+                ),
+                "makeRequest returned nil for vector \(v.name)"
+            )
+            XCTAssertEqual(
+                request.url?.absoluteString,
+                v.expectedURL,
+                "URL mismatch for vector \(v.name)"
+            )
+        }
+    }
+
+    func testHTTPMethodAndContentTypeMatchHelixRumJsBeacon() throws {
+        for v in Self.vectors {
+            let request = try XCTUnwrap(
+                URLSessionOptelTransport.makeRequest(
+                    event: v.event,
+                    collectBaseURL: v.collectBaseURL,
+                    timeout: 10
+                ),
+                "makeRequest returned nil for vector \(v.name)"
+            )
+            XCTAssertEqual(request.httpMethod, "POST", "method mismatch for \(v.name)")
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Content-Type"),
+                "application/json",
+                "Content-Type mismatch for \(v.name)"
+            )
+        }
+    }
+
+    func testEncodedBodyMatchesHelixRumJsFixtureForAllVectors() throws {
+        for v in Self.vectors {
+            let actualData = try JSONEncoder().encode(v.event)
+            let actualObject = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: actualData) as? NSDictionary,
+                "could not parse encoded body for \(v.name)"
+            )
+            let expectedObject = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: Data(v.expectedBody.utf8)) as? NSDictionary,
+                "could not parse expected fixture for \(v.name)"
+            )
+            XCTAssertEqual(
+                actualObject,
+                expectedObject,
+                "body mismatch for vector \(v.name)"
+            )
+        }
+    }
+
+    func testRequestBodyParsesToSameObjectAsExpectedFixture() throws {
+        // What the transport puts on the wire must parse to the same JSON
+        // object as the helix-rum-js fixture. Compared as parsed objects so
+        // the assertion is independent of `JSONEncoder` key-ordering (which
+        // is implementation-defined across Swift toolchains).
+        for v in Self.vectors {
+            let request = try XCTUnwrap(
+                URLSessionOptelTransport.makeRequest(
+                    event: v.event,
+                    collectBaseURL: v.collectBaseURL,
+                    timeout: 10
+                ),
+                "makeRequest returned nil for vector \(v.name)"
+            )
+            let body = try XCTUnwrap(request.httpBody, "missing body for \(v.name)")
+            let actualObject = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: body) as? NSDictionary,
+                "could not parse request body for \(v.name)"
+            )
+            let expectedObject = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: Data(v.expectedBody.utf8)) as? NSDictionary,
+                "could not parse expected fixture for \(v.name)"
+            )
+            XCTAssertEqual(
+                actualObject,
+                expectedObject,
+                "wire-format body mismatch for vector \(v.name)"
+            )
+        }
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelCollectorTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelCollectorTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import SwiftOptel
+
+/// Deterministic ``RandomSource`` for sampling-session construction.
+private struct FixedRandomSource: RandomSource {
+    let value: Double
+    func nextUnitDouble() -> Double { value }
+}
+
+final class OptelCollectorTests: XCTestCase {
+    private let baseURL = URL(string: "https://rum.hlx.page/")!
+
+    private func event(_ checkpoint: RUMCheckpoint, t: Int = 0) -> RUMEvent {
+        RUMEvent(
+            weight: 100,
+            id: "abc123def",
+            referer: "https://com.example.app/",
+            checkpoint: checkpoint,
+            t: t
+        )
+    }
+
+    private func session(selected: Bool, weight: Int = 100) -> SamplingSession {
+        // weight=1 + random=0 → selected (0 * 1 < 1).
+        // weight=100 + random=0.99 → not selected (0.99 * 100 = 99 ≥ 1).
+        let random = FixedRandomSource(value: selected ? 0 : 0.99)
+        let config = SamplingConfig(weight: selected ? 1 : weight)
+        return SamplingSession(id: "abc123def", config: config, random: random)
+    }
+
+    func testEventsAreBufferedUntilSessionAttached() {
+        let mock = RecordingTransport()
+        let collector = OptelCollector(transport: mock, collectBaseURL: baseURL)
+        collector.enqueue(event(.top))
+        collector.enqueue(event(.enter))
+        XCTAssertEqual(mock.sent.count, 0)
+        XCTAssertEqual(collector.bufferedCount, 2)
+    }
+
+    func testFlushesBufferedEventsWhenSelectedSessionAttaches() {
+        let mock = RecordingTransport()
+        let collector = OptelCollector(transport: mock, collectBaseURL: baseURL)
+        collector.enqueue(event(.top))
+        collector.enqueue(event(.enter))
+        collector.attach(session: session(selected: true))
+        XCTAssertEqual(mock.sent.count, 2)
+        XCTAssertEqual(mock.sent.map { $0.event.checkpoint.rawValue }, ["top", "enter"])
+        XCTAssertEqual(collector.bufferedCount, 0)
+    }
+
+    func testDropsBufferedEventsWhenUnselectedSessionAttaches() {
+        let mock = RecordingTransport()
+        let collector = OptelCollector(transport: mock, collectBaseURL: baseURL)
+        collector.enqueue(event(.top))
+        collector.enqueue(event(.enter))
+        collector.attach(session: session(selected: false))
+        XCTAssertEqual(mock.sent.count, 0)
+        XCTAssertEqual(collector.bufferedCount, 0)
+    }
+
+    func testForwardsEventsImmediatelyAfterSelectedSessionAttached() {
+        let mock = RecordingTransport()
+        let collector = OptelCollector(transport: mock, collectBaseURL: baseURL)
+        collector.attach(session: session(selected: true))
+        collector.enqueue(event(.click))
+        XCTAssertEqual(mock.sent.count, 1)
+        XCTAssertEqual(mock.sent.first?.event.checkpoint.rawValue, "click")
+        XCTAssertEqual(mock.sent.first?.baseURL, baseURL)
+    }
+
+    func testDropsEventsAfterUnselectedSessionAttached() {
+        let mock = RecordingTransport()
+        let collector = OptelCollector(transport: mock, collectBaseURL: baseURL)
+        collector.attach(session: session(selected: false))
+        collector.enqueue(event(.click))
+        collector.enqueue(event(.navigate))
+        XCTAssertEqual(mock.sent.count, 0)
+        XCTAssertEqual(collector.bufferedCount, 0)
+    }
+
+    func testAttachIsIdempotent() {
+        let mock = RecordingTransport()
+        let collector = OptelCollector(transport: mock, collectBaseURL: baseURL)
+        collector.enqueue(event(.top))
+        collector.attach(session: session(selected: true))
+        XCTAssertEqual(mock.sent.count, 1)
+        // Second attach (even with a different decision) must be a no-op.
+        collector.attach(session: session(selected: false))
+        collector.enqueue(event(.enter))
+        XCTAssertEqual(mock.sent.count, 2)
+        XCTAssertEqual(mock.sent.last?.event.checkpoint.rawValue, "enter")
+    }
+
+    func testQueueLimitDropsOldestWhileBuffered() {
+        let mock = RecordingTransport()
+        let collector = OptelCollector(
+            transport: mock,
+            collectBaseURL: baseURL,
+            queueLimit: 2
+        )
+        collector.enqueue(event(.top, t: 1))
+        collector.enqueue(event(.enter, t: 2))
+        collector.enqueue(event(.click, t: 3))
+        XCTAssertEqual(collector.bufferedCount, 2)
+        collector.attach(session: session(selected: true))
+        XCTAssertEqual(mock.sent.map { $0.event.t }, [2, 3])
+    }
+
+    func testDefaultBaseURLMatchesRumHlxPage() {
+        let mock = RecordingTransport()
+        let collector = OptelCollector(transport: mock)
+        collector.attach(session: session(selected: true))
+        collector.enqueue(event(.top))
+        XCTAssertEqual(mock.sent.first?.baseURL.absoluteString, "https://rum.hlx.page/")
+    }
+
+    func testHasSessionReflectsAttachState() {
+        let mock = RecordingTransport()
+        let collector = OptelCollector(transport: mock, collectBaseURL: baseURL)
+        XCTAssertFalse(collector.hasSession)
+        collector.attach(session: session(selected: false))
+        XCTAssertTrue(collector.hasSession)
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelErrorReportingTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelErrorReportingTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import SwiftOptel
+
+private struct FixedRandomSource: RandomSource {
+    let value: Double
+    func nextUnitDouble() -> Double { value }
+}
+
+private enum SampleError: Error {
+    case missingField
+}
+
+private struct DomainError: CustomNSError {
+    static var errorDomain: String { "io.acme.network" }
+    var errorCode: Int { 503 }
+    var errorUserInfo: [String: Any] {
+        [NSLocalizedDescriptionKey: "Service unavailable"]
+    }
+}
+
+final class OptelErrorReportingTests: XCTestCase {
+    private let baseURL = URL(string: "https://rum.hlx.page/")!
+
+    func testErrorMappingUsesBridgedDomainAndDescription() {
+        let mapping = OptelErrorMapping.from(error: DomainError())
+        XCTAssertEqual(mapping.source, "io.acme.network")
+        XCTAssertEqual(mapping.target, "Service unavailable")
+    }
+
+    func testErrorMappingForPlainSwiftErrorUsesBridgedDomain() {
+        let mapping = OptelErrorMapping.from(error: SampleError.missingField)
+        // Plain Swift error enums bridge to a domain of `<Module>.<TypeName>`.
+        XCTAssertTrue(
+            mapping.source.contains("SampleError"),
+            "expected source to mention the type name, got \(mapping.source)"
+        )
+        XCTAssertFalse(mapping.target.isEmpty)
+    }
+
+    func testExceptionMappingUsesNameAndReason() {
+        let exception = NSException(
+            name: NSExceptionName("OptelDemoException"),
+            reason: "synthetic",
+            userInfo: nil
+        )
+        let mapping = OptelErrorMapping.from(exception: exception)
+        XCTAssertEqual(mapping.source, "OptelDemoException")
+        XCTAssertEqual(mapping.target, "synthetic")
+    }
+
+    func testExceptionMappingFallsBackToDescriptionWhenReasonIsBlank() {
+        let exception = NSException(
+            name: NSExceptionName("OptelDemoException"),
+            reason: "  ",
+            userInfo: nil
+        )
+        let mapping = OptelErrorMapping.from(exception: exception)
+        XCTAssertEqual(mapping.source, "OptelDemoException")
+        XCTAssertFalse(mapping.target.isEmpty)
+    }
+
+    func testReportErrorEmitsErrorCheckpoint() {
+        let mock = RecordingTransport()
+        let optel = Optel()
+        optel.configure(
+            appID: "com.example.app",
+            rate: "on",
+            collectBaseURL: baseURL,
+            transport: mock,
+            randomSource: FixedRandomSource(value: 0)
+        )
+
+        optel.reportError(DomainError())
+
+        XCTAssertEqual(mock.sent.map { $0.event.checkpoint.rawValue }, ["top", "error"])
+        let errorBeacon = mock.sent[1].event
+        XCTAssertEqual(errorBeacon.pingData.source, "io.acme.network")
+        XCTAssertEqual(errorBeacon.pingData.target, "Service unavailable")
+        XCTAssertNil(errorBeacon.pingData.value)
+        XCTAssertEqual(errorBeacon.referer, "https://com.example.app/")
+    }
+
+    func testUncaughtHookInstallIsIdempotent() {
+        OptelUncaughtExceptionHook._testing_reset()
+        XCTAssertFalse(OptelUncaughtExceptionHook.isInstalled)
+        OptelUncaughtExceptionHook.installIfNeeded()
+        XCTAssertTrue(OptelUncaughtExceptionHook.isInstalled)
+        // Second call is a no-op; must not crash and the flag must remain set.
+        OptelUncaughtExceptionHook.installIfNeeded()
+        XCTAssertTrue(OptelUncaughtExceptionHook.isInstalled)
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelSourceDeriverTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelSourceDeriverTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import SwiftOptel
+
+final class OptelSourceDeriverTests: XCTestCase {
+    func testIdentifierTakesPrecedenceOverLabel() {
+        let result = OptelSourceDeriver.source(
+            element: "button",
+            identifier: "submit",
+            label: "Submit"
+        )
+        XCTAssertEqual(result, "button#submit")
+    }
+
+    func testLabelUsedWhenIdentifierAbsent() {
+        let result = OptelSourceDeriver.source(
+            element: "button",
+            label: "Submit"
+        )
+        XCTAssertEqual(result, "button \"Submit\"")
+    }
+
+    func testElementOnlyWhenNeitherIDNorLabel() {
+        let result = OptelSourceDeriver.source(element: "view")
+        XCTAssertEqual(result, "view")
+    }
+
+    func testContextPrefixedWhenProvided() {
+        let result = OptelSourceDeriver.source(
+            element: "button",
+            identifier: "submit",
+            context: "ContentView"
+        )
+        XCTAssertEqual(result, "ContentView button#submit")
+    }
+
+    func testContextWithLabel() {
+        let result = OptelSourceDeriver.source(
+            element: "button",
+            label: "Buy",
+            context: "Cart"
+        )
+        XCTAssertEqual(result, "Cart button \"Buy\"")
+    }
+
+    func testContextOnlyDropsToElementWhenNothingElse() {
+        let result = OptelSourceDeriver.source(element: "view", context: "Home")
+        XCTAssertEqual(result, "Home view")
+    }
+
+    func testWhitespaceOnlyInputsAreTreatedAsAbsent() {
+        let result = OptelSourceDeriver.source(
+            element: "button",
+            identifier: "   ",
+            label: " Submit ",
+            context: "\t"
+        )
+        XCTAssertEqual(result, "button \"Submit\"")
+    }
+
+    func testEmptyElementFallsBackToView() {
+        let result = OptelSourceDeriver.source(element: "", identifier: "x")
+        XCTAssertEqual(result, "view#x")
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelSwiftUITests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelSwiftUITests.swift
@@ -1,0 +1,90 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import XCTest
+@testable import SwiftOptel
+
+@available(iOS 16.0, macOS 13.0, *)
+final class OptelSwiftUITests: XCTestCase {
+    // MARK: - Scene-phase transition logic
+
+    /// Drives the documented `.background → .inactive → .active` sequence
+    /// and asserts the modifier re-fires `enter` exactly once. This is the
+    /// regression test for the `lastPhase`-based check that lost the
+    /// was-background signal when `.inactive` arrived in between.
+    func testEnterRefiresOnBackgroundInactiveActiveSequence() {
+        var wasBackgrounded = false
+        var enterFires = 0
+
+        let phases: [ScenePhase] = [.background, .inactive, .active]
+        for phase in phases {
+            let next = OptelAutoInstrumentModifier.nextState(
+                forNewPhase: phase,
+                wasBackgrounded: wasBackgrounded
+            )
+            wasBackgrounded = next.wasBackgrounded
+            if next.shouldFireEnter { enterFires += 1 }
+        }
+        XCTAssertEqual(enterFires, 1)
+        XCTAssertFalse(wasBackgrounded, "active transition should clear the flag")
+    }
+
+    func testEnterDoesNotFireWithoutPriorBackground() {
+        var wasBackgrounded = false
+        var enterFires = 0
+        // Cold launch path: SwiftUI may publish .inactive → .active before any
+        // .background ever occurs. The modifier must NOT re-fire `enter` here
+        // (the initial `enter` is fired from `.task`, not from `.onChange`).
+        for phase in [ScenePhase.inactive, .active] {
+            let next = OptelAutoInstrumentModifier.nextState(
+                forNewPhase: phase,
+                wasBackgrounded: wasBackgrounded
+            )
+            wasBackgrounded = next.wasBackgrounded
+            if next.shouldFireEnter { enterFires += 1 }
+        }
+        XCTAssertEqual(enterFires, 0)
+    }
+
+    func testEnterFiresOncePerForegroundCycle() {
+        var wasBackgrounded = false
+        var enterFires = 0
+        // Two full background→active cycles must fire `enter` twice (once per
+        // cycle), and `.active → .active` must not re-fire.
+        let sequence: [ScenePhase] = [
+            .background, .inactive, .active,
+            .active,
+            .background, .inactive, .active,
+        ]
+        for phase in sequence {
+            let next = OptelAutoInstrumentModifier.nextState(
+                forNewPhase: phase,
+                wasBackgrounded: wasBackgrounded
+            )
+            wasBackgrounded = next.wasBackgrounded
+            if next.shouldFireEnter { enterFires += 1 }
+        }
+        XCTAssertEqual(enterFires, 2)
+    }
+
+    func testBackgroundSetsStickyFlagEvenAfterInactive() {
+        // After `.background`, an arbitrary number of `.inactive` updates
+        // must preserve the sticky flag until `.active` arrives.
+        var wasBackgrounded = false
+        for phase in [ScenePhase.background, .inactive, .inactive, .inactive] {
+            let next = OptelAutoInstrumentModifier.nextState(
+                forNewPhase: phase,
+                wasBackgrounded: wasBackgrounded
+            )
+            wasBackgrounded = next.wasBackgrounded
+            XCTAssertFalse(next.shouldFireEnter)
+        }
+        XCTAssertTrue(wasBackgrounded)
+        let final = OptelAutoInstrumentModifier.nextState(
+            forNewPhase: .active,
+            wasBackgrounded: wasBackgrounded
+        )
+        XCTAssertTrue(final.shouldFireEnter)
+        XCTAssertFalse(final.wasBackgrounded)
+    }
+}
+#endif

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import SwiftOptel
+
+/// Deterministic ``RandomSource`` for pinning the per-session selection
+/// decision in tests.
+private struct FixedRandomSource: RandomSource {
+    let value: Double
+    func nextUnitDouble() -> Double { value }
+}
+
+final class OptelTests: XCTestCase {
+    private let baseURL = URL(string: "https://rum.hlx.page/")!
+
+    private func makeOptel(
+        appID: String = "com.example.app",
+        rate: String? = nil,
+        transport: OptelTransport,
+        selected: Bool = true
+    ) -> Optel {
+        let optel = Optel()
+        // weight=1 + random=0 → selected; weight=100 + random=0.99 → not selected
+        let random = FixedRandomSource(value: selected ? 0 : 0.99)
+        optel.configure(
+            appID: appID,
+            rate: rate ?? (selected ? "on" : nil),
+            collectBaseURL: baseURL,
+            transport: transport,
+            randomSource: random
+        )
+        return optel
+    }
+
+    func testConfigureThenSampleProducesOneBeaconForTopWhenSelected() {
+        let mock = RecordingTransport()
+        let optel = makeOptel(transport: mock, selected: true)
+        optel.sample(.top, source: "app", target: "/", value: 1)
+        XCTAssertEqual(mock.sent.count, 1)
+        let call = mock.sent[0]
+        XCTAssertEqual(call.event.checkpoint.rawValue, "top")
+        XCTAssertEqual(call.event.referer, "https://com.example.app/")
+        XCTAssertEqual(call.event.pingData.source, "app")
+        XCTAssertEqual(call.event.pingData.target, "/")
+        XCTAssertEqual(call.event.pingData.value, 1)
+        XCTAssertEqual(call.baseURL, baseURL)
+    }
+
+    func testFirstSampleAutoEmitsTopBeforeUserCheckpoint() {
+        let mock = RecordingTransport()
+        let optel = makeOptel(transport: mock, selected: true)
+        optel.sample(.click, source: ".button#submit")
+        XCTAssertEqual(mock.sent.map { $0.event.checkpoint.rawValue }, ["top", "click"])
+        XCTAssertEqual(mock.sent[0].event.t, 0)
+        XCTAssertNil(mock.sent[0].event.pingData.source)
+        XCTAssertEqual(mock.sent[1].event.pingData.source, ".button#submit")
+    }
+
+    func testSubsequentSamplesDoNotReEmitTop() {
+        let mock = RecordingTransport()
+        let optel = makeOptel(transport: mock, selected: true)
+        optel.sample(.enter)
+        optel.sample(.click)
+        optel.sample(.navigate)
+        XCTAssertEqual(
+            mock.sent.map { $0.event.checkpoint.rawValue },
+            ["top", "enter", "click", "navigate"]
+        )
+    }
+
+    func testUnselectedSessionProducesZeroBeacons() {
+        let mock = RecordingTransport()
+        let optel = makeOptel(transport: mock, selected: false)
+        optel.sample(.click)
+        optel.sample(.navigate)
+        XCTAssertEqual(mock.sent.count, 0)
+    }
+
+    func testEventCarriesSessionWeightAndStableID() {
+        let mock = RecordingTransport()
+        let optel = makeOptel(rate: "on", transport: mock, selected: true)
+        optel.sample(.click)
+        XCTAssertEqual(mock.sent.count, 2)
+        let first = mock.sent[0].event
+        let second = mock.sent[1].event
+        XCTAssertEqual(first.weight, 1)
+        XCTAssertEqual(second.weight, 1)
+        XCTAssertEqual(first.id.count, 9)
+        XCTAssertEqual(first.id, second.id)
+    }
+
+    func testRefererUsesAppIDAsHostname() {
+        let mock = RecordingTransport()
+        let optel = makeOptel(appID: "io.acme.client", transport: mock, selected: true)
+        optel.sample(.click)
+        XCTAssertEqual(mock.sent.first?.event.referer, "https://io.acme.client/")
+    }
+
+    func testReconfigureResetsTopAndSessionID() {
+        let mock = RecordingTransport()
+        let optel = makeOptel(transport: mock, selected: true)
+        optel.sample(.click)
+        XCTAssertEqual(mock.sent.count, 2)
+        let firstID = mock.sent[0].event.id
+
+        optel.configure(
+            appID: "com.example.app",
+            rate: "on",
+            collectBaseURL: baseURL,
+            transport: mock,
+            randomSource: FixedRandomSource(value: 0)
+        )
+        optel.sample(.click)
+        XCTAssertEqual(mock.sent.count, 4)
+        XCTAssertEqual(mock.sent[2].event.checkpoint.rawValue, "top")
+        XCTAssertEqual(mock.sent[3].event.checkpoint.rawValue, "click")
+        XCTAssertNotEqual(mock.sent[2].event.id, firstID)
+    }
+
+    func testSampleBeforeConfigureIsNoOp() {
+        let optel = Optel()
+        // No configure call. Sample must not crash and must not emit.
+        optel.sample(.click, source: "x")
+        // No transport to inspect; success is "no crash".
+    }
+
+    func testTimeShiftIsNonNegativeForUserCheckpoint() {
+        let mock = RecordingTransport()
+        let optel = makeOptel(transport: mock, selected: true)
+        optel.sample(.enter)
+        XCTAssertGreaterThanOrEqual(mock.sent.last?.event.t ?? -1, 0)
+    }
+
+    func testConcurrentSamplesAreThreadSafe() {
+        let mock = RecordingTransport()
+        let optel = makeOptel(transport: mock, selected: true)
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "optel.test", attributes: .concurrent)
+        for _ in 0..<200 {
+            group.enter()
+            queue.async {
+                optel.sample(.click)
+                group.leave()
+            }
+        }
+        group.wait()
+        let tops = mock.sent.filter { $0.event.checkpoint.rawValue == "top" }
+        XCTAssertEqual(tops.count, 1)
+        XCTAssertEqual(mock.sent.count, 201)
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelTests.swift
@@ -146,4 +146,42 @@ final class OptelTests: XCTestCase {
         XCTAssertEqual(tops.count, 1)
         XCTAssertEqual(mock.sent.count, 201)
     }
+
+    func testTopBeaconIsFirstOnTheWireUnderConcurrentFirstCallers() {
+        // Race many threads through `sample` immediately after `configure`,
+        // synchronized on a `DispatchSemaphore` so they all unblock together.
+        // The auto-`top` beacon must be the very first entry on the wire even
+        // though the caller that flipped `hasEmittedTop` is not guaranteed to
+        // be scheduled before the others.
+        for trial in 0..<20 {
+            let mock = RecordingTransport()
+            let optel = makeOptel(transport: mock, selected: true)
+            let threadCount = 32
+            let startGate = DispatchSemaphore(value: 0)
+            let group = DispatchGroup()
+            let queue = DispatchQueue(label: "optel.race", attributes: .concurrent)
+            for _ in 0..<threadCount {
+                group.enter()
+                queue.async {
+                    startGate.wait()
+                    optel.sample(.click)
+                    group.leave()
+                }
+            }
+            for _ in 0..<threadCount { startGate.signal() }
+            group.wait()
+            XCTAssertEqual(
+                mock.sent.first?.event.checkpoint.rawValue,
+                "top",
+                "trial \(trial): top must be the first beacon on the wire"
+            )
+            let tops = mock.sent.filter { $0.event.checkpoint.rawValue == "top" }
+            XCTAssertEqual(tops.count, 1, "trial \(trial): expected exactly one top beacon")
+            XCTAssertEqual(
+                mock.sent.count,
+                threadCount + 1,
+                "trial \(trial): expected one top + \(threadCount) clicks"
+            )
+        }
+    }
 }

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelTransportTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelTransportTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+@testable import SwiftOptel
+
+final class OptelTransportTests: XCTestCase {
+    private let baseURL = URL(string: "https://rum.hlx.page/")!
+
+    private func sampleEvent(weight: Int = 100) -> RUMEvent {
+        RUMEvent(
+            weight: weight,
+            id: "abc123def",
+            referer: "https://com.example.app/home",
+            checkpoint: .click,
+            t: 1234,
+            pingData: RUMPingData(source: ".button#submit", target: "/api/checkout", value: 42)
+        )
+    }
+
+    func testMakeRequestBuildsCollectorURLWithWeight() throws {
+        let request = try XCTUnwrap(URLSessionOptelTransport.makeRequest(
+            event: sampleEvent(weight: 100),
+            collectBaseURL: baseURL,
+            timeout: 10
+        ))
+        XCTAssertEqual(request.url?.absoluteString, "https://rum.hlx.page/.rum/100")
+    }
+
+    func testMakeRequestHonorsCustomWeightInPath() throws {
+        let request = try XCTUnwrap(URLSessionOptelTransport.makeRequest(
+            event: sampleEvent(weight: 1000),
+            collectBaseURL: baseURL,
+            timeout: 10
+        ))
+        XCTAssertEqual(request.url?.absoluteString, "https://rum.hlx.page/.rum/1000")
+    }
+
+    func testMakeRequestHonorsCustomBaseURL() throws {
+        let base = URL(string: "https://custom.example.com/path/")!
+        let request = try XCTUnwrap(URLSessionOptelTransport.makeRequest(
+            event: sampleEvent(),
+            collectBaseURL: base,
+            timeout: 10
+        ))
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "https://custom.example.com/path/.rum/100"
+        )
+    }
+
+    func testMakeRequestSetsPostMethodAndJSONHeader() throws {
+        let request = try XCTUnwrap(URLSessionOptelTransport.makeRequest(
+            event: sampleEvent(),
+            collectBaseURL: baseURL,
+            timeout: 10
+        ))
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    func testMakeRequestPropagatesTimeout() throws {
+        let request = try XCTUnwrap(URLSessionOptelTransport.makeRequest(
+            event: sampleEvent(),
+            collectBaseURL: baseURL,
+            timeout: 3.5
+        ))
+        XCTAssertEqual(request.timeoutInterval, 3.5, accuracy: 0.0001)
+    }
+
+    func testMakeRequestEncodesEventAsBody() throws {
+        let event = sampleEvent()
+        let request = try XCTUnwrap(URLSessionOptelTransport.makeRequest(
+            event: event,
+            collectBaseURL: baseURL,
+            timeout: 10
+        ))
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        XCTAssertEqual(json["weight"] as? Int, 100)
+        XCTAssertEqual(json["id"] as? String, "abc123def")
+        XCTAssertEqual(json["referer"] as? String, "https://com.example.app/home")
+        XCTAssertEqual(json["checkpoint"] as? String, "click")
+        XCTAssertEqual(json["t"] as? Int, 1234)
+        XCTAssertEqual(json["source"] as? String, ".button#submit")
+        XCTAssertEqual(json["target"] as? String, "/api/checkout")
+        XCTAssertEqual(json["value"] as? Double, 42)
+    }
+
+    func testBodyRefererHostMatchesAppIDFromBuilder() throws {
+        let referer = RUMReferer.build(appID: "com.example.app", viewPath: "/home")
+        let event = RUMEvent(
+            weight: 100,
+            id: "abc123def",
+            referer: referer,
+            checkpoint: .top,
+            t: 0
+        )
+        let request = try XCTUnwrap(URLSessionOptelTransport.makeRequest(
+            event: event,
+            collectBaseURL: baseURL,
+            timeout: 10
+        ))
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        let bodyReferer = try XCTUnwrap(json["referer"] as? String)
+        let components = try XCTUnwrap(URLComponents(string: bodyReferer))
+        XCTAssertEqual(components.scheme, "https")
+        XCTAssertEqual(components.host, "com.example.app")
+        XCTAssertEqual(components.path, "/home")
+    }
+
+    func testSendThroughMockTransportDoesNotThrowAndRecordsInputs() {
+        let mock = RecordingTransport()
+        mock.send(sampleEvent(), collectBaseURL: baseURL)
+        XCTAssertEqual(mock.sent.count, 1)
+        XCTAssertEqual(mock.sent.first?.event.id, "abc123def")
+        XCTAssertEqual(mock.sent.first?.baseURL, baseURL)
+    }
+
+    func testSendIsFireAndForgetAndNonBlocking() {
+        // Use an unreachable URL via a mock URLProtocol to verify the call
+        // returns promptly even when the network errors out.
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FailingURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let transport = URLSessionOptelTransport(session: session, timeout: 1)
+        let start = Date()
+        transport.send(sampleEvent(), collectBaseURL: baseURL)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 0.5)
+    }
+}
+
+/// `URLProtocol` that fails every request synchronously. Used to confirm the
+/// transport swallows errors and never blocks.
+private final class FailingURLProtocol: URLProtocol {
+    override static func canInit(with request: URLRequest) -> Bool { true }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+    }
+    override func stopLoading() {}
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/RUMEventTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/RUMEventTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import SwiftOptel
+
+final class RUMEventTests: XCTestCase {
+    private func encode(_ event: RUMEvent) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(event)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NSError(domain: "RUMEventTests", code: 1)
+        }
+        return json
+    }
+
+    func testCheckpointRawValues() {
+        XCTAssertEqual(RUMCheckpoint.top.rawValue, "top")
+        XCTAssertEqual(RUMCheckpoint.enter.rawValue, "enter")
+        XCTAssertEqual(RUMCheckpoint.navigate.rawValue, "navigate")
+        XCTAssertEqual(RUMCheckpoint.reload.rawValue, "reload")
+        XCTAssertEqual(RUMCheckpoint.cwv.rawValue, "cwv")
+        XCTAssertEqual(RUMCheckpoint.pagesviewed.rawValue, "pagesviewed")
+        XCTAssertEqual(RUMCheckpoint.click.rawValue, "click")
+        XCTAssertEqual(RUMCheckpoint.viewblock.rawValue, "viewblock")
+        XCTAssertEqual(RUMCheckpoint.viewmedia.rawValue, "viewmedia")
+        XCTAssertEqual(RUMCheckpoint.formsubmit.rawValue, "formsubmit")
+        XCTAssertEqual(RUMCheckpoint.error.rawValue, "error")
+        XCTAssertEqual(RUMCheckpoint.raw("custom-cp").rawValue, "custom-cp")
+    }
+
+    func testEncodesFullEventWithFlattenedPingData() throws {
+        let event = RUMEvent(
+            weight: 100,
+            id: "abc123def",
+            referer: "https://com.example.app/home",
+            checkpoint: .click,
+            t: 1234,
+            pingData: RUMPingData(source: ".button#submit", target: "/api/checkout", value: 42)
+        )
+        let json = try encode(event)
+        XCTAssertEqual(
+            Set(json.keys),
+            ["weight", "id", "referer", "checkpoint", "t", "source", "target", "value"]
+        )
+        XCTAssertEqual(json["weight"] as? Int, 100)
+        XCTAssertEqual(json["id"] as? String, "abc123def")
+        XCTAssertEqual(json["referer"] as? String, "https://com.example.app/home")
+        XCTAssertEqual(json["checkpoint"] as? String, "click")
+        XCTAssertEqual(json["t"] as? Int, 1234)
+        XCTAssertEqual(json["source"] as? String, ".button#submit")
+        XCTAssertEqual(json["target"] as? String, "/api/checkout")
+        XCTAssertEqual(json["value"] as? Double, 42)
+    }
+
+    func testOmitsAbsentPingDataFields() throws {
+        let event = RUMEvent(
+            weight: 100,
+            id: "xxxxxxxxx",
+            referer: "https://com.example.app/",
+            checkpoint: .top,
+            t: 0
+        )
+        let json = try encode(event)
+        XCTAssertEqual(Set(json.keys), ["weight", "id", "referer", "checkpoint", "t"])
+        XCTAssertNil(json["source"])
+        XCTAssertNil(json["target"])
+        XCTAssertNil(json["value"])
+    }
+
+    func testFixtureByteShapeMatchesHelixRumJsPayload() throws {
+        // Hand-written fixture mirroring helix-rum-js `sendPing` JSON body for
+        // the same event. Comparison is via parsed-JSON shape (key set + values)
+        // so it is independent of object-key ordering.
+        let event = RUMEvent(
+            weight: 100,
+            id: "abc123def",
+            referer: "https://com.example.app/home",
+            checkpoint: .click,
+            t: 1234,
+            pingData: RUMPingData(source: ".button#submit", target: "/api/checkout", value: 42)
+        )
+        let actualData = try JSONEncoder().encode(event)
+        let fixture = """
+        {"weight":100,"id":"abc123def","referer":"https://com.example.app/home",\
+        "checkpoint":"click","t":1234,"source":".button#submit",\
+        "target":"/api/checkout","value":42}
+        """
+        let actualObject = try JSONSerialization.jsonObject(with: actualData) as? NSDictionary
+        let expectedObject = try JSONSerialization.jsonObject(
+            with: Data(fixture.utf8)
+        ) as? NSDictionary
+        XCTAssertEqual(actualObject, expectedObject)
+    }
+
+    func testRawCheckpointPassesThroughInEncodedJSON() throws {
+        let event = RUMEvent(
+            weight: 100,
+            id: "abc123def",
+            referer: "https://com.example.app/",
+            checkpoint: .raw("custom-cp"),
+            t: 1
+        )
+        let json = try encode(event)
+        XCTAssertEqual(json["checkpoint"] as? String, "custom-cp")
+    }
+
+    func testPingDataIsEmpty() {
+        XCTAssertTrue(RUMPingData().isEmpty)
+        XCTAssertFalse(RUMPingData(source: "x").isEmpty)
+        XCTAssertFalse(RUMPingData(target: "x").isEmpty)
+        XCTAssertFalse(RUMPingData(value: 0).isEmpty)
+    }
+
+    func testSessionIDIsNineLowercaseHexCharacters() {
+        let hex = CharacterSet(charactersIn: "0123456789abcdef")
+        for _ in 0..<32 {
+            let sid = RUMSessionID.generate()
+            XCTAssertEqual(sid.count, 9, "expected 9-char session id, got \(sid)")
+            XCTAssertEqual(sid, sid.lowercased())
+            for scalar in sid.unicodeScalars {
+                XCTAssertTrue(hex.contains(scalar), "non-hex char in \(sid): \(scalar)")
+            }
+        }
+    }
+
+    func testSessionIDsAreDistinct() {
+        let many = (0..<200).map { _ in RUMSessionID.generate() }
+        // Collisions across 9 hex chars are extremely unlikely; require >195
+        // distinct ids out of 200 to keep the test stable.
+        XCTAssertGreaterThan(Set(many).count, 195)
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/RUMRefererTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/RUMRefererTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import SwiftOptel
+
+final class RUMRefererTests: XCTestCase {
+    func testBuildUsesAppIDAsHost() {
+        XCTAssertEqual(
+            RUMReferer.build(appID: "com.example.app", viewPath: "/home"),
+            "https://com.example.app/home"
+        )
+    }
+
+    func testBuildNormalizesEmptyPathToRoot() {
+        XCTAssertEqual(
+            RUMReferer.build(appID: "com.example.app", viewPath: ""),
+            "https://com.example.app/"
+        )
+    }
+
+    func testBuildDefaultsToRootPath() {
+        XCTAssertEqual(
+            RUMReferer.build(appID: "com.example.app"),
+            "https://com.example.app/"
+        )
+    }
+
+    func testBuildPrependsLeadingSlashToRelativePath() {
+        XCTAssertEqual(
+            RUMReferer.build(appID: "com.example.app", viewPath: "settings/profile"),
+            "https://com.example.app/settings/profile"
+        )
+    }
+
+    func testBuildPreservesLeadingSlash() {
+        XCTAssertEqual(
+            RUMReferer.build(appID: "com.example.app", viewPath: "/a/b/c"),
+            "https://com.example.app/a/b/c"
+        )
+    }
+
+    func testDefaultCollectBaseURLMatchesHelixRumJs() {
+        XCTAssertEqual(
+            RUMReferer.defaultCollectBaseURL.absoluteString,
+            "https://rum.hlx.page/"
+        )
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/RecordingTransport.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/RecordingTransport.swift
@@ -1,0 +1,31 @@
+import Foundation
+@testable import SwiftOptel
+
+/// Thread-safe mock ``OptelTransport`` that records every call instead of
+/// performing network I/O. Shared by the transport and collector test suites.
+final class RecordingTransport: OptelTransport, @unchecked Sendable {
+    struct Call: Equatable {
+        let event: RUMEvent
+        let baseURL: URL
+    }
+
+    private let lock = NSLock()
+    private var calls: [Call] = []
+
+    var sent: [Call] {
+        lock.lock(); defer { lock.unlock() }
+        return calls
+    }
+
+    func send(_ event: RUMEvent, collectBaseURL: URL) {
+        lock.lock()
+        calls.append(Call(event: event, baseURL: collectBaseURL))
+        lock.unlock()
+    }
+
+    func reset() {
+        lock.lock()
+        calls.removeAll()
+        lock.unlock()
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/SamplingConfigTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/SamplingConfigTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import SwiftOptel
+
+final class SamplingConfigTests: XCTestCase {
+    func testNilRateUsesDefaultWeight() {
+        XCTAssertEqual(SamplingConfig(rate: nil).weight, 100)
+    }
+
+    func testRateAliasOnMapsToOne() {
+        XCTAssertEqual(SamplingConfig(rate: "on").weight, 1)
+    }
+
+    func testRateAliasOffMapsToZero() {
+        XCTAssertEqual(SamplingConfig(rate: "off").weight, 0)
+    }
+
+    func testRateAliasHighMapsToTen() {
+        XCTAssertEqual(SamplingConfig(rate: "high").weight, 10)
+    }
+
+    func testRateAliasLowMapsToThousand() {
+        XCTAssertEqual(SamplingConfig(rate: "low").weight, 1000)
+    }
+
+    func testNumericStringParsesAsWeight() {
+        XCTAssertEqual(SamplingConfig(rate: "0").weight, 0)
+        XCTAssertEqual(SamplingConfig(rate: "1").weight, 1)
+        XCTAssertEqual(SamplingConfig(rate: "42").weight, 42)
+        XCTAssertEqual(SamplingConfig(rate: "500").weight, 500)
+    }
+
+    func testUnknownStringFallsBackToDefault() {
+        XCTAssertEqual(SamplingConfig(rate: "bogus").weight, 100)
+        XCTAssertEqual(SamplingConfig(rate: "").weight, 100)
+        XCTAssertEqual(SamplingConfig(rate: "3.14").weight, 100)
+    }
+
+    func testNumericInitPreservesWeight() {
+        XCTAssertEqual(SamplingConfig(weight: 42).weight, 42)
+        XCTAssertEqual(SamplingConfig(weight: 0).weight, 0)
+    }
+
+    func testDefaultConfigUsesDefaultWeight() {
+        XCTAssertEqual(SamplingConfig.default.weight, SamplingConfig.defaultWeight)
+        XCTAssertEqual(SamplingConfig.defaultWeight, 100)
+    }
+
+    func testParseWeightStaticAPI() {
+        XCTAssertEqual(SamplingConfig.parseWeight(from: "high"), 10)
+        XCTAssertEqual(SamplingConfig.parseWeight(from: "200"), 200)
+        XCTAssertEqual(SamplingConfig.parseWeight(from: nil), 100)
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/SamplingConfigTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/SamplingConfigTests.swift
@@ -22,11 +22,13 @@ final class SamplingConfigTests: XCTestCase {
         XCTAssertEqual(SamplingConfig(rate: "low").weight, 1000)
     }
 
-    func testNumericStringParsesAsWeight() {
-        XCTAssertEqual(SamplingConfig(rate: "0").weight, 0)
-        XCTAssertEqual(SamplingConfig(rate: "1").weight, 1)
-        XCTAssertEqual(SamplingConfig(rate: "42").weight, 42)
-        XCTAssertEqual(SamplingConfig(rate: "500").weight, 500)
+    func testNumericStringFallsBackToDefault() {
+        // helix-rum-js only recognizes the four aliases; numeric strings are
+        // not a supported rate format and must resolve to the default weight.
+        XCTAssertEqual(SamplingConfig(rate: "0").weight, 100)
+        XCTAssertEqual(SamplingConfig(rate: "1").weight, 100)
+        XCTAssertEqual(SamplingConfig(rate: "42").weight, 100)
+        XCTAssertEqual(SamplingConfig(rate: "500").weight, 100)
     }
 
     func testUnknownStringFallsBackToDefault() {
@@ -47,7 +49,7 @@ final class SamplingConfigTests: XCTestCase {
 
     func testParseWeightStaticAPI() {
         XCTAssertEqual(SamplingConfig.parseWeight(from: "high"), 10)
-        XCTAssertEqual(SamplingConfig.parseWeight(from: "200"), 200)
+        XCTAssertEqual(SamplingConfig.parseWeight(from: "200"), 100)
         XCTAssertEqual(SamplingConfig.parseWeight(from: nil), 100)
     }
 }

--- a/packages/swift-optel/Tests/SwiftOptelTests/SamplingSessionTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/SamplingSessionTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+@testable import SwiftOptel
+
+/// RNG stub that always returns the same value.
+private struct FixedRandom: RandomSource {
+    let value: Double
+    func nextUnitDouble() -> Double { value }
+}
+
+/// RNG that records how many times it was invoked so tests can assert the
+/// selection decision is cached after the first call.
+private final class CountingRandom: RandomSource {
+    var calls = 0
+    private let values: [Double]
+
+    init(values: [Double]) { self.values = values }
+
+    func nextUnitDouble() -> Double {
+        defer { calls += 1 }
+        return values[min(calls, values.count - 1)]
+    }
+}
+
+final class SamplingSessionTests: XCTestCase {
+    // MARK: weight 0 / off
+
+    func testWeightZeroNeverSelects() {
+        for value in [0.0, 0.0001, 0.5, 0.999_999] {
+            let session = SamplingSession(
+                id: "abc",
+                config: SamplingConfig(weight: 0),
+                random: FixedRandom(value: value)
+            )
+            XCTAssertFalse(session.isSelected, "weight=0 must never select (r=\(value))")
+        }
+    }
+
+    func testOffRateNeverSelects() {
+        let session = SamplingSession(
+            id: "abc",
+            config: SamplingConfig(rate: "off"),
+            random: FixedRandom(value: 0)
+        )
+        XCTAssertFalse(session.isSelected)
+    }
+
+    func testNegativeWeightNeverSelects() {
+        let session = SamplingSession(
+            id: "x",
+            config: SamplingConfig(weight: -5),
+            random: FixedRandom(value: 0)
+        )
+        XCTAssertFalse(session.isSelected)
+    }
+
+    // MARK: helix-rum-js formula across weights
+
+    func testRandomZeroAlwaysSelectsForPositiveWeights() {
+        for weight in [1, 10, 100, 1000] {
+            let session = SamplingSession(
+                id: "abc",
+                config: SamplingConfig(weight: weight),
+                random: FixedRandom(value: 0)
+            )
+            XCTAssertTrue(session.isSelected, "weight=\(weight), r=0 must select")
+        }
+    }
+
+    func testWeightOneSelectsForAnyRandomBelowOne() {
+        for value in [0.0, 0.5, 0.999_999] {
+            let session = SamplingSession(
+                id: "x",
+                config: SamplingConfig(rate: "on"),
+                random: FixedRandom(value: value)
+            )
+            XCTAssertTrue(session.isSelected, "weight=1, r=\(value) must select")
+        }
+    }
+
+    func testWeight10BoundarySelection() {
+        // r * 10 < 1  →  r < 0.1
+        XCTAssertTrue(makeSession(weight: 10, random: 0.099).isSelected)
+        XCTAssertFalse(makeSession(weight: 10, random: 0.1).isSelected) // 0.1*10 = 1.0, not < 1
+        XCTAssertFalse(makeSession(weight: 10, random: 0.2).isSelected)
+    }
+
+    func testWeight100BoundarySelection() {
+        // r * 100 < 1  →  r < 0.01
+        XCTAssertTrue(makeSession(weight: 100, random: 0.009).isSelected)
+        XCTAssertFalse(makeSession(weight: 100, random: 0.01).isSelected)
+        XCTAssertFalse(makeSession(weight: 100, random: 0.5).isSelected)
+    }
+
+    func testWeight1000BoundarySelection() {
+        // r * 1000 < 1  →  r < 0.001
+        XCTAssertTrue(makeSession(weight: 1000, random: 0.0009).isSelected)
+        XCTAssertFalse(makeSession(weight: 1000, random: 0.001).isSelected)
+        XCTAssertFalse(makeSession(weight: 1000, random: 0.5).isSelected)
+    }
+
+    // MARK: cache semantics
+
+    func testIsSelectedComputedOnlyOnce() {
+        // First call returns a value that selects, second would deselect.
+        // If recomputed, the second read would flip; we assert it does not.
+        let rng = CountingRandom(values: [0.0, 0.999])
+        let session = SamplingSession(
+            id: "x",
+            config: SamplingConfig(weight: 10),
+            random: rng
+        )
+        XCTAssertTrue(session.isSelected)
+        XCTAssertTrue(session.isSelected)
+        XCTAssertEqual(rng.calls, 1, "RNG must be consulted exactly once per session")
+    }
+
+    func testSessionRetainsIdAndWeight() {
+        let session = SamplingSession(
+            id: "abcdef123",
+            config: SamplingConfig(weight: 100),
+            random: FixedRandom(value: 0.5)
+        )
+        XCTAssertEqual(session.id, "abcdef123")
+        XCTAssertEqual(session.weight, 100)
+    }
+
+    // MARK: pure predicate
+
+    func testComputeIsSelectedMatchesFormula() {
+        XCTAssertFalse(SamplingSession.computeIsSelected(weight: 0, random: FixedRandom(value: 0)))
+        XCTAssertTrue(SamplingSession.computeIsSelected(weight: 1, random: FixedRandom(value: 0.5)))
+        XCTAssertFalse(SamplingSession.computeIsSelected(weight: 100, random: FixedRandom(value: 0.5)))
+    }
+
+    // MARK: helpers
+
+    private func makeSession(weight: Int, random: Double) -> SamplingSession {
+        SamplingSession(
+            id: "x",
+            config: SamplingConfig(weight: weight),
+            random: FixedRandom(value: random)
+        )
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/SwiftOptelTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/SwiftOptelTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import SwiftOptel
+
+final class SwiftOptelTests: XCTestCase {
+    func testVersionIsNonEmpty() {
+        XCTAssertFalse(SwiftOptel.version.isEmpty)
+    }
+}

--- a/packages/swift-optel/package.json
+++ b/packages/swift-optel/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@slicc/swift-optel",
+  "private": true,
+  "scripts": {
+    "build": "swift build -c release",
+    "test": "swift test",
+    "lint": "swiftlint lint",
+    "lint:fix": "swiftlint --fix"
+  }
+}

--- a/packages/swift-optel/package.json
+++ b/packages/swift-optel/package.json
@@ -5,6 +5,7 @@
     "build": "swift build -c release",
     "test": "swift test",
     "lint": "swiftlint lint",
-    "lint:fix": "swiftlint --fix"
+    "lint:fix": "swiftlint --fix",
+    "deadcode": "periphery scan"
   }
 }


### PR DESCRIPTION
## Summary

Adds `packages/swift-optel`, a Swift RUM/operational-telemetry client for native Swift (esp. SwiftUI) apps. It mirrors the wire format and sampling behavior of Adobe's `helix-rum-js`, using the **app ID (bundle identifier) as the URL hostname**, and ships SwiftUI auto-instrumentation hooks.

## What's included

- **Wire format** byte-compatible with `helix-rum-js` — `POST {base}/.rum/{weight}` with flattened JSON `{ weight, id, referer, checkpoint, t, ...pingData }`, pinned by `CrossImplementationTests` against 6 reference fixtures.
- **App ID as hostname** — `referer = https://{appID}{viewPath}`, with `collectBaseURL` defaulting to `rum.hlx.page`.
- **Sampling** identical to the JS reference — rate-string mapping (`on/off/high/low`), `isSelected = weight > 0 && random * weight < 1`, computed once per session, injectable RNG, `top` emitted first.
- **Public API** — `Optel.configure(appID:rate:collectBaseURL:)` + `Optel.sample(...)`, thread-safe.
- **SwiftUI auto-instrumentation** — `.optelAutoInstrument()` → enter, `.optelView(_:)` → navigate, `.optelTap(source:)` / `OptelButton` → click, `Optel.reportError(_:)` → error.

## CI & quality-gate integration

- `.github/workflows/ci.yml` — paths-filter output + entry, a dedicated `swift-optel` macOS job (SwiftLint, `swift build -c release`, coverage gate, Periphery scan) mirroring `swift-server`, and added to the required `ci` summary check.
- `coverage-ratchet.mjs` — `SwiftOptelPackageTests` bundle mapping.
- Root `package.json` — registered in `workspaces`, `build`, `lint:swift`, `deadcode:swift`; `package-lock.json` synced.
- `packages/swift-optel/package.json` — `deadcode` script; new `packages/swift-optel/.periphery.yml`.
- `coverage-thresholds.json` — `swift.swift-optel` floor (lines 65 / functions 55 / regions 70).

## Verification

- `swift build` + `swift test` → 82/82 passing.
- Coverage: lines 70.67% / functions 61.64% / regions 76.25% — all above floors.
- `lint:swift` green (1 non-serious SwiftLint warning on `_testing_reset`).
- Wire-format parity locked vs `helix-rum-js` fixtures.

## Follow-up

- macOS app wiring (apply `.optelAutoInstrument(...)` in `packages/swift-launcher`) will land as a separate PR.

## Non-goals

- Server-side ingestion changes; native Core Web Vitals collection; UIKit/AppKit auto-instrumentation; cross-launch sampling persistence.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author