### PR TITLE
fix(tray): sync sprinkle content reloads to followers

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -331,7 +331,6 @@
         "packages/webapp/src/shell/supplemental-commands/pdftk-command.ts",
         "packages/webapp/src/shell/supplemental-commands/ps-command.ts",
         "packages/webapp/src/shell/supplemental-commands/screencapture-command.ts",
-        "packages/webapp/src/shell/supplemental-commands/sprinkle-command.ts",
         "packages/webapp/src/shell/supplemental-commands/sqlite-command.ts",
         "packages/webapp/src/shell/supplemental-commands/unzip-command.ts",
         "packages/webapp/src/shell/supplemental-commands/webhook-command.ts",

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -64,6 +64,8 @@ class AppState: ObservableObject {
     private var sprinkleContentWaiters: [String: [CheckedContinuation<String, Error>]] = [:]
     /// Most recent sprinkle update payloads keyed by sprinkle name. Drained by views.
     @Published var sprinkleUpdates: [String: AnyCodable] = [:]
+    /// Monotonic reload generation per sprinkle; bumped on `sprinkle.reloaded`.
+    @Published var sprinkleReloadGeneration: [String: Int] = [:]
 
     // Connection metadata (populated after successful connect)
     @Published var leaderConnected: Bool = false
@@ -669,6 +671,11 @@ class AppState: ObservableObject {
             if let data = data {
                 sprinkleUpdates[sprinkleName] = data
             }
+
+        case let .sprinkleReloaded(sprinkleName):
+            logger.info("Sprinkle reloaded on leader: \(sprinkleName)")
+            sprinkleContents.removeValue(forKey: sprinkleName)
+            sprinkleReloadGeneration[sprinkleName, default: 0] += 1
 
         case let .cdpRequest(requestId, localTargetId, method, params, sessionId):
             logger.debug("CDP request \(method) target=\(localTargetId)")

--- a/packages/ios-app/SliccFollower/Models/SyncProtocol.swift
+++ b/packages/ios-app/SliccFollower/Models/SyncProtocol.swift
@@ -179,6 +179,7 @@ enum LeaderToFollowerMessage: Codable {
         totalChunks: Int?,
         error: String?)
     case sprinkleUpdate(sprinkleName: String, data: AnyCodable?)
+    case sprinkleReloaded(sprinkleName: String)
     // CDP / federated targets — leader → follower
     case cdpRequest(
         requestId: String,
@@ -252,6 +253,10 @@ enum LeaderToFollowerMessage: Codable {
             self = .sprinkleUpdate(
                 sprinkleName: try container.decode(String.self, forKey: .sprinkleName),
                 data: try container.decodeIfPresent(AnyCodable.self, forKey: .data)
+            )
+        case "sprinkle.reloaded":
+            self = .sprinkleReloaded(
+                sprinkleName: try container.decode(String.self, forKey: .sprinkleName)
             )
         case "cdp.request":
             self = .cdpRequest(
@@ -336,6 +341,9 @@ enum LeaderToFollowerMessage: Codable {
             try container.encode("sprinkle.update", forKey: .type)
             try container.encode(sprinkleName, forKey: .sprinkleName)
             try container.encodeIfPresent(data, forKey: .data)
+        case let .sprinkleReloaded(sprinkleName):
+            try container.encode("sprinkle.reloaded", forKey: .type)
+            try container.encode(sprinkleName, forKey: .sprinkleName)
         case let .cdpRequest(requestId, localTargetId, method, params, sessionId):
             try container.encode("cdp.request", forKey: .type)
             try container.encode(requestId, forKey: .requestId)

--- a/packages/ios-app/SliccFollower/Sync/FollowerSyncManager.swift
+++ b/packages/ios-app/SliccFollower/Sync/FollowerSyncManager.swift
@@ -146,8 +146,8 @@ class FollowerSyncManager {
             }
 
         case .scoopsList, .sprinklesList, .sprinkleContent, .sprinkleUpdate,
-             .cdpRequest, .targetsRegistry, .tabOpen, .cherrySliccEvent,
-             .previewOpen:
+             .sprinkleReloaded, .cdpRequest, .targetsRegistry, .tabOpen,
+             .cherrySliccEvent, .previewOpen:
             // Newer protocol messages — handled by AppState directly, not by this
             // legacy delegate-based sync manager. Ignored here.
             break

--- a/packages/ios-app/SliccFollower/Views/SprinkleSidebarView.swift
+++ b/packages/ios-app/SliccFollower/Views/SprinkleSidebarView.swift
@@ -227,7 +227,7 @@ struct SprinkleDetailView: View {
         .task(id: sprinkle.id) {
             await load()
         }
-        .onChange(of: appState.sprinkleReloadGeneration[sprinkle.name]) {
+        .onChange(of: appState.sprinkleReloadGeneration[sprinkle.name]) { _ in
             Task { await load() }
         }
     }

--- a/packages/ios-app/SliccFollower/Views/SprinkleSidebarView.swift
+++ b/packages/ios-app/SliccFollower/Views/SprinkleSidebarView.swift
@@ -227,6 +227,9 @@ struct SprinkleDetailView: View {
         .task(id: sprinkle.id) {
             await load()
         }
+        .onChange(of: appState.sprinkleReloadGeneration[sprinkle.name]) {
+            Task { await load() }
+        }
     }
 
     private func load() async {

--- a/packages/webapp/src/kernel/kernel-worker.ts
+++ b/packages/webapp/src/kernel/kernel-worker.ts
@@ -319,8 +319,39 @@ async function boot(init: KernelWorkerInitMsg): Promise<void> {
   const { createSprinkleManagerProxyOverChannel } = await import(
     '../scoops/sprinkle-bridge-channel.js'
   );
-  (globalThis as Record<string, unknown>).__slicc_sprinkleManager =
-    createSprinkleManagerProxyOverChannel({ instanceId: init.instanceId });
+  const sprinkleProxy = createSprinkleManagerProxyOverChannel({ instanceId: init.instanceId });
+  (globalThis as Record<string, unknown>).__slicc_sprinkleManager = sprinkleProxy;
+
+  // Auto-reload open sprinkles when their .shtml file changes in the VFS.
+  const watcher = host.sharedFs?.getWatcher();
+  if (watcher) {
+    const SPRINKLE_ROOTS = ['/workspace', '/shared', '/scoops'] as const;
+    let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+    const pendingReloads = new Set<string>();
+    for (const root of SPRINKLE_ROOTS) {
+      watcher.watch(
+        root,
+        (path) => path.endsWith('.shtml'),
+        (events) => {
+          for (const e of events) {
+            const base = e.path
+              .split('/')
+              .pop()
+              ?.replace(/\.shtml$/, '');
+            if (base) pendingReloads.add(base);
+          }
+          if (reloadTimer) return;
+          reloadTimer = setTimeout(() => {
+            reloadTimer = null;
+            for (const name of pendingReloads) {
+              sprinkleProxy.reload(name).catch(() => {});
+            }
+            pendingReloads.clear();
+          }, 300);
+        }
+      );
+    }
+  }
 
   // Publish the panel-RPC bridge client. DOM-bound shell supplemental
   // commands (`screencapture`, `say`, `afplay`, `pbcopy`/`pbpaste`,

--- a/packages/webapp/src/scoops/sprinkle-bridge-channel.ts
+++ b/packages/webapp/src/scoops/sprinkle-bridge-channel.ts
@@ -49,7 +49,7 @@ export function sprinkleBridgeChannelName(instanceId?: string): string {
 export interface SprinkleBridgeRequestMsg {
   type: 'sprinkle-op-request';
   id: string;
-  op: 'list' | 'opened' | 'refresh' | 'open' | 'close' | 'send' | 'openNewAutoOpen';
+  op: 'list' | 'opened' | 'refresh' | 'open' | 'close' | 'send' | 'reload' | 'openNewAutoOpen';
   name?: string;
   data?: unknown;
 }
@@ -163,6 +163,9 @@ export function createSprinkleManagerProxyOverChannel(
     sendToSprinkle(name: string, data: unknown): void {
       request('send', { name, data }).catch(() => {});
     },
+    async reload(name: string): Promise<void> {
+      await request('reload', { name });
+    },
     async openNewAutoOpenSprinkles(): Promise<void> {
       await request('openNewAutoOpen');
     },
@@ -183,6 +186,9 @@ function makeNullProxy(): SprinkleManager {
     },
     close: () => {},
     sendToSprinkle: () => {},
+    reload: async () => {
+      throw unavailable('reload');
+    },
     openNewAutoOpenSprinkles: async () => {
       throw unavailable('openNewAutoOpenSprinkles');
     },
@@ -251,6 +257,10 @@ export function installSprinkleManagerHandlerOverChannel(
             return;
           case 'send':
             manager.sendToSprinkle(name ?? '', data);
+            respond(id, true);
+            return;
+          case 'reload':
+            await manager.reload(name ?? '');
             respond(id, true);
             return;
           case 'openNewAutoOpen':

--- a/packages/webapp/src/scoops/tray-follower-sync.ts
+++ b/packages/webapp/src/scoops/tray-follower-sync.ts
@@ -67,6 +67,8 @@ export interface FollowerSyncManagerOptions {
   onSprinklesList?: (sprinkles: SprinkleSummary[]) => void;
   /** Called when the leader sends a `sprinkle.update` payload (mirrors `SprinkleManager.sendToSprinkle`). */
   onSprinkleUpdate?: (sprinkleName: string, data: unknown) => void;
+  /** Called when the leader signals that a sprinkle's content has been reloaded (file changed). */
+  onSprinkleReloaded?: (sprinkleName: string) => void;
   /**
    * Called when the leader sends a `cherry.slicc_event` (cone → host page). Only
    * a cherry follower wires this — it forwards the event to the host SDK via
@@ -662,8 +664,10 @@ export class FollowerSyncManager implements AgentHandle {
         break;
 
       case 'sprinkle.update':
-        log.debug('Sprinkle update received', { sprinkleName: message.sprinkleName });
         this.options.onSprinkleUpdate?.(message.sprinkleName, message.data);
+        break;
+      case 'sprinkle.reloaded':
+        this.handleSprinkleReloaded(message.sprinkleName);
         break;
 
       case 'cherry.slicc_event':
@@ -703,6 +707,11 @@ export class FollowerSyncManager implements AgentHandle {
    * fetchers. Mirrors `handleSprinkleContent` in iOS `AppState.swift` — same
    * chunk-buffer + ordered-join + waiter-resolve flow, plus error rejection.
    */
+  private handleSprinkleReloaded(sprinkleName: string): void {
+    this.sprinkleContentCache.delete(sprinkleName);
+    this.options.onSprinkleReloaded?.(sprinkleName);
+  }
+
   private handleSprinkleContent(
     message: LeaderToFollowerMessage & { type: 'sprinkle.content' }
   ): void {

--- a/packages/webapp/src/scoops/tray-leader-sync.ts
+++ b/packages/webapp/src/scoops/tray-leader-sync.ts
@@ -564,6 +564,16 @@ export class LeaderSyncManager {
   }
 
   /**
+   * Notify every connected follower that a sprinkle's content has changed
+   * and should be re-fetched/re-rendered. The follower closes and reopens
+   * the sprinkle locally to pick up the new `.shtml`.
+   */
+  broadcastSprinkleReloaded(sprinkleName: string): void {
+    if (this.followers.size === 0) return;
+    this.broadcastToAllFollowers({ type: 'sprinkle.reloaded', sprinkleName });
+  }
+
+  /**
    * Tell every connected follower to open the worker-served preview URL.
    * Phase 1: fire-and-forget; followers don't ack (no preview.opened reply).
    */

--- a/packages/webapp/src/scoops/tray-leader-sync.ts
+++ b/packages/webapp/src/scoops/tray-leader-sync.ts
@@ -565,8 +565,7 @@ export class LeaderSyncManager {
 
   /**
    * Notify every connected follower that a sprinkle's content has changed
-   * and should be re-fetched/re-rendered. The follower closes and reopens
-   * the sprinkle locally to pick up the new `.shtml`.
+   * and should be re-fetched and re-rendered in place.
    */
   broadcastSprinkleReloaded(sprinkleName: string): void {
     if (this.followers.size === 0) return;

--- a/packages/webapp/src/scoops/tray-sync-protocol.ts
+++ b/packages/webapp/src/scoops/tray-sync-protocol.ts
@@ -74,6 +74,7 @@ export type LeaderToFollowerMessage =
       error?: string;
     }
   | { type: 'sprinkle.update'; sprinkleName: string; data: unknown }
+  | { type: 'sprinkle.reloaded'; sprinkleName: string }
   | { type: 'targets.registry'; targets: TrayTargetEntry[] }
   | {
       type: 'cdp.request';

--- a/packages/webapp/src/shell/supplemental-commands/sprinkle-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/sprinkle-command.ts
@@ -11,7 +11,7 @@
  *   echo "<html>" | sprinkle chat  — show piped HTML in chat
  */
 
-import type { Command } from 'just-bash';
+import type { Command, CommandContext } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { showToolUIFromContext } from '../../tools/tool-ui.js';
 import {
@@ -23,7 +23,9 @@ import {
 import type { SprinkleManager } from '../../ui/sprinkle-manager.js';
 import { stdinAsText } from '../just-bash-compat.js';
 
-function sprinkleHelp(): { stdout: string; stderr: string; exitCode: number } {
+type Result = { stdout: string; stderr: string; exitCode: number };
+
+function sprinkleHelp(): Result {
   return {
     stdout:
       'usage: sprinkle <subcommand> [args]\n\n' +
@@ -45,13 +47,141 @@ function sprinkleHelp(): { stdout: string; stderr: string; exitCode: number } {
 }
 
 function getSprinkleManager(): SprinkleManager | null {
-  // Read from `globalThis` rather than `window` so the lookup works in
-  // both the page realm (where the real `SprinkleManager` is published
-  // by the standalone bootstrap) and the kernel-worker realm (where a
-  // BroadcastChannel-backed proxy from `sprinkle-bridge-channel.ts` is
-  // published on `globalThis.__slicc_sprinkleManager`).
   const mgr = (globalThis as Record<string, unknown>).__slicc_sprinkleManager;
   return (mgr as SprinkleManager) ?? null;
+}
+
+async function handleChat(args: string[], ctx: CommandContext): Promise<Result> {
+  let html = args.slice(1).join(' ');
+  if (!html) {
+    const stdinText = stdinAsText(ctx.stdin);
+    if (stdinText) html = stdinText;
+  }
+  if (!html) {
+    return { stdout: '', stderr: 'sprinkle chat: HTML content required\n', exitCode: 1 };
+  }
+  const result = await showToolUIFromContext({
+    html,
+    onAction: async (action, data) => ({ action, data }),
+  });
+  if (result === null) {
+    return { stdout: '', stderr: 'sprinkle chat: not in tool execution context\n', exitCode: 1 };
+  }
+  return { stdout: JSON.stringify(result) + '\n', stderr: '', exitCode: 0 };
+}
+
+async function handleList(mgr: SprinkleManager): Promise<Result> {
+  await mgr.refresh();
+  const sprinkles = mgr.available();
+  if (sprinkles.length === 0) {
+    return { stdout: 'No .shtml sprinkles found.\n', stderr: '', exitCode: 0 };
+  }
+  const opened = new Set(mgr.opened());
+  const lines = sprinkles.map((p) => {
+    const status = opened.has(p.name) ? ' [open]' : '';
+    return `  ${p.name}${status}  ${p.title}  (${p.path})`;
+  });
+  return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
+}
+
+async function handleOpen(mgr: SprinkleManager, args: string[]): Promise<Result> {
+  const name = args[1];
+  if (!name) return { stdout: '', stderr: 'sprinkle open: name required\n', exitCode: 1 };
+  try {
+    await mgr.open(name);
+    return { stdout: `Sprinkle "${name}" opened.\n`, stderr: '', exitCode: 0 };
+  } catch (err) {
+    return {
+      stdout: '',
+      stderr: `sprinkle open: ${err instanceof Error ? err.message : String(err)}\n`,
+      exitCode: 1,
+    };
+  }
+}
+
+function handleClose(mgr: SprinkleManager, args: string[]): Result {
+  const name = args[1];
+  if (!name) return { stdout: '', stderr: 'sprinkle close: name required\n', exitCode: 1 };
+  mgr.close(name);
+  return { stdout: `Sprinkle "${name}" closed.\n`, stderr: '', exitCode: 0 };
+}
+
+async function handleReload(mgr: SprinkleManager, args: string[]): Promise<Result> {
+  const name = args[1];
+  if (!name) return { stdout: '', stderr: 'sprinkle reload: name required\n', exitCode: 1 };
+  try {
+    await mgr.reload(name);
+    return { stdout: `Sprinkle "${name}" reloaded.\n`, stderr: '', exitCode: 0 };
+  } catch (err) {
+    return {
+      stdout: '',
+      stderr: `sprinkle reload: ${err instanceof Error ? err.message : String(err)}\n`,
+      exitCode: 1,
+    };
+  }
+}
+
+async function handleRefresh(mgr: SprinkleManager): Promise<Result> {
+  await mgr.refresh();
+  const count = mgr.available().length;
+  return {
+    stdout: `Found ${count} sprinkle${count !== 1 ? 's' : ''}.\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+function handleRoute(args: string[]): Result {
+  const name = args[1];
+  if (!name) {
+    const routes = getAllSprinkleRoutes();
+    const entries = Object.entries(routes);
+    if (entries.length === 0) {
+      return {
+        stdout: 'No sprinkle routes configured (all licks go to cone).\n',
+        stderr: '',
+        exitCode: 0,
+      };
+    }
+    const lines = entries.map(([s, scoop]) => `  ${s} -> ${scoop}`);
+    return { stdout: 'Sprinkle routes:\n' + lines.join('\n') + '\n', stderr: '', exitCode: 0 };
+  }
+  if (args.includes('--clear')) {
+    clearSprinkleRoute(name);
+    return {
+      stdout: `Route cleared for sprinkle "${name}" (licks will go to cone).\n`,
+      stderr: '',
+      exitCode: 0,
+    };
+  }
+  const scoopIdx = args.indexOf('--scoop');
+  const scoop = scoopIdx !== -1 ? args[scoopIdx + 1] : undefined;
+  if (!scoop) {
+    const current = getSprinkleRoute(name);
+    if (current) return { stdout: `${name} -> ${current}\n`, stderr: '', exitCode: 0 };
+    return { stdout: `${name} -> cone (default)\n`, stderr: '', exitCode: 0 };
+  }
+  setSprinkleRoute(name, scoop);
+  return {
+    stdout: `Sprinkle "${name}" lick events will route to scoop "${scoop}".\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+function handleSend(mgr: SprinkleManager, args: string[]): Result {
+  const name = args[1];
+  if (!name) return { stdout: '', stderr: 'sprinkle send: name required\n', exitCode: 1 };
+  const jsonStr = args.slice(2).join(' ');
+  if (!jsonStr) return { stdout: '', stderr: 'sprinkle send: JSON data required\n', exitCode: 1 };
+  let data: unknown;
+  try {
+    data = JSON.parse(jsonStr);
+  } catch {
+    return { stdout: '', stderr: 'sprinkle send: invalid JSON\n', exitCode: 1 };
+  }
+  mgr.sendToSprinkle(name, data);
+  return { stdout: `Data sent to sprinkle "${name}".\n`, stderr: '', exitCode: 0 };
 }
 
 export function createSprinkleCommand(): Command {
@@ -59,43 +189,8 @@ export function createSprinkleCommand(): Command {
     if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
       return sprinkleHelp();
     }
-
     const sub = args[0];
-
-    // Handle 'chat' subcommand separately - doesn't need sprinkle manager
-    if (sub === 'chat') {
-      // Get HTML from args or stdin
-      let html = args.slice(1).join(' ');
-
-      // Check for piped stdin
-      if (!html) {
-        const stdinText = stdinAsText(ctx.stdin);
-        if (stdinText) html = stdinText;
-      }
-
-      if (!html) {
-        return { stdout: '', stderr: 'sprinkle chat: HTML content required\n', exitCode: 1 };
-      }
-
-      // Show inline UI in chat
-      const result = await showToolUIFromContext({
-        html,
-        onAction: async (action, data) => {
-          return { action, data };
-        },
-      });
-
-      if (result === null) {
-        return {
-          stdout: '',
-          stderr: 'sprinkle chat: not in tool execution context\n',
-          exitCode: 1,
-        };
-      }
-
-      // Return the action result as JSON
-      return { stdout: JSON.stringify(result) + '\n', stderr: '', exitCode: 0 };
-    }
+    if (sub === 'chat') return handleChat(args, ctx);
 
     const mgr = getSprinkleManager();
     if (!mgr) {
@@ -103,141 +198,20 @@ export function createSprinkleCommand(): Command {
     }
 
     switch (sub) {
-      case 'list': {
-        await mgr.refresh();
-        const sprinkles = mgr.available();
-        if (sprinkles.length === 0) {
-          return { stdout: 'No .shtml sprinkles found.\n', stderr: '', exitCode: 0 };
-        }
-        const opened = new Set(mgr.opened());
-        const lines = sprinkles.map((p) => {
-          const status = opened.has(p.name) ? ' [open]' : '';
-          return `  ${p.name}${status}  ${p.title}  (${p.path})`;
-        });
-        return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
-      }
-
-      case 'open': {
-        const name = args[1];
-        if (!name) {
-          return { stdout: '', stderr: 'sprinkle open: name required\n', exitCode: 1 };
-        }
-        try {
-          await mgr.open(name);
-          return { stdout: `Sprinkle "${name}" opened.\n`, stderr: '', exitCode: 0 };
-        } catch (err) {
-          return {
-            stdout: '',
-            stderr: `sprinkle open: ${err instanceof Error ? err.message : String(err)}\n`,
-            exitCode: 1,
-          };
-        }
-      }
-
-      case 'close': {
-        const name = args[1];
-        if (!name) {
-          return { stdout: '', stderr: 'sprinkle close: name required\n', exitCode: 1 };
-        }
-        mgr.close(name);
-        return { stdout: `Sprinkle "${name}" closed.\n`, stderr: '', exitCode: 0 };
-      }
-
-      case 'reload': {
-        const name = args[1];
-        if (!name) {
-          return { stdout: '', stderr: 'sprinkle reload: name required\n', exitCode: 1 };
-        }
-        try {
-          await mgr.reload(name);
-          return { stdout: `Sprinkle "${name}" reloaded.\n`, stderr: '', exitCode: 0 };
-        } catch (err) {
-          return {
-            stdout: '',
-            stderr: `sprinkle reload: ${err instanceof Error ? err.message : String(err)}\n`,
-            exitCode: 1,
-          };
-        }
-      }
-
-      case 'refresh': {
-        await mgr.refresh();
-        const count = mgr.available().length;
-        return {
-          stdout: `Found ${count} sprinkle${count !== 1 ? 's' : ''}.\n`,
-          stderr: '',
-          exitCode: 0,
-        };
-      }
-
-      case 'route': {
-        const name = args[1];
-        if (!name) {
-          // List all routes
-          const routes = getAllSprinkleRoutes();
-          const entries = Object.entries(routes);
-          if (entries.length === 0) {
-            return {
-              stdout: 'No sprinkle routes configured (all licks go to cone).\n',
-              stderr: '',
-              exitCode: 0,
-            };
-          }
-          const lines = entries.map(([s, scoop]) => `  ${s} -> ${scoop}`);
-          return {
-            stdout: 'Sprinkle routes:\n' + lines.join('\n') + '\n',
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        if (args.includes('--clear')) {
-          clearSprinkleRoute(name);
-          return {
-            stdout: `Route cleared for sprinkle "${name}" (licks will go to cone).\n`,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        const scoopIdx = args.indexOf('--scoop');
-        const scoop = scoopIdx !== -1 ? args[scoopIdx + 1] : undefined;
-        if (!scoop) {
-          // Show current route for this sprinkle
-          const current = getSprinkleRoute(name);
-          if (current) {
-            return { stdout: `${name} -> ${current}\n`, stderr: '', exitCode: 0 };
-          }
-          return { stdout: `${name} -> cone (default)\n`, stderr: '', exitCode: 0 };
-        }
-
-        setSprinkleRoute(name, scoop);
-        return {
-          stdout: `Sprinkle "${name}" lick events will route to scoop "${scoop}".\n`,
-          stderr: '',
-          exitCode: 0,
-        };
-      }
-
-      case 'send': {
-        const name = args[1];
-        if (!name) {
-          return { stdout: '', stderr: 'sprinkle send: name required\n', exitCode: 1 };
-        }
-        const jsonStr = args.slice(2).join(' ');
-        if (!jsonStr) {
-          return { stdout: '', stderr: 'sprinkle send: JSON data required\n', exitCode: 1 };
-        }
-        let data: unknown;
-        try {
-          data = JSON.parse(jsonStr);
-        } catch {
-          return { stdout: '', stderr: 'sprinkle send: invalid JSON\n', exitCode: 1 };
-        }
-        mgr.sendToSprinkle(name, data);
-        return { stdout: `Data sent to sprinkle "${name}".\n`, stderr: '', exitCode: 0 };
-      }
-
+      case 'list':
+        return handleList(mgr);
+      case 'open':
+        return handleOpen(mgr, args);
+      case 'close':
+        return handleClose(mgr, args);
+      case 'reload':
+        return handleReload(mgr, args);
+      case 'refresh':
+        return handleRefresh(mgr);
+      case 'route':
+        return handleRoute(args);
+      case 'send':
+        return handleSend(mgr, args);
       default:
         return { stdout: '', stderr: `sprinkle: unknown subcommand "${sub}"\n`, exitCode: 1 };
     }

--- a/packages/webapp/src/shell/supplemental-commands/sprinkle-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/sprinkle-command.ts
@@ -30,6 +30,7 @@ function sprinkleHelp(): { stdout: string; stderr: string; exitCode: number } {
       '  list                  List available .shtml sprinkles\n' +
       '  open <name>           Open a sprinkle by name\n' +
       '  close <name>          Close an open sprinkle\n' +
+      '  reload <name>         Reload an open sprinkle (re-read .shtml)\n' +
       '  refresh               Re-scan VFS for .shtml files\n' +
       '  send <name> <json>    Push data to a sprinkle\n' +
       '  route <name> --scoop <scoop>  Route lick events to a scoop instead of cone\n' +
@@ -140,6 +141,23 @@ export function createSprinkleCommand(): Command {
         }
         mgr.close(name);
         return { stdout: `Sprinkle "${name}" closed.\n`, stderr: '', exitCode: 0 };
+      }
+
+      case 'reload': {
+        const name = args[1];
+        if (!name) {
+          return { stdout: '', stderr: 'sprinkle reload: name required\n', exitCode: 1 };
+        }
+        try {
+          await mgr.reload(name);
+          return { stdout: `Sprinkle "${name}" reloaded.\n`, stderr: '', exitCode: 0 };
+        } catch (err) {
+          return {
+            stdout: '',
+            stderr: `sprinkle reload: ${err instanceof Error ? err.message : String(err)}\n`,
+            exitCode: 1,
+          };
+        }
       }
 
       case 'refresh': {

--- a/packages/webapp/src/ui/page-follower-tray.ts
+++ b/packages/webapp/src/ui/page-follower-tray.ts
@@ -262,6 +262,7 @@ export function startPageFollowerTray(
         void sprinkleController?.updateAvailable(sprinkles);
       },
       onSprinkleUpdate: (name, data) => sprinkleController?.handleSprinkleUpdate(name, data),
+      onSprinkleReloaded: (name) => void sprinkleController?.handleSprinkleReloaded(name),
       onDisconnect: (reason) => {
         log.warn('Follower sync disconnected', { reason });
         detachSync();

--- a/packages/webapp/src/ui/sprinkle-follower-controller.ts
+++ b/packages/webapp/src/ui/sprinkle-follower-controller.ts
@@ -189,6 +189,67 @@ export class SprinkleFollowerController {
     log.debug('Dropping sprinkle.update for unknown sprinkle', { sprinkleName });
   }
 
+  /**
+   * Handle a leader-side sprinkle reload: re-render in place so the
+   * follower picks up new `.shtml` content without the panel disappearing.
+   * The container stays in the layout — only the renderer's internal
+   * content (iframe/scripts) is replaced.
+   */
+  async handleSprinkleReloaded(sprinkleName: string): Promise<void> {
+    if (this.disposed) return;
+
+    const entry = this.open.get(sprinkleName);
+    if (!entry) {
+      if (this.opening.has(sprinkleName)) {
+        this.pendingUpdates.delete(sprinkleName);
+      }
+      return;
+    }
+
+    this.updateListeners.delete(sprinkleName);
+
+    let content: string;
+    try {
+      content = await this.sync.fetchSprinkleContent(sprinkleName);
+    } catch (err) {
+      log.warn('Failed to fetch sprinkle content for reload', {
+        sprinkleName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    if (this.disposed || !this.open.has(sprinkleName)) return;
+
+    try {
+      entry.renderer.dispose();
+    } catch (err) {
+      log.warn('Sprinkle dispose threw during reload', {
+        sprinkleName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const api = this.createBridge(sprinkleName);
+    const renderer = new SprinkleRenderer(entry.container, api);
+    try {
+      await renderer.render(content, sprinkleName);
+    } catch (err) {
+      log.warn('Sprinkle re-render failed during reload', {
+        sprinkleName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    if (this.disposed || !this.open.has(sprinkleName)) {
+      renderer.dispose();
+      return;
+    }
+
+    entry.renderer = renderer;
+    log.info('Sprinkle reloaded in place', { sprinkleName });
+  }
+
   /** Tear down all open sprinkles. */
   dispose(): void {
     if (this.disposed) return;

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -234,6 +234,12 @@ export interface SprinkleManagerOptions {
    * must not skip the local renderer push or break the sprinkle.
    */
   onSendToSprinkle?: (name: string, data: unknown) => void;
+  /**
+   * Fired after a sprinkle is reloaded (content file changed while
+   * the sprinkle was open). Wired by the leader tray boot path to
+   * `broadcastSprinkleReloaded` so followers re-fetch and re-render.
+   */
+  onSprinkleReloaded?: (name: string) => void;
   /** Called when a sprinkle pushes an image into the chat input via slicc.attachImage(). */
   onAttachImage?: (base64: string, name?: string, mimeType?: string) => void;
   /**
@@ -296,6 +302,7 @@ export class SprinkleManager {
   private lastRefreshAt = 0;
   private autoOpenBehavior: 'activate' | 'attention';
   private onSendToSprinkle?: (name: string, data: unknown) => void;
+  private onSprinkleReloaded?: (name: string) => void;
   /**
    * Names whose rail icons have been pushed to the layout via
    * `callbacks.registerSprinkle`. Used to diff against the next
@@ -421,6 +428,7 @@ export class SprinkleManager {
     this.callbacks = callbacks;
     this.autoOpenBehavior = options.autoOpenBehavior ?? 'activate';
     this.onSendToSprinkle = options.onSendToSprinkle;
+    this.onSprinkleReloaded = options.onSprinkleReloaded;
     this.inlineSprinkles = options.inlineSprinkles ?? new Set();
   }
 
@@ -454,6 +462,68 @@ export class SprinkleManager {
       log.error('SprinkleManager broadcast hook detached');
     }
     this.onSendToSprinkle = hook;
+  }
+
+  /**
+   * Replace the reload-broadcast hook after construction. Symmetric to
+   * `setSendToSprinkleHook` — wired by the standalone-leader boot path
+   * once `pageLeaderTray.sync` is available.
+   */
+  setReloadHook(hook: ((name: string) => void) | undefined): void {
+    this.onSprinkleReloaded = hook;
+  }
+
+  /**
+   * Reload an already-open sprinkle by re-reading its `.shtml` from the
+   * VFS and re-rendering. No-op if the sprinkle is not currently open.
+   * Fires the reload hook so the leader can broadcast to followers.
+   */
+  async reload(name: string): Promise<void> {
+    const entry = this.openSprinkles.get(name);
+    if (!entry) {
+      log.info('Cannot reload closed sprinkle', { name });
+      return;
+    }
+
+    let sprinkle = this.availableSprinkles.get(name);
+    if (!sprinkle) {
+      await this.refresh();
+      sprinkle = this.availableSprinkles.get(name);
+    }
+    if (!sprinkle) {
+      log.warn('Sprinkle not found during reload', { name });
+      return;
+    }
+
+    const rawContent = await this.fs.readFile(sprinkle.path, { encoding: 'utf-8' });
+    if (rawContent === undefined || rawContent === null) {
+      log.warn('Failed to read sprinkle content during reload', { name });
+      return;
+    }
+    const content =
+      typeof rawContent === 'string' ? rawContent : new TextDecoder('utf-8').decode(rawContent);
+
+    entry.renderer?.dispose();
+    this.bridge.removeSprinkle(name);
+
+    const api = this.bridge.createAPI(name);
+    const renderer = new SprinkleRenderer(entry.container, api);
+    await renderer.render(content, name);
+    entry.renderer = renderer;
+
+    log.info('Sprinkle reloaded', { name });
+    this.notifyChange();
+
+    if (this.onSprinkleReloaded) {
+      try {
+        this.onSprinkleReloaded(name);
+      } catch (err) {
+        log.error('onSprinkleReloaded hook threw', {
+          name,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 
   /** Restore sprinkles that were open in the previous session.
@@ -986,28 +1056,65 @@ export class SprinkleManager {
    * `REFRESH_COOLDOWN_MS`.
    */
   setupWatcher(watcher: FsWatcher): void {
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    const trigger = () => {
-      if (timer) return;
-      timer = setTimeout(() => {
-        timer = null;
-        void this.openNewAutoOpenSprinkles().catch((err) => {
-          log.warn('Sprinkle refresh on watcher event failed', {
-            error: err instanceof Error ? err.message : String(err),
+    let newSprinkleTimer: ReturnType<typeof setTimeout> | null = null;
+    const reloadTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    const RELOAD_DEBOUNCE_MS = 300;
+
+    const trigger = (events: Array<{ path: string }>) => {
+      let needsNewSprinkleScan = false;
+      for (const event of events) {
+        const matchingName = this.findOpenSprinkleByPath(event.path);
+        if (matchingName) {
+          const existing = reloadTimers.get(matchingName);
+          if (existing) clearTimeout(existing);
+          reloadTimers.set(
+            matchingName,
+            setTimeout(() => {
+              reloadTimers.delete(matchingName);
+              void this.reload(matchingName).catch((err) => {
+                log.warn('Sprinkle reload on watcher event failed', {
+                  name: matchingName,
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              });
+            }, RELOAD_DEBOUNCE_MS)
+          );
+        } else {
+          needsNewSprinkleScan = true;
+        }
+      }
+
+      if (needsNewSprinkleScan && !newSprinkleTimer) {
+        newSprinkleTimer = setTimeout(() => {
+          newSprinkleTimer = null;
+          void this.openNewAutoOpenSprinkles().catch((err) => {
+            log.warn('Sprinkle refresh on watcher event failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
           });
-        });
-      }, 150);
+        }, 150);
+      }
     };
     const unsubs: Array<() => void> = WATCHER_ROOTS.map((root) =>
       watcher.watch(root, (path) => path.endsWith('.shtml'), trigger)
     );
     this.watcherUnsub = () => {
       for (const u of unsubs) u();
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
+      if (newSprinkleTimer) {
+        clearTimeout(newSprinkleTimer);
+        newSprinkleTimer = null;
       }
+      for (const t of reloadTimers.values()) clearTimeout(t);
+      reloadTimers.clear();
     };
+  }
+
+  private findOpenSprinkleByPath(path: string): string | null {
+    for (const [name] of this.openSprinkles) {
+      const sprinkle = this.availableSprinkles.get(name);
+      if (sprinkle && sprinkle.path === path) return name;
+    }
+    return null;
   }
 
   /** Clean up watcher subscriptions. */

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -509,6 +509,11 @@ export class SprinkleManager {
     const api = this.bridge.createAPI(name);
     const renderer = new SprinkleRenderer(entry.container, api);
     await renderer.render(content, name);
+
+    if (!this.openSprinkles.has(name)) {
+      renderer.dispose();
+      return;
+    }
     entry.renderer = renderer;
 
     log.info('Sprinkle reloaded', { name });
@@ -1040,9 +1045,12 @@ export class SprinkleManager {
 
   /**
    * Set up watchers that auto-surface newly-added `.shtml` files in
-   * the rail. Calls `openNewAutoOpenSprinkles()` (refreshes the
-   * available list AND surfaces new sprinkles), so non-auto-open
-   * sprinkles appear in the rail without a reload.
+   * the rail and auto-reload already-open sprinkles on content change.
+   *
+   * **Production note:** In the WC boot path this method has no caller —
+   * the kernel-worker watcher (`kernel-worker.ts`) owns the real VFS and
+   * drives reloads over the BroadcastChannel proxy. This method exists
+   * for tests and the legacy inline-orchestrator path.
    *
    * Watches only canonical sprinkle roots (`WATCHER_ROOTS`). A
    * watcher rooted at `/` would re-scan the entire VFS on every

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -199,6 +199,7 @@ function createLeaderHookSetup(
       deps.sprinkleManager.setSendToSprinkleHook((name, data) =>
         handle.sync.broadcastSprinkleUpdate(name, data)
       );
+      deps.sprinkleManager.setReloadHook((name) => handle.sync.broadcastSprinkleReloaded(name));
       deps
         .getController()
         ?.setOnLocalUserMessage((text, messageId, attachments) =>
@@ -223,6 +224,7 @@ function createLeaderHookSetup(
       deps.getController()?.setOnLocalUserMessage(undefined);
       deps.getController()?.setOnLocalProcessingChange(undefined);
       deps.sprinkleManager.setSendToSprinkleHook(undefined);
+      deps.sprinkleManager.setReloadHook(undefined);
       remoteCdpBridge.disposeAll();
     },
   };

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -338,6 +338,9 @@ function installRoleSwitchListeners(
 }
 
 export async function wireWcTray(deps: WcTrayDeps): Promise<WcTrayHandle> {
+  const { loadSprinkleStyles } = await import('../legacy-styles.js');
+  await loadSprinkleStyles();
+
   const { client, instanceId, window: win, log } = deps;
   const state: TrayRoleState = { leader: null, follower: null };
 

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -338,6 +338,10 @@ function installRoleSwitchListeners(
 }
 
 export async function wireWcTray(deps: WcTrayDeps): Promise<WcTrayHandle> {
+  // Idempotent; also called by wireWcSprinkles. Duplicated here because in
+  // follower mode openVfs() may never resolve (no local kernel), so
+  // wireWcSprinkles never runs — without this the follower renders sprinkles
+  // without sprinkle-components.css.
   const { loadSprinkleStyles } = await import('../legacy-styles.js');
   await loadSprinkleStyles();
 

--- a/packages/webapp/tests/ui/sprinkle-follower-controller.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-follower-controller.test.ts
@@ -654,4 +654,45 @@ describe('SprinkleFollowerController', () => {
       expect(removeSprinkle).toHaveBeenCalledWith('x');
     });
   });
+
+  describe('handleSprinkleReloaded', () => {
+    it('re-renders the sprinkle in place without removing it from the layout', async () => {
+      sync.contentByName.set('dash', '<div>v1</div>');
+      await controller.updateAvailable([makeSprinkle('dash', { open: true })]);
+
+      expect(FakeRenderer.instances).toHaveLength(1);
+      const firstRenderer = FakeRenderer.instances[0];
+      expect(firstRenderer.rendered).toBe('<div>v1</div>');
+
+      sync.contentByName.set('dash', '<div>v2</div>');
+      await controller.handleSprinkleReloaded('dash');
+
+      expect(firstRenderer.disposed).toBe(true);
+      expect(FakeRenderer.instances).toHaveLength(2);
+      expect(FakeRenderer.instances[1].rendered).toBe('<div>v2</div>');
+      expect(removeSprinkle).not.toHaveBeenCalled();
+    });
+
+    it('no-ops for a sprinkle that is not open', async () => {
+      await controller.handleSprinkleReloaded('nonexistent');
+
+      expect(FakeRenderer.instances).toHaveLength(0);
+      expect(sync.fetched).toHaveLength(0);
+    });
+
+    it('clears update listeners so re-registered ones work after reload', async () => {
+      sync.contentByName.set('dash', '<div>v1</div>');
+      await controller.updateAvailable([makeSprinkle('dash', { open: true })]);
+
+      const listener = vi.fn();
+      const api = FakeRenderer.instances[0].api;
+      api.on('update', listener);
+
+      sync.contentByName.set('dash', '<div>v2</div>');
+      await controller.handleSprinkleReloaded('dash');
+
+      controller.handleSprinkleUpdate('dash', { x: 1 });
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/webapp/tests/ui/sprinkle-manager.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-manager.test.ts
@@ -1132,4 +1132,57 @@ describe('SprinkleManager', () => {
       expect(addSprinkle).not.toHaveBeenCalled();
     });
   });
+
+  describe('reload', () => {
+    it('re-renders an open sprinkle with fresh VFS content', async () => {
+      await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v1</div>');
+      await mgr.refresh();
+      await mgr.open('dash');
+      expect(mgr.opened()).toContain('dash');
+
+      await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v2</div>');
+      await mgr.reload('dash');
+
+      expect(mgr.opened()).toContain('dash');
+    });
+
+    it('no-ops for a sprinkle that is not open', async () => {
+      await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v1</div>');
+      await mgr.refresh();
+
+      await mgr.reload('dash');
+      expect(mgr.opened()).not.toContain('dash');
+    });
+
+    it('fires the onSprinkleReloaded hook', async () => {
+      const reloadHook = vi.fn();
+      mgr.setReloadHook(reloadHook);
+
+      await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v1</div>');
+      await mgr.refresh();
+      await mgr.open('dash');
+
+      await mgr.reload('dash');
+      expect(reloadHook).toHaveBeenCalledWith('dash');
+    });
+
+    it('setupWatcher triggers reload for already-open sprinkle on file change', async () => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      const watcher = new FsWatcher();
+      vfs.setWatcher(watcher);
+      mgr.setupWatcher(watcher);
+
+      await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v1</div>');
+      await mgr.refresh();
+      await mgr.open('dash');
+
+      const reloadHook = vi.fn();
+      mgr.setReloadHook(reloadHook);
+
+      await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v2</div>');
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(reloadHook).toHaveBeenCalledWith('dash');
+    });
+  });
 });


### PR DESCRIPTION
<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

- When a leader modifies/reloads a sprinkle's `.shtml` file, followers now re-render seamlessly in place (no panel flash)
- Adds `sprinkle.reloaded` protocol message and VFS watcher that auto-triggers reload when open sprinkles change
- Fixes follower sprinkle styling (sprinkle-components.css was never loaded because `openVfs()` doesn't resolve without a local kernel)
- Adds `sprinkle reload <name>` shell command for manual triggering
 
Fixes #702 

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
