### PR TITLE
fix(webapp): show explanatory placeholder for Monitor in follower mode

### DIFF
--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -42,13 +42,16 @@ function renderFollowerBootError(app: HTMLElement, message: string): void {
 }
 
 /**
- * Follower mode has no kernel worker, so there's no local VFS, shell, or memory
- * store - the Files, Terminal, and Memory panels in the shared shell layout are
- * inert (nothing populates them, and the follower-sync protocol doesn't stream
- * the leader's filesystem, terminal, or memory). Replace them with the same
- * `wcui-placeholder` treatment the Browser surface already uses so the user gets
- * an explanation instead of an empty/black panel. A follower mirrors the
- * leader's chat, sprinkles, and browser tabs - not its filesystem/shell/memory.
+ * Follower mode has no kernel worker, so there's no local VFS, shell, memory
+ * store, or orchestrator - the Files, Terminal, Memory, and Monitor panels in
+ * the shared shell layout are inert (nothing populates them, and the
+ * follower-sync protocol doesn't stream the leader's filesystem, terminal,
+ * memory, or kernel/orchestrator state that Monitor reads - scoops, cost,
+ * processes, cron tasks, webhooks, mounts, MCP servers). Replace them with the
+ * same `wcui-placeholder` treatment the Browser surface already uses so the
+ * user gets an explanation instead of an empty/black panel. A follower mirrors
+ * the leader's chat, sprinkles, and browser tabs - not its filesystem/shell/
+ * memory/kernel state.
  *
  * When cherry features disable a panel (feature = false), the entire
  * `slicc-surface` parent is removed from the DOM so the tab bar auto-hides it.
@@ -57,7 +60,8 @@ function renderFollowerInertPanels(
   fileTree: HTMLElement,
   termSurface: HTMLElement,
   memoryHost: HTMLElement,
-  features: { terminal: boolean; files: boolean; memory: boolean }
+  monitor: HTMLElement,
+  features: { terminal: boolean; files: boolean; memory: boolean; monitor: boolean }
 ): void {
   const placeholder = (text: string): HTMLElement => {
     const el = document.createElement('div');
@@ -95,6 +99,18 @@ function renderFollowerInertPanels(
   } else {
     memoryHost.append(
       placeholder('Memory lives on the leader. A follower has no local memory store.')
+    );
+  }
+  // Monitor: the dashboard (scoops, cost, processes, cron, webhooks, mounts,
+  // MCP servers) is entirely orchestrator/kernel-backed - never wired in
+  // follower mode, so the panel would otherwise render permanently empty.
+  if (!features.monitor) {
+    // Completely remove the monitor surface from DOM
+    monitor.closest('slicc-surface')?.remove();
+  } else {
+    monitor.style.display = 'none';
+    monitor.parentElement?.append(
+      placeholder("Monitor reads the leader's kernel state. A follower has no local kernel.")
     );
   }
 }
@@ -213,6 +229,7 @@ export async function mountWcUiFollower(
     boot.refs.fileTree,
     boot.refs.termSurface,
     boot.refs.memoryHost,
+    boot.refs.monitor,
     features
   );
   applyFeatureVisibility(features);

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -46,12 +46,12 @@ function renderFollowerBootError(app: HTMLElement, message: string): void {
  * store, or orchestrator - the Files, Terminal, Memory, and Monitor panels in
  * the shared shell layout are inert (nothing populates them, and the
  * follower-sync protocol doesn't stream the leader's filesystem, terminal,
- * memory, or kernel/orchestrator state that Monitor reads - scoops, cost,
- * processes, cron tasks, webhooks, mounts, MCP servers). Replace them with the
- * same `wcui-placeholder` treatment the Browser surface already uses so the
- * user gets an explanation instead of an empty/black panel. A follower mirrors
- * the leader's chat, sprinkles, and browser tabs - not its filesystem/shell/
- * memory/kernel state.
+ * memory, or kernel/orchestrator state that Monitor reads - scoops, session
+ * cost, processes, cron tasks, webhooks, mounts, MCP servers, and OAuth
+ * accounts). Replace them with the same `wcui-placeholder` treatment the
+ * Browser surface already uses so the user gets an explanation instead of an
+ * empty/black panel. A follower mirrors the leader's chat, sprinkles, and
+ * browser tabs - not its filesystem/shell/memory/kernel state.
  *
  * When cherry features disable a panel (feature = false), the entire
  * `slicc-surface` parent is removed from the DOM so the tab bar auto-hides it.
@@ -101,9 +101,10 @@ function renderFollowerInertPanels(
       placeholder('Memory lives on the leader. A follower has no local memory store.')
     );
   }
-  // Monitor: the dashboard (scoops, cost, processes, cron, webhooks, mounts,
-  // MCP servers) is entirely orchestrator/kernel-backed - never wired in
-  // follower mode, so the panel would otherwise render permanently empty.
+  // Monitor: the dashboard (scoops, session cost, processes, cron tasks,
+  // webhooks, mounts, MCP servers, OAuth accounts) is entirely
+  // orchestrator/kernel-backed - never wired in follower mode, so the panel
+  // would otherwise render permanently empty.
   if (!features.monitor) {
     // Completely remove the monitor surface from DOM
     monitor.closest('slicc-surface')?.remove();

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -144,7 +144,7 @@ describe('mountWcUiFollower', () => {
     expect(iframe?.srcdoc).not.toContain('data-action="deny"');
   });
 
-  it('replaces the inert Files/Terminal/Memory panels with a placeholder (no local VFS/shell)', async () => {
+  it('replaces the inert Files/Terminal/Memory/Monitor panels with a placeholder (no local VFS/shell/kernel)', async () => {
     const { mountWcUiFollower } = await import('../../../src/ui/wc/wc-follower.js');
     const app = document.getElementById('app')!;
     await mountWcUiFollower(app, { stage: () => {} } as never, 'follower');
@@ -154,13 +154,21 @@ describe('mountWcUiFollower', () => {
     expect(fileTree).toBeTruthy();
     expect(fileTree!.style.display).toBe('none');
 
-    // …and explanatory placeholders take the Files + Terminal + Memory panels.
+    // …and so is the monitor dashboard — it's entirely kernel/orchestrator-backed
+    // (scoops, cost, processes, cron, webhooks, mounts, MCP), and a follower has
+    // no kernel worker to source any of that from.
+    const monitor = app.querySelector('slicc-monitor') as HTMLElement | null;
+    expect(monitor).toBeTruthy();
+    expect(monitor!.style.display).toBe('none');
+
+    // …and explanatory placeholders take the Files + Terminal + Memory + Monitor panels.
     const texts = Array.from(app.querySelectorAll('.wcui-placeholder')).map(
       (e) => e.textContent ?? ''
     );
     expect(texts.some((t) => t.includes('Files live on the leader'))).toBe(true);
     expect(texts.some((t) => t.includes('The shell runs on the leader'))).toBe(true);
     expect(texts.some((t) => t.includes('Memory lives on the leader'))).toBe(true);
+    expect(texts.some((t) => t.includes('Monitor reads the leader'))).toBe(true);
   });
 
   it('disables the composer with a connecting placeholder until the leader connects', async () => {


### PR DESCRIPTION
## Summary
- Monitor's dashboard (scoops, cost, processes, cron tasks, webhooks, mounts, MCP servers) is entirely orchestrator/kernel-backed, but a follower — including a Cherry-embedded page — has no kernel worker.
- The activation code that actually populates Monitor (`createWorkbenchActivator` → `fetchMonitorData`) is only wired up in the leader path (`wc-live.ts`); `wc-follower.ts` never calls `boot.setActivateSurface`, so that code never runs for followers.
- When the `monitor` feature toggle was added to `CherryFeatureSet` (commit `259cbbb9`), it only got show/hide-icon treatment — unlike Files/Terminal/Memory, which already got the explanatory `wcui-placeholder` treatment in `renderFollowerInertPanels` for the identical "no kernel worker" reason. Monitor was left showing a permanently blank panel with no explanation, which is what was reported: "the monitor just shows empty" when integrating via the Cherry SDK.
- Fix: extend `renderFollowerInertPanels` in `packages/webapp/src/ui/wc/wc-follower.ts` to hide the Monitor panel and show the same explanatory placeholder pattern used by Files/Terminal/Memory (or remove the surface entirely if the host disables the `monitor` feature).

## Test plan
- [x] Added a regression test in `packages/webapp/tests/ui/wc/wc-follower.test.ts` (extended the existing inert-panels test) — confirmed it fails before the fix and passes after.
- [x] `npx vitest run tests/ui/wc/` — 409 tests passed.
- [x] `tsc --noEmit` (browser bundle) — clean.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)