### PR TITLE
feat(composer): debounce push-to-talk (100ms engage) + 3s hold-to-enable

### DIFF
--- a/packages/webcomponents/CLAUDE.md
+++ b/packages/webcomponents/CLAUDE.md
@@ -61,7 +61,7 @@ tests/**/<name>.test.ts    co-located browser tests, mirroring src/ subsystem
   `::part` hooks, named slots, and `CustomEvent`s (composed + bubbling) — never
   reach into another component's internals.
 - **Composer push-to-talk:** `<slicc-composer ptt>` owns the hold-to-dictate
-  GESTURE (5s hold-to-enable permission stage, recording overlay with caption
+  GESTURE (3s hold-to-enable permission stage, recording overlay with caption
   line + mic picker + engine-status line, append+submit on release) but not the
   audio stack — hosts inject a `ComposerSpeech` controller via the `speech`
   property. The contract + built-in Web Speech fallback live in

--- a/packages/webcomponents/src/composer/slicc-composer.stories.ts
+++ b/packages/webcomponents/src/composer/slicc-composer.stories.ts
@@ -318,7 +318,7 @@ function armPress(el: SliccComposer): void {
 
 /**
  * Push-to-talk, stage 1 — no microphone permission yet. Holding the textarea
- * shows the "Hold to enable push to talk" bar filling over five seconds; a
+ * shows the "Hold to enable push to talk" bar filling over three seconds; a
  * press held to completion requests mic permission (scripted to grant here,
  * upgrading the held press straight into the recording stage). Release early
  * to cancel without prompting.
@@ -329,7 +329,7 @@ export const PushToTalkEnable: Story = {
     const el = pttComposer(scriptedSpeech({ permission: 'prompt' }), open);
     armPress(el);
     return pttShell(
-      'Hold the input below: the 5s bar fills, then permission is requested (scripted to grant).',
+      'Hold the input below: the 3s bar fills, then permission is requested (scripted to grant).',
       el
     );
   },

--- a/packages/webcomponents/src/composer/slicc-composer.ts
+++ b/packages/webcomponents/src/composer/slicc-composer.ts
@@ -310,6 +310,11 @@ export const HOLD_TO_ENABLE_MS = 5000;
  *  'granted' goes straight to recording with no enable-stage flash. */
 const PERMISSION_RACE_MS = 60;
 
+/** Delay between mousedown and arming the push-to-talk lifecycle. A pure
+ *  click whose release lands within this window never flashes the overlay
+ *  or touches the speech controller, so plain caret presses stay silent. */
+export const PTT_ENGAGE_MS = 100;
+
 /** The caption line keeps only the trailing words, like movie closed captions. */
 const CAPTION_MAX_WORDS = 8;
 
@@ -426,6 +431,9 @@ export class SliccComposer extends HTMLElement {
   #device: string | null = readStoredDevice();
   /** Hold-to-enable gate timer. */
   #enableTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Engage-delay timer: defers the press lifecycle until the pointer has
+   *  been held past {@link PTT_ENGAGE_MS} so a pure click never flashes. */
+  #engageTimer: ReturnType<typeof setTimeout> | null = null;
   /** Engine status subscription teardown (active while the overlay is up). */
   #statusUnsub: (() => void) | null = null;
   /** Latest engine status snapshot for the status line. */
@@ -457,6 +465,7 @@ export class SliccComposer extends HTMLElement {
     this.#pressed = false;
     this.#target = null;
     this.#token++;
+    this.#clearEngageTimer();
     if (this.#enableTimer) clearTimeout(this.#enableTimer);
     this.#enableTimer = null;
     this.#removePressListeners();
@@ -570,7 +579,13 @@ export class SliccComposer extends HTMLElement {
     doc.addEventListener('mouseup', this.#onDocMouseUp);
     this.addEventListener('mouseleave', this.#onMouseLeave);
 
-    void this.#beginPress(this.speech, this.#token);
+    // Defer the press lifecycle so a pure click (released within the engage
+    // window) never flashes the overlay nor touches the speech controller.
+    const engageToken = this.#token;
+    this.#engageTimer = setTimeout(() => {
+      this.#engageTimer = null;
+      void this.#beginPress(this.speech, engageToken);
+    }, PTT_ENGAGE_MS);
   };
 
   /**
@@ -730,6 +745,9 @@ export class SliccComposer extends HTMLElement {
   #endPress(finalize: boolean): void {
     if (!this.#pressed) return;
     this.#pressed = false;
+    // A release within the engage window cancels the deferred lifecycle so
+    // #beginPress never runs for this press (stage stays 'idle' below).
+    this.#clearEngageTimer();
     this.#removePressListeners();
 
     switch (this.#stage) {
@@ -830,6 +848,11 @@ export class SliccComposer extends HTMLElement {
   #clearEnableTimer(): void {
     if (this.#enableTimer) clearTimeout(this.#enableTimer);
     this.#enableTimer = null;
+  }
+
+  #clearEngageTimer(): void {
+    if (this.#engageTimer) clearTimeout(this.#engageTimer);
+    this.#engageTimer = null;
   }
 
   #removePressListeners(): void {

--- a/packages/webcomponents/src/composer/slicc-composer.ts
+++ b/packages/webcomponents/src/composer/slicc-composer.ts
@@ -69,7 +69,7 @@ slicc-composer[open] slicc-composer-meta::part(hint) {
    textarea the band turns into one big active push button. The overlay is a
    direct host child (not the 680px inner band) so it covers the whole footer,
    and sits above it via z-index. Stage classes select the variant:
-   .is-enable    — no mic permission yet: 5s hold-to-enable progress bar
+   .is-enable    — no mic permission yet: 3s hold-to-enable progress bar
    .is-prompting — the browser's permission prompt is up
    .is-denied    — permission blocked: instructions, no bar
    .is-recording — live dictation: pulsing mic, captions, picker, engine status
@@ -142,11 +142,11 @@ slicc-composer .slicc-composer__ptt-bar-fill {
   transform-origin: left center;
   background: var(--ctx);
 }
-/* Hold-to-enable: the bar sweeps over the SAME 5s the gesture timer counts
+/* Hold-to-enable: the bar sweeps over the SAME 3s the gesture timer counts
    (HOLD_TO_ENABLE_MS) — the animation is presentation, the timer is truth. */
 slicc-composer .slicc-composer__ptt.is-enable .slicc-composer__ptt-bar-fill {
   animation-name: slicc-ptt-load;
-  animation-duration: 5s;
+  animation-duration: 3s;
   animation-timing-function: linear;
   animation-fill-mode: forwards;
 }
@@ -303,8 +303,8 @@ function ensureComposerStyle(doc: Document): void {
 }
 
 /** How long the textarea must be held before the mic permission is requested.
- *  Mirrored by the `.is-enable` bar's 5s CSS sweep — keep the two in step. */
-export const HOLD_TO_ENABLE_MS = 5000;
+ *  Mirrored by the `.is-enable` bar's 3s CSS sweep — keep the two in step. */
+export const HOLD_TO_ENABLE_MS = 3000;
 
 /** Grace window for the cached-permission check on mousedown: a fast
  *  'granted' goes straight to recording with no enable-stage flash. */
@@ -369,7 +369,7 @@ function formatEta(etaSeconds: number | null): string {
  * stages keyed to the microphone permission:
  *
  * 1. **Not granted** — a "Hold to enable push to talk" progress bar fills over
- *    five seconds ({@link HOLD_TO_ENABLE_MS}); a press held to completion
+ *    three seconds ({@link HOLD_TO_ENABLE_MS}); a press held to completion
  *    requests microphone permission through the injected speech controller
  *    (triggering the browser prompt). A denied/blocked permission renders
  *    instructions instead of a bar.
@@ -612,7 +612,7 @@ export class SliccComposer extends HTMLElement {
       return;
     }
 
-    // 'prompt', or the query is still settling — run the 5s enable gate.
+    // 'prompt', or the query is still settling — run the 3s enable gate.
     this.#showOverlay('enable');
     this.#enableTimer = setTimeout(() => {
       this.#enableTimer = null;
@@ -636,7 +636,7 @@ export class SliccComposer extends HTMLElement {
     }
   }
 
-  /** The 5s hold completed — request microphone permission. */
+  /** The 3s hold completed — request microphone permission. */
   #onHoldComplete(speech: ComposerSpeech, token: number): void {
     if (token !== this.#token || !this.#pressed || this.#stage !== 'enable') return;
     this.#showOverlay('prompting');

--- a/packages/webcomponents/tests/composer/slicc-composer.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-composer.test.ts
@@ -376,7 +376,7 @@ describe('slicc-composer / push-to-talk', () => {
 
   // ── Stage 1: no permission yet ────────────────────────────────────
 
-  it('without permission, holding shows the 5s "hold to enable" bar (no recording)', async () => {
+  it('without permission, holding shows the 3s "hold to enable" bar (no recording)', async () => {
     const fake = makeFakeSpeech({ permission: 'prompt' });
     const el = mount(fake);
     press(el);
@@ -389,16 +389,16 @@ describe('slicc-composer / push-to-talk', () => {
       'Hold to enable push to talk'
     );
     expect(ptt!.querySelector('.slicc-composer__ptt-bar-fill')).not.toBeNull();
-    // The 5s sweep is wired via the .is-enable stage class.
+    // The 3s sweep is wired via the .is-enable stage class.
     const fill = ptt!.querySelector('.slicc-composer__ptt-bar-fill') as HTMLElement;
     if (!matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      expect(getComputedStyle(fill).animationDuration).toBe('5s');
+      expect(getComputedStyle(fill).animationDuration).toBe('3s');
     }
     expect(fake.calls.requestPermission).toBe(0);
     expect(fake.calls.start.length).toBe(0);
   });
 
-  it('holding through the 5s gate requests permission, then records while still held', async () => {
+  it('holding through the 3s gate requests permission, then records while still held', async () => {
     const fake = makeFakeSpeech({ permission: 'prompt', grantOnRequest: true, transcript: 'hi' });
     const el = mount(fake);
     press(el);
@@ -416,7 +416,7 @@ describe('slicc-composer / push-to-talk', () => {
     expect(fake.calls.warmup).toBeGreaterThan(0);
   });
 
-  it('releasing before the 5s gate never requests permission', async () => {
+  it('releasing before the 3s gate never requests permission', async () => {
     const fake = makeFakeSpeech({ permission: 'prompt' });
     const el = mount(fake);
     press(el);
@@ -718,7 +718,7 @@ describe('slicc-composer / push-to-talk edge paths', () => {
     expect(pttOf(el)?.classList.contains('is-enable')).toBe(true);
 
     // The query lands 'granted' mid-hold: the press upgrades straight to
-    // recording without waiting out the 5s gate.
+    // recording without waiting out the 3s gate.
     resolvePermission('granted');
     await flush();
     expect(pttOf(el)?.classList.contains('is-recording')).toBe(true);

--- a/packages/webcomponents/tests/composer/slicc-composer.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-composer.test.ts
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // populated composer mirrors the prototype's footer (input card + meta row).
 import '../../src/add-menu/slicc-add-menu.js';
 import '../../src/composer/slicc-composer-meta.js';
-import { HOLD_TO_ENABLE_MS, SliccComposer } from '../../src/composer/slicc-composer.js';
+import {
+  HOLD_TO_ENABLE_MS,
+  PTT_ENGAGE_MS,
+  SliccComposer,
+} from '../../src/composer/slicc-composer.js';
 import '../../src/composer/slicc-input-card.js';
 import type {
   ComposerSpeech,
@@ -335,8 +339,12 @@ describe('slicc-composer / push-to-talk', () => {
     vi.useRealTimers();
   });
 
-  /** Flush microtasks + 0ms timers so async stage transitions settle. */
-  const flush = () => vi.advanceTimersByTimeAsync(0);
+  /** Engage the deferred press lifecycle + drain async stage transitions:
+   *  press waits PTT_ENGAGE_MS before #beginPress runs, so advancing exactly
+   *  the engage window after press(el) is what every "and then overlay X
+   *  appears" assertion needs. Tests that intentionally release inside the
+   *  engage window advance less and don't call flush() at all. */
+  const flush = () => vi.advanceTimersByTimeAsync(PTT_ENGAGE_MS);
 
   /** The textarea the host renders / relocates into its light DOM. */
   function taOf(el: SliccComposer): HTMLTextAreaElement {
@@ -421,6 +429,29 @@ describe('slicc-composer / push-to-talk', () => {
     // The cleared timer must not fire later.
     await vi.advanceTimersByTimeAsync(HOLD_TO_ENABLE_MS);
     expect(fake.calls.requestPermission).toBe(0);
+  });
+
+  it('a click released inside the engage window shows no overlay and never queries the speech controller', async () => {
+    const fake = makeFakeSpeech({ permission: 'granted' });
+    // permission() is the first thing #beginPress touches — spy on it to
+    // catch a stray engage-timer fire even if no overlay is mounted.
+    const permissionSpy = vi.spyOn(fake.controller, 'permission');
+    const el = mount(fake);
+    press(el);
+
+    // Release strictly inside the engage window: the deferred lifecycle
+    // is cancelled before it ever arms.
+    await vi.advanceTimersByTimeAsync(PTT_ENGAGE_MS - 1);
+    expect(pttOf(el)).toBeNull();
+    release();
+    expect(pttOf(el)).toBeNull();
+
+    // Past the engage window: the cancelled timer must not fire.
+    await vi.advanceTimersByTimeAsync(HOLD_TO_ENABLE_MS);
+    expect(pttOf(el)).toBeNull();
+    expect(permissionSpy).not.toHaveBeenCalled();
+    expect(fake.calls.requestPermission).toBe(0);
+    expect(fake.calls.start.length).toBe(0);
   });
 
   it('a blocked permission shows instructions instead of the enable bar', async () => {
@@ -648,7 +679,7 @@ describe('slicc-composer / push-to-talk edge paths', () => {
     vi.useRealTimers();
   });
 
-  const flush = () => vi.advanceTimersByTimeAsync(0);
+  const flush = () => vi.advanceTimersByTimeAsync(PTT_ENGAGE_MS);
 
   function press(el: SliccComposer): HTMLTextAreaElement {
     const ta = el.querySelector('textarea') as HTMLTextAreaElement;
@@ -681,8 +712,9 @@ describe('slicc-composer / push-to-talk edge paths', () => {
     const el = mount(fake);
     press(el);
 
-    // The 60ms race window elapses with the query still pending → enable stage.
-    await vi.advanceTimersByTimeAsync(100);
+    // Engage delay + the 60ms race window elapse with the query still
+    // pending → enable stage.
+    await vi.advanceTimersByTimeAsync(PTT_ENGAGE_MS + 100);
     expect(pttOf(el)?.classList.contains('is-enable')).toBe(true);
 
     // The query lands 'granted' mid-hold: the press upgrades straight to
@@ -703,7 +735,7 @@ describe('slicc-composer / push-to-talk edge paths', () => {
       });
     const el = mount(fake);
     press(el);
-    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(PTT_ENGAGE_MS + 100);
 
     resolvePermission('denied');
     await flush();


### PR DESCRIPTION
## What

Two push-to-talk refinements on the composer:

1. **100ms engage delay** — a pure click on the textarea no longer flickers the push-to-talk overlay. The walkie-talkie gesture only engages once the pointer has been held ~100ms after `mousedown`.
2. **3s hold-to-enable** — the permission gate now requires a 3s hold (was 5s) before microphone access is requested.

## 1. Engage delay (no click flicker)

Previously `#onMouseDown` called `#beginPress` immediately, which could mount an overlay in the same tick (the `enable` bar, or — with cached `granted` permission — jump straight to `recording`). A click to place the caret momentarily mounted and tore down the overlay, producing a visible flash.

- Added exported `PTT_ENGAGE_MS = 100`.
- `#onMouseDown` still arms the press but defers `#beginPress` behind a new `#engageTimer`.
- The engage timer is cleared on every press-ending path via `#clearEngageTimer()` (from `#endPress`, covering both `#onDocMouseUp` and `#onMouseLeave`) and in `disconnectedCallback`, so a release within the window is a clean no-op with no overlay shown.

## 2. Hold-to-enable reduced to 3s

- `HOLD_TO_ENABLE_MS` 5000 → 3000, with the `.is-enable` bar's CSS sweep updated to `3s` so the animation completes exactly when permission is requested (the two are documented to stay in step).
- Updated all stale "5s"/"five seconds" wording in comments, JSDoc, stories, the `'3s'` test assertion, and `packages/webcomponents/CLAUDE.md`.

The permission race (`PERMISSION_RACE_MS`), the speech contract, and the recording/finalizing UI are untouched.

## Tests

- Updated composer tests to advance fake timers by `PTT_ENGAGE_MS` after pressing (race-window tests strengthened, not weakened).
- Added a regression test: a click released inside the engage window shows no overlay and never queries the speech controller, then advances `HOLD_TO_ENABLE_MS` to prove the cancelled timer never fires.
- Tests advancing by the imported `HOLD_TO_ENABLE_MS` constant need no numeric change; the literal sweep assertion now expects `'3s'`.

## Verification

- `npm run typecheck -w @slicc/webcomponents` — PASS
- `npm run test -w @slicc/webcomponents` — 1360/1360 PASS
- `npm run lint` — PASS