### PR TITLE
fix(webapp): restore leader-followers shim so standalone host shows live followers

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/host-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/host-command.ts
@@ -64,7 +64,7 @@ export function getConnectedFollowersWithFallback(): ConnectedFollowerInfo[] {
 }
 
 // Same reason: the module-level getter is only set on the page thread.
-// Fall back to the localStorage shim value written by onFollowerCountChanged.
+// Fall back to the localStorage shim value written by writeConnectedFollowersToShim.
 function getFollowersWithFallback(): ConnectedFollowerInfo[] {
   if (connectedFollowersGetter) return connectedFollowersGetter();
   try {
@@ -76,6 +76,29 @@ function getFollowersWithFallback(): ConnectedFollowerInfo[] {
     // ignore parse errors
   }
   return [];
+}
+
+/**
+ * Mirror the leader's connected-follower list into the
+ * `slicc.leaderTrayFollowers` shim so the standalone kernel-worker `host`
+ * command — which has no live `connectedFollowersGetter` — sees it via
+ * `getFollowersWithFallback`. The page calls this on every follower-count
+ * change, on boot (to clear a stale value), and when the leader stops;
+ * `installPageStorageSync` forwards the write into the worker's Map-backed
+ * shim. Symmetric with the `slicc.leaderTrayStatus` mirror written in
+ * `wc-tray.ts`. Best-effort: a missing `localStorage` (Node/tests without an
+ * override) or a quota/serialization error is swallowed.
+ */
+export function writeConnectedFollowersToShim(
+  followers: ConnectedFollowerInfo[],
+  storage: Pick<Storage, 'setItem'> | undefined = (globalThis as { localStorage?: Storage })
+    .localStorage
+): void {
+  try {
+    storage?.setItem(LEADER_FOLLOWERS_STORAGE_KEY, JSON.stringify(followers));
+  } catch {
+    // best-effort mirror — ignore quota / serialization failures
+  }
 }
 
 // When `host reset` runs from the kernel-worker's terminal, the worker's

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -21,8 +21,10 @@ import {
   TRAY_WORKER_STORAGE_KEY,
 } from '../../scoops/tray-runtime-config.js';
 import {
+  getConnectedFollowers,
   setConnectedFollowersGetter,
   setTrayResetter,
+  writeConnectedFollowersToShim,
 } from '../../shell/supplemental-commands/host-command.js';
 import { setupStandalonePanelRpc } from '../boot/setup-standalone-panel-rpc.js';
 import { runHostedBootstrap } from '../boot/setup-standalone-tray-init-hosted.js';
@@ -159,6 +161,9 @@ function createLeaderOptionsFactory(
           ? `tray · ${count} follower${count === 1 ? '' : 's'}`
           : (deps.baseFloatLabel ?? 'standalone · live')
       );
+      // Mirror the live follower list into the shim so the standalone
+      // worker-side `host` command (no live getter) reflects it.
+      writeConnectedFollowersToShim(getConnectedFollowers());
     },
     onRemoteTransportsCleaned: (runtimeId) => remoteCdpBridge.cleanupRuntime(runtimeId),
     onForwardedLick: (event) => client.sendForwardedLick(event),
@@ -198,6 +203,9 @@ function createLeaderHookSetup(
     },
     clearLeaderHooks: () => {
       setConnectedFollowersGetter(null);
+      // Leader stopped — clear the worker-visible follower shim so `host`
+      // doesn't keep reporting the followers of a tray we just left.
+      writeConnectedFollowersToShim([]);
       setTrayResetter(null);
       deps.getController()?.setOnLocalUserMessage(undefined);
       deps.sprinkleManager.setSendToSprinkleHook(undefined);
@@ -394,6 +402,9 @@ export async function wireWcTray(deps: WcTrayDeps): Promise<WcTrayHandle> {
     win.localStorage.setItem('slicc.leaderTrayStatus', JSON.stringify(status));
   });
   win.localStorage.setItem('slicc.leaderTrayStatus', JSON.stringify(getLeaderTrayRuntimeStatus()));
+  // Seed the follower shim on boot so a stale value from a previous session
+  // can't make the worker-side `host` report phantom followers.
+  writeConnectedFollowersToShim(getConnectedFollowers(), win.localStorage);
 
   installRoleSwitchListeners(deps, state, clearLeaderHooks, performTrayLeaveLocally);
 

--- a/packages/webapp/tests/shell/supplemental-commands/host-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/host-command.test.ts
@@ -5,6 +5,9 @@ import {
   formatDuration,
   formatFollowerOutput,
   formatLeaderOutput,
+  getConnectedFollowersWithFallback,
+  setConnectedFollowersGetter,
+  writeConnectedFollowersToShim,
 } from '../../../src/shell/supplemental-commands/host-command.js';
 
 /** Helper to build a FollowerTrayRuntimeStatus with sensible defaults for the new diagnostic fields. */
@@ -93,6 +96,70 @@ describe('host command', () => {
     expect(result.stdout).toContain('followers:');
     expect(result.stdout).toContain('  - follower-abc123');
     expect(result.stdout).toContain('  - follower-def456');
+  });
+
+  it('mirrors connected followers to the shim so a worker-side host reads them', () => {
+    // Kernel-worker thread: no live getter, only the page→worker
+    // localStorage shim is available. Before the page-side writer was
+    // restored, nothing populated this key, so worker-side `host` never
+    // showed live followers.
+    setConnectedFollowersGetter(null);
+    const store = new Map<string, string>();
+    const fakeLs = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+    } as unknown as Storage;
+    const original = (globalThis as { localStorage?: Storage }).localStorage;
+    (globalThis as { localStorage?: Storage }).localStorage = fakeLs;
+    try {
+      const followers = [
+        {
+          runtimeId: 'follower-abc123',
+          runtime: 'slicc-extension-offscreen',
+          connectedAt: '2026-06-16T00:00:00.000Z',
+        },
+      ];
+      // Page side mirrors the live list into the shim.
+      writeConnectedFollowersToShim(followers);
+      // Worker side reads it back via the shim fallback.
+      expect(getConnectedFollowersWithFallback()).toEqual(followers);
+    } finally {
+      if (original === undefined) delete (globalThis as { localStorage?: Storage }).localStorage;
+      else (globalThis as { localStorage?: Storage }).localStorage = original;
+    }
+  });
+
+  it('writing an empty follower list clears a stale shim value', () => {
+    setConnectedFollowersGetter(null);
+    const store = new Map<string, string>([
+      [
+        'slicc.leaderTrayFollowers',
+        JSON.stringify([{ runtimeId: 'stale-follower', connectedAt: '2026-06-14T00:00:00.000Z' }]),
+      ],
+    ]);
+    const fakeLs = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+    } as unknown as Storage;
+    const original = (globalThis as { localStorage?: Storage }).localStorage;
+    (globalThis as { localStorage?: Storage }).localStorage = fakeLs;
+    try {
+      writeConnectedFollowersToShim([]);
+      expect(getConnectedFollowersWithFallback()).toEqual([]);
+    } finally {
+      if (original === undefined) delete (globalThis as { localStorage?: Storage }).localStorage;
+      else (globalThis as { localStorage?: Storage }).localStorage = original;
+    }
   });
 
   it('prints error details when leader startup failed', async () => {


### PR DESCRIPTION
## Problem

Standalone `host` runs in the kernel worker, where the live `connectedFollowersGetter` is never set (it is page/offscreen-only). So it reads the connected-follower list solely from the `slicc.leaderTrayFollowers` localStorage shim — but **nothing wrote that key**. The page-side writer was lost in the migration to the wc-shell UI, so:

- a standalone leader's `host` never reflected live followers, and
- it kept showing stale "follower" fossils from older builds that survived `nuke` / `host reset` (nothing refreshed the key — the frozen `connected Nh ago` timestamps were the tell).

The sibling `slicc.leaderTrayStatus` mirror works correctly because the page writes it on boot and on every status change (`wc-tray.ts`); the followers mirror simply lost its writer.

## Fix

Restore the page-side writer, symmetric with the status mirror:

- `writeConnectedFollowersToShim()` next to the reader in `host-command.ts`.
- `wc-tray.ts` calls it on every follower-count change, when the leader stops (→ `[]`), and on boot (seeds/clears any stale value).
- `installPageStorageSync` forwards the page write into the worker's Map-backed shim, so worker-side `host` reads the live list.

No change to the read path, and extension mode is unaffected (the offscreen leader sets the live getter and never hits the shim fallback).

## Verification

- TDD: 2 new tests in `host-command.test.ts` (worker-side read reflects a mirrored list; an empty list clears a stale value).
- `npm run lint:ci`, full `npm run typecheck` (incl. the no-DOM worker guard), `npm run test`, the webapp coverage gate, and `build -w @slicc/webapp` + `build -w @slicc/chrome-extension` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
