### PR TITLE
fix(ui): write-first session freeze so a hung LLM provider can't lose the chat

### DIFF
--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -31,6 +31,17 @@ const log = createLogger('new-session');
  */
 const FREEZER_SESSION_ANCHOR = 'ui-new-session';
 
+/**
+ * Default race window (ms) the single-click "save" path waits for LLM
+ * enrichment before clearing the chat and letting enrichment finish in the
+ * background. The durable archive is already on disk at t=0, so this only
+ * bounds how long the user watches the spinner — never data safety.
+ */
+const DEFAULT_ENRICHMENT_RACE_MS = 20_000;
+
+/** How often the race timer reports progress (ms) to drive the spinner ring. */
+const ENRICHMENT_PROGRESS_TICK_MS = 250;
+
 export interface RunNewSessionFreezeOptions {
   /**
    * Writable VFS handle. Under `slicc_opfs_vfs === 'opfs'` AND on the
@@ -40,16 +51,55 @@ export interface RunNewSessionFreezeOptions {
    * the same shape structurally.
    */
   vfs: WritableVfsClient;
+  /**
+   * Race window in ms: how long to wait for LLM enrichment before resolving
+   * (so the caller can clear the chat) and continuing enrichment in the
+   * background. Injectable so tests don't block on the real 20s timer.
+   * Defaults to {@link DEFAULT_ENRICHMENT_RACE_MS}.
+   */
+  enrichmentRaceMs?: number;
+  /**
+   * Progress callback driven by the race timer: a 0..1 fraction of the race
+   * window elapsed, then `null` once the race resolves (LLM done or timer
+   * fired). The freezer button maps this to its busy/progress ring.
+   */
+  onProgress?: (fraction: number | null) => void;
+  /**
+   * Fired once background enrichment (the timer-won path) finally resolves,
+   * with the updated index entry (or `null` if it stayed pending). Lets the
+   * caller refresh the freezer rail when the rename + icon land late.
+   */
+  onBackgroundEnriched?: (entry: FrozenSessionIndexEntry | null) => void;
 }
 
+/** Outcome of the enrichment-vs-timer race. */
+type EnrichmentRaceResult =
+  | { kind: 'llm'; updated: FrozenSessionIndexEntry | null }
+  | { kind: 'timer' };
+
 /**
- * Resolve credentials + model + headers, then run the freezer. Returns the
- * frozen entry on success, `null` when nothing was archived (short session,
- * missing creds, or write failure). Never throws.
+ * Single-click "save" freeze — robust against LLM provider outages.
+ *
+ * 1. **Write first.** Quick-freeze the cone session to a durable
+ *    `pending-<id>.md` archive BEFORE any LLM call, so a hung provider can
+ *    never lose the conversation.
+ * 2. **Enrich + race.** Start the combined memory → title → icon enrichment
+ *    over the just-written archive and race it against a {@link
+ *    DEFAULT_ENRICHMENT_RACE_MS} timer that also drives the spinner progress.
+ * 3. **LLM wins (< race window):** apply enrichment synchronously and return
+ *    the fully-enriched entry — the chat clears at LLM-done.
+ * 4. **Timer wins:** return the (still-pending) entry so the caller clears the
+ *    chat now; enrichment continues in the background and `onBackgroundEnriched`
+ *    fires with the renamed entry once it resolves.
+ *
+ * Returns the frozen entry (pending or enriched), or `null` when nothing was
+ * archived (short session / write failure). Never throws.
  */
 export async function runNewSessionFreeze(
   opts: RunNewSessionFreezeOptions
 ): Promise<FrozenSession | null> {
+  const raceMs = opts.enrichmentRaceMs ?? DEFAULT_ENRICHMENT_RACE_MS;
+
   const apiKey = getApiKey() ?? undefined;
   let model: Model<Api> | undefined;
   try {
@@ -75,13 +125,93 @@ export async function runNewSessionFreeze(
     return null;
   }
 
-  return freezeConeSession({
+  // 1. WRITE FIRST — durable archive on disk before any LLM call.
+  const frozen = await freezeConeSession({
     sessionStore,
     vfs: opts.vfs,
-    model,
+    mode: 'quick',
+  });
+  if (!frozen) return null; // short session / write failure — nothing to do.
+
+  // No credentials → nothing to enrich now; leave the entry pending so the
+  // next boot's background scanner finishes it.
+  if (!apiKey || !model) {
+    log.info('Frozen without enrichment (no LLM credentials) — left pending', {
+      filename: frozen.filename,
+    });
+    return frozen;
+  }
+
+  // 2. Start the combined enrichment (memory → title → icon) over the
+  //    already-written pending archive. Best-effort — never throws.
+  const enrichModel = model;
+  const enrichment = enrichPendingSession(opts.vfs, frozen, {
+    model: enrichModel,
     apiKey,
     headers,
+    pickIcon: (iconOpts) =>
+      import('./quick-llm.js').then(({ pickLucideIcon }) => pickLucideIcon(iconOpts)),
+  }).catch((err) => {
+    log.warn('Single-click enrichment threw (entry stays pending)', {
+      filename: frozen.filename,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
   });
+
+  // 3 + 4. Race enrichment against the timer, driving the spinner progress.
+  const winner = await raceEnrichmentAgainstTimer(enrichment, raceMs, opts.onProgress);
+
+  if (winner.kind === 'llm') {
+    // LLM won (< raceMs): enrichment already applied; return the enriched entry.
+    return winner.updated ? { ...winner.updated, archive: frozen.archive } : frozen;
+  }
+
+  // Timer won: the archive is durable, so the caller may clear the chat now.
+  // Let enrichment finish in the background and notify the caller so the rail
+  // can refresh once the rename + icon land.
+  void enrichment.then((updated) => {
+    log.info('Background enrichment resolved after race window', {
+      filename: frozen.filename,
+      enriched: updated?.filename ?? null,
+    });
+    opts.onBackgroundEnriched?.(updated);
+  });
+  return frozen;
+}
+
+/**
+ * Race the enrichment promise against a timer, reporting 0..1 progress on a
+ * fixed tick so the freezer spinner can render a countdown ring. Always
+ * clears both timers and emits a final `null` progress on resolution.
+ */
+async function raceEnrichmentAgainstTimer(
+  enrichment: Promise<FrozenSessionIndexEntry | null>,
+  raceMs: number,
+  onProgress?: (fraction: number | null) => void
+): Promise<EnrichmentRaceResult> {
+  const start = Date.now();
+  let progressTimer: ReturnType<typeof setInterval> | undefined;
+  let raceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  onProgress?.(0);
+  if (onProgress) {
+    progressTimer = setInterval(() => {
+      onProgress(Math.min(1, (Date.now() - start) / raceMs));
+    }, ENRICHMENT_PROGRESS_TICK_MS);
+  }
+  const timer = new Promise<EnrichmentRaceResult>((resolve) => {
+    raceTimer = setTimeout(() => resolve({ kind: 'timer' }), raceMs);
+  });
+  const llm = enrichment.then((updated): EnrichmentRaceResult => ({ kind: 'llm', updated }));
+
+  try {
+    return await Promise.race([llm, timer]);
+  } finally {
+    if (progressTimer) clearInterval(progressTimer);
+    if (raceTimer) clearTimeout(raceTimer);
+    onProgress?.(null);
+  }
 }
 
 /**

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -173,11 +173,29 @@ async function pickIconBestEffort(
 ): Promise<string | undefined> {
   try {
     const pick = opts.pickIcon ?? (await import('./quick-llm.js')).pickLucideIcon;
-    return (await pick({ subject: `"${title}" — an archived chat session` })) ?? undefined;
+    const picked = (await pick({ subject: `"${title}" — an archived chat session` })) ?? undefined;
+    return await keepIfLucide(picked);
   } catch (err) {
     log.warn('Icon pick failed (freeze still proceeds)', {
       error: err instanceof Error ? err.message : String(err),
     });
+    return undefined;
+  }
+}
+
+/**
+ * Validation gate at the recording boundary: drop any picked name that isn't
+ * a real lucide registry entry so a non-lucide string never reaches the index
+ * (the card then falls back to its snowflake / lazy backfill). The injectable
+ * `pickIcon` seam can return any string, so we validate against the same
+ * `lucideIconNames()` registry the default picker validates against.
+ */
+async function keepIfLucide(name: string | undefined): Promise<string | undefined> {
+  if (!name) return undefined;
+  try {
+    const { lucideIconNames } = await import('./quick-llm.js');
+    return lucideIconNames().includes(name) ? name : undefined;
+  } catch {
     return undefined;
   }
 }
@@ -593,8 +611,12 @@ export async function enrichPendingSession(
   if (agentMessages === null) return null;
   const calls = await runEnrichmentCalls(entry, agentMessages, opts);
   if (calls === null) return null;
-  await appendEnrichmentMemory(vfs, entry, calls.bullets, opts);
+  // Pick the icon BEFORE appending memory: the pick is a read-only LLM call
+  // that can hang, while the append is non-idempotent. Running it first means
+  // a hung/aborted pick leaves the archive cleanly pending with NO memory
+  // written yet, so the boot retry runs once with no duplicate memory.
   const icon = await pickEnrichmentIcon(opts, calls.newTitle);
+  await appendEnrichmentMemory(vfs, entry, calls.bullets, opts);
   return await commitEnrichedArchive(vfs, entry, archiveContent, calls.newTitle, icon);
 }
 
@@ -610,7 +632,9 @@ async function pickEnrichmentIcon(
 ): Promise<string | undefined> {
   if (!opts.pickIcon) return undefined;
   try {
-    return (await opts.pickIcon({ subject: `"${title}" — an archived chat session` })) ?? undefined;
+    const picked =
+      (await opts.pickIcon({ subject: `"${title}" — an archived chat session` })) ?? undefined;
+    return await keepIfLucide(picked);
   } catch (err) {
     log.warn('Enrichment icon pick failed (continuing without icon)', {
       error: err instanceof Error ? err.message : String(err),

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -291,10 +291,10 @@ async function writeFrozenArchive(
     await ensureDir(opts.vfs, SESSIONS_DIR);
     await opts.vfs.writeFile(`${SESSIONS_DIR}/${filename}`, archiveMarkdown);
     await updateSessionsIndex(opts.vfs, indexEntry);
-    // LightningFS debounces superblock saves — `location.reload()` after
-    // this returns would race the debounce timer and orphan the new
-    // /sessions/ directory inode. Force a flush so the writes are
-    // durable on IDB before the caller reloads.
+    // The WC new-session flow clears the chat in-place (no `location.reload()`),
+    // but the OPFS backend still persists on its own debounce; force a flush so
+    // the archive + index are durable before the caller proceeds to clear the
+    // cone (and, on the single-click "save" path, before any LLM enrichment runs).
     await opts.vfs.flush();
     log.info('Cone session frozen', { filename, title, messageCount: session.messages.length });
     return { ...indexEntry, archive };
@@ -553,6 +553,14 @@ export interface EnrichPendingSessionOptions {
   apiKey: string;
   /** Adobe X-Session-Id and friends — forwarded to both LLM calls. */
   headers?: Record<string, string>;
+  /**
+   * Optional lucide icon picker. When provided, enrichment picks a rail
+   * icon from the LLM title and records it on the renamed index entry —
+   * so the single-click "save" path lands a fully-enriched archive (real
+   * slug + icon) without waiting for the rail's lazy backfill. Omitted by
+   * the boot-time pass, which leaves icons to the rail's lazy enrichment.
+   */
+  pickIcon?: (opts: { subject: string }) => Promise<string | null>;
 }
 
 /**
@@ -586,7 +594,29 @@ export async function enrichPendingSession(
   const calls = await runEnrichmentCalls(entry, agentMessages, opts);
   if (calls === null) return null;
   await appendEnrichmentMemory(vfs, entry, calls.bullets, opts);
-  return await commitEnrichedArchive(vfs, entry, archiveContent, calls.newTitle);
+  const icon = await pickEnrichmentIcon(opts, calls.newTitle);
+  return await commitEnrichedArchive(vfs, entry, archiveContent, calls.newTitle, icon);
+}
+
+/**
+ * Enrichment step 5b — pick a lucide rail icon from the LLM title
+ * (best-effort; `undefined` on failure or when no picker was supplied).
+ * Only the single-click "save" path passes `pickIcon`; the boot pass
+ * leaves icons to the rail's lazy backfill.
+ */
+async function pickEnrichmentIcon(
+  opts: EnrichPendingSessionOptions,
+  title: string
+): Promise<string | undefined> {
+  if (!opts.pickIcon) return undefined;
+  try {
+    return (await opts.pickIcon({ subject: `"${title}" — an archived chat session` })) ?? undefined;
+  } catch (err) {
+    log.warn('Enrichment icon pick failed (continuing without icon)', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
 }
 
 /**
@@ -731,7 +761,8 @@ async function commitEnrichedArchive(
   vfs: WritableVfsClient,
   entry: FrozenSessionIndexEntry,
   archiveContent: string,
-  newTitle: string
+  newTitle: string,
+  icon?: string
 ): Promise<FrozenSessionIndexEntry | null> {
   const oldPath = frozenSessionPath(entry);
   const newContent = rewriteArchiveTitle(archiveContent, newTitle);
@@ -748,11 +779,15 @@ async function commitEnrichedArchive(
     return null;
   }
 
+  // Carry a freshly-picked icon (single-click "save" path) or preserve an
+  // existing one; absent on the boot pass, where the rail backfills lazily.
+  const resolvedIcon = icon ?? entry.icon;
   const updatedEntry: FrozenSessionIndexEntry = {
     filename: newFilename,
     title: newTitle,
     frozenAt: entry.frozenAt,
     messageCount: entry.messageCount,
+    ...(resolvedIcon ? { icon: resolvedIcon } : {}),
   };
   try {
     await replaceIndexEntry(vfs, entry.filename, updatedEntry);

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -363,8 +363,23 @@ function wireFreezerRail(deps: FreezerRailDeps): FreezerRailHandles {
           const { runNewSessionFreeze, runNewSessionFreezeQuick } = await import(
             '../new-session.js'
           );
-          if (action === 'save') await runNewSessionFreeze({ vfs: writer });
-          else await runNewSessionFreezeQuick({ vfs: writer });
+          if (action === 'save') {
+            // Write-first + race: the durable archive lands before any LLM
+            // call, and this resolves at min(LLM-done, race window) so the
+            // chat clears even if the provider is hung. The race timer drives
+            // the spinner's progress ring; background enrichment (timer-won)
+            // refreshes the rail when the late rename/icon land.
+            await runNewSessionFreeze({
+              vfs: writer,
+              onProgress: (fraction) => {
+                const el = freezerNew();
+                if (!el) return;
+                if (fraction === null) el.removeAttribute('progress');
+                else el.setAttribute('progress', String(fraction));
+              },
+              onBackgroundEnriched: () => refreshFreezer(),
+            });
+          } else await runNewSessionFreezeQuick({ vfs: writer });
         }
         await client.clearAllMessages();
         // Clear the thread directly — re-selection only *requests* a replay,
@@ -378,7 +393,9 @@ function wireFreezerRail(deps: FreezerRailDeps): FreezerRailHandles {
         log.error('WC new session failed', err);
       } finally {
         newSessionInFlight = false;
-        freezerNew()?.removeAttribute('busy');
+        const el = freezerNew();
+        el?.removeAttribute('busy');
+        el?.removeAttribute('progress');
       }
     })();
   };

--- a/packages/webapp/tests/ui/new-session.test.ts
+++ b/packages/webapp/tests/ui/new-session.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FrozenSession, FrozenSessionIndexEntry } from '../../src/ui/session-freezer.js';
+
+const mockGetApiKey = vi.fn();
+const mockResolveCurrentModel = vi.fn();
+vi.mock('../../src/ui/provider-settings.js', () => ({
+  getApiKey: () => mockGetApiKey(),
+  resolveCurrentModel: () => mockResolveCurrentModel(),
+}));
+
+vi.mock('../../src/scoops/llm-session-id.js', () => ({ getDailyAdobeUuid: () => 'uuid-x' }));
+
+const mockInit = vi.fn(async () => {});
+vi.mock('../../src/ui/session-store.js', () => ({
+  SessionStore: class {
+    init = mockInit;
+  },
+}));
+
+const mockFreezeConeSession = vi.fn();
+const mockEnrichPendingSession = vi.fn();
+vi.mock('../../src/ui/session-freezer.js', () => ({
+  freezeConeSession: (...a: unknown[]) => mockFreezeConeSession(...a),
+  enrichPendingSession: (...a: unknown[]) => mockEnrichPendingSession(...a),
+  listPendingEnrichments: vi.fn(),
+}));
+
+const mockPickLucideIcon = vi.fn(async () => 'wrench');
+vi.mock('../../src/ui/quick-llm.js', () => ({ pickLucideIcon: mockPickLucideIcon }));
+
+import { runNewSessionFreeze } from '../../src/ui/new-session.js';
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const fakeModel = { id: 'm', provider: 'anthropic' };
+const pending: FrozenSession = {
+  filename: 'pending-abc.md',
+  title: 'heuristic title',
+  frozenAt: '2026-06-16T00-00-00-000Z',
+  messageCount: 4,
+  pendingEnrichment: true,
+  archive: {
+    id: 's',
+    title: 'heuristic title',
+    frozenAt: '',
+    createdAt: 0,
+    updatedAt: 0,
+    messageCount: 4,
+    messages: [],
+  },
+};
+const enriched: FrozenSessionIndexEntry = {
+  filename: '2026-06-16T00-00-00-000Z-real-slug.md',
+  title: 'Real Slug',
+  frozenAt: '2026-06-16T00-00-00-000Z',
+  messageCount: 4,
+  icon: 'wrench',
+};
+
+describe('runNewSessionFreeze — write-first + race', () => {
+  beforeEach(() => {
+    mockGetApiKey.mockReset().mockReturnValue('k');
+    mockResolveCurrentModel.mockReset().mockReturnValue(fakeModel);
+    mockInit.mockReset().mockResolvedValue(undefined);
+    mockFreezeConeSession.mockReset().mockResolvedValue(pending);
+    mockEnrichPendingSession.mockReset();
+    mockPickLucideIcon.mockClear();
+  });
+
+  it('writes a durable quick archive BEFORE any LLM enrichment call', async () => {
+    mockEnrichPendingSession.mockRejectedValue(new Error('provider 502'));
+    const result = await runNewSessionFreeze({ vfs: {} as never, enrichmentRaceMs: 20 });
+    // Quick (write-first) freeze ran, and ran before enrichment.
+    expect(mockFreezeConeSession).toHaveBeenCalledTimes(1);
+    expect(mockFreezeConeSession.mock.calls[0][0].mode).toBe('quick');
+    expect(mockFreezeConeSession.mock.invocationCallOrder[0]).toBeLessThan(
+      mockEnrichPendingSession.mock.invocationCallOrder[0]
+    );
+    // A hung/failing provider never loses the archive — the pending entry is returned.
+    expect(result).not.toBeNull();
+  });
+
+  it('timer wins → returns pending entry, enrichment finishes in the background', async () => {
+    const d = deferred<FrozenSessionIndexEntry | null>();
+    mockEnrichPendingSession.mockReturnValue(d.promise);
+    const onBackgroundEnriched = vi.fn();
+    const result = await runNewSessionFreeze({
+      vfs: {} as never,
+      enrichmentRaceMs: 10,
+      onBackgroundEnriched,
+    });
+    // Chat may clear now: still the pending entry, enrichment not yet applied.
+    expect(result?.filename).toBe('pending-abc.md');
+    expect(result?.pendingEnrichment).toBe(true);
+    expect(onBackgroundEnriched).not.toHaveBeenCalled();
+    // Background enrichment lands the rename + icon after the race window.
+    d.resolve(enriched);
+    await flush();
+    expect(onBackgroundEnriched).toHaveBeenCalledWith(enriched);
+  });
+
+  it('LLM wins (fast) → fully-enriched entry synchronously, no pending leftovers', async () => {
+    mockEnrichPendingSession.mockResolvedValue(enriched);
+    const result = await runNewSessionFreeze({ vfs: {} as never, enrichmentRaceMs: 10_000 });
+    expect(result?.filename).toBe(enriched.filename);
+    expect(result?.title).toBe('Real Slug');
+    expect(result?.icon).toBe('wrench');
+    expect(result?.pendingEnrichment).toBeUndefined();
+    // The save path supplies an icon picker so the healthy archive lands an icon.
+    const enrichOpts = mockEnrichPendingSession.mock.calls[0][2] as {
+      pickIcon: (o: { subject: string }) => Promise<string | null>;
+    };
+    expect(typeof enrichOpts.pickIcon).toBe('function');
+    await expect(enrichOpts.pickIcon({ subject: 's' })).resolves.toBe('wrench');
+  });
+
+  it('reports timer-driven progress: starts at 0, clears with null', async () => {
+    mockEnrichPendingSession.mockResolvedValue(enriched);
+    const onProgress = vi.fn();
+    await runNewSessionFreeze({ vfs: {} as never, enrichmentRaceMs: 50, onProgress });
+    expect(onProgress.mock.calls[0][0]).toBe(0);
+    expect(onProgress.mock.calls.at(-1)?.[0]).toBeNull();
+  });
+
+  it('no credentials → returns pending entry, skips enrichment entirely', async () => {
+    mockGetApiKey.mockReturnValue(null);
+    const result = await runNewSessionFreeze({ vfs: {} as never, enrichmentRaceMs: 10 });
+    expect(result?.filename).toBe('pending-abc.md');
+    expect(mockEnrichPendingSession).not.toHaveBeenCalled();
+  });
+
+  it('returns null when nothing was archived (short session / write failure)', async () => {
+    mockFreezeConeSession.mockResolvedValue(null);
+    const result = await runNewSessionFreeze({ vfs: {} as never, enrichmentRaceMs: 10 });
+    expect(result).toBeNull();
+    expect(mockEnrichPendingSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -245,6 +245,39 @@ describe('freezeConeSession', () => {
     expect(r2!.icon).toBeUndefined();
   });
 
+  it('drops a non-lucide picked name so the full-freeze entry records no icon', async () => {
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('NONE')
+      .mockResolvedValueOnce('Fix the auth bug');
+    const store = makeFakeStore({
+      id: 'session-cone',
+      messages: [
+        userMessage('q1'),
+        assistantMessage('a1'),
+        userMessage('q2'),
+        assistantMessage('a2'),
+      ],
+      createdAt: 100,
+      updatedAt: 200,
+    });
+    const vfs = makeFakeVfs();
+    const pickIcon = vi.fn(async () => 'not-a-real-icon');
+
+    const result = await freezeConeSession({
+      sessionStore: store,
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+      pickIcon,
+    });
+    expect(pickIcon).toHaveBeenCalledTimes(1);
+    expect(result!.icon).toBeUndefined();
+    const index = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    expect(index[0].icon).toBeUndefined();
+  });
+
   it('skips memory append when LLM returns NONE', async () => {
     mockRunOneOffCompactionCall.mockResolvedValueOnce('NONE').mockResolvedValueOnce('Quick chat');
 
@@ -958,6 +991,96 @@ describe('enrichPendingSession', () => {
       { model: fakeModel!, apiKey: 'k' }
     );
     expect(updated2!.icon).toBeUndefined();
+  });
+
+  it('drops a non-lucide picked name so the renamed entry records no icon', async () => {
+    const vfs = makeFakeVfs();
+    const { pendingFilename, frozenAt } = await seedPending(vfs);
+
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('NONE')
+      .mockResolvedValueOnce('Build pipeline debug');
+    const pickIcon = vi.fn(async () => 'not-a-real-icon');
+
+    const updated = await enrichPendingSession(
+      vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: pendingFilename,
+        title: 'debug the build pipeline',
+        frozenAt,
+        messageCount: 4,
+        pendingEnrichment: true,
+      },
+      { model: fakeModel!, apiKey: 'k', pickIcon }
+    );
+
+    expect(pickIcon).toHaveBeenCalledTimes(1);
+    expect(updated!.icon).toBeUndefined();
+    const index = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    expect(index[0].icon).toBeUndefined();
+  });
+
+  it('picks the icon before appending memory: a hung pick writes no memory, retry appends once', async () => {
+    const vfs = makeFakeVfs();
+    const { pendingFilename, frozenAt } = await seedPending(vfs);
+
+    // Run 1: a pickIcon that never resolves — the 20s-race / page-close case.
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('- prefers vitest')
+      .mockResolvedValueOnce('Build pipeline debug');
+    const hang = vi.fn(() => new Promise<string>(() => {}));
+
+    // Start enrichment but do NOT await — the hung pick never resolves.
+    void enrichPendingSession(
+      vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: pendingFilename,
+        title: 'debug the build pipeline',
+        frozenAt,
+        messageCount: 4,
+        pendingEnrichment: true,
+      },
+      { model: fakeModel!, apiKey: 'k', pickIcon: hang }
+    );
+
+    // Flush microtasks so the two LLM mock calls resolve and the flow reaches
+    // the hung pick (which runs BEFORE the non-idempotent memory append).
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(hang).toHaveBeenCalledTimes(1);
+    // Pick-before-append means the hang leaves the archive cleanly pending
+    // with NO memory written and NO commit/rename.
+    expect(vfs.files.get('/workspace/CLAUDE.md')).toBeUndefined();
+    expect(vfs.files.has(`/sessions/${pendingFilename}`)).toBe(true);
+    const indexAfterHang = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    expect(indexAfterHang[0].pendingEnrichment).toBe(true);
+
+    // Run 2 (boot retry): same bullets, no picker. Memory appends exactly once.
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('- prefers vitest')
+      .mockResolvedValueOnce('Build pipeline debug');
+    const updated = await enrichPendingSession(
+      vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: pendingFilename,
+        title: 'debug the build pipeline',
+        frozenAt,
+        messageCount: 4,
+        pendingEnrichment: true,
+      },
+      { model: fakeModel!, apiKey: 'k' }
+    );
+
+    expect(updated!.pendingEnrichment).toBeUndefined();
+    const memory = vfs.files.get('/workspace/CLAUDE.md');
+    expect(memory).toBeTruthy();
+    // The bullet appears exactly once — no duplicate-memory-on-retry.
+    expect(memory!.match(/prefers vitest/g)).toHaveLength(1);
   });
 
   it('is a no-op when the archive file is missing (already renamed)', async () => {

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -911,6 +911,55 @@ describe('enrichPendingSession', () => {
     expect(lastCall.apiKey).toBe('k');
   });
 
+  it('records a picked lucide icon on the renamed entry when pickIcon is supplied', async () => {
+    const vfs = makeFakeVfs();
+    const { pendingFilename, frozenAt } = await seedPending(vfs);
+
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('NONE')
+      .mockResolvedValueOnce('Build pipeline debug');
+    const pickIcon = vi.fn(async () => 'wrench');
+
+    const updated = await enrichPendingSession(
+      vfs as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: pendingFilename,
+        title: 'debug the build pipeline',
+        frozenAt,
+        messageCount: 4,
+        pendingEnrichment: true,
+      },
+      { model: fakeModel!, apiKey: 'k', pickIcon }
+    );
+
+    expect(pickIcon).toHaveBeenCalledTimes(1);
+    expect(pickIcon.mock.calls[0][0].subject).toContain('Build pipeline debug');
+    expect(updated!.icon).toBe('wrench');
+    const index = await readSessionsIndex(
+      vfs as unknown as Parameters<typeof readSessionsIndex>[0]
+    );
+    expect(index[0].icon).toBe('wrench');
+
+    // Without a picker the enrichment leaves the icon to the rail's backfill.
+    const vfs2 = makeFakeVfs();
+    const seeded2 = await seedPending(vfs2);
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('NONE')
+      .mockResolvedValueOnce('Another title');
+    const updated2 = await enrichPendingSession(
+      vfs2 as unknown as Parameters<typeof enrichPendingSession>[0],
+      {
+        filename: seeded2.pendingFilename,
+        title: 'debug the build pipeline',
+        frozenAt: seeded2.frozenAt,
+        messageCount: 4,
+        pendingEnrichment: true,
+      },
+      { model: fakeModel!, apiKey: 'k' }
+    );
+    expect(updated2!.icon).toBeUndefined();
+  });
+
   it('is a no-op when the archive file is missing (already renamed)', async () => {
     const vfs = makeFakeVfs();
     const result = await enrichPendingSession(

--- a/packages/webcomponents/src/freezer/slicc-freezer-new.ts
+++ b/packages/webcomponents/src/freezer/slicc-freezer-new.ts
@@ -169,12 +169,30 @@ const STYLE = `
    lucide loader the moment the new-chat work is kicked off (optimistically on a
    save click, or whenever the host sets the busy attribute), so there is
    immediate feedback before any save/reload completes. */
-.fznew-spinner { display: grid; place-items: center; color: var(--ctx); }
+.fznew-spinner { display: grid; place-items: center; color: var(--ctx); position: relative; }
 .fznew-spinner svg { display: block; animation: slicc-fznew-spin 0.8s linear infinite; }
 @keyframes slicc-fznew-spin { to { transform: rotate(360deg); } }
 
+/* .fznew-ring — determinate countdown ring drawn around the badge when the host
+   drives the progress attribute (the new-session save race's 20s timer). A
+   conic-gradient sweep filled to --fznew-progress (0..1) of a full turn,
+   masked to a thin ring so the spinning loader still reads inside it. */
+.fznew-ring {
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--ctx) calc(var(--fznew-progress, 0) * 360deg),
+    color-mix(in srgb, var(--ctx) 18%, transparent) 0
+  );
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 2px), #000 calc(100% - 2px));
+  mask: radial-gradient(farthest-side, transparent calc(100% - 2px), #000 calc(100% - 2px));
+  pointer-events: none;
+}
+
 /* Respect prefers-reduced-motion: no fade, no spin — just hold the static end
-   state (the loader glyph still shows, it simply does not rotate). */
+   state (the loader glyph still shows, it simply does not rotate). The
+   determinate ring stays — it conveys progress, not motion. */
 @media (prefers-reduced-motion: reduce) {
   .fznew, .nlbl { transition: none; }
   .fznew-spinner svg { animation: none; }
@@ -222,10 +240,14 @@ const SHEET = sheet(STYLE);
  * @attr label - the label text / accessible name (default "New chat")
  * @attr busy - boolean; swaps the badge glyph for a spinning loader (entered
  *   optimistically on a save click; also host-drivable)
+ * @attr progress - number 0..1; while busy, draws a determinate countdown ring
+ *   around the badge filled to this fraction (host-driven by the save race's
+ *   20s timer). Absent → the busy state is the plain indeterminate spinner.
  * @csspart button - the inner `<button>` element (the `.fznew` node)
  * @csspart badge - the circular `.nico` icon badge
  * @csspart icon - the lucide `<svg>` glyph inside the badge
  * @csspart spinner - the busy-state spinner wrapper around the loader glyph
+ * @csspart ring - the determinate progress ring drawn around the spinner
  * @csspart label - the `.nlbl` text span
  * @csspart options - the `.fznew-options` legend (expanded, hover/focus only)
  * @csspart option-save / option-skip / option-erase - the three legend buttons
@@ -236,7 +258,7 @@ const SHEET = sheet(STYLE);
  * @fires new-chat-erase - long press / modifier-click: new chat erasing this one
  */
 export class SliccFreezerNew extends HTMLElement {
-  static readonly observedAttributes = ['expanded', 'label', 'busy'];
+  static readonly observedAttributes = ['expanded', 'label', 'busy', 'progress'];
 
   readonly #root: ShadowRoot;
   #button: HTMLButtonElement | null = null;
@@ -261,7 +283,11 @@ export class SliccFreezerNew extends HTMLElement {
     this.#clearPendingShort();
   }
 
-  attributeChangedCallback(): void {
+  attributeChangedCallback(name: string): void {
+    // Progress updates fire on a fast timer; when the ring already exists,
+    // mutate its CSS var in place rather than re-rendering — a full render
+    // would rebuild the loader <svg> and restart its spin animation each tick.
+    if (name === 'progress' && this.#updateProgressInPlace()) return;
     if (this.isConnected) this.#render();
   }
 
@@ -298,14 +324,53 @@ export class SliccFreezerNew extends HTMLElement {
     this.toggleAttribute('busy', value);
   }
 
+  /**
+   * Determinate progress (0..1) for the busy-state countdown ring. `null`
+   * (attribute absent) → the plain indeterminate spinner. Out-of-range values
+   * are clamped. Reflected to the `progress` attribute; only renders a ring
+   * while {@link busy}.
+   */
+  get progress(): number | null {
+    const raw = this.getAttribute('progress');
+    if (raw == null) return null;
+    const n = Number.parseFloat(raw);
+    return Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : null;
+  }
+
+  set progress(value: number | null) {
+    if (value == null) this.removeAttribute('progress');
+    else this.setAttribute('progress', String(Math.min(1, Math.max(0, value))));
+  }
+
+  /**
+   * Fast-path for streaming `progress` updates: if the ring is already in the
+   * DOM (busy + progress present), just update its `--fznew-progress` var and
+   * skip the full re-render. Returns false when a full render is needed to add
+   * or remove the ring (busy/progress just toggled).
+   */
+  #updateProgressInPlace(): boolean {
+    const ring = this.#root.querySelector('.fznew-ring') as HTMLElement | null;
+    if (!ring || !this.busy || !this.hasAttribute('progress')) return false;
+    ring.style.setProperty('--fznew-progress', String(this.progress ?? 0));
+    return true;
+  }
+
   #render(): void {
     const label = this.label;
     const busy = this.busy;
+    const showRing = busy && this.hasAttribute('progress');
 
     const glyph = busy
       ? h(
           'span',
           { class: 'fznew-spinner', part: 'spinner' },
+          showRing
+            ? h('span', {
+                class: 'fznew-ring',
+                part: 'ring',
+                style: `--fznew-progress:${this.progress ?? 0}`,
+              })
+            : null,
           iconEl(SPINNER_ICON, { size: ICON_SIZE, part: 'icon' })
         )
       : h('slot', { name: 'icon' }, iconEl(NEW_CHAT_ICON, { size: ICON_SIZE, part: 'icon' }));

--- a/packages/webcomponents/tests/freezer/slicc-freezer-new.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-freezer-new.test.ts
@@ -393,6 +393,73 @@ describe('slicc-freezer-new', () => {
     expect(spinRule?.style.animationName).toBe('none');
   });
 
+  // --- determinate progress ring -------------------------------------------
+
+  it('reflects the progress property to the attribute and clamps to 0..1', () => {
+    const el = mount();
+    expect(el.progress).toBeNull();
+    el.progress = 0.5;
+    expect(el.getAttribute('progress')).toBe('0.5');
+    expect(el.progress).toBe(0.5);
+    el.progress = 2;
+    expect(el.progress).toBe(1);
+    el.progress = -1;
+    expect(el.progress).toBe(0);
+    el.progress = null;
+    expect(el.hasAttribute('progress')).toBe(false);
+    expect(el.progress).toBeNull();
+  });
+
+  it('busy without progress shows no determinate ring (plain spinner)', () => {
+    const el = mount((node) => {
+      node.busy = true;
+    });
+    expect(el.shadowRoot?.querySelector('.fznew-spinner')).toBeTruthy();
+    expect(el.shadowRoot?.querySelector('.fznew-ring')).toBeNull();
+  });
+
+  it('busy + progress renders the ring with the part hook and the progress var', () => {
+    const el = mount((node) => {
+      node.busy = true;
+      node.progress = 0.25;
+    });
+    const ring = el.shadowRoot?.querySelector('.fznew-ring') as HTMLElement;
+    expect(ring).toBeTruthy();
+    expect(ring.getAttribute('part')).toBe('ring');
+    expect(ring.style.getPropertyValue('--fznew-progress')).toBe('0.25');
+  });
+
+  it('does NOT render a ring when progress is set but the element is idle', () => {
+    const el = mount((node) => {
+      node.progress = 0.5;
+    });
+    expect(el.shadowRoot?.querySelector('.fznew-ring')).toBeNull();
+  });
+
+  it('streams progress updates in place without rebuilding the spinner svg', () => {
+    const el = mount((node) => {
+      node.busy = true;
+      node.progress = 0.1;
+    });
+    const svgBefore = el.shadowRoot?.querySelector('.fznew-spinner svg');
+    el.progress = 0.8;
+    const ring = el.shadowRoot?.querySelector('.fznew-ring') as HTMLElement;
+    expect(ring.style.getPropertyValue('--fznew-progress')).toBe('0.8');
+    // Same svg node — the fast path updated the var, it did not re-render.
+    expect(el.shadowRoot?.querySelector('.fznew-spinner svg')).toBe(svgBefore);
+  });
+
+  it('removing the progress attribute drops the ring back to the plain spinner', () => {
+    const el = mount((node) => {
+      node.busy = true;
+      node.progress = 0.5;
+    });
+    expect(el.shadowRoot?.querySelector('.fznew-ring')).toBeTruthy();
+    el.progress = null;
+    expect(el.shadowRoot?.querySelector('.fznew-ring')).toBeNull();
+    expect(el.shadowRoot?.querySelector('.fznew-spinner')).toBeTruthy();
+  });
+
   // --- base appearance / metrics (real Chromium) ---------------------------
 
   it('is a full-width 36px-row button with an 8px radius and pointer cursor', () => {


### PR DESCRIPTION
## Problem

Clicking "New chat" (single-click "Save & start new") in the collapsed side rail could leave `/sessions` empty, losing the conversation. Root cause: the save path ran three sequential LLM calls (memory → title → icon) *before* the durable archive write, and `runOneOffCompactionCall` has no timeout. When the provider degraded (Bedrock/tray 502s + retry loop), the `await` hung and the write at `session-freezer.ts` was never reached.

## Fix (write-first + 20s race + background enrichment)

1. **Write first** — the save path now durably writes the archive (`pending-<id>.md`, `pendingEnrichment: true`) to `/sessions` BEFORE any LLM call, reusing the existing quick-mode machinery. The conversation is safe regardless of the provider.
2. **20s race** — enrichment (memory → title → icon) is raced against an injectable 20-second timer (`enrichmentRaceMs`); the chat clears at `min(LLM-done, 20s)`.
3. **Timer wins** — chat clears immediately and enrichment continues in the background, then renames `pending-<id>.md` → canonical `<timestamp>-<slug>.md`, sets the icon, appends memory to `/workspace/CLAUDE.md`, and clears `pendingEnrichment` in `index.json`. Survives the in-place chat clear (no reload).
4. **LLM wins** — fully-enriched archive synchronously, no `pending-` / `pendingEnrichment` leftovers.
5. **Spinner** — a timer-driven progress ring on `slicc-freezer-new` shows the wait.
6. Stale LightningFS/`location.reload()` comment in `session-freezer.ts` corrected.

Works in both standalone and extension floats via the shared `wc-live` save path.

## Files

- `packages/webapp/src/ui/new-session.ts`
- `packages/webapp/src/ui/session-freezer.ts`
- `packages/webapp/src/ui/wc/wc-live.ts`
- `packages/webcomponents/src/freezer/slicc-freezer-new.ts`
- plus mirrored tests

## Verification

- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `npm run test -w @slicc/webapp` — PASS
- `npm run test -w @slicc/webcomponents` — PASS

New regression tests cover: LLM hang/reject → archive still written first; timer wins → background enrichment renames pending → canonical and clears the flag; LLM wins → enriched synchronously with no leftovers. The 20s window is injectable so the suite doesn't block on a real timer.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author