### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -55,7 +55,7 @@
       "lines": 76,
       "statements": 74,
       "functions": 75,
-      "branches": 64,
+      "branches": 65,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",
@@ -73,7 +73,7 @@
       "lines": 80,
       "statements": 79,
       "functions": 96,
-      "branches": 59
+      "branches": 62
     },
     "cloud-core": {
       "lines": 80,


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.