### PR TITLE
fix(webcomponents): thinking level pill opens dropdown instead of cycling

### DIFF
--- a/packages/webcomponents/src/composer/slicc-composer-meta.stories.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-meta.stories.ts
@@ -112,6 +112,23 @@ export const InComposer: Story = {
 };
 
 /**
+ * The thinking dropdown — click the thinking pill to open it. All six wetness
+ * levels listed with the current one ticked; hovering a row shows the Italian
+ * gloss as a tooltip. Pops UP like the model dropdown.
+ */
+export const ThinkingDropdown: Story = {
+  render: () => {
+    const wrap = document.createElement('div');
+    wrap.style.cssText = 'min-height:320px;display:flex;align-items:flex-end;padding:16px;';
+    const row = document.createElement('slicc-composer-meta');
+    row.setAttribute('model', 'Opus 4.8');
+    row.setAttribute('thinking', 'high');
+    wrap.append(row);
+    return wrap;
+  },
+};
+
+/**
  * The model dropdown across many providers — rows show model + provider, and the
  * long list grows a type-ahead search (filter by model name or provider). Click
  * "Opus 4.8" to open it; it pops UP from the bottom-anchored row.

--- a/packages/webcomponents/src/composer/slicc-composer-meta.stories.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-meta.stories.ts
@@ -17,7 +17,7 @@ const meta: Meta<MetaArgs> = {
       control: 'inline-radio',
       options: ['off', 'low', 'medium', 'high', 'xhigh', 'max'],
       description:
-        'Thinking effort level (cycles on click): Secco · Goccia · Bagnato · Affogato · Inzuppato · Sprofondato',
+        'Thinking effort level (dropdown): Secco · Goccia · Bagnato · Affogato · Inzuppato · Sprofondato',
     },
     narrow: { control: 'boolean', description: 'Hide the keyboard hint (narrow chat column)' },
   },
@@ -38,7 +38,7 @@ type Story = StoryObj<MetaArgs>;
  * stroke), `max` thinking (`Sprofondato` — lucide `brain` tinted full violet,
  * violet border), each pill capped by a lucide `chevron-down` caret, and the
  * full keyboard hint. Click the model pill to fire `model-change`; click the
- * thinking pill to cycle the effort level. No glyph is an emoji or bespoke
+ * thinking pill to open the effort-level dropdown. No glyph is an emoji or bespoke
  * unicode symbol.
  */
 export const Default: Story = { args: { model: 'Opus 4.8', thinking: 'max' } };

--- a/packages/webcomponents/src/composer/slicc-composer-meta.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-meta.ts
@@ -665,6 +665,7 @@ export class SliccComposerMeta extends HTMLElement {
 
   #openMenu(): void {
     if (this.#menuOpen) return;
+    this.#closeThinkingMenu();
     this.#menuOpen = true;
     // Start each open with a cleared filter, then focus the search box (if shown).
     this.#query = '';
@@ -720,6 +721,7 @@ export class SliccComposerMeta extends HTMLElement {
 
   #openThinkingMenu(): void {
     if (this.#thinkingMenuOpen) return;
+    this.#closeMenu();
     this.#thinkingMenuOpen = true;
     this.#reflectThinkingMenu();
     document.addEventListener('mousedown', this.#onDocDown);

--- a/packages/webcomponents/src/composer/slicc-composer-meta.ts
+++ b/packages/webcomponents/src/composer/slicc-composer-meta.ts
@@ -206,15 +206,15 @@ const STYLE = `
   .brain{color:var(--violet);display:block;vertical-align:-2px;flex:0 0 auto;}
   /* Model dropdown — anchored to the model pill and opening UPWARD (the meta row
      sits at the very bottom of the composer, so a downward menu would clip). */
-  .mwrap{position:relative;flex:0 0 auto;display:inline-flex;}
+  .mwrap,.twrap{position:relative;flex:0 0 auto;display:inline-flex;}
   .ctl .cx svg{transition:transform .15s ease;}
-  .mwrap.open .ctl .cx svg{transform:rotate(180deg);}
+  .mwrap.open .ctl .cx svg,.twrap.open .ctl .cx svg{transform:rotate(180deg);}
   .menu{position:absolute;bottom:calc(100% + 6px);left:0;min-width:170px;
     background:var(--canvas);border:1px solid var(--line);border-radius:10px;
     box-shadow:0 -10px 28px -10px rgba(10,10,10,.22),0 -2px 8px -4px rgba(10,10,10,.12);
     padding:5px;opacity:0;transform:translateY(4px);pointer-events:none;
     transition:opacity .12s ease,transform .12s ease;z-index:20;}
-  .mwrap.open .menu{opacity:1;transform:none;pointer-events:auto;}
+  .mwrap.open .menu,.twrap.open .menu{opacity:1;transform:none;pointer-events:auto;}
   /* type-ahead search (shown when the list is long) */
   .msearch{width:100%;box-sizing:border-box;margin:0 0 5px;padding:6px 9px;border:1px solid var(--line);
     border-radius:7px;background:var(--ghost);color:var(--ink);font:inherit;font-size:12.5px;outline:none;}
@@ -229,6 +229,7 @@ const STYLE = `
   .mitem .tick{margin-left:auto;display:inline-flex;color:var(--violet);visibility:hidden;}
   .mitem[aria-selected="true"] .tick{visibility:visible;}
   .mempty{padding:10px;color:var(--txt-3);font-size:12px;text-align:center;}
+  .titem .mname{min-width:unset;overflow:visible;text-overflow:unset;}
   @media (prefers-reduced-motion: reduce){.menu,.ctl .cx svg{transition:none;}}
   .mspacer{flex:1;}
   .hint{font-size:11px;color:var(--txt-3);display:inline-flex;align-items:center;gap:7px;}
@@ -302,19 +303,30 @@ export class SliccComposerMeta extends HTMLElement {
   #modelEl: HTMLButtonElement | null = null;
   #thinkingEl: HTMLButtonElement | null = null;
   #mwrapEl: HTMLElement | null = null;
+  #twrapEl: HTMLElement | null = null;
   #listEl: HTMLElement | null = null;
   #models: (string | ModelOption)[] | null = null;
   #menuOpen = false;
+  #thinkingMenuOpen = false;
   #query = '';
 
   #onDocDown = (e: MouseEvent): void => {
-    if (this.#menuOpen && !e.composedPath().includes(this)) this.#closeMenu();
+    const path = e.composedPath();
+    if (this.#menuOpen && !path.includes(this)) this.#closeMenu();
+    if (this.#thinkingMenuOpen && !path.includes(this)) this.#closeThinkingMenu();
   };
   #onKey = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape' && this.#menuOpen) {
-      e.stopPropagation();
-      this.#closeMenu();
-      this.#modelEl?.focus();
+    if (e.key === 'Escape') {
+      if (this.#menuOpen) {
+        e.stopPropagation();
+        this.#closeMenu();
+        this.#modelEl?.focus();
+      }
+      if (this.#thinkingMenuOpen) {
+        e.stopPropagation();
+        this.#closeThinkingMenu();
+        this.#thinkingEl?.focus();
+      }
     }
   };
 
@@ -480,19 +492,19 @@ export class SliccComposerMeta extends HTMLElement {
     // sets `no-thinking` for plain completion models, and the no-accounts
     // "Add AI" state has no model at all.
     const showThinking = !this.noThinking && !noModels;
-    let thinkingBtn: HTMLElement | null = null;
+    let thinkingWrap: HTMLElement | null = null;
     if (showThinking) {
       const brain = brainIcon();
-      // The brain tint tracks the thinking intensity (dry → violet), overriding
-      // the `.brain` rule's fallback colour with the per-level token blend.
       brain.style.color = levelMeta.tint;
-      thinkingBtn = h(
+      const thinkingBtn = h(
         'button',
         {
           type: 'button',
           class: `ctl tsel${accented ? ' x' : ''}`,
           part: 'thinking',
           title: levelMeta.gloss,
+          'aria-haspopup': 'menu',
+          'aria-expanded': 'false',
         },
         brain,
         ' ',
@@ -500,9 +512,31 @@ export class SliccComposerMeta extends HTMLElement {
         ' ',
         h('span', { class: 'cx' }, caretIcon())
       );
-      // The whole pill ramps with intensity: feed the per-level accent to the
-      // `--tw`-driven text/border/background-wash rules above.
       thinkingBtn.style.setProperty('--tw', levelMeta.tint);
+
+      const tmenu = h('div', { class: 'menu tmenu', part: 'thinking-menu', role: 'menu' });
+      const tlist = h('div', { class: 'mlist', role: 'none' });
+      for (const level of THINKING_LEVELS) {
+        const meta = THINKING_META[level];
+        const selected = level === thinking;
+        const row = h(
+          'button',
+          {
+            type: 'button',
+            class: 'mitem titem',
+            role: 'menuitemradio',
+            'data-level': level,
+            'aria-selected': selected ? 'true' : 'false',
+            title: meta.gloss,
+          },
+          h('span', { class: 'mname' }, meta.label),
+          h('span', { class: 'tick' }, iconEl('check', { size: 14 }))
+        );
+        row.addEventListener('click', () => this.#selectThinking(level));
+        tlist.append(row);
+      }
+      tmenu.append(tlist);
+      thinkingWrap = h('div', { class: 'twrap' }, thinkingBtn, tmenu);
     }
 
     const hintSlot = h('slot', { name: 'hint' });
@@ -519,7 +553,7 @@ export class SliccComposerMeta extends HTMLElement {
       'div',
       { class: 'meta', part: 'meta' },
       mwrap,
-      thinkingBtn ?? false,
+      thinkingWrap ?? false,
       h('div', { class: 'mspacer' }),
       h('span', { class: 'hint', part: 'hint' }, hintSlot)
     );
@@ -527,11 +561,13 @@ export class SliccComposerMeta extends HTMLElement {
     this.#root.replaceChildren(rainbowDefs(), meta);
 
     this.#mwrapEl = mwrap;
+    this.#twrapEl = this.#root.querySelector('.twrap');
     this.#modelEl = this.#root.querySelector('.msel');
     this.#thinkingEl = this.#root.querySelector('.tsel');
     this.#renderModelList();
     // A re-render (e.g. an attribute change) preserves the open menu state.
     this.#reflectMenu();
+    this.#reflectThinkingMenu();
     this.#bind();
   }
 
@@ -585,7 +621,7 @@ export class SliccComposerMeta extends HTMLElement {
       this.#modelEl.addEventListener('click', this.#onModelClick);
     }
     if (this.#thinkingEl) {
-      this.#onThinkingClick = () => this.#cycleThinking();
+      this.#onThinkingClick = () => this.#toggleThinkingMenu();
       this.#thinkingEl.addEventListener('click', this.#onThinkingClick);
     }
   }
@@ -602,6 +638,7 @@ export class SliccComposerMeta extends HTMLElement {
     this.#modelEl = null;
     this.#thinkingEl = null;
     this.#mwrapEl = null;
+    this.#twrapEl = null;
     this.#listEl = null;
   }
 
@@ -646,8 +683,10 @@ export class SliccComposerMeta extends HTMLElement {
     if (!this.#menuOpen) return;
     this.#menuOpen = false;
     this.#reflectMenu();
-    document.removeEventListener('mousedown', this.#onDocDown);
-    document.removeEventListener('keydown', this.#onKey, true);
+    if (!this.#thinkingMenuOpen) {
+      document.removeEventListener('mousedown', this.#onDocDown);
+      document.removeEventListener('keydown', this.#onKey, true);
+    }
   }
 
   /** Mirror `#menuOpen` onto the DOM (the open class + the pill's aria-expanded). */
@@ -675,20 +714,42 @@ export class SliccComposerMeta extends HTMLElement {
     );
   }
 
-  /**
-   * Advance to the next wetness effort level (wrapping), swap the label, retint
-   * the brain glyph, toggle the violet border, and emit `thinking-change`.
-   */
-  #cycleThinking(): void {
-    const idx = THINKING_LEVELS.indexOf(this.thinking);
-    const next = THINKING_LEVELS[(idx + 1) % THINKING_LEVELS.length];
-    this.thinking = next; // re-renders via attributeChangedCallback
+  #toggleThinkingMenu(): void {
+    this.#thinkingMenuOpen ? this.#closeThinkingMenu() : this.#openThinkingMenu();
+  }
+
+  #openThinkingMenu(): void {
+    if (this.#thinkingMenuOpen) return;
+    this.#thinkingMenuOpen = true;
+    this.#reflectThinkingMenu();
+    document.addEventListener('mousedown', this.#onDocDown);
+    document.addEventListener('keydown', this.#onKey, true);
+  }
+
+  #closeThinkingMenu(): void {
+    if (!this.#thinkingMenuOpen) return;
+    this.#thinkingMenuOpen = false;
+    this.#reflectThinkingMenu();
+    if (!this.#menuOpen) {
+      document.removeEventListener('mousedown', this.#onDocDown);
+      document.removeEventListener('keydown', this.#onKey, true);
+    }
+  }
+
+  #reflectThinkingMenu(): void {
+    this.#twrapEl?.classList.toggle('open', this.#thinkingMenuOpen);
+    this.#thinkingEl?.setAttribute('aria-expanded', this.#thinkingMenuOpen ? 'true' : 'false');
+  }
+
+  #selectThinking(level: ThinkingLevel): void {
+    this.#closeThinkingMenu();
+    this.thinking = level;
     this.dispatchEvent(
       new CustomEvent('thinking-change', {
         detail: {
-          thinking: next,
-          label: THINKING_META[next].label,
-          accented: next === ACCENTED_LEVEL,
+          thinking: level,
+          label: THINKING_META[level].label,
+          accented: level === ACCENTED_LEVEL,
         },
         bubbles: true,
         composed: true,

--- a/packages/webcomponents/tests/composer/slicc-composer-meta.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-composer-meta.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { SliccComposerMeta, THINKING_LEVELS } from '../../src/composer/slicc-composer-meta.js';
+import { SliccComposerMeta } from '../../src/composer/slicc-composer-meta.js';
 import { ensureGlobalTokens } from '../../src/theme/tokens.js';
 
 function mount(setup?: (el: SliccComposerMeta) => void): SliccComposerMeta {
@@ -309,20 +309,20 @@ describe('slicc-composer-meta', () => {
         e.model = 'Sonnet 4.6';
       });
       modelPill(el).click();
-      const items = [...(el.shadowRoot?.querySelectorAll('.mitem') ?? [])];
+      const items = [...(el.shadowRoot?.querySelectorAll('.mwrap .mitem') ?? [])];
       expect(items.map((i) => i.querySelector('.mname')?.textContent)).toEqual([
         'Opus 4.8',
         'Sonnet 4.6',
         'Haiku 4.5',
       ]);
-      const selected = el.shadowRoot?.querySelector('.mitem[aria-selected="true"]');
+      const selected = el.shadowRoot?.querySelector('.mwrap .mitem[aria-selected="true"]');
       expect(selected?.querySelector('.mname')?.textContent).toBe('Sonnet 4.6');
     });
 
     it('shows each row as model name + provider (the webapp two-part label)', () => {
       const el = mount();
       modelPill(el).click();
-      const first = el.shadowRoot?.querySelector('.mitem');
+      const first = el.shadowRoot?.querySelector('.mwrap .mitem');
       expect(first?.querySelector('.mname')?.textContent).toBe('Opus 4.8');
       expect(first?.querySelector('.mprov')?.textContent).toBe('Anthropic');
     });
@@ -331,7 +331,7 @@ describe('slicc-composer-meta', () => {
       const el = mount();
       el.models = ['gpt-5', { name: 'o4', provider: 'OpenAI', id: 'o4-mini' }];
       modelPill(el).click();
-      const items = [...(el.shadowRoot?.querySelectorAll('.mitem') ?? [])];
+      const items = [...(el.shadowRoot?.querySelectorAll('.mwrap .mitem') ?? [])];
       expect(items.map((i) => i.querySelector('.mname')?.textContent)).toEqual(['gpt-5', 'o4']);
       expect(items[1].querySelector('.mprov')?.textContent).toBe('OpenAI');
     });
@@ -373,17 +373,21 @@ describe('slicc-composer-meta', () => {
       // Filter by provider name.
       search.value = 'openai';
       search.dispatchEvent(new Event('input'));
-      let names = [...(el.shadowRoot?.querySelectorAll('.mname') ?? [])].map((n) => n.textContent);
+      let names = [...(el.shadowRoot?.querySelectorAll('.mwrap .mname') ?? [])].map(
+        (n) => n.textContent
+      );
       expect(names).toEqual(['GPT-5', 'GPT-5 mini', 'o4']);
       // Filter by model name.
       search.value = 'gemini';
       search.dispatchEvent(new Event('input'));
-      names = [...(el.shadowRoot?.querySelectorAll('.mname') ?? [])].map((n) => n.textContent);
+      names = [...(el.shadowRoot?.querySelectorAll('.mwrap .mname') ?? [])].map(
+        (n) => n.textContent
+      );
       expect(names).toEqual(['Gemini 2.5 Pro', 'Gemini 2.5 Flash']);
       // No match → empty state.
       search.value = 'zzz';
       search.dispatchEvent(new Event('input'));
-      expect(el.shadowRoot?.querySelectorAll('.mitem').length).toBe(0);
+      expect(el.shadowRoot?.querySelectorAll('.mwrap .mitem').length).toBe(0);
       expect(el.shadowRoot?.querySelector('.mempty')).not.toBeNull();
     });
 
@@ -408,43 +412,93 @@ describe('slicc-composer-meta', () => {
       expect(el.menuOpen).toBe(false);
     });
 
-    it('cycles the thinking level forward (wrapping) on each click', () => {
+    it('opens the thinking dropdown on pill click', () => {
+      const el = mount((e) => {
+        e.thinking = 'medium';
+      });
+      let fired = false;
+      el.addEventListener('thinking-change', () => {
+        fired = true;
+      });
+      thinkingPill(el).click();
+      // The pill toggles the menu open; nothing is committed yet.
+      expect(el.shadowRoot?.querySelector('.twrap.open')).not.toBeNull();
+      expect(thinkingPill(el).getAttribute('aria-expanded')).toBe('true');
+      expect(fired).toBe(false);
+    });
+
+    it('lists all six thinking levels with the current one ticked', () => {
+      const el = mount((e) => {
+        e.thinking = 'high';
+      });
+      thinkingPill(el).click();
+      const items = [...(el.shadowRoot?.querySelectorAll('.titem') ?? [])];
+      expect(items.map((i) => i.querySelector('.mname')?.textContent)).toEqual([
+        'Secco',
+        'Goccia',
+        'Bagnato',
+        'Affogato',
+        'Inzuppato',
+        'Sprofondato',
+      ]);
+      const selected = el.shadowRoot?.querySelector('.titem[aria-selected="true"]');
+      expect(selected?.querySelector('.mname')?.textContent).toBe('Affogato');
+    });
+
+    it('selecting a level sets thinking, closes the menu, and emits thinking-change', () => {
       const el = mount((e) => {
         e.thinking = 'off';
       });
-      const seen: string[] = [];
+      let detail: { thinking: string; label: string; accented: boolean } | null = null;
       el.addEventListener('thinking-change', (e) => {
-        seen.push((e as CustomEvent).detail.thinking);
+        detail = (e as CustomEvent).detail;
       });
-
-      // off → low → medium → high → xhigh → max → off (wrap).
-      for (let i = 0; i < THINKING_LEVELS.length; i++) thinkingPill(el).click();
-
-      expect(seen).toEqual(['low', 'medium', 'high', 'xhigh', 'max', 'off']);
-      expect(el.thinking).toBe('off');
+      thinkingPill(el).click();
+      const maxRow = el.shadowRoot?.querySelector('.titem[data-level="max"]') as HTMLButtonElement;
+      maxRow.click();
+      expect(el.thinking).toBe('max');
+      expect(el.shadowRoot?.querySelector('.twrap.open')).toBeNull();
+      expect(detail).toEqual({ thinking: 'max', label: 'Sprofondato', accented: true });
     });
 
-    it('swaps the label and toggles the violet border as it cycles', () => {
+    it('closes the thinking dropdown on outside mousedown', () => {
+      const el = mount();
+      thinkingPill(el).click();
+      expect(el.shadowRoot?.querySelector('.twrap.open')).not.toBeNull();
+      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
+      expect(el.shadowRoot?.querySelector('.twrap.open')).toBeNull();
+    });
+
+    it('closes the thinking dropdown on Escape', () => {
+      const el = mount();
+      thinkingPill(el).click();
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(el.shadowRoot?.querySelector('.twrap.open')).toBeNull();
+    });
+
+    it('swaps the label and toggles the violet border when a level is selected', () => {
       const el = mount((e) => {
         e.thinking = 'xhigh';
       });
       expect(thinkingPill(el).classList.contains('x')).toBe(false);
       expect(el.shadowRoot?.querySelector('.tlabel')?.textContent).toBe('Inzuppato');
 
-      // xhigh → max turns the border on.
+      // Select max → turns the border on.
       thinkingPill(el).click();
+      (el.shadowRoot?.querySelector('.titem[data-level="max"]') as HTMLButtonElement).click();
       expect(el.thinking).toBe('max');
       expect(el.shadowRoot?.querySelector('.tlabel')?.textContent).toBe('Sprofondato');
       expect(thinkingPill(el).classList.contains('x')).toBe(true);
 
-      // max → off turns it back off.
+      // Select off → turns it back off.
       thinkingPill(el).click();
+      (el.shadowRoot?.querySelector('.titem[data-level="off"]') as HTMLButtonElement).click();
       expect(el.thinking).toBe('off');
       expect(el.shadowRoot?.querySelector('.tlabel')?.textContent).toBe('Secco');
       expect(thinkingPill(el).classList.contains('x')).toBe(false);
     });
 
-    it('reports accented=true (with the label) only for max in the thinking-change detail', () => {
+    it('reports accented=true only for max in the thinking-change detail', () => {
       const el = mount((e) => {
         e.thinking = 'xhigh';
       });
@@ -452,7 +506,8 @@ describe('slicc-composer-meta', () => {
       el.addEventListener('thinking-change', (e) => {
         detail = (e as CustomEvent).detail;
       });
-      thinkingPill(el).click(); // → max
+      thinkingPill(el).click();
+      (el.shadowRoot?.querySelector('.titem[data-level="max"]') as HTMLButtonElement).click();
       expect(detail).toEqual({ thinking: 'max', label: 'Sprofondato', accented: true });
     });
 
@@ -555,7 +610,7 @@ describe('slicc-composer-meta', () => {
       const tsel = thinkingPill(el);
       el.remove();
       tsel.click();
-      // Detached: cycling must not advance the (removed) element's state.
+      // Detached: the menu must not open or change state.
       expect(el.thinking).toBe('max');
     });
   });

--- a/packages/webcomponents/tests/composer/slicc-composer-meta.test.ts
+++ b/packages/webcomponents/tests/composer/slicc-composer-meta.test.ts
@@ -476,6 +476,20 @@ describe('slicc-composer-meta', () => {
       expect(el.shadowRoot?.querySelector('.twrap.open')).toBeNull();
     });
 
+    it('opening one dropdown closes the other', () => {
+      const el = mount();
+      // Open model menu, then click thinking pill → model closes.
+      modelPill(el).click();
+      expect(el.menuOpen).toBe(true);
+      thinkingPill(el).click();
+      expect(el.menuOpen).toBe(false);
+      expect(el.shadowRoot?.querySelector('.twrap.open')).not.toBeNull();
+      // Open thinking menu, then click model pill → thinking closes.
+      modelPill(el).click();
+      expect(el.menuOpen).toBe(true);
+      expect(el.shadowRoot?.querySelector('.twrap.open')).toBeNull();
+    });
+
     it('swaps the label and toggles the violet border when a level is selected', () => {
       const el = mount((e) => {
         e.thinking = 'xhigh';


### PR DESCRIPTION
## Summary
- The thinking level pill (Secco/Goccia/Bagnato/Affogato/Inzuppato/Sprofondato) now opens a proper dropdown menu on click, matching the model picker UX
- Previously it just cycled through levels one-by-one despite having a caret icon suggesting a dropdown
- Gloss descriptions (the jokey Italian comments) are tooltip-only, keeping the menu clean

## Test plan
- [x] Typecheck passes (`tsc --noEmit` on webcomponents)
- [x] Package builds cleanly
- [x] Updated existing tests to cover dropdown open/close/select behavior
- [ ] Visual verification in dev mode (tested locally at localhost:5710)

🤖 Generated with [Claude Code](https://claude.com/claude-code)