### PR TITLE
fix(model-picker): persist provider-qualified model ids (fix cone github-anthropic regression)

### DIFF
--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -230,6 +230,31 @@ export function providerOffersLlmModels(providerId: string): boolean {
   return false;
 }
 
+/**
+ * Per-model variant of `providerOffersLlmModels`: does `providerId` advertise
+ * `modelId` in any of the three catalog sources (provider models → pi-ai
+ * static registry → `modelOverrides`)? Used by `getSelectedProvider()`'s
+ * bare-id repair path so a WC-regressed `selected-model = "gpt-5"` resolves
+ * to the account that actually offers `gpt-5`, not just the first LLM
+ * account in storage.
+ */
+function providerOffersModelId(providerId: string, modelId: string): boolean {
+  try {
+    if (getProviderModels(providerId).some((m) => m.id === modelId)) return true;
+  } catch {
+    /* fall through */
+  }
+  try {
+    const piModels = (getModels as (id: string) => { id: string }[])(providerId);
+    if (piModels.some((m) => m.id === modelId)) return true;
+  } catch {
+    /* provider not registered with pi-ai */
+  }
+  const cfg = getRegisteredProviderConfig(providerId);
+  if (cfg?.modelOverrides && Object.hasOwn(cfg.modelOverrides, modelId)) return true;
+  return false;
+}
+
 // Get provider config with fallback for unknown providers
 export function getProviderConfig(providerId: string): ProviderConfig {
   return (
@@ -1107,12 +1132,28 @@ export function getSelectedProvider(): string {
   const raw = getRawSelectedModel();
   const idx = raw.indexOf(':');
   if (idx > 0) return raw.slice(0, idx);
-  // No provider encoded (or empty prefix like ":gpt-5") — fall back to the
-  // first account that actually offers LLM models. An auth-only account
-  // (e.g. `github` for git push/pull) would otherwise win the fallback and
-  // drag the cone into an unregistered `github-anthropic` api route. Only
-  // collapse to `accounts[0]`/`'anthropic'` when nothing qualifies.
+  // No provider encoded (or empty prefix like ":gpt-5") — repair the bare id.
+  // Priority order:
+  //   1. The first LLM account whose catalog actually offers the bare
+  //      `selected-model`. Without this check, a WC-regressed profile with
+  //      `selected-model = "gpt-5"` and accounts ordered `github, anthropic,
+  //      openai` would route through Anthropic; `resolveCurrentModel()`
+  //      cannot find `gpt-5` there and degrades to the native Anthropic
+  //      default, silently swapping the user's OpenAI selection.
+  //   2. The first account that offers any LLM models. An auth-only account
+  //      (e.g. `github` for git push/pull) would otherwise win the fallback
+  //      and drag the cone into an unregistered `github-anthropic` api route.
+  //   3. Collapse to `accounts[0]` / `'anthropic'` when nothing qualifies.
   const accounts = getAccounts();
+  const selectedModelId = getSelectedModelId();
+  if (selectedModelId) {
+    const offering = accounts.find(
+      (a) =>
+        providerOffersLlmModels(a.providerId) &&
+        providerOffersModelId(a.providerId, selectedModelId)
+    );
+    if (offering) return offering.providerId;
+  }
   const llmAccount = accounts.find((a) => providerOffersLlmModels(a.providerId));
   if (llmAccount) return llmAccount.providerId;
   if (accounts.length > 0) return accounts[0].providerId;

--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -1107,8 +1107,14 @@ export function getSelectedProvider(): string {
   const raw = getRawSelectedModel();
   const idx = raw.indexOf(':');
   if (idx > 0) return raw.slice(0, idx);
-  // No provider encoded (or empty prefix like ":gpt-5") — fall back
+  // No provider encoded (or empty prefix like ":gpt-5") — fall back to the
+  // first account that actually offers LLM models. An auth-only account
+  // (e.g. `github` for git push/pull) would otherwise win the fallback and
+  // drag the cone into an unregistered `github-anthropic` api route. Only
+  // collapse to `accounts[0]`/`'anthropic'` when nothing qualifies.
   const accounts = getAccounts();
+  const llmAccount = accounts.find((a) => providerOffersLlmModels(a.providerId));
+  if (llmAccount) return llmAccount.providerId;
   if (accounts.length > 0) return accounts[0].providerId;
   return 'anthropic';
 }

--- a/packages/webapp/src/ui/wc/wc-nav.ts
+++ b/packages/webapp/src/ui/wc/wc-nav.ts
@@ -23,6 +23,12 @@ import type { WcShellRefs } from './wc-shell.js';
 export interface MetaModel {
   name: string;
   provider?: string;
+  /**
+   * Provider-qualified model id (`providerId:modelId`). The picker echoes it
+   * back on `model-change` so the handler persists the correct provider —
+   * disambiguates models offered by multiple providers (e.g. `claude-opus-4-8`
+   * under both adobe and github-copilot).
+   */
   id: string;
 }
 
@@ -53,7 +59,7 @@ export function modelListForMeta(groups: readonly GroupedModels[]): MetaModel[] 
     group.models.map((model) => ({
       name: model.name ?? model.id,
       provider: group.providerName,
-      id: model.id,
+      id: `${group.providerId}:${model.id}`,
     }))
   );
 }
@@ -243,10 +249,21 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
  * composer so the thinking-effort pill only shows for a model that supports it.
  */
 async function wireModelPicker(refs: WcShellRefs, client: OffscreenClient): Promise<void> {
-  const { resolveModelById, resolveCurrentModel } = await import('../provider-settings.js');
+  const { resolveModelById, resolveCurrentModel, setSelectedModelId } = await import(
+    '../provider-settings.js'
+  );
+  /**
+   * Strip the `providerId:` prefix before consulting `resolveModelById`,
+   * which expects the bare model id (the provider is sourced from
+   * `getSelectedProvider()` internally).
+   */
+  const bareModelId = (id: string): string => {
+    const idx = id.indexOf(':');
+    return idx > 0 ? id.slice(idx + 1) : id;
+  };
   const applyThinkingCapability = (modelId?: string): void => {
     try {
-      const model = modelId ? resolveModelById(modelId) : resolveCurrentModel();
+      const model = modelId ? resolveModelById(bareModelId(modelId)) : resolveCurrentModel();
       refs.composerMeta.toggleAttribute(
         'no-thinking',
         (model as { reasoning?: boolean }).reasoning !== true
@@ -259,7 +276,9 @@ async function wireModelPicker(refs: WcShellRefs, client: OffscreenClient): Prom
   refs.composerMeta.addEventListener('model-change', (event) => {
     const id = (event as CustomEvent<{ id?: string }>).detail?.id;
     if (!id) return;
-    localStorage.setItem('selected-model', id);
+    // Route through `setSelectedModelId` so the `providerId:` prefix is
+    // guaranteed even if the picker ever hands us a bare id.
+    setSelectedModelId(id);
     applyThinkingCapability(id);
     client.updateModel();
   });

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -345,6 +345,34 @@ describe('selected model encodes provider', () => {
     expect(getSelectedProvider()).toBe('anthropic');
   });
 
+  it('getSelectedProvider skips auth-only accounts when falling back without a prefix', () => {
+    // GitHub is auth-only (git push/pull, oauth-token shell command) and
+    // exposes no LLM models — picking it as the fallback would drag the cone
+    // into an unregistered `github-anthropic` api route. The fallback must
+    // prefer the first account that actually offers LLM models.
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([
+        { providerId: 'github', apiKey: '', accessToken: 'gho_xxx', userName: 'lars' },
+        { providerId: 'anthropic', apiKey: 'sk-ant-key' },
+      ])
+    );
+    expect(getSelectedProvider()).toBe('anthropic');
+  });
+
+  it('getSelectedProvider collapses to accounts[0] when no account offers LLM models', () => {
+    // Last-resort: with only auth-only accounts connected, the fallback
+    // still returns a deterministic value (the first account) rather than
+    // a hardcoded `anthropic` that no account is configured to authenticate.
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([
+        { providerId: 'github', apiKey: '', accessToken: 'gho_xxx', userName: 'lars' },
+      ])
+    );
+    expect(getSelectedProvider()).toBe('github');
+  });
+
   it('setSelectedProvider updates the provider prefix in selected-model', () => {
     storage.set('selected-model', 'anthropic:claude-sonnet-4-0');
     setSelectedProvider('openai');

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -373,6 +373,25 @@ describe('selected model encodes provider', () => {
     expect(getSelectedProvider()).toBe('github');
   });
 
+  it('getSelectedProvider prefers the LLM account whose catalog offers the bare model', () => {
+    // WC-regressed profile: `selected-model` lost its provider prefix and now
+    // reads as the bare `gpt-5`. The previous fallback picked the first
+    // LLM-capable account (`anthropic`) and `resolveCurrentModel()` then
+    // degraded to the native Anthropic default — silently swapping the
+    // user's OpenAI selection. The repair must now find `openai` because
+    // its catalog actually contains `gpt-5`.
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([
+        { providerId: 'github', apiKey: '', accessToken: 'gho_xxx', userName: 'lars' },
+        { providerId: 'anthropic', apiKey: 'sk-ant-key' },
+        { providerId: 'openai', apiKey: 'oai-key' },
+      ])
+    );
+    storage.set('selected-model', 'gpt-5');
+    expect(getSelectedProvider()).toBe('openai');
+  });
+
   it('setSelectedProvider updates the provider prefix in selected-model', () => {
     storage.set('selected-model', 'anthropic:claude-sonnet-4-0');
     setSelectedProvider('openai');

--- a/packages/webapp/tests/ui/wc/wc-nav.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-nav.test.ts
@@ -15,7 +15,7 @@ import { accountIdentity, modelListForMeta, wireWcNav } from '../../../src/ui/wc
 import type { WcShellRefs } from '../../../src/ui/wc/wc-shell.js';
 
 describe('modelListForMeta', () => {
-  it('flattens provider groups into picker rows', () => {
+  it('flattens provider groups into picker rows with provider-qualified ids', () => {
     const groups = [
       {
         providerId: 'anthropic',
@@ -25,9 +25,9 @@ describe('modelListForMeta', () => {
       { providerId: 'openai', providerName: 'OpenAI', models: [{ id: 'gpt-5', name: 'GPT-5' }] },
     ] as unknown as GroupedModels[];
     expect(modelListForMeta(groups)).toEqual([
-      { name: 'Opus 4.8', provider: 'Anthropic', id: 'claude-opus-4-8' },
-      { name: 'claude-haiku-4-5', provider: 'Anthropic', id: 'claude-haiku-4-5' },
-      { name: 'GPT-5', provider: 'OpenAI', id: 'gpt-5' },
+      { name: 'Opus 4.8', provider: 'Anthropic', id: 'anthropic:claude-opus-4-8' },
+      { name: 'claude-haiku-4-5', provider: 'Anthropic', id: 'anthropic:claude-haiku-4-5' },
+      { name: 'GPT-5', provider: 'OpenAI', id: 'openai:gpt-5' },
     ]);
   });
 });
@@ -78,9 +78,14 @@ describe('wireWcNav', () => {
     expect(refs.avatarMenu.items.some((i) => i.id === 'tray-enable')).toBe(true);
 
     refs.composerMeta.dispatchEvent(
-      new CustomEvent('model-change', { bubbles: true, detail: { id: 'claude-opus-4-8' } })
+      new CustomEvent('model-change', {
+        bubbles: true,
+        detail: { id: 'adobe:claude-opus-4-8' },
+      })
     );
-    expect(localStorage.getItem('selected-model')).toBe('claude-opus-4-8');
+    // The picker emits a provider-qualified id; the handler must persist it
+    // unchanged so `getSelectedProvider()` recovers the correct provider.
+    expect(localStorage.getItem('selected-model')).toBe('adobe:claude-opus-4-8');
     expect(client.updateModel).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Fixes a WebComponent-migration regression (PR #961) where the WC model picker persisted a bare model id (e.g. `claude-opus-4-8`) with no provider prefix.

**Problem:** `getSelectedProvider()` then fell back to the first account (`github`, which is auth-only) and synthesized an invalid `github-anthropic` api, so the cone failed with: `No API provider registered for api: github-anthropic`.

**Fix:**
- `wc-nav.ts` now persists the provider-qualified model id (`providerId:modelId`), matching the legacy picker.
- `account-store.ts` hardens the no-prefix fallback in `getSelectedProvider()` to skip auth-only providers (via `providerOffersLlmModels`), self-healing any existing bad localStorage value.

**Tests:** regression coverage added in `wc-nav.test.ts` and `provider-settings.test.ts`. Lint, typecheck, and the full suite are green.

**Scope:** webapp only; cleanly separable from the avatar and sudo work.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author