### PR TITLE
fix(onboarding): fail closed when provider catalogue read throws (#1104)

### DIFF
--- a/packages/webapp/src/scoops/onboarding-orchestrator.ts
+++ b/packages/webapp/src/scoops/onboarding-orchestrator.ts
@@ -520,8 +520,13 @@ export class OnboardingOrchestrator {
     let providerEntry: ProviderEntry | undefined;
     try {
       providerEntry = this.deps.getProviderCatalogue().providers.find((p) => p.id === provider);
-    } catch {
-      return null;
+    } catch (err) {
+      // Fail closed: a catalogue read error must block the save so we
+      // never let a half-configured account through. Surfacing an
+      // actionable error string routes through the same dip-reject +
+      // `awaiting-connect` rollback as the field-specific gates.
+      log.warn('getProviderCatalogue threw during required-field gate', err);
+      return 'Could not load provider requirements. Please try again.';
     }
     if (providerEntry?.requiresDeployment && !deployment?.trim()) {
       return `${providerEntry.name} requires a deployment name.`;

--- a/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
@@ -434,6 +434,42 @@ describe('OnboardingOrchestrator', () => {
       expect(reject.message.toLowerCase()).toContain('base url');
     });
 
+    it('fails closed when the provider catalogue read throws during the required-field gate', async () => {
+      // A catalogue throw must block the save instead of letting a
+      // half-configured account through — regression for #1104.
+      const fs = new VirtualFS('catalogue-throw-' + Math.random());
+      const accounts: AccountSnapshot[] = [];
+      const dipInbox: DipMessage[] = [];
+      const finalLicks: { action: string; data: Record<string, unknown> }[] = [];
+      const orch = new OnboardingOrchestrator({
+        fs,
+        postSystemMessage: () => {},
+        postDipReference: () => {},
+        getProviderCatalogue: () => {
+          throw new Error('catalogue unavailable');
+        },
+        saveAccount: (id, key) => accounts.push({ id, key }),
+        setSelectedModel: () => {},
+        broadcastToDip: (msg) => dipInbox.push(msg),
+        fireFinalLick: (data) => finalLicks.push(data),
+        fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
+        rand: () => 0,
+      });
+      await orch.handleOnboardingComplete({});
+      await orch.handleConnectAttempt({
+        provider: 'openai',
+        apiKey: 'sk-good',
+        model: 'gpt-4o',
+      });
+      expect(accounts).toEqual([]);
+      expect(finalLicks).toEqual([]);
+      const reject = dipInbox.find((m) => m.type === 'slicc-connect-result');
+      expect(reject).toBeDefined();
+      expect(reject!.ok).toBe(false);
+      expect(reject!.kind).toBe('failed');
+      expect(orch.getStage()).toBe('awaiting-connect');
+    });
+
     it('rejects empty payloads gracefully', async () => {
       const h = makeHarness();
       await h.orchestrator.handleOnboardingComplete({});


### PR DESCRIPTION
Fixes #1104.

## Problem

The welcome-dip required-field gate `validateProviderRequiredFields` (in `packages/webapp/src/scoops/onboarding-orchestrator.ts`) wrapped `getProviderCatalogue()` in an empty `catch { return null }`. Returning `null` means "no validation error", so on any catalogue read throw the sole caller `handleConnectAttempt` proceeded straight into `saveAccount` with a missing `deployment`/`baseUrl` — the exact half-configured Azure-style account the method's docstring says it exists to prevent. It was the only place in the file that swallowed a throw into a success-shaped value.

## Fix

The gate now fails CLOSED: on a catalogue throw it returns an actionable error string instead of `null`, so `handleConnectAttempt` rejects the dip with `slicc-connect-result` (`ok: false`) and rolls back `stage` to `awaiting-connect` before `saveAccount` is ever reached. The happy-path field gates are unchanged.

## Tests

- Added a regression test that exercises the throwing-catalogue case and asserts no account is saved and no licks are emitted.
- Verified green: `npm run lint` (0), `npm run typecheck` (0), `vitest` 32/32 on the onboarding-orchestrator suite.

## Verification

```
npm run lint
npm run typecheck
npx vitest run packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author