### PR TITLE
fix(worker): strip user-supplied adobe account from resume delta

### DIFF
--- a/packages/cloudflare-worker/src/cloud/cloud-sessions-do.ts
+++ b/packages/cloudflare-worker/src/cloud/cloud-sessions-do.ts
@@ -274,11 +274,14 @@ export class CloudSessionsDurableObject {
       // window-less kernel worker would otherwise treat the refreshed (valid)
       // token as expired and throw "Adobe session expired" on its first turn.
       const adobeExpiresAt = imsTokenExpiry(body.bearer);
-      // Strip any user-supplied adobe account — the worker's fresh bearer from
-      // the Auth header is authoritative. Without this, a stale token cached in
-      // localStorage overwrites the fresh one (last-write-wins in mergeConeConfig).
+      // Strip any user-supplied adobe account/secret — the worker's fresh bearer
+      // from the Auth header is authoritative. Without this, a stale token cached
+      // in localStorage overwrites the fresh one (last-write-wins in mergeConeConfig).
       const userAccounts = (userDelta?.upsert?.accounts ?? []).filter(
         (a) => a.providerId !== 'adobe'
+      );
+      const userSecrets = (userDelta?.upsert?.secrets ?? []).filter(
+        (s) => s.name !== 'ADOBE_IMS_TOKEN'
       );
       const mergedDelta: ConeConfigDelta = {
         ...(userDelta?.model ? { model: userDelta.model } : {}),
@@ -294,7 +297,7 @@ export class CloudSessionsDurableObject {
           ],
           secrets: [
             { name: 'ADOBE_IMS_TOKEN', value: body.bearer, domains: [ADOBE_TOKEN_DOMAINS] },
-            ...(userDelta?.upsert?.secrets ?? []),
+            ...userSecrets,
           ],
         },
         ...(userDelta?.delete ? { delete: userDelta.delete } : {}),

--- a/packages/cloudflare-worker/src/cloud/cloud-sessions-do.ts
+++ b/packages/cloudflare-worker/src/cloud/cloud-sessions-do.ts
@@ -265,14 +265,21 @@ export class CloudSessionsDurableObject {
       const userDelta = body.coneConfigDelta as ConeConfigDelta | undefined;
       // Always refresh the Adobe IMS bearer, merged with any user edits, through
       // the read-modify-write delta path. A raw refreshSecretsContents overwrite
-      // would clobber every OTHER flat secret/account in /slicc/secrets.env. User
-      // upserts come after Adobe's (so a user re-auth wins by providerId/name),
-      // and a user delete of 'adobe' still wins (merge applies upserts then deletes).
+      // would clobber every OTHER flat secret/account in /slicc/secrets.env. The
+      // worker's bearer is authoritative for adobe (user-supplied adobe accounts
+      // are stripped), and a user delete of 'adobe' still wins (merge applies
+      // upserts then deletes).
       // Stamp tokenExpiresAt so a resume without a fresh user-supplied adobe
       // account doesn't leave the cone with an expiry-less oauth entry — the
       // window-less kernel worker would otherwise treat the refreshed (valid)
       // token as expired and throw "Adobe session expired" on its first turn.
       const adobeExpiresAt = imsTokenExpiry(body.bearer);
+      // Strip any user-supplied adobe account — the worker's fresh bearer from
+      // the Auth header is authoritative. Without this, a stale token cached in
+      // localStorage overwrites the fresh one (last-write-wins in mergeConeConfig).
+      const userAccounts = (userDelta?.upsert?.accounts ?? []).filter(
+        (a) => a.providerId !== 'adobe'
+      );
       const mergedDelta: ConeConfigDelta = {
         ...(userDelta?.model ? { model: userDelta.model } : {}),
         upsert: {
@@ -283,7 +290,7 @@ export class CloudSessionsDurableObject {
               accessToken: body.bearer,
               ...(adobeExpiresAt !== undefined ? { tokenExpiresAt: adobeExpiresAt } : {}),
             },
-            ...(userDelta?.upsert?.accounts ?? []),
+            ...userAccounts,
           ],
           secrets: [
             { name: 'ADOBE_IMS_TOKEN', value: body.bearer, domains: [ADOBE_TOKEN_DOMAINS] },

--- a/packages/cloudflare-worker/tests/cloud-sessions-do.test.ts
+++ b/packages/cloudflare-worker/tests/cloud-sessions-do.test.ts
@@ -439,4 +439,54 @@ describe('CloudSessionsDurableObject — lifecycle endpoints', () => {
     );
     expect(adobe).toMatchObject({ kind: 'oauth', tokenExpiresAt: created + ttl });
   });
+
+  it('resume-cone strips user-supplied adobe account so the fresh bearer wins', async () => {
+    const created = 1_780_000_000_000;
+    const ttl = 86_400_000;
+    const b64url = (o: object) =>
+      btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const freshBearer = [
+      b64url({ alg: 'RS256', typ: 'JWT' }),
+      b64url({ created_at: String(created), expires_in: String(ttl) }),
+      'fresh-sig',
+    ].join('.');
+    const staleToken = 'stale-adobe-token-from-localstorage';
+
+    const substrate = new FakeSubstrate();
+    substrate.seedSandbox('s-stale', {
+      metadata: { userId: 'u1', name: 'stale' },
+      state: 'paused',
+    });
+    const { state } = makeFakeState();
+    const do_ = new CloudSessionsDurableObject(state as any, makeDoEnv(substrate));
+    await call(do_, '/list-cones', { userId: 'u1' });
+
+    const res = await call(do_, '/resume-cone', {
+      bearer: freshBearer,
+      sandboxId: 's-stale',
+      localSliccVersion: 'v',
+      userId: 'u1',
+      coneConfigDelta: {
+        upsert: {
+          accounts: [
+            { providerId: 'adobe', kind: 'oauth', accessToken: staleToken },
+            { providerId: 'github', kind: 'oauth', accessToken: 'ghp_valid' },
+          ],
+        },
+      },
+    });
+    expect(res.status).toBe(200);
+
+    const written = await (await substrate.connect('s-stale')).readFile('/slicc/cone-config.json');
+    const accounts = JSON.parse(written).accounts as Array<{
+      providerId: string;
+      accessToken?: string;
+    }>;
+    const adobe = accounts.find((a) => a.providerId === 'adobe');
+    const github = accounts.find((a) => a.providerId === 'github');
+    // Fresh bearer from the Auth header wins — stale user-supplied adobe is stripped
+    expect(adobe?.accessToken).toBe(freshBearer);
+    // Non-adobe user accounts pass through
+    expect(github?.accessToken).toBe('ghp_valid');
+  });
 });

--- a/packages/webapp/cloud/cone-config-client.js
+++ b/packages/webapp/cloud/cone-config-client.js
@@ -147,12 +147,11 @@ export function validateModelHasAccount(model, selectedProviderIds, authOptional
   return selectedProviderIds.includes(provider);
 }
 
-// Build the coneConfigDelta for a plain resume. The worker injects a fresh
-// Adobe IMS bearer server-side, but WITHOUT a tokenExpiresAt — and the cone's
-// getValidAccessToken treats a missing expiry as already-expired, then fails
-// silent renewal headlessly ("Adobe session expired"). So resume must re-ship
-// the connected accounts the same shape as start (carrying tokenExpiresAt); the
-// later upsert wins by providerId in mergeConeConfig, restoring the expiry.
+// Build the coneConfigDelta for a plain resume. The worker strips any
+// user-supplied adobe account/secret (its fresh Auth header bearer is
+// authoritative), but non-adobe accounts (e.g. github) are passed through.
+// We still ship all connected accounts so their tokenExpiresAt values reach
+// the cone — without expiry the kernel worker treats valid tokens as expired.
 // Only accounts (no model/secrets/deletes) — a plain resume changes nothing else.
 export function assembleResumeDelta(allAccounts) {
   return assembleDelta({


### PR DESCRIPTION
The dashboard's Manage panel sends all localStorage accounts in the coneConfigDelta, including a potentially stale Adobe token. Because mergeConeConfig uses last-write-wins by providerId, the stale user token was overwriting the fresh bearer from the Authorization header, causing 401 errors on the first LLM call after resume.

Filter out providerId:'adobe' from user-supplied accounts so the worker's fresh bearer always wins.

Closes #1272

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
