### PR TITLE
fix(webapp): bridge worker silent token renewal to the page (#1181)

### DIFF
--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -36,6 +36,7 @@ import {
   streamSimpleAnthropic,
   streamSimpleOpenAICompletions,
 } from '@earendil-works/pi-ai';
+import { getPanelRpcClient } from '../src/kernel/panel-rpc.js';
 import { withAdaptiveThinkingShim } from '../src/providers/adaptive-thinking.js';
 import {
   type AdobeModelMetadata,
@@ -515,11 +516,32 @@ function isTokenExpired(): boolean {
  */
 async function silentRenewToken(): Promise<string | null> {
   // Silent renewal needs a DOM (popup/iframe) to drive the IMS authorize
-  // flow. The kernel-worker has no `window`, so bail out cleanly here and
-  // let getValidAccessToken surface "session expired — please log in again"
-  // back to the page. The page-side oauth-bootstrap is responsible for
-  // pre-renewing tokens before the worker streams.
-  if (typeof window === 'undefined') return null;
+  // flow. The kernel-worker has no `window`, so bridge to the page realm
+  // over panel-RPC: the page runs the renewal and persists the rotated
+  // token via saveOAuthAccount, which fans back into the worker's
+  // localStorage shim (issue #1181). When no bridge is published yet
+  // (pre-attach boot) we fall back to null — oauth-bootstrap still
+  // pre-renews tokens before the worker streams.
+  if (typeof window === 'undefined') {
+    const rpc = getPanelRpcClient();
+    if (!rpc) return null;
+    try {
+      // Generous timeout: page-side renewal can drive a full IMS authorize
+      // round-trip (matches the oauth-popup op's window).
+      const { accessToken } = await rpc.call(
+        'silent-renew',
+        { providerId: 'adobe' },
+        { timeoutMs: 130_000 }
+      );
+      return accessToken;
+    } catch (err) {
+      console.warn(
+        '[adobe] worker→page silent-renew bridge failed:',
+        err instanceof Error ? err.message : String(err)
+      );
+      return null;
+    }
+  }
 
   // Deduplicate concurrent renewal attempts
   if (renewalInProgress) return renewalInProgress;

--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -127,6 +127,19 @@ export type PanelRpcRequest =
       payload: { url: string };
     }
   | {
+      // Drive a provider's `onSilentRenew()` from the page realm on behalf
+      // of the kernel worker. The worker has no `window` to run the IMS
+      // popup/iframe flow, so a worker-realm provider (e.g. Adobe) bridges
+      // here instead of bailing on `typeof window === 'undefined'`. The page
+      // renews and persists the rotated token via `saveOAuthAccount`, which
+      // fans back into the worker's localStorage shim. Gated worker-side by
+      // `silentRenewBackoff` so a revoked session can't hot-loop (issue
+      // #1181). Result `accessToken` is null when the provider is unknown,
+      // has no renewal hook, or renewal failed.
+      op: 'silent-renew';
+      payload: { providerId: string };
+    }
+  | {
       op: 'capture-camera';
       payload: {
         mode: 'photo' | 'video';
@@ -511,6 +524,7 @@ export interface PanelRpcResults {
   'clipboard-write-image': { done: true };
   'window-open': { opened: boolean };
   'oauth-popup': { redirectUrl: string | null };
+  'silent-renew': { accessToken: string | null };
   'capture-camera': {
     bytes: ArrayBuffer;
     mimeType: string;

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -583,6 +583,19 @@ function buildTrayOauthHandlers(options: StandalonePanelRpcHandlerOptions) {
       return { storeAfter: getAllExtraOAuthDomains() };
     },
 
+    'silent-renew': async ({ providerId }) => {
+      // Page-side silent token renewal for a worker-realm provider that
+      // can't drive the IMS popup/iframe flow without a `window` (issue
+      // #1181). Runs the provider's registered `onSilentRenew`, which
+      // persists the rotated token via `saveOAuthAccount` so it fans back
+      // into the worker's localStorage shim. Returns null when the provider
+      // is unknown or exposes no renewal hook.
+      const { getRegisteredProviderConfig } = await import('../providers/index.js');
+      const cfg = getRegisteredProviderConfig(providerId);
+      if (!cfg?.onSilentRenew) return { accessToken: null };
+      return { accessToken: await cfg.onSilentRenew() };
+    },
+
     'save-oauth-accounts': ({ accountsJson }) => {
       // Page-side write of `slicc_accounts` for `saveOAuthAccount`
       // calls originating in the kernel worker (`mcp add`, MCP

--- a/packages/webapp/tests/providers/adobe-session-expired-worker.test.ts
+++ b/packages/webapp/tests/providers/adobe-session-expired-worker.test.ts
@@ -1,30 +1,33 @@
 /**
- * Regression reproduction for issue #1181:
+ * Regression coverage for issue #1181:
  * "Adobe session expired surfaces as unrecoverable cone error when token
  *  expires mid-session in worker realm".
  *
- * Bug chain being reproduced:
+ * Original bug chain:
  *  1. The kernel-worker realm has no DOM, so `typeof window === 'undefined'`.
  *  2. When the locally-cached IMS token has crossed its `tokenExpiresAt`
  *     boundary, `getValidAccessToken` (providers/adobe.ts) calls
- *     `silentRenewToken`, which short-circuits with `return null` because it
+ *     `silentRenewToken`, which short-circuited with `return null` because it
  *     cannot drive the IMS popup/iframe flow without a `window`.
- *  3. With no renewed token, `getValidAccessToken` throws the literal
- *     `Adobe session expired — please log in again` — this is the raw stream
- *     error RUM records under `source: llm`.
+ *  3. With no renewed token, `getValidAccessToken` threw the literal
+ *     `Adobe session expired — please log in again` — the raw stream error
+ *     RUM records under `source: llm`.
  *  4. `isNonRetryableError` (scoops/scoop-context.ts) matches the
  *     `session expired|log in again` pattern, so the cone's
- *     `handleNonRetryableError` skips retry and re-emits the SAME message
+ *     `handleNonRetryableError` skipped retry and re-emitted the SAME message
  *     wrapped as `Scoop "Cone" failed with unrecoverable error: …` under
  *     `source: scoop:cone` — the second RUM fingerprint.
  *
- * This file does NOT fix the bug; it pins the failing behavior so the eventual
- * fix (a worker→page silent-renew RPC, per the issue) has a reproduction to
- * flip. The vitest `webapp` project runs in the `node` environment, which has
- * no `window`, so the worker-realm condition holds with no extra setup.
+ * The fix bridges the worker to the page over panel-RPC: when `window` is
+ * absent `silentRenewToken` calls the `silent-renew` op so the page realm
+ * renews on its behalf. This file pins both the fixed path (a renewal comes
+ * back through the bridge) and the preserved graceful fallback (no bridge ⇒
+ * the old session-expired surface). The vitest `webapp` project runs in the
+ * `node` environment, which has no `window`, so the worker-realm condition
+ * holds with no extra setup; the panel-RPC bridge is stubbed per test.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isNonRetryableError } from '../../src/scoops/scoop-context.js';
 
 // Map-backed localStorage shim — mirrors how the kernel worker reads the
@@ -58,22 +61,77 @@ function seedAdobeAccount(tokenExpiresAt: number): void {
   );
 }
 
+/**
+ * Publish a stub panel-RPC bridge on `globalThis.__slicc_panelRpc` — the
+ * surface `getPanelRpcClient()` reads. `handler` answers each op; the
+ * worker-side `silentRenewToken` calls `silent-renew`.
+ */
+function installPanelRpcBridge(handler: (op: string, payload: unknown) => unknown): void {
+  (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = {
+    call: vi.fn(async (op: string, payload?: unknown) => handler(op, payload)),
+    onEvent: () => () => {},
+    registerPushTarget: () => {},
+    unregisterPushTarget: () => {},
+    dispose: () => {},
+  };
+}
+
 describe('issue #1181: Adobe session expiry in the worker realm', () => {
-  beforeEach(() => storage.clear());
+  beforeEach(() => {
+    storage.clear();
+    // Each test imports a fresh adobe.js so the module-level silent-renew
+    // backoff / in-flight dedup don't leak across cases.
+    vi.resetModules();
+    delete (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc;
+  });
+
+  afterEach(() => {
+    delete (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc;
+  });
 
   it('has no DOM — the worker-realm precondition the bug depends on', () => {
     expect(typeof window).toBe('undefined');
   });
 
-  it('throws the literal session-expired error when an expired token cannot be silently renewed', async () => {
+  it('renews via the panel-RPC bridge when the page can silently refresh the token (the #1181 fix)', async () => {
     seedAdobeAccount(Date.now() - 60_000); // expired one minute ago
+    installPanelRpcBridge((op) => {
+      if (op === 'silent-renew') return { accessToken: 'renewed-access-token' };
+      throw new Error(`unexpected op ${op}`);
+    });
+    const { getValidAccessToken } = await import('../../providers/adobe.js');
+
+    // The worker no longer bails: the bridged page renewal flows back.
+    await expect(getValidAccessToken()).resolves.toBe('renewed-access-token');
+  });
+
+  it('forwards the adobe providerId to the bridge silent-renew op', async () => {
+    seedAdobeAccount(Date.now() - 60_000);
+    let seenOp: string | undefined;
+    let seenPayload: unknown;
+    installPanelRpcBridge((op, payload) => {
+      seenOp = op;
+      seenPayload = payload;
+      return { accessToken: 'renewed-access-token' };
+    });
+    const { getValidAccessToken } = await import('../../providers/adobe.js');
+
+    await getValidAccessToken();
+    expect(seenOp).toBe('silent-renew');
+    expect(seenPayload).toEqual({ providerId: 'adobe' });
+  });
+
+  it('still surfaces session-expired when no page bridge is available to renew', async () => {
+    seedAdobeAccount(Date.now() - 60_000);
+    // No __slicc_panelRpc published → worker silentRenewToken falls back to
+    // null, reproducing the pre-attach / no-bridge graceful path.
     const { getValidAccessToken } = await import('../../providers/adobe.js');
 
     // This is the raw stream error RUM records under `source: llm`.
     await expect(getValidAccessToken()).rejects.toThrow(SESSION_EXPIRED);
   });
 
-  it('classifies the surfaced error as non-retryable, producing the wrapped cone error', async () => {
+  it('classifies the no-bridge surfaced error as non-retryable, producing the wrapped cone error', async () => {
     seedAdobeAccount(Date.now() - 60_000);
     const { getValidAccessToken } = await import('../../providers/adobe.js');
 

--- a/packages/webapp/tests/providers/adobe-session-expired-worker.test.ts
+++ b/packages/webapp/tests/providers/adobe-session-expired-worker.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression reproduction for issue #1181:
+ * "Adobe session expired surfaces as unrecoverable cone error when token
+ *  expires mid-session in worker realm".
+ *
+ * Bug chain being reproduced:
+ *  1. The kernel-worker realm has no DOM, so `typeof window === 'undefined'`.
+ *  2. When the locally-cached IMS token has crossed its `tokenExpiresAt`
+ *     boundary, `getValidAccessToken` (providers/adobe.ts) calls
+ *     `silentRenewToken`, which short-circuits with `return null` because it
+ *     cannot drive the IMS popup/iframe flow without a `window`.
+ *  3. With no renewed token, `getValidAccessToken` throws the literal
+ *     `Adobe session expired — please log in again` — this is the raw stream
+ *     error RUM records under `source: llm`.
+ *  4. `isNonRetryableError` (scoops/scoop-context.ts) matches the
+ *     `session expired|log in again` pattern, so the cone's
+ *     `handleNonRetryableError` skips retry and re-emits the SAME message
+ *     wrapped as `Scoop "Cone" failed with unrecoverable error: …` under
+ *     `source: scoop:cone` — the second RUM fingerprint.
+ *
+ * This file does NOT fix the bug; it pins the failing behavior so the eventual
+ * fix (a worker→page silent-renew RPC, per the issue) has a reproduction to
+ * flip. The vitest `webapp` project runs in the `node` environment, which has
+ * no `window`, so the worker-realm condition holds with no extra setup.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { isNonRetryableError } from '../../src/scoops/scoop-context.js';
+
+// Map-backed localStorage shim — mirrors how the kernel worker reads the
+// `slicc_accounts` token replica the page pushed in before boot.
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => storage.set(k, v),
+  removeItem: (k: string) => storage.delete(k),
+  get length() {
+    return storage.size;
+  },
+  key: (i: number) => [...storage.keys()][i] ?? null,
+  clear: () => storage.clear(),
+});
+
+const SESSION_EXPIRED = 'Adobe session expired — please log in again';
+
+/** Seed the `slicc_accounts` replica with a single Adobe account. */
+function seedAdobeAccount(tokenExpiresAt: number): void {
+  storage.set(
+    'slicc_accounts',
+    JSON.stringify([
+      {
+        providerId: 'adobe',
+        apiKey: 'cached-access-token',
+        accessToken: 'cached-access-token',
+        tokenExpiresAt,
+      },
+    ])
+  );
+}
+
+describe('issue #1181: Adobe session expiry in the worker realm', () => {
+  beforeEach(() => storage.clear());
+
+  it('has no DOM — the worker-realm precondition the bug depends on', () => {
+    expect(typeof window).toBe('undefined');
+  });
+
+  it('throws the literal session-expired error when an expired token cannot be silently renewed', async () => {
+    seedAdobeAccount(Date.now() - 60_000); // expired one minute ago
+    const { getValidAccessToken } = await import('../../providers/adobe.js');
+
+    // This is the raw stream error RUM records under `source: llm`.
+    await expect(getValidAccessToken()).rejects.toThrow(SESSION_EXPIRED);
+  });
+
+  it('classifies the surfaced error as non-retryable, producing the wrapped cone error', async () => {
+    seedAdobeAccount(Date.now() - 60_000);
+    const { getValidAccessToken } = await import('../../providers/adobe.js');
+
+    const message = await getValidAccessToken().then(
+      () => {
+        throw new Error('expected getValidAccessToken to reject');
+      },
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
+
+    // The cone treats this as terminal (no retry, no live re-auth) ...
+    expect(isNonRetryableError(message)).toBe(true);
+
+    // ... and re-emits the SAME text wrapped under `source: scoop:cone`.
+    // Mirrors ScoopContext.handleNonRetryableError's fatal-error format.
+    const wrapped = `Scoop "Cone" failed with unrecoverable error: ${message}`;
+    expect(wrapped).toBe(
+      'Scoop "Cone" failed with unrecoverable error: Adobe session expired — please log in again'
+    );
+  });
+
+  it('control: a still-valid token is returned without attempting renewal', async () => {
+    seedAdobeAccount(Date.now() + 10 * 60_000); // 10 minutes of headroom
+    const { getValidAccessToken } = await import('../../providers/adobe.js');
+
+    await expect(getValidAccessToken()).resolves.toBe('cached-access-token');
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #1181. In the kernel-worker realm there is no DOM, so once the cached Adobe IMS token crosses `tokenExpiresAt`, the silent-renewal path in `packages/webapp/providers/adobe.ts` short-circuited on `typeof window === 'undefined'` and `getValidAccessToken` threw the literal `Adobe session expired — please log in again`. `isNonRetryableError` (`scoops/scoop-context.ts`) matches that text, so the cone re-emitted it wrapped as the unrecoverable `scoop:cone` error — the two RUM fingerprints in the issue.

## Solution

Bridges silent renewal from the worker to the page over panel-RPC:

- `packages/webapp/src/kernel/panel-rpc.ts` — new `silent-renew` op (typed payload `{ providerId }`, result `{ accessToken: string | null }`).
- `packages/webapp/src/ui/panel-rpc-handlers.ts` — page handler runs the registered provider's `onSilentRenew()` (loaded via `getRegisteredProviderConfig`), which persists the rotated token via `saveOAuthAccount` so it fans back into the worker's `localStorage` shim.
- `packages/webapp/providers/adobe.ts` — `silentRenewToken` now calls the bridge when `typeof window === 'undefined'` instead of returning `null`. Worker-side renewal stays gated by `silentRenewBackoff` so a revoked session can't hot-loop, and falls back to the prior session-expired surface only when no bridge is published (pre-attach boot). Returns the new access token (`{ accessToken }`) on success.

Commits are stacked so the regression is visible standalone:

1. `14a133d` — adds the failing-then-passing regression suite that pins the worker-realm chain end-to-end.
2. `1f55292` — implements the bridge + flips the test to assert the renewed token flows back.

## Testing

- `vitest run --project webapp packages/webapp/tests/providers/adobe-session-expired-worker.test.ts` — 6 passing, covering: worker-realm precondition (no `window`), bridged renewal, payload/op forwarding (`silent-renew` + `{ providerId: 'adobe' }`), no-bridge fallback, non-retryable classification + wrapped cone error, and still-valid-token control.
- Adjacent suites (`panel-rpc`, `adobe`, `github-oauth`) green.
- `biome check` + `prettier --check` clean; both `tsc --noEmit` targets clean (incl. the no-DOM worker guard).
- Staging worker deploy + smoke tests green.

Closes #1181

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KW1YDTNESMHR6QR6KC8B0JVJ&panel=chat)
