### PR TITLE
fix(webapp): wire installPageStorageSync in standalone mode

### DIFF
--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -8,6 +8,7 @@
  */
 
 import type { BrowserAPI, CDPTransport } from '../../cdp/index.js';
+import { installPageStorageSync } from '../../kernel/page-storage-sync.js';
 import { spawnKernelWorker } from '../../kernel/spawn.js';
 import type { LickEvent } from '../../scoops/lick-manager.js';
 import type { RegisteredScoop, ThinkingLevel } from '../../scoops/types.js';
@@ -1173,6 +1174,7 @@ export async function mountWcUiLive(
     instanceId,
     callbacks: createWcLiveCallbacks(boot.wiring),
   });
+  installPageStorageSync({ send: (m) => host.client.sendRaw(m) });
   attachWcClient(boot, host.client, log, {
     instanceId,
     standalone: {


### PR DESCRIPTION
## Summary

  Wires `installPageStorageSync` in the standalone kernel worker boot path so that page-side localStorage writes (OAuth login, model selection) are forwarded to the worker's Map-backed shim after boot. Before this fix, logging into a non-Anthropic provider on a fresh profile would still show "No API key configured for provider 'anthropic'" on the first message. After this fix, the provider selection resolves correctly immediately after login.
  
  ## Why

  The kernel worker has no real `localStorage` — it runs in a `DedicatedWorker` and gets a shim seeded from a snapshot of the page's `localStorage` at boot time (`collectLocalStorageSeed`).
  `installPageStorageSync` patches `Storage.prototype.setItem` on the page to forward subsequent writes to the worker via the existing `local-storage-{set,remove,clear}` message handlers in `OffscreenBridge`.

  This forwarding was already wired in the Chrome extension float (the side panel and offscreen document share the same origin's real `localStorage`, so it isn't needed there), and the function, its message types, and the worker-side handler were all fully implemented and tested — but `installPageStorageSync` was never actually called in the standalone boot path (`wc-live.ts`).

  **Repro:**
  1. Delete the SLICC Chrome profile and cache (`~/Library/Application Support/Slicc/profiles/<port>`, `~/Library/Caches/Slicc/profiles/<port>`)
  2. `npm run dev` — fresh profile, no accounts
  3. Open provider settings, log in with Adobe (or any OAuth provider)
  4. Send any message to the cone

  Expected: agent responds using the configured provider
  Actual (before fix): `No API key configured for provider "anthropic". Open Settings to add one.`

  ## Approach / Implementation notes

  - One import + one call added to `mountWcUiLive` in `wc-live.ts`, immediately after `spawnKernelWorker`:
    ```ts
    installPageStorageSync({ send: (m) => host.client.sendRaw(m) });
  - installPageStorageSync patches Storage.prototype.setItem/removeItem/clear on the page, filtered to the specific window.localStorage instance captured at install time (this !== ls guard). It also attaches a
   storage event listener for cross-tab writes. The worker-side OffscreenBridge already handles local-storage-set/remove/clear by calling applyLocalStorageOp on globalThis.localStorage (the shim Map). No new 
  message types or worker changes.
  - The function is intentionally not called in the extension float — not needed there, and the comment in offscreen-bridge.ts confirms the branches are no-ops in extension mode.
  - No disposal wiring added: installPageStorageSync returns a dispose() for tests; in production the page lives for the tab's lifetime so cleanup is not needed.

  Cross-cutting impact

  - Floats exercised: CLI standalone only. Chrome extension unaffected (confirmed: OffscreenBridge local-storage-* cases are documented as no-ops in extension mode). Electron overlay uses the same
  mountWcUiLive path — now also gets the fix.
  - All page-side localStorage writes after boot are forwarded: this includes tray runtime config (slicc.trayWorkerBaseUrl, slicc.leaderTrayStatus, slicc.leaderTrayFollowers) which tray-leader.ts and
  host-command.ts already document as requiring this forwarding. No new keys introduced.
  - No persisted state side-effects: the forwarding is read-only from the worker's perspective — it only updates the in-memory shim Map, never writes back to the page.

  Test plan

  - [x] npm run typecheck — clean (pre-existing croner module error on main unchanged)
  - [x] npm run test — 471 files, 7697 tests, all passing, no new failures
  - [x] Manual smoke (CLI): fresh profile on new port → log in with Adobe → send message → agent responds correctly, no "No API key configured" error
  - [ ] npm run build / npm run build -w @slicc/chrome-extension
  - [ ] N/A — no unit test added; the fix is a missing call-site wire-up with an integration-level repro that requires a real OAuth round-trip and browser CDP, which the test suite cannot exercise

  Pre-existing failures: none observed against this branch.

  Documentation

  - [ ] No documentation changes needed — installPageStorageSync behavior and the page→worker shim contract are already described in kernel-worker.ts comments and page-storage-sync.ts.

  Risk & rollback
  
  - Blast radius: standalone CLI and Electron overlay only. Chrome extension is unaffected.
  - Rollback: revert this PR cleanly — one call removed, no persisted state or migration involved.
  - CI cannot catch: the root repro requires a real OAuth login on a fresh Chrome profile. Verify manually: delete the profile dir, npm run dev, log in with Adobe, send a message — should respond without
  error.

  Checklist
  
  - [x] Commits are focused and package-local where possible
  - [x] No hand-edited files under dist/
  - [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
  - [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
  - [x] If this changes a contract used by other floats, I checked the followers/leader/offscreen paths