### PR TITLE
fix(webapp): cherry sprinkle visibility repaint

### DIFF
--- a/packages/webapp/src/ui/iframe-repaint.ts
+++ b/packages/webapp/src/ui/iframe-repaint.ts
@@ -1,0 +1,36 @@
+/**
+ * Whether this page itself is running inside another frame (e.g. a cherry
+ * follower embedded in a third-party host page's iframe). A sprinkle's or
+ * dip's own render iframe is then nested two levels deep instead of one,
+ * which hits a Chromium first-paint bug: the innermost iframe's content
+ * loads and executes correctly but the compositor never rasterizes it,
+ * leaving the panel blank until something forces a full frame-tree repaint
+ * (DevTools attaching, or a page reload). `nudgeIframeRepaint` works around
+ * it without either of those.
+ */
+export function isNestedInAnotherFrame(): boolean {
+  try {
+    return window.self !== window.top;
+  } catch {
+    // Cross-origin access to `window.top` throws — that itself means we're
+    // framed by a different origin, which is the case this guards against.
+    return true;
+  }
+}
+
+/**
+ * Force the browser to redo the render/compositing pass for `iframe` by
+ * toggling `display` off and back on across two animation frames. A resize
+ * event or explicit layout read (`getBoundingClientRect`) does NOT trigger
+ * the missing repaint for this bug — only a `display` toggle (or an
+ * out-of-band event like DevTools attaching) does.
+ */
+export function nudgeIframeRepaint(iframe: HTMLIFrameElement): void {
+  const previousDisplay = iframe.style.display;
+  iframe.style.display = 'none';
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      iframe.style.display = previousDisplay;
+    });
+  });
+}

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -7,6 +7,7 @@
  * which is CSP-exempt. Bridge communication uses postMessage.
  */
 
+import { isNestedInAnotherFrame, nudgeIframeRepaint } from './iframe-repaint.js';
 import type { SprinkleBridgeAPI } from './sprinkle-bridge.js';
 import { isThemeLight, registerSprinkleWindow, unregisterSprinkleWindow } from './theme.js';
 
@@ -17,42 +18,6 @@ declare global {
 }
 
 const isExtension = typeof chrome !== 'undefined' && !!chrome?.runtime?.id;
-
-/**
- * Whether this page itself is running inside another frame (e.g. a cherry
- * follower embedded in a third-party host page's iframe). A sprinkle's own
- * render iframe is then nested two levels deep instead of one, which hits a
- * Chromium first-paint bug: the innermost iframe's content loads and executes
- * correctly but the compositor never rasterizes it, leaving the panel blank
- * until something forces a full frame-tree repaint (DevTools attaching, or a
- * page reload). `nudgeIframeRepaint` works around it without either of those.
- */
-function isNestedInAnotherFrame(): boolean {
-  try {
-    return window.self !== window.top;
-  } catch {
-    // Cross-origin access to `window.top` throws — that itself means we're
-    // framed by a different origin, which is the case this guards against.
-    return true;
-  }
-}
-
-/**
- * Force the browser to redo the render/compositing pass for `iframe` by
- * toggling `display` off and back on across two animation frames. A resize
- * event or explicit layout read (`getBoundingClientRect`) does NOT trigger
- * the missing repaint for this bug — only a `display` toggle (or an
- * out-of-band event like DevTools attaching) does.
- */
-function nudgeIframeRepaint(iframe: HTMLIFrameElement): void {
-  const previousDisplay = iframe.style.display;
-  iframe.style.display = 'none';
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      iframe.style.display = previousDisplay;
-    });
-  });
-}
 
 const EXTERNAL_SCRIPT_RE =
   /<script\b([^>]*)\bsrc\s*=\s*["'](https?:\/\/[^"']+)["']([^>]*)><\/script>/gi;
@@ -371,6 +336,7 @@ export class SprinkleRenderer {
   private static cachedLucideScript: string | null = null;
   private static lucideScriptPromise: Promise<string> | null = null;
   private messageHandler: ((event: MessageEvent) => void) | null = null;
+  private visibilityObserver: IntersectionObserver | null = null;
 
   constructor(container: HTMLElement, bridge: SprinkleBridgeAPI) {
     this.container = container;
@@ -867,6 +833,24 @@ export class SprinkleRenderer {
       createSharedBridgeHandlers(this.bridge)
     );
     window.addEventListener('message', this.messageHandler);
+
+    // The sprinkle's `<slicc-surface>` host stays mounted and toggles
+    // `display:none`/`display:flex` on tab switches instead of destroying the
+    // iframe — no new `load` event fires on re-show, so the one-shot nudge
+    // above can't catch a re-show that resurfaces the Chromium compositor
+    // bug. Re-nudge on every hidden→visible transition after the first.
+    if (isNestedInAnotherFrame() && typeof IntersectionObserver !== 'undefined') {
+      let sawInitialState = false;
+      this.visibilityObserver = new IntersectionObserver((entries) => {
+        const entry = entries[entries.length - 1];
+        if (!sawInitialState) {
+          sawInitialState = true;
+          return;
+        }
+        if (entry.isIntersecting) nudgeIframeRepaint(iframe);
+      });
+      this.visibilityObserver.observe(iframe);
+    }
   }
 
   /**
@@ -896,6 +880,10 @@ export class SprinkleRenderer {
 
   /** Clean up scripts and content. */
   dispose(): void {
+    if (this.visibilityObserver) {
+      this.visibilityObserver.disconnect();
+      this.visibilityObserver = null;
+    }
     if (this.messageHandler) {
       window.removeEventListener('message', this.messageHandler);
       this.messageHandler = null;

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -477,6 +477,61 @@ describe('full document rendering', () => {
     expect(iframe.style.display).not.toBe('none');
   });
 
+  it('re-nudges the iframe repaint when a hidden cherry sprinkle surface becomes visible again', async () => {
+    // The sprinkle's `<slicc-surface>` host stays mounted and toggles
+    // `display:none`/`display:flex` on tab switches — no new `load` event
+    // fires on re-show, so only an IntersectionObserver-driven re-nudge can
+    // catch the Chromium compositor bug resurfacing on a later show.
+    (dom.window as any).self = {};
+    const rafCallbacks: Array<() => void> = [];
+    const originalRaf = (globalThis as any).requestAnimationFrame;
+    (globalThis as any).requestAnimationFrame = (cb: () => void) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    };
+
+    let observerCallback: ((entries: Array<{ isIntersecting: boolean }>) => void) | null = null;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    const originalIO = (globalThis as any).IntersectionObserver;
+    class FakeIntersectionObserver {
+      constructor(cb: typeof observerCallback) {
+        observerCallback = cb;
+      }
+      observe = observe;
+      disconnect = disconnect;
+      unobserve = vi.fn();
+    }
+    (globalThis as any).IntersectionObserver = FakeIntersectionObserver;
+
+    try {
+      const bridge = makeBridge('full-doc');
+      const renderer = new SprinkleRenderer(container, bridge);
+      const html = '<!DOCTYPE html><html><head></head><body>Hi</body></html>';
+      await renderer.render(html, 'full-doc');
+
+      expect(observe).toHaveBeenCalled();
+      // Consume the initial-load nudge's raf pair before simulating tab switches.
+      rafCallbacks.shift()!();
+      rafCallbacks.shift()!();
+      rafCallbacks.length = 0;
+
+      // First observer callback reports the initial (already-handled) state —
+      // must not double-nudge on top of the load-event nudge.
+      observerCallback!([{ isIntersecting: true }]);
+      expect(rafCallbacks.length).toBe(0);
+
+      // Tab switched away, then back: a later hidden -> visible transition
+      // must trigger a fresh nudge.
+      observerCallback!([{ isIntersecting: false }]);
+      observerCallback!([{ isIntersecting: true }]);
+      expect(rafCallbacks.length).toBe(1);
+    } finally {
+      (globalThis as any).requestAnimationFrame = originalRaf;
+      (globalThis as any).IntersectionObserver = originalIO;
+    }
+  });
+
   it('grants allow-popups on the sprinkle iframe when the page itself is framed (cherry)', async () => {
     (dom.window as any).self = {};
     const originalRaf = (globalThis as any).requestAnimationFrame;


### PR DESCRIPTION
The Chromium nested-iframe compositor bug (fixed in a prior PR via nudgeIframeRepaint) only re-fires the workaround once, on the iframe's initial load event. A sprinkle's <slicc-surface> host stays mounted and just toggles display:none/flex on workbench tab switches, so a later re-show never gets a fresh load event and the compositor bug can resurface with no way to recover short of a full page reload.

Extract the shared helpers into iframe-repaint.ts and add an IntersectionObserver on the cherry-only sprinkle iframe to re-nudge on every hidden -> visible transition after the first.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
