### PR TITLE
feat(webcomponents): add tunable brightness/contrast/noise/blur to cone shader

### DIFF
--- a/packages/webcomponents/src/freezer/slicc-shader.stories.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.stories.ts
@@ -51,10 +51,10 @@ export const Cone: Story = {
     mode: 'cone',
     tint: '#b07823',
     coverage: 0.66,
-    brightness: 1,
-    contrast: 1,
-    noise: 0,
-    blur: 0,
+    brightness: 1.2,
+    contrast: 0.75,
+    noise: 0.04,
+    blur: 0.09,
   },
 };
 /** Scoop — the flowing ice-cream swirl, tinted to the active scoop accent. */

--- a/packages/webcomponents/src/freezer/slicc-shader.stories.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.stories.ts
@@ -5,6 +5,10 @@ interface ShaderArgs {
   mode: 'cone' | 'scoop' | 'freezer';
   tint: string;
   coverage: number;
+  brightness: number;
+  contrast: number;
+  noise: number;
+  blur: number;
 }
 
 const meta: Meta<ShaderArgs> = {
@@ -15,8 +19,12 @@ const meta: Meta<ShaderArgs> = {
     mode: { control: 'inline-radio', options: ['cone', 'scoop', 'freezer'] },
     tint: { control: 'color' },
     coverage: { control: { type: 'range', min: 0, max: 1, step: 0.05 } },
+    brightness: { control: { type: 'range', min: 0.5, max: 1.5, step: 0.01 } },
+    contrast: { control: { type: 'range', min: 0.5, max: 2, step: 0.01 } },
+    noise: { control: { type: 'range', min: 0, max: 0.3, step: 0.01 } },
+    blur: { control: { type: 'range', min: 0, max: 1, step: 0.01 } },
   },
-  render: ({ mode, tint, coverage }) => {
+  render: ({ mode, tint, coverage, brightness, contrast, noise, blur }) => {
     const box = document.createElement('div');
     box.style.cssText =
       'position:relative;width:520px;height:320px;border-radius:14px;overflow:hidden;border:1px solid var(--line);background:var(--bg);';
@@ -25,6 +33,10 @@ const meta: Meta<ShaderArgs> = {
     s.setAttribute('mode', mode);
     if (tint) s.setAttribute('tint', tint);
     if (coverage != null) s.setAttribute('coverage', String(coverage));
+    if (brightness != null) s.setAttribute('brightness', String(brightness));
+    if (contrast != null) s.setAttribute('contrast', String(contrast));
+    if (noise != null) s.setAttribute('noise', String(noise));
+    if (blur != null) s.setAttribute('blur', String(blur));
     box.appendChild(s);
     return box;
   },
@@ -34,8 +46,38 @@ export default meta;
 type Story = StoryObj<ShaderArgs>;
 
 /** Cone — the sheared waffle lattice behind the cone/chat context. */
-export const Cone: Story = { args: { mode: 'cone', tint: '#b07823', coverage: 0.66 } };
+export const Cone: Story = {
+  args: {
+    mode: 'cone',
+    tint: '#b07823',
+    coverage: 0.66,
+    brightness: 1,
+    contrast: 1,
+    noise: 0,
+    blur: 0,
+  },
+};
 /** Scoop — the flowing ice-cream swirl, tinted to the active scoop accent. */
-export const Scoop: Story = { args: { mode: 'scoop', tint: '#f43f5e', coverage: 0.66 } };
+export const Scoop: Story = {
+  args: {
+    mode: 'scoop',
+    tint: '#f43f5e',
+    coverage: 0.66,
+    brightness: 1,
+    contrast: 1,
+    noise: 0,
+    blur: 0,
+  },
+};
 /** Freezer — frost crystallizing from the corner. */
-export const Freezer: Story = { args: { mode: 'freezer', tint: '#3b6cb2', coverage: 0.85 } };
+export const Freezer: Story = {
+  args: {
+    mode: 'freezer',
+    tint: '#3b6cb2',
+    coverage: 0.85,
+    brightness: 1,
+    contrast: 1,
+    noise: 0,
+    blur: 0,
+  },
+};

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -83,8 +83,9 @@ void main(){
   col+=u_evt*u_energy*stroke*exp(-dist*dist*4.0)*0.18;
   /* Cone-only post: a noise/grain layer whose sample frequency is driven by
      u_blur (high blur => low frequency / soft, low blur => sharp grain), then
-     contrast around 0.5 and brightness as a multiplier. Defaults are identity:
-     u_noise=0 zeroes the grain, u_contrast=1 and u_brightness=1 pass col through. */
+     contrast around 0.5 and brightness as a multiplier. The JS getters bake in
+     tuned defaults (brightness=1.2, contrast=0.75, noise=0.04, blur=0.09); at
+     the shader level the identity is still u_noise=0, u_contrast=1, u_brightness=1. */
   float noiseFreq=mix(80.0,4.0,clamp(u_blur,0.0,1.0));
   float grain=fbm(uv*noiseFreq)-0.5;
   col+=u_noise*grain;
@@ -322,25 +323,25 @@ export class SliccShader extends HTMLElement {
     this.setAttribute('scroll', String(value));
   }
 
-  /** Cone-mode multiplier on final color (identity = 1). */
+  /** Cone-mode multiplier on final color (tuned default = 1.2). */
   get brightness(): number {
-    return clampNum(Number.parseFloat(this.getAttribute('brightness') ?? ''), 0.5, 1.5, 1);
+    return clampNum(Number.parseFloat(this.getAttribute('brightness') ?? ''), 0.5, 1.5, 1.2);
   }
   set brightness(value: number) {
     this.setAttribute('brightness', String(value));
   }
 
-  /** Cone-mode contrast around a 0.5 pivot (identity = 1). */
+  /** Cone-mode contrast around a 0.5 pivot (tuned default = 0.75). */
   get contrast(): number {
-    return clampNum(Number.parseFloat(this.getAttribute('contrast') ?? ''), 0.5, 2, 1);
+    return clampNum(Number.parseFloat(this.getAttribute('contrast') ?? ''), 0.5, 2, 0.75);
   }
   set contrast(value: number) {
     this.setAttribute('contrast', String(value));
   }
 
-  /** Cone-mode grain amount added to the final color (identity = 0). */
+  /** Cone-mode grain amount added to the final color (tuned default = 0.04). */
   get noise(): number {
-    return clampNum(Number.parseFloat(this.getAttribute('noise') ?? ''), 0, 0.3, 0);
+    return clampNum(Number.parseFloat(this.getAttribute('noise') ?? ''), 0, 0.3, 0.04);
   }
   set noise(value: number) {
     this.setAttribute('noise', String(value));
@@ -349,10 +350,10 @@ export class SliccShader extends HTMLElement {
   /**
    * Cone-mode blur of the noise layer only (0 = sharp grain, 1 = soft).
    * Reflects the `blur` attribute; named `blurAmount` because `HTMLElement`
-   * already defines a `blur()` method.
+   * already defines a `blur()` method. Tuned default = 0.09.
    */
   get blurAmount(): number {
-    return clampNum(Number.parseFloat(this.getAttribute('blur') ?? ''), 0, 1, 0);
+    return clampNum(Number.parseFloat(this.getAttribute('blur') ?? ''), 0, 1, 0.09);
   }
   set blurAmount(value: number) {
     this.setAttribute('blur', String(value));

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -34,6 +34,7 @@ uniform vec2 u_res; uniform float u_time; uniform float u_energy;
 uniform vec2 u_center; uniform vec3 u_evt; uniform float u_freeze; uniform float u_dark;
 uniform float u_density; uniform float u_falloff; uniform float u_life;
 uniform float u_blink; uniform float u_thick; uniform vec3 u_tint; uniform float u_scroll;
+uniform float u_brightness; uniform float u_contrast; uniform float u_noise; uniform float u_blur;
 vec3 themeBg(){ return mix(vec3(0.97,0.95,0.89), vec3(0.09,0.08,0.06), u_dark); }`;
 
 const NOISE = `
@@ -80,6 +81,16 @@ void main(){
   // the light bg in light mode, toward the dark bg in dark mode.
   vec3 col=mix(bg,tint,clamp(stroke*0.20,0.0,0.20));
   col+=u_evt*u_energy*stroke*exp(-dist*dist*4.0)*0.18;
+  /* Cone-only post: a noise/grain layer whose sample frequency is driven by
+     u_blur (high blur => low frequency / soft, low blur => sharp grain), then
+     contrast around 0.5 and brightness as a multiplier. Defaults are identity:
+     u_noise=0 zeroes the grain, u_contrast=1 and u_brightness=1 pass col through. */
+  float noiseFreq=mix(80.0,4.0,clamp(u_blur,0.0,1.0));
+  float grain=fbm(uv*noiseFreq)-0.5;
+  col+=u_noise*grain;
+  col=(col-0.5)*u_contrast+0.5;
+  col*=u_brightness;
+  col=clamp(col,0.0,1.0);
   gl_FragColor=vec4(col,1.0);
 }`;
 
@@ -178,6 +189,10 @@ const UNIFORMS = [
   'u_blink',
   'u_thick',
   'u_tint',
+  'u_brightness',
+  'u_contrast',
+  'u_noise',
+  'u_blur',
 ] as const;
 type UniformName = (typeof UNIFORMS)[number];
 
@@ -200,7 +215,17 @@ function colorToVec3(css: string, fallback: [number, number, number]): [number, 
 }
 
 export class SliccShader extends HTMLElement {
-  static readonly observedAttributes = ['mode', 'tint', 'coverage', 'intensity', 'scroll'];
+  static readonly observedAttributes = [
+    'mode',
+    'tint',
+    'coverage',
+    'intensity',
+    'scroll',
+    'brightness',
+    'contrast',
+    'noise',
+    'blur',
+  ];
 
   readonly #root: ShadowRoot;
   #canvas: HTMLCanvasElement | null = null;
@@ -295,6 +320,42 @@ export class SliccShader extends HTMLElement {
   }
   set scrollOffset(value: number) {
     this.setAttribute('scroll', String(value));
+  }
+
+  /** Cone-mode multiplier on final color (identity = 1). */
+  get brightness(): number {
+    return clampNum(Number.parseFloat(this.getAttribute('brightness') ?? ''), 0.5, 1.5, 1);
+  }
+  set brightness(value: number) {
+    this.setAttribute('brightness', String(value));
+  }
+
+  /** Cone-mode contrast around a 0.5 pivot (identity = 1). */
+  get contrast(): number {
+    return clampNum(Number.parseFloat(this.getAttribute('contrast') ?? ''), 0.5, 2, 1);
+  }
+  set contrast(value: number) {
+    this.setAttribute('contrast', String(value));
+  }
+
+  /** Cone-mode grain amount added to the final color (identity = 0). */
+  get noise(): number {
+    return clampNum(Number.parseFloat(this.getAttribute('noise') ?? ''), 0, 0.3, 0);
+  }
+  set noise(value: number) {
+    this.setAttribute('noise', String(value));
+  }
+
+  /**
+   * Cone-mode blur of the noise layer only (0 = sharp grain, 1 = soft).
+   * Reflects the `blur` attribute; named `blurAmount` because `HTMLElement`
+   * already defines a `blur()` method.
+   */
+  get blurAmount(): number {
+    return clampNum(Number.parseFloat(this.getAttribute('blur') ?? ''), 0, 1, 0);
+  }
+  set blurAmount(value: number) {
+    this.setAttribute('blur', String(value));
   }
 
   get noWebgl(): boolean {
@@ -449,6 +510,10 @@ export class SliccShader extends HTMLElement {
     gl.uniform1f(u.u_blink ?? null, 0.05);
     gl.uniform1f(u.u_thick ?? null, 0.02);
     gl.uniform3f(u.u_tint ?? null, tint[0], tint[1], tint[2]);
+    gl.uniform1f(u.u_brightness ?? null, this.brightness);
+    gl.uniform1f(u.u_contrast ?? null, this.contrast);
+    gl.uniform1f(u.u_noise ?? null, this.noise);
+    gl.uniform1f(u.u_blur ?? null, this.blurAmount);
     gl.drawArrays(gl.TRIANGLES, 0, 3);
     // Energy decays toward rest.
     this.#energy *= 0.95;

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -66,15 +66,16 @@ describe('slicc-shader', () => {
     expect(() => el.pulse()).not.toThrow();
   });
 
-  it('reflects cone-mode brightness/contrast/noise/blur knobs (identity defaults)', () => {
+  it('reflects cone-mode brightness/contrast/noise/blur knobs (tuned defaults)', () => {
     const el = mount();
-    // Defaults: brightness=1, contrast=1, noise=0, blur=0 (visual identity).
+    // Tuned defaults baked in so the cone field renders with the Storybook
+    // texture everywhere with no attributes required.
     // The blur attribute reflects to `blurAmount` because HTMLElement already
     // defines a `blur()` method — same renaming dance as `scroll`/`scrollOffset`.
-    expect(el.brightness).toBe(1);
-    expect(el.contrast).toBe(1);
-    expect(el.noise).toBe(0);
-    expect(el.blurAmount).toBe(0);
+    expect(el.brightness).toBe(1.2);
+    expect(el.contrast).toBe(0.75);
+    expect(el.noise).toBeCloseTo(0.04, 5);
+    expect(el.blurAmount).toBeCloseTo(0.09, 5);
     // Property → attribute round-trip.
     el.brightness = 1.25;
     el.contrast = 1.5;
@@ -93,15 +94,15 @@ describe('slicc-shader', () => {
     expect(el.contrast).toBe(0.5);
     expect(el.noise).toBe(0.3);
     expect(el.blurAmount).toBe(0);
-    // Bogus values fall back to the identity defaults.
+    // Bogus values fall back to the tuned defaults.
     el.setAttribute('brightness', 'nope');
     el.setAttribute('contrast', 'nope');
     el.setAttribute('noise', 'nope');
     el.setAttribute('blur', 'nope');
-    expect(el.brightness).toBe(1);
-    expect(el.contrast).toBe(1);
-    expect(el.noise).toBe(0);
-    expect(el.blurAmount).toBe(0);
+    expect(el.brightness).toBe(1.2);
+    expect(el.contrast).toBe(0.75);
+    expect(el.noise).toBeCloseTo(0.04, 5);
+    expect(el.blurAmount).toBeCloseTo(0.09, 5);
   });
 
   it('cone fragment program references the new brightness/contrast/noise/blur uniforms', () => {

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -66,6 +66,57 @@ describe('slicc-shader', () => {
     expect(() => el.pulse()).not.toThrow();
   });
 
+  it('reflects cone-mode brightness/contrast/noise/blur knobs (identity defaults)', () => {
+    const el = mount();
+    // Defaults: brightness=1, contrast=1, noise=0, blur=0 (visual identity).
+    // The blur attribute reflects to `blurAmount` because HTMLElement already
+    // defines a `blur()` method — same renaming dance as `scroll`/`scrollOffset`.
+    expect(el.brightness).toBe(1);
+    expect(el.contrast).toBe(1);
+    expect(el.noise).toBe(0);
+    expect(el.blurAmount).toBe(0);
+    // Property → attribute round-trip.
+    el.brightness = 1.25;
+    el.contrast = 1.5;
+    el.noise = 0.15;
+    el.blurAmount = 0.5;
+    expect(el.getAttribute('brightness')).toBe('1.25');
+    expect(el.getAttribute('contrast')).toBe('1.5');
+    expect(el.getAttribute('noise')).toBe('0.15');
+    expect(el.getAttribute('blur')).toBe('0.5');
+    // Attribute → property reflection and clamping at the documented ranges.
+    el.setAttribute('brightness', '99');
+    el.setAttribute('contrast', '0');
+    el.setAttribute('noise', '5');
+    el.setAttribute('blur', '-1');
+    expect(el.brightness).toBe(1.5);
+    expect(el.contrast).toBe(0.5);
+    expect(el.noise).toBe(0.3);
+    expect(el.blurAmount).toBe(0);
+    // Bogus values fall back to the identity defaults.
+    el.setAttribute('brightness', 'nope');
+    el.setAttribute('contrast', 'nope');
+    el.setAttribute('noise', 'nope');
+    el.setAttribute('blur', 'nope');
+    expect(el.brightness).toBe(1);
+    expect(el.contrast).toBe(1);
+    expect(el.noise).toBe(0);
+    expect(el.blurAmount).toBe(0);
+  });
+
+  it('cone fragment program references the new brightness/contrast/noise/blur uniforms', () => {
+    const cone = SHADER_FRAGMENTS.cone;
+    expect(cone).toContain('uniform float u_brightness');
+    expect(cone).toContain('uniform float u_contrast');
+    expect(cone).toContain('uniform float u_noise');
+    expect(cone).toContain('uniform float u_blur');
+    // And the body actually applies them before the final write.
+    expect(cone).toContain('u_brightness');
+    expect(cone).toContain('u_contrast');
+    expect(cone).toContain('u_noise');
+    expect(cone).toContain('u_blur');
+  });
+
   it('keeps the canvas pointer-transparent and disposes cleanly', async () => {
     const el = mount({ mode: 'scoop' });
     expect(getComputedStyle(el.shadowRoot?.querySelector('canvas') as Element).pointerEvents).toBe(


### PR DESCRIPTION
## Summary

Adds four tunable knobs to the SLICC cone (waffle) background shader and exposes them as live Storybook controls, then bakes the tuned values in as the new defaults so the cone field renders with more texture everywhere.

## Changes

- **New uniforms** on the cone fragment program (`FRAG_CONE`): `u_brightness`, `u_contrast`, `u_noise`, `u_blur`.
  - brightness: color multiplier
  - contrast: scales color around a mid pivot
  - noise: adds a grain texture to the field
  - blur: controls the blurriness of the **noise layer only** (drives noise frequency/scale) — it does NOT blur the waffle lattice lines
- **Reflected attributes/properties** on `<slicc-shader>` with clamped ranges: brightness (0.5–1.5), contrast (0.5–2), noise (0–0.3), blur (0–1). The blur attribute reflects to the `blurAmount` property to avoid colliding with `HTMLElement.blur()`.
- **Render loop** feeds all four uniforms each frame via `gl.uniform1f`.
- **Storybook** (`Freezer/Shader`): four range controls added to the Cone story.
- **New defaults baked in**: brightness `1.2`, contrast `0.75`, noise `0.04`, blur `0.09` — the cone field renders with this tuned texture by default, no attributes required.
- **Tests** updated in place (reflection + GLSL-uniform assertions; `toBeCloseTo` for the float defaults).

## Verification

- `npm run typecheck -w @slicc/webcomponents` ✅
- `npm run lint` ✅
- `npm run test -w @slicc/webcomponents` ✅ (1407/1407)

Scope is cone mode only; scoop/freezer visuals are unchanged.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author