### PR TITLE
fix(tray): exhaustive-switch enforcement on leader/follower dispatchers

### DIFF
--- a/packages/webapp/src/scoops/tray-follower-sync.ts
+++ b/packages/webapp/src/scoops/tray-follower-sync.ts
@@ -34,6 +34,7 @@ import {
   type TrayFsResponse,
   type TraySyncChannel,
   type TrayTargetEntry,
+  unhandledProtocolMessage,
 } from './tray-sync-protocol.js';
 import type { TrayDataChannelLike } from './tray-webrtc.js';
 
@@ -689,12 +690,17 @@ export class FollowerSyncManager implements AgentHandle {
         this.keepalive.receivePong();
         setFollowerLastPingTime(Date.now());
         break;
-      default:
-        // Protocol drift safety net — mirrors iOS `.unknown` case (AppState.swift)
-        log.debug('Unknown leader message type', {
-          type: (message as { type?: string }).type,
+      default: {
+        // Exhaustiveness guard: a new LeaderToFollowerMessage variant fails
+        // compile here until this dispatcher decides (mirrors the iOS
+        // `.unknown` case in AppState.swift). At runtime this branch means a
+        // version-skewed leader — log loudly, never throw.
+        const unknown = unhandledProtocolMessage(message);
+        log.warn('Unknown leader message type — skewed leader?', {
+          type: unknown.type,
         });
         break;
+      }
     }
   }
 

--- a/packages/webapp/src/scoops/tray-leader-sync.ts
+++ b/packages/webapp/src/scoops/tray-leader-sync.ts
@@ -39,6 +39,7 @@ import {
   type TrayFsResponse,
   type TraySyncChannel,
   type TrayTargetEntry,
+  unhandledProtocolMessage,
 } from './tray-sync-protocol.js';
 import { TrayTargetRegistry } from './tray-target-registry.js';
 import type { TrayDataChannelLike } from './tray-webrtc.js';
@@ -922,6 +923,17 @@ export class LeaderSyncManager {
           follower.keepalive.receivePong();
           follower.lastActivity = Date.now();
         }
+        break;
+      }
+      default: {
+        // Exhaustiveness guard: a new FollowerToLeaderMessage variant fails
+        // compile here until this dispatcher decides. At runtime this branch
+        // means a version-skewed follower — log loudly, never throw.
+        const unknown = unhandledProtocolMessage(message);
+        log.warn('Unknown follower message type — skewed follower?', {
+          bootstrapId,
+          type: unknown.type,
+        });
         break;
       }
     }

--- a/packages/webapp/src/scoops/tray-sync-protocol.ts
+++ b/packages/webapp/src/scoops/tray-sync-protocol.ts
@@ -319,6 +319,24 @@ export type TrayFsResponseData =
 
 export type TraySyncMessage = LeaderToFollowerMessage | FollowerToLeaderMessage;
 
+/**
+ * Compile-time exhaustiveness guard for protocol dispatchers.
+ *
+ * Call this from the `default:` branch of a `switch (message.type)` over a
+ * protocol union. Because the parameter is `never`, adding a new message
+ * variant to the union fails compile in every dispatcher until that
+ * dispatcher makes an explicit decision — a documented no-op `case` is
+ * allowed, silence is not.
+ *
+ * Unlike a classic `assertNever` this must NOT throw: at runtime a
+ * version-skewed peer (shipped iOS binary, older hosted UI, cherry embed)
+ * can legitimately deliver a message type this build doesn't know. It
+ * returns the loosely-typed message so the caller can log it loudly.
+ */
+export function unhandledProtocolMessage(message: never): { type?: string } {
+  return message as { type?: string };
+}
+
 // ---------------------------------------------------------------------------
 // CDP response chunking helpers
 // ---------------------------------------------------------------------------

--- a/packages/webapp/tests/scoops/tray-follower-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-follower-sync.test.ts
@@ -2317,18 +2317,25 @@ describe('FollowerSyncManager', () => {
   });
 
   describe('protocol drift safety', () => {
-    it('logs but does not throw on an unknown leader message type', () => {
+    it('warns but does not throw on an unknown leader message type', () => {
       const channel = new FakeChannel();
       new FollowerSyncManager(channel);
 
-      expect(() =>
-        channel.simulateLeaderMessage({
-          // Intentionally invent a type the switch does not handle.
-          type: 'future.feature' as unknown as 'snapshot',
-          messages: [],
-          scoopJid: '',
-        } as never)
-      ).not.toThrow();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        expect(() =>
+          channel.simulateLeaderMessage({
+            // Intentionally invent a type the switch does not handle.
+            type: 'future.feature' as unknown as 'snapshot',
+            messages: [],
+            scoopJid: '',
+          } as never)
+        ).not.toThrow();
+        const warned = warnSpy.mock.calls.flat().map(String).join(' ');
+        expect(warned).toContain('Unknown leader message type');
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/webapp/tests/scoops/tray-leader-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader-sync.test.ts
@@ -68,6 +68,7 @@ function createManager(overrides?: Partial<LeaderSyncManagerOptions>) {
   const onFollowerMessage = vi.fn();
   const onFollowerAbort = vi.fn();
   const options: LeaderSyncManagerOptions = {
+    sendControl: () => {},
     getMessages: () => [...messages],
     getScoopJid: () => 'cone',
     onFollowerMessage,
@@ -1540,9 +1541,10 @@ describe('LeaderSyncManager', () => {
         connectedAt: new Date().toISOString(),
       });
 
-      const followers = manager.getConnectedFollowers();
-      // No runtimeId mapping yet because targets.advertise hasn't been sent
-      // But we can verify via the internal state by advertising targets
+      // Not visible yet: getConnectedFollowers() is keyed by the runtimeId
+      // mapping, which only exists after the follower advertises targets.
+      expect(manager.getConnectedFollowers()).toHaveLength(0);
+      // Verify floatType/lastActivity via the internal state by advertising targets
       ch.simulateMessage({ type: 'targets.advertise', targets: [], runtimeId: 'follower-b1' });
       const updated = manager.getConnectedFollowers();
       expect(updated).toHaveLength(1);
@@ -2510,5 +2512,24 @@ describe('cherry teleport selection', () => {
     });
     manager.removeFollower('b1');
     expect(onRemoteTransportsCleaned).toHaveBeenCalledWith('follower-b1');
+  });
+});
+
+describe('protocol drift safety', () => {
+  it('warns but does not throw on an unknown follower message type', () => {
+    const { manager } = createManager();
+    const channel = new FakeChannel();
+    manager.addFollower('b1', channel);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(() =>
+        channel.simulateMessage({ type: 'future.feature' } as unknown as FollowerToLeaderMessage)
+      ).not.toThrow();
+      const warned = warnSpy.mock.calls.flat().map(String).join(' ');
+      expect(warned).toContain('Unknown follower message type');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Fixes #1334 (P0-3 in the #1294 architecture audit).

## Problem

The largest empirical bug class since March (~30–40 commits) is **"renders but not wired"**: a new leader broadcast is added, no follower dispatcher fails to compile, and the omission ships silently until a user clicks something that no-ops (precedents: #1286 scoop-select, #1283 tool_ui cards, #1261). The leader's `handleFollowerMessage` had **no `default:` at all** — unknown follower messages vanished with zero logging; the follower's `default:` logged at `debug`, invisible under the prod ERROR gate.

## Changes

- **`unhandledProtocolMessage(message: never)`** in `tray-sync-protocol.ts` — the `default:` branch of both dispatchers now narrows to `never`, so adding a variant to `LeaderToFollowerMessage` / `FollowerToLeaderMessage` fails compile in every dispatcher until it makes an explicit decision (documented no-op `case` allowed, silence not)
- **Leader** (`tray-leader-sync.ts` `handleFollowerMessage`): first-ever `default:` — warns with the message type ("skewed follower?")
- **Follower** (`tray-follower-sync.ts` `handleLeaderMessage`): `default:` raised debug → warn ("skewed leader?") — this also lands the TS half of #1335's "make drift loud"
- **Deliberately non-throwing at runtime**: version-skewed peers (shipped iOS binaries, older hosted UIs, cherry embeds) may legitimately deliver unknown types — the guard is compile-time-only enforcement, runtime is log-loudly
- Regression tests assert warn-not-throw on both sides; also fixes a pre-existing type error (`sendControl` missing from the test options factory) and converts a dead `followers` capture into a real assertion in `tray-leader-sync.test.ts` (#1337 class)

## Verification

- Both dispatchers are currently exhaustive — `tsc` green with the guard in place (no unwired variants exist today)
- **Mutation-verified**: adding a phantom variant to either union breaks the build at exactly the matching dispatcher (`TS2345 … not assignable to parameter of type 'never'`)
- `npm run lint` / `npm run typecheck` green; all 1,136 webapp scoops tests pass

## Cross-runtime parity

iOS: N/A — `SyncProtocol.swift` already decodes unknown types to `.unknown` (its own drift logging is tracked with the golden-fixture work in #1333). This PR is TS-side compile-time enforcement, which has no Swift equivalent.
