### PR TITLE
fix(webapp): stop the cherry sprinkle repaint nudge from self-triggering

### DIFF
--- a/packages/webapp/src/ui/iframe-repaint.ts
+++ b/packages/webapp/src/ui/iframe-repaint.ts
@@ -25,12 +25,13 @@ export function isNestedInAnotherFrame(): boolean {
  * the missing repaint for this bug — only a `display` toggle (or an
  * out-of-band event like DevTools attaching) does.
  */
-export function nudgeIframeRepaint(iframe: HTMLIFrameElement): void {
+export function nudgeIframeRepaint(iframe: HTMLIFrameElement, onDone?: () => void): void {
   const previousDisplay = iframe.style.display;
   iframe.style.display = 'none';
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       iframe.style.display = previousDisplay;
+      onDone?.();
     });
   });
 }

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -839,17 +839,33 @@ export class SprinkleRenderer {
     // iframe — no new `load` event fires on re-show, so the one-shot nudge
     // above can't catch a re-show that resurfaces the Chromium compositor
     // bug. Re-nudge on every hidden→visible transition after the first.
+    //
+    // `nudgeIframeRepaint` itself toggles the iframe's `display`, which is
+    // exactly what this observer watches. A "skip while nudging" flag isn't
+    // enough — the nudge's own display:none→restore flip is still a real
+    // hidden→visible transition that fires AFTER the flag resets, so it
+    // re-triggers another nudge forever. Actually unobserve for the duration
+    // of the nudge and re-observe once it settles, so the nudge's own
+    // display flicker never reaches this callback.
     if (isNestedInAnotherFrame() && typeof IntersectionObserver !== 'undefined') {
       let sawInitialState = false;
-      this.visibilityObserver = new IntersectionObserver((entries) => {
+      const observer = new IntersectionObserver((entries) => {
         const entry = entries[entries.length - 1];
         if (!sawInitialState) {
           sawInitialState = true;
           return;
         }
-        if (entry.isIntersecting) nudgeIframeRepaint(iframe);
+        if (!entry.isIntersecting) return;
+        observer.unobserve(iframe);
+        nudgeIframeRepaint(iframe, () => {
+          // Re-observing fires a fresh synthetic "initial state" callback —
+          // treat it as such so it doesn't immediately re-nudge.
+          sawInitialState = false;
+          observer.observe(iframe);
+        });
       });
-      this.visibilityObserver.observe(iframe);
+      this.visibilityObserver = observer;
+      observer.observe(iframe);
     }
   }
 

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -493,6 +493,7 @@ describe('full document rendering', () => {
     let observerCallback: ((entries: Array<{ isIntersecting: boolean }>) => void) | null = null;
     const observe = vi.fn();
     const disconnect = vi.fn();
+    const unobserve = vi.fn();
     const originalIO = (globalThis as any).IntersectionObserver;
     class FakeIntersectionObserver {
       constructor(cb: typeof observerCallback) {
@@ -500,7 +501,7 @@ describe('full document rendering', () => {
       }
       observe = observe;
       disconnect = disconnect;
-      unobserve = vi.fn();
+      unobserve = unobserve;
     }
     (globalThis as any).IntersectionObserver = FakeIntersectionObserver;
 
@@ -526,6 +527,17 @@ describe('full document rendering', () => {
       observerCallback!([{ isIntersecting: false }]);
       observerCallback!([{ isIntersecting: true }]);
       expect(rafCallbacks.length).toBe(1);
+      expect(unobserve).toHaveBeenCalledTimes(1);
+
+      // Completing the nudge's own display:none -> restore flip must NOT
+      // retrigger another nudge — regression test for a self-sustaining
+      // infinite nudge loop (the nudge's own visibility flicker was feeding
+      // straight back into this same observer).
+      rafCallbacks.shift()!();
+      rafCallbacks.shift()!();
+      expect(observe).toHaveBeenCalledTimes(2); // initial + re-observe after nudge
+      observerCallback!([{ isIntersecting: true }]); // synthetic post-reobserve callback
+      expect(rafCallbacks.length).toBe(0);
     } finally {
       (globalThis as any).requestAnimationFrame = originalRaf;
       (globalThis as any).IntersectionObserver = originalIO;


### PR DESCRIPTION
nudgeIframeRepaint() toggles the iframe's display to force Chromium to recomposite — but the visibility-triggered re-nudge added for tab-switch re-shows watches that same iframe's intersection state. The nudge's own display:none -> restore flip is itself a hidden -> visible transition, so it fed straight back into the observer and re-triggered another nudge forever: the iframe never settled, stuck flickering and never staying visible long enough to render.

Unobserve for the duration of each nudge and re-observe only once it settles, so the nudge's own flicker never reaches the callback.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
