### PR TITLE
test(e2e): fake-LLM E2E framework with deterministic CDP assertions

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -462,11 +462,44 @@ Three pieces compose the framework:
 ### Writing a Scenario
 
 See `packages/webapp/tests/e2e/reference-scenario.test.ts` for the
-working reference. Boilerplate:
+working reference. It runs a single Playwright test against a
+3-phase fixture and interleaves chat-transcript + CDP-state
+assertions after each phase:
+
+- **Phase 1** — user input `"open the reference page"` matches
+  `turns[0]` (substring matcher); the agent runs one `bash`
+  `playwright-cli tab-new` opening Page A
+  (title `FAKE LLM REFERENCE TARGET`). `turns[1]` (cursor follow-up)
+  delivers `"Done. Page A is open."`. The test then asserts both
+  strings are in the thread and that `readCdpPageState` sees exactly
+  one target at the Page A `data:` URL.
+- **Phase 2** — user input `"open the comparison pages"` matches
+  `turns[2]`, which emits **two** `bash` tool calls in one turn
+  (Page B `FAKE LLM COMPARE ALPHA`, Page C `FAKE LLM COMPARE BETA`)
+  with small `contentChunkSize` and `toolArgumentsChunkSize` to
+  stress SSE delta reassembly. `turns[3]` (cursor) closes the
+  phase with `"Done. Pages B and C are open."`. The test asserts
+  the closing text and that `readCdpPageState` filtered to the two
+  Page B/C URLs reports both distinct titles.
+- **Phase 3** — user input `"give me a summary"` matches `turns[4]`
+  via the object-form regex matcher
+  (`{ "pattern": "summar(y|ize)", "flags": "i" }`); the turn returns
+  text only (no tool call). The test asserts the summary text in the
+  thread and that `readCdpPageState` filtered to all three `data:`
+  URLs enumerates Pages A/B/C with their three distinct titles
+  (sorted for a stable assertion).
+
+Boilerplate, lightly abbreviated from
+`reference-scenario.test.ts`:
 
 ```typescript
 import { expect, test } from '@playwright/test';
-import { readCdpPageState, runUserInputFixture, seedLocalLlmProvider } from './fake-llm-helpers.js';
+import {
+  readCdpPageState,
+  seedLocalLlmProvider,
+  submitUserMessage,
+  waitForTurnComplete,
+} from './fake-llm-helpers.js';
 import { seedSkipSwReload, waitForSW } from './helpers.js';
 
 // Binds Chrome's CDP at the default port the helper probes AND the
@@ -475,64 +508,33 @@ import { seedSkipSwReload, waitForSW } from './helpers.js';
 test.use({ launchOptions: { args: ['--remote-debugging-port=9222'] } });
 test.describe.configure({ mode: 'serial' });
 
-test('scripted tool call drives a real CDP navigation', async ({ page }) => {
-  // 1. Seed the local-llm provider BEFORE goto so the kernel worker's
-  //    localStorage shim picks the seed up at boot.
+test('multi-phase scripted tool calls drive multiple CDP navigations', async ({ page }) => {
   await seedLocalLlmProvider(page, { modelId: 'fake-coder-reference' });
   await seedSkipSwReload(page);
   await page.goto('/');
   await waitForSW(page);
-
-  // 2. Wait for the cone to be created AND selected. The composer
-  //    renders earlier; submitting before this point produces a
-  //    "No scoop selected" error card.
   await page.waitForSelector('slicc-input-card');
   await expect(page.locator('slicc-chat-thread')).toContainText('Welcome to SLICC');
 
-  // 3. Submit the scripted user input. `runUserInputFixture` calls
-  //    `submitUserMessage` + `waitForTurnComplete` for each entry.
-  await runUserInputFixture(page, ['open the reference page']);
-
-  // 4. Chat-transcript assertion — positive proof the fake LLM
-  //    streamed back AND the agent loop ran the scripted turn.
-  await expect(page.locator('slicc-chat-thread')).toContainText('Opening the reference');
-
-  // 5. CDP/browser-state assertion — Chrome at 9222 reports the
-  //    target the agent's `bash playwright-cli tab-new …` opened.
+  // Drive one phase at a time so per-phase assertions can interleave.
+  await submitUserMessage(page, 'open the reference page');
+  await waitForTurnComplete(page);
+  await expect(page.locator('slicc-chat-thread')).toContainText('Done. Page A is open.');
   await expect
-    .poll(async () => {
-      const targets = await readCdpPageState({
-        filter: (t) => t.type === 'page' && t.url.startsWith('data:text/html'),
-      });
-      return targets.map((t) => t.title);
-    })
+    .poll(async () =>
+      (await readCdpPageState({ filter: (t) => t.type === 'page' })).map((t) => t.title)
+    )
     .toContain('FAKE LLM REFERENCE TARGET');
+
+  // Phases 2 and 3 follow the same submit + wait + assert pattern.
 });
 ```
 
-Matching fixture (`fixtures/reference-scenario.json`):
-
-```json
-{
-  "model": "fake-coder-reference",
-  "turns": [
-    {
-      "whenUserMessageMatches": "open the reference page",
-      "content": "Opening the reference data: URL so the test can assert on the CDP target.",
-      "tool_calls": [
-        {
-          "name": "bash",
-          "arguments": {
-            "command": "playwright-cli tab-new 'data:text/html,<!DOCTYPE html><title>FAKE LLM REFERENCE TARGET</title><h1>Agent landed here</h1>'"
-          }
-        }
-      ]
-    },
-    { "content": "Done. The agent navigated to the reference page." }
-  ],
-  "onOverflow": "error"
-}
-```
+For full inputs, fixture content, and assertions, read the working
+test directly. The fixture lives at
+`packages/webapp/tests/e2e/fake-llm/fixtures/reference-scenario.json`
+and uses `onOverflow: "error"` so a fixture/test mismatch fails fast
+with a 400 from the fake server rather than hanging.
 
 ### CDP Assertions
 
@@ -573,8 +575,18 @@ via the seeded `local-llm` provider. Override the fixture with the
   the seeded `slicc_accounts` + `selected-model` make it from page
   storage into the worker's `localStorage` shim — otherwise the agent
   never resolves the `local-llm` model and never calls the fake server.
-- **`waitForTurnComplete` masking failures**: the popup + chat-transcript
-  assertions are positive — they only succeed when the scripted turn
-  actually ran end to end.
+- **`waitForTurnComplete` masking failures**: the per-phase
+  chat-transcript + CDP-state assertions are positive — each one only
+  succeeds when the prior scripted turn actually ran end to end, so a
+  silent "turn never started" surfaces as a timeout, not a false green.
 - **CDP port alignment**: the helper, the `node-server --serve-only`
-  proxy, and the test's `launchOptions.args` all agree on 9222.
+  proxy, and the test's `launchOptions.args` all agree on 9222, and
+  the per-phase `readCdpPageState` filters key on each target's
+  distinct title/URL so multi-tab assertions stay unambiguous.
+- **SSE delta reassembly**: phase 2's turn sets small
+  `contentChunkSize` and `toolArgumentsChunkSize` so the agent has to
+  reassemble both streamed content and multi-tool-call argument
+  fragments before the bash commands run.
+- **Matcher coverage**: the three matched turns exercise the
+  substring form (phases 1 + 2) and the object-form regex
+  (`{ pattern, flags }`, phase 3) of `whenUserMessageMatches`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -569,6 +569,16 @@ npm run test:e2e
 via the seeded `local-llm` provider. Override the fixture with the
 `FAKE_LLM_FIXTURE` env var.
 
+The project pins `workers: 1` so only one CDP-binding scenario runs
+at a time. The `node-server --serve-only --cdp-port=9222` proxy can
+only point at one Chrome at a time, and every scenario that drives
+the agent's `playwright-cli` (`reference-scenario.test.ts`,
+`preview-serve.test.ts`) launches Playwright Chrome with
+`--remote-debugging-port=9222` — running them in parallel would
+collide on the port and on the proxy's outbound target. The fake-LLM
+webServer entry also sets `reuseExistingServer: false` so each run
+starts with a fresh turn cursor and fixture.
+
 ### Risks Covered by the Reference Scenario
 
 - **localStorage → kernel-worker shim sync**: the test only passes if

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -437,3 +437,144 @@ describe('Bash tool integration', () => {
 ```
 
 But avoid testing implementation details across many layers. Keep most tests focused and fast.
+
+## Fake-LLM E2E Framework
+
+End-to-end agent-loop tests run the real WC composer + kernel-worker
+agent against a deterministic OpenAI-compatible fake LLM server. The
+agent loop is identical to production — fixtures only change which
+assistant turns stream back.
+
+Three pieces compose the framework:
+
+- **Fake server** (`packages/webapp/tests/e2e/fake-llm/`): SSE-streaming
+  OpenAI-compatible server with permissive CORS. Started by a second
+  `webServer` entry in `playwright.config.ts` on port 5781.
+- **Fixture** (`packages/webapp/tests/e2e/fake-llm/fixtures/*.json`):
+  ordered list of scripted assistant `turns` (text + optional
+  `tool_calls`). Turns are matched cursor-first; per-turn
+  `whenUserMessageMatches` (substring or `{ pattern, flags }` regex)
+  selects a specific turn for a specific user input.
+- **Playwright harness** (`packages/webapp/tests/e2e/fake-llm-helpers.ts`):
+  `seedLocalLlmProvider`, `submitUserMessage`, `waitForTurnComplete`,
+  `runUserInputFixture`, and `readCdpPageState`.
+
+### Writing a Scenario
+
+See `packages/webapp/tests/e2e/reference-scenario.test.ts` for the
+working reference. Boilerplate:
+
+```typescript
+import { expect, test } from '@playwright/test';
+import { readCdpPageState, runUserInputFixture, seedLocalLlmProvider } from './fake-llm-helpers.js';
+import { seedSkipSwReload, waitForSW } from './helpers.js';
+
+// Binds Chrome's CDP at the default port the helper probes AND the
+// port the `node-server --serve-only --cdp-port=9222` proxy expects.
+// Run this file serially when other specs also touch 9222.
+test.use({ launchOptions: { args: ['--remote-debugging-port=9222'] } });
+test.describe.configure({ mode: 'serial' });
+
+test('scripted tool call drives a real CDP navigation', async ({ page }) => {
+  // 1. Seed the local-llm provider BEFORE goto so the kernel worker's
+  //    localStorage shim picks the seed up at boot.
+  await seedLocalLlmProvider(page, { modelId: 'fake-coder-reference' });
+  await seedSkipSwReload(page);
+  await page.goto('/');
+  await waitForSW(page);
+
+  // 2. Wait for the cone to be created AND selected. The composer
+  //    renders earlier; submitting before this point produces a
+  //    "No scoop selected" error card.
+  await page.waitForSelector('slicc-input-card');
+  await expect(page.locator('slicc-chat-thread')).toContainText('Welcome to SLICC');
+
+  // 3. Submit the scripted user input. `runUserInputFixture` calls
+  //    `submitUserMessage` + `waitForTurnComplete` for each entry.
+  await runUserInputFixture(page, ['open the reference page']);
+
+  // 4. Chat-transcript assertion — positive proof the fake LLM
+  //    streamed back AND the agent loop ran the scripted turn.
+  await expect(page.locator('slicc-chat-thread')).toContainText('Opening the reference');
+
+  // 5. CDP/browser-state assertion — Chrome at 9222 reports the
+  //    target the agent's `bash playwright-cli tab-new …` opened.
+  await expect
+    .poll(async () => {
+      const targets = await readCdpPageState({
+        filter: (t) => t.type === 'page' && t.url.startsWith('data:text/html'),
+      });
+      return targets.map((t) => t.title);
+    })
+    .toContain('FAKE LLM REFERENCE TARGET');
+});
+```
+
+Matching fixture (`fixtures/reference-scenario.json`):
+
+```json
+{
+  "model": "fake-coder-reference",
+  "turns": [
+    {
+      "whenUserMessageMatches": "open the reference page",
+      "content": "Opening the reference data: URL so the test can assert on the CDP target.",
+      "tool_calls": [
+        {
+          "name": "bash",
+          "arguments": {
+            "command": "playwright-cli tab-new 'data:text/html,<!DOCTYPE html><title>FAKE LLM REFERENCE TARGET</title><h1>Agent landed here</h1>'"
+          }
+        }
+      ]
+    },
+    { "content": "Done. The agent navigated to the reference page." }
+  ],
+  "onOverflow": "error"
+}
+```
+
+### CDP Assertions
+
+`readCdpPageState` polls `http://127.0.0.1:9222/json` and returns the
+browser's CDP target list. Use it whenever you need to observe the
+agent-driven Chrome from the outside — it is runtime-agnostic and
+works against any Chrome with `--remote-debugging-port` set, including
+a cone-driven Chrome the test process never launched.
+
+Why `data:text/html,…` instead of a seeded `/preview/*` page: tabs
+opened via CDP `Target.createTarget` (which is what `playwright-cli
+tab-new` does) are not claimed by the `preview-vfs` service worker —
+the SW only controls clients that loaded the SLICC bootstrap. A `data:`
+URL carries its HTML inline, so the agent-driven tab gets a
+deterministic title without depending on SW interception. When a test
+needs to assert on Playwright-controlled DOM, navigate the existing
+`page` via `bash playwright-cli goto …` instead (and assert via
+`page.locator(...)` before the navigation breaks the test page).
+
+If a scenario needs a `/preview/*` page rendered for assertion,
+`seedVFS` continues to work for content the _test page_ itself loads
+— it just doesn't reach CDP-spawned tabs.
+
+### Running
+
+```bash
+npm run test:e2e
+```
+
+`playwright.config.ts` boots both `webServer` entries (the app on
+5780, the fake LLM on 5781) and the agent talks to the fake server
+via the seeded `local-llm` provider. Override the fixture with the
+`FAKE_LLM_FIXTURE` env var.
+
+### Risks Covered by the Reference Scenario
+
+- **localStorage → kernel-worker shim sync**: the test only passes if
+  the seeded `slicc_accounts` + `selected-model` make it from page
+  storage into the worker's `localStorage` shim — otherwise the agent
+  never resolves the `local-llm` model and never calls the fake server.
+- **`waitForTurnComplete` masking failures**: the popup + chat-transcript
+  assertions are positive — they only succeed when the scripted turn
+  actually ran end to end.
+- **CDP port alignment**: the helper, the `node-server --serve-only`
+  proxy, and the test's `launchOptions.args` all agree on 9222.

--- a/packages/node-server/CLAUDE.md
+++ b/packages/node-server/CLAUDE.md
@@ -25,6 +25,8 @@ npm run package:release
 
 `packages/node-server/src/runtime-flags.ts` is the source of truth for supported flags such as `--serve-only`, `--cdp-port`, `--electron`, `--profile`, `--lead`, `--join`, and `--prompt`.
 
+`--serve-only` now honors `--cdp-port` (previously parsed but silently dropped, so the CDP proxy always pointed at 9222); the fake-LLM E2E harness depends on this to keep the proxy, the helper's `readCdpPageState` probe, and Playwright Chrome's `--remote-debugging-port` agreed on the same port.
+
 ## `--prompt` for Automated Testing
 
 The `--prompt` flag auto-submits a prompt when the UI loads and is the quickest way to smoke-test common flows.

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -429,9 +429,13 @@ async function resolvePorts(state: ServerState): Promise<void> {
     state.servePort = await findAvailablePort(PREFERRED_SERVE_PORT);
     // Pass 0 for Chrome CDP so Chrome picks an available port (parsed from its
     // stderr) — avoids a race where Node's probe succeeds but Chrome can't bind.
-    // Electron keeps the preferred port (external CDP, not launched by us).
-    state.requestedCdpPort = ELECTRON_MODE ? PREFERRED_CDP_PORT : 0;
-    state.cdpPort = ELECTRON_MODE ? PREFERRED_CDP_PORT : 0;
+    // Electron / serve-only modes keep the preferred port: in both cases the
+    // CDP target is external (Electron app, or a user-launched Chrome / a
+    // Playwright-launched Chrome with --remote-debugging-port=<PREFERRED>),
+    // so the proxy needs the exact port up front.
+    const useExternalCdpPort = ELECTRON_MODE || SERVE_ONLY;
+    state.requestedCdpPort = useExternalCdpPort ? PREFERRED_CDP_PORT : 0;
+    state.cdpPort = useExternalCdpPort ? PREFERRED_CDP_PORT : 0;
   }
   state.serveOrigin = `http://localhost:${state.servePort}`;
 

--- a/packages/webapp/tests/e2e/fake-llm-helpers.ts
+++ b/packages/webapp/tests/e2e/fake-llm-helpers.ts
@@ -126,8 +126,14 @@ export interface WaitForTurnOptions {
   timeoutMs?: number;
   /** How long to wait for the processing flag to RISE before assuming
    *  the turn never started (e.g. the model returned synchronously
-   *  before observation). Defaults to 2000ms. */
+   *  before observation). Defaults to 8000ms. */
   riseTimeoutMs?: number;
+  /** When `true`, throw if `[data-processing]` never rises within
+   *  `riseTimeoutMs`. Default `false` preserves the original "treat as
+   *  already-finished" behaviour for fast fixtures. Set to `true` in
+   *  tests where you depend on the turn actually streaming — otherwise
+   *  a silent "turn never started" can pass as a false green. */
+  mustObserveTurnRise?: boolean;
 }
 
 /**
@@ -138,16 +144,19 @@ export interface WaitForTurnOptions {
  * waits for the attribute to rise, then to fall again — the same
  * signal `onTurnComplete` hangs off internally.
  *
- * If `[data-processing]` never rises within `riseTimeoutMs`, the
- * helper assumes the turn already finished (or never streamed) and
- * returns successfully — making it safe to call right after a fast
- * fake-fixture turn.
+ * Invariant: by default, if `[data-processing]` never rises within
+ * `riseTimeoutMs`, the helper assumes the turn already finished (or
+ * never streamed) and returns successfully — making it safe to call
+ * right after a fast fake-fixture turn. Callers that need the rise
+ * to be observed (so a "turn never started" failure cannot pass
+ * silently) MUST set `mustObserveTurnRise: true`, which makes the
+ * helper throw instead of returning when no rise is seen.
  */
 export async function waitForTurnComplete(
   page: Page,
   options: WaitForTurnOptions = {}
 ): Promise<void> {
-  const rise = options.riseTimeoutMs ?? 2_000;
+  const rise = options.riseTimeoutMs ?? 8_000;
   const fallTimeout = options.timeoutMs ?? 20_000;
 
   await page.waitForSelector('.wcui-frame');
@@ -160,7 +169,17 @@ export async function waitForTurnComplete(
     )
     .then(() => true)
     .catch(() => false);
-  if (!rose) return;
+  if (!rose) {
+    if (options.mustObserveTurnRise) {
+      throw new Error(
+        `waitForTurnComplete: [data-processing] never rose within ${rise}ms ` +
+          `(mustObserveTurnRise=true). The turn likely never started — ` +
+          `check that the user message was submitted and the fake LLM ` +
+          `picked the expected fixture turn.`
+      );
+    }
+    return;
+  }
 
   await page.waitForFunction(
     () => document.querySelector('.wcui-frame')?.hasAttribute('data-processing') === false,
@@ -223,9 +242,13 @@ export async function readCdpPageState(
   let raw: unknown;
   try {
     const res = await fetch(`${base.replace(/\/+$/, '')}/json`);
-    if (!res.ok) return [];
+    if (!res.ok) {
+      console.warn(`[readCdpPageState] CDP probe failed: HTTP ${res.status} from ${base}/json`);
+      return [];
+    }
     raw = await res.json();
-  } catch {
+  } catch (err) {
+    console.warn('[readCdpPageState] CDP probe failed:', err);
     return [];
   }
   if (!Array.isArray(raw)) return [];

--- a/packages/webapp/tests/e2e/fake-llm-helpers.ts
+++ b/packages/webapp/tests/e2e/fake-llm-helpers.ts
@@ -1,0 +1,249 @@
+// packages/webapp/tests/e2e/fake-llm-helpers.ts
+/**
+ * Playwright helpers for driving the WC shell against the fake LLM
+ * server (see `./fake-llm/server.ts`). Pairs with the second `webServer`
+ * entry in `./playwright.config.ts`.
+ *
+ * Provides:
+ *   - {@link seedLocalLlmProvider}    — `addInitScript` that seeds
+ *     `slicc_accounts` + `selected-model` in `localStorage` before boot,
+ *     pointing the `local-llm` provider at the fake server.
+ *   - {@link submitUserMessage}       — drives the `<slicc-input-card>`
+ *     submit path the host listens for.
+ *   - {@link waitForTurnComplete}     — waits for the WC shell's
+ *     `[data-processing]` rising-then-falling edge that marks a turn
+ *     boundary.
+ *   - {@link runUserInputFixture}     — sequences multiple
+ *     submit→waitForTurnComplete pairs.
+ *   - {@link readCdpPageState}        — enumerates page targets via
+ *     Chrome's HTTP CDP discovery, for asserting on tabs the agent
+ *     drove via the `open` shell command.
+ *
+ * The helpers do NOT depend on each other beyond the import surface
+ * here, so individual scenarios can pick and choose.
+ */
+
+import type { Page } from '@playwright/test';
+import { FAKE_LLM_PORT } from './playwright.config.js';
+
+/** Default base URL the fake LLM webServer listens on. */
+export const FAKE_LLM_BASE_URL = `http://127.0.0.1:${FAKE_LLM_PORT}/v1`;
+
+/** Provider id of the built-in OpenAI-compat local provider. */
+const LOCAL_LLM_PROVIDER_ID = 'local-llm';
+
+/** localStorage keys mirrored from `src/providers/account-store.ts`. */
+const ACCOUNTS_KEY = 'slicc_accounts';
+const MODEL_KEY = 'selected-model';
+
+export interface SeedLocalLlmOptions {
+  /** Defaults to {@link FAKE_LLM_BASE_URL}. Must end in `/v1`. */
+  baseUrl?: string;
+  /** Model id to register + select. Matches the fake fixture's `model`. */
+  modelId: string;
+  /** Optional placeholder key. Local servers ignore it; pi-ai requires
+   *  a non-empty string. Defaults to `'local'`. */
+  apiKey?: string;
+}
+
+/**
+ * Seed the `local-llm` account + selected-model pair into the page's
+ * localStorage BEFORE boot. The webapp's account store reads these on
+ * first paint, so the shell comes up with the fake server as the
+ * active provider — no Settings dialog round-trip required.
+ *
+ * Call BEFORE `page.goto('/')` so the init script is in place when the
+ * page document is created.
+ */
+export async function seedLocalLlmProvider(
+  page: Page,
+  options: SeedLocalLlmOptions
+): Promise<void> {
+  const baseUrl = options.baseUrl ?? FAKE_LLM_BASE_URL;
+  const apiKey = options.apiKey ?? 'local';
+  const { modelId } = options;
+  await page.addInitScript(
+    (seed: {
+      providerId: string;
+      apiKey: string;
+      baseUrl: string;
+      modelId: string;
+      accountsKey: string;
+      modelKey: string;
+    }) => {
+      try {
+        const entry = {
+          providerId: seed.providerId,
+          apiKey: seed.apiKey,
+          baseUrl: seed.baseUrl,
+          deployment: seed.modelId,
+        };
+        localStorage.setItem(seed.accountsKey, JSON.stringify([entry]));
+        localStorage.setItem(seed.modelKey, `${seed.providerId}:${seed.modelId}`);
+      } catch {
+        /* localStorage may be unavailable for opaque origins */
+      }
+    },
+    {
+      providerId: LOCAL_LLM_PROVIDER_ID,
+      apiKey,
+      baseUrl,
+      modelId,
+      accountsKey: ACCOUNTS_KEY,
+      modelKey: MODEL_KEY,
+    }
+  );
+}
+
+/**
+ * Submit a user message through the WC composer's public contract.
+ *
+ * Mirrors the real submit path: sets `<slicc-input-card>.value`, then
+ * calls its `submit()` method, which dispatches the composed `submit`
+ * CustomEvent the host listens for in `wc-live.ts`. The card's empty/
+ * disabled guard is preserved — empty `text` is a no-op.
+ *
+ * Throws if the input card isn't mounted yet; callers should
+ * `page.waitForSelector('slicc-input-card')` first.
+ */
+export async function submitUserMessage(page: Page, text: string): Promise<void> {
+  await page.waitForSelector('slicc-input-card');
+  await page.evaluate((value: string) => {
+    const card = document.querySelector('slicc-input-card') as
+      | (HTMLElement & { value?: string; submit?: () => void })
+      | null;
+    if (!card) throw new Error('slicc-input-card not found');
+    if (typeof card.submit !== 'function') {
+      throw new Error('slicc-input-card.submit() is unavailable');
+    }
+    card.value = value;
+    card.submit();
+  }, text);
+}
+
+export interface WaitForTurnOptions {
+  /** Total wait budget in ms. Defaults to the Playwright test timeout. */
+  timeoutMs?: number;
+  /** How long to wait for the processing flag to RISE before assuming
+   *  the turn never started (e.g. the model returned synchronously
+   *  before observation). Defaults to 2000ms. */
+  riseTimeoutMs?: number;
+}
+
+/**
+ * Wait for a turn-boundary edge on the WC shell.
+ *
+ * The shell sets `[data-processing]` on `.wcui-frame` while a turn is
+ * streaming (see `wc-live.ts`'s `onProcessingChange`). This helper
+ * waits for the attribute to rise, then to fall again — the same
+ * signal `onTurnComplete` hangs off internally.
+ *
+ * If `[data-processing]` never rises within `riseTimeoutMs`, the
+ * helper assumes the turn already finished (or never streamed) and
+ * returns successfully — making it safe to call right after a fast
+ * fake-fixture turn.
+ */
+export async function waitForTurnComplete(
+  page: Page,
+  options: WaitForTurnOptions = {}
+): Promise<void> {
+  const rise = options.riseTimeoutMs ?? 2_000;
+  const fallTimeout = options.timeoutMs ?? 20_000;
+
+  await page.waitForSelector('.wcui-frame');
+
+  const rose = await page
+    .waitForFunction(
+      () => document.querySelector('.wcui-frame')?.hasAttribute('data-processing') === true,
+      undefined,
+      { timeout: rise }
+    )
+    .then(() => true)
+    .catch(() => false);
+  if (!rose) return;
+
+  await page.waitForFunction(
+    () => document.querySelector('.wcui-frame')?.hasAttribute('data-processing') === false,
+    undefined,
+    { timeout: fallTimeout }
+  );
+}
+
+/**
+ * Drive an ordered list of user messages, awaiting turn completion
+ * between each. Identical in effect to interleaving manual calls; the
+ * helper exists so multi-turn fixtures stay declarative.
+ */
+export async function runUserInputFixture(
+  page: Page,
+  inputs: readonly string[],
+  options: WaitForTurnOptions = {}
+): Promise<void> {
+  for (const input of inputs) {
+    await submitUserMessage(page, input);
+    await waitForTurnComplete(page, options);
+  }
+}
+
+export interface CdpPageTarget {
+  /** Stable CDP target id (key it back to `Target.attachToTarget`). */
+  id: string;
+  /** Target type — typically `page` for browser tabs. */
+  type: string;
+  /** Current top-level URL. */
+  url: string;
+  /** Document `<title>` as Chrome reports it. */
+  title: string;
+  /** Chrome's frontend devtools URL for the target. */
+  devtoolsUrl?: string;
+}
+
+export interface ReadCdpPageStateOptions {
+  /** Chrome HTTP CDP discovery base URL, e.g. `http://127.0.0.1:9222`.
+   *  Defaults to the Chromium devtools default. */
+  cdpEndpoint?: string;
+  /** Optional predicate — only matching targets are returned. */
+  filter?: (target: CdpPageTarget) => boolean;
+}
+
+/**
+ * Enumerate Chrome page targets via the HTTP CDP discovery endpoint
+ * (`GET /json`). Used by scenario tests to assert on the URL/title of
+ * tabs the agent drove via the `open` shell command, without taking a
+ * dependency on Playwright's own browser context (the agent-driven
+ * Chrome is typically distinct from the Playwright-launched one).
+ *
+ * Returns `[]` (NOT throws) on connection failure so a scenario can
+ * poll without try/catch noise. The caller decides how long to wait.
+ */
+export async function readCdpPageState(
+  options: ReadCdpPageStateOptions = {}
+): Promise<CdpPageTarget[]> {
+  const base = options.cdpEndpoint ?? 'http://127.0.0.1:9222';
+  let raw: unknown;
+  try {
+    const res = await fetch(`${base.replace(/\/+$/, '')}/json`);
+    if (!res.ok) return [];
+    raw = await res.json();
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(raw)) return [];
+  const targets: CdpPageTarget[] = [];
+  for (const entry of raw as Array<Record<string, unknown>>) {
+    if (typeof entry?.['id'] !== 'string') continue;
+    const target: CdpPageTarget = {
+      id: entry['id'] as string,
+      type: typeof entry['type'] === 'string' ? (entry['type'] as string) : '',
+      url: typeof entry['url'] === 'string' ? (entry['url'] as string) : '',
+      title: typeof entry['title'] === 'string' ? (entry['title'] as string) : '',
+      devtoolsUrl:
+        typeof entry['devtoolsFrontendUrl'] === 'string'
+          ? (entry['devtoolsFrontendUrl'] as string)
+          : undefined,
+    };
+    if (options.filter && !options.filter(target)) continue;
+    targets.push(target);
+  }
+  return targets;
+}

--- a/packages/webapp/tests/e2e/fake-llm/fixtures/example.json
+++ b/packages/webapp/tests/e2e/fake-llm/fixtures/example.json
@@ -1,0 +1,19 @@
+{
+  "model": "fake-coder",
+  "models": ["fake-coder-mini"],
+  "turns": [
+    {
+      "content": "Hi! Let me check the file system.",
+      "tool_calls": [{ "name": "list_files", "arguments": { "path": "/workspace" } }]
+    },
+    {
+      "whenUserMessageMatches": "open",
+      "content": "Opening the requested URL.",
+      "tool_calls": [{ "name": "bash", "arguments": "{\"command\":\"open https://example.com\"}" }]
+    },
+    {
+      "content": "All done."
+    }
+  ],
+  "onOverflow": "error"
+}

--- a/packages/webapp/tests/e2e/fake-llm/fixtures/reference-scenario.json
+++ b/packages/webapp/tests/e2e/fake-llm/fixtures/reference-scenario.json
@@ -1,0 +1,21 @@
+{
+  "model": "fake-coder-reference",
+  "turns": [
+    {
+      "whenUserMessageMatches": "open the reference page",
+      "content": "Opening the reference data: URL so the test can assert on the CDP target.",
+      "tool_calls": [
+        {
+          "name": "bash",
+          "arguments": {
+            "command": "playwright-cli tab-new 'data:text/html,<!DOCTYPE html><title>FAKE LLM REFERENCE TARGET</title><h1>Agent landed here</h1>'"
+          }
+        }
+      ]
+    },
+    {
+      "content": "Done. The agent navigated to the reference page."
+    }
+  ],
+  "onOverflow": "error"
+}

--- a/packages/webapp/tests/e2e/fake-llm/fixtures/reference-scenario.json
+++ b/packages/webapp/tests/e2e/fake-llm/fixtures/reference-scenario.json
@@ -8,13 +8,40 @@
         {
           "name": "bash",
           "arguments": {
-            "command": "playwright-cli tab-new 'data:text/html,<!DOCTYPE html><title>FAKE LLM REFERENCE TARGET</title><h1>Agent landed here</h1>'"
+            "command": "playwright-cli tab-new 'data:text/html,<!DOCTYPE html><title>FAKE LLM REFERENCE TARGET</title><h1>Page A</h1>'"
           }
         }
       ]
     },
     {
-      "content": "Done. The agent navigated to the reference page."
+      "content": "Done. Page A is open."
+    },
+    {
+      "whenUserMessageMatches": "open the comparison pages",
+      "content": "Opening comparison pages B and C in parallel so the test can assert on multiple CDP targets.",
+      "contentChunkSize": 4,
+      "toolArgumentsChunkSize": 8,
+      "tool_calls": [
+        {
+          "name": "bash",
+          "arguments": {
+            "command": "playwright-cli tab-new 'data:text/html,<!DOCTYPE html><title>FAKE LLM COMPARE ALPHA</title><h1>Page B</h1>'"
+          }
+        },
+        {
+          "name": "bash",
+          "arguments": {
+            "command": "playwright-cli tab-new 'data:text/html,<!DOCTYPE html><title>FAKE LLM COMPARE BETA</title><h1>Page C</h1>'"
+          }
+        }
+      ]
+    },
+    {
+      "content": "Done. Pages B and C are open."
+    },
+    {
+      "whenUserMessageMatches": { "pattern": "summar(y|ize)", "flags": "i" },
+      "content": "Summary: opened three CDP targets - Page A (FAKE LLM REFERENCE TARGET), Page B (FAKE LLM COMPARE ALPHA), and Page C (FAKE LLM COMPARE BETA)."
     }
   ],
   "onOverflow": "error"

--- a/packages/webapp/tests/e2e/fake-llm/index.ts
+++ b/packages/webapp/tests/e2e/fake-llm/index.ts
@@ -1,0 +1,7 @@
+export { type FakeLlmServer, type StartOptions, startFakeLlmServer } from './server.js';
+export type {
+  AssistantTurn,
+  Fixture,
+  ToolCallFixture,
+  UserMessageMatcher,
+} from './types.js';

--- a/packages/webapp/tests/e2e/fake-llm/server.ts
+++ b/packages/webapp/tests/e2e/fake-llm/server.ts
@@ -69,6 +69,14 @@ export async function startFakeLlmServer(opts: StartOptions): Promise<FakeLlmSer
 
   const server = createServer((req, res) => {
     handleRequest(req, res).catch((err) => {
+      // If the response already started (e.g. an SSE stream that errored
+      // mid-write), the headers/body are out the door — overwriting with
+      // a 500 JSON would throw `ERR_HTTP_HEADERS_SENT`. Tear the socket
+      // down so the client sees a clean disconnect.
+      if (res.headersSent) {
+        res.destroy(err);
+        return;
+      }
       writeJson(res, 500, {
         error: { message: String(err?.message ?? err), type: 'server_error' },
       });
@@ -81,6 +89,15 @@ export async function startFakeLlmServer(opts: StartOptions): Promise<FakeLlmSer
     const method = (req.method ?? 'GET').toUpperCase();
     const url = req.url ?? '/';
     if (method === 'OPTIONS') {
+      // Echo the client's requested headers when present so direct
+      // browser/extension callers (e.g. pi-ai's X-Stainless-* set) pass
+      // the preflight without us having to enumerate every header up
+      // front. Header lookup is case-insensitive via node's lowercased
+      // `req.headers` map.
+      const requested = req.headers['access-control-request-headers'];
+      if (typeof requested === 'string' && requested.length > 0) {
+        res.setHeader('Access-Control-Allow-Headers', requested);
+      }
       res.statusCode = 204;
       res.end();
       return;

--- a/packages/webapp/tests/e2e/fake-llm/server.ts
+++ b/packages/webapp/tests/e2e/fake-llm/server.ts
@@ -1,0 +1,346 @@
+/**
+ * Deterministic fake OpenAI-compatible LLM server for E2E tests.
+ *
+ * Speaks the OpenAI Chat Completions wire format consumed by pi-ai's
+ * `streamOpenAICompletions` (and any other OpenAI-compat client). Streams
+ * scripted turns from a {@link Fixture}, with permissive CORS so a
+ * browser/extension can call it directly. See `./types.ts` for the
+ * fixture schema and matching rules.
+ *
+ * Endpoints:
+ *   - `POST /v1/chat/completions` — SSE stream of OpenAI-shaped
+ *     `chat.completion.chunk` events terminated by `data: [DONE]`. When
+ *     the request body has `stream: false` the same content is returned
+ *     as a single `chat.completion` JSON.
+ *   - `GET  /v1/models` — `{ data: [{ id, object, owned_by, ... }] }`.
+ *   - `OPTIONS *` — CORS preflight; every response also carries
+ *     `Access-Control-Allow-Origin: *`.
+ *
+ * The server is stateful per process (advances a turn cursor) but
+ * {@link FakeLlmServer.reset} and {@link FakeLlmServer.setFixture} make
+ * a test run reproducible.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { AssistantTurn, Fixture, UserMessageMatcher } from './types.js';
+
+export type { AssistantTurn, Fixture, ToolCallFixture, UserMessageMatcher } from './types.js';
+
+export interface FakeLlmServer {
+  /** e.g. `http://127.0.0.1:54321` (no trailing slash). */
+  readonly url: string;
+  /** Base URL ready for the `local-llm` provider, i.e. `${url}/v1`. */
+  readonly baseUrl: string;
+  readonly port: number;
+  close(): Promise<void>;
+  /** Reset the turn cursor and request counter; fixture is preserved. */
+  reset(): void;
+  setFixture(fixture: Fixture): void;
+  getState(): { cursor: number; requestCount: number };
+}
+
+export interface StartOptions {
+  fixture: Fixture;
+  /** Default `0` (random free port). */
+  port?: number;
+  /** Default `'127.0.0.1'`. */
+  host?: string;
+}
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Session-Id',
+  'Access-Control-Max-Age': '86400',
+};
+
+interface ChatRequest {
+  model?: string;
+  messages?: Array<{ role: string; content?: unknown }>;
+  stream?: boolean;
+}
+
+export async function startFakeLlmServer(opts: StartOptions): Promise<FakeLlmServer> {
+  let fixture = validateFixture(opts.fixture);
+  let cursor = 0;
+  let requestCount = 0;
+  let lastUsedTurnIndex = -1;
+
+  const server = createServer((req, res) => {
+    handleRequest(req, res).catch((err) => {
+      writeJson(res, 500, {
+        error: { message: String(err?.message ?? err), type: 'server_error' },
+      });
+    });
+  });
+
+  async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    for (const [k, v] of Object.entries(CORS_HEADERS)) res.setHeader(k, v);
+
+    const method = (req.method ?? 'GET').toUpperCase();
+    const url = req.url ?? '/';
+    if (method === 'OPTIONS') {
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
+    if (method === 'GET' && (url === '/v1/models' || url.startsWith('/v1/models?'))) {
+      writeJson(res, 200, { object: 'list', data: modelsList(fixture) });
+      return;
+    }
+    if (
+      method === 'POST' &&
+      (url === '/v1/chat/completions' || url.startsWith('/v1/chat/completions?'))
+    ) {
+      requestCount += 1;
+      const body = await readJsonBody(req);
+      const stream = body?.stream !== false;
+      const latestUserMessage = extractLatestUserMessage(body);
+      const picked = pickTurn(fixture, cursor, latestUserMessage);
+      if (!picked) {
+        writeJson(res, 400, {
+          error: {
+            message: `fake-llm: no eligible turn for request #${requestCount} (cursor=${cursor}, fixture has ${fixture.turns.length} turns). Latest user message: ${JSON.stringify(latestUserMessage)}`,
+            type: 'fixture_overflow',
+            code: 'fixture_overflow',
+          },
+        });
+        return;
+      }
+      cursor = picked.nextCursor;
+      lastUsedTurnIndex = picked.index;
+      if (stream) await writeSseStream(res, fixture.model, picked.turn);
+      else writeJson(res, 200, buildNonStreamResponse(fixture.model, picked.turn));
+      return;
+    }
+    writeJson(res, 404, { error: { message: `Not found: ${method} ${url}`, type: 'not_found' } });
+  }
+
+  function pickTurn(fx: Fixture, fromCursor: number, userMessage: string | null) {
+    const turns = fx.turns;
+    if (turns.length === 0) return overflowFallback(fx);
+    const at = turns[fromCursor];
+    if (at && (!at.whenUserMessageMatches || matches(at.whenUserMessageMatches, userMessage))) {
+      return { turn: at, index: fromCursor, nextCursor: fromCursor + 1 };
+    }
+    for (let i = fromCursor + 1; i < turns.length; i++) {
+      const t = turns[i];
+      if (t?.whenUserMessageMatches && matches(t.whenUserMessageMatches, userMessage)) {
+        return { turn: t, index: i, nextCursor: i + 1 };
+      }
+    }
+    return overflowFallback(fx);
+  }
+
+  function overflowFallback(fx: Fixture) {
+    if (fx.onOverflow === 'repeat-last' && lastUsedTurnIndex >= 0) {
+      const t = fx.turns[lastUsedTurnIndex];
+      if (t) return { turn: t, index: lastUsedTurnIndex, nextCursor: cursor };
+    }
+    return null;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(opts.port ?? 0, opts.host ?? '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const addr = server.address() as AddressInfo;
+  const url = `http://${opts.host ?? '127.0.0.1'}:${addr.port}`;
+
+  return {
+    url,
+    baseUrl: `${url}/v1`,
+    port: addr.port,
+    close: () => closeServer(server),
+    reset: () => {
+      cursor = 0;
+      requestCount = 0;
+      lastUsedTurnIndex = -1;
+    },
+    setFixture: (next) => {
+      fixture = validateFixture(next);
+      cursor = 0;
+      requestCount = 0;
+      lastUsedTurnIndex = -1;
+    },
+    getState: () => ({ cursor, requestCount }),
+  };
+}
+
+function validateFixture(fx: Fixture): Fixture {
+  if (!fx || typeof fx !== 'object') throw new Error('fake-llm: fixture must be an object');
+  if (typeof fx.model !== 'string' || !fx.model)
+    throw new Error('fake-llm: fixture.model required');
+  if (!Array.isArray(fx.turns)) throw new Error('fake-llm: fixture.turns must be an array');
+  return fx;
+}
+
+function modelsList(fx: Fixture) {
+  const uniqueIds = Array.from(new Set([fx.model, ...(fx.models ?? [])]));
+  const now = Math.floor(Date.now() / 1000);
+  return uniqueIds.map((id) => ({ id, object: 'model', created: now, owned_by: 'fake-llm' }));
+}
+
+function matches(m: UserMessageMatcher, msg: string | null): boolean {
+  if (msg == null) return false;
+  if (typeof m === 'string') return msg.includes(m);
+  if (m instanceof RegExp) return m.test(msg);
+  if (typeof m === 'object' && typeof m.pattern === 'string') {
+    return new RegExp(m.pattern, m.flags ?? '').test(msg);
+  }
+  return false;
+}
+
+function extractLatestUserMessage(body: ChatRequest | null): string | null {
+  const messages = body?.messages;
+  if (!Array.isArray(messages)) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m?.role !== 'user') continue;
+    return flattenContent(m.content);
+  }
+  return null;
+}
+
+function flattenContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((p: unknown) => {
+        if (typeof p === 'string') return p;
+        if (p && typeof p === 'object') {
+          const part = p as { type?: string; text?: string };
+          if (part.type === 'text' && typeof part.text === 'string') return part.text;
+        }
+        return '';
+      })
+      .join('');
+  }
+  return '';
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<ChatRequest | null> {
+  const chunks: Buffer[] = [];
+  for await (const c of req) chunks.push(c as Buffer);
+  if (chunks.length === 0) return null;
+  const raw = Buffer.concat(chunks).toString('utf8');
+  try {
+    return JSON.parse(raw) as ChatRequest;
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+    server.closeAllConnections?.();
+  });
+}
+
+// ── SSE writers ────────────────────────────────────────────────────
+
+function writeSseStream(res: ServerResponse, model: string, turn: AssistantTurn): Promise<void> {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+
+  const id = `chatcmpl-fake-${Math.random().toString(36).slice(2, 12)}`;
+  const created = Math.floor(Date.now() / 1000);
+  const send = (delta: Record<string, unknown>, finish: string | null) => {
+    const chunk = {
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model,
+      choices: [{ index: 0, delta, finish_reason: finish }],
+    };
+    res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  };
+
+  send({ role: 'assistant' }, null);
+
+  for (const piece of chunkContent(turn.content ?? '', turn.contentChunkSize ?? 16)) {
+    send({ content: piece }, null);
+  }
+
+  const toolCalls = turn.tool_calls ?? [];
+  for (let i = 0; i < toolCalls.length; i++) {
+    const tc = toolCalls[i];
+    if (!tc) continue;
+    const argString =
+      typeof tc.arguments === 'string' ? tc.arguments : JSON.stringify(tc.arguments);
+    send(
+      {
+        tool_calls: [
+          {
+            index: i,
+            id: tc.id ?? `call_fake_${i}_${Math.random().toString(36).slice(2, 8)}`,
+            type: 'function',
+            function: { name: tc.name, arguments: '' },
+          },
+        ],
+      },
+      null
+    );
+    for (const frag of chunkContent(argString, turn.toolArgumentsChunkSize ?? 24)) {
+      send({ tool_calls: [{ index: i, function: { arguments: frag } }] }, null);
+    }
+  }
+
+  const finish = turn.finish_reason ?? (toolCalls.length > 0 ? 'tool_calls' : 'stop');
+  send({}, finish);
+  res.write('data: [DONE]\n\n');
+  res.end();
+  return Promise.resolve();
+}
+
+function chunkContent(text: string, size: number): string[] {
+  if (!text) return [];
+  const step = Math.max(1, Math.floor(size));
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i += step) out.push(text.slice(i, i + step));
+  return out;
+}
+
+function buildNonStreamResponse(model: string, turn: AssistantTurn): unknown {
+  const toolCalls = (turn.tool_calls ?? []).map((tc, i) => ({
+    id: tc.id ?? `call_fake_${i}`,
+    type: 'function',
+    function: {
+      name: tc.name,
+      arguments: typeof tc.arguments === 'string' ? tc.arguments : JSON.stringify(tc.arguments),
+    },
+  }));
+  const finish = turn.finish_reason ?? (toolCalls.length > 0 ? 'tool_calls' : 'stop');
+  return {
+    id: `chatcmpl-fake-${Math.random().toString(36).slice(2, 12)}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: turn.content ?? null,
+          ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+        },
+        finish_reason: finish,
+      },
+    ],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  };
+}

--- a/packages/webapp/tests/e2e/fake-llm/start.ts
+++ b/packages/webapp/tests/e2e/fake-llm/start.ts
@@ -1,0 +1,89 @@
+/**
+ * Runnable entry for the fake LLM server. Suitable for use as a
+ * Playwright `webServer.command` entry:
+ *
+ *   webServer: {
+ *     command: 'tsx packages/webapp/tests/e2e/fake-llm/start.ts',
+ *     port: 5781,
+ *     env: { FAKE_LLM_FIXTURE: 'packages/webapp/tests/e2e/fake-llm/fixtures/...' },
+ *   }
+ *
+ * CLI:
+ *   tsx start.ts [--fixture <path>] [--port <n>] [--host <ip>]
+ *
+ * Env (CLI args win when both are set):
+ *   FAKE_LLM_FIXTURE  path to a JSON fixture file
+ *   FAKE_LLM_PORT     numeric port (default 5781)
+ *   FAKE_LLM_HOST     bind address (default 127.0.0.1)
+ *
+ * Wiring this into the Playwright config is intentionally out of scope
+ * for this task — that's the next task in the spec.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
+import { startFakeLlmServer } from './server.js';
+import type { Fixture } from './types.js';
+
+interface CliArgs {
+  fixture?: string;
+  port?: number;
+  host?: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--fixture' && argv[i + 1]) {
+      out.fixture = argv[++i];
+    } else if (arg === '--port' && argv[i + 1]) {
+      out.port = Number(argv[++i]);
+    } else if (arg === '--host' && argv[i + 1]) {
+      out.host = argv[++i];
+    } else if (arg?.startsWith('--fixture=')) {
+      out.fixture = arg.slice('--fixture='.length);
+    } else if (arg?.startsWith('--port=')) {
+      out.port = Number(arg.slice('--port='.length));
+    } else if (arg?.startsWith('--host=')) {
+      out.host = arg.slice('--host='.length);
+    }
+  }
+  return out;
+}
+
+function loadFixture(path: string): Fixture {
+  const abs = resolvePath(process.cwd(), path);
+  const raw = readFileSync(abs, 'utf8');
+  return JSON.parse(raw) as Fixture;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const fixturePath = args.fixture ?? process.env['FAKE_LLM_FIXTURE'];
+  if (!fixturePath) {
+    process.stderr.write(
+      'fake-llm: no fixture supplied. Pass --fixture <path> or set FAKE_LLM_FIXTURE.\n'
+    );
+    process.exit(2);
+  }
+  const port = args.port ?? Number(process.env['FAKE_LLM_PORT'] ?? 5781);
+  const host = args.host ?? process.env['FAKE_LLM_HOST'] ?? '127.0.0.1';
+
+  const fixture = loadFixture(fixturePath);
+  const server = await startFakeLlmServer({ fixture, port, host });
+  process.stdout.write(`fake-llm: listening on ${server.url} (model=${fixture.model})\n`);
+
+  const shutdown = async (signal: string) => {
+    process.stdout.write(`fake-llm: ${signal} received, shutting down\n`);
+    await server.close();
+    process.exit(0);
+  };
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+}
+
+void main().catch((err) => {
+  process.stderr.write(`fake-llm: fatal: ${String(err?.stack ?? err)}\n`);
+  process.exit(1);
+});

--- a/packages/webapp/tests/e2e/fake-llm/types.ts
+++ b/packages/webapp/tests/e2e/fake-llm/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Fixture schema for the deterministic fake OpenAI-compatible LLM server
+ * (see `./server.ts`).
+ *
+ * A fixture is an ordered list of scripted assistant `turns`. For each
+ * `POST /v1/chat/completions` call the server picks a turn using:
+ *
+ *   1. If `turns[cursor]` has no matcher, OR its matcher matches the
+ *      latest user message, that turn is used and the cursor advances
+ *      past it.
+ *   2. Otherwise the server scans forward from `cursor+1` for the first
+ *      turn whose matcher matches; if found, that turn is used and the
+ *      cursor advances past it (skipped, non-matching turns become
+ *      unreachable).
+ *   3. If nothing matches, behavior is governed by `onOverflow`
+ *      (default `error` — the server returns a 400 with a clear
+ *      diagnostic, never a hang).
+ *
+ * The matching algorithm makes plain cursor-order fixtures work without
+ * any matcher boilerplate, while still allowing per-turn selection
+ * (`whenUserMessageMatches`) when a single fixture needs to react to
+ * different inputs.
+ */
+
+/** A scripted tool call. `arguments` accepts either an already-serialized
+ *  JSON string (passed through unchanged) or an object (JSON.stringified
+ *  by the server). `id` is auto-generated when omitted. */
+export interface ToolCallFixture {
+  id?: string;
+  name: string;
+  arguments: string | Record<string, unknown>;
+}
+
+/** Selector for {@link AssistantTurn.whenUserMessageMatches}. Strings are
+ *  treated as case-sensitive substring matches; regex literals are used
+ *  directly; the object form lets JSON fixtures express regex matchers. */
+export type UserMessageMatcher = string | RegExp | { pattern: string; flags?: string };
+
+/** A single scripted assistant turn. At least one of `content` or
+ *  `tool_calls` should be present; both is also valid (mirrors real
+ *  OpenAI behavior where an assistant turn may emit prose AND tool
+ *  calls before a `finish_reason: 'tool_calls'`). */
+export interface AssistantTurn {
+  content?: string;
+  tool_calls?: ToolCallFixture[];
+  /** Defaults to `'tool_calls'` if `tool_calls` is non-empty, else `'stop'`. */
+  finish_reason?: 'stop' | 'length' | 'tool_calls' | 'content_filter' | (string & {});
+  /** Optional gate — turn is only eligible when the latest user message
+   *  matches. Omit for purely cursor-ordered fixtures. */
+  whenUserMessageMatches?: UserMessageMatcher;
+  /** Streaming character chunk size for `content`. Defaults to 16. */
+  contentChunkSize?: number;
+  /** Streaming character chunk size for each tool-call's `arguments`
+   *  string. Defaults to 24. The leading chunk always carries the
+   *  id/name with empty arguments to mirror real OpenAI streaming. */
+  toolArgumentsChunkSize?: number;
+}
+
+export interface Fixture {
+  /** Primary model id. Echoed in every SSE chunk and returned first
+   *  from `GET /v1/models`. */
+  model: string;
+  /** Optional extra model ids advertised by `GET /v1/models` (for
+   *  multi-model fixtures or `local-llm discover` testing). */
+  models?: string[];
+  turns: AssistantTurn[];
+  /** Behavior when no turn is eligible for the current request.
+   *  `error` (default): respond 400 with a JSON diagnostic.
+   *  `repeat-last`: replay the most recently used turn. */
+  onOverflow?: 'error' | 'repeat-last';
+}

--- a/packages/webapp/tests/e2e/playwright.config.ts
+++ b/packages/webapp/tests/e2e/playwright.config.ts
@@ -34,7 +34,10 @@ export default defineConfig({
     {
       command: `npx tsx ${resolve(repoRoot, 'packages/webapp/tests/e2e/fake-llm/start.ts')}`,
       port: FAKE_LLM_PORT,
-      reuseExistingServer: !process.env['CI'],
+      // Always boot a fresh fake server so the turn cursor + fixture are
+      // pristine each run; reusing a previous run's process would leak
+      // stale cursor state across scenarios.
+      reuseExistingServer: false,
       env: {
         FAKE_LLM_PORT: String(FAKE_LLM_PORT),
         FAKE_LLM_HOST: '127.0.0.1',
@@ -45,6 +48,12 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:5780',
   },
+  // Single-worker by construction: the node-server CDP proxy points at one
+  // Chrome on port 9222, and every CDP-binding scenario (reference-scenario,
+  // preview-serve) launches Playwright Chrome with `--remote-debugging-port=9222`.
+  // Running them in parallel would collide on the port and on the proxy's
+  // outbound target.
+  workers: 1,
   fullyParallel: true,
   timeout: 30_000,
   retries: 0,

--- a/packages/webapp/tests/e2e/playwright.config.ts
+++ b/packages/webapp/tests/e2e/playwright.config.ts
@@ -5,14 +5,43 @@ import { fileURLToPath } from 'url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
 
+/** Fixed port for the fake OpenAI-compatible LLM webServer.
+ *  Pinned so `seedLocalLlmProvider` can derive a stable baseUrl
+ *  without a global setup step. */
+export const FAKE_LLM_PORT = 5781;
+
+/** Default fixture the harness loads when nothing else is wired. Points
+ *  at the reference scenario consumed by `reference-scenario.test.ts`;
+ *  override via `FAKE_LLM_FIXTURE` when a test needs different turns. */
+const DEFAULT_FAKE_LLM_FIXTURE = resolve(
+  repoRoot,
+  'packages/webapp/tests/e2e/fake-llm/fixtures/reference-scenario.json'
+);
+
 export default defineConfig({
   testDir: '.',
-  webServer: {
-    command: `node ${resolve(repoRoot, 'dist/node-server/index.js')} --serve-only`,
-    port: 5780,
-    reuseExistingServer: !process.env['CI'],
-    env: { PORT: '5780' },
-  },
+  webServer: [
+    {
+      // `--cdp-port=9222` pins the proxy's outbound CDP target so the
+      // agent's `playwright-cli` and the harness's `readCdpPageState`
+      // both speak to the same Chrome — see `reference-scenario.test.ts`,
+      // which launches Playwright Chrome with `--remote-debugging-port=9222`.
+      command: `node ${resolve(repoRoot, 'dist/node-server/index.js')} --serve-only --cdp-port=9222`,
+      port: 5780,
+      reuseExistingServer: !process.env['CI'],
+      env: { PORT: '5780' },
+    },
+    {
+      command: `npx tsx ${resolve(repoRoot, 'packages/webapp/tests/e2e/fake-llm/start.ts')}`,
+      port: FAKE_LLM_PORT,
+      reuseExistingServer: !process.env['CI'],
+      env: {
+        FAKE_LLM_PORT: String(FAKE_LLM_PORT),
+        FAKE_LLM_HOST: '127.0.0.1',
+        FAKE_LLM_FIXTURE: process.env['FAKE_LLM_FIXTURE'] ?? DEFAULT_FAKE_LLM_FIXTURE,
+      },
+    },
+  ],
   use: {
     baseURL: 'http://localhost:5780',
   },

--- a/packages/webapp/tests/e2e/reference-scenario.test.ts
+++ b/packages/webapp/tests/e2e/reference-scenario.test.ts
@@ -70,11 +70,12 @@ const PHASE2_TITLES_SORTED = [PAGE_B_TITLE, PAGE_C_TITLE].slice().sort();
 //     connects to a real Chrome
 //   - the agent's `playwright-cli tab-new` opens a CDP-driven tab there
 //   - {@link readCdpPageState} sees the same target at its default port
-// Sequential mode keeps the port singular within this file.
+// Project-level `workers: 1` in `playwright.config.ts` already
+// serializes every CDP-binding scenario (preview-serve.test.ts also
+// claims 9222), so no per-file `mode: 'serial'` is needed here.
 test.use({
   launchOptions: { args: ['--remote-debugging-port=9222'] },
 });
-test.describe.configure({ mode: 'serial' });
 
 test.describe('fake-llm reference scenario', () => {
   test('multi-phase scripted tool calls drive multiple CDP navigations', async ({ page }) => {

--- a/packages/webapp/tests/e2e/reference-scenario.test.ts
+++ b/packages/webapp/tests/e2e/reference-scenario.test.ts
@@ -6,44 +6,64 @@
  *
  *   1. `localStorage` → kernel-worker shim sync — proven by seeding
  *      the `local-llm` provider via {@link seedLocalLlmProvider} BEFORE
- *      `page.goto('/')` and then submitting a user message that only
- *      reaches the fake server if the worker's shim picked the seed
- *      up. The chat-transcript assertion below is positive — it only
- *      fires when the agent's scripted turn actually streamed back
+ *      `page.goto('/')` and then submitting user messages that only
+ *      reach the fake server if the worker's shim picked the seed up.
+ *      Per-phase chat-transcript assertions are positive — they only
+ *      fire when the agent's scripted turns actually streamed back
  *      from the fake server and ran.
  *
  *   2. `waitForTurnComplete` masking failures — guarded by the
- *      chat-transcript + CDP-state assertions: both depend on the
- *      scripted turn actually completing, so a silent "turn never
- *      started" failure mode surfaces as a timeout, not a false green.
+ *      chat-transcript + CDP-state assertions interleaved between
+ *      phases: each depends on the prior scripted turn actually
+ *      completing, so a silent "turn never started" failure mode
+ *      surfaces as a timeout, not a false green.
  *
  *   3. CDP port matches the harness default — Playwright launches
  *      Chrome with `--remote-debugging-port=9222` for this file,
  *      `node-server --serve-only --cdp-port=9222` (from
  *      `playwright.config.ts`) proxies to the same port, and
- *      {@link readCdpPageState} probes it by default. The final
- *      assertion calls the helper without a `cdpEndpoint` override;
- *      it returning the scripted target proves the wiring end to end.
+ *      {@link readCdpPageState} probes it by default. The per-phase
+ *      assertions call the helper without a `cdpEndpoint` override.
+ *
+ * The elaborated 3-phase shape additionally exercises the fake-LLM
+ * harness's multi-turn sequencing (cursor + matcher ordering, see
+ * `./fake-llm/types.ts`), a single turn emitting two `bash` tool
+ * calls under small content + tool-arg chunk sizes (SSE delta
+ * reassembly), the object-form regex matcher
+ * (`{ pattern, flags }`), and multi-target CDP enumeration at 9222.
  */
 
 import { expect, test } from '@playwright/test';
 import {
   FAKE_LLM_BASE_URL,
   readCdpPageState,
-  runUserInputFixture,
   seedLocalLlmProvider,
+  submitUserMessage,
+  waitForTurnComplete,
 } from './fake-llm-helpers.js';
 import { seedSkipSwReload, waitForSW } from './helpers.js';
 
 const REFERENCE_MODEL = 'fake-coder-reference';
-const TARGET_TITLE = 'FAKE LLM REFERENCE TARGET';
-// `data:` URL keeps the CDP-driven tab self-contained: no service-worker
-// claim, no VFS seed dance. The URL itself carries the deterministic
-// HTML, so the agent's `playwright-cli tab-new …` is enough to make
-// Chrome report a target whose URL and title both come straight from
-// the scripted bash command — exactly the read-back signal we want.
-const TARGET_HTML = `<!DOCTYPE html><title>${TARGET_TITLE}</title><h1>Agent landed here</h1>`;
-const TARGET_DATA_URL = `data:text/html,${TARGET_HTML}`;
+
+// Distinct titles so multi-tab CDP filters at 9222 are unambiguous.
+const PAGE_A_TITLE = 'FAKE LLM REFERENCE TARGET';
+const PAGE_B_TITLE = 'FAKE LLM COMPARE ALPHA';
+const PAGE_C_TITLE = 'FAKE LLM COMPARE BETA';
+
+// `data:` URLs keep the CDP-driven tabs self-contained: no service-worker
+// claim, no VFS seed dance. Each URL carries its deterministic HTML, so
+// the agent's `playwright-cli tab-new …` is enough to make Chrome
+// report a target whose URL and title both come straight from the
+// scripted bash command — exactly the read-back signal we want.
+const PAGE_A_HTML = `<!DOCTYPE html><title>${PAGE_A_TITLE}</title><h1>Page A</h1>`;
+const PAGE_B_HTML = `<!DOCTYPE html><title>${PAGE_B_TITLE}</title><h1>Page B</h1>`;
+const PAGE_C_HTML = `<!DOCTYPE html><title>${PAGE_C_TITLE}</title><h1>Page C</h1>`;
+const PAGE_A_URL = `data:text/html,${PAGE_A_HTML}`;
+const PAGE_B_URL = `data:text/html,${PAGE_B_HTML}`;
+const PAGE_C_URL = `data:text/html,${PAGE_C_HTML}`;
+
+const ALL_TITLES_SORTED = [PAGE_A_TITLE, PAGE_B_TITLE, PAGE_C_TITLE].slice().sort();
+const PHASE2_TITLES_SORTED = [PAGE_B_TITLE, PAGE_C_TITLE].slice().sort();
 
 // Bind 9222 on the Playwright-launched Chrome so:
 //   - the `node-server --serve-only` CDP proxy (`--cdp-port=9222`)
@@ -57,7 +77,7 @@ test.use({
 test.describe.configure({ mode: 'serial' });
 
 test.describe('fake-llm reference scenario', () => {
-  test('scripted tool call drives a real CDP navigation', async ({ page }) => {
+  test('multi-phase scripted tool calls drive multiple CDP navigations', async ({ page }) => {
     // Sanity: fake server is the one the harness expects.
     expect(FAKE_LLM_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/v1$/);
 
@@ -78,43 +98,82 @@ test.describe('fake-llm reference scenario', () => {
     await expect(page.locator('slicc-chat-thread')).toContainText('Welcome to SLICC', {
       timeout: 20_000,
     });
-    await runUserInputFixture(page, ['open the reference page']);
 
-    // ── (a) chat-transcript assertion: scripted assistant text rendered ──
-    // Canonical positive proof that the fake LLM streamed back AND the
-    // agent loop processed the turn — both required for the
-    // localStorage → kernel-worker shim sync to be exercised.
+    // ── Phase 1: single tool call → Page A ───────────────────────────
+    // Fixture turn[0] (matched) + turn[1] (cursor follow-up) deliver
+    // the scripted text and a `playwright-cli tab-new` for Page A.
+    await submitUserMessage(page, 'open the reference page');
+    await waitForTurnComplete(page);
+
     await expect(page.locator('slicc-chat-thread')).toContainText(
       'Opening the reference data: URL'
     );
-    await expect(page.locator('slicc-chat-thread')).toContainText(
-      'Done. The agent navigated to the reference page'
-    );
+    await expect(page.locator('slicc-chat-thread')).toContainText('Done. Page A is open.');
 
-    // ── (b) CDP/browser-state assertion via the harness helper ──────
-    // After the scripted `bash playwright-cli tab-new …` ran, Chrome at
-    // 9222 should report a `page` target whose URL is the data: URL
-    // the agent navigated to AND whose title matches the embedded HTML.
-    // Polls because the target registers a beat after the CDP
-    // `Target.createTarget` resolves on the agent side.
     await expect
       .poll(
         async () => {
           const targets = await readCdpPageState({
-            filter: (t) => t.type === 'page' && t.url.startsWith('data:text/html'),
+            filter: (t) => t.type === 'page' && t.url === PAGE_A_URL,
+          });
+          return { count: targets.length, titles: targets.map((t) => t.title) };
+        },
+        { timeout: 15_000 }
+      )
+      .toMatchObject({ count: 1, titles: [PAGE_A_TITLE] });
+
+    // ── Phase 2: two tool calls in one turn → Pages B + C ────────────
+    // Fixture turn[2] (matched, small `contentChunkSize` +
+    // `toolArgumentsChunkSize`) emits two `bash` tool calls back to
+    // back; the agent runs both, then turn[3] (cursor) closes the
+    // phase.
+    await submitUserMessage(page, 'open the comparison pages');
+    await waitForTurnComplete(page);
+
+    await expect(page.locator('slicc-chat-thread')).toContainText('Done. Pages B and C are open.');
+
+    await expect
+      .poll(
+        async () => {
+          const targets = await readCdpPageState({
+            filter: (t) => t.type === 'page' && (t.url === PAGE_B_URL || t.url === PAGE_C_URL),
           });
           return {
             count: targets.length,
-            titles: targets.map((t) => t.title),
-            urls: targets.map((t) => t.url),
+            titles: targets.map((t) => t.title).sort(),
           };
         },
         { timeout: 15_000 }
       )
-      .toMatchObject({
-        count: 1,
-        titles: [TARGET_TITLE],
-        urls: [TARGET_DATA_URL],
-      });
+      .toMatchObject({ count: 2, titles: PHASE2_TITLES_SORTED });
+
+    // ── Phase 3: regex-matcher → text-only summary turn ──────────────
+    // Fixture turn[4] uses the object-form regex matcher
+    // (`{ pattern: 'summar(y|ize)', flags: 'i' }`) and returns text
+    // only (no tool call) — proves both the regex path and a
+    // text-only terminal turn.
+    await submitUserMessage(page, 'give me a summary');
+    await waitForTurnComplete(page);
+
+    await expect(page.locator('slicc-chat-thread')).toContainText(
+      'Summary: opened three CDP targets'
+    );
+
+    await expect
+      .poll(
+        async () => {
+          const targets = await readCdpPageState({
+            filter: (t) =>
+              t.type === 'page' &&
+              (t.url === PAGE_A_URL || t.url === PAGE_B_URL || t.url === PAGE_C_URL),
+          });
+          return {
+            count: targets.length,
+            titles: targets.map((t) => t.title).sort(),
+          };
+        },
+        { timeout: 15_000 }
+      )
+      .toMatchObject({ count: 3, titles: ALL_TITLES_SORTED });
   });
 });

--- a/packages/webapp/tests/e2e/reference-scenario.test.ts
+++ b/packages/webapp/tests/e2e/reference-scenario.test.ts
@@ -1,0 +1,120 @@
+// packages/webapp/tests/e2e/reference-scenario.test.ts
+/**
+ * Reference Fake-LLM E2E scenario.
+ *
+ * Closes the three risks the Task 2 verifier flagged on the harness:
+ *
+ *   1. `localStorage` → kernel-worker shim sync — proven by seeding
+ *      the `local-llm` provider via {@link seedLocalLlmProvider} BEFORE
+ *      `page.goto('/')` and then submitting a user message that only
+ *      reaches the fake server if the worker's shim picked the seed
+ *      up. The chat-transcript assertion below is positive — it only
+ *      fires when the agent's scripted turn actually streamed back
+ *      from the fake server and ran.
+ *
+ *   2. `waitForTurnComplete` masking failures — guarded by the
+ *      chat-transcript + CDP-state assertions: both depend on the
+ *      scripted turn actually completing, so a silent "turn never
+ *      started" failure mode surfaces as a timeout, not a false green.
+ *
+ *   3. CDP port matches the harness default — Playwright launches
+ *      Chrome with `--remote-debugging-port=9222` for this file,
+ *      `node-server --serve-only --cdp-port=9222` (from
+ *      `playwright.config.ts`) proxies to the same port, and
+ *      {@link readCdpPageState} probes it by default. The final
+ *      assertion calls the helper without a `cdpEndpoint` override;
+ *      it returning the scripted target proves the wiring end to end.
+ */
+
+import { expect, test } from '@playwright/test';
+import {
+  FAKE_LLM_BASE_URL,
+  readCdpPageState,
+  runUserInputFixture,
+  seedLocalLlmProvider,
+} from './fake-llm-helpers.js';
+import { seedSkipSwReload, waitForSW } from './helpers.js';
+
+const REFERENCE_MODEL = 'fake-coder-reference';
+const TARGET_TITLE = 'FAKE LLM REFERENCE TARGET';
+// `data:` URL keeps the CDP-driven tab self-contained: no service-worker
+// claim, no VFS seed dance. The URL itself carries the deterministic
+// HTML, so the agent's `playwright-cli tab-new …` is enough to make
+// Chrome report a target whose URL and title both come straight from
+// the scripted bash command — exactly the read-back signal we want.
+const TARGET_HTML = `<!DOCTYPE html><title>${TARGET_TITLE}</title><h1>Agent landed here</h1>`;
+const TARGET_DATA_URL = `data:text/html,${TARGET_HTML}`;
+
+// Bind 9222 on the Playwright-launched Chrome so:
+//   - the `node-server --serve-only` CDP proxy (`--cdp-port=9222`)
+//     connects to a real Chrome
+//   - the agent's `playwright-cli tab-new` opens a CDP-driven tab there
+//   - {@link readCdpPageState} sees the same target at its default port
+// Sequential mode keeps the port singular within this file.
+test.use({
+  launchOptions: { args: ['--remote-debugging-port=9222'] },
+});
+test.describe.configure({ mode: 'serial' });
+
+test.describe('fake-llm reference scenario', () => {
+  test('scripted tool call drives a real CDP navigation', async ({ page }) => {
+    // Sanity: fake server is the one the harness expects.
+    expect(FAKE_LLM_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/v1$/);
+
+    // Seed BEFORE goto so the seed lands in the page's localStorage
+    // before boot and is forwarded to the kernel-worker shim.
+    await seedLocalLlmProvider(page, { modelId: REFERENCE_MODEL });
+    await seedSkipSwReload(page);
+    await page.goto('/');
+    await waitForSW(page);
+
+    // The composer renders before the kernel-worker finishes the cone
+    // bootstrap. Submitting before then produces a "No scoop selected"
+    // error card (the OffscreenClient agent handle bails when
+    // `selectedScoopJid` is null). The bootstrapped cone renders a
+    // welcome message into the thread as its first turn — wait for
+    // that to confirm the cone is created AND selected.
+    await page.waitForSelector('slicc-input-card');
+    await expect(page.locator('slicc-chat-thread')).toContainText('Welcome to SLICC', {
+      timeout: 20_000,
+    });
+    await runUserInputFixture(page, ['open the reference page']);
+
+    // ── (a) chat-transcript assertion: scripted assistant text rendered ──
+    // Canonical positive proof that the fake LLM streamed back AND the
+    // agent loop processed the turn — both required for the
+    // localStorage → kernel-worker shim sync to be exercised.
+    await expect(page.locator('slicc-chat-thread')).toContainText(
+      'Opening the reference data: URL'
+    );
+    await expect(page.locator('slicc-chat-thread')).toContainText(
+      'Done. The agent navigated to the reference page'
+    );
+
+    // ── (b) CDP/browser-state assertion via the harness helper ──────
+    // After the scripted `bash playwright-cli tab-new …` ran, Chrome at
+    // 9222 should report a `page` target whose URL is the data: URL
+    // the agent navigated to AND whose title matches the embedded HTML.
+    // Polls because the target registers a beat after the CDP
+    // `Target.createTarget` resolves on the agent side.
+    await expect
+      .poll(
+        async () => {
+          const targets = await readCdpPageState({
+            filter: (t) => t.type === 'page' && t.url.startsWith('data:text/html'),
+          });
+          return {
+            count: targets.length,
+            titles: targets.map((t) => t.title),
+            urls: targets.map((t) => t.url),
+          };
+        },
+        { timeout: 15_000 }
+      )
+      .toMatchObject({
+        count: 1,
+        titles: [TARGET_TITLE],
+        urls: [TARGET_DATA_URL],
+      });
+  });
+});

--- a/packages/webapp/tests/fake-llm/server.test.ts
+++ b/packages/webapp/tests/fake-llm/server.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Unit tests for the fake OpenAI-compatible LLM server used by the E2E
+ * harness. The server itself lives under `tests/e2e/fake-llm/` because
+ * it's a test-only artifact; the tests live here so the webapp vitest
+ * project picks them up (`tests/e2e/**` is excluded from `npm run test`).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  type FakeLlmServer,
+  type Fixture,
+  startFakeLlmServer,
+} from '../../tests/e2e/fake-llm/server.js';
+
+let server: FakeLlmServer;
+
+async function start(fixture: Fixture): Promise<FakeLlmServer> {
+  server = await startFakeLlmServer({ fixture, port: 0 });
+  return server;
+}
+
+afterEach(async () => {
+  await server?.close();
+});
+
+/** Parse an OpenAI-shape SSE stream into typed events. */
+async function readSse(res: Response): Promise<{
+  events: Array<Record<string, unknown>>;
+  done: boolean;
+}> {
+  const text = await res.text();
+  const events: Array<Record<string, unknown>> = [];
+  let done = false;
+  for (const block of text.split('\n\n')) {
+    const lines = block.split('\n').filter((l) => l.startsWith('data:'));
+    for (const line of lines) {
+      const payload = line.slice('data:'.length).trim();
+      if (payload === '[DONE]') {
+        done = true;
+        continue;
+      }
+      if (!payload) continue;
+      events.push(JSON.parse(payload));
+    }
+  }
+  return { events, done };
+}
+
+function userTurnBody(content: string, opts: { stream?: boolean; model?: string } = {}) {
+  return {
+    model: opts.model ?? 'fake-coder',
+    stream: opts.stream ?? true,
+    messages: [{ role: 'user', content }],
+  };
+}
+
+describe('startFakeLlmServer — boot + endpoints', () => {
+  it('binds to a random port and serves /v1/models in OpenAI shape', async () => {
+    await start({ model: 'fake-coder', models: ['fake-mini'], turns: [] });
+    const res = await fetch(`${server.url}/v1/models`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+    const body = (await res.json()) as { object: string; data: Array<{ id: string }> };
+    expect(body.object).toBe('list');
+    expect(body.data.map((m) => m.id)).toEqual(['fake-coder', 'fake-mini']);
+  });
+
+  it('responds 204 with CORS headers to OPTIONS preflight', async () => {
+    await start({ model: 'fake', turns: [] });
+    const res = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'OPTIONS',
+      headers: { 'Access-Control-Request-Method': 'POST' },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+    expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(res.headers.get('access-control-allow-headers')).toContain('Content-Type');
+  });
+
+  it('returns 404 JSON for unknown routes', async () => {
+    await start({ model: 'fake', turns: [] });
+    const res = await fetch(`${server.url}/v1/nope`);
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.type).toBe('not_found');
+  });
+});
+
+describe('POST /v1/chat/completions — streaming SSE', () => {
+  beforeEach(async () => {
+    await start({
+      model: 'fake-coder',
+      turns: [
+        { content: 'Hello there!', contentChunkSize: 5 },
+        {
+          tool_calls: [{ name: 'bash', arguments: { command: 'ls' } }],
+          toolArgumentsChunkSize: 6,
+        },
+        { content: 'done' },
+      ],
+    });
+  });
+
+  it('streams a text turn as valid OpenAI SSE deltas ending with [DONE]', async () => {
+    const res = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('hi')),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const { events, done } = await readSse(res);
+    expect(done).toBe(true);
+
+    expect(events[0]).toMatchObject({
+      object: 'chat.completion.chunk',
+      model: 'fake-coder',
+      choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }],
+    });
+    const textChunks = events
+      .map((e) => {
+        const choices = e['choices'] as Array<{ delta: { content?: string } }>;
+        return choices[0]?.delta.content;
+      })
+      .filter((c): c is string => typeof c === 'string');
+    expect(textChunks.join('')).toBe('Hello there!');
+    expect(textChunks.length).toBeGreaterThan(1);
+    const finish = events.at(-1) as { choices: Array<{ finish_reason: string }> };
+    expect(finish.choices[0]?.finish_reason).toBe('stop');
+  });
+
+  it('streams tool_calls as a name-then-arguments fragment chain', async () => {
+    await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('first')),
+    });
+    const res = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('run it')),
+    });
+    const { events } = await readSse(res);
+
+    type ToolDelta = {
+      index: number;
+      id?: string;
+      type?: string;
+      function?: { name?: string; arguments?: string };
+    };
+    const toolDeltas: ToolDelta[] = [];
+    for (const e of events) {
+      const choices = e['choices'] as Array<{ delta: { tool_calls?: ToolDelta[] } }>;
+      const calls = choices[0]?.delta.tool_calls;
+      if (calls) toolDeltas.push(...calls);
+    }
+    expect(toolDeltas.length).toBeGreaterThan(1);
+    const head = toolDeltas[0];
+    expect(head?.function?.name).toBe('bash');
+    expect(head?.type).toBe('function');
+    expect(head?.id).toMatch(/^call_/);
+    expect(head?.function?.arguments).toBe('');
+
+    const reconstructed = toolDeltas.map((d) => d.function?.arguments ?? '').join('');
+    expect(JSON.parse(reconstructed)).toEqual({ command: 'ls' });
+
+    const last = events.at(-1) as { choices: Array<{ finish_reason: string }> };
+    expect(last.choices[0]?.finish_reason).toBe('tool_calls');
+  });
+
+  it('advances the turn cursor across sequential requests', async () => {
+    const responses = await Promise.all(
+      ['a', 'b', 'c'].map((m) =>
+        fetch(`${server.url}/v1/chat/completions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(userTurnBody(m)),
+        })
+      )
+    );
+    // Sequential cursor advance: parse text contents in order.
+    const allEvents = await Promise.all(responses.map((r) => readSse(r)));
+    const joined = allEvents.map(({ events }) =>
+      events
+        .map((e) => {
+          const choices = e['choices'] as Array<{ delta: { content?: string } }>;
+          return choices[0]?.delta.content ?? '';
+        })
+        .join('')
+    );
+    expect(joined).toEqual(['Hello there!', '', 'done']);
+    expect(server.getState()).toEqual({ cursor: 3, requestCount: 3 });
+  });
+});
+
+describe('matching + overflow', () => {
+  it('uses whenUserMessageMatches (string substring) to pick later turns and skip non-matching ones', async () => {
+    await start({
+      model: 'fake',
+      turns: [
+        { whenUserMessageMatches: 'login', content: 'doing login' },
+        { whenUserMessageMatches: 'logout', content: 'doing logout' },
+      ],
+    });
+    const r = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('please logout now')),
+    });
+    const { events } = await readSse(r);
+    const content = events
+      .map((e) => {
+        const ch = e['choices'] as Array<{ delta: { content?: string } }>;
+        return ch[0]?.delta.content ?? '';
+      })
+      .join('');
+    expect(content).toBe('doing logout');
+    // The first (login) turn was skipped, not used — cursor sits past 'logout'.
+    expect(server.getState().cursor).toBe(2);
+  });
+
+  it('supports regex matchers via object form (JSON-friendly)', async () => {
+    await start({
+      model: 'fake',
+      turns: [{ whenUserMessageMatches: { pattern: '^hi\\b', flags: 'i' }, content: 'hello' }],
+    });
+    const r = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('Hi there')),
+    });
+    expect(r.status).toBe(200);
+    const { events, done } = await readSse(r);
+    expect(done).toBe(true);
+    const content = events
+      .map((e) => {
+        const ch = e['choices'] as Array<{ delta: { content?: string } }>;
+        return ch[0]?.delta.content ?? '';
+      })
+      .join('');
+    expect(content).toBe('hello');
+  });
+
+  it('returns a 400 fixture_overflow when no turn matches (default)', async () => {
+    await start({
+      model: 'fake',
+      turns: [{ whenUserMessageMatches: 'login', content: 'x' }],
+    });
+    const r = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('something else')),
+    });
+    expect(r.status).toBe(400);
+    const body = (await r.json()) as { error: { type: string; code: string; message: string } };
+    expect(body.error.code).toBe('fixture_overflow');
+    expect(body.error.message).toContain('no eligible turn');
+  });
+
+  it('repeats the last used turn when onOverflow=repeat-last', async () => {
+    await start({
+      model: 'fake',
+      turns: [{ content: 'only' }],
+      onOverflow: 'repeat-last',
+    });
+    const a = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('first')),
+    });
+    const b = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('second')),
+    });
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    const aText = await readSse(a);
+    const bText = await readSse(b);
+    const join = (ev: { events: Array<Record<string, unknown>> }) =>
+      ev.events
+        .map((e) => {
+          const ch = e['choices'] as Array<{ delta: { content?: string } }>;
+          return ch[0]?.delta.content ?? '';
+        })
+        .join('');
+    expect(join(aText)).toBe('only');
+    expect(join(bText)).toBe('only');
+  });
+});
+
+describe('non-streaming + reset + setFixture', () => {
+  it('returns a single chat.completion JSON when stream:false', async () => {
+    await start({
+      model: 'fake-coder',
+      turns: [
+        {
+          content: 'sync ok',
+          tool_calls: [{ id: 'call_pinned', name: 'noop', arguments: '{}' }],
+        },
+      ],
+    });
+    const r = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('go', { stream: false })),
+    });
+    expect(r.headers.get('content-type')).toContain('application/json');
+    const body = (await r.json()) as {
+      object: string;
+      model: string;
+      choices: Array<{
+        message: {
+          content: string;
+          tool_calls: Array<{ id: string; function: { name: string; arguments: string } }>;
+        };
+        finish_reason: string;
+      }>;
+    };
+    expect(body.object).toBe('chat.completion');
+    expect(body.model).toBe('fake-coder');
+    expect(body.choices[0]?.message.content).toBe('sync ok');
+    expect(body.choices[0]?.message.tool_calls[0]).toMatchObject({
+      id: 'call_pinned',
+      function: { name: 'noop', arguments: '{}' },
+    });
+    expect(body.choices[0]?.finish_reason).toBe('tool_calls');
+  });
+
+  it('reset() rewinds the cursor and setFixture() swaps the script', async () => {
+    await start({
+      model: 'fake',
+      turns: [{ content: 'first' }, { content: 'second' }],
+    });
+    await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('a')),
+    });
+    expect(server.getState().cursor).toBe(1);
+
+    server.reset();
+    expect(server.getState()).toEqual({ cursor: 0, requestCount: 0 });
+
+    server.setFixture({ model: 'fake-v2', turns: [{ content: 'reloaded' }] });
+    const r = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userTurnBody('a')),
+    });
+    const { events } = await readSse(r);
+    const content = events
+      .map((e) => {
+        const ch = e['choices'] as Array<{ delta: { content?: string } }>;
+        return ch[0]?.delta.content ?? '';
+      })
+      .join('');
+    expect(content).toBe('reloaded');
+    const models = (await (await fetch(`${server.url}/v1/models`)).json()) as {
+      data: Array<{ id: string }>;
+    };
+    expect(models.data.map((m) => m.id)).toEqual(['fake-v2']);
+  });
+});

--- a/packages/webapp/tests/fake-llm/server.test.ts
+++ b/packages/webapp/tests/fake-llm/server.test.ts
@@ -77,6 +77,20 @@ describe('startFakeLlmServer — boot + endpoints', () => {
     expect(res.headers.get('access-control-allow-headers')).toContain('Content-Type');
   });
 
+  it('echoes Access-Control-Request-Headers into Access-Control-Allow-Headers when present', async () => {
+    await start({ model: 'fake', turns: [] });
+    const requested = 'x-stainless-os, x-stainless-arch';
+    const res = await fetch(`${server.url}/v1/chat/completions`, {
+      method: 'OPTIONS',
+      headers: {
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': requested,
+      },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-headers')).toBe(requested);
+  });
+
   it('returns 404 JSON for unknown routes', async () => {
     await start({ model: 'fake', turns: [] });
     const res = await fetch(`${server.url}/v1/nope`);


### PR DESCRIPTION
## Summary

Adds an end-to-end test framework that runs the **full agent loop deterministically** — no real LLM calls. It points the existing `local-llm` provider at a **fake OpenAI-compatible server** whose responses (text + tool calls) come from a fixture, drives the agent with scripted user inputs, then **asserts against the real CDP/browser state** the agent produced.

### How it works
Seeding `localStorage` (`slicc_accounts` + `selected-model`) via a Playwright init script redirects the agent at the fake server with no production-code change to the webapp. Scripted tool calls deterministically drive a real Chrome via the node-server CDP proxy, so the resulting browser state becomes assertable.

## What landed

**Test-only (`packages/webapp/tests/`)**
- `e2e/fake-llm/` — mock OpenAI-compatible server (`server.ts`), fixture schema (`types.ts`), entry/start helpers, and fixtures (`example.json`, `reference-scenario.json`). Streaming `/v1/chat/completions` (text + `tool_calls` deltas), `/v1/models`, CORS/OPTIONS, cursor-ordered turns with `whenUserMessageMatches`, and `onOverflow` handling.
- `fake-llm/server.test.ts` — 12 unit tests (SSE shape, tool calls, turn advancement, overflow, CORS).
- `e2e/fake-llm-helpers.ts` — Playwright helpers: `seedLocalLlmProvider`, `submitUserMessage`, `waitForTurnComplete`, `runUserInputFixture`, `readCdpPageState`.
- `e2e/reference-scenario.test.ts` — canonical scenario: scripted user input → fake LLM tool call → real CDP navigation → CDP-state assertion + chat-transcript assertion.
- `e2e/playwright.config.ts` — boots the fake server as a second `webServer` (port 5781) and pins the node-server CDP port to 9222.

**Docs**
- `docs/testing.md` — new "Fake-LLM E2E Framework" section: architecture, fixture authoring, scenario template, how to run, and the `data:`-URL / SW-claim limitation.

## Production code change (flagged for review)

`packages/node-server/src/index.ts` — one logic line extends the external-CDP branch from `ELECTRON_MODE` to `ELECTRON_MODE || SERVE_ONLY`, so `--cdp-port` is honored in `--serve-only` mode (previously parsed but dropped on the floor). This is a **genuine pre-existing bug**: in serve-only mode the CDP proxy used port 0 and could never connect to an externally-launched Chrome with a known port. No default-behavior regression — normal `node-server` runs (not serve-only / not Electron) still let Chrome pick a port. The harness depends on this to pin CDP to 9222.

## Verification
- `CI=1 npm run test:e2e` → 11 passed (incl. `reference-scenario.test.ts`)
- `npm run typecheck` → exit 0 (all tsc configs)
- `npm run lint` → exit 0 (biome + prettier + lint:docs)
- fake-server unit tests → 12/12

## Notes
- Positive assertions live outside `waitForTurnComplete`, so a stalled/no-fire turn fails by timeout rather than passing silently.
- CDP-spawned tabs (`Target.createTarget`) aren't claimed by the `preview-vfs` SW; the reference scenario uses a `data:` URL to sidestep this (documented).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author