### PR TITLE
fix(tray): surface leader's scoop list in follower nav bar

### DIFF
--- a/packages/webapp/src/scoops/tray-follower-sync.ts
+++ b/packages/webapp/src/scoops/tray-follower-sync.ts
@@ -26,6 +26,7 @@ import {
   type RemoteTargetInfo,
   reassembleCDPResponse,
   reassembleSnapshot,
+  type ScoopSummary,
   type SprinkleSummary,
   sendCDPResponse,
   type TrayFsRequest,
@@ -65,6 +66,8 @@ export interface FollowerSyncManagerOptions {
   onTargetsChanged?: () => void;
   /** Called when the leader sends an updated sprinkle list. */
   onSprinklesList?: (sprinkles: SprinkleSummary[]) => void;
+  /** Called when the leader sends an updated scoop list (nav bar / scoop picker). */
+  onScoopsList?: (scoops: ScoopSummary[], activeScoopJid: string) => void;
   /** Called when the leader sends a `sprinkle.update` payload (mirrors `SprinkleManager.sendToSprinkle`). */
   onSprinkleUpdate?: (sprinkleName: string, data: unknown) => void;
   /** Called when the leader signals that a sprinkle's content has been reloaded (file changed). */
@@ -560,21 +563,7 @@ export class FollowerSyncManager implements AgentHandle {
         break;
 
       case 'user_message_echo':
-        if (this.sentMessageIds.has(message.messageId)) {
-          this.sentMessageIds.delete(message.messageId);
-          log.debug('Skipping own message echo', { messageId: message.messageId });
-          break;
-        }
-        log.info('User message echo received', {
-          messageId: message.messageId,
-          scoopJid: message.scoopJid,
-        });
-        this.options.onUserMessage?.(
-          message.text,
-          message.messageId,
-          message.scoopJid,
-          message.attachments
-        );
+        this.handleUserMessageEcho(message);
         break;
 
       case 'status':
@@ -641,6 +630,11 @@ export class FollowerSyncManager implements AgentHandle {
         this.routeFsResponse(message.requestId, message.response);
         break;
       }
+      case 'scoops.list': {
+        this.handleScoopsList(message.scoops, message.activeScoopJid);
+        break;
+      }
+
       case 'sprinkles.list': {
         log.info('Sprinkles list received from leader', {
           sprinkleCount: message.sprinkles.length,
@@ -696,6 +690,31 @@ export class FollowerSyncManager implements AgentHandle {
         });
         break;
     }
+  }
+
+  private handleUserMessageEcho(
+    message: LeaderToFollowerMessage & { type: 'user_message_echo' }
+  ): void {
+    if (this.sentMessageIds.has(message.messageId)) {
+      this.sentMessageIds.delete(message.messageId);
+      log.debug('Skipping own message echo', { messageId: message.messageId });
+      return;
+    }
+    log.info('User message echo received', {
+      messageId: message.messageId,
+      scoopJid: message.scoopJid,
+    });
+    this.options.onUserMessage?.(
+      message.text,
+      message.messageId,
+      message.scoopJid,
+      message.attachments
+    );
+  }
+
+  private handleScoopsList(scoops: ScoopSummary[], activeScoopJid: string): void {
+    log.info('Scoops list received from leader', { scoopCount: scoops.length });
+    this.options.onScoopsList?.(scoops, activeScoopJid);
   }
 
   /**

--- a/packages/webapp/src/ui/page-follower-tray.ts
+++ b/packages/webapp/src/ui/page-follower-tray.ts
@@ -31,7 +31,7 @@ import { createLogger } from '../core/logger.js';
 import { ThrottledErrorTracker } from '../scoops/throttled-error-tracker.js';
 import { setFollowerTrayRuntimeStatus } from '../scoops/tray-follower-status.js';
 import { FollowerSyncManager } from '../scoops/tray-follower-sync.js';
-import type { SprinkleSummary } from '../scoops/tray-sync-protocol.js';
+import type { ScoopSummary, SprinkleSummary } from '../scoops/tray-sync-protocol.js';
 import { CHERRY_RUNTIME_TAG, type RemoteTargetInfo } from '../scoops/tray-sync-protocol.js';
 import {
   type FollowerAutoReconnectHandle,
@@ -106,6 +106,12 @@ export interface StartPageFollowerTrayOptions {
    * followers, where the event has no host page to reach.
    */
   onCherrySliccEvent?: (name: string, detail?: unknown) => void;
+  /**
+   * Notified when the leader updates the scoop list (nav bar / scoop picker).
+   * Optional — when omitted, the follower still syncs chat fully, it just has
+   * no scoop switcher UI to update.
+   */
+  onScoopsList?: (scoops: ScoopSummary[], activeScoopJid: string) => void;
 
   // --- Page-side wiring callbacks ---
   /**
@@ -256,6 +262,7 @@ export function startPageFollowerTray(
       onUserMessage: options.onUserMessage,
       onStatus: options.onStatus,
       onCherrySliccEvent: options.onCherrySliccEvent,
+      onScoopsList: options.onScoopsList,
       selfRuntimeId: runtimeId,
       onTargetsChanged: () => void refreshTargets(),
       onSprinklesList: (sprinkles) => {

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -9,6 +9,7 @@ import type { AgentHandle } from '../types.js';
 import { wireWcAttach } from './wc-attach.js';
 import { WcChatController } from './wc-chat-controller.js';
 import { prepareWcShell } from './wc-live.js';
+import { scoopColor } from './wc-scoop-color.js';
 import { submittedText } from './wc-shell.js';
 import { WcSprinkleZone } from './wc-sprinkles.js';
 
@@ -302,6 +303,16 @@ export async function mountWcUiFollower(
     onOpen: (path) => {
       if (/^https?:\/\//.test(path)) window.open(path, '_blank', 'noopener');
       else log.warn('follower sprinkle open() of a local path is unavailable', { path });
+    },
+    onScoopsList: (scoops, activeScoopJid) => {
+      boot.refs.switcher.scoops = scoops.map((s) => ({
+        key: s.jid,
+        type: s.isCone ? 'cone' : 'scoop',
+        color: scoopColor(s),
+        label: s.isCone ? 'sliccy' : s.name,
+        eyes: 'open',
+      }));
+      boot.refs.switcher.setAttribute('active', activeScoopJid);
     },
     ...(isCherry
       ? {

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -47,6 +47,7 @@ import type { UiRuntimeMode } from '../runtime-mode.js';
 import type { SprinkleManager } from '../sprinkle-manager.js';
 import type { AgentHandle } from '../types.js';
 import type { WcChatController } from './wc-chat-controller.js';
+import { scoopColor } from './wc-scoop-color.js';
 import type { WcShellRefs } from './wc-shell.js';
 
 export interface WcTrayDeps {
@@ -100,6 +101,16 @@ function buildFollowerOptions(
     onForwardingToggle: (enabled) => client.sendSetFollowerForwarding(enabled),
     addSprinkle: (name, title, element) => deps.addSprinkle(name, title, element),
     removeSprinkle: (name) => deps.removeSprinkle(name),
+    onScoopsList: (scoops, activeScoopJid) => {
+      deps.refs.switcher.scoops = scoops.map((s) => ({
+        key: s.jid,
+        type: s.isCone ? 'cone' : 'scoop',
+        color: scoopColor(s),
+        label: s.isCone ? 'sliccy' : s.name,
+        eyes: 'open',
+      }));
+      deps.refs.switcher.setAttribute('active', activeScoopJid);
+    },
   };
 }
 

--- a/packages/webapp/tests/scoops/tray-follower-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-follower-sync.test.ts
@@ -1311,6 +1311,43 @@ describe('FollowerSyncManager', () => {
   // outbound: refreshSprinkles / fetchSprinkleContent / sendSprinkleLick.
   // ---------------------------------------------------------------------------
 
+  describe('scoops.list handling', () => {
+    it('dispatches scoops.list to onScoopsList', () => {
+      const channel = new FakeChannel();
+      const onScoopsList = vi.fn();
+      new FollowerSyncManager(channel, { onScoopsList });
+
+      const scoops = [
+        {
+          jid: 'cone-jid',
+          name: 'cone',
+          folder: '/workspace',
+          isCone: true,
+          assistantLabel: 'sliccy',
+        },
+        {
+          jid: 'scoop-1',
+          name: 'research',
+          folder: '/scoops/research',
+          isCone: false,
+          assistantLabel: 'research',
+        },
+      ];
+      channel.simulateLeaderMessage({ type: 'scoops.list', scoops, activeScoopJid: 'cone-jid' });
+
+      expect(onScoopsList).toHaveBeenCalledWith(scoops, 'cone-jid');
+    });
+
+    it('does not crash on scoops.list when no callback is registered', () => {
+      const channel = new FakeChannel();
+      new FollowerSyncManager(channel, {});
+
+      expect(() =>
+        channel.simulateLeaderMessage({ type: 'scoops.list', scoops: [], activeScoopJid: '' })
+      ).not.toThrow();
+    });
+  });
+
   describe('sprinkle handling', () => {
     it('dispatches sprinkles.list to onSprinklesList', () => {
       const channel = new FakeChannel();

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -144,6 +144,45 @@ describe('mountWcUiFollower', () => {
     expect(inputCard.getAttribute('placeholder')).toBe('Connecting to leader…');
   });
 
+  it('populates the nav switcher when the leader broadcasts a scoops.list', async () => {
+    const { mountWcUiFollower } = await import('../../../src/ui/wc/wc-follower.js');
+    const app = document.getElementById('app')!;
+    await mountWcUiFollower(app, { stage: () => {} } as never, 'follower');
+    const opts = startFollowerSpy.mock.calls[0]![0];
+
+    const switcher = app.querySelector('slicc-scoop-switcher') as HTMLElement & {
+      scoops: { key: string; type: string; label: string }[];
+    };
+    expect(switcher).toBeTruthy();
+    expect(switcher.scoops).toEqual([]);
+
+    opts.onScoopsList?.(
+      [
+        {
+          jid: 'cone-jid',
+          name: 'cone',
+          folder: '/workspace',
+          isCone: true,
+          assistantLabel: 'sliccy',
+        },
+        {
+          jid: 'scoop-1',
+          name: 'research',
+          folder: '/scoops/research',
+          isCone: false,
+          assistantLabel: 'research',
+        },
+      ],
+      'cone-jid'
+    );
+
+    expect(switcher.scoops.map((s) => s.key)).toEqual(['cone-jid', 'scoop-1']);
+    expect(switcher.scoops.map((s) => s.type)).toEqual(['cone', 'scoop']);
+    expect(switcher.scoops[0]!.label).toBe('sliccy');
+    expect(switcher.scoops[1]!.label).toBe('research');
+    expect(switcher.getAttribute('active')).toBe('cone-jid');
+  });
+
   it('shows a terminal "reload to retry" state when the tray gives up', async () => {
     const { mountWcUiFollower } = await import('../../../src/ui/wc/wc-follower.js');
     const app = document.getElementById('app')!;


### PR DESCRIPTION
The leader already broadcasts scoops.list to every follower on attach and every 5s, but FollowerSyncManager had no handler for it, so the message was silently dropped and the follower's scoop switcher stayed empty. Wire onScoopsList through the follower sync, page boot, and wc-tray so the leader's scoops populate the follower's nav bar.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
