### PR TITLE
Fix IndexedDB cached connections entering 'closing' state (#1049)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -331,7 +331,6 @@
         "packages/webapp/src/net/handoff-link.ts",
         "packages/webapp/src/net/link-header.ts",
         "packages/webapp/src/providers/built-in/azure-openai.ts",
-        "packages/webapp/src/scoops/db.ts",
         "packages/webapp/src/scoops/tray-leader-sync.ts",
         "packages/webapp/src/scoops/tray-webrtc.ts",
         "packages/webapp/src/shell/mcp/oauth.ts",

--- a/packages/webapp/src/core/session.ts
+++ b/packages/webapp/src/core/session.ts
@@ -33,7 +33,19 @@ export class SessionStore {
 
   private getDB(): Promise<IDBDatabase> {
     if (!this.dbPromise) {
-      this.dbPromise = openDB();
+      this.dbPromise = openDB().then((db) => {
+        // Drop the cached promise if another context bumps the schema or
+        // `nuke` deletes the DB — the next caller re-opens cleanly instead
+        // of throwing "the database connection is closing".
+        db.onversionchange = () => {
+          db.close();
+          this.dbPromise = null;
+        };
+        db.onclose = () => {
+          this.dbPromise = null;
+        };
+        return db;
+      });
     }
     return this.dbPromise;
   }

--- a/packages/webapp/src/fs/mount/remote-cache.ts
+++ b/packages/webapp/src/fs/mount/remote-cache.ts
@@ -67,7 +67,20 @@ export class RemoteMountCache {
             db.createObjectStore(BODY_STORE);
           }
         };
-        req.onsuccess = () => resolve(req.result);
+        req.onsuccess = () => {
+          const db = req.result;
+          // Drop the cached promise if a peer context bumps the schema or
+          // `nuke` deletes the DB — the next caller re-opens cleanly instead
+          // of throwing "the database connection is closing".
+          db.onversionchange = () => {
+            db.close();
+            this.dbPromise = null;
+          };
+          db.onclose = () => {
+            this.dbPromise = null;
+          };
+          resolve(db);
+        };
         req.onerror = () => reject(req.error);
       });
     }

--- a/packages/webapp/src/scoops/db.ts
+++ b/packages/webapp/src/scoops/db.ts
@@ -21,112 +21,141 @@ const STORES = {
 
 let db: IDBDatabase | null = null;
 
-async function openDB(): Promise<IDBDatabase> {
-  // If we have a cached connection, verify it has all required stores
-  if (db) {
-    const hasAllStores = Object.values(STORES).every((name) => db!.objectStoreNames.contains(name));
-    if (db.version === DB_VERSION && hasAllStores) {
-      return db;
-    }
-    // Close outdated/incomplete connection to trigger upgrade
-    db.close();
-    db = null;
+function runMigrationV1(database: IDBDatabase): void {
+  // Fresh install — create all stores
+  if (!database.objectStoreNames.contains(STORES.MESSAGES)) {
+    const store = database.createObjectStore(STORES.MESSAGES, { keyPath: 'id' });
+    store.createIndex('chatJid', 'chatJid');
+    store.createIndex('timestamp', 'timestamp');
+    store.createIndex('chatJid_timestamp', ['chatJid', 'timestamp']);
   }
+
+  if (!database.objectStoreNames.contains(STORES.SESSIONS)) {
+    database.createObjectStore(STORES.SESSIONS, { keyPath: 'groupFolder' });
+  }
+
+  if (!database.objectStoreNames.contains(STORES.TASKS)) {
+    const store = database.createObjectStore(STORES.TASKS, { keyPath: 'id' });
+    store.createIndex('groupFolder', 'groupFolder');
+  }
+
+  if (!database.objectStoreNames.contains(STORES.STATE)) {
+    database.createObjectStore(STORES.STATE, { keyPath: 'key' });
+  }
+}
+
+function mapLegacyGroupToScoop(g: {
+  jid: string;
+  name: string;
+  folder: string;
+  trigger?: string;
+  requiresTrigger?: boolean;
+  isMain?: boolean;
+  addedAt: string;
+  config?: {
+    systemPromptAppend?: string;
+    timeout?: number;
+    assistantName?: string;
+  };
+}): RegisteredScoop {
+  const isCone = g.isMain ?? false;
+  return {
+    jid: g.jid,
+    name: g.name,
+    folder: g.folder,
+    trigger: isCone ? undefined : g.trigger || `@${g.folder}`,
+    requiresTrigger: !isCone && (g.requiresTrigger ?? true),
+    isCone,
+    type: isCone ? 'cone' : 'scoop',
+    assistantLabel: isCone ? 'sliccy' : g.config?.assistantName || g.folder,
+    addedAt: g.addedAt,
+    config: g.config
+      ? {
+          systemPromptAppend: g.config.systemPromptAppend,
+          timeout: g.config.timeout,
+          assistantName: g.config.assistantName,
+        }
+      : undefined,
+  };
+}
+
+function runMigrationV2(event: IDBVersionChangeEvent, database: IDBDatabase): void {
+  // Migration: groups → scoops
+  if (database.objectStoreNames.contains('groups')) {
+    const tx = (event.target as IDBOpenDBRequest).transaction!;
+    const oldStore = tx.objectStore('groups');
+    const getAllReq = oldStore.getAll();
+    getAllReq.onsuccess = () => {
+      const oldGroups = getAllReq.result;
+      database.deleteObjectStore('groups');
+      const scoopsStore = database.createObjectStore(STORES.SCOOPS, { keyPath: 'jid' });
+      scoopsStore.createIndex('type', 'type');
+      for (const g of oldGroups) {
+        scoopsStore.put(mapLegacyGroupToScoop(g));
+      }
+    };
+    return;
+  }
+  if (!database.objectStoreNames.contains(STORES.SCOOPS)) {
+    const scoopsStore = database.createObjectStore(STORES.SCOOPS, { keyPath: 'jid' });
+    scoopsStore.createIndex('type', 'type');
+  }
+}
+
+function runMigrationV3(database: IDBDatabase): void {
+  if (!database.objectStoreNames.contains(STORES.WEBHOOKS)) {
+    database.createObjectStore(STORES.WEBHOOKS, { keyPath: 'id' });
+  }
+  if (!database.objectStoreNames.contains(STORES.CRONTASKS)) {
+    database.createObjectStore(STORES.CRONTASKS, { keyPath: 'id' });
+  }
+}
+
+function applyMigrations(event: IDBVersionChangeEvent): void {
+  const database = (event.target as IDBOpenDBRequest).result;
+  const oldVersion = event.oldVersion;
+  if (oldVersion < 1) runMigrationV1(database);
+  if (oldVersion < 2) runMigrationV2(event, database);
+  if (oldVersion < 3) runMigrationV3(database);
+}
+
+function getCachedDB(): IDBDatabase | null {
+  if (!db) return null;
+  const hasAllStores = Object.values(STORES).every((name) => db!.objectStoreNames.contains(name));
+  if (db.version === DB_VERSION && hasAllStores) return db;
+  // Close outdated/incomplete connection to trigger upgrade
+  db.close();
+  db = null;
+  return null;
+}
+
+function bindLifecycle(connection: IDBDatabase): void {
+  // Drop the cache if another context (side panel ↔ offscreen) bumps the
+  // schema or `nuke` runs `deleteDatabase` — the next caller re-opens
+  // cleanly instead of throwing "the database connection is closing".
+  // Capture `connection` so concurrent opens close their own handle even
+  // when a later open has already overwritten the module-level cache.
+  connection.onversionchange = () => {
+    connection.close();
+    if (db === connection) db = null;
+  };
+  connection.onclose = () => {
+    if (db === connection) db = null;
+  };
+}
+
+async function openDB(): Promise<IDBDatabase> {
+  const cached = getCachedDB();
+  if (cached) return cached;
 
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
-
-    request.onupgradeneeded = (event) => {
-      const database = (event.target as IDBOpenDBRequest).result;
-      const oldVersion = event.oldVersion;
-
-      if (oldVersion < 1) {
-        // Fresh install — create all stores
-        if (!database.objectStoreNames.contains(STORES.MESSAGES)) {
-          const store = database.createObjectStore(STORES.MESSAGES, { keyPath: 'id' });
-          store.createIndex('chatJid', 'chatJid');
-          store.createIndex('timestamp', 'timestamp');
-          store.createIndex('chatJid_timestamp', ['chatJid', 'timestamp']);
-        }
-
-        if (!database.objectStoreNames.contains(STORES.SESSIONS)) {
-          database.createObjectStore(STORES.SESSIONS, { keyPath: 'groupFolder' });
-        }
-
-        if (!database.objectStoreNames.contains(STORES.TASKS)) {
-          const store = database.createObjectStore(STORES.TASKS, { keyPath: 'id' });
-          store.createIndex('groupFolder', 'groupFolder');
-        }
-
-        if (!database.objectStoreNames.contains(STORES.STATE)) {
-          database.createObjectStore(STORES.STATE, { keyPath: 'key' });
-        }
-      }
-
-      if (oldVersion < 2) {
-        // Migration: groups → scoops
-        const tx = (event.target as IDBOpenDBRequest).transaction!;
-
-        // If old 'groups' store exists, migrate data
-        if (database.objectStoreNames.contains('groups')) {
-          // Read all groups from old store
-          const oldStore = tx.objectStore('groups');
-          const getAllReq = oldStore.getAll();
-          getAllReq.onsuccess = () => {
-            const oldGroups = getAllReq.result;
-
-            // Delete old store
-            database.deleteObjectStore('groups');
-
-            // Create new scoops store
-            const scoopsStore = database.createObjectStore(STORES.SCOOPS, { keyPath: 'jid' });
-            scoopsStore.createIndex('type', 'type');
-
-            // Migrate records
-            for (const g of oldGroups) {
-              const isCone = g.isMain ?? false;
-              const scoop: RegisteredScoop = {
-                jid: g.jid,
-                name: g.name,
-                folder: g.folder,
-                trigger: isCone ? undefined : g.trigger || `@${g.folder}`,
-                requiresTrigger: !isCone && (g.requiresTrigger ?? true),
-                isCone,
-                type: isCone ? 'cone' : 'scoop',
-                assistantLabel: isCone ? 'sliccy' : g.config?.assistantName || g.folder,
-                addedAt: g.addedAt,
-                config: g.config
-                  ? {
-                      systemPromptAppend: g.config.systemPromptAppend,
-                      timeout: g.config.timeout,
-                      assistantName: g.config.assistantName,
-                    }
-                  : undefined,
-              };
-              scoopsStore.put(scoop);
-            }
-          };
-        } else if (!database.objectStoreNames.contains(STORES.SCOOPS)) {
-          // No old store, just create the new one
-          const scoopsStore = database.createObjectStore(STORES.SCOOPS, { keyPath: 'jid' });
-          scoopsStore.createIndex('type', 'type');
-        }
-      }
-
-      if (oldVersion < 3) {
-        // Add webhooks and crontasks stores
-        if (!database.objectStoreNames.contains(STORES.WEBHOOKS)) {
-          database.createObjectStore(STORES.WEBHOOKS, { keyPath: 'id' });
-        }
-        if (!database.objectStoreNames.contains(STORES.CRONTASKS)) {
-          database.createObjectStore(STORES.CRONTASKS, { keyPath: 'id' });
-        }
-      }
-    };
-
+    request.onupgradeneeded = applyMigrations;
     request.onsuccess = () => {
-      db = request.result;
-      resolve(db);
+      const connection = request.result;
+      bindLifecycle(connection);
+      db = connection;
+      resolve(connection);
     };
     request.onerror = () => reject(request.error);
   });

--- a/packages/webapp/src/ui/session-store.ts
+++ b/packages/webapp/src/ui/session-store.ts
@@ -26,17 +26,33 @@ export class SessionStore {
   private db: IDBDatabase | null = null;
 
   async init(): Promise<void> {
-    this.db = await openDb();
+    await this.getDb();
   }
 
-  private ensureDb(): IDBDatabase {
-    if (!this.db) throw new Error('SessionStore not initialized. Call init() first.');
+  /**
+   * Lazy connection accessor — re-opens transparently after a `versionchange`
+   * or `close` event drops the cached handle (e.g. a peer context bumped the
+   * schema or `nuke` ran `deleteDatabase`). Replaces the old throw-if-null
+   * `ensureDb()` so callers don't have to re-`init()` after such events.
+   */
+  private async getDb(): Promise<IDBDatabase> {
+    if (!this.db) {
+      const db = await openDb();
+      db.onversionchange = () => {
+        db.close();
+        this.db = null;
+      };
+      db.onclose = () => {
+        this.db = null;
+      };
+      this.db = db;
+    }
     return this.db;
   }
 
   /** Save a session (upsert). */
   async save(session: Session): Promise<void> {
-    const db = this.ensureDb();
+    const db = await this.getDb();
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, 'readwrite');
       tx.objectStore(STORE_NAME).put(session);
@@ -47,7 +63,7 @@ export class SessionStore {
 
   /** Load a session by ID. */
   async load(id: string): Promise<Session | null> {
-    const db = this.ensureDb();
+    const db = await this.getDb();
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, 'readonly');
       const req = tx.objectStore(STORE_NAME).get(id);
@@ -58,7 +74,7 @@ export class SessionStore {
 
   /** List all session IDs (most recent first). */
   async list(): Promise<string[]> {
-    const db = this.ensureDb();
+    const db = await this.getDb();
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, 'readonly');
       const req = tx.objectStore(STORE_NAME).getAll();
@@ -72,7 +88,7 @@ export class SessionStore {
 
   /** Delete a session. */
   async delete(id: string): Promise<void> {
-    const db = this.ensureDb();
+    const db = await this.getDb();
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, 'readwrite');
       tx.objectStore(STORE_NAME).delete(id);

--- a/packages/webapp/tests/fs/mount/remote-cache.test.ts
+++ b/packages/webapp/tests/fs/mount/remote-cache.test.ts
@@ -140,4 +140,33 @@ describe('RemoteMountCache.bodies', () => {
     expect(await a.getBody('foo.txt')).toBeNull();
     expect(await b.getBody('bar.txt')).not.toBeNull();
   });
+
+  it('re-opens transparently after versionchange (deleteDatabase) drops the cached connection', async () => {
+    // Use real timers for this case — fake timers break the indexedDB
+    // microtask scheduling that deleteDatabase relies on to deliver
+    // versionchange to open connections.
+    vi.useRealTimers();
+    const dbName = uniqueDbName();
+    const cache = new RemoteMountCache({ mountId: 'm1', ttlMs: 30_000, dbName });
+
+    // First call opens + caches the connection.
+    await cache.putBody('foo.txt', new Uint8Array([1]), '"e"');
+    expect(await cache.getBody('foo.txt')).not.toBeNull();
+
+    // deleteDatabase delivers `versionchange` to open connections. With the
+    // handler installed, the cached connection closes and the cached
+    // dbPromise is nulled; without it, the next transaction would throw the
+    // closing error.
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.deleteDatabase(dbName);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+      req.onblocked = () =>
+        reject(new Error('deleteDatabase blocked — cached connection was not closed'));
+    });
+
+    // Next op must re-open transparently against the fresh DB.
+    await cache.putBody('bar.txt', new Uint8Array([2]), '"e2"');
+    expect(await cache.getBody('bar.txt')).not.toBeNull();
+  });
 });

--- a/packages/webapp/tests/scoops/db-handlers.test.ts
+++ b/packages/webapp/tests/scoops/db-handlers.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression tests for the versionchange/close handler wiring in
+ * `scoops/db.ts` — when another context bumps the schema or `nuke` deletes
+ * the database, the cached connection must be dropped and the next caller
+ * must re-open cleanly instead of throwing "the database connection is
+ * closing".
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, expect, it } from 'vitest';
+import { getScoop, saveScoop } from '../../src/scoops/db.js';
+import type { RegisteredScoop } from '../../src/scoops/types.js';
+
+const sample = (jid: string): RegisteredScoop => ({
+  jid,
+  name: 'sample',
+  folder: 'sample',
+  requiresTrigger: false,
+  isCone: false,
+  type: 'scoop',
+  assistantLabel: 'sample',
+  addedAt: '2025-01-01T00:00:00.000Z',
+});
+
+describe('scoops/db.ts versionchange/close handler', () => {
+  it('re-opens transparently after deleteDatabase fires versionchange', async () => {
+    // First call opens + caches the connection.
+    await saveScoop(sample('s1'));
+    expect(await getScoop('s1')).not.toBeNull();
+
+    // deleteDatabase delivers `versionchange` to every open connection. With
+    // the handler installed the cached connection closes and the cache is
+    // nulled; without it, deleteDatabase would block and the next
+    // transaction would throw the closing error.
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.deleteDatabase('slicc-groups');
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+      req.onblocked = () =>
+        reject(new Error('deleteDatabase blocked — cached connection was not closed'));
+    });
+
+    // Next operation must re-open transparently.
+    await saveScoop(sample('s2'));
+    expect(await getScoop('s2')).not.toBeNull();
+  });
+
+  it('does not block deleteDatabase after concurrent opens overwrite the cache', async () => {
+    // Two parallel callers both miss the module-level cache and each opens
+    // its own connection — the second `onsuccess` overwrites the first in
+    // the cache. The previous handler closed whatever was cached when a
+    // `versionchange` fired on the FIRST (non-cached) connection, leaving
+    // the original connection open and blocking `deleteDatabase`. The fix
+    // captures `request.result` per open so each handler closes its own
+    // connection regardless of cache state.
+    await Promise.all([saveScoop(sample('cc1')), saveScoop(sample('cc2'))]);
+
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.deleteDatabase('slicc-groups');
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+      req.onblocked = () =>
+        reject(new Error('deleteDatabase blocked — a concurrent-open connection was not closed'));
+    });
+
+    await saveScoop(sample('cc3'));
+    expect(await getScoop('cc3')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #1049.

## Problem

Four long-lived cached IndexedDB connections never installed versionchange/close handlers. When a peer context (side panel vs offscreen document in the extension float) bumps a schema, or when nuke runs deleteDatabase across every DB, the held connection silently enters the 'closing' state. The next db.transaction(...) then throws 'failed to execute transaction on idbdatabase: the database connection is closing.'

Note: this is distinct from the removed legacy slicc-fs VFS backend. These four databases are separate and still active:

- scoops/db.ts -> slicc-groups (v3, version-bumps on new stores)
- core/session.ts -> agent-sessions
- ui/session-store.ts -> browser-coding-agent
- fs/mount/remote-cache.ts -> slicc-mount-cache

## Fix

At each cached open-success point, install:

- onversionchange: close the connection and null the cache
- onclose: null the cache

so a connection invalidated by another context is dropped and the next caller re-opens transparently.

- scoops/db.ts: nulls the module-level db (existing staleness close() path preserved).
- core/session.ts and fs/mount/remote-cache.ts: null the instance dbPromise.
- ui/session-store.ts: refactored ensureDb() -> lazy getDb() so all CRUD methods re-open transparently instead of hard-throwing 'not initialized' after a drop.

No schema versions or object-store definitions changed.

## Tests

Added non-vacuous regression tests for scoops/db.ts and remote-cache.ts that simulate connection invalidation and assert the next call re-opens rather than throwing.

## Verification

- npm run lint: PASS
- npm run typecheck: PASS (all 7 tsc projects)
- npm run test: PASS (7926/7946 tests, 0 failures)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author