### PR TITLE
feat(files-panel): restore and improve VFS file tree panel

### DIFF
--- a/.claude/skills/demo-recording/SKILL.md
+++ b/.claude/skills/demo-recording/SKILL.md
@@ -91,6 +91,84 @@ playwright-cli run-code --filename /tmp/demo-script.js
 
 ## Key Gotchas
 
+### Scripts must be self-contained
+
+Always inject the cursor **inside** the `run-code` script, not in a
+prior `playwright-cli eval`. If the page URL changes (e.g., switching
+workbench surfaces updates `?ws=` via `replaceState`), `window.__mc`
+survives. But a full reload wipes it. Putting injection at the top of
+every script makes it idempotent:
+
+```js
+async (page) => {
+  // Always re-inject — idempotent, safe to call multiple times
+  await page.evaluate(() => {
+    const old = document.getElementById('fake-cursor');
+    if (old) old.remove();
+    const c = document.createElement('div');
+    c.id = 'fake-cursor';
+    c.style.cssText =
+      'position:fixed;width:24px;height:24px;z-index:999999;pointer-events:none;display:none;';
+    c.innerHTML =
+      '<svg width="24" height="24" viewBox="0 0 24 24"><path d="M5.5 3.21V20.8c0 .45.54.67.85.35l4.86-4.86a.5.5 0 01.35-.15h6.87a.5.5 0 00.35-.85L6.35 2.86a.5.5 0 00-.85.35z" fill="#111" stroke="#fff" stroke-width="1.5"/></svg>';
+    document.body.appendChild(c);
+    window.__mc = (x, y) => {
+      c.style.left = x + 'px';
+      c.style.top = y + 'px';
+      c.style.display = 'block';
+    };
+    window.__hc = () => {
+      c.style.display = 'none';
+    };
+  });
+  // ... rest of script
+};
+```
+
+### Reset page/component state before recording
+
+Component state persists between recording takes. If a previous run
+expanded a tree node or left a file selected, the next run will start
+in that state — shifting all coordinates and breaking the script. Reset
+before recording:
+
+```js
+// Example: ensure a file tree starts clean
+await page.evaluate(() => {
+  const ft = document.querySelector('slicc-file-tree');
+  if (ft && ft.isDirOpen('/workspace/skills')) ft.toggleDir('/workspace/skills');
+});
+```
+
+Always verify state with a measurement eval before starting the
+recording, especially when re-taking a failed demo.
+
+### Combine `page.mouse.move` with `window.__mc` for hover events
+
+The visible cursor and the real browser pointer are independent.
+`page.evaluate(() => window.__mc(x, y))` only moves the SVG — it does
+NOT fire `pointerover`/`pointermove` events on page elements. Always
+drive both together in the `moveTo` loop:
+
+```js
+async function moveTo(tx, ty, steps = 14, delay = 18) {
+  const p = await page.evaluate(() => {
+    const c = document.getElementById('fake-cursor');
+    return { x: parseInt(c.style.left || '640'), y: parseInt(c.style.top || '360') };
+  });
+  for (let i = 1; i <= steps; i++) {
+    const nx = p.x + (tx - p.x) * (i / steps);
+    const ny = p.y + (ty - p.y) * (i / steps);
+    await page.evaluate((v) => window.__mc(v[0], v[1]), [nx, ny]);
+    await page.mouse.move(nx, ny); // ← fires real pointerover/hover
+    await wait(delay);
+  }
+}
+```
+
+Without `page.mouse.move`, hover-triggered UI (dropdown buttons,
+tooltips, action overlays) will not appear on screen.
+
 ### CDP mouse events vs Pointer Events
 
 `page.mouse.down()` dispatches CDP-level mouse events. These do NOT
@@ -118,10 +196,27 @@ await page.evaluate(
   },
   [x, y]
 );
-
 // Move the visible cursor in sync
-await page.evaluate(([px, py]) => window.__mc(px, py), [x, y]);
+await page.evaluate((v) => window.__mc(v[0], v[1]), [x, y]);
 ```
+
+### Timing estimates drift — verify with frame screenshots
+
+Script timing is cumulative and unpredictable: `page.evaluate`
+overhead, animation frames, and async VFS calls all add invisible
+latency. **Never trust timing math alone.** The correct workflow:
+
+1. Record the raw webm
+2. Convert to mp4
+3. Extract frames at estimated timestamps:
+   ```bash
+   for ts in 1.5 3.0 5.5 9.0; do
+     frame=$(echo "$ts * 25" | bc | cut -d. -f1)
+     ffmpeg -y -i demo.mp4 -vf "select=eq(n\,${frame})" -vframes 1 /tmp/check_${ts}.png -loglevel quiet
+   done
+   ```
+4. Read each frame image — adjust timestamps based on what's actually visible
+5. Only then add overlays/toasts
 
 ### Timing
 
@@ -182,6 +277,98 @@ ffmpeg -y -ss 5 -t 15 -i demo.webm \
   -pix_fmt yuv420p -movflags +faststart \
   demo.mp4
 ```
+
+## Text Overlays / Chapter Toasts
+
+`ffmpeg`'s `drawtext` filter requires freetype, which may not be
+compiled in. Check first: `ffmpeg -filters 2>/dev/null | grep drawtext`.
+If missing, use Python + OpenCV + Pillow instead.
+
+### Freeze-frame toast pattern (Python)
+
+Insert a static freeze at key moments with a text overlay — much more
+reliable than trying to match exact timestamps to fast-moving content.
+The workflow:
+
+1. **Extract verification frames** at estimated timestamps (see timing section above)
+2. **Identify the right freeze frame** for each section by reading the PNGs
+3. **Run the script** to insert freezes and overlay text
+
+```python
+# /tmp/add_toasts.py
+import cv2, subprocess
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+
+INPUT  = "/tmp/demo.mp4"
+OUTPUT = "/tmp/demo-toasts.mp4"
+
+# (original_video_time_s, freeze_duration_s, text) — ASCII only, no Unicode arrows/dots
+FREEZE = [
+    (1.2, 1.5, "Files panel - folder icons, file sizes, navigation"),
+    (3.0, 1.5, "Hover a file - action buttons appear"),
+    (6.0, 2.0, "Click CAT - file opens in terminal"),
+]
+FONT_SIZE = 15; PAD_X = 16; PAD_Y = 9; MARGIN_BOT = 38; FADE = 0.20
+
+cap = cv2.VideoCapture(INPUT)
+FPS = cap.get(cv2.CAP_PROP_FPS)
+W   = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+H   = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+try:
+    font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", FONT_SIZE)
+except Exception:
+    font = ImageFont.load_default()
+
+frames = []
+while True:
+    ok, f = cap.read()
+    if not ok: break
+    frames.append(f)
+cap.release()
+
+def draw_toast(frame_bgr, text, alpha):
+    img = Image.fromarray(cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)).convert("RGBA")
+    ov  = Image.new("RGBA", img.size, (0, 0, 0, 0))
+    d   = ImageDraw.Draw(ov)
+    bb  = d.textbbox((0, 0), text, font=font)
+    tw, th = bb[2]-bb[0], bb[3]-bb[1]
+    bx = (W - tw)//2 - PAD_X; by = H - MARGIN_BOT - th - PAD_Y*2
+    d.rounded_rectangle([bx, by, bx+tw+PAD_X*2, by+th+PAD_Y*2], radius=6,
+                        fill=(20, 20, 20, int(180*alpha)))
+    d.text((bx+PAD_X, by+PAD_Y), text, font=font, fill=(255, 255, 255, int(240*alpha)))
+    return cv2.cvtColor(np.array(Image.alpha_composite(img, ov).convert("RGB")), cv2.COLOR_RGB2BGR)
+
+output_frames = []
+freeze_specs  = [(int(t * FPS), int(dur * FPS), txt) for t, dur, txt in FREEZE]
+prev_src = 0
+for (orig_idx, n_freeze, txt) in freeze_specs:
+    for i in range(prev_src, min(orig_idx, len(frames))):
+        output_frames.append((frames[i], None, None))
+    ff = frames[min(orig_idx, len(frames)-1)]
+    fade_f = int(FADE * FPS)
+    for j in range(n_freeze):
+        a = j/fade_f if j < fade_f else (n_freeze-j)/fade_f if j > n_freeze-fade_f else 1.0
+        output_frames.append((ff, txt, max(0.0, min(1.0, a))))
+    prev_src = orig_idx
+for i in range(prev_src, len(frames)):
+    output_frames.append((frames[i], None, None))
+
+cmd = ["ffmpeg", "-y", "-f", "rawvideo", "-vcodec", "rawvideo",
+       "-s", f"{W}x{H}", "-pix_fmt", "rgb24", "-r", str(FPS), "-i", "pipe:0",
+       "-c:v", "libx264", "-preset", "fast", "-crf", "20",
+       "-pix_fmt", "yuv420p", "-movflags", "+faststart", OUTPUT]
+proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.DEVNULL)
+for frame_bgr, txt, alpha in output_frames:
+    out = draw_toast(frame_bgr, txt, alpha) if txt and alpha and alpha > 0.01 else frame_bgr
+    proc.stdin.write(cv2.cvtColor(out, cv2.COLOR_BGR2RGB).tobytes())
+proc.stdin.close(); proc.wait()
+```
+
+**Important:** Use ASCII-only text — Unicode arrows (`→`), dots (`·`),
+and em-dashes (`—`) render as empty squares with Helvetica.ttc in PIL.
+Use `-` and `->` instead.
 
 ## Embedding in GitHub PRs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -784,9 +784,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -804,9 +801,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -824,9 +818,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -844,9 +835,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1930,7 +1918,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2046,9 +2034,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2064,9 +2049,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2084,9 +2066,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2103,9 +2082,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2121,9 +2097,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4908,9 +4881,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4928,9 +4898,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4948,9 +4915,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4968,9 +4932,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4988,9 +4949,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5008,9 +4966,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5028,9 +4983,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5048,9 +5000,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5263,9 +5212,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5280,9 +5226,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5297,9 +5240,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5314,9 +5254,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5331,9 +5268,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5348,9 +5282,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5365,9 +5296,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5382,9 +5310,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5978,9 +5903,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5998,9 +5920,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6018,9 +5937,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6038,9 +5954,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6058,9 +5971,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6078,9 +5988,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18356,9 +18263,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18376,9 +18280,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18396,9 +18297,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18416,9 +18314,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18436,9 +18331,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18456,9 +18348,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18476,9 +18365,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18496,9 +18382,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/webapp/src/ui/wc/wc-file-actions.ts
+++ b/packages/webapp/src/ui/wc/wc-file-actions.ts
@@ -1,0 +1,236 @@
+/**
+ * File-tree action wiring: hover buttons (CAT preview, DL download, ZIP download)
+ * and keyboard copy-path (Cmd/Ctrl+C). App-specific behaviors that belong in the
+ * webapp layer, not in the generic `<slicc-file-tree>` WC.
+ *
+ * Buttons are injected into a `.ft-acts` container on `pointerover` and removed
+ * on `pointerout`. `replaceChildren` in the tree's render cycle destroys them,
+ * so they're always re-injected fresh.
+ */
+
+import type { SliccFileTree } from '@slicc/webcomponents';
+import { zipSync } from 'fflate';
+import { isTerminalPreviewableMediaPath } from '../../core/mime-types.js';
+import type { LocalVfsClient } from '../../kernel/local-vfs-client.js';
+
+export interface FileActionDeps {
+  fileTree: SliccFileTree;
+  openFs(): Promise<LocalVfsClient>;
+  /** Switch the workbench to the named surface (e.g. 'term'). */
+  activateSurface(surfaceId: string): void;
+}
+
+/** Shell-escape a path with single quotes. */
+function q(p: string): string {
+  return `'${p.replace(/'/g, "'\\''")}'`;
+}
+
+/** Recursively collect all files under a VFS dir as { relPath: Uint8Array }. */
+async function collectFiles(
+  fs: LocalVfsClient,
+  dir: string,
+  prefix: string
+): Promise<Record<string, Uint8Array>> {
+  const out: Record<string, Uint8Array> = {};
+  let entries;
+  try {
+    entries = await fs.readDir(dir);
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = `${dir}/${e.name}`;
+    const rel = prefix ? `${prefix}/${e.name}` : e.name;
+    if (e.type === 'directory') {
+      Object.assign(out, await collectFiles(fs, full, rel));
+    } else {
+      try {
+        const content = await fs.readFile(full, { encoding: 'binary' });
+        out[rel] = content instanceof Uint8Array ? content : new TextEncoder().encode(content);
+      } catch {
+        // skip unreadable files
+      }
+    }
+  }
+  return out;
+}
+
+function makeActionBtn(label: string): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.className = 'ft-act';
+  btn.textContent = label;
+  return btn;
+}
+
+function makeActsContainer(): HTMLDivElement {
+  const div = document.createElement('div');
+  div.className = 'ft-acts';
+  return div;
+}
+
+/** Trigger a browser download of bytes with the given filename. */
+function downloadBytes(
+  bytes: Uint8Array,
+  filename: string,
+  mime = 'application/octet-stream'
+): void {
+  // new Uint8Array(typed) copies into a plain ArrayBuffer, satisfying Blob's BlobPart constraint.
+  const url = URL.createObjectURL(new Blob([new Uint8Array(bytes)], { type: mime }));
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Switch to the terminal surface and run a command, waiting up to 3 s for the
+ * terminal view to mount (it's lazily initialised on first activation).
+ */
+async function runInTerminal(cmd: string, activateSurface: (id: string) => void): Promise<void> {
+  activateSurface('term');
+  for (let i = 0; i < 30; i++) {
+    const tv = (globalThis as Record<string, unknown>).__slicc_terminal_view as
+      | { executeCommandInTerminal(cmd: string): unknown }
+      | undefined;
+    if (tv) {
+      tv.executeCommandInTerminal(cmd);
+      return;
+    }
+    await new Promise<void>((r) => setTimeout(r, 100));
+  }
+}
+
+/**
+ * Wire hover action buttons and Cmd+C copy-path onto the file tree.
+ * Returns a dispose function that cleans up all listeners.
+ */
+export function wireFileTreeActions(deps: FileActionDeps): () => void {
+  const { fileTree, openFs, activateSurface } = deps;
+
+  let selectedPath: string | null = null;
+
+  const onFileSelect = (e: Event): void => {
+    const detail = (e as CustomEvent<{ id: string; path: string }>).detail;
+    selectedPath = detail?.path ?? null;
+    // Clear tabIndex on any previously focused row.
+    for (const r of fileTree.querySelectorAll<HTMLElement>('.f[tabindex]')) {
+      r.removeAttribute('tabindex');
+    }
+    // Make the selected row focusable and focus it so keydown bubbles to our listener.
+    if (detail?.id) {
+      for (const r of fileTree.querySelectorAll<HTMLElement>('.f')) {
+        if (r.dataset.id === detail.id) {
+          r.tabIndex = 0;
+          r.focus({ preventScroll: true });
+          break;
+        }
+      }
+    }
+  };
+
+  // --- Hover action buttons ---
+
+  const onPointerOver = (e: PointerEvent): void => {
+    const target = e.target as HTMLElement | null;
+
+    // File row: CAT + DL buttons
+    const fileRow = target?.closest<HTMLElement>('.f');
+    if (fileRow && fileTree.contains(fileRow) && !fileRow.querySelector('.ft-acts')) {
+      const path = fileRow.dataset.id;
+      if (!path) return;
+      const filename = path.split('/').pop() ?? path;
+      const acts = makeActsContainer();
+
+      const catBtn = makeActionBtn(isTerminalPreviewableMediaPath(path) ? 'IMGCAT' : 'CAT');
+      catBtn.title = 'Preview in terminal';
+      catBtn.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        const cmd = isTerminalPreviewableMediaPath(path) ? `imgcat ${q(path)}` : `cat ${q(path)}`;
+        void runInTerminal(cmd, activateSurface);
+      });
+
+      const dlBtn = makeActionBtn('DL');
+      dlBtn.title = 'Download file';
+      dlBtn.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        void openFs()
+          .then(async (fs) => {
+            const content = await fs.readFile(path, { encoding: 'binary' });
+            const bytes =
+              content instanceof Uint8Array ? content : new TextEncoder().encode(content);
+            downloadBytes(bytes, filename);
+          })
+          .catch(console.error);
+      });
+
+      acts.append(catBtn, dlBtn);
+      fileRow.appendChild(acts);
+    }
+
+    // Dir row: ZIP button
+    const dirRow = target?.closest<HTMLElement>('.dir');
+    if (dirRow && fileTree.contains(dirRow) && !dirRow.querySelector('.ft-acts')) {
+      const dirPath = dirRow.dataset.dirId;
+      const dirName = dirRow.textContent?.trim() ?? 'archive';
+      if (!dirPath) return;
+      const acts = makeActsContainer();
+      const zipBtn = makeActionBtn('ZIP');
+      zipBtn.title = 'Download as ZIP';
+      zipBtn.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        void openFs()
+          .then(async (fs) => {
+            const files = await collectFiles(fs, dirPath, '');
+            const zipped = zipSync(files);
+            downloadBytes(zipped, `${dirName}.zip`, 'application/zip');
+          })
+          .catch(console.error);
+      });
+      acts.append(zipBtn);
+      dirRow.appendChild(acts);
+    }
+  };
+
+  const onPointerOut = (e: PointerEvent): void => {
+    const target = e.target as HTMLElement | null;
+    const related = e.relatedTarget as HTMLElement | null;
+    const row = target?.closest<HTMLElement>('.f,.dir');
+    if (!row || !fileTree.contains(row)) return;
+    // Keep buttons while the pointer is still inside the row (e.g. moving to a button).
+    if (related && row.contains(related)) return;
+    row.querySelector('.ft-acts')?.remove();
+  };
+
+  // --- Cmd/Ctrl+C copy path ---
+
+  const onKeyDown = (e: KeyboardEvent): void => {
+    if (!(e.metaKey || e.ctrlKey) || e.key !== 'c') return;
+    if (!selectedPath) return;
+    if (window.getSelection()?.isCollapsed === false) return;
+    e.preventDefault();
+    navigator.clipboard.writeText(selectedPath).then(() => {
+      const sel = fileTree.getAttribute('selected');
+      if (!sel) return;
+      for (const r of fileTree.querySelectorAll<HTMLElement>('.f')) {
+        if (r.dataset.id === sel) {
+          r.classList.add('ft-copy-flash');
+          setTimeout(() => r.classList.remove('ft-copy-flash'), 300);
+          break;
+        }
+      }
+    }, console.warn);
+  };
+
+  fileTree.addEventListener('file-select', onFileSelect);
+  fileTree.addEventListener('pointerover', onPointerOver);
+  fileTree.addEventListener('pointerout', onPointerOut);
+  fileTree.addEventListener('keydown', onKeyDown);
+
+  return (): void => {
+    fileTree.removeEventListener('file-select', onFileSelect);
+    fileTree.removeEventListener('pointerover', onPointerOver);
+    fileTree.removeEventListener('pointerout', onPointerOut);
+    fileTree.removeEventListener('keydown', onKeyDown);
+  };
+}

--- a/packages/webapp/src/ui/wc/wc-file-actions.ts
+++ b/packages/webapp/src/ui/wc/wc-file-actions.ts
@@ -172,7 +172,7 @@ export function wireFileTreeActions(deps: FileActionDeps): () => void {
     const dirRow = target?.closest<HTMLElement>('.dir');
     if (dirRow && fileTree.contains(dirRow) && !dirRow.querySelector('.ft-acts')) {
       const dirPath = dirRow.dataset.dirId;
-      const dirName = dirRow.textContent?.trim() ?? 'archive';
+      const dirName = dirPath?.split('/').pop() ?? 'archive';
       if (!dirPath) return;
       const acts = makeActsContainer();
       const zipBtn = makeActionBtn('ZIP');

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -26,6 +26,7 @@ import { scoopColor } from './wc-scoop-color.js';
 
 export { scoopColor } from './wc-scoop-color.js';
 
+import { wireFileTreeActions } from './wc-file-actions.js';
 import {
   enrichFreezerIcons,
   FREEZER_TINT,
@@ -593,8 +594,13 @@ export function prepareWcShell(app: HTMLElement, floatLabel: string): WcShellBoo
       activateSurface = fn;
       // The shell's connect-time URL restore (`ws` param) ran before the
       // activator existed — re-fire it so the restored surface lazily mounts.
+      // Gate behind kernel ready: VFS RPCs (e.g. file tree load) need the
+      // worker's VfsRpcHost to be attached, which only happens after host.ready.
       const active = refs.workbenchBody.getAttribute('active');
-      if (active && refs.shell.hasAttribute('open')) fn(active);
+      if (active && refs.shell.hasAttribute('open')) {
+        if (clientReady) fn(active);
+        else readyListeners.add(() => fn(active));
+      }
     },
     onClientReady: (fn) => {
       readyListeners.add(fn);
@@ -982,7 +988,10 @@ function wireWcStats(wiring: WcLiveWiring, client: OffscreenClient): () => void 
       if (!stats) return;
       wiring.refs.floatbar.setAttribute('spent', stats.totalCost.toFixed(2));
       // Feed per-model and per-scoop breakdown to the floatbar overlay
-      const fb = wiring.refs.floatbar as any;
+      const fb = wiring.refs.floatbar as HTMLElement & {
+        costModels?: unknown;
+        costScoops?: unknown;
+      };
       if (stats.models) fb.costModels = stats.models;
       if (stats.scoops) fb.costScoops = stats.scoops;
       wiring.fills.clear();
@@ -1298,6 +1307,20 @@ export function makeSprinkleAttachImage(
   };
 }
 
+function wireWorkbenchFileActions(
+  refs: WcShellRefs,
+  openFs: () => Promise<import('../../kernel/local-vfs-client.js').LocalVfsClient>
+): void {
+  wireFileTreeActions({
+    fileTree: refs.fileTree,
+    openFs,
+    // selectItem() sets the dock's active state AND emits slicc-dock-select,
+    // so the icon highlights and wireDockToWorkbench both fire correctly.
+    activateSurface: (id) =>
+      (refs.dock as HTMLElement & { selectItem(id: string): void }).selectItem(id),
+  });
+}
+
 export function attachWcClient(
   boot: WcShellBoot,
   client: OffscreenClient,
@@ -1353,10 +1376,12 @@ export function attachWcClient(
       termSurface: refs.termSurface,
       memoryHost: refs.memoryHost,
       openFs: openReader,
+      onKernelReady: (fn) => boot.onClientReady(fn),
       mountTerminal: (container) => mountWorkbenchTerminal(boot, client, container),
       log,
     })
   );
+  wireWorkbenchFileActions(refs, openReader);
 
   // Freezer rail: frozen cone sessions thaw read-only into the thread;
   // selecting any scoop chip returns to the live conversation.

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1311,7 +1311,7 @@ function wireWorkbenchFileActions(
   refs: WcShellRefs,
   openFs: () => Promise<import('../../kernel/local-vfs-client.js').LocalVfsClient>
 ): void {
-  wireFileTreeActions({
+  const dispose = wireFileTreeActions({
     fileTree: refs.fileTree,
     openFs,
     // selectItem() sets the dock's active state AND emits slicc-dock-select,
@@ -1319,6 +1319,7 @@ function wireWorkbenchFileActions(
     activateSurface: (id) =>
       (refs.dock as HTMLElement & { selectItem(id: string): void }).selectItem(id),
   });
+  window.addEventListener('beforeunload', dispose, { once: true });
 }
 
 export function attachWcClient(

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -125,6 +125,18 @@ const CSS = [
   '.wcui-term .terminal-panel__preview{flex:0 0 auto;}',
   // The files surface is the tree: no dead second column, no divider.
   '.wcui-frame slicc-file-tree{width:100%;border-right:none;}',
+  // Rows need a positioning context so the absolute button never shifts row height.
+  'slicc-file-tree .f,slicc-file-tree .dir{position:relative;}',
+  // Hover action button container — absolutely positioned at the row's right edge.
+  'slicc-file-tree .ft-acts{position:absolute;right:8px;top:50%;transform:translateY(-50%);',
+  'display:flex;gap:3px;}',
+  // Individual action buttons inside .ft-acts.
+  'slicc-file-tree .ft-act{padding:0 5px;font-size:10px;line-height:16px;height:16px;',
+  'box-sizing:border-box;font-family:var(--ui);border-radius:3px;border:1px solid var(--line);',
+  'background:var(--canvas);color:var(--txt-2);cursor:pointer;}',
+  'slicc-file-tree .ft-act:hover{background:var(--ghost);}',
+  // 300ms green flash on Cmd+C copy-path.
+  'slicc-file-tree .ft-copy-flash{background:color-mix(in srgb,#22c55e 18%,var(--canvas))!important;}',
   '.wcui-memory{flex:1;min-height:0;overflow:auto;display:flex;flex-direction:column;',
   'gap:8px;padding:10px;}',
   '.wcui-placeholder{flex:1;display:flex;align-items:center;justify-content:center;',

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -473,10 +473,20 @@ export function mountWcUiPreview(root: HTMLElement): void {
   });
 
   refs.fileTree.items = [
-    { kind: 'group', label: 'workspace/' },
-    { kind: 'file', id: '/workspace/CLAUDE.md', label: 'CLAUDE.md' },
-    { kind: 'group', label: 'shared/' },
-    { kind: 'file', id: '/shared/CLAUDE.md', label: 'CLAUDE.md' },
+    {
+      kind: 'dir',
+      id: '/workspace',
+      label: 'workspace',
+      open: true,
+      children: [{ kind: 'file', id: '/workspace/CLAUDE.md', label: 'CLAUDE.md', size: 3200 }],
+    },
+    {
+      kind: 'dir',
+      id: '/shared',
+      label: 'shared',
+      open: true,
+      children: [{ kind: 'file', id: '/shared/CLAUDE.md', label: 'CLAUDE.md', size: 1800 }],
+    },
   ];
 
   // Eyes show one-pair-at-a-time (hover > attention); give the fixture's cone

--- a/packages/webapp/src/ui/wc/wc-workbench.ts
+++ b/packages/webapp/src/ui/wc/wc-workbench.ts
@@ -35,8 +35,20 @@ async function dirChildren(
   const files = entries
     .filter((e) => e.type === 'file')
     .sort((a, b) => a.name.localeCompare(b.name));
+
+  const capped = [...dirs, ...files].slice(0, MAX_ENTRIES_PER_DIR);
+
+  // Stat all files in parallel; failures degrade gracefully to no size.
+  const filePaths = capped.filter((e) => e.type === 'file').map((e) => `${dir}/${e.name}`);
+  const stats = await Promise.allSettled(filePaths.map((p) => fs.stat(p)));
+  const sizeMap = new Map<string, number>();
+  filePaths.forEach((p, i) => {
+    const r = stats[i];
+    if (r?.status === 'fulfilled') sizeMap.set(p, r.value.size);
+  });
+
   const items: FileTreeItem[] = [];
-  for (const entry of [...dirs, ...files].slice(0, MAX_ENTRIES_PER_DIR)) {
+  for (const entry of capped) {
     const path = `${dir}/${entry.name}`;
     if (entry.type === 'directory') {
       items.push({
@@ -47,21 +59,28 @@ async function dirChildren(
         children: depth < MAX_DEPTH ? await dirChildren(fs, path, depth + 1) : [],
       });
     } else {
-      items.push({ kind: 'file', id: path, label: entry.name, path });
+      const size = sizeMap.get(path);
+      items.push({ kind: 'file', id: path, label: entry.name, path, size });
     }
   }
   return items;
 }
 
 /**
- * Build `<slicc-file-tree>` items for the VFS workbench roots: one group per
- * root with its (depth-capped) directory tree underneath.
+ * Build `<slicc-file-tree>` items for the VFS workbench roots: each root is
+ * rendered as an expanded `dir` item so it looks and behaves like any other
+ * folder (chevron, collapsible, consistent icon).
  */
 export async function buildVfsTreeItems(fs: LocalVfsClient): Promise<FileTreeItem[]> {
   const items: FileTreeItem[] = [];
   for (const root of TREE_ROOTS) {
-    items.push({ kind: 'group', label: `${root.slice(1)}/` });
-    items.push(...(await dirChildren(fs, root, 1)));
+    items.push({
+      kind: 'dir',
+      id: root,
+      label: root.slice(1), // 'workspace' | 'shared'
+      open: true,
+      children: await dirChildren(fs, root, 1),
+    });
   }
   return items;
 }
@@ -75,27 +94,59 @@ export interface WcWorkbenchDeps {
   openFs(): Promise<LocalVfsClient>;
   /** Mounts the worker-shell terminal into the surface; resolves on attach. */
   mountTerminal(container: HTMLElement): Promise<void>;
+  /**
+   * Fires `fn` once the kernel's VfsRpcHost is attached (immediately if it
+   * already is). Used to avoid sending VFS RPCs before the worker is ready,
+   * which would cause them to hang until the timer rescues them.
+   */
+  onKernelReady(fn: () => void): void;
   log: { error(message: string, ...data: unknown[]): void };
 }
 
 /**
  * Lazy workbench activation: the file tree and memory rows populate on
  * (re-)activation of their surfaces; the terminal mounts once on first
- * `term` activation. Returns the activation handler so callers wire it to
+ * `term` activation. The file tree also auto-refreshes every 3 s while
+ * its surface is active. Returns the activation handler so callers wire it to
  * dock/tab selection.
  */
 export function createWorkbenchActivator(deps: WcWorkbenchDeps): (surfaceId: string) => void {
   let terminalMounted = false;
+  let refreshTimer: ReturnType<typeof setInterval> | null = null;
+  // Tracks whether a kernel-ready callback is still pending for the files surface.
+  // Cleared by stopRefresh so that switching away cancels a pre-ready activation.
+  let refreshPending = false;
+
+  const refreshFileTree = (): void => {
+    void deps
+      .openFs()
+      .then(async (fs) => {
+        deps.fileTree.items = await buildVfsTreeItems(fs);
+      })
+      .catch((err) => deps.log.error('WC file tree refresh failed', err));
+  };
+
+  const stopRefresh = (): void => {
+    refreshPending = false;
+    if (refreshTimer != null) {
+      clearInterval(refreshTimer);
+      refreshTimer = null;
+    }
+  };
+
   return (surfaceId: string): void => {
     if (surfaceId === 'files') {
-      void deps
-        .openFs()
-        .then(async (fs) => {
-          deps.fileTree.items = await buildVfsTreeItems(fs);
-        })
-        .catch((err) => deps.log.error('WC file tree refresh failed', err));
+      stopRefresh();
+      refreshPending = true;
+      deps.onKernelReady(() => {
+        if (!refreshPending) return; // surface was deactivated before kernel ready
+        refreshPending = false;
+        refreshFileTree();
+        refreshTimer = setInterval(refreshFileTree, 3000);
+      });
       return;
     }
+    stopRefresh();
     if (surfaceId === 'memory') {
       void deps
         .openFs()

--- a/packages/webapp/tests/ui/wc/wc-boot.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-boot.test.ts
@@ -296,12 +296,16 @@ describe('URL state sync (live boot)', () => {
     boot.refs.workbenchBody.setAttribute('active', 'files');
     const activate = vi.fn();
     boot.setActivateSurface(activate);
+    // The re-fire is gated behind kernel ready (VFS RPCs need the worker).
+    expect(activate).not.toHaveBeenCalled();
+    boot.wiring.notifyReady?.();
     expect(activate).toHaveBeenCalledWith('files');
 
     // Without a restored surface the assignment stays passive.
     boot.refs.shell.removeAttribute('open');
     const idle = vi.fn();
     boot.setActivateSurface(idle);
+    boot.wiring.notifyReady?.();
     expect(idle).not.toHaveBeenCalled();
   });
 

--- a/packages/webapp/tests/ui/wc/wc-workbench.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-workbench.test.ts
@@ -26,43 +26,64 @@ async function seededFs(): Promise<VirtualFS> {
 }
 
 describe('buildVfsTreeItems', () => {
-  it('maps the workspace and shared roots into groups, dirs, and files', async () => {
+  it('maps the workspace and shared roots into expanded dir items', async () => {
     const fs = await seededFs();
     const items = await buildVfsTreeItems(fs);
 
-    const groups = items.filter((i) => i.kind === 'group').map((i) => i.label);
-    expect(groups).toEqual(['workspace/', 'shared/']);
+    // Roots are now dir items (open by default), not group headers.
+    const roots = items.filter((i) => i.kind === 'dir').map((i) => i.id);
+    expect(roots).toEqual(['/workspace', '/shared']);
+    const wsRoot = items.find((i) => i.kind === 'dir' && i.id === '/workspace');
+    expect(wsRoot?.kind === 'dir' && wsRoot.open).toBe(true);
+    expect(wsRoot?.kind === 'dir' && wsRoot.label).toBe('workspace');
 
-    const skillsDir = items.find((i) => i.kind === 'dir' && i.id === '/workspace/skills');
+    // Children are nested inside the root dir.
+    const wsChildren = wsRoot?.kind === 'dir' ? wsRoot.children : [];
+    const skillsDir = wsChildren.find((c) => c.kind === 'dir' && c.id === '/workspace/skills');
     expect(skillsDir).toBeTruthy();
-    // Directory rows show the bare name — the chevron already marks them as
-    // folders, so no trailing slash (only the root group headers keep it).
     expect(skillsDir?.kind === 'dir' && skillsDir.label).toBe('skills');
     expect(
       skillsDir?.kind === 'dir' &&
         skillsDir.children.some((c) => c.kind === 'file' && c.id === '/workspace/skills/SKILL.md')
     ).toBe(true);
 
-    expect(items.some((i) => i.kind === 'file' && i.id === '/workspace/CLAUDE.md')).toBe(true);
-    expect(items.some((i) => i.kind === 'file' && i.id === '/shared/notes.txt')).toBe(true);
+    expect(wsChildren.some((i) => i.kind === 'file' && i.id === '/workspace/CLAUDE.md')).toBe(true);
+    const sharedRoot = items.find((i) => i.kind === 'dir' && i.id === '/shared');
+    const sharedChildren = sharedRoot?.kind === 'dir' ? sharedRoot.children : [];
+    expect(sharedChildren.some((i) => i.kind === 'file' && i.id === '/shared/notes.txt')).toBe(
+      true
+    );
   });
 
   it('lists directories before files, alphabetically', async () => {
     const fs = await seededFs();
     await fs.writeFile('/workspace/aaa.txt', 'x');
     const items = await buildVfsTreeItems(fs);
-    const workspaceIds = items
-      .filter((i) => i.kind !== 'group' && 'id' in i && i.id.startsWith('/workspace'))
-      .map((i) => ('id' in i ? i.id : ''));
-    expect(workspaceIds.indexOf('/workspace/skills')).toBeLessThan(
-      workspaceIds.indexOf('/workspace/aaa.txt')
+    const wsRoot = items.find((i) => i.kind === 'dir' && i.id === '/workspace');
+    const children = wsRoot?.kind === 'dir' ? wsRoot.children : [];
+    const childIds = children.filter((c) => 'id' in c).map((c) => ('id' in c ? c.id : ''));
+    expect(childIds.indexOf('/workspace/skills')).toBeLessThan(
+      childIds.indexOf('/workspace/aaa.txt')
     );
   });
 
   it('survives missing roots', async () => {
     const fs = await VirtualFS.create({ dbName: `wc-empty-${Math.random()}`, wipe: true });
     const items = await buildVfsTreeItems(fs);
-    expect(items.filter((i) => i.kind === 'group')).toHaveLength(2);
+    // Still emits both root dir items, each with empty children.
+    expect(items.filter((i) => i.kind === 'dir')).toHaveLength(2);
+  });
+
+  it('includes a size field on file items', async () => {
+    const fs = await seededFs();
+    const items = await buildVfsTreeItems(fs);
+    const wsRoot = items.find((i) => i.kind === 'dir' && i.id === '/workspace');
+    const wsChildren = wsRoot?.kind === 'dir' ? wsRoot.children : [];
+    const claudeMd = wsChildren.find((i) => i.kind === 'file' && i.id === '/workspace/CLAUDE.md');
+    expect(claudeMd?.kind).toBe('file');
+    // size comes from stat(); the content is '# memory' (9 bytes).
+    expect(claudeMd?.kind === 'file' && typeof claudeMd.size).toBe('number');
+    expect(claudeMd?.kind === 'file' && (claudeMd.size ?? 0) > 0).toBe(true);
   });
 });
 
@@ -72,8 +93,11 @@ describe('createWorkbenchActivator', () => {
     return {
       fileTree,
       termSurface: document.createElement('div'),
+      memoryHost: document.createElement('div'),
       openFs: vi.fn(async () => await seededFs()),
       mountTerminal: vi.fn(async () => undefined),
+      // In tests the "kernel" is always ready — fire the callback immediately.
+      onKernelReady: vi.fn((fn: () => void) => fn()),
       log: { error: vi.fn() },
     };
   }
@@ -115,5 +139,30 @@ describe('createWorkbenchActivator', () => {
     const activate = createWorkbenchActivator(deps);
     activate('files');
     await vi.waitFor(() => expect(deps.log.error).toHaveBeenCalled());
+  });
+
+  it('polls the file tree every 3 s while files surface is active', async () => {
+    vi.useFakeTimers();
+    const deps = makeDeps();
+    const activate = createWorkbenchActivator(deps);
+    activate('files');
+    // Advance past the first tick and let promises settle
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(deps.openFs.mock.calls.length).toBeGreaterThanOrEqual(2);
+    vi.useRealTimers();
+  });
+
+  it('stops polling when another surface is activated', async () => {
+    vi.useFakeTimers();
+    const deps = makeDeps();
+    const activate = createWorkbenchActivator(deps);
+    activate('files');
+    await vi.advanceTimersByTimeAsync(0);
+    const callsAfterFirst = deps.openFs.mock.calls.length;
+    activate('term');
+    await vi.advanceTimersByTimeAsync(6000);
+    // No additional openFs calls after switching away from files
+    expect(deps.openFs.mock.calls.length).toBe(callsAfterFirst);
+    vi.useRealTimers();
   });
 });

--- a/packages/webcomponents/src/workbench/slicc-file-tree.stories.ts
+++ b/packages/webcomponents/src/workbench/slicc-file-tree.stories.ts
@@ -21,8 +21,20 @@ const PROTOTYPE_ITEMS: FileTreeItem[] = [
     label: 'components',
     open: true,
     children: [
-      { kind: 'file', id: 'hero.tsx', label: 'hero.tsx', path: 'workspace/components/hero.tsx' },
-      { kind: 'file', id: 'hero.css', label: 'hero.css', path: 'workspace/components/hero.css' },
+      {
+        kind: 'file',
+        id: 'hero.tsx',
+        label: 'hero.tsx',
+        path: 'workspace/components/hero.tsx',
+        size: 3412,
+      },
+      {
+        kind: 'file',
+        id: 'hero.css',
+        label: 'hero.css',
+        path: 'workspace/components/hero.css',
+        size: 1842,
+      },
       {
         kind: 'dir',
         id: 'ui',

--- a/packages/webcomponents/src/workbench/slicc-file-tree.stories.ts
+++ b/packages/webcomponents/src/workbench/slicc-file-tree.stories.ts
@@ -128,3 +128,112 @@ export const ActiveFile: Story = { args: { selected: 'hero.css' } };
  * file row stays selected, preserving the existing selection behavior.
  */
 export const DirectorySelected: Story = { args: { selected: 'sprinkles/' } };
+
+/**
+ * Production VFS panel layout: `workspace` and `shared` are collapsible `dir`
+ * items (open by default) rather than flat `group` headers. Files carry a `size`
+ * field that renders as a dimmed badge on the right. This matches exactly what
+ * `buildVfsTreeItems` produces in the live workbench.
+ *
+ * Click a chevron to collapse a root dir — the tree remembers the state across
+ * re-renders (the `items` setter only seeds from `open:true` flags on the very
+ * first assignment; subsequent refreshes leave user toggles untouched).
+ */
+export const VfsPanel: Story = {
+  args: {},
+  render: () => {
+    const VFS_ITEMS: FileTreeItem[] = [
+      {
+        kind: 'dir',
+        id: '/workspace',
+        label: 'workspace',
+        open: true,
+        children: [
+          {
+            kind: 'dir',
+            id: '/workspace/skills',
+            label: 'skills',
+            children: [
+              {
+                kind: 'file',
+                id: '/workspace/skills/SKILL.md',
+                label: 'SKILL.md',
+                path: '/workspace/skills/SKILL.md',
+                size: 4210,
+              },
+            ],
+          },
+          {
+            kind: 'file',
+            id: '/workspace/CLAUDE.md',
+            label: 'CLAUDE.md',
+            path: '/workspace/CLAUDE.md',
+            size: 872,
+          },
+          {
+            kind: 'file',
+            id: '/workspace/tokens.css',
+            label: 'tokens.css',
+            path: '/workspace/tokens.css',
+            size: 3412,
+          },
+        ],
+      },
+      {
+        kind: 'dir',
+        id: '/shared',
+        label: 'shared',
+        open: true,
+        children: [
+          {
+            kind: 'dir',
+            id: '/shared/sprinkles',
+            label: 'sprinkles',
+            children: [
+              {
+                kind: 'file',
+                id: '/shared/sprinkles/welcome.shtml',
+                label: 'welcome.shtml',
+                path: '/shared/sprinkles/welcome.shtml',
+                size: 1540,
+              },
+            ],
+          },
+          {
+            kind: 'file',
+            id: '/shared/CLAUDE.md',
+            label: 'CLAUDE.md',
+            path: '/shared/CLAUDE.md',
+            size: 2980,
+          },
+        ],
+      },
+    ];
+
+    const wrap = document.createElement('div');
+    wrap.style.cssText =
+      'display:flex;align-items:stretch;height:320px;font-family:var(--ui);color:var(--ink);background:var(--canvas);';
+
+    const tree = document.createElement('slicc-file-tree') as SliccFileTree;
+    tree.style.cssText = 'width:100%;border-right:none;';
+    tree.items = VFS_ITEMS;
+
+    const status = document.createElement('div');
+    status.style.cssText =
+      'position:absolute;bottom:8px;left:50%;transform:translateX(-50%);font-size:11px;color:var(--txt-3);white-space:nowrap;';
+    status.textContent = 'click a file to select · click a chevron to collapse';
+
+    tree.addEventListener('file-select', (e) => {
+      const { id } = (e as CustomEvent<{ id: string }>).detail;
+      status.textContent = `selected: ${id}`;
+    });
+    tree.addEventListener('dir-toggle', (e) => {
+      const { id, open } = (e as CustomEvent<{ id: string; open: boolean }>).detail;
+      status.textContent = `${id} ${open ? 'expanded' : 'collapsed'}`;
+    });
+
+    wrap.style.position = 'relative';
+    wrap.append(tree, status);
+    return wrap;
+  },
+};

--- a/packages/webcomponents/src/workbench/slicc-file-tree.ts
+++ b/packages/webcomponents/src/workbench/slicc-file-tree.ts
@@ -16,7 +16,15 @@ import { iconEl } from '../internal/icons.js';
 export type FileTreeItem =
   | { kind: 'group'; label: string }
   | { kind: 'dir'; id: string; label: string; open?: boolean; children: FileTreeItem[] }
-  | { kind: 'file'; id: string; label: string; path?: string };
+  | { kind: 'file'; id: string; label: string; path?: string; size?: number };
+
+/** Human-readable byte size (B / K / M / G). */
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + 'K';
+  if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + 'M';
+  return (bytes / (1024 * 1024 * 1024)).toFixed(1) + 'G';
+}
 
 /**
  * Scoped, document-level stylesheet for `<slicc-file-tree>`. A light-DOM
@@ -44,25 +52,30 @@ slicc-file-tree {
   display: block;
   border-right: 1px solid var(--line);
   overflow: auto;
-  padding: 10px 8px;
+  padding: 6px 4px;
   font-family: var(--ui);
-  font-size: 12px;
+  font-size: 13px;
 }
 slicc-file-tree .grp {
   color: var(--txt-3);
-  padding: 5px 8px 3px;
+  padding: 10px 8px 3px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
-slicc-file-tree .grp + .grp {
-  margin-top: 8px;
+slicc-file-tree .grp:first-child {
+  padding-top: 4px;
 }
 slicc-file-tree .f {
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 4px 8px;
-  border-radius: 7px;
+  gap: 5px;
+  padding: 3px 8px;
+  border-radius: 5px;
   color: var(--ink);
   cursor: pointer;
+  transition: background 0.1s ease;
 }
 slicc-file-tree .f:hover {
   background: var(--ghost);
@@ -70,27 +83,25 @@ slicc-file-tree .f:hover {
 slicc-file-tree .f.on {
   background: color-mix(in srgb, var(--violet) 10%, var(--canvas));
   color: var(--violet);
+  box-shadow: inset 2px 0 0 var(--violet);
 }
-slicc-file-tree .f::before {
-  content: "";
-  width: 5px;
-  height: 5px;
+slicc-file-tree .f .ficon {
   flex: 0 0 auto;
-  border-radius: 1px;
-  background: var(--txt-3);
+  color: var(--txt-3);
 }
-slicc-file-tree .f.on::before {
-  background: var(--violet);
+slicc-file-tree .f.on .ficon {
+  color: var(--violet);
 }
 slicc-file-tree .dir {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  border-radius: 7px;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 5px;
   color: var(--ink);
   cursor: pointer;
   user-select: none;
+  transition: background 0.1s ease;
 }
 slicc-file-tree .dir:hover {
   background: var(--ghost);
@@ -98,7 +109,7 @@ slicc-file-tree .dir:hover {
 slicc-file-tree .dir .chev {
   flex: 0 0 auto;
   color: var(--txt-3);
-  transition: transform 0.12s ease;
+  transition: transform 0.15s ease;
 }
 slicc-file-tree .dir.open .chev {
   transform: rotate(90deg);
@@ -108,6 +119,13 @@ slicc-file-tree .children {
 }
 slicc-file-tree .children[hidden] {
   display: none;
+}
+slicc-file-tree .f .sz {
+  margin-left: auto;
+  color: var(--txt-3);
+  font-size: 10px;
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 
 .dark slicc-file-tree .f.on,
@@ -157,7 +175,14 @@ function buildNodes(items: readonly FileTreeItem[], openDirs: ReadonlySet<string
       append(wrap, buildNodes(item.children ?? [], openDirs));
       rows.push(wrap);
     } else {
-      rows.push(h('div', { class: 'f', 'data-id': item.id }, item.label));
+      const row = h(
+        'div',
+        { class: 'f', 'data-id': item.id },
+        iconEl('file-text', { size: 12, class: 'ficon' }),
+        item.label
+      );
+      if (item.size != null) row.appendChild(h('span', { class: 'sz' }, formatSize(item.size)));
+      rows.push(row);
     }
   }
   return rows;
@@ -242,9 +267,10 @@ export class SliccFileTree extends HTMLElement {
   }
 
   set items(value: FileTreeItem[]) {
+    const first = !this.#initialized;
     this.#items = Array.isArray(value) ? value.slice() : [];
     this.#initialized = true;
-    this.#seedOpenDirs();
+    this.#seedOpenDirs(first);
     if (this.isConnected) {
       this.#render();
       this.#bindClick();
@@ -351,9 +377,14 @@ export class SliccFileTree extends HTMLElement {
     }
   }
 
-  /** Re-seed the open-dir set from the items' `open` flags (collapsed default). */
-  #seedOpenDirs(): void {
-    this.#openDirs.clear();
+  /**
+   * Seed the open-dir set from the items' `open` flags.
+   * On the first assignment (first=true) clears the set first so `open` flags
+   * are authoritative. On subsequent assignments (refresh) preserves dirs the
+   * user already expanded, and unions in any new `open:true` dirs.
+   */
+  #seedOpenDirs(first = true): void {
+    if (first) this.#openDirs.clear();
     const walk = (items: readonly FileTreeItem[]): void => {
       for (const item of items) {
         if (item.kind !== 'dir') continue;

--- a/packages/webcomponents/src/workbench/slicc-file-tree.ts
+++ b/packages/webcomponents/src/workbench/slicc-file-tree.ts
@@ -270,7 +270,10 @@ export class SliccFileTree extends HTMLElement {
     const first = !this.#initialized;
     this.#items = Array.isArray(value) ? value.slice() : [];
     this.#initialized = true;
-    this.#seedOpenDirs(first);
+    // Only seed open dirs from item.open flags on the very first assignment.
+    // Subsequent refreshes must not touch #openDirs — doing so would re-open
+    // any dir the user manually collapsed (the roots always carry open:true).
+    if (first) this.#seedOpenDirs();
     if (this.isConnected) {
       this.#render();
       this.#bindClick();
@@ -377,14 +380,9 @@ export class SliccFileTree extends HTMLElement {
     }
   }
 
-  /**
-   * Seed the open-dir set from the items' `open` flags.
-   * On the first assignment (first=true) clears the set first so `open` flags
-   * are authoritative. On subsequent assignments (refresh) preserves dirs the
-   * user already expanded, and unions in any new `open:true` dirs.
-   */
-  #seedOpenDirs(first = true): void {
-    if (first) this.#openDirs.clear();
+  /** Seed the open-dir set from the items' `open` flags (first assignment only). */
+  #seedOpenDirs(): void {
+    this.#openDirs.clear();
     const walk = (items: readonly FileTreeItem[]): void => {
       for (const item of items) {
         if (item.kind !== 'dir') continue;

--- a/packages/webcomponents/tests/workbench/slicc-file-tree.test.ts
+++ b/packages/webcomponents/tests/workbench/slicc-file-tree.test.ts
@@ -174,6 +174,23 @@ describe('slicc-file-tree', () => {
       document.body.appendChild(el);
       expect(el.isDirOpen('lib')).toBe(true);
     });
+
+    it('user-collapsed dir (open:true in items) stays collapsed after refresh', () => {
+      // Regression for: 3s refresh re-opens dirs the user manually collapsed.
+      // buildVfsTreeItems always emits root dirs with open:true, so the
+      // old union logic would re-add a collapsed root on every refresh.
+      const el = document.createElement('slicc-file-tree') as SliccFileTree;
+      el.items = [{ kind: 'dir', id: 'workspace', label: 'workspace', open: true, children: [] }];
+      document.body.appendChild(el);
+      expect(el.isDirOpen('workspace')).toBe(true);
+      // User collapses the dir
+      el.toggleDir('workspace');
+      expect(el.isDirOpen('workspace')).toBe(false);
+      // Simulate a refresh: re-assign items, still carrying open:true
+      el.items = [{ kind: 'dir', id: 'workspace', label: 'workspace', open: true, children: [] }];
+      // Must stay collapsed — the refresh must not undo the user's toggle
+      expect(el.isDirOpen('workspace')).toBe(false);
+    });
   });
 
   describe('selected attribute ↔ property reflection', () => {

--- a/packages/webcomponents/tests/workbench/slicc-file-tree.test.ts
+++ b/packages/webcomponents/tests/workbench/slicc-file-tree.test.ts
@@ -104,6 +104,78 @@ describe('slicc-file-tree', () => {
     });
   });
 
+  describe('file size display', () => {
+    it('renders a .sz span when the file item has a size', () => {
+      const el = makeTree([{ kind: 'file', id: 'big.zip', label: 'big.zip', size: 1536 }]);
+      document.body.appendChild(el);
+      const sz = fileRow(el, 'big.zip')?.querySelector('.sz');
+      expect(sz?.textContent).toBe('1.5K');
+    });
+
+    it('formats sizes across B / K / M / G boundaries', () => {
+      const el = makeTree([
+        { kind: 'file', id: 'b', label: 'b', size: 512 },
+        { kind: 'file', id: 'k', label: 'k', size: 1024 },
+        { kind: 'file', id: 'm', label: 'm', size: 1024 * 1024 },
+        { kind: 'file', id: 'g', label: 'g', size: 1024 * 1024 * 1024 },
+      ]);
+      document.body.appendChild(el);
+      expect(fileRow(el, 'b')?.querySelector('.sz')?.textContent).toBe('512 B');
+      expect(fileRow(el, 'k')?.querySelector('.sz')?.textContent).toBe('1.0K');
+      expect(fileRow(el, 'm')?.querySelector('.sz')?.textContent).toBe('1.0M');
+      expect(fileRow(el, 'g')?.querySelector('.sz')?.textContent).toBe('1.0G');
+    });
+
+    it('omits .sz when size is not provided', () => {
+      const el = makeTree([{ kind: 'file', id: 'no-size.ts', label: 'no-size.ts' }]);
+      document.body.appendChild(el);
+      expect(fileRow(el, 'no-size.ts')?.querySelector('.sz')).toBeNull();
+    });
+  });
+
+  describe('open-dir preservation across refresh', () => {
+    it('preserves user-expanded dirs when items is re-assigned', () => {
+      const el = makeTree([
+        {
+          kind: 'dir',
+          id: 'src',
+          label: 'src',
+          children: [{ kind: 'file', id: 'a.ts', label: 'a.ts' }],
+        },
+      ]);
+      document.body.appendChild(el);
+      el.toggleDir('src');
+      expect(el.isDirOpen('src')).toBe(true);
+      el.items = [
+        {
+          kind: 'dir',
+          id: 'src',
+          label: 'src',
+          children: [
+            { kind: 'file', id: 'a.ts', label: 'a.ts' },
+            { kind: 'file', id: 'b.ts', label: 'b.ts' },
+          ],
+        },
+      ];
+      expect(el.isDirOpen('src')).toBe(true);
+    });
+
+    it('seeds open dirs from item.open on the first assignment', () => {
+      const el = document.createElement('slicc-file-tree') as SliccFileTree;
+      el.items = [
+        {
+          kind: 'dir',
+          id: 'lib',
+          label: 'lib',
+          open: true,
+          children: [],
+        },
+      ];
+      document.body.appendChild(el);
+      expect(el.isDirOpen('lib')).toBe(true);
+    });
+  });
+
   describe('selected attribute ↔ property reflection', () => {
     it('reflects the selected property to the attribute and back', () => {
       const el = makeTree();
@@ -385,27 +457,28 @@ describe('slicc-file-tree', () => {
       expect(getComputedStyle(fileRow(el, 'hero.tsx') as HTMLElement).color).toBe(rgb('#0a0a0a'));
     });
 
-    it('tints the active row violet (text + bullet) in light mode', () => {
+    it('tints the active row violet (text + icon) in light mode', () => {
       const el = makeTree();
       el.selected = 'hero.css';
       document.body.appendChild(el);
       const row = fileRow(el, 'hero.css') as HTMLElement;
       // light --violet === #8b5cf6
       expect(getComputedStyle(row).color).toBe(rgb('#8b5cf6'));
-      const bullet = getComputedStyle(row, '::before');
-      expect(bullet.backgroundColor).toBe(rgb('#8b5cf6'));
+      // icon inherits the violet tint via .f.on .ficon rule
+      const icon = row.querySelector<HTMLElement>('.ficon');
+      expect(icon).not.toBeNull();
+      expect(getComputedStyle(icon as HTMLElement).color).toBe(rgb('#8b5cf6'));
       // active background is a violet/canvas mix, distinct from the idle row.
       const idle = getComputedStyle(fileRow(el, 'hero.tsx') as HTMLElement).backgroundColor;
       expect(getComputedStyle(row).backgroundColor).not.toBe(idle);
     });
 
-    it('renders the 5x5 bullet on every file row', () => {
+    it('renders a file icon on every file row', () => {
       const el = makeTree();
       document.body.appendChild(el);
-      const bullet = getComputedStyle(fileRow(el, 'hero.tsx') as HTMLElement, '::before');
-      expect(bullet.width).toBe('5px');
-      expect(bullet.height).toBe('5px');
-      expect(bullet.backgroundColor).toBe(rgb('#a1a1a1'));
+      const icon = fileRow(el, 'hero.tsx')?.querySelector('.ficon');
+      expect(icon).not.toBeNull();
+      expect(icon?.tagName.toLowerCase()).toBe('svg');
     });
 
     it('re-bases the active tint over --canvas in dark mode', () => {


### PR DESCRIPTION


https://github.com/user-attachments/assets/00c28260-c0a9-42e7-a1e3-e2dedd264a29



## Summary

- Restores five features lost in the WC refactor: file sizes (via `stat()`), hover action buttons (CAT/DL for files, ZIP for dirs), auto-refresh polling, Cmd/Ctrl+C copy-path with flash feedback, and open-dir state preservation across refreshes
- Root dirs (`/workspace`, `/shared`) now render as collapsible dir rows expanded by default — consistent with all other folders
- CAT preview gates on terminal mount and updates the dock icon on surface switch
- Auto-refresh is gated behind kernel-ready so the panel never shows empty on page reload
- Visual improvements: `file-text` icon replaces the CSS bullet, left-accent bar on selection, smooth hover transitions, uppercase section labels, 13px body / 11px label font sizes

## Test plan

- [ ] Open Files panel — file sizes appear next to each filename
- [ ] Hover a file → CAT + DL buttons appear; CAT previews in terminal, DL downloads the file
- [ ] Hover a dir → ZIP button appears; clicking downloads a zip of that directory
- [ ] Select a file, press Cmd/Ctrl+C → path copied, row flashes green
- [ ] Expand a dir, wait 3s → tree refreshes without collapsing expanded dirs
- [ ] Reload with Files panel open → tree populates immediately (no empty state)
- [ ] workspace and shared render as collapsible dir rows, expanded by default
- [ ] `npm run typecheck && npm test && npm test -w @slicc/webcomponents` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)