### PR TITLE
fix(dev-tools): retry + log Pangram failures instead of silently mislabelling

### DIFF
--- a/packages/dev-tools/ai-comment-detection/README.md
+++ b/packages/dev-tools/ai-comment-detection/README.md
@@ -31,6 +31,15 @@ contribution **defaults to human** — a thread is never labelled `ai-generated`
 on a missing signal. The thread label is then `human-in-the-loop` if any
 contribution is human, else `ai-generated` (`decideLabels`).
 
+Because that default is silent and the `human-in-the-loop` label is sticky, a
+transient Pangram outage would otherwise permanently mislabel a thread. So the
+driver **retries the `POST /task` submit** on transient `429`/`5xx`
+(`isRetryablePangramStatus`, bounded linear backoff) and **logs every non-2xx
+status** for both the submit and the poll. A `via default-human` verdict
+accompanied by a `⚠️ Pangram … → HTTP …` line means the tier was unavailable,
+not that the text read as human — the two are otherwise indistinguishable in the
+log.
+
 `human-in-the-loop` is **sticky**: once any human has contributed, later bot/AI
 activity can never make the thread fully AI again. So when the label is already
 present (`isThreadSettledHuman`) the driver exits before gathering comments or

--- a/packages/dev-tools/ai-comment-detection/detect-comment-authors.mjs
+++ b/packages/dev-tools/ai-comment-detection/detect-comment-authors.mjs
@@ -41,6 +41,7 @@ const POLL_INTERVAL_MS = 2000;
 const MAX_POLLS = 30;
 const PANGRAM_POST_ATTEMPTS = 3; // retry the submit on transient 429/5xx before giving up
 const PANGRAM_RETRY_BASE_MS = 1000; // linear backoff base between POST retries
+const PANGRAM_REQUEST_TIMEOUT_MS = 10000; // bound each fetch so a hung request can't stall the job
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -142,6 +143,7 @@ async function createPangramTask(headers, payload) {
         method: 'POST',
         headers,
         body: payload,
+        signal: AbortSignal.timeout(PANGRAM_REQUEST_TIMEOUT_MS),
       });
       if (created.ok) {
         const { task_id: taskId } = await created.json();
@@ -185,9 +187,17 @@ async function pangramDetect(text) {
   for (let i = 0; i < MAX_POLLS; i += 1) {
     await sleep(POLL_INTERVAL_MS);
     try {
-      const res = await fetch(`${PANGRAM_BASE}/task/${taskId}`, { headers });
+      const res = await fetch(`${PANGRAM_BASE}/task/${taskId}`, {
+        headers,
+        signal: AbortSignal.timeout(PANGRAM_REQUEST_TIMEOUT_MS),
+      });
       if (!res.ok) {
-        console.warn(`⚠️  Pangram GET /task/${taskId} → HTTP ${res.status}; retrying poll.`);
+        const retryable = isRetryablePangramStatus(res.status);
+        console.warn(
+          `⚠️  Pangram GET /task/${taskId} → HTTP ${res.status}` +
+            (retryable ? '; retrying poll.' : ' (terminal; not retrying).')
+        );
+        if (!retryable) return null;
         continue;
       }
       const data = await res.json();

--- a/packages/dev-tools/ai-comment-detection/detect-comment-authors.mjs
+++ b/packages/dev-tools/ai-comment-detection/detect-comment-authors.mjs
@@ -27,6 +27,7 @@ import {
   classifyComment,
   decideLabels,
   HUMAN_IN_THE_LOOP_LABEL,
+  isRetryablePangramStatus,
   isThreadSettledHuman,
 } from './lib.mjs';
 
@@ -38,6 +39,8 @@ const PANGRAM_BASE = (
 const MIN_PANGRAM_CHARS = 50; // shorter text carries too little signal to spend a call on
 const POLL_INTERVAL_MS = 2000;
 const MAX_POLLS = 30;
+const PANGRAM_POST_ATTEMPTS = 3; // retry the submit on transient 429/5xx before giving up
+const PANGRAM_RETRY_BASE_MS = 1000; // linear backoff base between POST retries
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -124,33 +127,78 @@ function gatherIssueContributions(number, issue) {
 }
 
 /**
+ * Submit a Pangram detection task, retrying transient failures. Returns the
+ * task id, or null when the submit is unrecoverable. Every non-2xx status is
+ * logged with its code so a silent downgrade to the human default (which then
+ * sticks the `human-in-the-loop` label) is diagnosable from the Actions log —
+ * distinguishing "service unavailable" from a genuine "not AI" verdict. Only
+ * transient 429/5xx are retried; terminal 4xx (bad key, no credits, invalid
+ * input) fail fast.
+ */
+async function createPangramTask(headers, payload) {
+  for (let attempt = 1; attempt <= PANGRAM_POST_ATTEMPTS; attempt += 1) {
+    try {
+      const created = await fetch(`${PANGRAM_BASE}/task`, {
+        method: 'POST',
+        headers,
+        body: payload,
+      });
+      if (created.ok) {
+        const { task_id: taskId } = await created.json();
+        if (taskId) return taskId;
+        console.warn(
+          '⚠️  Pangram POST /task returned 2xx without a task_id; treating as unavailable.'
+        );
+        return null;
+      }
+      const retryable = isRetryablePangramStatus(created.status);
+      console.warn(
+        `⚠️  Pangram POST /task → HTTP ${created.status}` +
+          (retryable
+            ? ` (attempt ${attempt}/${PANGRAM_POST_ATTEMPTS})`
+            : ' (terminal; not retrying)')
+      );
+      if (!retryable) return null;
+    } catch (err) {
+      console.warn(
+        `⚠️  Pangram POST /task failed: ${err.message?.split('\n')[0]} (attempt ${attempt}/${PANGRAM_POST_ATTEMPTS})`
+      );
+    }
+    if (attempt < PANGRAM_POST_ATTEMPTS) await sleep(PANGRAM_RETRY_BASE_MS * attempt);
+  }
+  return null;
+}
+
+/**
  * Pangram async detection: create a task, poll until it settles, return the
  * result object (consumed by `interpretPangram`). Returns null when Pangram is
  * unconfigured, the text is too short, or the call fails — the cascade then
- * defaults the contribution to human.
+ * defaults the contribution to human. Failures are logged with their HTTP
+ * status so a transient outage is visible rather than silently mislabelling.
  */
 async function pangramDetect(text) {
   if (!PANGRAM_KEY || (text ?? '').trim().length < MIN_PANGRAM_CHARS) return null;
   const headers = { 'Content-Type': 'application/json', 'x-api-key': PANGRAM_KEY };
-  try {
-    const created = await fetch(`${PANGRAM_BASE}/task`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ text, public_dashboard_link: false }),
-    });
-    if (!created.ok) return null;
-    const { task_id: taskId } = await created.json();
-    if (!taskId) return null;
-    for (let i = 0; i < MAX_POLLS; i += 1) {
-      await sleep(POLL_INTERVAL_MS);
+  const payload = JSON.stringify({ text, public_dashboard_link: false });
+  const taskId = await createPangramTask(headers, payload);
+  if (!taskId) return null;
+  for (let i = 0; i < MAX_POLLS; i += 1) {
+    await sleep(POLL_INTERVAL_MS);
+    try {
       const res = await fetch(`${PANGRAM_BASE}/task/${taskId}`, { headers });
-      if (!res.ok) continue;
+      if (!res.ok) {
+        console.warn(`⚠️  Pangram GET /task/${taskId} → HTTP ${res.status}; retrying poll.`);
+        continue;
+      }
       const data = await res.json();
       if (data.stage === 'STAGE_SUCCESS' || data.stage === 'STAGE_FAILED') return data;
+    } catch (err) {
+      console.warn(`⚠️  Pangram poll failed: ${err.message?.split('\n')[0]}; retrying poll.`);
     }
-  } catch (err) {
-    console.warn(`⚠️  Pangram detection failed: ${err.message?.split('\n')[0]}`);
   }
+  console.warn(
+    `⚠️  Pangram task ${taskId} did not settle in ${MAX_POLLS} polls; treating as unavailable.`
+  );
   return null;
 }
 

--- a/packages/dev-tools/ai-comment-detection/lib.mjs
+++ b/packages/dev-tools/ai-comment-detection/lib.mjs
@@ -148,6 +148,17 @@ export function interpretPangram(result, threshold = 0.5) {
 }
 
 /**
+ * Whether a Pangram HTTP status is worth retrying: only transient rate-limit
+ * (429) or server (5xx) errors. Client errors (400/401/402/403/413/422) are
+ * terminal — a retry can't fix a bad key, no credits, or invalid input — so the
+ * call fails fast to the human default rather than burning the poll budget.
+ * @param {number} status
+ */
+export function isRetryablePangramStatus(status) {
+  return status === 429 || (status >= 500 && status <= 599);
+}
+
+/**
  * Markdown-density above which a comment is treated as machine-formatted.
  * Tuned against a 395-contribution sample across the ai-ecoverse org validated
  * with Pangram: at 0.15 the flag was 96% precise but missed AI-written prose

--- a/packages/dev-tools/ai-comment-detection/lib.test.mjs
+++ b/packages/dev-tools/ai-comment-detection/lib.test.mjs
@@ -7,6 +7,7 @@ import {
   interpretPangram,
   isBotAccount,
   isBotLogin,
+  isRetryablePangramStatus,
   isThreadSettledHuman,
   jaccardSimilarity,
   MARKDOWN_DENSITY_THRESHOLD,
@@ -86,6 +87,20 @@ describe('interpretPangram', () => {
   it('marks failed/empty results unavailable', () => {
     expect(interpretPangram({ stage: 'STAGE_FAILED' }).available).toBe(false);
     expect(interpretPangram(null).available).toBe(false);
+  });
+});
+
+describe('isRetryablePangramStatus', () => {
+  it('retries transient rate-limit and server errors', () => {
+    expect(isRetryablePangramStatus(429)).toBe(true);
+    expect(isRetryablePangramStatus(500)).toBe(true);
+    expect(isRetryablePangramStatus(503)).toBe(true);
+    expect(isRetryablePangramStatus(599)).toBe(true);
+  });
+  it('does not retry terminal client errors', () => {
+    for (const status of [400, 401, 402, 403, 404, 413, 422]) {
+      expect(isRetryablePangramStatus(status)).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

[#1205](https://github.com/ai-ecoverse/slicc/issues/1205) was labelled `human-in-the-loop` but is fully AI. Its AI-written body has markdown density `0.0875` (below the `0.12` threshold, diluted by long prose), so it correctly fell to the Pangram tier — then came back `default-human` in ~0.5s with **no `via pangram` line and no warning**. That fingerprint means the `POST /task` submit returned a non-2xx that `if (!created.ok) return null` swallowed silently.

Pangram itself is healthy and has credits (a later run, PR #1318, classified `via pangram` on the same unchanged code), so this was a **transient/silent tier failure**, not a heuristic miss or a bad key. Two defects turned it permanent:
1. The submit discarded the HTTP status (402/429/5xx/422 all looked identical) and never retried.
2. The resulting human verdict applied the **sticky** `human-in-the-loop` label, which can't self-correct.

## Solution

Retry the submit on transient `429`/`5xx` (`isRetryablePangramStatus`, bounded linear backoff) and log every non-2xx submit/poll status, so a `default-human` verdict caused by an outage is distinguishable from a genuine "not AI" verdict in the Actions log. Terminal 4xx (bad key, no credits, invalid input) still fail fast. Heuristic thresholds are untouched.

## Testing

`npx vitest run --project dev-tools packages/dev-tools/ai-comment-detection` — 26 passing (2 new for the retry-policy helper); `biome check` clean.

## Misc

Residual risk / possible follow-up: fail-to-human on a *full* Pangram outage still applies the sticky label — retry only covers transient blips. Catching long AI docs when Pangram is unavailable (a structural-feature heuristic) or a relabel tool for already-stuck threads would need separate approval since they retune classification.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KW203E50DVNX34FS0D4QDXDP&panel=chat)