### PR TITLE
feat: per-model cost breakdown overlay on floatbar hover

### DIFF
--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -197,7 +197,7 @@ export interface SessionStatsMsg {
   /** Per-scoop context-window fill, 0..1 (last assistant turn's usage). */
   fills: Array<{ jid: string; fill: number }>;
   /** Per-model cost breakdown, sorted by cost descending. */
-  models: Array<{ model: string; cost: number; turns: number }>;
+  models: Array<{ model: string; cost: number; turns: number; tokens: number }>;
   /** Per-scoop cost breakdown. */
   scoops: Array<{ name: string; model: string; cost: number; type: 'cone' | 'scoop' }>;
 }

--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -196,6 +196,10 @@ export interface SessionStatsMsg {
   totalCost: number;
   /** Per-scoop context-window fill, 0..1 (last assistant turn's usage). */
   fills: Array<{ jid: string; fill: number }>;
+  /** Per-model cost breakdown, sorted by cost descending. */
+  models: Array<{ model: string; cost: number; turns: number }>;
+  /** Per-scoop cost breakdown. */
+  scoops: Array<{ name: string; model: string; cost: number; type: 'cone' | 'scoop' }>;
 }
 
 export interface ClearChatMsg {

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -1188,7 +1188,7 @@ export class OffscreenBridge implements KernelFacade {
   private handleRequestSessionStats(requestId: string): void {
     let totalCost = 0;
     let fills: Array<{ jid: string; fill: number }> = [];
-    let models: Array<{ model: string; cost: number; turns: number }> = [];
+    let models: Array<{ model: string; cost: number; turns: number; tokens: number }> = [];
     let scoops: Array<{ name: string; model: string; cost: number; type: 'cone' | 'scoop' }> = [];
     try {
       const sessionCosts = this.orchestrator?.getSessionCosts() ?? [];
@@ -1198,6 +1198,7 @@ export class OffscreenBridge implements KernelFacade {
         model: m.model,
         cost: m.cost,
         turns: m.turns,
+        tokens: m.input + m.output + m.cacheRead + m.cacheWrite,
       }));
       scoops = sessionCosts.map((s) => ({
         name: s.name,

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -1188,16 +1188,27 @@ export class OffscreenBridge implements KernelFacade {
   private handleRequestSessionStats(requestId: string): void {
     let totalCost = 0;
     let fills: Array<{ jid: string; fill: number }> = [];
+    let models: Array<{ model: string; cost: number; turns: number }> = [];
+    let scoops: Array<{ name: string; model: string; cost: number; type: 'cone' | 'scoop' }> = [];
     try {
-      totalCost = (this.orchestrator?.getSessionCosts() ?? []).reduce(
-        (sum, scoop) => sum + scoop.usage.cost.total,
-        0
-      );
+      const sessionCosts = this.orchestrator?.getSessionCosts() ?? [];
+      totalCost = sessionCosts.reduce((sum, scoop) => sum + scoop.usage.cost.total, 0);
       fills = this.orchestrator?.getContextFills() ?? [];
+      models = (this.orchestrator?.getModelCosts() ?? []).map((m) => ({
+        model: m.model,
+        cost: m.cost,
+        turns: m.turns,
+      }));
+      scoops = sessionCosts.map((s) => ({
+        name: s.name,
+        model: s.model,
+        cost: s.usage.cost.total,
+        type: s.type,
+      }));
     } catch {
       // Stats are decorative — never fail the request loop over them.
     }
-    this.emit({ type: 'session-stats', requestId, totalCost, fills });
+    this.emit({ type: 'session-stats', requestId, totalCost, fills, models, scoops });
   }
 
   private async handleRequestScoopTranscript(requestId: string, scoopJid: string): Promise<void> {

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -926,6 +926,11 @@ export class Orchestrator implements ConeApprovalRouter {
     return this.costTracker.getSessionCosts();
   }
 
+  /** Per-model cost breakdown (sorted by cost descending) for the session-stats wire. */
+  getModelCosts(): ReturnType<ScoopCostTracker['getModelCosts']> {
+    return this.costTracker.getModelCosts();
+  }
+
   /**
    * Per-scoop context-window fill (0..1), from each scoop's last assistant
    * turn. Drives the chip pupils — they dilate as the context fills up.

--- a/packages/webapp/src/scoops/scoop-cost-tracker.ts
+++ b/packages/webapp/src/scoops/scoop-cost-tracker.ts
@@ -16,6 +16,16 @@ import type { ScoopCostData } from '../shell/supplemental-commands/cost-command.
 import type { ScoopContext } from './scoop-context.js';
 import type { RegisteredScoop } from './types.js';
 
+export interface ModelCostData {
+  model: string;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cost: number;
+  turns: number;
+}
+
 export interface ScoopCostTrackerDeps {
   /** Live registered scoops (cone + non-cone), keyed by jid. */
   getScoops(): ReadonlyMap<string, RegisteredScoop>;
@@ -94,6 +104,8 @@ export function buildScoopCost(
 export class ScoopCostTracker {
   /** Preserves cost data for scoops that have been dropped this session. */
   private dropped: ScoopCostData[] = [];
+  /** Preserves assistant messages for dropped scoops to enable per-model aggregation. */
+  private droppedMessages: AssistantMessage[][] = [];
   private readonly deps: ScoopCostTrackerDeps;
 
   constructor(deps: ScoopCostTrackerDeps) {
@@ -108,6 +120,11 @@ export class ScoopCostTracker {
     const costData = buildScoopCost(scoop, context);
     if (costData) {
       this.dropped.push(costData);
+    }
+    const messages = context.getAgentMessages();
+    const assistantMsgs = messages.filter((m): m is AssistantMessage => m.role === 'assistant');
+    if (assistantMsgs.length > 0) {
+      this.droppedMessages.push(assistantMsgs);
     }
   }
 
@@ -136,8 +153,61 @@ export class ScoopCostTracker {
     }));
   }
 
+  /**
+   * Aggregate token usage and cost across all live + dropped scoops, grouped by model name.
+   * Returns results sorted by cost descending.
+   */
+  getModelCosts(): ModelCostData[] {
+    const modelMap = new Map<string, ModelCostData>();
+
+    // Aggregate live scoops
+    const contexts = this.deps.getContexts();
+    for (const context of contexts.values()) {
+      const messages = context.getAgentMessages();
+      const assistantMsgs = messages.filter((m): m is AssistantMessage => m.role === 'assistant');
+      this.aggregateMessages(assistantMsgs, modelMap);
+    }
+
+    // Aggregate dropped scoops
+    for (const messages of this.droppedMessages) {
+      this.aggregateMessages(messages, modelMap);
+    }
+
+    // Convert to array and sort by cost descending
+    return Array.from(modelMap.values()).sort((a, b) => b.cost - a.cost);
+  }
+
+  /** Helper to aggregate messages into the model map. */
+  private aggregateMessages(
+    messages: AssistantMessage[],
+    modelMap: Map<string, ModelCostData>
+  ): void {
+    for (const msg of messages) {
+      const existing = modelMap.get(msg.model);
+      if (existing) {
+        existing.input += msg.usage.input;
+        existing.output += msg.usage.output;
+        existing.cacheRead += msg.usage.cacheRead;
+        existing.cacheWrite += msg.usage.cacheWrite;
+        existing.cost += msg.usage.cost.total;
+        existing.turns += 1;
+      } else {
+        modelMap.set(msg.model, {
+          model: msg.model,
+          input: msg.usage.input,
+          output: msg.usage.output,
+          cacheRead: msg.usage.cacheRead,
+          cacheWrite: msg.usage.cacheWrite,
+          cost: msg.usage.cost.total,
+          turns: 1,
+        });
+      }
+    }
+  }
+
   /** Drop all preserved cost data (e.g. on filesystem reset or clear-all). */
   reset(): void {
     this.dropped = [];
+    this.droppedMessages = [];
   }
 }

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -60,6 +60,10 @@ export interface SessionStats {
   totalCost: number;
   /** Per-scoop context-window fill, 0..1 (last assistant turn's usage). */
   fills: Array<{ jid: string; fill: number }>;
+  /** Per-model cost breakdown, sorted by cost descending. */
+  models: Array<{ model: string; cost: number; turns: number }>;
+  /** Per-scoop cost breakdown. */
+  scoops: Array<{ name: string; model: string; cost: number; type: 'cone' | 'scoop' }>;
 }
 
 export interface OffscreenClientCallbacks {
@@ -677,7 +681,12 @@ export class OffscreenClient implements KernelClientFacade {
         const resolve = this.pendingStatsRequests.get(m.requestId);
         if (resolve) {
           this.pendingStatsRequests.delete(m.requestId);
-          resolve({ totalCost: m.totalCost, fills: m.fills });
+          resolve({
+            totalCost: m.totalCost,
+            fills: m.fills,
+            models: m.models ?? [],
+            scoops: m.scoops ?? [],
+          });
         }
         break;
       }

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -61,7 +61,7 @@ export interface SessionStats {
   /** Per-scoop context-window fill, 0..1 (last assistant turn's usage). */
   fills: Array<{ jid: string; fill: number }>;
   /** Per-model cost breakdown, sorted by cost descending. */
-  models: Array<{ model: string; cost: number; turns: number }>;
+  models: Array<{ model: string; cost: number; turns: number; tokens: number }>;
   /** Per-scoop cost breakdown. */
   scoops: Array<{ name: string; model: string; cost: number; type: 'cone' | 'scoop' }>;
 }

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -979,6 +979,10 @@ function wireWcStats(wiring: WcLiveWiring, client: OffscreenClient): () => void 
     void client.getSessionStats?.().then((stats) => {
       if (!stats) return;
       wiring.refs.floatbar.setAttribute('spent', stats.totalCost.toFixed(2));
+      // Feed per-model and per-scoop breakdown to the floatbar overlay
+      const fb = wiring.refs.floatbar as any;
+      if (stats.models) fb.costModels = stats.models;
+      if (stats.scoops) fb.costScoops = stats.scoops;
       wiring.fills.clear();
       for (const f of stats.fills) wiring.fills.set(f.jid, f.fill);
       wiring.refs.switcher.scoops = toSwitcherScoops(

--- a/packages/webapp/tests/scoops/scoop-cost-tracker.test.ts
+++ b/packages/webapp/tests/scoops/scoop-cost-tracker.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { AssistantMessage } from '../../src/core/types.js';
+import type { ScoopContext } from '../../src/scoops/scoop-context.js';
+import { ScoopCostTracker } from '../../src/scoops/scoop-cost-tracker.js';
+import type { RegisteredScoop } from '../../src/scoops/types.js';
+
+describe('ScoopCostTracker.getModelCosts', () => {
+  function createMockScoop(jid: string, label: string, isCone = false): RegisteredScoop {
+    return {
+      jid,
+      assistantLabel: label,
+      isCone,
+      tab: { id: `tab-${jid}`, type: 'scoop' as const, label },
+    } as RegisteredScoop;
+  }
+
+  function createMockContext(messages: AssistantMessage[]): ScoopContext {
+    return {
+      getAgentMessages: () => messages,
+    } as ScoopContext;
+  }
+
+  function createAssistantMessage(
+    model: string,
+    input: number,
+    output: number,
+    cacheRead = 0,
+    cacheWrite = 0,
+    inputCost = 0,
+    outputCost = 0,
+    cacheReadCost = 0,
+    cacheWriteCost = 0,
+    timestamp = Date.now()
+  ): AssistantMessage {
+    const totalCost = inputCost + outputCost + cacheReadCost + cacheWriteCost;
+    return {
+      role: 'assistant',
+      model,
+      timestamp,
+      usage: {
+        input,
+        output,
+        cacheRead,
+        cacheWrite,
+        totalTokens: input + output + cacheRead + cacheWrite,
+        cost: {
+          input: inputCost,
+          output: outputCost,
+          cacheRead: cacheReadCost,
+          cacheWrite: cacheWriteCost,
+          total: totalCost,
+        },
+      },
+    } as AssistantMessage;
+  }
+
+  let tracker: ScoopCostTracker;
+  let scoopsMap: Map<string, RegisteredScoop>;
+  let contextsMap: Map<string, ScoopContext>;
+
+  beforeEach(() => {
+    scoopsMap = new Map();
+    contextsMap = new Map();
+    tracker = new ScoopCostTracker({
+      getScoops: () => scoopsMap,
+      getContexts: () => contextsMap,
+    });
+  });
+
+  it('aggregates costs by model across all live scoops', () => {
+    const scoop1 = createMockScoop('scoop1', 'Scoop 1');
+    const scoop2 = createMockScoop('scoop2', 'Scoop 2');
+
+    const messages1 = [
+      createAssistantMessage('claude-opus-4-6', 1000, 500, 0, 0, 0.01, 0.005),
+      createAssistantMessage('claude-opus-4-6', 2000, 1000, 0, 0, 0.02, 0.01),
+      createAssistantMessage('claude-sonnet-4-5', 500, 250, 0, 0, 0.002, 0.001),
+    ];
+
+    const messages2 = [
+      createAssistantMessage('claude-opus-4-6', 1500, 750, 0, 0, 0.015, 0.0075),
+      createAssistantMessage('claude-sonnet-4-5', 1000, 500, 0, 0, 0.004, 0.002),
+    ];
+
+    scoopsMap.set('scoop1', scoop1);
+    scoopsMap.set('scoop2', scoop2);
+    contextsMap.set('scoop1', createMockContext(messages1));
+    contextsMap.set('scoop2', createMockContext(messages2));
+
+    const result = tracker.getModelCosts();
+
+    expect(result).toHaveLength(2);
+
+    const opus = result.find((r) => r.model === 'claude-opus-4-6');
+    expect(opus).toBeDefined();
+    expect(opus!.input).toBe(4500); // 1000 + 2000 + 1500
+    expect(opus!.output).toBe(2250); // 500 + 1000 + 750
+    expect(opus!.cost).toBeCloseTo(0.0675, 4); // (0.01 + 0.005) + (0.02 + 0.01) + (0.015 + 0.0075)
+    expect(opus!.turns).toBe(3);
+
+    const sonnet = result.find((r) => r.model === 'claude-sonnet-4-5');
+    expect(sonnet).toBeDefined();
+    expect(sonnet!.input).toBe(1500); // 500 + 1000
+    expect(sonnet!.output).toBe(750); // 250 + 500
+    expect(sonnet!.cost).toBeCloseTo(0.009, 4); // 0.002 + 0.001 + 0.004 + 0.002
+    expect(sonnet!.turns).toBe(2);
+  });
+
+  it('includes dropped scoops in the model aggregation', () => {
+    const scoop1 = createMockScoop('scoop1', 'Live Scoop');
+    const scoop2 = createMockScoop('scoop2', 'Dropped Scoop');
+
+    const liveMessages = [createAssistantMessage('claude-opus-4-6', 1000, 500, 0, 0, 0.01, 0.005)];
+
+    const droppedMessages = [
+      createAssistantMessage('claude-opus-4-6', 2000, 1000, 0, 0, 0.02, 0.01),
+      createAssistantMessage('claude-sonnet-4-5', 500, 250, 0, 0, 0.002, 0.001),
+    ];
+
+    scoopsMap.set('scoop1', scoop1);
+    scoopsMap.set('scoop2', scoop2);
+    contextsMap.set('scoop1', createMockContext(liveMessages));
+    contextsMap.set('scoop2', createMockContext(droppedMessages));
+
+    // Snapshot scoop2 before removing it
+    tracker.snapshot('scoop2');
+    scoopsMap.delete('scoop2');
+    contextsMap.delete('scoop2');
+
+    const result = tracker.getModelCosts();
+
+    expect(result).toHaveLength(2);
+
+    const opus = result.find((r) => r.model === 'claude-opus-4-6');
+    expect(opus).toBeDefined();
+    expect(opus!.input).toBe(3000); // 1000 + 2000
+    expect(opus!.output).toBe(1500); // 500 + 1000
+    expect(opus!.cost).toBeCloseTo(0.045, 4); // 0.01 + 0.005 + 0.02 + 0.01
+
+    const sonnet = result.find((r) => r.model === 'claude-sonnet-4-5');
+    expect(sonnet).toBeDefined();
+    expect(sonnet!.input).toBe(500);
+    expect(sonnet!.output).toBe(250);
+    expect(sonnet!.cost).toBeCloseTo(0.003, 4);
+  });
+
+  it('sorts results by cost descending', () => {
+    const scoop1 = createMockScoop('scoop1', 'Scoop 1');
+
+    const messages = [
+      createAssistantMessage('model-cheap', 100, 50, 0, 0, 0.001, 0.0005),
+      createAssistantMessage('model-expensive', 1000, 500, 0, 0, 0.1, 0.05),
+      createAssistantMessage('model-medium', 500, 250, 0, 0, 0.01, 0.005),
+    ];
+
+    scoopsMap.set('scoop1', scoop1);
+    contextsMap.set('scoop1', createMockContext(messages));
+
+    const result = tracker.getModelCosts();
+
+    expect(result).toHaveLength(3);
+    expect(result[0].model).toBe('model-expensive');
+    expect(result[0].cost).toBeCloseTo(0.15, 4);
+    expect(result[1].model).toBe('model-medium');
+    expect(result[1].cost).toBeCloseTo(0.015, 4);
+    expect(result[2].model).toBe('model-cheap');
+    expect(result[2].cost).toBeCloseTo(0.0015, 4);
+  });
+
+  it('returns empty array when no usage exists', () => {
+    const scoop1 = createMockScoop('scoop1', 'Empty Scoop');
+    scoopsMap.set('scoop1', scoop1);
+    contextsMap.set('scoop1', createMockContext([]));
+
+    const result = tracker.getModelCosts();
+
+    expect(result).toEqual([]);
+  });
+
+  it('handles cache tokens correctly', () => {
+    const scoop1 = createMockScoop('scoop1', 'Cached Scoop');
+
+    const messages = [
+      createAssistantMessage('claude-opus-4-6', 1000, 500, 2000, 1000, 0.01, 0.005, 0.001, 0.002),
+    ];
+
+    scoopsMap.set('scoop1', scoop1);
+    contextsMap.set('scoop1', createMockContext(messages));
+
+    const result = tracker.getModelCosts();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].cacheRead).toBe(2000);
+    expect(result[0].cacheWrite).toBe(1000);
+    expect(result[0].cost).toBeCloseTo(0.018, 4); // 0.01 + 0.005 + 0.001 + 0.002
+  });
+
+  it('clears dropped messages on reset', () => {
+    const scoop1 = createMockScoop('scoop1', 'Dropped Scoop');
+    const messages = [createAssistantMessage('claude-opus-4-6', 1000, 500, 0, 0, 0.01, 0.005)];
+
+    scoopsMap.set('scoop1', scoop1);
+    contextsMap.set('scoop1', createMockContext(messages));
+
+    tracker.snapshot('scoop1');
+    scoopsMap.delete('scoop1');
+    contextsMap.delete('scoop1');
+
+    // Should have one model from dropped scoop
+    expect(tracker.getModelCosts()).toHaveLength(1);
+
+    tracker.reset();
+
+    // After reset, should be empty
+    expect(tracker.getModelCosts()).toEqual([]);
+  });
+});

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -97,6 +97,11 @@ export { SliccTooltip } from './overlay/slicc-tooltip.js';
 export { SliccPill } from './pill/slicc-pill.js';
 export { SliccAvatar } from './primitives/slicc-avatar.js';
 export { SliccCollapseBtn } from './primitives/slicc-collapse-btn.js';
+export {
+  type CostOverlayModel,
+  type CostOverlayScoop,
+  SliccCostOverlay,
+} from './primitives/slicc-cost-overlay.js';
 export { SliccDaySeparator } from './primitives/slicc-day-separator.js';
 export { SliccFloatbar } from './primitives/slicc-floatbar.js';
 export { SliccGooglyEyes } from './primitives/slicc-googly-eyes.js';

--- a/packages/webcomponents/src/primitives/slicc-cost-overlay.stories.ts
+++ b/packages/webcomponents/src/primitives/slicc-cost-overlay.stories.ts
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import './slicc-floatbar.js';
+import './slicc-cost-overlay.js';
+import type { SliccFloatbar } from './slicc-floatbar.js';
+
+const meta: Meta = {
+  title: 'Primitives/CostOverlay',
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+/** Standalone overlay card (always open) showing typical session data. */
+export const Standalone: Story = {
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.position = 'relative';
+    wrapper.style.display = 'inline-block';
+    wrapper.style.marginTop = '16px';
+    wrapper.style.marginLeft = '100px';
+
+    const el = document.createElement('slicc-cost-overlay');
+    el.models = [
+      { model: 'claude-opus-4-6', cost: 3.5, turns: 8, tokens: 1_200_000 },
+      { model: 'claude-sonnet-4-6', cost: 0.44, turns: 3, tokens: 85_000 },
+      { model: 'claude-haiku-4-5', cost: 0.02, turns: 1, tokens: 4_500 },
+    ];
+    el.scoops = [
+      { name: 'sliccy', model: 'claude-opus-4-6', cost: 2.8, type: 'cone' },
+      { name: 'researcher', model: 'claude-sonnet-4-6', cost: 0.94, type: 'scoop' },
+      { name: 'code-review', model: 'claude-sonnet-4-6', cost: 0.2, type: 'scoop' },
+      { name: 'quick-lookup', model: 'claude-haiku-4-5', cost: 0.02, type: 'scoop' },
+    ];
+    el.open = true;
+    wrapper.appendChild(el);
+    return wrapper;
+  },
+};
+
+/** Floatbar with cost overlay — hover the $ amount to see the overlay. */
+export const FloatbarWithOverlay: Story = {
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.display = 'flex';
+    wrapper.style.justifyContent = 'flex-end';
+    wrapper.style.padding = '16px 24px';
+
+    const fb = document.createElement('slicc-floatbar') as SliccFloatbar;
+    fb.label = 'npx · live';
+    fb.online = true;
+    fb.spent = '3.96';
+    fb.costModels = [
+      { model: 'claude-opus-4-6', cost: 3.5, turns: 8, tokens: 1_200_000 },
+      { model: 'claude-sonnet-4-6', cost: 0.44, turns: 3, tokens: 85_000 },
+      { model: 'claude-haiku-4-5', cost: 0.02, turns: 1, tokens: 4_500 },
+    ];
+    fb.costScoops = [
+      { name: 'sliccy', model: 'claude-opus-4-6', cost: 2.8, type: 'cone' },
+      { name: 'researcher', model: 'claude-sonnet-4-6', cost: 0.94, type: 'scoop' },
+      { name: 'code-review', model: 'claude-sonnet-4-6', cost: 0.2, type: 'scoop' },
+      { name: 'quick-lookup', model: 'claude-haiku-4-5', cost: 0.02, type: 'scoop' },
+    ];
+    wrapper.appendChild(fb);
+    return wrapper;
+  },
+};
+
+/** Overlay with only models (no scoops section). */
+export const ModelsOnly: Story = {
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.position = 'relative';
+    wrapper.style.display = 'inline-block';
+    wrapper.style.marginTop = '16px';
+    wrapper.style.marginLeft = '100px';
+
+    const el = document.createElement('slicc-cost-overlay');
+    el.models = [{ model: 'claude-opus-4-6', cost: 1.23, turns: 4, tokens: 450_000 }];
+    el.scoops = [];
+    el.open = true;
+    wrapper.appendChild(el);
+    return wrapper;
+  },
+};
+
+/** Large session with many models and agents. */
+export const LargeSession: Story = {
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.position = 'relative';
+    wrapper.style.display = 'inline-block';
+    wrapper.style.marginTop = '16px';
+    wrapper.style.marginLeft = '100px';
+
+    const el = document.createElement('slicc-cost-overlay');
+    el.models = [
+      { model: 'claude-opus-4-6', cost: 12.45, turns: 30, tokens: 4_200_000 },
+      { model: 'claude-sonnet-4-6', cost: 3.21, turns: 15, tokens: 1_800_000 },
+      { model: 'claude-haiku-4-5', cost: 0.18, turns: 8, tokens: 120_000 },
+    ];
+    el.scoops = [
+      { name: 'sliccy', model: 'claude-opus-4-6', cost: 8.5, type: 'cone' },
+      { name: 'architect', model: 'claude-opus-4-6', cost: 3.95, type: 'scoop' },
+      { name: 'implementer-1', model: 'claude-sonnet-4-6', cost: 1.8, type: 'scoop' },
+      { name: 'implementer-2', model: 'claude-sonnet-4-6', cost: 1.41, type: 'scoop' },
+      { name: 'reviewer', model: 'claude-haiku-4-5', cost: 0.18, type: 'scoop' },
+    ];
+    el.open = true;
+    wrapper.appendChild(el);
+    return wrapper;
+  },
+};

--- a/packages/webcomponents/src/primitives/slicc-cost-overlay.ts
+++ b/packages/webcomponents/src/primitives/slicc-cost-overlay.ts
@@ -1,0 +1,273 @@
+import { define } from '../internal/define.js';
+import { h, sheet } from '../internal/dom.js';
+
+export interface CostOverlayModel {
+  model: string;
+  cost: number;
+  turns: number;
+}
+
+export interface CostOverlayScoop {
+  name: string;
+  model: string;
+  cost: number;
+  type: 'cone' | 'scoop';
+}
+
+/**
+ * Strip the `claude-` prefix from model names for brevity.
+ * E.g., `claude-opus-4-6` → `opus-4-6`,
+ * `claude-sonnet-4-20250514` → `sonnet-4-20250514`.
+ */
+function shortModel(model: string): string {
+  return model.replace('claude-', '');
+}
+
+const STYLE = `
+:host {
+  display: block;
+}
+
+.card {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 100;
+
+  display: none;
+  flex-direction: column;
+  gap: 0;
+
+  min-width: 220px;
+  max-width: 320px;
+
+  background: var(--canvas);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+  font-family: var(--ui);
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--ink);
+
+  overflow: hidden;
+}
+
+:host([open]) .card {
+  display: flex;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.section:last-child {
+  border-bottom: none;
+}
+
+.section-title {
+  font-size: 9px;
+  text-transform: uppercase;
+  color: var(--txt-2);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.model-row,
+.scoop-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+}
+
+.model-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+}
+
+.model-name {
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.model-turns {
+  font-variant-numeric: tabular-nums;
+  color: var(--txt-2);
+  text-align: right;
+  min-width: 2ch;
+}
+
+.model-cost,
+.scoop-cost {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  color: var(--ink);
+  text-align: right;
+  min-width: 5ch;
+}
+
+.scoop-name {
+  flex: 1;
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.total-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px;
+  font-weight: 600;
+  font-size: 13px;
+  border-top: 1px solid var(--line);
+}
+
+.total-label {
+  color: var(--ink);
+}
+
+.total-cost {
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+`;
+const SHEET = sheet(STYLE);
+
+/**
+ * `<slicc-cost-overlay>` — a floating card that renders per-model and per-scoop
+ * cost breakdown. Anchored absolute below its parent (typically the floatbar's
+ * `.spent` segment). Shows/hides via the `open` boolean attribute.
+ *
+ * @attr open - boolean; shows the card when present, hides when absent
+ * @property models - array of {@link CostOverlayModel} — per-model costs
+ * @property scoops - array of {@link CostOverlayScoop} — per-scoop costs
+ * @property open - boolean; reflects to/from the `open` attribute
+ */
+export class SliccCostOverlay extends HTMLElement {
+  static readonly observedAttributes = ['open'];
+
+  readonly #root: ShadowRoot;
+  #models: CostOverlayModel[] = [];
+  #scoops: CostOverlayScoop[] = [];
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.adoptedStyleSheets = [SHEET];
+  }
+
+  connectedCallback(): void {
+    this.#render();
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this.#render();
+  }
+
+  /** Whether the overlay card is visible. */
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
+
+  set open(value: boolean) {
+    this.toggleAttribute('open', !!value);
+  }
+
+  /** Per-model cost breakdown. */
+  get models(): CostOverlayModel[] {
+    return this.#models;
+  }
+
+  set models(value: CostOverlayModel[]) {
+    this.#models = value;
+    if (this.isConnected) this.#render();
+  }
+
+  /** Per-scoop cost breakdown. */
+  get scoops(): CostOverlayScoop[] {
+    return this.#scoops;
+  }
+
+  set scoops(value: CostOverlayScoop[]) {
+    this.#scoops = value;
+    if (this.isConnected) this.#render();
+  }
+
+  #render(): void {
+    const sections: Node[] = [];
+
+    // BY MODEL section
+    if (this.#models.length > 0) {
+      const modelRows = this.#models.map((m) =>
+        h(
+          'div',
+          { class: 'model-row' },
+          h('span', { class: 'model-name' }, shortModel(m.model)),
+          h('span', { class: 'model-turns' }, String(m.turns)),
+          h('span', { class: 'model-cost' }, `$${m.cost.toFixed(2)}`)
+        )
+      );
+
+      sections.push(
+        h(
+          'div',
+          { class: 'section section--models' },
+          h('div', { class: 'section-title' }, 'BY MODEL'),
+          ...modelRows
+        )
+      );
+    }
+
+    // BY AGENT section
+    if (this.#scoops.length > 0) {
+      const scoopRows = this.#scoops.map((s) =>
+        h(
+          'div',
+          { class: 'scoop-row' },
+          h('span', { class: 'scoop-name' }, s.name),
+          h('span', { class: 'scoop-cost' }, `$${s.cost.toFixed(2)}`)
+        )
+      );
+
+      sections.push(
+        h(
+          'div',
+          { class: 'section section--scoops' },
+          h('div', { class: 'section-title' }, 'BY AGENT'),
+          ...scoopRows
+        )
+      );
+    }
+
+    // Total row
+    const total = this.#models.reduce((sum, m) => sum + m.cost, 0);
+    sections.push(
+      h(
+        'div',
+        { class: 'total-row' },
+        h('span', { class: 'total-label' }, 'Total'),
+        h('span', { class: 'total-cost' }, `$${total.toFixed(2)}`)
+      )
+    );
+
+    const card = h('div', { class: 'card' }, ...sections);
+    this.#root.replaceChildren(card);
+  }
+}
+
+define('slicc-cost-overlay', SliccCostOverlay);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'slicc-cost-overlay': SliccCostOverlay;
+  }
+}

--- a/packages/webcomponents/src/primitives/slicc-cost-overlay.ts
+++ b/packages/webcomponents/src/primitives/slicc-cost-overlay.ts
@@ -5,6 +5,8 @@ export interface CostOverlayModel {
   model: string;
   cost: number;
   turns: number;
+  /** Total tokens (input + output + cache). Displayed as K/M shorthand. */
+  tokens?: number;
 }
 
 export interface CostOverlayScoop {
@@ -14,13 +16,15 @@ export interface CostOverlayScoop {
   type: 'cone' | 'scoop';
 }
 
-/**
- * Strip the `claude-` prefix from model names for brevity.
- * E.g., `claude-opus-4-6` → `opus-4-6`,
- * `claude-sonnet-4-20250514` → `sonnet-4-20250514`.
- */
 function shortModel(model: string): string {
   return model.replace('claude-', '');
+}
+
+function fmtTokens(n: number | undefined): string {
+  if (n == null || n === 0) return '';
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return String(n);
 }
 
 const STYLE = `
@@ -89,21 +93,21 @@ const STYLE = `
 }
 
 .model-row {
-  display: grid;
-  grid-template-columns: 1fr auto auto;
+  display: flex;
   gap: 8px;
 }
 
 .model-name {
+  flex: 1;
   font-weight: 500;
   color: var(--ink);
 }
 
-.model-turns {
+.model-tokens {
   font-variant-numeric: tabular-nums;
   color: var(--txt-2);
   text-align: right;
-  min-width: 2ch;
+  font-size: 11px;
 }
 
 .model-cost,
@@ -207,15 +211,16 @@ export class SliccCostOverlay extends HTMLElement {
 
     // BY MODEL section
     if (this.#models.length > 0) {
-      const modelRows = this.#models.map((m) =>
-        h(
+      const modelRows = this.#models.map((m) => {
+        const tok = fmtTokens(m.tokens);
+        return h(
           'div',
           { class: 'model-row' },
           h('span', { class: 'model-name' }, shortModel(m.model)),
-          h('span', { class: 'model-turns' }, String(m.turns)),
+          tok ? h('span', { class: 'model-tokens' }, tok) : false,
           h('span', { class: 'model-cost' }, `$${m.cost.toFixed(2)}`)
-        )
-      );
+        );
+      });
 
       sections.push(
         h(

--- a/packages/webcomponents/src/primitives/slicc-cost-overlay.ts
+++ b/packages/webcomponents/src/primitives/slicc-cost-overlay.ts
@@ -29,32 +29,28 @@ function fmtTokens(n: number | undefined): string {
 
 const STYLE = `
 :host {
-  display: block;
-}
-
-.card {
   position: absolute;
   top: calc(100% + 8px);
   right: 0;
   z-index: 100;
+  display: block;
+  pointer-events: none;
+}
+:host([open]) { pointer-events: auto; }
 
+.card {
   display: none;
   flex-direction: column;
-  gap: 0;
-
   min-width: 220px;
   max-width: 320px;
-
   background: var(--canvas);
   border: 1px solid var(--line);
   border-radius: 10px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-
   font-family: var(--ui);
   font-size: 12px;
   line-height: 1.4;
   color: var(--ink);
-
   overflow: hidden;
 }
 

--- a/packages/webcomponents/src/primitives/slicc-floatbar.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.ts
@@ -294,6 +294,7 @@ export class SliccFloatbar extends HTMLElement {
 
     nodes.push(h('span', { class: 'tip', part: 'tip', 'aria-hidden': 'true' }, this.#tipText()));
 
+    this.#overlay = null;
     this.#root.replaceChildren(...nodes);
     this.#syncTitle();
   }

--- a/packages/webcomponents/src/primitives/slicc-floatbar.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.ts
@@ -1,6 +1,8 @@
 import { define } from '../internal/define.js';
 import { h, sheet } from '../internal/dom.js';
 import { iconEl } from '../internal/icons.js';
+import type { CostOverlayModel, CostOverlayScoop } from './slicc-cost-overlay.js';
+import './slicc-cost-overlay.js';
 
 const DEFAULT_LABEL = 'CLI float';
 
@@ -161,6 +163,10 @@ export class SliccFloatbar extends HTMLElement {
   readonly #onNarrowChange = (): void => {
     if (this.isConnected) this.#syncTitle();
   };
+  #overlay: HTMLElement | null = null;
+  #costModels: CostOverlayModel[] = [];
+  #costScoops: CostOverlayScoop[] = [];
+  #hideTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor() {
     super();
@@ -179,6 +185,7 @@ export class SliccFloatbar extends HTMLElement {
 
   disconnectedCallback(): void {
     this.#narrow?.removeEventListener('change', this.#onNarrowChange);
+    clearTimeout(this.#hideTimer);
   }
 
   attributeChangedCallback(): void {
@@ -223,6 +230,24 @@ export class SliccFloatbar extends HTMLElement {
     else this.setAttribute('spent', String(value));
   }
 
+  get costModels(): CostOverlayModel[] {
+    return this.#costModels;
+  }
+
+  set costModels(value: CostOverlayModel[]) {
+    this.#costModels = value;
+    if (this.#overlay) (this.#overlay as any).models = value;
+  }
+
+  get costScoops(): CostOverlayScoop[] {
+    return this.#costScoops;
+  }
+
+  set costScoops(value: CostOverlayScoop[]) {
+    this.#costScoops = value;
+    if (this.#overlay) (this.#overlay as any).scoops = value;
+  }
+
   /**
    * The tooltip text for the narrow square badge — the label, the formatted
    * spend (when present), and the connection state, joined with the same ` · `
@@ -256,20 +281,41 @@ export class SliccFloatbar extends HTMLElement {
     const amount = formatSpent(this.spent);
     if (amount != null) {
       nodes.push(h('span', { class: 'sep', part: 'sep' }));
-      nodes.push(
-        h(
-          'span',
-          { class: 'spent', part: 'spent' },
-          iconEl('circle-dollar-sign', { size: 12 }),
-          h('span', { class: 'amount' }, amount)
-        )
+      const spentEl = h(
+        'span',
+        { class: 'spent', part: 'spent' },
+        iconEl('circle-dollar-sign', { size: 12 }),
+        h('span', { class: 'amount' }, amount)
       );
+      spentEl.addEventListener('mouseenter', () => this.#showOverlay());
+      spentEl.addEventListener('mouseleave', () => this.#scheduleHide());
+      nodes.push(spentEl);
     }
 
     nodes.push(h('span', { class: 'tip', part: 'tip', 'aria-hidden': 'true' }, this.#tipText()));
 
     this.#root.replaceChildren(...nodes);
     this.#syncTitle();
+  }
+
+  #showOverlay(): void {
+    clearTimeout(this.#hideTimer);
+    if (!this.#overlay) {
+      const overlay = document.createElement('slicc-cost-overlay');
+      (overlay as any).models = this.#costModels;
+      (overlay as any).scoops = this.#costScoops;
+      overlay.addEventListener('mouseenter', () => this.#showOverlay());
+      overlay.addEventListener('mouseleave', () => this.#scheduleHide());
+      this.#root.appendChild(overlay);
+      this.#overlay = overlay;
+    }
+    this.#overlay.toggleAttribute('open', true);
+  }
+
+  #scheduleHide(): void {
+    this.#hideTimer = setTimeout(() => {
+      if (this.#overlay) this.#overlay.removeAttribute('open');
+    }, 150);
   }
 }
 

--- a/packages/webcomponents/src/primitives/slicc-floatbar.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.ts
@@ -188,7 +188,8 @@ export class SliccFloatbar extends HTMLElement {
     clearTimeout(this.#hideTimer);
   }
 
-  attributeChangedCallback(): void {
+  attributeChangedCallback(_name: string, oldValue: string | null, newValue: string | null): void {
+    if (oldValue === newValue) return;
     if (this.isConnected) this.#render();
   }
 

--- a/packages/webcomponents/src/register.ts
+++ b/packages/webcomponents/src/register.ts
@@ -40,6 +40,7 @@ import './overlay/slicc-tooltip.js';
 import './pill/slicc-pill.js';
 import './primitives/slicc-avatar.js';
 import './primitives/slicc-collapse-btn.js';
+import './primitives/slicc-cost-overlay.js';
 import './primitives/slicc-day-separator.js';
 import './primitives/slicc-floatbar.js';
 import './primitives/slicc-googly-eyes.js';

--- a/packages/webcomponents/tests/primitives/slicc-cost-overlay.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-cost-overlay.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  type CostOverlayModel,
+  type CostOverlayScoop,
+  SliccCostOverlay,
+} from '../../src/primitives/slicc-cost-overlay.js';
+import { ensureGlobalTokens } from '../../src/theme/tokens.js';
+
+describe('slicc-cost-overlay', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    document.body.replaceChildren();
+  });
+
+  it('registers the custom element', () => {
+    expect(customElements.get('slicc-cost-overlay')).toBe(SliccCostOverlay);
+  });
+
+  describe('visibility', () => {
+    it('card is hidden (display:none) when open attribute is absent', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      document.body.appendChild(el);
+      const card = el.shadowRoot?.querySelector('.card') as HTMLElement;
+      expect(card).not.toBeNull();
+      expect(getComputedStyle(card).display).toBe('none');
+    });
+
+    it('card is visible when open is set', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      el.open = true;
+      document.body.appendChild(el);
+      const card = el.shadowRoot?.querySelector('.card') as HTMLElement;
+      expect(card).not.toBeNull();
+      expect(getComputedStyle(card).display).toBe('flex');
+    });
+
+    it('open property reflects to/from attribute', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      document.body.appendChild(el);
+
+      expect(el.open).toBe(false);
+      expect(el.hasAttribute('open')).toBe(false);
+
+      el.open = true;
+      expect(el.hasAttribute('open')).toBe(true);
+
+      el.setAttribute('open', '');
+      expect(el.open).toBe(true);
+
+      el.removeAttribute('open');
+      expect(el.open).toBe(false);
+    });
+  });
+
+  describe('per-model rows', () => {
+    it('renders model rows from the models property', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      const models: CostOverlayModel[] = [
+        { model: 'claude-opus-4-6', cost: 3.5, turns: 8 },
+        { model: 'claude-sonnet-4-6', cost: 0.44, turns: 3 },
+        { model: 'claude-haiku-4-5', cost: 0.02, turns: 1 },
+      ];
+      el.models = models;
+      el.open = true;
+      document.body.appendChild(el);
+
+      const modelSection = el.shadowRoot?.querySelector('.section--models');
+      expect(modelSection).not.toBeNull();
+
+      const rows = modelSection?.querySelectorAll('.model-row');
+      expect(rows?.length).toBe(3);
+
+      // Check first model row content
+      const firstRow = rows?.[0];
+      expect(firstRow?.textContent).toContain('opus-4-6');
+      expect(firstRow?.textContent).toContain('8');
+      expect(firstRow?.textContent).toContain('$3.50');
+    });
+
+    it('strips claude- prefix and trailing date from model names', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      el.models = [
+        { model: 'claude-opus-4-20250514', cost: 1.0, turns: 2 },
+        { model: 'claude-sonnet-4-6', cost: 0.5, turns: 1 },
+      ];
+      el.open = true;
+      document.body.appendChild(el);
+
+      const rows = el.shadowRoot?.querySelectorAll('.model-row');
+      expect(rows?.[0]?.textContent).toContain('opus-4-20250514');
+      expect(rows?.[1]?.textContent).toContain('sonnet-4-6');
+    });
+
+    it('handles empty models array', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      el.models = [];
+      el.open = true;
+      document.body.appendChild(el);
+
+      const rows = el.shadowRoot?.querySelectorAll('.model-row');
+      expect(rows?.length).toBe(0);
+    });
+  });
+
+  describe('per-scoop rows', () => {
+    it('renders scoop rows from the scoops property', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      const scoops: CostOverlayScoop[] = [
+        { name: 'sliccy', model: 'opus-4-6', cost: 2.8, type: 'cone' },
+        { name: 'researcher', model: 'sonnet-4-6', cost: 0.94, type: 'scoop' },
+        { name: 'code-review', model: 'sonnet-4-6', cost: 0.2, type: 'scoop' },
+        { name: 'quick-lookup', model: 'haiku-4-5', cost: 0.02, type: 'scoop' },
+      ];
+      el.scoops = scoops;
+      el.open = true;
+      document.body.appendChild(el);
+
+      const scoopSection = el.shadowRoot?.querySelector('.section--scoops');
+      expect(scoopSection).not.toBeNull();
+
+      const rows = scoopSection?.querySelectorAll('.scoop-row');
+      expect(rows?.length).toBe(4);
+
+      // Check first scoop row content
+      const firstRow = rows?.[0];
+      expect(firstRow?.textContent).toContain('sliccy');
+      expect(firstRow?.textContent).toContain('$2.80');
+    });
+
+    it('handles empty scoops array', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      el.scoops = [];
+      el.open = true;
+      document.body.appendChild(el);
+
+      const rows = el.shadowRoot?.querySelectorAll('.scoop-row');
+      expect(rows?.length).toBe(0);
+    });
+  });
+
+  describe('total row', () => {
+    it('renders a total row summing model costs', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      el.models = [
+        { model: 'opus-4-6', cost: 3.5, turns: 8 },
+        { model: 'sonnet-4-6', cost: 0.44, turns: 3 },
+        { model: 'haiku-4-5', cost: 0.02, turns: 1 },
+      ];
+      el.open = true;
+      document.body.appendChild(el);
+
+      const totalRow = el.shadowRoot?.querySelector('.total-row');
+      expect(totalRow).not.toBeNull();
+      expect(totalRow?.textContent).toContain('Total');
+      expect(totalRow?.textContent).toContain('$3.96');
+    });
+
+    it('displays $0.00 when models array is empty', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      el.models = [];
+      el.open = true;
+      document.body.appendChild(el);
+
+      const totalRow = el.shadowRoot?.querySelector('.total-row');
+      expect(totalRow?.textContent).toContain('$0.00');
+    });
+  });
+
+  describe('complete UI structure', () => {
+    it('renders all three sections with headers when data is provided', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      el.models = [{ model: 'opus-4-6', cost: 2.0, turns: 5 }];
+      el.scoops = [{ name: 'sliccy', model: 'opus-4-6', cost: 2.0, type: 'cone' }];
+      el.open = true;
+      document.body.appendChild(el);
+
+      const modelHeader = el.shadowRoot?.querySelector('.section-title');
+      expect(modelHeader?.textContent).toContain('BY MODEL');
+
+      const scoopHeader = Array.from(el.shadowRoot?.querySelectorAll('.section-title') || []).find(
+        (h) => h.textContent?.includes('BY AGENT')
+      );
+      expect(scoopHeader).toBeDefined();
+      expect(scoopHeader?.textContent).toContain('BY AGENT');
+
+      const totalRow = el.shadowRoot?.querySelector('.total-row');
+      expect(totalRow).not.toBeNull();
+    });
+  });
+
+  describe('positioning', () => {
+    it('is absolutely positioned below its parent', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      document.body.appendChild(el);
+
+      const card = el.shadowRoot?.querySelector('.card') as HTMLElement;
+      const cs = getComputedStyle(card);
+      expect(cs.position).toBe('absolute');
+      expect(cs.top).toBe('calc(100% + 8px)');
+      expect(cs.right).toBe('0px');
+    });
+
+    it('has a high z-index to float above content', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      document.body.appendChild(el);
+
+      const card = el.shadowRoot?.querySelector('.card') as HTMLElement;
+      expect(getComputedStyle(card).zIndex).toBe('100');
+    });
+  });
+});

--- a/packages/webcomponents/tests/primitives/slicc-cost-overlay.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-cost-overlay.test.ts
@@ -208,23 +208,13 @@ describe('slicc-cost-overlay', () => {
   });
 
   describe('positioning', () => {
-    it('is absolutely positioned below its parent', () => {
+    it('host is absolutely positioned below its parent', () => {
       const el = document.createElement('slicc-cost-overlay');
       document.body.appendChild(el);
 
-      const card = el.shadowRoot?.querySelector('.card') as HTMLElement;
-      const cs = getComputedStyle(card);
+      const cs = getComputedStyle(el);
       expect(cs.position).toBe('absolute');
-      expect(cs.top).toBe('calc(100% + 8px)');
-      expect(cs.right).toBe('0px');
-    });
-
-    it('has a high z-index to float above content', () => {
-      const el = document.createElement('slicc-cost-overlay');
-      document.body.appendChild(el);
-
-      const card = el.shadowRoot?.querySelector('.card') as HTMLElement;
-      expect(getComputedStyle(card).zIndex).toBe('100');
+      expect(cs.zIndex).toBe('100');
     });
   });
 });

--- a/packages/webcomponents/tests/primitives/slicc-cost-overlay.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-cost-overlay.test.ts
@@ -56,9 +56,9 @@ describe('slicc-cost-overlay', () => {
     it('renders model rows from the models property', () => {
       const el = document.createElement('slicc-cost-overlay');
       const models: CostOverlayModel[] = [
-        { model: 'claude-opus-4-6', cost: 3.5, turns: 8 },
-        { model: 'claude-sonnet-4-6', cost: 0.44, turns: 3 },
-        { model: 'claude-haiku-4-5', cost: 0.02, turns: 1 },
+        { model: 'claude-opus-4-6', cost: 3.5, turns: 8, tokens: 150_000 },
+        { model: 'claude-sonnet-4-6', cost: 0.44, turns: 3, tokens: 45_000 },
+        { model: 'claude-haiku-4-5', cost: 0.02, turns: 1, tokens: 2_000 },
       ];
       el.models = models;
       el.open = true;
@@ -70,18 +70,37 @@ describe('slicc-cost-overlay', () => {
       const rows = modelSection?.querySelectorAll('.model-row');
       expect(rows?.length).toBe(3);
 
-      // Check first model row content
       const firstRow = rows?.[0];
       expect(firstRow?.textContent).toContain('opus-4-6');
-      expect(firstRow?.textContent).toContain('8');
+      expect(firstRow?.textContent).toContain('150K');
       expect(firstRow?.textContent).toContain('$3.50');
     });
 
-    it('strips claude- prefix and trailing date from model names', () => {
+    it('formats tokens as M for millions', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      el.models = [{ model: 'claude-opus-4-6', cost: 5.0, turns: 20, tokens: 2_500_000 }];
+      el.open = true;
+      document.body.appendChild(el);
+
+      const row = el.shadowRoot?.querySelector('.model-row');
+      expect(row?.textContent).toContain('2.5M');
+    });
+
+    it('omits token display when tokens is 0 or undefined', () => {
+      const el = document.createElement('slicc-cost-overlay');
+      el.models = [{ model: 'claude-opus-4-6', cost: 1.0, turns: 2 }];
+      el.open = true;
+      document.body.appendChild(el);
+
+      const tokenEl = el.shadowRoot?.querySelector('.model-tokens');
+      expect(tokenEl).toBeNull();
+    });
+
+    it('strips claude- prefix from model names', () => {
       const el = document.createElement('slicc-cost-overlay');
       el.models = [
-        { model: 'claude-opus-4-20250514', cost: 1.0, turns: 2 },
-        { model: 'claude-sonnet-4-6', cost: 0.5, turns: 1 },
+        { model: 'claude-opus-4-20250514', cost: 1.0, turns: 2, tokens: 50_000 },
+        { model: 'claude-sonnet-4-6', cost: 0.5, turns: 1, tokens: 20_000 },
       ];
       el.open = true;
       document.body.appendChild(el);

--- a/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
@@ -377,4 +377,88 @@ describe('slicc-floatbar', () => {
       }
     });
   });
+
+  describe('cost overlay integration', () => {
+    it('exposes costModels and costScoops properties', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+
+      expect(el.costModels).toEqual([]);
+      expect(el.costScoops).toEqual([]);
+
+      const models = [{ model: 'claude-opus-4-6', cost: 1.5, turns: 3, tokens: 50000 }];
+      const scoops = [{ name: 'sliccy', model: 'opus-4-6', cost: 1.5, type: 'cone' as const }];
+      el.costModels = models;
+      el.costScoops = scoops;
+      expect(el.costModels).toBe(models);
+      expect(el.costScoops).toBe(scoops);
+    });
+
+    it('creates and shows overlay on mouseenter of the spent segment', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      el.spent = '2.41';
+      el.costModels = [{ model: 'claude-opus-4-6', cost: 2.41, turns: 5, tokens: 100000 }];
+      document.body.appendChild(el);
+
+      const spent = el.shadowRoot?.querySelector('.spent') as HTMLElement;
+      expect(spent).not.toBeNull();
+
+      spent.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+
+      const overlay = el.shadowRoot?.querySelector('slicc-cost-overlay');
+      expect(overlay).not.toBeNull();
+      expect(overlay?.hasAttribute('open')).toBe(true);
+    });
+
+    it('hides overlay on mouseleave after delay', async () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      el.spent = '2.41';
+      el.costModels = [{ model: 'claude-opus-4-6', cost: 2.41, turns: 5, tokens: 100000 }];
+      document.body.appendChild(el);
+
+      const spent = el.shadowRoot?.querySelector('.spent') as HTMLElement;
+      spent.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      spent.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      const overlay = el.shadowRoot?.querySelector('slicc-cost-overlay');
+      expect(overlay?.hasAttribute('open')).toBe(false);
+    });
+
+    it('does not re-render when attribute value is unchanged', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      el.spent = '2.41';
+      el.costModels = [{ model: 'claude-opus-4-6', cost: 2.41, turns: 5, tokens: 100000 }];
+      document.body.appendChild(el);
+
+      // Show overlay
+      const spent = el.shadowRoot?.querySelector('.spent') as HTMLElement;
+      spent.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      const overlay = el.shadowRoot?.querySelector('slicc-cost-overlay');
+      expect(overlay?.hasAttribute('open')).toBe(true);
+
+      // Set same value — should NOT re-render and destroy overlay
+      el.setAttribute('spent', '2.41');
+      const overlayAfter = el.shadowRoot?.querySelector('slicc-cost-overlay');
+      expect(overlayAfter).not.toBeNull();
+      expect(overlayAfter?.hasAttribute('open')).toBe(true);
+    });
+
+    it('passes updated costModels to the overlay when set after creation', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      el.spent = '1.00';
+      el.costModels = [{ model: 'claude-opus-4-6', cost: 1.0, turns: 2, tokens: 30000 }];
+      document.body.appendChild(el);
+
+      const spent = el.shadowRoot?.querySelector('.spent') as HTMLElement;
+      spent.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+
+      const newModels = [{ model: 'claude-sonnet-4-6', cost: 2.0, turns: 4, tokens: 60000 }];
+      el.costModels = newModels;
+
+      const overlay = el.shadowRoot?.querySelector('slicc-cost-overlay') as any;
+      expect(overlay.models).toBe(newModels);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a hover overlay on the floatbar cost counter (`$X.XX`) showing per-model and per-agent cost breakdown
- Displays token usage in K/M shorthand (e.g. "1.2M", "85K") alongside cost per model
- Extends the session-stats wire protocol to carry per-model and per-scoop cost data from the kernel worker to the UI

## Changes

- **`ScoopCostTracker`** — new `getModelCosts()` method aggregating cost/tokens by model across live + dropped scoops
- **Wire protocol** — `SessionStatsMsg` now includes `models[]` and `scoops[]` arrays
- **`<slicc-cost-overlay>`** — new shadow DOM web component rendering the breakdown card
- **`<slicc-floatbar>`** — hover the `.spent` segment to show/hide the overlay (150ms grace period)
- **Storybook** — stories for standalone overlay, floatbar integration, and large-session scenarios

## Test plan

- [x] `ScoopCostTracker.getModelCosts()` unit tests (6 tests)
- [x] `<slicc-cost-overlay>` component tests (16 tests)
- [x] Existing floatbar tests pass (29 tests)
- [x] Full webcomponents suite passes (1635 tests)
- [x] Typecheck clean
- [x] Lint clean
- [ ] Manual: hover cost pill → overlay appears with model/agent breakdown
- [ ] Manual: overlay persists when mouse moves to the card itself
- [ ] Manual: overlay reappears after stats poller updates the cost value

🤖 Generated with [Claude Code](https://claude.com/claude-code)