### PR TITLE
fix(ui): nudge iframe repaint on first visibility in cherry mode

### DIFF
--- a/packages/webapp/src/ui/dip.ts
+++ b/packages/webapp/src/ui/dip.ts
@@ -33,6 +33,7 @@ import {
   type UsbDeviceFilter,
 } from '../kernel/usb-device-registry.js';
 import * as usbOps from '../kernel/usb-operations.js';
+import { isNestedInAnotherFrame, nudgeIframeRepaint } from './iframe-repaint.js';
 import {
   runJshOp,
   type SprinkleAgentOptions,
@@ -1029,6 +1030,7 @@ export function mountDip(
         liveDipWindows.add(iframe.contentWindow);
         if (trusted) trustedDipWindows.add(iframe.contentWindow);
       }
+      if (isNestedInAnotherFrame()) nudgeIframeRepaint(iframe);
     },
     {
       once: true,
@@ -1070,8 +1072,29 @@ export function mountDip(
   };
   window.addEventListener('message', messageHandler);
 
+  let visibilityObserver: IntersectionObserver | null = null;
+  if (isNestedInAnotherFrame() && typeof IntersectionObserver !== 'undefined') {
+    let skipNextVisible = false;
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[entries.length - 1];
+      if (!entry.isIntersecting) return;
+      if (skipNextVisible) {
+        skipNextVisible = false;
+        return;
+      }
+      observer.unobserve(iframe);
+      nudgeIframeRepaint(iframe, () => {
+        skipNextVisible = true;
+        observer.observe(iframe);
+      });
+    });
+    visibilityObserver = observer;
+    observer.observe(iframe);
+  }
+
   return {
     dispose() {
+      visibilityObserver?.disconnect();
       window.removeEventListener('message', messageHandler);
       unregisterSprinkleWindow(iframe.contentWindow);
       if (iframe.contentWindow) {
@@ -1142,6 +1165,7 @@ export function mountDraftDip(onLick: (action: string, data: unknown) => void): 
         sendUpdate(pendingContent);
         pendingContent = null;
       }
+      if (isNestedInAnotherFrame()) nudgeIframeRepaint(iframe);
     },
     { once: true }
   );

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -840,6 +840,13 @@ export class SprinkleRenderer {
     // above can't catch a re-show that resurfaces the Chromium compositor
     // bug. Re-nudge on every hidden→visible transition after the first.
     //
+    // The initial nudge (on load) can also miss when the workbench is still
+    // mid-transition (width:0 → full width takes ~380ms) — the iframe has
+    // zero visible area at that point so the display toggle has nothing to
+    // composite. The observer catches BOTH cases: a first-paint that arrives
+    // while the container is still expanding, and subsequent tab-switch
+    // re-shows.
+    //
     // `nudgeIframeRepaint` itself toggles the iframe's `display`, which is
     // exactly what this observer watches. A "skip while nudging" flag isn't
     // enough — the nudge's own display:none→restore flip is still a real
@@ -848,19 +855,20 @@ export class SprinkleRenderer {
     // of the nudge and re-observe once it settles, so the nudge's own
     // display flicker never reaches this callback.
     if (isNestedInAnotherFrame() && typeof IntersectionObserver !== 'undefined') {
-      let sawInitialState = false;
+      let skipNextVisible = false;
       const observer = new IntersectionObserver((entries) => {
         const entry = entries[entries.length - 1];
-        if (!sawInitialState) {
-          sawInitialState = true;
+        if (!entry.isIntersecting) return;
+        if (skipNextVisible) {
+          skipNextVisible = false;
           return;
         }
-        if (!entry.isIntersecting) return;
         observer.unobserve(iframe);
         nudgeIframeRepaint(iframe, () => {
-          // Re-observing fires a fresh synthetic "initial state" callback —
-          // treat it as such so it doesn't immediately re-nudge.
-          sawInitialState = false;
+          // Re-observing fires a new initial callback with isIntersecting:true
+          // (the iframe is visible right after the nudge restored display).
+          // Skip that one — it's not a real visibility change.
+          skipNextVisible = true;
           observer.observe(iframe);
         });
       });

--- a/packages/webapp/tests/ui/dip.test.ts
+++ b/packages/webapp/tests/ui/dip.test.ts
@@ -574,3 +574,85 @@ describe('dip exec/agent trust gating', () => {
     inst.dispose();
   });
 });
+
+describe('cherry iframe repaint workaround', () => {
+  it('nudges repaint on load and re-nudges on visibility transitions without infinite loop', () => {
+    // Simulate being inside a frame (cherry mode)
+    const dom = globalThis as { window?: { self?: object; top?: object } };
+    const origSelf = dom.window?.self;
+    const origTop = dom.window?.top;
+    (dom.window as any).self = {};
+    // window.self !== window.top → isNestedInAnotherFrame() returns true
+
+    const rafCallbacks: Array<() => void> = [];
+    const originalRaf = globalThis.requestAnimationFrame;
+    (globalThis as any).requestAnimationFrame = (cb: () => void) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    };
+
+    let observerCallback: ((entries: Array<{ isIntersecting: boolean }>) => void) | null = null;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    const unobserve = vi.fn();
+    const originalIO = (globalThis as any).IntersectionObserver;
+    class FakeIntersectionObserver {
+      constructor(cb: typeof observerCallback) {
+        observerCallback = cb;
+      }
+      observe = observe;
+      disconnect = disconnect;
+      unobserve = unobserve;
+    }
+    (globalThis as any).IntersectionObserver = FakeIntersectionObserver;
+
+    try {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const onLick = vi.fn();
+      const inst = mountDip(container, '<p>hello</p>', onLick);
+
+      // Load-event nudge fires (2 rAF callbacks queued)
+      const iframe = container.querySelector('iframe')!;
+      iframe.dispatchEvent(new Event('load'));
+      expect(rafCallbacks.length).toBe(1);
+      rafCallbacks.shift()!();
+      rafCallbacks.shift()!();
+      rafCallbacks.length = 0;
+
+      // Visibility observer is installed
+      expect(observe).toHaveBeenCalled();
+
+      // First IO callback with isIntersecting:true triggers a nudge
+      observerCallback!([{ isIntersecting: true }]);
+      expect(rafCallbacks.length).toBe(1);
+      expect(unobserve).toHaveBeenCalledTimes(1);
+
+      // Complete the nudge
+      rafCallbacks.shift()!();
+      rafCallbacks.shift()!();
+      rafCallbacks.length = 0;
+      expect(observe).toHaveBeenCalledTimes(2); // initial + re-observe
+
+      // Post-re-observe synthetic callback is skipped (no infinite loop)
+      observerCallback!([{ isIntersecting: true }]);
+      expect(rafCallbacks.length).toBe(0);
+
+      // Later tab switch: hidden → visible triggers a fresh nudge
+      observerCallback!([{ isIntersecting: false }]);
+      observerCallback!([{ isIntersecting: true }]);
+      expect(rafCallbacks.length).toBe(1);
+
+      // Dispose disconnects the observer
+      inst.dispose();
+      expect(disconnect).toHaveBeenCalled();
+
+      container.remove();
+    } finally {
+      (globalThis as any).requestAnimationFrame = originalRaf;
+      (globalThis as any).IntersectionObserver = originalIO;
+      if (origSelf !== undefined) (dom.window as any).self = origSelf;
+      if (origTop !== undefined) (dom.window as any).top = origTop;
+    }
+  });
+});

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -517,26 +517,37 @@ describe('full document rendering', () => {
       rafCallbacks.shift()!();
       rafCallbacks.length = 0;
 
-      // First observer callback reports the initial (already-handled) state —
-      // must not double-nudge on top of the load-event nudge.
+      // First observer callback with isIntersecting: true triggers a nudge —
+      // this covers the case where the iframe loaded while its container was
+      // not yet visible (e.g. workbench mid-transition in cherry mode).
       observerCallback!([{ isIntersecting: true }]);
-      expect(rafCallbacks.length).toBe(0);
+      expect(rafCallbacks.length).toBe(1);
+      expect(unobserve).toHaveBeenCalledTimes(1);
+
+      // Complete the nudge's rAF pair — re-observe fires a synthetic callback.
+      rafCallbacks.shift()!();
+      rafCallbacks.shift()!();
+      rafCallbacks.length = 0;
+      expect(observe).toHaveBeenCalledTimes(2); // initial + re-observe after nudge
+
+      // The post-re-observe callback with isIntersecting: true must be skipped
+      // (it's the nudge's own display restore, not a real visibility change).
+      observerCallback!([{ isIntersecting: true }]);
+      expect(rafCallbacks.length).toBe(0); // no infinite loop
 
       // Tab switched away, then back: a later hidden -> visible transition
       // must trigger a fresh nudge.
       observerCallback!([{ isIntersecting: false }]);
       observerCallback!([{ isIntersecting: true }]);
       expect(rafCallbacks.length).toBe(1);
-      expect(unobserve).toHaveBeenCalledTimes(1);
+      expect(unobserve).toHaveBeenCalledTimes(2);
 
-      // Completing the nudge's own display:none -> restore flip must NOT
-      // retrigger another nudge — regression test for a self-sustaining
-      // infinite nudge loop (the nudge's own visibility flicker was feeding
-      // straight back into this same observer).
+      // Complete the second nudge — no infinite loop.
       rafCallbacks.shift()!();
       rafCallbacks.shift()!();
-      expect(observe).toHaveBeenCalledTimes(2); // initial + re-observe after nudge
-      observerCallback!([{ isIntersecting: true }]); // synthetic post-reobserve callback
+      expect(observe).toHaveBeenCalledTimes(3); // initial + 2 re-observes
+      // Post-nudge synthetic callback is skipped.
+      observerCallback!([{ isIntersecting: true }]);
       expect(rafCallbacks.length).toBe(0);
     } finally {
       (globalThis as any).requestAnimationFrame = originalRaf;


### PR DESCRIPTION
The sprinkle iframe's load event fires while the workbench pane is still mid-CSS-transition (width:0 → full width over 380ms). The nudgeIframeRepaint on load has no effect because there's zero visible area to composite. The IntersectionObserver previously skipped its first callback unconditionally (sawInitialState), so when the container finally became visible, no nudge fired — leaving the sprinkle blank until devtools or a refresh.

Replace the sawInitialState logic with skipNextVisible: now the observer nudges on every isIntersecting:true callback except the synthetic one that IO fires immediately after re-observe post-nudge. This catches both the initial visibility (workbench finishing its transition) and subsequent tab-switch re-shows, without infinite loops.

Also adds the nudgeIframeRepaint workaround to dip.ts (chat-embedded shtml iframes), which was completely missing the repaint fix for nested iframes.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
