### PR TITLE
fix(webapp,cherry): follower tool_ui placeholder + cherry origin normalization

### DIFF
--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -25,6 +25,13 @@ type MountSliccImplOptions = MountSliccOptions & {
 export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandle {
   const iframe = document.createElement('iframe');
   const src = new URL(options.sliccOrigin);
+  // Normalize to the bare origin (drops any trailing slash / path / query the
+  // caller passed in `sliccOrigin`, e.g. "http://localhost:8787/"). This must
+  // match `MessageEvent.origin` on inbound postMessages, which browsers NEVER
+  // report with a trailing slash — using the raw string here made the
+  // `acceptEnvelope` allowlist check fail silently on a trailing slash,
+  // surfacing only as an opaque 30s handshake timeout.
+  const sliccOrigin = src.origin;
   src.searchParams.set('cherry', '1');
   iframe.src = src.toString();
   iframe.style.border = '0';
@@ -43,7 +50,7 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
       options.__test_post(env);
       return;
     }
-    iframe.contentWindow?.postMessage(env, options.sliccOrigin);
+    iframe.contentWindow?.postMessage(env, sliccOrigin);
   };
 
   const dispatchCdp = async (
@@ -137,7 +144,7 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
   const onMessage = (event: MessageEvent) => {
     if (
       !acceptEnvelope(event, {
-        allowOrigins: [options.sliccOrigin],
+        allowOrigins: [sliccOrigin],
         expectedSource: iframe.contentWindow,
         channelId,
       })
@@ -149,7 +156,7 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
       if (isCherryEnvelope(event.data)) {
         console.warn('[cherry] rejected a cherry envelope (origin/source/channel mismatch)', {
           origin: event.origin,
-          expectedOrigin: options.sliccOrigin,
+          expectedOrigin: sliccOrigin,
         });
       }
       return;

--- a/packages/cherry/tests/mount.test.ts
+++ b/packages/cherry/tests/mount.test.ts
@@ -218,6 +218,60 @@ describe('mountSliccImpl', () => {
     handle.destroy();
   });
 
+  it('normalizes a trailing-slash sliccOrigin to the bare origin for postMessage targeting', async () => {
+    const container = document.createElement('div');
+    const posted: { kind?: string; channelId?: string }[] = [];
+    const handle = mountSliccImpl({
+      container,
+      // A trailing slash is a common copy-paste mistake — MessageEvent.origin
+      // never carries one, so using the raw string here would make every
+      // postMessage silently rejected by the follower's acceptEnvelope gate.
+      sliccOrigin: 'https://app.example/',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      joinToken: 'https://app.example/join?t=X',
+      __test_post: (env) => posted.push(env as never),
+    });
+    const iframe = container.querySelector('iframe')!;
+    expect(iframe.src).toBe('https://app.example/?cherry=1');
+    await handle.__test_receive({
+      cherry: 1,
+      channelId: 'ch-slash',
+      kind: 'handshake.hello',
+    } as never);
+    expect(posted.some((e) => e.kind === 'handshake.welcome')).toBe(true);
+    handle.destroy();
+  });
+
+  it('accepts an inbound envelope whose event.origin matches the bare (slash-stripped) sliccOrigin', async () => {
+    const container = document.createElement('div');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onHandshakeComplete = vi.fn();
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example/',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      hooks: { onHandshakeComplete },
+      joinToken: 'https://app.example/join?t=X',
+    });
+    const iframe = container.querySelector('iframe')!;
+    // Real MessageEvent.origin values never carry a trailing slash. Before
+    // normalizing sliccOrigin, the allowlist held 'https://app.example/' and
+    // rejected every real postMessage as an origin mismatch — logging the
+    // warning below and leaving the handshake hanging (a 30s timeout
+    // downstream) instead of firing onHandshakeComplete.
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { cherry: 1, channelId: 'ch-real', kind: 'handshake.hello' },
+        origin: 'https://app.example',
+        source: iframe.contentWindow,
+      })
+    );
+    await vi.waitFor(() => expect(onHandshakeComplete).toHaveBeenCalledTimes(1));
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+    handle.destroy();
+  });
+
   it('emitHostEvent drops (with a warning) before the handshake completes', () => {
     const container = document.createElement('div');
     const posted: unknown[] = [];

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -111,10 +111,70 @@ export interface WcChatControllerOptions {
    * worker-side mount backend can fail fast when no panel is listening.
    */
   onToolUiAction?: (requestId: string, action: string, data?: unknown) => void;
+  /**
+   * True for tray followers (including cherry): the follower has no
+   * `onToolUiAction` wiring and no mounted permissions surface, so an
+   * agent-driven `tool_ui` card (mount/USB/serial/HID approval) broadcast
+   * from the leader can never be acted on here — clicking its buttons
+   * would silently no-op. When set, `#handleToolUI` renders a static,
+   * non-interactive "waiting for approval on the leader" card instead of
+   * mounting the live dip.
+   */
+  readOnlyToolUi?: boolean;
 }
 
 function uid(): string {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Pull the human-readable title out of a `buildApprovalCardHtml` card
+ * (`picker-approval.ts`) — e.g. "Mount local directory" — so the follower
+ * placeholder can name what's pending without importing the picker-kind
+ * text table. Falls back to a generic label if the header can't be found
+ * (defensive: any tool_ui card, not just picker-approval, could arrive).
+ */
+function extractToolUiTitle(html: string): string {
+  try {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const header = doc.querySelector('.sprinkle-action-card__header');
+    if (header) {
+      // Strip the trailing "approval" badge text, keep just the title.
+      const badge = header.querySelector('.sprinkle-badge');
+      badge?.remove();
+      const title = header.textContent?.trim();
+      if (title) return title;
+    }
+  } catch {
+    /* malformed html — fall through to the generic label */
+  }
+  return 'Approval requested';
+}
+
+/** Escape text for safe interpolation into an HTML string. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Static, non-interactive placeholder shown to a tray follower in place of
+ * a cone-driven `tool_ui` approval card (mount/USB/serial/HID). Followers
+ * have no `onToolUiAction` wiring and no mounted permissions surface —
+ * clicking Deny/Approve here would silently no-op — so this renders plain
+ * status text instead of live buttons.
+ */
+function buildReadOnlyToolUiHtml(html: string): string {
+  const title = escapeHtml(extractToolUiTitle(html));
+  return `
+    <div class="sprinkle-action-card">
+      <div class="sprinkle-action-card__header">${title} <span class="sprinkle-badge sprinkle-badge--informative">pending</span></div>
+      <div class="sprinkle-action-card__body">Waiting for approval on the leader&hellip;</div>
+    </div>
+  `;
 }
 
 /** Project a queued `ChatMessage` onto the host-render shape. */
@@ -136,6 +196,7 @@ export class WcChatController {
   readonly #onQueuedChange?: (items: readonly QueuedMessageView[]) => void;
   readonly #onQueuedCancel?: (messageId: string) => void;
   readonly #onToolUiAction?: (requestId: string, action: string, data?: unknown) => void;
+  readonly #readOnlyToolUi: boolean;
   #unsubscribe: () => void;
   #onLocalUserMessage?: (
     text: string,
@@ -204,6 +265,7 @@ export class WcChatController {
     this.#onQueuedChange = options.onQueuedChange;
     this.#onQueuedCancel = options.onQueuedCancel;
     this.#onToolUiAction = options.onToolUiAction;
+    this.#readOnlyToolUi = options.readOnlyToolUi ?? false;
     this.#unsubscribe = options.agent.onEvent((event) => this.#handleAgentEvent(event));
     // Bubbled retry event from any rendered `slicc-error-card` (composed, so it
     // pierces shadow roots). One listener at the thread covers every error card.
@@ -799,6 +861,13 @@ export class WcChatController {
    * realm's `toolUIRegistry.handleAction` runs; a reserved
    * {@link TOOL_UI_MOUNTED_ACTION} ack fires immediately after mount so
    * the worker-side mount backend can fail fast if no panel was listening.
+   *
+   * On a tray follower ({@link WcChatControllerOptions.readOnlyToolUi}) the
+   * card is broadcast from the leader purely for visibility — this instance
+   * has no `onToolUiAction` and no mounted permissions surface, so the real
+   * buttons would silently no-op. Render a static "waiting on the leader"
+   * placeholder instead, and skip the mount ack (the leader's OWN card is
+   * what the worker-side mount backend is waiting on).
    */
   #handleToolUI(_messageId: string, requestId: string, html: string): void {
     // Defensive: a re-entrant tool_ui for the same id replaces the
@@ -809,6 +878,11 @@ export class WcChatController {
     container.setAttribute('data-tool-ui-request', requestId);
     const inner = (this.#thread as { inner?: HTMLElement }).inner ?? this.#thread;
     inner.append(container);
+    if (this.#readOnlyToolUi) {
+      const instance = mountDip(container, buildReadOnlyToolUiHtml(html), () => {}, false);
+      this.#toolUiDips.set(requestId, { instance, container });
+      return;
+    }
     const instance = mountDip(
       container,
       html,

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -229,6 +229,11 @@ export async function mountWcUiFollower(
     onQueuedChange: (items) => {
       boot.refs.queuedStack.setMessages(items);
     },
+    // A follower has no onToolUiAction wiring and no mounted permissions
+    // surface (installLeaderPermissionsSurface never runs here) — a
+    // leader-broadcast tool_ui card's buttons would silently no-op. Render
+    // the static "waiting on the leader" placeholder instead.
+    readOnlyToolUi: true,
   });
   boot.setController(controller);
 

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -1194,3 +1194,89 @@ describe('WcChatController render-failure degradation', () => {
     expect(completed).toEqual([null]);
   });
 });
+
+describe('WcChatController readOnlyToolUi (tray follower tool_ui rendering)', () => {
+  // Mirrors buildApprovalCardHtml('directory') from picker-approval.ts —
+  // the real card the mount tool broadcasts to followers via `tool_ui`.
+  const MOUNT_APPROVAL_HTML = `
+    <div class="sprinkle-action-card">
+      <div class="sprinkle-action-card__header">Mount local directory <span class="sprinkle-badge sprinkle-badge--notice">approval</span></div>
+      <div class="sprinkle-action-card__actions">
+        <button class="sprinkle-btn sprinkle-btn--secondary" data-action="deny">Deny</button>
+        <button class="sprinkle-btn sprinkle-btn--primary" data-action="approve" data-picker="directory">Select directory</button>
+      </div>
+    </div>
+  `;
+
+  it('renders the interactive card with live buttons when readOnlyToolUi is unset (leader/standalone)', () => {
+    installWcDomStubs();
+    const thread = document.createElement('slicc-chat-thread');
+    document.body.appendChild(thread);
+    const agent = new FakeAgent();
+    const controller = new WcChatController({ thread, agent });
+
+    agent.emit({
+      type: 'tool_ui',
+      messageId: 'm1',
+      toolName: 'bash',
+      requestId: 'req-1',
+      html: MOUNT_APPROVAL_HTML,
+    });
+
+    const iframe = thread.querySelector<HTMLIFrameElement>('[data-tool-ui-request="req-1"] iframe');
+    expect(iframe?.srcdoc).toContain('data-action="approve"');
+    expect(iframe?.srcdoc).toContain('Select directory');
+  });
+
+  it('renders a static, non-interactive "waiting on the leader" placeholder when readOnlyToolUi is set', () => {
+    installWcDomStubs();
+    const thread = document.createElement('slicc-chat-thread');
+    document.body.appendChild(thread);
+    const agent = new FakeAgent();
+    const onToolUiAction = vi.fn();
+    const controller = new WcChatController({
+      thread,
+      agent,
+      onToolUiAction,
+      readOnlyToolUi: true,
+    });
+
+    agent.emit({
+      type: 'tool_ui',
+      messageId: 'm1',
+      toolName: 'bash',
+      requestId: 'req-1',
+      html: MOUNT_APPROVAL_HTML,
+    });
+
+    const container = thread.querySelector<HTMLElement>('[data-tool-ui-request="req-1"]');
+    const iframe = container?.querySelector('iframe');
+    expect(iframe?.srcdoc).toContain('Mount local directory');
+    expect(iframe?.srcdoc).toContain('Waiting for approval on the leader');
+    // No live buttons and no mount ack — a follower click could never
+    // resolve the leader's own pending approval anyway.
+    expect(iframe?.srcdoc).not.toContain('data-action="approve"');
+    expect(iframe?.srcdoc).not.toContain('data-action="deny"');
+    expect(onToolUiAction).not.toHaveBeenCalled();
+  });
+
+  it('disposes the placeholder on tool_ui_done, same as the interactive card', () => {
+    installWcDomStubs();
+    const thread = document.createElement('slicc-chat-thread');
+    document.body.appendChild(thread);
+    const agent = new FakeAgent();
+    const controller = new WcChatController({ thread, agent, readOnlyToolUi: true });
+
+    agent.emit({
+      type: 'tool_ui',
+      messageId: 'm1',
+      toolName: 'bash',
+      requestId: 'req-1',
+      html: MOUNT_APPROVAL_HTML,
+    });
+    expect(thread.querySelector('[data-tool-ui-request="req-1"]')).toBeTruthy();
+
+    agent.emit({ type: 'tool_ui_done', messageId: 'm1', requestId: 'req-1' });
+    expect(thread.querySelector('[data-tool-ui-request="req-1"]')).toBeNull();
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -103,6 +103,47 @@ describe('mountWcUiFollower', () => {
     expect(attachments[0]!.path).toBeUndefined();
   });
 
+  it('renders a leader-broadcast tool_ui approval card as a static "waiting on the leader" placeholder, not live buttons', async () => {
+    const { mountWcUiFollower } = await import('../../../src/ui/wc/wc-follower.js');
+    const app = document.getElementById('app')!;
+    await mountWcUiFollower(app, { stage: () => {} } as never, 'follower');
+
+    // Simulate the WebRTC channel connecting: the tray installs the real
+    // follower-sync agent, which relays the leader's `agent_event` (including
+    // `tool_ui`) via onEvent.
+    const opts = startFollowerSpy.mock.calls[0]![0];
+    let emit: ((event: unknown) => void) | undefined;
+    opts.setChatAgent?.({
+      sendMessage: () => {},
+      onEvent: (cb: (event: unknown) => void) => {
+        emit = cb;
+        return () => {};
+      },
+      stop: () => {},
+    });
+
+    emit?.({
+      type: 'tool_ui',
+      messageId: 'm1',
+      toolName: 'bash',
+      requestId: 'req-1',
+      html: `<div class="sprinkle-action-card">
+        <div class="sprinkle-action-card__header">Mount local directory <span class="sprinkle-badge sprinkle-badge--notice">approval</span></div>
+        <div class="sprinkle-action-card__actions">
+          <button class="sprinkle-btn sprinkle-btn--secondary" data-action="deny">Deny</button>
+          <button class="sprinkle-btn sprinkle-btn--primary" data-action="approve" data-picker="directory">Select directory</button>
+        </div>
+      </div>`,
+    });
+
+    const container = app.querySelector('[data-tool-ui-request="req-1"]');
+    const iframe = container?.querySelector('iframe');
+    expect(iframe?.srcdoc).toContain('Mount local directory');
+    expect(iframe?.srcdoc).toContain('Waiting for approval on the leader');
+    expect(iframe?.srcdoc).not.toContain('data-action="approve"');
+    expect(iframe?.srcdoc).not.toContain('data-action="deny"');
+  });
+
   it('replaces the inert Files/Terminal/Memory panels with a placeholder (no local VFS/shell)', async () => {
     const { mountWcUiFollower } = await import('../../../src/ui/wc/wc-follower.js');
     const app = document.getElementById('app')!;


### PR DESCRIPTION
## Summary
- Tray followers (including Cherry) were rendering the leader's `tool_ui` approval cards (mount/USB/serial/HID) as live interactive buttons, but the follower has no `onToolUiAction` wiring and no mounted permissions surface — clicking Deny/Approve silently no-oped. `WcChatController` now renders a static "Waiting for approval on the leader…" placeholder for followers via a new `readOnlyToolUi` option, which `wc-follower.ts` always sets.
- `@ai-ecoverse/cherry`'s `mountSliccImpl` used the raw `sliccOrigin` string (which can carry a trailing slash, e.g. `http://localhost:8787/`) for `postMessage` targeting and the `acceptEnvelope` origin allowlist. A real `MessageEvent.origin` never carries a trailing slash, so a trailing-slash `sliccOrigin` silently failed the allowlist check on every message — manifesting only as an opaque 30s handshake timeout. Now normalized via `URL.origin` once and reused everywhere.

## Test plan
- [x] `npx vitest run` — 601 test files / 9985 tests pass (15 pre-existing skips, unrelated)
- [x] `npm run typecheck` — all 8 tsc targets pass, including `packages/cherry`
- [x] `npm run lint` — biome/prettier/docs/skills/no-innerhtml/no-ui-in-providers/patches all clean
- [x] `npm run test:coverage:webapp` / `test:coverage:cherry` — both pass their floors
- [x] New regression tests added for both fixes (verified they fail without the fix, pass with it):
  - `wc-chat-controller.test.ts`: interactive vs read-only rendering, no-op action callback, disposal on `tool_ui_done`
  - `wc-follower.test.ts`: end-to-end leader-broadcast → follower placeholder render
  - `cherry/tests/mount.test.ts`: trailing-slash origin normalizes for outbound postMessage/iframe src, and a real (slash-less) `MessageEvent.origin` is accepted
- [x] Manually verified in a local leader/follower + Cherry harness setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)