### PR TITLE
fix(webapp): remove dead enrichPendingSessions + scheduleBackgroundEnrichment (#1226)

### DIFF
--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -17,7 +17,6 @@ import {
   type FrozenSession,
   type FrozenSessionIndexEntry,
   freezeConeSession,
-  listPendingEnrichments,
 } from './session-freezer.js';
 import { SessionStore } from './session-store.js';
 
@@ -133,8 +132,9 @@ export async function runNewSessionFreeze(
   });
   if (!frozen) return null; // short session / write failure — nothing to do.
 
-  // No credentials → nothing to enrich now; leave the entry pending so the
-  // next boot's background scanner finishes it.
+  // No credentials → nothing to enrich now; leave a durable
+  // `pending-*.md` archive. Auto-finish was removed (see #1226);
+  // re-saving once a provider is configured will run enrichment.
   if (!apiKey || !model) {
     log.info('Frozen without enrichment (no LLM credentials) — left pending', {
       filename: frozen.filename,
@@ -218,10 +218,10 @@ async function raceEnrichmentAgainstTimer(
  * Quick-freeze variant of `runNewSessionFreeze`. Skips the two LLM calls
  * (and therefore the credential/header resolution they need), writing
  * the cone session under a synthetic `pending-…md` filename with the
- * heuristic title. Boot-time enrichment finishes the work later via
- * `enrichPendingSessions`. Returns as quickly as the VFS write + index
- * update allow — designed for the double-click "impatient" gesture
- * where reload latency matters more than archive title fidelity.
+ * heuristic title. The archive is durable but **never enriched** — the
+ * entry stays with its heuristic title and no icon. Designed for the
+ * double-click "impatient" gesture where reload latency matters more
+ * than archive title fidelity.
  */
 export async function runNewSessionFreezeQuick(
   opts: RunNewSessionFreezeOptions
@@ -241,118 +241,4 @@ export async function runNewSessionFreezeQuick(
     vfs: opts.vfs,
     mode: 'quick',
   });
-}
-
-export interface EnrichPendingSessionsResult {
-  /** Total pending entries found in the index. */
-  found: number;
-  /** Entries successfully enriched (title rewritten + file renamed). */
-  enriched: FrozenSessionIndexEntry[];
-}
-
-/**
- * Resolve credentials + model + headers once, then walk the sessions
- * index and finish every `pendingEnrichment: true` archive. Designed
- * to be fire-and-forget from boot — never throws, and best-effort per
- * entry so one bad archive doesn't block the rest. When no LLM
- * credentials are available, this is a no-op (entries stay pending and
- * will be retried on the next boot once credentials are configured).
- */
-export async function enrichPendingSessions(
-  opts: RunNewSessionFreezeOptions
-): Promise<EnrichPendingSessionsResult> {
-  const result: EnrichPendingSessionsResult = { found: 0, enriched: [] };
-
-  let pending: FrozenSessionIndexEntry[] = [];
-  try {
-    pending = await listPendingEnrichments(opts.vfs);
-  } catch (err) {
-    log.warn('Failed to list pending enrichments', {
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return result;
-  }
-  result.found = pending.length;
-  if (pending.length === 0) return result;
-
-  const apiKey = getApiKey() ?? undefined;
-  let model: Model<Api> | undefined;
-  try {
-    model = resolveCurrentModel();
-  } catch (err) {
-    log.info('No active model — skipping background enrichment', {
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return result;
-  }
-  if (!apiKey || !model) {
-    log.info('LLM credentials unavailable — leaving pending entries for later boot', {
-      pending: pending.length,
-    });
-    return result;
-  }
-
-  const headers: Record<string, string> | undefined =
-    model.provider === 'adobe'
-      ? { 'X-Session-Id': getDailyAdobeUuid(FREEZER_SESSION_ANCHOR) }
-      : undefined;
-
-  for (const entry of pending) {
-    try {
-      const updated = await enrichPendingSession(opts.vfs, entry, {
-        model,
-        apiKey,
-        headers,
-      });
-      if (updated) result.enriched.push(updated);
-    } catch (err) {
-      log.warn('Background enrichment threw (entry stays pending)', {
-        filename: entry.filename,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-
-  log.info('Background enrichment pass complete', {
-    found: result.found,
-    enriched: result.enriched.length,
-  });
-  return result;
-}
-
-/**
- * Schedule a fire-and-forget background enrichment pass over pending
- * frozen sessions (those archived by the impatient double-click path).
- * Defers via `requestIdleCallback` where available so a slow LLM call
- * can't delay first paint; falls back to `setTimeout(0)` otherwise.
- * Never throws — `enrichPendingSessions` is already best-effort.
- *
- * Callers pass `isWriter: false` for non-leader tabs under
- * `slicc_opfs_vfs === 'opfs'`. Enrichment writes go via the supplied
- * VFS; on a follower that VFS is the page-side LFS shadow which the
- * worker-OPFS-backed UI never reads → silent orphan. Skip the pass
- * entirely on followers (read-only mode), matching the read-only
- * banner.
- */
-export function scheduleBackgroundEnrichment(
-  vfs: WritableVfsClient,
-  opts: { isWriter?: boolean } = {}
-): void {
-  if (opts.isWriter === false) {
-    log.info('Background enrichment skipped (OPFS follower — read-only tab)');
-    return;
-  }
-  const run = (): void => {
-    void enrichPendingSessions({ vfs }).catch(() => {
-      // `enrichPendingSessions` already logs internally and is best-effort
-      // per entry; swallow here so the boot path stays silent on failure.
-    });
-  };
-  const ric = (globalThis as { requestIdleCallback?: (cb: () => void) => number })
-    .requestIdleCallback;
-  if (typeof ric === 'function') {
-    ric(run);
-  } else {
-    setTimeout(run, 0);
-  }
 }

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -120,8 +120,9 @@ export interface FreezeConeSessionOptions {
    * synchronously before writing. `'quick'` skips both calls, writes the
    * archive under a synthetic `pending-<short-id>.md` filename with the
    * heuristic title, and marks the index entry `pendingEnrichment: true`
-   * so a boot-time scanner can finish the enrichment in the background
-   * after the next reload.
+   * so a boot-time enrichment pass can finish the enrichment in the background
+   * after the next reload. (Note: `scheduleBackgroundEnrichment` was removed
+   * in #1226 — entries stay `pendingEnrichment: true` until manually re-saved.)
    */
   mode?: 'full' | 'quick';
   /**
@@ -865,7 +866,7 @@ function rewriteArchiveTitle(content: string, newTitle: string): string {
  * Promise-chain mutex serializing every `replaceIndexEntry` call within
  * this module. The sessions index is a single shared JSON file with a
  * read-modify-write update; two concurrent callers (e.g. the boot-time
- * background enrichment scanner racing a freshly-quick-frozen entry)
+ * background enrichment pass racing a freshly-quick-frozen entry)
  * would otherwise read the same stale snapshot and clobber one of the
  * writes. Cross-tab concurrency is out of scope — the app runs in a
  * single context.

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -406,7 +406,11 @@ function wireFreezerRail(deps: FreezerRailDeps): FreezerRailHandles {
               },
               onBackgroundEnriched: () => refreshFreezer(),
             });
-          } else await runNewSessionFreezeQuick({ vfs: writer });
+          } else {
+            // Quick-freeze: durable archive with heuristic title, no LLM
+            // enrichment (the entry stays pending-*.md forever).
+            await runNewSessionFreezeQuick({ vfs: writer });
+          }
         }
         await client.clearAllMessages();
         // Clear the thread directly — re-selection only *requests* a replay,

--- a/packages/webapp/tests/ui/new-session.test.ts
+++ b/packages/webapp/tests/ui/new-session.test.ts
@@ -22,7 +22,6 @@ const mockEnrichPendingSession = vi.fn();
 vi.mock('../../src/ui/session-freezer.js', () => ({
   freezeConeSession: (...a: unknown[]) => mockFreezeConeSession(...a),
   enrichPendingSession: (...a: unknown[]) => mockEnrichPendingSession(...a),
-  listPendingEnrichments: vi.fn(),
 }));
 
 const mockPickLucideIcon = vi.fn(async () => 'wrench');


### PR DESCRIPTION
Closes #1226

## What

Remove two dead functions from `new-session.ts` that had zero callers anywhere in the codebase:

- `enrichPendingSessions()` — walked the sessions index and enriched every `pendingEnrichment: true` archive
- `scheduleBackgroundEnrichment()` — fire-and-forget `requestIdleCallback` wrapper that called `enrichPendingSessions`

Also removes the `EnrichPendingSessionsResult` interface and the `listPendingEnrichments` import that was only used by the dead code.

## Why

These were introduced in commit `24b4d37d` (impatient double-click freeze) but never wired into any boot or initialization path. The consequence is that `runNewSessionFreezeQuick` creates `pending-*.md` archives that sit forever with heuristic titles and no icons — the enrichment mechanism was designed but never activated.

## Changes

| File | Change |
|---|---|
| `packages/webapp/src/ui/new-session.ts` | Removed `enrichPendingSessions`, `scheduleBackgroundEnrichment`, `EnrichPendingSessionsResult`, and `listPendingEnrichments` import (-121 lines). Updated `runNewSessionFreezeQuick` JSDoc to honestly say the archive is never enriched. |
| `packages/webapp/src/ui/wc/wc-live.ts` | Added explicit comment documenting the quick-freeze trade-off at the call site. |
| `packages/webapp/tests/ui/new-session.test.ts` | Removed unused `listPendingEnrichments` mock. |

## Verification

- All 52 tests in `new-session.test.ts`, `session-freezer.test.ts`, and `wc-freezer.test.ts` pass
- Biome lint passes
- Linear history check passes
- No remaining references to the removed functions anywhere in the codebase