### PR TITLE
Redirect followers away from a superseded tray join link

### DIFF
--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -25,7 +25,12 @@ import {
 } from './oauth-exchange.js';
 import { handlePreviewRequest } from './preview-handler.js';
 import { previewTokenFromHost } from './preview-host.js';
-import { handlePreviewList, handlePreviewMint, handlePreviewStop } from './preview-routes.js';
+import {
+  handlePreviewList,
+  handlePreviewMint,
+  handlePreviewStop,
+  handleTraySupersede,
+} from './preview-routes.js';
 import { buildRelResponse } from './rel-docs.js';
 import { SessionTrayDurableObject } from './session-tray.js';
 import {
@@ -429,6 +434,7 @@ const ROUTES_INDEX_BODY = {
     'POST /api/tray/:trayId/preview',
     'POST /api/tray/:trayId/preview/stop',
     'GET /api/tray/:trayId/previews',
+    'POST /api/tray/:trayId/supersede',
     'GET /auth/callback',
     'POST /oauth/token',
     'POST /oauth/revoke',
@@ -670,6 +676,11 @@ async function tryHandleCapabilityRoutes(
   if (previewListMatch && request.method === 'GET') {
     const stub = env.TRAY_HUB.get(env.TRAY_HUB.idFromName(previewListMatch[1]));
     return handlePreviewList(request, stub);
+  }
+  const supersedeMatch = url.pathname.match(/^\/api\/tray\/([^/]+)\/supersede$/);
+  if (supersedeMatch && request.method === 'POST') {
+    const stub = env.TRAY_HUB.get(env.TRAY_HUB.idFromName(supersedeMatch[1]));
+    return handleTraySupersede(request, stub);
   }
 
   const tokenMatch = url.pathname.match(/^\/(join|controller|webhook)\/([^/]+?)(?:\/([^/]+))?$/);

--- a/packages/cloudflare-worker/src/preview-routes.ts
+++ b/packages/cloudflare-worker/src/preview-routes.ts
@@ -103,3 +103,29 @@ export async function handlePreviewList(request: Request, trayStub: TrayStub): P
     })
   );
 }
+
+/**
+ * `POST /api/tray/:trayId/supersede` — Bearer = the OLD tray's controllerToken.
+ * Called by the leader right before it abandons this tray for a freshly-minted
+ * one (see `shouldRecreateTray` in the webapp's `tray-leader.ts`), so a follower
+ * still holding the old `/join/:token` link gets redirected instead of dead-ending.
+ */
+export async function handleTraySupersede(request: Request, trayStub: TrayStub): Promise<Response> {
+  const controllerToken = extractBearer(request);
+  if (!controllerToken) {
+    return jsonResponse({ error: 'unauthorized' }, 401);
+  }
+  let body: { joinUrl?: string };
+  try {
+    body = (await request.json()) as { joinUrl?: string };
+  } catch {
+    return jsonResponse({ error: 'invalid body' }, 400);
+  }
+  return trayStub.fetch(
+    new Request('https://internal/internal/supersede', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ controllerToken, joinUrl: body.joinUrl }),
+    })
+  );
+}

--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -175,6 +175,10 @@ export class SessionTrayDurableObject {
       return jsonResponse({ error: 'Tray not initialized', code: 'TRAY_NOT_INITIALIZED' }, 500);
     }
 
+    if (url.pathname === '/internal/supersede' && request.method === 'POST') {
+      return this.handleSupersede(request);
+    }
+
     const joinMatch = url.pathname.match(/^\/join\/([^/]+)$/);
     if (joinMatch) {
       if (request.method === 'OPTIONS') {
@@ -457,6 +461,45 @@ export class SessionTrayDurableObject {
     return jsonResponse(this.tray, 201);
   }
 
+  /**
+   * Mark this tray as superseded by a freshly-minted tray's join URL. Called
+   * by the leader (via the worker's `POST /api/tray/:trayId/supersede`,
+   * Bearer = this tray's controllerToken) right before it abandons this tray
+   * for a new one — see `shouldRecreateTray` in the webapp's
+   * `tray-leader.ts`. Best-effort: if the leader crashes before this call
+   * lands, followers still fall back to the existing TRAY_EXPIRED path once
+   * the reclaim TTL elapses.
+   */
+  private async handleSupersede(request: Request): Promise<Response> {
+    const tray = this.requireTray();
+    let body: { controllerToken?: string; joinUrl?: string };
+    try {
+      body = (await request.json()) as { controllerToken?: string; joinUrl?: string };
+    } catch {
+      return jsonResponse({ error: 'Invalid body', code: 'INVALID_BODY' }, 400);
+    }
+    if (!this.matchesToken(body.controllerToken ?? '', tray.controllerToken)) {
+      return jsonResponse(
+        { error: 'Invalid controller capability', code: 'INVALID_CONTROLLER_CAPABILITY' },
+        403
+      );
+    }
+    if (typeof body.joinUrl !== 'string' || !body.joinUrl) {
+      return jsonResponse({ error: 'joinUrl is required', code: 'INVALID_BODY' }, 400);
+    }
+    try {
+      new URL(body.joinUrl);
+    } catch {
+      return jsonResponse({ error: 'joinUrl must be an absolute URL', code: 'INVALID_BODY' }, 400);
+    }
+    tray.supersededByJoinUrl = body.joinUrl;
+    await this.persistTray();
+    return jsonResponse(
+      { trayId: tray.trayId, supersededByJoinUrl: tray.supersededByJoinUrl },
+      200
+    );
+  }
+
   private async handleJoin(request: Request, token: string, url: URL): Promise<Response> {
     const tray = this.requireTray();
     const joinRequest = request.method === 'POST' ? await this.readJoinRequest(request, url) : null;
@@ -475,6 +518,34 @@ export class SessionTrayDurableObject {
       return jsonResponse(
         { error: 'Invalid join capability', code: 'INVALID_JOIN_CAPABILITY' },
         403
+      );
+    }
+
+    // The leader abandoned this tray in favor of a fresh one (see
+    // `/internal/supersede` below) — this tray's leader socket will never
+    // reconnect, so point the follower at the replacement instead of leaving
+    // it to retry FOLLOWER_JOIN_NOT_READY / TRAY_EXPIRED forever. Checked
+    // before the expiry gate: a superseded tray is a more actionable signal
+    // than a generic expiry, and supersession can be set before expiry hits.
+    if (tray.supersededByJoinUrl) {
+      const joinUrl = tray.supersededByJoinUrl;
+      const error = 'This session moved to a new tray after the leader reconnected';
+      if (joinRequest) {
+        return this.buildFollowerAttachResponse(
+          this.getJoinRequestControllerId(joinRequest),
+          { action: 'fail', code: 'TRAY_SUPERSEDED', error, joinUrl },
+          409
+        );
+      }
+      return jsonResponse(
+        {
+          trayId: tray.trayId,
+          capability: 'join',
+          error,
+          code: 'TRAY_SUPERSEDED',
+          joinUrl,
+        },
+        409
       );
     }
 

--- a/packages/cloudflare-worker/src/shared.ts
+++ b/packages/cloudflare-worker/src/shared.ts
@@ -114,6 +114,15 @@ export interface TrayRecord {
   expiredAt?: string;
   kind?: TrayKind;
   previews?: Record<string, PreviewRecord>;
+  /**
+   * Set by the leader (via `POST /api/tray/:trayId/supersede`, Bearer =
+   * controllerToken) when it abandons this tray and mints a fresh one on
+   * resume/reconnect (see `shouldRecreateTray` in the webapp's
+   * `tray-leader.ts`). A follower hitting this tray's `/join/:token` gets
+   * redirected here instead of dead-ending on `FOLLOWER_JOIN_NOT_READY` or
+   * `TRAY_EXPIRED` forever — the old tray's leader socket will never come back.
+   */
+  supersededByJoinUrl?: string;
 }
 
 export interface CreateTrayRequest {

--- a/packages/cloudflare-worker/tests/deployed.test.ts
+++ b/packages/cloudflare-worker/tests/deployed.test.ts
@@ -40,6 +40,7 @@ describeIfConfigured('deployed tray worker', () => {
         'POST /api/tray/:trayId/preview',
         'POST /api/tray/:trayId/preview/stop',
         'GET /api/tray/:trayId/previews',
+        'POST /api/tray/:trayId/supersede',
         'GET /auth/callback',
         'POST /oauth/token',
         'POST /oauth/revoke',

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1169,6 +1169,7 @@ describe('tray worker skeleton', () => {
         'POST /api/tray/:trayId/preview',
         'POST /api/tray/:trayId/preview/stop',
         'GET /api/tray/:trayId/previews',
+        'POST /api/tray/:trayId/supersede',
         'GET /auth/callback',
         'POST /oauth/token',
         'POST /oauth/revoke',

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1669,6 +1669,216 @@ describe('preview mint API', () => {
   });
 });
 
+describe('POST /api/tray/:trayId/supersede', () => {
+  async function setupTrayWithLeader(env: ReturnType<typeof createTestHarness>['env']): Promise<{
+    trayId: string;
+    controllerToken: string;
+    joinUrl: string;
+  }> {
+    const created = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/tray', { method: 'POST' }),
+      env
+    );
+    const session = (await created.json()) as {
+      trayId: string;
+      capabilities: { controller: { url: string }; join: { url: string } };
+    };
+    const controllerToken = new URL(session.capabilities.controller.url).pathname.split('/').pop()!;
+
+    const leaderAttach = await handleWorkerRequest(
+      new Request(session.capabilities.controller.url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ controllerId: 'cone-1', runtime: 'cli' }),
+      }),
+      env
+    );
+    expect(leaderAttach.status).toBe(200);
+
+    return { trayId: session.trayId, controllerToken, joinUrl: session.capabilities.join.url };
+  }
+
+  it('marks the tray superseded when authorized with the controllerToken', async () => {
+    const { env, readTray } = createTestHarness();
+    const { trayId, controllerToken } = await setupTrayWithLeader(env);
+
+    const response = await handleWorkerRequest(
+      new Request(`https://www.sliccy.ai/api/tray/${trayId}/supersede`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${controllerToken}`,
+        },
+        body: JSON.stringify({ joinUrl: 'https://www.sliccy.ai/join/fresh-tray.deadbeef' }),
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      trayId,
+      supersededByJoinUrl: 'https://www.sliccy.ai/join/fresh-tray.deadbeef',
+    });
+    const tray = await readTray(trayId);
+    expect(tray?.supersededByJoinUrl).toBe('https://www.sliccy.ai/join/fresh-tray.deadbeef');
+  });
+
+  it('rejects with 401 when bearer is missing', async () => {
+    const { env } = createTestHarness();
+    const { trayId } = await setupTrayWithLeader(env);
+
+    const response = await handleWorkerRequest(
+      new Request(`https://www.sliccy.ai/api/tray/${trayId}/supersede`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ joinUrl: 'https://www.sliccy.ai/join/fresh-tray.deadbeef' }),
+      }),
+      env
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects with 403 on a wrong bearer', async () => {
+    const { env } = createTestHarness();
+    const { trayId } = await setupTrayWithLeader(env);
+
+    const response = await handleWorkerRequest(
+      new Request(`https://www.sliccy.ai/api/tray/${trayId}/supersede`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer wrong.token',
+        },
+        body: JSON.stringify({ joinUrl: 'https://www.sliccy.ai/join/fresh-tray.deadbeef' }),
+      }),
+      env
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it('rejects with 400 when joinUrl is missing or malformed', async () => {
+    const { env } = createTestHarness();
+    const { trayId, controllerToken } = await setupTrayWithLeader(env);
+
+    const missing = await handleWorkerRequest(
+      new Request(`https://www.sliccy.ai/api/tray/${trayId}/supersede`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${controllerToken}`,
+        },
+        body: JSON.stringify({}),
+      }),
+      env
+    );
+    expect(missing.status).toBe(400);
+
+    const malformed = await handleWorkerRequest(
+      new Request(`https://www.sliccy.ai/api/tray/${trayId}/supersede`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${controllerToken}`,
+        },
+        body: JSON.stringify({ joinUrl: 'not-a-url' }),
+      }),
+      env
+    );
+    expect(malformed.status).toBe(400);
+  });
+
+  it('rejects with 400 on an invalid JSON body', async () => {
+    const { env } = createTestHarness();
+    const { trayId, controllerToken } = await setupTrayWithLeader(env);
+
+    const response = await handleWorkerRequest(
+      new Request(`https://www.sliccy.ai/api/tray/${trayId}/supersede`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${controllerToken}`,
+        },
+        body: '{not json',
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('redirects a follower join with TRAY_SUPERSEDED once the tray is marked superseded', async () => {
+    const { env } = createTestHarness();
+    const { trayId, controllerToken, joinUrl } = await setupTrayWithLeader(env);
+    const freshJoinUrl = 'https://www.sliccy.ai/join/fresh-tray.deadbeef';
+
+    const supersede = await handleWorkerRequest(
+      new Request(`https://www.sliccy.ai/api/tray/${trayId}/supersede`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${controllerToken}`,
+        },
+        body: JSON.stringify({ joinUrl: freshJoinUrl }),
+      }),
+      env
+    );
+    expect(supersede.status).toBe(200);
+
+    const followerAttach = await handleWorkerRequest(
+      new Request(joinUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ controllerId: 'follow-1', runtime: 'electron' }),
+      }),
+      env
+    );
+
+    expect(followerAttach.status).toBe(409);
+    await expect(followerAttach.json()).resolves.toMatchObject({
+      trayId,
+      controllerId: 'follow-1',
+      role: 'follower',
+      result: {
+        action: 'fail',
+        code: 'TRAY_SUPERSEDED',
+        joinUrl: freshJoinUrl,
+      },
+    });
+  });
+
+  it('returns TRAY_SUPERSEDED on a plain GET status probe once marked superseded', async () => {
+    const { env } = createTestHarness();
+    const { trayId, controllerToken, joinUrl } = await setupTrayWithLeader(env);
+    const freshJoinUrl = 'https://www.sliccy.ai/join/fresh-tray.deadbeef';
+
+    await handleWorkerRequest(
+      new Request(`https://www.sliccy.ai/api/tray/${trayId}/supersede`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${controllerToken}`,
+        },
+        body: JSON.stringify({ joinUrl: freshJoinUrl }),
+      }),
+      env
+    );
+
+    const probeUrl = new URL(joinUrl);
+    probeUrl.searchParams.set('json', 'true');
+    const probe = await handleWorkerRequest(new Request(probeUrl), env);
+
+    expect(probe.status).toBe(409);
+    await expect(probe.json()).resolves.toMatchObject({
+      trayId,
+      capability: 'join',
+      code: 'TRAY_SUPERSEDED',
+      joinUrl: freshJoinUrl,
+    });
+  });
+});
+
 describe('standard Link header set', () => {
   // The outer fetch handler wraps every response with applySliccLinks. The
   // unit tests above call handleWorkerRequest directly, which intentionally

--- a/packages/shared-ts/src/tray-signaling.ts
+++ b/packages/shared-ts/src/tray-signaling.ts
@@ -326,6 +326,12 @@ export type FollowerAttachResult =
       action: 'fail';
       code: 'INVALID_JOIN_CAPABILITY' | 'TRAY_EXPIRED';
       error: string;
+    }
+  | {
+      action: 'fail';
+      code: 'TRAY_SUPERSEDED';
+      error: string;
+      joinUrl: string;
     };
 
 export interface FollowerAttachResponse {

--- a/packages/webapp/src/scoops/tray-follower.ts
+++ b/packages/webapp/src/scoops/tray-follower.ts
@@ -35,6 +35,8 @@ export interface FollowerAttachPlan {
   error?: string;
   bootstrap?: TrayBootstrapStatus;
   iceServers?: TurnIceServer[];
+  /** Set when `code === 'TRAY_SUPERSEDED'` — the join URL to follow instead. */
+  supersededByJoinUrl?: string;
 }
 
 export interface FollowerBootstrapOptions {
@@ -98,7 +100,13 @@ export function normalizeFollowerAttachResponse(
     return { ...base, bootstrap: response.result.bootstrap };
   }
   if (response.result.action === 'fail') {
-    return { ...base, error: response.result.error };
+    return {
+      ...base,
+      error: response.result.error,
+      ...(response.result.code === 'TRAY_SUPERSEDED'
+        ? { supersededByJoinUrl: response.result.joinUrl }
+        : {}),
+    };
   }
   return base;
 }
@@ -243,6 +251,11 @@ function isFollowerAttachResponse(value: unknown): value is FollowerAttachRespon
     );
   }
   if (attachResult['action'] === 'fail') {
+    if (attachResult['code'] === 'TRAY_SUPERSEDED') {
+      return (
+        typeof attachResult['error'] === 'string' && typeof attachResult['joinUrl'] === 'string'
+      );
+    }
     return (
       (attachResult['code'] === 'INVALID_JOIN_CAPABILITY' ||
         attachResult['code'] === 'TRAY_EXPIRED') &&

--- a/packages/webapp/src/scoops/tray-leader.ts
+++ b/packages/webapp/src/scoops/tray-leader.ts
@@ -19,6 +19,7 @@ const LEADER_TRAY_RECONNECT_BASE_DELAY_MS = 1_000;
 const LEADER_TRAY_RECONNECT_MAX_DELAY_MS = 30_000;
 const LEADER_TRAY_RECONNECT_BACKOFF_MULTIPLIER = 2;
 const LEADER_TRAY_RECONNECT_MAX_ATTEMPTS = 20;
+const NOTIFY_SUPERSEDED_TIMEOUT_MS = 10_000;
 
 interface CreateTrayResponse {
   trayId: string;
@@ -495,11 +496,13 @@ export class LeaderTrayManager {
       });
       await this.store.clear();
       const fresh = await this.claimLeaderSession(null);
-      // Best-effort: point any follower still holding the old join link at the
-      // new tray. Failure here never fails the reconnect — a crashed leader
-      // (no chance to run this) just falls back to the existing TRAY_EXPIRED
-      // path once the old tray's reclaim TTL elapses.
-      await this.notifyTraySuperseded(session, fresh.joinUrl);
+      // Best-effort, fire-and-forget: point any follower still holding the old
+      // join link at the new tray. Never awaited — notifyTraySuperseded already
+      // catches every error internally and bounds the request with its own
+      // timeout, so a hung/unreachable old tray can never stall the leader's
+      // reconnect. A crashed leader (no chance to run this at all) falls back
+      // to the existing TRAY_EXPIRED path once the old tray's reclaim TTL elapses.
+      void this.notifyTraySuperseded(session, fresh.joinUrl);
       return fresh;
     }
   }
@@ -509,13 +512,15 @@ export class LeaderTrayManager {
    * so a follower still holding the old `/join/:token` link gets redirected
    * instead of dead-ending on FOLLOWER_JOIN_NOT_READY / TRAY_EXPIRED forever.
    * Bearer = the old session's controllerToken (extracted from `controllerUrl`).
+   * Best-effort: fire-and-forget from the caller, and every failure (including
+   * a request that never settles) is caught here so it can never surface.
    */
   private async notifyTraySuperseded(
     oldSession: LeaderTraySession,
     newJoinUrl: string
   ): Promise<void> {
     try {
-      const controllerToken = oldSession.controllerUrl.split('/').pop();
+      const controllerToken = new URL(oldSession.controllerUrl).pathname.split('/').pop();
       if (!controllerToken) return;
       const supersedeUrl = buildTrayWorkerUrl(
         oldSession.workerBaseUrl,
@@ -528,6 +533,7 @@ export class LeaderTrayManager {
           authorization: `Bearer ${controllerToken}`,
         },
         body: JSON.stringify({ joinUrl: newJoinUrl }),
+        signal: AbortSignal.timeout(NOTIFY_SUPERSEDED_TIMEOUT_MS),
       });
     } catch (error) {
       log.warn('Failed to notify old tray of supersession (best-effort)', {

--- a/packages/webapp/src/scoops/tray-leader.ts
+++ b/packages/webapp/src/scoops/tray-leader.ts
@@ -494,7 +494,46 @@ export class LeaderTrayManager {
         error: error instanceof Error ? error.message : String(error),
       });
       await this.store.clear();
-      return this.claimLeaderSession(null);
+      const fresh = await this.claimLeaderSession(null);
+      // Best-effort: point any follower still holding the old join link at the
+      // new tray. Failure here never fails the reconnect — a crashed leader
+      // (no chance to run this) just falls back to the existing TRAY_EXPIRED
+      // path once the old tray's reclaim TTL elapses.
+      await this.notifyTraySuperseded(session, fresh.joinUrl);
+      return fresh;
+    }
+  }
+
+  /**
+   * Tell the OLD tray's Durable Object that it has been superseded by `newJoinUrl`,
+   * so a follower still holding the old `/join/:token` link gets redirected
+   * instead of dead-ending on FOLLOWER_JOIN_NOT_READY / TRAY_EXPIRED forever.
+   * Bearer = the old session's controllerToken (extracted from `controllerUrl`).
+   */
+  private async notifyTraySuperseded(
+    oldSession: LeaderTraySession,
+    newJoinUrl: string
+  ): Promise<void> {
+    try {
+      const controllerToken = oldSession.controllerUrl.split('/').pop();
+      if (!controllerToken) return;
+      const supersedeUrl = buildTrayWorkerUrl(
+        oldSession.workerBaseUrl,
+        `api/tray/${oldSession.trayId}/supersede`
+      );
+      await this.fetchImpl(supersedeUrl, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${controllerToken}`,
+        },
+        body: JSON.stringify({ joinUrl: newJoinUrl }),
+      });
+    } catch (error) {
+      log.warn('Failed to notify old tray of supersession (best-effort)', {
+        oldTrayId: oldSession.trayId,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/packages/webapp/src/scoops/tray-webrtc.ts
+++ b/packages/webapp/src/scoops/tray-webrtc.ts
@@ -10,6 +10,7 @@ import type {
 import { createLogger } from '../core/logger.js';
 import {
   attachTrayFollower,
+  type FollowerAttachPlan,
   pollTrayFollowerBootstrap,
   retryTrayFollowerBootstrap,
   sendTrayFollowerAnswer,
@@ -95,6 +96,15 @@ export interface FollowerTrayManagerOptions {
   iceServers?: TrayIceServerConfig[];
   /** Called when an established peer connection transitions to 'disconnected' or 'failed'. */
   onDisconnected?: (reason: string) => void;
+  /**
+   * Called when the tray hub reports this join URL has been superseded by a
+   * fresh one (the leader abandoned this tray and minted a new one — see
+   * `TRAY_SUPERSEDED` in `tray-follower.ts`). The manager transparently
+   * retries against the new URL; this callback exists so the caller can
+   * persist the replacement (e.g. localStorage) before a future reload would
+   * otherwise resurrect the dead URL.
+   */
+  onJoinUrlChanged?: (newJoinUrl: string) => void;
 }
 
 interface ActiveLeaderPeer {
@@ -361,6 +371,9 @@ export class FollowerTrayManager {
         await this.sleep(retryMs);
         continue;
       }
+      if (this.followSupersededJoinUrl(attach)) {
+        continue;
+      }
       if (attach.action === 'fail' || !attach.bootstrap) {
         const errorMsg = attach.error ?? `Tray follower attach failed (${attach.code})`;
         setFollowerTrayRuntimeStatus({
@@ -419,6 +432,29 @@ export class FollowerTrayManager {
         throw error;
       }
     }
+  }
+
+  /**
+   * If `attach` reports the join URL was superseded by a fresh one (the
+   * leader abandoned this tray and minted a new one on resume/reconnect),
+   * swap `this.options.joinUrl` and notify the caller so it can persist the
+   * replacement. Returns true when the caller should retry the attach loop.
+   */
+  private followSupersededJoinUrl(attach: FollowerAttachPlan): boolean {
+    if (
+      attach.action !== 'fail' ||
+      attach.code !== 'TRAY_SUPERSEDED' ||
+      !attach.supersededByJoinUrl
+    ) {
+      return false;
+    }
+    log.info('Follower tray superseded, following redirect', {
+      oldJoinUrl: this.options.joinUrl,
+      newJoinUrl: attach.supersededByJoinUrl,
+    });
+    this.options.joinUrl = attach.supersededByJoinUrl;
+    this.options.onJoinUrlChanged?.(attach.supersededByJoinUrl);
+    return true;
   }
 
   stop(): void {
@@ -673,6 +709,12 @@ export function startFollowerWithAutoReconnect(
         if (cancelled) return;
         log.warn('Follower disconnected, starting reconnect loop', { reason });
         void reconnectLoop(reason);
+      },
+      onJoinUrlChanged: (newJoinUrl: string) => {
+        // Persist onto managerOptions so a later reconnect's `connectOnce()`
+        // spreads the fresh URL instead of resurrecting the superseded one.
+        managerOptions.joinUrl = newJoinUrl;
+        managerOptions.onJoinUrlChanged?.(newJoinUrl);
       },
     });
     activeManager = manager;

--- a/packages/webapp/src/scoops/tray-webrtc.ts
+++ b/packages/webapp/src/scoops/tray-webrtc.ts
@@ -24,6 +24,8 @@ import {
 const log = createLogger('tray-webrtc');
 const DEFAULT_DATA_CHANNEL_LABEL = 'tray-control';
 const DEFAULT_POLL_INTERVAL_MS = 250;
+const MAX_SUPERSEDE_REDIRECTS = 5;
+const SUPERSEDE_REDIRECT_DELAY_MS = 1000;
 
 export interface TrayDataChannelLike {
   readyState?: string;
@@ -326,6 +328,7 @@ export class FollowerTrayManager {
     log.info('Follower tray join starting', { joinUrl: this.options.joinUrl });
 
     let attachAttempt = 0;
+    let supersedeRedirects = 0;
     for (;;) {
       ensureNotStopped(this.stopped);
       attachAttempt++;
@@ -354,6 +357,11 @@ export class FollowerTrayManager {
         lastAttachCode: attach.code,
       });
 
+      if (this.followSupersededJoinUrl(attach, supersedeRedirects)) {
+        supersedeRedirects++;
+        await this.sleep(SUPERSEDE_REDIRECT_DELAY_MS);
+        continue;
+      }
       if (attach.action === 'wait') {
         const retryMs = attach.retryAfterMs ?? 1000;
         log.info('Follower tray attach waiting', {
@@ -369,9 +377,6 @@ export class FollowerTrayManager {
           });
         }
         await this.sleep(retryMs);
-        continue;
-      }
-      if (this.followSupersededJoinUrl(attach)) {
         continue;
       }
       if (attach.action === 'fail' || !attach.bootstrap) {
@@ -439,8 +444,12 @@ export class FollowerTrayManager {
    * leader abandoned this tray and minted a new one on resume/reconnect),
    * swap `this.options.joinUrl` and notify the caller so it can persist the
    * replacement. Returns true when the caller should retry the attach loop.
+   * Throws once `redirectCount` reaches `MAX_SUPERSEDE_REDIRECTS`, so a
+   * misbehaving hub (a redirect cycle, or a chain that never resolves) can't
+   * spin the follower forever — the caller's own attach-loop sleep still
+   * applies on top of this for backoff between redirects.
    */
-  private followSupersededJoinUrl(attach: FollowerAttachPlan): boolean {
+  private followSupersededJoinUrl(attach: FollowerAttachPlan, redirectCount: number): boolean {
     if (
       attach.action !== 'fail' ||
       attach.code !== 'TRAY_SUPERSEDED' ||
@@ -448,12 +457,25 @@ export class FollowerTrayManager {
     ) {
       return false;
     }
+    if (redirectCount >= MAX_SUPERSEDE_REDIRECTS) {
+      throw new Error(
+        `Follower tray attach gave up after ${redirectCount} supersede redirects (possible redirect cycle)`
+      );
+    }
+    let newJoinUrl: URL;
+    try {
+      newJoinUrl = new URL(attach.supersededByJoinUrl);
+    } catch {
+      throw new Error(
+        `Follower tray superseded with an invalid joinUrl: ${attach.supersededByJoinUrl}`
+      );
+    }
     log.info('Follower tray superseded, following redirect', {
       oldJoinUrl: this.options.joinUrl,
-      newJoinUrl: attach.supersededByJoinUrl,
+      newJoinUrl: newJoinUrl.toString(),
     });
-    this.options.joinUrl = attach.supersededByJoinUrl;
-    this.options.onJoinUrlChanged?.(attach.supersededByJoinUrl);
+    this.options.joinUrl = newJoinUrl.toString();
+    this.options.onJoinUrlChanged?.(newJoinUrl.toString());
     return true;
   }
 

--- a/packages/webapp/src/ui/page-follower-tray.ts
+++ b/packages/webapp/src/ui/page-follower-tray.ts
@@ -155,6 +155,14 @@ export interface StartPageFollowerTrayOptions {
    * a "couldn't reach the leader" state. `lastError` is the final failure.
    */
   onGaveUp?: (lastError: unknown) => void;
+  /**
+   * Called when the tray hub reports this join URL was superseded by a fresh
+   * one (the leader abandoned this tray and minted a new one on resume). The
+   * connection recovers transparently — this callback exists so the caller
+   * can persist the replacement (e.g. `TRAY_JOIN_STORAGE_KEY`) before a
+   * future reload would otherwise resurrect the dead URL.
+   */
+  onJoinUrlChanged?: (newJoinUrl: string) => void;
 
   // --- Sprinkle sync wiring (optional) ---
   /**
@@ -349,6 +357,7 @@ export function startPageFollowerTray(
       fetchImpl: options._fetchImpl,
       peerConnectionFactory: options._peerConnectionFactory,
       sleep: options._sleep,
+      onJoinUrlChanged: options.onJoinUrlChanged,
     },
     {
       onConnected: wireFollowerSync,

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../../core/logger.js';
-import { resolveFollowerJoinUrl } from '../../scoops/tray-runtime-config.js';
+import { resolveFollowerJoinUrl, storeTrayJoinUrl } from '../../scoops/tray-runtime-config.js';
 import { setupStandalonePrelude } from '../boot/setup-standalone-prelude.js';
 import type { BootStageLogger } from '../boot/types.js';
 import { type DipInstance, disposeDips, hydrateDips } from '../dip.js';
@@ -467,6 +467,17 @@ export async function mountWcUiFollower(
       // detachSync suppresses onConnectionChange(false) here - emit terminal.
       if (isCherry) prelude.cherryTransport?.emitSliccEventToHost('slicc.follower.disconnected');
     },
+    // Cherry's join token comes from the host page out-of-band (no localStorage
+    // entry to update); only persist for the plain standalone follower, whose
+    // joinUrl is what `resolveFollowerJoinUrl` re-reads from storage on reload.
+    ...(isCherry
+      ? {}
+      : {
+          onJoinUrlChanged: (newJoinUrl: string) => {
+            log.info('follower joinUrl superseded, persisting replacement', { newJoinUrl });
+            storeTrayJoinUrl(window.localStorage, newJoinUrl);
+          },
+        }),
     addSprinkle: sprinkleCallbacks.addSprinkle,
     removeSprinkle: sprinkleCallbacks.removeSprinkle,
     onOpen: (path) => {

--- a/packages/webapp/tests/scoops/tray-follower.test.ts
+++ b/packages/webapp/tests/scoops/tray-follower.test.ts
@@ -128,6 +128,58 @@ describe('tray-follower', () => {
     });
   });
 
+  it('carries the replacement joinUrl through for TRAY_SUPERSEDED fail outcomes', () => {
+    expect(
+      normalizeFollowerAttachResponse({
+        trayId: 'stale-tray',
+        controllerId: 'follower-2',
+        role: 'follower',
+        leader: null,
+        participantCount: 1,
+        result: {
+          action: 'fail',
+          code: 'TRAY_SUPERSEDED',
+          error: 'This session moved to a new tray after the leader reconnected',
+          joinUrl: 'https://tray.example.com/join/fresh-tray.deadbeef',
+        },
+      })
+    ).toEqual({
+      trayId: 'stale-tray',
+      controllerId: 'follower-2',
+      participantCount: 1,
+      leader: null,
+      action: 'fail',
+      code: 'TRAY_SUPERSEDED',
+      error: 'This session moved to a new tray after the leader reconnected',
+      supersededByJoinUrl: 'https://tray.example.com/join/fresh-tray.deadbeef',
+    });
+  });
+
+  it('rejects a TRAY_SUPERSEDED response missing joinUrl', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          trayId: 'stale-tray',
+          controllerId: 'follower-1',
+          role: 'follower',
+          leader: null,
+          participantCount: 1,
+          result: { action: 'fail', code: 'TRAY_SUPERSEDED', error: 'moved' },
+        }),
+        { status: 409, headers: { 'content-type': 'application/json' } }
+      )
+    );
+
+    await expect(
+      attachTrayFollower({
+        joinUrl: 'https://tray.example.com/join/token',
+        controllerId: 'follower-1',
+        runtime: 'electron',
+        fetchImpl,
+      })
+    ).rejects.toThrow(/invalid response/);
+  });
+
   it('rejects malformed worker responses', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), {

--- a/packages/webapp/tests/scoops/tray-leader.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader.test.ts
@@ -302,7 +302,8 @@ describe('tray-leader', () => {
           }),
           { status: 200, headers: { 'content-type': 'application/json' } }
         )
-      );
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
 
     const manager = new LeaderTrayManager({
       workerBaseUrl: 'https://tray.example.com',
@@ -324,7 +325,11 @@ describe('tray-leader', () => {
     const session = await startPromise;
 
     expect(session.trayId).toBe('fresh-tray');
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    // 4th call is the best-effort POST notifying the old tray it was superseded.
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl.mock.calls[3]?.[0]).toBe(
+      'https://tray.example.com/api/tray/stale-tray/supersede'
+    );
     expect(store.value?.controllerUrl).toBe('https://tray.example.com/controller/fresh-token');
 
     manager.stop();
@@ -407,7 +412,8 @@ describe('tray-leader', () => {
     });
     const session = await startPromise;
     expect(session.trayId).toBe('fresh-tray');
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    // 4th call is the best-effort POST notifying the old tray it was superseded.
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
     expect(store.value?.controllerUrl).toBe('https://tray.example.com/controller/fresh-token');
     manager.stop();
   }
@@ -421,7 +427,8 @@ describe('tray-leader', () => {
       .fn<typeof fetch>()
       .mockRejectedValueOnce(new TrayProxyFetchError('Proxy fetch failed: fetch failed'))
       .mockResolvedValueOnce(freshTrayResponse())
-      .mockResolvedValueOnce(freshLeaderAttachResponse());
+      .mockResolvedValueOnce(freshLeaderAttachResponse())
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
     await expectRecoveryToFreshTray(fetchImpl);
   });
 
@@ -435,7 +442,8 @@ describe('tray-leader', () => {
         })
       )
       .mockResolvedValueOnce(freshTrayResponse())
-      .mockResolvedValueOnce(freshLeaderAttachResponse());
+      .mockResolvedValueOnce(freshLeaderAttachResponse())
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
     await expectRecoveryToFreshTray(fetchImpl);
   });
 

--- a/packages/webapp/tests/scoops/tray-webrtc.test.ts
+++ b/packages/webapp/tests/scoops/tray-webrtc.test.ts
@@ -687,6 +687,112 @@ describe('tray-webrtc', () => {
   });
 });
 
+describe('FollowerTrayManager — TRAY_SUPERSEDED redirect', () => {
+  // Response bodies can only be consumed once, so every mock call must build
+  // a fresh Response — reusing one instance across calls silently yields an
+  // already-drained (empty) body on the second read.
+  function supersededResponse(joinUrl: string): Response {
+    return new Response(
+      JSON.stringify({
+        trayId: 'stale-tray',
+        controllerId: 'follower-1',
+        role: 'follower',
+        leader: null,
+        participantCount: 1,
+        result: {
+          action: 'fail',
+          code: 'TRAY_SUPERSEDED',
+          error: 'This session moved to a new tray after the leader reconnected',
+          joinUrl,
+        },
+      }),
+      { status: 409, headers: { 'content-type': 'application/json' } }
+    );
+  }
+
+  function terminalFailResponse(trayId: string): Response {
+    return new Response(
+      JSON.stringify({
+        trayId,
+        controllerId: 'follower-1',
+        role: 'follower',
+        leader: null,
+        participantCount: 1,
+        result: { action: 'fail', code: 'TRAY_EXPIRED', error: 'Tray expired' },
+      }),
+      { status: 410, headers: { 'content-type': 'application/json' } }
+    );
+  }
+
+  it('follows a single redirect, retrying the attach loop against the new joinUrl', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(async () =>
+        supersededResponse('https://tray.example.com/join/fresh-tray.secret')
+      )
+      // A terminal (non-superseded) fail on the second call makes start()
+      // settle deterministically instead of racing an infinite 'wait' retry.
+      .mockImplementationOnce(async () => terminalFailResponse('fresh-tray'));
+    const onJoinUrlChanged = vi.fn();
+
+    const manager = new FollowerTrayManager({
+      joinUrl: 'https://tray.example.com/join/stale-tray.secret',
+      runtime: 'slicc-standalone',
+      fetchImpl,
+      controllerIdFactory: () => 'follower-1',
+      sleep: async () => {},
+      onJoinUrlChanged,
+    });
+
+    await expect(manager.start()).rejects.toThrow('Tray expired');
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(onJoinUrlChanged).toHaveBeenCalledExactlyOnceWith(
+      'https://tray.example.com/join/fresh-tray.secret'
+    );
+    expect(fetchImpl.mock.calls[1]?.[0]).toBe(
+      'https://tray.example.com/join/fresh-tray.secret?json=true'
+    );
+  });
+
+  it('throws instead of looping forever on a redirect cycle', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () =>
+        supersededResponse('https://tray.example.com/join/stale-tray.secret')
+      );
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const manager = new FollowerTrayManager({
+      joinUrl: 'https://tray.example.com/join/stale-tray.secret',
+      runtime: 'slicc-standalone',
+      fetchImpl,
+      controllerIdFactory: () => 'follower-1',
+      sleep,
+    });
+
+    await expect(manager.start()).rejects.toThrow(/supersede redirects/);
+    // A sleep is awaited between each redirect, so the loop isn't a tight spin.
+    expect(sleep.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it('throws a clean error instead of an unhandled TypeError on a malformed redirect URL', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => supersededResponse('not-a-url'));
+
+    const manager = new FollowerTrayManager({
+      joinUrl: 'https://tray.example.com/join/stale-tray.secret',
+      runtime: 'slicc-standalone',
+      fetchImpl,
+      controllerIdFactory: () => 'follower-1',
+      sleep: async () => {},
+    });
+
+    await expect(manager.start()).rejects.toThrow(/invalid joinUrl/);
+  });
+});
+
 describe('startFollowerWithAutoReconnect', () => {
   // Helper: creates a full signaling harness that auto-connects a follower.
   // Returns a disconnect trigger to simulate connection loss.


### PR DESCRIPTION
## Summary
- When a hosted cone's leader reconnects and its stored tray session is stale, it mints a fresh tray instead of reattaching to the old one — leaving any follower still holding the old `/join/:token` link permanently stuck on `FOLLOWER_JOIN_NOT_READY` / `TRAY_EXPIRED`.
- The leader now best-effort notifies the old tray's Durable Object of the new join URL via `POST /api/tray/:trayId/supersede` (Bearer = old controllerToken).
- The old tray's `/join/:token` handler returns a new `TRAY_SUPERSEDED` code carrying the replacement URL; the follower's attach loop (`tray-webrtc.ts`) transparently retries against it — including Cherry-embedded followers, which reuse the same attach code path.

## Test plan
- [x] `packages/webapp/tests/scoops/tray-leader.test.ts`, `tray-follower*.test.ts`, `tray-webrtc*.test.ts` — 160 tests pass
- [x] `packages/cloudflare-worker/tests/index.test.ts`, `session-tray-preview.test.ts`, `preview-bridge-routes.test.ts` — 135 tests pass
- [x] `tsc --noEmit` clean on `tsconfig.json` (webapp) and `tsconfig.worker.json` (cloudflare-worker)
- [x] Routes mirrored in `src/index.ts`, `tests/index.test.ts`, `tests/deployed.test.ts` per repo convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)