### PR TITLE
fix(webcomponents): cache shader programs per mode + immediate repaint to kill cone↔freezer blue flicker

### DIFF
--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -201,6 +201,15 @@ function clampNum(v: number, lo: number, hi: number, fb: number): number {
   return Number.isFinite(v) ? Math.max(lo, Math.min(hi, v)) : fb;
 }
 
+/** A compiled+linked program kept per mode so a switch never recompiles. */
+interface CachedProgram {
+  program: WebGLProgram;
+  vs: WebGLShader;
+  fs: WebGLShader;
+  aPos: number;
+  loc: Partial<Record<UniformName, WebGLUniformLocation | null>>;
+}
+
 /** Parse a CSS color via getComputedStyle into a 0..1 rgb triple. */
 function colorToVec3(css: string, fallback: [number, number, number]): [number, number, number] {
   if (!css || typeof getComputedStyle !== 'function') return fallback;
@@ -232,6 +241,8 @@ export class SliccShader extends HTMLElement {
   #canvas: HTMLCanvasElement | null = null;
   #gl: WebGLRenderingContext | null = null;
   #program: WebGLProgram | null = null;
+  /** Compiled+linked program per mode — built once, reused on every switch. */
+  #programs: Partial<Record<ShaderMode, CachedProgram>> = {};
   #buffer: WebGLBuffer | null = null;
   #loc: Partial<Record<UniformName, WebGLUniformLocation | null>> = {};
   #aPos = -1;
@@ -241,6 +252,8 @@ export class SliccShader extends HTMLElement {
   #ro: ResizeObserver | null = null;
   #reduced = false;
   #builtMode: ShaderMode | null = null;
+  #onContextLost: ((e: Event) => void) | null = null;
+  #onContextRestored: (() => void) | null = null;
 
   constructor() {
     super();
@@ -280,7 +293,13 @@ export class SliccShader extends HTMLElement {
   attributeChangedCallback(name: string): void {
     if (!this.isConnected) return;
     if (name === 'mode' && this.#gl && this.mode !== this.#builtMode) {
-      this.#linkMode();
+      // Switch to the (cached) program and repaint synchronously so the
+      // previous mode's frame does not linger for a rAF — the blue flicker.
+      if (this.#linkMode()) {
+        this.#renderFrame();
+        this.#applyFallbackBg();
+        return;
+      }
     }
     this.#applyFallbackBg();
     this.#renderIfStatic();
@@ -392,25 +411,59 @@ export class SliccShader extends HTMLElement {
     return s;
   }
 
+  /** Compile + link a fresh program for a mode (no caching, no activation). */
+  #buildProgram(mode: ShaderMode): CachedProgram | null {
+    const gl = this.#gl;
+    if (!gl) return null;
+    const vs = this.#compile(gl, gl.VERTEX_SHADER, VERT);
+    const fs = this.#compile(gl, gl.FRAGMENT_SHADER, PROGRAMS[mode]);
+    if (!vs || !fs) {
+      if (vs) gl.deleteShader(vs);
+      if (fs) gl.deleteShader(fs);
+      return null;
+    }
+    const program = gl.createProgram();
+    if (!program) {
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
+      return null;
+    }
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      gl.deleteProgram(program);
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
+      return null;
+    }
+    const aPos = gl.getAttribLocation(program, 'a_pos');
+    const loc: Partial<Record<UniformName, WebGLUniformLocation | null>> = {};
+    for (const u of UNIFORMS) loc[u] = gl.getUniformLocation(program, u);
+    return { program, vs, fs, aPos, loc };
+  }
+
+  /**
+   * Activate the program for the current mode, building it once and caching it.
+   * Revisiting a mode reuses the cached program — no recompile/relink — and just
+   * refreshes the active program + uniform locations.
+   */
   #linkMode(): boolean {
     const gl = this.#gl;
     if (!gl) return false;
-    const vs = this.#compile(gl, gl.VERTEX_SHADER, VERT);
-    const fs = this.#compile(gl, gl.FRAGMENT_SHADER, PROGRAMS[this.mode]);
-    if (!vs || !fs) return false;
-    const prog = gl.createProgram();
-    if (!prog) return false;
-    gl.attachShader(prog, vs);
-    gl.attachShader(prog, fs);
-    gl.linkProgram(prog);
-    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) return false;
-    if (this.#program) gl.deleteProgram(this.#program);
-    this.#program = prog;
-    gl.useProgram(prog);
-    this.#aPos = gl.getAttribLocation(prog, 'a_pos');
-    this.#loc = {};
-    for (const u of UNIFORMS) this.#loc[u] = gl.getUniformLocation(prog, u);
-    this.#builtMode = this.mode;
+    const mode = this.mode;
+    let cached = this.#programs[mode];
+    if (!cached) {
+      const built = this.#buildProgram(mode);
+      if (!built) return false;
+      this.#programs[mode] = built;
+      cached = built;
+    }
+    this.#program = cached.program;
+    this.#aPos = cached.aPos;
+    this.#loc = cached.loc;
+    gl.useProgram(cached.program);
+    this.#builtMode = mode;
     return true;
   }
 
@@ -427,6 +480,14 @@ export class SliccShader extends HTMLElement {
     }
     if (!gl) return false;
     this.#gl = gl;
+    this.#installContextHandlers(cv);
+    return this.#setupGlResources();
+  }
+
+  /** Link the active mode and (re)build the fullscreen-triangle buffer. */
+  #setupGlResources(): boolean {
+    const gl = this.#gl;
+    if (!gl) return false;
     if (!this.#linkMode()) {
       this.#gl = null;
       return false;
@@ -440,6 +501,42 @@ export class SliccShader extends HTMLElement {
     gl.bindBuffer(gl.ARRAY_BUFFER, buf);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
     return true;
+  }
+
+  /**
+   * On context loss the cached programs/shaders/buffer are invalid GPU handles,
+   * so drop the whole cache; on restore the same context is reusable, so relink
+   * (rebuilding the cache lazily) and resume the loop.
+   */
+  #installContextHandlers(cv: HTMLCanvasElement): void {
+    this.#removeContextHandlers(cv);
+    this.#onContextLost = (e: Event) => {
+      e.preventDefault();
+      this.#stopLoop();
+      this.#programs = {};
+      this.#program = null;
+      this.#builtMode = null;
+      this.#loc = {};
+      this.#buffer = null;
+    };
+    this.#onContextRestored = () => {
+      if (!this.isConnected || !this.#gl) return;
+      this.#programs = {};
+      if (!this.#setupGlResources()) return;
+      this.#start = performance.now() / 1000;
+      if (this.#reduced) this.#renderFrame();
+      else this.#startLoop();
+    };
+    cv.addEventListener('webglcontextlost', this.#onContextLost, false);
+    cv.addEventListener('webglcontextrestored', this.#onContextRestored, false);
+  }
+
+  #removeContextHandlers(cv: HTMLCanvasElement): void {
+    if (this.#onContextLost) cv.removeEventListener('webglcontextlost', this.#onContextLost);
+    if (this.#onContextRestored)
+      cv.removeEventListener('webglcontextrestored', this.#onContextRestored);
+    this.#onContextLost = null;
+    this.#onContextRestored = null;
   }
 
   #resize(): void {
@@ -537,13 +634,23 @@ export class SliccShader extends HTMLElement {
 
   #dispose(): void {
     const gl = this.#gl;
+    const cv = this.#canvas;
+    if (cv) this.#removeContextHandlers(cv);
     if (gl) {
       if (this.#buffer) gl.deleteBuffer(this.#buffer);
-      if (this.#program) gl.deleteProgram(this.#program);
+      // Free every cached program + its shaders, not just the active one.
+      for (const cached of Object.values(this.#programs)) {
+        if (!cached) continue;
+        gl.deleteProgram(cached.program);
+        gl.deleteShader(cached.vs);
+        gl.deleteShader(cached.fs);
+      }
       gl.getExtension('WEBGL_lose_context')?.loseContext();
     }
     this.#gl = null;
     this.#program = null;
+    this.#programs = {};
+    this.#loc = {};
     this.#buffer = null;
     this.#builtMode = null;
   }

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SHADER_FRAGMENTS, SliccShader } from '../../src/freezer/slicc-shader.js';
 import { ensureGlobalTokens } from '../../src/theme/tokens.js';
 
@@ -125,6 +125,68 @@ describe('slicc-shader', () => {
     );
     await frame();
     expect(() => el.remove()).not.toThrow();
+  });
+});
+
+describe('slicc-shader program cache + immediate repaint (anti-flicker)', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    document.body.replaceChildren();
+  });
+  afterEach(() => document.body.replaceChildren());
+
+  it('caches programs: revisiting a mode does NOT recompile or relink', async () => {
+    const compileSpy = vi.spyOn(WebGLRenderingContext.prototype, 'compileShader');
+    const createProgramSpy = vi.spyOn(WebGLRenderingContext.prototype, 'createProgram');
+    try {
+      const el = mount({ mode: 'cone' });
+      await frame();
+      if (el.noWebgl) return; // no WebGL in this runner — caching is N/A
+      // Cold visits: cone is built at init, scoop + freezer on switch. Each
+      // mode-set is synchronous, so all three programs are cached after this.
+      el.mode = 'scoop';
+      el.mode = 'freezer';
+      const coldCompiles = compileSpy.mock.calls.length;
+      const coldPrograms = createProgramSpy.mock.calls.length;
+      expect(coldPrograms).toBeGreaterThan(0); // we really did build programs
+      // Revisit every already-built mode — the cache must be reused.
+      el.mode = 'cone';
+      el.mode = 'scoop';
+      el.mode = 'freezer';
+      el.mode = 'cone';
+      expect(compileSpy.mock.calls.length).toBe(coldCompiles);
+      expect(createProgramSpy.mock.calls.length).toBe(coldPrograms);
+      el.remove();
+    } finally {
+      compileSpy.mockRestore();
+      createProgramSpy.mockRestore();
+    }
+  });
+
+  it('repaints immediately with the new program on a mode change (not deferred to rAF)', async () => {
+    const drawSpy = vi.spyOn(WebGLRenderingContext.prototype, 'drawArrays');
+    const useProgramSpy = vi.spyOn(WebGLRenderingContext.prototype, 'useProgram');
+    try {
+      const el = mount({ mode: 'cone' });
+      await frame();
+      if (el.noWebgl) return;
+      const drawsBefore = drawSpy.mock.calls.length;
+      const programBefore = useProgramSpy.mock.calls.at(-1)?.[0];
+      // Synchronous attribute change — read state in the SAME tick, before any
+      // requestAnimationFrame callback can fire.
+      el.mode = 'freezer';
+      // The canvas was repainted synchronously, so the old frame never lingers.
+      expect(drawSpy.mock.calls.length).toBeGreaterThan(drawsBefore);
+      // …and the new (freezer) program is the active one — a different handle.
+      const programAfter = useProgramSpy.mock.calls.at(-1)?.[0];
+      expect(programAfter).toBeTruthy();
+      expect(programAfter).not.toBe(programBefore);
+      expect(el.mode).toBe('freezer');
+      el.remove();
+    } finally {
+      drawSpy.mockRestore();
+      useProgramSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

When the background `<slicc-shader>` switches between modes (cone / scoop / freezer), the **blue of the freezer state lingers on screen for a few frames** before the new mode paints.

## Root cause (runtime-measured via CDP)

Two compounding bugs in `packages/webcomponents/src/freezer/slicc-shader.ts`:

1. **No program cache** — `#linkMode()` recompiled + relinked the GLSL program on *every* mode change. The cold compile blocks the main thread:

   | switch | ms |
   |--------|----|
   | → freezer (cold) | **40.1** |
   | → scoop (cold) | **17.8** |
   | → cone / warm | ~2 |

   During the ~40ms stall `requestAnimationFrame` cannot run, so the last-painted frame freezes on screen.

2. **Deferred repaint** — on a mode change in animated mode, `attributeChangedCallback` relinked but only called `#renderIfStatic()` (a no-op when animated), so the canvas wasn't repainted with the new program until the next rAF tick. The old program's last frame (blue freezer) lingered an extra frame.

## Fix

- **Cache the compiled+linked `WebGLProgram` per `ShaderMode`** (built once, reused on switch). Revisiting a mode is now a cached `useProgram` swap with no recompile/relink.
- **Repaint synchronously** (`#renderFrame()`) after a successful relink on a mode change, so the new program paints in the same task instead of showing the old blue frame.
- **Teardown safety**: `#dispose()` frees *all* cached programs and their shaders (not just the active one); `webglcontextlost`/`webglcontextrestored` handlers clear and rebuild the cache; listeners are removed on dispose.
- No change to the observation set, animation loop, uniforms, scroll/tint behavior, or the `no-webgl` fallback.

## Tests

Added 2 regression tests in `packages/webcomponents/tests/freezer/slicc-shader.test.ts`:
- switching to a mode, away, then back does **not** recompile (compile/createProgram call counts stay flat on revisit)
- a mode change triggers an **immediate** render with the new program (not deferred to rAF)

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test -w @slicc/webcomponents` ✅ (73 files / 1597 tests)

Scoped to 2 files. Separate from the switcher ResizeObserver fix (#1136).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author