### PR TITLE
refactor(extension): drop dead rawSvgEsbuildPlugin after launcher removal

### DIFF
--- a/packages/chrome-extension/vite.config.ts
+++ b/packages/chrome-extension/vite.config.ts
@@ -150,26 +150,6 @@ function buildPreviewSwPlugin() {
 }
 
 /**
- * esbuild plugin: load `*.svg?raw` imports as text — matches Vite's `?raw`
- * loader so the launcher's inline mono-logo SVGs bundle correctly.
- */
-function rawSvgEsbuildPlugin(): import('esbuild').Plugin {
-  return {
-    name: 'raw-svg',
-    setup(build) {
-      build.onResolve({ filter: /\.svg\?raw$/ }, (args) => ({
-        path: resolve(args.resolveDir, args.path.replace('?raw', '')),
-        namespace: 'raw-svg',
-      }));
-      build.onLoad({ filter: /.*/, namespace: 'raw-svg' }, async (args) => {
-        const { readFile } = await import('fs/promises');
-        return { contents: await readFile(args.path, 'utf8'), loader: 'text' };
-      });
-    },
-  };
-}
-
-/**
  * Build the side-panel host as ESM. The panel mounts a UI-only cherry follower
  * iframe and runs the tri-state controller (booting → ready → disconnected)
  * via a chrome-panel Port to the service worker.
@@ -189,7 +169,6 @@ function buildSidePanelPlugin() {
           '@slicc/shared-ts': resolve(repoRoot, 'packages/shared-ts/src/index.ts'),
         },
         external: ['html2canvas-pro'],
-        plugins: [rawSvgEsbuildPlugin()],
         define: { ...PROD_IIFE_DEFAULTS.define, __SLICC_EXT_DEV__: JSON.stringify(isExtDev) },
       });
     },


### PR DESCRIPTION
## Problem
Follow-up cleanup for #1210. The launcher/content-script removal in 64b98c5 closed most of the issue, leaving one orphan: `rawSvgEsbuildPlugin()` in `packages/chrome-extension/vite.config.ts`.

## Solution
The only `.svg?raw` imports in the repo live in `packages/spoon/src/slicc-launcher.ts` (the removed launcher). The plugin stayed registered in `buildSidePanelPlugin`, but the sidepanel bundle graph imports no `.svg?raw`, so esbuild never invoked it — pure dead code, no functional change. Removed the definition + its registration.

## Testing
- `npm run build -w @slicc/chrome-extension` — still emits `sidepanel.js`; `content-script.js` absent.
- `knip` — no new dead files/deps.
- `biome check` — clean.

Closes #1210

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWVKH1P9C5VGREF1FSMWHF3J&panel=chat)