### PR TITLE
perf(webcomponents): stop forcing a style recalc on every shader frame

### DIFF
--- a/packages/webcomponents/CLAUDE.md
+++ b/packages/webcomponents/CLAUDE.md
@@ -57,6 +57,16 @@ tests/**/<name>.test.ts    co-located browser tests, mirroring src/ subsystem
   `[data-theme="dark"]`. Components needing per-element dark tweaks add their own
   `.dark &` / `:host(...)` rules. Preserve `::part` hooks on lifted elements
   (`slicc-pill`, `slicc-add-menu`) exactly.
+- **Animation loops must not force reflow.** A `requestAnimationFrame` loop must
+  never call `getComputedStyle`, append/measure a DOM probe, or otherwise read
+  computed style/layout per frame — each one forces a full-document style recalc,
+  and the cumulative storm flickers/janks the whole app (regression: `slicc-shader`
+  resolved its `tint` + `--ink` uniforms via `getComputedStyle` plus a
+  `document.body` color probe ~3×/frame — at 120 Hz that's ~360 style-recalcs/sec).
+  Resolve CSS-derived values ONCE and cache them; invalidate on the relevant
+  attribute change and on a theme change (a `class` / `data-theme` MutationObserver
+  on `<html>`/`<body>` plus a `prefers-color-scheme` listener, torn down in
+  `disconnectedCallback`).
 - **Public API:** export the class; expose attributes (reflected to properties),
   `::part` hooks, named slots, and `CustomEvent`s (composed + bubbling) — never
   reach into another component's internals.

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -251,6 +251,16 @@ export class SliccShader extends HTMLElement {
   #energy = 0;
   #ro: ResizeObserver | null = null;
   #reduced = false;
+  // Cached CSS-derived uniforms. Resolved on connect / `tint` change / theme
+  // change — NEVER per frame: resolving them calls getComputedStyle and (via
+  // colorToVec3) appends a probe to document.body, which forces a full-document
+  // style recalc. Doing that every animation frame was the flicker's cause.
+  #tintVec: [number, number, number] = [0.545, 0.361, 0.965];
+  #evtVec: [number, number, number] = [0.957, 0.247, 0.369];
+  #darkVal = 0;
+  #themeObserver: MutationObserver | null = null;
+  #colorSchemeMq: MediaQueryList | null = null;
+  #onColorSchemeChange: (() => void) | null = null;
   #builtMode: ShaderMode | null = null;
   #onContextLost: ((e: Event) => void) | null = null;
   #onContextRestored: (() => void) | null = null;
@@ -278,6 +288,8 @@ export class SliccShader extends HTMLElement {
       this.#ro = new ResizeObserver(() => this.#renderIfStatic());
       this.#ro.observe(this);
     }
+    this.#refreshColorUniforms();
+    this.#observeTheme();
     this.#start = performance.now() / 1000;
     if (this.#reduced) this.#renderFrame();
     else this.#startLoop();
@@ -287,11 +299,21 @@ export class SliccShader extends HTMLElement {
     this.#stopLoop();
     this.#ro?.disconnect();
     this.#ro = null;
+    this.#themeObserver?.disconnect();
+    this.#themeObserver = null;
+    if (this.#colorSchemeMq && this.#onColorSchemeChange) {
+      this.#colorSchemeMq.removeEventListener('change', this.#onColorSchemeChange);
+    }
+    this.#colorSchemeMq = null;
+    this.#onColorSchemeChange = null;
     this.#dispose();
   }
 
   attributeChangedCallback(name: string): void {
     if (!this.isConnected) return;
+    // `tint` drives the tint + event-tint uniforms — re-resolve the cache before
+    // any repaint below. (`mode` only swaps the GL program, not the colors.)
+    if (name === 'tint') this.#refreshColorUniforms();
     if (name === 'mode' && this.#gl && this.mode !== this.#builtMode) {
       // Switch to the (cached) program and repaint synchronously so the
       // previous mode's frame does not linger for a rAF — the blue flicker.
@@ -397,6 +419,47 @@ export class SliccShader extends HTMLElement {
 
   #renderIfStatic(): void {
     if (this.#reduced && this.#gl) this.#renderFrame();
+  }
+
+  /** Resolve + cache the CSS-derived uniforms (tint, event tint, dark mode).
+   *  Called on connect, on a `tint` change, and on a theme change — NEVER per
+   *  frame. Each call uses getComputedStyle and (via colorToVec3) a one-shot
+   *  probe appended to document.body, so running it every animation frame
+   *  forced a full-document style recalc — the flicker. The values only change
+   *  on a theme/tint switch, so caching them is safe. */
+  #refreshColorUniforms(): void {
+    const tintAttr = this.getAttribute('tint') ?? '';
+    this.#tintVec = colorToVec3(tintAttr, [0.545, 0.361, 0.965]);
+    this.#evtVec = colorToVec3(tintAttr, [0.957, 0.247, 0.369]);
+    this.#darkVal = this.#darkUniform();
+  }
+
+  /** Re-resolve the cached color uniforms when the theme flips. `tint` is often
+   *  `var(--waffle)` and `--ink` is theme-dependent, so a light/dark toggle (a
+   *  class / `data-theme` change on <html>/<body>, or the OS color-scheme media
+   *  query) changes the resolved values WITHOUT firing attributeChangedCallback.
+   *  A running rAF loop picks the new cache up on its next frame; reduced-motion
+   *  mode repaints once via #renderIfStatic. */
+  #observeTheme(): void {
+    const refresh = (): void => {
+      this.#refreshColorUniforms();
+      this.#renderIfStatic();
+    };
+    if (typeof MutationObserver !== 'undefined') {
+      this.#themeObserver = new MutationObserver(refresh);
+      for (const node of [document.documentElement, document.body]) {
+        if (node)
+          this.#themeObserver.observe(node, {
+            attributes: true,
+            attributeFilter: ['class', 'data-theme'],
+          });
+      }
+    }
+    if (typeof matchMedia === 'function') {
+      this.#colorSchemeMq = matchMedia('(prefers-color-scheme: dark)');
+      this.#onColorSchemeChange = refresh;
+      this.#colorSchemeMq.addEventListener('change', this.#onColorSchemeChange);
+    }
   }
 
   #compile(gl: WebGLRenderingContext, type: number, src: string): WebGLShader | null {
@@ -577,9 +640,12 @@ export class SliccShader extends HTMLElement {
     const s2 = 0.5 + 0.5 * Math.sin(t * 0.097 + 1.0);
     const cx = 0.2 * (1 - s) + 0.46 * s;
     const cy = 0.74 * (1 - s2) + 0.3 * s2;
-    const dark = this.#darkUniform();
-    const tint = colorToVec3(this.getAttribute('tint') ?? '', [0.545, 0.361, 0.965]);
-    const evt = colorToVec3(this.getAttribute('tint') ?? '', [0.957, 0.247, 0.369]);
+    // Cached (resolved on connect / tint change / theme change) — never
+    // recomputed here: getComputedStyle + a document.body probe per frame was
+    // the flicker. See #refreshColorUniforms / #observeTheme.
+    const dark = this.#darkVal;
+    const tint = this.#tintVec;
+    const evt = this.#evtVec;
     gl.viewport(0, 0, cv.width, cv.height);
     gl.useProgram(prog);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.#buffer);

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -190,6 +190,45 @@ describe('slicc-shader program cache + immediate repaint (anti-flicker)', () => 
   });
 });
 
+describe('slicc-shader does not force a style recalc per frame (flicker fix)', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    document.body.replaceChildren();
+  });
+  afterEach(() => document.body.replaceChildren());
+
+  it('resolves CSS-derived uniforms once, not on every animation frame', async () => {
+    const el = mount({ mode: 'cone', tint: 'var(--waffle)' });
+    await frame();
+    await frame();
+    if (el.noWebgl) return; // no WebGL in this runner — the rAF render loop never runs
+
+    // Steady state: a running rAF loop must NOT query computed style. The
+    // shader resolves its tint/evt/--ink uniforms once (on connect + on a
+    // theme/tint change), so getComputedStyle should not be called while it
+    // merely animates. The bug called getComputedStyle 3x/frame (colorToVec3
+    // for tint + evt, plus #darkUniform reading --ink) and appended a probe
+    // <span> to document.body twice/frame — forcing a full-document style
+    // recalc on every frame, which is the flicker.
+    const gcs = vi.spyOn(window, 'getComputedStyle');
+    let probeAppends = 0;
+    const mo = new MutationObserver((records) => {
+      for (const r of records)
+        for (const n of r.addedNodes) if ((n as Element).tagName === 'SPAN') probeAppends++;
+    });
+    mo.observe(document.body, { childList: true });
+    try {
+      for (let i = 0; i < 6; i++) await frame();
+      expect(gcs).not.toHaveBeenCalled();
+      expect(probeAppends).toBe(0);
+    } finally {
+      mo.disconnect();
+      gcs.mockRestore();
+      el.remove();
+    }
+  });
+});
+
 /**
  * Compile a fragment program standalone and read back the rendered pixels —
  * the component's own context never preserves its drawing buffer, so color


### PR DESCRIPTION
## Problem — UI flicker

A captured DevTools Performance trace (21s, steady state) showed a sustained forced-reflow storm dominated by one function: `tick @ packages/webcomponents/src/freezer/slicc-shader.ts`. Fingerprint:

- `ScheduleStyleRecalculation` / `UpdateLayoutTree` / `Commit` ≈ **3 × the shader tick count** (~7,500 each over ~2,500 ticks)
- `Paint = 0` → pure **composited reflow thrash**, not painting
- ~120 ticks/sec (single shader on a 120 Hz ProMotion display) → **~360 style-recalcs + commits per second**, sustained — visible as flicker/jank.

## Root cause

`<slicc-shader>`'s `requestAnimationFrame` loop re-resolved its CSS-derived uniforms **every frame** inside `#renderFrame()`:

- `colorToVec3(tint…)` and `colorToVec3(evt…)` — each **appends a probe `<span>` to `document.body`** and calls `getComputedStyle` (2×/frame)
- `#darkUniform()` — `getComputedStyle(this).getPropertyValue('--ink')` (1×/frame)

That's ~3 forced full-document style recalcs + 2 `document.body` mutations per frame. A WebGL canvas animation should touch **zero** style/layout per frame.

## Fix

These values only change on a **theme or `tint` switch**, so resolve them once and cache:

- `#refreshColorUniforms()` resolves `tint` / `evt` / `dark` and caches them.
- Called on `connectedCallback`, on a `tint` attribute change, and on a **theme change** — a `MutationObserver` on `<html>`/`<body>` (`class` + `data-theme`) plus a `prefers-color-scheme` listener, torn down in `disconnectedCallback`.
- `#renderFrame()` now reads the cached uniforms — **zero `getComputedStyle` / DOM-probe per frame**. The GPU draw is unchanged.

## Verification

Real-browser measurement via direct Playwright (mounting the built component, mirroring the test's spy + `MutationObserver` logic over 6 steady-state frames):

| Build | `getComputedStyle` / 6 frames | `document.body` probe `<span>`s / 6 frames |
|---|---|---|
| old | **24** | **18** |
| this PR | **0** | **0** |

- Added regression test (`tests/freezer/slicc-shader.test.ts`) asserting `getComputedStyle` isn't called per frame; its discriminating power is confirmed by the table above (old → fails, fix → passes). Soft-skips if WebGL is unavailable, matching the existing shader tests.
- Local gates green: `lint`, full `typecheck`, webcomponents + webapp + chrome-extension builds.
- Note: vitest **browser-mode** could not be executed in my sandbox (its Chromium↔dev-server handshake hangs there); the browser test runs in CI / locally. The fix's behavior is verified by the Playwright measurement above.
- Theme/scoop/freezer switches still update the shader colors correctly (preserved by the `tint`-change + theme-observer cache invalidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)