### PR TITLE
fix(error-card): open Settings instead of retrying for No API key errors

### DIFF
--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -584,13 +584,34 @@ function delegationEls(message: ChatMessage): HTMLElement[] {
 }
 
 /**
+ * Literal prefix shared by both `No API key configured…` variants emitted by
+ * `scoop-context.ts` (`No API key configured for provider "<id>". …` and the
+ * provider-less `No API key configured. …`). Prefix-match rather than full
+ * string match so the interpolated provider name doesn't break detection.
+ */
+export const NO_API_KEY_ERROR_PREFIX = 'No API key configured';
+
+/** Whether an error message string is the "no API key" failure. */
+export function isNoApiKeyError(content: string): boolean {
+  return typeof content === 'string' && content.startsWith(NO_API_KEY_ERROR_PREFIX);
+}
+
+/**
  * `slicc-error-card` for a cone-error message. The card is purely
  * presentational; the chat controller listens for the bubbled
  * `slicc-error-retry` event to re-run the last user turn via its existing
- * agent send path.
+ * agent send path. For the "No API key configured" failure the CTA flips to
+ * "Open Settings" (the agent retry path would just re-hit the same missing
+ * key) — the card then fires `slicc-error-open-settings` instead and the
+ * shell-level listener wired by `wireWcNav` routes it to the settings dialog.
  */
 function errorCardEl(message: ChatMessage): HTMLElement {
-  return el('slicc-error-card', { message: message.content, 'message-id': message.id });
+  const attrs: Record<string, string> = {
+    message: message.content,
+    'message-id': message.id,
+  };
+  if (isNoApiKeyError(message.content)) attrs.action = 'settings';
+  return el('slicc-error-card', attrs);
 }
 
 /** Elements for a single chat message, in thread order. */

--- a/packages/webapp/src/ui/wc/wc-nav.ts
+++ b/packages/webapp/src/ui/wc/wc-nav.ts
@@ -239,6 +239,14 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
   // routes straight into account settings.
   refs.composerMeta.addEventListener('add-ai', openSettings);
 
+  // The "No API key" error card flips its CTA to "Open Settings" (see
+  // `wc-message-view.ts:errorCardEl`) and bubbles a `slicc-error-open-settings`
+  // event up through the thread. Route it to the same settings dialog as the
+  // composer-meta `add-ai` action so the user lands in one place regardless
+  // of which surface they used. Both standalone and extension floats share
+  // this WC shell, so the listener covers them both.
+  refs.thread?.addEventListener('slicc-error-open-settings', openSettings);
+
   wireAccountsChangedResync({ refreshModels, applyIdentity, client });
 }
 

--- a/packages/webapp/tests/ui/wc/wc-message-view.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-message-view.test.ts
@@ -22,7 +22,9 @@ import {
   BASH_ICONS,
   buildThreadChildren,
   collateLickMessages,
+  isNoApiKeyError,
   messageEls,
+  NO_API_KEY_ERROR_PREFIX,
   summarizeToolInput,
   TOOL_ICONS,
 } from '../../../src/ui/wc/wc-message-view.js';
@@ -484,6 +486,45 @@ describe('summarizeToolInput', () => {
     const long = 'x'.repeat(120);
     expect(summarizeToolInput(long)).toHaveLength(80);
     expect(summarizeToolInput(long).endsWith('…')).toBe(true);
+  });
+});
+
+describe('isNoApiKeyError + errorCardEl', () => {
+  it('matches both no-API-key error variants by prefix', () => {
+    expect(NO_API_KEY_ERROR_PREFIX).toBe('No API key configured');
+    expect(isNoApiKeyError('No API key configured. Open Settings to add one.')).toBe(true);
+    expect(
+      isNoApiKeyError('No API key configured for provider "adobe". Open Settings to add one.')
+    ).toBe(true);
+    expect(isNoApiKeyError('rate limited')).toBe(false);
+    expect(isNoApiKeyError('')).toBe(false);
+    expect(isNoApiKeyError(null as unknown as string)).toBe(false);
+  });
+
+  it('renders the no-API-key error as a settings-action error card', () => {
+    const [card] = messageEls({
+      id: 'err-1',
+      role: 'assistant',
+      content: 'No API key configured for provider "adobe". Open Settings to add one.',
+      timestamp: 1,
+      error: true,
+    });
+    expect(card.tagName.toLowerCase()).toBe('slicc-error-card');
+    expect(card.getAttribute('action')).toBe('settings');
+    expect(card.getAttribute('message-id')).toBe('err-1');
+    expect(card.getAttribute('message')).toContain('No API key configured');
+  });
+
+  it('keeps the retry CTA for every other error', () => {
+    const [card] = messageEls({
+      id: 'err-2',
+      role: 'assistant',
+      content: 'The model rate-limited this turn.',
+      timestamp: 1,
+      error: true,
+    });
+    expect(card.tagName.toLowerCase()).toBe('slicc-error-card');
+    expect(card.hasAttribute('action')).toBe(false);
   });
 });
 

--- a/packages/webapp/tests/ui/wc/wc-nav.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-nav.test.ts
@@ -9,6 +9,12 @@ import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();
 
+// Capture the dialog-open invocations so we can assert that the bubbled
+// `slicc-error-open-settings` event routes the user into the same surface
+// as the composer-meta `add-ai` action — without booting the real dialog.
+const showWcSettingsSpy = vi.fn(async () => undefined);
+vi.mock('../../../src/ui/wc/wc-settings.js', () => ({ showWcSettings: showWcSettingsSpy }));
+
 import type { OffscreenClient } from '../../../src/ui/offscreen-client.js';
 import type { GroupedModels } from '../../../src/ui/provider-settings.js';
 import { accountIdentity, modelListForMeta, wireWcNav } from '../../../src/ui/wc/wc-nav.js';
@@ -60,8 +66,9 @@ describe('wireWcNav', () => {
     avatarMenu.append(document.createElement('slicc-avatar'));
     const inputCard = document.createElement('slicc-input-card');
     inputCard.append(document.createElement('slicc-send-button'));
-    document.body.append(composerMeta, avatarMenu, inputCard);
-    return { composerMeta, avatarMenu, inputCard } as unknown as WcShellRefs;
+    const thread = document.createElement('slicc-chat-thread');
+    document.body.append(composerMeta, avatarMenu, inputCard, thread);
+    return { composerMeta, avatarMenu, inputCard, thread } as unknown as WcShellRefs;
   }
 
   it('feeds the model picker, persists selection, and wires the menu', async () => {
@@ -144,5 +151,35 @@ describe('wireWcNav', () => {
     );
     expect(events).toHaveLength(1);
     expect(events[0].detail).toEqual({ workerBaseUrl: null });
+  });
+
+  it('routes slicc-error-open-settings from the thread to the settings dialog', async () => {
+    const refs = makeRefs();
+    const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
+    await wireWcNav({ refs, client, log: { error: vi.fn() } as never });
+
+    showWcSettingsSpy.mockClear();
+    refs.thread.dispatchEvent(
+      new CustomEvent('slicc-error-open-settings', {
+        detail: { messageId: 'err-1' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    // The handler dynamically imports the settings dialog; wait a microtask
+    // tick for the import to resolve before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(showWcSettingsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the same settings dialog for the composer-meta add-ai action', async () => {
+    const refs = makeRefs();
+    const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
+    await wireWcNav({ refs, client, log: { error: vi.fn() } as never });
+
+    showWcSettingsSpy.mockClear();
+    refs.composerMeta.dispatchEvent(new CustomEvent('add-ai', { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(showWcSettingsSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/webcomponents/src/chat/slicc-error-card.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.stories.ts
@@ -6,6 +6,7 @@ interface ErrorCardArgs {
   message?: string;
   bodyHtml?: string;
   'button-label'?: string;
+  action?: 'retry' | 'settings';
   theme?: 'light' | 'dark';
 }
 
@@ -34,6 +35,7 @@ function build(args: ErrorCardArgs): HTMLElement {
   const el = document.createElement('slicc-error-card');
   if (args.label != null) el.setAttribute('label', args.label);
   if (args['button-label'] != null) el.setAttribute('button-label', args['button-label']);
+  if (args.action) el.setAttribute('action', args.action);
   if (args.theme) el.setAttribute('theme', args.theme);
   // Rich slotted markup wins over the plain `message` attribute when supplied.
   if (args.bodyHtml != null) appendRichBody(el, args.bodyHtml);
@@ -62,6 +64,13 @@ const meta: Meta<ErrorCardArgs> = {
     message: { control: 'text', description: 'Error body text (escaped)' },
     bodyHtml: { control: 'text', description: 'Rich slotted body markup (overrides message)' },
     'button-label': { control: 'text', description: 'Retry button label (default "Try again")' },
+    action: {
+      control: 'inline-radio',
+      options: ['retry', 'settings'],
+      description:
+        'Action mode: `retry` (default) fires `slicc-error-retry`; `settings` flips the CTA to ' +
+        '"Open Settings" and fires `slicc-error-open-settings` instead.',
+    },
     theme: { control: 'inline-radio', options: ['light', 'dark'], description: 'Theme override' },
   },
   render: build,
@@ -114,6 +123,30 @@ export const CustomLabels: Story = {
     label: 'Network unreachable',
     'button-label': 'Retry connection',
     message: 'The LLM provider returned no response. Check your connection and retry.',
+  },
+};
+
+/**
+ * `action="settings"` variant — the CTA flips to "Open Settings" with a
+ * settings glyph and dispatches `slicc-error-open-settings` instead of
+ * `slicc-error-retry`. Used by the host for failures the user fixes by
+ * opening Settings (e.g. "No API key configured").
+ */
+export const SettingsAction: Story = {
+  args: {
+    label: 'Cannot reach the model',
+    action: 'settings',
+    message: 'No API key configured for provider "adobe". Open Settings to add one.',
+  },
+};
+
+/** Settings variant in dark mode — same red tint over the dark canvas. */
+export const SettingsActionDark: Story = {
+  args: {
+    label: 'Cannot reach the model',
+    action: 'settings',
+    theme: 'dark',
+    message: 'No API key configured. Open Settings to add one.',
   },
 };
 

--- a/packages/webcomponents/src/chat/slicc-error-card.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.ts
@@ -20,21 +20,33 @@ import { iconEl } from '../internal/icons.js';
  * Set the body via the `message` attribute (escaped plain text) or project
  * content into the default slot for rich markup.
  *
+ * The `action` attribute switches the trailing affordance from the default
+ * `retry` CTA to a `settings` CTA — clicking dispatches `slicc-error-open-settings`
+ * instead of `slicc-error-retry`, the default label flips to "Open Settings",
+ * and the glyph swaps to `settings`. Hosts use this for failures the user
+ * fixes by opening Settings (e.g. "No API key configured") rather than by
+ * re-running the same failing turn.
+ *
  * @attr label - the header label (default "Something went wrong")
  * @attr message - error body text (escaped); ignored when slotted content is present
- * @attr button-label - retry button label (default "Try again")
+ * @attr button-label - action button label (default "Try again", or "Open Settings"
+ *   when `action="settings"`)
  * @attr message-id - id of the failed chat message this card stands for; echoed
- *   back on `slicc-error-retry` so the host can bind retry to THIS turn
+ *   back on the action event so the host can bind it to THIS turn
+ * @attr action - `retry` (default) | `settings`; switches the CTA event,
+ *   default label, and glyph
  * @attr theme - `light` | `dark`; per-element override of the inherited theme
  * @csspart card - the outer `.err` card
  * @csspart header - the `.eh` header row
  * @csspart icon - the `.ic` span wrapping the lucide `triangle-alert` `<svg>`
  * @csspart label - the header label span
  * @csspart body - the `.eb` body line
- * @csspart button - the retry button
+ * @csspart button - the action button
  * @slot - rich body content (overrides the `message` attribute)
  * @fires slicc-error-retry - { messageId: string | null } dispatched on retry
- *   click (bubbles, composed); `messageId` mirrors the `message-id` attribute
+ *   click (bubbles, composed) when `action="retry"` (the default)
+ * @fires slicc-error-open-settings - { messageId: string | null } dispatched on
+ *   click (bubbles, composed) when `action="settings"`
  */
 
 /** Pixel size of the lucide header icon. */
@@ -43,6 +55,11 @@ const HEADER_ICON_SIZE = 14;
 const DEFAULT_LABEL = 'Something went wrong';
 /** Default retry button label. */
 const DEFAULT_BUTTON_LABEL = 'Try again';
+/** Default button label when the `settings` action is selected. */
+const DEFAULT_SETTINGS_BUTTON_LABEL = 'Open Settings';
+
+/** Recognized values for the `action` attribute. */
+type ErrorAction = 'retry' | 'settings';
 
 const STYLE = `
 :host{
@@ -107,10 +124,17 @@ const STYLE = `
 const SHEET = sheet(STYLE);
 
 export class SliccErrorCard extends HTMLElement {
-  static readonly observedAttributes = ['label', 'message', 'button-label', 'message-id', 'theme'];
+  static readonly observedAttributes = [
+    'label',
+    'message',
+    'button-label',
+    'message-id',
+    'action',
+    'theme',
+  ];
 
   readonly #root: ShadowRoot;
-  #onRetryClick: ((e: MouseEvent) => void) | null = null;
+  #onActionClick: ((e: MouseEvent) => void) | null = null;
 
   constructor() {
     super();
@@ -123,7 +147,7 @@ export class SliccErrorCard extends HTMLElement {
   }
 
   disconnectedCallback(): void {
-    this.#unbindRetry();
+    this.#unbindAction();
   }
 
   attributeChangedCallback(): void {
@@ -150,7 +174,7 @@ export class SliccErrorCard extends HTMLElement {
     else this.setAttribute('message', value);
   }
 
-  /** Retry button label (default "Try again"). */
+  /** Action button label (defaults vary by `action`). */
   get buttonLabel(): string | null {
     return this.getAttribute('button-label');
   }
@@ -162,8 +186,8 @@ export class SliccErrorCard extends HTMLElement {
 
   /**
    * Id of the failed chat message this card stands for. Echoed back on the
-   * `slicc-error-retry` event so the host can bind retry to the SPECIFIC turn
-   * that produced this card rather than the newest user message in the thread.
+   * action event so the host can bind it to the SPECIFIC turn that produced
+   * this card rather than the newest user message in the thread.
    */
   get messageId(): string | null {
     return this.getAttribute('message-id');
@@ -172,6 +196,20 @@ export class SliccErrorCard extends HTMLElement {
   set messageId(value: string | null) {
     if (value == null) this.removeAttribute('message-id');
     else this.setAttribute('message-id', value);
+  }
+
+  /**
+   * Action mode: `retry` (default) fires `slicc-error-retry`; `settings` fires
+   * `slicc-error-open-settings`. Any unknown value is normalized back to
+   * `retry` so the default behavior is byte-for-byte preserved.
+   */
+  get action(): ErrorAction {
+    return this.getAttribute('action') === 'settings' ? 'settings' : 'retry';
+  }
+
+  set action(value: ErrorAction | null) {
+    if (value == null) this.removeAttribute('action');
+    else this.setAttribute('action', value);
   }
 
   /** Per-element theme override for the card tokens. */
@@ -196,10 +234,25 @@ export class SliccErrorCard extends HTMLElement {
     );
   }
 
+  /** Dispatch `slicc-error-open-settings` — fired by the button in `settings` mode. */
+  openSettings(): void {
+    this.dispatchEvent(
+      new CustomEvent('slicc-error-open-settings', {
+        detail: { messageId: this.getAttribute('message-id') ?? null },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
   #render(): void {
+    const action = this.action;
     const label = this.label ?? DEFAULT_LABEL;
     const message = this.message;
-    const buttonLabel = this.buttonLabel ?? DEFAULT_BUTTON_LABEL;
+    const defaultButtonLabel =
+      action === 'settings' ? DEFAULT_SETTINGS_BUTTON_LABEL : DEFAULT_BUTTON_LABEL;
+    const buttonLabel = this.buttonLabel ?? defaultButtonLabel;
+    const buttonIcon = action === 'settings' ? 'settings' : 'rotate-ccw';
 
     const icon = h('span', { class: 'ic', part: 'icon', 'aria-hidden': true });
     icon.append(iconEl('triangle-alert', { size: HEADER_ICON_SIZE }));
@@ -215,7 +268,7 @@ export class SliccErrorCard extends HTMLElement {
     // attribute (a text node escapes by construction — no markup interpolation).
     const bodyRow = h('div', { class: 'eb', part: 'body' }, message != null ? message : h('slot'));
 
-    const retryBtn = h(
+    const actionBtn = h(
       'button',
       {
         type: 'button',
@@ -223,32 +276,32 @@ export class SliccErrorCard extends HTMLElement {
         part: 'button',
         'aria-label': buttonLabel,
       },
-      iconEl('rotate-ccw', { size: 12 }),
+      iconEl(buttonIcon, { size: 12 }),
       buttonLabel
     );
 
-    const foot = h('div', { class: 'foot' }, retryBtn);
+    const foot = h('div', { class: 'foot' }, actionBtn);
 
     const cardEl = h('div', { class: 'err', part: 'card' }, headerRow, bodyRow, foot);
     this.#root.replaceChildren(cardEl);
 
-    this.#bindRetry();
+    this.#bindAction();
   }
 
-  #bindRetry(): void {
-    this.#unbindRetry();
+  #bindAction(): void {
+    this.#unbindAction();
     const btn = this.#root.querySelector('.retry');
     if (!btn) return;
-    this.#onRetryClick = () => this.retry();
-    btn.addEventListener('click', this.#onRetryClick as EventListener);
+    this.#onActionClick = () => (this.action === 'settings' ? this.openSettings() : this.retry());
+    btn.addEventListener('click', this.#onActionClick as EventListener);
   }
 
-  #unbindRetry(): void {
+  #unbindAction(): void {
     const btn = this.#root.querySelector('.retry');
-    if (btn && this.#onRetryClick) {
-      btn.removeEventListener('click', this.#onRetryClick as EventListener);
+    if (btn && this.#onActionClick) {
+      btn.removeEventListener('click', this.#onActionClick as EventListener);
     }
-    this.#onRetryClick = null;
+    this.#onActionClick = null;
   }
 }
 

--- a/packages/webcomponents/tests/chat/slicc-error-card.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-error-card.test.ts
@@ -187,4 +187,99 @@ describe('slicc-error-card', () => {
     btn.click();
     expect(seen).toHaveLength(0);
   });
+
+  describe('action="settings" variant', () => {
+    it('defaults the action attribute to "retry"', () => {
+      const el = mount({ message: 'oops' });
+      expect(el.action).toBe('retry');
+    });
+
+    it('reflects the action attribute to the property and back', () => {
+      const el = mount();
+      el.action = 'settings';
+      expect(el.getAttribute('action')).toBe('settings');
+      el.setAttribute('action', 'retry');
+      expect(el.action).toBe('retry');
+      // Unknown values normalize back to the default so existing hosts stay safe.
+      el.setAttribute('action', 'banana');
+      expect(el.action).toBe('retry');
+      el.action = null;
+      expect(el.hasAttribute('action')).toBe(false);
+    });
+
+    it('defaults the button label to "Open Settings"', () => {
+      const el = mount({ message: 'No API key configured.', action: 'settings' });
+      expect(el.shadowRoot?.querySelector('[part="button"]')?.textContent?.trim()).toBe(
+        'Open Settings'
+      );
+    });
+
+    it('still honors an explicit button-label override', () => {
+      const el = mount({
+        message: 'No API key configured.',
+        action: 'settings',
+        'button-label': 'Add a key',
+      });
+      expect(el.shadowRoot?.querySelector('[part="button"]')?.textContent?.trim()).toBe(
+        'Add a key'
+      );
+    });
+
+    it('renders the lucide settings glyph instead of rotate-ccw', () => {
+      const el = mount({ message: 'No API key configured.', action: 'settings' });
+      const btn = el.shadowRoot?.querySelector('[part="button"]') as HTMLButtonElement;
+      const svg = btn.querySelector('svg');
+      expect(svg).toBeInstanceOf(SVGSVGElement);
+      expect(svg?.innerHTML).toBe(iconShape('settings', 12));
+      expect(svg?.innerHTML).not.toBe(iconShape('rotate-ccw', 12));
+    });
+
+    it('dispatches slicc-error-open-settings (bubbling, composed) on click', () => {
+      const el = mount({
+        message: 'No API key configured.',
+        action: 'settings',
+        'message-id': 'err-9',
+      });
+      const settingsSeen: CustomEvent[] = [];
+      const retrySeen: CustomEvent[] = [];
+      document.body.addEventListener('slicc-error-open-settings', (e) =>
+        settingsSeen.push(e as CustomEvent)
+      );
+      document.body.addEventListener('slicc-error-retry', (e) => retrySeen.push(e as CustomEvent));
+      const btn = el.shadowRoot?.querySelector('[part="button"]') as HTMLButtonElement;
+      btn.click();
+      expect(settingsSeen).toHaveLength(1);
+      expect(settingsSeen[0].bubbles).toBe(true);
+      expect(settingsSeen[0].composed).toBe(true);
+      expect(settingsSeen[0].detail).toEqual({ messageId: 'err-9' });
+      // The retry event is mutually exclusive in settings mode.
+      expect(retrySeen).toHaveLength(0);
+    });
+
+    it('exposes a programmatic openSettings() that dispatches the same event', () => {
+      const el = mount({ message: 'oops', 'message-id': 'err-2', action: 'settings' });
+      const spy = vi.fn();
+      el.addEventListener('slicc-error-open-settings', spy);
+      el.openSettings();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect((spy.mock.calls[0][0] as CustomEvent).detail).toEqual({ messageId: 'err-2' });
+    });
+
+    it('re-renders when the action attribute toggles back to retry', () => {
+      const el = mount({ message: 'oops', action: 'settings' });
+      expect(el.shadowRoot?.querySelector('[part="button"]')?.textContent?.trim()).toBe(
+        'Open Settings'
+      );
+      el.removeAttribute('action');
+      expect(el.shadowRoot?.querySelector('[part="button"]')?.textContent?.trim()).toBe(
+        'Try again'
+      );
+      const svg = el.shadowRoot?.querySelector('[part="button"] svg');
+      expect(svg?.innerHTML).toBe(iconShape('rotate-ccw', 12));
+      const seen: CustomEvent[] = [];
+      el.addEventListener('slicc-error-retry', (e) => seen.push(e as CustomEvent));
+      (el.shadowRoot?.querySelector('[part="button"]') as HTMLButtonElement).click();
+      expect(seen).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
## What

When a cone turn fails because no API key is configured, the error card showed the message "No API key configured for provider …. Open Settings to add one." but the button still said **Try again** and merely re-ran the same failing turn — landing the user in the same place.

This PR changes the CTA for that specific error to **Open Settings**, which opens the provider/model settings dialog so the user can actually fix the cause.

## How

- `slicc-error-card.ts` (`@slicc/webcomponents`) gains an opt-in `action` attribute (`retry` default, `settings` opt-in):
  - `action="settings"` defaults the button label to **Open Settings** (still overridable via `button-label`), swaps the glyph from `rotate-ccw` to `settings`, and dispatches a new bubbling+composed `slicc-error-open-settings` CustomEvent (carrying `{ messageId }` like the retry event) instead of `slicc-error-retry`.
  - Unknown `action` values normalize back to `retry` so existing hosts stay safe.
  - **The default behavior is byte-for-byte unchanged** — label "Try again", `rotate-ccw` icon, `slicc-error-retry` event. Every existing test passes untouched.
- `wc-message-view.ts`'s `errorCardEl` exports a small `NO_API_KEY_ERROR_PREFIX` helper and sets `action="settings"` on the card only when the error message starts with `No API key configured` (matches both `scoop-context.ts` variants — with and without provider name interpolation).
- `wc-nav.ts` adds a thread-level `slicc-error-open-settings` listener that calls the same `openSettings()` helper already wired to the composer-meta `add-ai` action, so the user lands in one settings surface regardless of which control they used. The listener lives in the shared `wireWcNav` path, so it covers both standalone and extension floats.
- New story `SettingsAction` (+ dark variant) in `slicc-error-card.stories.ts` covers the new variant.
- Mirrored tests under `packages/webcomponents/tests/chat/` and `packages/webapp/tests/ui/wc/`.

Out of scope (per task brief):
- Onboarding fixes (Bugs A/B/C) — separate PR. Did not touch `onboarding-orchestrator.ts`, `account-store.ts`, or `setup-onboarding-orchestrator.ts`.
- The error string wording in `scoop-context.ts` is unchanged.

## Verification

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run test -w @slicc/webcomponents` — 1398 / 1398 pass
- `npm run test -w @slicc/webapp` — 6383 pass / 10 skipped

`package-lock.json` was not committed.

## Risks / follow-ups

- The settings event uses the same `openSettings()` helper as the composer-meta `add-ai` action, so the dialog surface is shared. No new code path to maintain.
- The card-level retry semantics are byte-for-byte preserved — `slicc-error-retry` event, default button label, and `rotate-ccw` glyph all unchanged when `action` is unset or `retry`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author