### PR TITLE
fix: GitHub oauth-token login silently fails in thin-bridge mode

### DIFF
--- a/packages/node-server/src/routes/oauth-callback.ts
+++ b/packages/node-server/src/routes/oauth-callback.ts
@@ -35,7 +35,11 @@ export function registerOAuthCallbackRoutes(app: Express): void {
         token_type: h.get('token_type')
       };
       if (window.opener) {
-        try { window.opener.postMessage(payload, '*'); } catch (e) { /* opener may reject */ }
+        try {
+          window.opener.postMessage(payload, '*');
+        } catch (e) {
+          console.warn('[oauth-callback] postMessage to opener failed:', e);
+        }
       }
       fetch('/api/oauth-result', {
         method: 'POST',

--- a/packages/node-server/src/routes/oauth-callback.ts
+++ b/packages/node-server/src/routes/oauth-callback.ts
@@ -3,11 +3,18 @@ import express, { type Express, type Request, type Response } from 'express';
 /**
  * Generic OAuth redirect target for OAuth providers (implicit + PKCE).
  *
- * The callback page tries `window.opener.postMessage` first (works in the
- * CLI popup flow). When `window.opener` is null (Electron overlay opens the
- * system browser), it falls back to POSTing the result to
- * `/api/oauth-result`, which the UI polls via the GET counterpart — the
- * server holds the single pending result in memory between the two calls.
+ * The callback page always POSTs the result to `/api/oauth-result`, which
+ * the UI polls via the GET counterpart — the server holds the single
+ * pending result in memory between the two calls. It ALSO best-effort
+ * `window.opener.postMessage`s when an opener is present, as a faster
+ * same-origin shortcut. The POST must not be conditional on a missing
+ * opener: in the standalone thin-bridge float the UI is always loaded
+ * cross-origin from the local server (`node-server serves no UI in any
+ * mode`), so the popup's opener origin never matches `window.location.origin`
+ * on the receiving end and the message is silently dropped even when
+ * `window.opener` is non-null (e.g. GitHub, which does not sever it via
+ * COOP) — leaving the poll as the only path that can actually deliver the
+ * result.
  */
 export function registerOAuthCallbackRoutes(app: Express): void {
   // Pending OAuth result for server-side relay (Electron overlay can't use window.opener)
@@ -28,14 +35,13 @@ export function registerOAuthCallbackRoutes(app: Express): void {
         token_type: h.get('token_type')
       };
       if (window.opener) {
-        window.opener.postMessage(payload, '*');
-      } else {
-        fetch('/api/oauth-result', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        }).catch(function(err) { console.error('[oauth-callback] Failed to relay result to server:', err); });
+        try { window.opener.postMessage(payload, '*'); } catch (e) { /* opener may reject */ }
       }
+      fetch('/api/oauth-result', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      }).catch(function(err) { console.error('[oauth-callback] Failed to relay result to server:', err); });
       window.close();
     </script><p>Completing login... you can close this window.</p></body></html>`);
   });

--- a/packages/node-server/tests/routes/oauth-callback.test.ts
+++ b/packages/node-server/tests/routes/oauth-callback.test.ts
@@ -2,11 +2,17 @@
  * Coverage for the OAuth callback relay routes extracted from index.ts:
  * the HTML callback page plus the POST→GET pending-result handoff used by
  * the Electron overlay flow (where window.opener is unavailable) AND by
- * the worker-served thin-bridge SPA (where GitHub's `COOP: same-origin`
- * severs `window.opener`). The cross-origin round-trip is regression-
- * covered by the bridge-CORS integration block below.
+ * the worker-served thin-bridge SPA. The POST must fire unconditionally —
+ * GitHub does not send a `Cross-Origin-Opener-Policy` header, so
+ * `window.opener` stays intact there, and the page's postMessage would
+ * silently miss anyway (the receiving listener only accepts messages whose
+ * origin matches its own, which never holds cross-origin in thin-bridge
+ * mode). The cross-origin round-trip is regression-covered by the
+ * bridge-CORS integration block below; the script-execution block covers
+ * the branching itself.
  */
 
+import { runInNewContext } from 'node:vm';
 import type { NextFunction, Request, Response } from 'express';
 import express from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -136,6 +142,77 @@ describe('registerOAuthCallbackRoutes', () => {
     expect(warn).toHaveBeenCalled();
     const get = await fetch(base);
     expect(await get.json()).toEqual({ redirectUrl: '', error: 'access_denied' });
+  });
+
+  describe('callback script branching', () => {
+    /**
+     * Extract the inline `<script>` body from the served HTML and run it in
+     * a fresh VM context with stubbed browser globals, so the test exercises
+     * the ACTUAL branching logic rather than just the `/api/oauth-result`
+     * endpoint pair (which the "204/no-op" bug could still pass even while
+     * the script itself never called fetch).
+     */
+    function runCallbackScript(opener: { postMessage: (...args: unknown[]) => void } | null): {
+      fetchCalls: Array<{ url: string; body: unknown }>;
+      closed: boolean;
+      postMessageCalls: unknown[][];
+    } {
+      const html = SERVED_HTML;
+      const scriptMatch = html.match(/<script>([\s\S]*?)<\/script>/);
+      if (!scriptMatch) throw new Error('callback HTML has no <script> block');
+      const fetchCalls: Array<{ url: string; body: unknown }> = [];
+      const postMessageCalls: unknown[][] = [];
+      const sandbox = {
+        window: {
+          opener: opener
+            ? {
+                postMessage: (...args: unknown[]) => postMessageCalls.push(args),
+              }
+            : null,
+          close: () => {
+            sandbox.closed = true;
+          },
+        },
+        location: { search: '?code=abc123&state=xyz', hash: '' },
+        fetch: (url: string, init: { body: unknown }) => {
+          fetchCalls.push({ url, body: JSON.parse(init.body as string) });
+          return Promise.resolve({ ok: true });
+        },
+        URLSearchParams,
+        console: { error: () => {} },
+        closed: false,
+      };
+      runInNewContext(scriptMatch[1] as string, sandbox);
+      return { fetchCalls, closed: sandbox.closed, postMessageCalls };
+    }
+
+    let SERVED_HTML = '';
+
+    it('POSTs to /api/oauth-result even when window.opener is present (GitHub: no COOP)', async () => {
+      server = await startServer();
+      const res = await fetch(`http://localhost:${server.port}/auth/callback?code=abc`);
+      SERVED_HTML = await res.text();
+
+      const { fetchCalls, closed, postMessageCalls } = runCallbackScript({
+        postMessage: () => {},
+      });
+      expect(fetchCalls).toHaveLength(1);
+      expect(fetchCalls[0]?.url).toBe('/api/oauth-result');
+      expect(fetchCalls[0]?.body).toMatchObject({ type: 'oauth-callback', code: 'abc123' });
+      expect(postMessageCalls).toHaveLength(1);
+      expect(closed).toBe(true);
+    });
+
+    it('still POSTs when window.opener is null (Electron overlay)', async () => {
+      server = await startServer();
+      const res = await fetch(`http://localhost:${server.port}/auth/callback?code=abc`);
+      SERVED_HTML = await res.text();
+
+      const { fetchCalls, closed } = runCallbackScript(null);
+      expect(fetchCalls).toHaveLength(1);
+      expect(fetchCalls[0]?.url).toBe('/api/oauth-result');
+      expect(closed).toBe(true);
+    });
   });
 
   describe('cross-origin thin-bridge round-trip', () => {

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -497,7 +497,11 @@ private let oauthCallbackHTML = """
     token_type: h.get('token_type')
   };
   if (window.opener) {
-    try { window.opener.postMessage(payload, '*'); } catch (e) { /* opener may reject */ }
+    try {
+      window.opener.postMessage(payload, '*');
+    } catch (e) {
+      console.warn('[oauth-callback] postMessage to opener failed:', e);
+    }
   }
   fetch('/api/oauth-result', {
     method: 'POST',

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -497,14 +497,13 @@ private let oauthCallbackHTML = """
     token_type: h.get('token_type')
   };
   if (window.opener) {
-    window.opener.postMessage(payload, '*');
-  } else {
-    fetch('/api/oauth-result', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    }).catch(function(err) { console.error('[oauth-callback] Failed to relay result to server:', err); });
+    try { window.opener.postMessage(payload, '*'); } catch (e) { /* opener may reject */ }
   }
+  fetch('/api/oauth-result', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  }).catch(function(err) { console.error('[oauth-callback] Failed to relay result to server:', err); });
   window.close();
 </script><p>Completing login... you can close this window.</p></body></html>
 """

--- a/packages/swift-server/Tests/APIRoutesTests.swift
+++ b/packages/swift-server/Tests/APIRoutesTests.swift
@@ -136,6 +136,31 @@ final class APIRoutesTests: XCTestCase {
         }
     }
 
+    func testAuthCallbackAlwaysPostsResultRegardlessOfOpener() async throws {
+        // Regression: the callback script previously only POSTed to
+        // /api/oauth-result inside an `else` branch of `if (window.opener)`,
+        // relying on postMessage otherwise. GitHub does not send
+        // `Cross-Origin-Opener-Policy`, so `window.opener` stays intact
+        // there, and the thin-bridge receiving page only accepts
+        // same-origin postMessages (never true cross-origin) — so the POST
+        // must fire unconditionally, not just when opener is absent.
+        // Mirrors `packages/node-server/tests/routes/oauth-callback.test.ts`.
+        try await self.withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/auth/callback?code=abc", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    let html = String(buffer: response.body)
+                    XCTAssertTrue(html.contains("fetch('/api/oauth-result'"))
+                    XCTAssertFalse(html.contains("} else {"), "POST must not be gated behind an opener-absent branch")
+                }
+            }
+        }
+    }
+
     func testFetchProxyMissingTargetURLIsTaggedAsProxyError() async throws {
         // The proxy must mark its own infrastructure errors with X-Proxy-Error: 1
         // so SecureFetch clients can distinguish them from upstream 4xx/5xx

--- a/packages/swift-server/Tests/APIRoutesTests.swift
+++ b/packages/swift-server/Tests/APIRoutesTests.swift
@@ -159,30 +159,44 @@ final class APIRoutesTests: XCTestCase {
                         return
                     }
                     // Structural check robust to reformatting: the POST must not be
-                    // nested inside the `if (window.opener) { ... }` block. Find that
-                    // block's matching close brace by depth and assert the fetch call
-                    // occurs at or after it, rather than pattern-matching a specific
-                    // brace/else style that a linter pass could innocuously reshape.
+                    // nested inside `if (window.opener) { ... }` OR a trailing
+                    // `else { ... }` (both are equally conditional gates). Walk
+                    // brace depth to find the end of the if-body, then — if an
+                    // `else` immediately follows — walk its body too, so the
+                    // "safe" boundary is genuinely past the whole construct
+                    // rather than pattern-matching a specific brace/else style
+                    // a linter pass could innocuously reshape.
+                    func skipBraceBlock(from openBrace: String.Index) -> String.Index? {
+                        var depth = 1
+                        var idx = html.index(after: openBrace)
+                        while depth > 0 {
+                            guard idx < html.endIndex else { return nil }
+                            if html[idx] == "{" { depth += 1 }
+                            if html[idx] == "}" { depth -= 1 }
+                            idx = html.index(after: idx)
+                        }
+                        return idx
+                    }
                     guard let ifRange = html.range(of: "if (window.opener)"),
-                        let openBrace = html[ifRange.upperBound...].firstIndex(of: "{")
+                        let ifOpenBrace = html[ifRange.upperBound...].firstIndex(of: "{"),
+                        var boundary = skipBraceBlock(from: ifOpenBrace)
                     else {
-                        XCTFail("could not locate the `if (window.opener) {` block")
+                        XCTFail("could not locate/parse the `if (window.opener) { ... }` block")
                         return
                     }
-                    var depth = 1
-                    var idx = html.index(after: openBrace)
-                    while depth > 0 {
-                        guard idx < html.endIndex else {
-                            XCTFail("unbalanced braces in callback script")
+                    let afterIf = html[boundary...].drop(while: { $0 == " " || $0 == "\n" || $0 == "\t" })
+                    if afterIf.hasPrefix("else") {
+                        guard let elseOpenBrace = afterIf.firstIndex(of: "{"),
+                            let afterElse = skipBraceBlock(from: elseOpenBrace)
+                        else {
+                            XCTFail("could not parse the `else { ... }` block")
                             return
                         }
-                        if html[idx] == "{" { depth += 1 }
-                        if html[idx] == "}" { depth -= 1 }
-                        idx = html.index(after: idx)
+                        boundary = afterElse
                     }
                     XCTAssertTrue(
-                        fetchRange.lowerBound >= idx,
-                        "POST must not be gated behind an opener-absent branch"
+                        fetchRange.lowerBound >= boundary,
+                        "POST must not be gated behind either the opener or opener-absent branch"
                     )
                 }
             }

--- a/packages/swift-server/Tests/APIRoutesTests.swift
+++ b/packages/swift-server/Tests/APIRoutesTests.swift
@@ -154,8 +154,36 @@ final class APIRoutesTests: XCTestCase {
                 try await client.execute(uri: "/auth/callback?code=abc", method: .get) { response in
                     XCTAssertEqual(response.status, .ok)
                     let html = String(buffer: response.body)
-                    XCTAssertTrue(html.contains("fetch('/api/oauth-result'"))
-                    XCTAssertFalse(html.contains("} else {"), "POST must not be gated behind an opener-absent branch")
+                    guard let fetchRange = html.range(of: "fetch('/api/oauth-result'") else {
+                        XCTFail("callback script has no /api/oauth-result POST")
+                        return
+                    }
+                    // Structural check robust to reformatting: the POST must not be
+                    // nested inside the `if (window.opener) { ... }` block. Find that
+                    // block's matching close brace by depth and assert the fetch call
+                    // occurs at or after it, rather than pattern-matching a specific
+                    // brace/else style that a linter pass could innocuously reshape.
+                    guard let ifRange = html.range(of: "if (window.opener)"),
+                        let openBrace = html[ifRange.upperBound...].firstIndex(of: "{")
+                    else {
+                        XCTFail("could not locate the `if (window.opener) {` block")
+                        return
+                    }
+                    var depth = 1
+                    var idx = html.index(after: openBrace)
+                    while depth > 0 {
+                        guard idx < html.endIndex else {
+                            XCTFail("unbalanced braces in callback script")
+                            return
+                        }
+                        if html[idx] == "{" { depth += 1 }
+                        if html[idx] == "}" { depth -= 1 }
+                        idx = html.index(after: idx)
+                    }
+                    XCTAssertTrue(
+                        fetchRange.lowerBound >= idx,
+                        "POST must not be gated behind an opener-absent branch"
+                    )
                 }
             }
         }

--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -130,8 +130,11 @@ export function resolveGithubOAuthRedirect(opts: {
   }
   // Worker-served thin-bridge: SPA at `:8787` (wrangler) or hosted leader at
   // `www.sliccy.ai` with a local node-server bridge. Route the relay back to
-  // the bridge port (whose `/auth/callback` POSTs to `/api/oauth-result`) so
-  // GitHub's COOP-severed opener doesn't kill delivery.
+  // the bridge port (whose `/auth/callback` always POSTs the result to
+  // `/api/oauth-result`, which the SPA polls) — postMessage back to the SPA
+  // can't work here regardless of `window.opener` state, since the callback
+  // page's origin (the local node-server) never matches the SPA's own
+  // origin, and the receiving listener only accepts same-origin messages.
   if (bridgeApiBaseUrl && pageHref && isWorkerServedSpa(pageHref)) {
     let bridgePort: number | null = null;
     try {
@@ -434,7 +437,8 @@ export const config: ProviderConfig = {
       // worker (wrangler `:8787` / hosted leader) and a local node-server
       // bridge is configured, route the relay back to the bridge port so
       // its `/auth/callback` page can POST `?code` to its loopback
-      // `/api/oauth-result` (GitHub's COOP severs `window.opener`).
+      // `/api/oauth-result` (postMessage can't reach the SPA cross-origin
+      // regardless of `window.opener` state — see `resolveGithubOAuthRedirect`).
       bridgeApiBaseUrl: getLocalApiBaseUrl(),
       extensionId,
       nonce,

--- a/packages/webapp/src/providers/oauth-service.ts
+++ b/packages/webapp/src/providers/oauth-service.ts
@@ -119,12 +119,15 @@ async function launchOAuthViaPanel(authorizeUrl: string): Promise<string | null>
  * `window.open`.
  *
  * Two parallel signals race to deliver the redirect URL:
- *   1. postMessage from the /auth/callback page back to this window
- *      (works when window.opener is intact).
- *   2. Polling /api/oauth-result on the backing server (works even when
- *      window.opener is severed — e.g. by a COOP `same-origin` provider
- *      such as GitHub/Google/Microsoft, or in Electron overlay mode
- *      where window.open spawns the system browser).
+ *   1. postMessage from the /auth/callback page back to this window (only
+ *      accepted from `window.location.origin` below — fires in the legacy
+ *      same-origin case, never in thin-bridge mode, where the callback page
+ *      is always served cross-origin from the local node-server).
+ *   2. Polling /api/oauth-result on the backing server — the sole signal
+ *      that works in thin-bridge mode (the callback page always POSTs the
+ *      result there regardless of `window.opener` state — see
+ *      `oauth-callback.ts`), and also covers Electron overlay mode where
+ *      window.open spawns the system browser.
  *
  * Whichever signal arrives first resolves the launcher promise; the
  * other is cancelled in cleanup(). The 120 s timeout still applies.
@@ -212,9 +215,11 @@ function runOAuthRedirectRace(popup: Window | null): Promise<string | null> {
     window.addEventListener('message', handler);
 
     // Always poll the server for the OAuth result as a fallback to
-    // postMessage. The callback page POSTs the result to /api/oauth-result
-    // when window.opener is null; both node-server and swift-server stash
-    // it for GET retrieval. Whichever signal arrives first wins.
+    // postMessage. The callback page always POSTs the result to
+    // /api/oauth-result regardless of window.opener state (postMessage
+    // can't reach a cross-origin opener's same-origin-only listener
+    // anyway); both node-server and swift-server stash it for GET
+    // retrieval. Whichever signal arrives first wins.
     pollTimer = setInterval(async () => {
       if (resolved) return;
       try {

--- a/packages/webapp/src/shell/proxied-fetch.ts
+++ b/packages/webapp/src/shell/proxied-fetch.ts
@@ -32,6 +32,9 @@ import {
 
 const REQUEST_BODY_CAP = 32 * 1024 * 1024;
 
+/** Statuses that forbid a body argument on the `Response` constructor. */
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
 /**
  * Optional absolute origin (e.g. `http://localhost:5710`) the CLI mode
  * should prepend to `/api/fetch-proxy`. Set in thin-bridge mode where
@@ -266,7 +269,11 @@ async function finalizeProxyResponse(
 ): Promise<Awaited<ReturnType<SecureFetch>>> {
   const respHeaders = new Headers();
   for (const [k, v] of Object.entries(headInfo.headers)) respHeaders.set(k, String(v));
-  const synth = new Response(merged, {
+  // Null-body statuses (101/103/204/205/304) forbid a body argument on the
+  // Response constructor, even a 0-byte Uint8Array — see
+  // `ui/llm-proxy-response.ts` for the full rationale.
+  const bodyInit = NULL_BODY_STATUSES.has(headInfo.status) ? null : merged;
+  const synth = new Response(bodyInit, {
     status: headInfo.status,
     statusText: headInfo.statusText,
     headers: respHeaders,

--- a/packages/webapp/src/ui/llm-proxy-extension-delegate.ts
+++ b/packages/webapp/src/ui/llm-proxy-extension-delegate.ts
@@ -28,6 +28,9 @@ export interface DelegateResponsePort {
   close?: () => void;
 }
 
+/** Statuses that forbid a body argument on the `Response` constructor. */
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
 function decodeBase64Bytes(b64: string): Uint8Array {
   const bin = atob(b64);
   const out = new Uint8Array(bin.length);
@@ -85,7 +88,11 @@ export function buildDelegatedResponseStream(port: DelegateResponsePort): {
     for (const [k, v] of Object.entries(decodeForbiddenResponseHeaders(msg.headers))) {
       headers.set(k, v);
     }
-    resolveResp(new Response(stream, { status: msg.status, statusText: msg.statusText, headers }));
+    // Null-body statuses (101/103/204/205/304) forbid a body argument on the
+    // Response constructor — see `ui/llm-proxy-response.ts` for the full
+    // rationale. No chunks are expected to follow for these statuses.
+    const body = NULL_BODY_STATUSES.has(msg.status) ? null : stream;
+    resolveResp(new Response(body, { status: msg.status, statusText: msg.statusText, headers }));
   };
 
   const onError = (msg: Extract<ResponseMsg, { type: 'response-error' }>): void => {

--- a/packages/webapp/src/ui/llm-proxy-response.ts
+++ b/packages/webapp/src/ui/llm-proxy-response.ts
@@ -16,10 +16,22 @@
  * error). Synthetic Responses have no own URL, and the SW contract
  * surfaces them as the original request URL so relative imports
  * route back at the cross-origin host.
+ *
+ * Null-body statuses (101/103/204/205/304) are special-cased: a
+ * network-fetched Response for one of these can still carry a non-null
+ * (empty) `body` stream inside a Service Worker, and re-passing that stream
+ * into `new Response()` throws `TypeError: Response with null body status
+ * cannot have body` — breaking every proxied call to an endpoint that
+ * legitimately replies 204 (e.g. the OAuth-callback poll's "nothing yet"
+ * response). Same set used by `fs/mount/signed-fetch.ts` and
+ * `ui/sprinkle-bridge.ts`.
  */
 
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
 export function synthesizeForwardResponse(proxyResponse: Response): Response {
-  return new Response(proxyResponse.body, {
+  const body = NULL_BODY_STATUSES.has(proxyResponse.status) ? null : proxyResponse.body;
+  return new Response(body, {
     status: proxyResponse.status,
     statusText: proxyResponse.statusText,
     headers: proxyResponse.headers,

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -1382,12 +1382,16 @@ async function getStreamWithFallback(spec: StreamSpec): Promise<MediaStream> {
  * (tests, transitional boot) it falls back to a direct `window.open`.
  *
  * Two parallel signals race to deliver the redirect URL:
- *   1. postMessage from the /auth/callback page back to this window
- *      (works when window.opener is intact).
- *   2. Polling /api/oauth-result on the backing server (works even when
- *      window.opener is severed — e.g. by a COOP `same-origin` provider
- *      such as GitHub/Google/Microsoft, or in Electron overlay mode
- *      where window.open spawns the system browser).
+ *   1. postMessage from the /auth/callback page back to this window (only
+ *      accepted from `window.location.origin` below — this is the ONLY
+ *      signal that can ever fire in the legacy same-origin case, and can
+ *      never fire in thin-bridge mode, where the callback page is always
+ *      served cross-origin from the local node-server).
+ *   2. Polling /api/oauth-result on the backing server — the sole signal
+ *      that works in thin-bridge mode (`window.opener` staying intact
+ *      doesn't help there; the callback page now always POSTs the result
+ *      regardless of opener — see `oauth-callback.ts`), and also covers
+ *      Electron overlay mode where window.open spawns the system browser.
  *
  * Whichever signal arrives first wins; the other is cancelled in
  * cleanup(). The 120 s timeout still applies.

--- a/packages/webapp/tests/shell/proxied-fetch-extension.test.ts
+++ b/packages/webapp/tests/shell/proxied-fetch-extension.test.ts
@@ -70,6 +70,38 @@ describe('createProxiedFetch — extension branch (Port-based)', () => {
     await expect(fetchPromise).rejects.toThrow(/port disconnected/i);
   });
 
+  it('does not throw finalizing a null-body status (204) response', async () => {
+    // Regression: `finalizeProxyResponse` always wrapped the merged bytes
+    // (a Uint8Array, never null) in `new Response()`, which throws "Response
+    // with null body status cannot have body" for 101/103/204/205/304 —
+    // breaking any agent shell fetch to an endpoint that legitimately
+    // replies 204 (e.g. `curl -X DELETE`, or the OAuth-callback poll).
+    const msgListeners: ((m: any) => void)[] = [];
+    const port: any = {
+      postMessage: vi.fn(),
+      disconnect: vi.fn(),
+      onMessage: { addListener: (fn: any) => msgListeners.push(fn) },
+      onDisconnect: { addListener: vi.fn() },
+    };
+    (globalThis as any).chrome = { runtime: { connect: vi.fn(() => port), id: 'test-id' } };
+
+    const { createProxiedFetch } = await import('../../src/shell/proxied-fetch.js');
+    const proxiedFetch = createProxiedFetch();
+
+    const fetchPromise = proxiedFetch('https://api.github.com/user', { method: 'DELETE' });
+    await new Promise((r) => setTimeout(r, 0));
+    msgListeners.forEach((l) => {
+      l({ type: 'response-head', status: 204, statusText: 'No Content', headers: {} });
+    });
+    msgListeners.forEach((l) => {
+      l({ type: 'response-end' });
+    });
+
+    const resp = await fetchPromise;
+    expect(resp.status).toBe(204);
+    expect(resp.body.byteLength).toBe(0);
+  });
+
   it('rejects with response-error message when the SW reports an error', async () => {
     const msgListeners: ((m: any) => void)[] = [];
     const port: any = {

--- a/packages/webapp/tests/ui/llm-proxy-extension-delegate.test.ts
+++ b/packages/webapp/tests/ui/llm-proxy-extension-delegate.test.ts
@@ -93,4 +93,19 @@ describe('buildDelegatedResponseStream', () => {
     port.emit({ type: 'response-chunk', dataBase64: b64('late') });
     expect(await resp.text()).toBe('');
   });
+
+  it('does not throw constructing a Response for a null-body status (204)', async () => {
+    // Regression: the delegate previously always attached the (empty)
+    // ReadableStream to the Response regardless of status, which throws
+    // "Response with null body status cannot have body" for 101/103/204/
+    // 205/304 — breaking any extension-mode delegated fetch to an endpoint
+    // that legitimately replies 204 (e.g. the OAuth-callback poll).
+    const port = makePort();
+    const { responsePromise } = buildDelegatedResponseStream(port);
+    port.emit({ type: 'response-head', status: 204, statusText: 'No Content', headers: {} });
+    const resp = await responsePromise;
+    expect(resp.status).toBe(204);
+    expect(resp.body).toBeNull();
+    port.emit({ type: 'response-end' });
+  });
 });

--- a/packages/webapp/tests/ui/llm-proxy-response.test.ts
+++ b/packages/webapp/tests/ui/llm-proxy-response.test.ts
@@ -93,4 +93,23 @@ describe('synthesizeForwardResponse', () => {
     expect(wrapped.status).toBe(204);
     expect(await wrapped.text()).toBe('');
   });
+
+  it('does not throw when a fetched 204 response reports a non-null body stream', () => {
+    // Regression for the OAuth-callback poll ("nothing yet" → 204) breaking
+    // every attempt inside the LLM-proxy Service Worker: in production
+    // Chrome a network-`fetch()`ed 204/205/304 Response can still carry a
+    // non-null (empty) `body` stream, unlike a directly-`new Response()`ed
+    // one (which the constructor already nulls out, as exercised above).
+    // `Response.body` has no setter, so simulate the lying network response
+    // via a getter override rather than construction.
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const proxyResponse = new Response(null, { status: 204 });
+    Object.defineProperty(proxyResponse, 'body', { value: stream });
+    expect(() => synthesizeForwardResponse(proxyResponse)).not.toThrow();
+    expect(synthesizeForwardResponse(proxyResponse).body).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

`oauth-token github` reported "login completed but no token was saved" even after a successful GitHub login, in the standalone thin-bridge float. Two independent bugs combined to cause this.

- The LLM-proxy Service Worker's `synthesizeForwardResponse()` (and its extension-mode and agent-fetch-proxy counterparts) reconstructs a `Response` from a fetched one without guarding null-body statuses (101/103/204/205/304). A network-fetched 204/304 Response can still carry a non-null body stream inside a Service Worker, and the `Response` constructor throws for those statuses regardless — breaking every proxied fetch to an endpoint that legitimately replies 204, including the OAuth-callback result poll (`/api/oauth-result`, which replies 204 while a login is pending).
- Once that crash was fixed, the poll ran cleanly but never received a result. `packages/node-server/src/routes/oauth-callback.ts` (and the byte-for-byte swift-server twin) only POSTs the OAuth result to `/api/oauth-result` when `window.opener` is absent, falling back to `window.opener.postMessage` otherwise. GitHub does not send `Cross-Origin-Opener-Policy`, so the opener stays intact and the postMessage branch is taken — but in thin-bridge mode the callback page's origin never matches the receiving listener's origin (which only accepts same-origin messages), so the message is silently dropped and the POST never fires.

## Changes

- Guard null-body-status responses in `llm-proxy-response.ts`, `llm-proxy-extension-delegate.ts`, and `proxied-fetch.ts`, matching the existing `NULL_BODY_STATUSES` pattern already used by `signed-fetch.ts` and `sprinkle-bridge.ts`.
- Callback page now always POSTs the result to `/api/oauth-result` regardless of `window.opener` state, in both node-server and swift-server; postMessage stays as a best-effort same-origin fast path.
- Corrected stale comments in `github.ts` and `panel-rpc-handlers.ts` that attributed the poll's necessity to GitHub's COOP severing `window.opener` (verified via `curl` that GitHub sends no COOP header at all).

## Test plan

- [x] `vitest` — all affected suites pass (`llm-proxy-response`, `llm-proxy-extension-delegate`, `proxied-fetch-extension`, `oauth-callback`), including new regression tests for each fix
- [x] `swift test` — new regression test for the callback branching passes
- [x] Full webapp + node-server `tsc --noEmit` clean
- [x] Verified end-to-end against a live standalone thin-bridge instance: `oauth-token github` now completes and saves the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)