### PR TITLE
fix(node-server): clean Chrome launch — clear session restore + reap a profile-locked Chrome

### DIFF
--- a/packages/node-server/src/chrome-launch.ts
+++ b/packages/node-server/src/chrome-launch.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
-import { cp, mkdir, readFile, rm, unlink, writeFile } from 'fs/promises';
+import { cp, mkdir, readFile, readlink, rm, unlink, writeFile } from 'fs/promises';
 import { request as httpRequest } from 'http';
 import { homedir, platform as osPlatform, tmpdir } from 'os';
 import { dirname, join } from 'path';
@@ -739,6 +739,118 @@ export async function clearChromeRestoreState(userDataDir: string): Promise<void
     await writeJsonFile(prefsPath, prefs);
   } catch {
     // Best-effort — a write failure just leaves the prior restore behavior.
+  }
+}
+
+/**
+ * Remove Chrome's session-restore snapshot so a relaunch opens ONLY the
+ * command-line tab instead of also reopening the previous window's tabs.
+ *
+ * The dev launcher passes the UI URL on the command line, but Chrome ALSO
+ * restores `Default/Sessions/` (+ the legacy `Current/Last Session/Tabs`) from
+ * the prior run — so every `npm run dev` was adding a tab. `exit_type` only
+ * governs the *crash* bubble, not this; the fix is to drop the snapshot. Run
+ * before every spawn (like {@link clearStaleDevToolsActivePort}). Cookies /
+ * localStorage / IndexedDB live elsewhere and are untouched. Best-effort.
+ */
+export async function clearChromeSessionRestore(userDataDir: string): Promise<void> {
+  const defaultDir = join(userDataDir, 'Default');
+  try {
+    await rm(join(defaultDir, 'Sessions'), { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+  for (const name of ['Current Session', 'Current Tabs', 'Last Session', 'Last Tabs']) {
+    try {
+      await unlink(join(defaultDir, name));
+    } catch {
+      // ignore (missing)
+    }
+  }
+}
+
+/** Injectable seams for {@link terminateExistingProfileChrome} (tests). */
+export interface ProfileChromeTerminationDeps {
+  readlinkImpl?: (path: string) => Promise<string>;
+  isAlive?: (pid: number) => boolean;
+  kill?: (pid: number, signal: NodeJS.Signals) => void;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Terminate a Chrome instance still holding this `user-data-dir`, then clear
+ * the stale Singleton lock files, so a fresh launch isn't refused.
+ *
+ * Chrome is single-instance per profile: a second `open -n` against a locked
+ * profile either exits non-zero ("Chrome exited … before reporting CDP port")
+ * or silently adds a tab to the running instance. On macOS the launcher starts
+ * Chrome via LaunchServices, so it isn't our child and Ctrl-C never reaps it —
+ * a leftover Chrome lingers across `npm run dev` runs. Chrome records the
+ * owning PID in the `SingletonLock` symlink (`<host>-<pid>`); if that process
+ * is alive we stop it (SIGTERM, then SIGKILL), then unlink the Singleton lock
+ * files. Best-effort and idempotent; a missing lock is a no-op.
+ */
+export async function terminateExistingProfileChrome(
+  userDataDir: string,
+  deps: ProfileChromeTerminationDeps = {}
+): Promise<void> {
+  const readlinkImpl = deps.readlinkImpl ?? readlink;
+  const isAlive = deps.isAlive ?? defaultPidIsAlive;
+  const kill = deps.kill ?? ((pid, signal) => process.kill(pid, signal));
+  const sleep = deps.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  let pid: number | null = null;
+  try {
+    pid = parseSingletonLockPid(await readlinkImpl(join(userDataDir, 'SingletonLock')));
+  } catch {
+    pid = null; // no SingletonLock — nothing holding the profile
+  }
+
+  if (pid !== null && isAlive(pid)) {
+    try {
+      kill(pid, 'SIGTERM');
+    } catch {
+      // already gone between the alive-check and the signal
+    }
+    for (let i = 0; i < 30 && isAlive(pid); i++) {
+      await sleep(100);
+    }
+    if (isAlive(pid)) {
+      try {
+        kill(pid, 'SIGKILL');
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  for (const name of ['SingletonLock', 'SingletonSocket', 'SingletonCookie']) {
+    try {
+      await unlink(join(userDataDir, name));
+    } catch {
+      // ignore (missing)
+    }
+  }
+}
+
+/**
+ * `SingletonLock` is a symlink to `<hostname>-<pid>`. The hostname can contain
+ * dashes, so the PID is the segment after the LAST dash.
+ */
+function parseSingletonLockPid(target: string): number | null {
+  const dash = target.lastIndexOf('-');
+  if (dash < 0) return null;
+  const pid = Number.parseInt(target.slice(dash + 1), 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function defaultPidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // ESRCH = no such process; EPERM = exists but not signalable by us.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
   }
 }
 

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -25,6 +25,7 @@ import { createCdpSessionUrlTracker } from './cdp-proxy/session-url-tracker.js';
 import {
   buildChromeLaunchArgs,
   clearChromeRestoreState,
+  clearChromeSessionRestore,
   clearStaleDevToolsActivePort,
   ensureQaProfileScaffold,
   findChromeExecutable,
@@ -32,6 +33,7 @@ import {
   migrateLegacyDefaultChromeProfile,
   planChromeSpawn,
   resolveChromeLaunchProfile,
+  terminateExistingProfileChrome,
   waitForCdpPort,
 } from './chrome-launch.js';
 import { CliLogDedup } from './cli-log-dedup.js';
@@ -727,11 +729,20 @@ async function launchChromeTarget(state: ServerState): Promise<void> {
   // wrong port. Clear it before spawn.
   await clearStaleDevToolsActivePort(chromeProfile.userDataDir);
 
-  // Ctrl-C kills Chrome uncleanly, so the persistent profile keeps
-  // `exit_type: "Crashed"` and the next launch would restore the prior
-  // session's tabs. A restored duplicate webapp tab fights the fresh tab over
-  // the single-client CDP proxy slot (endless ~5s reconnect war). Reset the
-  // crash flags before spawn so Chrome starts with a single tab.
+  // A Chrome from a prior run can still hold this profile: Ctrl-C doesn't reap
+  // the LaunchServices-owned process, so the profile stays locked and a second
+  // `open -n` either exits non-zero ("before reporting CDP port") or just adds
+  // a tab to the lingering instance. Terminate it first so this launch is clean.
+  await terminateExistingProfileChrome(chromeProfile.userDataDir);
+
+  // Drop the session-restore snapshot so Chrome opens ONLY the command-line
+  // tab. Otherwise it reopens the previous window's tabs too — a duplicate
+  // webapp tab that fights the fresh one over the single-client CDP proxy slot.
+  await clearChromeSessionRestore(chromeProfile.userDataDir);
+
+  // Belt-and-suspenders for genuine crashes: reset the `exit_type: "Crashed"`
+  // flag so Chrome doesn't show the crash-restore bubble. (The tab-restore
+  // itself is handled by clearChromeSessionRestore above, not this.)
   await clearChromeRestoreState(chromeProfile.userDataDir);
 
   // On macOS, route through `/usr/bin/open` so LaunchServices owns the new Chrome

--- a/packages/node-server/tests/chrome-launch.test.ts
+++ b/packages/node-server/tests/chrome-launch.test.ts
@@ -1,5 +1,5 @@
 import { type existsSync, existsSync as fsExistsSync, type readdirSync } from 'fs';
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildChromeLaunchArgs,
   clearChromeRestoreState,
+  clearChromeSessionRestore,
   clearStaleDevToolsActivePort,
   DEFAULT_CDP_LAUNCH_TIMEOUT_MS,
   ensureQaProfileScaffold,
@@ -20,6 +21,7 @@ import {
   resolveChromeAppBundle,
   resolveChromeLaunchProfile,
   resolveProfilesDir,
+  terminateExistingProfileChrome,
   waitForCdpPort,
   waitForCdpPortFromActivePortFile,
   waitForCdpPortFromStderr,
@@ -880,6 +882,102 @@ describe('clearChromeRestoreState', () => {
   it('does not throw when the directory itself is missing', async () => {
     const missing = join(tmpdir(), `slicc-clear-restore-missing-${Date.now()}-${Math.random()}`);
     await expect(clearChromeRestoreState(missing)).resolves.toBeUndefined();
+  });
+});
+
+describe('clearChromeSessionRestore', () => {
+  it('removes the session-restore files so Chrome does not reopen prior tabs', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-clear-sessions-'));
+    tempDirs.push(dir);
+    const sessionsDir = join(dir, 'Default', 'Sessions');
+    await mkdir(sessionsDir, { recursive: true });
+    await writeFile(join(sessionsDir, 'Session_123'), 'x');
+    await writeFile(join(sessionsDir, 'Tabs_123'), 'x');
+    await writeFile(join(dir, 'Default', 'Last Session'), 'x');
+    await writeFile(join(dir, 'Default', 'Last Tabs'), 'x');
+    // Cookies / localStorage / IndexedDB live elsewhere and must survive.
+    await writeFile(join(dir, 'Default', 'Preferences'), '{}');
+
+    await clearChromeSessionRestore(dir);
+
+    expect(fsExistsSync(sessionsDir)).toBe(false);
+    expect(fsExistsSync(join(dir, 'Default', 'Last Session'))).toBe(false);
+    expect(fsExistsSync(join(dir, 'Default', 'Last Tabs'))).toBe(false);
+    expect(fsExistsSync(join(dir, 'Default', 'Preferences'))).toBe(true);
+  });
+
+  it('is a no-op when the profile has no session files (first run)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-clear-sessions-'));
+    tempDirs.push(dir);
+    await expect(clearChromeSessionRestore(dir)).resolves.toBeUndefined();
+  });
+});
+
+describe('terminateExistingProfileChrome', () => {
+  it('kills a live Chrome holding the profile and clears the Singleton lock files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-singleton-'));
+    tempDirs.push(dir);
+    // Chrome records the owning PID in SingletonLock -> `<host>-<pid>`.
+    await symlink('silver-air-4242', join(dir, 'SingletonLock'));
+    await writeFile(join(dir, 'SingletonCookie'), '');
+    let alive = true;
+    const killed: Array<[number, string]> = [];
+    await terminateExistingProfileChrome(dir, {
+      isAlive: () => alive,
+      kill: (pid, sig) => {
+        killed.push([pid, sig]);
+        if (sig === 'SIGTERM') alive = false;
+      },
+      sleep: async () => {},
+    });
+    expect(killed).toContainEqual([4242, 'SIGTERM']);
+    expect(killed).not.toContainEqual([4242, 'SIGKILL']);
+    expect(fsExistsSync(join(dir, 'SingletonLock'))).toBe(false);
+    expect(fsExistsSync(join(dir, 'SingletonCookie'))).toBe(false);
+  });
+
+  it('escalates to SIGKILL when SIGTERM does not stop it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-singleton-'));
+    tempDirs.push(dir);
+    await symlink('host-99', join(dir, 'SingletonLock'));
+    const signals: string[] = [];
+    await terminateExistingProfileChrome(dir, {
+      isAlive: () => true, // never dies
+      kill: (_pid, sig) => signals.push(sig),
+      sleep: async () => {},
+    });
+    expect(signals).toContain('SIGTERM');
+    expect(signals).toContain('SIGKILL');
+  });
+
+  it('does not kill a stale lock (dead PID) but still removes it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-singleton-'));
+    tempDirs.push(dir);
+    await symlink('host-123', join(dir, 'SingletonLock'));
+    let killCalls = 0;
+    await terminateExistingProfileChrome(dir, {
+      isAlive: () => false,
+      kill: () => {
+        killCalls += 1;
+      },
+      sleep: async () => {},
+    });
+    expect(killCalls).toBe(0);
+    expect(fsExistsSync(join(dir, 'SingletonLock'))).toBe(false);
+  });
+
+  it('is a no-op when there is no SingletonLock', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slicc-singleton-'));
+    tempDirs.push(dir);
+    let killCalls = 0;
+    await terminateExistingProfileChrome(dir, {
+      isAlive: () => true,
+      kill: () => {
+        killCalls += 1;
+      },
+      sleep: async () => {},
+    });
+    expect(killCalls).toBe(0);
   });
 });
 


### PR DESCRIPTION
> Draft — stacked on #1096 (shares the chrome-launch pre-spawn area). Found while testing leader setup: this is what actually makes `npm run dev` open a single tab and not fail when a prior Chrome is still around. **Supersedes the duplicate-tab intent of #1096's `clearChromeRestoreState`** (which targeted crash-restore — the wrong mechanism; kept here only as a crash-bubble belt-and-suspenders).

## Symptoms (verified live)

1. Every `npm run dev` opens **+1 tab** — even after Chrome fully shut down. Only avoidable by manually closing the tab before quitting.
2. If Chrome is still running, `npm run dev` aborts: `Chrome exited with code 1 before reporting CDP port`.

## Root cause

On macOS the launcher starts Chrome via `/usr/bin/open` → **LaunchServices owns it**, so it's not the dev server's child and Ctrl-C never reaps it (the graceful shutdown also wasn't running — separate issue). That produces two failures:

1. **Session restore.** Chrome reopens `Default/Sessions/` (the prior window's tabs) *in addition* to the command-line URL. Confirmed against the live profile: `exit_type` was already `Normal` (so the crash-restore reset wasn't the cause) yet `Default/Sessions/Session_*`/`Tabs_*` were present → +1 tab each run.
2. **Profile lock.** A lingering Chrome holds the `user-data-dir`; the next `open -n` can't claim it, so the launched process exits non-zero before reporting a CDP port (or silently adds a tab to the running instance). `SingletonLock -> <host>-<pid>` is the tell.

## Fix (both pre-spawn, beside `clearStaleDevToolsActivePort`)

- **`clearChromeSessionRestore(userDataDir)`** — wipe `Default/Sessions/` + legacy `Current/Last Session/Tabs` so the launch opens only the command-line tab. Cookies / localStorage / IndexedDB live elsewhere and are untouched (tray/leader auto-start still works).
- **`terminateExistingProfileChrome(userDataDir)`** — read the owning PID from the `SingletonLock` symlink; if alive, stop it (SIGTERM → SIGKILL after a bounded wait); then clear the `Singleton{Lock,Socket,Cookie}` files. Idempotent; a missing lock is a no-op. Injectable seams (`readlinkImpl`/`isAlive`/`kill`/`sleep`) for tests.

`clearChromeRestoreState` stays only as crash-bubble belt-and-suspenders, with its comment corrected.

## Cross-runtime parity

node-server (CLI/standalone) only. Extension/swift/ios N/A.

## Tests

- `clearChromeSessionRestore` (2): removes session files while preserving `Preferences`; no-op on a fresh profile.
- `terminateExistingProfileChrome` (4): live kill (SIGTERM, lock cleared), SIGKILL escalation when SIGTERM doesn't stop it, stale lock (dead PID — no kill, lock still cleared), no lock (no-op).

Local verification: lint (biome+prettier), typecheck (all 7 targets), chrome-launch suite (84 pass).

## Not fixed here (follow-up)

Ctrl-C not running `gracefulShutdown` under `tsx --dev` (so Chrome lingers in the first place). This PR makes launch robust regardless; the shutdown gap is worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)