### PR TITLE
fix(webapp): exempt image/media loads from LLM-proxy SW interception

### DIFF
--- a/packages/webapp/src/ui/llm-proxy-sw-config.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw-config.ts
@@ -175,36 +175,6 @@ export function isBridgeFetchProxyUrl(
  * messages tagged with `SW_BRIDGE_CONFIG_MESSAGE` and ignores anything
  * else (other code may be using `postMessage` against the SW too).
  */
-/**
- * Resource types that never need the proxy rewrite: they carry no secrets to
- * inject and aren't subject to CORS the way a script-initiated `fetch()`/XHR
- * is (a plain `<img src>`/`<link>`/`<video>` loads cross-origin natively).
- * Only `fetch()`/XHR calls — reported with an empty `destination` — need the
- * rewrite, for LLM provider SDKs that call `fetch()` directly against a
- * cross-origin API. Sweeping these resource types in too caused a real bug:
- * any sprinkle with a plain cross-origin `<img>` 404'd through
- * `/api/fetch-proxy`, which the worker deployment always dead-stubs (see
- * `packages/cloudflare-worker/src/index.ts`'s `/api/fetch-proxy` handler,
- * `'Fetch proxy not available in worker mode'`) — the image never needed
- * proxying at all.
- */
-const PASSTHROUGH_DESTINATIONS = new Set([
-  'image',
-  'font',
-  'style',
-  'video',
-  'audio',
-  'track',
-  'iframe',
-  'object',
-  'embed',
-]);
-
-/** Whether a fetch of `destination` should skip the proxy rewrite entirely. */
-export function isPassthroughDestination(destination: string): boolean {
-  return PASSTHROUGH_DESTINATIONS.has(destination);
-}
-
 export function isBridgeConfigMessage(value: unknown): value is BridgeConfigMessage {
   if (!value || typeof value !== 'object') return false;
   const v = value as { type?: unknown };
@@ -419,4 +389,34 @@ export class ExtensionDelegateCache {
   size(): number {
     return this.byClient.size;
   }
+}
+
+/**
+ * Resource types that never need the proxy rewrite: they carry no secrets to
+ * inject and aren't subject to CORS the way a script-initiated `fetch()`/XHR
+ * is (a plain `<img src>`/`<link>`/`<video>` loads cross-origin natively).
+ * Only `fetch()`/XHR calls — reported with an empty `destination` — need the
+ * rewrite, for LLM provider SDKs that call `fetch()` directly against a
+ * cross-origin API. Sweeping these resource types in too caused a real bug:
+ * any sprinkle with a plain cross-origin `<img>` 404'd through
+ * `/api/fetch-proxy`, which the worker deployment always dead-stubs (see
+ * `packages/cloudflare-worker/src/index.ts`'s `/api/fetch-proxy` handler,
+ * `'Fetch proxy not available in worker mode'`) — the image never needed
+ * proxying at all.
+ */
+const PASSTHROUGH_DESTINATIONS = new Set([
+  'image',
+  'font',
+  'style',
+  'video',
+  'audio',
+  'track',
+  'iframe',
+  'object',
+  'embed',
+]);
+
+/** Whether a fetch of `destination` should skip the proxy rewrite entirely. */
+export function isPassthroughDestination(destination: string): boolean {
+  return PASSTHROUGH_DESTINATIONS.has(destination);
 }

--- a/packages/webapp/src/ui/llm-proxy-sw-config.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw-config.ts
@@ -175,6 +175,36 @@ export function isBridgeFetchProxyUrl(
  * messages tagged with `SW_BRIDGE_CONFIG_MESSAGE` and ignores anything
  * else (other code may be using `postMessage` against the SW too).
  */
+/**
+ * Resource types that never need the proxy rewrite: they carry no secrets to
+ * inject and aren't subject to CORS the way a script-initiated `fetch()`/XHR
+ * is (a plain `<img src>`/`<link>`/`<video>` loads cross-origin natively).
+ * Only `fetch()`/XHR calls — reported with an empty `destination` — need the
+ * rewrite, for LLM provider SDKs that call `fetch()` directly against a
+ * cross-origin API. Sweeping these resource types in too caused a real bug:
+ * any sprinkle with a plain cross-origin `<img>` 404'd through
+ * `/api/fetch-proxy`, which the worker deployment always dead-stubs (see
+ * `packages/cloudflare-worker/src/index.ts`'s `/api/fetch-proxy` handler,
+ * `'Fetch proxy not available in worker mode'`) — the image never needed
+ * proxying at all.
+ */
+const PASSTHROUGH_DESTINATIONS = new Set([
+  'image',
+  'font',
+  'style',
+  'video',
+  'audio',
+  'track',
+  'iframe',
+  'object',
+  'embed',
+]);
+
+/** Whether a fetch of `destination` should skip the proxy rewrite entirely. */
+export function isPassthroughDestination(destination: string): boolean {
+  return PASSTHROUGH_DESTINATIONS.has(destination);
+}
+
 export function isBridgeConfigMessage(value: unknown): value is BridgeConfigMessage {
   if (!value || typeof value !== 'object') return false;
   const v = value as { type?: unknown };

--- a/packages/webapp/src/ui/llm-proxy-sw.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw.ts
@@ -45,6 +45,7 @@ import {
   isBridgeConfigMessage,
   isBridgeLocalApiUrl,
   isExtensionDelegateMessage,
+  isPassthroughDestination,
   parseExtensionDelegateFromClientUrl,
   type ResolvedExtensionDelegate,
   resolveBridgeFromClientUrls,
@@ -139,6 +140,7 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
 self.addEventListener('fetch', (event: FetchEvent) => {
   const req = event.request;
   if (req.headers.get(BYPASS_HEADER) === '1') return;
+  if (isPassthroughDestination(req.destination)) return;
 
   let url: URL;
   try {

--- a/packages/webapp/tests/ui/llm-proxy-sw-config.test.ts
+++ b/packages/webapp/tests/ui/llm-proxy-sw-config.test.ts
@@ -19,6 +19,7 @@ import {
   isBridgeLocalApiUrl,
   isExtensionDelegateMessage,
   isExtensionFetchDelegateRequest,
+  isPassthroughDestination,
   parseExtensionDelegateFromClientUrl,
   resolveBridgeConfig,
   resolveBridgeFromClientUrls,
@@ -462,5 +463,42 @@ describe('ExtensionDelegateCache', () => {
     const cache = new ExtensionDelegateCache();
     expect(cache.get(null)).toBeNull();
     expect(cache.get('missing')).toBeNull();
+  });
+});
+
+/**
+ * Regression: a plain cross-origin `<img>` inside a sprinkle's srcdoc
+ * iframe was getting swept into the proxy rewrite alongside genuine
+ * `fetch()`/XHR calls. Images don't need CORS bypass or secret injection,
+ * but the worker deployment's `/api/fetch-proxy` always dead-stubs with
+ * 404 ("Fetch proxy not available in worker mode") — so any sprinkle with
+ * an external image 404'd. Only `fetch()`/XHR (empty `destination`) should
+ * ever be rewritten.
+ */
+describe('isPassthroughDestination', () => {
+  it('exempts image, font, and other passive resource loads', () => {
+    for (const destination of [
+      'image',
+      'font',
+      'style',
+      'video',
+      'audio',
+      'track',
+      'iframe',
+      'object',
+      'embed',
+    ]) {
+      expect(isPassthroughDestination(destination)).toBe(true);
+    }
+  });
+
+  it('does not exempt fetch()/XHR calls (empty destination)', () => {
+    expect(isPassthroughDestination('')).toBe(false);
+  });
+
+  it('does not exempt document/script/worker loads', () => {
+    expect(isPassthroughDestination('document')).toBe(false);
+    expect(isPassthroughDestination('script')).toBe(false);
+    expect(isPassthroughDestination('worker')).toBe(false);
   });
 });


### PR DESCRIPTION
llm-proxy-sw.ts's fetch handler intercepted every cross-origin request regardless of destination, including plain <img>/<video>/<font> loads from sprinkle srcdoc iframes -- not just the fetch()/XHR calls it was built for (LLM provider SDKs calling api.*.com directly). Those passive resource loads don't need CORS bypass or secret injection, but got rewritten to /api/fetch-proxy anyway -- which the Cloudflare Worker deployment always dead-stubs with a 404 ("Fetch proxy not available in worker mode"), so any sprinkle with an external image consistently 404'd there.

This surfaced as a "cherry vs. follower" asymmetry: a follower tab with pre-existing browser state (stale Cache Storage from before this SW behavior existed) masked the bug, while cherry's storage-partitioned, always-fresh Service Worker instance hit it every time. A private window against a plain follower reproduced the same failure, confirming it was never cherry-specific -- just fresh vs. stale state hitting the same underlying defect.

Add isPassthroughDestination() (keyed on FetchEvent.request.destination) to the existing pure-helpers module so it's testable without a ServiceWorkerGlobalScope, and check it before the proxy rewrite.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
