### PR TITLE
feat(wc): queued-message stack in the composer

### DIFF
--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -120,6 +120,12 @@ export interface AbortMsg {
   scoopJid: string;
 }
 
+export interface DeleteQueuedMessageMsg {
+  type: 'delete-queued-message';
+  scoopJid: string;
+  messageId: string;
+}
+
 export interface SetModelMsg {
   type: 'set-model';
   provider: string;
@@ -761,6 +767,7 @@ export type PanelToOffscreenMessage =
   | ScoopFeedMsg
   | ScoopDropMsg
   | AbortMsg
+  | DeleteQueuedMessageMsg
   | SetModelMsg
   | RequestStateMsg
   | RequestScoopMessagesMsg

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -1402,6 +1402,13 @@ export class OffscreenBridge implements KernelFacade {
         break;
       }
 
+      case 'delete-queued-message': {
+        this.orchestrator.deleteQueuedMessage(msg.scoopJid, msg.messageId).catch((err) => {
+          console.warn('[offscreen-bridge] Failed to delete queued message:', err);
+        });
+        break;
+      }
+
       case 'set-model': {
         // Side panel already wrote to localStorage (shared origin).
         // Just tell all running ScoopContexts to re-read the model.

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -1403,9 +1403,7 @@ export class OffscreenBridge implements KernelFacade {
       }
 
       case 'delete-queued-message': {
-        this.orchestrator.deleteQueuedMessage(msg.scoopJid, msg.messageId).catch((err) => {
-          console.warn('[offscreen-bridge] Failed to delete queued message:', err);
-        });
+        this.handleDeleteQueuedMessage(msg.scoopJid, msg.messageId);
         break;
       }
 
@@ -1542,6 +1540,27 @@ export class OffscreenBridge implements KernelFacade {
         break;
       }
     }
+  }
+
+  /**
+   * Drop a queued message from the orchestrator AND from the bridge's
+   * per-scoop chat buffer (and its persisted UI session) so a subsequent
+   * `request-scoop-messages` — panel reload, HMR, scoop switch back —
+   * cannot resurrect the dismissed prompt from `messageBuffers` or the
+   * session store. No-op safe when the buffer or entry is absent;
+   * `persistScoop` is fire-and-forget like every other bridge writeback.
+   */
+  private handleDeleteQueuedMessage(scoopJid: string, messageId: string): void {
+    if (!this.orchestrator) return;
+    this.orchestrator.deleteQueuedMessage(scoopJid, messageId).catch((err) => {
+      console.warn('[offscreen-bridge] Failed to delete queued message:', err);
+    });
+    const buf = this.messageBuffers.get(scoopJid);
+    if (!buf) return;
+    const next = buf.filter((m) => m.id !== messageId);
+    if (next.length === buf.length) return;
+    this.messageBuffers.set(scoopJid, next);
+    this.persistScoop(scoopJid);
   }
 
   /**

--- a/packages/chrome-extension/tests/offscreen-bridge.test.ts
+++ b/packages/chrome-extension/tests/offscreen-bridge.test.ts
@@ -2083,6 +2083,51 @@ describe('OffscreenBridge handlePanelMessage dispatch', () => {
     expect(mockOrchestrator.clearQueuedMessages).not.toHaveBeenCalled();
   });
 
+  it('delete-queued-message evicts the matching entry from the per-scoop buffer', async () => {
+    // Regression for PR #1062 review: a dismissed queued bubble could be
+    // resurrected after a reload/HMR because the bridge's messageBuffers
+    // still carried the entry — `request-scoop-messages` would replay it.
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push({ id: 'msg-keep', role: 'user', content: 'keep me', timestamp: 1 });
+    buf.push({ id: 'msg-drop', role: 'user', content: 'drop me', timestamp: 2 });
+    buf.push({ id: 'msg-also-keep', role: 'user', content: 'also keep', timestamp: 3 });
+    const persistSpy = vi.spyOn(bridge as any, 'persistScoop');
+    await (bridge as any).handlePanelMessage({
+      type: 'delete-queued-message',
+      scoopJid: 'cone_1',
+      messageId: 'msg-drop',
+    });
+    const after = (bridge as any).messageBuffers.get('cone_1');
+    expect(after.map((m: any) => m.id)).toEqual(['msg-keep', 'msg-also-keep']);
+    // Re-persists so the UI session store mirrors the eviction; a later
+    // session-store-backed rehydration cannot resurrect the dropped entry.
+    expect(persistSpy).toHaveBeenCalledWith('cone_1');
+  });
+
+  it('delete-queued-message is a no-op when the buffer is absent or missing the id', async () => {
+    const persistSpy = vi.spyOn(bridge as any, 'persistScoop');
+    // Buffer absent: orchestrator delete still fires, no buffer mutation.
+    await (bridge as any).handlePanelMessage({
+      type: 'delete-queued-message',
+      scoopJid: 'scoop_a',
+      messageId: 'ghost',
+    });
+    expect((bridge as any).messageBuffers.has('scoop_a')).toBe(false);
+    expect(persistSpy).not.toHaveBeenCalled();
+    // Buffer present but no matching entry: no mutation, no re-persist.
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push({ id: 'msg-keep', role: 'user', content: 'keep me', timestamp: 1 });
+    await (bridge as any).handlePanelMessage({
+      type: 'delete-queued-message',
+      scoopJid: 'cone_1',
+      messageId: 'unknown',
+    });
+    expect((bridge as any).messageBuffers.get('cone_1').map((m: any) => m.id)).toEqual([
+      'msg-keep',
+    ]);
+    expect(persistSpy).not.toHaveBeenCalled();
+  });
+
   it('local-storage-set writes through to globalThis.localStorage', async () => {
     const ls = {
       setItem: vi.fn(),

--- a/packages/chrome-extension/tests/offscreen-bridge.test.ts
+++ b/packages/chrome-extension/tests/offscreen-bridge.test.ts
@@ -1943,6 +1943,7 @@ describe('OffscreenBridge handlePanelMessage dispatch', () => {
       handleWebhookEvent: vi.fn(),
       stopScoop: vi.fn(),
       clearQueuedMessages: vi.fn().mockResolvedValue(undefined),
+      deleteQueuedMessage: vi.fn().mockResolvedValue(undefined),
       clearScoopMessages: vi.fn().mockResolvedValue(undefined),
       getScoopContext: vi.fn(() => undefined),
       createScoopTab: vi.fn(),
@@ -2069,6 +2070,17 @@ describe('OffscreenBridge handlePanelMessage dispatch', () => {
     await (bridge as any).handlePanelMessage({ type: 'abort', scoopJid: 'cone_1' });
     expect(mockOrchestrator.stopScoop).toHaveBeenCalledWith('cone_1');
     expect(mockOrchestrator.clearQueuedMessages).toHaveBeenCalledWith('cone_1');
+  });
+
+  it('delete-queued-message forwards to orchestrator.deleteQueuedMessage', async () => {
+    await (bridge as any).handlePanelMessage({
+      type: 'delete-queued-message',
+      scoopJid: 'cone_1',
+      messageId: 'msg-42',
+    });
+    expect(mockOrchestrator.deleteQueuedMessage).toHaveBeenCalledWith('cone_1', 'msg-42');
+    // Must not drop neighbouring queued items.
+    expect(mockOrchestrator.clearQueuedMessages).not.toHaveBeenCalled();
   });
 
   it('local-storage-set writes through to globalThis.localStorage', async () => {

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -339,8 +339,8 @@ export class OffscreenClient implements KernelClientFacade {
     // Handled by the abort message
   }
 
-  async deleteQueuedMessage(_jid: string, _messageId: string): Promise<void> {
-    // Not supported through offscreen proxy
+  async deleteQueuedMessage(jid: string, messageId: string): Promise<void> {
+    this.send({ type: 'delete-queued-message', scoopJid: jid, messageId });
   }
 
   updateModel(): void {

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -16,6 +16,20 @@ import type { AgentEvent, AgentHandle, ChatMessage } from '../types.js';
 import { createCopyRow } from './wc-copy-row.js';
 import { collateLickMessages, daySeparatorEl, messageEls } from './wc-message-view.js';
 
+/**
+ * View shape the controller hands the host for stack rendering. The full
+ * `ChatMessage` is kept internally; this is the projection the
+ * `slicc-queued-stack` component consumes via `setMessages`. Mirrors the
+ * library's `QueuedMessage` shape without importing the component, so the
+ * controller stays framework-free.
+ */
+export interface QueuedMessageView {
+  id: string;
+  text: string;
+  /** Optional attachment count — shown as a small `+N` hint on the front card. */
+  attachments?: number;
+}
+
 export interface WcChatControllerOptions {
   /** The `<slicc-chat-thread>` element messages render into. */
   thread: HTMLElement;
@@ -44,10 +58,24 @@ export interface WcChatControllerOptions {
    * null / throwing skips the beacon (telemetry must never block a send).
    */
   resolveTelemetryContext?: () => { scoopName: string; model: string } | null;
+  /**
+   * Invoked when the queued-submissions list changes (enqueue, local
+   * dismiss, flush-on-consume). The host wires this to its
+   * `<slicc-queued-stack>` ref's `setMessages`. The controller never
+   * touches the component directly.
+   */
+  onQueuedChange?: (items: readonly QueuedMessageView[]) => void;
 }
 
 function uid(): string {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Project a queued `ChatMessage` onto the host-render shape. */
+function toQueuedView(message: ChatMessage): QueuedMessageView {
+  const view: QueuedMessageView = { id: message.id, text: message.content };
+  if (message.attachments?.length) view.attachments = message.attachments.length;
+  return view;
 }
 
 export class WcChatController {
@@ -58,6 +86,7 @@ export class WcChatController {
   readonly #onMessageDisposed?: (messageId: string) => void;
   readonly #onTurnComplete?: (message: ChatMessage | null) => void;
   readonly #resolveTelemetryContext?: () => { scoopName: string; model: string } | null;
+  readonly #onQueuedChange?: (items: readonly QueuedMessageView[]) => void;
   #unsubscribe: () => void;
   #onLocalUserMessage?: (
     text: string,
@@ -68,6 +97,14 @@ export class WcChatController {
   readonly #onErrorRetry: (event: Event) => void;
 
   #messages: ChatMessage[] = [];
+  /**
+   * User submissions sent while `#processing` is true — held OUT of the
+   * thread (no inline bubble) and OUT of `#messages` until the next turn's
+   * first `message_start` flushes them in enqueue order. The host renders
+   * the stack via `onQueuedChange`; the agent already received each one
+   * synchronously in `sendUserMessage` (delivery cancel is a separate task).
+   */
+  #queued: ChatMessage[] = [];
   /** Rendered thread elements per message id (a message can span several). */
   readonly #els = new Map<string, HTMLElement[]>();
   #currentStreamId: string | null = null;
@@ -87,6 +124,7 @@ export class WcChatController {
     this.#onMessageDisposed = options.onMessageDisposed;
     this.#onTurnComplete = options.onTurnComplete;
     this.#resolveTelemetryContext = options.resolveTelemetryContext;
+    this.#onQueuedChange = options.onQueuedChange;
     this.#unsubscribe = options.agent.onEvent((event) => this.#handleAgentEvent(event));
     // Bubbled retry event from any rendered `slicc-error-card` (composed, so it
     // pierces shadow roots). One listener at the thread covers every error card.
@@ -139,6 +177,42 @@ export class WcChatController {
     });
   }
 
+  /** Snapshot of the currently-queued submissions (host-render projection). */
+  getQueuedMessages(): QueuedMessageView[] {
+    return this.#queued.map(toQueuedView);
+  }
+
+  /**
+   * Local dismiss path for the stack's `×` button — drops the item from
+   * `#queued` and refreshes the host. Delivery has already happened (the
+   * agent's send fires synchronously on enqueue); cancelling the orchestrator
+   * dequeue is tracked separately. No-op for unknown ids.
+   */
+  removeQueuedMessage(id: string): void {
+    const next = this.#queued.filter((m) => m.id !== id);
+    if (next.length === this.#queued.length) return;
+    this.#queued = next;
+    this.#fireQueuedChange();
+  }
+
+  /**
+   * Flush the queued submissions into the thread as ordinary user bubbles —
+   * in enqueue order, with no `queued` flag set so they render plain. The
+   * agent already received each one in `sendUserMessage`; this is the
+   * presentation-only consume boundary. Fires `onQueuedChange([])` once.
+   */
+  #flushQueued(): void {
+    if (this.#queued.length === 0) return;
+    const items = this.#queued;
+    this.#queued = [];
+    for (const message of items) this.#appendMessage(message);
+    this.#fireQueuedChange();
+  }
+
+  #fireQueuedChange(): void {
+    this.#onQueuedChange?.(this.#queued.map(toQueuedView));
+  }
+
   /**
    * Append a synthetic assistant message that never touched the agent —
    * deterministic onboarding lines and dip references (`![…](…shtml)`,
@@ -156,6 +230,12 @@ export class WcChatController {
   /** Replace the whole thread with a scoop's canonical history. */
   loadMessages(messages: readonly ChatMessage[]): void {
     for (const id of this.#els.keys()) this.#onMessageDisposed?.(id);
+    // The queued stack is live-only — a scoop switch / session reload starts
+    // with an empty pile rather than carrying the previous scoop's queue.
+    if (this.#queued.length > 0) {
+      this.#queued = [];
+      this.#fireQueuedChange();
+    }
     // Runs of same-channel licks render as ONE collated card ("×2" pill).
     this.#messages = collateLickMessages(messages);
     // A canonical replay can land mid-turn (rehydrate after a scoop switch /
@@ -223,9 +303,16 @@ export class WcChatController {
       content,
       timestamp: Date.now(),
       attachments: attachments?.length ? attachments : undefined,
-      queued: this.#processing ? true : undefined,
     };
-    this.#appendMessage(message);
+    if (this.#processing) {
+      // Busy-submit: park the bubble in the stack instead of the thread. The
+      // agent still receives it now (orchestrator owns turn batching); the
+      // bubble flushes into the thread when the consuming turn starts.
+      this.#queued.push(message);
+      this.#fireQueuedChange();
+    } else {
+      this.#appendMessage(message);
+    }
     this.#agent.sendMessage(content, message.id, message.attachments);
     // Fire ONLY on the single user-initiated send site. The retry path
     // (`#handleErrorRetry`) replays an existing user turn through
@@ -407,11 +494,19 @@ export class WcChatController {
   }
 
   #handleMessageStart(messageId: string): void {
+    // The rising edge of processing is the consume boundary for the queued
+    // stack: any submissions parked while busy belong to THIS turn, so flush
+    // them into the thread (in enqueue order, as ordinary user bubbles)
+    // BEFORE the streaming assistant lands. A mid-turn second `message_start`
+    // (multi-message turns) finds `wasProcessing=true` and skips the flush,
+    // so items queued mid-turn keep waiting for the NEXT turn's first start.
+    const wasProcessing = this.#processing;
     this.setProcessing(true);
     this.#currentStreamId = messageId;
     // Record AFTER the rise (which resets it): a multi-message turn keeps
     // overwriting, so the turn-complete hook gets the turn's LAST message.
     this.#turnAssistantId = messageId;
+    if (!wasProcessing) this.#flushQueued();
     this.#appendMessage({
       id: messageId,
       role: 'assistant',

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -419,6 +419,19 @@ export class WcChatController {
     // A RISING edge starts a fresh turn — forget the previous turn's reply
     // so a turn that streams nothing can never surface a stale one.
     if (processing) this.#turnAssistantId = null;
+    // The RISING edge is also the queue-consume boundary: items parked
+    // while busy belong to THIS turn, so flush them into the thread (in
+    // enqueue order, as ordinary user bubbles) BEFORE the streaming
+    // assistant lands. Hanging the flush off the rising edge (rather than
+    // off `message_start`) is the one turn-boundary signal BOTH floats
+    // share — live floats drive processing via scoop STATUS broadcasts
+    // that fire BEFORE the agent's `message_start` arrives, so a flush
+    // gated on `message_start` would miss the live ordering entirely. A
+    // mid-turn second `message_start` (multi-message turns) finds
+    // `#processing` already true → `setProcessing` early-returns above →
+    // no double flush, so items queued mid-turn keep waiting for the NEXT
+    // turn's rising edge.
+    if (processing) this.#flushQueued();
     if (!processing) this.#syncCopyRow();
     this.#onProcessingChange?.(processing);
     // End-of-turn = the processing flag FALLING. This is deliberately not
@@ -494,19 +507,15 @@ export class WcChatController {
   }
 
   #handleMessageStart(messageId: string): void {
-    // The rising edge of processing is the consume boundary for the queued
-    // stack: any submissions parked while busy belong to THIS turn, so flush
-    // them into the thread (in enqueue order, as ordinary user bubbles)
-    // BEFORE the streaming assistant lands. A mid-turn second `message_start`
-    // (multi-message turns) finds `wasProcessing=true` and skips the flush,
-    // so items queued mid-turn keep waiting for the NEXT turn's first start.
-    const wasProcessing = this.#processing;
+    // The queued-stack flush rides the processing rising edge inside
+    // `setProcessing` — both this code path AND the live-float scoop-status
+    // broadcast path go through that one chokepoint, so a flush gated here
+    // would miss the live ordering (status fires BEFORE `message_start`).
     this.setProcessing(true);
     this.#currentStreamId = messageId;
     // Record AFTER the rise (which resets it): a multi-message turn keeps
     // overwriting, so the turn-complete hook gets the turn's LAST message.
     this.#turnAssistantId = messageId;
-    if (!wasProcessing) this.#flushQueued();
     this.#appendMessage({
       id: messageId,
       role: 'assistant',

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -65,6 +65,17 @@ export interface WcChatControllerOptions {
    * touches the component directly.
    */
   onQueuedChange?: (items: readonly QueuedMessageView[]) => void;
+  /**
+   * Invoked once per dropped queued message id when the live-only stack
+   * is discarded by a scoop switch / session reload (`loadMessages` with
+   * a non-empty `#queued`). The host wires this to the SAME backend
+   * cancel path the local `×` dismiss uses (the offscreen client's
+   * `deleteQueuedMessage` RPC) so the orchestrator never delivers a
+   * queued prompt the user has implicitly dropped by navigating away.
+   * The controller stays free of any direct client/RPC dependency,
+   * consistent with the existing `onQueuedChange` seam.
+   */
+  onQueuedCancel?: (messageId: string) => void;
 }
 
 function uid(): string {
@@ -87,6 +98,7 @@ export class WcChatController {
   readonly #onTurnComplete?: (message: ChatMessage | null) => void;
   readonly #resolveTelemetryContext?: () => { scoopName: string; model: string } | null;
   readonly #onQueuedChange?: (items: readonly QueuedMessageView[]) => void;
+  readonly #onQueuedCancel?: (messageId: string) => void;
   #unsubscribe: () => void;
   #onLocalUserMessage?: (
     text: string,
@@ -125,6 +137,7 @@ export class WcChatController {
     this.#onTurnComplete = options.onTurnComplete;
     this.#resolveTelemetryContext = options.resolveTelemetryContext;
     this.#onQueuedChange = options.onQueuedChange;
+    this.#onQueuedCancel = options.onQueuedCancel;
     this.#unsubscribe = options.agent.onEvent((event) => this.#handleAgentEvent(event));
     // Bubbled retry event from any rendered `slicc-error-card` (composed, so it
     // pierces shadow roots). One listener at the thread covers every error card.
@@ -232,7 +245,20 @@ export class WcChatController {
     for (const id of this.#els.keys()) this.#onMessageDisposed?.(id);
     // The queued stack is live-only — a scoop switch / session reload starts
     // with an empty pile rather than carrying the previous scoop's queue.
+    // Each dropped id routes through the SAME backend cancel path the local
+    // `×` dismiss uses so the orchestrator never delivers a prompt the user
+    // implicitly dropped by switching away. The hook is fired BEFORE we clear
+    // the local queue so a throwing host can't strand entries half-dropped.
     if (this.#queued.length > 0) {
+      if (this.#onQueuedCancel) {
+        for (const message of this.#queued) {
+          try {
+            this.#onQueuedCancel(message.id);
+          } catch (err) {
+            console.error('onQueuedCancel hook threw', err);
+          }
+        }
+      }
       this.#queued = [];
       this.#fireQueuedChange();
     }

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -516,6 +516,20 @@ export function prepareWcShell(app: HTMLElement, floatLabel: string): WcShellBoo
   const selectScoop = (scoop: RegisteredScoop): void => {
     selected = scoop;
     if (!client) return;
+    // Scoop-switch queue-cancel: snapshot the OLD scoop's currently-queued
+    // ids and cancel them on the backend BEFORE switching selectedScoopJid,
+    // so the orchestrator never silently delivers a prompt the user dropped
+    // by navigating to a different scoop. The controller's #queued is
+    // dropped locally later via loadMessages; its onQueuedCancel hook then
+    // fires against the NEW jid as defense-in-depth (a redundant per-id
+    // delete is a no-op once the backend already removed it).
+    const previousJid = client.selectedScoopJid;
+    if (previousJid && previousJid !== scoop.jid) {
+      const queued = controller?.getQueuedMessages() ?? [];
+      for (const m of queued) {
+        void client.deleteQueuedMessage(previousJid, m.id).catch(() => undefined);
+      }
+    }
     client.setSelectedScoopJid(scoop.jid);
     refs.inputCard.removeAttribute('disabled');
     void applyThreadContext(refs, scoop);
@@ -745,6 +759,16 @@ function createWcController(
     // list); the controller owns enqueue / dismiss / flush-on-consume.
     onQueuedChange: (items) => {
       refs.queuedStack.setMessages(items);
+    },
+    // Scoop switch / session reload drops the live-only stack. Route each
+    // dropped id through the SAME backend cancel RPC the `×` dismiss uses
+    // so the orchestrator never delivers a prompt the user implicitly
+    // dropped by navigating away. Best-effort — a transient RPC failure
+    // must not block the local UI from clearing.
+    onQueuedCancel: (messageId) => {
+      const jid = client.selectedScoopJid;
+      if (!jid) return;
+      void client.deleteQueuedMessage(jid, messageId).catch(() => undefined);
     },
   });
   // Local dismiss path: the `×` button on the stack's front card emits a

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -740,6 +740,20 @@ function createWcController(
         })
       );
     },
+    // Route the controller's queued list into the composer's stack. The
+    // component is purely presentational (setMessages replaces the rendered
+    // list); the controller owns enqueue / dismiss / flush-on-consume.
+    onQueuedChange: (items) => {
+      refs.queuedStack.setMessages(items);
+    },
+  });
+  // Local dismiss path: the `×` button on the stack's front card emits a
+  // composed `slicc-queued-remove`; the controller drops the matching item
+  // and re-fires `onQueuedChange` so the stack re-renders. Orchestrator
+  // dequeue is tracked separately — for now the agent keeps the message.
+  refs.queuedStack.addEventListener('slicc-queued-remove', (event) => {
+    const id = (event as CustomEvent<{ id?: string }>).detail?.id;
+    if (id) controller.removeQueuedMessage(id);
   });
   return { controller, agentHandle };
 }

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -749,11 +749,17 @@ function createWcController(
   });
   // Local dismiss path: the `×` button on the stack's front card emits a
   // composed `slicc-queued-remove`; the controller drops the matching item
-  // and re-fires `onQueuedChange` so the stack re-renders. Orchestrator
-  // dequeue is tracked separately — for now the agent keeps the message.
+  // and re-fires `onQueuedChange` so the stack re-renders. The same id is
+  // also dropped from the orchestrator's queue so the message never reaches
+  // the agent on the next poll.
   refs.queuedStack.addEventListener('slicc-queued-remove', (event) => {
     const id = (event as CustomEvent<{ id?: string }>).detail?.id;
-    if (id) controller.removeQueuedMessage(id);
+    if (!id) return;
+    controller.removeQueuedMessage(id);
+    const jid = client.selectedScoopJid;
+    if (jid) {
+      void client.deleteQueuedMessage(jid, id).catch(() => undefined);
+    }
   });
   return { controller, agentHandle };
 }

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -446,7 +446,11 @@ function userMessageEl(message: ChatMessage): HTMLElement {
   // the persisted `content` (what the agent sees on replay/compaction) and
   // the rendered view cleanly separated — typed messages are a no-op pass.
   bubble.setBodyHtml(renderMessageContent(stripDictationMarkers(message.content)));
-  if (message.queued) bubble.setAttribute('queued', '');
+  // The inline `queued` attribute path is dead: live queued submissions render
+  // in `<slicc-queued-stack>` until they flush, and persisted user messages
+  // (replay/history) — including any legacy rows that still carry the flag —
+  // render as ordinary bubbles. The `queued` field on `ChatMessage` is kept
+  // for the placeholder/copy-row filters and for back-compat with stored sessions.
   if (message.attachments?.length) {
     bubble.setAttachments(message.attachments.map(toUserAttachment));
     // Fire `viewmedia` once per displayed image — the thread rebuilds many

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -188,11 +188,16 @@ function buildComposer(options: WcShellOptions): {
   // `z-index:1` and the stack is pinned to `z-index:0`, and the stack carries
   // the overlap margin that tucks its front card under the opaque input card.
   // The component renders nothing when empty, so an idle composer is visually
-  // unchanged.
+  // unchanged. `minHeight` guarantees a visible peek above the overlap even
+  // for a short single-line front card: a 41px card would otherwise leave
+  // only ~9px above the 32px overlap, almost entirely hidden by the textarea.
+  // 76px reserves badge(~16) + gap(6) + ~22px card peek above the 32px tuck;
+  // taller cards exceed the floor and keep the deeper tucked-behind look.
   const queuedStack = el('slicc-queued-stack') as SliccQueuedStack;
   queuedStack.style.position = 'relative';
   queuedStack.style.zIndex = '0';
   queuedStack.style.marginBottom = '-32px';
+  queuedStack.style.minHeight = '76px';
   const inputCard = el('slicc-input-card', { placeholder: options.placeholder });
   inputCard.style.position = 'relative';
   inputCard.style.zIndex = '1';

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -16,6 +16,7 @@ import {
   followSystemTheme,
   type SliccAvatarMenu,
   type SliccFileTree,
+  type SliccQueuedStack,
 } from '@slicc/webcomponents';
 // Adobe Clean @font-face — the library tokens reference the family but the
 // declarations lived only in the (never-loaded) legacy stylesheet.
@@ -71,6 +72,13 @@ export interface WcShellRefs {
   composer: HTMLElement;
   inputCard: HTMLElement;
   composerMeta: HTMLElement;
+  /**
+   * The pile of pending user submissions pinned above the input card. Renders
+   * nothing when empty (the component hides itself), so the idle composer is
+   * unchanged. Live floats populate it when submissions queue behind a busy
+   * agent; the fixture/preview keeps it empty.
+   */
+  queuedStack: SliccQueuedStack;
   switcher: HTMLElement & { scoops: SwitcherScoop[] };
   floatbar: HTMLElement;
   shell: HTMLElement;
@@ -170,12 +178,27 @@ function buildComposer(options: WcShellOptions): {
   composer: HTMLElement;
   inputCard: HTMLElement;
   composerMeta: HTMLElement;
+  queuedStack: SliccQueuedStack;
 } {
   const composer = el('slicc-composer');
+  // The queued pile sits ABOVE the input card inside the composer. Placement
+  // matches the Storybook `InComposer` story: the stack's `.stack` grid is
+  // positioned (so its cards can grid-overlap), which would paint atop a
+  // static sibling regardless of DOM order — so the input card is lifted to
+  // `z-index:1` and the stack is pinned to `z-index:0`, and the stack carries
+  // the overlap margin that tucks its front card under the opaque input card.
+  // The component renders nothing when empty, so an idle composer is visually
+  // unchanged.
+  const queuedStack = el('slicc-queued-stack') as SliccQueuedStack;
+  queuedStack.style.position = 'relative';
+  queuedStack.style.zIndex = '0';
+  queuedStack.style.marginBottom = '-32px';
   const inputCard = el('slicc-input-card', { placeholder: options.placeholder });
+  inputCard.style.position = 'relative';
+  inputCard.style.zIndex = '1';
   const composerMeta = el('slicc-composer-meta', { model: 'Preview', thinking: 'off' });
-  composer.append(inputCard, composerMeta);
-  return { composer, inputCard, composerMeta };
+  composer.append(queuedStack, inputCard, composerMeta);
+  return { composer, inputCard, composerMeta, queuedStack };
 }
 
 function buildWorkbench(): {
@@ -305,7 +328,7 @@ export function mountWcShell(root: HTMLElement, options: WcShellOptions): WcShel
     ...urlState,
   });
   thread.append(...buildThreadChildren(options.messages));
-  const { composer, inputCard, composerMeta } = buildComposer(options);
+  const { composer, inputCard, composerMeta, queuedStack } = buildComposer(options);
   pane.append(thread, composer);
 
   const { workbench, body, header, tree, termSurface, memoryHost, tabBar } = buildWorkbench();
@@ -348,6 +371,7 @@ export function mountWcShell(root: HTMLElement, options: WcShellOptions): WcShel
     composer,
     inputCard,
     composerMeta,
+    queuedStack,
     switcher,
     floatbar,
     shell,

--- a/packages/webapp/tests/kernel/facade.test.ts
+++ b/packages/webapp/tests/kernel/facade.test.ts
@@ -138,6 +138,7 @@ function makeOrchestratorMock() {
     unregisterScoop: vi.fn().mockResolvedValue(undefined),
     stopScoop: vi.fn(),
     clearQueuedMessages: vi.fn().mockResolvedValue(undefined),
+    deleteQueuedMessage: vi.fn().mockResolvedValue(undefined),
     clearAllMessages: vi.fn().mockResolvedValue(undefined),
     clearScoopMessages: vi.fn().mockResolvedValue(undefined),
     delegateToScoop: vi.fn().mockResolvedValue(undefined),
@@ -233,6 +234,16 @@ describe('Kernel facade parity', () => {
     const sessionStore = (facade as unknown as { sessionStore: { delete: Mock } }).sessionStore;
     expect(sessionStore.delete).toHaveBeenCalledWith('session-test-scoop');
     expect(orchestrator.unregisterScoop).toHaveBeenCalledWith('scoop_test');
+  });
+
+  // 2b. delete-queued-message: dismissing a queued card on the panel
+  //     drops the matching id from the orchestrator queue (and IndexedDB
+  //     via deleteMessage), leaving neighbouring queued items intact.
+  it('client.deleteQueuedMessage(jid, id) → orchestrator.deleteQueuedMessage(jid, id)', async () => {
+    await client.deleteQueuedMessage('cone_1', 'msg-42');
+    await tick();
+    expect(orchestrator.deleteQueuedMessage).toHaveBeenCalledWith('cone_1', 'msg-42');
+    expect(orchestrator.clearQueuedMessages).not.toHaveBeenCalled();
   });
 
   // 3. clear-chat is cone-only by design: only the cone's session row

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -546,11 +546,103 @@ describe('WcChatController', () => {
     expect(thread.querySelector('slicc-lick-card')?.getAttribute('state')).toBe('dismissed');
   });
 
-  it('flags prompts sent while processing as queued', () => {
+  it('routes busy-submit prompts to the queued stack and skips the inline bubble', () => {
+    const queuedChanges: Array<readonly { id: string; text: string; attachments?: number }[]> = [];
+    const localController = new WcChatController({
+      thread,
+      agent,
+      onQueuedChange: (items) => queuedChanges.push(items.slice()),
+    });
     agent.emit({ type: 'message_start', messageId: 'm1' });
-    controller.sendUserMessage('queued one');
-    const bubble = [...thread.querySelectorAll('slicc-user-message')].at(-1);
-    expect(bubble?.hasAttribute('queued')).toBe(true);
+    const bubblesBefore = thread.querySelectorAll('slicc-user-message').length;
+    localController.sendUserMessage('queued one');
+    // Delivery still fires immediately (agent received it; orchestrator owns
+    // turn batching). The thread DOM is untouched — no inline bubble.
+    expect(agent.sent.at(-1)?.text).toBe('queued one');
+    expect(thread.querySelectorAll('slicc-user-message').length).toBe(bubblesBefore);
+    expect(thread.querySelector('slicc-user-message[queued]')).toBeNull();
+    // The host-render hook fired with the queued view (id + text only).
+    expect(queuedChanges.length).toBe(1);
+    expect(queuedChanges[0]).toHaveLength(1);
+    expect(queuedChanges[0][0].text).toBe('queued one');
+    expect(localController.getQueuedMessages()).toHaveLength(1);
+  });
+
+  it('flushes queued submissions into the thread at the next turn start', () => {
+    const queuedChanges: Array<readonly { id: string }[]> = [];
+    const localController = new WcChatController({
+      thread,
+      agent,
+      onQueuedChange: (items) => queuedChanges.push(items.slice()),
+    });
+    // Turn 1 starts, two prompts queue mid-turn, turn 1 ends.
+    agent.emit({ type: 'message_start', messageId: 'm1' });
+    localController.sendUserMessage('first queued');
+    localController.sendUserMessage('second queued');
+    agent.emit({ type: 'turn_end', messageId: 'm1' });
+    expect(localController.getQueuedMessages()).toHaveLength(2);
+    expect(thread.querySelectorAll('slicc-user-message').length).toBe(0);
+
+    // Turn 2's first message_start consumes the queue: both bubbles flush
+    // into the thread in enqueue order — first queued first — BEFORE the
+    // streaming assistant bubble. No `queued` attribute on either.
+    agent.emit({ type: 'message_start', messageId: 'm2' });
+    const userBubbles = thread.querySelectorAll('slicc-user-message');
+    expect(userBubbles).toHaveLength(2);
+    expect(userBubbles[0].shadowRoot?.textContent).toContain('first queued');
+    expect(userBubbles[1].shadowRoot?.textContent).toContain('second queued');
+    expect([...userBubbles].some((b) => b.hasAttribute('queued'))).toBe(false);
+    // The queued list is empty and the host got a final change call.
+    expect(localController.getQueuedMessages()).toHaveLength(0);
+    expect(queuedChanges.at(-1)).toHaveLength(0);
+  });
+
+  it('does not re-flush queued items on mid-turn second message_start (multi-message turn)', () => {
+    agent.emit({ type: 'message_start', messageId: 'm1' });
+    controller.sendUserMessage('queued mid-turn');
+    expect(thread.querySelectorAll('slicc-user-message').length).toBe(0);
+    // A second message_start in the SAME turn (multi-message) must NOT
+    // flush — those items belong to the NEXT turn.
+    agent.emit({ type: 'message_start', messageId: 'm1b' });
+    expect(thread.querySelectorAll('slicc-user-message').length).toBe(0);
+    expect(controller.getQueuedMessages()).toHaveLength(1);
+  });
+
+  it('removeQueuedMessage drops the item locally and re-fires onQueuedChange', () => {
+    const queuedChanges: Array<readonly { id: string }[]> = [];
+    const localController = new WcChatController({
+      thread,
+      agent,
+      onQueuedChange: (items) => queuedChanges.push(items.slice()),
+    });
+    agent.emit({ type: 'message_start', messageId: 'm1' });
+    localController.sendUserMessage('keep me');
+    localController.sendUserMessage('drop me');
+    const view = localController.getQueuedMessages();
+    expect(view).toHaveLength(2);
+    const dropId = view[1].id;
+    queuedChanges.length = 0;
+    localController.removeQueuedMessage(dropId);
+    expect(localController.getQueuedMessages().map((m) => m.text)).toEqual(['keep me']);
+    expect(queuedChanges.at(-1)).toHaveLength(1);
+    // Unknown id is a no-op (no change notification).
+    queuedChanges.length = 0;
+    localController.removeQueuedMessage('does-not-exist');
+    expect(queuedChanges).toHaveLength(0);
+  });
+
+  it('idle submits append a plain user bubble (no stack routing)', () => {
+    const queuedChanges: number[] = [];
+    const localController = new WcChatController({
+      thread,
+      agent,
+      onQueuedChange: (items) => queuedChanges.push(items.length),
+    });
+    localController.sendUserMessage('idle prompt');
+    expect(thread.querySelectorAll('slicc-user-message')).toHaveLength(1);
+    expect(thread.querySelector('slicc-user-message[queued]')).toBeNull();
+    expect(localController.getQueuedMessages()).toHaveLength(0);
+    expect(queuedChanges).toEqual([]);
   });
 
   it('stops listening after dispose', () => {

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -675,6 +675,61 @@ describe('WcChatController', () => {
     expect(queuedChanges).toHaveLength(0);
   });
 
+  it('loadMessages cancels every dropped queued id on the backend via onQueuedCancel', () => {
+    // Regression for PR #1062 review: a queue-drop on scoop switch / reload
+    // must route each dropped id through the SAME backend cancel path the
+    // local `×` dismiss uses, otherwise the orchestrator silently delivers
+    // the dropped prompts after the user navigated away.
+    const cancelled: string[] = [];
+    const localController = new WcChatController({
+      thread,
+      agent,
+      onQueuedCancel: (id) => cancelled.push(id),
+    });
+    agent.emit({ type: 'message_start', messageId: 'm1' });
+    localController.sendUserMessage('queued one');
+    localController.sendUserMessage('queued two');
+    const ids = localController.getQueuedMessages().map((m) => m.id);
+    expect(ids).toHaveLength(2);
+    // Scoop switch / session reload: loadMessages clears #queued.
+    localController.loadMessages([]);
+    expect(cancelled).toEqual(ids);
+    expect(localController.getQueuedMessages()).toHaveLength(0);
+  });
+
+  it('loadMessages does not fire onQueuedCancel when the queue is already empty', () => {
+    const cancelled: string[] = [];
+    const localController = new WcChatController({
+      thread,
+      agent,
+      onQueuedCancel: (id) => cancelled.push(id),
+    });
+    localController.loadMessages([{ id: 'h1', role: 'user', content: 'historical', timestamp: 1 }]);
+    expect(cancelled).toEqual([]);
+  });
+
+  it('loadMessages still clears #queued and notifies the host even when onQueuedCancel throws', () => {
+    const queuedChanges: Array<readonly { id: string }[]> = [];
+    const localController = new WcChatController({
+      thread,
+      agent,
+      onQueuedChange: (items) => queuedChanges.push(items.slice()),
+      onQueuedCancel: () => {
+        throw new Error('host blew up');
+      },
+    });
+    agent.emit({ type: 'message_start', messageId: 'm1' });
+    localController.sendUserMessage('queued one');
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      localController.loadMessages([]);
+    } finally {
+      errSpy.mockRestore();
+    }
+    expect(localController.getQueuedMessages()).toHaveLength(0);
+    expect(queuedChanges.at(-1)).toHaveLength(0);
+  });
+
   it('idle submits append a plain user bubble (no stack routing)', () => {
     const queuedChanges: number[] = [];
     const localController = new WcChatController({

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -597,6 +597,50 @@ describe('WcChatController', () => {
     expect(queuedChanges.at(-1)).toHaveLength(0);
   });
 
+  it('flushes queued submissions when scoop status drives the rising edge BEFORE message_start (live ordering)', () => {
+    // The LIVE-FLOAT regression: in `wc-live.ts` the scoop STATUS broadcast
+    // (`onStatusChange → setProcessing(status === 'processing')`) flips
+    // `#processing` to true BEFORE the agent's `message_start` arrives. A
+    // flush gated on the `message_start` handler would see `#processing`
+    // already true and skip — leaving queued bubbles invisible (never
+    // appended to the thread) AND uncleared (never removed from the stack).
+    const queuedChanges: Array<readonly { id: string }[]> = [];
+    const localController = new WcChatController({
+      thread,
+      agent,
+      onQueuedChange: (items) => queuedChanges.push(items.slice()),
+    });
+    // Turn 1 runs and ends — queue two prompts mid-turn, then the falling
+    // edge lands so the next rise is a real false→true transition.
+    agent.emit({ type: 'message_start', messageId: 'm1' });
+    localController.sendUserMessage('first queued');
+    localController.sendUserMessage('second queued');
+    agent.emit({ type: 'turn_end', messageId: 'm1' });
+    expect(localController.getQueuedMessages()).toHaveLength(2);
+    expect(thread.querySelectorAll('slicc-user-message').length).toBe(0);
+    queuedChanges.length = 0;
+
+    // Live ordering: status broadcast fires the rising edge FIRST, with no
+    // accompanying `message_start` from the agent. The flush MUST happen
+    // here — both into the thread (two user bubbles, enqueue order) and
+    // into the host hook (final onQueuedChange with an empty list).
+    localController.setProcessing(true);
+    const flushed = thread.querySelectorAll('slicc-user-message');
+    expect(flushed).toHaveLength(2);
+    expect(flushed[0].shadowRoot?.textContent).toContain('first queued');
+    expect(flushed[1].shadowRoot?.textContent).toContain('second queued');
+    expect([...flushed].some((b) => b.hasAttribute('queued'))).toBe(false);
+    expect(localController.getQueuedMessages()).toHaveLength(0);
+    expect(queuedChanges.at(-1)).toHaveLength(0);
+
+    // The trailing `message_start` finds `#processing` already true → the
+    // setProcessing early-return short-circuits the second flush, so the
+    // user bubbles stay (no duplicates) and the streaming assistant lands
+    // beneath them.
+    agent.emit({ type: 'message_start', messageId: 'm2' });
+    expect(thread.querySelectorAll('slicc-user-message')).toHaveLength(2);
+  });
+
   it('does not re-flush queued items on mid-turn second message_start (multi-message turn)', () => {
     agent.emit({ type: 'message_start', messageId: 'm1' });
     controller.sendUserMessage('queued mid-turn');

--- a/packages/webapp/tests/ui/wc/wc-message-view.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-message-view.test.ts
@@ -178,8 +178,14 @@ describe('buildThreadChildren', () => {
     expect(next?.tagName.toLowerCase()).toBe('slicc-user-message');
   });
 
-  it('flags queued messages', () => {
-    expect(children.some((c) => c.hasAttribute('queued'))).toBe(true);
+  it('renders queued user messages as ordinary bubbles (the stack is live-only)', () => {
+    // The inline `queued` attribute path is dead: live queued submissions
+    // live in `<slicc-queued-stack>`, and persisted/historical user messages
+    // — including any that still carry the legacy `queued` flag — render as
+    // plain bubbles in the thread.
+    expect(children.some((c) => c.hasAttribute('queued'))).toBe(false);
+    // The user-message bubble is still rendered (history rehydrates as normal).
+    expect(children.some((c) => c.tagName.toLowerCase() === 'slicc-user-message')).toBe(true);
   });
 });
 

--- a/packages/webapp/tests/ui/wc/wc-shell.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shell.test.ts
@@ -320,9 +320,13 @@ describe('mountWcUiPreview', () => {
     ).toBeTruthy();
     // The InComposer placement contract: stack at z-index 0 + overlap margin,
     // input card lifted to z-index 1 so its opaque background hides the bottom
-    // edge of the front card.
+    // edge of the front card. The `minHeight` floor guarantees the badge and a
+    // sliver of the front card stay visible above the overlap even when the
+    // queued card is a single short line (without it, a ~41px card would leave
+    // only ~9px above the 32px tuck and be obscured by the textarea).
     expect((stack as HTMLElement).style.zIndex).toBe('0');
     expect((stack as HTMLElement).style.marginBottom).toBe('-32px');
+    expect((stack as HTMLElement).style.minHeight).toBe('76px');
     expect((inputCard as HTMLElement).style.zIndex).toBe('1');
     // The ref handle is the same node — controllers drive it via setMessages.
     expect(refs.queuedStack).toBe(stack);

--- a/packages/webapp/tests/ui/wc/wc-shell.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shell.test.ts
@@ -295,6 +295,39 @@ describe('mountWcUiPreview', () => {
     expect(shader.getAttribute('scroll')).toBe('240');
   });
 
+  it('mounts a queued stack above the input card inside the composer (refs.queuedStack)', async () => {
+    const { mountWcShell } = await import('../../../src/ui/wc/wc-shell.js');
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const refs = mountWcShell(host, {
+      messages: [],
+      scoops: [],
+      floatLabel: 'live',
+      placeholder: 'p',
+    });
+    const composer = host.querySelector('slicc-composer');
+    const stack = composer?.querySelector('slicc-queued-stack');
+    const inputCard = composer?.querySelector('slicc-input-card');
+    expect(stack).toBeTruthy();
+    expect(inputCard).toBeTruthy();
+    // The stack must sit ABOVE the input card inside the composer so its pile
+    // grows out of the top of the composer band. The composer wraps its
+    // children in a `.slicc-composer__inner` band, so check document order
+    // via `compareDocumentPosition` rather than `composer.children` indices.
+    expect(
+      (stack as Element).compareDocumentPosition(inputCard as Element) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    // The InComposer placement contract: stack at z-index 0 + overlap margin,
+    // input card lifted to z-index 1 so its opaque background hides the bottom
+    // edge of the front card.
+    expect((stack as HTMLElement).style.zIndex).toBe('0');
+    expect((stack as HTMLElement).style.marginBottom).toBe('-32px');
+    expect((inputCard as HTMLElement).style.zIndex).toBe('1');
+    // The ref handle is the same node — controllers drive it via setMessages.
+    expect(refs.queuedStack).toBe(stack);
+  });
+
   it('echoes composer submissions into the thread', () => {
     const root = mount();
     const card = root.querySelector('slicc-input-card') as HTMLElement;

--- a/packages/webcomponents/src/composer/slicc-queued-stack.stories.ts
+++ b/packages/webcomponents/src/composer/slicc-queued-stack.stories.ts
@@ -1,0 +1,150 @@
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import '../add-menu/slicc-add-menu.js';
+import '../primitives/slicc-send-button.js';
+import './slicc-composer-meta.js';
+import './slicc-composer.js';
+import './slicc-input-card.js';
+import type { QueuedMessage, SliccQueuedStack } from './slicc-queued-stack.js';
+
+interface StackArgs {
+  count: number;
+}
+
+/**
+ * Realistic, prototype-flavored queued lines — short enough that the front
+ * card stays a single line, long enough that the line-clamp is exercised.
+ */
+const SAMPLES: ReadonlyArray<string> = [
+  'Audit the cold landing hero and propose a warmer palette.',
+  'Then redesign it in a live sprinkle and verify before/after in the browser.',
+  'Open a PR with the before/after screenshots attached.',
+  'Also: tighten the meta row hint so it does not wrap on narrow chat.',
+  'Re-run the typecheck and the webcomponents test suite once everything is green.',
+  'If the build passes, rebase onto main and request a review.',
+  'And remember to update the prototype CLAUDE.md if conventions shifted.',
+];
+
+/** Pull the first `n` samples and stamp each one with a stable id. */
+function buildMessages(n: number): QueuedMessage[] {
+  return SAMPLES.slice(0, Math.max(0, n)).map((text, i) => ({
+    id: `q-${i + 1}`,
+    text,
+  }));
+}
+
+/** Mount the stack inside a 680px composer-width band on the off-white `--bg`. */
+function inBand(el: HTMLElement): HTMLElement {
+  const band = document.createElement('div');
+  band.style.background = 'var(--bg)';
+  band.style.padding = '24px 16px';
+  const inner = document.createElement('div');
+  inner.style.maxWidth = '680px';
+  inner.style.margin = '0 auto';
+  inner.appendChild(el);
+  band.appendChild(inner);
+  return band;
+}
+
+function buildStack(count: number): SliccQueuedStack {
+  const el = document.createElement('slicc-queued-stack');
+  el.setMessages(buildMessages(count));
+  return el;
+}
+
+const meta: Meta<StackArgs> = {
+  title: 'Composer/Queued Stack',
+  component: 'slicc-queued-stack',
+  tags: ['autodocs'],
+  argTypes: {
+    count: {
+      control: { type: 'number', min: 0, max: SAMPLES.length, step: 1 },
+      description: 'Number of queued messages to render (newest = front card)',
+    },
+  },
+  render: ({ count }) => inBand(buildStack(count)),
+};
+
+export default meta;
+type Story = StoryObj<StackArgs>;
+
+/** Single message — one upright card, no fan. The `×` is the only dismiss. */
+export const Single: Story = {
+  args: { count: 1 },
+};
+
+/** Three messages — front card upright, two cards fanned behind with ±2° tilts. */
+export const Three: Story = {
+  args: { count: 3 },
+};
+
+/** Deep pile — 6+ cards fanned via the alternating ±1–3° rotation table. */
+export const Deep: Story = {
+  args: { count: SAMPLES.length },
+};
+
+/** A short queued message paired with an attachment count, surfaced as +N on the front card. */
+export const WithAttachments: Story = {
+  args: { count: 2 },
+  render: () => {
+    const el = document.createElement('slicc-queued-stack');
+    el.setMessages([
+      { id: 'a-1', text: 'Use these references for the warm palette study.' },
+      {
+        id: 'a-2',
+        text: 'Tighten the meta row hint, attaching the prototype screenshot.',
+        attachments: 2,
+      },
+    ]);
+    return inBand(el);
+  },
+};
+
+/**
+ * In-composer placement — the stack pinned above the `<slicc-input-card>` inside
+ * a real `<slicc-composer>`. Matches the design intent: queued messages perch
+ * directly over the composer's input card so the user sees the agent's backlog
+ * exactly where the next message will be sent.
+ */
+export const InComposer: Story = {
+  args: { count: 3 },
+  render: ({ count }) => {
+    const shell = document.createElement('div');
+    shell.style.cssText =
+      'display:flex;flex-direction:column;height:480px;width:100%;background:var(--bg);' +
+      'overflow:hidden;font-family:var(--ui);';
+
+    const thread = document.createElement('div');
+    thread.style.cssText =
+      'flex:1 1 auto;overflow:hidden;padding:28px 24px;color:var(--txt-2);font-size:14px;line-height:1.5;';
+    const intro = document.createElement('p');
+    intro.style.margin = '0 0 12px';
+    intro.style.color = 'var(--ink)';
+    intro.textContent = 'Make the landing hero feel warmer.';
+    const reply = document.createElement('p');
+    reply.style.margin = '0';
+    reply.textContent =
+      'Working through the queue below — these lines are pinned above the input card.';
+    thread.append(intro, reply);
+
+    const composer = document.createElement('slicc-composer');
+    const stack = buildStack(count);
+    const card = document.createElement('slicc-input-card');
+    card.setAttribute('placeholder', 'Ask sliccy…');
+    const addMenu = document.createElement('slicc-add-menu');
+    addMenu.setAttribute('slot', 'toolbar');
+    const spacer = document.createElement('div');
+    spacer.setAttribute('slot', 'toolbar');
+    spacer.style.flex = '1';
+    const send = document.createElement('slicc-send-button');
+    send.setAttribute('slot', 'toolbar');
+    card.append(addMenu, spacer, send);
+
+    const metaRow = document.createElement('slicc-composer-meta');
+    metaRow.setAttribute('model', 'Opus 4.8');
+    metaRow.setAttribute('thinking', 'max');
+
+    composer.append(stack, card, metaRow);
+    shell.append(thread, composer);
+    return shell;
+  },
+};

--- a/packages/webcomponents/src/composer/slicc-queued-stack.stories.ts
+++ b/packages/webcomponents/src/composer/slicc-queued-stack.stories.ts
@@ -142,7 +142,12 @@ export const InComposer: Story = {
     const stack = buildStack(count);
     // Pull the stack down so most of the front card tucks under the input
     // card — only the top of the pile peeks above into the chat area.
+    // `minHeight` guarantees the badge + a sliver of the front card stay
+    // visible above the overlap even when the front card is a single short
+    // line (otherwise a ~41px card would leave only ~9px peeking above the
+    // 32px tuck and disappear behind the textarea).
     stack.style.marginBottom = '-32px';
+    stack.style.minHeight = '76px';
     // The stack's `.stack` grid is `position: relative` (so its cards can
     // grid-overlap), which makes it a positioned element. Positioned
     // siblings paint above static ones regardless of DOM order, so without

--- a/packages/webcomponents/src/composer/slicc-queued-stack.stories.ts
+++ b/packages/webcomponents/src/composer/slicc-queued-stack.stories.ts
@@ -4,6 +4,7 @@ import '../primitives/slicc-send-button.js';
 import './slicc-composer-meta.js';
 import './slicc-composer.js';
 import './slicc-input-card.js';
+import './slicc-queued-stack.js';
 import type { QueuedMessage, SliccQueuedStack } from './slicc-queued-stack.js';
 
 interface StackArgs {
@@ -100,10 +101,17 @@ export const WithAttachments: Story = {
 };
 
 /**
- * In-composer placement — the stack pinned above the `<slicc-input-card>` inside
- * a real `<slicc-composer>`. Matches the design intent: queued messages perch
- * directly over the composer's input card so the user sees the agent's backlog
- * exactly where the next message will be sent.
+ * In-composer placement — the stack tucks BEHIND the `<slicc-input-card>`
+ * inside a real `<slicc-composer>`: the bottom of the front card slips under
+ * the opaque white input card (negative bottom margin pulls them into
+ * overlap, and an explicit `position: relative; z-index: 1` on the input
+ * card lifts it above the stack's positioned `.stack` grid — which would
+ * otherwise paint atop a static sibling regardless of DOM order). The
+ * composer's frosted band extends upward to wrap the visible top of the
+ * pile, even nudging slightly into the chat thread above (small negative
+ * top margin). Matches the design intent: the stack appears to grow out of
+ * the composer rather than float as a separate band, with only its top
+ * peeking up above the input card.
  */
 export const InComposer: Story = {
   args: { count: 3 },
@@ -127,9 +135,29 @@ export const InComposer: Story = {
     thread.append(intro, reply);
 
     const composer = document.createElement('slicc-composer');
+    // Let the composer's frosted band creep up into the chat thread above so
+    // it visually wraps the top of the pile rather than floating as a band.
+    composer.style.marginTop = '-12px';
+
     const stack = buildStack(count);
+    // Pull the stack down so most of the front card tucks under the input
+    // card — only the top of the pile peeks above into the chat area.
+    stack.style.marginBottom = '-32px';
+    // The stack's `.stack` grid is `position: relative` (so its cards can
+    // grid-overlap), which makes it a positioned element. Positioned
+    // siblings paint above static ones regardless of DOM order, so without
+    // an explicit stacking context here the stack would draw OVER the
+    // input card. Pin it to z-index 0 so the input card's z-index 1 wins.
+    stack.style.position = 'relative';
+    stack.style.zIndex = '0';
+
     const card = document.createElement('slicc-input-card');
     card.setAttribute('placeholder', 'Ask sliccy…');
+    // Lift the opaque white input card above the queued stack so its
+    // background hides the bottom edge of the front card (and the box
+    // shadow reads cleanly against the chat thread below the cut line).
+    card.style.position = 'relative';
+    card.style.zIndex = '1';
     const addMenu = document.createElement('slicc-add-menu');
     addMenu.setAttribute('slot', 'toolbar');
     const spacer = document.createElement('div');

--- a/packages/webcomponents/src/composer/slicc-queued-stack.ts
+++ b/packages/webcomponents/src/composer/slicc-queued-stack.ts
@@ -20,16 +20,21 @@ export interface QueuedMessage {
  * the lucide `clock` glyph for the count badge, and the 0.62 dim on dimmed
  * cards. Cards stack with CSS grid (`grid-template-areas: 'card'`) so they all
  * occupy the same cell and the front card defines the container's height;
- * layering is z-index only.
+ * layering is z-index only. The badge sits at the top-left of the wrap, above
+ * the pile, so the stack can grow upward out of the composer band beneath it.
+ * `.stack` is `isolation: isolate` so the per-card z-indices stay scoped and
+ * don't compete with the composer's input card stacked below the stack.
+ * `.card` rotates about its center (not a corner) so the back cards read as a
+ * loosely stacked pile of paper rather than a hand-held fan.
  */
 const STYLE = `
 :host{display:block;font-family:var(--ui);}
 :host(:not([count])),:host([count="0"]),:host([count="-0"]){display:none;}
-.wrap{display:flex;flex-direction:column;align-items:flex-end;gap:6px;}
-.badge{display:inline-flex;align-items:center;gap:4px;font-size:10.5px;color:var(--txt-3);}
+.wrap{display:flex;flex-direction:column;align-items:stretch;gap:6px;}
+.badge{display:inline-flex;align-self:flex-start;align-items:center;gap:4px;font-size:10.5px;color:var(--txt-3);}
 .badge svg{display:block;}
-.stack{position:relative;display:grid;grid-template-areas:"card";align-self:stretch;justify-items:end;}
-.card{grid-area:card;display:flex;align-items:flex-start;gap:8px;box-sizing:border-box;max-width:80%;background:var(--deep);color:#fff;padding:10px 14px;border-radius:16px 16px 4px 16px;font-size:14px;line-height:1.5;transform-origin:bottom right;will-change:transform;}
+.stack{position:relative;display:grid;grid-template-areas:"card";align-self:stretch;justify-items:end;isolation:isolate;}
+.card{grid-area:card;display:flex;align-items:flex-start;gap:8px;box-sizing:border-box;max-width:80%;background:var(--deep);color:#fff;padding:10px 14px;border-radius:16px 16px 4px 16px;font-size:14px;line-height:1.5;transform-origin:center;will-change:transform;}
 .card.is-back{opacity:.62;}
 .card.is-deep{opacity:.45;}
 .bubble{flex:1 1 auto;min-width:0;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden;text-overflow:ellipsis;word-break:break-word;}
@@ -186,7 +191,7 @@ export class SliccQueuedStack extends HTMLElement {
       iconEl('clock', { size: 11 }),
       `${total} queued`
     );
-    const wrap = h('div', { class: 'wrap' }, stack, badge);
+    const wrap = h('div', { class: 'wrap' }, badge, stack);
     this.#root.replaceChildren(wrap);
   }
 }

--- a/packages/webcomponents/src/composer/slicc-queued-stack.ts
+++ b/packages/webcomponents/src/composer/slicc-queued-stack.ts
@@ -1,0 +1,200 @@
+import { define } from '../internal/define.js';
+import { h, sheet } from '../internal/dom.js';
+import { iconEl } from '../internal/icons.js';
+
+/**
+ * One queued message — host-supplied. The list is owned by the host; the
+ * component only renders. The most-recently-enqueued item is the **last** in
+ * the array (it becomes the front/top card).
+ */
+export interface QueuedMessage {
+  id: string;
+  text: string;
+  /** Optional attachment count — shown as a small "+N" hint on the front card. */
+  attachments?: number;
+}
+
+/**
+ * Visual lifted from `slicc-user-message`'s queued state: the `--deep` bubble
+ * ground with white text (dark mode flips text to `#0a0a0a` via `:host-context`),
+ * the lucide `clock` glyph for the count badge, and the 0.62 dim on dimmed
+ * cards. Cards stack with CSS grid (`grid-template-areas: 'card'`) so they all
+ * occupy the same cell and the front card defines the container's height;
+ * layering is z-index only.
+ */
+const STYLE = `
+:host{display:block;font-family:var(--ui);}
+:host(:not([count])),:host([count="0"]),:host([count="-0"]){display:none;}
+.wrap{display:flex;flex-direction:column;align-items:flex-end;gap:6px;}
+.badge{display:inline-flex;align-items:center;gap:4px;font-size:10.5px;color:var(--txt-3);}
+.badge svg{display:block;}
+.stack{position:relative;display:grid;grid-template-areas:"card";align-self:stretch;justify-items:end;}
+.card{grid-area:card;display:flex;align-items:flex-start;gap:8px;box-sizing:border-box;max-width:80%;background:var(--deep);color:#fff;padding:10px 14px;border-radius:16px 16px 4px 16px;font-size:14px;line-height:1.5;transform-origin:bottom right;will-change:transform;}
+.card.is-back{opacity:.62;}
+.card.is-deep{opacity:.45;}
+.bubble{flex:1 1 auto;min-width:0;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden;text-overflow:ellipsis;word-break:break-word;}
+.attach{flex:0 0 auto;font-size:11px;opacity:.78;align-self:center;font-family:var(--mono);}
+.dismiss{flex:0 0 auto;align-self:flex-start;display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border:none;background:transparent;color:inherit;border-radius:50%;cursor:pointer;padding:0;margin:-2px -4px -2px 0;opacity:.78;}
+.dismiss:hover,.dismiss:focus-visible{opacity:1;background:color-mix(in srgb,#fff 14%,transparent);outline:none;}
+.dismiss svg{display:block;}
+:host-context(body.dark) .card,
+:host-context(.dark) .card,
+:host-context([data-theme="dark"]) .card{color:#0a0a0a;}
+:host-context(body.dark) .dismiss:hover,:host-context(body.dark) .dismiss:focus-visible,
+:host-context(.dark) .dismiss:hover,:host-context(.dark) .dismiss:focus-visible,
+:host-context([data-theme="dark"]) .dismiss:hover,:host-context([data-theme="dark"]) .dismiss:focus-visible{background:color-mix(in srgb,#0a0a0a 14%,transparent);}
+`;
+const SHEET = sheet(STYLE);
+
+/**
+ * Deterministic per-depth transform table for the rotated pile — depth 0 is
+ * the front (no rotation/offset, fully legible); deeper cards alternate
+ * ±1–3° with small x/y offsets so the pile fans out behind the front card.
+ */
+const TILT: ReadonlyArray<{ rot: number; x: number; y: number }> = [
+  { rot: 0, x: 0, y: 0 },
+  { rot: -2, x: -3, y: -2 },
+  { rot: 2, x: 3, y: -4 },
+  { rot: -3, x: -5, y: -6 },
+  { rot: 3, x: 5, y: -8 },
+  { rot: -1, x: -2, y: -10 },
+  { rot: 1, x: 2, y: -12 },
+];
+
+/** Pick the depth-th tilt; deeper than the table simply reuses the deepest entry. */
+function tiltFor(depth: number): { rot: number; x: number; y: number } {
+  return TILT[Math.min(depth, TILT.length - 1)] ?? TILT[0];
+}
+
+/**
+ * `<slicc-queued-stack>` — renders a host-owned list of queued messages as a
+ * slightly-rotated pile of cards pinned above the composer's input card. The
+ * most-recently-enqueued message (the **last** item in the list) is the front
+ * card: upright, legible, and the only card with a `×` dismiss button. Older
+ * cards fan behind it via z-index plus alternating ±1–3° rotations and small
+ * offsets, and are dimmed. The cap is none — N items render N cards.
+ *
+ * The component is purely presentational: it does not mutate its own list. The
+ * dismiss button fires a composed + bubbling `slicc-queued-remove` `CustomEvent`
+ * carrying `detail.id` so the host can dequeue. The visual language (the
+ * `clock` count badge, the `--deep` bubble, dark-mode `:host-context` flips) is
+ * lifted from `slicc-user-message[queued]` so the stack feels native.
+ *
+ * @attr count - reflected message count (set by `setMessages`); when missing
+ *   or `0` the host renders nothing (`display: none`).
+ * @csspart stack - the grid container holding all cards.
+ * @csspart card - any card (back or front).
+ * @csspart front - the front-most card (highest z-index, upright, legible).
+ * @csspart badge - the "N queued" count badge with the clock icon.
+ * @csspart dismiss - the `×` button on the front card.
+ * @fires slicc-queued-remove - `CustomEvent<{ id: string }>` (composed, bubbles)
+ *   when the front card's `×` is activated; the component does not dequeue.
+ */
+export class SliccQueuedStack extends HTMLElement {
+  readonly #root: ShadowRoot;
+  #items: ReadonlyArray<QueuedMessage> = [];
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.adoptedStyleSheets = [SHEET];
+  }
+
+  connectedCallback(): void {
+    this.#render();
+  }
+
+  /** Current message count (mirrors the reflected `count` attribute). */
+  get count(): number {
+    return this.#items.length;
+  }
+
+  /**
+   * Replace the rendered list. The host owns the queue; this component only
+   * renders. The newest item is the **last** in the array — it becomes the
+   * front card. Reflects the length to the `count` attribute and re-renders.
+   */
+  setMessages(items: ReadonlyArray<QueuedMessage>): void {
+    this.#items = items.slice();
+    this.setAttribute('count', String(this.#items.length));
+    this.#render();
+  }
+
+  #onDismiss(id: string): void {
+    this.dispatchEvent(
+      new CustomEvent<{ id: string }>('slicc-queued-remove', {
+        detail: { id },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  #renderCard(item: QueuedMessage, depth: number, isFront: boolean, zIndex: number): HTMLElement {
+    const { rot, x, y } = tiltFor(depth);
+    const transform = isFront ? 'none' : `translate(${x}px, ${y}px) rotate(${rot}deg)`;
+    const dim = depth === 0 ? '' : depth === 1 ? ' is-back' : ' is-deep';
+    const cls = `card${isFront ? ' is-front' : ''}${dim}`;
+    const part = isFront ? 'card front' : 'card';
+    const style = `transform:${transform};z-index:${zIndex};`;
+    const children: Array<Node | string> = [h('span', { class: 'bubble' }, item.text)];
+    if (item.attachments && item.attachments > 0) {
+      children.push(h('span', { class: 'attach' }, `+${item.attachments}`));
+    }
+    if (isFront) {
+      const btn = h(
+        'button',
+        {
+          type: 'button',
+          class: 'dismiss',
+          part: 'dismiss',
+          'aria-label': 'Remove queued message',
+        },
+        iconEl('x', { size: 14 })
+      ) as HTMLButtonElement;
+      btn.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        this.#onDismiss(item.id);
+      });
+      children.push(btn);
+    }
+    return h('div', { class: cls, part, style }, ...children);
+  }
+
+  #render(): void {
+    if (this.#items.length === 0) {
+      this.#root.replaceChildren();
+      return;
+    }
+    const total = this.#items.length;
+    // Render order doesn't matter for stacking (z-index does), but iterate
+    // newest-first so the front card is the first child — handy for `:first-child`
+    // selectors and stable test assertions like `querySelector('.card.is-front')`.
+    const cards: HTMLElement[] = [];
+    for (let i = total - 1; i >= 0; i--) {
+      const depth = total - 1 - i;
+      const isFront = depth === 0;
+      const zIndex = i + 1;
+      const item = this.#items[i];
+      if (!item) continue;
+      cards.push(this.#renderCard(item, depth, isFront, zIndex));
+    }
+    const stack = h('div', { class: 'stack', part: 'stack' }, ...cards);
+    const badge = h(
+      'span',
+      { class: 'badge', part: 'badge' },
+      iconEl('clock', { size: 11 }),
+      `${total} queued`
+    );
+    const wrap = h('div', { class: 'wrap' }, stack, badge);
+    this.#root.replaceChildren(wrap);
+  }
+}
+
+define('slicc-queued-stack', SliccQueuedStack);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'slicc-queued-stack': SliccQueuedStack;
+  }
+}

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -23,6 +23,7 @@ export { SliccUserMessage } from './chat/slicc-user-message.js';
 export { HOLD_TO_ENABLE_MS, SliccComposer } from './composer/slicc-composer.js';
 export { SliccComposerMeta } from './composer/slicc-composer-meta.js';
 export { SliccInputCard } from './composer/slicc-input-card.js';
+export { type QueuedMessage, SliccQueuedStack } from './composer/slicc-queued-stack.js';
 export {
   type ComposerSpeech,
   createBuiltinComposerSpeech,

--- a/packages/webcomponents/src/register.ts
+++ b/packages/webcomponents/src/register.ts
@@ -16,6 +16,7 @@ import './chat/slicc-user-message.js';
 import './composer/slicc-composer-meta.js';
 import './composer/slicc-composer.js';
 import './composer/slicc-input-card.js';
+import './composer/slicc-queued-stack.js';
 import './dock/slicc-dock-item.js';
 import './dock/slicc-dock.js';
 import './dock/slicc-tab-overlay.js';

--- a/packages/webcomponents/tests/composer/slicc-queued-stack.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-queued-stack.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type QueuedMessage, SliccQueuedStack } from '../../src/composer/slicc-queued-stack.js';
+import { ensureGlobalTokens } from '../../src/theme/tokens.js';
+
+function mount(): SliccQueuedStack {
+  const el = document.createElement('slicc-queued-stack');
+  document.body.appendChild(el);
+  return el;
+}
+
+function items(n: number): QueuedMessage[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `m-${i + 1}`,
+    text: `message ${i + 1}`,
+  }));
+}
+
+describe('slicc-queued-stack', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    document.body.replaceChildren();
+    document.body.classList.remove('dark');
+    document.body.removeAttribute('data-theme');
+  });
+
+  it('registers the custom element', () => {
+    expect(customElements.get('slicc-queued-stack')).toBe(SliccQueuedStack);
+  });
+
+  it('renders nothing for an empty queue', () => {
+    const el = mount();
+    el.setMessages([]);
+    expect(el.shadowRoot?.children.length).toBe(0);
+    expect(el.getAttribute('count')).toBe('0');
+    expect(getComputedStyle(el).display).toBe('none');
+  });
+
+  it('renders nothing when no `count` attribute is set (initial mount)', () => {
+    const el = mount();
+    expect(el.hasAttribute('count')).toBe(false);
+    expect(getComputedStyle(el).display).toBe('none');
+  });
+
+  it('reflects the message count to the `count` attribute', () => {
+    const el = mount();
+    el.setMessages(items(4));
+    expect(el.getAttribute('count')).toBe('4');
+    expect(el.count).toBe(4);
+  });
+
+  it('renders one card per item — N items → N cards', () => {
+    const el = mount();
+    el.setMessages(items(5));
+    const cards = el.shadowRoot?.querySelectorAll('.card');
+    expect(cards?.length).toBe(5);
+  });
+
+  it('puts the most-recently-enqueued item at the front (highest z-index, upright)', () => {
+    const el = mount();
+    el.setMessages(items(3));
+    const front = el.shadowRoot?.querySelector('.card.is-front') as HTMLElement;
+    expect(front).not.toBeNull();
+    // The front card carries both `card` and `front` part hooks.
+    expect(front.getAttribute('part')).toBe('card front');
+    // The front bubble contents are the LAST item's text — "message 3".
+    expect(front.querySelector('.bubble')?.textContent).toBe('message 3');
+    // The front card's z-index is the largest (equals the item count).
+    expect(Number(front.style.zIndex)).toBe(3);
+    // And no rotation/offset — the front card must read upright.
+    expect(front.style.transform).toBe('none');
+  });
+
+  it('renders the badge with a clock icon and "N queued" label', () => {
+    const el = mount();
+    el.setMessages(items(4));
+    const badge = el.shadowRoot?.querySelector('[part="badge"]') as HTMLElement;
+    expect(badge).not.toBeNull();
+    expect(badge.querySelector('svg')).toBeTruthy();
+    expect(badge.textContent).toContain('4 queued');
+  });
+
+  it('exposes ::part hooks on stack, card, front, badge, dismiss', () => {
+    const el = mount();
+    el.setMessages(items(2));
+    const root = el.shadowRoot as ShadowRoot;
+    expect(root.querySelector('[part="stack"]')).not.toBeNull();
+    expect(root.querySelector('[part~="card"]')).not.toBeNull();
+    expect(root.querySelector('[part~="front"]')).not.toBeNull();
+    expect(root.querySelector('[part="badge"]')).not.toBeNull();
+    expect(root.querySelector('[part="dismiss"]')).not.toBeNull();
+  });
+
+  it('renders the × dismiss button only on the front card', () => {
+    const el = mount();
+    el.setMessages(items(3));
+    const buttons = el.shadowRoot?.querySelectorAll('.dismiss');
+    expect(buttons?.length).toBe(1);
+    const front = el.shadowRoot?.querySelector('.card.is-front');
+    expect(front?.querySelector('.dismiss')).not.toBeNull();
+  });
+
+  it('fires slicc-queued-remove with detail.id of the FRONT (newest) item', () => {
+    const el = mount();
+    el.setMessages(items(3));
+    const spy = vi.fn();
+    el.addEventListener('slicc-queued-remove', spy as EventListener);
+    const btn = el.shadowRoot?.querySelector('.dismiss') as HTMLButtonElement;
+    btn.click();
+    expect(spy).toHaveBeenCalledTimes(1);
+    const ev = spy.mock.calls[0][0] as CustomEvent<{ id: string }>;
+    expect(ev.detail).toEqual({ id: 'm-3' });
+    expect(ev.bubbles).toBe(true);
+    expect(ev.composed).toBe(true);
+  });
+
+  it('does NOT mutate its own list when dismiss fires (host owns dequeue)', () => {
+    const el = mount();
+    el.setMessages(items(3));
+    const btn = el.shadowRoot?.querySelector('.dismiss') as HTMLButtonElement;
+    btn.click();
+    // Still 3 cards — the host is responsible for calling setMessages again.
+    expect(el.shadowRoot?.querySelectorAll('.card').length).toBe(3);
+    expect(el.count).toBe(3);
+    expect(el.getAttribute('count')).toBe('3');
+  });
+
+  it('applies alternating ±1–3° tilts and small offsets to back cards', () => {
+    const el = mount();
+    el.setMessages(items(4));
+    const backs = el.shadowRoot?.querySelectorAll(
+      '.card:not(.is-front)'
+    ) as NodeListOf<HTMLElement>;
+    expect(backs.length).toBe(3);
+    for (const back of backs) {
+      expect(back.style.transform).toMatch(/translate\(-?\d+px, -?\d+px\) rotate\(-?[1-3]deg\)/);
+    }
+  });
+
+  it('replaces the rendered list on a subsequent setMessages call', () => {
+    const el = mount();
+    el.setMessages(items(5));
+    el.setMessages(items(2));
+    expect(el.shadowRoot?.querySelectorAll('.card').length).toBe(2);
+    expect(el.getAttribute('count')).toBe('2');
+    el.setMessages([]);
+    expect(el.shadowRoot?.children.length).toBe(0);
+    expect(el.getAttribute('count')).toBe('0');
+  });
+
+  it('renders the optional +N attachment hint on a card', () => {
+    const el = mount();
+    el.setMessages([{ id: 'm-1', text: 'with files', attachments: 3 }]);
+    const attach = el.shadowRoot?.querySelector('.attach') as HTMLElement;
+    expect(attach?.textContent).toBe('+3');
+  });
+});

--- a/packages/webcomponents/tests/composer/slicc-queued-stack.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-queued-stack.test.ts
@@ -79,6 +79,31 @@ describe('slicc-queued-stack', () => {
     expect(badge.textContent).toContain('4 queued');
   });
 
+  it('places the badge above the stack in the shadow DOM (badge then stack)', () => {
+    const el = mount();
+    el.setMessages(items(3));
+    const root = el.shadowRoot as ShadowRoot;
+    const badge = root.querySelector('[part="badge"]') as HTMLElement;
+    const stack = root.querySelector('[part="stack"]') as HTMLElement;
+    expect(badge).not.toBeNull();
+    expect(stack).not.toBeNull();
+    // The badge must be the first child of `.wrap` so it sits at the top-left
+    // above the pile (the pile then grows upward out of the composer band).
+    expect(badge.parentElement).toBe(stack.parentElement);
+    const order = badge.compareDocumentPosition(stack);
+    // DOCUMENT_POSITION_FOLLOWING === 4 — stack comes AFTER badge.
+    expect(order & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('isolates the stack so its per-card z-indices do not leak to siblings', () => {
+    const el = mount();
+    el.setMessages(items(3));
+    const stack = el.shadowRoot?.querySelector('[part="stack"]') as HTMLElement;
+    // `isolation: isolate` creates a stacking context so the cards' positive
+    // z-indices cannot float above the composer's input card layered beneath.
+    expect(getComputedStyle(stack).isolation).toBe('isolate');
+  });
+
   it('exposes ::part hooks on stack, card, front, badge, dismiss', () => {
     const el = mount();
     el.setMessages(items(2));


### PR DESCRIPTION
Replaces the misleading inline rendering of queued messages with a pile-of-paper stack above the composer. New slicc-queued-stack web component (Storybook-first) wired into the live WC composer in both floats. Busy submits park in the stack (still delivered immediately), flush into the thread as plain bubbles on the consuming turn (flush rides the setProcessing rising edge so it works in the live float), and the dismiss x cancels delivery via a new deleteQueuedMessage path through OffscreenBridge. Removed the inline queued bubble render path. Full TS suites green plus new coverage (live-ordering regression, bridge dispatch, facade parity, DOM/style regressions); lint, typecheck, build, and extension build pass; manually verified on the standalone dev server.