### PR TITLE
docs(shell): record arg-parser migration decisions for agent/websocat (#1150)

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/agent-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/agent-command.ts
@@ -285,6 +285,28 @@ function validatePositionals(
  *   - Any other `-...` / `--...` token is an unknown-flag error.
  *   - Exactly three positional arguments are required; more is a too-many
  *     error.
+ *
+ * Why this is NOT on the shared `parseArgs` / `parseFlagArgs` from
+ * `shell/arg-parser.ts` (decision tracked in #1150, follow-up to #1141): two
+ * semantic mismatches with the `mri`-based shared parser:
+ *
+ *   1. **Value-shadowing is inverted.** The shared parser's core feature is
+ *      that a value-taking flag swallows its next token even when flag-looking
+ *      (`commit -m --help` -> message is `--help`). `agent` requires the
+ *      opposite: `--model --help`, `--thinking --help`, `--read-only --help`,
+ *      and `--schema-b64 --help` MUST error. Locked by tests in
+ *      `agent-command.test.ts` around lines 530, 682, 981, 1054.
+ *   2. **Context-sensitive positionals.** The 3rd positional (the prompt) is
+ *      taken literally even when it looks like a flag (`agent . "*" -h` ->
+ *      prompt is `-h`). The shared parser's `stopEarly` stops at the FIRST
+ *      positional, but tests require flags to still parse in the middle/after
+ *      positionals — no single `mri` mode satisfies both.
+ *
+ * Forcing the shared parser would require wrapping it in enough
+ * `agent`-specific post-validation that it ADDS a layer rather than removes
+ * one — the opposite of #1119's "reduce complicatification" goal. Revisit
+ * only if the shared parser gains an opt-in "strict value" plus
+ * "literal Nth positional" mode.
  */
 function parseArgs(args: string[]): ParsedArgs {
   const state: ParseState = {

--- a/packages/webapp/src/shell/supplemental-commands/websocat-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/websocat-command.ts
@@ -97,39 +97,6 @@ const UNSUPPORTED_FLAGS = new Set([
   '-S',
 ]);
 
-/**
- * Why this is NOT on the shared `parseArgs` / `parseFlagArgs` from
- * `shell/arg-parser.ts` (decision tracked in #1150, follow-up to #1141):
- * websocat was evaluated against the shared `mri`-based parser and is not a
- * clean fit. Several behaviors carry their own validation surface that the
- * shared parser does not express, so migrating would ADD a layer on top of
- * `mri` rather than remove one — the opposite of #1119's "reduce
- * complicatification" goal. Concrete mismatches:
- *
- *   - **Unsupported-flag rejection table** (`UNSUPPORTED_FLAGS`): `-s`,
- *     `--server-mode`, `--socks5`, `--exec`, … must error with a websocat-
- *     specific message. `mri` would silently parse them as unknown booleans.
- *   - **Count flag** `-v` / `-vv`: must increment a numeric counter. `mri`
- *     models repeated booleans as an array, not a count.
- *   - **Mutually exclusive toggles** `-t` / `-b`: each flips the other off
- *     (last-wins). `mri` would set both to true independently.
- *   - **Flag-implication** `--jsonrpc-omit-jsonrpc` implies `--jsonrpc`.
- *   - **Per-flag numeric range and missing-value validation**: e.g.
- *     `--close-status-code` requires 1000..4999 and emits a
- *     `websocat: --close-status-code expects 1000..4999, got '<v>'` error;
- *     `--buffer-size`, `--max-messages`, `--conn-timeout` each have their own
- *     range checks and bespoke error strings. `mri` validates none of this.
- *   - **Cross-flag validation** `--close-reason` requires `--close-status-code`.
- *   - **Extra-positional rejection**: a second positional must error with
- *     `advanced mode is not supported`, not be silently collected.
- *
- * The remaining behaviors (long/short aliases, `--flag=value` plus
- * `--flag value`, value-shadowing of `-H <next>`) would map cleanly. But the
- * validation surface above dominates the file's parser logic, so a migration
- * would replace ~200 lines of cohesive parsing with a small `mri` spec plus
- * an even larger post-validation block — net negative. Revisit only if the
- * shared parser grows declarative support for these constraints.
- */
 function parseArgs(args: string[]): ParsedArgs {
   const out: ParsedArgs = {
     text: true,

--- a/packages/webapp/src/shell/supplemental-commands/websocat-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/websocat-command.ts
@@ -97,6 +97,39 @@ const UNSUPPORTED_FLAGS = new Set([
   '-S',
 ]);
 
+/**
+ * Why this is NOT on the shared `parseArgs` / `parseFlagArgs` from
+ * `shell/arg-parser.ts` (decision tracked in #1150, follow-up to #1141):
+ * websocat was evaluated against the shared `mri`-based parser and is not a
+ * clean fit. Several behaviors carry their own validation surface that the
+ * shared parser does not express, so migrating would ADD a layer on top of
+ * `mri` rather than remove one — the opposite of #1119's "reduce
+ * complicatification" goal. Concrete mismatches:
+ *
+ *   - **Unsupported-flag rejection table** (`UNSUPPORTED_FLAGS`): `-s`,
+ *     `--server-mode`, `--socks5`, `--exec`, … must error with a websocat-
+ *     specific message. `mri` would silently parse them as unknown booleans.
+ *   - **Count flag** `-v` / `-vv`: must increment a numeric counter. `mri`
+ *     models repeated booleans as an array, not a count.
+ *   - **Mutually exclusive toggles** `-t` / `-b`: each flips the other off
+ *     (last-wins). `mri` would set both to true independently.
+ *   - **Flag-implication** `--jsonrpc-omit-jsonrpc` implies `--jsonrpc`.
+ *   - **Per-flag numeric range and missing-value validation**: e.g.
+ *     `--close-status-code` requires 1000..4999 and emits a
+ *     `websocat: --close-status-code expects 1000..4999, got '<v>'` error;
+ *     `--buffer-size`, `--max-messages`, `--conn-timeout` each have their own
+ *     range checks and bespoke error strings. `mri` validates none of this.
+ *   - **Cross-flag validation** `--close-reason` requires `--close-status-code`.
+ *   - **Extra-positional rejection**: a second positional must error with
+ *     `advanced mode is not supported`, not be silently collected.
+ *
+ * The remaining behaviors (long/short aliases, `--flag=value` plus
+ * `--flag value`, value-shadowing of `-H <next>`) would map cleanly. But the
+ * validation surface above dominates the file's parser logic, so a migration
+ * would replace ~200 lines of cohesive parsing with a small `mri` spec plus
+ * an even larger post-validation block — net negative. Revisit only if the
+ * shared parser grows declarative support for these constraints.
+ */
 function parseArgs(args: string[]): ParsedArgs {
   const out: ParsedArgs = {
     text: true,


### PR DESCRIPTION
Closes #1150 (follow-up to #1141).

## Solution

PR #1141 left two commands' hand-rolled parsers untouched as "evaluate later". This PR records the migrate-or-wontfix decision for both. Pure docs — no behavior changes, no test changes.

- **`agent-command.ts` — wontfix, documented as JSDoc on `parseArgs`.** Two semantic mismatches with the shared mri-based parser, both locked by existing tests:
  1. Inverted value-shadowing — `--model --help` etc. must REJECT; the shared parser's core feature is the opposite.
  2. Context-sensitive literal Nth positional — `agent . "*" -h` takes `-h` as the prompt literally. `stopEarly` stops at the FIRST positional but flags must still parse mid-stream; no single mri mode satisfies both.
- **`websocat-command.ts` — wontfix, recorded here only.** Evaluated against the shared parser; not a clean fit. The validation surface (unsupported-flag rejection table, `-v` count flag, mutually-exclusive `-t`/`-b`, `--jsonrpc-omit-jsonrpc` implication, per-flag numeric range and bespoke `websocat:` error strings, cross-flag `--close-reason` requires `--close-status-code`, extra-positional rejection) dominates the file. Migration would replace ~200 lines of cohesive parsing with a small mri spec plus a larger post-validation block — net negative, and the same trap #1141 identified for agent-command. The in-file JSDoc was reverted because `websocat-command.ts` is on the function-size debt list (`check-touched-exemptions` rejects any modification without a refactor); the rationale lives here and in #1150 instead. Revisit only if the shared parser grows declarative support for these constraints.

## Testing

None needed — JSDoc-only edit (agent-command.ts) inside an existing comment block. CI runs the canonical verification pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KVZ6RHM93PSVGVCMRPYB97WF&panel=chat)