### PR TITLE
fix(tray): load scoop chat history when follower selects a different scoop

### DIFF
--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -180,6 +180,26 @@ export interface ScoopTranscriptMsg {
 }
 
 /**
+ * Side-effect-free chat-messages fetch for a scoop. Returns the full
+ * `ChatMessage[]` shape (unlike `request-scoop-transcript` which
+ * flattens to text). Used by the tray leader to send a scoop's history
+ * to a follower that selected a different scoop.
+ */
+export interface RequestScoopChatMessagesMsg {
+  type: 'request-scoop-chat-messages';
+  requestId: string;
+  scoopJid: string;
+}
+
+/** Reply to {@link RequestScoopChatMessagesMsg}. */
+export interface ScoopChatMessagesMsg {
+  type: 'scoop-chat-messages';
+  requestId: string;
+  scoopJid: string;
+  messages: ScoopMessagesReplacedMsg['messages'];
+}
+
+/**
  * Panel → engine: session-stats pull (floatbar cost counter + the chip
  * pupils' context-fill). The `requestId` correlates the reply.
  */
@@ -792,6 +812,7 @@ export type PanelToOffscreenMessage =
   | RequestStateMsg
   | RequestScoopMessagesMsg
   | RequestScoopTranscriptMsg
+  | RequestScoopChatMessagesMsg
   | RequestSessionStatsMsg
   | ClearChatMsg
   | ClearFilesystemMsg
@@ -1156,6 +1177,7 @@ export type OffscreenToPanelMessage =
   | MessageUpdatedMsg
   | ScoopMessagesReplacedMsg
   | ScoopTranscriptMsg
+  | ScoopChatMessagesMsg
   | SessionStatsMsg
   | PanelCdpResponseMsg
   | OAuthResultMsg

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -1575,15 +1575,7 @@ export class OffscreenBridge implements KernelFacade {
         break;
       }
 
-      // Live localStorage sync from the page to the worker. In
-      // standalone-worker mode, the page intercepts its own
-      // localStorage writes (and listens for storage events from other
-      // tabs) and forwards them through the kernel transport. The
-      // worker's `localStorage` is a Map-backed shim installed during
-      // boot — direct setItem/removeItem here mutates that shim. In
-      // extension mode the panel and offscreen share the extension
-      // origin's localStorage, so the panel never sends these
-      // messages; the case branches stay no-ops on that path.
+      // Live localStorage sync: page→worker shim (standalone-worker mode only).
       case 'local-storage-set': {
         this.applyLocalStorageOp(msg.type, (s) => s.setItem(msg.key, msg.value));
         break;

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -1484,10 +1484,9 @@ export class OffscreenBridge implements KernelFacade {
         break;
       }
 
-      case 'request-scoop-chat-messages': {
+      case 'request-scoop-chat-messages':
         await this.handleRequestScoopChatMessages(msg.requestId, msg.scoopJid);
         break;
-      }
 
       case 'request-session-stats':
         this.handleRequestSessionStats(msg.requestId);

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -50,6 +50,7 @@ import type {
   PanelToOffscreenMessage,
   ScoopCreatedMsg,
   ScoopListMsg,
+  ScoopMessagesReplacedMsg,
   ScoopSnapshotConfig,
   ScoopStatusMsg,
   SetThinkingLevelMsg,
@@ -1261,6 +1262,57 @@ export class OffscreenBridge implements KernelFacade {
   }
 
   /**
+   * Side-effect-free chat-messages fetch. Returns the full ChatMessage[]
+   * without mutating message buffers or emitting scoop-messages-replaced.
+   * Used by the tray leader to serve a follower's scoop-select request.
+   */
+  private async handleRequestScoopChatMessages(requestId: string, scoopJid: string): Promise<void> {
+    const empty = (): void => {
+      this.emit({ type: 'scoop-chat-messages', requestId, scoopJid, messages: [] });
+    };
+    if (!this.orchestrator) {
+      empty();
+      return;
+    }
+    const scoop = this.orchestrator.getScoops().find((s) => s.jid === scoopJid);
+    if (!scoop) {
+      empty();
+      return;
+    }
+
+    const buffered = this.messageBuffers.get(scoopJid);
+    if (buffered && buffered.length > 0) {
+      this.emit({ type: 'scoop-chat-messages', requestId, scoopJid, messages: buffered });
+      return;
+    }
+
+    const buf = await this.buildBufferFromAgentMessages(scoop);
+    if (buf && buf.length > 0) {
+      this.emit({ type: 'scoop-chat-messages', requestId, scoopJid, messages: buf });
+      return;
+    }
+
+    if (this.sessionStore) {
+      const sessionId = scoop.isCone ? 'session-cone' : `session-${scoop.folder}`;
+      try {
+        const session = await this.sessionStore.load(sessionId);
+        const messages = session?.messages ?? [];
+        this.emit({
+          type: 'scoop-chat-messages',
+          requestId,
+          scoopJid,
+          messages: messages as unknown as ScoopMessagesReplacedMsg['messages'],
+        });
+        return;
+      } catch {
+        // fall through to empty
+      }
+    }
+
+    empty();
+  }
+
+  /**
    * Persist a scoop's message buffer to the shared UI session store.
    * Fire-and-forget — errors are swallowed to avoid blocking agent processing.
    *
@@ -1429,6 +1481,11 @@ export class OffscreenBridge implements KernelFacade {
 
       case 'request-scoop-transcript': {
         await this.handleRequestScoopTranscript(msg.requestId, msg.scoopJid);
+        break;
+      }
+
+      case 'request-scoop-chat-messages': {
+        await this.handleRequestScoopChatMessages(msg.requestId, msg.scoopJid);
         break;
       }
 

--- a/packages/chrome-extension/tests/offscreen-bridge.test.ts
+++ b/packages/chrome-extension/tests/offscreen-bridge.test.ts
@@ -1915,6 +1915,110 @@ describe('OffscreenBridge request-scoop-transcript', () => {
   });
 });
 
+describe('OffscreenBridge request-scoop-chat-messages', () => {
+  let bridge: InstanceType<typeof OffscreenBridge>;
+
+  beforeEach(async () => {
+    sentMessages.length = 0;
+    messageListeners.length = 0;
+    vi.clearAllMocks();
+    bridge = new OffscreenBridge();
+    await bridge.bind({
+      getScoops: vi.fn(() => [
+        { jid: 'cone_1', name: 'Cone', folder: 'cone', isCone: true, assistantLabel: 'sliccy' },
+      ]),
+      handleMessage: vi.fn().mockResolvedValue(undefined),
+      getScoopContext: vi.fn(() => undefined),
+    } as any);
+  });
+
+  it('returns buffered messages with correlated requestId', async () => {
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push(
+      { id: 'u1', role: 'user', content: 'hello', timestamp: 100 },
+      { id: 'a1', role: 'assistant', content: 'hi there', timestamp: 200 }
+    );
+
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-chat-messages',
+      requestId: 'cm-test-1',
+      scoopJid: 'cone_1',
+    });
+
+    const reply = sentMessages.find((m: any) => m.payload?.type === 'scoop-chat-messages') as any;
+    expect(reply).toBeDefined();
+    expect(reply.payload.requestId).toBe('cm-test-1');
+    expect(reply.payload.scoopJid).toBe('cone_1');
+    expect(reply.payload.messages).toHaveLength(2);
+    expect(reply.payload.messages[0].content).toBe('hello');
+    expect(reply.payload.messages[1].content).toBe('hi there');
+  });
+
+  it('returns empty messages array for an unknown scoop', async () => {
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-chat-messages',
+      requestId: 'cm-test-2',
+      scoopJid: 'does-not-exist',
+    });
+
+    const reply = sentMessages.find((m: any) => m.payload?.type === 'scoop-chat-messages') as any;
+    expect(reply).toBeDefined();
+    expect(reply.payload.requestId).toBe('cm-test-2');
+    expect(reply.payload.messages).toEqual([]);
+  });
+
+  it('does NOT emit scoop-messages-replaced (side-effect-free)', async () => {
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push({ id: 'u1', role: 'user', content: 'hi', timestamp: 100 });
+
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-chat-messages',
+      requestId: 'cm-test-3',
+      scoopJid: 'cone_1',
+    });
+
+    const replacedReply = sentMessages.find(
+      (m: any) => m.payload?.type === 'scoop-messages-replaced'
+    );
+    expect(replacedReply).toBeUndefined();
+  });
+
+  it('falls back to sessionStore when no buffer or agent messages exist', async () => {
+    (bridge as any).sessionStore = {
+      load: vi.fn().mockResolvedValue({
+        messages: [{ id: 's1', role: 'user', content: 'from store', timestamp: 50 }],
+      }),
+    };
+
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-chat-messages',
+      requestId: 'cm-test-4',
+      scoopJid: 'cone_1',
+    });
+
+    const reply = sentMessages.find((m: any) => m.payload?.type === 'scoop-chat-messages') as any;
+    expect(reply.payload.requestId).toBe('cm-test-4');
+    expect(reply.payload.messages).toHaveLength(1);
+    expect(reply.payload.messages[0].content).toBe('from store');
+  });
+
+  it('returns empty when sessionStore throws', async () => {
+    (bridge as any).sessionStore = {
+      load: vi.fn().mockRejectedValue(new Error('idb closed')),
+    };
+
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-chat-messages',
+      requestId: 'cm-test-5',
+      scoopJid: 'cone_1',
+    });
+
+    const reply = sentMessages.find((m: any) => m.payload?.type === 'scoop-chat-messages') as any;
+    expect(reply.payload.requestId).toBe('cm-test-5');
+    expect(reply.payload.messages).toEqual([]);
+  });
+});
+
 describe('OffscreenBridge handlePanelMessage dispatch', () => {
   let bridge: InstanceType<typeof OffscreenBridge>;
   let mockOrchestrator: any;

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -17,6 +17,7 @@ import type {
   MessageUpdatedMsg,
   OffscreenToPanelMessage,
   PanelToOffscreenMessage,
+  ScoopChatMessagesMsg,
   ScoopCreatedMsg,
   ScoopListMsg,
   ScoopMessagesReplacedMsg,
@@ -459,13 +460,18 @@ export class OffscreenClient implements KernelClientFacade {
       requestId,
       scoopJid,
     } as PanelToOffscreenMessage);
+    let timedOut = false;
     const result = await Promise.race([
       reply,
       new Promise<ScoopMessagesReplacedMsg['messages']>((resolve) =>
-        setTimeout(() => resolve([]), 5000)
+        setTimeout(() => {
+          timedOut = true;
+          resolve([]);
+        }, 5000)
       ),
     ]);
     this.pendingChatMessagesRequests.delete(requestId);
+    if (timedOut) log.warn('getMessagesForScoop timed out', { scoopJid });
     return result;
   }
 
@@ -706,7 +712,7 @@ export class OffscreenClient implements KernelClientFacade {
       }
 
       case 'scoop-chat-messages': {
-        const m = msg as { requestId: string; messages: ScoopMessagesReplacedMsg['messages'] };
+        const m = msg as ScoopChatMessagesMsg;
         const resolve = this.pendingChatMessagesRequests.get(m.requestId);
         if (resolve) {
           this.pendingChatMessagesRequests.delete(m.requestId);

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -134,6 +134,10 @@ export class OffscreenClient implements KernelClientFacade {
    * (or `''` on timeout) when a `scoop-transcript` envelope arrives.
    */
   private pendingTranscriptRequests = new Map<string, (transcript: string) => void>();
+  private pendingChatMessagesRequests = new Map<
+    string,
+    (messages: ScoopMessagesReplacedMsg['messages']) => void
+  >();
   private pendingStatsRequests = new Map<string, (stats: SessionStats) => void>();
   /**
    * KernelTransport — defaults to the chrome.runtime adapter.
@@ -441,6 +445,31 @@ export class OffscreenClient implements KernelClientFacade {
   }
 
   /**
+   * Side-effect-free chat-messages fetch for a specific scoop. Returns
+   * the full ChatMessage[] without mutating the local panel state.
+   * Used by the tray leader to serve follower scoop-select requests.
+   */
+  async getMessagesForScoop(scoopJid: string): Promise<ScoopMessagesReplacedMsg['messages']> {
+    const requestId = `cm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const reply = new Promise<ScoopMessagesReplacedMsg['messages']>((resolve) => {
+      this.pendingChatMessagesRequests.set(requestId, resolve);
+    });
+    this.send({
+      type: 'request-scoop-chat-messages',
+      requestId,
+      scoopJid,
+    } as PanelToOffscreenMessage);
+    const result = await Promise.race([
+      reply,
+      new Promise<ScoopMessagesReplacedMsg['messages']>((resolve) =>
+        setTimeout(() => resolve([]), 5000)
+      ),
+    ]);
+    this.pendingChatMessagesRequests.delete(requestId);
+    return result;
+  }
+
+  /**
    * Session-stats pull: total session cost + per-scoop context-window
    * fill. Resolves `null` on timeout (the UI keeps its last values).
    */
@@ -672,6 +701,16 @@ export class OffscreenClient implements KernelClientFacade {
         if (resolve) {
           this.pendingTranscriptRequests.delete(m.requestId);
           resolve(m.transcript);
+        }
+        break;
+      }
+
+      case 'scoop-chat-messages': {
+        const m = msg as { requestId: string; messages: ScoopMessagesReplacedMsg['messages'] };
+        const resolve = this.pendingChatMessagesRequests.get(m.requestId);
+        if (resolve) {
+          this.pendingChatMessagesRequests.delete(m.requestId);
+          resolve(m.messages);
         }
         break;
       }

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -124,6 +124,7 @@ function createLeaderOptionsFactory(
   return (workerBaseUrl) => ({
     workerBaseUrl,
     getMessages: () => deps.getController()?.getMessages() ?? [],
+    getMessagesForScoop: (scoopJid) => client.getMessagesForScoop(scoopJid),
     getScoopJid: () => deps.getSelectedJid(),
     getScoops: () =>
       client.getScoops().map((s) => ({


### PR DESCRIPTION
When a follower clicked a scoop pill, it sent `scoops.select` to the leader which called `sendSnapshotToFollower`. Without `getMessagesForScoop` provided, the leader fell back to `getMessages()` (the currently active scoop), so the follower always saw the same chat regardless of selection.

Add a side-effect-free `request-scoop-chat-messages` / `scoop-chat-messages` request-reply pair that returns ChatMessage[] without mutating the leader's local panel state. Wire it through offscreen-bridge → offscreen-client → wc-tray leader options.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
