### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -102,7 +102,7 @@
   },
   "swift": {
     "swift-server": {
-      "lines": 58,
+      "lines": 59,
       "functions": 58,
       "regions": 56
     },


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.