### PR TITLE
fix(webapp): hosted-leader boot fails to write /tmp/slicc-join.json

### DIFF
--- a/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
@@ -308,7 +308,7 @@ export async function setupStandalonePrelude(
 
   const runtimeConfig = await fetchRuntimeConfig();
   const runtimeDefaultWorkerBaseUrl = shouldUseRuntimeModeTrayDefaults(
-    isElectronOverlay ? 'electron-overlay' : 'standalone',
+    runtimeMode,
     runtimeConfig !== null
   )
     ? __DEV__

--- a/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
@@ -466,6 +466,32 @@ describe('setupStandalonePrelude — thin-bridge runtime-config origin', () => {
     }
   });
 
+  it('seeds the tray worker base URL in hosted-leader mode even without a runtime-config endpoint', async () => {
+    // Regression guard: hosted-leader must pass its runtimeMode (not
+    // 'standalone') to shouldUseRuntimeModeTrayDefaults so the default
+    // production worker URL is seeded. Without this, the tray never
+    // initializes and /api/cloud-status is never called — cones time out.
+    const search = '?runtime=hosted-leader';
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 404 })) // no runtime-config endpoint
+    );
+
+    const fakeWindow = createFakeWindow(search);
+    await setupStandalonePrelude({
+      runtimeMode: 'hosted-leader',
+      envBaseUrl: null,
+      window: fakeWindow,
+      log: createLog(),
+    });
+
+    const stored = (
+      fakeWindow as unknown as { localStorage: { getItem(k: string): string | null } }
+    ).localStorage.getItem('slicc.trayWorkerBaseUrl');
+    expect(stored).toBeTruthy();
+  });
+
   it('keeps the runtime-config fetch same-origin with no bridge token when no bridge is wired (no regression)', async () => {
     // No bridge configured (the legacy bundled-UI path). `resolveApiUrl`
     // returns the relative path and `apiHeaders` is empty, so the fetch must


### PR DESCRIPTION
<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

- Fix setupStandalonePrelude passing 'standalone' instead of runtimeMode to shouldUseRuntimeModeTrayDefaults, which caused hosted-leader cones to never seed the tray worker base URL
- Add regression test that asserts hosted-leader mode seeds the worker URL even without a runtime-config endpoint
  
<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

All cloud cone starts have been failing with SANDBOX_NOT_READY: cloud-status did not appear within 60000ms since the refactor that introduced the isElectronOverlay ? 'electron-overlay' : 'standalone' ternary (ignoring hosted-leader as a third mode).

  Root cause chain:
  1. shouldUseRuntimeModeTrayDefaults('standalone', false) → returns false (no runtime-config in sandboxes)
  2. No default worker base URL seeded in localStorage
  3. startInitialRole logs "hosted-leader: tray worker base URL not seeded" and returns early
  4. Tray never initializes → POST /api/cloud-status never fires → /tmp/slicc-join.json never written
  5. pollCloudStatus times out after 60s → cone is killed → SANDBOX_NOT_READY

## Approach / Implementation notes

```
- isElectronOverlay ? 'electron-overlay' : 'standalone',
+ runtimeMode,
```

This is safe because runtimeMode is already 'electron-overlay' when isElectronOverlay is true, and 'standalone' in the default case — the only behavioral change is for 'hosted-leader'.

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
