### PR TITLE
fix(fs): add /dev/null virtual device to RestrictedFS

### DIFF
--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -33,6 +33,27 @@ import type { VirtualFS } from './virtual-fs.js';
 
 export type RestrictedFsWriteEnforcement = 'hard' | 'sudo-delegated';
 
+// ── Virtual device files (/dev/*) ─────────────────────────────────────
+//
+// Device files are always accessible regardless of sandbox ACLs. To add a
+// new device, add an entry to VIRTUAL_DEVICES keyed by its full path.
+
+interface VirtualDevice {
+  stat(): Stats;
+  read(options?: ReadFileOptions): FileContent;
+  readText(): string;
+  write(content: FileContent): void;
+}
+
+const VIRTUAL_DEVICES: Record<string, VirtualDevice> = {
+  '/dev/null': {
+    stat: () => ({ type: 'file', size: 0, mtime: 0, ctime: 0 }),
+    read: (options?) => ((options?.encoding ?? 'utf-8') === 'utf-8' ? '' : new Uint8Array(0)),
+    readText: () => '',
+    write: () => {},
+  },
+};
+
 export class RestrictedFS {
   private vfs: VirtualFS;
   private allowedPrefixes: string[];
@@ -222,6 +243,8 @@ export class RestrictedFS {
   // ── Read operations: return "not found" for outside paths ────────────
 
   async readFile(path: string, options?: ReadFileOptions): Promise<FileContent> {
+    const devRead = VIRTUAL_DEVICES[normalizePath(path)];
+    if (devRead) return devRead.read(options);
     if (!this.isAllowedStrict(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }
@@ -254,6 +277,8 @@ export class RestrictedFS {
   }
 
   async stat(path: string): Promise<Stats> {
+    const dev = VIRTUAL_DEVICES[normalizePath(path)];
+    if (dev) return dev.stat();
     if (!this.isAllowed(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }
@@ -327,6 +352,8 @@ export class RestrictedFS {
    * canonical path through `resolveAndCheckRead` (VAL-FS-019).
    */
   statSync(path: string): Stats | null {
+    const dev = VIRTUAL_DEVICES[normalizePath(path)];
+    if (dev) return dev.stat();
     if (!this.isAllowedStrict(path)) return null;
     // Scan ancestors AND leaf: `statSync` follows symlinks (via
     // `resolveSymlinksSync`), so a symlink anywhere in the path can
@@ -346,6 +373,8 @@ export class RestrictedFS {
    * still leak the resolved node. Scan ancestors only.
    */
   lstatSync(path: string): Stats | null {
+    const dev = VIRTUAL_DEVICES[normalizePath(path)];
+    if (dev) return dev.stat();
     if (!this.isAllowed(path)) return null;
     const scan = this.scanPathForSymlinks(path, false);
     if (scan !== false) return null;
@@ -407,6 +436,7 @@ export class RestrictedFS {
   }
 
   async exists(path: string): Promise<boolean> {
+    if (VIRTUAL_DEVICES[normalizePath(path)]) return true;
     if (!this.isAllowed(path)) return false;
     if (this.isAllowedStrict(path)) {
       try {
@@ -419,6 +449,8 @@ export class RestrictedFS {
   }
 
   async readTextFile(path: string): Promise<string> {
+    const devText = VIRTUAL_DEVICES[normalizePath(path)];
+    if (devText) return devText.readText();
     if (!this.isAllowedStrict(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }
@@ -450,6 +482,11 @@ export class RestrictedFS {
     content: FileContent,
     options?: { recursive?: boolean }
   ): Promise<void> {
+    const devWrite = VIRTUAL_DEVICES[normalizePath(path)];
+    if (devWrite) {
+      devWrite.write(content);
+      return;
+    }
     this.checkWrite(path);
     await this.checkParentRealpathEscape(path);
     // Also check if destination itself is a symlink pointing outside sandbox
@@ -548,6 +585,8 @@ export class RestrictedFS {
   }
 
   async lstat(path: string): Promise<Stats> {
+    const dev = VIRTUAL_DEVICES[normalizePath(path)];
+    if (dev) return dev.stat();
     if (!this.isAllowed(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -490,4 +490,53 @@ describe('RestrictedFS', () => {
       await expect(delegated.writeFile('/scoops/sd/escape-link', 'x')).rejects.toThrow('EACCES');
     });
   });
+
+  describe('/dev/null virtual device', () => {
+    it('stat returns a file with size 0', async () => {
+      const st = await restricted.stat('/dev/null');
+      expect(st.type).toBe('file');
+      expect(st.size).toBe(0);
+    });
+
+    it('statSync returns a file with size 0', () => {
+      const st = restricted.statSync('/dev/null');
+      expect(st).not.toBeNull();
+      expect(st!.type).toBe('file');
+      expect(st!.size).toBe(0);
+    });
+
+    it('exists returns true', async () => {
+      expect(await restricted.exists('/dev/null')).toBe(true);
+    });
+
+    it('readFile returns empty string with default encoding', async () => {
+      const content = await restricted.readFile('/dev/null');
+      expect(content).toBe('');
+    });
+
+    it('readFile returns empty Uint8Array with binary encoding', async () => {
+      const content = await restricted.readFile('/dev/null', { encoding: 'binary' });
+      expect(content).toEqual(new Uint8Array(0));
+    });
+
+    it('readTextFile returns empty string', async () => {
+      expect(await restricted.readTextFile('/dev/null')).toBe('');
+    });
+
+    it('writeFile silently discards data', async () => {
+      await expect(restricted.writeFile('/dev/null', 'anything')).resolves.toBeUndefined();
+    });
+
+    it('lstat returns a file with size 0', async () => {
+      const st = await restricted.lstat('/dev/null');
+      expect(st.type).toBe('file');
+      expect(st.size).toBe(0);
+    });
+
+    it('lstatSync returns a file with size 0', () => {
+      const st = restricted.lstatSync('/dev/null');
+      expect(st).not.toBeNull();
+      expect(st!.type).toBe('file');
+    });
+  });
 });


### PR DESCRIPTION


<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

Shell redirections like `> /dev/null 2>&1` inside workflow agent sandboxes would hang because RestrictedFS returned ENOENT for paths outside the sandbox ACL. Now /dev/null is handled as a special device: stat always succeeds, reads return empty, writes silently discard.
<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
