### PR TITLE
fix(webapp): route /api calls through thin bridge in hosted-leader mode

### DIFF
--- a/packages/webapp/src/ui/boot/setup-standalone-tray-init-hosted.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-tray-init-hosted.ts
@@ -13,6 +13,7 @@
  * an id pi-ai doesn't know resolves against a cold default).
  */
 
+import { apiHeaders, resolveApiUrl } from '../../shell/proxied-fetch.js';
 import { removeAccount, saveOAuthAccount } from '../provider-settings.js';
 import type { BootStageLogger } from './types.js';
 
@@ -24,8 +25,9 @@ export async function runHostedBootstrap(deps: RunHostedBootstrapDeps): Promise<
   const { log } = deps;
   await new Promise((r) => setTimeout(r, 5000));
   try {
-    const res = await fetch('/api/hosted-bootstrap', {
+    const res = await fetch(resolveApiUrl('/api/hosted-bootstrap'), {
       signal: AbortSignal.timeout(10000),
+      headers: apiHeaders(),
     });
     if (!res.ok) return;
     const boot = (await res.json()) as {

--- a/packages/webapp/src/ui/wc/wc-float-label.ts
+++ b/packages/webapp/src/ui/wc/wc-float-label.ts
@@ -7,6 +7,8 @@
  * Unknown/unreachable keeps the generic label (cherry iframes, old servers).
  */
 
+import { apiHeaders, resolveApiUrl } from '../../shell/proxied-fetch.js';
+
 const FLOAT_BY_SERVICE: Record<string, string> = {
   'slicc-server': 'sliccstart',
   'slicc-node-server': 'npx',
@@ -23,9 +25,11 @@ export async function resolveStandaloneFloatLabel(opts?: {
   try {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
-    const res = await fetchFn('/api/status', { cache: 'no-store', signal: ctrl.signal }).finally(
-      () => clearTimeout(timer)
-    );
+    const res = await fetchFn(resolveApiUrl('/api/status'), {
+      cache: 'no-store',
+      signal: ctrl.signal,
+      headers: apiHeaders(),
+    }).finally(() => clearTimeout(timer));
     if (!res.ok) return DEFAULT_STANDALONE_LABEL;
     const body = (await res.json()) as { service?: string };
     const float = body.service ? FLOAT_BY_SERVICE[body.service] : undefined;

--- a/packages/webapp/tests/ui/boot/setup-standalone-tray-init-hosted.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-standalone-tray-init-hosted.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+/**
+ * Regression test: runHostedBootstrap must route through the thin bridge
+ * (resolveApiUrl + apiHeaders) so hosted-leader pages served from
+ * www.sliccy.ai reach the local node-server instead of the hosted origin.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/ui/provider-settings.js', () => ({
+  saveOAuthAccount: vi.fn(async () => {}),
+  removeAccount: vi.fn(async () => {}),
+  addAccount: vi.fn(),
+  getAccounts: vi.fn(() => []),
+  getProviderConfig: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../src/ui/hosted-config-apply.js', () => ({
+  applyHostedAccounts: vi.fn(async () => {}),
+  prewarmHostedModels: vi.fn(async () => {}),
+}));
+
+import { setLocalApiBaseUrl, setBridgeToken } from '../../../src/shell/proxied-fetch.js';
+import { runHostedBootstrap } from '../../../src/ui/boot/setup-standalone-tray-init-hosted.js';
+
+const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  setLocalApiBaseUrl(null);
+  setBridgeToken(null);
+  localStorage.clear();
+});
+
+describe('runHostedBootstrap — thin-bridge routing', () => {
+  it('rewrites URL and attaches X-Bridge-Token when bridge is configured', async () => {
+    setLocalApiBaseUrl('http://localhost:5710');
+    setBridgeToken('my-bridge-token');
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          model: 'adobe:claude-opus-4-6',
+          accounts: [{ providerId: 'adobe', kind: 'oauth', accessToken: 'tok' }],
+        }),
+        { status: 200 }
+      )
+    );
+
+    const done = runHostedBootstrap({ log });
+    await vi.advanceTimersByTimeAsync(5500);
+    await done;
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('http://localhost:5710/api/hosted-bootstrap');
+    const headers = init?.headers as Record<string, string> | undefined;
+    expect(headers?.['X-Bridge-Token']).toBe('my-bridge-token');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('sets selected-model from the bootstrap response', async () => {
+    setLocalApiBaseUrl('http://localhost:5710');
+    setBridgeToken('tok');
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          model: 'adobe:claude-opus-4-6',
+          accounts: [{ providerId: 'adobe', kind: 'oauth', accessToken: 'x' }],
+        }),
+        { status: 200 }
+      )
+    );
+
+    const done = runHostedBootstrap({ log });
+    await vi.advanceTimersByTimeAsync(5500);
+    await done;
+
+    expect(localStorage.getItem('selected-model')).toBe('adobe:claude-opus-4-6');
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/packages/webapp/tests/ui/boot/setup-standalone-tray-init-hosted.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-standalone-tray-init-hosted.test.ts
@@ -20,20 +20,34 @@ vi.mock('../../../src/ui/hosted-config-apply.js', () => ({
   prewarmHostedModels: vi.fn(async () => {}),
 }));
 
-import { setLocalApiBaseUrl, setBridgeToken } from '../../../src/shell/proxied-fetch.js';
+import { setBridgeToken, setLocalApiBaseUrl } from '../../../src/shell/proxied-fetch.js';
 import { runHostedBootstrap } from '../../../src/ui/boot/setup-standalone-tray-init-hosted.js';
 
 const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
+const store = new Map<string, string>();
+const fakeStorage = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => store.set(k, v),
+  removeItem: (k: string) => store.delete(k),
+  clear: () => store.clear(),
+  get length() {
+    return store.size;
+  },
+  key: (_i: number) => null,
+};
+
 beforeEach(() => {
   vi.useFakeTimers();
+  vi.stubGlobal('localStorage', fakeStorage);
 });
 
 afterEach(() => {
   vi.useRealTimers();
   setLocalApiBaseUrl(null);
   setBridgeToken(null);
-  localStorage.clear();
+  store.clear();
+  vi.unstubAllGlobals();
 });
 
 describe('runHostedBootstrap — thin-bridge routing', () => {
@@ -82,7 +96,7 @@ describe('runHostedBootstrap — thin-bridge routing', () => {
     await vi.advanceTimersByTimeAsync(5500);
     await done;
 
-    expect(localStorage.getItem('selected-model')).toBe('adobe:claude-opus-4-6');
+    expect(store.get('selected-model')).toBe('adobe:claude-opus-4-6');
 
     fetchSpy.mockRestore();
   });

--- a/packages/webapp/tests/ui/wc/wc-float-label.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-float-label.test.ts
@@ -5,7 +5,8 @@
  * keeps the generic standalone label.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setLocalApiBaseUrl, setBridgeToken } from '../../../src/shell/proxied-fetch.js';
 import {
   DEFAULT_STANDALONE_LABEL,
   resolveStandaloneFloatLabel,
@@ -14,6 +15,11 @@ import {
 function okJson(body: unknown): typeof fetch {
   return vi.fn(async () => ({ ok: true, json: async () => body })) as unknown as typeof fetch;
 }
+
+afterEach(() => {
+  setLocalApiBaseUrl(null);
+  setBridgeToken(null);
+});
 
 describe('resolveStandaloneFloatLabel', () => {
   it('labels the native Sliccstart server', async () => {
@@ -69,5 +75,22 @@ describe('resolveStandaloneFloatLabel', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('rewrites URL and attaches X-Bridge-Token in thin-bridge mode', async () => {
+    setLocalApiBaseUrl('http://localhost:5710');
+    setBridgeToken('test-bridge-token');
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ status: 'ok', service: 'slicc-node-server' }),
+    })) as unknown as typeof fetch;
+
+    await resolveStandaloneFloatLabel({ fetchFn });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('http://localhost:5710/api/status');
+    const headers = init?.headers as Record<string, string> | undefined;
+    expect(headers?.['X-Bridge-Token']).toBe('test-bridge-token');
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-float-label.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-float-label.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { setLocalApiBaseUrl, setBridgeToken } from '../../../src/shell/proxied-fetch.js';
+import { setBridgeToken, setLocalApiBaseUrl } from '../../../src/shell/proxied-fetch.js';
 import {
   DEFAULT_STANDALONE_LABEL,
   resolveStandaloneFloatLabel,


### PR DESCRIPTION
<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary
- Cloud cones (hosted-leader) load the UI from www.sliccy.ai cross-origin. Bare fetch('/api/...') calls hit the hosted origin instead of the local node-server, returning HTML instead of JSON and silently failing.
- The bootstrap (/api/hosted-bootstrap) parsed HTML as JSON, threw in the catch, and never set selected-model — causing "No API key configured for provider anthropic" on every message despite the Adobe token being present.
- /api/status (float label fingerprinting) had the same bug — label always fell back to the generic default.
- Both now route through resolveApiUrl() + apiHeaders() to reach the local node-server via the thin bridge.
 
<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
