### PR TITLE
feat(fs): bound mount index with configurable limits and distinct abort causes

### DIFF
--- a/docs/mounts.md
+++ b/docs/mounts.md
@@ -140,6 +140,35 @@ The `RemoteMountCache` (TTL + ETag, IDB-backed under `slicc-mount-cache`) sits i
 - **Writes**: existing files use `If-Match: <etag>`; new files use `If-None-Match: *` to refuse silent overwrite. A 412 from a fresh first-attempt PUT surfaces as `FsError('EBUSY', …)` so the agent's edit loop can re-read and retry. (412 inside a bounded retry window of an in-flight PUT is silently reconciled — that case means "we already won this PUT" rather than a conflict.)
 - **Mount-relative cache keys**: cached entries live under `(mountId, mountRelativePath)` so re-mounting at the same target path with a different source produces a fresh cache namespace; no aliasing.
 
+## Index bounds and skip states
+
+Each mount is indexed in the background so file discovery (`.jsh` / `.bsh` / skills) and listings are fast once ready. The walk is bounded so a pathologically deep, huge, or self-referential mount can't peg or OOM the kernel worker. When a bound is hit the index is **skipped** for that mount — reads still work through the slow per-`readDir` fallback, just without the fast index.
+
+Defaults (raised 10× in #1186):
+
+- Max directory depth: **400**
+- Max total entries: **2,000,000**
+
+Two environment variables override the defaults. Each must parse to a positive integer; a non-numeric, zero, negative, or `NaN` value is ignored — the default is used and a warning is logged.
+
+| Variable                        | Overrides           | Default     |
+| ------------------------------- | ------------------- | ----------- |
+| `SLICC_MOUNT_INDEX_MAX_DEPTH`   | max directory depth | `400`       |
+| `SLICC_MOUNT_INDEX_MAX_ENTRIES` | max total entries   | `2,000,000` |
+
+(The worker / browser float has no OS env, so the defaults always apply there; the overrides are read once at construction in CLI / Electron mode.)
+
+`mount list` renders a distinct, actionable line per skip cause:
+
+| State              | `mount list` message                                        | Meaning / remedy                                                                                                |
+| ------------------ | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `depth-exceeded`   | `index skipped: directory nesting exceeded the depth limit` | Legitimate but very deep tree. Raise `SLICC_MOUNT_INDEX_MAX_DEPTH`, or `mount unmount` it.                      |
+| `entries-exceeded` | `index skipped: mounted tree is too large`                  | Legitimate but very large tree (explicitly **not** a cycle). Raise `SLICC_MOUNT_INDEX_MAX_ENTRIES`, or unmount. |
+| `cycle-detected`   | `index skipped: self-referential mount cycle detected`      | A real, confirmed self-reference. Unmount it.                                                                   |
+| `indexing-error`   | `index error: <message>`                                    | Any other indexing failure.                                                                                     |
+
+A cycle is reported only when a cheap directory-fingerprint prefilter is confirmed by `FileSystemHandle.isSameEntry()` — a large or deep but legitimate mount is no longer mislabeled as "likely cyclic". Only `cycle-detected` means a true self-reference.
+
 ## Architecture
 
 The browser bundle never computes signatures or holds credentials. Backends construct _logical_ requests (`{method, bucket, key, body, ...}` for S3; `{method, path, body, ...}` for DA) and hand them to an injected transport. The transport routes per deployment:

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -456,14 +456,14 @@ Implementation lives outside `supplemental-commands/`: `packages/webapp/src/fs/m
 
 ### Subcommands
 
-| Form                                               | Behavior                                                                                                                                                                                                                                                         |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mount <path>`                                     | Local FS Access mount. Opens a directory picker (cone-only — fails fast in scoops, which have no UI gesture).                                                                                                                                                    |
-| `mount --source s3://<bucket>[/<prefix>] <path>`   | S3 / S3-compatible mount. Reads creds from `s3.<profile>.*` secrets (`--profile` selects the namespace; defaults to `default`). Allowed in scoops.                                                                                                               |
-| `mount --source da://<org>/<repo>[/<path>] <path>` | Adobe da.live mount. Reuses the existing Adobe provider's IMS bearer token; `--profile` is accepted for symmetry but has a single global identity in v1. Allowed in scoops.                                                                                      |
-| `mount list`                                       | Show all active mounts with their kind, source, and profile (where applicable).                                                                                                                                                                                  |
-| `mount unmount [--clear-cache] <path>`             | Tear down a mount. `--clear-cache` also drops cached listings + bodies for that mount; without it, cache entries persist until TTL or the next session.                                                                                                          |
-| `mount refresh [--bodies] <path>`                  | Re-walk the source and diff against the cache. Prints `Refreshed <path>: +<added> -<removed> ~<changed> (<unchanged> unchanged, <errors> errors)`. Without `--bodies` only the listing is rechecked; with `--bodies` changed files are conditionally re-fetched. |
+| Form                                               | Behavior                                                                                                                                                                                                                                                                                                                                                                                                |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mount <path>`                                     | Local FS Access mount. Opens a directory picker (cone-only — fails fast in scoops, which have no UI gesture).                                                                                                                                                                                                                                                                                           |
+| `mount --source s3://<bucket>[/<prefix>] <path>`   | S3 / S3-compatible mount. Reads creds from `s3.<profile>.*` secrets (`--profile` selects the namespace; defaults to `default`). Allowed in scoops.                                                                                                                                                                                                                                                      |
+| `mount --source da://<org>/<repo>[/<path>] <path>` | Adobe da.live mount. Reuses the existing Adobe provider's IMS bearer token; `--profile` is accepted for symmetry but has a single global identity in v1. Allowed in scoops.                                                                                                                                                                                                                             |
+| `mount list`                                       | List active mounts with each mount's index state: `indexed: <n> entries`, `indexing: <n> entries...`, `pending index`, or — when the index was skipped — a distinct cause line (depth-exceeded, entries-exceeded, cycle-detected, or a generic index error; see [Index bounds and skip states](#index-bounds-and-skip-states)). A skipped index still serves reads via the slow per-`readDir` fallback. |
+| `mount unmount [--clear-cache] <path>`             | Tear down a mount. `--clear-cache` also drops cached listings + bodies for that mount; without it, cache entries persist until TTL or the next session.                                                                                                                                                                                                                                                 |
+| `mount refresh [--bodies] <path>`                  | Re-walk the source and diff against the cache. Prints `Refreshed <path>: +<added> -<removed> ~<changed> (<unchanged> unchanged, <errors> errors)`. Without `--bodies` only the listing is rechecked; with `--bodies` changed files are conditionally re-fetched.                                                                                                                                        |
 
 ### Mount-time flags
 
@@ -475,6 +475,21 @@ Implementation lives outside `supplemental-commands/`: `packages/webapp/src/fs/m
 | `--max-body-mb <n>` | mount         | Override the per-mount maximum body size for read/write. Defaults: S3 25 MB, DA 5 MB. Files exceeding the threshold throw `EFBIG` before any body bytes flow.                          |
 | `--clear-cache`     | mount unmount | Drop the `RemoteMountCache` entries (listings + bodies) for this mount.                                                                                                                |
 | `--bodies`          | mount refresh | After the listing diff, conditionally re-fetch bodies for paths whose ETag changed. Without this flag a refresh is one paginated list (or one DA recursive walk) plus zero body bytes. |
+
+### Index bounds and skip states
+
+Each mount is indexed in the background for fast file discovery and listings. The walk is bounded so a deep, huge, or self-referential tree can't peg / OOM the kernel worker; hitting a bound **skips** the index (reads fall back to the slow per-`readDir` path).
+
+Defaults (raised 10× in #1186): max directory depth **400**, max total entries **2,000,000**. Two env vars override them — `SLICC_MOUNT_INDEX_MAX_DEPTH` and `SLICC_MOUNT_INDEX_MAX_ENTRIES`. Each must be a positive integer; an invalid value (non-numeric, zero, negative, or `NaN`) is ignored, falling back to the default with a logged warning. (The worker / browser float has no OS env, so defaults always apply there.)
+
+`mount list` reports the index state per mount and distinguishes four skip causes:
+
+- `index skipped: directory nesting exceeded the depth limit` — **depth-exceeded**; raise `SLICC_MOUNT_INDEX_MAX_DEPTH` or unmount.
+- `index skipped: mounted tree is too large` — **entries-exceeded** (explicitly not a cycle); raise `SLICC_MOUNT_INDEX_MAX_ENTRIES` or unmount.
+- `index skipped: self-referential mount cycle detected` — **cycle-detected**; a confirmed self-reference (directory-fingerprint prefilter + `FileSystemHandle.isSameEntry()`), unmount it.
+- `index error: <message>` — **indexing-error**; any other failure.
+
+Only a confirmed self-reference is labeled a cycle — a large or deep but legitimate mount is no longer mislabeled as "likely cyclic".
 
 ### Caching and conflict semantics
 

--- a/packages/vfs-root/workspace/skills/mount/SKILL.md
+++ b/packages/vfs-root/workspace/skills/mount/SKILL.md
@@ -103,6 +103,19 @@ mount refresh --bodies /mnt/r2     # also conditionally re-fetch changed bodies
 
 `mount refresh` prints a structured summary: `Refreshed /mnt/r2: +2 -1 ~3 (47 unchanged, 0 errors)`. Use it after you know the remote changed externally and you want the local view to catch up before the 30 s TTL expires.
 
+## Index state and bounds (`mount list`)
+
+Each mount is indexed in the background for fast file discovery and listings; `mount list` shows each mount's index state. The walk is bounded — defaults (raised 10×): max directory depth **400**, max total entries **2,000,000**. Two env vars override them: `SLICC_MOUNT_INDEX_MAX_DEPTH` and `SLICC_MOUNT_INDEX_MAX_ENTRIES` (an invalid value falls back to the default with a warning).
+
+When a bound is hit the index is **skipped** (reads still work via the slow fallback) and `mount list` shows a distinct cause, so advise the right remedy:
+
+- `directory nesting exceeded the depth limit` → raise `SLICC_MOUNT_INDEX_MAX_DEPTH` or unmount.
+- `mounted tree is too large` → raise `SLICC_MOUNT_INDEX_MAX_ENTRIES` or unmount (this is **not** a cycle).
+- `self-referential mount cycle detected` → a real, confirmed cycle; unmount it.
+- `index error: <message>` → any other indexing failure.
+
+Don't call a large or deep mount "cyclic" — only `self-referential mount cycle detected` means a true self-reference.
+
 ## Reading and writing once mounted
 
 Treat the mount path like any other VFS directory:

--- a/packages/webapp/src/fs/index.ts
+++ b/packages/webapp/src/fs/index.ts
@@ -1,6 +1,11 @@
 export type { FsChangeEvent, FsChangeType, FsWatchCallback, FsWatchFilter } from './fs-watcher.js';
 export { FsWatcher } from './fs-watcher.js';
-export type { IndexingStatus, MountIndexEntry, MountIndexState } from './mount-index.js';
+export type {
+  IndexingStatus,
+  MountIndexAbortCause,
+  MountIndexEntry,
+  MountIndexState,
+} from './mount-index.js';
 export { MountIndex } from './mount-index.js';
 export { joinPath, normalizePath, pathSegments, splitPath } from './path-utils.js';
 export { RestrictedFS } from './restricted-fs.js';

--- a/packages/webapp/src/fs/mount-commands.ts
+++ b/packages/webapp/src/fs/mount-commands.ts
@@ -22,6 +22,7 @@ import { S3MountBackend, type SignedFetchS3 } from './mount/backend-s3.js';
 import { newMountId } from './mount/mount-id.js';
 import { RemoteMountCache } from './mount/remote-cache.js';
 import { makeSignedFetchDa, makeSignedFetchS3 } from './mount/signed-fetch.js';
+import type { MountIndexEnv } from './mount-index.js';
 import { loadAndClearPendingHandle, reactivateHandle } from './mount-picker-popup.js';
 import type { VirtualFS } from './virtual-fs.js';
 
@@ -95,7 +96,7 @@ export class MountCommands {
     this.signedFetchDa = options.signedFetchDa;
   }
 
-  async execute(args: string[], cwd: string): Promise<MountCommandResult> {
+  async execute(args: string[], cwd: string, env?: MountIndexEnv): Promise<MountCommandResult> {
     const sub = args[0];
 
     if (sub === '--help' || sub === '-h') {
@@ -111,7 +112,7 @@ export class MountCommands {
     }
 
     if (sub === 'refresh') {
-      return this.handleRefresh(args.slice(1), cwd);
+      return this.handleRefresh(args.slice(1), cwd, env);
     }
 
     const parsed = parseArgs(args);
@@ -134,12 +135,12 @@ export class MountCommands {
     }
 
     // No --source → local picker.
-    return this.mountLocal(targetPath);
+    return this.mountLocal(targetPath, env);
   }
 
   // ---- handlers ----
 
-  private async mountLocal(targetPath: string): Promise<MountCommandResult> {
+  private async mountLocal(targetPath: string, env?: MountIndexEnv): Promise<MountCommandResult> {
     try {
       const isScoop = this.options.isScoop ?? (() => false);
       const ctx = getToolExecutionContext();
@@ -156,7 +157,7 @@ export class MountCommands {
       if (!ctx) {
         const preBackend = await tryAdoptPrePickedHandle(targetPath);
         if (preBackend) {
-          await this.options.fs.mount(targetPath, preBackend);
+          await this.options.fs.mount(targetPath, preBackend, { env });
           const desc = preBackend.describe();
           return {
             stdout:
@@ -174,7 +175,7 @@ export class MountCommands {
         toolContext: ctx ?? undefined,
         isExtension: typeof chrome !== 'undefined' && !!chrome?.runtime?.id,
       });
-      await this.options.fs.mount(targetPath, backend);
+      await this.options.fs.mount(targetPath, backend, { env });
       const desc = backend.describe();
       return {
         stdout:
@@ -375,7 +376,11 @@ export class MountCommands {
     }
   }
 
-  private async handleRefresh(args: string[], cwd: string): Promise<MountCommandResult> {
+  private async handleRefresh(
+    args: string[],
+    cwd: string,
+    env?: MountIndexEnv
+  ): Promise<MountCommandResult> {
     const parsed = parseArgs(args);
     if (parsed.positional.length === 0) {
       return { stdout: '', stderr: 'mount refresh: path required\n', exitCode: 1 };
@@ -383,7 +388,7 @@ export class MountCommands {
     const targetPath = this.resolvePath(parsed.positional[0], cwd);
 
     try {
-      const report = await this.options.fs.refreshMount(targetPath, { bodies: parsed.bodies });
+      const report = await this.options.fs.refreshMount(targetPath, { bodies: parsed.bodies, env });
       const summary = `Refreshed ${targetPath}: +${report.added.length} -${report.removed.length} ~${report.changed.length} (${report.unchanged} unchanged, ${report.errors.length} errors)\n`;
       const errLines = report.errors.map((e) => `  ${e.path}: ${e.message}\n`).join('');
       return {

--- a/packages/webapp/src/fs/mount-commands.ts
+++ b/packages/webapp/src/fs/mount-commands.ts
@@ -350,12 +350,18 @@ export class MountCommands {
         } else if (state.status === 'indexing') {
           return `${m} (indexing: ${state.indexed} entries...)`;
         } else if (state.status === 'error') {
-          if (state.likelyCyclic) {
-            // A self-referential / oversized mount: reads still work (slow path),
-            // but the index can't complete. Tell the user how to clear it.
-            return `${m} (index error: likely a self-referential mount cycle — run 'mount unmount ${m}' to remove it)`;
+          // Reads still work via the slow per-readDir fallback; classify why the
+          // index was skipped so the user gets an actionable remedy per cause.
+          switch (state.abortCause) {
+            case 'depth-exceeded':
+              return `${m} (index skipped: directory nesting exceeded the depth limit — reads use the slow path; raise SLICC_MOUNT_INDEX_MAX_DEPTH or 'mount unmount ${m}')`;
+            case 'entries-exceeded':
+              return `${m} (index skipped: mounted tree is too large — reads use the slow path; raise SLICC_MOUNT_INDEX_MAX_ENTRIES or 'mount unmount ${m}')`;
+            case 'cycle-detected':
+              return `${m} (index skipped: self-referential mount cycle detected — run 'mount unmount ${m}' to remove it)`;
+            default:
+              return `${m} (index error: ${state.error})`;
           }
-          return `${m} (index error: ${state.error})`;
         }
         return `${m} (pending index)`;
       });

--- a/packages/webapp/src/fs/mount-index.ts
+++ b/packages/webapp/src/fs/mount-index.ts
@@ -112,9 +112,26 @@ async function isSameEntrySafe(
   }
 }
 
-/** Parse a positive-integer env value, or undefined when missing/invalid. */
-function parsePositiveIntLimit(raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
+/** Resolved mount-index walk bounds. */
+export interface MountIndexLimits {
+  maxDepth: number;
+  maxEntries: number;
+}
+
+/**
+ * The env shapes `resolveMountIndexLimits` accepts. The shell threads just-bash's
+ * `CommandContext.env` (a `Map`, populated by `export`); plain records are still
+ * accepted for non-shell callers and tests.
+ */
+export type MountIndexEnv = ReadonlyMap<string, string> | Record<string, string | undefined>;
+
+/** Read a single key from either env shape. */
+function readEnvValue(env: MountIndexEnv, name: string): string | undefined {
+  return env instanceof Map ? env.get(name) : (env as Record<string, string | undefined>)[name];
+}
+
+/** Parse a positive-integer env value, or undefined when invalid. */
+function parsePositiveIntLimit(raw: string): number | undefined {
   const trimmed = raw.trim();
   if (trimmed === '') return undefined;
   const value = Number(trimmed);
@@ -122,12 +139,8 @@ function parsePositiveIntLimit(raw: string | undefined): number | undefined {
   return value;
 }
 
-function resolveLimit(
-  env: Record<string, string | undefined>,
-  name: string,
-  fallback: number
-): number {
-  const raw = env[name];
+function resolveLimit(env: MountIndexEnv, name: string, fallback: number): number {
+  const raw = readEnvValue(env, name);
   // Absent (or empty) is normal — the worker/browser float has no OS env, so
   // stay silent and use the default.
   if (raw === undefined || raw.trim() === '') return fallback;
@@ -144,14 +157,13 @@ function resolveLimit(
 
 /**
  * Pure resolver for the mount-index bounds. Reads `SLICC_MOUNT_INDEX_MAX_DEPTH`
- * and `SLICC_MOUNT_INDEX_MAX_ENTRIES` from the supplied env snapshot; each must
- * parse to a positive integer, otherwise it falls back to the default and warns.
- * Pass a runtime-safe snapshot (`typeof process !== 'undefined' ? process.env : {}`).
+ * and `SLICC_MOUNT_INDEX_MAX_ENTRIES` from the supplied env; each must parse to a
+ * positive integer, otherwise it falls back to the default and warns. The env is
+ * just-bash's shell `CommandContext.env` `Map` (populated by `export`), threaded
+ * down from the `mount` command; pass `{}` for non-shell callers (reload/restore)
+ * to get the defaults.
  */
-export function resolveMountIndexLimits(env: Record<string, string | undefined>): {
-  maxDepth: number;
-  maxEntries: number;
-} {
+export function resolveMountIndexLimits(env: MountIndexEnv): MountIndexLimits {
   return {
     maxDepth: resolveLimit(env, ENV_MAX_DEPTH, MAX_INDEX_DEPTH),
     maxEntries: resolveLimit(env, ENV_MAX_ENTRIES, MAX_INDEX_ENTRIES),
@@ -188,6 +200,12 @@ interface MountData {
   directories: Set<string>;
   /** Abort controller for cancelling in-progress indexing */
   abortController: AbortController | null;
+  /**
+   * Walk bounds for THIS mount, resolved from the shell env at register/refresh
+   * time. `walkHandle`/`enforceWalkBounds`/`readChildren` compare against these
+   * — not the module-level constants — so per-mount env overrides take effect.
+   */
+  limits: MountIndexLimits;
 }
 
 export class MountIndex {
@@ -195,20 +213,18 @@ export class MountIndex {
   private listeners = new Set<() => void>();
 
   /**
-   * Resolved walk bounds, read ONCE from the runtime-safe env snapshot at
-   * construction (the worker/browser float has no OS env, so this is the
-   * default there). `walkHandle` compares against these — not the module-level
-   * constants — so env overrides actually take effect.
-   */
-  private readonly limits = resolveMountIndexLimits(
-    typeof process !== 'undefined' ? process.env : {}
-  );
-
-  /**
    * Register a mount point and begin async indexing.
    * Returns immediately — indexing runs in the background.
+   *
+   * `limits` are the resolved walk bounds for this mount (the VFS resolves them
+   * from the shell env at mount time); callers without a shell env should pass
+   * `resolveMountIndexLimits({})` (the default).
    */
-  registerMount(mountPath: string, handle: FileSystemDirectoryHandle): void {
+  registerMount(
+    mountPath: string,
+    handle: FileSystemDirectoryHandle,
+    limits: MountIndexLimits = resolveMountIndexLimits({})
+  ): void {
     // Cancel any existing indexing for this path
     this.mounts.get(mountPath)?.abortController?.abort();
 
@@ -219,6 +235,7 @@ export class MountIndex {
       files: new Set(),
       directories: new Set(),
       abortController,
+      limits,
     };
 
     this.mounts.set(mountPath, data);
@@ -241,9 +258,11 @@ export class MountIndex {
   }
 
   /**
-   * Re-index a mount point. Use after external changes.
+   * Re-index a mount point. Use after external changes. When `limits` are
+   * supplied (e.g. a `mount refresh` after a new `export`), they replace the
+   * stored bounds; otherwise the existing per-mount bounds are kept.
    */
-  async refreshMount(mountPath: string): Promise<void> {
+  async refreshMount(mountPath: string, limits?: MountIndexLimits): Promise<void> {
     const data = this.mounts.get(mountPath);
     if (!data) {
       throw new Error(`No mount at ${mountPath}`);
@@ -258,6 +277,7 @@ export class MountIndex {
     data.state = { status: 'pending', indexed: 0 };
     data.files.clear();
     data.directories.clear();
+    if (limits) data.limits = limits;
     this.notifyListeners();
 
     await this.indexMount(mountPath, data, abortController.signal);
@@ -554,8 +574,9 @@ export class MountIndex {
     data.directories.add(basePath);
 
     // Read this directory's entries up front so we can fingerprint it for cycle
-    // detection before descending.
-    const children = await this.readChildren(handle, signal);
+    // detection before descending. `readChildren` enforces the entry budget as
+    // it buffers so a single huge flat directory can't OOM before the bound.
+    const children = await this.readChildren(handle, signal, data);
     if (signal.aborted) return;
 
     const signature = await this.confirmNoCycle(basePath, handle, children, signatureBuckets);
@@ -578,29 +599,41 @@ export class MountIndex {
    * back to the slow per-`readDir` path instead of trusting a partial index.
    */
   private enforceWalkBounds(depth: number, data: MountData): void {
-    if (depth > this.limits.maxDepth) {
+    if (depth > data.limits.maxDepth) {
       throw new MountIndexAbortError(
-        `mount indexing aborted: directory nesting exceeded ${this.limits.maxDepth} levels`,
+        `mount indexing aborted: directory nesting exceeded ${data.limits.maxDepth} levels`,
         'depth-exceeded'
       );
     }
-    if (data.directories.size + data.files.size >= this.limits.maxEntries) {
+    if (data.directories.size + data.files.size >= data.limits.maxEntries) {
       throw new MountIndexAbortError(
-        `mount indexing aborted: exceeded ${this.limits.maxEntries} entries`,
+        `mount indexing aborted: exceeded ${data.limits.maxEntries} entries`,
         'entries-exceeded'
       );
     }
   }
 
-  /** Buffer a directory's entries (type assertion for async iteration). */
+  /**
+   * Buffer a directory's entries (type assertion for async iteration). The entry
+   * budget is re-checked against the running total as each child is read so a
+   * single huge flat directory aborts with `entries-exceeded` immediately,
+   * before its full listing is materialized in memory.
+   */
   private async readChildren(
     handle: FileSystemDirectoryHandle,
-    signal: AbortSignal
+    signal: AbortSignal,
+    data: MountData
   ): Promise<Array<[string, FileSystemHandle]>> {
     const entries = handle as unknown as AsyncIterable<[string, FileSystemHandle]>;
     const children: Array<[string, FileSystemHandle]> = [];
     for await (const entry of entries) {
       if (signal.aborted) break;
+      if (data.directories.size + data.files.size + children.length >= data.limits.maxEntries) {
+        throw new MountIndexAbortError(
+          `mount indexing aborted: exceeded ${data.limits.maxEntries} entries`,
+          'entries-exceeded'
+        );
+      }
       children.push(entry);
     }
     return children;

--- a/packages/webapp/src/fs/mount-index.ts
+++ b/packages/webapp/src/fs/mount-index.ts
@@ -24,17 +24,139 @@ const log = createLogger('mount-index');
 // re-exposes one of its own ancestors (e.g. a repo checkout whose
 // `.claude/worktrees/` nests further checkouts of itself) — cannot grow the
 // index without limit and peg / OOM the kernel worker. See `walkHandle`.
-const MAX_INDEX_DEPTH = 40;
-const MAX_INDEX_ENTRIES = 200_000;
+// These are the defaults; both are overridable via env (see
+// `resolveMountIndexLimits`).
+const MAX_INDEX_DEPTH = 400;
+const MAX_INDEX_ENTRIES = 2_000_000;
+
+/** Env var overriding the recursion depth bound. */
+const ENV_MAX_DEPTH = 'SLICC_MOUNT_INDEX_MAX_DEPTH';
+/** Env var overriding the total-entry budget. */
+const ENV_MAX_ENTRIES = 'SLICC_MOUNT_INDEX_MAX_ENTRIES';
 
 /**
- * Thrown by `walkHandle` when a depth / entry bound is exceeded — i.e. the tree
- * is almost certainly self-referential (or pathologically oversized) rather than
- * a backend failure. `indexMount` uses it to set `likelyCyclic` so consumers
- * (e.g. `mount list`) can surface an actionable "unmount it" hint instead of the
- * raw abort message.
+ * Cap on how many sorted `name+kind` tokens contribute to a directory's cheap
+ * cycle-detection signature. Large directories are sampled to the first N tokens
+ * so signature construction stays O(entries) rather than ballooning per level.
  */
-class MountIndexBoundError extends Error {}
+const SIGNATURE_SAMPLE_CAP = 256;
+
+/**
+ * Classifies why a mount index aborted (set on `MountIndexState.abortCause` when
+ * `status === 'error'`). Lets consumers (e.g. `mount list`) render a distinct,
+ * actionable message per cause instead of conflating every abort into "likely
+ * cyclic".
+ */
+export type MountIndexAbortCause =
+  | 'depth-exceeded'
+  | 'entries-exceeded'
+  | 'cycle-detected'
+  | 'indexing-error';
+
+/**
+ * Thrown by `walkHandle` when indexing must abort for a classified reason — a
+ * depth / entry bound, or a confirmed self-referential cycle. `indexMount` reads
+ * `cause` to populate `MountIndexState.abortCause`.
+ */
+class MountIndexAbortError extends Error {
+  readonly cause: MountIndexAbortCause;
+  constructor(message: string, cause: MountIndexAbortCause) {
+    super(message);
+    this.name = 'MountIndexAbortError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * One frame of the ancestor stack threaded through `walkHandle` for cycle
+ * detection: the directory's VFS path, its live handle (the only thing
+ * `isSameEntry()` can compare), and a cheap fingerprint of its entries.
+ */
+interface AncestorEntry {
+  path: string;
+  handle: FileSystemDirectoryHandle;
+  signature: string;
+}
+
+/**
+ * Compute a cheap, order-independent fingerprint of a directory from the
+ * entries already read: sorted `name + kind` tokens plus the child count. Large
+ * directories are sampled to the first `SIGNATURE_SAMPLE_CAP` tokens so this
+ * stays O(entries) rather than O(entries·depth). This is a PREFILTER only — a
+ * match merely narrows which ancestors are worth an exact `isSameEntry()` call.
+ */
+function computeDirSignature(children: Array<[string, FileSystemHandle]>): string {
+  const tokens = children.map(([name, child]) => `${name}\u0000${child.kind}`).sort();
+  const sampled =
+    tokens.length > SIGNATURE_SAMPLE_CAP ? tokens.slice(0, SIGNATURE_SAMPLE_CAP) : tokens;
+  return `${tokens.length}\u0001${sampled.join('\u0002')}`;
+}
+
+/**
+ * Exact cycle confirmation. `FileSystemHandle.isSameEntry()` is the ONLY proof
+ * of a real cycle. The in-memory Node test FS lacks it, so guard for a missing
+ * method or a throwing call — when unavailable we report "not the same" and the
+ * depth / entry caps remain the safety net.
+ */
+async function isSameEntrySafe(
+  ancestor: FileSystemDirectoryHandle,
+  candidate: FileSystemDirectoryHandle
+): Promise<boolean> {
+  const isSameEntry = (ancestor as { isSameEntry?: (other: FileSystemHandle) => Promise<boolean> })
+    .isSameEntry;
+  if (typeof isSameEntry !== 'function') return false;
+  try {
+    return await isSameEntry.call(ancestor, candidate);
+  } catch {
+    return false;
+  }
+}
+
+/** Parse a positive-integer env value, or undefined when missing/invalid. */
+function parsePositiveIntLimit(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === '') return undefined;
+  const value = Number(trimmed);
+  if (!Number.isInteger(value) || value <= 0) return undefined;
+  return value;
+}
+
+function resolveLimit(
+  env: Record<string, string | undefined>,
+  name: string,
+  fallback: number
+): number {
+  const raw = env[name];
+  // Absent (or empty) is normal — the worker/browser float has no OS env, so
+  // stay silent and use the default.
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const parsed = parsePositiveIntLimit(raw);
+  if (parsed === undefined) {
+    log.warn(`Ignoring invalid ${name}; expected a positive integer, using default`, {
+      value: raw,
+      fallback,
+    });
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * Pure resolver for the mount-index bounds. Reads `SLICC_MOUNT_INDEX_MAX_DEPTH`
+ * and `SLICC_MOUNT_INDEX_MAX_ENTRIES` from the supplied env snapshot; each must
+ * parse to a positive integer, otherwise it falls back to the default and warns.
+ * Pass a runtime-safe snapshot (`typeof process !== 'undefined' ? process.env : {}`).
+ */
+export function resolveMountIndexLimits(env: Record<string, string | undefined>): {
+  maxDepth: number;
+  maxEntries: number;
+} {
+  return {
+    maxDepth: resolveLimit(env, ENV_MAX_DEPTH, MAX_INDEX_DEPTH),
+    maxEntries: resolveLimit(env, ENV_MAX_ENTRIES, MAX_INDEX_ENTRIES),
+  };
+}
 
 export interface MountIndexEntry {
   /** Absolute VFS path */
@@ -53,12 +175,8 @@ export interface MountIndexState {
   total?: number;
   /** Error message if status is 'error' */
   error?: string;
-  /**
-   * True when the 'error' was an exceeded depth / entry bound — a likely
-   * self-referential mount cycle (or oversized tree), not a backend failure.
-   * Lets consumers render an actionable remedy rather than the raw message.
-   */
-  likelyCyclic?: boolean;
+  /** Set only when status === 'error'; classifies why indexing aborted. */
+  abortCause?: MountIndexAbortCause;
 }
 
 interface MountData {
@@ -75,6 +193,16 @@ interface MountData {
 export class MountIndex {
   private mounts = new Map<string, MountData>();
   private listeners = new Set<() => void>();
+
+  /**
+   * Resolved walk bounds, read ONCE from the runtime-safe env snapshot at
+   * construction (the worker/browser float has no OS env, so this is the
+   * default there). `walkHandle` compares against these — not the module-level
+   * constants — so env overrides actually take effect.
+   */
+  private readonly limits = resolveMountIndexLimits(
+    typeof process !== 'undefined' ? process.env : {}
+  );
 
   /**
    * Register a mount point and begin async indexing.
@@ -400,9 +528,10 @@ export class MountIndex {
       if (signal.aborted) return;
 
       const message = err instanceof Error ? err.message : String(err);
-      const likelyCyclic = err instanceof MountIndexBoundError;
-      data.state = { status: 'error', indexed: 0, error: message, likelyCyclic };
-      log.error('Mount indexing failed', { path: mountPath, error: message, likelyCyclic });
+      const abortCause: MountIndexAbortCause =
+        err instanceof MountIndexAbortError ? err.cause : 'indexing-error';
+      data.state = { status: 'error', indexed: 0, error: message, abortCause };
+      log.error('Mount indexing failed', { path: mountPath, error: message, abortCause });
     }
 
     this.notifyListeners();
@@ -416,30 +545,131 @@ export class MountIndex {
     handle: FileSystemDirectoryHandle,
     data: MountData,
     signal: AbortSignal,
-    depth = 0
+    depth = 0,
+    signatureBuckets: Map<string, AncestorEntry[]> = new Map()
   ): Promise<void> {
     if (signal.aborted) return;
-    // A self-referential mount would otherwise descend forever, growing the
-    // index until it OOMs / pegs the kernel worker. Exceeding either bound
-    // aborts indexing; `indexMount` marks the mount `error`, so reads fall back
-    // to the slow per-`readDir` path instead of trusting a partial index.
-    if (depth > MAX_INDEX_DEPTH) {
-      throw new MountIndexBoundError(
-        `mount indexing aborted: directory nesting exceeded ${MAX_INDEX_DEPTH} levels (likely a self-referential mount cycle)`
-      );
-    }
-    if (data.directories.size + data.files.size >= MAX_INDEX_ENTRIES) {
-      throw new MountIndexBoundError(
-        `mount indexing aborted: exceeded ${MAX_INDEX_ENTRIES} entries (likely a self-referential mount cycle or oversized tree)`
-      );
-    }
+    this.enforceWalkBounds(depth, data);
 
     data.directories.add(basePath);
 
-    // Type assertion for async iteration over directory entries
-    const entries = handle as unknown as AsyncIterable<[string, FileSystemHandle]>;
+    // Read this directory's entries up front so we can fingerprint it for cycle
+    // detection before descending.
+    const children = await this.readChildren(handle, signal);
+    if (signal.aborted) return;
 
-    for await (const [name, childHandle] of entries) {
+    const signature = await this.confirmNoCycle(basePath, handle, children, signatureBuckets);
+
+    // Push this directory onto its signature bucket for descendants, popping it
+    // back off after — keeps the buckets scoped to the current ancestor chain.
+    const bucket = this.pushAncestor(signatureBuckets, signature, basePath, handle);
+    try {
+      await this.walkChildren(basePath, children, data, signal, depth, signatureBuckets);
+    } finally {
+      this.popAncestor(signatureBuckets, signature, bucket);
+    }
+  }
+
+  /**
+   * Depth / entry caps are the unconditional safety net: even when cycle
+   * detection can't run (no `isSameEntry`), a self-referential mount cannot grow
+   * the index without limit and OOM / peg the kernel worker. Exceeding either
+   * bound aborts indexing; `indexMount` marks the mount `error`, so reads fall
+   * back to the slow per-`readDir` path instead of trusting a partial index.
+   */
+  private enforceWalkBounds(depth: number, data: MountData): void {
+    if (depth > this.limits.maxDepth) {
+      throw new MountIndexAbortError(
+        `mount indexing aborted: directory nesting exceeded ${this.limits.maxDepth} levels`,
+        'depth-exceeded'
+      );
+    }
+    if (data.directories.size + data.files.size >= this.limits.maxEntries) {
+      throw new MountIndexAbortError(
+        `mount indexing aborted: exceeded ${this.limits.maxEntries} entries`,
+        'entries-exceeded'
+      );
+    }
+  }
+
+  /** Buffer a directory's entries (type assertion for async iteration). */
+  private async readChildren(
+    handle: FileSystemDirectoryHandle,
+    signal: AbortSignal
+  ): Promise<Array<[string, FileSystemHandle]>> {
+    const entries = handle as unknown as AsyncIterable<[string, FileSystemHandle]>;
+    const children: Array<[string, FileSystemHandle]> = [];
+    for await (const entry of entries) {
+      if (signal.aborted) break;
+      children.push(entry);
+    }
+    return children;
+  }
+
+  /**
+   * Best-effort cycle detection (approximate prefilter + exact confirmation): a
+   * self-referential mount re-exposes one of its own ancestors. Only ancestors
+   * sharing this directory's cheap signature are worth an exact `isSameEntry()`
+   * check; a confirmed match is the only proof of a cycle. Returns the computed
+   * signature so the caller can bucket this directory for its descendants.
+   */
+  private async confirmNoCycle(
+    basePath: string,
+    handle: FileSystemDirectoryHandle,
+    children: Array<[string, FileSystemHandle]>,
+    signatureBuckets: Map<string, AncestorEntry[]>
+  ): Promise<string> {
+    const signature = computeDirSignature(children);
+    const candidates = signatureBuckets.get(signature);
+    if (candidates) {
+      for (const ancestor of candidates) {
+        if (await isSameEntrySafe(ancestor.handle, handle)) {
+          throw new MountIndexAbortError(
+            `mount indexing aborted: self-referential mount cycle detected at ${basePath} (re-exposes ${ancestor.path})`,
+            'cycle-detected'
+          );
+        }
+      }
+    }
+    return signature;
+  }
+
+  /** Push this directory onto its signature bucket, creating the bucket if new. */
+  private pushAncestor(
+    signatureBuckets: Map<string, AncestorEntry[]>,
+    signature: string,
+    basePath: string,
+    handle: FileSystemDirectoryHandle
+  ): AncestorEntry[] {
+    let bucket = signatureBuckets.get(signature);
+    if (!bucket) {
+      bucket = [];
+      signatureBuckets.set(signature, bucket);
+    }
+    bucket.push({ path: basePath, handle, signature });
+    return bucket;
+  }
+
+  /** Pop this directory off its signature bucket, dropping the bucket if empty. */
+  private popAncestor(
+    signatureBuckets: Map<string, AncestorEntry[]>,
+    signature: string,
+    bucket: AncestorEntry[]
+  ): void {
+    bucket.pop();
+    if (bucket.length === 0) signatureBuckets.delete(signature);
+  }
+
+  /** Index each child entry, recursing into directories. */
+  private async walkChildren(
+    basePath: string,
+    children: Array<[string, FileSystemHandle]>,
+    data: MountData,
+    signal: AbortSignal,
+    depth: number,
+    signatureBuckets: Map<string, AncestorEntry[]>
+  ): Promise<void> {
+    for (const [name, childHandle] of children) {
       if (signal.aborted) return;
 
       const childPath = basePath === '/' ? `/${name}` : `${basePath}/${name}`;
@@ -453,7 +683,8 @@ export class MountIndex {
           childHandle as FileSystemDirectoryHandle,
           data,
           signal,
-          depth + 1
+          depth + 1,
+          signatureBuckets
         );
       }
 

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -18,7 +18,7 @@
 import type { FsWatcher } from './fs-watcher.js';
 import type { MountBackend, RefreshReport } from './mount/backend.js';
 import { LocalMountBackend } from './mount/backend-local.js';
-import { MountIndex } from './mount-index.js';
+import { MountIndex, type MountIndexEnv, resolveMountIndexLimits } from './mount-index.js';
 import type { BackendDescriptor, MountTableEntry } from './mount-table-store.js';
 import {
   clearMountEntries,
@@ -899,7 +899,11 @@ export class VirtualFS {
    * A placeholder directory is created in LightningFS so that ancestor paths
    * (e.g. `cd /workspace`) resolve correctly.
    */
-  async mount(absolutePath: string, backend: MountBackend): Promise<void> {
+  async mount(
+    absolutePath: string,
+    backend: MountBackend,
+    opts?: { env?: MountIndexEnv }
+  ): Promise<void> {
     const normalized = normalizePath(absolutePath);
     if (this.mountPoints.has(normalized)) {
       throw new FsError('EEXIST', 'mount point is already mounted', normalized);
@@ -937,7 +941,11 @@ export class VirtualFS {
     // so fast directory walks work. Remote backends have their own
     // listing cache (RemoteMountCache); MountIndex stays local-only.
     if (backend.kind === 'local') {
-      this.mountIndex.registerMount(normalized, (backend as LocalMountBackend).getHandle());
+      // Resolve the index walk bounds from the shell env threaded down by the
+      // `mount` command (SLICC_MOUNT_INDEX_MAX_DEPTH / _MAX_ENTRIES via `export`);
+      // non-shell callers (peer sync, reload/restore) get the defaults.
+      const limits = resolveMountIndexLimits(opts?.env ?? {});
+      this.mountIndex.registerMount(normalized, (backend as LocalMountBackend).getHandle(), limits);
     }
     // Build the persistence descriptor.
     const descriptor: BackendDescriptor =
@@ -1147,7 +1155,10 @@ export class VirtualFS {
    * Re-index a mounted directory. Use after external changes.
    * @throws Error if the path is not a mount point
    */
-  async refreshMount(mountPath: string, opts?: { bodies?: boolean }): Promise<RefreshReport> {
+  async refreshMount(
+    mountPath: string,
+    opts?: { bodies?: boolean; env?: MountIndexEnv }
+  ): Promise<RefreshReport> {
     const normalized = normalizePath(mountPath);
     const backend = this.mountPoints.get(normalized);
     if (!backend) {
@@ -1155,9 +1166,10 @@ export class VirtualFS {
     }
     const report = await backend.refresh(opts);
     // Local backend's refresh is a no-op; existing MountIndex re-walk still
-    // happens here for local mounts.
+    // happens here for local mounts. Re-resolve the walk bounds from the shell
+    // env so a refresh after a new `export` picks up the change.
     if (backend.kind === 'local') {
-      await this.mountIndex.refreshMount(normalized);
+      await this.mountIndex.refreshMount(normalized, resolveMountIndexLimits(opts?.env ?? {}));
     }
     return report;
   }

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -907,7 +907,7 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
     const mountCommands = this.mountCommands;
     return defineCommand('mount', async (args, ctx) => {
       const cwd = ctx.cwd;
-      const result = await mountCommands.execute(args, cwd);
+      const result = await mountCommands.execute(args, cwd, ctx.env);
       return {
         stdout: result.stdout,
         stderr: result.stderr,

--- a/packages/webapp/tests/fs/mount-commands.test.ts
+++ b/packages/webapp/tests/fs/mount-commands.test.ts
@@ -444,6 +444,28 @@ describe('MountCommands', () => {
       expect(result.stdout).toMatch(/Refreshed \/mnt\/s3:\s*\+2\s*-1\s*~1.*5 unchanged.*0 errors/);
     });
 
+    it('threads the just-bash env through to fs.refreshMount', async () => {
+      // A `mount refresh` after a new `export SLICC_MOUNT_INDEX_MAX_*` must
+      // forward that env so the re-walk picks up the changed bounds.
+      const refreshMount = vi.fn(async () => ({
+        added: [],
+        removed: [],
+        changed: [],
+        unchanged: 0,
+        errors: [],
+      }));
+      const fs = makeFs({ refreshMount } as Partial<VirtualFS>);
+      const cmd = new MountCommands({ fs });
+      const env = new Map([['SLICC_MOUNT_INDEX_MAX_ENTRIES', '7']]);
+
+      await cmd.execute(['refresh', '/mnt/s3'], '/workspace', env);
+
+      expect(refreshMount).toHaveBeenCalledTimes(1);
+      const [path, opts] = refreshMount.mock.calls[0] as [string, { env?: unknown }];
+      expect(path).toBe('/mnt/s3');
+      expect(opts.env).toBe(env);
+    });
+
     it('surfaces refresh errors on stderr', async () => {
       const fs = makeFs({
         refreshMount: vi.fn(async () => ({

--- a/packages/webapp/tests/fs/mount-commands.test.ts
+++ b/packages/webapp/tests/fs/mount-commands.test.ts
@@ -76,52 +76,70 @@ describe('MountCommands', () => {
       expect(result.exitCode).toBe(0);
     });
 
-    it('renders an actionable hint for a likely-cyclic mount index error', async () => {
+    async function runListWithErrorState(
+      mountPath: string,
+      state: Record<string, unknown>
+    ): Promise<string> {
       const mountIndex = {
-        getState: vi.fn(() => ({
-          status: 'error' as const,
-          indexed: 0,
-          error: 'mount indexing aborted: directory nesting exceeded 40 levels',
-          likelyCyclic: true,
-        })),
+        getState: vi.fn(() => ({ status: 'error' as const, indexed: 0, ...state })),
         isReady: vi.fn(() => false),
       };
       const cmd = new MountCommands({
         fs: makeFs({
-          listMounts: vi.fn(() => ['/mnt/cyclic']),
+          listMounts: vi.fn(() => [mountPath]),
           getMountIndex: vi.fn(() => mountIndex) as unknown as VirtualFS['getMountIndex'],
         }),
       });
       const result = await cmd.execute(['list'], '/workspace');
-
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('/mnt/cyclic');
-      // Names the condition and tells the user how to clear it, rather than
-      // dumping the raw indexer abort message.
-      expect(result.stdout.toLowerCase()).toContain('cycl');
-      expect(result.stdout).toContain('mount unmount /mnt/cyclic');
+      return result.stdout;
+    }
+
+    it('renders a depth-exceeded index skip with the depth env var hint', async () => {
+      const stdout = await runListWithErrorState('/mnt/deep', {
+        error: 'mount indexing aborted: directory nesting exceeded 400 levels',
+        abortCause: 'depth-exceeded',
+      });
+      expect(stdout).toContain('/mnt/deep');
+      expect(stdout).toContain('index skipped');
+      expect(stdout.toLowerCase()).toContain('depth');
+      expect(stdout).toContain('SLICC_MOUNT_INDEX_MAX_DEPTH');
+      expect(stdout).toContain('mount unmount /mnt/deep');
+      expect(stdout.toLowerCase()).not.toContain('cycl');
     });
 
-    it('still renders the raw message for a non-cyclic index error', async () => {
-      const mountIndex = {
-        getState: vi.fn(() => ({
-          status: 'error' as const,
-          indexed: 0,
-          error: 'backend unavailable',
-        })),
-        isReady: vi.fn(() => false),
-      };
-      const cmd = new MountCommands({
-        fs: makeFs({
-          listMounts: vi.fn(() => ['/mnt/broken']),
-          getMountIndex: vi.fn(() => mountIndex) as unknown as VirtualFS['getMountIndex'],
-        }),
+    it('renders an entries-exceeded index skip as a too-large tree, not a cycle', async () => {
+      const stdout = await runListWithErrorState('/mnt/huge', {
+        error: 'mount indexing aborted: entry budget of 2000000 exceeded',
+        abortCause: 'entries-exceeded',
       });
-      const result = await cmd.execute(['list'], '/workspace');
+      expect(stdout).toContain('/mnt/huge');
+      expect(stdout).toContain('index skipped');
+      expect(stdout.toLowerCase()).toContain('too large');
+      expect(stdout).toContain('SLICC_MOUNT_INDEX_MAX_ENTRIES');
+      expect(stdout).toContain('mount unmount /mnt/huge');
+      expect(stdout.toLowerCase()).not.toContain('cycl');
+    });
 
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('backend unavailable');
-      expect(result.stdout).not.toContain('mount unmount');
+    it('renders a cycle-detected index skip with an actionable unmount hint', async () => {
+      const stdout = await runListWithErrorState('/mnt/cyclic', {
+        error: 'mount indexing aborted: self-referential mount cycle detected',
+        abortCause: 'cycle-detected',
+      });
+      expect(stdout).toContain('/mnt/cyclic');
+      expect(stdout).toContain('index skipped');
+      expect(stdout.toLowerCase()).toContain('cycle');
+      expect(stdout).toContain('mount unmount /mnt/cyclic');
+    });
+
+    it('renders the raw message for a generic indexing-error', async () => {
+      const stdout = await runListWithErrorState('/mnt/broken', {
+        error: 'backend unavailable',
+        abortCause: 'indexing-error',
+      });
+      expect(stdout).toContain('index error: backend unavailable');
+      expect(stdout).not.toContain('mount unmount');
+      expect(stdout).not.toContain('index skipped');
     });
   });
 

--- a/packages/webapp/tests/fs/mount-index.test.ts
+++ b/packages/webapp/tests/fs/mount-index.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { MountIndex } from '../../src/fs/mount-index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LogLevel, resetLoggerDedupForTests, setLogLevel } from '../../src/core/logger.js';
+import { MountIndex, resolveMountIndexLimits } from '../../src/fs/mount-index.js';
 
 /**
  * A self-referential FileSystemDirectoryHandle: it contains a file plus a
@@ -7,6 +8,9 @@ import { MountIndex } from '../../src/fs/mount-index.js';
  * descends `/mnt/cyclic/loop/loop/loop/…` forever. This mirrors a real
  * self-nesting local mount (e.g. a repo checkout whose `.claude/worktrees/`
  * re-contains the repo), which pegged the kernel worker in substrate mode.
+ *
+ * This variant has NO `isSameEntry` (like the in-memory Node FS), so exact
+ * cycle confirmation can't run — the depth cap is the safety net.
  */
 function makeCyclicHandle(): FileSystemDirectoryHandle {
   const self = {
@@ -17,6 +21,47 @@ function makeCyclicHandle(): FileSystemDirectoryHandle {
     },
   };
   return self as unknown as FileSystemDirectoryHandle;
+}
+
+/**
+ * Like `makeCyclicHandle` but it implements `isSameEntry`, returning true when
+ * compared against itself — so the fingerprint prefilter is confirmed by an
+ * exact match and the walk aborts with `'cycle-detected'` rather than falling
+ * through to the depth cap.
+ */
+function makeCyclicHandleWithIdentity(): FileSystemDirectoryHandle {
+  const self = {
+    kind: 'directory' as const,
+    isSameEntry: async (other: unknown) => other === self,
+    async *[Symbol.asyncIterator](): AsyncGenerator<[string, { kind: 'file' | 'directory' }]> {
+      yield ['file.txt', { kind: 'file' }];
+      yield ['loop', self];
+    },
+  };
+  return self as unknown as FileSystemDirectoryHandle;
+}
+
+/**
+ * A finite tree with several files plus a subdirectory, so the per-directory
+ * entry-budget check fires when descending into `sub`.
+ */
+function makeWideHandle(): FileSystemDirectoryHandle {
+  const sub = {
+    kind: 'directory' as const,
+    async *[Symbol.asyncIterator](): AsyncGenerator<[string, { kind: 'file' | 'directory' }]> {
+      yield ['x.txt', { kind: 'file' }];
+    },
+  };
+  const root = {
+    kind: 'directory' as const,
+    async *[Symbol.asyncIterator](): AsyncGenerator<[string, { kind: 'file' | 'directory' }]> {
+      yield ['a.txt', { kind: 'file' }];
+      yield ['b.txt', { kind: 'file' }];
+      yield ['c.txt', { kind: 'file' }];
+      yield ['sub', sub];
+    },
+  };
+  return root as unknown as FileSystemDirectoryHandle;
 }
 
 async function waitForTerminalState(
@@ -34,28 +79,65 @@ async function waitForTerminalState(
 }
 
 describe('MountIndex cycle safety', () => {
-  it('terminates a self-referential mount and flags it as likely cyclic', async () => {
-    const index = new MountIndex();
-    index.registerMount('/mnt/cyclic', makeCyclicHandle());
+  const savedEnv = {
+    depth: process.env.SLICC_MOUNT_INDEX_MAX_DEPTH,
+    entries: process.env.SLICC_MOUNT_INDEX_MAX_ENTRIES,
+  };
 
-    // The bounded walk must reach a terminal state quickly. Without the depth /
-    // entry caps the walk never returns and this stays 'indexing' until the
-    // poll deadline, failing the assertion (and, in production, wedging the
-    // worker). With the caps it aborts → 'error' (the mount falls back to the
-    // slow per-readDir path).
+  afterEach(() => {
+    if (savedEnv.depth === undefined) delete process.env.SLICC_MOUNT_INDEX_MAX_DEPTH;
+    else process.env.SLICC_MOUNT_INDEX_MAX_DEPTH = savedEnv.depth;
+    if (savedEnv.entries === undefined) delete process.env.SLICC_MOUNT_INDEX_MAX_ENTRIES;
+    else process.env.SLICC_MOUNT_INDEX_MAX_ENTRIES = savedEnv.entries;
+  });
+
+  it('aborts a self-referential mount with abortCause "cycle-detected" via isSameEntry', async () => {
+    const index = new MountIndex();
+    index.registerMount('/mnt/cyclic', makeCyclicHandleWithIdentity());
+
+    // The fingerprint prefilter matches the re-exposed ancestor, and the exact
+    // isSameEntry() confirmation proves the cycle — so the walk aborts as
+    // 'cycle-detected' (not merely depth-exceeded) and falls back to the slow
+    // per-readDir path.
     const status = await waitForTerminalState(index, '/mnt/cyclic', 4000);
     const state = index.getState('/mnt/cyclic');
     index.unregisterMount('/mnt/cyclic'); // abort the walk so it can't leak past the test
 
     expect(status).toBe('error');
-    // The error is attributable to a bound (cycle / oversized tree), not a
-    // backend failure — `mount list` renders an actionable unmount hint off this.
-    expect(state?.likelyCyclic).toBe(true);
+    expect(state?.abortCause).toBe('cycle-detected');
   }, 9000);
 
-  it('marks a generic backend failure as error WITHOUT the cyclic flag', async () => {
+  it('aborts with abortCause "depth-exceeded" when nesting exceeds the depth bound', async () => {
+    // No isSameEntry on this handle, so cycle confirmation can't run — the depth
+    // cap is the safety net. Lower the cap via env so the test is fast.
+    process.env.SLICC_MOUNT_INDEX_MAX_DEPTH = '3';
+    const index = new MountIndex();
+    index.registerMount('/mnt/deep', makeCyclicHandle());
+
+    const status = await waitForTerminalState(index, '/mnt/deep', 4000);
+    const state = index.getState('/mnt/deep');
+    index.unregisterMount('/mnt/deep');
+
+    expect(status).toBe('error');
+    expect(state?.abortCause).toBe('depth-exceeded');
+  }, 9000);
+
+  it('aborts with abortCause "entries-exceeded" when the entry budget is hit', async () => {
+    process.env.SLICC_MOUNT_INDEX_MAX_ENTRIES = '2';
+    const index = new MountIndex();
+    index.registerMount('/mnt/big', makeWideHandle());
+
+    const status = await waitForTerminalState(index, '/mnt/big', 4000);
+    const state = index.getState('/mnt/big');
+    index.unregisterMount('/mnt/big');
+
+    expect(status).toBe('error');
+    expect(state?.abortCause).toBe('entries-exceeded');
+  }, 9000);
+
+  it('marks a generic backend failure with abortCause "indexing-error"', async () => {
     // A handle whose iteration throws a non-bound error: still terminal 'error',
-    // but it is NOT a cycle, so the actionable-unmount hint must not fire.
+    // but it is NOT a classified abort, so it falls back to the generic cause.
     const failing = {
       kind: 'directory' as const,
       [Symbol.asyncIterator]() {
@@ -71,7 +153,7 @@ describe('MountIndex cycle safety', () => {
     index.unregisterMount('/mnt/broken');
 
     expect(status).toBe('error');
-    expect(state?.likelyCyclic).toBeFalsy();
+    expect(state?.abortCause).toBe('indexing-error');
   }, 9000);
 
   it('indexes a normal finite tree to ready', async () => {
@@ -91,4 +173,45 @@ describe('MountIndex cycle safety', () => {
     expect(status).toBe('ready');
     expect(index.getState('/mnt/finite')?.indexed).toBe(3); // 2 files + the root dir
   }, 9000);
+});
+
+describe('resolveMountIndexLimits', () => {
+  const DEFAULT_MAX_DEPTH = 400;
+  const DEFAULT_MAX_ENTRIES = 2_000_000;
+
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetLoggerDedupForTests();
+    setLogLevel(LogLevel.WARN);
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('reads positive-integer overrides from the env snapshot', () => {
+    const limits = resolveMountIndexLimits({
+      SLICC_MOUNT_INDEX_MAX_DEPTH: '12',
+      SLICC_MOUNT_INDEX_MAX_ENTRIES: '500',
+    });
+    expect(limits).toEqual({ maxDepth: 12, maxEntries: 500 });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to defaults and warns on invalid values', () => {
+    const limits = resolveMountIndexLimits({
+      SLICC_MOUNT_INDEX_MAX_DEPTH: '-5',
+      SLICC_MOUNT_INDEX_MAX_ENTRIES: 'not-a-number',
+    });
+    expect(limits).toEqual({ maxDepth: DEFAULT_MAX_DEPTH, maxEntries: DEFAULT_MAX_ENTRIES });
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses defaults silently when the env vars are absent', () => {
+    const limits = resolveMountIndexLimits({});
+    expect(limits).toEqual({ maxDepth: DEFAULT_MAX_DEPTH, maxEntries: DEFAULT_MAX_ENTRIES });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/webapp/tests/fs/mount-index.test.ts
+++ b/packages/webapp/tests/fs/mount-index.test.ts
@@ -79,18 +79,6 @@ async function waitForTerminalState(
 }
 
 describe('MountIndex cycle safety', () => {
-  const savedEnv = {
-    depth: process.env.SLICC_MOUNT_INDEX_MAX_DEPTH,
-    entries: process.env.SLICC_MOUNT_INDEX_MAX_ENTRIES,
-  };
-
-  afterEach(() => {
-    if (savedEnv.depth === undefined) delete process.env.SLICC_MOUNT_INDEX_MAX_DEPTH;
-    else process.env.SLICC_MOUNT_INDEX_MAX_DEPTH = savedEnv.depth;
-    if (savedEnv.entries === undefined) delete process.env.SLICC_MOUNT_INDEX_MAX_ENTRIES;
-    else process.env.SLICC_MOUNT_INDEX_MAX_ENTRIES = savedEnv.entries;
-  });
-
   it('aborts a self-referential mount with abortCause "cycle-detected" via isSameEntry', async () => {
     const index = new MountIndex();
     index.registerMount('/mnt/cyclic', makeCyclicHandleWithIdentity());
@@ -109,10 +97,14 @@ describe('MountIndex cycle safety', () => {
 
   it('aborts with abortCause "depth-exceeded" when nesting exceeds the depth bound', async () => {
     // No isSameEntry on this handle, so cycle confirmation can't run — the depth
-    // cap is the safety net. Lower the cap via env so the test is fast.
-    process.env.SLICC_MOUNT_INDEX_MAX_DEPTH = '3';
+    // cap is the safety net. Lower the cap via the resolved per-mount limits
+    // (sourced from the shell env, not process.env) so the test is fast.
     const index = new MountIndex();
-    index.registerMount('/mnt/deep', makeCyclicHandle());
+    index.registerMount(
+      '/mnt/deep',
+      makeCyclicHandle(),
+      resolveMountIndexLimits(new Map([['SLICC_MOUNT_INDEX_MAX_DEPTH', '3']]))
+    );
 
     const status = await waitForTerminalState(index, '/mnt/deep', 4000);
     const state = index.getState('/mnt/deep');
@@ -123,9 +115,12 @@ describe('MountIndex cycle safety', () => {
   }, 9000);
 
   it('aborts with abortCause "entries-exceeded" when the entry budget is hit', async () => {
-    process.env.SLICC_MOUNT_INDEX_MAX_ENTRIES = '2';
     const index = new MountIndex();
-    index.registerMount('/mnt/big', makeWideHandle());
+    index.registerMount(
+      '/mnt/big',
+      makeWideHandle(),
+      resolveMountIndexLimits(new Map([['SLICC_MOUNT_INDEX_MAX_ENTRIES', '2']]))
+    );
 
     const status = await waitForTerminalState(index, '/mnt/big', 4000);
     const state = index.getState('/mnt/big');
@@ -133,6 +128,34 @@ describe('MountIndex cycle safety', () => {
 
     expect(status).toBe('error');
     expect(state?.abortCause).toBe('entries-exceeded');
+  }, 9000);
+
+  it('aborts a huge flat directory DURING read, before buffering every child', async () => {
+    // A single directory with far more immediate children than the entry budget.
+    // The in-read budget check must abort once the running total would exceed
+    // maxEntries instead of buffering the full listing first (OOM guard).
+    let yielded = 0;
+    const flat = {
+      kind: 'directory' as const,
+      async *[Symbol.asyncIterator](): AsyncGenerator<[string, { kind: 'file' | 'directory' }]> {
+        for (let i = 0; i < 1000; i++) {
+          yielded++;
+          yield [`f${i}.txt`, { kind: 'file' }];
+        }
+      },
+    } as unknown as FileSystemDirectoryHandle;
+
+    const index = new MountIndex();
+    index.registerMount('/mnt/flat', flat, { maxDepth: 400, maxEntries: 5 });
+
+    const status = await waitForTerminalState(index, '/mnt/flat', 4000);
+    const state = index.getState('/mnt/flat');
+    index.unregisterMount('/mnt/flat');
+
+    expect(status).toBe('error');
+    expect(state?.abortCause).toBe('entries-exceeded');
+    // Proves the abort happened mid-read, not after materializing all 1000.
+    expect(yielded).toBeLessThan(1000);
   }, 9000);
 
   it('marks a generic backend failure with abortCause "indexing-error"', async () => {
@@ -212,6 +235,17 @@ describe('resolveMountIndexLimits', () => {
   it('uses defaults silently when the env vars are absent', () => {
     const limits = resolveMountIndexLimits({});
     expect(limits).toEqual({ maxDepth: DEFAULT_MAX_DEPTH, maxEntries: DEFAULT_MAX_ENTRIES });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('reads overrides from a just-bash env Map (ctx.env shape)', () => {
+    const limits = resolveMountIndexLimits(
+      new Map([
+        ['SLICC_MOUNT_INDEX_MAX_DEPTH', '12'],
+        ['SLICC_MOUNT_INDEX_MAX_ENTRIES', '500'],
+      ])
+    );
+    expect(limits).toEqual({ maxDepth: 12, maxEntries: 500 });
     expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/webapp/tests/fs/virtual-fs.mount.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.mount.test.ts
@@ -13,6 +13,21 @@ function backendOf(handle: FileSystemDirectoryHandle): LocalMountBackend {
 
 let dbCounter = 0;
 
+async function waitForTerminalState(
+  vfs: VirtualFS,
+  path: string,
+  timeoutMs: number
+): Promise<string | undefined> {
+  const index = vfs.getMountIndex();
+  const deadline = Date.now() + timeoutMs;
+  let state = index.getState(path);
+  while (Date.now() < deadline && (state?.status === 'indexing' || state?.status === 'pending')) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    state = index.getState(path);
+  }
+  return state?.status;
+}
+
 describe('VirtualFS mount interactions with script discovery', () => {
   let vfs: VirtualFS;
 
@@ -102,4 +117,46 @@ describe('VirtualFS mount interactions with script discovery', () => {
       ])
     );
   });
+
+  // Mount-index walk bounds must come from the just-bash shell env threaded
+  // through `mount` → `vfs.mount(..., { env })`, NOT `process.env` (absent in
+  // the worker/browser/Electron-renderer floats). A `Map` env carrying a low
+  // SLICC_MOUNT_INDEX_MAX_ENTRIES must therefore actually bound the indexer.
+  it('threads the shell env into the per-mount index walk bounds', async () => {
+    await vfs.mkdir('/mnt/wide', { recursive: true });
+    await vfs.mount(
+      '/mnt/wide',
+      backendOf(
+        createDirectoryHandle({
+          'a.txt': 'a',
+          'b.txt': 'b',
+          'c.txt': 'c',
+        })
+      ),
+      { env: new Map([['SLICC_MOUNT_INDEX_MAX_ENTRIES', '2']]) }
+    );
+
+    const status = await waitForTerminalState(vfs, '/mnt/wide', 4000);
+    const state = vfs.getMountIndex().getState('/mnt/wide');
+
+    expect(status).toBe('error');
+    expect(state?.abortCause).toBe('entries-exceeded');
+  }, 9000);
+
+  it('uses the default bounds when no shell env is supplied at mount time', async () => {
+    await vfs.mkdir('/mnt/ok', { recursive: true });
+    await vfs.mount(
+      '/mnt/ok',
+      backendOf(
+        createDirectoryHandle({
+          'a.txt': 'a',
+          'b.txt': 'b',
+          'c.txt': 'c',
+        })
+      )
+    );
+
+    const status = await waitForTerminalState(vfs, '/mnt/ok', 4000);
+    expect(status).toBe('ready');
+  }, 9000);
 });


### PR DESCRIPTION
Closes #1186.

## Problem

Legitimate large/deep mounts were being mislabeled as "likely cyclic" because the mount indexer used low bounds (depth 40 / 200,000 entries) and a single boolean `likelyCyclic` flag that conflated three very different situations: a real self-reference, a tree that is simply deep, and a tree that is simply large.

## Changes

**Core (`packages/webapp/src/fs/mount-index.ts`)**
- Raised default index bounds 10x: depth `40 -> 400`, entries `200,000 -> 2,000,000`.
- Made both bounds overridable via env vars `SLICC_MOUNT_INDEX_MAX_DEPTH` and `SLICC_MOUNT_INDEX_MAX_ENTRIES`, resolved through a pure `resolveMountIndexLimits` helper. Invalid values (non-numeric / zero / negative / NaN) fall back to the default and emit a `log.warn`.
- Replaced the boolean `likelyCyclic` with a four-value `abortCause` taxonomy: `depth-exceeded`, `entries-exceeded`, `cycle-detected`, `indexing-error` (carried by `MountIndexAbortError`).
- Added fingerprint-bucketed cycle detection: a cheap per-directory signature (sorted name+kind, child count) prefilters candidates, and a match is confirmed **only** by `FileSystemHandle.isSameEntry()`. A fingerprint match alone never sets `cycle-detected`.
- `walkHandle` refactored into small helpers (`enforceWalkBounds` / `readChildren` / `confirmNoCycle` / `pushAncestor` / `popAncestor` / `walkChildren`) to satisfy the cognitive-complexity gate without any biome-ignore.

**Rendering (`mount-commands.ts`)**
- `mount list` renders a distinct, actionable message per abort cause (e.g. an entry-budget abort says the tree is *too large*, not that it is probably cyclic). Aborted/failed indexes still fall back to the slow per-`readDir` path.

**Docs**
- Updated `docs/mounts.md`, `docs/shell-reference.md`, and `packages/vfs-root/workspace/skills/mount/SKILL.md` to document the raised defaults, the two env vars, and the four index-skip states.

## Verification

- lint PASS, typecheck PASS (7 tsc projects), mount-index + mount-commands tests 38/38 PASS, `test:coverage:webapp` floors held.
- All 5 correctness invariants verified: `isSameEntry()` is the sole `cycle-detected` trigger (guarded against undefined/throw); `resolveMountIndexLimits` is wired into `walkHandle`; invalid env -> defaults + warn; aborted index keeps the slow-path fallback; no remaining `likelyCyclic` / `MountIndexBoundError` references.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author