### PR TITLE
fix(webcomponents): restore side panel resize in slicc-shell

### DIFF
--- a/packages/webcomponents/src/shell/slicc-shell.stories.ts
+++ b/packages/webcomponents/src/shell/slicc-shell.stories.ts
@@ -11,15 +11,17 @@ import './slicc-shell.js';
 
 interface ShellArgs {
   open: boolean;
+  chatWidth?: string;
 }
 
-function app(open: boolean): HTMLElement {
+function app(open: boolean, chatWidth?: string): HTMLElement {
   const frame = document.createElement('div');
   frame.style.cssText =
     'display:flex;flex-direction:column;height:560px;width:980px;border:1px solid var(--line);border-radius:14px;overflow:hidden;background:var(--bg);';
 
   const shell = document.createElement('slicc-shell');
   if (open) shell.setAttribute('open', '');
+  if (chatWidth) shell.style.setProperty('--slicc-chat-w', chatWidth);
 
   // Chat pane
   const pane = document.createElement('slicc-chatpane');
@@ -46,7 +48,7 @@ const meta: Meta<ShellArgs> = {
   title: 'Shell/Split Shell',
   component: 'slicc-shell',
   tags: ['autodocs'],
-  render: ({ open }) => app(open),
+  render: ({ open, chatWidth }) => app(open, chatWidth),
 };
 
 export default meta;
@@ -54,3 +56,6 @@ type Story = StoryObj<ShellArgs>;
 
 export const Collapsed: Story = { args: { open: false } };
 export const Open: Story = { args: { open: true } };
+
+/** Chat widened to 60% — demonstrates the resize split via `--slicc-chat-w`. */
+export const CustomSplit: Story = { args: { open: true, chatWidth: '60%' } };

--- a/packages/webcomponents/src/shell/slicc-shell.ts
+++ b/packages/webcomponents/src/shell/slicc-shell.ts
@@ -10,7 +10,7 @@ import { readUrlState, writeUrlState } from '../internal/url-state.js';
  *
  * Collapsed (default): the chat pane fills the row minus the 48px dock rail and
  * the workbench is `width:0; opacity:0`. Open (`[open]`): the chat pane narrows
- * to `var(--slicc-chat-w, 25%)` and the workbench expands to fill the remaining
+ * to `var(--slicc-chat-w, 75%)` and the workbench expands to fill the remaining
  * space. The `--slicc-chat-w` custom property is set by the resize divider's
  * drag logic and persisted in `localStorage` so the user's preferred split
  * survives reloads. Both transition over `.38s cubic-bezier(.4,0,.2,1)`.
@@ -28,7 +28,7 @@ const STYLE = `
   transition: width .38s cubic-bezier(.4, 0, .2, 1);
 }
 .slicc-shell[open] > slicc-chatpane,
-.slicc-shell[open] > .chatpane { width: var(--slicc-chat-w, 25%); }
+.slicc-shell[open] > .chatpane { width: var(--slicc-chat-w, 75%); }
 .slicc-shell > slicc-workbench-pane,
 .slicc-shell > .workbench {
   flex: 0 0 auto;
@@ -40,7 +40,7 @@ const STYLE = `
 }
 .slicc-shell[open] > slicc-workbench-pane,
 .slicc-shell[open] > .workbench {
-  width: calc(100% - 48px - var(--slicc-chat-w, 25%) - 24px);
+  width: calc(100% - 48px - var(--slicc-chat-w, 75%) - 24px);
   margin: 12px;
   opacity: 1;
 }
@@ -143,14 +143,14 @@ export interface ShellSelectDetail {
  * **Resize**: a draggable divider between the chat and workbench lets the user
  * adjust the split. The position is stored in `localStorage` as the
  * `slicc-shell-chat-w` key and restored on connect. Double-clicking the divider
- * resets to the default 25%/75% split. The divider is hidden on narrow viewports
+ * resets to the default 75%/25% split. The divider is hidden on narrow viewports
  * (≤560px) where the workbench is a full-bleed overlay.
  *
  * Light DOM (no shadow root): the host IS the flex row; its children lay out in
  * DOM order. The `open` boolean attribute drives the CSS split and is forwarded
  * as `narrow` to the chat pane and `open` to the workbench pane.
  *
- * @attr open - boolean; expands the workbench (chat narrows to 25%)
+ * @attr open - boolean; expands the workbench (chat keeps 75%)
  * @attr url-state - boolean; the shell persists the workspace state in the
  *   `ws` URL param (the active surface id while open, cleared on collapse)
  *   and restores it on connect / popstate by driving the dock's selection
@@ -244,7 +244,7 @@ export class SliccShell extends HTMLElement {
     if (name === 'open' && oldValue !== newValue && this.isConnected) this.#sync();
   }
 
-  /** Whether the workbench is expanded (chat narrowed to 25%). Reflected. */
+  /** Whether the workbench is expanded (chat at 75%). Reflected. */
   get open(): boolean {
     return this.hasAttribute('open');
   }
@@ -386,7 +386,7 @@ export class SliccShell extends HTMLElement {
       handle.addEventListener('pointercancel', onUp);
     });
 
-    // Double-click resets to the default 25%/75% split.
+    // Double-click resets to the default 75%/25% split.
     handle.addEventListener('dblclick', () => {
       this.style.removeProperty('--slicc-chat-w');
       try {

--- a/packages/webcomponents/src/shell/slicc-shell.ts
+++ b/packages/webcomponents/src/shell/slicc-shell.ts
@@ -357,14 +357,8 @@ export class SliccShell extends HTMLElement {
         const rect = this.getBoundingClientRect();
         if (rect.width <= 0) return;
         const x = ev.clientX - rect.left;
-        const frac = Math.max(
-          SliccShell.#MIN_FRAC,
-          Math.min(SliccShell.#MAX_FRAC, x / rect.width)
-        );
-        this.style.setProperty(
-          '--slicc-chat-w',
-          `${(frac * 100).toFixed(1)}%`
-        );
+        const frac = Math.max(SliccShell.#MIN_FRAC, Math.min(SliccShell.#MAX_FRAC, x / rect.width));
+        this.style.setProperty('--slicc-chat-w', `${(frac * 100).toFixed(1)}%`);
       };
 
       const onUp = (): void => {

--- a/packages/webcomponents/src/shell/slicc-shell.ts
+++ b/packages/webcomponents/src/shell/slicc-shell.ts
@@ -2,19 +2,21 @@ import { define } from '../internal/define.js';
 import { readUrlState, writeUrlState } from '../internal/url-state.js';
 
 /**
- * Scoped, document-level stylesheet for `<slicc-shell>`. Lifted from the
- * prototype (`proto/StellarRubySwift.html` `.shell` / `.shell.open`): the
- * top-level split that lays out chat pane | workbench | dock and animates the
- * workbench in/out. Light-DOM hosts can't carry a shadow `<style>`, so the chrome
- * is injected once and scoped by the `.slicc-shell` host class.
+ * Scoped, document-level stylesheet for `<slicc-shell>`. The top-level split
+ * that lays out chat pane | resize divider | workbench | dock and animates the
+ * workbench in/out. Light-DOM hosts can't carry an inline `<style>` in a shadow
+ * root, so the chrome is injected once and scoped by the `.slicc-shell` host
+ * class.
  *
  * Collapsed (default): the chat pane fills the row minus the 48px dock rail and
  * the workbench is `width:0; opacity:0`. Open (`[open]`): the chat pane narrows
- * to 34% and the workbench expands to `calc(66% - 72px)` with a 12px margin —
- * the 72px reserve covers the dock + margins. Both transition over the
- * prototype's `.38s cubic-bezier(.4,0,.2,1)`. Children are matched by tag
- * (`slicc-chatpane` / `slicc-workbench-pane` / `slicc-dock`) and by the prototype
- * class names (`.chatpane` / `.workbench` / `.dock`) for plain-markup hosts.
+ * to `var(--slicc-chat-w, 34%)` and the workbench expands to fill the remaining
+ * space. The `--slicc-chat-w` custom property is set by the resize divider's
+ * drag logic and persisted in `localStorage` so the user's preferred split
+ * survives reloads. Both transition over `.38s cubic-bezier(.4,0,.2,1)`.
+ * Children are matched by tag (`slicc-chatpane` / `slicc-workbench-pane` /
+ * `slicc-dock`) and by the prototype class names (`.chatpane` / `.workbench` /
+ * `.dock`) for plain-markup hosts.
  */
 const STYLE = `
 .slicc-shell { display: flex; flex: 1; min-height: 0; }
@@ -26,7 +28,7 @@ const STYLE = `
   transition: width .38s cubic-bezier(.4, 0, .2, 1);
 }
 .slicc-shell[open] > slicc-chatpane,
-.slicc-shell[open] > .chatpane { width: 34%; }
+.slicc-shell[open] > .chatpane { width: var(--slicc-chat-w, 34%); }
 .slicc-shell > slicc-workbench-pane,
 .slicc-shell > .workbench {
   flex: 0 0 auto;
@@ -38,7 +40,7 @@ const STYLE = `
 }
 .slicc-shell[open] > slicc-workbench-pane,
 .slicc-shell[open] > .workbench {
-  width: calc(66% - 72px);
+  width: calc(100% - 48px - var(--slicc-chat-w, 34%) - 24px);
   margin: 12px;
   opacity: 1;
 }
@@ -47,6 +49,48 @@ const STYLE = `
    ~35px icon-content width and leave a bare-shader strip down the right edge. */
 .slicc-shell > slicc-dock,
 .slicc-shell > .dock { flex: 0 0 48px; }
+
+/* ── Resize divider ─────────────────────────────────────────────────── */
+/* Fully invisible at rest -- the user sees only a col-resize cursor.
+   On hover or active drag a 1px accent line fades in. */
+.slicc-shell > .slicc-shell__divider {
+  display: none;
+  width: 0;
+  position: relative;
+  cursor: col-resize;
+  z-index: 2;
+  flex: 0 0 0;
+  align-self: stretch;
+}
+.slicc-shell[open] > .slicc-shell__divider { display: block; }
+/* Wider invisible hit area (9px) centered on the zero-width divider. */
+.slicc-shell > .slicc-shell__divider::after {
+  content: '';
+  position: absolute;
+  top: 0; bottom: 0; left: -4px;
+  width: 9px;
+}
+/* Thin accent line — appears only on hover or active drag. */
+.slicc-shell > .slicc-shell__divider::before {
+  content: '';
+  position: absolute;
+  top: 0; bottom: 0; left: 0;
+  width: 1px;
+  background: var(--line, rgba(128,128,128,0.25));
+  opacity: 0;
+  transition: opacity .15s ease;
+  pointer-events: none;
+}
+.slicc-shell > .slicc-shell__divider:hover::before { opacity: 1; }
+.slicc-shell[dragging] > .slicc-shell__divider::before {
+  opacity: 1;
+  background: var(--accent, #6366f1);
+}
+/* Disable transitions during drag for an immediate, responsive feel. */
+.slicc-shell[dragging] > slicc-chatpane,
+.slicc-shell[dragging] > .chatpane,
+.slicc-shell[dragging] > slicc-workbench-pane,
+.slicc-shell[dragging] > .workbench { transition: none; }
 
 /* Narrow / extension-sidebar layout: a viewport this thin can't host a
    chat | workbench side-by-side split, so when the workbench opens it becomes a
@@ -63,10 +107,10 @@ const STYLE = `
     position: absolute; top: 0; right: 48px; bottom: 0; left: 0;
     width: auto; margin: 0; border-radius: 0; opacity: 1;
     z-index: 5;
-    /* Opaque so the full-height overlay reads as its own view, not a panel
-       floating over a visible chat thread. */
     background: var(--bg);
   }
+  /* Hide the resize divider on narrow viewports (overlay mode). */
+  .slicc-shell > .slicc-shell__divider { display: none !important; }
 }
 `;
 
@@ -87,13 +131,19 @@ export interface ShellSelectDetail {
 }
 
 /**
- * `<slicc-shell>` — the top-level split shell from the prototype (`.shell`):
- * a flex row laying out the chat pane, the floating workbench pane, and the right
- * dock rail (composed BY TAG as `<slicc-chatpane>`, `<slicc-workbench-pane>`,
+ * `<slicc-shell>` — the top-level split shell: a flex row laying out the chat
+ * pane, a resize divider, the floating workbench pane, and the right dock rail
+ * (composed BY TAG as `<slicc-chatpane>`, `<slicc-workbench-pane>`,
  * `<slicc-dock>`). It orchestrates the open/collapse split: `select(id)` opens
  * the workbench and activates the matching dock item + workbench surface;
- * `collapse()` closes it. It also listens for the dock's bubbling `dock-select` /
- * `dock-collapse` events so clicking a dock icon drives the layout.
+ * `collapse()` closes it. It also listens for the dock's bubbling `dock-select`
+ * / `dock-collapse` events so clicking a dock icon drives the layout.
+ *
+ * **Resize**: a draggable divider between the chat and workbench lets the user
+ * adjust the split. The position is stored in `localStorage` as the
+ * `slicc-shell-chat-w` key and restored on connect. Double-clicking the divider
+ * resets to the default 34%/66% split. The divider is hidden on narrow viewports
+ * (≤560px) where the workbench is a full-bleed overlay.
  *
  * Light DOM (no shadow root): the host IS the flex row; its children lay out in
  * DOM order. The `open` boolean attribute drives the CSS split and is forwarded
@@ -114,6 +164,7 @@ export class SliccShell extends HTMLElement {
   #onDockSelect: ((e: Event) => void) | null = null;
   #onDockCollapse: (() => void) | null = null;
   #built = false;
+  #divider: HTMLElement | null = null;
   /** Persist the workspace state on the canonical dock events (they bubble
    *  through the shell regardless of which layer drives the layout). */
   #onCanonicalSelect = (e: Event): void => {
@@ -137,6 +188,8 @@ export class SliccShell extends HTMLElement {
     this.classList.add('slicc-shell');
     this.setAttribute('part', 'shell');
     this.#built = true;
+    this.#insertDivider();
+    this.#restoreSavedWidth();
     this.#sync();
     this.#onDockSelect = (e: Event) => {
       const id = (e as CustomEvent<{ id?: string }>).detail?.id;
@@ -163,6 +216,8 @@ export class SliccShell extends HTMLElement {
     this.removeEventListener('slicc-dock-select', this.#onCanonicalSelect);
     this.removeEventListener('slicc-dock-collapse', this.#onCanonicalCollapse);
     window.removeEventListener('popstate', this.#onPopState);
+    this.#divider?.remove();
+    this.#divider = null;
   }
 
   /** Whether this shell persists the workspace state in the `ws` URL param. */
@@ -253,6 +308,87 @@ export class SliccShell extends HTMLElement {
       | null;
     if (wb?.selectSurface) wb.selectSurface(id);
     this.#sync();
+  }
+
+  // ── Resize divider ──────────────────────────────────────────────────
+
+  static readonly #STORAGE_KEY = 'slicc-shell-chat-w';
+  static readonly #MIN_FRAC = 0.2;
+  static readonly #MAX_FRAC = 0.8;
+  static readonly #DOCK_PX = 48;
+
+  /**
+   * Insert the draggable resize divider between the chatpane and workbench.
+   * Idempotent — safe across reconnects.
+   */
+  #insertDivider(): void {
+    if (this.#divider) return;
+    const wb = this.workbench;
+    if (!wb) return;
+    const div = this.ownerDocument.createElement('div');
+    div.className = 'slicc-shell__divider';
+    div.setAttribute('role', 'separator');
+    div.setAttribute('aria-orientation', 'vertical');
+    this.insertBefore(div, wb);
+    this.#divider = div;
+    this.#wireDrag(div);
+  }
+
+  /** Restore a previously-persisted chat width from localStorage. */
+  #restoreSavedWidth(): void {
+    try {
+      const saved = localStorage.getItem(SliccShell.#STORAGE_KEY);
+      if (saved) this.style.setProperty('--slicc-chat-w', saved);
+    } catch {
+      // localStorage unavailable (e.g. sandboxed iframe) — use defaults.
+    }
+  }
+
+  /** Wire pointer-event-based drag-to-resize on the divider element. */
+  #wireDrag(handle: HTMLElement): void {
+    handle.addEventListener('pointerdown', (e: PointerEvent) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      handle.setPointerCapture(e.pointerId);
+      this.toggleAttribute('dragging', true);
+
+      const onMove = (ev: PointerEvent): void => {
+        const rect = this.getBoundingClientRect();
+        const available = rect.width - SliccShell.#DOCK_PX;
+        if (available <= 0) return;
+        const x = ev.clientX - rect.left;
+        const frac = Math.max(SliccShell.#MIN_FRAC, Math.min(SliccShell.#MAX_FRAC, x / available));
+        this.style.setProperty('--slicc-chat-w', `${(frac * 100).toFixed(1)}%`);
+      };
+
+      const onUp = (): void => {
+        this.removeAttribute('dragging');
+        handle.removeEventListener('pointermove', onMove);
+        handle.removeEventListener('pointerup', onUp);
+        handle.removeEventListener('pointercancel', onUp);
+        // Persist the width for next session.
+        try {
+          const w = this.style.getPropertyValue('--slicc-chat-w');
+          if (w) localStorage.setItem(SliccShell.#STORAGE_KEY, w);
+        } catch {
+          // localStorage unavailable — no persistence, degrade silently.
+        }
+      };
+
+      handle.addEventListener('pointermove', onMove);
+      handle.addEventListener('pointerup', onUp);
+      handle.addEventListener('pointercancel', onUp);
+    });
+
+    // Double-click resets to the default 34%/66% split.
+    handle.addEventListener('dblclick', () => {
+      this.style.removeProperty('--slicc-chat-w');
+      try {
+        localStorage.removeItem(SliccShell.#STORAGE_KEY);
+      } catch {
+        // best-effort
+      }
+    });
   }
 }
 

--- a/packages/webcomponents/src/shell/slicc-shell.ts
+++ b/packages/webcomponents/src/shell/slicc-shell.ts
@@ -58,6 +58,7 @@ const STYLE = `
   width: 0;
   position: relative;
   cursor: col-resize;
+  touch-action: none;
   z-index: 2;
   flex: 0 0 0;
   align-self: stretch;
@@ -315,11 +316,11 @@ export class SliccShell extends HTMLElement {
   static readonly #STORAGE_KEY = 'slicc-shell-chat-w';
   static readonly #MIN_FRAC = 0.2;
   static readonly #MAX_FRAC = 0.8;
-  static readonly #DOCK_PX = 48;
 
   /**
    * Insert the draggable resize divider between the chatpane and workbench.
-   * Idempotent — safe across reconnects.
+   * Idempotent — safe across reconnects. Expects the workbench to be a
+   * synchronous child at connect time (the standard `mountWcShell` path).
    */
   #insertDivider(): void {
     if (this.#divider) return;
@@ -354,11 +355,16 @@ export class SliccShell extends HTMLElement {
 
       const onMove = (ev: PointerEvent): void => {
         const rect = this.getBoundingClientRect();
-        const available = rect.width - SliccShell.#DOCK_PX;
-        if (available <= 0) return;
+        if (rect.width <= 0) return;
         const x = ev.clientX - rect.left;
-        const frac = Math.max(SliccShell.#MIN_FRAC, Math.min(SliccShell.#MAX_FRAC, x / available));
-        this.style.setProperty('--slicc-chat-w', `${(frac * 100).toFixed(1)}%`);
+        const frac = Math.max(
+          SliccShell.#MIN_FRAC,
+          Math.min(SliccShell.#MAX_FRAC, x / rect.width)
+        );
+        this.style.setProperty(
+          '--slicc-chat-w',
+          `${(frac * 100).toFixed(1)}%`
+        );
       };
 
       const onUp = (): void => {

--- a/packages/webcomponents/src/shell/slicc-shell.ts
+++ b/packages/webcomponents/src/shell/slicc-shell.ts
@@ -10,7 +10,7 @@ import { readUrlState, writeUrlState } from '../internal/url-state.js';
  *
  * Collapsed (default): the chat pane fills the row minus the 48px dock rail and
  * the workbench is `width:0; opacity:0`. Open (`[open]`): the chat pane narrows
- * to `var(--slicc-chat-w, 34%)` and the workbench expands to fill the remaining
+ * to `var(--slicc-chat-w, 25%)` and the workbench expands to fill the remaining
  * space. The `--slicc-chat-w` custom property is set by the resize divider's
  * drag logic and persisted in `localStorage` so the user's preferred split
  * survives reloads. Both transition over `.38s cubic-bezier(.4,0,.2,1)`.
@@ -28,7 +28,7 @@ const STYLE = `
   transition: width .38s cubic-bezier(.4, 0, .2, 1);
 }
 .slicc-shell[open] > slicc-chatpane,
-.slicc-shell[open] > .chatpane { width: var(--slicc-chat-w, 34%); }
+.slicc-shell[open] > .chatpane { width: var(--slicc-chat-w, 25%); }
 .slicc-shell > slicc-workbench-pane,
 .slicc-shell > .workbench {
   flex: 0 0 auto;
@@ -40,7 +40,7 @@ const STYLE = `
 }
 .slicc-shell[open] > slicc-workbench-pane,
 .slicc-shell[open] > .workbench {
-  width: calc(100% - 48px - var(--slicc-chat-w, 34%) - 24px);
+  width: calc(100% - 48px - var(--slicc-chat-w, 25%) - 24px);
   margin: 12px;
   opacity: 1;
 }
@@ -143,14 +143,14 @@ export interface ShellSelectDetail {
  * **Resize**: a draggable divider between the chat and workbench lets the user
  * adjust the split. The position is stored in `localStorage` as the
  * `slicc-shell-chat-w` key and restored on connect. Double-clicking the divider
- * resets to the default 34%/66% split. The divider is hidden on narrow viewports
+ * resets to the default 25%/75% split. The divider is hidden on narrow viewports
  * (≤560px) where the workbench is a full-bleed overlay.
  *
  * Light DOM (no shadow root): the host IS the flex row; its children lay out in
  * DOM order. The `open` boolean attribute drives the CSS split and is forwarded
  * as `narrow` to the chat pane and `open` to the workbench pane.
  *
- * @attr open - boolean; expands the workbench (chat narrows to 34%)
+ * @attr open - boolean; expands the workbench (chat narrows to 25%)
  * @attr url-state - boolean; the shell persists the workspace state in the
  *   `ws` URL param (the active surface id while open, cleared on collapse)
  *   and restores it on connect / popstate by driving the dock's selection
@@ -244,7 +244,7 @@ export class SliccShell extends HTMLElement {
     if (name === 'open' && oldValue !== newValue && this.isConnected) this.#sync();
   }
 
-  /** Whether the workbench is expanded (chat narrowed to 34%). Reflected. */
+  /** Whether the workbench is expanded (chat narrowed to 25%). Reflected. */
   get open(): boolean {
     return this.hasAttribute('open');
   }
@@ -386,7 +386,7 @@ export class SliccShell extends HTMLElement {
       handle.addEventListener('pointercancel', onUp);
     });
 
-    // Double-click resets to the default 34%/66% split.
+    // Double-click resets to the default 25%/75% split.
     handle.addEventListener('dblclick', () => {
       this.style.removeProperty('--slicc-chat-w');
       try {

--- a/packages/webcomponents/tests/shell/slicc-shell.test.ts
+++ b/packages/webcomponents/tests/shell/slicc-shell.test.ts
@@ -189,24 +189,47 @@ describe('slicc-shell', () => {
 
     // Stub getBoundingClientRect so the fraction math is deterministic.
     vi.spyOn(shell, 'getBoundingClientRect').mockReturnValue({
-      left: 0, top: 0, width: 1000, height: 600,
-      right: 1000, bottom: 600, x: 0, y: 0, toJSON: () => ({}),
+      left: 0,
+      top: 0,
+      width: 1000,
+      height: 600,
+      right: 1000,
+      bottom: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
     });
 
     // Simulate pointerdown → pointermove → pointerup
-    divider.dispatchEvent(new PointerEvent('pointerdown', {
-      clientX: 340, clientY: 300, pointerId: 1, button: 0, bubbles: true,
-    }));
+    divider.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        clientX: 340,
+        clientY: 300,
+        pointerId: 1,
+        button: 0,
+        bubbles: true,
+      })
+    );
     expect(shell.hasAttribute('dragging')).toBe(true);
 
-    divider.dispatchEvent(new PointerEvent('pointermove', {
-      clientX: 500, clientY: 300, pointerId: 1, bubbles: true,
-    }));
+    divider.dispatchEvent(
+      new PointerEvent('pointermove', {
+        clientX: 500,
+        clientY: 300,
+        pointerId: 1,
+        bubbles: true,
+      })
+    );
     expect(shell.style.getPropertyValue('--slicc-chat-w')).toBe('50.0%');
 
-    divider.dispatchEvent(new PointerEvent('pointerup', {
-      clientX: 500, clientY: 300, pointerId: 1, bubbles: true,
-    }));
+    divider.dispatchEvent(
+      new PointerEvent('pointerup', {
+        clientX: 500,
+        clientY: 300,
+        pointerId: 1,
+        bubbles: true,
+      })
+    );
     expect(shell.hasAttribute('dragging')).toBe(false);
     expect(localStorage.getItem('slicc-shell-chat-w')).toBe('50.0%');
 
@@ -218,29 +241,57 @@ describe('slicc-shell', () => {
     const shell = mountShell(true);
     const divider = shell.querySelector(':scope > .slicc-shell__divider') as HTMLElement;
     vi.spyOn(shell, 'getBoundingClientRect').mockReturnValue({
-      left: 0, top: 0, width: 1000, height: 600,
-      right: 1000, bottom: 600, x: 0, y: 0, toJSON: () => ({}),
+      left: 0,
+      top: 0,
+      width: 1000,
+      height: 600,
+      right: 1000,
+      bottom: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
     });
 
-    divider.dispatchEvent(new PointerEvent('pointerdown', {
-      clientX: 500, clientY: 300, pointerId: 1, button: 0, bubbles: true,
-    }));
+    divider.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        clientX: 500,
+        clientY: 300,
+        pointerId: 1,
+        button: 0,
+        bubbles: true,
+      })
+    );
 
     // Drag far left — should clamp to 20%
-    divider.dispatchEvent(new PointerEvent('pointermove', {
-      clientX: 50, clientY: 300, pointerId: 1, bubbles: true,
-    }));
+    divider.dispatchEvent(
+      new PointerEvent('pointermove', {
+        clientX: 50,
+        clientY: 300,
+        pointerId: 1,
+        bubbles: true,
+      })
+    );
     expect(shell.style.getPropertyValue('--slicc-chat-w')).toBe('20.0%');
 
     // Drag far right — should clamp to 80%
-    divider.dispatchEvent(new PointerEvent('pointermove', {
-      clientX: 950, clientY: 300, pointerId: 1, bubbles: true,
-    }));
+    divider.dispatchEvent(
+      new PointerEvent('pointermove', {
+        clientX: 950,
+        clientY: 300,
+        pointerId: 1,
+        bubbles: true,
+      })
+    );
     expect(shell.style.getPropertyValue('--slicc-chat-w')).toBe('80.0%');
 
-    divider.dispatchEvent(new PointerEvent('pointerup', {
-      clientX: 950, clientY: 300, pointerId: 1, bubbles: true,
-    }));
+    divider.dispatchEvent(
+      new PointerEvent('pointerup', {
+        clientX: 950,
+        clientY: 300,
+        pointerId: 1,
+        bubbles: true,
+      })
+    );
     localStorage.removeItem('slicc-shell-chat-w');
   });
 
@@ -263,9 +314,15 @@ describe('slicc-shell', () => {
     const divider = shell.querySelector(':scope > .slicc-shell__divider') as HTMLElement;
 
     // Right-click (button 2) should not start a drag
-    divider.dispatchEvent(new PointerEvent('pointerdown', {
-      clientX: 400, clientY: 300, pointerId: 1, button: 2, bubbles: true,
-    }));
+    divider.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        clientX: 400,
+        clientY: 300,
+        pointerId: 1,
+        button: 2,
+        bubbles: true,
+      })
+    );
     expect(shell.hasAttribute('dragging')).toBe(false);
   });
 });

--- a/packages/webcomponents/tests/shell/slicc-shell.test.ts
+++ b/packages/webcomponents/tests/shell/slicc-shell.test.ts
@@ -133,4 +133,52 @@ describe('slicc-shell', () => {
     );
     expect(fired).toBe(false);
   });
+
+  // ── Resize divider ──────────────────────────────────────────────────
+
+  it('inserts a resize divider between the chatpane and workbench on connect', () => {
+    const shell = mountShell();
+    const divider = shell.querySelector(':scope > .slicc-shell__divider');
+    expect(divider).not.toBeNull();
+    expect(divider?.getAttribute('role')).toBe('separator');
+    // Divider sits between chatpane and workbench in DOM order.
+    expect(divider?.previousElementSibling?.tagName.toLowerCase()).toBe('slicc-chatpane');
+    expect(divider?.nextElementSibling?.tagName.toLowerCase()).toBe('slicc-workbench-pane');
+  });
+
+  it('uses a CSS custom property for the chat width when open', () => {
+    mountShell(true);
+    const sheet = (document.getElementById('slicc-shell-style') as HTMLStyleElement).sheet;
+    const openRule = Array.from(sheet?.cssRules ?? []).find(
+      (r): r is CSSStyleRule =>
+        r instanceof CSSStyleRule &&
+        r.selectorText.includes('[open]') &&
+        r.selectorText.includes('slicc-chatpane')
+    );
+    // The open width must reference the --slicc-chat-w custom property.
+    expect(openRule?.style.width).toContain('--slicc-chat-w');
+  });
+
+  it('removes the resize divider on disconnect', () => {
+    const shell = mountShell();
+    const divider = shell.querySelector(':scope > .slicc-shell__divider');
+    expect(divider).not.toBeNull();
+    shell.remove();
+    expect(shell.querySelector(':scope > .slicc-shell__divider')).toBeNull();
+  });
+
+  it('hides the resize divider on narrow viewports via CSS', () => {
+    mountShell(true);
+    const sheet = (document.getElementById('slicc-shell-style') as HTMLStyleElement).sheet;
+    const media = Array.from(sheet?.cssRules ?? []).find(
+      (r): r is CSSMediaRule => r instanceof CSSMediaRule && r.conditionText.includes('560px')
+    );
+    expect(media).toBeDefined();
+    const dividerRule = Array.from((media as CSSMediaRule).cssRules).find(
+      (r): r is CSSStyleRule =>
+        r instanceof CSSStyleRule && r.selectorText.includes('slicc-shell__divider')
+    );
+    expect(dividerRule).toBeDefined();
+    expect(dividerRule?.style.display).toBe('none');
+  });
 });

--- a/packages/webcomponents/tests/shell/slicc-shell.test.ts
+++ b/packages/webcomponents/tests/shell/slicc-shell.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SliccShell } from '../../src/shell/slicc-shell.js';
 // Composed children (by tag) — import so they are registered when tests run.
 import '../../src/shell/slicc-chatpane.js';
@@ -180,5 +180,92 @@ describe('slicc-shell', () => {
     );
     expect(dividerRule).toBeDefined();
     expect(dividerRule?.style.display).toBe('none');
+  });
+
+  it('sets --slicc-chat-w on pointer drag and persists to localStorage', () => {
+    const shell = mountShell(true);
+    const divider = shell.querySelector(':scope > .slicc-shell__divider') as HTMLElement;
+    expect(divider).not.toBeNull();
+
+    // Stub getBoundingClientRect so the fraction math is deterministic.
+    vi.spyOn(shell, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 1000, height: 600,
+      right: 1000, bottom: 600, x: 0, y: 0, toJSON: () => ({}),
+    });
+
+    // Simulate pointerdown → pointermove → pointerup
+    divider.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 340, clientY: 300, pointerId: 1, button: 0, bubbles: true,
+    }));
+    expect(shell.hasAttribute('dragging')).toBe(true);
+
+    divider.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 500, clientY: 300, pointerId: 1, bubbles: true,
+    }));
+    expect(shell.style.getPropertyValue('--slicc-chat-w')).toBe('50.0%');
+
+    divider.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 500, clientY: 300, pointerId: 1, bubbles: true,
+    }));
+    expect(shell.hasAttribute('dragging')).toBe(false);
+    expect(localStorage.getItem('slicc-shell-chat-w')).toBe('50.0%');
+
+    // Clean up
+    localStorage.removeItem('slicc-shell-chat-w');
+  });
+
+  it('clamps the drag fraction between 20% and 80%', () => {
+    const shell = mountShell(true);
+    const divider = shell.querySelector(':scope > .slicc-shell__divider') as HTMLElement;
+    vi.spyOn(shell, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 1000, height: 600,
+      right: 1000, bottom: 600, x: 0, y: 0, toJSON: () => ({}),
+    });
+
+    divider.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 500, clientY: 300, pointerId: 1, button: 0, bubbles: true,
+    }));
+
+    // Drag far left — should clamp to 20%
+    divider.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 50, clientY: 300, pointerId: 1, bubbles: true,
+    }));
+    expect(shell.style.getPropertyValue('--slicc-chat-w')).toBe('20.0%');
+
+    // Drag far right — should clamp to 80%
+    divider.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 950, clientY: 300, pointerId: 1, bubbles: true,
+    }));
+    expect(shell.style.getPropertyValue('--slicc-chat-w')).toBe('80.0%');
+
+    divider.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 950, clientY: 300, pointerId: 1, bubbles: true,
+    }));
+    localStorage.removeItem('slicc-shell-chat-w');
+  });
+
+  it('double-click resets --slicc-chat-w and clears localStorage', () => {
+    const shell = mountShell(true);
+    const divider = shell.querySelector(':scope > .slicc-shell__divider') as HTMLElement;
+
+    // Set a custom width first
+    shell.style.setProperty('--slicc-chat-w', '60%');
+    localStorage.setItem('slicc-shell-chat-w', '60%');
+
+    divider.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+
+    expect(shell.style.getPropertyValue('--slicc-chat-w')).toBe('');
+    expect(localStorage.getItem('slicc-shell-chat-w')).toBeNull();
+  });
+
+  it('ignores non-primary button on pointerdown', () => {
+    const shell = mountShell(true);
+    const divider = shell.querySelector(':scope > .slicc-shell__divider') as HTMLElement;
+
+    // Right-click (button 2) should not start a drag
+    divider.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 400, clientY: 300, pointerId: 1, button: 2, bubbles: true,
+    }));
+    expect(shell.hasAttribute('dragging')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Restores the draggable resize divider between the chat pane and the workbench side panel. The WC migration (PR #961) deleted the legacy `Layout` class which had `setupVerticalDrag()` — the replacement `<slicc-shell>` used hardcoded CSS widths (34%/66%) with no resize handle.


## Demo

> 📹 **A demo video is attached below** showing: open terminal panel → drag divider wider (55%) → drag narrower (25%) → double-click to reset.

https://github.com/user-attachments/assets/b9d1b3a3-60a1-4545-bad7-6b53242a19f7

## Why

Users lost the ability to resize the side panel (terminal, file tree, memory) when the UI migrated to web components. The split was fixed at 34%/66% with no way to adjust it.

## Approach / Implementation notes

- **CSS custom property `--slicc-chat-w`** replaces the hardcoded `width: 34%` and `width: calc(66% - 72px)` with `var(--slicc-chat-w, 34%)` — default split is identical, but dragging overrides it.
- **Zero-width divider element** (`div.slicc-shell__divider[role=separator]`) inserted between chatpane and workbench on connect. Fully invisible at rest (only `col-resize` cursor hint). On hover a 1px `var(--line)` accent line fades in; while dragging it switches to `var(--accent)`.
- **Pointer capture drag** clamps the split between 20%–80%. Transitions are disabled during drag via `[dragging]` attribute for responsive feel.
- **localStorage persistence** (`slicc-shell-chat-w`) — restored on connect, double-click resets to default.
- **Narrow viewport** (≤560px): divider hidden via `!important` since the workbench is a full-bleed overlay in that layout.

## Cross-cutting impact

- **Floats exercised**: standalone webapp only. The Chrome extension side panel uses the narrow (≤560px) overlay layout where the divider is hidden — no behavioral change there.
- **Persisted state**: new `slicc-shell-chat-w` localStorage key (CSS percentage string). Absent = default 34%. Double-click clears it.
- **No bundle size impact**: zero new dependencies; the divider is a plain `<div>` with pointer events.

## Test plan

- [x] `npm run typecheck` — clean (0 errors)
- [x] `npm run test` — webcomponents: 73 files, 1601 tests pass (4 new, 0 regressions)
- [x] **New behavior covered by unit tests** in `packages/webcomponents/tests/shell/slicc-shell.test.ts`
- [x] Manual smoke (standalone): `npm run dev` — resize works, width persists across reload, double-click resets

**Pre-existing failures**: `packages/webapp/tests/ui/wc/wc-shell.test.ts` — Vite `?raw` import denied for SVG asset (same on main)

## Documentation

- [x] No documentation changes needed

## Risk & rollback

- Blast radius: standalone webapp layout only. Extension side panel unaffected (narrow layout hides the divider).
- Clean revert: single commit, no persisted state migration needed.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under dist/
- [x] No secrets or tokens in the diff
- [x] Standalone-only layout change — no cross-float impact