### PR TITLE
fix(webapp): prevent SW from double-proxying /api/* calls in thin-bridge mode

### DIFF
--- a/packages/webapp/src/kernel/kernel-worker-fetch-bypass.ts
+++ b/packages/webapp/src/kernel/kernel-worker-fetch-bypass.ts
@@ -23,22 +23,22 @@
  * wasm/asset payloads but works uniformly across CDNs and matches
  * the path `proxiedFetch` uses for everything else.
  *
- * Thin-bridge exception: the local node-server's own `/api/fetch-proxy`
- * is OUR infra endpoint, not a third-party CDN, and is reachable
- * cross-origin from a hosted-leader / wrangler-served UI. When the
- * worker realm's `proxiedFetch` calls it directly we must stamp the
- * bypass header so the page-installed SW skips re-interception
- * (re-proxying would clobber the caller's `X-Target-URL`). The
- * bridge already handles the resulting CORS preflight via
- * `createThinBridgeCorsMiddleware`, so the CDN-preflight rationale
- * above doesn't apply. The caller wires `getBridgeProxyOrigin` to
- * `() => getLocalApiBaseUrl()`-derived origin so the check stays
+ * Thin-bridge exception: any `/api/*` endpoint on the local node-server
+ * is OUR infra, not a third-party CDN, and is reachable cross-origin
+ * from a hosted-leader / wrangler-served UI. When the worker realm calls
+ * these endpoints directly (e.g. `/api/fetch-proxy`, `/api/da-sign-and-forward`,
+ * `/api/s3-sign-and-forward`) we must stamp the bypass header so the
+ * page-installed SW skips re-interception — re-proxying strips
+ * `X-Bridge-Token` and causes the node-server's CORS gate to reject with
+ * `bridge-token-required`. The bridge already handles the resulting CORS
+ * preflight via `createThinBridgeCorsMiddleware`, so the CDN-preflight
+ * rationale above doesn't apply. The caller wires `getBridgeProxyOrigin`
+ * to `() => getLocalApiBaseUrl()`-derived origin so the check stays
  * dynamic (the bridge origin is set AFTER `installFetchBypass` runs).
  */
 
 const BYPASS_HEADER = 'x-bypass-llm-proxy';
 const BYPASS_VALUE = '1';
-const FETCH_PROXY_PATH = '/api/fetch-proxy';
 
 // Track the global `fetch` signature so the wrapper composes
 // transparently and stays in lockstep with lib.dom updates.
@@ -91,16 +91,19 @@ function shouldStampBypass(
   if (isSameOrigin(input, selfOrigin)) return true;
   const bridgeOrigin = getBridgeProxyOrigin?.() ?? null;
   if (!bridgeOrigin) return false;
-  return isBridgeFetchProxyTarget(input, bridgeOrigin, selfOrigin);
+  return isBridgeLocalApiTarget(input, bridgeOrigin, selfOrigin);
 }
 
 /**
- * `true` when `input`'s target URL is the bridge's own
- * `/api/fetch-proxy` endpoint (origin + path match). Used to recognize
- * the worker realm's own infra calls so the bypass header can be safely
- * stamped on the cross-origin hop. Unparseable inputs return `false`.
+ * `true` when `input`'s target URL is any `/api/*` endpoint on the bridge
+ * origin (origin + `/api/` prefix match). Covers `/api/fetch-proxy`,
+ * `/api/da-sign-and-forward`, `/api/s3-sign-and-forward`, etc. — all direct
+ * calls to the local node-server's API surface that already carry
+ * `X-Bridge-Token` via `apiHeaders()` and must NOT be re-routed through the
+ * LLM proxy SW's fetch-proxy chain (which would strip the token).
+ * Unparseable inputs return `false`.
  */
-export function isBridgeFetchProxyTarget(
+export function isBridgeLocalApiTarget(
   input: RequestInfo | URL,
   bridgeOrigin: string,
   selfOrigin: string
@@ -114,7 +117,7 @@ export function isBridgeFetchProxyTarget(
   } catch {
     return false;
   }
-  return target.origin === bridge.origin && target.pathname === FETCH_PROXY_PATH;
+  return target.origin === bridge.origin && target.pathname.startsWith('/api/');
 }
 
 /**

--- a/packages/webapp/src/ui/llm-proxy-sw-config.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw-config.ts
@@ -122,6 +122,27 @@ export function resolveFetchProxyTarget(
 }
 
 /**
+ * True when `requestUrl` targets any `/api/*` endpoint at the configured
+ * `bridgeApiBaseUrl`. Used by the SW to recognize direct calls to the local
+ * node-server's API surface — these should pass through with the caller's
+ * original headers intact (including `X-Bridge-Token`) rather than being
+ * re-routed through `/api/fetch-proxy`, which would strip the bridge token
+ * and decode `X-Proxy-Origin` back onto the internal request, causing the
+ * node-server's CORS middleware to reject with `bridge-token-required`.
+ */
+export function isBridgeLocalApiUrl(requestUrl: string, bridgeApiBaseUrl: string): boolean {
+  let bridge: URL;
+  let target: URL;
+  try {
+    bridge = new URL(bridgeApiBaseUrl);
+    target = new URL(requestUrl);
+  } catch {
+    return false;
+  }
+  return target.origin === bridge.origin && target.pathname.startsWith('/api/');
+}
+
+/**
  * True when `requestUrl` already targets the bridge's own `/api/fetch-proxy`
  * endpoint at the configured `bridgeApiBaseUrl`. Used by the SW (cross-origin
  * analogue of the same-origin pass-through) and the kernel worker's

--- a/packages/webapp/src/ui/llm-proxy-sw.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw.ts
@@ -43,7 +43,7 @@ import {
   ExtensionDelegateCache,
   type ExtensionFetchDelegateRequest,
   isBridgeConfigMessage,
-  isBridgeFetchProxyUrl,
+  isBridgeLocalApiUrl,
   isExtensionDelegateMessage,
   parseExtensionDelegateFromClientUrl,
   type ResolvedExtensionDelegate,
@@ -219,13 +219,14 @@ async function forwardThroughProxy(req: Request, clientId: string | null): Promi
 
   const bridge = resolveBridgeFromClientUrls(cached, candidateUrls);
 
-  // Bridge-proxy pass-through: when the original request ALREADY targets
-  // the bridge's own `/api/fetch-proxy`, re-proxying it would clobber the
-  // caller's `X-Target-URL` (the cross-origin analogue of the same-origin
-  // skip at the top of the fetch handler). Re-fetch with the bypass
-  // header so this SW instance does not re-intercept the outgoing call,
-  // preserving the caller's headers byte-for-byte.
-  if (bridge && isBridgeFetchProxyUrl(req.url, bridge.apiBaseUrl, FETCH_PROXY_PATH)) {
+  // Bridge local-API pass-through: direct calls to any `/api/*` endpoint
+  // on the local node-server must reach it with the caller's original headers
+  // intact (including `X-Bridge-Token`). Re-routing through fetch-proxy would
+  // strip the bridge token (it's in FETCH_PROXY_SKIP_HEADERS) and decode
+  // X-Proxy-Origin back onto the internal request, causing the node-server's
+  // CORS middleware to reject with `bridge-token-required`. Re-fetch with the
+  // bypass header so this SW instance does not re-intercept the outgoing call.
+  if (bridge && isBridgeLocalApiUrl(req.url, bridge.apiBaseUrl)) {
     const passHeaders = new Headers(req.headers);
     passHeaders.set(BYPASS_HEADER, '1');
     const passInit: RequestInit = {

--- a/packages/webapp/tests/kernel/kernel-worker-fetch-bypass.test.ts
+++ b/packages/webapp/tests/kernel/kernel-worker-fetch-bypass.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   type FetchFn,
-  isBridgeFetchProxyTarget,
+  isBridgeLocalApiTarget,
   isSameOrigin,
   makeSameOriginBypassFetch,
 } from '../../src/kernel/kernel-worker-fetch-bypass.js';
@@ -183,10 +183,10 @@ describe('makeSameOriginBypassFetch', () => {
   });
 });
 
-describe('isBridgeFetchProxyTarget', () => {
+describe('isBridgeLocalApiTarget', () => {
   it('matches the bridge /api/fetch-proxy URL', () => {
     expect(
-      isBridgeFetchProxyTarget(
+      isBridgeLocalApiTarget(
         'http://localhost:5711/api/fetch-proxy',
         'http://localhost:5711',
         SELF_ORIGIN
@@ -194,19 +194,49 @@ describe('isBridgeFetchProxyTarget', () => {
     ).toBe(true);
   });
 
-  it('rejects a different path on the bridge origin', () => {
+  it('matches any /api/* path at the bridge origin', () => {
     expect(
-      isBridgeFetchProxyTarget(
+      isBridgeLocalApiTarget(
         'http://localhost:5711/api/other',
+        'http://localhost:5711',
+        SELF_ORIGIN
+      )
+    ).toBe(true);
+  });
+
+  it('matches /api/da-sign-and-forward at the bridge origin', () => {
+    expect(
+      isBridgeLocalApiTarget(
+        'http://localhost:5711/api/da-sign-and-forward',
+        'http://localhost:5711',
+        SELF_ORIGIN
+      )
+    ).toBe(true);
+  });
+
+  it('matches /api/s3-sign-and-forward at the bridge origin', () => {
+    expect(
+      isBridgeLocalApiTarget(
+        'http://localhost:5711/api/s3-sign-and-forward',
+        'http://localhost:5711',
+        SELF_ORIGIN
+      )
+    ).toBe(true);
+  });
+
+  it('rejects non-/api/ paths at the bridge origin', () => {
+    expect(
+      isBridgeLocalApiTarget(
+        'http://localhost:5711/some-other-route',
         'http://localhost:5711',
         SELF_ORIGIN
       )
     ).toBe(false);
   });
 
-  it('rejects a different origin even with the matching path', () => {
+  it('rejects a different origin even with a matching /api/ path', () => {
     expect(
-      isBridgeFetchProxyTarget(
+      isBridgeLocalApiTarget(
         'http://localhost:5710/api/fetch-proxy',
         'http://localhost:5711',
         SELF_ORIGIN
@@ -216,8 +246,8 @@ describe('isBridgeFetchProxyTarget', () => {
 
   it('handles Request objects', () => {
     expect(
-      isBridgeFetchProxyTarget(
-        new Request('http://localhost:5711/api/fetch-proxy'),
+      isBridgeLocalApiTarget(
+        new Request('http://localhost:5711/api/da-sign-and-forward'),
         'http://localhost:5711',
         SELF_ORIGIN
       )
@@ -226,7 +256,7 @@ describe('isBridgeFetchProxyTarget', () => {
 
   it('returns false on unparseable bridge origin', () => {
     expect(
-      isBridgeFetchProxyTarget('http://localhost:5711/api/fetch-proxy', 'not a url', SELF_ORIGIN)
+      isBridgeLocalApiTarget('http://localhost:5711/api/fetch-proxy', 'not a url', SELF_ORIGIN)
     ).toBe(false);
   });
 });

--- a/packages/webapp/tests/ui/llm-proxy-sw-config.test.ts
+++ b/packages/webapp/tests/ui/llm-proxy-sw-config.test.ts
@@ -16,6 +16,7 @@ import {
   ExtensionDelegateCache,
   isBridgeConfigMessage,
   isBridgeFetchProxyUrl,
+  isBridgeLocalApiUrl,
   isExtensionDelegateMessage,
   isExtensionFetchDelegateRequest,
   parseExtensionDelegateFromClientUrl,
@@ -201,6 +202,45 @@ describe('isBridgeFetchProxyUrl', () => {
   it('returns false for unparseable inputs', () => {
     expect(isBridgeFetchProxyUrl('not a url', 'http://localhost:5710')).toBe(false);
     expect(isBridgeFetchProxyUrl('http://localhost:5710/api/fetch-proxy', 'not a url')).toBe(false);
+  });
+});
+
+describe('isBridgeLocalApiUrl', () => {
+  it('matches /api/da-sign-and-forward at the bridge origin', () => {
+    expect(
+      isBridgeLocalApiUrl('http://localhost:5710/api/da-sign-and-forward', 'http://localhost:5710')
+    ).toBe(true);
+  });
+
+  it('matches /api/s3-sign-and-forward at the bridge origin', () => {
+    expect(
+      isBridgeLocalApiUrl('http://localhost:5710/api/s3-sign-and-forward', 'http://localhost:5710')
+    ).toBe(true);
+  });
+
+  it('matches /api/fetch-proxy at the bridge origin', () => {
+    expect(
+      isBridgeLocalApiUrl('http://localhost:5710/api/fetch-proxy', 'http://localhost:5710')
+    ).toBe(true);
+  });
+
+  it('rejects a non-/api/ path at the bridge origin', () => {
+    expect(isBridgeLocalApiUrl('http://localhost:5710/preview/foo', 'http://localhost:5710')).toBe(
+      false
+    );
+  });
+
+  it('rejects an /api/ path on a different origin', () => {
+    expect(
+      isBridgeLocalApiUrl('http://localhost:5711/api/da-sign-and-forward', 'http://localhost:5710')
+    ).toBe(false);
+  });
+
+  it('returns false for unparseable inputs', () => {
+    expect(isBridgeLocalApiUrl('not a url', 'http://localhost:5710')).toBe(false);
+    expect(isBridgeLocalApiUrl('http://localhost:5710/api/da-sign-and-forward', 'not a url')).toBe(
+      false
+    );
   });
 });
 


### PR DESCRIPTION
 ## Summary

  In thin-bridge mode (`npx sliccy`), the LLM-proxy service worker intercepts cross-origin fetches from the kernel DedicatedWorker — including direct calls to node-server endpoints like `/api/da-sign-and-forward`. Re-routing these through `/api/fetch-proxy` strips `X-Bridge-Token` (it's in
  `FETCH_PROXY_SKIP_HEADERS`) and decodes `X-Proxy-Origin` back to `Origin` on the internal request, causing the node-server's CORS middleware to reject with `bridge-token-required`.

  This PR extends the SW's bridge-local-API pass-through — previously only `/api/fetch-proxy` — to cover any `/api/*` path at the bridge origin, so DA and S3 mount calls reach the node-server with their original headers intact.

  > **Note:** #1168 collapses all node-server modes into thin-bridge permanently. Once that lands, this fix applies to every float, not just `npx sliccy`.

  ## Why

  **Repro:**
  1. `npx sliccy` (thin-bridge mode — UI served from `https://www.sliccy.ai`)
  2. `mount --source da://org/site /mnt/site`

  Expected: mount succeeds
  Actual: `bridge-token-required` (403) — the SW double-proxied the `/api/da-sign-and-forward` call, stripping the bridge token in the process

  The bug affects any direct `/api/*` call the kernel worker makes in thin-bridge mode: `/api/da-sign-and-forward`, `/api/s3-sign-and-forward`, and any future node-server endpoint called directly from the worker.

  ## Approach / Implementation notes

  - **`isBridgeFetchProxyTarget` (`kernel-worker-fetch-bypass.ts`)**: changed from exact path match on `/api/fetch-proxy` to prefix match on `/api/` at the bridge origin. This stamps `x-bypass-llm-proxy: 1` on all direct `/api/*` calls from the kernel worker so the SW skips re-interception.
  - **`isBridgeLocalApiUrl` (`llm-proxy-sw-config.ts`)**: new exported function — same `/api/` prefix + bridge origin check, extracted so the SW and its tests can share the logic independently of the kernel-worker path.
  - **`llm-proxy-sw.ts`**: switched the bridge pass-through guard from `isBridgeFetchProxyUrl` (exact `/api/fetch-proxy` match) to `isBridgeLocalApiUrl` (any `/api/*`). The pass-through re-fetches with `x-bypass-llm-proxy: 1` so the SW does not re-intercept the outgoing call.

  ## Cross-cutting impact

  - **Floats exercised**: currently thin-bridge only (`npx sliccy`). Once `remove-localhost-webapp-serving` lands and thin-bridge becomes the only mode, this fix applies to all floats.
  - **Other callers of `isBridgeFetchProxyTarget`**: only `shouldStampBypass` in the same file. `isBridgeFetchProxyUrl` (the exact-match variant) is still exported and used by existing tests — it is unchanged.
  - **Security**: the pass-through re-fetches with `x-bypass-llm-proxy: 1` but preserves all caller headers byte-for-byte, including `X-Bridge-Token`. No headers are added or removed beyond the bypass marker. The node-server's bridge-token gate still validates every non-loopback request.
  - **No persisted state changes**, no new dependencies, no IndexedDB or localStorage changes.

  ## Test plan

  - [x] `npm run lint` — clean
  - [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — 0 of 5 changed files on any debt list
  - [x] `npm run typecheck` — clean
  - [x] `npm run test` — 9594 passing, 15 skipped, no new failures
  - [x] `npm run test:coverage` — above thresholds
  - [x] `npm run build` — clean
  - [x] `npm run build -w @slicc/chrome-extension` — clean
  - [x] **New behavior is covered by unit tests**:
    - `npx vitest run packages/webapp/tests/kernel/kernel-worker-fetch-bypass.test.ts` — updated `isBridgeFetchProxyTarget` describe block with 4 new cases for `/api/da-sign-and-forward`, `/api/s3-sign-and-forward`, any `/api/*`, and non-`/api/` rejection
    - `npx vitest run packages/webapp/tests/ui/llm-proxy-sw-config.test.ts` — new `isBridgeLocalApiUrl` describe block with 6 cases
  - [x] Manual smoke (thin-bridge): `npm start` + `mount --source da://org/site /mnt/site` — mount succeeded; retry logic kicked in automatically after fix was applied
  - [ ] Manual smoke (CLI dev mode / extension): N/A — SW pass-through only fires when `getBridgeProxyOrigin()` returns non-null, which only happens when a bridge config is present

  **Pre-existing failures**: none observed — 15 skipped tests reproduce on `main` (timeout/interactive shell tests).

  ## Documentation

  - [x] No documentation changes needed — the SW routing architecture is already documented; thin-bridge-specific framing will be superseded by #1168 

  ## Risk & rollback

  - **Blast radius**: currently thin-bridge mode only; expands to all floats once #1168 lands. Previously broken calls to `/api/da-sign-and-forward` and `/api/s3-sign-and-forward` now pass through correctly — no regression path for previously working code paths.
  - **No feature flags or kill switches** — the fix is unconditional within thin-bridge mode.
  - **Rollback**: revert this PR cleanly. No persisted state migration. 
  - **CI cannot catch**: the full thin-bridge routing path (page → SW → node-server) requires a real browser with a live SW; unit tests cover the routing predicates but not the full chain.

  ## Checklist

  - [x] Commits are focused and package-local where possible
  - [x] No hand-edited files under `dist/`
  - [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
  - [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
  - [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths — SW pass-through change is bridge-config-gated; extension and non-bridge CLI are unaffected
