### PR TITLE
fix(tray): recover a stale stored tray at boot; hide stale followers when inactive

### DIFF
--- a/packages/webapp/src/scoops/tray-leader.ts
+++ b/packages/webapp/src/scoops/tray-leader.ts
@@ -670,8 +670,36 @@ class LeaderTrayHttpError extends Error {
   }
 }
 
+/**
+ * Thrown by {@link createTrayFetch} when the node-server `/api/fetch-proxy`
+ * itself failed to reach the tray worker (a tagged proxy/transport error, not a
+ * real upstream HTTP status). Typed so `shouldRecreateTray` can recognise it
+ * and mint a fresh tray instead of leaving the leader inactive — a dead stored
+ * tray surfaces here as "Proxy fetch failed", not as a LeaderTrayHttpError.
+ */
+export class TrayProxyFetchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TrayProxyFetchError';
+  }
+}
+
 function shouldRecreateTray(error: unknown): boolean {
-  return error instanceof LeaderTrayHttpError && [403, 404, 410].includes(error.status);
+  // A stored tray session is just a cache. If reusing it fails because the tray
+  // is gone (403/404/410), the worker is failing (5xx), or the proxy transport
+  // itself failed (worker unreachable → node-server returns a tagged proxy
+  // error), discard it and mint a fresh tray rather than leaving the leader
+  // inactive. `attachWithRecovery` only reaches here with a stored session and
+  // retries with session=null (which is NOT recreate-eligible), so this can't
+  // loop. Without the 5xx / transport cases, a boot whose stored tray had
+  // expired would 502 and give up (the original "host won't lead" symptom).
+  if (error instanceof TrayProxyFetchError) return true;
+  if (error instanceof LeaderTrayHttpError) {
+    return (
+      error.status === 403 || error.status === 404 || error.status === 410 || error.status >= 500
+    );
+  }
+  return false;
 }
 
 function parseSocketMessage(data: unknown): WorkerToLeaderControlMessage | null {
@@ -716,7 +744,7 @@ export function createTrayFetch(fetchImpl: typeof fetch = fetch): typeof fetch {
     // Only treat as proxy infrastructure failure when the proxy tagged it.
     // Upstream 4xx/5xx (e.g. tray-worker auth/quotas) must flow through.
     if (isProxyError(response)) {
-      throw new Error(await readProxyErrorMessage(response));
+      throw new TrayProxyFetchError(await readProxyErrorMessage(response));
     }
     return response;
   };

--- a/packages/webapp/src/shell/supplemental-commands/host-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/host-command.ts
@@ -178,7 +178,10 @@ export function formatLeaderOutput(
     lines.push(`error: ${status.error}`);
   }
 
-  if (followers.length > 0) {
+  // Only surface followers when there's an active tray session. The followers
+  // shim persists across sessions, so without this gate a leftover entry would
+  // be shown under an `inactive` leader as if it were still connected.
+  if (status.session && followers.length > 0) {
     lines.push('followers:');
     for (const f of followers) {
       const parts = [f.runtimeId];

--- a/packages/webapp/tests/scoops/tray-leader.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader.test.ts
@@ -10,6 +10,7 @@ import {
   parseLeaderTraySession,
   setLeaderTrayRuntimeStatus,
   subscribeToLeaderTrayRuntimeStatus,
+  TrayProxyFetchError,
 } from '../../src/scoops/tray-leader.js';
 
 class MemorySessionStore implements LeaderTraySessionStore {
@@ -327,6 +328,115 @@ describe('tray-leader', () => {
     expect(store.value?.controllerUrl).toBe('https://tray.example.com/controller/fresh-token');
 
     manager.stop();
+  });
+
+  function staleStoredSession(): LeaderTraySession {
+    return {
+      workerBaseUrl: 'https://tray.example.com',
+      trayId: 'stale-tray',
+      createdAt: '2026-03-11T00:00:00.000Z',
+      controllerId: 'controller-1',
+      controllerUrl: 'https://tray.example.com/controller/stale-token',
+      joinUrl: 'https://tray.example.com/join/stale-token',
+      webhookUrl: 'https://tray.example.com/webhook/stale-token',
+      leaderKey: 'old-key',
+      leaderWebSocketUrl:
+        'wss://tray.example.com/controller/stale-token?controllerId=controller-1&leaderKey=old-key',
+      runtime: 'slicc-standalone',
+    };
+  }
+
+  function freshTrayResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        trayId: 'fresh-tray',
+        createdAt: '2026-03-11T00:01:00.000Z',
+        capabilities: {
+          join: { url: 'https://tray.example.com/join/fresh-token' },
+          controller: { url: 'https://tray.example.com/controller/fresh-token' },
+          webhook: { url: 'https://tray.example.com/webhook/fresh-token' },
+        },
+      }),
+      { status: 201, headers: { 'content-type': 'application/json' } }
+    );
+  }
+
+  function freshLeaderAttachResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        trayId: 'fresh-tray',
+        controllerId: 'controller-2',
+        role: 'leader',
+        leaderKey: 'fresh-key',
+        websocket: {
+          url: 'wss://tray.example.com/controller/fresh-token?controllerId=controller-2&leaderKey=fresh-key',
+        },
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+  }
+
+  // Drive a leader start from a STALE stored session and assert it recovers by
+  // minting a fresh tray. `fetchImpl` must fail the first call (stored attach)
+  // and then return freshTrayResponse() + freshLeaderAttachResponse().
+  async function expectRecoveryToFreshTray(
+    fetchImpl: ReturnType<typeof vi.fn<typeof fetch>>
+  ): Promise<void> {
+    const store = new MemorySessionStore();
+    store.value = staleStoredSession();
+    const socket = new FakeWebSocket();
+    let resolveSocketReady!: () => void;
+    const socketReady = new Promise<void>((resolve) => {
+      resolveSocketReady = resolve;
+    });
+    const manager = new LeaderTrayManager({
+      workerBaseUrl: 'https://tray.example.com',
+      runtime: 'slicc-standalone',
+      store,
+      fetchImpl,
+      webSocketFactory: () => {
+        resolveSocketReady();
+        return socket;
+      },
+      pingIntervalMs: 60_000,
+    });
+    const startPromise = manager.start();
+    await socketReady;
+    socket.dispatch('message', {
+      data: JSON.stringify({ type: 'leader.connected', trayId: 'fresh-tray' }),
+    });
+    const session = await startPromise;
+    expect(session.trayId).toBe('fresh-tray');
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(store.value?.controllerUrl).toBe('https://tray.example.com/controller/fresh-token');
+    manager.stop();
+  }
+
+  it('recreates the tray when reusing the stored controller fails with a proxy transport error', async () => {
+    // Boot scenario: the stored tray is gone, so the node-server proxy's
+    // upstream fetch to the worker fails and createTrayFetch throws a
+    // TrayProxyFetchError (NOT a LeaderTrayHttpError). Recovery must still mint
+    // a fresh tray instead of leaving the leader inactive.
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new TrayProxyFetchError('Proxy fetch failed: fetch failed'))
+      .mockResolvedValueOnce(freshTrayResponse())
+      .mockResolvedValueOnce(freshLeaderAttachResponse());
+    await expectRecoveryToFreshTray(fetchImpl);
+  });
+
+  it('recreates the tray when reusing the stored controller returns a 5xx', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'bad gateway' }), {
+          status: 502,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(freshTrayResponse())
+      .mockResolvedValueOnce(freshLeaderAttachResponse());
+    await expectRecoveryToFreshTray(fetchImpl);
   });
 
   it('fails leader startup when the websocket never confirms leader.connected', async () => {

--- a/packages/webapp/tests/shell/supplemental-commands/host-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/host-command.test.ts
@@ -98,6 +98,23 @@ describe('host command', () => {
     expect(result.stdout).toContain('  - follower-def456');
   });
 
+  it('does not list stale followers when there is no active session (inactive)', async () => {
+    // The followers shim persists across sessions; once the leader is inactive
+    // (no tray session), a leftover entry must not be shown as if connected.
+    const cmd = createHostCommand({
+      getStatus: () => ({ state: 'inactive', session: null, error: null }),
+      getFollowers: () => [
+        { runtimeId: 'follower-stale', connectedAt: '2026-06-22T07:00:00.000Z' },
+      ],
+    });
+
+    const result = await cmd.execute([], {} as never);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('status: inactive');
+    expect(result.stdout).not.toContain('followers:');
+    expect(result.stdout).not.toContain('follower-stale');
+  });
+
   it('mirrors connected followers to the shim so a worker-side host reads them', () => {
     // Kernel-worker thread: no live getter, only the page→worker
     // localStorage shim is available. Before the page-side writer was


### PR DESCRIPTION
> Draft — found while testing leader setup on the integration branch (alongside #1093 and #1096). These are the two papercuts behind "host won't become a leader anymore / shows a dead follower."

## Symptoms

1. After a tray expired, a fresh `npm run dev` came up **`inactive`** instead of leading — and `host leave --leader <worker>` appeared to *hang* (~60–90s) before recovering. Logs showed boot auto-lead hitting `POST …/controller/<stale-tray> ← 502 (fetch failed)` → `Leader tray start failed` → inactive; the fresh-tray recovery only fired later on the explicit leave→lead.
2. `host` listed a follower "connected 3h ago" under `status: inactive` — a stale entry from the persisted shim shown as if live.

## Root causes

1. **Stale-tray recovery was too narrow.** Reusing the stored tray session goes through the node-server fetch-proxy. When the tray is gone the worker is unreachable *at the proxy layer*, surfaced as a generic "Proxy fetch failed" `Error` — **not** a `LeaderTrayHttpError`. `shouldRecreateTray` only matched `LeaderTrayHttpError` 403/404/410, so this threw and the leader stayed inactive instead of re-minting.
2. **Followers shown without a session.** `formatLeaderOutput` listed followers whenever the shim was non-empty, ignoring `status.state`/`status.session`. The shim persists across sessions, so a leftover entry showed under an inactive tray.

## Fixes

1. Introduce a typed **`TrayProxyFetchError`** (thrown by `createTrayFetch` on a tagged proxy/transport failure) and **broaden `shouldRecreateTray`** to also recover on it **and** on 5xx. The stored session is just a cache; the recovery retry passes `session=null` (not recreate-eligible), so it can't loop. Now a boot whose stored tray expired re-mints a fresh tray automatically instead of going inactive.
2. Gate the follower list on an active **`status.session`** (consistent with the `join_url` line) so stale followers never show under `inactive`.

## Cross-runtime parity

Tray-leader + host command are shared webapp code; no float-specific branches touched. N/A for swift/ios.

## Tests

- `tray-leader`: recovers to a fresh tray when the stored controller attach fails with a proxy-transport error (the actual boot case) **and** when it returns a 5xx; existing 410 recovery still passes.
- `host-command`: does not list stale followers when there's no active session.

Local verification: `lint` (biome+prettier), `typecheck` (all 7 targets), affected suites (87 pass), `build -w @slicc/webapp`. CI runs the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)