### PR TITLE
fix(wc-settings): add deployment field and fix stale provider dropdown

### DIFF
--- a/packages/webapp/src/ui/wc/wc-settings.ts
+++ b/packages/webapp/src/ui/wc/wc-settings.ts
@@ -217,7 +217,7 @@ function buildAddSection(deps: ViewDeps): HTMLElement {
 
     const baseUrlInput = document.createElement('input');
     baseUrlInput.className = 'wcset__input';
-    baseUrlInput.placeholder = 'Base URL';
+    baseUrlInput.placeholder = config.baseUrlPlaceholder ?? 'Base URL';
     baseUrlInput.value = ps.getBaseUrlForProvider(pid) ?? '';
     if (config.requiresBaseUrl) controls.append(baseUrlInput);
 
@@ -230,16 +230,22 @@ function buildAddSection(deps: ViewDeps): HTMLElement {
       return;
     }
 
+    const deploymentInput = document.createElement('input');
+    deploymentInput.className = 'wcset__input';
+    deploymentInput.placeholder = config.deploymentPlaceholder ?? 'Model IDs (comma-separated)';
+    deploymentInput.value = ps.getDeploymentForProvider(pid) ?? '';
+    if (config.requiresDeployment) controls.append(deploymentInput);
+
     const keyInput = document.createElement('input');
     keyInput.className = 'wcset__input';
     keyInput.type = 'password';
-    keyInput.placeholder = 'API key';
+    keyInput.placeholder = config.apiKeyPlaceholder ?? 'API key';
     keyInput.setAttribute('data-testid', 'wcset-api-key');
-    controls.append(keyInput);
+    if (config.requiresApiKey || config.optionalApiKey) controls.append(keyInput);
     controls.append(
       button('wcset__btn wcset__btn--primary', 'Save', () => {
         const key = keyInput.value.trim();
-        if (!key) {
+        if (config.requiresApiKey && !key) {
           setStatus('An API key is required.', true);
           keyInput.focus();
           return;
@@ -249,7 +255,17 @@ function buildAddSection(deps: ViewDeps): HTMLElement {
           baseUrlInput.focus();
           return;
         }
-        ps.addAccount(pid, key, baseUrlInput.value.trim() || undefined);
+        if (config.requiresDeployment && !deploymentInput.value.trim()) {
+          setStatus('Model IDs are required.', true);
+          deploymentInput.focus();
+          return;
+        }
+        ps.addAccount(
+          pid,
+          key,
+          baseUrlInput.value.trim() || undefined,
+          deploymentInput.value.trim() || undefined
+        );
         keyInput.value = '';
         setStatus(`${config.name} connected.`);
         deps.renderList();
@@ -297,6 +313,7 @@ export async function showWcSettings(log: SettingsLogger): Promise<boolean> {
       window.dispatchEvent(new CustomEvent('slicc:accounts-changed'));
     };
 
+    const addSectionSlot = div('');
     const deps: ViewDeps = {
       ps,
       log,
@@ -307,16 +324,17 @@ export async function showWcSettings(log: SettingsLogger): Promise<boolean> {
         const accounts = ps.getAccounts();
         if (accounts.length === 0) {
           list.append(div('wcset__empty', 'No accounts configured.'));
-          return;
+        } else {
+          for (const account of accounts) {
+            list.append(accountRow(account, ps.getProviderConfig(account.providerId), deps));
+          }
         }
-        for (const account of accounts) {
-          list.append(accountRow(account, ps.getProviderConfig(account.providerId), deps));
-        }
+        addSectionSlot.replaceChildren(buildAddSection(deps));
       },
     };
     deps.renderList();
 
-    body.append(list, buildAddSection(deps), status);
+    body.append(list, addSectionSlot, status);
     dialog.append(body);
 
     const done = button('wcset__btn wcset__btn--primary', 'Done', () => {


### PR DESCRIPTION
## Summary

- **Missing deployment field**: the new `wc-settings` dialog never rendered the model-ID (deployment) input for providers that require it (e.g. Local LLM). Added the field with provider-supplied placeholder text, pre-population from any existing saved value, and validation on Save. The value is now passed through to `addAccount` so model IDs are actually persisted.
- **Optional API key not respected**: `optionalApiKey: true` providers (like Local LLM) were blocked from saving without an API key. Save now only requires the key when `config.requiresApiKey` is true.
- **Stale provider dropdown after delete**: the add-account provider `<select>` was built once when the dialog opened, so deleting an account didn't make that provider re-selectable until the dialog was closed and reopened. Fixed by rebuilding the add-account section inside every `renderList` call via an `addSectionSlot` container.

<img width="579" height="465" alt="Screenshot 2026-06-24 at 16 25 07" src="https://github.com/user-attachments/assets/bd6bbefe-e122-492f-936c-218a9cfc46ba" />


## Test plan

- [ ] Open Accounts dialog → select **Local LLM (OpenAI-compatible)** → confirm Base URL, Model IDs, and API key (optional) fields all appear
- [ ] Fill in Base URL + Model IDs, leave API key empty → Save succeeds
- [ ] Remove the account → the same provider immediately reappears in the dropdown without closing the dialog
- [ ] Add it again → confirm it saves correctly and appears in the account list

🤖 Generated with [Claude Code](https://claude.com/claude-code)