### PR TITLE
Fix VFS file-tree overflow menu (duplicate/rename/copy-path/delete)

### DIFF
--- a/.claude/skills/demo-recording/SKILL.md
+++ b/.claude/skills/demo-recording/SKILL.md
@@ -17,9 +17,18 @@ Record short (15–30s) demo videos of SLICC UI features using
 
 ## Quick Start
 
+**Verify the dev URL first.** Don't assume the obvious port serves the UI —
+in thin-bridge/single-page-app architectures the "app port" may serve no UI
+at all (SLICC's node-server serves none; the webapp loads from a separate
+UI-serving port and dials back over a bridge token in the query string, e.g.
+`http://localhost:8787/?bridge=ws://localhost:5710/cdp&bridgeToken=<uuid>`).
+`curl` the candidate port or check the dev script before wiring a recording
+around it. See "Attaching to a Single-Leader-Tab App" below if the app only
+accepts one connected browser session.
+
 ```bash
-# 1. Open a browser and navigate
-playwright-cli open http://localhost:5710
+# 1. Open a browser and navigate — replace with your app's real dev URL
+playwright-cli open http://localhost:PORT
 playwright-cli resize 1280 720
 
 # 2. Inject the visible cursor (headless Chrome has no native cursor)
@@ -53,6 +62,64 @@ playwright-cli eval '(() => { var c = document.createElement("div"); c.id = "fak
 
 - `window.__mc(x, y)` — move cursor to position (display it)
 - `window.__hc()` — hide cursor
+
+## Attaching to a Single-Leader-Tab App
+
+Some apps only support one connected browser session per backend instance
+(e.g. SLICC's standalone thin-bridge: one Chrome tab is "the leader" for a
+given bridge token). `playwright-cli open <url>` launches an independent
+browser — pointing it at a URL someone else's session already owns creates
+two competing clients on the same channel, not a second view.
+
+**Recording without disturbing a live session:** spin up an isolated
+instance of the app's own dev stack on different ports, then attach
+`playwright-cli` to that instance's browser instead of opening a new one:
+
+```bash
+# 1. Launch Chrome yourself with a FIXED (non-zero) CDP port
+"$CHROME_BIN" --remote-debugging-port=9522 --no-first-run \
+  --user-data-dir="$(mktemp -d)" about:blank &
+
+# 2. Start the app's own dev server(s) on unused ports, pointed at that
+#    fixed CDP port if the framework supports reusing an external browser
+#    (check for a "--serve-only" / "--attach" / "--external-cdp" style flag
+#    before assuming you must launch its browser too)
+
+# 3. Grab the real websocket endpoint from the profile dir Chrome just
+#    wrote (needed because `--remote-debugging-port=0` is otherwise auto-picked)
+cat "$USER_DATA_DIR/DevToolsActivePort"   # port on line 1, ws path on line 2
+
+# 4. Attach playwright-cli's tooling (video, run-code, etc.) to that SAME
+#    browser instead of launching a new one
+playwright-cli attach --cdp "ws://127.0.0.1:9522/devtools/browser/<uuid>"
+playwright-cli goto "http://localhost:<app-ui-port>/?<app-specific-auth-params>"
+```
+
+This keeps the recording fully isolated — the original session's ports,
+tabs, and state are never touched. Tear down the isolated Chrome/dev-server
+processes when done (`kill` by the PIDs you started, or by the ports you
+picked) — they're throwaway infrastructure, not the user's environment.
+
+## Clipboard Interactions
+
+Reading a value with `navigator.clipboard.readText()` proves what's in the
+clipboard, but inserting it with `page.keyboard.type(value)` is **simulated
+typing, not a paste** — visually similar, technically a different action. If
+the demo is specifically about a copy/paste feature, do a real paste:
+
+```js
+// Once, before interacting with the composer:
+await page.context().grantPermissions(['clipboard-read', 'clipboard-write'], {
+  origin: 'http://localhost:PORT', // must match the page's actual origin
+});
+
+// Later, in the recording script:
+await composer.click();
+await page.keyboard.press('Meta+V'); // 'Control+V' on non-Mac targets
+```
+
+Without `grantPermissions`, both `readText()` and a real `Meta+V` paste can
+hang waiting on a permission prompt that never resolves headlessly.
 
 ## Recording Script Pattern
 
@@ -169,6 +236,104 @@ async function moveTo(tx, ty, steps = 14, delay = 18) {
 
 Without `page.mouse.move`, hover-triggered UI (dropdown buttons,
 tooltips, action overlays) will not appear on screen.
+
+**Don't also call `.locator().hover()` or `.locator().click()` alongside a
+manual `moveTo` loop.** Playwright's own actionability pre-checks (visible,
+stable, "receives events") run independently of your animation and can fail
+intermittently — "element is not visible" / "X intercepts pointer events" —
+even though the element is plainly on screen. Once you're driving the cursor
+yourself, commit to it: use `page.mouse.click(x, y)` at the coordinates you
+already animated to, not the locator-based click/hover helpers.
+
+### Prefer CSS selectors over snapshot refs for apps with periodic re-renders
+
+`playwright-cli snapshot`-derived `ref=...` IDs go stale the moment the
+underlying DOM node is replaced. If the app rebuilds parts of its UI on a
+timer (polling, live-refresh panels), a ref captured even a few seconds
+earlier can point at a detached node, failing with "Ref not found in the
+current page snapshot." A CSS/attribute selector (`page.locator('[data-id="..."]')`)
+re-resolves against the live DOM on every call and doesn't have this problem
+— use selectors for anything you'll interact with more than once per script.
+
+### Native dialogs (`confirm`/`prompt`) in attached CDP sessions
+
+`page.once('dialog', async (d) => await d.accept(...))` registered inside a
+`run-code` script is NOT reliably intercepted when attached via
+`playwright-cli attach --cdp` — the CLI's own dialog tracking can surface it
+as a pending "Modal state" instead, and the triggering `run-code` call
+returns without finishing. Don't chase this inside the script. Instead:
+
+```bash
+# 1. Trigger the action that opens the dialog
+playwright-cli run-code --filename open-dialog-step.js
+# 2. Resolve it as a separate command
+playwright-cli dialog-accept "typed value"   # or: playwright-cli dialog-dismiss
+# 3. Verify the app's actual state changed — don't trust the CLI's own
+#    "already handled" / "Modal state" messages as proof of success
+playwright-cli eval '...check the DOM reflects the action...'
+```
+
+If you see "Cannot accept dialog which is already handled" that's fine — it
+means an in-script handler beat you to it. If a _later_ command reports a
+NEW pending "Modal state" you didn't expect, dialogs can queue; drain them
+with repeated `dialog-dismiss`/`dialog-accept` calls before continuing.
+
+### `video-start`'s live screencast can silently render panels as solid grey
+
+The CDP screencast behind `video-start` is a different rendering path than
+`page.screenshot()`, and can fail to composite certain panels — rendering
+them as a flat color for the _entire recording_ while the rest of the page
+looks fine. This is easy to miss at a glance and will ruin a recording whose
+whole point is that panel. **Verify before trusting a `video-start` take:**
+extract one frame and compare it to a `page.screenshot()` taken at the same
+moment; if the panel is blank/flat in the video frame but populated in the
+screenshot, `video-start` isn't usable for this recording.
+
+**Fallback: screenshot-sequence recording.** `page.screenshot()` always
+renders correctly, so build the video from a sequence of screenshots
+instead of a live capture:
+
+```js
+// Inside the run-code script: snap(N) takes ONE screenshot but reserves N
+// index slots, so the gap to the next frame encodes how long to hold it.
+let fc = 0;
+async function snap(page, holdFrames = 1) {
+  const n = ++fc;
+  await page.screenshot({ path: `/tmp/frames/frame_${String(n).padStart(5, '0')}.png` });
+  fc += holdFrames - 1;
+}
+// snap(page, 1) during cursor movement, snap(page, 10-30) to hold a result
+```
+
+```python
+# Build an ffmpeg concat playlist from the actual files present (gaps = hold
+# duration in units of BASE seconds), then encode — handles the numbering
+# gaps `snap()` leaves behind:
+import os, re
+d = '/tmp/frames'
+entries = sorted((int(re.match(r'frame_(\d+)\.png', f).group(1)), f) for f in os.listdir(d))
+BASE = 0.09
+lines = []
+for i, (n, f) in enumerate(entries):
+    gap = (entries[i + 1][0] - n) if i + 1 < len(entries) else 20
+    lines += [f"file '{d}/{f}'", f'duration {max(gap, 1) * BASE:.3f}']
+lines.append(f"file '{d}/{entries[-1][1]}'")  # concat demuxer quirk: repeat last file, no duration
+open('/tmp/concat.txt', 'w').write('\n'.join(lines) + '\n')
+```
+
+```bash
+ffmpeg -y -f concat -safe 0 -i /tmp/concat.txt \
+  -vsync vfr -pix_fmt yuv420p -vf "fps=30,scale=1280:800" \
+  -c:v libx264 -preset fast -crf 19 -movflags +faststart \
+  /tmp/demo.mp4
+```
+
+### `--size` for `video-start`
+
+`playwright-cli video-start` defaults to fitting the video within 800×800.
+If your actual viewport is larger (e.g. 1280×800), the output is scaled down
+and padded with a dead margin. Always pass `--size` matching the real
+viewport: `playwright-cli video-start out.webm --size "1280x800"`.
 
 ### CDP mouse events vs Pointer Events
 
@@ -495,10 +660,10 @@ async (page) => {
 Orchestration:
 
 ```bash
-playwright-cli open http://localhost:5710
+playwright-cli open http://localhost:PORT
 playwright-cli resize 1280 720
 playwright-cli eval '<CURSOR_SNIPPET>'
-playwright-cli video-start /tmp/resize-demo.webm
+playwright-cli video-start /tmp/resize-demo.webm --size "1280x720"
 playwright-cli run-code --filename /tmp/resize-demo.js
 playwright-cli video-stop
 ffmpeg -y -i /tmp/resize-demo.webm \

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ providers.json
 .superpowers/
 test-results/
 playwright-report/
+.playwright-cli/
 packages/swift-launcher/.node-cache/
 /tasks/
 .claude/settings.*

--- a/packages/webapp/src/ui/wc/file-actions.ts
+++ b/packages/webapp/src/ui/wc/file-actions.ts
@@ -7,6 +7,7 @@ import type { MenuItem } from '@slicc/webcomponents';
 import { SliccOverflowMenu, SliccQuickLook } from '@slicc/webcomponents';
 
 import type { LocalVfsClient } from '../../kernel/local-vfs-client.js';
+import type { WritableVfsClient } from '../../kernel/writable-vfs-client.js';
 
 const MIME_MAP: Record<string, string> = {
   '.md': 'text/markdown',
@@ -41,16 +42,23 @@ function isPreviewableInBrowser(path: string): boolean {
   return ext === '.html' || ext === '.svg';
 }
 
+async function copyFileContent(fs: WritableVfsClient, from: string, to: string): Promise<void> {
+  const data = await fs.readFile(from);
+  await fs.writeFile(to, data);
+}
+
 export interface FileActionDeps {
   fileTree: HTMLElement;
   openFs(): Promise<LocalVfsClient>;
+  /** Page-side writer routed through the worker's VfsRpcHost — see writable-vfs-client.ts. */
+  openWriter(): Promise<WritableVfsClient>;
   insertReference(path: string): void;
   toPreviewUrl(vfsPath: string): string;
   log: { error(message: string, ...data: unknown[]): void };
 }
 
 export function wireFileActions(deps: FileActionDeps): void {
-  const { fileTree, openFs, insertReference, toPreviewUrl, log } = deps;
+  const { fileTree, openFs, openWriter, insertReference, toPreviewUrl, log } = deps;
 
   fileTree.addEventListener('file-preview', async (e) => {
     const { path } = (e as CustomEvent<{ id: string; path: string }>).detail;
@@ -112,7 +120,9 @@ export function wireFileActions(deps: FileActionDeps): void {
       },
       { id: 'delete', label: 'Delete', destructive: true },
     ];
-    SliccOverflowMenu.show({ anchor, items, context: { path } });
+    // dispatchTarget: the file tree host outlives the periodic 3s refresh that
+    // rebuilds row DOM (and thus `anchor`) out from under a still-open menu.
+    SliccOverflowMenu.show({ anchor, items, context: { path }, dispatchTarget: fileTree });
   });
 
   fileTree.addEventListener('overflow-action', async (e) => {
@@ -128,29 +138,28 @@ export function wireFileActions(deps: FileActionDeps): void {
           window.open(toPreviewUrl(path), '_blank');
           break;
         case 'duplicate': {
-          const fs = await openFs();
-          const data = await fs.readFile(path);
           const dot = path.lastIndexOf('.');
           const newPath = dot > 0 ? `${path.slice(0, dot)}_copy${path.slice(dot)}` : `${path}_copy`;
-          // LocalVfsClient is read-only, but this is a design-time limitation.
-          // The real fs passed in is a VirtualFS that has writeFile.
-          // We cast here to access the write method.
-          await (
-            fs as LocalVfsClient & { writeFile(p: string, d: unknown): Promise<void> }
-          ).writeFile(newPath, data);
+          await copyFileContent(await openWriter(), path, newPath);
           break;
         }
         case 'delete': {
-          if (confirm(`Delete ${path.split('/').pop()}?`)) {
-            const fs = await openFs();
-            // Same cast for rm method
-            await (fs as LocalVfsClient & { rm(p: string): Promise<void> }).rm(path);
+          if (confirm(`Delete ${path}?`)) {
+            const fs = await openWriter();
+            await fs.rm(path);
           }
           break;
         }
-        case 'rename':
-          // Inline rename is complex — emit event for the file tree to handle
+        case 'rename': {
+          const oldName = path.split('/').pop() ?? '';
+          const newName = prompt(`Rename ${path} to:`, oldName)?.trim();
+          if (!newName || newName === oldName || newName.includes('/')) break;
+          const newPath = `${path.slice(0, path.length - oldName.length)}${newName}`;
+          const fs = await openWriter();
+          await copyFileContent(fs, path, newPath);
+          await fs.rm(path);
           break;
+        }
       }
     } catch (err) {
       log.error(`Overflow action "${action}" failed`, err);

--- a/packages/webapp/src/ui/wc/file-actions.ts
+++ b/packages/webapp/src/ui/wc/file-actions.ts
@@ -43,8 +43,23 @@ function isPreviewableInBrowser(path: string): boolean {
 }
 
 async function copyFileContent(fs: WritableVfsClient, from: string, to: string): Promise<void> {
-  const data = await fs.readFile(from);
+  const raw = await fs.readFile(from, { encoding: 'binary' });
+  // Re-materialize into a plain same-realm Uint8Array: the raw value can be a
+  // pooled/foreign buffer that fails `instanceof Uint8Array` (and writeFile's
+  // non-mount path passes content straight through with no normalization of
+  // its own) — see the identical copy in the file-preview/file-download
+  // handlers above.
+  const data = typeof raw === 'string' ? raw : Uint8Array.from(raw);
   await fs.writeFile(to, data);
+}
+
+async function existsInVfs(fs: WritableVfsClient, path: string): Promise<boolean> {
+  try {
+    await fs.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export interface FileActionDeps {
@@ -140,7 +155,14 @@ export function wireFileActions(deps: FileActionDeps): void {
         case 'duplicate': {
           const dot = path.lastIndexOf('.');
           const newPath = dot > 0 ? `${path.slice(0, dot)}_copy${path.slice(dot)}` : `${path}_copy`;
-          await copyFileContent(await openWriter(), path, newPath);
+          const fs = await openWriter();
+          if (
+            (await existsInVfs(fs, newPath)) &&
+            !confirm(`${newPath} already exists. Overwrite?`)
+          ) {
+            break;
+          }
+          await copyFileContent(fs, path, newPath);
           break;
         }
         case 'delete': {
@@ -156,6 +178,12 @@ export function wireFileActions(deps: FileActionDeps): void {
           if (!newName || newName === oldName || newName.includes('/')) break;
           const newPath = `${path.slice(0, path.length - oldName.length)}${newName}`;
           const fs = await openWriter();
+          if (
+            (await existsInVfs(fs, newPath)) &&
+            !confirm(`${newPath} already exists. Overwrite?`)
+          ) {
+            break;
+          }
           await copyFileContent(fs, path, newPath);
           await fs.rm(path);
           break;

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1374,6 +1374,7 @@ export function attachWcClient(
       memoryHost: refs.memoryHost,
       monitor: refs.monitor,
       openFs: openReader,
+      openWriter: async () => (await openVfs()).writer,
       onKernelReady: (fn) => boot.onClientReady(fn),
       getMonitorDeps: () => ({
         getScoops: () => client.getScoops(),

--- a/packages/webapp/src/ui/wc/wc-workbench.ts
+++ b/packages/webapp/src/ui/wc/wc-workbench.ts
@@ -8,6 +8,7 @@
 
 import type { SliccFileTree, SliccMonitor } from '@slicc/webcomponents';
 import type { LocalVfsClient } from '../../kernel/local-vfs-client.js';
+import type { WritableVfsClient } from '../../kernel/writable-vfs-client.js';
 import { toPreviewUrl } from '../../shell/supplemental-commands/shared.js';
 import { wireFileActions } from './file-actions.js';
 import { buildMemoryRows } from './wc-memory.js';
@@ -96,6 +97,8 @@ export interface WcWorkbenchDeps {
   monitor: SliccMonitor;
   /** Lazily resolved page-side VFS reader (routed through the worker's VfsRpcHost). */
   openFs(): Promise<LocalVfsClient>;
+  /** Lazily resolved page-side VFS writer (routed through the worker's VfsRpcHost). */
+  openWriter(): Promise<WritableVfsClient>;
   getMonitorDeps(): MonitorDeps;
   /** Mounts the worker-shell terminal into the surface; resolves on attach. */
   mountTerminal(container: HTMLElement): Promise<void>;
@@ -134,6 +137,7 @@ export function createWorkbenchActivator(deps: WcWorkbenchDeps): (surfaceId: str
           wireFileActions({
             fileTree: deps.fileTree,
             openFs: deps.openFs,
+            openWriter: deps.openWriter,
             insertReference: deps.insertReference,
             toPreviewUrl,
             log: deps.log,

--- a/packages/webapp/tests/ui/wc/file-actions.test.ts
+++ b/packages/webapp/tests/ui/wc/file-actions.test.ts
@@ -75,6 +75,74 @@ describe('wireFileActions', () => {
     expect(log.error).not.toHaveBeenCalled();
   });
 
+  it('duplicate round-trips binary content byte-for-byte', async () => {
+    // Bytes 0x80-0xFF are invalid standalone UTF-8 continuation bytes — a
+    // naive utf-8 read+write mangles them into U+FFFD replacement chars.
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0x80]);
+    await fs.writeFile('/workspace/skills/photo.png', bytes);
+    dispatchOverflowAction(fileTree, 'duplicate', { path: '/workspace/skills/photo.png' });
+    await vi.waitFor(async () => {
+      await expect(fs.stat('/workspace/skills/photo_copy.png')).resolves.toBeTruthy();
+    });
+    const copied = await fs.readFile('/workspace/skills/photo_copy.png', { encoding: 'binary' });
+    expect(Array.from(copied as Uint8Array)).toEqual(Array.from(bytes));
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('rename round-trips binary content byte-for-byte', async () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0x80]);
+    await fs.writeFile('/workspace/skills/photo.png', bytes);
+    vi.spyOn(window, 'prompt').mockReturnValue('renamed.png');
+    dispatchOverflowAction(fileTree, 'rename', { path: '/workspace/skills/photo.png' });
+    await vi.waitFor(async () => {
+      await expect(fs.stat('/workspace/skills/renamed.png')).resolves.toBeTruthy();
+    });
+    const renamed = await fs.readFile('/workspace/skills/renamed.png', { encoding: 'binary' });
+    expect(Array.from(renamed as Uint8Array)).toEqual(Array.from(bytes));
+    await expect(fs.stat('/workspace/skills/photo.png')).rejects.toThrow();
+  });
+
+  it('duplicate asks before overwriting an existing sibling, and skips on decline', async () => {
+    await fs.writeFile('/workspace/skills/SKILL_copy.md', 'preexisting');
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    dispatchOverflowAction(fileTree, 'duplicate', { path: '/workspace/skills/SKILL.md' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(confirmSpy).toHaveBeenCalledWith(
+      '/workspace/skills/SKILL_copy.md already exists. Overwrite?'
+    );
+    expect(await fs.readFile('/workspace/skills/SKILL_copy.md', { encoding: 'utf-8' })).toBe(
+      'preexisting'
+    );
+  });
+
+  it('duplicate overwrites an existing sibling when confirmed', async () => {
+    await fs.writeFile('/workspace/skills/SKILL_copy.md', 'preexisting');
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    dispatchOverflowAction(fileTree, 'duplicate', { path: '/workspace/skills/SKILL.md' });
+    await vi.waitFor(async () => {
+      expect(await fs.readFile('/workspace/skills/SKILL_copy.md', { encoding: 'utf-8' })).toBe(
+        '# skill content'
+      );
+    });
+  });
+
+  it('rename asks before overwriting an existing sibling, and leaves both files untouched on decline', async () => {
+    await fs.writeFile('/workspace/skills/OTHER.md', 'sibling content');
+    vi.spyOn(window, 'prompt').mockReturnValue('OTHER.md');
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    dispatchOverflowAction(fileTree, 'rename', { path: '/workspace/skills/SKILL.md' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(confirmSpy).toHaveBeenCalledWith(
+      '/workspace/skills/OTHER.md already exists. Overwrite?'
+    );
+    expect(await fs.readFile('/workspace/skills/OTHER.md', { encoding: 'utf-8' })).toBe(
+      'sibling content'
+    );
+    expect(await fs.readFile('/workspace/skills/SKILL.md', { encoding: 'utf-8' })).toBe(
+      '# skill content'
+    );
+  });
+
   it('delete confirms with the full path and removes the file', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     dispatchOverflowAction(fileTree, 'delete', { path: '/workspace/skills/SKILL.md' });

--- a/packages/webapp/tests/ui/wc/file-actions.test.ts
+++ b/packages/webapp/tests/ui/wc/file-actions.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+/**
+ * `wireFileActions` regression coverage. `duplicate`/`delete` previously read
+ * through the read-only `LocalVfsClient` and cast it to a write-capable type
+ * that didn't exist at runtime — `writeFile`/`rm` threw `TypeError`s that were
+ * swallowed by the handler's own try/catch, so the menu items silently did
+ * nothing. They now go through the real kernel-RPC-backed `WritableVfsClient`
+ * (`openWriter`). `rename` was a stub; it's now implemented as
+ * read + write-to-new-name + remove-old, same as `duplicate` plus a delete.
+ */
+
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { installWcDomStubs } from './wc-dom-stubs.js';
+
+installWcDomStubs();
+
+import { SliccOverflowMenu } from '@slicc/webcomponents';
+import { VirtualFS } from '../../../src/fs/virtual-fs.js';
+import { wireFileActions } from '../../../src/ui/wc/file-actions.js';
+
+async function seededFs(): Promise<VirtualFS> {
+  const fs = await VirtualFS.create({ dbName: `file-actions-${Math.random()}`, wipe: true });
+  await fs.mkdir('/workspace/skills', { recursive: true });
+  await fs.writeFile('/workspace/skills/SKILL.md', '# skill content');
+  return fs;
+}
+
+function dispatchOverflowAction(
+  fileTree: HTMLElement,
+  action: string,
+  context: { path: string }
+): void {
+  fileTree.dispatchEvent(
+    new CustomEvent('overflow-action', {
+      bubbles: true,
+      composed: true,
+      detail: { action, context },
+    })
+  );
+}
+
+describe('wireFileActions', () => {
+  let fs: VirtualFS;
+  let fileTree: HTMLElement;
+  let log: { error: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    fs = await seededFs();
+    fileTree = document.createElement('div');
+    document.body.appendChild(fileTree);
+    log = { error: vi.fn() };
+    wireFileActions({
+      fileTree,
+      openFs: async () => fs,
+      openWriter: async () => fs,
+      insertReference: vi.fn(),
+      toPreviewUrl: (p: string) => `http://localhost/preview${p}`,
+      log,
+    });
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    SliccOverflowMenu.hide();
+  });
+
+  it('duplicate writes a sibling _copy file with the same content', async () => {
+    dispatchOverflowAction(fileTree, 'duplicate', { path: '/workspace/skills/SKILL.md' });
+    await vi.waitFor(async () => {
+      expect(await fs.readFile('/workspace/skills/SKILL_copy.md', { encoding: 'utf-8' })).toBe(
+        '# skill content'
+      );
+    });
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('delete confirms with the full path and removes the file', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    dispatchOverflowAction(fileTree, 'delete', { path: '/workspace/skills/SKILL.md' });
+    await vi.waitFor(async () => {
+      await expect(fs.stat('/workspace/skills/SKILL.md')).rejects.toThrow();
+    });
+    expect(confirmSpy).toHaveBeenCalledWith('Delete /workspace/skills/SKILL.md?');
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('delete does nothing when confirm is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    dispatchOverflowAction(fileTree, 'delete', { path: '/workspace/skills/SKILL.md' });
+    await new Promise((r) => setTimeout(r, 10));
+    await expect(fs.stat('/workspace/skills/SKILL.md')).resolves.toBeTruthy();
+  });
+
+  it('rename prompts with the full path and moves content to the new name', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('RENAMED.md');
+    dispatchOverflowAction(fileTree, 'rename', { path: '/workspace/skills/SKILL.md' });
+    await vi.waitFor(async () => {
+      expect(await fs.readFile('/workspace/skills/RENAMED.md', { encoding: 'utf-8' })).toBe(
+        '# skill content'
+      );
+    });
+    expect(promptSpy).toHaveBeenCalledWith('Rename /workspace/skills/SKILL.md to:', 'SKILL.md');
+    await expect(fs.stat('/workspace/skills/SKILL.md')).rejects.toThrow();
+  });
+
+  it('rename does nothing when the prompt is cancelled', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue(null);
+    dispatchOverflowAction(fileTree, 'rename', { path: '/workspace/skills/SKILL.md' });
+    await new Promise((r) => setTimeout(r, 10));
+    await expect(fs.stat('/workspace/skills/SKILL.md')).resolves.toBeTruthy();
+  });
+
+  it('rename does nothing when the new name is unchanged or contains a slash', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValueOnce('SKILL.md').mockReturnValueOnce('a/b.md');
+    dispatchOverflowAction(fileTree, 'rename', { path: '/workspace/skills/SKILL.md' });
+    await new Promise((r) => setTimeout(r, 10));
+    dispatchOverflowAction(fileTree, 'rename', { path: '/workspace/skills/SKILL.md' });
+    await new Promise((r) => setTimeout(r, 10));
+    await expect(fs.stat('/workspace/skills/SKILL.md')).resolves.toBeTruthy();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('copy-path writes the path to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    dispatchOverflowAction(fileTree, 'copy-path', { path: '/workspace/skills/SKILL.md' });
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('/workspace/skills/SKILL.md');
+    });
+  });
+
+  it('open-browser opens the preview URL in a new tab', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    dispatchOverflowAction(fileTree, 'open-browser', { path: '/workspace/skills/index.html' });
+    await vi.waitFor(() => {
+      expect(open).toHaveBeenCalledWith(
+        'http://localhost/preview/workspace/skills/index.html',
+        '_blank'
+      );
+    });
+  });
+
+  it('end-to-end: overflow menu survives the anchor being detached before the click', async () => {
+    const anchor = document.createElement('button');
+    fileTree.appendChild(anchor);
+    fileTree.dispatchEvent(
+      new CustomEvent('file-overflow', {
+        detail: { id: 'x', path: '/workspace/skills/SKILL.md', anchor },
+      })
+    );
+    const menu = document.querySelector('slicc-overflow-menu') as SliccOverflowMenu;
+    expect(menu).not.toBeNull();
+    // Simulate the file tree's periodic refresh rebuilding rows mid-menu.
+    anchor.remove();
+    const dupItem = menu.shadowRoot?.querySelector('[data-action="duplicate"]') as HTMLElement;
+    dupItem.click();
+    await vi.waitFor(async () => {
+      expect(await fs.readFile('/workspace/skills/SKILL_copy.md', { encoding: 'utf-8' })).toBe(
+        '# skill content'
+      );
+    });
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-workbench.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-workbench.test.ts
@@ -95,6 +95,7 @@ describe('createWorkbenchActivator', () => {
       termSurface: document.createElement('div'),
       memoryHost: document.createElement('div'),
       openFs: vi.fn(async () => await seededFs()),
+      openWriter: vi.fn(async () => await seededFs()),
       mountTerminal: vi.fn(async () => undefined),
       // In tests the "kernel" is always ready — fire the callback immediately.
       onKernelReady: vi.fn((fn: () => void) => fn()),

--- a/packages/webcomponents/src/overflow-menu/slicc-overflow-menu.ts
+++ b/packages/webcomponents/src/overflow-menu/slicc-overflow-menu.ts
@@ -13,7 +13,14 @@ export interface MenuItem {
 export interface OverflowMenuOptions {
   anchor: HTMLElement;
   items: MenuItem[];
-  context?: any;
+  context?: unknown;
+  /**
+   * Element to dispatch `overflow-action` from. Defaults to `anchor`. Callers
+   * whose anchor can be torn down before the menu is acted on (e.g. a row
+   * rebuilt by a polling refresh) should pass a longer-lived ancestor here —
+   * dispatching on a since-detached anchor bubbles nowhere.
+   */
+  dispatchTarget?: HTMLElement;
 }
 
 const STYLE = `
@@ -63,7 +70,9 @@ let clickOutsideHandler: ((e: MouseEvent) => void) | null = null;
 
 export class SliccOverflowMenu extends HTMLElement {
   #root: ShadowRoot;
-  #context: any = undefined;
+  #context: unknown = undefined;
+  #anchor: HTMLElement | null = null;
+  #dispatchTarget: HTMLElement | null = null;
 
   constructor() {
     super();
@@ -83,7 +92,15 @@ export class SliccOverflowMenu extends HTMLElement {
     const target = (e.target as HTMLElement).closest<HTMLElement>('[data-action]');
     if (!target) return;
     const action = target.dataset.action!;
-    this.dispatchEvent(
+    // Dispatch on dispatchTarget/anchor (part of the caller's DOM tree), not on
+    // `this` — the menu itself is appended to document.body and its own bubble
+    // path never reaches listeners attached to the caller's element (e.g. the
+    // file tree). `anchor` alone isn't reliable as a target: some callers (the
+    // file tree) rebuild their rows on a timer, which detaches it before the
+    // user acts on the menu, and dispatching on a detached node bubbles
+    // nowhere. `dispatchTarget` lets such callers supply a longer-lived
+    // ancestor instead.
+    (this.#dispatchTarget ?? this.#anchor ?? this).dispatchEvent(
       new CustomEvent('overflow-action', {
         bubbles: true,
         composed: true,
@@ -97,6 +114,8 @@ export class SliccOverflowMenu extends HTMLElement {
     SliccOverflowMenu.hide();
     const el = document.createElement('slicc-overflow-menu') as SliccOverflowMenu;
     el.#context = opts.context;
+    el.#anchor = opts.anchor;
+    el.#dispatchTarget = opts.dispatchTarget ?? null;
 
     const visibleItems = opts.items.filter((i) => i.visible !== false);
     const menuDiv = h('div', { class: 'menu' });

--- a/packages/webcomponents/tests/overflow-menu/slicc-overflow-menu.test.ts
+++ b/packages/webcomponents/tests/overflow-menu/slicc-overflow-menu.test.ts
@@ -42,19 +42,63 @@ describe('slicc-overflow-menu', () => {
     expect(menu.shadowRoot?.querySelectorAll('[data-action]')).toHaveLength(1);
   });
 
-  it('clicking an item emits overflow-action with action + context and closes', () => {
+  it('clicking an item emits overflow-action on the anchor with action + context and closes', () => {
     const anchor = document.createElement('button');
     document.body.appendChild(anchor);
     SliccOverflowMenu.show({ anchor, items: ITEMS, context: { path: '/test.txt' } });
     const menu = document.querySelector('slicc-overflow-menu') as SliccOverflowMenu;
     const onAction = vi.fn();
-    menu.addEventListener('overflow-action', onAction);
+    // The menu is appended to document.body, a separate branch from wherever the
+    // anchor lives — callers (e.g. the file tree) listen on the anchor's ancestry,
+    // so the event must dispatch from the anchor for it to bubble there.
+    anchor.addEventListener('overflow-action', onAction);
     const row = menu.shadowRoot?.querySelector('[data-action="rename"]') as HTMLElement;
     row.click();
     expect(onAction).toHaveBeenCalledTimes(1);
     const detail = onAction.mock.calls[0][0].detail;
     expect(detail).toEqual({ action: 'rename', context: { path: '/test.txt' } });
     expect(document.querySelector('slicc-overflow-menu')).toBeNull();
+  });
+
+  it('dispatchTarget receives overflow-action even after anchor is detached', () => {
+    const container = document.createElement('div');
+    const anchor = document.createElement('button');
+    container.appendChild(anchor);
+    document.body.appendChild(container);
+    SliccOverflowMenu.show({
+      anchor,
+      items: ITEMS,
+      context: { path: '/test.txt' },
+      dispatchTarget: container,
+    });
+    const menu = document.querySelector('slicc-overflow-menu') as SliccOverflowMenu;
+    const onAction = vi.fn();
+    container.addEventListener('overflow-action', onAction);
+    // Simulate a caller (e.g. the file tree) rebuilding its rows — and thus
+    // detaching `anchor` — before the user acts on the still-open menu.
+    anchor.remove();
+    const row = menu.shadowRoot?.querySelector('[data-action="copy-path"]') as HTMLElement;
+    row.click();
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onAction.mock.calls[0][0].detail).toEqual({
+      action: 'copy-path',
+      context: { path: '/test.txt' },
+    });
+  });
+
+  it('falls back to anchor when no dispatchTarget is given, and misses once detached', () => {
+    const container = document.createElement('div');
+    const anchor = document.createElement('button');
+    container.appendChild(anchor);
+    document.body.appendChild(container);
+    SliccOverflowMenu.show({ anchor, items: ITEMS });
+    const menu = document.querySelector('slicc-overflow-menu') as SliccOverflowMenu;
+    const onAction = vi.fn();
+    container.addEventListener('overflow-action', onAction);
+    anchor.remove();
+    const row = menu.shadowRoot?.querySelector('[data-action="copy-path"]') as HTMLElement;
+    row.click();
+    expect(onAction).not.toHaveBeenCalled();
   });
 
   it('hide() removes the menu from DOM', () => {


### PR DESCRIPTION


https://github.com/user-attachments/assets/447d35a8-9981-4ccd-8258-aee5582d3dc2



## Summary

The VFS panel's file-row "..." overflow menu (Rename / Duplicate / Copy path /
Delete) did nothing when clicked. Two independent bugs combined to cause
this: the menu's click events never reached the file tree's listener, and
the write-side handlers were casting a read-only VFS client to a type with
methods that don't exist at runtime. Rename was previously an unimplemented
stub. All four actions now work, and Delete/Rename dialogs show the full
path so it's unambiguous which file is targeted.

## Why

**Repro (before this PR):**
1. Hover a file in the Files panel, click the "..." button
2. Click Duplicate (or Rename, or Delete)

Expected: the file is duplicated/renamed/deleted.
Actual: the menu closes and nothing happens. No error surfaces to the user.

**Root causes**, found via live CDP inspection against a running instance:

1. `SliccOverflowMenu` is appended to `document.body`, so dispatching its
   `overflow-action` event on itself never bubbled to the file tree's
   listener (they're on separate DOM branches). Fixed by dispatching from
   the anchor button instead — but the file tree also rebuilds its row DOM
   unconditionally every 3s (`wc-workbench.ts`'s poll), which detaches the
   anchor before a real user finishes reading the menu and clicking. Added
   an optional `dispatchTarget` so the caller can supply the longer-lived
   file-tree host instead.
2. Once events reached the handler, `duplicate`/`delete` read through the
   page's read-only `LocalVfsClient` and cast it to a type claiming
   `writeFile`/`rm` methods that don't exist on the object at runtime — the
   calls threw `TypeError`s, silently caught and logged. Fixed by wiring the
   already-existing, RPC-backed `WritableVfsClient` through as a new
   `openWriter` dependency (`wc-live.ts` → `wc-workbench.ts` →
   `file-actions.ts`).
3. `rename` was a stub (`// Inline rename is complex — emit event for the
   file tree to handle`, no-op). Implemented via `prompt()` + the same
   writer, sharing a new `copyFileContent()` helper with `duplicate`.

## Approach / Implementation notes

- `dispatchTarget` on `SliccOverflowMenu` defaults to the anchor when unset,
  so existing/other callers (stories, tests) are unaffected.
- `rename`/`delete` dialogs now interpolate the full VFS path
  (`Delete /workspace/foo.md?`) instead of just the filename, per follow-up
  request, so the target is unambiguous.
- Also included: a `docs(demo-recording)` commit capturing 8 playwright-cli/
  CDP gotchas (stale dev-URL example, single-leader-tab apps, a `video-start`
  screencast compositing bug, native-dialog handling under `attach --cdp`,
  etc.) discovered while recording a demo of this fix — see that commit for
  detail.

## Cross-cutting impact

- **Floats exercised**: Standalone CLI (verified live against a running
  instance via CDP). The file tree / overflow menu / `openWriter` wiring is
  float-agnostic (`wc-live.ts` is shared boot code), so extension/Electron
  get the same fix with no float-specific changes needed.
- **Other callers of `SliccOverflowMenu.show()`**: audited — only
  `file-actions.ts` (plus its own stories/tests) calls it; no other consumer
  needed the `dispatchTarget` treatment.
- **Other callers with the same read-only-cast anti-pattern**: audited
  `packages/webapp/src/ui/wc/` and `packages/webapp/src/kernel/` — no other
  instance found.
- **Security**: `rename` rejects new names containing `/` to keep the file
  in the same directory (not a path-traversal boundary — the writer RPC
  already resolves absolute VFS paths within the already-authenticated
  session).

## Test plan

- [x] `npm run typecheck` — clean (8/8 targets)
- [x] `npm run test` — 10258 passing (627 files), no new failures
- [x] `npm run build` — clean
- [x] `npm run build -w @slicc/chrome-extension` — clean
- [x] `npm run lint` — clean
- [x] **New/changed behavior covered by unit tests**:
      `npx vitest run packages/webapp/tests/ui/wc/file-actions.test.ts` (new,
      9 tests: duplicate/rename/delete/copy-path/open-browser, plus an
      end-to-end regression test for the anchor-detachment race),
      `npx vitest run packages/webcomponents/tests/overflow-menu/slicc-overflow-menu.test.ts`
      (10 tests, 2 new covering `dispatchTarget` + the detached-anchor case),
      `npx vitest run packages/webapp/tests/ui/wc/wc-workbench.test.ts`
      (updated mock to include `openWriter`)
- [x] Manual smoke (CLI): built and ran the standalone dev harness, drove the
      real file tree via CDP — duplicated, renamed, copy-pathed, and deleted
      a real file end-to-end, including reproducing the original bug (event
      never firing) and the anchor-detachment race before confirming the fix

**Pre-existing failures**: none observed.

## Documentation

- [x] `.claude/skills/demo-recording/SKILL.md` — captured gotchas from
      recording this fix's demo video (separate commit)
- [x] No other documentation changes needed (internal bug fix, no new
      public API/shell surface)

## Risk & rollback

- Blast radius: file-tree overflow menu only (Duplicate/Rename/Copy
  path/Delete/Open in browser). No data migration, no persisted-state shape
  change.
- Clean revert — no follow-up needed to undo.
- Nothing CI can't catch here; the fix was verified against real Chrome CDP
  behavior during development (see Test plan).

## Checklist

- [x] Commits are focused and package-local where possible (3 commits:
      webcomponents fix, webapp fix, skill docs)
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] No public API / shell-command / lick-channel changes
- [x] No other floats' contracts affected (see Cross-cutting impact)