### PR TITLE
fix(cloudflare-worker): relax preview pipe CSP to allow any resource domain

### DIFF
--- a/packages/cloudflare-worker/src/session-tray-preview.ts
+++ b/packages/cloudflare-worker/src/session-tray-preview.ts
@@ -292,9 +292,11 @@ async function handlePreviewFetch(request: Request, deps: PreviewDeps): Promise<
       headers: {
         'content-type': result.mime,
         'cache-control': 'no-store',
+        // ponytail: served pages may need arbitrary third-party resources
+        // (CDN scripts/fonts/APIs); frame-ancestors stays 'none' — that's
+        // about framing THIS preview elsewhere, unrelated to what it loads.
         'content-security-policy':
-          "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:;" +
-          " frame-ancestors 'none'",
+          "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:; frame-ancestors 'none'",
       },
     });
   } finally {


### PR DESCRIPTION
## Summary
- The `serve` command's worker-hosted preview pipe (`session-tray-preview.ts:handlePreviewFetch`) sent `default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:`, which blocked served pages from loading scripts, styles, images, fonts, or making requests to any other domain.
- Changed `default-src` to `*` (keeping `'unsafe-inline' 'unsafe-eval' data: blob:` explicit, since `*` doesn't cover non-network schemes) so served content can pull resources from any domain.
- `frame-ancestors 'none'` is unchanged — it controls who can frame the preview itself, not what the preview loads.

## Test plan
- [x] `npx vitest run --project cloudflare-worker` — 253 passed
- [x] `npx tsc --noEmit -p tsconfig.worker.json` — clean