### PR TITLE
fix(webapp): add mount/unmount to RestrictedFS for scoop DA/S3 mounts

### DIFF
--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -19,8 +19,8 @@
  */
 
 import type { FsWatchCallback, FsWatchFilter } from './fs-watcher.js';
-import type { MountIndexEnv } from './mount-index.js';
 import type { MountBackend, RefreshReport } from './mount/backend.js';
+import type { MountIndexEnv } from './mount-index.js';
 import { normalizePath } from './path-utils.js';
 import type {
   DirEntry,
@@ -658,11 +658,13 @@ export class RestrictedFS {
     opts?: { env?: MountIndexEnv }
   ): Promise<void> {
     this.checkWrite(absolutePath);
+    await this.checkParentRealpathEscape(absolutePath);
     return this.vfs.mount(absolutePath, backend, opts);
   }
 
   async unmount(absolutePath: string): Promise<void> {
     this.checkWrite(absolutePath);
+    await this.checkParentRealpathEscape(absolutePath);
     return this.vfs.unmount(absolutePath);
   }
 
@@ -678,6 +680,7 @@ export class RestrictedFS {
     absolutePath: string,
     opts?: { bodies?: boolean; env?: MountIndexEnv }
   ): Promise<RefreshReport> {
+    this.checkWrite(absolutePath);
     return this.vfs.refreshMount(absolutePath, opts);
   }
 

--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -19,6 +19,8 @@
  */
 
 import type { FsWatchCallback, FsWatchFilter } from './fs-watcher.js';
+import type { MountIndexEnv } from './mount-index.js';
+import type { MountBackend, RefreshReport } from './mount/backend.js';
 import { normalizePath } from './path-utils.js';
 import type {
   DirEntry,
@@ -644,6 +646,39 @@ export class RestrictedFS {
 
   basename(path: string): string {
     return this.vfs.basename(path);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mount operations — delegate to VFS with writable-path enforcement.
+  // ---------------------------------------------------------------------------
+
+  async mount(
+    absolutePath: string,
+    backend: MountBackend,
+    opts?: { env?: MountIndexEnv }
+  ): Promise<void> {
+    this.checkWrite(absolutePath);
+    return this.vfs.mount(absolutePath, backend, opts);
+  }
+
+  async unmount(absolutePath: string): Promise<void> {
+    this.checkWrite(absolutePath);
+    return this.vfs.unmount(absolutePath);
+  }
+
+  listMounts(): string[] {
+    return this.vfs.listMounts();
+  }
+
+  getMountIndex(): ReturnType<VirtualFS['getMountIndex']> {
+    return this.vfs.getMountIndex();
+  }
+
+  async refreshMount(
+    absolutePath: string,
+    opts?: { bodies?: boolean; env?: MountIndexEnv }
+  ): Promise<RefreshReport> {
+    return this.vfs.refreshMount(absolutePath, opts);
   }
 
   /**

--- a/packages/webapp/src/fs/sudo-fs.ts
+++ b/packages/webapp/src/fs/sudo-fs.ts
@@ -239,6 +239,24 @@ export function createSudoFs<T extends object>(target: T, deps: SudoFsDeps): T {
       return (target as Record<string, (...a: unknown[]) => unknown>).copyFile(src, dest);
     };
   }
+  if (has('mount')) {
+    overrides.mount = async (path: unknown, ...rest: unknown[]) => {
+      await gate('write', path as string);
+      return (target as Record<string, (...a: unknown[]) => unknown>).mount(path, ...rest);
+    };
+  }
+  if (has('unmount')) {
+    overrides.unmount = async (path: unknown) => {
+      await gate('write', path as string);
+      return (target as Record<string, (...a: unknown[]) => unknown>).unmount(path);
+    };
+  }
+  if (has('refreshMount')) {
+    overrides.refreshMount = async (path: unknown, ...rest: unknown[]) => {
+      await gate('write', path as string);
+      return (target as Record<string, (...a: unknown[]) => unknown>).refreshMount(path, ...rest);
+    };
+  }
   if (has('statSync')) {
     overrides.statSync = (path: unknown) =>
       syncAllowed(path as string)

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -287,7 +287,7 @@ describe('RestrictedFS', () => {
       await expect(rfs.mount('/workspace/external', fakeBackend)).rejects.toThrow('EACCES');
     });
 
-    it('mount is ungated at RestrictedFS layer under sudo-delegated (credential resolver is the real gate)', async () => {
+    it('mount passes through RestrictedFS under sudo-delegated (SudoFS gates via cone approval)', async () => {
       const rfs = new RestrictedFS(mountOpVfs, ['/scoops/editor/'], [], 'sudo-delegated');
       const fakeBackend = {
         readDir: async () => [],
@@ -299,6 +299,7 @@ describe('RestrictedFS', () => {
         exists: async () => true,
         close: async () => {},
       };
+      // RestrictedFS layer passes through — SudoFS is responsible for gating
       await expect(rfs.mount('/workspace/external', fakeBackend)).resolves.not.toThrow();
       expect(rfs.listMounts()).toContain('/workspace/external');
       await rfs.unmount('/workspace/external');

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -246,6 +246,71 @@ describe('RestrictedFS', () => {
     });
   });
 
+  describe('mount/unmount operations', () => {
+    let mountOpVfs: VirtualFS;
+
+    beforeAll(async () => {
+      mountOpVfs = await VirtualFS.create({ dbName: 'test-restricted-fs-mount-ops', wipe: true });
+      await mountOpVfs.mkdir('/scoops/editor', { recursive: true });
+      await mountOpVfs.mkdir('/scoops/editor/da-site', { recursive: true });
+      await mountOpVfs.mkdir('/workspace/external', { recursive: true });
+    });
+
+    it('mount succeeds when target is within writable paths', async () => {
+      const rfs = new RestrictedFS(mountOpVfs, ['/scoops/editor/']);
+      const fakeBackend = {
+        readDir: async () => [],
+        readFile: async () => new Uint8Array(),
+        stat: async () => ({ type: 'directory' as const, size: 0, mtimeMs: 0 }),
+        writeFile: async () => {},
+        mkdir: async () => {},
+        rm: async () => {},
+        exists: async () => true,
+        close: async () => {},
+      };
+      await expect(rfs.mount('/scoops/editor/da-site', fakeBackend)).resolves.not.toThrow();
+      expect(rfs.listMounts()).toContain('/scoops/editor/da-site');
+      await rfs.unmount('/scoops/editor/da-site');
+    });
+
+    it('mount throws EACCES when target is outside writable paths (hard enforcement)', async () => {
+      const rfs = new RestrictedFS(mountOpVfs, ['/scoops/editor/'], [], 'hard');
+      const fakeBackend = {
+        readDir: async () => [],
+        readFile: async () => new Uint8Array(),
+        stat: async () => ({ type: 'directory' as const, size: 0, mtimeMs: 0 }),
+        writeFile: async () => {},
+        mkdir: async () => {},
+        rm: async () => {},
+        exists: async () => true,
+      };
+      await expect(rfs.mount('/workspace/external', fakeBackend)).rejects.toThrow('EACCES');
+    });
+
+    it('mount passes through under sudo-delegated enforcement', async () => {
+      const rfs = new RestrictedFS(mountOpVfs, ['/scoops/editor/'], [], 'sudo-delegated');
+      const fakeBackend = {
+        readDir: async () => [],
+        readFile: async () => new Uint8Array(),
+        stat: async () => ({ type: 'directory' as const, size: 0, mtimeMs: 0 }),
+        writeFile: async () => {},
+        mkdir: async () => {},
+        rm: async () => {},
+        exists: async () => true,
+        close: async () => {},
+      };
+      await expect(rfs.mount('/workspace/external', fakeBackend)).resolves.not.toThrow();
+      expect(rfs.listMounts()).toContain('/workspace/external');
+      await rfs.unmount('/workspace/external');
+    });
+
+    it('listMounts and getMountIndex delegate to VFS', async () => {
+      const rfs = new RestrictedFS(mountOpVfs, ['/scoops/editor/']);
+      expect(rfs.listMounts()).toEqual(mountOpVfs.listMounts());
+      expect(rfs.getMountIndex()).toBe(mountOpVfs.getMountIndex());
+    });
+  });
+
   // ── Symlink target validation ─────────────────────────────────────
 
   describe('symlink target validation', () => {

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -287,7 +287,7 @@ describe('RestrictedFS', () => {
       await expect(rfs.mount('/workspace/external', fakeBackend)).rejects.toThrow('EACCES');
     });
 
-    it('mount passes through under sudo-delegated enforcement', async () => {
+    it('mount is ungated at RestrictedFS layer under sudo-delegated (credential resolver is the real gate)', async () => {
       const rfs = new RestrictedFS(mountOpVfs, ['/scoops/editor/'], [], 'sudo-delegated');
       const fakeBackend = {
         readDir: async () => [],

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -4,8 +4,26 @@
 
 import { beforeAll, describe, expect, it } from 'vitest';
 import 'fake-indexeddb/auto';
+import type { MountBackend } from '../../src/fs/mount/backend.js';
 import { RestrictedFS } from '../../src/fs/restricted-fs.js';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
+
+function fakeMountBackend(): MountBackend {
+  return {
+    kind: 'da',
+    source: 'da://test/repo',
+    mountId: 'test-mount-id',
+    readDir: async () => [],
+    readFile: async () => new Uint8Array(),
+    stat: async () => ({ kind: 'directory', size: 0, mtime: 0 }),
+    writeFile: async () => {},
+    mkdir: async () => {},
+    remove: async () => {},
+    refresh: async () => ({ added: [], removed: [], changed: [], unchanged: 0, errors: [] }),
+    describe: () => ({ displayName: 'test/repo' }),
+    close: async () => {},
+  };
+}
 
 describe('RestrictedFS', () => {
   let vfs: VirtualFS;
@@ -258,49 +276,20 @@ describe('RestrictedFS', () => {
 
     it('mount succeeds when target is within writable paths', async () => {
       const rfs = new RestrictedFS(mountOpVfs, ['/scoops/editor/']);
-      const fakeBackend = {
-        readDir: async () => [],
-        readFile: async () => new Uint8Array(),
-        stat: async () => ({ type: 'directory' as const, size: 0, mtimeMs: 0 }),
-        writeFile: async () => {},
-        mkdir: async () => {},
-        rm: async () => {},
-        exists: async () => true,
-        close: async () => {},
-      };
-      await expect(rfs.mount('/scoops/editor/da-site', fakeBackend)).resolves.not.toThrow();
+      await expect(rfs.mount('/scoops/editor/da-site', fakeMountBackend())).resolves.not.toThrow();
       expect(rfs.listMounts()).toContain('/scoops/editor/da-site');
       await rfs.unmount('/scoops/editor/da-site');
     });
 
     it('mount throws EACCES when target is outside writable paths (hard enforcement)', async () => {
       const rfs = new RestrictedFS(mountOpVfs, ['/scoops/editor/'], [], 'hard');
-      const fakeBackend = {
-        readDir: async () => [],
-        readFile: async () => new Uint8Array(),
-        stat: async () => ({ type: 'directory' as const, size: 0, mtimeMs: 0 }),
-        writeFile: async () => {},
-        mkdir: async () => {},
-        rm: async () => {},
-        exists: async () => true,
-      };
-      await expect(rfs.mount('/workspace/external', fakeBackend)).rejects.toThrow('EACCES');
+      await expect(rfs.mount('/workspace/external', fakeMountBackend())).rejects.toThrow('EACCES');
     });
 
     it('mount passes through RestrictedFS under sudo-delegated (SudoFS gates via cone approval)', async () => {
       const rfs = new RestrictedFS(mountOpVfs, ['/scoops/editor/'], [], 'sudo-delegated');
-      const fakeBackend = {
-        readDir: async () => [],
-        readFile: async () => new Uint8Array(),
-        stat: async () => ({ type: 'directory' as const, size: 0, mtimeMs: 0 }),
-        writeFile: async () => {},
-        mkdir: async () => {},
-        rm: async () => {},
-        exists: async () => true,
-        close: async () => {},
-      };
       // RestrictedFS layer passes through — SudoFS is responsible for gating
-      await expect(rfs.mount('/workspace/external', fakeBackend)).resolves.not.toThrow();
+      await expect(rfs.mount('/workspace/external', fakeMountBackend())).resolves.not.toThrow();
       expect(rfs.listMounts()).toContain('/workspace/external');
       await rfs.unmount('/workspace/external');
     });

--- a/packages/webapp/tests/fs/sudo-fs.test.ts
+++ b/packages/webapp/tests/fs/sudo-fs.test.ts
@@ -10,6 +10,7 @@
 import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { FsError, RestrictedFS, VirtualFS } from '../../src/fs/index.js';
+import type { MountBackend } from '../../src/fs/mount/backend.js';
 import { createSudoFs, GRANTED_FILE } from '../../src/fs/sudo-fs.js';
 import { NO_OP_WRITE_DEVICE_PATHS } from '../../src/fs/virtual-device-paths.js';
 import { mergePolicies, parseSudoers, type SudoersPolicy } from '../../src/shell/sudo/sudoers.js';
@@ -238,20 +239,28 @@ describe('SudoFS', () => {
   });
 
   describe('mount/unmount/refreshMount gating', () => {
+    function fakeMountBackend(): MountBackend {
+      return {
+        kind: 'da',
+        source: 'da://test/repo',
+        mountId: 'test-mount-id',
+        readDir: async () => [],
+        readFile: async () => new Uint8Array(),
+        stat: async () => ({ kind: 'directory', size: 0, mtime: 0 }),
+        writeFile: async () => {},
+        mkdir: async () => {},
+        remove: async () => {},
+        refresh: async () => ({ added: [], removed: [], changed: [], unchanged: 0, errors: [] }),
+        describe: () => ({ displayName: 'test/repo' }),
+        close: async () => {},
+      };
+    }
+
     it('gates mount as a write and blocks on deny', async () => {
       const { calls, broker } = makeBroker({ decision: 'deny' });
       const sfs = createSudoFs(vfs, { broker, getPolicy, defaultDisposition: 'require-approval' });
 
-      const fakeBackend = {
-        readDir: async () => [],
-        readFile: async () => new Uint8Array(),
-        stat: async () => ({ type: 'directory' as const, size: 0, mtimeMs: 0 }),
-        writeFile: async () => {},
-        mkdir: async () => {},
-        rm: async () => {},
-        exists: async () => true,
-      };
-      await expect(sfs.mount('/workspace/external', fakeBackend)).rejects.toMatchObject({
+      await expect(sfs.mount('/workspace/external', fakeMountBackend())).rejects.toMatchObject({
         code: 'EACCES',
       });
       expect(calls[0]).toMatchObject({ kind: 'write', detail: '/workspace/external' });
@@ -261,16 +270,7 @@ describe('SudoFS', () => {
       const { calls, broker } = makeBroker({ decision: 'allow' });
       const sfs = createSudoFs(vfs, { broker, getPolicy, defaultDisposition: 'require-approval' });
 
-      const fakeBackend = {
-        readDir: async () => [],
-        readFile: async () => new Uint8Array(),
-        stat: async () => ({ type: 'directory' as const, size: 0, mtimeMs: 0 }),
-        writeFile: async () => {},
-        mkdir: async () => {},
-        rm: async () => {},
-        exists: async () => true,
-      };
-      await sfs.mount('/workspace/external', fakeBackend);
+      await sfs.mount('/workspace/external', fakeMountBackend());
       expect(calls[0]).toMatchObject({ kind: 'write', detail: '/workspace/external' });
       expect(sfs.listMounts()).toContain('/workspace/external');
     });

--- a/packages/webapp/tests/fs/sudo-fs.test.ts
+++ b/packages/webapp/tests/fs/sudo-fs.test.ts
@@ -237,6 +237,65 @@ describe('SudoFS', () => {
     expect(calls[0]).toMatchObject({ kind: 'write', detail: '/etc/sudoers.d/inject' });
   });
 
+  describe('mount/unmount/refreshMount gating', () => {
+    it('gates mount as a write and blocks on deny', async () => {
+      const { calls, broker } = makeBroker({ decision: 'deny' });
+      const sfs = createSudoFs(vfs, { broker, getPolicy, defaultDisposition: 'require-approval' });
+
+      const fakeBackend = {
+        readDir: async () => [],
+        readFile: async () => new Uint8Array(),
+        stat: async () => ({ type: 'directory' as const, size: 0, mtimeMs: 0 }),
+        writeFile: async () => {},
+        mkdir: async () => {},
+        rm: async () => {},
+        exists: async () => true,
+      };
+      await expect(sfs.mount('/workspace/external', fakeBackend)).rejects.toMatchObject({
+        code: 'EACCES',
+      });
+      expect(calls[0]).toMatchObject({ kind: 'write', detail: '/workspace/external' });
+    });
+
+    it('allows mount when broker approves', async () => {
+      const { calls, broker } = makeBroker({ decision: 'allow' });
+      const sfs = createSudoFs(vfs, { broker, getPolicy, defaultDisposition: 'require-approval' });
+
+      const fakeBackend = {
+        readDir: async () => [],
+        readFile: async () => new Uint8Array(),
+        stat: async () => ({ type: 'directory' as const, size: 0, mtimeMs: 0 }),
+        writeFile: async () => {},
+        mkdir: async () => {},
+        rm: async () => {},
+        exists: async () => true,
+      };
+      await sfs.mount('/workspace/external', fakeBackend);
+      expect(calls[0]).toMatchObject({ kind: 'write', detail: '/workspace/external' });
+      expect(sfs.listMounts()).toContain('/workspace/external');
+    });
+
+    it('gates unmount as a write', async () => {
+      const { calls, broker } = makeBroker({ decision: 'deny' });
+      const sfs = createSudoFs(vfs, { broker, getPolicy, defaultDisposition: 'require-approval' });
+
+      await expect(sfs.unmount('/workspace/external')).rejects.toMatchObject({
+        code: 'EACCES',
+      });
+      expect(calls[0]).toMatchObject({ kind: 'write', detail: '/workspace/external' });
+    });
+
+    it('gates refreshMount as a write', async () => {
+      const { calls, broker } = makeBroker({ decision: 'deny' });
+      const sfs = createSudoFs(vfs, { broker, getPolicy, defaultDisposition: 'require-approval' });
+
+      await expect(sfs.refreshMount('/workspace/external')).rejects.toMatchObject({
+        code: 'EACCES',
+      });
+      expect(calls[0]).toMatchObject({ kind: 'write', detail: '/workspace/external' });
+    });
+  });
+
   describe('defaultDisposition: "require-approval"', () => {
     it('escalates writes to unmatched paths and proceeds on allow', async () => {
       policy = parseSudoers(''); // no rules — everything is no-match by default


### PR DESCRIPTION
<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary
- Scoops running mount --source da://... threw this.options.fs.mount is not a function because RestrictedFS lacked mount operations.
- Added mount(), unmount(), listMounts(), getMountIndex(), and refreshMount() to RestrictedFS, delegating to the underlying VFS.
- mount and unmount enforce both checkWrite() and checkParentRealpathEscape() (symlink escape guard), consistent with sibling write ops.
- refreshMount enforces checkWrite() for parity.
- Under 'hard' enforcement a scoop can only mount into its writable paths. Under 'sudo-delegated' (production) the mount is ungated at the RestrictedFS layer — the credential resolver (node-server sign-and-forward for DA/S3) is the real trust boundary, matching the design intent in mount-commands.ts: "Scoops can mount S3 and DA freely."
<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

**Trust boundary**

The mount itself is path-level plumbing. The actual security gate is the credential resolver: DA mounts go through /api/da-sign-and-forward (which requires a valid IMS token), and S3 mounts go through /api/s3-sign-and-forward (which requires stored profile credentials). A scoop cannot fabricate these credentials — it can mount the VFS path but the backend requests fail without auth.

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
