### PR TITLE
fix(webapp): retry lucide-icons.js fetch instead of caching failures

### DIFF
--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -952,10 +952,17 @@ export class SprinkleRenderer {
           SprinkleRenderer.cachedLucideScript = text;
           return text;
         }
-      } catch {
-        // Lucide unavailable — sprinkle will render without icons
+        console.warn(
+          '[sprinkle-renderer] lucide-icons.js fetch returned non-ok status:',
+          resp.status
+        );
+      } catch (err) {
+        console.warn('[sprinkle-renderer] lucide-icons.js fetch failed:', err);
+      } finally {
+        // Reset the in-flight promise so the next sprinkle render can retry,
+        // rather than caching '' permanently after one transient failure.
+        SprinkleRenderer.lucideScriptPromise = null;
       }
-      SprinkleRenderer.cachedLucideScript = '';
       return '';
     })();
 

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -1,5 +1,5 @@
 import { JSDOM } from 'jsdom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SprinkleBridgeAPI } from '../../src/ui/sprinkle-bridge.js';
 import { isFullDocument, SprinkleRenderer } from '../../src/ui/sprinkle-renderer.js';
 
@@ -360,6 +360,77 @@ describe('SprinkleRenderer', () => {
 
       removeItemSpy.mockRestore();
     });
+  });
+});
+
+describe('getLucideScript caching and retry (extension mode)', () => {
+  let dom: JSDOM;
+  let container: HTMLElement;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
+      url: 'http://localhost',
+    });
+    container = dom.window.document.getElementById('root')!;
+    (globalThis as any).window = dom.window;
+    (globalThis as any).document = dom.window.document;
+    // Reset the process-wide static cache between tests.
+    (SprinkleRenderer as any).cachedLucideScript = null;
+    (SprinkleRenderer as any).lucideScriptPromise = null;
+    // Extension APIs the lucide fetch path depends on.
+    (globalThis as any).chrome = { runtime: { getURL: (p: string) => p } };
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    (globalThis as any).fetch = undefined;
+    (globalThis as any).chrome = undefined;
+  });
+
+  it('caches a successful bundle and does not re-fetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => 'ICONS' });
+    (globalThis as any).fetch = fetchMock;
+    const renderer = new SprinkleRenderer(container, makeBridge('s'));
+
+    expect(await (renderer as any).getLucideScript()).toBe('ICONS');
+    expect(await (renderer as any).getLucideScript()).toBe('ICONS');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs and retries after a transient fetch rejection instead of caching the failure', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('extension context invalidated'))
+      .mockResolvedValueOnce({ ok: true, text: async () => 'ICONS' });
+    (globalThis as any).fetch = fetchMock;
+    const renderer = new SprinkleRenderer(container, makeBridge('s'));
+
+    // First render hits the transient failure: empty string, logged, not cached.
+    expect(await (renderer as any).getLucideScript()).toBe('');
+    expect(warnSpy).toHaveBeenCalled();
+    expect((SprinkleRenderer as any).cachedLucideScript).toBeNull();
+
+    // The next render must retry the fetch and recover rather than being stuck.
+    expect(await (renderer as any).getLucideScript()).toBe('ICONS');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs a non-ok response and retries rather than caching it permanently', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 404, text: async () => '' })
+      .mockResolvedValueOnce({ ok: true, text: async () => 'ICONS' });
+    (globalThis as any).fetch = fetchMock;
+    const renderer = new SprinkleRenderer(container, makeBridge('s'));
+
+    expect(await (renderer as any).getLucideScript()).toBe('');
+    expect(warnSpy).toHaveBeenCalled();
+    expect((SprinkleRenderer as any).cachedLucideScript).toBeNull();
+
+    expect(await (renderer as any).getLucideScript()).toBe('ICONS');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -367,8 +367,16 @@ describe('getLucideScript caching and retry (extension mode)', () => {
   let dom: JSDOM;
   let container: HTMLElement;
   let warnSpy: ReturnType<typeof vi.spyOn>;
+  // Capture original global descriptors so we restore (not clobber) them.
+  // In Node 22+ `fetch` is a built-in global; clearing it leaks into later tests.
+  const touchedGlobals = ['window', 'document', 'chrome', 'fetch'] as const;
+  let savedGlobals: Record<string, PropertyDescriptor | undefined>;
 
   beforeEach(() => {
+    savedGlobals = {};
+    for (const key of touchedGlobals) {
+      savedGlobals[key] = Object.getOwnPropertyDescriptor(globalThis, key);
+    }
     dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
       url: 'http://localhost',
     });
@@ -385,8 +393,16 @@ describe('getLucideScript caching and retry (extension mode)', () => {
 
   afterEach(() => {
     warnSpy.mockRestore();
-    (globalThis as any).fetch = undefined;
-    (globalThis as any).chrome = undefined;
+    // Restore each touched global to its original state: reinstate the
+    // original descriptor when one existed, otherwise remove our addition.
+    for (const key of touchedGlobals) {
+      const desc = savedGlobals[key];
+      if (desc) {
+        Object.defineProperty(globalThis, key, desc);
+      } else {
+        delete (globalThis as any)[key];
+      }
+    }
   });
 
   it('caches a successful bundle and does not re-fetch', async () => {


### PR DESCRIPTION
## Problem

Closes #1233. `getLucideScript` swallowed every fetch failure with an empty `catch {}` and wrote `cachedLucideScript = ''` unconditionally on any non-success path. Since the cache is checked first on every call, a single transient blip on the first sprinkle render permanently disabled icons for every subsequent sprinkle in the session (extension float only).

## Solution

Log the non-ok and failed-fetch paths, and reset the in-flight promise in a `finally` block instead of caching `''`. The empty result is still returned for the current render, but the next render retries the fetch and can recover. Uses the file's existing `console.warn('[sprinkle-renderer] …')` convention.

## Testing

Added regression tests covering: successful bundle is cached (no re-fetch), a transient rejection is logged and retried (not cached), and a non-ok response is logged and retried.

## Misc

The boy-scout complexity gate that blocked the earlier automated attempt (#1256) is already satisfied — `sprinkle-renderer.ts` was refactored off both biome debt lists on `main` (commit `729c268`), so this focused fix passes the gate without further refactoring.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWVK78HSNBMVHZB6V2MZ4S6X&panel=chat)