### PR TITLE
fix: OAuth callback result-POST race + swift /api/secrets/scrub parity

### DIFF
--- a/packages/node-server/src/routes/oauth-callback.ts
+++ b/packages/node-server/src/routes/oauth-callback.ts
@@ -41,12 +41,19 @@ export function registerOAuthCallbackRoutes(app: Express): void {
           console.warn('[oauth-callback] postMessage to opener failed:', e);
         }
       }
+      var closed = false;
+      function closeWindow() {
+        if (closed) return;
+        closed = true;
+        window.close();
+      }
+      setTimeout(closeWindow, 2000);
       fetch('/api/oauth-result', {
         method: 'POST',
+        keepalive: true,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
-      }).catch(function(err) { console.error('[oauth-callback] Failed to relay result to server:', err); });
-      window.close();
+      }).catch(function(err) { console.error('[oauth-callback] Failed to relay result to server:', err); }).finally(closeWindow);
     </script><p>Completing login... you can close this window.</p></body></html>`);
   });
 

--- a/packages/node-server/tests/routes/oauth-callback.test.ts
+++ b/packages/node-server/tests/routes/oauth-callback.test.ts
@@ -101,6 +101,11 @@ describe('registerOAuthCallbackRoutes', () => {
     const html = await res.text();
     expect(html).toContain('oauth-callback');
     expect(html).toContain('/api/oauth-result');
+    // The relay POST must survive window teardown: keepalive + a deferred
+    // close that only runs once the fetch settles (or a fallback timer fires).
+    expect(html).toContain('keepalive: true');
+    expect(html).toContain('.finally(closeWindow)');
+    expect(html).toContain('setTimeout(closeWindow');
   });
 
   it('relays a posted result to the next GET, then clears it (204)', async () => {
@@ -152,16 +157,21 @@ describe('registerOAuthCallbackRoutes', () => {
      * endpoint pair (which the "204/no-op" bug could still pass even while
      * the script itself never called fetch).
      */
-    function runCallbackScript(opener: { postMessage: (...args: unknown[]) => void } | null): {
-      fetchCalls: Array<{ url: string; body: unknown }>;
-      closed: boolean;
+    function runCallbackScript(
+      opener: { postMessage: (...args: unknown[]) => void } | null,
+      opts: { fetchNeverSettles?: boolean } = {}
+    ): {
+      fetchCalls: Array<{ url: string; keepalive: unknown; body: unknown }>;
       postMessageCalls: unknown[][];
+      timers: Array<{ fn: () => void; delay: number }>;
+      sandbox: { closed: boolean };
     } {
       const html = SERVED_HTML;
       const scriptMatch = html.match(/<script>([\s\S]*?)<\/script>/);
       if (!scriptMatch) throw new Error('callback HTML has no <script> block');
-      const fetchCalls: Array<{ url: string; body: unknown }> = [];
+      const fetchCalls: Array<{ url: string; keepalive: unknown; body: unknown }> = [];
       const postMessageCalls: unknown[][] = [];
+      const timers: Array<{ fn: () => void; delay: number }> = [];
       const sandbox = {
         window: {
           opener: opener
@@ -174,33 +184,45 @@ describe('registerOAuthCallbackRoutes', () => {
           },
         },
         location: { search: '?code=abc123&state=xyz', hash: '' },
-        fetch: (url: string, init: { body: unknown }) => {
-          fetchCalls.push({ url, body: JSON.parse(init.body as string) });
-          return Promise.resolve({ ok: true });
+        fetch: (url: string, init: { body: unknown; keepalive?: unknown }) => {
+          fetchCalls.push({ url, keepalive: init.keepalive, body: JSON.parse(init.body as string) });
+          return opts.fetchNeverSettles ? new Promise(() => {}) : Promise.resolve({ ok: true });
+        },
+        setTimeout: (fn: () => void, delay: number) => {
+          timers.push({ fn, delay });
+          return timers.length;
         },
         URLSearchParams,
         console: { error: () => {} },
         closed: false,
       };
       runInNewContext(scriptMatch[1] as string, sandbox);
-      return { fetchCalls, closed: sandbox.closed, postMessageCalls };
+      return { fetchCalls, postMessageCalls, timers, sandbox };
     }
 
     let SERVED_HTML = '';
+
+    // Let the fetch().catch().finally(closeWindow) chain drain its microtasks.
+    const flushMicrotasks = () => new Promise((r) => setTimeout(r, 0));
 
     it('POSTs to /api/oauth-result even when window.opener is present (GitHub: no COOP)', async () => {
       server = await startServer();
       const res = await fetch(`http://localhost:${server.port}/auth/callback?code=abc`);
       SERVED_HTML = await res.text();
 
-      const { fetchCalls, closed, postMessageCalls } = runCallbackScript({
+      const { fetchCalls, postMessageCalls, sandbox } = runCallbackScript({
         postMessage: () => {},
       });
       expect(fetchCalls).toHaveLength(1);
       expect(fetchCalls[0]?.url).toBe('/api/oauth-result');
+      expect(fetchCalls[0]?.keepalive).toBe(true);
       expect(fetchCalls[0]?.body).toMatchObject({ type: 'oauth-callback', code: 'abc123' });
       expect(postMessageCalls).toHaveLength(1);
-      expect(closed).toBe(true);
+      // window.close() must be deferred until the POST settles, not fired in
+      // the same tick (which would cancel the in-flight relay POST).
+      expect(sandbox.closed).toBe(false);
+      await flushMicrotasks();
+      expect(sandbox.closed).toBe(true);
     });
 
     it('still POSTs when window.opener is null (Electron overlay)', async () => {
@@ -208,10 +230,30 @@ describe('registerOAuthCallbackRoutes', () => {
       const res = await fetch(`http://localhost:${server.port}/auth/callback?code=abc`);
       SERVED_HTML = await res.text();
 
-      const { fetchCalls, closed } = runCallbackScript(null);
+      const { fetchCalls, sandbox } = runCallbackScript(null);
       expect(fetchCalls).toHaveLength(1);
       expect(fetchCalls[0]?.url).toBe('/api/oauth-result');
-      expect(closed).toBe(true);
+      expect(fetchCalls[0]?.keepalive).toBe(true);
+      await flushMicrotasks();
+      expect(sandbox.closed).toBe(true);
+    });
+
+    it('closes via the fallback timeout if the POST never settles', async () => {
+      server = await startServer();
+      const res = await fetch(`http://localhost:${server.port}/auth/callback?code=abc`);
+      SERVED_HTML = await res.text();
+
+      const { fetchCalls, timers, sandbox } = runCallbackScript(null, {
+        fetchNeverSettles: true,
+      });
+      expect(fetchCalls).toHaveLength(1);
+      // The .finally() close never runs because the POST is still in flight.
+      await flushMicrotasks();
+      expect(sandbox.closed).toBe(false);
+      // A single fallback timer was scheduled; firing it closes the window.
+      expect(timers).toHaveLength(1);
+      timers[0]?.fn();
+      expect(sandbox.closed).toBe(true);
     });
   });
 

--- a/packages/node-server/tests/routes/oauth-callback.test.ts
+++ b/packages/node-server/tests/routes/oauth-callback.test.ts
@@ -185,7 +185,11 @@ describe('registerOAuthCallbackRoutes', () => {
         },
         location: { search: '?code=abc123&state=xyz', hash: '' },
         fetch: (url: string, init: { body: unknown; keepalive?: unknown }) => {
-          fetchCalls.push({ url, keepalive: init.keepalive, body: JSON.parse(init.body as string) });
+          fetchCalls.push({
+            url,
+            keepalive: init.keepalive,
+            body: JSON.parse(init.body as string),
+          });
           return opts.fetchNeverSettles ? new Promise(() => {}) : Promise.resolve({ ok: true });
         },
         setTimeout: (fn: () => void, delay: number) => {

--- a/packages/swift-server/CLAUDE.md
+++ b/packages/swift-server/CLAUDE.md
@@ -61,6 +61,7 @@ violations.
 - `GET /auth/callback`
 - `GET|POST /api/oauth-result`
 - `GET /api/secrets`, `GET /api/secrets/masked`
+- `POST /api/secrets/scrub` — tool-output real→masked scrub (defense-in-depth). Mirrors node-server's `routes/secrets.ts`: 400 on non-string `text`, else `{ text: scrubbed }` via `SecretInjector.scrub(text:)`.
 - `POST /api/s3-sign-and-forward`, `POST /api/da-sign-and-forward` — server-side request signing for S3 and Adobe da.live mounts. Mirrors `packages/node-server/src/secrets/sign-and-forward.ts`; resolves S3 credentials from the Keychain (`SecretStore`) and accepts a transient IMS bearer for DA. See `Sources/Server/SignAndForward.swift`.
 - `POST /api/sudo-approve` — native sudo approval for the in-browser broker. Mirrors `packages/node-server/src/sudo/` (`endpoint.ts` + `dialog-backends.ts`): validates a `{ kind, detail, suggestedPattern? }` envelope (invalid → 400) and raises the same native `osascript` dialog by shelling out via `Process`. Loopback-only by construction; fail-closed to `{ decision: "deny" }` on any error. See `Sources/Server/SudoApprove.swift`.
 - `ALL /api/fetch-proxy` — accepts standard verbs (`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`) plus the WebDAV (RFC 4918) and CalDAV (RFC 4791) verbs `PROPFIND`, `PROPPATCH`, `MKCOL`, `MKCALENDAR`, `REPORT`, `COPY`, `MOVE`, `LOCK`, `UNLOCK`. Unknown verbs are forwarded to AsyncHTTPClient via `HTTPMethod.RAW(value:)`.

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -287,10 +287,11 @@ func registerAPIRoutes(
     // scrub is defense-in-depth, not the primary defense. Mirrors node-server's
     // `POST /api/secrets/scrub` in routes/secrets.ts: 400 on non-string `text`,
     // else `{ text: scrubbed }`.
-    router.post("/api/secrets/scrub") { request, context in
+    router.post("/api/secrets/scrub") { request, _ in
         let payload: ScrubPayload
         do {
-            payload = try await request.decode(as: ScrubPayload.self, context: context)
+            let body = try await collectBody(from: request)
+            payload = try decodeJSON(from: body, as: ScrubPayload.self)
         } catch {
             return try jsonErrorResponse(status: .badRequest, message: "bad-request")
         }

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -278,6 +278,28 @@ func registerAPIRoutes(
         return try jsonResponse(.array(items))
     }
 
+    // Tool-output real→masked scrub. The browser-side agent realm never holds
+    // real secret values, so the defense-in-depth scrub of bash / read_file /
+    // other tool results runs here against the server-owned SecretInjector.
+    // Direction is real→masked ONLY (`scrub`), so it is always safe and
+    // idempotent for already-masked tokens and secret-free output. The caller
+    // treats any non-2xx / malformed response as "return input unchanged" — the
+    // scrub is defense-in-depth, not the primary defense. Mirrors node-server's
+    // `POST /api/secrets/scrub` in routes/secrets.ts: 400 on non-string `text`,
+    // else `{ text: scrubbed }`.
+    router.post("/api/secrets/scrub") { request, context in
+        let payload: ScrubPayload
+        do {
+            payload = try await request.decode(as: ScrubPayload.self, context: context)
+        } catch {
+            return try jsonErrorResponse(status: .badRequest, message: "bad-request")
+        }
+        guard let text = payload.text else {
+            return try jsonErrorResponse(status: .badRequest, message: "bad-request")
+        }
+        return try jsonResponse(.object(["text": .string(secretInjector.scrub(text: text))]))
+    }
+
     // OAuth secret replicas — the webapp pushes provider access tokens here
     // so the fetch proxy can unmask them on outbound requests. Mirrors
     // packages/node-server/src/index.ts handlers around `/api/secrets/oauth-update`.
@@ -472,6 +494,13 @@ func registerAPIRoutes(
 private struct OAuthRelayPayload: Decodable {
     let redirectUrl: String?
     let error: String?
+}
+
+/// Body of POST /api/secrets/scrub. `text` is optional so a missing key or a
+/// non-string value both surface as a 400 (matching node-server's
+/// `typeof text !== 'string'` guard).
+private struct ScrubPayload: Decodable {
+    let text: String?
 }
 
 /// Body of POST /api/secrets/oauth-update. Mirrors the TS payload shape

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -503,12 +503,19 @@ private let oauthCallbackHTML = """
       console.warn('[oauth-callback] postMessage to opener failed:', e);
     }
   }
+  var closed = false;
+  function closeWindow() {
+    if (closed) return;
+    closed = true;
+    window.close();
+  }
+  setTimeout(closeWindow, 2000);
   fetch('/api/oauth-result', {
     method: 'POST',
+    keepalive: true,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
-  }).catch(function(err) { console.error('[oauth-callback] Failed to relay result to server:', err); });
-  window.close();
+  }).catch(function(err) { console.error('[oauth-callback] Failed to relay result to server:', err); }).finally(closeWindow);
 </script><p>Completing login... you can close this window.</p></body></html>
 """
 

--- a/packages/swift-server/Tests/APIRoutesTests.swift
+++ b/packages/swift-server/Tests/APIRoutesTests.swift
@@ -203,6 +203,54 @@ final class APIRoutesTests: XCTestCase {
         }
     }
 
+    func testAuthCallbackDefersCloseUntilResultPosted() async throws {
+        // Regression: the callback ran `window.close()` synchronously in the
+        // same tick as the un-awaited relay POST, cancelling the in-flight
+        // request before it reached the server (fatal in hosted-leader
+        // thin-bridge mode where postMessage is severed by COOP). The POST
+        // must now use keepalive and the window must only close once the fetch
+        // settles, with a fallback timer so it can't hang open.
+        // Mirrors `packages/node-server/tests/routes/oauth-callback.test.ts`.
+        try await self.withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/auth/callback?code=abc", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    let html = String(buffer: response.body)
+                    XCTAssertTrue(
+                        html.contains("keepalive: true"),
+                        "relay POST must set keepalive so it survives window teardown"
+                    )
+                    XCTAssertTrue(
+                        html.contains(".finally(closeWindow)"),
+                        "window must close only after the relay POST settles"
+                    )
+                    XCTAssertTrue(
+                        html.contains("setTimeout(closeWindow"),
+                        "a fallback timer must close the window if the POST hangs"
+                    )
+                    guard let fetchRange = html.range(of: "fetch('/api/oauth-result'"),
+                        let closeRange = html.range(of: "window.close();")
+                    else {
+                        XCTFail("callback script missing fetch or window.close()")
+                        return
+                    }
+                    // The only literal `window.close()` call lives inside the
+                    // deferred `closeWindow` helper, which is defined before the
+                    // fetch — so a bare synchronous close after the POST would
+                    // have moved this call past the fetch. Assert it stays before.
+                    XCTAssertTrue(
+                        closeRange.lowerBound < fetchRange.lowerBound,
+                        "window.close() must live in the pre-fetch closeWindow helper, not fire synchronously after the POST"
+                    )
+                }
+            }
+        }
+    }
+
     func testFetchProxyMissingTargetURLIsTaggedAsProxyError() async throws {
         // The proxy must mark its own infrastructure errors with X-Proxy-Error: 1
         // so SecureFetch clients can distinguish them from upstream 4xx/5xx

--- a/packages/swift-server/Tests/SecretAPIRoutesTests.swift
+++ b/packages/swift-server/Tests/SecretAPIRoutesTests.swift
@@ -282,6 +282,102 @@ final class SecretAPIRoutesTests: XCTestCase {
         }
     }
 
+    // MARK: - Scrub route
+
+    func testScrubReplacesRealValuesWithMasked() async throws {
+        let injector = SecretInjector(secrets: [
+            .init(
+                name: "GH",
+                realValue: "ghp_realSecret123",
+                maskedValue: "ghp_maskedAAA0001",
+                domains: ["github.com"]
+            ),
+        ])
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(
+                router: router,
+                lickSystem: LickSystem(),
+                config: self.makeConfig(),
+                httpClient: httpClient,
+                secretInjector: injector
+            )
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                let body = #"{"text":"token: ghp_realSecret123 done"}"#
+                try await client.execute(
+                    uri: "/api/secrets/scrub",
+                    method: .post,
+                    headers: [.contentType: "application/json"],
+                    body: ByteBuffer(string: body)
+                ) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    let obj = try self.decodeJSONObject(from: response.body)
+                    XCTAssertEqual(obj["text"]?.stringValue, "token: ghp_maskedAAA0001 done")
+                }
+            }
+        }
+    }
+
+    func testScrubReturnsInputUnchangedWhenNoSecrets() async throws {
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                let body = #"{"text":"nothing to scrub here"}"#
+                try await client.execute(
+                    uri: "/api/secrets/scrub",
+                    method: .post,
+                    headers: [.contentType: "application/json"],
+                    body: ByteBuffer(string: body)
+                ) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    let obj = try self.decodeJSONObject(from: response.body)
+                    XCTAssertEqual(obj["text"]?.stringValue, "nothing to scrub here")
+                }
+            }
+        }
+    }
+
+    func testScrubRejectsNonStringText() async throws {
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                let body = #"{"text":123}"#
+                try await client.execute(
+                    uri: "/api/secrets/scrub",
+                    method: .post,
+                    headers: [.contentType: "application/json"],
+                    body: ByteBuffer(string: body)
+                ) { response in
+                    XCTAssertEqual(response.status, .badRequest)
+                }
+            }
+        }
+    }
+
+    func testScrubRejectsMissingText() async throws {
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(router: router, lickSystem: LickSystem(), config: self.makeConfig(), httpClient: httpClient)
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                let body = "{}"
+                try await client.execute(
+                    uri: "/api/secrets/scrub",
+                    method: .post,
+                    headers: [.contentType: "application/json"],
+                    body: ByteBuffer(string: body)
+                ) { response in
+                    XCTAssertEqual(response.status, .badRequest)
+                }
+            }
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeConfig() -> ServerConfig {

--- a/packages/swift-server/Tests/SecretAPIRoutesTests.swift
+++ b/packages/swift-server/Tests/SecretAPIRoutesTests.swift
@@ -319,6 +319,47 @@ final class SecretAPIRoutesTests: XCTestCase {
         }
     }
 
+    func testScrubHandlesBodyLargerThanDefaultUploadLimit() async throws {
+        // Regression: Hummingbird's default ~2 MiB maxUploadSize used to make the
+        // scrub route 400 on large tool results, so oversized output skipped
+        // real→masked scrubbing. The handler now collects the body explicitly
+        // (>=32 MiB, matching node-server), so a ~3 MiB payload must still scrub.
+        let injector = SecretInjector(secrets: [
+            .init(
+                name: "GH",
+                realValue: "ghp_realSecret123",
+                maskedValue: "ghp_maskedAAA0001",
+                domains: ["github.com"]
+            ),
+        ])
+        let filler = String(repeating: "a", count: 3 * 1024 * 1024)
+        let text = "\(filler) token: ghp_realSecret123 done"
+        let bodyData = try JSONEncoder().encode(["text": text])
+        try await withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(
+                router: router,
+                lickSystem: LickSystem(),
+                config: self.makeConfig(),
+                httpClient: httpClient,
+                secretInjector: injector
+            )
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(
+                    uri: "/api/secrets/scrub",
+                    method: .post,
+                    headers: [.contentType: "application/json"],
+                    body: ByteBuffer(bytes: bodyData)
+                ) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    let obj = try self.decodeJSONObject(from: response.body)
+                    XCTAssertEqual(obj["text"]?.stringValue, "\(filler) token: ghp_maskedAAA0001 done")
+                }
+            }
+        }
+    }
+
     func testScrubReturnsInputUnchangedWhenNoSecrets() async throws {
         try await withHTTPClient { httpClient in
             let router = Router()

--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -207,6 +207,12 @@ async function resolveClientId(): Promise<string> {
       };
       if (localData.oauth?.github) {
         runtimeClientId = localData.oauth.github;
+        // Capture the worker base that supplied this client id so the
+        // OAuth `redirect_uri` is built from the same worker (the active
+        // prod/staging relay), not the production fallback.
+        if (localData.trayWorkerBaseUrl) {
+          runtimeWorkerBaseUrl = localData.trayWorkerBaseUrl;
+        }
         return runtimeClientId;
       }
       // Dev mode: local server has no OAuth config — fetch from the worker

--- a/packages/webapp/tests/providers/github-oauth-login.test.ts
+++ b/packages/webapp/tests/providers/github-oauth-login.test.ts
@@ -361,6 +361,121 @@ describe('github.ts onOAuthLogin in worker context (no window)', () => {
   });
 });
 
+describe('resolveClientId captures runtimeWorkerBaseUrl from runtime-config', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalLocalStorage: Storage;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalLocalStorage = globalThis.localStorage;
+    const lsData: Record<string, string> = {};
+    (globalThis as any).localStorage = {
+      getItem: (k: string) => lsData[k] ?? null,
+      setItem: (k: string, v: string) => {
+        lsData[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete lsData[k];
+      },
+      clear: () => {
+        for (const k of Object.keys(lsData)) delete lsData[k];
+      },
+    };
+    delete (globalThis as any).chrome;
+    (globalThis as any).document = {};
+    // Fresh module graph so the module-level `runtimeClientId` /
+    // `runtimeWorkerBaseUrl` start null and `resolveClientId` actually runs.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    (globalThis as any).localStorage = originalLocalStorage;
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+  });
+
+  it('builds redirect_uri from the runtime-config worker base, not the www.sliccy.ai fallback', async () => {
+    const STAGING_WORKER = 'https://slicc-staging.example.workers.dev';
+
+    // Worker-served thin-bridge SPA: page on :8787 carrying the bridge launch
+    // param, with a local node-server bridge on :5710. `getWorkerBaseUrl()`
+    // has no stored override so it returns the production default
+    // (www.sliccy.ai) — the fallback we must NOT redirect to.
+    (globalThis as any).window = {
+      location: {
+        origin: 'http://localhost:8787',
+        href: 'http://localhost:8787/?bridge=ws://localhost:5710/cdp&bridgeToken=abc',
+      },
+      dispatchEvent: vi.fn(),
+    };
+
+    let observedAuthorizeUrl = '';
+    globalThis.fetch = vi.fn(async (url: any) => {
+      const urlStr = String(url);
+      // Runtime config carries BOTH the client id and the worker base that
+      // supplied it (staging in dev mode).
+      if (urlStr.includes('/api/runtime-config')) {
+        return {
+          ok: true,
+          json: async () => ({
+            oauth: { github: 'staging-client-id' },
+            trayWorkerBaseUrl: STAGING_WORKER,
+          }),
+        } as any;
+      }
+      if (urlStr.includes('/oauth/token')) {
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: 'ghp_staging_token',
+            token_type: 'Bearer',
+            scope: 'repo',
+          }),
+        } as any;
+      }
+      if (urlStr.includes('api.github.com/user')) {
+        return { ok: true, json: async () => ({ login: 'staging-user', id: 42 }) } as any;
+      }
+      if (urlStr.includes('/api/secrets/oauth-update')) {
+        return {
+          ok: true,
+          json: async () => ({
+            providerId: 'github',
+            name: 'oauth.github.token',
+            maskedValue: 'ghp_masked_staging',
+            domains: ['github.com'],
+          }),
+        } as any;
+      }
+      return { ok: false, status: 404 } as any;
+    });
+
+    const { config } = await import('../../providers/github.js');
+    const { setLocalApiBaseUrl } = await import('../../src/shell/proxied-fetch.js');
+    // Configure the local node-server bridge so the thin-bridge branch fires.
+    setLocalApiBaseUrl('http://localhost:5710');
+
+    const fakeLauncher = vi.fn(async (url: string) => {
+      observedAuthorizeUrl = url;
+      const authUrl = new URL(url);
+      const state = authUrl.searchParams.get('state');
+      const stateData = state ? JSON.parse(atob(state)) : null;
+      return `https://x.com/callback?code=staging-code&nonce=${stateData?.nonce ?? ''}`;
+    });
+
+    await config.onOAuthLogin!(fakeLauncher, () => {}, undefined);
+
+    const auth = new URL(observedAuthorizeUrl);
+    // The client id came from the local runtime-config.
+    expect(auth.searchParams.get('client_id')).toBe('staging-client-id');
+    // The redirect_uri must be built from the SAME worker that supplied the
+    // client id (the staging relay), NOT the production www.sliccy.ai fallback.
+    expect(auth.searchParams.get('redirect_uri')).toBe(`${STAGING_WORKER}/auth/callback`);
+    expect(auth.searchParams.get('redirect_uri')).not.toBe('https://www.sliccy.ai/auth/callback');
+  });
+});
+
 describe('resolveGithubOAuthRedirect (per-runtime redirect_uri + state)', () => {
   const base = {
     workerBaseUrl: 'https://www.sliccy.ai',


### PR DESCRIPTION
## Problem

'oauth-token github' never completes when SLICC runs as the hosted leader (www.sliccy.ai) bridged to a local bridge (Swift slicc-server or node-server) on :5710.

**Root cause:** the OAuth /auth/callback page fired an un-awaited fetch('/api/oauth-result', POST) and then called window.close() synchronously. Closing the callback popup cancels the in-flight POST before it reaches the bridge, so the result is never stored. The cone's poll (GET /api/oauth-result) never sees a result, times out (120s), the launcher resolves to null, and github.ts:onOAuthLogin early-returns — printing "login completed but no token was saved".

This is fatal specifically in hosted-leader thin-bridge mode: GitHub's COOP same-origin severs window.opener, so the postMessage(opener) path can never fire — the /api/oauth-result POST is the only delivery channel, and the window.close() race kills it.

## Changes

**Fix 1 — OAuth callback result-POST race (both bridges)**
- packages/node-server/src/routes/oauth-callback.ts
- packages/swift-server/Sources/Server/APIRoutes.swift (oauthCallbackHTML)

The relay fetch now uses keepalive: true, and window.close() is deferred to .finally(closeWindow) with a ~2s fallback timer so the window still closes if the POST hangs. The postMessage(opener) fallback path is preserved for standalone/electron.

**Fix 2 — POST /api/secrets/scrub on swift-server (parity)**
- packages/swift-server/Sources/Server/APIRoutes.swift

Adds the tool-result scrub endpoint that node-server already has (routes/secrets.ts): 400 on non-string text, else { text: SecretInjector.scrub(text:) }. Closes the hosted-leader /api/secrets/scrub CORS/500 console flood.

## Verification

- node vitest: 11/11 passing (packages/node-server/tests/routes/oauth-callback.test.ts)
- swift test: 13/13 SecretAPIRoutesTests passing
- postMessage(opener) fallback preserved for standalone/electron

**Live verification pending:** run 'oauth-token github' end-to-end in the hosted-leader + local bridge and confirm a token is saved.
