### PR TITLE
fix(scoop-context): classify decommissioned/deprecated-model 400s as non-retryable

### DIFF
--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -115,6 +115,10 @@ export function isNonRetryableError(msg: string): boolean {
     /session expired|log in again|re-?authenticate/i.test(msg) ||
     // Invalid model errors
     /model.*not.*found|invalid.*model|unknown.*model|does.*not.*exist/i.test(msg) ||
+    // Decommissioned / deprecated / retired models (permanent provider-side 400s)
+    /decommissioned|no longer supported|deprecated.*model|model.*deprecated|model.*retired/i.test(
+      msg
+    ) ||
     // Account/billing issues
     /insufficient.*quota|billing|payment.*required|account.*suspended/i.test(msg) ||
     // Malformed request (won't succeed on retry)

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -1139,6 +1139,26 @@ describe('isNonRetryableError', () => {
     expect(isNonRetryableError('bad request: missing field')).toBe(true);
   });
 
+  it('matches decommissioned / deprecated / retired model errors', () => {
+    expect(
+      isNonRetryableError(
+        '400 The model `deepseek-r1-distill-llama-70b` has been decommissioned and is no longer supported. Please refer to https://console.groq.com/docs/... for a recommendation on which model to use'
+      )
+    ).toBe(true);
+    expect(isNonRetryableError('this model is no longer supported')).toBe(true);
+    expect(isNonRetryableError('deprecated model: gpt-3')).toBe(true);
+    expect(isNonRetryableError('the model has been deprecated')).toBe(true);
+    expect(isNonRetryableError('that model was retired last year')).toBe(true);
+  });
+
+  it('does NOT match a bare generic 400 (stays retryable)', () => {
+    // A 400 with no decommissioned/deprecated/model-not-found wording must stay
+    // retryable. ("400 Bad Request" is intentionally avoided here because the
+    // pre-existing `bad.*request` malformed-request alternative already matches
+    // it — out of scope for this change.)
+    expect(isNonRetryableError('400 status returned')).toBe(false);
+  });
+
   it('does NOT match 429 rate limit (retryable)', () => {
     expect(isNonRetryableError('429 Too Many Requests')).toBe(false);
   });


### PR DESCRIPTION
Fixes #1114.

## Problem

A provider-side 400 that rejects a decommissioned model (e.g. `400 The model \`deepseek-r1-distill-llama-70b\` has been decommissioned and is no longer supported …`) was not classified by `isNonRetryableError` in `packages/webapp/src/scoops/scoop-context.ts`:

- The literal `400` is intentionally excluded from the HTTP allowlist (`401|403|404|405|410|422`).
- None of the existing model/auth/billing/malformed alternatives match "decommissioned" / "no longer supported" / "deprecated" / "retired".

The error fell through both `isNonRetryableError` and `isRetryableError`, so `runAgentWithRetries` retried it 3 times (~3s plus three identically-failing API round-trips) before surfacing it via `handleExhaustedRetries` as `Scoop "Cone" failed after 3 attempts: …`.

## Fix

Add one regex alternative to `isNonRetryableError` for permanently-retired models:

```ts
/decommissioned|no longer supported|deprecated.*model|model.*deprecated|model.*retired/i.test(msg)
```

Now the same string takes the unrecoverable-error branch, and the cone surfaces it on the **first** attempt as `Scoop "Cone" failed with unrecoverable error: …` instead of after a 3-attempt retry storm.

## Scope / non-goals

- No change to `isRetryableError`, the retry loop, or the generic-`400` exclusion — a bare `400` stays retryable.

## Tests

Added assertions to the existing `describe('isNonRetryableError', …)` block in `packages/webapp/tests/scoops/scoop-context.test.ts`:

- Decommissioned / no-longer-supported / deprecated-model / model-deprecated / model-retired all classify as non-retryable.
- A bare generic `400` (`400 status returned`) stays retryable (regression guard).

Regex logic verified against all DoD cases. Note: `npm run test`/`typecheck`/`lint` were not run locally because `node_modules` is not installed in this environment; CI will exercise the full suite.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author