### PR TITLE
docs(chrome-extension): correct dev leader-tab URL to :8787

### DIFF
--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -242,7 +242,7 @@ of the webapp is required.
    ```
 
 6. **Open the hosted leader tab** — the thin extension's UI lives at
-   `https://www.sliccy.ai/?slicc=leader` (or `http://localhost:5710/?slicc=leader`
+   `https://www.sliccy.ai/?slicc=leader` (or `http://localhost:8787/?slicc=leader`
    when `SLICC_EXT_DEV=1`). The service worker pins it on install, but
    you can drive it directly via CDP:
 


### PR DESCRIPTION
The local-debug recipe in `packages/chrome-extension/CLAUDE.md` stated that the `SLICC_EXT_DEV` leader tab opens at `http://localhost:5710/?slicc=leader`. That port is wrong: `service-worker.ts`'s `DEV_LEADER_TAB_URL` constant and the same document's line ~189 both use `:8787` (the Wrangler dev port). This fix corrects the one stale occurrence to `:8787` so the doc is internally consistent and matches the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)