### PR TITLE
fix(scoops): log destroyScoopTab rollback failures during scoop init

### DIFF
--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -2055,7 +2055,13 @@ export class Orchestrator implements ConeApprovalRouter {
         error: err instanceof Error ? err.message : String(err),
       });
       // Best-effort rollback — leave no half-registered scoop behind.
-      await this.destroyScoopTab(scoop.jid).catch(() => {});
+      await this.destroyScoopTab(scoop.jid).catch((destroyErr) => {
+        log.warn('Failed to destroy scoop runtime during init rollback', {
+          jid: scoop.jid,
+          name: scoop.name,
+          error: destroyErr instanceof Error ? destroyErr.message : String(destroyErr),
+        });
+      });
       this.scoops.delete(scoop.jid);
       this.messageQueues.delete(scoop.jid);
       await db.deleteScoop(scoop.jid).catch((rollbackErr) => {

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -1271,6 +1271,105 @@ describe('Orchestrator observer cleanup on scoop teardown', () => {
   });
 });
 
+describe('Orchestrator registerScoop init-failure rollback', () => {
+  let orch: Orchestrator;
+  let priorWindow: unknown;
+  let windowWasShimmed = false;
+
+  beforeAll(() => {
+    if (typeof (globalThis as any).window === 'undefined') {
+      priorWindow = (globalThis as any).window;
+      (globalThis as any).window = globalThis;
+      windowWasShimmed = true;
+    }
+  });
+
+  afterAll(() => {
+    if (windowWasShimmed) {
+      if (priorWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = priorWindow;
+      }
+    }
+  });
+
+  beforeEach(async () => {
+    await initDB();
+    const existing = await getAllScoops();
+    const { deleteScoop } = await import('../../src/scoops/db.js');
+    for (const jid of Object.keys(existing)) {
+      await deleteScoop(jid);
+    }
+    await saveScoop(cone);
+  });
+
+  afterEach(async () => {
+    const sharedFs = orch?.getSharedFS();
+    await orch?.shutdown();
+    await settleAndDisposeSharedFs(sharedFs);
+  });
+
+  function noopCallbacks() {
+    return {
+      onResponse: vi.fn(),
+      onResponseDone: vi.fn(),
+      onSendMessage: vi.fn(),
+      onStatusChange: vi.fn(),
+      onError: vi.fn(),
+      getBrowserAPI: vi.fn(() => ({}) as any),
+    };
+  }
+
+  it('logs destroyScoopTab rollback failure via log.warn and still surfaces the init error', async () => {
+    const scoop: RegisteredScoop = {
+      jid: 'scoop_init_rollback_1',
+      name: 'init-rollback',
+      folder: 'init-rollback-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'init-rollback-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(container, noopCallbacks());
+    await orch.init();
+
+    const initErr = new Error('createScoopTab boom');
+    const destroyErr = new Error('destroyScoopTab boom');
+    vi.spyOn(orch, 'createScoopTab').mockRejectedValueOnce(initErr);
+    vi.spyOn(orch, 'destroyScoopTab').mockRejectedValueOnce(destroyErr);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await expect(orch.registerScoop(scoop)).rejects.toBe(initErr);
+
+      // Assert log.warn was called with the rollback-specific message and
+      // a payload carrying jid/name plus the string-normalized error.
+      const rollbackCall = warnSpy.mock.calls.find(
+        (call) =>
+          typeof call[1] === 'string' &&
+          call[1].includes('Failed to destroy scoop runtime during init rollback')
+      );
+      expect(rollbackCall).toBeDefined();
+      expect(rollbackCall![2]).toMatchObject({
+        jid: scoop.jid,
+        name: scoop.name,
+        error: destroyErr.message,
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
 describe('Orchestrator scoop-notify onIncomingMessage visibility', () => {
   // Confirms the regression fix: when a scoop completes, the orchestrator
   // must fire `onIncomingMessage` for the cone so the UI can render the


### PR DESCRIPTION
## What

Fixes #1029.

`Orchestrator.registerScoop`'s init-failure rollback swallowed any error from `destroyScoopTab` with an empty `.catch(() => {})`, while the very next rollback step (`db.deleteScoop`) logs its error. `destroyScoopTab` is the call that tears down the scoop's running kernel/page-worker runtime — exactly the thing most likely to fail when init has already gone wrong, and a silent failure there leaks a worker under a now-deleted scoop record.

This matches the sibling rollback's logging shape: the catch stays (rollback must not mask the original init error — `throw err` is preserved), but it now emits a `log.warn` with `jid`, `name`, and the string-normalized error.

## Changes

- `packages/webapp/src/scoops/orchestrator.ts`: replace the silent `.catch(() => {})` on the rollback `destroyScoopTab` call with a logging catch.
- `packages/webapp/tests/scoops/orchestrator.test.ts`: add a regression test that stubs `createScoopTab` + `destroyScoopTab` to reject, asserting the warning is emitted **and** the original init error still surfaces.

## Verification

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test -w @slicc/webapp -- orchestrator` — 115/115 pass

## Cross-runtime parity

N/A — this is a single logging change inside the shared webapp orchestrator; no peer runtime (`chrome-extension` / `node-server` / `swift-server` / `ios-app`) carries an equivalent rollback path.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author