### PR TITLE
fix(coverage): add ratchet rounding safety margin + clear webapp branch floor (supersedes #1015)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,8 +240,9 @@ Every change must satisfy **tests**, **docs**, and **verification**.
     nightly coverage ratchet
     (`packages/dev-tools/tools/coverage-ratchet.mjs` →
     `.github/workflows/coverage-ratchet.yml`), which only ever raises floors
-    toward measured coverage (whole-point steps, <1% headroom) and opens a
-    PR when anything changed. Never hand-lower these values.
+    toward measured coverage (whole-point steps, ~0.5-1.5pp headroom via a
+    half-point safety margin) and opens a PR when anything changed. Never
+    hand-lower these values.
   - **TypeScript packages**: `vitest --coverage` (v8 provider) via
     `npm run test:coverage:<package>`, which runs `coverage-gate.mjs` to read
     the package's floors from `coverage-thresholds.json`. CI runs the same

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Single source of truth for per-package coverage floors. Edited automatically by the nightly coverage ratchet (packages/dev-tools/tools/coverage-ratchet.mjs), which only ever raises floors and keeps <=1% headroom below measured coverage. Consumed by the CI gates via coverage-gate.mjs (TypeScript) and swift-coverage-check.sh (Swift). Do not hand-lower these values.",
+  "$comment": "Single source of truth for per-package coverage floors. Edited automatically by the nightly coverage ratchet (packages/dev-tools/tools/coverage-ratchet.mjs), which only ever raises floors and keeps a ~0.5-1.5pp headroom below measured coverage (a half-point safety margin then floored to a whole percentage). Consumed by the CI gates via coverage-gate.mjs (TypeScript) and swift-coverage-check.sh (Swift). Do not hand-lower these values.",
   "typescript": {
     "cloudflare-worker": {
       "lines": 82,
@@ -9,8 +9,8 @@
     },
     "node-server": {
       "lines": 79,
-      "statements": 76,
-      "functions": 80,
+      "statements": 77,
+      "functions": 82,
       "branches": 66
     },
     "chrome-extension": {
@@ -40,7 +40,7 @@
       "lines": 74,
       "statements": 72,
       "functions": 73,
-      "branches": 62,
+      "branches": 63,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",
@@ -86,14 +86,14 @@
       "regions": 53
     },
     "swift-launcher": {
-      "lines": 27,
-      "functions": 31,
-      "regions": 34
+      "lines": 28,
+      "functions": 32,
+      "regions": 36
     },
     "swift-optel": {
-      "lines": 65,
-      "functions": 55,
-      "regions": 70
+      "lines": 70,
+      "functions": 63,
+      "regions": 77
     }
   }
 }

--- a/packages/dev-tools/tools/coverage-ratchet-lib.mjs
+++ b/packages/dev-tools/tools/coverage-ratchet-lib.mjs
@@ -14,12 +14,18 @@ export const thresholdsPath = resolve(repoRoot, 'coverage-thresholds.json');
 export const TS_METRICS = ['lines', 'statements', 'functions', 'branches'];
 export const SWIFT_METRICS = ['lines', 'functions', 'regions'];
 
+// Half-point safety margin subtracted before flooring, so a measurement
+// like 63.06% won't ratchet a floor to 63 (which a 0.1pp jitter on the
+// next run could miss). With MARGIN = 0.5 the effective headroom below
+// measured coverage is ~0.5-1.5pp. See PR #1015's webapp branches miss
+// (62 -> 63 set with only 0.06pp headroom, failed CI next run).
+export const MARGIN = 0.5;
+
 // A floor only ever moves up, and it tracks the integer part of the
-// measured percentage. Flooring to an integer keeps headroom strictly
-// below one percentage point while making each ratchet step a clean,
-// reviewable >=1pp bump (sub-1pp drift can never raise an integer floor).
+// measured percentage minus MARGIN. Each ratchet step is still a clean,
+// reviewable whole-point bump.
 export function nextFloor(currentFloor, actualPct) {
-  const candidate = Math.floor(actualPct);
+  const candidate = Math.floor(actualPct - MARGIN);
   const current = typeof currentFloor === 'number' ? currentFloor : 0;
   return Math.max(current, candidate);
 }

--- a/packages/dev-tools/tools/coverage-ratchet-lib.test.mjs
+++ b/packages/dev-tools/tools/coverage-ratchet-lib.test.mjs
@@ -7,37 +7,44 @@ import {
 } from './coverage-ratchet-lib.mjs';
 
 describe('nextFloor', () => {
-  it('floors the measured percentage, keeping <1pp headroom', () => {
-    expect(nextFloor(80, 82.03)).toBe(82);
-    expect(nextFloor(50, 50.0)).toBe(50);
+  it('subtracts the half-point safety margin before flooring (~0.5-1.5pp headroom)', () => {
+    expect(nextFloor(80, 82.03)).toBe(81);
+    expect(nextFloor(50, 50.6)).toBe(50);
   });
 
   it('never lowers an existing floor', () => {
     expect(nextFloor(85, 82.9)).toBe(85);
+    expect(nextFloor(50, 50.0)).toBe(50);
   });
 
-  it('only steps up in whole points (sub-1pp drift cannot raise it)', () => {
+  it('needs >=0.5pp clearance to raise a floor (whole-point steps)', () => {
     expect(nextFloor(82, 82.99)).toBe(82);
-    expect(nextFloor(82, 83.0)).toBe(83);
+    expect(nextFloor(82, 83.49)).toBe(82);
+    expect(nextFloor(82, 83.5)).toBe(83);
   });
 
   it('treats a missing current floor as zero', () => {
     expect(nextFloor(undefined, 41.7)).toBe(41);
   });
+
+  // Regression for PR #1015's webapp branches miss: 62 -> 63 was set with
+  // only ~0.06pp headroom and the next CI run measured 62.94 (failure).
+  // With the 0.5pp margin, 63.06 must keep the floor at 62.
+  it('keeps the floor when measurement is within the margin of the next integer (PR #1015 miss)', () => {
+    expect(nextFloor(62, 63.06)).toBe(62);
+    expect(nextFloor(62, 63.6)).toBe(63);
+  });
 });
 
 describe('ratchetPackage', () => {
-  it('raises only metrics that increased and reports the change', () => {
+  it('raises only metrics that clear the safety margin and reports the change', () => {
     const { floors, changes } = ratchetPackage(
       { lines: 71, statements: 69, functions: 70, branches: 60 },
-      { lines: 73.4, statements: 69.2, functions: 70.9, branches: 61.0 },
+      { lines: 73.9, statements: 69.2, functions: 70.9, branches: 61.0 },
       ['lines', 'statements', 'functions', 'branches']
     );
-    expect(floors).toEqual({ lines: 73, statements: 69, functions: 70, branches: 61 });
-    expect(changes).toEqual([
-      { metric: 'lines', from: 71, to: 73, actual: 73.4 },
-      { metric: 'branches', from: 60, to: 61, actual: 61.0 },
-    ]);
+    expect(floors).toEqual({ lines: 73, statements: 69, functions: 70, branches: 60 });
+    expect(changes).toEqual([{ metric: 'lines', from: 71, to: 73, actual: 73.9 }]);
   });
 
   it('ignores missing/NaN measurements', () => {
@@ -67,10 +74,10 @@ describe('applyRatchet', () => {
     };
     const measured = {
       typescript: {
-        webapp: { lines: 72.5, statements: 69.1, functions: 70.0, branches: 60.0 },
+        webapp: { lines: 72.9, statements: 69.1, functions: 70.0, branches: 60.0 },
         'chrome-extension': { lines: 69.0, statements: 67.0, functions: 62.0, branches: 56.0 },
       },
-      swift: { 'swift-server': { lines: 55.1, functions: 53.0, regions: 49.9 } },
+      swift: { 'swift-server': { lines: 55.7, functions: 53.0, regions: 49.9 } },
     };
     const { thresholds: next, changes } = applyRatchet(thresholds, measured);
 

--- a/packages/dev-tools/tools/coverage-ratchet.mjs
+++ b/packages/dev-tools/tools/coverage-ratchet.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 // Coverage ratchet. Measures current coverage for every gated package and
 // raises the floors in coverage-thresholds.json toward reality (never
-// lowering, keeping <1% headroom). Intended to run nightly; a workflow then
-// opens a PR when the file changed. Each ratchet step is a clean >=1pp bump,
-// so there is never a sub-1pp change to review.
+// lowering, keeping ~0.5-1.5pp headroom via a half-point safety margin;
+// see nextFloor in coverage-ratchet-lib.mjs). Intended to run nightly; a
+// workflow then opens a PR when the file changed. Each ratchet step is a
+// clean whole-point bump, so there is never a sub-1pp change to review.
 //
 // Usage:
 //   node packages/dev-tools/tools/coverage-ratchet.mjs [options]

--- a/packages/node-server/tests/shared-ts/oauth-extra-domains-storage.test.ts
+++ b/packages/node-server/tests/shared-ts/oauth-extra-domains-storage.test.ts
@@ -1,0 +1,196 @@
+// Coverage for `@slicc/shared-ts/oauth-extra-domains-storage` attributed to
+// the node-server vitest project. The module is imported (transitively) by
+// node-server runtime code via the `@slicc/shared-ts` barrel, but
+// node-server's own tests never exercise it, so its coverage rolls up at
+// ~2% under the node-server gate while the shared-ts gate covers it ~100%.
+// Mirrors the shape of `packages/shared-ts/tests/oauth-extra-domains-storage.test.ts`.
+
+import {
+  addOAuthExtraDomain,
+  clearOAuthExtras,
+  type LocalStorageLike,
+  OAUTH_EXTRA_DOMAINS_KEY,
+  readOAuthExtras,
+  removeOAuthExtraDomain,
+  writeOAuthExtras,
+} from '@slicc/shared-ts';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+function makeStorage(initial?: Record<string, string>): LocalStorageLike & {
+  data: Record<string, string>;
+} {
+  const data: Record<string, string> = { ...initial };
+  return {
+    data,
+    getItem: (key: string) => (key in data ? data[key] : null),
+    setItem: (key: string, value: string) => {
+      data[key] = value;
+    },
+  };
+}
+
+function makeQuotaStorage(): LocalStorageLike {
+  return {
+    getItem: () => null,
+    setItem: () => {
+      throw new Error('QuotaExceededError');
+    },
+  };
+}
+
+describe('oauth-extra-domains storage (node-server coverage attribution)', () => {
+  let storage: ReturnType<typeof makeStorage>;
+
+  beforeEach(() => {
+    storage = makeStorage();
+  });
+
+  describe('readOAuthExtras', () => {
+    it('returns an empty object when the key is missing', () => {
+      expect(readOAuthExtras(storage)).toEqual({});
+    });
+
+    it('returns an empty object for malformed JSON (try/catch path)', () => {
+      storage.data[OAUTH_EXTRA_DOMAINS_KEY] = '{not json';
+      expect(readOAuthExtras(storage)).toEqual({});
+    });
+
+    it('returns an empty object when JSON parses to null', () => {
+      storage.data[OAUTH_EXTRA_DOMAINS_KEY] = 'null';
+      expect(readOAuthExtras(storage)).toEqual({});
+    });
+
+    it('returns an empty object when JSON parses to an array (not an object)', () => {
+      storage.data[OAUTH_EXTRA_DOMAINS_KEY] = JSON.stringify(['nope']);
+      expect(readOAuthExtras(storage)).toEqual({});
+    });
+
+    it('returns an empty object when JSON parses to a primitive', () => {
+      storage.data[OAUTH_EXTRA_DOMAINS_KEY] = JSON.stringify(42);
+      expect(readOAuthExtras(storage)).toEqual({});
+    });
+
+    it('drops non-array provider values and non-string domain entries', () => {
+      storage.data[OAUTH_EXTRA_DOMAINS_KEY] = JSON.stringify({
+        adobe: ['admin.da.live', 42, '*.da.live', ''],
+        github: 'not-an-array',
+        bare: [],
+      });
+      // `github` is dropped (not an array). `bare` is dropped (cleaned length 0).
+      // `adobe` keeps only the non-empty string entries.
+      expect(readOAuthExtras(storage)).toEqual({ adobe: ['admin.da.live', '*.da.live'] });
+    });
+  });
+
+  describe('writeOAuthExtras', () => {
+    it('round-trips with readOAuthExtras', () => {
+      writeOAuthExtras(storage, { adobe: ['admin.da.live'], github: ['hub.example.com'] });
+      expect(JSON.parse(storage.data[OAUTH_EXTRA_DOMAINS_KEY])).toEqual({
+        adobe: ['admin.da.live'],
+        github: ['hub.example.com'],
+      });
+      expect(readOAuthExtras(storage)).toEqual({
+        adobe: ['admin.da.live'],
+        github: ['hub.example.com'],
+      });
+    });
+
+    it('wraps QuotaExceededError with a descriptive message', () => {
+      const quota = makeQuotaStorage();
+      expect(() => writeOAuthExtras(quota, { adobe: ['x'] })).toThrow(
+        /Failed to persist OAuth extras.*QuotaExceededError/
+      );
+    });
+  });
+
+  describe('addOAuthExtraDomain', () => {
+    it('appends a new domain to a fresh provider entry', () => {
+      expect(addOAuthExtraDomain(storage, 'adobe', 'admin.da.live')).toEqual({ added: true });
+      expect(readOAuthExtras(storage)).toEqual({ adobe: ['admin.da.live'] });
+    });
+
+    it('appends a second distinct domain to the existing provider entry', () => {
+      addOAuthExtraDomain(storage, 'adobe', 'admin.da.live');
+      expect(addOAuthExtraDomain(storage, 'adobe', '*.da.live')).toEqual({ added: true });
+      expect(readOAuthExtras(storage)).toEqual({ adobe: ['admin.da.live', '*.da.live'] });
+    });
+
+    it('rejects duplicates case-insensitively without rewriting storage', () => {
+      addOAuthExtraDomain(storage, 'adobe', 'admin.da.live');
+      const before = storage.data[OAUTH_EXTRA_DOMAINS_KEY];
+      expect(addOAuthExtraDomain(storage, 'adobe', 'ADMIN.DA.LIVE')).toEqual({
+        added: false,
+        reason: 'duplicate',
+      });
+      // Duplicate path bails before writeOAuthExtras, so storage is byte-identical.
+      expect(storage.data[OAUTH_EXTRA_DOMAINS_KEY]).toBe(before);
+    });
+
+    it('rejects an empty provider id', () => {
+      expect(addOAuthExtraDomain(storage, '', 'x.com')).toEqual({
+        added: false,
+        reason: 'provider and domain required',
+      });
+    });
+
+    it('rejects an empty domain', () => {
+      expect(addOAuthExtraDomain(storage, 'adobe', '')).toEqual({
+        added: false,
+        reason: 'provider and domain required',
+      });
+    });
+
+    it('returns {added:false, reason} when storage throws (QuotaExceededError path)', () => {
+      const quota = makeQuotaStorage();
+      const result = addOAuthExtraDomain(quota, 'adobe', 'admin.da.live');
+      expect(result.added).toBe(false);
+      expect(result.reason).toMatch(/Failed to persist OAuth extras/);
+    });
+  });
+
+  describe('removeOAuthExtraDomain', () => {
+    it('removes a matching entry case-insensitively', () => {
+      writeOAuthExtras(storage, { adobe: ['admin.da.live', '*.da.live'] });
+      expect(removeOAuthExtraDomain(storage, 'adobe', 'ADMIN.DA.LIVE')).toEqual({ removed: true });
+      expect(readOAuthExtras(storage)).toEqual({ adobe: ['*.da.live'] });
+    });
+
+    it('returns {removed:false} and leaves storage untouched when nothing matches', () => {
+      writeOAuthExtras(storage, { adobe: ['admin.da.live'] });
+      const before = storage.data[OAUTH_EXTRA_DOMAINS_KEY];
+      expect(removeOAuthExtraDomain(storage, 'adobe', 'not-there.com')).toEqual({
+        removed: false,
+      });
+      expect(storage.data[OAUTH_EXTRA_DOMAINS_KEY]).toBe(before);
+      expect(readOAuthExtras(storage)).toEqual({ adobe: ['admin.da.live'] });
+    });
+
+    it('drops the provider entry entirely when the last domain is removed', () => {
+      writeOAuthExtras(storage, { adobe: ['admin.da.live'], github: ['hub.example.com'] });
+      removeOAuthExtraDomain(storage, 'adobe', 'admin.da.live');
+      expect(readOAuthExtras(storage)).toEqual({ github: ['hub.example.com'] });
+    });
+
+    it('treats an unknown provider as a no-op', () => {
+      writeOAuthExtras(storage, { github: ['hub.example.com'] });
+      expect(removeOAuthExtraDomain(storage, 'adobe', 'admin.da.live')).toEqual({
+        removed: false,
+      });
+      expect(readOAuthExtras(storage)).toEqual({ github: ['hub.example.com'] });
+    });
+  });
+
+  describe('clearOAuthExtras', () => {
+    it('removes a single provider without affecting others', () => {
+      writeOAuthExtras(storage, { adobe: ['admin.da.live'], github: ['hub.example.com'] });
+      clearOAuthExtras(storage, 'adobe');
+      expect(readOAuthExtras(storage)).toEqual({ github: ['hub.example.com'] });
+    });
+
+    it('is a no-op for an unknown provider id', () => {
+      writeOAuthExtras(storage, { github: ['hub.example.com'] });
+      clearOAuthExtras(storage, 'adobe');
+      expect(readOAuthExtras(storage)).toEqual({ github: ['hub.example.com'] });
+    });
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/secret-backends.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/secret-backends.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createCliSecretBackend,
+  createDefaultSecretBackend,
+  createExtensionSecretBackend,
+} from '../../../src/shell/supplemental-commands/secret-backends.js';
+
+type FetchInit = { method?: string; body?: string; headers?: Record<string, string> };
+type Recorded = { url: string; init: FetchInit };
+
+function mockFetch(handler: (call: Recorded) => Response | Promise<Response>) {
+  const calls: Recorded[] = [];
+  const fn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const recorded: Recorded = {
+      url: String(url),
+      init: (init ?? {}) as FetchInit,
+    };
+    calls.push(recorded);
+    return handler(recorded);
+  });
+  vi.stubGlobal('fetch', fn);
+  return { calls, fn };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('createCliSecretBackend.list', () => {
+  it('merges persisted + session records flagged by origin', async () => {
+    mockFetch(({ url }) => {
+      if (url.endsWith('/api/secrets/session')) {
+        return jsonResponse([{ name: 'TMP', domains: ['x.example'] }]);
+      }
+      return jsonResponse([{ name: 'PERSIST', domains: ['y.example'] }]);
+    });
+    const records = await createCliSecretBackend().list();
+    expect(records).toEqual([
+      { name: 'PERSIST', domains: ['y.example'], persisted: true },
+      { name: 'TMP', domains: ['x.example'], persisted: false },
+    ]);
+  });
+
+  it('skips a failing store and still returns the healthy one', async () => {
+    mockFetch(({ url }) =>
+      url.endsWith('/session')
+        ? new Response('boom', { status: 500 })
+        : jsonResponse([{ name: 'A', domains: [] }])
+    );
+    expect(await createCliSecretBackend().list()).toEqual([
+      { name: 'A', domains: [], persisted: true },
+    ]);
+  });
+});
+
+describe('createCliSecretBackend.getInfo / getMasked / peek', () => {
+  it('getInfo returns the matching record or null when absent', async () => {
+    mockFetch(({ url }) =>
+      url.endsWith('/session')
+        ? jsonResponse([])
+        : jsonResponse([{ name: 'TOKEN', domains: ['api.example'] }])
+    );
+    const be = createCliSecretBackend();
+    expect(await be.getInfo('TOKEN')).toEqual({
+      name: 'TOKEN',
+      domains: ['api.example'],
+      persisted: true,
+    });
+    expect(await be.getInfo('MISSING')).toBeNull();
+  });
+
+  it('getMasked returns null when the masked endpoint fails', async () => {
+    mockFetch(() => new Response('nope', { status: 500 }));
+    expect(await createCliSecretBackend().getMasked('X')).toBeNull();
+  });
+
+  it('peek returns null when the peek endpoint fails', async () => {
+    mockFetch(() => new Response('nope', { status: 404 }));
+    expect(await createCliSecretBackend().peek('X')).toBeNull();
+  });
+
+  it('peek encodes the secret name into the query string', async () => {
+    const { calls } = mockFetch(() =>
+      jsonResponse({ name: 'A B', preview: 'masked', domains: [] })
+    );
+    await createCliSecretBackend().peek('A B');
+    expect(calls[0].url).toBe('/api/secrets/peek?name=A%20B');
+  });
+});
+
+describe('createCliSecretBackend.set* — error surface', () => {
+  it('setSession propagates the server error message when present', async () => {
+    mockFetch(() => jsonResponse({ error: 'bad name' }, { status: 400 }));
+    await expect(createCliSecretBackend().setSession('X', 'v', [])).rejects.toThrow('bad name');
+  });
+
+  it('setPersisted falls back to a default message when no error field is present', async () => {
+    mockFetch(() => jsonResponse({}, { status: 500 }));
+    await expect(createCliSecretBackend().setPersisted('X', 'v', [])).rejects.toThrow(
+      'failed to persist secret'
+    );
+  });
+
+  it('setScope succeeds silently on a 2xx response', async () => {
+    const { calls } = mockFetch(() => jsonResponse({ ok: true }));
+    await createCliSecretBackend().setScope('X', ['a.example']);
+    expect(calls[0].url).toBe('/api/secrets/scope');
+    expect(calls[0].init.method).toBe('POST');
+  });
+});
+
+describe('createCliSecretBackend.delete', () => {
+  it('reports removed=false when the server returns 404', async () => {
+    mockFetch(() => new Response('', { status: 404 }));
+    expect(await createCliSecretBackend().delete('X')).toEqual({ removed: false });
+  });
+
+  it('threads fromSession through when the server returns it', async () => {
+    mockFetch(() => jsonResponse({ fromSession: true }));
+    expect(await createCliSecretBackend().delete('X')).toEqual({
+      removed: true,
+      fromSession: true,
+    });
+  });
+
+  it('omits fromSession when the response body is missing the field', async () => {
+    mockFetch(() => jsonResponse({}));
+    expect(await createCliSecretBackend().delete('X')).toEqual({
+      removed: true,
+      fromSession: undefined,
+    });
+  });
+
+  it('throws when the server returns a non-404 error', async () => {
+    mockFetch(() => jsonResponse({ error: 'locked' }, { status: 409 }));
+    await expect(createCliSecretBackend().delete('X')).rejects.toThrow('locked');
+  });
+});
+
+describe('createDefaultSecretBackend', () => {
+  it('routes to the CLI backend when isExtension is false', async () => {
+    mockFetch(() => jsonResponse([]));
+    const be = createDefaultSecretBackend(false);
+    await be.list();
+    // CLI backend hits /api/secrets — extension would not call fetch at all.
+    expect(globalThis.fetch).toHaveBeenCalled();
+  });
+});
+
+interface SwMessage {
+  type: string;
+  name?: string;
+}
+
+function stubChromeRuntime(handler: (msg: SwMessage) => unknown): { calls: SwMessage[] } {
+  const calls: SwMessage[] = [];
+  const sendMessage = vi.fn((msg: SwMessage, cb: (response: unknown) => void) => {
+    calls.push(msg);
+    queueMicrotask(() => cb(handler(msg)));
+  });
+  vi.stubGlobal('chrome', { runtime: { sendMessage, lastError: undefined } });
+  return { calls };
+}
+
+describe('createExtensionSecretBackend', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('merges persisted + session entries from two SW calls', async () => {
+    stubChromeRuntime((msg) => {
+      if (msg.type === 'secrets.session.list') return { entries: [{ name: 'S', domains: [] }] };
+      return { entries: [{ name: 'P', domains: ['a.example'] }] };
+    });
+    const records = await createExtensionSecretBackend().list();
+    expect(records).toEqual([
+      { name: 'P', domains: ['a.example'], persisted: true },
+      { name: 'S', domains: [], persisted: false },
+    ]);
+  });
+
+  it('tolerates a malformed SW response by treating entries as empty', async () => {
+    stubChromeRuntime(() => ({}));
+    expect(await createExtensionSecretBackend().list()).toEqual([]);
+  });
+
+  it('peek rejects when the SW response carries an error field', async () => {
+    stubChromeRuntime(() => ({ error: 'no such secret' }));
+    await expect(createExtensionSecretBackend().peek('X')).rejects.toThrow('no such secret');
+  });
+
+  it('peek returns null when the SW response has no record', async () => {
+    stubChromeRuntime(() => ({}));
+    expect(await createExtensionSecretBackend().peek('X')).toBeNull();
+  });
+
+  it('setSession throws using the SW-supplied error when ok is false', async () => {
+    stubChromeRuntime(() => ({ ok: false, error: 'denied' }));
+    await expect(createExtensionSecretBackend().setSession('X', 'v', [])).rejects.toThrow('denied');
+  });
+
+  it('setPersisted falls back to a default error message when ok is missing', async () => {
+    stubChromeRuntime(() => ({}));
+    await expect(createExtensionSecretBackend().setPersisted('X', 'v', [])).rejects.toThrow(
+      'secrets.set failed'
+    );
+  });
+
+  it('delete defaults removed=true when the SW omits the field', async () => {
+    stubChromeRuntime(() => ({ ok: true }));
+    expect(await createExtensionSecretBackend().delete('X')).toEqual({
+      removed: true,
+      fromSession: undefined,
+    });
+  });
+
+  it('delete threads removed=false through when the SW reports it', async () => {
+    stubChromeRuntime(() => ({ ok: true, removed: false }));
+    expect(await createExtensionSecretBackend().delete('X')).toEqual({
+      removed: false,
+      fromSession: undefined,
+    });
+  });
+
+  it('rejects when chrome.runtime.lastError is set', async () => {
+    const sendMessage = vi.fn((_msg: unknown, cb: (response: unknown) => void) => {
+      (
+        globalThis as { chrome: { runtime: { lastError: { message: string } } } }
+      ).chrome.runtime.lastError = { message: 'disconnected' };
+      queueMicrotask(() => cb(undefined));
+    });
+    vi.stubGlobal('chrome', { runtime: { sendMessage, lastError: undefined } });
+    await expect(createExtensionSecretBackend().list()).rejects.toThrow('disconnected');
+  });
+
+  it('createDefaultSecretBackend(true) routes to the extension backend', async () => {
+    stubChromeRuntime(() => ({ entries: [] }));
+    await createDefaultSecretBackend(true).list();
+    expect(
+      (globalThis as { chrome: { runtime: { sendMessage: ReturnType<typeof vi.fn> } } }).chrome
+        .runtime.sendMessage
+    ).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

This PR combines three changes and supersedes the failed nightly ratchet PR #1015:

1. **Ratchet rounding safety margin** — `nextFloor()` in `coverage-ratchet-lib.mjs` now subtracts a `MARGIN = 0.5` before flooring (`Math.floor(actualPct - MARGIN)`), so a measurement like 63.06% no longer ratchets a floor up to 63 with near-zero headroom. Effective headroom below measured coverage is now ~0.5–1.5pp. It still never lowers an existing floor.
2. **#1015's raised floors** — `coverage-thresholds.json` carries PR #1015's raises unchanged: node-server statements 76→77 / functions 80→82, webapp branches 62→63, swift-launcher 27/31/34→28/32/36, swift-optel 65/55/70→70/63/77.
3. **Tiny webapp test** — new `packages/webapp/tests/shell/supplemental-commands/secret-backends.test.ts` covering the secret-backend factory functions (previously ~12% branch coverage), lifting webapp branch coverage to 63.23% so the raised 63% floor is satisfiable.

## Why

PR #1015 (branch `automation/coverage-ratchet`) failed CI: the ratchet raised `webapp.branches` 62→63, but the PR's own CI run measured ~62.94% — a ~0.06pp miss. Root cause was zero-headroom flooring. The margin change prevents this class of failure; the test makes the already-raised 63% floor pass now.

## Verification

- dev-tools ratchet unit tests pass (incl. regression test `nextFloor(62, 63.06) === 62`).
- `node packages/dev-tools/tools/coverage-gate.mjs webapp` exits 0 — branches 63.23%, statements 72.86%, functions 73.8%, lines 74.82%.
- `npm run lint` clean.

Supersedes #1015.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author