### PR TITLE
fix(tray): surface a connected follower in the worker-side host command

### DIFF
--- a/packages/webapp/src/scoops/tray-follower-status.ts
+++ b/packages/webapp/src/scoops/tray-follower-status.ts
@@ -42,6 +42,46 @@ export function getFollowerTrayRuntimeStatus(): FollowerTrayRuntimeStatus {
   return { ...followerTrayRuntimeStatus };
 }
 
+/**
+ * Key for the page→worker `localStorage` shim mirroring the follower tray
+ * status. `wc-tray.ts` writes this on every `subscribeToFollowerTrayRuntimeStatus`
+ * tick (and seeds it on boot); `installPageStorageSync` forwards the write into
+ * the kernel worker's Map-backed `localStorage` shim so worker readers see it.
+ * Symmetric with `LEADER_STATUS_STORAGE_KEY` in `tray-leader.ts`.
+ */
+export const FOLLOWER_STATUS_STORAGE_KEY = 'slicc.followerTrayStatus';
+
+/**
+ * Follower tray status with a `localStorage` fallback for the standalone
+ * kernel-worker thread. The worker never runs the `FollowerSyncManager`
+ * (it lives on the page), so the worker's module global is permanently
+ * `inactive`. When it is, read the shim value that `wc-tray.ts` keeps
+ * current. Extension/offscreen mode keeps the module global as the source
+ * of truth because the offscreen runs the manager there (the page mirror
+ * pushes a non-inactive global, so the fallback is never consulted).
+ *
+ * Mirror of `getLeaderStatusWithFallback`. The worker-side `host` command
+ * reads this so it reports `status: follower (connected)` while following,
+ * instead of falling through to the leader path and printing
+ * `status: inactive`.
+ */
+export function getFollowerStatusWithFallback(): FollowerTrayRuntimeStatus {
+  const moduleStatus = getFollowerTrayRuntimeStatus();
+  if (moduleStatus.state !== 'inactive') return moduleStatus;
+  try {
+    const stored = (globalThis as { localStorage?: Storage }).localStorage?.getItem(
+      FOLLOWER_STATUS_STORAGE_KEY
+    );
+    if (stored) {
+      const parsed = JSON.parse(stored) as FollowerTrayRuntimeStatus;
+      if (parsed?.state && parsed.state !== 'inactive') return parsed;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return moduleStatus;
+}
+
 type FollowerTrayRuntimeStatusListener = (status: FollowerTrayRuntimeStatus) => void;
 const followerTrayRuntimeStatusListeners = new Set<FollowerTrayRuntimeStatusListener>();
 

--- a/packages/webapp/src/shell/supplemental-commands/host-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/host-command.ts
@@ -3,6 +3,7 @@ import { defineCommand } from 'just-bash';
 import { getPanelRpcClient } from '../../kernel/panel-rpc.js';
 import {
   type FollowerTrayRuntimeStatus,
+  getFollowerStatusWithFallback,
   getFollowerTrayRuntimeStatus,
 } from '../../scoops/tray-follower-status.js';
 import { joinTray as defaultJoinTray } from '../../scoops/tray-join.js';
@@ -248,7 +249,11 @@ export function formatFollowerOutput(status: FollowerTrayRuntimeStatus): string 
 
 export function createHostCommand(options: HostCommandOptions = {}): Command {
   const getStatus = options.getStatus ?? getLeaderStatusWithFallback;
-  const getFollowerSt = options.getFollowerStatus ?? getFollowerTrayRuntimeStatus;
+  // Default to the fallback-aware reader so the standalone kernel-worker `host`
+  // sees a page-side follower via the `slicc.followerTrayStatus` shim. Without
+  // it the worker's module global is permanently inactive and `host` reports
+  // `status: inactive` while the follower is connected (the b268 symptom).
+  const getFollowerSt = options.getFollowerStatus ?? getFollowerStatusWithFallback;
   const getFollowers = options.getFollowers ?? getFollowersWithFallback;
 
   return defineCommand('host', async (args) => {

--- a/packages/webapp/src/ui/page-follower-tray.ts
+++ b/packages/webapp/src/ui/page-follower-tray.ts
@@ -29,6 +29,7 @@ import type { BrowserAPI } from '../cdp/browser-api.js';
 import type { MessageAttachment } from '../core/attachments.js';
 import { createLogger } from '../core/logger.js';
 import { ThrottledErrorTracker } from '../scoops/throttled-error-tracker.js';
+import { setFollowerTrayRuntimeStatus } from '../scoops/tray-follower-status.js';
 import { FollowerSyncManager } from '../scoops/tray-follower-sync.js';
 import type { SprinkleSummary } from '../scoops/tray-sync-protocol.js';
 import { CHERRY_RUNTIME_TAG, type RemoteTargetInfo } from '../scoops/tray-sync-protocol.js';
@@ -350,6 +351,27 @@ export function startPageFollowerTray(
       detachSync();
       reconnectHandle?.cancel();
       reconnectHandle = null;
+      // Force the follower runtime status to inactive on teardown. When a
+      // reconnect loop has already given up, `activeManager` is null, so the
+      // `cancel()` above is a no-op and the page-side status lingers at
+      // `error`. That status is mirrored to the `slicc.followerTrayStatus`
+      // shim, so without this reset the worker-side `host` would report a
+      // phantom `status: follower (error)` after a `host leave` or a switch to
+      // leading. `stop()` is the teardown boundary, so clearing here is
+      // unconditional and idempotent (a live manager's own stop() also sets
+      // inactive; this just guarantees it for the gave-up path too).
+      setFollowerTrayRuntimeStatus({
+        state: 'inactive',
+        joinUrl: null,
+        trayId: null,
+        error: null,
+        lastPingTime: null,
+        reconnectAttempts: 0,
+        attachAttempts: 0,
+        lastAttachCode: null,
+        connectingSince: null,
+        lastError: null,
+      });
     },
     get currentSync() {
       return activeSync;

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -11,6 +11,11 @@ import type { BrowserAPI, CDPTransport } from '../../cdp/index.js';
 import { type PanelRpcPushMsg, panelRpcChannelName } from '../../kernel/panel-rpc.js';
 import type { LickEvent } from '../../scoops/lick-manager.js';
 import {
+  FOLLOWER_STATUS_STORAGE_KEY,
+  getFollowerTrayRuntimeStatus,
+  subscribeToFollowerTrayRuntimeStatus,
+} from '../../scoops/tray-follower-status.js';
+import {
   getLeaderTrayRuntimeStatus,
   subscribeToLeaderTrayRuntimeStatus,
 } from '../../scoops/tray-leader.js';
@@ -402,6 +407,21 @@ export async function wireWcTray(deps: WcTrayDeps): Promise<WcTrayHandle> {
     win.localStorage.setItem('slicc.leaderTrayStatus', JSON.stringify(status));
   });
   win.localStorage.setItem('slicc.leaderTrayStatus', JSON.stringify(getLeaderTrayRuntimeStatus()));
+  // Mirror the follower status the same way the leader status is mirrored.
+  // The standalone kernel worker runs the `host` command but never runs the
+  // FollowerSyncManager (it lives here on the page), so without this shim the
+  // worker's follower global is permanently inactive and `host` reports
+  // `status: inactive` while genuinely following. `installPageStorageSync`
+  // forwards these writes into the worker's localStorage shim, where
+  // `getFollowerStatusWithFallback` reads them. Seed on boot so a stale value
+  // from a prior session can't fake a connection.
+  subscribeToFollowerTrayRuntimeStatus((status) => {
+    win.localStorage.setItem(FOLLOWER_STATUS_STORAGE_KEY, JSON.stringify(status));
+  });
+  win.localStorage.setItem(
+    FOLLOWER_STATUS_STORAGE_KEY,
+    JSON.stringify(getFollowerTrayRuntimeStatus())
+  );
   // Seed the follower shim on boot so a stale value from a previous session
   // can't make the worker-side `host` report phantom followers.
   writeConnectedFollowersToShim(getConnectedFollowers(), win.localStorage);

--- a/packages/webapp/tests/scoops/tray-follower-status.test.ts
+++ b/packages/webapp/tests/scoops/tray-follower-status.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  FOLLOWER_STATUS_STORAGE_KEY,
   type FollowerTrayRuntimeStatus,
+  getFollowerStatusWithFallback,
   getFollowerTrayRuntimeStatus,
   resetReconnectAttempts,
   setFollowerLastPingTime,
@@ -232,5 +234,80 @@ describe('subscribeToFollowerTrayRuntimeStatus', () => {
     expect(calls).toEqual([0, 123]);
     expect(getFollowerTrayRuntimeStatus().reconnectAttempts).toBe(0);
     unsubscribe();
+  });
+});
+
+describe('getFollowerStatusWithFallback (standalone-worker path)', () => {
+  // Symmetric to getLeaderStatusWithFallback: the standalone kernel-worker
+  // thread never runs the FollowerSyncManager (it lives on the page), so its
+  // module global is permanently `inactive`. Without this fallback the worker
+  // -side `host` command reports `status: inactive` while the page-side
+  // follower is genuinely connected — the exact b268 symptom (chat synced +
+  // screenshot worked, but `host` said inactive). The fallback reads the
+  // `slicc.followerTrayStatus` shim that `wc-tray.ts` mirrors on the page.
+  let original: Storage | undefined;
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    setFollowerTrayRuntimeStatus(makeStatus());
+    store = new Map<string, string>();
+    original = (globalThis as { localStorage?: Storage }).localStorage;
+    (globalThis as { localStorage?: Storage }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+    } as unknown as Storage;
+  });
+
+  afterEach(() => {
+    setFollowerTrayRuntimeStatus(makeStatus());
+    if (original === undefined) delete (globalThis as { localStorage?: Storage }).localStorage;
+    else (globalThis as { localStorage?: Storage }).localStorage = original;
+  });
+
+  it('reads a connected follower from the shim when the module global is inactive', () => {
+    store.set(
+      FOLLOWER_STATUS_STORAGE_KEY,
+      JSON.stringify(
+        makeStatus({
+          state: 'connected',
+          joinUrl: 'https://www.sliccy.ai/join/abc.def',
+          trayId: 'tray-xyz',
+        })
+      )
+    );
+    const status = getFollowerStatusWithFallback();
+    expect(status.state).toBe('connected');
+    expect(status.joinUrl).toBe('https://www.sliccy.ai/join/abc.def');
+    expect(status.trayId).toBe('tray-xyz');
+  });
+
+  it('prefers the module global when it is non-inactive (extension/offscreen owns it)', () => {
+    setFollowerTrayRuntimeStatus(makeStatus({ state: 'connecting', joinUrl: 'live://global' }));
+    store.set(
+      FOLLOWER_STATUS_STORAGE_KEY,
+      JSON.stringify(makeStatus({ state: 'connected', joinUrl: 'stale://shim' }))
+    );
+    const status = getFollowerStatusWithFallback();
+    expect(status.state).toBe('connecting');
+    expect(status.joinUrl).toBe('live://global');
+  });
+
+  it('returns the inactive module global when the shim is absent', () => {
+    expect(getFollowerStatusWithFallback().state).toBe('inactive');
+  });
+
+  it('ignores an inactive shim value (a seeded/cleared shim is not a follower)', () => {
+    store.set(FOLLOWER_STATUS_STORAGE_KEY, JSON.stringify(makeStatus({ state: 'inactive' })));
+    expect(getFollowerStatusWithFallback().state).toBe('inactive');
+  });
+
+  it('swallows a malformed shim value and falls back to the module global', () => {
+    store.set(FOLLOWER_STATUS_STORAGE_KEY, '{not json');
+    expect(getFollowerStatusWithFallback().state).toBe('inactive');
   });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/host-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/host-command.test.ts
@@ -493,6 +493,35 @@ describe('host command', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('status: inactive');
     });
+
+    it('reads follower status from localStorage when the module global is inactive', async () => {
+      // The b268 bug: a connected follower's status lives in the page-side
+      // module global, mirrored to `slicc.followerTrayStatus`. The worker-side
+      // `host` (default reader) must consult that shim, otherwise it falls
+      // through to the leader path and prints `status: inactive` while the
+      // follower is genuinely connected (chat synced, screenshot worked).
+      (globalThis as { localStorage?: Storage }).localStorage?.setItem(
+        'slicc.followerTrayStatus',
+        JSON.stringify({
+          state: 'connected',
+          joinUrl: 'https://www.sliccy.ai/join/abc.def',
+          trayId: 'tray-follow-1',
+          error: null,
+          lastPingTime: null,
+          reconnectAttempts: 0,
+          attachAttempts: 0,
+          lastAttachCode: null,
+          connectingSince: null,
+          lastError: null,
+        })
+      );
+
+      // No getFollowerStatus override → must default to the fallback reader.
+      const result = await createHostCommand().execute([], {} as never);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('status: follower (connected)');
+      expect(result.stdout).toContain('join_url: https://www.sliccy.ai/join/abc.def');
+    });
   });
 
   describe('host reset — panel-RPC bridge fallback (standalone-worker path)', () => {

--- a/packages/webapp/tests/ui/page-follower-tray-stop-reset.test.ts
+++ b/packages/webapp/tests/ui/page-follower-tray-stop-reset.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression: `startPageFollowerTray().stop()` must force the follower runtime
+ * status to `inactive`, even when the underlying reconnect handle's `cancel()`
+ * is a no-op.
+ *
+ * After a reconnect loop gives up (`tray-webrtc.ts` sets `state: 'error'` and
+ * nulls `activeManager`), the handle's `cancel()` does `activeManager?.stop()`
+ * — a no-op — so nothing resets the page-side follower status. That status is
+ * mirrored to the `slicc.followerTrayStatus` shim, so the worker-side `host`
+ * would keep reporting a phantom `status: follower (error)` after a `host leave`
+ * or a switch to leading. `stop()` is the teardown boundary; it must clear the
+ * status unconditionally.
+ *
+ * We mock `startFollowerWithAutoReconnect` to return a handle whose `cancel()`
+ * does nothing — the exact post-gave-up shape — and assert `stop()` still lands
+ * the status on `inactive`.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/scoops/tray-webrtc.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../src/scoops/tray-webrtc.js')>();
+  return {
+    ...actual,
+    // A reconnect handle that has already given up: cancel() is inert because
+    // its activeManager is null. This is what makes the teardown reset load-bearing.
+    startFollowerWithAutoReconnect: vi.fn(() => ({
+      cancel: vi.fn(),
+      get reconnecting() {
+        return false;
+      },
+    })),
+  };
+});
+
+import {
+  type FollowerTrayRuntimeStatus,
+  getFollowerTrayRuntimeStatus,
+  setFollowerTrayRuntimeStatus,
+} from '../../src/scoops/tray-follower-status.js';
+import {
+  type StartPageFollowerTrayOptions,
+  startPageFollowerTray,
+} from '../../src/ui/page-follower-tray.js';
+
+function inactive(): FollowerTrayRuntimeStatus {
+  return {
+    state: 'inactive',
+    joinUrl: null,
+    trayId: null,
+    error: null,
+    lastPingTime: null,
+    reconnectAttempts: 0,
+    attachAttempts: 0,
+    lastAttachCode: null,
+    connectingSince: null,
+    lastError: null,
+  };
+}
+
+function makeOptions(): StartPageFollowerTrayOptions {
+  return {
+    joinUrl: 'https://www.sliccy.ai/join/tray-1.secret',
+    onSnapshot: vi.fn(),
+    onUserMessage: vi.fn(),
+    onStatus: vi.fn(),
+    setChatAgent: vi.fn(),
+    browserAPI: {
+      setTrayTargetProvider: vi.fn(),
+      getTransport: vi.fn(),
+      listPages: vi.fn().mockResolvedValue([]),
+    } as unknown as StartPageFollowerTrayOptions['browserAPI'],
+    _fetchImpl: vi.fn<typeof fetch>().mockRejectedValue(new Error('unused — reconnect mocked')),
+    _sleep: vi.fn(() => new Promise<void>(() => {})),
+    _refreshIntervalMs: 60_000,
+  };
+}
+
+describe('startPageFollowerTray stop() clears follower status', () => {
+  afterEach(() => {
+    setFollowerTrayRuntimeStatus(inactive());
+    vi.clearAllMocks();
+  });
+
+  it('forces follower status to inactive on stop even when the reconnect gave up (cancel is a no-op)', () => {
+    const handle = startPageFollowerTray(makeOptions());
+
+    // Simulate the post-gave-up page state the failed-join reconnect leaves
+    // behind: error, with a join URL still attached.
+    setFollowerTrayRuntimeStatus({
+      ...inactive(),
+      state: 'error',
+      joinUrl: 'https://www.sliccy.ai/join/tray-1.secret',
+      trayId: 'tray-1',
+      error: 'Reconnect failed after 10 attempts',
+      reconnectAttempts: 10,
+      lastError: 'Network unreachable',
+    });
+
+    handle.stop();
+
+    expect(getFollowerTrayRuntimeStatus().state).toBe('inactive');
+    expect(getFollowerTrayRuntimeStatus().joinUrl).toBeNull();
+    expect(getFollowerTrayRuntimeStatus().error).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem (b268)

In the standalone / hosted-leader floats, `host` reported `status: inactive` / `join_url: unavailable` while the browser was **genuinely following a tray leader** — chat synced and screenshots worked, but `host` claimed nothing was connected.

## Root cause

`host` runs in the **kernel worker**, but the tray `FollowerSyncManager` runs on the **page**. The *leader* status already had a worker-side fallback (`getLeaderStatusWithFallback` reads the `slicc.leaderTrayStatus` localStorage shim the page mirrors; `installPageStorageSync` forwards page writes into the worker's shim). The *follower* status had **no equivalent**, so the worker's follower global was permanently `inactive` and `host` fell through to the leader path.

## Fix

A faithful, symmetric mirror of the proven leader path:

1. `tray-follower-status.ts` — add `FOLLOWER_STATUS_STORAGE_KEY` + `getFollowerStatusWithFallback()` (module-global wins when non-inactive, else the shim — so the extension/offscreen path, where the global is authoritative, is unaffected).
2. `wc-tray.ts` — mirror page-side follower status into the shim on every change + seed on boot (exactly as the leader status is mirrored).
3. `host-command.ts` — default the follower reader to the fallback.

A second commit closes a teardown edge: after a reconnect *gives up* (`tray-webrtc` sets `error`, `activeManager` is null → the handle's `cancel()` is a no-op), the follower status lingered at `error`. `page-follower-tray.ts` `stop()` now forces `inactive` on teardown, so a failed-join follower can't leave a stale shim that makes `host` report a phantom `follower (error)` after `host leave` or a switch to leading.

**Bonus:** the fallback also repairs `host leave` on a standalone follower — previously both leader+follower read `inactive` in the worker, so `host leave` hit the "no active tray session" no-op and never actually left.

## Result

`host` on a follower now reports `status: follower (connected)` + `join_url`.

## Verification

- **Live-confirmed** by the maintainer (the original repro).
- Reviewed against `docs/review-patterns.md` (six categories + five-runtime parity) — clean, no blockers.
- `typecheck` (all 5 targets), full suite (**9835 passing**), `lint:ci`, and the webapp build all green.
- Tests added: follower-status fallback precedence (5 cases), the worker-side `host` follower-fallback read, and a `page-follower-tray` stop-reset regression (mocks an inert-`cancel()` handle, so it fails without the teardown commit).
- **Cross-runtime parity: N/A** — entirely a webapp-internal page→worker localStorage shim. `/api/tray-status` reports *leader* status only, unchanged.

## Reviewer notes (optional, non-blocking)

The review flagged 3 optional nits left out to keep the diff focused: (a) reset module globals in the `host-command.test.ts` localStorage-fallback `beforeEach` for order-independence; (b) wrap the `wc-tray.ts` boot-seed `setItem` in try/catch (symmetric with the existing leader seed); (c) no direct unit test for the wc-tray mirror+seed (matches the existing untested-`wireWcTray` pattern; net coverage rises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)