### PR TITLE
fix(webcomponents): defer switcher ResizeObserver reflow to break feedback loop (#1134)

### DIFF
--- a/packages/webcomponents/src/switcher/slicc-scoop-switcher.ts
+++ b/packages/webcomponents/src/switcher/slicc-scoop-switcher.ts
@@ -193,6 +193,9 @@ export class SliccScoopSwitcher extends HTMLElement {
   #ro: ResizeObserver | null = null;
   /** Guards against ResizeObserver re-entering reflow mid-pass. */
   #reflowing = false;
+  /** Pending rAF id for a deferred reflow (coalesces multiple ResizeObserver
+   *  callbacks in one frame into a single pass), or null when none is queued. */
+  #reflowRaf: number | null = null;
   #onClick: ((e: Event) => void) | null = null;
   #initialized = false;
   /** Chip key currently under the pointer — eyes priority over `attention`. */
@@ -235,6 +238,10 @@ export class SliccScoopSwitcher extends HTMLElement {
   disconnectedCallback(): void {
     this.#ro?.disconnect();
     this.#ro = null;
+    if (this.#reflowRaf !== null) {
+      cancelAnimationFrame(this.#reflowRaf);
+      this.#reflowRaf = null;
+    }
     if (this.#onClick) {
       this.removeEventListener('click', this.#onClick);
       this.#onClick = null;
@@ -525,7 +532,19 @@ export class SliccScoopSwitcher extends HTMLElement {
    *  observation a transient squeeze leaves chips stuck in the overflow forever. */
   #observe(): void {
     if (this.#ro || typeof ResizeObserver === 'undefined') return;
-    this.#ro = new ResizeObserver(() => this.reflow());
+    // Defer reflow out of the ResizeObserver delivery cycle: #reflowOnce mutates
+    // the host's OWN width (toggling `.hide` on chips while the host is
+    // `flex: 0 1 auto`), which would feed straight back into this same delivery
+    // and trip "ResizeObserver loop completed with undelivered notifications".
+    // Scheduling on the next frame (coalesced — at most one pending pass) breaks
+    // that cross-frame loop while preserving the observation set.
+    this.#ro = new ResizeObserver(() => {
+      if (this.#reflowRaf !== null) return;
+      this.#reflowRaf = requestAnimationFrame(() => {
+        this.#reflowRaf = null;
+        this.reflow();
+      });
+    });
     this.#ro.observe(this);
     if (this.parentElement) this.#ro.observe(this.parentElement);
   }

--- a/packages/webcomponents/tests/switcher/slicc-scoop-switcher.test.ts
+++ b/packages/webcomponents/tests/switcher/slicc-scoop-switcher.test.ts
@@ -304,6 +304,94 @@ describe('slicc-scoop-switcher', () => {
     });
   });
 
+  describe('ResizeObserver feedback loop (deferred reflow)', () => {
+    /** Capture the callback the switcher hands to `new ResizeObserver(...)` so we
+     *  can drive it directly and observe the scheduling, then restore the real
+     *  global. Mirrors the runtime fix: reflow must NOT run synchronously inside
+     *  the observer callback (that re-entry is what trips "ResizeObserver loop
+     *  completed with undelivered notifications" when hiding chips resizes the
+     *  flex-sized host), it must be deferred + coalesced via requestAnimationFrame. */
+    const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    /** Swap in a ResizeObserver whose callback is captured into `ref.current`,
+     *  returning a restore fn. A ref object (not a `let`) keeps TS from narrowing
+     *  the captured callback away under control-flow analysis. */
+    function stubResizeObserver(): {
+      ref: { current: ResizeObserverCallback | null };
+      restore: () => void;
+    } {
+      const real = globalThis.ResizeObserver;
+      const ref: { current: ResizeObserverCallback | null } = { current: null };
+      class StubRO {
+        constructor(cb: ResizeObserverCallback) {
+          ref.current = cb;
+        }
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+      globalThis.ResizeObserver = StubRO as unknown as typeof ResizeObserver;
+      return { ref, restore: () => (globalThis.ResizeObserver = real) };
+    }
+
+    it('schedules reflow on the next frame instead of running it synchronously, coalescing bursts', async () => {
+      const { ref, restore } = stubResizeObserver();
+      try {
+        const el = mount();
+        // Let the initial connectedCallback reflow rAF flush so it doesn't
+        // confound the spy installed below.
+        await nextFrame();
+        expect(ref.current).not.toBeNull();
+        const fire = ref.current as ResizeObserverCallback;
+
+        const spy = vi.spyOn(el, 'reflow');
+        // Fire the observer callback twice in the same frame (host + parent box).
+        fire([], el as unknown as ResizeObserver);
+        fire([], el as unknown as ResizeObserver);
+        // Deferred: nothing ran inside the delivery cycle.
+        expect(spy).not.toHaveBeenCalled();
+
+        await nextFrame();
+        // Coalesced: the burst collapses to a single reflow on the next frame.
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        restore();
+      }
+    });
+
+    it('cancels a pending deferred reflow on disconnect (no reflow after teardown)', async () => {
+      const { ref, restore } = stubResizeObserver();
+      try {
+        const el = mount();
+        await nextFrame();
+        const fire = ref.current as ResizeObserverCallback;
+        const spy = vi.spyOn(el, 'reflow');
+        fire([], el as unknown as ResizeObserver);
+        el.remove();
+        await nextFrame();
+        expect(spy).not.toHaveBeenCalled();
+      } finally {
+        restore();
+      }
+    });
+
+    it('still corrects overflow across a width change once the deferred pass runs', async () => {
+      // End-to-end with the real ResizeObserver: a squeeze hides chips, and
+      // widening the host lets the deferred reflow restore them — proving the
+      // rAF deferral preserves overflow correctness, not just timing.
+      const el = mount();
+      el.style.cssText = 'display:flex;width:120px;overflow:hidden;';
+      el.reflow();
+      expect(chips(el).some((c) => c.classList.contains('hide'))).toBe(true);
+
+      el.style.width = '2000px';
+      await vi.waitFor(() => {
+        expect(chips(el).some((c) => c.classList.contains('hide'))).toBe(false);
+        expect(overflow(el)?.items.length ?? 0).toBe(0);
+      });
+    });
+  });
+
   describe('eyes: one pair at a time (hover > attention)', () => {
     const EYED: ScoopDescriptor[] = [
       { key: 'cone', type: 'cone', color: '#b07823', label: 'Sliccy', eyes: 'open' },


### PR DESCRIPTION
## Summary

Fixes the recurring `ResizeObserver loop completed with undelivered notifications` warning (#1134) at its source, so it stops being forwarded to RUM telemetry as noise. **No telemetry filtering is added** — the loop is eliminated structurally.

## Root cause (pinned at runtime, not static analysis)

The loop originates from the scoop switcher's reflow `ResizeObserver` in `packages/webcomponents/src/switcher/slicc-scoop-switcher.ts`:

- `#observe()` created `new ResizeObserver(() => this.reflow())` and observed **both** the host (`this`) and `this.parentElement`.
- The callback `reflow()` → `#reflowOnce()` mutates the host's own layout (toggling `.hide` on chips). Because the host is `flex: 0 1 auto`, hiding/showing chips changes the host width — which the observer watches — producing a cross-frame self-feedback resize that Chrome reports as the loop warning.
- The existing `#reflowing` guard only blocks synchronous re-entry within a single callback; it does not break the cross-frame loop.

### Runtime evidence (CDP probe on the live dev app, `?ui-fixture` + 31 chips + viewport-width sweep)

A wrapped `window.ResizeObserver` tagged every observer by creation site, counted callbacks, and snapshotted which site was "hot" when the loop fired.

| Run | Loop errors | Total callbacks (switcher / shader) | Hot at loop time |
|-----|-------------|-------------------------------------|------------------|
| Baseline (all observers synchronous) | 1 | 148 (99 / 49) | switcher only |
| Defer **only** switcher callback via rAF | 0 | 148 (99 / 49) | none |
| **After this fix** (plain probe, in-source fix active) | **0** | 148 (99 / 49) | none |

Identical workload; deferring just the switcher callback removes the loop. The shader observer fires on viewport resize but was never hot at loop time; terminal/dip observers never fired. Causal A/B, not correlation.

## The fix

- `#observe()` now schedules `reflow()` via a **coalesced** `requestAnimationFrame` (new `#reflowRaf` field) instead of running it synchronously inside the ResizeObserver delivery cycle, so host-mutating reflow no longer feeds back into the same delivery.
- `disconnectedCallback()` cancels any pending rAF and clears `#reflowRaf`.
- The host **and** parent observation is intentionally preserved (only the timing changes).

## Tests / verification

- 3 new regression tests in `packages/webcomponents/tests/switcher/slicc-scoop-switcher.test.ts` (deferred/coalesced reflow, cancel-on-disconnect, end-to-end overflow correctness).
- `npm run lint`, `npm run typecheck`, and `npm run test -w @slicc/webcomponents` (1595 browser tests) all pass.
- Independent verifier review: approved, no defects.
- Coordinator CDP runtime re-verify: `loopErrors` 1 → 0.

Closes #1134.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author