### PR TITLE
fix(protocol): make version drift loud — tray hello handshake + distinct mismatch errors

### DIFF
--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -5,6 +5,7 @@ import {
   CHERRY_PROTOCOL_VERSION,
   type CherryEnvelope,
   isCherryEnvelope,
+  isCherryVersionMismatch,
 } from './protocol.js';
 
 interface CdpResponseShape {
@@ -155,11 +156,19 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
         channelId,
       })
     ) {
-      // A well-formed cherry envelope that still fails the gate is almost
-      // always a misconfiguration (wrong sliccOrigin, source/channel mismatch).
-      // Surface it — otherwise it manifests downstream as an opaque 30s
-      // handshake/CDP timeout. Non-cherry postMessage noise stays silent.
-      if (isCherryEnvelope(event.data)) {
+      // A version-skewed follower fails `isCherryEnvelope` itself — without
+      // this distinct log the skew is indistinguishable from the 30s timeout.
+      if (isCherryVersionMismatch(event.data)) {
+        console.warn('[cherry] protocol version mismatch — update the older side', {
+          peerVersion: event.data.cherry,
+          ourVersion: CHERRY_PROTOCOL_VERSION,
+          origin: event.origin,
+        });
+      } else if (isCherryEnvelope(event.data)) {
+        // A well-formed cherry envelope that still fails the gate is almost
+        // always a misconfiguration (wrong sliccOrigin, source/channel mismatch).
+        // Surface it — otherwise it manifests downstream as an opaque 30s
+        // handshake/CDP timeout. Non-cherry postMessage noise stays silent.
         console.warn('[cherry] rejected a cherry envelope (origin/source/channel mismatch)', {
           origin: event.origin,
           expectedOrigin: sliccOrigin,

--- a/packages/cherry/src/protocol.ts
+++ b/packages/cherry/src/protocol.ts
@@ -169,3 +169,21 @@ export function acceptEnvelope(event: MessageEvent, ctx: AcceptContext): boolean
   if (ctx.channelId !== null && event.data.channelId !== ctx.channelId) return false;
   return true;
 }
+
+/**
+ * True when a message is shaped like a cherry envelope but carries a DIFFERENT
+ * protocol version — i.e. the peer is a version-skewed build, not postMessage
+ * noise. `isCherryEnvelope` (and therefore `acceptEnvelope`) rejects these, so
+ * without this check a skewed peer is indistinguishable from the generic
+ * handshake timeout. Callers log it distinctly ("update the older side").
+ */
+export function isCherryVersionMismatch(value: unknown): value is { cherry: number } {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.cherry === 'number' &&
+    v.cherry !== CHERRY_PROTOCOL_VERSION &&
+    typeof v.channelId === 'string' &&
+    typeof v.kind === 'string'
+  );
+}

--- a/packages/cherry/src/protocol.ts
+++ b/packages/cherry/src/protocol.ts
@@ -177,7 +177,9 @@ export function acceptEnvelope(event: MessageEvent, ctx: AcceptContext): boolean
  * without this check a skewed peer is indistinguishable from the generic
  * handshake timeout. Callers log it distinctly ("update the older side").
  */
-export function isCherryVersionMismatch(value: unknown): value is { cherry: number } {
+export function isCherryVersionMismatch(
+  value: unknown
+): value is { cherry: number; channelId: string; kind: string } {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   return (

--- a/packages/cherry/tests/protocol.test.ts
+++ b/packages/cherry/tests/protocol.test.ts
@@ -5,6 +5,7 @@ import {
   CHERRY_PROTOCOL_VERSION,
   type CherryEnvelope,
   isCherryEnvelope,
+  isCherryVersionMismatch,
 } from '../src/protocol.js';
 
 /** A minimal but structurally valid envelope. */
@@ -44,6 +45,17 @@ describe('isCherryEnvelope', () => {
 
   it('accepts a structurally valid envelope', () => {
     expect(isCherryEnvelope(validEnvelope())).toBe(true);
+  });
+});
+
+describe('isCherryVersionMismatch', () => {
+  it('detects an envelope-shaped message with a different version', () => {
+    expect(isCherryVersionMismatch({ ...validEnvelope(), cherry: 2 })).toBe(true);
+  });
+  it('is false for the current version and for noise', () => {
+    expect(isCherryVersionMismatch(validEnvelope())).toBe(false);
+    expect(isCherryVersionMismatch(null)).toBe(false);
+    expect(isCherryVersionMismatch({ cherry: 2 })).toBe(false);
   });
 });
 

--- a/packages/chrome-extension/src/bridge-sw.ts
+++ b/packages/chrome-extension/src/bridge-sw.ts
@@ -32,6 +32,7 @@ import {
   EXTENSION_BRIDGE_PROTOCOL_VERSION,
   type ExtensionBridgeEnvelope,
   type ExtensionBridgeLick,
+  isBridgeVersionMismatch,
   isExtensionBridgeEnvelope,
 } from '../../webapp/src/cdp/extension-bridge-protocol.js';
 
@@ -388,6 +389,16 @@ async function handleBridgeMessage(
   raw: unknown,
   deps: BridgeSwDeps
 ): Promise<void> {
+  if (isBridgeVersionMismatch(raw)) {
+    // A skewed hosted-UI peer fails the structural validator — without this
+    // distinct log the mismatch is indistinguishable from the handshake
+    // timeout on the leader side.
+    console.warn('[slicc-bridge-sw] bridge protocol version mismatch — update the older side', {
+      peerVersion: raw.bridge,
+      ourVersion: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+    });
+    return;
+  }
   if (!isExtensionBridgeEnvelope(raw)) return;
   const env = raw as ExtensionBridgeEnvelope;
 

--- a/packages/chrome-extension/src/bridge-sw.ts
+++ b/packages/chrome-extension/src/bridge-sw.ts
@@ -397,6 +397,20 @@ async function handleBridgeMessage(
       peerVersion: raw.bridge,
       ourVersion: EXTENSION_BRIDGE_PROTOCOL_VERSION,
     });
+    // Best-effort fail-fast: reply with handshake.rejected so a peer that
+    // still understands our version rejects its connect() immediately
+    // instead of eating the handshake timeout, then drop the port.
+    try {
+      port.postMessage({
+        bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+        channelId: raw.channelId,
+        kind: 'handshake.rejected',
+        reason: 'version-mismatch',
+      } satisfies ExtensionBridgeEnvelope);
+      port.disconnect();
+    } catch {
+      /* port already gone */
+    }
     return;
   }
   if (!isExtensionBridgeEnvelope(raw)) return;

--- a/packages/chrome-extension/tests/bridge-sw.test.ts
+++ b/packages/chrome-extension/tests/bridge-sw.test.ts
@@ -218,6 +218,24 @@ describe('handleBridgePortConnect — pin gating', () => {
     });
     expect(port.disconnected).toBe(true);
   });
+
+  it('replies handshake.rejected (version-mismatch) and disconnects on a skewed envelope', async () => {
+    await handleBridgePortConnect(port as never, makeDeps());
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      port.receive({ bridge: 2, channelId: 'bridge-v2', kind: 'handshake.hello' });
+      const warned = warnSpy.mock.calls.flat().map(String).join(' ');
+      expect(warned).toContain('version mismatch');
+    } finally {
+      warnSpy.mockRestore();
+    }
+    expect(port.posted[0]).toMatchObject({
+      kind: 'handshake.rejected',
+      reason: 'version-mismatch',
+      channelId: 'bridge-v2',
+    });
+    expect(port.disconnected).toBe(true);
+  });
 });
 
 describe('handleBridgePortConnect — CDP pass-through', () => {

--- a/packages/webapp/src/cdp/cherry-host-protocol.ts
+++ b/packages/webapp/src/cdp/cherry-host-protocol.ts
@@ -159,3 +159,21 @@ export function acceptEnvelope(event: MessageEvent, ctx: AcceptContext): boolean
   if (ctx.channelId !== null && event.data.channelId !== ctx.channelId) return false;
   return true;
 }
+
+/**
+ * True when a message is shaped like a cherry envelope but carries a DIFFERENT
+ * protocol version — i.e. the peer is a version-skewed build, not postMessage
+ * noise. `isCherryEnvelope` (and therefore `acceptEnvelope`) rejects these, so
+ * without this check a skewed peer is indistinguishable from the generic
+ * handshake timeout. Callers log it distinctly ("update the older side").
+ */
+export function isCherryVersionMismatch(value: unknown): value is { cherry: number } {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.cherry === 'number' &&
+    v.cherry !== CHERRY_PROTOCOL_VERSION &&
+    typeof v.channelId === 'string' &&
+    typeof v.kind === 'string'
+  );
+}

--- a/packages/webapp/src/cdp/cherry-host-protocol.ts
+++ b/packages/webapp/src/cdp/cherry-host-protocol.ts
@@ -167,7 +167,9 @@ export function acceptEnvelope(event: MessageEvent, ctx: AcceptContext): boolean
  * without this check a skewed peer is indistinguishable from the generic
  * handshake timeout. Callers log it distinctly ("update the older side").
  */
-export function isCherryVersionMismatch(value: unknown): value is { cherry: number } {
+export function isCherryVersionMismatch(
+  value: unknown
+): value is { cherry: number; channelId: string; kind: string } {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   return (

--- a/packages/webapp/src/cdp/cherry-host-transport.ts
+++ b/packages/webapp/src/cdp/cherry-host-transport.ts
@@ -16,6 +16,7 @@ import {
   CHERRY_PROTOCOL_VERSION,
   type CherryEnvelope,
   isCherryEnvelope,
+  isCherryVersionMismatch,
 } from './cherry-host-protocol.js';
 import { SyntheticCdpTransport } from './synthetic-cdp-transport.js';
 import type { CDPConnectOptions } from './types.js';
@@ -266,11 +267,19 @@ export class CherryHostTransport extends SyntheticCdpTransport {
         channelId: this.channelId,
       })
     ) {
-      // A well-formed cherry envelope rejected by the gate signals a
-      // misconfiguration (wrong host origin, source/channel mismatch) rather
-      // than unrelated postMessage noise — log it so it doesn't surface only as
-      // an opaque 30s connect timeout. Plain noise is filtered out silently.
-      if (isCherryEnvelope(event.data)) {
+      // A version-skewed peer fails `isCherryEnvelope` itself — without this
+      // distinct log the skew is indistinguishable from the 30s timeout.
+      if (isCherryVersionMismatch(event.data)) {
+        log.warn('Cherry protocol version mismatch — update the older side', {
+          peerVersion: event.data.cherry,
+          ourVersion: CHERRY_PROTOCOL_VERSION,
+          origin: event.origin,
+        });
+      } else if (isCherryEnvelope(event.data)) {
+        // A well-formed cherry envelope rejected by the gate signals a
+        // misconfiguration (wrong host origin, source/channel mismatch) rather
+        // than unrelated postMessage noise — log it so it doesn't surface only
+        // as an opaque 30s connect timeout. Plain noise is filtered silently.
         log.warn('Rejected a cherry envelope (origin/source/channel mismatch)', {
           origin: event.origin,
           allowOrigins: this.opts.allowOrigins,

--- a/packages/webapp/src/cdp/cherry-host-transport.ts
+++ b/packages/webapp/src/cdp/cherry-host-transport.ts
@@ -44,6 +44,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
     { resolve: (r: Record<string, unknown>) => void; reject: (e: Error) => void }
   >();
   private connectResolve: (() => void) | null = null;
+  private connectReject: ((err: Error) => void) | null = null;
   private connectTimer: ReturnType<typeof setTimeout> | null = null;
   private _joinUrl: string | null = null;
   private _features: {
@@ -152,6 +153,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
     const timeoutMs = options?.timeout ?? DEFAULT_TIMEOUT;
     return new Promise<void>((resolve, reject) => {
       this.connectResolve = resolve;
+      this.connectReject = reject;
       this.connectTimer = setTimeout(() => {
         this.connectTimer = null;
         if (typeof window !== 'undefined') {
@@ -160,6 +162,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
         this._state = 'disconnected';
         this.channelId = null;
         this.connectResolve = null;
+        this.connectReject = null;
         reject(new Error(`Cherry handshake timed out after ${timeoutMs}ms`));
       }, timeoutMs);
       this.post({
@@ -173,6 +176,24 @@ export class CherryHostTransport extends SyntheticCdpTransport {
         },
       });
     });
+  }
+
+  /** Reject a pending connect() early (e.g. diagnosed version skew). No-op when not connecting. */
+  private failPendingConnect(err: Error): void {
+    if (this.connectReject === null) return;
+    if (this.connectTimer !== null) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('message', this.boundHandler);
+    }
+    this._state = 'disconnected';
+    this.channelId = null;
+    const reject = this.connectReject;
+    this.connectResolve = null;
+    this.connectReject = null;
+    reject(err);
   }
 
   disconnect(): void {
@@ -275,6 +296,21 @@ export class CherryHostTransport extends SyntheticCdpTransport {
           ourVersion: CHERRY_PROTOCOL_VERSION,
           origin: event.origin,
         });
+        // Fail the pending connect() immediately instead of eating the 30s
+        // timeout — but ONLY when origin + source match the pinned host page.
+        // Without that gate any hostile frame could post a mismatch-shaped
+        // message and kill the handshake.
+        const trustedPeer =
+          this.opts.allowOrigins.includes(event.origin) &&
+          event.source === (this.opts.counterpart as unknown as MessageEventSource);
+        if (trustedPeer) {
+          this.failPendingConnect(
+            new Error(
+              `Cherry protocol version mismatch (peer v${event.data.cherry}, ` +
+                `ours v${CHERRY_PROTOCOL_VERSION}) — update the older side`
+            )
+          );
+        }
       } else if (isCherryEnvelope(event.data)) {
         // A well-formed cherry envelope rejected by the gate signals a
         // misconfiguration (wrong host origin, source/channel mismatch) rather
@@ -311,6 +347,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
         log.info('Cherry handshake complete', { channelId: this.channelId });
         this.connectResolve?.();
         this.connectResolve = null;
+        this.connectReject = null;
         return;
       case 'cdp.response': {
         const p = this.pending.get(env.id);

--- a/packages/webapp/src/cdp/extension-bridge-protocol.ts
+++ b/packages/webapp/src/cdp/extension-bridge-protocol.ts
@@ -154,7 +154,9 @@ export function isExtensionBridgeEnvelope(value: unknown): value is ExtensionBri
  * rejects these, so without this check a skewed peer is indistinguishable
  * from the generic handshake timeout. Callers log it distinctly.
  */
-export function isBridgeVersionMismatch(value: unknown): value is { bridge: number } {
+export function isBridgeVersionMismatch(
+  value: unknown
+): value is { bridge: number; channelId: string; kind: string } {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   return (

--- a/packages/webapp/src/cdp/extension-bridge-protocol.ts
+++ b/packages/webapp/src/cdp/extension-bridge-protocol.ts
@@ -146,3 +146,21 @@ export function isExtensionBridgeEnvelope(value: unknown): value is ExtensionBri
     KINDS.has(v.kind as ExtensionBridgeEnvelope['kind'])
   );
 }
+
+/**
+ * True when a message is shaped like a bridge envelope but carries a DIFFERENT
+ * protocol version — i.e. the peer (hosted leader tab vs installed extension)
+ * is a version-skewed build, not Port noise. `isExtensionBridgeEnvelope`
+ * rejects these, so without this check a skewed peer is indistinguishable
+ * from the generic handshake timeout. Callers log it distinctly.
+ */
+export function isBridgeVersionMismatch(value: unknown): value is { bridge: number } {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.bridge === 'number' &&
+    v.bridge !== EXTENSION_BRIDGE_PROTOCOL_VERSION &&
+    typeof v.channelId === 'string' &&
+    typeof v.kind === 'string'
+  );
+}

--- a/packages/webapp/src/cdp/extension-bridge-transport.ts
+++ b/packages/webapp/src/cdp/extension-bridge-transport.ts
@@ -29,6 +29,7 @@ import {
   EXTENSION_BRIDGE_PROTOCOL_VERSION,
   type ExtensionBridgeEnvelope,
   type ExtensionBridgeLick,
+  isBridgeVersionMismatch,
   isExtensionBridgeEnvelope,
 } from './extension-bridge-protocol.js';
 import type { CDPConnectOptions } from './types.js';
@@ -226,6 +227,15 @@ export class ExtensionBridgeTransport extends CdpTransportBridge {
   }
 
   private handleHandshake(raw: unknown): void {
+    if (isBridgeVersionMismatch(raw)) {
+      // A skewed peer fails the structural validator — without this distinct
+      // log the mismatch is indistinguishable from the handshake timeout.
+      log.warn('Extension bridge protocol version mismatch — update the older side', {
+        peerVersion: raw.bridge,
+        ourVersion: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      });
+      return;
+    }
     if (!isExtensionBridgeEnvelope(raw)) return;
     const env = raw as ExtensionBridgeEnvelope;
     if (env.channelId !== this.channelId) return;

--- a/packages/webapp/src/cdp/extension-bridge-transport.ts
+++ b/packages/webapp/src/cdp/extension-bridge-transport.ts
@@ -234,6 +234,18 @@ export class ExtensionBridgeTransport extends CdpTransportBridge {
         peerVersion: raw.bridge,
         ourVersion: EXTENSION_BRIDGE_PROTOCOL_VERSION,
       });
+      // The Port peer is pinned (onConnectExternal + name), and the envelope
+      // echoes our channelId — fail the pending connect() immediately instead
+      // of letting the caller eat the handshake timeout.
+      if (raw.channelId === this.channelId && this.rejectWelcome) {
+        this.rejectWelcome(
+          new Error(
+            `Extension bridge protocol version mismatch (peer v${raw.bridge}, ` +
+              `ours v${EXTENSION_BRIDGE_PROTOCOL_VERSION}) — update the older side`
+          )
+        );
+        this.cleanupHandshake();
+      }
       return;
     }
     if (!isExtensionBridgeEnvelope(raw)) return;

--- a/packages/webapp/src/scoops/tray-follower-sync.ts
+++ b/packages/webapp/src/scoops/tray-follower-sync.ts
@@ -30,6 +30,7 @@ import {
   type ScoopSummary,
   type SprinkleSummary,
   sendCDPResponse,
+  TRAY_SYNC_PROTOCOL_VERSION,
   type TrayFsRequest,
   type TrayFsResponse,
   type TraySyncChannel,
@@ -155,6 +156,10 @@ export class FollowerSyncManager implements AgentHandle {
       responses: TrayFsResponse[];
     }
   >();
+  /** Tray sync protocol version from the leader's `hello`; undefined until it arrives. */
+  private leaderProtocolVersion?: number;
+  /** True once the no-hello legacy-leader diagnosis has been logged. */
+  private legacyLeaderLogged = false;
   /** Latest sprinkle summaries received from the leader (most-recent `sprinkles.list`). */
   private latestSprinkles: SprinkleSummary[] = [];
   /** Cache of resolved sprinkle .shtml content by name. Cleared on explicit invalidate. */
@@ -206,6 +211,12 @@ export class FollowerSyncManager implements AgentHandle {
     this.sync = createFollowerSyncChannel(channel);
     this.unsubscribe = this.sync.onMessage((message: LeaderToFollowerMessage) => {
       this.handleLeaderMessage(message);
+    });
+    // Version handshake first — additive; legacy leaders drop it harmlessly.
+    this.sync.send({
+      type: 'hello',
+      protocolVersion: TRAY_SYNC_PROTOCOL_VERSION,
+      ...(this.options.selfRuntimeId ? { runtime: this.options.selfRuntimeId } : {}),
     });
     this.keepalive = new DataChannelKeepalive({
       sendPing: () => this.sync.send({ type: 'ping' }),
@@ -535,7 +546,32 @@ export class FollowerSyncManager implements AgentHandle {
     this.options.onDisconnect?.(reason);
   }
 
+  /**
+   * Record the leader's `hello`. Warn when the leader is newer than this
+   * build — the skew otherwise surfaces only as silently missing features.
+   */
+  private handleLeaderHello(protocolVersion: number): void {
+    this.leaderProtocolVersion = protocolVersion;
+    if (protocolVersion > TRAY_SYNC_PROTOCOL_VERSION) {
+      log.warn('Leader speaks a newer tray sync protocol — update this build', {
+        leaderVersion: protocolVersion,
+        ourVersion: TRAY_SYNC_PROTOCOL_VERSION,
+      });
+    } else {
+      log.info('Leader hello', { protocolVersion });
+    }
+  }
+
+  /** Log once when the leader's first message is not `hello` (ordered channel ⇒ legacy build). */
+  private noteLegacyLeader(messageType: string): void {
+    if (messageType === 'hello' || this.leaderProtocolVersion !== undefined) return;
+    if (this.legacyLeaderLogged) return;
+    this.legacyLeaderLogged = true;
+    log.info('Leader sent no hello — legacy peer (pre-versioning build)');
+  }
+
   private handleLeaderMessage(message: LeaderToFollowerMessage): void {
+    this.noteLegacyLeader(message.type);
     if (message.type === 'theme.apply') {
       this.applyLeaderTheme(message.themeJson);
       return;
@@ -689,6 +725,9 @@ export class FollowerSyncManager implements AgentHandle {
       case 'pong':
         this.keepalive.receivePong();
         setFollowerLastPingTime(Date.now());
+        break;
+      case 'hello':
+        this.handleLeaderHello(message.protocolVersion);
         break;
       default: {
         // Exhaustiveness guard: a new LeaderToFollowerMessage variant fails

--- a/packages/webapp/src/scoops/tray-leader-sync.ts
+++ b/packages/webapp/src/scoops/tray-leader-sync.ts
@@ -35,6 +35,7 @@ import {
   type SprinkleSummary,
   sendCDPResponse,
   sendSnapshot,
+  TRAY_SYNC_PROTOCOL_VERSION,
   type TrayFsRequest,
   type TrayFsResponse,
   type TraySyncChannel,
@@ -197,6 +198,14 @@ interface ConnectedFollower {
    * Defaults to the leader's active scoop until the follower sends `scoops.select`.
    */
   selectedScoopJid?: string;
+  /**
+   * Tray sync protocol version from the follower's `hello`. `undefined` until
+   * a hello arrives; a follower that sends other traffic first is a legacy
+   * (pre-versioning) build — logged once via `legacyPeerLogged`.
+   */
+  peerProtocolVersion?: number;
+  /** True once the no-hello legacy diagnosis has been logged for this follower. */
+  legacyPeerLogged?: boolean;
 }
 
 /** Tracks a CDP request being routed through the leader. */
@@ -321,6 +330,9 @@ export class LeaderSyncManager {
     });
     log.info('Follower added to sync', { bootstrapId, followerCount: this.followers.size });
     this.options.onFollowerCountChanged?.(this.followers.size);
+
+    // Version handshake first — additive; legacy followers drop it harmlessly.
+    sync.send({ type: 'hello', protocolVersion: TRAY_SYNC_PROTOCOL_VERSION });
 
     // Send initial snapshot
     void this.sendSnapshotToFollower(bootstrapId);
@@ -815,6 +827,16 @@ export class LeaderSyncManager {
    * Handle incoming messages from a follower.
    */
   private handleFollowerMessage(bootstrapId: string, message: FollowerToLeaderMessage): void {
+    if (message.type !== 'hello') {
+      // Ordered channel: a versioned follower's first message is `hello`.
+      // Anything else first means a legacy (pre-versioning) build — say so
+      // once, so missing-feature reports are diagnosable.
+      const follower = this.followers.get(bootstrapId);
+      if (follower && follower.peerProtocolVersion === undefined && !follower.legacyPeerLogged) {
+        follower.legacyPeerLogged = true;
+        log.info('Follower sent no hello — legacy peer (pre-versioning build)', { bootstrapId });
+      }
+    }
     switch (message.type) {
       case 'user_message':
         this.handleFollowerUserMessage(bootstrapId, message);
@@ -922,6 +944,20 @@ export class LeaderSyncManager {
         if (follower) {
           follower.keepalive.receivePong();
           follower.lastActivity = Date.now();
+        }
+        break;
+      }
+      case 'hello': {
+        const follower = this.followers.get(bootstrapId);
+        if (follower) follower.peerProtocolVersion = message.protocolVersion;
+        if (message.protocolVersion > TRAY_SYNC_PROTOCOL_VERSION) {
+          log.warn('Follower speaks a newer tray sync protocol — update this build', {
+            bootstrapId,
+            followerVersion: message.protocolVersion,
+            ourVersion: TRAY_SYNC_PROTOCOL_VERSION,
+          });
+        } else {
+          log.info('Follower hello', { bootstrapId, protocolVersion: message.protocolVersion });
         }
         break;
       }

--- a/packages/webapp/src/scoops/tray-sync-protocol.ts
+++ b/packages/webapp/src/scoops/tray-sync-protocol.ts
@@ -40,6 +40,27 @@ const log = createLogger('tray-sync');
  */
 export const CHERRY_RUNTIME_TAG = 'slicc-cherry';
 
+/**
+ * Tray sync protocol version, exchanged via the additive `hello` message both
+ * sides send on channel open. A peer that never sends `hello` is a legacy
+ * build (pre-versioning); a peer with a HIGHER version than ours means this
+ * build is outdated — both cases log loudly instead of surfacing as silently
+ * missing features. Bump when the wire format changes incompatibly.
+ */
+export const TRAY_SYNC_PROTOCOL_VERSION = 1;
+
+/**
+ * Additive version handshake, sent by BOTH sides as their first message on
+ * channel open. Legacy peers drop it harmlessly (TS: unknown-message warn;
+ * iOS: `.unknown`), so it is backward and forward compatible.
+ */
+export interface TraySyncHelloMessage {
+  type: 'hello';
+  protocolVersion: number;
+  /** Optional runtime tag of the sender (e.g. 'slicc-standalone'). */
+  runtime?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Protocol messages
 // ---------------------------------------------------------------------------
@@ -103,6 +124,7 @@ export type LeaderToFollowerMessage =
   | { type: 'fs.response'; requestId: string; response: TrayFsResponse }
   | CherrySliccEventMessage
   | { type: 'theme.apply'; themeJson: string | null }
+  | TraySyncHelloMessage
   | { type: 'ping' }
   | { type: 'pong' };
 
@@ -146,6 +168,7 @@ export type FollowerToLeaderMessage =
   | { type: 'fs.request'; requestId: string; targetRuntimeId: string; request: TrayFsRequest }
   | { type: 'fs.response'; requestId: string; response: TrayFsResponse }
   | CherryHostEventMessage
+  | TraySyncHelloMessage
   | { type: 'ping' }
   | { type: 'pong' };
 

--- a/packages/webapp/tests/cdp/cherry-host-protocol.test.ts
+++ b/packages/webapp/tests/cdp/cherry-host-protocol.test.ts
@@ -4,6 +4,7 @@ import {
   CHERRY_PROTOCOL_VERSION,
   type CherryEnvelope,
   isCherryEnvelope,
+  isCherryVersionMismatch,
 } from '../../src/cdp/cherry-host-protocol.js';
 
 const make = (over: Partial<CherryEnvelope> = {}): CherryEnvelope =>
@@ -32,6 +33,23 @@ describe('isCherryEnvelope', () => {
   });
   it('rejects an unknown kind', () => {
     expect(isCherryEnvelope({ ...make(), kind: 'bogus.kind' })).toBe(false);
+  });
+});
+
+describe('isCherryVersionMismatch', () => {
+  it('detects an envelope-shaped message with a different version', () => {
+    expect(isCherryVersionMismatch({ ...make(), cherry: 2 })).toBe(true);
+    expect(isCherryVersionMismatch({ cherry: 0, channelId: 'x', kind: 'handshake.hello' })).toBe(
+      true
+    );
+  });
+  it('is false for the current version (that is a valid envelope, not a mismatch)', () => {
+    expect(isCherryVersionMismatch(make())).toBe(false);
+  });
+  it('is false for non-envelope noise', () => {
+    expect(isCherryVersionMismatch(null)).toBe(false);
+    expect(isCherryVersionMismatch({ cherry: 2 })).toBe(false);
+    expect(isCherryVersionMismatch({ cherry: '2', channelId: 'x', kind: 'k' })).toBe(false);
   });
 });
 

--- a/packages/webapp/tests/cdp/cherry-host-transport.test.ts
+++ b/packages/webapp/tests/cdp/cherry-host-transport.test.ts
@@ -45,6 +45,48 @@ describe('CherryHostTransport', () => {
     expect(h.transport.joinUrl).toBe('https://app.example/join?t=Z');
   });
 
+  it('rejects connect() immediately with a distinct error on a version-mismatched welcome', async () => {
+    const p = h.transport.connect();
+    const hello = h.posted.find((m) => m.kind === 'handshake.hello');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // Host SDK speaking cherry v2 — fails the structural validator, but
+      // must be diagnosed as skew (and fail fast), not eaten as noise.
+      h.inbound({ cherry: 2, channelId: hello.channelId, kind: 'handshake.welcome' });
+      await expect(p).rejects.toThrow(/version mismatch \(peer v2, ours v1\)/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+    expect(h.transport.state).toBe('disconnected');
+  });
+
+  it('does not fail the handshake on a mismatch-shaped message from an untrusted origin', async () => {
+    const p = h.transport.connect();
+    const hello = h.posted.find((m) => m.kind === 'handshake.hello');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // Hostile frame: right shape, wrong origin — must NOT kill the handshake.
+      h.transport.__test_receive({
+        origin: 'https://evil.example',
+        source: {} as MessageEventSource,
+        data: { cherry: 2, channelId: hello.channelId, kind: 'handshake.welcome' },
+      } as MessageEvent);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    // Still pending — a valid welcome completes it.
+    h.inbound({
+      cherry: CHERRY_PROTOCOL_VERSION,
+      channelId: hello.channelId,
+      kind: 'handshake.welcome',
+    });
+    await expect(p).resolves.toBeUndefined();
+    expect(h.transport.state).toBe('connected');
+  });
+
   it('synthesizes Target.getTargets locally without a host round-trip', async () => {
     await connectHelper(h);
     const res = await h.transport.send('Target.getTargets');

--- a/packages/webapp/tests/cdp/extension-bridge-protocol.test.ts
+++ b/packages/webapp/tests/cdp/extension-bridge-protocol.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   EXTENSION_BRIDGE_PORT_NAME,
   EXTENSION_BRIDGE_PROTOCOL_VERSION,
+  isBridgeVersionMismatch,
   isExtensionBridgeEnvelope,
 } from '../../src/cdp/extension-bridge-protocol.js';
 
@@ -104,5 +105,21 @@ describe('extension-bridge-protocol', () => {
     expect(isExtensionBridgeEnvelope({ cherry: 1, channelId: 'x', kind: 'handshake.hello' })).toBe(
       false
     );
+  });
+
+  describe('isBridgeVersionMismatch', () => {
+    it('detects an envelope-shaped message with a different version', () => {
+      expect(isBridgeVersionMismatch({ bridge: 2, channelId: 'x', kind: 'handshake.hello' })).toBe(
+        true
+      );
+    });
+    it('is false for the current version and for noise', () => {
+      expect(isBridgeVersionMismatch({ bridge: 1, channelId: 'x', kind: 'handshake.hello' })).toBe(
+        false
+      );
+      expect(isBridgeVersionMismatch(null)).toBe(false);
+      expect(isBridgeVersionMismatch({ bridge: 2 })).toBe(false);
+      expect(isBridgeVersionMismatch({ cherry: 2, channelId: 'x', kind: 'k' })).toBe(false);
+    });
   });
 });

--- a/packages/webapp/tests/cdp/extension-bridge-transport.test.ts
+++ b/packages/webapp/tests/cdp/extension-bridge-transport.test.ts
@@ -7,6 +7,7 @@ import {
   type ExtensionBridgePort,
   ExtensionBridgeTransport,
 } from '../../src/cdp/extension-bridge-transport.js';
+import type { CDPConnectOptions } from '../../src/cdp/types.js';
 
 interface FakePort extends ExtensionBridgePort {
   posted: unknown[];
@@ -120,6 +121,32 @@ describe('ExtensionBridgeTransport', () => {
     expect(transport.state).toBe('disconnected');
   });
 
+  it('warns distinctly on a version-mismatched envelope instead of silently dropping it', async () => {
+    const p = transport.connect();
+    await Promise.resolve();
+    const channelId = lastChannelId(port);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // A peer speaking bridge v2 — fails the structural validator, but must
+      // be diagnosed as skew, not dropped like Port noise.
+      port.receive({ bridge: 2, channelId, kind: 'handshake.welcome' });
+      const warned = warnSpy.mock.calls.flat().map(String).join(' ');
+      expect(warned).toContain('version mismatch');
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    // The handshake is still pending — resolve it so the promise doesn't dangle.
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId,
+      kind: 'handshake.welcome',
+    });
+    await p;
+    expect(transport.state).toBe('connected');
+  });
+
   it('rejects connect() if the port disconnects before welcome', async () => {
     const p = transport.connect();
     await Promise.resolve();
@@ -129,7 +156,9 @@ describe('ExtensionBridgeTransport', () => {
 
   it('rejects connect() on handshake timeout', async () => {
     vi.useFakeTimers();
-    const p = transport.connect({ timeout: 50 });
+    // The bridge transport dials a chrome.runtime Port, not a WebSocket —
+    // `url` is unused, so the cast narrows the shared CDPConnectOptions shape.
+    const p = transport.connect({ timeout: 50 } as CDPConnectOptions);
     await Promise.resolve();
     vi.advanceTimersByTime(60);
     await expect(p).rejects.toThrow(/handshake timed out/);

--- a/packages/webapp/tests/cdp/extension-bridge-transport.test.ts
+++ b/packages/webapp/tests/cdp/extension-bridge-transport.test.ts
@@ -121,7 +121,7 @@ describe('ExtensionBridgeTransport', () => {
     expect(transport.state).toBe('disconnected');
   });
 
-  it('warns distinctly on a version-mismatched envelope instead of silently dropping it', async () => {
+  it('rejects connect() immediately with a distinct error on a version-mismatched envelope', async () => {
     const p = transport.connect();
     await Promise.resolve();
     const channelId = lastChannelId(port);
@@ -129,7 +129,7 @@ describe('ExtensionBridgeTransport', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       // A peer speaking bridge v2 — fails the structural validator, but must
-      // be diagnosed as skew, not dropped like Port noise.
+      // be diagnosed as skew (and fail fast), not dropped like Port noise.
       port.receive({ bridge: 2, channelId, kind: 'handshake.welcome' });
       const warned = warnSpy.mock.calls.flat().map(String).join(' ');
       expect(warned).toContain('version mismatch');
@@ -137,7 +137,23 @@ describe('ExtensionBridgeTransport', () => {
       warnSpy.mockRestore();
     }
 
-    // The handshake is still pending — resolve it so the promise doesn't dangle.
+    await expect(p).rejects.toThrow(/version mismatch \(peer v2, ours v1\)/);
+  });
+
+  it('does not fail the handshake on a mismatched envelope for a different channelId', async () => {
+    const p = transport.connect();
+    await Promise.resolve();
+    const channelId = lastChannelId(port);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // Wrong channelId — diagnosable noise, but must not kill OUR handshake.
+      port.receive({ bridge: 2, channelId: 'bridge-someone-else', kind: 'handshake.welcome' });
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    // Still pending — a valid welcome completes it.
     port.receive({
       bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
       channelId,

--- a/packages/webapp/tests/scoops/tray-follower-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-follower-sync.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentEvent } from '../../src/core/agent-types.js';
+import { resetLoggerDedupForTests } from '../../src/core/logger.js';
 import type { ChatMessage } from '../../src/scoops/chat-types.js';
 import {
   getFollowerTrayRuntimeStatus,
@@ -59,7 +60,12 @@ class FakeChannel implements TrayDataChannelLike {
   }
 
   parseSent(): FollowerToLeaderMessage[] {
-    return this.sent.map((s) => JSON.parse(s));
+    // The manager sends a `hello` version handshake on construction; filter it
+    // out so per-feature assertions stay focused. Hello-specific tests read
+    // the raw `sent` array instead.
+    return this.sent
+      .map((s) => JSON.parse(s) as FollowerToLeaderMessage)
+      .filter((m) => m.type !== 'hello');
   }
 }
 
@@ -1454,7 +1460,7 @@ describe('FollowerSyncManager', () => {
         body: {},
       });
       expect(ok).toBe(false);
-      expect(channel.sent).toHaveLength(0);
+      expect(channel.parseSent()).toHaveLength(0);
     });
 
     it('fetchSprinkleContent sends sprinkle.fetch and resolves with single-chunk content', async () => {
@@ -2313,6 +2319,55 @@ describe('FollowerSyncManager', () => {
       const sent = channel.parseSent() as Array<{ type: string; targetId: string }>;
       expect(sent[0].type).toBe('cherry.host_event');
       expect(sent[0].targetId).toBe('');
+    });
+  });
+
+  describe('version handshake', () => {
+    it('sends hello with the protocol version as its first message', () => {
+      const channel = new FakeChannel();
+      new FollowerSyncManager(channel, { selfRuntimeId: 'follower-1' });
+
+      const first = JSON.parse(channel.sent[0]) as {
+        type: string;
+        protocolVersion: number;
+        runtime?: string;
+      };
+      expect(first.type).toBe('hello');
+      expect(first.protocolVersion).toBe(1);
+      expect(first.runtime).toBe('follower-1');
+    });
+
+    it('warns when the leader speaks a newer protocol version', () => {
+      const channel = new FakeChannel();
+      new FollowerSyncManager(channel);
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        channel.simulateLeaderMessage({ type: 'hello', protocolVersion: 999 });
+        const warned = warnSpy.mock.calls.flat().map(String).join(' ');
+        expect(warned).toContain('newer tray sync protocol');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('diagnoses a legacy leader once when the first message is not hello', () => {
+      // Earlier tests in this file also trip the legacy diagnosis; clear the
+      // module-global dedup buffer so this instance's log is not suppressed.
+      resetLoggerDedupForTests();
+      const channel = new FakeChannel();
+      new FollowerSyncManager(channel);
+
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+      try {
+        channel.simulateLeaderMessage({ type: 'status', scoopStatus: 'idle' });
+        channel.simulateLeaderMessage({ type: 'status', scoopStatus: 'idle' });
+        const infos = infoSpy.mock.calls.flat().map(String).join('\n');
+        const matches = infos.match(/legacy peer \(pre-versioning build\)/g) ?? [];
+        expect(matches).toHaveLength(1);
+      } finally {
+        infoSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/webapp/tests/scoops/tray-leader-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader-sync.test.ts
@@ -1,6 +1,7 @@
 import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentEvent } from '../../src/core/agent-types.js';
+import { resetLoggerDedupForTests } from '../../src/core/logger.js';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
 import type { ChatMessage } from '../../src/scoops/chat-types.js';
 import {
@@ -48,7 +49,12 @@ class FakeChannel implements TrayDataChannelLike {
   }
 
   parseSent(): LeaderToFollowerMessage[] {
-    return this.sent.map((s) => JSON.parse(s));
+    // The manager sends a `hello` version handshake on addFollower; filter it
+    // out so per-feature assertions stay focused. Hello-specific tests read
+    // the raw `sent` array instead.
+    return this.sent
+      .map((s) => JSON.parse(s) as LeaderToFollowerMessage)
+      .filter((m) => m.type !== 'hello');
   }
 }
 
@@ -2512,6 +2518,53 @@ describe('cherry teleport selection', () => {
     });
     manager.removeFollower('b1');
     expect(onRemoteTransportsCleaned).toHaveBeenCalledWith('follower-b1');
+  });
+});
+
+describe('version handshake', () => {
+  it('sends hello as the first message on addFollower', () => {
+    const { manager } = createManager();
+    const channel = new FakeChannel();
+    manager.addFollower('b1', channel);
+
+    const first = JSON.parse(channel.sent[0]) as { type: string; protocolVersion: number };
+    expect(first.type).toBe('hello');
+    expect(first.protocolVersion).toBe(1);
+  });
+
+  it('warns when a follower speaks a newer protocol version', () => {
+    const { manager } = createManager();
+    const channel = new FakeChannel();
+    manager.addFollower('b1', channel);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      channel.simulateMessage({ type: 'hello', protocolVersion: 999 });
+      const warned = warnSpy.mock.calls.flat().map(String).join(' ');
+      expect(warned).toContain('newer tray sync protocol');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('diagnoses a legacy follower once when the first message is not hello', () => {
+    // Earlier tests in this file also trip the legacy diagnosis; clear the
+    // module-global dedup buffer so this instance's log is not suppressed.
+    resetLoggerDedupForTests();
+    const { manager } = createManager();
+    const channel = new FakeChannel();
+    manager.addFollower('b1', channel);
+
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    try {
+      channel.simulateMessage({ type: 'abort' });
+      channel.simulateMessage({ type: 'abort' });
+      const infos = infoSpy.mock.calls.flat().map(String).join('\n');
+      const matches = infos.match(/legacy peer \(pre-versioning build\)/g) ?? [];
+      expect(matches).toHaveLength(1);
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #1335 (P0-4 in the #1294 architecture audit). Completes what #1344 started: where drift can't be prevented at compile time (shipped peers, cross-language mirrors), it must be **diagnosable at runtime** instead of presenting as "nothing happened" or a generic timeout.

## Tray sync channel — previously unversioned

The highest-risk wire (spoken to shipped iOS binaries and third-party cherry embeds) had no version field and no handshake.

- **`TRAY_SYNC_PROTOCOL_VERSION` + additive `hello` message** in both unions. Leader sends it first in `addFollower`, follower first in its constructor. Legacy peers drop it harmlessly (TS: the #1344 unknown-message warn; iOS: `.unknown`)
- Each side records the peer version; a **newer peer** logs `update this build` at warn
- A peer whose first message is not `hello` is diagnosed **once** as a legacy (pre-versioning) build — the ordered data channel makes first-message order reliable
- Pleasing detail: the #1344 exhaustive guard forced both dispatchers to handle the new variant at compile time — the mechanism working exactly as designed on its first real protocol change

## Already-versioned protocols — mismatch was indistinguishable from an outage

A version-bumped peer fails the structural validators, so the old side never answers: cherry → generic 30s handshake timeout; extension bridge → 10s timeout.

- **Cherry**: `isCherryVersionMismatch` in `cherry-host-protocol.ts` **and** the byte-identical SDK mirror (`protocol-mirror` invariant stays green). Both drop sites (webapp transport + host SDK `mount.ts`) now log `protocol version mismatch — update the older side` with peer/our versions
- **Extension bridge**: `isBridgeVersionMismatch` in `extension-bridge-protocol.ts`, wired into the webapp transport handshake and the SW's `handleBridgeMessage`

## Tests

- hello-first ordering, newer-peer warn, once-only legacy diagnosis (leader + follower)
- mismatch detectors (webapp + SDK copies), transport-level distinct-warn on a v2 envelope
- test fakes filter the hello handshake in `parseSent()` so existing assertions stay focused; hello tests read the raw sent array
- fixes a pre-existing `CDPConnectOptions` type error in `extension-bridge-transport.test.ts` (#1337 class)

## Verification

`npm run lint` / `npm run typecheck` green; webapp scoops+cdp (1,372), cherry (54), chrome-extension (527) suites green; cherry, webapp, and extension builds green.

## Cross-runtime parity

iOS receives `hello` as `.unknown` (safe no-op). The Swift-side `hello` case and unknown-type logging land with the golden-fixture corpus in #1333 — that issue is now the single remaining place the Swift mirror needs mechanical enforcement.
