### PR TITLE
fix(extension): stop duplicating the leader tab on Chrome restart

### DIFF
--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -56,13 +56,40 @@ Side-panel cockpit (sidepanel.html + sidepanel-entry.ts)
 
 ### Leader tab lifecycle
 
-The service worker keeps one pinned tab at the hosted leader URL.
-`reconcileLeaderTabOnBoot()` runs at top-level + `onStartup` +
-`onInstalled`, persists the tab id in `chrome.storage.session`, and
-re-creates the tab if it was closed. `chrome.action.onClicked` focuses
-the leader tab (creating it if missing). `tabs.onRemoved` clears the
-stored id when the user closes the leader tab; the next action click
-re-creates it.
+The service worker keeps one pinned tab at the hosted leader URL, but it does
+**not** create it on browser startup — the pinned tab is sticky, so Chrome
+restores it on restart. `ensureLeaderTab()` (adopt-or-create + dedup) runs **on
+demand**: the action-icon click opens the side panel, which connects a
+cherry-panel Port, and the SW ensures the leader tab on that Port's `hello`.
+`tabs.onRemoved` clears the stored id when the user closes the leader tab; the
+next icon click re-creates it. `reconcileLeaderTabOnBoot()` runs at top-level
+(SW-wake hygiene) to clear a stale stored id so it can't block a fresh leader.
+
+**Why no startup create (restart de-duplication).** `chrome.storage.session` is
+wiped on browser restart, and the startup trigger fires BEFORE Chrome's "Continue
+where you left off" finishes restoring the pinned leader tab. The old code
+created a leader tab on `onStartup`/`onInstalled`; that query found nothing (the
+tab hadn't restored yet) and spawned a **second** pinned tab. Because created
+leader tabs are pinned, each duplicate is itself restored next launch → **one
+extra leader tab per restart**. (A `setTimeout` poll is not a fix: an MV3 SW can
+be evicted mid-poll — this fooled an earlier attempt that only looked right
+because a CDP debugger kept the SW awake.) The fix is to simply **not create on
+startup at all** — Chrome restores the sticky pinned tab, and:
+
+- **Re-identification** after restart happens via the tab's own **bridge
+  connection**, not a startup query. `chrome.storage.session` no longer holds the
+  id, so `validateBridgePin` (`bridge-sw.ts`) SELF-ADOPTS: when no leader is
+  pinned yet, a **top-frame** connection from an **allowlisted origin** whose URL
+  carries **`?slicc=leader`** is accepted and its tab id persisted
+  (`writeStoredLeaderTabId`). The restored leader thus re-pins itself the moment
+  it boots and connects — no race, no polling.
+- **Creation + dedup** happen on the **icon click** (`ensureLeaderTab` →
+  keep-one/close-extras, or create if none). This also heals any pre-fix pile:
+  the next icon click collapses it to one. `ensureLeaderTab` is serialized by
+  `leaderTabLock` and shared by the cherry-panel connect and cherry-recovery.
+
+Net: a restart can never duplicate the tab (nothing creates on startup), and the
+restored tab stays fully functional (self-adopt re-pins its bridge).
 
 ### Tray leader / multi-browser sync
 

--- a/packages/chrome-extension/src/bridge-sw.ts
+++ b/packages/chrome-extension/src/bridge-sw.ts
@@ -60,6 +60,10 @@ export const BRIDGE_DEV_ORIGINS: readonly string[] = [
 export interface BridgeSwDeps {
   /** Resolve the storage-pinned leader tab id, or `undefined` if unset. */
   readStoredLeaderTabId: () => Promise<number | undefined>;
+  /** Persist the leader tab id. Called by the pin's self-adopt path when no
+   *  leader is pinned yet (e.g. after a browser restart wiped storage.session)
+   *  and the connecting top-frame tab is the leader page (`?slicc=leader`). */
+  writeStoredLeaderTabId?: (tabId: number) => Promise<void>;
   /** Unmask whole-token secret fields in outbound CDP frames against the
    *  target tab's CURRENT hostname. Reuses the existing
    *  `maybeUnmaskCdpFrame` in service-worker.ts. */
@@ -116,17 +120,37 @@ export interface PinResult {
   reason?: string;
 }
 
+/** True when a bridge sender's top-frame URL is the leader page (`?slicc=leader`).
+ *  Used by the pin's self-adopt path — the origin is already allowlist-checked,
+ *  so requiring `slicc=leader` authenticates the connector as the leader page (a
+ *  sibling tab on the same origin can't forge its own top-frame URL). */
+function senderUrlIsLeaderTab(rawUrl: string | undefined): boolean {
+  if (!rawUrl) return false;
+  try {
+    return new URL(rawUrl).searchParams.get('slicc') === 'leader';
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Three-factor pin check. Pure function (modulo the async storage read in
  * `deps.readStoredLeaderTabId`) so unit tests can drive it directly.
  *
  *   1. origin ∈ allowlist
- *   2. sender.tab.id === storedLeaderTabId  (key absent → fail closed)
+ *   2. sender.tab.id === storedLeaderTabId
  *   3. sender.frameId === 0
+ *
+ * SELF-ADOPT: when no leader is pinned yet (storage.session is wiped on browser
+ * restart, so the restored leader tab has no stored id), a top-frame connection
+ * from an allowlisted origin whose URL carries `?slicc=leader` IS the restored
+ * leader — adopt it (persist its tab id) and accept. This is how the leader
+ * re-identifies itself after a restart without the SW recreating the tab. If the
+ * connector isn't a leader-URL page, fail closed.
  */
 export async function validateBridgePin(
   sender: ChromeMessageSender | undefined,
-  deps: Pick<BridgeSwDeps, 'readStoredLeaderTabId' | 'allowedOrigins'>
+  deps: Pick<BridgeSwDeps, 'readStoredLeaderTabId' | 'writeStoredLeaderTabId' | 'allowedOrigins'>
 ): Promise<PinResult> {
   const allowed = deps.allowedOrigins ?? BRIDGE_ALLOWED_ORIGINS;
   if (!sender) return { ok: false, reason: 'no-sender' };
@@ -142,8 +166,11 @@ export async function validateBridgePin(
   }
   const storedTabId = await deps.readStoredLeaderTabId();
   if (storedTabId === undefined) {
-    // The sibling leader-tab task owns the storage key. Absent → fail
-    // closed: we don't know which tab is "the leader" yet.
+    // No leader pinned yet. Self-adopt IF this is the leader page.
+    if (senderUrlIsLeaderTab(sender.url) && deps.writeStoredLeaderTabId) {
+      await deps.writeStoredLeaderTabId(senderTabId);
+      return { ok: true };
+    }
     return { ok: false, reason: 'leader-tab-not-pinned' };
   }
   if (storedTabId !== senderTabId) {
@@ -245,6 +272,15 @@ export async function readStoredLeaderTabIdFromSession(): Promise<number | undef
   }
 }
 
+/** Default `writeStoredLeaderTabId` — the write half of the pin's self-adopt. */
+export async function writeStoredLeaderTabIdToSession(tabId: number): Promise<void> {
+  try {
+    await chrome.storage.session.set({ [LEADER_TAB_ID_KEY]: tabId });
+  } catch {
+    /* storage unavailable; self-adopt is best-effort */
+  }
+}
+
 /**
  * Default deps wired against the real chrome.* APIs. Provided as a factory
  * so the SW can override `attachDebugger` / `detachDebugger` etc. to share
@@ -253,6 +289,7 @@ export async function readStoredLeaderTabIdFromSession(): Promise<number | undef
 export function buildDefaultBridgeSwDeps(overrides?: Partial<BridgeSwDeps>): BridgeSwDeps {
   const base: BridgeSwDeps = {
     readStoredLeaderTabId: readStoredLeaderTabIdFromSession,
+    writeStoredLeaderTabId: writeStoredLeaderTabIdToSession,
     maybeUnmaskCdpFrame: async (_tabId, _method, params) => params,
     attachDebugger: async (tabId) => {
       await chrome.debugger.attach({ tabId }, '1.3');

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -202,75 +202,86 @@ async function reconcileLeaderTabOnBoot(): Promise<void> {
   await clearStoredLeaderTabId();
 }
 
-// Serialize concurrent ensureLeaderTab() calls so multiple lifecycle
-// triggers (top-level + onStartup + onInstalled) firing in quick
-// succession can't race past the storage check and create duplicate
-// pinned tabs.
+// Serialize concurrent ensureLeaderTab() calls (action-icon click + cherry-panel
+// recovery can fire together) so they can't race past the query and create
+// duplicate pinned tabs.
 let leaderTabLock: Promise<void> | null = null;
 
-/**
- * Adopt a restored leader tab if Chrome's "Continue where you left off" — or the
- * dev harness's command-line launch — left one open. storage.session is wiped on
- * restart but the tab itself may still be open; claim it instead of spawning a
- * duplicate. An adopted tab may (a) lack the `ext=` param the page needs to open
- * the bridge Port and (b) be unpinned (Chrome restores a pinned leader as
- * pinned, but the harness opens it as a plain tab). Reload with `ext=` baked in
- * (tabs.update keeps the same id, so the three-factor pin stays valid) AND pin
- * it, so an adopted leader honors the same pinned-in-background invariant as a
- * freshly created one — skipping tabs.update entirely when ext= is already
- * correct and the tab is already pinned. Returns true if a tab was adopted.
- */
-async function tryAdoptRestoredLeaderTab(): Promise<boolean> {
-  let restored: ChromeTab | undefined;
+/** Query every open tab that is a valid leader tab (origin + `slicc=leader`). */
+async function queryLeaderTabs(): Promise<ChromeTab[]> {
   try {
     const matches = await chrome.tabs.query({ url: LEADER_TAB_URL_GLOB });
-    restored = matches.find((t) => isLeaderTabUrl(t.url) && t.id !== undefined);
+    return matches.filter((t) => isLeaderTabUrl(t.url) && t.id !== undefined);
   } catch (err) {
     console.error('[slicc-sw] tabs.query for leader tab failed', err);
-    return false;
+    return [];
   }
-  if (!restored || restored.id === undefined) return false;
+}
+
+/**
+ * Ensure EXACTLY ONE pinned leader tab exists, keeping/adopting one and closing
+ * any duplicates, and creating one only when none is open.
+ *
+ * This runs ON DEMAND — from the action-icon click (which opens the side panel
+ * and connects the cherry-panel Port) and cherry-panel recovery — NOT on browser
+ * startup. The pinned leader tab is sticky: Chrome restores it on restart, so
+ * there is nothing to create then. Creating on `onStartup`/`onInstalled` is what
+ * used to RACE session-restore and spawn a duplicate every launch (the tab is
+ * restored a moment after the SW's startup query ran and found nothing). By only
+ * ensuring on the user's icon click, restart can never duplicate the tab. The
+ * restored tab re-identifies itself to the SW via its bridge connection (see
+ * `validateBridgePin` self-adopt), so it doesn't need the SW to find it on boot.
+ *
+ * Adoption bakes in the `ext=` param the page needs to open the bridge Port and
+ * pins the tab, matching a freshly-created leader; the `tabs.update` is skipped
+ * when the kept tab is already correct.
+ */
+/** Create a fresh pinned leader tab and store its id. */
+async function createLeaderTab(): Promise<void> {
+  const created = await chrome.tabs.create({
+    url: appendLeaderExtIdParam(LEADER_TAB_URL, chrome.runtime.id),
+    active: false,
+    pinned: true,
+  });
+  if (created.id !== undefined) await writeStoredLeaderTabId(created.id);
+}
+
+/** Keep the first leader tab (stamp `ext=` + pin if needed, store its id) and
+ *  close every duplicate. `matches` must be non-empty. */
+async function adoptSingleLeaderTab(matches: ChromeTab[]): Promise<void> {
+  const [keep, ...extras] = matches;
+  if (keep.id === undefined) return;
+
+  for (const extra of extras) {
+    if (extra.id === undefined || extra.id === keep.id) continue;
+    try {
+      await chrome.tabs.remove(extra.id);
+    } catch (err) {
+      console.error('[slicc-sw] failed to close duplicate leader tab', err);
+    }
+  }
 
   const extIdUrl =
-    restored.url !== undefined &&
+    keep.url !== undefined &&
     chrome.runtime.id !== undefined &&
-    !leaderUrlHasExtId(restored.url, chrome.runtime.id)
-      ? appendLeaderExtIdParam(restored.url, chrome.runtime.id)
+    !leaderUrlHasExtId(keep.url, chrome.runtime.id)
+      ? appendLeaderExtIdParam(keep.url, chrome.runtime.id)
       : undefined;
-  if (extIdUrl !== undefined || restored.pinned !== true) {
+  if (extIdUrl !== undefined || keep.pinned !== true) {
     const props: { pinned: true; url?: string } = { pinned: true };
     if (extIdUrl !== undefined) props.url = extIdUrl;
-    await chrome.tabs.update(restored.id, props);
+    await chrome.tabs.update(keep.id, props);
   }
-  await writeStoredLeaderTabId(restored.id);
-  return true;
+  await writeStoredLeaderTabId(keep.id);
 }
 
 async function ensureLeaderTab(): Promise<void> {
   if (leaderTabLock) return leaderTabLock;
   leaderTabLock = (async () => {
     try {
-      const storedId = await readStoredLeaderTabId();
-      if (storedId !== undefined) {
-        try {
-          const tab = await chrome.tabs.get(storedId);
-          if (isLeaderTabUrl(tab.url)) return;
-        } catch {
-          // fall through to recovery
-        }
-        await clearStoredLeaderTabId();
-      }
-
-      if (await tryAdoptRestoredLeaderTab()) return;
-
-      const created = await chrome.tabs.create({
-        url: appendLeaderExtIdParam(LEADER_TAB_URL, chrome.runtime.id),
-        active: false,
-        pinned: true,
-      });
-      if (created.id !== undefined) {
-        await writeStoredLeaderTabId(created.id);
-      }
+      const matches = await queryLeaderTabs();
+      if (matches.length === 0) await createLeaderTab();
+      else await adoptSingleLeaderTab(matches);
     } finally {
       leaderTabLock = null;
     }
@@ -289,10 +300,14 @@ async function reloadLeaderTabIfExists(): Promise<boolean> {
   }
 }
 
-// Top-level: reconcile only (defensive cleanup on SW eviction recovery).
-// `ensureLeaderTab` is intentionally NOT called here — that path runs from
-// the lifecycle listeners below, so MV3 SW recycles within a session don't
-// keep recreating the leader tab.
+// Top-level: reconcile the STORED id only (clear it if the stored tab is gone),
+// so a stale id from a crashed/navigated leader doesn't block the bridge's
+// self-adopt of a fresh one. We deliberately DO NOT create a leader tab on
+// startup: the pinned tab is sticky and Chrome restores it on restart, so
+// creating here only races session-restore and spawns a duplicate. The restored
+// tab re-pins itself via its bridge connection (`validateBridgePin` self-adopt);
+// a missing leader is (re)created on the next action-icon click. There are no
+// `onStartup` / `onInstalled` leader-tab listeners for this reason.
 reconcileLeaderTabOnBoot().catch((err) => {
   console.error('[slicc-sw] reconcile leader tab failed', err);
 });
@@ -306,18 +321,6 @@ chrome.sidePanel
 // Let the panel state machine recover a dead tray by reloading the leader tab,
 // even when no panel is open (so a background leader isn't silently broken).
 setCherryPanelRecoveryDeps({ reloadLeaderTabIfExists });
-
-chrome.runtime.onStartup.addListener(() => {
-  reconcileLeaderTabOnBoot()
-    .then(() => ensureLeaderTab())
-    .catch(() => {});
-});
-
-chrome.runtime.onInstalled.addListener(() => {
-  reconcileLeaderTabOnBoot()
-    .then(() => ensureLeaderTab())
-    .catch(() => {});
-});
 
 async function handleLeaderTabRemoved(tabId: number): Promise<void> {
   const storedId = await readStoredLeaderTabId();
@@ -1210,6 +1213,7 @@ chrome.runtime.onConnectExternal.addListener((port: ChromeRuntimePort) => {
     const pipelinePromise = (async () => {
       const pin = await validateBridgePin(port.sender, {
         readStoredLeaderTabId: bridgeSwDeps.readStoredLeaderTabId,
+        writeStoredLeaderTabId: bridgeSwDeps.writeStoredLeaderTabId,
         allowedOrigins: bridgeSwDeps.allowedOrigins,
       });
       if (!pin.ok) throw new Error(`fetch-proxy pin failed: ${pin.reason ?? 'pin-failed'}`);
@@ -1231,6 +1235,7 @@ chrome.runtime.onConnectExternal.addListener((port: ChromeRuntimePort) => {
     // the async pin read completes). Mirrors the fetch-proxy branch above.
     const pinPromise = validateBridgePin(port.sender, {
       readStoredLeaderTabId: bridgeSwDeps.readStoredLeaderTabId,
+      writeStoredLeaderTabId: bridgeSwDeps.writeStoredLeaderTabId,
       allowedOrigins: bridgeSwDeps.allowedOrigins,
     });
     pinPromise.catch((err) => {
@@ -1271,6 +1276,7 @@ chrome.runtime.onConnectExternal.addListener((port: ChromeRuntimePort) => {
     // INSIDE the handler. Mirrors the secrets.crud branch above (EXT8).
     const pinPromise = validateBridgePin(port.sender, {
       readStoredLeaderTabId: bridgeSwDeps.readStoredLeaderTabId,
+      writeStoredLeaderTabId: bridgeSwDeps.writeStoredLeaderTabId,
       allowedOrigins: bridgeSwDeps.allowedOrigins,
     });
     pinPromise.catch((err) => {

--- a/packages/chrome-extension/tests/bridge-sw.test.ts
+++ b/packages/chrome-extension/tests/bridge-sw.test.ts
@@ -108,8 +108,49 @@ describe('validateBridgePin', () => {
     expect(r.ok).toBe(true);
   });
 
-  it('rejects when the storage key is absent (fail closed)', async () => {
+  it('rejects when the storage key is absent and the sender is not a leader-URL page (fail closed)', async () => {
+    // goodSender has no ?slicc=leader url → not self-adoptable.
     const r = await validateBridgePin(goodSender as never, {
+      readStoredLeaderTabId: async () => undefined,
+    });
+    expect(r).toEqual({ ok: false, reason: 'leader-tab-not-pinned' });
+  });
+
+  it('self-adopts the connecting leader tab when no leader is pinned yet (restart recovery)', async () => {
+    // storage.session is wiped on browser restart, so the restored leader tab
+    // has no stored id. A top-frame, allowlisted-origin, ?slicc=leader connector
+    // IS the leader — adopt it (persist the tab id) and accept.
+    let written: number | undefined;
+    const leaderSender = {
+      ...goodSender,
+      url: 'https://www.sliccy.ai/?slicc=leader&ext=abc',
+    };
+    const r = await validateBridgePin(leaderSender as never, {
+      readStoredLeaderTabId: async () => undefined,
+      writeStoredLeaderTabId: async (id) => {
+        written = id;
+      },
+    });
+    expect(r.ok).toBe(true);
+    expect(written).toBe(42);
+  });
+
+  it('does NOT self-adopt a same-origin top-frame tab that is not the leader page', async () => {
+    let written: number | undefined;
+    const nonLeaderSender = { ...goodSender, url: 'https://www.sliccy.ai/some/other/page' };
+    const r = await validateBridgePin(nonLeaderSender as never, {
+      readStoredLeaderTabId: async () => undefined,
+      writeStoredLeaderTabId: async (id) => {
+        written = id;
+      },
+    });
+    expect(r).toEqual({ ok: false, reason: 'leader-tab-not-pinned' });
+    expect(written).toBeUndefined();
+  });
+
+  it('does not self-adopt when no writeStoredLeaderTabId dep is provided', async () => {
+    const leaderSender = { ...goodSender, url: 'https://www.sliccy.ai/?slicc=leader' };
+    const r = await validateBridgePin(leaderSender as never, {
       readStoredLeaderTabId: async () => undefined,
     });
     expect(r).toEqual({ ok: false, reason: 'leader-tab-not-pinned' });

--- a/packages/chrome-extension/tests/service-worker-leader-tab.test.ts
+++ b/packages/chrome-extension/tests/service-worker-leader-tab.test.ts
@@ -24,6 +24,16 @@ const tabsRemoved: number[] = [];
 
 const onStartupListeners: Array<() => void> = [];
 const onInstalledListeners: Array<() => void> = [];
+const onCreatedListeners: Array<(tab: { id?: number; url?: string; pinned?: boolean }) => void> =
+  [];
+const onUpdatedListeners: Array<(tabId: number, changeInfo: { url?: string }) => void> = [];
+
+/** A tabs.query({url}) glob like `https://www.sliccy.ai/*` → prefix match. */
+function globMatches(glob: string | undefined, url: string | undefined): boolean {
+  if (!glob) return true;
+  const prefix = glob.endsWith('*') ? glob.slice(0, -1) : glob;
+  return (url ?? '').startsWith(prefix);
+}
 const onMessageListeners: Array<
   (
     msg: unknown,
@@ -75,10 +85,23 @@ const mockChrome = {
       tabsStore.delete(id);
       tabsRemoved.push(id);
     }),
-    query: vi.fn(async (_filter: { url?: string }) => [] as Array<{ id?: number; url?: string }>),
+    // Reflect the tab store so reconcile sees the real open tabs (as production
+    // chrome.tabs.query does), not a hardcoded []. Individual tests still
+    // override this when they need a specific/lazy result.
+    query: vi.fn(async (filter: { url?: string }) =>
+      [...tabsStore.values()].filter((t) => globMatches(filter?.url, t.url))
+    ),
     group: vi.fn(async () => 1),
-    onCreated: { addListener: vi.fn() },
-    onUpdated: { addListener: vi.fn() },
+    onCreated: {
+      addListener: (cb: (typeof onCreatedListeners)[number]) => {
+        onCreatedListeners.push(cb);
+      },
+    },
+    onUpdated: {
+      addListener: (cb: (typeof onUpdatedListeners)[number]) => {
+        onUpdatedListeners.push(cb);
+      },
+    },
     onRemoved: {
       addListener: (cb: (typeof tabsRemovedListeners)[number]) => {
         tabsRemovedListeners.push(cb);
@@ -174,6 +197,8 @@ function resetMocks(): void {
   tabsRemoved.length = 0;
   onStartupListeners.length = 0;
   onInstalledListeners.length = 0;
+  onCreatedListeners.length = 0;
+  onUpdatedListeners.length = 0;
   onMessageListeners.length = 0;
   actionClickListeners.length = 0;
   tabsRemovedListeners.length = 0;
@@ -186,7 +211,8 @@ function resetMocks(): void {
     if (typeof fn === 'function' && 'mockClear' in fn) (fn as { mockClear(): void }).mockClear();
   }
   (mockChrome.tabs.query as ReturnType<typeof vi.fn>).mockImplementation(
-    async (_filter: { url?: string }) => [] as Array<{ id?: number; url?: string }>
+    async (filter: { url?: string }) =>
+      [...tabsStore.values()].filter((t) => globMatches(filter?.url, t.url))
   );
 }
 
@@ -195,6 +221,27 @@ async function loadSw(): Promise<void> {
   await import('../src/service-worker.js');
   // Allow the top-level reconcile…OnBoot() promises to settle.
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** Count leader tabs currently in the mock tab store. */
+function leaderTabCount(): number {
+  return [...tabsStore.values()].filter(
+    (t) =>
+      (t.url ?? '').startsWith('https://www.sliccy.ai/') && (t.url ?? '').includes('slicc=leader')
+  ).length;
+}
+
+/**
+ * Drive `ensureLeaderTab` the way production does — via the action-icon click,
+ * which opens the side panel and connects a cherry-panel Port; the SW ensures
+ * (adopts/dedups/creates) the leader tab on that Port's `hello`. There are no
+ * `onStartup`/`onInstalled` leader-tab triggers anymore.
+ */
+async function fireIconClick(windowId = 1): Promise<void> {
+  const port = fakePanelPort();
+  for (const cb of onConnectListeners) cb(port);
+  port._rx({ kind: 'hello', windowId });
+  await new Promise((r) => setTimeout(r, 20));
 }
 
 async function fireOnStartup(): Promise<void> {
@@ -260,14 +307,28 @@ describe('leader tab — boot reconciliation', () => {
   });
 });
 
-describe('leader tab — ensure on lifecycle events', () => {
+describe('leader tab — ensure on demand (icon click), never on startup', () => {
   beforeEach(() => {
     resetMocks();
   });
 
-  it('creates a pinned leader tab on onInstalled when none exists', async () => {
+  it('does NOT auto-create a leader tab on browser startup (no onStartup/onInstalled trigger)', async () => {
+    // The pinned tab is sticky — Chrome restores it on restart, so creating on
+    // startup only races session-restore and spawns a duplicate. The extension
+    // registers NO leader-tab startup listeners; firing them is a no-op.
     await loadSw();
+    expect(onStartupListeners).toHaveLength(0);
+    expect(onInstalledListeners).toHaveLength(0);
+    await fireOnStartup();
     await fireOnInstalled();
+    expect(mockChrome.tabs.create).not.toHaveBeenCalled();
+    expect(sessionStorage.has(LEADER_KEY)).toBe(false);
+  });
+
+  it('creates a pinned leader tab on icon click when none is open', async () => {
+    await loadSw();
+    mockChrome.tabs.create.mockClear();
+    await fireIconClick();
 
     expect(mockChrome.tabs.create).toHaveBeenCalledWith({
       url: LEADER_URL_WITH_EXT,
@@ -279,46 +340,41 @@ describe('leader tab — ensure on lifecycle events', () => {
     expect(tabsStore.has(storedId)).toBe(true);
   });
 
-  it('creates a pinned leader tab on onStartup when none exists', async () => {
-    await loadSw();
-    await fireOnStartup();
-
-    expect(mockChrome.tabs.create).toHaveBeenCalledWith({
-      url: LEADER_URL_WITH_EXT,
-      active: false,
-      pinned: true,
-    });
-    expect(sessionStorage.has(LEADER_KEY)).toBe(true);
-  });
-
-  it('adopts a Chrome-restored leader tab instead of spawning a duplicate', async () => {
-    // Browser restart with "Continue where you left off": storage.session is
-    // wiped, but the previous pinned sliccy.ai tab is restored. The SW must
-    // adopt that tab id rather than create a second pinned tab.
+  it('adopts an existing leader tab on icon click instead of creating a duplicate', async () => {
+    // The pinned tab was restored by Chrome; the icon click adopts it (stamps
+    // ext=, pins, stores id) rather than spawning a second one.
     tabsStore.set(7, { id: 7, windowId: 100, url: LEADER_URL });
-    (mockChrome.tabs.query as ReturnType<typeof vi.fn>).mockImplementation(
-      async (_filter: { url?: string }) => [{ id: 7, url: LEADER_URL }]
-    );
-
     await loadSw();
-    await fireOnStartup();
+    mockChrome.tabs.create.mockClear();
+    await fireIconClick();
 
     expect(mockChrome.tabs.create).not.toHaveBeenCalled();
     expect(sessionStorage.get(LEADER_KEY)).toBe(7);
   });
 
-  it('reloads + pins an adopted leader tab that lacks ext= so the page can open the bridge Port', async () => {
-    // The restored tab matched isLeaderTabUrl (origin + slicc=leader) but has
-    // no ext= param, so chrome.runtime.connect could never wire the bridge.
-    // The SW must tabs.update it with ext= baked in (preserving the tab id)
-    // AND pin it, rather than leaving a dead / unpinned leader tab.
-    tabsStore.set(8, { id: 8, windowId: 100, url: LEADER_URL, pinned: false });
-    (mockChrome.tabs.query as ReturnType<typeof vi.fn>).mockImplementation(
-      async (_filter: { url?: string }) => [{ id: 8, url: LEADER_URL, pinned: false }]
-    );
-
+  it('dedups multiple leader tabs down to one on icon click (heals prior accumulation)', async () => {
+    // A user who already accumulated pinned leader tabs (pre-fix) converges back
+    // to one the next time they click the icon: keep the first, close the rest.
+    for (const id of [4, 5, 6]) {
+      tabsStore.set(id, { id, windowId: 100, url: LEADER_URL_WITH_EXT, pinned: true });
+    }
     await loadSw();
-    await fireOnStartup();
+    mockChrome.tabs.create.mockClear();
+    await fireIconClick();
+
+    expect(mockChrome.tabs.create).not.toHaveBeenCalled();
+    expect(mockChrome.tabs.remove).toHaveBeenCalledWith(5);
+    expect(mockChrome.tabs.remove).toHaveBeenCalledWith(6);
+    expect(mockChrome.tabs.remove).not.toHaveBeenCalledWith(4);
+    expect(leaderTabCount()).toBe(1);
+    expect(sessionStorage.get(LEADER_KEY)).toBe(4);
+  });
+
+  it('reloads + pins an adopted leader tab that lacks ext= so the page can open the bridge Port', async () => {
+    tabsStore.set(8, { id: 8, windowId: 100, url: LEADER_URL, pinned: false });
+    await loadSw();
+    mockChrome.tabs.create.mockClear();
+    await fireIconClick();
 
     expect(mockChrome.tabs.create).not.toHaveBeenCalled();
     expect(mockChrome.tabs.update).toHaveBeenCalledWith(8, {
@@ -329,16 +385,10 @@ describe('leader tab — ensure on lifecycle events', () => {
   });
 
   it('pins an adopted leader tab that already has ext= but is unpinned (no reload)', async () => {
-    // Harness case: Chrome opens the leader from the command line (ext= already
-    // present via the dev build) as a plain, unpinned tab. The SW must pin it —
-    // without reloading, since ext= is already correct.
     tabsStore.set(12, { id: 12, windowId: 100, url: LEADER_URL_WITH_EXT, pinned: false });
-    (mockChrome.tabs.query as ReturnType<typeof vi.fn>).mockImplementation(
-      async (_filter: { url?: string }) => [{ id: 12, url: LEADER_URL_WITH_EXT, pinned: false }]
-    );
-
     await loadSw();
-    await fireOnStartup();
+    mockChrome.tabs.create.mockClear();
+    await fireIconClick();
 
     expect(mockChrome.tabs.create).not.toHaveBeenCalled();
     expect(mockChrome.tabs.update).toHaveBeenCalledWith(12, { pinned: true });
@@ -346,38 +396,23 @@ describe('leader tab — ensure on lifecycle events', () => {
   });
 
   it('does NOT touch an adopted leader tab that already carries ext= and is pinned', async () => {
-    // No needless reload/pin when the restored tab is already fully correct.
     tabsStore.set(9, { id: 9, windowId: 100, url: LEADER_URL_WITH_EXT, pinned: true });
-    (mockChrome.tabs.query as ReturnType<typeof vi.fn>).mockImplementation(
-      async (_filter: { url?: string }) => [{ id: 9, url: LEADER_URL_WITH_EXT, pinned: true }]
-    );
-
     await loadSw();
-    await fireOnStartup();
+    mockChrome.tabs.create.mockClear();
+    mockChrome.tabs.update.mockClear();
+    await fireIconClick();
 
     expect(mockChrome.tabs.create).not.toHaveBeenCalled();
     expect(mockChrome.tabs.update).not.toHaveBeenCalled();
     expect(sessionStorage.get(LEADER_KEY)).toBe(9);
   });
 
-  it('does not create a duplicate when the stored leader tab is already alive', async () => {
-    sessionStorage.set(LEADER_KEY, 11);
-    tabsStore.set(11, { id: 11, windowId: 100, url: LEADER_URL });
-
-    await loadSw();
-    await fireOnInstalled();
-
-    expect(mockChrome.tabs.create).not.toHaveBeenCalled();
-    expect(sessionStorage.get(LEADER_KEY)).toBe(11);
-  });
-
-  it('re-creates after the stored tab has been removed and lifecycle fires again', async () => {
-    sessionStorage.set(LEADER_KEY, 3);
+  it('re-creates the leader tab on icon click after the user closed it', async () => {
     tabsStore.set(3, { id: 3, windowId: 100, url: LEADER_URL });
-
+    sessionStorage.set(LEADER_KEY, 3);
     await loadSw();
 
-    // User closes the leader tab.
+    // User closes the leader tab → onRemoved clears the stored id.
     tabsStore.delete(3);
     for (const cb of tabsRemovedListeners) {
       cb(3, { windowId: 100, isWindowClosing: false });
@@ -385,8 +420,9 @@ describe('leader tab — ensure on lifecycle events', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(sessionStorage.has(LEADER_KEY)).toBe(false);
 
-    // Browser restart → onStartup fires → ensure brings the tab back.
-    await fireOnStartup();
+    // Next icon click brings it back.
+    mockChrome.tabs.create.mockClear();
+    await fireIconClick();
     expect(mockChrome.tabs.create).toHaveBeenCalledWith({
       url: LEADER_URL_WITH_EXT,
       active: false,


### PR DESCRIPTION
## Problem

Every Chrome restart added another pinned SLICC leader tab (3 restarts → 3 tabs), accumulating without bound. Very bad for users.

## Root cause

The pinned leader tab is **sticky** — Chrome restores it on browser restart — but the service worker *also* created one on `onStartup`/`onInstalled`. `chrome.storage.session` (the leader tab id) is wiped on restart, and the startup trigger fires **before** Chrome finishes restoring the tab, so the create query found nothing and spawned a **second** pinned tab. Being pinned, each duplicate was itself restored next launch → one extra tab per restart.

## Fix

**Don't create on startup at all.** Chrome restores the sticky pinned tab; nothing on our side needs to recreate it.

- **Re-identification after restart** happens via the tab's own **bridge connection**, not a startup query. `validateBridgePin` (`bridge-sw.ts`) now **self-adopts**: when no leader is pinned yet (post-restart), a **top-frame** connection from an **allowlisted origin** whose URL is **`?slicc=leader`** is accepted and its tab id persisted. The restored leader re-pins itself the moment it boots — no race, no polling.
- **Creation + dedup** happen only on the **action-icon click** (`ensureLeaderTab` → adopt-or-create + close duplicates, via the side-panel/cherry-panel connect). This also heals any pre-fix pile on the next click.

Compensating controls on the self-adopt path: origin allowlist + top-frame (`frameId === 0`) + the `?slicc=leader` URL check.

### Why not a wait/poll or tab-event dedup
Both were tried and rejected: an MV3 service worker is **evicted mid-poll** (a `setTimeout` wait doesn't keep it alive), and background *discarded* restored tabs don't reliably fire `tabs.onCreated`/`onUpdated`. Not creating on startup sidesteps the timing problem entirely.

## Changes
- `service-worker.ts`: remove the `onStartup`/`onInstalled` leader-tab create; `ensureLeaderTab` = adopt-or-create + dedup, run only on the icon-click / cherry-recovery paths.
- `bridge-sw.ts`: `validateBridgePin` self-adopt (+ `writeStoredLeaderTabId` dep).
- Tests: drive ensure via the icon-click path; assert no startup create; add bridge self-adopt + dedup coverage.
- Docs: `chrome-extension/CLAUDE.md` leader-tab section rewritten.

## Verification
Unit: 541 chrome-extension tests pass (incl. new self-adopt, dedup, and no-startup-create cases).

Live (Chrome for Testing): install → **0 tabs** (no auto-create); create/icon-click → **1**, leader id stored (self-adopt); restart ×N → **stays 1**, leader id re-pinned each launch. Pre-fix code reproduced 2/2/3 duplicates in the same harness.

Gates green: typecheck, lint:ci, deadcode, build:extension. Extension-SW-only (no cross-runtime parity impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)