### PR TITLE
fix(swift-server): match node-server CDP-war guard + session-restore clear

### DIFF
--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -292,6 +292,44 @@ struct ChromeLauncher: Sendable {
         }
     }
 
+    /// Mark the prior session as having exited cleanly so Chrome doesn't pop the
+    /// "Chrome didn't shut down correctly — restore?" bubble on the next launch.
+    ///
+    /// `closeBrowser` in `GracefulShutdown.swift` SIGKILLs Chrome if it doesn't
+    /// exit within 3s of `Browser.close`; a SIGKILL leaves `Default/Preferences`
+    /// with `exit_type: "Crashed"`, which surfaces the crash-restore bubble even
+    /// though `clearChromeSessionRestore` already dropped the tabs. Rewriting
+    /// `exit_type` to `"Normal"` (+ `exited_cleanly` true) — the same trick
+    /// ChromeDriver uses — before spawn makes Chrome believe the last session
+    /// ended cleanly. Mirrors node-server's `clearChromeRestoreState` (PR #1096).
+    ///
+    /// Best-effort and idempotent: a missing Preferences file (first run) is left
+    /// absent, an unparseable one is left for Chrome to regenerate, and an
+    /// already-clean one is left untouched. Never throws.
+    func clearChromeRestoreState(userDataDir: String) {
+        let prefsPath = URL(fileURLWithPath: userDataDir, isDirectory: true)
+            .appendingPathComponent("Default", isDirectory: true)
+            .appendingPathComponent("Preferences")
+        guard let data = try? Data(contentsOf: prefsPath) else {
+            return // no Preferences yet (first run) — nothing to restore
+        }
+        guard
+            let parsed = try? JSONSerialization.jsonObject(with: data),
+            var prefs = parsed as? [String: Any]
+        else {
+            return // corrupt / not an object — leave it for Chrome to regenerate
+        }
+        var profile = prefs["profile"] as? [String: Any] ?? [:]
+        if profile["exit_type"] as? String == "Normal", profile["exited_cleanly"] as? Bool == true {
+            return // already clean — avoid a needless rewrite
+        }
+        profile["exit_type"] = "Normal"
+        profile["exited_cleanly"] = true
+        prefs["profile"] = profile
+        guard let out = try? JSONSerialization.data(withJSONObject: prefs) else { return }
+        try? out.write(to: prefsPath)
+    }
+
     /// Builds the ordered list of legacy candidate paths for a given profile dir name.
     /// Checks the previous `~/.slicc/profiles` location first because that was the
     /// most recent stable default and therefore holds the freshest profile — so it
@@ -351,6 +389,10 @@ struct ChromeLauncher: Sendable {
         // the command-line tab; a duplicate restored SLICC tab would trigger the
         // CDP eviction war on `/cdp` (parity with node-server, PR #1096).
         clearChromeSessionRestore(userDataDir: config.userDataDir)
+        // Mark the prior session as clean so a SIGKILL-fallback shutdown doesn't
+        // pop Chrome's crash-restore bubble on the next launch (parity with
+        // node-server, PR #1096).
+        clearChromeRestoreState(userDataDir: config.userDataDir)
 
         let process = processFactory()
         let chromeArgs = buildLaunchArgs(

--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -270,6 +270,28 @@ struct ChromeLauncher: Sendable {
         }
     }
 
+    /// Remove Chrome's session-restore snapshot so a relaunch opens ONLY the
+    /// command-line tab instead of also reopening the previous window's tabs.
+    ///
+    /// The launcher passes the UI URL on the command line, but Chrome ALSO
+    /// restores `Default/Sessions/` from the prior run — so every `slicc-server`
+    /// launch was adding a tab, and a duplicate restored SLICC tab triggers the
+    /// CDP eviction war on `/cdp`. Mirrors node-server's
+    /// `clearChromeSessionRestore` (PR #1096). Best-effort; cookies /
+    /// localStorage / IndexedDB live elsewhere and are untouched.
+    ///
+    /// Modern Chrome keeps the whole snapshot under `Default/Sessions/`; `Last
+    /// Session` / `Last Tabs` are belt-and-suspenders for older Chromium builds
+    /// that still wrote those two as top-level files under `Default/`.
+    func clearChromeSessionRestore(userDataDir: String) {
+        let defaultDir = URL(fileURLWithPath: userDataDir, isDirectory: true)
+            .appendingPathComponent("Default", isDirectory: true)
+        try? FileManager.default.removeItem(at: defaultDir.appendingPathComponent("Sessions", isDirectory: true))
+        for name in ["Last Session", "Last Tabs"] {
+            try? FileManager.default.removeItem(at: defaultDir.appendingPathComponent(name))
+        }
+    }
+
     /// Builds the ordered list of legacy candidate paths for a given profile dir name.
     /// Checks the previous `~/.slicc/profiles` location first because that was the
     /// most recent stable default and therefore holds the freshest profile — so it
@@ -324,6 +346,11 @@ struct ChromeLauncher: Sendable {
             logger.warning("Chrome already on CDP port \(config.cdpPort): \(existing)")
             throw ChromeLauncherError.chromeAlreadyRunning(port: config.cdpPort, browser: existing)
         }
+
+        // Drop the previous run's session-restore snapshot so Chrome opens only
+        // the command-line tab; a duplicate restored SLICC tab would trigger the
+        // CDP eviction war on `/cdp` (parity with node-server, PR #1096).
+        clearChromeSessionRestore(userDataDir: config.userDataDir)
 
         let process = processFactory()
         let chromeArgs = buildLaunchArgs(

--- a/packages/swift-server/Sources/WebSocket/CDPProxy.swift
+++ b/packages/swift-server/Sources/WebSocket/CDPProxy.swift
@@ -13,6 +13,15 @@ actor CDPProxy {
     static let defaultChromeInboundMessageBufferLimit = 1_000
     static let defaultReconnectDelayNanoseconds: UInt64 = 1_000_000_000
 
+    /// WebSocket close code SLICC sends when the proxy hands its single `/cdp`
+    /// client slot to a newer client (another SLICC tab/window). The webapp
+    /// `CDPClient` latches on this exact code (see
+    /// `packages/webapp/src/cdp/cdp-client.ts` `CDP_SUPERSEDED_CLOSE_CODE`) and
+    /// stops re-dialing, so the two tabs don't fight over the slot — matching
+    /// node-server's CDP-war guard (PR #1096). `.goingAway` (1001) would not
+    /// match the latch, so a Sliccstart user would see the eviction war.
+    static let supersededCloseCode: UInt16 = 4001
+
     private let logger: Logger
     private let logDedup: CliLogDedup
     private let discoverer: @Sendable (Int) async throws -> String
@@ -154,7 +163,10 @@ actor CDPProxy {
     func addClient(_ client: ClientHandle) async {
         if let activeClient {
             self.logger.info("[cdp-proxy] Closing previous client connection")
-            await activeClient.close(.goingAway, "Replaced by newer /cdp client")
+            // Close code 4001 (not 1001/.goingAway) so the webapp CDPClient
+            // latches "superseded" and stops re-dialing — otherwise the two
+            // SLICC tabs evict each other in a loop. See `supersededCloseCode`.
+            await activeClient.close(.unknown(Self.supersededCloseCode), "Replaced by newer /cdp client")
         }
 
         self.activeClient = client

--- a/packages/swift-server/Tests/CDPProxyTests.swift
+++ b/packages/swift-server/Tests/CDPProxyTests.swift
@@ -68,6 +68,9 @@ final class CDPProxyTests: XCTestCase {
         await harness.emitText("{\"id\":7}")
 
         XCTAssertEqual(firstClient.closeReasonsSnapshot(), ["Replaced by newer /cdp client"])
+        // Close with the supersede code (4001), NOT .goingAway (1001), so the
+        // webapp CDPClient latches "superseded" and stops re-dialing.
+        XCTAssertEqual(firstClient.closeCodesSnapshot(), [.unknown(CDPProxy.supersededCloseCode)])
         XCTAssertEqual(firstClient.sentTextsSnapshot(), [])
         XCTAssertEqual(secondClient.sentTextsSnapshot(), ["{\"id\":7}"])
     }
@@ -474,6 +477,7 @@ private final class ClientRecorder: @unchecked Sendable {
     private let lock = NSLock()
     private var sentTexts: [String] = []
     private var closeReasons: [String] = []
+    private var closeCodes: [WebSocketErrorCode] = []
 
     lazy var handle: ClientHandle = ClientHandle(
         send: { [weak self] message in
@@ -485,8 +489,8 @@ private final class ClientRecorder: @unchecked Sendable {
                 XCTFail("Expected text-only message in test client")
             }
         },
-        close: { [weak self] _, reason in
-            self?.recordCloseReason(reason)
+        close: { [weak self] code, reason in
+            self?.recordClose(code: code, reason: reason)
         }
     )
 
@@ -502,14 +506,21 @@ private final class ClientRecorder: @unchecked Sendable {
         return self.closeReasons
     }
 
+    func closeCodesSnapshot() -> [WebSocketErrorCode] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.closeCodes
+    }
+
     private func recordSentText(_ text: String) {
         self.lock.lock()
         self.sentTexts.append(text)
         self.lock.unlock()
     }
 
-    private func recordCloseReason(_ reason: String?) {
+    private func recordClose(code: WebSocketErrorCode, reason: String?) {
         self.lock.lock()
+        self.closeCodes.append(code)
         self.closeReasons.append(reason ?? "")
         self.lock.unlock()
     }

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -261,6 +261,83 @@ final class ChromeLauncherTests: XCTestCase {
         XCTAssertFalse(fm.fileExists(atPath: root.appendingPathComponent("Default").path))
     }
 
+    func testClearChromeRestoreStateRewritesCrashedToNormalAndKeepsOtherKeys() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fm.removeItem(at: root) }
+
+        let defaultDir = root.appendingPathComponent("Default")
+        try fm.createDirectory(at: defaultDir, withIntermediateDirectories: true)
+        let prefsPath = defaultDir.appendingPathComponent("Preferences")
+        let original: [String: Any] = [
+            "profile": ["exit_type": "Crashed", "exited_cleanly": false, "name": "keep"],
+            "other": "keep",
+        ]
+        try JSONSerialization.data(withJSONObject: original).write(to: prefsPath)
+
+        let launcher = makeLauncher()
+        launcher.clearChromeRestoreState(userDataDir: root.path)
+
+        let data = try Data(contentsOf: prefsPath)
+        let prefs = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let profile = try XCTUnwrap(prefs["profile"] as? [String: Any])
+        XCTAssertEqual(profile["exit_type"] as? String, "Normal")
+        XCTAssertEqual(profile["exited_cleanly"] as? Bool, true)
+        XCTAssertEqual(profile["name"] as? String, "keep")
+        XCTAssertEqual(prefs["other"] as? String, "keep")
+    }
+
+    func testClearChromeRestoreStateLeavesAlreadyCleanPreferencesValid() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fm.removeItem(at: root) }
+
+        let defaultDir = root.appendingPathComponent("Default")
+        try fm.createDirectory(at: defaultDir, withIntermediateDirectories: true)
+        let prefsPath = defaultDir.appendingPathComponent("Preferences")
+        let clean: [String: Any] = ["profile": ["exit_type": "Normal", "exited_cleanly": true]]
+        try JSONSerialization.data(withJSONObject: clean).write(to: prefsPath)
+
+        let launcher = makeLauncher()
+        launcher.clearChromeRestoreState(userDataDir: root.path)
+
+        let prefs = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(contentsOf: prefsPath)) as? [String: Any]
+        )
+        let profile = try XCTUnwrap(prefs["profile"] as? [String: Any])
+        XCTAssertEqual(profile["exit_type"] as? String, "Normal")
+        XCTAssertEqual(profile["exited_cleanly"] as? Bool, true)
+    }
+
+    func testClearChromeRestoreStateIsNoOpOnFirstRun() {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fm.removeItem(at: root) }
+
+        // No Preferences file — must not throw or create one.
+        let launcher = makeLauncher()
+        launcher.clearChromeRestoreState(userDataDir: root.path)
+        XCTAssertFalse(fm.fileExists(atPath: root.appendingPathComponent("Default/Preferences").path))
+    }
+
+    func testClearChromeRestoreStateLeavesCorruptPreferencesUntouched() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fm.removeItem(at: root) }
+
+        let defaultDir = root.appendingPathComponent("Default")
+        try fm.createDirectory(at: defaultDir, withIntermediateDirectories: true)
+        let prefsPath = defaultDir.appendingPathComponent("Preferences")
+        fm.createFile(atPath: prefsPath.path, contents: Data("{not json".utf8))
+
+        let launcher = makeLauncher()
+        launcher.clearChromeRestoreState(userDataDir: root.path)
+
+        // Left as-is for Chrome to regenerate; never throws.
+        let content = try String(contentsOf: prefsPath, encoding: .utf8)
+        XCTAssertEqual(content, "{not json")
+    }
+
     func testParseCdpPortFromStderrExtractsPort() {
         XCTAssertEqual(
             ChromeLauncher.parseCdpPortFromStderr(

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -227,6 +227,40 @@ final class ChromeLauncherTests: XCTestCase {
         XCTAssertFalse(fm.fileExists(atPath: newProfile.path))
     }
 
+    func testClearChromeSessionRestoreDropsSnapshotButKeepsOtherProfileData() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fm.removeItem(at: root) }
+
+        let defaultDir = root.appendingPathComponent("Default")
+        let sessionsDir = defaultDir.appendingPathComponent("Sessions")
+        try fm.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        fm.createFile(atPath: sessionsDir.appendingPathComponent("Session_123").path, contents: Data("x".utf8))
+        fm.createFile(atPath: defaultDir.appendingPathComponent("Last Session").path, contents: Data("x".utf8))
+        fm.createFile(atPath: defaultDir.appendingPathComponent("Last Tabs").path, contents: Data("x".utf8))
+        // Cookies / localStorage / IndexedDB live elsewhere and must survive.
+        fm.createFile(atPath: defaultDir.appendingPathComponent("Cookies").path, contents: Data("keep".utf8))
+
+        let launcher = makeLauncher()
+        launcher.clearChromeSessionRestore(userDataDir: root.path)
+
+        XCTAssertFalse(fm.fileExists(atPath: sessionsDir.path))
+        XCTAssertFalse(fm.fileExists(atPath: defaultDir.appendingPathComponent("Last Session").path))
+        XCTAssertFalse(fm.fileExists(atPath: defaultDir.appendingPathComponent("Last Tabs").path))
+        XCTAssertTrue(fm.fileExists(atPath: defaultDir.appendingPathComponent("Cookies").path))
+    }
+
+    func testClearChromeSessionRestoreIsNoOpOnFirstRun() {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fm.removeItem(at: root) }
+
+        // No profile yet — must not throw or create anything.
+        let launcher = makeLauncher()
+        launcher.clearChromeSessionRestore(userDataDir: root.path)
+        XCTAssertFalse(fm.fileExists(atPath: root.appendingPathComponent("Default").path))
+    }
+
     func testParseCdpPortFromStderrExtractsPort() {
         XCTAssertEqual(
             ChromeLauncher.parseCdpPortFromStderr(


### PR DESCRIPTION
Cross-runtime parity follow-up for **#1096** (CDP eviction war on dev restart), flagged by the PR reviewer on #1096.

## Why

Sliccstart (`swift-launcher` → `swift-server`) launches Chrome the same way node-server does and shares the same single-client `/cdp` proxy + persistent `Library/Application Support/Slicc/profiles/...` user-data-dir. So a Sliccstart user hits the exact bug #1096 fixes for the Node float: a duplicate restored SLICC tab fights with the original over the proxy's single client slot (eviction war), and every launch reopens the prior session's tab.

## What

- **`CDPProxy.addClient`** now closes the superseded client with WebSocket close code **4001** (`CDPProxy.supersededCloseCode`) instead of `.goingAway` (1001). The webapp `CDPClient` latches on exactly `4001` (`CDP_SUPERSEDED_CLOSE_CODE`) and stops re-dialing — `1001` would not match the latch, so the war would continue under Sliccstart.
- **`ChromeLauncher`** drops the previous run's `Default/Sessions/` snapshot (+ legacy `Last Session`/`Last Tabs`) before spawning Chrome, mirroring node-server's `clearChromeSessionRestore`, so a relaunch opens only the command-line tab.
- node-server's `terminateExistingProfileChrome` (reap a profile-locked Chrome) has **no peer to port**: swift-server already fails fast on a port-locked Chrome via `probeExistingChrome` → `chromeAlreadyRunning`.

## Tests

- `CDPProxyTests`: the existing replace-client test now also asserts the superseded client is closed with `.unknown(4001)`.
- `ChromeLauncherTests`: two new tests for `clearChromeSessionRestore` (drops the snapshot + legacy files while keeping `Cookies`; no-op on first run).
- `swift build` ✓, `swift test` ✓ (46 affected tests pass), coverage gate ✓ (lines 57.70 / functions 57.63 / regions 54.09, all ≥ floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)