### PR TITLE
feat(speech): add multilingual on-device Kokoro voices (es/fr/it/hi/pt)

### DIFF
--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -463,7 +463,9 @@ export interface PanelRpcResults {
   'page-info': { origin: string; href: string; title: string };
   screencapture: { bytes: ArrayBuffer; width: number; height: number; mimeType: string };
   'speak-text': { done: true };
-  'list-voices': { voices: Array<{ name: string; lang: string; default: boolean }> };
+  'list-voices': {
+    voices: Array<{ name: string; lang: string; default: boolean; onDevice: boolean }>;
+  };
   'speak-status': KokoroRpcStatus;
   'speak-warmup': KokoroRpcStatus;
   'play-audio': { done: true };

--- a/packages/webapp/src/shell/supplemental-commands/say-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/say-command.ts
@@ -15,14 +15,16 @@ function sayHelp(): CommandResult {
     stdout:
       'usage: say [-v voice] [-r rate] [-l lang] [--list] <text>\n' +
       '       say --status | --warmup\n\n' +
-      '  Speaks the given text. Uses the on-device Kokoro voice when its\n' +
-      '  model has downloaded (run say --warmup, or it chains after the\n' +
-      '  whisper download) and English text; the Web Speech API otherwise.\n' +
+      '  Speaks the given text. Uses on-device Kokoro voices when the model\n' +
+      '  has downloaded (run say --warmup, or it chains after the whisper\n' +
+      '  download) for supported languages (English, Spanish, French,\n' +
+      '  Italian, Hindi, Portuguese); the Web Speech API otherwise.\n' +
       '  -v voice   Voice name (partial match; kokoro ids like af_heart work\n' +
       '             once the model is ready)\n' +
       '  -r rate    Speech rate (0.1 to 10, default 1)\n' +
-      '  -l lang    Language tag (required, BCP 47, e.g. en-US, de-DE, fr-FR)\n' +
-      '  --list     List available voices (kokoro voices first when ready)\n' +
+      '  -l lang    Language tag (required, BCP 47, e.g. en-US, es-ES, fr-FR)\n' +
+      '  --list     List voices with an engine marker ([kokoro] = on-device,\n' +
+      '             [web speech] otherwise); kokoro voices lead when ready\n' +
       '  --status   Show the on-device voice state (downloading/ready + ETA)\n' +
       '  --warmup   Stage + start the on-device voice download in the background\n',
     stderr: '',
@@ -156,22 +158,37 @@ function parseSayArgs(args: string[]): SayArgs | CommandResult {
   return parsed;
 }
 
+/** One `--list` row: `<name> (<lang>) <engine>[ [default]]`. The engine marker
+ *  is honest about playback — `[kokoro]` for on-device voices, `[web speech]`
+ *  otherwise (including kokoro voices like ja/zh that have no JS G2P). */
+function formatVoiceLine(v: {
+  name: string;
+  lang: string;
+  onDevice: boolean;
+  default?: boolean;
+}): string {
+  const engine = v.onDevice ? '[kokoro]' : '[web speech]';
+  return `${v.name} (${v.lang}) ${engine}${v.default ? ' [default]' : ''}`;
+}
+
 /** `--list`: kokoro voices lead when the on-device engine is warm — listed
- *  by their stable ids so `-v af_heart` round-trips. */
+ *  by their stable ids so `-v af_heart` round-trips. Each row carries its
+ *  language and an on-device/Web-Speech engine marker. */
 async function runList(bridge: SayBridge): Promise<CommandResult> {
   if (bridge.local) {
     const { kokoroVoicesIfReady } = await import('../../speech/speak.js');
-    const kokoro = kokoroVoicesIfReady().map((v) => `${v.id} (${v.lang}) [kokoro]`);
+    const kokoro = kokoroVoicesIfReady().map((v) =>
+      formatVoiceLine({ name: v.id, lang: v.lang, onDevice: v.onDevice })
+    );
     const voices = await getVoices();
-    const lines = [
-      ...kokoro,
-      ...voices.map((v) => `${v.name} (${v.lang})${v.default ? ' [default]' : ''}`),
-    ];
-    return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
+    const web = voices.map((v) =>
+      formatVoiceLine({ name: v.name, lang: v.lang, onDevice: false, default: v.default })
+    );
+    return { stdout: [...kokoro, ...web].join('\n') + '\n', stderr: '', exitCode: 0 };
   }
   try {
     const r = await bridge.panelRpc!.call('list-voices', undefined);
-    const lines = r.voices.map((v) => `${v.name} (${v.lang})${v.default ? ' [default]' : ''}`);
+    const lines = r.voices.map((v) => formatVoiceLine(v));
     return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
   } catch (err) {
     return fail(errText(err));

--- a/packages/webapp/src/speech/ensure-speech-assets.ts
+++ b/packages/webapp/src/speech/ensure-speech-assets.ts
@@ -32,6 +32,7 @@ import {
   type HfFileEvent,
   resolveTargetDir,
 } from '../shell/supplemental-commands/hf-download.js';
+import { ESPEAK_DIST_VFS_PATH, ESPEAK_GLUE_FILE, ESPEAK_WASM_FILE } from './espeak-phonemizer.js';
 import { KOKORO_MODEL_ID } from './kokoro-engine.js';
 import { ORT_DIST_VFS_PATH, ORT_WASM_DIST_FILES } from './transformers-env.js';
 import { WHISPER_MODEL_ID } from './whisper-engine.js';
@@ -39,6 +40,10 @@ import { WHISPER_MODEL_ID } from './whisper-engine.js';
 const log = createLogger('speech:ensure-assets');
 
 const ORT_PACKAGE = 'onnxruntime-web';
+/** Multilingual espeak-ng wasm — phonemizes the non-English on-device voices
+ *  (es/fr/it/hi/pt). Staged like ort; not bundled (~17 MB). */
+const ESPEAK_PACKAGE = 'espeak-ng';
+const ESPEAK_DIST_FILES: ReadonlyArray<string> = [ESPEAK_GLUE_FILE, ESPEAK_WASM_FILE];
 const WORKSPACE_CWD = '/workspace';
 
 const isExtensionFloat = (): boolean => typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
@@ -83,6 +88,8 @@ export interface EnsureSpeechAssetsResult {
   skipped: boolean;
   /** True when the ort runtime was (re)installed this call. */
   ortStaged: boolean;
+  /** True when the espeak-ng multilingual phonemizer was (re)installed. */
+  espeakStaged: boolean;
   repos: Array<{ repo: string; downloaded: number; skipped: number }>;
 }
 
@@ -108,6 +115,32 @@ async function ensureOrtStaged(
     throw new Error(`failed to stage ${ORT_PACKAGE} wasm runtime: ${errors[0].error.message}`);
   }
   onProgress?.({ asset: ORT_PACKAGE, phase: 'done' });
+  return true;
+}
+
+/** Stage the multilingual espeak-ng wasm if either dist file is missing —
+ *  parallel to `ensureOrtStaged`, reusing the same `ipk` installer path. */
+async function ensureEspeakStaged(
+  deps: EnsureSpeechAssetsDeps,
+  onProgress?: SpeechAssetProgressFn
+): Promise<boolean> {
+  const present = await Promise.all(
+    ESPEAK_DIST_FILES.map((f) => deps.fs.exists(`${ESPEAK_DIST_VFS_PATH}${f}`))
+  );
+  if (present.every(Boolean)) {
+    onProgress?.({ asset: ESPEAK_PACKAGE, phase: 'present' });
+    return false;
+  }
+  onProgress?.({ asset: ESPEAK_PACKAGE, phase: 'staging' });
+  const { errors } = await installPackages([ESPEAK_PACKAGE], {
+    fs: deps.fs,
+    fetch: deps.fetch,
+    cwd: WORKSPACE_CWD,
+  });
+  if (errors.length > 0) {
+    throw new Error(`failed to stage ${ESPEAK_PACKAGE} wasm: ${errors[0].error.message}`);
+  }
+  onProgress?.({ asset: ESPEAK_PACKAGE, phase: 'done' });
   return true;
 }
 
@@ -168,14 +201,15 @@ export async function ensureSpeechAssetsStaged(
   onProgress?: SpeechAssetProgressFn
 ): Promise<EnsureSpeechAssetsResult> {
   if (isExtensionFloat()) {
-    return { skipped: true, ortStaged: false, repos: [] };
+    return { skipped: true, ortStaged: false, espeakStaged: false, repos: [] };
   }
   const ortStaged = await ensureOrtStaged(deps, onProgress);
+  const espeakStaged = await ensureEspeakStaged(deps, onProgress);
   const repos = deps.repos ?? [WHISPER_MODEL_ID, KOKORO_MODEL_ID];
   const repoResults: Array<{ repo: string; downloaded: number; skipped: number }> = [];
   for (const repo of repos) {
     repoResults.push(await stageRepo(deps, repo, onProgress));
   }
-  log.info('speech assets staged', { ortStaged, repos: repoResults.length });
-  return { skipped: false, ortStaged, repos: repoResults };
+  log.info('speech assets staged', { ortStaged, espeakStaged, repos: repoResults.length });
+  return { skipped: false, ortStaged, espeakStaged, repos: repoResults };
 }

--- a/packages/webapp/src/speech/ensure-speech-assets.ts
+++ b/packages/webapp/src/speech/ensure-speech-assets.ts
@@ -9,6 +9,10 @@
  *      (reusing the `hf download` core — list + per-file byte-skip + proxied
  *      `SecureFetch` + dir creation).
  *
+ * The multilingual `espeak-ng` wasm is staged best-effort after the core assets:
+ * non-English Kokoro voices use it, but Whisper and English Kokoro should still
+ * come up if that optional package is unavailable.
+ *
  * Already-staged assets are skipped, so a second call is a fast no-op (the ort
  * fast path avoids the network entirely when every dist file is present; weight
  * repos still list the tree once, then skip every byte-matching file).
@@ -144,6 +148,20 @@ async function ensureEspeakStaged(
   return true;
 }
 
+/** Best-effort espeak staging: non-English Kokoro can retry later, but core
+ * speech assets must not fail just because this optional package is blocked. */
+async function ensureEspeakStagedBestEffort(
+  deps: EnsureSpeechAssetsDeps,
+  onProgress?: SpeechAssetProgressFn
+): Promise<boolean> {
+  try {
+    return await ensureEspeakStaged(deps, onProgress);
+  } catch (err) {
+    log.warn('optional espeak-ng staging failed; non-English Kokoro voices may fall back', err);
+    return false;
+  }
+}
+
 /** Stage one weight repo via the shared `hf download` core. */
 async function stageRepo(
   deps: EnsureSpeechAssetsDeps,
@@ -204,12 +222,12 @@ export async function ensureSpeechAssetsStaged(
     return { skipped: true, ortStaged: false, espeakStaged: false, repos: [] };
   }
   const ortStaged = await ensureOrtStaged(deps, onProgress);
-  const espeakStaged = await ensureEspeakStaged(deps, onProgress);
   const repos = deps.repos ?? [WHISPER_MODEL_ID, KOKORO_MODEL_ID];
   const repoResults: Array<{ repo: string; downloaded: number; skipped: number }> = [];
   for (const repo of repos) {
     repoResults.push(await stageRepo(deps, repo, onProgress));
   }
+  const espeakStaged = await ensureEspeakStagedBestEffort(deps, onProgress);
   log.info('speech assets staged', { ortStaged, espeakStaged, repos: repoResults.length });
   return { skipped: false, ortStaged, espeakStaged, repos: repoResults };
 }

--- a/packages/webapp/src/speech/espeak-phonemizer.ts
+++ b/packages/webapp/src/speech/espeak-phonemizer.ts
@@ -1,0 +1,168 @@
+/**
+ * Multilingual espeak-ng phonemizer for Kokoro's non-English voices.
+ *
+ * The `phonemizer` package kokoro-js bundles is English-only (its inlined
+ * espeak-ng-data carries just `en_dict` + the shared `phon*` tables). To
+ * phonemize es/fr/it/hi/pt we load the full `espeak-ng` npm package (~17 MB
+ * wasm with ALL language data embedded) — the path hexgrad/kokoro #65
+ * recommends. Like `onnxruntime-web`, it is NOT bundled: it is staged into the
+ * VFS on demand (`ensure-speech-assets.ts`) and loaded here from VFS bytes.
+ *
+ * `phonemizeWithEspeak` is the PURE core (runs the espeak CLI args against an
+ * injected module factory, reads the phoneme output) and is unit-tested with a
+ * fake factory. `getEspeakPhonemize` memoizes the real VFS-loaded factory.
+ *
+ * Cross-runtime: standalone / CLI is primary. The extension float can't
+ * dynamic-import a VFS blob-URL ESM module under MV3 CSP, so on-device
+ * non-English there needs the glue bundled into the extension build — a
+ * follow-up; it degrades to Web Speech via the routing task until then.
+ */
+
+import { createLogger } from '../core/logger.js';
+import type { EspeakPhonemize } from './kokoro-phonemize.js';
+
+const log = createLogger('speech:espeak');
+
+/** Where `ipk add espeak-ng` materializes the package in the VFS. */
+export const ESPEAK_DIST_VFS_PATH = '/workspace/node_modules/espeak-ng/dist/';
+/** The glue (ESM) + wasm dist files espeak-ng ships. */
+export const ESPEAK_GLUE_FILE = 'espeak-ng.js';
+export const ESPEAK_WASM_FILE = 'espeak-ng.wasm';
+
+/** Minimal slice of an instantiated espeak-ng emscripten module. */
+interface EspeakModule {
+  FS: { readFile(path: string, opts: { encoding: 'utf8' }): string };
+}
+/** The espeak-ng default export: a CLI-style emscripten module factory. */
+export type EspeakFactory = (options: {
+  arguments: string[];
+  locateFile?: (path: string) => string;
+}) => Promise<EspeakModule>;
+
+/**
+ * Phonemize `text` in `espeakLang` via the espeak-ng CLI surface: emit IPA
+ * (UTF-8 input via `-b=1` so accents / Devanagari survive) to an in-FS file,
+ * then read it back. Returns IPA lines (one per clause) with blanks dropped —
+ * the same shape as the `phonemizer` package's `phonemize`. Pure given
+ * `factory` (mock it in tests).
+ */
+export async function phonemizeWithEspeak(
+  factory: EspeakFactory,
+  text: string,
+  espeakLang: string,
+  locateFile?: (path: string) => string
+): Promise<string[]> {
+  const outFile = 'phonemes.txt';
+  const espeak = await factory({
+    arguments: ['-q', '-b=1', '--ipa', '-v', espeakLang, '--phonout', outFile, text],
+    ...(locateFile ? { locateFile } : {}),
+  });
+  const raw = espeak.FS.readFile(outFile, { encoding: 'utf8' });
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/** Read VFS bytes via the page-side `preview-vfs` responder (same wire the ort
+ *  wasm load uses) — bypassing the preview SW. Page/offscreen realm only. */
+function readVfsBytes(path: string): Promise<Uint8Array> {
+  if (typeof BroadcastChannel === 'undefined') {
+    return Promise.reject(new Error(`Cannot read VFS path ${path}: BroadcastChannel unavailable`));
+  }
+  const channel = new BroadcastChannel('preview-vfs');
+  const id = `espeak-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return new Promise<Uint8Array>((resolve, reject) => {
+    const done = (cb: () => void): void => {
+      channel.removeEventListener('message', listener);
+      channel.close();
+      cb();
+    };
+    const timer = setTimeout(
+      () => done(() => reject(new Error(`ENOENT: ${path} (timed out)`))),
+      30000
+    );
+    const listener = (ev: MessageEvent): void => {
+      const data = ev.data as { type?: string; id?: string; content?: unknown; error?: string };
+      if (data?.type !== 'preview-vfs-response' || data.id !== id) return;
+      clearTimeout(timer);
+      if (typeof data.error === 'string') {
+        done(() => reject(new Error(data.error)));
+      } else if (data.content instanceof Uint8Array) {
+        const c = data.content;
+        done(() => resolve(c));
+      } else if (typeof data.content === 'string') {
+        const c = data.content;
+        done(() => resolve(new TextEncoder().encode(c)));
+      } else {
+        done(() => reject(new Error(`Empty preview-vfs response for ${path}`)));
+      }
+    };
+    channel.addEventListener('message', listener);
+    channel.postMessage({ type: 'preview-vfs-read', id, path, asText: false });
+  });
+}
+
+/** Default real loader: read the staged glue + wasm from VFS, blob-URL them,
+ *  and dynamic-import the glue's emscripten factory with `locateFile` pointed
+ *  at the wasm blob. Browser realm only. */
+async function loadEspeakFactoryFromVfs(): Promise<{
+  factory: EspeakFactory;
+  locateFile: (path: string) => string;
+}> {
+  const [glue, wasm] = await Promise.all([
+    readVfsBytes(`${ESPEAK_DIST_VFS_PATH}${ESPEAK_GLUE_FILE}`),
+    readVfsBytes(`${ESPEAK_DIST_VFS_PATH}${ESPEAK_WASM_FILE}`),
+  ]);
+  const wasmUrl = URL.createObjectURL(
+    new Blob([new Uint8Array(wasm)], { type: 'application/wasm' })
+  );
+  const glueUrl = URL.createObjectURL(
+    new Blob([new Uint8Array(glue)], { type: 'text/javascript' })
+  );
+  const mod = (await import(/* @vite-ignore */ glueUrl)) as { default: EspeakFactory };
+  const locateFile = (path: string): string => (path.endsWith('.wasm') ? wasmUrl : path);
+  return { factory: mod.default, locateFile };
+}
+
+let factoryLoader: () => Promise<{
+  factory: EspeakFactory;
+  locateFile?: (path: string) => string;
+}> = loadEspeakFactoryFromVfs;
+let phonemizePromise: Promise<EspeakPhonemize> | null = null;
+
+/**
+ * The memoized multilingual `EspeakPhonemize`. First call loads the staged
+ * espeak-ng wasm; subsequent calls reuse it. A failed load resets so a later
+ * call can retry.
+ */
+export function getEspeakPhonemize(): Promise<EspeakPhonemize> {
+  if (!phonemizePromise) {
+    phonemizePromise = factoryLoader().then(
+      ({ factory, locateFile }) => {
+        log.info('espeak-ng multilingual phonemizer loaded');
+        return (text: string, lang: string) => phonemizeWithEspeak(factory, text, lang, locateFile);
+      },
+      (err) => {
+        phonemizePromise = null;
+        log.error('espeak-ng load failed', err);
+        throw err;
+      }
+    );
+  }
+  return phonemizePromise;
+}
+
+/** Test seam: inject a fake factory loader (and reset the memo). */
+export function setEspeakFactoryLoaderForTests(
+  loader: () => Promise<{ factory: EspeakFactory; locateFile?: (path: string) => string }>
+): void {
+  factoryLoader = loader;
+  phonemizePromise = null;
+}
+
+/** Test-only: restore the real VFS loader + drop the memo. */
+export function resetEspeakForTests(): void {
+  factoryLoader = loadEspeakFactoryFromVfs;
+  phonemizePromise = null;
+}

--- a/packages/webapp/src/speech/espeak-phonemizer.ts
+++ b/packages/webapp/src/speech/espeak-phonemizer.ts
@@ -64,6 +64,29 @@ export async function phonemizeWithEspeak(
     .filter((line) => line.length > 0);
 }
 
+/** Wrap an espeak factory with a per-invocation wasm blob URL. Emscripten only
+ * needs the URL while the factory promise is instantiating the module, so each
+ * call can revoke it immediately after success or failure. */
+export function createBlobBackedEspeakFactory(
+  factory: EspeakFactory,
+  wasm: Uint8Array
+): EspeakFactory {
+  return async (options) => {
+    const wasmUrl = URL.createObjectURL(
+      new Blob([new Uint8Array(wasm)], { type: 'application/wasm' })
+    );
+    try {
+      const locateFile = (path: string): string => {
+        if (path.endsWith('.wasm')) return wasmUrl;
+        return options.locateFile?.(path) ?? path;
+      };
+      return await factory({ ...options, locateFile });
+    } finally {
+      URL.revokeObjectURL(wasmUrl);
+    }
+  };
+}
+
 /** Read VFS bytes via the page-side `preview-vfs` responder (same wire the ort
  *  wasm load uses) — bypassing the preview SW. Page/offscreen realm only. */
 function readVfsBytes(path: string): Promise<Uint8Array> {
@@ -108,21 +131,20 @@ function readVfsBytes(path: string): Promise<Uint8Array> {
  *  at the wasm blob. Browser realm only. */
 async function loadEspeakFactoryFromVfs(): Promise<{
   factory: EspeakFactory;
-  locateFile: (path: string) => string;
 }> {
   const [glue, wasm] = await Promise.all([
     readVfsBytes(`${ESPEAK_DIST_VFS_PATH}${ESPEAK_GLUE_FILE}`),
     readVfsBytes(`${ESPEAK_DIST_VFS_PATH}${ESPEAK_WASM_FILE}`),
   ]);
-  const wasmUrl = URL.createObjectURL(
-    new Blob([new Uint8Array(wasm)], { type: 'application/wasm' })
-  );
   const glueUrl = URL.createObjectURL(
     new Blob([new Uint8Array(glue)], { type: 'text/javascript' })
   );
-  const mod = (await import(/* @vite-ignore */ glueUrl)) as { default: EspeakFactory };
-  const locateFile = (path: string): string => (path.endsWith('.wasm') ? wasmUrl : path);
-  return { factory: mod.default, locateFile };
+  try {
+    const mod = (await import(/* @vite-ignore */ glueUrl)) as { default: EspeakFactory };
+    return { factory: createBlobBackedEspeakFactory(mod.default, wasm) };
+  } finally {
+    URL.revokeObjectURL(glueUrl);
+  }
 }
 
 let factoryLoader: () => Promise<{

--- a/packages/webapp/src/speech/kokoro-engine.ts
+++ b/packages/webapp/src/speech/kokoro-engine.ts
@@ -107,14 +107,40 @@ const KOKORO_PREFIX_LANG: Record<string, string> = {
   z: 'zh-CN',
 };
 
-/** Base languages the base Kokoro model can phonemize on-device (espeak-ng).
- * ja/zh need misaki (no JS port), so they fall back to Web Speech. */
-const KOKORO_ON_DEVICE_LANGS = new Set(['en', 'es', 'fr', 'it', 'hi', 'pt']);
+/** Exact languages the base Kokoro model can phonemize on-device. ja/zh need
+ * misaki (no JS port), and region-different future voices (for example pt-PT)
+ * must not be treated as equivalent to the trained pt-BR head. */
+const KOKORO_ON_DEVICE_LANG_TAGS = new Set([
+  'en-US',
+  'en-GB',
+  'es-ES',
+  'fr-FR',
+  'it-IT',
+  'hi-IN',
+  'pt-BR',
+]);
 
 /** Normalize a language tag to BCP-47 casing (`en-us` → `en-US`, `es` → `es`). */
 function normalizeLangTag(lang: string): string {
   const [base, region] = lang.split('-');
   return region ? `${base.toLowerCase()}-${region.toUpperCase()}` : base.toLowerCase();
+}
+
+/** Whether a voice id + resolved language names an on-device Kokoro head. */
+function isKokoroOnDeviceVoice(id: string, resolvedLang: string | undefined): boolean {
+  if (!resolvedLang) return false;
+  if (KOKORO_ON_DEVICE_LANG_TAGS.has(resolvedLang)) return true;
+
+  // kokoro-js sometimes reports base tags (`es`) while the voice id still
+  // carries the region-bearing Kokoro prefix. Trust that only for regionless
+  // tags; a reported `pt-PT` must not collapse to the `p` prefix's pt-BR head.
+  if (resolvedLang.includes('-')) return false;
+  const prefixLang = KOKORO_PREFIX_LANG[id[0]];
+  return (
+    prefixLang !== undefined &&
+    KOKORO_ON_DEVICE_LANG_TAGS.has(prefixLang) &&
+    prefixLang.split('-')[0].toLowerCase() === resolvedLang
+  );
 }
 
 /** Map kokoro-js's voices object into the normalized picker shape. Resolves
@@ -130,7 +156,6 @@ export function toKokoroVoiceInfos(
     const resolvedLang = meta.language
       ? normalizeLangTag(meta.language)
       : KOKORO_PREFIX_LANG[id[0]];
-    const baseLang = resolvedLang?.split('-')[0].toLowerCase();
     return {
       id,
       name: meta.name || id,
@@ -139,7 +164,7 @@ export function toKokoroVoiceInfos(
       // Only on-device when the language was actually resolved AND the base
       // Kokoro model can phonemize it — so future community voices with
       // unknown prefixes default to Web Speech (onDevice:false), not Kokoro.
-      onDevice: baseLang !== undefined && KOKORO_ON_DEVICE_LANGS.has(baseLang),
+      onDevice: isKokoroOnDeviceVoice(id, resolvedLang),
       ...(meta.gender ? { gender: meta.gender } : {}),
     };
   });
@@ -331,6 +356,22 @@ async function synthesizeWithEspeak(
   return { audio: audio.audio as Float32Array, sampleRate: audio.sampling_rate };
 }
 
+const DEFAULT_STREAM_SPLIT = /(?<=[.!?。！？…])\s+|\n{2,}/u;
+
+/** Split text into synthesis chunks before the espeak path phonemizes it.
+ * kokoro-js's splitter is load-bearing for English streaming; here we need an
+ * explicit sentence-ish split so long non-English replies avoid one giant
+ * phoneme sequence and the model's ~510-token truncation. */
+export function splitKokoroStreamText(text: string, splitPattern?: RegExp): string[] {
+  const pattern = splitPattern ?? DEFAULT_STREAM_SPLIT;
+  const parts = text
+    .split(pattern)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  const trimmed = text.trim();
+  return parts.length > 0 ? parts : trimmed ? [trimmed] : [];
+}
+
 let kokoroPromise: Promise<KokoroTts> | null = null;
 let loadState: KokoroLoadState = 'idle';
 let lastSnapshot: DownloadSnapshot | null = null;
@@ -437,18 +478,7 @@ async function loadKokoro(onProgress?: WhisperProgress): Promise<KokoroTts> {
       const espeakLang = espeakVoiceForKokoroVoice(voiceId);
       if (espeakLang) {
         const phonemize = await getEspeakPhonemize();
-        const splitter = new TextSplitterStream();
-        if (opts?.splitPattern) {
-          const parts = text
-            .split(opts.splitPattern)
-            .map((p) => p.trim())
-            .filter((p) => p.length > 0);
-          splitter.push(...parts);
-        } else {
-          splitter.push(text);
-        }
-        splitter.close();
-        for await (const sentence of splitter) {
+        for (const sentence of splitKokoroStreamText(text, opts?.splitPattern)) {
           yield await synthesizeWithEspeak(
             tts,
             sentence,

--- a/packages/webapp/src/speech/kokoro-engine.ts
+++ b/packages/webapp/src/speech/kokoro-engine.ts
@@ -14,8 +14,11 @@
  * ready, so by the time a dictated turn completes the reply voice is
  * usually warm.
  *
- * Kokoro v1.0 ONNX ships English voices only (`a*` = en-US, `b*` = en-GB) —
- * engine pick for other languages stays on Web Speech (see `speak.ts`).
+ * Kokoro v1.0 ONNX ships voices across several languages, keyed by the id
+ * prefix (`a` en-US, `b` en-GB, `e` es-ES, `f` fr-FR, `i` it-IT, `h` hi-IN,
+ * `p` pt-BR, `j` ja-JP, `z` zh-CN). en/es/fr/it/hi/pt are synthesizable
+ * on-device via the espeak-ng phonemizer; ja/zh have no JS G2P and stay on
+ * Web Speech (see `KokoroVoiceInfo.onDevice` and `speak.ts`).
  */
 
 import { createLogger } from '../core/logger.js';
@@ -34,8 +37,18 @@ export interface KokoroVoiceInfo {
   id: string;
   /** Display name, e.g. `Heart`. */
   name: string;
-  /** BCP-47-ish tag derived from the id prefix (`a*` en-US, `b*` en-GB). */
+  /**
+   * BCP-47 language tag. Uses kokoro-js's reported `language` when present,
+   * otherwise derives from the id prefix: `a`→en-US, `b`→en-GB, `e`→es-ES,
+   * `f`→fr-FR, `i`→it-IT, `h`→hi-IN, `p`→pt-BR, `j`→ja-JP, `z`→zh-CN.
+   */
   lang: string;
+  /**
+   * Whether this voice can be synthesized on-device by the base Kokoro model.
+   * en/es/fr/it/hi/pt have an espeak-ng phonemizer (true); ja/zh have no JS
+   * G2P and are Web-Speech-only (false).
+   */
+  onDevice: boolean;
   gender?: string;
 }
 
@@ -72,16 +85,49 @@ export interface KokoroTts {
 
 export type KokoroLoadState = 'idle' | 'loading' | 'ready' | 'failed';
 
-/** Map kokoro-js's voices object into the normalized picker shape. */
+/** Kokoro voice id prefix → BCP-47 language tag (fallback when kokoro-js
+ * doesn't report a `language`). */
+const KOKORO_PREFIX_LANG: Record<string, string> = {
+  a: 'en-US',
+  b: 'en-GB',
+  e: 'es-ES',
+  f: 'fr-FR',
+  i: 'it-IT',
+  h: 'hi-IN',
+  p: 'pt-BR',
+  j: 'ja-JP',
+  z: 'zh-CN',
+};
+
+/** Base languages the base Kokoro model can phonemize on-device (espeak-ng).
+ * ja/zh need misaki (no JS port), so they fall back to Web Speech. */
+const KOKORO_ON_DEVICE_LANGS = new Set(['en', 'es', 'fr', 'it', 'hi', 'pt']);
+
+/** Normalize a language tag to BCP-47 casing (`en-us` → `en-US`, `es` → `es`). */
+function normalizeLangTag(lang: string): string {
+  const [base, region] = lang.split('-');
+  return region ? `${base.toLowerCase()}-${region.toUpperCase()}` : base.toLowerCase();
+}
+
+/** Map kokoro-js's voices object into the normalized picker shape. Resolves
+ * the language from kokoro-js's reported `language` when present, else from the
+ * id prefix, and marks whether the voice is synthesizable on-device. */
 export function toKokoroVoiceInfos(
   voices: Record<string, { name?: string; language?: string; gender?: string }>
 ): KokoroVoiceInfo[] {
-  return Object.entries(voices).map(([id, meta]) => ({
-    id,
-    name: meta.name || id,
-    lang: meta.language === 'en-gb' || id.startsWith('b') ? 'en-GB' : 'en-US',
-    ...(meta.gender ? { gender: meta.gender } : {}),
-  }));
+  return Object.entries(voices).map(([id, meta]) => {
+    const lang = meta.language
+      ? normalizeLangTag(meta.language)
+      : (KOKORO_PREFIX_LANG[id[0]] ?? 'en-US');
+    const baseLang = lang.split('-')[0].toLowerCase();
+    return {
+      id,
+      name: meta.name || id,
+      lang,
+      onDevice: KOKORO_ON_DEVICE_LANGS.has(baseLang),
+      ...(meta.gender ? { gender: meta.gender } : {}),
+    };
+  });
 }
 
 /**

--- a/packages/webapp/src/speech/kokoro-engine.ts
+++ b/packages/webapp/src/speech/kokoro-engine.ts
@@ -146,6 +146,77 @@ export function toKokoroVoiceInfos(
 }
 
 /**
+ * The non-English voices the base `onnx-community/Kokoro-82M-v1.0-ONNX` model
+ * ships that kokoro-js@1.2.1's static (English-only) `VOICES` map omits — so
+ * `tts.voices` alone never exposes them and every es/fr/it/hi/pt/ja/zh request
+ * silently falls back to Web Speech (the Wave 2 espeak wrapper is never
+ * reached). Ids + display names + genders mirror the hexgrad/Kokoro voices
+ * manifest, cross-checked against the actual `voices/*.bin` filenames in the
+ * staged HF repo. Language + on-device routing are derived from the id prefix
+ * by `toKokoroVoiceInfos` (es/fr/it/hi/pt → on-device via espeak-ng; ja/zh →
+ * Web-Speech-only, no JS G2P). The `.bin` style vectors load lazily inside
+ * kokoro-js's own `getVoiceData` at `generate_from_ids` time — they ride along
+ * in the same model repo the speech-assets staging already pulls in full.
+ */
+export const KOKORO_MULTILINGUAL_VOICES: Readonly<
+  Record<string, { name?: string; gender?: string }>
+> = Object.freeze({
+  // Spanish (es)
+  ef_dora: { name: 'Dora', gender: 'Female' },
+  em_alex: { name: 'Alex', gender: 'Male' },
+  em_santa: { name: 'Santa', gender: 'Male' },
+  // French (fr)
+  ff_siwis: { name: 'Siwis', gender: 'Female' },
+  // Hindi (hi)
+  hf_alpha: { name: 'Alpha', gender: 'Female' },
+  hf_beta: { name: 'Beta', gender: 'Female' },
+  hm_omega: { name: 'Omega', gender: 'Male' },
+  hm_psi: { name: 'Psi', gender: 'Male' },
+  // Italian (it)
+  if_sara: { name: 'Sara', gender: 'Female' },
+  im_nicola: { name: 'Nicola', gender: 'Male' },
+  // Brazilian Portuguese (pt)
+  pf_dora: { name: 'Dora', gender: 'Female' },
+  pm_alex: { name: 'Alex', gender: 'Male' },
+  pm_santa: { name: 'Santa', gender: 'Male' },
+  // Japanese (ja) — Web-Speech-only (no JS G2P)
+  jf_alpha: { name: 'Alpha', gender: 'Female' },
+  jf_gongitsune: { name: 'Gongitsune', gender: 'Female' },
+  jf_nezumi: { name: 'Nezumi', gender: 'Female' },
+  jf_tebukuro: { name: 'Tebukuro', gender: 'Female' },
+  jm_kumo: { name: 'Kumo', gender: 'Male' },
+  // Mandarin Chinese (zh) — Web-Speech-only (no JS G2P)
+  zf_xiaobei: { name: 'Xiaobei', gender: 'Female' },
+  zf_xiaoni: { name: 'Xiaoni', gender: 'Female' },
+  zf_xiaoxiao: { name: 'Xiaoxiao', gender: 'Female' },
+  zf_xiaoyi: { name: 'Xiaoyi', gender: 'Female' },
+  zm_yunjian: { name: 'Yunjian', gender: 'Male' },
+  zm_yunxi: { name: 'Yunxi', gender: 'Male' },
+  zm_yunxia: { name: 'Yunxia', gender: 'Male' },
+  zm_yunyang: { name: 'Yunyang', gender: 'Male' },
+});
+
+/**
+ * Build the picker voice list from kokoro-js's reported `tts.voices` augmented
+ * with `KOKORO_MULTILINGUAL_VOICES`. Only ids ABSENT from kokoro-js are added,
+ * so a future kokoro-js that ships these voices natively (with richer metadata)
+ * supersedes the static augmentation — the library is always the source of
+ * truth on collision. Pure (no I/O) for direct testing against the real
+ * kokoro-js `VOICES`.
+ */
+export function buildKokoroVoiceInfos(
+  ttsVoices: Record<string, { name?: string; language?: string; gender?: string }>
+): KokoroVoiceInfo[] {
+  const merged: Record<string, { name?: string; language?: string; gender?: string }> = {
+    ...ttsVoices,
+  };
+  for (const [id, meta] of Object.entries(KOKORO_MULTILINGUAL_VOICES)) {
+    if (!(id in merged)) merged[id] = meta;
+  }
+  return toKokoroVoiceInfos(merged);
+}
+
+/**
  * StyleTTS2 ⇄ workspace-transformers reconciliation.
  *
  * kokoro-js@1.2.1 is written + tested against `@huggingface/transformers` ^3.x,
@@ -336,7 +407,10 @@ async function loadKokoro(onProgress?: WhisperProgress): Promise<KokoroTts> {
   });
 
   log.info('kokoro ready', { model: KOKORO_MODEL_ID, device: wantGpu ? 'webgpu' : 'wasm' });
-  const voiceInfos = toKokoroVoiceInfos(
+  // Augment kokoro-js's English-only `tts.voices` with the multilingual voices
+  // the base model supports (es/fr/it/hi/pt on-device; ja/zh Web-Speech) so the
+  // picker, `say --list`, and `pickSpeakEngine` actually see them.
+  const voiceInfos = buildKokoroVoiceInfos(
     tts.voices as Record<string, { name?: string; language?: string; gender?: string }>
   );
 

--- a/packages/webapp/src/speech/kokoro-engine.ts
+++ b/packages/webapp/src/speech/kokoro-engine.ts
@@ -21,8 +21,16 @@
  * Web Speech (see `KokoroVoiceInfo.onDevice` and `speak.ts`).
  */
 
+import type { Tensor } from '@huggingface/transformers';
+import type { KokoroTTS as KokoroTtsClass } from 'kokoro-js';
 import { createLogger } from '../core/logger.js';
 import { createDownloadTracker, type DownloadSnapshot } from './download-progress.js';
+import { getEspeakPhonemize } from './espeak-phonemizer.js';
+import {
+  type EspeakPhonemize,
+  espeakVoiceForKokoroVoice,
+  phonemizeForKokoro,
+} from './kokoro-phonemize.js';
 import { assertLocalModelPresent, configureTransformersEnv } from './transformers-env.js';
 import type { WhisperProgress } from './whisper-engine.js';
 
@@ -218,6 +226,33 @@ export function applyStyleTts2ConfigShim(transformers: TransformersWithAutoConfi
   log.debug('style_text_to_speech_2 architecture shim installed on AutoConfig.from_pretrained');
 }
 
+/**
+ * Synthesize one chunk for a non-English voice via the wrapper synth path:
+ * phonemize with the correct espeak language, then drive kokoro-js's public
+ * `tokenizer` + `generate_from_ids` directly — bypassing kokoro-js's
+ * English-only internal phonemize (`kokoro-phonemize.ts`).
+ */
+async function synthesizeWithEspeak(
+  tts: KokoroTtsClass,
+  text: string,
+  espeakLang: string,
+  voiceId: string,
+  speed: number | undefined,
+  phonemize: EspeakPhonemize
+): Promise<KokoroAudioChunk> {
+  const phonemes = await phonemizeForKokoro(text, espeakLang, phonemize);
+  const tokenize = tts.tokenizer as unknown as (
+    t: string,
+    o: { truncation: boolean }
+  ) => { input_ids: Tensor };
+  const { input_ids } = tokenize(phonemes, { truncation: true });
+  const audio = await tts.generate_from_ids(input_ids, {
+    voice: voiceId as never,
+    ...(speed ? { speed } : {}),
+  });
+  return { audio: audio.audio as Float32Array, sampleRate: audio.sampling_rate };
+}
+
 let kokoroPromise: Promise<KokoroTts> | null = null;
 let loadState: KokoroLoadState = 'idle';
 let lastSnapshot: DownloadSnapshot | null = null;
@@ -300,6 +335,14 @@ async function loadKokoro(onProgress?: WhisperProgress): Promise<KokoroTts> {
 
   return {
     async synthesize(text, opts) {
+      const voiceId = opts?.voice ?? 'af_heart';
+      // Non-English voices (es/fr/it/hi/pt) phonemize via espeak ourselves and
+      // feed token ids to kokoro-js directly; English keeps the native path.
+      const espeakLang = espeakVoiceForKokoroVoice(voiceId);
+      if (espeakLang) {
+        const phonemize = await getEspeakPhonemize();
+        return synthesizeWithEspeak(tts, text, espeakLang, voiceId, opts?.speed, phonemize);
+      }
       const audio = await tts.generate(text, {
         ...(opts?.voice ? { voice: opts.voice as never } : {}),
         ...(opts?.speed ? { speed: opts.speed } : {}),
@@ -307,6 +350,35 @@ async function loadKokoro(onProgress?: WhisperProgress): Promise<KokoroTts> {
       return { audio: audio.audio as Float32Array, sampleRate: audio.sampling_rate };
     },
     async *synthesizeStream(text, opts) {
+      const voiceId = opts?.voice ?? 'af_heart';
+      // Non-English wrapper path: split into sentences (so a long reply isn't
+      // clamped to ~510 tokens, #1038), phonemize + generate each ourselves.
+      const espeakLang = espeakVoiceForKokoroVoice(voiceId);
+      if (espeakLang) {
+        const phonemize = await getEspeakPhonemize();
+        const splitter = new TextSplitterStream();
+        if (opts?.splitPattern) {
+          const parts = text
+            .split(opts.splitPattern)
+            .map((p) => p.trim())
+            .filter((p) => p.length > 0);
+          splitter.push(...parts);
+        } else {
+          splitter.push(text);
+        }
+        splitter.close();
+        for await (const sentence of splitter) {
+          yield await synthesizeWithEspeak(
+            tts,
+            sentence,
+            espeakLang,
+            voiceId,
+            opts?.speed,
+            phonemize
+          );
+        }
+        return;
+      }
       const streamOpts = {
         ...(opts?.voice ? { voice: opts.voice as never } : {}),
         ...(opts?.speed ? { speed: opts.speed } : {}),

--- a/packages/webapp/src/speech/kokoro-engine.ts
+++ b/packages/webapp/src/speech/kokoro-engine.ts
@@ -124,15 +124,22 @@ export function toKokoroVoiceInfos(
   voices: Record<string, { name?: string; language?: string; gender?: string }>
 ): KokoroVoiceInfo[] {
   return Object.entries(voices).map(([id, meta]) => {
-    const lang = meta.language
+    // Resolve the language from kokoro-js's reported `language`, else the id
+    // prefix. An unknown/unmapped prefix with no reported language stays
+    // undefined here so it can't wrongly route to Kokoro.
+    const resolvedLang = meta.language
       ? normalizeLangTag(meta.language)
-      : (KOKORO_PREFIX_LANG[id[0]] ?? 'en-US');
-    const baseLang = lang.split('-')[0].toLowerCase();
+      : KOKORO_PREFIX_LANG[id[0]];
+    const baseLang = resolvedLang?.split('-')[0].toLowerCase();
     return {
       id,
       name: meta.name || id,
-      lang,
-      onDevice: KOKORO_ON_DEVICE_LANGS.has(baseLang),
+      // Keep en-US as a display fallback for an unresolved language.
+      lang: resolvedLang ?? 'en-US',
+      // Only on-device when the language was actually resolved AND the base
+      // Kokoro model can phonemize it — so future community voices with
+      // unknown prefixes default to Web Speech (onDevice:false), not Kokoro.
+      onDevice: baseLang !== undefined && KOKORO_ON_DEVICE_LANGS.has(baseLang),
       ...(meta.gender ? { gender: meta.gender } : {}),
     };
   });

--- a/packages/webapp/src/speech/kokoro-phonemize.ts
+++ b/packages/webapp/src/speech/kokoro-phonemize.ts
@@ -1,0 +1,111 @@
+/**
+ * Language-aware phonemization for Kokoro's non-English on-device voices.
+ *
+ * kokoro-js@1.2.1 phonemizes everything as English: its module-private `m()`
+ * picks `en-us` (voice prefix `a`) or `en` (everything else) and feeds the
+ * English-only bundled `phonemizer`. There is no exported seam to patch, so for
+ * es/fr/it/hi/pt we phonemize the text OURSELVES with the correct espeak
+ * language (via the staged multilingual `espeak-ng` wasm — see
+ * `espeak-phonemizer.ts`) and feed the result straight into kokoro-js's public
+ * `tokenizer` + `generate_from_ids`, bypassing `m()`.
+ *
+ * This module is the PURE core (no wasm, no I/O): the prefix→espeak map, the
+ * punctuation-preserving split + join, and kokoro-js's own phoneme fixups —
+ * all unit-tested against an injected `EspeakPhonemize`. English (prefix
+ * `a`/`b`) never reaches here; it keeps kokoro-js's native path.
+ */
+
+/** Phonemize one chunk of text in `espeakLang`, IPA lines (mirrors the
+ *  `phonemizer` package's `phonemize` signature so either backend fits). */
+export type EspeakPhonemize = (text: string, espeakLang: string) => Promise<string[]>;
+
+/**
+ * Kokoro voice-id prefix → espeak-ng voice identifier. Mirrors
+ * hexgrad/kokoro's pipeline (`e`→es, `f`→fr-fr, `i`→it, `h`→hi, `p`→pt-br).
+ * English (`a`/`b`) and the no-JS-G2P languages (`j`/`z`) are intentionally
+ * absent — only these five route through the wrapper synth path.
+ */
+export const KOKORO_PREFIX_ESPEAK: Readonly<Record<string, string>> = Object.freeze({
+  e: 'es',
+  f: 'fr-fr',
+  i: 'it',
+  h: 'hi',
+  p: 'pt-br',
+});
+
+/** The espeak voice for a kokoro voice id, or null when it is not one of the
+ *  five wrapper-path languages (English / ja / zh / unknown). */
+export function espeakVoiceForKokoroVoice(voiceId: string): string | null {
+  return KOKORO_PREFIX_ESPEAK[voiceId[0]] ?? null;
+}
+
+/** The punctuation kokoro-js splits on before phonemizing — kept verbatim in
+ *  the output so prosody/pauses survive (same set as kokoro-js' `m()`). */
+const PUNCT = ';:,.!?¡¿—…"«»“”(){}[]';
+const PUNCT_SPLIT = new RegExp(
+  `(\\s*[${PUNCT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}]+\\s*)+`,
+  'g'
+);
+
+interface TextPart {
+  /** True for a punctuation run (kept verbatim), false for phonemizable text. */
+  punct: boolean;
+  text: string;
+}
+
+/** Split into alternating phonemizable / punctuation parts (kokoro-js' splitter
+ *  reproduced) so punctuation passes through untouched. */
+export function splitOnPunctuation(text: string): TextPart[] {
+  const parts: TextPart[] = [];
+  let cursor = 0;
+  for (const match of text.matchAll(PUNCT_SPLIT)) {
+    const run = match[0];
+    const index = match.index ?? 0;
+    if (cursor < index) parts.push({ punct: false, text: text.slice(cursor, index) });
+    if (run.length > 0) parts.push({ punct: true, text: run });
+    cursor = index + run.length;
+  }
+  if (cursor < text.length) parts.push({ punct: false, text: text.slice(cursor) });
+  return parts;
+}
+
+/**
+ * kokoro-js's universal phoneme fixups (the prefix-`!== "a"` subset). Maps the
+ * espeak phonemes the Kokoro vocab does NOT carry onto the ones it expects
+ * (`ʲ→j`, `r→ɹ`, `x→k`, `ɬ→l`), normalizes the embedded "kokoro" pronunciation,
+ * fixes "…hundred" spacing and a trailing devoiced `z`. The English-only text
+ * normalization and the `a`-only `nˈaɪnti→nˈaɪndi` tweak are deliberately NOT
+ * applied — exactly what kokoro-js does for non-`a` voices.
+ */
+export function applyKokoroPhonemeFixups(phonemes: string): string {
+  return phonemes
+    .replace(/kəkˈoːɹoʊ/g, 'kˈoʊkəɹoʊ')
+    .replace(/kəkˈɔːɹəʊ/g, 'kˈəʊkəɹəʊ')
+    .replace(/ʲ/g, 'j')
+    .replace(/r/g, 'ɹ')
+    .replace(/x/g, 'k')
+    .replace(/ɬ/g, 'l')
+    .replace(/(?<=[a-zɹː])(?=hˈʌndɹɪd)/g, ' ')
+    .replace(/ z(?=[;:,.!?¡¿—…"«»“” ]|$)/g, 'z')
+    .trim();
+}
+
+/**
+ * Phonemize `text` for a non-English Kokoro voice: split off punctuation,
+ * phonemize each text run in `espeakLang`, re-join with the punctuation
+ * preserved, then apply kokoro-js's fixups. The returned IPA string is ready
+ * for `tts.tokenizer(...)`. Pure given `phonemize` (mock it in tests).
+ */
+export async function phonemizeForKokoro(
+  text: string,
+  espeakLang: string,
+  phonemize: EspeakPhonemize
+): Promise<string> {
+  const parts = splitOnPunctuation(text);
+  const rendered = await Promise.all(
+    parts.map(async (part) =>
+      part.punct ? part.text : (await phonemize(part.text, espeakLang)).join(' ')
+    )
+  );
+  return applyKokoroPhonemeFixups(rendered.join(''));
+}

--- a/packages/webapp/src/speech/kokoro-phonemize.ts
+++ b/packages/webapp/src/speech/kokoro-phonemize.ts
@@ -10,7 +10,7 @@
  * `tokenizer` + `generate_from_ids`, bypassing `m()`.
  *
  * This module is the PURE core (no wasm, no I/O): the prefix→espeak map, the
- * punctuation-preserving split + join, and kokoro-js's own phoneme fixups —
+ * punctuation-preserving split + join, and Kokoro-safe phoneme fixups —
  * all unit-tested against an injected `EspeakPhonemize`. English (prefix
  * `a`/`b`) never reaches here; it keeps kokoro-js's native path.
  */
@@ -70,22 +70,15 @@ export function splitOnPunctuation(text: string): TextPart[] {
 }
 
 /**
- * kokoro-js's universal phoneme fixups (the prefix-`!== "a"` subset). Maps the
- * espeak phonemes the Kokoro vocab does NOT carry onto the ones it expects
- * (`ʲ→j`, `r→ɹ`, `x→k`, `ɬ→l`), normalizes the embedded "kokoro" pronunciation,
- * fixes "…hundred" spacing and a trailing devoiced `z`. The English-only text
- * normalization and the `a`-only `nˈaɪnti→nˈaɪndi` tweak are deliberately NOT
- * applied — exactly what kokoro-js does for non-`a` voices.
+ * Fixups that are safe for Kokoro's multilingual espeak path. Do NOT apply
+ * kokoro-js's English-oriented `ʲ→j`, `r→ɹ`, `x→k`, or `ɬ→l` replacements here:
+ * those erase real multilingual phonemes such as Spanish/Italian taps/trills.
  */
 export function applyKokoroPhonemeFixups(phonemes: string): string {
   return phonemes
     .replace(/kəkˈoːɹoʊ/g, 'kˈoʊkəɹoʊ')
     .replace(/kəkˈɔːɹəʊ/g, 'kˈəʊkəɹəʊ')
-    .replace(/ʲ/g, 'j')
-    .replace(/r/g, 'ɹ')
-    .replace(/x/g, 'k')
-    .replace(/ɬ/g, 'l')
-    .replace(/(?<=[a-zɹː])(?=hˈʌndɹɪd)/g, ' ')
+    .replace(/(?<=[a-zɹrː])(?=hˈʌndɹɪd)/g, ' ')
     .replace(/ z(?=[;:,.!?¡¿—…"«»“” ]|$)/g, 'z')
     .trim();
 }

--- a/packages/webapp/src/speech/speak.ts
+++ b/packages/webapp/src/speech/speak.ts
@@ -148,9 +148,20 @@ export function speechTextFromMarkdown(markdown: string): string {
   return text;
 }
 
+const isExtensionFloat = (): boolean => typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
+
+/** Whether a model-capable Kokoro voice can actually run on-device here. */
+function onDeviceInCurrentRuntime(v: KokoroVoiceInfo): boolean {
+  return v.onDevice && (isEnglishLang(v.lang) || !isExtensionFloat());
+}
+
 /** The kokoro voices when the engine is ready, else an empty list. */
 export function kokoroVoicesIfReady(): KokoroVoiceInfo[] {
-  return kokoroIfReady()?.voices() ?? [];
+  return (
+    kokoroIfReady()
+      ?.voices()
+      .map((v) => ({ ...v, onDevice: onDeviceInCurrentRuntime(v) })) ?? []
+  );
 }
 
 /** Enhanced-voice (kokoro) lifecycle snapshot — the `say --status` shape. */
@@ -160,8 +171,6 @@ export interface KokoroStatus {
   total?: number;
   etaSeconds?: number | null;
 }
-
-const isExtensionFloat = (): boolean => typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
 
 /** Kernel-worker instance id scoping the page→worker speech-assets bridge (R10). */
 let assetsInstanceId: string | undefined;

--- a/packages/webapp/src/speech/speak.ts
+++ b/packages/webapp/src/speech/speak.ts
@@ -4,10 +4,12 @@
  * Two engines behind one `speak()` call:
  *
  * - **kokoro** — the on-device Kokoro-82M voice (`kokoro-engine.ts`), used
- *   once its chained download (after whisper) has completed, for English
- *   text, or whenever the requested voice names a kokoro voice id.
+ *   once its chained download (after whisper) has completed, for any language
+ *   it can synthesize on-device (en/es/fr/it/hi/pt via espeak-ng), or whenever
+ *   the requested voice names a synthesizable kokoro voice id.
  * - **webspeech** — `speechSynthesis`, the always-available fallback and the
- *   route for non-English languages (Kokoro v1.0 ONNX is English-only).
+ *   route for ja/zh (no JS G2P) and any other language. The extension float
+ *   also routes es/fr/it/hi/pt here (MV3 CSP blocks the espeak-ng glue).
  *
  * Consumers: the `say` command (local realm + the `speak-text` panel-RPC
  * handler) and the spoken-reply loop (`voice-reply.ts`). Page/offscreen
@@ -31,7 +33,7 @@ export type SpeakEngine = 'kokoro' | 'webspeech';
 
 export interface SpeakRequest {
   text: string;
-  /** BCP-47 tag; non-English routes to webspeech (kokoro is English-only). */
+  /** BCP-47 tag; ja/zh and unsupported languages route to webspeech. */
   lang?: string;
   /** A kokoro voice id (`af_heart`, …) or a Web Speech voice name. */
   voice?: string;
@@ -51,21 +53,63 @@ export interface SpeakRequest {
  */
 const MAX_SPEECH_CHARS = 20000;
 
+/** A language tag is English when its base subtag is `en`. */
+function isEnglishLang(lang: string): boolean {
+  return lang.toLowerCase().startsWith('en');
+}
+
 /**
- * Pick the synthesis engine for a request (pure — unit-tested):
- * an explicit kokoro voice id forces kokoro (when ready); any other explicit
- * voice forces webspeech; non-English languages force webspeech; otherwise
- * kokoro wins whenever it's ready.
+ * Pick the synthesis engine for a request (pure — unit-tested). Kokoro wins
+ * for any voice it can synthesize ON-DEVICE in this runtime; everything else
+ * routes to Web Speech.
+ *
+ * A voice is synthesizable now when the engine is ready, the voice is flagged
+ * `onDevice` (en/es/fr/it/hi/pt — ja/zh have no JS G2P), AND, for non-English,
+ * the runtime can load the espeak-ng phonemizer (`nonEnglishOnDevice`). The
+ * extension float can't dynamic-import the espeak-ng glue from a VFS blob URL
+ * under MV3 CSP, so it sets that flag false and non-English degrades to Web
+ * Speech (see `espeak-phonemizer.ts` and the spec's cross-runtime status).
+ *
+ * - explicit voice id → kokoro when that voice is synthesizable, else webspeech
+ * - otherwise → kokoro when a synthesizable voice matches the request language
+ *   (English when no `lang` is given), else webspeech
  */
 export function pickSpeakEngine(
   req: { lang?: string; voice?: string },
-  kokoro: { ready: boolean; voiceIds: readonly string[] }
-): SpeakEngine {
-  if (req.voice) {
-    return kokoro.ready && kokoro.voiceIds.includes(req.voice) ? 'kokoro' : 'webspeech';
+  kokoro: {
+    ready: boolean;
+    voices: readonly { id: string; lang: string; onDevice: boolean }[];
+    /** Whether non-English on-device synthesis works in this runtime. */
+    nonEnglishOnDevice: boolean;
   }
-  if (req.lang && !req.lang.toLowerCase().startsWith('en')) return 'webspeech';
-  return kokoro.ready ? 'kokoro' : 'webspeech';
+): SpeakEngine {
+  if (!kokoro.ready) return 'webspeech';
+  const synthesizable = (v: { lang: string; onDevice: boolean }): boolean =>
+    v.onDevice && (isEnglishLang(v.lang) || kokoro.nonEnglishOnDevice);
+  if (req.voice) {
+    const match = kokoro.voices.find((v) => v.id === req.voice);
+    return match && synthesizable(match) ? 'kokoro' : 'webspeech';
+  }
+  const baseLang = (req.lang ? req.lang.split('-')[0] : 'en').toLowerCase();
+  const matched = kokoro.voices.some(
+    (v) => v.lang.split('-')[0].toLowerCase() === baseLang && synthesizable(v)
+  );
+  return matched ? 'kokoro' : 'webspeech';
+}
+
+/**
+ * The kokoro voice id to synthesize `lang` with when the caller named none
+ * (pure — unit-tested). English uses kokoro's built-in default (undefined →
+ * af_heart); a non-English request resolves to the first on-device voice for
+ * that base language so the audio is actually spoken in the requested tongue.
+ */
+function pickKokoroVoiceForLang(
+  lang: string | undefined,
+  voices: readonly KokoroVoiceInfo[]
+): string | undefined {
+  if (!lang || isEnglishLang(lang)) return undefined;
+  const baseLang = lang.split('-')[0].toLowerCase();
+  return voices.find((v) => v.onDevice && v.lang.split('-')[0].toLowerCase() === baseLang)?.id;
 }
 
 /** Inline code spans longer than this are code, not vocabulary — dropped. */
@@ -237,15 +281,20 @@ function webSpeak(req: SpeakRequest): Promise<void> {
  */
 export async function speak(req: SpeakRequest): Promise<{ engine: SpeakEngine }> {
   const tts = kokoroIfReady();
+  const voices = tts?.voices() ?? [];
   const engine = pickSpeakEngine(req, {
     ready: tts !== null,
-    voiceIds: tts?.voices().map((v) => v.id) ?? [],
+    voices,
+    nonEnglishOnDevice: !isExtensionFloat(),
   });
   if (engine === 'kokoro' && tts) {
+    // No explicit voice on a non-English request → pick a language-matched one
+    // (kokoro's default voice is English) so es/fr/it/hi/pt speak correctly.
+    const voice = req.voice ?? pickKokoroVoiceForLang(req.lang, voices);
     let played = 0;
     try {
       const stream = tts.synthesizeStream(req.text, {
-        ...(req.voice ? { voice: req.voice } : {}),
+        ...(voice ? { voice } : {}),
         ...(req.rate ? { speed: req.rate } : {}),
       });
       for await (const chunk of stream) {

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -261,6 +261,7 @@ function buildPageAudioHandlers() {
         name: v.id,
         lang: v.lang,
         default: false,
+        onDevice: v.onDevice,
       }));
       if (typeof speechSynthesis === 'undefined') {
         if (kokoro.length > 0) return { voices: kokoro };
@@ -1421,8 +1422,15 @@ async function openOAuthPopupViaSurface(
 
 // ── Internal helpers ────────────────────────────────────────────────
 
-function toVoiceInfo(v: SpeechSynthesisVoice): { name: string; lang: string; default: boolean } {
-  return { name: v.name, lang: v.lang, default: v.default };
+function toVoiceInfo(v: SpeechSynthesisVoice): {
+  name: string;
+  lang: string;
+  default: boolean;
+  onDevice: boolean;
+} {
+  // Web Speech voices never play on-device (Kokoro); only kokoro voice infos
+  // carry an on-device flag.
+  return { name: v.name, lang: v.lang, default: v.default, onDevice: false };
 }
 
 async function captureScreen(mimeType: string, quality: number): Promise<Blob> {

--- a/packages/webapp/tests/shell/supplemental-commands/say-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/say-command.test.ts
@@ -173,6 +173,66 @@ describe('say command', () => {
     expect(mockUtterance.text).toBe('Hallo Welt');
   });
 
+  it('help advertises multilingual on-device support (not English-only)', async () => {
+    const cmd = createSayCommand();
+    const result = await cmd.execute(['--help'], createMockCtx());
+
+    expect(result.stdout).toContain('Spanish');
+    expect(result.stdout).toContain('[kokoro]');
+    expect(result.stdout).not.toMatch(/English text/i);
+  });
+
+  it('--list shows every kokoro voice with language + engine marker (local realm)', async () => {
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('speechSynthesis', {
+      getVoices: () => [{ name: 'Alex', lang: 'en-US', default: true }],
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.doMock('../../../src/speech/speak.js', () => ({
+      kokoroVoicesIfReady: () => [
+        { id: 'ef_dora', name: 'Dora', lang: 'es-ES', onDevice: true },
+        { id: 'jf_alpha', name: 'Alpha', lang: 'ja-JP', onDevice: false },
+      ],
+    }));
+    vi.resetModules();
+    const { createSayCommand: makeCmd } = await import(
+      '../../../src/shell/supplemental-commands/say-command.js'
+    );
+
+    const result = await makeCmd().execute(['--list'], createMockCtx());
+    expect(result.exitCode).toBe(0);
+    // On-device Spanish kokoro voice → [kokoro]; ja kokoro voice has no JS G2P
+    // → [web speech]; Web Speech voice → [web speech] + [default].
+    expect(result.stdout).toContain('ef_dora (es-ES) [kokoro]');
+    expect(result.stdout).toContain('jf_alpha (ja-JP) [web speech]');
+    expect(result.stdout).toContain('Alex (en-US) [web speech] [default]');
+    vi.doUnmock('../../../src/speech/speak.js');
+  });
+
+  it('--list formats voices from the worker panel-RPC with engine markers', async () => {
+    const call = vi.fn().mockResolvedValue({
+      voices: [
+        { name: 'ef_dora', lang: 'es-ES', default: false, onDevice: true },
+        { name: 'Samantha', lang: 'en-US', default: true, onDevice: false },
+      ],
+    });
+    vi.doMock('../../../src/kernel/panel-rpc.js', () => ({
+      getPanelRpcClient: () => ({ call }),
+    }));
+    vi.resetModules();
+    const { createSayCommand: makeCmd } = await import(
+      '../../../src/shell/supplemental-commands/say-command.js'
+    );
+
+    const result = await makeCmd().execute(['--list'], createMockCtx());
+    expect(result.exitCode).toBe(0);
+    expect(call).toHaveBeenCalledWith('list-voices', undefined);
+    expect(result.stdout).toContain('ef_dora (es-ES) [kokoro]');
+    expect(result.stdout).toContain('Samantha (en-US) [web speech] [default]');
+    vi.doUnmock('../../../src/kernel/panel-rpc.js');
+  });
+
   it('documents --status and --warmup in help', async () => {
     const cmd = createSayCommand();
     const result = await cmd.execute(['--help'], createMockCtx());

--- a/packages/webapp/tests/speech/ensure-speech-assets.test.ts
+++ b/packages/webapp/tests/speech/ensure-speech-assets.test.ts
@@ -131,16 +131,19 @@ describe('ensureSpeechAssetsStaged', () => {
     );
   });
 
-  it('rejects with an actionable error when the espeak-ng install fails', async () => {
+  it('still stages weight repos when optional espeak-ng staging fails', async () => {
     const fs = await newFs();
     // ort present, espeak absent → its installPackages runs and the fetch fails.
     await stageOrt(fs);
-    const failing: SecureFetch = (async (url: string): Promise<FetchResult> => {
+    const hf = hfFetch({ 'config.json': bytes('{}'), 'model.onnx': bytes('abcd') });
+    const fetch: SecureFetch = (async (url: string, opts?: SecureFetchOptions) => {
+      if (url.includes('huggingface.co')) return hf(url, opts);
       throw new TypeError(`Failed to fetch ${url}`);
     }) as unknown as SecureFetch;
-    await expect(ensureSpeechAssetsStaged({ fs, fetch: failing, repos: [REPO] })).rejects.toThrow(
-      /failed to stage espeak-ng/
-    );
+    const result = await ensureSpeechAssetsStaged({ fs, fetch, repos: [REPO] });
+    expect(result).toMatchObject({ skipped: false, ortStaged: false, espeakStaged: false });
+    expect(result.repos).toEqual([{ repo: REPO, downloaded: 2, skipped: 0 }]);
+    expect(await fs.exists(`/workspace/models/${REPO}/model.onnx`)).toBe(true);
   });
 
   it('rejects with an actionable error when the ort runtime install fails', async () => {

--- a/packages/webapp/tests/speech/ensure-speech-assets.test.ts
+++ b/packages/webapp/tests/speech/ensure-speech-assets.test.ts
@@ -6,6 +6,11 @@ import {
   ensureSpeechAssetsStaged,
   type SpeechAssetProgress,
 } from '../../src/speech/ensure-speech-assets.js';
+import {
+  ESPEAK_DIST_VFS_PATH,
+  ESPEAK_GLUE_FILE,
+  ESPEAK_WASM_FILE,
+} from '../../src/speech/espeak-phonemizer.js';
 import { ORT_DIST_VFS_PATH, ORT_WASM_DIST_FILES } from '../../src/speech/transformers-env.js';
 
 type FetchResult = Awaited<ReturnType<SecureFetch>>;
@@ -24,6 +29,19 @@ async function stageOrt(fs: VirtualFS): Promise<void> {
     await fs.mkdir(ORT_DIST_VFS_PATH, { recursive: true });
     await fs.writeFile(`${ORT_DIST_VFS_PATH}${f}`, bytes('wasm'));
   }
+}
+
+/** Pre-stage the espeak-ng dist files so its install fast-path is skipped. */
+async function stageEspeak(fs: VirtualFS): Promise<void> {
+  await fs.mkdir(ESPEAK_DIST_VFS_PATH, { recursive: true });
+  await fs.writeFile(`${ESPEAK_DIST_VFS_PATH}${ESPEAK_GLUE_FILE}`, bytes('glue'));
+  await fs.writeFile(`${ESPEAK_DIST_VFS_PATH}${ESPEAK_WASM_FILE}`, bytes('wasm'));
+}
+
+/** Pre-stage both wasm runtimes (ort + espeak) so only repo staging remains. */
+async function stageRuntimes(fs: VirtualFS): Promise<void> {
+  await stageOrt(fs);
+  await stageEspeak(fs);
 }
 
 function hfFetch(files: Record<string, Uint8Array>): SecureFetch {
@@ -63,28 +81,30 @@ afterEach(() => {
 describe('ensureSpeechAssetsStaged', () => {
   it('stages weight repos (ort already present) and streams per-asset progress', async () => {
     const fs = await newFs();
-    await stageOrt(fs);
+    await stageRuntimes(fs);
     const fetch = hfFetch({ 'config.json': bytes('{}'), 'model.onnx': bytes('abcd') });
     const progress: SpeechAssetProgress[] = [];
     const result = await ensureSpeechAssetsStaged({ fs, fetch, repos: [REPO] }, (p) =>
       progress.push(p)
     );
-    expect(result).toMatchObject({ skipped: false, ortStaged: false });
+    expect(result).toMatchObject({ skipped: false, ortStaged: false, espeakStaged: false });
     expect(result.repos).toEqual([{ repo: REPO, downloaded: 2, skipped: 0 }]);
     expect(await fs.exists(`/workspace/models/${REPO}/model.onnx`)).toBe(true);
     expect(progress.some((p) => p.asset === 'onnxruntime-web' && p.phase === 'present')).toBe(true);
+    expect(progress.some((p) => p.asset === 'espeak-ng' && p.phase === 'present')).toBe(true);
     const listing = progress.find((p) => p.asset === REPO && p.phase === 'listing');
     expect(listing).toMatchObject({ filesTotal: 2, bytesTotal: 6 });
   });
 
   it('is a fast no-op on a second call (weights byte-skipped)', async () => {
     const fs = await newFs();
-    await stageOrt(fs);
+    await stageRuntimes(fs);
     const fetch = hfFetch({ 'config.json': bytes('{}'), 'model.onnx': bytes('abcd') });
     await ensureSpeechAssetsStaged({ fs, fetch, repos: [REPO] });
     const second = await ensureSpeechAssetsStaged({ fs, fetch, repos: [REPO] });
     expect(second.repos).toEqual([{ repo: REPO, downloaded: 0, skipped: 2 }]);
     expect(second.ortStaged).toBe(false);
+    expect(second.espeakStaged).toBe(false);
   });
 
   it('early-returns on the extension float without touching the network', async () => {
@@ -96,18 +116,30 @@ describe('ensureSpeechAssetsStaged', () => {
     }) as unknown as SecureFetch;
     (globalThis as { chrome?: unknown }).chrome = { runtime: { id: 'ext-id' } };
     const result = await ensureSpeechAssetsStaged({ fs, fetch, repos: [REPO] });
-    expect(result).toEqual({ skipped: true, ortStaged: false, repos: [] });
+    expect(result).toEqual({ skipped: true, ortStaged: false, espeakStaged: false, repos: [] });
     expect(called).toBe(false);
   });
 
   it('rejects with a host-named error when HF is unreachable', async () => {
     const fs = await newFs();
-    await stageOrt(fs);
+    await stageRuntimes(fs);
     const failing: SecureFetch = (async () => {
       throw new TypeError('Failed to fetch');
     }) as unknown as SecureFetch;
     await expect(ensureSpeechAssetsStaged({ fs, fetch: failing, repos: [REPO] })).rejects.toThrow(
       /huggingface\.co/
+    );
+  });
+
+  it('rejects with an actionable error when the espeak-ng install fails', async () => {
+    const fs = await newFs();
+    // ort present, espeak absent → its installPackages runs and the fetch fails.
+    await stageOrt(fs);
+    const failing: SecureFetch = (async (url: string): Promise<FetchResult> => {
+      throw new TypeError(`Failed to fetch ${url}`);
+    }) as unknown as SecureFetch;
+    await expect(ensureSpeechAssetsStaged({ fs, fetch: failing, repos: [REPO] })).rejects.toThrow(
+      /failed to stage espeak-ng/
     );
   });
 

--- a/packages/webapp/tests/speech/espeak-phonemizer.test.ts
+++ b/packages/webapp/tests/speech/espeak-phonemizer.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type EspeakFactory,
+  getEspeakPhonemize,
+  phonemizeWithEspeak,
+  resetEspeakForTests,
+  setEspeakFactoryLoaderForTests,
+} from '../../src/speech/espeak-phonemizer.js';
+
+/** A fake espeak-ng emscripten module factory: records the args it was called
+ *  with and returns the canned phoneme `output` from `FS.readFile`. */
+function fakeFactory(output: string): {
+  factory: EspeakFactory;
+  calls: Array<{ arguments: string[] }>;
+} {
+  const calls: Array<{ arguments: string[] }> = [];
+  const factory: EspeakFactory = async (opts) => {
+    calls.push({ arguments: opts.arguments });
+    return { FS: { readFile: () => output } };
+  };
+  return { factory, calls };
+}
+
+describe('phonemizeWithEspeak', () => {
+  it('passes UTF-8 + IPA CLI args with the language and text, returns IPA lines', async () => {
+    const { factory, calls } = fakeFactory('ˈola\n\nˈmundo\n');
+    const out = await phonemizeWithEspeak(factory, 'Hola mundo', 'es');
+    expect(out).toEqual(['ˈola', 'ˈmundo']);
+    const args = calls[0].arguments;
+    expect(args).toContain('-b=1');
+    expect(args).toContain('--ipa');
+    expect(args).toContain('-q');
+    expect(args).toEqual(expect.arrayContaining(['-v', 'es']));
+    expect(args.at(-1)).toBe('Hola mundo');
+  });
+
+  it('forwards locateFile when provided', async () => {
+    const factory = vi.fn(async () => ({
+      FS: { readFile: () => 'p' },
+    })) as unknown as EspeakFactory;
+    const locateFile = (p: string): string => `blob:${p}`;
+    await phonemizeWithEspeak(factory, 'ciao', 'it', locateFile);
+    expect((factory as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].locateFile).toBe(
+      locateFile
+    );
+  });
+});
+
+describe('getEspeakPhonemize', () => {
+  afterEach(() => resetEspeakForTests());
+
+  it('loads the factory once and reuses it across calls', async () => {
+    const { factory } = fakeFactory('fɔ̃\n');
+    const loader = vi.fn(async () => ({ factory }));
+    setEspeakFactoryLoaderForTests(loader);
+    const phonemize = await getEspeakPhonemize();
+    const again = await getEspeakPhonemize();
+    expect(again).toBe(phonemize);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(await phonemize('bonjour', 'fr-fr')).toEqual(['fɔ̃']);
+  });
+
+  it('resets the memo on a failed load so a retry can succeed', async () => {
+    const failing = vi.fn(async () => {
+      throw new Error('vfs read failed');
+    });
+    setEspeakFactoryLoaderForTests(failing as never);
+    await expect(getEspeakPhonemize()).rejects.toThrow(/vfs read failed/);
+    const { factory } = fakeFactory('a\n');
+    setEspeakFactoryLoaderForTests(async () => ({ factory }));
+    await expect(getEspeakPhonemize()).resolves.toBeTypeOf('function');
+  });
+});

--- a/packages/webapp/tests/speech/espeak-phonemizer.test.ts
+++ b/packages/webapp/tests/speech/espeak-phonemizer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  createBlobBackedEspeakFactory,
   type EspeakFactory,
   getEspeakPhonemize,
   phonemizeWithEspeak,
@@ -22,6 +23,10 @@ function fakeFactory(output: string): {
 }
 
 describe('phonemizeWithEspeak', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('passes UTF-8 + IPA CLI args with the language and text, returns IPA lines', async () => {
     const { factory, calls } = fakeFactory('ˈola\n\nˈmundo\n');
     const out = await phonemizeWithEspeak(factory, 'Hola mundo', 'es');
@@ -43,6 +48,33 @@ describe('phonemizeWithEspeak', () => {
     expect((factory as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].locateFile).toBe(
       locateFile
     );
+  });
+
+  it('revokes the per-call wasm blob URL after the factory resolves', async () => {
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:wasm');
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const inner = vi.fn(async (opts) => {
+      expect(opts.locateFile?.('espeak-ng.wasm')).toBe('blob:wasm');
+      expect(opts.locateFile?.('other.data')).toBe('other.data');
+      return { FS: { readFile: () => 'p\n' } };
+    }) as unknown as EspeakFactory;
+
+    const factory = createBlobBackedEspeakFactory(inner, new Uint8Array([1, 2, 3]));
+    expect(await phonemizeWithEspeak(factory, 'hola', 'es')).toEqual(['p']);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:wasm');
+  });
+
+  it('revokes the wasm blob URL when the factory rejects', async () => {
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:wasm');
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const inner = vi.fn(async () => {
+      throw new Error('instantiate failed');
+    }) as unknown as EspeakFactory;
+
+    const factory = createBlobBackedEspeakFactory(inner, new Uint8Array([1]));
+    await expect(phonemizeWithEspeak(factory, 'hola', 'es')).rejects.toThrow(/instantiate failed/);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:wasm');
   });
 });
 

--- a/packages/webapp/tests/speech/kokoro-engine.multilang.test.ts
+++ b/packages/webapp/tests/speech/kokoro-engine.multilang.test.ts
@@ -1,23 +1,29 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   type EspeakFactory,
+  resetEspeakForTests,
   setEspeakFactoryLoaderForTests,
 } from '../../src/speech/espeak-phonemizer.js';
 
-// Minimal sentence-splitting stand-in for kokoro-js' TextSplitterStream.
+// Stand-in for kokoro-js' TextSplitterStream. If the non-English path used it
+// with one push+close, this fake would flush the whole input as one chunk.
 class FakeTextSplitterStream {
-  private sentences: string[] = [];
+  private buffer = '';
+  private chunks: string[] = [];
   private closed = false;
   push(...texts: string[]): void {
     for (const t of texts) {
-      for (const s of t.split(/(?<=[.!?])\s+/)) if (s.trim()) this.sentences.push(s.trim());
+      this.buffer += t;
     }
   }
   close(): void {
     this.closed = true;
+    const tail = this.buffer.trim();
+    if (tail) this.chunks.push(tail);
+    this.buffer = '';
   }
   async *[Symbol.asyncIterator](): AsyncGenerator<string, void, void> {
-    while (this.sentences.length) yield this.sentences.shift() as string;
+    while (this.chunks.length) yield this.chunks.shift() as string;
     if (!this.closed) throw new Error('iterated before close');
   }
 }
@@ -50,17 +56,25 @@ vi.mock('kokoro-js', () => ({
   TextSplitterStream: FakeTextSplitterStream,
 }));
 
-const { getKokoro, resetKokoroForTests } = await import('../../src/speech/kokoro-engine.js');
+const { getKokoro, resetKokoroForTests, splitKokoroStreamText } = await import(
+  '../../src/speech/kokoro-engine.js'
+);
 
 /** espeak factory returning a fixed phoneme string per call. */
-function stubEspeak(out: string): void {
-  const factory: EspeakFactory = async () => ({ FS: { readFile: () => out } });
+function stubEspeak(out: string): Array<{ arguments: string[] }> {
+  const calls: Array<{ arguments: string[] }> = [];
+  const factory: EspeakFactory = async (opts) => {
+    calls.push({ arguments: opts.arguments });
+    return { FS: { readFile: () => out } };
+  };
   setEspeakFactoryLoaderForTests(async () => ({ factory }));
+  return calls;
 }
 
 describe('kokoro non-English wrapper synth path', () => {
   afterEach(() => {
     resetKokoroForTests();
+    resetEspeakForTests();
     vi.clearAllMocks();
   });
 
@@ -84,13 +98,20 @@ describe('kokoro non-English wrapper synth path', () => {
   });
 
   it('streams a Spanish reply sentence-by-sentence via the espeak path', async () => {
-    stubEspeak('x');
+    const calls = stubEspeak('x');
     const tts = await getKokoro();
     const chunks: Array<{ audio: Float32Array }> = [];
-    for await (const c of tts.synthesizeStream('Hola. Adios.', { voice: 'ef_dora' })) {
+    for await (const c of tts.synthesizeStream('Hola. Adios. Tercero?', { voice: 'ef_dora' })) {
       chunks.push(c);
     }
-    expect(chunks).toHaveLength(2);
-    expect(fakeTts.generate_from_ids).toHaveBeenCalledTimes(2);
+    expect(chunks).toHaveLength(3);
+    expect(fakeTts.generate_from_ids).toHaveBeenCalledTimes(3);
+    expect(calls.map((c) => c.arguments.at(-1))).toEqual(['Hola', 'Adios', 'Tercero']);
+    expect(fakeTts.tokenizer.mock.calls.map(([text]) => text)).toEqual(['x.', 'x.', 'x?']);
+  });
+
+  it('splits non-English stream text on sentence and paragraph boundaries', () => {
+    expect(splitKokoroStreamText('Uno. Dos!\n\nTres?')).toEqual(['Uno.', 'Dos!', 'Tres?']);
+    expect(splitKokoroStreamText('alpha|beta|gamma', /\|/)).toEqual(['alpha', 'beta', 'gamma']);
   });
 });

--- a/packages/webapp/tests/speech/kokoro-engine.multilang.test.ts
+++ b/packages/webapp/tests/speech/kokoro-engine.multilang.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type EspeakFactory,
+  setEspeakFactoryLoaderForTests,
+} from '../../src/speech/espeak-phonemizer.js';
+
+// Minimal sentence-splitting stand-in for kokoro-js' TextSplitterStream.
+class FakeTextSplitterStream {
+  private sentences: string[] = [];
+  private closed = false;
+  push(...texts: string[]): void {
+    for (const t of texts) {
+      for (const s of t.split(/(?<=[.!?])\s+/)) if (s.trim()) this.sentences.push(s.trim());
+    }
+  }
+  close(): void {
+    this.closed = true;
+  }
+  async *[Symbol.asyncIterator](): AsyncGenerator<string, void, void> {
+    while (this.sentences.length) yield this.sentences.shift() as string;
+    if (!this.closed) throw new Error('iterated before close');
+  }
+}
+
+const fakeTts = {
+  voices: {
+    af_heart: { name: 'Heart', language: 'en-us', gender: 'Female' },
+    ef_dora: { name: 'Dora', language: 'es', gender: 'Female' },
+  },
+  tokenizer: vi.fn((text: string, _o: { truncation: boolean }) => ({
+    input_ids: { dims: [1, text.length], data: new Int32Array() } as never,
+  })),
+  generate: vi.fn(async () => ({ audio: new Float32Array([1]), sampling_rate: 24000 })),
+  generate_from_ids: vi.fn(async () => ({ audio: new Float32Array([2]), sampling_rate: 24000 })),
+  async *stream() {
+    yield { text: '', phonemes: '', audio: { audio: new Float32Array([1]), sampling_rate: 24000 } };
+  },
+};
+
+vi.mock('../../src/speech/transformers-env.js', () => ({
+  configureTransformersEnv: vi.fn(),
+  assertLocalModelPresent: vi.fn(async () => undefined),
+}));
+vi.mock('@huggingface/transformers', () => ({
+  env: { backends: { onnx: { wasm: {} } } },
+  AutoConfig: { from_pretrained: vi.fn(async () => ({ model_type: 'whisper' })) },
+}));
+vi.mock('kokoro-js', () => ({
+  KokoroTTS: { from_pretrained: vi.fn(async () => fakeTts) },
+  TextSplitterStream: FakeTextSplitterStream,
+}));
+
+const { getKokoro, resetKokoroForTests } = await import('../../src/speech/kokoro-engine.js');
+
+/** espeak factory returning a fixed phoneme string per call. */
+function stubEspeak(out: string): void {
+  const factory: EspeakFactory = async () => ({ FS: { readFile: () => out } });
+  setEspeakFactoryLoaderForTests(async () => ({ factory }));
+}
+
+describe('kokoro non-English wrapper synth path', () => {
+  afterEach(() => {
+    resetKokoroForTests();
+    vi.clearAllMocks();
+  });
+
+  it('routes a Spanish voice through espeak + generate_from_ids (not native generate)', async () => {
+    stubEspeak('ˈola');
+    const tts = await getKokoro();
+    const chunk = await tts.synthesize('Hola', { voice: 'ef_dora' });
+    expect(fakeTts.generate_from_ids).toHaveBeenCalledTimes(1);
+    expect(fakeTts.generate).not.toHaveBeenCalled();
+    expect(fakeTts.tokenizer).toHaveBeenCalledWith('ˈola', { truncation: true });
+    expect(Array.from(chunk.audio)).toEqual([2]);
+    expect(chunk.sampleRate).toBe(24000);
+  });
+
+  it('keeps an English voice on kokoro-js native generate', async () => {
+    const tts = await getKokoro();
+    const chunk = await tts.synthesize('Hello', { voice: 'af_heart' });
+    expect(fakeTts.generate).toHaveBeenCalledTimes(1);
+    expect(fakeTts.generate_from_ids).not.toHaveBeenCalled();
+    expect(Array.from(chunk.audio)).toEqual([1]);
+  });
+
+  it('streams a Spanish reply sentence-by-sentence via the espeak path', async () => {
+    stubEspeak('x');
+    const tts = await getKokoro();
+    const chunks: Array<{ audio: Float32Array }> = [];
+    for await (const c of tts.synthesizeStream('Hola. Adios.', { voice: 'ef_dora' })) {
+      chunks.push(c);
+    }
+    expect(chunks).toHaveLength(2);
+    expect(fakeTts.generate_from_ids).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/webapp/tests/speech/kokoro-phonemize.test.ts
+++ b/packages/webapp/tests/speech/kokoro-phonemize.test.ts
@@ -45,8 +45,8 @@ describe('splitOnPunctuation', () => {
 });
 
 describe('applyKokoroPhonemeFixups', () => {
-  it('applies the universal espeak→kokoro vocab mappings', () => {
-    expect(applyKokoroPhonemeFixups('rxɬʲ')).toBe('ɹklj');
+  it('preserves multilingual phonemes instead of applying English substitutions', () => {
+    expect(applyKokoroPhonemeFixups('rxɬʲ')).toBe('rxɬʲ');
   });
 
   it('normalizes the embedded kokoro pronunciation and trailing z', () => {
@@ -64,9 +64,9 @@ describe('phonemizeForKokoro', () => {
     expect(out).toBe('ˈola, ˈmundo');
   });
 
-  it('applies kokoro fixups to the joined espeak output', async () => {
-    const phonemize = vi.fn(async () => ['xeˈro']); // x→k, r→ɹ
-    expect(await phonemizeForKokoro('perro', 'es', phonemize)).toBe('keˈɹo');
+  it('keeps native espeak phonemes in the joined output', async () => {
+    const phonemize = vi.fn(async () => ['peˈro']);
+    expect(await phonemizeForKokoro('perro', 'es', phonemize)).toBe('peˈro');
   });
 
   it.each([

--- a/packages/webapp/tests/speech/kokoro-phonemize.test.ts
+++ b/packages/webapp/tests/speech/kokoro-phonemize.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyKokoroPhonemeFixups,
+  espeakVoiceForKokoroVoice,
+  KOKORO_PREFIX_ESPEAK,
+  phonemizeForKokoro,
+  splitOnPunctuation,
+} from '../../src/speech/kokoro-phonemize.js';
+
+describe('espeakVoiceForKokoroVoice', () => {
+  it('maps the five on-device non-English prefixes to espeak codes', () => {
+    expect(espeakVoiceForKokoroVoice('ef_dora')).toBe('es');
+    expect(espeakVoiceForKokoroVoice('ff_siwis')).toBe('fr-fr');
+    expect(espeakVoiceForKokoroVoice('if_sara')).toBe('it');
+    expect(espeakVoiceForKokoroVoice('hf_alpha')).toBe('hi');
+    expect(espeakVoiceForKokoroVoice('pf_dora')).toBe('pt-br');
+  });
+
+  it('returns null for English and the no-JS-G2P languages', () => {
+    expect(espeakVoiceForKokoroVoice('af_heart')).toBeNull();
+    expect(espeakVoiceForKokoroVoice('bm_george')).toBeNull();
+    expect(espeakVoiceForKokoroVoice('jf_alpha')).toBeNull();
+    expect(espeakVoiceForKokoroVoice('zf_xiaobei')).toBeNull();
+    expect(espeakVoiceForKokoroVoice('qq_unknown')).toBeNull();
+  });
+
+  it('exposes exactly the five wrapper-path languages', () => {
+    expect(Object.keys(KOKORO_PREFIX_ESPEAK).sort()).toEqual(['e', 'f', 'h', 'i', 'p']);
+  });
+});
+
+describe('splitOnPunctuation', () => {
+  it('keeps punctuation runs verbatim between phonemizable text', () => {
+    expect(splitOnPunctuation('Hola, mundo!')).toEqual([
+      { punct: false, text: 'Hola' },
+      { punct: true, text: ', ' },
+      { punct: false, text: 'mundo' },
+      { punct: true, text: '!' },
+    ]);
+  });
+
+  it('returns a single text part when there is no punctuation', () => {
+    expect(splitOnPunctuation('bonjour')).toEqual([{ punct: false, text: 'bonjour' }]);
+  });
+});
+
+describe('applyKokoroPhonemeFixups', () => {
+  it('applies the universal espeak→kokoro vocab mappings', () => {
+    expect(applyKokoroPhonemeFixups('rxɬʲ')).toBe('ɹklj');
+  });
+
+  it('normalizes the embedded kokoro pronunciation and trailing z', () => {
+    expect(applyKokoroPhonemeFixups('kəkˈoːɹoʊ')).toBe('kˈoʊkəɹoʊ');
+    expect(applyKokoroPhonemeFixups('foo z')).toBe('fooz');
+  });
+});
+
+describe('phonemizeForKokoro', () => {
+  it('phonemizes text runs in the given espeak language, keeping punctuation', async () => {
+    const phonemize = vi.fn(async (text: string) => (text === 'Hola' ? ['ˈola'] : ['ˈmundo']));
+    const out = await phonemizeForKokoro('Hola, mundo', 'es', phonemize);
+    expect(phonemize).toHaveBeenCalledWith('Hola', 'es');
+    expect(phonemize).toHaveBeenCalledWith('mundo', 'es');
+    expect(out).toBe('ˈola, ˈmundo');
+  });
+
+  it('applies kokoro fixups to the joined espeak output', async () => {
+    const phonemize = vi.fn(async () => ['xeˈro']); // x→k, r→ɹ
+    expect(await phonemizeForKokoro('perro', 'es', phonemize)).toBe('keˈɹo');
+  });
+
+  it.each([
+    ['ef_dora', 'es'],
+    ['ff_siwis', 'fr-fr'],
+    ['if_sara', 'it'],
+    ['hf_alpha', 'hi'],
+    ['pf_dora', 'pt-br'],
+  ])('routes %s through espeak language %s', async (voiceId, espeakLang) => {
+    const phonemize = vi.fn(async () => ['x']);
+    const lang = espeakVoiceForKokoroVoice(voiceId);
+    expect(lang).toBe(espeakLang);
+    await phonemizeForKokoro('texto', lang as string, phonemize);
+    expect(phonemize).toHaveBeenCalledWith('texto', espeakLang);
+  });
+});

--- a/packages/webapp/tests/speech/kokoro-voices.test.ts
+++ b/packages/webapp/tests/speech/kokoro-voices.test.ts
@@ -1,7 +1,10 @@
+import { KokoroTTS } from 'kokoro-js';
 import { describe, expect, it, vi } from 'vitest';
 import {
   applyStyleTts2ConfigShim,
+  buildKokoroVoiceInfos,
   injectStyleTts2Architectures,
+  KOKORO_MULTILINGUAL_VOICES,
   toKokoroVoiceInfos,
 } from '../../src/speech/kokoro-engine.js';
 
@@ -68,6 +71,65 @@ describe('toKokoroVoiceInfos', () => {
     expect(toKokoroVoiceInfos({ ef_dora: { language: 'es' } })).toEqual([
       { id: 'ef_dora', name: 'ef_dora', lang: 'es', onDevice: true },
     ]);
+  });
+});
+
+describe('buildKokoroVoiceInfos (multilingual augmentation)', () => {
+  // The frozen English-only map kokoro-js@1.2.1 actually ships. Constructing an
+  // instance with no model/tokenizer is safe — `get voices()` only returns the
+  // module-private static map. This is the REAL library list, not a mock, so a
+  // future kokoro-js that still omits multilingual voices can't silently
+  // regress this engine back to English-only.
+  const realVoices = new KokoroTTS(null as never, null as never).voices as Record<
+    string,
+    { name?: string; language?: string; gender?: string }
+  >;
+
+  it('confirms the real kokoro-js VOICES is English-only (the root cause)', () => {
+    const langs = new Set(toKokoroVoiceInfos(realVoices).map((v) => v.lang.split('-')[0]));
+    expect([...langs].sort()).toEqual(['en']);
+  });
+
+  it('augments the real English-only list with the base model multilingual voices', () => {
+    const infos = buildKokoroVoiceInfos(realVoices);
+    const byId = new Map(infos.map((v) => [v.id, v]));
+
+    // English voices kokoro-js reports survive unchanged.
+    expect(byId.get('af_heart')).toMatchObject({ lang: 'en-US', onDevice: true });
+    expect(byId.get('bm_george')).toMatchObject({ lang: 'en-GB', onDevice: true });
+
+    // es/fr/it/hi/pt are present AND on-device (reach the espeak wrapper path).
+    expect(byId.get('ef_dora')).toMatchObject({ name: 'Dora', lang: 'es-ES', onDevice: true });
+    expect(byId.get('ff_siwis')).toMatchObject({ name: 'Siwis', lang: 'fr-FR', onDevice: true });
+    expect(byId.get('if_sara')).toMatchObject({ name: 'Sara', lang: 'it-IT', onDevice: true });
+    expect(byId.get('hf_alpha')).toMatchObject({ name: 'Alpha', lang: 'hi-IN', onDevice: true });
+    expect(byId.get('pm_alex')).toMatchObject({ name: 'Alex', lang: 'pt-BR', onDevice: true });
+
+    // ja/zh are present but Web-Speech-only (no JS G2P).
+    expect(byId.get('jf_alpha')).toMatchObject({ lang: 'ja-JP', onDevice: false });
+    expect(byId.get('zm_yunjian')).toMatchObject({ lang: 'zh-CN', onDevice: false });
+  });
+
+  it('marks every es/fr/it/hi/pt augmentation voice on-device and ja/zh off', () => {
+    const infos = buildKokoroVoiceInfos(realVoices);
+    const onDevicePrefixes = new Set(['e', 'f', 'i', 'h', 'p']);
+    for (const id of Object.keys(KOKORO_MULTILINGUAL_VOICES)) {
+      const info = infos.find((v) => v.id === id);
+      expect(info, `voice ${id} should be exposed`).toBeDefined();
+      expect(info?.onDevice, `voice ${id} on-device flag`).toBe(onDevicePrefixes.has(id[0]));
+    }
+  });
+
+  it('lets a real kokoro-js entry win over the static augmentation on id collision', () => {
+    // A hypothetical future kokoro-js that ships ef_dora natively with its own
+    // metadata must supersede our static fallback (library is source of truth).
+    const infos = buildKokoroVoiceInfos({
+      ...realVoices,
+      ef_dora: { name: 'Dora (native)', language: 'es-ES', gender: 'Female' },
+    });
+    const dora = infos.filter((v) => v.id === 'ef_dora');
+    expect(dora).toHaveLength(1);
+    expect(dora[0].name).toBe('Dora (native)');
   });
 });
 

--- a/packages/webapp/tests/speech/kokoro-voices.test.ts
+++ b/packages/webapp/tests/speech/kokoro-voices.test.ts
@@ -58,9 +58,14 @@ describe('toKokoroVoiceInfos', () => {
     expect(toKokoroVoiceInfos({ xf_unknown: {} })).toEqual([
       { id: 'xf_unknown', name: 'xf_unknown', lang: 'en-US', onDevice: false },
     ]);
-    // A reported language still wins (and is trusted for on-device routing).
+    // A full reported language still wins (and is trusted for on-device routing).
     expect(toKokoroVoiceInfos({ xf_unknown: { language: 'es-ES' } })).toEqual([
       { id: 'xf_unknown', name: 'xf_unknown', lang: 'es-ES', onDevice: true },
+    ]);
+    // A regionless reported language on an unknown prefix is too ambiguous to
+    // route on-device.
+    expect(toKokoroVoiceInfos({ xf_unknown: { language: 'es' } })).toEqual([
+      { id: 'xf_unknown', name: 'xf_unknown', lang: 'es', onDevice: false },
     ]);
   });
 
@@ -70,6 +75,12 @@ describe('toKokoroVoiceInfos', () => {
     ]);
     expect(toKokoroVoiceInfos({ ef_dora: { language: 'es' } })).toEqual([
       { id: 'ef_dora', name: 'ef_dora', lang: 'es', onDevice: true },
+    ]);
+  });
+
+  it('does not collapse region-different voices onto a base-language Kokoro head', () => {
+    expect(toKokoroVoiceInfos({ pf_dora: { language: 'pt-PT' } })).toEqual([
+      { id: 'pf_dora', name: 'pf_dora', lang: 'pt-PT', onDevice: false },
     ]);
   });
 });

--- a/packages/webapp/tests/speech/kokoro-voices.test.ts
+++ b/packages/webapp/tests/speech/kokoro-voices.test.ts
@@ -49,6 +49,18 @@ describe('toKokoroVoiceInfos', () => {
     ]);
   });
 
+  it('defaults an unknown/unmapped prefix with no reported language to onDevice:false', () => {
+    // Future community voices with prefixes we don't map must NOT route to
+    // Kokoro: we keep en-US as a display fallback but mark them Web-Speech-only.
+    expect(toKokoroVoiceInfos({ xf_unknown: {} })).toEqual([
+      { id: 'xf_unknown', name: 'xf_unknown', lang: 'en-US', onDevice: false },
+    ]);
+    // A reported language still wins (and is trusted for on-device routing).
+    expect(toKokoroVoiceInfos({ xf_unknown: { language: 'es-ES' } })).toEqual([
+      { id: 'xf_unknown', name: 'xf_unknown', lang: 'es-ES', onDevice: true },
+    ]);
+  });
+
   it('prefers a reported language over the id prefix, normalizing its casing', () => {
     expect(toKokoroVoiceInfos({ pf_dora: { language: 'pt-br' } })).toEqual([
       { id: 'pf_dora', name: 'pf_dora', lang: 'pt-BR', onDevice: true },

--- a/packages/webapp/tests/speech/kokoro-voices.test.ts
+++ b/packages/webapp/tests/speech/kokoro-voices.test.ts
@@ -13,15 +13,48 @@ describe('toKokoroVoiceInfos', () => {
       bm_george: { name: 'George', language: 'en-gb', gender: 'Male' },
     });
     expect(infos).toEqual([
-      { id: 'af_heart', name: 'Heart', lang: 'en-US', gender: 'Female' },
-      { id: 'am_adam', name: 'Adam', lang: 'en-US', gender: 'Male' },
-      { id: 'bm_george', name: 'George', lang: 'en-GB', gender: 'Male' },
+      { id: 'af_heart', name: 'Heart', lang: 'en-US', onDevice: true, gender: 'Female' },
+      { id: 'am_adam', name: 'Adam', lang: 'en-US', onDevice: true, gender: 'Male' },
+      { id: 'bm_george', name: 'George', lang: 'en-GB', onDevice: true, gender: 'Male' },
     ]);
   });
 
-  it('falls back to the id and the id-prefix language when metadata is sparse', () => {
+  it('maps each id prefix to its real BCP-47 language when metadata is sparse', () => {
     expect(toKokoroVoiceInfos({ bf_alice: {} })).toEqual([
-      { id: 'bf_alice', name: 'bf_alice', lang: 'en-GB' },
+      { id: 'bf_alice', name: 'bf_alice', lang: 'en-GB', onDevice: true },
+    ]);
+    expect(toKokoroVoiceInfos({ ef_dora: {} })).toEqual([
+      { id: 'ef_dora', name: 'ef_dora', lang: 'es-ES', onDevice: true },
+    ]);
+    expect(toKokoroVoiceInfos({ ff_siwis: {} })).toEqual([
+      { id: 'ff_siwis', name: 'ff_siwis', lang: 'fr-FR', onDevice: true },
+    ]);
+    expect(toKokoroVoiceInfos({ if_sara: {} })).toEqual([
+      { id: 'if_sara', name: 'if_sara', lang: 'it-IT', onDevice: true },
+    ]);
+    expect(toKokoroVoiceInfos({ hf_alpha: {} })).toEqual([
+      { id: 'hf_alpha', name: 'hf_alpha', lang: 'hi-IN', onDevice: true },
+    ]);
+    expect(toKokoroVoiceInfos({ pf_dora: {} })).toEqual([
+      { id: 'pf_dora', name: 'pf_dora', lang: 'pt-BR', onDevice: true },
+    ]);
+  });
+
+  it('marks Japanese and Mandarin voices as Web-Speech-only (not on-device)', () => {
+    expect(toKokoroVoiceInfos({ jf_alpha: { gender: 'Female' } })).toEqual([
+      { id: 'jf_alpha', name: 'jf_alpha', lang: 'ja-JP', onDevice: false, gender: 'Female' },
+    ]);
+    expect(toKokoroVoiceInfos({ zm_yunjian: { gender: 'Male' } })).toEqual([
+      { id: 'zm_yunjian', name: 'zm_yunjian', lang: 'zh-CN', onDevice: false, gender: 'Male' },
+    ]);
+  });
+
+  it('prefers a reported language over the id prefix, normalizing its casing', () => {
+    expect(toKokoroVoiceInfos({ pf_dora: { language: 'pt-br' } })).toEqual([
+      { id: 'pf_dora', name: 'pf_dora', lang: 'pt-BR', onDevice: true },
+    ]);
+    expect(toKokoroVoiceInfos({ ef_dora: { language: 'es' } })).toEqual([
+      { id: 'ef_dora', name: 'ef_dora', lang: 'es', onDevice: true },
     ]);
   });
 });

--- a/packages/webapp/tests/speech/speak.test.ts
+++ b/packages/webapp/tests/speech/speak.test.ts
@@ -74,8 +74,10 @@ function fakeKokoro(opts?: {
       vi.fn().mockResolvedValue({ audio: new Float32Array([0, 0.5, -0.5]), sampleRate: 24000 }),
     synthesizeStream: synthesizeStream as never,
     voices: () => [
-      { id: 'af_heart', name: 'Heart', lang: 'en-US' },
-      { id: 'bm_george', name: 'George', lang: 'en-GB' },
+      { id: 'af_heart', name: 'Heart', lang: 'en-US', onDevice: true },
+      { id: 'bm_george', name: 'George', lang: 'en-GB', onDevice: true },
+      { id: 'ef_dora', name: 'Dora', lang: 'es-ES', onDevice: true },
+      { id: 'jf_alpha', name: 'Alpha', lang: 'ja-JP', onDevice: false },
     ],
   };
 }
@@ -139,8 +141,20 @@ afterEach(() => {
 });
 
 describe('pickSpeakEngine', () => {
-  const ready = { ready: true, voiceIds: ['af_heart', 'bm_george'] };
-  const notReady = { ready: false, voiceIds: [] };
+  const voices = [
+    { id: 'af_heart', lang: 'en-US', onDevice: true },
+    { id: 'bm_george', lang: 'en-GB', onDevice: true },
+    { id: 'ef_dora', lang: 'es-ES', onDevice: true },
+    { id: 'ff_siwis', lang: 'fr-FR', onDevice: true },
+    { id: 'jf_alpha', lang: 'ja-JP', onDevice: false },
+  ];
+  // CLI/standalone realm: the espeak-ng phonemizer loads, so non-English
+  // on-device synthesis is available.
+  const ready = { ready: true, voices, nonEnglishOnDevice: true };
+  // Extension float: MV3 CSP blocks the espeak-ng glue, so non-English falls
+  // back to Web Speech.
+  const extension = { ready: true, voices, nonEnglishOnDevice: false };
+  const notReady = { ready: false, voices: [], nonEnglishOnDevice: true };
 
   it('prefers kokoro whenever it is ready and nothing forces webspeech', () => {
     expect(pickSpeakEngine({}, ready)).toBe('kokoro');
@@ -148,17 +162,38 @@ describe('pickSpeakEngine', () => {
     expect(pickSpeakEngine({}, notReady)).toBe('webspeech');
   });
 
-  it('routes non-English languages to webspeech (kokoro is English-only)', () => {
-    expect(pickSpeakEngine({ lang: 'de-DE' }, ready)).toBe('webspeech');
+  it('routes es/fr/it/hi/pt to kokoro on-device (espeak-ng phonemizer)', () => {
+    expect(pickSpeakEngine({ lang: 'es-ES' }, ready)).toBe('kokoro');
+    expect(pickSpeakEngine({ lang: 'fr' }, ready)).toBe('kokoro');
+  });
+
+  it('keeps ja/zh and other languages on webspeech (no JS G2P / no voice)', () => {
     expect(pickSpeakEngine({ lang: 'ja' }, ready)).toBe('webspeech');
+    expect(pickSpeakEngine({ lang: 'zh-CN' }, ready)).toBe('webspeech');
+    expect(pickSpeakEngine({ lang: 'de-DE' }, ready)).toBe('webspeech');
+  });
+
+  it('gates non-English to webspeech in the extension float (CSP), English stays kokoro', () => {
+    expect(pickSpeakEngine({ lang: 'es-ES' }, extension)).toBe('webspeech');
+    expect(pickSpeakEngine({ lang: 'fr' }, extension)).toBe('webspeech');
+    // English still synthesizes on-device there (kokoro-js bundles en_dict).
+    expect(pickSpeakEngine({ lang: 'en-US' }, extension)).toBe('kokoro');
+    expect(pickSpeakEngine({}, extension)).toBe('kokoro');
+    // An explicit non-English kokoro voice also degrades to webspeech there.
+    expect(pickSpeakEngine({ voice: 'ef_dora' }, extension)).toBe('webspeech');
+    // …but an explicit English kokoro voice still routes on-device.
+    expect(pickSpeakEngine({ voice: 'af_heart' }, extension)).toBe('kokoro');
   });
 
   it('an explicit voice picks its engine: kokoro ids → kokoro, names → webspeech', () => {
     expect(pickSpeakEngine({ voice: 'af_heart' }, ready)).toBe('kokoro');
+    expect(pickSpeakEngine({ voice: 'ef_dora' }, ready)).toBe('kokoro');
     expect(pickSpeakEngine({ voice: 'Samantha' }, ready)).toBe('webspeech');
+    // A kokoro voice with no JS G2P (ja/zh) is not synthesizable → webspeech.
+    expect(pickSpeakEngine({ voice: 'jf_alpha' }, ready)).toBe('webspeech');
     // A kokoro id before the model is ready can't synthesize — webspeech.
     expect(pickSpeakEngine({ voice: 'af_heart' }, notReady)).toBe('webspeech');
-    // An explicit kokoro voice overrides the language gate.
+    // An explicit (synthesizable) kokoro voice overrides the language hint.
     expect(pickSpeakEngine({ voice: 'af_heart', lang: 'de-DE' }, ready)).toBe('kokoro');
   });
 });
@@ -343,7 +378,37 @@ describe('speak', () => {
   it('exposes kokoro voices only once the engine is warm', () => {
     expect(kokoroVoicesIfReady()).toEqual([]);
     kokoroHolder.tts = fakeKokoro();
-    expect(kokoroVoicesIfReady().map((v) => v.id)).toEqual(['af_heart', 'bm_george']);
+    expect(kokoroVoicesIfReady().map((v) => v.id)).toEqual([
+      'af_heart',
+      'bm_george',
+      'ef_dora',
+      'jf_alpha',
+    ]);
+  });
+
+  it('selects a language-matched kokoro voice for a non-English request (CLI realm)', async () => {
+    const { started } = stubSpeechGlobals();
+    const tts = fakeKokoro();
+    kokoroHolder.tts = tts;
+
+    // No explicit voice: es-ES must resolve to the Spanish kokoro voice, not
+    // the English default, so the audio is actually spoken in Spanish.
+    const result = await speak({ text: 'hola', lang: 'es-ES' });
+    expect(result.engine).toBe('kokoro');
+    expect(tts.synthesizeStream).toHaveBeenCalledWith('hola', { voice: 'ef_dora' });
+    expect(started.length).toBe(1);
+  });
+
+  it('uses the kokoro default voice for English (no explicit voice id)', async () => {
+    const { started } = stubSpeechGlobals();
+    const tts = fakeKokoro();
+    kokoroHolder.tts = tts;
+
+    const result = await speak({ text: 'hello', lang: 'en-US' });
+    expect(result.engine).toBe('kokoro');
+    // English passes no voice → kokoro-js applies its built-in default.
+    expect(tts.synthesizeStream).toHaveBeenCalledWith('hello', {});
+    expect(started.length).toBe(1);
   });
 });
 

--- a/packages/webapp/tests/speech/speak.test.ts
+++ b/packages/webapp/tests/speech/speak.test.ts
@@ -386,6 +386,17 @@ describe('speak', () => {
     ]);
   });
 
+  it('demotes non-English kokoro voices in the extension runtime voice list', () => {
+    kokoroHolder.tts = fakeKokoro();
+    vi.stubGlobal('chrome', { runtime: { id: 'ext-id' } });
+    expect(kokoroVoicesIfReady()).toEqual([
+      { id: 'af_heart', name: 'Heart', lang: 'en-US', onDevice: true },
+      { id: 'bm_george', name: 'George', lang: 'en-GB', onDevice: true },
+      { id: 'ef_dora', name: 'Dora', lang: 'es-ES', onDevice: false },
+      { id: 'jf_alpha', name: 'Alpha', lang: 'ja-JP', onDevice: false },
+    ]);
+  });
+
   it('selects a language-matched kokoro voice for a non-English request (CLI realm)', async () => {
     const { started } = stubSpeechGlobals();
     const tts = fakeKokoro();

--- a/packages/webapp/tests/ui/panel-rpc-device-handlers.test.ts
+++ b/packages/webapp/tests/ui/panel-rpc-device-handlers.test.ts
@@ -740,6 +740,8 @@ describe('createStandalonePanelRpcHandlers — page misc', () => {
     });
     const result = await promise;
     expect(result.voices.map((v) => v.name)).toEqual(['Daniel', 'Karen']);
+    // Web Speech voices are never on-device.
+    expect(result.voices.every((v) => v.onDevice === false)).toBe(true);
   });
 
   it('speak-status returns the page-side kokoro status', async () => {


### PR DESCRIPTION
Closes #1095.

## What

Adds on-device (Kokoro) synthesis for **Spanish, French, Italian, Hindi, and Portuguese**, and corrects voice labelling so the non-on-device languages are clearly marked. Previously `say --list` only exposed the 28 English voices and every non-English request silently fell back to the browser's Web Speech system voices.

## How

- **Multilingual phonemization** (`kokoro-phonemize.ts`): an `espeak-ng` (WASM) wrapper generates phonemes for non-English text and feeds them to `generate_from_ids`, bypassing kokoro-js's English-only synthesis path.
- **Voice registry augmentation** (`kokoro-engine.ts`): kokoro-js@1.2.1's static `VOICES` map ships only the 28 English voices, even though the base `onnx-community/Kokoro-82M-v1.0-ONNX` model bundles the multilingual style vectors. A pure `buildKokoroVoiceInfos()` merges kokoro-js's `tts.voices` with the 26 non-English base-model voices (library wins on id collision). es/fr/it/hi/pt are flagged `onDevice:true`; ja/zh are flagged `onDevice:false` (no JS G2P port, so they remain Web Speech).
- **Routing** (`speak.ts` `pickSpeakEngine`): es/fr/it/hi/pt now route to Kokoro both by language (`say -l es-ES`) and by explicit voice id (`say -v ef_dora`); ja/zh stay on Web Speech.
- **Labelling** (`say --list`): on-device voices are marked `[kokoro]`; Web Speech voices are marked accordingly.

## Cross-runtime status

On-device non-English synthesis works in the **standalone / CLI / Electron** floats. The **extension** float (MV3 CSP) cannot dynamic-import the espeak-ng glue from a VFS blob URL, so non-English gracefully degrades to Web Speech there. Japanese and Mandarin are intentionally Web-Speech-only everywhere (no JS G2P). German is **not** included here and is tracked as a follow-up (see below).

## Testing

- `npm run typecheck` (all projects) — pass.
- `npm run test -w @slicc/webapp` speech suite — pass.
- Lint — pass.
- **Non-mocked regression guard**: a new test in `kokoro-voices.test.ts` exercises the engine's voice-list construction against the **real** kokoro-js `VOICES` (no mock), so a future kokoro-js that still omits multilingual voices cannot silently regress the feature back to English-only. This guards against the exact gap that an earlier mocked-only suite missed.
- **Manual listen-test** in the SLICC-Swift float: warmed the model, confirmed `say --list` marks es/fr/it/hi/pt as `[kokoro]`, and verified by ear that all five play in the Kokoro neural timbre (not the macOS system voices), while ja/zh correctly remain Web Speech.

## Follow-up

German on-device voice support requires a dedicated raw ONNX engine (the community German model uses a format incompatible with the kokoro-js backbone) and is deferred to a separate issue.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author