### PR TITLE
fix(attachments): route composer attachments to /tmp/upload instead of inlining

### DIFF
--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -61,7 +61,13 @@ function mimeFor(name: string): string {
   return map[ext] ?? 'text/plain';
 }
 
-/** Bytes → MessageAttachment: images inline as base64, the rest as text. */
+/**
+ * Bytes → MessageAttachment. Images inline as base64 (within the 4 MB cap);
+ * every other file becomes a `kind:'file'` reference with NO inline content —
+ * the staging step persists the raw bytes to {@link UPLOAD_DIR} and links the
+ * path, so binary files are never UTF-8-decoded (no mojibake) and text files
+ * are never inlined.
+ */
 export function attachmentFromBytes(name: string, bytes: Uint8Array): MessageAttachment {
   const base = { id: uid(), name, size: bytes.length };
   if (IMAGE_EXT.test(name)) {
@@ -75,13 +81,13 @@ export function attachmentFromBytes(name: string, bytes: Uint8Array): MessageAtt
     }
     return { ...base, mimeType: mimeFor(name), kind: 'image', data: toBase64(bytes) };
   }
-  if (bytes.length > MAX_TEXT_BYTES) {
-    return { ...base, mimeType: 'text/plain', kind: 'file', error: 'file too large to inline' };
-  }
-  return { ...base, mimeType: mimeFor(name), kind: 'text', text: new TextDecoder().decode(bytes) };
+  const file = { ...base, mimeType: mimeFor(name), kind: 'file' as const };
+  // Oversized files keep a fallback label only — the staging step replaces it
+  // with a persisted path when a writer is available.
+  return bytes.length > MAX_TEXT_BYTES ? { ...file, error: 'file too large to inline' } : file;
 }
 
-/** A picked/dropped File → MessageAttachment (same inlining rules). */
+/** A picked/dropped File → MessageAttachment (same rules). */
 export async function attachmentFromFile(file: File): Promise<MessageAttachment> {
   const bytes = new Uint8Array(await file.arrayBuffer());
   const attachment = attachmentFromBytes(file.name, bytes);
@@ -430,29 +436,51 @@ async function stageCapture(
   if (attachment) stage.add(attachment);
 }
 
-/** Oversized payloads fall back to a VFS copy under /tmp/upload instead of a
- *  "not included" note — the agent reads the path on demand. */
-async function withOversizeFallback(
+/**
+ * Persist a staged upload's raw bytes under {@link UPLOAD_DIR} and reference
+ * the written path — never inline file content. Images within the inline cap
+ * keep their base64 `data` (so the model still sees them) AND gain a `path` to
+ * the full-resolution original; oversized images get the path with no inline
+ * `data`. Once persisted, any inline-fallback `error` is cleared. When no
+ * writer is available we degrade gracefully: images keep their inline data (no
+ * path), and files surface a "not included" note rather than mojibake.
+ */
+async function persistStagedUpload(
   attachment: MessageAttachment,
   bytes: Uint8Array,
   deps: WireWcAttachDeps
 ): Promise<MessageAttachment> {
-  if (!attachment.error) return attachment;
   const writer = (await deps.openWriter?.().catch(() => null)) ?? null;
-  if (!writer) return attachment;
-  const path = await persistUpload(writer, attachment.name, bytes).catch(() => undefined);
-  if (!path) return attachment;
-  return { ...attachment, error: undefined, path };
+  const path = writer
+    ? await persistUpload(writer, attachment.name, bytes).catch(() => undefined)
+    : undefined;
+  if (path) return { ...attachment, error: undefined, path };
+  // No writer (or the write failed): keep inline image data; for files there is
+  // no inline content, so flag a clear "not included" reason.
+  if (attachment.kind === 'image') return attachment;
+  return { ...attachment, error: 'could not be saved to the virtual filesystem' };
 }
 
-/** Stage a VFS file pick, read through the worker-routed reader. */
+/** Stage a VFS file pick by reference — the pick already HAS a canonical path,
+ *  so link it directly instead of reading + inlining its contents. */
 async function stageVfsFile(id: string, deps: WireWcAttachDeps, stage: WcAttachmentStage) {
-  const reader = await deps.openReader();
-  const raw = await reader.readFile(id);
-  const bytes = typeof raw === 'string' ? new TextEncoder().encode(raw) : raw;
-  const attachment = attachmentFromBytes(id.split('/').pop() ?? id, bytes);
-  // A VFS pick already HAS a canonical path — reference it instead of erroring.
-  stage.add(attachment.error ? { ...attachment, error: undefined, path: id } : attachment);
+  const name = id.split('/').pop() ?? id;
+  if (IMAGE_EXT.test(name)) {
+    // Images keep an inline copy for vision alongside the existing path.
+    const reader = await deps.openReader();
+    const raw = await reader.readFile(id);
+    const bytes = typeof raw === 'string' ? new TextEncoder().encode(raw) : raw;
+    const attachment = attachmentFromBytes(name, bytes);
+    stage.add({ ...attachment, error: undefined, path: id });
+    return;
+  }
+  let size = 0;
+  try {
+    size = (await (await deps.openReader()).stat(id)).size;
+  } catch {
+    // Stat failure leaves size at 0 — the reference line still renders.
+  }
+  stage.add({ id: uid(), name, mimeType: mimeFor(name), size, kind: 'file', path: id });
 }
 
 /** Append a skill mention to the composer's draft. */
@@ -469,7 +497,7 @@ async function handleAdd(
 ): Promise<void> {
   if (detail.kind === 'upload' && detail.file instanceof File) {
     const bytes = new Uint8Array(await detail.file.arrayBuffer());
-    stage.add(await withOversizeFallback(await attachmentFromFile(detail.file), bytes, deps));
+    stage.add(await persistStagedUpload(await attachmentFromFile(detail.file), bytes, deps));
   } else if (detail.kind === 'capture') {
     await stageCapture(detail, deps, stage);
   } else if (detail.kind === 'file' && typeof detail.id === 'string') {

--- a/packages/webapp/tests/ui/wc/wc-attach.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-attach.test.ts
@@ -37,11 +37,24 @@ async function seededFs(): Promise<VirtualFS> {
 }
 
 describe('attachmentFromBytes', () => {
-  it('inlines text files as text with a mime from the extension', () => {
-    const att = attachmentFromBytes('notes.md', new TextEncoder().encode('hello'));
-    expect(att.kind).toBe('text');
-    expect(att.text).toBe('hello');
-    expect(att.mimeType).toBe('text/markdown');
+  it('references text and binary files without inlining (no text decode)', () => {
+    const text = attachmentFromBytes('notes.md', new TextEncoder().encode('hello'));
+    expect(text.kind).toBe('file');
+    expect(text.text).toBeUndefined();
+    expect(text.data).toBeUndefined();
+    expect(text.mimeType).toBe('text/markdown');
+
+    // Binary bytes are never UTF-8-decoded — no mojibake, no inline content.
+    const bin = attachmentFromBytes('archive.zip', new Uint8Array([0xff, 0xfe, 0x00, 0x01]));
+    expect(bin.kind).toBe('file');
+    expect(bin.text).toBeUndefined();
+    expect(bin.data).toBeUndefined();
+
+    // Oversized non-images keep only a fallback label (no inline content).
+    const big = attachmentFromBytes('big.bin', new Uint8Array(512 * 1024));
+    expect(big.kind).toBe('file');
+    expect(big.error).toContain('too large');
+    expect(big.text).toBeUndefined();
   });
 
   it('inlines images as base64 and flags oversized payloads instead', () => {
@@ -183,7 +196,7 @@ describe('WcAttachmentStage', () => {
 });
 
 describe('wireWcAttach action routing', () => {
-  async function setup() {
+  async function setup(opts: { withWriter?: boolean } = {}) {
     const fs = await seededFs();
     const inputCard = document.createElement('slicc-input-card') as HTMLElement & {
       value?: string;
@@ -194,6 +207,7 @@ describe('wireWcAttach action routing', () => {
       inputCard,
       freezer,
       openReader: async () => fs,
+      openWriter: opts.withWriter === false ? undefined : async () => fs,
       listConversations: async () => [],
       log,
     });
@@ -204,8 +218,8 @@ describe('wireWcAttach action routing', () => {
     inputCard.dispatchEvent(new CustomEvent('slicc-add', { bubbles: true, detail }));
   }
 
-  it('stages an uploaded File', async () => {
-    const { inputCard, stage } = await setup();
+  it('persists an uploaded text file to /tmp/upload by reference (no inline text)', async () => {
+    const { fs, inputCard, stage } = await setup();
     emitAdd(inputCard, {
       kind: 'upload',
       name: 'drop.md',
@@ -215,16 +229,106 @@ describe('wireWcAttach action routing', () => {
     await vi.waitFor(() => {
       expect(stage.items.map((a) => a.name)).toEqual(['drop.md']);
     });
-    expect(stage.items[0].text).toBe('drop');
+    const item = stage.items[0];
+    expect(item.kind).toBe('file');
+    expect(item.text).toBeUndefined();
+    expect(item.error).toBeUndefined();
+    expect(item.path?.startsWith(`${UPLOAD_DIR}/`)).toBe(true);
+    const raw = await fs.readFile(item.path as string, { encoding: 'utf-8' });
+    expect(typeof raw === 'string' ? raw : new TextDecoder().decode(raw)).toBe('drop');
   });
 
-  it('stages a VFS file pick read through the reader', async () => {
+  it('persists a binary/zip upload to /tmp/upload without decoding bytes', async () => {
+    const { fs, inputCard, stage } = await setup();
+    const bytes = new Uint8Array([0xff, 0xfe, 0x00, 0x01]);
+    emitAdd(inputCard, {
+      kind: 'upload',
+      name: 'pkg.zip',
+      size: bytes.length,
+      file: new File([bytes], 'pkg.zip', { type: 'application/zip' }),
+    });
+    await vi.waitFor(() => {
+      expect(stage.items.map((a) => a.name)).toEqual(['pkg.zip']);
+    });
+    const item = stage.items[0];
+    expect(item.kind).toBe('file');
+    expect(item.text).toBeUndefined();
+    expect(item.data).toBeUndefined();
+    expect(item.error).toBeUndefined();
+    expect(item.path?.startsWith(`${UPLOAD_DIR}/`)).toBe(true);
+    const saved = (await fs.readFile(item.path as string, { encoding: 'binary' })) as Uint8Array;
+    expect(Array.from(saved)).toEqual(Array.from(bytes));
+  });
+
+  it('degrades an upload to a not-included note when no writer is available', async () => {
+    const { inputCard, stage } = await setup({ withWriter: false });
+    emitAdd(inputCard, {
+      kind: 'upload',
+      name: 'drop.txt',
+      size: 4,
+      file: new File(['drop'], 'drop.txt', { type: 'text/plain' }),
+    });
+    await vi.waitFor(() => {
+      expect(stage.items.map((a) => a.name)).toEqual(['drop.txt']);
+    });
+    const item = stage.items[0];
+    expect(item.kind).toBe('file');
+    expect(item.text).toBeUndefined();
+    expect(item.path).toBeUndefined();
+    expect(item.error).toBe('could not be saved to the virtual filesystem');
+  });
+
+  it('keeps an image inline AND persists the original to /tmp/upload', async () => {
+    const { fs, inputCard, stage } = await setup();
+    emitAdd(inputCard, {
+      kind: 'upload',
+      name: 'pic.png',
+      size: 3,
+      file: new File([new Uint8Array([1, 2, 3])], 'pic.png', { type: 'image/png' }),
+    });
+    await vi.waitFor(() => {
+      expect(stage.items.map((a) => a.name)).toEqual(['pic.png']);
+    });
+    const item = stage.items[0];
+    expect(item.kind).toBe('image');
+    expect(item.data).toBe(btoa(String.fromCharCode(1, 2, 3)));
+    expect(item.error).toBeUndefined();
+    expect(item.path?.startsWith(`${UPLOAD_DIR}/`)).toBe(true);
+    const saved = (await fs.readFile(item.path as string, { encoding: 'binary' })) as Uint8Array;
+    expect(Array.from(saved)).toEqual([1, 2, 3]);
+  });
+
+  it('persists an over-4MB image to /tmp/upload with no inline data and no leftover error', async () => {
+    const { fs, inputCard, stage } = await setup();
+    const big = new Uint8Array(5 * 1024 * 1024);
+    emitAdd(inputCard, {
+      kind: 'upload',
+      name: 'huge.png',
+      size: big.length,
+      file: new File([big], 'huge.png', { type: 'image/png' }),
+    });
+    await vi.waitFor(() => {
+      expect(stage.items.map((a) => a.name)).toEqual(['huge.png']);
+    });
+    const item = stage.items[0];
+    expect(item.kind).toBe('image');
+    expect(item.data).toBeUndefined();
+    expect(item.error).toBeUndefined();
+    expect(item.path?.startsWith(`${UPLOAD_DIR}/`)).toBe(true);
+    const saved = (await fs.readFile(item.path as string)) as Uint8Array;
+    expect(saved.length).toBe(big.length);
+  });
+
+  it('references a VFS file pick by its existing path without inlining', async () => {
     const { inputCard, stage } = await setup();
     emitAdd(inputCard, { kind: 'file', id: '/workspace/notes.md', label: 'notes.md' });
     await vi.waitFor(() => {
       expect(stage.items.map((a) => a.name)).toEqual(['notes.md']);
     });
-    expect(stage.items[0].text).toContain('notes with');
+    const item = stage.items[0];
+    expect(item.kind).toBe('file');
+    expect(item.text).toBeUndefined();
+    expect(item.path).toBe('/workspace/notes.md');
   });
 
   it('inserts a skill mention into the composer value', async () => {


### PR DESCRIPTION
## Problem

Dropping a binary file (e.g. a `.zip`) into the composer produced two bugs:

1. The file never reached `/tmp/upload`, so the agent couldn't find it.
2. Its bytes were UTF-8-decoded and **inlined into the message as garbled mojibake**.

**Root cause** (`packages/webapp/src/ui/wc/wc-attach.ts`): `attachmentFromBytes()` classified any non-image file under 256 KB as `kind:'text'` and ran `new TextDecoder().decode(bytes)` on it. Separately, the persist step (`withOversizeFallback()`) only wrote to `/tmp/upload` when an `error` was set, so successful sub-256 KB uploads were never saved.

## Fix

Stop inlining file content. Every uploaded/dropped/picked file is persisted to `/tmp/upload` and referenced by path; images keep their inline vision copy **and** get a saved original.

| Attachment | New behavior |
|---|---|
| Text / binary file | Saved to `/tmp/upload/<ts>-<name>`, referenced by path only — no `TextDecoder`, no mojibake |
| Image ≤ 4 MB | Inline vision copy kept **+** original saved to `/tmp/upload` |
| Image > 4 MB | Full original saved to `/tmp/upload` (no inline data, no "too large" error) |
| VFS pick | References its existing path — no inlining |
| No writer (degrade) | File → clean "not included" note instead of mojibake |

### Changes (confined to 2 files)
- `packages/webapp/src/ui/wc/wc-attach.ts`: removed text-inlining/`TextDecoder` from `attachmentFromBytes` (non-image bytes → `kind:'file'`, no `text`/`data`); generalized the staging persist step into `persistStagedUpload` (always saves raw upload bytes to `/tmp/upload`, sets `path`, clears `error`; degrades to an error note when no writer); `stageVfsFile` references the existing VFS path directly; images keep downscaled inline `data` + `path`, >4 MB images saved with no inline data.
- `packages/webapp/tests/ui/wc/wc-attach.test.ts`: updated/added tests (text + binary → file, writer-backed persistence for text + zip, no-writer degrade, image inline+persist incl. >4 MB).

## Cross-runtime parity
Both standalone and extension floats route through the shared `attachWcClient` → `wireWcAttach` wiring, which supplies `openWriter` via `createRemoteWritableVfsClient`. Extension uploads also reach `/tmp/upload` — no silent gap.

## Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test -- wc-attach` ✅ (18/18)
- `npm run test:coverage:webapp` ✅ (gate passed, Lines 74.95%)

Over-4 MB image and binary-zip cases are explicitly tested.

## Follow-up (non-blocking)
No test yet for the no-writer + *image* path via `wireWcAttach` (the file no-writer path is covered).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author