### PR TITLE
fix(adobe): don't cache failed /v1/config responses

### DIFF
--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -21,10 +21,13 @@
 import type {
   AnthropicOptions,
   Api,
+  AssistantMessageEvent,
   Context,
   Model,
+  OpenAICompletionsCompat,
   OpenAICompletionsOptions,
   SimpleStreamOptions,
+  StreamFunction,
 } from '@earendil-works/pi-ai';
 import {
   createAssistantMessageEventStream,
@@ -153,9 +156,9 @@ async function fetchProxyConfig(proxyEndpoint: string): Promise<ProxyConfig> {
       err instanceof Error ? err.message : String(err)
     );
   }
-  const empty: ProxyConfig = {};
-  proxyConfigCache.set(proxyEndpoint, empty);
-  return empty;
+  // ponytail: failures are intentionally NOT cached — a transient proxy blip
+  // must not poison the session-level Map and block every subsequent retry.
+  return {};
 }
 
 /** Resolve the IMS client ID. Fetched config takes precedence over build-time config. */
@@ -191,7 +194,8 @@ function imsHost(env?: string): string {
 
 // ── Runtime detection ───────────────────────────────────────────────
 
-const isExtension = typeof chrome !== 'undefined' && !!(chrome as any)?.runtime?.id;
+const isExtension =
+  typeof chrome !== 'undefined' && !!(chrome as { runtime?: { id?: string } })?.runtime?.id;
 
 // ── Shared helpers ──────────────────────────────────────────────────
 
@@ -294,7 +298,7 @@ export const config: ProviderConfig = {
       const persisted = localStorage.getItem(ADOBE_MODELS_KEY);
       if (persisted) {
         const models = JSON.parse(persisted) as Array<
-          { id: string; name?: string } & Record<string, any>
+          { id: string; name?: string } & Record<string, unknown>
         >;
         if (models.length) return models;
       }
@@ -338,7 +342,7 @@ export const config: ProviderConfig = {
       : null;
     const redirectUri = isExtension
       ? (adobeConfig.extensionRedirectUri ??
-        `https://${(chrome as any).runtime.id}.chromiumapp.org/`)
+        `https://${(chrome as { runtime: { id: string } }).runtime.id}.chromiumapp.org/`)
       : stateInfo!.redirectUri;
 
     const oauthState = stateInfo?.oauthState;
@@ -567,7 +571,8 @@ function buildSilentRenewAuthorize(
   const imsEnv = resolveImsEnvironment(proxyConfig);
 
   const redirectUri = isExtension
-    ? (adobeConfig.extensionRedirectUri ?? `https://${(chrome as any).runtime.id}.chromiumapp.org/`)
+    ? (adobeConfig.extensionRedirectUri ??
+      `https://${(chrome as { runtime: { id: string } }).runtime.id}.chromiumapp.org/`)
     : (adobeConfig.redirectUri ?? `${window.location.origin}/auth/callback`);
 
   // Build OAuth state with port and CSRF nonce for the sliccy.ai relay (CLI only)
@@ -805,16 +810,20 @@ const streamAdobe = (
           ...model,
           baseUrl: `${getProxyEndpoint()}/v1`,
           api: 'openai-completions' as Api,
-          compat: { ...(model as any).compat, supportsStore: false, supportsDeveloperRole: false },
+          compat: {
+            ...(model as unknown as { compat?: OpenAICompletionsCompat }).compat,
+            supportsStore: false,
+            supportsDeveloperRole: false,
+          },
         };
         const inner = streamOpenAICompletions(
-          proxyModel as any,
+          proxyModel as unknown as Model<'openai-completions'>,
           context,
           withSliccVersionHeader(
             ensureSessionIdHeader({ ...options, apiKey: accessToken }, 'streamAdobe[openai]')
-          ) as any
+          ) as unknown as OpenAICompletionsOptions
         );
-        for await (const event of inner) stream.push(event as any);
+        for await (const event of inner) stream.push(event);
       } else {
         // Route to Anthropic Messages API
         const proxyModel = {
@@ -823,7 +832,7 @@ const streamAdobe = (
           api: 'anthropic-messages' as Api,
         };
         const inner = streamAnthropic(
-          proxyModel as any,
+          proxyModel as unknown as Model<'anthropic-messages'>,
           context,
           withSliccVersionHeader(
             ensureSessionIdHeader(
@@ -838,7 +847,7 @@ const streamAdobe = (
             )
           )
         );
-        for await (const event of inner) stream.push(event as any);
+        for await (const event of inner) stream.push(event);
       }
       stream.end();
     } catch (error) {
@@ -846,7 +855,7 @@ const streamAdobe = (
         '[adobe] Stream error:',
         error instanceof Error ? error.message : String(error)
       );
-      stream.push(makeErrorOutput(model, error) as any);
+      stream.push(makeErrorOutput(model, error) as unknown as AssistantMessageEvent);
       stream.end();
     }
   })();
@@ -865,16 +874,20 @@ const streamSimpleAdobe = (model: Model<Api>, context: Context, options?: Simple
           ...model,
           baseUrl: `${getProxyEndpoint()}/v1`,
           api: 'openai-completions' as Api,
-          compat: { ...(model as any).compat, supportsStore: false, supportsDeveloperRole: false },
+          compat: {
+            ...(model as unknown as { compat?: OpenAICompletionsCompat }).compat,
+            supportsStore: false,
+            supportsDeveloperRole: false,
+          },
         };
         const inner = streamSimpleOpenAICompletions(
-          proxyModel as any,
+          proxyModel as unknown as Model<'openai-completions'>,
           context,
           withSliccVersionHeader(
             ensureSessionIdHeader({ ...options, apiKey: accessToken }, 'streamSimpleAdobe[openai]')
-          ) as any
+          ) as unknown as SimpleStreamOptions
         );
-        for await (const event of inner) stream.push(event as any);
+        for await (const event of inner) stream.push(event);
       } else {
         // Route to Anthropic Messages API
         const proxyModel = {
@@ -883,7 +896,7 @@ const streamSimpleAdobe = (model: Model<Api>, context: Context, options?: Simple
           api: 'anthropic-messages' as Api,
         };
         const inner = streamSimpleAnthropic(
-          proxyModel as any,
+          proxyModel as unknown as Model<'anthropic-messages'>,
           context,
           withSliccVersionHeader(
             ensureSessionIdHeader(
@@ -897,9 +910,9 @@ const streamSimpleAdobe = (model: Model<Api>, context: Context, options?: Simple
               ),
               'streamSimpleAdobe[anthropic]'
             )
-          ) as any
+          ) as unknown as SimpleStreamOptions
         );
-        for await (const event of inner) stream.push(event as any);
+        for await (const event of inner) stream.push(event);
       }
       stream.end();
     } catch (error) {
@@ -907,7 +920,7 @@ const streamSimpleAdobe = (model: Model<Api>, context: Context, options?: Simple
         '[adobe] Stream error:',
         error instanceof Error ? error.message : String(error)
       );
-      stream.push(makeErrorOutput(model, error) as any);
+      stream.push(makeErrorOutput(model, error) as unknown as AssistantMessageEvent);
       stream.end();
     }
   })();
@@ -917,7 +930,7 @@ const streamSimpleAdobe = (model: Model<Api>, context: Context, options?: Simple
 // ── Model list ──────────────────────────────────────────────────────
 
 /** Pull the typed metadata fields off a raw proxy `/v1/models` entry. */
-function toMetadataEntry(pm: Record<string, any>): AdobeModelMetadata {
+function toMetadataEntry(pm: Record<string, unknown>): AdobeModelMetadata {
   const entry: AdobeModelMetadata = { id: pm.id, name: pm.name };
   if (pm.api !== undefined) entry.api = pm.api;
   if (pm.context_window !== undefined) entry.context_window = pm.context_window;
@@ -930,9 +943,9 @@ function toMetadataEntry(pm: Record<string, any>): AdobeModelMetadata {
 /** Lookup across all pi-ai providers (Anthropic, Cerebras, OpenAI, etc.). */
 function buildPiAiModelMap(): Map<string, Model<Api>> {
   const modelMap = new Map<string, Model<Api>>();
-  for (const provider of getProviders() as string[]) {
+  for (const provider of getProviders()) {
     try {
-      for (const m of getModels(provider as any) as Model<Api>[]) modelMap.set(m.id, m);
+      for (const m of getModels(provider) as unknown as Model<Api>[]) modelMap.set(m.id, m);
     } catch {}
   }
   return modelMap;
@@ -940,7 +953,7 @@ function buildPiAiModelMap(): Map<string, Model<Api>> {
 
 /** Construct an Adobe-tagged Model from a proxy entry, reusing pi-ai metadata when present. */
 function buildAdobeModel(
-  pm: Record<string, any>,
+  pm: Record<string, unknown>,
   endpoint: string,
   modelMap: Map<string, Model<Api>>
 ): Model<Api> {
@@ -970,7 +983,7 @@ function buildAdobeModel(
 /** Map a successful `/v1/models` payload into the Adobe-tagged Model<Api>[] list,
  * populating `proxyMetadataCache` as a side effect for later use in `getModelIds()`. */
 function processProxyModelsPayload(
-  rawModels: Array<Record<string, any>>,
+  rawModels: Array<Record<string, unknown>>,
   endpoint: string
 ): Model<Api>[] {
   for (const pm of rawModels) proxyMetadataCache.set(pm.id, toMetadataEntry(pm));
@@ -995,7 +1008,7 @@ async function fetchProxyModels(accessToken?: string): Promise<Model<Api>[] | nu
         `[adobe] Proxy /v1/models returned ${res.status}, falling back to Anthropic models`
       );
     } else {
-      const data = (await res.json()) as { data?: Array<any> };
+      const data = (await res.json()) as { data?: Array<Record<string, unknown>> };
       if (data.data?.length) return processProxyModelsPayload(data.data, endpoint);
     }
   } catch (err) {
@@ -1018,7 +1031,7 @@ const modelsCache = new Map<string, Model<Api>[]>();
 /** Anthropic-registry models tagged as Adobe — the best-effort fallback when
  * the proxy `/v1/models` fetch fails. Intentionally NOT cached by callers. */
 function adobeAnthropicFallbackModels(): Model<Api>[] {
-  const anthropicModels = getModels('anthropic' as any) as Model<Api>[];
+  const anthropicModels = getModels('anthropic') as unknown as Model<Api>[];
   return anthropicModels.map((m) => ({ ...m, provider: 'adobe', api: 'adobe-anthropic' as Api }));
 }
 
@@ -1041,13 +1054,13 @@ export async function getAdobeModels(accessToken?: string): Promise<Model<Api>[]
 export function register(): void {
   registerApiProvider({
     api: 'adobe-anthropic' as Api,
-    stream: streamAdobe as any,
-    streamSimple: streamSimpleAdobe as any,
+    stream: streamAdobe as unknown as StreamFunction<Api>,
+    streamSimple: streamSimpleAdobe as unknown as StreamFunction<Api, SimpleStreamOptions>,
   });
   registerApiProvider({
     api: 'adobe-openai' as Api,
-    stream: streamAdobe as any,
-    streamSimple: streamSimpleAdobe as any,
+    stream: streamAdobe as unknown as StreamFunction<Api>,
+    streamSimple: streamSimpleAdobe as unknown as StreamFunction<Api, SimpleStreamOptions>,
   });
 }
 

--- a/packages/webapp/tests/providers/adobe-provider.test.ts
+++ b/packages/webapp/tests/providers/adobe-provider.test.ts
@@ -161,12 +161,18 @@ describe('Model metadata survives renewal', () => {
 
     // Simulate fetchProxyModels populating the cache
     for (const pm of proxyResponse) {
-      proxyMetadataCache.set(pm.id, { api: (pm as any).api, context_window: pm.context_window });
+      proxyMetadataCache.set(pm.id, {
+        api: (pm as { api?: string }).api,
+        context_window: pm.context_window,
+      });
     }
 
     // Simulate enrichModel using the cache
     const enriched = proxyResponse.map((m) => {
-      const entry: any = { id: m.id, name: m.name };
+      const entry: { id: string; name: string; api?: string; context_window?: number } = {
+        id: m.id,
+        name: m.name,
+      };
       const meta = proxyMetadataCache.get(m.id);
       if (meta?.api) entry.api = meta.api;
       if (meta?.context_window !== undefined) entry.context_window = meta.context_window;
@@ -320,26 +326,26 @@ describe('silentRenewToken worker-safety guard (pattern)', () => {
   };
 
   it('returns null when window is undefined (worker context)', async () => {
-    const originalWindow = (globalThis as any).window;
-    delete (globalThis as any).window;
+    const originalWindow = (globalThis as Record<string, unknown>).window;
+    delete (globalThis as Record<string, unknown>).window;
     try {
-      expect(typeof (globalThis as any).window).toBe('undefined');
+      expect(typeof (globalThis as Record<string, unknown>).window).toBe('undefined');
       const result = await silentRenewMimic();
       expect(result).toBeNull();
     } finally {
-      (globalThis as any).window = originalWindow;
+      (globalThis as Record<string, unknown>).window = originalWindow;
     }
   });
 
   it('does NOT throw a ReferenceError in worker context', async () => {
-    const originalWindow = (globalThis as any).window;
-    delete (globalThis as any).window;
+    const originalWindow = (globalThis as Record<string, unknown>).window;
+    delete (globalThis as Record<string, unknown>).window;
     try {
       // The pre-fix code dereferenced `window.location.href` and threw.
       // Post-fix it returns null cleanly without exceptions.
       await expect(silentRenewMimic()).resolves.toBeNull();
     } finally {
-      (globalThis as any).window = originalWindow;
+      (globalThis as Record<string, unknown>).window = originalWindow;
     }
   });
 });
@@ -589,5 +595,115 @@ describe('X-Session-Id fallback enforcement', () => {
     expect(withSessionAndVersion.headers?.['X-Session-Id']).toBe('real-cone-uuid');
     expect(withSessionAndVersion.headers?.[SLICC_VERSION_HEADER]).toBe(sliccVersion);
     expect(warned).toEqual([]);
+  });
+});
+
+describe('fetchProxyConfig caching contract', () => {
+  // Mirrors the caching logic in adobe.ts fetchProxyConfig. Same
+  // mirror-rather-than-import pattern: adobe.ts pulls in import.meta.glob
+  // and chrome globals that aren't available under vitest/node.
+  //
+  // Regression for: a failed /v1/config fetch used to cache an empty {}
+  // object, so every subsequent login retry in the same session reused the
+  // poisoned cache even after the proxy recovered — requiring a full page
+  // reload to clear it.
+
+  const SLICC_VERSION_HEADER = 'X-Slicc-Version';
+
+  interface ProxyConfig {
+    clientId?: string;
+    scopes?: string;
+    imsEnvironment?: string;
+  }
+
+  async function fetchProxyConfig(
+    proxyEndpoint: string,
+    cache: Map<string, ProxyConfig>,
+    fetchImpl: typeof fetch
+  ): Promise<ProxyConfig> {
+    const cached = cache.get(proxyEndpoint);
+    if (cached) return cached;
+    try {
+      const res = await fetchImpl(`${proxyEndpoint}/v1/config`, {
+        headers: { [SLICC_VERSION_HEADER]: '1.0.0-test' },
+      });
+      if (res.ok) {
+        const config = (await res.json()) as ProxyConfig;
+        cache.set(proxyEndpoint, config);
+        return config;
+      }
+      console.warn(
+        `[adobe] Proxy /v1/config returned ${res.status}, falling back to build-time config`
+      );
+    } catch (err) {
+      console.warn(
+        '[adobe] Failed to fetch proxy config:',
+        err instanceof Error ? err.message : String(err)
+      );
+    }
+    // ponytail: failures are intentionally NOT cached
+    return {};
+  }
+
+  const ENDPOINT = 'https://proxy.example.com';
+
+  it('successful fetch is cached — second call does not re-fetch', async () => {
+    let callCount = 0;
+    const mockFetch = async () => {
+      callCount++;
+      return {
+        ok: true,
+        json: async () => ({ clientId: 'test-client', scopes: 'openid' }),
+      } as Response;
+    };
+    const cache = new Map<string, ProxyConfig>();
+    const first = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
+    const second = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
+    expect(callCount).toBe(1);
+    expect(first.clientId).toBe('test-client');
+    expect(second.clientId).toBe('test-client');
+  });
+
+  it('failed fetch (non-ok status) is NOT cached — second call re-fetches', async () => {
+    let callCount = 0;
+    const mockFetch = async () => {
+      callCount++;
+      return { ok: false, status: 503 } as Response;
+    };
+    const cache = new Map<string, ProxyConfig>();
+    await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
+    await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
+    expect(callCount).toBe(2);
+    expect(cache.size).toBe(0);
+  });
+
+  it('failed fetch (network throw) is NOT cached — second call re-fetches', async () => {
+    let callCount = 0;
+    const mockFetch = async () => {
+      callCount++;
+      throw new Error('fetch failed');
+    };
+    const cache = new Map<string, ProxyConfig>();
+    await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
+    await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
+    expect(callCount).toBe(2);
+    expect(cache.size).toBe(0);
+  });
+
+  it('recovers after a blip — retry after failure returns real clientId without reload', async () => {
+    let callCount = 0;
+    // First call: proxy down
+    // Second call: proxy recovered
+    const mockFetch = async () => {
+      callCount++;
+      if (callCount === 1) return { ok: false, status: 503 } as Response;
+      return { ok: true, json: async () => ({ clientId: 'experience-catalyst-prod' }) } as Response;
+    };
+    const cache = new Map<string, ProxyConfig>();
+    const first = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
+    expect(first.clientId).toBeUndefined(); // blip: empty fallback
+    const second = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
+    expect(second.clientId).toBe('experience-catalyst-prod'); // recovery: real value
+    expect(callCount).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- `fetchProxyConfig` was caching the empty `{}` fallback on any failure (non-ok status or network throw), poisoning `proxyConfigCache` for the rest of the session — so retrying login after a transient proxy blip kept throwing `Could not determine IMS client ID` until the user did a full page reload
- Fix: return the empty fallback without writing to the cache, so the next login attempt re-fetches
- Adds 4 regression tests covering: successful responses still cache, failed responses don't cache (both non-ok and network throw), and recovery-without-reload works

## Test plan

- [ ] `npm run test -w @slicc/webapp` — all `fetchProxyConfig caching contract` tests pass
- [ ] `npm run typecheck` — clean
- [ ] Manual: in DevTools Network tab, block `adobe-llm-proxy.paolo-moz.workers.dev`, attempt Adobe login (fails), unblock, retry **without reloading** — login should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)