### PR TITLE
fix(thin-extension): deliver navigate/upskill licks over the bridge Port

### DIFF
--- a/packages/chrome-extension/src/bridge-sw.ts
+++ b/packages/chrome-extension/src/bridge-sw.ts
@@ -30,6 +30,7 @@ import {
   EXTENSION_BRIDGE_PORT_NAME,
   EXTENSION_BRIDGE_PROTOCOL_VERSION,
   type ExtensionBridgeEnvelope,
+  type ExtensionBridgeLick,
   isExtensionBridgeEnvelope,
 } from '../../webapp/src/cdp/extension-bridge-protocol.js';
 
@@ -149,6 +150,48 @@ interface PortState {
 }
 
 /**
+ * Registry of WELCOMED leader Ports keyed by Port → its pinned channelId. A
+ * Port is added right after `handshake.welcome` is posted (in
+ * {@link handleBridgeMessage}) and removed in the Port's `onDisconnect` (in
+ * {@link handleBridgePortConnect}). Used by
+ * {@link postLickToWelcomedLeaderPorts} to push SW-observed handoff licks over
+ * the live bridge instead of the unreliable `chrome.runtime.sendMessage`
+ * broadcast (the leader has no in-page listener for that in thin mode).
+ */
+const welcomedLeaderPorts = new Map<ChromeRuntimePort, string>();
+
+/**
+ * Post an `extension.lick` envelope to every welcomed leader Port, each
+ * stamped with that Port's pinned channelId. Best-effort: a post to a dead
+ * Port is swallowed (its `onDisconnect` evicts it from the registry). The
+ * caller passes the lick fields minus `bridge` / `channelId`, which are
+ * stamped here. Returns the number of Ports the envelope was posted to.
+ */
+export function postLickToWelcomedLeaderPorts(
+  lick: Omit<ExtensionBridgeLick, 'bridge' | 'channelId'>
+): number {
+  let delivered = 0;
+  for (const [port, channelId] of welcomedLeaderPorts) {
+    try {
+      port.postMessage({
+        ...lick,
+        bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+        channelId,
+      } satisfies ExtensionBridgeLick);
+      delivered += 1;
+    } catch {
+      /* port disconnected; its onDisconnect will evict it */
+    }
+  }
+  return delivered;
+}
+
+/** Test-only: clear the welcomed-port registry between cases. */
+export function __clearWelcomedLeaderPortsForTest(): void {
+  welcomedLeaderPorts.clear();
+}
+
+/**
  * Default `readStoredLeaderTabId` implementation. The sibling leader-tab
  * task writes the key to `chrome.storage.session`; this is the read half.
  */
@@ -255,6 +298,9 @@ export async function handleBridgePortConnect(
   });
 
   port.onDisconnect.addListener(() => {
+    // Evict from the welcomed-port registry so we never post a lick to a dead
+    // Port (no-op if the port never reached the welcome step).
+    welcomedLeaderPorts.delete(port);
     if (state.unsubscribeEvents) {
       state.unsubscribeEvents();
       state.unsubscribeEvents = null;
@@ -360,6 +406,9 @@ async function handleBridgeMessage(
       channelId: state.channelId,
       kind: 'handshake.welcome',
     } satisfies ExtensionBridgeEnvelope);
+    // The Port is now welcomed — register it so SW-observed handoff licks can
+    // be pushed over the live bridge (see postLickToWelcomedLeaderPorts).
+    welcomedLeaderPorts.set(port, state.channelId);
     return;
   }
 

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -35,6 +35,7 @@ import {
   BRIDGE_DEV_ORIGINS,
   buildDefaultBridgeSwDeps,
   handleBridgePortConnect,
+  postLickToWelcomedLeaderPorts,
   validateBridgePin,
 } from './bridge-sw.js';
 import { handleFetchProxyConnectionAsync } from './fetch-proxy-shared.js';
@@ -455,11 +456,12 @@ chrome.notifications.onClicked.addListener((notificationId: string) => {
  * re-shows the toast.
  *
  * IMPORTANT: this set gates ONLY the notification — never the forward. The
- * forward here (`chrome.runtime.sendMessage`) is best-effort and silently
- * drops when nothing is listening yet (e.g. the leader tab still booting).
- * If we suppressed the forward on "seen", a first delivery that was dropped
- * before the leader was ready would lose the handoff permanently. So we
- * always forward and let the receiver dedup the cone turn. MV3 may evict
+ * forward (an `extension.lick` envelope over the welcomed leader Port(s), plus
+ * the legacy `chrome.runtime.sendMessage` fallback) is best-effort and
+ * silently drops when no port is welcomed yet (e.g. the leader tab still
+ * booting). If we suppressed the forward on "seen", a first delivery that was
+ * dropped before the leader was ready would lose the handoff permanently. So
+ * we always forward and let the receiver dedup the cone turn. MV3 may evict
  * and respawn the worker, resetting this set — an accepted limitation of
  * the in-memory design (a repeat toast can appear once after eviction).
  * See {@link handoffFingerprint}.
@@ -486,6 +488,26 @@ chrome.webRequest.onHeadersReceived.addListener(
     const tabId = details.tabId;
     const dispatch = (title?: string) => {
       if (title) payload.title = title;
+      // Primary path: push the lick over the live bridge Port(s) the welcomed
+      // leader tab holds. The forward is ALWAYS attempted (never gated by the
+      // notification fingerprint) so a handoff that arrived before the leader
+      // was ready isn't lost; dedup of the resulting cone turn is the
+      // receiver's job. The envelope is stamped per-port with that port's
+      // pinned channelId inside postLickToWelcomedLeaderPorts.
+      postLickToWelcomedLeaderPorts({
+        kind: 'extension.lick',
+        verb: payload.verb,
+        target: payload.target,
+        url: payload.url,
+        ...(payload.instruction ? { instruction: payload.instruction } : {}),
+        ...(payload.branch ? { branch: payload.branch } : {}),
+        ...(payload.path ? { path: payload.path } : {}),
+        ...(payload.title ? { title: payload.title } : {}),
+      });
+      // Legacy best-effort broadcast. Retained as a harmless fallback: in thin
+      // mode the leader tab has no in-page `chrome.runtime.onMessage` listener
+      // for this, so it silently drops — but keeping it costs nothing and
+      // covers any legacy/detached receiver that does listen.
       chrome.runtime.sendMessage({ source: 'service-worker' as const, payload }).catch(() => {
         // Leader may not be listening yet — best effort.
       });

--- a/packages/chrome-extension/tests/bridge-sw.test.ts
+++ b/packages/chrome-extension/tests/bridge-sw.test.ts
@@ -4,9 +4,11 @@ import {
   EXTENSION_BRIDGE_PROTOCOL_VERSION,
 } from '../../webapp/src/cdp/extension-bridge-protocol.js';
 import {
+  __clearWelcomedLeaderPortsForTest,
   BRIDGE_ALLOWED_ORIGINS,
   type BridgeSwDeps,
   handleBridgePortConnect,
+  postLickToWelcomedLeaderPorts,
   validateBridgePin,
 } from '../src/bridge-sw.js';
 
@@ -547,6 +549,76 @@ describe('handleBridgePortConnect — synchronous listener (MV3 Port race)', () 
     expect(port.disconnectListenerAttachedAt).not.toBeNull();
 
     await connectPromise;
+  });
+});
+
+describe('postLickToWelcomedLeaderPorts — handoff lick forwarding', () => {
+  beforeEach(() => {
+    __clearWelcomedLeaderPortsForTest();
+  });
+
+  async function welcome(channelId: string): Promise<FakePort> {
+    const port = makePort(EXTENSION_BRIDGE_PORT_NAME, goodSender);
+    await handleBridgePortConnect(port as never, makeDeps());
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId,
+      kind: 'handshake.hello',
+    });
+    return port;
+  }
+
+  it('posts the lick envelope to a welcomed port, stamped with its channelId', async () => {
+    const port = await welcome('bridge-abc');
+    const delivered = postLickToWelcomedLeaderPorts({
+      kind: 'extension.lick',
+      verb: 'handoff',
+      target: 'do the thing',
+      url: 'https://example.com/',
+      instruction: 'do the thing',
+    });
+    expect(delivered).toBe(1);
+    const lick = port.posted.find((m) => (m as { kind?: string }).kind === 'extension.lick');
+    expect(lick).toEqual({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'bridge-abc',
+      kind: 'extension.lick',
+      verb: 'handoff',
+      target: 'do the thing',
+      url: 'https://example.com/',
+      instruction: 'do the thing',
+    });
+  });
+
+  it('does not post to a disconnected port (evicted from the registry)', async () => {
+    const port = await welcome('bridge-gone');
+    port.triggerDisconnect();
+    const delivered = postLickToWelcomedLeaderPorts({
+      kind: 'extension.lick',
+      verb: 'handoff',
+      target: 'late',
+      url: 'https://example.com/late',
+    });
+    expect(delivered).toBe(0);
+    const lick = port.posted.find((m) => (m as { kind?: string }).kind === 'extension.lick');
+    expect(lick).toBeUndefined();
+  });
+
+  it('stamps each welcomed port with its own channelId', async () => {
+    const portA = await welcome('chan-a');
+    const portB = await welcome('chan-b');
+    const delivered = postLickToWelcomedLeaderPorts({
+      kind: 'extension.lick',
+      verb: 'upskill',
+      target: 'https://github.com/acme/skill',
+      url: 'https://github.com/acme/skill',
+      branch: 'main',
+    });
+    expect(delivered).toBe(2);
+    const lickA = portA.posted.find((m) => (m as { kind?: string }).kind === 'extension.lick');
+    const lickB = portB.posted.find((m) => (m as { kind?: string }).kind === 'extension.lick');
+    expect((lickA as { channelId: string }).channelId).toBe('chan-a');
+    expect((lickB as { channelId: string }).channelId).toBe('chan-b');
   });
 });
 

--- a/packages/webapp/src/cdp/extension-bridge-protocol.ts
+++ b/packages/webapp/src/cdp/extension-bridge-protocol.ts
@@ -75,13 +75,34 @@ export interface ExtensionBridgeCdpEvent {
   sessionId?: string;
 }
 
+/**
+ * Navigate/upskill lick pushed SW → leader tab. The SW observes a SLICC
+ * handoff `Link` header (`chrome.webRequest.onHeadersReceived`) and forwards
+ * it over the welcomed Port so the leader can inject it into the worker-side
+ * `LickManager`. The payload mirrors `dispatchNavigateEvent`'s fields in
+ * `scoops/lick-ws-bridge.ts` (the standalone `/licks-ws` navigate shape).
+ */
+export interface ExtensionBridgeLick {
+  bridge: typeof EXTENSION_BRIDGE_PROTOCOL_VERSION;
+  channelId: string;
+  kind: 'extension.lick';
+  verb: 'handoff' | 'upskill';
+  target: string;
+  url: string;
+  instruction?: string;
+  branch?: string;
+  path?: string;
+  title?: string;
+}
+
 export type ExtensionBridgeEnvelope =
   | ExtensionBridgeHello
   | ExtensionBridgeWelcome
   | ExtensionBridgeRejected
   | ExtensionBridgeCdpRequest
   | ExtensionBridgeCdpResponse
-  | ExtensionBridgeCdpEvent;
+  | ExtensionBridgeCdpEvent
+  | ExtensionBridgeLick;
 
 const KINDS = new Set<ExtensionBridgeEnvelope['kind']>([
   'handshake.hello',
@@ -90,6 +111,7 @@ const KINDS = new Set<ExtensionBridgeEnvelope['kind']>([
   'cdp.request',
   'cdp.response',
   'cdp.event',
+  'extension.lick',
 ]);
 
 /**

--- a/packages/webapp/src/cdp/extension-bridge-transport.ts
+++ b/packages/webapp/src/cdp/extension-bridge-transport.ts
@@ -28,6 +28,7 @@ import {
   EXTENSION_BRIDGE_PORT_NAME,
   EXTENSION_BRIDGE_PROTOCOL_VERSION,
   type ExtensionBridgeEnvelope,
+  type ExtensionBridgeLick,
   isExtensionBridgeEnvelope,
 } from './extension-bridge-protocol.js';
 import type { CDPConnectOptions } from './types.js';
@@ -56,6 +57,15 @@ export interface ExtensionBridgeTransportOptions {
   connect?: (extensionId: string, info: { name: string }) => ExtensionBridgePort;
   /** Handshake timeout in ms. Defaults to 10000. */
   handshakeTimeoutMs?: number;
+  /**
+   * Optional sink for `extension.lick` envelopes pushed SW → leader tab. The
+   * SW observes a SLICC handoff `Link` header and forwards it over the
+   * welcomed Port; this fires (channelId-matched) for each such envelope so
+   * the leader bootstrap can inject a navigate `LickEvent` into the worker
+   * `LickManager`. CDP plumbing is untouched — lick envelopes never reach the
+   * CDP bridge's response/event parse path.
+   */
+  onLick?: (lick: ExtensionBridgeLick) => void;
 }
 
 const DEFAULT_HANDSHAKE_TIMEOUT = 10000;
@@ -209,6 +219,10 @@ export class ExtensionBridgeTransport extends CdpTransportBridge {
       log.warn('Extension bridge handshake rejected', { reason: env.reason });
       this.rejectWelcome?.(new Error(`Extension bridge handshake rejected: ${env.reason}`));
       this.cleanupHandshake();
+      return;
+    }
+    if (env.kind === 'extension.lick') {
+      this.bridgeOpts.onLick?.(env);
     }
   }
 

--- a/packages/webapp/src/scoops/lick-ws-bridge.ts
+++ b/packages/webapp/src/scoops/lick-ws-bridge.ts
@@ -27,7 +27,7 @@
  */
 import { createLogger } from '../core/logger.js';
 import { getLickWebSocketUrl, getTrayWebhookUrl, getWebhookUrl } from '../ui/runtime-mode.js';
-import type { LickManager } from './lick-manager.js';
+import type { LickEvent, LickManager } from './lick-manager.js';
 import { getLeaderStatusWithFallback, getLeaderTrayRuntimeStatus } from './tray-leader.js';
 
 const log = createLogger('lick-ws-bridge');
@@ -319,34 +319,47 @@ function dispatchWebhookEvent(lickManager: LickManager, data: RequestMessage): v
   }
 }
 
-function dispatchNavigateEvent(lickManager: LickManager, data: RequestMessage): void {
-  // Payload mirrors `packages/node-server/src/index.ts` POST
-  // /api/handoff — `{ verb, target, instruction?, url, title?,
-  // branch?, path? }` (RFC 8288 Link shape). The older `sliccHeader`
-  // envelope is no longer emitted.
+/**
+ * Map a navigate payload onto a navigate `LickEvent`, or `null` when the
+ * payload lacks the structured handoff fields. The payload shape mirrors
+ * `packages/node-server/src/index.ts` POST /api/handoff — `{ verb, target,
+ * instruction?, url, title?, branch?, path? }` (RFC 8288 Link shape). Shared
+ * with the extension-bridge leader path so both navigate sources validate +
+ * build the event body identically (the older `sliccHeader` envelope is no
+ * longer emitted).
+ */
+export function mapNavigatePayloadToLickEvent(data: Record<string, unknown>): LickEvent | null {
   const verb = typeof data.verb === 'string' ? data.verb : null;
   const target = typeof data.target === 'string' ? data.target : null;
   const navUrl = typeof data.url === 'string' && data.url.length > 0 ? data.url : null;
   if ((verb !== 'handoff' && verb !== 'upskill') || !target || !navUrl) {
-    log.debug('navigate_event dropped — invalid payload', {
-      hasVerb: !!verb,
-      hasTarget: !!target,
-      hasUrl: !!navUrl,
-    });
-    return;
+    return null;
   }
   const body: Record<string, unknown> = { url: navUrl, verb, target };
   if (typeof data.instruction === 'string') body.instruction = data.instruction;
   if (typeof data.branch === 'string') body.branch = data.branch;
   if (typeof data.path === 'string') body.path = data.path;
   if (typeof data.title === 'string') body.title = data.title;
-  lickManager.emitEvent({
+  return {
     type: 'navigate',
     navigateUrl: navUrl,
     targetScoop: undefined,
     timestamp: typeof data.timestamp === 'string' ? data.timestamp : new Date().toISOString(),
     body,
-  });
+  };
+}
+
+function dispatchNavigateEvent(lickManager: LickManager, data: RequestMessage): void {
+  const event = mapNavigatePayloadToLickEvent(data);
+  if (!event) {
+    log.debug('navigate_event dropped — invalid payload', {
+      hasVerb: typeof data.verb === 'string',
+      hasTarget: typeof data.target === 'string',
+      hasUrl: typeof data.url === 'string' && data.url.length > 0,
+    });
+    return;
+  }
+  lickManager.emitEvent(event);
 }
 
 async function handleLickRequest(

--- a/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
@@ -23,6 +23,7 @@ import {
 } from '../../../../chrome-extension/src/messages.js';
 import type { CherryHostTransport } from '../../cdp/cherry-host-transport.js';
 import type { BrowserAPI, CDPTransport } from '../../cdp/index.js';
+import type { LickEvent } from '../../scoops/lick-manager.js';
 import {
   DEFAULT_PRODUCTION_TRAY_WORKER_BASE_URL,
   DEFAULT_STAGING_TRAY_WORKER_BASE_URL,
@@ -46,6 +47,15 @@ export interface StandalonePreludeDeps {
   envBaseUrl: string | null;
   window: Window;
   log: BootStageLogger;
+}
+
+/**
+ * Minimal page→worker seam the extension-bridge lick handler depends on —
+ * the `OffscreenClient.sendForwardedLick` method that relays a navigate lick
+ * into the worker-resident `LickManager` (the same path the tray leader uses).
+ */
+export interface LickForwardingClient {
+  sendForwardedLick(event: LickEvent): void;
 }
 
 export interface StandalonePreludeResult {
@@ -88,6 +98,16 @@ export interface StandalonePreludeResult {
    * the page. `null` outside the thin-bridge extension leader.
    */
   extensionDelegateId: string | null;
+  /**
+   * Late-binds the kernel client that injects extension-bridge licks into the
+   * worker `LickManager`. Set ONLY on the extension-leader CDP path: the
+   * bridge transport (and its `onLick` handler) is constructed here, before
+   * `spawnKernelWorker` mints the client, so the caller calls this once the
+   * client exists. `undefined` on every other path (no extension bridge → no
+   * lick seam). No new `chrome.runtime` listener is involved — the lick
+   * arrives on the existing welcomed bridge Port.
+   */
+  attachLickForwardingClient?: (client: LickForwardingClient) => void;
 }
 
 function mintInstanceId(): string {
@@ -161,6 +181,44 @@ export async function connectWithBoundedRetry(
   );
 }
 
+/**
+ * Build the extension-leader `BrowserAPI` over an `ExtensionBridgeTransport`
+ * and wire its `onLick` sink. The kernel client that owns the page→worker
+ * inject seam doesn't exist yet (`spawnKernelWorker` runs after the prelude),
+ * so the `onLick` closure reads a deferred slot the caller late-binds via the
+ * returned `attachLickForwardingClient`. The lick rides the existing welcomed
+ * bridge Port — no new `chrome.runtime` listener is added to the webapp. The
+ * standalone `/licks-ws` navigate mapping is reused so the handoff-approval /
+ * upskill-actionable behavior matches that path.
+ */
+async function createExtensionLeaderBrowser(
+  BrowserAPICtor: new (transport?: CDPTransport) => BrowserAPI,
+  extensionId: string,
+  log: BootStageLogger
+): Promise<{
+  browser: BrowserAPI;
+  attachLickForwardingClient: (client: LickForwardingClient) => void;
+}> {
+  const { ExtensionBridgeTransport } = await import('../../cdp/extension-bridge-transport.js');
+  const { mapNavigatePayloadToLickEvent } = await import('../../scoops/lick-ws-bridge.js');
+  const lickClientHolder: { client: LickForwardingClient | null } = { client: null };
+  const attachLickForwardingClient = (client: LickForwardingClient): void => {
+    lickClientHolder.client = client;
+  };
+  const browser = new BrowserAPICtor(
+    new ExtensionBridgeTransport({
+      extensionId,
+      onLick: (lick) => {
+        const event = mapNavigatePayloadToLickEvent(lick as unknown as Record<string, unknown>);
+        if (!event) return;
+        lickClientHolder.client?.sendForwardedLick(event);
+      },
+    })
+  );
+  await connectWithBoundedRetry(browser, undefined, log);
+  return { browser, attachLickForwardingClient };
+}
+
 export async function setupStandalonePrelude(
   deps: StandalonePreludeDeps
 ): Promise<StandalonePreludeResult> {
@@ -179,6 +237,7 @@ export async function setupStandalonePrelude(
   let bridgeToken: string | null = null;
   let localLickWsUrl: string | null = null;
   let extensionDelegateId: string | null = null;
+  let attachLickForwardingClient: ((client: LickForwardingClient) => void) | undefined;
   const extLeader =
     runtimeMode === 'cherry' ? null : parseExtensionLeaderParams(win.location.search);
 
@@ -242,9 +301,9 @@ export async function setupStandalonePrelude(
     cherryTransport = cherry.transport;
   } else if (extLeader && hasChromeRuntimeConnect()) {
     log.info('Routing CDP through the extension bridge (leader tab)');
-    const { ExtensionBridgeTransport } = await import('../../cdp/extension-bridge-transport.js');
-    browser = new BrowserAPI(new ExtensionBridgeTransport({ extensionId: extLeader.extensionId }));
-    await connectWithBoundedRetry(browser, undefined, log);
+    const leader = await createExtensionLeaderBrowser(BrowserAPI, extLeader.extensionId, log);
+    browser = leader.browser;
+    attachLickForwardingClient = leader.attachLickForwardingClient;
     // Thin-bridge: this page realm can `chrome.runtime.connect(<extensionId>)`
     // to the extension's fetch-proxy. Record the id locally (set on the page
     // realm + forwarded to the kernel worker) so cross-origin shell fetches
@@ -313,5 +372,6 @@ export async function setupStandalonePrelude(
     bridgeToken,
     localLickWsUrl,
     extensionDelegateId,
+    attachLickForwardingClient,
   };
 }

--- a/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
@@ -201,9 +201,22 @@ async function createExtensionLeaderBrowser(
 }> {
   const { ExtensionBridgeTransport } = await import('../../cdp/extension-bridge-transport.js');
   const { mapNavigatePayloadToLickEvent } = await import('../../scoops/lick-ws-bridge.js');
-  const lickClientHolder: { client: LickForwardingClient | null } = { client: null };
+  // The kernel client that injects licks into the worker `LickManager` is
+  // late-bound — `spawnKernelWorker` mints it after this prelude returns. Until
+  // it attaches, buffer mapped licks in arrival order instead of dropping them,
+  // then flush once on attach (closing the pre-attach drop window). The buffer
+  // is bounded so a page re-advertising the same `Link` header on every response
+  // during a stuck boot can't grow it unboundedly; on overflow the OLDEST entry
+  // is dropped with a single warn. Dedup is still handled downstream by the
+  // worker's `navigateFingerprint`, so none is done here.
+  const PENDING_LICK_CAP = 50;
+  let lickClient: LickForwardingClient | null = null;
+  const pendingLicks: LickEvent[] = [];
+  let overflowWarned = false;
   const attachLickForwardingClient = (client: LickForwardingClient): void => {
-    lickClientHolder.client = client;
+    lickClient = client;
+    for (const event of pendingLicks) client.sendForwardedLick(event);
+    pendingLicks.length = 0;
   };
   const browser = new BrowserAPICtor(
     new ExtensionBridgeTransport({
@@ -211,7 +224,20 @@ async function createExtensionLeaderBrowser(
       onLick: (lick) => {
         const event = mapNavigatePayloadToLickEvent(lick as unknown as Record<string, unknown>);
         if (!event) return;
-        lickClientHolder.client?.sendForwardedLick(event);
+        if (lickClient) {
+          lickClient.sendForwardedLick(event);
+          return;
+        }
+        if (pendingLicks.length >= PENDING_LICK_CAP) {
+          pendingLicks.shift();
+          if (!overflowWarned) {
+            overflowWarned = true;
+            log.warn(
+              `extension-bridge lick buffer overflow (cap ${PENDING_LICK_CAP}); dropping oldest pending licks until the kernel client attaches`
+            );
+          }
+        }
+        pendingLicks.push(event);
       },
     })
   );

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1440,6 +1440,7 @@ export async function mountWcUiLive(
     bridgeToken,
     localLickWsUrl,
     extensionDelegateId,
+    attachLickForwardingClient,
   } = await setupStandalonePrelude({
     runtimeMode,
     envBaseUrl: import.meta.env.VITE_WORKER_BASE_URL ?? null,
@@ -1468,6 +1469,10 @@ export async function mountWcUiLive(
     extensionDelegateId,
   });
   installPageStorageSync({ send: (m) => host.client.sendRaw(m) });
+  // Extension-leader path only: late-bind the now-minted kernel client into the
+  // extension-bridge `onLick` handler so forwarded handoff/upskill licks reach
+  // the worker `LickManager`. No-op on every other CDP path.
+  attachLickForwardingClient?.(host.client);
   attachWcClient(boot, host.client, log, {
     instanceId,
     standalone: {

--- a/packages/webapp/tests/cdp/extension-bridge-protocol.test.ts
+++ b/packages/webapp/tests/cdp/extension-bridge-protocol.test.ts
@@ -20,6 +20,26 @@ describe('extension-bridge-protocol', () => {
       { bridge: 1, channelId: ch, kind: 'cdp.request', id: 1, method: 'X' },
       { bridge: 1, channelId: ch, kind: 'cdp.response', id: 1 },
       { bridge: 1, channelId: ch, kind: 'cdp.event', method: 'X' },
+      {
+        bridge: 1,
+        channelId: ch,
+        kind: 'extension.lick',
+        verb: 'handoff',
+        target: 'sliccy.ai',
+        url: 'https://www.sliccy.ai/handoff?handoff=do%20a%20thing',
+      },
+      {
+        bridge: 1,
+        channelId: ch,
+        kind: 'extension.lick',
+        verb: 'upskill',
+        target: 'github.com/owner/repo',
+        url: 'https://www.sliccy.ai/handoff?upskill=https://github.com/owner/repo',
+        instruction: 'install this skill',
+        branch: 'main',
+        path: 'skills/foo',
+        title: 'Foo skill',
+      },
     ];
     for (const env of kinds) {
       expect(isExtensionBridgeEnvelope(env)).toBe(true);
@@ -42,6 +62,27 @@ describe('extension-bridge-protocol', () => {
     expect(isExtensionBridgeEnvelope({ bridge: 1, channelId: 42, kind: 'handshake.hello' })).toBe(
       false
     );
+    // Lick with wrong protocol version.
+    expect(
+      isExtensionBridgeEnvelope({
+        bridge: 99,
+        channelId: 'x',
+        kind: 'extension.lick',
+        verb: 'handoff',
+        target: 't',
+        url: 'u',
+      })
+    ).toBe(false);
+    // Lick missing channelId.
+    expect(
+      isExtensionBridgeEnvelope({
+        bridge: 1,
+        kind: 'extension.lick',
+        verb: 'handoff',
+        target: 't',
+        url: 'u',
+      })
+    ).toBe(false);
   });
 
   it('rejects envelopes that look almost right (Cherry envelopes)', () => {

--- a/packages/webapp/tests/cdp/extension-bridge-transport.test.ts
+++ b/packages/webapp/tests/cdp/extension-bridge-transport.test.ts
@@ -213,6 +213,48 @@ describe('ExtensionBridgeTransport', () => {
     expect(received).toEqual([]);
   });
 
+  it('invokes onLick with a channelId-matched extension.lick envelope', async () => {
+    const licks: unknown[] = [];
+    const onLick = vi.fn((lick: unknown) => licks.push(lick));
+    const t = new ExtensionBridgeTransport({
+      extensionId: 'fake-ext-id',
+      connect: () => port,
+      onLick,
+    });
+    const channelId = await connect(t, port);
+    const envelope = {
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId,
+      kind: 'extension.lick' as const,
+      verb: 'handoff' as const,
+      target: 'https://github.com/acme/repo',
+      url: 'https://www.sliccy.ai/handoff?handoff=fix+the+bug',
+      instruction: 'fix the bug',
+    };
+    t.__test_receive(envelope);
+    expect(onLick).toHaveBeenCalledTimes(1);
+    expect(licks[0]).toEqual(envelope);
+  });
+
+  it('drops an extension.lick envelope whose channelId does not match', async () => {
+    const onLick = vi.fn();
+    const t = new ExtensionBridgeTransport({
+      extensionId: 'fake-ext-id',
+      connect: () => port,
+      onLick,
+    });
+    await connect(t, port);
+    t.__test_receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'other-bridge',
+      kind: 'extension.lick',
+      verb: 'upskill',
+      target: 'https://github.com/acme/skill',
+      url: 'https://www.sliccy.ai/handoff?upskill=https://github.com/acme/skill',
+    });
+    expect(onLick).not.toHaveBeenCalled();
+  });
+
   it('disconnect() tears down the port and the bridge state', async () => {
     await connect(transport, port);
     transport.disconnect();

--- a/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
@@ -217,6 +217,80 @@ describe('setupStandalonePrelude — extension leader transport selection', () =
     expect(result.realCdpTransport).toBeInstanceOf(ExtensionBridgeTransport);
     expect(result.browser).toBeDefined();
   });
+
+  it('forwards an extension.lick into the late-bound client inject seam as a navigate LickEvent', async () => {
+    // Capture the live port listeners + the channelId the transport minted so
+    // the test can push an `extension.lick` envelope down the welcomed Port.
+    const listeners: Array<(msg: unknown) => void> = [];
+    let channelId: string | undefined;
+    const connect = vi.fn((_extensionId: string, _info: { name: string }): FakeBridgePort => {
+      return {
+        postMessage: (msg: unknown) => {
+          const env = msg as { kind?: string; channelId?: string };
+          if (env?.kind === 'handshake.hello') {
+            channelId = env.channelId;
+            queueMicrotask(() => {
+              for (const l of listeners) {
+                l({
+                  bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+                  channelId: env.channelId,
+                  kind: 'handshake.welcome',
+                });
+              }
+            });
+          }
+        },
+        disconnect: vi.fn(),
+        onMessage: {
+          addListener: (cb: (msg: unknown) => void) => {
+            listeners.push(cb);
+          },
+        },
+        onDisconnect: { addListener: () => {} },
+      };
+    });
+    (globalThis as { chrome?: unknown }).chrome = { runtime: { connect } };
+
+    const result = await setupStandalonePrelude({
+      runtimeMode: 'standalone',
+      envBaseUrl: null,
+      window: createFakeWindow('?slicc=leader&ext=test-ext-id'),
+      log: createLog(),
+    });
+
+    // Late-bind the kernel client (minted after the prelude in real boot).
+    const forwarded: unknown[] = [];
+    expect(result.attachLickForwardingClient).toBeDefined();
+    result.attachLickForwardingClient?.({
+      sendForwardedLick: (event) => forwarded.push(event),
+    });
+
+    // Push a handoff lick down the (welcomed) Port — channelId-matched.
+    expect(channelId).toBeDefined();
+    for (const l of listeners) {
+      l({
+        bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+        channelId,
+        kind: 'extension.lick',
+        verb: 'handoff',
+        target: 'https://github.com/acme/repo',
+        url: 'https://www.sliccy.ai/handoff?handoff=fix+the+bug',
+        instruction: 'fix the bug',
+      });
+    }
+
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0]).toMatchObject({
+      type: 'navigate',
+      navigateUrl: 'https://www.sliccy.ai/handoff?handoff=fix+the+bug',
+      body: {
+        verb: 'handoff',
+        target: 'https://github.com/acme/repo',
+        url: 'https://www.sliccy.ai/handoff?handoff=fix+the+bug',
+        instruction: 'fix the bug',
+      },
+    });
+  });
 });
 
 describe('setupStandalonePrelude — thin-bridge runtime-config origin', () => {

--- a/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
@@ -291,6 +291,90 @@ describe('setupStandalonePrelude — extension leader transport selection', () =
       },
     });
   });
+
+  it('buffers extension.licks delivered BEFORE the client attaches and flushes them in order on attach', async () => {
+    const listeners: Array<(msg: unknown) => void> = [];
+    let channelId: string | undefined;
+    const connect = vi.fn((_extensionId: string, _info: { name: string }): FakeBridgePort => {
+      return {
+        postMessage: (msg: unknown) => {
+          const env = msg as { kind?: string; channelId?: string };
+          if (env?.kind === 'handshake.hello') {
+            channelId = env.channelId;
+            queueMicrotask(() => {
+              for (const l of listeners) {
+                l({
+                  bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+                  channelId: env.channelId,
+                  kind: 'handshake.welcome',
+                });
+              }
+            });
+          }
+        },
+        disconnect: vi.fn(),
+        onMessage: {
+          addListener: (cb: (msg: unknown) => void) => {
+            listeners.push(cb);
+          },
+        },
+        onDisconnect: { addListener: () => {} },
+      };
+    });
+    (globalThis as { chrome?: unknown }).chrome = { runtime: { connect } };
+
+    const result = await setupStandalonePrelude({
+      runtimeMode: 'standalone',
+      envBaseUrl: null,
+      window: createFakeWindow('?slicc=leader&ext=test-ext-id'),
+      log: createLog(),
+    });
+
+    expect(result.attachLickForwardingClient).toBeDefined();
+    expect(channelId).toBeDefined();
+
+    // Two licks arrive on the welcomed Port BEFORE the kernel client attaches.
+    const pushLick = (target: string, instruction: string): void => {
+      const url = `https://www.sliccy.ai/handoff?handoff=${encodeURIComponent(instruction)}`;
+      for (const l of listeners) {
+        l({
+          bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+          channelId,
+          kind: 'extension.lick',
+          verb: 'handoff',
+          target,
+          url,
+          instruction,
+        });
+      }
+    };
+    pushLick('https://github.com/acme/first', 'first');
+    pushLick('https://github.com/acme/second', 'second');
+
+    // Late-bind the kernel client — buffered licks flush in arrival order.
+    const forwarded: unknown[] = [];
+    result.attachLickForwardingClient?.({
+      sendForwardedLick: (event) => forwarded.push(event),
+    });
+
+    expect(forwarded).toHaveLength(2);
+    expect(forwarded[0]).toMatchObject({
+      type: 'navigate',
+      body: { target: 'https://github.com/acme/first', instruction: 'first' },
+    });
+    expect(forwarded[1]).toMatchObject({
+      type: 'navigate',
+      body: { target: 'https://github.com/acme/second', instruction: 'second' },
+    });
+
+    // A lick after attach forwards synchronously (no second flush).
+    pushLick('https://github.com/acme/third', 'third');
+    expect(forwarded).toHaveLength(3);
+    expect(forwarded[2]).toMatchObject({
+      type: 'navigate',
+      body: { target: 'https://github.com/acme/third', instruction: 'third' },
+    });
+  });
 });
 
 describe('setupStandalonePrelude — thin-bridge runtime-config origin', () => {


### PR DESCRIPTION
Fixes #1127.

## Problem

In the thin-extension float (PR #1085), the service worker observes a SLICC handoff `Link` header on main-frame responses and emits a `navigate-lick` via `chrome.runtime.sendMessage`. But the hosted leader tab is a regular web page and **cannot receive `chrome.runtime.sendMessage`**, so the navigate/upskill lick never reached `LickManager`. The handoff toast fired, but the agent was never woken.

## Fix

Route the lick over the **existing authenticated bridge Port** the leader already opens for CDP pass-through, instead of an unreachable broadcast.

| Layer | Change |
|-------|--------|
| **Protocol** | Added an additive `extension.lick` envelope kind to `extension-bridge-protocol.ts` (no protocol-version bump). |
| **SW forward** | `bridge-sw.ts` now tracks welcomed leader Ports (Port→channelId) and `postLickToWelcomedLeaderPorts()`; the `onHeadersReceived` handoff observer posts the lick over the live Port. |
| **Leader receive** | `extension-bridge-transport.ts` gained a channelId-matched `onLick` callback; `setup-standalone-prelude.ts` maps and injects via the existing `sendForwardedLick` seam, late-bound to the kernel client (no new always-on `chrome.runtime.onMessage` listener on the hosted page). |

**Delivered path:** SW handoff `Link` header → `extension.lick` over the bridge Port → leader validates channelId + fires `onLick` → shared `mapNavigatePayloadToLickEvent` → `sendForwardedLick` → `inject-forwarded-lick` → `LickManager.emitEvent`.

Field parity, `navigateFingerprint` duplicate suppression, and handoff-vs-upskill verb routing are all preserved end-to-end. An audit confirmed no other SW→leader payload is unwired — this was an isolated gap.

## Validation

- Validated live end-to-end in the `dev:extension:fresh` harness: a handoff `Link` header now surfaces as a navigate lick in the leader agent UI.
- `npm run typecheck` ✅ · `npm run test` ✅ (9411 tests) · `npm run lint` ✅
- Targeted tests added: `bridge-sw`, `extension-bridge-protocol`, `extension-bridge-transport`, `setup-standalone-prelude`.

## Notes

Dev-harness hardening (self-building the leader UI + a more robust wrangler probe) is intentionally **excluded** from this PR and will follow in a separate PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author