### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -73,13 +73,13 @@
       "lines": 80,
       "statements": 79,
       "functions": 96,
-      "branches": 62
+      "branches": 63
     },
     "cloud-core": {
-      "lines": 80,
-      "statements": 78,
+      "lines": 81,
+      "statements": 79,
       "functions": 74,
-      "branches": 75
+      "branches": 76
     },
     "shared": {
       "lines": 94,


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.