### PR TITLE
fix(webapp): force a repaint of nested sprinkle iframes in cherry

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -281,8 +281,7 @@
         "packages/webapp/src/shell/supplemental-commands/open-command.ts",
         "packages/webapp/src/shell/supplemental-commands/pdftk-command.ts",
         "packages/webapp/src/shell/supplemental-commands/websocat-command.ts",
-        "packages/webapp/src/ui/sprinkle-bridge.ts",
-        "packages/webapp/src/ui/sprinkle-renderer.ts"
+        "packages/webapp/src/ui/sprinkle-bridge.ts"
       ],
       "linter": {
         "rules": {
@@ -334,8 +333,7 @@
         "packages/webapp/src/shell/supplemental-commands/websocat-command.ts",
         "packages/webapp/src/skills/install-from-drop.ts",
         "packages/webapp/src/tools/search-tools.ts",
-        "packages/webapp/src/ui/oauth-bootstrap.ts",
-        "packages/webapp/src/ui/sprinkle-renderer.ts"
+        "packages/webapp/src/ui/oauth-bootstrap.ts"
       ],
       "linter": {
         "rules": {

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -18,6 +18,42 @@ declare global {
 
 const isExtension = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
 
+/**
+ * Whether this page itself is running inside another frame (e.g. a cherry
+ * follower embedded in a third-party host page's iframe). A sprinkle's own
+ * render iframe is then nested two levels deep instead of one, which hits a
+ * Chromium first-paint bug: the innermost iframe's content loads and executes
+ * correctly but the compositor never rasterizes it, leaving the panel blank
+ * until something forces a full frame-tree repaint (DevTools attaching, or a
+ * page reload). `nudgeIframeRepaint` works around it without either of those.
+ */
+function isNestedInAnotherFrame(): boolean {
+  try {
+    return window.self !== window.top;
+  } catch {
+    // Cross-origin access to `window.top` throws — that itself means we're
+    // framed by a different origin, which is the case this guards against.
+    return true;
+  }
+}
+
+/**
+ * Force the browser to redo the render/compositing pass for `iframe` by
+ * toggling `display` off and back on across two animation frames. A resize
+ * event or explicit layout read (`getBoundingClientRect`) does NOT trigger
+ * the missing repaint for this bug — only a `display` toggle (or an
+ * out-of-band event like DevTools attaching) does.
+ */
+function nudgeIframeRepaint(iframe: HTMLIFrameElement): void {
+  const previousDisplay = iframe.style.display;
+  iframe.style.display = 'none';
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      iframe.style.display = previousDisplay;
+    });
+  });
+}
+
 const EXTERNAL_SCRIPT_RE =
   /<script\b([^>]*)\bsrc\s*=\s*["'](https?:\/\/[^"']+)["']([^>]*)><\/script>/gi;
 
@@ -751,6 +787,7 @@ export class SprinkleRenderer {
             { type: 'sprinkle-init', name: sprinkleName, savedState },
             '*'
           );
+          if (isNestedInAnotherFrame()) nudgeIframeRepaint(iframe);
           resolve();
         },
         { once: true }

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -95,6 +95,274 @@ export function isFullDocument(content: string): boolean {
   return trimmed.startsWith('<!doctype') || trimmed.startsWith('<html');
 }
 
+/** A message the sprinkle iframe posted up to the renderer. */
+type SprinkleInboundMessage = Record<string, unknown> & { type: string };
+
+/** A handler for one inbound message type. */
+type BridgeMessageHandler = (iframe: HTMLIFrameElement, msg: SprinkleInboundMessage) => void;
+
+function postToIframe(
+  iframe: HTMLIFrameElement,
+  type: string,
+  id: unknown,
+  extra: Record<string, unknown> = {}
+): void {
+  iframe.contentWindow?.postMessage({ type, id, ...extra }, '*');
+}
+
+/**
+ * Resolve `promise` and post a `<responseType>` message back to the iframe —
+ * `mapResult(value)` on success, `{ error }` on rejection. Factors out the
+ * `.then(success, error)` postMessage pattern repeated for every VFS/exec/
+ * device bridge call in both `renderInSandbox` and `renderFullDoc`.
+ */
+function respondToIframe<T>(
+  iframe: HTMLIFrameElement,
+  responseType: string,
+  id: unknown,
+  promise: Promise<T>,
+  mapResult: (value: T) => Record<string, unknown>
+): void {
+  promise.then(
+    (value) => postToIframe(iframe, responseType, id, mapResult(value)),
+    (err: unknown) =>
+      postToIframe(iframe, responseType, id, {
+        error: err instanceof Error ? err.message : String(err),
+      })
+  );
+}
+
+/**
+ * Bridge message handlers shared by both the extension sandbox iframe
+ * (`renderInSandbox`) and the CLI/standalone full-document iframe
+ * (`renderFullDoc`) — every VFS/exec/device/lifecycle call the sprinkle-side
+ * bridge script (`generateBridgeScript`) can send. Each renderer merges in
+ * its own additional handlers (sandbox mode also has localStorage proxying,
+ * `sprinkle-open`, and `sprinkle-fetch-script`).
+ */
+function createSharedBridgeHandlers(
+  bridge: SprinkleBridgeAPI
+): Record<string, BridgeMessageHandler> {
+  return {
+    'sprinkle-lick': (_iframe, msg) =>
+      bridge.lick({ action: msg.action as string, data: msg.data }),
+    'sprinkle-set-state': (_iframe, msg) => bridge.setState(msg.data),
+    'sprinkle-close': () => bridge.close(),
+    'sprinkle-minimize': () => bridge.minimize(),
+    'sprinkle-stop-cone': () => bridge.stopCone(),
+    'sprinkle-attach-image': (_iframe, msg) =>
+      bridge.attachImage(msg.base64 as string, msg.name as string, msg.mimeType as string),
+    'sprinkle-readfile': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-readfile-response',
+        msg.id,
+        bridge.readFile(msg.path as string),
+        (content) => ({
+          content,
+        })
+      ),
+    'sprinkle-writefile': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-writefile-response',
+        msg.id,
+        bridge.writeFile(msg.path as string, msg.content as string),
+        () => ({})
+      ),
+    'sprinkle-readdir': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-readdir-response',
+        msg.id,
+        bridge.readDir(msg.path as string),
+        (entries) => ({
+          entries,
+        })
+      ),
+    'sprinkle-exists': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-exists-response',
+        msg.id,
+        bridge.exists(msg.path as string),
+        (exists) => ({
+          exists,
+        })
+      ),
+    'sprinkle-stat': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-stat-response',
+        msg.id,
+        bridge.stat(msg.path as string),
+        (stat) => ({ stat })
+      ),
+    'sprinkle-mkdir': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-mkdir-response',
+        msg.id,
+        bridge.mkdir(msg.path as string),
+        () => ({})
+      ),
+    'sprinkle-rm': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-rm-response',
+        msg.id,
+        bridge.rm(msg.path as string),
+        () => ({})
+      ),
+    'sprinkle-capture-screen': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-capture-screen-response',
+        msg.id,
+        bridge.captureScreen(),
+        (result) => ({
+          base64: result.base64,
+          width: result.width,
+          height: result.height,
+          mimeType: result.mimeType,
+        })
+      ),
+    'sprinkle-exec': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-exec-response',
+        msg.id,
+        bridge.exec(msg.cmd as string),
+        (result) => ({
+          result,
+        })
+      ),
+    'sprinkle-agent': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-agent-response',
+        msg.id,
+        bridge.agent(msg.prompt as string, msg.opts as Parameters<typeof bridge.agent>[1]),
+        (result) => ({ result })
+      ),
+    'sprinkle-jsh': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-jsh-response',
+        msg.id,
+        bridge._jsh(msg.op as string, msg.args as unknown[]),
+        (result) => ({ result })
+      ),
+    'sprinkle-device-op': (iframe, msg) =>
+      respondToIframe(
+        iframe,
+        'sprinkle-device-op-response',
+        msg.id,
+        bridge._device(
+          msg.channel as Parameters<typeof bridge._device>[0],
+          msg.op as string,
+          (msg.args as unknown[]) ?? []
+        ),
+        (result) => ({ result })
+      ),
+  };
+}
+
+/** Build a `window` `message` listener that dispatches through `handlers` for messages from `iframe`. */
+function createIframeMessageListener(
+  iframe: HTMLIFrameElement,
+  handlers: Record<string, BridgeMessageHandler>
+): (event: MessageEvent) => void {
+  return (event: MessageEvent) => {
+    if (event.source !== iframe.contentWindow) return;
+    const msg = event.data as SprinkleInboundMessage | undefined;
+    if (!msg?.type) return;
+    handlers[msg.type]?.(iframe, msg);
+  };
+}
+
+/** Lazily load custom-element bundles a CLI-inline sprinkle's markup references. */
+function lazyLoadInlineCustomElements(content: string): void {
+  if (content.includes('<slicc-editor') && !customElements.get('slicc-editor')) {
+    void import('./slicc-editor.js');
+  }
+  if (content.includes('<slicc-diff') && !customElements.get('slicc-diff')) {
+    // Load via script tag (not Vite import) so the IIFE bundle includes
+    // @pierre/diffs' web-components.js which isn't in the package exports map.
+    const s = document.createElement('script');
+    s.src = '/slicc-diff.js';
+    document.head.appendChild(s);
+  }
+}
+
+/** Auto-set width on `.fill[data-value]` elements from their `data-value` attribute. */
+function applyFillWidths(wrapper: HTMLElement): void {
+  for (const fill of wrapper.querySelectorAll<HTMLElement>('.fill[data-value]')) {
+    const v = parseFloat(fill.dataset.value || '0');
+    if (v >= 0 && v <= 100) fill.style.width = `${v}%`;
+  }
+}
+
+/**
+ * Rewrite onclick `slicc`/`bridge` references to the sprinkle-specific bridge
+ * global, so multiple inline sprinkles on one page don't collide on a shared
+ * `window.slicc`. Returns the bridge expression, reused by script revival.
+ */
+function rewriteOnclickBridgeReferences(wrapper: HTMLElement, sprinkleName: string): string {
+  const bridgeExpr = `window.__slicc_sprinkles[${JSON.stringify(sprinkleName)}]`;
+  for (const el of wrapper.querySelectorAll('[onclick]')) {
+    const attr = el.getAttribute('onclick') || '';
+    if (/\b(slicc|bridge)\b/.test(attr)) {
+      el.setAttribute('onclick', attr.replace(/\b(slicc|bridge)\b/g, bridgeExpr));
+    }
+  }
+  return bridgeExpr;
+}
+
+/** Function names an onclick handler calls, excluding known bridge methods. */
+function collectOnclickFunctionNames(wrapper: HTMLElement): Set<string> {
+  const names = new Set<string>();
+  for (const el of wrapper.querySelectorAll('[onclick]')) {
+    const attr = el.getAttribute('onclick') || '';
+    for (const m of attr.matchAll(/\b(\w+)\s*\(/g)) {
+      const name = m[1];
+      if (!['slicc', 'bridge', 'lick', 'close', 'exec', 'agent'].includes(name)) names.add(name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Extract `<script>` tags from `wrapper` and re-create them as live elements
+ * (scripts set via `innerHTML` never execute). Non-`src` scripts are wrapped
+ * in an IIFE binding `slicc`/`bridge` to this sprinkle's bridge instance, and
+ * any onclick-referenced function they define is hoisted onto `window` so
+ * inline `onclick="fn()"` handlers can still find it.
+ */
+function reviveInlineScripts(wrapper: HTMLElement, bridgeExpr: string): HTMLScriptElement[] {
+  const live: HTMLScriptElement[] = [];
+  for (const dead of Array.from(wrapper.querySelectorAll('script'))) {
+    dead.remove();
+    const script = document.createElement('script');
+    for (const attr of dead.attributes) {
+      script.setAttribute(attr.name, attr.value);
+    }
+    if (!dead.src) {
+      const hoists = [...collectOnclickFunctionNames(wrapper)]
+        .map((fn) => `if (typeof ${fn} === 'function') window.${fn} = ${fn};`)
+        .join('\n');
+      script.textContent =
+        `(function() { var slicc = ${bridgeExpr}; var bridge = slicc;\n` +
+        dead.textContent +
+        (hoists ? '\n' + hoists : '') +
+        '\n})();';
+    }
+    wrapper.appendChild(script);
+    live.push(script);
+  }
+  return live;
+}
+
 export class SprinkleRenderer {
   private container: HTMLElement;
   private bridge: SprinkleBridgeAPI;
@@ -167,274 +435,51 @@ export class SprinkleRenderer {
       this.container.appendChild(iframe);
     });
 
-    // Listen for messages from the sandbox
-    this.messageHandler = (event: MessageEvent) => {
-      // Only accept messages from our iframe
-      if (event.source !== iframe.contentWindow) return;
-      const msg = event.data;
-      if (!msg?.type) return;
-
-      if (msg.type === 'sprinkle-lick') {
-        this.bridge.lick({ action: msg.action, data: msg.data });
-      } else if (msg.type === 'sprinkle-set-state') {
-        this.bridge.setState(msg.data);
-      } else if (msg.type === 'sprinkle-close') {
-        this.bridge.close();
-      } else if (msg.type === 'sprinkle-minimize') {
-        this.bridge.minimize();
-      } else if (msg.type === 'sprinkle-stop-cone') {
-        this.bridge.stopCone();
-      } else if (msg.type === 'sprinkle-storage-set') {
+    // Listen for messages from the sandbox — the shared handlers plus the
+    // sandbox-only extras (localStorage proxying, `sprinkle-open`, and
+    // `sprinkle-fetch-script`, none of which the full-doc bridge script sends).
+    this.messageHandler = createIframeMessageListener(iframe, {
+      ...createSharedBridgeHandlers(this.bridge),
+      'sprinkle-storage-set': (_iframe, msg) => {
         try {
-          localStorage.setItem(`slicc-sprinkle-ls:${sprinkleName}:${msg.key}`, msg.value);
+          localStorage.setItem(`slicc-sprinkle-ls:${sprinkleName}:${msg.key}`, msg.value as string);
         } catch (e) {
           console.warn('[sprinkle-renderer] localStorage setItem failed:', msg.key, e);
         }
-      } else if (msg.type === 'sprinkle-storage-remove') {
+      },
+      'sprinkle-storage-remove': (_iframe, msg) => {
         try {
           localStorage.removeItem(`slicc-sprinkle-ls:${sprinkleName}:${msg.key}`);
         } catch (e) {
           console.warn('[sprinkle-renderer] localStorage removeItem failed:', msg.key, e);
         }
-      } else if (msg.type === 'sprinkle-storage-clear') {
+      },
+      'sprinkle-storage-clear': () => {
         const prefix = `slicc-sprinkle-ls:${sprinkleName}:`;
         for (let i = localStorage.length - 1; i >= 0; i--) {
           const k = localStorage.key(i);
           if (k?.startsWith(prefix)) localStorage.removeItem(k);
         }
-      } else if (msg.type === 'sprinkle-attach-image') {
-        this.bridge.attachImage(msg.base64, msg.name, msg.mimeType);
-      } else if (msg.type === 'sprinkle-open') {
-        this.bridge.open(msg.path, msg.projectRoot ? { projectRoot: msg.projectRoot } : undefined);
-      } else if (msg.type === 'sprinkle-readfile') {
-        this.bridge.readFile(msg.path).then(
-          (fileContent) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-readfile-response', id: msg.id, content: fileContent },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-readfile-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-writefile') {
-        this.bridge.writeFile(msg.path, msg.content).then(
-          () =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-writefile-response', id: msg.id },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-writefile-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-readdir') {
-        this.bridge.readDir(msg.path).then(
-          (entries) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-readdir-response', id: msg.id, entries },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-readdir-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-exists') {
-        this.bridge.exists(msg.path).then(
-          (exists) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-exists-response', id: msg.id, exists },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-exists-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-stat') {
-        this.bridge.stat(msg.path).then(
-          (stat) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-stat-response', id: msg.id, stat },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-stat-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-mkdir') {
-        this.bridge.mkdir(msg.path).then(
-          () =>
-            iframe.contentWindow?.postMessage({ type: 'sprinkle-mkdir-response', id: msg.id }, '*'),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-mkdir-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-rm') {
-        this.bridge.rm(msg.path).then(
-          () =>
-            iframe.contentWindow?.postMessage({ type: 'sprinkle-rm-response', id: msg.id }, '*'),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-rm-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-capture-screen') {
-        this.bridge.captureScreen().then(
-          (result) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-capture-screen-response',
-                id: msg.id,
-                base64: result.base64,
-                width: result.width,
-                height: result.height,
-                mimeType: result.mimeType,
-              },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-capture-screen-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-exec') {
-        this.bridge.exec(msg.cmd).then(
-          (result) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-exec-response', id: msg.id, result },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-exec-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-agent') {
-        this.bridge.agent(msg.prompt, msg.opts).then(
-          (result) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-agent-response', id: msg.id, result },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-agent-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-jsh') {
-        this.bridge._jsh(msg.op, msg.args).then(
-          (result) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-jsh-response', id: msg.id, result },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-jsh-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-device-op') {
-        this.bridge._device(msg.channel, msg.op, msg.args ?? []).then(
-          (result) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-device-op-response', id: msg.id, result },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-device-op-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-fetch-script') {
+      },
+      'sprinkle-open': (_iframe, msg) =>
+        this.bridge.open(
+          msg.path as string,
+          msg.projectRoot ? { projectRoot: msg.projectRoot as string } : undefined
+        ),
+      'sprinkle-fetch-script': (iframe, msg) => {
         const url = msg.url as string;
         const id = msg.id as string;
         fetch(url)
           .then((r) => (r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`))))
-          .then((text) => {
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-fetch-script-response', id, url, text },
-              '*'
-            );
-          })
-          .catch((err: unknown) => {
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-fetch-script-response',
-                id,
-                url,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            );
-          });
-      }
-    };
+          .then((text) => postToIframe(iframe, 'sprinkle-fetch-script-response', id, { url, text }))
+          .catch((err: unknown) =>
+            postToIframe(iframe, 'sprinkle-fetch-script-response', id, {
+              url,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          );
+      },
+    });
     window.addEventListener('message', this.messageHandler);
 
     const themeCSS = this.collectThemeCSS();
@@ -803,231 +848,14 @@ export class SprinkleRenderer {
       this.container.appendChild(iframe);
     });
 
-    // Listen for messages from the iframe
-    this.messageHandler = (event: MessageEvent) => {
-      if (event.source !== iframe.contentWindow) return;
-      const msg = event.data;
-      if (!msg?.type) return;
-
-      if (msg.type === 'sprinkle-lick') {
-        this.bridge.lick({ action: msg.action, data: msg.data });
-      } else if (msg.type === 'sprinkle-set-state') {
-        this.bridge.setState(msg.data);
-      } else if (msg.type === 'sprinkle-close') {
-        this.bridge.close();
-      } else if (msg.type === 'sprinkle-minimize') {
-        this.bridge.minimize();
-      } else if (msg.type === 'sprinkle-stop-cone') {
-        this.bridge.stopCone();
-      } else if (msg.type === 'sprinkle-attach-image') {
-        this.bridge.attachImage(msg.base64, msg.name, msg.mimeType);
-      } else if (msg.type === 'sprinkle-readfile') {
-        this.bridge.readFile(msg.path).then(
-          (fileContent) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-readfile-response', id: msg.id, content: fileContent },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-readfile-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-writefile') {
-        this.bridge.writeFile(msg.path, msg.content).then(
-          () =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-writefile-response', id: msg.id },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-writefile-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-readdir') {
-        this.bridge.readDir(msg.path).then(
-          (entries) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-readdir-response', id: msg.id, entries },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-readdir-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-exists') {
-        this.bridge.exists(msg.path).then(
-          (exists) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-exists-response', id: msg.id, exists },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-exists-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-stat') {
-        this.bridge.stat(msg.path).then(
-          (stat) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-stat-response', id: msg.id, stat },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-stat-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-mkdir') {
-        this.bridge.mkdir(msg.path).then(
-          () =>
-            iframe.contentWindow?.postMessage({ type: 'sprinkle-mkdir-response', id: msg.id }, '*'),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-mkdir-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-rm') {
-        this.bridge.rm(msg.path).then(
-          () =>
-            iframe.contentWindow?.postMessage({ type: 'sprinkle-rm-response', id: msg.id }, '*'),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-rm-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-capture-screen') {
-        this.bridge.captureScreen().then(
-          (result) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-capture-screen-response',
-                id: msg.id,
-                base64: result.base64,
-                width: result.width,
-                height: result.height,
-                mimeType: result.mimeType,
-              },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-capture-screen-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-exec') {
-        this.bridge.exec(msg.cmd).then(
-          (result) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-exec-response', id: msg.id, result },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-exec-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-agent') {
-        this.bridge.agent(msg.prompt, msg.opts).then(
-          (result) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-agent-response', id: msg.id, result },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-agent-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-jsh') {
-        this.bridge._jsh(msg.op, msg.args).then(
-          (result) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-jsh-response', id: msg.id, result },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-jsh-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      } else if (msg.type === 'sprinkle-device-op') {
-        this.bridge._device(msg.channel, msg.op, msg.args ?? []).then(
-          (result) =>
-            iframe.contentWindow?.postMessage(
-              { type: 'sprinkle-device-op-response', id: msg.id, result },
-              '*'
-            ),
-          (err: unknown) =>
-            iframe.contentWindow?.postMessage(
-              {
-                type: 'sprinkle-device-op-response',
-                id: msg.id,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              '*'
-            )
-        );
-      }
-    };
+    // Listen for messages from the iframe — the full-doc bridge script only
+    // sends the shared VFS/exec/device/lifecycle messages (no localStorage
+    // proxying, `sprinkle-open`, or `sprinkle-fetch-script` — those are
+    // sandbox-only, injected via extension-runtime-only script tags).
+    this.messageHandler = createIframeMessageListener(
+      iframe,
+      createSharedBridgeHandlers(this.bridge)
+    );
     window.addEventListener('message', this.messageHandler);
   }
 
@@ -1035,17 +863,7 @@ export class SprinkleRenderer {
    * CLI mode: render directly in the page DOM (no CSP restrictions).
    */
   private renderInline(content: string, sprinkleName: string): void {
-    // Lazy-load the <slicc-editor> custom element when a sprinkle uses it
-    if (content.includes('<slicc-editor') && !customElements.get('slicc-editor')) {
-      void import('./slicc-editor.js');
-    }
-    if (content.includes('<slicc-diff') && !customElements.get('slicc-diff')) {
-      // Load via script tag (not Vite import) so the IIFE bundle includes
-      // @pierre/diffs' web-components.js which isn't in the package exports map.
-      const s = document.createElement('script');
-      s.src = '/slicc-diff.js';
-      document.head.appendChild(s);
-    }
+    lazyLoadInlineCustomElements(content);
 
     // Ensure the global sprinkle registry exists
     if (!window.__slicc_sprinkles) window.__slicc_sprinkles = {};
@@ -1061,52 +879,9 @@ export class SprinkleRenderer {
     wrapper.innerHTML = content;
     this.container.appendChild(wrapper);
 
-    // Auto-set width on .fill elements from data-value attribute
-    for (const fill of wrapper.querySelectorAll<HTMLElement>('.fill[data-value]')) {
-      const v = parseFloat(fill.dataset.value || '0');
-      if (v >= 0 && v <= 100) fill.style.width = `${v}%`;
-    }
-
-    // Rewrite onclick `slicc` or `bridge` references to use the sprinkle-specific bridge.
-    const bridgeExpr = `window.__slicc_sprinkles[${JSON.stringify(sprinkleName)}]`;
-    for (const el of wrapper.querySelectorAll('[onclick]')) {
-      const attr = el.getAttribute('onclick') || '';
-      if (/\b(slicc|bridge)\b/.test(attr)) {
-        el.setAttribute('onclick', attr.replace(/\b(slicc|bridge)\b/g, bridgeExpr));
-      }
-    }
-
-    // Extract <script> tags and re-create them as live elements.
-    const deadScripts = Array.from(wrapper.querySelectorAll('script'));
-    for (const dead of deadScripts) {
-      dead.remove();
-      const live = document.createElement('script');
-      for (const attr of dead.attributes) {
-        live.setAttribute(attr.name, attr.value);
-      }
-      if (!dead.src) {
-        const onclickFns = new Set<string>();
-        for (const el of wrapper.querySelectorAll('[onclick]')) {
-          const attr = el.getAttribute('onclick') || '';
-          for (const m of attr.matchAll(/\b(\w+)\s*\(/g)) {
-            const name = m[1];
-            if (!['slicc', 'bridge', 'lick', 'close', 'exec', 'agent'].includes(name))
-              onclickFns.add(name);
-          }
-        }
-        const hoists = [...onclickFns]
-          .map((fn) => `if (typeof ${fn} === 'function') window.${fn} = ${fn};`)
-          .join('\n');
-
-        live.textContent =
-          `(function() { var slicc = ${bridgeExpr}; var bridge = slicc;\n` +
-          dead.textContent +
-          (hoists ? '\n' + hoists : '') +
-          '\n})();';
-      }
-      wrapper.appendChild(live);
-      this.scripts.push(live);
-    }
+    applyFillWidths(wrapper);
+    const bridgeExpr = rewriteOnclickBridgeReferences(wrapper, sprinkleName);
+    this.scripts = reviveInlineScripts(wrapper, bridgeExpr);
   }
 
   /** Clean up scripts and content. */

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -435,6 +435,48 @@ describe('full document rendering', () => {
     expect(container.querySelector('iframe')).toBeNull();
   });
 
+  it('nudges the iframe repaint when the page itself is framed (cherry)', async () => {
+    // Simulate the cherry follower: this page is embedded in another frame,
+    // so `window.self !== window.top`. jsdom's `top` getter isn't
+    // configurable, so override `self` instead — the source checks equality
+    // between the two either way.
+    (dom.window as any).self = {};
+    const rafCallbacks: Array<() => void> = [];
+    const originalRaf = (globalThis as any).requestAnimationFrame;
+    (globalThis as any).requestAnimationFrame = (cb: () => void) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    };
+
+    const bridge = makeBridge('full-doc');
+    const renderer = new SprinkleRenderer(container, bridge);
+    const html = '<!DOCTYPE html><html><head></head><body>Hi</body></html>';
+    await renderer.render(html, 'full-doc');
+
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe).toBeTruthy();
+    // The repaint nudge hides the iframe immediately after load...
+    expect(iframe.style.display).toBe('none');
+    expect(rafCallbacks.length).toBe(1);
+    // ...then restores it across two animation frames.
+    rafCallbacks.shift()!();
+    expect(rafCallbacks.length).toBe(1);
+    rafCallbacks.shift()!();
+    expect(iframe.style.display).toBe('');
+
+    (globalThis as any).requestAnimationFrame = originalRaf;
+  });
+
+  it('does not nudge the iframe repaint when the page is top-level (standalone follower)', async () => {
+    const bridge = makeBridge('full-doc');
+    const renderer = new SprinkleRenderer(container, bridge);
+    const html = '<!DOCTYPE html><html><head></head><body>Hi</body></html>';
+    await renderer.render(html, 'full-doc');
+
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe.style.display).not.toBe('none');
+  });
+
   it('handles sprinkle-capture-screen message and posts response', async () => {
     const bridge = makeBridge('full-doc');
     (bridge.captureScreen as ReturnType<typeof vi.fn>).mockResolvedValue({


### PR DESCRIPTION
Sprinkles render into their own srcdoc iframe, which sits one level deeper when the app itself is embedded (cherry follower) than in a top-level float. Chromium sometimes never rasterizes that innermost iframe on first load in this nested configuration, leaving the panel blank until something forces a full frame-tree repaint (opening DevTools, or reloading). Toggle the iframe's display off/on across two animation frames after load to force the missing repaint ourselves, scoped to when the page is actually framed.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
