### PR TITLE
feat: add slicc-error-card webcomponent with cone-error retry

### DIFF
--- a/packages/webapp/src/ui/types.ts
+++ b/packages/webapp/src/ui/types.ts
@@ -61,6 +61,12 @@ export interface ChatMessage {
   lickParts?: string[];
   /** True when the message is queued (submitted while the agent is still processing). */
   queued?: boolean;
+  /**
+   * Cone-error marker — set by the chat controller's `error` AgentEvent
+   * handler. The view renders this assistant message as a `slicc-error-card`
+   * with a retry affordance instead of a plain assistant bubble.
+   */
+  error?: boolean;
 }
 
 export interface ToolCall {

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -51,6 +51,8 @@ export class WcChatController {
     messageId: string,
     attachments?: ChatMessage['attachments']
   ) => void;
+  /** Bubbled `slicc-error-retry` listener wired to the thread — see `#handleErrorRetry`. */
+  readonly #onErrorRetry: (event: Event) => void;
 
   #messages: ChatMessage[] = [];
   /** Rendered thread elements per message id (a message can span several). */
@@ -72,10 +74,15 @@ export class WcChatController {
     this.#onMessageDisposed = options.onMessageDisposed;
     this.#onTurnComplete = options.onTurnComplete;
     this.#unsubscribe = options.agent.onEvent((event) => this.#handleAgentEvent(event));
+    // Bubbled retry event from any rendered `slicc-error-card` (composed, so it
+    // pierces shadow roots). One listener at the thread covers every error card.
+    this.#onErrorRetry = () => this.#handleErrorRetry();
+    this.#thread.addEventListener('slicc-error-retry', this.#onErrorRetry);
   }
 
   dispose(): void {
     this.#unsubscribe();
+    this.#thread.removeEventListener('slicc-error-retry', this.#onErrorRetry);
   }
 
   get processing(): boolean {
@@ -387,12 +394,37 @@ export class WcChatController {
 
   #handleError(error: string): void {
     this.setProcessing(false);
+    // The error path renders as `<slicc-error-card>` (a presentational card
+    // with a "Try again" button that emits the bubbled `slicc-error-retry`
+    // event picked up by `#handleErrorRetry`). Mark the message with `error`
+    // so `messageEls` routes it to the card instead of the plain bubble.
     this.#appendMessage({
       id: uid(),
       role: 'assistant',
-      content: `**Error:** ${error}`,
+      content: error,
       timestamp: Date.now(),
+      error: true,
     });
+  }
+
+  /**
+   * Re-run the last user turn through the EXISTING agent send path
+   * (`#agent.sendMessage`) — no new agent API, no duplicate user bubble. A
+   * retry while a turn is in flight is dropped to avoid double-submissions.
+   * Lick / delegation user-rows are skipped: they are not user turns.
+   */
+  #handleErrorRetry(): void {
+    if (this.#processing) return;
+    let lastUser: ChatMessage | undefined;
+    for (let i = this.#messages.length - 1; i >= 0; i--) {
+      const m = this.#messages[i];
+      if (m.role === 'user' && m.source !== 'lick' && m.source !== 'delegation') {
+        lastUser = m;
+        break;
+      }
+    }
+    if (!lastUser) return;
+    this.#agent.sendMessage(lastUser.content, uid(), lastUser.attachments);
   }
 
   // -- rendering ------------------------------------------------------------

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -76,7 +76,9 @@ export class WcChatController {
     this.#unsubscribe = options.agent.onEvent((event) => this.#handleAgentEvent(event));
     // Bubbled retry event from any rendered `slicc-error-card` (composed, so it
     // pierces shadow roots). One listener at the thread covers every error card.
-    this.#onErrorRetry = () => this.#handleErrorRetry();
+    // The event's `detail.messageId` identifies WHICH error card was clicked so
+    // retry binds to that specific failed turn (see `#handleErrorRetry`).
+    this.#onErrorRetry = (event) => this.#handleErrorRetry(event);
     this.#thread.addEventListener('slicc-error-retry', this.#onErrorRetry);
   }
 
@@ -408,23 +410,38 @@ export class WcChatController {
   }
 
   /**
-   * Re-run the last user turn through the EXISTING agent send path
-   * (`#agent.sendMessage`) — no new agent API, no duplicate user bubble. A
-   * retry while a turn is in flight is dropped to avoid double-submissions.
-   * Lick / delegation user-rows are skipped: they are not user turns.
+   * Re-run the user turn that produced THIS error card through the existing
+   * agent send path (`#agent.sendMessage`) — no new agent API, no duplicate
+   * user bubble. The card forwards its `message-id` (the failed error
+   * message's id) on the event; we walk backward from that message to find the
+   * user turn that produced it, so a click on an older error card or a retry
+   * after a newer prompt was queued still re-runs the RIGHT turn. A retry
+   * while a turn is in flight is dropped to avoid double-submissions. Lick /
+   * delegation user-rows are skipped: they are not user turns. Falls back to
+   * the legacy "last user message in the whole thread" scan if the event
+   * carries no messageId (older callers / non-card dispatchers).
    */
-  #handleErrorRetry(): void {
+  #handleErrorRetry(event: Event): void {
     if (this.#processing) return;
-    let lastUser: ChatMessage | undefined;
-    for (let i = this.#messages.length - 1; i >= 0; i--) {
+    const messageId =
+      (event as CustomEvent<{ messageId?: string | null }>).detail?.messageId ?? null;
+    let startIndex = this.#messages.length;
+    if (messageId) {
+      const errorIndex = this.#messages.findIndex((m) => m.id === messageId);
+      if (errorIndex >= 0) startIndex = errorIndex;
+      // If the id is unknown (stale card, history reload), fall back to the
+      // legacy whole-thread scan rather than silently dropping the retry.
+    }
+    let target: ChatMessage | undefined;
+    for (let i = startIndex - 1; i >= 0; i--) {
       const m = this.#messages[i];
       if (m.role === 'user' && m.source !== 'lick' && m.source !== 'delegation') {
-        lastUser = m;
+        target = m;
         break;
       }
     }
-    if (!lastUser) return;
-    this.#agent.sendMessage(lastUser.content, uid(), lastUser.attachments);
+    if (!target) return;
+    this.#agent.sendMessage(target.content, uid(), target.attachments);
   }
 
   // -- rendering ------------------------------------------------------------

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -518,12 +518,23 @@ function delegationEls(message: ChatMessage): HTMLElement[] {
   return [line, bubble];
 }
 
+/**
+ * `slicc-error-card` for a cone-error message. The card is purely
+ * presentational; the chat controller listens for the bubbled
+ * `slicc-error-retry` event to re-run the last user turn via its existing
+ * agent send path.
+ */
+function errorCardEl(message: ChatMessage): HTMLElement {
+  return el('slicc-error-card', { message: message.content });
+}
+
 /** Elements for a single chat message, in thread order. */
 export function messageEls(message: ChatMessage): HTMLElement[] {
   if (message.source === 'lick') return [lickCardEl(message)];
   if (message.source === 'delegation' || message.channel === 'delegation') {
     return delegationEls(message);
   }
+  if (message.error) return [errorCardEl(message)];
   if (message.role === 'assistant') return assistantMessageEls(message);
   // Unstamped lick bodies (histories persisted before channel stamping)
   // classify at render so old idle/completed notifications never regress

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -525,7 +525,7 @@ function delegationEls(message: ChatMessage): HTMLElement[] {
  * agent send path.
  */
 function errorCardEl(message: ChatMessage): HTMLElement {
-  return el('slicc-error-card', { message: message.content });
+  return el('slicc-error-card', { message: message.content, 'message-id': message.id });
 }
 
 /** Elements for a single chat message, in thread order. */

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -139,12 +139,66 @@ describe('WcChatController', () => {
     expect(thread.querySelector('slicc-action-row')?.getAttribute('result')).toBe('error');
   });
 
-  it('renders agent errors as an error bubble and clears processing', () => {
+  it('renders agent errors as a slicc-error-card and clears processing', () => {
     agent.emit({ type: 'message_start', messageId: 'm1' });
     agent.emit({ type: 'error', error: 'rate limited' });
     expect(controller.processing).toBe(false);
-    const bubbles = thread.querySelectorAll('slicc-agent-message');
-    expect(bubbles[bubbles.length - 1].textContent).toContain('rate limited');
+    const card = thread.querySelector('slicc-error-card');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute('message')).toBe('rate limited');
+  });
+
+  it('retries the last user turn through the agent send path on slicc-error-retry', () => {
+    controller.sendUserMessage('hello world');
+    agent.sent.length = 0;
+    agent.emit({ type: 'message_start', messageId: 'm1' });
+    agent.emit({ type: 'error', error: 'rate limited' });
+    const card = thread.querySelector('slicc-error-card');
+    card?.dispatchEvent(new CustomEvent('slicc-error-retry', { bubbles: true, composed: true }));
+    expect(agent.sent).toHaveLength(1);
+    expect(agent.sent[0].text).toBe('hello world');
+    // No duplicate user bubble — retry routes through `#agent.sendMessage`
+    // directly, not `sendUserMessage`.
+    expect(thread.querySelectorAll('slicc-user-message')).toHaveLength(1);
+  });
+
+  it('does nothing on retry while a turn is already in flight', () => {
+    controller.sendUserMessage('hi');
+    agent.sent.length = 0;
+    agent.emit({ type: 'message_start', messageId: 'm1' });
+    // No content_done / turn_end / error — controller is still processing.
+    expect(controller.processing).toBe(true);
+    thread.dispatchEvent(new CustomEvent('slicc-error-retry', { bubbles: true, composed: true }));
+    expect(agent.sent).toHaveLength(0);
+  });
+
+  it('skips lick rows when finding the last user turn for retry', () => {
+    controller.sendUserMessage('first');
+    controller.addLickMessage('l1', '[Webhook Event: x]', 'webhook', Date.now());
+    agent.sent.length = 0;
+    agent.emit({ type: 'error', error: 'rate limited' });
+    const card = thread.querySelector('slicc-error-card');
+    card?.dispatchEvent(new CustomEvent('slicc-error-retry', { bubbles: true, composed: true }));
+    expect(agent.sent).toHaveLength(1);
+    expect(agent.sent[0].text).toBe('first');
+  });
+
+  it('no-ops a retry when there is no prior user turn', () => {
+    agent.sent.length = 0;
+    agent.emit({ type: 'error', error: 'rate limited' });
+    const card = thread.querySelector('slicc-error-card');
+    card?.dispatchEvent(new CustomEvent('slicc-error-retry', { bubbles: true, composed: true }));
+    expect(agent.sent).toHaveLength(0);
+  });
+
+  it('stops listening for retry after dispose', () => {
+    controller.sendUserMessage('hi');
+    agent.sent.length = 0;
+    agent.emit({ type: 'error', error: 'rate limited' });
+    const card = thread.querySelector('slicc-error-card');
+    controller.dispose();
+    card?.dispatchEvent(new CustomEvent('slicc-error-retry', { bubbles: true, composed: true }));
+    expect(agent.sent).toHaveLength(0);
   });
 
   it('replaces history wholesale on loadMessages', () => {

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -148,18 +148,50 @@ describe('WcChatController', () => {
     expect(card?.getAttribute('message')).toBe('rate limited');
   });
 
-  it('retries the last user turn through the agent send path on slicc-error-retry', () => {
+  it('retries the failed turn through the agent send path on slicc-error-retry', () => {
     controller.sendUserMessage('hello world');
     agent.sent.length = 0;
     agent.emit({ type: 'message_start', messageId: 'm1' });
     agent.emit({ type: 'error', error: 'rate limited' });
     const card = thread.querySelector('slicc-error-card');
-    card?.dispatchEvent(new CustomEvent('slicc-error-retry', { bubbles: true, composed: true }));
+    const errorId = card?.getAttribute('message-id') ?? null;
+    expect(errorId).not.toBeNull();
+    card?.dispatchEvent(
+      new CustomEvent('slicc-error-retry', {
+        detail: { messageId: errorId },
+        bubbles: true,
+        composed: true,
+      })
+    );
     expect(agent.sent).toHaveLength(1);
     expect(agent.sent[0].text).toBe('hello world');
     // No duplicate user bubble — retry routes through `#agent.sendMessage`
     // directly, not `sendUserMessage`.
     expect(thread.querySelectorAll('slicc-user-message')).toHaveLength(1);
+  });
+
+  it('binds retry to the failed turn even when a newer prompt was queued', () => {
+    // Turn A: user prompt + agent error. The user then queues prompt B while
+    // the (no-longer-)in-flight controller is still settling. Retry must
+    // resubmit A — the prompt that actually failed — not the newest user row.
+    controller.sendUserMessage('prompt A');
+    agent.emit({ type: 'message_start', messageId: 'm1' });
+    agent.emit({ type: 'error', error: 'rate limited' });
+    const card = thread.querySelector('slicc-error-card');
+    const errorId = card?.getAttribute('message-id') ?? null;
+    expect(errorId).not.toBeNull();
+    // Newer user prompt queued AFTER the error card.
+    controller.sendUserMessage('prompt B (newer)');
+    agent.sent.length = 0;
+    card?.dispatchEvent(
+      new CustomEvent('slicc-error-retry', {
+        detail: { messageId: errorId },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    expect(agent.sent).toHaveLength(1);
+    expect(agent.sent[0].text).toBe('prompt A');
   });
 
   it('does nothing on retry while a turn is already in flight', () => {
@@ -178,9 +210,26 @@ describe('WcChatController', () => {
     agent.sent.length = 0;
     agent.emit({ type: 'error', error: 'rate limited' });
     const card = thread.querySelector('slicc-error-card');
-    card?.dispatchEvent(new CustomEvent('slicc-error-retry', { bubbles: true, composed: true }));
+    const errorId = card?.getAttribute('message-id') ?? null;
+    card?.dispatchEvent(
+      new CustomEvent('slicc-error-retry', {
+        detail: { messageId: errorId },
+        bubbles: true,
+        composed: true,
+      })
+    );
     expect(agent.sent).toHaveLength(1);
     expect(agent.sent[0].text).toBe('first');
+  });
+
+  it('falls back to the legacy whole-thread scan when detail.messageId is absent', () => {
+    controller.sendUserMessage('hello world');
+    agent.sent.length = 0;
+    agent.emit({ type: 'error', error: 'rate limited' });
+    // No detail on the event — older callers / non-card dispatchers.
+    thread.dispatchEvent(new CustomEvent('slicc-error-retry', { bubbles: true, composed: true }));
+    expect(agent.sent).toHaveLength(1);
+    expect(agent.sent[0].text).toBe('hello world');
   });
 
   it('no-ops a retry when there is no prior user turn', () => {

--- a/packages/webcomponents/src/chat/slicc-error-card.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.stories.ts
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import './slicc-error-card.js';
+
+interface ErrorCardArgs {
+  label?: string;
+  message?: string;
+  bodyHtml?: string;
+  'button-label'?: string;
+  theme?: 'light' | 'dark';
+}
+
+/**
+ * Project the demo `bodyHtml` (plain text with `<b>…</b>` emphasis) into the
+ * card's default slot as real DOM — text nodes plus `<b>` elements — instead of
+ * an HTML-string assignment. The library builds markup by DOM construction,
+ * stories included.
+ */
+function appendRichBody(el: HTMLElement, markup: string): void {
+  // A capture-group split yields alternating segments: even indices are the
+  // surrounding plain text, odd indices are the inner text of each `<b>…</b>`.
+  markup.split(/<b>(.*?)<\/b>/g).forEach((part, i) => {
+    if (part === '') return;
+    if (i % 2 === 1) {
+      const b = document.createElement('b');
+      b.textContent = part;
+      el.append(b);
+    } else {
+      el.append(document.createTextNode(part));
+    }
+  });
+}
+
+function build(args: ErrorCardArgs): HTMLElement {
+  const el = document.createElement('slicc-error-card');
+  if (args.label != null) el.setAttribute('label', args.label);
+  if (args['button-label'] != null) el.setAttribute('button-label', args['button-label']);
+  if (args.theme) el.setAttribute('theme', args.theme);
+  // Rich slotted markup wins over the plain `message` attribute when supplied.
+  if (args.bodyHtml != null) appendRichBody(el, args.bodyHtml);
+  else if (args.message != null) el.setAttribute('message', args.message);
+  return el;
+}
+
+const meta: Meta<ErrorCardArgs> = {
+  title: 'Chat/ErrorCard',
+  component: 'slicc-error-card',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The cone error card rendered in the chat stream when an agent turn fails. ' +
+          'Mirrors the `slicc-lick-card` shape (rounded card, iconed header, body line) but ' +
+          'in the red/destructive palette with a trailing "Try again" affordance. The button ' +
+          'dispatches a bubbling, composed `slicc-error-retry` CustomEvent the host catches ' +
+          'to re-run the last user turn through its existing send path.',
+      },
+    },
+  },
+  argTypes: {
+    label: { control: 'text', description: 'Header label (default "Something went wrong")' },
+    message: { control: 'text', description: 'Error body text (escaped)' },
+    bodyHtml: { control: 'text', description: 'Rich slotted body markup (overrides message)' },
+    'button-label': { control: 'text', description: 'Retry button label (default "Try again")' },
+    theme: { control: 'inline-radio', options: ['light', 'dark'], description: 'Theme override' },
+  },
+  render: build,
+};
+
+export default meta;
+type Story = StoryObj<ErrorCardArgs>;
+
+/** The canonical card: a typical cone error with the default label and retry affordance. */
+export const Default: Story = {
+  args: {
+    message: 'The agent turn failed. Check the network tab and try again.',
+  },
+};
+
+/** Rich slotted body with `<b>` emphasis spans inside the message line. */
+export const RichBody: Story = {
+  args: {
+    bodyHtml:
+      'The model returned a <b>400 Bad Request</b> — the prompt likely exceeded the ' +
+      'context window. Retry to re-run the last turn through the send path.',
+  },
+};
+
+/** Long multiline body — confirms the card wraps and the retry button stays right-aligned. */
+export const LongMessage: Story = {
+  args: {
+    label: 'Tool call failed',
+    bodyHtml:
+      'The <b>bash</b> tool call timed out after 30 seconds while running the build. ' +
+      'The shell process was terminated and the partial output was discarded. ' +
+      'This usually means the command is waiting on input that never arrives, or the ' +
+      'build step itself is hung. Retry to re-run the last turn — if it fails again, ' +
+      'inspect the terminal panel for the hanging process and kill it manually before ' +
+      'retrying.',
+  },
+};
+
+/** Explicit dark variant — red re-mixes over the canvas and the header lightens. */
+export const Dark: Story = {
+  args: {
+    theme: 'dark',
+    bodyHtml: 'A failed turn in <b>dark mode</b> — the red tint re-mixes over the canvas.',
+  },
+};
+
+/** Custom header label and button label — host can override both copy slots. */
+export const CustomLabels: Story = {
+  args: {
+    label: 'Network unreachable',
+    'button-label': 'Retry connection',
+    message: 'The LLM provider returned no response. Check your connection and retry.',
+  },
+};
+
+/**
+ * Live event demo: the `slicc-error-retry` CustomEvent is captured and logged
+ * to the panel below the card. Click "Try again" to fire it.
+ */
+export const RetryEvent: Story = {
+  render: () => {
+    const wrap = document.createElement('div');
+    wrap.style.cssText = 'display:flex;flex-direction:column;gap:8px;max-width:560px;';
+
+    const card = build({
+      message: 'Click the button below to dispatch the slicc-error-retry event.',
+    });
+
+    const out = document.createElement('div');
+    out.style.cssText =
+      'font:11px ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--txt-2);padding:6px 8px;border:1px dashed var(--line);border-radius:6px;';
+    out.textContent = 'waiting for retry…';
+
+    let count = 0;
+    card.addEventListener('slicc-error-retry', (e) => {
+      count += 1;
+      out.textContent = `slicc-error-retry × ${count} → ${JSON.stringify((e as CustomEvent).detail)}`;
+    });
+
+    wrap.append(card, out);
+    return wrap;
+  },
+};

--- a/packages/webcomponents/src/chat/slicc-error-card.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.ts
@@ -1,0 +1,244 @@
+import { define } from '../internal/define.js';
+import { h, sheet } from '../internal/dom.js';
+import { iconEl } from '../internal/icons.js';
+
+/**
+ * `<slicc-error-card>` — the **cone error card** rendered in the chat stream
+ * when an agent turn fails. Mirrors the `slicc-lick-card` shape (rounded
+ * card, iconed header, body line) but in the red/destructive palette and with
+ * a trailing "Try again" affordance. It is presentational only: clicking the
+ * button dispatches a bubbling, composed `slicc-error-retry` CustomEvent the
+ * host (the chat controller) catches to re-run the last user turn through its
+ * existing send path. The card itself never talks to the agent.
+ *
+ * Self-contained shadow DOM; themes via inherited tokens (`--red`, `--line`,
+ * `--canvas`, `--ink`, `--ui`, `--txt-2`). Dark mode flips through the
+ * library's `.dark` / `[data-theme="dark"]` / `body.dark` scopes (or the
+ * per-element `theme` attribute), re-mixing the red tint over `--canvas` so
+ * the card reads on a dark ground.
+ *
+ * Set the body via the `message` attribute (escaped plain text) or project
+ * content into the default slot for rich markup.
+ *
+ * @attr label - the header label (default "Something went wrong")
+ * @attr message - error body text (escaped); ignored when slotted content is present
+ * @attr button-label - retry button label (default "Try again")
+ * @attr theme - `light` | `dark`; per-element override of the inherited theme
+ * @csspart card - the outer `.err` card
+ * @csspart header - the `.eh` header row
+ * @csspart icon - the `.ic` span wrapping the lucide `triangle-alert` `<svg>`
+ * @csspart label - the header label span
+ * @csspart body - the `.eb` body line
+ * @csspart button - the retry button
+ * @slot - rich body content (overrides the `message` attribute)
+ * @fires slicc-error-retry - {} dispatched on retry click (bubbles, composed)
+ */
+
+/** Pixel size of the lucide header icon. */
+const HEADER_ICON_SIZE = 14;
+/** Default header label. */
+const DEFAULT_LABEL = 'Something went wrong';
+/** Default retry button label. */
+const DEFAULT_BUTTON_LABEL = 'Try again';
+
+const STYLE = `
+:host{
+  /* Error cards sit in the assistant column (left-aligned). Tokens default to
+     the light palette and flip in dark mode via the library's outer scopes
+     (.dark / [data-theme="dark"] / body.dark) or per-element [theme="dark"]. */
+  display:block;width:100%;
+  font-family:var(--ui,"adobe-clean","Inter",system-ui,sans-serif);
+  --err-bg:color-mix(in srgb,var(--red) 8%,#fff);
+  --err-border:color-mix(in srgb,var(--red) 38%,var(--line));
+  --err-head:var(--red);
+  --err-btn-bg:var(--red);
+  --err-btn-ink:#fff;
+}
+:host-context(.dark),:host-context([data-theme="dark"]),:host([theme="dark"]){
+  --err-bg:color-mix(in srgb,var(--red) 18%,var(--canvas));
+  --err-border:color-mix(in srgb,var(--red) 40%,var(--line));
+  --err-head:color-mix(in srgb,var(--red) 60%,var(--ink));
+}
+:host([theme="light"]){
+  --err-bg:color-mix(in srgb,var(--red) 8%,#fff);
+  --err-border:color-mix(in srgb,var(--red) 38%,var(--line));
+  --err-head:var(--red);
+}
+*{box-sizing:border-box;}
+
+.err{
+  margin:2px 0 16px;
+  max-width:85%;
+  border:1px solid var(--err-border);
+  background:var(--err-bg);
+  border-radius:12px;
+  padding:10px 12px;
+  box-shadow:rgba(10,10,10,.05) 0 4px 14px -6px;
+}
+
+.eh{
+  display:flex;align-items:center;gap:7px;
+  font-family:var(--ui);font-size:10.5px;color:var(--err-head);
+  margin-bottom:4px;
+  font-weight:600;letter-spacing:.02em;text-transform:uppercase;
+}
+.eh .ic{display:inline-flex;flex:0 0 auto;align-items:center;color:var(--err-head);}
+.eh .ic svg{display:block;}
+
+.eb{font-size:12.5px;color:var(--ink);line-height:1.4;}
+.eb ::slotted(b),.eb b{font-weight:600;}
+
+.foot{display:flex;justify-content:flex-end;margin-top:8px;}
+.retry{
+  appearance:none;border:none;cursor:pointer;
+  font-family:var(--ui);font-size:11.5px;font-weight:600;
+  padding:5px 11px;border-radius:8px;
+  background:var(--err-btn-bg);color:var(--err-btn-ink);
+  display:inline-flex;align-items:center;gap:5px;
+  transition:filter .12s ease;
+}
+.retry:hover{filter:brightness(1.08);}
+.retry:focus-visible{outline:2px solid color-mix(in srgb,var(--err-btn-bg) 60%,var(--ink));outline-offset:2px;}
+.retry svg{display:block;}
+`;
+const SHEET = sheet(STYLE);
+
+export class SliccErrorCard extends HTMLElement {
+  static readonly observedAttributes = ['label', 'message', 'button-label', 'theme'];
+
+  readonly #root: ShadowRoot;
+  #onRetryClick: ((e: MouseEvent) => void) | null = null;
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.adoptedStyleSheets = [SHEET];
+  }
+
+  connectedCallback(): void {
+    this.#render();
+  }
+
+  disconnectedCallback(): void {
+    this.#unbindRetry();
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this.#render();
+  }
+
+  /** Header label (default "Something went wrong"). */
+  get label(): string | null {
+    return this.getAttribute('label');
+  }
+
+  set label(value: string | null) {
+    if (value == null) this.removeAttribute('label');
+    else this.setAttribute('label', value);
+  }
+
+  /** Error body text (escaped). Ignored when default-slot content is present. */
+  get message(): string | null {
+    return this.getAttribute('message');
+  }
+
+  set message(value: string | null) {
+    if (value == null) this.removeAttribute('message');
+    else this.setAttribute('message', value);
+  }
+
+  /** Retry button label (default "Try again"). */
+  get buttonLabel(): string | null {
+    return this.getAttribute('button-label');
+  }
+
+  set buttonLabel(value: string | null) {
+    if (value == null) this.removeAttribute('button-label');
+    else this.setAttribute('button-label', value);
+  }
+
+  /** Per-element theme override for the card tokens. */
+  get theme(): 'light' | 'dark' | null {
+    const t = this.getAttribute('theme');
+    return t === 'light' || t === 'dark' ? t : null;
+  }
+
+  set theme(value: 'light' | 'dark' | null) {
+    if (value == null) this.removeAttribute('theme');
+    else this.setAttribute('theme', value);
+  }
+
+  /** Dispatch `slicc-error-retry` — used by the button and exposed for hosts. */
+  retry(): void {
+    this.dispatchEvent(
+      new CustomEvent('slicc-error-retry', {
+        detail: {},
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  #render(): void {
+    const label = this.label ?? DEFAULT_LABEL;
+    const message = this.message;
+    const buttonLabel = this.buttonLabel ?? DEFAULT_BUTTON_LABEL;
+
+    const icon = h('span', { class: 'ic', part: 'icon', 'aria-hidden': true });
+    icon.append(iconEl('triangle-alert', { size: HEADER_ICON_SIZE }));
+
+    const headerRow = h(
+      'div',
+      { class: 'eh', part: 'header' },
+      icon,
+      h('span', { class: 'lbl', part: 'label' }, label)
+    );
+
+    // Body: rich slotted content wins; otherwise the escaped `message`
+    // attribute (a text node escapes by construction — no markup interpolation).
+    const bodyRow = h('div', { class: 'eb', part: 'body' }, message != null ? message : h('slot'));
+
+    const retryBtn = h(
+      'button',
+      {
+        type: 'button',
+        class: 'retry',
+        part: 'button',
+        'aria-label': buttonLabel,
+      },
+      iconEl('rotate-ccw', { size: 12 }),
+      buttonLabel
+    );
+
+    const foot = h('div', { class: 'foot' }, retryBtn);
+
+    const cardEl = h('div', { class: 'err', part: 'card' }, headerRow, bodyRow, foot);
+    this.#root.replaceChildren(cardEl);
+
+    this.#bindRetry();
+  }
+
+  #bindRetry(): void {
+    this.#unbindRetry();
+    const btn = this.#root.querySelector('.retry');
+    if (!btn) return;
+    this.#onRetryClick = () => this.retry();
+    btn.addEventListener('click', this.#onRetryClick as EventListener);
+  }
+
+  #unbindRetry(): void {
+    const btn = this.#root.querySelector('.retry');
+    if (btn && this.#onRetryClick) {
+      btn.removeEventListener('click', this.#onRetryClick as EventListener);
+    }
+    this.#onRetryClick = null;
+  }
+}
+
+define('slicc-error-card', SliccErrorCard);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'slicc-error-card': SliccErrorCard;
+  }
+}

--- a/packages/webcomponents/src/chat/slicc-error-card.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.ts
@@ -23,6 +23,8 @@ import { iconEl } from '../internal/icons.js';
  * @attr label - the header label (default "Something went wrong")
  * @attr message - error body text (escaped); ignored when slotted content is present
  * @attr button-label - retry button label (default "Try again")
+ * @attr message-id - id of the failed chat message this card stands for; echoed
+ *   back on `slicc-error-retry` so the host can bind retry to THIS turn
  * @attr theme - `light` | `dark`; per-element override of the inherited theme
  * @csspart card - the outer `.err` card
  * @csspart header - the `.eh` header row
@@ -31,7 +33,8 @@ import { iconEl } from '../internal/icons.js';
  * @csspart body - the `.eb` body line
  * @csspart button - the retry button
  * @slot - rich body content (overrides the `message` attribute)
- * @fires slicc-error-retry - {} dispatched on retry click (bubbles, composed)
+ * @fires slicc-error-retry - { messageId: string | null } dispatched on retry
+ *   click (bubbles, composed); `messageId` mirrors the `message-id` attribute
  */
 
 /** Pixel size of the lucide header icon. */
@@ -104,7 +107,7 @@ const STYLE = `
 const SHEET = sheet(STYLE);
 
 export class SliccErrorCard extends HTMLElement {
-  static readonly observedAttributes = ['label', 'message', 'button-label', 'theme'];
+  static readonly observedAttributes = ['label', 'message', 'button-label', 'message-id', 'theme'];
 
   readonly #root: ShadowRoot;
   #onRetryClick: ((e: MouseEvent) => void) | null = null;
@@ -157,6 +160,20 @@ export class SliccErrorCard extends HTMLElement {
     else this.setAttribute('button-label', value);
   }
 
+  /**
+   * Id of the failed chat message this card stands for. Echoed back on the
+   * `slicc-error-retry` event so the host can bind retry to the SPECIFIC turn
+   * that produced this card rather than the newest user message in the thread.
+   */
+  get messageId(): string | null {
+    return this.getAttribute('message-id');
+  }
+
+  set messageId(value: string | null) {
+    if (value == null) this.removeAttribute('message-id');
+    else this.setAttribute('message-id', value);
+  }
+
   /** Per-element theme override for the card tokens. */
   get theme(): 'light' | 'dark' | null {
     const t = this.getAttribute('theme');
@@ -172,7 +189,7 @@ export class SliccErrorCard extends HTMLElement {
   retry(): void {
     this.dispatchEvent(
       new CustomEvent('slicc-error-retry', {
-        detail: {},
+        detail: { messageId: this.getAttribute('message-id') ?? null },
         bubbles: true,
         composed: true,
       })

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -8,6 +8,7 @@ export { SliccChatTable } from './chat/slicc-chat-table.js';
 export { SliccChatThread } from './chat/slicc-chat-thread.js';
 export { SliccDelegationLine } from './chat/slicc-delegation-line.js';
 export { SliccDip } from './chat/slicc-dip.js';
+export { SliccErrorCard } from './chat/slicc-error-card.js';
 export { SliccHandoffCard } from './chat/slicc-handoff-card.js';
 export { SliccLickCard } from './chat/slicc-lick-card.js';
 export { SliccToolCluster } from './chat/slicc-tool-cluster.js';

--- a/packages/webcomponents/src/register.ts
+++ b/packages/webcomponents/src/register.ts
@@ -7,6 +7,7 @@ import './chat/slicc-chat-table.js';
 import './chat/slicc-chat-thread.js';
 import './chat/slicc-delegation-line.js';
 import './chat/slicc-dip.js';
+import './chat/slicc-error-card.js';
 import './chat/slicc-handoff-card.js';
 import './chat/slicc-lick-card.js';
 import './chat/slicc-tool-cluster.js';

--- a/packages/webcomponents/tests/chat/slicc-error-card.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-error-card.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SliccErrorCard } from '../../src/chat/slicc-error-card.js';
+import { iconEl } from '../../src/internal/icons.js';
+import { ensureGlobalTokens } from '../../src/theme/tokens.js';
+
+/** Inner shape markup of a lucide icon at the header size, for comparison. */
+function iconShape(name: string, size: number): string {
+  return iconEl(name, { size }).innerHTML;
+}
+
+function mount(attrs: Record<string, string> = {}): SliccErrorCard {
+  const el = document.createElement('slicc-error-card') as SliccErrorCard;
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('slicc-error-card', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    document.body.replaceChildren();
+  });
+
+  afterEach(() => {
+    document.body.classList.remove('dark');
+    document.body.removeAttribute('data-theme');
+  });
+
+  it('registers the custom element', () => {
+    expect(customElements.get('slicc-error-card')).toBe(SliccErrorCard);
+  });
+
+  it('reflects attributes to properties and back', () => {
+    const el = mount();
+    el.label = 'Boom';
+    el.message = 'Something broke';
+    el.buttonLabel = 'Retry now';
+    expect(el.getAttribute('label')).toBe('Boom');
+    expect(el.getAttribute('message')).toBe('Something broke');
+    expect(el.getAttribute('button-label')).toBe('Retry now');
+
+    el.label = null;
+    el.message = null;
+    el.buttonLabel = null;
+    expect(el.hasAttribute('label')).toBe(false);
+    expect(el.hasAttribute('message')).toBe(false);
+    expect(el.hasAttribute('button-label')).toBe(false);
+  });
+
+  it('renders the prototype structure with ::part hooks', () => {
+    const el = mount({ message: 'Connection refused' });
+    const root = el.shadowRoot;
+    expect(root).toBeTruthy();
+    expect(root?.querySelector('[part="card"]')).toBeTruthy();
+    expect(root?.querySelector('[part="header"]')).toBeTruthy();
+    expect(root?.querySelector('[part="icon"]')).toBeTruthy();
+    expect(root?.querySelector('[part="label"]')).toBeTruthy();
+    expect(root?.querySelector('[part="body"]')).toBeTruthy();
+    expect(root?.querySelector('[part="button"]')).toBeTruthy();
+  });
+
+  it('renders defaults for label and button label', () => {
+    const el = mount({ message: 'oops' });
+    expect(el.shadowRoot?.querySelector('[part="label"]')?.textContent).toBe(
+      'Something went wrong'
+    );
+    expect(el.shadowRoot?.querySelector('[part="button"]')?.textContent?.trim()).toBe('Try again');
+  });
+
+  it('honors custom label and button-label attributes', () => {
+    const el = mount({
+      label: 'Cone error',
+      message: 'rate limited',
+      'button-label': 'Try once more',
+    });
+    expect(el.shadowRoot?.querySelector('[part="label"]')?.textContent).toBe('Cone error');
+    expect(el.shadowRoot?.querySelector('[part="button"]')?.textContent?.trim()).toBe(
+      'Try once more'
+    );
+  });
+
+  it('renders a lucide triangle-alert icon in the header (never an emoji)', () => {
+    const el = mount({ message: 'oops' });
+    const icon = el.shadowRoot?.querySelector('[part="icon"]') as HTMLElement;
+    const svg = icon.querySelector('svg');
+    expect(svg).toBeInstanceOf(SVGSVGElement);
+    expect(svg?.innerHTML).toBe(iconShape('triangle-alert', 14));
+    expect(svg?.getAttribute('width')).toBe('14');
+    // No emoji / unicode-symbol text in the rendered card.
+    expect(
+      (el.shadowRoot?.textContent ?? '').match(/[\u{1F000}-\u{1FAFF}]|[\u{26A0}]/u)
+    ).toBeNull();
+  });
+
+  it('renders the retry button with a rotate-ccw glyph', () => {
+    const el = mount({ message: 'oops' });
+    const btn = el.shadowRoot?.querySelector('[part="button"]') as HTMLButtonElement;
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn.getAttribute('type')).toBe('button');
+    const svg = btn.querySelector('svg');
+    expect(svg).toBeInstanceOf(SVGSVGElement);
+    expect(svg?.innerHTML).toBe(iconShape('rotate-ccw', 12));
+  });
+
+  it('renders the escaped message body and falls back to a slot when absent', () => {
+    const withMessage = mount({ message: '<b>boom</b>' });
+    const body = withMessage.shadowRoot?.querySelector('[part="body"]');
+    // text node escapes by construction — no <b> child is interpolated
+    expect(body?.querySelector('b')).toBeNull();
+    expect(body?.textContent).toBe('<b>boom</b>');
+
+    const slotted = mount();
+    expect(slotted.shadowRoot?.querySelector('[part="body"] slot')).not.toBeNull();
+  });
+
+  it('dispatches slicc-error-retry (bubbling, composed) on retry click', () => {
+    const el = mount({ message: 'rate limited' });
+    const seen: Event[] = [];
+    document.body.addEventListener('slicc-error-retry', (e) => seen.push(e));
+    const btn = el.shadowRoot?.querySelector('[part="button"]') as HTMLButtonElement;
+    btn.click();
+    expect(seen).toHaveLength(1);
+    expect(seen[0].bubbles).toBe(true);
+    expect(seen[0].composed).toBe(true);
+    expect(seen[0] instanceof CustomEvent).toBe(true);
+  });
+
+  it('exposes a programmatic retry() that dispatches the same event', () => {
+    const el = mount({ message: 'oops' });
+    const spy = vi.fn();
+    el.addEventListener('slicc-error-retry', spy);
+    el.retry();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-renders on attribute change', () => {
+    const el = mount({ message: 'first' });
+    expect(el.shadowRoot?.querySelector('[part="body"]')?.textContent).toBe('first');
+    el.message = 'second';
+    expect(el.shadowRoot?.querySelector('[part="body"]')?.textContent).toBe('second');
+  });
+
+  it('paints the card with a red-tinted border (light mode)', () => {
+    const el = mount({ message: 'oops' });
+    const card = el.shadowRoot?.querySelector('.err') as HTMLElement;
+    const cs = getComputedStyle(card);
+    // border resolved from color-mix(in srgb, var(--red) 38%, var(--line))
+    expect(cs.borderTopWidth).not.toBe('0px');
+    expect(cs.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+  });
+
+  it('routes the card tint toward the dark canvas in dark mode', () => {
+    const el = mount({ message: 'oops' });
+    const card = el.shadowRoot?.querySelector('.err') as HTMLElement;
+    const light = getComputedStyle(card).backgroundColor;
+    document.body.classList.add('dark');
+    const dark = getComputedStyle(card).backgroundColor;
+    expect(dark).not.toBe(light);
+  });
+
+  it('unbinds the click listener on disconnect', () => {
+    const el = mount({ message: 'oops' });
+    const seen: Event[] = [];
+    document.body.addEventListener('slicc-error-retry', (e) => seen.push(e));
+    const btn = el.shadowRoot?.querySelector('[part="button"]') as HTMLButtonElement;
+    el.remove();
+    btn.click();
+    expect(seen).toHaveLength(0);
+  });
+});

--- a/packages/webcomponents/tests/chat/slicc-error-card.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-error-card.test.ts
@@ -35,16 +35,24 @@ describe('slicc-error-card', () => {
     el.label = 'Boom';
     el.message = 'Something broke';
     el.buttonLabel = 'Retry now';
+    el.messageId = 'msg-42';
     expect(el.getAttribute('label')).toBe('Boom');
     expect(el.getAttribute('message')).toBe('Something broke');
     expect(el.getAttribute('button-label')).toBe('Retry now');
+    expect(el.getAttribute('message-id')).toBe('msg-42');
+    // Attribute → property direction.
+    el.setAttribute('message-id', 'msg-99');
+    expect(el.messageId).toBe('msg-99');
 
     el.label = null;
     el.message = null;
     el.buttonLabel = null;
+    el.messageId = null;
     expect(el.hasAttribute('label')).toBe(false);
     expect(el.hasAttribute('message')).toBe(false);
     expect(el.hasAttribute('button-label')).toBe(false);
+    expect(el.hasAttribute('message-id')).toBe(false);
+    expect(el.messageId).toBeNull();
   });
 
   it('renders the prototype structure with ::part hooks', () => {
@@ -114,23 +122,35 @@ describe('slicc-error-card', () => {
   });
 
   it('dispatches slicc-error-retry (bubbling, composed) on retry click', () => {
-    const el = mount({ message: 'rate limited' });
-    const seen: Event[] = [];
-    document.body.addEventListener('slicc-error-retry', (e) => seen.push(e));
+    const el = mount({ message: 'rate limited', 'message-id': 'err-7' });
+    const seen: CustomEvent[] = [];
+    document.body.addEventListener('slicc-error-retry', (e) => seen.push(e as CustomEvent));
     const btn = el.shadowRoot?.querySelector('[part="button"]') as HTMLButtonElement;
     btn.click();
     expect(seen).toHaveLength(1);
     expect(seen[0].bubbles).toBe(true);
     expect(seen[0].composed).toBe(true);
     expect(seen[0] instanceof CustomEvent).toBe(true);
+    // The card stamps its `message-id` onto the event so the host can bind
+    // retry to the specific failed turn rather than scanning the whole thread.
+    expect(seen[0].detail).toEqual({ messageId: 'err-7' });
   });
 
   it('exposes a programmatic retry() that dispatches the same event', () => {
-    const el = mount({ message: 'oops' });
+    const el = mount({ message: 'oops', 'message-id': 'err-1' });
     const spy = vi.fn();
     el.addEventListener('slicc-error-retry', spy);
     el.retry();
     expect(spy).toHaveBeenCalledTimes(1);
+    expect((spy.mock.calls[0][0] as CustomEvent).detail).toEqual({ messageId: 'err-1' });
+  });
+
+  it('emits a null messageId when no message-id attribute is set', () => {
+    const el = mount({ message: 'oops' });
+    const seen: CustomEvent[] = [];
+    el.addEventListener('slicc-error-retry', (e) => seen.push(e as CustomEvent));
+    el.retry();
+    expect(seen[0].detail).toEqual({ messageId: null });
   });
 
   it('re-renders on attribute change', () => {


### PR DESCRIPTION
## What
Adds a presentational `<slicc-error-card>` webcomponent and wires it into the WC chat controller so cone errors render as a styled, actionable card with a **Retry** button instead of a bare error string.

## Why
After the WebComponent migration, cone errors surfaced as plain text with no recovery affordance. This restores a clear, accessible error surface and a one-click retry.

## Changes
- `@slicc/webcomponents`: new `<slicc-error-card>` (shadow-DOM, mirrors `slicc-lick-card` quality) emitting a `bubbles: true` + `composed: true` `slicc-error-retry` CustomEvent so it crosses shadow boundaries.
- `webapp`: `wc-chat-controller` renders the card for cone errors and re-runs the last user turn through the existing `#agent.sendMessage` path (no new agent API, no duplicate bubble).

## Tests
- lint + typecheck green.
- webapp 6426/6426 pass; webcomponents 1358/1358 pass (14 new). Coverage above floor in both.

## Scope
UI only (webcomponents + webapp wiring); cleanly separable from the masker-guard and secret-delete work.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author