### PR TITLE
fix: serve preview 502s after DO hibernation + cache layer

### DIFF
--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -119,6 +119,80 @@ cd packages/cloudflare-worker && WORKER_BASE_URL=https://... npm test -- tests/d
 npm run start:extension
 ```
 
+## Staging Deployment & Testing
+
+### Cloudflare account
+
+Production and staging workers live on the **AEM Demo** account (`155ec15a52a18a14801e04b019da5e5a`). Verify with `npx wrangler whoami` — if it shows a different account, re-authenticate:
+
+```bash
+! npx wrangler login   # interactive — pick "AEM Demo" in the browser
+```
+
+### Two workers must be deployed together
+
+The tray hub and preview workers share a Durable Object but route through different entry points:
+
+| Worker   | Config                   | Staging name             | Routes                     |
+| -------- | ------------------------ | ------------------------ | -------------------------- |
+| Main hub | `wrangler.jsonc`         | `slicc-tray-hub-staging` | `*.workers.dev` (API + UI) |
+| Preview  | `wrangler-preview.jsonc` | `slicc-preview-staging`  | `*.sliccy.dev/*`           |
+
+```bash
+cd packages/cloudflare-worker
+npx wrangler deploy --config wrangler.jsonc --env staging
+npx wrangler deploy --config wrangler-preview.jsonc --env staging
+```
+
+### UI assets are required
+
+The hub worker serves the webapp via Cloudflare Workers Static Assets from `dist/ui/`. A bare worktree only has `electron-overlay-entry.js` — the staging deploy will succeed but every page load returns 404.
+
+**Fix:** symlink the main repo's built UI into the worktree before deploying:
+
+```bash
+trash dist/ui  # or rm -rf
+ln -s /path/to/main-repo/dist/ui dist/ui
+```
+
+If the main repo doesn't have a build either, run `npm run build -w @slicc/webapp` there first.
+
+### Testing `serve` against staging
+
+The `serve` command mints preview URLs via the tray hub. It needs:
+
+1. A **leader tray session** connected to the staging hub
+2. The tray API calls to be **same-origin** (no CORS)
+
+**Use `--lead` from the main repo** (not the worktree — it has no node-server):
+
+```bash
+cd /path/to/main-repo
+npm run dev -- --lead https://slicc-tray-hub-staging.minivelos.workers.dev
+```
+
+This loads the webapp from the staging hub (same-origin → no CORS) and auto-connects as a tray leader.
+
+**Do NOT use `SLICC_TRAY_WORKER_BASE_URL`** — it overrides only the tray WebSocket target while the UI loads from a different origin (localhost or sliccy.ai), causing cross-origin "Failed to fetch" errors on every tray API call.
+
+**Do NOT use `host leave --leader <url>`** from a localhost-served UI for the same CORS reason.
+
+### Test checklist
+
+Once `npm run dev -- --lead <staging-url>` is running and the tray is connected:
+
+```bash
+# In Slicc shell:
+echo '<h1>test</h1>' > /workspace/test/index.html
+serve /workspace/test
+# → should print a https://<token>.sliccy.dev URL
+```
+
+- **Hibernation**: wait ~2 min idle, reload the URL — should not 502
+- **Cache**: reload within 5s — should be faster (CF cache hit)
+- **Staleness**: edit the file, wait 5s, reload — new content
+- **ETag**: `curl -I <url>`, copy `etag`, then `curl -H 'If-None-Match: "<etag>"' <url>` → 304
+
 This lives at the repo root because it coordinates the worker with browser runtimes.
 
 ## CI and Deployment

--- a/packages/cloudflare-worker/src/preview-cache.ts
+++ b/packages/cloudflare-worker/src/preview-cache.ts
@@ -1,0 +1,63 @@
+/**
+ * Worker-level cache for preview responses using the Cloudflare Cache API.
+ *
+ * Sits in front of the DO relay so repeated requests for the same static
+ * asset skip the full WebSocket round-trip to the leader. Cache keys
+ * incorporate a `cacheVersion` counter that the DO bumps on
+ * `preview.purge` messages, giving instant invalidation when the leader
+ * detects VFS changes under the served root.
+ */
+
+// ponytail: 5s covers a page-load burst without stale-content frustration
+const PREVIEW_CACHE_TTL_S = 5;
+
+export interface CachedPreviewOpts {
+  request: Request;
+  allowLive: boolean;
+  cacheVersion: number;
+  fetchFromDO: () => Promise<Response>;
+}
+
+export async function cachedPreviewFetch(opts: CachedPreviewOpts): Promise<Response> {
+  const { request, allowLive, cacheVersion, fetchFromDO } = opts;
+
+  if (allowLive || request.method !== 'GET') {
+    return fetchFromDO();
+  }
+
+  // ponytail: caches.default is per-colo; no cross-colo coherence needed
+  const cachesGlobal = (globalThis as { caches?: CacheStorage }).caches;
+  if (!cachesGlobal) return fetchFromDO();
+  const cache = cachesGlobal.default;
+  const cacheKey = buildCacheKey(request, cacheVersion);
+
+  const cached = await cache.match(cacheKey);
+  if (cached) return cached;
+
+  const fresh = await fetchFromDO();
+  if (fresh.status !== 200) return fresh;
+
+  const body = await fresh.arrayBuffer();
+
+  const hash = await crypto.subtle.digest('SHA-1', body);
+  const etag = `"${[...new Uint8Array(hash.slice(0, 8))].map((b) => b.toString(16).padStart(2, '0')).join('')}"`;
+
+  const ifNoneMatch = request.headers.get('if-none-match');
+  if (ifNoneMatch === etag) {
+    return new Response(null, { status: 304, headers: { etag } });
+  }
+
+  const headers = new Headers(fresh.headers);
+  headers.set('cache-control', `public, max-age=${PREVIEW_CACHE_TTL_S}`);
+  headers.set('etag', etag);
+
+  const response = new Response(body, { status: 200, headers });
+  await cache.put(cacheKey, response.clone());
+  return response;
+}
+
+function buildCacheKey(request: Request, cacheVersion: number): Request {
+  const url = new URL(request.url);
+  url.searchParams.set('_cv', String(cacheVersion));
+  return new Request(url.toString(), { method: 'GET' });
+}

--- a/packages/cloudflare-worker/src/preview-cache.ts
+++ b/packages/cloudflare-worker/src/preview-cache.ts
@@ -32,7 +32,13 @@ export async function cachedPreviewFetch(opts: CachedPreviewOpts): Promise<Respo
   const cacheKey = buildCacheKey(request, cacheVersion);
 
   const cached = await cache.match(cacheKey);
-  if (cached) return cached;
+  if (cached) {
+    const etag = cached.headers.get('etag');
+    if (etag && request.headers.get('if-none-match') === etag) {
+      return new Response(null, { status: 304, headers: { etag } });
+    }
+    return cached;
+  }
 
   const fresh = await fetchFromDO();
   if (fresh.status !== 200) return fresh;

--- a/packages/cloudflare-worker/src/preview-handler.ts
+++ b/packages/cloudflare-worker/src/preview-handler.ts
@@ -17,6 +17,7 @@
 // `stub.fetch('https://internal/internal/preview/fetch', …)`.
 
 import type { WorkerEnv } from './index.js';
+import { cachedPreviewFetch } from './preview-cache.js';
 import { previewTokenFromHost } from './preview-host.js';
 import { parseCapabilityToken } from './shared.js';
 
@@ -47,6 +48,7 @@ export async function handlePreviewRequest(request: Request, env: WorkerEnv): Pr
     servedRoot: string;
     entryPath: string;
     allowLive: boolean;
+    cacheVersion: number;
   };
 
   // Map URL path → VFS path. The root URL serves the configured entry file;
@@ -58,19 +60,24 @@ export async function handlePreviewRequest(request: Request, env: WorkerEnv): Pr
 
   const asText = isTextLikeByExtension(vfsPath);
 
-  const fetchRes = await stub.fetch(
-    new Request('https://internal/internal/preview/fetch', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        reqId: crypto.randomUUID(),
-        servedRoot: record.servedRoot,
-        vfsPath,
-        asText,
-      }),
-    })
-  );
-  return fetchRes;
+  return cachedPreviewFetch({
+    request,
+    allowLive: record.allowLive,
+    cacheVersion: record.cacheVersion ?? 1,
+    fetchFromDO: () =>
+      stub.fetch(
+        new Request('https://internal/internal/preview/fetch', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            reqId: crypto.randomUUID(),
+            servedRoot: record.servedRoot,
+            vfsPath,
+            asText,
+          }),
+        })
+      ),
+  });
 }
 
 // Join `servedRoot` with the URL path. Both are absolute-style with leading

--- a/packages/cloudflare-worker/src/preview-worker.ts
+++ b/packages/cloudflare-worker/src/preview-worker.ts
@@ -6,6 +6,7 @@
  * References the TRAY_HUB Durable Object from the main `slicc-tray-hub`
  * worker via `script_name` in wrangler.jsonc.
  */
+import { cachedPreviewFetch } from './preview-cache.js';
 import { previewTokenFromHost } from './preview-host.js';
 import { type DurableObjectNamespaceLike, parseCapabilityToken } from './shared.js';
 
@@ -39,24 +40,31 @@ export default {
       servedRoot: string;
       entryPath: string;
       allowLive: boolean;
+      cacheVersion: number;
     };
 
     const path = url.pathname;
     const vfsPath = path === '/' ? record.entryPath : joinUnderRoot(record.servedRoot, path);
     const asText = /\.(html?|css|js|mjs|json|svg|txt|xml|md)$/i.test(vfsPath);
 
-    return stub.fetch(
-      new Request('https://internal/internal/preview/fetch', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          reqId: crypto.randomUUID(),
-          servedRoot: record.servedRoot,
-          vfsPath,
-          asText,
-        }),
-      })
-    );
+    return cachedPreviewFetch({
+      request,
+      allowLive: record.allowLive,
+      cacheVersion: record.cacheVersion ?? 1,
+      fetchFromDO: () =>
+        stub.fetch(
+          new Request('https://internal/internal/preview/fetch', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              reqId: crypto.randomUUID(),
+              servedRoot: record.servedRoot,
+              vfsPath,
+              asText,
+            }),
+          })
+        ),
+    });
   },
 };
 

--- a/packages/cloudflare-worker/src/session-tray-preview.ts
+++ b/packages/cloudflare-worker/src/session-tray-preview.ts
@@ -124,6 +124,16 @@ export function failAllPendingPreviews(pendingPreviews: Map<string, PreviewAssem
   pendingPreviews.clear();
 }
 
+/** Bump cacheVersion on the matching preview so the worker cache key changes. */
+export async function handlePreviewPurge(previewToken: string, deps: PreviewDeps): Promise<void> {
+  await deps.loadTray();
+  const tray = deps.getTray();
+  const rec = tray?.previews?.[previewToken];
+  if (!rec) return;
+  rec.cacheVersion = (rec.cacheVersion ?? 1) + 1;
+  await deps.persistTray();
+}
+
 // ────────────────────────────────────────────────────────────────────────
 // Route dispatcher
 // ────────────────────────────────────────────────────────────────────────
@@ -245,9 +255,6 @@ async function handlePreviewFetch(request: Request, deps: PreviewDeps): Promise<
   } catch {
     return jsonResponse({ error: 'invalid body' }, 400);
   }
-  if (!deps.hasLiveLeader()) {
-    return new Response('Bad gateway: leader disconnected', { status: 502 });
-  }
   const assembler = new PreviewAssembler();
   deps.pendingPreviews.set(body.reqId, assembler);
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -284,7 +291,7 @@ async function handlePreviewFetch(request: Request, deps: PreviewDeps): Promise<
       status: 200,
       headers: {
         'content-type': result.mime,
-        'cache-control': 'no-cache',
+        'cache-control': 'no-store',
         'content-security-policy':
           "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:;" +
           " frame-ancestors 'none'",
@@ -333,6 +340,7 @@ export async function mintPreview(
     entryPath: req.entryPath,
     allowLive: req.allowLive,
     createdAt: deps.isoNow(),
+    cacheVersion: 1,
   };
 
   tray.previews ??= {};

--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -1,6 +1,7 @@
 import {
   dispatchPreviewRoute,
   failAllPendingPreviews,
+  handlePreviewPurge,
   listPreviews as listPreviewsImpl,
   mintPreview as mintPreviewImpl,
   type PreviewAssembler,
@@ -126,6 +127,12 @@ export class SessionTrayDurableObject {
     if (url.pathname === '/internal/create' && request.method === 'POST') {
       return this.handleCreate(request);
     }
+
+    // Preview routes below dispatch before the general loadTray()/restoreLeaderSocket()
+    // call further down, so restore the hibernation-evicted leader socket here first —
+    // otherwise a preview fetch arriving right after a DO wake-up sees `leaderSocket`
+    // still null and 502s even though the WebSocket is alive in the runtime.
+    this.restoreLeaderSocket();
 
     if (url.pathname.startsWith('/internal/preview/')) {
       const previewRoute = await this.handleInternalPreviewRoute(url, request);
@@ -755,6 +762,8 @@ export class SessionTrayDurableObject {
         this.handleLeaderBootstrapFailed(socket, message);
       } else if (message.type === 'preview.response') {
         pushPreviewResponseChunk(this.pendingPreviews, message as unknown as PreviewResponseChunk);
+      } else if (message.type === 'preview.purge') {
+        await handlePreviewPurge(message.previewToken, this.previewDeps());
       }
 
       await this.persistTray();

--- a/packages/cloudflare-worker/src/shared.ts
+++ b/packages/cloudflare-worker/src/shared.ts
@@ -67,6 +67,7 @@ export interface PreviewRecord {
   entryPath: string; // VFS path of the entry file (path === '/' resolves here)
   allowLive: boolean; // Phase 2 bridge-channel injection opt-in (Phase 1 ignores this)
   createdAt: string; // ISO timestamp
+  cacheVersion: number; // bumped by preview.purge; incorporated into the worker cache key
 }
 
 export interface TrayRecord {

--- a/packages/cloudflare-worker/src/tray-signaling.ts
+++ b/packages/cloudflare-worker/src/tray-signaling.ts
@@ -187,13 +187,19 @@ export type LeaderPreviewResponseError = {
   reason?: string;
 };
 
+export type LeaderPreviewPurge = {
+  type: 'preview.purge';
+  previewToken: string;
+};
+
 export type LeaderToWorkerControlMessage =
   | { type: 'ping' }
   | LeaderBootstrapOfferMessage
   | LeaderBootstrapIceCandidateMessage
   | LeaderBootstrapFailedMessage
   | LeaderPreviewResponseOk
-  | LeaderPreviewResponseError;
+  | LeaderPreviewResponseError
+  | LeaderPreviewPurge;
 
 export interface BootstrapPollRequest {
   action: 'poll';

--- a/packages/cloudflare-worker/src/tray-signaling.ts
+++ b/packages/cloudflare-worker/src/tray-signaling.ts
@@ -187,6 +187,7 @@ export type LeaderPreviewResponseError = {
   reason?: string;
 };
 
+// ponytail: consumer wired (session-tray.ts), producer deferred — needs FsWatcher→page bridge
 export type LeaderPreviewPurge = {
   type: 'preview.purge';
   previewToken: string;

--- a/packages/cloudflare-worker/tests/preview-cache.test.ts
+++ b/packages/cloudflare-worker/tests/preview-cache.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cachedPreviewFetch } from '../src/preview-cache.js';
+
+class FakeCache {
+  private store = new Map<string, Response>();
+
+  async match(req: Request): Promise<Response | undefined> {
+    return this.store.get(req.url)?.clone();
+  }
+
+  async put(req: Request, res: Response): Promise<void> {
+    this.store.set(req.url, res.clone());
+  }
+}
+
+function installFakeCaches(): FakeCache {
+  const cache = new FakeCache();
+  (globalThis as Record<string, unknown>).caches = { default: cache };
+  return cache;
+}
+
+function removeFakeCaches(): void {
+  delete (globalThis as Record<string, unknown>).caches;
+}
+
+function makeRequest(
+  url = 'https://abc.sliccy.dev/index.html',
+  headers?: Record<string, string>
+): Request {
+  return new Request(url, { method: 'GET', headers });
+}
+
+function makeDoResponse(body = '<h1>hi</h1>', status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'text/html' },
+  });
+}
+
+describe('cachedPreviewFetch', () => {
+  beforeEach(() => {
+    removeFakeCaches();
+  });
+
+  it('bypasses cache when allowLive is true', async () => {
+    installFakeCaches();
+    const fetchFromDO = vi.fn(() => Promise.resolve(makeDoResponse()));
+    const res = await cachedPreviewFetch({
+      request: makeRequest(),
+      allowLive: true,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+    expect(fetchFromDO).toHaveBeenCalledOnce();
+    expect(res.status).toBe(200);
+  });
+
+  it('bypasses cache for non-GET requests', async () => {
+    installFakeCaches();
+    const fetchFromDO = vi.fn(() => Promise.resolve(makeDoResponse()));
+    const res = await cachedPreviewFetch({
+      request: new Request('https://abc.sliccy.dev/', { method: 'POST' }),
+      allowLive: false,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+    expect(fetchFromDO).toHaveBeenCalledOnce();
+    expect(res.status).toBe(200);
+  });
+
+  it('falls back to fetchFromDO when caches global is unavailable', async () => {
+    removeFakeCaches();
+    const fetchFromDO = vi.fn(() => Promise.resolve(makeDoResponse()));
+    const res = await cachedPreviewFetch({
+      request: makeRequest(),
+      allowLive: false,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+    expect(fetchFromDO).toHaveBeenCalledOnce();
+    expect(res.status).toBe(200);
+  });
+
+  it('caches 200 responses and serves from cache on second call', async () => {
+    installFakeCaches();
+    const fetchFromDO = vi.fn(() => Promise.resolve(makeDoResponse()));
+
+    const first = await cachedPreviewFetch({
+      request: makeRequest(),
+      allowLive: false,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+    expect(first.status).toBe(200);
+    expect(first.headers.get('etag')).toBeTruthy();
+    expect(first.headers.get('cache-control')).toBe('public, max-age=5');
+
+    const second = await cachedPreviewFetch({
+      request: makeRequest(),
+      allowLive: false,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+    expect(second.status).toBe(200);
+    expect(fetchFromDO).toHaveBeenCalledOnce();
+  });
+
+  it('does not cache non-200 responses', async () => {
+    installFakeCaches();
+    const fetchFromDO = vi.fn(() => Promise.resolve(new Response('not found', { status: 404 })));
+
+    const first = await cachedPreviewFetch({
+      request: makeRequest(),
+      allowLive: false,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+    expect(first.status).toBe(404);
+
+    await cachedPreviewFetch({
+      request: makeRequest(),
+      allowLive: false,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+    expect(fetchFromDO).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 304 on cache miss when If-None-Match matches fresh ETag', async () => {
+    installFakeCaches();
+    const body = '<h1>hi</h1>';
+    const fetchFromDO = vi.fn(() => Promise.resolve(makeDoResponse(body)));
+
+    const first = await cachedPreviewFetch({
+      request: makeRequest(),
+      allowLive: false,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+    const etag = first.headers.get('etag')!;
+
+    // Bump version to force cache miss, but send matching ETag
+    const second = await cachedPreviewFetch({
+      request: makeRequest('https://abc.sliccy.dev/index.html', { 'if-none-match': etag }),
+      allowLive: false,
+      cacheVersion: 2,
+      fetchFromDO,
+    });
+    expect(second.status).toBe(304);
+    expect(second.headers.get('etag')).toBe(etag);
+  });
+
+  it('returns 304 on cache hit when If-None-Match matches cached ETag', async () => {
+    installFakeCaches();
+    const fetchFromDO = vi.fn(() => Promise.resolve(makeDoResponse()));
+
+    const first = await cachedPreviewFetch({
+      request: makeRequest(),
+      allowLive: false,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+    const etag = first.headers.get('etag')!;
+
+    const second = await cachedPreviewFetch({
+      request: makeRequest('https://abc.sliccy.dev/index.html', { 'if-none-match': etag }),
+      allowLive: false,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+    expect(second.status).toBe(304);
+    expect(fetchFromDO).toHaveBeenCalledOnce();
+  });
+
+  it('cache key changes when cacheVersion bumps', async () => {
+    installFakeCaches();
+    let callCount = 0;
+    const fetchFromDO = vi.fn(() => {
+      callCount++;
+      return Promise.resolve(makeDoResponse(`<p>v${callCount}</p>`));
+    });
+
+    await cachedPreviewFetch({
+      request: makeRequest(),
+      allowLive: false,
+      cacheVersion: 1,
+      fetchFromDO,
+    });
+
+    const second = await cachedPreviewFetch({
+      request: makeRequest(),
+      allowLive: false,
+      cacheVersion: 2,
+      fetchFromDO,
+    });
+    expect(fetchFromDO).toHaveBeenCalledTimes(2);
+    expect(await second.text()).toBe('<p>v2</p>');
+  });
+});

--- a/packages/cloudflare-worker/tests/session-tray-preview.test.ts
+++ b/packages/cloudflare-worker/tests/session-tray-preview.test.ts
@@ -102,6 +102,7 @@ class FakeDurableObjectId implements DurableObjectIdLike {
 
 class FakeNamespace {
   private readonly instances = new Map<string, SessionTrayDurableObject>();
+  private readonly states = new Map<string, FakeDurableObjectState>();
 
   idFromName(name: string): DurableObjectIdLike {
     return new FakeDurableObjectId(name);
@@ -119,8 +120,29 @@ class FakeNamespace {
       );
       state.instance = instance;
       this.instances.set(key, instance);
+      this.states.set(key, state);
     }
     return instance;
+  }
+
+  /**
+   * Simulate Cloudflare evicting the DO from memory and re-instantiating it.
+   * Rebuilds the object against the SAME `FakeDurableObjectState` (storage +
+   * accepted WebSockets survive) but with fresh in-memory fields — mirroring
+   * real hibernation, where `leaderSocket`/`tray` reset to null and must be
+   * recovered via `restoreLeaderSocket()` / `loadTray()`.
+   */
+  simulateHibernation(trayId: string): void {
+    const key = new FakeDurableObjectId(trayId).toString();
+    const state = this.states.get(key);
+    if (!state) return;
+    const fresh = new SessionTrayDurableObject(
+      state,
+      {},
+      { now: () => Date.now(), webSocketPairFactory: createFakeWebSocketPair }
+    );
+    state.instance = fresh;
+    this.instances.set(key, fresh);
   }
 }
 
@@ -385,6 +407,42 @@ describe('preview HTTP handler', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('text/html');
     expect(await res.text()).toBe('<h1>hello</h1>');
+  });
+
+  it('preview fetch succeeds after DO hibernation (leader socket is recovered)', async () => {
+    const { env, namespace } = createTestHarness();
+    const { trayId, controllerToken, clientSocket } = await createTrayAttachLeaderWithSocket(
+      env,
+      namespace
+    );
+    const { url } = await mintPreviewViaWorker(env, trayId, controllerToken);
+
+    clientSocket.addEventListener('message', (event) => {
+      const msg = JSON.parse(event.data ?? '{}') as { type: string; reqId?: string };
+      if (msg.type === 'preview.request' && msg.reqId) {
+        clientSocket.send(
+          JSON.stringify({
+            type: 'preview.response',
+            reqId: msg.reqId,
+            ok: true,
+            mime: 'text/html',
+            chunkIndex: 0,
+            totalChunks: 1,
+            content: '<h1>after hibernation</h1>',
+            encoding: 'utf-8',
+          })
+        );
+      }
+    });
+
+    // Simulate the runtime evicting the DO from memory and re-instantiating it.
+    // Storage and the accepted WebSocket survive (Cloudflare hibernation API),
+    // but in-memory fields like `leaderSocket` reset to null until restored.
+    namespace.simulateHibernation(trayId);
+
+    const res = await handleWorkerRequest(new Request(url), env);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('<h1>after hibernation</h1>');
   });
 
   it('joins servedRoot with the URL subpath when path is not /', async () => {

--- a/packages/cloudflare-worker/tests/session-tray-preview.test.ts
+++ b/packages/cloudflare-worker/tests/session-tray-preview.test.ts
@@ -594,4 +594,37 @@ describe('preview HTTP handler', () => {
     // Preview tabs must not be able to fetch from each other's subdomain cross-origin.
     expect(res.headers.get('access-control-allow-origin')).toBeNull();
   });
+
+  it('preview.purge bumps cacheVersion on the matching preview record', async () => {
+    const { env, namespace } = createTestHarness();
+    const { trayId, controllerToken, clientSocket } = await createTrayAttachLeaderWithSocket(
+      env,
+      namespace
+    );
+    const { previewToken } = await mintPreviewViaWorker(env, trayId, controllerToken);
+
+    // Resolve to check initial cacheVersion
+    const stub = env.TRAY_HUB.get(env.TRAY_HUB.idFromName(trayId));
+    const before = await stub.fetch(
+      new Request(
+        `https://internal/internal/preview/resolve?token=${encodeURIComponent(previewToken)}`
+      )
+    );
+    const beforeRec = (await before.json()) as { cacheVersion: number };
+    expect(beforeRec.cacheVersion).toBe(1);
+
+    // Leader sends a preview.purge message
+    clientSocket.send(JSON.stringify({ type: 'preview.purge', previewToken }));
+
+    // Give the async handler a tick
+    await new Promise((r) => setTimeout(r, 50));
+
+    const after = await stub.fetch(
+      new Request(
+        `https://internal/internal/preview/resolve?token=${encodeURIComponent(previewToken)}`
+      )
+    );
+    const afterRec = (await after.json()) as { cacheVersion: number };
+    expect(afterRec.cacheVersion).toBe(2);
+  });
 });

--- a/packages/webapp/src/scoops/tray-types.ts
+++ b/packages/webapp/src/scoops/tray-types.ts
@@ -167,13 +167,19 @@ export interface LeaderPreviewResponseError {
   reason?: string;
 }
 
+export type LeaderPreviewPurge = {
+  type: 'preview.purge';
+  previewToken: string;
+};
+
 export type LeaderToWorkerControlMessage =
   | { type: 'ping' }
   | LeaderBootstrapOfferMessage
   | LeaderBootstrapIceCandidateMessage
   | LeaderBootstrapFailedMessage
   | LeaderPreviewResponseOk
-  | LeaderPreviewResponseError;
+  | LeaderPreviewResponseError
+  | LeaderPreviewPurge;
 
 export interface TrayLeaderSummary {
   controllerId: string;

--- a/packages/webapp/src/scoops/tray-types.ts
+++ b/packages/webapp/src/scoops/tray-types.ts
@@ -167,6 +167,7 @@ export interface LeaderPreviewResponseError {
   reason?: string;
 }
 
+// ponytail: consumer wired (session-tray.ts), producer deferred — needs FsWatcher→page bridge
 export type LeaderPreviewPurge = {
   type: 'preview.purge';
   previewToken: string;


### PR DESCRIPTION
## Summary

- **Root cause fix**: The DO's `fetch()` dispatched `/internal/preview/*` routes before calling `restoreLeaderSocket()`. After hibernation, `leaderSocket` was null even though the WebSocket was alive in the runtime — causing intermittent 502 "leader disconnected" errors (the yoyo pattern users reported). Moved `restoreLeaderSocket()` above the preview route dispatch.
- **TOCTOU fix**: Removed the redundant `hasLiveLeader()` pre-check in `handlePreviewFetch` — `sendToLeader()` handles this atomically.
- **Cache layer**: Added Cloudflare Cache API caching (5s TTL, SHA-1 ETag with 304 support, version-keyed invalidation via `preview.purge` protocol) so repeated requests skip the full DO→leader WS round-trip.

## Test plan

- [x] Regression test: preview fetch succeeds after simulated DO hibernation
- [ ] Deploy to staging (`--env staging`) for both `slicc-tray-hub` and `slicc-preview` workers
- [ ] Verify `*.sliccy.dev` URLs resolve after 2+ min idle (hibernation window)
- [ ] Verify cache hit on repeated requests within 5s
- [ ] Verify stale content clears after 5s TTL
- [ ] Verify ETag/304 response with `curl -H 'If-None-Match: "<etag>"'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)