### PR TITLE
feat(webcomponents): inline composer capture surface

### DIFF
--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -411,18 +411,18 @@ async function captureScreenshot(): Promise<string | null> {
 const CAMERA_PREF_KEY = 'slicc_camera_device';
 const MIC_PREF_KEY = 'slicc_microphone_device';
 
-/** Compact "drop-target" placement that mirrors the `<slicc-add-menu>`
- *  `.results` panel: the capture surface mounts inside the composer band
- *  (`<slicc-composer>` is `position:relative; z-index:2`) and pops UP out of
- *  the band into the thread area above the input row, constrained to the
- *  composer's inner-column width (max 680px, centered). The composer band's
- *  height never grows; the input row stays visible underneath. */
+/** Compact "drop-target" placement that mounts inside the composer band
+ *  (`<slicc-composer>` is `position:relative; z-index:2`) and overlays the
+ *  input row from the bottom up — `bottom:0` aligns the surface's bottom
+ *  with the composer band's bottom so the enlarged capture box covers the
+ *  textarea while open. Constrained to the composer's inner-column width
+ *  (max 680px, centered via translateX). */
 const COMPACT_CSS = [
   'position:absolute',
   'left:50%',
   'right:auto',
   'transform:translateX(-50%)',
-  'bottom:calc(100% + 6px)',
+  'bottom:0',
   'width:calc(100% - 32px)',
   'max-width:680px',
   'aspect-ratio:auto',
@@ -431,8 +431,8 @@ const COMPACT_CSS = [
 
 /**
  * Camera capture via the inline `<slicc-composer-capture>` surface, mounted
- * as a compact drop-target box inside the composer band (mirrors the
- * `<slicc-add-menu>` `.results` geometry). Photo + video are both reachable
+ * inside the composer band and anchored to its bottom so the enlarged box
+ * overlays the input textarea while open. Photo + video are both reachable
  * through the in-surface mode toggle; the caller picks the initial mode.
  * Resolves with the raw `CaptureResult` or `null` on cancel / no camera.
  *
@@ -478,9 +478,9 @@ export interface WireWcAttachDeps {
   freezer: HTMLElement;
   /** Host for the inline `<slicc-composer-capture>` surface — the
    *  `<slicc-composer>` band element (already `position:relative; z-index:2`).
-   *  The surface pops UP out of the band into the thread area above the input
-   *  row, mirroring the `<slicc-add-menu>` `.results` geometry. Optional:
-   *  hosts without an overlay site (tests, harnesses) get the legacy
+   *  The surface anchors to the band's bottom (`bottom:0`) so the enlarged
+   *  capture box overlays the input textarea while open. Optional: hosts
+   *  without an overlay site (tests, harnesses) get the legacy
    *  `<slicc-camera-dialog>` modal as a fallback. */
   composer?: HTMLElement;
   openReader(): Promise<LocalVfsClient>;
@@ -519,9 +519,9 @@ async function stageVideoResult(
 
 /**
  * Stage a captured frame:
- * - `mode:'photo'` (camera) → inline `<slicc-composer-capture>` mounted as a
- *    compact drop-target box inside the composer band (popping above the
- *    input row into the thread area); the in-surface toggle reaches video;
+ * - `mode:'photo'` (camera) → inline `<slicc-composer-capture>` mounted
+ *    inside the composer band and anchored to its bottom so the enlarged
+ *    box overlays the input textarea; the in-surface toggle reaches video;
  *    photo result → image attachment, video result → file attachment
  *    (WebM persisted to VFS).
  * - `mode:'screen'` (or anything else) → `getDisplayMedia` one-frame grab.

--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -413,27 +413,30 @@ const MIC_PREF_KEY = 'slicc_microphone_device';
 
 /** Compact "drop-target" placement that mounts inside the composer band
  *  (`<slicc-composer>` is `position:relative; z-index:2`) and overlays the
- *  input row from the bottom up — `bottom:0` aligns the surface's bottom
- *  with the composer band's bottom so the enlarged capture box covers the
- *  textarea while open. Constrained to the composer's inner-column width
- *  (max 680px, centered via translateX). */
+ *  input card region from above the meta row. The meta row sits at the
+ *  bottom of the band (composer padding-bottom 14px + `.ctl` height 30px =
+ *  44px); anchoring at `bottom:56px` keeps the model/thinking pills fully
+ *  visible and clickable while the capture box covers the textarea above.
+ *  Constrained to the composer's inner-column width (max 680px, centered
+ *  via translateX). The component owns its responsive aspect-ratio
+ *  (3:4 desktop / 4:3 mobile), so this wrapper imposes none. */
 const COMPACT_CSS = [
   'position:absolute',
   'left:50%',
   'right:auto',
   'transform:translateX(-50%)',
-  'bottom:0',
+  'bottom:56px',
   'width:calc(100% - 32px)',
   'max-width:680px',
-  'aspect-ratio:auto',
   'z-index:3',
 ].join(';');
 
 /**
  * Camera capture via the inline `<slicc-composer-capture>` surface, mounted
- * inside the composer band and anchored to its bottom so the enlarged box
- * overlays the input textarea while open. Photo + video are both reachable
- * through the in-surface mode toggle; the caller picks the initial mode.
+ * inside the composer band and anchored above the meta row so the box
+ * overlays the input textarea while leaving the model/thinking pills
+ * visible and interactive. Photo + video are both reachable through the
+ * in-surface mode toggle; the caller picks the initial mode.
  * Resolves with the raw `CaptureResult` or `null` on cancel / no camera.
  *
  * Camera + mic picks persist across sessions via the
@@ -478,10 +481,11 @@ export interface WireWcAttachDeps {
   freezer: HTMLElement;
   /** Host for the inline `<slicc-composer-capture>` surface — the
    *  `<slicc-composer>` band element (already `position:relative; z-index:2`).
-   *  The surface anchors to the band's bottom (`bottom:0`) so the enlarged
-   *  capture box overlays the input textarea while open. Optional: hosts
-   *  without an overlay site (tests, harnesses) get the legacy
-   *  `<slicc-camera-dialog>` modal as a fallback. */
+   *  The surface anchors above the meta row (`bottom:56px`) so the capture
+   *  box covers the input textarea while the model/thinking pills stay
+   *  visible and interactive. Optional: hosts without an overlay site
+   *  (tests, harnesses) get the legacy `<slicc-camera-dialog>` modal as a
+   *  fallback. */
   composer?: HTMLElement;
   openReader(): Promise<LocalVfsClient>;
   /** Writable VFS for persisting captures + oversized uploads to /tmp/upload. */
@@ -520,10 +524,10 @@ async function stageVideoResult(
 /**
  * Stage a captured frame:
  * - `mode:'photo'` (camera) → inline `<slicc-composer-capture>` mounted
- *    inside the composer band and anchored to its bottom so the enlarged
- *    box overlays the input textarea; the in-surface toggle reaches video;
- *    photo result → image attachment, video result → file attachment
- *    (WebM persisted to VFS).
+ *    inside the composer band and anchored above the meta row so the box
+ *    overlays the input textarea while leaving the meta row visible;
+ *    the in-surface toggle reaches video; photo result → image attachment,
+ *    video result → file attachment (WebM persisted to VFS).
  * - `mode:'screen'` (or anything else) → `getDisplayMedia` one-frame grab.
  */
 async function stageCapture(

--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -6,6 +6,7 @@
  * render inside the input card and ride the next submit.
  */
 
+import type { CaptureDeviceChangeDetail, CaptureResult } from '@slicc/webcomponents';
 import type { MessageAttachment } from '../../core/attachments.js';
 import type { LocalVfsClient } from '../../kernel/local-vfs-client.js';
 import type { WritableVfsClient } from '../../kernel/writable-vfs-client.js';
@@ -169,6 +170,31 @@ export async function attachmentFromCapture(
   }
   const inline = attachmentFromDataUrl(name, await downscaleDataUrl(dataUrl).catch(() => dataUrl));
   return { ...(inline ?? full), name, path };
+}
+
+/**
+ * A recorded video Blob → file attachment. The WebM (with its mic audio track)
+ * is persisted to {@link UPLOAD_DIR} and referenced by path — video is not a
+ * vision input, so no inline `data` is carried. Returns `null` when no writer
+ * is available (a video with no path is just a dead chip).
+ */
+export async function attachmentFromVideoBlob(
+  name: string,
+  blob: Blob,
+  writer: WritableVfsClient | null
+): Promise<MessageAttachment | null> {
+  if (!writer) return null;
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const path = await persistUpload(writer, name, bytes).catch(() => undefined);
+  if (!path) return null;
+  return {
+    id: uid(),
+    name,
+    mimeType: blob.type || 'video/webm',
+    size: bytes.length,
+    kind: 'file',
+    path,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -381,15 +407,141 @@ async function captureScreenshot(): Promise<string | null> {
   return grabFrame(stream);
 }
 
-/** Remembered camera pick (the component reports changes via its event). */
+/** Remembered camera + mic picks (the component reports changes via its event). */
 const CAMERA_PREF_KEY = 'slicc_camera_device';
+const MIC_PREF_KEY = 'slicc_microphone_device';
+
+/** Overlay styles that turn the self-bounded capture surface into a full-area
+ *  overlay over the chat pane (mirrors the Storybook + drop-zone pattern). */
+const OVERLAY_CSS =
+  'position:absolute;inset:0;z-index:10;max-height:none;aspect-ratio:auto;border-radius:0;';
 
 /**
- * Camera photo through the library's `<slicc-camera-dialog>` — live preview,
- * camera picker, mirrored selfie view. Resolves the raw data URL, or null on
- * cancel / no camera.
+ * Camera capture via the inline `<slicc-composer-capture>` surface, mounted as
+ * a full-area overlay on the chat pane (same pattern as the PTT overlay / drop
+ * zone). Photo + video are both reachable through the in-surface mode toggle;
+ * the caller picks the initial mode. Resolves with the raw `CaptureResult` or
+ * `null` on cancel / no camera.
+ *
+ * Camera + mic picks persist across sessions via the
+ * `slicc-capture-device-change` event (`detail.kind: 'camera' | 'microphone'`).
  */
-async function capturePhoto(): Promise<string | null> {
+async function captureInline(
+  host: HTMLElement,
+  initialMode: 'photo' | 'video'
+): Promise<CaptureResult | null> {
+  // The library barrel is already imported by `wc-shell.ts`, so the
+  // `<slicc-composer-capture>` element is registered by the time we mount it.
+  const capture = document.createElement('slicc-composer-capture') as HTMLElement & {
+    open(mode?: 'photo' | 'video'): Promise<CaptureResult | null>;
+  };
+  const preferredCam = localStorage.getItem(CAMERA_PREF_KEY);
+  if (preferredCam) capture.setAttribute('preferred-device', preferredCam);
+  const preferredMic = localStorage.getItem(MIC_PREF_KEY);
+  if (preferredMic) capture.setAttribute('preferred-audio-device', preferredMic);
+  capture.style.cssText = OVERLAY_CSS;
+  capture.hidden = true;
+  capture.addEventListener('slicc-capture-device-change', (event) => {
+    const detail = (event as CustomEvent<CaptureDeviceChangeDetail>).detail;
+    if (!detail?.deviceId) return;
+    const key = detail.kind === 'microphone' ? MIC_PREF_KEY : CAMERA_PREF_KEY;
+    localStorage.setItem(key, detail.deviceId);
+  });
+  host.append(capture);
+  try {
+    return await capture.open(initialMode);
+  } finally {
+    capture.remove();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Wiring
+// ---------------------------------------------------------------------------
+
+export interface WireWcAttachDeps {
+  inputCard: HTMLElement & { value?: string };
+  /** The freezer rail — conversation picks thaw through its select event. */
+  freezer: HTMLElement;
+  /** Host for the inline `<slicc-composer-capture>` overlay (the chat pane in
+   *  the live shell). Must be `position:relative` so the overlay's `inset:0`
+   *  fills it. Optional: hosts without an overlay site (tests, harnesses) get
+   *  the legacy `<slicc-camera-dialog>` modal as a fallback. */
+  chatPane?: HTMLElement;
+  openReader(): Promise<LocalVfsClient>;
+  /** Writable VFS for persisting captures + oversized uploads to /tmp/upload. */
+  openWriter?(): Promise<WritableVfsClient>;
+  listConversations(): Promise<{ id: string; label: string; sub?: string }[]>;
+  log: { error(message: string, ...data: unknown[]): void };
+}
+
+/** Stage a photo result (image data URL) — full-res to VFS + inline downscale. */
+async function stagePhotoResult(
+  result: CaptureResult,
+  deps: WireWcAttachDeps,
+  stage: WcAttachmentStage
+): Promise<void> {
+  if (!result.dataUrl) return;
+  const name = `photo-${Date.now()}.png`;
+  const writer = (await deps.openWriter?.().catch(() => null)) ?? null;
+  const attachment = await attachmentFromCapture(name, result.dataUrl, writer);
+  if (attachment) stage.add(attachment);
+}
+
+/** Stage a video result (WebM Blob) — persist to VFS, reference by path. */
+async function stageVideoResult(
+  result: CaptureResult,
+  deps: WireWcAttachDeps,
+  stage: WcAttachmentStage
+): Promise<void> {
+  if (!result.blob) return;
+  const ext = /webm/i.test(result.mimeType) ? 'webm' : 'bin';
+  const name = `video-${Date.now()}.${ext}`;
+  const writer = (await deps.openWriter?.().catch(() => null)) ?? null;
+  const attachment = await attachmentFromVideoBlob(name, result.blob, writer);
+  if (attachment) stage.add(attachment);
+}
+
+/**
+ * Stage a captured frame:
+ * - `mode:'photo'` (camera) → inline overlay over the chat pane (`<slicc-
+ *    composer-capture>`); the in-surface toggle reaches video; photo result →
+ *    image attachment, video result → file attachment (WebM persisted to VFS).
+ * - `mode:'screen'` (or anything else) → `getDisplayMedia` one-frame grab.
+ */
+async function stageCapture(
+  detail: Record<string, unknown>,
+  deps: WireWcAttachDeps,
+  stage: WcAttachmentStage
+): Promise<void> {
+  if (detail.mode === 'photo') {
+    // No overlay host (preview / test harness) → fall back to the modal.
+    if (!deps.chatPane) {
+      const dataUrl = await capturePhotoFallback();
+      if (!dataUrl) return;
+      const name = `photo-${Date.now()}.png`;
+      const writer = (await deps.openWriter?.().catch(() => null)) ?? null;
+      const attachment = await attachmentFromCapture(name, dataUrl, writer);
+      if (attachment) stage.add(attachment);
+      return;
+    }
+    const result = await captureInline(deps.chatPane, 'photo');
+    if (!result) return;
+    if (result.kind === 'image') await stagePhotoResult(result, deps, stage);
+    else if (result.kind === 'video') await stageVideoResult(result, deps, stage);
+    return;
+  }
+  const dataUrl = await captureScreenshot();
+  if (!dataUrl) return;
+  const name = `screenshot-${Date.now()}.png`;
+  const writer = (await deps.openWriter?.().catch(() => null)) ?? null;
+  const attachment = await attachmentFromCapture(name, dataUrl, writer);
+  if (attachment) stage.add(attachment);
+}
+
+/** Fallback camera capture via the legacy `<slicc-camera-dialog>` for hosts
+ *  with no chat-pane overlay site. */
+async function capturePhotoFallback(): Promise<string | null> {
   const dialog = document.createElement('slicc-camera-dialog');
   const preferred = localStorage.getItem(CAMERA_PREF_KEY);
   if (preferred) dialog.setAttribute('preferred-device', preferred);
@@ -403,37 +555,6 @@ async function capturePhoto(): Promise<string | null> {
   } finally {
     dialog.remove();
   }
-}
-
-// ---------------------------------------------------------------------------
-// Wiring
-// ---------------------------------------------------------------------------
-
-export interface WireWcAttachDeps {
-  inputCard: HTMLElement & { value?: string };
-  /** The freezer rail — conversation picks thaw through its select event. */
-  freezer: HTMLElement;
-  openReader(): Promise<LocalVfsClient>;
-  /** Writable VFS for persisting captures + oversized uploads to /tmp/upload. */
-  openWriter?(): Promise<WritableVfsClient>;
-  listConversations(): Promise<{ id: string; label: string; sub?: string }[]>;
-  log: { error(message: string, ...data: unknown[]): void };
-}
-
-/** Stage a captured frame (camera vs screen): full-res original persisted to
- *  the VFS, downscaled inline copy for vision. */
-async function stageCapture(
-  detail: Record<string, unknown>,
-  deps: WireWcAttachDeps,
-  stage: WcAttachmentStage
-) {
-  const isPhoto = detail.mode === 'photo';
-  const dataUrl = isPhoto ? await capturePhoto() : await captureScreenshot();
-  if (!dataUrl) return;
-  const name = `${isPhoto ? 'photo' : 'screenshot'}-${Date.now()}.png`;
-  const writer = (await deps.openWriter?.().catch(() => null)) ?? null;
-  const attachment = await attachmentFromCapture(name, dataUrl, writer);
-  if (attachment) stage.add(attachment);
 }
 
 /**

--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -411,17 +411,30 @@ async function captureScreenshot(): Promise<string | null> {
 const CAMERA_PREF_KEY = 'slicc_camera_device';
 const MIC_PREF_KEY = 'slicc_microphone_device';
 
-/** Overlay styles that turn the self-bounded capture surface into a full-area
- *  overlay over the chat pane (mirrors the Storybook + drop-zone pattern). */
-const OVERLAY_CSS =
-  'position:absolute;inset:0;z-index:10;max-height:none;aspect-ratio:auto;border-radius:0;';
+/** Compact "drop-target" placement that mirrors the `<slicc-add-menu>`
+ *  `.results` panel: the capture surface mounts inside the composer band
+ *  (`<slicc-composer>` is `position:relative; z-index:2`) and pops UP out of
+ *  the band into the thread area above the input row, constrained to the
+ *  composer's inner-column width (max 680px, centered). The composer band's
+ *  height never grows; the input row stays visible underneath. */
+const COMPACT_CSS = [
+  'position:absolute',
+  'left:50%',
+  'right:auto',
+  'transform:translateX(-50%)',
+  'bottom:calc(100% + 6px)',
+  'width:calc(100% - 32px)',
+  'max-width:680px',
+  'aspect-ratio:auto',
+  'z-index:3',
+].join(';');
 
 /**
- * Camera capture via the inline `<slicc-composer-capture>` surface, mounted as
- * a full-area overlay on the chat pane (same pattern as the PTT overlay / drop
- * zone). Photo + video are both reachable through the in-surface mode toggle;
- * the caller picks the initial mode. Resolves with the raw `CaptureResult` or
- * `null` on cancel / no camera.
+ * Camera capture via the inline `<slicc-composer-capture>` surface, mounted
+ * as a compact drop-target box inside the composer band (mirrors the
+ * `<slicc-add-menu>` `.results` geometry). Photo + video are both reachable
+ * through the in-surface mode toggle; the caller picks the initial mode.
+ * Resolves with the raw `CaptureResult` or `null` on cancel / no camera.
  *
  * Camera + mic picks persist across sessions via the
  * `slicc-capture-device-change` event (`detail.kind: 'camera' | 'microphone'`).
@@ -439,7 +452,7 @@ async function captureInline(
   if (preferredCam) capture.setAttribute('preferred-device', preferredCam);
   const preferredMic = localStorage.getItem(MIC_PREF_KEY);
   if (preferredMic) capture.setAttribute('preferred-audio-device', preferredMic);
-  capture.style.cssText = OVERLAY_CSS;
+  capture.style.cssText = COMPACT_CSS;
   capture.hidden = true;
   capture.addEventListener('slicc-capture-device-change', (event) => {
     const detail = (event as CustomEvent<CaptureDeviceChangeDetail>).detail;
@@ -463,11 +476,13 @@ export interface WireWcAttachDeps {
   inputCard: HTMLElement & { value?: string };
   /** The freezer rail — conversation picks thaw through its select event. */
   freezer: HTMLElement;
-  /** Host for the inline `<slicc-composer-capture>` overlay (the chat pane in
-   *  the live shell). Must be `position:relative` so the overlay's `inset:0`
-   *  fills it. Optional: hosts without an overlay site (tests, harnesses) get
-   *  the legacy `<slicc-camera-dialog>` modal as a fallback. */
-  chatPane?: HTMLElement;
+  /** Host for the inline `<slicc-composer-capture>` surface — the
+   *  `<slicc-composer>` band element (already `position:relative; z-index:2`).
+   *  The surface pops UP out of the band into the thread area above the input
+   *  row, mirroring the `<slicc-add-menu>` `.results` geometry. Optional:
+   *  hosts without an overlay site (tests, harnesses) get the legacy
+   *  `<slicc-camera-dialog>` modal as a fallback. */
+  composer?: HTMLElement;
   openReader(): Promise<LocalVfsClient>;
   /** Writable VFS for persisting captures + oversized uploads to /tmp/upload. */
   openWriter?(): Promise<WritableVfsClient>;
@@ -504,9 +519,11 @@ async function stageVideoResult(
 
 /**
  * Stage a captured frame:
- * - `mode:'photo'` (camera) → inline overlay over the chat pane (`<slicc-
- *    composer-capture>`); the in-surface toggle reaches video; photo result →
- *    image attachment, video result → file attachment (WebM persisted to VFS).
+ * - `mode:'photo'` (camera) → inline `<slicc-composer-capture>` mounted as a
+ *    compact drop-target box inside the composer band (popping above the
+ *    input row into the thread area); the in-surface toggle reaches video;
+ *    photo result → image attachment, video result → file attachment
+ *    (WebM persisted to VFS).
  * - `mode:'screen'` (or anything else) → `getDisplayMedia` one-frame grab.
  */
 async function stageCapture(
@@ -516,7 +533,7 @@ async function stageCapture(
 ): Promise<void> {
   if (detail.mode === 'photo') {
     // No overlay host (preview / test harness) → fall back to the modal.
-    if (!deps.chatPane) {
+    if (!deps.composer) {
       const dataUrl = await capturePhotoFallback();
       if (!dataUrl) return;
       const name = `photo-${Date.now()}.png`;
@@ -525,7 +542,7 @@ async function stageCapture(
       if (attachment) stage.add(attachment);
       return;
     }
-    const result = await captureInline(deps.chatPane, 'photo');
+    const result = await captureInline(deps.composer, 'photo');
     if (!result) return;
     if (result.kind === 'image') await stagePhotoResult(result, deps, stage);
     else if (result.kind === 'video') await stageVideoResult(result, deps, stage);

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -799,6 +799,9 @@ function wireWcComposer(deps: {
       attachStage = wireWcAttach({
         inputCard: refs.inputCard as HTMLElement & { value?: string },
         freezer: refs.freezer,
+        // Camera capture mounts as a full-area overlay on the chat pane —
+        // see `slicc-composer-capture` + the Storybook reference pattern.
+        chatPane: refs.chatPane,
         openReader,
         openWriter: deps.openWriter,
         listConversations: async () => {

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -799,9 +799,9 @@ function wireWcComposer(deps: {
       attachStage = wireWcAttach({
         inputCard: refs.inputCard as HTMLElement & { value?: string },
         freezer: refs.freezer,
-        // Camera capture mounts as a full-area overlay on the chat pane —
-        // see `slicc-composer-capture` + the Storybook reference pattern.
-        chatPane: refs.chatPane,
+        // Camera capture mounts as a compact drop-target box inside the
+        // composer band — mirrors the `<slicc-add-menu>` `.results` geometry.
+        composer: refs.composer,
         openReader,
         openWriter: deps.openWriter,
         listConversations: async () => {

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -67,7 +67,8 @@ export interface WcShellRefs {
   /** The WebGL background field (`<slicc-shader>`, one of three programs). */
   shader: HTMLElement;
   /** The chat column (`<slicc-chatpane>`) — `position:relative` so it can host
-   *  full-area overlays (capture surface, drop zone). */
+   *  full-area overlays (drop zone, PTT). The compact `<slicc-composer-capture>`
+   *  surface anchors against the composer band, not the chat pane. */
   chatPane: HTMLElement;
   thread: HTMLElement;
   /** The composer footer band (PTT host — live floats arm + inject speech). */
@@ -99,8 +100,9 @@ const CSS = [
   '.wcui-shader{position:absolute;inset:0;z-index:0;}',
   // The chat column must stay transparent so the cone shader shows through
   // (the component paints an opaque background by default), and `relative`
-  // so it can host the full-area `<slicc-composer-capture>` overlay (and any
-  // other inset:0 surface — drop zone, PTT) without a separate wrapper.
+  // so it can host any `inset:0` overlay (drop zone, PTT) without a
+  // separate wrapper. The compact capture surface anchors on the composer
+  // band instead — see `wc-attach.ts` `captureInline`.
   '.wcui-frame slicc-chatpane{position:relative;background:transparent;}',
   '.wcui-appcol{position:relative;z-index:1;height:100%;display:flex;flex-direction:column;',
   'box-sizing:border-box;padding-left:var(--rail-w,44px);',

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -66,6 +66,9 @@ export interface WcShellRefs {
   frame: HTMLElement;
   /** The WebGL background field (`<slicc-shader>`, one of three programs). */
   shader: HTMLElement;
+  /** The chat column (`<slicc-chatpane>`) — `position:relative` so it can host
+   *  full-area overlays (capture surface, drop zone). */
+  chatPane: HTMLElement;
   thread: HTMLElement;
   /** The composer footer band (PTT host — live floats arm + inject speech). */
   composer: HTMLElement;
@@ -95,8 +98,10 @@ const CSS = [
   'overflow:hidden;background:var(--bg);font-family:var(--ui);}',
   '.wcui-shader{position:absolute;inset:0;z-index:0;}',
   // The chat column must stay transparent so the cone shader shows through
-  // (the component paints an opaque background by default).
-  '.wcui-frame slicc-chatpane{background:transparent;}',
+  // (the component paints an opaque background by default), and `relative`
+  // so it can host the full-area `<slicc-composer-capture>` overlay (and any
+  // other inset:0 surface — drop zone, PTT) without a separate wrapper.
+  '.wcui-frame slicc-chatpane{position:relative;background:transparent;}',
   '.wcui-appcol{position:relative;z-index:1;height:100%;display:flex;flex-direction:column;',
   'box-sizing:border-box;padding-left:var(--rail-w,44px);',
   'transition:padding-left .4s cubic-bezier(.4,0,.2,1);}',
@@ -344,6 +349,7 @@ export function mountWcShell(root: HTMLElement, options: WcShellOptions): WcShel
   return {
     frame,
     shader,
+    chatPane: pane,
     thread,
     composer,
     inputCard,

--- a/packages/webapp/tests/ui/wc/wc-attach.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-attach.test.ts
@@ -467,14 +467,15 @@ describe('wireWcAttach inline capture overlay', () => {
         liveCapture = composer.querySelector<HTMLElement>('slicc-composer-capture');
         expect(liveCapture).toBeTruthy();
       });
-      // Compact drop-target geometry: absolute placement, popped UP out of
-      // the band's top edge, constrained to the composer's inner-column
-      // width (max 680px, centered via translateX). No `inset:0` full-pane
-      // takeover — the composer band's height never grows.
+      // Enlarged overlay geometry: absolute placement anchored to the
+      // composer band's bottom (`bottom:0`) so the box covers the input
+      // textarea, constrained to the composer's inner-column width
+      // (max 680px, centered via translateX). No `inset:0` full-pane
+      // takeover — the surface still self-bounds via its own max-height.
       const style = (liveCapture as unknown as HTMLElement).style;
       expect(style.position).toBe('absolute');
       expect(style.maxWidth).toBe('680px');
-      expect(style.bottom).toMatch(/100%/);
+      expect(style.bottom).toBe('0px');
       expect(style.transform).toContain('translateX(-50%)');
       expect(style.zIndex).toBe('3');
       resolveOpen(stubResult);

--- a/packages/webapp/tests/ui/wc/wc-attach.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-attach.test.ts
@@ -228,7 +228,7 @@ describe('WcAttachmentStage', () => {
 });
 
 describe('wireWcAttach action routing', () => {
-  async function setup(opts: { withWriter?: boolean; chatPane?: HTMLElement } = {}) {
+  async function setup(opts: { withWriter?: boolean; composer?: HTMLElement } = {}) {
     const fs = await seededFs();
     const inputCard = document.createElement('slicc-input-card') as HTMLElement & {
       value?: string;
@@ -238,7 +238,7 @@ describe('wireWcAttach action routing', () => {
     const stage = wireWcAttach({
       inputCard,
       freezer,
-      chatPane: opts.chatPane,
+      composer: opts.composer,
       openReader: async () => fs,
       openWriter: opts.withWriter === false ? undefined : async () => fs,
       listConversations: async () => [],
@@ -419,27 +419,31 @@ describe('wireWcAttach inline capture overlay', () => {
       value?: string;
     };
     const freezer = document.createElement('slicc-freezer');
-    const chatPane = document.createElement('div');
-    chatPane.style.position = 'relative';
-    document.body.append(inputCard, freezer, chatPane);
+    // The composer-band host is `<slicc-composer>` in the live shell — a
+    // `position:relative` element so the compact capture surface's absolute
+    // placement anchors against it. A bare div with the same property
+    // exercises the same wiring without booting the library.
+    const composer = document.createElement('div');
+    composer.style.position = 'relative';
+    document.body.append(inputCard, freezer, composer);
     const stage = wireWcAttach({
       inputCard,
       freezer,
-      chatPane,
+      composer,
       openReader: async () => fs,
       openWriter: opts.withWriter === false ? undefined : async () => fs,
       listConversations: async () => [],
       log,
     });
-    return { fs, inputCard, chatPane, stage };
+    return { fs, inputCard, composer, stage };
   }
 
   function emitAdd(inputCard: HTMLElement, detail: Record<string, unknown>): void {
     inputCard.dispatchEvent(new CustomEvent('slicc-add', { bubbles: true, detail }));
   }
 
-  it('mounts the capture overlay on the chat pane and removes it after open() resolves', async () => {
-    const { inputCard, chatPane, stage } = await setup();
+  it('mounts the capture surface on the composer band with compact drop-target placement and removes it after open() resolves', async () => {
+    const { inputCard, composer, stage } = await setup();
     stubResult = {
       kind: 'image',
       mimeType: 'image/png',
@@ -447,13 +451,42 @@ describe('wireWcAttach inline capture overlay', () => {
       height: 1,
       dataUrl: `data:image/png;base64,${btoa('snap')}`,
     };
-    emitAdd(inputCard, { kind: 'capture', mode: 'photo' });
-    // The overlay is appended to the chat pane during open() and removed
-    // on resolve — so the staged item is the post-condition we wait on.
+    let liveCapture: HTMLElement | null = null;
+    // Hold the open() resolution so we can inspect the live surface placement
+    // before the wiring tears it down.
+    let resolveOpen!: (v: StubResult) => void;
+    stubDeferred = {
+      promise: new Promise<StubResult>((r) => {
+        resolveOpen = r;
+      }),
+      resolve: (v) => resolveOpen(v),
+    };
+    try {
+      emitAdd(inputCard, { kind: 'capture', mode: 'photo' });
+      await vi.waitFor(() => {
+        liveCapture = composer.querySelector<HTMLElement>('slicc-composer-capture');
+        expect(liveCapture).toBeTruthy();
+      });
+      // Compact drop-target geometry: absolute placement, popped UP out of
+      // the band's top edge, constrained to the composer's inner-column
+      // width (max 680px, centered via translateX). No `inset:0` full-pane
+      // takeover — the composer band's height never grows.
+      const style = (liveCapture as unknown as HTMLElement).style;
+      expect(style.position).toBe('absolute');
+      expect(style.maxWidth).toBe('680px');
+      expect(style.bottom).toMatch(/100%/);
+      expect(style.transform).toContain('translateX(-50%)');
+      expect(style.zIndex).toBe('3');
+      resolveOpen(stubResult);
+    } finally {
+      stubDeferred = null;
+    }
+    // The surface is appended during open() and removed on resolve — so the
+    // staged item is the post-condition we wait on.
     await vi.waitFor(() => {
       expect(stage.items).toHaveLength(1);
     });
-    expect(chatPane.querySelector('slicc-composer-capture')).toBeNull();
+    expect(composer.querySelector('slicc-composer-capture')).toBeNull();
   });
 
   it('stages a photo capture result as an image attachment (inline data + VFS path)', async () => {
@@ -504,13 +537,13 @@ describe('wireWcAttach inline capture overlay', () => {
     expect(Array.from(saved)).toEqual(Array.from(videoBytes));
   });
 
-  it('cancel resolves to no attachment and tears down the overlay', async () => {
-    const { inputCard, chatPane, stage } = await setup();
+  it('cancel resolves to no attachment and tears down the surface', async () => {
+    const { inputCard, composer, stage } = await setup();
     stubResult = null;
     emitAdd(inputCard, { kind: 'capture', mode: 'photo' });
-    // No staged items; the overlay was removed.
+    // No staged items; the surface was removed.
     await vi.waitFor(() => {
-      expect(chatPane.querySelector('slicc-composer-capture')).toBeNull();
+      expect(composer.querySelector('slicc-composer-capture')).toBeNull();
     });
     expect(stage.items).toHaveLength(0);
   });

--- a/packages/webapp/tests/ui/wc/wc-attach.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-attach.test.ts
@@ -16,6 +16,7 @@ import {
   attachmentFromBytes,
   attachmentFromCapture,
   attachmentFromDataUrl,
+  attachmentFromVideoBlob,
   createAddProvider,
   persistUpload,
   UPLOAD_DIR,
@@ -157,6 +158,37 @@ describe('capture persistence (/tmp/upload)', () => {
   });
 });
 
+describe('attachmentFromVideoBlob', () => {
+  it('persists the WebM under /tmp/upload as a kind:file (no inline data)', async () => {
+    const fs = await seededFs();
+    const bytes = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0xff, 0x00]); // mock WebM header bytes
+    const blob = new Blob([bytes], { type: 'video/webm' });
+    const attachment = await attachmentFromVideoBlob('clip.webm', blob, fs);
+    expect(attachment?.kind).toBe('file');
+    expect(attachment?.mimeType).toBe('video/webm');
+    expect(attachment?.size).toBe(bytes.length);
+    expect(attachment?.data).toBeUndefined();
+    expect(attachment?.text).toBeUndefined();
+    expect(attachment?.path?.startsWith(`${UPLOAD_DIR}/`)).toBe(true);
+    const saved = (await fs.readFile(attachment?.path as string, {
+      encoding: 'binary',
+    })) as Uint8Array;
+    expect(Array.from(saved)).toEqual(Array.from(bytes));
+  });
+
+  it('returns null without a writer (a video chip without a path is useless)', async () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: 'video/webm' });
+    expect(await attachmentFromVideoBlob('clip.webm', blob, null)).toBeNull();
+  });
+
+  it('falls back to video/webm when the Blob carries no MIME type', async () => {
+    const fs = await seededFs();
+    const blob = new Blob([new Uint8Array([1, 2, 3])]);
+    const attachment = await attachmentFromVideoBlob('clip.webm', blob, fs);
+    expect(attachment?.mimeType).toBe('video/webm');
+  });
+});
+
 describe('WcAttachmentStage', () => {
   it('renders image attachments with a data-URI thumbnail', () => {
     const card = document.createElement('slicc-input-card');
@@ -196,7 +228,7 @@ describe('WcAttachmentStage', () => {
 });
 
 describe('wireWcAttach action routing', () => {
-  async function setup(opts: { withWriter?: boolean } = {}) {
+  async function setup(opts: { withWriter?: boolean; chatPane?: HTMLElement } = {}) {
     const fs = await seededFs();
     const inputCard = document.createElement('slicc-input-card') as HTMLElement & {
       value?: string;
@@ -206,6 +238,7 @@ describe('wireWcAttach action routing', () => {
     const stage = wireWcAttach({
       inputCard,
       freezer,
+      chatPane: opts.chatPane,
       openReader: async () => fs,
       openWriter: opts.withWriter === false ? undefined : async () => fs,
       listConversations: async () => [],
@@ -350,5 +383,195 @@ describe('wireWcAttach action routing', () => {
     await vi.waitFor(() => {
       expect(selects).toEqual(['2026-06-11-session.md']);
     });
+  });
+});
+
+// Stub the `<slicc-composer-capture>` element once so the inline-overlay tests
+// can drive the capture flow without a real camera or the full library load.
+// The stub keeps the public `open()` contract (resolves a `CaptureResult | null`)
+// so the wiring exercises the real photo/video result branches.
+type StubResult =
+  | { kind: 'image'; mimeType: string; width: number; height: number; dataUrl: string }
+  | { kind: 'video'; mimeType: string; width: number; height: number; blob: Blob }
+  | null;
+let stubResult: StubResult = null;
+let stubDeferred: { promise: Promise<StubResult>; resolve: (v: StubResult) => void } | null = null;
+const liveStubs = new Set<HTMLElement>();
+class CaptureStub extends HTMLElement {
+  open(mode?: 'photo' | 'video'): Promise<StubResult> {
+    (this as HTMLElement & { __mode?: string }).__mode = mode ?? 'photo';
+    liveStubs.add(this);
+    if (stubDeferred) return stubDeferred.promise;
+    return Promise.resolve(stubResult);
+  }
+  disconnectedCallback(): void {
+    liveStubs.delete(this);
+  }
+}
+if (!customElements.get('slicc-composer-capture')) {
+  customElements.define('slicc-composer-capture', CaptureStub);
+}
+
+describe('wireWcAttach inline capture overlay', () => {
+  async function setup(opts: { withWriter?: boolean } = {}) {
+    const fs = await seededFs();
+    const inputCard = document.createElement('slicc-input-card') as HTMLElement & {
+      value?: string;
+    };
+    const freezer = document.createElement('slicc-freezer');
+    const chatPane = document.createElement('div');
+    chatPane.style.position = 'relative';
+    document.body.append(inputCard, freezer, chatPane);
+    const stage = wireWcAttach({
+      inputCard,
+      freezer,
+      chatPane,
+      openReader: async () => fs,
+      openWriter: opts.withWriter === false ? undefined : async () => fs,
+      listConversations: async () => [],
+      log,
+    });
+    return { fs, inputCard, chatPane, stage };
+  }
+
+  function emitAdd(inputCard: HTMLElement, detail: Record<string, unknown>): void {
+    inputCard.dispatchEvent(new CustomEvent('slicc-add', { bubbles: true, detail }));
+  }
+
+  it('mounts the capture overlay on the chat pane and removes it after open() resolves', async () => {
+    const { inputCard, chatPane, stage } = await setup();
+    stubResult = {
+      kind: 'image',
+      mimeType: 'image/png',
+      width: 1,
+      height: 1,
+      dataUrl: `data:image/png;base64,${btoa('snap')}`,
+    };
+    emitAdd(inputCard, { kind: 'capture', mode: 'photo' });
+    // The overlay is appended to the chat pane during open() and removed
+    // on resolve — so the staged item is the post-condition we wait on.
+    await vi.waitFor(() => {
+      expect(stage.items).toHaveLength(1);
+    });
+    expect(chatPane.querySelector('slicc-composer-capture')).toBeNull();
+  });
+
+  it('stages a photo capture result as an image attachment (inline data + VFS path)', async () => {
+    const { fs, inputCard, stage } = await setup();
+    stubResult = {
+      kind: 'image',
+      mimeType: 'image/png',
+      width: 1,
+      height: 1,
+      dataUrl: `data:image/png;base64,${btoa('snap')}`,
+    };
+    emitAdd(inputCard, { kind: 'capture', mode: 'photo' });
+    await vi.waitFor(() => {
+      expect(stage.items).toHaveLength(1);
+    });
+    const item = stage.items[0];
+    expect(item.kind).toBe('image');
+    expect(item.name).toMatch(/^photo-\d+\.png$/);
+    expect(item.data).toBe(btoa('snap'));
+    expect(item.path?.startsWith(`${UPLOAD_DIR}/`)).toBe(true);
+    const saved = await fs.readFile(item.path as string, { encoding: 'utf-8' });
+    expect(typeof saved === 'string' ? saved : new TextDecoder().decode(saved)).toBe('snap');
+  });
+
+  it('stages a video capture result as a kind:file with the WebM persisted to /tmp/upload', async () => {
+    const { fs, inputCard, stage } = await setup();
+    const videoBytes = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0x42, 0x82]);
+    stubResult = {
+      kind: 'video',
+      mimeType: 'video/webm;codecs=vp9,opus',
+      width: 640,
+      height: 480,
+      blob: new Blob([videoBytes], { type: 'video/webm' }),
+    };
+    emitAdd(inputCard, { kind: 'capture', mode: 'photo' });
+    await vi.waitFor(() => {
+      expect(stage.items).toHaveLength(1);
+    });
+    const item = stage.items[0];
+    expect(item.kind).toBe('file');
+    expect(item.name).toMatch(/^video-\d+\.webm$/);
+    expect(item.mimeType).toBe('video/webm');
+    expect(item.data).toBeUndefined();
+    expect(item.path?.startsWith(`${UPLOAD_DIR}/`)).toBe(true);
+    const saved = (await fs.readFile(item.path as string, {
+      encoding: 'binary',
+    })) as Uint8Array;
+    expect(Array.from(saved)).toEqual(Array.from(videoBytes));
+  });
+
+  it('cancel resolves to no attachment and tears down the overlay', async () => {
+    const { inputCard, chatPane, stage } = await setup();
+    stubResult = null;
+    emitAdd(inputCard, { kind: 'capture', mode: 'photo' });
+    // No staged items; the overlay was removed.
+    await vi.waitFor(() => {
+      expect(chatPane.querySelector('slicc-composer-capture')).toBeNull();
+    });
+    expect(stage.items).toHaveLength(0);
+  });
+
+  it('drops a video result when no writer is available (no orphan chip)', async () => {
+    const { inputCard, stage } = await setup({ withWriter: false });
+    stubResult = {
+      kind: 'video',
+      mimeType: 'video/webm',
+      width: 1,
+      height: 1,
+      blob: new Blob([new Uint8Array([1])], { type: 'video/webm' }),
+    };
+    emitAdd(inputCard, { kind: 'capture', mode: 'photo' });
+    // Give the async chain a chance to settle without staging anything.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(stage.items).toHaveLength(0);
+  });
+
+  it('persists camera + mic picks via slicc-capture-device-change', async () => {
+    // Seed the preference store fresh — other tests in the suite may have
+    // written values we'd otherwise be asserting against by accident.
+    localStorage.removeItem('slicc_camera_device');
+    localStorage.removeItem('slicc_microphone_device');
+    // Pause the open() resolution so the overlay stays mounted while we
+    // dispatch device-change events on the live element.
+    let resolveOpen!: (v: StubResult) => void;
+    stubDeferred = {
+      promise: new Promise<StubResult>((r) => {
+        resolveOpen = r;
+      }),
+      resolve: (v) => resolveOpen(v),
+    };
+    try {
+      const { inputCard } = await setup();
+      emitAdd(inputCard, { kind: 'capture', mode: 'photo' });
+      // Wait for the overlay to mount.
+      let live: HTMLElement | null = null;
+      await vi.waitFor(() => {
+        live = [...liveStubs][0] ?? null;
+        expect(live).toBeTruthy();
+      });
+      live?.dispatchEvent(
+        new CustomEvent('slicc-capture-device-change', {
+          bubbles: true,
+          composed: true,
+          detail: { deviceId: 'cam-42', kind: 'camera' },
+        })
+      );
+      live?.dispatchEvent(
+        new CustomEvent('slicc-capture-device-change', {
+          bubbles: true,
+          composed: true,
+          detail: { deviceId: 'mic-99', kind: 'microphone' },
+        })
+      );
+      expect(localStorage.getItem('slicc_camera_device')).toBe('cam-42');
+      expect(localStorage.getItem('slicc_microphone_device')).toBe('mic-99');
+      resolveOpen(null);
+    } finally {
+      stubDeferred = null;
+    }
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-attach.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-attach.test.ts
@@ -467,17 +467,23 @@ describe('wireWcAttach inline capture overlay', () => {
         liveCapture = composer.querySelector<HTMLElement>('slicc-composer-capture');
         expect(liveCapture).toBeTruthy();
       });
-      // Enlarged overlay geometry: absolute placement anchored to the
-      // composer band's bottom (`bottom:0`) so the box covers the input
-      // textarea, constrained to the composer's inner-column width
-      // (max 680px, centered via translateX). No `inset:0` full-pane
-      // takeover — the surface still self-bounds via its own max-height.
+      // Enlarged overlay geometry: absolute placement anchored ABOVE the
+      // meta row (`bottom:56px` clears the composer's 14px bottom padding
+      // + the 30px `.ctl` meta-pill row) so the model/thinking pills stay
+      // visible and clickable while the box covers the input textarea.
+      // Constrained to the composer's inner-column width (max 680px,
+      // centered via translateX). No `inset:0` full-pane takeover — the
+      // surface still self-bounds via its own responsive aspect-ratio +
+      // max-height (the wrapper imposes no aspect-ratio override).
       const style = (liveCapture as unknown as HTMLElement).style;
       expect(style.position).toBe('absolute');
       expect(style.maxWidth).toBe('680px');
-      expect(style.bottom).toBe('0px');
+      expect(style.bottom).toBe('56px');
       expect(style.transform).toContain('translateX(-50%)');
       expect(style.zIndex).toBe('3');
+      // The wrapper deliberately omits `aspect-ratio` so the component's
+      // responsive 3:4 desktop / 4:3 mobile rule applies.
+      expect(style.aspectRatio).toBe('');
       resolveOpen(stubResult);
     } finally {
       stubDeferred = null;

--- a/packages/webapp/tests/ui/wc/wc-boot.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-boot.test.ts
@@ -6,10 +6,26 @@
  */
 
 import 'fake-indexeddb/auto';
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();
+
+// The boot path dynamically imports real kernel modules that log via real
+// `console` on the intentionally-throwing test transport's async catch-paths.
+// Those late logs queue an `onUserConsoleLog` RPC that races worker teardown
+// under full-suite scheduling on Node 26. Replacing Vitest's interceptor with
+// a no-op spy stops any RPC from being queued.
+beforeAll(() => {
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+  vi.spyOn(console, 'info').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
 
 import type { RegisteredScoop } from '../../../src/scoops/types.js';
 import type { OffscreenClient } from '../../../src/ui/offscreen-client.js';

--- a/packages/webcomponents/src/composer/devices.ts
+++ b/packages/webcomponents/src/composer/devices.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared, DOM-light helpers for the composer's device pickers.
+ *
+ * Both `<slicc-composer-capture>` (camera + mic `<option>` lists) and
+ * `<slicc-composer>`'s push-to-talk mic menu need the same two rules:
+ *
+ * 1. **Label fallback** — when a `MediaDeviceInfo` has no usable `label`
+ *    (no permission yet, or the platform never exposed one), substitute a
+ *    stable positional placeholder: `Camera 1`, `Microphone 2`, …
+ * 2. **Visibility** — surface the picker only when there is a real choice
+ *    to make: ≥ 2 devices.
+ *
+ * Keeping these rules here (no DOM dependencies) means both consumers stay
+ * in lockstep without growing a runtime coupling — each renders its own
+ * widget (a `<select>` for capture, a custom menu for PTT) but the data
+ * shape and the "should we even show it" decision are identical.
+ */
+
+/** The kinds of device the composer surfaces a picker for. */
+export type DeviceKind = 'camera' | 'microphone';
+
+/**
+ * The minimal option/row shape both pickers consume. Compatible with the
+ * existing {@link import('./speech.js').MicrophoneInfo} (same fields), so
+ * speech.ts results flow straight into the PTT menu without remapping.
+ */
+export interface DeviceOption {
+  deviceId: string;
+  label: string;
+}
+
+/** The label-fallback word for each device kind. */
+const KIND_LABEL: Record<DeviceKind, string> = {
+  camera: 'Camera',
+  microphone: 'Microphone',
+};
+
+/**
+ * Resolve the user-facing label for one device, falling back to a stable
+ * positional placeholder (`Camera N` / `Microphone N`, 1-indexed) when the
+ * platform did not give us one. The placeholder mirrors the index passed
+ * by the caller so list order is preserved.
+ */
+export function deviceLabel(
+  label: string | null | undefined,
+  index: number,
+  kind: DeviceKind
+): string {
+  const trimmed = (label ?? '').trim();
+  return trimmed || `${KIND_LABEL[kind]} ${index + 1}`;
+}
+
+/**
+ * Normalize a raw device list (typically `MediaDeviceInfo[]` filtered to the
+ * matching `kind`, or anything carrying `{ deviceId, label? }`) into the
+ * picker-ready {@link DeviceOption} shape, applying {@link deviceLabel} per
+ * row. Input order is preserved.
+ */
+export function labelDevices(
+  items: ReadonlyArray<{ deviceId: string; label?: string | null }>,
+  kind: DeviceKind
+): DeviceOption[] {
+  return items.map((item, index) => ({
+    deviceId: item.deviceId,
+    label: deviceLabel(item.label, index, kind),
+  }));
+}
+
+/**
+ * The shared visibility rule: only surface the picker when there is more
+ * than one device. A single (or zero) input means no real choice — hiding
+ * it keeps both the capture bar and the PTT overlay free of dead chrome.
+ */
+export function shouldShowDevicePicker(items: ArrayLike<unknown>): boolean {
+  return items.length >= 2;
+}

--- a/packages/webcomponents/src/composer/slicc-composer-capture.stories.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-capture.stories.ts
@@ -1,0 +1,360 @@
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+// Compose the capture surface inside a real <slicc-composer> by tag — importing
+// the sibling module registers the composer element so the markup below upgrades
+// on mount. The capture element itself is light-DOM and fills its layout slot,
+// so dropping it into the composer's 680px inner band reproduces the same "fill
+// the composer area" pattern the drag-and-drop drop target uses.
+import './slicc-composer-capture.js';
+import './slicc-composer.js';
+import type { SliccComposer } from './slicc-composer.js';
+import type {
+  CameraMediaProvider,
+  CaptureMode,
+  CaptureResult,
+  SliccComposerCapture,
+} from './slicc-composer-capture.js';
+
+interface CaptureArgs {
+  mode?: CaptureMode;
+  deviceCount?: number;
+  micCount?: number;
+  useFake?: boolean;
+}
+
+const meta: Meta<CaptureArgs> = {
+  title: 'Composer/CaptureSurface',
+  component: 'slicc-composer-capture',
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  argTypes: {
+    mode: {
+      control: 'inline-radio',
+      options: ['photo', 'video'],
+      description: 'Initial capture mode (still photo or recorded video).',
+    },
+    deviceCount: {
+      control: { type: 'number', min: 1, max: 2 },
+      description: 'How many fake cameras the provider exposes (picker hidden at 1).',
+    },
+    micCount: {
+      control: { type: 'number', min: 1, max: 2 },
+      description: 'How many fake mics the provider exposes (picker hidden at 1).',
+    },
+    useFake: {
+      control: 'boolean',
+      description: 'Use the canvas-backed fake provider (off → real navigator.mediaDevices).',
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<CaptureArgs>;
+
+/** Canvas dimensions for the fake video feed (4:3, matches the composer band). */
+const FAKE_W = 640;
+const FAKE_H = 480;
+
+/** Hue + label pair for each fake device, keyed by deviceId. */
+const FAKE_DEVICES = [
+  { deviceId: 'demo-front', label: 'Demo front camera', facing: 'user', hue: 28 },
+  { deviceId: 'demo-rear', label: 'Demo rear camera', facing: 'environment', hue: 200 },
+] as const;
+
+/** Fake mic options, keyed by deviceId. */
+const FAKE_MICS = [
+  { deviceId: 'demo-mic-internal', label: 'Demo built-in microphone' },
+  { deviceId: 'demo-mic-usb', label: 'Demo USB condenser' },
+] as const;
+
+/** Pull `video.deviceId.exact` out of a MediaStreamConstraints.video union. */
+function extractExactDeviceId(video: MediaStreamConstraints['video']): string | undefined {
+  if (typeof video !== 'object' || video === null) return undefined;
+  if (!('deviceId' in video)) return undefined;
+  const d = (video as MediaTrackConstraints).deviceId;
+  if (typeof d === 'string') return d;
+  if (d && typeof d === 'object' && 'exact' in d) {
+    const exact = (d as { exact?: string | string[] }).exact;
+    return Array.isArray(exact) ? exact[0] : exact;
+  }
+  return undefined;
+}
+
+/**
+ * Make a video track by painting an animated, hued canvas at 15fps and capturing
+ * it as a MediaStream. The deviceId + facingMode are stamped onto `getSettings()`
+ * so the capture surface mirrors selfie cameras and the picker can drive
+ * `switchCamera()` against the correct exact-id constraint.
+ */
+function makeFakeVideoTrack(device: (typeof FAKE_DEVICES)[number]): MediaStreamTrack {
+  const canvas = document.createElement('canvas');
+  canvas.width = FAKE_W;
+  canvas.height = FAKE_H;
+  const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+  let t = 0;
+  const tick = setInterval(() => {
+    t += 1;
+    ctx.fillStyle = `hsl(${device.hue}, 70%, ${55 + 10 * Math.sin(t / 10)}%)`;
+    ctx.fillRect(0, 0, FAKE_W, FAKE_H);
+    ctx.fillStyle = '#fff';
+    ctx.font = '28px sans-serif';
+    ctx.fillText(device.label, 24, 240);
+    ctx.font = '14px monospace';
+    ctx.fillText(`frame ${t}`, 24, 280);
+  }, 80);
+  const stream = canvas.captureStream(15);
+  const track = stream.getVideoTracks()[0];
+  const origStop = track.stop.bind(track);
+  track.stop = () => {
+    clearInterval(tick);
+    origStop();
+  };
+  track.getSettings = () =>
+    ({ deviceId: device.deviceId, facingMode: device.facing }) as MediaTrackSettings;
+  return track;
+}
+
+/**
+ * Make a synthetic audio track: a 220Hz oscillator at near-zero gain piped into
+ * a `MediaStreamDestination`, so MediaRecorder produces a multi-track WebM with
+ * a real audio track but no actual microphone access. The track's `stop()` is
+ * patched to also stop the oscillator so the AudioContext doesn't keep ticking.
+ * The requested mic `deviceId` is stamped onto `getSettings()` so the capture
+ * surface's mic picker reflects the active mic.
+ */
+function makeFakeAudioTrack(deviceId: string): MediaStreamTrack {
+  const ctx = new AudioContext();
+  const osc = ctx.createOscillator();
+  osc.frequency.value = 220;
+  const gain = ctx.createGain();
+  gain.gain.value = 0.00001;
+  const dest = ctx.createMediaStreamDestination();
+  osc.connect(gain).connect(dest);
+  osc.start();
+  const track = dest.stream.getAudioTracks()[0];
+  const origStop = track.stop.bind(track);
+  track.stop = () => {
+    try {
+      osc.stop();
+    } catch {
+      // already stopped — ignore.
+    }
+    origStop();
+  };
+  track.getSettings = () => ({ deviceId }) as MediaTrackSettings;
+  return track;
+}
+
+/** Pull `audio.deviceId.exact` out of a MediaStreamConstraints.audio union. */
+function extractExactAudioId(audio: MediaStreamConstraints['audio']): string | undefined {
+  if (typeof audio !== 'object' || audio === null) return undefined;
+  if (!('deviceId' in audio)) return undefined;
+  const d = (audio as MediaTrackConstraints).deviceId;
+  if (typeof d === 'string') return d;
+  if (d && typeof d === 'object' && 'exact' in d) {
+    const exact = (d as { exact?: string | string[] }).exact;
+    return Array.isArray(exact) ? exact[0] : exact;
+  }
+  return undefined;
+}
+
+/**
+ * A canvas-backed `CameraMediaProvider`: each fake "device" paints its own hued
+ * animated canvas captured at 15fps, and `audio: true` (or a deviceId-pinned
+ * constraint) adds a synthetic oscillator track so video recordings carry an
+ * audio track without any real microphone permission prompt. Defaults to TWO
+ * cameras + ONE mic so the camera picker is visible — pass `1` cameras or
+ * `2`+ mics to exercise the other picker-visibility paths.
+ */
+function makeFakeProvider(deviceCount: number, micCount: number): CameraMediaProvider {
+  const devices = FAKE_DEVICES.slice(0, Math.max(1, Math.min(deviceCount, FAKE_DEVICES.length)));
+  const mics = FAKE_MICS.slice(0, Math.max(1, Math.min(micCount, FAKE_MICS.length)));
+  return {
+    getUserMedia: async (constraints) => {
+      const stream = new MediaStream();
+      if (constraints.video) {
+        const exact = extractExactDeviceId(constraints.video) ?? devices[0].deviceId;
+        const device = devices.find((d) => d.deviceId === exact) ?? devices[0];
+        stream.addTrack(makeFakeVideoTrack(device));
+      }
+      if (constraints.audio) {
+        const exactMic = extractExactAudioId(constraints.audio) ?? mics[0].deviceId;
+        const mic = mics.find((m) => m.deviceId === exactMic) ?? mics[0];
+        stream.addTrack(makeFakeAudioTrack(mic.deviceId));
+      }
+      return stream;
+    },
+    enumerateDevices: async () => [
+      ...devices.map(
+        (d) => ({ kind: 'videoinput', deviceId: d.deviceId, label: d.label }) as MediaDeviceInfo
+      ),
+      ...mics.map(
+        (m) => ({ kind: 'audioinput', deviceId: m.deviceId, label: m.label }) as MediaDeviceInfo
+      ),
+    ],
+  };
+}
+
+function formatDuration(ms?: number): string {
+  if (!ms || ms <= 0) return '0:00';
+  const total = Math.floor(ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+/** Append a result preview (image thumbnail or playable video) to the thread. */
+function appendResult(thread: HTMLElement, result: CaptureResult): void {
+  const block = document.createElement('div');
+  block.style.cssText =
+    'margin-top:14px;padding:12px;border:1px solid var(--line);border-radius:10px;' +
+    'background:var(--canvas);color:var(--ink);';
+  const cap = document.createElement('p');
+  cap.style.cssText = 'margin:0 0 8px;font-size:12px;color:var(--txt-2);';
+  if (result.kind === 'image' && result.dataUrl) {
+    cap.textContent = `Snapped ${result.width}×${result.height} · ${result.mimeType}`;
+    const img = document.createElement('img');
+    img.src = result.dataUrl;
+    img.alt = 'Captured photo';
+    img.style.cssText = 'max-width:280px;display:block;border-radius:8px;';
+    block.append(cap, img);
+  } else if (result.kind === 'video' && result.dataUrl) {
+    const tracks = result.blob ? ` · ${(result.blob.size / 1024).toFixed(1)} KB` : '';
+    cap.textContent =
+      `Recorded ${formatDuration(result.durationMs)} · ` +
+      `${result.width}×${result.height} · ${result.mimeType}${tracks}`;
+    const vid = document.createElement('video');
+    vid.src = result.dataUrl;
+    vid.controls = true;
+    vid.playsInline = true;
+    vid.style.cssText = 'max-width:360px;display:block;border-radius:8px;';
+    block.append(cap, vid);
+  }
+  thread.appendChild(block);
+  thread.scrollTop = thread.scrollHeight;
+}
+
+/**
+ * Build the story shell: a chat-column layout (thread above, composer band
+ * below) with the capture surface mounted INSIDE the composer's inner band so
+ * it fills the band the way the drag-and-drop drop target does. The fake
+ * provider stories auto-open on mount; the real-camera story shows an explicit
+ * Open button so the permission prompt is gated by a user gesture.
+ */
+function buildShell(args: CaptureArgs): HTMLElement {
+  const mode: CaptureMode = args.mode === 'video' ? 'video' : 'photo';
+  const useFake = args.useFake !== false;
+  const deviceCount = args.deviceCount ?? 2;
+  const micCount = args.micCount ?? 1;
+
+  const shell = document.createElement('div');
+  shell.style.cssText =
+    'display:flex;flex-direction:column;height:560px;width:100%;background:var(--bg);' +
+    'overflow:hidden;font-family:var(--ui);';
+
+  const thread = document.createElement('div');
+  thread.style.cssText =
+    'flex:1 1 auto;overflow:auto;padding:28px 24px;color:var(--txt-2);' +
+    'font-size:14px;line-height:1.5;';
+  const intro = document.createElement('p');
+  intro.style.cssText = 'margin:0 0 12px;color:var(--ink);';
+  intro.textContent = useFake
+    ? 'Inline capture surface, inside the composer band below — canvas-backed fake stream, no permission needed. Snap (photo) or Record / Stop (video); the result appears in this thread.'
+    : 'Inline capture surface against the real navigator.mediaDevices — the browser will ask for camera access when you press Open.';
+  thread.appendChild(intro);
+
+  const composer = document.createElement('slicc-composer') as SliccComposer;
+  const capture = document.createElement('slicc-composer-capture') as SliccComposerCapture;
+  if (useFake) capture.media = makeFakeProvider(deviceCount, micCount);
+  capture.setAttribute('mode', mode);
+  // Hide until opened so the composer band reads as the chat footer at rest —
+  // then the auto-open / button-trigger flips it into the live capture state.
+  capture.hidden = true;
+  composer.append(capture);
+
+  const openOnce = (): void => {
+    void capture.open(mode).then((result) => {
+      if (result) appendResult(thread, result);
+    });
+  };
+
+  const trigger = document.createElement('button');
+  trigger.type = 'button';
+  trigger.textContent = useFake ? 'Reopen capture…' : 'Open camera…';
+  trigger.style.cssText =
+    'font:500 13px var(--ui);padding:8px 14px;border:1px solid var(--line);border-radius:9px;' +
+    'background:var(--canvas);color:var(--ink);cursor:pointer;margin-top:6px;align-self:flex-start;';
+  trigger.addEventListener('click', openOnce);
+  thread.appendChild(trigger);
+
+  shell.append(thread, composer);
+
+  // Auto-open the fake-provider stories so reviewers see the live surface
+  // inside the composer band immediately. rAF defers until connectedCallback
+  // has injected the scoped stylesheet and the live preview can attach.
+  if (useFake) requestAnimationFrame(openOnce);
+  return shell;
+}
+
+/**
+ * Photo mode against the fake provider — Snap returns a PNG data URL and the
+ * surface closes back to the composer. The thumbnail appears in the thread
+ * above so the round-trip result is visible without leaving the story.
+ */
+export const PhotoMode: Story = {
+  args: { mode: 'photo', useFake: true, deviceCount: 2 },
+  render: buildShell,
+};
+
+/**
+ * Video mode against the fake provider — Record→Stop runs a real
+ * MediaRecorder over the canvas stream (plus a synthetic audio track), so the
+ * returned `Blob` carries both video and audio without any microphone
+ * permission. The resulting WebM plays in the result block. Two fake mics so
+ * the mic `<select>` is visible alongside the camera picker — switching it
+ * swaps the recorded audio track on the fly.
+ */
+export const VideoMode: Story = {
+  args: { mode: 'video', useFake: true, deviceCount: 2, micCount: 2 },
+  render: buildShell,
+};
+
+/**
+ * Single fake camera — the device picker is hidden because there is only one
+ * `videoinput`. Mirrors the prototype's "no picker on single-camera laptops"
+ * behavior.
+ */
+export const SingleCamera: Story = {
+  args: { mode: 'photo', useFake: true, deviceCount: 1, micCount: 1 },
+  render: buildShell,
+};
+
+/**
+ * Two fake cameras + two fake mics — both pickers are wired into the fake
+ * provider. The story opens in video mode so the mic `<select>` is visible
+ * alongside the camera picker; switching cameras preserves the mic choice,
+ * and switching mics swaps the live audio track without tearing down video.
+ */
+export const MultiCamera: Story = {
+  args: { mode: 'video', useFake: true, deviceCount: 2, micCount: 2 },
+  render: buildShell,
+};
+
+/**
+ * Two fake mics in video mode — the mic picker is visible alongside the camera
+ * picker. Switching the `<select>` swaps the live audio track on the same
+ * stream and persists the choice in `preferred-audio-device` so camera
+ * switches and photo→video promotions reuse it.
+ */
+export const MultiMicrophone: Story = {
+  args: { mode: 'video', useFake: true, deviceCount: 2, micCount: 2 },
+  render: buildShell,
+};
+
+/**
+ * Real `navigator.mediaDevices` — the provider seam is `null`, so the
+ * component falls back to the real browser stack. Storybook will prompt for
+ * camera (and microphone, in video mode) permission when Open is pressed.
+ */
+export const RealCamera: Story = {
+  args: { mode: 'photo', useFake: false, deviceCount: 0 },
+  render: buildShell,
+};

--- a/packages/webcomponents/src/composer/slicc-composer-capture.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-capture.ts
@@ -56,14 +56,18 @@ slicc-composer-capture {
   position: relative;
   display: block;
   width: 100%;
-  /* Self-bounded box: the surface fills the composer area at a 4:3 ratio,
-     clamped between a usable min and a sensible max, so the absolutely
-     positioned bar / close / status overlays always sit inside the host
-     rect rather than being pushed below by the <video>'s intrinsic size.
-     The enlarged max-height lets the box cover the composer textarea
-     when anchored to the band's bottom while keeping the control bar
-     one row at the bottom. */
-  aspect-ratio: 4 / 3;
+  /* Self-bounded box: the surface fills the composer area at a responsive
+     ratio (3:4 portrait on desktop / 4:3 landscape on mobile), clamped
+     between a usable min and a sensible max, so the absolutely positioned
+     bar / close / status overlays always sit inside the host rect rather
+     than being pushed below by the <video>'s intrinsic size. The desktop
+     max-width:360px lets the 3:4 ratio actually manifest as portrait
+     within the wider 680px composer column (480px tall x 360px wide),
+     with the box centered via margin:0 auto; the control bar stays one
+     row at the bottom. */
+  aspect-ratio: 3 / 4;
+  max-width: 360px;
+  margin: 0 auto;
   min-height: 220px;
   max-height: min(60vh, 480px);
   border-radius: 14px;
@@ -75,6 +79,15 @@ slicc-composer-capture {
 }
 slicc-composer-capture[hidden] {
   display: none;
+}
+/* Narrow / mobile: switch to landscape 4:3 and drop the desktop width
+   cap so the box fills the column (matches the WC shell's 560px narrow
+   breakpoint used by the chat thread / meta hint / logo). */
+@media (max-width: 560px) {
+  slicc-composer-capture {
+    aspect-ratio: 4 / 3;
+    max-width: 100%;
+  }
 }
 slicc-composer-capture .slicc-capture__video {
   position: absolute;

--- a/packages/webcomponents/src/composer/slicc-composer-capture.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-capture.ts
@@ -495,6 +495,9 @@ export class SliccComposerCapture extends HTMLElement {
 
   #attachStream(stream: MediaStream): void {
     this.#video.srcObject = stream;
+    // Defensive: ensure the IDL property is set before `play()` so a
+    // mic-carrying stream cannot echo through the preview element.
+    this.#video.muted = true;
     void this.#video.play?.()?.catch(() => undefined);
     const facing = stream.getVideoTracks()[0]?.getSettings?.().facingMode;
     this.#video.toggleAttribute('data-mirrored', facing !== 'environment');
@@ -829,6 +832,10 @@ export class SliccComposerCapture extends HTMLElement {
       muted: true,
       playsinline: true,
     }) as HTMLVideoElement;
+    // Chromium honors the `muted` IDL property — not the content attribute —
+    // when playback is driven by `srcObject`. Set it directly so the live
+    // preview never replays microphone audio (recorded stream is untouched).
+    this.#video.muted = true;
 
     this.#status = h('div', { class: 'slicc-capture__status' });
 

--- a/packages/webcomponents/src/composer/slicc-composer-capture.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-capture.ts
@@ -2,6 +2,7 @@ import { define } from '../internal/define.js';
 import { h } from '../internal/dom.js';
 import { iconEl } from '../internal/icons.js';
 import type { CameraMediaProvider } from '../overlay/slicc-camera-dialog.js';
+import { labelDevices, shouldShowDevicePicker } from './devices.js';
 
 /** Re-export for hosts that swap the media seam without importing from overlay. */
 export type { CameraMediaProvider } from '../overlay/slicc-camera-dialog.js';
@@ -24,9 +25,14 @@ export interface CaptureResult {
   durationMs?: number;
 }
 
-/** The `slicc-capture-device-change` event detail — the chosen camera. */
+/**
+ * The `slicc-capture-device-change` event detail — the chosen device. `kind`
+ * tells the host whether the user picked a new camera or a new microphone so
+ * a single listener can persist both preferences.
+ */
 export interface CaptureDeviceChangeDetail {
   deviceId: string;
+  kind: 'camera' | 'microphone';
 }
 
 /**
@@ -50,7 +56,13 @@ slicc-composer-capture {
   position: relative;
   display: block;
   width: 100%;
+  /* Self-bounded box: the surface fills the composer area at a 4:3 ratio,
+     clamped between a usable min and a sensible max, so the absolutely
+     positioned bar / close / status overlays always sit inside the host
+     rect rather than being pushed below by the <video>'s intrinsic size. */
+  aspect-ratio: 4 / 3;
   min-height: 220px;
+  max-height: min(60vh, 480px);
   border-radius: 14px;
   overflow: hidden;
   background: #000;
@@ -62,9 +74,10 @@ slicc-composer-capture[hidden] {
   display: none;
 }
 slicc-composer-capture .slicc-capture__video {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
-  min-height: 220px;
   display: block;
   object-fit: cover;
   background: #000;
@@ -76,12 +89,36 @@ slicc-composer-capture .slicc-capture__status {
   position: absolute;
   top: 8px;
   left: 10px;
-  right: 10px;
+  /* Leave clearance for the absolutely-positioned close button in the
+     top-right corner so the status text never visually collides with it. */
+  right: 44px;
   font-size: 11.5px;
   color: rgba(255, 255, 255, 0.85);
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
   pointer-events: none;
   min-height: 14px;
+}
+slicc-composer-capture .slicc-capture__close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  color: #fff;
+  background: color-mix(in srgb, #000 55%, transparent);
+  border: 1px solid color-mix(in srgb, #fff 35%, transparent);
+  border-radius: 50%;
+  cursor: pointer;
+  backdrop-filter: blur(8px) saturate(1.2);
+  -webkit-backdrop-filter: blur(8px) saturate(1.2);
+}
+slicc-composer-capture .slicc-capture__close:hover {
+  background: color-mix(in srgb, #fff 18%, transparent);
 }
 slicc-composer-capture .slicc-capture__bar {
   position: absolute;
@@ -91,7 +128,10 @@ slicc-composer-capture .slicc-capture__bar {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
+  /* Single row: selects shrink (min-width: 0 + flex: 0 1 auto below) instead
+     of wrapping so the bar never becomes two rows when the mic <select>
+     appears in video mode. */
+  flex-wrap: nowrap;
   padding: 6px 8px;
   border-radius: 10px;
   background: color-mix(in srgb, #000 55%, transparent);
@@ -109,7 +149,14 @@ slicc-composer-capture .slicc-capture__select {
   border-radius: 8px;
   padding: 5px 8px;
   outline: none;
-  max-width: 180px;
+  /* Allow shrinking below intrinsic width so long device labels truncate
+     instead of forcing the control bar onto a second row. */
+  min-width: 0;
+  max-width: 140px;
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 slicc-composer-capture .slicc-capture__select[hidden] {
   display: none;
@@ -122,13 +169,18 @@ slicc-composer-capture .slicc-capture__mode {
   border: 1px solid color-mix(in srgb, #fff 35%, transparent);
   border-radius: 8px;
   overflow: hidden;
+  flex: 0 0 auto;
 }
 slicc-composer-capture .slicc-capture__mode-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font: 500 12px var(--ui);
   color: #fff;
   background: transparent;
   border: 0;
-  padding: 5px 10px;
+  /* Icon-only buttons: square-ish padding centers the 14px lucide glyph. */
+  padding: 5px 8px;
   cursor: pointer;
 }
 slicc-composer-capture .slicc-capture__mode-btn[aria-pressed='true'] {
@@ -238,12 +290,16 @@ function formatElapsed(ms: number): string {
  * `new MediaRecorder(stream, opts)`) so tests / stories can drive the full
  * flow with canvas-backed fake streams and fake recorders.
  *
- * Audio: video mode requests `getUserMedia({ video, audio: true })` so the
- * recorded stream carries the camera video track AND the mic audio track.
- * Photo mode requests video only (no mic). Mic is on by default in video
- * mode — the UI surfaces this in the status line. On camera switch in video
- * mode, the video track for the new device is re-requested and the existing
- * audio track is preserved on the live stream.
+ * Audio: video mode requests `getUserMedia({ video, audio })` so the recorded
+ * stream carries the camera video track AND the mic audio track. Photo mode
+ * requests video only (no mic). Mic is on by default in video mode — the UI
+ * surfaces this in the status line. On camera switch in video mode, the
+ * video track for the new device is re-requested and the existing audio
+ * track is preserved on the live stream. A second `<select part="audio-picker">`
+ * surfaces in video mode when ≥ 2 `audioinput` devices exist; the chosen
+ * mic is preserved across camera switches and the photo→video promotion
+ * path. The picker is disabled while a `MediaRecorder` is running because
+ * mid-recording audio-track swaps are not reliably picked up.
  *
  * Imperative API: `open(mode?)` starts the stream + shows the surface and
  * resolves with a {@link CaptureResult} — or `null` when the user cancels.
@@ -251,9 +307,11 @@ function formatElapsed(ms: number): string {
  * `disconnectedCallback`); ALL tracks — video AND audio — are stopped.
  *
  * @attr mode - `photo` (default) or `video`
- * @attr preferred-device - deviceId to open first; falls back to any camera
+ * @attr preferred-device - camera deviceId to open first; falls back to any camera
+ * @attr preferred-audio-device - mic deviceId to open first (video mode); falls back to default mic
  * @csspart video - the live preview element
  * @csspart picker - the camera `<select>` (hidden for a single camera)
+ * @csspart audio-picker - the microphone `<select>` (video mode only, hidden for <2 mics)
  * @csspart mode - the Photo / Video toggle buttons
  * @csspart snap - the primary Snap button (photo mode)
  * @csspart record - the primary Record button (video mode, idle)
@@ -261,10 +319,10 @@ function formatElapsed(ms: number): string {
  * @csspart cancel - the Cancel button
  * @fires slicc-capture - composed + bubbling; `detail` is the CaptureResult
  * @fires slicc-capture-cancel - composed + bubbling; no detail; on cancel
- * @fires slicc-capture-device-change - composed + bubbling; `detail.deviceId`
+ * @fires slicc-capture-device-change - composed + bubbling; `detail` is `{ deviceId, kind: 'camera' | 'microphone' }`
  */
 export class SliccComposerCapture extends HTMLElement {
-  static readonly observedAttributes = ['mode', 'preferred-device'];
+  static readonly observedAttributes = ['mode', 'preferred-device', 'preferred-audio-device'];
 
   /** Injectable media seam; `null` falls back to `navigator.mediaDevices`. */
   media: CameraMediaProvider | null = null;
@@ -274,6 +332,7 @@ export class SliccComposerCapture extends HTMLElement {
 
   #video!: HTMLVideoElement;
   #select!: HTMLSelectElement;
+  #audioSelect!: HTMLSelectElement;
   #status!: HTMLElement;
   #timer!: HTMLElement;
   #primary!: HTMLButtonElement;
@@ -336,6 +395,21 @@ export class SliccComposerCapture extends HTMLElement {
     else this.setAttribute('preferred-device', value);
   }
 
+  /**
+   * The microphone deviceId to open first in video mode (reflected to
+   * `preferred-audio-device`). Updated automatically by `#switchMicrophone`
+   * so subsequent camera switches / photo→video promotions preserve the
+   * user's mic choice.
+   */
+  get preferredAudioDevice(): string | null {
+    return this.getAttribute('preferred-audio-device');
+  }
+
+  set preferredAudioDevice(value: string | null) {
+    if (value == null) this.removeAttribute('preferred-audio-device');
+    else this.setAttribute('preferred-audio-device', value);
+  }
+
   #mediaProvider(): CameraMediaProvider | null {
     return this.media ?? (typeof navigator !== 'undefined' ? navigator.mediaDevices : null) ?? null;
   }
@@ -358,13 +432,19 @@ export class SliccComposerCapture extends HTMLElement {
     const provider = this.#mediaProvider();
     if (!provider) return null;
     try {
-      this.#stream = await this.#openStream(provider, this.preferredDevice, this.mode);
+      this.#stream = await this.#openStream(
+        provider,
+        this.preferredDevice,
+        this.preferredAudioDevice,
+        this.mode
+      );
     } catch {
       return null;
     }
     this.#captureAudioTrack();
     this.#attachStream(this.#stream);
     await this.#populatePicker(provider);
+    await this.#populateAudioPicker(provider);
     this.hidden = false;
     return new Promise((resolve) => {
       this.#resolve = resolve;
@@ -374,17 +454,39 @@ export class SliccComposerCapture extends HTMLElement {
   async #openStream(
     provider: CameraMediaProvider,
     deviceId: string | null,
+    audioDeviceId: string | null,
     mode: CaptureMode
   ): Promise<MediaStream> {
-    const audio = mode === 'video';
+    const audio = this.#audioConstraint(audioDeviceId, mode);
     if (deviceId) {
       try {
         return await provider.getUserMedia({ video: { deviceId: { exact: deviceId } }, audio });
       } catch {
-        // Preferred camera is gone — fall through.
+        // Preferred camera (or its audio pairing) is gone — fall through.
       }
     }
-    return provider.getUserMedia({ video: true, audio });
+    try {
+      return await provider.getUserMedia({ video: true, audio });
+    } catch (err) {
+      if (audio === false) throw err;
+      // Mic was requested but unavailable — degrade to video-only so the
+      // caller still gets a usable stream, and surface the degraded state.
+      this.#status.textContent = 'Microphone unavailable — recording video only.';
+      return provider.getUserMedia({ video: true, audio: false });
+    }
+  }
+
+  /**
+   * Build the `audio` half of a `getUserMedia` constraint for the current
+   * mode. Photo mode never asks for audio. Video mode pins the preferred
+   * mic deviceId when set, falling back to the default device otherwise.
+   */
+  #audioConstraint(
+    audioDeviceId: string | null,
+    mode: CaptureMode
+  ): MediaTrackConstraints | boolean {
+    if (mode !== 'video') return false;
+    return audioDeviceId ? { deviceId: { exact: audioDeviceId } } : true;
   }
 
   #captureAudioTrack(): void {
@@ -405,14 +507,45 @@ export class SliccComposerCapture extends HTMLElement {
     } catch {
       cameras = [];
     }
+    const options = labelDevices(cameras, 'camera');
     this.#select.replaceChildren(
-      ...cameras.map((camera, index) =>
-        h('option', { value: camera.deviceId }, camera.label || `Camera ${index + 1}`)
-      )
+      ...options.map((opt) => h('option', { value: opt.deviceId }, opt.label))
     );
     const activeId = this.#stream?.getVideoTracks()[0]?.getSettings?.().deviceId;
     if (activeId) this.#select.value = activeId;
-    this.#select.toggleAttribute('hidden', cameras.length < 2);
+    this.#select.toggleAttribute('hidden', !shouldShowDevicePicker(options));
+  }
+
+  async #populateAudioPicker(provider: CameraMediaProvider): Promise<void> {
+    let mics: MediaDeviceInfo[] = [];
+    try {
+      mics = (await provider.enumerateDevices()).filter((d) => d.kind === 'audioinput');
+    } catch {
+      mics = [];
+    }
+    const options = labelDevices(mics, 'microphone');
+    this.#audioSelect.replaceChildren(
+      ...options.map((opt) => h('option', { value: opt.deviceId }, opt.label))
+    );
+    const activeId =
+      this.#audioTrack?.getSettings?.().deviceId ?? this.preferredAudioDevice ?? null;
+    if (activeId && options.some((o) => o.deviceId === activeId)) {
+      this.#audioSelect.value = activeId;
+    }
+    this.#applyAudioPickerVisibility();
+  }
+
+  /**
+   * Hide the mic `<select>` unless we are in video mode AND the underlying
+   * device list offers a real choice (≥ 2 mics). Called from `#applyMode`
+   * (mode toggle) and `#populateAudioPicker` (after enumeration), so both
+   * triggers stay in lockstep.
+   */
+  #applyAudioPickerVisibility(): void {
+    if (!this.#audioSelect) return;
+    const enough = this.#audioSelect.options.length >= 2;
+    const visible = this.mode === 'video' && enough;
+    this.#audioSelect.toggleAttribute('hidden', !visible);
   }
 
   async #switchCamera(deviceId: string): Promise<void> {
@@ -428,9 +561,11 @@ export class SliccComposerCapture extends HTMLElement {
       if (this.mode === 'video' && this.#audioTrack && this.#audioTrack.readyState === 'live') {
         merged.addTrack(this.#audioTrack);
       } else if (this.mode === 'video') {
-        // No live audio track — re-request one alongside the new video.
+        // No live audio track — re-request one (honoring the preferred mic).
         try {
-          const a = await provider.getUserMedia({ audio: true });
+          const a = await provider.getUserMedia({
+            audio: this.#audioConstraint(this.preferredAudioDevice, 'video'),
+          });
           for (const t of a.getAudioTracks()) {
             this.#audioTrack = t;
             merged.addTrack(t);
@@ -443,7 +578,7 @@ export class SliccComposerCapture extends HTMLElement {
       this.#attachStream(merged);
       this.dispatchEvent(
         new CustomEvent<CaptureDeviceChangeDetail>('slicc-capture-device-change', {
-          detail: { deviceId },
+          detail: { deviceId, kind: 'camera' },
           bubbles: true,
           composed: true,
         })
@@ -451,6 +586,49 @@ export class SliccComposerCapture extends HTMLElement {
     } catch {
       this.#status.textContent = 'Could not switch camera — keeping the current one.';
     }
+  }
+
+  /**
+   * Swap the live audio track for one bound to `deviceId`. Requests an
+   * audio-only stream for the chosen mic, removes + stops the old audio
+   * track on the live `#stream`, adds the new one, and persists the choice
+   * to `preferredAudioDevice` so subsequent camera switches / photo→video
+   * promotions reuse it. No-op (with a status message) on failure.
+   */
+  async #switchMicrophone(deviceId: string): Promise<void> {
+    const provider = this.#mediaProvider();
+    if (!provider || !this.#stream) return;
+    this.#status.textContent = '';
+    let next: MediaStream;
+    try {
+      next = await provider.getUserMedia({ audio: { deviceId: { exact: deviceId } } });
+    } catch {
+      this.#status.textContent = 'Could not switch microphone — keeping the current one.';
+      return;
+    }
+    const newTrack = next.getAudioTracks()[0];
+    if (!newTrack) {
+      this.#status.textContent = 'Could not switch microphone — keeping the current one.';
+      return;
+    }
+    if (this.#audioTrack) {
+      try {
+        this.#stream.removeTrack(this.#audioTrack);
+      } catch {
+        // ignore — removeTrack only throws if the track is already gone.
+      }
+      this.#audioTrack.stop();
+    }
+    this.#stream.addTrack(newTrack);
+    this.#audioTrack = newTrack;
+    this.preferredAudioDevice = deviceId;
+    this.dispatchEvent(
+      new CustomEvent<CaptureDeviceChangeDetail>('slicc-capture-device-change', {
+        detail: { deviceId, kind: 'microphone' },
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   #snap(): void {
@@ -496,6 +674,9 @@ export class SliccComposerCapture extends HTMLElement {
     }
     this.#recorder = recorder;
     this.#recordStartedAt = Date.now();
+    // MediaRecorder doesn't reliably pick up an audio-track swap mid-flight,
+    // so lock the mic picker until recording stops.
+    this.#audioSelect.disabled = true;
     this.#timer.hidden = false;
     this.#timer.textContent = formatElapsed(0);
     this.#timerHandle = setInterval(() => {
@@ -515,12 +696,14 @@ export class SliccComposerCapture extends HTMLElement {
   }
 
   #assembleRecording(mimeType: string): void {
-    this.#stopTimer();
+    // Capture duration BEFORE #stopTimer() — it resets #recordStartedAt to 0.
     const durationMs = this.#recordStartedAt ? Date.now() - this.#recordStartedAt : 0;
+    this.#stopTimer();
     const effectiveType = this.#recorder?.mimeType || mimeType || 'video/webm';
     const blob = new Blob(this.#chunks, { type: effectiveType });
     this.#chunks = [];
     this.#recorder = null;
+    if (this.#audioSelect) this.#audioSelect.disabled = false;
     const dataUrl = typeof URL !== 'undefined' ? URL.createObjectURL(blob) : undefined;
     this.#finishCapture({
       kind: 'video',
@@ -547,6 +730,7 @@ export class SliccComposerCapture extends HTMLElement {
     const recorder = this.#recorder;
     this.#recorder = null;
     this.#chunks = [];
+    if (this.#audioSelect) this.#audioSelect.disabled = false;
     if (recorder) {
       recorder.ondataavailable = null;
       recorder.onstop = null;
@@ -599,6 +783,7 @@ export class SliccComposerCapture extends HTMLElement {
     this.#modeVideo.setAttribute('aria-pressed', String(isVideo));
     this.#status.textContent = isVideo ? 'Mic on — video will record audio.' : '';
     this.#renderPrimary();
+    this.#applyAudioPickerVisibility();
   }
 
   #renderPrimary(): void {
@@ -657,6 +842,16 @@ export class SliccComposerCapture extends HTMLElement {
       void this.#switchCamera(this.#select.value);
     });
 
+    this.#audioSelect = h('select', {
+      class: 'slicc-capture__select',
+      part: 'audio-picker',
+      'aria-label': 'Microphone',
+      hidden: true,
+    }) as HTMLSelectElement;
+    this.#audioSelect.addEventListener('change', () => {
+      void this.#switchMicrophone(this.#audioSelect.value);
+    });
+
     this.#modePhoto = h(
       'button',
       {
@@ -664,8 +859,9 @@ export class SliccComposerCapture extends HTMLElement {
         class: 'slicc-capture__mode-btn',
         part: 'mode',
         'aria-pressed': 'true',
+        'aria-label': 'Photo',
       },
-      'Photo'
+      iconEl('image', { size: 14 })
     ) as HTMLButtonElement;
     this.#modePhoto.addEventListener('click', () => {
       this.mode = 'photo';
@@ -678,8 +874,9 @@ export class SliccComposerCapture extends HTMLElement {
         class: 'slicc-capture__mode-btn',
         part: 'mode',
         'aria-pressed': 'false',
+        'aria-label': 'Video',
       },
-      'Video'
+      iconEl('video', { size: 14 })
     ) as HTMLButtonElement;
     this.#modeVideo.addEventListener('click', () => {
       void this.#switchToVideoMode();
@@ -696,8 +893,13 @@ export class SliccComposerCapture extends HTMLElement {
 
     this.#cancel = h(
       'button',
-      { type: 'button', class: 'slicc-capture__btn', part: 'cancel' },
-      'Cancel'
+      {
+        type: 'button',
+        class: 'slicc-capture__close',
+        part: 'cancel',
+        'aria-label': 'Cancel',
+      },
+      iconEl('x', { size: 14 })
     ) as HTMLButtonElement;
     this.#cancel.addEventListener('click', () => this.#cancelCapture());
 
@@ -713,21 +915,24 @@ export class SliccComposerCapture extends HTMLElement {
       'div',
       { class: 'slicc-capture__bar' },
       this.#select,
-      modeGroup,
+      this.#audioSelect,
       h('span', { class: 'slicc-capture__spacer' }),
       this.#timer,
-      this.#cancel,
-      this.#primary
+      this.#primary,
+      modeGroup
     );
 
-    this.replaceChildren(this.#video, this.#status, bar);
+    this.replaceChildren(this.#video, this.#status, bar, this.#cancel);
     this.#applyMode(this.mode);
   }
 
   /**
    * Promote the surface into video mode mid-session. If the current stream
    * has no audio track (started in photo mode), reopen with audio so the
-   * recorded video carries microphone sound.
+   * recorded video carries microphone sound. Honors `preferredAudioDevice`
+   * so the user's mic choice survives the photo→video promotion, and
+   * re-populates the mic picker so its labels reflect the now-granted
+   * microphone permission.
    */
   async #switchToVideoMode(): Promise<void> {
     this.mode = 'video';
@@ -737,14 +942,16 @@ export class SliccComposerCapture extends HTMLElement {
     if (!provider) return;
     const activeId =
       this.#stream.getVideoTracks()[0]?.getSettings?.().deviceId ?? this.preferredDevice ?? null;
+    const audio = this.#audioConstraint(this.preferredAudioDevice, 'video');
     try {
       const next = activeId
-        ? await provider.getUserMedia({ video: { deviceId: { exact: activeId } }, audio: true })
-        : await provider.getUserMedia({ video: true, audio: true });
+        ? await provider.getUserMedia({ video: { deviceId: { exact: activeId } }, audio })
+        : await provider.getUserMedia({ video: true, audio });
       this.#stopStream();
       this.#stream = next;
       this.#captureAudioTrack();
       this.#attachStream(next);
+      await this.#populateAudioPicker(provider);
     } catch {
       this.#status.textContent = 'Microphone unavailable — recording video only.';
     }

--- a/packages/webcomponents/src/composer/slicc-composer-capture.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-capture.ts
@@ -1,0 +1,765 @@
+import { define } from '../internal/define.js';
+import { h } from '../internal/dom.js';
+import { iconEl } from '../internal/icons.js';
+import type { CameraMediaProvider } from '../overlay/slicc-camera-dialog.js';
+
+/** Re-export for hosts that swap the media seam without importing from overlay. */
+export type { CameraMediaProvider } from '../overlay/slicc-camera-dialog.js';
+
+/** Capture mode: still photo or recorded video. */
+export type CaptureMode = 'photo' | 'video';
+
+/**
+ * The shape returned by {@link SliccComposerCapture.open} and carried on the
+ * `slicc-capture` event. `image` results carry a PNG data URL; `video` results
+ * carry the assembled WebM `Blob` plus an object URL (`dataUrl`).
+ */
+export interface CaptureResult {
+  kind: 'image' | 'video';
+  dataUrl?: string;
+  blob?: Blob;
+  mimeType: string;
+  width: number;
+  height: number;
+  durationMs?: number;
+}
+
+/** The `slicc-capture-device-change` event detail — the chosen camera. */
+export interface CaptureDeviceChangeDetail {
+  deviceId: string;
+}
+
+/**
+ * Injectable recorder factory seam — defaults to `new MediaRecorder(...)` so
+ * tests / stories can drive recording deterministically with a fake recorder.
+ */
+export type RecorderFactory = (
+  stream: MediaStream,
+  options?: MediaRecorderOptions
+) => MediaRecorder;
+
+/**
+ * Scoped, document-level stylesheet. Light-DOM host (it fills its layout slot
+ * as a capture surface inside the composer band), so the chrome is injected
+ * once into the host document and selected by the host tag. Token-driven
+ * (`--canvas` / `--ink` / `--line` / `--ghost` / `--ctx` / `--ui`), so dark
+ * mode flips automatically through the inherited theme scope.
+ */
+const STYLE = `
+slicc-composer-capture {
+  position: relative;
+  display: block;
+  width: 100%;
+  min-height: 220px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  font-family: var(--ui);
+  color: #fff;
+  isolation: isolate;
+}
+slicc-composer-capture[hidden] {
+  display: none;
+}
+slicc-composer-capture .slicc-capture__video {
+  width: 100%;
+  height: 100%;
+  min-height: 220px;
+  display: block;
+  object-fit: cover;
+  background: #000;
+}
+slicc-composer-capture .slicc-capture__video[data-mirrored] {
+  transform: scaleX(-1);
+}
+slicc-composer-capture .slicc-capture__status {
+  position: absolute;
+  top: 8px;
+  left: 10px;
+  right: 10px;
+  font-size: 11.5px;
+  color: rgba(255, 255, 255, 0.85);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+  min-height: 14px;
+}
+slicc-composer-capture .slicc-capture__bar {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 6px 8px;
+  border-radius: 10px;
+  background: color-mix(in srgb, #000 55%, transparent);
+  backdrop-filter: blur(8px) saturate(1.2);
+  -webkit-backdrop-filter: blur(8px) saturate(1.2);
+}
+slicc-composer-capture .slicc-capture__spacer {
+  flex: 1 1 auto;
+}
+slicc-composer-capture .slicc-capture__select {
+  font: 400 12px var(--ui);
+  color: #fff;
+  background: color-mix(in srgb, #000 35%, transparent);
+  border: 1px solid color-mix(in srgb, #fff 35%, transparent);
+  border-radius: 8px;
+  padding: 5px 8px;
+  outline: none;
+  max-width: 180px;
+}
+slicc-composer-capture .slicc-capture__select[hidden] {
+  display: none;
+}
+slicc-composer-capture .slicc-capture__select:focus {
+  border-color: var(--ctx);
+}
+slicc-composer-capture .slicc-capture__mode {
+  display: inline-flex;
+  border: 1px solid color-mix(in srgb, #fff 35%, transparent);
+  border-radius: 8px;
+  overflow: hidden;
+}
+slicc-composer-capture .slicc-capture__mode-btn {
+  font: 500 12px var(--ui);
+  color: #fff;
+  background: transparent;
+  border: 0;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+slicc-composer-capture .slicc-capture__mode-btn[aria-pressed='true'] {
+  background: color-mix(in srgb, #fff 22%, transparent);
+}
+slicc-composer-capture .slicc-capture__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: 500 12px var(--ui);
+  color: #fff;
+  background: color-mix(in srgb, #000 35%, transparent);
+  border: 1px solid color-mix(in srgb, #fff 35%, transparent);
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+slicc-composer-capture .slicc-capture__btn:hover {
+  background: color-mix(in srgb, #fff 18%, transparent);
+}
+slicc-composer-capture .slicc-capture__btn--primary {
+  background: var(--canvas, #fff);
+  color: var(--ink, #111);
+  border-color: var(--canvas, #fff);
+}
+slicc-composer-capture .slicc-capture__btn--primary:hover {
+  background: color-mix(in srgb, var(--canvas, #fff) 85%, var(--ink, #111));
+}
+slicc-composer-capture .slicc-capture__btn--rec {
+  background: #d9362b;
+  color: #fff;
+  border-color: #d9362b;
+}
+slicc-composer-capture .slicc-capture__btn--rec:hover {
+  background: color-mix(in srgb, #d9362b 88%, #fff);
+}
+slicc-composer-capture .slicc-capture__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: currentColor;
+  display: inline-block;
+}
+slicc-composer-capture .slicc-capture__square {
+  width: 10px;
+  height: 10px;
+  background: currentColor;
+  display: inline-block;
+}
+slicc-composer-capture .slicc-capture__timer {
+  font: 500 12px var(--ui);
+  color: #fff;
+  font-variant-numeric: tabular-nums;
+  padding: 0 4px;
+}
+slicc-composer-capture .slicc-capture__timer[hidden] {
+  display: none;
+}
+`;
+
+const STYLE_ID = 'slicc-composer-capture-style';
+
+function ensureCaptureStyle(doc: Document): void {
+  if (doc.getElementById(STYLE_ID)) return;
+  const style = doc.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = STYLE;
+  (doc.head ?? doc.documentElement).appendChild(style);
+}
+
+const DEFAULT_MODE: CaptureMode = 'photo';
+const VIDEO_MIME_CANDIDATES = [
+  'video/webm;codecs=vp9,opus',
+  'video/webm;codecs=vp8,opus',
+  'video/webm',
+];
+
+function pickRecorderMime(): string {
+  if (typeof MediaRecorder === 'undefined') return 'video/webm';
+  for (const m of VIDEO_MIME_CANDIDATES) {
+    if (MediaRecorder.isTypeSupported?.(m)) return m;
+  }
+  return 'video/webm';
+}
+
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+/**
+ * `<slicc-composer-capture>` — an **inline** camera capture surface that fills
+ * its layout slot (designed to overlay/fill the composer band, like the
+ * drag-drop drop zone), not a centered modal. Live `<video>` preview (mirrored
+ * for user-facing cameras), camera picker when more than one `videoinput`
+ * exists, mode toggle (Photo / Video), and primary action: Snap (Photo) or
+ * Record / Stop (Video) with an elapsed timer. Cancel / Escape returns to the
+ * composer with nothing captured.
+ *
+ * Light DOM (no shadow root) — the host fills its slot and injects its scoped
+ * stylesheet once into the host document. Media access flows through the
+ * injectable {@link CameraMediaProvider} (`media` property, defaulting to
+ * `navigator.mediaDevices`); recording flows through the injectable
+ * {@link RecorderFactory} (`recorderFactory` property, defaulting to
+ * `new MediaRecorder(stream, opts)`) so tests / stories can drive the full
+ * flow with canvas-backed fake streams and fake recorders.
+ *
+ * Audio: video mode requests `getUserMedia({ video, audio: true })` so the
+ * recorded stream carries the camera video track AND the mic audio track.
+ * Photo mode requests video only (no mic). Mic is on by default in video
+ * mode — the UI surfaces this in the status line. On camera switch in video
+ * mode, the video track for the new device is re-requested and the existing
+ * audio track is preserved on the live stream.
+ *
+ * Imperative API: `open(mode?)` starts the stream + shows the surface and
+ * resolves with a {@link CaptureResult} — or `null` when the user cancels.
+ * The stream + recorder are always torn down on the way out (incl.
+ * `disconnectedCallback`); ALL tracks — video AND audio — are stopped.
+ *
+ * @attr mode - `photo` (default) or `video`
+ * @attr preferred-device - deviceId to open first; falls back to any camera
+ * @csspart video - the live preview element
+ * @csspart picker - the camera `<select>` (hidden for a single camera)
+ * @csspart mode - the Photo / Video toggle buttons
+ * @csspart snap - the primary Snap button (photo mode)
+ * @csspart record - the primary Record button (video mode, idle)
+ * @csspart stop - the primary Stop button (video mode, recording)
+ * @csspart cancel - the Cancel button
+ * @fires slicc-capture - composed + bubbling; `detail` is the CaptureResult
+ * @fires slicc-capture-cancel - composed + bubbling; no detail; on cancel
+ * @fires slicc-capture-device-change - composed + bubbling; `detail.deviceId`
+ */
+export class SliccComposerCapture extends HTMLElement {
+  static readonly observedAttributes = ['mode', 'preferred-device'];
+
+  /** Injectable media seam; `null` falls back to `navigator.mediaDevices`. */
+  media: CameraMediaProvider | null = null;
+
+  /** Injectable recorder factory; `null` falls back to `new MediaRecorder()`. */
+  recorderFactory: RecorderFactory | null = null;
+
+  #video!: HTMLVideoElement;
+  #select!: HTMLSelectElement;
+  #status!: HTMLElement;
+  #timer!: HTMLElement;
+  #primary!: HTMLButtonElement;
+  #cancel!: HTMLButtonElement;
+  #modePhoto!: HTMLButtonElement;
+  #modeVideo!: HTMLButtonElement;
+  #built = false;
+  #stream: MediaStream | null = null;
+  #audioTrack: MediaStreamTrack | null = null;
+  #recorder: MediaRecorder | null = null;
+  #chunks: Blob[] = [];
+  #recordStartedAt = 0;
+  #timerHandle: ReturnType<typeof setInterval> | null = null;
+  #resolve: ((result: CaptureResult | null) => void) | null = null;
+  #onKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this.#resolve) this.#cancelCapture();
+  };
+
+  connectedCallback(): void {
+    ensureCaptureStyle(this.ownerDocument);
+    this.#build();
+    this.ownerDocument.addEventListener('keydown', this.#onKeyDown);
+  }
+
+  disconnectedCallback(): void {
+    this.ownerDocument.removeEventListener('keydown', this.#onKeyDown);
+    this.#stopTimer();
+    this.#stopRecorder();
+    this.#stopStream();
+    if (this.#resolve) {
+      const resolve = this.#resolve;
+      this.#resolve = null;
+      resolve(null);
+    }
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, value: string | null): void {
+    if (name === 'mode' && this.#built) {
+      this.#applyMode((value as CaptureMode) ?? DEFAULT_MODE);
+    }
+  }
+
+  /** Active mode (reflected from the `mode` attribute). */
+  get mode(): CaptureMode {
+    return (this.getAttribute('mode') as CaptureMode) === 'video' ? 'video' : 'photo';
+  }
+
+  set mode(value: CaptureMode | null) {
+    if (value == null) this.removeAttribute('mode');
+    else this.setAttribute('mode', value);
+  }
+
+  /** The camera deviceId to open first (reflected to `preferred-device`). */
+  get preferredDevice(): string | null {
+    return this.getAttribute('preferred-device');
+  }
+
+  set preferredDevice(value: string | null) {
+    if (value == null) this.removeAttribute('preferred-device');
+    else this.setAttribute('preferred-device', value);
+  }
+
+  #mediaProvider(): CameraMediaProvider | null {
+    return this.media ?? (typeof navigator !== 'undefined' ? navigator.mediaDevices : null) ?? null;
+  }
+
+  #makeRecorder(stream: MediaStream, opts?: MediaRecorderOptions): MediaRecorder {
+    if (this.recorderFactory) return this.recorderFactory(stream, opts);
+    return new MediaRecorder(stream, opts);
+  }
+
+  /**
+   * Start the camera (preferred device first, any camera as fallback), show
+   * the capture surface, and resolve with a {@link CaptureResult} — `null`
+   * on cancel or when no camera is available. The stream + recorder are
+   * always stopped on the way out.
+   */
+  async open(mode?: CaptureMode): Promise<CaptureResult | null> {
+    this.#build();
+    if (mode) this.mode = mode;
+    this.#applyMode(this.mode);
+    const provider = this.#mediaProvider();
+    if (!provider) return null;
+    try {
+      this.#stream = await this.#openStream(provider, this.preferredDevice, this.mode);
+    } catch {
+      return null;
+    }
+    this.#captureAudioTrack();
+    this.#attachStream(this.#stream);
+    await this.#populatePicker(provider);
+    this.hidden = false;
+    return new Promise((resolve) => {
+      this.#resolve = resolve;
+    });
+  }
+
+  async #openStream(
+    provider: CameraMediaProvider,
+    deviceId: string | null,
+    mode: CaptureMode
+  ): Promise<MediaStream> {
+    const audio = mode === 'video';
+    if (deviceId) {
+      try {
+        return await provider.getUserMedia({ video: { deviceId: { exact: deviceId } }, audio });
+      } catch {
+        // Preferred camera is gone — fall through.
+      }
+    }
+    return provider.getUserMedia({ video: true, audio });
+  }
+
+  #captureAudioTrack(): void {
+    this.#audioTrack = this.#stream?.getAudioTracks()[0] ?? null;
+  }
+
+  #attachStream(stream: MediaStream): void {
+    this.#video.srcObject = stream;
+    void this.#video.play?.()?.catch(() => undefined);
+    const facing = stream.getVideoTracks()[0]?.getSettings?.().facingMode;
+    this.#video.toggleAttribute('data-mirrored', facing !== 'environment');
+  }
+
+  async #populatePicker(provider: CameraMediaProvider): Promise<void> {
+    let cameras: MediaDeviceInfo[] = [];
+    try {
+      cameras = (await provider.enumerateDevices()).filter((d) => d.kind === 'videoinput');
+    } catch {
+      cameras = [];
+    }
+    this.#select.replaceChildren(
+      ...cameras.map((camera, index) =>
+        h('option', { value: camera.deviceId }, camera.label || `Camera ${index + 1}`)
+      )
+    );
+    const activeId = this.#stream?.getVideoTracks()[0]?.getSettings?.().deviceId;
+    if (activeId) this.#select.value = activeId;
+    this.#select.toggleAttribute('hidden', cameras.length < 2);
+  }
+
+  async #switchCamera(deviceId: string): Promise<void> {
+    const provider = this.#mediaProvider();
+    if (!provider) return;
+    this.#status.textContent = '';
+    try {
+      // Video mode keeps the existing mic track alive: request video-only for
+      // the new device and re-attach the preserved audio track to the stream.
+      const next = await provider.getUserMedia({ video: { deviceId: { exact: deviceId } } });
+      this.#stopVideoTracks();
+      const merged = next;
+      if (this.mode === 'video' && this.#audioTrack && this.#audioTrack.readyState === 'live') {
+        merged.addTrack(this.#audioTrack);
+      } else if (this.mode === 'video') {
+        // No live audio track — re-request one alongside the new video.
+        try {
+          const a = await provider.getUserMedia({ audio: true });
+          for (const t of a.getAudioTracks()) {
+            this.#audioTrack = t;
+            merged.addTrack(t);
+          }
+        } catch {
+          this.#status.textContent = 'Microphone unavailable — recording video only.';
+        }
+      }
+      this.#stream = merged;
+      this.#attachStream(merged);
+      this.dispatchEvent(
+        new CustomEvent<CaptureDeviceChangeDetail>('slicc-capture-device-change', {
+          detail: { deviceId },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    } catch {
+      this.#status.textContent = 'Could not switch camera — keeping the current one.';
+    }
+  }
+
+  #snap(): void {
+    const canvas = this.ownerDocument.createElement('canvas');
+    canvas.width = this.#video.videoWidth;
+    canvas.height = this.#video.videoHeight;
+    if (canvas.width === 0 || canvas.height === 0) {
+      this.#status.textContent = 'No frame yet — give the camera a moment.';
+      return;
+    }
+    canvas.getContext('2d')?.drawImage(this.#video, 0, 0);
+    const mimeType = 'image/png';
+    const dataUrl = canvas.toDataURL(mimeType);
+    this.#finishCapture({
+      kind: 'image',
+      dataUrl,
+      mimeType,
+      width: canvas.width,
+      height: canvas.height,
+    });
+  }
+
+  #startRecording(): void {
+    if (!this.#stream || this.#recorder) return;
+    this.#chunks = [];
+    const mimeType = pickRecorderMime();
+    let recorder: MediaRecorder;
+    try {
+      recorder = this.#makeRecorder(this.#stream, { mimeType });
+    } catch {
+      this.#status.textContent = 'Recording is not supported in this browser.';
+      return;
+    }
+    recorder.ondataavailable = (e: BlobEvent) => {
+      if (e.data && e.data.size > 0) this.#chunks.push(e.data);
+    };
+    recorder.onstop = () => this.#assembleRecording(mimeType);
+    try {
+      recorder.start();
+    } catch {
+      this.#status.textContent = 'Could not start recording.';
+      return;
+    }
+    this.#recorder = recorder;
+    this.#recordStartedAt = Date.now();
+    this.#timer.hidden = false;
+    this.#timer.textContent = formatElapsed(0);
+    this.#timerHandle = setInterval(() => {
+      this.#timer.textContent = formatElapsed(Date.now() - this.#recordStartedAt);
+    }, 250);
+    this.#renderPrimary();
+  }
+
+  #stopRecording(): void {
+    const recorder = this.#recorder;
+    if (!recorder) return;
+    try {
+      if (recorder.state !== 'inactive') recorder.stop();
+    } catch {
+      this.#assembleRecording(recorder.mimeType || 'video/webm');
+    }
+  }
+
+  #assembleRecording(mimeType: string): void {
+    this.#stopTimer();
+    const durationMs = this.#recordStartedAt ? Date.now() - this.#recordStartedAt : 0;
+    const effectiveType = this.#recorder?.mimeType || mimeType || 'video/webm';
+    const blob = new Blob(this.#chunks, { type: effectiveType });
+    this.#chunks = [];
+    this.#recorder = null;
+    const dataUrl = typeof URL !== 'undefined' ? URL.createObjectURL(blob) : undefined;
+    this.#finishCapture({
+      kind: 'video',
+      blob,
+      dataUrl,
+      mimeType: effectiveType,
+      width: this.#video.videoWidth,
+      height: this.#video.videoHeight,
+      durationMs,
+    });
+  }
+
+  #stopTimer(): void {
+    if (this.#timerHandle != null) {
+      clearInterval(this.#timerHandle);
+      this.#timerHandle = null;
+    }
+    this.#timer.hidden = true;
+    this.#timer.textContent = '';
+    this.#recordStartedAt = 0;
+  }
+
+  #stopRecorder(): void {
+    const recorder = this.#recorder;
+    this.#recorder = null;
+    this.#chunks = [];
+    if (recorder) {
+      recorder.ondataavailable = null;
+      recorder.onstop = null;
+      try {
+        if (recorder.state !== 'inactive') recorder.stop();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  #stopVideoTracks(): void {
+    for (const t of this.#stream?.getVideoTracks() ?? []) t.stop();
+  }
+
+  #stopStream(): void {
+    for (const track of this.#stream?.getTracks() ?? []) track.stop();
+    this.#stream = null;
+    this.#audioTrack = null;
+    if (this.#video) this.#video.srcObject = null;
+  }
+
+  #cancelCapture(): void {
+    this.dispatchEvent(new CustomEvent('slicc-capture-cancel', { bubbles: true, composed: true }));
+    this.#finishCapture(null);
+  }
+
+  #finishCapture(result: CaptureResult | null): void {
+    if (result) {
+      this.dispatchEvent(
+        new CustomEvent<CaptureResult>('slicc-capture', {
+          detail: result,
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }
+    this.#stopTimer();
+    this.#stopRecorder();
+    this.#stopStream();
+    const resolve = this.#resolve;
+    this.#resolve = null;
+    this.hidden = true;
+    resolve?.(result);
+  }
+
+  #applyMode(mode: CaptureMode): void {
+    const isVideo = mode === 'video';
+    this.#modePhoto.setAttribute('aria-pressed', String(!isVideo));
+    this.#modeVideo.setAttribute('aria-pressed', String(isVideo));
+    this.#status.textContent = isVideo ? 'Mic on — video will record audio.' : '';
+    this.#renderPrimary();
+  }
+
+  #renderPrimary(): void {
+    const btn = this.#primary;
+    btn.replaceChildren();
+    if (this.mode === 'photo') {
+      btn.className = 'slicc-capture__btn slicc-capture__btn--primary';
+      btn.setAttribute('part', 'snap');
+      btn.setAttribute('aria-label', 'Snap photo');
+      btn.append(iconEl('camera', { size: 14 }), document.createTextNode(' Snap'));
+      return;
+    }
+    if (this.#recorder) {
+      btn.className = 'slicc-capture__btn slicc-capture__btn--rec';
+      btn.setAttribute('part', 'stop');
+      btn.setAttribute('aria-label', 'Stop recording');
+      btn.append(h('span', { class: 'slicc-capture__square' }), document.createTextNode(' Stop'));
+    } else {
+      btn.className = 'slicc-capture__btn slicc-capture__btn--rec';
+      btn.setAttribute('part', 'record');
+      btn.setAttribute('aria-label', 'Start recording');
+      btn.append(h('span', { class: 'slicc-capture__dot' }), document.createTextNode(' Record'));
+    }
+  }
+
+  #onPrimaryClick(): void {
+    if (this.mode === 'photo') {
+      this.#snap();
+      return;
+    }
+    if (this.#recorder) this.#stopRecording();
+    else this.#startRecording();
+  }
+
+  #build(): void {
+    if (this.#built) return;
+    this.#built = true;
+
+    this.#video = h('video', {
+      class: 'slicc-capture__video',
+      part: 'video',
+      autoplay: true,
+      muted: true,
+      playsinline: true,
+    }) as HTMLVideoElement;
+
+    this.#status = h('div', { class: 'slicc-capture__status' });
+
+    this.#select = h('select', {
+      class: 'slicc-capture__select',
+      part: 'picker',
+      'aria-label': 'Camera',
+      hidden: true,
+    }) as HTMLSelectElement;
+    this.#select.addEventListener('change', () => {
+      void this.#switchCamera(this.#select.value);
+    });
+
+    this.#modePhoto = h(
+      'button',
+      {
+        type: 'button',
+        class: 'slicc-capture__mode-btn',
+        part: 'mode',
+        'aria-pressed': 'true',
+      },
+      'Photo'
+    ) as HTMLButtonElement;
+    this.#modePhoto.addEventListener('click', () => {
+      this.mode = 'photo';
+    });
+
+    this.#modeVideo = h(
+      'button',
+      {
+        type: 'button',
+        class: 'slicc-capture__mode-btn',
+        part: 'mode',
+        'aria-pressed': 'false',
+      },
+      'Video'
+    ) as HTMLButtonElement;
+    this.#modeVideo.addEventListener('click', () => {
+      void this.#switchToVideoMode();
+    });
+
+    const modeGroup = h(
+      'div',
+      { class: 'slicc-capture__mode', role: 'group', 'aria-label': 'Capture mode' },
+      this.#modePhoto,
+      this.#modeVideo
+    );
+
+    this.#timer = h('span', { class: 'slicc-capture__timer', hidden: true });
+
+    this.#cancel = h(
+      'button',
+      { type: 'button', class: 'slicc-capture__btn', part: 'cancel' },
+      'Cancel'
+    ) as HTMLButtonElement;
+    this.#cancel.addEventListener('click', () => this.#cancelCapture());
+
+    this.#primary = h('button', {
+      type: 'button',
+      class: 'slicc-capture__btn slicc-capture__btn--primary',
+      part: 'snap',
+      'aria-label': 'Snap photo',
+    }) as HTMLButtonElement;
+    this.#primary.addEventListener('click', () => this.#onPrimaryClick());
+
+    const bar = h(
+      'div',
+      { class: 'slicc-capture__bar' },
+      this.#select,
+      modeGroup,
+      h('span', { class: 'slicc-capture__spacer' }),
+      this.#timer,
+      this.#cancel,
+      this.#primary
+    );
+
+    this.replaceChildren(this.#video, this.#status, bar);
+    this.#applyMode(this.mode);
+  }
+
+  /**
+   * Promote the surface into video mode mid-session. If the current stream
+   * has no audio track (started in photo mode), reopen with audio so the
+   * recorded video carries microphone sound.
+   */
+  async #switchToVideoMode(): Promise<void> {
+    this.mode = 'video';
+    if (!this.#stream) return;
+    if (this.#stream.getAudioTracks().length > 0) return;
+    const provider = this.#mediaProvider();
+    if (!provider) return;
+    const activeId =
+      this.#stream.getVideoTracks()[0]?.getSettings?.().deviceId ?? this.preferredDevice ?? null;
+    try {
+      const next = activeId
+        ? await provider.getUserMedia({ video: { deviceId: { exact: activeId } }, audio: true })
+        : await provider.getUserMedia({ video: true, audio: true });
+      this.#stopStream();
+      this.#stream = next;
+      this.#captureAudioTrack();
+      this.#attachStream(next);
+    } catch {
+      this.#status.textContent = 'Microphone unavailable — recording video only.';
+    }
+  }
+}
+
+define('slicc-composer-capture', SliccComposerCapture);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'slicc-composer-capture': SliccComposerCapture;
+  }
+  interface HTMLElementEventMap {
+    'slicc-capture': CustomEvent<CaptureResult>;
+    'slicc-capture-cancel': CustomEvent<void>;
+    'slicc-capture-device-change': CustomEvent<CaptureDeviceChangeDetail>;
+  }
+}

--- a/packages/webcomponents/src/composer/slicc-composer-capture.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-capture.ts
@@ -694,8 +694,11 @@ export class SliccComposerCapture extends HTMLElement {
     this.#recorder = recorder;
     this.#recordStartedAt = Date.now();
     // MediaRecorder doesn't reliably pick up an audio-track swap mid-flight,
-    // so lock the mic picker until recording stops.
+    // so lock the mic picker until recording stops. Lock the camera picker
+    // too — switching cameras would stop the video tracks the recorder is
+    // bound to and produce a broken recording.
     this.#audioSelect.disabled = true;
+    this.#select.disabled = true;
     this.#timer.hidden = false;
     this.#timer.textContent = formatElapsed(0);
     this.#timerHandle = setInterval(() => {
@@ -723,6 +726,7 @@ export class SliccComposerCapture extends HTMLElement {
     this.#chunks = [];
     this.#recorder = null;
     if (this.#audioSelect) this.#audioSelect.disabled = false;
+    if (this.#select) this.#select.disabled = false;
     const dataUrl = typeof URL !== 'undefined' ? URL.createObjectURL(blob) : undefined;
     this.#finishCapture({
       kind: 'video',
@@ -750,6 +754,7 @@ export class SliccComposerCapture extends HTMLElement {
     this.#recorder = null;
     this.#chunks = [];
     if (this.#audioSelect) this.#audioSelect.disabled = false;
+    if (this.#select) this.#select.disabled = false;
     if (recorder) {
       recorder.ondataavailable = null;
       recorder.onstop = null;

--- a/packages/webcomponents/src/composer/slicc-composer-capture.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-capture.ts
@@ -60,12 +60,12 @@ slicc-composer-capture {
      clamped between a usable min and a sensible max, so the absolutely
      positioned bar / close / status overlays always sit inside the host
      rect rather than being pushed below by the <video>'s intrinsic size.
-     Compact drop-target max-height mirrors the ~300px add-menu .results
-     panel so the surface reads as an overlay above the input row, not a
-     full chat-pane takeover. */
+     The enlarged max-height lets the box cover the composer textarea
+     when anchored to the band's bottom while keeping the control bar
+     one row at the bottom. */
   aspect-ratio: 4 / 3;
   min-height: 220px;
-  max-height: min(40vh, 300px);
+  max-height: min(60vh, 480px);
   border-radius: 14px;
   overflow: hidden;
   background: #000;

--- a/packages/webcomponents/src/composer/slicc-composer-capture.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-capture.ts
@@ -59,10 +59,13 @@ slicc-composer-capture {
   /* Self-bounded box: the surface fills the composer area at a 4:3 ratio,
      clamped between a usable min and a sensible max, so the absolutely
      positioned bar / close / status overlays always sit inside the host
-     rect rather than being pushed below by the <video>'s intrinsic size. */
+     rect rather than being pushed below by the <video>'s intrinsic size.
+     Compact drop-target max-height mirrors the ~300px add-menu .results
+     panel so the surface reads as an overlay above the input row, not a
+     full chat-pane takeover. */
   aspect-ratio: 4 / 3;
   min-height: 220px;
-  max-height: min(60vh, 480px);
+  max-height: min(40vh, 300px);
   border-radius: 14px;
   overflow: hidden;
   background: #000;

--- a/packages/webcomponents/src/composer/slicc-composer.stories.ts
+++ b/packages/webcomponents/src/composer/slicc-composer.stories.ts
@@ -161,17 +161,17 @@ function appendPhotoResult(thread: HTMLElement, result: CaptureResult): void {
 
 /**
  * Wire the add-menu's "Take a photo" quick-action to the inline capture
- * surface mounted inside the composer band: when `slicc-add` bubbles up with
- * `{ kind: 'capture', mode: 'photo' }`, hide the input card + meta row,
- * un-hide the capture surface, and `open('photo')`. When the promise resolves
- * (snap or cancel — `#finishCapture` re-hides the surface itself), restore
- * the input card + meta row and surface any photo result in the thread.
+ * surface mounted as a full-area overlay on the chat-column shell: when
+ * `slicc-add` bubbles up with `{ kind: 'capture', mode: 'photo' }`, un-hide
+ * the surface (it covers the thread + composer band, mirroring the PTT
+ * overlay / drop-zone pattern) and `open('photo')`. When the promise
+ * resolves (snap or cancel — `#finishCapture` re-hides the surface itself),
+ * surface any photo result in the thread. The composer band stays untouched
+ * underneath the overlay, so no card/meta toggling is needed.
  */
 function wireInlineCapture(
   composer: SliccComposer,
   capture: SliccComposerCapture,
-  inputCardEl: HTMLElement,
-  metaRowEl: HTMLElement,
   thread: HTMLElement
 ): void {
   let active = false;
@@ -182,11 +182,7 @@ function wireInlineCapture(
     if (active || detail.kind !== 'capture' || !('mode' in detail)) return;
     if (detail.mode !== 'photo') return;
     active = true;
-    inputCardEl.hidden = true;
-    metaRowEl.hidden = true;
     void capture.open('photo').then((result) => {
-      inputCardEl.hidden = false;
-      metaRowEl.hidden = false;
       active = false;
       if (result) appendPhotoResult(thread, result);
     });
@@ -200,17 +196,22 @@ function wireInlineCapture(
  * components: `<slicc-input-card>` (add-menu + gravatar send button) + a
  * `<slicc-composer-meta>` row. Light/dark is driven by the global theme toolbar.
  *
- * The composer also mounts a `<slicc-composer-capture>` surface (hidden at
- * rest, fake camera provider so no real permission is needed). The add-menu's
- * "Take a photo" quick-action drives it inline via the bubbling `slicc-add`
- * event — Snap or Cancel returns to the input card and surfaces any photo
- * result in the thread.
+ * The shell also hosts a `<slicc-composer-capture>` surface as a full-area
+ * overlay (hidden at rest, fake camera provider so no real permission is
+ * needed). It is appended to the shell — not into the composer band — and
+ * given story-level inline styles that override the component's self-bounded
+ * tag stylesheet so it fills the whole chat column (`position:absolute;
+ * inset:0; z-index:10`), mirroring the PTT overlay and add-menu drop-zone
+ * pattern. The add-menu's "Take a photo" quick-action drives it inline via
+ * the bubbling `slicc-add` event — Snap or Cancel returns to the resting
+ * composer and surfaces any photo result in the thread.
  */
 function composer({ open }: ComposerArgs): HTMLElement {
   // A chat-column shell: faux thread above, composer footer pinned below.
+  // `position:relative` anchors the absolutely-positioned capture overlay.
   const shell = document.createElement('div');
   shell.style.cssText =
-    'display:flex;flex-direction:column;height:460px;width:100%;background:var(--bg);overflow:hidden;font-family:var(--ui);';
+    'position:relative;display:flex;flex-direction:column;height:460px;width:100%;background:var(--bg);overflow:hidden;font-family:var(--ui);';
 
   const thread = document.createElement('div');
   thread.style.cssText =
@@ -234,17 +235,22 @@ function composer({ open }: ComposerArgs): HTMLElement {
 
   const el = document.createElement('slicc-composer') as SliccComposer;
   if (open) el.setAttribute('open', '');
-  const card = inputCard();
-  const meta = metaRow(Boolean(open));
+  el.append(inputCard(), metaRow(Boolean(open)));
+
   const capture = document.createElement('slicc-composer-capture') as SliccComposerCapture;
   capture.media = makeFakePhotoProvider();
   capture.setAttribute('mode', 'photo');
   capture.hidden = true;
-  el.append(card, meta, capture);
+  // Story-level overlay: inline styles win over the component's tag-selector
+  // self-bounded box (4:3 / max 480px) so the surface fills the whole chat
+  // column with its bottom control bar fully visible. Same pattern as the
+  // PTT overlay (`.slicc-composer__ptt`) and the add-menu drop zone (`.drop`).
+  capture.style.cssText =
+    'position:absolute;inset:0;z-index:10;max-height:none;aspect-ratio:auto;border-radius:0;';
 
-  wireInlineCapture(el, capture, card, meta, thread);
+  wireInlineCapture(el, capture, thread);
 
-  shell.append(thread, el);
+  shell.append(thread, el, capture);
   return shell;
 }
 

--- a/packages/webcomponents/src/composer/slicc-composer.stories.ts
+++ b/packages/webcomponents/src/composer/slicc-composer.stories.ts
@@ -5,7 +5,14 @@ import type { Meta, StoryObj } from '@storybook/web-components-vite';
 // directly so the custom send-button (with a gravatar `email`) we slot in is
 // registered too, and so the meta row's model/thinking pills are available.
 import '../add-menu/slicc-add-menu.js';
+import type { SliccAddDetail } from '../add-menu/slicc-add-menu.js';
 import '../primitives/slicc-send-button.js';
+import './slicc-composer-capture.js';
+import type {
+  CameraMediaProvider,
+  CaptureResult,
+  SliccComposerCapture,
+} from './slicc-composer-capture.js';
 import './slicc-composer-meta.js';
 import './slicc-composer.js';
 import './slicc-input-card.js';
@@ -85,11 +92,119 @@ function metaRow(narrow: boolean): HTMLElement {
 }
 
 /**
+ * A canvas-backed `CameraMediaProvider` for photo-only capture in the composer
+ * story: one fake `videoinput` paints a hued, animated canvas at 15fps and
+ * `enumerateDevices()` returns the matching `MediaDeviceInfo`. Photo mode never
+ * asks for audio, so no oscillator / mic track is needed here — the broader
+ * multi-camera + video + mic variants live in `slicc-composer-capture.stories.ts`.
+ * Keeps the inline-capture demo permission-free without dragging the full fake
+ * provider over from the capture-surface story.
+ */
+function makeFakePhotoProvider(): CameraMediaProvider {
+  return {
+    getUserMedia: async () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 640;
+      canvas.height = 480;
+      const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+      let t = 0;
+      const tick = setInterval(() => {
+        t += 1;
+        ctx.fillStyle = `hsl(28, 70%, ${55 + 10 * Math.sin(t / 10)}%)`;
+        ctx.fillRect(0, 0, 640, 480);
+        ctx.fillStyle = '#fff';
+        ctx.font = '28px sans-serif';
+        ctx.fillText('Demo camera', 24, 240);
+        ctx.font = '14px monospace';
+        ctx.fillText(`frame ${t}`, 24, 280);
+      }, 80);
+      const stream = new MediaStream();
+      const track = canvas.captureStream(15).getVideoTracks()[0];
+      const origStop = track.stop.bind(track);
+      track.stop = () => {
+        clearInterval(tick);
+        origStop();
+      };
+      track.getSettings = () =>
+        ({ deviceId: 'demo-front', facingMode: 'user' }) as MediaTrackSettings;
+      stream.addTrack(track);
+      return stream;
+    },
+    enumerateDevices: async () => [
+      { kind: 'videoinput', deviceId: 'demo-front', label: 'Demo camera' } as MediaDeviceInfo,
+    ],
+  };
+}
+
+/**
+ * Append a small thumbnail line to the faux thread so the add-menu → capture →
+ * result round-trip is visible without leaving the story. Photo results carry
+ * a PNG data URL; the block uses token-driven surfaces so it reads in both
+ * light and dark themes.
+ */
+function appendPhotoResult(thread: HTMLElement, result: CaptureResult): void {
+  if (result.kind !== 'image' || !result.dataUrl) return;
+  const block = document.createElement('p');
+  block.style.cssText =
+    'margin:14px 0 0;padding:10px;border:1px solid var(--line);border-radius:10px;' +
+    'background:var(--canvas);color:var(--ink);display:flex;align-items:center;gap:10px;';
+  const img = document.createElement('img');
+  img.src = result.dataUrl;
+  img.alt = 'Captured photo';
+  img.style.cssText = 'width:64px;height:48px;object-fit:cover;border-radius:6px;display:block;';
+  const cap = document.createElement('span');
+  cap.style.cssText = 'font-size:12px;color:var(--txt-2);';
+  cap.textContent = `Snapped ${result.width}×${result.height} · ${result.mimeType}`;
+  block.append(img, cap);
+  thread.appendChild(block);
+}
+
+/**
+ * Wire the add-menu's "Take a photo" quick-action to the inline capture
+ * surface mounted inside the composer band: when `slicc-add` bubbles up with
+ * `{ kind: 'capture', mode: 'photo' }`, hide the input card + meta row,
+ * un-hide the capture surface, and `open('photo')`. When the promise resolves
+ * (snap or cancel — `#finishCapture` re-hides the surface itself), restore
+ * the input card + meta row and surface any photo result in the thread.
+ */
+function wireInlineCapture(
+  composer: SliccComposer,
+  capture: SliccComposerCapture,
+  inputCardEl: HTMLElement,
+  metaRowEl: HTMLElement,
+  thread: HTMLElement
+): void {
+  let active = false;
+  composer.addEventListener('slicc-add', (event) => {
+    const detail = (event as CustomEvent<SliccAddDetail>).detail;
+    // The detail union's catch-all variant overlaps with `kind: 'capture'`, so
+    // narrow on the `mode` property's presence before reading it.
+    if (active || detail.kind !== 'capture' || !('mode' in detail)) return;
+    if (detail.mode !== 'photo') return;
+    active = true;
+    inputCardEl.hidden = true;
+    metaRowEl.hidden = true;
+    void capture.open('photo').then((result) => {
+      inputCardEl.hidden = false;
+      metaRowEl.hidden = false;
+      active = false;
+      if (result) appendPhotoResult(thread, result);
+    });
+  });
+}
+
+/**
  * Build a fully-populated composer mounted in a chat-column shell, so the
  * frosted footer band reads against a chat-thread-like surface above it (the
  * prototype layout). The footer is composed entirely from real library
  * components: `<slicc-input-card>` (add-menu + gravatar send button) + a
  * `<slicc-composer-meta>` row. Light/dark is driven by the global theme toolbar.
+ *
+ * The composer also mounts a `<slicc-composer-capture>` surface (hidden at
+ * rest, fake camera provider so no real permission is needed). The add-menu's
+ * "Take a photo" quick-action drives it inline via the bubbling `slicc-add`
+ * event — Snap or Cancel returns to the input card and surfaces any photo
+ * result in the thread.
  */
 function composer({ open }: ComposerArgs): HTMLElement {
   // A chat-column shell: faux thread above, composer footer pinned below.
@@ -99,15 +214,35 @@ function composer({ open }: ComposerArgs): HTMLElement {
 
   const thread = document.createElement('div');
   thread.style.cssText =
-    'flex:1 1 auto;overflow:hidden;padding:28px 24px;color:var(--txt-2);font-size:14px;line-height:1.5;';
-  thread.innerHTML =
-    '<p style="margin:0 0 12px;color:var(--ink);">Make the landing hero feel warmer.</p>' +
-    '<p style="margin:0 0 12px;">On it — auditing the cold hero, then redesigning in a live sprinkle. I will verify before/after in the browser and open a PR.</p>' +
-    '<p style="margin:0;">The composer footer below frosts over this thread; opening the add-menu pops a results panel <b>up and over</b> these lines (z-index:2) without growing the band.</p>';
+    'flex:1 1 auto;overflow:auto;padding:28px 24px;color:var(--txt-2);font-size:14px;line-height:1.5;';
+  for (const [tone, text] of [
+    ['ink', 'Make the landing hero feel warmer.'],
+    [
+      'mute',
+      'On it — auditing the cold hero, then redesigning in a live sprinkle. I will verify before/after in the browser and open a PR.',
+    ],
+    [
+      'mute',
+      'The composer footer below frosts over this thread; opening the add-menu pops a results panel up and over these lines (z-index:2) without growing the band.',
+    ],
+  ] as const) {
+    const p = document.createElement('p');
+    p.textContent = text;
+    p.style.cssText = tone === 'ink' ? 'margin:0 0 12px;color:var(--ink);' : 'margin:0 0 12px;';
+    thread.appendChild(p);
+  }
 
   const el = document.createElement('slicc-composer') as SliccComposer;
   if (open) el.setAttribute('open', '');
-  el.append(inputCard(), metaRow(Boolean(open)));
+  const card = inputCard();
+  const meta = metaRow(Boolean(open));
+  const capture = document.createElement('slicc-composer-capture') as SliccComposerCapture;
+  capture.media = makeFakePhotoProvider();
+  capture.setAttribute('mode', 'photo');
+  capture.hidden = true;
+  el.append(card, meta, capture);
+
+  wireInlineCapture(el, capture, card, meta, thread);
 
   shell.append(thread, el);
   return shell;

--- a/packages/webcomponents/src/composer/slicc-composer.ts
+++ b/packages/webcomponents/src/composer/slicc-composer.ts
@@ -1,6 +1,7 @@
 import { define } from '../internal/define.js';
 import { h } from '../internal/dom.js';
 import { iconEl } from '../internal/icons.js';
+import { shouldShowDevicePicker } from './devices.js';
 import {
   type ComposerSpeech,
   createBuiltinComposerSpeech,
@@ -719,7 +720,7 @@ export class SliccComposer extends HTMLElement {
 
     void speech.microphones().then((mics) => {
       if (token !== this.#token) return;
-      if (mics.length > 1) this.#renderDevicePicker(mics);
+      if (shouldShowDevicePicker(mics)) this.#renderDevicePicker(mics);
     });
 
     void speech

--- a/packages/webcomponents/src/composer/speech.ts
+++ b/packages/webcomponents/src/composer/speech.ts
@@ -1,3 +1,5 @@
+import { labelDevices } from './devices.js';
+
 /**
  * Speech contract for the composer's push-to-talk gesture.
  *
@@ -172,9 +174,10 @@ export function createBuiltinComposerSpeech(): ComposerSpeech {
       if (!navigator.mediaDevices?.enumerateDevices) return [];
       try {
         const devices = await navigator.mediaDevices.enumerateDevices();
-        return devices
-          .filter((d) => d.kind === 'audioinput')
-          .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${i + 1}` }));
+        return labelDevices(
+          devices.filter((d) => d.kind === 'audioinput'),
+          'microphone'
+        );
       } catch {
         return [];
       }

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -21,6 +21,14 @@ export { SliccLickCard } from './chat/slicc-lick-card.js';
 export { SliccToolCluster } from './chat/slicc-tool-cluster.js';
 export { SliccUserMessage } from './chat/slicc-user-message.js';
 export { HOLD_TO_ENABLE_MS, SliccComposer } from './composer/slicc-composer.js';
+export {
+  type CameraMediaProvider,
+  type CaptureDeviceChangeDetail,
+  type CaptureMode,
+  type CaptureResult,
+  type RecorderFactory,
+  SliccComposerCapture,
+} from './composer/slicc-composer-capture.js';
 export { SliccComposerMeta } from './composer/slicc-composer-meta.js';
 export { SliccInputCard } from './composer/slicc-input-card.js';
 export {

--- a/packages/webcomponents/src/register.ts
+++ b/packages/webcomponents/src/register.ts
@@ -13,6 +13,7 @@ import './chat/slicc-handoff-card.js';
 import './chat/slicc-lick-card.js';
 import './chat/slicc-tool-cluster.js';
 import './chat/slicc-user-message.js';
+import './composer/slicc-composer-capture.js';
 import './composer/slicc-composer-meta.js';
 import './composer/slicc-composer.js';
 import './composer/slicc-input-card.js';

--- a/packages/webcomponents/tests/composer/devices.test.ts
+++ b/packages/webcomponents/tests/composer/devices.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { deviceLabel, labelDevices, shouldShowDevicePicker } from '../../src/composer/devices.js';
+
+describe('devices (shared composer picker helpers)', () => {
+  describe('deviceLabel', () => {
+    it('returns the trimmed label when present', () => {
+      expect(deviceLabel('FaceTime HD', 0, 'camera')).toBe('FaceTime HD');
+      expect(deviceLabel('  USB Condenser  ', 1, 'microphone')).toBe('USB Condenser');
+    });
+
+    it('falls back to a 1-indexed positional placeholder per kind', () => {
+      expect(deviceLabel('', 0, 'camera')).toBe('Camera 1');
+      expect(deviceLabel(null, 1, 'camera')).toBe('Camera 2');
+      expect(deviceLabel(undefined, 0, 'microphone')).toBe('Microphone 1');
+      expect(deviceLabel('   ', 2, 'microphone')).toBe('Microphone 3');
+    });
+  });
+
+  describe('labelDevices', () => {
+    it('normalizes a mixed list, preserving input order and ids', () => {
+      const out = labelDevices(
+        [
+          { deviceId: 'a', label: 'Alpha' },
+          { deviceId: 'b', label: '' },
+          { deviceId: 'c', label: null },
+          { deviceId: 'd' },
+        ],
+        'camera'
+      );
+      expect(out).toEqual([
+        { deviceId: 'a', label: 'Alpha' },
+        { deviceId: 'b', label: 'Camera 2' },
+        { deviceId: 'c', label: 'Camera 3' },
+        { deviceId: 'd', label: 'Camera 4' },
+      ]);
+    });
+
+    it('uses the microphone placeholder when kind is microphone', () => {
+      const out = labelDevices(
+        [
+          { deviceId: 'm1', label: '' },
+          { deviceId: 'm2', label: 'Studio Mic' },
+        ],
+        'microphone'
+      );
+      expect(out).toEqual([
+        { deviceId: 'm1', label: 'Microphone 1' },
+        { deviceId: 'm2', label: 'Studio Mic' },
+      ]);
+    });
+
+    it('returns an empty array for an empty input', () => {
+      expect(labelDevices([], 'camera')).toEqual([]);
+      expect(labelDevices([], 'microphone')).toEqual([]);
+    });
+  });
+
+  describe('shouldShowDevicePicker', () => {
+    it('is false for 0 or 1 devices, true for 2+', () => {
+      expect(shouldShowDevicePicker([])).toBe(false);
+      expect(shouldShowDevicePicker([{}])).toBe(false);
+      expect(shouldShowDevicePicker([{}, {}])).toBe(true);
+      expect(shouldShowDevicePicker([{}, {}, {}])).toBe(true);
+    });
+
+    it('accepts any ArrayLike (length-only), not just arrays', () => {
+      expect(shouldShowDevicePicker({ length: 0 })).toBe(false);
+      expect(shouldShowDevicePicker({ length: 1 })).toBe(false);
+      expect(shouldShowDevicePicker({ length: 2 })).toBe(true);
+    });
+  });
+});

--- a/packages/webcomponents/tests/composer/slicc-composer-capture.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-composer-capture.test.ts
@@ -531,7 +531,7 @@ describe('slicc-composer-capture', () => {
     await pending;
   });
 
-  it('disables the mic picker while recording and re-enables it on stop', async () => {
+  it('disables the mic and camera pickers while recording and re-enables them on stop', async () => {
     const provider = makeProvider(TWO_CAMERAS, TWO_MICS);
     const { factory, recorders } = makeRecorderFactory();
     const el = mount(provider);
@@ -542,7 +542,9 @@ describe('slicc-composer-capture', () => {
       expect(videoOf(el).srcObject).toBeTruthy();
     });
     const picker = micPickerOf(el);
+    const camPicker = pickerOf(el);
     expect(picker.disabled).toBe(false);
+    expect(camPicker.disabled).toBe(false);
 
     // Record.
     primaryOf(el).click();
@@ -551,13 +553,18 @@ describe('slicc-composer-capture', () => {
       expect(recorders[0].state).toBe('recording');
     });
     expect(picker.disabled).toBe(true);
+    // Camera picker is locked too — switching cameras mid-recording would
+    // stop the video tracks the active MediaRecorder is bound to.
+    expect(camPicker.disabled).toBe(true);
 
     // Stop.
     primaryOf(el).click();
     await pending;
-    // After assembly, the picker is unlocked again — even though the element
-    // is hidden, the disabled state has been cleared for the next session.
+    // After assembly, both pickers are unlocked again — even though the
+    // element is hidden, the disabled state has been cleared for the next
+    // session.
     expect(picker.disabled).toBe(false);
+    expect(camPicker.disabled).toBe(false);
   });
 
   it('switching mics replaces the live audio track instance on the stream', async () => {

--- a/packages/webcomponents/tests/composer/slicc-composer-capture.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-composer-capture.test.ts
@@ -327,6 +327,10 @@ describe('slicc-composer-capture', () => {
     // Video mode requests audio AND video so the recorded stream carries mic.
     expect(provider.calls[0]).toEqual({ video: true, audio: true });
     expect(provider.streams[0].getAudioTracks().length).toBe(1);
+    // The live preview element is muted so the mic doesn't echo back through
+    // local playback. `srcObject` ignores the `muted` content attribute in
+    // Chromium — only the IDL property mutes a MediaStream preview.
+    expect(videoOf(el).muted).toBe(true);
 
     // Record.
     primaryOf(el).click();
@@ -624,6 +628,49 @@ describe('slicc-composer-capture', () => {
     expect(audioAfter).toBe(liveAudio);
     expect(audioAfter.getSettings?.().deviceId).toBe('mic-usb');
     expect(audioAfter.readyState).toBe('live');
+
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+
+  it('preview <video>.muted stays true across attachStream paths (open/switch/promote)', async () => {
+    const provider = makeProvider(TWO_CAMERAS, TWO_MICS);
+    const el = mount(provider);
+
+    // Start in photo mode (no mic) — preview must already be muted.
+    const pending = el.open('photo');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    expect(videoOf(el).muted).toBe(true);
+
+    // Promote photo→video — `#attachStream` runs again with an audio track.
+    const videoBtn = el.querySelectorAll<HTMLElement>('[part="mode"]')[1];
+    videoBtn?.click();
+    await vi.waitFor(() => {
+      expect(provider.streams.at(-1)?.getAudioTracks().length).toBe(1);
+    });
+    expect(videoOf(el).muted).toBe(true);
+
+    // Camera switch — `#attachStream` runs against the merged stream.
+    const camPicker = pickerOf(el);
+    camPicker.value = 'cam-rear';
+    camPicker.dispatchEvent(new Event('change'));
+    await vi.waitFor(() => {
+      const last = provider.calls.at(-1);
+      expect(last && 'video' in last).toBe(true);
+    });
+    expect(videoOf(el).muted).toBe(true);
+
+    // Mic switch — audio track is swapped on the live stream.
+    const micPicker = micPickerOf(el);
+    micPicker.value = 'mic-usb';
+    micPicker.dispatchEvent(new Event('change'));
+    await vi.waitFor(() => {
+      const live = videoOf(el).srcObject as MediaStream;
+      expect(live.getAudioTracks()[0]?.getSettings?.().deviceId).toBe('mic-usb');
+    });
+    expect(videoOf(el).muted).toBe(true);
 
     el.querySelector<HTMLElement>('[part="cancel"]')?.click();
     await pending;

--- a/packages/webcomponents/tests/composer/slicc-composer-capture.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-composer-capture.test.ts
@@ -1,0 +1,696 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type CameraMediaProvider,
+  type CaptureResult,
+  type RecorderFactory,
+  SliccComposerCapture,
+} from '../../src/composer/slicc-composer-capture.js';
+import { ensureGlobalTokens } from '../../src/theme/tokens.js';
+
+interface FakeDevice {
+  deviceId: string;
+  label: string;
+  facing?: string;
+}
+
+interface FakeProvider extends CameraMediaProvider {
+  calls: MediaStreamConstraints[];
+  streams: MediaStream[];
+}
+
+/** An oscillator-backed audio track — `track.stop()` flips it to `'ended'`. */
+function makeAudioTrack(): MediaStreamTrack {
+  const ctx = new AudioContext();
+  const osc = ctx.createOscillator();
+  const dst = ctx.createMediaStreamDestination();
+  osc.connect(dst);
+  osc.start();
+  return dst.stream.getAudioTracks()[0];
+}
+
+/**
+ * A drawable MediaStream with optional audio. Chromium gives the canvas a
+ * genuine video track (so play / drawImage / toDataURL all work) and the audio
+ * track is a real, stoppable MediaStreamTrack — exactly what the capture
+ * surface tears down on exit.
+ */
+function makeStream(deviceId: string, facingMode: string | undefined, audio: boolean): MediaStream {
+  const canvas = document.createElement('canvas');
+  canvas.width = 64;
+  canvas.height = 48;
+  const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+  ctx.fillStyle = '#c2410c';
+  ctx.fillRect(0, 0, 64, 48);
+  const stream = canvas.captureStream(10);
+  const tick = setInterval(() => ctx.fillRect(0, 0, 64, 48), 50);
+  const track = stream.getVideoTracks()[0];
+  const stop = track.stop.bind(track);
+  track.stop = () => {
+    clearInterval(tick);
+    stop();
+  };
+  track.getSettings = () => ({ deviceId, facingMode }) as MediaTrackSettings;
+  if (audio) stream.addTrack(makeAudioTrack());
+  return stream;
+}
+
+function makeAudioOnlyStream(): MediaStream {
+  const stream = new MediaStream();
+  stream.addTrack(makeAudioTrack());
+  return stream;
+}
+
+interface FakeMic {
+  deviceId: string;
+  label: string;
+}
+
+/**
+ * Audio-only stream tagged with `getSettings().deviceId` so the capture
+ * surface's mic picker can reflect the active mic.
+ */
+function makeAudioStreamFor(deviceId: string): MediaStream {
+  const stream = makeAudioOnlyStream();
+  const track = stream.getAudioTracks()[0];
+  track.getSettings = () => ({ deviceId }) as MediaTrackSettings;
+  return stream;
+}
+
+function makeProvider(devices: FakeDevice[], mics: FakeMic[] = []): FakeProvider {
+  const provider: FakeProvider = {
+    calls: [],
+    streams: [],
+    getUserMedia: async (constraints) => {
+      provider.calls.push(constraints);
+      const v = constraints.video;
+      const a = constraints.audio;
+      const audioRequested = a !== undefined && a !== false;
+      let stream: MediaStream;
+      if (!v && audioRequested) {
+        const exactMic =
+          typeof a === 'object' && a !== null && 'deviceId' in a
+            ? ((a as MediaTrackConstraints).deviceId as { exact: string }).exact
+            : (mics[0]?.deviceId ?? 'mic-default');
+        stream = makeAudioStreamFor(exactMic);
+      } else {
+        const exact =
+          typeof v === 'object' && v !== null && 'deviceId' in v
+            ? (v.deviceId as { exact: string }).exact
+            : devices[0].deviceId;
+        const device = devices.find((d) => d.deviceId === exact) ?? devices[0];
+        stream = makeStream(device.deviceId, device.facing, audioRequested);
+        if (audioRequested) {
+          const audioTrack = stream.getAudioTracks()[0];
+          const exactMic =
+            typeof a === 'object' && a !== null && 'deviceId' in a
+              ? ((a as MediaTrackConstraints).deviceId as { exact: string }).exact
+              : (mics[0]?.deviceId ?? 'mic-default');
+          if (audioTrack)
+            audioTrack.getSettings = () => ({ deviceId: exactMic }) as MediaTrackSettings;
+        }
+      }
+      provider.streams.push(stream);
+      return stream;
+    },
+    enumerateDevices: async () => [
+      ...devices.map(
+        (d) => ({ kind: 'videoinput', deviceId: d.deviceId, label: d.label }) as MediaDeviceInfo
+      ),
+      ...mics.map(
+        (m) => ({ kind: 'audioinput', deviceId: m.deviceId, label: m.label }) as MediaDeviceInfo
+      ),
+    ],
+  };
+  return provider;
+}
+
+/** A deterministic recorder seam — pushes a chunk on stop, then `onstop`. */
+class FakeRecorder extends EventTarget {
+  state: 'inactive' | 'recording' | 'paused' = 'inactive';
+  mimeType: string;
+  ondataavailable: ((e: BlobEvent) => void) | null = null;
+  onstop: (() => void) | null = null;
+  stream: MediaStream;
+  constructor(stream: MediaStream, opts?: MediaRecorderOptions) {
+    super();
+    this.stream = stream;
+    this.mimeType = opts?.mimeType ?? 'video/webm';
+  }
+  start(): void {
+    this.state = 'recording';
+  }
+  stop(): void {
+    this.state = 'inactive';
+    this.ondataavailable?.({
+      data: new Blob([new Uint8Array([1, 2, 3])], { type: this.mimeType }),
+    } as BlobEvent);
+    this.onstop?.();
+  }
+}
+
+function makeRecorderFactory(): { factory: RecorderFactory; recorders: FakeRecorder[] } {
+  const recorders: FakeRecorder[] = [];
+  const factory: RecorderFactory = (stream, opts) => {
+    const rec = new FakeRecorder(stream, opts);
+    recorders.push(rec);
+    return rec as unknown as MediaRecorder;
+  };
+  return { factory, recorders };
+}
+
+const TWO_CAMERAS: FakeDevice[] = [
+  { deviceId: 'cam-front', label: 'FaceTime HD', facing: 'user' },
+  { deviceId: 'cam-rear', label: 'Iris Rear', facing: 'environment' },
+];
+
+const TWO_MICS: FakeMic[] = [
+  { deviceId: 'mic-internal', label: 'MacBook Microphone' },
+  { deviceId: 'mic-usb', label: 'USB Condenser' },
+];
+
+function mount(provider?: CameraMediaProvider): SliccComposerCapture {
+  const el = document.createElement('slicc-composer-capture') as SliccComposerCapture;
+  if (provider) el.media = provider;
+  document.body.appendChild(el);
+  return el;
+}
+
+function videoOf(el: SliccComposerCapture): HTMLVideoElement {
+  return el.querySelector('[part="video"]') as HTMLVideoElement;
+}
+
+function pickerOf(el: SliccComposerCapture): HTMLSelectElement {
+  return el.querySelector('[part="picker"]') as HTMLSelectElement;
+}
+
+function micPickerOf(el: SliccComposerCapture): HTMLSelectElement {
+  return el.querySelector('[part="audio-picker"]') as HTMLSelectElement;
+}
+
+function primaryOf(el: SliccComposerCapture): HTMLButtonElement {
+  return el.querySelector('[part="snap"], [part="record"], [part="stop"]') as HTMLButtonElement;
+}
+
+describe('slicc-composer-capture', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    document.body.replaceChildren();
+  });
+
+  it('registers the custom element', () => {
+    expect(customElements.get('slicc-composer-capture')).toBe(SliccComposerCapture);
+  });
+
+  it('reflects `mode` attribute ↔ property (default photo)', () => {
+    const el = mount();
+    expect(el.mode).toBe('photo');
+    el.mode = 'video';
+    expect(el.getAttribute('mode')).toBe('video');
+    el.setAttribute('mode', 'photo');
+    expect(el.mode).toBe('photo');
+    el.mode = null;
+    expect(el.hasAttribute('mode')).toBe(false);
+  });
+
+  it('reflects `preferred-device` attribute ↔ property', () => {
+    const el = mount();
+    expect(el.preferredDevice).toBeNull();
+    el.preferredDevice = 'cam-rear';
+    expect(el.getAttribute('preferred-device')).toBe('cam-rear');
+    el.setAttribute('preferred-device', 'cam-front');
+    expect(el.preferredDevice).toBe('cam-front');
+    el.preferredDevice = null;
+    expect(el.hasAttribute('preferred-device')).toBe(false);
+  });
+
+  it('hides the camera picker for one camera and shows it for two', async () => {
+    const elOne = mount(makeProvider([TWO_CAMERAS[0]]));
+    const pendingOne = elOne.open('photo');
+    await vi.waitFor(() => {
+      expect(videoOf(elOne).srcObject).toBeTruthy();
+    });
+    expect(pickerOf(elOne).hidden).toBe(true);
+    elOne.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pendingOne;
+
+    const elTwo = mount(makeProvider(TWO_CAMERAS));
+    const pendingTwo = elTwo.open('photo');
+    await vi.waitFor(() => {
+      expect(videoOf(elTwo).srcObject).toBeTruthy();
+    });
+    const picker = pickerOf(elTwo);
+    expect(picker.hidden).toBe(false);
+    expect([...picker.options].map((o) => o.textContent)).toEqual(['FaceTime HD', 'Iris Rear']);
+    elTwo.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pendingTwo;
+  });
+
+  it('open("photo") + Snap resolves an image result, fires slicc-capture, ends every track', async () => {
+    const provider = makeProvider(TWO_CAMERAS);
+    const el = mount(provider);
+    const captures: CaptureResult[] = [];
+    el.addEventListener('slicc-capture', (e) =>
+      captures.push((e as CustomEvent<CaptureResult>).detail)
+    );
+
+    const pending = el.open('photo');
+    await vi.waitFor(() => {
+      expect(videoOf(el).videoWidth).toBeGreaterThan(0);
+    });
+    // Photo mode requests video-only — no mic.
+    expect(provider.calls[0]).toEqual({ video: true, audio: false });
+
+    primaryOf(el).click();
+    const result = (await pending) as CaptureResult;
+    expect(result.kind).toBe('image');
+    expect(result.mimeType).toBe('image/png');
+    expect(result.dataUrl).toMatch(/^data:image\/png;base64,/);
+    expect(result.width).toBeGreaterThan(0);
+    expect(result.height).toBeGreaterThan(0);
+    expect(captures).toEqual([result]);
+    for (const track of provider.streams[0].getTracks()) {
+      expect(track.readyState).toBe('ended');
+    }
+    expect(el.hidden).toBe(true);
+  });
+
+  it('switching cameras through the picker emits slicc-capture-device-change', async () => {
+    const provider = makeProvider(TWO_CAMERAS);
+    const el = mount(provider);
+    el.preferredDevice = 'cam-rear';
+    const changes: Array<{ deviceId: string; kind: string }> = [];
+    el.addEventListener('slicc-capture-device-change', (e) =>
+      changes.push((e as CustomEvent<{ deviceId: string; kind: string }>).detail)
+    );
+
+    const pending = el.open('photo');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    expect(provider.calls[0]).toEqual({
+      video: { deviceId: { exact: 'cam-rear' } },
+      audio: false,
+    });
+    // Environment-facing camera previews unmirrored.
+    expect(videoOf(el).hasAttribute('data-mirrored')).toBe(false);
+
+    const picker = pickerOf(el);
+    picker.value = 'cam-front';
+    picker.dispatchEvent(new Event('change'));
+    await vi.waitFor(() => {
+      expect(changes).toEqual([{ deviceId: 'cam-front', kind: 'camera' }]);
+    });
+    // Switching re-requests video-only (existing audio, if any, is preserved).
+    expect(provider.calls.at(-1)).toEqual({ video: { deviceId: { exact: 'cam-front' } } });
+    // The replaced video track stopped; selfie view is mirrored on the new one.
+    expect(provider.streams[0].getVideoTracks()[0].readyState).toBe('ended');
+    expect(videoOf(el).hasAttribute('data-mirrored')).toBe(true);
+
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+
+  it('open("video") requests audio+video, Record→Stop resolves a video result with duration', async () => {
+    const provider = makeProvider(TWO_CAMERAS);
+    const { factory, recorders } = makeRecorderFactory();
+    const el = mount(provider);
+    el.recorderFactory = factory;
+    const captures: CaptureResult[] = [];
+    el.addEventListener('slicc-capture', (e) =>
+      captures.push((e as CustomEvent<CaptureResult>).detail)
+    );
+
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    // Video mode requests audio AND video so the recorded stream carries mic.
+    expect(provider.calls[0]).toEqual({ video: true, audio: true });
+    expect(provider.streams[0].getAudioTracks().length).toBe(1);
+
+    // Record.
+    primaryOf(el).click();
+    await vi.waitFor(() => {
+      expect(recorders.length).toBe(1);
+      expect(recorders[0].state).toBe('recording');
+      expect(el.querySelector('[part="stop"]')).toBeTruthy();
+    });
+    // Let the wall clock advance so durationMs > 0.
+    await new Promise((r) => setTimeout(r, 25));
+
+    // Stop.
+    primaryOf(el).click();
+    const result = (await pending) as CaptureResult;
+    expect(result.kind).toBe('video');
+    expect(result.mimeType).toMatch(/^video\/webm/);
+    expect(result.blob).toBeInstanceOf(Blob);
+    expect(result.blob?.size).toBeGreaterThan(0);
+    expect(result.durationMs).toBeGreaterThan(0);
+    expect(captures).toEqual([result]);
+    // Both video AND audio tracks ended on the way out.
+    for (const track of provider.streams[0].getTracks()) {
+      expect(track.readyState).toBe('ended');
+    }
+  });
+
+  it('Cancel button resolves null and emits slicc-capture-cancel (no slicc-capture)', async () => {
+    const provider = makeProvider(TWO_CAMERAS);
+    const el = mount(provider);
+    let captureSeen = 0;
+    let cancelSeen = 0;
+    el.addEventListener('slicc-capture', () => captureSeen++);
+    el.addEventListener('slicc-capture-cancel', () => cancelSeen++);
+
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await expect(pending).resolves.toBeNull();
+    expect(cancelSeen).toBe(1);
+    expect(captureSeen).toBe(0);
+    for (const track of provider.streams[0].getTracks()) {
+      expect(track.readyState).toBe('ended');
+    }
+  });
+
+  it('Escape key resolves null and emits slicc-capture-cancel', async () => {
+    const provider = makeProvider(TWO_CAMERAS);
+    const el = mount(provider);
+    let cancelSeen = 0;
+    el.addEventListener('slicc-capture-cancel', () => cancelSeen++);
+
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await expect(pending).resolves.toBeNull();
+    expect(cancelSeen).toBe(1);
+    for (const track of provider.streams[0].getTracks()) {
+      expect(track.readyState).toBe('ended');
+    }
+  });
+
+  it('disconnectedCallback stops every video AND audio track and resolves null', async () => {
+    const provider = makeProvider(TWO_CAMERAS);
+    const el = mount(provider);
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    expect(provider.streams[0].getAudioTracks().length).toBe(1);
+    expect(provider.streams[0].getVideoTracks()[0].readyState).toBe('live');
+    expect(provider.streams[0].getAudioTracks()[0].readyState).toBe('live');
+
+    el.remove();
+    await expect(pending).resolves.toBeNull();
+    for (const track of provider.streams[0].getTracks()) {
+      expect(track.readyState).toBe('ended');
+    }
+  });
+
+  it('resolves null when no media provider is reachable', async () => {
+    const el = mount();
+    el.media = {
+      getUserMedia: async () => {
+        throw new Error('denied');
+      },
+      enumerateDevices: async () => [],
+    };
+    await expect(el.open('photo')).resolves.toBeNull();
+  });
+
+  it('reflects `preferred-audio-device` attribute ↔ property', () => {
+    const el = mount();
+    expect(el.preferredAudioDevice).toBeNull();
+    el.preferredAudioDevice = 'mic-usb';
+    expect(el.getAttribute('preferred-audio-device')).toBe('mic-usb');
+    el.setAttribute('preferred-audio-device', 'mic-internal');
+    expect(el.preferredAudioDevice).toBe('mic-internal');
+    el.preferredAudioDevice = null;
+    expect(el.hasAttribute('preferred-audio-device')).toBe(false);
+  });
+
+  it('hides the mic picker in photo mode even with multiple mics', async () => {
+    const el = mount(makeProvider(TWO_CAMERAS, TWO_MICS));
+    const pending = el.open('photo');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    // Picker exists in the DOM but is hidden — photo mode never records mic.
+    expect(micPickerOf(el).hidden).toBe(true);
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+
+  it('hides the mic picker in video mode with only one mic', async () => {
+    const el = mount(makeProvider(TWO_CAMERAS, [TWO_MICS[0]]));
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    expect(micPickerOf(el).hidden).toBe(true);
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+
+  it('shows the mic picker in video mode with ≥2 mics, labeled and reflecting the active mic', async () => {
+    const el = mount(makeProvider(TWO_CAMERAS, TWO_MICS));
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    const picker = micPickerOf(el);
+    expect(picker.hidden).toBe(false);
+    expect([...picker.options].map((o) => o.textContent)).toEqual([
+      'MacBook Microphone',
+      'USB Condenser',
+    ]);
+    // First mic is the default since no preferred-audio-device was set.
+    expect(picker.value).toBe('mic-internal');
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+
+  it('opens with `preferred-audio-device` pinned to the requested mic', async () => {
+    const provider = makeProvider(TWO_CAMERAS, TWO_MICS);
+    const el = mount(provider);
+    el.preferredAudioDevice = 'mic-usb';
+
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    expect(provider.calls[0]).toEqual({
+      video: true,
+      audio: { deviceId: { exact: 'mic-usb' } },
+    });
+    expect(micPickerOf(el).value).toBe('mic-usb');
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+
+  it('switching mics swaps the live audio track, persists the choice, and emits microphone change', async () => {
+    const provider = makeProvider(TWO_CAMERAS, TWO_MICS);
+    const el = mount(provider);
+    const changes: Array<{ deviceId: string; kind: string }> = [];
+    el.addEventListener('slicc-capture-device-change', (e) =>
+      changes.push((e as CustomEvent<{ deviceId: string; kind: string }>).detail)
+    );
+
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    const stream = provider.streams[0];
+    const originalAudio = stream.getAudioTracks()[0];
+    expect(originalAudio.readyState).toBe('live');
+
+    const picker = micPickerOf(el);
+    picker.value = 'mic-usb';
+    picker.dispatchEvent(new Event('change'));
+    await vi.waitFor(() => {
+      expect(changes).toEqual([{ deviceId: 'mic-usb', kind: 'microphone' }]);
+    });
+    // Old track stopped, new track installed on the same live stream.
+    expect(originalAudio.readyState).toBe('ended');
+    const audioTracks = stream.getAudioTracks();
+    expect(audioTracks.length).toBe(1);
+    expect(audioTracks[0].getSettings?.().deviceId).toBe('mic-usb');
+    // Preference persists for later opens / promotions.
+    expect(el.preferredAudioDevice).toBe('mic-usb');
+    // The audio-only swap call pinned the requested mic.
+    expect(provider.calls.at(-1)).toEqual({ audio: { deviceId: { exact: 'mic-usb' } } });
+
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+
+  it('disables the mic picker while recording and re-enables it on stop', async () => {
+    const provider = makeProvider(TWO_CAMERAS, TWO_MICS);
+    const { factory, recorders } = makeRecorderFactory();
+    const el = mount(provider);
+    el.recorderFactory = factory;
+
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    const picker = micPickerOf(el);
+    expect(picker.disabled).toBe(false);
+
+    // Record.
+    primaryOf(el).click();
+    await vi.waitFor(() => {
+      expect(recorders.length).toBe(1);
+      expect(recorders[0].state).toBe('recording');
+    });
+    expect(picker.disabled).toBe(true);
+
+    // Stop.
+    primaryOf(el).click();
+    await pending;
+    // After assembly, the picker is unlocked again — even though the element
+    // is hidden, the disabled state has been cleared for the next session.
+    expect(picker.disabled).toBe(false);
+  });
+
+  it('switching mics replaces the live audio track instance on the stream', async () => {
+    const provider = makeProvider(TWO_CAMERAS, TWO_MICS);
+    const el = mount(provider);
+
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    const stream = provider.streams[0];
+    const originalAudio = stream.getAudioTracks()[0];
+    expect(originalAudio.getSettings?.().deviceId).toBe('mic-internal');
+
+    const picker = micPickerOf(el);
+    picker.value = 'mic-usb';
+    picker.dispatchEvent(new Event('change'));
+    await vi.waitFor(() => {
+      expect(stream.getAudioTracks()[0].getSettings?.().deviceId).toBe('mic-usb');
+    });
+    const swapped = stream.getAudioTracks()[0];
+    // Track identity changed (different MediaStreamTrack instance) AND the
+    // old track's deviceId is no longer the one on the live stream.
+    expect(swapped).not.toBe(originalAudio);
+    expect(swapped.getSettings?.().deviceId).not.toBe(originalAudio.getSettings?.().deviceId);
+
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+
+  it('mic selection survives a camera switch in video mode', async () => {
+    const provider = makeProvider(TWO_CAMERAS, TWO_MICS);
+    const el = mount(provider);
+
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    // Pick the second mic before switching cameras.
+    const micPicker = micPickerOf(el);
+    micPicker.value = 'mic-usb';
+    micPicker.dispatchEvent(new Event('change'));
+    await vi.waitFor(() => {
+      expect(el.preferredAudioDevice).toBe('mic-usb');
+    });
+    const stream = provider.streams[0];
+    const liveAudio = stream.getAudioTracks()[0];
+    expect(liveAudio.getSettings?.().deviceId).toBe('mic-usb');
+
+    // Switch camera — the existing audio track (mic-usb) is preserved verbatim
+    // on the new live stream rather than re-requested. The video element's
+    // `srcObject` is swapped to the new stream returned by `getUserMedia`.
+    const camPicker = pickerOf(el);
+    camPicker.value = 'cam-rear';
+    camPicker.dispatchEvent(new Event('change'));
+    await vi.waitFor(() => {
+      // The camera switch was video-only — no fresh audio request.
+      const last = provider.calls.at(-1);
+      expect(last).toEqual({ video: { deviceId: { exact: 'cam-rear' } } });
+    });
+    // Mic picker value + preference still pinned to mic-usb after the switch.
+    expect(micPicker.value).toBe('mic-usb');
+    expect(el.preferredAudioDevice).toBe('mic-usb');
+    // The mic-usb audio track instance is now part of the new live stream;
+    // it was added (not re-requested), so it's still the same track object.
+    const liveStream = videoOf(el).srcObject as MediaStream;
+    const audioAfter = liveStream.getAudioTracks()[0];
+    expect(audioAfter).toBe(liveAudio);
+    expect(audioAfter.getSettings?.().deviceId).toBe('mic-usb');
+    expect(audioAfter.readyState).toBe('live');
+
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+
+  it('photo→video promotion honors `preferred-audio-device` and reveals the mic picker', async () => {
+    const provider = makeProvider(TWO_CAMERAS, TWO_MICS);
+    const el = mount(provider);
+    el.preferredAudioDevice = 'mic-usb';
+
+    const pending = el.open('photo');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+    // Photo mode does not enumerate mic options yet — the picker is hidden.
+    expect(micPickerOf(el).hidden).toBe(true);
+    // Photo open() did not ask for audio.
+    expect(provider.calls[0]).toEqual({ video: true, audio: false });
+
+    // Click the Video mode button to promote.
+    const videoBtn = el.querySelectorAll<HTMLElement>('[part="mode"]')[1];
+    videoBtn?.click();
+    await vi.waitFor(() => {
+      // Promotion re-requests video+audio with the preferred mic pinned.
+      const last = provider.calls.at(-1);
+      expect(last).toEqual({
+        video: { deviceId: { exact: 'cam-front' } },
+        audio: { deviceId: { exact: 'mic-usb' } },
+      });
+    });
+    await vi.waitFor(() => {
+      const picker = micPickerOf(el);
+      expect(picker.hidden).toBe(false);
+      expect(picker.value).toBe('mic-usb');
+    });
+
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+
+  it('keeps the bottom control bar inside the host rect (no vertical clipping)', async () => {
+    // Constrain the host width to a typical composer band so the <video>'s
+    // intrinsic 4:3 size would otherwise push the bar below the host.
+    const frame = document.createElement('div');
+    frame.style.width = '640px';
+    document.body.appendChild(frame);
+    const el = document.createElement('slicc-composer-capture') as SliccComposerCapture;
+    el.media = makeProvider(TWO_CAMERAS, TWO_MICS);
+    frame.appendChild(el);
+
+    const pending = el.open('video');
+    await vi.waitFor(() => {
+      expect(videoOf(el).srcObject).toBeTruthy();
+    });
+
+    const hostRect = el.getBoundingClientRect();
+    const bar = el.querySelector('.slicc-capture__bar') as HTMLElement;
+    const close = el.querySelector('[part="cancel"]') as HTMLElement;
+    const barRect = bar.getBoundingClientRect();
+    const closeRect = close.getBoundingClientRect();
+    // 0.5px slack for sub-pixel rounding in real Chromium layout.
+    expect(barRect.bottom).toBeLessThanOrEqual(hostRect.bottom + 0.5);
+    expect(barRect.top).toBeGreaterThanOrEqual(hostRect.top - 0.5);
+    expect(closeRect.top).toBeGreaterThanOrEqual(hostRect.top - 0.5);
+    expect(closeRect.bottom).toBeLessThanOrEqual(hostRect.bottom + 0.5);
+
+    el.querySelector<HTMLElement>('[part="cancel"]')?.click();
+    await pending;
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `<slicc-composer-capture>` web component: an **inline** camera capture surface that takes over the composer area (the same full-area overlay pattern as drag-and-drop / PTT), replacing the standalone centered camera dialog for the composer flow.

- Photo + video capture with live mirrored preview
- Camera switcher when multiple `videoinput` devices exist
- Microphone picker in video mode (video recordings include mic audio); choice preserved across camera switches and the photo→video promotion path
- Single-row control bar with Lucide icon labels; corner close (×) with blurred backdrop
- Injectable `CameraMediaProvider` seam (real hardware or a canvas-backed fake for Storybook/tests)
- Self-bounded 4:3 box (max-height `min(60vh, 480px)`) so the control bar never clips

## Storybook

- Dedicated `slicc-composer-capture.stories.ts`
- Wired into the `Composer/Composer` **Default** story via the add-menu “Take a photo” action as a full-area overlay over the chat column

## Tests

- Comprehensive `@vitest/browser` tests (geometry checks ensure controls stay inside the host rect; teardown stops all video + audio tracks)
- Device-picker helper tests

## Status

**Draft.** Component + Storybook + tests are complete and green. **Still pending:** wiring into the real webapp composer (`wc-attach.ts`), `kind:'video'` attachment staging, and extension popup-capture parity.

## Out of scope

`slicc-camera-dialog` is left as-is for now.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author