### PR TITLE
fix(webcomponents): copy file/folder path with Ctrl/Cmd+C in file tree

### DIFF
--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -137,8 +137,6 @@ const CSS = [
   'box-sizing:border-box;font-family:var(--ui);border-radius:3px;border:1px solid var(--line);',
   'background:var(--canvas);color:var(--txt-2);cursor:pointer;}',
   'slicc-file-tree .ft-act:hover{background:var(--ghost);}',
-  // 300ms green flash on Cmd+C copy-path.
-  'slicc-file-tree .ft-copy-flash{background:color-mix(in srgb,#22c55e 18%,var(--canvas))!important;}',
   '.wcui-memory{flex:1;min-height:0;overflow:auto;display:flex;flex-direction:column;',
   'gap:8px;padding:10px;}',
   '.wcui-monitor{flex:1;min-height:0;}',

--- a/packages/webcomponents/src/workbench/slicc-file-tree.ts
+++ b/packages/webcomponents/src/workbench/slicc-file-tree.ts
@@ -370,6 +370,7 @@ export class SliccFileTree extends HTMLElement {
   #initialized = false;
   #onClick: ((e: MouseEvent) => void) | null = null;
   #onKeyDown: ((e: KeyboardEvent) => void) | null = null;
+  #flashTimeout: ReturnType<typeof setTimeout> | null = null;
 
   connectedCallback(): void {
     ensureFileTreeStyle(this.ownerDocument);
@@ -395,6 +396,10 @@ export class SliccFileTree extends HTMLElement {
     if (this.#onKeyDown) {
       this.removeEventListener('keydown', this.#onKeyDown);
       this.#onKeyDown = null;
+    }
+    if (this.#flashTimeout != null) {
+      clearTimeout(this.#flashTimeout);
+      this.#flashTimeout = null;
     }
   }
 
@@ -657,9 +662,17 @@ export class SliccFileTree extends HTMLElement {
       if (!row) return;
       e.preventDefault();
       const path = this.#paths.get(id) ?? id;
-      void navigator.clipboard?.writeText(path);
-      row.classList.add('ft-copy-flash');
-      setTimeout(() => row.classList.remove('ft-copy-flash'), 300);
+      navigator.clipboard
+        ?.writeText(path)
+        .then(() => {
+          if (this.#flashTimeout != null) clearTimeout(this.#flashTimeout);
+          row.classList.add('ft-copy-flash');
+          this.#flashTimeout = setTimeout(() => {
+            row.classList.remove('ft-copy-flash');
+            this.#flashTimeout = null;
+          }, 300);
+        })
+        .catch(() => undefined);
     };
     this.addEventListener('keydown', this.#onKeyDown);
   }

--- a/packages/webcomponents/src/workbench/slicc-file-tree.ts
+++ b/packages/webcomponents/src/workbench/slicc-file-tree.ts
@@ -15,7 +15,14 @@ import { iconEl } from '../internal/icons.js';
  */
 export type FileTreeItem =
   | { kind: 'group'; label: string }
-  | { kind: 'dir'; id: string; label: string; open?: boolean; children: FileTreeItem[] }
+  | {
+      kind: 'dir';
+      id: string;
+      label: string;
+      path?: string;
+      open?: boolean;
+      children: FileTreeItem[];
+    }
   | { kind: 'file'; id: string; label: string; path?: string; size?: number };
 
 /** Pick a lucide icon name based on the file's extension. */
@@ -165,6 +172,18 @@ slicc-file-tree .dir .chev {
 slicc-file-tree .dir.open .chev {
   transform: rotate(90deg);
 }
+slicc-file-tree .dir.on {
+  background: color-mix(in srgb, var(--violet) 10%, var(--canvas));
+  color: var(--violet);
+  box-shadow: inset 2px 0 0 var(--violet);
+}
+slicc-file-tree .dir.on .chev {
+  color: var(--violet);
+}
+slicc-file-tree .f.ft-copy-flash,
+slicc-file-tree .dir.ft-copy-flash {
+  background: color-mix(in srgb, #22c55e 18%, var(--canvas)) !important;
+}
 slicc-file-tree .children {
   padding-left: 12px;
 }
@@ -192,12 +211,14 @@ slicc-file-tree .actions {
   align-items: center;
   gap: 2px;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 0.1s ease;
   background: linear-gradient(to right, transparent, var(--canvas, #fff) 8px);
   padding-left: 12px;
 }
 slicc-file-tree .f:hover .actions {
   opacity: 1;
+  pointer-events: auto;
 }
 slicc-file-tree .f.on .actions {
   background: linear-gradient(to right, transparent, color-mix(in srgb, var(--violet) 10%, var(--canvas)) 8px);
@@ -223,7 +244,9 @@ slicc-file-tree .actions button:active {
 }
 
 .dark slicc-file-tree .f.on,
-[data-theme="dark"] slicc-file-tree .f.on {
+[data-theme="dark"] slicc-file-tree .f.on,
+.dark slicc-file-tree .dir.on,
+[data-theme="dark"] slicc-file-tree .dir.on {
   background: color-mix(in srgb, var(--violet) 22%, var(--canvas));
 }
 `;
@@ -260,6 +283,7 @@ function buildNodes(items: readonly FileTreeItem[], openDirs: ReadonlySet<string
             class: open ? 'dir open' : 'dir',
             'data-dir-id': item.id,
             'aria-expanded': open ? 'true' : 'false',
+            tabindex: '0',
           },
           iconEl('chevron-right', { size: 14, class: 'chev' }),
           item.label
@@ -287,7 +311,7 @@ function buildNodes(items: readonly FileTreeItem[], openDirs: ReadonlySet<string
       );
       const row = h(
         'div',
-        { class: 'f', 'data-id': item.id },
+        { class: 'f', 'data-id': item.id, tabindex: '0' },
         iconEl(fileIcon(item.label), { size: 12, class: 'ficon' }),
         item.label,
         actions
@@ -303,11 +327,13 @@ function buildNodes(items: readonly FileTreeItem[], openDirs: ReadonlySet<string
  * `<slicc-file-tree>` — the VFS sidebar from the prototype (`.tree`). A fixed
  * 190px, non-shrinking column of directory group headers (`.grp`), foldable
  * directories (`.dir`, a chevron toggle), and clickable file rows (`.f`), each
- * with a small bullet. Single-selection: the active file (`.f.on`) is tinted
- * violet, and clicking a file row (or calling {@link SliccFileTree.selectFile})
- * selects it and emits `file-select`. Clicking a `.dir` row (or calling
- * {@link SliccFileTree.toggleDir}) folds/expands its nested children and emits
- * `dir-toggle`.
+ * with a small bullet. Single-selection across both kinds: the active row
+ * (`.f.on` or `.dir.on`) is tinted violet. Clicking a file row (or calling
+ * {@link SliccFileTree.selectFile}) selects it and emits `file-select`.
+ * Clicking a `.dir` row (or calling {@link SliccFileTree.toggleDir}) selects
+ * it, folds/expands its nested children, and emits `dir-toggle`. With a row
+ * selected, Ctrl/Cmd+C copies its resolved VFS path to the clipboard and
+ * flashes the row green for 300ms.
  *
  * Light DOM (no shadow root): the host renders its rows directly into itself so
  * the host app can style/slot it. The scoped stylesheet is injected once into
@@ -343,6 +369,7 @@ export class SliccFileTree extends HTMLElement {
   #openDirs = new Set<string>();
   #initialized = false;
   #onClick: ((e: MouseEvent) => void) | null = null;
+  #onKeyDown: ((e: KeyboardEvent) => void) | null = null;
 
   connectedCallback(): void {
     ensureFileTreeStyle(this.ownerDocument);
@@ -357,12 +384,17 @@ export class SliccFileTree extends HTMLElement {
     }
     this.#render();
     this.#bindClick();
+    this.#bindKeyDown();
   }
 
   disconnectedCallback(): void {
     if (this.#onClick) {
       this.removeEventListener('click', this.#onClick);
       this.#onClick = null;
+    }
+    if (this.#onKeyDown) {
+      this.removeEventListener('keydown', this.#onKeyDown);
+      this.#onKeyDown = null;
     }
   }
 
@@ -434,8 +466,7 @@ export class SliccFileTree extends HTMLElement {
   selectFile(id: string): void {
     const target = this.querySelector<HTMLElement>(`.f[data-id="${cssEscape(id)}"]`);
     if (!target) return;
-    if (this.getAttribute('selected') !== id) this.setAttribute('selected', id);
-    this.#applySelection();
+    this.#setSelected(id, target);
     const path = this.#paths.get(id) ?? id;
     this.dispatchEvent(
       new CustomEvent('file-select', {
@@ -446,11 +477,18 @@ export class SliccFileTree extends HTMLElement {
     );
   }
 
+  /** Mark `id` as the active selection, tint its row, and focus it (for Ctrl/Cmd+C). */
+  #setSelected(id: string, row: HTMLElement): void {
+    if (this.getAttribute('selected') !== id) this.setAttribute('selected', id);
+    this.#applySelection();
+    row.focus();
+  }
+
   /** Read the active selection into the live rows (toggling `.on`). */
   #applySelection(): void {
     const sel = this.getAttribute('selected');
-    for (const row of this.querySelectorAll<HTMLElement>('.f')) {
-      row.classList.toggle('on', row.dataset.id === sel);
+    for (const row of this.querySelectorAll<HTMLElement>('.f, .dir')) {
+      row.classList.toggle('on', (row.dataset.id ?? row.dataset.dirId) === sel);
     }
   }
 
@@ -475,19 +513,37 @@ export class SliccFileTree extends HTMLElement {
     return items;
   }
 
+  /**
+   * Rebuild every row from `#items`. `replaceChildren` tears down and recreates
+   * the DOM nodes wholesale, which silently drops focus (a click-triggered
+   * `toggleDir` right after selecting a row, or the workbench's periodic VFS
+   * refresh reassigning `items` while a row is focused). Re-focus the
+   * surviving selection's row afterward whenever focus was inside the tree,
+   * so Ctrl/Cmd+C keeps working across a toggle or a background refresh.
+   */
   #render(): void {
+    const hadFocus = this.contains(document.activeElement);
     const items = this.#items ?? [];
     this.#paths.clear();
     this.#collectPaths(items);
     this.replaceChildren(...buildNodes(items, this.#openDirs));
     this.#applySelection();
+    const sel = this.getAttribute('selected');
+    if (hadFocus && sel != null) {
+      this.querySelector<HTMLElement>(
+        `.f[data-id="${cssEscape(sel)}"], .dir[data-dir-id="${cssEscape(sel)}"]`
+      )?.focus();
+    }
   }
 
-  /** Map every file id (at any depth) to its logical path for `file-select`. */
+  /** Map every file/dir id (at any depth) to its logical path for selection + copy. */
   #collectPaths(items: readonly FileTreeItem[]): void {
     for (const item of items) {
       if (item.kind === 'file') this.#paths.set(item.id, item.path ?? item.label);
-      else if (item.kind === 'dir') this.#collectPaths(item.children ?? []);
+      else if (item.kind === 'dir') {
+        this.#paths.set(item.id, item.path ?? item.id);
+        this.#collectPaths(item.children ?? []);
+      }
     }
   }
 
@@ -574,7 +630,10 @@ export class SliccFileTree extends HTMLElement {
       const dirRow = target?.closest<HTMLElement>('.dir');
       if (dirRow && this.contains(dirRow)) {
         const dirId = dirRow.dataset.dirId;
-        if (dirId != null) this.toggleDir(dirId);
+        if (dirId != null) {
+          this.#setSelected(dirId, dirRow);
+          this.toggleDir(dirId);
+        }
         return;
       }
       const row = target?.closest<HTMLElement>('.f');
@@ -583,6 +642,26 @@ export class SliccFileTree extends HTMLElement {
       if (id != null) this.selectFile(id);
     };
     this.addEventListener('click', this.#onClick);
+  }
+
+  /** Ctrl/Cmd+C on the selected row copies its VFS path and flashes the row green. */
+  #bindKeyDown(): void {
+    if (this.#onKeyDown) return;
+    this.#onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'c' || !(e.ctrlKey || e.metaKey)) return;
+      const id = this.getAttribute('selected');
+      if (id == null) return;
+      const row = this.querySelector<HTMLElement>(
+        `.f[data-id="${cssEscape(id)}"], .dir[data-dir-id="${cssEscape(id)}"]`
+      );
+      if (!row) return;
+      e.preventDefault();
+      const path = this.#paths.get(id) ?? id;
+      void navigator.clipboard?.writeText(path);
+      row.classList.add('ft-copy-flash');
+      setTimeout(() => row.classList.remove('ft-copy-flash'), 300);
+    };
+    this.addEventListener('keydown', this.#onKeyDown);
   }
 }
 

--- a/packages/webcomponents/tests/workbench/slicc-file-tree.test.ts
+++ b/packages/webcomponents/tests/workbench/slicc-file-tree.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureGlobalTokens } from '../../src/theme/tokens.js';
 import type { FileTreeItem } from '../../src/workbench/slicc-file-tree.js';
 import { SliccFileTree } from '../../src/workbench/slicc-file-tree.js';
@@ -528,6 +528,22 @@ describe('slicc-file-tree', () => {
       expect(strip.querySelectorAll('button')).toHaveLength(4);
     });
 
+    it('does not let the idle (opacity:0) actions strip intercept clicks meant for the row', () => {
+      // Regression: the strip used to keep pointer-events:auto while hidden,
+      // silently swallowing clicks over the right ~60% of the row (hitting an
+      // invisible action button) instead of selecting the file.
+      const el = makeTree();
+      document.body.appendChild(el);
+      const row = fileRow(el, 'hero.tsx') as HTMLElement;
+      const strip = row.querySelector('.actions') as HTMLElement;
+      expect(getComputedStyle(strip).pointerEvents).toBe('none');
+
+      const r = row.getBoundingClientRect();
+      const hit = document.elementFromPoint(r.right - 5, r.top + r.height / 2);
+      expect(hit?.closest('.actions')).toBeNull();
+      expect(hit?.closest<HTMLElement>('.f')?.dataset.id).toBe('hero.tsx');
+    });
+
     it('does NOT render action buttons on directory rows', () => {
       const items: FileTreeItem[] = [
         {
@@ -606,6 +622,206 @@ describe('slicc-file-tree', () => {
       const previewBtn = row.querySelector('[data-action="preview"]') as HTMLElement;
       previewBtn.click();
       expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('directory selection', () => {
+    function dirRow(el: SliccFileTree, id: string): HTMLElement | null {
+      return el.querySelector<HTMLElement>(`.dir[data-dir-id="${id}"]`);
+    }
+
+    it('clicking a dir row selects/highlights it in addition to toggling it open', () => {
+      const el = makeTree([
+        { kind: 'dir', id: 'src', label: 'src', children: [] },
+        { kind: 'file', id: 'a.ts', label: 'a.ts' },
+      ]);
+      document.body.appendChild(el);
+      dirRow(el, 'src')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(el.selected).toBe('src');
+      expect(dirRow(el, 'src')?.classList.contains('on')).toBe(true);
+      expect(el.isDirOpen('src')).toBe(true);
+    });
+
+    it('selecting a dir clears a previous file selection (single selection across kinds)', () => {
+      const el = makeTree([
+        { kind: 'dir', id: 'src', label: 'src', children: [] },
+        { kind: 'file', id: 'a.ts', label: 'a.ts' },
+      ]);
+      document.body.appendChild(el);
+      el.selectFile('a.ts');
+      dirRow(el, 'src')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(fileRow(el, 'a.ts')?.classList.contains('on')).toBe(false);
+      expect(dirRow(el, 'src')?.classList.contains('on')).toBe(true);
+    });
+
+    it('keeps focus on the row across the click-triggered toggle re-render', () => {
+      // Regression: clicking a dir selects+focuses it, then toggleDir()
+      // immediately replaceChildren()s the whole tree, which used to strand
+      // focus on the now-detached old row (breaking Ctrl+C right after click).
+      const el = makeTree([{ kind: 'dir', id: 'src', label: 'src', children: [] }]);
+      document.body.appendChild(el);
+      dirRow(el, 'src')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(document.activeElement).toBe(dirRow(el, 'src'));
+    });
+  });
+
+  describe('Ctrl/Cmd+C copy-path', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    function fireCopy(el: SliccFileTree, opts: KeyboardEventInit = {}): void {
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true, ...opts })
+      );
+    }
+
+    /**
+     * Fires Ctrl+C on `document.activeElement` rather than on the host
+     * directly, so it only reaches `el`'s listener via real DOM bubbling —
+     * exactly what a genuine keypress does. `fireCopy` above dispatches
+     * straight on the host and would pass even if focus had been silently
+     * dropped (the actual bug these tests guard against).
+     */
+    function fireCopyOnFocusedRow(): void {
+      document.activeElement?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true })
+      );
+    }
+
+    it('copies the selected file path and flashes the row on Ctrl+C', () => {
+      vi.useFakeTimers();
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree();
+      document.body.appendChild(el);
+      el.selectFile('hero.css');
+
+      fireCopy(el);
+
+      expect(writeText).toHaveBeenCalledWith('workspace/hero.css');
+      const row = fileRow(el, 'hero.css') as HTMLElement;
+      expect(row.classList.contains('ft-copy-flash')).toBe(true);
+      vi.advanceTimersByTime(300);
+      expect(row.classList.contains('ft-copy-flash')).toBe(false);
+    });
+
+    it('also responds to Cmd+C (metaKey)', () => {
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree();
+      document.body.appendChild(el);
+      el.selectFile('hero.css');
+
+      fireCopy(el, { ctrlKey: false, metaKey: true });
+
+      expect(writeText).toHaveBeenCalledWith('workspace/hero.css');
+    });
+
+    it('copies the selected directory path (falling back to id when no path is given)', () => {
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree([{ kind: 'dir', id: '/workspace/src', label: 'src', children: [] }]);
+      document.body.appendChild(el);
+      el.querySelector<HTMLElement>('.dir')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      );
+
+      fireCopy(el);
+
+      expect(writeText).toHaveBeenCalledWith('/workspace/src');
+    });
+
+    it('honors an explicit dir path over its id', () => {
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree([
+        { kind: 'dir', id: 'src', label: 'src', path: '/workspace/src', children: [] },
+      ]);
+      document.body.appendChild(el);
+      el.querySelector<HTMLElement>('.dir')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      );
+
+      fireCopy(el);
+
+      expect(writeText).toHaveBeenCalledWith('/workspace/src');
+    });
+
+    it('is a no-op when nothing is selected', () => {
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree();
+      document.body.appendChild(el);
+
+      fireCopy(el);
+
+      expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('ignores a plain "c" keydown with no modifier', () => {
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree();
+      document.body.appendChild(el);
+      el.selectFile('hero.css');
+
+      fireCopy(el, { ctrlKey: false });
+
+      expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('stops handling Ctrl+C after disconnect', () => {
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree();
+      document.body.appendChild(el);
+      el.selectFile('hero.css');
+      el.remove();
+
+      fireCopy(el);
+
+      expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('still copies a directory path right after the click-triggered toggle re-render', () => {
+      // End-to-end regression for the reported bug: clicking a dir used to
+      // strand focus on the destroyed pre-toggle row, so a real keypress
+      // (which targets document.activeElement) never reached the listener.
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree([{ kind: 'dir', id: '/workspace/src', label: 'src', children: [] }]);
+      document.body.appendChild(el);
+      el.querySelector<HTMLElement>('.dir')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      );
+
+      fireCopyOnFocusedRow();
+
+      expect(writeText).toHaveBeenCalledWith('/workspace/src');
+    });
+
+    it('keeps working after a background `items` refresh while the row is focused', () => {
+      // Regression: the workbench polls the VFS and reassigns `.items` every
+      // 3s while the Files panel is open, which used to strand focus on the
+      // destroyed pre-refresh row exactly like the toggle case above.
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree();
+      document.body.appendChild(el);
+      el.selectFile('hero.css');
+
+      const currentItems = el.items;
+      el.items = currentItems; // simulate the periodic refresh reassigning items
+
+      fireCopyOnFocusedRow();
+
+      expect(writeText).toHaveBeenCalledWith('workspace/hero.css');
+    });
+
+    it('does not steal focus on a background refresh when nothing in the tree is focused', () => {
+      const el = makeTree();
+      document.body.appendChild(el);
+      const outside = document.createElement('input');
+      document.body.appendChild(outside);
+      outside.focus();
+
+      const currentItems = el.items;
+      el.items = currentItems;
+
+      expect(document.activeElement).toBe(outside);
     });
   });
 });

--- a/packages/webcomponents/tests/workbench/slicc-file-tree.test.ts
+++ b/packages/webcomponents/tests/workbench/slicc-file-tree.test.ts
@@ -690,7 +690,7 @@ describe('slicc-file-tree', () => {
       );
     }
 
-    it('copies the selected file path and flashes the row on Ctrl+C', () => {
+    it('copies the selected file path and flashes the row on Ctrl+C', async () => {
       vi.useFakeTimers();
       const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
       const el = makeTree();
@@ -698,6 +698,7 @@ describe('slicc-file-tree', () => {
       el.selectFile('hero.css');
 
       fireCopy(el);
+      await Promise.resolve(); // flush the writeText().then() microtask
 
       expect(writeText).toHaveBeenCalledWith('workspace/hero.css');
       const row = fileRow(el, 'hero.css') as HTMLElement;
@@ -776,6 +777,62 @@ describe('slicc-file-tree', () => {
       fireCopy(el);
 
       expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('does not flash the row when the clipboard write fails', async () => {
+      // Review fix: a rejected write must not report a false success.
+      vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(new Error('denied'));
+      const el = makeTree();
+      document.body.appendChild(el);
+      el.selectFile('hero.css');
+
+      fireCopy(el);
+      await Promise.resolve();
+      await Promise.resolve(); // flush both the rejection and the .catch()
+
+      expect(fileRow(el, 'hero.css')?.classList.contains('ft-copy-flash')).toBe(false);
+    });
+
+    it('cancels a pending flash timeout on disconnect instead of touching a detached row', async () => {
+      // Review fix: the flash setTimeout is now tracked so it can be
+      // cleared rather than firing against a torn-down component later.
+      vi.useFakeTimers();
+      vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree();
+      document.body.appendChild(el);
+      el.selectFile('hero.css');
+
+      fireCopy(el);
+      await Promise.resolve();
+      const row = fileRow(el, 'hero.css') as HTMLElement;
+      expect(row.classList.contains('ft-copy-flash')).toBe(true);
+
+      el.remove();
+      // Should not throw, and the (now-detached) row's class is untouched.
+      vi.advanceTimersByTime(300);
+      expect(row.classList.contains('ft-copy-flash')).toBe(true);
+    });
+
+    it('a second Ctrl+C within the flash window resets the fade instead of stacking timeouts', async () => {
+      vi.useFakeTimers();
+      vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const el = makeTree();
+      document.body.appendChild(el);
+      el.selectFile('hero.css');
+      const row = fileRow(el, 'hero.css') as HTMLElement;
+
+      fireCopy(el);
+      await Promise.resolve();
+      vi.advanceTimersByTime(200);
+      fireCopy(el);
+      await Promise.resolve();
+
+      // The first timeout (due at 300ms) must not clear a flash re-applied
+      // by the second copy at 200ms.
+      vi.advanceTimersByTime(100);
+      expect(row.classList.contains('ft-copy-flash')).toBe(true);
+      vi.advanceTimersByTime(200);
+      expect(row.classList.contains('ft-copy-flash')).toBe(false);
     });
 
     it('still copies a directory path right after the click-triggered toggle re-render', () => {


### PR DESCRIPTION
## Summary
- Ctrl/Cmd+C on the selected file-tree row copies its VFS path to the clipboard and flashes the row green — finishing a feature the CSS was already staged for (`wc-shell.ts` had a dead `.ft-copy-flash` rule, now moved into the component itself)
- Folders are now selectable/highlighted the same way files are, so the shortcut works on them too
- Fixed the idle hover-action strip on file rows keeping `pointer-events` enabled while invisible, which silently swallowed clicks meant for the row
- Fixed focus being dropped by any DOM re-render (a click-triggered dir toggle, or the workbench's periodic VFS refresh), which broke the shortcut right after selecting a row

## Test plan
- [x] `npm run typecheck` / `biome check` clean for `webcomponents` and `webapp`
- [x] `webcomponents` test suite: 1695/1695 passing (56 in `slicc-file-tree.test.ts`, including new regressions for focus-preservation across re-render and the actions-strip pointer-events fix)
- [x] Manually verified in Storybook and in the full app (`npm run dev:standalone:fresh`): clicking a file or folder selects/highlights it, Ctrl/Cmd+C copies the real path to the clipboard with a green flash, and the shortcut survives a folder-toggle re-render and the 3s background VFS refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)