### PR TITLE
fix(cloud): increase resume retry budget for long-paused sandboxes

### DIFF
--- a/packages/cloud-core/src/operations/resume.ts
+++ b/packages/cloud-core/src/operations/resume.ts
@@ -183,7 +183,7 @@ export async function resumeCone(
   if (!kicked) {
     throw new CloudError(
       'LEADER_NOT_READY',
-      'Failed to kick leader after 15 retries (sandbox may not be healthy)'
+      `Failed to kick leader after ${RESUME_MAX_RETRIES} retries (sandbox may not be healthy)`
     );
   }
 
@@ -221,8 +221,11 @@ export async function resumeCone(
   };
 }
 
+const RESUME_MAX_RETRIES = 15;
+const RESUME_RETRY_DELAY_MS = 2000;
+
 async function kickLeaderUntilReady(handle: SandboxHandle): Promise<boolean> {
-  for (let i = 0; i < 15; i++) {
+  for (let i = 0; i < RESUME_MAX_RETRIES; i++) {
     const result = await handle.run(KICK_CMD);
     if (result.exitCode === 0) {
       const status = result.stdout.trim();
@@ -234,7 +237,7 @@ async function kickLeaderUntilReady(handle: SandboxHandle): Promise<boolean> {
         );
       }
     }
-    await new Promise((r) => setTimeout(r, 2000));
+    await new Promise((r) => setTimeout(r, RESUME_RETRY_DELAY_MS));
   }
   return false;
 }
@@ -246,10 +249,8 @@ const RELOAD_CMD =
 // window like the leader kick. Throws if it never succeeds — a stale fetch-proxy
 // would silently serve old flat secrets.
 async function reloadSecretsProxyUntilReady(handle: SandboxHandle): Promise<void> {
-  // Track why the last attempt didn't succeed so the exhaustion error is
-  // actionable (HTTP 503 cold-start vs. a connection-level curl failure).
   let lastError = 'no attempt made';
-  for (let i = 0; i < 15; i++) {
+  for (let i = 0; i < RESUME_MAX_RETRIES; i++) {
     const result = await handle.run(RELOAD_CMD);
     if (result.exitCode === 0) {
       const status = result.stdout.trim();
@@ -264,10 +265,10 @@ async function reloadSecretsProxyUntilReady(handle: SandboxHandle): Promise<void
     } else {
       lastError = `curl exit ${result.exitCode}: ${result.stderr.trim()}`;
     }
-    await new Promise((r) => setTimeout(r, 2000));
+    await new Promise((r) => setTimeout(r, RESUME_RETRY_DELAY_MS));
   }
   throw new CloudError(
     'INTERNAL',
-    `Failed to reload secrets proxy after 15 retries (changed secrets may be stale; last: ${lastError})`
+    `Failed to reload secrets proxy after ${RESUME_MAX_RETRIES} retries (changed secrets may be stale; last: ${lastError})`
   );
 }

--- a/packages/cloud-core/src/operations/resume.ts
+++ b/packages/cloud-core/src/operations/resume.ts
@@ -175,14 +175,15 @@ export async function resumeCone(
   }
 
   // Kick the leader to recover from a possible onReconnectGaveUp state.
-  // 5×1s retry covers the CDP-cold-start race after a long pause.
+  // 15×2s retry covers the CDP-cold-start race after a long pause —
+  // Chrome needs time to restore renderer processes after multi-hour pauses.
   // Success = curl exited 0 AND status is 200. 503 means the SLICC page
   // target isn't ready yet — retry. Any other status is a hard error.
   const kicked = await kickLeaderUntilReady(handle);
   if (!kicked) {
     throw new CloudError(
       'LEADER_NOT_READY',
-      'Failed to kick leader after 5 retries (sandbox may not be healthy)'
+      'Failed to kick leader after 15 retries (sandbox may not be healthy)'
     );
   }
 
@@ -221,7 +222,7 @@ export async function resumeCone(
 }
 
 async function kickLeaderUntilReady(handle: SandboxHandle): Promise<boolean> {
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 15; i++) {
     const result = await handle.run(KICK_CMD);
     if (result.exitCode === 0) {
       const status = result.stdout.trim();
@@ -233,7 +234,7 @@ async function kickLeaderUntilReady(handle: SandboxHandle): Promise<boolean> {
         );
       }
     }
-    await new Promise((r) => setTimeout(r, 1000));
+    await new Promise((r) => setTimeout(r, 2000));
   }
   return false;
 }
@@ -248,7 +249,7 @@ async function reloadSecretsProxyUntilReady(handle: SandboxHandle): Promise<void
   // Track why the last attempt didn't succeed so the exhaustion error is
   // actionable (HTTP 503 cold-start vs. a connection-level curl failure).
   let lastError = 'no attempt made';
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 15; i++) {
     const result = await handle.run(RELOAD_CMD);
     if (result.exitCode === 0) {
       const status = result.stdout.trim();
@@ -263,10 +264,10 @@ async function reloadSecretsProxyUntilReady(handle: SandboxHandle): Promise<void
     } else {
       lastError = `curl exit ${result.exitCode}: ${result.stderr.trim()}`;
     }
-    await new Promise((r) => setTimeout(r, 1000));
+    await new Promise((r) => setTimeout(r, 2000));
   }
   throw new CloudError(
     'INTERNAL',
-    `Failed to reload secrets proxy after 5 retries (changed secrets may be stale; last: ${lastError})`
+    `Failed to reload secrets proxy after 15 retries (changed secrets may be stale; last: ${lastError})`
   );
 }


### PR DESCRIPTION
After multi-hour pauses Chrome needs more than 5s to restore renderer processes and register CDP targets. The previous 5×1s retry budget caused LEADER_NOT_READY failures on every resume with coneConfigDelta.

Increase both kickLeaderUntilReady and reloadSecretsProxyUntilReady from 5×1s (5s) to 15×2s (30s).

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
