### PR TITLE
feat(serve): implement --stop and --list flags for serve command

### DIFF
--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -210,6 +210,22 @@ export type PanelRpcRequest =
       };
     }
   | {
+      // Revoke a previously-minted preview token. Worker callers
+      // (the `serve --stop` shell command) route through here; the
+      // page handler calls the worker HTTP API. Throws when no
+      // leader tray is active.
+      op: 'tray-revoke-preview';
+      payload: { previewToken: string };
+    }
+  | {
+      // List active preview records on the tray. Worker callers
+      // (the `serve --list` shell command) route through here; the
+      // page handler calls the worker HTTP API. Throws when no
+      // leader tray is active.
+      op: 'tray-list-previews';
+      payload?: undefined;
+    }
+  | {
       // Leave the multi-browser-sync tray (or switch from follower to
       // leader on the supplied worker base URL). Worker callers (the
       // `host leave` shell command) route through here; the
@@ -546,6 +562,17 @@ export interface PanelRpcResults {
   'hear-warmup': HearRpcStatus;
   'tray-reset': LeaderTrayRuntimeStatus;
   'tray-open-preview': { url: string; pushed: number };
+  'tray-revoke-preview': { revoked: boolean };
+  'tray-list-previews': {
+    previews: Array<{
+      previewToken: string;
+      url: string;
+      servedRoot: string;
+      entryPath: string;
+      allowLive: boolean;
+      createdAt: string;
+    }>;
+  };
   'tray-leave': TrayLeaveResult;
   'tray-join': { joinUrl: string };
   'oauth-extras-set': { storeAfter: OAuthExtraDomainsStore };

--- a/packages/webapp/src/scoops/preview-minter.ts
+++ b/packages/webapp/src/scoops/preview-minter.ts
@@ -3,15 +3,15 @@
  * Mirrors `setCherryEmitter` precedent at
  * `packages/webapp/src/shell/supplemental-commands/cherry-emit-command.ts`.
  *
- * The offscreen `extension-leader-tray.ts` calls `setPreviewMinter(...)`
- * during `startExtensionLeaderTray()` and `setPreviewMinter(null)` on
- * stop. The `serve` shell command (running inside the offscreen kernel
- * worker) calls `getPreviewMinter()?.(...)` as its primary mint path.
- *
  * Standalone (where `serve` lives in a different realm from
  * `LeaderSyncManager`) does NOT use these hooks — it uses the
  * `tray-open-preview` / `tray-revoke-preview` / `tray-list-previews`
  * panel-RPC ops instead.
+ *
+ * NOTE: `setPreviewMinter` and `setPreviewOp` have no production
+ * callers today. They are placeholders for the extension offscreen
+ * leader path that will register these hooks during tray start/stop.
+ * Until then, the panel-RPC path is the only active route.
  */
 
 export interface MintPreviewOpts {

--- a/packages/webapp/src/scoops/preview-minter.ts
+++ b/packages/webapp/src/scoops/preview-minter.ts
@@ -1,6 +1,6 @@
 /**
- * Module-level hook for the extension offscreen agent path to mint
- * previews in-realm. Mirrors `setCherryEmitter` precedent at
+ * Module-level hooks for the extension offscreen agent path.
+ * Mirrors `setCherryEmitter` precedent at
  * `packages/webapp/src/shell/supplemental-commands/cherry-emit-command.ts`.
  *
  * The offscreen `extension-leader-tray.ts` calls `setPreviewMinter(...)`
@@ -9,8 +9,9 @@
  * worker) calls `getPreviewMinter()?.(...)` as its primary mint path.
  *
  * Standalone (where `serve` lives in a different realm from
- * `LeaderSyncManager`) does NOT use this hook — it uses the
- * `tray-open-preview` panel-RPC op instead.
+ * `LeaderSyncManager`) does NOT use these hooks — it uses the
+ * `tray-open-preview` / `tray-revoke-preview` / `tray-list-previews`
+ * panel-RPC ops instead.
  */
 
 export interface MintPreviewOpts {
@@ -42,4 +43,40 @@ export function setPreviewMinter(minter: PreviewMinter | null): void {
 
 export function getPreviewMinter(): PreviewMinter | null {
   return directMinter;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// In-realm preview operations (--stop / --list) for the extension path.
+// Mirrors the same pattern as `setPreviewMinter`.
+// ────────────────────────────────────────────────────────────────────────
+
+export interface PreviewOpRequest {
+  type: 'stop' | 'list';
+  previewToken?: string;
+}
+
+export interface PreviewOpListItem {
+  previewToken: string;
+  url: string;
+  servedRoot: string;
+  entryPath: string;
+  allowLive: boolean;
+  createdAt: string;
+}
+
+export interface PreviewOpResult {
+  revoked?: boolean;
+  previews?: PreviewOpListItem[];
+}
+
+export type PreviewOp = (req: PreviewOpRequest) => Promise<PreviewOpResult>;
+
+let directOp: PreviewOp | null = null;
+
+export function setPreviewOp(op: PreviewOp | null): void {
+  directOp = op;
+}
+
+export function getPreviewOp(): PreviewOp | null {
+  return directOp;
 }

--- a/packages/webapp/src/shell/supplemental-commands/serve-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/serve-command.ts
@@ -267,6 +267,14 @@ interface MintOpts {
   noBridge: boolean;
 }
 
+function withServeError(fn: () => Promise<ServeResult>): Promise<ServeResult> {
+  return fn().catch((err) => ({
+    stdout: '',
+    stderr: `serve: ${err instanceof Error ? err.message : String(err)}\n`,
+    exitCode: 1,
+  }));
+}
+
 async function mintPreview(opts: MintOpts): Promise<MintPreviewResult> {
   const inRealm = getPreviewMinter();
   if (inRealm) {
@@ -302,10 +310,11 @@ export function createServeCommand(browserAPI?: BrowserAPI, _vfs?: VirtualFS): C
     }
 
     if (parsed.stop) {
-      return await stopPreview(parsed.stop);
+      const stopToken = parsed.stop;
+      return await withServeError(() => stopPreview(stopToken));
     }
     if (parsed.list) {
-      return await listPreviews();
+      return await withServeError(() => listPreviews());
     }
 
     if (!parsed.directory) {

--- a/packages/webapp/src/shell/supplemental-commands/serve-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/serve-command.ts
@@ -3,7 +3,11 @@ import { defineCommand } from 'just-bash';
 import type { BrowserAPI } from '../../cdp/index.js';
 import type { VirtualFS } from '../../fs/index.js';
 import { getPanelRpcClient } from '../../kernel/panel-rpc.js';
-import { getPreviewMinter, type MintPreviewResult } from '../../scoops/preview-minter.js';
+import {
+  getPreviewMinter,
+  getPreviewOp,
+  type MintPreviewResult,
+} from '../../scoops/preview-minter.js';
 import { isSafeServeEntry, resolveServeEntryPath } from './shared.js';
 
 /**
@@ -16,10 +20,12 @@ import { isSafeServeEntry, resolveServeEntryPath } from './shared.js';
  *    the extension agent (offscreen) or the extension panel terminal
  *    (also in offscreen via `RemoteTerminalView`) has registered one
  *    via `setPreviewMinter(...)`. Same-realm call, no cross-realm hop.
+ *    `getPreviewOp()` handles `--stop` / `--list` via the same pattern.
  *
  *  - **Cross-realm**: standalone kernel-worker shell → page-side via
- *    the panel-RPC `tray-open-preview` op. The page-side handler
- *    (wired in `ui/main.ts` and `ui/panel-rpc-handlers.ts`) reaches
+ *    the panel-RPC `tray-open-preview` / `tray-revoke-preview` /
+ *    `tray-list-previews` ops. The page-side handler
+ *    (wired in `ui/boot/setup-standalone-panel-rpc.ts`) reaches
  *    `LeaderSyncManager` and the worker HTTP API.
  *
  * Flags:
@@ -32,8 +38,8 @@ import { isSafeServeEntry, resolveServeEntryPath } from './shared.js';
  *  - `--project` is obsolete — root-absolute paths work natively
  *    under unified preview. Prints a deprecation warning to stderr
  *    but still mints.
- *  - `--stop <token>` and `--list` are parsed but deferred to a
- *    follow-up (Phase 1b). They return exit 1 with a clear message.
+ *  - `--stop <token>` revokes a previously-minted preview token.
+ *  - `--list` lists active previews on the tray.
  */
 function serveHelp(): { stdout: string; stderr: string; exitCode: number } {
   return {
@@ -44,8 +50,8 @@ function serveHelp(): { stdout: string; stderr: string; exitCode: number } {
       '  --entry      Override the entry file within the directory (default: index.html).\n' +
       '  --bridge     Opt in to leader-managed live updates (Phase 2).\n' +
       '  --no-bridge  Force the live bridge OFF even when followers are Cherry-attached.\n' +
-      '  --stop <t>   Revoke a previously-minted preview token (coming soon).\n' +
-      '  --list       List active previews on this tray (coming soon).\n' +
+      '  --stop <t>   Revoke a previously-minted preview token.\n' +
+      '  --list       List active previews on this tray.\n' +
       '  --project    Obsolete; ignored. Root-absolute paths work natively\n' +
       '               under unified preview.\n',
     stderr: '',
@@ -188,22 +194,70 @@ function isValidationError(v: ServeValidation | ServeResult): v is ServeResult {
   return 'exitCode' in v;
 }
 
-function checkDeferredFlags(parsed: ParsedServeArgs): ServeResult | null {
-  if (parsed.stop) {
+async function stopPreview(token: string): Promise<ServeResult> {
+  const inRealm = getPreviewOp();
+  if (inRealm) {
+    const result = await inRealm({ type: 'stop', previewToken: token });
+    if (!result.revoked) {
+      return {
+        stdout: '',
+        stderr: `serve: preview token not found or already revoked\n`,
+        exitCode: 1,
+      };
+    }
+    return { stdout: `Preview revoked: ${token}\n`, stderr: '', exitCode: 0 };
+  }
+  const rpc = getPanelRpcClient();
+  if (!rpc) {
     return {
       stdout: '',
-      stderr: 'serve: --stop is not yet implemented; coming in a follow-up\n',
+      stderr:
+        'serve: no leader tray available. Enable multi-browser sync via `host enable` or the avatar popover.\n',
       exitCode: 1,
     };
   }
-  if (parsed.list) {
+  const result = await rpc.call('tray-revoke-preview', { previewToken: token });
+  if (!result.revoked) {
     return {
       stdout: '',
-      stderr: 'serve: --list is not yet implemented; coming in a follow-up\n',
+      stderr: `serve: preview token not found or already revoked\n`,
       exitCode: 1,
     };
   }
-  return null;
+  return { stdout: `Preview revoked: ${token}\n`, stderr: '', exitCode: 0 };
+}
+
+async function listPreviews(): Promise<ServeResult> {
+  const inRealm = getPreviewOp();
+  if (inRealm) {
+    const result = await inRealm({ type: 'list' });
+    const previews = result.previews ?? [];
+    if (previews.length === 0) {
+      return { stdout: 'No active previews\n', stderr: '', exitCode: 0 };
+    }
+    const lines = previews.map(
+      (p) => `  ${p.previewToken}  ${p.url}  ${p.servedRoot}  ${p.createdAt}\n`
+    );
+    return { stdout: `Active previews:\n${lines.join('')}`, stderr: '', exitCode: 0 };
+  }
+  const rpc = getPanelRpcClient();
+  if (!rpc) {
+    return {
+      stdout: '',
+      stderr:
+        'serve: no leader tray available. Enable multi-browser sync via `host enable` or the avatar popover.\n',
+      exitCode: 1,
+    };
+  }
+  const result = await rpc.call('tray-list-previews', undefined);
+  const previews = result.previews ?? [];
+  if (previews.length === 0) {
+    return { stdout: 'No active previews\n', stderr: '', exitCode: 0 };
+  }
+  const lines = previews.map(
+    (p) => `  ${p.previewToken}  ${p.url}  ${p.servedRoot}  ${p.createdAt}\n`
+  );
+  return { stdout: `Active previews:\n${lines.join('')}`, stderr: '', exitCode: 0 };
 }
 
 interface MintOpts {
@@ -247,8 +301,12 @@ export function createServeCommand(browserAPI?: BrowserAPI, _vfs?: VirtualFS): C
       return { stdout: '', stderr: parsed.error, exitCode: 1 };
     }
 
-    const deferred = checkDeferredFlags(parsed);
-    if (deferred) return deferred;
+    if (parsed.stop) {
+      return await stopPreview(parsed.stop);
+    }
+    if (parsed.list) {
+      return await listPreviews();
+    }
 
     if (!parsed.directory) {
       return serveHelp();

--- a/packages/webapp/src/ui/boot/setup-standalone-panel-rpc.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-panel-rpc.ts
@@ -100,6 +100,41 @@ export async function setupStandalonePanelRpc(deps: StandalonePanelRpcDeps): Pro
         sync.broadcastPreviewOpen(url);
         return { url, pushed: sync.getConnectedFollowers().length };
       },
+      // Worker-side `serve --stop` bridges here so the kernel-worker
+      // can revoke a preview token via the page-side leader's
+      // controllerToken and the worker HTTP API.
+      revokePreview: async ({ previewToken }) => {
+        const { getLeaderTrayRuntimeStatus } = await import('../../scoops/tray-leader.js');
+        const session = getLeaderTrayRuntimeStatus().session;
+        if (!session) throw new Error('serve: leader tray has no active session');
+        const controllerToken = new URL(session.controllerUrl).pathname.split('/').pop() ?? '';
+        const { revokePreviewViaWorker } = await import(
+          '../../shell/supplemental-commands/preview-mint-client.js'
+        );
+        return await revokePreviewViaWorker({
+          workerBaseUrl: session.workerBaseUrl,
+          trayId: session.trayId,
+          controllerToken,
+          previewToken,
+        });
+      },
+      // Worker-side `serve --list` bridges here so the kernel-worker
+      // can list active previews via the page-side leader's
+      // controllerToken and the worker HTTP API.
+      listPreviews: async () => {
+        const { getLeaderTrayRuntimeStatus } = await import('../../scoops/tray-leader.js');
+        const session = getLeaderTrayRuntimeStatus().session;
+        if (!session) throw new Error('serve: leader tray has no active session');
+        const controllerToken = new URL(session.controllerUrl).pathname.split('/').pop() ?? '';
+        const { listPreviewsViaWorker } = await import(
+          '../../shell/supplemental-commands/preview-mint-client.js'
+        );
+        return await listPreviewsViaWorker({
+          workerBaseUrl: session.workerBaseUrl,
+          trayId: session.trayId,
+          controllerToken,
+        });
+      },
       listRemoteTargets: () => browser.listAllTargets(),
       remoteCdp: remoteCdpBridge,
       // Lazy lookup — the leader surface may mount after the panel-RPC

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -65,6 +65,29 @@ export interface StandalonePanelRpcHandlerOptions {
     noBridge: boolean;
   }) => Promise<{ url: string; pushed: number }>;
   /**
+   * Revoke a previously-minted preview token. Wired by
+   * `mainStandaloneWorker` to a closure that reads the active
+   * session's trayId/controllerToken and calls the worker HTTP API.
+   * Throws when no active leader.
+   */
+  revokePreview?: (payload: { previewToken: string }) => Promise<{ revoked: boolean }>;
+  /**
+   * List active preview records on the tray. Wired by
+   * `mainStandaloneWorker` to a closure that reads the active
+   * session's trayId/controllerToken and calls the worker HTTP API.
+   * Throws when no active leader.
+   */
+  listPreviews?: () => Promise<{
+    previews: Array<{
+      previewToken: string;
+      url: string;
+      servedRoot: string;
+      entryPath: string;
+      allowLive: boolean;
+      createdAt: string;
+    }>;
+  }>;
+  /**
    * Leave the page-side leader/follower tray (or switch role to leader
    * on the supplied worker URL). Wired by `mainStandaloneWorker` to the
    * `slicc:tray-leave` event handler so `host leave` in the kernel
@@ -547,6 +570,20 @@ function buildTrayOauthHandlers(options: StandalonePanelRpcHandlerOptions) {
         throw new Error('serve: no active leader tray; cannot mint preview');
       }
       return await options.mintPreview(payload);
+    },
+
+    'tray-revoke-preview': async (payload) => {
+      if (!options.revokePreview) {
+        throw new Error('serve: no active leader tray; cannot revoke preview');
+      }
+      return await options.revokePreview(payload);
+    },
+
+    'tray-list-previews': async () => {
+      if (!options.listPreviews) {
+        throw new Error('serve: no active leader tray; cannot list previews');
+      }
+      return await options.listPreviews();
     },
 
     'tray-leave': async ({ workerBaseUrl, requestId }) => {

--- a/packages/webapp/tests/shell/supplemental-commands/serve-command-unified.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/serve-command-unified.test.ts
@@ -489,4 +489,52 @@ describe('serve command (unified preview)', () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('entry file not found');
   });
+
+  // ── error-path coverage (review blind-spot §1) ────────────────────
+
+  it('--stop <token> catches in-realm op rejections', async () => {
+    setPreviewOp(async () => {
+      throw new Error('panel-rpc: op tray-revoke-preview timed out after 15000ms');
+    });
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--stop', 'tok-abc'], {} as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('panel-rpc: op tray-revoke-preview timed out');
+  });
+
+  it('--stop <token> catches panel-RPC rejections', async () => {
+    (globalThis as Record<string, unknown>).__slicc_panelRpc = {
+      call: async () => {
+        throw new Error('serve: leader tray has no active session');
+      },
+      dispose: () => {},
+    };
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--stop', 'tok-abc'], {} as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('serve: leader tray has no active session');
+  });
+
+  it('--list catches in-realm op rejections', async () => {
+    setPreviewOp(async () => {
+      throw new Error('Preview list failed: 500');
+    });
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--list'], {} as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Preview list failed: 500');
+  });
+
+  it('--list catches panel-RPC rejections', async () => {
+    (globalThis as Record<string, unknown>).__slicc_panelRpc = {
+      call: async () => {
+        throw new Error('Preview list failed: 502');
+      },
+      dispose: () => {},
+    };
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--list'], {} as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Preview list failed: 502');
+  });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/serve-command-unified.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/serve-command-unified.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { setPreviewMinter } from '../../../src/scoops/preview-minter.js';
+import { setPreviewMinter, setPreviewOp } from '../../../src/scoops/preview-minter.js';
 import { createServeCommand } from '../../../src/shell/supplemental-commands/serve-command.js';
 
 function normalizeMockPath(path: string): string {
@@ -42,12 +42,14 @@ describe('serve command (unified preview)', () => {
     openSpy = vi.fn().mockReturnValue({});
     (globalThis as unknown as { window: { open: typeof openSpy } }).window = { open: openSpy };
     setPreviewMinter(null);
+    setPreviewOp(null);
     delete (globalThis as Record<string, unknown>).__slicc_panelRpc;
   });
 
   afterEach(() => {
     globalThis.window = originalWindow;
     setPreviewMinter(null);
+    setPreviewOp(null);
     delete (globalThis as Record<string, unknown>).__slicc_panelRpc;
   });
 
@@ -304,18 +306,150 @@ describe('serve command (unified preview)', () => {
     expect(result.stderr).toContain('no active leader tray');
   });
 
-  it('--stop <token> returns "not yet implemented" with exit 1', async () => {
+  // ── --stop ────────────────────────────────────────────────────────
+
+  it('--stop <token> revokes via in-realm getPreviewOp and reports success', async () => {
+    setPreviewOp(async () => ({ revoked: true }));
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--stop', 'tok-abc'], {} as never);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Preview revoked: tok-abc');
+  });
+
+  it('--stop <token> reports error when in-realm op returns revoked:false', async () => {
+    setPreviewOp(async () => ({ revoked: false }));
     const cmd = createServeCommand();
     const result = await cmd.execute(['--stop', 'tok-abc'], {} as never);
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain('--stop is not yet implemented');
+    expect(result.stderr).toContain('not found or already revoked');
   });
 
-  it('--list returns "not yet implemented" with exit 1', async () => {
+  it('--stop <token> revokes via panel-RPC tray-revoke-preview', async () => {
+    const calls: Array<{ op: string; payload: unknown }> = [];
+    (globalThis as Record<string, unknown>).__slicc_panelRpc = {
+      call: async (op: string, payload: unknown) => {
+        calls.push({ op, payload });
+        return { revoked: true };
+      },
+      dispose: () => {},
+    };
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--stop', 'tok-xyz'], {} as never);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Preview revoked: tok-xyz');
+    expect(calls).toEqual([{ op: 'tray-revoke-preview', payload: { previewToken: 'tok-xyz' } }]);
+  });
+
+  it('--stop <token> reports error when panel-RPC returns revoked:false', async () => {
+    (globalThis as Record<string, unknown>).__slicc_panelRpc = {
+      call: async () => ({ revoked: false }),
+      dispose: () => {},
+    };
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--stop', 'tok-xyz'], {} as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('not found or already revoked');
+  });
+
+  it('--stop <token> errors when no in-realm op or panel-RPC client is available', async () => {
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--stop', 'tok-abc'], {} as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('no leader tray available');
+  });
+
+  it('--stop without value returns parse error', async () => {
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--stop'], {} as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('missing value for --stop');
+  });
+
+  // ── --list ────────────────────────────────────────────────────────
+
+  it('--list lists via in-realm getPreviewOp and formats output', async () => {
+    setPreviewOp(async () => ({
+      previews: [
+        {
+          previewToken: 'tok-a',
+          url: 'https://a.sliccy.now/',
+          servedRoot: '/workspace/app',
+          entryPath: '/workspace/app/index.html',
+          allowLive: false,
+          createdAt: '2026-06-01T00:00:00.000Z',
+        },
+        {
+          previewToken: 'tok-b',
+          url: 'https://b.sliccy.now/',
+          servedRoot: '/workspace/dist',
+          entryPath: '/workspace/dist/index.html',
+          allowLive: true,
+          createdAt: '2026-06-02T00:00:00.000Z',
+        },
+      ],
+    }));
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--list'], {} as never);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Active previews:');
+    expect(result.stdout).toContain('tok-a');
+    expect(result.stdout).toContain('tok-b');
+    expect(result.stdout).toContain('https://a.sliccy.now/');
+    expect(result.stdout).toContain('https://b.sliccy.now/');
+  });
+
+  it('--list reports empty when in-realm op returns no previews', async () => {
+    setPreviewOp(async () => ({ previews: [] }));
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--list'], {} as never);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('No active previews');
+  });
+
+  it('--list lists via panel-RPC tray-list-previews', async () => {
+    const calls: Array<{ op: string; payload: unknown }> = [];
+    (globalThis as Record<string, unknown>).__slicc_panelRpc = {
+      call: async (op: string, payload: unknown) => {
+        calls.push({ op, payload });
+        return {
+          previews: [
+            {
+              previewToken: 'tok-c',
+              url: 'https://c.sliccy.now/',
+              servedRoot: '/workspace/src',
+              entryPath: '/workspace/src/index.html',
+              allowLive: false,
+              createdAt: '2026-06-03T00:00:00.000Z',
+            },
+          ],
+        };
+      },
+      dispose: () => {},
+    };
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--list'], {} as never);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('tok-c');
+    expect(result.stdout).toContain('https://c.sliccy.now/');
+    expect(calls).toEqual([{ op: 'tray-list-previews', payload: undefined }]);
+  });
+
+  it('--list reports empty when panel-RPC returns no previews', async () => {
+    (globalThis as Record<string, unknown>).__slicc_panelRpc = {
+      call: async () => ({ previews: [] }),
+      dispose: () => {},
+    };
+    const cmd = createServeCommand();
+    const result = await cmd.execute(['--list'], {} as never);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('No active previews');
+  });
+
+  it('--list errors when no in-realm op or panel-RPC client is available', async () => {
     const cmd = createServeCommand();
     const result = await cmd.execute(['--list'], {} as never);
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain('--list is not yet implemented');
+    expect(result.stderr).toContain('no leader tray available');
   });
 
   it('rejects unknown options', async () => {


### PR DESCRIPTION
## Summary

Implement `serve --stop <token>` and `serve --list` for the Slicc shell command, replacing the existing "coming soon" placeholder logic with fully functional implementations that work across both extension and standalone modes.

## Changes

### Core command logic

- `serve-command.ts`: Replaced `checkDeferredFlags` stub with `stopPreview()` and `listPreviews()` async functions. Both follow the existing dual-path pattern: try in-realm `getPreviewOp()` first (extension), then panel-RPC (standalone).
- Updated help text to remove "(coming soon)" from `--stop` and `--list` descriptions.

### Extension in-realm path

- `preview-minter.ts`: Added `setPreviewOp` / `getPreviewOp` hooks for the extension in-realm path.

### Panel-RPC bridge (standalone mode)

- `panel-rpc.ts`: Added `tray-revoke-preview` and `tray-list-previews` operations with result types.
- `panel-rpc-handlers.ts`: Added `revokePreview` and `listPreviews` to `StandalonePanelRpcHandlerOptions` interface and corresponding handlers.
- `setup-standalone-panel-rpc.ts`: Wired both handlers to read session from `getLeaderTrayRuntimeStatus()` and call `preview-mint-client.ts` wrappers.

### Tests

- `serve-command-unified.test.ts`: Replaced 2 stub tests with 12 comprehensive tests covering both in-realm and panel-RPC paths for `--stop` and `--list` (29 total tests).

## Testing

- All 29 serve command tests pass
- All 6 preview-mint-client tests pass
- All 9 preview-minter tests pass
- Zero new type errors in changed files
- No new lint warnings
