### PR TITLE
fix(wc): start the tray leader on boot even if sprinkle discovery stalls

### DIFF
--- a/packages/webapp/src/ui/wc/wc-sprinkles.ts
+++ b/packages/webapp/src/ui/wc/wc-sprinkles.ts
@@ -407,7 +407,13 @@ export async function wireWcSprinkles(deps: WireWcSprinklesDeps): Promise<WcSpri
         });
     }
   };
-  await resync();
+  // Fire the initial discovery+restore in the BACKGROUND — never block the
+  // caller on it. It is VFS-backed and kernel-gated, so a slow or stalled walk
+  // must not strand the rest of boot: `attachWcClient` sequences the tray
+  // leader wiring AFTER this returns, and the awaited resync used to hang there
+  // forever when discovery stalled (the leader never started). Hosts re-run
+  // resync() on kernel-ready as the recovery, and resync() is idempotent.
+  void resync().catch((err) => log.warn('WC shell: initial sprinkle resync failed', err));
   return { manager, zone, resync };
 }
 

--- a/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
@@ -12,6 +12,9 @@ installWcDomStubs();
 // Registers the library elements so makeRefs gets a REAL slicc-tab-bar —
 // the tab-close regression test drives its actual event contract.
 import '@slicc/webcomponents';
+import type { VirtualFS } from '../../../src/fs/virtual-fs.js';
+import type { BootStageLogger } from '../../../src/ui/boot/types.js';
+import type { OffscreenClient } from '../../../src/ui/offscreen-client.js';
 import type { WcShellRefs } from '../../../src/ui/wc/wc-shell.js';
 import {
   enrichSprinkleIcons,
@@ -23,6 +26,7 @@ import {
   sprinkleSurfaceId,
   WcSprinkleZone,
   wireSprinkleTabClose,
+  wireWcSprinkles,
 } from '../../../src/ui/wc/wc-sprinkles.js';
 
 function makeRefs(): WcShellRefs {
@@ -51,6 +55,43 @@ function dockItem(refs: WcShellRefs, id: string): { id: string; icon: string } |
     (refs.dock as HTMLElement & { items?: Array<{ id: string; icon: string }> }).items ?? [];
   return items.find((i) => i.id === id);
 }
+
+describe('wireWcSprinkles boot resilience', () => {
+  it('resolves without waiting for the initial discovery (a hung VFS walk must not strand boot)', async () => {
+    // Discovery does `for await (... of fs.walk(root))`; a walk that never
+    // yields makes manager.refresh() — and the initial resync() — hang.
+    // wireWcSprinkles MUST still resolve so downstream boot (the tray leader,
+    // sequenced after it in attachWcClient) runs. The initial resync is
+    // best-effort and re-run on kernel-ready, so dropping the await is safe.
+    const fs = {
+      exists: async () => true, // enter scanDir so discovery reaches the walk
+      async *walk(): AsyncGenerator<string> {
+        await new Promise<void>(() => {}); // never resolves → discovery hangs
+        yield ''; // unreachable; present so this is a generator
+      },
+      readFile: async () => '',
+    } as unknown as VirtualFS;
+    const client = {
+      sendSprinkleLick: () => {},
+      getScoops: () => [],
+      stopScoop: () => {},
+    } as unknown as OffscreenClient;
+    const log = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    } as unknown as BootStageLogger;
+
+    const settled = await Promise.race([
+      wireWcSprinkles({ refs: makeRefs(), client, fs, log }).then(() => 'resolved' as const),
+      new Promise<'blocked'>((resolve) => {
+        setTimeout(() => resolve('blocked'), 1000);
+      }),
+    ]);
+    expect(settled).toBe('resolved');
+  });
+});
 
 describe('sprinkle ids', () => {
   it('round-trips names through surface ids', () => {


### PR DESCRIPTION
> Draft — found while testing leader setup on the integration branch (with #1093, #1096, #1099). This is the one that makes a fresh `npm run dev` *deterministically* lead.

## Symptom

A fresh standalone `npm run dev` comes up `status: inactive` and never starts a tray leader — even though `/api/runtime-config` returns a worker and `slicc.trayWorkerBaseUrl` is seeded in localStorage. It's non-deterministic: sometimes it leads, sometimes not.

## Root cause (confirmed with boot instrumentation)

`mountWcUiLive` → `attachWcClient` wires the tray inside a single chain:

```js
const sprinkles = await wireWcSprinkles({...});   // ← awaited
boot.onClientReady(() => sprinkles.resync());
if (standalone && instanceId) await wireWcTray({...});  // ← tray leader (startInitialRole)
```

and `wireWcSprinkles` ended with `await resync()`, where `resync()` awaits `manager.refresh()` → VFS sprinkle discovery (`for await (... of fs.walk(root))`). When that discovery **stalls** (a kernel-gated walk that doesn't resolve), `wireWcSprinkles` never returns, so `wireWcTray` → `startInitialRole` never runs and the leader never starts. Temp `[boot-diag]` logging showed the trace stop dead at `calling wireWcSprinkles` with no `wireWcSprinkles done`, across every reload.

Unlike the freezer rail and sprinkles (both re-run on `onClientReady`), the tray wiring had **no recovery** — so a single stalled discovery stranded leadership permanently.

## Fix

Fire the initial `resync()` in the **background** instead of awaiting it:

```js
void resync().catch((err) => log.warn('WC shell: initial sprinkle resync failed', err));
return { manager, zone, resync };
```

Discovery is best-effort, already re-run on kernel-ready (idempotent), and the instant dock rail is seeded *before* it — so nothing downstream needs it to have completed. `wireWcSprinkles` now returns promptly, `wireWcTray` runs, and `startInitialRole` leads deterministically from the seeded worker URL.

This is the minimal change; it matches the code's own "instant rail before the (VFS-backed, kernel-gated) discovery resolves" design note.

## Cross-runtime parity

WC live shell (standalone/extension popout) only; no float-specific branches touched. N/A for swift/ios.

## Tests

`wireWcSprinkles` now has its first unit test: with an injected `fs` whose `walk` hangs, `wireWcSprinkles` still resolves within the window (pre-fix it blocks). Drives the real `SprinkleManager` over the jsdom `makeRefs()` harness.

Local verification: `lint` (biome+prettier), `typecheck` (all 7 targets), `wc-sprinkles` suite (21 pass). CI runs the full gate.

## Follow-up (separate)

This makes the **leader** deterministic, but the underlying *why does discovery stall* (sprinkles not loading on some boots) is a distinct bug worth its own investigation — the decoupling means it can no longer take the leader down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)