### PR TITLE
fix(ci): build e2b template under isolated slicc-staging alias on PRs (don't republish prod)

### DIFF
--- a/.github/workflows/worker-staging.yml
+++ b/.github/workflows/worker-staging.yml
@@ -9,6 +9,18 @@ on:
       - 'packages/webapp/src/providers/**'
       - 'packages/webapp/providers/**'
 
+# Serialize across ALL PRs: this job mutates two shared singletons — the
+# `slicc-staging` e2b template alias (build overwrites it) and the
+# `slicc-tray-hub-staging` worker (deploy overwrites it). Without this, two
+# concurrent PRs can interleave (PR A builds → PR B overwrites → PR A's verify
+# boots PR B's template), giving PR A a false pass against PR B's artifacts.
+# cancel-in-progress: false → queue rather than cancel, so an in-flight deploy
+# never gets killed half-way. Unrelated CI (the ci.yml jobs) still runs in
+# parallel; only this workflow's runs serialize.
+concurrency:
+  group: worker-staging-e2b-slicc-staging
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/worker-staging.yml
+++ b/.github/workflows/worker-staging.yml
@@ -37,14 +37,26 @@ jobs:
       - name: Build dependencies for e2b template
         run: npm run build -w @slicc/shared-ts && npm run build -w @slicc/cloud-core && npm run build -w @slicc/node-server
 
-      - name: Build and push e2b template
+      # Build + verify under the isolated `slicc-staging` alias, NEVER the prod
+      # `slicc` alias. This job runs on every PR touching cloudflare-worker/ or
+      # cloud-core/, and e2b has no build-without-deploy — `Template.build`
+      # publishes the alias it builds. Defaulting to `slicc` (template.ts's
+      # default) would republish the PRODUCTION template from un-merged PR
+      # branch code, and `Sandbox.create('slicc')` in prod would pick it up
+      # immediately. A fixed `slicc-staging` alias keeps the per-PR "template
+      # builds & boots" signal while leaving prod untouched; it's overwritten by
+      # each staging run (no per-PR template sprawl). Prod `slicc` is built only
+      # by release.yml (on merge) and worker.yml (manual prod deploy).
+      - name: Build and push e2b template (isolated staging alias)
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          SLICC_E2B_TEMPLATE_NAME: slicc-staging
         run: bash packages/dev-tools/e2b-template/scripts/build-template.sh
 
-      - name: Verify template boots
+      - name: Verify template boots (isolated staging alias)
         env:
           SLICC_TEST_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          SLICC_E2B_TEMPLATE_NAME: slicc-staging
         run: bash packages/dev-tools/e2b-template/scripts/verify-template.sh
 
       # The staging Worker (slicc-tray-hub-staging) has Worker Versions enabled.

--- a/packages/dev-tools/e2b-template/README.md
+++ b/packages/dev-tools/e2b-template/README.md
@@ -38,6 +38,21 @@ is how you manage and kill them, rather than them appearing `dead`).
 
 Creates one sandbox, polls `/tmp/slicc-join.json`, kills the sandbox.
 
+## Which CI workflow builds which alias
+
+`Template.build` always publishes (e2b has no build-without-deploy), so the
+alias a workflow builds is what its consumers see. The split:
+
+- **`release.yml`** (push to `main`, i.e. merge) and **`worker.yml`** (manual
+  prod deploy) build the production **`slicc`** alias via `publish-worker.sh`.
+  This is the real release — `Sandbox.create('slicc')` should serve merged code.
+- **`worker-staging.yml`** runs on **every PR** touching `cloudflare-worker/` or
+  `cloud-core/`, so it MUST NOT build `slicc` — that would republish prod from
+  un-merged branch code. It sets `SLICC_E2B_TEMPLATE_NAME=slicc-staging` on both
+  the build and verify steps, so it validates "this PR's template builds &
+  boots" under the isolated **`slicc-staging`** alias (overwritten each run; no
+  per-PR sprawl). Prod `slicc` is untouched.
+
 ## Notes
 
 - Not an npm workspace. Invoke the scripts directly.


### PR DESCRIPTION
## Summary

Fixes a production-safety hole uncovered after #1108 re-enabled the e2b template build: **`worker-staging.yml` was republishing the production `slicc` template on every PR.**

## The problem

`worker-staging.yml` runs on every PR touching `packages/cloudflare-worker/**` or `packages/cloud-core/**`. Its "Build and push e2b template" step ran `build-template.sh` with no `SLICC_E2B_TEMPLATE_NAME`, which `template.ts` defaults to the **production `slicc` alias**.

e2b has no build-without-deploy — `Template.build` publishes whatever alias it builds. So every such PR rebuilt and republished the prod template **from un-merged branch code**, and `Sandbox.create('slicc')` in prod (worker + CLI default in `cloud-core/operations/start.ts`) picked it up immediately. A PR with broken template/boot code would poison prod until the next good build; even a good PR pushes pre-merge code ahead of the actual release.

This was masked while `SLICC_SKIP_E2B_TEMPLATE=1` no-op'd the build. Re-enabling the build in #1108 (correctly) un-masked it.

## The fix

Set `SLICC_E2B_TEMPLATE_NAME=slicc-staging` on the staging job's build + verify steps. This keeps the per-PR "template builds & boots" signal under an isolated alias (overwritten each run — no per-PR sprawl) while leaving prod `slicc` untouched. The wiring already exists from #1108: `template.ts` reads the var, and `verify-template.sh` honors it (boots the alias it built).

## Scope (deliberately minimal)

- **`worker-staging.yml`** — the only PR-triggered template builder → redirected to `slicc-staging`. **(changed)**
- **`release.yml`** (push to `main`/merge) and **`worker.yml`** (manual prod deploy) build `slicc` via `publish-worker.sh` — that **is** the real release. **(unchanged, correct)**
- Worker runtime default stays `slicc` — out of scope; the staging smoke test (`deployed.test.ts`) only hits HTTP routes and never starts a cone, so the only e2b boot in the staging job is the verify step, now on `slicc-staging`.

## Docs

Added a "Which CI workflow builds which alias" section to the e2b-template README so the split is explicit and the redirect isn't regressed.

## Verification

- `prettier --check` (YAML + Markdown) ✓, `lint:docs` ✓. No TS/source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
