### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -10,7 +10,7 @@
     "node-server": {
       "lines": 80,
       "statements": 78,
-      "functions": 83,
+      "functions": 84,
       "branches": 68
     },
     "chrome-extension": {


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.