### PR TITLE
feat(secrets): implement secret delete / rm across all runtimes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -277,7 +277,6 @@
     {
       "includes": [
         "packages/chrome-extension/src/extension-leader-tray.ts",
-        "packages/chrome-extension/src/service-worker.ts",
         "packages/cloudflare-worker/src/index.ts",
         "packages/webapp/cloud/app.js",
         "packages/webapp/src/core/context-compaction.ts",
@@ -288,7 +287,6 @@
         "packages/webapp/src/shell/supplemental-commands/ffmpeg-command.ts",
         "packages/webapp/src/shell/supplemental-commands/open-command.ts",
         "packages/webapp/src/shell/supplemental-commands/pdftk-command.ts",
-        "packages/webapp/src/shell/supplemental-commands/secret-command.ts",
         "packages/webapp/src/shell/supplemental-commands/websocat-command.ts",
         "packages/webapp/src/ui/api-key-dialog.ts",
         "packages/webapp/src/ui/chat-fixture.ts",
@@ -308,7 +306,6 @@
       "includes": [
         "packages/cherry/src/cdp-host-handlers.ts",
         "packages/chrome-extension/src/secrets-entry.ts",
-        "packages/chrome-extension/src/service-worker.ts",
         "packages/cloud-core/src/cone-config/index.ts",
         "packages/cloud-core/src/operations/list.ts",
         "packages/cloud-core/src/operations/start.ts",
@@ -364,7 +361,6 @@
         "packages/webapp/src/shell/supplemental-commands/ps-command.ts",
         "packages/webapp/src/shell/supplemental-commands/python-command.ts",
         "packages/webapp/src/shell/supplemental-commands/screencapture-command.ts",
-        "packages/webapp/src/shell/supplemental-commands/secret-command.ts",
         "packages/webapp/src/shell/supplemental-commands/serial-command.ts",
         "packages/webapp/src/shell/supplemental-commands/serve-command.ts",
         "packages/webapp/src/shell/supplemental-commands/sprinkle-command.ts",

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -1315,8 +1315,20 @@ chrome.runtime.onMessage.addListener(
       const name = msg.name;
       (async () => {
         try {
+          // Session secrets win over persisted on name collision (mirrors the
+          // node-server endpoint), so they are also checked first on delete.
+          if (sessionSecretStore.has(name)) {
+            sessionSecretStore.delete(name);
+            sendResponse({ ok: true, removed: true, fromSession: true });
+            return;
+          }
+          const existing = await listSecrets(chrome.storage.local as any);
+          if (!existing.some((e) => e.name === name)) {
+            sendResponse({ ok: true, removed: false });
+            return;
+          }
           await deleteSecret(chrome.storage.local as any, name);
-          sendResponse({ ok: true });
+          sendResponse({ ok: true, removed: true, fromSession: false });
         } catch (err) {
           console.error('[sw] secrets.delete failed', err);
           sendResponse({ ok: false, error: err instanceof Error ? err.message : String(err) });

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -1174,329 +1174,303 @@ chrome.runtime.onConnect.addListener((port) => {
 // Secrets message handlers
 // ---------------------------------------------------------------------------
 
+type SendResponse = (response?: unknown) => void;
+type SecretsHandler = (msg: unknown, sendResponse: SendResponse) => boolean;
+
+function getMsgType(msg: unknown): string | undefined {
+  if (typeof msg !== 'object' || msg === null || !('type' in msg)) return undefined;
+  const t = (msg as { type: unknown }).type;
+  return typeof t === 'string' ? t : undefined;
+}
+
+function getStringField(msg: unknown, field: string): string | undefined {
+  if (typeof msg !== 'object' || msg === null || !(field in msg)) return undefined;
+  const v = (msg as Record<string, unknown>)[field];
+  return typeof v === 'string' ? v : undefined;
+}
+
+function getStringArrayField(msg: unknown, field: string): string[] | undefined {
+  if (typeof msg !== 'object' || msg === null || !(field in msg)) return undefined;
+  const v = (msg as Record<string, unknown>)[field];
+  if (!Array.isArray(v)) return undefined;
+  return v.filter((d): d is string => typeof d === 'string');
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function runSecretsListMaskedEntries(_msg: unknown, sendResponse: SendResponse): boolean {
+  (async () => {
+    try {
+      const pipeline = await buildSecretsPipeline();
+      await pipeline.reload();
+      sendResponse({ entries: pipeline.getMaskedEntries() });
+    } catch (err) {
+      // Without this catch, the unhandled rejection closes the
+      // message port and the caller resolves with `undefined` —
+      // indistinguishable from "no entries", which silently
+      // populates the agent shell with an empty env.
+      console.error('[sw] secrets.list-masked-entries failed', err);
+      sendResponse({ entries: [], error: errMsg(err) });
+    }
+  })();
+  return true;
+}
+// Tool-output real→masked scrub. The offscreen agent realm holds
+// only masked entries (no real values), so the scrub runs here
+// against the SW-owned `SecretsPipeline`. Direction is real→masked
+// ONLY; idempotent for already-masked tokens and secret-free
+// output. Errors degrade to the input text so a transient SW issue
+// never blocks a tool result from reaching the agent loop.
+function runSecretsScrubToolResult(msg: unknown, sendResponse: SendResponse): boolean {
+  const text = getStringField(msg, 'text');
+  if (text === undefined) return false;
+  (async () => {
+    try {
+      const pipeline = await buildSecretsPipeline();
+      await pipeline.reload();
+      sendResponse({ text: pipeline.scrubResponse(text) });
+    } catch (err) {
+      console.error('[sw] secrets.scrub-tool-result failed', err);
+      sendResponse({ text, error: errMsg(err) });
+    }
+  })();
+  return true;
+}
+
+// Offscreen-only: snapshot the secrets needed to seed the outbound-scrub
+// pipeline (defense-in-depth real → masked scrub on the LLM-wire `fetch`
+// leg). The offscreen has no `chrome.storage`, so it RPCs here for the
+// sessionId + merged {persisted, session} entry list. Mirrors
+// `buildSecretsPipeline()` above so the offscreen's pipeline produces the
+// same masked values as the SW fetch-proxy pipeline.
+function runSecretsListWithValuesForPipeline(_msg: unknown, sendResponse: SendResponse): boolean {
+  (async () => {
+    try {
+      const sessionId = await readOrCreateSwSessionId();
+      const persisted = await listSecretsWithValues(chrome.storage.local as any);
+      const persistedNames = new Set(persisted.map((e) => e.name));
+      const session = sessionSecretStore.listAll().filter((s) => !persistedNames.has(s.name));
+      const entries = [...persisted, ...session];
+      sendResponse({ sessionId, entries });
+    } catch (err) {
+      console.error('[sw] secrets.list-with-values-for-pipeline failed', err);
+      sendResponse({ sessionId: undefined, entries: [], error: errMsg(err) });
+    }
+  })();
+  return true;
+}
+
+// The panel-terminal `secret` command can't touch chrome.storage directly:
+// it runs in the offscreen document, which lacks chrome.storage even when
+// the manifest grants it (MV3 quirk). Route the management ops through
+// the SW, which DOES have chrome.storage.
+function runSecretsList(_msg: unknown, sendResponse: SendResponse): boolean {
+  (async () => {
+    try {
+      const entries = await listSecrets(chrome.storage.local as any);
+      sendResponse({ entries });
+    } catch (err) {
+      console.error('[sw] secrets.list failed', err);
+      sendResponse({ entries: [], error: errMsg(err) });
+    }
+  })();
+  return true;
+}
+
+function runSecretsSet(msg: unknown, sendResponse: SendResponse): boolean {
+  const name = getStringField(msg, 'name');
+  const value = getStringField(msg, 'value');
+  const domains = getStringArrayField(msg, 'domains');
+  if (name === undefined || value === undefined || domains === undefined) return false;
+  (async () => {
+    try {
+      await setSecret(chrome.storage.local as any, name, value, domains);
+      sendResponse({ ok: true });
+    } catch (err) {
+      console.error('[sw] secrets.set failed', err);
+      sendResponse({ ok: false, error: errMsg(err) });
+    }
+  })();
+  return true;
+}
+
+function runSecretsDelete(msg: unknown, sendResponse: SendResponse): boolean {
+  const name = getStringField(msg, 'name');
+  if (name === undefined) return false;
+  (async () => {
+    try {
+      // Session secrets win over persisted on name collision (mirrors the
+      // node-server endpoint), so they are also checked first on delete.
+      if (sessionSecretStore.has(name)) {
+        sessionSecretStore.delete(name);
+        sendResponse({ ok: true, removed: true, fromSession: true });
+        return;
+      }
+      const existing = await listSecrets(chrome.storage.local as any);
+      if (!existing.some((e) => e.name === name)) {
+        sendResponse({ ok: true, removed: false });
+        return;
+      }
+      await deleteSecret(chrome.storage.local as any, name);
+      sendResponse({ ok: true, removed: true, fromSession: false });
+    } catch (err) {
+      console.error('[sw] secrets.delete failed', err);
+      sendResponse({ ok: false, error: errMsg(err) });
+    }
+  })();
+  return true;
+}
+
+// Session-secret set — in-memory only, never written to chrome.storage.
+function runSecretsSessionSet(msg: unknown, sendResponse: SendResponse): boolean {
+  const name = getStringField(msg, 'name');
+  const value = getStringField(msg, 'value');
+  const domains = getStringArrayField(msg, 'domains');
+  if (name === undefined || value === undefined || domains === undefined) return false;
+  sessionSecretStore.set(name, value, domains);
+  sendResponse({ ok: true });
+  return true;
+}
+
+function runSecretsSessionList(_msg: unknown, sendResponse: SendResponse): boolean {
+  sendResponse({ entries: sessionSecretStore.list() });
+  return true;
+}
+
+// Peek — returns an elided preview of the unmasked value (session or
+// persisted). The full value never leaves the SW.
+function runSecretsPeek(msg: unknown, sendResponse: SendResponse): boolean {
+  const name = getStringField(msg, 'name');
+  if (name === undefined) return false;
+  (async () => {
+    try {
+      const sessionRec = sessionSecretStore.getRecord(name);
+      if (sessionRec) {
+        sendResponse({
+          record: {
+            name,
+            preview: previewSecret(sessionRec.value),
+            domains: sessionRec.domains,
+          },
+        });
+        return;
+      }
+      const all = await listSecretsWithValues(chrome.storage.local as any);
+      const found = all.find((e) => e.name === name);
+      sendResponse({
+        record: found
+          ? { name, preview: previewSecret(found.value), domains: found.domains }
+          : undefined,
+      });
+    } catch (err) {
+      console.error('[sw] secrets.peek failed', err);
+      sendResponse({ record: undefined, error: errMsg(err) });
+    }
+  })();
+  return true;
+}
+
+// Scope edit — update the allowed domains of an existing secret (session or
+// persisted), preserving the value.
+function runSecretsSetDomains(msg: unknown, sendResponse: SendResponse): boolean {
+  const name = getStringField(msg, 'name');
+  const domains = getStringArrayField(msg, 'domains');
+  if (name === undefined || domains === undefined) return false;
+  (async () => {
+    try {
+      if (sessionSecretStore.has(name)) {
+        sessionSecretStore.setDomains(name, domains);
+        sendResponse({ ok: true });
+        return;
+      }
+      const all = await listSecretsWithValues(chrome.storage.local as any);
+      const found = all.find((e) => e.name === name);
+      if (!found) {
+        sendResponse({ ok: false, error: `no secret named "${name}"` });
+        return;
+      }
+      await setSecret(chrome.storage.local as any, name, found.value, domains);
+      sendResponse({ ok: true });
+    } catch (err) {
+      console.error('[sw] secrets.set-domains failed', err);
+      sendResponse({ ok: false, error: errMsg(err) });
+    }
+  })();
+  return true;
+}
+
+async function runMaskOauthTokenWrite(
+  providerId: string,
+  accessToken: string | undefined,
+  domains: string | undefined
+): Promise<string | undefined> {
+  // #847: the caller may be the offscreen document, which has
+  // `chrome.runtime` but NOT `chrome.storage` (MV3 quirk — same reason
+  // `secrets.set` proxies through the SW). Write the secret here, where
+  // the SW owns `chrome.storage`, before building the pipeline that
+  // masks it. `domains` is the comma-joined `_DOMAINS` companion.
+  if (accessToken && domains) {
+    await chrome.storage.local.set({
+      [`oauth.${providerId}.token`]: accessToken,
+      [`oauth.${providerId}.token_DOMAINS`]: domains,
+    });
+  }
+  const pipeline = await buildSecretsPipeline();
+  await pipeline.reload();
+  const name = `oauth.${providerId}.token`;
+  return pipeline.getMaskedEntries().find((e) => e.name === name)?.maskedValue;
+}
+
+function runSecretsMaskOauthToken(msg: unknown, sendResponse: SendResponse): boolean {
+  const providerId = getStringField(msg, 'providerId');
+  if (providerId === undefined) return false;
+  const accessToken = getStringField(msg, 'accessToken');
+  const domains = getStringField(msg, 'domains');
+  (async () => {
+    try {
+      const maskedValue = await runMaskOauthTokenWrite(providerId, accessToken, domains);
+      // We just wrote the secret above, so a missing entry here is NOT a
+      // cold-start miss — it's a real fault (write didn't land, or the
+      // pipeline stopped emitting it). Surface it so the page side can
+      // distinguish "not warm yet" from "wrote it and still missing".
+      if (accessToken && domains && maskedValue === undefined) {
+        const name = `oauth.${providerId}.token`;
+        // Real fault (not a cold miss): surface a reason so the page can
+        // distinguish it and the give-up log isn't reason-less (#847).
+        console.warn('[sw] secrets.mask-oauth-token: entry missing after write', { name });
+        sendResponse({ maskedValue: undefined, error: 'entry missing after write' });
+        return;
+      }
+      sendResponse({ maskedValue });
+    } catch (err) {
+      console.error('[sw] secrets.mask-oauth-token failed', err);
+      sendResponse({ maskedValue: undefined, error: errMsg(err) });
+    }
+  })();
+  return true;
+}
+
+const SECRETS_HANDLERS: Record<string, SecretsHandler> = {
+  'secrets.list-masked-entries': runSecretsListMaskedEntries,
+  'secrets.scrub-tool-result': runSecretsScrubToolResult,
+  'secrets.list-with-values-for-pipeline': runSecretsListWithValuesForPipeline,
+  'secrets.list': runSecretsList,
+  'secrets.set': runSecretsSet,
+  'secrets.delete': runSecretsDelete,
+  'secrets.session.set': runSecretsSessionSet,
+  'secrets.session.list': runSecretsSessionList,
+  'secrets.peek': runSecretsPeek,
+  'secrets.set-domains': runSecretsSetDomains,
+  'secrets.mask-oauth-token': runSecretsMaskOauthToken,
+};
+
 chrome.runtime.onMessage.addListener(
   (msg: unknown, _sender: ChromeMessageSender, sendResponse: (response?: unknown) => void) => {
-    if (
-      typeof msg === 'object' &&
-      msg != null &&
-      'type' in msg &&
-      msg.type === 'secrets.list-masked-entries'
-    ) {
-      (async () => {
-        try {
-          const pipeline = await buildSecretsPipeline();
-          await pipeline.reload();
-          sendResponse({ entries: pipeline.getMaskedEntries() });
-        } catch (err) {
-          // Without this catch, the unhandled rejection closes the
-          // message port and the caller resolves with `undefined` —
-          // indistinguishable from "no entries", which silently
-          // populates the agent shell with an empty env.
-          console.error('[sw] secrets.list-masked-entries failed', err);
-          sendResponse({
-            entries: [],
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      })();
-      return true;
-    }
-    // Tool-output real→masked scrub. The offscreen agent realm holds
-    // only masked entries (no real values), so the scrub runs here
-    // against the SW-owned `SecretsPipeline`. Direction is real→masked
-    // ONLY; idempotent for already-masked tokens and secret-free
-    // output. Errors degrade to the input text so a transient SW issue
-    // never blocks a tool result from reaching the agent loop.
-    if (
-      typeof msg === 'object' &&
-      msg != null &&
-      'type' in msg &&
-      msg.type === 'secrets.scrub-tool-result' &&
-      'text' in msg &&
-      typeof msg.text === 'string'
-    ) {
-      const text = msg.text;
-      (async () => {
-        try {
-          const pipeline = await buildSecretsPipeline();
-          await pipeline.reload();
-          sendResponse({ text: pipeline.scrubResponse(text) });
-        } catch (err) {
-          console.error('[sw] secrets.scrub-tool-result failed', err);
-          sendResponse({ text, error: err instanceof Error ? err.message : String(err) });
-        }
-      })();
-      return true;
-    }
-    // Offscreen-only: snapshot the secrets needed to seed the outbound-scrub
-    // pipeline (defense-in-depth real → masked scrub on the LLM-wire `fetch`
-    // leg). The offscreen has no `chrome.storage`, so it RPCs here for the
-    // sessionId + merged {persisted, session} entry list. Mirrors
-    // `buildSecretsPipeline()` above so the offscreen's pipeline produces the
-    // same masked values as the SW fetch-proxy pipeline.
-    if (
-      typeof msg === 'object' &&
-      msg != null &&
-      'type' in msg &&
-      msg.type === 'secrets.list-with-values-for-pipeline'
-    ) {
-      (async () => {
-        try {
-          const sessionId = await readOrCreateSwSessionId();
-          const persisted = await listSecretsWithValues(chrome.storage.local as any);
-          const persistedNames = new Set(persisted.map((e) => e.name));
-          const session = sessionSecretStore.listAll().filter((s) => !persistedNames.has(s.name));
-          const entries = [...persisted, ...session];
-          sendResponse({ sessionId, entries });
-        } catch (err) {
-          console.error('[sw] secrets.list-with-values-for-pipeline failed', err);
-          sendResponse({
-            sessionId: undefined,
-            entries: [],
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      })();
-      return true;
-    }
-    // The panel-terminal `secret` command can't touch chrome.storage directly:
-    // it runs in the offscreen document, which lacks chrome.storage even when
-    // the manifest grants it (MV3 quirk). Route the management ops through
-    // the SW, which DOES have chrome.storage.
-    if (typeof msg === 'object' && msg != null && 'type' in msg && msg.type === 'secrets.list') {
-      (async () => {
-        try {
-          const entries = await listSecrets(chrome.storage.local as any);
-          sendResponse({ entries });
-        } catch (err) {
-          console.error('[sw] secrets.list failed', err);
-          sendResponse({
-            entries: [],
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      })();
-      return true;
-    }
-    if (
-      typeof msg === 'object' &&
-      msg != null &&
-      'type' in msg &&
-      msg.type === 'secrets.set' &&
-      'name' in msg &&
-      typeof msg.name === 'string' &&
-      'value' in msg &&
-      typeof msg.value === 'string' &&
-      'domains' in msg &&
-      Array.isArray(msg.domains)
-    ) {
-      const name = msg.name;
-      const value = msg.value;
-      const domains = (msg.domains as unknown[]).filter((d): d is string => typeof d === 'string');
-      (async () => {
-        try {
-          await setSecret(chrome.storage.local as any, name, value, domains);
-          sendResponse({ ok: true });
-        } catch (err) {
-          console.error('[sw] secrets.set failed', err);
-          sendResponse({ ok: false, error: err instanceof Error ? err.message : String(err) });
-        }
-      })();
-      return true;
-    }
-    if (
-      typeof msg === 'object' &&
-      msg != null &&
-      'type' in msg &&
-      msg.type === 'secrets.delete' &&
-      'name' in msg &&
-      typeof msg.name === 'string'
-    ) {
-      const name = msg.name;
-      (async () => {
-        try {
-          // Session secrets win over persisted on name collision (mirrors the
-          // node-server endpoint), so they are also checked first on delete.
-          if (sessionSecretStore.has(name)) {
-            sessionSecretStore.delete(name);
-            sendResponse({ ok: true, removed: true, fromSession: true });
-            return;
-          }
-          const existing = await listSecrets(chrome.storage.local as any);
-          if (!existing.some((e) => e.name === name)) {
-            sendResponse({ ok: true, removed: false });
-            return;
-          }
-          await deleteSecret(chrome.storage.local as any, name);
-          sendResponse({ ok: true, removed: true, fromSession: false });
-        } catch (err) {
-          console.error('[sw] secrets.delete failed', err);
-          sendResponse({ ok: false, error: err instanceof Error ? err.message : String(err) });
-        }
-      })();
-      return true;
-    }
-    // Session-secret set — in-memory only, never written to chrome.storage.
-    if (
-      typeof msg === 'object' &&
-      msg != null &&
-      'type' in msg &&
-      msg.type === 'secrets.session.set' &&
-      'name' in msg &&
-      typeof msg.name === 'string' &&
-      'value' in msg &&
-      typeof msg.value === 'string' &&
-      'domains' in msg &&
-      Array.isArray(msg.domains)
-    ) {
-      const name = msg.name;
-      const value = msg.value;
-      const domains = (msg.domains as unknown[]).filter((d): d is string => typeof d === 'string');
-      sessionSecretStore.set(name, value, domains);
-      sendResponse({ ok: true });
-      return true;
-    }
-    if (
-      typeof msg === 'object' &&
-      msg != null &&
-      'type' in msg &&
-      msg.type === 'secrets.session.list'
-    ) {
-      sendResponse({ entries: sessionSecretStore.list() });
-      return true;
-    }
-    // Peek — returns an elided preview of the unmasked value (session or
-    // persisted). The full value never leaves the SW.
-    if (
-      typeof msg === 'object' &&
-      msg != null &&
-      'type' in msg &&
-      msg.type === 'secrets.peek' &&
-      'name' in msg &&
-      typeof msg.name === 'string'
-    ) {
-      const name = msg.name;
-      (async () => {
-        try {
-          const sessionRec = sessionSecretStore.getRecord(name);
-          if (sessionRec) {
-            sendResponse({
-              record: {
-                name,
-                preview: previewSecret(sessionRec.value),
-                domains: sessionRec.domains,
-              },
-            });
-            return;
-          }
-          const all = await listSecretsWithValues(chrome.storage.local as any);
-          const found = all.find((e) => e.name === name);
-          sendResponse({
-            record: found
-              ? { name, preview: previewSecret(found.value), domains: found.domains }
-              : undefined,
-          });
-        } catch (err) {
-          console.error('[sw] secrets.peek failed', err);
-          sendResponse({
-            record: undefined,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      })();
-      return true;
-    }
-    // Scope edit — update the allowed domains of an existing secret (session or
-    // persisted), preserving the value.
-    if (
-      typeof msg === 'object' &&
-      msg != null &&
-      'type' in msg &&
-      msg.type === 'secrets.set-domains' &&
-      'name' in msg &&
-      typeof msg.name === 'string' &&
-      'domains' in msg &&
-      Array.isArray(msg.domains)
-    ) {
-      const name = msg.name;
-      const domains = (msg.domains as unknown[]).filter((d): d is string => typeof d === 'string');
-      (async () => {
-        try {
-          if (sessionSecretStore.has(name)) {
-            sessionSecretStore.setDomains(name, domains);
-            sendResponse({ ok: true });
-            return;
-          }
-          const all = await listSecretsWithValues(chrome.storage.local as any);
-          const found = all.find((e) => e.name === name);
-          if (!found) {
-            sendResponse({ ok: false, error: `no secret named "${name}"` });
-            return;
-          }
-          await setSecret(chrome.storage.local as any, name, found.value, domains);
-          sendResponse({ ok: true });
-        } catch (err) {
-          console.error('[sw] secrets.set-domains failed', err);
-          sendResponse({ ok: false, error: err instanceof Error ? err.message : String(err) });
-        }
-      })();
-      return true;
-    }
-    if (
-      typeof msg === 'object' &&
-      msg != null &&
-      'type' in msg &&
-      msg.type === 'secrets.mask-oauth-token' &&
-      'providerId' in msg &&
-      typeof msg.providerId === 'string'
-    ) {
-      const providerId = msg.providerId;
-      const accessToken =
-        'accessToken' in msg && typeof (msg as { accessToken?: unknown }).accessToken === 'string'
-          ? (msg as { accessToken: string }).accessToken
-          : undefined;
-      const domains =
-        'domains' in msg && typeof (msg as { domains?: unknown }).domains === 'string'
-          ? (msg as { domains: string }).domains
-          : undefined;
-      (async () => {
-        try {
-          // #847: the caller may be the offscreen document, which has
-          // `chrome.runtime` but NOT `chrome.storage` (MV3 quirk — same reason
-          // `secrets.set` proxies through the SW). Write the secret here, where
-          // the SW owns `chrome.storage`, before building the pipeline that
-          // masks it. `domains` is the comma-joined `_DOMAINS` companion.
-          if (accessToken && domains) {
-            await chrome.storage.local.set({
-              [`oauth.${providerId}.token`]: accessToken,
-              [`oauth.${providerId}.token_DOMAINS`]: domains,
-            });
-          }
-          const pipeline = await buildSecretsPipeline();
-          await pipeline.reload();
-          const name = `oauth.${providerId}.token`;
-          const found = pipeline.getMaskedEntries().find((e) => e.name === name);
-          // We just wrote the secret above, so a missing entry here is NOT a
-          // cold-start miss — it's a real fault (write didn't land, or the
-          // pipeline stopped emitting it). Surface it so the page side can
-          // distinguish "not warm yet" from "wrote it and still missing".
-          if (accessToken && domains && !found) {
-            // Real fault (not a cold miss): surface a reason so the page can
-            // distinguish it and the give-up log isn't reason-less (#847).
-            console.warn('[sw] secrets.mask-oauth-token: entry missing after write', { name });
-            sendResponse({ maskedValue: undefined, error: 'entry missing after write' });
-            return;
-          }
-          sendResponse({ maskedValue: found?.maskedValue });
-        } catch (err) {
-          console.error('[sw] secrets.mask-oauth-token failed', err);
-          sendResponse({
-            maskedValue: undefined,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      })();
-      return true;
-    }
+    const type = getMsgType(msg);
+    if (type === undefined) return false;
+    const handler = SECRETS_HANDLERS[type];
+    return handler ? handler(msg, sendResponse) : false;
   }
 );

--- a/packages/chrome-extension/tests/service-worker-secrets-coverage.test.ts
+++ b/packages/chrome-extension/tests/service-worker-secrets-coverage.test.ts
@@ -1,0 +1,449 @@
+// Branch-coverage tests targeting the refactored type-narrowing helpers
+// (`getMsgType` / `getStringField` / `getStringArrayField`), the
+// dispatcher fallthroughs (no `type`, `type` non-string, unknown
+// `type`), per-handler missing-field early returns, and the error
+// catch paths in the SECRETS_HANDLERS registry — the new branches
+// introduced by the boy-scout refactor in PR #1012 that the
+// pre-existing service-worker-secrets suite did not exercise.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MsgListener = (msg: any, sender: any, sendResponse: (r: any) => void) => boolean | void;
+
+describe('service-worker secrets handlers — branch coverage', () => {
+  let messageListeners: MsgListener[];
+  let storageMap: Record<string, string>;
+
+  function buildChromeMock(overrides?: { localGet?: any; localSet?: any; localRemove?: any }) {
+    const localGet =
+      overrides?.localGet ??
+      vi.fn(async (key?: string | string[] | null) => {
+        if (key == null) return { ...storageMap };
+        if (typeof key === 'string') return key in storageMap ? { [key]: storageMap[key] } : {};
+        const out: Record<string, string> = {};
+        for (const k of key as string[]) if (k in storageMap) out[k] = storageMap[k];
+        return out;
+      });
+    const localSet =
+      overrides?.localSet ??
+      vi.fn(async (obj: Record<string, string>) => Object.assign(storageMap, obj));
+    const localRemove =
+      overrides?.localRemove ??
+      vi.fn(async (keys: string | string[]) => {
+        const arr = Array.isArray(keys) ? keys : [keys];
+        for (const k of arr) delete storageMap[k];
+      });
+    (globalThis as any).chrome = {
+      runtime: {
+        onConnect: { addListener: vi.fn() },
+        onMessage: { addListener: (fn: MsgListener) => messageListeners.push(fn) },
+        onInstalled: { addListener: vi.fn() },
+        onStartup: { addListener: vi.fn() },
+        getContexts: vi.fn(async () => []),
+        id: 'test-id',
+      },
+      storage: {
+        local: { get: localGet, set: localSet, remove: localRemove },
+        session: {
+          get: vi.fn(async () => ({})),
+          set: vi.fn(async () => undefined),
+          remove: vi.fn(async () => undefined),
+        },
+      },
+      sidePanel: { setPanelBehavior: vi.fn(), setOptions: vi.fn() },
+      offscreen: { hasDocument: vi.fn(async () => true) },
+      action: {
+        setBadgeText: vi.fn(),
+        setBadgeBackgroundColor: vi.fn(),
+        onClicked: { addListener: vi.fn() },
+      },
+      tabs: {
+        query: vi.fn(async () => []),
+        create: vi.fn(),
+        remove: vi.fn(),
+        group: vi.fn(),
+        onCreated: { addListener: vi.fn() },
+        onUpdated: { addListener: vi.fn() },
+        onRemoved: { addListener: vi.fn() },
+      },
+      tabGroups: { update: vi.fn() },
+      debugger: {
+        attach: vi.fn(),
+        detach: vi.fn(),
+        sendCommand: vi.fn(),
+        onEvent: { addListener: vi.fn() },
+        onDetach: { addListener: vi.fn() },
+      },
+      identity: { launchWebAuthFlow: vi.fn(), getRedirectURL: vi.fn() },
+      notifications: { create: vi.fn(), onClicked: { addListener: vi.fn() } },
+      webRequest: { onHeadersReceived: { addListener: vi.fn() } },
+    };
+  }
+
+  beforeEach(() => {
+    messageListeners = [];
+    storageMap = {
+      '_session.id': 'test-session-uuid',
+      GITHUB_TOKEN: 'ghp_real',
+      GITHUB_TOKEN_DOMAINS: 'api.github.com',
+    };
+    buildChromeMock();
+    (globalThis as any).WebSocket = class MockWebSocket {
+      addEventListener() {}
+      send() {}
+      close() {}
+    };
+    vi.resetModules();
+    // Silence the expected console.error noise from the negative paths so
+    // the suite output stays clean. Each test still asserts response shape.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  /**
+   * Drives the SW's `onMessage` listener exactly like the production
+   * runtime: each registered listener is invoked in order until one
+   * returns `true` (kept-port for async response) or all return falsy
+   * (no handler claimed the message). Returns the listener's boolean
+   * return and the response (if `sendResponse` was called).
+   */
+  async function dispatch(msg: any): Promise<{ kept: boolean; response: any }> {
+    await import('../src/service-worker.js');
+    let response: any;
+    let kept = false;
+    for (const l of messageListeners) {
+      let captured = false;
+      const result = l(msg, {}, (r: any) => {
+        captured = true;
+        response = r;
+      });
+      if (result === true) {
+        kept = true;
+        break;
+      }
+      if (captured) break;
+    }
+    await new Promise((r) => setTimeout(r, 30));
+    return { kept, response };
+  }
+
+  // --- getMsgType branches ----------------------------------------------
+
+  it('listener returns false when msg is undefined (getMsgType: not an object)', async () => {
+    const { kept, response } = await dispatch(undefined);
+    expect(kept).toBe(false);
+    expect(response).toBeUndefined();
+  });
+
+  it('listener returns false when msg is null (getMsgType: msg === null branch)', async () => {
+    const { kept, response } = await dispatch(null);
+    expect(kept).toBe(false);
+    expect(response).toBeUndefined();
+  });
+
+  it('listener returns false when msg has no "type" field (getMsgType: !("type" in msg))', async () => {
+    const { kept, response } = await dispatch({ name: 'X' });
+    expect(kept).toBe(false);
+    expect(response).toBeUndefined();
+  });
+
+  it('listener returns false when msg.type is not a string (getMsgType: typeof t !== "string")', async () => {
+    const { kept, response } = await dispatch({ type: 42 });
+    expect(kept).toBe(false);
+    expect(response).toBeUndefined();
+  });
+
+  it('listener returns false for an unknown message type (dispatcher: no handler)', async () => {
+    const { kept, response } = await dispatch({ type: 'secrets.nope.unknown' });
+    expect(kept).toBe(false);
+    expect(response).toBeUndefined();
+  });
+
+  // --- per-handler missing-field early returns --------------------------
+
+  it('secrets.scrub-tool-result returns false when text field is missing (getStringField undefined)', async () => {
+    const { kept } = await dispatch({ type: 'secrets.scrub-tool-result' });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.scrub-tool-result returns false when text is the wrong type (number, not string)', async () => {
+    const { kept } = await dispatch({ type: 'secrets.scrub-tool-result', text: 123 });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.scrub-tool-result success path runs the pipeline against the text', async () => {
+    const { kept, response } = await dispatch({
+      type: 'secrets.scrub-tool-result',
+      text: 'hello no secrets here',
+    });
+    expect(kept).toBe(true);
+    expect(typeof response.text).toBe('string');
+  });
+
+  it('secrets.set returns false when name is missing', async () => {
+    const { kept } = await dispatch({
+      type: 'secrets.set',
+      value: 'v',
+      domains: ['x'],
+    });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.set returns false when value is missing', async () => {
+    const { kept } = await dispatch({
+      type: 'secrets.set',
+      name: 'N',
+      domains: ['x'],
+    });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.set returns false when domains is missing entirely (not an array on the wire)', async () => {
+    const { kept } = await dispatch({ type: 'secrets.set', name: 'N', value: 'v' });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.set returns false when domains is the wrong type (getStringArrayField: !Array.isArray)', async () => {
+    const { kept } = await dispatch({
+      type: 'secrets.set',
+      name: 'N',
+      value: 'v',
+      domains: 'not-an-array',
+    });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.set filters non-string entries from a heterogeneous domains array', async () => {
+    // getStringArrayField uses `.filter((d): d is string => typeof d === 'string')`
+    // — the branch that drops non-string elements. The handler must still
+    // accept the call (kept=true) and the persisted _DOMAINS must contain
+    // only the string entries.
+    const { kept, response } = await dispatch({
+      type: 'secrets.set',
+      name: 'MIXED_KEY',
+      value: 'v',
+      domains: ['api.ok.com', 42, null, 'api.also.com'],
+    });
+    expect(kept).toBe(true);
+    expect(response).toEqual({ ok: true });
+    expect(storageMap.MIXED_KEY_DOMAINS).toBe('api.ok.com,api.also.com');
+  });
+
+  it('secrets.delete returns false when name is missing', async () => {
+    const { kept } = await dispatch({ type: 'secrets.delete' });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.session.set returns false when any required field is missing', async () => {
+    const { kept } = await dispatch({
+      type: 'secrets.session.set',
+      name: 'N',
+      // value + domains missing
+    });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.peek returns false when name is missing', async () => {
+    const { kept } = await dispatch({ type: 'secrets.peek' });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.peek returns { record: undefined } for an unknown name (neither session nor persisted)', async () => {
+    const { kept, response } = await dispatch({
+      type: 'secrets.peek',
+      name: 'NO_SUCH_SECRET',
+    });
+    expect(kept).toBe(true);
+    expect(response).toEqual({ record: undefined });
+  });
+
+  it('secrets.set-domains returns false when name is missing', async () => {
+    const { kept } = await dispatch({
+      type: 'secrets.set-domains',
+      domains: ['x'],
+    });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.set-domains returns false when domains is missing', async () => {
+    const { kept } = await dispatch({
+      type: 'secrets.set-domains',
+      name: 'GITHUB_TOKEN',
+    });
+    expect(kept).toBe(false);
+  });
+
+  it('secrets.set-domains takes the session-shadow branch when a session entry exists', async () => {
+    await dispatch({
+      type: 'secrets.session.set',
+      name: 'SESS_SCOPE',
+      value: 'v',
+      domains: ['api.old.com'],
+    });
+    const { kept, response } = await dispatch({
+      type: 'secrets.set-domains',
+      name: 'SESS_SCOPE',
+      domains: ['api.new.com', '*.new.com'],
+    });
+    expect(kept).toBe(true);
+    expect(response).toEqual({ ok: true });
+    // Session-secret scope edit must NOT touch chrome.storage.
+    expect(storageMap.SESS_SCOPE).toBeUndefined();
+    expect(storageMap.SESS_SCOPE_DOMAINS).toBeUndefined();
+    const list = await dispatch({ type: 'secrets.session.list' });
+    expect(list.response.entries).toEqual([
+      { name: 'SESS_SCOPE', domains: ['api.new.com', '*.new.com'] },
+    ]);
+  });
+
+  it('secrets.set-domains reports { ok: false, error } when no such secret exists (line 1390 branch)', async () => {
+    const { kept, response } = await dispatch({
+      type: 'secrets.set-domains',
+      name: 'NEVER_EXISTED',
+      domains: ['x.com'],
+    });
+    expect(kept).toBe(true);
+    expect(response.ok).toBe(false);
+    expect(response.error).toBe('no secret named "NEVER_EXISTED"');
+  });
+
+  it('secrets.mask-oauth-token returns false when providerId is missing', async () => {
+    const { kept } = await dispatch({ type: 'secrets.mask-oauth-token' });
+    expect(kept).toBe(false);
+  });
+
+  // --- error catch paths (storage throws) -------------------------------
+
+  it('secrets.list surfaces { error } when chrome.storage.local.get rejects (catch branch)', async () => {
+    buildChromeMock({
+      localGet: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    });
+    const { kept, response } = await dispatch({ type: 'secrets.list' });
+    expect(kept).toBe(true);
+    expect(response.entries).toEqual([]);
+    expect(response.error).toBe('boom');
+  });
+
+  it('secrets.set surfaces { ok: false, error } when chrome.storage.local.set rejects', async () => {
+    buildChromeMock({
+      localSet: vi.fn(async () => {
+        throw new Error('quota');
+      }),
+    });
+    const { kept, response } = await dispatch({
+      type: 'secrets.set',
+      name: 'X',
+      value: 'v',
+      domains: ['api.x.com'],
+    });
+    expect(kept).toBe(true);
+    expect(response.ok).toBe(false);
+    expect(response.error).toBe('quota');
+  });
+
+  it('secrets.delete surfaces { ok: false, error } when chrome.storage.local rejects', async () => {
+    buildChromeMock({
+      localRemove: vi.fn(async () => {
+        throw new Error('disk-full');
+      }),
+    });
+    const { kept, response } = await dispatch({
+      type: 'secrets.delete',
+      name: 'GITHUB_TOKEN',
+    });
+    expect(kept).toBe(true);
+    expect(response.ok).toBe(false);
+    expect(response.error).toBe('disk-full');
+  });
+
+  it('secrets.peek surfaces { error } when chrome.storage.local.get rejects', async () => {
+    buildChromeMock({
+      localGet: vi.fn(async () => {
+        throw new Error('peek-fail');
+      }),
+    });
+    const { kept, response } = await dispatch({ type: 'secrets.peek', name: 'GITHUB_TOKEN' });
+    expect(kept).toBe(true);
+    expect(response.record).toBeUndefined();
+    expect(response.error).toBe('peek-fail');
+  });
+
+  it('secrets.set-domains surfaces { ok: false, error } when chrome.storage.local.get rejects', async () => {
+    buildChromeMock({
+      localGet: vi.fn(async () => {
+        throw new Error('lookup-fail');
+      }),
+    });
+    const { kept, response } = await dispatch({
+      type: 'secrets.set-domains',
+      name: 'GITHUB_TOKEN',
+      domains: ['api.x.com'],
+    });
+    expect(kept).toBe(true);
+    expect(response.ok).toBe(false);
+    expect(response.error).toBe('lookup-fail');
+  });
+
+  it('secrets.scrub-tool-result degrades to { text, error } when the pipeline build throws (catch branch)', async () => {
+    // Force the pipeline to fail on this call by making the SW-session-id
+    // read reject. The handler MUST return the input text plus the error
+    // — agents must never lose tool output to a transient SW issue.
+    buildChromeMock({
+      localGet: vi.fn(async () => {
+        throw new Error('pipeline-fail');
+      }),
+    });
+    const { kept, response } = await dispatch({
+      type: 'secrets.scrub-tool-result',
+      text: 'some tool output',
+    });
+    expect(kept).toBe(true);
+    expect(response.text).toBe('some tool output');
+    expect(typeof response.error).toBe('string');
+  });
+
+  it('secrets.list-with-values-for-pipeline surfaces { entries: [], error } on a chrome.storage failure', async () => {
+    buildChromeMock({
+      localGet: vi.fn(async () => {
+        throw new Error('pipeline-list-fail');
+      }),
+    });
+    const { kept, response } = await dispatch({
+      type: 'secrets.list-with-values-for-pipeline',
+    });
+    expect(kept).toBe(true);
+    expect(response.entries).toEqual([]);
+    expect(typeof response.error).toBe('string');
+  });
+
+  it('secrets.list-masked-entries surfaces { entries: [], error } on a chrome.storage failure', async () => {
+    buildChromeMock({
+      localGet: vi.fn(async () => {
+        throw new Error('masked-fail');
+      }),
+    });
+    const { kept, response } = await dispatch({
+      type: 'secrets.list-masked-entries',
+    });
+    expect(kept).toBe(true);
+    expect(response.entries).toEqual([]);
+    expect(typeof response.error).toBe('string');
+  });
+
+  // --- errMsg(err) non-Error branch --------------------------------------
+
+  it('non-Error rejections are stringified by errMsg in the response error', async () => {
+    buildChromeMock({
+      localGet: vi.fn(async () => {
+        // Reject with a plain string (not an Error instance) to hit
+        // the `String(err)` branch of `errMsg`.
+        throw 'plain-string-reject';
+      }),
+    });
+    const { kept, response } = await dispatch({ type: 'secrets.list' });
+    expect(kept).toBe(true);
+    expect(response.error).toBe('plain-string-reject');
+  });
+});

--- a/packages/chrome-extension/tests/service-worker-secrets.test.ts
+++ b/packages/chrome-extension/tests/service-worker-secrets.test.ts
@@ -260,22 +260,36 @@ describe('service-worker fetch-proxy.fetch + secrets handlers', () => {
 
   it('secrets.delete removes both name and name_DOMAINS', async () => {
     await import('../src/service-worker.js');
-    let response: any;
-    let kept = false;
-    for (const l of messageListeners) {
-      const result = l({ type: 'secrets.delete', name: 'GITHUB_TOKEN' }, {}, (r: any) => {
-        response = r;
-      });
-      if (result === true) {
-        kept = true;
-        break;
-      }
-    }
-    expect(kept).toBe(true);
-    await new Promise((r) => setTimeout(r, 10));
-    expect(response).toEqual({ ok: true });
+    const response = await dispatch({ type: 'secrets.delete', name: 'GITHUB_TOKEN' });
+    expect(response).toEqual({ ok: true, removed: true, fromSession: false });
     expect(storageMap.GITHUB_TOKEN).toBeUndefined();
     expect(storageMap.GITHUB_TOKEN_DOMAINS).toBeUndefined();
+  });
+
+  it('secrets.delete prefers the session store when both stores hold the name', async () => {
+    await import('../src/service-worker.js');
+    // Seed a session secret that shadows a persisted name; delete must remove
+    // the session entry first (mirrors the node-server endpoint precedence).
+    await dispatch({
+      type: 'secrets.session.set',
+      name: 'GITHUB_TOKEN',
+      value: 'session-val',
+      domains: ['api.github.com'],
+    });
+    const response = await dispatch({ type: 'secrets.delete', name: 'GITHUB_TOKEN' });
+    expect(response).toEqual({ ok: true, removed: true, fromSession: true });
+    // Persisted entry must remain after the session-only deletion.
+    expect(storageMap.GITHUB_TOKEN).toBe('ghp_real');
+    expect(storageMap.GITHUB_TOKEN_DOMAINS).toBe('api.github.com');
+    // The session list is now empty for that name.
+    const list = await dispatch({ type: 'secrets.session.list' });
+    expect(list.entries).toEqual([]);
+  });
+
+  it('secrets.delete reports removed:false for an unknown name', async () => {
+    await import('../src/service-worker.js');
+    const response = await dispatch({ type: 'secrets.delete', name: 'NO_SUCH_KEY' });
+    expect(response).toEqual({ ok: true, removed: false });
   });
 
   async function dispatch(msg: any): Promise<any> {

--- a/packages/node-server/src/routes/secrets.ts
+++ b/packages/node-server/src/routes/secrets.ts
@@ -47,6 +47,39 @@ function isStringArray(value: unknown): value is string[] {
 }
 
 /**
+ * Persisted/session delete handler — checks the session store first so a
+ * session shadow does not leak through after deletion, then falls back to the
+ * persisted store. Reloads the masking pipeline either way.
+ */
+async function handleDeleteSecret(
+  name: string | undefined,
+  res: Response,
+  secretStore: EnvSecretStore,
+  secretProxy: SecretProxyManager
+): Promise<Response> {
+  if (typeof name !== 'string' || name.length === 0) {
+    return res.status(400).json({ error: 'bad-request' });
+  }
+  try {
+    if (secretProxy.sessionStore.has(name)) {
+      secretProxy.sessionStore.delete(name);
+      await secretProxy.reload();
+      return res.json({ ok: true, name, fromSession: true });
+    }
+    if (secretStore.get(name)) {
+      secretStore.delete(name);
+      await secretProxy.reload();
+      return res.json({ ok: true, name, fromSession: false });
+    }
+    return res.status(404).json({ error: `no secret named "${name}"` });
+  } catch (err) {
+    return res
+      .status(500)
+      .json({ error: err instanceof Error ? err.message : 'Failed to delete secret' });
+  }
+}
+
+/**
  * Secret management API — direct .env file access (no browser needed). The
  * `secretStore` is wired into `secretProxy` so the fetch-proxy and the
  * management API share one source of truth.
@@ -79,6 +112,14 @@ export function registerSecretRoutes(app: Express, deps: SecretRoutesDeps): void
       res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to set secret' });
     }
   });
+
+  // Persisted/session delete — remove a named secret (and its _DOMAINS
+  // companion) from whichever store currently holds it. Session secrets are
+  // checked first so a session shadow does not leak through after deletion.
+  // Reloads the masking pipeline so the change takes effect without restart.
+  app.delete('/api/secrets/:name', (req, res) =>
+    handleDeleteSecret(req.params.name, res, secretStore, secretProxy)
+  );
 
   // Scope edit — update the allowed domains of an existing secret (persisted or
   // session), preserving the value. Gated by the agent before sending.

--- a/packages/node-server/tests/integration/server/server-api.test.ts
+++ b/packages/node-server/tests/integration/server/server-api.test.ts
@@ -553,10 +553,19 @@ describe('shared server API conformance', () => {
     expect(res.status).toBeGreaterThanOrEqual(400);
   });
 
-  it('rejects DELETE /api/secrets/:name (write route removed)', async () => {
-    const res = await fetchFromServer('/api/secrets/INTTEST_BLOCKED', { method: 'DELETE' });
-    // Express returns 404 for unmatched routes
-    expect(res.status).toBeGreaterThanOrEqual(400);
+  it('returns 404 for DELETE /api/secrets/:name when the secret is unknown', async () => {
+    // Negative coverage for the delete route: a name that almost certainly does
+    // not exist must come back as 404 (not 500, not 200) so the shell can
+    // report "no secret named …" cleanly. Positive deletion is exercised in
+    // unit tests against the EnvSecretStore + service-worker handlers; this
+    // suite cannot mutate the live server's secrets blob safely.
+    const res = await fetchFromServer(
+      `/api/secrets/INTTEST_UNKNOWN_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+      { method: 'DELETE' }
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(typeof body['error']).toBe('string');
   });
 
   it('returns structured responses from lick-backed REST endpoints based on browser connectivity', async () => {

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -238,6 +238,31 @@ func registerAPIRoutes(
         return try jsonResponse(.array(items))
     }
 
+    // Persisted delete — remove a named secret (and its _DOMAINS companion)
+    // from the Keychain blob and reload the masking pipeline so the change
+    // takes effect without a restart. 404 when no secret with that name
+    // exists. Mirrors `DELETE /api/secrets/:name` in node-server.
+    router.delete("/api/secrets/:name") { _, context in
+        let name = context.parameters.get("name") ?? ""
+        guard !name.isEmpty else {
+            return try jsonErrorResponse(status: .badRequest, message: "Missing required field: name")
+        }
+        guard SecretStore.get(name: name) != nil else {
+            return try jsonErrorResponse(status: .notFound, message: "no secret named \"\(name)\"")
+        }
+        do {
+            try SecretStore.delete(name: name)
+        } catch {
+            return try jsonErrorResponse(status: .internalServerError, message: errorMessage(error))
+        }
+        await secretInjector.reload()
+        return try jsonResponse(.object([
+            "ok": .bool(true),
+            "name": .string(name),
+            "fromSession": .bool(false),
+        ]))
+    }
+
     // Masked secrets endpoint — returns name + maskedValue + domains for shell env population.
     // The browser fetches this at shell init to populate env vars with masked values.
     // Real values are never exposed; only deterministic session-scoped masks.

--- a/packages/swift-server/Tests/SecretAPIRoutesTests.swift
+++ b/packages/swift-server/Tests/SecretAPIRoutesTests.swift
@@ -72,7 +72,7 @@ final class SecretAPIRoutesTests: XCTestCase {
         }
     }
 
-    func testDeleteSecretRouteIsRemoved() async throws {
+    func testDeleteSecretRemovesEntryFromKeychainBlob() async throws {
         let name = secretName("DEL_TOK")
         try SecretStore.set(name: name, value: "val", domains: ["x.com"])
 
@@ -83,8 +83,39 @@ final class SecretAPIRoutesTests: XCTestCase {
             let app = Application(responder: router.buildResponder())
             try await app.test(.router) { client in
                 try await client.execute(uri: "/api/secrets/\(name)", method: .delete) { response in
-                    // Route no longer exists — expect 404
+                    XCTAssertEqual(response.status, .ok)
+                    let obj = try self.decodeJSONObject(from: response.body)
+                    if case .bool(let ok) = obj["ok"] ?? .null {
+                        XCTAssertTrue(ok)
+                    } else {
+                        XCTFail("Expected ok: true")
+                    }
+                    XCTAssertEqual(obj["name"]?.stringValue, name)
+                    if case .bool(let fromSession) = obj["fromSession"] ?? .null {
+                        XCTAssertFalse(fromSession)
+                    } else {
+                        XCTFail("Expected fromSession: false")
+                    }
+                }
+                // Entry must be gone after the delete.
+                XCTAssertNil(SecretStore.get(name: name))
+            }
+        }
+    }
+
+    func testDeleteSecretReturnsNotFoundForUnknownName() async throws {
+        let name = secretName("DEL_MISS")
+
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/api/secrets/\(name)", method: .delete) { response in
                     XCTAssertEqual(response.status, .notFound)
+                    let obj = try self.decodeJSONObject(from: response.body)
+                    XCTAssertNotNil(obj["error"]?.stringValue)
                 }
             }
         }

--- a/packages/webapp/src/shell/supplemental-commands/secret-backends.ts
+++ b/packages/webapp/src/shell/supplemental-commands/secret-backends.ts
@@ -29,6 +29,14 @@ export interface PeekRecord {
   domains: string[];
 }
 
+/** Result of {@link SecretBackend.delete}. */
+export interface DeleteResult {
+  /** Whether the secret existed before the call. */
+  removed: boolean;
+  /** When set, the secret was in the session store; otherwise the persisted store. */
+  fromSession?: boolean;
+}
+
 /** The trusted-realm operations the `secret` command depends on. */
 export interface SecretBackend {
   list(): Promise<SecretRecord[]>;
@@ -38,6 +46,12 @@ export interface SecretBackend {
   setSession(name: string, value: string, domains: string[]): Promise<void>;
   setPersisted(name: string, value: string, domains: string[]): Promise<void>;
   setScope(name: string, domains: string[]): Promise<void>;
+  /**
+   * Remove a secret from the active backend, including its `_DOMAINS` companion.
+   * Triggers a masking-pipeline reload so the change takes effect without a
+   * restart. Returns `{ removed: false }` when no secret with that name existed.
+   */
+  delete(name: string): Promise<DeleteResult>;
 }
 
 function swSendMessage<T>(msg: Record<string, unknown>): Promise<T> {
@@ -109,6 +123,16 @@ export function createCliSecretBackend(): SecretBackend {
       const { ok, data } = await apiCall('POST', '/scope', { name, domains });
       if (!ok) throw new Error(errOf(data) ?? 'failed to update scope');
     },
+    async delete(name) {
+      const { ok, status, data } = await apiCall('DELETE', `/${encodeURIComponent(name)}`);
+      if (status === 404) return { removed: false };
+      if (!ok) throw new Error(errOf(data) ?? 'failed to delete secret');
+      const fromSession =
+        data && typeof data === 'object' && 'fromSession' in data
+          ? Boolean((data as { fromSession?: unknown }).fromSession)
+          : undefined;
+      return { removed: true, fromSession };
+    },
   };
 }
 
@@ -171,6 +195,20 @@ export function createExtensionSecretBackend(): SecretBackend {
         domains,
       });
       if (!resp?.ok) throw new Error(resp?.error ?? 'secrets.set-domains failed');
+    },
+    async delete(name) {
+      const resp = await swSendMessage<{
+        ok?: boolean;
+        removed?: boolean;
+        fromSession?: boolean;
+        error?: string;
+      }>({ type: 'secrets.delete', name });
+      if (!resp?.ok) throw new Error(resp?.error ?? 'secrets.delete failed');
+      // Older SWs return `{ ok: true }` with no `removed` field. Treat that as
+      // best-effort "removed" so the shell still reports success — same end
+      // state as the request requested.
+      const removed = resp.removed ?? true;
+      return { removed, fromSession: resp.fromSession };
     },
   };
 }

--- a/packages/webapp/src/shell/supplemental-commands/secret-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/secret-command.ts
@@ -29,7 +29,10 @@ Requires approval (native prompt; deny blocks the change):
   secret scope <name> --domain <pat>           Edit allowed host/domain scope.
 
 Other:
-  secret delete <name>                         Remove a secret (or show how).
+  secret delete <name>                         Remove a secret (session or
+  secret rm <name>                             persisted) and its _DOMAINS
+                                               entry; reloads the masking
+                                               pipeline.
   secret edit                                  Open the Mount Secrets options page
                                                (extension) or print the env path.
 
@@ -48,27 +51,6 @@ Examples:
 
 function isExtensionContext(): boolean {
   return typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
-}
-
-function swSendMessage<T>(msg: Record<string, unknown>): Promise<T> {
-  return new Promise((resolve, reject) => {
-    chrome.runtime.sendMessage(msg, (response: unknown) => {
-      const err = chrome.runtime.lastError;
-      if (err) {
-        reject(new Error(err.message ?? 'chrome.runtime.lastError'));
-        return;
-      }
-      resolve(response as T);
-    });
-  });
-}
-
-async function deleteFromStorage(name: string): Promise<void> {
-  const resp = await swSendMessage<{ ok?: boolean; error?: string }>({
-    type: 'secrets.delete',
-    name,
-  });
-  if (!resp?.ok) throw new Error(resp?.error ?? 'secrets.delete failed');
 }
 
 function parseDomainFlag(args: string[]): string[] | null {
@@ -341,36 +323,30 @@ export function createSecretCommand(deps: SecretCommandDeps = {}): Command {
           return { stdout: output, stderr: '', exitCode: 0 };
         }
 
-        case 'delete': {
+        case 'delete':
+        case 'rm': {
           const name = args[1];
           if (!name) {
-            return { stdout: '', stderr: 'secret: delete requires a <name>\n', exitCode: 1 };
-          }
-
-          if (inExtension) {
-            try {
-              await deleteFromStorage(name);
-            } catch (err) {
-              return {
-                stdout: '',
-                stderr: `secret: failed to remove from chrome.storage.local: ${err instanceof Error ? err.message : String(err)}\n`,
-                exitCode: 1,
-              };
-            }
             return {
-              stdout: `Removed "${name}" from chrome.storage.local\n`,
-              stderr: '',
-              exitCode: 0,
+              stdout: '',
+              stderr: `secret: ${subcommand} requires a <name>\n`,
+              exitCode: 1,
             };
           }
-
-          let output = `To delete the secret "${name}", use one of the following methods:\n\n`;
-          output += `  macOS Keychain (swift-server):\n`;
-          output += `    security delete-generic-password -s ai.sliccy.slicc -a ${name}\n\n`;
-          output += `  Environment file (node-server):\n`;
-          output += `    Remove the ${name}= and ${name}_DOMAINS= lines from ~/.slicc/secrets.env\n\n`;
-          output += `Then restart the server to pick up changes.\n`;
-          return { stdout: output, stderr: '', exitCode: 0 };
+          const result = await backend.delete(name);
+          if (!result.removed) {
+            return {
+              stdout: '',
+              stderr: `secret: no secret named "${name}"\n`,
+              exitCode: 1,
+            };
+          }
+          const scope = result.fromSession === true ? 'session' : 'persisted';
+          return {
+            stdout: `Removed ${scope} secret "${name}"\n`,
+            stderr: '',
+            exitCode: 0,
+          };
         }
 
         case 'test': {

--- a/packages/webapp/src/shell/supplemental-commands/secret-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/secret-command.ts
@@ -1,10 +1,10 @@
 import { isAllowedDomain } from '@slicc/shared-ts';
-import type { Command } from 'just-bash';
+import type { Command, CommandContext, ExecResult } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { isValidShellEnvName } from '../../core/secret-env.js';
 import { createSudoBroker } from '../../sudo/index.js';
 import type { SudoBroker } from '../../sudo/types.js';
-import { stdinAsText } from '../just-bash-compat.js';
+import { type ByteString, stdinAsText } from '../just-bash-compat.js';
 import { commandGlobToRegExp } from '../sudo/sudoers.js';
 import { createDefaultSecretBackend, type SecretBackend } from './secret-backends.js';
 
@@ -119,7 +119,18 @@ export interface SecretCommandDeps {
   setEnv?: (name: string, value: string) => void;
 }
 
-export function createSecretCommand(deps: SecretCommandDeps = {}): Command {
+interface SecretCmdEnv {
+  backend: SecretBackend;
+  inExtension: boolean;
+  gate: (op: GatedOp, name: string) => Promise<boolean>;
+  injectMaskedEnv: (name: string) => Promise<void>;
+}
+
+function denied(): ExecResult {
+  return { stdout: '', stderr: 'secret: approval denied\n', exitCode: 1 };
+}
+
+function buildEnv(deps: SecretCommandDeps): SecretCmdEnv {
   const inExtension = deps.isExtension ?? isExtensionContext();
   const backend = deps.backend ?? createDefaultSecretBackend(inExtension);
   const grants = deps.grants ?? moduleGrants;
@@ -150,8 +161,6 @@ export function createSecretCommand(deps: SecretCommandDeps = {}): Command {
     return true;
   };
 
-  const denied = () => ({ stdout: '', stderr: 'secret: approval denied\n', exitCode: 1 });
-
   // Best-effort masked-value injection into the owning shell's live env, called
   // after a successful session/persisted set. The agent's $K then reads the same
   // masked token the fetch proxy will unmask — LLM context parity with
@@ -169,264 +178,295 @@ export function createSecretCommand(deps: SecretCommandDeps = {}): Command {
     }
   };
 
+  return { backend, inExtension, gate, injectMaskedEnv };
+}
+
+// Pipeline-friendly: `echo $TOKEN | secret set NAME` keeps the literal
+// value out of the agent's tool-call argv (and thus out of the LLM
+// transcript). Trim exactly one trailing newline so `echo` and
+// `printf '%s\n'` both work; preserve any embedded newlines verbatim
+// since some token formats carry them.
+function readStdinValue(stdin: ByteString): string | undefined {
+  const raw = stdinAsText(stdin);
+  if (raw.length === 0) return undefined;
+  if (raw.endsWith('\r\n')) return raw.slice(0, -2);
+  if (raw.endsWith('\n')) return raw.slice(0, -1);
+  return raw;
+}
+
+async function handleSetPersisted(
+  name: string,
+  value: string,
+  domains: string[],
+  env: SecretCmdEnv
+): Promise<ExecResult> {
+  // Persisted set writes to secrets.env / Keychain / chrome.storage —
+  // a sensitive, durable mutation, so it's gated.
+  if (domains.length === 0) {
+    return {
+      stdout: '',
+      stderr: 'secret: --domain is required to persist a secret\n',
+      exitCode: 1,
+    };
+  }
+  if (!(await env.gate('persist', name))) return denied();
+  await env.backend.setPersisted(name, value, domains);
+  await env.injectMaskedEnv(name);
+  return {
+    stdout: `Persisted "${name}" (domains: ${domains.join(', ')})\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+async function handleSetSession(
+  name: string,
+  value: string,
+  domains: string[],
+  env: SecretCmdEnv
+): Promise<ExecResult> {
+  // Session set: free for a new name; changing the value of an existing
+  // secret is gated (an agent must not silently overwrite a real one).
+  const info = await env.backend.getInfo(name);
+  if (info && !(await env.gate('value', name))) return denied();
+  await env.backend.setSession(name, value, domains);
+  await env.injectMaskedEnv(name);
+  const scope = domains.length > 0 ? ` (domains: ${domains.join(', ')})` : '';
+  return {
+    stdout: `Set session secret "${name}"${scope} — in-memory only, not persisted.\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+async function handleSet(
+  args: string[],
+  ctx: CommandContext,
+  env: SecretCmdEnv
+): Promise<ExecResult> {
+  const name = args[1];
+  if (!name || name.startsWith('-')) {
+    return { stdout: '', stderr: 'secret: set requires a <name>\n', exitCode: 1 };
+  }
+  const argValue = args[2] && !args[2].startsWith('-') ? args[2] : undefined;
+  const stdinValue = readStdinValue(ctx.stdin);
+
+  if (argValue !== undefined && stdinValue !== undefined) {
+    return {
+      stdout: '',
+      stderr: 'secret: provide <value> as an argument OR via stdin, not both\n',
+      exitCode: 1,
+    };
+  }
+
+  const value = argValue ?? stdinValue;
+  if (value === undefined) {
+    return {
+      stdout: '',
+      stderr:
+        'secret: set requires a <value>: ' +
+        'secret set <name> <value> [--domain <patterns>] [--persist]\n  ' +
+        'or pipe the value on stdin: echo "$TOKEN" | secret set <name> [--domain ...]\n',
+      exitCode: 1,
+    };
+  }
+  const domains = parseDomainFlag(args) ?? [];
+  return args.includes('--persist')
+    ? handleSetPersisted(name, value, domains, env)
+    : handleSetSession(name, value, domains, env);
+}
+
+async function handleGet(args: string[], env: SecretCmdEnv): Promise<ExecResult> {
+  const name = args[1];
+  if (!name) {
+    return { stdout: '', stderr: 'secret: get requires a <name>\n', exitCode: 1 };
+  }
+  const rec = await env.backend.getMasked(name);
+  if (!rec) {
+    return { stdout: '', stderr: `secret: no secret named "${name}"\n`, exitCode: 1 };
+  }
+  return {
+    stdout: `${rec.name}=${rec.maskedValue}\n  domains: ${rec.domains.join(', ') || '(none)'}\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+async function handlePeek(args: string[], env: SecretCmdEnv): Promise<ExecResult> {
+  const name = args[1];
+  if (!name) {
+    return { stdout: '', stderr: 'secret: peek requires a <name>\n', exitCode: 1 };
+  }
+  const rec = await env.backend.peek(name);
+  if (!rec) {
+    return { stdout: '', stderr: `secret: no secret named "${name}"\n`, exitCode: 1 };
+  }
+  return {
+    stdout: `${rec.name}: ${rec.preview}\n  domains: ${rec.domains.join(', ') || '(none)'}\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+async function handleScope(args: string[], env: SecretCmdEnv): Promise<ExecResult> {
+  const name = args[1];
+  if (!name || name.startsWith('-')) {
+    return { stdout: '', stderr: 'secret: scope requires a <name>\n', exitCode: 1 };
+  }
+  const domains = parseDomainFlag(args) ?? [];
+  if (domains.length === 0) {
+    return {
+      stdout: '',
+      stderr: 'secret: scope requires --domain <patterns>\n',
+      exitCode: 1,
+    };
+  }
+  if (!(await env.gate('scope', name))) return denied();
+  await env.backend.setScope(name, domains);
+  return {
+    stdout: `Updated scope for "${name}" (domains: ${domains.join(', ')})\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+async function handleList(env: SecretCmdEnv): Promise<ExecResult> {
+  const entries = await env.backend.list();
+  if (entries.length === 0) {
+    return { stdout: 'No secrets stored\n', stderr: '', exitCode: 0 };
+  }
+  const nameWidth = Math.max(4, ...entries.map((e) => e.name.length));
+  let output = `${'NAME'.padEnd(nameWidth)}  TYPE     DOMAINS\n`;
+  for (const entry of entries) {
+    const type = entry.persisted ? 'SAVED' : 'SESSION';
+    output += `${entry.name.padEnd(nameWidth)}  ${type.padEnd(7)}  ${entry.domains.join(', ')}\n`;
+  }
+  return { stdout: output, stderr: '', exitCode: 0 };
+}
+
+async function handleDelete(
+  args: string[],
+  subcommand: string,
+  env: SecretCmdEnv
+): Promise<ExecResult> {
+  const name = args[1];
+  if (!name) {
+    return {
+      stdout: '',
+      stderr: `secret: ${subcommand} requires a <name>\n`,
+      exitCode: 1,
+    };
+  }
+  const result = await env.backend.delete(name);
+  if (!result.removed) {
+    return { stdout: '', stderr: `secret: no secret named "${name}"\n`, exitCode: 1 };
+  }
+  const scope = result.fromSession === true ? 'session' : 'persisted';
+  return { stdout: `Removed ${scope} secret "${name}"\n`, stderr: '', exitCode: 0 };
+}
+
+async function handleTest(args: string[], env: SecretCmdEnv): Promise<ExecResult> {
+  const name = args[1];
+  const url = args[2];
+  if (!name || !url) {
+    return { stdout: '', stderr: 'secret: test requires <name> <url>\n', exitCode: 1 };
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return { stdout: '', stderr: `secret: invalid URL "${url}"\n`, exitCode: 1 };
+  }
+
+  const entries = await env.backend.list();
+  const entry = entries.find((e) => e.name === name);
+  if (!entry) {
+    return { stdout: '', stderr: `secret: no secret named "${name}"\n`, exitCode: 1 };
+  }
+
+  // Client-side domain check using the same logic as the fetch proxy
+  if (isAllowedDomain(entry.domains, hostname)) {
+    return { stdout: `✓ ${name} is allowed for ${hostname}\n`, stderr: '', exitCode: 0 };
+  }
+  return {
+    stdout: `✗ ${name} is NOT allowed for ${hostname}\n  Allowed domains: ${entry.domains.join(', ')}\n`,
+    stderr: '',
+    exitCode: 1,
+  };
+}
+
+async function handleEdit(env: SecretCmdEnv): Promise<ExecResult> {
+  if (!env.inExtension) {
+    return {
+      stdout:
+        'secret: in CLI mode, edit ~/.slicc/secrets.env directly with your text editor.\n' +
+        '          (changes are picked up on the next request — no restart needed)\n',
+      stderr: '',
+      exitCode: 0,
+    };
+  }
+  // Open the extension's options page (`secrets.html`) in a new tab.
+  // chrome.runtime.openOptionsPage() is the canonical way; falls back
+  // to a tab if the user disabled the options page.
+  try {
+    await chrome.runtime.openOptionsPage();
+    return {
+      stdout: 'Opened Mount Secrets options page in a new tab.\n',
+      stderr: '',
+      exitCode: 0,
+    };
+  } catch (_err) {
+    // Fallback: open the URL directly via window.open (no permission needed
+    // for extension pages; works from the side panel context).
+    const url = chrome.runtime.getURL('secrets.html');
+    window.open(url, '_blank');
+    return { stdout: `Opened ${url}\n`, stderr: '', exitCode: 0 };
+  }
+}
+
+async function dispatch(
+  args: string[],
+  ctx: CommandContext,
+  env: SecretCmdEnv
+): Promise<ExecResult> {
+  const subcommand = args[0];
+  switch (subcommand) {
+    case 'set':
+      return handleSet(args, ctx, env);
+    case 'get':
+    case 'read':
+      return handleGet(args, env);
+    case 'peek':
+      return handlePeek(args, env);
+    case 'scope':
+      return handleScope(args, env);
+    case 'list':
+      return handleList(env);
+    case 'delete':
+    case 'rm':
+      return handleDelete(args, subcommand, env);
+    case 'test':
+      return handleTest(args, env);
+    case 'edit':
+      return handleEdit(env);
+    default:
+      return {
+        stdout: '',
+        stderr: `secret: unknown command "${subcommand}"\n`,
+        exitCode: 1,
+      };
+  }
+}
+
+export function createSecretCommand(deps: SecretCommandDeps = {}): Command {
+  const env = buildEnv(deps);
   return defineCommand('secret', async (args, ctx) => {
     if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
       return { stdout: helpText(), stderr: '', exitCode: 0 };
     }
-
-    const subcommand = args[0];
-
     try {
-      switch (subcommand) {
-        case 'set': {
-          const name = args[1];
-          if (!name || name.startsWith('-')) {
-            return { stdout: '', stderr: 'secret: set requires a <name>\n', exitCode: 1 };
-          }
-          const argValue = args[2] && !args[2].startsWith('-') ? args[2] : undefined;
-
-          // Pipeline-friendly: `echo $TOKEN | secret set NAME` keeps the literal
-          // value out of the agent's tool-call argv (and thus out of the LLM
-          // transcript). Trim exactly one trailing newline so `echo` and
-          // `printf '%s\n'` both work; preserve any embedded newlines verbatim
-          // since some token formats carry them.
-          const rawStdin = stdinAsText(ctx.stdin);
-          const trimmedStdin = rawStdin.endsWith('\r\n')
-            ? rawStdin.slice(0, -2)
-            : rawStdin.endsWith('\n')
-              ? rawStdin.slice(0, -1)
-              : rawStdin;
-          const stdinValue = rawStdin.length > 0 ? trimmedStdin : undefined;
-
-          if (argValue !== undefined && stdinValue !== undefined) {
-            return {
-              stdout: '',
-              stderr: 'secret: provide <value> as an argument OR via stdin, not both\n',
-              exitCode: 1,
-            };
-          }
-
-          const value = argValue ?? stdinValue;
-          if (value === undefined) {
-            return {
-              stdout: '',
-              stderr:
-                'secret: set requires a <value>: ' +
-                'secret set <name> <value> [--domain <patterns>] [--persist]\n  ' +
-                'or pipe the value on stdin: echo "$TOKEN" | secret set <name> [--domain ...]\n',
-              exitCode: 1,
-            };
-          }
-          const domains = parseDomainFlag(args) ?? [];
-          const persist = args.includes('--persist');
-
-          if (persist) {
-            // Persisted set writes to secrets.env / Keychain / chrome.storage —
-            // a sensitive, durable mutation, so it's gated.
-            if (domains.length === 0) {
-              return {
-                stdout: '',
-                stderr: 'secret: --domain is required to persist a secret\n',
-                exitCode: 1,
-              };
-            }
-            if (!(await gate('persist', name))) return denied();
-            await backend.setPersisted(name, value, domains);
-            await injectMaskedEnv(name);
-            return {
-              stdout: `Persisted "${name}" (domains: ${domains.join(', ')})\n`,
-              stderr: '',
-              exitCode: 0,
-            };
-          }
-
-          // Session set: free for a new name; changing the value of an existing
-          // secret is gated (an agent must not silently overwrite a real one).
-          const info = await backend.getInfo(name);
-          if (info && !(await gate('value', name))) return denied();
-          await backend.setSession(name, value, domains);
-          await injectMaskedEnv(name);
-          const scope = domains.length > 0 ? ` (domains: ${domains.join(', ')})` : '';
-          return {
-            stdout: `Set session secret "${name}"${scope} — in-memory only, not persisted.\n`,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        case 'get':
-        case 'read': {
-          const name = args[1];
-          if (!name) {
-            return { stdout: '', stderr: 'secret: get requires a <name>\n', exitCode: 1 };
-          }
-          const rec = await backend.getMasked(name);
-          if (!rec) {
-            return { stdout: '', stderr: `secret: no secret named "${name}"\n`, exitCode: 1 };
-          }
-          return {
-            stdout: `${rec.name}=${rec.maskedValue}\n  domains: ${rec.domains.join(', ') || '(none)'}\n`,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        case 'peek': {
-          const name = args[1];
-          if (!name) {
-            return { stdout: '', stderr: 'secret: peek requires a <name>\n', exitCode: 1 };
-          }
-          const rec = await backend.peek(name);
-          if (!rec) {
-            return { stdout: '', stderr: `secret: no secret named "${name}"\n`, exitCode: 1 };
-          }
-          return {
-            stdout: `${rec.name}: ${rec.preview}\n  domains: ${rec.domains.join(', ') || '(none)'}\n`,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        case 'scope': {
-          const name = args[1];
-          if (!name || name.startsWith('-')) {
-            return { stdout: '', stderr: 'secret: scope requires a <name>\n', exitCode: 1 };
-          }
-          const domains = parseDomainFlag(args) ?? [];
-          if (domains.length === 0) {
-            return {
-              stdout: '',
-              stderr: 'secret: scope requires --domain <patterns>\n',
-              exitCode: 1,
-            };
-          }
-          if (!(await gate('scope', name))) return denied();
-          await backend.setScope(name, domains);
-          return {
-            stdout: `Updated scope for "${name}" (domains: ${domains.join(', ')})\n`,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        case 'list': {
-          const entries = await backend.list();
-          if (entries.length === 0) {
-            return { stdout: 'No secrets stored\n', stderr: '', exitCode: 0 };
-          }
-          const nameWidth = Math.max(4, ...entries.map((e) => e.name.length));
-          let output = `${'NAME'.padEnd(nameWidth)}  TYPE     DOMAINS\n`;
-          for (const entry of entries) {
-            const type = entry.persisted ? 'SAVED' : 'SESSION';
-            output += `${entry.name.padEnd(nameWidth)}  ${type.padEnd(7)}  ${entry.domains.join(', ')}\n`;
-          }
-          return { stdout: output, stderr: '', exitCode: 0 };
-        }
-
-        case 'delete':
-        case 'rm': {
-          const name = args[1];
-          if (!name) {
-            return {
-              stdout: '',
-              stderr: `secret: ${subcommand} requires a <name>\n`,
-              exitCode: 1,
-            };
-          }
-          const result = await backend.delete(name);
-          if (!result.removed) {
-            return {
-              stdout: '',
-              stderr: `secret: no secret named "${name}"\n`,
-              exitCode: 1,
-            };
-          }
-          const scope = result.fromSession === true ? 'session' : 'persisted';
-          return {
-            stdout: `Removed ${scope} secret "${name}"\n`,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        case 'test': {
-          const name = args[1];
-          const url = args[2];
-          if (!name || !url) {
-            return { stdout: '', stderr: 'secret: test requires <name> <url>\n', exitCode: 1 };
-          }
-
-          let hostname: string;
-          try {
-            hostname = new URL(url).hostname;
-          } catch {
-            return { stdout: '', stderr: `secret: invalid URL "${url}"\n`, exitCode: 1 };
-          }
-
-          const entries = await backend.list();
-          const entry = entries.find((e) => e.name === name);
-          if (!entry) {
-            return { stdout: '', stderr: `secret: no secret named "${name}"\n`, exitCode: 1 };
-          }
-
-          // Client-side domain check using the same logic as the fetch proxy
-          const allowed = isAllowedDomain(entry.domains, hostname);
-
-          if (allowed) {
-            return {
-              stdout: `✓ ${name} is allowed for ${hostname}\n`,
-              stderr: '',
-              exitCode: 0,
-            };
-          } else {
-            return {
-              stdout: `✗ ${name} is NOT allowed for ${hostname}\n  Allowed domains: ${entry.domains.join(', ')}\n`,
-              stderr: '',
-              exitCode: 1,
-            };
-          }
-        }
-
-        case 'edit': {
-          if (!inExtension) {
-            return {
-              stdout:
-                'secret: in CLI mode, edit ~/.slicc/secrets.env directly with your text editor.\n' +
-                '          (changes are picked up on the next request — no restart needed)\n',
-              stderr: '',
-              exitCode: 0,
-            };
-          }
-          // Open the extension's options page (`secrets.html`) in a new tab.
-          // chrome.runtime.openOptionsPage() is the canonical way; falls back
-          // to a tab if the user disabled the options page.
-          try {
-            await chrome.runtime.openOptionsPage();
-            return {
-              stdout: 'Opened Mount Secrets options page in a new tab.\n',
-              stderr: '',
-              exitCode: 0,
-            };
-          } catch (_err) {
-            // Fallback: open the URL directly via window.open (no permission needed
-            // for extension pages; works from the side panel context).
-            const url = chrome.runtime.getURL('secrets.html');
-            window.open(url, '_blank');
-            return {
-              stdout: `Opened ${url}\n`,
-              stderr: '',
-              exitCode: 0,
-            };
-          }
-        }
-
-        default:
-          return {
-            stdout: '',
-            stderr: `secret: unknown command "${subcommand}"\n`,
-            exitCode: 1,
-          };
-      }
+      return await dispatch(args, ctx, env);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { stdout: '', stderr: `secret: ${msg}\n`, exitCode: 1 };

--- a/packages/webapp/tests/shell/supplemental-commands/secret-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/secret-command.test.ts
@@ -23,6 +23,7 @@ function makeBackend(overrides: Partial<SecretBackend> = {}): SecretBackend {
     setSession: vi.fn(async () => {}),
     setPersisted: vi.fn(async () => {}),
     setScope: vi.fn(async () => {}),
+    delete: vi.fn(async () => ({ removed: false })),
     ...overrides,
   };
 }
@@ -354,5 +355,83 @@ describe('secret command — masked-env injection on set', () => {
     });
     expect(res.exitCode).toBe(0);
     expect(setEnv).not.toHaveBeenCalled();
+  });
+});
+
+describe('secret command — delete / rm', () => {
+  let broker: ReturnType<typeof makeBroker>;
+  beforeEach(() => {
+    broker = makeBroker({ decision: 'deny' });
+  });
+
+  it('delete removes a persisted secret and reports the scope', async () => {
+    const backend = makeBackend({
+      delete: vi.fn(async () => ({ removed: true, fromSession: false })),
+    });
+    const res = await run(['delete', 'GITHUB_TOKEN'], { backend, broker: broker.broker });
+    expect(res.exitCode).toBe(0);
+    expect(backend.delete).toHaveBeenCalledWith('GITHUB_TOKEN');
+    expect(res.stdout).toContain('Removed persisted secret "GITHUB_TOKEN"');
+    expect(res.stderr).toBe('');
+    // No prompt — agent self-cleanup should not require sudo approval.
+    expect(broker.calls()).toBe(0);
+  });
+
+  it('rm is an alias of delete', async () => {
+    const backend = makeBackend({
+      delete: vi.fn(async () => ({ removed: true, fromSession: true })),
+    });
+    const res = await run(['rm', 'SESSION_KEY'], { backend, broker: broker.broker });
+    expect(res.exitCode).toBe(0);
+    expect(backend.delete).toHaveBeenCalledWith('SESSION_KEY');
+    expect(res.stdout).toContain('Removed session secret "SESSION_KEY"');
+  });
+
+  it('reports a clean not-found error when the secret does not exist', async () => {
+    const backend = makeBackend({
+      delete: vi.fn(async () => ({ removed: false })),
+    });
+    const res = await run(['delete', 'GHOST'], { backend, broker: broker.broker });
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain('no secret named "GHOST"');
+    expect(res.stdout).toBe('');
+  });
+
+  it('requires a <name> argument', async () => {
+    const backend = makeBackend();
+    const res = await run(['delete'], { backend, broker: broker.broker });
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain('delete requires a <name>');
+    expect(backend.delete).not.toHaveBeenCalled();
+  });
+
+  it('rm also requires a <name> argument', async () => {
+    const backend = makeBackend();
+    const res = await run(['rm'], { backend, broker: broker.broker });
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain('rm requires a <name>');
+  });
+
+  it('surfaces backend errors via stderr without crashing', async () => {
+    const backend = makeBackend({
+      delete: vi.fn(async () => {
+        throw new Error('network down');
+      }),
+    });
+    const res = await run(['delete', 'KEY'], { backend, broker: broker.broker });
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain('network down');
+  });
+
+  it('never echoes the secret value', async () => {
+    // Defense-in-depth: even if a misbehaving backend leaked a value, the
+    // command must not echo it back. The mock returns only `removed`/
+    // `fromSession`, so the produced output should not contain anything
+    // resembling a token.
+    const backend = makeBackend({
+      delete: vi.fn(async () => ({ removed: true, fromSession: false })),
+    });
+    const res = await run(['delete', 'GITHUB_TOKEN'], { backend, broker: broker.broker });
+    expect(res.stdout).not.toMatch(/ghp_|sk-|=/);
   });
 });


### PR DESCRIPTION
## What
Adds `secret delete <name>` (with a `secret rm` alias) so a stored secret can be removed from the shell, wired through the full secret stack in every runtime.

## Why
There was no way to remove a secret once set — stale or bad values (including a degenerate short token observed wedging provider auth in dev) had to be cleared out-of-band. `delete`/`rm` closes the CRUD gap alongside `set`/`peek`.

## Changes
- **Shell**: `secret delete` + `secret rm` alias in `secret-command.ts` + `secret-backends.ts`.
- **node-server**: `DELETE /api/secrets/:name` in `routes/secrets.ts` (session-first then persisted, with reload); extracted a `handleDeleteSecret` helper to stay under the biome 150-line/function limit.
- **service-worker**: `secrets.delete` is now session-aware and returns `{ ok, removed, fromSession }`.
- **swift-server**: parity `DELETE` route in `APIRoutes.swift`.
- Deleting an unknown name exits cleanly with a not-found message; **no secret values are ever echoed**.

## Tests
- 7 shell delete/rm tests + 3 service-worker delete tests pass.
- lint + typecheck green; webapp + chrome-extension builds green.
- Swift XCTest cases updated to mirror the new contract (run on macOS CI).

## Scope
Secret deletion only; cleanly separable from the masker-guard (#1010) and error-card (#1011) work.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author