### PR TITLE
fix(webapp): serve directory preview URLs via index.html fallback

### DIFF
--- a/packages/webapp/src/ui/preview-vfs-responder.ts
+++ b/packages/webapp/src/ui/preview-vfs-responder.ts
@@ -85,8 +85,25 @@ export function installPreviewVfsResponder(
     channel.postMessage({ type: 'preview-vfs-ack', id } satisfies PreviewVfsResponse);
     void (async () => {
       try {
+        const reader = getReader();
+        // ZenFS' readFile does not throw EISDIR on a directory — it returns
+        // the directory entry's bytes — so the preview SW's directory →
+        // index.html fallback (which keys off an EISDIR error) never fires.
+        // Detect directories with a stat and surface EISDIR explicitly, the
+        // same POSIX-contract enforcement shell/vfs-adapter.ts applies for
+        // ZenFS. stat() throws ENOENT for missing paths, so the silent-404
+        // path below is preserved.
+        const stats = await reader.stat(path);
+        if (stats.type === 'directory') {
+          channel.postMessage({
+            type: 'preview-vfs-response',
+            id,
+            error: `EISDIR: is a directory '${path}'`,
+          } satisfies PreviewVfsResponse);
+          return;
+        }
         const encoding = asText ? 'utf-8' : 'binary';
-        const content = await getReader().readFile(path, { encoding });
+        const content = await reader.readFile(path, { encoding });
         channel.postMessage({
           type: 'preview-vfs-response',
           id,

--- a/packages/webapp/tests/ui/preview-serve-integration.test.ts
+++ b/packages/webapp/tests/ui/preview-serve-integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration test for the `serve` / `/preview/*` directory → index.html
+ * fallback, wiring the THREE real production halves with no stubs:
+ *
+ *   handlePreviewRequest (SW side)  ⇄  installPreviewVfsResponder (page side)
+ *                                   ⇅
+ *                              real VirtualFS (in-memory backend)
+ *
+ * Regression guard for the bug where ZenFS' `readFile` returns a
+ * directory's index bytes instead of throwing `EISDIR`, which left the
+ * SW handler's directory → index.html retry as dead code: directory
+ * preview URLs (`/preview/site`, project-serve `<a href="/products/">`)
+ * served an empty `200` instead of the directory's `index.html`.
+ *
+ * The pre-existing e2e suite (`tests/e2e/preview-serve.test.ts`) stubs
+ * the responder with a synchronous sessionStorage seed, so it never
+ * exercises the real responder → VFS path this test covers.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import type { LocalVfsClient } from '../../src/kernel/local-vfs-client.js';
+import { handlePreviewRequest, type PreviewChannel } from '../../src/ui/preview-sw-handler.js';
+import {
+  installPreviewVfsResponder,
+  type PreviewVfsChannelLike,
+} from '../../src/ui/preview-vfs-responder.js';
+
+type Listener = (ev: MessageEvent) => void;
+
+/**
+ * In-memory stand-in for `BroadcastChannel`: every `BusChannel` posting
+ * delivers to all OTHER channels' listeners (never its own), matching
+ * the cross-context fan-out the SW ⇄ page channel relies on.
+ */
+class BroadcastBus {
+  private readonly channels = new Set<BusChannel>();
+  register(ch: BusChannel): void {
+    this.channels.add(ch);
+  }
+  publish(from: BusChannel, data: unknown): void {
+    for (const ch of this.channels) {
+      if (ch !== from) ch.deliver(data);
+    }
+  }
+}
+
+class BusChannel implements PreviewChannel, PreviewVfsChannelLike {
+  private readonly listeners = new Set<Listener>();
+  constructor(private readonly bus: BroadcastBus) {
+    bus.register(this);
+  }
+  postMessage(data: unknown): void {
+    this.bus.publish(this, data);
+  }
+  addEventListener(_t: 'message', l: Listener): void {
+    this.listeners.add(l);
+  }
+  removeEventListener(_t: 'message', l: Listener): void {
+    this.listeners.delete(l);
+  }
+  close(): void {
+    this.listeners.clear();
+  }
+  deliver(data: unknown): void {
+    for (const l of this.listeners) l(new MessageEvent('message', { data }));
+  }
+}
+
+describe('serve directory → index.html fallback (real responder + handler + VFS)', () => {
+  let vfs: VirtualFS;
+  let swChannel: BusChannel;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ backend: 'memory', wipe: true });
+    await vfs.mkdir('/site/products', { recursive: true });
+    await vfs.writeFile('/site/index.html', '<!DOCTYPE html><h1>Home</h1>');
+    await vfs.writeFile('/site/app.js', 'console.log("ok")');
+    await vfs.writeFile('/site/products/index.html', '<h1>Products</h1>');
+
+    const bus = new BroadcastBus();
+    const responderChannel = new BusChannel(bus);
+    swChannel = new BusChannel(bus);
+    installPreviewVfsResponder({
+      channel: responderChannel,
+      getReader: () => vfs as unknown as LocalVfsClient,
+    });
+  });
+
+  afterEach(async () => {
+    await vfs.dispose();
+  });
+
+  it('serves a real file directly', async () => {
+    const res = await handlePreviewRequest(swChannel, '/site/app.js', 1000);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/javascript');
+    expect(await res.text()).toContain('console.log');
+  });
+
+  it('serves index.html for a directory path with no trailing slash', async () => {
+    const res = await handlePreviewRequest(swChannel, '/site', 1000);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/html');
+    expect(await res.text()).toContain('<h1>Home</h1>');
+  });
+
+  it('serves index.html for a directory path with a trailing slash', async () => {
+    const res = await handlePreviewRequest(swChannel, '/site/', 1000);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/html');
+    expect(await res.text()).toContain('<h1>Home</h1>');
+  });
+
+  it('serves index.html for a nested directory (project-serve link target)', async () => {
+    const res = await handlePreviewRequest(swChannel, '/site/products', 1000);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/html');
+    expect(await res.text()).toContain('<h1>Products</h1>');
+  });
+
+  it('returns 404 for a directory that has no index.html', async () => {
+    await vfs.mkdir('/empty-dir', { recursive: true });
+    const res = await handlePreviewRequest(swChannel, '/empty-dir', 1000);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for a missing path', async () => {
+    const res = await handlePreviewRequest(swChannel, '/site/missing.html', 1000);
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/webapp/tests/ui/preview-vfs-responder.test.ts
+++ b/packages/webapp/tests/ui/preview-vfs-responder.test.ts
@@ -216,6 +216,25 @@ describe('installPreviewVfsResponder', () => {
     expect(vfs.readFile).not.toHaveBeenCalled();
   });
 
+  it('directory paths surface EISDIR so the SW falls back to index.html', async () => {
+    // ZenFS readFile does not throw on a directory (it returns the dir
+    // entry's index bytes), so the responder stats first and reports
+    // EISDIR for directories. The preview SW keys its index.html retry
+    // off that error code.
+    const ch = new FakeChannel();
+    const vfs = makeStubVfs();
+    vfs.stat.mockResolvedValue({ type: 'directory', size: 0, mtime: 0, ctime: 0 });
+    installPreviewVfsResponder({ channel: ch, getReader: () => vfs.client });
+
+    ch.emit({ type: 'preview-vfs-read', id: 'd1', path: '/site', asText: true });
+    await tick();
+
+    expect(acksOf(ch)).toEqual([{ type: 'preview-vfs-ack', id: 'd1' }]);
+    const resp = responsesOf(ch)[0] as PreviewVfsResponse;
+    expect('error' in resp && resp.error).toContain('EISDIR');
+    expect(vfs.readFile).not.toHaveBeenCalled();
+  });
+
   it('end-to-end: forwards through a real VfsRpcHost + RemoteVfsClient', async () => {
     // Canonical OPFS-flag-on path: the swapped reader is a
     // `RemoteVfsClient` talking to the kernel worker's `VfsRpcHost`


### PR DESCRIPTION
## Summary

The `serve` / `/preview/*` directory → `index.html` fallback was dead under the ZenFS/OPFS VFS. **Before:** opening a directory preview URL (`/preview/<dir>`, a trailing-slash URL, or a project-serve link like `<a href="/products/">`) returned an empty `200`. **Now:** the directory's `index.html` is served, and a directory with no `index.html` correctly `404`s.

## Why

`handlePreviewRequest` retries `<path>/index.html` only when the responder returns an error containing `EISDIR`. ZenFS 2.5.6 `readFile` on a directory returns the directory's index bytes instead of throwing `EISDIR`, so that retry never fired — `VirtualFS.readFile`'s documented `@throws EISDIR` contract was silently broken by the OPFS migration. The existing e2e suite stubs the responder with a sessionStorage seed, so it never exercised the real responder → VFS path and missed the regression.

**Repro** (real browser, real worker VFS, before this change):
1. Boot SLICC (CLI/standalone), let the preview SW activate.
2. `fetch('/preview/workspace')` (a real existing directory).

Expected: `200` with `/workspace/index.html`, or `404` if absent.
Actual:   `200` with an **empty body** (`Content-Type: application/octet-stream`); the `preview-vfs` responder returned `content len:0` instead of `EISDIR`.

## Approach / Implementation notes

- Fix lives in `installPreviewVfsResponder` (`packages/webapp/src/ui/preview-vfs-responder.ts`): `stat` the path and surface `EISDIR` for directories, restoring the signal `handlePreviewRequest` already keys off. No SW-handler change.
- Mirrors the established convention in `shell/vfs-adapter.ts`, which already enforces POSIX `EISDIR` via a `stat` for the same ZenFS quirk.
- Scoped to preview reads — `VirtualFS.readFile`'s global hot path is untouched (no added `stat` there).
- `stat()` throws `ENOENT` for missing paths, so the existing silent-404 behavior is preserved.

## Cross-cutting impact

- **Floats exercised**: webapp-side responder, so all floats that render previews (CLI, Chrome extension, Electron, hosted-leader) get the fix. node-server / swift-server only serve the SW bytes (`Service-Worker-Allowed: /`, `no-store`) — verified unchanged, no parity change needed.
- **Other callers of the changed function**: `installPreviewVfsResponder` is called only from `wc/wc-live.ts` (standalone) and the extension boot path; signature unchanged. The reader contract (`LocalVfsClient.stat`) is already implemented by both `VirtualFS` and `RemoteVfsClient`.
- **Persisted state**: none.

## Test plan

- [x] `npm run typecheck` — clean (webapp `src` + the new test files).
- [x] `npx vitest run packages/webapp/tests/ui/preview-vfs-responder.test.ts packages/webapp/tests/ui/preview-sw-handler.test.ts packages/webapp/tests/ui/preview-serve-integration.test.ts packages/webapp/tests/shell/supplemental-commands/serve-command.test.ts` — 36 passing.
- [x] `npx playwright test --config packages/webapp/tests/e2e/playwright.config.ts preview-serve` — 10 passing.
- [x] `npm run build -w @slicc/webapp` + `-w @slicc/node-server` — clean.
- [x] biome clean on changed files.
- [x] **New coverage**: 1 responder unit test (directory → `EISDIR`, `readFile` not called) + 6 integration tests wiring the real responder + real handler + real in-memory `VirtualFS` (which reproduces the quirk: `stat`→directory, `readFile`→bytes, no throw) — directory-no-slash, directory-with-slash, nested directory, dir-without-index→404, missing→404, direct file.
- [x] **Manual smoke (CLI)**: built `--serve-only` server + real browser, real worker VFS. After fix: `readFile('/workspace')` → `EISDIR: is a directory '/workspace'`; `/preview/workspace` and `/preview/workspace/` → `404`; `/preview/workspace/CLAUDE.md` → `200` unchanged.

## Documentation

- [x] No documentation changes needed.

## Risk & rollback

- Blast radius: preview rendering only. A regression would affect directory preview URLs; direct file serving is unchanged and covered by tests.
- No feature flags / migrations. Reverts cleanly (single commit, no persisted-state changes).
- CI cannot exercise the real OPFS/ZenFS directory-read quirk in the stubbed e2e; the integration test reproduces it against a real in-memory `VirtualFS`, and the behavior was verified by hand in a real browser SW context (see Test plan).

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets/credentials in the diff
- [x] No public API / tool / shell-command / lick-channel contract changes
- [x] Checked the other `installPreviewVfsResponder` callers (standalone + extension); reader contract unchanged
