### PR TITLE
Fix clipped focus ring in connect-llm welcome sprinkle

### DIFF
--- a/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
+++ b/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
@@ -9,6 +9,10 @@
         font-size: 13px;
         color: var(--s2-content-default, #e8e8e8);
         background: transparent;
+        /* Small inset so input :focus `box-shadow: 0 0 0 1px` rings,
+           which paint 1px outside the border, aren't clipped by the
+           tight-fitting dip iframe edge. */
+        padding: 2px 3px;
       }
       .step { display: none; animation: fadeUp 0.18s ease both; }
       .step.active { display: block; }


### PR DESCRIPTION
## Summary

Fix the clipped input focus ring in the `connect-llm` welcome dip sprinkle.

## Root cause

`packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml` ships these styles:

- `* { box-sizing: border-box; margin: 0; padding: 0; }` reset zeros out `<body>` padding.
- Inputs in `.form` are `width: 100%`, so they span the full body width.
- `:focus` adds `border-color: var(--s2-accent)` and `box-shadow: 0 0 0 1px var(--s2-accent)`.

The `box-shadow: 0 0 0 1px` paints 1px **outside** the input border, but the dip iframe is sized tightly to the sprinkle body — so the left and right edges of that 1px accent ring get clipped at the iframe boundary.

## Fix

Minimal CSS-only change: add a small inset on the sprinkle `<body>` so the ring has room to render:

```diff
       body {
         font-family: var(--s2-font-family, -apple-system, BlinkMacSystemFont, sans-serif);
         font-size: 13px;
         color: var(--s2-content-default, #e8e8e8);
         background: transparent;
+        /* Small inset so input :focus `box-shadow: 0 0 0 1px` rings,
+           which paint 1px outside the border, aren't clipped by the
+           tight-fitting dip iframe edge. */
+        padding: 2px 3px;
       }
```

Inputs stay effectively full-width inside the padded box (`width: 100%` on the form inputs flexes to the inner width). No change to input `width: 100%`, the `:focus` `box-shadow` itself, dip wrapper CSS (`.msg__dip`), buttons, the device-code box, or step headings.

## Sibling check: `welcome.shtml`

The task asked to apply the same fix to the sibling `welcome.shtml` **only** if it has the identical flush-edge focusable-field-with-ring pattern. It does not:

- Its text inputs sit inside an `.input-row` wrapper (with its own background/border) and are themselves `border: none; outline: none; background: transparent` with **no** `:focus` `box-shadow` on the input.
- The wrapper intentionally has no `:focus-within` accent (per the file's own comment: "the input's own focus ring already signals focus; a second ring on the wrapper looks like a bug").
- Pills do use `box-shadow: 0 0 0 1px` on `.selected`, but pills are pill-sized chips that wrap on a row with `gap: 8px`, not flush to the iframe edge.

So `welcome.shtml` doesn't have the clipped-ring failure mode and is left untouched.

## Before / after

- **Before:** Focusing the API Key / Base URL / Deployment / API Version input in the connect-llm dip shows the blue accent border, but the 1px outer `box-shadow` ring is clipped on the left and right (and potentially top/bottom) edges by the dip iframe.
- **After:** The 1px outer ring renders fully around the input on all four sides. No other visual change — input width, spacing, buttons, device-code box, and step layout are visually identical.

## Verification

- `npm run lint` — pass
- `npm run build -w @slicc/webapp` — pass

`.shtml` sprinkles ship via `packages/vfs-root` and are bundled into the VFS at build time; no unit tests exist for sprinkle CSS, and none are introduced.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author