### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -43,7 +43,7 @@
       "lines": 76,
       "statements": 74,
       "functions": 75,
-      "branches": 64,
+      "branches": 65,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.