### PR TITLE
feat(telemetry): close RUM instrumentation gaps for issue #795

### DIFF
--- a/docs/operational-telemetry.md
+++ b/docs/operational-telemetry.md
@@ -47,7 +47,42 @@ The flag is read by `rum.js` on first call and cached in `window.hlx.rum`. CLI/E
 
 - The extension's manifest CSP and the no-target-page-URL nature of the side panel make the inlined approach simpler and avoid an external script load that would silently 404.
 - CLI/Electron benefit from helix-rum-js's enhancer (CWV, auto-click) which is not reproduced manually.
-- The cost is a per-mode sampling decision (independent RNG draws) and an `error`-beacon payload-shape asymmetry (see "Wiring status" below).
+- The cost is a per-mode sampling decision (independent RNG draws), an `error`-beacon payload-shape asymmetry (see "Wiring status" below), and the extension has no enhancer-derived checkpoints at all (see "Extension Enhancer Parity Decision" below).
+
+## Extension Enhancer Parity Decision
+
+**Decision (2026-06-14, issue #795 Gap 3): accept the gap.** The extension intentionally emits no enhancer-derived checkpoints (`cwv`, `click`, `loadresource`, `missingresource`, `a11y`, `language`, `enter`, `top`, `redirect`). We do **not** bundle a CSP-safe enhancer, and we do **not** add a manual `web-vitals` integration for the extension panel.
+
+### Why not bundle the helix-rum-enhancer
+
+The extension manifest CSP is `script-src 'self' 'wasm-unsafe-eval'` (`packages/chrome-extension/manifest.json`). `@adobe/helix-rum-enhancer` is fundamentally incompatible with this:
+
+1. Helix-rum-js auto-loads the enhancer by injecting a `<script src="https://rum.hlx.page/.rum/@adobe/helix-rum-enhancer@^2/src/index.js">` tag — blocked by CSP.
+2. The enhancer's plugin loader uses `document.currentScript.src` to discover sibling plugins (`/tmp/helix-rum-enhancer/modules/index.js`), which only resolves when the enhancer itself was loaded as an external script. A bundled module has no `currentScript`.
+3. The enhancer's `cwv` plugin loads `web-vitals` via a **second** external `<script src="https://rum.hlx.page/.rum/web-vitals/dist/web-vitals.iife.js">` injection — also blocked by CSP.
+4. Most enhancer plugins (`form`, `video`, `martech`, `consent`, `redirect`, `onetrust`, `trustarc`, `usercentrics`, `webcomponent`) target content websites and have no meaningful signal for a chat-app shell.
+
+Vendoring the entire enhancer + `web-vitals` + retrofitting plugin discovery against a bundler would be substantial maintenance debt for low-value signal.
+
+### Why not bundle `web-vitals` directly
+
+`web-vitals` (5.3.0, ~13 KB) bundles cleanly and exposes `onLCP` / `onINP` / `onCLS` / `onTTFB` / `onFCP` as ES modules — no external script load required, so the CSP constraint is not the blocker. The blockers are signal quality and architectural fit:
+
+- **LCP / FCP**: the side panel is a chat-app shell, not a content page. These would mostly measure initial empty-panel render and would not generalize to user-perceived performance.
+- **CLS**: dominated by streaming-token reflow and chat-history scroll, swamping any real layout-shift signal.
+- **INP**: the only metric with a plausible use case — chat-input latency — but `formsubmit` and `fill` checkpoints already cover those interaction surfaces explicitly, and they carry richer context (scoop name, model id, command name) than a generic INP value.
+- **TTFB**: irrelevant for a `chrome-extension://` page.
+- The **offscreen document is headless** — no DOM, no render — so CWV would only ever apply to the side panel and the detached popout (`?detached=1`, same `index.html`), not the agent runtime where most extension activity happens.
+- The highest-value piece of the original Gap 3 was the `error` checkpoint, which is **already wired in the extension** via `telemetry.ts`'s window `error`/`unhandledrejection` listeners (extension branch), and the parallel work to instrument the offscreen realm closes the remaining capture gap.
+
+### Cross-mode dashboard guidance
+
+- All checkpoints carry `RUM_GENERATION` (`slicc-cli`, `slicc-extension`, `slicc-electron`). Dashboards that query `cwv` MUST filter to `slicc-cli` / `slicc-electron`; querying `cwv` across all generations will show zero events for `slicc-extension` and risk being misread as a regression.
+- The same applies to `click`, `loadresource`, and the other enhancer-derived checkpoints listed above.
+
+### Future option (not committed)
+
+If a concrete extension-perf question emerges in production (e.g., the side panel feeling laggy on chat sends), the smallest sensible addition is a bundled `web-vitals.onINP(…)` call wired through `sampleRUM('cwv', { source: 'inp', target: value })` in the extension branch of `initTelemetry()`. This adds ~3 KB to the extension bundle and would emit one INP value per panel pageview. Defer until the use case is concrete.
 
 ### Where init happens
 
@@ -109,7 +144,7 @@ Historical note: before 2026-05-29, the offscreen realm did not initialize telem
 
 - The extension service worker (`packages/chrome-extension/src/service-worker.ts`). CDP attach/detach, OAuth completion, navigate-licks, tray-socket lifecycle.
 - Custom agent-loop events from the offscreen realm — turn end, tool-call durations, explicit scoop create/delegate/drop. The offscreen `AlmostBashShell` now emits `fill` beacons for every bash call (so the cone-side `agent ...` invocations and `feed_scoop` tool calls show up indirectly), but there are no dedicated `agent-spawn` or `scoop-delegate` checkpoints yet.
-- Core Web Vitals in the extension. The helix enhancer that captures CWV cannot run under the extension's CSP, and we do not self-host it here.
+- Core Web Vitals and other enhancer-derived checkpoints in the extension. See "Extension Enhancer Parity Decision" above for the full rationale; the short version is that CSP makes the auto-loaded enhancer impossible, manual `web-vitals` integration is low-signal for a chat-app shell, and the highest-value piece (`error`) is already wired separately.
 
 These are tracked as future work in `docs/superpowers/specs/2026-04-28-extension-telemetry-design.md`.
 

--- a/packages/webapp/src/core/telemetry-hook.ts
+++ b/packages/webapp/src/core/telemetry-hook.ts
@@ -1,0 +1,35 @@
+/**
+ * Worker-safe telemetry hook for agent-loop errors.
+ *
+ * The agent loop (a low layer in the stack) must not import the UI's
+ * `ui/telemetry.ts` directly — it reaches `window` / `localStorage` /
+ * `@adobe/helix-rum-js` in branches the worker realm never takes, and
+ * a direct import would also push `scoops/scoop-context.ts` into the
+ * no-DOM typecheck guard (`tsconfig.webapp-worker.json`).
+ *
+ * Instead, agent-loop error sites emit through this dependency-inversion
+ * sink: the UI registers `trackError` via `setAgentErrorTelemetrySink`
+ * during `initTelemetry()`, and the agent loop calls `emitAgentError`
+ * with no knowledge of the UI. When no sink is registered (worker realm
+ * before the page-side init runs, or a host that never calls `initTelemetry`),
+ * emits are silently dropped — telemetry is best-effort.
+ *
+ * Mirrors `shell/telemetry-hook.ts` (the same pattern for shell-command
+ * beacons).
+ */
+
+export type AgentErrorSource = 'llm' | 'tool';
+
+type AgentErrorTelemetrySink = (source: AgentErrorSource, details: string) => void;
+
+let sink: AgentErrorTelemetrySink | null = null;
+
+/** Register (or clear with `null`) the agent-error telemetry sink. */
+export function setAgentErrorTelemetrySink(fn: AgentErrorTelemetrySink | null): void {
+  sink = fn;
+}
+
+/** Emit an agent-loop error through the registered sink. No-op if unset. */
+export function emitAgentError(source: AgentErrorSource, details: string): void {
+  sink?.(source, details);
+}

--- a/packages/webapp/src/kernel/kernel-worker.ts
+++ b/packages/webapp/src/kernel/kernel-worker.ts
@@ -35,6 +35,7 @@ import { createPanelRpcTrayProvider } from '../cdp/panel-rpc-tray-provider.js';
 // `registerProviders()` during boot before any code that reads from
 // the registry runs.
 import { registerProviders } from '../providers/index.js';
+import { initTelemetry } from '../ui/telemetry.js';
 import { WorkerCdpProxy } from './cdp-worker-proxy.js';
 import { createKernelHost, type KernelHost } from './host.js';
 import { makeSameOriginBypassFetch } from './kernel-worker-fetch-bypass.js';
@@ -191,6 +192,15 @@ async function boot(init: KernelWorkerInitMsg): Promise<void> {
   // `local-storage-*` handlers + `installPageStorageSync` on the page
   // keep the shim in sync with subsequent page writes.
   installLocalStorageShim(init.localStorageSeed ?? {});
+
+  // Initialize RUM telemetry so beacons fire from the worker
+  // AlmostBashShell and uncaught errors in the agent loop are captured.
+  // Without this, `trackShellCommand` and friends silently no-op because
+  // `sampleRUM` is per-realm module state. Runs AFTER the localStorage
+  // shim so the `telemetry-disabled` / `slicc-rum-debug` keys the page
+  // seeded propagate into the worker's `initTelemetry` decision. Fire-
+  // and-forget — telemetry init must never block the boot.
+  void initTelemetry().catch(() => {});
 
   // Register providers first — kernel host construction reads the
   // provider registry (via scoop-context → provider-settings).

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -39,6 +39,7 @@ import { isExternalLickChannel } from './lick-formatting.js';
 import { buildActiveLicksError, type LickEvent, type LickManager } from './lick-manager.js';
 import { TaskScheduler } from './scheduler.js';
 import { ScoopContext, type ScoopContextCallbacks } from './scoop-context.js';
+import { emitScoopLifecycle } from './scoop-telemetry-hook.js';
 import { createDefaultSharedFiles, createDefaultSkills } from './skills.js';
 import {
   type ChannelMessage,
@@ -854,6 +855,12 @@ export class Orchestrator implements ConeApprovalRouter {
     const responseText = this.scoopResponseBuffer.get(jid);
     this.scoopResponseBuffer.delete(jid);
     if (!responseText) return;
+
+    // Emit completion telemetry before the notify-policy / mute / waiter
+    // branches: a scoop that produced output has lifecycle-completed
+    // regardless of how (or whether) the cone is told about it.
+    emitScoopLifecycle('complete', scoop.folder);
+
     if (scoop.notifyOnComplete === false) return;
 
     // Fire any pending scoop_wait resolvers first. A waiter claims the
@@ -2048,6 +2055,10 @@ export class Orchestrator implements ConeApprovalRouter {
     log.info('Scoop registered', { jid: scoop.jid, name: scoop.name });
     try {
       await this.createScoopTab(scoop.jid);
+      // Cones are tracked separately via boot-time `createScoopTab`
+      // (not `registerScoop`), so this only fires for runtime-spawned
+      // sub-scoops — which is what "delegation activity" cares about.
+      if (!scoop.isCone) emitScoopLifecycle('spawn', scoop.folder);
     } catch (err) {
       log.error('Scoop init failed', {
         jid: scoop.jid,
@@ -2312,6 +2323,8 @@ export class Orchestrator implements ConeApprovalRouter {
     const scoop = this.scoops.get(scoopJid);
     if (!scoop) throw new Error(`Scoop not found: ${scoopJid}`);
 
+    emitScoopLifecycle('feed', scoop.folder);
+
     // Save as a channel message so it shows up in history
     const msg: ChannelMessage = {
       id: `delegate-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -2569,6 +2582,7 @@ export class Orchestrator implements ConeApprovalRouter {
           tab.error = error;
           this.tabs.set(jid, tab);
         }
+        emitScoopLifecycle('error', scoop.folder, error);
         this.callbacks.onError(jid, error);
         this.callbacks.onStatusChange(jid, 'error');
         this.dispatchScoopEvent(jid, 'onError', error);
@@ -2670,6 +2684,8 @@ export class Orchestrator implements ConeApprovalRouter {
 
     const scoopRecord = this.scoops.get(jid)!;
     log.error('Fatal scoop error', { jid, folder: scoopRecord.folder, error });
+
+    emitScoopLifecycle('error', scoopRecord.folder, error);
 
     const tab = this.tabs.get(jid);
     if (tab) {

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -852,14 +852,18 @@ export class Orchestrator implements ConeApprovalRouter {
     const scoop = this.scoops.get(jid);
     if (!scoop || scoop.isCone) return;
 
+    // Emit completion telemetry before the notify-policy / mute / waiter
+    // branches AND before the empty-response early-return: any non-cone
+    // scoop that transitions to ready has lifecycle-completed regardless
+    // of how (or whether) the cone is told about it, and regardless of
+    // whether it buffered any text (structured-output-only turns, the
+    // `agent` shell-bridge spawns, and empty streams all hit this path).
+    // Without it, dashboards see enter ≫ leave counts.
+    emitScoopLifecycle('complete', scoop.folder);
+
     const responseText = this.scoopResponseBuffer.get(jid);
     this.scoopResponseBuffer.delete(jid);
     if (!responseText) return;
-
-    // Emit completion telemetry before the notify-policy / mute / waiter
-    // branches: a scoop that produced output has lifecycle-completed
-    // regardless of how (or whether) the cone is told about it.
-    emitScoopLifecycle('complete', scoop.folder);
 
     if (scoop.notifyOnComplete === false) return;
 

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -1169,7 +1169,13 @@ export class ScoopContext {
     if (event.isError) {
       // Telemetry is best-effort — `target` is sanitized+truncated by
       // `trackError` downstream so passing the raw text excerpt is safe.
-      emitAgentError('tool', `${event.toolName}: ${joined}`);
+      // Strip `<img:data:...;base64,...>` parts before emitting: their
+      // base64 payload can run into MBs per failed image-emitting tool
+      // call, and the telemetry sink only truncates downstream on the
+      // wire. The full `joined` (images included) still flows to the
+      // onToolEnd callback unchanged.
+      const telemetryText = parts.filter((p) => !p.startsWith('<img:')).join('\n');
+      emitAgentError('tool', `${event.toolName}: ${telemetryText}`);
     }
     this.callbacks.onToolEnd?.(event.toolName, joined, event.isError);
   }

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -28,6 +28,7 @@ import { Agent, adaptTools, createLogger } from '../core/index.js';
 import { fetchSecretEnvVars } from '../core/secret-env.js';
 import { getToolResultScrubber } from '../core/secret-scrub.js';
 import type { SessionStore } from '../core/session.js';
+import { emitAgentError } from '../core/telemetry-hook.js';
 import type { VirtualFS } from '../fs/index.js';
 import type { RestrictedFS } from '../fs/restricted-fs.js';
 import { createSudoFs } from '../fs/sudo-fs.js';
@@ -739,6 +740,7 @@ export class ScoopContext {
       folder: this.scoop.folder,
       error: message,
     });
+    emitAgentError('llm', message);
     this.setStatus('error');
     if (this.callbacks.onFatalError) {
       this.callbacks.onFatalError(
@@ -780,6 +782,7 @@ export class ScoopContext {
       error: message,
       maxRetries,
     });
+    emitAgentError('llm', message);
     this.setStatus('error');
     if (this.callbacks.onFatalError) {
       this.callbacks.onFatalError(
@@ -1162,7 +1165,13 @@ export class ScoopContext {
       if (c.type === 'image' && c.data && c.mimeType)
         parts.push(`<img:data:${c.mimeType};base64,${c.data}>`);
     }
-    this.callbacks.onToolEnd?.(event.toolName, parts.join('\n'), event.isError);
+    const joined = parts.join('\n');
+    if (event.isError) {
+      // Telemetry is best-effort — `target` is sanitized+truncated by
+      // `trackError` downstream so passing the raw text excerpt is safe.
+      emitAgentError('tool', `${event.toolName}: ${joined}`);
+    }
+    this.callbacks.onToolEnd?.(event.toolName, joined, event.isError);
   }
 
   /** Handle agent_end error recovery and persistence. */
@@ -1184,6 +1193,7 @@ export class ScoopContext {
           return;
         }
         this.isRecovering = false;
+        emitAgentError('llm', errorMsg);
         this.callbacks.onError(errorMsg);
       } else {
         this.isRecovering = false;

--- a/packages/webapp/src/scoops/scoop-telemetry-hook.ts
+++ b/packages/webapp/src/scoops/scoop-telemetry-hook.ts
@@ -1,0 +1,40 @@
+/**
+ * Worker-safe telemetry hook for scoop lifecycle events.
+ *
+ * The scoops layer (orchestrator + scoop-context) sits below the UI in
+ * the layer stack and must not import `ui/telemetry.ts`, which reaches
+ * `window`, `localStorage`, and `@adobe/helix-rum-js`. That back-edge
+ * would also pull the worker-resident scoops code out of the no-DOM
+ * typecheck guard (`tsconfig.webapp-worker.json`).
+ *
+ * Mirrors the `shell/telemetry-hook.ts` pattern: the UI registers a
+ * sink during `initTelemetry()`, and the scoops layer calls
+ * `emitScoopLifecycle` with no knowledge of the UI. When no sink is
+ * registered (worker float without a page-side telemetry init), emits
+ * are dropped.
+ */
+
+export type ScoopLifecycleEvent = 'spawn' | 'feed' | 'complete' | 'error';
+
+type ScoopTelemetrySink = (event: ScoopLifecycleEvent, scoopName: string, details?: string) => void;
+
+let sink: ScoopTelemetrySink | null = null;
+
+/** Register (or clear with `null`) the scoop lifecycle telemetry sink. */
+export function setScoopTelemetrySink(fn: ScoopTelemetrySink | null): void {
+  sink = fn;
+}
+
+/**
+ * Emit a scoop lifecycle event through the registered sink. `scoopName`
+ * is the scoop folder (used as the source attribution in RUM). `details`
+ * is an optional free-form payload — currently only the `error` event
+ * uses it, to carry the sanitized error message.
+ */
+export function emitScoopLifecycle(
+  event: ScoopLifecycleEvent,
+  scoopName: string,
+  details?: string
+): void {
+  sink?.(event, scoopName, details);
+}

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -24,6 +24,7 @@ import { setupNukeReloadListener } from './boot/setup-nuke-reload-listener.js';
 import { setupSwRegistration } from './boot/setup-sw-registration.js';
 import { applyProviderDefaults } from './provider-settings.js';
 import { resolveUiRuntimeMode } from './runtime-mode.js';
+import { initTelemetry } from './telemetry.js';
 
 const log = createLogger('main');
 
@@ -59,6 +60,16 @@ async function main(): Promise<void> {
   // window-context listener acts on (clearing select localStorage
   // keys, then reloading). Idempotent — safe to call across re-inits.
   setupNukeReloadListener();
+
+  // Initialize RUM telemetry for the page/panel realm — `trackShellCommand`,
+  // `trackChatSubmit`, sprinkle `viewblock`, settings `signup`, and panel JS
+  // `error` are silent no-ops until `sampleRUM` is bound here. Mirrors the
+  // offscreen init (see chrome-extension/src/offscreen.ts). Skipped for the
+  // `?connect=1` login-only surface, which has no kernel and no shell.
+  // Fire-and-forget — telemetry init must never block the boot.
+  if (runtimeMode !== 'connect') {
+    initTelemetry().catch(() => {});
+  }
 
   // Service-worker registration (preview SW + connect-mode SW detach). The
   // helper returns `'reload-pending'` when it has triggered a one-shot

--- a/packages/webapp/src/ui/rum-worker.d.ts
+++ b/packages/webapp/src/ui/rum-worker.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Type declaration for the worker-safe inlined Helix RUM beacon sampler.
+ * The implementation lives in rum-worker.js (intentionally JavaScript — a
+ * worker-globals mirror of rum.js). This file gives TypeScript a
+ * default-export signature for callers like telemetry.ts.
+ */
+declare const sampleRUM: (checkpoint: string, data?: { source?: string; target?: string }) => void;
+export default sampleRUM;

--- a/packages/webapp/src/ui/rum-worker.js
+++ b/packages/webapp/src/ui/rum-worker.js
@@ -1,0 +1,58 @@
+/**
+ * Worker-safe inlined Helix RUM sampler — used by the standalone
+ * kernel-worker DedicatedWorker. Mirrors `rum.js` but uses worker-safe
+ * globals: `self.location` for the referer URL, `globalThis.hlx` for the
+ * cached sampling decision, and `globalThis.RUM_GENERATION` for the
+ * deployment generation. helix-rum-js itself touches `document.currentScript`
+ * and `window.location`, neither of which exists in a DedicatedWorker.
+ */
+
+export default function sampleRUM(checkpoint, data = {}) {
+  try {
+    if (typeof self === 'undefined' || typeof navigator === 'undefined') return;
+    if (typeof navigator.sendBeacon !== 'function') return;
+    const g = globalThis;
+    g.hlx = g.hlx || {};
+    if (!g.hlx.rum) {
+      // Sampling decision is per-worker-lifetime. Cache state on
+      // globalThis.hlx.rum so every sampleRUM() call within this worker
+      // lifetime reuses the same weight, id, and isSelected verdict.
+      let debug = false;
+      try {
+        debug =
+          typeof localStorage !== 'undefined' && localStorage.getItem('slicc-rum-debug') === '1';
+      } catch {
+        // localStorage may be a Map-backed shim that throws in edge cases;
+        // fall back to default weight.
+      }
+      const weight = debug ? 1 : 10;
+      const random = Math.random();
+      const isSelected = random * weight < 1;
+      const href = self.location?.href || '';
+      const id = `${hashCode(href)}-${Date.now()}-${rand14()}`;
+      g.hlx.rum = { weight, id, random, isSelected, sampleRUM };
+    }
+    const { weight, id, isSelected } = g.hlx.rum;
+    if (!isSelected) return;
+    const href = self.location?.href || '';
+    const body = JSON.stringify({
+      weight,
+      id,
+      referer: href,
+      generation: g.RUM_GENERATION,
+      checkpoint,
+      ...data,
+    });
+    navigator.sendBeacon(`https://rum.hlx.page/.rum/${weight}`, body);
+  } catch {
+    // never throw
+  }
+}
+
+function hashCode(s) {
+  return s.split('').reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0);
+}
+
+function rand14() {
+  return Math.random().toString(16).slice(2, 16);
+}

--- a/packages/webapp/src/ui/telemetry.ts
+++ b/packages/webapp/src/ui/telemetry.ts
@@ -30,6 +30,24 @@ declare global {
 }
 
 /**
+ * Capability-based detection for the standalone-worker realm. Trusts
+ * functional shape rather than `typeof` checks because newer Node versions
+ * (25+) expose partial DOM globals (e.g. `localStorage` as an empty object,
+ * `window` / `document` shells) that would otherwise misroute the
+ * worker-realm boot through the page branch and crash on
+ * `localStorage.getItem(...)`. A real DedicatedWorker has none of these;
+ * a real browser page has all of them in functional form.
+ */
+function isWorkerLikeRealm(): boolean {
+  return (
+    typeof window === 'undefined' ||
+    typeof document === 'undefined' ||
+    typeof (document as Document | undefined)?.documentElement === 'undefined' ||
+    typeof (localStorage as Storage | undefined)?.getItem !== 'function'
+  );
+}
+
+/**
  * Get the deployment mode label for telemetry. `standalone-worker` covers
  * the standalone kernel-worker DedicatedWorker (no `window`), distinguishing
  * it from the page-side standalone shell.
@@ -37,7 +55,7 @@ declare global {
 function getModeLabel(): 'cli' | 'extension' | 'electron' | 'standalone-worker' {
   // Workers have no `window`. `chrome` / `document` / `localStorage` are
   // also unavailable, so this check has to come first.
-  if (typeof window === 'undefined') return 'standalone-worker';
+  if (isWorkerLikeRealm()) return 'standalone-worker';
   if (typeof chrome !== 'undefined' && chrome?.runtime?.id) return 'extension';
   if (typeof document !== 'undefined' && document.documentElement?.dataset?.electronOverlay)
     return 'electron';
@@ -59,7 +77,11 @@ function getModeLabel(): 'cli' | 'extension' | 'electron' | 'standalone-worker' 
  */
 export async function initTelemetry(): Promise<void> {
   if (initialized) return;
-  if (typeof localStorage !== 'undefined' && localStorage.getItem('telemetry-disabled') === 'true')
+  if (
+    typeof localStorage !== 'undefined' &&
+    typeof localStorage?.getItem === 'function' &&
+    localStorage.getItem('telemetry-disabled') === 'true'
+  )
     return;
 
   // Register the shell telemetry sink so the worker-resident shell can emit
@@ -82,7 +104,7 @@ export async function initTelemetry(): Promise<void> {
   try {
     const mode = getModeLabel();
 
-    if (typeof window !== 'undefined') {
+    if (mode !== 'standalone-worker' && typeof window !== 'undefined') {
       window.RUM_GENERATION = `slicc-${mode}`;
     } else {
       // Worker realm: no Window, but rum-worker.js reads `globalThis.RUM_GENERATION`.

--- a/packages/webapp/src/ui/telemetry.ts
+++ b/packages/webapp/src/ui/telemetry.ts
@@ -12,6 +12,8 @@
  * - navigate: page load with deployment mode
  */
 
+import { setAgentErrorTelemetrySink } from '../core/telemetry-hook.js';
+import { type ScoopLifecycleEvent, setScoopTelemetrySink } from '../scoops/scoop-telemetry-hook.js';
 import { setShellTelemetrySink } from '../shell/telemetry-hook.js';
 
 type SampleRUM = (checkpoint: string, data?: { source?: string; target?: string }) => void;
@@ -65,6 +67,18 @@ export async function initTelemetry(): Promise<void> {
   // inversion — keeps the shell layer free of a back-edge into ui/).
   setShellTelemetrySink(trackShellCommand);
 
+  // Same dependency-inversion pattern for scoop lifecycle events
+  // (spawn / feed / complete / error). The orchestrator runs in the
+  // kernel worker / offscreen agent realm and never imports this module
+  // directly.
+  setScoopTelemetrySink(trackScoopLifecycle);
+
+  // Register the agent-error telemetry sink (same dependency-inversion
+  // pattern) so LLM stream failures and tool execution errors in
+  // `scoops/scoop-context.ts` reach `trackError` with the correct typed
+  // source ('llm' / 'tool') instead of being lost or mislabeled as 'js'.
+  setAgentErrorTelemetrySink(trackError);
+
   try {
     const mode = getModeLabel();
 
@@ -117,21 +131,22 @@ export async function initTelemetry(): Promise<void> {
       if (typeof window !== 'undefined') {
         window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
       }
+      // Wrap navigator.sendBeacon BEFORE importing @adobe/helix-rum-js. Helix
+      // auto-registers its own window.error / unhandledrejection listeners that
+      // resolve `sampleRUM` via lexical closure to its internal function
+      // declaration, bypassing any wrapper we put on the exported binding.
+      // The beacon path is the only chokepoint we can intercept from the
+      // outside, so we filter Vite-noise error checkpoints there. Without this,
+      // ~99% of CLI dev-mode error volume is @vite/client HMR frames that drown
+      // out real app errors (issue #795). Same-origin bodies (helix sends a
+      // Blob when sampleRUM.collectBaseURL shares window.location.origin) are
+      // passed through unchanged — the default rum.hlx.page endpoint is always
+      // cross-origin so the body is a plain JSON string in practice. The
+      // wrapper is intentionally not restored on teardown: there is no
+      // disposeTelemetry helper, and CLI / Electron pages live for the session.
+      wrapSendBeaconForViteFilter();
       const mod = await import('@adobe/helix-rum-js');
-      // Wrap helix's sampleRUM so its auto-registered error/unhandledrejection
-      // listeners get the same Vite-noise filter and path collapse as direct
-      // trackError calls. Without this, ~99% of CLI dev-mode error volume is
-      // @vite/client HMR frames that drown out real app errors (issue #795).
-      const helixSampleRUM = mod.sampleRUM as SampleRUM;
-      sampleRUM = ((checkpoint, data) => {
-        if (checkpoint === 'error' && typeof data?.target === 'string') {
-          const sanitized = sanitizeError(data.target);
-          if (sanitized === null) return;
-          helixSampleRUM(checkpoint, { ...data, target: sanitized });
-          return;
-        }
-        helixSampleRUM(checkpoint, data);
-      }) as SampleRUM;
+      sampleRUM = mod.sampleRUM as SampleRUM;
     }
 
     initialized = true;
@@ -184,6 +199,41 @@ export function trackSettingsOpen(trigger: string): void {
 }
 
 /**
+ * Map a scoop lifecycle event to a helix-rum checkpoint. Used as the
+ * sink registered with `setScoopTelemetrySink` during `initTelemetry`.
+ *
+ * Checkpoint mapping (consistent with the module's reuse of helix-rum
+ * checkpoints for SLICC-specific semantics):
+ * - spawn    → `enter`   (a new scoop joined the orchestrator)
+ * - feed     → `convert` (the cone delegated work to a scoop)
+ * - complete → `leave`   (a scoop finished a turn with output)
+ * - error    → `error`   (fatal or non-fatal scoop failure)
+ *
+ * `source` always carries the scoop folder so RUM filtering by scoop
+ * name works for every checkpoint. The `error` branch runs the details
+ * through `sanitizeError` so Vite-dev-server noise and VFS paths are
+ * collapsed the same way they are for `trackError`.
+ */
+export function trackScoopLifecycle(
+  event: ScoopLifecycleEvent,
+  scoopName: string,
+  details?: string
+): void {
+  if (event === 'error') {
+    let target: string | undefined = details;
+    if (typeof target === 'string') {
+      const sanitized = sanitizeError(target);
+      if (sanitized === null) return;
+      target = sanitized;
+    }
+    sampleRUM?.('error', { source: `scoop:${scoopName}`, target });
+    return;
+  }
+  const checkpoint = event === 'spawn' ? 'enter' : event === 'feed' ? 'convert' : 'leave';
+  sampleRUM?.(checkpoint, { source: scoopName, target: `scoop-${event}` });
+}
+
+/**
  * Reduce error messages to a privacy-safe form, and drop Vite dev-server noise.
  * - Strip frames originating from Vite's HMR client (@vite/client, @vite/env,
  *   localhost:<port>/@vite/*, [vite] tags, /__vite_ping pings). In CLI dev
@@ -217,6 +267,55 @@ function sanitizeError(msg: string): string | null {
 
   const truncated = raw.slice(0, 200);
   return truncated.replace(/(\/[a-z]+)(?:\/[^\s/]+)+/gi, '$1/.../');
+}
+
+/**
+ * Sentinel marker so a re-init (or a second helix-rum-js import) doesn't wrap
+ * an already-wrapped sendBeacon and build up a recursive chain.
+ */
+const SENDBEACON_WRAPPED = Symbol.for('slicc.telemetry.sendBeacon.wrapped');
+
+/**
+ * Wrap `navigator.sendBeacon` so error beacons emitted by helix-rum-js's
+ * internal listeners (which we cannot intercept at the sampleRUM seam) are
+ * filtered through sanitizeError. Vite-noise-only beacons are dropped and a
+ * mixed beacon is rewritten with a sanitized `target`. Non-error checkpoints
+ * pass through untouched. Opaque (Blob/ArrayBufferView) bodies are passed
+ * through unchanged — sendBeacon is sync and Blob.text() is async.
+ */
+function wrapSendBeaconForViteFilter(): void {
+  if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') return;
+  const current = navigator.sendBeacon as typeof navigator.sendBeacon & {
+    [SENDBEACON_WRAPPED]?: boolean;
+  };
+  if (current[SENDBEACON_WRAPPED]) return;
+  const original = current.bind(navigator);
+  const wrapped = ((url, data) => {
+    try {
+      const text =
+        typeof data === 'string'
+          ? data
+          : data instanceof ArrayBuffer
+            ? new TextDecoder().decode(data)
+            : null;
+      if (text && text.length > 0 && text.charCodeAt(0) === 123 /* '{' */) {
+        const parsed = JSON.parse(text) as { checkpoint?: string; target?: unknown };
+        if (parsed?.checkpoint === 'error' && typeof parsed.target === 'string') {
+          const sanitized = sanitizeError(parsed.target);
+          if (sanitized === null) return true;
+          if (sanitized !== parsed.target) {
+            parsed.target = sanitized;
+            return original(url, JSON.stringify(parsed));
+          }
+        }
+      }
+    } catch {
+      // Opaque or non-JSON body — fall through and send as-is.
+    }
+    return original(url, data);
+  }) as typeof navigator.sendBeacon & { [SENDBEACON_WRAPPED]?: boolean };
+  wrapped[SENDBEACON_WRAPPED] = true;
+  navigator.sendBeacon = wrapped;
 }
 
 /**

--- a/packages/webapp/src/ui/telemetry.ts
+++ b/packages/webapp/src/ui/telemetry.ts
@@ -28,9 +28,14 @@ declare global {
 }
 
 /**
- * Get the deployment mode label for telemetry.
+ * Get the deployment mode label for telemetry. `standalone-worker` covers
+ * the standalone kernel-worker DedicatedWorker (no `window`), distinguishing
+ * it from the page-side standalone shell.
  */
-function getModeLabel(): 'cli' | 'extension' | 'electron' {
+function getModeLabel(): 'cli' | 'extension' | 'electron' | 'standalone-worker' {
+  // Workers have no `window`. `chrome` / `document` / `localStorage` are
+  // also unavailable, so this check has to come first.
+  if (typeof window === 'undefined') return 'standalone-worker';
   if (typeof chrome !== 'undefined' && chrome?.runtime?.id) return 'extension';
   if (typeof document !== 'undefined' && document.documentElement?.dataset?.electronOverlay)
     return 'electron';
@@ -38,7 +43,16 @@ function getModeLabel(): 'cli' | 'extension' | 'electron' {
 }
 
 /**
- * Initialize operational telemetry. Call once from main.ts.
+ * Initialize operational telemetry. Call once from each host's boot:
+ * `ui/main.ts` (page-side standalone / electron / extension panel),
+ * `chrome-extension/src/offscreen.ts` (extension agent realm), and
+ * `kernel/kernel-worker.ts` (standalone agent realm).
+ *
+ * In worker contexts (`standalone-worker`) the inlined `rum.js` is replaced
+ * by `rum-worker.js`, error listeners are registered on `self` instead of
+ * `window`, and the `RUM_GENERATION` / `SAMPLE_PAGEVIEWS_AT_RATE` writes
+ * are gated on `typeof window !== 'undefined'`.
+ *
  * No-op if telemetry is disabled via localStorage toggle.
  */
 export async function initTelemetry(): Promise<void> {
@@ -56,9 +70,26 @@ export async function initTelemetry(): Promise<void> {
 
     if (typeof window !== 'undefined') {
       window.RUM_GENERATION = `slicc-${mode}`;
+    } else {
+      // Worker realm: no Window, but rum-worker.js reads `globalThis.RUM_GENERATION`.
+      (globalThis as Record<string, unknown>).RUM_GENERATION = `slicc-${mode}`;
     }
 
-    if (mode === 'extension') {
+    if (mode === 'standalone-worker') {
+      // Worker realm: helix-rum-js touches `document.currentScript` and
+      // `window.location` which don't exist in a DedicatedWorker. Use the
+      // worker-safe inlined sampler and register error listeners on `self`.
+      const mod = await import('./rum-worker.js');
+      sampleRUM = mod.default as SampleRUM;
+      self.addEventListener('error', (e) => {
+        trackError('js', (e as ErrorEvent).message ?? '');
+      });
+      self.addEventListener('unhandledrejection', (e) => {
+        const reason = (e as PromiseRejectionEvent).reason;
+        const msg = reason instanceof Error ? reason.message : String(reason);
+        trackError('js', msg);
+      });
+    } else if (mode === 'extension') {
       const mod = await import('./rum.js');
       sampleRUM = mod.default as SampleRUM;
 
@@ -66,14 +97,16 @@ export async function initTelemetry(): Promise<void> {
       // for selected sessions. The inlined rum.js does not — register equivalents
       // here so the extension panel still records JS errors. Do NOT add these to
       // the CLI/Electron branch (would double-fire alongside helix's listeners).
+      // trackError applies sanitizeError internally so Vite/path filtering is
+      // shared with the CLI sampleRUM wrapper below.
       if (typeof window !== 'undefined') {
         window.addEventListener('error', (e) => {
-          trackError('js', sanitizeError((e as ErrorEvent).message ?? ''));
+          trackError('js', (e as ErrorEvent).message ?? '');
         });
         window.addEventListener('unhandledrejection', (e) => {
           const reason = (e as PromiseRejectionEvent).reason;
           const msg = reason instanceof Error ? reason.message : String(reason);
-          trackError('js', sanitizeError(msg));
+          trackError('js', msg);
         });
       }
     } else {
@@ -85,7 +118,20 @@ export async function initTelemetry(): Promise<void> {
         window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
       }
       const mod = await import('@adobe/helix-rum-js');
-      sampleRUM = mod.sampleRUM;
+      // Wrap helix's sampleRUM so its auto-registered error/unhandledrejection
+      // listeners get the same Vite-noise filter and path collapse as direct
+      // trackError calls. Without this, ~99% of CLI dev-mode error volume is
+      // @vite/client HMR frames that drown out real app errors (issue #795).
+      const helixSampleRUM = mod.sampleRUM as SampleRUM;
+      sampleRUM = ((checkpoint, data) => {
+        if (checkpoint === 'error' && typeof data?.target === 'string') {
+          const sanitized = sanitizeError(data.target);
+          if (sanitized === null) return;
+          helixSampleRUM(checkpoint, { ...data, target: sanitized });
+          return;
+        }
+        helixSampleRUM(checkpoint, data);
+      }) as SampleRUM;
     }
 
     initialized = true;
@@ -123,7 +169,13 @@ export function trackImageView(context: string): void {
 
 /** Error occurred. source=error type (js/llm/tool), target=details */
 export function trackError(errorType: string, details?: string): void {
-  sampleRUM?.('error', { source: errorType, target: details });
+  let target = details;
+  if (typeof target === 'string') {
+    const sanitized = sanitizeError(target);
+    if (sanitized === null) return;
+    target = sanitized;
+  }
+  sampleRUM?.('error', { source: errorType, target });
 }
 
 /** Settings dialog opened. source=trigger (button/shortcut) */
@@ -132,14 +184,38 @@ export function trackSettingsOpen(trigger: string): void {
 }
 
 /**
- * Reduce error messages to a privacy-safe form.
+ * Reduce error messages to a privacy-safe form, and drop Vite dev-server noise.
+ * - Strip frames originating from Vite's HMR client (@vite/client, @vite/env,
+ *   localhost:<port>/@vite/*, [vite] tags, /__vite_ping pings). In CLI dev
+ *   mode these dominate error volume (~99% per issue #795) and obscure real
+ *   app errors. Return `null` if the entire message is Vite noise so callers
+ *   can skip emitting the error checkpoint entirely.
  * - Truncate to 200 characters.
  * - Collapse VFS-style paths (/<root>/...) past their first segment to /<root>/.../
  *   so `/workspace/skills/foo/bar.ts` becomes `/workspace/.../`.
  *   The regex uses the `i` flag, so `/Workspace/...` and `/SHARED/...` collapse too.
  */
-function sanitizeError(msg: string): string {
-  const truncated = (msg ?? '').slice(0, 200);
+function isViteDevFrame(line: string): boolean {
+  return (
+    line.includes('@vite/client') ||
+    line.includes('@vite/env') ||
+    line.includes('[vite]') ||
+    /https?:\/\/localhost:\d+\/@vite\//.test(line) ||
+    /\/__vite_ping/.test(line)
+  );
+}
+
+function sanitizeError(msg: string): string | null {
+  const raw = msg ?? '';
+
+  if (raw.includes('@vite/') || raw.includes('[vite]') || raw.includes('__vite_ping')) {
+    const kept = raw.split('\n').filter((line) => !isViteDevFrame(line));
+    const cleaned = kept.join('\n').trim();
+    if (!cleaned) return null;
+    return cleaned.slice(0, 200).replace(/(\/[a-z]+)(?:\/[^\s/]+)+/gi, '$1/.../');
+  }
+
+  const truncated = raw.slice(0, 200);
   return truncated.replace(/(\/[a-z]+)(?:\/[^\s/]+)+/gi, '$1/.../');
 }
 

--- a/packages/webapp/src/ui/telemetry.ts
+++ b/packages/webapp/src/ui/telemetry.ts
@@ -37,6 +37,13 @@ declare global {
  * worker-realm boot through the page branch and crash on
  * `localStorage.getItem(...)`. A real DedicatedWorker has none of these;
  * a real browser page has all of them in functional form.
+ *
+ * The duck-typing here couples the page branch to the worker branch:
+ * jsdom satisfies all four predicates, so a future page-branch test
+ * must not stub `localStorage` (or any of the other three) to a
+ * non-function shape, or the boot will silently route through the
+ * worker branch.
+ * @see telemetry-worker.test.ts
  */
 function isWorkerLikeRealm(): boolean {
   return (
@@ -118,7 +125,11 @@ export async function initTelemetry(): Promise<void> {
       const mod = await import('./rum-worker.js');
       sampleRUM = mod.default as SampleRUM;
       self.addEventListener('error', (e) => {
-        trackError('js', (e as ErrorEvent).message ?? '');
+        // Prefer `error.message` over `event.message`: a thrown Error with
+        // an empty top-level event message still yields a useful payload via
+        // the underlying Error.message.
+        const evt = e as ErrorEvent;
+        trackError('js', evt.error?.message ?? evt.message ?? '');
       });
       self.addEventListener('unhandledrejection', (e) => {
         const reason = (e as PromiseRejectionEvent).reason;
@@ -137,7 +148,9 @@ export async function initTelemetry(): Promise<void> {
       // shared with the CLI sampleRUM wrapper below.
       if (typeof window !== 'undefined') {
         window.addEventListener('error', (e) => {
-          trackError('js', (e as ErrorEvent).message ?? '');
+          // Same `error.message`-first preference as the worker branch above.
+          const evt = e as ErrorEvent;
+          trackError('js', evt.error?.message ?? evt.message ?? '');
         });
         window.addEventListener('unhandledrejection', (e) => {
           const reason = (e as PromiseRejectionEvent).reason;
@@ -297,13 +310,70 @@ function sanitizeError(msg: string): string | null {
  */
 const SENDBEACON_WRAPPED = Symbol.for('slicc.telemetry.sendBeacon.wrapped');
 
+type ParsedBeacon = { checkpoint?: string; source?: unknown; target?: unknown };
+
+/** Outcome of sanitizing one error-beacon string field. */
+type FieldOutcome =
+  /** Field absent — neither contributes a "drop" vote nor mutates. */
+  | { kind: 'absent' }
+  /** Field present and informative; may have been rewritten. */
+  | { kind: 'kept'; value: string; mutated: boolean }
+  /** Field present but reduced to pure Vite noise; should blank or drop. */
+  | { kind: 'noise' };
+
+function sanitizeBeaconField(raw: unknown): FieldOutcome {
+  if (typeof raw !== 'string') return { kind: 'absent' };
+  const sanitized = sanitizeError(raw);
+  if (sanitized === null) return { kind: 'noise' };
+  return { kind: 'kept', value: sanitized, mutated: sanitized !== raw };
+}
+
+/**
+ * Sanitize an error-checkpoint beacon body. Returns the literal `true` when
+ * the beacon should be dropped (every present string field is pure Vite
+ * noise), a re-serialized JSON string when at least one field changed, or
+ * `null` to forward the original body unchanged.
+ */
+function sanitizeErrorBeaconBody(parsed: ParsedBeacon): true | string | null {
+  const sourceOutcome = sanitizeBeaconField(parsed.source);
+  const targetOutcome = sanitizeBeaconField(parsed.target);
+  // Drop only when at least one field was present AND every present field
+  // reduced to pure noise. A missing field can't vote for "drop" on its own.
+  const sourceVotesDrop = sourceOutcome.kind !== 'kept';
+  const targetVotesDrop = targetOutcome.kind !== 'kept';
+  const eitherPresent = sourceOutcome.kind !== 'absent' || targetOutcome.kind !== 'absent';
+  if (eitherPresent && sourceVotesDrop && targetVotesDrop) return true;
+  let mutated = false;
+  if (sourceOutcome.kind === 'kept') {
+    if (sourceOutcome.mutated) {
+      parsed.source = sourceOutcome.value;
+      mutated = true;
+    }
+  } else if (sourceOutcome.kind === 'noise') {
+    // Source was pure noise but target survived — blank source so the
+    // rewritten beacon doesn't carry the dropped URL.
+    parsed.source = '';
+    mutated = true;
+  }
+  if (targetOutcome.kind === 'kept') {
+    if (targetOutcome.mutated) {
+      parsed.target = targetOutcome.value;
+      mutated = true;
+    }
+  } else if (targetOutcome.kind === 'noise') {
+    parsed.target = '';
+    mutated = true;
+  }
+  return mutated ? JSON.stringify(parsed) : null;
+}
+
 /**
  * Wrap `navigator.sendBeacon` so error beacons emitted by helix-rum-js's
  * internal listeners (which we cannot intercept at the sampleRUM seam) are
  * filtered through sanitizeError. Vite-noise-only beacons are dropped and a
- * mixed beacon is rewritten with a sanitized `target`. Non-error checkpoints
- * pass through untouched. Opaque (Blob/ArrayBufferView) bodies are passed
- * through unchanged — sendBeacon is sync and Blob.text() is async.
+ * mixed beacon is rewritten with sanitized `source` / `target`. Non-error
+ * checkpoints pass through untouched. Opaque (Blob/ArrayBufferView) bodies are
+ * passed through unchanged — sendBeacon is sync and Blob.text() is async.
  */
 function wrapSendBeaconForViteFilter(): void {
   if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') return;
@@ -321,18 +391,18 @@ function wrapSendBeaconForViteFilter(): void {
             ? new TextDecoder().decode(data)
             : null;
       if (text && text.length > 0 && text.charCodeAt(0) === 123 /* '{' */) {
-        const parsed = JSON.parse(text) as { checkpoint?: string; target?: unknown };
-        if (parsed?.checkpoint === 'error' && typeof parsed.target === 'string') {
-          const sanitized = sanitizeError(parsed.target);
-          if (sanitized === null) return true;
-          if (sanitized !== parsed.target) {
-            parsed.target = sanitized;
-            return original(url, JSON.stringify(parsed));
-          }
+        const parsed = JSON.parse(text) as ParsedBeacon;
+        if (parsed?.checkpoint === 'error') {
+          const outcome = sanitizeErrorBeaconBody(parsed);
+          if (outcome === true) return true;
+          if (outcome !== null) return original(url, outcome);
         }
       }
     } catch {
       // Opaque or non-JSON body — fall through and send as-is.
+      // TODO: a same-origin self-host (see docs/operational-telemetry.md
+      // "Self-Hosting Option") sends Blob beacons that bypass this Vite
+      // filter; sync sendBeacon can't await Blob.text() to peek at them.
     }
     return original(url, data);
   }) as typeof navigator.sendBeacon & { [SENDBEACON_WRAPPED]?: boolean };

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -11,6 +11,7 @@ import {
   consumeDictationFirst,
   stripDictationMarkers,
 } from '../../speech/dictation-priming.js';
+import { trackChatSend } from '../telemetry.js';
 import type { AgentEvent, AgentHandle, ChatMessage } from '../types.js';
 import { createCopyRow } from './wc-copy-row.js';
 import { collateLickMessages, daySeparatorEl, messageEls } from './wc-message-view.js';
@@ -37,6 +38,12 @@ export interface WcChatControllerOptions {
    * when none exists). The spoken-reply loop hangs off this.
    */
   onTurnComplete?: (message: ChatMessage | null) => void;
+  /**
+   * Telemetry context resolver fired on each user-initiated send. Returns the
+   * scoop name + resolved model id for the `formsubmit` beacon; returning
+   * null / throwing skips the beacon (telemetry must never block a send).
+   */
+  resolveTelemetryContext?: () => { scoopName: string; model: string } | null;
 }
 
 function uid(): string {
@@ -50,6 +57,7 @@ export class WcChatController {
   readonly #onMessageRendered?: (message: ChatMessage, els: readonly HTMLElement[]) => void;
   readonly #onMessageDisposed?: (messageId: string) => void;
   readonly #onTurnComplete?: (message: ChatMessage | null) => void;
+  readonly #resolveTelemetryContext?: () => { scoopName: string; model: string } | null;
   #unsubscribe: () => void;
   #onLocalUserMessage?: (
     text: string,
@@ -78,6 +86,7 @@ export class WcChatController {
     this.#onMessageRendered = options.onMessageRendered;
     this.#onMessageDisposed = options.onMessageDisposed;
     this.#onTurnComplete = options.onTurnComplete;
+    this.#resolveTelemetryContext = options.resolveTelemetryContext;
     this.#unsubscribe = options.agent.onEvent((event) => this.#handleAgentEvent(event));
     // Bubbled retry event from any rendered `slicc-error-card` (composed, so it
     // pierces shadow roots). One listener at the thread covers every error card.
@@ -218,6 +227,11 @@ export class WcChatController {
     };
     this.#appendMessage(message);
     this.#agent.sendMessage(content, message.id, message.attachments);
+    // Fire ONLY on the single user-initiated send site. The retry path
+    // (`#handleErrorRetry`) replays an existing user turn through
+    // `#agent.sendMessage` directly and intentionally does NOT re-beacon,
+    // so a click on "Try again" can't inflate the chat-send count.
+    this.#emitChatSendBeacon();
     try {
       // Attachments ride along so tray followers see the full prompt, not a
       // text-only echo. The follower echo is a DISPLAY string — iOS renders
@@ -241,6 +255,22 @@ export class WcChatController {
    */
   #applyDictation(text: string): string {
     return applyDictationMarkers(text, consumeDictationFirst());
+  }
+
+  /**
+   * Resolve the active scoop name + model and emit the `formsubmit` telemetry
+   * beacon. Failure to resolve is silently swallowed — telemetry is fire and
+   * forget and must never disrupt the send path.
+   */
+  #emitChatSendBeacon(): void {
+    if (!this.#resolveTelemetryContext) return;
+    try {
+      const ctx = this.#resolveTelemetryContext();
+      if (!ctx) return;
+      trackChatSend(ctx.scoopName, ctx.model);
+    } catch {
+      // Telemetry must never block the send.
+    }
   }
 
   /** Render an inbound lick (webhook/cron/…) into the thread. */

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -10,6 +10,7 @@
 import type { BrowserAPI, CDPTransport } from '../../cdp/index.js';
 import { installPageStorageSync } from '../../kernel/page-storage-sync.js';
 import { spawnKernelWorker } from '../../kernel/spawn.js';
+import { resolveCurrentModel, resolveModelById } from '../../providers/account-store.js';
 import type { LickEvent } from '../../scoops/lick-manager.js';
 import type { RegisteredScoop, ThinkingLevel } from '../../scoops/types.js';
 import { setupStandalonePrelude } from '../boot/setup-standalone-prelude.js';
@@ -628,6 +629,7 @@ function wireWcWelcome(
 function createWcController(
   refs: WcShellRefs,
   client: OffscreenClient,
+  getSelected: () => RegisteredScoop | null,
   onIdle?: () => void,
   welcome?: WelcomeInterceptHolder
 ): { controller: WcChatController; agentHandle: ReturnType<OffscreenClient['createAgentHandle']> } {
@@ -660,6 +662,24 @@ function createWcController(
   const controller = new WcChatController({
     thread: refs.thread,
     agent: agentHandle,
+    // Operational telemetry — emit a `formsubmit` beacon per user-initiated
+    // chat send carrying the active scoop name + resolved model id. Resolves
+    // the same way `applyThreadContext` builds the composer meta pill so the
+    // beacon agrees with what the user sees in the UI. Returns null when no
+    // scoop is selected (boot race) so the beacon is skipped rather than
+    // reporting a meaningless empty source.
+    resolveTelemetryContext: () => {
+      const scoop = getSelected();
+      if (!scoop) return null;
+      const scoopName = scoop.isCone ? 'cone' : scoop.name;
+      try {
+        const modelId = scoop.config?.modelId;
+        const model = modelId ? resolveModelById(modelId) : resolveCurrentModel();
+        return { scoopName, model: model.id };
+      } catch {
+        return { scoopName, model: '' };
+      }
+    },
     // Spoken-reply loop: a turn that began as push-to-talk dictation (the
     // submit listener marks it) gets its reply read aloud — kokoro once the
     // chained model download is warm, Web Speech until then. The one-shot
@@ -1065,13 +1085,12 @@ export function attachWcClient(
   // wireWcComposer once its module loads) + a stats refresh.
   let refreshPlaceholder: (() => void) | null = null;
   const refreshStats = wireWcStats(boot.wiring, client);
-  const triggerPlaceholder = (): void => {
-    refreshPlaceholder?.();
-  };
+  const triggerPlaceholder = (): void => refreshPlaceholder?.();
   const welcomeHolder: WelcomeInterceptHolder = { intercept: null };
   const { controller, agentHandle } = createWcController(
     refs,
     client,
+    () => boot.getSelected(),
     makeTurnFinishedHook({ boot, triggerPlaceholder, refreshStats }),
     welcomeHolder
   );

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -16,7 +16,16 @@ import type { ChatMessage, ToolCall } from '../types.js';
 import '@slicc/webcomponents';
 import { lickChannelFromBody } from '../../scoops/agent-message-to-chat.js';
 import { isLickChannel } from '../lick-channels.js';
+import { trackImageView } from '../telemetry.js';
 import { scoopColor } from './wc-scoop-color.js';
+
+/**
+ * Dedup set for `viewmedia` beacons: the thread is rebuilt on every render
+ * (streaming, scoop-switch, replay) so `userMessageEl` runs many times per
+ * displayed image. Key by `messageId:attachmentId` so each image fires
+ * `trackImageView` exactly once per session.
+ */
+const trackedImageViews = new Set<string>();
 
 /** Attachment chip shape accepted by `<slicc-user-message>` (not re-exported
  *  by the barrel, so derive it from the class's method signature). */
@@ -440,6 +449,15 @@ function userMessageEl(message: ChatMessage): HTMLElement {
   if (message.queued) bubble.setAttribute('queued', '');
   if (message.attachments?.length) {
     bubble.setAttachments(message.attachments.map(toUserAttachment));
+    // Fire `viewmedia` once per displayed image — the thread rebuilds many
+    // times per session, so dedup by `messageId:attachmentId`.
+    for (const attachment of message.attachments) {
+      if (attachment.kind !== 'image' || !attachment.data) continue;
+      const key = `${message.id}:${attachment.id}`;
+      if (trackedImageViews.has(key)) continue;
+      trackedImageViews.add(key);
+      trackImageView('chat');
+    }
   }
   return bubble;
 }

--- a/packages/webapp/tests/core/telemetry-hook.test.ts
+++ b/packages/webapp/tests/core/telemetry-hook.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { emitAgentError, setAgentErrorTelemetrySink } from '../../src/core/telemetry-hook.js';
+
+describe('agent-error telemetry-hook', () => {
+  beforeEach(() => {
+    setAgentErrorTelemetrySink(null);
+  });
+
+  afterEach(() => {
+    setAgentErrorTelemetrySink(null);
+  });
+
+  it('drops emits when no sink is registered', () => {
+    expect(() => emitAgentError('llm', 'rate_limit')).not.toThrow();
+    expect(() => emitAgentError('tool', 'bash: failed')).not.toThrow();
+  });
+
+  it('routes emits to the registered sink with the typed source', () => {
+    const sink = vi.fn();
+    setAgentErrorTelemetrySink(sink);
+
+    emitAgentError('llm', 'rate_limit');
+    emitAgentError('tool', 'bash: command failed');
+
+    expect(sink).toHaveBeenCalledTimes(2);
+    expect(sink).toHaveBeenNthCalledWith(1, 'llm', 'rate_limit');
+    expect(sink).toHaveBeenNthCalledWith(2, 'tool', 'bash: command failed');
+  });
+
+  it('stops emitting after the sink is cleared', () => {
+    const sink = vi.fn();
+    setAgentErrorTelemetrySink(sink);
+    emitAgentError('llm', 'first');
+    setAgentErrorTelemetrySink(null);
+    emitAgentError('llm', 'dropped');
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledWith('llm', 'first');
+  });
+
+  it('replaces a previously registered sink', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    setAgentErrorTelemetrySink(first);
+    setAgentErrorTelemetrySink(second);
+
+    emitAgentError('llm', 'boom');
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith('llm', 'boom');
+  });
+});

--- a/packages/webapp/tests/kernel/kernel-worker-telemetry.test.ts
+++ b/packages/webapp/tests/kernel/kernel-worker-telemetry.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression guard: the standalone kernel-worker DedicatedWorker MUST call
+ * `initTelemetry()` during boot so RUM beacons fire from the worker
+ * AlmostBashShell and uncaught errors in the agent loop are captured.
+ * Without this, `trackShellCommand` / `trackError` are silent no-ops because
+ * `sampleRUM` is per-realm module state.
+ *
+ * Static-text guard — boot side effects are exercised end-to-end by the
+ * existing kernel-worker init-guard and fetch-bypass tests; this just pins
+ * the call site so a refactor cannot regress the wiring.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const workerPath = join(here, '..', '..', 'src', 'kernel', 'kernel-worker.ts');
+const source = readFileSync(workerPath, 'utf8');
+
+describe('kernel-worker.ts telemetry wiring', () => {
+  it('imports initTelemetry from the webapp telemetry module', () => {
+    expect(source).toMatch(
+      /import\s+\{\s*initTelemetry\s*\}\s+from\s+['"][^'"]*\/ui\/telemetry\.js['"]/
+    );
+  });
+
+  it('calls initTelemetry exactly once in the module', () => {
+    const matches = source.match(/initTelemetry\(\)/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('calls initTelemetry AFTER installLocalStorageShim so seeded keys propagate', () => {
+    // The page seeds `telemetry-disabled` and `slicc-rum-debug` into
+    // `localStorageSeed`; initTelemetry reads them via the worker's Map-backed
+    // shim, which is installed by installLocalStorageShim. Ordering is
+    // load-bearing — initTelemetry running before the shim would always see
+    // an undefined localStorage and skip the disable check.
+    const shimIdx = source.indexOf('installLocalStorageShim(init.localStorageSeed');
+    const telemIdx = source.indexOf('initTelemetry()');
+    expect(shimIdx).toBeGreaterThan(-1);
+    expect(telemIdx).toBeGreaterThan(-1);
+    expect(telemIdx).toBeGreaterThan(shimIdx);
+  });
+
+  it('calls initTelemetry BEFORE createKernelHost so beacons cover host construction errors', () => {
+    const telemIdx = source.indexOf('initTelemetry()');
+    // Match the actual factory call (`await createKernelHost(`), not the
+    // import statement or the `Awaited<ReturnType<typeof createKernelHost>>`
+    // type alias both of which appear earlier in the module.
+    const hostIdx = source.indexOf('await createKernelHost(');
+    expect(telemIdx).toBeGreaterThan(-1);
+    expect(hostIdx).toBeGreaterThan(-1);
+    expect(telemIdx).toBeLessThan(hostIdx);
+  });
+
+  it('swallows initTelemetry rejection so a telemetry failure cannot block boot', () => {
+    // Match the same `.catch(() => {})` discipline used by offscreen.ts so
+    // a transient rum-worker.js import / fetch failure does not break the
+    // worker boot sequence.
+    expect(source).toMatch(/initTelemetry\(\)\s*\.catch\(/);
+  });
+});

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -880,6 +880,45 @@ describe('Orchestrator scoop-notify gating (notifyOnComplete)', () => {
     // Even with notifyOnComplete default, empty output => no notify sent.
     expect(captured).toHaveLength(0);
   });
+
+  it('emits the complete lifecycle beacon even when the scoop produced no output', async () => {
+    const { setScoopTelemetrySink } = await import('../../src/scoops/scoop-telemetry-hook.js');
+    const sink = vi.fn();
+    setScoopTelemetrySink(sink);
+
+    try {
+      const emptyScoop: RegisteredScoop = {
+        jid: 'scoop_empty_lifecycle_1',
+        name: 'empty-lifecycle',
+        folder: 'empty-lifecycle-scoop',
+        isCone: false,
+        type: 'scoop',
+        requiresTrigger: false,
+        assistantLabel: 'empty-lifecycle-scoop',
+        addedAt: new Date().toISOString(),
+        configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+      };
+      await saveScoop(emptyScoop);
+      const o = await initOrchestrator();
+      const priv = o as unknown as OrchestratorPrivate;
+      priv.handleMessage = async () => {};
+
+      // Drop any spawn/feed emits from earlier setup so the assertion below
+      // pins specifically the empty-response complete path.
+      sink.mockClear();
+
+      // No response buffer entry — structured-output-only / agent shell-bridge
+      // / empty-stream paths all hit this. The complete beacon must still
+      // fire so dashboards keep enter ≈ leave counts.
+      await priv.maybeNotifyConeOnScoopComplete(emptyScoop.jid);
+
+      const completeEmits = sink.mock.calls.filter((c) => c[0] === 'complete');
+      expect(completeEmits).toHaveLength(1);
+      expect(completeEmits[0][1]).toBe('empty-lifecycle-scoop');
+    } finally {
+      setScoopTelemetrySink(null);
+    }
+  });
 });
 
 describe('Orchestrator scoop-notify file artifacts', () => {

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -2349,6 +2349,47 @@ describe('ScoopContext typed-source error telemetry', () => {
     );
   });
 
+  it('strips <img:data:...;base64,...> parts from the tool-error telemetry payload but keeps them in onToolEnd', () => {
+    const callbacks = createMockCallbacks();
+    const onToolEnd = vi.fn();
+    callbacks.onToolEnd = onToolEnd;
+    const ctx = new ScoopContext(testScoop, callbacks, {} as any);
+    injectMockAgent(ctx, async () => {});
+
+    const handler = (ctx as any).handleAgentEvent.bind(ctx);
+    // Base64 stand-in long enough to make the cost of routing it through
+    // telemetry obvious if the strip regresses.
+    const fakeBase64 = 'A'.repeat(4096);
+    handler({
+      type: 'tool_execution_end',
+      toolName: 'playwright',
+      isError: true,
+      result: {
+        content: [
+          { type: 'text', text: 'navigation failed: target closed' },
+          { type: 'image', mimeType: 'image/png', data: fakeBase64 },
+        ],
+      },
+    });
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    const [src, payload] = sink.mock.calls[0] as [string, string];
+    expect(src).toBe('tool');
+    expect(payload).toContain('playwright:');
+    expect(payload).toContain('navigation failed: target closed');
+    expect(payload).not.toContain('<img:');
+    expect(payload).not.toContain(fakeBase64);
+
+    // onToolEnd still sees the full joined string — the strip is
+    // telemetry-only so the agent's tool-result rendering is unchanged.
+    expect(callbacks.onToolEnd).toHaveBeenCalledTimes(1);
+    const onToolEndArgs = (callbacks.onToolEnd as any).mock.calls[0];
+    expect(onToolEndArgs[0]).toBe('playwright');
+    expect(onToolEndArgs[1]).toContain('<img:data:image/png;base64,');
+    expect(onToolEndArgs[1]).toContain(fakeBase64);
+    expect(onToolEndArgs[2]).toBe(true);
+  });
+
   it('does NOT emit telemetry on a successful tool_execution_end (isError=false)', () => {
     const callbacks = createMockCallbacks();
     const ctx = new ScoopContext(testScoop, callbacks, {} as any);

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -6,7 +6,7 @@
  */
 
 import 'fake-indexeddb/auto';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   abortableSleep,
   isImageProcessingError,
@@ -2250,5 +2250,118 @@ describe('ScoopContext buildSudoWiring (per-scoop command grant isolation)', () 
 
     mgr.dispose();
     vfs.dispose?.();
+  });
+});
+
+describe('ScoopContext typed-source error telemetry', () => {
+  // Each test installs a fresh sink so we can observe emit calls without
+  // touching the global ui/telemetry RUM pipeline. The hook lives one layer
+  // below ui/, so we drive it directly via setAgentErrorTelemetrySink.
+  let sink: ReturnType<typeof vi.fn>;
+  let restoreSink: () => void;
+
+  beforeEach(async () => {
+    const { setAgentErrorTelemetrySink } = await import('../../src/core/telemetry-hook.js');
+    sink = vi.fn();
+    setAgentErrorTelemetrySink(sink);
+    restoreSink = () => setAgentErrorTelemetrySink(null);
+  });
+
+  afterEach(() => {
+    restoreSink?.();
+  });
+
+  it("emits source='llm' for non-retryable agent errors", async () => {
+    const callbacks = createMockCallbacks();
+    const ctx = new ScoopContext(testScoop, callbacks, {} as any);
+    injectMockAgent(ctx, async () => {
+      throw new Error('400 Bad Request: invalid api key');
+    });
+
+    await ctx.prompt('test');
+
+    expect(sink).toHaveBeenCalledWith('llm', expect.stringContaining('invalid api key'));
+  });
+
+  it("emits source='llm' once retries are exhausted on retryable errors", async () => {
+    const callbacks = createMockCallbacks();
+    const ctx = new ScoopContext(testScoop, callbacks, {} as any);
+    // 429 is retryable per isRetryableError. Inject a perma-failing prompt
+    // so the loop hits MAX_RETRIES (3) and calls handleExhaustedRetries.
+    injectMockAgent(ctx, async () => {
+      throw new Error('429 Too Many Requests: rate limit exceeded');
+    });
+
+    await ctx.prompt('test');
+
+    // We don't care how many retry attempts there were here — we just need to
+    // see that the exhausted-retries path produced an `llm` emit. Real call
+    // sites may also emit from `handleAgentEndEvent` (errorMessage path), so
+    // assert ≥1 instead of ===1.
+    const llmCalls = sink.mock.calls.filter((c) => c[0] === 'llm');
+    expect(llmCalls.length).toBeGreaterThanOrEqual(1);
+    expect(llmCalls.at(-1)![1]).toContain('rate limit');
+  }, 30_000);
+
+  it("emits source='llm' from handleAgentEndEvent when an assistant errorMessage surfaces post-stream", () => {
+    const callbacks = createMockCallbacks();
+    const ctx = new ScoopContext(testScoop, callbacks, {} as any);
+    injectMockAgent(ctx, async () => {});
+
+    // Simulate the path where deltas already streamed so the error escapes
+    // the retry-capture branch and flows through onError + telemetry.
+    (ctx as any).didStreamDeltas = true;
+    (ctx as any).isProcessing = false;
+    (ctx as any).isRecovering = false;
+
+    const handler = (ctx as any).handleAgentEvent.bind(ctx);
+    handler({
+      type: 'agent_end',
+      messages: [
+        {
+          role: 'assistant',
+          content: [],
+          errorMessage: 'stream aborted: upstream EOF',
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    expect(sink).toHaveBeenCalledWith('llm', 'stream aborted: upstream EOF');
+  });
+
+  it("emits source='tool' with toolName+excerpt on tool_execution_end with isError=true", () => {
+    const callbacks = createMockCallbacks();
+    const ctx = new ScoopContext(testScoop, callbacks, {} as any);
+    injectMockAgent(ctx, async () => {});
+
+    const handler = (ctx as any).handleAgentEvent.bind(ctx);
+    handler({
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      isError: true,
+      result: { content: [{ type: 'text', text: 'command not found: foo' }] },
+    });
+
+    expect(sink).toHaveBeenCalledWith(
+      'tool',
+      expect.stringMatching(/^bash:.*command not found: foo/)
+    );
+  });
+
+  it('does NOT emit telemetry on a successful tool_execution_end (isError=false)', () => {
+    const callbacks = createMockCallbacks();
+    const ctx = new ScoopContext(testScoop, callbacks, {} as any);
+    injectMockAgent(ctx, async () => {});
+
+    const handler = (ctx as any).handleAgentEvent.bind(ctx);
+    handler({
+      type: 'tool_execution_end',
+      toolName: 'read_file',
+      isError: false,
+      result: { content: [{ type: 'text', text: 'file contents' }] },
+    });
+
+    expect(sink).not.toHaveBeenCalled();
   });
 });

--- a/packages/webapp/tests/scoops/scoop-telemetry-hook.test.ts
+++ b/packages/webapp/tests/scoops/scoop-telemetry-hook.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  emitScoopLifecycle,
+  setScoopTelemetrySink,
+} from '../../src/scoops/scoop-telemetry-hook.js';
+
+describe('scoop telemetry-hook', () => {
+  beforeEach(() => {
+    setScoopTelemetrySink(null);
+  });
+
+  afterEach(() => {
+    setScoopTelemetrySink(null);
+  });
+
+  it('drops emits when no sink is registered', () => {
+    expect(() => emitScoopLifecycle('spawn', 'researcher')).not.toThrow();
+    expect(() => emitScoopLifecycle('error', 'researcher', 'boom')).not.toThrow();
+  });
+
+  it('routes lifecycle events to the registered sink', () => {
+    const sink = vi.fn();
+    setScoopTelemetrySink(sink);
+
+    emitScoopLifecycle('spawn', 'researcher');
+    emitScoopLifecycle('feed', 'researcher');
+    emitScoopLifecycle('complete', 'researcher');
+    emitScoopLifecycle('error', 'researcher', 'oops');
+
+    expect(sink).toHaveBeenCalledTimes(4);
+    expect(sink).toHaveBeenNthCalledWith(1, 'spawn', 'researcher', undefined);
+    expect(sink).toHaveBeenNthCalledWith(2, 'feed', 'researcher', undefined);
+    expect(sink).toHaveBeenNthCalledWith(3, 'complete', 'researcher', undefined);
+    expect(sink).toHaveBeenNthCalledWith(4, 'error', 'researcher', 'oops');
+  });
+
+  it('stops emitting after the sink is cleared', () => {
+    const sink = vi.fn();
+    setScoopTelemetrySink(sink);
+    emitScoopLifecycle('spawn', 'a');
+    setScoopTelemetrySink(null);
+    emitScoopLifecycle('spawn', 'b');
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledWith('spawn', 'a', undefined);
+  });
+
+  it('replaces a previously registered sink', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    setScoopTelemetrySink(first);
+    setScoopTelemetrySink(second);
+
+    emitScoopLifecycle('feed', 'planner');
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith('feed', 'planner', undefined);
+  });
+});

--- a/packages/webapp/tests/ui/main-telemetry.test.ts
+++ b/packages/webapp/tests/ui/main-telemetry.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression guard: `ui/main.ts` MUST call `initTelemetry()` so RUM beacons
+ * fire from the page/panel realm. Without this, `viewblock` (sprinkles),
+ * `signup` (settings), panel JS `error`, and `trackChatSubmit` are silent
+ * no-ops because `sampleRUM` is module-level singleton state per-realm.
+ *
+ * Static-text guard, not a behavior test — main.ts has a long async boot
+ * sequence (SW registration, provider registration, OAuth bootstrap) that's
+ * expensive to mock. Behavior of `initTelemetry` itself is covered by
+ * `webapp/tests/ui/telemetry.test.ts`. Mirrors
+ * `chrome-extension/tests/offscreen-telemetry.test.ts`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const mainPath = join(here, '..', '..', 'src', 'ui', 'main.ts');
+const source = readFileSync(mainPath, 'utf8');
+
+describe('ui/main.ts telemetry wiring', () => {
+  it('imports initTelemetry from the telemetry module', () => {
+    expect(source).toMatch(/import\s+\{\s*initTelemetry\s*\}\s+from\s+['"]\.\/telemetry\.js['"]/);
+  });
+
+  it('calls initTelemetry() with a swallowed catch', () => {
+    expect(source).toMatch(/initTelemetry\(\)\s*\.catch\(/);
+  });
+
+  it('calls initTelemetry after the fixture early-return', () => {
+    const fixtureIdx = source.indexOf('isFixtureRequested(window.location.href)');
+    const initIdx = source.indexOf('initTelemetry()');
+    expect(fixtureIdx).toBeGreaterThan(-1);
+    expect(initIdx).toBeGreaterThan(-1);
+    expect(initIdx).toBeGreaterThan(fixtureIdx);
+  });
+
+  it('calls initTelemetry before the heavy boot (registerProviders)', () => {
+    const initIdx = source.indexOf('initTelemetry()');
+    const providersIdx = source.indexOf('await registerProviders');
+    expect(initIdx).toBeGreaterThan(-1);
+    expect(providersIdx).toBeGreaterThan(-1);
+    expect(initIdx).toBeLessThan(providersIdx);
+  });
+
+  it('gates initTelemetry on a non-connect runtime mode', () => {
+    expect(source).toMatch(/runtimeMode\s*!==\s*['"]connect['"][\s\S]{0,200}initTelemetry\(\)/);
+  });
+});

--- a/packages/webapp/tests/ui/rum-worker.test.ts
+++ b/packages/webapp/tests/ui/rum-worker.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Worker-safe RUM sampler — pins the `navigator.sendBeacon` path used by the
+ * standalone kernel-worker DedicatedWorker.
+ *
+ * Differences from `rum.js` (extension-only, page realm):
+ *  - reads `self.location.href` (not `window.location.href`)
+ *  - reads `globalThis.hlx` / `globalThis.RUM_GENERATION` (no `window`)
+ *  - tolerates `localStorage` being absent or throwing
+ */
+
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type SampleRUM = (checkpoint: string, data?: Record<string, unknown>) => void;
+
+describe('rum-worker.js', () => {
+  let sendBeacon: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    sendBeacon = vi.fn().mockReturnValue(true);
+    vi.stubGlobal('navigator', { sendBeacon });
+    vi.stubGlobal('self', { location: { href: 'http://worker.test/main.js' } });
+    (globalThis as Record<string, unknown>).RUM_GENERATION = 'slicc-standalone-worker';
+    delete (globalThis as Record<string, unknown>).hlx;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (globalThis as Record<string, unknown>).RUM_GENERATION;
+    delete (globalThis as Record<string, unknown>).hlx;
+    vi.restoreAllMocks();
+  });
+
+  it('caches sampling decision on globalThis.hlx.rum on first call', async () => {
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    sampleRUM('navigate', { target: 'standalone-worker' });
+    const cached = (globalThis as Record<string, unknown>).hlx as {
+      rum?: { weight: number; id: string; isSelected: boolean };
+    };
+    expect(cached?.rum).toBeDefined();
+    expect(typeof cached.rum?.id).toBe('string');
+    expect(cached.rum?.weight).toBe(10);
+  });
+
+  it('emits sendBeacon when isSelected (Math.random=0 forces selection)', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    sampleRUM('navigate', { target: 'standalone-worker' });
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    const [url, body] = sendBeacon.mock.calls[0];
+    expect(url).toBe('https://rum.hlx.page/.rum/10');
+    const parsed = JSON.parse(body as string);
+    expect(parsed.checkpoint).toBe('navigate');
+    expect(parsed.target).toBe('standalone-worker');
+    expect(parsed.generation).toBe('slicc-standalone-worker');
+    expect(parsed.referer).toBe('http://worker.test/main.js');
+    expect(parsed.weight).toBe(10);
+  });
+
+  it('skips sendBeacon when not selected', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    sampleRUM('navigate', { target: 'standalone-worker' });
+    expect(sendBeacon).not.toHaveBeenCalled();
+  });
+
+  it('honors slicc-rum-debug=1 in localStorage (weight=1, always selected)', async () => {
+    const storage: Record<string, string> = { 'slicc-rum-debug': '1' };
+    vi.stubGlobal('localStorage', { getItem: (k: string) => storage[k] ?? null });
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    sampleRUM('navigate');
+    const cached = (globalThis as Record<string, unknown>).hlx as {
+      rum: { weight: number };
+    };
+    expect(cached.rum.weight).toBe(1);
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    const [url] = sendBeacon.mock.calls[0];
+    expect(url).toBe('https://rum.hlx.page/.rum/1');
+  });
+
+  it('falls back to weight=10 when localStorage is absent', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    sampleRUM('navigate');
+    const cached = (globalThis as Record<string, unknown>).hlx as {
+      rum: { weight: number };
+    };
+    expect(cached.rum.weight).toBe(10);
+  });
+
+  it('tolerates a localStorage shim that throws on getItem', async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('storage disabled');
+      },
+    });
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    expect(() => sampleRUM('navigate')).not.toThrow();
+    const cached = (globalThis as Record<string, unknown>).hlx as {
+      rum: { weight: number };
+    };
+    expect(cached.rum.weight).toBe(10);
+  });
+
+  it('no-ops when navigator.sendBeacon is missing', async () => {
+    vi.stubGlobal('navigator', {});
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    expect(() => sampleRUM('navigate')).not.toThrow();
+    expect(sendBeacon).not.toHaveBeenCalled();
+  });
+
+  it('never throws when JSON.stringify rejects circular data', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => sampleRUM('navigate', circular)).not.toThrow();
+  });
+
+  it('does not throw when navigator is missing entirely', async () => {
+    // Stub navigator to undefined so the first guard
+    // (`typeof navigator === 'undefined'`) trips. `vi.stubGlobal('navigator',
+    // undefined)` actually replaces the property so the typeof check returns
+    // 'undefined' even on Node >=22 (where globalThis.navigator exists).
+    vi.stubGlobal('navigator', undefined);
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    expect(() => sampleRUM('navigate')).not.toThrow();
+  });
+
+  it('falls back to empty-string referer when self.location is undefined', async () => {
+    vi.stubGlobal('self', {});
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    sampleRUM('navigate');
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    const [, body] = sendBeacon.mock.calls[0];
+    expect(JSON.parse(body as string).referer).toBe('');
+  });
+
+  it('reuses cached sampling decision across multiple calls', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const { default: sampleRUM } = (await import('../../src/ui/rum-worker.js')) as {
+      default: SampleRUM;
+    };
+    sampleRUM('navigate');
+    const firstId = ((globalThis as Record<string, unknown>).hlx as { rum: { id: string } }).rum.id;
+    sampleRUM('fill', { source: 'ls' });
+    const secondId = ((globalThis as Record<string, unknown>).hlx as { rum: { id: string } }).rum
+      .id;
+    expect(secondId).toBe(firstId);
+    expect(sendBeacon).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/webapp/tests/ui/telemetry-worker.test.ts
+++ b/packages/webapp/tests/ui/telemetry-worker.test.ts
@@ -40,6 +40,14 @@ describe('telemetry — standalone-worker branch', () => {
     delete (globalThis as Record<string, unknown>).hlx;
     workerSelf = new EventTarget();
     vi.stubGlobal('self', workerSelf);
+    // Force a DedicatedWorker-shaped realm regardless of host Node version.
+    // Node 25+ exposes partial DOM-like globals (e.g. `localStorage` as an
+    // empty object) which would otherwise misroute the worker branch through
+    // the page branch. Stubbing here also exercises the production guard
+    // against the worst-case partial-globals environment.
+    vi.stubGlobal('window', undefined);
+    vi.stubGlobal('document', undefined);
+    vi.stubGlobal('localStorage', undefined);
   });
 
   afterEach(() => {

--- a/packages/webapp/tests/ui/telemetry-worker.test.ts
+++ b/packages/webapp/tests/ui/telemetry-worker.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Worker-context tests for `initTelemetry()` — covers the standalone-worker
+ * branch where there is no `window` / `document` / `localStorage`
+ * (DedicatedWorker realm).
+ *
+ * Pins:
+ *  - `getModeLabel()` returns 'standalone-worker' when window is undefined
+ *  - `initTelemetry()` does not throw and does not early-return
+ *  - `error` + `unhandledrejection` listeners are registered on `self`
+ *  - `RUM_GENERATION` is written to `globalThis` (not window — there is none)
+ *  - The inlined worker sampler emits a `navigate` checkpoint with
+ *    target='standalone-worker'
+ */
+
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockWorkerRum = vi.fn();
+const mockHelixRum = vi.fn();
+
+// Mock both sampler modules so we can prove which branch fired and that the
+// worker path never falls through to the helix path.
+vi.mock('../../src/ui/rum-worker.js', () => ({ default: mockWorkerRum }));
+vi.mock('@adobe/helix-rum-js', () => ({ sampleRUM: mockHelixRum }));
+
+// EventTarget shaped `self` stub so `self.addEventListener` /
+// `self.dispatchEvent` resolve to a real, isolated event bus. The Node test
+// env's `globalThis` is not an EventTarget by default (`dispatchEvent` is
+// missing), and a worker's `self` is a distinct EventTarget from
+// `globalThis`, so we mirror that shape here.
+let workerSelf: EventTarget;
+
+describe('telemetry — standalone-worker branch', () => {
+  beforeEach(() => {
+    mockWorkerRum.mockClear();
+    mockHelixRum.mockClear();
+    vi.resetModules();
+    delete (globalThis as Record<string, unknown>).RUM_GENERATION;
+    delete (globalThis as Record<string, unknown>).hlx;
+    workerSelf = new EventTarget();
+    vi.stubGlobal('self', workerSelf);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (globalThis as Record<string, unknown>).RUM_GENERATION;
+    delete (globalThis as Record<string, unknown>).hlx;
+  });
+
+  it('returns and does NOT throw when window/document/localStorage are undefined', async () => {
+    // Sanity-check the env so the test actually exercises the worker branch.
+    expect(typeof window).toBe('undefined');
+    expect(typeof document).toBe('undefined');
+    expect(typeof localStorage).toBe('undefined');
+
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await expect(initTelemetry()).resolves.toBeUndefined();
+  });
+
+  it('emits a navigate checkpoint via the worker-safe sampler with target=standalone-worker', async () => {
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    expect(mockWorkerRum).toHaveBeenCalledWith(
+      'navigate',
+      expect.objectContaining({ target: 'standalone-worker' })
+    );
+    // helix-rum-js path is CLI/Electron only; the worker branch must never load it.
+    expect(mockHelixRum).not.toHaveBeenCalled();
+  });
+
+  it('writes RUM_GENERATION=slicc-standalone-worker to globalThis (no window to write to)', async () => {
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    expect((globalThis as Record<string, unknown>).RUM_GENERATION).toBe('slicc-standalone-worker');
+  });
+
+  it('registers error and unhandledrejection listeners on self', async () => {
+    const addSpy = vi.spyOn(workerSelf, 'addEventListener');
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    const types = addSpy.mock.calls.map((c) => c[0]);
+    expect(types).toContain('error');
+    expect(types).toContain('unhandledrejection');
+  });
+
+  it('error listener falls back to empty string when message is null (?? branch)', async () => {
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockWorkerRum.mockClear();
+
+    const ev = new Event('error') as ErrorEvent;
+    // No `message` property set — `(e as ErrorEvent).message` is `undefined`
+    // so the `?? ''` fallback fires and `trackError('js', '')` runs.
+    workerSelf.dispatchEvent(ev);
+
+    expect(mockWorkerRum).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ source: 'js', target: '' })
+    );
+  });
+
+  it('error listener forwards sanitized message via trackError → sampleRUM', async () => {
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockWorkerRum.mockClear();
+
+    const ev = new Event('error') as ErrorEvent;
+    Object.defineProperty(ev, 'message', { value: 'boom at /workspace/skills/x/y.ts' });
+    workerSelf.dispatchEvent(ev);
+
+    expect(mockWorkerRum).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({
+        source: 'js',
+        target: expect.stringContaining('/workspace/.../'),
+      })
+    );
+  });
+
+  it('unhandledrejection listener stringifies non-Error reasons', async () => {
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockWorkerRum.mockClear();
+
+    const ev = new Event('unhandledrejection') as PromiseRejectionEvent;
+    Object.defineProperty(ev, 'reason', { value: 'plain string reason' });
+    workerSelf.dispatchEvent(ev);
+
+    expect(mockWorkerRum).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ source: 'js', target: 'plain string reason' })
+    );
+  });
+
+  it('unhandledrejection listener uses Error.message when reason is an Error', async () => {
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockWorkerRum.mockClear();
+
+    const ev = new Event('unhandledrejection') as PromiseRejectionEvent;
+    Object.defineProperty(ev, 'reason', { value: new Error('typed boom') });
+    workerSelf.dispatchEvent(ev);
+
+    expect(mockWorkerRum).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ source: 'js', target: expect.stringContaining('typed boom') })
+    );
+  });
+});

--- a/packages/webapp/tests/ui/telemetry.test.ts
+++ b/packages/webapp/tests/ui/telemetry.test.ts
@@ -451,6 +451,126 @@ describe('telemetry — extension branch', () => {
 });
 
 // ---------------------------------------------------------------------------
+// CLI sendBeacon wrapper — covers the Vite-noise filter applied to beacons
+// emitted by helix-rum-js's internal window.error / unhandledrejection
+// listeners. Those listeners resolve `sampleRUM` via lexical closure to the
+// helix module's internal function declaration, so a wrapper on the exported
+// binding can't intercept them. navigator.sendBeacon is the only chokepoint
+// we can wrap from the outside (issue #795 regression guard).
+// ---------------------------------------------------------------------------
+
+describe('telemetry — CLI sendBeacon wrapper', () => {
+  let savedSendBeacon: typeof navigator.sendBeacon | undefined;
+
+  beforeEach(() => {
+    mockLocalStorage.clear();
+    mockSampleRUM.mockClear();
+    vi.resetModules();
+    stubLocalStorage();
+    savedSendBeacon = (navigator as Navigator).sendBeacon;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    if (savedSendBeacon) {
+      Object.defineProperty(navigator, 'sendBeacon', {
+        value: savedSendBeacon,
+        writable: true,
+        configurable: true,
+      });
+    } else {
+      delete (navigator as unknown as { sendBeacon?: unknown }).sendBeacon;
+    }
+  });
+
+  function installUnderlyingBeacon(): ReturnType<typeof vi.fn> {
+    const underlying = vi.fn(() => true);
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: underlying,
+      writable: true,
+      configurable: true,
+    });
+    return underlying;
+  }
+
+  it('drops error beacons whose target is entirely Vite noise', async () => {
+    const underlying = installUnderlyingBeacon();
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    expect(navigator.sendBeacon).not.toBe(underlying);
+
+    const body = JSON.stringify({
+      checkpoint: 'error',
+      source: 'undefined error',
+      target: 'http://localhost:5710/@vite/client',
+    });
+    const result = navigator.sendBeacon('https://rum.hlx.page/.rum/100', body);
+    expect(result).toBe(true);
+    expect(underlying).not.toHaveBeenCalled();
+  });
+
+  it('rewrites error beacons with mixed Vite + real-app content', async () => {
+    const underlying = installUnderlyingBeacon();
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+
+    const body = JSON.stringify({
+      checkpoint: 'error',
+      source: 'undefined error',
+      target: 'TypeError: oops\n  at http://localhost:5710/@vite/client.js:1:1',
+    });
+    navigator.sendBeacon('https://rum.hlx.page/.rum/100', body);
+    expect(underlying).toHaveBeenCalledOnce();
+    const sent = JSON.parse(underlying.mock.calls[0][1] as string);
+    expect(sent.target).toContain('TypeError');
+    expect(sent.target).not.toContain('@vite/client');
+    expect(sent.checkpoint).toBe('error');
+  });
+
+  it('passes through non-error beacons unchanged', async () => {
+    const underlying = installUnderlyingBeacon();
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    const body = JSON.stringify({ checkpoint: 'navigate', target: 'cli' });
+    navigator.sendBeacon('https://rum.hlx.page/.rum/100', body);
+    expect(underlying).toHaveBeenCalledOnce();
+    expect(underlying.mock.calls[0][1]).toBe(body);
+  });
+
+  it('falls through opaque (Blob) bodies without throwing', async () => {
+    const underlying = installUnderlyingBeacon();
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    const blob = new Blob(['{"checkpoint":"error","target":"x"}'], {
+      type: 'application/json',
+    });
+    navigator.sendBeacon('https://rum.hlx.page/.rum/100', blob);
+    expect(underlying).toHaveBeenCalledOnce();
+    expect(underlying.mock.calls[0][1]).toBe(blob);
+  });
+
+  it('does not re-wrap an already-wrapped sendBeacon on re-init', async () => {
+    const underlying = installUnderlyingBeacon();
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    const wrappedOnce = navigator.sendBeacon;
+
+    vi.resetModules();
+    const reloaded = await import('../../src/ui/telemetry.js');
+    await reloaded.initTelemetry();
+    expect(navigator.sendBeacon).toBe(wrappedOnce);
+
+    const viteBody = JSON.stringify({
+      checkpoint: 'error',
+      target: 'http://localhost:5710/@vite/client',
+    });
+    navigator.sendBeacon('https://rum.hlx.page/.rum/100', viteBody);
+    expect(underlying).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Electron branch — covers the third arm of the dispatcher (overlay attribute).
 // CLI/Electron share the helix-rum-js code path; the only branch difference
 // from CLI is the mode label that drives RUM_GENERATION.

--- a/packages/webapp/tests/ui/telemetry.test.ts
+++ b/packages/webapp/tests/ui/telemetry.test.ts
@@ -137,14 +137,80 @@ describe('telemetry', () => {
     expect(mockSampleRUM).toHaveBeenCalledWith('signup', { source: 'button' });
   });
 
-  it('trackError forwards source/target as-is (sanitization happens at the listener)', async () => {
+  it('trackError sanitizes target (truncates to 200 chars)', async () => {
     const { initTelemetry, trackError } = await import('../../src/ui/telemetry.js');
     await initTelemetry();
     mockSampleRUM.mockClear();
 
     const long = 'x'.repeat(250);
     trackError('js', long);
-    expect(mockSampleRUM).toHaveBeenCalledWith('error', { source: 'js', target: long });
+    const target = mockSampleRUM.mock.calls[0][1].target as string;
+    expect(target.length).toBeLessThanOrEqual(200);
+    expect(target.length).toBe(200);
+  });
+
+  it('trackError drops errors that are entirely Vite dev-server noise', async () => {
+    const { initTelemetry, trackError } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    trackError(
+      'js',
+      'Failed to fetch dynamically imported module: http://localhost:5710/@vite/client'
+    );
+    const errorCalls = mockSampleRUM.mock.calls.filter(([cp]) => cp === 'error');
+    expect(errorCalls).toHaveLength(0);
+  });
+
+  it('trackError drops [vite] HMR overlay noise entirely', async () => {
+    const { initTelemetry, trackError } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    trackError('js', '[vite] hot updated: /src/foo.ts');
+    const errorCalls = mockSampleRUM.mock.calls.filter(([cp]) => cp === 'error');
+    expect(errorCalls).toHaveLength(0);
+  });
+
+  it('trackError strips Vite frames from real app errors but keeps the rest', async () => {
+    const { initTelemetry, trackError } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    const mixed = [
+      'TypeError: cannot read property x of undefined',
+      '  at handler (/workspace/skills/foo.ts:10:5)',
+      '  at http://localhost:5710/@vite/client.js:42:1',
+    ].join('\n');
+    trackError('js', mixed);
+
+    const target = mockSampleRUM.mock.calls[0][1].target as string;
+    expect(target).toContain('TypeError');
+    expect(target).not.toContain('@vite/client');
+    expect(target).not.toContain('localhost:5710');
+  });
+
+  it('trackError preserves real errors unchanged (no Vite content)', async () => {
+    const { initTelemetry, trackError } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    trackError('llm', 'rate_limit');
+    expect(mockSampleRUM).toHaveBeenCalledWith('error', { source: 'llm', target: 'rate_limit' });
+  });
+
+  it('CLI sampleRUM wrapper passes through non-error checkpoints unchanged', async () => {
+    const { initTelemetry, trackChatSend } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    // The wrapper sits between trackChatSend and helix's mocked sampleRUM.
+    // Non-error checkpoints must pass through with data intact.
+    trackChatSend('cone', 'claude-sonnet');
+    expect(mockSampleRUM).toHaveBeenCalledWith('formsubmit', {
+      source: 'cone',
+      target: 'claude-sonnet',
+    });
   });
 
   it('track functions are no-op before init', async () => {

--- a/packages/webapp/tests/ui/telemetry.test.ts
+++ b/packages/webapp/tests/ui/telemetry.test.ts
@@ -101,6 +101,83 @@ describe('telemetry', () => {
     expect(mockSampleRUM).toHaveBeenCalledWith('fill', { source: 'node' });
   });
 
+  it('trackScoopLifecycle emits enter/convert/leave for spawn/feed/complete', async () => {
+    const { initTelemetry, trackScoopLifecycle } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    trackScoopLifecycle('spawn', 'researcher');
+    trackScoopLifecycle('feed', 'researcher');
+    trackScoopLifecycle('complete', 'researcher');
+
+    expect(mockSampleRUM).toHaveBeenNthCalledWith(1, 'enter', {
+      source: 'researcher',
+      target: 'scoop-spawn',
+    });
+    expect(mockSampleRUM).toHaveBeenNthCalledWith(2, 'convert', {
+      source: 'researcher',
+      target: 'scoop-feed',
+    });
+    expect(mockSampleRUM).toHaveBeenNthCalledWith(3, 'leave', {
+      source: 'researcher',
+      target: 'scoop-complete',
+    });
+  });
+
+  it('trackScoopLifecycle error namespaces source and sanitizes target', async () => {
+    const { initTelemetry, trackScoopLifecycle } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    trackScoopLifecycle('error', 'planner', 'rate_limit');
+    expect(mockSampleRUM).toHaveBeenCalledWith('error', {
+      source: 'scoop:planner',
+      target: 'rate_limit',
+    });
+  });
+
+  it('trackScoopLifecycle drops error entirely on pure Vite-noise details', async () => {
+    const { initTelemetry, trackScoopLifecycle } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    trackScoopLifecycle('error', 'planner', '[vite] hot updated: /src/foo.ts');
+    const errorCalls = mockSampleRUM.mock.calls.filter(([cp]) => cp === 'error');
+    expect(errorCalls).toHaveLength(0);
+  });
+
+  it('initTelemetry registers the scoop telemetry sink so emitScoopLifecycle reaches RUM', async () => {
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    const { emitScoopLifecycle } = await import('../../src/scoops/scoop-telemetry-hook.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    emitScoopLifecycle('spawn', 'researcher');
+    expect(mockSampleRUM).toHaveBeenCalledWith('enter', {
+      source: 'researcher',
+      target: 'scoop-spawn',
+    });
+  });
+
+  it('initTelemetry registers the agent-error sink so emitAgentError reaches RUM with typed source', async () => {
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    const { emitAgentError } = await import('../../src/core/telemetry-hook.js');
+    await initTelemetry();
+    mockSampleRUM.mockClear();
+
+    emitAgentError('llm', 'rate_limit');
+    emitAgentError('tool', 'bash: command failed');
+
+    expect(mockSampleRUM).toHaveBeenNthCalledWith(1, 'error', {
+      source: 'llm',
+      target: 'rate_limit',
+    });
+    expect(mockSampleRUM).toHaveBeenNthCalledWith(2, 'error', {
+      source: 'tool',
+      target: 'bash: command failed',
+    });
+  });
+
   it('trackSprinkleView emits viewblock', async () => {
     const { initTelemetry, trackSprinkleView } = await import('../../src/ui/telemetry.js');
     await initTelemetry();

--- a/packages/webapp/tests/ui/telemetry.test.ts
+++ b/packages/webapp/tests/ui/telemetry.test.ts
@@ -430,6 +430,31 @@ describe('telemetry — extension branch', () => {
     expect(mockSampleRumJs.mock.calls[0][1].target).not.toContain('/foo/bar.ts');
   });
 
+  it('error listener falls back to error.message when event.message is empty', async () => {
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+    mockSampleRumJs.mockClear();
+
+    // Chromium synthesizes both ErrorEvent.message and ErrorEvent.error for
+    // an uncaught Error. When the top-level message is empty (e.g. a thrown
+    // Error with no string coercion) we still want context from the nested
+    // Error.message rather than emitting an empty target.
+    const errorEvent = new Event('error') as ErrorEvent;
+    Object.defineProperty(errorEvent, 'message', { value: '' });
+    Object.defineProperty(errorEvent, 'error', {
+      value: new Error('nested error context'),
+    });
+    window.dispatchEvent(errorEvent);
+
+    expect(mockSampleRumJs).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({
+        source: 'js',
+        target: expect.stringContaining('nested error context'),
+      })
+    );
+  });
+
   it('registers unhandledrejection listener that calls trackError("js", sanitized)', async () => {
     const { initTelemetry } = await import('../../src/ui/telemetry.js');
     await initTelemetry();
@@ -579,12 +604,61 @@ describe('telemetry — CLI sendBeacon wrapper', () => {
 
     const body = JSON.stringify({
       checkpoint: 'error',
-      source: 'undefined error',
       target: 'http://localhost:5710/@vite/client',
     });
     const result = navigator.sendBeacon('https://rum.hlx.page/.rum/100', body);
     expect(result).toBe(true);
     expect(underlying).not.toHaveBeenCalled();
+  });
+
+  it('drops error beacons whose source AND target are both pure Vite noise', async () => {
+    const underlying = installUnderlyingBeacon();
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+
+    const body = JSON.stringify({
+      checkpoint: 'error',
+      source: 'http://localhost:5710/@vite/client',
+      target: 'http://localhost:5710/@vite/client.js',
+    });
+    const result = navigator.sendBeacon('https://rum.hlx.page/.rum/100', body);
+    expect(result).toBe(true);
+    expect(underlying).not.toHaveBeenCalled();
+  });
+
+  it('blanks a noisy source but keeps the beacon when the target survives', async () => {
+    const underlying = installUnderlyingBeacon();
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+
+    const body = JSON.stringify({
+      checkpoint: 'error',
+      source: 'http://localhost:5710/@vite/client',
+      target: 'TypeError: real app failure',
+    });
+    navigator.sendBeacon('https://rum.hlx.page/.rum/100', body);
+    expect(underlying).toHaveBeenCalledOnce();
+    const sent = JSON.parse(underlying.mock.calls[0][1] as string);
+    expect(sent.source).toBe('');
+    expect(sent.target).toContain('TypeError');
+    expect(sent.checkpoint).toBe('error');
+  });
+
+  it('blanks a noisy target but keeps the beacon when the source survives', async () => {
+    const underlying = installUnderlyingBeacon();
+    const { initTelemetry } = await import('../../src/ui/telemetry.js');
+    await initTelemetry();
+
+    const body = JSON.stringify({
+      checkpoint: 'error',
+      source: 'https://example.com/app.js',
+      target: 'http://localhost:5710/@vite/client',
+    });
+    navigator.sendBeacon('https://rum.hlx.page/.rum/100', body);
+    expect(underlying).toHaveBeenCalledOnce();
+    const sent = JSON.parse(underlying.mock.calls[0][1] as string);
+    expect(sent.source).toBe('https://example.com/app.js');
+    expect(sent.target).toBe('');
   });
 
   it('rewrites error beacons with mixed Vite + real-app content', async () => {

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -10,6 +10,14 @@ import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();
 
+vi.mock('../../../src/ui/telemetry.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/ui/telemetry.js')>(
+    '../../../src/ui/telemetry.js'
+  );
+  return { ...actual, trackChatSend: vi.fn() };
+});
+
+import { trackChatSend } from '../../../src/ui/telemetry.js';
 import type { AgentEvent, AgentHandle } from '../../../src/ui/types.js';
 import { WcChatController } from '../../../src/ui/wc/wc-chat-controller.js';
 
@@ -52,6 +60,7 @@ describe('WcChatController', () => {
     document.body.appendChild(thread);
     agent = new FakeAgent();
     processingStates = [];
+    vi.mocked(trackChatSend).mockClear();
     controller = new WcChatController({
       thread,
       agent,
@@ -106,6 +115,72 @@ describe('WcChatController', () => {
     controller.sendUserMessage('plain typed prompt');
     expect(agent.sent.map((s) => s.text)).toEqual(['plain typed prompt']);
     expect(localEchoes.map((e) => e.text)).toEqual(['plain typed prompt']);
+  });
+
+  describe('telemetry beacon (trackChatSend)', () => {
+    it('fires once per user-initiated send with the resolved scoop + model', () => {
+      const local = document.createElement('slicc-chat-thread');
+      document.body.appendChild(local);
+      const localAgent = new FakeAgent();
+      const ctl = new WcChatController({
+        thread: local,
+        agent: localAgent,
+        resolveTelemetryContext: () => ({ scoopName: 'cone', model: 'claude-sonnet-4-6' }),
+      });
+      ctl.sendUserMessage('hello world');
+      expect(trackChatSend).toHaveBeenCalledTimes(1);
+      expect(trackChatSend).toHaveBeenCalledWith('cone', 'claude-sonnet-4-6');
+    });
+
+    it('does not fire when the prompt is empty (no send happened)', () => {
+      const local = document.createElement('slicc-chat-thread');
+      document.body.appendChild(local);
+      const localAgent = new FakeAgent();
+      const ctl = new WcChatController({
+        thread: local,
+        agent: localAgent,
+        resolveTelemetryContext: () => ({ scoopName: 'cone', model: 'm' }),
+      });
+      ctl.sendUserMessage('   ');
+      expect(trackChatSend).not.toHaveBeenCalled();
+    });
+
+    it('skips the beacon when the context resolver returns null (boot race)', () => {
+      const local = document.createElement('slicc-chat-thread');
+      document.body.appendChild(local);
+      const localAgent = new FakeAgent();
+      const ctl = new WcChatController({
+        thread: local,
+        agent: localAgent,
+        resolveTelemetryContext: () => null,
+      });
+      ctl.sendUserMessage('hello');
+      expect(trackChatSend).not.toHaveBeenCalled();
+      // The send itself must still go through — telemetry never blocks send.
+      expect(localAgent.sent.map((s) => s.text)).toEqual(['hello']);
+    });
+
+    it('swallows resolver throws so a broken resolver cannot block the send', () => {
+      const local = document.createElement('slicc-chat-thread');
+      document.body.appendChild(local);
+      const localAgent = new FakeAgent();
+      const ctl = new WcChatController({
+        thread: local,
+        agent: localAgent,
+        resolveTelemetryContext: () => {
+          throw new Error('resolver blew up');
+        },
+      });
+      expect(() => ctl.sendUserMessage('hello')).not.toThrow();
+      expect(trackChatSend).not.toHaveBeenCalled();
+      expect(localAgent.sent.map((s) => s.text)).toEqual(['hello']);
+    });
+
+    it('is a no-op when no resolveTelemetryContext is wired (default constructor)', () => {
+      // The default `controller` from beforeEach has no resolver wired.
+      controller.sendUserMessage('hi');
+      expect(trackChatSend).not.toHaveBeenCalled();
+    });
   });
 
   it('streams an assistant message through start → delta → done', async () => {

--- a/packages/webapp/tests/ui/wc/wc-message-view-telemetry.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-message-view-telemetry.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+/**
+ * `userMessageEl` fires `trackImageView('chat')` once per displayed image
+ * attachment. The thread is rebuilt on every render (streaming, scoop switch,
+ * replay) so this guards both the wiring and the per-attachment dedup.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { installWcDomStubs } from './wc-dom-stubs.js';
+
+installWcDomStubs();
+
+vi.mock('../../../src/ui/telemetry.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/ui/telemetry.js')>(
+    '../../../src/ui/telemetry.js'
+  );
+  return { ...actual, trackImageView: vi.fn() };
+});
+
+import { trackImageView } from '../../../src/ui/telemetry.js';
+import type { ChatMessage } from '../../../src/ui/types.js';
+import { messageEls } from '../../../src/ui/wc/wc-message-view.js';
+
+function imageMessage(id: string, attachmentId: string): ChatMessage {
+  return {
+    id,
+    role: 'user',
+    content: 'see attached',
+    timestamp: 1,
+    attachments: [
+      {
+        id: attachmentId,
+        name: 'shot.png',
+        mimeType: 'image/png',
+        size: 4,
+        kind: 'image',
+        data: 'AAAA',
+      },
+    ],
+  };
+}
+
+describe('userMessageEl — trackImageView wiring', () => {
+  beforeEach(() => {
+    vi.mocked(trackImageView).mockClear();
+  });
+
+  it('fires viewmedia with source=chat for an image attachment', () => {
+    messageEls(imageMessage('m1', 'a1'));
+    expect(trackImageView).toHaveBeenCalledTimes(1);
+    expect(trackImageView).toHaveBeenCalledWith('chat');
+  });
+
+  it('does not double-fire on re-render of the same message', () => {
+    const message = imageMessage('m2', 'a2');
+    messageEls(message);
+    messageEls(message);
+    messageEls(message);
+    expect(trackImageView).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires once per distinct attachment within a message', () => {
+    const message: ChatMessage = {
+      id: 'm3',
+      role: 'user',
+      content: 'two images',
+      timestamp: 1,
+      attachments: [
+        { id: 'a3a', name: 'a.png', mimeType: 'image/png', size: 4, kind: 'image', data: 'AAAA' },
+        { id: 'a3b', name: 'b.png', mimeType: 'image/png', size: 4, kind: 'image', data: 'BBBB' },
+      ],
+    };
+    messageEls(message);
+    expect(trackImageView).toHaveBeenCalledTimes(2);
+    // Re-render: still only the original two.
+    messageEls(message);
+    expect(trackImageView).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips non-image attachments', () => {
+    const message: ChatMessage = {
+      id: 'm4',
+      role: 'user',
+      content: 'a text file',
+      timestamp: 1,
+      attachments: [
+        {
+          id: 'a4',
+          name: 'notes.txt',
+          mimeType: 'text/plain',
+          size: 4,
+          kind: 'text',
+          text: 'hi',
+        },
+      ],
+    };
+    messageEls(message);
+    expect(trackImageView).not.toHaveBeenCalled();
+  });
+
+  it('skips image attachments with no inlined data', () => {
+    const message: ChatMessage = {
+      id: 'm5',
+      role: 'user',
+      content: 'image too large to inline',
+      timestamp: 1,
+      attachments: [
+        {
+          id: 'a5',
+          name: 'big.png',
+          mimeType: 'image/png',
+          size: 999999,
+          kind: 'image',
+          path: '/tmp/big.png',
+        },
+      ],
+    };
+    messageEls(message);
+    expect(trackImageView).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #795.

Audits and closes the telemetry blind spots called out in the issue across both CLI and extension floats. Two waves, both verified by a verifier sub-agent before push.

## What changed

| Gap (issue #795) | Resolution |
|---|---|
| Extension agent errors invisible (`initTelemetry()` never called in offscreen, no-ops in workers) | `initTelemetry()` now wired in offscreen + standalone kernel-worker, with a worker-safe branch and a new `standalone-worker` mode label. Worker-realm RUM sampler registers `error` / `unhandledrejection` on `self`. |
| Scoop delegation uninstrumented | New worker-safe sink `scoops/scoop-telemetry-hook.ts` (mirrors the shell `telemetry-hook` pattern); orchestrator emits at 5 sites (spawn / feed / complete / error × 2) mapped to helix-rum `enter` / `convert` / `leave` / `error` checkpoints with scoop folder in `source` for RUM filtering. |
| LLM / tool failures mistyped as `js` | New worker-safe sink `core/telemetry-hook.ts`; scoop-context emits `trackError('llm', …)` at 3 LLM failure sites and `trackError('tool', 'bash:…')` at the tool failure site. Integration tests inject fake LLM / tool errors and assert the typed calls. |
| Vite dev noise polluting error stream | `sanitizeError` drops pure `@vite/client` errors and strips Vite frames from mixed real errors. Also: CLI float wraps `navigator.sendBeacon` **before** importing `@adobe/helix-rum-js` so helix's auto-registered `window.error` / `unhandledrejection` listeners can't bypass the filter (closes a leak path the Wave 1 verifier flagged). Symbol-keyed sentinel guards against double-wrap. |
| Extension enhancer parity | Decision documented in `docs/operational-telemetry.md`: bundling `helix-rum-enhancer` is infeasible (CSP + `document.currentScript` plugin discovery + nested external `web-vitals` load) and manual `web-vitals` bundling is low-signal for a chat-app shell. Gap is accepted with rationale + dashboard guidance + deferred-future-option. |

## Architecture

Low-level worker-realm code (kernel worker, scoops orchestrator, scoop-context) can't import the DOM-bound `ui/telemetry.ts` directly, so each subsystem exposes a dependency-inversion sink (`shell/telemetry-hook.ts`, `scoops/scoop-telemetry-hook.ts`, `core/telemetry-hook.ts`). `ui/telemetry.ts` registers concrete emitters into those sinks during `initTelemetry()`. The `tsconfig.webapp-worker.json` no-DOM guard still rejects `window` references in the worker bundle.

Dual-mode parity:
- **Standalone**: `initTelemetry()` called from page realm (`ui/main.ts`) and kernel-worker realm (`kernel/kernel-worker.ts`).
- **Extension**: `initTelemetry()` called from offscreen document.
- **Cherry / hosted-leader / Cloud follower**: inherit through the standalone path.

## Verification

- `npm run lint` ✅
- `npm run typecheck` (7 tsc configs incl. `tsconfig.webapp-worker.json` no-DOM guard) ✅
- `npm run test -w @slicc/webapp` — 6391/6391 pass
- `npm run test --project chrome-extension` — 416/416 pass
- Targeted telemetry suites — 152/152 pass (4 files: telemetry, rum-worker sampler, scoop-telemetry-hook, error-telemetry-hook)

All work delegated to Implementor sub-agents and verified by Verifier sub-agents (Wave 1: tasks 1/4/5; Wave 2: tasks 2/3 + a CLI leak cleanup the Wave 1 verifier flagged). Diff coverage 4×100% on changed code.

## Non-blocking follow-up

The Wave 2 verifier suggested expanding `tsconfig.webapp-worker.json` `include` to cover `scoops/` and `core/` so future DOM leakage into the new worker-shared hooks fails at typecheck instead of relying on the kernel-worker entry point being the single guarded surface. Out of scope here; happy to file a follow-up issue if useful.

## Rollback

Telemetry is write-only append — no data migration. Per-subsystem rollback steps are listed in the spec note (`Rollback Plan` section).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author