### PR TITLE
fix(e2b): retry full boot+poll cycle in template smoke test

### DIFF
--- a/packages/dev-tools/e2b-template/scripts/verify-template.sh
+++ b/packages/dev-tools/e2b-template/scripts/verify-template.sh
@@ -13,19 +13,20 @@ export E2B_API_KEY="$SLICC_TEST_E2B_API_KEY"
 # instead of the live 'slicc' one. Defaults to 'slicc'.
 export SLICC_E2B_TEMPLATE_NAME="${SLICC_E2B_TEMPLATE_NAME:-slicc}"
 
-# Spin one sandbox, poll for /tmp/slicc-join.json, kill.
-#
-# `Sandbox.create` against a freshly published template occasionally exceeds the
-# e2b SDK's default 30s `requestTimeoutMs` while the build is still cold. We
-# bump the per-call timeout to 2 minutes and retry the create up to 3 times
-# with linear backoff before giving up.
+# Spin a sandbox, poll for /tmp/slicc-join.json, kill. The whole boot+poll
+# cycle is retried up to MAX_ATTEMPTS times with linear backoff: a freshly
+# published template occasionally either (a) exceeds the e2b SDK's default 30s
+# create `requestTimeoutMs` while the build is still cold, or (b) creates fine
+# but its in-sandbox startup hasn't written the join file before the poll budget
+# elapses. Both failure modes get a fresh sandbox rather than failing the run.
 #
 # The long create timeout is intentionally NOT carried over to the post-create
 # polling / kill calls: `requestTimeoutMs` set on `Sandbox.create` becomes the
 # default for every subsequent method on the returned sandbox, so a hung envd
-# read would stall up to 120s per attempt and blow past the 60s poll budget.
-# We pass a short per-call `requestTimeoutMs` to `files.read` and `kill` so
-# the poll loop's wall-clock budget is what actually bounds the script.
+# read would stall up to 120s per attempt and blow past the join-poll budget.
+# We pass a short per-call `requestTimeoutMs` to `files.read` and `kill` so the
+# poll loop's wall-clock budget (SLICC_E2B_JOIN_TIMEOUT_MS, default 120s) is
+# what actually bounds each attempt.
 node --input-type=module -e '
 import { Sandbox } from "e2b";
 
@@ -33,19 +34,26 @@ const MAX_ATTEMPTS = 3;
 const CREATE_TIMEOUT_MS = 120_000;
 const POST_CREATE_TIMEOUT_MS = 10_000;
 const BACKOFF_MS = 5_000;
+// How long to poll for the in-sandbox startup to write /tmp/slicc-join.json
+// after create returns. A cold first boot can lag well past the old hard-coded
+// 60s budget, which was the dominant smoke-test flake; override via env if a
+// future template needs longer.
+const JOIN_TIMEOUT_MS = Number(process.env.SLICC_E2B_JOIN_TIMEOUT_MS) || 120_000;
 // Boot the same alias build-template.sh published (default "slicc"), so an
 // isolated test build (SLICC_E2B_TEMPLATE_NAME=slicc-test) is what gets verified.
 const TEMPLATE_NAME = process.env.SLICC_E2B_TEMPLATE_NAME || "slicc";
 
-let sbx;
-for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let joinJson = null;
+for (let attempt = 1; attempt <= MAX_ATTEMPTS && !joinJson?.joinUrl; attempt++) {
+  let sbx;
   try {
     sbx = await Sandbox.create(TEMPLATE_NAME, {
       lifecycle: { onTimeout: "kill" },
       requestTimeoutMs: CREATE_TIMEOUT_MS,
     });
     console.log("created", sbx.sandboxId, "(attempt " + attempt + ")");
-    break;
   } catch (err) {
     const msg = err && err.message ? err.message : String(err);
     console.error("Sandbox.create attempt " + attempt + " failed: " + msg);
@@ -53,26 +61,34 @@ for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       console.error("FAIL: Sandbox.create failed after " + MAX_ATTEMPTS + " attempts");
       throw err;
     }
-    await new Promise((r) => setTimeout(r, BACKOFF_MS * attempt));
+    await sleep(BACKOFF_MS * attempt);
+    continue;
+  }
+
+  const start = Date.now();
+  while (Date.now() - start < JOIN_TIMEOUT_MS) {
+    try {
+      const text = await sbx.files.read("/tmp/slicc-join.json", {
+        requestTimeoutMs: POST_CREATE_TIMEOUT_MS,
+      });
+      const parsed = JSON.parse(text);
+      if (parsed.joinUrl) {
+        joinJson = parsed;
+        break;
+      }
+    } catch {}
+    await sleep(500);
+  }
+
+  await sbx.kill({ requestTimeoutMs: POST_CREATE_TIMEOUT_MS });
+  if (!joinJson?.joinUrl) {
+    console.error("join URL not ready within " + JOIN_TIMEOUT_MS + "ms on attempt " + attempt);
+    if (attempt < MAX_ATTEMPTS) await sleep(BACKOFF_MS * attempt);
   }
 }
 
-const start = Date.now();
-let joinJson = null;
-while (Date.now() - start < 60_000) {
-  try {
-    const text = await sbx.files.read("/tmp/slicc-join.json", {
-      requestTimeoutMs: POST_CREATE_TIMEOUT_MS,
-    });
-    joinJson = JSON.parse(text);
-    if (joinJson.joinUrl) break;
-  } catch {}
-  await new Promise((r) => setTimeout(r, 500));
-}
-
-await sbx.kill({ requestTimeoutMs: POST_CREATE_TIMEOUT_MS });
 if (!joinJson?.joinUrl) {
-  console.error("FAIL: /tmp/slicc-join.json never produced joinUrl");
+  console.error("FAIL: /tmp/slicc-join.json never produced joinUrl after " + MAX_ATTEMPTS + " attempts");
   process.exit(1);
 }
 console.log("OK", joinJson.joinUrl);

--- a/packages/dev-tools/e2b-template/scripts/verify-template.sh
+++ b/packages/dev-tools/e2b-template/scripts/verify-template.sh
@@ -80,7 +80,14 @@ for (let attempt = 1; attempt <= MAX_ATTEMPTS && !joinJson?.joinUrl; attempt++) 
     await sleep(500);
   }
 
-  await sbx.kill({ requestTimeoutMs: POST_CREATE_TIMEOUT_MS });
+  // Best-effort cleanup: a kill that rejects (E2B/API timeout or other error)
+  // must not abort the retry loop before attempts 2-3 get a fresh sandbox.
+  try {
+    await sbx.kill({ requestTimeoutMs: POST_CREATE_TIMEOUT_MS });
+  } catch (err) {
+    const msg = err && err.message ? err.message : String(err);
+    console.error("sandbox kill on attempt " + attempt + " failed (ignored): " + msg);
+  }
   if (!joinJson?.joinUrl) {
     console.error("join URL not ready within " + JOIN_TIMEOUT_MS + "ms on attempt " + attempt);
     if (attempt < MAX_ATTEMPTS) await sleep(BACKOFF_MS * attempt);


### PR DESCRIPTION
## Problem
The `Verify template boots` smoke test in `worker.yml` / `worker-staging.yml` is intermittently red (e.g. [this staging run](https://github.com/ai-ecoverse/slicc/actions/runs/28324369075/job/83921258497)). The template builds and publishes fine, but the verifier polled for `/tmp/slicc-join.json` for only a hard-coded **60s** after `Sandbox.create` returned. On a freshly published (cold) template the in-sandbox startup occasionally writes the join file later than that, so the poll budget elapsed and the step failed even though the template was healthy.

## Solution
Fold the join-poll into the existing create-retry loop so a slow/stuck boot gets a **fresh sandbox** (the same recovery a cold-create timeout already gets), instead of failing the whole run on the first sandbox's slow boot. Also raise the per-attempt poll budget from 60s to **120s**, overridable via `SLICC_E2B_JOIN_TIMEOUT_MS`. The short per-call `requestTimeoutMs` on `files.read`/`kill` is preserved so each attempt's wall-clock stays bounded by that budget.

## Testing
- `bash -n` + `node --check` on the embedded module both pass. The smoke test itself needs a live E2B key, so end-to-end coverage is the workflow runs on this PR.

## Misc
Split out of #1216 per request; unblocks rebasing that Renovate PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KW77KYXS9QP4W87RN8PRZC7M&panel=chat)