### PR TITLE
feat: auth-aware error CTA + RUM instrumentation for unhandled error cards

### DIFF
--- a/packages/webapp/src/ui/provider-settings.ts
+++ b/packages/webapp/src/ui/provider-settings.ts
@@ -287,7 +287,10 @@ function buildAccountDetail(account: Account): HTMLDivElement {
   return detail;
 }
 
-async function reloginOAuthAccount(config: ProviderConfig, onDone: () => void): Promise<void> {
+export async function reloginOAuthAccount(
+  config: ProviderConfig,
+  onDone: () => void
+): Promise<void> {
   const { createOAuthLauncher, createInterceptingOAuthLauncherForCurrentRuntime } = await import(
     '../providers/oauth-service.js'
   );

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -13,12 +13,15 @@ import {
 } from '../../speech/dictation-priming.js';
 import { TOOL_UI_MOUNTED_ACTION } from '../../tools/tool-ui.js';
 import { type DipInstance, mountDip } from '../dip.js';
-import { trackChatSend } from '../telemetry.js';
+import { trackChatSend, trackError } from '../telemetry.js';
 import type { AgentEvent, AgentHandle, ChatMessage, ToolCall } from '../types.js';
 import { createCopyRow } from './wc-copy-row.js';
 import {
   collateLickMessages,
   daySeparatorEl,
+  isAuthExpiredError,
+  isInvalidModelError,
+  isNoApiKeyError,
   messageEls,
   reflowToolClusters,
   unwrapToolClusters,
@@ -707,6 +710,27 @@ export class WcChatController {
       timestamp: Date.now(),
       error: true,
     });
+    this.#emitErrorCardBeacon(error);
+  }
+
+  /**
+   * Best-effort RUM beacon for user-visible error cards that have NO dedicated
+   * handler (the default "Try again" variant). The handled families — no-api-key,
+   * invalid-model, auth-expired — own remediation UX and are user-fixable known
+   * states, so beaconing them would only add triage noise; we skip them. A
+   * distinct `'error-card'` source lets the nightly triage distinguish these
+   * from the agent-loop `'llm'`/`'tool'` beacons. Mirrors `#emitChatSendBeacon`'s
+   * fire-and-forget style — telemetry must never disrupt the error-render path.
+   */
+  #emitErrorCardBeacon(error: string): void {
+    try {
+      if (isNoApiKeyError(error) || isInvalidModelError(error) || isAuthExpiredError(error)) {
+        return;
+      }
+      trackError('error-card', error);
+    } catch {
+      // Telemetry must never block the error render.
+    }
   }
 
   /**

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -905,16 +905,31 @@ export function isInvalidModelError(content: string | null | undefined): boolean
 }
 
 /**
+ * Detect a cone failure caused by an expired/revoked auth session. The Adobe
+ * `getValidAccessToken` session-expired message ends with `please log in
+ * again`; the cone may wrap it with a `Scoop … failed with unrecoverable
+ * error: ` prefix, so match the substring case-insensitively rather than the
+ * whole string.
+ */
+export function isAuthExpiredError(content: string | null | undefined): boolean {
+  if (!content) return false;
+  return content.toLowerCase().includes('please log in again');
+}
+
+/**
  * `slicc-error-card` for a cone-error message. The card is purely
  * presentational; the chat controller listens for the bubbled
  * `slicc-error-retry` event to re-run the last user turn via its existing
- * agent send path. Two error families flip the CTA:
+ * agent send path. Three error families flip the CTA:
  * - "No API key configured" → `action="settings"`, fires
  *   `slicc-error-open-settings`; routed to the settings dialog by
  *   `wireWcNav` since the retry path would just re-hit the same missing key.
  * - Invalid-model errors → `action="change-model"`, fires
  *   `slicc-error-change-model`; routed to the composer model picker by
  *   `wireWcNav` so the user can pick a working model.
+ * - Auth-expired errors → `action="login"`, fires `slicc-error-login`; routed
+ *   to the connected provider's OAuth window by `wireWcNav` since the retry
+ *   path would just re-hit the same expired session.
  */
 function errorCardEl(message: ChatMessage): HTMLElement {
   const attrs: Record<string, string> = {
@@ -923,6 +938,7 @@ function errorCardEl(message: ChatMessage): HTMLElement {
   };
   if (isNoApiKeyError(message.content)) attrs.action = 'settings';
   else if (isInvalidModelError(message.content)) attrs.action = 'change-model';
+  else if (isAuthExpiredError(message.content)) attrs.action = 'login';
   return el('slicc-error-card', attrs);
 }
 

--- a/packages/webapp/src/ui/wc/wc-nav.ts
+++ b/packages/webapp/src/ui/wc/wc-nav.ts
@@ -240,7 +240,7 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
 
   // The auth-expired error card flips its CTA to "Log in again" (see
   // `wc-message-view.ts:errorCardEl`) and bubbles `slicc-error-login`. Re-open
-  // the connected provider's OAuth window so an expired session is refreshed
+  // the selected provider's OAuth window so an expired session is refreshed
   // in place rather than re-running the same failing turn.
   await wireLoginEvent({ refs, log, openSettings, refreshModels, applyIdentity, client });
 
@@ -328,13 +328,14 @@ function wireChangeModelEvent(opts: {
 /**
  * The auth-expired error card (see `wc-message-view.ts:errorCardEl`) flips its
  * CTA to "Log in again" and bubbles `slicc-error-login` up through the thread.
- * Re-open the connected provider's OAuth window — reusing `reloginOAuthAccount`,
- * which forces re-auth so an SSO provider (e.g. Adobe IMS) doesn't silently
- * re-authorize the same expired session — so the user refreshes their session
- * without re-running the failing turn. After a successful re-login, refresh the
- * model list / identity / active model the same way `openSettings` does. Falls
- * back to the account-settings dialog when no OAuth-capable provider resolves
- * (no connected accounts, or an API-key-only provider).
+ * Re-open the selected provider's OAuth window — the provider derived from the
+ * selected model, i.e. the one that produced the cone error — reusing
+ * `reloginOAuthAccount`, which forces re-auth so an SSO provider (e.g. Adobe
+ * IMS) doesn't silently re-authorize the same expired session — so the user
+ * refreshes their session without re-running the failing turn. After a
+ * successful re-login, refresh the model list / identity / active model the
+ * same way `openSettings` does. Falls back to the account-settings dialog when
+ * no OAuth-capable provider resolves (an API-key-only provider).
  */
 async function wireLoginEvent(opts: {
   refs: WcShellRefs;
@@ -345,11 +346,11 @@ async function wireLoginEvent(opts: {
   client: OffscreenClient;
 }): Promise<void> {
   const { refs, log, openSettings, refreshModels, applyIdentity, client } = opts;
-  const { getAccounts, getProviderConfig, reloginOAuthAccount } = await import(
+  const { getSelectedProvider, getProviderConfig, reloginOAuthAccount } = await import(
     '../provider-settings.js'
   );
   refs.thread?.addEventListener('slicc-error-login', () => {
-    const provider = accountIdentity(getAccounts())?.provider;
+    const provider = getSelectedProvider();
     const config = provider ? getProviderConfig(provider) : null;
     if (!config || (!config.onOAuthLogin && !config.onOAuthLoginIntercepted)) {
       openSettings();

--- a/packages/webapp/src/ui/wc/wc-nav.ts
+++ b/packages/webapp/src/ui/wc/wc-nav.ts
@@ -238,6 +238,12 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
     },
   });
 
+  // The auth-expired error card flips its CTA to "Log in again" (see
+  // `wc-message-view.ts:errorCardEl`) and bubbles `slicc-error-login`. Re-open
+  // the connected provider's OAuth window so an expired session is refreshed
+  // in place rather than re-running the same failing turn.
+  await wireLoginEvent({ refs, log, openSettings, refreshModels, applyIdentity, client });
+
   wireAccountsChangedResync({ refreshModels, applyIdentity, client });
 }
 
@@ -316,6 +322,44 @@ function wireChangeModelEvent(opts: {
     } catch (err) {
       log.error('opening composer model picker failed', err);
     }
+  });
+}
+
+/**
+ * The auth-expired error card (see `wc-message-view.ts:errorCardEl`) flips its
+ * CTA to "Log in again" and bubbles `slicc-error-login` up through the thread.
+ * Re-open the connected provider's OAuth window — reusing `reloginOAuthAccount`,
+ * which forces re-auth so an SSO provider (e.g. Adobe IMS) doesn't silently
+ * re-authorize the same expired session — so the user refreshes their session
+ * without re-running the failing turn. After a successful re-login, refresh the
+ * model list / identity / active model the same way `openSettings` does. Falls
+ * back to the account-settings dialog when no OAuth-capable provider resolves
+ * (no connected accounts, or an API-key-only provider).
+ */
+async function wireLoginEvent(opts: {
+  refs: WcShellRefs;
+  log: BootStageLogger;
+  openSettings(): void;
+  refreshModels(): void;
+  applyIdentity(): void;
+  client: OffscreenClient;
+}): Promise<void> {
+  const { refs, log, openSettings, refreshModels, applyIdentity, client } = opts;
+  const { getAccounts, getProviderConfig, reloginOAuthAccount } = await import(
+    '../provider-settings.js'
+  );
+  refs.thread?.addEventListener('slicc-error-login', () => {
+    const provider = accountIdentity(getAccounts())?.provider;
+    const config = provider ? getProviderConfig(provider) : null;
+    if (!config || (!config.onOAuthLogin && !config.onOAuthLoginIntercepted)) {
+      openSettings();
+      return;
+    }
+    void reloginOAuthAccount(config, () => {
+      refreshModels();
+      applyIdentity();
+      client.updateModel();
+    }).catch((err) => log.error('re-login from error card failed', err));
   });
 }
 

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -14,10 +14,10 @@ vi.mock('../../../src/ui/telemetry.js', async () => {
   const actual = await vi.importActual<typeof import('../../../src/ui/telemetry.js')>(
     '../../../src/ui/telemetry.js'
   );
-  return { ...actual, trackChatSend: vi.fn() };
+  return { ...actual, trackChatSend: vi.fn(), trackError: vi.fn() };
 });
 
-import { trackChatSend } from '../../../src/ui/telemetry.js';
+import { trackChatSend, trackError } from '../../../src/ui/telemetry.js';
 import type { AgentEvent, AgentHandle } from '../../../src/ui/types.js';
 import { WcChatController } from '../../../src/ui/wc/wc-chat-controller.js';
 
@@ -61,6 +61,7 @@ describe('WcChatController', () => {
     agent = new FakeAgent();
     processingStates = [];
     vi.mocked(trackChatSend).mockClear();
+    vi.mocked(trackError).mockClear();
     controller = new WcChatController({
       thread,
       agent,
@@ -257,6 +258,40 @@ describe('WcChatController', () => {
     const card = thread.querySelector('slicc-error-card');
     expect(card).not.toBeNull();
     expect(card?.getAttribute('message')).toBe('rate limited');
+  });
+
+  describe('no-handler error-card RUM beacon (trackError)', () => {
+    it('fires once with source=error-card for a generic error', () => {
+      agent.emit({ type: 'error', error: 'rate limited' });
+      expect(trackError).toHaveBeenCalledTimes(1);
+      expect(trackError).toHaveBeenCalledWith('error-card', 'rate limited');
+    });
+
+    it('does NOT fire for a no-api-key error (dedicated handler)', () => {
+      agent.emit({ type: 'error', error: 'No API key configured for Anthropic' });
+      expect(trackError).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire for an invalid-model error (dedicated handler)', () => {
+      agent.emit({ type: 'error', error: 'The provided model identifier is invalid' });
+      expect(trackError).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire for an auth-expired error (dedicated handler)', () => {
+      agent.emit({
+        type: 'error',
+        error: 'Scoop cone failed with unrecoverable error: session expired, please log in again',
+      });
+      expect(trackError).not.toHaveBeenCalled();
+    });
+
+    it('still renders the error card when the beacon throws', () => {
+      vi.mocked(trackError).mockImplementationOnce(() => {
+        throw new Error('telemetry blew up');
+      });
+      expect(() => agent.emit({ type: 'error', error: 'rate limited' })).not.toThrow();
+      expect(thread.querySelector('slicc-error-card')).not.toBeNull();
+    });
   });
 
   it('retries the failed turn through the agent send path on slicc-error-retry', () => {

--- a/packages/webapp/tests/ui/wc/wc-message-view.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-message-view.test.ts
@@ -22,6 +22,7 @@ import {
   BASH_ICONS,
   buildThreadChildren,
   collateLickMessages,
+  isAuthExpiredError,
   isInvalidModelError,
   isNoApiKeyError,
   messageEls,
@@ -230,6 +231,22 @@ describe('messageEls', () => {
     expect(card.tagName.toLowerCase()).toBe('slicc-error-card');
     expect(card.getAttribute('action')).toBe('change-model');
   });
+
+  it('flips to action="login" when the body carries the auth-expired marker', () => {
+    // The Adobe `getValidAccessToken` session-expired message ends with
+    // "please log in again" and the cone may wrap it with a "Scoop … failed
+    // with unrecoverable error: " prefix. Detection MUST survive both shapes.
+    const [card] = messageEls({
+      id: 'e-login',
+      role: 'assistant',
+      content:
+        'Scoop "alpha" failed with unrecoverable error: Adobe session expired — please log in again',
+      timestamp: 1,
+      error: true,
+    });
+    expect(card.tagName.toLowerCase()).toBe('slicc-error-card');
+    expect(card.getAttribute('action')).toBe('login');
+  });
 });
 
 describe('isInvalidModelError', () => {
@@ -256,6 +273,26 @@ describe('isInvalidModelError', () => {
     expect(isInvalidModelError('')).toBe(false);
     expect(isInvalidModelError(null)).toBe(false);
     expect(isInvalidModelError(undefined)).toBe(false);
+  });
+});
+
+describe('isAuthExpiredError', () => {
+  it('matches the bare and Scoop-prefixed session-expired forms (case-insensitive)', () => {
+    expect(isAuthExpiredError('Adobe session expired — please log in again')).toBe(true);
+    expect(
+      isAuthExpiredError(
+        'Scoop "alpha" failed with unrecoverable error: Adobe session expired — please log in again'
+      )
+    ).toBe(true);
+    expect(isAuthExpiredError('Session expired. PLEASE LOG IN AGAIN.')).toBe(true);
+  });
+
+  it('rejects unrelated errors, empty strings, and nullish input', () => {
+    expect(isAuthExpiredError('rate limited')).toBe(false);
+    expect(isAuthExpiredError('No API key configured')).toBe(false);
+    expect(isAuthExpiredError('')).toBe(false);
+    expect(isAuthExpiredError(null)).toBe(false);
+    expect(isAuthExpiredError(undefined)).toBe(false);
   });
 });
 

--- a/packages/webapp/tests/ui/wc/wc-nav.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-nav.test.ts
@@ -283,9 +283,15 @@ describe('wireWcNav', () => {
     expect(openMenu).not.toHaveBeenCalled();
   });
 
-  it('re-opens the connected provider OAuth window on slicc-error-login', async () => {
-    const onOAuthLogin = vi.fn(async (_launcher, onSuccess: () => void, _options) => {
-      // Drive the success callback so the host runs its post-login refresh.
+  it('re-opens the SELECTED provider (not the avatar account) on slicc-error-login', async () => {
+    // Two connected accounts: an avatar-bearing github account (the one the
+    // nav-display `accountIdentity` helper would prefer) and an adobe account
+    // selected as the current model (the provider that produced the cone
+    // error). The handler must re-log in ADOBE, not github.
+    const adobeLogin = vi.fn(async (_launcher, onSuccess: () => void, _options) => {
+      onSuccess();
+    });
+    const githubLogin = vi.fn(async (_launcher, onSuccess: () => void, _options) => {
       onSuccess();
     });
     registerProviderConfig({
@@ -294,12 +300,31 @@ describe('wireWcNav', () => {
       description: 'Adobe test provider',
       requiresApiKey: false,
       requiresBaseUrl: false,
-      onOAuthLogin,
+      onOAuthLogin: adobeLogin,
+    });
+    registerProviderConfig({
+      id: 'github',
+      name: 'GitHub',
+      description: 'GitHub test provider',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      onOAuthLogin: githubLogin,
     });
     localStorage.setItem(
       'slicc_accounts',
-      JSON.stringify([{ providerId: 'adobe', apiKey: '', userName: 'Lars', accessToken: 'tok' }])
+      JSON.stringify([
+        {
+          providerId: 'github',
+          apiKey: '',
+          userName: 'Lars Trieloff',
+          userAvatar: 'https://avatars.example/lars.png',
+          accessToken: 'gh',
+        },
+        { providerId: 'adobe', apiKey: '', userName: 'Lars', accessToken: 'tok' },
+      ])
     );
+    // Adobe is the provider derived from the selected model.
+    localStorage.setItem('selected-model', 'adobe:claude-opus-4-8');
     try {
       const refs = makeRefs();
       const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
@@ -312,39 +337,58 @@ describe('wireWcNav', () => {
           composed: true,
         })
       );
-      // The handler resolves the connected provider, then re-opens its OAuth
+      // The handler resolves the selected provider, then re-opens its OAuth
       // window via `reloginOAuthAccount`. That dynamically imports the (mocked)
       // OAuth service before invoking the login hook — poll across a few
       // macrotask ticks for it to resolve.
-      for (let i = 0; i < 50 && onOAuthLogin.mock.calls.length === 0; i++) {
+      for (let i = 0; i < 50 && adobeLogin.mock.calls.length === 0; i++) {
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
-      expect(onOAuthLogin).toHaveBeenCalledTimes(1);
+      expect(adobeLogin).toHaveBeenCalledTimes(1);
+      // The avatar-bearing github account must NOT be re-logged in.
+      expect(githubLogin).not.toHaveBeenCalled();
       // The third arg forces re-auth so SSO providers don't silently re-authorize.
-      expect(onOAuthLogin.mock.calls[0][2]).toEqual({ forceReauth: true });
+      expect(adobeLogin.mock.calls[0][2]).toEqual({ forceReauth: true });
       // The success callback runs the post-login refresh (same as openSettings).
       expect(client.updateModel).toHaveBeenCalledTimes(1);
     } finally {
       localStorage.removeItem('slicc_accounts');
+      localStorage.removeItem('selected-model');
       unregisterProviderConfig('adobe');
+      unregisterProviderConfig('github');
     }
   });
 
-  it('falls back to settings on slicc-error-login when no OAuth provider resolves', async () => {
+  it('falls back to settings on slicc-error-login when the selected provider has no OAuth config', async () => {
+    // An API-key-only provider selected as the current model: no OAuth hooks,
+    // so the handler routes the user into account settings instead.
+    registerProviderConfig({
+      id: 'openai-test',
+      name: 'OpenAI Test',
+      description: 'API-key-only test provider',
+      requiresApiKey: true,
+      requiresBaseUrl: false,
+    });
+    localStorage.setItem('selected-model', 'openai-test:gpt-5');
     localStorage.removeItem('slicc_accounts');
-    const refs = makeRefs();
-    const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
-    await wireWcNav({ refs, client, log: { error: vi.fn() } as never });
+    try {
+      const refs = makeRefs();
+      const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
+      await wireWcNav({ refs, client, log: { error: vi.fn() } as never });
 
-    showWcSettingsSpy.mockClear();
-    refs.thread.dispatchEvent(
-      new CustomEvent('slicc-error-login', {
-        detail: { messageId: 'err-login' },
-        bubbles: true,
-        composed: true,
-      })
-    );
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(showWcSettingsSpy).toHaveBeenCalledTimes(1);
+      showWcSettingsSpy.mockClear();
+      refs.thread.dispatchEvent(
+        new CustomEvent('slicc-error-login', {
+          detail: { messageId: 'err-login' },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(showWcSettingsSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      localStorage.removeItem('selected-model');
+      unregisterProviderConfig('openai-test');
+    }
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-nav.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-nav.test.ts
@@ -15,6 +15,16 @@ installWcDomStubs();
 const showWcSettingsSpy = vi.fn(async () => undefined);
 vi.mock('../../../src/ui/wc/wc-settings.js', () => ({ showWcSettings: showWcSettingsSpy }));
 
+// Stub the OAuth transport leaf so the real `reloginOAuthAccount` runs end to
+// end without booting the popup/CDP module graph: `createOAuthLauncher`
+// returns an inert launcher and the intercepting variant resolves to null, so
+// `reloginOAuthAccount` drives the provider's `onOAuthLogin` hook directly.
+vi.mock('../../../src/providers/oauth-service.js', () => ({
+  createOAuthLauncher: () => async () => '',
+  createInterceptingOAuthLauncherForCurrentRuntime: async () => null,
+}));
+
+import { registerProviderConfig, unregisterProviderConfig } from '../../../src/providers/index.js';
 import type { OffscreenClient } from '../../../src/ui/offscreen-client.js';
 import type { GroupedModels } from '../../../src/ui/provider-settings.js';
 import { accountIdentity, modelListForMeta, wireWcNav } from '../../../src/ui/wc/wc-nav.js';
@@ -271,5 +281,70 @@ describe('wireWcNav', () => {
     // untouched; the settings-dialog import is dynamic and exercised in the
     // settings-wiring tests).
     expect(openMenu).not.toHaveBeenCalled();
+  });
+
+  it('re-opens the connected provider OAuth window on slicc-error-login', async () => {
+    const onOAuthLogin = vi.fn(async (_launcher, onSuccess: () => void, _options) => {
+      // Drive the success callback so the host runs its post-login refresh.
+      onSuccess();
+    });
+    registerProviderConfig({
+      id: 'adobe',
+      name: 'Adobe',
+      description: 'Adobe test provider',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      onOAuthLogin,
+    });
+    localStorage.setItem(
+      'slicc_accounts',
+      JSON.stringify([{ providerId: 'adobe', apiKey: '', userName: 'Lars', accessToken: 'tok' }])
+    );
+    try {
+      const refs = makeRefs();
+      const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
+      await wireWcNav({ refs, client, log: { error: vi.fn() } as never });
+
+      refs.thread.dispatchEvent(
+        new CustomEvent('slicc-error-login', {
+          detail: { messageId: 'err-login' },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      // The handler resolves the connected provider, then re-opens its OAuth
+      // window via `reloginOAuthAccount`. That dynamically imports the (mocked)
+      // OAuth service before invoking the login hook — poll across a few
+      // macrotask ticks for it to resolve.
+      for (let i = 0; i < 50 && onOAuthLogin.mock.calls.length === 0; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      expect(onOAuthLogin).toHaveBeenCalledTimes(1);
+      // The third arg forces re-auth so SSO providers don't silently re-authorize.
+      expect(onOAuthLogin.mock.calls[0][2]).toEqual({ forceReauth: true });
+      // The success callback runs the post-login refresh (same as openSettings).
+      expect(client.updateModel).toHaveBeenCalledTimes(1);
+    } finally {
+      localStorage.removeItem('slicc_accounts');
+      unregisterProviderConfig('adobe');
+    }
+  });
+
+  it('falls back to settings on slicc-error-login when no OAuth provider resolves', async () => {
+    localStorage.removeItem('slicc_accounts');
+    const refs = makeRefs();
+    const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
+    await wireWcNav({ refs, client, log: { error: vi.fn() } as never });
+
+    showWcSettingsSpy.mockClear();
+    refs.thread.dispatchEvent(
+      new CustomEvent('slicc-error-login', {
+        detail: { messageId: 'err-login' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(showWcSettingsSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/webcomponents/src/chat/slicc-error-card.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.stories.ts
@@ -6,7 +6,7 @@ interface ErrorCardArgs {
   message?: string;
   bodyHtml?: string;
   'button-label'?: string;
-  action?: 'retry' | 'settings';
+  action?: 'retry' | 'settings' | 'change-model' | 'login';
   theme?: 'light' | 'dark';
 }
 
@@ -66,10 +66,12 @@ const meta: Meta<ErrorCardArgs> = {
     'button-label': { control: 'text', description: 'Retry button label (default "Try again")' },
     action: {
       control: 'inline-radio',
-      options: ['retry', 'settings'],
+      options: ['retry', 'settings', 'change-model', 'login'],
       description:
         'Action mode: `retry` (default) fires `slicc-error-retry`; `settings` flips the CTA to ' +
-        '"Open Settings" and fires `slicc-error-open-settings` instead.',
+        '"Open Settings" and fires `slicc-error-open-settings`; `change-model` flips it to ' +
+        '"Change model" and fires `slicc-error-change-model`; `login` flips it to "Log in again" ' +
+        'and fires `slicc-error-login`.',
     },
     theme: { control: 'inline-radio', options: ['light', 'dark'], description: 'Theme override' },
   },
@@ -147,6 +149,20 @@ export const SettingsActionDark: Story = {
     action: 'settings',
     theme: 'dark',
     message: 'No API key configured. Open Settings to add one.',
+  },
+};
+
+/**
+ * `action="login"` variant — the CTA flips to "Log in again" with a `log-in`
+ * glyph and dispatches `slicc-error-login` instead of `slicc-error-retry`.
+ * Used by the host for auth failures (e.g. an expired session) the user fixes
+ * by re-running the login flow rather than re-running the same failing turn.
+ */
+export const LoginAction: Story = {
+  args: {
+    label: 'Session expired',
+    action: 'login',
+    message: 'Your session has expired. Log in again to continue.',
   },
 };
 

--- a/packages/webcomponents/src/chat/slicc-error-card.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.ts
@@ -20,7 +20,7 @@ import { iconEl } from '../internal/icons.js';
  * Set the body via the `message` attribute (escaped plain text) or project
  * content into the default slot for rich markup.
  *
- * The `action` attribute switches the trailing affordance between three
+ * The `action` attribute switches the trailing affordance between four
  * CTAs that share the same surface:
  * - `"retry"` (default) — "Try again" label, `rotate-ccw` icon, fires
  *   `slicc-error-retry`.
@@ -32,16 +32,20 @@ import { iconEl } from '../internal/icons.js';
  *   `slicc-error-change-model`. Used for invalid-model failures so the host
  *   can open the composer model picker instead of pointlessly re-running
  *   the same failed turn.
+ * - `"login"` — "Log in again" label, `log-in` icon, fires
+ *   `slicc-error-login`. Used for auth failures (e.g. an expired session or
+ *   revoked token) so the host can re-run its login flow instead of
+ *   re-running the same failed turn.
  *
  * @attr label - the header label (default "Something went wrong")
  * @attr message - error body text (escaped); ignored when slotted content is present
  * @attr button-label - action button label (defaults vary by `action`:
- *   "Try again" / "Open Settings" / "Change model")
+ *   "Try again" / "Open Settings" / "Change model" / "Log in again")
  * @attr message-id - id of the failed chat message this card stands for; echoed
  *   back on the action event so the host can bind it to THIS turn
- * @attr action - `retry` (default) | `settings` | `change-model`; switches the
- *   CTA event, default label, and glyph. Unknown values normalize back to
- *   `"retry"` so legacy hosts stay safe.
+ * @attr action - `retry` (default) | `settings` | `change-model` | `login`;
+ *   switches the CTA event, default label, and glyph. Unknown values normalize
+ *   back to `"retry"` so legacy hosts stay safe.
  * @attr theme - `light` | `dark`; per-element override of the inherited theme
  * @csspart card - the outer `.err` card
  * @csspart header - the `.eh` header row
@@ -56,10 +60,12 @@ import { iconEl } from '../internal/icons.js';
  *   click (bubbles, composed) when `action="settings"`
  * @fires slicc-error-change-model - { messageId: string | null } dispatched on
  *   click (bubbles, composed) when `action="change-model"`
+ * @fires slicc-error-login - { messageId: string | null } dispatched on
+ *   click (bubbles, composed) when `action="login"`
  */
 
 /** Recognized values for the `action` attribute. */
-export type ErrorAction = 'retry' | 'settings' | 'change-model';
+export type ErrorAction = 'retry' | 'settings' | 'change-model' | 'login';
 
 /** Pixel size of the lucide header icon. */
 const HEADER_ICON_SIZE = 14;
@@ -72,12 +78,14 @@ const DEFAULT_BUTTON_LABEL: Record<ErrorAction, string> = {
   retry: 'Try again',
   settings: 'Open Settings',
   'change-model': 'Change model',
+  login: 'Log in again',
 };
 /** Lucide icon name per action variant. */
 const BUTTON_ICON: Record<ErrorAction, string> = {
   retry: 'rotate-ccw',
   settings: 'settings',
   'change-model': 'sparkles',
+  login: 'log-in',
 };
 
 const STYLE = `
@@ -220,12 +228,12 @@ export class SliccErrorCard extends HTMLElement {
   /**
    * Action mode: `retry` (default) fires `slicc-error-retry`; `settings`
    * fires `slicc-error-open-settings`; `change-model` fires
-   * `slicc-error-change-model`. Any unknown value is normalized back to
-   * `retry` so legacy hosts stay safe.
+   * `slicc-error-change-model`; `login` fires `slicc-error-login`. Any
+   * unknown value is normalized back to `retry` so legacy hosts stay safe.
    */
   get action(): ErrorAction {
     const a = this.getAttribute('action');
-    if (a === 'settings' || a === 'change-model') return a;
+    if (a === 'settings' || a === 'change-model' || a === 'login') return a;
     return 'retry';
   }
 
@@ -271,6 +279,17 @@ export class SliccErrorCard extends HTMLElement {
   changeModel(): void {
     this.dispatchEvent(
       new CustomEvent('slicc-error-change-model', {
+        detail: { messageId: this.getAttribute('message-id') ?? null },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  /** Dispatch `slicc-error-login` — fired by the button in `login` mode. */
+  login(): void {
+    this.dispatchEvent(
+      new CustomEvent('slicc-error-login', {
         detail: { messageId: this.getAttribute('message-id') ?? null },
         bubbles: true,
         composed: true,
@@ -329,6 +348,7 @@ export class SliccErrorCard extends HTMLElement {
     this.#onActionClick = () => {
       if (action === 'settings') this.openSettings();
       else if (action === 'change-model') this.changeModel();
+      else if (action === 'login') this.login();
       else this.retry();
     };
     btn.addEventListener('click', this.#onActionClick as EventListener);

--- a/packages/webcomponents/tests/chat/slicc-error-card.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-error-card.test.ts
@@ -378,4 +378,77 @@ describe('slicc-error-card', () => {
       );
     });
   });
+
+  describe('action="login" variant', () => {
+    it('reflects action="login" through the property', () => {
+      const el = mount();
+      el.action = 'login';
+      expect(el.getAttribute('action')).toBe('login');
+      el.setAttribute('action', 'retry');
+      expect(el.action).toBe('retry');
+      // Unknown values normalize back to retry.
+      el.setAttribute('action', 'banana');
+      expect(el.action).toBe('retry');
+    });
+
+    it('defaults the button label to "Log in again"', () => {
+      const el = mount({ message: 'session expired', action: 'login' });
+      expect(el.shadowRoot?.querySelector('[part="button"]')?.textContent?.trim()).toBe(
+        'Log in again'
+      );
+    });
+
+    it('still honors an explicit button-label override', () => {
+      const el = mount({
+        message: 'session expired',
+        action: 'login',
+        'button-label': 'Sign in',
+      });
+      expect(el.shadowRoot?.querySelector('[part="button"]')?.textContent?.trim()).toBe('Sign in');
+    });
+
+    it('renders the lucide log-in glyph instead of rotate-ccw or settings', () => {
+      const el = mount({ message: 'session expired', action: 'login' });
+      const btn = el.shadowRoot?.querySelector('[part="button"]') as HTMLButtonElement;
+      const svg = btn.querySelector('svg');
+      expect(svg).toBeInstanceOf(SVGSVGElement);
+      expect(svg?.innerHTML).toBe(iconShape('log-in', 12));
+      expect(svg?.innerHTML).not.toBe(iconShape('rotate-ccw', 12));
+      expect(svg?.innerHTML).not.toBe(iconShape('settings', 12));
+    });
+
+    it('dispatches slicc-error-login (bubbling, composed) on click', () => {
+      const el = mount({
+        message: 'session expired',
+        action: 'login',
+        'message-id': 'err-lg',
+      });
+      const loginSeen: CustomEvent[] = [];
+      const retrySeen: CustomEvent[] = [];
+      const settingsSeen: CustomEvent[] = [];
+      document.body.addEventListener('slicc-error-login', (e) => loginSeen.push(e as CustomEvent));
+      document.body.addEventListener('slicc-error-retry', (e) => retrySeen.push(e as CustomEvent));
+      document.body.addEventListener('slicc-error-open-settings', (e) =>
+        settingsSeen.push(e as CustomEvent)
+      );
+      const btn = el.shadowRoot?.querySelector('[part="button"]') as HTMLButtonElement;
+      btn.click();
+      expect(loginSeen).toHaveLength(1);
+      expect(loginSeen[0].bubbles).toBe(true);
+      expect(loginSeen[0].composed).toBe(true);
+      expect(loginSeen[0].detail).toEqual({ messageId: 'err-lg' });
+      // Sibling action events are mutually exclusive in login mode.
+      expect(retrySeen).toHaveLength(0);
+      expect(settingsSeen).toHaveLength(0);
+    });
+
+    it('exposes a programmatic login() that dispatches the same event', () => {
+      const el = mount({ message: 'oops', 'message-id': 'err-2', action: 'login' });
+      const spy = vi.fn();
+      el.addEventListener('slicc-error-login', spy);
+      el.login();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect((spy.mock.calls[0][0] as CustomEvent).detail).toEqual({ messageId: 'err-2' });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When an Adobe session expires, the error card previously showed a generic **"Try again"** button that just re-hit the dead session. This PR makes that CTA **"Log in again"** and wires it to re-open the OAuth window, and adds RUM instrumentation for generic (no-handler) error cards so frequent user-visible failures surface in the nightly triage pipeline.

## Changes (3 waves)

### Wave 1 — `login` action variant in `slicc-error-card` (`@slicc/webcomponents`)
- Adds `action="login"` → **"Log in again"** label, `log-in` icon, bubbling `slicc-error-login` event.
- Unknown actions still fall back to `retry`.

### Wave 2 — Wire auth-expired card to the OAuth window (`@slicc/webapp`)
- Exports `isAuthExpiredError(content)` (case-insensitive match on `please log in again`, robust to a `Scoop … unrecoverable error:` prefix).
- `errorCardEl()` selects `action="login"` for auth-expired errors, ordered after the no-api-key and invalid-model branches.
- `wireLoginEvent()` re-opens the connected provider's OAuth window via `reloginOAuthAccount` (`forceReauth`), falling back to settings when no OAuth-capable provider resolves.

### Wave 3 — RUM beacon for generic no-handler error cards (`@slicc/webapp`)
- `wc-chat-controller.ts#handleError` emits a best-effort `trackError('error-card', …)` beacon **only** for errors with no dedicated handler (excludes no-api-key / invalid-model / auth-expired).
- Wrapped in try/catch so telemetry never blocks rendering. Feeds the existing nightly `rum-error-triage.yml` action.

## Verification
- `@slicc/webcomponents` `slicc-error-card`: 36 tests pass
- `@slicc/webapp` `wc-message-view` + `wc-nav` + `wc-chat-controller`: 85 tests pass
- `npm run lint`: ok
- `npm run typecheck`: ok (all tsc projects)
- Two independent verifier passes: APPROVED (high confidence) — RUM exclusion set exactly matches the three handled error families; `'error-card'` source correctly consumed by `rum-error-triage`.

## Notes
- Additive only; no change to the underlying error text.
- Cross-runtime parity: N/A for native peers — this is shared webapp/webcomponents UI covering both standalone and extension floats.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author