### PR TITLE
fix(node-server): prevent duplicate-tab CDP eviction war on dev restart

### DIFF
--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
-import { cp, mkdir, readFile, rm, unlink, writeFile } from 'fs/promises';
+import { cp, mkdir, readFile, readlink, rm, unlink, writeFile } from 'fs/promises';
 import { request as httpRequest } from 'http';
 import { homedir, platform as osPlatform, tmpdir } from 'os';
 import { dirname, join } from 'path';
@@ -739,6 +739,118 @@ export async function clearChromeRestoreState(userDataDir: string): Promise<void
     await writeJsonFile(prefsPath, prefs);
   } catch {
     // Best-effort — a write failure just leaves the prior restore behavior.
+  }
+}
+
+/**
+ * Remove Chrome's session-restore snapshot so a relaunch opens ONLY the
+ * command-line tab instead of also reopening the previous window's tabs.
+ *
+ * The dev launcher passes the UI URL on the command line, but Chrome ALSO
+ * restores `Default/Sessions/` (+ the legacy `Current/Last Session/Tabs`) from
+ * the prior run — so every `npm run dev` was adding a tab. `exit_type` only
+ * governs the *crash* bubble, not this; the fix is to drop the snapshot. Run
+ * before every spawn (like {@link clearStaleDevToolsActivePort}). Cookies /
+ * localStorage / IndexedDB live elsewhere and are untouched. Best-effort.
+ */
+export async function clearChromeSessionRestore(userDataDir: string): Promise<void> {
+  const defaultDir = join(userDataDir, 'Default');
+  try {
+    await rm(join(defaultDir, 'Sessions'), { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+  for (const name of ['Current Session', 'Current Tabs', 'Last Session', 'Last Tabs']) {
+    try {
+      await unlink(join(defaultDir, name));
+    } catch {
+      // ignore (missing)
+    }
+  }
+}
+
+/** Injectable seams for {@link terminateExistingProfileChrome} (tests). */
+export interface ProfileChromeTerminationDeps {
+  readlinkImpl?: (path: string) => Promise<string>;
+  isAlive?: (pid: number) => boolean;
+  kill?: (pid: number, signal: NodeJS.Signals) => void;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Terminate a Chrome instance still holding this `user-data-dir`, then clear
+ * the stale Singleton lock files, so a fresh launch isn't refused.
+ *
+ * Chrome is single-instance per profile: a second `open -n` against a locked
+ * profile either exits non-zero ("Chrome exited … before reporting CDP port")
+ * or silently adds a tab to the running instance. On macOS the launcher starts
+ * Chrome via LaunchServices, so it isn't our child and Ctrl-C never reaps it —
+ * a leftover Chrome lingers across `npm run dev` runs. Chrome records the
+ * owning PID in the `SingletonLock` symlink (`<host>-<pid>`); if that process
+ * is alive we stop it (SIGTERM, then SIGKILL), then unlink the Singleton lock
+ * files. Best-effort and idempotent; a missing lock is a no-op.
+ */
+export async function terminateExistingProfileChrome(
+  userDataDir: string,
+  deps: ProfileChromeTerminationDeps = {}
+): Promise<void> {
+  const readlinkImpl = deps.readlinkImpl ?? readlink;
+  const isAlive = deps.isAlive ?? defaultPidIsAlive;
+  const kill = deps.kill ?? ((pid, signal) => process.kill(pid, signal));
+  const sleep = deps.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  let pid: number | null = null;
+  try {
+    pid = parseSingletonLockPid(await readlinkImpl(join(userDataDir, 'SingletonLock')));
+  } catch {
+    pid = null; // no SingletonLock — nothing holding the profile
+  }
+
+  if (pid !== null && isAlive(pid)) {
+    try {
+      kill(pid, 'SIGTERM');
+    } catch {
+      // already gone between the alive-check and the signal
+    }
+    for (let i = 0; i < 30 && isAlive(pid); i++) {
+      await sleep(100);
+    }
+    if (isAlive(pid)) {
+      try {
+        kill(pid, 'SIGKILL');
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  for (const name of ['SingletonLock', 'SingletonSocket', 'SingletonCookie']) {
+    try {
+      await unlink(join(userDataDir, name));
+    } catch {
+      // ignore (missing)
+    }
+  }
+}
+
+/**
+ * `SingletonLock` is a symlink to `<hostname>-<pid>`. The hostname can contain
+ * dashes, so the PID is the segment after the LAST dash.
+ */
+function parseSingletonLockPid(target: string): number | null {
+  const dash = target.lastIndexOf('-');
+  if (dash < 0) return null;
+  const pid = Number.parseInt(target.slice(dash + 1), 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function defaultPidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // ESRCH = no such process; EPERM = exists but not signalable by us.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
   }
 }
 

--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -690,6 +690,58 @@ export async function clearStaleDevToolsActivePort(userDataDir: string): Promise
   }
 }
 
+/**
+ * Clear Chrome's "did not exit cleanly" flags so the next launch does NOT
+ * restore the previous session's tabs (or pop the crash-restore bubble).
+ *
+ * `npm run dev` is almost always stopped with Ctrl-C, which terminates the
+ * launched Chrome without a graceful shutdown. Chrome then records
+ * `profile.exit_type: "Crashed"` in `Default/Preferences` and, on the next
+ * launch against the same persistent profile, reopens the prior session's
+ * tabs. With the standalone single-client CDP proxy that is actively
+ * harmful: a *restored* duplicate webapp tab and the freshly-launched tab
+ * both dial `ws://<host>/cdp`, and because the proxy keeps only one client
+ * they evict each other in an endless ~5s reconnect war (each evicted page
+ * re-dials on the next leader-target refresh).
+ *
+ * Rewriting `exit_type` to `"Normal"` (and `exited_cleanly` to `true`) — the
+ * same trick ChromeDriver uses — before spawn makes Chrome believe the last
+ * session ended cleanly, so it starts fresh with a single tab.
+ *
+ * Best-effort and idempotent: a missing Preferences file (first run) is left
+ * absent — there is nothing to restore — and an unparseable one is left as-is
+ * for Chrome to regenerate. Never throws; a failure here must not block a
+ * launch.
+ */
+export async function clearChromeRestoreState(userDataDir: string): Promise<void> {
+  const prefsPath = join(userDataDir, 'Default', 'Preferences');
+  let raw: string;
+  try {
+    raw = await readFile(prefsPath, 'utf8');
+  } catch {
+    return; // no Preferences yet (first run) — nothing to restore
+  }
+  let prefs: JsonObject;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isJsonObject(parsed)) return;
+    prefs = parsed;
+  } catch {
+    return; // corrupt file — leave it for Chrome to regenerate
+  }
+  const profile = ensureObject(prefs, 'profile');
+  if (profile['exit_type'] === 'Normal' && profile['exited_cleanly'] === true) {
+    return; // already clean — avoid a needless rewrite
+  }
+  profile['exit_type'] = 'Normal';
+  profile['exited_cleanly'] = true;
+  try {
+    await writeJsonFile(prefsPath, prefs);
+  } catch {
+    // Best-effort — a write failure just leaves the prior restore behavior.
+  }
+}
+
 export interface ProbeCdpAliveOptions {
   /** Per-probe HTTP timeout in milliseconds. Default 500 ms. */
   timeoutMs?: number;

--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -747,11 +747,15 @@ export async function clearChromeRestoreState(userDataDir: string): Promise<void
  * command-line tab instead of also reopening the previous window's tabs.
  *
  * The dev launcher passes the UI URL on the command line, but Chrome ALSO
- * restores `Default/Sessions/` (+ the legacy `Current/Last Session/Tabs`) from
- * the prior run — so every `npm run dev` was adding a tab. `exit_type` only
- * governs the *crash* bubble, not this; the fix is to drop the snapshot. Run
- * before every spawn (like {@link clearStaleDevToolsActivePort}). Cookies /
- * localStorage / IndexedDB live elsewhere and are untouched. Best-effort.
+ * restores `Default/Sessions/` from the prior run — so every `npm run dev` was
+ * adding a tab. `exit_type` only governs the *crash* bubble, not this; the fix
+ * is to drop the snapshot. Run before every spawn (like
+ * {@link clearStaleDevToolsActivePort}). Cookies / localStorage / IndexedDB
+ * live elsewhere and are untouched. Best-effort.
+ *
+ * Modern Chrome keeps the whole snapshot under `Default/Sessions/`; `Last
+ * Session` / `Last Tabs` are belt-and-suspenders for older Chromium builds that
+ * still wrote those two as top-level files under `Default/`.
  */
 export async function clearChromeSessionRestore(userDataDir: string): Promise<void> {
   const defaultDir = join(userDataDir, 'Default');
@@ -760,7 +764,7 @@ export async function clearChromeSessionRestore(userDataDir: string): Promise<vo
   } catch {
     // ignore
   }
-  for (const name of ['Current Session', 'Current Tabs', 'Last Session', 'Last Tabs']) {
+  for (const name of ['Last Session', 'Last Tabs']) {
     try {
       await unlink(join(defaultDir, name));
     } catch {

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -24,6 +24,7 @@ import { applyCdpUnmask } from './cdp-proxy/cdp-unmask.js';
 import { createCdpSessionUrlTracker } from './cdp-proxy/session-url-tracker.js';
 import {
   buildChromeLaunchArgs,
+  clearChromeRestoreState,
   clearStaleDevToolsActivePort,
   ensureQaProfileScaffold,
   findChromeExecutable,
@@ -726,6 +727,13 @@ async function launchChromeTarget(state: ServerState): Promise<void> {
   // wrong port. Clear it before spawn.
   await clearStaleDevToolsActivePort(chromeProfile.userDataDir);
 
+  // Ctrl-C kills Chrome uncleanly, so the persistent profile keeps
+  // `exit_type: "Crashed"` and the next launch would restore the prior
+  // session's tabs. A restored duplicate webapp tab fights the fresh tab over
+  // the single-client CDP proxy slot (endless ~5s reconnect war). Reset the
+  // crash flags before spawn so Chrome starts with a single tab.
+  await clearChromeRestoreState(chromeProfile.userDataDir);
+
   // On macOS, route through `/usr/bin/open` so LaunchServices owns the new Chrome
   // process — otherwise the launching terminal stays in Chrome's TCC responsibility
   // chain and silently breaks getUserMedia() camera/mic grants.
@@ -1013,6 +1021,15 @@ async function waitForServerCdpPort(state: ServerState, timeoutMs = 30_000): Pro
   return state.cdpPort;
 }
 
+/**
+ * WebSocket close code sent to a CDP client that is evicted because a newer
+ * client took the single proxy slot. The page-side `CDPClient` recognises it
+ * and stops auto-reconnecting (otherwise two webapp tabs on one instance evict
+ * each other forever). Application-range code; MUST stay in sync with
+ * `CDP_SUPERSEDED_CLOSE_CODE` in `packages/webapp/src/cdp/cdp-client.ts`.
+ */
+const CDP_SUPERSEDED_CLOSE_CODE = 4001;
+
 async function handleCdpClient(
   state: ServerState,
   clientWs: WebSocket,
@@ -1020,10 +1037,12 @@ async function handleCdpClient(
   cdpPort?: number
 ): Promise<void> {
   try {
-    // Only one client active at a time — close the previous one.
+    // Only one client active at a time — close the previous one. Use the
+    // "superseded" close code so the evicted page knows it lost the slot to a
+    // sibling tab and must not re-dial (see CDP_SUPERSEDED_CLOSE_CODE).
     if (state.activeClientWs && state.activeClientWs.readyState === WebSocket.OPEN) {
-      console.log('[cdp-proxy] Closing previous client connection');
-      state.activeClientWs.close();
+      console.log('[cdp-proxy] Closing previous client connection (superseded by new client)');
+      state.activeClientWs.close(CDP_SUPERSEDED_CLOSE_CODE, 'superseded-by-new-cdp-client');
     }
     state.activeClientWs = clientWs;
     console.log('[cdp-proxy] New client connected');

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -25,6 +25,7 @@ import { createCdpSessionUrlTracker } from './cdp-proxy/session-url-tracker.js';
 import {
   buildChromeLaunchArgs,
   clearChromeRestoreState,
+  clearChromeSessionRestore,
   clearStaleDevToolsActivePort,
   ensureQaProfileScaffold,
   findChromeExecutable,
@@ -32,6 +33,7 @@ import {
   migrateLegacyDefaultChromeProfile,
   planChromeSpawn,
   resolveChromeLaunchProfile,
+  terminateExistingProfileChrome,
   waitForCdpPort,
 } from './chrome-launch.js';
 import { CliLogDedup } from './cli-log-dedup.js';
@@ -727,11 +729,20 @@ async function launchChromeTarget(state: ServerState): Promise<void> {
   // wrong port. Clear it before spawn.
   await clearStaleDevToolsActivePort(chromeProfile.userDataDir);
 
-  // Ctrl-C kills Chrome uncleanly, so the persistent profile keeps
-  // `exit_type: "Crashed"` and the next launch would restore the prior
-  // session's tabs. A restored duplicate webapp tab fights the fresh tab over
-  // the single-client CDP proxy slot (endless ~5s reconnect war). Reset the
-  // crash flags before spawn so Chrome starts with a single tab.
+  // A Chrome from a prior run can still hold this profile: Ctrl-C doesn't reap
+  // the LaunchServices-owned process, so the profile stays locked and a second
+  // `open -n` either exits non-zero ("before reporting CDP port") or just adds
+  // a tab to the lingering instance. Terminate it first so this launch is clean.
+  await terminateExistingProfileChrome(chromeProfile.userDataDir);
+
+  // Drop the session-restore snapshot so Chrome opens ONLY the command-line
+  // tab. Otherwise it reopens the previous window's tabs too — a duplicate
+  // webapp tab that fights the fresh one over the single-client CDP proxy slot.
+  await clearChromeSessionRestore(chromeProfile.userDataDir);
+
+  // Belt-and-suspenders for genuine crashes: reset the `exit_type: "Crashed"`
+  // flag so Chrome doesn't show the crash-restore bubble. (The tab-restore
+  // itself is handled by clearChromeSessionRestore above, not this.)
   await clearChromeRestoreState(chromeProfile.userDataDir);
 
   // On macOS, route through `/usr/bin/open` so LaunchServices owns the new Chrome

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   buildChromeLaunchArgs,
+  clearChromeRestoreState,
   clearStaleDevToolsActivePort,
   DEFAULT_CDP_LAUNCH_TIMEOUT_MS,
   ensureQaProfileScaffold,
@@ -827,6 +828,58 @@ describe('clearStaleDevToolsActivePort', () => {
       `slicc-clear-active-port-missing-${Date.now()}-${Math.random()}`
     );
     await expect(clearStaleDevToolsActivePort(missing)).resolves.toBeUndefined();
+  });
+});
+
+describe('clearChromeRestoreState', () => {
+  it('rewrites a crashed exit_type to Normal so Chrome does not restore tabs', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-clear-restore-'));
+    tempDirs.push(dir);
+    const prefsPath = join(dir, 'Default', 'Preferences');
+    await mkdir(join(dir, 'Default'), { recursive: true });
+    await writeFile(
+      prefsPath,
+      JSON.stringify({
+        profile: { exit_type: 'Crashed', exited_cleanly: false, name: 'keep-me' },
+        session: { restore_on_startup: 1 },
+      })
+    );
+
+    await clearChromeRestoreState(dir);
+
+    const after = JSON.parse(await readFile(prefsPath, 'utf8')) as {
+      profile: { exit_type: string; exited_cleanly: boolean; name: string };
+      session: { restore_on_startup: number };
+    };
+    expect(after.profile.exit_type).toBe('Normal');
+    expect(after.profile.exited_cleanly).toBe(true);
+    // Unrelated keys are preserved — we only touch the crash flags.
+    expect(after.profile.name).toBe('keep-me');
+    expect(after.session.restore_on_startup).toBe(1);
+  });
+
+  it('is a no-op when no Preferences file exists (first run)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-clear-restore-'));
+    tempDirs.push(dir);
+    await expect(clearChromeRestoreState(dir)).resolves.toBeUndefined();
+    // Must not fabricate a Preferences file when there was nothing to restore.
+    expect(fsExistsSync(join(dir, 'Default', 'Preferences'))).toBe(false);
+  });
+
+  it('leaves a corrupt Preferences file untouched for Chrome to regenerate', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-clear-restore-'));
+    tempDirs.push(dir);
+    const prefsPath = join(dir, 'Default', 'Preferences');
+    await mkdir(join(dir, 'Default'), { recursive: true });
+    await writeFile(prefsPath, 'not valid json {');
+
+    await expect(clearChromeRestoreState(dir)).resolves.toBeUndefined();
+    expect(await readFile(prefsPath, 'utf8')).toBe('not valid json {');
+  });
+
+  it('does not throw when the directory itself is missing', async () => {
+    const missing = join(tmpdir(), `slicc-clear-restore-missing-${Date.now()}-${Math.random()}`);
+    await expect(clearChromeRestoreState(missing)).resolves.toBeUndefined();
   });
 });
 

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -1,5 +1,5 @@
 import { type existsSync, existsSync as fsExistsSync, type readdirSync } from 'fs';
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildChromeLaunchArgs,
   clearChromeRestoreState,
+  clearChromeSessionRestore,
   clearStaleDevToolsActivePort,
   DEFAULT_CDP_LAUNCH_TIMEOUT_MS,
   ensureQaProfileScaffold,
@@ -20,6 +21,7 @@ import {
   resolveChromeAppBundle,
   resolveChromeLaunchProfile,
   resolveProfilesDir,
+  terminateExistingProfileChrome,
   waitForCdpPort,
   waitForCdpPortFromActivePortFile,
   waitForCdpPortFromStderr,
@@ -880,6 +882,102 @@ describe('clearChromeRestoreState', () => {
   it('does not throw when the directory itself is missing', async () => {
     const missing = join(tmpdir(), `slicc-clear-restore-missing-${Date.now()}-${Math.random()}`);
     await expect(clearChromeRestoreState(missing)).resolves.toBeUndefined();
+  });
+});
+
+describe('clearChromeSessionRestore', () => {
+  it('removes the session-restore files so Chrome does not reopen prior tabs', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-clear-sessions-'));
+    tempDirs.push(dir);
+    const sessionsDir = join(dir, 'Default', 'Sessions');
+    await mkdir(sessionsDir, { recursive: true });
+    await writeFile(join(sessionsDir, 'Session_123'), 'x');
+    await writeFile(join(sessionsDir, 'Tabs_123'), 'x');
+    await writeFile(join(dir, 'Default', 'Last Session'), 'x');
+    await writeFile(join(dir, 'Default', 'Last Tabs'), 'x');
+    // Cookies / localStorage / IndexedDB live elsewhere and must survive.
+    await writeFile(join(dir, 'Default', 'Preferences'), '{}');
+
+    await clearChromeSessionRestore(dir);
+
+    expect(fsExistsSync(sessionsDir)).toBe(false);
+    expect(fsExistsSync(join(dir, 'Default', 'Last Session'))).toBe(false);
+    expect(fsExistsSync(join(dir, 'Default', 'Last Tabs'))).toBe(false);
+    expect(fsExistsSync(join(dir, 'Default', 'Preferences'))).toBe(true);
+  });
+
+  it('is a no-op when the profile has no session files (first run)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-clear-sessions-'));
+    tempDirs.push(dir);
+    await expect(clearChromeSessionRestore(dir)).resolves.toBeUndefined();
+  });
+});
+
+describe('terminateExistingProfileChrome', () => {
+  it('kills a live Chrome holding the profile and clears the Singleton lock files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-singleton-'));
+    tempDirs.push(dir);
+    // Chrome records the owning PID in SingletonLock -> `<host>-<pid>`.
+    await symlink('silver-air-4242', join(dir, 'SingletonLock'));
+    await writeFile(join(dir, 'SingletonCookie'), '');
+    let alive = true;
+    const killed: Array<[number, string]> = [];
+    await terminateExistingProfileChrome(dir, {
+      isAlive: () => alive,
+      kill: (pid, sig) => {
+        killed.push([pid, sig]);
+        if (sig === 'SIGTERM') alive = false;
+      },
+      sleep: async () => {},
+    });
+    expect(killed).toContainEqual([4242, 'SIGTERM']);
+    expect(killed).not.toContainEqual([4242, 'SIGKILL']);
+    expect(fsExistsSync(join(dir, 'SingletonLock'))).toBe(false);
+    expect(fsExistsSync(join(dir, 'SingletonCookie'))).toBe(false);
+  });
+
+  it('escalates to SIGKILL when SIGTERM does not stop it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-singleton-'));
+    tempDirs.push(dir);
+    await symlink('host-99', join(dir, 'SingletonLock'));
+    const signals: string[] = [];
+    await terminateExistingProfileChrome(dir, {
+      isAlive: () => true, // never dies
+      kill: (_pid, sig) => signals.push(sig),
+      sleep: async () => {},
+    });
+    expect(signals).toContain('SIGTERM');
+    expect(signals).toContain('SIGKILL');
+  });
+
+  it('does not kill a stale lock (dead PID) but still removes it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-singleton-'));
+    tempDirs.push(dir);
+    await symlink('host-123', join(dir, 'SingletonLock'));
+    let killCalls = 0;
+    await terminateExistingProfileChrome(dir, {
+      isAlive: () => false,
+      kill: () => {
+        killCalls += 1;
+      },
+      sleep: async () => {},
+    });
+    expect(killCalls).toBe(0);
+    expect(fsExistsSync(join(dir, 'SingletonLock'))).toBe(false);
+  });
+
+  it('is a no-op when there is no SingletonLock', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-singleton-'));
+    tempDirs.push(dir);
+    let killCalls = 0;
+    await terminateExistingProfileChrome(dir, {
+      isAlive: () => true,
+      kill: () => {
+        killCalls += 1;
+      },
+      sleep: async () => {},
+    });
+    expect(killCalls).toBe(0);
   });
 });
 

--- a/packages/webapp/src/cdp/browser-api.ts
+++ b/packages/webapp/src/cdp/browser-api.ts
@@ -66,6 +66,14 @@ export class BrowserAPI {
    * try to hit `wss://<hosted-leader-host>/cdp`, which doesn't exist.
    */
   private _lastConnectOptions: Partial<CDPConnectOptions> | null = null;
+  /**
+   * Fired once when the local CDP client is superseded by a newer client
+   * (another SLICC tab/window on the same standalone instance). Boot wires
+   * this to a user-facing banner. Standalone-only — extension `DebuggerClient`
+   * has no `/cdp` proxy, so it never supersedes.
+   */
+  private supersededHandler: (() => void) | null = null;
+  private supersededNotified = false;
   private readonly handleJavaScriptDialogOpening = async (
     params: Record<string, unknown>
   ): Promise<void> => {
@@ -208,6 +216,29 @@ export class BrowserAPI {
       timeout: options?.timeout,
       ...(options?.protocols !== undefined ? { protocols: options.protocols } : {}),
     });
+    // A successful (re)connect re-arms the supersede notification so a later
+    // eviction can surface again.
+    this.supersededNotified = false;
+  }
+
+  /**
+   * Register a callback fired (once per episode) when the local CDP slot is
+   * taken over by a newer client — see {@link CDP_SUPERSEDED_CLOSE_CODE}.
+   * Pass `null` to clear. Boot uses this to show a banner instead of letting
+   * two tabs evict each other over the single proxy slot in silence.
+   */
+  setCdpSupersededHandler(handler: (() => void) | null): void {
+    this.supersededHandler = handler;
+  }
+
+  private notifySuperseded(): void {
+    if (this.supersededNotified) return;
+    this.supersededNotified = true;
+    try {
+      this.supersededHandler?.();
+    } catch {
+      // A banner failure must not break the agent's CDP path.
+    }
   }
 
   /**
@@ -1171,6 +1202,13 @@ export class BrowserAPI {
    * If the current client is a disconnected remote transport, restores the local transport.
    */
   private async ensureLocalConnected(): Promise<void> {
+    // A superseded local client lost the single CDP proxy slot to a newer
+    // tab/window — re-dialing would evict that newcomer and restart the war.
+    // Surface it and leave the client disconnected.
+    if (this.localClient.superseded === true) {
+      this.notifySuperseded();
+      return;
+    }
     if (this.localClient.state === 'disconnected') {
       const opts = this._lastConnectOptions;
       await this.localClient.connect({
@@ -1182,6 +1220,11 @@ export class BrowserAPI {
   }
 
   private async ensureConnected(): Promise<void> {
+    // See ensureLocalConnected: don't re-dial a slot we were evicted from.
+    if (this.client.superseded === true) {
+      this.notifySuperseded();
+      return;
+    }
     if (this.client.state === 'disconnected') {
       // If we were using a remote transport that got disconnected (follower went away),
       // restore the local transport and clear stale remote state.

--- a/packages/webapp/src/cdp/cdp-client.ts
+++ b/packages/webapp/src/cdp/cdp-client.ts
@@ -21,9 +21,19 @@ import type {
 
 const log = createLogger('cdp');
 
+/**
+ * WebSocket close code the standalone CDP proxy uses when it evicts this
+ * client because a newer client (another SLICC tab/window on the same
+ * instance) took the single proxy slot. Application-range (4000-4999) code;
+ * MUST stay in sync with `CDP_SUPERSEDED_CLOSE_CODE` in
+ * `packages/node-server/src/index.ts`.
+ */
+export const CDP_SUPERSEDED_CLOSE_CODE = 4001;
+
 export class CDPClient implements CDPTransport {
   private ws: WebSocket | null = null;
   private nextId = 1;
+  private _superseded = false;
   private pending = new Map<
     number,
     {
@@ -36,6 +46,18 @@ export class CDPClient implements CDPTransport {
 
   get state(): ConnectionState {
     return this._state;
+  }
+
+  /**
+   * True when the last close was the proxy evicting us in favour of a newer
+   * client (close code {@link CDP_SUPERSEDED_CLOSE_CODE}). Higher layers
+   * (`BrowserAPI.ensureConnected`) read this to STOP auto-reconnecting —
+   * otherwise two webapp tabs on one standalone instance would evict each
+   * other over the single CDP proxy slot forever. Cleared on the next
+   * successful `connect()` (e.g. a tab reload) and on explicit `disconnect()`.
+   */
+  get superseded(): boolean {
+    return this._superseded;
   }
 
   /**
@@ -70,6 +92,7 @@ export class CDPClient implements CDPTransport {
       this.ws.onopen = () => {
         clearTimeout(timer);
         this._state = 'connected';
+        this._superseded = false; // a fresh connection clears any prior eviction latch
         log.info('Connected', { url });
         resolve();
       };
@@ -87,8 +110,8 @@ export class CDPClient implements CDPTransport {
         this.handleMessage(ev.data as string);
       };
 
-      this.ws.onclose = () => {
-        this.handleClose();
+      this.ws.onclose = (ev) => {
+        this.handleClose((ev as { code?: number } | undefined)?.code);
       };
     });
   }
@@ -101,6 +124,7 @@ export class CDPClient implements CDPTransport {
       this.ws.onclose = null; // prevent handleClose from firing
       this.ws.close();
     }
+    this._superseded = false; // an explicit teardown is not a supersede
     this.cleanup();
     log.info('Disconnected');
   }
@@ -242,7 +266,14 @@ export class CDPClient implements CDPTransport {
     }
   }
 
-  private handleClose(): void {
+  private handleClose(code?: number): void {
+    if (code === CDP_SUPERSEDED_CLOSE_CODE) {
+      // The proxy gave our single CDP slot to a newer client — another SLICC
+      // tab/window on this instance. Latch it so the reconnect supervisor
+      // stops re-dialing (which would evict the newcomer and restart the war).
+      this._superseded = true;
+      log.warn('CDP slot superseded by another SLICC tab/window on this instance', { code });
+    }
     log.error('Connection closed unexpectedly', { pendingCommands: this.pending.size });
     // Reject all pending commands
     for (const [, p] of this.pending) {

--- a/packages/webapp/src/cdp/cdp-client.ts
+++ b/packages/webapp/src/cdp/cdp-client.ts
@@ -267,17 +267,24 @@ export class CDPClient implements CDPTransport {
   }
 
   private handleClose(code?: number): void {
-    if (code === CDP_SUPERSEDED_CLOSE_CODE) {
+    const superseded = code === CDP_SUPERSEDED_CLOSE_CODE;
+    if (superseded) {
       // The proxy gave our single CDP slot to a newer client — another SLICC
       // tab/window on this instance. Latch it so the reconnect supervisor
       // stops re-dialing (which would evict the newcomer and restart the war).
       this._superseded = true;
       log.warn('CDP slot superseded by another SLICC tab/window on this instance', { code });
+    } else {
+      log.error('Connection closed unexpectedly', { pendingCommands: this.pending.size });
     }
-    log.error('Connection closed unexpectedly', { pendingCommands: this.pending.size });
-    // Reject all pending commands
+    // Reject all pending commands with a reason that distinguishes a supersede
+    // ("another SLICC tab took our slot") from Chrome going away, so callers
+    // and logs can tell the two apart.
+    const reason = superseded
+      ? 'CDP connection superseded by another SLICC tab/window on this instance'
+      : 'CDP connection closed';
     for (const [, p] of this.pending) {
-      p.reject(new Error('CDP connection closed'));
+      p.reject(new Error(reason));
     }
     this.cleanup();
   }

--- a/packages/webapp/src/cdp/transport.ts
+++ b/packages/webapp/src/cdp/transport.ts
@@ -33,4 +33,13 @@ export interface CDPTransport {
 
   /** Current connection state. */
   readonly state: ConnectionState;
+
+  /**
+   * True when this transport's last close was the standalone CDP proxy
+   * evicting it because a newer client took the single proxy slot (see
+   * `CDP_SUPERSEDED_CLOSE_CODE`). Only `CDPClient` (the WebSocket transport)
+   * tracks this; other transports leave it `undefined`. `BrowserAPI` reads it
+   * to stop auto-reconnecting an evicted local client.
+   */
+  readonly superseded?: boolean;
 }

--- a/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
@@ -25,6 +25,7 @@ import {
   resolveTrayRuntimeConfig,
 } from '../../scoops/tray-runtime-config.js';
 import { setBridgeToken, setLocalApiBaseUrl } from '../../shell/proxied-fetch.js';
+import { showCdpSupersededBanner } from '../cdp-superseded-banner.js';
 import type { UiRuntimeMode } from '../runtime-mode.js';
 import { shouldUseRuntimeModeTrayDefaults } from '../runtime-mode.js';
 import { parseBridgeLaunchParams } from './bridge-launch-params.js';
@@ -193,6 +194,12 @@ export async function setupStandalonePrelude(
     // Retry with capped backoff so we recover from the boot race without
     // hanging boot if the bridge truly never comes up.
     await connectWithBoundedRetry(browser, connectOpts, log);
+    // If another SLICC tab/window later seizes the single CDP proxy slot, the
+    // reconnect guard stops this tab from re-dialing (which would restart the
+    // eviction war). Surface that to the user with a banner rather than letting
+    // browser automation fail silently here. Standalone-only — the page realm
+    // owns the real `/cdp` client; cherry/extension floats never supersede.
+    browser.setCdpSupersededHandler(() => showCdpSupersededBanner(win.document));
   }
   const realCdpTransport = browser.getTransport();
 

--- a/packages/webapp/src/ui/cdp-superseded-banner.ts
+++ b/packages/webapp/src/ui/cdp-superseded-banner.ts
@@ -1,0 +1,45 @@
+/**
+ * `cdp-superseded-banner.ts` — page-realm banner shown when this standalone
+ * tab loses the single CDP proxy slot to another SLICC tab/window on the same
+ * instance (close code `CDP_SUPERSEDED_CLOSE_CODE`). Without the reconnect
+ * guard the two tabs evict each other over `ws://<host>/cdp` forever; with it,
+ * the losing tab goes quiet — so this banner tells the user why browser
+ * automation stopped working here and how to recover.
+ *
+ * Standalone-only: the extension float drives CDP via `chrome.debugger`, which
+ * has no proxy and never supersedes.
+ */
+
+const BANNER_ID = 'slicc-cdp-superseded-banner';
+
+/**
+ * Inject the "another tab took control" banner. Idempotent — a second call is
+ * a no-op while the banner is already present. Pure DOM; the document is
+ * passed in so the helper stays testable and never reaches for a global.
+ */
+export function showCdpSupersededBanner(doc: Document): void {
+  if (doc.getElementById(BANNER_ID)) return;
+  const banner = doc.createElement('div');
+  banner.id = BANNER_ID;
+  banner.setAttribute('role', 'alert');
+  banner.textContent =
+    'Another SLICC tab or window has taken control of this browser instance. ' +
+    'Only one tab can drive the browser per instance — close the other tabs, ' +
+    'then reload this page to resume.';
+  // Inline styles so the banner needs no stylesheet wiring and survives any
+  // CSS reset. Pinned to the top, above app chrome.
+  banner.style.cssText = [
+    'position:fixed',
+    'top:0',
+    'left:0',
+    'right:0',
+    'z-index:2147483647',
+    'padding:10px 16px',
+    'background:#b3261e',
+    'color:#fff',
+    'font:13px/1.4 system-ui,sans-serif',
+    'text-align:center',
+    'box-shadow:0 1px 4px rgba(0,0,0,0.3)',
+  ].join(';');
+  doc.body.appendChild(banner);
+}

--- a/packages/webapp/tests/cdp/browser-api.test.ts
+++ b/packages/webapp/tests/cdp/browser-api.test.ts
@@ -87,6 +87,37 @@ describe('BrowserAPI', () => {
     });
   });
 
+  describe('superseded gate (duplicate-tab CDP war guard)', () => {
+    it('does not reconnect a superseded local client and notifies once', async () => {
+      (mockClient as unknown as { state: string }).state = 'disconnected';
+      (mockClient as unknown as { superseded: boolean }).superseded = true;
+      const onSuperseded = vi.fn();
+      api.setCdpSupersededHandler(onSuperseded);
+
+      // Two refresh cycles (mirrors the 5s leader-target refresh loop).
+      await api.listPages();
+      await api.listPages();
+
+      // The whole point: we must NOT re-dial /cdp (that restarts the war).
+      expect(mockClient.connect).not.toHaveBeenCalled();
+      // Surfaced to the user exactly once, not once per refresh.
+      expect(onSuperseded).toHaveBeenCalledTimes(1);
+    });
+
+    it('reconnects normally when the client is not superseded', async () => {
+      (mockClient as unknown as { state: string }).state = 'disconnected';
+      (mockClient as unknown as { superseded: boolean }).superseded = false;
+      (mockClient.send as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ targetInfos: [] });
+      const onSuperseded = vi.fn();
+      api.setCdpSupersededHandler(onSuperseded);
+
+      await api.listPages();
+
+      expect(mockClient.connect).toHaveBeenCalled();
+      expect(onSuperseded).not.toHaveBeenCalled();
+    });
+  });
+
   describe('ensureConnected (lazy auto-connect)', () => {
     it('auto-connects when client is disconnected on listPages', async () => {
       // Start disconnected

--- a/packages/webapp/tests/cdp/cdp-client.test.ts
+++ b/packages/webapp/tests/cdp/cdp-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { CDPClient } from '../../src/cdp/cdp-client.js';
+import { CDP_SUPERSEDED_CLOSE_CODE, CDPClient } from '../../src/cdp/cdp-client.js';
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket
@@ -11,7 +11,7 @@ class MockWebSocket {
   static instances: MockWebSocket[] = [];
   readyState = 0; // CONNECTING
   onopen: (() => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((ev?: { code?: number }) => void) | null = null;
   onerror: ((ev: unknown) => void) | null = null;
   onmessage: WSHandler | null = null;
 
@@ -30,9 +30,9 @@ class MockWebSocket {
     this.sent.push(data);
   }
 
-  close() {
+  close(code?: number) {
     this.readyState = 3; // CLOSED
-    if (this.onclose) this.onclose();
+    if (this.onclose) this.onclose(code !== undefined ? { code } : undefined);
   }
 
   // Test helpers
@@ -49,8 +49,8 @@ class MockWebSocket {
     if (this.onerror) this.onerror(new Error('connection error'));
   }
 
-  simulateClose() {
-    if (this.onclose) this.onclose();
+  simulateClose(code?: number) {
+    if (this.onclose) this.onclose(code !== undefined ? { code } : undefined);
   }
 }
 
@@ -318,6 +318,52 @@ describe('CDPClient', () => {
 
       client.disconnect();
       expect(client.state).toBe('disconnected');
+    });
+  });
+
+  describe('superseded latch', () => {
+    async function connectOpen(): Promise<MockWebSocket> {
+      const p = client.connect({ url: 'ws://test/cdp' });
+      const ws = MockWebSocket.instances.at(-1)!;
+      ws.simulateOpen();
+      await p;
+      return ws;
+    }
+
+    it('is not superseded after a normal (no-code) close', async () => {
+      const ws = await connectOpen();
+      ws.simulateClose();
+      expect(client.superseded).toBe(false);
+    });
+
+    it('is not superseded after a non-supersede close code', async () => {
+      const ws = await connectOpen();
+      ws.simulateClose(1006); // abnormal closure, not our eviction code
+      expect(client.superseded).toBe(false);
+    });
+
+    it('latches superseded when evicted with CDP_SUPERSEDED_CLOSE_CODE', async () => {
+      const ws = await connectOpen();
+      ws.simulateClose(CDP_SUPERSEDED_CLOSE_CODE);
+      expect(client.superseded).toBe(true);
+    });
+
+    it('clears the latch on the next successful connect', async () => {
+      const ws = await connectOpen();
+      ws.simulateClose(CDP_SUPERSEDED_CLOSE_CODE);
+      expect(client.superseded).toBe(true);
+
+      await connectOpen(); // reload-style reconnect
+      expect(client.superseded).toBe(false);
+    });
+
+    it('clears the latch on an explicit disconnect()', async () => {
+      const ws = await connectOpen();
+      ws.simulateClose(CDP_SUPERSEDED_CLOSE_CODE);
+      expect(client.superseded).toBe(true);
+
+      client.disconnect();
+      expect(client.superseded).toBe(false);
     });
   });
 });

--- a/packages/webapp/tests/cdp/cdp-client.test.ts
+++ b/packages/webapp/tests/cdp/cdp-client.test.ts
@@ -348,6 +348,21 @@ describe('CDPClient', () => {
       expect(client.superseded).toBe(true);
     });
 
+    it('rejects in-flight commands with a distinguishable superseded reason', async () => {
+      const ws = await connectOpen();
+      const sendPromise = client.send('Page.enable');
+      ws.simulateClose(CDP_SUPERSEDED_CLOSE_CODE);
+      await expect(sendPromise).rejects.toThrow(/superseded/i);
+    });
+
+    it('rejects in-flight commands with the generic reason on a non-supersede close', async () => {
+      const ws = await connectOpen();
+      const sendPromise = client.send('Page.enable');
+      ws.simulateClose(1006); // abnormal closure, not our eviction code
+      await expect(sendPromise).rejects.toThrow('connection closed');
+      await expect(sendPromise).rejects.not.toThrow(/superseded/i);
+    });
+
     it('clears the latch on the next successful connect', async () => {
       const ws = await connectOpen();
       ws.simulateClose(CDP_SUPERSEDED_CLOSE_CODE);

--- a/packages/webapp/tests/ui/cdp-superseded-banner.test.ts
+++ b/packages/webapp/tests/ui/cdp-superseded-banner.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { showCdpSupersededBanner } from '../../src/ui/cdp-superseded-banner.js';
+
+describe('showCdpSupersededBanner', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('injects a single alert banner with recovery guidance', () => {
+    showCdpSupersededBanner(document);
+    const el = document.getElementById('slicc-cdp-superseded-banner');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('role')).toBe('alert');
+    expect(el?.textContent).toMatch(/taken control/i);
+    expect(el?.textContent).toMatch(/reload/i);
+  });
+
+  it('is idempotent — a second call does not add a duplicate', () => {
+    showCdpSupersededBanner(document);
+    showCdpSupersededBanner(document);
+    expect(document.querySelectorAll('#slicc-cdp-superseded-banner')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
> Draft — paired with #1093 (VFS drop-unmatched spam). Both came out of one tray-leader debugging session. Holding for local testing on an integration branch.

## Symptom

Setting up a local instance as a tray leader produced a relentless `[cdp-proxy]` reconnect flood (`Closing previous client connection` / `New client connected` / `Client disconnected` every ~5s, 9+ min nonstop) and a `host` command that never returned.

## Root cause

Chrome's `/json/list` showed **two identical SLICC tabs** open (`localhost:5710/?ws=term&tray=…`). Each runs the full webapp and dials `ws://<host>/cdp`; the node-server proxy is single-client ([keeps only `activeClientWs`](https://github.com/ai-ecoverse/slicc/blob/main/packages/node-server/src/index.ts)), so the two tabs evict each other forever — each evicted page re-dials on the next 5s leader-target refresh (`page-leader-tray` → `listPages` → `ensureConnected`). The war only goes permanent **after becoming a leader**, because that's what starts the 5s refresh.

The duplicate tab wasn't opened by `npm run dev` (which launches exactly one). Both tabs carried the user's hand-edited `?ws=term&tray=…`, proving they were **restored by Chrome** from a prior session: Ctrl-C kills Chrome uncleanly → persistent profile keeps `exit_type: "Crashed"` → next launch restores tabs. The launcher never reset that flag and passed no restore-suppression flag.

## Fixes

**1. Restore-suppression (root cause).** `clearChromeRestoreState(userDataDir)` rewrites `Default/Preferences` `profile.exit_type` → `"Normal"` (+ `exited_cleanly: true`) before spawn — the ChromeDriver trick — so Chrome starts with a single tab. Best-effort/idempotent; missing or corrupt Preferences left untouched. Sits beside the existing `clearStaleDevToolsActivePort` (same class of prior-crash cleanup).

**2. War guard (defense-in-depth).** For the genuinely-two-tabs case:
- Proxy evicts the previous client with WebSocket close code **4001** ("superseded") instead of a bare close.
- Page-side `CDPClient` latches `superseded` on a 4001 close (cleared on next connect / disconnect).
- `BrowserAPI.ensureConnected` / `ensureLocalConnected` stop re-dialing a superseded slot and fire a one-shot handler → the **newest** tab keeps CDP, the loser goes quiet.
- A banner tells the user another tab took control and to close duplicates + reload, instead of warring silently.

Constant `CDP_SUPERSEDED_CLOSE_CODE = 4001` is duplicated in the webapp CDP client and node-server with sync comments (webapp can't import node-server — same pattern as `bridge-launch-params.ts`).

## Cross-runtime parity

Standalone (CLI/Electron) only. The **extension** float drives CDP via `chrome.debugger` — no `/cdp` proxy, no eviction — so it's N/A.

## Tests

- `clearChromeRestoreState` — 4 (crash→Normal, first-run no-op, corrupt untouched, missing dir)
- `CDPClient` superseded latch — 5 (normal/non-4001 closes don't latch, 4001 latches, cleared on connect + disconnect)
- `BrowserAPI` superseded gate — 2 (no reconnect + notify-once, normal reconnect when not superseded)
- banner — 2 (injects alert with recovery text, idempotent)

Local verification: `lint`, `typecheck` (all 7 targets), the affected suites (153 pass), `build -w @slicc/webapp`. CI runs the full gate (coverage + extension build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)