### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -14,7 +14,7 @@
       "branches": 67
     },
     "chrome-extension": {
-      "lines": 74,
+      "lines": 75,
       "statements": 73,
       "functions": 68,
       "branches": 60,


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.