### PR TITLE
fix(chrome-extension): stop shipping ~29 MB of unused logos (68 MB → 39 MB)

### DIFF
--- a/packages/chrome-extension/tests/manifest-sidepanel.test.ts
+++ b/packages/chrome-extension/tests/manifest-sidepanel.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import manifest from '../manifest.json';
@@ -72,6 +72,36 @@ describe('cherry side-panel framing contract (manifest key ↔ worker CSP allowl
     const origin = `chrome-extension://${extId}`;
     for (const list of allowlists) {
       expect(list.split(/\s+/)).toContain(origin);
+    }
+  });
+});
+
+/**
+ * The extension build copies ONLY the manifest-referenced icons out of the
+ * shared `packages/assets/logos` tree (the rest is ~25 MB of macOS/iOS app
+ * icons that don't belong in a Chrome extension). `copyLogoAndFontAssets`
+ * silently skips a missing icon, so a manifest icon that isn't a real asset
+ * would ship a broken toolbar icon with no build error. This guard asserts
+ * every referenced icon resolves to a real file under `packages/assets/logos`.
+ */
+describe('manifest toolbar icons resolve in packages/assets (thin logos-copy contract)', () => {
+  const iconPaths = [
+    ...Object.values((manifest as { icons?: Record<string, string> }).icons ?? {}),
+    ...Object.values(
+      (manifest as { action?: { default_icon?: Record<string, string> } }).action?.default_icon ??
+        {}
+    ),
+  ];
+
+  it('references at least one toolbar icon', () => {
+    expect(iconPaths.length).toBeGreaterThan(0);
+  });
+
+  it('every referenced icon lives under logos/ and exists in packages/assets', () => {
+    for (const rel of iconPaths) {
+      expect(rel.startsWith('logos/'), `${rel} must be under logos/`).toBe(true);
+      const srcPath = fileURLToPath(new URL(`../../assets/${rel}`, import.meta.url));
+      expect(existsSync(srcPath), `${rel} missing from packages/assets`).toBe(true);
     }
   });
 });

--- a/packages/chrome-extension/vite.config.ts
+++ b/packages/chrome-extension/vite.config.ts
@@ -349,9 +349,36 @@ function copyAssetDir(srcDir: string, destDir: string, extensions: string[]): vo
   }
 }
 
-/** Logos (extension icons/header) + fonts (Adobe Clean — local dev only). */
+/**
+ * Copy ONLY the logo files the manifest actually references (the toolbar
+ * icons) + fonts (Adobe Clean — local dev only).
+ *
+ * The previous blanket `copyAssetDir('../assets/logos')` copied the whole
+ * shared logos dir into the extension — ~29 MB, dominated by 1024×1024
+ * macOS/iOS app icons that belong to the swift-launcher / ios-app, not a
+ * Chrome extension. The extension only loads its `manifest.icons`, so derive
+ * the copy set from the manifest (self-correcting if the icons change).
+ */
 function copyLogoAndFontAssets(): void {
-  copyAssetDir(resolve(Dirname, '../assets/logos'), resolve(outDir, 'logos'), ['.png', '.ico']);
+  const manifest = JSON.parse(readFileSync(resolve(Dirname, 'manifest.json'), 'utf-8')) as {
+    icons?: Record<string, string>;
+    action?: { default_icon?: Record<string, string> };
+  };
+  const referenced = new Set<string>([
+    ...Object.values(manifest.icons ?? {}),
+    ...Object.values(manifest.action?.default_icon ?? {}),
+  ]);
+  const logosSrc = resolve(Dirname, '../assets/logos');
+  const logosDest = resolve(outDir, 'logos');
+  mkdirSync(logosDest, { recursive: true });
+  for (const rel of referenced) {
+    const file = rel.replace(/^logos\//, '');
+    try {
+      copyFileSync(resolve(logosSrc, file), resolve(logosDest, file));
+    } catch {
+      /* referenced icon missing from assets/logos — skip (manifest guard test catches it) */
+    }
+  }
   try {
     copyAssetDir(resolve(Dirname, '../assets/fonts'), resolve(outDir, 'fonts'), ['.otf', '.woff2']);
   } catch {
@@ -458,7 +485,11 @@ const devReloadCdpPort = Number(process.env['SLICC_CDP_PORT'] ?? '9333');
 
 export default defineConfig(({ mode }) => ({
   root: repoRoot,
-  publicDir: resolve(repoRoot, 'packages/assets'),
+  // Do NOT use `packages/assets` as publicDir — Vite would blanket-copy the whole
+  // shared assets tree (~25 MB of logos, mostly 1024×1024 macOS/iOS app icons) into
+  // the extension. The extension only needs its manifest toolbar icons + fonts, which
+  // `copyLogoAndFontAssets()` copies explicitly in `copyExtensionAssetsPlugin`.
+  publicDir: false,
   define: {
     __DEV__: JSON.stringify(mode !== 'production'),
     __SLICC_EXT_DEV__: JSON.stringify(isExtDev),


### PR DESCRIPTION
## Problem

The built Chrome extension is **68 MB**. The single biggest chunk (~29 MB) is the `logos/` directory, which is dominated by **1024×1024 macOS/iOS app icons** (`macos-icon-iOS-Default/Dark/Tinted*/Clear*`, `icon_contained`, big neon/favicon PNGs) that belong to the swift-launcher / ios-app — **not** a Chrome extension.

Root cause: the extension build sets `publicDir: resolve(repoRoot, 'packages/assets')`, so Vite blanket-copies the entire shared `packages/assets` tree into `dist/extension`. The extension only ever loads its 4 manifest toolbar icons (`sliccy-color-1scoops-{16,32,48,128}`) plus fonts.

## Fix

- **`publicDir: false`** — stop Vite's blanket copy of `packages/assets`.
- **`copyLogoAndFontAssets()`** now derives the copy set from `manifest.icons` (+ `action.default_icon`) rather than copying the whole logos dir, so it self-corrects if the icons ever change. Fonts are still copied exactly as before.
- **Regression guard** (`manifest-sidepanel.test.ts`): every manifest-referenced icon must live under `logos/` and exist in `packages/assets` — because the slim copy silently skips a missing icon, which would otherwise ship a broken toolbar icon with no build error.

## Result

`dist/extension`: **68 MB → 39 MB** (logos dir 29 MB → 24 KB). The 4 toolbar icons + all fonts are retained; verified the extension still builds, the RHC scan is clean, and all `chrome-extension` tests pass (incl. the new guard).

## Follow-up

The remaining ~37 MB is vestigial fat-extension weight (shell WASM `pyodide`/`magick`/`ffmpeg-core`, the `slicc-editor`/`slicc-diff`/`realm-vendor` bundles, and the unused sandbox pages) — tracked in #1339. This PR is the safe, obviously-correct first cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
