### PR TITLE
Add configurable effort level to Cherry SDK and ConeConfig

### DIFF
--- a/packages/cherry/src/index.ts
+++ b/packages/cherry/src/index.ts
@@ -53,6 +53,9 @@ export interface HostHooks {
   onHandshakeComplete?: () => void;
 }
 
+/** Effort / thinking level the cone should use. Locked — the UI picker is hidden. */
+export type EffortLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
 export interface MountSliccOptions {
   /** Element the follower iframe is appended to. Optional when `iframe` is provided. */
   container?: HTMLElement;
@@ -87,6 +90,12 @@ export interface MountSliccOptions {
    * `cherry=1` (the `?cherry=1` prefix is enforced by the worker CSP frame-ancestors).
    */
   uiOnly?: boolean;
+  /**
+   * Lock the cone's reasoning effort level. When set, the thinking-level picker
+   * is hidden and the cone uses this level for all turns. The embedder controls
+   * cost/quality tradeoff; the end user cannot override it.
+   */
+  effortLevel?: EffortLevel;
 }
 
 export interface SliccHandle {

--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -119,6 +119,7 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
           joinUrl: options.joinToken,
           features: resolvedFeatures,
           ...(themeJson ? { theme: themeJson } : {}),
+          ...(options.effortLevel ? { effortLevel: options.effortLevel } : {}),
         };
         post(welcome);
         options.hooks?.onHandshakeComplete?.();

--- a/packages/cherry/src/protocol.ts
+++ b/packages/cherry/src/protocol.ts
@@ -46,6 +46,8 @@ export interface CherryHandshakeWelcome {
   };
   /** JSON-serialized SliccTheme the follower should apply. */
   theme?: string;
+  /** Locked effort level. When set, the thinking-level picker is hidden. */
+  effortLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 }
 
 export interface CherryCdpRequest {

--- a/packages/cherry/tests/mount.test.ts
+++ b/packages/cherry/tests/mount.test.ts
@@ -218,6 +218,47 @@ describe('mountSliccImpl', () => {
     handle.destroy();
   });
 
+  it('includes effortLevel in the welcome envelope when the option is set', async () => {
+    const container = document.createElement('div');
+    const posted: { kind?: string; effortLevel?: string }[] = [];
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      joinToken: 'https://app.example/join?t=X',
+      effortLevel: 'low',
+      __test_post: (env) => posted.push(env as never),
+    });
+    await handle.__test_receive({
+      cherry: 1,
+      channelId: 'ch-effort',
+      kind: 'handshake.hello',
+    } as never);
+    const welcome = posted.find((e) => e.kind === 'handshake.welcome');
+    expect(welcome?.effortLevel).toBe('low');
+    handle.destroy();
+  });
+
+  it('omits effortLevel from the welcome envelope when the option is not set', async () => {
+    const container = document.createElement('div');
+    const posted: { kind?: string; effortLevel?: string }[] = [];
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      joinToken: 'https://app.example/join?t=X',
+      __test_post: (env) => posted.push(env as never),
+    });
+    await handle.__test_receive({
+      cherry: 1,
+      channelId: 'ch-no-effort',
+      kind: 'handshake.hello',
+    } as never);
+    const welcome = posted.find((e) => e.kind === 'handshake.welcome');
+    expect(welcome?.effortLevel).toBeUndefined();
+    handle.destroy();
+  });
+
   it('normalizes a trailing-slash sliccOrigin to the bare origin for postMessage targeting', async () => {
     const container = document.createElement('div');
     const posted: { kind?: string; channelId?: string }[] = [];

--- a/packages/cloud-core/src/cone-config/index.ts
+++ b/packages/cloud-core/src/cone-config/index.ts
@@ -29,18 +29,21 @@ export interface SecretEntry {
 
 export interface ConeConfig {
   model: string;
+  effortLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
   accounts: Account[];
   secrets: SecretEntry[];
 }
 
 export interface ConeConfigDelta {
   model?: string;
+  effortLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | null;
   upsert?: { accounts?: Account[]; secrets?: SecretEntry[] };
   delete?: { providerIds?: string[]; secretNames?: string[] };
 }
 
 export interface ConeConfigIndex {
   model: string;
+  effortLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
   accountProviderIds: string[];
   accountMeta: Array<{ providerId: string; kind: Account['kind']; tokenExpiresAt?: number }>;
   secretNames: string[];
@@ -53,6 +56,8 @@ function isStr(v: unknown): v is string {
   return typeof v === 'string';
 }
 
+const VALID_EFFORT_LEVELS = new Set(['off', 'minimal', 'low', 'medium', 'high', 'xhigh']);
+
 export function validateConeConfig(input: unknown): ConeConfig {
   if (!input || typeof input !== 'object') throw new Error('cone-config: not an object');
   const cfg = input as Record<string, unknown>;
@@ -61,7 +66,14 @@ export function validateConeConfig(input: unknown): ConeConfig {
   if (!Array.isArray(cfg.secrets)) throw new Error('cone-config: secrets must be an array');
   const accounts = cfg.accounts.map((a) => validateAccount(a));
   const secrets = cfg.secrets.map((s) => validateSecret(s));
-  return { model: cfg.model, accounts, secrets };
+  const result: ConeConfig = { model: cfg.model, accounts, secrets };
+  if (cfg.effortLevel !== undefined) {
+    if (!isStr(cfg.effortLevel) || !VALID_EFFORT_LEVELS.has(cfg.effortLevel)) {
+      throw new Error('cone-config: effortLevel must be one of off|minimal|low|medium|high|xhigh');
+    }
+    result.effortLevel = cfg.effortLevel as ConeConfig['effortLevel'];
+  }
+  return result;
 }
 
 function validateAccount(a: unknown): Account {
@@ -181,6 +193,17 @@ export function validateConeConfigDelta(input: unknown): ConeConfigDelta {
     if (!isStr(d.model)) throw new Error('cone-config: delta.model must be a string');
     out.model = d.model;
   }
+  if (d.effortLevel !== undefined) {
+    if (d.effortLevel === null) {
+      out.effortLevel = null;
+    } else if (!isStr(d.effortLevel) || !VALID_EFFORT_LEVELS.has(d.effortLevel)) {
+      throw new Error(
+        'cone-config: delta.effortLevel must be one of off|minimal|low|medium|high|xhigh or null'
+      );
+    } else {
+      out.effortLevel = d.effortLevel as ConeConfig['effortLevel'];
+    }
+  }
   if (d.upsert !== undefined) out.upsert = validateDeltaUpsert(d.upsert);
   if (d.delete !== undefined) out.delete = validateDeltaDelete(d.delete);
   return out;
@@ -193,11 +216,17 @@ export function mergeConeConfig(base: ConeConfig, delta: ConeConfigDelta): ConeC
   const secrets = new Map(base.secrets.map((s) => [s.name, s]));
   for (const s of delta.upsert?.secrets ?? []) secrets.set(s.name, s);
   for (const n of delta.delete?.secretNames ?? []) secrets.delete(n);
-  return {
+  const result: ConeConfig = {
     model: delta.model ?? base.model,
     accounts: [...accounts.values()],
     secrets: [...secrets.values()],
   };
+  if (delta.effortLevel !== undefined) {
+    result.effortLevel = delta.effortLevel === null ? undefined : delta.effortLevel;
+  } else if (base.effortLevel) {
+    result.effortLevel = base.effortLevel;
+  }
+  return result;
 }
 
 /**
@@ -219,7 +248,11 @@ export function serializeSecretsEnv(secrets: SecretEntry[]): string {
 export function bundleToFiles(cfg: ConeConfig): { coneConfigJson: string; secretsEnv: string } {
   return {
     // Secrets are excluded here and serialized separately into secretsEnv.
-    coneConfigJson: JSON.stringify({ model: cfg.model, accounts: cfg.accounts }),
+    coneConfigJson: JSON.stringify({
+      model: cfg.model,
+      ...(cfg.effortLevel ? { effortLevel: cfg.effortLevel } : {}),
+      accounts: cfg.accounts,
+    }),
     secretsEnv: serializeSecretsEnv(cfg.secrets),
   };
 }
@@ -227,6 +260,7 @@ export function bundleToFiles(cfg: ConeConfig): { coneConfigJson: string; secret
 export function bundleIndex(cfg: ConeConfig): ConeConfigIndex {
   return {
     model: cfg.model,
+    ...(cfg.effortLevel ? { effortLevel: cfg.effortLevel } : {}),
     accountProviderIds: cfg.accounts.map((a) => a.providerId),
     accountMeta: cfg.accounts.map((a) => ({
       providerId: a.providerId,

--- a/packages/cloud-core/tests/cone-config/cone-config.test.ts
+++ b/packages/cloud-core/tests/cone-config/cone-config.test.ts
@@ -74,6 +74,19 @@ describe('validateConeConfig', () => {
       validateConeConfig({ ...base, secrets: [{ name: 'X', value: 'v', domains: ['a,b'] }] })
     ).toThrow(/comma-free/);
   });
+  it('accepts a config with a valid effortLevel', () => {
+    expect(validateConeConfig({ ...base, effortLevel: 'high' })).toEqual({
+      ...base,
+      effortLevel: 'high',
+    });
+  });
+  it('accepts a config without effortLevel (it is optional)', () => {
+    expect(validateConeConfig(base)).toEqual(base);
+    expect(validateConeConfig(base).effortLevel).toBeUndefined();
+  });
+  it('rejects an invalid effortLevel string', () => {
+    expect(() => validateConeConfig({ ...base, effortLevel: 'ultra' })).toThrow(/effortLevel/);
+  });
 });
 
 describe('validateConeConfigDelta', () => {
@@ -102,6 +115,15 @@ describe('validateConeConfigDelta', () => {
   });
   it('accepts an empty delta', () => {
     expect(validateConeConfigDelta({})).toEqual({});
+  });
+  it('accepts a delta with a valid effortLevel', () => {
+    expect(validateConeConfigDelta({ effortLevel: 'low' })).toEqual({ effortLevel: 'low' });
+  });
+  it('accepts a delta with effortLevel: null (to clear it)', () => {
+    expect(validateConeConfigDelta({ effortLevel: null })).toEqual({ effortLevel: null });
+  });
+  it('rejects a delta with an invalid effortLevel', () => {
+    expect(() => validateConeConfigDelta({ effortLevel: 'turbo' })).toThrow(/effortLevel/);
   });
 });
 
@@ -134,6 +156,17 @@ describe('mergeConeConfig', () => {
     expect(mergeConeConfig(base, {}).accounts).toEqual(base.accounts);
     expect(base).toEqual(snapshot); // base not mutated
   });
+  it('applies effortLevel from delta when present', () => {
+    expect(mergeConeConfig(base, { effortLevel: 'medium' }).effortLevel).toBe('medium');
+  });
+  it('clears effortLevel when delta specifies null', () => {
+    const withEffort: ConeConfig = { ...base, effortLevel: 'high' };
+    expect(mergeConeConfig(withEffort, { effortLevel: null }).effortLevel).toBeUndefined();
+  });
+  it('preserves base effortLevel when delta does not mention it', () => {
+    const withEffort: ConeConfig = { ...base, effortLevel: 'low' };
+    expect(mergeConeConfig(withEffort, {}).effortLevel).toBe('low');
+  });
 });
 
 describe('serializeSecretsEnv + bundleToFiles', () => {
@@ -150,6 +183,19 @@ describe('serializeSecretsEnv + bundleToFiles', () => {
     expect(JSON.parse(coneConfigJson)).toEqual({ model: base.model, accounts: base.accounts });
     expect(secretsEnv).toContain('GITHUB_TOKEN=gt');
   });
+  it('includes effortLevel in the JSON when set', () => {
+    const withEffort: ConeConfig = { ...base, effortLevel: 'xhigh' };
+    const { coneConfigJson } = bundleToFiles(withEffort);
+    expect(JSON.parse(coneConfigJson)).toEqual({
+      model: base.model,
+      effortLevel: 'xhigh',
+      accounts: base.accounts,
+    });
+  });
+  it('omits effortLevel from the JSON when not set', () => {
+    const { coneConfigJson } = bundleToFiles(base);
+    expect(JSON.parse(coneConfigJson)).not.toHaveProperty('effortLevel');
+  });
 });
 
 describe('bundleIndex', () => {
@@ -165,6 +211,11 @@ describe('bundleIndex', () => {
       secretNames: ['GITHUB_TOKEN'],
     });
     expect(JSON.stringify(idx)).not.toContain('gt'); // no secret values leak
+  });
+  it('includes effortLevel in the index when set', () => {
+    const withEffort: ConeConfig = { ...base, effortLevel: 'minimal' };
+    const idx = bundleIndex(withEffort);
+    expect(idx.effortLevel).toBe('minimal');
   });
 });
 

--- a/packages/node-server/src/hosted-bootstrap.ts
+++ b/packages/node-server/src/hosted-bootstrap.ts
@@ -32,6 +32,7 @@ const DEFAULT_MODEL = 'adobe:claude-opus-4-6';
 
 export interface HostedBootstrapPayload {
   model?: string;
+  effortLevel?: string;
   accounts?: Account[];
   /** Back-compat: retained so older webapp builds still read the IMS token. */
   adobeImsToken?: string;
@@ -45,8 +46,16 @@ export interface BootstrapSources {
 export function buildHostedBootstrapPayload(sources: BootstrapSources): HostedBootstrapPayload {
   const raw = sources.readConeConfig();
   if (raw) {
-    const parsed = JSON.parse(raw) as { model?: string; accounts?: Account[] };
-    return { model: parsed.model, accounts: parsed.accounts ?? [] };
+    const parsed = JSON.parse(raw) as {
+      model?: string;
+      effortLevel?: string;
+      accounts?: Account[];
+    };
+    return {
+      model: parsed.model,
+      ...(parsed.effortLevel ? { effortLevel: parsed.effortLevel } : {}),
+      accounts: parsed.accounts ?? [],
+    };
   }
   const legacy = sources.getLegacyAdobeToken();
   if (legacy) {

--- a/packages/node-server/tests/hosted-bootstrap.test.ts
+++ b/packages/node-server/tests/hosted-bootstrap.test.ts
@@ -92,6 +92,30 @@ describe('buildHostedBootstrapPayload', () => {
     expect(payload.accounts).toEqual([{ providerId: 'anthropic', kind: 'apikey', apiKey: 'k' }]);
   });
 
+  it('passes effortLevel from cone-config.json when present', () => {
+    const readConeConfig = () =>
+      JSON.stringify({
+        model: 'anthropic:claude-opus-4-6',
+        effortLevel: 'high',
+        accounts: [],
+      });
+    const payload = buildHostedBootstrapPayload({
+      readConeConfig,
+      getLegacyAdobeToken: () => undefined,
+    });
+    expect(payload.effortLevel).toBe('high');
+  });
+
+  it('omits effortLevel from payload when cone-config.json has none', () => {
+    const readConeConfig = () =>
+      JSON.stringify({ model: 'anthropic:claude-opus-4-6', accounts: [] });
+    const payload = buildHostedBootstrapPayload({
+      readConeConfig,
+      getLegacyAdobeToken: () => undefined,
+    });
+    expect(payload.effortLevel).toBeUndefined();
+  });
+
   it('falls back to a legacy Adobe token when cone-config.json is absent (opaque token ⇒ no expiry)', () => {
     const payload = buildHostedBootstrapPayload({
       readConeConfig: () => null,

--- a/packages/webapp/src/cdp/cherry-host-protocol.ts
+++ b/packages/webapp/src/cdp/cherry-host-protocol.ts
@@ -36,6 +36,8 @@ export interface CherryHandshakeWelcome {
   };
   /** JSON-serialized SliccTheme the follower should apply. */
   theme?: string;
+  /** Locked effort level. When set, the thinking-level picker is hidden. */
+  effortLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 }
 
 export interface CherryCdpRequest {

--- a/packages/webapp/src/cdp/cherry-host-transport.ts
+++ b/packages/webapp/src/cdp/cherry-host-transport.ts
@@ -69,6 +69,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
     monitor: true,
   };
   private _theme: string | null = null;
+  private _effortLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | null = null;
   private boundHandler = (ev: MessageEvent) => this.handleMessage(ev);
 
   /**
@@ -139,6 +140,14 @@ export class CherryHostTransport extends SyntheticCdpTransport {
    */
   get theme(): string | null {
     return this._theme;
+  }
+
+  /**
+   * Locked effort level from the host SDK's handshake.welcome.
+   * Null when the host did not supply one (UI picker remains visible).
+   */
+  get effortLevel(): 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | null {
+    return this._effortLevel;
   }
 
   async connect(options?: CDPConnectOptions): Promise<void> {
@@ -333,6 +342,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
         this._state = 'connected';
         this._joinUrl = env.joinUrl ?? null;
         this._theme = env.theme ?? null;
+        this._effortLevel = env.effortLevel ?? null;
         this._features = env.features ?? {
           terminal: true,
           files: true,

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -52,7 +52,7 @@ import {
   type ScoopManagementToolsConfig,
 } from './scoop-management-tools.js';
 import { createDefaultSkills, formatSkillsForPrompt, loadSkills } from './skills.js';
-import type { RegisteredScoop } from './types.js';
+import { type RegisteredScoop, THINKING_LEVELS } from './types.js';
 
 const log = createLogger('scoop-context');
 
@@ -656,7 +656,11 @@ export class ScoopContext {
 
       if (this.disposed) return;
 
-      const thinkingLevel = resolveThinkingLevel(this.scoop.config?.thinkingLevel, model);
+      const lockedEffort = this.getLockedEffortLevel();
+      const thinkingLevel = resolveThinkingLevel(
+        lockedEffort ?? this.scoop.config?.thinkingLevel,
+        model
+      );
 
       this.agent = new Agent({
         initialState: {
@@ -1063,7 +1067,8 @@ export class ScoopContext {
     // clamped by a previous resolution) so a model swap that re-enables
     // a higher tier (e.g. switching to an xhigh-capable Opus) restores
     // it instead of leaving the previously-clamped value in place.
-    const requested = this.scoop.config?.thinkingLevel;
+    const lockedEffort = this.getLockedEffortLevel();
+    const requested = lockedEffort ?? this.scoop.config?.thinkingLevel;
     this.agent.state.thinkingLevel = resolveThinkingLevel(requested, model);
     log.info('Model updated on running agent', {
       folder: this.scoop.folder,
@@ -1116,9 +1121,21 @@ export class ScoopContext {
    */
   setThinkingLevel(level: ThinkingLevel | undefined): ThinkingLevel {
     if (!this.agent) return 'off';
+    const locked = this.getLockedEffortLevel();
+    if (locked) return this.agent.state.thinkingLevel;
     const resolved = resolveThinkingLevel(level, this.agent.state.model);
     this.agent.state.thinkingLevel = resolved;
     return resolved;
+  }
+
+  private getLockedEffortLevel(): ThinkingLevel | null {
+    try {
+      const val = localStorage.getItem('slicc_locked_effort_level');
+      if (val && THINKING_LEVELS.includes(val as ThinkingLevel)) return val as ThinkingLevel;
+    } catch {
+      // Worker shim or test env may not have localStorage
+    }
+    return null;
   }
 
   /** Currently applied thinking level on the running agent. */

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -1131,7 +1131,9 @@ export class ScoopContext {
   private getLockedEffortLevel(): ThinkingLevel | null {
     try {
       const val = localStorage.getItem('slicc_locked_effort_level');
-      if (val && THINKING_LEVELS.includes(val as ThinkingLevel)) return val as ThinkingLevel;
+      if (!val) return null;
+      if (THINKING_LEVELS.includes(val as ThinkingLevel)) return val as ThinkingLevel;
+      log.warn('Unrecognized locked effort level in localStorage, ignoring:', val);
     } catch {
       // Worker shim or test env may not have localStorage
     }

--- a/packages/webapp/src/ui/boot/setup-standalone-tray-init-hosted.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-tray-init-hosted.ts
@@ -32,6 +32,7 @@ export async function runHostedBootstrap(deps: RunHostedBootstrapDeps): Promise<
     if (!res.ok) return;
     const boot = (await res.json()) as {
       model?: string;
+      effortLevel?: string;
       accounts?: import('@slicc/cloud-core/cone-config').Account[];
       adobeImsToken?: string;
     };
@@ -43,6 +44,8 @@ export async function runHostedBootstrap(deps: RunHostedBootstrapDeps): Promise<
     if (boot.model) localStorage.setItem('selected-model', boot.model);
     else if (!localStorage.getItem('selected-model'))
       localStorage.setItem('selected-model', 'adobe:claude-opus-4-6');
+    if (boot.effortLevel) localStorage.setItem('slicc_locked_effort_level', boot.effortLevel);
+    else localStorage.removeItem('slicc_locked_effort_level');
     const [{ applyHostedAccounts, prewarmHostedModels }, ps] = await Promise.all([
       import('../hosted-config-apply.js'),
       import('../provider-settings.js'),

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -261,6 +261,7 @@ export async function mountWcUiFollower(
   // show all panels by default.
   const cherryEffortLevel = isCherry && prelude.cherryTransport?.effortLevel;
   if (cherryEffortLevel) localStorage.setItem('slicc_locked_effort_level', cherryEffortLevel);
+  else localStorage.removeItem('slicc_locked_effort_level');
   const features: CherryFeatureSet =
     isCherry && prelude.cherryTransport ? prelude.cherryTransport.features : ALL_FEATURES_ENABLED;
   renderFollowerInertPanels(

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -195,6 +195,7 @@ function applyFeatureVisibility(features: CherryFeatureSet): void {
 }
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: follower boot has sequential setup steps
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: follower boot has sequential setup steps
 export async function mountWcUiFollower(
   app: HTMLElement,
   bootLog: BootStageLogger,
@@ -258,6 +259,8 @@ export async function mountWcUiFollower(
   // inert. Swap them for an explanatory placeholder instead of an empty panel.
   // For cherry followers, respect the host's feature toggles; for regular followers,
   // show all panels by default.
+  const cherryEffortLevel = isCherry && prelude.cherryTransport?.effortLevel;
+  if (cherryEffortLevel) localStorage.setItem('slicc_locked_effort_level', cherryEffortLevel);
   const features: CherryFeatureSet =
     isCherry && prelude.cherryTransport ? prelude.cherryTransport.features : ALL_FEATURES_ENABLED;
   renderFollowerInertPanels(

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -276,16 +276,21 @@ async function applyThreadContext(refs: WcShellRefs, scoop: RegisteredScoop): Pr
     scoop.isCone ? { kind: 'cone' } : { kind: 'scoop', accent: scoopColor(scoop) }
   );
   refs.switcher.setAttribute('active', scoop.jid);
-  refs.composerMeta.setAttribute('thinking', metaThinkingForScoop(scoop.config?.thinkingLevel));
+  const lockedEffort = localStorage.getItem('slicc_locked_effort_level');
+  refs.composerMeta.setAttribute(
+    'thinking',
+    metaThinkingForScoop((lockedEffort ?? scoop.config?.thinkingLevel) as ThinkingLevel | undefined)
+  );
   try {
     const { resolveCurrentModel, resolveModelById } = await import('../provider-settings.js');
     const modelId = scoop.config?.modelId;
     const model = modelId ? resolveModelById(modelId) : resolveCurrentModel();
     refs.composerMeta.setAttribute('model', model.name ?? model.id);
     // The thinking-effort pill only shows for a reasoning-capable model.
+    // When locked, hide the pill entirely so the user cannot change it.
     refs.composerMeta.toggleAttribute(
       'no-thinking',
-      (model as { reasoning?: boolean }).reasoning !== true
+      (model as { reasoning?: boolean }).reasoning !== true || !!lockedEffort
     );
   } catch {
     // Model display is informational; never block scoop selection on it.
@@ -975,6 +980,7 @@ function wireWcComposer(deps: {
 
   // Brain pill: cycle the scoop's thinking level (persisted by the worker).
   refs.composerMeta.addEventListener('thinking-change', (event) => {
+    if (localStorage.getItem('slicc_locked_effort_level')) return;
     const metaLevel = (event as CustomEvent<{ thinking?: string }>).detail?.thinking;
     const level = thinkingLevelForAgent(metaLevel);
     const selected = boot.getSelected();


### PR DESCRIPTION
## Summary

- Add `effortLevel` option to `mountSlicc()` in the Cherry SDK — allows the embedder to lock the cone's reasoning effort level
- Add `effortLevel` field to `ConeConfig` in cloud-core — hosted cones can have their effort level pinned at provisioning time
- When locked, the thinking-level UI picker is hidden and `setThinkingLevel` no-ops so the end user cannot override the embedder's cost/quality choice
- Both paths converge through `localStorage('slicc_locked_effort_level')` which the cone's `ScoopContext` reads at init and on model-switch

## Test plan

- [x] Cherry SDK tests: verify `effortLevel` appears in the `handshake.welcome` envelope when set, and is omitted when not set
- [x] Cloud-core tests: validate/reject effortLevel in ConeConfig and ConeConfigDelta, merge semantics (apply/clear/preserve), bundleToFiles and bundleIndex output
- [x] All existing cherry tests pass (56/56)
- [x] All existing cloud-core tests pass (94/94)
- [x] Typecheck passes for cherry and cloud-core packages
- [ ] Manual: mount a cherry embed with `effortLevel: 'high'` and verify the brain pill is hidden
- [ ] Manual: provision a cloud cone with `effortLevel` in config and verify the agent uses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)