### PR TITLE
fix(dip): give .sprinkle-inline 2px horizontal padding so focus rings aren't clipped

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -369,7 +369,6 @@
         "packages/webapp/src/shell/supplemental-commands/websocat-command.ts",
         "packages/webapp/src/skills/install-from-drop.ts",
         "packages/webapp/src/tools/search-tools.ts",
-        "packages/webapp/src/ui/dip.ts",
         "packages/webapp/src/ui/oauth-bootstrap.ts",
         "packages/webapp/src/ui/sprinkle-renderer.ts"
       ],

--- a/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
+++ b/packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml
@@ -9,10 +9,6 @@
         font-size: 13px;
         color: var(--s2-content-default, #e8e8e8);
         background: transparent;
-        /* Small inset so input :focus `box-shadow: 0 0 0 1px` rings,
-           which paint 1px outside the border, aren't clipped by the
-           tight-fitting dip iframe edge. */
-        padding: 2px 3px;
       }
       .step { display: none; animation: fadeUp 0.18s ease both; }
       .step.active { display: block; }

--- a/packages/webapp/src/ui/dip.ts
+++ b/packages/webapp/src/ui/dip.ts
@@ -449,9 +449,12 @@ const DIP_HOST_STYLES = `html,body{margin:0;padding:0;overflow:hidden;background
    by the dip's own content (e.g. .sprinkle-action-card__body) so shtml
    widgets that already pad themselves don't end up double-indented. The
    ResizeObserver on document.body reports the post-padding scrollHeight
-   correctly, so auto-height continues to work. */
+   correctly, so auto-height continues to work. The .sprinkle-inline rule
+   (set on the iframe body) carries 2px of horizontal padding so the 1px
+   focus ring (box-shadow:0 0 0 1px on inputs/select below) doesn't get
+   clipped at the iframe paint boundary. */
 body{padding:12px 0;font-family:var(--s2-font-family, sans-serif);font-size:13px;color:var(--s2-content-default)}
-.sprinkle-inline{padding:var(--s2-spacing-100) 0}
+.sprinkle-inline{padding:var(--s2-spacing-100) 2px}
 .sprinkle-inline .sprinkle-btn{padding:4px 12px;font-size:12px;height:28px;box-shadow:none}
 .sprinkle-inline .sprinkle-btn:not([class*="sprinkle-btn--"]){background:var(--s2-bg-elevated)}
 .sprinkle-inline .sprinkle-card{box-shadow:none;margin:0}
@@ -739,111 +742,127 @@ function toDipUint8Array(value: unknown): Uint8Array {
  * `inputreport` listener for this dip window; `hid.close` and dispose
  * tear it down.
  */
+async function runDipHidOp(
+  iframeWindow: Window,
+  op: string,
+  args: readonly unknown[]
+): Promise<unknown> {
+  const reg = getSharedHidRegistry();
+  switch (op) {
+    case 'list': {
+      const hid = getNavigatorHid();
+      if (!hid) throw new Error('WebHID is unavailable in this browser');
+      return hidOps.hidList(reg, hid);
+    }
+    case 'request': {
+      const hid = getNavigatorHid();
+      if (!hid) throw new Error('WebHID is unavailable in this browser');
+      return hidOps.hidRequest(reg, hid, (args[0] as HidDeviceFilter[]) ?? []);
+    }
+    case 'info':
+      return hidOps.hidDeviceInfo(reg, args[0] as string);
+    case 'open': {
+      const handle = args[0] as string;
+      await hidOps.hidOpen(reg, handle);
+      await attachDipHidInputReports(iframeWindow, handle);
+      return { ok: true };
+    }
+    case 'close': {
+      const handle = args[0] as string;
+      await detachDipHidInputReports(iframeWindow, handle);
+      await hidOps.hidClose(reg, handle);
+      return { ok: true };
+    }
+    case 'sendReport': {
+      const handle = args[0] as string;
+      const reportId = args[1] as number;
+      const bytes = toDipUint8Array(args[2]);
+      const buf = bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength
+      ) as ArrayBuffer;
+      await hidOps.hidSendReport(reg, handle, reportId, buf);
+      return { ok: true };
+    }
+    default:
+      throw new Error(`hid: unknown op '${op}'`);
+  }
+}
+
+async function runDipSerialOp(op: string, args: readonly unknown[]): Promise<unknown> {
+  const reg = getSharedSerialRegistry();
+  switch (op) {
+    case 'list': {
+      const serial = getNavigatorSerial();
+      if (!serial) throw new Error('Web Serial is unavailable in this browser');
+      return serialOps.serialList(reg, serial);
+    }
+    case 'request': {
+      const serial = getNavigatorSerial();
+      if (!serial) throw new Error('Web Serial is unavailable in this browser');
+      return serialOps.serialRequest(reg, serial, (args[0] as SerialFilter[]) ?? []);
+    }
+    case 'info':
+      return serialOps.serialDeviceInfo(reg, args[0] as string);
+    case 'open': {
+      const handle = args[0] as string;
+      const options = (args[1] as SerialOpenOptions) ?? { baudRate: 9600 };
+      await serialOps.serialOpen(reg, handle, options);
+      return { ok: true };
+    }
+    case 'close': {
+      await serialOps.serialClose(reg, args[0] as string);
+      return { ok: true };
+    }
+    default:
+      throw new Error(`serial: unknown op '${op}'`);
+  }
+}
+
+async function runDipUsbOp(op: string, args: readonly unknown[]): Promise<unknown> {
+  const reg = getSharedUsbRegistry();
+  switch (op) {
+    case 'list': {
+      const usb = getNavigatorUsb();
+      if (!usb) throw new Error('WebUSB is unavailable in this browser');
+      return usbOps.usbList(reg, usb);
+    }
+    case 'request': {
+      const usb = getNavigatorUsb();
+      if (!usb) throw new Error('WebUSB is unavailable in this browser');
+      return usbOps.usbRequest(reg, usb, (args[0] as UsbDeviceFilter[]) ?? []);
+    }
+    case 'info':
+      return usbOps.usbDeviceInfo(reg, args[0] as string);
+    case 'open': {
+      await usbOps.usbOpen(reg, args[0] as string);
+      return { ok: true };
+    }
+    case 'close': {
+      await usbOps.usbClose(reg, args[0] as string);
+      return { ok: true };
+    }
+    default:
+      throw new Error(`usb: unknown op '${op}'`);
+  }
+}
+
 async function runDipDeviceOp(
   iframeWindow: Window,
   channel: 'hid' | 'serial' | 'usb',
   op: string,
   args: readonly unknown[]
 ): Promise<unknown> {
-  if (channel === 'hid') {
-    const reg = getSharedHidRegistry();
-    switch (op) {
-      case 'list': {
-        const hid = getNavigatorHid();
-        if (!hid) throw new Error('WebHID is unavailable in this browser');
-        return hidOps.hidList(reg, hid);
-      }
-      case 'request': {
-        const hid = getNavigatorHid();
-        if (!hid) throw new Error('WebHID is unavailable in this browser');
-        return hidOps.hidRequest(reg, hid, (args[0] as HidDeviceFilter[]) ?? []);
-      }
-      case 'info':
-        return hidOps.hidDeviceInfo(reg, args[0] as string);
-      case 'open': {
-        const handle = args[0] as string;
-        await hidOps.hidOpen(reg, handle);
-        await attachDipHidInputReports(iframeWindow, handle);
-        return { ok: true };
-      }
-      case 'close': {
-        const handle = args[0] as string;
-        await detachDipHidInputReports(iframeWindow, handle);
-        await hidOps.hidClose(reg, handle);
-        return { ok: true };
-      }
-      case 'sendReport': {
-        const handle = args[0] as string;
-        const reportId = args[1] as number;
-        const bytes = toDipUint8Array(args[2]);
-        const buf = bytes.buffer.slice(
-          bytes.byteOffset,
-          bytes.byteOffset + bytes.byteLength
-        ) as ArrayBuffer;
-        await hidOps.hidSendReport(reg, handle, reportId, buf);
-        return { ok: true };
-      }
-      default:
-        throw new Error(`hid: unknown op '${op}'`);
-    }
+  switch (channel) {
+    case 'hid':
+      return runDipHidOp(iframeWindow, op, args);
+    case 'serial':
+      return runDipSerialOp(op, args);
+    case 'usb':
+      return runDipUsbOp(op, args);
+    default:
+      throw new Error(`unknown device channel '${channel}'`);
   }
-  if (channel === 'serial') {
-    const reg = getSharedSerialRegistry();
-    switch (op) {
-      case 'list': {
-        const serial = getNavigatorSerial();
-        if (!serial) throw new Error('Web Serial is unavailable in this browser');
-        return serialOps.serialList(reg, serial);
-      }
-      case 'request': {
-        const serial = getNavigatorSerial();
-        if (!serial) throw new Error('Web Serial is unavailable in this browser');
-        return serialOps.serialRequest(reg, serial, (args[0] as SerialFilter[]) ?? []);
-      }
-      case 'info':
-        return serialOps.serialDeviceInfo(reg, args[0] as string);
-      case 'open': {
-        const handle = args[0] as string;
-        const options = (args[1] as SerialOpenOptions) ?? { baudRate: 9600 };
-        await serialOps.serialOpen(reg, handle, options);
-        return { ok: true };
-      }
-      case 'close': {
-        await serialOps.serialClose(reg, args[0] as string);
-        return { ok: true };
-      }
-      default:
-        throw new Error(`serial: unknown op '${op}'`);
-    }
-  }
-  if (channel === 'usb') {
-    const reg = getSharedUsbRegistry();
-    switch (op) {
-      case 'list': {
-        const usb = getNavigatorUsb();
-        if (!usb) throw new Error('WebUSB is unavailable in this browser');
-        return usbOps.usbList(reg, usb);
-      }
-      case 'request': {
-        const usb = getNavigatorUsb();
-        if (!usb) throw new Error('WebUSB is unavailable in this browser');
-        return usbOps.usbRequest(reg, usb, (args[0] as UsbDeviceFilter[]) ?? []);
-      }
-      case 'info':
-        return usbOps.usbDeviceInfo(reg, args[0] as string);
-      case 'open': {
-        await usbOps.usbOpen(reg, args[0] as string);
-        return { ok: true };
-      }
-      case 'close': {
-        await usbOps.usbClose(reg, args[0] as string);
-        return { ok: true };
-      }
-      default:
-        throw new Error(`usb: unknown op '${op}'`);
-    }
-  }
-  throw new Error(`unknown device channel '${channel}'`);
 }
 
 /**


### PR DESCRIPTION
## Problem

Focus rings on inputs/select inside any inline dip (reported on the connect-llm welcome dip) are visibly clipped on the left/right edges. The ring is `box-shadow: 0 0 0 1px var(--s2-accent)` from `DIP_HOST_STYLES`, and `box-shadow` paints outside the element's border box. With 0px of horizontal padding on the iframe body it has nowhere to land.

## Root cause

The dip iframe's `<body>` carries `class="sprinkle-inline"` (set by `buildDipSrcdoc` in `packages/webapp/src/ui/dip.ts`), and `DIP_HOST_STYLES` previously applied:

```css
.sprinkle-inline { padding: var(--s2-spacing-100) 0 }   /* 8px vertical, 0px HORIZONTAL */
```

The iframe is a hard paint boundary, so a 0-px horizontal inset means the 1-px focus shadow paints right at the iframe edge and is clipped.

(PR #1046 tried to fix it with `body { padding: 2px 3px }` in `connect-llm.shtml`, but a plain `body` type selector — specificity `(0,0,0,1)` — is outranked by the host's `.sprinkle-inline` class rule — `(0,0,1,0)`. The earlier revision of this PR worked around that with `body.sprinkle-inline` in the leaf sprinkle; this revision fixes it at the shared host stylesheet instead, so every inline dip benefits.)

## Fix

Give `.sprinkle-inline` 2 px of horizontal padding in `DIP_HOST_STYLES`:

```css
.sprinkle-inline { padding: var(--s2-spacing-100) 2px }
```

Applies to every inline dip across both rendering paths because both build the iframe srcdoc via the same `buildDipSrcdoc` + `DIP_HOST_STYLES`:

- **Standalone** — `mountDip` inserts the srcdoc directly into the chat iframe.
- **Extension** — `mountDipExtension` posts the same srcdoc to `sprinkle-sandbox.html`, which mounts it as a nested srcdoc iframe.

Also removes the dead `body { padding: 2px 3px }` rule from `connect-llm.shtml` (the one #1046 added — never applied due to specificity, no longer needed now that the host owns the clearance).

## Complexity boy-scout

`packages/webapp/src/ui/dip.ts` was on `biome.json`'s `noExcessiveCognitiveComplexity` debt list because `runDipDeviceOp` scored 31 (cap 25). Refactored the per-channel dispatch out into three small helpers:

- `runDipHidOp(iframeWindow, op, args)` — the `list/request/info/open/close/sendReport` switch for HID.
- `runDipSerialOp(op, args)` — the `list/request/info/open/close` switch for Serial.
- `runDipUsbOp(op, args)` — the `list/request/info/open/close` switch for USB.

`runDipDeviceOp` becomes a 3-arm `switch (channel)` that delegates. No behavior change; the per-helper switches all score well under 25. Removed `packages/webapp/src/ui/dip.ts` from the debt list in `biome.json`; `biome lint packages/webapp/src/ui/dip.ts` now passes cleanly with the rule enforced. No rule disabled and no ignore comments added.

## Verification

```
npm run lint                            # passes
npm run lint:ci                         # passes (biome / prettier / docs / skills / no-innerhtml / patches)
npm run typecheck                       # passes (all 7 tsc projects)
npm run test -w @slicc/webapp           # 6466 passed | 10 skipped (357 files)
npm run build                           # passes (root + swift-launcher)
npm run build -w @slicc/chrome-extension # passes (vite build)
node packages/dev-tools/tools/check-touched-exemptions.mjs
                                        # OK (3 changed file(s), 0 still on any debt list)
```

## Files changed

- `packages/webapp/src/ui/dip.ts` — host CSS clearance + per-channel device-op refactor.
- `biome.json` — removed `packages/webapp/src/ui/dip.ts` from the cognitive-complexity debt list.
- `packages/vfs-root/shared/sprinkles/welcome/connect-llm.shtml` — removed the dead `body` padding rule from PR #1046.

Follow-up to #1046.