### PR TITLE
fix: refresh model pill after Adobe OAuth connects

### DIFF
--- a/packages/webapp/src/ui/wc/wc-nav.ts
+++ b/packages/webapp/src/ui/wc/wc-nav.ts
@@ -64,6 +64,22 @@ export function modelListForMeta(groups: readonly GroupedModels[]): MetaModel[] 
   );
 }
 
+/**
+ * Sync the model-pill label to the currently-resolved model. Extracted from
+ * `wireWcNav` so the function stays within the 150-line limit.
+ */
+function applyModelPillFromCurrentModel(
+  composerMeta: Element,
+  resolveCurrentModel: () => { name?: string; id: string }
+): void {
+  try {
+    const model = resolveCurrentModel();
+    composerMeta.setAttribute('model', model.name ?? model.id);
+  } catch {
+    // Model pill is informational; never block on resolution.
+  }
+}
+
 export interface WcNavDeps {
   refs: WcShellRefs;
   client: OffscreenClient;
@@ -72,13 +88,17 @@ export interface WcNavDeps {
 
 export async function wireWcNav(deps: WcNavDeps): Promise<void> {
   const { refs, client, log } = deps;
-  const { getAllAvailableModels, getAccounts } = await import('../provider-settings.js');
+  const { getAllAvailableModels, getAccounts, resolveCurrentModel } = await import(
+    '../provider-settings.js'
+  );
 
   const refreshModels = (): void => {
     (refs.composerMeta as HTMLElement & { models?: unknown }).models = modelListForMeta(
       getAllAvailableModels()
     );
   };
+  const refreshModelPill = () =>
+    applyModelPillFromCurrentModel(refs.composerMeta, resolveCurrentModel);
   refreshModels();
   // After the invalid-model error card opens the picker via
   // `slicc-error-change-model`, the next model pick should auto-replay the
@@ -186,8 +206,6 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
   refs.avatarMenu.addEventListener('slicc-avatar-menu-toggle', (event) => {
     if ((event as CustomEvent<{ open?: boolean }>).detail?.open) syncMenuItems();
   });
-  const handleTrayAction = (id: string): boolean => handleTrayActionId(id, log);
-
   // The WC-native settings surface (slicc-dialog chrome). The legacy
   // provider-settings dialog survives only for the onboarding-only
   // flows (connect surface, tray join).
@@ -204,7 +222,7 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
 
   refs.avatarMenu.addEventListener('slicc-avatar-action', (event) => {
     const id = (event as CustomEvent<{ id?: string }>).detail?.id;
-    if (id && handleTrayAction(id)) {
+    if (id && handleTrayActionId(id, log)) {
       syncMenuItems();
       return;
     }
@@ -244,7 +262,7 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
   // in place rather than re-running the same failing turn.
   await wireLoginEvent({ refs, log, openSettings, refreshModels, applyIdentity, client });
 
-  wireAccountsChangedResync({ refreshModels, applyIdentity, client });
+  wireAccountsChangedResync({ refreshModels, refreshModelPill, applyIdentity, client });
 }
 
 /**
@@ -423,13 +441,16 @@ async function wireModelPicker(
  */
 async function wireAccountsChangedResync(opts: {
   refreshModels(): void;
+  /** Sync the model-pill label after accounts or catalog change. */
+  refreshModelPill(): void;
   applyIdentity(): void;
   client: OffscreenClient;
 }): Promise<void> {
-  const { refreshModels, applyIdentity, client } = opts;
+  const { refreshModels, refreshModelPill, applyIdentity, client } = opts;
   const { getAccounts, getProviderConfig } = await import('../provider-settings.js');
   window.addEventListener('slicc:accounts-changed', () => {
     refreshModels();
+    refreshModelPill();
     applyIdentity();
     client.updateModel();
     for (const account of getAccounts()) {
@@ -438,6 +459,7 @@ async function wireAccountsChangedResync(opts: {
       void fetchCatalog()
         .then(() => {
           refreshModels();
+          refreshModelPill();
           client.updateModel();
         })
         .catch(() => undefined);

--- a/packages/webapp/tests/ui/wc/wc-nav.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-nav.test.ts
@@ -391,4 +391,54 @@ describe('wireWcNav', () => {
       unregisterProviderConfig('openai-test');
     }
   });
+
+  it('updates the model-pill label when accounts change after Adobe OAuth', async () => {
+    // Simulate the state right after connecting Adobe via OAuth:
+    //   – selected-model is set to the adobe sonnet model (from setSelectedModel)
+    //   – slicc_accounts has the adobe account
+    //   – slicc:accounts-changed fires
+    // Before the fix, the model pill stayed on whatever resolveCurrentModel()
+    // returned at initial boot (haiku 3.5 from the native Anthropic registry).
+    registerProviderConfig({
+      id: 'adobe-pill-test',
+      name: 'Adobe',
+      description: 'Adobe test provider',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      isOAuth: true,
+      defaultModelId: 'sonnet',
+    });
+    localStorage.setItem(
+      'slicc_accounts',
+      JSON.stringify([{ providerId: 'adobe-pill-test', apiKey: '', accessToken: 'tok' }])
+    );
+    localStorage.setItem('selected-model', 'adobe-pill-test:claude-sonnet-4-6');
+    try {
+      const refs = makeRefs();
+      const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
+      await wireWcNav({ refs, client, log: { error: vi.fn() } as never });
+
+      // Simulate the model pill being stale (set to haiku 3.5 from pre-connection boot).
+      refs.composerMeta.setAttribute('model', 'Claude Haiku 3.5');
+
+      // wireAccountsChangedResync is called without `await` in wireWcNav, so its
+      // `await import(...)` defers listener registration by one microtask tick.
+      // Yield here so the listener is registered before we fire the event.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Fire the accounts-changed event that the onboarding orchestrator fires
+      // after setSelectedModel() returns.
+      window.dispatchEvent(new Event('slicc:accounts-changed'));
+
+      // Flush the synchronous listener body.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The pill label must no longer be the stale haiku value.
+      expect(refs.composerMeta.getAttribute('model')).not.toBe('Claude Haiku 3.5');
+    } finally {
+      localStorage.removeItem('slicc_accounts');
+      localStorage.removeItem('selected-model');
+      unregisterProviderConfig('adobe-pill-test');
+    }
+  });
 });


### PR DESCRIPTION
## Problem

When starting a fresh SLICC instance and connecting the Adobe LLM provider via OAuth, the model pill (the sparkles label in the composer) showed **"Claude Haiku 3.5"** — a model not available via Adobe — instead of the correct default model selected during onboarding.

## Root cause

`wireAccountsChangedResync` called `refreshModels()` (which populates the picker's model list) after `slicc:accounts-changed` fires, but never updated the `composerMeta` `model` attribute (the displayed pill label).

Timeline:
1. Fresh boot, no provider → `applyThreadContext` calls `resolveCurrentModel()` → provider falls back to `'anthropic'` → `models[0]` is `claude-3-5-haiku-20241022` (pi-ai orders haiku first) → pill set to `"Claude Haiku 3.5"`
2. Pill shows **"Add AI"** correctly (empty model list suppresses the stale attribute)
3. User connects Adobe → `setSelectedModel('adobe:claude-sonnet-4-6')` saved to localStorage ✓
4. `slicc:accounts-changed` fires → `refreshModels()` fills the picker with adobe models (non-empty) → pill switches out of "Add AI" mode and starts rendering the **stale** `model` attribute → **"Claude Haiku 3.5"** appears

## Fix

Add a `refreshModelPill` callback to `wireAccountsChangedResync` that calls `resolveCurrentModel()` and writes the fresh name to `composerMeta.setAttribute('model', ...)`. Fires in both the immediate listener body and the `fetchCatalog().then()` callback that runs when the dynamic catalog arrives.

Two structural changes to stay within the 150-line biome limit:
- The pill-sync logic is extracted to `applyModelPillFromCurrentModel` (top-level helper)
- The local `handleTrayAction` wrapper is inlined into its single callsite

## Testing

- Manually verified with a fresh dev instance (ephemeral Chrome profile): model pill shows the correct Adobe model immediately after OAuth completes
- Added regression test in `wc-nav.test.ts`: verifies the pill label changes away from a stale haiku value when `slicc:accounts-changed` fires after `setSelectedModel`