### PR TITLE
feat(ci): add manual re-trigger for Claude PR review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -140,9 +140,11 @@ jobs:
           # of free-form agent mode. With a bare `prompt` the action runs in
           # agent mode, where the model posts only a top-level summary and never
           # calls the inline-comment tool (run logs show "No buffered inline
-          # comments"). track_progress is supported on the opened /
-          # ready_for_review events this workflow triggers on.
-          track_progress: true
+          # comments"). track_progress is only supported on entity events
+          # (pull_request, issues, etc.) — workflow_dispatch throws, so disable
+          # it for manual runs (the prompt + MCP tool still produce inline
+          # comments, just without the tracking comment).
+          track_progress: ${{ github.event_name != 'workflow_dispatch' }}
           # Needed by the action for the inline-comment MCP tool.
           github_token: ${{ github.token }}
           # allowedTools: the inline-comment MCP tool PLUS unrestricted Bash, so

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -42,9 +42,15 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
 
 concurrency:
-  group: claude-pr-review-${{ github.event.pull_request.number }}
+  group: claude-pr-review-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 permissions:
@@ -61,12 +67,15 @@ jobs:
     # Also skip bot-authored PRs (e.g. Renovate dependency bumps): they don't
     # need an AI review, and claude-code-action rejects bot-initiated runs by
     # default ("Workflow initiated by non-human actor"), which only produced
-    # noisy failed runs.
+    # noisy failed runs. Manual dispatch always runs (operator intent).
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.type != 'Bot'
+      github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.type != 'Bot'
+      )
     steps:
       - name: Wait 5 minutes for personal/human reviewers
+        if: github.event_name != 'workflow_dispatch'
         run: sleep 300
 
       # Trusted checkout: the PR BASE revision contains the gate script. The gate
@@ -74,7 +83,7 @@ jobs:
       # check out the PR head before the gate decides.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           fetch-depth: 1
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -85,16 +94,30 @@ jobs:
         id: gate
         env:
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           GH_TOKEN: ${{ github.token }}
+          FORCE_REVIEW: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
         run: node packages/dev-tools/pr-review-gate/check-pr-review-gate.mjs
+
+      - name: Resolve PR head SHA
+        if: steps.gate.outputs.should_review == 'true'
+        id: pr_head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          SHA="${{ github.event.pull_request.head.sha }}"
+          if [ -z "$SHA" ]; then
+            SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
       # Only now (and only if the gate approved) check out the PR head so the
       # review step sees the proposed changes.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: steps.gate.outputs.should_review == 'true'
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ steps.pr_head.outputs.sha }}
           fetch-depth: 1
 
       - name: Claude PR review
@@ -135,7 +158,7 @@ jobs:
             You are performing an automated code review for the SLICC codebase.
 
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
 
             Review the pull request above. Use `gh pr view` and `gh pr diff` to
             read the PR description and the changed code. Focus your review on:

--- a/packages/dev-tools/pr-review-gate/check-pr-review-gate.mjs
+++ b/packages/dev-tools/pr-review-gate/check-pr-review-gate.mjs
@@ -69,6 +69,15 @@ async function main() {
   const repo = requireEnv('REPO');
   const prNumber = requireEnv('PR_NUMBER');
   const token = requireEnv('GH_TOKEN');
+  const forceReview = (process.env.FORCE_REVIEW ?? '').trim() === 'true';
+
+  if (forceReview) {
+    const reason = 'Manual dispatch — skipping gate, forcing review.';
+    setOutput('should_review', 'true');
+    setOutput('reason', reason);
+    console.log(reason);
+    return;
+  }
 
   const pr = await ghGet(`/repos/${repo}/pulls/${prNumber}`, token);
   const comments = await fetchInlineComments(repo, prNumber, token);


### PR DESCRIPTION
Add workflow_dispatch trigger with a pr_number input so reviews can be re-run on demand — even when inline comments already exist (which the automatic gate skips). FORCE_REVIEW env var bypasses the gate entirely on manual dispatch.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
