### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -8,10 +8,10 @@
       "branches": 69
     },
     "node-server": {
-      "lines": 79,
-      "statements": 77,
+      "lines": 80,
+      "statements": 78,
       "functions": 83,
-      "branches": 67
+      "branches": 68
     },
     "chrome-extension": {
       "lines": 75,


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.