### PR TITLE
fix: use custom sprinkle icons in panel header tabs

### DIFF
--- a/packages/webapp/src/ui/wc/wc-sprinkles.ts
+++ b/packages/webapp/src/ui/wc/wc-sprinkles.ts
@@ -90,6 +90,7 @@ interface TabDescriptor {
   label: string;
   kind: 'tool' | 'sprinkle';
   closable?: boolean;
+  badge?: string;
 }
 
 interface DockItemDescriptor {
@@ -199,7 +200,9 @@ export class WcSprinkleZone {
       this.#surfaces.set(name, surface);
     }
     surface.replaceChildren(element);
-    this.#tabs.set(name, { id, label: title, kind: 'sprinkle', closable: true });
+    const icon = this.#resolveIcon(name, options?.icon);
+
+    this.#tabs.set(name, { id, label: title, kind: 'sprinkle', closable: true, badge: icon });
     this.#ensureDockItem(name, title, options?.icon);
     this.#sync();
     // Background adds (session restore) keep the current focus: what's on
@@ -233,9 +236,7 @@ export class WcSprinkleZone {
   #ensureDockItem(name: string, title: string, iconSpec?: string): void {
     // Discovery (or an open) confirmed this name — it's no longer a seed.
     this.#seeded.delete(name);
-    const icon = isLucideIconSpec(iconSpec)
-      ? iconSpec
-      : (readSprinkleIconLedger()[name] ?? 'sparkles');
+    const icon = this.#resolveIcon(name, iconSpec);
     this.#dockItems.set(name, {
       id: sprinkleSurfaceId(name),
       icon,
@@ -243,6 +244,10 @@ export class WcSprinkleZone {
       kind: 'sprinkle',
     });
     this.#sync();
+  }
+
+  #resolveIcon(name: string, spec?: string): string {
+    return isLucideIconSpec(spec) ? spec : (readSprinkleIconLedger()[name] ?? 'sparkles');
   }
 
   #unregister(name: string): void {

--- a/packages/webcomponents/src/workbench/slicc-tab-bar.ts
+++ b/packages/webcomponents/src/workbench/slicc-tab-bar.ts
@@ -66,6 +66,8 @@ export interface TabDescriptor {
   kind?: TabKind;
   /** Whether a close affordance is shown (sprinkle tabs are closable). */
   closable?: boolean;
+  /** Sprinkle badge lucide icon name, kebab-case (sprinkle kind only). */
+  badge?: string;
   /** Optional leading glyph for tool tabs (the prototype `.gl`), e.g. an icon. */
   glyph?: string;
 }
@@ -344,6 +346,7 @@ export class SliccTabBar extends HTMLElement {
           label: t.label,
           part: 'tab',
           closable: t.closable ? true : undefined,
+          badge: t.badge || undefined,
           glyph: t.glyph || undefined,
           active: active != null && active === t.id ? true : undefined,
         })


### PR DESCRIPTION
Fixes an issue where the custom icon of a sprinkle was not being displayed in the Slicc Panel header.

- Updated  to include the  property for icons.
- Implemented  in  to correctly determine the sprinkle icon (declared spec $\rightarrow$ ledger $\rightarrow$ default).
- Wired the resolved icon into tab descriptors during sprinkle addition and registration.
- Updated  rendering logic to pass the  attribute to  components.