### PR TITLE
feat(swift-optel): comprehensive macOS auto-instrumentation (clicks, navigation, errors)

### DIFF
--- a/packages/swift-launcher/CLAUDE.md
+++ b/packages/swift-launcher/CLAUDE.md
@@ -40,6 +40,14 @@ violations.
 - `Models/SliccBootstrapper.swift` and `Models/SliccProcess.swift` handle runtime launch and lifecycle.
 - `Views/` contains the launcher UI and setup/progress views.
 
+## Operational Telemetry (OpTel)
+
+Sliccstart depends on `@slicc/swift-optel` and wires `.optelAutoInstrument(appID:)` once on the `WindowGroup` root in `SliccstartApp.swift`. On macOS that single call activates the full RUM surface: `enter` (launch + foreground), global `click` (app-level `NSEvent` monitor → `NSAccessibility`-derived `source`), `navigate` (key/main-window changes + new Settings window), and `error` (uncaught `NSException`). No per-control plumbing is needed in the launcher views.
+
+The `appID` is sourced from `Bundle.main.bundleIdentifier` (`com.slicc.sliccstart`); RUM beacons land in `helix-225321.helix_rum.cluster` filtered by that hostname. The opt-in per-view modifiers (`.optelView`, `.optelTap`, `OptelButton`) and `Optel.reportError(_:)` remain available for finer-grained `source` quality or Swift-`Error` boundaries.
+
+Key launcher controls carry stable `.accessibilityIdentifier` values (`get-extension`, `rescan`, `check-for-updates`, `apply-ui-update`, `restart-to-update`, `update`, `app-row-<Name>`) so RUM `click` sources stay readable across releases.
+
 ## App Scanning
 
 - Known Chromium browsers are discovered by bundle ID.

--- a/packages/swift-launcher/Sliccstart/Views/AppListView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/AppListView.swift
@@ -83,6 +83,8 @@ struct AppListView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityIdentifier("get-extension")
+            .accessibilityLabel("Get Extension")
 
             Spacer(minLength: 0)
 
@@ -97,6 +99,7 @@ struct AppListView: View {
                 Spacer()
                 Button("Rescan") { onRescan() }
                     .buttonStyle(.borderless).font(.caption)
+                    .accessibilityIdentifier("rescan")
             }
             .padding(.horizontal, 12).padding(.vertical, 6)
         }
@@ -115,6 +118,7 @@ struct AppListView: View {
                 .buttonStyle(.borderless).font(.caption)
                 .foregroundStyle(.green)
                 .help("Webapp-only update — applies live, no restart.")
+                .accessibilityIdentifier("apply-ui-update")
 
             case .applying(let version, let progress):
                 Text("Updating v\(version): \(progress)")
@@ -130,6 +134,7 @@ struct AppListView: View {
         } else {
             Button("Update") { onUpdate() }
                 .buttonStyle(.borderless).font(.caption)
+                .accessibilityIdentifier("update")
         }
     }
 
@@ -143,6 +148,7 @@ struct AppListView: View {
                 }
                 .buttonStyle(.borderless).font(.caption)
                 .foregroundStyle(.green)
+                .accessibilityIdentifier("restart-to-update")
             } else {
                 Button("Restart to Update") {
                     onBeginUpdate()
@@ -150,6 +156,7 @@ struct AppListView: View {
                 }
                 .buttonStyle(.borderless).font(.caption)
                 .foregroundStyle(.green)
+                .accessibilityIdentifier("restart-to-update")
             }
         } else {
             Button("Check for Updates") {
@@ -157,6 +164,7 @@ struct AppListView: View {
                 onCheckSmoothUpdate()
             }
             .buttonStyle(.borderless).font(.caption)
+            .accessibilityIdentifier("check-for-updates")
         }
     }
 }
@@ -232,6 +240,8 @@ struct AppRow: View {
         .buttonStyle(.plain)
         .disabled(isDisabled)
         .help(isDisabled ? AppRowStatusDot.needsLeader.help : "")
+        .accessibilityIdentifier("app-row-\(target.name)")
+        .accessibilityLabel(target.name)
         .onHover { hovering in
             // Avoid the pointing-hand affordance when the row is disabled
             // — the user can't actually start the app without a leader.

--- a/packages/swift-optel/CLAUDE.md
+++ b/packages/swift-optel/CLAUDE.md
@@ -29,15 +29,20 @@ violations.
 
 ## SwiftUI Auto-Instrumentation
 
-Ergonomic hooks for the four RUM checkpoints a SwiftUI app cares about. All
+Ergonomic hooks for the four RUM checkpoints a SwiftUI app cares about. The
 SwiftUI surface lives in `OptelSwiftUI.swift` under `#if canImport(SwiftUI)`;
-the mapping helpers (`OptelSourceDeriver`, `OptelErrorMapping`,
-`OptelUncaughtExceptionHook`) are platform-agnostic and unit-tested.
+the platform-agnostic mapping helpers (`OptelSourceDeriver`,
+`OptelErrorMapping`, `OptelUncaughtExceptionHook`) and the macOS-only globals
+(`OptelClickMonitor`, `OptelWindowObserver`, `OptelAccessibilityDeriver`,
+`OptelMacAutoInstrument`) are unit-tested independently.
 
-- `.optelAutoInstrument(appID:rate:)` — root modifier. Configures `Optel`
-  once, fires `enter` on launch, observes `scenePhase` and re-fires `enter`
-  on `background → active` transitions, and installs the best-effort
-  uncaught-exception hook.
+- `.optelAutoInstrument(appID:rate:globalHooks:)` — root modifier. Configures
+  `Optel` once, fires `enter` on launch, observes `scenePhase` and re-fires
+  `enter` on `background → active`, installs the uncaught-exception hook on
+  every platform, and on macOS installs the global click monitor + window
+  observer (via `OptelMacAutoInstrument.installIfNeeded()`) so `click` and
+  `navigate` beacons fire automatically. `globalHooks: false` opts out of
+  every install-once global hook (still fires `enter`).
 - `.optelView(_:)` — emits `navigate` with `source = name` on `.onAppear`.
 - `.optelTap(source:)` — attaches a `simultaneousGesture` that emits `click`
   with the supplied source.
@@ -47,16 +52,28 @@ the mapping helpers (`OptelSourceDeriver`, `OptelErrorMapping`,
 - `Optel.reportError(_:)` — emits `error` with `source` = bridged NSError
   domain (or Swift type name) and `target` = `localizedDescription`.
 
-### Interception limits (known, accepted)
+### Interception surface
 
-- **No global tap / navigation interception.** SwiftUI has no AppKit/UIKit-
-  style responder chain that third-party code can hook. Per-view opt-in is
-  the only reliable surface — hence the `.optelView` / `.optelTap` /
-  `OptelButton` per-control modifiers rather than a single magic root hook.
+On macOS, `.optelAutoInstrument` is a one-call wire-up that covers all four
+checkpoints: `enter` (launch + foreground), `click` (global `NSEvent`
+monitor → `OptelAccessibilityDeriver`), `navigate` (key/main-window changes
+
+- new windows via `OptelWindowObserver`), and `error` (uncaught
+  `NSException`). The per-view modifiers below are opt-in refinements — they
+  upgrade the `source` quality for specific controls / screens rather than
+  being the only surface that emits beacons.
+
+### Known limits (still accepted)
+
+- **iOS / UIKit auto-detection is not implemented.** The global click and
+  window-navigation hooks are macOS-only (`#if os(macOS)`). On iOS,
+  `.optelTap` / `OptelButton` / `.optelView` remain the per-control surface
+  for `click` / `navigate`.
 - **Uncaught-error hook is Objective-C only.** `NSSetUncaughtExceptionHandler`
-  fires for `NSException`s; Swift `Error` values are not exceptions and cannot
-  be intercepted globally. Catch and forward to `Optel.reportError(_:)`
-  explicitly at the boundaries where you `try?` / `do/catch`.
+  fires for `NSException`s; Swift `Error` values are not exceptions and
+  cannot be intercepted globally. Catch and forward to
+  `Optel.reportError(_:)` explicitly at the boundaries where you `try?` /
+  `do/catch`.
 - **`.optelAutoInstrument` covers launch and foregrounding only.** Background
   / suspend / inactive transitions are intentionally not mapped to RUM
   checkpoints (no helix-rum-js analogue).
@@ -66,6 +83,9 @@ the mapping helpers (`OptelSourceDeriver`, `OptelErrorMapping`,
 - **Reconfiguration resets state.** Calling `.optelAutoInstrument` on a
   remounted root view will re-`configure` `Optel` and re-fire `enter` (and a
   fresh session id). Mount it on a stable root.
+- **No PII capture.** The macOS click monitor records only the derived
+  `source` / `target` from `NSAccessibility` (identifier / label / role /
+  window title) — never typed text or field contents.
 
 ## Related Guides
 

--- a/packages/swift-optel/CLAUDE.md
+++ b/packages/swift-optel/CLAUDE.md
@@ -1,10 +1,10 @@
 # CLAUDE.md
 
-This file covers the Swift OpenTelemetry / RUM library in `packages/swift-optel/`.
+This file covers the Swift Operational Telemetry / RUM library in `packages/swift-optel/`.
 
 ## Scope
 
-`packages/swift-optel/` is a pure-Swift library (`SwiftOptel`) that will host the shared RUM / OpenTelemetry instrumentation consumed by the iOS follower app and the macOS native server / launcher. Skeleton only at this stage — actual RUM logic lands in later tasks. Supports `.iOS(.v16)` and `.macOS(.v13)`; no third-party dependencies.
+`packages/swift-optel/` is a pure-Swift library (`SwiftOptel`) that will host the shared RUM / Operational Telemetry instrumentation consumed by the iOS follower app and the macOS native server / launcher. Skeleton only at this stage — actual RUM logic lands in later tasks. Supports `.iOS(.v16)` and `.macOS(.v13)`; no third-party dependencies.
 
 ## Build and Test Commands
 

--- a/packages/swift-optel/README.md
+++ b/packages/swift-optel/README.md
@@ -1,6 +1,8 @@
 # swift-optel
 
-Swift OpenTelemetry / RUM library for the SLICC iOS and macOS apps. Emits the same checkpoints and JSON wire format as Adobe's [`helix-rum-js`](https://github.com/adobe/helix-rum-js), using the configured app ID as the `referer` hostname.
+Swift Operational Telemetry / RUM library for the SLICC iOS and macOS apps. Emits the same checkpoints and JSON wire format as Adobe's [`helix-rum-js`](https://github.com/adobe/helix-rum-js), using the configured app ID as the `referer` hostname.
+
+> OpTel = Operational Telemetry — Adobe's RUM-style operational telemetry; not to be confused with OpenTelemetry (OTel).
 
 ## SwiftUI auto-instrumentation
 

--- a/packages/swift-optel/README.md
+++ b/packages/swift-optel/README.md
@@ -49,22 +49,44 @@ func signIn() {
 }
 ```
 
-| Modifier / API                      | Checkpoint | Source                                                          |
-| ----------------------------------- | ---------- | --------------------------------------------------------------- |
-| `.optelAutoInstrument(appID:rate:)` | `enter`    | — (also on `background → active`)                               |
-| `.optelView(_:)`                    | `navigate` | view name                                                       |
-| `.optelTap(source:)`                | `click`    | caller-supplied                                                 |
-| `OptelButton(...)`                  | `click`    | derived `<context> <element>#<identifier>` via accessibility id |
-| `Optel.reportError(_:)`             | `error`    | bridged `NSError.domain` + `localizedDescription`               |
+| Modifier / API                                  | Checkpoint                | Source                                                          |
+| ----------------------------------------------- | ------------------------- | --------------------------------------------------------------- |
+| `.optelAutoInstrument(appID:rate:globalHooks:)` | `enter` (+ macOS globals) | — (also on `background → active`)                               |
+| `.optelView(_:)`                                | `navigate`                | view name                                                       |
+| `.optelTap(source:)`                            | `click`                   | caller-supplied                                                 |
+| `OptelButton(...)`                              | `click`                   | derived `<context> <element>#<identifier>` via accessibility id |
+| `Optel.reportError(_:)`                         | `error`                   | bridged `NSError.domain` + `localizedDescription`               |
 
-### Known interception limits
+On macOS, `.optelAutoInstrument` additionally installs an app-level click
+monitor and a key/main-window observer, so `click` and `navigate` beacons fire
+automatically with sources derived from `NSAccessibility` (identifier / label
+/ role / window title). Pass `globalHooks: false` to opt out — useful in tests
+or apps that drive their own beacons.
 
-- **Per-view opt-in only.** SwiftUI exposes no global tap / navigation
-  interception hook, so each tracked view / control must apply a modifier
-  (`.optelView`, `.optelTap`, or use `OptelButton`).
-- **Uncaught-error hook is Objective-C only.** Swift `Error` values are not
-  exceptions; only `NSException`s reach `NSSetUncaughtExceptionHandler`. Use
-  `Optel.reportError(_:)` from your own `catch` blocks for Swift errors.
+### Interception surface
+
+macOS auto-instrumentation is now first-class:
+
+- **Global clicks (macOS).** `.optelAutoInstrument` installs an `NSEvent`
+  left-mouse-up monitor; every click anywhere in the app emits a `click`
+  beacon with a `source` derived from the hit element's accessibility id /
+  label / role and the owning window title. The per-view modifiers
+  (`.optelTap`, `OptelButton`) are now opt-in refinements for finer-grained
+  `source` strings, not the only way to capture clicks.
+- **Window-level navigation (macOS).** The same modifier observes
+  `NSWindow` key / main-window changes and new-window notifications, emitting
+  `navigate` beacons sourced from the window title / identifier. `.optelView`
+  remains the way to express per-screen navigation inside a single window.
+- **Uncaught errors.** `NSSetUncaughtExceptionHandler` is installed on every
+  platform; uncaught `NSException`s emit `error` beacons. Swift `Error`
+  values are not exceptions and cannot be intercepted globally — catch them
+  at your `do/catch` boundaries and forward to `Optel.reportError(_:)`.
+
+### Known limits
+
+- **iOS / UIKit auto-detection is deferred.** On iOS the only auto-fired
+  checkpoint is `enter`; clicks and navigation still need `.optelTap` /
+  `OptelButton` / `.optelView`.
 - **Foregrounding only.** `enter` re-fires on `background → active`;
   background / suspend / inactive transitions are not mapped to a RUM
   checkpoint.
@@ -73,3 +95,6 @@ func signIn() {
 - **Reconfiguration resets the session.** Mount `.optelAutoInstrument` on
   a stable root view; remounting re-`configure`s `Optel` and starts a fresh
   session.
+- **No PII capture.** The click monitor records only the derived
+  source / target from accessibility metadata — never field contents or
+  typed text.

--- a/packages/swift-optel/Sources/SwiftOptel/Optel.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/Optel.swift
@@ -32,6 +32,13 @@ public final class Optel: @unchecked Sendable {
 
     /// Configure (or reconfigure) the client.
     ///
+    /// Honors two environment-variable overrides via ``OptelEnvConfig``:
+    /// `OPTEL_RATE` (overrides the `rate:` argument when set and non-empty —
+    /// the native analogue of helix-rum-js `?rum=on`) and `OPTEL_DEBUG`
+    /// (enables wire-level `os.Logger` logging in the default transport when
+    /// truthy). When `transport` is supplied explicitly the debug flag is
+    /// ignored — callers injecting their own transport own its logging.
+    ///
     /// - Parameters:
     ///   - appID: Identifier used as the `referer` hostname (e.g. bundle id).
     ///   - rate: Sampling rate string. Only the `on`/`off`/`high`/`low`
@@ -49,11 +56,34 @@ public final class Optel: @unchecked Sendable {
         transport: OptelTransport? = nil,
         randomSource: RandomSource? = nil
     ) {
-        let config = SamplingConfig(rate: rate)
+        configure(
+            appID: appID,
+            rate: rate,
+            collectBaseURL: collectBaseURL,
+            transport: transport,
+            randomSource: randomSource,
+            environment: ProcessInfo.processInfo.environment
+        )
+    }
+
+    /// Internal seam used by both the public ``configure`` overload and the
+    /// test suite to verify environment-variable resolution end-to-end
+    /// without mutating `ProcessInfo`.
+    internal func configure(
+        appID: String,
+        rate: String?,
+        collectBaseURL: URL,
+        transport: OptelTransport?,
+        randomSource: RandomSource?,
+        environment: [String: String]
+    ) {
+        let resolvedRate = OptelEnvConfig.resolveRate(explicit: rate, environment: environment)
+        let debugLogging = OptelEnvConfig.resolveDebugLogging(environment: environment)
+        let config = SamplingConfig(rate: resolvedRate)
         let id = RUMSessionID.generate()
         let resolvedRandom = randomSource ?? SystemRandomSource()
         let newSession = SamplingSession(id: id, config: config, random: resolvedRandom)
-        let resolvedTransport = transport ?? URLSessionOptelTransport()
+        let resolvedTransport = transport ?? URLSessionOptelTransport(debugLogging: debugLogging)
         let newCollector = OptelCollector(
             transport: resolvedTransport,
             collectBaseURL: collectBaseURL

--- a/packages/swift-optel/Sources/SwiftOptel/OptelAccessibilityDeriver.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelAccessibilityDeriver.swift
@@ -1,0 +1,135 @@
+#if os(macOS)
+import Foundation
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/// Minimal description of an accessibility element used to derive a RUM
+/// `source` / `target` pair without touching live AppKit objects.
+///
+/// AppKit types (`NSView`, accessibility proxies) adopt this protocol; tests
+/// supply pure value-type fakes so ``OptelAccessibilityDeriver`` can be
+/// exercised without a running app.
+public protocol OptelAccessibleElement {
+    /// Accessibility role (e.g. `AXButton`, `button`). Empty / whitespace
+    /// values are treated as absent.
+    var optelAccessibilityRole: String? { get }
+    /// Accessibility identifier (the AppKit analogue of an HTML `id`).
+    var optelAccessibilityIdentifier: String? { get }
+    /// Human-readable accessibility label / title.
+    var optelAccessibilityLabel: String? { get }
+    /// Title of the window that owns this element, if any.
+    var optelAccessibilityWindowTitle: String? { get }
+    /// Next element walking toward the window root (typically the superview).
+    var optelAccessibilityParent: OptelAccessibleElement? { get }
+}
+
+/// Walks from a hit element up its ancestor chain to the nearest meaningfully
+/// accessible control and composes a RUM `source` / `target` pair via
+/// ``OptelSourceDeriver``.
+///
+/// `source` follows the existing `<context> <element>#<identifier>` shape,
+/// using the resolved control's role as `element`, its identifier / label as
+/// the disambiguator, and the owning window's title as `context`. `target`
+/// is the human label (preferred) or title when nothing better is available.
+public enum OptelAccessibilityDeriver {
+    /// Maximum ancestors walked. Guards against pathological / cyclic chains
+    /// without imposing a meaningful limit on real UI hierarchies.
+    public static let maxAncestorDepth = 64
+
+    /// Resolved `source` / `target` pair for an `click` (or similar) checkpoint.
+    public struct Derived: Equatable, Sendable {
+        public let source: String
+        public let target: String?
+
+        public init(source: String, target: String?) {
+            self.source = source
+            self.target = target
+        }
+    }
+
+    /// Derive the RUM pair from `element`. Walks ancestors until a
+    /// meaningfully-accessible node is found (identifier, label, or a
+    /// non-generic role); falls back to the hit element itself when nothing
+    /// upstream qualifies.
+    public static func derive(from element: OptelAccessibleElement) -> Derived {
+        let resolved = nearestMeaningful(from: element) ?? element
+        let windowTitle = walkForWindowTitle(from: element)
+        let role = nonEmpty(resolved.optelAccessibilityRole) ?? "view"
+        let identifier = nonEmpty(resolved.optelAccessibilityIdentifier)
+        let label = nonEmpty(resolved.optelAccessibilityLabel)
+        let source = OptelSourceDeriver.source(
+            element: role,
+            identifier: identifier,
+            label: label,
+            context: windowTitle
+        )
+        return Derived(source: source, target: label)
+    }
+
+    /// Roles that describe layout containers rather than interactive controls;
+    /// the deriver walks through these looking for something meaningful.
+    static let genericRoles: Set<String> = [
+        "AXUnknown", "AXGroup", "AXSplitGroup", "AXScrollArea", "AXLayoutArea",
+        "AXLayoutItem", "AXGenericElement",
+        "unknown", "group", "splitGroup", "scrollArea", "layoutArea",
+    ]
+
+    static func isMeaningful(_ element: OptelAccessibleElement) -> Bool {
+        if nonEmpty(element.optelAccessibilityIdentifier) != nil { return true }
+        if nonEmpty(element.optelAccessibilityLabel) != nil { return true }
+        if let role = nonEmpty(element.optelAccessibilityRole),
+           !genericRoles.contains(role) {
+            return true
+        }
+        return false
+    }
+
+    static func nearestMeaningful(from element: OptelAccessibleElement) -> OptelAccessibleElement? {
+        var current: OptelAccessibleElement? = element
+        var depth = 0
+        while let node = current, depth < maxAncestorDepth {
+            if isMeaningful(node) { return node }
+            current = node.optelAccessibilityParent
+            depth += 1
+        }
+        return nil
+    }
+
+    static func walkForWindowTitle(from element: OptelAccessibleElement) -> String? {
+        var current: OptelAccessibleElement? = element
+        var depth = 0
+        while let node = current, depth < maxAncestorDepth {
+            if let title = nonEmpty(node.optelAccessibilityWindowTitle) {
+                return title
+            }
+            current = node.optelAccessibilityParent
+            depth += 1
+        }
+        return nil
+    }
+
+    static func nonEmpty(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+#if canImport(AppKit)
+/// AppKit adapter: any `NSView` can be passed to ``OptelAccessibilityDeriver``
+/// directly. Reads the standard NSAccessibility role / identifier / label
+/// values and walks the superview chain.
+extension NSView: OptelAccessibleElement {
+    public var optelAccessibilityRole: String? { accessibilityRole()?.rawValue }
+    public var optelAccessibilityIdentifier: String? { accessibilityIdentifier() }
+    public var optelAccessibilityLabel: String? {
+        let label = accessibilityLabel()
+        if let label, !label.isEmpty { return label }
+        return accessibilityTitle()
+    }
+    public var optelAccessibilityWindowTitle: String? { window?.title }
+    public var optelAccessibilityParent: OptelAccessibleElement? { superview }
+}
+#endif
+#endif

--- a/packages/swift-optel/Sources/SwiftOptel/OptelClickCoordinator.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelClickCoordinator.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Coordinates click-beacon emission between the macOS global click monitor
+/// (``OptelClickMonitor``) and the SwiftUI refinement points
+/// (``OptelTapModifier``, ``OptelButton``) so a single user interaction never
+/// produces two `click` beacons.
+///
+/// Why an explicit coordinator: with default ``View/optelAutoInstrument(appID:rate:globalHooks:)``,
+/// the global `NSEvent` monitor is installed *and* refined controls still
+/// emit their own higher-quality `click` from explicit handlers. Without
+/// coordination, a single tap on an ``OptelButton`` produces two beacons —
+/// one from the monitor's accessibility-derived path and one from the
+/// button's wrapper. The coordinator solves that by letting the monitor
+/// *defer* its emission until after SwiftUI has finished dispatching the
+/// event, and letting refined handlers *claim* the in-flight monitor event
+/// so the deferred emission is skipped.
+///
+/// Lifecycle:
+/// 1. The monitor calls ``beginMonitorEvent()`` synchronously inside its
+///    `NSEvent` callback. This returns a monotonically-increasing epoch
+///    representing "the monitor would emit for this event".
+/// 2. The monitor schedules its `Optel.sample(.click, …)` call on
+///    `DispatchQueue.main.async` so it runs after the current event's
+///    synchronous dispatch (including SwiftUI gesture handlers) has
+///    completed.
+/// 3. Refined handlers call ``claimByRefined()`` *during* event dispatch
+///    (from inside `simultaneousGesture` or `Button(action:)`) right before
+///    emitting their own `click`. This records the latest pending epoch as
+///    "claimed".
+/// 4. When the monitor's deferred block fires, it consults
+///    ``wasClaimedByRefined(epoch:)`` for its own epoch. If claimed, the
+///    monitor skips emission so only the refined beacon ships.
+///
+/// On iOS (and any other platform without the global monitor), refined
+/// handlers still call ``claimByRefined()``; the claim is harmless because
+/// no monitor ever checks it.
+public enum OptelClickCoordinator {
+    private static let lock = NSLock()
+    private static var pendingEpoch: UInt64 = 0
+    private static var refinedClaimEpoch: UInt64?
+
+    /// Allocate a new epoch for an in-flight monitor event. Called
+    /// synchronously by ``OptelClickMonitor`` immediately before scheduling
+    /// the deferred emission.
+    @discardableResult
+    public static func beginMonitorEvent() -> UInt64 {
+        lock.lock(); defer { lock.unlock() }
+        pendingEpoch &+= 1
+        return pendingEpoch
+    }
+
+    /// Mark the currently-pending monitor event as absorbed by a refined
+    /// handler. Called by ``OptelTapModifier`` / ``OptelButton`` right before
+    /// they emit their own `click`.
+    public static func claimByRefined() {
+        lock.lock(); defer { lock.unlock() }
+        refinedClaimEpoch = pendingEpoch
+    }
+
+    /// Whether a refined handler claimed the supplied monitor `epoch`. Used
+    /// by the monitor's deferred emission to decide whether to skip.
+    public static func wasClaimedByRefined(epoch: UInt64) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return refinedClaimEpoch == epoch
+    }
+
+    /// Test-only reset of every counter and claim. Mirrors the install-latch
+    /// resets exposed by the other macOS hooks.
+    internal static func _testing_reset() {
+        lock.lock(); defer { lock.unlock() }
+        pendingEpoch = 0
+        refinedClaimEpoch = nil
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/OptelClickMonitor.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelClickMonitor.swift
@@ -122,9 +122,12 @@ public enum OptelClickMonitor {
     }
 
     /// Internal hook used by the `NSEvent` callback. Resolves the hit element
-    /// from the source window's content view, runs the decider, and emits
-    /// `click` when appropriate. Never throws and never returns a value: the
-    /// caller's `return event` keeps the click flowing to the responder chain.
+    /// from the source window's content view, runs the decider, and *defers*
+    /// the actual emit via ``OptelClickCoordinator`` so any refined handler
+    /// (`.optelTap`, ``OptelButton``) that fires during the same event
+    /// dispatch can claim the click and suppress this global emission.
+    /// Never throws and never returns a value: the caller's `return event`
+    /// keeps the click flowing to the responder chain.
     static func handle(event: NSEvent) {
         guard let window = event.window ?? NSApplication.shared.keyWindow,
             let contentView = window.contentView else {
@@ -136,7 +139,27 @@ public enum OptelClickMonitor {
         let hit = contentView.hitTest(event.locationInWindow)
         let decision = OptelClickEmitDecider.decide(for: hit)
         guard decision.shouldEmit else { return }
-        Optel.sample(.click, source: decision.source, target: decision.target)
+        // Allocate an epoch for this monitor event; refined SwiftUI handlers
+        // that run during the synchronous event dispatch can claim it. We
+        // schedule the emit via `DispatchQueue.main.async` so the deferred
+        // block runs after the responder chain (and therefore after any
+        // refined claim) has finished processing the event.
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        DispatchQueue.main.async {
+            OptelClickMonitor.deferredEmit(
+                epoch: epoch,
+                source: decision.source,
+                target: decision.target
+            )
+        }
+    }
+
+    /// Testable seam mirroring the body of the monitor's deferred async
+    /// block. Emits `click` only when the supplied epoch was *not* claimed
+    /// by a refined handler since ``handle(event:)`` scheduled it.
+    static func deferredEmit(epoch: UInt64, source: String?, target: String?) {
+        guard !OptelClickCoordinator.wasClaimedByRefined(epoch: epoch) else { return }
+        Optel.sample(.click, source: source, target: target)
     }
 
     /// Test-only reset of the install latch and any registered monitor.

--- a/packages/swift-optel/Sources/SwiftOptel/OptelClickMonitor.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelClickMonitor.swift
@@ -1,0 +1,147 @@
+#if os(macOS)
+import Foundation
+import AppKit
+
+/// Pure decision for "given an accessibility element under the mouse, should
+/// we emit a `click` beacon, and with what `source` / `target`?".
+///
+/// The macOS click monitor is intentionally a thin shell around this enum so
+/// the emit-or-skip rules (including the documented `optel-ignore` opt-out)
+/// are exercised by ordinary unit tests rather than by driving live AppKit
+/// events.
+public enum OptelClickEmitDecider {
+    /// Accessibility identifier marker that opts an element (and its entire
+    /// subtree) out of click emission. Set this as the `accessibilityIdentifier`
+    /// on any `NSView` whose interactions must not produce RUM beacons —
+    /// typically password fields or other PII-bearing controls. The opt-out is
+    /// inherited: if any ancestor along the hit-test chain carries this
+    /// marker, the click is skipped.
+    public static let ignoreIdentifier = "optel-ignore"
+
+    /// Result of evaluating a hit element. When `shouldEmit` is `false`, both
+    /// `source` and `target` are `nil`.
+    public struct Decision: Equatable, Sendable {
+        public let shouldEmit: Bool
+        public let source: String?
+        public let target: String?
+
+        public init(shouldEmit: Bool, source: String?, target: String?) {
+            self.shouldEmit = shouldEmit
+            self.source = source
+            self.target = target
+        }
+    }
+
+    /// Skip-decision used when there's nothing to emit (nil element, opt-out
+    /// marker present, etc.).
+    public static let skip = Decision(shouldEmit: false, source: nil, target: nil)
+
+    /// Decide whether to emit `click` for `element`. Returns ``skip`` when:
+    /// - `element` is `nil` (hit-test failed or no key window),
+    /// - `element` (or any ancestor up to ``OptelAccessibilityDeriver/maxAncestorDepth``)
+    ///   carries the ``ignoreIdentifier`` opt-out marker.
+    ///
+    /// Otherwise delegates to ``OptelAccessibilityDeriver/derive(from:)`` and
+    /// returns an emit decision with the derived `source` / `target`.
+    public static func decide(for element: OptelAccessibleElement?) -> Decision {
+        guard let element else { return skip }
+        if hasIgnoreMarker(in: element) { return skip }
+        let derived = OptelAccessibilityDeriver.derive(from: element)
+        return Decision(shouldEmit: true, source: derived.source, target: derived.target)
+    }
+
+    /// Walks the ancestor chain looking for the ``ignoreIdentifier`` marker
+    /// on any element's `optelAccessibilityIdentifier`. Whitespace-only
+    /// identifiers are treated as absent (matching the deriver's policy).
+    static func hasIgnoreMarker(in element: OptelAccessibleElement) -> Bool {
+        var current: OptelAccessibleElement? = element
+        var depth = 0
+        while let node = current, depth < OptelAccessibilityDeriver.maxAncestorDepth {
+            if let identifier = node.optelAccessibilityIdentifier?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                identifier == ignoreIdentifier {
+                return true
+            }
+            current = node.optelAccessibilityParent
+            depth += 1
+        }
+        return false
+    }
+}
+
+/// macOS-only app-level click monitor. Installs a single
+/// `NSEvent.addLocalMonitorForEvents(matching: [.leftMouseUp])` handler that
+/// hit-tests the source window's content view, runs ``OptelClickEmitDecider``,
+/// and emits a `click` beacon via ``Optel/sample(_:source:target:value:)`` for
+/// non-opt-out elements. The monitor **always returns the event unmodified**
+/// so clicks are never swallowed.
+///
+/// Install/uninstall is idempotent; a second `installIfNeeded()` is a no-op,
+/// and `uninstall()` is safe to call when nothing is installed. The actual
+/// emit/skip decision lives in ``OptelClickEmitDecider`` so the rules are
+/// unit-tested in pure Swift without a running app.
+public enum OptelClickMonitor {
+    private static let lock = NSLock()
+    private static var installed = false
+    private static var monitor: Any?
+
+    /// `true` once the monitor has been installed for this process.
+    public static var isInstalled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return installed
+    }
+
+    /// Install the local `.leftMouseUp` monitor. Safe to call repeatedly; the
+    /// second and subsequent calls are no-ops so the monitor is never retained
+    /// twice.
+    public static func installIfNeeded() {
+        lock.lock()
+        guard !installed else {
+            lock.unlock()
+            return
+        }
+        installed = true
+        let token = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseUp]) { event in
+            OptelClickMonitor.handle(event: event)
+            return event
+        }
+        monitor = token
+        lock.unlock()
+    }
+
+    /// Remove the installed monitor. Safe to call when nothing is installed.
+    public static func uninstall() {
+        lock.lock()
+        let token = monitor
+        monitor = nil
+        installed = false
+        lock.unlock()
+        if let token {
+            NSEvent.removeMonitor(token)
+        }
+    }
+
+    /// Internal hook used by the `NSEvent` callback. Resolves the hit element
+    /// from the source window's content view, runs the decider, and emits
+    /// `click` when appropriate. Never throws and never returns a value: the
+    /// caller's `return event` keeps the click flowing to the responder chain.
+    static func handle(event: NSEvent) {
+        guard let window = event.window ?? NSApplication.shared.keyWindow,
+            let contentView = window.contentView else {
+            return
+        }
+        // `hitTest(_:)` expects the point in the receiver's *superview*
+        // coordinates; for the content view that superview is the window, so
+        // `event.locationInWindow` is already in the right space.
+        let hit = contentView.hitTest(event.locationInWindow)
+        let decision = OptelClickEmitDecider.decide(for: hit)
+        guard decision.shouldEmit else { return }
+        Optel.sample(.click, source: decision.source, target: decision.target)
+    }
+
+    /// Test-only reset of the install latch and any registered monitor.
+    internal static func _testing_reset() {
+        uninstall()
+    }
+}
+#endif

--- a/packages/swift-optel/Sources/SwiftOptel/OptelEnvConfig.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelEnvConfig.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Pure resolvers for environment-variable overrides honored by ``Optel``.
+///
+/// Two override knobs are recognized:
+///
+/// - `OPTEL_RATE` — overrides the sampling rate passed to ``Optel/configure``.
+///   When present and non-empty, this value wins over the explicit `rate:`
+///   argument. Accepts the same values as ``SamplingConfig/init(rate:)`` (the
+///   `on`/`off`/`high`/`low` aliases; anything else falls back to the default
+///   weight of `100`). This is the native analogue of the `?rum=on` URL knob
+///   in `helix-rum-js` — set `OPTEL_RATE=on` to force 100% sampling at
+///   runtime without rebuilding.
+///
+/// - `OPTEL_DEBUG` — when set to a truthy value (`1`/`true`/`on`/`yes`,
+///   case-insensitive), enables wire-level `os.Logger` logging in the default
+///   ``URLSessionOptelTransport`` (request URL, payload size, HTTP status).
+///   Default off → no logging, no behavior change.
+///
+/// The resolvers are intentionally pure: they take an injected
+/// `[String: String]` environment dictionary so they can be unit-tested
+/// without mutating `ProcessInfo`. The non-pure call site in
+/// ``Optel/configure(appID:rate:collectBaseURL:transport:randomSource:)``
+/// simply passes `ProcessInfo.processInfo.environment`.
+public enum OptelEnvConfig {
+    /// Environment variable name for the sampling-rate override.
+    public static let rateKey = "OPTEL_RATE"
+
+    /// Environment variable name for the debug-logging flag.
+    public static let debugKey = "OPTEL_DEBUG"
+
+    /// Resolve the effective sampling rate string. The env override takes
+    /// precedence when present and non-empty; otherwise the explicit value is
+    /// returned unchanged (which may itself be `nil`, yielding the default
+    /// weight downstream in ``SamplingConfig/init(rate:)``).
+    public static func resolveRate(
+        explicit: String?,
+        environment: [String: String]
+    ) -> String? {
+        if let envRate = environment[rateKey], !envRate.isEmpty {
+            return envRate
+        }
+        return explicit
+    }
+
+    /// Resolve the debug-logging flag from the environment. Truthy values are
+    /// `1`/`true`/`on`/`yes` (case-insensitive); any other value (including
+    /// `0`/`false`/`off`/`no`, empty, or missing key) returns `false`.
+    public static func resolveDebugLogging(environment: [String: String]) -> Bool {
+        guard let value = environment[debugKey] else { return false }
+        switch value.lowercased() {
+        case "1", "true", "on", "yes": return true
+        default: return false
+        }
+    }
+}

--- a/packages/swift-optel/Sources/SwiftOptel/OptelSwiftUI.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelSwiftUI.swift
@@ -10,8 +10,22 @@ extension View {
     /// `enter` checkpoint on launch, re-fires `enter` whenever the scene
     /// returns to `.active` from `.background`, and installs the best-effort
     /// uncaught Objective-C exception hook.
-    public func optelAutoInstrument(appID: String, rate: String? = nil) -> some View {
-        modifier(OptelAutoInstrumentModifier(appID: appID, rate: rate))
+    ///
+    /// On macOS, when `globalHooks` is `true` (the default), the app-level
+    /// click monitor (``OptelClickMonitor``) and the key/main-window observer
+    /// (``OptelWindowObserver``) are also installed so the app gets `click`
+    /// and `navigate` beacons for free. Pass `globalHooks: false` to opt out
+    /// of every install-once global hook (including the cross-platform
+    /// uncaught-exception hook) without removing the modifier — useful in
+    /// tests or apps that drive their own beacons manually.
+    public func optelAutoInstrument(
+        appID: String,
+        rate: String? = nil,
+        globalHooks: Bool = true
+    ) -> some View {
+        modifier(
+            OptelAutoInstrumentModifier(appID: appID, rate: rate, globalHooks: globalHooks)
+        )
     }
 
     /// Per-view instrumentation. Emits a `navigate` checkpoint with `source`
@@ -35,6 +49,7 @@ public struct OptelAutoInstrumentModifier: ViewModifier {
     @Environment(\.scenePhase) private var scenePhase
     let appID: String
     let rate: String?
+    let globalHooks: Bool
     @State private var configured = false
     // Sticky "has been backgrounded" flag. SwiftUI scene transitions go
     // `.background → .inactive → .active`, so we cannot infer "was just
@@ -46,9 +61,11 @@ public struct OptelAutoInstrumentModifier: ViewModifier {
         content
             .task {
                 guard !configured else { return }
-                Optel.configure(appID: appID, rate: rate)
-                OptelUncaughtExceptionHook.installIfNeeded()
-                Optel.sample(.enter)
+                OptelAutoInstrumentModifier.performInstall(
+                    appID: appID,
+                    rate: rate,
+                    globalHooks: globalHooks
+                )
                 configured = true
             }
             .onChange(of: scenePhase) { newPhase in
@@ -78,7 +95,64 @@ public struct OptelAutoInstrumentModifier: ViewModifier {
         }
         return (false, wasBackgrounded)
     }
+
+    /// Testable seam mirroring the modifier's `.task` body. Configures
+    /// ``Optel``, installs the requested global hooks (each underlying hook
+    /// is itself idempotent via its own install latch), and fires the
+    /// initial `enter` checkpoint. On macOS, `globalHooks: true` additionally
+    /// installs the click monitor and the window observer; on every platform
+    /// it installs the uncaught-exception hook. `globalHooks: false` skips
+    /// every install-once hook (the `enter` checkpoint still fires).
+    static func performInstall(
+        appID: String,
+        rate: String?,
+        globalHooks: Bool
+    ) {
+        Optel.configure(appID: appID, rate: rate)
+        if globalHooks {
+            OptelUncaughtExceptionHook.installIfNeeded()
+            #if os(macOS)
+            OptelMacAutoInstrument.installIfNeeded()
+            #endif
+        }
+        Optel.sample(.enter)
+    }
 }
+
+#if os(macOS)
+/// Grouping helper for the macOS-only global hooks installed by
+/// ``View/optelAutoInstrument(appID:rate:globalHooks:)``. Delegates to the
+/// underlying ``OptelClickMonitor`` and ``OptelWindowObserver``, which both
+/// guard their own state with an install latch, so calling
+/// ``installIfNeeded()`` twice is a no-op.
+@available(macOS 13.0, *)
+public enum OptelMacAutoInstrument {
+    /// `true` once both macOS hooks have been installed for this process.
+    public static var isInstalled: Bool {
+        OptelClickMonitor.isInstalled && OptelWindowObserver.isInstalled
+    }
+
+    /// Install the macOS click monitor and window observer. Each call is
+    /// idempotent at the individual-hook level, so remounting the root view
+    /// never registers a second monitor or observer.
+    public static func installIfNeeded() {
+        OptelClickMonitor.installIfNeeded()
+        OptelWindowObserver.installIfNeeded()
+    }
+
+    /// Remove both hooks. Safe to call when nothing is installed.
+    public static func uninstall() {
+        OptelClickMonitor.uninstall()
+        OptelWindowObserver.uninstall()
+    }
+
+    /// Test-only reset of the install latches for both macOS hooks.
+    internal static func _testing_reset() {
+        OptelClickMonitor._testing_reset()
+        OptelWindowObserver._testing_reset()
+    }
+}
+#endif
 
 @available(iOS 16.0, macOS 13.0, *)
 public struct OptelViewModifier: ViewModifier {

--- a/packages/swift-optel/Sources/SwiftOptel/OptelSwiftUI.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelSwiftUI.swift
@@ -171,8 +171,16 @@ public struct OptelTapModifier: ViewModifier {
 
     public func body(content: Content) -> some View {
         content.simultaneousGesture(TapGesture().onEnded {
-            Optel.sample(.click, source: source)
+            OptelTapModifier.performTap(source: source)
         })
+    }
+
+    /// Testable seam mirroring the gesture's `onEnded` body. Claims the
+    /// in-flight global-monitor click (so the monitor's deferred emission
+    /// is skipped on macOS) and emits the refined `click` beacon.
+    static func performTap(source: String) {
+        OptelClickCoordinator.claimByRefined()
+        Optel.sample(.click, source: source)
     }
 }
 
@@ -209,15 +217,27 @@ public struct OptelButton<Label: View>: View {
 
     public var body: some View {
         Button(action: {
-            let derived = OptelSourceDeriver.source(
-                element: "button",
+            OptelButton<Label>.performTap(
                 identifier: identifier,
                 label: accessibilityLabel,
                 context: context
             )
-            Optel.sample(.click, source: derived)
             action()
         }, label: labelBuilder)
+    }
+
+    /// Testable seam mirroring the button's action body. Derives the refined
+    /// `source`, claims the in-flight global-monitor click (so the monitor's
+    /// deferred emission is skipped on macOS), and emits the `click` beacon.
+    static func performTap(identifier: String?, label: String?, context: String?) {
+        let derived = OptelSourceDeriver.source(
+            element: "button",
+            identifier: identifier,
+            label: label,
+            context: context
+        )
+        OptelClickCoordinator.claimByRefined()
+        Optel.sample(.click, source: derived)
     }
 }
 

--- a/packages/swift-optel/Sources/SwiftOptel/OptelTransport.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelTransport.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(os)
+import os
+#endif
 
 /// Fire-and-forget beacon transport. Implementations send a single
 /// ``RUMEvent`` to the collector identified by `collectBaseURL` and must
@@ -18,27 +21,49 @@ public protocol OptelTransport: Sendable {
 /// - The returned `URLSessionDataTask` is resumed and discarded; any
 ///   transport / decode error from the completion handler is silently
 ///   dropped.
+///
+/// When `debugLogging` is enabled (via ``OptelEnvConfig`` honoring
+/// `OPTEL_DEBUG`, or the explicit init parameter) every beacon is logged to
+/// `os.Logger` with the request URL, payload byte count, and (on response)
+/// HTTP status code. Default off — no logging, no behavior change.
 public final class URLSessionOptelTransport: OptelTransport {
     /// Default per-request timeout. Beacons are best-effort, so a short
     /// window is preferable to letting requests pile up.
     public static let defaultTimeout: TimeInterval = 10
 
+    /// Subsystem used for `os.Logger` wire logging when `debugLogging` is on.
+    public static let loggerSubsystem = "com.slicc.swift-optel"
+
+    /// Category used for `os.Logger` wire logging when `debugLogging` is on.
+    public static let loggerCategory = "transport"
+
     private let session: URLSession
     private let timeout: TimeInterval
     private let encoder: JSONEncoder
+    #if canImport(os)
+    private let logger: Logger?
+    #endif
 
     /// Construct a transport.
     ///
     /// - Parameters:
     ///   - session: Override for testing; defaults to an ephemeral session.
     ///   - timeout: Per-request timeout in seconds.
+    ///   - debugLogging: When `true`, emit `os.Logger` entries for every
+    ///     beacon (URL, payload size, response status). Default `false`.
     public init(
         session: URLSession = URLSessionOptelTransport.makeDefaultSession(),
-        timeout: TimeInterval = URLSessionOptelTransport.defaultTimeout
+        timeout: TimeInterval = URLSessionOptelTransport.defaultTimeout,
+        debugLogging: Bool = false
     ) {
         self.session = session
         self.timeout = timeout
         self.encoder = JSONEncoder()
+        #if canImport(os)
+        self.logger = debugLogging
+            ? Logger(subsystem: Self.loggerSubsystem, category: Self.loggerCategory)
+            : nil
+        #endif
     }
 
     public func send(_ event: RUMEvent, collectBaseURL: URL) {
@@ -50,11 +75,28 @@ public final class URLSessionOptelTransport: OptelTransport {
         ) else {
             return
         }
+        #if canImport(os)
+        let logger = self.logger
+        let urlString = request.url?.absoluteString ?? "<unknown>"
+        let bodySize = request.httpBody?.count ?? 0
+        logger?.debug("optel beacon → \(urlString, privacy: .public) (\(bodySize) bytes)")
+        let task = session.dataTask(with: request) { _, response, _ in
+            // Fire-and-forget: beacon failures are non-actionable; never
+            // propagate them back to the caller. This is the Swift analogue
+            // of the JS `.catch(() => {})` swallow.
+            if let http = response as? HTTPURLResponse {
+                logger?.debug(
+                    "optel beacon ← \(urlString, privacy: .public) status=\(http.statusCode)"
+                )
+            }
+        }
+        #else
         let task = session.dataTask(with: request) { _, _, _ in
             // Fire-and-forget: beacon failures are non-actionable; never
             // propagate them back to the caller. This is the Swift analogue
             // of the JS `.catch(() => {})` swallow.
         }
+        #endif
         task.resume()
     }
 

--- a/packages/swift-optel/Sources/SwiftOptel/OptelWindowObserver.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelWindowObserver.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+/// Identity + display source for a window candidate, in a form that does not
+/// depend on AppKit so the dedupe logic can be unit-tested on every platform.
+///
+/// `key` is the stable identity used to decide "same window vs. different
+/// window" — re-focusing the same window must not emit `navigate`. `source` is
+/// the human-facing string carried as the beacon's `source` field; preferring
+/// the window title when available falls back to the accessibility identifier.
+public struct OptelWindowIdentity: Equatable, Hashable, Sendable {
+    public let key: String
+    public let source: String
+
+    public init(key: String, source: String) {
+        self.key = key
+        self.source = source
+    }
+
+    /// Compose an identity from the raw bits AppKit gives us on macOS. Exposed
+    /// at module scope so tests can synthesize identities without an `NSWindow`.
+    ///
+    /// - Parameters:
+    ///   - identifier: `NSWindow.identifier?.rawValue` (or `nil`).
+    ///   - title: `NSWindow.title` (may be empty).
+    ///   - fallbackKey: Stable per-window fallback (e.g. `ObjectIdentifier`
+    ///     hash) used when both identifier and title are blank. Required so
+    ///     two distinct, equally-blank windows are not collapsed into one.
+    public static func make(
+        identifier: String?,
+        title: String?,
+        fallbackKey: String
+    ) -> OptelWindowIdentity {
+        let trimmedID = identifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let trimmedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        let key: String
+        if !trimmedID.isEmpty {
+            key = "id:\(trimmedID)"
+        } else if !trimmedTitle.isEmpty {
+            key = "title:\(trimmedTitle)"
+        } else {
+            key = "ref:\(fallbackKey)"
+        }
+
+        let source: String
+        if !trimmedTitle.isEmpty {
+            source = trimmedTitle
+        } else if !trimmedID.isEmpty {
+            source = trimmedID
+        } else {
+            source = "window"
+        }
+
+        return OptelWindowIdentity(key: key, source: source)
+    }
+}
+
+/// Pure decision for "should this key/main change emit a `navigate` beacon?".
+///
+/// The macOS observer is intentionally a thin shell around this enum so the
+/// dedupe rules are exercised by ordinary unit tests rather than by driving a
+/// live `NSApplication` event loop.
+public enum OptelWindowNavigateDecider {
+    public struct Decision: Equatable, Sendable {
+        public let shouldEmit: Bool
+        public let source: String?
+
+        public init(shouldEmit: Bool, source: String?) {
+            self.shouldEmit = shouldEmit
+            self.source = source
+        }
+    }
+
+    /// Decide whether to emit `navigate` given the previously-seen identity
+    /// (or `nil` for the first observation) and the newly-focused identity.
+    public static func decide(
+        previous: OptelWindowIdentity?,
+        current: OptelWindowIdentity
+    ) -> Decision {
+        if let previous, previous.key == current.key {
+            return Decision(shouldEmit: false, source: nil)
+        }
+        return Decision(shouldEmit: true, source: current.source)
+    }
+}
+
+#if os(macOS)
+import AppKit
+
+/// macOS-only observer that watches for key/main window changes and emits
+/// `navigate` beacons whenever focus moves to a *different* window.
+///
+/// Install/uninstall is idempotent; the dedupe state is reset on uninstall so
+/// the next install starts fresh. The actual emit/skip decision is delegated
+/// to ``OptelWindowNavigateDecider`` so the behavior is unit-tested in pure
+/// Swift without requiring a running app.
+public enum OptelWindowObserver {
+    private static let lock = NSLock()
+    private static var installed = false
+    private static var observers: [NSObjectProtocol] = []
+    private static var lastIdentity: OptelWindowIdentity?
+
+    /// `true` once the observer has been installed for this process.
+    public static var isInstalled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return installed
+    }
+
+    /// Install observers for `NSWindow.didBecomeKeyNotification` and
+    /// `didBecomeMainNotification`. Safe to call repeatedly; the second and
+    /// subsequent calls are no-ops.
+    public static func installIfNeeded() {
+        lock.lock()
+        guard !installed else {
+            lock.unlock()
+            return
+        }
+        installed = true
+        let center = NotificationCenter.default
+        let names: [Notification.Name] = [
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didBecomeMainNotification,
+        ]
+        for name in names {
+            let token = center.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { notification in
+                guard let window = notification.object as? NSWindow else { return }
+                OptelWindowObserver.handle(window: window)
+            }
+            observers.append(token)
+        }
+        lock.unlock()
+    }
+
+    /// Remove the installed observers and reset dedupe state. Safe to call
+    /// when nothing is installed.
+    public static func uninstall() {
+        lock.lock()
+        let toRemove = observers
+        observers.removeAll()
+        lastIdentity = nil
+        installed = false
+        lock.unlock()
+        let center = NotificationCenter.default
+        for token in toRemove {
+            center.removeObserver(token)
+        }
+    }
+
+    /// Internal hook used by the notification handlers. Runs the identity +
+    /// decider seam against the supplied window and emits when appropriate.
+    static func handle(window: NSWindow) {
+        let identity = identity(for: window)
+        let decision: OptelWindowNavigateDecider.Decision
+        lock.lock()
+        decision = OptelWindowNavigateDecider.decide(
+            previous: lastIdentity,
+            current: identity
+        )
+        lastIdentity = identity
+        lock.unlock()
+        if decision.shouldEmit, let source = decision.source {
+            Optel.sample(.navigate, source: source)
+        }
+    }
+
+    /// Build an ``OptelWindowIdentity`` for an `NSWindow`. Extracted so tests
+    /// can construct equivalent identities without instantiating AppKit.
+    static func identity(for window: NSWindow) -> OptelWindowIdentity {
+        OptelWindowIdentity.make(
+            identifier: window.identifier?.rawValue,
+            title: window.title,
+            fallbackKey: String(ObjectIdentifier(window).hashValue)
+        )
+    }
+
+    /// Test-only reset of the install latch and dedupe state. Removes any
+    /// currently-registered notification observers.
+    internal static func _testing_reset() {
+        uninstall()
+    }
+}
+#endif

--- a/packages/swift-optel/Sources/SwiftOptel/OptelWindowObserver.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/OptelWindowObserver.swift
@@ -23,8 +23,12 @@ public struct OptelWindowIdentity: Equatable, Hashable, Sendable {
     ///   - identifier: `NSWindow.identifier?.rawValue` (or `nil`).
     ///   - title: `NSWindow.title` (may be empty).
     ///   - fallbackKey: Stable per-window fallback (e.g. `ObjectIdentifier`
-    ///     hash) used when both identifier and title are blank. Required so
-    ///     two distinct, equally-blank windows are not collapsed into one.
+    ///     hash). Required because two distinct windows can share the same
+    ///     title (duplicate document/utility windows), so the title alone is
+    ///     not a unique key. Whenever there is no explicit identifier, the
+    ///     fallback is folded into the key so distinct window objects always
+    ///     get distinct keys while re-focusing the same window object still
+    ///     resolves to the same key.
     public static func make(
         identifier: String?,
         title: String?,
@@ -37,7 +41,10 @@ public struct OptelWindowIdentity: Equatable, Hashable, Sendable {
         if !trimmedID.isEmpty {
             key = "id:\(trimmedID)"
         } else if !trimmedTitle.isEmpty {
-            key = "title:\(trimmedTitle)"
+            // Title alone is not unique — two windows can carry the same
+            // title — so fold in the per-window `fallbackKey` to keep distinct
+            // windows distinct while preserving stability across re-focus.
+            key = "title:\(trimmedTitle)#ref:\(fallbackKey)"
         } else {
             key = "ref:\(fallbackKey)"
         }

--- a/packages/swift-optel/Sources/SwiftOptel/SwiftOptel.swift
+++ b/packages/swift-optel/Sources/SwiftOptel/SwiftOptel.swift
@@ -2,8 +2,11 @@ import Foundation
 
 /// Placeholder entry point for the SwiftOptel library.
 ///
-/// The real RUM / OpenTelemetry surface is implemented in later tasks; this
-/// type only exists so the package has something to build and test against.
+/// OpTel = Operational Telemetry — Adobe's RUM-style operational telemetry;
+/// not to be confused with OpenTelemetry (OTel).
+///
+/// The real RUM / Operational Telemetry surface is implemented in later tasks;
+/// this type only exists so the package has something to build and test against.
 public enum SwiftOptel {
     /// Package version string. Bumped manually when the surface stabilizes.
     public static let version = "0.0.0"

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelAccessibilityDeriverTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelAccessibilityDeriverTests.swift
@@ -1,0 +1,135 @@
+#if os(macOS)
+import XCTest
+@testable import SwiftOptel
+
+/// Pure value-type fake so the deriver can be exercised without a running app.
+private final class FakeElement: OptelAccessibleElement {
+    var optelAccessibilityRole: String?
+    var optelAccessibilityIdentifier: String?
+    var optelAccessibilityLabel: String?
+    var optelAccessibilityWindowTitle: String?
+    var optelAccessibilityParent: OptelAccessibleElement?
+
+    init(
+        role: String? = nil,
+        identifier: String? = nil,
+        label: String? = nil,
+        windowTitle: String? = nil,
+        parent: OptelAccessibleElement? = nil
+    ) {
+        self.optelAccessibilityRole = role
+        self.optelAccessibilityIdentifier = identifier
+        self.optelAccessibilityLabel = label
+        self.optelAccessibilityWindowTitle = windowTitle
+        self.optelAccessibilityParent = parent
+    }
+}
+
+final class OptelAccessibilityDeriverTests: XCTestCase {
+    func testIdentifierWinsOverLabel() {
+        let hit = FakeElement(role: "button", identifier: "submit", label: "Submit")
+        let derived = OptelAccessibilityDeriver.derive(from: hit)
+        XCTAssertEqual(derived.source, "button#submit")
+        XCTAssertEqual(derived.target, "Submit")
+    }
+
+    func testLabelFallbackWhenNoIdentifier() {
+        let hit = FakeElement(role: "button", label: "Buy")
+        let derived = OptelAccessibilityDeriver.derive(from: hit)
+        XCTAssertEqual(derived.source, "button \"Buy\"")
+        XCTAssertEqual(derived.target, "Buy")
+    }
+
+    func testRoleOnlyFallback() {
+        let hit = FakeElement(role: "slider")
+        let derived = OptelAccessibilityDeriver.derive(from: hit)
+        XCTAssertEqual(derived.source, "slider")
+        XCTAssertNil(derived.target)
+    }
+
+    func testWindowTitleProvidesContext() {
+        let window = FakeElement(windowTitle: "Settings")
+        let hit = FakeElement(role: "button", identifier: "ok", parent: window)
+        let derived = OptelAccessibilityDeriver.derive(from: hit)
+        XCTAssertEqual(derived.source, "Settings button#ok")
+        XCTAssertNil(derived.target)
+    }
+
+    func testWindowTitleFromHitElementDirectly() {
+        let hit = FakeElement(role: "button", label: "Close", windowTitle: "Document")
+        let derived = OptelAccessibilityDeriver.derive(from: hit)
+        XCTAssertEqual(derived.source, "Document button \"Close\"")
+        XCTAssertEqual(derived.target, "Close")
+    }
+
+    func testWalksPastGenericContainerToMeaningfulAncestor() {
+        let window = FakeElement(windowTitle: "Main")
+        let button = FakeElement(role: "AXButton", identifier: "save", parent: window)
+        let group = FakeElement(role: "AXGroup", parent: button)
+        let unknown = FakeElement(role: "AXUnknown", parent: group)
+        let derived = OptelAccessibilityDeriver.derive(from: unknown)
+        XCTAssertEqual(derived.source, "Main AXButton#save")
+    }
+
+    func testFallsBackToHitElementWhenNothingMeaningful() {
+        let chain = FakeElement(role: "AXGroup", parent: FakeElement(role: "AXUnknown"))
+        let derived = OptelAccessibilityDeriver.derive(from: chain)
+        XCTAssertEqual(derived.source, "AXGroup")
+        XCTAssertNil(derived.target)
+    }
+
+    func testHitElementWithNothingAndNoAncestorsYieldsViewFallback() {
+        let hit = FakeElement()
+        let derived = OptelAccessibilityDeriver.derive(from: hit)
+        XCTAssertEqual(derived.source, "view")
+        XCTAssertNil(derived.target)
+    }
+
+    func testWhitespaceOnlyFieldsAreTreatedAsAbsent() {
+        let window = FakeElement(windowTitle: "   ")
+        let hit = FakeElement(
+            role: "button",
+            identifier: "  ",
+            label: " Save ",
+            parent: window
+        )
+        let derived = OptelAccessibilityDeriver.derive(from: hit)
+        XCTAssertEqual(derived.source, "button \"Save\"")
+        XCTAssertEqual(derived.target, "Save")
+    }
+
+    func testEmptyStringRoleFallsBackToView() {
+        let hit = FakeElement(role: "", identifier: "x")
+        let derived = OptelAccessibilityDeriver.derive(from: hit)
+        XCTAssertEqual(derived.source, "view#x")
+    }
+
+    func testWindowTitleWalksOnlyUntilFirstNonEmpty() {
+        let outer = FakeElement(windowTitle: "Outer")
+        let middle = FakeElement(windowTitle: "Inner", parent: outer)
+        let hit = FakeElement(role: "button", identifier: "go", parent: middle)
+        let derived = OptelAccessibilityDeriver.derive(from: hit)
+        XCTAssertEqual(derived.source, "Inner button#go")
+    }
+
+    func testDepthCapPreventsRunawayWalk() {
+        // Build a chain longer than the cap; only the deepest node is meaningful.
+        let leaf = FakeElement(role: "button", identifier: "deep")
+        var current: OptelAccessibleElement = leaf
+        for _ in 0..<(OptelAccessibilityDeriver.maxAncestorDepth + 10) {
+            current = FakeElement(role: "AXGroup", parent: current)
+        }
+        let derived = OptelAccessibilityDeriver.derive(from: current)
+        // The deep meaningful node is beyond the cap, so the deriver falls
+        // back to the hit element itself (a generic group, role-only source).
+        XCTAssertEqual(derived.source, "AXGroup")
+    }
+
+    func testMeaningfulnessIgnoresGenericRolesButHonorsIdentifier() {
+        let containerWithID = FakeElement(role: "AXGroup", identifier: "toolbar")
+        XCTAssertTrue(OptelAccessibilityDeriver.isMeaningful(containerWithID))
+        let bareGroup = FakeElement(role: "AXGroup")
+        XCTAssertFalse(OptelAccessibilityDeriver.isMeaningful(bareGroup))
+    }
+}
+#endif

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelClickCoordinatorTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelClickCoordinatorTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import SwiftOptel
+
+final class OptelClickCoordinatorTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        OptelClickCoordinator._testing_reset()
+    }
+
+    override func tearDown() {
+        OptelClickCoordinator._testing_reset()
+        super.tearDown()
+    }
+
+    func testEpochsAreMonotonicallyIncreasing() {
+        let first = OptelClickCoordinator.beginMonitorEvent()
+        let second = OptelClickCoordinator.beginMonitorEvent()
+        let third = OptelClickCoordinator.beginMonitorEvent()
+        XCTAssertLessThan(first, second)
+        XCTAssertLessThan(second, third)
+    }
+
+    func testClaimByRefinedMarksLatestEpochAsClaimed() {
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        OptelClickCoordinator.claimByRefined()
+        XCTAssertTrue(OptelClickCoordinator.wasClaimedByRefined(epoch: epoch))
+    }
+
+    func testUnclaimedEpochReportsAsNotClaimed() {
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        XCTAssertFalse(OptelClickCoordinator.wasClaimedByRefined(epoch: epoch))
+    }
+
+    func testClaimAppliesOnlyToCurrentPendingEpoch() {
+        // A refined claim only marks the most-recent pending monitor event;
+        // an older monitor epoch from a prior event is NOT collapsed into the
+        // same claim, so its deferred emit will still fire.
+        let older = OptelClickCoordinator.beginMonitorEvent()
+        _ = OptelClickCoordinator.beginMonitorEvent()
+        OptelClickCoordinator.claimByRefined()
+        XCTAssertFalse(OptelClickCoordinator.wasClaimedByRefined(epoch: older))
+    }
+
+    func testClaimWithoutPriorMonitorEventDoesNotPoisonFutureEpochs() {
+        // A refined fire that happens with no in-flight monitor event (the
+        // monitor is not installed, or the click was on `optel-ignore`) must
+        // not cause the NEXT real monitor event's deferred emit to be
+        // suppressed.
+        OptelClickCoordinator.claimByRefined()
+        let nextEpoch = OptelClickCoordinator.beginMonitorEvent()
+        XCTAssertFalse(OptelClickCoordinator.wasClaimedByRefined(epoch: nextEpoch))
+    }
+
+    func testTestingResetClearsPendingAndClaim() {
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        OptelClickCoordinator.claimByRefined()
+        XCTAssertTrue(OptelClickCoordinator.wasClaimedByRefined(epoch: epoch))
+        OptelClickCoordinator._testing_reset()
+        let reset = OptelClickCoordinator.beginMonitorEvent()
+        XCTAssertFalse(OptelClickCoordinator.wasClaimedByRefined(epoch: epoch))
+        XCTAssertFalse(OptelClickCoordinator.wasClaimedByRefined(epoch: reset))
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelClickMonitorTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelClickMonitorTests.swift
@@ -135,5 +135,73 @@ final class OptelClickMonitorTests: XCTestCase {
         OptelClickMonitor.uninstall()
         XCTAssertFalse(OptelClickMonitor.isInstalled)
     }
+
+    // MARK: - Refined-vs-monitor dedupe (deferredEmit)
+
+    /// Deterministic ``RandomSource`` for pinning sample selection in the
+    /// dedupe regression tests below.
+    private struct FixedRandom: RandomSource {
+        let value: Double
+        func nextUnitDouble() -> Double { value }
+    }
+
+    private func makeRecordingOptel() -> RecordingTransport {
+        let transport = RecordingTransport()
+        Optel.shared.configure(
+            appID: "com.example.app",
+            rate: "on",
+            collectBaseURL: URL(string: "https://rum.hlx.page/")!,
+            transport: transport,
+            randomSource: FixedRandom(value: 0)
+        )
+        return transport
+    }
+
+    func testDeferredEmitFiresWhenNoRefinedClaim() {
+        OptelClickCoordinator._testing_reset()
+        let transport = makeRecordingOptel()
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        // No refined claim: the monitor's deferred emission ships.
+        OptelClickMonitor.deferredEmit(epoch: epoch, source: "Main button#go", target: "Go")
+        let clicks = transport.sent.filter { $0.event.checkpoint.rawValue == "click" }
+        XCTAssertEqual(clicks.count, 1)
+        XCTAssertEqual(clicks.first?.event.pingData.source, "Main button#go")
+        XCTAssertEqual(clicks.first?.event.pingData.target, "Go")
+    }
+
+    func testDeferredEmitIsSkippedWhenRefinedClaimsTheEpoch() {
+        // Simulates a real user interaction: the global monitor schedules a
+        // click for an in-flight event, a refined SwiftUI handler runs and
+        // claims that event during synchronous dispatch, then the deferred
+        // monitor block fires. Only the refined beacon must ship.
+        OptelClickCoordinator._testing_reset()
+        let transport = makeRecordingOptel()
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        OptelClickCoordinator.claimByRefined()
+        // Refined handler does its own `Optel.sample(.click, …)` separately;
+        // here we emulate that explicit emit so the assertion exercises the
+        // end-to-end "exactly one click on the wire" contract.
+        Optel.sample(.click, source: "panel button#submit")
+        OptelClickMonitor.deferredEmit(epoch: epoch, source: "ax-derived", target: "Submit")
+        let clicks = transport.sent.filter { $0.event.checkpoint.rawValue == "click" }
+        XCTAssertEqual(clicks.count, 1)
+        XCTAssertEqual(clicks.first?.event.pingData.source, "panel button#submit")
+    }
+
+    func testDeferredEmitFiresForUnrelatedSubsequentEvent() {
+        // After a refined claim absorbs one monitor event, the *next* monitor
+        // event must still emit (its epoch is fresh and unclaimed). This is
+        // the regression for "stale claim suppresses everything forever".
+        OptelClickCoordinator._testing_reset()
+        let transport = makeRecordingOptel()
+        let firstEpoch = OptelClickCoordinator.beginMonitorEvent()
+        OptelClickCoordinator.claimByRefined()
+        OptelClickMonitor.deferredEmit(epoch: firstEpoch, source: "a", target: nil)
+        let secondEpoch = OptelClickCoordinator.beginMonitorEvent()
+        OptelClickMonitor.deferredEmit(epoch: secondEpoch, source: "b", target: nil)
+        let clicks = transport.sent.filter { $0.event.checkpoint.rawValue == "click" }
+        XCTAssertEqual(clicks.count, 1)
+        XCTAssertEqual(clicks.first?.event.pingData.source, "b")
+    }
 }
 #endif

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelClickMonitorTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelClickMonitorTests.swift
@@ -1,0 +1,139 @@
+#if os(macOS)
+import XCTest
+@testable import SwiftOptel
+
+/// Pure value-type fake mirroring ``OptelAccessibilityDeriver``'s test fake —
+/// lets the decider be exercised without any AppKit state.
+private final class FakeElement: OptelAccessibleElement {
+    var optelAccessibilityRole: String?
+    var optelAccessibilityIdentifier: String?
+    var optelAccessibilityLabel: String?
+    var optelAccessibilityWindowTitle: String?
+    var optelAccessibilityParent: OptelAccessibleElement?
+
+    init(
+        role: String? = nil,
+        identifier: String? = nil,
+        label: String? = nil,
+        windowTitle: String? = nil,
+        parent: OptelAccessibleElement? = nil
+    ) {
+        self.optelAccessibilityRole = role
+        self.optelAccessibilityIdentifier = identifier
+        self.optelAccessibilityLabel = label
+        self.optelAccessibilityWindowTitle = windowTitle
+        self.optelAccessibilityParent = parent
+    }
+}
+
+final class OptelClickMonitorTests: XCTestCase {
+    // MARK: - OptelClickEmitDecider.decide
+
+    func testNormalElementEmitsWithDerivedSourceAndTarget() {
+        let window = FakeElement(windowTitle: "Main")
+        let hit = FakeElement(role: "button", identifier: "buy", label: "Buy", parent: window)
+        let decision = OptelClickEmitDecider.decide(for: hit)
+        XCTAssertTrue(decision.shouldEmit)
+        XCTAssertEqual(decision.source, "Main button#buy")
+        XCTAssertEqual(decision.target, "Buy")
+    }
+
+    func testNilElementSkips() {
+        let decision = OptelClickEmitDecider.decide(for: nil)
+        XCTAssertFalse(decision.shouldEmit)
+        XCTAssertNil(decision.source)
+        XCTAssertNil(decision.target)
+    }
+
+    func testUndeterminableElementStillEmitsViewFallback() {
+        // Hit-test found *something* but the element has no usable identity.
+        // We still emit (clicks on bare views are meaningful as engagement
+        // signals); the deriver supplies the `view` source fallback.
+        let bare = FakeElement()
+        let decision = OptelClickEmitDecider.decide(for: bare)
+        XCTAssertTrue(decision.shouldEmit)
+        XCTAssertEqual(decision.source, "view")
+        XCTAssertNil(decision.target)
+    }
+
+    func testElementWithIgnoreMarkerIsSkipped() {
+        let hit = FakeElement(
+            role: "textField",
+            identifier: OptelClickEmitDecider.ignoreIdentifier,
+            label: "Password"
+        )
+        let decision = OptelClickEmitDecider.decide(for: hit)
+        XCTAssertFalse(decision.shouldEmit)
+        XCTAssertNil(decision.source)
+        XCTAssertNil(decision.target)
+    }
+
+    func testAncestorWithIgnoreMarkerSkipsTheClick() {
+        // Opt-out is inherited: marking a containing group as `optel-ignore`
+        // suppresses click emission for every descendant.
+        let container = FakeElement(
+            role: "group",
+            identifier: OptelClickEmitDecider.ignoreIdentifier
+        )
+        let hit = FakeElement(role: "button", identifier: "submit", parent: container)
+        let decision = OptelClickEmitDecider.decide(for: hit)
+        XCTAssertFalse(decision.shouldEmit)
+    }
+
+    func testWhitespacePaddedIgnoreIdentifierStillOptsOut() {
+        let hit = FakeElement(
+            role: "button",
+            identifier: "  \(OptelClickEmitDecider.ignoreIdentifier)  "
+        )
+        let decision = OptelClickEmitDecider.decide(for: hit)
+        XCTAssertFalse(decision.shouldEmit)
+    }
+
+    func testNonMatchingIdentifierDoesNotOptOut() {
+        let hit = FakeElement(role: "button", identifier: "do-not-ignore-me")
+        let decision = OptelClickEmitDecider.decide(for: hit)
+        XCTAssertTrue(decision.shouldEmit)
+        XCTAssertEqual(decision.source, "button#do-not-ignore-me")
+    }
+
+    func testIgnoreMarkerOnDeepAncestorIsHonored() {
+        // Build a moderately deep chain with the marker on the outermost
+        // ancestor; the decider should still walk up and find it.
+        let outer = FakeElement(
+            role: "window",
+            identifier: OptelClickEmitDecider.ignoreIdentifier
+        )
+        var current: OptelAccessibleElement = outer
+        for _ in 0..<8 {
+            current = FakeElement(role: "AXGroup", parent: current)
+        }
+        let hit = FakeElement(role: "button", identifier: "go", parent: current)
+        let decision = OptelClickEmitDecider.decide(for: hit)
+        XCTAssertFalse(decision.shouldEmit)
+    }
+
+    func testSkipDecisionExposesAllNilFields() {
+        let skip = OptelClickEmitDecider.skip
+        XCTAssertFalse(skip.shouldEmit)
+        XCTAssertNil(skip.source)
+        XCTAssertNil(skip.target)
+    }
+
+    // MARK: - macOS monitor install/uninstall
+
+    func testMonitorInstallIsIdempotent() {
+        OptelClickMonitor._testing_reset()
+        XCTAssertFalse(OptelClickMonitor.isInstalled)
+        OptelClickMonitor.installIfNeeded()
+        XCTAssertTrue(OptelClickMonitor.isInstalled)
+        // Second call is a no-op; the monitor must not be retained twice.
+        OptelClickMonitor.installIfNeeded()
+        XCTAssertTrue(OptelClickMonitor.isInstalled)
+        OptelClickMonitor.uninstall()
+        XCTAssertFalse(OptelClickMonitor.isInstalled)
+        // Uninstall when nothing is installed is also a no-op.
+        OptelClickMonitor.uninstall()
+        XCTAssertFalse(OptelClickMonitor.isInstalled)
+    }
+}
+#endif

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelEnvConfigTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelEnvConfigTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import SwiftOptel
+
+final class OptelEnvConfigTests: XCTestCase {
+    // MARK: - resolveRate
+
+    func testResolveRateEnvWinsOverExplicit() {
+        XCTAssertEqual(
+            OptelEnvConfig.resolveRate(explicit: "off", environment: ["OPTEL_RATE": "on"]),
+            "on"
+        )
+        XCTAssertEqual(
+            OptelEnvConfig.resolveRate(explicit: nil, environment: ["OPTEL_RATE": "on"]),
+            "on"
+        )
+    }
+
+    func testResolveRateUsesExplicitWhenEnvAbsent() {
+        XCTAssertEqual(
+            OptelEnvConfig.resolveRate(explicit: "high", environment: [:]),
+            "high"
+        )
+        XCTAssertEqual(
+            OptelEnvConfig.resolveRate(explicit: "low", environment: ["OTHER": "x"]),
+            "low"
+        )
+    }
+
+    func testResolveRateReturnsNilWhenBothAbsent() {
+        XCTAssertNil(OptelEnvConfig.resolveRate(explicit: nil, environment: [:]))
+    }
+
+    func testResolveRateEmptyEnvFallsBackToExplicit() {
+        // Empty env value is treated as "not set" so an explicitly cleared
+        // shell variable doesn't accidentally wipe a baked-in rate.
+        XCTAssertEqual(
+            OptelEnvConfig.resolveRate(explicit: "on", environment: ["OPTEL_RATE": ""]),
+            "on"
+        )
+        XCTAssertNil(
+            OptelEnvConfig.resolveRate(explicit: nil, environment: ["OPTEL_RATE": ""])
+        )
+    }
+
+    func testResolveRatePassesThroughEachAlias() {
+        // Each helix-rum-js alias is returned verbatim so the downstream
+        // SamplingConfig parser produces the canonical weight.
+        let expectedWeights: [String: Int] = ["on": 1, "off": 0, "high": 10, "low": 1000]
+        for (alias, expectedWeight) in expectedWeights {
+            XCTAssertEqual(
+                OptelEnvConfig.resolveRate(explicit: nil, environment: ["OPTEL_RATE": alias]),
+                alias
+            )
+            XCTAssertEqual(SamplingConfig(rate: alias).weight, expectedWeight)
+        }
+    }
+
+    func testResolveRatePassesNumericAndGarbageThroughForDefaultFallback() {
+        // Non-alias env values still override the explicit value; the final
+        // weight is the helix-rum-js default of 100 via SamplingConfig.
+        for raw in ["42", "0.5", "banana", "bogus"] {
+            let resolved = OptelEnvConfig.resolveRate(
+                explicit: "on",
+                environment: ["OPTEL_RATE": raw]
+            )
+            XCTAssertEqual(resolved, raw)
+            XCTAssertEqual(SamplingConfig(rate: resolved).weight, 100)
+        }
+    }
+
+    // MARK: - resolveDebugLogging
+
+    func testResolveDebugLoggingTruthyValues() {
+        for raw in ["1", "true", "on", "yes", "TRUE", "On", "YES"] {
+            XCTAssertTrue(
+                OptelEnvConfig.resolveDebugLogging(environment: ["OPTEL_DEBUG": raw]),
+                "expected truthy parsing for \(raw)"
+            )
+        }
+    }
+
+    func testResolveDebugLoggingFalseyValues() {
+        for raw in ["0", "false", "off", "no", "", "garbage", "2"] {
+            XCTAssertFalse(
+                OptelEnvConfig.resolveDebugLogging(environment: ["OPTEL_DEBUG": raw]),
+                "expected falsey parsing for \(raw)"
+            )
+        }
+    }
+
+    func testResolveDebugLoggingMissingKeyIsFalse() {
+        XCTAssertFalse(OptelEnvConfig.resolveDebugLogging(environment: [:]))
+        XCTAssertFalse(OptelEnvConfig.resolveDebugLogging(environment: ["OTHER": "1"]))
+    }
+
+    // MARK: - Public constants
+
+    func testEnvKeysMatchDocumentedSpec() {
+        XCTAssertEqual(OptelEnvConfig.rateKey, "OPTEL_RATE")
+        XCTAssertEqual(OptelEnvConfig.debugKey, "OPTEL_DEBUG")
+    }
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelSwiftUITests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelSwiftUITests.swift
@@ -169,5 +169,94 @@ final class OptelSwiftUITests: XCTestCase {
         XCTAssertFalse(OptelMacAutoInstrument.isInstalled)
     }
     #endif
+
+    // MARK: - Refined controls coordinate with the global click monitor
+
+    private struct FixedRandomSource: RandomSource {
+        let value: Double
+        func nextUnitDouble() -> Double { value }
+    }
+
+    private func configureRecordingOptel() -> RecordingTransport {
+        let transport = RecordingTransport()
+        Optel.shared.configure(
+            appID: "com.example.app",
+            rate: "on",
+            collectBaseURL: URL(string: "https://rum.hlx.page/")!,
+            transport: transport,
+            randomSource: FixedRandomSource(value: 0)
+        )
+        return transport
+    }
+
+    func testOptelTapPerformTapClaimsAndEmits() {
+        OptelClickCoordinator._testing_reset()
+        let transport = configureRecordingOptel()
+        // Monitor begins an event, refined `.optelTap` handler fires.
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        OptelTapModifier.performTap(source: "panel view#detail")
+        XCTAssertTrue(OptelClickCoordinator.wasClaimedByRefined(epoch: epoch))
+        let clicks = transport.sent.filter { $0.event.checkpoint.rawValue == "click" }
+        XCTAssertEqual(clicks.count, 1)
+        XCTAssertEqual(clicks.first?.event.pingData.source, "panel view#detail")
+    }
+
+    func testOptelButtonPerformTapClaimsAndEmitsDerivedSource() {
+        OptelClickCoordinator._testing_reset()
+        let transport = configureRecordingOptel()
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        OptelButton<Text>.performTap(
+            identifier: "submit",
+            label: "Submit",
+            context: "checkout"
+        )
+        XCTAssertTrue(OptelClickCoordinator.wasClaimedByRefined(epoch: epoch))
+        let clicks = transport.sent.filter { $0.event.checkpoint.rawValue == "click" }
+        XCTAssertEqual(clicks.count, 1)
+        // Source uses the standard `<context> <element>#<identifier>` shape.
+        XCTAssertEqual(clicks.first?.event.pingData.source, "checkout button#submit")
+    }
+
+    #if os(macOS)
+    func testRefinedTapAndMonitorTogetherProduceExactlyOneBeacon() {
+        // End-to-end dedupe regression: a refined `.optelTap` fires *and* the
+        // global monitor's deferred emit runs for the same event. Only the
+        // refined beacon ships.
+        OptelClickCoordinator._testing_reset()
+        let transport = configureRecordingOptel()
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        OptelTapModifier.performTap(source: "refined#go")
+        // The deferred monitor block now fires (as it would after the run
+        // loop has drained the synchronous event dispatch).
+        OptelClickMonitor.deferredEmit(epoch: epoch, source: "ax#go", target: "Go")
+        let clicks = transport.sent.filter { $0.event.checkpoint.rawValue == "click" }
+        XCTAssertEqual(clicks.count, 1)
+        XCTAssertEqual(clicks.first?.event.pingData.source, "refined#go")
+    }
+
+    func testRefinedButtonAndMonitorTogetherProduceExactlyOneBeacon() {
+        OptelClickCoordinator._testing_reset()
+        let transport = configureRecordingOptel()
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        OptelButton<Text>.performTap(identifier: "buy", label: "Buy", context: "cart")
+        OptelClickMonitor.deferredEmit(epoch: epoch, source: "ax#buy", target: "Buy")
+        let clicks = transport.sent.filter { $0.event.checkpoint.rawValue == "click" }
+        XCTAssertEqual(clicks.count, 1)
+        XCTAssertEqual(clicks.first?.event.pingData.source, "cart button#buy")
+    }
+
+    func testUnrefinedClickStillEmitsViaMonitor() {
+        // A bare control with no refined wrapper: the monitor's deferred
+        // emission must still ship (one beacon, from the monitor).
+        OptelClickCoordinator._testing_reset()
+        let transport = configureRecordingOptel()
+        let epoch = OptelClickCoordinator.beginMonitorEvent()
+        // No refined claim happens for this event.
+        OptelClickMonitor.deferredEmit(epoch: epoch, source: "ax#bare", target: "Bare")
+        let clicks = transport.sent.filter { $0.event.checkpoint.rawValue == "click" }
+        XCTAssertEqual(clicks.count, 1)
+        XCTAssertEqual(clicks.first?.event.pingData.source, "ax#bare")
+    }
+    #endif
 }
 #endif

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelSwiftUITests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelSwiftUITests.swift
@@ -86,5 +86,88 @@ final class OptelSwiftUITests: XCTestCase {
         XCTAssertTrue(final.shouldFireEnter)
         XCTAssertFalse(final.wasBackgrounded)
     }
+
+    // MARK: - Unified install seam (performInstall)
+
+    func testPerformInstallWithGlobalHooksInstallsUncaughtExceptionHook() {
+        OptelUncaughtExceptionHook._testing_reset()
+        XCTAssertFalse(OptelUncaughtExceptionHook.isInstalled)
+        OptelAutoInstrumentModifier.performInstall(
+            appID: "com.example.app",
+            rate: "off",
+            globalHooks: true
+        )
+        XCTAssertTrue(OptelUncaughtExceptionHook.isInstalled)
+    }
+
+    func testPerformInstallWithoutGlobalHooksSkipsUncaughtExceptionHook() {
+        OptelUncaughtExceptionHook._testing_reset()
+        XCTAssertFalse(OptelUncaughtExceptionHook.isInstalled)
+        OptelAutoInstrumentModifier.performInstall(
+            appID: "com.example.app",
+            rate: "off",
+            globalHooks: false
+        )
+        XCTAssertFalse(OptelUncaughtExceptionHook.isInstalled)
+    }
+
+    #if os(macOS)
+    func testPerformInstallWithGlobalHooksInstallsMacHooks() {
+        OptelMacAutoInstrument._testing_reset()
+        XCTAssertFalse(OptelMacAutoInstrument.isInstalled)
+        OptelAutoInstrumentModifier.performInstall(
+            appID: "com.example.app",
+            rate: "off",
+            globalHooks: true
+        )
+        XCTAssertTrue(OptelMacAutoInstrument.isInstalled)
+        OptelMacAutoInstrument.uninstall()
+    }
+
+    func testPerformInstallWithoutGlobalHooksSkipsMacHooks() {
+        OptelMacAutoInstrument._testing_reset()
+        XCTAssertFalse(OptelMacAutoInstrument.isInstalled)
+        OptelAutoInstrumentModifier.performInstall(
+            appID: "com.example.app",
+            rate: "off",
+            globalHooks: false
+        )
+        XCTAssertFalse(OptelMacAutoInstrument.isInstalled)
+    }
+
+    func testPerformInstallIsIdempotentForMacHooks() {
+        // Remounting the root view must not double-install. Each underlying
+        // hook's `installIfNeeded()` is itself a no-op on the second call,
+        // and `OptelMacAutoInstrument.isInstalled` stays `true` throughout.
+        OptelMacAutoInstrument._testing_reset()
+        for _ in 0..<3 {
+            OptelAutoInstrumentModifier.performInstall(
+                appID: "com.example.app",
+                rate: "off",
+                globalHooks: true
+            )
+        }
+        XCTAssertTrue(OptelMacAutoInstrument.isInstalled)
+        XCTAssertTrue(OptelClickMonitor.isInstalled)
+        XCTAssertTrue(OptelWindowObserver.isInstalled)
+        OptelMacAutoInstrument.uninstall()
+        XCTAssertFalse(OptelMacAutoInstrument.isInstalled)
+    }
+
+    func testMacAutoInstrumentCoordinatorInstallUninstall() {
+        OptelMacAutoInstrument._testing_reset()
+        XCTAssertFalse(OptelMacAutoInstrument.isInstalled)
+        OptelMacAutoInstrument.installIfNeeded()
+        XCTAssertTrue(OptelMacAutoInstrument.isInstalled)
+        // Second call is a no-op — each underlying hook latches.
+        OptelMacAutoInstrument.installIfNeeded()
+        XCTAssertTrue(OptelMacAutoInstrument.isInstalled)
+        OptelMacAutoInstrument.uninstall()
+        XCTAssertFalse(OptelMacAutoInstrument.isInstalled)
+        // Uninstall when nothing is installed is safe.
+        OptelMacAutoInstrument.uninstall()
+        XCTAssertFalse(OptelMacAutoInstrument.isInstalled)
+    }
+    #endif
 }
 #endif

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelTests.swift
@@ -147,6 +147,58 @@ final class OptelTests: XCTestCase {
         XCTAssertEqual(mock.sent.count, 201)
     }
 
+    func testConfigureHonorsOptelRateEnvOverExplicit() {
+        // OPTEL_RATE=on must force weight=1 (100% selection) even when the
+        // explicit `rate:` argument would otherwise produce a default-100
+        // weight that the FixedRandomSource cannot satisfy.
+        let mock = RecordingTransport()
+        let optel = Optel()
+        optel.configure(
+            appID: "com.example.app",
+            rate: nil,
+            collectBaseURL: baseURL,
+            transport: mock,
+            randomSource: FixedRandomSource(value: 0.5),
+            environment: ["OPTEL_RATE": "on"]
+        )
+        optel.sample(.click)
+        // weight 1 + random 0.5 → 0.5 < 1 → selected → top + click beacons
+        XCTAssertEqual(mock.sent.map { $0.event.weight }, [1, 1])
+        XCTAssertEqual(mock.sent.map { $0.event.checkpoint.rawValue }, ["top", "click"])
+    }
+
+    func testConfigureUsesExplicitRateWhenEnvAbsent() {
+        let mock = RecordingTransport()
+        let optel = Optel()
+        optel.configure(
+            appID: "com.example.app",
+            rate: "on",
+            collectBaseURL: baseURL,
+            transport: mock,
+            randomSource: FixedRandomSource(value: 0),
+            environment: [:]
+        )
+        optel.sample(.click)
+        XCTAssertEqual(mock.sent.first?.event.weight, 1)
+    }
+
+    func testConfigureEmptyEnvRateFallsBackToExplicit() {
+        // OPTEL_RATE="" must behave as unset so a cleared shell variable
+        // doesn't accidentally override an explicit rate.
+        let mock = RecordingTransport()
+        let optel = Optel()
+        optel.configure(
+            appID: "com.example.app",
+            rate: "on",
+            collectBaseURL: baseURL,
+            transport: mock,
+            randomSource: FixedRandomSource(value: 0),
+            environment: ["OPTEL_RATE": ""]
+        )
+        optel.sample(.click)
+        XCTAssertEqual(mock.sent.first?.event.weight, 1)
+    }
+
     func testTopBeaconIsFirstOnTheWireUnderConcurrentFirstCallers() {
         // Race many threads through `sample` immediately after `configure`,
         // synchronized on a `DispatchSemaphore` so they all unblock together.

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelTransportTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelTransportTests.swift
@@ -130,6 +130,41 @@ final class OptelTransportTests: XCTestCase {
         transport.send(sampleEvent(), collectBaseURL: baseURL)
         XCTAssertLessThan(Date().timeIntervalSince(start), 0.5)
     }
+
+    func testDebugLoggingEnabledTransportStillFireAndForget() {
+        // With debugLogging=true the transport additionally emits os.Logger
+        // entries; behavior on the wire (and the swallow-on-error contract)
+        // must be unchanged. We can't observe the os.Logger sink directly,
+        // so the assertion is "no blocking, no crash".
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FailingURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let transport = URLSessionOptelTransport(
+            session: session,
+            timeout: 1,
+            debugLogging: true
+        )
+        let start = Date()
+        transport.send(sampleEvent(), collectBaseURL: baseURL)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 0.5)
+    }
+
+    func testDebugLoggingDefaultsToOff() {
+        // The default initializer must keep the no-logging behavior so
+        // existing callers see no change.
+        let transport = URLSessionOptelTransport()
+        // No public way to introspect the flag; success is "constructs and
+        // sends" with the same fire-and-forget contract.
+        transport.send(sampleEvent(), collectBaseURL: baseURL)
+    }
+
+    func testLoggerSubsystemAndCategoryAreStable() {
+        // These constants are part of the documented public surface so users
+        // can filter log streams (e.g. `log show --predicate
+        // 'subsystem == "com.slicc.swift-optel"'`).
+        XCTAssertEqual(URLSessionOptelTransport.loggerSubsystem, "com.slicc.swift-optel")
+        XCTAssertEqual(URLSessionOptelTransport.loggerCategory, "transport")
+    }
 }
 
 /// `URLProtocol` that fails every request synchronously. Used to confirm the

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelWindowObserverTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelWindowObserverTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import SwiftOptel
+
+final class OptelWindowObserverTests: XCTestCase {
+    // MARK: - OptelWindowIdentity.make
+
+    func testIdentityPrefersTitleAsSourceWhenPresent() {
+        let identity = OptelWindowIdentity.make(
+            identifier: "main-window",
+            title: "Sliccstart",
+            fallbackKey: "0xDEAD"
+        )
+        XCTAssertEqual(identity.source, "Sliccstart")
+        // Identifier wins as the stable key even when title is the visible source.
+        XCTAssertEqual(identity.key, "id:main-window")
+    }
+
+    func testIdentityFallsBackToIdentifierAsSourceWhenTitleIsBlank() {
+        let identity = OptelWindowIdentity.make(
+            identifier: "settings-window",
+            title: "   ",
+            fallbackKey: "0xCAFE"
+        )
+        XCTAssertEqual(identity.source, "settings-window")
+        XCTAssertEqual(identity.key, "id:settings-window")
+    }
+
+    func testIdentityFallsBackToTitleKeyWhenIdentifierIsBlank() {
+        let identity = OptelWindowIdentity.make(
+            identifier: nil,
+            title: "Inspector",
+            fallbackKey: "0xBEEF"
+        )
+        XCTAssertEqual(identity.source, "Inspector")
+        XCTAssertEqual(identity.key, "title:Inspector")
+    }
+
+    func testIdentityFallsBackToProvidedRefWhenIdAndTitleAreBlank() {
+        let identity = OptelWindowIdentity.make(
+            identifier: "",
+            title: "",
+            fallbackKey: "0xFEED"
+        )
+        XCTAssertEqual(identity.source, "window")
+        XCTAssertEqual(identity.key, "ref:0xFEED")
+    }
+
+    func testIdentityKeysDistinguishBlankWindowsByFallback() {
+        let a = OptelWindowIdentity.make(identifier: nil, title: nil, fallbackKey: "A")
+        let b = OptelWindowIdentity.make(identifier: nil, title: nil, fallbackKey: "B")
+        XCTAssertNotEqual(a.key, b.key)
+    }
+
+    // MARK: - OptelWindowNavigateDecider.decide
+
+    func testFirstWindowEmits() {
+        let current = OptelWindowIdentity(key: "id:A", source: "Window A")
+        let decision = OptelWindowNavigateDecider.decide(previous: nil, current: current)
+        XCTAssertTrue(decision.shouldEmit)
+        XCTAssertEqual(decision.source, "Window A")
+    }
+
+    func testReFocusingSameWindowDoesNotEmit() {
+        let identity = OptelWindowIdentity(key: "id:A", source: "Window A")
+        let decision = OptelWindowNavigateDecider.decide(previous: identity, current: identity)
+        XCTAssertFalse(decision.shouldEmit)
+        XCTAssertNil(decision.source)
+    }
+
+    func testSwitchingWindowsEmitsNewSource() {
+        let previous = OptelWindowIdentity(key: "id:A", source: "Window A")
+        let current = OptelWindowIdentity(key: "id:B", source: "Window B")
+        let decision = OptelWindowNavigateDecider.decide(previous: previous, current: current)
+        XCTAssertTrue(decision.shouldEmit)
+        XCTAssertEqual(decision.source, "Window B")
+    }
+
+    func testKeyComparisonIgnoresDisplaySourceChanges() {
+        // Same underlying window (same key) re-reported with a renamed title
+        // should not emit again — `key`, not `source`, drives the dedupe.
+        let previous = OptelWindowIdentity(key: "id:A", source: "Window A")
+        let renamed = OptelWindowIdentity(key: "id:A", source: "Window A (modified)")
+        let decision = OptelWindowNavigateDecider.decide(previous: previous, current: renamed)
+        XCTAssertFalse(decision.shouldEmit)
+    }
+
+    // MARK: - macOS observer install/uninstall
+
+    #if os(macOS)
+    func testObserverInstallIsIdempotent() {
+        OptelWindowObserver._testing_reset()
+        XCTAssertFalse(OptelWindowObserver.isInstalled)
+        OptelWindowObserver.installIfNeeded()
+        XCTAssertTrue(OptelWindowObserver.isInstalled)
+        // Second call is a no-op; flag remains set and no crash.
+        OptelWindowObserver.installIfNeeded()
+        XCTAssertTrue(OptelWindowObserver.isInstalled)
+        OptelWindowObserver.uninstall()
+        XCTAssertFalse(OptelWindowObserver.isInstalled)
+        // Uninstall when nothing is installed is also a no-op.
+        OptelWindowObserver.uninstall()
+        XCTAssertFalse(OptelWindowObserver.isInstalled)
+    }
+    #endif
+}

--- a/packages/swift-optel/Tests/SwiftOptelTests/OptelWindowObserverTests.swift
+++ b/packages/swift-optel/Tests/SwiftOptelTests/OptelWindowObserverTests.swift
@@ -32,7 +32,10 @@ final class OptelWindowObserverTests: XCTestCase {
             fallbackKey: "0xBEEF"
         )
         XCTAssertEqual(identity.source, "Inspector")
-        XCTAssertEqual(identity.key, "title:Inspector")
+        // When there is no explicit identifier, the per-window fallbackKey is
+        // folded into the dedupe key so two windows with the same title but
+        // different object identities are not collapsed into one.
+        XCTAssertEqual(identity.key, "title:Inspector#ref:0xBEEF")
     }
 
     func testIdentityFallsBackToProvidedRefWhenIdAndTitleAreBlank() {
@@ -49,6 +52,69 @@ final class OptelWindowObserverTests: XCTestCase {
         let a = OptelWindowIdentity.make(identifier: nil, title: nil, fallbackKey: "A")
         let b = OptelWindowIdentity.make(identifier: nil, title: nil, fallbackKey: "B")
         XCTAssertNotEqual(a.key, b.key)
+    }
+
+    func testIdentityKeysDistinguishSameTitleWindowsByFallback() {
+        // Two distinct NSWindow objects with no identifier and the same
+        // non-empty title (duplicate document windows) must produce distinct
+        // dedupe keys; otherwise switching between them would be treated as
+        // re-focusing the same window and `navigate` would never emit.
+        let first = OptelWindowIdentity.make(
+            identifier: nil,
+            title: "Untitled",
+            fallbackKey: "0xAAA"
+        )
+        let second = OptelWindowIdentity.make(
+            identifier: nil,
+            title: "Untitled",
+            fallbackKey: "0xBBB"
+        )
+        XCTAssertNotEqual(first.key, second.key)
+        // Source still prefers the title for human readability.
+        XCTAssertEqual(first.source, "Untitled")
+        XCTAssertEqual(second.source, "Untitled")
+
+        let decision = OptelWindowNavigateDecider.decide(previous: first, current: second)
+        XCTAssertTrue(decision.shouldEmit)
+        XCTAssertEqual(decision.source, "Untitled")
+    }
+
+    func testIdentityKeyStableAcrossReFocusOfSameWindow() {
+        // Re-observing the same window object (same fallbackKey, same title,
+        // no identifier) must produce the same key so the decider treats it
+        // as a re-focus and skips emission.
+        let first = OptelWindowIdentity.make(
+            identifier: nil,
+            title: "Untitled",
+            fallbackKey: "0xSAME"
+        )
+        let second = OptelWindowIdentity.make(
+            identifier: nil,
+            title: "Untitled",
+            fallbackKey: "0xSAME"
+        )
+        XCTAssertEqual(first.key, second.key)
+        let decision = OptelWindowNavigateDecider.decide(previous: first, current: second)
+        XCTAssertFalse(decision.shouldEmit)
+    }
+
+    func testIdentityKeyIgnoresFallbackWhenIdentifierPresent() {
+        // When an explicit identifier exists, the key is identifier-based and
+        // does NOT depend on the fallback. Two observations of the same
+        // logical window with the same identifier collapse to one key even
+        // if the underlying object identities differ.
+        let first = OptelWindowIdentity.make(
+            identifier: "main-window",
+            title: "Sliccstart",
+            fallbackKey: "0xAAA"
+        )
+        let second = OptelWindowIdentity.make(
+            identifier: "main-window",
+            title: "Sliccstart",
+            fallbackKey: "0xBBB"
+        )
+        XCTAssertEqual(first.key, "id:main-window")
+        XCTAssertEqual(second.key, "id:main-window")
     }
 
     // MARK: - OptelWindowNavigateDecider.decide


### PR DESCRIPTION
## Summary

PR #3 of the SwiftOptel rollout. Adds a "do-nothing" auto-instrumentation layer for macOS that mirrors the JS helix-rum-enhancer philosophy:

- Global AppKit click capture (NSEvent local monitor)
- Window-level navigation checkpoints (NSWindow didBecomeKey/didBecomeMain with dedupe)
- Accessibility-based source/target derivation
- Expanded error capture
- Idempotent `optelAutoInstrument` entry point with a `globalHooks` parameter
- Launcher wiring with stable accessibility identifiers
- OpTel (Operational Telemetry) terminology cleanup
- `OPTEL_RATE` / `OPTEL_DEBUG` env overrides (native analogue of helix-rum-js `?rum=on`) for branch-free verification and operability

## Live E2E evidence

Debug release Sliccstart, `OPTEL_RATE=on OPTEL_DEBUG=1`:
- On launch, `top` + `enter` + window-level `navigate` beacons fired and returned HTTP 201.
- Manual UI clicks produced many `click` beacons (accessibility-derived source/target, 127–157 byte payloads) all returning HTTP 201.
- Wire endpoint: `https://rum.hlx.page/.rum/1`.
- The `error` checkpoint emit path is covered by unit tests + verifier approval (no live trigger; inducing a real release-build exception on demand isn't practical).

## Verification

- `swift build -c release` clean for both swift-optel and swift-launcher.
- `swift test` all passing (swift-optel: 142 tests; swift-launcher: 150 tests).
- SwiftLint clean.
- Coverage gates green for both packages (swift-optel: 76.46% lines / 69.60% functions / 79.58% regions vs 65/55/70 floors; swift-launcher: 28.43% / 32.98% / 36.17% vs 27/31/34 floors).
- `npm run lint` clean.

## Notes

Branched off the (now-merged) #1007 wiring branch; rebased onto fresh `main` with linear history.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author