### PR TITLE
fix(ui): improve quick-label icon picking for tool activity

### DIFF
--- a/packages/webapp/src/ui/quick-llm.ts
+++ b/packages/webapp/src/ui/quick-llm.ts
@@ -14,6 +14,7 @@
 
 import type { Api, Model, UserMessage } from '@earendil-works/pi-ai';
 import { completeSimple } from '@earendil-works/pi-ai';
+import { hasIcon } from '@slicc/webcomponents/icons';
 // The registry is already in the page bundle — the web components render from it.
 import { icons as lucideIcons } from 'lucide';
 import { createLogger } from '../core/logger.js';
@@ -167,7 +168,7 @@ export async function pickLucideIcon(opts: PickLucideIconOptions): Promise<strin
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9-]/g, '');
-  return names.includes(candidate) ? candidate : null;
+  return hasIcon(candidate) ? candidate : null;
 }
 
 // --- Model picking ---

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -22,6 +22,7 @@
 
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
 import type { Api, Model } from '@earendil-works/pi-ai';
+import { hasIcon } from '@slicc/webcomponents/icons';
 import {
   COMPACTION_MEMORY_INSTRUCTION,
   COMPACTION_TITLE_INSTRUCTION,
@@ -174,7 +175,7 @@ async function pickIconBestEffort(
   try {
     const pick = opts.pickIcon ?? (await import('./quick-llm.js')).pickLucideIcon;
     const picked = (await pick({ subject: `"${title}" — an archived chat session` })) ?? undefined;
-    return await keepIfLucide(picked);
+    return keepIfLucide(picked);
   } catch (err) {
     log.warn('Icon pick failed (freeze still proceeds)', {
       error: err instanceof Error ? err.message : String(err),
@@ -187,17 +188,12 @@ async function pickIconBestEffort(
  * Validation gate at the recording boundary: drop any picked name that isn't
  * a real lucide registry entry so a non-lucide string never reaches the index
  * (the card then falls back to its snowflake / lazy backfill). The injectable
- * `pickIcon` seam can return any string, so we validate against the same
- * `lucideIconNames()` registry the default picker validates against.
+ * `pickIcon` seam can return any string, so we validate against the shared
+ * `hasIcon` registry check used by the default picker.
  */
-async function keepIfLucide(name: string | undefined): Promise<string | undefined> {
+function keepIfLucide(name: string | undefined): string | undefined {
   if (!name) return undefined;
-  try {
-    const { lucideIconNames } = await import('./quick-llm.js');
-    return lucideIconNames().includes(name) ? name : undefined;
-  } catch {
-    return undefined;
-  }
+  return hasIcon(name) ? name : undefined;
 }
 
 /** Freeze step 1 — memory extraction (best-effort; failures never block). */

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -6,7 +6,7 @@
  * pipeline so both UIs render byte-identical HTML for the same content.
  */
 
-import type { SliccUserMessage } from '@slicc/webcomponents';
+import { hasIcon, type SliccUserMessage } from '@slicc/webcomponents';
 import type { MessageAttachment } from '../../core/attachments.js';
 import { renderAssistantMessageContent, renderMessageContent } from '../message-renderer.js';
 import type { ChatMessage, ToolCall } from '../types.js';
@@ -116,9 +116,9 @@ export function bashProgram(command: string): string {
  * Lucide icons for the shell's built-in commands — the cogwheel/CLI glyph is
  * the last resort, not the default look of every bash row.
  */
-const BASH_ICONS: Readonly<Record<string, string>> = {
+export const BASH_ICONS: Readonly<Record<string, string>> = {
   git: 'git-branch',
-  gh: 'github',
+  gh: 'git-pull-request',
   ls: 'folder-open',
   cat: 'file-text',
   head: 'file-text',
@@ -179,30 +179,37 @@ const BASH_ICONS: Readonly<Record<string, string>> = {
   pbpaste: 'clipboard-paste',
 };
 
-/** Lucide icon for a tool row (per-command for bash, per-tool otherwise). */
+/** Lucide icons for the non-bash tools — exported for the icon-validity guard. */
+export const TOOL_ICONS: Readonly<Record<string, string>> = {
+  read_file: 'file-text',
+  write_file: 'file-plus',
+  edit_file: 'file-pen',
+  send_message: 'message-circle',
+  list_scoops: 'ice-cream-cone',
+  scoop_scoop: 'ice-cream-cone',
+  feed_scoop: 'utensils',
+  drop_scoop: 'trash-2',
+  scoop_mute: 'bell-off',
+  scoop_unmute: 'bell-ring',
+  scoop_wait: 'hourglass',
+  update_global_memory: 'brain',
+  lick_confirm: 'shield-check',
+  lick_dismiss: 'shield-x',
+  sudo_request: 'shield-question',
+  list_sudo_requests: 'list-checks',
+};
+
+/** Lucide icon for a tool row (per-command for bash, per-tool otherwise). The
+ *  chosen name is validated against the live `lucide` registry so a typo (e.g.
+ *  the historic `github` entry, which lucide ships as `github-` family glyphs)
+ *  falls back to a known-good generic instead of a blank `<svg>` placeholder. */
 export function toolIcon(call: Pick<ToolCall, 'name' | 'input'>): string {
   if (call.name === 'bash') {
-    return BASH_ICONS[bashProgram(bashCommand(call.input))] ?? 'terminal';
+    const picked = BASH_ICONS[bashProgram(bashCommand(call.input))] ?? 'terminal';
+    return hasIcon(picked) ? picked : 'terminal';
   }
-  const fixed: Record<string, string> = {
-    read_file: 'file-text',
-    write_file: 'file-plus',
-    edit_file: 'file-pen',
-    send_message: 'message-circle',
-    list_scoops: 'ice-cream-cone',
-    scoop_scoop: 'ice-cream-cone',
-    feed_scoop: 'utensils',
-    drop_scoop: 'trash-2',
-    scoop_mute: 'bell-off',
-    scoop_unmute: 'bell-ring',
-    scoop_wait: 'hourglass',
-    update_global_memory: 'brain',
-    lick_confirm: 'shield-check',
-    lick_dismiss: 'shield-x',
-    sudo_request: 'shield-question',
-    list_sudo_requests: 'list-checks',
-  };
-  return fixed[call.name] ?? 'wrench';
+  const picked = TOOL_ICONS[call.name] ?? 'wrench';
+  return hasIcon(picked) ? picked : 'wrench';
 }
 
 /**

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -133,6 +133,10 @@ const HOUSEKEEPING_PROGRAMS: ReadonlySet<string> = new Set([
  * highest scorer — first wins on ties. When every segment is housekeeping
  * (e.g. `cd /tmp && pwd`), the first one still wins so the row icon stays
  * deterministic instead of going empty.
+ *
+ * The segment split is purely textual and does NOT honor shell quoting or
+ * comments — deliberate, since worst case is a slightly-off icon, never a
+ * crash.
  */
 export function bashIconProgram(command: string): string {
   const segments = command.split(/&&|\|\||[;|\n]/);
@@ -140,7 +144,7 @@ export function bashIconProgram(command: string): string {
   for (const seg of segments) {
     const prog = bashProgram(seg);
     if (!prog) continue;
-    const score = HOUSEKEEPING_PROGRAMS.has(prog) ? 1 : prog in BASH_ICONS ? 3 : 2;
+    const score = HOUSEKEEPING_PROGRAMS.has(prog) ? 1 : Object.hasOwn(BASH_ICONS, prog) ? 3 : 2;
     if (!best || score > best.score) best = { program: prog, score };
   }
   return best?.program ?? '';
@@ -239,10 +243,11 @@ export const TOOL_ICONS: Readonly<Record<string, string>> = {
  *  falls back to a known-good generic instead of a blank `<svg>` placeholder. */
 export function toolIcon(call: Pick<ToolCall, 'name' | 'input'>): string {
   if (call.name === 'bash') {
-    const picked = BASH_ICONS[bashIconProgram(bashCommand(call.input))] ?? 'terminal';
+    const key = bashIconProgram(bashCommand(call.input));
+    const picked = Object.hasOwn(BASH_ICONS, key) ? BASH_ICONS[key] : 'terminal';
     return hasIcon(picked) ? picked : 'terminal';
   }
-  const picked = TOOL_ICONS[call.name] ?? 'wrench';
+  const picked = Object.hasOwn(TOOL_ICONS, call.name) ? TOOL_ICONS[call.name] : 'wrench';
   return hasIcon(picked) ? picked : 'wrench';
 }
 

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -112,6 +112,40 @@ export function bashProgram(command: string): string {
   return '';
 }
 
+/** Low-signal "housekeeping" programs: navigation, env setup, no-ops. They
+ *  rank below any real command so a chained `cd repo && git push` draws the
+ *  `git-branch` icon, not `corner-down-right`. */
+const HOUSEKEEPING_PROGRAMS: ReadonlySet<string> = new Set([
+  'cd',
+  'echo',
+  'export',
+  'pwd',
+  'true',
+  ':',
+  'set',
+]);
+
+/**
+ * Pick the most semantically meaningful program from a bash command that may
+ * chain several segments together. Splits on `&&`, `||`, `;`, `|`, and
+ * newlines, extracts each segment's program via {@link bashProgram}, scores
+ * each (known-in-`BASH_ICONS` > unknown > housekeeping), and returns the
+ * highest scorer — first wins on ties. When every segment is housekeeping
+ * (e.g. `cd /tmp && pwd`), the first one still wins so the row icon stays
+ * deterministic instead of going empty.
+ */
+export function bashIconProgram(command: string): string {
+  const segments = command.split(/&&|\|\||[;|\n]/);
+  let best: { program: string; score: number } | null = null;
+  for (const seg of segments) {
+    const prog = bashProgram(seg);
+    if (!prog) continue;
+    const score = HOUSEKEEPING_PROGRAMS.has(prog) ? 1 : prog in BASH_ICONS ? 3 : 2;
+    if (!best || score > best.score) best = { program: prog, score };
+  }
+  return best?.program ?? '';
+}
+
 /**
  * Lucide icons for the shell's built-in commands — the cogwheel/CLI glyph is
  * the last resort, not the default look of every bash row.
@@ -205,7 +239,7 @@ export const TOOL_ICONS: Readonly<Record<string, string>> = {
  *  falls back to a known-good generic instead of a blank `<svg>` placeholder. */
 export function toolIcon(call: Pick<ToolCall, 'name' | 'input'>): string {
   if (call.name === 'bash') {
-    const picked = BASH_ICONS[bashProgram(bashCommand(call.input))] ?? 'terminal';
+    const picked = BASH_ICONS[bashIconProgram(bashCommand(call.input))] ?? 'terminal';
     return hasIcon(picked) ? picked : 'terminal';
   }
   const picked = TOOL_ICONS[call.name] ?? 'wrench';

--- a/packages/webapp/tests/ui/quick-llm.test.ts
+++ b/packages/webapp/tests/ui/quick-llm.test.ts
@@ -254,4 +254,15 @@ describe('lucideIconNames / pickLucideIcon', () => {
     );
     expect(await pickLucideIcon({ subject: 'x', labelFn: async () => null })).toBe(null);
   });
+
+  it('hasIcon agrees with every name lucideIconNames() enumerates', async () => {
+    // Pins the two derivations together so the kebab↔Pascal round-trips
+    // (pascalToKebab in quick-llm.ts ↔ toPascal in webcomponents/internal/icons.ts)
+    // can never silently diverge after consolidating on hasIcon().
+    const { lucideIconNames } = await import('../../src/ui/quick-llm.js');
+    const { hasIcon } = await import('@slicc/webcomponents/icons');
+    const names = lucideIconNames();
+    const missing = names.filter((name) => !hasIcon(name));
+    expect(missing).toEqual([]);
+  });
 });

--- a/packages/webapp/tests/ui/wc/wc-message-view.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-message-view.test.ts
@@ -15,13 +15,16 @@ vi.mock('../../../src/ui/quick-llm.js', () => ({
   quickLabel: vi.fn(async () => 'Push the release to main'),
 }));
 
+import { hasIcon } from '@slicc/webcomponents';
 import { createChatFixture } from '../../../src/ui/chat-fixture.js';
 import type { ChatMessage } from '../../../src/ui/types.js';
 import {
+  BASH_ICONS,
   buildThreadChildren,
   collateLickMessages,
   messageEls,
   summarizeToolInput,
+  TOOL_ICONS,
 } from '../../../src/ui/wc/wc-message-view.js';
 
 const fixture = createChatFixture();
@@ -298,6 +301,25 @@ describe('tool presentation', () => {
       expect(row.getAttribute('label'), name).toBe(title);
       expect(row.getAttribute('icon'), name).toBe(icon);
     }
+  });
+
+  // Regression guard: every name in `BASH_ICONS` and `TOOL_ICONS` must resolve
+  // against the real lucide registry, plus the generic fallbacks `toolIcon`
+  // returns on miss. Without this guard, a bad entry (historically
+  // `gh: 'github'` — lucide ships `Github` is gone, only family glyphs) ships
+  // a blank `<svg>` placeholder for the row icon.
+  it('every quick-label icon name is a real lucide icon', () => {
+    const bad: string[] = [];
+    for (const [key, name] of Object.entries(BASH_ICONS)) {
+      if (!hasIcon(name)) bad.push(`BASH_ICONS.${key} → ${name}`);
+    }
+    for (const [key, name] of Object.entries(TOOL_ICONS)) {
+      if (!hasIcon(name)) bad.push(`TOOL_ICONS.${key} → ${name}`);
+    }
+    for (const name of ['terminal', 'wrench']) {
+      if (!hasIcon(name)) bad.push(`fallback → ${name}`);
+    }
+    expect(bad).toEqual([]);
   });
 
   it('bash bodies render terminal-style: command + output, dark classes', () => {

--- a/packages/webapp/tests/ui/wc/wc-message-view.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-message-view.test.ts
@@ -377,6 +377,31 @@ describe('tool presentation', () => {
     }
   });
 
+  // Prototype-chain hardening: `in`/bracket access on plain objects walks the
+  // prototype chain, so a segment whose program literally is `toString` (or
+  // any Object.prototype member) would otherwise score as a real tool and the
+  // lookup would return an inherited function — which crashes `hasIcon()`
+  // (`name.replace is not a function`) while rendering the row.
+  it('bash segments named after Object.prototype members fall back to terminal', () => {
+    const cases: string[] = [
+      'cd /tmp && toString',
+      'cd /tmp && hasOwnProperty',
+      'cd /tmp && valueOf',
+      'cd /tmp && constructor',
+    ];
+    for (const command of cases) {
+      const [, row] = messageEls(call('bash', { command }, 'ok'));
+      expect(row.getAttribute('icon'), command).toBe('terminal');
+    }
+  });
+
+  it('tool names equal to Object.prototype members fall back to wrench', () => {
+    for (const name of ['toString', 'hasOwnProperty', 'valueOf', 'constructor']) {
+      const [, row] = messageEls(call(name, {}, 'ok'));
+      expect(row.getAttribute('icon'), name).toBe('wrench');
+    }
+  });
+
   it('edit bodies show old/new with the diff classes; writes show added content', () => {
     const [, editRow] = messageEls(
       call('edit_file', { path: '/a.ts', old_string: 'before', new_string: 'after' }, 'ok')

--- a/packages/webapp/tests/ui/wc/wc-message-view.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-message-view.test.ts
@@ -345,6 +345,38 @@ describe('tool presentation', () => {
     expect(custom.output).toBe('On branch main');
   });
 
+  // Chained bash commands: the row icon is driven by the most semantically
+  // meaningful segment (the "real work"), not a low-signal preamble like a
+  // `cd`/`echo`/`export`. See issue #1035.
+  it('ranks chained bash segments so housekeeping preambles lose the icon', () => {
+    const cases: Array<[string, string]> = [
+      // Housekeeping preamble loses to a known git command.
+      ['cd repo && git push', 'git-branch'],
+      // Pure housekeeping pipe still resolves deterministically (first wins).
+      ['cd /tmp && pwd', 'corner-down-right'],
+      // Env-setup housekeeping loses to curl (known network tool).
+      ['export FOO=1 && curl https://x', 'globe'],
+      // Echo housekeeping loses to a known command — npm beats echo here, so
+      // the row picks up npm's `package` icon rather than echo's `quote`.
+      ['echo hi && npm test', 'package'],
+      // The `test` supplemental command outranks an echo preamble: this is
+      // the literal "echo + real-command → real-command icon" case from the
+      // spec, picking `flask-conical` from BASH_ICONS.test.
+      ['echo hi && test foo', 'flask-conical'],
+      // Pipe is also a separator.
+      ['cat foo | grep bar', 'file-text'],
+      // Newline is a separator.
+      ['cd /tmp\ngit status', 'git-branch'],
+      // `||` and `;` are separators too.
+      ['true || rm -rf /tmp/x', 'trash-2'],
+      ['set -e; npm install', 'package'],
+    ];
+    for (const [command, icon] of cases) {
+      const [, row] = messageEls(call('bash', { command }, 'ok'));
+      expect(row.getAttribute('icon'), command).toBe(icon);
+    }
+  });
+
   it('edit bodies show old/new with the diff classes; writes show added content', () => {
     const [, editRow] = messageEls(
       call('edit_file', { path: '/a.ts', old_string: 'before', new_string: 'after' }, 'ok')

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -14,6 +14,10 @@
       "types": "./src/composer/speech.ts",
       "default": "./src/composer/speech.ts"
     },
+    "./icons": {
+      "types": "./src/internal/icons.ts",
+      "default": "./src/internal/icons.ts"
+    },
     "./src/*": "./src/*"
   },
   "files": [


### PR DESCRIPTION
## Summary

Fixes #1035. Two quality problems with the per-tool-row quick-label activity icon in the chat view (both localized to `packages/webapp/src/ui/wc/wc-message-view.ts`), plus a follow-up cleanup that unifies icon-name validation on a single shared helper.

### Problem 1 — broken icon names

`toolIcon()` returned icon names from a static map without validating them against the actual Lucide set. The map contained `gh: 'github'`, but `github` is a brand icon removed from `lucide ^1.8.0`, so it rendered as a blank SVG.

**Fix:**

- `toolIcon()` now validates the chosen name via `hasIcon` from `@slicc/webcomponents`, falling back to `terminal` (bash) / `wrench` (other tools) when a name isn't a real icon.
- `gh: 'github'` → `gh: 'git-pull-request'`.
- A guard test iterates every entry in `BASH_ICONS` + `TOOL_ICONS` plus the fallbacks and asserts each is a real Lucide icon, so any future bad entry fails CI.

### Problem 2 — least-interesting command drove the icon

`bashProgram()` returned the first real word of a command, so `cd repo && git push` picked `cd` instead of `git`.

**Fix:**

- Bash commands are split on `&&`/`||`/`;`/`|`/newlines, each segment's program scored with a three-tier ranking (recognized tool = 3 > unknown = 2 > housekeeping like `cd`/`echo`/`export`/`pwd`/`true`/`:`/`set`/bare assignments = 1), and the highest scorer drives the icon.
- All-housekeeping batches resolve deterministically (first wins).
- The `slicc-bash-renderer-<program>` lookup in `bashBody` intentionally stays on the single-command program.

### Problem 3 — duplicate icon validation

There were multiple independent answers to "is this a real Lucide icon?" — the new `hasIcon()` gate in `wc-message-view.ts` plus `lucideIconNames().includes(...)` membership checks in the freezer labeling path (`quick-llm.ts` / `session-freezer.ts`).

**Fix:**

- `pickLucideIcon` (`quick-llm.ts`) now validates via `hasIcon()`; `lucideIconNames()` is retained only to enumerate the full name list into the LLM prompt.
- `keepIfLucide` (`session-freezer.ts`) is now synchronous and validates via `hasIcon()` — no `lucideIconNames` import remains there.
- Zero `lucideIconNames().includes(...)` checks remain in webapp src.
- **Realm safety:** both modules import `hasIcon` from the new `@slicc/webcomponents/icons` subpath (added to `package.json` exports, mirroring `./composer/speech`) so no `customElements.define` side effects leak into non-DOM realms; the no-DOM webapp-worker tsconfig stays green.
- A consistency test pins `lucideIconNames()` ↔ `hasIcon()` so the two derivations can't drift.

No user-visible behavior change from Problem 3 — it's a pure source-of-truth consolidation.

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅ (7 tsc projects, incl. the no-DOM webapp-worker guard)
- `npx vitest run quick-llm.test.ts new-session.test.ts wc-message-view.test.ts` ✅ 55/55

## Note

One intentional, documented spec deviation: `echo hi && npm test` resolves to `package` (npm outranks echo), with a separate `echo hi && test foo` → `flask-conical` case honoring the spec's literal example.

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author