### PR TITLE
fix(webapp): skip stale session hydration for cloud cone followers

### DIFF
--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -838,10 +838,14 @@ function wireWcComposer(deps: {
   // canonical replay (request-scoop-messages on selection) replaces it.
   // Skipped when the URL deep-links a non-cone context: flashing the cone
   // history there would be wrong content.
+  // Also skipped for cloud cone followers — the leader's snapshot replaces
+  // any local history, so showing stale IndexedDB messages causes flicker.
   void (async () => {
     try {
       const pending = boot.wiring.pendingUrlContext;
       if (pending != null && pending !== 'cone') return;
+      const { hasStoredTrayJoinUrl } = await import('../../scoops/tray-runtime-config.js');
+      if (hasStoredTrayJoinUrl(window.localStorage)) return;
       const { SessionStore } = await import('../session-store.js');
       const store = new SessionStore();
       await store.init();

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -12,6 +12,7 @@ import { installPageStorageSync } from '../../kernel/page-storage-sync.js';
 import { spawnKernelWorker } from '../../kernel/spawn.js';
 import { resolveCurrentModel, resolveModelById } from '../../providers/account-store.js';
 import type { LickEvent } from '../../scoops/lick-manager.js';
+import { hasStoredTrayJoinUrl } from '../../scoops/tray-runtime-config.js';
 import type { RegisteredScoop, ThinkingLevel } from '../../scoops/types.js';
 import { setupStandalonePrelude } from '../boot/setup-standalone-prelude.js';
 import type { BootStageLogger } from '../boot/types.js';
@@ -73,6 +74,21 @@ export function thinkingLevelForAgent(metaLevel: string | undefined): ThinkingLe
 
 export function metaThinkingForScoop(level: ThinkingLevel | undefined): string {
   return (level && META_FROM_PI[level]) ?? 'off';
+}
+
+/**
+ * Whether stale-session hydration should be skipped: true when the page is a
+ * tray follower (stored join URL or cherry embed) or when a non-cone URL
+ * context is pending. In all these cases the leader's snapshot replaces local
+ * history, so flashing IndexedDB content first would cause flicker.
+ */
+export function shouldSkipSessionHydration(
+  pendingUrlContext: string | null | undefined,
+  win: { location: { href: string }; localStorage: Storage }
+): boolean {
+  if (pendingUrlContext != null && pendingUrlContext !== 'cone') return true;
+  if (new URL(win.location.href).searchParams.get('cherry') === '1') return true;
+  return hasStoredTrayJoinUrl(win.localStorage);
 }
 
 /** Scoop runtime status, as broadcast by `onStatusChange`. */
@@ -838,14 +854,12 @@ function wireWcComposer(deps: {
   // canonical replay (request-scoop-messages on selection) replaces it.
   // Skipped when the URL deep-links a non-cone context: flashing the cone
   // history there would be wrong content.
-  // Also skipped for cloud cone followers — the leader's snapshot replaces
-  // any local history, so showing stale IndexedDB messages causes flicker.
+  // Also skipped for cloud cone followers and cherry embeds — the leader's
+  // snapshot replaces any local history, so showing stale IndexedDB messages
+  // causes flicker.
   void (async () => {
     try {
-      const pending = boot.wiring.pendingUrlContext;
-      if (pending != null && pending !== 'cone') return;
-      const { hasStoredTrayJoinUrl } = await import('../../scoops/tray-runtime-config.js');
-      if (hasStoredTrayJoinUrl(window.localStorage)) return;
+      if (shouldSkipSessionHydration(boot.wiring.pendingUrlContext, window)) return;
       const { SessionStore } = await import('../session-store.js');
       const store = new SessionStore();
       await store.init();

--- a/packages/webapp/tests/ui/wc/wc-live-hydration-skip.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-live-hydration-skip.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+/**
+ * Regression test: stale-session hydration must be skipped for tray followers
+ * (cloud cone join URL in localStorage) and cherry embeds (?cherry=1), so the
+ * leader's snapshot lands without a stale-IndexedDB flash.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { installWcDomStubs } from './wc-dom-stubs.js';
+
+installWcDomStubs();
+
+import { shouldSkipSessionHydration } from '../../../src/ui/wc/wc-live.js';
+
+function fakeWindow(
+  href: string,
+  storageEntries: Record<string, string> = {}
+): { location: { href: string }; localStorage: Storage } {
+  const store = new Map(Object.entries(storageEntries));
+  return {
+    location: { href },
+    localStorage: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage,
+  };
+}
+
+describe('shouldSkipSessionHydration', () => {
+  it('returns false for a plain standalone boot (no join URL, no cherry)', () => {
+    const win = fakeWindow('http://localhost:5710/');
+    expect(shouldSkipSessionHydration(null, win)).toBe(false);
+  });
+
+  it('returns true when localStorage has a stored tray join URL (cloud cone follower)', () => {
+    const win = fakeWindow('https://www.sliccy.ai/join/trayId.secret', {
+      'slicc.trayJoinUrl': 'https://www.sliccy.ai/join/trayId.secret',
+    });
+    expect(shouldSkipSessionHydration(null, win)).toBe(true);
+  });
+
+  it('returns true for a cherry embed (?cherry=1)', () => {
+    const win = fakeWindow('https://www.sliccy.ai/?cherry=1');
+    expect(shouldSkipSessionHydration(null, win)).toBe(true);
+  });
+
+  it('returns true when pendingUrlContext is a non-cone deep link', () => {
+    const win = fakeWindow('http://localhost:5710/?ctx=scoop:researcher');
+    expect(shouldSkipSessionHydration('scoop:researcher', win)).toBe(true);
+  });
+
+  it('returns true for a freezer deep link', () => {
+    const win = fakeWindow('http://localhost:5710/?ctx=freezer:session.md');
+    expect(shouldSkipSessionHydration('freezer:session.md', win)).toBe(true);
+  });
+
+  it('returns false when pendingUrlContext is explicitly "cone"', () => {
+    const win = fakeWindow('http://localhost:5710/?ctx=cone');
+    expect(shouldSkipSessionHydration('cone', win)).toBe(false);
+  });
+});


### PR DESCRIPTION
Cloud cone followers loaded past conversations from IndexedDB before the leader's snapshot arrived, causing confusing flicker of old messages. Skip the local hydration when a tray join URL is stored — the leader's snapshot will populate the chat once the connection succeeds.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
