### PR TITLE
Fix async leader rollback in performTrayLeave

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -789,6 +789,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -806,6 +809,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -823,6 +829,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -840,6 +849,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1956,7 +1968,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2072,6 +2084,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2087,6 +2102,9 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2104,6 +2122,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2120,6 +2141,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2135,6 +2159,9 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6045,6 +6072,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6062,6 +6092,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6079,6 +6112,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6096,6 +6132,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6113,6 +6152,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6130,6 +6172,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,7 +1968,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2084,9 +2084,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2102,9 +2099,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2122,9 +2116,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2141,9 +2132,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2159,9 +2147,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6072,9 +6057,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6092,9 +6074,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6112,9 +6091,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6132,9 +6108,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6152,9 +6125,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6172,9 +6142,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -789,9 +789,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -809,9 +806,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -829,9 +823,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -849,9 +840,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [

--- a/packages/webapp/src/ui/page-leader-tray.ts
+++ b/packages/webapp/src/ui/page-leader-tray.ts
@@ -138,6 +138,15 @@ export interface PageLeaderTrayHandle {
   /** Stop the tray, peer manager, sync manager, and all periodic refreshes. */
   stop(): void;
   /**
+   * Resolves with the {@link LeaderTraySession} once the leader has
+   * connected to the tray worker. Rejects when `leader.start()` fails
+   * (timeout, auth, network). Derived from the same `start()` call —
+   * no double invocation. Boot-path consumers that ignore `ready` see
+   * unchanged behavior: the existing `.catch(log.error)` fires on a
+   * separate branch, preventing unhandled rejections.
+   */
+  readonly ready: Promise<LeaderTraySession>;
+  /**
    * Reset the tray session (used by the `host reset` shell command).
    * Stops the leader, clears its persisted session, starts a new one,
    * and updates the URL bar. Returns the post-reset runtime status.
@@ -460,24 +469,24 @@ export function startPageLeaderTray(options: StartPageLeaderTrayOptions): PageLe
   void refreshLeaderTargets();
   intervals.push(scheduleListBroadcasts(sync, refreshIntervalMs));
 
-  // Kick off the leader connection.
-  void leader
-    .start()
-    .then((session) => {
-      updateUrlBar(session);
-    })
-    .catch((err) => {
-      // `error`, not `warn` — initial leader-tray start failure means
-      // multi-browser sync never came up at all. Prod log gate is ERROR,
-      // so a `warn` here would leave operators with no signal that the
-      // user's tray-leader configuration silently failed to activate.
-      log.error('Leader tray start failed', {
-        error: err instanceof Error ? err.message : String(err),
-      });
+  // Kick off the leader connection. The promise is shared between the
+  // `ready` handle field (for callers that need to await connection) and
+  // a fire-and-forget branch that logs failures so boot-path consumers
+  // that ignore `ready` see unchanged behavior (no unhandled rejection).
+  const startResult = leader.start();
+  void startResult.then(updateUrlBar).catch((err) => {
+    // `error`, not `warn` — initial leader-tray start failure means
+    // multi-browser sync never came up at all. Prod log gate is ERROR,
+    // so a `warn` here would leave operators with no signal that the
+    // user's tray-leader configuration silently failed to activate.
+    log.error('Leader tray start failed', {
+      error: err instanceof Error ? err.message : String(err),
     });
+  });
 
   let stopped = false;
   return {
+    ready: startResult,
     stop() {
       stopped = true;
       unsubscribeAgent();

--- a/packages/webapp/src/ui/tray-leave-runtime.ts
+++ b/packages/webapp/src/ui/tray-leave-runtime.ts
@@ -195,7 +195,11 @@ export async function performTrayLeave<TLeaderHandle extends TrayLeaveReadyHandl
     await newHandle.ready;
   } catch (err) {
     // Async failure: tear down the partially-started leader and
-    // roll back to fully-dormant state.
+    // roll back to fully-dormant state. Guard against reentrancy:
+    // a concurrent `performTrayLeave` call may have already replaced
+    // the leader during our await window — only roll back if the
+    // current leader is still the handle we installed.
+    const stillOurs = deps.getLeader() === newHandle;
     try {
       newHandle.stop();
     } catch (stopErr) {
@@ -207,19 +211,21 @@ export async function performTrayLeave<TLeaderHandle extends TrayLeaveReadyHandl
         }
       );
     }
-    deps.setLeader(null);
-    deps.clearLeaderHooks();
+    if (stillOurs) {
+      deps.setLeader(null);
+      deps.clearLeaderHooks();
+      writeStorage(
+        () => deps.storage.removeItem(TRAY_WORKER_STORAGE_KEY),
+        deps.log,
+        'worker-clear-on-async-failure',
+        requestId
+      );
+    }
     deps.log.error('Leader ready failed during tray-leave — runtime is now dormant', {
       workerBaseUrl: newWorkerBaseUrl,
       requestId,
       error: err instanceof Error ? err.message : String(err),
     });
-    writeStorage(
-      () => deps.storage.removeItem(TRAY_WORKER_STORAGE_KEY),
-      deps.log,
-      'worker-clear-on-async-failure',
-      requestId
-    );
     throw err;
   }
 

--- a/packages/webapp/src/ui/tray-leave-runtime.ts
+++ b/packages/webapp/src/ui/tray-leave-runtime.ts
@@ -99,7 +99,7 @@ export interface PerformTrayLeaveOptions {
  * dormant", so the rethrow surfaces to the caller as "stop succeeded,
  * restart failed" rather than "tray is left in a half-state".
  */
-export async function performTrayLeave<TLeaderHandle extends TrayLeaveStoppable>(
+export async function performTrayLeave<TLeaderHandle extends TrayLeaveReadyHandle>(
   opts: PerformTrayLeaveOptions,
   deps: TrayLeaveDeps<TLeaderHandle>
 ): Promise<TrayLeaveResult> {

--- a/packages/webapp/src/ui/tray-leave-runtime.ts
+++ b/packages/webapp/src/ui/tray-leave-runtime.ts
@@ -6,10 +6,12 @@
  * getters / setters / callbacks so this file is unit-testable.
  *
  * Storage update order is load-bearing: the leader-restart branch
- * writes storage AFTER `startLeader` resolves so a failed startup
- * leaves the runtime fully dormant (both keys cleared) instead of
- * persisting a stale leader-on-failed-worker config that the next
- * page reload would try to revive.
+ * writes `TRAY_WORKER_STORAGE_KEY` only AFTER the leader's `ready`
+ * promise resolves, so both synchronous throws from `startLeader` and
+ * asynchronous failures (timeout, auth, WebRTC init) leave the
+ * runtime fully dormant (both keys cleared) instead of persisting a
+ * stale leader-on-failed-worker config that the next page reload
+ * would try to revive.
  */
 
 import type { TrayLeaveResult } from '../scoops/tray-leave.js';
@@ -35,7 +37,16 @@ export interface TrayLeaveStoppable {
   stop(): void;
 }
 
-export interface TrayLeaveDeps<TLeaderHandle extends TrayLeaveStoppable> {
+/**
+ * Extended handle for leader restarts — adds a `ready` signal so
+ * `performTrayLeave` can await actual connection before persisting.
+ */
+export interface TrayLeaveReadyHandle extends TrayLeaveStoppable {
+  /** Resolves when the leader has connected; rejects on failure. */
+  readonly ready: Promise<unknown>;
+}
+
+export interface TrayLeaveDeps<TLeaderHandle extends TrayLeaveReadyHandle> {
   /** Read the current leader handle. Returns `null` when not a leader. */
   getLeader(): TLeaderHandle | null;
   /** Replace the leader handle reference (used to null on stop / set after restart). */
@@ -46,8 +57,9 @@ export interface TrayLeaveDeps<TLeaderHandle extends TrayLeaveStoppable> {
   setFollower(handle: TrayLeaveStoppable | null): void;
   /**
    * Start a fresh leader tray on the given worker. Returns the new
-   * handle on success; throws on failure (auth, network, WebRTC init,
-   * etc.) — the executor catches and rolls back storage.
+   * handle synchronously; the handle's `ready` promise resolves once
+   * the leader has connected. Synchronous throws and async `ready`
+   * rejections are both caught and rolled back by the executor.
    */
   startLeader(workerBaseUrl: string): TLeaderHandle;
   /** Clear callbacks the orchestrator exposes for follower count / reset. */
@@ -147,10 +159,11 @@ export async function performTrayLeave<TLeaderHandle extends TrayLeaveStoppable>
     return { kind: 'left', previousMode };
   }
 
-  // Leader-restart branch: storage write happens AFTER the start
-  // succeeds. If start throws, we roll back to fully-dormant storage
-  // so the next page reload doesn't try to revive a stale leader on
-  // the failed worker.
+  // Leader-restart branch: storage write happens AFTER the leader's
+  // `ready` promise resolves. Both synchronous throws from
+  // `startLeader` and asynchronous failures roll back to
+  // fully-dormant storage so the next page reload doesn't try to
+  // revive a stale leader on a dead worker.
   const newWorkerBaseUrl = opts.workerBaseUrl;
   let newHandle: TLeaderHandle;
   try {
@@ -170,8 +183,46 @@ export async function performTrayLeave<TLeaderHandle extends TrayLeaveStoppable>
     throw err;
   }
 
+  // Install the handle so the leader can function during connection
+  // (receive signaling, set up peers). Undone on async failure below.
   deps.setLeader(newHandle);
   deps.wireLeaderHooks(newHandle);
+
+  // Await readiness — leader.start() already has its own connect
+  // timeout (LEADER_TRAY_CONNECT_TIMEOUT_MS = 10s), so no extra
+  // race is needed here.
+  try {
+    await newHandle.ready;
+  } catch (err) {
+    // Async failure: tear down the partially-started leader and
+    // roll back to fully-dormant state.
+    try {
+      newHandle.stop();
+    } catch (stopErr) {
+      deps.log.error(
+        'Leader stop threw during async-failure rollback — resources may have leaked',
+        {
+          requestId,
+          error: stopErr instanceof Error ? stopErr.message : String(stopErr),
+        }
+      );
+    }
+    deps.setLeader(null);
+    deps.clearLeaderHooks();
+    deps.log.error('Leader ready failed during tray-leave — runtime is now dormant', {
+      workerBaseUrl: newWorkerBaseUrl,
+      requestId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    writeStorage(
+      () => deps.storage.removeItem(TRAY_WORKER_STORAGE_KEY),
+      deps.log,
+      'worker-clear-on-async-failure',
+      requestId
+    );
+    throw err;
+  }
+
   writeStorage(
     () => deps.storage.setItem(TRAY_WORKER_STORAGE_KEY, newWorkerBaseUrl),
     deps.log,

--- a/packages/webapp/src/ui/tray-leave-runtime.ts
+++ b/packages/webapp/src/ui/tray-leave-runtime.ts
@@ -194,39 +194,24 @@ export async function performTrayLeave<TLeaderHandle extends TrayLeaveReadyHandl
   try {
     await newHandle.ready;
   } catch (err) {
-    // Async failure: tear down the partially-started leader and
-    // roll back to fully-dormant state. Guard against reentrancy:
-    // a concurrent `performTrayLeave` call may have already replaced
-    // the leader during our await window — only roll back if the
-    // current leader is still the handle we installed.
-    const stillOurs = deps.getLeader() === newHandle;
-    try {
-      newHandle.stop();
-    } catch (stopErr) {
-      deps.log.error(
-        'Leader stop threw during async-failure rollback — resources may have leaked',
-        {
-          requestId,
-          error: stopErr instanceof Error ? stopErr.message : String(stopErr),
-        }
-      );
-    }
-    if (stillOurs) {
-      deps.setLeader(null);
-      deps.clearLeaderHooks();
-      writeStorage(
-        () => deps.storage.removeItem(TRAY_WORKER_STORAGE_KEY),
-        deps.log,
-        'worker-clear-on-async-failure',
-        requestId
-      );
-    }
-    deps.log.error('Leader ready failed during tray-leave — runtime is now dormant', {
+    rollbackAfterReadyFailure(newHandle, deps, err, newWorkerBaseUrl, requestId);
+    throw err;
+  }
+
+  // Success-path reentrancy guard, mirroring the failure path: a
+  // concurrent call may have replaced (switch) or stopped (leave) this
+  // leader during the await window — that call now owns runtime state
+  // AND storage. Writing our worker URL here would resurrect a leader
+  // the user just left/replaced on the next reload (the exact stale-
+  // persisted-state class this executor exists to prevent). Skip the
+  // write; report `switched` because this call's switch did succeed —
+  // final state belongs to the superseding call.
+  if (deps.getLeader() !== newHandle) {
+    deps.log.error('Leader superseded during connect — skipping storage write', {
       workerBaseUrl: newWorkerBaseUrl,
       requestId,
-      error: err instanceof Error ? err.message : String(err),
     });
-    throw err;
+    return { kind: 'switched', previousMode, workerBaseUrl: newWorkerBaseUrl };
   }
 
   writeStorage(
@@ -237,6 +222,47 @@ export async function performTrayLeave<TLeaderHandle extends TrayLeaveReadyHandl
   );
 
   return { kind: 'switched', previousMode, workerBaseUrl: newWorkerBaseUrl };
+}
+
+/**
+ * Async-failure rollback for the leader-restart branch: tear down the
+ * partially-started leader and roll back to fully-dormant state. Guards
+ * against reentrancy — a concurrent `performTrayLeave` call may have
+ * already replaced the leader during the await window, in which case
+ * only the failed handle is stopped and the superseding call's
+ * leader/hooks/storage are left untouched.
+ */
+function rollbackAfterReadyFailure<TLeaderHandle extends TrayLeaveReadyHandle>(
+  newHandle: TLeaderHandle,
+  deps: TrayLeaveDeps<TLeaderHandle>,
+  err: unknown,
+  newWorkerBaseUrl: string,
+  requestId: string | undefined
+): void {
+  const stillOurs = deps.getLeader() === newHandle;
+  try {
+    newHandle.stop();
+  } catch (stopErr) {
+    deps.log.error('Leader stop threw during async-failure rollback — resources may have leaked', {
+      requestId,
+      error: stopErr instanceof Error ? stopErr.message : String(stopErr),
+    });
+  }
+  if (stillOurs) {
+    deps.setLeader(null);
+    deps.clearLeaderHooks();
+    writeStorage(
+      () => deps.storage.removeItem(TRAY_WORKER_STORAGE_KEY),
+      deps.log,
+      'worker-clear-on-async-failure',
+      requestId
+    );
+  }
+  deps.log.error('Leader ready failed during tray-leave — runtime is now dormant', {
+    workerBaseUrl: newWorkerBaseUrl,
+    requestId,
+    error: err instanceof Error ? err.message : String(err),
+  });
 }
 
 /**

--- a/packages/webapp/tests/ui/page-leader-tray.test.ts
+++ b/packages/webapp/tests/ui/page-leader-tray.test.ts
@@ -405,6 +405,46 @@ describe('startPageLeaderTray', () => {
     expect(syncStop).toHaveBeenCalledOnce();
   });
 
+  it('ready resolves with the session on successful start', async () => {
+    const { fetchImpl, webSocketFactory, sockets } = makeLeaderFetch();
+    const handle = startPageLeaderTray(makeBaseOptions({ fetchImpl, webSocketFactory, store }));
+
+    await vi.waitFor(() => expect(sockets.length).toBeGreaterThan(0));
+    sockets[0].dispatch('open', {});
+    sockets[0].dispatch('message', { data: JSON.stringify({ type: 'leader.connected' }) });
+
+    const session = await handle.ready;
+    expect(session.trayId).toBe('tray-1');
+    expect(session.controllerId).toBe('ctrl-1');
+
+    handle.stop();
+  });
+
+  it('ready rejects on start failure and the log-on-error branch still fires', async () => {
+    // Provide a fetch that always rejects to simulate a network failure.
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error('network down'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const handle = startPageLeaderTray(makeBaseOptions({ fetchImpl, store }));
+
+      // ready should reject
+      await expect(handle.ready).rejects.toThrow(/network down/);
+
+      // The fire-and-forget branch should also have logged the error
+      await vi.waitFor(() =>
+        expect(
+          errorSpy.mock.calls.some((args) =>
+            String(args[1] ?? '').includes('Leader tray start failed')
+          )
+        ).toBe(true)
+      );
+
+      handle.stop();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('threads onRemoteTransportsCleaned into the sync manager', () => {
     const { fetchImpl, webSocketFactory } = makeLeaderFetch();
     const onRemoteTransportsCleaned = vi.fn();

--- a/packages/webapp/tests/ui/tray-leave-runtime.test.ts
+++ b/packages/webapp/tests/ui/tray-leave-runtime.test.ts
@@ -280,6 +280,122 @@ describe('performTrayLeave', () => {
     });
   });
 
+  describe('async ready failure recovery', () => {
+    it('rolls storage back to fully-dormant when ready rejects', async () => {
+      const readyError = new Error('worker down');
+      const oldLeader = makeHandle('L1');
+      const newLeader = makeHandle('L2', { ready: Promise.reject(readyError) });
+      // Suppress unhandled rejection from the test promise
+      newLeader.ready.catch(() => {});
+      const state: DepsState<RecordingHandle> = {
+        leader: oldLeader,
+        follower: null,
+        hooksWired: [],
+        hooksCleared: 0,
+        startLeaderCalls: [],
+        startLeaderImpl: () => newLeader,
+        storage: makeStorage({
+          [TRAY_JOIN_STORAGE_KEY]: 'https://x/join/abc',
+          [TRAY_WORKER_STORAGE_KEY]: 'https://x',
+        }),
+        log: makeLog(),
+      };
+      await expect(
+        performTrayLeave({ workerBaseUrl: 'https://bad.example' }, makeDeps(state))
+      ).rejects.toThrow(/worker down/);
+      // Critical: storage MUST NOT point at the failed URL.
+      expect(state.storage.data.has(TRAY_JOIN_STORAGE_KEY)).toBe(false);
+      expect(state.storage.data.has(TRAY_WORKER_STORAGE_KEY)).toBe(false);
+      // New handle was stopped during rollback.
+      expect(newLeader.stopCalls).toBe(1);
+      // Leader ref was reset to null.
+      expect(state.leader).toBeNull();
+      // Hooks were wired then cleared on failure.
+      expect(state.hooksWired).toEqual([newLeader]);
+      expect(state.hooksCleared).toBe(2); // initial + rollback
+      // Failure was logged.
+      expect(
+        state.log.errors.some((e) => /Leader ready failed/.test(e.message))
+      ).toBe(true);
+    });
+
+    it('writes storage only after ready resolves (ordering)', async () => {
+      const events: string[] = [];
+      let resolveReady!: (v: unknown) => void;
+      const readyPromise = new Promise((resolve) => {
+        resolveReady = resolve;
+      });
+      const newLeader = makeHandle('L2', { ready: readyPromise });
+      const storage = makeStorage();
+      const originalSetItem = storage.setItem;
+      storage.setItem = (k, v) => {
+        events.push(`setItem:${k}`);
+        originalSetItem.call(storage, k, v);
+      };
+      const state: DepsState<RecordingHandle> = {
+        leader: null,
+        follower: null,
+        hooksWired: [],
+        hooksCleared: 0,
+        startLeaderCalls: [],
+        startLeaderImpl: () => {
+          events.push('startLeader');
+          return newLeader;
+        },
+        storage,
+        log: makeLog(),
+      };
+      const resultPromise = performTrayLeave(
+        { workerBaseUrl: 'https://new.example' },
+        makeDeps(state)
+      );
+      // Storage must NOT have been written yet.
+      expect(state.storage.data.has(TRAY_WORKER_STORAGE_KEY)).toBe(false);
+      expect(events).toEqual(['startLeader']);
+      // Resolve ready.
+      resolveReady({ trayId: 'ok' });
+      await resultPromise;
+      // NOW storage is written.
+      expect(state.storage.data.get(TRAY_WORKER_STORAGE_KEY)).toBe(
+        'https://new.example'
+      );
+      expect(events).toEqual([
+        'startLeader',
+        `setItem:${TRAY_WORKER_STORAGE_KEY}`,
+      ]);
+    });
+
+    it('logs stop-throw during async-failure rollback without hiding the original error', async () => {
+      const readyError = new Error('auth rejected');
+      const newLeader = makeHandle('L2', {
+        ready: Promise.reject(readyError),
+        throwOnStop: true,
+      });
+      newLeader.ready.catch(() => {});
+      const state: DepsState<RecordingHandle> = {
+        leader: null,
+        follower: null,
+        hooksWired: [],
+        hooksCleared: 0,
+        startLeaderCalls: [],
+        startLeaderImpl: () => newLeader,
+        storage: makeStorage(),
+        log: makeLog(),
+      };
+      // The original ready error should be rethrown, not the stop error.
+      await expect(
+        performTrayLeave({ workerBaseUrl: 'https://x' }, makeDeps(state))
+      ).rejects.toThrow(/auth rejected/);
+      // Both the stop-throw and the ready failure should be logged.
+      expect(
+        state.log.errors.some((e) => /async-failure rollback/.test(e.message))
+      ).toBe(true);
+      expect(
+        state.log.errors.some((e) => /Leader ready failed/.test(e.message))
+      ).toBe(true);
+    });
+  });
+
   describe('half-state failure recovery (startLeader throws)', () => {
     it('rolls storage back to fully-dormant when startLeader rejects', async () => {
       const oldLeader = makeHandle('L1');

--- a/packages/webapp/tests/ui/tray-leave-runtime.test.ts
+++ b/packages/webapp/tests/ui/tray-leave-runtime.test.ts
@@ -358,6 +358,48 @@ describe('performTrayLeave', () => {
       expect(events).toEqual(['startLeader', `setItem:${TRAY_WORKER_STORAGE_KEY}`]);
     });
 
+    it('skips leader/hooks rollback when a concurrent call replaced the leader', async () => {
+      let resolveReadyA!: (v: unknown) => void;
+      let rejectReadyA!: (e: Error) => void;
+      const readyA = new Promise((resolve, reject) => {
+        resolveReadyA = resolve;
+        rejectReadyA = reject;
+      });
+      const handleA = makeHandle('A', { ready: readyA });
+      readyA.catch(() => {}); // suppress unhandled rejection
+
+      const handleB = makeHandle('B');
+
+      const state: DepsState<RecordingHandle> = {
+        leader: null,
+        follower: null,
+        hooksWired: [],
+        hooksCleared: 0,
+        startLeaderCalls: [],
+        startLeaderImpl: () => handleA,
+        storage: makeStorage(),
+        log: makeLog(),
+      };
+      const deps = makeDeps(state);
+
+      // Start call A — it will await handleA.ready
+      const callA = performTrayLeave({ workerBaseUrl: 'https://A' }, deps);
+
+      // Simulate call B arriving before A resolves: replace the leader
+      state.leader = handleB;
+      state.hooksCleared = 0; // reset counter
+
+      // Now fail A's ready
+      rejectReadyA(new Error('A timed out'));
+      await expect(callA).rejects.toThrow(/A timed out/);
+
+      // handleA was stopped (always), but leader/hooks/storage were
+      // NOT rolled back because the leader is no longer handleA.
+      expect(handleA.stopCalls).toBe(1);
+      expect(state.leader).toBe(handleB); // NOT null
+      expect(state.hooksCleared).toBe(0); // NOT cleared
+    });
+
     it('logs stop-throw during async-failure rollback without hiding the original error', async () => {
       const readyError = new Error('auth rejected');
       const newLeader = makeHandle('L2', {

--- a/packages/webapp/tests/ui/tray-leave-runtime.test.ts
+++ b/packages/webapp/tests/ui/tray-leave-runtime.test.ts
@@ -314,9 +314,7 @@ describe('performTrayLeave', () => {
       expect(state.hooksWired).toEqual([newLeader]);
       expect(state.hooksCleared).toBe(2); // initial + rollback
       // Failure was logged.
-      expect(
-        state.log.errors.some((e) => /Leader ready failed/.test(e.message))
-      ).toBe(true);
+      expect(state.log.errors.some((e) => /Leader ready failed/.test(e.message))).toBe(true);
     });
 
     it('writes storage only after ready resolves (ordering)', async () => {
@@ -356,13 +354,8 @@ describe('performTrayLeave', () => {
       resolveReady({ trayId: 'ok' });
       await resultPromise;
       // NOW storage is written.
-      expect(state.storage.data.get(TRAY_WORKER_STORAGE_KEY)).toBe(
-        'https://new.example'
-      );
-      expect(events).toEqual([
-        'startLeader',
-        `setItem:${TRAY_WORKER_STORAGE_KEY}`,
-      ]);
+      expect(state.storage.data.get(TRAY_WORKER_STORAGE_KEY)).toBe('https://new.example');
+      expect(events).toEqual(['startLeader', `setItem:${TRAY_WORKER_STORAGE_KEY}`]);
     });
 
     it('logs stop-throw during async-failure rollback without hiding the original error', async () => {
@@ -387,12 +380,8 @@ describe('performTrayLeave', () => {
         performTrayLeave({ workerBaseUrl: 'https://x' }, makeDeps(state))
       ).rejects.toThrow(/auth rejected/);
       // Both the stop-throw and the ready failure should be logged.
-      expect(
-        state.log.errors.some((e) => /async-failure rollback/.test(e.message))
-      ).toBe(true);
-      expect(
-        state.log.errors.some((e) => /Leader ready failed/.test(e.message))
-      ).toBe(true);
+      expect(state.log.errors.some((e) => /async-failure rollback/.test(e.message))).toBe(true);
+      expect(state.log.errors.some((e) => /Leader ready failed/.test(e.message))).toBe(true);
     });
   });
 

--- a/packages/webapp/tests/ui/tray-leave-runtime.test.ts
+++ b/packages/webapp/tests/ui/tray-leave-runtime.test.ts
@@ -400,6 +400,52 @@ describe('performTrayLeave', () => {
       expect(state.hooksCleared).toBe(0); // NOT cleared
     });
 
+    it('skips the storage write when ready resolves after a concurrent call took over', async () => {
+      // Scenario: "switch to A" then "Stop" (leave entirely) inside the
+      // connect window, with A's connect racing the stop and resolving.
+      // A must NOT write TRAY_WORKER_STORAGE_KEY — that would resurrect
+      // a leader the user explicitly stopped on the next reload.
+      let resolveReadyA!: (v: unknown) => void;
+      const readyA = new Promise((resolve) => {
+        resolveReadyA = resolve;
+      });
+      const handleA = makeHandle('A', { ready: readyA });
+
+      const state: DepsState<RecordingHandle> = {
+        leader: null,
+        follower: null,
+        hooksWired: [],
+        hooksCleared: 0,
+        startLeaderCalls: [],
+        startLeaderImpl: () => handleA,
+        storage: makeStorage(),
+        log: makeLog(),
+      };
+      const deps = makeDeps(state);
+
+      // Call A starts switching and awaits handleA.ready.
+      const callA = performTrayLeave({ workerBaseUrl: 'https://A' }, deps);
+
+      // Call B (leave entirely) completes during A's await window: it
+      // stopped handleA, nulled the leader, and cleared storage.
+      const callB = performTrayLeave({ workerBaseUrl: null }, deps);
+      await callB;
+      expect(state.leader).toBeNull();
+      expect(state.storage.data.has(TRAY_WORKER_STORAGE_KEY)).toBe(false);
+
+      // A's connect nonetheless resolves (raced the stop).
+      resolveReadyA({ trayId: 'A' });
+      const resultA = await callA;
+
+      // A's switch did happen, but storage must stay dormant — the
+      // superseding leave owns final state.
+      expect(resultA.kind).toBe('switched');
+      expect(state.storage.data.has(TRAY_WORKER_STORAGE_KEY)).toBe(false);
+      expect(state.leader).toBeNull();
+      // The supersession was logged.
+      expect(state.log.errors.some((e) => /superseded during connect/.test(e.message))).toBe(true);
+    });
+
     it('logs stop-throw during async-failure rollback without hiding the original error', async () => {
       const readyError = new Error('auth rejected');
       const newLeader = makeHandle('L2', {

--- a/packages/webapp/tests/ui/tray-leave-runtime.test.ts
+++ b/packages/webapp/tests/ui/tray-leave-runtime.test.ts
@@ -6,21 +6,27 @@ import {
 import {
   performTrayLeave,
   type TrayLeaveDeps,
+  type TrayLeaveReadyHandle,
   type TrayLeaveStoppable,
 } from '../../src/ui/tray-leave-runtime.js';
 
-interface RecordingHandle extends TrayLeaveStoppable {
+interface RecordingHandle extends TrayLeaveReadyHandle {
   id: string;
   stopCalls: number;
+  ready: Promise<unknown>;
 }
 
-function makeHandle(id: string, throwOnStop = false): RecordingHandle {
+function makeHandle(
+  id: string,
+  opts?: { throwOnStop?: boolean; ready?: Promise<unknown> }
+): RecordingHandle {
   const handle: RecordingHandle = {
     id,
     stopCalls: 0,
+    ready: opts?.ready ?? Promise.resolve({ trayId: 'test' }),
     stop() {
       this.stopCalls += 1;
-      if (throwOnStop) throw new Error(`${id} stop boom`);
+      if (opts?.throwOnStop) throw new Error(`${id} stop boom`);
     },
   };
   return handle;
@@ -311,7 +317,7 @@ describe('performTrayLeave', () => {
 
   describe('teardown error handling', () => {
     it('logs leader.stop() throws via deps.log and continues with the follower stop', async () => {
-      const leader = makeHandle('L1', true /* throwOnStop */);
+      const leader = makeHandle('L1', { throwOnStop: true });
       const follower = makeHandle('F1');
       const state: DepsState<RecordingHandle> = {
         leader,


### PR DESCRIPTION
Fixes #1387

## Problem

When `performTrayLeave` switches trays, it calls `startLeader(url)` which returns a handle synchronously while `leader.start()` runs fire-and-forget. If the async connection fails (worker down, auth rejected, WebRTC init failure), storage is already persisted pointing at the dead worker — the next page reload tries to revive a leader that can never start.

## Solution

### 1. Add `ready` promise to `PageLeaderTrayHandle`

Exposed on the handle, derived from the same `leader.start()` call (no double invocation). A separate fire-and-forget branch keeps the existing `.catch(log.error)` so boot-path consumers that ignore `ready` see unchanged behavior with no unhandled rejections.

### 2. Await `ready` before persisting storage

`performTrayLeave`'s leader-restart branch now:
- Installs the handle immediately (`setLeader` + `wireLeaderHooks`) so the leader can function during connection
- Awaits `handle.ready` — the leader's own connect timeout (10s, `LEADER_TRAY_CONNECT_TIMEOUT_MS`) bounds it; no extra race needed
- Only writes `TRAY_WORKER_STORAGE_KEY` after `ready` resolves
- On rejection: stops the handle, nulls the leader, clears hooks, removes storage keys, logs, and rethrows

### 3. Type changes

Added `TrayLeaveReadyHandle extends TrayLeaveStoppable` with a `ready: Promise<unknown>` field. Updated `TrayLeaveDeps` generic constraint. All existing call sites (`wc-tray.ts`, `setup-standalone-panel-rpc.ts`, `host-command.ts`) compile against the widened type since `PageLeaderTrayHandle` now satisfies `TrayLeaveReadyHandle`.

## Tests

- **`tray-leave-runtime.test.ts`**: async `ready` rejection → both keys removed, handle stopped, hooks cleared, error rethrown; async success → storage written only after resolution (ordering via deferred promise); stop-throw during rollback logs but surfaces the original error
- **`page-leader-tray.test.ts`**: `ready` resolves with session on success; rejects on start failure while the log-on-error branch still fires

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅ (zero errors, all 9 tsc targets)
- Targeted vitest (23 tests passing) ✅
- `npm run test:coverage:webapp` gate ✅ (exit 0)