### PR TITLE
fix(webapp): recover long-lived tabs from stale chunks after deploy (#1330)

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1075,3 +1075,13 @@ always runs in the pinned hosted leader tab at `https://www.sliccy.ai/?slicc=lea
 and `?detached=1` is no longer a recognized boot mode. Future code MUST
 NOT reintroduce the detached-claim pattern without redesigning around
 the hosted-origin model.
+
+## Stale content-hashed chunks after a deploy (#1330)
+
+A long-lived tab/worker holds an old module graph; after a deploy the old
+`/assets/<hash>.js` is gone and the worker's SPA fallback returns `index.html` as
+`200 text/html`, so the lazy `import()` rejects with a MIME/module-script error.
+The failing import is usually WORKER-owned (providers load in the kernel worker),
+and Vite injects `vite:preloadError` only into the PAGE bundle — so a `window`
+listener alone can't catch it. Recovery is the four-trigger guarded reload in
+`core/stale-asset-channel.ts` + `ui/boot/setup-preload-error-reload.ts`.

--- a/docs/superpowers/plans/2026-07-07-stale-asset-recovery.md
+++ b/docs/superpowers/plans/2026-07-07-stale-asset-recovery.md
@@ -6,57 +6,125 @@
 
 **Architecture:** Four triggers funnel into one shared, instanceId-scoped, fail-closed, timestamp-guarded page reload. Two page-side triggers (`window` `vite:preloadError` for page-owned lazy chunks; a `Worker` `error` event for a stale worker entry chunk) and two worker-side triggers (a `boot()` `try/catch` for boot-time provider imports; the `scoop-context` turn-error classifier) — the worker triggers `postMessage` an instanceId-stamped signal over a `BroadcastChannel` that only the owning page acts on.
 
-**Tech Stack:** TypeScript, Vite (content-hashed chunks + `__vitePreload`/`vite:preloadError`), Vitest (jsdom for DOM/BroadcastChannel tests), Cloudflare Workers Static Assets (SPA fallback).
+**Tech Stack:** TypeScript, Vite (content-hashed chunks + `__vitePreload`/`vite:preloadError`), Vitest (node env + a fake `BroadcastChannel`; jsdom for the DOM/`window` test), Cloudflare Workers Static Assets (SPA fallback).
 
 ## Global Constraints
 
 - Scope is **`packages/webapp` only** — no `cloudflare-worker` / `cloud-core` changes.
-- The shared detection/channel module MUST be realm-agnostic (no `window`/`document` at module scope) — it is imported by the page AND the kernel worker.
-- Reload guard: **timestamp window `RELOAD_WINDOW_MS = 60_000`** (must exceed the 30 s host-ready boot timeout), **fail-closed** on any `sessionStorage` throw (never reload if the guard can't be read/persisted), `sessionStorage` key `'slicc:stale-asset-reloaded-at'`.
+- The shared detection/channel module MUST be realm-agnostic (no `window`/`document` at module scope) — imported by the page AND the kernel worker. Prove it by adding the module to `tsconfig.webapp-worker.json`'s `include` (no-DOM `WebWorker` lib) — Task 1.
+- Reload guard: **timestamp window `RELOAD_WINDOW_MS = 60_000`** (must exceed the 30 s host-ready boot timeout), **fail-closed** on any `sessionStorage` throw, `sessionStorage` key `'slicc:stale-asset-reloaded-at'`.
 - Worker→page signal is **instanceId-scoped** (`BroadcastChannel 'slicc-stale-asset-reload'`, message `{ type: 'stale-asset-reload', instanceId }`); the page listener acts only on its own `instanceId`. Never origin-wide.
 - **Ordering is load-bearing:** `BroadcastChannel` does NOT buffer and `spawnKernelWorker()` posts `kernel-worker-init` synchronously, so the page reload listener MUST be installed BEFORE `spawnKernelWorker()` is called.
 - `isDynamicImportError` anchors on module-script context (`module script` / `JavaScript module` / `dynamically imported module`); a bare `MIME type` match is forbidden (false-positive risk).
+- **Tests use the repo fake-`BroadcastChannel`** (neither node nor jsdom implements a working cross-instance one) — a shared helper, mirroring `tests/kernel/panel-rpc.test.ts`.
 - Commits: focused, package-local, **no `Co-Authored-By` trailer**. Run `npx prettier --write` on touched files before each commit.
 
 ## File Structure
 
-- **Create** `packages/webapp/src/core/stale-asset-channel.ts` — realm-agnostic: `isDynamicImportError`, the `BroadcastChannel` name + message type, `setStaleAssetInstanceId`, `broadcastStaleAssetReload`, `installStaleAssetReloadListener`. (In `core/` — imported by both page and worker; avoids a worker→`ui/` import.)
-- **Create** `packages/webapp/src/ui/boot/setup-preload-error-reload.ts` — page-only: `decideStaleReload`, `guardedReload`, `setupPreloadErrorReload`, `installWorkerStaleAssetReloadListener`.
-- **Modify** `packages/webapp/src/ui/main.ts` — call `setupPreloadErrorReload()` first in `main()`.
-- **Modify** `packages/webapp/src/scoops/scoop-context.ts` — turn-time trigger: a stale-asset guard checked before `handleNonRetryableError`.
-- **Modify** `packages/webapp/src/kernel/kernel-worker.ts` — boot-time trigger: `setStaleAssetInstanceId` + `try/catch` around `boot()`.
-- **Modify** `packages/webapp/src/kernel/spawn.ts` — `onWorkerScriptError?` option → `worker.addEventListener('error', …)`.
+- **Create** `packages/webapp/src/core/stale-asset-channel.ts` — realm-agnostic: `isDynamicImportError`, channel name + message type, `setStaleAssetInstanceId`, `broadcastStaleAssetReload`, `broadcastIfStaleAssetError`, `installStaleAssetReloadListener`. (In `core/` — imported by both realms; avoids a worker→`ui/` import.)
+- **Create** `packages/webapp/tests/helpers/fake-broadcast-channel.ts` — shared in-memory `BroadcastChannel` polyfill + install/reset.
+- **Create** `packages/webapp/src/ui/boot/setup-preload-error-reload.ts` — page-only: `decideStaleReload`, `guardedReload`, `setupPreloadErrorReload`, `installWorkerStaleAssetReloadListener`, `__resetForTest`.
+- **Modify** `packages/webapp/src/ui/main.ts` — `setupPreloadErrorReload()` first in `main()`.
+- **Modify** `packages/webapp/src/scoops/scoop-context.ts` — `handleStaleAssetError` before `handleNonRetryableError` in `handlePromptAttemptError`.
+- **Modify** `packages/webapp/src/kernel/kernel-worker.ts` — `setStaleAssetInstanceId` + `try/catch(broadcastIfStaleAssetError)` around `boot()`.
+- **Modify** `packages/webapp/src/kernel/spawn.ts` — `WorkerLike.addEventListener?` + `onWorkerScriptError?` on both option types + attach in `bootstrapKernelWorker`.
 - **Modify** `packages/webapp/src/ui/wc/wc-live.ts` — install the listener before `spawnKernelWorker`, pass `onWorkerScriptError`.
-- **Create** tests: `tests/core/stale-asset-channel.test.ts`, `tests/ui/boot/setup-preload-error-reload.test.ts`; **extend** `tests/scoops/scoop-context.test.ts`.
+- **Modify** `tsconfig.webapp-worker.json` — add the channel module to `include`.
+- **Create/extend** tests: `tests/core/stale-asset-channel.test.ts`, `tests/ui/boot/setup-preload-error-reload.test.ts`; extend `tests/scoops/scoop-context.test.ts`, `tests/kernel/spawn.test.ts`.
 - **Modify** docs: `packages/webapp/CLAUDE.md`, `docs/pitfalls.md`.
 
 ---
 
-### Task 1: Shared detection + channel module
+### Task 1: Shared detection + channel module (+ fake-channel test helper)
 
 **Files:**
 
 - Create: `packages/webapp/src/core/stale-asset-channel.ts`
+- Create: `packages/webapp/tests/helpers/fake-broadcast-channel.ts`
 - Test: `packages/webapp/tests/core/stale-asset-channel.test.ts`
+- Modify: `tsconfig.webapp-worker.json` (add module to `include`)
 
 **Interfaces:**
 
-- Consumes: nothing (leaf module).
+- Consumes: `createLogger` from `../core/logger.js` (relative `./logger.js`).
 - Produces:
   - `isDynamicImportError(msg: string): boolean`
-  - `STALE_ASSET_RELOAD_CHANNEL: string`
-  - `interface StaleAssetReloadMsg { type: 'stale-asset-reload'; instanceId: string }`
+  - `STALE_ASSET_RELOAD_CHANNEL: string`, `interface StaleAssetReloadMsg { type: 'stale-asset-reload'; instanceId: string }`
   - `setStaleAssetInstanceId(id: string | undefined): void`
   - `broadcastStaleAssetReload(): void`
+  - `broadcastIfStaleAssetError(err: unknown): void`
   - `installStaleAssetReloadListener(instanceId: string, onReload: () => void): () => void`
+  - Test helper: `FakeBroadcastChannel`, `installFakeBroadcastChannel()`, `resetFakeBroadcastChannel()`
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the shared fake-channel helper**
+
+```ts
+// packages/webapp/tests/helpers/fake-broadcast-channel.ts
+/**
+ * In-memory BroadcastChannel polyfill for tests. Neither the node vitest env
+ * nor jsdom provides a working cross-instance BroadcastChannel; this mirrors
+ * the real async-same-thread delivery via queueMicrotask. Based on the pattern
+ * in tests/kernel/panel-rpc.test.ts. Install onto globalThis BEFORE code
+ * constructs `new BroadcastChannel(...)`.
+ */
+export class FakeBroadcastChannel {
+  private static buses = new Map<string, Set<FakeBroadcastChannel>>();
+  private listeners = new Set<(ev: MessageEvent) => void>();
+  private closed = false;
+
+  constructor(public readonly name: string) {
+    let bus = FakeBroadcastChannel.buses.get(name);
+    if (!bus) {
+      bus = new Set();
+      FakeBroadcastChannel.buses.set(name, bus);
+    }
+    bus.add(this);
+  }
+  postMessage(data: unknown): void {
+    if (this.closed) return;
+    const bus = FakeBroadcastChannel.buses.get(this.name);
+    if (!bus) return;
+    for (const peer of bus) {
+      if (peer === this || peer.closed) continue;
+      queueMicrotask(() => {
+        for (const l of peer.listeners) l(new MessageEvent('message', { data }));
+      });
+    }
+  }
+  addEventListener(_t: 'message', l: (ev: MessageEvent) => void): void {
+    this.listeners.add(l);
+  }
+  removeEventListener(_t: 'message', l: (ev: MessageEvent) => void): void {
+    this.listeners.delete(l);
+  }
+  close(): void {
+    this.closed = true;
+    FakeBroadcastChannel.buses.get(this.name)?.delete(this);
+  }
+}
+
+let original: unknown;
+export function installFakeBroadcastChannel(): void {
+  original = (globalThis as Record<string, unknown>).BroadcastChannel;
+  (globalThis as Record<string, unknown>).BroadcastChannel = FakeBroadcastChannel;
+}
+export function resetFakeBroadcastChannel(): void {
+  (FakeBroadcastChannel as unknown as { buses: Map<string, unknown> }).buses = new Map();
+  (globalThis as Record<string, unknown>).BroadcastChannel = original;
+}
+```
+
+- [ ] **Step 2: Write the failing test**
 
 ```ts
 // packages/webapp/tests/core/stale-asset-channel.test.ts
-// @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  installFakeBroadcastChannel,
+  resetFakeBroadcastChannel,
+} from '../helpers/fake-broadcast-channel.js';
+import {
+  broadcastIfStaleAssetError,
   broadcastStaleAssetReload,
   installStaleAssetReloadListener,
   isDynamicImportError,
@@ -76,8 +144,7 @@ describe('isDynamicImportError', () => {
       )
     ).toBe(true);
   });
-
-  it('does NOT match unrelated errors (no bare MIME / bare failed-to-fetch)', () => {
+  it('does NOT match unrelated errors', () => {
     expect(isDynamicImportError('401 Unauthorized')).toBe(false);
     expect(isDynamicImportError('rate limit exceeded')).toBe(false);
     expect(isDynamicImportError('network error')).toBe(false);
@@ -86,17 +153,21 @@ describe('isDynamicImportError', () => {
   });
 });
 
-describe('broadcastStaleAssetReload / installStaleAssetReloadListener', () => {
-  afterEach(() => setStaleAssetInstanceId(undefined));
+describe('broadcast + listener (instanceId-scoped)', () => {
+  beforeEach(() => installFakeBroadcastChannel());
+  afterEach(() => {
+    setStaleAssetInstanceId(undefined);
+    resetFakeBroadcastChannel();
+  });
 
-  it('delivers only to a listener with the matching instanceId', async () => {
+  it('delivers only to a listener whose instanceId matches', async () => {
     const matched = vi.fn();
     const other = vi.fn();
     const d1 = installStaleAssetReloadListener('inst-A', matched);
     const d2 = installStaleAssetReloadListener('inst-B', other);
     setStaleAssetInstanceId('inst-A');
     broadcastStaleAssetReload();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
     expect(matched).toHaveBeenCalledTimes(1);
     expect(other).not.toHaveBeenCalled();
     d1();
@@ -107,35 +178,55 @@ describe('broadcastStaleAssetReload / installStaleAssetReloadListener', () => {
     const cb = vi.fn();
     const d = installStaleAssetReloadListener('inst-A', cb);
     broadcastStaleAssetReload();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
     expect(cb).not.toHaveBeenCalled();
     d();
+  });
+
+  it('broadcastIfStaleAssetError broadcasts for a dynamic-import Error only', async () => {
+    const cb = vi.fn();
+    const d = installStaleAssetReloadListener('inst-A', cb);
+    setStaleAssetInstanceId('inst-A');
+    broadcastIfStaleAssetError(new Error('random failure'));
+    await Promise.resolve();
+    expect(cb).not.toHaveBeenCalled();
+    broadcastIfStaleAssetError(new Error('Failed to fetch dynamically imported module: /a.js'));
+    await Promise.resolve();
+    expect(cb).toHaveBeenCalledTimes(1);
+    d();
+  });
+
+  it('setStaleAssetInstanceId(undefined) dev-warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    setStaleAssetInstanceId(undefined);
+    // Dev-only warning; assert it does not throw and (in DEV) warns at least 0+ times.
+    expect(() => setStaleAssetInstanceId(undefined)).not.toThrow();
+    warn.mockRestore();
   });
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Run test to verify it fails**
 
 Run: `npx vitest run packages/webapp/tests/core/stale-asset-channel.test.ts`
 Expected: FAIL — cannot resolve `../../src/core/stale-asset-channel.js`.
 
-- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Write the implementation**
 
 ```ts
 // packages/webapp/src/core/stale-asset-channel.ts
 /**
  * Realm-agnostic detection + worker→page signal for stale-chunk recovery after
- * a deploy (#1330). Shell-free and DOM-free at module scope (only
- * `BroadcastChannel`, available in the page AND the kernel worker), so both
- * realms import it. Mirrors the split-out shape of `nuke-channel.ts`.
+ * a deploy (#1330). DOM-free at module scope (only `BroadcastChannel`, in the
+ * page AND the kernel worker), so both realms import it. Mirrors the split-out
+ * shape of `nuke-channel.ts`.
  */
 import { createLogger } from './logger.js';
 
 const log = createLogger('stale-asset');
 
-// Anchored on module-script context — NOT a bare "MIME type" or "failed to
-// fetch", which would false-positive on unrelated tool/upload/provider errors
-// classified from a generic error.message.
+// Module-script context ONLY — never a bare "MIME type" / "failed to fetch",
+// which would false-positive on unrelated tool/upload/provider errors.
 const DYNAMIC_IMPORT_ERROR_RE =
   /dynamically imported module|importing a module script failed|expected a javascript module|module script/i;
 
@@ -144,7 +235,7 @@ export function isDynamicImportError(msg: string): boolean {
   return DYNAMIC_IMPORT_ERROR_RE.test(msg);
 }
 
-/** Same-origin channel the failing worker uses to ask its owning page to reload. */
+/** Same-origin channel a failing worker uses to ask its owning page to reload. */
 export const STALE_ASSET_RELOAD_CHANNEL = 'slicc-stale-asset-reload';
 
 export interface StaleAssetReloadMsg {
@@ -152,8 +243,6 @@ export interface StaleAssetReloadMsg {
   instanceId: string;
 }
 
-// Set once by the kernel worker at boot start; read by the broadcasters so both
-// worker failure sites reach the signal without threading the id through.
 let workerInstanceId: string | null = null;
 
 /** Kernel worker records `init.instanceId` at boot start. Dev-warns if absent. */
@@ -182,9 +271,19 @@ export function broadcastStaleAssetReload(): void {
   }
 }
 
+/** Broadcast iff `err` is a dynamic-import failure. Called from the worker
+ *  `boot()` catch — lives here (not in `kernel-worker.ts`) so it is unit-testable
+ *  without triggering that module's load-time `self.addEventListener` side effect. */
+export function broadcastIfStaleAssetError(err: unknown): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (isDynamicImportError(msg)) broadcastStaleAssetReload();
+}
+
 /**
- * Page-side listener. Invokes `onReload` only for a broadcast stamped with the
- * page's own `instanceId` (never another tab's). Returns a disposer.
+ * Page-side listener PRIMITIVE. Invokes `onReload` only for a broadcast stamped
+ * with the page's own `instanceId`. Returns a fresh disposer per call (like
+ * `installNukeReloadListener`); single-install is enforced by the page wrapper
+ * `installWorkerStaleAssetReloadListener`.
  */
 export function installStaleAssetReloadListener(
   instanceId: string,
@@ -205,16 +304,26 @@ export function installStaleAssetReloadListener(
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Add the module to the no-DOM worker typecheck**
+
+In `tsconfig.webapp-worker.json`, add to the `include` array (proves the module has no `window`/DOM dependency):
+
+```json
+    "packages/webapp/src/core/stale-asset-channel.ts",
+```
+
+- [ ] **Step 6: Run test + the worker typecheck to verify they pass**
 
 Run: `npx vitest run packages/webapp/tests/core/stale-asset-channel.test.ts`
-Expected: PASS (5 tests).
+Expected: PASS.
+Run: `npx tsc --noEmit -p tsconfig.webapp-worker.json`
+Expected: PASS (no `window`/DOM errors — proves worker-safety).
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-npx prettier --write packages/webapp/src/core/stale-asset-channel.ts packages/webapp/tests/core/stale-asset-channel.test.ts
-git add packages/webapp/src/core/stale-asset-channel.ts packages/webapp/tests/core/stale-asset-channel.test.ts
+npx prettier --write packages/webapp/src/core/stale-asset-channel.ts packages/webapp/tests/helpers/fake-broadcast-channel.ts packages/webapp/tests/core/stale-asset-channel.test.ts tsconfig.webapp-worker.json
+git add packages/webapp/src/core/stale-asset-channel.ts packages/webapp/tests/helpers/fake-broadcast-channel.ts packages/webapp/tests/core/stale-asset-channel.test.ts tsconfig.webapp-worker.json
 git commit -m "feat(webapp): stale-asset detection + instanceId-scoped reload channel (#1330)"
 ```
 
@@ -229,22 +338,23 @@ git commit -m "feat(webapp): stale-asset detection + instanceId-scoped reload ch
 
 **Interfaces:**
 
-- Consumes: `installStaleAssetReloadListener` from Task 1.
-- Produces:
-  - `RELOAD_WINDOW_MS: number`
-  - `decideStaleReload(lastReloadAt: number | null, now: number, windowMs: number): boolean`
-  - `interface GuardedReloadDeps { reload: () => void; storage: Pick<Storage,'getItem'|'setItem'>; now: () => number; windowMs: number; storageKey: string }`
-  - `guardedReload(deps?: GuardedReloadDeps): boolean`
-  - `setupPreloadErrorReload(deps?: Partial<GuardedReloadDeps>): void`
-  - `installWorkerStaleAssetReloadListener(instanceId: string): () => void`
-  - `__resetForTest(): void`
+- Consumes: `installStaleAssetReloadListener` (Task 1); the fake-channel helper.
+- Produces: `RELOAD_WINDOW_MS`, `decideStaleReload`, `GuardedReloadDeps`, `guardedReload(deps?)`, `setupPreloadErrorReload(deps?)`, `installWorkerStaleAssetReloadListener(instanceId)`, `__resetForTest()`.
 
 - [ ] **Step 1: Write the failing test**
 
 ```ts
 // packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  installFakeBroadcastChannel,
+  resetFakeBroadcastChannel,
+} from '../../helpers/fake-broadcast-channel.js';
+import {
+  broadcastStaleAssetReload,
+  setStaleAssetInstanceId,
+} from '../../../src/core/stale-asset-channel.js';
 import {
   __resetForTest,
   decideStaleReload,
@@ -253,10 +363,6 @@ import {
   RELOAD_WINDOW_MS,
   setupPreloadErrorReload,
 } from '../../../src/ui/boot/setup-preload-error-reload.js';
-import {
-  broadcastStaleAssetReload,
-  setStaleAssetInstanceId,
-} from '../../../src/core/stale-asset-channel.js';
 
 function makeStorage(initial: Record<string, string> = {}, opts: { throwOn?: 'get' | 'set' } = {}) {
   const map = new Map(Object.entries(initial));
@@ -281,50 +387,40 @@ describe('decideStaleReload', () => {
 });
 
 describe('guardedReload', () => {
-  it('reloads once and persists the timestamp; suppresses a second call in-window', () => {
+  it('reloads once, persists, suppresses in-window, reloads again past window', () => {
     const reload = vi.fn();
     const storage = makeStorage();
     let t = 10_000;
     const deps = { reload, storage, now: () => t, windowMs: RELOAD_WINDOW_MS, storageKey: 'k' };
     expect(guardedReload(deps)).toBe(true);
-    expect(reload).toHaveBeenCalledTimes(1);
     t += 5_000;
     expect(guardedReload(deps)).toBe(false);
-    expect(reload).toHaveBeenCalledTimes(1);
     t += RELOAD_WINDOW_MS;
     expect(guardedReload(deps)).toBe(true);
     expect(reload).toHaveBeenCalledTimes(2);
   });
-
-  it('fail-closed: does not reload (and does not throw) when storage throws', () => {
+  it('fail-closed on storage throw (get or set): no reload, no throw', () => {
     const reload = vi.fn();
-    expect(() =>
-      guardedReload({
-        reload,
-        storage: makeStorage({}, { throwOn: 'get' }),
-        now: () => 1,
-        windowMs: RELOAD_WINDOW_MS,
-        storageKey: 'k',
-      })
-    ).not.toThrow();
-    expect(reload).not.toHaveBeenCalled();
-    expect(() =>
-      guardedReload({
-        reload,
-        storage: makeStorage({}, { throwOn: 'set' }),
-        now: () => 1,
-        windowMs: RELOAD_WINDOW_MS,
-        storageKey: 'k',
-      })
-    ).not.toThrow();
+    for (const throwOn of ['get', 'set'] as const) {
+      expect(() =>
+        guardedReload({
+          reload,
+          storage: makeStorage({}, { throwOn }),
+          now: () => 1,
+          windowMs: RELOAD_WINDOW_MS,
+          storageKey: 'k',
+        })
+      ).not.toThrow();
+    }
     expect(reload).not.toHaveBeenCalled();
   });
 });
 
 describe('setupPreloadErrorReload (page trigger)', () => {
   beforeEach(() => __resetForTest());
+  afterEach(() => __resetForTest());
 
-  it('reloads on vite:preloadError and preventDefaults only when it reloads', () => {
+  it('reloads on vite:preloadError; preventDefaults only when it reloads; suppresses in-window', () => {
     const reload = vi.fn();
     const storage = makeStorage();
     let t = 1_000;
@@ -352,23 +448,33 @@ describe('setupPreloadErrorReload (page trigger)', () => {
 describe('installWorkerStaleAssetReloadListener (worker trigger)', () => {
   beforeEach(() => {
     __resetForTest();
+    installFakeBroadcastChannel();
+  });
+  afterEach(() => {
     setStaleAssetInstanceId(undefined);
+    resetFakeBroadcastChannel();
+    __resetForTest();
   });
 
-  it('runs the guarded reload on a matching-instanceId broadcast', async () => {
+  it('runs the guarded reload on a matching-instanceId broadcast, ignores non-matching', async () => {
     const reload = vi.fn();
-    const storage = makeStorage();
     setupPreloadErrorReload({
       reload,
-      storage,
+      storage: makeStorage(),
       now: () => 1_000,
       windowMs: RELOAD_WINDOW_MS,
       storageKey: 'k',
     });
     installWorkerStaleAssetReloadListener('inst-A');
-    setStaleAssetInstanceId('inst-A');
+
+    setStaleAssetInstanceId('inst-B'); // other worker
     broadcastStaleAssetReload();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
+    expect(reload).not.toHaveBeenCalled();
+
+    setStaleAssetInstanceId('inst-A'); // our worker
+    broadcastStaleAssetReload();
+    await Promise.resolve();
     expect(reload).toHaveBeenCalledTimes(1);
   });
 });
@@ -379,15 +485,14 @@ describe('installWorkerStaleAssetReloadListener (worker trigger)', () => {
 Run: `npx vitest run packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts`
 Expected: FAIL — cannot resolve `setup-preload-error-reload.js`.
 
-- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 3: Write the implementation**
 
 ```ts
 // packages/webapp/src/ui/boot/setup-preload-error-reload.ts
 /**
  * Page-side stale-asset recovery (#1330). Owns the one guarded reload every
- * trigger shares, plus the page `vite:preloadError` handler (page-owned lazy
- * chunks) and the worker-broadcast listener. Sibling to
- * `setup-nuke-reload-listener.ts`. See the spec for the four-trigger design.
+ * trigger shares, the page `vite:preloadError` handler (page-owned lazy chunks),
+ * and the worker-broadcast listener. Sibling to `setup-nuke-reload-listener.ts`.
  */
 import { installStaleAssetReloadListener } from '../../core/stale-asset-channel.js';
 
@@ -424,10 +529,9 @@ export function decideStaleReload(
 }
 
 /**
- * Reload the page at most once per `windowMs` per tab. Fail-closed: if
- * `sessionStorage` can't be read or written we do NOT reload (never reload
- * without a persistable guard, or a broken deploy could loop). Returns whether
- * it triggered a reload.
+ * Reload at most once per `windowMs` per tab. Fail-closed: if `sessionStorage`
+ * can't be read or written we do NOT reload (never reload without a persistable
+ * guard, or a broken deploy could loop). Returns whether it reloaded.
  */
 export function guardedReload(deps: GuardedReloadDeps = defaultDeps()): boolean {
   let raw: string | null;
@@ -452,11 +556,8 @@ export function guardedReload(deps: GuardedReloadDeps = defaultDeps()): boolean 
 let vitePreloadHandler: ((e: Event) => void) | null = null;
 let activeDeps: GuardedReloadDeps | null = null;
 
-/**
- * Install the page `vite:preloadError` handler (idempotent). Call FIRST in
- * `main()`, before any dynamic `import()`. `preventDefault()` is called only
- * when we actually reload, so a guard-suppressed error still surfaces.
- */
+/** Install the page `vite:preloadError` handler (idempotent). Call FIRST in
+ *  `main()`. `preventDefault()` only when we actually reload. */
 export function setupPreloadErrorReload(deps?: Partial<GuardedReloadDeps>): void {
   if (vitePreloadHandler) return;
   activeDeps = { ...defaultDeps(), ...deps };
@@ -468,12 +569,9 @@ export function setupPreloadErrorReload(deps?: Partial<GuardedReloadDeps>): void
 
 let workerListenerDispose: (() => void) | null = null;
 
-/**
- * Install the instanceId-scoped worker-broadcast listener (idempotent). MUST be
- * called BEFORE `spawnKernelWorker()` — `BroadcastChannel` does not buffer and
- * the worker posts init synchronously, so a late listener misses a fast
- * boot-time failure. Runs the same `guardedReload` as the page trigger.
- */
+/** Install the instanceId-scoped worker-broadcast listener (idempotent). MUST be
+ *  called BEFORE `spawnKernelWorker()` — BroadcastChannel doesn't buffer and the
+ *  worker posts init synchronously. Runs the same `guardedReload`. */
 export function installWorkerStaleAssetReloadListener(instanceId: string): () => void {
   if (workerListenerDispose) return workerListenerDispose;
   workerListenerDispose = installStaleAssetReloadListener(instanceId, () => {
@@ -482,7 +580,7 @@ export function installWorkerStaleAssetReloadListener(instanceId: string): () =>
   return workerListenerDispose;
 }
 
-/** Test-only: detach handlers and clear module state. */
+/** Test-only: detach handlers + clear module state. */
 export function __resetForTest(): void {
   if (vitePreloadHandler) window.removeEventListener('vite:preloadError', vitePreloadHandler);
   vitePreloadHandler = null;
@@ -495,7 +593,7 @@ export function __resetForTest(): void {
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `npx vitest run packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts`
-Expected: PASS (5 tests).
+Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -511,29 +609,23 @@ git commit -m "feat(webapp): shared guarded reload + page vite:preloadError trig
 
 **Files:**
 
-- Modify: `packages/webapp/src/ui/main.ts` (inside `main()`, first statement)
+- Modify: `packages/webapp/src/ui/main.ts` (import; first statement in `main()` at line ~48)
 
-**Interfaces:**
+**Interfaces:** Consumes `setupPreloadErrorReload` (Task 2).
 
-- Consumes: `setupPreloadErrorReload` from Task 2.
-- Produces: nothing new.
-
-- [ ] **Step 1: Add the import and the first-statement call**
-
-At the top of `packages/webapp/src/ui/main.ts`, add the import alongside the other `./boot/…` imports:
+- [ ] **Step 1: Add the import** (alongside the other `./boot/…` imports):
 
 ```ts
 import { setupPreloadErrorReload } from './boot/setup-preload-error-reload.js';
 ```
 
-Then make it the FIRST statement inside `async function main()` (before `const app = document.getElementById('app')` and before the `?ui-fixture` check):
+- [ ] **Step 2: Make it the first statement in `main()`** (before `const app = document.getElementById('app')` and the `?ui-fixture` check):
 
 ```ts
 async function main(): Promise<void> {
-  // Recover any long-lived tab that crashes on a now-gone content-hashed chunk
+  // Recover a long-lived tab that crashes on a now-gone content-hashed chunk
   // after a deploy (#1330). Installed before any dynamic import() so page-owned
-  // lazy-chunk failures are always caught. Harmless on the ?ui-fixture surface
-  // (no worker, no provider imports).
+  // lazy-chunk failures are always caught. Harmless on the ?ui-fixture surface.
   setupPreloadErrorReload();
 
   const app = document.getElementById('app');
@@ -541,12 +633,12 @@ async function main(): Promise<void> {
 }
 ```
 
-- [ ] **Step 2: Typecheck**
+- [ ] **Step 3: Typecheck**
 
 Run: `npm run typecheck`
-Expected: PASS (no errors).
+Expected: PASS.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
 npx prettier --write packages/webapp/src/ui/main.ts
@@ -560,55 +652,91 @@ git commit -m "feat(webapp): register the stale-asset page trigger first in main
 
 **Files:**
 
-- Modify: `packages/webapp/src/scoops/scoop-context.ts` (import; new `handleStaleAssetError`; call before `handleNonRetryableError` at ~line 871)
+- Modify: `packages/webapp/src/scoops/scoop-context.ts` (import; `handleStaleAssetError`; call in `handlePromptAttemptError` at line ~871, before `handleNonRetryableError`)
 - Test: `packages/webapp/tests/scoops/scoop-context.test.ts` (extend)
 
-**Interfaces:**
+**Interfaces:** Consumes `isDynamicImportError`, `broadcastStaleAssetReload` (Task 1); existing `isRetryableError`, `emitAgentError`, `ScoopContext`.
 
-- Consumes: `isDynamicImportError`, `broadcastStaleAssetReload` from Task 1; existing `isRetryableError`.
-- Produces: private `handleStaleAssetError(message: string): boolean`.
+- [ ] **Step 1: Write the failing test**
 
-- [ ] **Step 1: Write the failing test (precedence)**
-
-Append to `packages/webapp/tests/scoops/scoop-context.test.ts`. It proves the stale-asset string ALSO matches the generic retry matcher, so the stale check must run first:
+Append to `packages/webapp/tests/scoops/scoop-context.test.ts`. Mock the channel module so `broadcastStaleAssetReload` is a spy but `isDynamicImportError` stays real (hoisted `vi.mock`):
 
 ```ts
 import { isDynamicImportError } from '../../src/core/stale-asset-channel.js';
 
-describe('stale-asset error takes precedence over the retry matcher', () => {
-  const staleMsg = 'Failed to fetch dynamically imported module: https://x/assets/anthropic-abc.js';
-  it('is detected as a dynamic-import error', () => {
-    expect(isDynamicImportError(staleMsg)).toBe(true);
+vi.mock('../../src/core/stale-asset-channel.js', async (orig) => {
+  const actual = await orig<typeof import('../../src/core/stale-asset-channel.js')>();
+  return { ...actual, broadcastStaleAssetReload: vi.fn() };
+});
+// eslint-disable-next-line import/first — grouped with the mock for clarity
+import { broadcastStaleAssetReload } from '../../src/core/stale-asset-channel.js';
+
+describe('ScoopContext stale-asset error handling', () => {
+  const STALE = 'Failed to fetch dynamically imported module: https://x/assets/anthropic-abc.js';
+
+  it('stale-asset string ALSO matches isRetryableError — so the stale check must run first', () => {
+    expect(isDynamicImportError(STALE)).toBe(true);
+    expect(isRetryableError(STALE)).toBe(true);
   });
-  it('ALSO matches isRetryableError ("failed to fetch") — hence the stale check must run first', () => {
-    expect(isRetryableError(staleMsg)).toBe(true);
+
+  it('handleStaleAssetError broadcasts + surfaces fatal for a dynamic-import error, and returns true', () => {
+    vi.mocked(broadcastStaleAssetReload).mockClear();
+    const callbacks = {
+      onError: vi.fn(),
+      onFatalError: vi.fn(),
+      onStatusChange: vi.fn(),
+      onMessagesUpdate: vi.fn(),
+      onScoopComplete: vi.fn(),
+    };
+    const ctx = new ScoopContext(testScoop, callbacks as any, {} as any);
+    const handled = (ctx as any).handleStaleAssetError(STALE) as boolean;
+    expect(handled).toBe(true);
+    expect(broadcastStaleAssetReload).toHaveBeenCalledTimes(1);
+    expect(callbacks.onFatalError).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleStaleAssetError ignores a non-dynamic-import error (returns false, no broadcast)', () => {
+    vi.mocked(broadcastStaleAssetReload).mockClear();
+    const callbacks = {
+      onError: vi.fn(),
+      onFatalError: vi.fn(),
+      onStatusChange: vi.fn(),
+      onMessagesUpdate: vi.fn(),
+      onScoopComplete: vi.fn(),
+    };
+    const ctx = new ScoopContext(testScoop, callbacks as any, {} as any);
+    expect((ctx as any).handleStaleAssetError('401 Unauthorized')).toBe(false);
+    expect(broadcastStaleAssetReload).not.toHaveBeenCalled();
   });
 });
 ```
 
+> Uses the file's existing `testScoop` fixture and the `new ScoopContext(...)` +
+> private-method-via-`as any` pattern already present in this test file. If the
+> callbacks shape differs from the current `ScoopContextCallbacks`, copy the exact
+> shape the other `describe` blocks build.
+
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run packages/webapp/tests/scoops/scoop-context.test.ts -t "stale-asset error takes precedence"`
-Expected: FAIL — cannot resolve `stale-asset-channel.js` import.
+Run: `npx vitest run packages/webapp/tests/scoops/scoop-context.test.ts -t "stale-asset error handling"`
+Expected: FAIL — `(ctx as any).handleStaleAssetError` is not a function.
 
 - [ ] **Step 3: Add the import**
 
-At the top of `packages/webapp/src/scoops/scoop-context.ts`, add:
+At the top of `packages/webapp/src/scoops/scoop-context.ts`:
 
 ```ts
 import { broadcastStaleAssetReload, isDynamicImportError } from '../core/stale-asset-channel.js';
 ```
 
-- [ ] **Step 4: Add the guard method**
-
-Add this private method next to `handleNonRetryableError` (after it, ~line 773):
+- [ ] **Step 4: Add `handleStaleAssetError`** (next to `handleNonRetryableError`, ~line 773):
 
 ```ts
   /**
    * Handle a stale-asset import failure (#1330). A gone content-hashed chunk
-   * after a deploy — retrying the cached-failed import is futile (checked
-   * before the retry matcher, which also matches "failed to fetch"), so ask the
-   * owning page to reload (guarded) and surface as fatal. Returns true if handled.
+   * after a deploy — retrying the cached-failed import is futile (checked BEFORE
+   * the retry matcher, which also matches "failed to fetch"), so ask the owning
+   * page to reload (guarded) and surface as fatal. Returns true if handled.
    */
   private handleStaleAssetError(message: string): boolean {
     if (!isDynamicImportError(message)) return false;
@@ -630,9 +758,7 @@ Add this private method next to `handleNonRetryableError` (after it, ~line 773):
   }
 ```
 
-- [ ] **Step 5: Call it first in the error sequence**
-
-In the turn-error handling (line ~871), add the stale check BEFORE the non-retryable check:
+- [ ] **Step 5: Call it first** in `handlePromptAttemptError` (line ~871), before the non-retryable check:
 
 ```ts
 if (this.handleStaleAssetError(message)) return true;
@@ -642,7 +768,7 @@ if (this.handleNonRetryableError(message)) return true;
 - [ ] **Step 6: Run tests**
 
 Run: `npx vitest run packages/webapp/tests/scoops/scoop-context.test.ts`
-Expected: PASS (existing + the 2 new precedence tests).
+Expected: PASS (existing + 3 new).
 
 - [ ] **Step 7: Commit**
 
@@ -658,61 +784,49 @@ git commit -m "feat(webapp): worker turn-time stale-asset trigger in scoop-conte
 
 **Files:**
 
-- Modify: `packages/webapp/src/kernel/kernel-worker.ts` (`boot()` — `setStaleAssetInstanceId` + `try/catch`)
+- Modify: `packages/webapp/src/kernel/kernel-worker.ts` (`boot()` at line ~241)
 
-**Interfaces:**
+**Interfaces:** Consumes `setStaleAssetInstanceId`, `broadcastIfStaleAssetError` (Task 1). Behavioral coverage for the detection lives in Task 1's `broadcastIfStaleAssetError` test (kernel-worker.ts can't be imported in a node test — its module-load `self.addEventListener` throws); the `boot()` wrap itself is verified by typecheck + the existing init-guard reset test.
 
-- Consumes: `setStaleAssetInstanceId`, `broadcastStaleAssetReload`, `isDynamicImportError` from Task 1.
-- Produces: nothing new (behavioral change to `boot`).
-
-- [ ] **Step 1: Add the import**
-
-At the top of `packages/webapp/src/kernel/kernel-worker.ts`:
+- [ ] **Step 1: Add the import** at the top of `packages/webapp/src/kernel/kernel-worker.ts`:
 
 ```ts
 import {
-  broadcastStaleAssetReload,
-  isDynamicImportError,
+  broadcastIfStaleAssetError,
   setStaleAssetInstanceId,
 } from '../core/stale-asset-channel.js';
 ```
 
-- [ ] **Step 2: Record the instanceId first, wrap the boot body**
+- [ ] **Step 2: Record instanceId + wrap the boot body**
 
-`boot()` currently reads `async function boot(init: KernelWorkerInitMsg): Promise<void> {` then runs its body (setBridgeToken … `registerProviders()` … `kernel-worker-ready`). Change to record the instanceId first and wrap the whole body so a stale boot import broadcasts then rethrows (preserving the init-guard reset + worker-ready-timeout fallback):
+`boot()` begins at line ~241 with `installFetchBypass()` and ends at line ~392 with `init.kernelPort.postMessage({ type: 'kernel-worker-ready' } satisfies KernelWorkerReadyMsg);`. Record the instanceId first, then wrap the ENTIRE existing body (from `installFetchBypass()` through the ready post) in a try/catch — only indent the existing statements, do not change them:
 
 ```ts
 async function boot(init: KernelWorkerInitMsg): Promise<void> {
-  // Record our instanceId up front so a stale-import failure anywhere in boot
-  // (registerProviders eagerly imports every provider chunk) can broadcast an
-  // instanceId-scoped reload request to the owning page. (#1330)
+  // #1330: record instanceId up front so a stale-import failure anywhere in boot
+  // (registerProviders eagerly imports every provider chunk) broadcasts an
+  // instanceId-scoped reload request to the owning page.
   setStaleAssetInstanceId(init.instanceId);
   try {
-    // ↓↓↓ the entire existing boot body, unchanged, moves inside this try ↓↓↓
-    setBridgeToken(init.bridgeToken ?? null);
-    // ... all existing statements through:
+    installFetchBypass();
+    // ... every existing boot statement, unchanged, through:
     init.kernelPort.postMessage({ type: 'kernel-worker-ready' } satisfies KernelWorkerReadyMsg);
-    // ↑↑↑ end existing body ↑↑↑
   } catch (err) {
-    if (isDynamicImportError(String((err as Error)?.message ?? err))) {
-      broadcastStaleAssetReload();
-    }
-    throw err;
+    broadcastIfStaleAssetError(err);
+    throw err; // preserve the init-guard reset + worker-ready-timeout fallback
   }
 }
 ```
-
-Do NOT change any statement inside the body — only indent it into the `try`.
 
 - [ ] **Step 3: Typecheck**
 
 Run: `npm run typecheck`
 Expected: PASS.
 
-- [ ] **Step 4: Run the kernel-worker unit tests (guard still resets on boot error)**
+- [ ] **Step 4: Run kernel tests (init-guard reset on boot error unchanged)**
 
 Run: `npx vitest run packages/webapp/tests/kernel/`
-Expected: PASS (the init-guard reset-on-error behavior is unchanged — `boot()` still rejects).
+Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -728,82 +842,85 @@ git commit -m "feat(webapp): worker boot-time stale-asset trigger in kernel-work
 
 **Files:**
 
-- Modify: `packages/webapp/src/kernel/spawn.ts` (`KernelWorkerSpawnOptions` + `spawnKernelWorker`)
-- Modify: `packages/webapp/src/ui/wc/wc-live.ts` (install listener before spawn; pass `onWorkerScriptError`)
-- Test: `packages/webapp/tests/kernel/spawn-worker-error.test.ts`
+- Modify: `packages/webapp/src/kernel/spawn.ts` (`WorkerLike` ~line 41; `KernelWorkerSpawnOptions` ~line 47; `KernelWorkerBootstrapOptions` ~line 108; `bootstrapKernelWorker` ~line 170; `spawnKernelWorker` ~line 301)
+- Modify: `packages/webapp/src/ui/wc/wc-live.ts` (spawn site ~line 1607; `instanceId` in scope from ~line 1580)
+- Test: `packages/webapp/tests/kernel/spawn.test.ts` (extend the existing `MockWorker`)
 
-**Interfaces:**
+**Interfaces:** Consumes `installWorkerStaleAssetReloadListener`, `guardedReload` (Task 2). Produces `onWorkerScriptError?: () => void` on both option types; `WorkerLike.addEventListener?`.
 
-- Consumes: `installWorkerStaleAssetReloadListener`, `guardedReload` from Task 2.
-- Produces: `KernelWorkerSpawnOptions.onWorkerScriptError?: () => void`.
+- [ ] **Step 1: Write the failing test** (extend `tests/kernel/spawn.test.ts`)
 
-- [ ] **Step 1: Write the failing test**
+Give the existing `MockWorker` an `addEventListener` that captures the `error` listener, then assert `bootstrapKernelWorker` wires it to `onWorkerScriptError`:
 
 ```ts
-// packages/webapp/tests/kernel/spawn-worker-error.test.ts
-// @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest';
-import { spawnKernelWorker } from '../../src/kernel/spawn.js';
-
-describe('spawnKernelWorker onWorkerScriptError', () => {
-  it('calls onWorkerScriptError when the worker script fails to load', () => {
+describe('bootstrapKernelWorker onWorkerScriptError', () => {
+  it('calls onWorkerScriptError when the worker fires an error event', () => {
+    let errorListener: (() => void) | null = null;
+    const worker: WorkerLike = {
+      postMessage: () => {},
+      terminate: () => {},
+      addEventListener: (_t: 'error', l: () => void) => {
+        errorListener = l;
+      },
+    };
     const onWorkerScriptError = vi.fn();
-    // A bogus workerUrl makes `new Worker` fail to load; jsdom emits an 'error'
-    // event on the Worker. (jsdom's Worker is a stub that never becomes ready,
-    // so we assert the listener is wired by dispatching the event ourselves.)
-    const host = spawnKernelWorker({
-      workerUrl: 'data:application/javascript,//noop',
+    const host = bootstrapKernelWorker({
+      worker,
       realCdpTransport: { on: () => {}, off: () => {}, send: async () => ({}) } as never,
       callbacks: {} as never,
-      instanceId: 'inst-A',
       onWorkerScriptError,
     });
-    // The Worker reference is not exposed; simulate the browser firing 'error'
-    // by grabbing it via the spy path is overkill — instead assert no throw and
-    // that a subsequent error event on any Worker created is handled. We assert
-    // wiring indirectly: the option is accepted and spawn returns a host.
-    expect(host).toBeTruthy();
-    host.dispose?.();
+    expect(errorListener).toBeTypeOf('function');
+    errorListener!();
+    expect(onWorkerScriptError).toHaveBeenCalledTimes(1);
+    host.dispose();
   });
 });
 ```
 
-> Note: jsdom's `Worker` does not reliably emit `error` for a bad module URL. Keep this test to "option accepted + no throw"; the behavioral guarantee (a real `error` event → `guardedReload`) is covered by Task 2's `installWorkerStaleAssetReloadListener` test plus the one-line `addEventListener` wiring, which is code-review-verifiable.
-
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run packages/webapp/tests/kernel/spawn-worker-error.test.ts`
-Expected: FAIL — `onWorkerScriptError` is not a known option (TS) / host shape mismatch.
+Run: `npx vitest run packages/webapp/tests/kernel/spawn.test.ts -t "onWorkerScriptError"`
+Expected: FAIL — `onWorkerScriptError` not in options / listener never captured.
 
-- [ ] **Step 3: Add the option to `spawn.ts`**
+- [ ] **Step 3: Extend `WorkerLike` + both option types + wire the listener in `bootstrapKernelWorker`**
 
-In `KernelWorkerSpawnOptions` (the interface around line 119), add:
+In `spawn.ts`, add to `WorkerLike` (~line 42):
+
+```ts
+  /** Optional — real `Worker` has it; the mock may omit it. */
+  addEventListener?(type: 'error', listener: () => void): void;
+```
+
+Add to BOTH `KernelWorkerSpawnOptions` (~line 47) and `KernelWorkerBootstrapOptions` (~line 108):
 
 ```ts
   /** Page-side hook fired if the worker ENTRY chunk fails to load (stale after a
-   *  deploy) — the worker never evaluates, so its own boot catch can't run.
-   *  Wired to the guarded reload. (#1330) */
+   *  deploy) — the worker never evaluates, so its own boot catch can't run. (#1330) */
   onWorkerScriptError?: () => void;
 ```
 
-In `spawnKernelWorker` (line 301), attach the handler right after the `Worker` is created, before `bootstrapKernelWorker`:
+In `bootstrapKernelWorker` (~line 170), attach the listener near the top (before/after wiring the ports — anywhere before returning):
 
 ```ts
-export function spawnKernelWorker(options: KernelWorkerSpawnOptions): SpawnedKernelHost {
-  const worker = options.workerUrl
-    ? new Worker(options.workerUrl, { type: 'module' })
-    : new Worker(new URL('./kernel-worker.ts', import.meta.url), { type: 'module' });
-  if (options.onWorkerScriptError) {
-    worker.addEventListener('error', () => options.onWorkerScriptError!());
-  }
-  return bootstrapKernelWorker({
-    worker,
-    // ...existing fields unchanged...
-  });
+if (options.onWorkerScriptError) {
+  options.worker.addEventListener?.('error', () => options.onWorkerScriptError!());
 }
 ```
 
-- [ ] **Step 4: Wire the caller in `wc-live.ts`**
+In `spawnKernelWorker` (~line 305), pass it through to `bootstrapKernelWorker`:
+
+```ts
+    extensionDelegateId: options.extensionDelegateId,
+    onWorkerScriptError: options.onWorkerScriptError,
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run packages/webapp/tests/kernel/spawn.test.ts`
+Expected: PASS (existing + new).
+
+- [ ] **Step 5: Wire the caller in `wc-live.ts`**
 
 Add the import near the other boot imports:
 
@@ -814,13 +931,13 @@ import {
 } from '../boot/setup-preload-error-reload.js';
 ```
 
-At the spawn site (line ~1607), install the listener BEFORE `spawnKernelWorker` and pass `onWorkerScriptError`:
+At the spawn site (~line 1607), install the listener BEFORE `spawnKernelWorker` and pass `onWorkerScriptError`:
 
 ```ts
 const boot = prepareWcShell(app, floatLabel);
-// #1330: install the instanceId-scoped reload listener BEFORE spawning the
-// worker — BroadcastChannel doesn't buffer and the worker posts init
-// synchronously, so a late listener would miss a fast boot-time failure.
+// #1330: install the reload listener BEFORE spawning — BroadcastChannel doesn't
+// buffer and the worker posts init synchronously, so a late listener would miss
+// a fast boot-time failure.
 if (instanceId) installWorkerStaleAssetReloadListener(instanceId);
 const host = spawnKernelWorker({
   realCdpTransport,
@@ -836,33 +953,28 @@ const host = spawnKernelWorker({
 });
 ```
 
-- [ ] **Step 5: Run test + typecheck**
+- [ ] **Step 6: Typecheck**
 
-Run: `npx vitest run packages/webapp/tests/kernel/spawn-worker-error.test.ts && npm run typecheck`
+Run: `npm run typecheck`
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-npx prettier --write packages/webapp/src/kernel/spawn.ts packages/webapp/src/ui/wc/wc-live.ts packages/webapp/tests/kernel/spawn-worker-error.test.ts
-git add packages/webapp/src/kernel/spawn.ts packages/webapp/src/ui/wc/wc-live.ts packages/webapp/tests/kernel/spawn-worker-error.test.ts
+npx prettier --write packages/webapp/src/kernel/spawn.ts packages/webapp/src/ui/wc/wc-live.ts packages/webapp/tests/kernel/spawn.test.ts
+git add packages/webapp/src/kernel/spawn.ts packages/webapp/src/ui/wc/wc-live.ts packages/webapp/tests/kernel/spawn.test.ts
 git commit -m "feat(webapp): worker.onerror trigger + install reload listener before spawn (#1330)"
 ```
 
 ---
 
-### Task 7: Docs + close the issue
+### Task 7: Docs + verification + close the issue
 
 **Files:**
 
-- Modify: `packages/webapp/CLAUDE.md` (UI/boot section)
-- Modify: `docs/pitfalls.md`
+- Modify: `packages/webapp/CLAUDE.md`, `docs/pitfalls.md`
 
-**Interfaces:** none.
-
-- [ ] **Step 1: Add the webapp CLAUDE.md note**
-
-Under the `packages/webapp/CLAUDE.md` "UI" or boot area, add:
+- [ ] **Step 1: Add the webapp CLAUDE.md note** (UI/boot section):
 
 ```markdown
 ### Stale-asset recovery (post-deploy)
@@ -870,36 +982,27 @@ Under the `packages/webapp/CLAUDE.md` "UI" or boot area, add:
 After a deploy, a long-lived tab/worker can crash on a now-gone content-hashed
 chunk (#1330). Four triggers funnel into one shared, **instanceId-scoped**,
 **fail-closed**, timestamp-guarded (`RELOAD_WINDOW_MS = 60_000`) page reload
-(`ui/boot/setup-preload-error-reload.ts` + the realm-agnostic
-`core/stale-asset-channel.ts`):
-
-- page `window` `vite:preloadError` — page-owned lazy chunks;
-- page `Worker` `error` (`spawn.ts` `onWorkerScriptError`) — a stale worker ENTRY chunk;
-- worker `boot()` `try/catch` — boot-time `registerProviders()` imports;
-- worker `scoop-context` classifier — turn-time imports (checked BEFORE the
-  `failed to fetch` retry matcher so it isn't retried 3× futilely).
-
-Worker triggers `broadcastStaleAssetReload()` over `BroadcastChannel`, stamped
-with the worker's `instanceId`; only the owning page reloads. The listener is
-installed BEFORE `spawnKernelWorker()` (BroadcastChannel doesn't buffer). Fresh
-`index.html` on reload relies on `location.reload()` top-document revalidation.
+(`ui/boot/setup-preload-error-reload.ts` + realm-agnostic
+`core/stale-asset-channel.ts`): page `vite:preloadError`; page `Worker` `error`
+(`spawn.ts` `onWorkerScriptError`); worker `boot()` `try/catch`
+(`broadcastIfStaleAssetError`); worker `scoop-context` classifier (checked BEFORE
+the `failed to fetch` retry matcher). Worker triggers broadcast over
+`BroadcastChannel` stamped with `instanceId`; only the owning page reloads. The
+listener installs BEFORE `spawnKernelWorker()` (BroadcastChannel doesn't buffer).
 ```
 
-- [ ] **Step 2: Add the pitfalls.md entry**
-
-Append to `docs/pitfalls.md`:
+- [ ] **Step 2: Add the pitfalls.md entry:**
 
 ```markdown
 ## Stale content-hashed chunks after a deploy (#1330)
 
-A long-lived sliccy.ai tab/worker holds an old module graph; after a deploy the
-old `/assets/<hash>.js` is gone. The worker's SPA fallback
-(`not_found_handling: single-page-application`) returns `index.html` as
-`200 text/html`, so the lazy `import()` rejects with a MIME/module-script error
-(not a 404). The failing import is usually WORKER-owned (providers load in the
-kernel worker), and Vite injects `vite:preloadError` only into the PAGE bundle —
-so a `window` listener alone can't catch it. Recovery is the four-trigger guarded
-reload in `core/stale-asset-channel.ts` + `ui/boot/setup-preload-error-reload.ts`.
+A long-lived tab/worker holds an old module graph; after a deploy the old
+`/assets/<hash>.js` is gone and the worker's SPA fallback returns `index.html` as
+`200 text/html`, so the lazy `import()` rejects with a MIME/module-script error.
+The failing import is usually WORKER-owned (providers load in the kernel worker),
+and Vite injects `vite:preloadError` only into the PAGE bundle — so a `window`
+listener alone can't catch it. Recovery is the four-trigger guarded reload in
+`core/stale-asset-channel.ts` + `ui/boot/setup-preload-error-reload.ts`.
 ```
 
 - [ ] **Step 3: Commit**
@@ -910,9 +1013,7 @@ git add packages/webapp/CLAUDE.md docs/pitfalls.md
 git commit -m "docs: stale-asset recovery note + pitfall (#1330)"
 ```
 
-- [ ] **Step 4: Full verification gate**
-
-Run each and confirm PASS:
+- [ ] **Step 4: Full verification gate** — run each, confirm PASS:
 
 ```bash
 npm run lint:ci
@@ -922,32 +1023,16 @@ npm run test:coverage:webapp
 npm run build -w @slicc/chrome-extension
 ```
 
-(The top-level `npm run build` fails only at the `swift-server` step on this
-machine — a known Swift-toolchain constraint unrelated to this change; the TS
-workspaces build before it.)
+(Top-level `npm run build` fails only at the `swift-server` step on this machine — a known Swift-toolchain constraint unrelated to this change; the TS workspaces build before it.)
 
-- [ ] **Step 5: Close the issue on merge**
-
-Ensure the PR body includes `Fixes #1330`.
+- [ ] **Step 5: PR body includes `Fixes #1330`.**
 
 ---
 
 ## Self-Review
 
-**Spec coverage:**
+**Spec coverage:** page `vite:preloadError` → Task 2/3; worker boot-time → Task 5 (+ `broadcastIfStaleAssetError` test in Task 1); worker turn-time → Task 4; page `worker.onerror` → Task 6; instanceId-scoped channel + module-script-anchored matcher → Task 1; 60 s timestamp guard + fail-closed → Task 2; install-before-spawn ordering → Task 6; `setStaleAssetInstanceId` + dev-warn → Task 1 (impl + test); listener idempotency at the wrapper → Task 2; worker-safety proof → Task 1 (tsconfig include); docs + close → Task 7. ✓
 
-- Page `vite:preloadError` trigger → Task 2 + Task 3. ✓
-- Worker boot-time trigger → Task 5. ✓
-- Worker turn-time trigger → Task 4. ✓
-- Page `worker.onerror` trigger → Task 6. ✓
-- instanceId-scoped channel + `isDynamicImportError` (module-script anchored) → Task 1. ✓
-- Timestamp guard (60 s) + fail-closed → Task 2. ✓
-- Install-before-spawn ordering → Task 6 (caller installs before `spawnKernelWorker`). ✓
-- `setStaleAssetInstanceId` at boot start + dev-warn → Task 1 + Task 5. ✓
-- Idempotent listener → Task 2 (`installWorkerStaleAssetReloadListener` guard). ✓
-- Docs + close #1330 → Task 7. ✓
-- Out-of-scope (worker `no-cache`, server 404, cloud auto-restart) → intentionally omitted. ✓
+**Placeholder scan:** every code step shows complete code; no TBD/TODO; the one test that can't be fully exercised in the env (real `Worker`) is replaced by the injectable `bootstrapKernelWorker` + `MockWorker` path — honest coverage. ✓
 
-**Placeholder scan:** No TBD/TODO; every code step shows complete code. The one soft spot (jsdom can't reliably fire `Worker` `error`) is called out explicitly with the compensating coverage, not hidden. ✓
-
-**Type consistency:** `guardedReload(deps?)`, `GuardedReloadDeps`, `installWorkerStaleAssetReloadListener(instanceId)`, `broadcastStaleAssetReload()`, `setStaleAssetInstanceId(id)`, `isDynamicImportError(msg)`, `onWorkerScriptError?` — names/signatures match across Tasks 1, 2, 4, 5, 6. ✓
+**Type consistency:** `guardedReload(deps?)`, `GuardedReloadDeps`, `installWorkerStaleAssetReloadListener(instanceId)`, `broadcastStaleAssetReload()`, `broadcastIfStaleAssetError(err)`, `setStaleAssetInstanceId(id)`, `isDynamicImportError(msg)`, `installStaleAssetReloadListener(instanceId,onReload)`, `WorkerLike.addEventListener?`, `onWorkerScriptError?` — consistent across Tasks 1, 2, 4, 5, 6. ✓

--- a/docs/superpowers/plans/2026-07-07-stale-asset-recovery.md
+++ b/docs/superpowers/plans/2026-07-07-stale-asset-recovery.md
@@ -659,18 +659,25 @@ git commit -m "feat(webapp): register the stale-asset page trigger first in main
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `packages/webapp/tests/scoops/scoop-context.test.ts`. Mock the channel module so `broadcastStaleAssetReload` is a spy but `isDynamicImportError` stays real (hoisted `vi.mock`):
+Add the mock + imports **at the top of the file, grouped with the existing imports/mocks** (Vitest hoists `vi.mock` regardless of position — this is a Biome repo, so do NOT add an `eslint-disable import/first` comment):
 
 ```ts
-import { isDynamicImportError } from '../../src/core/stale-asset-channel.js';
+// with the other top-level imports:
+import {
+  broadcastStaleAssetReload,
+  isDynamicImportError,
+} from '../../src/core/stale-asset-channel.js';
 
+// with the other top-level vi.mock() calls:
 vi.mock('../../src/core/stale-asset-channel.js', async (orig) => {
   const actual = await orig<typeof import('../../src/core/stale-asset-channel.js')>();
   return { ...actual, broadcastStaleAssetReload: vi.fn() };
 });
-// eslint-disable-next-line import/first — grouped with the mock for clarity
-import { broadcastStaleAssetReload } from '../../src/core/stale-asset-channel.js';
+```
 
+Then append the describe block, reusing the file's existing `createMockCallbacks()` helper and shared `testScoop` fixture (matching the other `describe` blocks):
+
+```ts
 describe('ScoopContext stale-asset error handling', () => {
   const STALE = 'Failed to fetch dynamically imported module: https://x/assets/anthropic-abc.js';
 
@@ -681,14 +688,8 @@ describe('ScoopContext stale-asset error handling', () => {
 
   it('handleStaleAssetError broadcasts + surfaces fatal for a dynamic-import error, and returns true', () => {
     vi.mocked(broadcastStaleAssetReload).mockClear();
-    const callbacks = {
-      onError: vi.fn(),
-      onFatalError: vi.fn(),
-      onStatusChange: vi.fn(),
-      onMessagesUpdate: vi.fn(),
-      onScoopComplete: vi.fn(),
-    };
-    const ctx = new ScoopContext(testScoop, callbacks as any, {} as any);
+    const callbacks = createMockCallbacks();
+    const ctx = new ScoopContext(testScoop, callbacks, {} as any);
     const handled = (ctx as any).handleStaleAssetError(STALE) as boolean;
     expect(handled).toBe(true);
     expect(broadcastStaleAssetReload).toHaveBeenCalledTimes(1);
@@ -697,24 +698,21 @@ describe('ScoopContext stale-asset error handling', () => {
 
   it('handleStaleAssetError ignores a non-dynamic-import error (returns false, no broadcast)', () => {
     vi.mocked(broadcastStaleAssetReload).mockClear();
-    const callbacks = {
-      onError: vi.fn(),
-      onFatalError: vi.fn(),
-      onStatusChange: vi.fn(),
-      onMessagesUpdate: vi.fn(),
-      onScoopComplete: vi.fn(),
-    };
-    const ctx = new ScoopContext(testScoop, callbacks as any, {} as any);
+    const callbacks = createMockCallbacks();
+    const ctx = new ScoopContext(testScoop, callbacks, {} as any);
     expect((ctx as any).handleStaleAssetError('401 Unauthorized')).toBe(false);
     expect(broadcastStaleAssetReload).not.toHaveBeenCalled();
   });
 });
 ```
 
-> Uses the file's existing `testScoop` fixture and the `new ScoopContext(...)` +
-> private-method-via-`as any` pattern already present in this test file. If the
-> callbacks shape differs from the current `ScoopContextCallbacks`, copy the exact
-> shape the other `describe` blocks build.
+> `createMockCallbacks()` and `testScoop` already exist in this test file, and
+> the private-method-via-`(ctx as any)` pattern is used elsewhere in it.
+> `handleStaleAssetError` only touches `onStatusChange` + `onFatalError`/`onError`
+>
+> - telemetry (`emitAgentError` is a no-op without a sink), so no real FS/container
+>   is needed. If `createMockCallbacks()` doesn't set `onFatalError` (it's optional
+>   on `ScoopContextCallbacks`), assert on `onError` instead — the fallback branch.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -864,16 +862,23 @@ describe('bootstrapKernelWorker onWorkerScriptError', () => {
       },
     };
     const onWorkerScriptError = vi.fn();
+    // Small readyTimeoutMs so the never-posts-ready mock can't arm a 30s timer,
+    // and dispose() in `finally` clears it even if an assertion throws (dispose
+    // → cleanupReady clears the ready timeout — spawn.ts).
     const host = bootstrapKernelWorker({
       worker,
       realCdpTransport: { on: () => {}, off: () => {}, send: async () => ({}) } as never,
       callbacks: {} as never,
+      readyTimeoutMs: 50,
       onWorkerScriptError,
     });
-    expect(errorListener).toBeTypeOf('function');
-    errorListener!();
-    expect(onWorkerScriptError).toHaveBeenCalledTimes(1);
-    host.dispose();
+    try {
+      expect(errorListener).toBeTypeOf('function');
+      errorListener!();
+      expect(onWorkerScriptError).toHaveBeenCalledTimes(1);
+    } finally {
+      host.dispose();
+    }
   });
 });
 ```

--- a/docs/superpowers/plans/2026-07-07-stale-asset-recovery.md
+++ b/docs/superpowers/plans/2026-07-07-stale-asset-recovery.md
@@ -1,0 +1,953 @@
+# Stale-asset recovery after deploy — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a deploy, automatically recover any long-lived SLICC tab/worker that crashes on a now-gone content-hashed Vite chunk, instead of leaving the session unrecoverable (issue #1330).
+
+**Architecture:** Four triggers funnel into one shared, instanceId-scoped, fail-closed, timestamp-guarded page reload. Two page-side triggers (`window` `vite:preloadError` for page-owned lazy chunks; a `Worker` `error` event for a stale worker entry chunk) and two worker-side triggers (a `boot()` `try/catch` for boot-time provider imports; the `scoop-context` turn-error classifier) — the worker triggers `postMessage` an instanceId-stamped signal over a `BroadcastChannel` that only the owning page acts on.
+
+**Tech Stack:** TypeScript, Vite (content-hashed chunks + `__vitePreload`/`vite:preloadError`), Vitest (jsdom for DOM/BroadcastChannel tests), Cloudflare Workers Static Assets (SPA fallback).
+
+## Global Constraints
+
+- Scope is **`packages/webapp` only** — no `cloudflare-worker` / `cloud-core` changes.
+- The shared detection/channel module MUST be realm-agnostic (no `window`/`document` at module scope) — it is imported by the page AND the kernel worker.
+- Reload guard: **timestamp window `RELOAD_WINDOW_MS = 60_000`** (must exceed the 30 s host-ready boot timeout), **fail-closed** on any `sessionStorage` throw (never reload if the guard can't be read/persisted), `sessionStorage` key `'slicc:stale-asset-reloaded-at'`.
+- Worker→page signal is **instanceId-scoped** (`BroadcastChannel 'slicc-stale-asset-reload'`, message `{ type: 'stale-asset-reload', instanceId }`); the page listener acts only on its own `instanceId`. Never origin-wide.
+- **Ordering is load-bearing:** `BroadcastChannel` does NOT buffer and `spawnKernelWorker()` posts `kernel-worker-init` synchronously, so the page reload listener MUST be installed BEFORE `spawnKernelWorker()` is called.
+- `isDynamicImportError` anchors on module-script context (`module script` / `JavaScript module` / `dynamically imported module`); a bare `MIME type` match is forbidden (false-positive risk).
+- Commits: focused, package-local, **no `Co-Authored-By` trailer**. Run `npx prettier --write` on touched files before each commit.
+
+## File Structure
+
+- **Create** `packages/webapp/src/core/stale-asset-channel.ts` — realm-agnostic: `isDynamicImportError`, the `BroadcastChannel` name + message type, `setStaleAssetInstanceId`, `broadcastStaleAssetReload`, `installStaleAssetReloadListener`. (In `core/` — imported by both page and worker; avoids a worker→`ui/` import.)
+- **Create** `packages/webapp/src/ui/boot/setup-preload-error-reload.ts` — page-only: `decideStaleReload`, `guardedReload`, `setupPreloadErrorReload`, `installWorkerStaleAssetReloadListener`.
+- **Modify** `packages/webapp/src/ui/main.ts` — call `setupPreloadErrorReload()` first in `main()`.
+- **Modify** `packages/webapp/src/scoops/scoop-context.ts` — turn-time trigger: a stale-asset guard checked before `handleNonRetryableError`.
+- **Modify** `packages/webapp/src/kernel/kernel-worker.ts` — boot-time trigger: `setStaleAssetInstanceId` + `try/catch` around `boot()`.
+- **Modify** `packages/webapp/src/kernel/spawn.ts` — `onWorkerScriptError?` option → `worker.addEventListener('error', …)`.
+- **Modify** `packages/webapp/src/ui/wc/wc-live.ts` — install the listener before `spawnKernelWorker`, pass `onWorkerScriptError`.
+- **Create** tests: `tests/core/stale-asset-channel.test.ts`, `tests/ui/boot/setup-preload-error-reload.test.ts`; **extend** `tests/scoops/scoop-context.test.ts`.
+- **Modify** docs: `packages/webapp/CLAUDE.md`, `docs/pitfalls.md`.
+
+---
+
+### Task 1: Shared detection + channel module
+
+**Files:**
+
+- Create: `packages/webapp/src/core/stale-asset-channel.ts`
+- Test: `packages/webapp/tests/core/stale-asset-channel.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing (leaf module).
+- Produces:
+  - `isDynamicImportError(msg: string): boolean`
+  - `STALE_ASSET_RELOAD_CHANNEL: string`
+  - `interface StaleAssetReloadMsg { type: 'stale-asset-reload'; instanceId: string }`
+  - `setStaleAssetInstanceId(id: string | undefined): void`
+  - `broadcastStaleAssetReload(): void`
+  - `installStaleAssetReloadListener(instanceId: string, onReload: () => void): () => void`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/webapp/tests/core/stale-asset-channel.test.ts
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  broadcastStaleAssetReload,
+  installStaleAssetReloadListener,
+  isDynamicImportError,
+  setStaleAssetInstanceId,
+} from '../../src/core/stale-asset-channel.js';
+
+describe('isDynamicImportError', () => {
+  it('matches the cross-browser dynamic-import / module-script failure family', () => {
+    expect(isDynamicImportError('Failed to fetch dynamically imported module: /assets/x.js')).toBe(
+      true
+    );
+    expect(isDynamicImportError('error loading dynamically imported module')).toBe(true);
+    expect(isDynamicImportError('Importing a module script failed.')).toBe(true);
+    expect(
+      isDynamicImportError(
+        'Expected a JavaScript module script but the server responded with a MIME type of text/html'
+      )
+    ).toBe(true);
+  });
+
+  it('does NOT match unrelated errors (no bare MIME / bare failed-to-fetch)', () => {
+    expect(isDynamicImportError('401 Unauthorized')).toBe(false);
+    expect(isDynamicImportError('rate limit exceeded')).toBe(false);
+    expect(isDynamicImportError('network error')).toBe(false);
+    expect(isDynamicImportError('Upload failed: unsupported MIME type image/tiff')).toBe(false);
+    expect(isDynamicImportError('TypeError: Failed to fetch')).toBe(false);
+  });
+});
+
+describe('broadcastStaleAssetReload / installStaleAssetReloadListener', () => {
+  afterEach(() => setStaleAssetInstanceId(undefined));
+
+  it('delivers only to a listener with the matching instanceId', async () => {
+    const matched = vi.fn();
+    const other = vi.fn();
+    const d1 = installStaleAssetReloadListener('inst-A', matched);
+    const d2 = installStaleAssetReloadListener('inst-B', other);
+    setStaleAssetInstanceId('inst-A');
+    broadcastStaleAssetReload();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(matched).toHaveBeenCalledTimes(1);
+    expect(other).not.toHaveBeenCalled();
+    d1();
+    d2();
+  });
+
+  it('no-ops when no instanceId has been set', async () => {
+    const cb = vi.fn();
+    const d = installStaleAssetReloadListener('inst-A', cb);
+    broadcastStaleAssetReload();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(cb).not.toHaveBeenCalled();
+    d();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/webapp/tests/core/stale-asset-channel.test.ts`
+Expected: FAIL — cannot resolve `../../src/core/stale-asset-channel.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// packages/webapp/src/core/stale-asset-channel.ts
+/**
+ * Realm-agnostic detection + worker→page signal for stale-chunk recovery after
+ * a deploy (#1330). Shell-free and DOM-free at module scope (only
+ * `BroadcastChannel`, available in the page AND the kernel worker), so both
+ * realms import it. Mirrors the split-out shape of `nuke-channel.ts`.
+ */
+import { createLogger } from './logger.js';
+
+const log = createLogger('stale-asset');
+
+// Anchored on module-script context — NOT a bare "MIME type" or "failed to
+// fetch", which would false-positive on unrelated tool/upload/provider errors
+// classified from a generic error.message.
+const DYNAMIC_IMPORT_ERROR_RE =
+  /dynamically imported module|importing a module script failed|expected a javascript module|module script/i;
+
+/** True for the cross-browser dynamic-import / module-script load failure family. */
+export function isDynamicImportError(msg: string): boolean {
+  return DYNAMIC_IMPORT_ERROR_RE.test(msg);
+}
+
+/** Same-origin channel the failing worker uses to ask its owning page to reload. */
+export const STALE_ASSET_RELOAD_CHANNEL = 'slicc-stale-asset-reload';
+
+export interface StaleAssetReloadMsg {
+  type: 'stale-asset-reload';
+  instanceId: string;
+}
+
+// Set once by the kernel worker at boot start; read by the broadcasters so both
+// worker failure sites reach the signal without threading the id through.
+let workerInstanceId: string | null = null;
+
+/** Kernel worker records `init.instanceId` at boot start. Dev-warns if absent. */
+export function setStaleAssetInstanceId(id: string | undefined): void {
+  if (!id) {
+    workerInstanceId = null;
+    if (import.meta.env?.DEV) {
+      log.warn('no instanceId for kernel worker; stale-asset reload signal disabled');
+    }
+    return;
+  }
+  workerInstanceId = id;
+}
+
+/** Post an instanceId-stamped reload request. No-op until an id is set. */
+export function broadcastStaleAssetReload(): void {
+  if (!workerInstanceId || typeof BroadcastChannel !== 'function') return;
+  const channel = new BroadcastChannel(STALE_ASSET_RELOAD_CHANNEL);
+  try {
+    channel.postMessage({
+      type: 'stale-asset-reload',
+      instanceId: workerInstanceId,
+    } satisfies StaleAssetReloadMsg);
+  } finally {
+    channel.close();
+  }
+}
+
+/**
+ * Page-side listener. Invokes `onReload` only for a broadcast stamped with the
+ * page's own `instanceId` (never another tab's). Returns a disposer.
+ */
+export function installStaleAssetReloadListener(
+  instanceId: string,
+  onReload: () => void
+): () => void {
+  if (typeof BroadcastChannel !== 'function') return () => {};
+  const channel = new BroadcastChannel(STALE_ASSET_RELOAD_CHANNEL);
+  const handler = (event: MessageEvent): void => {
+    const data = event.data as StaleAssetReloadMsg | undefined;
+    if (data?.type !== 'stale-asset-reload' || data.instanceId !== instanceId) return;
+    onReload();
+  };
+  channel.addEventListener('message', handler);
+  return () => {
+    channel.removeEventListener('message', handler);
+    channel.close();
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run packages/webapp/tests/core/stale-asset-channel.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+npx prettier --write packages/webapp/src/core/stale-asset-channel.ts packages/webapp/tests/core/stale-asset-channel.test.ts
+git add packages/webapp/src/core/stale-asset-channel.ts packages/webapp/tests/core/stale-asset-channel.test.ts
+git commit -m "feat(webapp): stale-asset detection + instanceId-scoped reload channel (#1330)"
+```
+
+---
+
+### Task 2: Shared guarded reload + page `vite:preloadError` trigger
+
+**Files:**
+
+- Create: `packages/webapp/src/ui/boot/setup-preload-error-reload.ts`
+- Test: `packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts`
+
+**Interfaces:**
+
+- Consumes: `installStaleAssetReloadListener` from Task 1.
+- Produces:
+  - `RELOAD_WINDOW_MS: number`
+  - `decideStaleReload(lastReloadAt: number | null, now: number, windowMs: number): boolean`
+  - `interface GuardedReloadDeps { reload: () => void; storage: Pick<Storage,'getItem'|'setItem'>; now: () => number; windowMs: number; storageKey: string }`
+  - `guardedReload(deps?: GuardedReloadDeps): boolean`
+  - `setupPreloadErrorReload(deps?: Partial<GuardedReloadDeps>): void`
+  - `installWorkerStaleAssetReloadListener(instanceId: string): () => void`
+  - `__resetForTest(): void`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetForTest,
+  decideStaleReload,
+  guardedReload,
+  installWorkerStaleAssetReloadListener,
+  RELOAD_WINDOW_MS,
+  setupPreloadErrorReload,
+} from '../../../src/ui/boot/setup-preload-error-reload.js';
+import {
+  broadcastStaleAssetReload,
+  setStaleAssetInstanceId,
+} from '../../../src/core/stale-asset-channel.js';
+
+function makeStorage(initial: Record<string, string> = {}, opts: { throwOn?: 'get' | 'set' } = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => {
+      if (opts.throwOn === 'get') throw new Error('storage disabled');
+      return map.get(k) ?? null;
+    },
+    setItem: (k: string, v: string) => {
+      if (opts.throwOn === 'set') throw new Error('storage disabled');
+      map.set(k, v);
+    },
+  };
+}
+
+describe('decideStaleReload', () => {
+  it('reloads when no prior timestamp; suppresses within window; allows past window', () => {
+    expect(decideStaleReload(null, 1_000, RELOAD_WINDOW_MS)).toBe(true);
+    expect(decideStaleReload(1_000, 1_000 + 5_000, RELOAD_WINDOW_MS)).toBe(false);
+    expect(decideStaleReload(1_000, 1_000 + RELOAD_WINDOW_MS, RELOAD_WINDOW_MS)).toBe(true);
+  });
+});
+
+describe('guardedReload', () => {
+  it('reloads once and persists the timestamp; suppresses a second call in-window', () => {
+    const reload = vi.fn();
+    const storage = makeStorage();
+    let t = 10_000;
+    const deps = { reload, storage, now: () => t, windowMs: RELOAD_WINDOW_MS, storageKey: 'k' };
+    expect(guardedReload(deps)).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(1);
+    t += 5_000;
+    expect(guardedReload(deps)).toBe(false);
+    expect(reload).toHaveBeenCalledTimes(1);
+    t += RELOAD_WINDOW_MS;
+    expect(guardedReload(deps)).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('fail-closed: does not reload (and does not throw) when storage throws', () => {
+    const reload = vi.fn();
+    expect(() =>
+      guardedReload({
+        reload,
+        storage: makeStorage({}, { throwOn: 'get' }),
+        now: () => 1,
+        windowMs: RELOAD_WINDOW_MS,
+        storageKey: 'k',
+      })
+    ).not.toThrow();
+    expect(reload).not.toHaveBeenCalled();
+    expect(() =>
+      guardedReload({
+        reload,
+        storage: makeStorage({}, { throwOn: 'set' }),
+        now: () => 1,
+        windowMs: RELOAD_WINDOW_MS,
+        storageKey: 'k',
+      })
+    ).not.toThrow();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe('setupPreloadErrorReload (page trigger)', () => {
+  beforeEach(() => __resetForTest());
+
+  it('reloads on vite:preloadError and preventDefaults only when it reloads', () => {
+    const reload = vi.fn();
+    const storage = makeStorage();
+    let t = 1_000;
+    setupPreloadErrorReload({
+      reload,
+      storage,
+      now: () => t,
+      windowMs: RELOAD_WINDOW_MS,
+      storageKey: 'k',
+    });
+
+    const e1 = new Event('vite:preloadError', { cancelable: true });
+    window.dispatchEvent(e1);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(e1.defaultPrevented).toBe(true);
+
+    t += 5_000;
+    const e2 = new Event('vite:preloadError', { cancelable: true });
+    window.dispatchEvent(e2);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(e2.defaultPrevented).toBe(false);
+  });
+});
+
+describe('installWorkerStaleAssetReloadListener (worker trigger)', () => {
+  beforeEach(() => {
+    __resetForTest();
+    setStaleAssetInstanceId(undefined);
+  });
+
+  it('runs the guarded reload on a matching-instanceId broadcast', async () => {
+    const reload = vi.fn();
+    const storage = makeStorage();
+    setupPreloadErrorReload({
+      reload,
+      storage,
+      now: () => 1_000,
+      windowMs: RELOAD_WINDOW_MS,
+      storageKey: 'k',
+    });
+    installWorkerStaleAssetReloadListener('inst-A');
+    setStaleAssetInstanceId('inst-A');
+    broadcastStaleAssetReload();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts`
+Expected: FAIL — cannot resolve `setup-preload-error-reload.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// packages/webapp/src/ui/boot/setup-preload-error-reload.ts
+/**
+ * Page-side stale-asset recovery (#1330). Owns the one guarded reload every
+ * trigger shares, plus the page `vite:preloadError` handler (page-owned lazy
+ * chunks) and the worker-broadcast listener. Sibling to
+ * `setup-nuke-reload-listener.ts`. See the spec for the four-trigger design.
+ */
+import { installStaleAssetReloadListener } from '../../core/stale-asset-channel.js';
+
+const STORAGE_KEY = 'slicc:stale-asset-reloaded-at';
+/** Must exceed the ~30 s host-ready boot timeout so a stale re-error at boot is
+ *  suppressed (loop-proof) while a genuinely new deploy later still reloads. */
+export const RELOAD_WINDOW_MS = 60_000;
+
+export interface GuardedReloadDeps {
+  reload: () => void;
+  storage: Pick<Storage, 'getItem' | 'setItem'>;
+  now: () => number;
+  windowMs: number;
+  storageKey: string;
+}
+
+function defaultDeps(): GuardedReloadDeps {
+  return {
+    reload: () => window.location.reload(),
+    storage: window.sessionStorage,
+    now: () => Date.now(),
+    windowMs: RELOAD_WINDOW_MS,
+    storageKey: STORAGE_KEY,
+  };
+}
+
+/** Pure guard: reload iff never reloaded or the window has elapsed. */
+export function decideStaleReload(
+  lastReloadAt: number | null,
+  now: number,
+  windowMs: number
+): boolean {
+  return lastReloadAt === null || now - lastReloadAt >= windowMs;
+}
+
+/**
+ * Reload the page at most once per `windowMs` per tab. Fail-closed: if
+ * `sessionStorage` can't be read or written we do NOT reload (never reload
+ * without a persistable guard, or a broken deploy could loop). Returns whether
+ * it triggered a reload.
+ */
+export function guardedReload(deps: GuardedReloadDeps = defaultDeps()): boolean {
+  let raw: string | null;
+  try {
+    raw = deps.storage.getItem(deps.storageKey);
+  } catch {
+    return false;
+  }
+  const parsed = raw === null ? null : Number(raw);
+  const lastReloadAt = parsed !== null && Number.isFinite(parsed) ? parsed : null;
+  const now = deps.now();
+  if (!decideStaleReload(lastReloadAt, now, deps.windowMs)) return false;
+  try {
+    deps.storage.setItem(deps.storageKey, String(now));
+  } catch {
+    return false;
+  }
+  deps.reload();
+  return true;
+}
+
+let vitePreloadHandler: ((e: Event) => void) | null = null;
+let activeDeps: GuardedReloadDeps | null = null;
+
+/**
+ * Install the page `vite:preloadError` handler (idempotent). Call FIRST in
+ * `main()`, before any dynamic `import()`. `preventDefault()` is called only
+ * when we actually reload, so a guard-suppressed error still surfaces.
+ */
+export function setupPreloadErrorReload(deps?: Partial<GuardedReloadDeps>): void {
+  if (vitePreloadHandler) return;
+  activeDeps = { ...defaultDeps(), ...deps };
+  vitePreloadHandler = (e: Event) => {
+    if (guardedReload(activeDeps!)) e.preventDefault();
+  };
+  window.addEventListener('vite:preloadError', vitePreloadHandler);
+}
+
+let workerListenerDispose: (() => void) | null = null;
+
+/**
+ * Install the instanceId-scoped worker-broadcast listener (idempotent). MUST be
+ * called BEFORE `spawnKernelWorker()` — `BroadcastChannel` does not buffer and
+ * the worker posts init synchronously, so a late listener misses a fast
+ * boot-time failure. Runs the same `guardedReload` as the page trigger.
+ */
+export function installWorkerStaleAssetReloadListener(instanceId: string): () => void {
+  if (workerListenerDispose) return workerListenerDispose;
+  workerListenerDispose = installStaleAssetReloadListener(instanceId, () => {
+    guardedReload(activeDeps ?? undefined);
+  });
+  return workerListenerDispose;
+}
+
+/** Test-only: detach handlers and clear module state. */
+export function __resetForTest(): void {
+  if (vitePreloadHandler) window.removeEventListener('vite:preloadError', vitePreloadHandler);
+  vitePreloadHandler = null;
+  activeDeps = null;
+  if (workerListenerDispose) workerListenerDispose();
+  workerListenerDispose = null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+npx prettier --write packages/webapp/src/ui/boot/setup-preload-error-reload.ts packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts
+git add packages/webapp/src/ui/boot/setup-preload-error-reload.ts packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts
+git commit -m "feat(webapp): shared guarded reload + page vite:preloadError trigger (#1330)"
+```
+
+---
+
+### Task 3: Register the page trigger in `main()`
+
+**Files:**
+
+- Modify: `packages/webapp/src/ui/main.ts` (inside `main()`, first statement)
+
+**Interfaces:**
+
+- Consumes: `setupPreloadErrorReload` from Task 2.
+- Produces: nothing new.
+
+- [ ] **Step 1: Add the import and the first-statement call**
+
+At the top of `packages/webapp/src/ui/main.ts`, add the import alongside the other `./boot/…` imports:
+
+```ts
+import { setupPreloadErrorReload } from './boot/setup-preload-error-reload.js';
+```
+
+Then make it the FIRST statement inside `async function main()` (before `const app = document.getElementById('app')` and before the `?ui-fixture` check):
+
+```ts
+async function main(): Promise<void> {
+  // Recover any long-lived tab that crashes on a now-gone content-hashed chunk
+  // after a deploy (#1330). Installed before any dynamic import() so page-owned
+  // lazy-chunk failures are always caught. Harmless on the ?ui-fixture surface
+  // (no worker, no provider imports).
+  setupPreloadErrorReload();
+
+  const app = document.getElementById('app');
+  // ...existing body unchanged...
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+npx prettier --write packages/webapp/src/ui/main.ts
+git add packages/webapp/src/ui/main.ts
+git commit -m "feat(webapp): register the stale-asset page trigger first in main() (#1330)"
+```
+
+---
+
+### Task 4: Worker turn-time trigger (`scoop-context`)
+
+**Files:**
+
+- Modify: `packages/webapp/src/scoops/scoop-context.ts` (import; new `handleStaleAssetError`; call before `handleNonRetryableError` at ~line 871)
+- Test: `packages/webapp/tests/scoops/scoop-context.test.ts` (extend)
+
+**Interfaces:**
+
+- Consumes: `isDynamicImportError`, `broadcastStaleAssetReload` from Task 1; existing `isRetryableError`.
+- Produces: private `handleStaleAssetError(message: string): boolean`.
+
+- [ ] **Step 1: Write the failing test (precedence)**
+
+Append to `packages/webapp/tests/scoops/scoop-context.test.ts`. It proves the stale-asset string ALSO matches the generic retry matcher, so the stale check must run first:
+
+```ts
+import { isDynamicImportError } from '../../src/core/stale-asset-channel.js';
+
+describe('stale-asset error takes precedence over the retry matcher', () => {
+  const staleMsg = 'Failed to fetch dynamically imported module: https://x/assets/anthropic-abc.js';
+  it('is detected as a dynamic-import error', () => {
+    expect(isDynamicImportError(staleMsg)).toBe(true);
+  });
+  it('ALSO matches isRetryableError ("failed to fetch") — hence the stale check must run first', () => {
+    expect(isRetryableError(staleMsg)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/webapp/tests/scoops/scoop-context.test.ts -t "stale-asset error takes precedence"`
+Expected: FAIL — cannot resolve `stale-asset-channel.js` import.
+
+- [ ] **Step 3: Add the import**
+
+At the top of `packages/webapp/src/scoops/scoop-context.ts`, add:
+
+```ts
+import { broadcastStaleAssetReload, isDynamicImportError } from '../core/stale-asset-channel.js';
+```
+
+- [ ] **Step 4: Add the guard method**
+
+Add this private method next to `handleNonRetryableError` (after it, ~line 773):
+
+```ts
+  /**
+   * Handle a stale-asset import failure (#1330). A gone content-hashed chunk
+   * after a deploy — retrying the cached-failed import is futile (checked
+   * before the retry matcher, which also matches "failed to fetch"), so ask the
+   * owning page to reload (guarded) and surface as fatal. Returns true if handled.
+   */
+  private handleStaleAssetError(message: string): boolean {
+    if (!isDynamicImportError(message)) return false;
+    log.error('Stale-asset import failure; requesting page reload', {
+      folder: this.scoop.folder,
+      error: message,
+    });
+    broadcastStaleAssetReload();
+    emitAgentError('llm', message);
+    this.setStatus('error');
+    if (this.callbacks.onFatalError) {
+      this.callbacks.onFatalError(
+        `Scoop "${this.scoop.name}" hit a stale build after a deploy; reloading to recover.`
+      );
+    } else {
+      this.callbacks.onError(message);
+    }
+    return true;
+  }
+```
+
+- [ ] **Step 5: Call it first in the error sequence**
+
+In the turn-error handling (line ~871), add the stale check BEFORE the non-retryable check:
+
+```ts
+if (this.handleStaleAssetError(message)) return true;
+if (this.handleNonRetryableError(message)) return true;
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run packages/webapp/tests/scoops/scoop-context.test.ts`
+Expected: PASS (existing + the 2 new precedence tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+npx prettier --write packages/webapp/src/scoops/scoop-context.ts packages/webapp/tests/scoops/scoop-context.test.ts
+git add packages/webapp/src/scoops/scoop-context.ts packages/webapp/tests/scoops/scoop-context.test.ts
+git commit -m "feat(webapp): worker turn-time stale-asset trigger in scoop-context (#1330)"
+```
+
+---
+
+### Task 5: Worker boot-time trigger (`kernel-worker`)
+
+**Files:**
+
+- Modify: `packages/webapp/src/kernel/kernel-worker.ts` (`boot()` — `setStaleAssetInstanceId` + `try/catch`)
+
+**Interfaces:**
+
+- Consumes: `setStaleAssetInstanceId`, `broadcastStaleAssetReload`, `isDynamicImportError` from Task 1.
+- Produces: nothing new (behavioral change to `boot`).
+
+- [ ] **Step 1: Add the import**
+
+At the top of `packages/webapp/src/kernel/kernel-worker.ts`:
+
+```ts
+import {
+  broadcastStaleAssetReload,
+  isDynamicImportError,
+  setStaleAssetInstanceId,
+} from '../core/stale-asset-channel.js';
+```
+
+- [ ] **Step 2: Record the instanceId first, wrap the boot body**
+
+`boot()` currently reads `async function boot(init: KernelWorkerInitMsg): Promise<void> {` then runs its body (setBridgeToken … `registerProviders()` … `kernel-worker-ready`). Change to record the instanceId first and wrap the whole body so a stale boot import broadcasts then rethrows (preserving the init-guard reset + worker-ready-timeout fallback):
+
+```ts
+async function boot(init: KernelWorkerInitMsg): Promise<void> {
+  // Record our instanceId up front so a stale-import failure anywhere in boot
+  // (registerProviders eagerly imports every provider chunk) can broadcast an
+  // instanceId-scoped reload request to the owning page. (#1330)
+  setStaleAssetInstanceId(init.instanceId);
+  try {
+    // ↓↓↓ the entire existing boot body, unchanged, moves inside this try ↓↓↓
+    setBridgeToken(init.bridgeToken ?? null);
+    // ... all existing statements through:
+    init.kernelPort.postMessage({ type: 'kernel-worker-ready' } satisfies KernelWorkerReadyMsg);
+    // ↑↑↑ end existing body ↑↑↑
+  } catch (err) {
+    if (isDynamicImportError(String((err as Error)?.message ?? err))) {
+      broadcastStaleAssetReload();
+    }
+    throw err;
+  }
+}
+```
+
+Do NOT change any statement inside the body — only indent it into the `try`.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Run the kernel-worker unit tests (guard still resets on boot error)**
+
+Run: `npx vitest run packages/webapp/tests/kernel/`
+Expected: PASS (the init-guard reset-on-error behavior is unchanged — `boot()` still rejects).
+
+- [ ] **Step 5: Commit**
+
+```bash
+npx prettier --write packages/webapp/src/kernel/kernel-worker.ts
+git add packages/webapp/src/kernel/kernel-worker.ts
+git commit -m "feat(webapp): worker boot-time stale-asset trigger in kernel-worker (#1330)"
+```
+
+---
+
+### Task 6: `worker.onerror` trigger + install-before-spawn ordering
+
+**Files:**
+
+- Modify: `packages/webapp/src/kernel/spawn.ts` (`KernelWorkerSpawnOptions` + `spawnKernelWorker`)
+- Modify: `packages/webapp/src/ui/wc/wc-live.ts` (install listener before spawn; pass `onWorkerScriptError`)
+- Test: `packages/webapp/tests/kernel/spawn-worker-error.test.ts`
+
+**Interfaces:**
+
+- Consumes: `installWorkerStaleAssetReloadListener`, `guardedReload` from Task 2.
+- Produces: `KernelWorkerSpawnOptions.onWorkerScriptError?: () => void`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/webapp/tests/kernel/spawn-worker-error.test.ts
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { spawnKernelWorker } from '../../src/kernel/spawn.js';
+
+describe('spawnKernelWorker onWorkerScriptError', () => {
+  it('calls onWorkerScriptError when the worker script fails to load', () => {
+    const onWorkerScriptError = vi.fn();
+    // A bogus workerUrl makes `new Worker` fail to load; jsdom emits an 'error'
+    // event on the Worker. (jsdom's Worker is a stub that never becomes ready,
+    // so we assert the listener is wired by dispatching the event ourselves.)
+    const host = spawnKernelWorker({
+      workerUrl: 'data:application/javascript,//noop',
+      realCdpTransport: { on: () => {}, off: () => {}, send: async () => ({}) } as never,
+      callbacks: {} as never,
+      instanceId: 'inst-A',
+      onWorkerScriptError,
+    });
+    // The Worker reference is not exposed; simulate the browser firing 'error'
+    // by grabbing it via the spy path is overkill — instead assert no throw and
+    // that a subsequent error event on any Worker created is handled. We assert
+    // wiring indirectly: the option is accepted and spawn returns a host.
+    expect(host).toBeTruthy();
+    host.dispose?.();
+  });
+});
+```
+
+> Note: jsdom's `Worker` does not reliably emit `error` for a bad module URL. Keep this test to "option accepted + no throw"; the behavioral guarantee (a real `error` event → `guardedReload`) is covered by Task 2's `installWorkerStaleAssetReloadListener` test plus the one-line `addEventListener` wiring, which is code-review-verifiable.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/webapp/tests/kernel/spawn-worker-error.test.ts`
+Expected: FAIL — `onWorkerScriptError` is not a known option (TS) / host shape mismatch.
+
+- [ ] **Step 3: Add the option to `spawn.ts`**
+
+In `KernelWorkerSpawnOptions` (the interface around line 119), add:
+
+```ts
+  /** Page-side hook fired if the worker ENTRY chunk fails to load (stale after a
+   *  deploy) — the worker never evaluates, so its own boot catch can't run.
+   *  Wired to the guarded reload. (#1330) */
+  onWorkerScriptError?: () => void;
+```
+
+In `spawnKernelWorker` (line 301), attach the handler right after the `Worker` is created, before `bootstrapKernelWorker`:
+
+```ts
+export function spawnKernelWorker(options: KernelWorkerSpawnOptions): SpawnedKernelHost {
+  const worker = options.workerUrl
+    ? new Worker(options.workerUrl, { type: 'module' })
+    : new Worker(new URL('./kernel-worker.ts', import.meta.url), { type: 'module' });
+  if (options.onWorkerScriptError) {
+    worker.addEventListener('error', () => options.onWorkerScriptError!());
+  }
+  return bootstrapKernelWorker({
+    worker,
+    // ...existing fields unchanged...
+  });
+}
+```
+
+- [ ] **Step 4: Wire the caller in `wc-live.ts`**
+
+Add the import near the other boot imports:
+
+```ts
+import {
+  guardedReload,
+  installWorkerStaleAssetReloadListener,
+} from '../boot/setup-preload-error-reload.js';
+```
+
+At the spawn site (line ~1607), install the listener BEFORE `spawnKernelWorker` and pass `onWorkerScriptError`:
+
+```ts
+const boot = prepareWcShell(app, floatLabel);
+// #1330: install the instanceId-scoped reload listener BEFORE spawning the
+// worker — BroadcastChannel doesn't buffer and the worker posts init
+// synchronously, so a late listener would miss a fast boot-time failure.
+if (instanceId) installWorkerStaleAssetReloadListener(instanceId);
+const host = spawnKernelWorker({
+  realCdpTransport,
+  instanceId,
+  callbacks: createWcLiveCallbacks(boot.wiring),
+  localApiBaseUrl,
+  bridgeToken,
+  localLickWsUrl,
+  extensionDelegateId,
+  onWorkerScriptError: () => {
+    guardedReload();
+  },
+});
+```
+
+- [ ] **Step 5: Run test + typecheck**
+
+Run: `npx vitest run packages/webapp/tests/kernel/spawn-worker-error.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx prettier --write packages/webapp/src/kernel/spawn.ts packages/webapp/src/ui/wc/wc-live.ts packages/webapp/tests/kernel/spawn-worker-error.test.ts
+git add packages/webapp/src/kernel/spawn.ts packages/webapp/src/ui/wc/wc-live.ts packages/webapp/tests/kernel/spawn-worker-error.test.ts
+git commit -m "feat(webapp): worker.onerror trigger + install reload listener before spawn (#1330)"
+```
+
+---
+
+### Task 7: Docs + close the issue
+
+**Files:**
+
+- Modify: `packages/webapp/CLAUDE.md` (UI/boot section)
+- Modify: `docs/pitfalls.md`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Add the webapp CLAUDE.md note**
+
+Under the `packages/webapp/CLAUDE.md` "UI" or boot area, add:
+
+```markdown
+### Stale-asset recovery (post-deploy)
+
+After a deploy, a long-lived tab/worker can crash on a now-gone content-hashed
+chunk (#1330). Four triggers funnel into one shared, **instanceId-scoped**,
+**fail-closed**, timestamp-guarded (`RELOAD_WINDOW_MS = 60_000`) page reload
+(`ui/boot/setup-preload-error-reload.ts` + the realm-agnostic
+`core/stale-asset-channel.ts`):
+
+- page `window` `vite:preloadError` — page-owned lazy chunks;
+- page `Worker` `error` (`spawn.ts` `onWorkerScriptError`) — a stale worker ENTRY chunk;
+- worker `boot()` `try/catch` — boot-time `registerProviders()` imports;
+- worker `scoop-context` classifier — turn-time imports (checked BEFORE the
+  `failed to fetch` retry matcher so it isn't retried 3× futilely).
+
+Worker triggers `broadcastStaleAssetReload()` over `BroadcastChannel`, stamped
+with the worker's `instanceId`; only the owning page reloads. The listener is
+installed BEFORE `spawnKernelWorker()` (BroadcastChannel doesn't buffer). Fresh
+`index.html` on reload relies on `location.reload()` top-document revalidation.
+```
+
+- [ ] **Step 2: Add the pitfalls.md entry**
+
+Append to `docs/pitfalls.md`:
+
+```markdown
+## Stale content-hashed chunks after a deploy (#1330)
+
+A long-lived sliccy.ai tab/worker holds an old module graph; after a deploy the
+old `/assets/<hash>.js` is gone. The worker's SPA fallback
+(`not_found_handling: single-page-application`) returns `index.html` as
+`200 text/html`, so the lazy `import()` rejects with a MIME/module-script error
+(not a 404). The failing import is usually WORKER-owned (providers load in the
+kernel worker), and Vite injects `vite:preloadError` only into the PAGE bundle —
+so a `window` listener alone can't catch it. Recovery is the four-trigger guarded
+reload in `core/stale-asset-channel.ts` + `ui/boot/setup-preload-error-reload.ts`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+npx prettier --write packages/webapp/CLAUDE.md docs/pitfalls.md
+git add packages/webapp/CLAUDE.md docs/pitfalls.md
+git commit -m "docs: stale-asset recovery note + pitfall (#1330)"
+```
+
+- [ ] **Step 4: Full verification gate**
+
+Run each and confirm PASS:
+
+```bash
+npm run lint:ci
+npm run deadcode
+npm run typecheck
+npm run test:coverage:webapp
+npm run build -w @slicc/chrome-extension
+```
+
+(The top-level `npm run build` fails only at the `swift-server` step on this
+machine — a known Swift-toolchain constraint unrelated to this change; the TS
+workspaces build before it.)
+
+- [ ] **Step 5: Close the issue on merge**
+
+Ensure the PR body includes `Fixes #1330`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Page `vite:preloadError` trigger → Task 2 + Task 3. ✓
+- Worker boot-time trigger → Task 5. ✓
+- Worker turn-time trigger → Task 4. ✓
+- Page `worker.onerror` trigger → Task 6. ✓
+- instanceId-scoped channel + `isDynamicImportError` (module-script anchored) → Task 1. ✓
+- Timestamp guard (60 s) + fail-closed → Task 2. ✓
+- Install-before-spawn ordering → Task 6 (caller installs before `spawnKernelWorker`). ✓
+- `setStaleAssetInstanceId` at boot start + dev-warn → Task 1 + Task 5. ✓
+- Idempotent listener → Task 2 (`installWorkerStaleAssetReloadListener` guard). ✓
+- Docs + close #1330 → Task 7. ✓
+- Out-of-scope (worker `no-cache`, server 404, cloud auto-restart) → intentionally omitted. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. The one soft spot (jsdom can't reliably fire `Worker` `error`) is called out explicitly with the compensating coverage, not hidden. ✓
+
+**Type consistency:** `guardedReload(deps?)`, `GuardedReloadDeps`, `installWorkerStaleAssetReloadListener(instanceId)`, `broadcastStaleAssetReload()`, `setStaleAssetInstanceId(id)`, `isDynamicImportError(msg)`, `onWorkerScriptError?` — names/signatures match across Tasks 1, 2, 4, 5, 6. ✓

--- a/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
@@ -1,0 +1,170 @@
+# Stale-asset recovery after deploy (issue #1330)
+
+**Date:** 2026-07-07
+**Issue:** [#1330](https://github.com/ai-ecoverse/slicc/issues/1330) — "Cloud cone crashes on stale assets after deploy"
+**Scope:** `packages/webapp` only. One new boot helper + one registration line + tests + docs.
+
+## Problem
+
+When a new build is deployed while a long-lived sliccy.ai UI tab is open, a
+subsequent lazy `import()` of a Vite chunk whose content-hash changed on the
+deploy fails, and the session becomes unrecoverable:
+
+```
+Something went wrong
+Scoop "Cone" failed after 3 attempts: Failed to fetch dynamically imported
+module: https://www.sliccy.ai/assets/anthropic-BOEkIcb-.js
+```
+
+This is **not** cloud-cone-specific. It hits **any** long-lived tab that spans a
+deploy:
+
+- the **cloud cone** (its UI runs in a headless browser inside the e2b sandbox,
+  loading the same webapp from sliccy.ai),
+- the **extension's pinned leader tab** (long-lived by design),
+- the **extension side-panel follower** (a side-panel-only user has no obvious
+  "reload" and won't know to hard-refresh),
+- any open **standalone** tab.
+
+## Root cause (verified against `main`)
+
+1. **The running tab holds an old module graph.** After a deploy, the CDN no
+   longer serves the old content-hashed chunk names. A lazy `import()` for a
+   now-gone chunk fails.
+2. **The worker's SPA fallback masks the 404.** The `assets` binding in
+   `packages/cloudflare-worker/wrangler.jsonc` uses
+   `not_found_handling: "single-page-application"`, so a request for a gone
+   `/assets/*.js` returns **`index.html` as `200 text/html`**, not a 404. The
+   `import()` therefore rejects with a MIME/parse error ("Expected a JavaScript
+   module … MIME type of text/html"). A `/assets/*` request can never cleanly
+   404 today. (Left as-is this PR — see Out of scope.)
+3. **Nothing recovers an already-open tab.** There is **no `vite:preloadError`
+   handler anywhere** in the webapp (grep-verified). `scoops/upgrade-detection.ts`
+   only compares the bundled version to the last-seen version **at boot**, so it
+   never helps a tab that is already running when the deploy lands.
+
+Vite's `__vitePreload` dispatches a cancelable `vite:preloadError` event on
+`window` when a dynamic import fails (and re-throws unless the event is
+`preventDefault()`-ed). A guarded global handler that reloads on that event is
+the cheap, universal recovery — the same webapp entry (`ui/main.ts`) boots every
+real-browser float, so one handler covers all of them.
+
+## Scope decisions
+
+- **Client handler only.** The guarded reload fully fixes the crash on its own;
+  the import rejection fires `vite:preloadError` regardless of the HTML-vs-404
+  response, so no server change is required.
+- **One uniform mechanism for every float**, including the cloud cone: the
+  in-sandbox browser runs the same guarded `location.reload()`, which re-fetches
+  a fresh `index.html` + module graph, re-boots the leader, rejoins the tray, and
+  resumes from the sandbox's OPFS. No `cloud-core` / worker / auto-restart
+  plumbing (issue solution #2 is unnecessary given the uniform reload).
+- **`location.reload()` runs in the page realm.** `ui/main.ts` executes in the
+  real browsing context of every float (not the kernel worker / offscreen), so
+  `location.reload()` is a real navigation here — unlike the agent shell's
+  `nuke-reload` path, which exists precisely because the worker realm can't
+  reload itself.
+
+## Design
+
+### Component — `packages/webapp/src/ui/boot/setup-preload-error-reload.ts`
+
+Sibling to the existing `boot/setup-*.ts` helpers (e.g.
+`setup-nuke-reload-listener.ts`, which already performs a page-side reload).
+
+- **`decidePreloadReload(currentVersion: string, storedFlag: string | null): boolean`**
+  — pure guard logic, no DOM. Returns `true` iff `storedFlag !== currentVersion`.
+- **`setupPreloadErrorReload(deps?): void`** — registers
+  `window.addEventListener('vite:preloadError', handler)`. `deps` are injectable
+  for testing and default to production values:
+  - `reload: () => void` → `() => window.location.reload()`
+  - `storage: Pick<Storage, 'getItem' | 'setItem'>` → `window.sessionStorage`
+  - `version: string` → `readBundledVersion().version` (from
+    `scoops/upgrade-detection.ts`, i.e. `__SLICC_VERSION__`)
+  - `storageKey` constant: `'slicc:preload-reloaded'`
+
+  Handler behavior on `vite:preloadError`:
+  1. Read the stored flag; compute `decidePreloadReload(version, flag)`.
+  2. If it returns `true`: `event.preventDefault()` (suppress Vite's re-throw so
+     no error boundary flashes before navigation), write `storage.setItem(key,
+version)`, then `reload()`.
+  3. If it returns `false` (already reloaded once for this exact version): do
+     **nothing** — do not `preventDefault`. Let the error propagate to the
+     existing "Something went wrong" + retry UI, so a genuinely-broken build
+     surfaces instead of hiding behind a silent reload loop.
+  4. `storage` access is wrapped in try/catch — a `sessionStorage` failure
+     (private-mode quota, etc.) must not throw inside the error handler; on a
+     storage read/write failure the handler still reloads once (fail-open toward
+     recovery) but cannot then guard, which is acceptable because a storage-less
+     context also can't loop-persist across the reload.
+
+### The guard (why version-keyed `sessionStorage`)
+
+Invariant: **reload at most once per deployed version**, so we never loop yet
+always recover a genuinely-stale tab.
+
+- Running (stale) bundle is version `V`. On `vite:preloadError` the flag is
+  unset (or holds an older version) → reload; set flag = `V` first.
+- After reload the tab runs the fresh bundle `V′`. The flag holds `V ≠ V′`, so a
+  _later_ deploy can still trigger a fresh recovery reload.
+- A _repeat_ failure while still on `V` (flag already `V`) is suppressed → the
+  error surfaces instead of looping. Worst case across back-to-back deploys is a
+  small bounded number of reloads (one per version actually observed), never an
+  infinite loop.
+
+`sessionStorage` is the correct lifetime: per-tab, survives the `reload()`,
+clears on tab close (so a new session isn't wrongly suppressed). `localStorage`
+would over-suppress across sessions; a time/count guard isn't causally tied to
+the version that changed (rejected as approaches B/C in brainstorming).
+
+### Registration — `packages/webapp/src/ui/main.ts`
+
+Call `setupPreloadErrorReload()` as the **first statement inside `main()`**,
+before the fixture check and before any dynamic `import()`. All lazy imports
+(provider modules, `wc-settings`, dip/sprinkle chunks, mount branches) happen
+after boot, so the handler is always registered before a stale chunk can be
+requested. The initial entry chunks are fetched fresh with `index.html` on first
+load and always match, so entry-chunk staleness is not a concern here.
+
+## Testing
+
+`packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts`:
+
+- **Guard matrix** (`decidePreloadReload`, pure):
+  - no prior flag (`null`) → `true`
+  - flag equals current version → `false`
+  - flag is an older version (post-deploy) → `true`
+- **Handler** (jsdom, injected `reload`/`storage` spies — jsdom's
+  `location.reload` throws "Not implemented", so injection is required):
+  - first `vite:preloadError` → `reload` called once, flag written = version,
+    `event.preventDefault()` called
+  - second dispatch (flag now == version) → `reload` **not** called,
+    `preventDefault` **not** called
+  - a post-deploy dispatch (flag holds an older version) → `reload` called again
+  - a `storage.setItem` that throws → handler still calls `reload` (fail-open),
+    does not itself throw
+
+## Docs
+
+- `packages/webapp/CLAUDE.md` — a "Stale-chunk recovery" note under the boot /
+  UI section describing the `vite:preloadError` handler and the version-keyed
+  guard.
+- `docs/pitfalls.md` — short entry: long-lived tabs + content-hashed chunks +
+  the worker's SPA-fallback-returns-HTML behavior, and how the handler recovers.
+- Close #1330 referencing the PR.
+
+## Out of scope (possible follow-ups)
+
+- **Server-side clean 404 for `/assets/*`.** Making the worker return a real 404
+  (instead of the SPA `index.html`) for a missing hashed chunk would fail fast +
+  clean and stop serving full HTML bodies for dead chunks. Deferred — the client
+  handler already recovers the crash; this is defense-in-depth in a different
+  package.
+- **Cloud-cone auto-restart** (issue solution #2). Unnecessary given the uniform
+  client reload recovers the in-sandbox browser too.
+
+## Verification gates
+
+`lint:ci`, `deadcode`, `typecheck`, `test` (+ `test:coverage:webapp`), `build`,
+and the extension build — the standard pre-PR pass. Only `packages/webapp` is
+touched, so no worker route-mirror or cross-runtime parity concerns apply.

--- a/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
@@ -2,17 +2,28 @@
 
 **Date:** 2026-07-07
 **Issue:** [#1330](https://github.com/ai-ecoverse/slicc/issues/1330) — "Cloud cone crashes on stale assets after deploy"
-**Scope:** `packages/webapp` only. Two trigger sites + one shared page-side guarded reload + tests + docs.
+**Scope:** `packages/webapp` only. Page trigger + two worker triggers → one shared, instanceId-scoped, timestamp-guarded page reload + tests + docs.
 
-> **Revision note (post-review).** A Codex review of the first draft found a
-> **blocker**: the exact failure in #1330 (`anthropic-*.js`) is a **worker-side**
-> dynamic import, which never dispatches `vite:preloadError` on `window`, so a
-> page-only handler would not fix the reported crash. Verified against the build.
-> The design below adds a worker-side trigger. Two scope calls were made while
-> the requester was away (both revisitable): (1) cover **both** page- and
-> worker-owned lazy-import failures; (2) stay **webapp-only** and rely on
-> `location.reload()`'s top-document revalidation for fresh HTML rather than
-> adding a worker `Cache-Control` header (deferred — see Out of scope).
+> **Revision history.**
+>
+> - **Draft 1** (page-only `vite:preloadError` handler). Codex review found a
+>   **blocker**: the #1330 failure (`anthropic-*.js`) is a **worker-side** import
+>   that never dispatches `vite:preloadError` on `window`. Also: version-keyed
+>   guard is too coarse; fail-open storage could loop; fresh-HTML unstated.
+> - **Draft 2** added a worker trigger via an origin-wide `BroadcastChannel`,
+>   timestamp guard, fail-closed. Second Codex review found two more **blockers**:
+>   (a) an origin-wide broadcast reloads **every** same-origin SLICC tab, not just
+>   the failing one, violating the codebase's established instanceId-scoping; (b)
+>   `registerProviders()` eagerly imports every provider at **worker boot**, so a
+>   stale chunk fails **before** any `ScoopContext` classifier exists — the
+>   turn-time hook misses it. Plus: broaden the matcher to the MIME/module-script
+>   family; the 20 s guard window is shorter than the 30 s boot timeout (loop
+>   risk); fix a `?ui-fixture` self-contradiction.
+> - **Draft 3 (this doc)** resolves all of the above; verified against `main`.
+>
+> Two scope calls remain (both revisitable): cover **both** page- and
+> worker-owned failures, and stay **webapp-only** relying on `location.reload()`
+> revalidation for fresh HTML (worker `no-cache` header deferred — Out of scope).
 
 ## Problem
 
@@ -27,229 +38,222 @@ module: https://www.sliccy.ai/assets/anthropic-BOEkIcb-.js
 ```
 
 This is **not** cloud-cone-specific. It hits **any** long-lived tab that spans a
-deploy:
-
-- the **cloud cone** (its UI runs in a headless browser inside the e2b sandbox,
-  loading the same webapp from sliccy.ai),
-- the **extension's pinned leader tab** (long-lived by design),
-- the **extension side-panel follower** (a side-panel-only user has no obvious
-  "reload" and won't know to hard-refresh),
-- any open **standalone** tab.
+deploy: the **cloud cone** (its UI runs in a headless browser inside the e2b
+sandbox), the **extension's pinned leader tab**, the **extension side-panel
+follower** (a side-panel-only user has no obvious "reload"), and any open
+**standalone** tab.
 
 ## Root cause (verified against `main`)
 
-1. **The running tab/worker holds an old module graph.** After a deploy the CDN
-   no longer serves the old content-hashed chunk names, so a lazy `import()` for
-   a now-gone chunk fails. The browser's module map caches that failure, so
-   retrying the same `import()` re-rejects — only a reload recovers.
-2. **The worker's SPA fallback masks the 404.** The `assets` binding in
-   `packages/cloudflare-worker/wrangler.jsonc` uses
-   `not_found_handling: "single-page-application"`, so a request for a gone
-   `/assets/*.js` returns **`index.html` as `200 text/html`**, not a 404. The
-   `import()` therefore rejects with a MIME/parse error ("Expected a JavaScript
-   module … MIME type of text/html"). A `/assets/*` request can never cleanly
-   404 today. (Left as-is this PR — see Out of scope.)
-3. **The failing import is usually worker-owned, and the worker has no
-   `vite:preloadError`.** `kernel-worker.ts` calls `registerProviders()` →
-   `providers/index.ts` uses lazy `import.meta.glob`, so provider chunks
-   (`anthropic-*.js`, etc.) are dynamically imported **inside the kernel
-   worker** during a cone/scoop turn. Verified: the built `kernel-worker-*.js`
-   chunk contains **zero** `preloadError` occurrences — Vite only injects the
-   `__vitePreload` helper (which dispatches the cancelable `vite:preloadError`
-   event) into the **page** bundle, not worker builds. So a `window` listener
-   cannot see the worker's import failures.
-4. **Worker import failures are currently retried 3× then surfaced as fatal.**
-   `scoop-context.ts:isRetryableError` matches `failed to fetch`
-   (line ~146), so "Failed to fetch dynamically imported module" is classified
-   retryable → 3 futile retries (the module map has cached the failure) → the
-   fatal "Scoop … failed after 3 attempts" message in the issue.
-5. **Nothing recovers an already-open tab.** There is **no `vite:preloadError`
-   handler anywhere** in the webapp (grep-verified), and
-   `scoops/upgrade-detection.ts` only compares the bundled version to the
-   last-seen version **at boot**, so it never helps a tab already running when
-   the deploy lands.
+1. **Old module graph.** After a deploy the CDN no longer serves the old
+   content-hashed chunk names; a lazy `import()` for a gone chunk fails, and the
+   browser's module map caches that failure so retrying the same `import()`
+   re-rejects — only a reload recovers.
+2. **SPA fallback masks the 404.** The `assets` binding
+   (`packages/cloudflare-worker/wrangler.jsonc`) uses
+   `not_found_handling: "single-page-application"`, so a gone `/assets/*.js`
+   returns **`index.html` as `200 text/html`** — the `import()` rejects with a
+   MIME/module-script error, not a network 404. (Left as-is — Out of scope.)
+3. **The failing import is usually worker-owned; the worker has no
+   `vite:preloadError`.** `kernel-worker.ts` `boot()` calls
+   `registerProviders()`, which **eagerly `await`s the import of every** built-in
+   - external provider config chunk (`providers/index.ts` loop), and the cone/
+     scoop turn later imports pi-ai streaming chunks — all **inside the kernel
+     worker**. Verified: the built `kernel-worker-*.js` chunk has **zero**
+     `preloadError` occurrences (Vite injects the `__vitePreload` helper only into
+     the **page** bundle, not worker builds). A `window` listener cannot see worker
+     import failures.
+4. **Two distinct worker failure timings:**
+   - **Boot-time** — a stale chunk needed by `registerProviders()` (or another
+     boot `await import()`) rejects in `boot()`. The init guard
+     (`kernel-worker-init-guard.ts`) catches it (`onError`), so it is a _handled_
+     rejection (no global `unhandledrejection`), and no `ScoopContext` exists yet;
+     the page just hits a worker-ready timeout.
+   - **Turn-time** — a stale chunk imported during a turn rejects and reaches
+     `scoop-context.ts`'s classifier. Note `isRetryableError` matches
+     `failed to fetch` (~line 146), so it is currently retried 3× (futile — the
+     module map cached the failure) → the fatal "Scoop … failed after 3 attempts".
+5. **Nothing recovers an already-open tab.** No `vite:preloadError` handler
+   exists (grep-verified); `scoops/upgrade-detection.ts` only compares versions
+   **at boot**.
 
 Vite's `__vitePreload` dispatches a cancelable `vite:preloadError` on `window`
-when a **page-owned** dynamic import rejects (including the MIME/parse rejection
-from the `200 text/html` fallback), and re-throws unless `preventDefault()` is
-called. That covers page-owned lazy chunks (settings dialog, dips, mount
-branches). Worker-owned failures need a separate detection path that reaches the
+for **page-owned** dynamic imports (covering the MIME rejection from the
+`200 text/html` fallback), re-throwing unless `preventDefault()` is called. That
+covers page-owned lazy chunks; worker-owned failures need a separate path to the
 page (which owns `location.reload()`).
-
-## Scope decisions
-
-- **Two triggers, one recovery.** Both a page-owned `vite:preloadError` and a
-  worker-owned dynamic-import failure funnel into the **same** guarded
-  page-reload. The worker trigger is what actually fixes #1330; the page trigger
-  covers page-owned lazy chunks.
-- **`location.reload()` runs in the page realm.** `ui/main.ts` executes in the
-  real browsing context of every float; the kernel worker cannot reload itself
-  (no `location`) so it **broadcasts** a reload request to the page — the same
-  worker→page pattern the existing `nuke-reload` already uses
-  (`shell/supplemental-commands/nuke-channel.ts`).
-- **Uniform across floats, including the cloud cone.** A page reload re-fetches a
-  fresh `index.html` + module graph, re-boots the kernel worker, rejoins the
-  tray, and resumes from OPFS. No `cloud-core` / auto-restart plumbing (issue
-  solution #2 is unnecessary). Topology check: the extension side-panel follower
-  has no kernel worker, so it recovers via the page trigger only; the leader tab
-  / standalone / cloud each have a kernel worker and use both triggers.
-- **Webapp-only; rely on reload revalidation for fresh HTML.** Recovery needs the
-  reload to fetch a _new_ `index.html`. The default (non-cherry/non-electron) SPA
-  response sets no explicit `Cache-Control`, but `location.reload()` forces
-  top-document revalidation in all major browsers (conditional GET → 200 with the
-  new build's HTML when the ETag changed), and the cherry side-panel response is
-  already `no-store`. A worker `Cache-Control: no-cache` on the SPA HTML is a
-  possible robustness follow-up (Out of scope), not required for correctness.
 
 ## Design
 
+One shared, guarded page reload is fed by **three** triggers (one page, two
+worker). The worker triggers are what actually fix #1330.
+
 ### Shared channel + detection — `packages/webapp/src/ui/boot/stale-asset-channel.ts`
 
-Shell-free and realm-agnostic (no `window`/`document` at module scope; only
-`BroadcastChannel`, which exists in both page and DedicatedWorker), so the kernel
-worker can import the detection + broadcast without pulling DOM code — mirroring
-how `nuke-channel.ts` is split out of `nuke-command.ts`.
+Shell-free, realm-agnostic (no `window`/`document` at module scope; only
+`BroadcastChannel`, available in page and DedicatedWorker) — so the kernel worker
+imports the detection + broadcast without DOM code, mirroring how
+`nuke-channel.ts` splits out of `nuke-command.ts`.
 
 - **`isDynamicImportError(msg: string): boolean`** — matches the cross-browser
-  dynamic-import-failure family:
-  - Chromium: `Failed to fetch dynamically imported module`
-  - Firefox: `error loading dynamically imported module`
-  - WebKit: `Importing a module script failed`
-- **`STALE_ASSET_RELOAD_CHANNEL = 'slicc-stale-asset-reload'`** and the wire type
-  `{ type: 'stale-asset-reload' }` (no payload — unlike nuke it clears no
-  storage).
-- **`broadcastStaleAssetReload(): void`** — posts the message on the channel
-  (no-op if `BroadcastChannel` is unavailable). Called from the worker realm.
-- **`installStaleAssetReloadListener(onReload: () => void): () => void`** —
-  page-side channel listener; returns a disposer.
+  dynamic-import / module-script failure family (case-insensitive):
+  - `Failed to fetch dynamically imported module` (Chromium)
+  - `error loading dynamically imported module` (Firefox)
+  - `Importing a module script failed` (WebKit)
+  - `expected a javascript( |-)?module` / `MIME type` module-script rejection
+    (the `200 text/html` fallback case)
+- **`STALE_ASSET_RELOAD_CHANNEL = 'slicc-stale-asset-reload'`**, wire type
+  `{ type: 'stale-asset-reload'; instanceId: string }`.
+- **`setStaleAssetInstanceId(id: string): void`** — the kernel worker records its
+  `init.instanceId` here at the very start of `boot()` so the broadcasters can
+  stamp it (both worker failure sites are reached without threading the id).
+- **`broadcastStaleAssetReload(): void`** — posts `{type, instanceId}` on the
+  channel (no-op if no instanceId set or `BroadcastChannel` is unavailable).
+- **`installStaleAssetReloadListener(instanceId: string, onReload: () => void): () => void`**
+  — page-side listener that invokes `onReload` only when the message's
+  `instanceId` matches (own worker), ignoring other tabs' broadcasts. Returns a
+  disposer.
+
+**Why instanceId-scoped, not origin-wide:** `BroadcastChannel` reaches every
+same-origin context, so an unscoped reload would reload _all_ SLICC tabs
+(leader + side-panel follower + any other sliccy.ai tab), disrupting a tab the
+user is actively using. The codebase already scopes worker↔page channels by
+`instanceId` for exactly this reason (`kernel-worker.ts` sprinkle-bridge +
+panel-rpc, threaded via `kernel-worker-init`). Scoping reloads only the page that
+owns the failing worker; each tab still recovers its own page-owned chunks via
+the page trigger.
 
 ### Shared guarded reload + page trigger — `packages/webapp/src/ui/boot/setup-preload-error-reload.ts`
 
-Sibling to `setup-nuke-reload-listener.ts`. Owns the one guarded-reload function
-that **both** triggers call.
+Sibling to `setup-nuke-reload-listener.ts`. Owns the one guarded-reload the
+triggers share (module-level guard state).
 
 - **`decideStaleReload(lastReloadAt: number | null, now: number, windowMs: number): boolean`**
-  — pure guard: reload iff `lastReloadAt === null || now - lastReloadAt >= windowMs`.
-- **`setupPreloadErrorReload(deps?): void`** — deps injectable for tests, default
-  to production:
-  - `reload` → `() => window.location.reload()`
-  - `storage: Pick<Storage,'getItem'|'setItem'>` → `window.sessionStorage`
-  - `now` → `() => Date.now()`
-  - `windowMs` → `RELOAD_WINDOW_MS` constant (**20_000**)
-  - `storageKey` → `'slicc:stale-asset-reloaded-at'`
-
-  It:
-  1. Defines `guardedReload()`:
-     - Read `lastReloadAt` from storage; **on any storage read/write throw,
-       return without reloading (fail-closed)** — we must never reload when we
-       cannot persist the guard, or a broken deploy could loop.
-     - If `decideStaleReload(...)` is `false` (reloaded within the window),
-       return — let the underlying error surface to the existing "Something went
-       wrong" + retry UI. Returns whether it will reload.
-     - Else `storage.setItem(key, String(now))` then `reload()`.
-  2. Registers `window.addEventListener('vite:preloadError', e => { if (guardedReload()) e.preventDefault(); })`
-     — `preventDefault()` only when we actually reload, so a suppressed
-     (guard-blocked) error still propagates.
-  3. Calls `installStaleAssetReloadListener(guardedReload)` so a worker broadcast
-     runs the identical guarded reload.
+  — pure: reload iff `lastReloadAt === null || now - lastReloadAt >= windowMs`.
+- **`guardedReload(deps): boolean`** — reads `lastReloadAt` from `sessionStorage`;
+  **fail-closed** (any storage read/write throw → return `false`, no reload — we
+  must never reload when we can't persist the guard). If `decideStaleReload` is
+  `false` (within window) → return `false` (let the error surface to the existing
+  "Something went wrong" + retry UI). Else write `now` and `reload()`, return
+  `true`. Deps injectable (`reload`→`location.reload`, `storage`→`sessionStorage`,
+  `now`→`Date.now`, `windowMs`→`RELOAD_WINDOW_MS`, `storageKey`).
+- **`RELOAD_WINDOW_MS = 60_000`.** Must exceed the worst-case reload→boot time so
+  a reload that did **not** fix the tab (cached stale HTML, or broken fresh build)
+  re-errors _within_ the window → suppressed → no loop. The kernel host-ready
+  timeout is 30 s, so a stale re-error surfaces well inside 60 s; a genuinely new
+  deploy minutes/hours later is past the window → reload allowed. (20 s was < the
+  30 s boot timeout — the review's loop concern.)
+- **`setupPreloadErrorReload(deps?): void`** — registers
+  `window.addEventListener('vite:preloadError', e => { if (guardedReload()) e.preventDefault(); })`
+  (`preventDefault` only when actually reloading, so a guard-suppressed error
+  still propagates).
+- **`installWorkerStaleAssetReloadListener(instanceId: string): void`** — wires
+  `installStaleAssetReloadListener(instanceId, () => { guardedReload(); })` so a
+  worker broadcast runs the identical guarded reload.
 
 ### Guard rationale (timestamp, not version)
 
 `__SLICC_VERSION__` only bumps on a semver **release**; PR-merge / manual /
 staging deploys rebuild `dist/ui` with new chunk hashes at the **same** version,
-so a version-keyed guard would wrongly suppress a legitimate second reload across
-those deploys. A **timestamp window** ("reload at most once per 20 s per tab") is
-causally correct: a reload that fixes the tab produces no further errors; a
-reload that does **not** fix it (broken/mid-propagation deploy) re-errors within
-the window → suppressed → error surfaces (no loop); a genuinely new deploy
-minutes/hours later is past the window → reload allowed. `sessionStorage` is the
-right lifetime (per-tab, survives the reload, clears on tab close).
+so a version-keyed guard would wrongly suppress a legitimate reload across those
+deploys. A timestamp window (per-tab `sessionStorage`, survives the reload,
+clears on tab close) is causally correct and, at 60 s > the 30 s boot timeout,
+loop-proof for the realistic re-error-at-boot case.
 
-### Worker trigger — `packages/webapp/src/scoops/scoop-context.ts`
+### Worker trigger A — boot-time — `packages/webapp/src/kernel/kernel-worker.ts`
 
-In the turn-error classification (where `isRetryableError` / `isNonRetryableError`
-are consulted), check `isDynamicImportError(msg)` **first**:
+At the very start of `boot(init)`, call `setStaleAssetInstanceId(init.instanceId)`.
+Wrap `boot()`'s body in `try { … } catch (err) { if
+(isDynamicImportError(String((err as Error)?.message ?? err))) broadcastStaleAssetReload(); throw err; }`
+— broadcast on a stale-import boot failure, then **rethrow** so the existing init
+guard `onError` / worker-ready-timeout fallback is unchanged. Covers
+`registerProviders()` and every boot `await import(...)`.
 
-- treat it as **non-retryable** (retrying a cached-failed `import()` is futile
-  and would burn the 3 attempts + backoff before recovery), and
-- call `broadcastStaleAssetReload()` so the owning page performs the guarded
-  reload.
+### Worker trigger B — turn-time — `packages/webapp/src/scoops/scoop-context.ts`
 
-This runs for the cone and every scoop (shared classifier). `BroadcastChannel`
-in the kernel worker reaches the same-origin page (leader tab / standalone /
-in-sandbox), exactly as `nuke-channel` already broadcasts worker→page.
+In the turn-error classification, check `isDynamicImportError(msg)` **before**
+`isRetryableError` (which matches `failed to fetch`): treat it as **non-retryable**
+(don't burn the 3 futile retries + backoff) and call `broadcastStaleAssetReload()`.
+Runs for the cone and every scoop.
 
-### Registration — `packages/webapp/src/ui/main.ts`
+### Registration — `packages/webapp/src/ui/main.ts` (+ worker-spawn site)
 
-Call `setupPreloadErrorReload()` as the **first statement inside `main()`**,
-before the fixture check and any dynamic `import()`, so both the page listener
-and the broadcast listener are installed before any lazy chunk can be requested.
-It runs once per page-owning float via the shared entry (standalone, extension
-leader + side-panel follower, cloud-in-sandbox); the `?ui-fixture` surface exits
-before boot and is unaffected, matching `setupNukeReloadListener`'s placement.
+- `setupPreloadErrorReload()` — first statement in `main()`, before the fixture
+  check and any dynamic `import()`. It installs only the page `vite:preloadError`
+  handler (page-local, no instanceId needed) and is harmless on the `?ui-fixture`
+  surface (which spawns no worker and does no provider imports).
+- `installWorkerStaleAssetReloadListener(instanceId)` — called on the
+  worker-owning floats at the point the page spawns the kernel worker (standalone
+  / hosted-leader / cloud, and the extension leader tab), where the page-generated
+  `instanceId` (the one threaded into `kernel-worker-init`) is known — which is
+  before the worker runs `registerProviders()`, so no failure can precede the
+  listener. The extension side-panel follower spawns no worker and installs only
+  the page handler.
 
 ## Testing
 
-`packages/webapp/tests/ui/boot/stale-asset-channel.test.ts`:
+`tests/ui/boot/stale-asset-channel.test.ts`:
 
-- `isDynamicImportError` matrix: the three browser strings → `true`; unrelated
-  errors (`401`, `rate limit`, `network error`) → `false`.
-- `broadcastStaleAssetReload` posts the message; `installStaleAssetReloadListener`
-  invokes `onReload` on receipt and the disposer detaches.
+- `isDynamicImportError` matrix: the three browser strings + the MIME/module-
+  script string → `true`; `401` / `rate limit` / plain `network error` → `false`.
+- `broadcastStaleAssetReload` no-ops before `setStaleAssetInstanceId`; after it,
+  posts `{type, instanceId}`.
+- `installStaleAssetReloadListener(id, onReload)` invokes `onReload` on a matching
+  instanceId, **ignores** a non-matching one, and the disposer detaches.
 
-`packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts` (jsdom;
-inject `reload`/`storage`/`now` — jsdom's `location.reload` throws "Not
-implemented"):
+`tests/ui/boot/setup-preload-error-reload.test.ts` (jsdom; inject
+`reload`/`storage`/`now` — jsdom's `location.reload` throws):
 
-- **Guard matrix** (`decideStaleReload`): no prior → `true`; within window →
-  `false`; past window → `true`.
-- **Page trigger**: first `vite:preloadError` → `reload` once + flag written +
-  `preventDefault` called; a second dispatch within the window → no `reload`, no
-  `preventDefault`; a dispatch past the window → `reload` again.
-- **Worker trigger**: a `stale-asset-reload` broadcast → same guarded `reload`.
-- **Fail-closed**: a `storage.getItem`/`setItem` that throws → handler does
-  **not** reload and does **not** throw.
+- `decideStaleReload`: null→true; within window→false; past window→true.
+- Page trigger: first `vite:preloadError` → `reload` once + flag written +
+  `preventDefault`; a dispatch within window → no reload, no `preventDefault`; a
+  dispatch past window → reload again.
+- Worker listener: a matching-instanceId broadcast → guarded `reload`; a
+  non-matching one → no reload.
+- Fail-closed: `storage.getItem`/`setItem` throws → no reload, no throw.
 
-`packages/webapp/tests/scoops/scoop-context.test.ts` (extend existing):
+`tests/scoops/scoop-context.test.ts` (extend): a "Failed to fetch dynamically
+imported module" message is classified non-retryable (checked before
+`isRetryableError`) and triggers the broadcast (spy the broadcast seam).
 
-- `isDynamicImportError` is consulted before `isRetryableError` for a "Failed to
-  fetch dynamically imported module" message (classified non-retryable), and the
-  broadcast fires. (Assert via the injected/spied broadcast seam.)
+`tests/kernel/kernel-worker*.test.ts` (or a focused unit around the boot
+try/catch): a `boot()` whose provider import rejects with a dynamic-import error
+broadcasts once and still rethrows (guard `onError` still runs).
 
 ## Docs
 
-- `packages/webapp/CLAUDE.md` — a "Stale-asset recovery" note (boot/UI section)
-  describing the two triggers, the shared timestamp-guarded reload, and the
-  worker→page broadcast.
+- `packages/webapp/CLAUDE.md` — "Stale-asset recovery" note: the three triggers,
+  the shared instanceId-scoped timestamp-guarded reload, the worker→page
+  broadcast, and the boot-vs-turn split.
 - `docs/pitfalls.md` — short entry: long-lived tabs + content-hashed chunks + the
-  worker's SPA-fallback-returns-HTML behavior + the worker-vs-page
-  `vite:preloadError` gap, and how the two triggers recover.
+  SPA-fallback-returns-HTML behavior + the worker-vs-page `vite:preloadError` gap.
 - Close #1330 referencing the PR.
 
 ## Out of scope (possible follow-ups)
 
-- **Worker `Cache-Control: no-cache` on the SPA HTML.** Would make "reload fetches
-  fresh `index.html`" an explicit server guarantee instead of relying on browser
-  reload-revalidation. Deferred to keep this PR webapp-only; revisit if testing
-  shows a reload that doesn't pick up the new build.
-- **Server-side clean 404 for `/assets/*`.** A real 404 (instead of the SPA
-  `index.html`) for a missing hashed chunk would fail fast + clean. Defense in
-  depth in a different package; not required for either trigger.
-- **Cloud-cone auto-restart** (issue solution #2). Unnecessary given the uniform
-  page reload recovers the in-sandbox browser too.
+- **Worker `Cache-Control: no-cache` on the SPA HTML** — makes "reload fetches a
+  fresh `index.html`" a server guarantee instead of relying on browser
+  reload-revalidation. Deferred to keep this webapp-only; revisit if a hosted
+  test shows a reload not picking up the new build.
+- **Server-side clean 404 for `/assets/*`** — fail fast/clean instead of the SPA
+  `index.html`. Defense in depth in another package; not required for any trigger.
+- **Cloud-cone auto-restart** (issue solution #2) — unnecessary; the page reload
+  recovers the in-sandbox browser too.
 
 ## Limitations (stated)
 
-- Recovers a tab/worker that is **already running** when the deploy lands. A page
-  whose **initial entry graph** can't evaluate (entry chunk itself gone before
-  `main()` runs) can't install the handler — but the first load fetches entry
-  chunks fresh with `index.html`, so that window is negligible.
+- Recovers a tab/worker **already running** when the deploy lands. A page whose
+  **initial entry graph** can't evaluate can't install the handler — but the
+  first load fetches entry chunks fresh with `index.html`, so that window is
+  negligible.
 - If `sessionStorage` is entirely unavailable (rare — private-mode/quota), the
-  fail-closed guard means **no auto-recovery** (the error surfaces and the user
-  reloads manually, i.e. today's behavior) — chosen over fail-open to guarantee
-  no reload loop.
-- bfcache restores and CDN-propagation windows can still momentarily re-error;
-  the guard ensures that degrades to a surfaced error, never a loop.
+  fail-closed guard means **no auto-recovery** (error surfaces, user reloads
+  manually — today's behavior) — chosen over fail-open to guarantee no loop.
+- Fresh HTML on reload relies on `location.reload()`'s top-document revalidation
+  (cherry/electron responses are already `no-store`; the default SPA response is
+  not). If ever insufficient, the deferred worker `no-cache` header closes it.
+- bfcache restores / CDN-propagation windows can momentarily re-error; the guard
+  degrades that to a surfaced error, never a loop.
 
 ## Verification gates
 

--- a/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
@@ -55,14 +55,13 @@ follower** (a side-panel-only user has no obvious "reload"), and any open
    returns **`index.html` as `200 text/html`** — the `import()` rejects with a
    MIME/module-script error, not a network 404. (Left as-is — Out of scope.)
 3. **The failing import is usually worker-owned; the worker has no
-   `vite:preloadError`.** `kernel-worker.ts` `boot()` calls
-   `registerProviders()`, which **eagerly `await`s the import of every** built-in
-   - external provider config chunk (`providers/index.ts` loop), and the cone/
-     scoop turn later imports pi-ai streaming chunks — all **inside the kernel
-     worker**. Verified: the built `kernel-worker-*.js` chunk has **zero**
-     `preloadError` occurrences (Vite injects the `__vitePreload` helper only into
-     the **page** bundle, not worker builds). A `window` listener cannot see worker
-     import failures.
+   `vite:preloadError`.** `kernel-worker.ts` `boot()` calls `registerProviders()`,
+   which **eagerly `await`s the import of every provider config chunk** (built-in
+   and external, in the `providers/index.ts` loop), and the cone/scoop turn later
+   imports pi-ai streaming chunks — all **inside the kernel worker**. Verified:
+   the built `kernel-worker-*.js` chunk has **zero** `preloadError` occurrences
+   (Vite injects the `__vitePreload` helper only into the **page** bundle, not
+   worker builds). A `window` listener cannot see worker import failures.
 4. **Two distinct worker failure timings:**
    - **Boot-time** — a stale chunk needed by `registerProviders()` (or another
      boot `await import()`) rejects in `boot()`. The init guard

--- a/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
@@ -2,7 +2,17 @@
 
 **Date:** 2026-07-07
 **Issue:** [#1330](https://github.com/ai-ecoverse/slicc/issues/1330) — "Cloud cone crashes on stale assets after deploy"
-**Scope:** `packages/webapp` only. One new boot helper + one registration line + tests + docs.
+**Scope:** `packages/webapp` only. Two trigger sites + one shared page-side guarded reload + tests + docs.
+
+> **Revision note (post-review).** A Codex review of the first draft found a
+> **blocker**: the exact failure in #1330 (`anthropic-*.js`) is a **worker-side**
+> dynamic import, which never dispatches `vite:preloadError` on `window`, so a
+> page-only handler would not fix the reported crash. Verified against the build.
+> The design below adds a worker-side trigger. Two scope calls were made while
+> the requester was away (both revisitable): (1) cover **both** page- and
+> worker-owned lazy-import failures; (2) stay **webapp-only** and rely on
+> `location.reload()`'s top-document revalidation for fresh HTML rather than
+> adding a worker `Cache-Control` header (deferred — see Out of scope).
 
 ## Problem
 
@@ -28,9 +38,10 @@ deploy:
 
 ## Root cause (verified against `main`)
 
-1. **The running tab holds an old module graph.** After a deploy, the CDN no
-   longer serves the old content-hashed chunk names. A lazy `import()` for a
-   now-gone chunk fails.
+1. **The running tab/worker holds an old module graph.** After a deploy the CDN
+   no longer serves the old content-hashed chunk names, so a lazy `import()` for
+   a now-gone chunk fails. The browser's module map caches that failure, so
+   retrying the same `import()` re-rejects — only a reload recovers.
 2. **The worker's SPA fallback masks the 404.** The `assets` binding in
    `packages/cloudflare-worker/wrangler.jsonc` uses
    `not_found_handling: "single-page-application"`, so a request for a gone
@@ -38,130 +49,207 @@ deploy:
    `import()` therefore rejects with a MIME/parse error ("Expected a JavaScript
    module … MIME type of text/html"). A `/assets/*` request can never cleanly
    404 today. (Left as-is this PR — see Out of scope.)
-3. **Nothing recovers an already-open tab.** There is **no `vite:preloadError`
-   handler anywhere** in the webapp (grep-verified). `scoops/upgrade-detection.ts`
-   only compares the bundled version to the last-seen version **at boot**, so it
-   never helps a tab that is already running when the deploy lands.
+3. **The failing import is usually worker-owned, and the worker has no
+   `vite:preloadError`.** `kernel-worker.ts` calls `registerProviders()` →
+   `providers/index.ts` uses lazy `import.meta.glob`, so provider chunks
+   (`anthropic-*.js`, etc.) are dynamically imported **inside the kernel
+   worker** during a cone/scoop turn. Verified: the built `kernel-worker-*.js`
+   chunk contains **zero** `preloadError` occurrences — Vite only injects the
+   `__vitePreload` helper (which dispatches the cancelable `vite:preloadError`
+   event) into the **page** bundle, not worker builds. So a `window` listener
+   cannot see the worker's import failures.
+4. **Worker import failures are currently retried 3× then surfaced as fatal.**
+   `scoop-context.ts:isRetryableError` matches `failed to fetch`
+   (line ~146), so "Failed to fetch dynamically imported module" is classified
+   retryable → 3 futile retries (the module map has cached the failure) → the
+   fatal "Scoop … failed after 3 attempts" message in the issue.
+5. **Nothing recovers an already-open tab.** There is **no `vite:preloadError`
+   handler anywhere** in the webapp (grep-verified), and
+   `scoops/upgrade-detection.ts` only compares the bundled version to the
+   last-seen version **at boot**, so it never helps a tab already running when
+   the deploy lands.
 
-Vite's `__vitePreload` dispatches a cancelable `vite:preloadError` event on
-`window` when a dynamic import fails (and re-throws unless the event is
-`preventDefault()`-ed). A guarded global handler that reloads on that event is
-the cheap, universal recovery — the same webapp entry (`ui/main.ts`) boots every
-real-browser float, so one handler covers all of them.
+Vite's `__vitePreload` dispatches a cancelable `vite:preloadError` on `window`
+when a **page-owned** dynamic import rejects (including the MIME/parse rejection
+from the `200 text/html` fallback), and re-throws unless `preventDefault()` is
+called. That covers page-owned lazy chunks (settings dialog, dips, mount
+branches). Worker-owned failures need a separate detection path that reaches the
+page (which owns `location.reload()`).
 
 ## Scope decisions
 
-- **Client handler only.** The guarded reload fully fixes the crash on its own;
-  the import rejection fires `vite:preloadError` regardless of the HTML-vs-404
-  response, so no server change is required.
-- **One uniform mechanism for every float**, including the cloud cone: the
-  in-sandbox browser runs the same guarded `location.reload()`, which re-fetches
-  a fresh `index.html` + module graph, re-boots the leader, rejoins the tray, and
-  resumes from the sandbox's OPFS. No `cloud-core` / worker / auto-restart
-  plumbing (issue solution #2 is unnecessary given the uniform reload).
+- **Two triggers, one recovery.** Both a page-owned `vite:preloadError` and a
+  worker-owned dynamic-import failure funnel into the **same** guarded
+  page-reload. The worker trigger is what actually fixes #1330; the page trigger
+  covers page-owned lazy chunks.
 - **`location.reload()` runs in the page realm.** `ui/main.ts` executes in the
-  real browsing context of every float (not the kernel worker / offscreen), so
-  `location.reload()` is a real navigation here — unlike the agent shell's
-  `nuke-reload` path, which exists precisely because the worker realm can't
-  reload itself.
+  real browsing context of every float; the kernel worker cannot reload itself
+  (no `location`) so it **broadcasts** a reload request to the page — the same
+  worker→page pattern the existing `nuke-reload` already uses
+  (`shell/supplemental-commands/nuke-channel.ts`).
+- **Uniform across floats, including the cloud cone.** A page reload re-fetches a
+  fresh `index.html` + module graph, re-boots the kernel worker, rejoins the
+  tray, and resumes from OPFS. No `cloud-core` / auto-restart plumbing (issue
+  solution #2 is unnecessary). Topology check: the extension side-panel follower
+  has no kernel worker, so it recovers via the page trigger only; the leader tab
+  / standalone / cloud each have a kernel worker and use both triggers.
+- **Webapp-only; rely on reload revalidation for fresh HTML.** Recovery needs the
+  reload to fetch a _new_ `index.html`. The default (non-cherry/non-electron) SPA
+  response sets no explicit `Cache-Control`, but `location.reload()` forces
+  top-document revalidation in all major browsers (conditional GET → 200 with the
+  new build's HTML when the ETag changed), and the cherry side-panel response is
+  already `no-store`. A worker `Cache-Control: no-cache` on the SPA HTML is a
+  possible robustness follow-up (Out of scope), not required for correctness.
 
 ## Design
 
-### Component — `packages/webapp/src/ui/boot/setup-preload-error-reload.ts`
+### Shared channel + detection — `packages/webapp/src/ui/boot/stale-asset-channel.ts`
 
-Sibling to the existing `boot/setup-*.ts` helpers (e.g.
-`setup-nuke-reload-listener.ts`, which already performs a page-side reload).
+Shell-free and realm-agnostic (no `window`/`document` at module scope; only
+`BroadcastChannel`, which exists in both page and DedicatedWorker), so the kernel
+worker can import the detection + broadcast without pulling DOM code — mirroring
+how `nuke-channel.ts` is split out of `nuke-command.ts`.
 
-- **`decidePreloadReload(currentVersion: string, storedFlag: string | null): boolean`**
-  — pure guard logic, no DOM. Returns `true` iff `storedFlag !== currentVersion`.
-- **`setupPreloadErrorReload(deps?): void`** — registers
-  `window.addEventListener('vite:preloadError', handler)`. `deps` are injectable
-  for testing and default to production values:
-  - `reload: () => void` → `() => window.location.reload()`
-  - `storage: Pick<Storage, 'getItem' | 'setItem'>` → `window.sessionStorage`
-  - `version: string` → `readBundledVersion().version` (from
-    `scoops/upgrade-detection.ts`, i.e. `__SLICC_VERSION__`)
-  - `storageKey` constant: `'slicc:preload-reloaded'`
+- **`isDynamicImportError(msg: string): boolean`** — matches the cross-browser
+  dynamic-import-failure family:
+  - Chromium: `Failed to fetch dynamically imported module`
+  - Firefox: `error loading dynamically imported module`
+  - WebKit: `Importing a module script failed`
+- **`STALE_ASSET_RELOAD_CHANNEL = 'slicc-stale-asset-reload'`** and the wire type
+  `{ type: 'stale-asset-reload' }` (no payload — unlike nuke it clears no
+  storage).
+- **`broadcastStaleAssetReload(): void`** — posts the message on the channel
+  (no-op if `BroadcastChannel` is unavailable). Called from the worker realm.
+- **`installStaleAssetReloadListener(onReload: () => void): () => void`** —
+  page-side channel listener; returns a disposer.
 
-  Handler behavior on `vite:preloadError`:
-  1. Read the stored flag; compute `decidePreloadReload(version, flag)`.
-  2. If it returns `true`: `event.preventDefault()` (suppress Vite's re-throw so
-     no error boundary flashes before navigation), write `storage.setItem(key,
-version)`, then `reload()`.
-  3. If it returns `false` (already reloaded once for this exact version): do
-     **nothing** — do not `preventDefault`. Let the error propagate to the
-     existing "Something went wrong" + retry UI, so a genuinely-broken build
-     surfaces instead of hiding behind a silent reload loop.
-  4. `storage` access is wrapped in try/catch — a `sessionStorage` failure
-     (private-mode quota, etc.) must not throw inside the error handler; on a
-     storage read/write failure the handler still reloads once (fail-open toward
-     recovery) but cannot then guard, which is acceptable because a storage-less
-     context also can't loop-persist across the reload.
+### Shared guarded reload + page trigger — `packages/webapp/src/ui/boot/setup-preload-error-reload.ts`
 
-### The guard (why version-keyed `sessionStorage`)
+Sibling to `setup-nuke-reload-listener.ts`. Owns the one guarded-reload function
+that **both** triggers call.
 
-Invariant: **reload at most once per deployed version**, so we never loop yet
-always recover a genuinely-stale tab.
+- **`decideStaleReload(lastReloadAt: number | null, now: number, windowMs: number): boolean`**
+  — pure guard: reload iff `lastReloadAt === null || now - lastReloadAt >= windowMs`.
+- **`setupPreloadErrorReload(deps?): void`** — deps injectable for tests, default
+  to production:
+  - `reload` → `() => window.location.reload()`
+  - `storage: Pick<Storage,'getItem'|'setItem'>` → `window.sessionStorage`
+  - `now` → `() => Date.now()`
+  - `windowMs` → `RELOAD_WINDOW_MS` constant (**20_000**)
+  - `storageKey` → `'slicc:stale-asset-reloaded-at'`
 
-- Running (stale) bundle is version `V`. On `vite:preloadError` the flag is
-  unset (or holds an older version) → reload; set flag = `V` first.
-- After reload the tab runs the fresh bundle `V′`. The flag holds `V ≠ V′`, so a
-  _later_ deploy can still trigger a fresh recovery reload.
-- A _repeat_ failure while still on `V` (flag already `V`) is suppressed → the
-  error surfaces instead of looping. Worst case across back-to-back deploys is a
-  small bounded number of reloads (one per version actually observed), never an
-  infinite loop.
+  It:
+  1. Defines `guardedReload()`:
+     - Read `lastReloadAt` from storage; **on any storage read/write throw,
+       return without reloading (fail-closed)** — we must never reload when we
+       cannot persist the guard, or a broken deploy could loop.
+     - If `decideStaleReload(...)` is `false` (reloaded within the window),
+       return — let the underlying error surface to the existing "Something went
+       wrong" + retry UI. Returns whether it will reload.
+     - Else `storage.setItem(key, String(now))` then `reload()`.
+  2. Registers `window.addEventListener('vite:preloadError', e => { if (guardedReload()) e.preventDefault(); })`
+     — `preventDefault()` only when we actually reload, so a suppressed
+     (guard-blocked) error still propagates.
+  3. Calls `installStaleAssetReloadListener(guardedReload)` so a worker broadcast
+     runs the identical guarded reload.
 
-`sessionStorage` is the correct lifetime: per-tab, survives the `reload()`,
-clears on tab close (so a new session isn't wrongly suppressed). `localStorage`
-would over-suppress across sessions; a time/count guard isn't causally tied to
-the version that changed (rejected as approaches B/C in brainstorming).
+### Guard rationale (timestamp, not version)
+
+`__SLICC_VERSION__` only bumps on a semver **release**; PR-merge / manual /
+staging deploys rebuild `dist/ui` with new chunk hashes at the **same** version,
+so a version-keyed guard would wrongly suppress a legitimate second reload across
+those deploys. A **timestamp window** ("reload at most once per 20 s per tab") is
+causally correct: a reload that fixes the tab produces no further errors; a
+reload that does **not** fix it (broken/mid-propagation deploy) re-errors within
+the window → suppressed → error surfaces (no loop); a genuinely new deploy
+minutes/hours later is past the window → reload allowed. `sessionStorage` is the
+right lifetime (per-tab, survives the reload, clears on tab close).
+
+### Worker trigger — `packages/webapp/src/scoops/scoop-context.ts`
+
+In the turn-error classification (where `isRetryableError` / `isNonRetryableError`
+are consulted), check `isDynamicImportError(msg)` **first**:
+
+- treat it as **non-retryable** (retrying a cached-failed `import()` is futile
+  and would burn the 3 attempts + backoff before recovery), and
+- call `broadcastStaleAssetReload()` so the owning page performs the guarded
+  reload.
+
+This runs for the cone and every scoop (shared classifier). `BroadcastChannel`
+in the kernel worker reaches the same-origin page (leader tab / standalone /
+in-sandbox), exactly as `nuke-channel` already broadcasts worker→page.
 
 ### Registration — `packages/webapp/src/ui/main.ts`
 
 Call `setupPreloadErrorReload()` as the **first statement inside `main()`**,
-before the fixture check and before any dynamic `import()`. All lazy imports
-(provider modules, `wc-settings`, dip/sprinkle chunks, mount branches) happen
-after boot, so the handler is always registered before a stale chunk can be
-requested. The initial entry chunks are fetched fresh with `index.html` on first
-load and always match, so entry-chunk staleness is not a concern here.
+before the fixture check and any dynamic `import()`, so both the page listener
+and the broadcast listener are installed before any lazy chunk can be requested.
+It runs once per page-owning float via the shared entry (standalone, extension
+leader + side-panel follower, cloud-in-sandbox); the `?ui-fixture` surface exits
+before boot and is unaffected, matching `setupNukeReloadListener`'s placement.
 
 ## Testing
 
-`packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts`:
+`packages/webapp/tests/ui/boot/stale-asset-channel.test.ts`:
 
-- **Guard matrix** (`decidePreloadReload`, pure):
-  - no prior flag (`null`) → `true`
-  - flag equals current version → `false`
-  - flag is an older version (post-deploy) → `true`
-- **Handler** (jsdom, injected `reload`/`storage` spies — jsdom's
-  `location.reload` throws "Not implemented", so injection is required):
-  - first `vite:preloadError` → `reload` called once, flag written = version,
-    `event.preventDefault()` called
-  - second dispatch (flag now == version) → `reload` **not** called,
-    `preventDefault` **not** called
-  - a post-deploy dispatch (flag holds an older version) → `reload` called again
-  - a `storage.setItem` that throws → handler still calls `reload` (fail-open),
-    does not itself throw
+- `isDynamicImportError` matrix: the three browser strings → `true`; unrelated
+  errors (`401`, `rate limit`, `network error`) → `false`.
+- `broadcastStaleAssetReload` posts the message; `installStaleAssetReloadListener`
+  invokes `onReload` on receipt and the disposer detaches.
+
+`packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts` (jsdom;
+inject `reload`/`storage`/`now` — jsdom's `location.reload` throws "Not
+implemented"):
+
+- **Guard matrix** (`decideStaleReload`): no prior → `true`; within window →
+  `false`; past window → `true`.
+- **Page trigger**: first `vite:preloadError` → `reload` once + flag written +
+  `preventDefault` called; a second dispatch within the window → no `reload`, no
+  `preventDefault`; a dispatch past the window → `reload` again.
+- **Worker trigger**: a `stale-asset-reload` broadcast → same guarded `reload`.
+- **Fail-closed**: a `storage.getItem`/`setItem` that throws → handler does
+  **not** reload and does **not** throw.
+
+`packages/webapp/tests/scoops/scoop-context.test.ts` (extend existing):
+
+- `isDynamicImportError` is consulted before `isRetryableError` for a "Failed to
+  fetch dynamically imported module" message (classified non-retryable), and the
+  broadcast fires. (Assert via the injected/spied broadcast seam.)
 
 ## Docs
 
-- `packages/webapp/CLAUDE.md` — a "Stale-chunk recovery" note under the boot /
-  UI section describing the `vite:preloadError` handler and the version-keyed
-  guard.
-- `docs/pitfalls.md` — short entry: long-lived tabs + content-hashed chunks +
-  the worker's SPA-fallback-returns-HTML behavior, and how the handler recovers.
+- `packages/webapp/CLAUDE.md` — a "Stale-asset recovery" note (boot/UI section)
+  describing the two triggers, the shared timestamp-guarded reload, and the
+  worker→page broadcast.
+- `docs/pitfalls.md` — short entry: long-lived tabs + content-hashed chunks + the
+  worker's SPA-fallback-returns-HTML behavior + the worker-vs-page
+  `vite:preloadError` gap, and how the two triggers recover.
 - Close #1330 referencing the PR.
 
 ## Out of scope (possible follow-ups)
 
-- **Server-side clean 404 for `/assets/*`.** Making the worker return a real 404
-  (instead of the SPA `index.html`) for a missing hashed chunk would fail fast +
-  clean and stop serving full HTML bodies for dead chunks. Deferred — the client
-  handler already recovers the crash; this is defense-in-depth in a different
-  package.
+- **Worker `Cache-Control: no-cache` on the SPA HTML.** Would make "reload fetches
+  fresh `index.html`" an explicit server guarantee instead of relying on browser
+  reload-revalidation. Deferred to keep this PR webapp-only; revisit if testing
+  shows a reload that doesn't pick up the new build.
+- **Server-side clean 404 for `/assets/*`.** A real 404 (instead of the SPA
+  `index.html`) for a missing hashed chunk would fail fast + clean. Defense in
+  depth in a different package; not required for either trigger.
 - **Cloud-cone auto-restart** (issue solution #2). Unnecessary given the uniform
-  client reload recovers the in-sandbox browser too.
+  page reload recovers the in-sandbox browser too.
+
+## Limitations (stated)
+
+- Recovers a tab/worker that is **already running** when the deploy lands. A page
+  whose **initial entry graph** can't evaluate (entry chunk itself gone before
+  `main()` runs) can't install the handler — but the first load fetches entry
+  chunks fresh with `index.html`, so that window is negligible.
+- If `sessionStorage` is entirely unavailable (rare — private-mode/quota), the
+  fail-closed guard means **no auto-recovery** (the error surfaces and the user
+  reloads manually, i.e. today's behavior) — chosen over fail-open to guarantee
+  no reload loop.
+- bfcache restores and CDN-propagation windows can still momentarily re-error;
+  the guard ensures that degrades to a surfaced error, never a loop.
 
 ## Verification gates
 

--- a/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
@@ -205,8 +205,43 @@ one-line wrap verified by typecheck + the existing init-guard reset test.
 
 In the turn-error classification, check `isDynamicImportError(msg)` **before**
 `isRetryableError` (which matches `failed to fetch`): treat it as **non-retryable**
-(don't burn the 3 futile retries + backoff) and call `broadcastStaleAssetReload()`.
-Runs for the cone and every scoop.
+(don't burn the 3 futile retries + backoff) and call
+`broadcastStaleAssetReload(this.scoop.isCone)`. Runs for the cone and every scoop;
+the `isCone` arg marks the dropped turn for auto-resubmit (see "Turn continuity").
+
+### Turn continuity — auto-resubmit the dropped cone turn (Task 8 follow-on)
+
+The recovery reload loses the in-flight turn: the user's message is persisted
+(shows as sent) but the agent never answers it. Only the **cone** turn-time
+trigger is user-resubmittable (scoop turns are cone-delegated; boot-time and
+page `vite:preloadError` reloads have no dropped user turn), so only it marks a
+replay:
+
+1. `broadcastStaleAssetReload(this.scoop.isCone)` stamps `replayTurn` on the
+   `BroadcastChannel` message (`StaleAssetReloadMsg.replayTurn?: boolean`).
+2. The page listener (`installWorkerStaleAssetReloadListener`) calls
+   `markStaleAssetReplayPending()` when `replayTurn` is true — a one-shot
+   `sessionStorage['slicc:stale-asset-replay'] = '1'` flag set **before** the
+   guarded reload. `sessionStorage` survives the reload but not a tab close, so
+   a stale flag can never linger. Both helpers are fail-safe (a storage throw
+   never breaks the reload).
+3. After boot, `wc-chat-controller.loadMessages(...)` — the convergence point
+   where the restored thread arrives post-(re)connect — ends with
+   `#maybeReplayDroppedTurn()`. It **consumes** the flag once
+   (`consumeStaleAssetReplayPending()` reads AND clears, so later `loadMessages`
+   on scoop switches never re-replay), and replays **only** when no turn is
+   already running (`#processing` false) AND the thread ends in an unanswered
+   user-typed turn (`role === 'user'`, not `lick` / `delegation` / `queued`).
+   An assistant reply as the tail means the turn completed — no resend (would
+   double-submit).
+4. Replay reuses the existing `#handleErrorRetry(new Event('slicc-error-retry'))`
+   path (no messageId → it scans back for the last user turn and re-sends via
+   `#agent.sendMessage`), which carries its own `#processing` double-submit
+   guard. No new agent API.
+
+Leader/standalone only — a follower has no kernel worker, so its reload drops no
+cone turn (and its `FollowerSyncManager` agent never receives a `replayTurn`
+broadcast).
 
 ### Worker-script-load trigger — page-side `Worker` `error`
 

--- a/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
@@ -130,11 +130,18 @@ imports the detection + broadcast without DOM code, mirroring how
   path silently degrades to no-broadcast rather than crashing).
 - **`broadcastStaleAssetReload(): void`** — posts `{type, instanceId}` on the
   channel (no-op if no instanceId set or `BroadcastChannel` is unavailable).
+- **`broadcastIfStaleAssetError(err: unknown): void`** — `if
+(isDynamicImportError(message-of-err)) broadcastStaleAssetReload()`. The
+  worker `boot()` catch calls this (it lives here, not in `kernel-worker.ts`,
+  so it is unit-testable without triggering that module's load-time
+  `self.addEventListener` side effect).
 - **`installStaleAssetReloadListener(instanceId: string, onReload: () => void): () => void`**
-  — page-side listener that invokes `onReload` only when the message's
-  `instanceId` matches (own worker), ignoring other tabs' broadcasts. Idempotent
-  (repeat calls return the same disposer, matching `installNukeReloadListener`);
-  returns a disposer.
+  — page-side listener primitive that invokes `onReload` only when the message's
+  `instanceId` matches (own worker), ignoring other tabs' broadcasts. Returns a
+  fresh disposer per call (like `installNukeReloadListener`); single-install
+  **idempotency is enforced by the page wrapper**
+  `installWorkerStaleAssetReloadListener` (below), matching how
+  `setup-nuke-reload-listener.ts` wraps the nuke listener.
 
 **Why instanceId-scoped, not origin-wide:** `BroadcastChannel` reaches every
 same-origin context, so an unscoped reload would reload _all_ SLICC tabs
@@ -185,11 +192,14 @@ loop-proof for the realistic re-error-at-boot case.
 ### Worker trigger A — boot-time — `packages/webapp/src/kernel/kernel-worker.ts`
 
 At the very start of `boot(init)`, call `setStaleAssetInstanceId(init.instanceId)`.
-Wrap `boot()`'s body in `try { … } catch (err) { if
-(isDynamicImportError(String((err as Error)?.message ?? err))) broadcastStaleAssetReload(); throw err; }`
-— broadcast on a stale-import boot failure, then **rethrow** so the existing init
-guard `onError` / worker-ready-timeout fallback is unchanged. Covers
-`registerProviders()` and every boot `await import(...)`.
+Wrap `boot()`'s whole body — from `installFetchBypass()` through the final
+`init.kernelPort.postMessage({ type: 'kernel-worker-ready' })` — in
+`try { … } catch (err) { broadcastIfStaleAssetError(err); throw err; }` — broadcast
+on a stale-import boot failure, then **rethrow** so the existing init guard
+`onError` / worker-ready-timeout fallback is unchanged. Covers
+`registerProviders()` and every boot `await import(...)`. The behavioral test
+lives on `broadcastIfStaleAssetError` (channel module); the `boot()` change is a
+one-line wrap verified by typecheck + the existing init-guard reset test.
 
 ### Worker trigger B — turn-time — `packages/webapp/src/scoops/scoop-context.ts`
 

--- a/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-07-stale-asset-recovery-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-07
 **Issue:** [#1330](https://github.com/ai-ecoverse/slicc/issues/1330) — "Cloud cone crashes on stale assets after deploy"
-**Scope:** `packages/webapp` only. Page trigger + two worker triggers → one shared, instanceId-scoped, timestamp-guarded page reload + tests + docs.
+**Scope:** `packages/webapp` only. Two page triggers + two worker triggers → one shared, instanceId-scoped, timestamp-guarded page reload + tests + docs.
 
 > **Revision history.**
 >
@@ -19,7 +19,17 @@
 >   turn-time hook misses it. Plus: broaden the matcher to the MIME/module-script
 >   family; the 20 s guard window is shorter than the 30 s boot timeout (loop
 >   risk); fix a `?ui-fixture` self-contradiction.
-> - **Draft 3 (this doc)** resolves all of the above; verified against `main`.
+> - **Draft 3** added the worker triggers + instanceId scoping + boot catch.
+>   Third Codex review confirmed R1/R2a/R2b genuinely resolved, and found one
+>   **blocker**: because `BroadcastChannel` does not buffer and
+>   `spawnKernelWorker()` posts `kernel-worker-init` synchronously, the reload
+>   listener must be installed **before** the spawn or a fast boot failure's
+>   broadcast is lost. Plus should-fixes: tighten the matcher (no bare `MIME
+type`), assert `instanceId`, precise extension wording, and a page-side
+>   `worker.onerror` fallback for a stale worker **entry chunk**.
+> - **Draft 4 (this doc)** pins the listener-before-spawn ordering, tightens the
+>   matcher, adds the fourth (`worker.onerror`) trigger, and makes the listener
+>   idempotent; verified against `main`.
 >
 > Two scope calls remain (both revisitable): cover **both** page- and
 > worker-owned failures, and stay **webapp-only** relying on `location.reload()`
@@ -84,8 +94,12 @@ page (which owns `location.reload()`).
 
 ## Design
 
-One shared, guarded page reload is fed by **three** triggers (one page, two
-worker). The worker triggers are what actually fix #1330.
+One shared, guarded page reload is fed by **four** triggers: two page-side
+(`vite:preloadError` for page-owned lazy chunks; a `Worker` `error` event for a
+failed worker **entry-chunk** load) and two worker-side (a `boot()` catch for
+boot-time provider imports; the `scoop-context` classifier for turn-time
+imports). The worker-side triggers are what actually fix the #1330 report. All
+four funnel into the one `guardedReload`.
 
 ### Shared channel + detection — `packages/webapp/src/ui/boot/stale-asset-channel.ts`
 
@@ -95,23 +109,32 @@ imports the detection + broadcast without DOM code, mirroring how
 `nuke-channel.ts` splits out of `nuke-command.ts`.
 
 - **`isDynamicImportError(msg: string): boolean`** — matches the cross-browser
-  dynamic-import / module-script failure family (case-insensitive):
-  - `Failed to fetch dynamically imported module` (Chromium)
+  dynamic-import / module-script failure family (case-insensitive). It requires
+  **module-script context** — a bare `MIME type` match is deliberately NOT used,
+  because `scoop-context` classifies from a generic `error.message` and a bare
+  MIME match would false-positive on unrelated tool / upload / provider errors
+  and spuriously reload:
+  - `failed to fetch dynamically imported module` (Chromium)
   - `error loading dynamically imported module` (Firefox)
-  - `Importing a module script failed` (WebKit)
-  - `expected a javascript( |-)?module` / `MIME type` module-script rejection
-    (the `200 text/html` fallback case)
+  - `importing a module script failed` (WebKit)
+  - `expected a javascript module` / `module script` (the `200 text/html`
+    fallback rejection — the phrase always names "module script" / "JavaScript
+    module", so we anchor on that, not on "MIME type" alone)
 - **`STALE_ASSET_RELOAD_CHANNEL = 'slicc-stale-asset-reload'`**, wire type
   `{ type: 'stale-asset-reload'; instanceId: string }`.
 - **`setStaleAssetInstanceId(id: string): void`** — the kernel worker records its
   `init.instanceId` here at the very start of `boot()` so the broadcasters can
   stamp it (both worker failure sites are reached without threading the id).
+  `KernelWorkerInitMsg.instanceId` is typed optional; the design depends on it, so
+  a missing id in a worker-owning boot logs a dev-visible warning (the recovery
+  path silently degrades to no-broadcast rather than crashing).
 - **`broadcastStaleAssetReload(): void`** — posts `{type, instanceId}` on the
   channel (no-op if no instanceId set or `BroadcastChannel` is unavailable).
 - **`installStaleAssetReloadListener(instanceId: string, onReload: () => void): () => void`**
   — page-side listener that invokes `onReload` only when the message's
-  `instanceId` matches (own worker), ignoring other tabs' broadcasts. Returns a
-  disposer.
+  `instanceId` matches (own worker), ignoring other tabs' broadcasts. Idempotent
+  (repeat calls return the same disposer, matching `installNukeReloadListener`);
+  returns a disposer.
 
 **Why instanceId-scoped, not origin-wide:** `BroadcastChannel` reaches every
 same-origin context, so an unscoped reload would reload _all_ SLICC tabs
@@ -175,26 +198,49 @@ In the turn-error classification, check `isDynamicImportError(msg)` **before**
 (don't burn the 3 futile retries + backoff) and call `broadcastStaleAssetReload()`.
 Runs for the cone and every scoop.
 
-### Registration — `packages/webapp/src/ui/main.ts` (+ worker-spawn site)
+### Worker-script-load trigger — page-side `Worker` `error`
+
+Triggers B/C run only _after_ the worker module evaluates. If the worker
+**entry chunk** itself (`kernel-worker-*.js`) is the stale asset, the worker
+never evaluates and `boot()` never runs, so neither worker trigger fires. The
+page owns the `Worker` object, so `spawnKernelWorker` / `bootstrapKernelWorker`
+attaches `worker.addEventListener('error', () => guardedReload())` to recover
+that case. (This is narrow — the worker chunk is referenced by a freshly-loaded
+`index.html` — but it closes the gap with no extra cost.)
+
+### Registration + ordering — `packages/webapp/src/ui/main.ts` + the worker-spawn site
 
 - `setupPreloadErrorReload()` — first statement in `main()`, before the fixture
   check and any dynamic `import()`. It installs only the page `vite:preloadError`
   handler (page-local, no instanceId needed) and is harmless on the `?ui-fixture`
   surface (which spawns no worker and does no provider imports).
-- `installWorkerStaleAssetReloadListener(instanceId)` — called on the
-  worker-owning floats at the point the page spawns the kernel worker (standalone
-  / hosted-leader / cloud, and the extension leader tab), where the page-generated
-  `instanceId` (the one threaded into `kernel-worker-init`) is known — which is
-  before the worker runs `registerProviders()`, so no failure can precede the
-  listener. The extension side-panel follower spawns no worker and installs only
-  the page handler.
+- **Ordering is load-bearing.** `spawnKernelWorker()` → `bootstrapKernelWorker()`
+  posts `kernel-worker-init` **synchronously** (`kernel/spawn.ts`), and
+  `BroadcastChannel` does **not** buffer — a message sent before a listener
+  exists is lost forever. So `installWorkerStaleAssetReloadListener(instanceId)`
+  MUST be installed **before** `spawnKernelWorker()` is called (equivalently,
+  inside `bootstrapKernelWorker` before `worker.postMessage`), never after it
+  returns. The page-generated `instanceId` is already available at that point
+  (`setupStandalonePrelude` returns it; `wc-live` passes it to
+  `spawnKernelWorker`). The `worker.onerror` handler above is attached in the
+  same place, on the same `Worker`.
+- **Floats.** Worker-owning floats — standalone, hosted-leader, cloud, and the
+  **extension leader tab** (which boots via the ordinary live webapp path
+  `mountWcUiLive` and spawns the kernel worker like any standalone leader; the
+  thin extension bundles no offscreen engine) — install both the broadcast
+  listener and the `worker.onerror` handler at spawn. The **extension side-panel
+  follower** is a cherry iframe that spawns no worker, so it installs only the
+  page `vite:preloadError` handler.
 
 ## Testing
 
 `tests/ui/boot/stale-asset-channel.test.ts`:
 
-- `isDynamicImportError` matrix: the three browser strings + the MIME/module-
-  script string → `true`; `401` / `rate limit` / plain `network error` → `false`.
+- `isDynamicImportError` matrix: the three browser strings + the "expected a
+  JavaScript module" / "module script" string → `true`; `401` / `rate limit` /
+  plain `network error` → `false`, AND explicit false-positive guards: a bare
+  "unsupported MIME type" upload/content error and a generic "failed to fetch"
+  (no "module") → `false`.
 - `broadcastStaleAssetReload` no-ops before `setStaleAssetInstanceId`; after it,
   posts `{type, instanceId}`.
 - `installStaleAssetReloadListener(id, onReload)` invokes `onReload` on a matching
@@ -209,6 +255,8 @@ Runs for the cone and every scoop.
   dispatch past window → reload again.
 - Worker listener: a matching-instanceId broadcast → guarded `reload`; a
   non-matching one → no reload.
+- `worker.onerror` trigger: a `Worker` `error` event → guarded `reload` (shares
+  the same guard, so it can't stack with a broadcast within the window).
 - Fail-closed: `storage.getItem`/`setItem` throws → no reload, no throw.
 
 `tests/scoops/scoop-context.test.ts` (extend): a "Failed to fetch dynamically
@@ -241,10 +289,11 @@ broadcasts once and still rethrows (guard `onError` still runs).
 
 ## Limitations (stated)
 
-- Recovers a tab/worker **already running** when the deploy lands. A page whose
-  **initial entry graph** can't evaluate can't install the handler — but the
-  first load fetches entry chunks fresh with `index.html`, so that window is
-  negligible.
+- Recovers a tab/worker **already running** when the deploy lands. A stale
+  **worker** entry chunk is covered by the `worker.onerror` trigger, but a stale
+  **page** entry chunk (the page's own `index.html`-referenced entry) can't
+  install any handler — that first load fetches entry chunks fresh with
+  `index.html`, though, so the window is negligible.
 - If `sessionStorage` is entirely unavailable (rare — private-mode/quota), the
   fail-closed guard means **no auto-recovery** (error surfaces, user reloads
   manually — today's behavior) — chosen over fail-open to guarantee no loop.

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -200,6 +200,19 @@ Deep reference: `docs/kernel/process-model.md`.
 - Hydrates assistant `shtml` code blocks into sandboxed iframes after streaming completes.
 - Uses a minimal lick bridge and auto-height reporting.
 
+### Stale-asset recovery (post-deploy)
+
+After a deploy, a long-lived tab/worker can crash on a now-gone content-hashed
+chunk (#1330). Four triggers funnel into one shared, **instanceId-scoped**,
+**fail-closed**, timestamp-guarded (`RELOAD_WINDOW_MS = 60_000`) page reload
+(`ui/boot/setup-preload-error-reload.ts` + realm-agnostic
+`core/stale-asset-channel.ts`): page `vite:preloadError`; page `Worker` `error`
+(`spawn.ts` `onWorkerScriptError`); worker `boot()` `try/catch`
+(`broadcastIfStaleAssetError`); worker `scoop-context` classifier (checked BEFORE
+the `failed to fetch` retry matcher). Worker triggers broadcast over
+`BroadcastChannel` stamped with `instanceId`; only the owning page reloads. The
+listener installs BEFORE `spawnKernelWorker()` (BroadcastChannel doesn't buffer).
+
 ## Key Conventions
 
 - **Two type systems**: legacy tool definitions in `tools/` and pi-compatible tools in `core/`; bridge them through `tool-adapter.ts`.

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -214,6 +214,14 @@ worker `boot()` `try/catch`
 the `failed to fetch` retry matcher). Worker triggers broadcast over
 `BroadcastChannel` stamped with `instanceId`; only the owning page reloads. The
 listener installs BEFORE `spawnKernelWorker()` (BroadcastChannel doesn't buffer).
+A dropped **cone** turn is auto-resubmitted once after the recovery reload: the
+worker turn-time trigger stamps `replayTurn` on the broadcast (cone only —
+`broadcastStaleAssetReload(this.scoop.isCone)`), the page sets a `sessionStorage`
+`slicc:stale-asset-replay` flag before reloading (`markStaleAssetReplayPending`),
+and after boot `wc-chat-controller.loadMessages` consumes it once
+(`consumeStaleAssetReplayPending`) and replays the thread's last unanswered
+user turn via the existing `#handleErrorRetry` path. Boot-time and page
+`vite:preloadError` reloads pass `replayTurn=false` (no dropped turn).
 
 ## Key Conventions
 

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -207,7 +207,9 @@ chunk (#1330). Four triggers funnel into one shared, **instanceId-scoped**,
 **fail-closed**, timestamp-guarded (`RELOAD_WINDOW_MS = 60_000`) page reload
 (`ui/boot/setup-preload-error-reload.ts` + realm-agnostic
 `core/stale-asset-channel.ts`): page `vite:preloadError`; page `Worker` `error`
-(`spawn.ts` `onWorkerScriptError`); worker `boot()` `try/catch`
+(`spawn.ts` `onWorkerScriptError` — fires on any uncaught worker error, incl. a
+stale worker ENTRY chunk failing to load; guarded, so reloads at most once);
+worker `boot()` `try/catch`
 (`broadcastIfStaleAssetError`); worker `scoop-context` classifier (checked BEFORE
 the `failed to fetch` retry matcher). Worker triggers broadcast over
 `BroadcastChannel` stamped with `instanceId`; only the owning page reloads. The

--- a/packages/webapp/src/core/stale-asset-channel.ts
+++ b/packages/webapp/src/core/stale-asset-channel.ts
@@ -1,0 +1,87 @@
+/**
+ * Realm-agnostic detection + worker→page signal for stale-chunk recovery after
+ * a deploy (#1330). DOM-free at module scope (only `BroadcastChannel`, in the
+ * page AND the kernel worker), so both realms import it. Mirrors the split-out
+ * shape of `nuke-channel.ts`.
+ */
+import { createLogger } from './logger.js';
+
+const log = createLogger('stale-asset');
+
+// Module-script context ONLY — never a bare "MIME type" / "failed to fetch",
+// which would false-positive on unrelated tool/upload/provider errors.
+const DYNAMIC_IMPORT_ERROR_RE =
+  /dynamically imported module|importing a module script failed|expected a javascript module|module script/i;
+
+/** True for the cross-browser dynamic-import / module-script load failure family. */
+export function isDynamicImportError(msg: string): boolean {
+  return DYNAMIC_IMPORT_ERROR_RE.test(msg);
+}
+
+/** Same-origin channel a failing worker uses to ask its owning page to reload. */
+export const STALE_ASSET_RELOAD_CHANNEL = 'slicc-stale-asset-reload';
+
+export interface StaleAssetReloadMsg {
+  type: 'stale-asset-reload';
+  instanceId: string;
+}
+
+let workerInstanceId: string | null = null;
+
+/** Kernel worker records `init.instanceId` at boot start. Dev-warns if absent. */
+export function setStaleAssetInstanceId(id: string | undefined): void {
+  if (!id) {
+    workerInstanceId = null;
+    if (import.meta.env?.DEV) {
+      log.warn('no instanceId for kernel worker; stale-asset reload signal disabled');
+    }
+    return;
+  }
+  workerInstanceId = id;
+}
+
+/** Post an instanceId-stamped reload request. No-op until an id is set. */
+export function broadcastStaleAssetReload(): void {
+  if (!workerInstanceId || typeof BroadcastChannel !== 'function') return;
+  const channel = new BroadcastChannel(STALE_ASSET_RELOAD_CHANNEL);
+  try {
+    channel.postMessage({
+      type: 'stale-asset-reload',
+      instanceId: workerInstanceId,
+    } satisfies StaleAssetReloadMsg);
+  } finally {
+    channel.close();
+  }
+}
+
+/** Broadcast iff `err` is a dynamic-import failure. Called from the worker
+ *  `boot()` catch — lives here (not in `kernel-worker.ts`) so it is unit-testable
+ *  without triggering that module's load-time `self.addEventListener` side effect. */
+export function broadcastIfStaleAssetError(err: unknown): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (isDynamicImportError(msg)) broadcastStaleAssetReload();
+}
+
+/**
+ * Page-side listener PRIMITIVE. Invokes `onReload` only for a broadcast stamped
+ * with the page's own `instanceId`. Returns a fresh disposer per call (like
+ * `installNukeReloadListener`); single-install is enforced by the page wrapper
+ * `installWorkerStaleAssetReloadListener`.
+ */
+export function installStaleAssetReloadListener(
+  instanceId: string,
+  onReload: () => void
+): () => void {
+  if (typeof BroadcastChannel !== 'function') return () => {};
+  const channel = new BroadcastChannel(STALE_ASSET_RELOAD_CHANNEL);
+  const handler = (event: MessageEvent): void => {
+    const data = event.data as StaleAssetReloadMsg | undefined;
+    if (data?.type !== 'stale-asset-reload' || data.instanceId !== instanceId) return;
+    onReload();
+  };
+  channel.addEventListener('message', handler);
+  return () => {
+    channel.removeEventListener('message', handler);
+    channel.close();
+  };
+}

--- a/packages/webapp/src/core/stale-asset-channel.ts
+++ b/packages/webapp/src/core/stale-asset-channel.ts
@@ -24,6 +24,13 @@ export const STALE_ASSET_RELOAD_CHANNEL = 'slicc-stale-asset-reload';
 export interface StaleAssetReloadMsg {
   type: 'stale-asset-reload';
   instanceId: string;
+  /**
+   * Set true only by the CONE turn-time trigger — the one dropped turn a user
+   * can resubmit. The page marks a replay pending before reloading; after boot
+   * the restored thread's last unanswered user turn is re-sent once. Boot-time
+   * and page `vite:preloadError` reloads leave this false (no dropped turn).
+   */
+  replayTurn?: boolean;
 }
 
 let workerInstanceId: string | null = null;
@@ -40,14 +47,19 @@ export function setStaleAssetInstanceId(id: string | undefined): void {
   workerInstanceId = id;
 }
 
-/** Post an instanceId-stamped reload request. No-op until an id is set. */
-export function broadcastStaleAssetReload(): void {
+/**
+ * Post an instanceId-stamped reload request. No-op until an id is set. Pass
+ * `replayTurn = true` (cone turn-time trigger only) to mark the dropped turn
+ * for one-shot auto-resubmit after the recovery reload.
+ */
+export function broadcastStaleAssetReload(replayTurn = false): void {
   if (!workerInstanceId || typeof BroadcastChannel !== 'function') return;
   const channel = new BroadcastChannel(STALE_ASSET_RELOAD_CHANNEL);
   try {
     channel.postMessage({
       type: 'stale-asset-reload',
       instanceId: workerInstanceId,
+      replayTurn,
     } satisfies StaleAssetReloadMsg);
   } finally {
     channel.close();
@@ -70,14 +82,14 @@ export function broadcastIfStaleAssetError(err: unknown): void {
  */
 export function installStaleAssetReloadListener(
   instanceId: string,
-  onReload: () => void
+  onReload: (replayTurn: boolean) => void
 ): () => void {
   if (typeof BroadcastChannel !== 'function') return () => {};
   const channel = new BroadcastChannel(STALE_ASSET_RELOAD_CHANNEL);
   const handler = (event: MessageEvent): void => {
     const data = event.data as StaleAssetReloadMsg | undefined;
     if (data?.type !== 'stale-asset-reload' || data.instanceId !== instanceId) return;
-    onReload();
+    onReload(data.replayTurn === true);
   };
   channel.addEventListener('message', handler);
   return () => {

--- a/packages/webapp/src/kernel/kernel-worker.ts
+++ b/packages/webapp/src/kernel/kernel-worker.ts
@@ -27,6 +27,10 @@
 import { OffscreenBridge } from '../../../chrome-extension/src/offscreen-bridge.js';
 import { BrowserAPI } from '../cdp/browser-api.js';
 import { createPanelRpcTrayProvider } from '../cdp/panel-rpc-tray-provider.js';
+import {
+  broadcastIfStaleAssetError,
+  setStaleAssetInstanceId,
+} from '../core/stale-asset-channel.js';
 import type { VirtualFS } from '../fs/index.js';
 // Provider registration is async-explicit (not side-effect import).
 // `providers/index.ts` switched to lazy `import.meta.glob` to break a
@@ -239,157 +243,166 @@ self.addEventListener('message', (event: MessageEvent) => {
 });
 
 async function boot(init: KernelWorkerInitMsg): Promise<void> {
-  // Stamp `x-bypass-llm-proxy: 1` on same-origin worker fetches so
-  // the page-installed LLM-proxy SW doesn't double-intercept them.
-  // Cross-origin requests are intentionally left bare — see
-  // `kernel-worker-fetch-bypass.ts` for the CORS-preflight reasoning.
-  // Must run before any fetcher does.
-  installFetchBypass();
+  // #1330: record instanceId up front so a stale-import failure anywhere in boot
+  // (registerProviders eagerly imports every provider chunk) broadcasts an
+  // instanceId-scoped reload request to the owning page.
+  setStaleAssetInstanceId(init.instanceId);
+  try {
+    // Stamp `x-bypass-llm-proxy: 1` on same-origin worker fetches so
+    // the page-installed LLM-proxy SW doesn't double-intercept them.
+    // Cross-origin requests are intentionally left bare — see
+    // `kernel-worker-fetch-bypass.ts` for the CORS-preflight reasoning.
+    // Must run before any fetcher does.
+    installFetchBypass();
 
-  // Thin-bridge: the hosted leader serves the UI but has no local /api
-  // surface, so proxied-fetch must target the bridge-discovered local
-  // node-server origin + carry the per-process `X-Bridge-Token` (origin
-  // allowlist alone is insufficient — see `bridge-security.ts`). The
-  // page realm sets its own copy in `setupStandalonePrelude`.
-  setLocalApiBaseUrl(init.localApiBaseUrl ?? null);
-  setBridgeToken(init.bridgeToken ?? null);
-  // Thin-bridge extension leader: the worker has no `chrome`, so a
-  // configured delegate id routes cross-origin shell fetches over panel-RPC
-  // to the page realm, which opens the extension Port (host_permissions CORS
-  // bypass). `null` outside the thin-bridge extension leader.
-  setExtensionDelegateId(init.extensionDelegateId ?? null);
+    // Thin-bridge: the hosted leader serves the UI but has no local /api
+    // surface, so proxied-fetch must target the bridge-discovered local
+    // node-server origin + carry the per-process `X-Bridge-Token` (origin
+    // allowlist alone is insufficient — see `bridge-security.ts`). The
+    // page realm sets its own copy in `setupStandalonePrelude`.
+    setLocalApiBaseUrl(init.localApiBaseUrl ?? null);
+    setBridgeToken(init.bridgeToken ?? null);
+    // Thin-bridge extension leader: the worker has no `chrome`, so a
+    // configured delegate id routes cross-origin shell fetches over panel-RPC
+    // to the page realm, which opens the extension Port (host_permissions CORS
+    // bypass). `null` outside the thin-bridge extension leader.
+    setExtensionDelegateId(init.extensionDelegateId ?? null);
 
-  // The worker has no `localStorage` (Web Workers don't get one).
-  // `provider-settings.getApiKey()` and `selected-model` reads on the
-  // worker side would otherwise crash or return empty, which makes
-  // `ScoopContext.init` fail with no provider configured. Seed a
-  // Map-backed shim from the page's `localStorage` snapshot the page
-  // passed in `kernel-worker-init`. The `OffscreenBridge`
-  // `local-storage-*` handlers + `installPageStorageSync` on the page
-  // keep the shim in sync with subsequent page writes.
-  installLocalStorageShim(init.localStorageSeed ?? {});
+    // The worker has no `localStorage` (Web Workers don't get one).
+    // `provider-settings.getApiKey()` and `selected-model` reads on the
+    // worker side would otherwise crash or return empty, which makes
+    // `ScoopContext.init` fail with no provider configured. Seed a
+    // Map-backed shim from the page's `localStorage` snapshot the page
+    // passed in `kernel-worker-init`. The `OffscreenBridge`
+    // `local-storage-*` handlers + `installPageStorageSync` on the page
+    // keep the shim in sync with subsequent page writes.
+    installLocalStorageShim(init.localStorageSeed ?? {});
 
-  // Initialize RUM telemetry so beacons fire from the worker
-  // AlmostBashShell and uncaught errors in the agent loop are captured.
-  // Without this, `trackShellCommand` and friends silently no-op because
-  // `sampleRUM` is per-realm module state. Runs AFTER the localStorage
-  // shim so the `telemetry-disabled` / `slicc-rum-debug` keys the page
-  // seeded propagate into the worker's `initTelemetry` decision. Fire-
-  // and-forget — telemetry init must never block the boot.
-  void initTelemetry().catch(() => {});
+    // Initialize RUM telemetry so beacons fire from the worker
+    // AlmostBashShell and uncaught errors in the agent loop are captured.
+    // Without this, `trackShellCommand` and friends silently no-op because
+    // `sampleRUM` is per-realm module state. Runs AFTER the localStorage
+    // shim so the `telemetry-disabled` / `slicc-rum-debug` keys the page
+    // seeded propagate into the worker's `initTelemetry` decision. Fire-
+    // and-forget — telemetry init must never block the boot.
+    void initTelemetry().catch(() => {});
 
-  // Register providers first — kernel host construction reads the
-  // provider registry (via scoop-context → provider-settings).
-  await registerProviders();
+    // Register providers first — kernel host construction reads the
+    // provider registry (via scoop-context → provider-settings).
+    await registerProviders();
 
-  const bridgeTransport = createBridgeMessageChannelTransport(init.kernelPort);
-  const bridge = new OffscreenBridge(bridgeTransport);
-  const callbacks = OffscreenBridge.createCallbacks(bridge);
+    const bridgeTransport = createBridgeMessageChannelTransport(init.kernelPort);
+    const bridge = new OffscreenBridge(bridgeTransport);
+    const callbacks = OffscreenBridge.createCallbacks(bridge);
 
-  const cdpProxy = new WorkerCdpProxy(init.cdpPort);
-  await cdpProxy.connect();
-  const browser = new BrowserAPI(cdpProxy);
+    const cdpProxy = new WorkerCdpProxy(init.cdpPort);
+    await cdpProxy.connect();
+    const browser = new BrowserAPI(cdpProxy);
 
-  // The orchestrator's `container` parameter is stored but never read
-  // in production (verified at the time of writing). A worker has no
-  // DOM; passing an empty stub satisfies the constructor without
-  // dragging in a fake DOM impl. If a future change to Orchestrator
-  // starts using `container`, this needs to grow into a UI capability
-  // RPC back to the page.
-  const stubContainer = {} as unknown as HTMLElement;
+    // The orchestrator's `container` parameter is stored but never read
+    // in production (verified at the time of writing). A worker has no
+    // DOM; passing an empty stub satisfies the constructor without
+    // dragging in a fake DOM impl. If a future change to Orchestrator
+    // starts using `container`, this needs to grow into a UI capability
+    // RPC back to the page.
+    const stubContainer = {} as unknown as HTMLElement;
 
-  host = await createKernelHost({
-    container: stubContainer,
-    browser,
-    bridge,
-    callbacks,
-    logger: console,
-    localLickWsUrl: init.localLickWsUrl ?? null,
-  });
+    host = await createKernelHost({
+      container: stubContainer,
+      browser,
+      bridge,
+      callbacks,
+      logger: console,
+      localLickWsUrl: init.localLickWsUrl ?? null,
+    });
 
-  // Publish a sprinkle-manager proxy on the worker's globalThis so the
-  // `sprinkle` / `open` / `upskill` shell commands can reach the real
-  // page-side manager. The bridge uses a same-origin BroadcastChannel
-  // scoped by `instanceId` (page-generated, threaded through
-  // `kernel-worker-init`) so two SLICC tabs on the same origin don't
-  // cross-talk. The page bootstrap (`mainStandaloneWorker`) installs
-  // the matching handler under the same id. Extension offscreen has
-  // its own chrome.runtime-based proxy in `offscreen.ts` and never
-  // goes through this path.
-  const { createSprinkleManagerProxyOverChannel } = await import(
-    '../scoops/sprinkle-bridge-channel.js'
-  );
-  const sprinkleProxy = createSprinkleManagerProxyOverChannel({ instanceId: init.instanceId });
-  (globalThis as Record<string, unknown>).__slicc_sprinkleManager = sprinkleProxy;
+    // Publish a sprinkle-manager proxy on the worker's globalThis so the
+    // `sprinkle` / `open` / `upskill` shell commands can reach the real
+    // page-side manager. The bridge uses a same-origin BroadcastChannel
+    // scoped by `instanceId` (page-generated, threaded through
+    // `kernel-worker-init`) so two SLICC tabs on the same origin don't
+    // cross-talk. The page bootstrap (`mainStandaloneWorker`) installs
+    // the matching handler under the same id. Extension offscreen has
+    // its own chrome.runtime-based proxy in `offscreen.ts` and never
+    // goes through this path.
+    const { createSprinkleManagerProxyOverChannel } = await import(
+      '../scoops/sprinkle-bridge-channel.js'
+    );
+    const sprinkleProxy = createSprinkleManagerProxyOverChannel({ instanceId: init.instanceId });
+    (globalThis as Record<string, unknown>).__slicc_sprinkleManager = sprinkleProxy;
 
-  // Auto-reload open sprinkles when their .shtml file changes in the VFS.
-  const watcher = host.sharedFs?.getWatcher();
-  if (watcher) {
-    const SPRINKLE_ROOTS = ['/workspace', '/shared', '/scoops'] as const;
-    let reloadTimer: ReturnType<typeof setTimeout> | null = null;
-    const pendingReloads = new Set<string>();
-    for (const root of SPRINKLE_ROOTS) {
-      watcher.watch(
-        root,
-        (path) => path.endsWith('.shtml'),
-        (events) => {
-          for (const e of events) {
-            const base = e.path
-              .split('/')
-              .pop()
-              ?.replace(/\.shtml$/, '');
-            if (base) pendingReloads.add(base);
-          }
-          if (reloadTimer) return;
-          reloadTimer = setTimeout(() => {
-            reloadTimer = null;
-            for (const name of pendingReloads) {
-              sprinkleProxy.reload(name).catch(() => {});
+    // Auto-reload open sprinkles when their .shtml file changes in the VFS.
+    const watcher = host.sharedFs?.getWatcher();
+    if (watcher) {
+      const SPRINKLE_ROOTS = ['/workspace', '/shared', '/scoops'] as const;
+      let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+      const pendingReloads = new Set<string>();
+      for (const root of SPRINKLE_ROOTS) {
+        watcher.watch(
+          root,
+          (path) => path.endsWith('.shtml'),
+          (events) => {
+            for (const e of events) {
+              const base = e.path
+                .split('/')
+                .pop()
+                ?.replace(/\.shtml$/, '');
+              if (base) pendingReloads.add(base);
             }
-            pendingReloads.clear();
-          }, 300);
-        }
-      );
+            if (reloadTimer) return;
+            reloadTimer = setTimeout(() => {
+              reloadTimer = null;
+              for (const name of pendingReloads) {
+                sprinkleProxy.reload(name).catch(() => {});
+              }
+              pendingReloads.clear();
+            }, 300);
+          }
+        );
+      }
     }
+
+    // Publish the panel-RPC bridge client. DOM-bound shell supplemental
+    // commands (`screencapture`, `say`, `afplay`, `pbcopy`/`pbpaste`,
+    // `open`, plus `playwright`'s appOrigin lookup) detect this global
+    // and route their DOM calls to the page handler installed by
+    // `mainStandaloneWorker`. See `kernel/panel-rpc.ts` for the op
+    // surface. `imgcat` is intentionally NOT bridged — it's terminal-only
+    // and the panel AlmostBashShell renders the preview locally.
+    const { createPanelRpcClient } = await import('./panel-rpc.js');
+    panelRpcClient = createPanelRpcClient({ instanceId: init.instanceId });
+    (globalThis as Record<string, unknown>).__slicc_panelRpc = panelRpcClient;
+
+    // Give the worker BrowserAPI a tray target provider so the cone can
+    // *drive* federated tray/cherry targets, not just list them. The
+    // provider tunnels each CDP op over panel-RPC to the page-side
+    // RemoteCDPTransport (which owns the WebRTC channel). Safe to set
+    // unconditionally: its methods run only for composite remote ids
+    // (which exist only when a tray is active), and with no panel-RPC
+    // client they fail closed. See issue #848.
+    browser.setTrayTargetProvider(createPanelRpcTrayProvider(getPanelRpcClient));
+
+    // Stand up the kernel transport's shared-FS surfaces (terminal-RPC host,
+    // VFS read/write RPC, page→worker speech-assets responder). No-op when the
+    // orchestrator failed to publish a shared FS.
+    const surfaces = await startSharedFsSurfaces({
+      host,
+      transport: bridgeTransport,
+      browser,
+      instanceId: init.instanceId,
+    });
+    if (surfaces) {
+      stopTerminalHost = surfaces.stopTerminalHost;
+      stopVfsRpcHost = surfaces.stopVfsRpcHost;
+      stopSpeechAssetsResponder = surfaces.stopSpeechAssetsResponder;
+    }
+
+    // Signal readiness to the page over the kernel port.
+    init.kernelPort.postMessage({ type: 'kernel-worker-ready' } satisfies KernelWorkerReadyMsg);
+  } catch (err) {
+    broadcastIfStaleAssetError(err);
+    throw err; // preserve the init-guard reset + worker-ready-timeout fallback
   }
-
-  // Publish the panel-RPC bridge client. DOM-bound shell supplemental
-  // commands (`screencapture`, `say`, `afplay`, `pbcopy`/`pbpaste`,
-  // `open`, plus `playwright`'s appOrigin lookup) detect this global
-  // and route their DOM calls to the page handler installed by
-  // `mainStandaloneWorker`. See `kernel/panel-rpc.ts` for the op
-  // surface. `imgcat` is intentionally NOT bridged — it's terminal-only
-  // and the panel AlmostBashShell renders the preview locally.
-  const { createPanelRpcClient } = await import('./panel-rpc.js');
-  panelRpcClient = createPanelRpcClient({ instanceId: init.instanceId });
-  (globalThis as Record<string, unknown>).__slicc_panelRpc = panelRpcClient;
-
-  // Give the worker BrowserAPI a tray target provider so the cone can
-  // *drive* federated tray/cherry targets, not just list them. The
-  // provider tunnels each CDP op over panel-RPC to the page-side
-  // RemoteCDPTransport (which owns the WebRTC channel). Safe to set
-  // unconditionally: its methods run only for composite remote ids
-  // (which exist only when a tray is active), and with no panel-RPC
-  // client they fail closed. See issue #848.
-  browser.setTrayTargetProvider(createPanelRpcTrayProvider(getPanelRpcClient));
-
-  // Stand up the kernel transport's shared-FS surfaces (terminal-RPC host,
-  // VFS read/write RPC, page→worker speech-assets responder). No-op when the
-  // orchestrator failed to publish a shared FS.
-  const surfaces = await startSharedFsSurfaces({
-    host,
-    transport: bridgeTransport,
-    browser,
-    instanceId: init.instanceId,
-  });
-  if (surfaces) {
-    stopTerminalHost = surfaces.stopTerminalHost;
-    stopVfsRpcHost = surfaces.stopVfsRpcHost;
-    stopSpeechAssetsResponder = surfaces.stopSpeechAssetsResponder;
-  }
-
-  // Signal readiness to the page over the kernel port.
-  init.kernelPort.postMessage({ type: 'kernel-worker-ready' } satisfies KernelWorkerReadyMsg);
 }
 
 type BridgeTransport = Parameters<typeof createPanelTerminalHost>[0]['transport'];

--- a/packages/webapp/src/kernel/spawn.ts
+++ b/packages/webapp/src/kernel/spawn.ts
@@ -42,6 +42,8 @@ import { createPanelMessageChannelTransport } from './transport-message-channel.
 export interface WorkerLike {
   postMessage(message: unknown, transfer?: Transferable[]): void;
   terminate(): void;
+  /** Optional — real `Worker` has it; the mock may omit it. */
+  addEventListener?(type: 'error', listener: () => void): void;
 }
 
 export interface KernelWorkerSpawnOptions {
@@ -103,6 +105,9 @@ export interface KernelWorkerSpawnOptions {
    * thin-bridge extension leader.
    */
   extensionDelegateId?: string | null;
+  /** Page-side hook fired if the worker ENTRY chunk fails to load (stale after a
+   *  deploy) — the worker never evaluates, so its own boot catch can't run. (#1330) */
+  onWorkerScriptError?: () => void;
 }
 
 export interface KernelWorkerBootstrapOptions {
@@ -125,6 +130,9 @@ export interface KernelWorkerBootstrapOptions {
   localLickWsUrl?: string | null;
   /** See `KernelWorkerSpawnOptions.extensionDelegateId`. */
   extensionDelegateId?: string | null;
+  /** Page-side hook fired if the worker ENTRY chunk fails to load (stale after a
+   *  deploy) — the worker never evaluates, so its own boot catch can't run. (#1330) */
+  onWorkerScriptError?: () => void;
 }
 
 /**
@@ -180,6 +188,12 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
   // exactly what chrome.runtime would have delivered.
   const panelTransport = createPanelMessageChannelTransport(kernelChannel.port1);
   const client = new OffscreenClient(callbacks, panelTransport);
+
+  // Attach the worker error listener before any async work so a stale worker
+  // ENTRY chunk triggering an error event calls onWorkerScriptError.
+  if (options.onWorkerScriptError) {
+    options.worker.addEventListener?.('error', () => options.onWorkerScriptError!());
+  }
 
   // Pump real CDP commands ⇄ wire on the cdp port.
   const stopForwarder = startPageCdpForwarder(cdpChannel.port1, realCdpTransport);
@@ -313,5 +327,6 @@ export function spawnKernelWorker(options: KernelWorkerSpawnOptions): SpawnedKer
     bridgeToken: options.bridgeToken,
     localLickWsUrl: options.localLickWsUrl,
     extensionDelegateId: options.extensionDelegateId,
+    onWorkerScriptError: options.onWorkerScriptError,
   });
 }

--- a/packages/webapp/src/kernel/spawn.ts
+++ b/packages/webapp/src/kernel/spawn.ts
@@ -105,8 +105,11 @@ export interface KernelWorkerSpawnOptions {
    * thin-bridge extension leader.
    */
   extensionDelegateId?: string | null;
-  /** Page-side hook fired if the worker ENTRY chunk fails to load (stale after a
-   *  deploy) — the worker never evaluates, so its own boot catch can't run. (#1330) */
+  /** Page-side hook fired on ANY uncaught kernel-worker `error` event — notably a
+   *  stale worker ENTRY chunk failing to load after a deploy (the worker never
+   *  evaluates, so its own boot catch can't run). Not message-filtered: a
+   *  load-failure ErrorEvent is often opaque, and the shared guarded reload makes
+   *  even an unrelated worker error reload at most once. (#1330) */
   onWorkerScriptError?: () => void;
 }
 
@@ -130,8 +133,11 @@ export interface KernelWorkerBootstrapOptions {
   localLickWsUrl?: string | null;
   /** See `KernelWorkerSpawnOptions.extensionDelegateId`. */
   extensionDelegateId?: string | null;
-  /** Page-side hook fired if the worker ENTRY chunk fails to load (stale after a
-   *  deploy) — the worker never evaluates, so its own boot catch can't run. (#1330) */
+  /** Page-side hook fired on ANY uncaught kernel-worker `error` event — notably a
+   *  stale worker ENTRY chunk failing to load after a deploy (the worker never
+   *  evaluates, so its own boot catch can't run). Not message-filtered: a
+   *  load-failure ErrorEvent is often opaque, and the shared guarded reload makes
+   *  even an unrelated worker error reload at most once. (#1330) */
   onWorkerScriptError?: () => void;
 }
 
@@ -189,8 +195,9 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
   const panelTransport = createPanelMessageChannelTransport(kernelChannel.port1);
   const client = new OffscreenClient(callbacks, panelTransport);
 
-  // Attach the worker error listener before any async work so a stale worker
-  // ENTRY chunk triggering an error event calls onWorkerScriptError.
+  // Attach the worker error listener before any async work so an uncaught
+  // worker `error` event — notably a stale worker ENTRY chunk failing to load —
+  // calls onWorkerScriptError.
   if (options.onWorkerScriptError) {
     options.worker.addEventListener?.('error', () => options.onWorkerScriptError!());
   }

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -32,6 +32,7 @@ import { Agent, adaptTools, createLogger } from '../core/index.js';
 import { fetchSecretEnvVars } from '../core/secret-env.js';
 import { getToolResultScrubber } from '../core/secret-scrub.js';
 import type { SessionStore } from '../core/session.js';
+import { broadcastStaleAssetReload, isDynamicImportError } from '../core/stale-asset-channel.js';
 import { emitAgentError } from '../core/telemetry-hook.js';
 import type { VirtualFS } from '../fs/index.js';
 import type { RestrictedFS } from '../fs/restricted-fs.js';
@@ -776,6 +777,31 @@ export class ScoopContext {
     return true;
   }
 
+  /**
+   * Handle a stale-asset import failure (#1330). A gone content-hashed chunk
+   * after a deploy — retrying the cached-failed import is futile (checked BEFORE
+   * the retry matcher, which also matches "failed to fetch"), so ask the owning
+   * page to reload (guarded) and surface as fatal. Returns true if handled.
+   */
+  private handleStaleAssetError(message: string): boolean {
+    if (!isDynamicImportError(message)) return false;
+    log.error('Stale-asset import failure; requesting page reload', {
+      folder: this.scoop.folder,
+      error: message,
+    });
+    broadcastStaleAssetReload();
+    emitAgentError('llm', message);
+    this.setStatus('error');
+    if (this.callbacks.onFatalError) {
+      this.callbacks.onFatalError(
+        `Scoop "${this.scoop.name}" hit a stale build after a deploy; reloading to recover.`
+      );
+    } else {
+      this.callbacks.onError(message);
+    }
+    return true;
+  }
+
   /** Handle retryable error with exponential backoff. Returns true if should retry. */
   private async handleRetryableError(
     message: string,
@@ -872,6 +898,7 @@ export class ScoopContext {
   ): Promise<boolean> {
     const message = error.message;
 
+    if (this.handleStaleAssetError(message)) return true;
     if (this.handleNonRetryableError(message)) return true;
 
     const shouldRetry = await this.handleRetryableError(

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -789,7 +789,11 @@ export class ScoopContext {
       folder: this.scoop.folder,
       error: message,
     });
-    broadcastStaleAssetReload();
+    // Only a CONE turn is user-resubmittable — pass isCone so the page marks
+    // the dropped turn for one-shot auto-resubmit after the recovery reload.
+    // Scoop turns are cone-delegated; they broadcast (false) to reload but are
+    // never replayed.
+    broadcastStaleAssetReload(this.scoop.isCone);
     emitAgentError('llm', message);
     this.setStatus('error');
     if (this.callbacks.onFatalError) {

--- a/packages/webapp/src/ui/boot/setup-preload-error-reload.ts
+++ b/packages/webapp/src/ui/boot/setup-preload-error-reload.ts
@@ -1,0 +1,99 @@
+/**
+ * Page-side stale-asset recovery (#1330). Owns the one guarded reload every
+ * trigger shares, the page `vite:preloadError` handler (page-owned lazy chunks),
+ * and the worker-broadcast listener. Sibling to `setup-nuke-reload-listener.ts`.
+ */
+import { installStaleAssetReloadListener } from '../../core/stale-asset-channel.js';
+
+const STORAGE_KEY = 'slicc:stale-asset-reloaded-at';
+/** Must exceed the ~30 s host-ready boot timeout so a stale re-error at boot is
+ *  suppressed (loop-proof) while a genuinely new deploy later still reloads. */
+export const RELOAD_WINDOW_MS = 60_000;
+
+export interface GuardedReloadDeps {
+  reload: () => void;
+  storage: Pick<Storage, 'getItem' | 'setItem'>;
+  now: () => number;
+  windowMs: number;
+  storageKey: string;
+}
+
+function defaultDeps(): GuardedReloadDeps {
+  return {
+    reload: () => window.location.reload(),
+    storage: window.sessionStorage,
+    now: () => Date.now(),
+    windowMs: RELOAD_WINDOW_MS,
+    storageKey: STORAGE_KEY,
+  };
+}
+
+/** Pure guard: reload iff never reloaded or the window has elapsed. */
+export function decideStaleReload(
+  lastReloadAt: number | null,
+  now: number,
+  windowMs: number
+): boolean {
+  return lastReloadAt === null || now - lastReloadAt >= windowMs;
+}
+
+/**
+ * Reload at most once per `windowMs` per tab. Fail-closed: if `sessionStorage`
+ * can't be read or written we do NOT reload (never reload without a persistable
+ * guard, or a broken deploy could loop). Returns whether it reloaded.
+ */
+export function guardedReload(deps: GuardedReloadDeps = defaultDeps()): boolean {
+  let raw: string | null;
+  try {
+    raw = deps.storage.getItem(deps.storageKey);
+  } catch {
+    return false;
+  }
+  const parsed = raw === null ? null : Number(raw);
+  const lastReloadAt = parsed !== null && Number.isFinite(parsed) ? parsed : null;
+  const now = deps.now();
+  if (!decideStaleReload(lastReloadAt, now, deps.windowMs)) return false;
+  try {
+    deps.storage.setItem(deps.storageKey, String(now));
+  } catch {
+    return false;
+  }
+  deps.reload();
+  return true;
+}
+
+let vitePreloadHandler: ((e: Event) => void) | null = null;
+let activeDeps: GuardedReloadDeps | null = null;
+
+/** Install the page `vite:preloadError` handler (idempotent). Call FIRST in
+ *  `main()`. `preventDefault()` only when we actually reload. */
+export function setupPreloadErrorReload(deps?: Partial<GuardedReloadDeps>): void {
+  if (vitePreloadHandler) return;
+  activeDeps = { ...defaultDeps(), ...deps };
+  vitePreloadHandler = (e: Event) => {
+    if (guardedReload(activeDeps!)) e.preventDefault();
+  };
+  window.addEventListener('vite:preloadError', vitePreloadHandler);
+}
+
+let workerListenerDispose: (() => void) | null = null;
+
+/** Install the instanceId-scoped worker-broadcast listener (idempotent). MUST be
+ *  called BEFORE `spawnKernelWorker()` — BroadcastChannel doesn't buffer and the
+ *  worker posts init synchronously. Runs the same `guardedReload`. */
+export function installWorkerStaleAssetReloadListener(instanceId: string): () => void {
+  if (workerListenerDispose) return workerListenerDispose;
+  workerListenerDispose = installStaleAssetReloadListener(instanceId, () => {
+    guardedReload(activeDeps ?? undefined);
+  });
+  return workerListenerDispose;
+}
+
+/** Test-only: detach handlers + clear module state. */
+export function __resetForTest(): void {
+  if (vitePreloadHandler) window.removeEventListener('vite:preloadError', vitePreloadHandler);
+  vitePreloadHandler = null;
+  activeDeps = null;
+  if (workerListenerDispose) workerListenerDispose();
+  workerListenerDispose = null;
+}

--- a/packages/webapp/src/ui/boot/setup-preload-error-reload.ts
+++ b/packages/webapp/src/ui/boot/setup-preload-error-reload.ts
@@ -71,6 +71,9 @@ export function setupPreloadErrorReload(deps?: Partial<GuardedReloadDeps>): void
   if (vitePreloadHandler) return;
   activeDeps = { ...defaultDeps(), ...deps };
   vitePreloadHandler = (e: Event) => {
+    // Invariant: activeDeps is assigned above, before this handler is created and
+    // registered, and only cleared by __resetForTest — so it's non-null whenever
+    // the handler fires.
     if (guardedReload(activeDeps!)) e.preventDefault();
   };
   window.addEventListener('vite:preloadError', vitePreloadHandler);

--- a/packages/webapp/src/ui/boot/setup-preload-error-reload.ts
+++ b/packages/webapp/src/ui/boot/setup-preload-error-reload.ts
@@ -10,6 +10,42 @@ const STORAGE_KEY = 'slicc:stale-asset-reloaded-at';
  *  suppressed (loop-proof) while a genuinely new deploy later still reloads. */
 export const RELOAD_WINDOW_MS = 60_000;
 
+/**
+ * One-shot flag set (before the recovery reload) when a CONE turn was dropped
+ * by a stale-asset crash, and consumed once after boot to auto-resubmit that
+ * turn. Distinct from `STORAGE_KEY` (the reload-rate guard). `sessionStorage`
+ * survives the reload but not a tab close, so a stale flag can never linger.
+ */
+const REPLAY_KEY = 'slicc:stale-asset-replay';
+
+/** Mark a dropped cone turn for one-shot auto-resubmit after the recovery
+ *  reload. Best-effort — a storage throw silently no-ops (we just skip the
+ *  resubmit, never break the reload). */
+export function markStaleAssetReplayPending(
+  storage: Pick<Storage, 'setItem'> = window.sessionStorage
+): void {
+  try {
+    storage.setItem(REPLAY_KEY, '1');
+  } catch {
+    /* storage unavailable — the reload still happens; only the resubmit is lost */
+  }
+}
+
+/** Read AND clear the replay flag. Returns true exactly once per mark — repeat
+ *  calls (later `loadMessages` on scoop switches) return false, so a turn is
+ *  never re-resubmitted. Fail-safe: any throw returns false. */
+export function consumeStaleAssetReplayPending(
+  storage: Pick<Storage, 'getItem' | 'removeItem'> = window.sessionStorage
+): boolean {
+  try {
+    if (storage.getItem(REPLAY_KEY) !== '1') return false;
+    storage.removeItem(REPLAY_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export interface GuardedReloadDeps {
   reload: () => void;
   storage: Pick<Storage, 'getItem' | 'setItem'>;
@@ -86,7 +122,10 @@ let workerListenerDispose: (() => void) | null = null;
  *  worker posts init synchronously. Runs the same `guardedReload`. */
 export function installWorkerStaleAssetReloadListener(instanceId: string): () => void {
   if (workerListenerDispose) return workerListenerDispose;
-  workerListenerDispose = installStaleAssetReloadListener(instanceId, () => {
+  workerListenerDispose = installStaleAssetReloadListener(instanceId, (replayTurn) => {
+    // A cone turn-time crash (replayTurn) marks its dropped turn for one-shot
+    // resubmit before we reload; boot-time / preloadError triggers pass false.
+    if (replayTurn) markStaleAssetReplayPending();
     guardedReload(activeDeps ?? undefined);
   });
   return workerListenerDispose;

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -26,6 +26,7 @@ import { parseBridgeLaunchParams } from './boot/bridge-launch-params.js';
 import { installExtensionFetchDelegate } from './boot/setup-extension-fetch-delegate.js';
 import { startFreezeWatchdog } from './boot/setup-freeze-watchdog.js';
 import { setupNukeReloadListener } from './boot/setup-nuke-reload-listener.js';
+import { setupPreloadErrorReload } from './boot/setup-preload-error-reload.js';
 import { parseExtensionLeaderParams } from './boot/setup-standalone-prelude.js';
 import { setupSwRegistration } from './boot/setup-sw-registration.js';
 import { applyProviderDefaults } from './provider-settings.js';
@@ -44,6 +45,11 @@ function isFixtureRequested(href: string): boolean {
 }
 
 async function main(): Promise<void> {
+  // Recover a long-lived tab that crashes on a now-gone content-hashed chunk
+  // after a deploy (#1330). Installed before any dynamic import() so page-owned
+  // lazy-chunk failures are always caught. Harmless on the ?ui-fixture surface.
+  setupPreloadErrorReload();
+
   const app = document.getElementById('app');
   if (!app) throw new Error('#app element not found');
 

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -12,6 +12,7 @@ import {
   stripDictationMarkers,
 } from '../../speech/dictation-priming.js';
 import { TOOL_UI_MOUNTED_ACTION } from '../../tools/tool-ui.js';
+import { consumeStaleAssetReplayPending } from '../boot/setup-preload-error-reload.js';
 import { type DipInstance, mountDip } from '../dip.js';
 import { trackChatSend, trackError } from '../telemetry.js';
 import type { AgentEvent, AgentHandle, ChatMessage, ToolCall } from '../types.js';
@@ -453,6 +454,44 @@ export class WcChatController {
     }
     this.#syncCopyRow();
     this.#scrollToBottom();
+    // loadMessages is the convergence point where the restored thread arrives
+    // post-(re)connect on the leader; auto-resubmit a cone turn dropped by a
+    // stale-asset recovery reload once the thread is in place (consume-once).
+    this.#maybeReplayDroppedTurn();
+  }
+
+  /**
+   * After a stale-asset recovery reload (#1330), the cone turn that was in
+   * flight was dropped: the user's message is persisted (shows as sent) but
+   * the agent never answered it. If the worker turn-time trigger marked a
+   * replay pending, re-send that dropped turn ONCE so the agent answers it —
+   * reusing the existing retry path, no new agent API. Leader/standalone only
+   * (a follower has no kernel worker, so its reload drops no cone turn).
+   */
+  #maybeReplayDroppedTurn(): void {
+    // Consume-once: reads AND clears the flag, so repeat loadMessages calls
+    // (scoop switches) never re-replay. No-op unless a cone turn was dropped.
+    if (!consumeStaleAssetReplayPending()) return;
+    // A turn is already running — the dropped turn either resumed or a new one
+    // started; resubmitting would double-submit.
+    if (this.#processing) return;
+    const last = this.#messages[this.#messages.length - 1];
+    if (!last) return;
+    // Only replay when the thread ENDS in an unanswered user-typed turn (a
+    // dropped turn). If the last message is an assistant reply, the turn
+    // completed — do not resend. Licks / delegations / queued rows are not
+    // user-resubmittable originators.
+    if (
+      last.role !== 'user' ||
+      last.source === 'lick' ||
+      last.source === 'delegation' ||
+      last.queued
+    ) {
+      return;
+    }
+    // No messageId → #handleErrorRetry replays the last user turn via
+    // #agent.sendMessage (it has its own #processing double-submit guard).
+    this.#handleErrorRetry(new Event('slicc-error-retry'));
   }
 
   /**

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -467,8 +467,23 @@ export class WcChatController {
    * replay pending, re-send that dropped turn ONCE so the agent answers it —
    * reusing the existing retry path, no new agent API. Leader/standalone only
    * (a follower has no kernel worker, so its reload drops no cone turn).
+   *
+   * Scoped to the CONE thread. `loadMessages` fires for whichever thread loads
+   * first post-boot, which can be a `scoop:<name>` / `freezer:<file>` deep-link
+   * — NOT the cone. Gating on the thread's `context` attribute (set
+   * synchronously by `applyThreadContext` BEFORE messages are requested) keeps
+   * the one-shot flag alive until the cone thread loads, so a non-cone load
+   * never (a) consumes the flag — which would MISS the cone's real dropped
+   * turn — nor (b) wrong-sends: a scoop mid-delegation ends in a
+   * `role:'user'` prompt that is NOT tagged `source:'delegation'`, so replaying
+   * there would inject the cone's prompt into the scoop's agent.
    */
   #maybeReplayDroppedTurn(): void {
+    // Only the cone thread carries a user-resubmittable dropped turn.
+    if (this.#thread.getAttribute('context') !== 'cone') return;
+    // A transient empty cone load must not waste the one-shot flag — wait for
+    // the real cone snapshot.
+    if (this.#messages.length === 0) return;
     // Consume-once: reads AND clears the flag, so repeat loadMessages calls
     // (scoop switches) never re-replay. No-op unless a cone turn was dropped.
     if (!consumeStaleAssetReplayPending()) return;
@@ -476,7 +491,6 @@ export class WcChatController {
     // started; resubmitting would double-submit.
     if (this.#processing) return;
     const last = this.#messages[this.#messages.length - 1];
-    if (!last) return;
     // Only replay when the thread ENDS in an unanswered user-typed turn (a
     // dropped turn). If the last message is an assistant reply, the turn
     // completed — do not resend. Licks / delegations / queued rows are not

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -14,6 +14,10 @@ import { resolveCurrentModel, resolveModelById } from '../../providers/account-s
 import type { LickEvent } from '../../scoops/lick-manager.js';
 import { hasStoredTrayJoinUrl } from '../../scoops/tray-runtime-config.js';
 import type { RegisteredScoop, ThinkingLevel } from '../../scoops/types.js';
+import {
+  guardedReload,
+  installWorkerStaleAssetReloadListener,
+} from '../boot/setup-preload-error-reload.js';
 import { setupStandalonePrelude } from '../boot/setup-standalone-prelude.js';
 import type { BootStageLogger } from '../boot/types.js';
 import { type DipInstance, disposeDips, hydrateDips } from '../dip.js';
@@ -1614,6 +1618,10 @@ export async function mountWcUiLive(
       : DEFAULT_STANDALONE_LABEL;
 
   const boot = prepareWcShell(app, floatLabel);
+  // #1330: install the reload listener BEFORE spawning — BroadcastChannel doesn't
+  // buffer and the worker posts init synchronously, so a late listener would miss
+  // a fast boot-time failure.
+  if (instanceId) installWorkerStaleAssetReloadListener(instanceId);
   const host = spawnKernelWorker({
     realCdpTransport,
     instanceId,
@@ -1622,6 +1630,9 @@ export async function mountWcUiLive(
     bridgeToken,
     localLickWsUrl,
     extensionDelegateId,
+    onWorkerScriptError: () => {
+      guardedReload();
+    },
   });
   installPageStorageSync({ send: (m) => host.client.sendRaw(m) });
   // Extension-leader path only: late-bind the now-minted kernel client into the

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -464,8 +464,12 @@ function wireFreezerRail(deps: FreezerRailDeps): FreezerRailHandles {
         reader,
         entry ?? { filename: slug, title: slug, frozenAt: '', messageCount: 0 }
       );
-      getController()?.loadMessages(messages);
+      // Set the thread context BEFORE loading messages (mirrors selectScoop's
+      // applyThreadContext-before-load order): loadMessages runs the cone-gated
+      // stale-asset replay, which must see `freezer:…` here — not a stale `cone`
+      // from a prior view — so a thaw can never consume/replay a dropped turn.
       refs.thread.setAttribute('context', `freezer:${entry?.filename ?? slug}`);
+      getController()?.loadMessages(messages);
       refs.thread.setAttribute('accent', FREEZER_TINT);
       // Frost mood: crystallizing shader + ice-blue accent across the frame.
       applyShellContext(refs, { kind: 'freezer' });

--- a/packages/webapp/tests/core/stale-asset-channel.test.ts
+++ b/packages/webapp/tests/core/stale-asset-channel.test.ts
@@ -4,6 +4,8 @@ import {
   broadcastStaleAssetReload,
   installStaleAssetReloadListener,
   isDynamicImportError,
+  STALE_ASSET_RELOAD_CHANNEL,
+  type StaleAssetReloadMsg,
   setStaleAssetInstanceId,
 } from '../../src/core/stale-asset-channel.js';
 import {
@@ -60,6 +62,35 @@ describe('broadcast + listener (instanceId-scoped)', () => {
     broadcastStaleAssetReload();
     await Promise.resolve();
     expect(cb).not.toHaveBeenCalled();
+    d();
+  });
+
+  it('stamps replayTurn onto the posted message (true when set, false by default)', async () => {
+    const raw = new BroadcastChannel(STALE_ASSET_RELOAD_CHANNEL);
+    const received: StaleAssetReloadMsg[] = [];
+    raw.addEventListener('message', (e) => received.push(e.data as StaleAssetReloadMsg));
+    setStaleAssetInstanceId('inst-M');
+    broadcastStaleAssetReload(true);
+    await Promise.resolve();
+    expect(received.at(-1)?.replayTurn).toBe(true);
+    broadcastStaleAssetReload();
+    await Promise.resolve();
+    expect(received.at(-1)?.replayTurn).toBe(false);
+    raw.close();
+  });
+
+  it('forwards replayTurn to the matching listener (true when set, false by default)', async () => {
+    const onReload = vi.fn();
+    const d = installStaleAssetReloadListener('inst-R', onReload);
+    setStaleAssetInstanceId('inst-R');
+    broadcastStaleAssetReload(true);
+    await Promise.resolve();
+    expect(onReload).toHaveBeenCalledTimes(1);
+    expect(onReload).toHaveBeenLastCalledWith(true);
+    broadcastStaleAssetReload();
+    await Promise.resolve();
+    expect(onReload).toHaveBeenCalledTimes(2);
+    expect(onReload).toHaveBeenLastCalledWith(false);
     d();
   });
 

--- a/packages/webapp/tests/core/stale-asset-channel.test.ts
+++ b/packages/webapp/tests/core/stale-asset-channel.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  broadcastIfStaleAssetError,
+  broadcastStaleAssetReload,
+  installStaleAssetReloadListener,
+  isDynamicImportError,
+  setStaleAssetInstanceId,
+} from '../../src/core/stale-asset-channel.js';
+import {
+  installFakeBroadcastChannel,
+  resetFakeBroadcastChannel,
+} from '../helpers/fake-broadcast-channel.js';
+
+describe('isDynamicImportError', () => {
+  it('matches the cross-browser dynamic-import / module-script failure family', () => {
+    expect(isDynamicImportError('Failed to fetch dynamically imported module: /assets/x.js')).toBe(
+      true
+    );
+    expect(isDynamicImportError('error loading dynamically imported module')).toBe(true);
+    expect(isDynamicImportError('Importing a module script failed.')).toBe(true);
+    expect(
+      isDynamicImportError(
+        'Expected a JavaScript module script but the server responded with a MIME type of text/html'
+      )
+    ).toBe(true);
+  });
+  it('does NOT match unrelated errors', () => {
+    expect(isDynamicImportError('401 Unauthorized')).toBe(false);
+    expect(isDynamicImportError('rate limit exceeded')).toBe(false);
+    expect(isDynamicImportError('network error')).toBe(false);
+    expect(isDynamicImportError('Upload failed: unsupported MIME type image/tiff')).toBe(false);
+    expect(isDynamicImportError('TypeError: Failed to fetch')).toBe(false);
+  });
+});
+
+describe('broadcast + listener (instanceId-scoped)', () => {
+  beforeEach(() => installFakeBroadcastChannel());
+  afterEach(() => {
+    setStaleAssetInstanceId(undefined);
+    resetFakeBroadcastChannel();
+  });
+
+  it('delivers only to a listener whose instanceId matches', async () => {
+    const matched = vi.fn();
+    const other = vi.fn();
+    const d1 = installStaleAssetReloadListener('inst-A', matched);
+    const d2 = installStaleAssetReloadListener('inst-B', other);
+    setStaleAssetInstanceId('inst-A');
+    broadcastStaleAssetReload();
+    await Promise.resolve();
+    expect(matched).toHaveBeenCalledTimes(1);
+    expect(other).not.toHaveBeenCalled();
+    d1();
+    d2();
+  });
+
+  it('no-ops when no instanceId has been set', async () => {
+    const cb = vi.fn();
+    const d = installStaleAssetReloadListener('inst-A', cb);
+    broadcastStaleAssetReload();
+    await Promise.resolve();
+    expect(cb).not.toHaveBeenCalled();
+    d();
+  });
+
+  it('broadcastIfStaleAssetError broadcasts for a dynamic-import Error only', async () => {
+    const cb = vi.fn();
+    const d = installStaleAssetReloadListener('inst-A', cb);
+    setStaleAssetInstanceId('inst-A');
+    broadcastIfStaleAssetError(new Error('random failure'));
+    await Promise.resolve();
+    expect(cb).not.toHaveBeenCalled();
+    broadcastIfStaleAssetError(new Error('Failed to fetch dynamically imported module: /a.js'));
+    await Promise.resolve();
+    expect(cb).toHaveBeenCalledTimes(1);
+    d();
+  });
+
+  it('setStaleAssetInstanceId(undefined) dev-warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    setStaleAssetInstanceId(undefined);
+    // Dev-only warning; assert it does not throw and (in DEV) warns at least 0+ times.
+    expect(() => setStaleAssetInstanceId(undefined)).not.toThrow();
+    warn.mockRestore();
+  });
+});

--- a/packages/webapp/tests/helpers/fake-broadcast-channel.ts
+++ b/packages/webapp/tests/helpers/fake-broadcast-channel.ts
@@ -1,0 +1,52 @@
+/**
+ * In-memory BroadcastChannel polyfill for tests. Neither the node vitest env
+ * nor jsdom provides a working cross-instance BroadcastChannel; this mirrors
+ * the real async-same-thread delivery via queueMicrotask. Based on the pattern
+ * in tests/kernel/panel-rpc.test.ts. Install onto globalThis BEFORE code
+ * constructs `new BroadcastChannel(...)`.
+ */
+export class FakeBroadcastChannel {
+  private static buses = new Map<string, Set<FakeBroadcastChannel>>();
+  private listeners = new Set<(ev: MessageEvent) => void>();
+  private closed = false;
+
+  constructor(public readonly name: string) {
+    let bus = FakeBroadcastChannel.buses.get(name);
+    if (!bus) {
+      bus = new Set();
+      FakeBroadcastChannel.buses.set(name, bus);
+    }
+    bus.add(this);
+  }
+  postMessage(data: unknown): void {
+    if (this.closed) return;
+    const bus = FakeBroadcastChannel.buses.get(this.name);
+    if (!bus) return;
+    for (const peer of bus) {
+      if (peer === this || peer.closed) continue;
+      queueMicrotask(() => {
+        for (const l of peer.listeners) l(new MessageEvent('message', { data }));
+      });
+    }
+  }
+  addEventListener(_t: 'message', l: (ev: MessageEvent) => void): void {
+    this.listeners.add(l);
+  }
+  removeEventListener(_t: 'message', l: (ev: MessageEvent) => void): void {
+    this.listeners.delete(l);
+  }
+  close(): void {
+    this.closed = true;
+    FakeBroadcastChannel.buses.get(this.name)?.delete(this);
+  }
+}
+
+let original: unknown;
+export function installFakeBroadcastChannel(): void {
+  original = (globalThis as Record<string, unknown>).BroadcastChannel;
+  (globalThis as Record<string, unknown>).BroadcastChannel = FakeBroadcastChannel;
+}
+export function resetFakeBroadcastChannel(): void {
+  (FakeBroadcastChannel as unknown as { buses: Map<string, unknown> }).buses = new Map();
+  (globalThis as Record<string, unknown>).BroadcastChannel = original;
+}

--- a/packages/webapp/tests/kernel/spawn.test.ts
+++ b/packages/webapp/tests/kernel/spawn.test.ts
@@ -216,4 +216,35 @@ describe('bootstrapKernelWorker', () => {
 
     host.dispose();
   });
+
+  describe('bootstrapKernelWorker onWorkerScriptError', () => {
+    it('calls onWorkerScriptError when the worker fires an error event', () => {
+      let errorListener: (() => void) | null = null;
+      const worker: WorkerLike = {
+        postMessage: () => {},
+        terminate: () => {},
+        addEventListener: (_t: 'error', l: () => void) => {
+          errorListener = l;
+        },
+      };
+      const onWorkerScriptError = vi.fn();
+      // Small readyTimeoutMs so the never-posts-ready mock can't arm a 30s timer,
+      // and dispose() in `finally` clears it even if an assertion throws (dispose
+      // → cleanupReady clears the ready timeout — spawn.ts).
+      const host = bootstrapKernelWorker({
+        worker,
+        realCdpTransport: { on: () => {}, off: () => {}, send: async () => ({}) } as never,
+        callbacks: {} as never,
+        readyTimeoutMs: 50,
+        onWorkerScriptError,
+      });
+      try {
+        expect(errorListener).toBeTypeOf('function');
+        errorListener!();
+        expect(onWorkerScriptError).toHaveBeenCalledTimes(1);
+      } finally {
+        host.dispose();
+      }
+    });
+  });
 });

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -10,6 +10,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentErrorTelemetrySink } from '../../src/core/telemetry-hook.js';
 import type { VirtualFS } from '../../src/fs/virtual-fs.js';
 import {
+  broadcastStaleAssetReload,
+  isDynamicImportError,
+} from '../../src/core/stale-asset-channel.js';
+import {
   abortableSleep,
   isImageProcessingError,
   isNonRetryableError,
@@ -19,6 +23,11 @@ import {
   type ScoopContextCallbacks,
 } from '../../src/scoops/scoop-context.js';
 import type { RegisteredScoop } from '../../src/scoops/types.js';
+
+vi.mock('../../src/core/stale-asset-channel.js', async (orig) => {
+  const actual = await orig<typeof import('../../src/core/stale-asset-channel.js')>();
+  return { ...actual, broadcastStaleAssetReload: vi.fn() };
+});
 
 // Minimal scoop registration for testing
 const testScoop: RegisteredScoop = {
@@ -2426,5 +2435,32 @@ describe('ScoopContext typed-source error telemetry', () => {
     });
 
     expect(sink).not.toHaveBeenCalled();
+  });
+});
+
+describe('ScoopContext stale-asset error handling', () => {
+  const STALE = 'Failed to fetch dynamically imported module: https://x/assets/anthropic-abc.js';
+
+  it('stale-asset string ALSO matches isRetryableError — so the stale check must run first', () => {
+    expect(isDynamicImportError(STALE)).toBe(true);
+    expect(isRetryableError(STALE)).toBe(true);
+  });
+
+  it('handleStaleAssetError broadcasts + surfaces fatal for a dynamic-import error, and returns true', () => {
+    vi.mocked(broadcastStaleAssetReload).mockClear();
+    const callbacks = createMockCallbacks();
+    const ctx = new ScoopContext(testScoop, callbacks, {} as any);
+    const handled = (ctx as any).handleStaleAssetError(STALE) as boolean;
+    expect(handled).toBe(true);
+    expect(broadcastStaleAssetReload).toHaveBeenCalledTimes(1);
+    expect(callbacks.onFatalError).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleStaleAssetError ignores a non-dynamic-import error (returns false, no broadcast)', () => {
+    vi.mocked(broadcastStaleAssetReload).mockClear();
+    const callbacks = createMockCallbacks();
+    const ctx = new ScoopContext(testScoop, callbacks, {} as any);
+    expect((ctx as any).handleStaleAssetError('401 Unauthorized')).toBe(false);
+    expect(broadcastStaleAssetReload).not.toHaveBeenCalled();
   });
 });

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -7,12 +7,12 @@
 
 import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AgentErrorTelemetrySink } from '../../src/core/telemetry-hook.js';
-import type { VirtualFS } from '../../src/fs/virtual-fs.js';
 import {
   broadcastStaleAssetReload,
   isDynamicImportError,
 } from '../../src/core/stale-asset-channel.js';
+import type { AgentErrorTelemetrySink } from '../../src/core/telemetry-hook.js';
+import type { VirtualFS } from '../../src/fs/virtual-fs.js';
 import {
   abortableSleep,
   isImageProcessingError,

--- a/packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts
@@ -6,9 +6,11 @@ import {
 } from '../../../src/core/stale-asset-channel.js';
 import {
   __resetForTest,
+  consumeStaleAssetReplayPending,
   decideStaleReload,
   guardedReload,
   installWorkerStaleAssetReloadListener,
+  markStaleAssetReplayPending,
   RELOAD_WINDOW_MS,
   setupPreloadErrorReload,
 } from '../../../src/ui/boot/setup-preload-error-reload.js';
@@ -27,6 +29,9 @@ function makeStorage(initial: Record<string, string> = {}, opts: { throwOn?: 'ge
     setItem: (k: string, v: string) => {
       if (opts.throwOn === 'set') throw new Error('storage disabled');
       map.set(k, v);
+    },
+    removeItem: (k: string) => {
+      map.delete(k);
     },
   };
 }
@@ -98,15 +103,43 @@ describe('setupPreloadErrorReload (page trigger)', () => {
   });
 });
 
+const REPLAY_KEY = 'slicc:stale-asset-replay';
+
+describe('markStaleAssetReplayPending / consumeStaleAssetReplayPending', () => {
+  it('consume-once: mark then consume returns true, second consume returns false', () => {
+    const storage = makeStorage();
+    expect(consumeStaleAssetReplayPending(storage)).toBe(false);
+    markStaleAssetReplayPending(storage);
+    expect(consumeStaleAssetReplayPending(storage)).toBe(true);
+    // Cleared on read — a repeat consume (later loadMessages) is a no-op.
+    expect(consumeStaleAssetReplayPending(storage)).toBe(false);
+  });
+
+  it('fail-safe on storage throw: mark swallows, consume returns false', () => {
+    expect(() => markStaleAssetReplayPending(makeStorage({}, { throwOn: 'set' }))).not.toThrow();
+    expect(consumeStaleAssetReplayPending(makeStorage({}, { throwOn: 'get' }))).toBe(false);
+  });
+
+  it('defaults to window.sessionStorage in the jsdom env', () => {
+    window.sessionStorage.removeItem(REPLAY_KEY);
+    markStaleAssetReplayPending();
+    expect(window.sessionStorage.getItem(REPLAY_KEY)).toBe('1');
+    expect(consumeStaleAssetReplayPending()).toBe(true);
+    expect(window.sessionStorage.getItem(REPLAY_KEY)).toBeNull();
+  });
+});
+
 describe('installWorkerStaleAssetReloadListener (worker trigger)', () => {
   beforeEach(() => {
     __resetForTest();
     installFakeBroadcastChannel();
+    window.sessionStorage.removeItem(REPLAY_KEY);
   });
   afterEach(() => {
     setStaleAssetInstanceId(undefined);
     resetFakeBroadcastChannel();
     __resetForTest();
+    window.sessionStorage.removeItem(REPLAY_KEY);
   });
 
   it('runs the guarded reload on a matching-instanceId broadcast, ignores non-matching', async () => {
@@ -129,5 +162,44 @@ describe('installWorkerStaleAssetReloadListener (worker trigger)', () => {
     broadcastStaleAssetReload();
     await Promise.resolve();
     expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks a replay pending AND reloads for a replayTurn=true broadcast (cone turn-time)', async () => {
+    const reload = vi.fn();
+    setupPreloadErrorReload({
+      reload,
+      storage: makeStorage(),
+      now: () => 1_000,
+      windowMs: RELOAD_WINDOW_MS,
+      storageKey: 'k',
+    });
+    installWorkerStaleAssetReloadListener('inst-A');
+
+    setStaleAssetInstanceId('inst-A');
+    broadcastStaleAssetReload(true);
+    await Promise.resolve();
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem(REPLAY_KEY)).toBe('1');
+    // consume-once: the flag drains on first read, then is gone.
+    expect(consumeStaleAssetReplayPending()).toBe(true);
+    expect(consumeStaleAssetReplayPending()).toBe(false);
+  });
+
+  it('does NOT mark a replay for a replayTurn=false broadcast but still reloads (boot-time)', async () => {
+    const reload = vi.fn();
+    setupPreloadErrorReload({
+      reload,
+      storage: makeStorage(),
+      now: () => 1_000,
+      windowMs: RELOAD_WINDOW_MS,
+      storageKey: 'k',
+    });
+    installWorkerStaleAssetReloadListener('inst-A');
+
+    setStaleAssetInstanceId('inst-A');
+    broadcastStaleAssetReload(); // default false
+    await Promise.resolve();
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem(REPLAY_KEY)).toBeNull();
   });
 });

--- a/packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-preload-error-reload.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  broadcastStaleAssetReload,
+  setStaleAssetInstanceId,
+} from '../../../src/core/stale-asset-channel.js';
+import {
+  __resetForTest,
+  decideStaleReload,
+  guardedReload,
+  installWorkerStaleAssetReloadListener,
+  RELOAD_WINDOW_MS,
+  setupPreloadErrorReload,
+} from '../../../src/ui/boot/setup-preload-error-reload.js';
+import {
+  installFakeBroadcastChannel,
+  resetFakeBroadcastChannel,
+} from '../../helpers/fake-broadcast-channel.js';
+
+function makeStorage(initial: Record<string, string> = {}, opts: { throwOn?: 'get' | 'set' } = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => {
+      if (opts.throwOn === 'get') throw new Error('storage disabled');
+      return map.get(k) ?? null;
+    },
+    setItem: (k: string, v: string) => {
+      if (opts.throwOn === 'set') throw new Error('storage disabled');
+      map.set(k, v);
+    },
+  };
+}
+
+describe('decideStaleReload', () => {
+  it('reloads when no prior timestamp; suppresses within window; allows past window', () => {
+    expect(decideStaleReload(null, 1_000, RELOAD_WINDOW_MS)).toBe(true);
+    expect(decideStaleReload(1_000, 1_000 + 5_000, RELOAD_WINDOW_MS)).toBe(false);
+    expect(decideStaleReload(1_000, 1_000 + RELOAD_WINDOW_MS, RELOAD_WINDOW_MS)).toBe(true);
+  });
+});
+
+describe('guardedReload', () => {
+  it('reloads once, persists, suppresses in-window, reloads again past window', () => {
+    const reload = vi.fn();
+    const storage = makeStorage();
+    let t = 10_000;
+    const deps = { reload, storage, now: () => t, windowMs: RELOAD_WINDOW_MS, storageKey: 'k' };
+    expect(guardedReload(deps)).toBe(true);
+    t += 5_000;
+    expect(guardedReload(deps)).toBe(false);
+    t += RELOAD_WINDOW_MS;
+    expect(guardedReload(deps)).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+  it('fail-closed on storage throw (get or set): no reload, no throw', () => {
+    const reload = vi.fn();
+    for (const throwOn of ['get', 'set'] as const) {
+      expect(() =>
+        guardedReload({
+          reload,
+          storage: makeStorage({}, { throwOn }),
+          now: () => 1,
+          windowMs: RELOAD_WINDOW_MS,
+          storageKey: 'k',
+        })
+      ).not.toThrow();
+    }
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe('setupPreloadErrorReload (page trigger)', () => {
+  beforeEach(() => __resetForTest());
+  afterEach(() => __resetForTest());
+
+  it('reloads on vite:preloadError; preventDefaults only when it reloads; suppresses in-window', () => {
+    const reload = vi.fn();
+    const storage = makeStorage();
+    let t = 1_000;
+    setupPreloadErrorReload({
+      reload,
+      storage,
+      now: () => t,
+      windowMs: RELOAD_WINDOW_MS,
+      storageKey: 'k',
+    });
+
+    const e1 = new Event('vite:preloadError', { cancelable: true });
+    window.dispatchEvent(e1);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(e1.defaultPrevented).toBe(true);
+
+    t += 5_000;
+    const e2 = new Event('vite:preloadError', { cancelable: true });
+    window.dispatchEvent(e2);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(e2.defaultPrevented).toBe(false);
+  });
+});
+
+describe('installWorkerStaleAssetReloadListener (worker trigger)', () => {
+  beforeEach(() => {
+    __resetForTest();
+    installFakeBroadcastChannel();
+  });
+  afterEach(() => {
+    setStaleAssetInstanceId(undefined);
+    resetFakeBroadcastChannel();
+    __resetForTest();
+  });
+
+  it('runs the guarded reload on a matching-instanceId broadcast, ignores non-matching', async () => {
+    const reload = vi.fn();
+    setupPreloadErrorReload({
+      reload,
+      storage: makeStorage(),
+      now: () => 1_000,
+      windowMs: RELOAD_WINDOW_MS,
+      storageKey: 'k',
+    });
+    installWorkerStaleAssetReloadListener('inst-A');
+
+    setStaleAssetInstanceId('inst-B'); // other worker
+    broadcastStaleAssetReload();
+    await Promise.resolve();
+    expect(reload).not.toHaveBeenCalled();
+
+    setStaleAssetInstanceId('inst-A'); // our worker
+    broadcastStaleAssetReload();
+    await Promise.resolve();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -5,7 +5,7 @@
  * message_start → deltas (rAF-batched) → tool rows → content_done/turn_end.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -925,7 +925,13 @@ describe('WcChatController', () => {
 
   describe('stale-asset dropped-turn auto-resubmit (#1330 follow-on)', () => {
     const REPLAY_KEY = 'slicc:stale-asset-replay';
-    beforeEach(() => window.sessionStorage.removeItem(REPLAY_KEY));
+    beforeEach(() => {
+      window.sessionStorage.removeItem(REPLAY_KEY);
+      // The replay is scoped to the CONE thread — `applyThreadContext` sets this
+      // attribute synchronously before messages load. The positive cases stand
+      // in for the cone; the non-cone case overrides it in-body.
+      thread.setAttribute('context', 'cone');
+    });
     afterEach(() => window.sessionStorage.removeItem(REPLAY_KEY));
 
     it('replays the dropped cone turn once when the flag is set and the thread ends in an unanswered user turn', () => {
@@ -989,6 +995,46 @@ describe('WcChatController', () => {
       controller.loadMessages([{ id: 'u2', role: 'user', content: 'second', timestamp: 2 }]);
       // Still 1 — the flag drained on the first load, so the second is inert.
       expect(agent.sent).toHaveLength(1);
+    });
+
+    it('does NOT resend or consume the flag on a non-cone (scoop) load; the later cone load replays', () => {
+      window.sessionStorage.setItem(REPLAY_KEY, '1');
+      // A scoop thread deep-link (`scoop:<name>`) loads FIRST post-boot. Its
+      // mid-delegation tail is a `role:'user'` prompt that is NOT tagged
+      // `source:'delegation'`, so the old global one-shot would BOTH wrong-send
+      // the cone's prompt into the scoop's agent AND drain the flag — missing
+      // the cone's real dropped turn.
+      thread.setAttribute('context', 'scoop:worker');
+      controller.loadMessages([
+        { id: 's1', role: 'user', content: 'delegated prompt', timestamp: 1 },
+      ]);
+      expect(agent.sent).toHaveLength(0);
+      // The flag SURVIVED the non-cone load (not consumed).
+      expect(window.sessionStorage.getItem(REPLAY_KEY)).toBe('1');
+
+      // The cone thread finally loads → the dropped cone turn replays.
+      thread.setAttribute('context', 'cone');
+      controller.loadMessages([
+        { id: 'u1', role: 'user', content: 'dropped cone prompt', timestamp: 2 },
+      ]);
+      expect(agent.sent).toHaveLength(1);
+      expect(agent.sent[0].text).toBe('dropped cone prompt');
+    });
+
+    it('does NOT consume the flag on a transient empty cone load; the next real snapshot replays', () => {
+      window.sessionStorage.setItem(REPLAY_KEY, '1');
+      // A transient empty cone load (pre-snapshot) must not waste the one-shot
+      // flag.
+      controller.loadMessages([]);
+      expect(agent.sent).toHaveLength(0);
+      expect(window.sessionStorage.getItem(REPLAY_KEY)).toBe('1');
+
+      // The real cone snapshot arrives with an unanswered user tail → replays.
+      controller.loadMessages([
+        { id: 'u1', role: 'user', content: 'dropped prompt', timestamp: 1 },
+      ]);
+      expect(agent.sent).toHaveLength(1);
+      expect(agent.sent[0].text).toBe('dropped prompt');
     });
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -922,6 +922,75 @@ describe('WcChatController', () => {
       expect(bubbles[0].hasAttribute('queued')).toBe(false);
     });
   });
+
+  describe('stale-asset dropped-turn auto-resubmit (#1330 follow-on)', () => {
+    const REPLAY_KEY = 'slicc:stale-asset-replay';
+    beforeEach(() => window.sessionStorage.removeItem(REPLAY_KEY));
+    afterEach(() => window.sessionStorage.removeItem(REPLAY_KEY));
+
+    it('replays the dropped cone turn once when the flag is set and the thread ends in an unanswered user turn', () => {
+      window.sessionStorage.setItem(REPLAY_KEY, '1');
+      controller.loadMessages([
+        { id: 'u1', role: 'user', content: 'dropped prompt', timestamp: 1 },
+      ]);
+      expect(agent.sent).toHaveLength(1);
+      expect(agent.sent[0].text).toBe('dropped prompt');
+      // No duplicate bubble — the resend routes through #agent.sendMessage.
+      expect(thread.querySelectorAll('slicc-user-message')).toHaveLength(1);
+    });
+
+    it('does NOT resend when the last message is an assistant reply (turn completed)', () => {
+      window.sessionStorage.setItem(REPLAY_KEY, '1');
+      controller.loadMessages([
+        { id: 'u1', role: 'user', content: 'answered', timestamp: 1 },
+        { id: 'a1', role: 'assistant', content: 'the reply', timestamp: 2 },
+      ]);
+      expect(agent.sent).toHaveLength(0);
+    });
+
+    it('does NOT resend when the flag is not set (ordinary scoop switch / reconnect)', () => {
+      controller.loadMessages([
+        { id: 'u1', role: 'user', content: 'dropped prompt', timestamp: 1 },
+      ]);
+      expect(agent.sent).toHaveLength(0);
+    });
+
+    it('does NOT resend while a turn is already running, but still consumes the flag', () => {
+      window.sessionStorage.setItem(REPLAY_KEY, '1');
+      controller.setProcessing(true);
+      controller.loadMessages([
+        { id: 'u1', role: 'user', content: 'dropped prompt', timestamp: 1 },
+      ]);
+      expect(agent.sent).toHaveLength(0);
+      // The flag was consumed (one-shot), so it can't leak into a later load.
+      expect(window.sessionStorage.getItem(REPLAY_KEY)).toBeNull();
+    });
+
+    it('does NOT resend when the last message is a lick-originated user turn', () => {
+      window.sessionStorage.setItem(REPLAY_KEY, '1');
+      controller.loadMessages([
+        {
+          id: 'l1',
+          role: 'user',
+          content: '[Webhook Event: x]',
+          timestamp: 1,
+          source: 'lick',
+          channel: 'webhook',
+        },
+      ]);
+      expect(agent.sent).toHaveLength(0);
+    });
+
+    it('consume-once: two loadMessages calls resend only the first (scoop switches do not re-replay)', () => {
+      window.sessionStorage.setItem(REPLAY_KEY, '1');
+      controller.loadMessages([{ id: 'u1', role: 'user', content: 'first', timestamp: 1 }]);
+      expect(agent.sent).toHaveLength(1);
+      expect(agent.sent[0].text).toBe('first');
+      controller.loadMessages([{ id: 'u2', role: 'user', content: 'second', timestamp: 2 }]);
+      // Still 1 — the flag drained on the first load, so the second is inert.
+      expect(agent.sent).toHaveLength(1);
+    });
+  });
 });
 
 describe('WcChatController render/dispose lifecycle hooks', () => {

--- a/tsconfig.webapp-worker.json
+++ b/tsconfig.webapp-worker.json
@@ -33,6 +33,7 @@
     "packages/webapp/src/types/helix-rum-js.d.ts",
     "packages/webapp/src/types/pi-ai-internals.d.ts",
     "packages/webapp/src/types/pi-coding-agent-compaction.d.ts",
+    "packages/webapp/src/core/stale-asset-channel.ts",
     "packages/chrome-extension/src/chrome.d.ts"
   ]
 }


### PR DESCRIPTION
## Problem

After a deploy, any long-lived sliccy.ai UI tab/worker holds an old module graph. A subsequent lazy `import()` of a content-hashed Vite chunk whose hash changed on deploy fails, and the session becomes unrecoverable:

```
Something went wrong
Scoop "Cone" failed after 3 attempts: Failed to fetch dynamically imported module: https://www.sliccy.ai/assets/anthropic-BOEkIcb-.js
```

Not cloud-cone-specific — it hits the cloud cone (in-sandbox browser), the extension's pinned leader tab, the extension side-panel follower, and any open standalone tab. Two subtleties made this non-trivial:

- The failing import is usually **worker-owned** (providers lazy-import in the kernel worker), and Vite injects `vite:preloadError` only into the **page** bundle — so a `window` listener alone can't catch it.
- The worker's SPA fallback (`not_found_handling: single-page-application`) returns `index.html` as `200 text/html` for a gone `/assets/*.js`, so the import rejects with a MIME/module-script error, not a clean 404.

## Fix

**Four triggers → one shared, `instanceId`-scoped, fail-closed, timestamp-guarded (60s) page reload:**

1. **Page** `window` `vite:preloadError` — page-owned lazy chunks.
2. **Page** `Worker` `error` (`spawn.ts` `onWorkerScriptError`) — a stale worker **entry** chunk that fails before `boot()` runs.
3. **Worker** `boot()` `try/catch` (`broadcastIfStaleAssetError`) — boot-time `registerProviders()` imports (before any `ScoopContext` exists).
4. **Worker** `scoop-context` turn classifier — checked **before** the generic `failed to fetch` retry matcher so a stale import isn't retried 3× futilely.

Worker triggers `broadcast` over a `BroadcastChannel` stamped with the kernel worker's `instanceId`; the page listener acts only on its own `instanceId` (never origin-wide), and is installed **before** `spawnKernelWorker()` since `BroadcastChannel` does not buffer. The 60s guard window exceeds the ~30s host-ready boot timeout, so a stale re-error at boot is suppressed rather than looping; fail-closed on any `sessionStorage` error. New shared module `core/stale-asset-channel.ts` is realm-agnostic (added to `tsconfig.webapp-worker.json` to prove it's DOM-free).

Scope: `packages/webapp` only.

## Deferred (out of scope, follow-ups)

- Worker `Cache-Control: no-cache` on the SPA HTML (fresh `index.html` currently relies on `location.reload()` top-document revalidation; cherry/electron responses are already `no-store`).
- Server-side clean 404 for `/assets/*`.

## Testing

- New unit tests: `stale-asset-channel` (detection matrix incl. false-positive guards, instanceId-scoped broadcast/listener, `broadcastIfStaleAssetError`), `setup-preload-error-reload` (guard, fail-closed, page + worker triggers), `scoop-context` (precedence + `handleStaleAssetError`), `spawn` (`onWorkerScriptError` wiring).
- Full pre-PR pass green: `lint:ci`, `deadcode`, `typecheck`, `test:coverage:webapp` (8419 pass, coverage floors met), `build -w @slicc/chrome-extension`.

Fixes #1330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
