### PR TITLE
Add per-message timestamps to chat UI

### DIFF
--- a/packages/cherry/src/index.ts
+++ b/packages/cherry/src/index.ts
@@ -40,6 +40,8 @@ export interface CherryFeatures {
   newSprinkle?: boolean;
   /** Show the monitor panel. Default: true. */
   monitor?: boolean;
+  /** Show timestamps on chat messages. Default: true. */
+  showTimestamps?: boolean;
 }
 
 export interface HostHooks {

--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -100,6 +100,7 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
           nav: true,
           newSprinkle: true,
           monitor: true,
+          showTimestamps: true,
           ...options.features,
         };
         // JSON.stringify can throw on cyclic/non-serializable theme objects — a

--- a/packages/cherry/src/protocol.ts
+++ b/packages/cherry/src/protocol.ts
@@ -43,6 +43,7 @@ export interface CherryHandshakeWelcome {
     nav: boolean;
     newSprinkle: boolean;
     monitor: boolean;
+    showTimestamps: boolean;
   };
   /** JSON-serialized SliccTheme the follower should apply. */
   theme?: string;

--- a/packages/cherry/tests/features.test.ts
+++ b/packages/cherry/tests/features.test.ts
@@ -35,6 +35,7 @@ describe('cherry features', () => {
       nav: true,
       newSprinkle: true,
       monitor: true,
+      showTimestamps: true,
     });
     handle.destroy();
   });
@@ -68,6 +69,7 @@ describe('cherry features', () => {
       nav: true,
       newSprinkle: true,
       monitor: true,
+      showTimestamps: true,
     });
     handle.destroy();
   });

--- a/packages/webapp/src/cdp/cherry-host-protocol.ts
+++ b/packages/webapp/src/cdp/cherry-host-protocol.ts
@@ -33,6 +33,7 @@ export interface CherryHandshakeWelcome {
     nav: boolean;
     newSprinkle: boolean;
     monitor: boolean;
+    showTimestamps: boolean;
   };
   /** JSON-serialized SliccTheme the follower should apply. */
   theme?: string;

--- a/packages/webapp/src/ui/timestamp-preference.ts
+++ b/packages/webapp/src/ui/timestamp-preference.ts
@@ -32,9 +32,10 @@ export function setShowTimestamps(show: boolean): void {
   applyTimestampVisibility();
 }
 
-export function applyTimestampVisibility(): void {
+export function applyTimestampVisibility(override?: boolean): void {
   ensureTimestampStyle(document);
-  document.documentElement.classList.toggle(CSS_CLASS, getShowTimestamps());
+  const show = override !== undefined ? override : getShowTimestamps();
+  document.documentElement.classList.toggle(CSS_CLASS, show);
   initialized = true;
 }
 

--- a/packages/webapp/src/ui/timestamp-preference.ts
+++ b/packages/webapp/src/ui/timestamp-preference.ts
@@ -22,17 +22,19 @@ function ensureTimestampStyle(doc: Document): void {
 }
 
 export function getShowTimestamps(): boolean {
+  if (typeof localStorage === 'undefined') return true;
   const stored = localStorage.getItem(STORAGE_KEY);
   if (stored === null) return true;
   return stored === 'true';
 }
 
 export function setShowTimestamps(show: boolean): void {
-  localStorage.setItem(STORAGE_KEY, String(show));
+  if (typeof localStorage !== 'undefined') localStorage.setItem(STORAGE_KEY, String(show));
   applyTimestampVisibility();
 }
 
 export function applyTimestampVisibility(override?: boolean): void {
+  if (typeof document === 'undefined') return;
   ensureTimestampStyle(document);
   const show = override !== undefined ? override : getShowTimestamps();
   document.documentElement.classList.toggle(CSS_CLASS, show);

--- a/packages/webapp/src/ui/timestamp-preference.ts
+++ b/packages/webapp/src/ui/timestamp-preference.ts
@@ -1,0 +1,50 @@
+const STORAGE_KEY = 'slicc_show_timestamps';
+const CSS_CLASS = 'slicc-show-timestamps';
+const STYLE_ID = 'slicc-timestamp-visibility';
+
+let initialized = false;
+
+function ensureTimestampStyle(doc: Document): void {
+  if (doc.getElementById(STYLE_ID)) return;
+  const style = doc.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = [
+    'slicc-user-message::part(timestamp),',
+    'slicc-agent-message .msg-ts {',
+    '  display: none;',
+    '}',
+    `.${CSS_CLASS} slicc-user-message::part(timestamp),`,
+    `.${CSS_CLASS} slicc-agent-message .msg-ts {`,
+    '  display: block;',
+    '}',
+  ].join('\n');
+  doc.head.appendChild(style);
+}
+
+export function getShowTimestamps(): boolean {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === null) return true;
+  return stored === 'true';
+}
+
+export function setShowTimestamps(show: boolean): void {
+  localStorage.setItem(STORAGE_KEY, String(show));
+  applyTimestampVisibility();
+}
+
+export function applyTimestampVisibility(): void {
+  ensureTimestampStyle(document);
+  document.documentElement.classList.toggle(CSS_CLASS, getShowTimestamps());
+  initialized = true;
+}
+
+export function initTimestampPreference(): void {
+  if (initialized) return;
+  applyTimestampVisibility();
+}
+
+export function formatMessageTimestamp(timestamp: number): string | null {
+  if (!timestamp) return null;
+  const d = new Date(timestamp);
+  return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}

--- a/packages/webapp/src/ui/timestamp-preference.ts
+++ b/packages/webapp/src/ui/timestamp-preference.ts
@@ -22,14 +22,16 @@ function ensureTimestampStyle(doc: Document): void {
 }
 
 export function getShowTimestamps(): boolean {
-  if (typeof localStorage === 'undefined') return true;
+  if (typeof localStorage === 'undefined' || typeof localStorage?.getItem !== 'function')
+    return true;
   const stored = localStorage.getItem(STORAGE_KEY);
   if (stored === null) return true;
   return stored === 'true';
 }
 
 export function setShowTimestamps(show: boolean): void {
-  if (typeof localStorage !== 'undefined') localStorage.setItem(STORAGE_KEY, String(show));
+  if (typeof localStorage !== 'undefined' && typeof localStorage?.setItem === 'function')
+    localStorage.setItem(STORAGE_KEY, String(show));
   applyTimestampVisibility();
 }
 

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -138,6 +138,7 @@ interface CherryFeatureSet {
   nav: boolean;
   newSprinkle: boolean;
   monitor: boolean;
+  showTimestamps: boolean;
 }
 
 /** All features enabled — the default for non-cherry followers. */
@@ -151,6 +152,7 @@ const ALL_FEATURES_ENABLED: CherryFeatureSet = {
   nav: true,
   newSprinkle: true,
   monitor: true,
+  showTimestamps: true,
 };
 
 /**
@@ -263,7 +265,9 @@ export async function mountWcUiFollower(
   if (cherryEffortLevel) localStorage.setItem('slicc_locked_effort_level', cherryEffortLevel);
   else localStorage.removeItem('slicc_locked_effort_level');
   const features: CherryFeatureSet =
-    isCherry && prelude.cherryTransport ? prelude.cherryTransport.features : ALL_FEATURES_ENABLED;
+    isCherry && prelude.cherryTransport
+      ? { ...ALL_FEATURES_ENABLED, ...prelude.cherryTransport.features }
+      : ALL_FEATURES_ENABLED;
   renderFollowerInertPanels(
     boot.refs.fileTree,
     boot.refs.termSurface,
@@ -272,6 +276,14 @@ export async function mountWcUiFollower(
     features
   );
   applyFeatureVisibility(features);
+
+  // Apply timestamp visibility: cherry embedders can force it off via features.
+  void import('../timestamp-preference.js').then(
+    ({ setShowTimestamps, initTimestampPreference }) => {
+      if (!features.showTimestamps) setShowTimestamps(false);
+      else initTimestampPreference();
+    }
+  );
 
   // Dip + sprinkle "chrome" styles (card backgrounds/borders, panel chrome) are
   // lazy legacy stylesheets — the leader loads `loadDipStyles` in `wc-live` and

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -278,9 +278,12 @@ export async function mountWcUiFollower(
   applyFeatureVisibility(features);
 
   // Apply timestamp visibility: cherry embedders can force it off via features.
+  // Use applyTimestampVisibility (transient class toggle) rather than
+  // setShowTimestamps (persists to localStorage) so the cherry flag doesn't
+  // leak into the user's standalone preference on the shared origin.
   void import('../timestamp-preference.js').then(
-    ({ setShowTimestamps, initTimestampPreference }) => {
-      if (!features.showTimestamps) setShowTimestamps(false);
+    ({ applyTimestampVisibility, initTimestampPreference }) => {
+      if (!features.showTimestamps) applyTimestampVisibility(false);
       else initTimestampPreference();
     }
   );

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1327,6 +1327,10 @@ export function attachWcClient(
   log: BootStageLogger,
   options: AttachWcClientOptions = {}
 ): void {
+  // Apply persisted timestamp visibility preference (both standalone + extension).
+  void import('../timestamp-preference.js')
+    .then(({ initTimestampPreference }) => initTimestampPreference())
+    .catch(() => undefined);
   const { refs } = boot;
   boot.setClient(client);
   // Turn-finished hooks: the suggested composer placeholder (assigned by

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -10,6 +10,7 @@ import { hasIcon, type SliccUserMessage } from '@slicc/webcomponents';
 import type { MessageAttachment } from '../../core/attachments.js';
 import { stripDictationMarkers } from '../../speech/dictation-priming.js';
 import { renderAssistantMessageContent, renderMessageContent } from '../message-renderer.js';
+import { formatMessageTimestamp } from '../timestamp-preference.js';
 import type { ChatMessage, ToolCall } from '../types.js';
 
 // Side-effect import registers every element this module instantiates.
@@ -456,6 +457,8 @@ function toolCallRow(call: ToolCall, msgId?: string): HTMLElement {
 
 function userMessageEl(message: ChatMessage): HTMLElement {
   const bubble = document.createElement('slicc-user-message');
+  const ts = formatMessageTimestamp(message.timestamp);
+  if (ts) bubble.setAttribute('timestamp', ts);
   // Dictated turns carry AI-only markers (🎙️ + the one-time ◁…▷ priming
   // note); the visible bubble must never show them. Stripping here keeps
   // the persisted `content` (what the agent sees on replay/compaction) and
@@ -613,6 +616,8 @@ export function buildClusterFromElements(
 function assistantMessageEls(message: ChatMessage): HTMLElement[] {
   const bubble = document.createElement('slicc-agent-message');
   bubble.setAttribute('data-msg-id', message.id);
+  const ts = formatMessageTimestamp(message.timestamp);
+  if (ts) bubble.setAttribute('timestamp', ts);
   if (message.isStreaming) bubble.setAttribute('streaming', '');
   bubble.setBodyHtml(renderAssistantMessageContent(message.content, message.isStreaming === true));
   // Empty / whitespace-only bubbles (e.g. message_start with no content

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -10,7 +10,12 @@ import { hasIcon, type SliccUserMessage } from '@slicc/webcomponents';
 import type { MessageAttachment } from '../../core/attachments.js';
 import { stripDictationMarkers } from '../../speech/dictation-priming.js';
 import { renderAssistantMessageContent, renderMessageContent } from '../message-renderer.js';
-import { formatMessageTimestamp } from '../timestamp-preference.js';
+import { formatMessageTimestamp, initTimestampPreference } from '../timestamp-preference.js';
+
+// Inject the timestamp visibility CSS synchronously before any messages render,
+// preventing a flash of unstyled timestamps on page load.
+initTimestampPreference();
+
 import type { ChatMessage, ToolCall } from '../types.js';
 
 // Side-effect import registers every element this module instantiates.

--- a/packages/webapp/src/ui/wc/wc-settings.ts
+++ b/packages/webapp/src/ui/wc/wc-settings.ts
@@ -24,6 +24,7 @@ import {
 import { PRESETS } from '../theme-presets.js';
 import type { SimplifiedSlots, SliccTheme, ThemeComponents } from '../theme-types.js';
 import { TOKEN_GROUPS } from '../theme-types.js';
+import { getShowTimestamps, setShowTimestamps } from '../timestamp-preference.js';
 
 type ProviderSettingsModule = typeof import('../provider-settings.js');
 
@@ -78,6 +79,9 @@ slicc-dialog.wcset-dialog::part(dialog){width:min(520px,92vw);}
 .wcset__base-toggle{display:flex;gap:4px;}
 .wcset__base-toggle button{font-size:11px;padding:3px 8px;border-radius:6px;border:1px solid var(--line);background:transparent;color:var(--txt-2);cursor:pointer;}
 .wcset__base-toggle button.active{background:var(--ink);color:var(--canvas);border-color:var(--ink);}
+.wcset__toggle-row{display:flex;align-items:center;justify-content:space-between;padding:8px 12px;border:1px solid var(--line);border-radius:10px;background:var(--canvas);}
+.wcset__toggle-row label{font-size:13px;font-weight:500;color:var(--ink);}
+.wcset__toggle-row input[type="checkbox"]{width:16px;height:16px;accent-color:var(--ctx);}
 `;
 
 function ensureSettingsStyle(doc: Document): void {
@@ -845,7 +849,20 @@ export async function showWcSettings(log: SettingsLogger): Promise<boolean> {
     };
     deps.renderList();
 
-    body.append(list, addSectionSlot, status);
+    // Chat preferences section
+    const chatSection = div('wcset__add');
+    chatSection.append(div('wcset__label', 'Chat'));
+    const tsRow = div('wcset__toggle-row');
+    const tsLabel = document.createElement('label');
+    tsLabel.textContent = 'Show timestamps';
+    const tsCheck = document.createElement('input');
+    tsCheck.type = 'checkbox';
+    tsCheck.checked = getShowTimestamps();
+    tsCheck.addEventListener('change', () => setShowTimestamps(tsCheck.checked));
+    tsRow.append(tsLabel, tsCheck);
+    chatSection.append(tsRow);
+
+    body.append(list, addSectionSlot, chatSection, status);
     dialog.append(body);
 
     const done = button('wcset__btn wcset__btn--primary', 'Done', () => {

--- a/packages/webcomponents/src/chat/slicc-agent-message.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-agent-message.stories.ts
@@ -287,3 +287,15 @@ export const States: Story = {
     return wrap;
   },
 };
+
+/** With a timestamp — a small HH:mm:ss label above the body. */
+export const WithTimestamp: Story = {
+  render: () => {
+    const el = buildMessage({});
+    el.setAttribute('timestamp', '14:32:15');
+    el.setBodyHtml(
+      '<p>Done — the hero is warmed up and the PR is open. Let me know if you want any tweaks.</p>'
+    );
+    return el;
+  },
+};

--- a/packages/webcomponents/src/chat/slicc-agent-message.ts
+++ b/packages/webcomponents/src/chat/slicc-agent-message.ts
@@ -21,6 +21,7 @@ import { h } from '../internal/dom.js';
  */
 const STYLE = `
 slicc-agent-message { display: block; margin-bottom: 18px; font-size: 15px; line-height: 1.5; --accent: color-mix(in srgb, var(--ctx) 55%, var(--ink)); }
+slicc-agent-message .msg-ts { font-family: var(--ui); font-size: 10px; color: var(--txt-3); opacity: .7; margin-bottom: 2px; font-variant-numeric: tabular-nums; }
 slicc-agent-message .body { font-family: var(--ui); font-size: 14px; }
 slicc-agent-message .body p { margin: 0 0 8px; }
 slicc-agent-message strong { font-weight: 600; color: var(--accent); }
@@ -164,7 +165,7 @@ function checkEl(items: readonly CheckItem[]): HTMLElement {
  * @fires slicc-agent-message-streaming - composed + bubbling; `detail.streaming` on state change
  */
 export class SliccAgentMessage extends HTMLElement {
-  static readonly observedAttributes = ['thinking', 'streaming', 'progress'];
+  static readonly observedAttributes = ['thinking', 'streaming', 'progress', 'timestamp'];
 
   #body!: HTMLElement;
   #think: HTMLElement | null = null;
@@ -298,6 +299,15 @@ export class SliccAgentMessage extends HTMLElement {
     const incoming = Array.from(this.childNodes).filter(
       (n) => !(n instanceof HTMLElement && n.classList.contains('body'))
     );
+
+    const ts = this.getAttribute('timestamp');
+    if (ts) {
+      const tsEl = this.ownerDocument.createElement('span');
+      tsEl.className = 'msg-ts';
+      tsEl.setAttribute('part', 'timestamp');
+      tsEl.textContent = ts;
+      this.appendChild(tsEl);
+    }
 
     this.#body = this.ownerDocument.createElement('div');
     this.#body.className = 'body';

--- a/packages/webcomponents/src/chat/slicc-agent-message.ts
+++ b/packages/webcomponents/src/chat/slicc-agent-message.ts
@@ -202,6 +202,8 @@ export class SliccAgentMessage extends HTMLElement {
           detail: { streaming: newValue !== null },
         })
       );
+    } else if (name === 'timestamp') {
+      this.#syncTimestamp();
     }
   }
 
@@ -376,6 +378,24 @@ export class SliccAgentMessage extends HTMLElement {
     } else if (this.#caret) {
       this.#caret.remove();
       this.#caret = null;
+    }
+  }
+
+  #syncTimestamp(): void {
+    const existing = this.querySelector('.msg-ts');
+    const ts = this.getAttribute('timestamp');
+    if (ts) {
+      if (existing) {
+        existing.textContent = ts;
+      } else {
+        const tsEl = this.ownerDocument.createElement('span');
+        tsEl.className = 'msg-ts';
+        tsEl.setAttribute('part', 'timestamp');
+        tsEl.textContent = ts;
+        this.insertBefore(tsEl, this.#body);
+      }
+    } else {
+      existing?.remove();
     }
   }
 }

--- a/packages/webcomponents/src/chat/slicc-user-message.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-user-message.stories.ts
@@ -230,3 +230,13 @@ export const Queued: Story = {
     return el;
   },
 };
+
+/** With a timestamp — a small HH:mm:ss label above the bubble. */
+export const WithTimestamp: Story = {
+  render: () => {
+    const el = document.createElement('slicc-user-message') as SliccUserMessage;
+    el.setAttribute('text', 'Warm up the landing hero and open a PR.');
+    el.setAttribute('timestamp', '14:32:07');
+    return el;
+  },
+};

--- a/packages/webcomponents/src/chat/slicc-user-message.ts
+++ b/packages/webcomponents/src/chat/slicc-user-message.ts
@@ -32,6 +32,7 @@ const STYLE = `
 :host([hidden]){display:none;}
 .msg{display:flex;justify-content:flex-end;}
 .stack{display:flex;flex-direction:column;align-items:flex-end;gap:6px;max-width:80%;}
+.ts{font-size:10px;color:var(--txt-3);opacity:.7;margin-bottom:2px;font-variant-numeric:tabular-nums;}
 .b{background:var(--deep);color:#fff;padding:10px 14px;border-radius:16px 16px 4px 16px;font-size:14px;max-width:100%;}
 :host-context(body.dark) .b,
 :host-context(.dark) .b,
@@ -129,7 +130,7 @@ function formatSize(bytes: number): string {
  * @slot - bubble content, used when neither `text` nor `setBodyHtml` is set
  */
 export class SliccUserMessage extends HTMLElement {
-  static readonly observedAttributes = ['text', 'queued'];
+  static readonly observedAttributes = ['text', 'queued', 'timestamp'];
 
   readonly #root: ShadowRoot;
   /** Rendered-markdown HTML for the bubble; wins over `text` / slot when set. */
@@ -231,6 +232,10 @@ export class SliccUserMessage extends HTMLElement {
     const showBubble = hasText || hasSlotted || !hasAttachments;
 
     const stack = h('div', { class: 'stack', part: 'stack' });
+    const ts = this.getAttribute('timestamp');
+    if (ts) {
+      stack.append(h('span', { class: 'ts', part: 'timestamp' }, ts));
+    }
     if (hasAttachments) {
       const list = h('div', { class: 'attachments', part: 'attachments' });
       for (const att of this.#attachments) list.append(this.#attachmentChip(att));

--- a/packages/webcomponents/tests/chat/slicc-agent-message.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-agent-message.test.ts
@@ -424,4 +424,35 @@ describe('slicc-agent-message', () => {
       expect(cs.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
     });
   });
+
+  describe('timestamp', () => {
+    it('renders a .msg-ts element when the timestamp attribute is set', () => {
+      const el = document.createElement('slicc-agent-message') as SliccAgentMessage;
+      el.setAttribute('timestamp', '14:32');
+      document.body.appendChild(el);
+      const ts = el.querySelector('.msg-ts');
+      expect(ts).not.toBeNull();
+      expect(ts?.textContent).toBe('14:32');
+    });
+
+    it('exposes a part="timestamp" hook', () => {
+      const el = document.createElement('slicc-agent-message') as SliccAgentMessage;
+      el.setAttribute('timestamp', '09:15');
+      document.body.appendChild(el);
+      expect(el.querySelector('[part="timestamp"]')).not.toBeNull();
+    });
+
+    it('does not render a timestamp when the attribute is absent', () => {
+      const el = mount();
+      expect(el.querySelector('.msg-ts')).toBeNull();
+    });
+
+    it('places the timestamp before the body', () => {
+      const el = document.createElement('slicc-agent-message') as SliccAgentMessage;
+      el.setAttribute('timestamp', '10:00');
+      document.body.appendChild(el);
+      const kids = Array.from(el.children).map((n) => n.className);
+      expect(kids.indexOf('msg-ts')).toBeLessThan(kids.indexOf('body'));
+    });
+  });
 });

--- a/packages/webcomponents/tests/chat/slicc-user-message.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-user-message.test.ts
@@ -257,3 +257,35 @@ describe('queued state', () => {
     expect(getComputedStyle(el.shadowRoot?.querySelector('.b') as Element).opacity).toBe('1');
   });
 });
+
+describe('timestamp', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    document.body.replaceChildren();
+  });
+
+  it('renders a .ts element when the timestamp attribute is set', () => {
+    const el = mount({ text: 'hello', timestamp: '14:32' });
+    const ts = el.shadowRoot?.querySelector('.ts');
+    expect(ts).not.toBeNull();
+    expect(ts?.textContent).toBe('14:32');
+  });
+
+  it('exposes a ::part(timestamp) hook', () => {
+    const el = mount({ text: 'parts', timestamp: '09:15' });
+    expect(el.shadowRoot?.querySelector('[part="timestamp"]')).not.toBeNull();
+  });
+
+  it('does not render a timestamp when the attribute is absent', () => {
+    const el = mount({ text: 'no time' });
+    expect(el.shadowRoot?.querySelector('.ts')).toBeNull();
+  });
+
+  it('places the timestamp before the bubble in the stack', () => {
+    const el = mount({ text: 'order', timestamp: '10:00' });
+    const stack = el.shadowRoot?.querySelector('.stack') as HTMLElement;
+    const kids = Array.from(stack.children).map((n) => n.className);
+    expect(kids[0]).toBe('ts');
+    expect(kids[1]).toBe('b');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds HH:mm:ss timestamps to both user and agent chat messages, shown by default
- Timestamps toggleable via Settings dialog ("Show timestamps" checkbox)
- Cherry embedders can control visibility via the `showTimestamps` feature flag in `mountSlicc()`

## Test plan
- [x] Webcomponents tests pass (1710 tests, 76 files)
- [x] Verified locally via `dev:standalone:fresh` — timestamps visible on messages
- [ ] Verify Settings toggle hides/shows timestamps
- [ ] Verify Cherry embed with `showTimestamps: false` hides timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)