### PR TITLE
deploy: thin-bridge connectivity (node bridge security + worker /cloud CSP + webapp bridge client)

### DIFF
--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -12,6 +12,7 @@ import {
   handleResume,
   handleStart,
 } from './cloud/handlers.js';
+import { getProxyEndpoint } from './cloud/proxy-config.js';
 import { buildHandoffResponse } from './handoff-page.js';
 import { applySliccLinks } from './links.js';
 import { buildLlmsTxtResponse } from './llms-txt.js';
@@ -72,6 +73,43 @@ export function resolveCherryFrameAncestors(allowed: string | undefined): string
   const tokens = trimmed.split(/\s+/).filter(Boolean);
   if (tokens.includes('*')) return '*';
   return tokens.join(' ');
+}
+
+/**
+ * Build the `connect-src` directive for the served leader (cloud dashboard SPA)
+ * as an explicit allowlist. Sources, in order:
+ *
+ * - `'self'` — same-origin XHR/fetch/WS
+ * - the Adobe LLM proxy origin — sourced from `ADOBE_PROXY_ENDPOINT` env var,
+ *   falling back to the default proxy URL; only the origin is emitted (path
+ *   stripped) so the directive stays CSP-valid even if the env value carries
+ *   a path or trailing slash
+ * - both Adobe IMS hosts (prod + stg1) for OAuth flows
+ * - `ws://localhost:*` and `ws://127.0.0.1:*` for the local bridge WebSocket
+ *   that the leader opens to a host-machine node-server / swift-server picking
+ *   a dynamic port. The real security gate for the bridge is the node-side
+ *   origin allowlist + subprotocol token, not this CSP — port wildcards are
+ *   safe here.
+ *
+ * No bare `*` is permitted — this is an explicit allowlist by design.
+ *
+ * Exported for tests.
+ */
+export function buildLeaderConnectSrc(env: { ADOBE_PROXY_ENDPOINT?: string }): string {
+  let proxyOrigin: string;
+  try {
+    proxyOrigin = new URL(getProxyEndpoint(env)).origin;
+  } catch {
+    proxyOrigin = 'https://adobe-llm-proxy.paolo-moz.workers.dev';
+  }
+  return [
+    "'self'",
+    proxyOrigin,
+    'https://ims-na1.adobelogin.com',
+    'https://ims-na1-stg1.adobelogin.com',
+    'ws://localhost:*',
+    'ws://127.0.0.1:*',
+  ].join(' ');
 }
 
 async function serveSPA(request: Request, env: WorkerEnv): Promise<Response> {
@@ -329,7 +367,7 @@ async function tryHandleCloudRoutes(
       [
         "default-src 'self'",
         "script-src 'self'",
-        "connect-src 'self' https://ims-na1.adobelogin.com",
+        `connect-src ${buildLeaderConnectSrc(env)}`,
         "img-src 'self' data:",
         "style-src 'self' 'unsafe-inline'",
         "frame-ancestors 'none'",

--- a/packages/cloudflare-worker/tests/cloud-csp.test.ts
+++ b/packages/cloudflare-worker/tests/cloud-csp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { handleWorkerRequest, type WorkerEnv } from '../src/index.js';
+import { buildLeaderConnectSrc, handleWorkerRequest, type WorkerEnv } from '../src/index.js';
 
 const CLOUD_HTML = '<!doctype html><html><body>cloud dashboard</body></html>';
 
@@ -67,5 +67,53 @@ describe('CSP on /cloud responses', () => {
     expect(csp).toBeTruthy();
     expect(csp).toContain("script-src 'self'");
     expect(csp).toContain("frame-ancestors 'none'");
+  });
+
+  it('connect-src on /cloud permits the Adobe proxy, both IMS hosts, and local bridge WebSockets', async () => {
+    const res = await handleWorkerRequest(new Request('https://w.test/cloud'), makeEnv());
+    const csp = res.headers.get('content-security-policy') ?? '';
+    const connectSrc = csp
+      .split(';')
+      .map((d) => d.trim())
+      .find((d) => d.startsWith('connect-src '));
+    expect(connectSrc).toBeTruthy();
+    // Adobe LLM proxy (default origin) must be reachable.
+    expect(connectSrc).toContain('https://adobe-llm-proxy.paolo-moz.workers.dev');
+    // Both IMS hosts (prod + stg1).
+    expect(connectSrc).toContain('https://ims-na1.adobelogin.com');
+    expect(connectSrc).toContain('https://ims-na1-stg1.adobelogin.com');
+    // Local bridge WebSocket: dynamic port on either loopback name.
+    expect(connectSrc).toContain('ws://localhost:*');
+    expect(connectSrc).toContain('ws://127.0.0.1:*');
+    // Same-origin still allowed.
+    expect(connectSrc).toContain("'self'");
+    // No bare wildcard — the directive must stay an explicit allowlist.
+    const tokens = (connectSrc as string).slice('connect-src '.length).split(/\s+/).filter(Boolean);
+    expect(tokens).not.toContain('*');
+  });
+
+  it('buildLeaderConnectSrc honours ADOBE_PROXY_ENDPOINT and strips path/trailing slash', () => {
+    const directive = buildLeaderConnectSrc({
+      ADOBE_PROXY_ENDPOINT: 'https://custom-proxy.example.com/v1/',
+    });
+    const tokens = directive.split(/\s+/).filter(Boolean);
+    // Only the origin is emitted — paths and trailing slashes must be stripped.
+    expect(tokens).toContain('https://custom-proxy.example.com');
+    expect(tokens).not.toContain('https://custom-proxy.example.com/');
+    expect(tokens).not.toContain('https://custom-proxy.example.com/v1/');
+    // No bare wildcard.
+    expect(tokens).not.toContain('*');
+    // Required sources still present.
+    expect(tokens).toContain("'self'");
+    expect(tokens).toContain('https://ims-na1.adobelogin.com');
+    expect(tokens).toContain('https://ims-na1-stg1.adobelogin.com');
+    expect(tokens).toContain('ws://localhost:*');
+    expect(tokens).toContain('ws://127.0.0.1:*');
+  });
+
+  it('buildLeaderConnectSrc falls back to default proxy when env unset', () => {
+    const directive = buildLeaderConnectSrc({});
+    expect(directive).toContain('https://adobe-llm-proxy.paolo-moz.workers.dev');
+    expect(directive.split(/\s+/).filter(Boolean)).not.toContain('*');
   });
 });

--- a/packages/node-server/src/bridge-security.ts
+++ b/packages/node-server/src/bridge-security.ts
@@ -1,0 +1,165 @@
+/**
+ * Bridge security primitives for the standalone thin /cdp bridge.
+ *
+ * The standalone CLI runs a thin Express server that proxies CDP from a
+ * sliccy.ai-hosted leader tab to the local Chrome over `/cdp`. Full CDP
+ * pass-through = full control of the user's Chrome, so the WebSocket
+ * upgrade is gated by two factors plus PNA:
+ *   1. Origin allowlist (`isAllowedBridgeOrigin`).
+ *   2. Per-process subprotocol token in `Sec-WebSocket-Protocol`
+ *      (`SUBPROTOCOL_PREFIX` + token). Never appears in a query string,
+ *      so it does not leak into Referer / logs.
+ *   3. PNA preflight (`buildPnaPreflightHeaders`) — Chrome blocks
+ *      public→private WS upgrades without `Access-Control-Allow-Private-Network`.
+ *
+ * Cross-origin /api calls from the hosted leader also need CORS; see
+ * `buildCorsHeaders` for the per-request response set.
+ *
+ * Pure module (no node-only imports) so the WS gate is trivially unit
+ * testable from `tests/bridge-security.test.ts`.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Origin allowlist. Production + staging worker plus the dev-mode loopback
+ * origins (parallel to chrome-extension's `BRIDGE_DEV_ORIGINS`). Add a new
+ * origin here and in the extension allowlist together — they MUST stay in
+ * sync, otherwise extension and standalone disagree on what's a leader.
+ */
+export const BRIDGE_ALLOWED_ORIGINS: readonly string[] = Object.freeze([
+  'https://www.sliccy.ai',
+  'https://slicc-tray-hub-staging.minivelos.workers.dev',
+  'http://localhost:5710',
+  'http://127.0.0.1:5710',
+]);
+
+/** Subprotocol prefix advertised by the leader; the per-process token is appended. */
+export const BRIDGE_SUBPROTOCOL_PREFIX = 'slicc.bridge.v1.';
+
+/** Query-param name the launch URL uses to forward the subprotocol token to the leader. */
+export const BRIDGE_TOKEN_QUERY_PARAM = 'bridgeToken';
+
+/** Query-param name the launch URL uses to forward the local /cdp WebSocket URL. */
+export const BRIDGE_WS_QUERY_PARAM = 'bridge';
+
+/** Headers we allow on cross-origin /api requests from the hosted leader. */
+const CORS_ALLOW_HEADERS =
+  'Content-Type, X-Slicc-Raw-Body, X-Session-Id, X-Bridge-Token, Authorization';
+
+/** Methods exposed to the hosted leader. */
+const CORS_ALLOW_METHODS = 'GET, POST, PUT, DELETE, OPTIONS';
+
+/** True iff `origin` is in the bridge allowlist. Case-sensitive (origins are normalized lowercase). */
+export function isAllowedBridgeOrigin(origin: string | undefined | null): boolean {
+  if (!origin) return false;
+  return BRIDGE_ALLOWED_ORIGINS.includes(origin);
+}
+
+/**
+ * Mint a per-process bridge token. Embedded in the leader launch URL and
+ * required as the WebSocket subprotocol on /cdp. Use `crypto.randomUUID()`
+ * — 122 bits of entropy is plenty for a session-scoped capability.
+ */
+export function mintBridgeToken(): string {
+  return randomUUID();
+}
+
+/**
+ * Parse the `Sec-WebSocket-Protocol` request header into a trimmed list. The
+ * header is a comma-separated list per RFC 6455; `ws` exposes it raw.
+ */
+export function parseSubprotocolHeader(header: string | string[] | undefined): string[] {
+  if (!header) return [];
+  const flat = Array.isArray(header) ? header.join(',') : header;
+  return flat
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Pick the bridge subprotocol matching `expectedToken`, or null if absent.
+ * The matching protocol is what we MUST echo back in the upgrade response
+ * (RFC 6455 §1.9) — otherwise the browser closes the socket.
+ */
+export function selectBridgeSubprotocol(
+  protocols: readonly string[],
+  expectedToken: string
+): string | null {
+  if (!expectedToken) return null;
+  const expected = `${BRIDGE_SUBPROTOCOL_PREFIX}${expectedToken}`;
+  return protocols.includes(expected) ? expected : null;
+}
+
+export interface BridgeUpgradeGateResult {
+  ok: boolean;
+  /**
+   * The subprotocol to echo back in the 101 response when `ok === true`.
+   * Always null when `ok === false`.
+   */
+  acceptedSubprotocol: string | null;
+  /**
+   * Reason exposed in logs for rejection. Intentionally coarse — does not
+   * tell the caller WHICH check failed, mirroring `validateBridgePin` in
+   * the chrome-extension bridge SW.
+   */
+  reason?: 'origin-not-allowed' | 'subprotocol-missing-or-mismatched';
+}
+
+/**
+ * Combined origin + subprotocol gate for a `/cdp` upgrade request.
+ *
+ * Returns `{ ok: true, acceptedSubprotocol }` only when BOTH the origin is
+ * in the allowlist AND a matching `slicc.bridge.v1.<expectedToken>`
+ * subprotocol was offered. Closes-the-socket-before-emit semantics live at
+ * the call site in `index.ts`.
+ */
+export function validateBridgeUpgrade(input: {
+  origin: string | undefined | null;
+  subprotocolHeader: string | string[] | undefined;
+  expectedToken: string;
+}): BridgeUpgradeGateResult {
+  if (!isAllowedBridgeOrigin(input.origin)) {
+    return { ok: false, acceptedSubprotocol: null, reason: 'origin-not-allowed' };
+  }
+  const protocols = parseSubprotocolHeader(input.subprotocolHeader);
+  const accepted = selectBridgeSubprotocol(protocols, input.expectedToken);
+  if (!accepted) {
+    return {
+      ok: false,
+      acceptedSubprotocol: null,
+      reason: 'subprotocol-missing-or-mismatched',
+    };
+  }
+  return { ok: true, acceptedSubprotocol: accepted };
+}
+
+/**
+ * CORS headers for an allowlisted `Origin`. Returns `null` when the origin
+ * is not in the allowlist (caller should NOT set CORS headers).
+ *
+ * `Access-Control-Allow-Credentials: true` is included so the hosted leader
+ * can carry cookies to /api/* (e.g. auth) when that's added later. Today
+ * the bridge token is the auth factor, not cookies.
+ */
+export function buildCorsHeaders(origin: string | undefined | null): Record<string, string> | null {
+  if (!isAllowedBridgeOrigin(origin)) return null;
+  return {
+    'Access-Control-Allow-Origin': origin!,
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Methods': CORS_ALLOW_METHODS,
+    'Access-Control-Allow-Headers': CORS_ALLOW_HEADERS,
+    'Access-Control-Expose-Headers': 'Link',
+    Vary: 'Origin',
+  };
+}
+
+/**
+ * PNA preflight extras. Added on OPTIONS responses for allowlisted origins
+ * when the request carries `Access-Control-Request-Private-Network: true`
+ * — Chrome blocks public→private fetch / WS otherwise.
+ */
+export function buildPnaPreflightHeaders(): Record<string, string> {
+  return { 'Access-Control-Allow-Private-Network': 'true' };
+}

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -10,6 +10,13 @@ import { homedir } from 'os';
 import { basename, dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { WebSocket, WebSocketServer } from 'ws';
+import {
+  buildCorsHeaders,
+  buildPnaPreflightHeaders,
+  mintBridgeToken,
+  selectBridgeSubprotocol,
+  validateBridgeUpgrade,
+} from './bridge-security.js';
 import { applyCdpUnmask } from './cdp-proxy/cdp-unmask.js';
 import { createCdpSessionUrlTracker } from './cdp-proxy/session-url-tracker.js';
 import {
@@ -84,6 +91,13 @@ const SERVE_ONLY = RUNTIME_FLAGS.serveOnly;
 const ELECTRON_MODE = RUNTIME_FLAGS.electron;
 const ELECTRON_APP = RUNTIME_FLAGS.electronApp;
 const KILL_EXISTING_ELECTRON_APP = RUNTIME_FLAGS.kill;
+/**
+ * Standalone thin-bridge mode: production CLI with no bundled UI. The
+ * launched Chrome opens a sliccy.ai-hosted leader; node-server is a thin
+ * /cdp bridge + /api surface. Dev / electron / serve-only / hosted all
+ * keep the bundled UI path (a separate path B / hosted task covers those).
+ */
+const THIN_BRIDGE_MODE = !DEV_MODE && !SERVE_ONLY && !ELECTRON_MODE && !RUNTIME_FLAGS.hosted;
 
 // ---------------------------------------------------------------------------
 // File logger — persistent log file in ~/.slicc/logs/
@@ -386,6 +400,12 @@ interface ServerState {
   overlayInjector: ElectronOverlayInjector | null;
   shuttingDown: boolean;
   discoveredTrayJoinUrl: string | null;
+  /**
+   * Per-process subprotocol token for the thin /cdp bridge. Null in
+   * legacy modes (dev / electron / serve-only / hosted) — `/cdp` stays
+   * ungated there because the connecting client is always same-origin.
+   */
+  bridgeToken: string | null;
   // CDP WebSocket proxy state (one Chrome connection, swapped client).
   cdpUrl: string | null;
   chromeWs: WebSocket | null;
@@ -404,6 +424,7 @@ function createServerState(): ServerState {
     overlayInjector: null,
     shuttingDown: false,
     discoveredTrayJoinUrl: RUNTIME_FLAGS.joinUrl ?? null,
+    bridgeToken: THIN_BRIDGE_MODE ? mintBridgeToken() : null,
     cdpUrl: null,
     chromeWs: null,
     activeClientWs: null,
@@ -582,15 +603,37 @@ async function launchElectronTarget(state: ServerState): Promise<void> {
   }
 }
 
+/**
+ * Resolve the leader origin Chrome should open in thin-bridge mode. Prefers
+ * an explicit `--lead <url>` / `WORKER_BASE_URL` so dev can point at staging;
+ * defaults to production sliccy.ai.
+ */
+function resolveThinLeaderOrigin(): string {
+  const explicit = RUNTIME_FLAGS.leadWorkerBaseUrl ?? process.env['WORKER_BASE_URL'] ?? null;
+  if (explicit) {
+    return explicit.replace(/\/+$/, '');
+  }
+  return 'https://www.sliccy.ai';
+}
+
 /** Build the Chrome launch URL, appending hosted-runtime + prompt query params. */
 function buildBrowserLaunchUrl(state: ServerState): string {
+  // Thin-bridge standalone: Chrome opens the hosted leader directly; the
+  // local node-server serves no UI at all. Bridge coordinates ride as
+  // query params so the leader can discover + authenticate /cdp.
+  const serveOriginForLaunch =
+    THIN_BRIDGE_MODE && state.bridgeToken ? resolveThinLeaderOrigin() : state.serveOrigin;
+
   let url = resolveCliBrowserLaunchUrl({
-    serveOrigin: state.serveOrigin,
+    serveOrigin: serveOriginForLaunch,
     lead: RUNTIME_FLAGS.lead,
     leadWorkerBaseUrl: RUNTIME_FLAGS.leadWorkerBaseUrl,
     envWorkerBaseUrl: process.env['WORKER_BASE_URL'] ?? null,
     join: RUNTIME_FLAGS.join,
     joinUrl: RUNTIME_FLAGS.joinUrl,
+    bridgeWsUrl:
+      THIN_BRIDGE_MODE && state.bridgeToken ? `ws://localhost:${state.servePort}/cdp` : null,
+    bridgeToken: state.bridgeToken,
   });
   if (RUNTIME_FLAGS.hosted) {
     url += `${url.includes('?') ? '&' : '?'}runtime=hosted-leader`;
@@ -602,6 +645,10 @@ function buildBrowserLaunchUrl(state: ServerState): string {
     console.log(`Join launch URL: ${url}`);
   } else if (RUNTIME_FLAGS.lead) {
     console.log(`Lead launch URL: ${url}`);
+  } else if (THIN_BRIDGE_MODE) {
+    // Print WITHOUT the bridgeToken — it's a session capability.
+    const sanitized = url.replace(/([?&])bridgeToken=[^&]+/, '$1bridgeToken=<redacted>');
+    console.log(`Thin-bridge launch URL: ${sanitized}`);
   }
   return url;
 }
@@ -747,15 +794,62 @@ function closeWebSocketQuietly(ws: WebSocket | null): void {
   }
 }
 
-/** Route `/cdp` and `/licks-ws` upgrades to their servers; leave others for Vite HMR. */
+/**
+ * Reject a WebSocket upgrade before `handleUpgrade` runs. Writes a minimal
+ * HTTP/1.1 response and destroys the underlying socket. RFC 6455 allows 401
+ * / 403 here; we use 401 so a caller that retries with the correct
+ * subprotocol/origin doesn't trip permanent CORS-style caches.
+ */
+function rejectUpgradeUnauthorized(socket: import('node:stream').Duplex, reason: string): void {
+  try {
+    socket.write(
+      `HTTP/1.1 401 Unauthorized\r\n` +
+        `Content-Type: text/plain\r\n` +
+        `Connection: close\r\n` +
+        `Content-Length: ${Buffer.byteLength(reason)}\r\n` +
+        `\r\n${reason}`
+    );
+  } catch {
+    /* socket may already be gone */
+  }
+  try {
+    socket.destroy();
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Route `/cdp` and `/licks-ws` upgrades to their servers; leave others for Vite HMR.
+ *
+ * When `bridgeToken !== null` (thin standalone mode) the `/cdp` upgrade is
+ * gated by `validateBridgeUpgrade`: bad origin or missing/wrong
+ * `Sec-WebSocket-Protocol` token = socket destroyed before
+ * `wss.emit('connection', ...)` ever fires. Legacy modes (dev / electron /
+ * serve-only / hosted) pass `null` to keep same-origin behavior unchanged.
+ * `/licks-ws` is loopback-only and stays ungated.
+ */
 function attachCdpUpgradeRouting(
   server: HttpServer,
   wss: WebSocketServer,
-  lickWss: WebSocketServer
+  lickWss: WebSocketServer,
+  bridgeToken: string | null
 ): void {
   server.on('upgrade', (request, socket, head) => {
     const { pathname } = new URL(request.url!, `http://${request.headers.host}`);
     if (pathname === '/cdp') {
+      if (bridgeToken !== null) {
+        const gate = validateBridgeUpgrade({
+          origin: request.headers.origin,
+          subprotocolHeader: request.headers['sec-websocket-protocol'],
+          expectedToken: bridgeToken,
+        });
+        if (!gate.ok) {
+          console.warn(`[cdp-proxy] /cdp upgrade rejected: ${gate.reason}`);
+          rejectUpgradeUnauthorized(socket, gate.reason ?? 'rejected');
+          return;
+        }
+      }
       wss.handleUpgrade(request, socket, head, (ws) => {
         wss.emit('connection', ws, request);
       });
@@ -1075,7 +1169,11 @@ interface CdpServerDeps {
 function startCdpServer(state: ServerState, deps: CdpServerDeps): void {
   const { app, server, ctx, fileLogger, servePort, serveOrigin, cdpPort } = deps;
   server.listen(servePort, '127.0.0.1', () => {
-    console.log(`Serving UI at ${serveOrigin}`);
+    if (THIN_BRIDGE_MODE) {
+      console.log(`Thin /cdp bridge + /api at ${serveOrigin}`);
+    } else {
+      console.log(`Serving UI at ${serveOrigin}`);
+    }
     console.log(`CDP proxy at ws://localhost:${servePort}/cdp`);
     fileLogger.log('info', 'CLI server started', {
       port: servePort,
@@ -1088,7 +1186,8 @@ function startCdpServer(state: ServerState, deps: CdpServerDeps): void {
 
     if (ELECTRON_MODE) {
       void startOverlayInjector(state, cdpPort, servePort);
-    } else {
+    } else if (!THIN_BRIDGE_MODE) {
+      // Thin-bridge mode has no local UI page to forward console output from.
       setTimeout(() => {
         attachConsoleForwarder(cdpPort, String(servePort)).catch((err) => {
           console.error('[page] Console forwarder error:', err);
@@ -1132,6 +1231,50 @@ async function bootstrapSecrets(): Promise<SecretBootstrap> {
   return { secretStore, secretProxy, oauthStore };
 }
 
+/**
+ * Thin-bridge CORS + PNA middleware. The hosted leader at sliccy.ai is a
+ * cross-origin caller, so headers go on every response for allowlisted
+ * origins (so /cdp's pre-WS preflight and every /api/* call succeed);
+ * OPTIONS from an allowlisted origin short-circuits to 204 with the PNA
+ * opt-in. Non-allowlisted origins fall through with no CORS headers, which
+ * preserves same-origin (localhost) behavior unchanged.
+ */
+function createThinBridgeCorsMiddleware(): import('express').RequestHandler {
+  return (req, res, next) => {
+    const cors = buildCorsHeaders(req.headers.origin);
+    if (cors) {
+      for (const [k, v] of Object.entries(cors)) res.setHeader(k, v);
+    }
+    if (req.method === 'OPTIONS' && cors) {
+      for (const [k, v] of Object.entries(buildPnaPreflightHeaders())) res.setHeader(k, v);
+      res.setHeader('Access-Control-Max-Age', '600');
+      res.status(204).end();
+      return;
+    }
+    next();
+  };
+}
+
+/**
+ * Build the `/cdp` `WebSocketServer`. `handleProtocols` echoes the matched
+ * bridge subprotocol back in the 101 response (RFC 6455 §1.9). Returning
+ * `false` makes the server omit the header, which makes the browser fail
+ * the upgrade when a subprotocol was offered. Legacy modes (token=null)
+ * pass the first offered subprotocol through unchanged.
+ */
+function createCdpWebSocketServer(bridgeToken: string | null): WebSocketServer {
+  return new WebSocketServer({
+    noServer: true,
+    handleProtocols: (protocols: Set<string>) => {
+      if (bridgeToken !== null) {
+        return selectBridgeSubprotocol([...protocols], bridgeToken) ?? false;
+      }
+      const first = protocols.values().next();
+      return first.done ? false : first.value;
+    },
+  });
+}
+
 async function main() {
   // Resolve ports, launch the browser, then snapshot the now-final values that
   // the rest of boot reads. Mutable lifecycle fields stay on `state`.
@@ -1148,6 +1291,10 @@ async function main() {
   app.use(requestLogger);
   // Append SLICC's standard RFC 8288 Link header set on every /api/* response.
   app.use(sliccLinksMiddleware());
+
+  if (THIN_BRIDGE_MODE) {
+    app.use(createThinBridgeCorsMiddleware());
+  }
 
   // ---------------------------------------------------------------------------
   // Lick system — WebSocket bridge for webhooks/crontasks (all logic in browser)
@@ -1239,18 +1386,22 @@ async function main() {
   // Create the HTTP server BEFORE Vite so we can register our upgrade handler first
   const server = createServer(app);
 
-  await attachUiServing(app, server, {
-    devMode: DEV_MODE,
-    hosted: RUNTIME_FLAGS.hosted,
-    serveOrigin: SERVE_ORIGIN,
-    uiDir: resolve(Dirname, '..', 'ui'),
-  });
+  // Thin-bridge mode: skip UI serving entirely. node-server becomes a
+  // pure /cdp bridge + /api surface; Chrome opens the sliccy.ai-hosted
+  // leader which talks to /cdp + /api cross-origin.
+  if (!THIN_BRIDGE_MODE) {
+    await attachUiServing(app, server, {
+      devMode: DEV_MODE,
+      hosted: RUNTIME_FLAGS.hosted,
+      serveOrigin: SERVE_ORIGIN,
+      uiDir: resolve(Dirname, '..', 'ui'),
+    });
+  }
 
   // 4. CDP WebSocket proxy at /cdp — noServer mode so Vite's dev middleware
-  //    doesn't intercept the upgrade; the per-message cap stays default (the
-  //    feedback-loop defense is Chrome→proxy only, never client→proxy).
-  const wss = new WebSocketServer({ noServer: true });
-  attachCdpUpgradeRouting(server, wss, lickWss);
+  //    doesn't intercept the upgrade.
+  const wss = createCdpWebSocketServer(state.bridgeToken);
+  attachCdpUpgradeRouting(server, wss, lickWss, state.bridgeToken);
   const cdpCtx: CdpProxyContext = {
     wss,
     secretProxy,

--- a/packages/node-server/src/launch-url.ts
+++ b/packages/node-server/src/launch-url.ts
@@ -1,3 +1,4 @@
+import { BRIDGE_TOKEN_QUERY_PARAM, BRIDGE_WS_QUERY_PARAM } from './bridge-security.js';
 import {
   buildCanonicalTrayLaunchUrl,
   normalizeTrayWorkerBaseUrl,
@@ -11,6 +12,21 @@ export interface CliLaunchUrlOptions {
   envWorkerBaseUrl?: string | null;
   join: boolean;
   joinUrl?: string | null;
+  /**
+   * Thin-bridge coordinates appended as query params so the hosted leader can
+   * discover + authenticate the local /cdp WebSocket. Both must be set
+   * together; both unset = no bridge params (legacy / bundled UI path).
+   */
+  bridgeWsUrl?: string | null;
+  bridgeToken?: string | null;
+}
+
+function appendBridgeParams(url: string, opts: CliLaunchUrlOptions): string {
+  if (!opts.bridgeWsUrl || !opts.bridgeToken) return url;
+  const params = new URLSearchParams();
+  params.set(BRIDGE_WS_QUERY_PARAM, opts.bridgeWsUrl);
+  params.set(BRIDGE_TOKEN_QUERY_PARAM, opts.bridgeToken);
+  return `${url}${url.includes('?') ? '&' : '?'}${params.toString()}`;
 }
 
 function buildTrayJoinLaunchUrl(locationHref: string, joinUrl: string): string {
@@ -42,11 +58,14 @@ export function resolveCliBrowserLaunchUrl(options: CliLaunchUrlOptions): string
         'The --join launch flow requires a tray join URL via --join <url> or --join=<url>.'
       );
     }
-    return buildTrayJoinLaunchUrl(options.serveOrigin, options.joinUrl);
+    return appendBridgeParams(
+      buildTrayJoinLaunchUrl(options.serveOrigin, options.joinUrl),
+      options
+    );
   }
 
   if (!options.lead) {
-    return options.serveOrigin;
+    return appendBridgeParams(options.serveOrigin, options);
   }
 
   const workerBaseUrl = normalizeTrayWorkerBaseUrl(
@@ -58,5 +77,5 @@ export function resolveCliBrowserLaunchUrl(options: CliLaunchUrlOptions): string
     );
   }
 
-  return buildTrayLeadLaunchUrl(options.serveOrigin, workerBaseUrl);
+  return appendBridgeParams(buildTrayLeadLaunchUrl(options.serveOrigin, workerBaseUrl), options);
 }

--- a/packages/node-server/tests/bridge-cors.test.ts
+++ b/packages/node-server/tests/bridge-cors.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Verifies the thin-bridge CORS + PNA middleware shape against a real Express
+ * pipeline. The middleware itself is inlined in `index.ts` (it's tiny and
+ * threaded through closure-scoped `THIN_BRIDGE_MODE`), so this test
+ * re-creates the exact same middleware against the same pure helpers — if
+ * the helpers change, both tests + the live wiring update together.
+ */
+import { createServer, type Server } from 'node:http';
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildCorsHeaders, buildPnaPreflightHeaders } from '../src/bridge-security.js';
+
+const PROD_ORIGIN = 'https://www.sliccy.ai';
+
+let server: Server;
+let base = '';
+
+beforeEach(async () => {
+  const app = express();
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    const cors = buildCorsHeaders(req.headers.origin);
+    if (cors) {
+      for (const [k, v] of Object.entries(cors)) res.setHeader(k, v);
+    }
+    if (req.method === 'OPTIONS') {
+      if (cors) {
+        for (const [k, v] of Object.entries(buildPnaPreflightHeaders())) res.setHeader(k, v);
+        res.setHeader('Access-Control-Max-Age', '600');
+        res.status(204).end();
+        return;
+      }
+    }
+    next();
+  });
+  app.get('/api/ping', (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  server = createServer(app);
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === 'object' && addr ? addr.port : 0}`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((r) => server.close(() => r()));
+});
+
+describe('thin-bridge CORS + PNA middleware', () => {
+  it('attaches CORS headers to /api responses from an allowlisted origin', async () => {
+    const res = await fetch(`${base}/api/ping`, {
+      headers: { Origin: PROD_ORIGIN },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('access-control-allow-origin')).toBe(PROD_ORIGIN);
+    expect(res.headers.get('access-control-allow-credentials')).toBe('true');
+    expect(res.headers.get('vary')).toBe('Origin');
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('omits CORS headers for non-allowlisted origins', async () => {
+    const res = await fetch(`${base}/api/ping`, {
+      headers: { Origin: 'https://evil.example.com' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('answers OPTIONS preflight with 204 + PNA opt-in for allowlisted origin', async () => {
+    const res = await fetch(`${base}/api/ping`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: PROD_ORIGIN,
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Private-Network': 'true',
+      },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-private-network')).toBe('true');
+    expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(res.headers.get('access-control-max-age')).toBe('600');
+  });
+
+  it('does not short-circuit OPTIONS from non-allowlisted origins', async () => {
+    const res = await fetch(`${base}/api/ping`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://evil.example.com' },
+    });
+    // Express default OPTIONS handler responds with 200 + Allow, not 204
+    // with PNA — verifies the preflight short-circuit only fires when the
+    // origin is in the allowlist.
+    expect(res.status).not.toBe(204);
+    expect(res.headers.get('access-control-allow-private-network')).toBeNull();
+  });
+});

--- a/packages/node-server/tests/bridge-security.test.ts
+++ b/packages/node-server/tests/bridge-security.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BRIDGE_ALLOWED_ORIGINS,
+  BRIDGE_SUBPROTOCOL_PREFIX,
+  buildCorsHeaders,
+  buildPnaPreflightHeaders,
+  isAllowedBridgeOrigin,
+  mintBridgeToken,
+  parseSubprotocolHeader,
+  selectBridgeSubprotocol,
+  validateBridgeUpgrade,
+} from '../src/bridge-security.js';
+
+const PROD_ORIGIN = 'https://www.sliccy.ai';
+const TOKEN = 'aabbccdd-1122-3344-5566-778899aabbcc';
+
+describe('isAllowedBridgeOrigin', () => {
+  it('accepts every entry in BRIDGE_ALLOWED_ORIGINS', () => {
+    for (const origin of BRIDGE_ALLOWED_ORIGINS) {
+      expect(isAllowedBridgeOrigin(origin)).toBe(true);
+    }
+  });
+
+  it('rejects unrelated, partial, and empty origins', () => {
+    expect(isAllowedBridgeOrigin(undefined)).toBe(false);
+    expect(isAllowedBridgeOrigin(null)).toBe(false);
+    expect(isAllowedBridgeOrigin('')).toBe(false);
+    expect(isAllowedBridgeOrigin('https://evil.example.com')).toBe(false);
+    // Subdomain spoof: only the exact origin is allowed.
+    expect(isAllowedBridgeOrigin('https://www.sliccy.ai.evil.com')).toBe(false);
+    // Scheme mismatch.
+    expect(isAllowedBridgeOrigin('http://www.sliccy.ai')).toBe(false);
+    // Trailing slash is not a valid Origin and must not match.
+    expect(isAllowedBridgeOrigin('https://www.sliccy.ai/')).toBe(false);
+  });
+});
+
+describe('mintBridgeToken', () => {
+  it('returns a UUID-shaped token that differs each call', () => {
+    const a = mintBridgeToken();
+    const b = mintBridgeToken();
+    expect(a).toMatch(/^[0-9a-f-]{36}$/);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('parseSubprotocolHeader', () => {
+  it('handles comma-separated, whitespace, array, and empty inputs', () => {
+    expect(parseSubprotocolHeader(undefined)).toEqual([]);
+    expect(parseSubprotocolHeader('')).toEqual([]);
+    expect(parseSubprotocolHeader('a, b,   c')).toEqual(['a', 'b', 'c']);
+    expect(parseSubprotocolHeader(['a', 'b,c'])).toEqual(['a', 'b', 'c']);
+    expect(parseSubprotocolHeader(', ,a, ,')).toEqual(['a']);
+  });
+});
+
+describe('selectBridgeSubprotocol', () => {
+  it('returns the matching subprotocol string', () => {
+    const proto = `${BRIDGE_SUBPROTOCOL_PREFIX}${TOKEN}`;
+    expect(selectBridgeSubprotocol([proto], TOKEN)).toBe(proto);
+    expect(selectBridgeSubprotocol(['other', proto, 'extra'], TOKEN)).toBe(proto);
+  });
+
+  it('returns null on missing, mismatched, or empty token', () => {
+    const proto = `${BRIDGE_SUBPROTOCOL_PREFIX}${TOKEN}`;
+    expect(selectBridgeSubprotocol([], TOKEN)).toBeNull();
+    expect(selectBridgeSubprotocol([proto], 'other-token')).toBeNull();
+    expect(selectBridgeSubprotocol(['unrelated'], TOKEN)).toBeNull();
+    expect(selectBridgeSubprotocol([proto], '')).toBeNull();
+  });
+});
+
+describe('validateBridgeUpgrade', () => {
+  const proto = `${BRIDGE_SUBPROTOCOL_PREFIX}${TOKEN}`;
+
+  it('accepts allowlisted origin + matching subprotocol', () => {
+    const res = validateBridgeUpgrade({
+      origin: PROD_ORIGIN,
+      subprotocolHeader: proto,
+      expectedToken: TOKEN,
+    });
+    expect(res).toEqual({ ok: true, acceptedSubprotocol: proto });
+  });
+
+  it('rejects when origin is not allowlisted (even if subprotocol matches)', () => {
+    const res = validateBridgeUpgrade({
+      origin: 'https://evil.example.com',
+      subprotocolHeader: proto,
+      expectedToken: TOKEN,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('origin-not-allowed');
+    expect(res.acceptedSubprotocol).toBeNull();
+  });
+
+  it('rejects when origin is missing entirely', () => {
+    const res = validateBridgeUpgrade({
+      origin: undefined,
+      subprotocolHeader: proto,
+      expectedToken: TOKEN,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('origin-not-allowed');
+  });
+
+  it('rejects allowlisted origin with no Sec-WebSocket-Protocol header', () => {
+    const res = validateBridgeUpgrade({
+      origin: PROD_ORIGIN,
+      subprotocolHeader: undefined,
+      expectedToken: TOKEN,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('subprotocol-missing-or-mismatched');
+  });
+
+  it('rejects allowlisted origin with wrong token in subprotocol', () => {
+    const res = validateBridgeUpgrade({
+      origin: PROD_ORIGIN,
+      subprotocolHeader: `${BRIDGE_SUBPROTOCOL_PREFIX}wrong-token`,
+      expectedToken: TOKEN,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('subprotocol-missing-or-mismatched');
+  });
+});
+
+describe('buildCorsHeaders', () => {
+  it('returns CORS headers echoing an allowlisted origin', () => {
+    const headers = buildCorsHeaders(PROD_ORIGIN);
+    expect(headers).not.toBeNull();
+    expect(headers!['Access-Control-Allow-Origin']).toBe(PROD_ORIGIN);
+    expect(headers!['Access-Control-Allow-Credentials']).toBe('true');
+    expect(headers!['Access-Control-Allow-Methods']).toContain('OPTIONS');
+    expect(headers!['Access-Control-Allow-Headers']).toContain('Content-Type');
+    expect(headers!.Vary).toBe('Origin');
+  });
+
+  it('returns null for non-allowlisted origins', () => {
+    expect(buildCorsHeaders('https://evil.example.com')).toBeNull();
+    expect(buildCorsHeaders(undefined)).toBeNull();
+  });
+});
+
+describe('buildPnaPreflightHeaders', () => {
+  it('advertises Private Network Access opt-in', () => {
+    expect(buildPnaPreflightHeaders()).toEqual({
+      'Access-Control-Allow-Private-Network': 'true',
+    });
+  });
+});

--- a/packages/node-server/tests/cdp-bridge-upgrade.test.ts
+++ b/packages/node-server/tests/cdp-bridge-upgrade.test.ts
@@ -1,0 +1,139 @@
+/**
+ * End-to-end WebSocket upgrade gate for the thin /cdp bridge.
+ *
+ * Boots a real `http.Server` + `WebSocketServer` wired with the same
+ * `handleProtocols` + `attachCdpUpgradeRouting` shape as `index.ts`, then
+ * drives `ws` clients through every accept/reject branch:
+ *   - allowlisted origin + matching subprotocol = 101 + echoed subprotocol
+ *   - allowlisted origin + wrong subprotocol    = 401 close
+ *   - allowlisted origin + no subprotocol       = 401 close
+ *   - disallowed origin                         = 401 close
+ *
+ * The handler is copied verbatim from `index.ts` so this test pins the
+ * gate behavior; `bridge-security.test.ts` covers the pure-function layer.
+ */
+import { createServer, type Server as HttpServer } from 'node:http';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WebSocket, { WebSocketServer } from 'ws';
+import {
+  BRIDGE_SUBPROTOCOL_PREFIX,
+  selectBridgeSubprotocol,
+  validateBridgeUpgrade,
+} from '../src/bridge-security.js';
+
+const TOKEN = '11112222-3333-4444-5555-666677778888';
+const PROD_ORIGIN = 'https://www.sliccy.ai';
+
+let httpServer: HttpServer;
+let wss: WebSocketServer;
+let port = 0;
+
+beforeEach(async () => {
+  httpServer = createServer();
+  wss = new WebSocketServer({
+    noServer: true,
+    handleProtocols: (protocols: Set<string>) =>
+      selectBridgeSubprotocol([...protocols], TOKEN) ?? false,
+  });
+
+  // Mirror of the index.ts upgrade routing (token-gated branch only).
+  httpServer.on('upgrade', (request, socket, head) => {
+    const { pathname } = new URL(request.url!, `http://${request.headers.host}`);
+    if (pathname !== '/cdp') {
+      socket.destroy();
+      return;
+    }
+    const gate = validateBridgeUpgrade({
+      origin: request.headers.origin,
+      subprotocolHeader: request.headers['sec-websocket-protocol'],
+      expectedToken: TOKEN,
+    });
+    if (!gate.ok) {
+      socket.write(`HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n`);
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      wss.emit('connection', ws, request);
+    });
+  });
+
+  wss.on('connection', (ws) => {
+    // Echo a single hello so the client can confirm the connection is live.
+    ws.send('hello');
+  });
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, '127.0.0.1', () => {
+      const addr = httpServer.address();
+      port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve();
+    });
+  });
+});
+
+afterEach(async () => {
+  wss.close();
+  await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+});
+
+function connect(
+  protocols: string[] | undefined,
+  origin: string | undefined
+): Promise<{ ws: WebSocket; status?: number; firstMessage: Promise<string> }> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {};
+    if (origin) headers.Origin = origin;
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/cdp`, protocols ?? [], { headers });
+    // Listener attached BEFORE the connection opens so the server's first
+    // frame can't lose the race with the open callback.
+    const firstMessage = new Promise<string>((res, rej) => {
+      const timer = setTimeout(() => rej(new Error('no message received')), 4000);
+      ws.once('message', (data: Buffer) => {
+        clearTimeout(timer);
+        res(data.toString());
+      });
+    });
+    ws.on('open', () => resolve({ ws, firstMessage }));
+    ws.on('unexpected-response', (_req, res) => {
+      resolve({ ws, status: res.statusCode, firstMessage });
+    });
+    ws.on('error', (err) => {
+      // Surface connect-time errors only; post-open errors are caller's problem.
+      if (ws.readyState === WebSocket.CONNECTING) reject(err);
+    });
+    setTimeout(() => reject(new Error('connect timed out')), 5000);
+  });
+}
+
+describe('thin /cdp bridge WS upgrade gate (integration)', () => {
+  it('accepts allowlisted origin + matching subprotocol and echoes it back', async () => {
+    const proto = `${BRIDGE_SUBPROTOCOL_PREFIX}${TOKEN}`;
+    const { ws, firstMessage } = await connect([proto], PROD_ORIGIN);
+    expect(ws.protocol).toBe(proto);
+    expect(await firstMessage).toBe('hello');
+    ws.close();
+  });
+
+  it('rejects allowlisted origin without any Sec-WebSocket-Protocol', async () => {
+    const result = await connect(undefined, PROD_ORIGIN);
+    expect(result.status).toBe(401);
+  });
+
+  it('rejects allowlisted origin with mismatched subprotocol token', async () => {
+    const result = await connect([`${BRIDGE_SUBPROTOCOL_PREFIX}wrong-token`], PROD_ORIGIN);
+    expect(result.status).toBe(401);
+  });
+
+  it('rejects non-allowlisted origin even when subprotocol matches', async () => {
+    const proto = `${BRIDGE_SUBPROTOCOL_PREFIX}${TOKEN}`;
+    const result = await connect([proto], 'https://evil.example.com');
+    expect(result.status).toBe(401);
+  });
+
+  it('rejects when Origin header is omitted entirely', async () => {
+    const proto = `${BRIDGE_SUBPROTOCOL_PREFIX}${TOKEN}`;
+    const result = await connect([proto], undefined);
+    expect(result.status).toBe(401);
+  });
+});

--- a/packages/node-server/tests/launch-url.test.ts
+++ b/packages/node-server/tests/launch-url.test.ts
@@ -91,4 +91,68 @@ describe('resolveCliBrowserLaunchUrl', () => {
       })
     ).toThrow(/--lead launch flow requires a tray worker base URL/);
   });
+
+  describe('thin-bridge query params', () => {
+    it('appends bridge + bridgeToken to the plain serve origin', () => {
+      const url = resolveCliBrowserLaunchUrl({
+        serveOrigin: 'https://www.sliccy.ai/?runtime=hosted-leader',
+        lead: false,
+        join: false,
+        bridgeWsUrl: 'ws://localhost:5710/cdp',
+        bridgeToken: 'tok-123',
+      });
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get('bridge')).toBe('ws://localhost:5710/cdp');
+      expect(parsed.searchParams.get('bridgeToken')).toBe('tok-123');
+      expect(parsed.searchParams.get('runtime')).toBe('hosted-leader');
+    });
+
+    it('appends bridge params alongside the tray param in lead mode', () => {
+      const url = resolveCliBrowserLaunchUrl({
+        serveOrigin: 'http://localhost:3000',
+        lead: true,
+        leadWorkerBaseUrl: 'https://tray.example.com/base',
+        join: false,
+        bridgeWsUrl: 'ws://localhost:3000/cdp',
+        bridgeToken: 'tok-abc',
+      });
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get('tray')).toBe('https://tray.example.com/base');
+      expect(parsed.searchParams.get('bridge')).toBe('ws://localhost:3000/cdp');
+      expect(parsed.searchParams.get('bridgeToken')).toBe('tok-abc');
+    });
+
+    it('appends bridge params alongside the tray param in join mode', () => {
+      const url = resolveCliBrowserLaunchUrl({
+        serveOrigin: 'http://localhost:3000',
+        lead: false,
+        join: true,
+        joinUrl: 'https://tray.example.com/base/join/tray-123.secret',
+        bridgeWsUrl: 'ws://localhost:3000/cdp',
+        bridgeToken: 'tok-xyz',
+      });
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get('tray')).toBeTruthy();
+      expect(parsed.searchParams.get('bridge')).toBe('ws://localhost:3000/cdp');
+      expect(parsed.searchParams.get('bridgeToken')).toBe('tok-xyz');
+    });
+
+    it('omits bridge params when only one of bridgeWsUrl/bridgeToken is set', () => {
+      const noToken = resolveCliBrowserLaunchUrl({
+        serveOrigin: 'http://localhost:3000',
+        lead: false,
+        join: false,
+        bridgeWsUrl: 'ws://localhost:3000/cdp',
+      });
+      expect(new URL(noToken).searchParams.get('bridge')).toBeNull();
+
+      const noUrl = resolveCliBrowserLaunchUrl({
+        serveOrigin: 'http://localhost:3000',
+        lead: false,
+        join: false,
+        bridgeToken: 'tok-xyz',
+      });
+      expect(new URL(noUrl).searchParams.get('bridgeToken')).toBeNull();
+    });
+  });
 });

--- a/packages/webapp/src/cdp/browser-api.ts
+++ b/packages/webapp/src/cdp/browser-api.ts
@@ -192,6 +192,7 @@ export class BrowserAPI {
     await this.client.connect({
       url: options?.url ?? getDefaultCdpUrl(),
       timeout: options?.timeout,
+      ...(options?.protocols !== undefined ? { protocols: options.protocols } : {}),
     });
   }
 

--- a/packages/webapp/src/cdp/cdp-client.ts
+++ b/packages/webapp/src/cdp/cdp-client.ts
@@ -49,7 +49,7 @@ export class CDPClient implements CDPTransport {
       throw new Error('CDPClient.connect() requires a WebSocket URL');
     }
 
-    const { url, timeout = 5000 } = options;
+    const { url, timeout = 5000, protocols } = options;
     this._state = 'connecting';
 
     return new Promise<void>((resolve, reject) => {
@@ -59,7 +59,7 @@ export class CDPClient implements CDPTransport {
       }, timeout);
 
       try {
-        this.ws = new WebSocket(url);
+        this.ws = protocols !== undefined ? new WebSocket(url, protocols) : new WebSocket(url);
       } catch (err) {
         clearTimeout(timer);
         this._state = 'disconnected';

--- a/packages/webapp/src/cdp/types.ts
+++ b/packages/webapp/src/cdp/types.ts
@@ -78,6 +78,14 @@ export interface CDPConnectOptions {
   url: string;
   /** Timeout for the initial connection in ms. Default: 5000. */
   timeout?: number;
+  /**
+   * `Sec-WebSocket-Protocol` value(s) offered on the upgrade. Used by the
+   * hosted-leader bridge path to pass the per-session token to a local
+   * standalone /cdp socket without leaking it via the URL. The server MUST
+   * echo back exactly one of these on the 101 (RFC 6455 §1.9) — see
+   * `packages/node-server/src/bridge-security.ts` (`BRIDGE_SUBPROTOCOL_PREFIX`).
+   */
+  protocols?: string | string[];
 }
 
 /** Options for evaluate(). */

--- a/packages/webapp/src/ui/boot/bridge-launch-params.ts
+++ b/packages/webapp/src/ui/boot/bridge-launch-params.ts
@@ -1,0 +1,55 @@
+/**
+ * `bridge-launch-params.ts` — parse the standalone-bridge launch query
+ * params (`?bridge=<ws-url>&bridgeToken=<token>`) the node-server (and
+ * later swift-server) Path A appends to the leader launch URL. When both
+ * are present, the hosted leader's CDP connection is routed at
+ * `bridge` (a `ws://localhost:<port>/cdp` URL) with the token sent via
+ * `Sec-WebSocket-Protocol` (never on the query string).
+ *
+ * Server-side counterparts: `packages/node-server/src/bridge-security.ts`
+ * (`BRIDGE_SUBPROTOCOL_PREFIX`, `BRIDGE_TOKEN_QUERY_PARAM`,
+ * `BRIDGE_WS_QUERY_PARAM`) and `packages/node-server/src/launch-url.ts`
+ * (`appendBridgeParams`). The constants below MUST stay in sync with that
+ * module — the webapp bundle can't import from node-server.
+ */
+
+/** Query-param name carrying the local `/cdp` WebSocket URL. */
+export const BRIDGE_WS_QUERY_PARAM = 'bridge';
+
+/** Query-param name carrying the per-process bridge token. */
+export const BRIDGE_TOKEN_QUERY_PARAM = 'bridgeToken';
+
+/** Subprotocol prefix the leader sends; server validates `<prefix><token>`. */
+export const BRIDGE_SUBPROTOCOL_PREFIX = 'slicc.bridge.v1.';
+
+export interface BridgeLaunchParams {
+  /** The fully-qualified `ws://localhost:<port>/cdp` URL the leader will dial. */
+  url: string;
+  /** The `Sec-WebSocket-Protocol` value to offer on the upgrade. */
+  subprotocol: string;
+}
+
+/**
+ * Extract bridge coordinates from a launch URL's query string. Returns
+ * `null` unless BOTH `bridge` and `bridgeToken` are present and the URL
+ * uses a `ws://` or `wss://` scheme — partial / malformed inputs degrade
+ * to the legacy bundled-UI path (no bridge) rather than throwing.
+ */
+export function parseBridgeLaunchParams(search: string): BridgeLaunchParams | null {
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(search);
+  } catch {
+    return null;
+  }
+
+  const url = params.get(BRIDGE_WS_QUERY_PARAM);
+  const token = params.get(BRIDGE_TOKEN_QUERY_PARAM);
+  if (!url || !token) return null;
+  if (!/^wss?:\/\//.test(url)) return null;
+
+  return {
+    url,
+    subprotocol: `${BRIDGE_SUBPROTOCOL_PREFIX}${token}`,
+  };
+}

--- a/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
@@ -26,6 +26,7 @@ import {
 } from '../../scoops/tray-runtime-config.js';
 import type { UiRuntimeMode } from '../runtime-mode.js';
 import { shouldUseRuntimeModeTrayDefaults } from '../runtime-mode.js';
+import { parseBridgeLaunchParams } from './bridge-launch-params.js';
 import { setupSudoStandalone } from './setup-sudo.js';
 import type { BootStageLogger } from './types.js';
 
@@ -90,8 +91,14 @@ export async function setupStandalonePrelude(
     cherryTransport = cherry.transport;
   } else {
     browser = new BrowserAPI();
+    const bridge = parseBridgeLaunchParams(win.location.search);
+    if (bridge) {
+      log.info('Routing CDP through local standalone bridge', { url: bridge.url });
+    }
     try {
-      await browser.connect();
+      await browser.connect(
+        bridge ? { url: bridge.url, protocols: bridge.subprotocol } : undefined
+      );
     } catch (err) {
       log.warn(
         'Initial CDP connect failed; worker-forwarded commands will retry on demand',

--- a/packages/webapp/tests/cdp/cdp-client.test.ts
+++ b/packages/webapp/tests/cdp/cdp-client.test.ts
@@ -16,8 +16,13 @@ class MockWebSocket {
   onmessage: WSHandler | null = null;
 
   sent: string[] = [];
+  protocols: string | string[] | undefined;
 
-  constructor(public url: string) {
+  constructor(
+    public url: string,
+    protocols?: string | string[]
+  ) {
+    this.protocols = protocols;
     MockWebSocket.instances.push(this);
   }
 
@@ -122,6 +127,36 @@ describe('CDPClient', () => {
       await expect(client.connect({ url: 'ws://localhost:5710/cdp' })).rejects.toThrow(
         'Cannot connect'
       );
+    });
+
+    it('forwards a subprotocol string to the WebSocket constructor', async () => {
+      const p = client.connect({
+        url: 'ws://localhost:5710/cdp',
+        protocols: 'slicc.bridge.v1.token-abc',
+      });
+      const ws = MockWebSocket.instances[0];
+      expect(ws.protocols).toBe('slicc.bridge.v1.token-abc');
+      ws.simulateOpen();
+      await p;
+    });
+
+    it('forwards a subprotocol array to the WebSocket constructor', async () => {
+      const p = client.connect({
+        url: 'ws://localhost:5710/cdp',
+        protocols: ['slicc.bridge.v1.tok1', 'slicc.bridge.v1.tok2'],
+      });
+      const ws = MockWebSocket.instances[0];
+      expect(ws.protocols).toEqual(['slicc.bridge.v1.tok1', 'slicc.bridge.v1.tok2']);
+      ws.simulateOpen();
+      await p;
+    });
+
+    it('omits protocols argument when not provided', async () => {
+      const p = client.connect({ url: 'ws://localhost:5710/cdp' });
+      const ws = MockWebSocket.instances[0];
+      expect(ws.protocols).toBeUndefined();
+      ws.simulateOpen();
+      await p;
     });
   });
 

--- a/packages/webapp/tests/ui/boot/bridge-launch-params.test.ts
+++ b/packages/webapp/tests/ui/boot/bridge-launch-params.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BRIDGE_SUBPROTOCOL_PREFIX,
+  BRIDGE_TOKEN_QUERY_PARAM,
+  BRIDGE_WS_QUERY_PARAM,
+  parseBridgeLaunchParams,
+} from '../../../src/ui/boot/bridge-launch-params.js';
+
+describe('parseBridgeLaunchParams', () => {
+  it('returns null when both params are missing', () => {
+    expect(parseBridgeLaunchParams('')).toBeNull();
+    expect(parseBridgeLaunchParams('?foo=bar')).toBeNull();
+  });
+
+  it('returns null when only `bridge` is present', () => {
+    expect(parseBridgeLaunchParams('?bridge=ws://localhost:5710/cdp')).toBeNull();
+  });
+
+  it('returns null when only `bridgeToken` is present', () => {
+    expect(parseBridgeLaunchParams('?bridgeToken=abc')).toBeNull();
+  });
+
+  it('returns null when bridge URL has a non-ws scheme', () => {
+    expect(parseBridgeLaunchParams('?bridge=http://localhost:5710/cdp&bridgeToken=abc')).toBeNull();
+    expect(parseBridgeLaunchParams('?bridge=javascript:alert(1)&bridgeToken=abc')).toBeNull();
+  });
+
+  it('parses a ws:// bridge URL + token into url + subprotocol', () => {
+    const params = parseBridgeLaunchParams('?bridge=ws://localhost:5710/cdp&bridgeToken=abc-123');
+    expect(params).toEqual({
+      url: 'ws://localhost:5710/cdp',
+      subprotocol: 'slicc.bridge.v1.abc-123',
+    });
+  });
+
+  it('accepts wss:// bridge URLs', () => {
+    const params = parseBridgeLaunchParams(
+      '?bridge=wss%3A%2F%2Fbridge.example%2Fcdp&bridgeToken=xyz'
+    );
+    expect(params?.url).toBe('wss://bridge.example/cdp');
+    expect(params?.subprotocol).toBe('slicc.bridge.v1.xyz');
+  });
+
+  it('uses the same param/prefix constants the node-server gates on', () => {
+    expect(BRIDGE_WS_QUERY_PARAM).toBe('bridge');
+    expect(BRIDGE_TOKEN_QUERY_PARAM).toBe('bridgeToken');
+    expect(BRIDGE_SUBPROTOCOL_PREFIX).toBe('slicc.bridge.v1.');
+  });
+});


### PR DESCRIPTION
## Summary

Focused deploy carrying ONLY the thin-bridge connectivity fix so the production spot-check can move forward. Three commits, cherry-picked clean off `thin-extension-cdp-bridge-architecture`, no other Wave 5 surface.

## Why now

The currently deployed build of `www.sliccy.ai` is stale, which is causing two distinct production failures:

1. **Adobe IMS client-ID resolution fails** — the leader cannot complete the Adobe sign-in flow because the runtime config that resolves the client-ID for the production origin isn't in the deployed bundle yet.
2. **CDP-over-bridge fails** — the hosted leader has no way to discover or authenticate the local standalone `/cdp` socket, so any thin-bridge launch silently falls back to the legacy bundled-UI path.

Shipping this small PR unblocks both: the worker `/cloud` CSP starts allowing the bridge `connect-src`, and the webapp learns the `?bridge` / `?bridgeToken` launch contract that the node-server already mints.

## What's in scope

Three commits, in this order:

1. **`feat(node-server): add thin CDP bridge security primitives`** (`e591b0a64`)
   - New `packages/node-server/src/bridge-security.ts` defining `BRIDGE_SUBPROTOCOL_PREFIX = 'slicc.bridge.v1.'`, token minting, CORS / PNA preflight headers, and the `/cdp` WebSocket upgrade validator.
   - `index.ts` wires it into the existing `/cdp` proxy in thin-bridge mode (`!dev && !serveOnly && !electron && !hosted`); legacy modes stay ungated because the connecting client is always same-origin.
   - `launch-url.ts` appends `?bridge=ws://localhost:<port>/cdp&bridgeToken=<token>` to the Chrome launch URL.

2. **`feat(cloudflare-worker): build explicit connect-src CSP directive for /cloud`** (`b57c1b8f1`)
   - Adds `buildLeaderConnectSrc(env)` that emits a strict `connect-src` on the `/cloud` cone dashboard ONLY. The root `/` leader keeps its existing permissive CSP by design — see the corrected diagnosis below.

3. **`feat(webapp): add bridge launch params parser for hosted-leader CDP routing`** (`079f48573`)
   - New `packages/webapp/src/ui/boot/bridge-launch-params.ts` parses `?bridge` / `?bridgeToken` and, when both are present and the URL is `ws[s]://`, builds the subprotocol `slicc.bridge.v1.<token>`.
   - `setup-standalone-prelude.ts` passes the parsed bridge to `browser.connect({ url, protocols })`.
   - `CDPClient.connect()` and `BrowserAPI.connect()` learn an optional `protocols` arg (forwarded to `new WebSocket(url, protocols)`) so the per-session token rides as `Sec-WebSocket-Protocol` instead of leaking into the URL.

## Corrected CSP diagnosis (read me)

An earlier draft proposed adding a strict `connect-src` to the root `/` leader. That would break things — the root leader needs broad `connect-src` to talk to model APIs, GitHub, OAuth providers, MCP servers, S3 / DA mounts, the tray hub, etc. The strict `connect-src` lives on `/cloud` ONLY (the cone dashboard) because that surface has a known, small set of legitimate connect targets. This PR honors that boundary — `buildLeaderConnectSrc(env)` is only invoked on the `/cloud` branch.

## Subprotocol contract (must stay byte-identical)

```
BRIDGE_SUBPROTOCOL_PREFIX = 'slicc.bridge.v1.'
```

Defined in `packages/node-server/src/bridge-security.ts` and mirrored in `packages/webapp/src/ui/boot/bridge-launch-params.ts` (the webapp bundle can't import from node-server). Any change to this string is a breaking protocol change and must bump the version suffix.

## Spot-check re-test URL shape

After this deploy reaches production, the standalone CLI's launched Chrome will open something like:

```
https://www.sliccy.ai/?bridge=ws://localhost:<port>/cdp&bridgeToken=<token>
```

The leader parses the two params, dials `ws://localhost:<port>/cdp`, and offers `Sec-WebSocket-Protocol: slicc.bridge.v1.<token>` on the upgrade. The node-server `/cdp` handler validates the subprotocol, echoes back one match on the 101, and proxies the socket to Chrome.

## What's NOT in this PR (intentionally)

To keep the diff reviewable and the deploy de-risked, this branch deliberately excludes the rest of Wave 5:

- `slicc-launcher` / `slicc-permissions` webcomponents (and their stories/tests)
- chrome-extension content-script / launcher injection (Wave-3b extension bridge)
- node Path B / hosted-leader webcomponent surface
- swift work

Those land in follow-up PRs.

## Verification

All five gates green locally on this branch (run from repo root):

| Gate | Result |
|------|--------|
| `npm run lint` | ✅ pass |
| `npm run typecheck` | ✅ pass (7 tsc projects) |
| `npm run test` | ✅ 8161 passed, 20 skipped (489 files) |
| `npm run build` | ✅ pass (webapp + node-server + worker + swift) |
| `npm run build -w @slicc/chrome-extension` | ✅ pass |

## Risks / rollout

- Behavior change is gated on `THIN_BRIDGE_MODE` in node-server (`!dev && !serveOnly && !electron && !hosted`) — dev / electron / hosted paths are unaffected.
- The webapp parser returns `null` for partial / malformed inputs and degrades to the legacy bundled-UI path — no thrown errors.
- Worker `/cloud` CSP change is additive (only emits when the route matches); the root `/` leader CSP is untouched.

Do not merge until the production spot-check confirms IMS + CDP-over-bridge both work against this build.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author