### PR TITLE
fix(protocol): golden-fixture corpus for the Swift mirror + iOS tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1015,6 +1015,9 @@ jobs:
       (needs.changes.outputs.ios-app == 'true' ||
       needs.changes.outputs.swift-config == 'true')
     runs-on: macos-latest
+    # Simulator boots can wedge on fresh runner images; fail fast instead of
+    # holding the merge queue for the 6h default.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install SwiftLint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1040,6 +1040,22 @@ jobs:
             -scheme SliccFollower \
             -destination 'generic/platform=iOS Simulator' \
             CODE_SIGNING_ALLOWED=NO
+      - name: Test (golden-fixture protocol corpus + unit tests)
+        run: |
+          set -o pipefail
+          cd packages/ios-app
+          UDID=$(xcrun simctl list devices available --json \
+            | jq -r '[.devices[][] | select(.isAvailable and (.name | test("iPhone")))] | first | .udid')
+          if [ -z "$UDID" ] || [ "$UDID" = "null" ]; then
+            echo '::error::No available iPhone simulator on this runner'
+            exit 1
+          fi
+          echo "Using simulator $UDID"
+          xcodebuild test \
+            -project SliccFollower.xcodeproj \
+            -scheme SliccFollower \
+            -destination "platform=iOS Simulator,id=$UDID" \
+            CODE_SIGNING_ALLOWED=NO
 
   global-install:
     needs: changes

--- a/knip.json
+++ b/knip.json
@@ -49,6 +49,7 @@
       "ignore": [
         "src/types/**",
         "src/globals.d.ts",
+        "src/scoops/tray-sync-protocol-corpus.ts",
         "tests/e2e/**",
         "tests/integration/**",
         "tests/test-dips.mjs"

--- a/packages/dev-tools/tools/generate-tray-sync-corpus.ts
+++ b/packages/dev-tools/tools/generate-tray-sync-corpus.ts
@@ -1,0 +1,24 @@
+/**
+ * Regenerate the tray-sync golden-fixture corpus JSON from its TS source of
+ * truth (`packages/webapp/src/scoops/tray-sync-protocol-corpus.ts`).
+ *
+ * Usage: npx tsx packages/dev-tools/tools/generate-tray-sync-corpus.ts
+ *
+ * The vitest guard (`packages/webapp/tests/scoops/tray-sync-corpus.test.ts`)
+ * fails whenever the checked-in JSON drifts from the TS module; running this
+ * script is the fix it suggests.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildCorpusDocument } from '../../webapp/src/scoops/tray-sync-protocol-corpus.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const out = resolve(
+  here,
+  '../../ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json'
+);
+
+writeFileSync(out, `${JSON.stringify(buildCorpusDocument(), null, 2)}\n`);
+console.log(`Wrote ${out}`);

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -46,6 +46,17 @@ iOS mirrors the cherry-target wire surface even though it cannot _host_ a cherry
 
 The doc-comment headers above the `LeaderToFollowerMessage` and `FollowerToLeaderMessage` enum declarations in `SyncProtocol.swift` declare the omission explicitly — `// MARK: -` boundaries are the stable anchors; line numbers shift whenever the headers expand.
 
+**Mechanical enforcement (golden-fixture corpus):** every variant of both TS
+unions has a fixture and an explicit iOS expectation in
+`packages/webapp/src/scoops/tray-sync-protocol-corpus.ts` (mapped types — a
+new variant fails typecheck until it gets both). The derived JSON at
+`SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json` is
+decoded by BOTH suites: the webapp vitest test
+(`tray-sync-corpus.test.ts`, guards JSON ↔ TS module) and
+`SyncProtocolCorpusTests.swift` (guards JSON ↔ this decoder, run in CI via
+`xcodebuild test` on a simulator). Regenerate the JSON with
+`npx tsx packages/dev-tools/tools/generate-tray-sync-corpus.ts`.
+
 When you change the protocol:
 
 1. Update the TS union in `tray-sync-protocol.ts`.
@@ -54,9 +65,9 @@ When you change the protocol:
 4. Update each follower that needs to handle the new message:
    - **Browser follower (TS)**: extend the `handleLeaderMessage` switch in `tray-follower-sync.ts`, plus the page-side controller wiring if the change is user-visible.
    - **iOS follower (Swift)**: edit `AppState.handleDataChannelMessage`. That's the only live dispatch point — every message (including chat events like `agent_event`, `snapshot`, `user_message_echo`) flows through it today. `FollowerSyncManager.swift` is dead code preserved for now; do NOT add new behavior there.
-5. Bump tests on both sides. Note: `swift test` is unavailable today (no XCTest target), so Swift parity is enforced by inspection until a test target lands.
+5. Add the variant's fixture + iOS expectation to `tray-sync-protocol-corpus.ts`, regenerate the corpus JSON, and bump tests on both sides. The `SliccFollowerTests` bundle runs in CI via `xcodebuild test` on an iOS Simulator (plain `swift test` still cannot run on a macOS host — the package depends on an iOS-only WebRTC binary).
 
-Skipping the iOS update lets `LeaderToFollowerMessage.init(from:)` quietly drop the new message via the `.unknown` case — no crash, no log, the feature just doesn't reach the iOS user. This is the most common form of protocol drift in this codebase.
+Skipping the iOS update now fails `SyncProtocolCorpusTests` in CI instead of quietly dropping the new message via the `.unknown` case (the pre-corpus era's most common form of protocol drift — `theme.apply` shipped exactly that way). Unknown leader message types are also logged at warning now.
 
 ## What this app supports vs the browser follower
 

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3A9E122F6A6C4C0F6258C5C6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A069AA812629AC5FE70AC9 /* SettingsView.swift */; };
 		3EDEBD047CEC3F24BC3ED785 /* SliccFollowerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D4AD0E32B059DB9EABFF3E /* SliccFollowerApp.swift */; };
 		44FAA1B19D8705A9AAD4D458 /* chat.html in Resources */ = {isa = PBXBuildFile; fileRef = A47A1376F89AB8ECBC3F688B /* chat.html */; };
+		472BB1BEB4E248916156C9EE /* tray-sync-corpus.json in Resources */ = {isa = PBXBuildFile; fileRef = FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */; };
 		4874F8858460397F336DE469 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = CEF104FB1C3EDA0B98BC5FFF /* WebRTC */; };
 		487756D13ED6B5D4FB9FF6A0 /* TrayFollowerConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93EE217FAA3F9F7DD3A0B07F /* TrayFollowerConnector.swift */; };
 		4BA93B0DC88934132A09F1D6 /* FollowerSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82060520ADE3CE44E0D0FAE0 /* FollowerSyncManager.swift */; };
@@ -38,11 +39,23 @@
 		B4A19D759C5C4CDDFFA1FC35 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8BFCDA8C3F71C0A853D573 /* ContentView.swift */; };
 		BBF4C5A147E77FE534564A87 /* SprinkleSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407939337779F91986E8DAB3 /* SprinkleSidebarView.swift */; };
 		C43F5710585B9C800CAAA0A2 /* ConnectionStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 940DB17683937E3DAE6E914C /* ConnectionStatusView.swift */; };
+		CB6A8F9EEAD1D4DAA552E0EC /* SyncProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */; };
 		D2A85DC611A43443DEC75989 /* TraySignaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E70132BA0E6C4BC99D8CB73 /* TraySignaling.swift */; };
 		E9A8037C43172F9E94827567 /* chat.js in Resources */ = {isa = PBXBuildFile; fileRef = 80B1AD93046CF0476B3BBC39 /* chat.js */; };
 		F5AC500C53CC1A9251A5718B /* SprinkleWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C3A976D441E4BB628F2183 /* SprinkleWebView.swift */; };
+		F908DA74A70E1C7F16EC6AD8 /* SyncProtocolCorpusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */; };
 		FBCB39B163E63ED4E5CA70C6 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4C27643E1CF51B1F1B38003 /* AVFoundation.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		30E5A34726196B59C05D18F4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 54B6C2249B6DB4AE685DD53E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DF5C349429D85D6ADB077CD0;
+			remoteInfo = SliccFollower;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		11B186EDFDE184DC8B3215C4 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
@@ -52,6 +65,7 @@
 		2EDB6F858D918DBBE06D4702 /* TrayTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayTypes.swift; sourceTree = "<group>"; };
 		39ADD0645C7DD3B30664E997 /* TabsCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsCarouselView.swift; sourceTree = "<group>"; };
 		3BA9A527E2D4BBCE1BDFA89C /* ChatFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFixture.swift; sourceTree = "<group>"; };
+		3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocolTests.swift; sourceTree = "<group>"; };
 		3FE6B46ECEC5C79FA6D986F9 /* CDPTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDPTarget.swift; sourceTree = "<group>"; };
 		407939337779F91986E8DAB3 /* SprinkleSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SprinkleSidebarView.swift; sourceTree = "<group>"; };
 		434BBAD25E91BD0B7D626821 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -65,6 +79,7 @@
 		82060520ADE3CE44E0D0FAE0 /* FollowerSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowerSyncManager.swift; sourceTree = "<group>"; };
 		93EE217FAA3F9F7DD3A0B07F /* TrayFollowerConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayFollowerConnector.swift; sourceTree = "<group>"; };
 		940DB17683937E3DAE6E914C /* ConnectionStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatusView.swift; sourceTree = "<group>"; };
+		9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocolCorpusTests.swift; sourceTree = "<group>"; };
 		A47A1376F89AB8ECBC3F688B /* chat.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = chat.html; sourceTree = "<group>"; };
 		A69E83B7BB267C230C892A29 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AF78C09597C5D63A373EB126 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
@@ -77,9 +92,11 @@
 		C9AF8A8A50FCC9C2DBECA0CF /* WebRTCManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCManager.swift; sourceTree = "<group>"; };
 		C9C3A976D441E4BB628F2183 /* SprinkleWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SprinkleWebView.swift; sourceTree = "<group>"; };
 		CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBar.swift; sourceTree = "<group>"; };
+		CFEC70BAB27CC325BCD99C01 /* SliccFollowerTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SliccFollowerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0052066D742EEE8123EDE79 /* chat.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = chat.css; sourceTree = "<group>"; };
 		F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F0A069AA812629AC5FE70AC9 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tray-sync-corpus.json"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +113,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		32BEF7BC73FC1288DC470211 /* SliccFollowerTests */ = {
+			isa = PBXGroup;
+			children = (
+				9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */,
+				3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */,
+				52A9B6A8BE5EE73A5DF4470C /* Fixtures */,
+			);
+			name = SliccFollowerTests;
+			path = SliccFollower/Tests/SliccFollowerTests;
+			sourceTree = "<group>";
+		};
 		465A70583C8607C07D58E04D /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -109,6 +137,7 @@
 			isa = PBXGroup;
 			children = (
 				C00DD8A5F90DA65983AA6601 /* SliccFollower.app */,
+				CFEC70BAB27CC325BCD99C01 /* SliccFollowerTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -123,10 +152,19 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		52A9B6A8BE5EE73A5DF4470C /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */,
+			);
+			path = Fixtures;
+			sourceTree = "<group>";
+		};
 		645B35912FE46A12B4225E91 = {
 			isa = PBXGroup;
 			children = (
 				BB5014359700AC04F578180A /* SliccFollower */,
+				32BEF7BC73FC1288DC470211 /* SliccFollowerTests */,
 				B2AAEACBF84A968A5C6054DD /* Frameworks */,
 				4F9716065FA89F76CAF30D9E /* Products */,
 			);
@@ -248,6 +286,25 @@
 			productReference = C00DD8A5F90DA65983AA6601 /* SliccFollower.app */;
 			productType = "com.apple.product-type.application";
 		};
+		EF35FD5A64E737F1EEFDEDE2 /* SliccFollowerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ECE10093593A02C414E5487E /* Build configuration list for PBXNativeTarget "SliccFollowerTests" */;
+			buildPhases = (
+				BE71480B5ED2CF2B18E60CD1 /* Sources */,
+				5FE233C93C37697D9A3B4C10 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				848263A7AC089AF8851BD101 /* PBXTargetDependency */,
+			);
+			name = SliccFollowerTests;
+			packageProductDependencies = (
+			);
+			productName = SliccFollowerTests;
+			productReference = CFEC70BAB27CC325BCD99C01 /* SliccFollowerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -277,6 +334,7 @@
 			projectRoot = "";
 			targets = (
 				DF5C349429D85D6ADB077CD0 /* SliccFollower */,
+				EF35FD5A64E737F1EEFDEDE2 /* SliccFollowerTests */,
 			);
 		};
 /* End PBXProject section */
@@ -291,6 +349,14 @@
 				07D3C6559F4B00E26067D5C4 /* chat.css in Resources */,
 				44FAA1B19D8705A9AAD4D458 /* chat.html in Resources */,
 				E9A8037C43172F9E94827567 /* chat.js in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5FE233C93C37697D9A3B4C10 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				472BB1BEB4E248916156C9EE /* tray-sync-corpus.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -331,7 +397,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BE71480B5ED2CF2B18E60CD1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F908DA74A70E1C7F16EC6AD8 /* SyncProtocolCorpusTests.swift in Sources */,
+				CB6A8F9EEAD1D4DAA552E0EC /* SyncProtocolTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		848263A7AC089AF8851BD101 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DF5C349429D85D6ADB077CD0 /* SliccFollower */;
+			targetProxy = 30E5A34726196B59C05D18F4 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		06C3FEC686A41AB83DA91216 /* Release */ = {
@@ -354,7 +437,27 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		3456B9AFABD93C2B8EF1B898 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.sliccy.follower.tests;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SliccFollower.app/SliccFollower";
 			};
 			name = Release;
 		};
@@ -439,7 +542,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -511,6 +614,26 @@
 			};
 			name = Debug;
 		};
+		D32C961F5ABE2A1D6FF64AAB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.sliccy.follower.tests;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SliccFollower.app/SliccFollower";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -532,6 +655,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		ECE10093593A02C414E5487E /* Build configuration list for PBXNativeTarget "SliccFollowerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D32C961F5ABE2A1D6FF64AAB /* Debug */,
+				3456B9AFABD93C2B8EF1B898 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -540,7 +672,7 @@
 			repositoryURL = "https://github.com/stasel/WebRTC.git";
 			requirement = {
 				kind = exactVersion;
-				version = 147.0.0;
+				version = 149.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/packages/ios-app/SliccFollower.xcodeproj/xcshareddata/xcschemes/SliccFollower.xcscheme
+++ b/packages/ios-app/SliccFollower.xcodeproj/xcshareddata/xcschemes/SliccFollower.xcscheme
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DF5C349429D85D6ADB077CD0"
+               BuildableName = "SliccFollower.app"
+               BlueprintName = "SliccFollower"
+               ReferencedContainer = "container:SliccFollower.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF35FD5A64E737F1EEFDEDE2"
+               BuildableName = "SliccFollowerTests.xctest"
+               BlueprintName = "SliccFollowerTests"
+               ReferencedContainer = "container:SliccFollower.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DF5C349429D85D6ADB077CD0"
+            BuildableName = "SliccFollower.app"
+            BlueprintName = "SliccFollower"
+            ReferencedContainer = "container:SliccFollower.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF35FD5A64E737F1EEFDEDE2"
+               BuildableName = "SliccFollowerTests.xctest"
+               BlueprintName = "SliccFollowerTests"
+               ReferencedContainer = "container:SliccFollower.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DF5C349429D85D6ADB077CD0"
+            BuildableName = "SliccFollower.app"
+            BlueprintName = "SliccFollower"
+            ReferencedContainer = "container:SliccFollower.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DF5C349429D85D6ADB077CD0"
+            BuildableName = "SliccFollower.app"
+            BlueprintName = "SliccFollower"
+            ReferencedContainer = "container:SliccFollower.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -557,6 +557,9 @@ class AppState: ObservableObject {
         )
         Task { await keepalive?.start() }
 
+        // Version handshake first — additive; legacy leaders drop it harmlessly.
+        sendToLeader(.hello(protocolVersion: traySyncProtocolVersion, runtime: "slicc-ios"))
+
         // Request initial snapshot.
         sendToLeader(.requestSnapshot(scoopJid: nil))
     }
@@ -718,9 +721,29 @@ class AppState: ObservableObject {
             // switch stays exhaustive and a future cherry-on-iOS path has a seam.
             logger.debug("Ignoring cherry.slicc_event for target=\(targetId) name=\(name) (cherry pages not hosted on iOS)")
 
-        case .unknown:
-            logger.debug("Unknown message type received")
-            break  // Silently ignore unhandled message types
+        case .themeApply:
+            // Documented no-op: iOS themes natively via SwiftUI and does not
+            // apply web theme JSON. Decoded (not `.unknown`) so protocol
+            // parity is explicit — this was the drift that shipped silently.
+            logger.debug("Ignoring theme.apply (iOS uses native theming)")
+
+        case let .hello(protocolVersion, runtime):
+            handleLeaderHello(protocolVersion: protocolVersion, runtime: runtime)
+
+        case let .unknown(type):
+            // Protocol drift safety net — mirror of the TS dispatchers' warn.
+            logger.warning("Unknown leader message type — skewed leader? type=\(type)")
+        }
+    }
+
+    /// Record the leader's `hello` version handshake. Warn when the leader is
+    /// newer than this build — the skew otherwise surfaces only as silently
+    /// missing features.
+    private func handleLeaderHello(protocolVersion: Int, runtime: String?) {
+        if protocolVersion > traySyncProtocolVersion {
+            logger.warning("Leader speaks a newer tray sync protocol (v\(protocolVersion) vs v\(traySyncProtocolVersion)) — update this app")
+        } else {
+            logger.info("Leader hello: protocol v\(protocolVersion) runtime=\(runtime ?? "?")")
         }
     }
 

--- a/packages/ios-app/SliccFollower/Models/SyncProtocol.swift
+++ b/packages/ios-app/SliccFollower/Models/SyncProtocol.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// Mirrors `TRAY_SYNC_PROTOCOL_VERSION` from tray-sync-protocol.ts. Exchanged
+/// via the additive `hello` message both sides send on channel open.
+let traySyncProtocolVersion = 1
+
 // MARK: - AgentEvent
 
 /// Mirrors AgentEvent from packages/webapp/src/ui/types.ts
@@ -191,6 +195,11 @@ enum LeaderToFollowerMessage: Codable {
     case tabOpen(requestId: String, url: String)
     case previewOpen(requestId: String, url: String)
     case cherrySliccEvent(targetId: String, name: String, detail: AnyCodable?)
+    /// Leader theme broadcast. iOS decodes it (protocol parity) but applies
+    /// native SwiftUI theming instead of web theme JSON — see AppState.
+    case themeApply(themeJson: String?)
+    /// Additive version handshake (`hello`) — both sides send it first.
+    case hello(protocolVersion: Int, runtime: String?)
     case ping
     case pong
     case unknown(type: String)
@@ -202,6 +211,7 @@ enum LeaderToFollowerMessage: Codable {
         case requestId, sprinkleName, content, data
         case localTargetId, method, params, sessionId, targets, url
         case targetId, name, detail
+        case themeJson, protocolVersion, runtime
     }
 
     init(from decoder: Decoder) throws {
@@ -285,6 +295,13 @@ enum LeaderToFollowerMessage: Codable {
                 targetId: try container.decode(String.self, forKey: .targetId),
                 name: try container.decode(String.self, forKey: .name),
                 detail: try container.decodeIfPresent(AnyCodable.self, forKey: .detail))
+        case "theme.apply":
+            self = .themeApply(
+                themeJson: try container.decodeIfPresent(String.self, forKey: .themeJson))
+        case "hello":
+            self = .hello(
+                protocolVersion: try container.decode(Int.self, forKey: .protocolVersion),
+                runtime: try container.decodeIfPresent(String.self, forKey: .runtime))
         case "ping":
             self = .ping
         case "pong":
@@ -367,6 +384,13 @@ enum LeaderToFollowerMessage: Codable {
             try container.encode(targetId, forKey: .targetId)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(detail, forKey: .detail)
+        case let .themeApply(themeJson):
+            try container.encode("theme.apply", forKey: .type)
+            try container.encodeIfPresent(themeJson, forKey: .themeJson)
+        case let .hello(protocolVersion, runtime):
+            try container.encode("hello", forKey: .type)
+            try container.encode(protocolVersion, forKey: .protocolVersion)
+            try container.encodeIfPresent(runtime, forKey: .runtime)
         case .ping:
             try container.encode("ping", forKey: .type)
         case .pong:
@@ -409,6 +433,8 @@ enum FollowerToLeaderMessage: Codable {
     case cdpEvent(method: String, params: AnyCodable, sessionId: String?)
     case tabOpened(requestId: String, targetId: String)
     case tabOpenError(requestId: String, error: String)
+    /// Additive version handshake (`hello`) — iOS sends it first on channel open.
+    case hello(protocolVersion: Int, runtime: String?)
     case ping
     case pong
 
@@ -417,6 +443,7 @@ enum FollowerToLeaderMessage: Codable {
         case requestId, sprinkleName, body, targetScoop
         case targets, runtimeId, result, error, chunkData, chunkIndex, totalChunks
         case method, params, sessionId, targetId, url
+        case protocolVersion, runtime
     }
 
     init(from decoder: Decoder) throws {
@@ -470,6 +497,10 @@ enum FollowerToLeaderMessage: Codable {
             self = .tabOpenError(
                 requestId: try container.decode(String.self, forKey: .requestId),
                 error: try container.decode(String.self, forKey: .error))
+        case "hello":
+            self = .hello(
+                protocolVersion: try container.decode(Int.self, forKey: .protocolVersion),
+                runtime: try container.decodeIfPresent(String.self, forKey: .runtime))
         case "ping":
             self = .ping
         case "pong":
@@ -532,6 +563,10 @@ enum FollowerToLeaderMessage: Codable {
             try container.encode("tab.open.error", forKey: .type)
             try container.encode(requestId, forKey: .requestId)
             try container.encode(error, forKey: .error)
+        case let .hello(protocolVersion, runtime):
+            try container.encode("hello", forKey: .type)
+            try container.encode(protocolVersion, forKey: .protocolVersion)
+            try container.encodeIfPresent(runtime, forKey: .runtime)
         case .ping:
             try container.encode("ping", forKey: .type)
         case .pong:
@@ -539,4 +574,3 @@ enum FollowerToLeaderMessage: Codable {
         }
     }
 }
-

--- a/packages/ios-app/SliccFollower/Sync/FollowerSyncManager.swift
+++ b/packages/ios-app/SliccFollower/Sync/FollowerSyncManager.swift
@@ -147,13 +147,14 @@ class FollowerSyncManager {
 
         case .scoopsList, .sprinklesList, .sprinkleContent, .sprinkleUpdate,
              .sprinkleReloaded, .cdpRequest, .targetsRegistry, .tabOpen,
-             .cherrySliccEvent, .previewOpen:
+             .cherrySliccEvent, .previewOpen, .themeApply, .hello:
             // Newer protocol messages — handled by AppState directly, not by this
             // legacy delegate-based sync manager. Ignored here.
             break
 
-        case .unknown:
-            break  // Silently ignore unhandled message types
+        case let .unknown(type):
+            // Protocol drift safety net — mirror of the TS dispatchers' warn.
+            logger.warning("Unknown leader message type — skewed leader? type=\(type)")
         }
     }
 

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json
@@ -1,0 +1,528 @@
+{
+  "traySyncProtocolVersion": 1,
+  "leaderToFollower": [
+    {
+      "type": "agent_event",
+      "ios": "decoded",
+      "message": {
+        "type": "agent_event",
+        "event": {
+          "type": "content_delta",
+          "messageId": "m2",
+          "text": "partial"
+        },
+        "scoopJid": "cone"
+      }
+    },
+    {
+      "type": "cdp.event",
+      "ios": "unknown",
+      "message": {
+        "type": "cdp.event",
+        "method": "Page.frameNavigated",
+        "params": {
+          "frame": {
+            "id": "f1"
+          }
+        }
+      }
+    },
+    {
+      "type": "cdp.request",
+      "ios": "decoded",
+      "message": {
+        "type": "cdp.request",
+        "requestId": "cdp-1",
+        "localTargetId": "tab1",
+        "method": "Page.navigate",
+        "params": {
+          "url": "https://example.com"
+        },
+        "sessionId": "sess-1"
+      }
+    },
+    {
+      "type": "cdp.response",
+      "ios": "unknown",
+      "message": {
+        "type": "cdp.response",
+        "requestId": "cdp-2",
+        "result": {
+          "ok": true
+        }
+      }
+    },
+    {
+      "type": "cherry.slicc_event",
+      "ios": "decoded",
+      "message": {
+        "type": "cherry.slicc_event",
+        "targetId": "cherry-1",
+        "name": "open-url",
+        "detail": {
+          "url": "https://example.com"
+        }
+      }
+    },
+    {
+      "type": "error",
+      "ios": "decoded",
+      "message": {
+        "type": "error",
+        "error": "boom"
+      }
+    },
+    {
+      "type": "fs.request",
+      "ios": "unknown",
+      "message": {
+        "type": "fs.request",
+        "requestId": "fs-1",
+        "request": {
+          "op": "readFile",
+          "path": "/workspace/notes.md",
+          "encoding": "utf-8"
+        }
+      }
+    },
+    {
+      "type": "fs.response",
+      "ios": "unknown",
+      "message": {
+        "type": "fs.response",
+        "requestId": "fs-2",
+        "response": {
+          "ok": true,
+          "data": {
+            "type": "void"
+          }
+        }
+      }
+    },
+    {
+      "type": "hello",
+      "ios": "decoded",
+      "message": {
+        "type": "hello",
+        "protocolVersion": 1,
+        "runtime": "slicc-standalone"
+      }
+    },
+    {
+      "type": "ping",
+      "ios": "decoded",
+      "message": {
+        "type": "ping"
+      }
+    },
+    {
+      "type": "pong",
+      "ios": "decoded",
+      "message": {
+        "type": "pong"
+      }
+    },
+    {
+      "type": "preview.open",
+      "ios": "decoded",
+      "message": {
+        "type": "preview.open",
+        "requestId": "prev-1",
+        "url": "https://x.sliccy.now/"
+      }
+    },
+    {
+      "type": "scoops.list",
+      "ios": "decoded",
+      "message": {
+        "type": "scoops.list",
+        "scoops": [
+          {
+            "jid": "cone",
+            "name": "sliccy",
+            "folder": "/workspace",
+            "isCone": true,
+            "assistantLabel": "Sliccy"
+          }
+        ],
+        "activeScoopJid": "cone"
+      }
+    },
+    {
+      "type": "snapshot",
+      "ios": "decoded",
+      "message": {
+        "type": "snapshot",
+        "messages": [
+          {
+            "id": "m1",
+            "role": "user",
+            "content": "hello",
+            "timestamp": 1750000000000
+          },
+          {
+            "id": "m2",
+            "role": "assistant",
+            "content": "hi there",
+            "timestamp": 1750000001000,
+            "source": "cone"
+          }
+        ],
+        "scoopJid": "cone"
+      }
+    },
+    {
+      "type": "snapshot_chunk",
+      "ios": "decoded",
+      "message": {
+        "type": "snapshot_chunk",
+        "chunkData": "{\"messages\":[],\"scoopJi",
+        "chunkIndex": 0,
+        "totalChunks": 2,
+        "scoopJid": "cone"
+      }
+    },
+    {
+      "type": "sprinkle.content",
+      "ios": "decoded",
+      "message": {
+        "type": "sprinkle.content",
+        "requestId": "req-1",
+        "sprinkleName": "todo",
+        "content": "<div>todo</div>",
+        "chunkIndex": 0,
+        "totalChunks": 1
+      }
+    },
+    {
+      "type": "sprinkle.reloaded",
+      "ios": "decoded",
+      "message": {
+        "type": "sprinkle.reloaded",
+        "sprinkleName": "todo"
+      }
+    },
+    {
+      "type": "sprinkle.update",
+      "ios": "decoded",
+      "message": {
+        "type": "sprinkle.update",
+        "sprinkleName": "todo",
+        "data": {
+          "counter": 1
+        }
+      }
+    },
+    {
+      "type": "sprinkles.list",
+      "ios": "decoded",
+      "message": {
+        "type": "sprinkles.list",
+        "sprinkles": [
+          {
+            "name": "todo",
+            "title": "Todo",
+            "path": "/workspace/sprinkles/todo.shtml",
+            "open": true,
+            "autoOpen": false
+          }
+        ]
+      }
+    },
+    {
+      "type": "status",
+      "ios": "decoded",
+      "message": {
+        "type": "status",
+        "scoopStatus": "processing"
+      }
+    },
+    {
+      "type": "tab.open",
+      "ios": "decoded",
+      "message": {
+        "type": "tab.open",
+        "requestId": "tab-1",
+        "url": "https://example.com"
+      }
+    },
+    {
+      "type": "tab.open.error",
+      "ios": "unknown",
+      "message": {
+        "type": "tab.open.error",
+        "requestId": "tab-3",
+        "error": "blocked"
+      }
+    },
+    {
+      "type": "tab.opened",
+      "ios": "unknown",
+      "message": {
+        "type": "tab.opened",
+        "requestId": "tab-2",
+        "targetId": "tab9"
+      }
+    },
+    {
+      "type": "targets.registry",
+      "ios": "decoded",
+      "message": {
+        "type": "targets.registry",
+        "targets": [
+          {
+            "targetId": "leader:tab1",
+            "localTargetId": "tab1",
+            "runtimeId": "leader",
+            "title": "Example",
+            "url": "https://example.com",
+            "isLocal": false,
+            "kind": "browser"
+          }
+        ]
+      }
+    },
+    {
+      "type": "theme.apply",
+      "ios": "decoded",
+      "message": {
+        "type": "theme.apply",
+        "themeJson": "{\"accent\":\"#ff0066\"}"
+      }
+    },
+    {
+      "type": "user_message_echo",
+      "ios": "decoded",
+      "message": {
+        "type": "user_message_echo",
+        "text": "echoed",
+        "messageId": "m3",
+        "scoopJid": "cone",
+        "attachments": [
+          {
+            "id": "a1",
+            "name": "notes.txt",
+            "mimeType": "text/plain",
+            "size": 5,
+            "kind": "text",
+            "text": "notes"
+          }
+        ]
+      }
+    }
+  ],
+  "followerToLeader": [
+    {
+      "type": "abort",
+      "ios": "decoded",
+      "message": {
+        "type": "abort"
+      }
+    },
+    {
+      "type": "cdp.event",
+      "ios": "decoded",
+      "message": {
+        "type": "cdp.event",
+        "method": "Page.loadEventFired",
+        "params": {
+          "timestamp": 1
+        },
+        "sessionId": "sess-1"
+      }
+    },
+    {
+      "type": "cdp.request",
+      "ios": "undecodable",
+      "message": {
+        "type": "cdp.request",
+        "requestId": "cdp-3",
+        "targetRuntimeId": "leader",
+        "localTargetId": "tab1",
+        "method": "Page.captureScreenshot"
+      }
+    },
+    {
+      "type": "cdp.response",
+      "ios": "decoded",
+      "message": {
+        "type": "cdp.response",
+        "requestId": "cdp-1",
+        "result": {
+          "frameId": "f1"
+        }
+      }
+    },
+    {
+      "type": "cherry.host_event",
+      "ios": "undecodable",
+      "message": {
+        "type": "cherry.host_event",
+        "targetId": "cherry-1",
+        "name": "form-submitted",
+        "detail": {
+          "fields": 2
+        }
+      }
+    },
+    {
+      "type": "fs.request",
+      "ios": "undecodable",
+      "message": {
+        "type": "fs.request",
+        "requestId": "fs-3",
+        "targetRuntimeId": "leader",
+        "request": {
+          "op": "exists",
+          "path": "/workspace"
+        }
+      }
+    },
+    {
+      "type": "fs.response",
+      "ios": "undecodable",
+      "message": {
+        "type": "fs.response",
+        "requestId": "fs-4",
+        "response": {
+          "ok": false,
+          "error": "ENOENT",
+          "code": "ENOENT"
+        }
+      }
+    },
+    {
+      "type": "hello",
+      "ios": "decoded",
+      "message": {
+        "type": "hello",
+        "protocolVersion": 1,
+        "runtime": "slicc-ios"
+      }
+    },
+    {
+      "type": "lick",
+      "ios": "undecodable",
+      "message": {
+        "type": "lick",
+        "event": {
+          "type": "navigate",
+          "navigateUrl": "https://www.sliccy.ai/handoff?handoff=x",
+          "timestamp": "2026-07-06T00:00:00Z",
+          "body": {}
+        }
+      }
+    },
+    {
+      "type": "ping",
+      "ios": "decoded",
+      "message": {
+        "type": "ping"
+      }
+    },
+    {
+      "type": "pong",
+      "ios": "decoded",
+      "message": {
+        "type": "pong"
+      }
+    },
+    {
+      "type": "request_snapshot",
+      "ios": "decoded",
+      "message": {
+        "type": "request_snapshot",
+        "scoopJid": "cone"
+      }
+    },
+    {
+      "type": "scoops.select",
+      "ios": "decoded",
+      "message": {
+        "type": "scoops.select",
+        "scoopJid": "cone"
+      }
+    },
+    {
+      "type": "sprinkle.fetch",
+      "ios": "decoded",
+      "message": {
+        "type": "sprinkle.fetch",
+        "requestId": "req-2",
+        "sprinkleName": "todo"
+      }
+    },
+    {
+      "type": "sprinkle.lick",
+      "ios": "decoded",
+      "message": {
+        "type": "sprinkle.lick",
+        "sprinkleName": "todo",
+        "body": {
+          "clicked": true
+        },
+        "targetScoop": "cone"
+      }
+    },
+    {
+      "type": "sprinkles.refresh",
+      "ios": "decoded",
+      "message": {
+        "type": "sprinkles.refresh"
+      }
+    },
+    {
+      "type": "tab.open",
+      "ios": "undecodable",
+      "message": {
+        "type": "tab.open",
+        "requestId": "tab-4",
+        "targetRuntimeId": "leader",
+        "url": "https://example.com"
+      }
+    },
+    {
+      "type": "tab.open.error",
+      "ios": "decoded",
+      "message": {
+        "type": "tab.open.error",
+        "requestId": "tab-1",
+        "error": "load failed"
+      }
+    },
+    {
+      "type": "tab.opened",
+      "ios": "decoded",
+      "message": {
+        "type": "tab.opened",
+        "requestId": "tab-1",
+        "targetId": "wk2"
+      }
+    },
+    {
+      "type": "targets.advertise",
+      "ios": "decoded",
+      "message": {
+        "type": "targets.advertise",
+        "targets": [
+          {
+            "targetId": "wk1",
+            "title": "Hosted tab",
+            "url": "https://example.com",
+            "kind": "browser"
+          }
+        ],
+        "runtimeId": "slicc-ios"
+      }
+    },
+    {
+      "type": "user_message",
+      "ios": "decoded",
+      "message": {
+        "type": "user_message",
+        "text": "hello from follower",
+        "messageId": "f-1"
+      }
+    }
+  ]
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json
@@ -1,5 +1,7 @@
 {
   "traySyncProtocolVersion": 1,
+  "leaderVariantCount": 26,
+  "followerVariantCount": 21,
   "leaderToFollower": [
     {
       "type": "agent_event",

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SyncProtocolCorpusTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SyncProtocolCorpusTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+import Foundation
+@testable import SliccFollower
+
+/// Golden-fixture corpus tests (#1294 P0-2).
+///
+/// Decodes every message variant of the tray sync wire protocol from
+/// `Fixtures/tray-sync-corpus.json` — the same bytes the TS suite
+/// (`packages/webapp/tests/scoops/tray-sync-corpus.test.ts`) verifies against
+/// the canonical TS unions — and asserts each variant's explicit iOS
+/// expectation:
+///  - `decoded`: `SyncProtocol.swift` must decode it to a real case.
+///  - `unknown`: TS-only leader→follower variant — must decode to `.unknown`.
+///  - `undecodable`: TS-only follower→leader variant — the decoder must throw.
+///
+/// A TS-side union change regenerates the corpus (the TS mapped types force a
+/// fixture + iOS decision per variant), so a variant this decoder mishandles
+/// fails HERE, in CI, instead of shipping as silently-dropped messages — the
+/// `theme.apply` drift class.
+final class SyncProtocolCorpusTests: XCTestCase {
+    private struct CorpusEntry: Decodable {
+        let type: String
+        let ios: String
+        // Raw JSON for the message re-extracted from the file separately.
+    }
+
+    private struct RawCorpus {
+        let traySyncProtocolVersion: Int
+        let leaderToFollower: [(type: String, ios: String, messageData: Data)]
+        let followerToLeader: [(type: String, ios: String, messageData: Data)]
+    }
+
+    private func loadCorpus() throws -> RawCorpus {
+        guard let url = Bundle(for: Self.self).url(forResource: "tray-sync-corpus", withExtension: "json") else {
+            throw XCTSkip("tray-sync-corpus.json missing from test bundle resources")
+        }
+        let data = try Data(contentsOf: url)
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let version = root["traySyncProtocolVersion"] as? Int,
+              let leader = root["leaderToFollower"] as? [[String: Any]],
+              let follower = root["followerToLeader"] as? [[String: Any]] else {
+            return RawCorpus(traySyncProtocolVersion: -1, leaderToFollower: [], followerToLeader: [])
+        }
+        func entries(_ items: [[String: Any]]) throws -> [(String, String, Data)] {
+            try items.map { item in
+                let type = item["type"] as? String ?? "<missing>"
+                let ios = item["ios"] as? String ?? "<missing>"
+                let messageData = try JSONSerialization.data(withJSONObject: item["message"] ?? [:])
+                return (type, ios, messageData)
+            }
+        }
+        return RawCorpus(
+            traySyncProtocolVersion: version,
+            leaderToFollower: try entries(leader),
+            followerToLeader: try entries(follower)
+        )
+    }
+
+    func testCorpusVersionMatchesThisBuild() throws {
+        let corpus = try loadCorpus()
+        XCTAssertEqual(
+            corpus.traySyncProtocolVersion, traySyncProtocolVersion,
+            "Corpus protocol version drifted from SyncProtocol.swift — regenerate / update the mirror")
+    }
+
+    func testCorpusIsNonEmpty() throws {
+        let corpus = try loadCorpus()
+        XCTAssertGreaterThan(corpus.leaderToFollower.count, 20)
+        XCTAssertGreaterThan(corpus.followerToLeader.count, 15)
+    }
+
+    func testLeaderToFollowerCorpusDecodesPerExpectation() throws {
+        let corpus = try loadCorpus()
+        let decoder = JSONDecoder()
+        for (type, ios, messageData) in corpus.leaderToFollower {
+            let decoded: LeaderToFollowerMessage
+            do {
+                decoded = try decoder.decode(LeaderToFollowerMessage.self, from: messageData)
+            } catch {
+                XCTFail("leaderToFollower '\(type)' failed to decode entirely: \(error)")
+                continue
+            }
+            let isUnknown: Bool
+            if case .unknown = decoded { isUnknown = true } else { isUnknown = false }
+            switch ios {
+            case "decoded":
+                XCTAssertFalse(
+                    isUnknown,
+                    "'\(type)' decoded to .unknown but the corpus expects a real case — SyncProtocol.swift is missing it (theme.apply drift class)")
+            case "unknown":
+                XCTAssertTrue(
+                    isUnknown,
+                    "'\(type)' decoded to a real case but the corpus marks it TS-only — update the corpus expectation in tray-sync-protocol-corpus.ts")
+            default:
+                XCTFail("'\(type)' has unexpected ios expectation '\(ios)'")
+            }
+        }
+    }
+
+    func testFollowerToLeaderCorpusDecodesPerExpectation() throws {
+        let corpus = try loadCorpus()
+        let decoder = JSONDecoder()
+        for (type, ios, messageData) in corpus.followerToLeader {
+            switch ios {
+            case "decoded":
+                XCTAssertNoThrow(
+                    try decoder.decode(FollowerToLeaderMessage.self, from: messageData),
+                    "'\(type)' should decode — SyncProtocol.swift is missing it")
+            case "undecodable":
+                XCTAssertThrowsError(
+                    try decoder.decode(FollowerToLeaderMessage.self, from: messageData),
+                    "'\(type)' decoded but the corpus marks it TS-only — update the corpus expectation in tray-sync-protocol-corpus.ts")
+            default:
+                XCTFail("'\(type)' has unexpected ios expectation '\(ios)'")
+            }
+        }
+    }
+
+    func testDecodedLeaderMessagesReencodeWithSameType() throws {
+        let corpus = try loadCorpus()
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+        for (type, ios, messageData) in corpus.leaderToFollower where ios == "decoded" {
+            let decoded = try decoder.decode(LeaderToFollowerMessage.self, from: messageData)
+            let reencoded = try encoder.encode(decoded)
+            let obj = try JSONSerialization.jsonObject(with: reencoded) as? [String: Any]
+            XCTAssertEqual(obj?["type"] as? String, type, "'\(type)' re-encoded with a different type tag")
+        }
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SyncProtocolCorpusTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SyncProtocolCorpusTests.swift
@@ -18,28 +18,34 @@ import Foundation
 /// fails HERE, in CI, instead of shipping as silently-dropped messages — the
 /// `theme.apply` drift class.
 final class SyncProtocolCorpusTests: XCTestCase {
-    private struct CorpusEntry: Decodable {
-        let type: String
-        let ios: String
-        // Raw JSON for the message re-extracted from the file separately.
+    private struct CorpusError: Error, CustomStringConvertible {
+        let description: String
     }
 
     private struct RawCorpus {
         let traySyncProtocolVersion: Int
+        let declaredLeaderVariantCount: Int
+        let declaredFollowerVariantCount: Int
         let leaderToFollower: [(type: String, ios: String, messageData: Data)]
         let followerToLeader: [(type: String, ios: String, messageData: Data)]
     }
 
     private func loadCorpus() throws -> RawCorpus {
+        // Fail HARD on a missing or malformed resource: a lost fixture copy
+        // (project.yml / pbxproj drift) must not turn every corpus test
+        // quietly green via a skip.
         guard let url = Bundle(for: Self.self).url(forResource: "tray-sync-corpus", withExtension: "json") else {
-            throw XCTSkip("tray-sync-corpus.json missing from test bundle resources")
+            throw CorpusError(
+                description: "tray-sync-corpus.json missing from test bundle — check the project.yml Fixtures copy")
         }
         let data = try Data(contentsOf: url)
         guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let version = root["traySyncProtocolVersion"] as? Int,
+              let leaderCount = root["leaderVariantCount"] as? Int,
+              let followerCount = root["followerVariantCount"] as? Int,
               let leader = root["leaderToFollower"] as? [[String: Any]],
               let follower = root["followerToLeader"] as? [[String: Any]] else {
-            return RawCorpus(traySyncProtocolVersion: -1, leaderToFollower: [], followerToLeader: [])
+            throw CorpusError(description: "tray-sync-corpus.json has an unexpected shape — regenerate it")
         }
         func entries(_ items: [[String: Any]]) throws -> [(String, String, Data)] {
             try items.map { item in
@@ -51,6 +57,8 @@ final class SyncProtocolCorpusTests: XCTestCase {
         }
         return RawCorpus(
             traySyncProtocolVersion: version,
+            declaredLeaderVariantCount: leaderCount,
+            declaredFollowerVariantCount: followerCount,
             leaderToFollower: try entries(leader),
             followerToLeader: try entries(follower)
         )
@@ -63,10 +71,19 @@ final class SyncProtocolCorpusTests: XCTestCase {
             "Corpus protocol version drifted from SyncProtocol.swift — regenerate / update the mirror")
     }
 
-    func testCorpusIsNonEmpty() throws {
+    func testCorpusCountsMatchDeclaredCounts() throws {
+        // The TS generator embeds the mapped-type-enforced variant counts; a
+        // truncated or stale JSON copy fails here instead of silently testing
+        // fewer variants than the unions declare.
         let corpus = try loadCorpus()
-        XCTAssertGreaterThan(corpus.leaderToFollower.count, 20)
-        XCTAssertGreaterThan(corpus.followerToLeader.count, 15)
+        XCTAssertEqual(corpus.leaderToFollower.count, corpus.declaredLeaderVariantCount)
+        XCTAssertEqual(corpus.followerToLeader.count, corpus.declaredFollowerVariantCount)
+        XCTAssertEqual(
+            Set(corpus.leaderToFollower.map(\.type)).count, corpus.leaderToFollower.count,
+            "duplicate leaderToFollower fixture types")
+        XCTAssertEqual(
+            Set(corpus.followerToLeader.map(\.type)).count, corpus.followerToLeader.count,
+            "duplicate followerToLeader fixture types")
     }
 
     func testLeaderToFollowerCorpusDecodesPerExpectation() throws {

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SyncProtocolTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SyncProtocolTests.swift
@@ -2,13 +2,10 @@ import XCTest
 import Foundation
 @testable import SliccFollower
 
-// NOTE: packages/ios-app/Package.swift does not yet declare an XCTest target,
-// so this file is not compiled by `swift test` today (see packages/ios-app/CLAUDE.md
-// — "Swift parity is enforced by inspection until a test target lands"). It is the
-// ready-to-wire seam for when an iOS test target is added under Xcode/CI with the
-// iOS SDK (the package depends on an iOS-only WebRTC binary, so `swift test` cannot
-// run on a plain macOS host). The assertions here were verified out-of-band by
-// compiling the Foundation-only protocol sources directly with swiftc.
+// Compiled into the `SliccFollowerTests` bundle (see project.yml) and run in CI
+// via `xcodebuild test` on an iOS Simulator — `swift test` cannot run on a plain
+// macOS host because the package depends on an iOS-only WebRTC binary. The
+// golden-fixture corpus suite lives in SyncProtocolCorpusTests.swift.
 final class SyncProtocolCherryTests: XCTestCase {
     func testRemoteTargetInfoDecodesCherryKindAndCapabilities() throws {
         let json = """

--- a/packages/ios-app/project.yml
+++ b/packages/ios-app/project.yml
@@ -17,10 +17,9 @@ targets:
     supportedDestinations: [iOS]
     sources:
       - path: SliccFollower
-        # Test sources (XCTest) must not compile into the app target — there is
-        # no XCTest test target yet (see packages/ios-app/CLAUDE.md), and the
-        # app target globs all of SliccFollower/. Excluding Tests/ keeps
-        # `xcodebuild build` green; the test file stays for a future test target.
+        # Test sources (XCTest) must not compile into the app target — they
+        # belong to the SliccFollowerTests bundle below, and the app target
+        # globs all of SliccFollower/.
         excludes:
           - Tests
     settings:
@@ -38,6 +37,26 @@ targets:
       - package: WebRTC
       - sdk: WebKit.framework
       - sdk: AVFoundation.framework
+  SliccFollowerTests:
+    type: bundle.unit-test
+    supportedDestinations: [iOS]
+    sources:
+      - path: SliccFollower/Tests/SliccFollowerTests
+    dependencies:
+      - target: SliccFollower
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.sliccy.follower.tests
+schemes:
+  SliccFollower:
+    build:
+      targets:
+        SliccFollower: all
+        SliccFollowerTests: [test]
+    test:
+      gatherCoverageData: false
+      targets:
+        - SliccFollowerTests
 packages:
   WebRTC:
     url: https://github.com/stasel/WebRTC.git

--- a/packages/webapp/src/scoops/tray-sync-protocol-corpus.ts
+++ b/packages/webapp/src/scoops/tray-sync-protocol-corpus.ts
@@ -381,6 +381,8 @@ export const FOLLOWER_TO_LEADER_CORPUS: FollowerCorpus = {
 /** Stable JSON document shared with the Swift test suite. */
 export function buildCorpusDocument(): {
   traySyncProtocolVersion: number;
+  leaderVariantCount: number;
+  followerVariantCount: number;
   leaderToFollower: Array<{ type: string; ios: string; message: unknown }>;
   followerToLeader: Array<{ type: string; ios: string; message: unknown }>;
 } {
@@ -390,6 +392,10 @@ export function buildCorpusDocument(): {
       .sort((a, b) => a.type.localeCompare(b.type));
   return {
     traySyncProtocolVersion: 1,
+    // Mapped-type-enforced variant counts; the Swift suite asserts the entry
+    // arrays match so a truncated/stale JSON copy fails loudly.
+    leaderVariantCount: Object.keys(LEADER_TO_FOLLOWER_CORPUS).length,
+    followerVariantCount: Object.keys(FOLLOWER_TO_LEADER_CORPUS).length,
     leaderToFollower: flatten(LEADER_TO_FOLLOWER_CORPUS),
     followerToLeader: flatten(FOLLOWER_TO_LEADER_CORPUS),
   };

--- a/packages/webapp/src/scoops/tray-sync-protocol-corpus.ts
+++ b/packages/webapp/src/scoops/tray-sync-protocol-corpus.ts
@@ -1,0 +1,396 @@
+/**
+ * Golden-fixture corpus for the tray sync wire protocol (#1294 P0-2).
+ *
+ * One representative fixture per message variant, in BOTH directions, plus an
+ * explicit iOS-mirror expectation for each. The mapped types below are the
+ * enforcement: adding a variant to `LeaderToFollowerMessage` /
+ * `FollowerToLeaderMessage` fails typecheck here until the variant gets a
+ * fixture AND an explicit iOS decision — the exact drift that shipped
+ * `theme.apply` silently dropped on iOS.
+ *
+ * The checked-in JSON derived from this module lives at
+ * `packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json`
+ * and is decoded by BOTH test suites:
+ *  - TS: `packages/webapp/tests/scoops/tray-sync-corpus.test.ts` asserts the
+ *    JSON file matches this module (regenerate with
+ *    `npx tsx packages/dev-tools/tools/generate-tray-sync-corpus.ts`).
+ *  - Swift: `SyncProtocolCorpusTests.swift` decodes every entry and asserts
+ *    the `ios` expectation against the real `SyncProtocol.swift` decoder.
+ *
+ * IMPORTANT: keep this module data-only (type-only imports) — the corpus
+ * generator executes it under plain tsx, outside the Vite define environment.
+ */
+
+import type { FollowerToLeaderMessage, LeaderToFollowerMessage } from './tray-sync-protocol.js';
+
+/**
+ * What the iOS mirror must do with a leader→follower variant:
+ * - `decoded`: `SyncProtocol.swift` decodes it to a real case (not `.unknown`).
+ * - `unknown`: TS-only variant — iOS deliberately decodes it to `.unknown`.
+ */
+export type IosLeaderDecodeExpectation = 'decoded' | 'unknown';
+
+/**
+ * What the iOS mirror must do with a follower→leader variant:
+ * - `decoded`: `SyncProtocol.swift` decodes it (iOS can also encode it).
+ * - `undecodable`: TS-only variant iOS never originates — its decoder throws.
+ */
+export type IosFollowerDecodeExpectation = 'decoded' | 'undecodable';
+
+type LeaderCorpus = {
+  [K in LeaderToFollowerMessage['type']]: {
+    ios: IosLeaderDecodeExpectation;
+    message: Extract<LeaderToFollowerMessage, { type: K }>;
+  };
+};
+
+type FollowerCorpus = {
+  [K in FollowerToLeaderMessage['type']]: {
+    ios: IosFollowerDecodeExpectation;
+    message: Extract<FollowerToLeaderMessage, { type: K }>;
+  };
+};
+
+export const LEADER_TO_FOLLOWER_CORPUS: LeaderCorpus = {
+  snapshot: {
+    ios: 'decoded',
+    message: {
+      type: 'snapshot',
+      messages: [
+        { id: 'm1', role: 'user', content: 'hello', timestamp: 1750000000000 },
+        {
+          id: 'm2',
+          role: 'assistant',
+          content: 'hi there',
+          timestamp: 1750000001000,
+          source: 'cone',
+        },
+      ],
+      scoopJid: 'cone',
+    },
+  },
+  snapshot_chunk: {
+    ios: 'decoded',
+    message: {
+      type: 'snapshot_chunk',
+      chunkData: '{"messages":[],"scoopJi',
+      chunkIndex: 0,
+      totalChunks: 2,
+      scoopJid: 'cone',
+    },
+  },
+  agent_event: {
+    ios: 'decoded',
+    message: {
+      type: 'agent_event',
+      event: { type: 'content_delta', messageId: 'm2', text: 'partial' },
+      scoopJid: 'cone',
+    },
+  },
+  user_message_echo: {
+    ios: 'decoded',
+    message: {
+      type: 'user_message_echo',
+      text: 'echoed',
+      messageId: 'm3',
+      scoopJid: 'cone',
+      attachments: [
+        {
+          id: 'a1',
+          name: 'notes.txt',
+          mimeType: 'text/plain',
+          size: 5,
+          kind: 'text',
+          text: 'notes',
+        },
+      ],
+    },
+  },
+  status: { ios: 'decoded', message: { type: 'status', scoopStatus: 'processing' } },
+  error: { ios: 'decoded', message: { type: 'error', error: 'boom' } },
+  'scoops.list': {
+    ios: 'decoded',
+    message: {
+      type: 'scoops.list',
+      scoops: [
+        {
+          jid: 'cone',
+          name: 'sliccy',
+          folder: '/workspace',
+          isCone: true,
+          assistantLabel: 'Sliccy',
+        },
+      ],
+      activeScoopJid: 'cone',
+    },
+  },
+  'sprinkles.list': {
+    ios: 'decoded',
+    message: {
+      type: 'sprinkles.list',
+      sprinkles: [
+        {
+          name: 'todo',
+          title: 'Todo',
+          path: '/workspace/sprinkles/todo.shtml',
+          open: true,
+          autoOpen: false,
+        },
+      ],
+    },
+  },
+  'sprinkle.content': {
+    ios: 'decoded',
+    message: {
+      type: 'sprinkle.content',
+      requestId: 'req-1',
+      sprinkleName: 'todo',
+      content: '<div>todo</div>',
+      chunkIndex: 0,
+      totalChunks: 1,
+    },
+  },
+  'sprinkle.update': {
+    ios: 'decoded',
+    message: { type: 'sprinkle.update', sprinkleName: 'todo', data: { counter: 1 } },
+  },
+  'sprinkle.reloaded': {
+    ios: 'decoded',
+    message: { type: 'sprinkle.reloaded', sprinkleName: 'todo' },
+  },
+  'targets.registry': {
+    ios: 'decoded',
+    message: {
+      type: 'targets.registry',
+      targets: [
+        {
+          targetId: 'leader:tab1',
+          localTargetId: 'tab1',
+          runtimeId: 'leader',
+          title: 'Example',
+          url: 'https://example.com',
+          isLocal: false,
+          kind: 'browser',
+        },
+      ],
+    },
+  },
+  'cdp.request': {
+    ios: 'decoded',
+    message: {
+      type: 'cdp.request',
+      requestId: 'cdp-1',
+      localTargetId: 'tab1',
+      method: 'Page.navigate',
+      params: { url: 'https://example.com' },
+      sessionId: 'sess-1',
+    },
+  },
+  // Reply path for follower-originated CDP — iOS never originates, so its
+  // mirror deliberately decodes these to `.unknown`.
+  'cdp.response': {
+    ios: 'unknown',
+    message: { type: 'cdp.response', requestId: 'cdp-2', result: { ok: true } },
+  },
+  'cdp.event': {
+    ios: 'unknown',
+    message: { type: 'cdp.event', method: 'Page.frameNavigated', params: { frame: { id: 'f1' } } },
+  },
+  'tab.open': {
+    ios: 'decoded',
+    message: { type: 'tab.open', requestId: 'tab-1', url: 'https://example.com' },
+  },
+  'tab.opened': {
+    ios: 'unknown',
+    message: { type: 'tab.opened', requestId: 'tab-2', targetId: 'tab9' },
+  },
+  'tab.open.error': {
+    ios: 'unknown',
+    message: { type: 'tab.open.error', requestId: 'tab-3', error: 'blocked' },
+  },
+  'preview.open': {
+    ios: 'decoded',
+    message: { type: 'preview.open', requestId: 'prev-1', url: 'https://x.sliccy.now/' },
+  },
+  // Federated FS is TS-only (no VFS on iOS).
+  'fs.request': {
+    ios: 'unknown',
+    message: {
+      type: 'fs.request',
+      requestId: 'fs-1',
+      request: { op: 'readFile', path: '/workspace/notes.md', encoding: 'utf-8' },
+    },
+  },
+  'fs.response': {
+    ios: 'unknown',
+    message: {
+      type: 'fs.response',
+      requestId: 'fs-2',
+      response: { ok: true, data: { type: 'void' } },
+    },
+  },
+  'cherry.slicc_event': {
+    ios: 'decoded',
+    message: {
+      type: 'cherry.slicc_event',
+      targetId: 'cherry-1',
+      name: 'open-url',
+      detail: { url: 'https://example.com' },
+    },
+  },
+  'theme.apply': {
+    ios: 'decoded',
+    message: { type: 'theme.apply', themeJson: '{"accent":"#ff0066"}' },
+  },
+  hello: {
+    ios: 'decoded',
+    message: { type: 'hello', protocolVersion: 1, runtime: 'slicc-standalone' },
+  },
+  ping: { ios: 'decoded', message: { type: 'ping' } },
+  pong: { ios: 'decoded', message: { type: 'pong' } },
+};
+
+export const FOLLOWER_TO_LEADER_CORPUS: FollowerCorpus = {
+  user_message: {
+    ios: 'decoded',
+    message: { type: 'user_message', text: 'hello from follower', messageId: 'f-1' },
+  },
+  abort: { ios: 'decoded', message: { type: 'abort' } },
+  request_snapshot: {
+    ios: 'decoded',
+    message: { type: 'request_snapshot', scoopJid: 'cone' },
+  },
+  'scoops.select': { ios: 'decoded', message: { type: 'scoops.select', scoopJid: 'cone' } },
+  'sprinkles.refresh': { ios: 'decoded', message: { type: 'sprinkles.refresh' } },
+  'sprinkle.fetch': {
+    ios: 'decoded',
+    message: { type: 'sprinkle.fetch', requestId: 'req-2', sprinkleName: 'todo' },
+  },
+  'sprinkle.lick': {
+    ios: 'decoded',
+    message: {
+      type: 'sprinkle.lick',
+      sprinkleName: 'todo',
+      body: { clicked: true },
+      targetScoop: 'cone',
+    },
+  },
+  // TS-only: iOS has no lick sources; its decoder throws on these.
+  lick: {
+    ios: 'undecodable',
+    message: {
+      type: 'lick',
+      event: {
+        type: 'navigate',
+        navigateUrl: 'https://www.sliccy.ai/handoff?handoff=x',
+        timestamp: '2026-07-06T00:00:00Z',
+        body: {},
+      },
+    },
+  },
+  'targets.advertise': {
+    ios: 'decoded',
+    message: {
+      type: 'targets.advertise',
+      targets: [
+        {
+          targetId: 'wk1',
+          title: 'Hosted tab',
+          url: 'https://example.com',
+          kind: 'browser',
+        },
+      ],
+      runtimeId: 'slicc-ios',
+    },
+  },
+  // Follower-originated CDP / tab.open / FS are TS-only (iOS only responds).
+  'cdp.request': {
+    ios: 'undecodable',
+    message: {
+      type: 'cdp.request',
+      requestId: 'cdp-3',
+      targetRuntimeId: 'leader',
+      localTargetId: 'tab1',
+      method: 'Page.captureScreenshot',
+    },
+  },
+  'cdp.response': {
+    ios: 'decoded',
+    message: { type: 'cdp.response', requestId: 'cdp-1', result: { frameId: 'f1' } },
+  },
+  'cdp.event': {
+    ios: 'decoded',
+    message: {
+      type: 'cdp.event',
+      method: 'Page.loadEventFired',
+      params: { timestamp: 1 },
+      sessionId: 'sess-1',
+    },
+  },
+  'tab.open': {
+    ios: 'undecodable',
+    message: {
+      type: 'tab.open',
+      requestId: 'tab-4',
+      targetRuntimeId: 'leader',
+      url: 'https://example.com',
+    },
+  },
+  'tab.opened': {
+    ios: 'decoded',
+    message: { type: 'tab.opened', requestId: 'tab-1', targetId: 'wk2' },
+  },
+  'tab.open.error': {
+    ios: 'decoded',
+    message: { type: 'tab.open.error', requestId: 'tab-1', error: 'load failed' },
+  },
+  'fs.request': {
+    ios: 'undecodable',
+    message: {
+      type: 'fs.request',
+      requestId: 'fs-3',
+      targetRuntimeId: 'leader',
+      request: { op: 'exists', path: '/workspace' },
+    },
+  },
+  'fs.response': {
+    ios: 'undecodable',
+    message: {
+      type: 'fs.response',
+      requestId: 'fs-4',
+      response: { ok: false, error: 'ENOENT', code: 'ENOENT' },
+    },
+  },
+  'cherry.host_event': {
+    ios: 'undecodable',
+    message: {
+      type: 'cherry.host_event',
+      targetId: 'cherry-1',
+      name: 'form-submitted',
+      detail: { fields: 2 },
+    },
+  },
+  hello: {
+    ios: 'decoded',
+    message: { type: 'hello', protocolVersion: 1, runtime: 'slicc-ios' },
+  },
+  ping: { ios: 'decoded', message: { type: 'ping' } },
+  pong: { ios: 'decoded', message: { type: 'pong' } },
+};
+
+/** Stable JSON document shared with the Swift test suite. */
+export function buildCorpusDocument(): {
+  traySyncProtocolVersion: number;
+  leaderToFollower: Array<{ type: string; ios: string; message: unknown }>;
+  followerToLeader: Array<{ type: string; ios: string; message: unknown }>;
+} {
+  const flatten = (corpus: Record<string, { ios: string; message: { type: string } }>) =>
+    Object.values(corpus)
+      .map(({ ios, message }) => ({ type: message.type, ios, message: message as unknown }))
+      .sort((a, b) => a.type.localeCompare(b.type));
+  return {
+    traySyncProtocolVersion: 1,
+    leaderToFollower: flatten(LEADER_TO_FOLLOWER_CORPUS),
+    followerToLeader: flatten(FOLLOWER_TO_LEADER_CORPUS),
+  };
+}

--- a/packages/webapp/src/scoops/tray-sync-protocol.ts
+++ b/packages/webapp/src/scoops/tray-sync-protocol.ts
@@ -16,9 +16,12 @@
  * TS-only; iOS responds to leader-initiated `cdp.request` / `tab.open` (and
  * sends back `cdp.response` / `cdp.event` / `tab.opened`) but does NOT
  * originate either, so the follower-initiated CDP/tab.open paths are also
- * TS-only. See `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture"
- * for the exact matrix and `packages/ios-app/CLAUDE.md` for the mirror-update
- * checklist.
+ * TS-only. The per-variant iOS decision is MECHANICALLY enforced by the
+ * golden-fixture corpus (`tray-sync-protocol-corpus.ts` →
+ * `packages/ios-app/.../Fixtures/tray-sync-corpus.json`, decoded by both the
+ * vitest and XCTest suites) — adding a variant here fails typecheck there
+ * until it gets a fixture + explicit iOS expectation. See
+ * `packages/ios-app/CLAUDE.md` "Protocol Mirror Invariant".
  */
 
 import type { AgentEvent } from '../core/agent-types.js';

--- a/packages/webapp/tests/scoops/tray-sync-corpus.test.ts
+++ b/packages/webapp/tests/scoops/tray-sync-corpus.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  buildCorpusDocument,
+  FOLLOWER_TO_LEADER_CORPUS,
+  LEADER_TO_FOLLOWER_CORPUS,
+} from '../../src/scoops/tray-sync-protocol-corpus.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const corpusJsonPath = resolve(
+  here,
+  '../../../ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json'
+);
+
+// The corpus module's mapped types enforce completeness at compile time; this
+// suite enforces that the checked-in JSON (shared with the Swift test target)
+// matches the module, so the two suites always decode the same bytes.
+describe('tray sync golden-fixture corpus', () => {
+  it('checked-in JSON matches the TS source of truth', () => {
+    let onDisk: unknown;
+    try {
+      onDisk = JSON.parse(readFileSync(corpusJsonPath, 'utf8'));
+    } catch {
+      onDisk = '<missing or unparseable>';
+    }
+    expect(
+      onDisk,
+      'tray-sync-corpus.json drifted from tray-sync-protocol-corpus.ts — regenerate with: npx tsx packages/dev-tools/tools/generate-tray-sync-corpus.ts'
+    ).toEqual(buildCorpusDocument());
+  });
+
+  it('every fixture declares the type it is keyed under', () => {
+    for (const [key, { message }] of Object.entries(LEADER_TO_FOLLOWER_CORPUS)) {
+      expect(message.type).toBe(key);
+    }
+    for (const [key, { message }] of Object.entries(FOLLOWER_TO_LEADER_CORPUS)) {
+      expect(message.type).toBe(key);
+    }
+  });
+
+  it('every fixture survives a JSON round-trip (what the data channel does)', () => {
+    const all = [
+      ...Object.values(LEADER_TO_FOLLOWER_CORPUS),
+      ...Object.values(FOLLOWER_TO_LEADER_CORPUS),
+    ];
+    for (const { message } of all) {
+      let roundTripped: unknown;
+      try {
+        roundTripped = JSON.parse(JSON.stringify(message)) as unknown;
+      } catch {
+        roundTripped = undefined; // the expect below fails loudly
+      }
+      expect(roundTripped).toEqual(message);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #1333 (P0-2 in the #1294 architecture audit — the last of the original five P0 items).

## Problem

The Swift mirror of the tray sync protocol (`SyncProtocol.swift`) was hand-synced by a 5-step prose checklist that demonstrably did not fire: `theme.apply` shipped silently dropped on every iOS follower. iOS protocol tests existed on disk but **no test target compiled them**, and the `ios-app` CI job only built — it ran zero tests.

## Golden-fixture corpus (single source of truth, decoded by both suites)

- **`tray-sync-protocol-corpus.ts`**: one fixture per variant of BOTH unions + an explicit iOS expectation per variant (`decoded` / `unknown` / `undecodable`), enforced by mapped types — **adding a TS variant fails typecheck until it gets a fixture AND an iOS decision** (phantom-variant mutation-verified; it now trips both the P0-3 dispatcher guard and the corpus)
- Derived JSON checked in at `ios-app/.../Fixtures/tray-sync-corpus.json` (regenerate: `npx tsx packages/dev-tools/tools/generate-tray-sync-corpus.ts`)
- **vitest guard** (`tray-sync-corpus.test.ts`): JSON ↔ TS module equality + JSON round-trip of every fixture
- **`SyncProtocolCorpusTests.swift`**: decodes every entry with the real decoder and asserts the expectation — a TS-only variant must decode to `.unknown` (leader→follower) or throw (follower→leader); a supported variant decoding to `.unknown` fails with a "theme.apply drift class" message

## Swift mirror fixes the corpus process surfaced

- **`theme.apply` case added** (the shipped drift) — decoded, documented no-op (iOS themes natively via SwiftUI)
- **`hello` version handshake** added in both directions; iOS now **sends** `hello` first on channel open (`protocolVersion: 1, runtime: "slicc-ios"`), so leaders stop diagnosing it as a legacy peer (completes the #1335/#1346 follow-through)
- Unknown leader message types now log at **warning** (were silently ignored — the audit's P0-4 iOS leg)

## CI

- `SliccFollowerTests` unit-test bundle + shared scheme via `project.yml` (XcodeGen); the previously never-compiled `SyncProtocolTests.swift` now builds and runs
- New **`xcodebuild test`** step on the first available iPhone simulator. Plain `swift test` cannot run on a macOS host — the package depends on an iOS-only WebRTC binary (this is why the acceptance criterion is met via `xcodebuild test` rather than literal `swift test`)

## Verification

- Root lint/typecheck green; all 1,145 webapp scoops tests green (incl. the new corpus guard)
- Swift decode logic verified locally with a standalone `swiftc` harness over the Foundation-only protocol sources: **all corpus checks pass**, and an expectation mutation fails as intended (no iOS simulator available locally; the XCTest run is CI's job — please watch the `ios-app` job on this PR)
- SwiftLint: no new violations beyond +2 complexity on the pre-existing `handleDataChannelMessage` warning (inherent to 3 new exhaustive-switch cases; hello handling extracted to a helper to minimize it)

## Docs

`packages/ios-app/CLAUDE.md` mirror-invariant section rewritten around the mechanical enforcement; `tray-sync-protocol.ts` header now points at the corpus.
