### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -3,7 +3,7 @@
   "typescript": {
     "cloudflare-worker": {
       "lines": 83,
-      "statements": 82,
+      "statements": 83,
       "functions": 92,
       "branches": 71,
       "coverageExclude": [
@@ -73,7 +73,7 @@
       "lines": 72,
       "statements": 71,
       "functions": 88,
-      "branches": 50
+      "branches": 51
     },
     "cloud-core": {
       "lines": 80,


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.