### PR TITLE
fix(ci): temporarily disable e2b template verify

### DIFF
--- a/.github/workflows/worker-staging.yml
+++ b/.github/workflows/worker-staging.yml
@@ -100,11 +100,12 @@ jobs:
           SLICC_E2B_TEMPLATE_NAME: slicc-staging
         run: bash packages/dev-tools/e2b-template/scripts/build-template.sh
 
-      - name: Verify template boots (isolated staging alias)
-        env:
-          SLICC_TEST_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-          SLICC_E2B_TEMPLATE_NAME: slicc-staging
-        run: bash packages/dev-tools/e2b-template/scripts/verify-template.sh
+      # TODO: Re-enable once template boots are self-contained (no sliccy.ai dependency).
+      # - name: Verify template boots (isolated staging alias)
+      #   env:
+      #     SLICC_TEST_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+      #     SLICC_E2B_TEMPLATE_NAME: slicc-staging
+      #   run: bash packages/dev-tools/e2b-template/scripts/verify-template.sh
 
       # The staging Worker (slicc-tray-hub-staging) has Worker Versions enabled.
       # wrangler-action runs `wrangler secret bulk` BEFORE the `command:`

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -41,10 +41,11 @@ jobs:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
         run: bash packages/dev-tools/e2b-template/scripts/build-template.sh
 
-      - name: Verify template boots
-        env:
-          SLICC_TEST_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-        run: bash packages/dev-tools/e2b-template/scripts/verify-template.sh
+      # TODO: Re-enable once template boots are self-contained (no sliccy.ai dependency).
+      # - name: Verify template boots
+      #   env:
+      #     SLICC_TEST_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+      #   run: bash packages/dev-tools/e2b-template/scripts/verify-template.sh
 
       - name: Deploy production worker (attempt 1)
         id: deploy_attempt_1

--- a/packages/cloudflare-worker/scripts/publish-worker.sh
+++ b/packages/cloudflare-worker/scripts/publish-worker.sh
@@ -22,8 +22,9 @@ SLEEP_BETWEEN=15
 echo "[publish-worker] Building and pushing e2b template..."
 bash packages/dev-tools/e2b-template/scripts/build-template.sh
 
-echo "[publish-worker] Verifying e2b template boots..."
-SLICC_TEST_E2B_API_KEY="$E2B_API_KEY" bash packages/dev-tools/e2b-template/scripts/verify-template.sh
+# TODO: Re-enable once template boots are self-contained (no sliccy.ai dependency).
+# echo "[publish-worker] Verifying e2b template boots..."
+# SLICC_TEST_E2B_API_KEY="$E2B_API_KEY" bash packages/dev-tools/e2b-template/scripts/verify-template.sh
 
 echo "[publish-worker] Uploading worker secrets..."
 echo "$CLOUDFLARE_TURN_API_TOKEN" | npx wrangler secret put CLOUDFLARE_TURN_API_TOKEN --config "$WRANGLER_CONFIG"


### PR DESCRIPTION
## Summary

  Disable the e2b template boot verification step in all release paths until the template can boot without depending on the live sliccy.ai webapp.

## Problem

  The template's headless Chrome loads the webapp from https://www.sliccy.ai. This creates a circular dependency:

  1. Webapp fix (merged in #1227) must be deployed to sliccy.ai before templates can boot
  2. Template verify blocks the deploy that would push the fixed webapp
  3. Release is permanently stuck

## Changes

  Commented out the verify step with a TODO in:
  - .github/workflows/worker-staging.yml
  - .github/workflows/worker.yml
  - packages/cloudflare-worker/scripts/publish-worker.sh

## What's still in place

  - Template build still runs (the image is pushed to e2b)
  - Worker unit tests still gate the deploy
  - Deployed smoke tests still run after deploy
  - The template itself is unchanged — once the webapp is live, it will boot fine

## Re-enable plan

  After this merges and the production release deploys the fixed webapp to sliccy.ai, re-enable verify. Longer term: make the template self-contained by bundling the webapp locally so it never depends on an external
  deploy.