### PR TITLE
fix(ui): googly eyes follow the actively-streaming scoop

### DIFF
--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -88,6 +88,15 @@ export interface OffscreenClientCallbacks {
     scoopJid: string,
     state: 'summarizing' | 'extracting-memory' | 'idle'
   ) => void;
+  /**
+   * Fired when any scoop (selected or not) produces meaningful agent
+   * activity — text deltas, tool starts, tool UI, or turn ends. Lets
+   * the host move the navbar `attention` (googly eyes) to whichever
+   * scoop is actively streaming, regardless of selection. Does NOT
+   * affect which scoop's thread renders — the selection gate that
+   * controls thread routing in {@link handleAgentEvent} is unchanged.
+   */
+  onScoopActivity?: (scoopJid: string) => void;
 }
 
 export class OffscreenClient implements KernelClientFacade {
@@ -728,6 +737,19 @@ export class OffscreenClient implements KernelClientFacade {
   }
 
   private handleAgentEvent(msg: AgentEventMsg): void {
+    // Per-scoop activity ping fires BEFORE the selection gate so the
+    // host can move the navbar eyes onto a non-selected scoop that is
+    // actively streaming. The gate below still controls which scoop's
+    // thread renders.
+    switch (msg.eventType) {
+      case 'text_delta':
+      case 'tool_start':
+      case 'tool_ui':
+      case 'turn_end':
+        this.callbacks.onScoopActivity?.(msg.scoopJid);
+        break;
+    }
+
     if (msg.scoopJid !== this.selectedScoopJid) return;
 
     switch (msg.eventType) {

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -202,6 +202,12 @@ export function createWcLiveCallbacks(wiring: WcLiveWiring): OffscreenClientCall
       refreshScoops();
       ensureSelection();
     },
+    onScoopActivity: (jid) => {
+      // Agent-event ping for ANY scoop (selected or not): keep the navbar
+      // eyes on whichever scoop is actively streaming. Mirrors the
+      // `attention` write in `onIncomingMessage`; no thread routing.
+      wiring.refs.switcher.setAttribute('attention', jid);
+    },
     onIncomingMessage: (jid, message) => {
       // Most-recent-activity tracking: the scoop that just received a message
       // wears the blinking navbar eyes (the switcher's `attention` chip) and

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -44,6 +44,7 @@ describe('OffscreenClient', () => {
     onScoopCreated: vi.fn(),
     onScoopListUpdate: vi.fn(),
     onIncomingMessage: vi.fn(),
+    onScoopActivity: vi.fn(),
   };
 
   beforeEach(() => {
@@ -144,6 +145,53 @@ describe('OffscreenClient', () => {
     });
 
     expect(events.length).toBe(0);
+  });
+
+  it('fires onScoopActivity for non-selected scoop agent events while not rendering them', () => {
+    // The navbar eyes follow the actively-streaming scoop even when it is
+    // not the selected one; the thread itself must NOT render those events.
+    client.setSelectedScoopJid('cone_123');
+    const handle = client.createAgentHandle();
+    const events: unknown[] = [];
+    handle.onEvent((e) => events.push(e));
+
+    for (const eventType of ['text_delta', 'tool_start', 'tool_ui', 'turn_end']) {
+      simulateMessage('offscreen', {
+        type: 'agent-event',
+        scoopJid: 'other_scoop',
+        eventType,
+        text: 'x',
+        toolName: 't',
+        requestId: 'r',
+        html: '<i/>',
+      });
+    }
+
+    expect(callbacks.onScoopActivity).toHaveBeenCalledTimes(4);
+    expect(callbacks.onScoopActivity).toHaveBeenCalledWith('other_scoop');
+    // Selection gate still suppresses thread rendering for non-selected scoops.
+    expect(events.length).toBe(0);
+  });
+
+  it('does not fire onScoopActivity for tool_end / response_done', () => {
+    // Activity ping is restricted to the four "loud" event types so the
+    // attention attribute doesn't flap on every micro-event.
+    client.setSelectedScoopJid('cone_123');
+
+    simulateMessage('offscreen', {
+      type: 'agent-event',
+      scoopJid: 'cone_123',
+      eventType: 'tool_end',
+      toolName: 't',
+      toolResult: 'ok',
+    });
+    simulateMessage('offscreen', {
+      type: 'agent-event',
+      scoopJid: 'cone_123',
+      eventType: 'response_done',
+    });
+
+    expect(callbacks.onScoopActivity).not.toHaveBeenCalled();
   });
 
   it('handles scoop-status changes', () => {

--- a/packages/webapp/tests/ui/wc/wc-live.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-live.test.ts
@@ -183,6 +183,18 @@ describe('createWcLiveCallbacks', () => {
     expect(wiring.refs.switcher.getAttribute('attention')).toBe('cone-1');
   });
 
+  it('moves switcher attention onto a non-selected, actively-streaming scoop', () => {
+    // Cone is selected, but a different scoop is streaming an agent turn —
+    // the eyes must follow the activity even though selection is unchanged.
+    const streamer = scoop({ jid: 'scoop-stream', name: 'researcher' });
+    const wiring = makeWiring({ selected: cone, scoops: [cone, streamer] });
+    const callbacks = createWcLiveCallbacks(wiring);
+    callbacks.onScoopActivity?.(streamer.jid);
+    expect(wiring.refs.switcher.getAttribute('attention')).toBe(streamer.jid);
+    // Selection is intentionally untouched — thread routing is owned elsewhere.
+    expect(wiring.getSelected()).toBe(cone);
+  });
+
   it('renders licks for the selected scoop only, skipping web messages', () => {
     const wiring = makeWiring({ selected: cone });
     const callbacks = createWcLiveCallbacks(wiring);


### PR DESCRIPTION
## Problem
In a multi-scoop run, the navbar googly eyes stayed on the cone instead of following whichever scoop (or cone) most recently produced agent output. While a non-selected scoop streamed its turn, the eyes never moved to it.

## Root cause
The eyes are driven by the `attention` attribute on `slicc-scoop-switcher`. The host only moved `attention` on messages routed *into* a scoop, on user input to the selected scoop, or on turn-finish for the selected scoop. A non-selected scoop's own streaming/tool activity never updated it, because agent events are dropped by the `selectedScoopJid` gate in `OffscreenClient.handleAgentEvent` before reaching the host. Net effect: the cone delegates, the scoop streams invisibly, then the scoop's completion notification routes back to the cone — so the eyes appear stuck on the cone.

## Fix
- `packages/webapp/src/ui/offscreen-client.ts` — add optional `onScoopActivity?(scoopJid)` to `OffscreenClientCallbacks`; `handleAgentEvent` fires it for `text_delta` / `tool_start` / `tool_ui` / `turn_end` **before** the selection gate. The gate that controls thread rendering is unchanged.
- `packages/webapp/src/ui/wc/wc-live.ts` — `createWcLiveCallbacks.onScoopActivity` sets the switcher `attention` attribute, mirroring `onIncomingMessage`.

`OffscreenClient` is shared by the standalone (kernel-worker) and extension floats, so one fix covers both.

## Tests
- `tests/ui/offscreen-client.test.ts` — a non-selected scoop fires `onScoopActivity` for all four event types **without** rendering its thread; `tool_end` / `response_done` do **not** fire.
- `tests/ui/wc/wc-live.test.ts` — attention follows the streaming scoop without changing selection.

## Verification
- `npm run lint` — exit 0
- `npm run typecheck` — exit 0 (7 tsc projects)
- `npm run test -w @slicc/webapp` — exit 0 (6367 tests)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author