### PR TITLE
fix(cloud): use hosted origin as leader page URL prefix for resume kick

### DIFF
--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -970,7 +970,7 @@ async function preconnectCdp(
     if (RUNTIME_FLAGS.hosted) {
       registerLeaderRestartEndpoint(app, {
         cdp: createHttpCdp(cdpPort),
-        localUrlPrefix: `http://localhost:${servePort}/`,
+        pageUrlPrefix: resolveThinLeaderOrigin() + '/',
       });
       console.log('[hosted] /api/leader-restart endpoint registered');
     }

--- a/packages/node-server/src/leader-restart.ts
+++ b/packages/node-server/src/leader-restart.ts
@@ -16,9 +16,9 @@ export interface CdpLike {
 
 export function findSliccPageTarget(
   targets: CdpTargetInfo[],
-  localUrlPrefix: string
+  pageUrlPrefix: string
 ): CdpTargetInfo | null {
-  const candidates = targets.filter((t) => t.type === 'page' && t.url.startsWith(localUrlPrefix));
+  const candidates = targets.filter((t) => t.type === 'page' && t.url.startsWith(pageUrlPrefix));
   if (candidates.length === 0) return null;
   return candidates.find((t) => t.attached) ?? candidates[0];
 }
@@ -31,7 +31,7 @@ export type RestartResult =
       message: string;
     };
 
-export async function restartLeader(cdp: CdpLike, localUrlPrefix: string): Promise<RestartResult> {
+export async function restartLeader(cdp: CdpLike, pageUrlPrefix: string): Promise<RestartResult> {
   let targets: CdpTargetInfo[];
   try {
     const result = (await cdp.send('Target.getTargets')) as { targetInfos: CdpTargetInfo[] };
@@ -47,7 +47,7 @@ export async function restartLeader(cdp: CdpLike, localUrlPrefix: string): Promi
       message: msg,
     };
   }
-  const target = findSliccPageTarget(targets, localUrlPrefix);
+  const target = findSliccPageTarget(targets, pageUrlPrefix);
   if (!target) return { ok: false, code: 'NO_LEADER_TAB', message: 'no SLICC page target found' };
 
   const tid = target.targetId ?? target.id;
@@ -170,10 +170,10 @@ export function createHttpCdp(cdpPort: number): CdpLike {
 
 export function registerLeaderRestartEndpoint(
   app: Express,
-  options: { cdp: CdpLike; localUrlPrefix: string }
+  options: { cdp: CdpLike; pageUrlPrefix: string }
 ): void {
   app.post('/api/leader-restart', requireLoopback, async (_req, res) => {
-    const result = await restartLeader(options.cdp, options.localUrlPrefix);
+    const result = await restartLeader(options.cdp, options.pageUrlPrefix);
     if (result.ok) {
       res.json({ ok: true });
       return;

--- a/packages/node-server/tests/leader-restart.test.ts
+++ b/packages/node-server/tests/leader-restart.test.ts
@@ -19,6 +19,20 @@ describe('findSliccPageTarget', () => {
     expect(t?.id).toBe('b');
   });
 
+  it('matches the hosted origin URL used in thin-bridge mode', () => {
+    const targets = [
+      { id: 'a', type: 'page', url: 'chrome://newtab/', attached: true },
+      {
+        id: 'b',
+        type: 'page',
+        url: 'https://www.sliccy.ai/?bridge=ws://localhost:5710/cdp&bridgeToken=abc&runtime=hosted-leader',
+        attached: true,
+      },
+    ];
+    const t = findSliccPageTarget(targets, 'https://www.sliccy.ai/');
+    expect(t?.id).toBe('b');
+  });
+
   it('returns null when no page target matches', () => {
     expect(findSliccPageTarget([], 'http://localhost:5710/')).toBeNull();
     expect(


### PR DESCRIPTION
The thin-bridge refactor moved the leader page from localhost to the hosted origin (sliccy.ai), but /api/leader-restart still matched against http://localhost:<port>/ — so findSliccPageTarget never found the page, returning NO_LEADER_TAB (503) on every resume regardless of timing.

Closes #1269

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
