### PR TITLE
feat(webapp): add clipboard image paste support

### DIFF
--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -754,5 +754,20 @@ export function wireWcAttach(deps: WireWcAttachDeps): WcAttachmentStage {
     if (!detail) return;
     void handleAdd(detail, deps, stage).catch((err) => log.error('WC add-menu action failed', err));
   });
+
+  document.addEventListener('paste', (e: ClipboardEvent) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    for (const item of Array.from(items)) {
+      if (!item.type.startsWith('image/')) continue;
+      const raw = item.getAsFile();
+      if (!raw) continue;
+      e.preventDefault();
+      const file = raw.name ? raw : new File([raw], 'pasted-image.png', { type: raw.type });
+      const detail = { kind: 'upload', name: file.name, size: file.size, file };
+      void handleAdd(detail, deps, stage).catch((err) => log.error('Paste image failed', err));
+    }
+  });
+
   return stage;
 }

--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -755,17 +755,16 @@ export function wireWcAttach(deps: WireWcAttachDeps): WcAttachmentStage {
     void handleAdd(detail, deps, stage).catch((err) => log.error('WC add-menu action failed', err));
   });
 
-  document.addEventListener('paste', (e: ClipboardEvent) => {
-    const active = document.activeElement;
-    if (!active || !inputCard.contains(active)) return;
-    const items = e.clipboardData?.items;
+  inputCard.addEventListener('paste', (e) => {
+    const items = (e as ClipboardEvent).clipboardData?.items;
     if (!items) return;
     for (const item of Array.from(items)) {
       if (!item.type.startsWith('image/')) continue;
       const raw = item.getAsFile();
       if (!raw) continue;
       e.preventDefault();
-      const file = raw.name ? raw : new File([raw], 'pasted-image.png', { type: raw.type });
+      const ext = (raw.type.split('/')[1] || 'png').replace(/[^a-z0-9]/gi, '') || 'png';
+      const file = raw.name ? raw : new File([raw], `pasted-image.${ext}`, { type: raw.type });
       const detail = { kind: 'upload', name: file.name, size: file.size, file };
       void handleAdd(detail, deps, stage).catch((err) => log.error('Paste image failed', err));
     }

--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -756,6 +756,8 @@ export function wireWcAttach(deps: WireWcAttachDeps): WcAttachmentStage {
   });
 
   document.addEventListener('paste', (e: ClipboardEvent) => {
+    const active = document.activeElement;
+    if (!active || !inputCard.contains(active)) return;
     const items = e.clipboardData?.items;
     if (!items) return;
     for (const item of Array.from(items)) {

--- a/packages/webapp/tests/ui/wc/wc-attach.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-attach.test.ts
@@ -385,6 +385,12 @@ describe('wireWcAttach action routing', () => {
     });
   });
 
+  function focusInputCard(inputCard: HTMLElement): void {
+    const ta = inputCard.querySelector('textarea') ?? inputCard;
+    ta.setAttribute('tabindex', '0');
+    ta.focus();
+  }
+
   function pasteFiles(files: File[]): ClipboardEvent {
     const items = files.map((f) => ({ type: f.type, getAsFile: () => f }));
     const ev = new Event('paste', { bubbles: true, cancelable: true }) as Event & {
@@ -396,7 +402,8 @@ describe('wireWcAttach action routing', () => {
   }
 
   it('stages a pasted clipboard image via the document paste listener', async () => {
-    const { stage } = await setup();
+    const { inputCard, stage } = await setup();
+    focusInputCard(inputCard);
     const file = new File([new Uint8Array([1, 2, 3])], 'screenshot.png', { type: 'image/png' });
     const ev = pasteFiles([file]);
     await vi.waitFor(() => {
@@ -408,7 +415,8 @@ describe('wireWcAttach action routing', () => {
   });
 
   it('uses a fallback name for pasted images with no filename', async () => {
-    const { stage } = await setup();
+    const { inputCard, stage } = await setup();
+    focusInputCard(inputCard);
     const file = new File([new Uint8Array([4, 5])], '', { type: 'image/png' });
     pasteFiles([file]);
     await vi.waitFor(() => {
@@ -418,8 +426,21 @@ describe('wireWcAttach action routing', () => {
   });
 
   it('ignores non-image clipboard pastes', async () => {
-    const { stage } = await setup();
+    const { inputCard, stage } = await setup();
+    focusInputCard(inputCard);
     const file = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+    const ev = pasteFiles([file]);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stage.items).toHaveLength(0);
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it('ignores image paste when focus is outside the input card', async () => {
+    const { stage } = await setup();
+    const other = document.createElement('input');
+    document.body.appendChild(other);
+    other.focus();
+    const file = new File([new Uint8Array([1, 2, 3])], 'shot.png', { type: 'image/png' });
     const ev = pasteFiles([file]);
     await new Promise((r) => setTimeout(r, 50));
     expect(stage.items).toHaveLength(0);

--- a/packages/webapp/tests/ui/wc/wc-attach.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-attach.test.ts
@@ -385,27 +385,20 @@ describe('wireWcAttach action routing', () => {
     });
   });
 
-  function focusInputCard(inputCard: HTMLElement): void {
-    const ta = inputCard.querySelector('textarea') ?? inputCard;
-    ta.setAttribute('tabindex', '0');
-    ta.focus();
-  }
-
-  function pasteFiles(files: File[]): ClipboardEvent {
+  function pasteFiles(target: HTMLElement, files: File[]): Event {
     const items = files.map((f) => ({ type: f.type, getAsFile: () => f }));
     const ev = new Event('paste', { bubbles: true, cancelable: true }) as Event & {
       clipboardData: { items: typeof items };
     };
     Object.defineProperty(ev, 'clipboardData', { value: { items } });
-    document.dispatchEvent(ev);
-    return ev as unknown as ClipboardEvent;
+    target.dispatchEvent(ev);
+    return ev;
   }
 
-  it('stages a pasted clipboard image via the document paste listener', async () => {
+  it('stages a pasted clipboard image via the input card paste listener', async () => {
     const { inputCard, stage } = await setup();
-    focusInputCard(inputCard);
     const file = new File([new Uint8Array([1, 2, 3])], 'screenshot.png', { type: 'image/png' });
-    const ev = pasteFiles([file]);
+    const ev = pasteFiles(inputCard, [file]);
     await vi.waitFor(() => {
       expect(stage.items).toHaveLength(1);
     });
@@ -414,34 +407,31 @@ describe('wireWcAttach action routing', () => {
     expect(ev.defaultPrevented).toBe(true);
   });
 
-  it('uses a fallback name for pasted images with no filename', async () => {
+  it('uses a fallback name with correct extension based on MIME type', async () => {
     const { inputCard, stage } = await setup();
-    focusInputCard(inputCard);
-    const file = new File([new Uint8Array([4, 5])], '', { type: 'image/png' });
-    pasteFiles([file]);
+    const file = new File([new Uint8Array([4, 5])], '', { type: 'image/jpeg' });
+    pasteFiles(inputCard, [file]);
     await vi.waitFor(() => {
       expect(stage.items).toHaveLength(1);
     });
-    expect(stage.items[0].name).toBe('pasted-image.png');
+    expect(stage.items[0].name).toBe('pasted-image.jpeg');
   });
 
   it('ignores non-image clipboard pastes', async () => {
     const { inputCard, stage } = await setup();
-    focusInputCard(inputCard);
     const file = new File(['hello'], 'notes.txt', { type: 'text/plain' });
-    const ev = pasteFiles([file]);
+    const ev = pasteFiles(inputCard, [file]);
     await new Promise((r) => setTimeout(r, 50));
     expect(stage.items).toHaveLength(0);
     expect(ev.defaultPrevented).toBe(false);
   });
 
-  it('ignores image paste when focus is outside the input card', async () => {
+  it('does not fire when paste targets an unrelated element', async () => {
     const { stage } = await setup();
     const other = document.createElement('input');
     document.body.appendChild(other);
-    other.focus();
     const file = new File([new Uint8Array([1, 2, 3])], 'shot.png', { type: 'image/png' });
-    const ev = pasteFiles([file]);
+    const ev = pasteFiles(other, [file]);
     await new Promise((r) => setTimeout(r, 50));
     expect(stage.items).toHaveLength(0);
     expect(ev.defaultPrevented).toBe(false);

--- a/packages/webapp/tests/ui/wc/wc-attach.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-attach.test.ts
@@ -384,6 +384,47 @@ describe('wireWcAttach action routing', () => {
       expect(selects).toEqual(['2026-06-11-session.md']);
     });
   });
+
+  function pasteFiles(files: File[]): ClipboardEvent {
+    const items = files.map((f) => ({ type: f.type, getAsFile: () => f }));
+    const ev = new Event('paste', { bubbles: true, cancelable: true }) as Event & {
+      clipboardData: { items: typeof items };
+    };
+    Object.defineProperty(ev, 'clipboardData', { value: { items } });
+    document.dispatchEvent(ev);
+    return ev as unknown as ClipboardEvent;
+  }
+
+  it('stages a pasted clipboard image via the document paste listener', async () => {
+    const { stage } = await setup();
+    const file = new File([new Uint8Array([1, 2, 3])], 'screenshot.png', { type: 'image/png' });
+    const ev = pasteFiles([file]);
+    await vi.waitFor(() => {
+      expect(stage.items).toHaveLength(1);
+    });
+    expect(stage.items[0].kind).toBe('image');
+    expect(stage.items[0].name).toBe('screenshot.png');
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('uses a fallback name for pasted images with no filename', async () => {
+    const { stage } = await setup();
+    const file = new File([new Uint8Array([4, 5])], '', { type: 'image/png' });
+    pasteFiles([file]);
+    await vi.waitFor(() => {
+      expect(stage.items).toHaveLength(1);
+    });
+    expect(stage.items[0].name).toBe('pasted-image.png');
+  });
+
+  it('ignores non-image clipboard pastes', async () => {
+    const { stage } = await setup();
+    const file = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+    const ev = pasteFiles([file]);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stage.items).toHaveLength(0);
+    expect(ev.defaultPrevented).toBe(false);
+  });
 });
 
 // Stub the `<slicc-composer-capture>` element once so the inline-overlay tests


### PR DESCRIPTION
## Summary
- Adds a document-level `paste` event listener in `wc-attach.ts` that intercepts clipboard images (e.g. screenshots via Cmd+Shift+4, or right-click → Copy Image) and stages them as prompt attachments
- Routes pasted images through the same upload pipeline that drag-and-drop already uses (`handleAdd` with `kind: 'upload'`)
- Assigns a fallback filename (`pasted-image.png`) when the clipboard item has no name

## Test plan
- [x] Unit tests added for: image paste stages correctly, fallback name for unnamed images, non-image pastes are ignored
- [ ] Manual: copy an image to clipboard (screenshot or Copy Image from browser), Cmd+V in chat input → image appears as staged attachment chip
- [ ] Manual: paste plain text → normal paste behavior, no attachment created

🤖 Generated with [Claude Code](https://claude.com/claude-code)