### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -38,8 +38,8 @@
     },
     "webapp": {
       "lines": 74,
-      "statements": 72,
-      "functions": 73,
+      "statements": 73,
+      "functions": 74,
       "branches": 63,
       "coverageExclude": [
         "**/node_modules/**",
@@ -63,7 +63,7 @@
     "cloud-core": {
       "lines": 80,
       "statements": 78,
-      "functions": 72,
+      "functions": 74,
       "branches": 75
     },
     "shared": {


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.