### PR TITLE
fix(fs): bound recursive walkers against filesystem cycles + surface cyclic mounts

### DIFF
--- a/packages/webapp/src/fs/mount-commands.ts
+++ b/packages/webapp/src/fs/mount-commands.ts
@@ -350,6 +350,11 @@ export class MountCommands {
         } else if (state.status === 'indexing') {
           return `${m} (indexing: ${state.indexed} entries...)`;
         } else if (state.status === 'error') {
+          if (state.likelyCyclic) {
+            // A self-referential / oversized mount: reads still work (slow path),
+            // but the index can't complete. Tell the user how to clear it.
+            return `${m} (index error: likely a self-referential mount cycle — run 'mount unmount ${m}' to remove it)`;
+          }
           return `${m} (index error: ${state.error})`;
         }
         return `${m} (pending index)`;

--- a/packages/webapp/src/fs/mount-index.ts
+++ b/packages/webapp/src/fs/mount-index.ts
@@ -20,6 +20,13 @@ import { createLogger } from '../core/logger.js';
 
 const log = createLogger('mount-index');
 
+// Bound the recursive mount-index walk so a self-referential mount — a tree that
+// re-exposes one of its own ancestors (e.g. a repo checkout whose
+// `.claude/worktrees/` nests further checkouts of itself) — cannot grow the
+// index without limit and peg / OOM the kernel worker. See `walkHandle`.
+const MAX_INDEX_DEPTH = 40;
+const MAX_INDEX_ENTRIES = 200_000;
+
 export interface MountIndexEntry {
   /** Absolute VFS path */
   path: string;
@@ -392,9 +399,24 @@ export class MountIndex {
     basePath: string,
     handle: FileSystemDirectoryHandle,
     data: MountData,
-    signal: AbortSignal
+    signal: AbortSignal,
+    depth = 0
   ): Promise<void> {
     if (signal.aborted) return;
+    // A self-referential mount would otherwise descend forever, growing the
+    // index until it OOMs / pegs the kernel worker. Exceeding either bound
+    // aborts indexing; `indexMount` marks the mount `error`, so reads fall back
+    // to the slow per-`readDir` path instead of trusting a partial index.
+    if (depth > MAX_INDEX_DEPTH) {
+      throw new Error(
+        `mount indexing aborted: directory nesting exceeded ${MAX_INDEX_DEPTH} levels (likely a self-referential mount cycle)`
+      );
+    }
+    if (data.directories.size + data.files.size >= MAX_INDEX_ENTRIES) {
+      throw new Error(
+        `mount indexing aborted: exceeded ${MAX_INDEX_ENTRIES} entries (likely a self-referential mount cycle or oversized tree)`
+      );
+    }
 
     data.directories.add(basePath);
 
@@ -410,7 +432,13 @@ export class MountIndex {
         data.files.add(childPath);
         data.state.indexed++;
       } else if (childHandle.kind === 'directory') {
-        await this.walkHandle(childPath, childHandle as FileSystemDirectoryHandle, data, signal);
+        await this.walkHandle(
+          childPath,
+          childHandle as FileSystemDirectoryHandle,
+          data,
+          signal,
+          depth + 1
+        );
       }
 
       // Yield to event loop periodically to keep UI responsive

--- a/packages/webapp/src/fs/mount-index.ts
+++ b/packages/webapp/src/fs/mount-index.ts
@@ -27,6 +27,15 @@ const log = createLogger('mount-index');
 const MAX_INDEX_DEPTH = 40;
 const MAX_INDEX_ENTRIES = 200_000;
 
+/**
+ * Thrown by `walkHandle` when a depth / entry bound is exceeded — i.e. the tree
+ * is almost certainly self-referential (or pathologically oversized) rather than
+ * a backend failure. `indexMount` uses it to set `likelyCyclic` so consumers
+ * (e.g. `mount list`) can surface an actionable "unmount it" hint instead of the
+ * raw abort message.
+ */
+class MountIndexBoundError extends Error {}
+
 export interface MountIndexEntry {
   /** Absolute VFS path */
   path: string;
@@ -44,6 +53,12 @@ export interface MountIndexState {
   total?: number;
   /** Error message if status is 'error' */
   error?: string;
+  /**
+   * True when the 'error' was an exceeded depth / entry bound — a likely
+   * self-referential mount cycle (or oversized tree), not a backend failure.
+   * Lets consumers render an actionable remedy rather than the raw message.
+   */
+  likelyCyclic?: boolean;
 }
 
 interface MountData {
@@ -385,8 +400,9 @@ export class MountIndex {
       if (signal.aborted) return;
 
       const message = err instanceof Error ? err.message : String(err);
-      data.state = { status: 'error', indexed: 0, error: message };
-      log.error('Mount indexing failed', { path: mountPath, error: message });
+      const likelyCyclic = err instanceof MountIndexBoundError;
+      data.state = { status: 'error', indexed: 0, error: message, likelyCyclic };
+      log.error('Mount indexing failed', { path: mountPath, error: message, likelyCyclic });
     }
 
     this.notifyListeners();
@@ -408,12 +424,12 @@ export class MountIndex {
     // aborts indexing; `indexMount` marks the mount `error`, so reads fall back
     // to the slow per-`readDir` path instead of trusting a partial index.
     if (depth > MAX_INDEX_DEPTH) {
-      throw new Error(
+      throw new MountIndexBoundError(
         `mount indexing aborted: directory nesting exceeded ${MAX_INDEX_DEPTH} levels (likely a self-referential mount cycle)`
       );
     }
     if (data.directories.size + data.files.size >= MAX_INDEX_ENTRIES) {
-      throw new Error(
+      throw new MountIndexBoundError(
         `mount indexing aborted: exceeded ${MAX_INDEX_ENTRIES} entries (likely a self-referential mount cycle or oversized tree)`
       );
     }

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -47,6 +47,12 @@ import { FsError } from './types.js';
  * bounded loop that protects against that.
  */
 const MAX_SYMLINK_DEPTH = 10;
+// Bound `walk()`'s slow-path recursion. Symlink cycles surface as ELOOP via
+// realpath, but realpath returns mount paths unchanged ("already real"), so a
+// self-referential mount yields ever-distinct paths the visited-set can't
+// collapse — cap depth and total entries so it can't loop forever. See `walk`.
+const MAX_WALK_DEPTH = 64;
+const MAX_WALK_ENTRIES = 100_000;
 
 /** Backend identifier for {@link VirtualFS}. */
 export type VfsBackend = 'memory' | 'opfs';
@@ -1672,7 +1678,7 @@ export class VirtualFS {
    * For mounted directories with a ready index, uses the fast path (O(n) iteration
    * over cached file list). Falls back to slow recursive readDir otherwise.
    */
-  async *walk(path: string, _visited?: Set<string>): AsyncGenerator<string> {
+  async *walk(path: string, _visited?: Set<string>, _depth = 0): AsyncGenerator<string> {
     const normalized = normalizePath(path);
 
     // Fast path: indexed mount with no nested mounts
@@ -1689,6 +1695,13 @@ export class VirtualFS {
     // Slow path: recursive readDir
     const visited = _visited ?? new Set<string>();
 
+    // Bound the recursion: realpath leaves mount paths unchanged, so the
+    // visited-set below cannot collapse a self-referential mount (a tree that
+    // re-exposes an ancestor — its nested paths are all distinct strings).
+    // Cap depth + total entries so such a mount can't make walk() — and the
+    // jsh/bsh/ScriptCatalog discovery built on it — loop forever.
+    if (_depth > MAX_WALK_DEPTH || visited.size >= MAX_WALK_ENTRIES) return;
+
     // Track the real path to detect symlink loops
     const realPath = await this.safeRealpath(normalized);
     if (visited.has(realPath)) return;
@@ -1698,7 +1711,7 @@ export class VirtualFS {
 
     for (const entry of entries) {
       const childPath = normalized === '/' ? `/${entry.name}` : `${normalized}/${entry.name}`;
-      yield* this.walkEntry(entry, childPath, visited);
+      yield* this.walkEntry(entry, childPath, visited, _depth + 1);
     }
   }
 
@@ -1725,27 +1738,32 @@ export class VirtualFS {
   private async *walkEntry(
     entry: DirEntry,
     childPath: string,
-    visited: Set<string>
+    visited: Set<string>,
+    depth: number
   ): AsyncGenerator<string> {
     if (entry.type === 'file') {
       yield childPath;
       return;
     }
     if (entry.type === 'symlink') {
-      yield* this.walkSymlink(childPath, visited);
+      yield* this.walkSymlink(childPath, visited, depth);
       return;
     }
-    yield* this.walk(childPath, visited);
+    yield* this.walk(childPath, visited, depth);
   }
 
   /** Follow a symlink during walk — yield as file or recurse as directory. */
-  private async *walkSymlink(childPath: string, visited: Set<string>): AsyncGenerator<string> {
+  private async *walkSymlink(
+    childPath: string,
+    visited: Set<string>,
+    depth: number
+  ): AsyncGenerator<string> {
     try {
       const targetStat = await this.stat(childPath);
       if (targetStat.type === 'file') {
         yield childPath;
       } else if (targetStat.type === 'directory') {
-        yield* this.walk(childPath, visited);
+        yield* this.walk(childPath, visited, depth);
       }
     } catch {
       // Dangling symlink — skip

--- a/packages/webapp/src/skills/catalog.ts
+++ b/packages/webapp/src/skills/catalog.ts
@@ -1,6 +1,9 @@
+import { createLogger } from '../core/logger.js';
 import type { VirtualFS } from '../fs/index.js';
 import { MONKEYPATCH_UNSAFE_FS } from '../fs/sudo-fs.js';
 import { SKILL_FILE, WORKSPACE_SKILLS_PATH } from './constants.js';
+
+const log = createLogger('skills-discovery');
 
 export type SkillDiscoverySource = 'native' | 'agents' | 'claude' | 'marketplace';
 
@@ -26,7 +29,18 @@ const COMPATIBILITY_DIRECTORY_SOURCES = new Map<string, Exclude<SkillDiscoverySo
   ['.agents', 'agents'],
   ['.claude', 'claude'],
 ]);
-const PRUNED_COMPATIBILITY_DIRECTORY_NAMES = new Set(['.git', '.slicc']);
+const PRUNED_COMPATIBILITY_DIRECTORY_NAMES = new Set(['.git', '.slicc', 'node_modules']);
+
+// Bound the compatibility-root walk. Skills/marketplaces live within a few
+// directories of their root; a directory cycle (e.g. a self-referential mount
+// that re-exposes an ancestor) yields arbitrarily deep and wide paths. A
+// filesystem walk must tolerate cycles — bound it by depth AND a hard directory
+// budget so a cyclic or pathologically large VFS can't peg the kernel worker.
+// (d14f81c6 removed the prior MAX_DISCOVERY_DIRECTORIES cap, which is what let
+// a cyclic profile hang skills discovery — and with it the whole steering bridge
+// in substrate mode.)
+const MAX_DISCOVERY_DEPTH = 24;
+const MAX_DISCOVERY_DIRECTORIES = 20_000;
 const COMPATIBILITY_CACHE_INVALIDATION_METHODS = [
   'mkdir',
   'mount',
@@ -264,14 +278,26 @@ async function discoverCompatibilitySkillCandidates(
 ): Promise<DiscoveredSkillCandidate[]> {
   const discovered: DiscoveredSkillCandidate[] = [];
   const seenPaths = new Set<string>();
-  const queue = ['/'];
+  const enqueued = new Set<string>(['/']);
+  const queue: Array<{ path: string; depth: number }> = [{ path: '/', depth: 0 }];
 
   for (let index = 0; index < queue.length; index += 1) {
-    const currentPath = queue[index];
+    if (index >= MAX_DISCOVERY_DIRECTORIES) {
+      // Hard backstop: a cyclic (e.g. self-referential mount) or pathologically
+      // large VFS would otherwise walk forever and peg the kernel worker.
+      log.warn('skills discovery: directory budget exhausted; walk truncated', {
+        budget: MAX_DISCOVERY_DIRECTORIES,
+      });
+      break;
+    }
+    const { path: currentPath, depth } = queue[index];
     const entries = await readSortedDir(fs, currentPath);
 
     for (const entry of entries) {
       if (entry.type !== 'directory') continue;
+      // `.`/`..` never come from VirtualFS.readDir, but guard so a backend that
+      // surfaces them cannot create a trivial self/parent cycle.
+      if (entry.name === '.' || entry.name === '..') continue;
       const childPath = currentPath === '/' ? `/${entry.name}` : `${currentPath}/${entry.name}`;
 
       const source = COMPATIBILITY_DIRECTORY_SOURCES.get(entry.name);
@@ -295,8 +321,13 @@ async function discoverCompatibilitySkillCandidates(
         continue;
       }
 
-      if (!PRUNED_COMPATIBILITY_DIRECTORY_NAMES.has(entry.name)) {
-        queue.push(childPath);
+      if (
+        !PRUNED_COMPATIBILITY_DIRECTORY_NAMES.has(entry.name) &&
+        depth < MAX_DISCOVERY_DEPTH &&
+        !enqueued.has(childPath)
+      ) {
+        enqueued.add(childPath);
+        queue.push({ path: childPath, depth: depth + 1 });
       }
     }
   }

--- a/packages/webapp/tests/fs/fsa-test-helpers.ts
+++ b/packages/webapp/tests/fs/fsa-test-helpers.ts
@@ -193,6 +193,23 @@ export function createDirectoryHandle(tree: MockTree, name = 'mounted'): FileSys
   return new MockDirectoryHandle(name, buildTree(tree)) as unknown as FileSystemDirectoryHandle;
 }
 
+/**
+ * A directory handle with a self-referential `loop` subdirectory — `loop` IS
+ * the same node — so navigating `loop/loop/loop/…` never terminates. Models a
+ * self-nesting local mount (a tree that re-exposes one of its own ancestors),
+ * the kind of cyclic VFS that hangs an unbounded `walk()`.
+ */
+export function createCyclicDirectoryHandle(name = 'cyclic'): FileSystemDirectoryHandle {
+  const node: MockDirectoryNode = { kind: 'directory', entries: new Map() };
+  node.entries.set('a.txt', {
+    kind: 'file',
+    content: new TextEncoder().encode('x'),
+    mtime: Date.now(),
+  });
+  node.entries.set('loop', node); // self-reference → cycle
+  return new MockDirectoryHandle(name, node) as unknown as FileSystemDirectoryHandle;
+}
+
 export interface MutableDirectoryHandle {
   handle: FileSystemDirectoryHandle;
   setFile(path: string, content: string): void;

--- a/packages/webapp/tests/fs/mount-commands.test.ts
+++ b/packages/webapp/tests/fs/mount-commands.test.ts
@@ -75,6 +75,54 @@ describe('MountCommands', () => {
       const result = await cmd.execute(['-l'], '/workspace');
       expect(result.exitCode).toBe(0);
     });
+
+    it('renders an actionable hint for a likely-cyclic mount index error', async () => {
+      const mountIndex = {
+        getState: vi.fn(() => ({
+          status: 'error' as const,
+          indexed: 0,
+          error: 'mount indexing aborted: directory nesting exceeded 40 levels',
+          likelyCyclic: true,
+        })),
+        isReady: vi.fn(() => false),
+      };
+      const cmd = new MountCommands({
+        fs: makeFs({
+          listMounts: vi.fn(() => ['/mnt/cyclic']),
+          getMountIndex: vi.fn(() => mountIndex) as unknown as VirtualFS['getMountIndex'],
+        }),
+      });
+      const result = await cmd.execute(['list'], '/workspace');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('/mnt/cyclic');
+      // Names the condition and tells the user how to clear it, rather than
+      // dumping the raw indexer abort message.
+      expect(result.stdout.toLowerCase()).toContain('cycl');
+      expect(result.stdout).toContain('mount unmount /mnt/cyclic');
+    });
+
+    it('still renders the raw message for a non-cyclic index error', async () => {
+      const mountIndex = {
+        getState: vi.fn(() => ({
+          status: 'error' as const,
+          indexed: 0,
+          error: 'backend unavailable',
+        })),
+        isReady: vi.fn(() => false),
+      };
+      const cmd = new MountCommands({
+        fs: makeFs({
+          listMounts: vi.fn(() => ['/mnt/broken']),
+          getMountIndex: vi.fn(() => mountIndex) as unknown as VirtualFS['getMountIndex'],
+        }),
+      });
+      const result = await cmd.execute(['list'], '/workspace');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('backend unavailable');
+      expect(result.stdout).not.toContain('mount unmount');
+    });
   });
 
   describe('unmount subcommand', () => {

--- a/packages/webapp/tests/fs/mount-index.test.ts
+++ b/packages/webapp/tests/fs/mount-index.test.ts
@@ -34,7 +34,7 @@ async function waitForTerminalState(
 }
 
 describe('MountIndex cycle safety', () => {
-  it('terminates indexing on a self-referential mount instead of hanging', async () => {
+  it('terminates a self-referential mount and flags it as likely cyclic', async () => {
     const index = new MountIndex();
     index.registerMount('/mnt/cyclic', makeCyclicHandle());
 
@@ -44,9 +44,34 @@ describe('MountIndex cycle safety', () => {
     // worker). With the caps it aborts → 'error' (the mount falls back to the
     // slow per-readDir path).
     const status = await waitForTerminalState(index, '/mnt/cyclic', 4000);
+    const state = index.getState('/mnt/cyclic');
     index.unregisterMount('/mnt/cyclic'); // abort the walk so it can't leak past the test
 
     expect(status).toBe('error');
+    // The error is attributable to a bound (cycle / oversized tree), not a
+    // backend failure — `mount list` renders an actionable unmount hint off this.
+    expect(state?.likelyCyclic).toBe(true);
+  }, 9000);
+
+  it('marks a generic backend failure as error WITHOUT the cyclic flag', async () => {
+    // A handle whose iteration throws a non-bound error: still terminal 'error',
+    // but it is NOT a cycle, so the actionable-unmount hint must not fire.
+    const failing = {
+      kind: 'directory' as const,
+      [Symbol.asyncIterator]() {
+        return { next: () => Promise.reject(new Error('backend unavailable')) };
+      },
+    } as unknown as FileSystemDirectoryHandle;
+
+    const index = new MountIndex();
+    index.registerMount('/mnt/broken', failing);
+
+    const status = await waitForTerminalState(index, '/mnt/broken', 4000);
+    const state = index.getState('/mnt/broken');
+    index.unregisterMount('/mnt/broken');
+
+    expect(status).toBe('error');
+    expect(state?.likelyCyclic).toBeFalsy();
   }, 9000);
 
   it('indexes a normal finite tree to ready', async () => {

--- a/packages/webapp/tests/fs/mount-index.test.ts
+++ b/packages/webapp/tests/fs/mount-index.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { MountIndex } from '../../src/fs/mount-index.js';
+
+/**
+ * A self-referential FileSystemDirectoryHandle: it contains a file plus a
+ * subdirectory `loop` that IS the same handle, so a naive recursive index walk
+ * descends `/mnt/cyclic/loop/loop/loop/…` forever. This mirrors a real
+ * self-nesting local mount (e.g. a repo checkout whose `.claude/worktrees/`
+ * re-contains the repo), which pegged the kernel worker in substrate mode.
+ */
+function makeCyclicHandle(): FileSystemDirectoryHandle {
+  const self = {
+    kind: 'directory' as const,
+    async *[Symbol.asyncIterator](): AsyncGenerator<[string, { kind: 'file' | 'directory' }]> {
+      yield ['file.txt', { kind: 'file' }];
+      yield ['loop', self];
+    },
+  };
+  return self as unknown as FileSystemDirectoryHandle;
+}
+
+async function waitForTerminalState(
+  index: MountIndex,
+  path: string,
+  timeoutMs: number
+): Promise<string | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  let state = index.getState(path);
+  while (Date.now() < deadline && (state?.status === 'indexing' || state?.status === 'pending')) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    state = index.getState(path);
+  }
+  return state?.status;
+}
+
+describe('MountIndex cycle safety', () => {
+  it('terminates indexing on a self-referential mount instead of hanging', async () => {
+    const index = new MountIndex();
+    index.registerMount('/mnt/cyclic', makeCyclicHandle());
+
+    // The bounded walk must reach a terminal state quickly. Without the depth /
+    // entry caps the walk never returns and this stays 'indexing' until the
+    // poll deadline, failing the assertion (and, in production, wedging the
+    // worker). With the caps it aborts → 'error' (the mount falls back to the
+    // slow per-readDir path).
+    const status = await waitForTerminalState(index, '/mnt/cyclic', 4000);
+    index.unregisterMount('/mnt/cyclic'); // abort the walk so it can't leak past the test
+
+    expect(status).toBe('error');
+  }, 9000);
+
+  it('indexes a normal finite tree to ready', async () => {
+    const finite = {
+      kind: 'directory' as const,
+      async *[Symbol.asyncIterator](): AsyncGenerator<[string, { kind: 'file' | 'directory' }]> {
+        yield ['a.txt', { kind: 'file' }];
+        yield ['b.txt', { kind: 'file' }];
+      },
+    } as unknown as FileSystemDirectoryHandle;
+
+    const index = new MountIndex();
+    index.registerMount('/mnt/finite', finite);
+
+    const status = await waitForTerminalState(index, '/mnt/finite', 4000);
+
+    expect(status).toBe('ready');
+    expect(index.getState('/mnt/finite')?.indexed).toBe(3); // 2 files + the root dir
+  }, 9000);
+});

--- a/packages/webapp/tests/fs/virtual-fs-walk-cycle.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs-walk-cycle.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+import { VirtualFS } from '../../src/fs/index.js';
+import { LocalMountBackend } from '../../src/fs/mount/backend-local.js';
+import { createCyclicDirectoryHandle } from './fsa-test-helpers.js';
+
+describe('VirtualFS.walk cycle safety', () => {
+  it('terminates on a self-referential mount instead of looping forever', async () => {
+    globalThis.indexedDB = new IDBFactory();
+    const vfs = await VirtualFS.create({ wipe: true });
+    await vfs.mount(
+      '/mnt/cyclic',
+      LocalMountBackend.fromHandle(createCyclicDirectoryHandle(), { mountId: 'walk-cycle-test' })
+    );
+
+    // `realpath()` returns mount paths unchanged ("already real"), so walk()'s
+    // visited-set cannot collapse the /mnt/cyclic/loop/loop/… cycle — only the
+    // depth/entry bound stops it. Without the bound this loops forever (the
+    // consumer would run until SAFETY, or the test would time out).
+    const SAFETY = 5000;
+    let count = 0;
+    for await (const _file of vfs.walk('/mnt/cyclic')) {
+      if (++count >= SAFETY) break;
+    }
+
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThan(SAFETY);
+  }, 15000);
+});

--- a/packages/webapp/tests/skills/catalog.test.ts
+++ b/packages/webapp/tests/skills/catalog.test.ts
@@ -275,6 +275,60 @@ describe('discoverSkillCandidates', () => {
       expect(marketplace[0].path).toBe('/mnt/repo/skills/root-skill');
     }
   });
+
+  it('terminates on a cyclic VFS (mount self-reference) instead of hanging, and still finds real skills', async () => {
+    // Regression for the substrate boot wedge: a profile whose VFS contains a
+    // directory cycle — e.g. a self-referential /mnt mount that re-exposes one
+    // of its own ancestors — made the unbounded BFS walk forever, pegging the
+    // kernel worker so the shell/steering bridge went dead. d14f81c6 ("remove
+    // discovery directory limit and counter") removed the bound that prevented
+    // this. A filesystem walk must tolerate cycles (depth + directory budget),
+    // the way every real walker does, while still reaching legitimate skills.
+    const tree: Record<string, Array<{ name: string; type: 'file' | 'directory' }>> = {
+      '/': [
+        { name: 'mnt', type: 'directory' },
+        { name: 'repo', type: 'directory' },
+        { name: 'workspace', type: 'directory' },
+      ],
+      '/workspace': [{ name: 'skills', type: 'directory' }],
+      '/workspace/skills': [],
+      '/repo': [{ name: '.claude', type: 'directory' }],
+      '/repo/.claude': [{ name: 'skills', type: 'directory' }],
+      '/repo/.claude/skills': [{ name: 'real', type: 'directory' }],
+      '/repo/.claude/skills/real': [{ name: 'SKILL.md', type: 'file' }],
+      '/mnt': [{ name: 'loop', type: 'directory' }],
+    };
+    // readDir of any /mnt/loop, /mnt/loop/loop, … re-exposes another `loop`
+    // child forever — an infinite chain of distinct paths (a path-cycle a
+    // simple visited-set cannot catch; only a depth/count bound terminates it).
+    const isCycle = (path: string): boolean => /^\/mnt(\/loop)+$/.test(path);
+    const cyclicFs = {
+      readDir: async (path: string) => {
+        // A tiny delay keeps the (pre-fix) unbounded walk memory-bounded, so the
+        // failing case is a clean timeout rather than an OOM of the test runner.
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        if (isCycle(path)) return [{ name: 'loop', type: 'directory' as const }];
+        return tree[path] ?? [];
+      },
+      stat: async (path: string) => {
+        if (path === '/repo/.claude/skills/real/SKILL.md') {
+          return { type: 'file' as const, size: 0, mtime: 0 };
+        }
+        if (path === '/mnt' || isCycle(path) || tree[path]) {
+          return { type: 'directory' as const, size: 0, mtime: 0 };
+        }
+        throw new Error(`ENOENT: ${path}`);
+      },
+      readTextFile: async (path: string) => {
+        if (path === '/repo/.claude/skills/real/SKILL.md') return '---\nname: real\n---\n';
+        throw new Error(`ENOENT: ${path}`);
+      },
+    } as unknown as VirtualFS;
+
+    const candidates = await discoverSkillCandidates(cyclicFs);
+
+    expect(candidates.map((candidate) => candidate.path)).toContain('/repo/.claude/skills/real');
+  }, 8000);
 });
 
 describe('discoverSkillCandidates over a sudo-fs Proxy (OOM regression)', () => {


### PR DESCRIPTION
## What

Three unbounded recursive walkers in the shared browser core could peg / OOM the
kernel-worker thread when a **self-referential (cyclic) mounted filesystem** is present —
e.g. a local mount of a repo checkout whose `.claude/worktrees/` re-contains full
checkouts of itself. In `--substrate` mode (and any float that boots a stale profile
carrying such a mount), the busy-loop starved the steering bridge and wedged the instance
at boot.

This PR bounds all three walkers and makes a cyclic mount **discoverable and
self-serviceable** from the shell.

## Changes

**1. Bound the walkers (`fix`)** — each now terminates on a cyclic VFS instead of looping
forever:

- `skills/catalog.ts` — compatibility-skill discovery BFS: depth + directory budget,
  `enqueued` de-dup, pruned dirs (`.git`, `.slicc`, `node_modules`).
- `fs/mount-index.ts` — `walkHandle` depth (≤40) + entry (≤200k) caps; exceeding either
  aborts indexing → mount marked `error` → reads fall back to the slow per-`readDir` path.
- `fs/virtual-fs.ts` — `walk()` slow-path depth (≤64) + entry (≤100k) bound. (`realpath()`
  returns mount paths unchanged — "already real" — so the visited-set can't collapse a
  `/mnt/x/loop/loop/…` mount cycle; only the bound stops it.)

**2. Surface the cyclic mount (`feat`)** — `mount-index.ts` tags a bound-triggered abort via
a `MountIndexBoundError` sentinel → `likelyCyclic` flag on `MountIndexState`; `mount list`
renders an actionable line:

```
/mnt/x (index error: likely a self-referential mount cycle — run 'mount unmount /mnt/x' to remove it)
```

instead of the raw indexer abort message.

## Why this shape (not mount-time prevention)

The walkers already neutralize the *harm* (a cyclic mount is non-fatal — bounded +
slow-pathed). Reliably *detecting* "an OS tree that re-exposes an ancestor" at mount time is
heuristic (nested checkouts, symlinks, macOS aliases) and risks false-positives rejecting
legit mounts. So: tolerate + surface clearly, rather than a mount-time guard.

## Tests

TDD throughout — each test watched RED before its fix:

- `tests/skills/catalog.test.ts` — terminates on a cyclic VFS.
- `tests/fs/mount-index.test.ts` — cyclic handle → terminal `error` + `likelyCyclic`; generic
  backend error → `error` WITHOUT the flag.
- `tests/fs/virtual-fs-walk-cycle.test.ts` — `walk()` over a self-referential local mount
  terminates under a safety bound.
- `tests/fs/mount-commands.test.ts` — `mount list` renders the actionable hint for a cyclic
  error; raw message for a non-cyclic one.

## Verification

`lint:ci`, typecheck (7 passes), full suite (9412 passed / 0 failed), webapp coverage floor,
webapp + chrome-extension builds, touched-file complexity gate — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
