### PR TITLE
fix(node-server): close launched browser reliably on dev shutdown

### DIFF
--- a/packages/node-server/CLAUDE.md
+++ b/packages/node-server/CLAUDE.md
@@ -68,6 +68,7 @@ Each instance gets its own browser profile and CDP port.
 ## Main Files
 
 - `src/index.ts` — entry point, server boot, Chrome/Electron launch, CDP WebSocket proxy
+- `src/browser-shutdown.ts` — graceful close of the launched browser on server shutdown; confirms via CDP polling rather than the launcher process's exit event, since on macOS Chrome is launched through `/usr/bin/open` (see `planChromeSpawn`), so the process handle is `open`, not Chrome itself
 - `src/chrome-launch.ts` — Chrome executable/profile/launch argument handling
 - `src/electron-controller.ts` — Electron app attach and overlay management
 - `src/qa-setup.ts` — isolated QA profile scaffolding

--- a/packages/node-server/src/browser-shutdown.ts
+++ b/packages/node-server/src/browser-shutdown.ts
@@ -1,0 +1,52 @@
+import type { ChildProcess } from 'node:child_process';
+import WebSocket from 'ws';
+
+import { probeCdpAlive } from './chrome-launch.js';
+
+export interface LaunchedBrowserHandle {
+  launchedBrowserProcess: ChildProcess | null;
+  launchedBrowserLabel: string;
+}
+
+/** Best-effort graceful close of the launched browser, escalating to SIGKILL. */
+export async function closeLaunchedBrowserGracefully(
+  state: LaunchedBrowserHandle,
+  cdpPort: number
+): Promise<void> {
+  const browser = state.launchedBrowserProcess;
+  if (!browser) return;
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${cdpPort}/json/version`);
+    const json = (await res.json()) as { webSocketDebuggerUrl: string };
+    const browserWs = new WebSocket(json.webSocketDebuggerUrl);
+    await new Promise<void>((resolve, reject) => {
+      browserWs.on('open', () => {
+        browserWs.send(JSON.stringify({ id: 1, method: 'Browser.close' }));
+        resolve();
+      });
+      browserWs.on('error', reject);
+    });
+  } catch {
+    // CDP not available — the launched browser may still be starting up; fall through to kill.
+  }
+
+  // On macOS Chrome is launched via `open` (see planChromeSpawn), so `browser` is the
+  // launcher process, not Chrome itself — its exit doesn't mean Chrome exited, and it
+  // dies immediately on SIGINT regardless of Chrome's state. Poll the CDP endpoint
+  // itself to confirm the browser actually shut down before declaring success.
+  const deadline = Date.now() + 3000;
+  let reachable = await probeCdpAlive(cdpPort);
+  while (reachable && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 100));
+    reachable = await probeCdpAlive(cdpPort);
+  }
+  if (reachable) {
+    try {
+      browser.kill('SIGKILL');
+    } catch {
+      /* ignore */
+    }
+  }
+  console.log(`${state.launchedBrowserLabel} closed`);
+}

--- a/packages/node-server/src/browser-shutdown.ts
+++ b/packages/node-server/src/browser-shutdown.ts
@@ -17,18 +17,26 @@ export async function closeLaunchedBrowserGracefully(
   if (!browser) return;
 
   try {
-    const res = await fetch(`http://127.0.0.1:${cdpPort}/json/version`);
+    const res = await fetch(`http://127.0.0.1:${cdpPort}/json/version`, {
+      signal: AbortSignal.timeout(500),
+    });
     const json = (await res.json()) as { webSocketDebuggerUrl: string };
     const browserWs = new WebSocket(json.webSocketDebuggerUrl);
     await new Promise<void>((resolve, reject) => {
       browserWs.on('open', () => {
-        browserWs.send(JSON.stringify({ id: 1, method: 'Browser.close' }));
-        resolve();
+        try {
+          browserWs.send(JSON.stringify({ id: 1, method: 'Browser.close' }));
+          browserWs.close();
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
       });
       browserWs.on('error', reject);
     });
   } catch {
-    // CDP not available — the launched browser may still be starting up; fall through to kill.
+    // CDP not available, or the send/response was too slow — the launched browser
+    // may still be starting up; fall through to the reachability poll below.
   }
 
   // On macOS Chrome is launched via `open` (see planChromeSpawn), so `browser` is the
@@ -42,6 +50,10 @@ export async function closeLaunchedBrowserGracefully(
     reachable = await probeCdpAlive(cdpPort);
   }
   if (reachable) {
+    // On macOS `browser` is the `open` launcher (already exited, see above), so this
+    // SIGKILL only helps on Linux/Windows where `browser` is Chrome itself. A hung
+    // Chrome that ignores Browser.close will leak past the deadline on macOS; fixing
+    // that needs finding the real Chrome pid (e.g. by unique --user-data-dir).
     try {
       browser.kill('SIGKILL');
     } catch {

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -21,6 +21,7 @@ import {
   validateBridgeToken,
   validateBridgeUpgrade,
 } from './bridge-security.js';
+import { closeLaunchedBrowserGracefully } from './browser-shutdown.js';
 import { applyCdpUnmask } from './cdp-proxy/cdp-unmask.js';
 import { createCdpSessionUrlTracker } from './cdp-proxy/session-url-tracker.js';
 import {
@@ -914,45 +915,6 @@ async function handleCdpClient(
     console.error('[cdp-proxy] Connection error:', err);
     clientWs.close();
   }
-}
-
-/** Best-effort graceful close of the launched browser, escalating to SIGKILL. */
-async function closeLaunchedBrowserGracefully(state: ServerState, cdpPort: number): Promise<void> {
-  const browser = state.launchedBrowserProcess;
-  if (!browser) return;
-
-  let browserExited = false;
-  browser.on('exit', () => {
-    browserExited = true;
-  });
-
-  try {
-    const res = await fetch(`http://127.0.0.1:${cdpPort}/json/version`);
-    const json = (await res.json()) as { webSocketDebuggerUrl: string };
-    const browserWs = new WebSocket(json.webSocketDebuggerUrl);
-    await new Promise<void>((resolve, reject) => {
-      browserWs.on('open', () => {
-        browserWs.send(JSON.stringify({ id: 1, method: 'Browser.close' }));
-        resolve();
-      });
-      browserWs.on('error', reject);
-    });
-  } catch {
-    // CDP not available — the launched browser may still be starting up; fall through to kill.
-  }
-
-  const deadline = Date.now() + 3000;
-  while (!browserExited && Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, 100));
-  }
-  if (!browserExited) {
-    try {
-      browser.kill('SIGKILL');
-    } catch {
-      /* ignore */
-    }
-  }
-  console.log(`${state.launchedBrowserLabel} closed`);
 }
 
 interface ShutdownDeps {

--- a/packages/node-server/tests/browser-shutdown.test.ts
+++ b/packages/node-server/tests/browser-shutdown.test.ts
@@ -1,0 +1,70 @@
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/chrome-launch.js', () => ({
+  probeCdpAlive: vi.fn(),
+}));
+
+import { closeLaunchedBrowserGracefully } from '../src/browser-shutdown.js';
+import { probeCdpAlive } from '../src/chrome-launch.js';
+
+function fakeLauncherProcess(): ChildProcess {
+  return Object.assign(new EventEmitter(), { kill: vi.fn() }) as unknown as ChildProcess;
+}
+
+describe('closeLaunchedBrowserGracefully', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // No CDP endpoint to send Browser.close to in these tests — exercises the
+    // fallback path so behavior hinges entirely on the reachability polling below.
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no CDP')));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.mocked(probeCdpAlive).mockReset();
+  });
+
+  it('does not treat the macOS `open` launcher exiting as the browser having closed', async () => {
+    // Regression: on macOS Chrome is launched via `open -W`, which dies immediately on
+    // SIGINT independent of whether Chrome itself has closed. Killing/exiting the
+    // launcher must not short-circuit the CDP-based confirmation.
+    const browser = fakeLauncherProcess();
+    vi.mocked(probeCdpAlive).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const promise = closeLaunchedBrowserGracefully(
+      { launchedBrowserProcess: browser, launchedBrowserLabel: 'Chrome' },
+      12345
+    );
+    browser.emit('exit', null, 'SIGINT');
+    await vi.advanceTimersByTimeAsync(100);
+    await promise;
+
+    expect(probeCdpAlive).toHaveBeenCalledWith(12345);
+    expect(browser.kill).not.toHaveBeenCalled();
+  });
+
+  it('kills the launcher if the CDP endpoint is still reachable past the deadline', async () => {
+    const browser = fakeLauncherProcess();
+    vi.mocked(probeCdpAlive).mockResolvedValue(true);
+
+    const promise = closeLaunchedBrowserGracefully(
+      { launchedBrowserProcess: browser, launchedBrowserLabel: 'Chrome' },
+      12345
+    );
+    await vi.advanceTimersByTimeAsync(3100);
+    await promise;
+
+    expect(browser.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('does nothing when no browser was launched', async () => {
+    await closeLaunchedBrowserGracefully(
+      { launchedBrowserProcess: null, launchedBrowserLabel: 'Chrome' },
+      12345
+    );
+    expect(probeCdpAlive).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- On macOS Chrome is launched via `/usr/bin/open` so LaunchServices owns the actual Chrome process, not node-server — the process handle we hold is the `open` launcher, which exits immediately on SIGINT regardless of Chrome's state.
- Shutdown previously used that launcher's `exit` event to decide the browser had closed, so it would declare success and let the whole node process exit before Chrome ever finished handling `Browser.close`, leaving Chrome running after `npm run dev` was stopped.
- Replaced that check with polling the browser's CDP endpoint (`probeCdpAlive`, from `chrome-launch.ts`) until it stops responding, confirming Chrome itself has shut down before returning.
- Extracted `closeLaunchedBrowserGracefully` into `packages/node-server/src/browser-shutdown.ts` since `index.ts` runs `main()` unconditionally at import and can't be unit tested directly.

## Test plan
- [x] Reproduced the bug against a real `npm run dev` + SIGINT: Chrome process stayed alive after the shutdown log claimed "Chrome closed"
- [x] Confirmed the fix closes Chrome (and its helper/renderer subprocesses) within ~1s of SIGINT, repeatedly
- [x] Added `packages/node-server/tests/browser-shutdown.test.ts`; verified it fails against the reverted buggy logic and passes against the fix
- [x] `tsc --noEmit -p tsconfig.cli.json`, `biome check`, and the node-server test suite all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)