### PR TITLE
feat(webcomponents): click-to-preview for chat image attachments

### DIFF
--- a/packages/webcomponents/src/chat/slicc-user-message.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-user-message.stories.ts
@@ -172,6 +172,36 @@ export const ImageOnly: Story = {
   },
 };
 
+/**
+ * Click-to-preview — clicking any image thumbnail opens the FLIP-zoom lightbox
+ * (`SliccImagePreview`). Click a swatch below to try.
+ */
+export const ClickToPreview: Story = {
+  render: () => {
+    const el = document.createElement('slicc-user-message') as SliccUserMessage;
+    el.style.display = 'block';
+    el.style.maxWidth = '520px';
+    el.setAttribute('text', 'Which screenshot looks better?');
+    el.setAttachments([
+      {
+        name: 'option-a.png',
+        kind: 'image',
+        src: swatch('#fbbf24', '#ef4444'),
+        mime: 'image/png',
+        size: 128_000,
+      },
+      {
+        name: 'option-b.png',
+        kind: 'image',
+        src: swatch('#06b6d4', '#7c3aed'),
+        mime: 'image/png',
+        size: 96_400,
+      },
+    ]);
+    return el;
+  },
+};
+
 /** A realistic two-bubble exchange, reviewing right-alignment and stacking. */
 export const Conversation: Story = {
   render: () => {

--- a/packages/webcomponents/src/chat/slicc-user-message.ts
+++ b/packages/webcomponents/src/chat/slicc-user-message.ts
@@ -1,6 +1,7 @@
 import { define } from '../internal/define.js';
 import { h, sheet } from '../internal/dom.js';
 import { iconEl } from '../internal/icons.js';
+import { SliccImagePreview } from '../primitives/slicc-image-preview.js';
 
 /**
  * Shared constructable stylesheet, lifted from the prototype's chat rules:
@@ -56,7 +57,7 @@ const STYLE = `
 .attachments{display:flex;flex-wrap:wrap;gap:6px;justify-content:flex-end;}
 .attachment-chip{display:inline-flex;align-items:center;gap:8px;max-width:240px;padding:6px 9px;border:1px solid var(--line);border-radius:10px;background:var(--ghost);font-family:var(--ui);}
 .attachment-chip__visual{display:inline-flex;flex:0 0 auto;width:30px;height:30px;border-radius:7px;overflow:hidden;align-items:center;justify-content:center;background:var(--bg);color:var(--txt-2);}
-.attachment-chip__visual img{width:100%;height:100%;object-fit:cover;display:block;}
+.attachment-chip__visual img{width:100%;height:100%;object-fit:cover;display:block;cursor:zoom-in;}
 .attachment-chip__visual svg{display:block;}
 .attachment-chip__body{display:flex;flex-direction:column;min-width:0;}
 .attachment-chip__name{font-size:12px;color:var(--ink);font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
@@ -201,7 +202,12 @@ export class SliccUserMessage extends HTMLElement {
     const kind = att.kind ?? 'file';
     const visual = h('span', { class: 'attachment-chip__visual' });
     if (kind === 'image' && att.src) {
-      visual.append(h('img', { src: att.src, alt: att.name || 'Attached image' }));
+      const img = h('img', { src: att.src, alt: att.name || 'Attached image' }) as HTMLImageElement;
+      img.addEventListener('click', (e) => {
+        e.stopPropagation();
+        SliccImagePreview.show(att.src!, img);
+      });
+      visual.append(img);
     } else {
       visual.append(iconEl(ATTACHMENT_ICON[kind], { size: 16 }));
     }

--- a/packages/webcomponents/tests/chat/slicc-user-message.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-user-message.test.ts
@@ -193,6 +193,53 @@ describe('slicc-user-message', () => {
       expect(el.shadowRoot?.querySelectorAll('.attachment-chip')).toHaveLength(1);
       expect(el.shadowRoot?.querySelector('.attachment-chip__name')?.textContent).toBe('b.txt');
     });
+
+    it('opens image preview on thumbnail click', () => {
+      const el = mount({ text: 'check this' });
+      el.setAttachments([{ name: 'p.png', kind: 'image', src: 'data:image/png;base64,AAAA' }]);
+      const img = el.shadowRoot?.querySelector('.attachment-chip--image img') as HTMLImageElement;
+      expect(img).not.toBeNull();
+      expect(getComputedStyle(img).cursor).toBe('zoom-in');
+      img.click();
+      const preview = document.querySelector('slicc-image-preview[data-shared]');
+      expect(preview).not.toBeNull();
+      expect(preview?.hasAttribute('open')).toBe(true);
+      expect(preview?.getAttribute('src')).toBe('data:image/png;base64,AAAA');
+      preview?.remove();
+    });
+
+    it('does not add preview behavior to non-image attachments', () => {
+      const el = mount({ text: 'doc' });
+      el.setAttachments([{ name: 'readme.txt', kind: 'text', mime: 'text/plain' }]);
+      const chip = el.shadowRoot?.querySelector('.attachment-chip--text') as HTMLElement;
+      const img = chip?.querySelector('img');
+      expect(img).toBeNull();
+      chip.click();
+      const preview = document.querySelector('slicc-image-preview[data-shared]');
+      expect(preview?.hasAttribute('open')).toBeFalsy();
+      preview?.remove();
+    });
+
+    it('each image attachment independently opens its own preview', () => {
+      const el = mount({ text: 'two images' });
+      el.setAttachments([
+        { name: 'a.png', kind: 'image', src: 'data:image/png;base64,AAAA' },
+        { name: 'b.jpg', kind: 'image', src: 'data:image/jpeg;base64,BBBB' },
+      ]);
+      const imgs = el.shadowRoot?.querySelectorAll(
+        '.attachment-chip--image img'
+      ) as NodeListOf<HTMLImageElement>;
+      expect(imgs).toHaveLength(2);
+
+      imgs[0].click();
+      let preview = document.querySelector('slicc-image-preview[data-shared]');
+      expect(preview?.getAttribute('src')).toBe('data:image/png;base64,AAAA');
+
+      imgs[1].click();
+      preview = document.querySelector('slicc-image-preview[data-shared]');
+      expect(preview?.getAttribute('src')).toBe('data:image/jpeg;base64,BBBB');
+      preview?.remove();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Image thumbnails in sent user messages now open the FLIP-zoom lightbox (`SliccImagePreview`) on click
- Matches the existing preview behavior already available in the composer's staged attachments
- Added `cursor: zoom-in` to signal interactivity

## Test plan

- [x] Typecheck passes (`npm run typecheck -w @slicc/webcomponents`)
- [x] All 1622 tests pass (`npm run test -w @slicc/webcomponents`)
- [x] Lint passes (`npm run lint`)
- [x] 3 new test cases: happy path click, non-image no-op, multiple images open independently
- [ ] Manual: paste an image in chat, send, click the thumbnail in the sent message — lightbox opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)