### PR TITLE
fix(ci): typecheck tests/ for node-server, worker, cherry, extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,8 +391,10 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - name: Typecheck
+      - name: Typecheck (build config)
         run: tsc --noEmit -p tsconfig.cli.json
+      - name: Typecheck (src + tests)
+        run: tsc --noEmit -p packages/node-server/tsconfig.json
       - name: Test (with coverage threshold gate)
         run: npm run test:coverage:node-server
       - name: Upload coverage report
@@ -425,6 +427,8 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - name: Typecheck
+        run: tsc --noEmit -p tsconfig.json
       - name: Test (with coverage threshold gate)
         run: npm run test:coverage:chrome-extension
       - name: Upload coverage report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,14 +148,14 @@ Virtual Filesystem (packages/webapp/src/fs/) → RestrictedFS → Shell (package
 
 ### Build Targets
 
-`npm run typecheck` runs eight `tsc --noEmit` invocations:
+`npm run typecheck` runs nine `tsc --noEmit` invocations:
 
-- **Browser bundle** (`tsconfig.json`): `packages/webapp/`. The Vite-built extension (`packages/chrome-extension/vite.config.ts`) reuses this config; its extra entries are bundle-time only, not a separate typecheck target.
-- **CLI/Electron** (`tsconfig.cli.json`): `packages/node-server/src/`. Compiled by TSC to `dist/node-server/`.
-- **Tray-hub worker** (`tsconfig.worker.json`): `packages/cloudflare-worker/src/`.
-- **Kernel-worker safety guard** (`tsconfig.webapp-worker.json`): typechecks the DedicatedWorker-side webapp code against a no-DOM lib set so accidental `window` references fail at typecheck time.
-- **Cloud-core library** (`packages/cloud-core/tsconfig.json`): `@slicc/cloud-core` is built ahead of `webapp` / `node-server` / `cloudflare-worker` (which all import it) via `postinstall` and the root `build` chain.
-- **Cherry / spoon / webcomponents** (`packages/cherry/tsconfig.json`, `packages/spoon/tsconfig.json`, `packages/webcomponents/tsconfig.json`): the host-embed SDK, injection web component, and UI-shell library.
+- **Browser bundle** (`tsconfig.json`): `packages/webapp/` + extension `tests/`. The Vite-built extension reuses this config; its extra entries are bundle-time only. Webapp `tests/` pending `#1337`.
+- **CLI/Electron** (`tsconfig.cli.json`): `packages/node-server/src/`, compiled to `dist/node-server/`; `packages/node-server/tsconfig.json` adds `tests/`.
+- **Tray-hub worker** (`tsconfig.worker.json`): `packages/cloudflare-worker/` src+tests.
+- **Kernel-worker safety guard** (`tsconfig.webapp-worker.json`): checks DedicatedWorker-side webapp code with a no-DOM lib set so accidental `window` references fail.
+- **Cloud-core library** (`packages/cloud-core/tsconfig.json`): `@slicc/cloud-core` is built ahead of its importers (webapp, node-server, cloudflare-worker) via `postinstall` and the root `build` chain.
+- **Cherry / spoon / webcomponents** (`packages/cherry/tsconfig.json`, `packages/spoon/tsconfig.json`, `packages/webcomponents/tsconfig.json`): the host-embed SDK, injection web component, and UI-shell library; each checks src+tests; cherry emits via `tsconfig.build.json`.
 
 `@slicc/shared-ts` uses the same postinstall pre-build pattern as `@slicc/cloud-core` (it must be built before `node-server` and `webapp` can typecheck), but its own `tsc --noEmit` is invoked by its workspace `npm run typecheck` script rather than the root pipeline.
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "start:electron": "node dist/node-server/index.js --electron",
     "preflight": "node packages/dev-tools/tools/preflight-deps.mjs",
     "pretypecheck": "npm run preflight",
-    "typecheck": "tsc --noEmit -p tsconfig.cli.json && tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.worker.json && tsc --noEmit -p tsconfig.webapp-worker.json && tsc --noEmit -p packages/cloud-core/tsconfig.json && tsc --noEmit -p packages/cherry/tsconfig.json && tsc --noEmit -p packages/spoon/tsconfig.json && tsc --noEmit -p packages/webcomponents/tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.cli.json && tsc --noEmit -p packages/node-server/tsconfig.json && tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.worker.json && tsc --noEmit -p tsconfig.webapp-worker.json && tsc --noEmit -p packages/cloud-core/tsconfig.json && tsc --noEmit -p packages/cherry/tsconfig.json && tsc --noEmit -p packages/spoon/tsconfig.json && tsc --noEmit -p packages/webcomponents/tsconfig.json",
     "pretest": "npm run preflight",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/packages/cherry/CLAUDE.md
+++ b/packages/cherry/CLAUDE.md
@@ -181,7 +181,7 @@ you change one, change the other.
 ## Build and test
 
 ```bash
-npm run build -w @ai-ecoverse/cherry   # tsc -p tsconfig.json → dist/
+npm run build -w @ai-ecoverse/cherry   # tsc -p tsconfig.build.json → dist/ (tsconfig.json is the noEmit typecheck config incl. tests/)
 npm test -w @ai-ecoverse/cherry        # vitest (jsdom)
 ```
 

--- a/packages/cherry/package.json
+++ b/packages/cherry/package.json
@@ -19,8 +19,9 @@
     "html2canvas-pro": "^2.0.4"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && node scripts/build-preview-bootstrap.mjs",
-    "test": "vitest run --root ../.. --config vitest.config.ts --project cherry"
+    "build": "tsc -p tsconfig.build.json && node scripts/build-preview-bootstrap.mjs",
+    "test": "vitest run --root ../.. --config vitest.config.ts --project cherry",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.0",

--- a/packages/cherry/tests/preview-bootstrap.test.ts
+++ b/packages/cherry/tests/preview-bootstrap.test.ts
@@ -210,7 +210,7 @@ describe('preview bootstrap', () => {
       vi.resetModules();
       await import('../src/preview-bootstrap.js');
       expect(instances).toHaveLength(1);
-      expect(instances[0].url).toBe('wss://x.sliccy.now/__slicc/bridge');
+      expect(instances[0]?.url).toBe('wss://x.sliccy.now/__slicc/bridge');
 
       // window.slicc is installed SYNCHRONOUSLY at bootstrap — before the socket
       // opens — so inline page scripts never see it undefined.

--- a/packages/cherry/tsconfig.build.json
+++ b/packages/cherry/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/cherry/tsconfig.json
+++ b/packages/cherry/tsconfig.json
@@ -4,14 +4,13 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "declaration": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
+    "noEmit": true,
+    "types": ["node"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
 }

--- a/packages/cloudflare-worker/tests/cloud-sessions-do.test.ts
+++ b/packages/cloudflare-worker/tests/cloud-sessions-do.test.ts
@@ -331,7 +331,7 @@ describe('CloudSessionsDurableObject — lifecycle endpoints', () => {
     const statuses = [res1.status, res2.status].sort();
     expect(statuses).toEqual([200, 403]);
 
-    const bodies = await Promise.all([res1.json(), res2.json()]);
+    const bodies = (await Promise.all([res1.json(), res2.json()])) as Array<{ error?: string }>;
     const errors = bodies.filter((b) => b.error);
     expect(errors).toHaveLength(1);
     expect(errors[0]?.error).toBe('CAP_EXCEEDED');

--- a/packages/cloudflare-worker/tests/fake-do-state.ts
+++ b/packages/cloudflare-worker/tests/fake-do-state.ts
@@ -33,6 +33,8 @@ export interface FakeWebSocket {
   close(): void;
   serializeAttachment(value: unknown): void;
   deserializeAttachment(): unknown;
+  /** Attached after construction via defineProperty so peers can deliver events. */
+  dispatch?: (type: 'message' | 'close' | 'error', event: { data?: string }) => void;
 }
 
 export class FakeDurableObjectState implements DurableObjectStateLike {
@@ -81,7 +83,7 @@ export class FakeDurableObjectState implements DurableObjectStateLike {
 
       send(data: string) {
         sent.push(data);
-        peer?.['dispatch']?.('message', { data });
+        peer?.dispatch?.('message', { data });
       },
 
       close() {
@@ -90,7 +92,7 @@ export class FakeDurableObjectState implements DurableObjectStateLike {
         dispatch('close', {});
         if (p) {
           p.peer = null;
-          p['dispatch']?.('close', {});
+          p.dispatch?.('close', {});
         }
       },
 

--- a/packages/cloudflare-worker/tests/preview-bridge-harness.ts
+++ b/packages/cloudflare-worker/tests/preview-bridge-harness.ts
@@ -98,11 +98,14 @@ export interface BridgeConnection {
   closed: boolean;
 }
 
+/** Parsed JSON message captured off the leader socket; shape asserted per test. */
+export type LeaderMessage = { type?: string } & Record<string, unknown>;
+
 export interface BridgeHarness {
   do: SessionTrayDurableObject;
   state: FakeDurableObjectState;
   stub: { fetch: (req: Request) => Promise<Response> };
-  leaderSent: unknown[];
+  leaderSent: LeaderMessage[];
   previewToken: string;
   workerBaseUrl: string;
   controllerToken: string;
@@ -293,7 +296,7 @@ async function setupConnectedLeader(
 ): Promise<{
   session: { capabilities: { controller: { url: string } }; trayId: string };
   leader: { leaderKey: string; websocket: { url: string } };
-  leaderSent: unknown[];
+  leaderSent: LeaderMessage[];
   controllerToken: string;
   stub: SessionTrayDurableObject;
   state: FakeDurableObjectState;
@@ -323,9 +326,9 @@ async function setupConnectedLeader(
   );
   const leaderSocket = (socketResponse as unknown as { webSocket: FakeWebSocket }).webSocket;
 
-  const leaderSent: unknown[] = [];
+  const leaderSent: LeaderMessage[] = [];
   leaderSocket.addEventListener('message', (event: { data?: string }) => {
-    if (event.data) leaderSent.push(JSON.parse(event.data));
+    if (event.data) leaderSent.push(JSON.parse(event.data) as LeaderMessage);
   });
 
   const controllerToken =

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -6,7 +6,7 @@
     "build": "node --input-type=module -e \"import { rmSync } from 'node:fs'; rmSync('../../dist/node-server', { recursive: true, force: true });\" && tsc -p ../../tsconfig.cli.json && node scripts/inline-workspaces.mjs",
     "test": "vitest run",
     "test:live:cloud": "vitest run tests/cloud-live.test.ts",
-    "typecheck": "tsc --noEmit -p ../../tsconfig.cli.json"
+    "typecheck": "tsc --noEmit -p ../../tsconfig.cli.json && tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@slicc/cloud-core": "*",

--- a/packages/node-server/src/electron-runtime.ts
+++ b/packages/node-server/src/electron-runtime.ts
@@ -21,6 +21,8 @@ export interface ElectronAppLaunchSpec {
 }
 
 export interface ElectronInspectableTarget {
+  /** CDP target id as reported by the `/json` endpoint. */
+  id?: string;
   type: string;
   title?: string;
   url: string;

--- a/packages/node-server/tests/cloud/fake-substrate.ts
+++ b/packages/node-server/tests/cloud/fake-substrate.ts
@@ -49,6 +49,11 @@ export class FakeSubstrate implements SandboxSubstrate {
     return this.handle(data);
   }
 
+  async extendTimeout(): Promise<void> {
+    // The fake has no TTL concept; the interface documents no-op as the
+    // correct implementation for substrates without timeout support.
+  }
+
   async list(): Promise<SandboxSummary[]> {
     return Array.from(this.sandboxes.values()).map((d) => ({
       sandboxId: d.id,

--- a/packages/node-server/tests/electron-controller.test.ts
+++ b/packages/node-server/tests/electron-controller.test.ts
@@ -771,7 +771,7 @@ describe('buildThinOverlayAppUrl', () => {
     const servePort = 5711;
     const thinBridge = resolveOverlayThinBridge({}, THIN_BRIDGE.bridgeToken, servePort);
     expect(thinBridge).not.toBeNull();
-    for (const role of [BRIDGE_ROLE_LEADER, BRIDGE_ROLE_FOLLOWER]) {
+    for (const role of [BRIDGE_ROLE_LEADER, BRIDGE_ROLE_FOLLOWER] as const) {
       const url = buildThinOverlayAppUrl({ ...thinBridge!, role });
       const parsed = new URL(url);
       expect(parsed.origin).toBe('https://www.sliccy.ai');

--- a/packages/node-server/tests/routes/fetch-proxy.test.ts
+++ b/packages/node-server/tests/routes/fetch-proxy.test.ts
@@ -10,7 +10,7 @@ import { createServer, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import express from 'express';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { registerFetchProxyRoute } from '../../src/routes/fetch-proxy.js';
 import { EnvSecretStore } from '../../src/secrets/env-secret-store.js';
 import { SecretProxyManager } from '../../src/secrets/proxy-manager.js';
@@ -28,11 +28,8 @@ let proxy: Server;
 let upstreamUrl = '';
 let proxyBase = '';
 let masked = '';
-let logger: {
-  log: ReturnType<typeof vi.fn>;
-  warn: ReturnType<typeof vi.fn>;
-  error: ReturnType<typeof vi.fn>;
-};
+type LogMock = Mock<(...args: unknown[]) => void>;
+let logger: { log: LogMock; warn: LogMock; error: LogMock };
 
 function tempSecrets(domains = '127.0.0.1'): string {
   tmpDir = join(tmpdir(), `slicc-fp-${randomUUID()}`);
@@ -68,7 +65,11 @@ async function setup(handler: UpstreamHandler, secretDomains?: string): Promise<
 
   const app = express();
   app.use(express.json({ type: () => false })); // never parse — proxy collects raw body
-  logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  logger = {
+    log: vi.fn<(...args: unknown[]) => void>(),
+    warn: vi.fn<(...args: unknown[]) => void>(),
+    error: vi.fn<(...args: unknown[]) => void>(),
+  };
   registerFetchProxyRoute(app, { secretProxy: proxyManager, logger });
   const proxyPort = await listen(proxy === undefined ? (proxy = createServer(app)) : proxy);
   proxyBase = `http://127.0.0.1:${proxyPort}`;

--- a/packages/node-server/tests/sudo/endpoint.test.ts
+++ b/packages/node-server/tests/sudo/endpoint.test.ts
@@ -49,7 +49,7 @@ describe('POST /api/sudo-approve', () => {
     registerSudoApproveEndpoint(app, { backend: backendReturning({ decision: 'allow' }) });
     const res = await makeRequest(app, { kind: 'nope', detail: 'x' });
     expect(res.status).toBe(400);
-    expect((await res.json()).error).toBe('invalid sudo-approve payload');
+    expect(((await res.json()) as { error?: string }).error).toBe('invalid sudo-approve payload');
   });
 
   it('rejects a missing detail with 400', async () => {

--- a/packages/node-server/tests/sudo/tty-backend.test.ts
+++ b/packages/node-server/tests/sudo/tty-backend.test.ts
@@ -3,6 +3,7 @@
  * interface and a capturing output stream.
  */
 
+import type { Interface as ReadlineInterface } from 'readline';
 import { describe, expect, it, vi } from 'vitest';
 import { createTtyBackend } from '../../src/sudo/tty-backend.js';
 import type { SudoApproveRequest } from '../../src/sudo/types.js';
@@ -14,10 +15,13 @@ const REQ: SudoApproveRequest = {
 };
 
 /** Build a fake readline that answers queued responses in order. */
-function fakeRl(answers: string[]): { question: ReturnType<typeof vi.fn>; close: () => void } {
+function fakeRl(answers: string[]) {
   let i = 0;
+  const question = vi.fn((_q: string, cb: (a: string) => void) => cb(answers[i++] ?? ''));
   return {
-    question: vi.fn((_q: string, cb: (a: string) => void) => cb(answers[i++] ?? '')),
+    // The real `question` has overloads the fake doesn't implement; the cast
+    // keeps the mock compatible with Pick<Interface, 'question' | 'close'>.
+    question: question as unknown as ReadlineInterface['question'],
     close: vi.fn(),
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
   "include": [
     "packages/shared-ts/src/**/*.ts",
     "packages/webapp/src/**/*.ts",
-    "packages/chrome-extension/src/**/*.ts"
+    "packages/chrome-extension/src/**/*.ts",
+    "packages/chrome-extension/tests/**/*.ts"
   ],
   "exclude": ["packages/node-server/src/**/*.ts"]
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -9,5 +9,5 @@
     "noEmit": true,
     "types": ["@cloudflare/workers-types"]
   },
-  "include": ["packages/cloudflare-worker/src/**/*.ts"]
+  "include": ["packages/cloudflare-worker/src/**/*.ts", "packages/cloudflare-worker/tests/**/*.ts"]
 }


### PR DESCRIPTION
Part of #1294, first slice of #1331 (P0-5 in the architecture audit).

## Problem

Protocol test files were never typechecked — no invoked tsconfig included `tests/` for node-server, cloudflare-worker, cherry, or chrome-extension, so "compile-time invariants" placed in tests were decorative. An extension-only PR also merged with zero `tsc` run anywhere (the extension CI job runs vitest + vite builds only; esbuild does not typecheck).

## Changes

- **tsconfig.json** (browser bundle): now includes `packages/chrome-extension/tests/`
- **tsconfig.worker.json**: now includes `packages/cloudflare-worker/tests/`
- **node-server**: the existing (previously editor-only) `packages/node-server/tsconfig.json` — which already covered `src/` + `tests/` — is wired into the root `typecheck` chain, the package `typecheck` script, and the CI job
- **cherry**: emit moved to a new `tsconfig.build.json` (same split shared-ts and webcomponents already use); `tsconfig.json` is now the noEmit typecheck config including `tests/`
- **ci.yml**: the `chrome-extension` job gets a Typecheck step, so an extension-only diff runs `tsc --noEmit -p tsconfig.json`
- Fixes the **46 latent type errors** this surfaces, all mechanical:
  - `FakeSubstrate` was missing `extendTimeout` (22 errors)
  - `ElectronInspectableTarget` lacked the `id` field the CDP `/json` payload (and the test fixtures) carry (11)
  - literal-widening on the bridge-role array, untyped `JSON.parse` results, readline/console mock typings, one `noUncheckedIndexedAccess` hit

## Verification

- `npm run lint` / `npm run typecheck` (now nine invocations) green
- `vitest run` for node-server, cloudflare-worker, cherry, chrome-extension: 1468 passed
- cherry build produces identical `dist/` (no test output leaks)
- Guard verified by mutation: an injected type error in a worker test file fails `tsc --noEmit -p tsconfig.worker.json`

## Out of scope

`packages/webapp/tests/` surfaces 678 latent errors across 132 files — including 13 in `providers/adobe.ts`, which is **not typechecked today** (the `providers/` dir isn't matched by the root include and is only reachable via `import.meta.glob`). Tracked in #1337 with a bucketed fix plan.
