### PR TITLE
fix(onboarding): prefix model id, refresh picker, and harden Bedrock prefix detection

### DIFF
--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -1111,14 +1111,40 @@ export function getSelectedModelId(): string {
 }
 
 export function setSelectedModelId(modelId: string): void {
-  // If modelId already has provider prefix, store as-is
-  if (modelId.includes(':')) {
-    localStorage.setItem(MODEL_KEY, modelId);
-  } else {
-    // Store with provider prefix from current selection
-    const provider = getSelectedProvider();
-    localStorage.setItem(MODEL_KEY, `${provider}:${modelId}`);
+  // Decide whether `modelId` is ALREADY prefixed by inspecting the
+  // leading token, NOT by a bare `includes(':')` test. Bedrock model
+  // ids legitimately carry a `:<version>` segment (e.g.
+  // `eu.anthropic.claude-opus-4-5-20251101-v1:0`); the previous
+  // `includes(':')` shortcut treated those as pre-prefixed, persisted
+  // them as-is, and `getSelectedProvider()` then resolved the leading
+  // token as the provider — leaving the cone routed at a phantom
+  // `eu.anthropic.claude-opus-4-5-20251101-v1` provider.
+  //
+  // The leading token is treated as a provider prefix when either:
+  //   1. It matches a known provider id (built-in extension, external
+  //      provider, or a pi-ai registry entry), OR
+  //   2. It looks like a provider id structurally — no `.` characters.
+  //      Bedrock model fragments invariably contain dots
+  //      (`anthropic.claude-…`, `eu.anthropic.claude-…`,
+  //      `us.amazon.titan-…`); no shipped provider id does. The
+  //      structural fallback keeps fixtures that call this function
+  //      before `registerProviders()` has populated the registry from
+  //      mis-routing a legitimate `adobe:claude-…` style payload.
+  const idx = modelId.indexOf(':');
+  if (idx > 0) {
+    const leading = modelId.slice(0, idx);
+    const known = new Set<string>([...getRegisteredProviderIds(), ...getAvailableProviders()]);
+    const looksLikeBedrockFragment = leading.includes('.');
+    if (known.has(leading) || !looksLikeBedrockFragment) {
+      localStorage.setItem(MODEL_KEY, modelId);
+      return;
+    }
   }
+  // Bare id, or a colon-bearing id whose leading token contains a dot
+  // (Bedrock): attach the current provider prefix so downstream
+  // resolvers don't mis-route.
+  const provider = getSelectedProvider();
+  localStorage.setItem(MODEL_KEY, `${provider}:${modelId}`);
 }
 
 /** Get the raw selected-model value (providerId:modelId) */

--- a/packages/webapp/src/scoops/onboarding-orchestrator.ts
+++ b/packages/webapp/src/scoops/onboarding-orchestrator.ts
@@ -139,6 +139,15 @@ export interface OrchestratorDeps {
   /** Fire the FINAL onboarding-complete-with-provider lick to the cone. */
   fireFinalLick: (data: Record<string, unknown>) => void;
   /**
+   * Notify the host that the persisted accounts/model changed so the
+   * UI can re-sync its model picker, identity badge, and pi-ai
+   * resolution. The host wires this to a UI-specific dispatch (the WC
+   * shell dispatches a `slicc:accounts-changed` window event). Without
+   * this hook the picker stayed populated from the boot snapshot and
+   * showed "No models" until the user reloaded.
+   */
+  onAccountsChanged?: () => void;
+  /**
    * Launch the provider's OAuth flow. Resolves once the popup
    * completes and the host has saved the OAuth account locally.
    * Optional — providers without OAuth support can skip this.
@@ -343,7 +352,15 @@ export class OnboardingOrchestrator {
         deployment?.trim() || undefined,
         apiVersion?.trim() || undefined
       );
-      if (effectiveModel) this.deps.setSelectedModel(effectiveModel);
+      // Commit the `providerId:modelId` form explicitly so the worker
+      // resolution path can't drift onto a previously-selected
+      // provider via the bare-id fallback in
+      // `account-store.setSelectedModelId`. Especially important for
+      // Bedrock model ids (they carry a colon and used to fool the
+      // store into treating them as already-prefixed).
+      if (effectiveModel) {
+        this.deps.setSelectedModel(prefixModel(provider, effectiveModel));
+      }
     } catch (err) {
       log.warn('saveAccount failed', err);
       this.deps.broadcastToDip({
@@ -354,6 +371,15 @@ export class OnboardingOrchestrator {
       });
       this.stage = 'awaiting-connect';
       return;
+    }
+    // Tell the host an account landed — the WC shell uses this to
+    // dispatch `slicc:accounts-changed`, which re-syncs the picker
+    // before the cone's onboarding-complete-with-provider reply
+    // renders. Best-effort: a hook throw must not undo the save.
+    try {
+      this.deps.onAccountsChanged?.();
+    } catch (err) {
+      log.warn('onAccountsChanged threw', err);
     }
 
     const note =
@@ -434,10 +460,22 @@ export class OnboardingOrchestrator {
 
     if (result.model) {
       try {
-        this.deps.setSelectedModel(result.model);
+        // Same prefixing contract as the connect-attempt path. The
+        // resolveDefaultModel helper already returns a prefixed id, so
+        // `prefixModel` is a no-op there; explicit hosts that pass a
+        // bare id from another source still get the right routing.
+        this.deps.setSelectedModel(prefixModel(payload.provider, result.model));
       } catch (err) {
         log.warn('setSelectedModel after OAuth failed', err);
       }
+    }
+    // Best-effort re-sync hook — matches the connect-attempt path so
+    // both onboarding entry points refresh the picker before the
+    // cone's reply renders.
+    try {
+      this.deps.onAccountsChanged?.();
+    } catch (err) {
+      log.warn('onAccountsChanged threw', err);
     }
 
     this.deps.broadcastToDip({
@@ -503,4 +541,20 @@ export class OnboardingOrchestrator {
     // separate mkdir call.
     await this.deps.fs.writeFile(`/home/${slug}/.welcome.json`, JSON.stringify(profile, null, 2));
   }
+}
+
+/**
+ * Ensure the model id reaches the host's `setSelectedModel` already
+ * prefixed with the just-saved provider. The downstream
+ * `account-store.setSelectedModelId` can repair a bare id from the
+ * current selection, but during onboarding `getSelectedProvider()`
+ * still points at the previously-selected provider (or the default)
+ * until the new account lands. Building the prefix here makes the
+ * commit deterministic regardless of repair-path heuristics — and
+ * keeps Bedrock model ids (which legitimately contain a colon) from
+ * being misclassified as already-prefixed.
+ */
+function prefixModel(provider: string, modelId: string): string {
+  if (modelId.startsWith(`${provider}:`)) return modelId;
+  return `${provider}:${modelId}`;
 }

--- a/packages/webapp/src/ui/boot/setup-onboarding-orchestrator.ts
+++ b/packages/webapp/src/ui/boot/setup-onboarding-orchestrator.ts
@@ -137,6 +137,14 @@ export interface OnboardingOrchestratorSetupDeps {
    * around `client.sendSprinkleLick('welcome', data)`.
    */
   onFireFinalLick(data: Record<string, unknown>): void;
+  /**
+   * UI-agnostic accounts-changed hook. The orchestrator fires it after
+   * a successful connect-attempt or OAuth flow so the host can refresh
+   * its model picker; the WC shell binds it to a
+   * `slicc:accounts-changed` window event. Kept optional so headless
+   * tests can omit it.
+   */
+  onAccountsChanged?(): void;
 }
 
 export interface OnboardingOrchestratorHandle {
@@ -186,6 +194,7 @@ export async function createOnboardingOrchestratorSetup(
       },
       broadcastToDip: (payload) => deps.broadcastToDip(payload),
       fireFinalLick: (data) => deps.onFireFinalLick(data),
+      onAccountsChanged: deps.onAccountsChanged ? () => deps.onAccountsChanged?.() : undefined,
       launchOAuth: async (providerId, baseUrl) =>
         await launchOnboardingOAuth(providerId, baseUrl ?? null, deps),
     });

--- a/packages/webapp/src/ui/wc/wc-onboarding.ts
+++ b/packages/webapp/src/ui/wc/wc-onboarding.ts
@@ -112,6 +112,20 @@ export async function wireWcOnboarding(deps: WcOnboardingDeps): Promise<WcOnboar
     postDipReference: postLine,
     broadcastToDip: (payload) => broadcastToDips(payload),
     onFireFinalLick: fireFinalLick,
+    // After onboarding lands an account, dispatch the same window
+    // event `wc-settings` fires when the user adds an account from
+    // the settings dialog. `wc-nav.wireAccountsChangedResync` listens
+    // for it and re-pulls models + identity so the picker doesn't
+    // show "No models" until the next reload.
+    onAccountsChanged: () => {
+      try {
+        if (typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('slicc:accounts-changed'));
+        }
+      } catch (err) {
+        log.warn('Failed to dispatch slicc:accounts-changed', err);
+      }
+    },
   });
 
   const interceptWelcomeLick = createWelcomeLickInterceptor({

--- a/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
@@ -255,7 +255,11 @@ describe('OnboardingOrchestrator', () => {
           apiVersion: undefined,
         },
       ]);
-      expect(h.selectedModels).toEqual(['gpt-4o']);
+      // The orchestrator commits the prefixed `providerId:modelId` form
+      // so the downstream account-store can't drift onto a stale
+      // provider via its bare-id repair path (and so Bedrock ids that
+      // carry their own colon stay routed correctly).
+      expect(h.selectedModels).toEqual(['openai:gpt-4o']);
       expect(h.finalLicks).toHaveLength(1);
       expect(h.finalLicks[0].action).toBe('onboarding-complete-with-provider');
       expect(h.finalLicks[0].data.provider).toBe('openai');
@@ -337,7 +341,8 @@ describe('OnboardingOrchestrator', () => {
         baseUrl: null,
         model: null,
       });
-      expect(h.selectedModels).toEqual(['claude-opus-4-6']);
+      // Same prefixing contract as the explicit-model path.
+      expect(h.selectedModels).toEqual(['anthropic:claude-opus-4-6']);
       expect(h.finalLicks).toHaveLength(1);
       expect(h.finalLicks[0].data.model).toBe('claude-opus-4-6');
       expect(h.finalLicks[0].data.modelLabel).toBe('CLAUDE-OPUS-4-6');
@@ -439,6 +444,135 @@ describe('OnboardingOrchestrator', () => {
       expect(h.accounts).toEqual([]);
       const reject = h.dipInbox.find((m) => m.type === 'slicc-connect-result');
       expect(reject.ok).toBe(false);
+    });
+
+    it('commits a prefixed model id even when the dip submitted a bare Bedrock id', async () => {
+      // Bedrock model ids legitimately carry a `:<version>` suffix. The
+      // host's setSelectedModelId can no longer rely on `includes(':')`
+      // alone, so the orchestrator builds the explicit
+      // `providerId:modelId` form before committing.
+      const fs = new VirtualFS('bedrock-' + Math.random());
+      const selectedModels: string[] = [];
+      const accounts: AccountSnapshot[] = [];
+      const catalogue: ProviderCatalogue = {
+        providers: [
+          {
+            id: 'amazon-bedrock',
+            name: 'AWS Bedrock',
+            requiresApiKey: true,
+            requiresBaseUrl: false,
+          },
+        ],
+        models: { 'amazon-bedrock': [] },
+      };
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => catalogue,
+        saveAccount: (id, key) => accounts.push({ id, key }),
+        setSelectedModel: (id) => selectedModels.push(id),
+        broadcastToDip: () => {},
+        fireFinalLick: () => {},
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleConnectAttempt({
+        provider: 'amazon-bedrock',
+        apiKey: 'bedrock-key',
+        model: 'eu.anthropic.claude-opus-4-5-20251101-v1:0',
+      });
+      expect(selectedModels).toEqual(['amazon-bedrock:eu.anthropic.claude-opus-4-5-20251101-v1:0']);
+    });
+
+    it('fires onAccountsChanged after a successful connect-attempt', async () => {
+      // Closes the "stale picker" hole: without this hook the WC shell
+      // kept rendering the previous account snapshot until the next
+      // reload because nothing dispatched `slicc:accounts-changed`.
+      const fs = new VirtualFS('changed-ok-' + Math.random());
+      const onAccountsChanged = vi.fn();
+      const finalLicks: FinalLickPayload[] = [];
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: () => {},
+        setSelectedModel: () => {},
+        broadcastToDip: () => {},
+        fireFinalLick: (data) => finalLicks.push(data),
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        onAccountsChanged,
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleConnectAttempt({
+        provider: 'openai',
+        apiKey: 'sk-good',
+        model: 'gpt-4o',
+      });
+      expect(onAccountsChanged).toHaveBeenCalledTimes(1);
+      expect(finalLicks).toHaveLength(1);
+    });
+
+    it('does NOT fire onAccountsChanged when saveAccount fails', async () => {
+      // The change-notification only fires after a clean save so a
+      // failed write doesn't yank the picker into a non-existent
+      // account.
+      const fs = new VirtualFS('changed-fail-' + Math.random());
+      const onAccountsChanged = vi.fn();
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: () => {
+          throw new Error('disk full');
+        },
+        setSelectedModel: () => {},
+        broadcastToDip: () => {},
+        fireFinalLick: () => {},
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        onAccountsChanged,
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleConnectAttempt({
+        provider: 'openai',
+        apiKey: 'sk-good',
+        model: 'gpt-4o',
+      });
+      expect(onAccountsChanged).not.toHaveBeenCalled();
+    });
+
+    it('swallows onAccountsChanged exceptions without rolling back the save', async () => {
+      const fs = new VirtualFS('changed-throw-' + Math.random());
+      const accounts: AccountSnapshot[] = [];
+      const finalLicks: FinalLickPayload[] = [];
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: (id, key) => accounts.push({ id, key }),
+        setSelectedModel: () => {},
+        broadcastToDip: () => {},
+        fireFinalLick: (data) => finalLicks.push(data),
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        onAccountsChanged: () => {
+          throw new Error('listener blew up');
+        },
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleConnectAttempt({
+        provider: 'openai',
+        apiKey: 'sk-good',
+        model: 'gpt-4o',
+      });
+      expect(accounts).toHaveLength(1);
+      expect(finalLicks).toHaveLength(1);
     });
   });
 
@@ -595,6 +729,75 @@ describe('OnboardingOrchestrator', () => {
       await h.orchestrator.handleOAuthAttempt({ provider: 'adobe' });
       expect(h.finalLicks).toEqual([]);
       expect(h.dipInbox).toEqual([]);
+    });
+
+    it('prefixes a bare OAuth model id with the just-authenticated provider', async () => {
+      // resolveDefaultModel already returns a prefixed id, but other
+      // OAuth hosts can hand back a bare id. The orchestrator must
+      // normalize so the picker doesn't keep resolving against the
+      // previously-selected provider.
+      const fs = new VirtualFS('oauth-bare-' + Math.random());
+      const selectedModels: string[] = [];
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: () => {},
+        setSelectedModel: (id) => selectedModels.push(id),
+        broadcastToDip: () => {},
+        fireFinalLick: () => {},
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        launchOAuth: async () => ({ ok: true, model: 'claude-sonnet-4-6' }),
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleOAuthAttempt({ provider: 'adobe' });
+      expect(selectedModels).toEqual(['adobe:claude-sonnet-4-6']);
+    });
+
+    it('fires onAccountsChanged after a successful OAuth login', async () => {
+      const fs = new VirtualFS('oauth-changed-' + Math.random());
+      const onAccountsChanged = vi.fn();
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: () => {},
+        setSelectedModel: () => {},
+        broadcastToDip: () => {},
+        fireFinalLick: () => {},
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        launchOAuth: async () => ({ ok: true, model: 'adobe:claude-sonnet-4-6' }),
+        onAccountsChanged,
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleOAuthAttempt({ provider: 'adobe' });
+      expect(onAccountsChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT fire onAccountsChanged when OAuth fails', async () => {
+      const fs = new VirtualFS('oauth-no-change-' + Math.random());
+      const onAccountsChanged = vi.fn();
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => baseCatalogue,
+        saveAccount: () => {},
+        setSelectedModel: () => {},
+        broadcastToDip: () => {},
+        fireFinalLick: () => {},
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+        launchOAuth: async () => ({ ok: false, message: 'cancelled' }),
+        onAccountsChanged,
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleOAuthAttempt({ provider: 'adobe' });
+      expect(onAccountsChanged).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -206,6 +206,7 @@ import {
   saveOAuthAccount,
   setApiKey,
   setBaseUrl,
+  setSelectedModelId,
   setSelectedProvider,
 } from '../../src/ui/provider-settings.js';
 
@@ -396,6 +397,50 @@ describe('selected model encodes provider', () => {
     storage.set('selected-model', 'anthropic:claude-sonnet-4-0');
     setSelectedProvider('openai');
     expect(storage.get('selected-model')).toBe('openai:claude-sonnet-4-0');
+  });
+
+  it('setSelectedModelId stores prefixed ids verbatim when the leading token is a known provider', () => {
+    addAccount('openai', 'oai-key');
+    setSelectedModelId('openai:gpt-5');
+    expect(storage.get('selected-model')).toBe('openai:gpt-5');
+  });
+
+  it('setSelectedModelId prefixes bare ids with the current provider', () => {
+    addAccount('anthropic', 'ant-key');
+    storage.set('selected-model', 'anthropic:claude-sonnet-4-0');
+    setSelectedModelId('claude-opus-4-6');
+    expect(storage.get('selected-model')).toBe('anthropic:claude-opus-4-6');
+  });
+
+  it('setSelectedModelId prefixes Bedrock model ids that legitimately contain a colon', () => {
+    // Bedrock ids like `eu.anthropic.claude-opus-4-5-20251101-v1:0` end with
+    // a `:<version>` segment. A bare `includes(':')` check would store this
+    // as-is and `getSelectedProvider()` would later resolve the phantom
+    // provider `eu.anthropic.claude-opus-4-5-20251101-v1`. The hardened
+    // check inspects the leading token against the registered providers.
+    addAccount('amazon-bedrock', 'bedrock-key');
+    storage.set('selected-model', 'amazon-bedrock:anthropic.claude-3-sonnet');
+    setSelectedModelId('eu.anthropic.claude-opus-4-5-20251101-v1:0');
+    expect(storage.get('selected-model')).toBe(
+      'amazon-bedrock:eu.anthropic.claude-opus-4-5-20251101-v1:0'
+    );
+    // Round-trip: `getSelectedModelId` strips only the first segment, so
+    // the colon-containing tail (`:0`) survives.
+    expect(getSelectedModelId()).toBe('eu.anthropic.claude-opus-4-5-20251101-v1:0');
+    expect(getSelectedProvider()).toBe('amazon-bedrock');
+  });
+
+  it('setSelectedModelId stores fully-prefixed Bedrock ids verbatim', () => {
+    // The picker emits `${providerId}:${bareId}` (and the bareId itself
+    // contains a colon for Bedrock). Storing the value as-is must
+    // preserve BOTH colons.
+    addAccount('amazon-bedrock', 'bedrock-key');
+    setSelectedModelId('amazon-bedrock:eu.anthropic.claude-opus-4-5-20251101-v1:0');
+    expect(storage.get('selected-model')).toBe(
+      'amazon-bedrock:eu.anthropic.claude-opus-4-5-20251101-v1:0'
+    );
+    expect(getSelectedProvider()).toBe('amazon-bedrock');
+    expect(getSelectedModelId()).toBe('eu.anthropic.claude-opus-4-5-20251101-v1:0');
   });
 });
 


### PR DESCRIPTION
## Summary

Three closely-related onboarding/model-selection bugs that surfaced when the welcome dip wired up the first LLM account, fixed together in a single change. Before: connecting a model through the welcome dip could leave the persisted selection routed at the wrong provider, the model picker showed "No models" until reload, and a Bedrock model id like `eu.anthropic.claude-opus-4-5-20251101-v1:0` was misclassified as already provider-prefixed. After: the orchestrator commits a `${providerId}:${modelId}` form, the picker re-syncs on the next dispatched event, and the prefix decision keys off the leading token rather than a bare `:` test.

## Why

Three independently-reachable failure modes shared a common root in the onboarding-to-account-store path:

1. **(A) Bare model id committed during onboarding.** `OnboardingOrchestrator` called `setSelectedModel(modelId)` with the bare id; `account-store.setSelectedModelId` then attached whatever `getSelectedProvider()` returned at that instant — which during first-run onboarding was still the default. A fresh `openai` connect could land prefixed with `anthropic:`.
2. **(B) Stale picker after connect/OAuth.** Nothing dispatched `slicc:accounts-changed` after the welcome dip wired credentials, so `wc-nav.wireAccountsChangedResync` never re-pulled models or identity. The picker stayed on the boot snapshot ("No models") until reload.
3. **(C) Bedrock ids fool `includes(':')`.** Bedrock model ids legitimately carry a `:<version>` segment, e.g. `eu.anthropic.claude-opus-4-5-20251101-v1:0`. The bare `includes(':')` shortcut treated them as pre-prefixed, persisted them verbatim, and `getSelectedProvider()` then resolved the phantom provider `eu.anthropic.claude-opus-4-5-20251101-v1`.

## Approach / Implementation notes

- **(A) Orchestrator builds the prefix.** New private helper `prefixModel(provider, modelId)` returns `modelId` if already prefixed with `${provider}:`, otherwise prepends it. Used on BOTH the API-key (`handleConnectAttempt`) and OAuth (`handleOAuthAttempt`) paths. `resolveDefaultModel` already returns a prefixed id, so the OAuth helper is a no-op there; hosts that hand back a bare id still get the right routing.
- **(B) UI-agnostic `onAccountsChanged` hook.** Optional `onAccountsChanged?: () => void` added to both `OrchestratorDeps` (orchestrator) and `OnboardingOrchestratorSetupDeps` (factory). Fired exactly once after a clean connect-attempt OR OAuth success — suppressed when the save fails, and hook exceptions are swallowed so a listener crash can't roll back the save. `wc-onboarding.ts` binds it to `window.dispatchEvent(new CustomEvent('slicc:accounts-changed'))`, mirroring the dispatch `wc-settings` already fires when an account is added from the settings dialog.
- **(C) `setSelectedModelId` keys off the leading token.** Treated as a provider prefix when EITHER it matches a known provider id (`getRegisteredProviderIds()` ∪ `getAvailableProviders()`) OR it contains no `.`. The structural dot fallback covers two real cases: (i) the wc-nav test (and any fixture that runs before `registerProviders()` populated the registry) still recognises a legitimate `adobe:claude-...` payload; (ii) every Bedrock model fragment contains `.` while no shipped provider id does, so dotted leading tokens are correctly re-prefixed with the current provider.

## Cross-cutting impact

- **Floats exercised**: standalone CLI + Chrome extension (both go through `wireWcOnboarding` from `attachWcClient`). Sliccstart / Electron / worker are unaffected by the welcome flow itself.
- **Other callers of `setSelectedModelId`** (audited):
  - `ui/wc/wc-nav.ts:281` — passes `id` from a `model-change` event whose ids are always provider-prefixed; the new heuristic stores them verbatim (test covers `adobe:claude-opus-4-8`).
  - `ui/boot/setup-onboarding-orchestrator.ts:178` — thin wrapper around the orchestrator's `setSelectedModel`. After fix (A) the value is always prefixed.
- **Persisted state**: `selected-model` localStorage key — round-trip behaviour now matches across bare ids, prefixed ids, bare Bedrock ids (`...v1:0`), and fully-prefixed Bedrock ids (`amazon-bedrock:...v1:0`).
- **Async lifecycle**: `onAccountsChanged` is invoked synchronously inside a `try/catch`; nothing awaits the listener so a slow / throwing handler can't stall the connect-attempt response.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test -w @slicc/webapp` — **6384 passed, 10 skipped, 0 failed**
- [x] **New / changed behavior is covered by a unit test**:
  - `packages/webapp/tests/ui/provider-settings.test.ts` — Bedrock + prefixed-id round-trip regression coverage
  - `packages/webapp/tests/scoops/onboarding-orchestrator.test.ts` — updated existing assertions to expect prefixed ids; added coverage for `onAccountsChanged` (fires on success, suppressed on failed save, swallows listener exceptions, OAuth equivalents)

## Documentation

- [x] No documentation changes needed — behaviour change is internal to the onboarding adapter and account-store. The picker re-sync contract was already documented in `wc-nav.wireAccountsChangedResync`'s JSDoc.

## Risk & rollback

- **Blast radius**: limited to the welcome / first-run path and the `selected-model` storage key resolution. Cleanly revertable; no migration of persisted state.
- **CI cannot catch**: real OAuth round-trip with a live Adobe / GitHub provider, real Bedrock account configured with a versioned model id. Manual smoke recommended for those two paths before merge.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs (new optional dep field documented in JSDoc)
- [x] If this changes a contract used by other floats (CLI <-> extension <-> tray), I checked the followers/leader/offscreen paths — both standalone CLI and extension reach `wireWcOnboarding` via `attachWcClient` and share the same wiring.
- [x] No `package-lock.json` churn committed.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author