### PR TITLE
fix(webapp): route crontask /api through thin bridge + refactor off debt list

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -278,7 +278,6 @@
       "includes": [
         "packages/webapp/cloud/app.js",
         "packages/webapp/src/core/context-compaction.ts",
-        "packages/webapp/src/shell/supplemental-commands/crontask-command.ts",
         "packages/webapp/src/shell/supplemental-commands/open-command.ts",
         "packages/webapp/src/shell/supplemental-commands/pdftk-command.ts",
         "packages/webapp/src/shell/supplemental-commands/websocat-command.ts",
@@ -316,7 +315,6 @@
         "packages/webapp/src/net/link-header.ts",
         "packages/webapp/src/shell/mcp/oauth.ts",
         "packages/webapp/src/shell/supplemental-commands/afplay-command.ts",
-        "packages/webapp/src/shell/supplemental-commands/crontask-command.ts",
         "packages/webapp/src/shell/supplemental-commands/dig-command.ts",
         "packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts",
         "packages/webapp/src/shell/supplemental-commands/fswatch-command.ts",

--- a/packages/webapp/src/shell/supplemental-commands/crontask-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/crontask-command.ts
@@ -1,7 +1,10 @@
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
+import { apiHeaders, resolveApiUrl } from '../proxied-fetch.js';
 
-function crontaskHelp(): { stdout: string; stderr: string; exitCode: number } {
+type CommandResult = { stdout: string; stderr: string; exitCode: number };
+
+function crontaskHelp(): CommandResult {
   return {
     stdout: `usage: crontask <command> [options]
 
@@ -86,15 +89,176 @@ async function apiCall(
 ): Promise<{ ok: boolean; status: number; data: unknown }> {
   const init: RequestInit = {
     method,
-    headers: { 'Content-Type': 'application/json' },
+    headers: apiHeaders({ 'Content-Type': 'application/json' }),
   };
   if (body) {
     init.body = JSON.stringify(body);
   }
 
-  const resp = await fetch(`/api/crontasks${path}`, init);
+  const resp = await fetch(resolveApiUrl(`/api/crontasks${path}`), init);
   const data = await resp.json().catch(() => ({}));
   return { ok: resp.ok, status: resp.status, data };
+}
+
+async function handleCreate(args: string[]): Promise<CommandResult> {
+  let name: string | undefined;
+  let cron: string | undefined;
+  let filter: string | undefined;
+  let scoop: string | undefined;
+
+  const nameIdx = args.indexOf('--name');
+  if (nameIdx !== -1 && args[nameIdx + 1]) {
+    name = args[nameIdx + 1];
+  }
+
+  const cronIdx = args.indexOf('--cron');
+  if (cronIdx !== -1 && args[cronIdx + 1]) {
+    cron = args[cronIdx + 1];
+  }
+
+  const filterIdx = args.indexOf('--filter');
+  if (filterIdx !== -1 && args[filterIdx + 1]) {
+    filter = args[filterIdx + 1];
+  }
+
+  const scoopIdx = args.indexOf('--scoop');
+  if (scoopIdx !== -1 && args[scoopIdx + 1]) {
+    scoop = args[scoopIdx + 1];
+  }
+
+  if (!name) {
+    return { stdout: '', stderr: 'crontask: --name is required\n', exitCode: 1 };
+  }
+
+  if (!cron) {
+    return { stdout: '', stderr: 'crontask: --cron is required\n', exitCode: 1 };
+  }
+
+  // Extension mode: use LickManager directly or proxy to offscreen
+  if (isExtension) {
+    // Warn about filter limitation in extension mode (CSP blocks dynamic eval)
+    if (filter) {
+      return {
+        stdout: '',
+        stderr: 'crontask: --filter is not supported in extension mode (CSP restriction)\n',
+        exitCode: 1,
+      };
+    }
+    const extLm = getExtensionLickManager();
+    const entry = extLm
+      ? await extLm.createCronTask(name, cron, scoop)
+      : await (await getLickProxy()).createCronTask(name, cron, scoop);
+    let output = `Created cron task "${entry.name}"\n`;
+    output += `ID:       ${entry.id}\n`;
+    output += `Cron:     ${entry.cron}\n`;
+    if (entry.scoop) output += `Scoop:    ${entry.scoop}\n`;
+    if (entry.nextRun) output += `Next run: ${new Date(entry.nextRun).toLocaleString()}\n`;
+    return { stdout: output, stderr: '', exitCode: 0 };
+  }
+
+  const { ok, data } = await apiCall('POST', '', { name, cron, filter, scoop });
+  if (!ok) {
+    return {
+      stdout: '',
+      stderr: `crontask: failed to create: ${(data as { error?: string }).error ?? 'unknown error'}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const info = data as CronTaskInfo;
+  let output = `Created cron task "${info.name}"\n`;
+  output += `ID:       ${info.id}\n`;
+  output += `Cron:     ${info.cron}\n`;
+  if (info.scoop) {
+    output += `Scoop:    ${info.scoop}\n`;
+  }
+  if (info.filter) {
+    output += `Filter:   ${info.filter}\n`;
+  }
+  if (info.nextRun) {
+    output += `Next run: ${new Date(info.nextRun).toLocaleString()}\n`;
+  }
+  return { stdout: output, stderr: '', exitCode: 0 };
+}
+
+function formatTaskList(tasks: CronTaskInfo[]): string {
+  let output = 'Active cron tasks:\n';
+  for (const task of tasks) {
+    output += `  ${task.id}  ${task.name.padEnd(20)}  ${task.cron.padEnd(15)}`;
+    if (task.scoop) output += `  -> ${task.scoop}`;
+    if (task.filter) output += `  [filtered]`;
+    output += `  (${task.status})`;
+    if (task.nextRun) output += `  next: ${new Date(task.nextRun).toLocaleString()}`;
+    output += '\n';
+  }
+  return output;
+}
+
+async function handleList(): Promise<CommandResult> {
+  if (isExtension) {
+    const extLm = getExtensionLickManager();
+    const tasks = extLm
+      ? extLm.listCronTasks()
+      : await (async () => {
+          const { listCronTasksAsync } = await import(
+            '../../../../chrome-extension/src/lick-manager-proxy.js'
+          );
+          return listCronTasksAsync();
+        })();
+    if (tasks.length === 0) {
+      return { stdout: 'No active cron tasks\n', stderr: '', exitCode: 0 };
+    }
+    return { stdout: formatTaskList(tasks as CronTaskInfo[]), stderr: '', exitCode: 0 };
+  }
+
+  const { ok, data } = await apiCall('GET', '');
+  if (!ok) {
+    return {
+      stdout: '',
+      stderr: `crontask: failed to list: ${(data as { error?: string }).error ?? 'unknown error'}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const tasks = data as CronTaskInfo[];
+  if (tasks.length === 0) {
+    return { stdout: 'No active cron tasks\n', stderr: '', exitCode: 0 };
+  }
+  return { stdout: formatTaskList(tasks), stderr: '', exitCode: 0 };
+}
+
+async function handleDelete(args: string[]): Promise<CommandResult> {
+  const subcommand = args[0];
+  const id = args[1];
+  if (!id) {
+    return { stdout: '', stderr: `crontask: ${subcommand} requires an ID\n`, exitCode: 1 };
+  }
+
+  // Extension mode: use LickManager directly or proxy to offscreen
+  if (isExtension) {
+    const extLm = getExtensionLickManager();
+    const deleted = extLm
+      ? await extLm.deleteCronTask(id)
+      : await (await getLickProxy()).deleteCronTask(id);
+    if (!deleted) {
+      return { stdout: '', stderr: `crontask: task "${id}" not found\n`, exitCode: 1 };
+    }
+    return { stdout: `Deleted cron task "${id}"\n`, stderr: '', exitCode: 0 };
+  }
+
+  const { ok, status, data } = await apiCall('DELETE', `/${id}`);
+  if (!ok) {
+    if (status === 404) {
+      return { stdout: '', stderr: `crontask: task "${id}" not found\n`, exitCode: 1 };
+    }
+    return {
+      stdout: '',
+      stderr: `crontask: failed to delete: ${(data as { error?: string }).error ?? 'unknown error'}\n`,
+      exitCode: 1,
+    };
+  }
+
+  return { stdout: `Deleted cron task "${id}"\n`, stderr: '', exitCode: 0 };
 }
 
 export function createCrontaskCommand(): Command {
@@ -107,226 +271,19 @@ export function createCrontaskCommand(): Command {
 
     try {
       switch (subcommand) {
-        case 'create': {
-          let name: string | undefined;
-          let cron: string | undefined;
-          let filter: string | undefined;
-          let scoop: string | undefined;
-
-          const nameIdx = args.indexOf('--name');
-          if (nameIdx !== -1 && args[nameIdx + 1]) {
-            name = args[nameIdx + 1];
-          }
-
-          const cronIdx = args.indexOf('--cron');
-          if (cronIdx !== -1 && args[cronIdx + 1]) {
-            cron = args[cronIdx + 1];
-          }
-
-          const filterIdx = args.indexOf('--filter');
-          if (filterIdx !== -1 && args[filterIdx + 1]) {
-            filter = args[filterIdx + 1];
-          }
-
-          const scoopIdx = args.indexOf('--scoop');
-          if (scoopIdx !== -1 && args[scoopIdx + 1]) {
-            scoop = args[scoopIdx + 1];
-          }
-
-          if (!name) {
-            return {
-              stdout: '',
-              stderr: 'crontask: --name is required\n',
-              exitCode: 1,
-            };
-          }
-
-          if (!cron) {
-            return {
-              stdout: '',
-              stderr: 'crontask: --cron is required\n',
-              exitCode: 1,
-            };
-          }
-
-          // Extension mode: use LickManager directly or proxy to offscreen
-          if (isExtension) {
-            // Warn about filter limitation in extension mode (CSP blocks dynamic eval)
-            if (filter) {
-              return {
-                stdout: '',
-                stderr: 'crontask: --filter is not supported in extension mode (CSP restriction)\n',
-                exitCode: 1,
-              };
-            }
-            const extLm = getExtensionLickManager();
-            const entry = extLm
-              ? await extLm.createCronTask(name, cron, scoop)
-              : await (await getLickProxy()).createCronTask(name, cron, scoop);
-            let output = `Created cron task "${entry.name}"\n`;
-            output += `ID:       ${entry.id}\n`;
-            output += `Cron:     ${entry.cron}\n`;
-            if (entry.scoop) output += `Scoop:    ${entry.scoop}\n`;
-            if (entry.nextRun) output += `Next run: ${new Date(entry.nextRun).toLocaleString()}\n`;
-            return { stdout: output, stderr: '', exitCode: 0 };
-          }
-
-          const { ok, data } = await apiCall('POST', '', { name, cron, filter, scoop });
-          if (!ok) {
-            return {
-              stdout: '',
-              stderr: `crontask: failed to create: ${(data as { error?: string }).error ?? 'unknown error'}\n`,
-              exitCode: 1,
-            };
-          }
-
-          const info = data as CronTaskInfo;
-          let output = `Created cron task "${info.name}"\n`;
-          output += `ID:       ${info.id}\n`;
-          output += `Cron:     ${info.cron}\n`;
-          if (info.scoop) {
-            output += `Scoop:    ${info.scoop}\n`;
-          }
-          if (info.filter) {
-            output += `Filter:   ${info.filter}\n`;
-          }
-          if (info.nextRun) {
-            output += `Next run: ${new Date(info.nextRun).toLocaleString()}\n`;
-          }
-          return {
-            stdout: output,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        case 'list': {
-          // Extension mode: use LickManager directly or proxy to offscreen
-          if (isExtension) {
-            const extLm = getExtensionLickManager();
-            const tasks = extLm
-              ? extLm.listCronTasks()
-              : await (async () => {
-                  const { listCronTasksAsync } = await import(
-                    '../../../../chrome-extension/src/lick-manager-proxy.js'
-                  );
-                  return listCronTasksAsync();
-                })();
-            if (tasks.length === 0) {
-              return { stdout: 'No active cron tasks\n', stderr: '', exitCode: 0 };
-            }
-            let output = 'Active cron tasks:\n';
-            for (const task of tasks) {
-              output += `  ${task.id}  ${task.name.padEnd(20)}  ${task.cron.padEnd(15)}`;
-              if (task.scoop) output += `  -> ${task.scoop}`;
-              if (task.filter) output += `  [filtered]`;
-              output += `  (${task.status})`;
-              if (task.nextRun) output += `  next: ${new Date(task.nextRun).toLocaleString()}`;
-              output += '\n';
-            }
-            return { stdout: output, stderr: '', exitCode: 0 };
-          }
-
-          const { ok, data } = await apiCall('GET', '');
-          if (!ok) {
-            return {
-              stdout: '',
-              stderr: `crontask: failed to list: ${(data as { error?: string }).error ?? 'unknown error'}\n`,
-              exitCode: 1,
-            };
-          }
-
-          const tasks = data as CronTaskInfo[];
-          if (tasks.length === 0) {
-            return {
-              stdout: 'No active cron tasks\n',
-              stderr: '',
-              exitCode: 0,
-            };
-          }
-
-          let output = 'Active cron tasks:\n';
-          for (const task of tasks) {
-            output += `  ${task.id}  ${task.name.padEnd(20)}  ${task.cron.padEnd(15)}`;
-            if (task.scoop) {
-              output += `  -> ${task.scoop}`;
-            }
-            if (task.filter) {
-              output += `  [filtered]`;
-            }
-            output += `  (${task.status})`;
-            if (task.nextRun) {
-              output += `  next: ${new Date(task.nextRun).toLocaleString()}`;
-            }
-            output += '\n';
-          }
-          return {
-            stdout: output,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
+        case 'create':
+          return await handleCreate(args);
+        case 'list':
+          return await handleList();
         case 'delete':
-        case 'kill': {
-          const id = args[1];
-          if (!id) {
-            return {
-              stdout: '',
-              stderr: `crontask: ${subcommand} requires an ID\n`,
-              exitCode: 1,
-            };
-          }
-
-          // Extension mode: use LickManager directly or proxy to offscreen
-          if (isExtension) {
-            const extLm = getExtensionLickManager();
-            const deleted = extLm
-              ? await extLm.deleteCronTask(id)
-              : await (await getLickProxy()).deleteCronTask(id);
-            if (!deleted) {
-              return { stdout: '', stderr: `crontask: task "${id}" not found\n`, exitCode: 1 };
-            }
-            return { stdout: `Deleted cron task "${id}"\n`, stderr: '', exitCode: 0 };
-          }
-
-          const { ok, status, data } = await apiCall('DELETE', `/${id}`);
-          if (!ok) {
-            if (status === 404) {
-              return {
-                stdout: '',
-                stderr: `crontask: task "${id}" not found\n`,
-                exitCode: 1,
-              };
-            }
-            return {
-              stdout: '',
-              stderr: `crontask: failed to delete: ${(data as { error?: string }).error ?? 'unknown error'}\n`,
-              exitCode: 1,
-            };
-          }
-
-          return {
-            stdout: `Deleted cron task "${id}"\n`,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
+        case 'kill':
+          return await handleDelete(args);
         default:
-          return {
-            stdout: '',
-            stderr: `crontask: unknown command "${subcommand}"\n`,
-            exitCode: 1,
-          };
+          return { stdout: '', stderr: `crontask: unknown command "${subcommand}"\n`, exitCode: 1 };
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      return {
-        stdout: '',
-        stderr: `crontask: ${msg}\n`,
-        exitCode: 1,
-      };
+      return { stdout: '', stderr: `crontask: ${msg}\n`, exitCode: 1 };
     }
   });
 }

--- a/packages/webapp/tests/shell/supplemental-commands/crontask-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/crontask-command.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { setLocalApiBaseUrl, setBridgeToken } from '../../../src/shell/proxied-fetch.js';
+import { setBridgeToken, setLocalApiBaseUrl } from '../../../src/shell/proxied-fetch.js';
 import { createCrontaskCommand } from '../../../src/shell/supplemental-commands/crontask-command.js';
 
 interface MockLickManager {

--- a/packages/webapp/tests/shell/supplemental-commands/crontask-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/crontask-command.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setLocalApiBaseUrl, setBridgeToken } from '../../../src/shell/proxied-fetch.js';
 import { createCrontaskCommand } from '../../../src/shell/supplemental-commands/crontask-command.js';
 
 interface MockLickManager {
@@ -688,5 +689,43 @@ describe('crontask command - Extension mode', () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Create failed');
     });
+  });
+});
+
+describe('crontask command — thin-bridge routing', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let command: ReturnType<typeof createCrontaskCommand>;
+
+  beforeEach(() => {
+    vi.stubGlobal('chrome', undefined);
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+    command = createCrontaskCommand();
+    setLocalApiBaseUrl('http://localhost:5710');
+    setBridgeToken('bridge-tok');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    setLocalApiBaseUrl(null);
+    setBridgeToken(null);
+  });
+
+  const run = (args: string[]) => {
+    return (command as any).execute(args, { cwd: '/', env: {}, fs: {} as any });
+  };
+
+  it('rewrites URL and attaches X-Bridge-Token in bridge mode', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    await run(['list']);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:5710/api/crontasks');
+    expect(init.headers['X-Bridge-Token']).toBe('bridge-tok');
   });
 });


### PR DESCRIPTION
<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary
- The crontask command used bare fetch('/api/crontasks...') which hits www.sliccy.ai instead of the local node-server in hosted-leader mode, making cron task management non-functional on cloud cones.
- Route through resolveApiUrl() + apiHeaders() to reach the local node-server via the thin bridge.
- Refactored the file to satisfy biome's complexity caps (required by the touched-file exemption gate):
- Extracted handleCreate, handleList, handleDelete as separate functions
- Extracted formatTaskList to deduplicate task rendering
- Removed the file from both biome override blocks (function-size + cognitive-complexity)

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
