### PR TITLE
fix(kernel): silence cross-sibling VFS "drop unmatched response" spam

### DIFF
--- a/packages/webapp/src/kernel/remote-vfs-client.ts
+++ b/packages/webapp/src/kernel/remote-vfs-client.ts
@@ -108,6 +108,14 @@ interface PendingRequest {
 /** Default per-request timeout (ms). */
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
+/**
+ * Request-id namespace for the read client. Disjoint from the writable
+ * client's `vfs-w-` prefix (note: NOT a prefix of it) so the two clients
+ * — which share one transport and both match `vfs-read-*-result` envelopes
+ * — can each tell its own responses from a sibling's. See `handleResult`.
+ */
+const READ_REQUEST_ID_PREFIX = 'vfs-r-';
+
 class RemoteVfsClient implements RemoteVfsClientHandle {
   private readonly transport: KernelTransport<ExtensionMessage, PanelToOffscreenMessage>;
   private readonly log: NonNullable<RemoteVfsClientOptions['logger']>;
@@ -126,7 +134,7 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
       (() => {
         this.counter = (this.counter + 1) >>> 0;
         const rand = Math.random().toString(36).slice(2, 8);
-        return `vfs-${this.counter.toString(36)}-${rand}`;
+        return `${READ_REQUEST_ID_PREFIX}${this.counter.toString(36)}-${rand}`;
       });
     this.unsubscribe = this.transport.onMessage((envelope) => {
       if (!isExtensionEnvelope(envelope)) return;
@@ -219,12 +227,20 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
   private handleResult(msg: ResultMsg): void {
     const pending = this.pending.get(msg.requestId);
     if (!pending) {
-      // Unsolicited (or already-rejected) reply. The host emits one
-      // response per request, so duplicates are bugs — log and drop.
-      this.log.debug?.('[remote-vfs-client] drop unmatched response', {
-        type: msg.type,
-        requestId: msg.requestId,
-      });
+      // No pending entry. In standalone the page runs this reader AND a
+      // sibling `RemoteWritableVfsClient` on the SAME transport, and both
+      // match `vfs-read-*-result` envelopes — so a response addressed to the
+      // sibling (id prefix `vfs-w-`) routinely lands here. That is expected;
+      // ignore it silently. Logging a "drop" per sibling read flooded the
+      // console and the page→node-server log relay under tray-leader load.
+      // Only an id in OUR namespace that has no pending entry is a genuine
+      // anomaly (duplicate/late host reply); surface that at debug level.
+      if (msg.requestId.startsWith(READ_REQUEST_ID_PREFIX)) {
+        this.log.debug?.('[remote-vfs-client] drop unmatched response', {
+          type: msg.type,
+          requestId: msg.requestId,
+        });
+      }
       return;
     }
     // A response landed — cancel the timeout before settling.

--- a/packages/webapp/src/kernel/writable-vfs-client.ts
+++ b/packages/webapp/src/kernel/writable-vfs-client.ts
@@ -156,6 +156,14 @@ interface PendingRequest {
   path: string;
 }
 
+/**
+ * Request-id namespace for the writable client. Disjoint from the read
+ * client's `vfs-r-` prefix so the two clients — which share one transport
+ * and both match `vfs-read-*-result` envelopes — can each tell its own
+ * responses from a sibling's. See `handleResult`.
+ */
+const WRITE_REQUEST_ID_PREFIX = 'vfs-w-';
+
 class RemoteWritableVfsClient implements RemoteWritableVfsClientHandle {
   private readonly transport: KernelTransport<ExtensionMessage, PanelToOffscreenMessage>;
   private readonly log: NonNullable<RemoteWritableVfsClientOptions['logger']>;
@@ -172,7 +180,7 @@ class RemoteWritableVfsClient implements RemoteWritableVfsClientHandle {
       (() => {
         this.counter = (this.counter + 1) >>> 0;
         const rand = Math.random().toString(36).slice(2, 8);
-        return `vfs-w-${this.counter.toString(36)}-${rand}`;
+        return `${WRITE_REQUEST_ID_PREFIX}${this.counter.toString(36)}-${rand}`;
       });
     this.unsubscribe = this.transport.onMessage((envelope) => {
       if (!isExtensionEnvelope(envelope)) return;
@@ -327,12 +335,20 @@ class RemoteWritableVfsClient implements RemoteWritableVfsClientHandle {
   private handleResult(msg: ResultMsg): void {
     const pending = this.pending.get(msg.requestId);
     if (!pending) {
-      // Unsolicited (or already-rejected) reply. The host emits one
-      // response per request, so duplicates are bugs — log and drop.
-      this.log.debug?.('[remote-writable-vfs-client] drop unmatched response', {
-        type: msg.type,
-        requestId: msg.requestId,
-      });
+      // No pending entry. In standalone the page runs this writable client
+      // AND a sibling read-only `RemoteVfsClient` on the SAME transport, and
+      // both match `vfs-read-*-result` envelopes — so a response addressed to
+      // the sibling (id prefix `vfs-r-`) routinely lands here. That is
+      // expected; ignore it silently. Logging a "drop" per sibling read
+      // flooded the console and the page→node-server log relay under
+      // tray-leader load. Only an id in OUR namespace that has no pending
+      // entry is a genuine anomaly (duplicate/late host reply).
+      if (msg.requestId.startsWith(WRITE_REQUEST_ID_PREFIX)) {
+        this.log.debug?.('[remote-writable-vfs-client] drop unmatched response', {
+          type: msg.type,
+          requestId: msg.requestId,
+        });
+      }
       return;
     }
     if (pending.expect !== msg.type) {

--- a/packages/webapp/tests/kernel/writable-vfs-client.test.ts
+++ b/packages/webapp/tests/kernel/writable-vfs-client.test.ts
@@ -37,6 +37,7 @@ import type {
 } from '../../src/fs/types.js';
 import { FsError } from '../../src/fs/types.js';
 import type { LocalVfsClient } from '../../src/kernel/local-vfs-client.js';
+import { createRemoteVfsClient } from '../../src/kernel/remote-vfs-client.js';
 import type { KernelTransport } from '../../src/kernel/transport.js';
 import {
   createBridgeMessageChannelTransport,
@@ -273,6 +274,85 @@ describe('WritableVfsClient — write round-trip over MessageChannel', () => {
     _resolveBackend();
     ctx.channel.port1.close();
     ctx.channel.port2.close();
+  });
+});
+
+describe('VFS clients sharing one transport — sibling-response handling', () => {
+  // Regression: in standalone the page constructs BOTH a `RemoteVfsClient`
+  // (reader, ids `vfs-…`) and a `RemoteWritableVfsClient` (writer, ids
+  // `vfs-w-…`) on the SAME kernel transport. Both match `vfs-read-*-result`
+  // envelopes, so every read response is delivered to both clients. The
+  // non-owner must drop it SILENTLY — the previous "drop unmatched response"
+  // debug log fired once per read on the wrong client, flooding the console
+  // (and the page→node-server relay) under leader load.
+  it('writable client does not log a drop for a sibling reader response', async () => {
+    const channel = new MessageChannel();
+    const bridge = createBridgeMessageChannelTransport(channel.port2);
+    const read = makeStubReadVfs();
+    const write = makeStubWriteBackend();
+    const host = startVfsRpcHost({
+      transport: bridge,
+      client: read.client,
+      writableClient: write.backend,
+      logger: { warn: vi.fn(), debug: vi.fn() },
+    });
+    const panel = createPanelMessageChannelTransport(channel.port1);
+    const writerDebug = vi.fn();
+    const writer = createRemoteWritableVfsClient({
+      transport: panel,
+      logger: { warn: vi.fn(), debug: writerDebug },
+    });
+    const reader = createRemoteVfsClient({
+      transport: panel,
+      logger: { warn: vi.fn(), debug: vi.fn() },
+    });
+
+    read.readDir.mockResolvedValue([{ name: 'a.txt', type: 'file' }]);
+    await expect(reader.readDir('/workspace')).resolves.toEqual([{ name: 'a.txt', type: 'file' }]);
+    await tick();
+
+    expect(writerDebug).not.toHaveBeenCalled();
+
+    reader.dispose();
+    writer.dispose();
+    host.stop();
+    channel.port1.close();
+    channel.port2.close();
+  });
+
+  it('reader does not log a drop for a sibling writable-client read response', async () => {
+    const channel = new MessageChannel();
+    const bridge = createBridgeMessageChannelTransport(channel.port2);
+    const read = makeStubReadVfs();
+    const write = makeStubWriteBackend();
+    const host = startVfsRpcHost({
+      transport: bridge,
+      client: read.client,
+      writableClient: write.backend,
+      logger: { warn: vi.fn(), debug: vi.fn() },
+    });
+    const panel = createPanelMessageChannelTransport(channel.port1);
+    const readerDebug = vi.fn();
+    const reader = createRemoteVfsClient({
+      transport: panel,
+      logger: { warn: vi.fn(), debug: readerDebug },
+    });
+    const writer = createRemoteWritableVfsClient({
+      transport: panel,
+      logger: { warn: vi.fn(), debug: vi.fn() },
+    });
+
+    read.readFile.mockResolvedValue('hi');
+    await expect(writer.readFile('/x.txt')).resolves.toBe('hi');
+    await tick();
+
+    expect(readerDebug).not.toHaveBeenCalled();
+
+    reader.dispose();
+    writer.dispose();
+    host.stop();
+    channel.port1.close();
+    channel.port2.close();
   });
 });
 


### PR DESCRIPTION
## Problem

In the standalone (kernel-worker) float the page runs **two** VFS clients on a **single** `KernelTransport`: the read-only `RemoteVfsClient` and the read+write `RemoteWritableVfsClient`. Both match `vfs-read-*-result` envelopes, so every response is delivered to *both* `handleResult` methods — and the one that didn't issue the request has no pending entry for it.

The old code treated "no pending entry" as an anomaly and logged a `drop unmatched response` debug line for **every** sibling response. Those debug lines are relayed page→node-server, so under tray-leader load the log filled with:

```
[remote-writable-vfs-client] drop unmatched response { ... }
```

(One line per read the *other* client issued.)

## Root cause

The two clients shared an overlapping id space and neither could tell its own responses from a sibling's, so the "unmatched ⇒ bug" assumption was wrong on a shared wire with two demuxers.

## Fix

- Give the clients **disjoint** request-id namespaces: `vfs-r-` (reader) and `vfs-w-` (writer) — deliberately chosen so neither is a prefix of the other.
- In each `handleResult`, only log a drop when the unmatched id is in **that client's own** namespace (a genuine duplicate/late host reply). A sibling's response is now ignored silently.

No behavior change beyond logging: the owning client still resolves/rejects exactly as before.

## Tests

Adds a regression block (`writable-vfs-client.test.ts`) that wires a reader + writer onto one shared transport and asserts that a read issued by one client does **not** produce a drop log on the other — covering both directions.

## Verification

- `vitest run` on both kernel client suites — 35 pass
- `npm run typecheck` — all targets clean
- `biome` / `prettier` — clean

Found while debugging a tray-leader log flood; this is the standalone-only spam half. (The other half of that investigation — a duplicate-tab CDP eviction war from Chrome session-restore after an unclean `Ctrl-C` — is a separate branch/PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)