### PR TITLE
feat(workflow): resolve bare "opus", "sonnet", "haiku" aliases to best available model

### DIFF
--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -1461,3 +1461,56 @@ export function resolveCurrentModel(): Model<Api> {
     return getModelDynamic('anthropic', 'claude-sonnet-4-0');
   }
 }
+
+/**
+ * Resolve a shorthand keyword (e.g. "opus", "sonnet", "haiku", "gpt",
+ * "gemini") to the best available model whose id or name contains the
+ * keyword. "Best" = largest contextWindow, with numeric version segments
+ * as tiebreaker for models sharing the same window size.
+ *
+ * The match is intentionally loose (any id/name containing the keyword
+ * wins) so it works across providers without a hardcoded family list.
+ *
+ * Returns the concrete model id, or null if no model matches.
+ */
+export function resolveModelByShorthand(input: string): string | null {
+  const keyword = input.toLowerCase();
+  if (!keyword) return null;
+
+  let bestId: string | null = null;
+  let bestContextWindow = -1;
+
+  for (const account of getAccounts()) {
+    for (const model of getProviderModels(account.providerId)) {
+      const idLower = model.id.toLowerCase();
+      const nameLower = (model.name ?? '').toLowerCase();
+      if (!idLower.includes(keyword) && !nameLower.includes(keyword)) continue;
+
+      const contextWindow = model.contextWindow ?? 0;
+      if (
+        contextWindow > bestContextWindow ||
+        (contextWindow === bestContextWindow && compareVersionSegments(model.id, bestId ?? '') > 0)
+      ) {
+        bestContextWindow = contextWindow;
+        bestId = model.id;
+      }
+    }
+  }
+
+  return bestId;
+}
+
+/**
+ * Compare two model ids by their trailing numeric segments. Handles
+ * multi-digit versions correctly (e.g. "4-10" > "4-9").
+ */
+function compareVersionSegments(a: string, b: string): number {
+  const segsA = a.match(/\d+/g)?.map(Number) ?? [];
+  const segsB = b.match(/\d+/g)?.map(Number) ?? [];
+  const len = Math.max(segsA.length, segsB.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (segsA[i] ?? 0) - (segsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -33,7 +33,11 @@ import { createLogger } from '../core/logger.js';
 import type { SessionStore } from '../core/session.js';
 import type { VirtualFS } from '../fs/index.js';
 import { normalizePath } from '../fs/path-utils.js';
-import { getAccounts, getProviderModels } from '../providers/account-store.js';
+import {
+  getAccounts,
+  getProviderModels,
+  resolveModelByShorthand,
+} from '../providers/account-store.js';
 import type { Orchestrator } from './orchestrator.js';
 import {
   CURRENT_SCOOP_CONFIG_VERSION,
@@ -223,31 +227,40 @@ function resolveParentThinkingLevel(
 }
 
 /**
- * Validate model and thinking level options. Returns error result on failure.
+ * Validate and resolve model/thinking options. On success returns
+ * `{ resolvedModelId }` (the canonical model id after shorthand
+ * expansion); on failure returns `{ error }`.
  */
 function validateSpawnOptions(
   options: AgentSpawnOptions,
   resolveModel: (modelId: string) => string | null
-): AgentSpawnResult | undefined {
+): { error: AgentSpawnResult } | { resolvedModelId: string | undefined } {
   const requestedModelId = options.modelId;
+  let resolvedModelId: string | undefined;
   if (requestedModelId !== undefined) {
-    if (requestedModelId === '' || resolveModel(requestedModelId) === null) {
+    const resolved = requestedModelId === '' ? null : resolveModel(requestedModelId);
+    if (resolved === null) {
       return {
-        finalText: `agent: unknown model: ${requestedModelId}`,
-        exitCode: 1,
+        error: {
+          finalText: `agent: unknown model: ${requestedModelId}`,
+          exitCode: 1,
+        },
       };
     }
+    resolvedModelId = resolved;
   }
 
   const requestedLevel = options.thinkingLevel;
   if (requestedLevel !== undefined && !isThinkingLevel(requestedLevel)) {
     return {
-      finalText: `agent: invalid thinking level: ${String(requestedLevel)} (one of: ${THINKING_LEVELS.join(', ')})`,
-      exitCode: 1,
+      error: {
+        finalText: `agent: invalid thinking level: ${String(requestedLevel)} (one of: ${THINKING_LEVELS.join(', ')})`,
+        exitCode: 1,
+      },
     };
   }
 
-  return undefined;
+  return { resolvedModelId };
 }
 
 /**
@@ -413,12 +426,11 @@ export function createAgentBridge(
   };
 
   async function spawn(options: AgentSpawnOptions): Promise<AgentSpawnResult> {
-    const validationError = validateSpawnOptions(options, ctx.resolveModel);
-    if (validationError) return validationError;
+    const validation = validateSpawnOptions(options, ctx.resolveModel);
+    if ('error' in validation) return validation.error;
 
-    const requestedModelId = options.modelId;
     const effectiveModelId =
-      requestedModelId ?? resolveParentModelId(ctx.orchestrator, options.parentJid) ?? '';
+      validation.resolvedModelId ?? resolveParentModelId(ctx.orchestrator, options.parentJid) ?? '';
 
     const requestedLevel = options.thinkingLevel;
     const effectiveThinkingLevel =
@@ -719,6 +731,9 @@ export function defaultResolveModel(modelId: string): string | null {
     for (const account of getAccounts()) {
       if (getProviderModels(account.providerId).some((m) => m.id === modelId)) return modelId;
     }
+    // Try shorthand alias: keyword match against available model ids/names
+    const alias = resolveModelByShorthand(modelId);
+    if (alias) return alias;
     return null;
   } catch (err) {
     // getAccounts/getProviderModels normally return [] (and self-log) on a provider/parse

--- a/packages/webapp/tests/scoops/agent-bridge.test.ts
+++ b/packages/webapp/tests/scoops/agent-bridge.test.ts
@@ -22,15 +22,66 @@ import {
 // adobe list here includes claude-haiku-4-5 (which the real picker hides via
 // PICKER_HIDDEN_MODEL_PATTERNS) — the regression: a picker-hidden model must still
 // validate for an explicit sub-agent target.
+const MOCK_ACCOUNTS = [
+  { providerId: 'adobe', accessToken: 'x' },
+  { providerId: 'openai', accessToken: 'y' },
+];
+
+function mockGetProviderModels(providerId: string) {
+  if (providerId === 'adobe')
+    return [
+      { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', contextWindow: 200000 },
+      { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', contextWindow: 200000 },
+      { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', contextWindow: 1000000 },
+      { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', contextWindow: 1000000 },
+    ];
+  if (providerId === 'openai')
+    return [
+      { id: 'gpt-4o', name: 'GPT-4o', contextWindow: 128000 },
+      { id: 'gpt-5', name: 'GPT-5', contextWindow: 1000000 },
+      { id: 'o3', name: 'o3', contextWindow: 200000 },
+    ];
+  return [];
+}
+
 vi.mock('../../src/providers/account-store.js', async (importActual) => {
   const actual = await importActual<typeof import('../../src/providers/account-store.js')>();
   return {
     ...actual,
-    getAccounts: () => [{ providerId: 'adobe', accessToken: 'x' }],
-    getProviderModels: (providerId: string) =>
-      providerId === 'adobe'
-        ? [{ id: 'claude-sonnet-4-6' }, { id: 'claude-haiku-4-5' }, { id: 'claude-opus-4-8' }]
-        : [],
+    getAccounts: () => MOCK_ACCOUNTS,
+    getProviderModels: mockGetProviderModels,
+    resolveModelByShorthand: (input: string) => {
+      const keyword = input.toLowerCase();
+      if (!keyword) return null;
+      let bestId: string | null = null;
+      let bestContextWindow = -1;
+      for (const account of MOCK_ACCOUNTS) {
+        for (const model of mockGetProviderModels(account.providerId)) {
+          const idLower = model.id.toLowerCase();
+          const nameLower = (model.name ?? '').toLowerCase();
+          if (!idLower.includes(keyword) && !nameLower.includes(keyword)) continue;
+          const contextWindow = model.contextWindow ?? 0;
+          const segsA = model.id.match(/\d+/g)?.map(Number) ?? [];
+          const segsB = (bestId ?? '').match(/\d+/g)?.map(Number) ?? [];
+          let cmp = 0;
+          for (let i = 0; i < Math.max(segsA.length, segsB.length); i++) {
+            const diff = (segsA[i] ?? 0) - (segsB[i] ?? 0);
+            if (diff !== 0) {
+              cmp = diff;
+              break;
+            }
+          }
+          if (
+            contextWindow > bestContextWindow ||
+            (contextWindow === bestContextWindow && cmp > 0)
+          ) {
+            bestContextWindow = contextWindow;
+            bestId = model.id;
+          }
+        }
+      }
+      return bestId;
+    },
   };
 });
 
@@ -501,6 +552,20 @@ describe('createAgentBridge — model resolution', () => {
     expect(result.finalText).toContain('unknown model');
     expect(registerCalls).toHaveLength(0);
     expect(rmCalls).toHaveLength(0);
+  });
+
+  it('stores the resolved model id in config when a shorthand is provided', async () => {
+    const { orchestrator, registerCalls, scripts } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+      resolveModel: (id) => (id === 'opus' ? 'claude-opus-4-8' : id),
+    });
+    scripts.set('agent_jolly_mint', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({ ...BASE_OPTS, modelId: 'opus' });
+
+    expect(registerCalls[0].config?.modelId).toBe('claude-opus-4-8');
   });
 
   it('inherits modelId from parent scoop when found in the orchestrator registry', async () => {
@@ -1091,6 +1156,33 @@ describe('defaultResolveModel', () => {
   });
 
   it('rejects a model no configured provider advertises', () => {
-    expect(defaultResolveModel('gpt-does-not-exist')).toBeNull();
+    expect(defaultResolveModel('nonexistent-xyz-999')).toBeNull();
+  });
+
+  it('resolves bare "opus" to the best available opus model (lexicographic tiebreaker)', () => {
+    // Both opus-4-8 and opus-4-6 have contextWindow=1000000; lexicographic tiebreaker picks 4-8
+    expect(defaultResolveModel('opus')).toBe('claude-opus-4-8');
+  });
+
+  it('resolves bare "sonnet" to the best available sonnet model', () => {
+    expect(defaultResolveModel('sonnet')).toBe('claude-sonnet-4-6');
+  });
+
+  it('resolves bare "haiku" to the best available haiku model', () => {
+    expect(defaultResolveModel('haiku')).toBe('claude-haiku-4-5');
+  });
+
+  it('resolves "gpt" to the best GPT model by context window', () => {
+    // gpt-5 has 1000000 context, gpt-4o has 128000 → picks gpt-5
+    expect(defaultResolveModel('gpt')).toBe('gpt-5');
+  });
+
+  it('resolves shorthands case-insensitively', () => {
+    expect(defaultResolveModel('Opus')).toBe('claude-opus-4-8');
+    expect(defaultResolveModel('GPT')).toBe('gpt-5');
+  });
+
+  it('does not match unrelated keywords', () => {
+    expect(defaultResolveModel('llama')).toBeNull();
   });
 });


### PR DESCRIPTION
<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary
Workflow agent() calls and the `agent --model` shell command now accept bare family names that resolve to the highest-versioned model of that family available from any configured provider.

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why
Claude Code accepts bare model name and is able to assign the right model ID (based on what is available and local setup).

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
