### PR TITLE
fix(lint): exempt generated preview-bridge-assets.ts from biome (unblocks CI lint on all PRs)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -36,6 +36,7 @@
       "!**/*.min.js",
       "!packages/webapp/src/ui/rum.js",
       "!packages/webapp/src/ui/lucide-icons.ts",
+      "!packages/cloudflare-worker/src/preview-bridge-assets.ts",
       "!**/tests/fixtures/workflows/**"
     ]
   },
@@ -69,7 +70,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "complexity": {
         "noExcessiveCognitiveComplexity": {
           "level": "error",
@@ -224,10 +225,10 @@
         "noAccumulatingSpread": "off"
       },
       "a11y": {
-        "recommended": false
+        "preset": "none"
       },
       "security": {
-        "recommended": true
+        "preset": "recommended"
       }
     }
   },


### PR DESCRIPTION
## Fast-track: unblocks CI `lint` on all PRs

CI's `lint` job builds `@ai-ecoverse/cherry` in setup, which runs
`build-preview-bootstrap.mjs` and **regenerates**
`packages/cloudflare-worker/src/preview-bridge-assets.ts` — a minified IIFE
(html2canvas-pro inlined) embedded as a `PREVIEW_BRIDGE_JS` string constant.
The freshly-generated blob **fails biome's `format` check**, so `biome check .`
exits 1 and the whole `lint` gate fails. The committed copy happens to pass, so
it never reproduces on a local `npm run lint:ci` — but it fails in CI for
**every** PR that reaches the lint job.

### Fix

- Exclude the generated artifact from biome via `files.includes`
  (`!packages/cloudflare-worker/src/preview-bridge-assets.ts`). It's build
  output, not hand-written source; prettier already skips it (all `*.ts` are
  Biome-owned per `.prettierignore`). This is the actual unblocker.
- While in the file, ran `biome migrate` to move the biome-2.5-deprecated
  `rules.recommended` boolean → `rules.preset` (`recommended`/`none`). Removes a
  config-deprecation diagnostic and future-proofs against biome's next major.

Rule behaviour is unchanged — still exactly **109 warnings, 0 errors** on a
clean build, verified with the asset both committed and freshly regenerated.

### Why standalone

This is repo-wide config (independent of any feature) and it blocks every open
PR's `lint` gate, so it should land on its own and fast rather than riding a
feature branch. Surfaced while taking over #1287; the deeper "generated worker
source is committed and not reproducible" problem is tracked in #1308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
