### PR TITLE
fix(realm): list federated fleet tabs in script browser API

### DIFF
--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -14,6 +14,11 @@
 
 import type { CommandContext } from 'just-bash';
 import type { BrowserAPI } from '../../cdp/browser-api.js';
+import { createLogger } from '../../core/logger.js';
+import {
+  TRAY_JOIN_STORAGE_KEY,
+  TRAY_WORKER_STORAGE_KEY,
+} from '../../scoops/tray-runtime-config.js';
 import { createEntryTranspile, createEsmTranspile } from '../../shell/ipk/esm-transpile.js';
 import { buildRealmModuleGraph } from '../../shell/ipk/module-loader.js';
 import type { ModuleReader } from '../../shell/ipk/resolver.js';
@@ -51,6 +56,8 @@ import type {
 } from './realm-types.js';
 import { compileWasmFromVfs } from './wasm-compiler.js';
 import type { WsSubscriberRegistry } from './ws-subscribers.js';
+
+const log = createLogger('realm-host');
 
 export interface RealmHostHandle {
   /** Detach the message listener. Idempotent. */
@@ -531,15 +538,65 @@ async function dispatchBrowser(
   }
 }
 
+/**
+ * Cheap, synchronous check for whether a multi-browser tray is configured
+ * (leader worker URL or follower join URL present). Reads `globalThis.localStorage`
+ * — the real Storage on the page, or the page-seeded shim in the kernel worker.
+ * Used to skip the `list-remote-targets` panel-RPC round-trip entirely when no
+ * tray exists, so a plain (non-tray) `findTab` / `ensureTab` stays at one local
+ * call. Mirrors `isTrayConfigured` in
+ * `shell/supplemental-commands/playwright/snapshot.ts`.
+ */
+function isTrayConfigured(): boolean {
+  try {
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (!ls) return false;
+    return !!(ls.getItem(TRAY_WORKER_STORAGE_KEY) || ls.getItem(TRAY_JOIN_STORAGE_KEY));
+  } catch {
+    return false;
+  }
+}
+
 async function listTabHandles(browser: BrowserAPI): Promise<TabHandle[]> {
-  // `listAllTargets` includes remote tray targets when wired; the
-  // standalone path with no tray transparently falls back to
-  // `listPages`.
-  const pages =
-    typeof browser.listAllTargets === 'function'
-      ? await browser.listAllTargets()
-      : await browser.listPages();
-  return pages.map((p) => ({ targetId: p.targetId, url: p.url, title: p.title }));
+  // `listAllTargets` is local-only in the kernel worker: the worker's tray
+  // provider's `getTargets()` returns `[]` (it exists only to *drive* remote
+  // targets, not list them). When a tray is configured, supplement the local
+  // set with the federated fleet via the page-side BrowserAPI over panel-RPC
+  // (`list-remote-targets`) and dedupe by targetId — exactly like
+  // `getActionablePages` does for the playwright-cli surface. The
+  // tray-configured gate keeps the no-tray common case to a single local call
+  // (no BroadcastChannel round-trip, no 3s-timeout exposure). The composite
+  // `<runtimeId>:<localTargetId>` ids surfaced here are drivable: `withTab` →
+  // `attachToPage` routes them through the worker tray provider's
+  // RemoteCDPTransport.
+  // TODO(dedupe): share with scoops/federated-targets.ts once the external-brain
+  // branch lands.
+  if (typeof browser.listAllTargets !== 'function') {
+    const pages = await browser.listPages();
+    return pages.map((p) => ({ targetId: p.targetId, url: p.url, title: p.title }));
+  }
+  const pages = await browser.listAllTargets();
+  const handles: TabHandle[] = pages.map((p) => ({
+    targetId: p.targetId,
+    url: p.url,
+    title: p.title,
+  }));
+  const rpc = isTrayConfigured() ? getPanelRpcClient() : null;
+  if (rpc) {
+    try {
+      const { targets } = await rpc.call('list-remote-targets', undefined, { timeoutMs: 3000 });
+      const seen = new Set(handles.map((h) => h.targetId));
+      for (const t of targets) {
+        if (!seen.has(t.targetId)) {
+          seen.add(t.targetId);
+          handles.push({ targetId: t.targetId, url: t.url, title: t.title });
+        }
+      }
+    } catch (err) {
+      log.debug('panel-rpc list-remote-targets failed', { err: String(err) });
+    }
+  }
+  return handles;
 }
 
 async function findTab(

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -569,8 +569,6 @@ async function listTabHandles(browser: BrowserAPI): Promise<TabHandle[]> {
   // `<runtimeId>:<localTargetId>` ids surfaced here are drivable: `withTab` →
   // `attachToPage` routes them through the worker tray provider's
   // RemoteCDPTransport.
-  // TODO(dedupe): share with scoops/federated-targets.ts once the external-brain
-  // branch lands.
   if (typeof browser.listAllTargets !== 'function') {
     const pages = await browser.listPages();
     return pages.map((p) => ({ targetId: p.targetId, url: p.url, title: p.title }));

--- a/packages/webapp/tests/kernel/realm/browser-realm.test.ts
+++ b/packages/webapp/tests/kernel/realm/browser-realm.test.ts
@@ -14,13 +14,14 @@
  */
 
 import type { CommandContext, FsStat, IFileSystem } from 'just-bash';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BrowserAPI } from '../../../src/cdp/browser-api.js';
 import type { PageInfo } from '../../../src/cdp/types.js';
 import { attachRealmHost } from '../../../src/kernel/realm/realm-host.js';
 import type { RealmPortLike } from '../../../src/kernel/realm/realm-rpc.js';
 import { RealmRpcClient } from '../../../src/kernel/realm/realm-rpc.js';
 import type { TabHandle } from '../../../src/kernel/realm/realm-types.js';
+import { TRAY_WORKER_STORAGE_KEY } from '../../../src/scoops/tray-runtime-config.js';
 
 interface PortPair {
   realm: RealmPortLike;
@@ -467,6 +468,173 @@ describe('realm RPC: browser channel — error paths', () => {
   it('rejects unknown browser ops with a clear error', async () => {
     const { client, dispose } = setup(makeBrowserState());
     await expect(client.call('browser', 'unknownOp', [])).rejects.toThrow(/unknown browser op/);
+    dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Federated fleet listing
+//
+// In the kernel worker, `browser.listAllTargets()` is local-only by design —
+// the worker's tray provider's `getTargets()` returns `[]`, and follower tabs
+// are reachable only through the `list-remote-targets` panel-RPC supplement
+// (the page-side BrowserAPI owns the tray provider). These tests pin that the
+// realm `browser` ops (`findTab` / `ensureTab`, both via `listTabHandles`)
+// merge that supplement so a standalone leader's realm scripts can see — and
+// then drive (composite `<runtimeId>:<localTargetId>` targetId) — follower
+// tabs. Mirrors `getActionablePages` in
+// `shell/supplemental-commands/playwright/snapshot.ts`.
+// ---------------------------------------------------------------------------
+
+describe('realm RPC: browser channel — federated fleet listing', () => {
+  let prevPanelRpc: unknown;
+  let prevLocalStorage: unknown;
+
+  beforeEach(() => {
+    prevPanelRpc = (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc;
+    prevLocalStorage = (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  afterEach(() => {
+    (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = prevPanelRpc;
+    (globalThis as { localStorage?: unknown }).localStorage = prevLocalStorage;
+  });
+
+  /** Install a panel-RPC client whose `call('list-remote-targets')` resolves to `targets`. */
+  function installPanelRpc(impl: (op: string) => Promise<unknown>): ReturnType<typeof vi.fn> {
+    const call = vi.fn(impl);
+    (globalThis as { __slicc_panelRpc?: unknown }).__slicc_panelRpc = {
+      call,
+      onEvent: vi.fn(),
+      registerPushTarget: vi.fn(),
+      unregisterPushTarget: vi.fn(),
+      dispose: vi.fn(),
+    };
+    return call;
+  }
+
+  /** Toggle `isTrayConfigured()` by seeding the leader-tray localStorage key. */
+  function setTrayConfigured(configured: boolean): void {
+    (globalThis as { localStorage?: unknown }).localStorage = {
+      getItem: (key: string) =>
+        configured && key === TRAY_WORKER_STORAGE_KEY ? 'https://tray.example.com' : null,
+    };
+  }
+
+  it('surfaces a follower tab (composite targetId) via findTab when a tray is configured', async () => {
+    // Worker-local listAllTargets sees only the leader's own tab.
+    const state = makeBrowserState({
+      pages: [{ targetId: 'local-1', url: 'https://local.example.com/', title: 'Local' }],
+    });
+    setTrayConfigured(true);
+    const call = installPanelRpc(async (op) => {
+      if (op === 'list-remote-targets') {
+        return {
+          targets: [
+            {
+              targetId: 'f-runtime:tab-7',
+              url: 'https://follower.example.com/app',
+              title: 'Follower',
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected op ${op}`);
+    });
+    const { client, dispose } = setup(state);
+    const hit = await client.call<TabHandle | null>('browser', 'findTab', [
+      { domain: 'follower.example.com' },
+    ]);
+    // Resolved to the follower's composite targetId — drivable via the
+    // worker tray provider's RemoteCDPTransport.
+    expect(hit?.targetId).toBe('f-runtime:tab-7');
+    expect(hit?.url).toBe('https://follower.example.com/app');
+    expect(call.mock.calls.map((c) => c[0])).toContain('list-remote-targets');
+    dispose();
+  });
+
+  it('still resolves local tabs while merging follower tabs', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 'local-1', url: 'https://local.example.com/', title: 'Local' }],
+    });
+    setTrayConfigured(true);
+    installPanelRpc(async () => ({
+      targets: [
+        { targetId: 'f-runtime:tab-7', url: 'https://follower.example.com/', title: 'Follower' },
+      ],
+    }));
+    const { client, dispose } = setup(state);
+    const local = await client.call<TabHandle | null>('browser', 'findTab', [
+      { domain: 'local.example.com' },
+    ]);
+    expect(local?.targetId).toBe('local-1');
+    dispose();
+  });
+
+  it('skips the panel-RPC supplement entirely when no tray is configured', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 'local-1', url: 'https://local.example.com/', title: 'Local' }],
+    });
+    setTrayConfigured(false);
+    // A client is present (it may serve unrelated ops) but the no-tray gate
+    // must short-circuit before any list-remote-targets round-trip.
+    const call = installPanelRpc(async () => ({ targets: [] }));
+    const { client, dispose } = setup(state);
+    const local = await client.call<TabHandle | null>('browser', 'findTab', [
+      { domain: 'local.example.com' },
+    ]);
+    expect(local?.targetId).toBe('local-1');
+    // No follower visible without the supplement.
+    const follower = await client.call<TabHandle | null>('browser', 'findTab', [
+      { domain: 'follower.example.com' },
+    ]);
+    expect(follower).toBeNull();
+    expect(call.mock.calls.map((c) => c[0])).not.toContain('list-remote-targets');
+    dispose();
+  });
+
+  it('degrades to the local set when the panel-RPC supplement rejects', async () => {
+    const state = makeBrowserState({
+      pages: [{ targetId: 'local-1', url: 'https://local.example.com/', title: 'Local' }],
+    });
+    setTrayConfigured(true);
+    installPanelRpc(async () => {
+      throw new Error('bridge offline');
+    });
+    const { client, dispose } = setup(state);
+    // Local tab still resolves — the RPC failure must not sink listTabHandles.
+    const local = await client.call<TabHandle | null>('browser', 'findTab', [
+      { domain: 'local.example.com' },
+    ]);
+    expect(local?.targetId).toBe('local-1');
+    // Follower is simply absent (not an error) when the supplement fails.
+    const follower = await client.call<TabHandle | null>('browser', 'findTab', [
+      { domain: 'follower.example.com' },
+    ]);
+    expect(follower).toBeNull();
+    dispose();
+  });
+
+  it('dedupes a follower targetId already present in the local set', async () => {
+    // Exercises the dedupe-skip branch: the RPC entry mirrors a local one, so
+    // it must not be appended a second time. findTab can't observe the array
+    // length, but the duplicate path is covered and still resolves cleanly.
+    const state = makeBrowserState({
+      pages: [
+        { targetId: 'f-runtime:tab-7', url: 'https://follower.example.com/', title: 'Local copy' },
+      ],
+    });
+    setTrayConfigured(true);
+    installPanelRpc(async () => ({
+      targets: [
+        { targetId: 'f-runtime:tab-7', url: 'https://follower.example.com/', title: 'Remote copy' },
+      ],
+    }));
+    const { client, dispose } = setup(state);
+    const hit = await client.call<TabHandle | null>('browser', 'findTab', [
+      { domain: 'follower.example.com' },
+    ]);
+    expect(hit?.targetId).toBe('f-runtime:tab-7');
     dispose();
   });
 });


### PR DESCRIPTION
## What & why

The realm `browser` API used by in-VFS scripts (`browser.findTab` / `browser.ensureTab`, both via `listTabHandles`) only listed **local** CDP tabs. In the kernel worker, `browser.listAllTargets()` is local-only by design — the worker's tray provider's `getTargets()` returns `[]`, and the federated fleet is reachable only through the `list-remote-targets` panel-RPC supplement. So a `node -e` / `.jsh` / `workflow` script running on a **standalone leader with followers** silently never saw follower tabs.

This is the same root cause recently fixed for `GET /api/targets` — a different consumer of the same gap.

## The fix

`listTabHandles` now supplements the local set with the federated fleet over panel-RPC (`list-remote-targets`, 3s timeout) and dedupes by `targetId`, mirroring `getActionablePages` in `playwright/snapshot.ts`. An `isTrayConfigured()` gate keeps the no-tray common case at a single local call (no BroadcastChannel round-trip). Scope is **listing only** — the composite `<runtimeId>:<localTargetId>` ids surfaced here are already drivable via `withTab` → `attachToPage` → the worker tray provider's `RemoteCDPTransport`, so no driving change was needed and no `TabHandle` shape change was required (consumers match by domain/url then use `targetId`).

## Verification

- **Unit tests** (`browser-realm.test.ts`, 5 added): a follower tab surfaces by its composite id when a tray is configured; local tabs still resolve; the panel-RPC supplement is skipped when no tray is configured; an RPC rejection degrades to the local set; a follower id already in the local set is deduped. The "surfaces a follower tab" test fails on the pre-fix `listTabHandles` and passes after — confirmed.
- `npm run lint` — clean.
- `npm run typecheck` — clean (all 8 targets, incl. the no-DOM kernel-worker guard).
- `npm run test:coverage:webapp` — 8117 passed, webapp coverage above floor (lines 76.7 / statements 74.65 / functions 75.29 / branches 65.21).

## Cross-runtime parity

Single shared `webapp` change (kernel realm). It mirrors the proven `getActionablePages` mechanism, so it inherits its float behavior: **standalone worker** uses the panel-RPC supplement (this fix); **extension** has no panel-RPC bridge and wires the tray provider page-side (offscreen DOM), so `listAllTargets()` already includes remotes — N/A. `node-server` / `swift-server` / `ios-app` are relays for this in-browser script API — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
