### PR TITLE
fix(adobe): enable thinking for Sonnet 5 and fix effort level mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,12 +269,13 @@ Run the full pre-push/PR pass — `lint` (always first; the most common CI failu
 
 Automated reviewers — the Claude action (`.github/workflows/claude-pr-review.yml`), Codex (via `AGENTS.md` → this file), and Copilot (`.github/copilot-instructions.md`) — plus human reviewers check changed code against these recurring blind spots. Full catalog with trigger patterns, verified historical precedents, the five-runtime parity matrix, and the severity rubric: [`docs/review-patterns.md`](docs/review-patterns.md).
 
-1. **Error-path coverage** — external calls (`fetch`, `Sandbox.create`/`connect`) need timeouts/retries/`.catch`; bound every async operation (precedent: PR #779).
-2. **UI state preservation** — capture and restore live UI state around `innerHTML`/`replaceChildren` and reflow/navigation rebuilds (PR #566/#567).
-3. **Cross-runtime parity** — a change to one of `webapp`/`chrome-extension`/`node-server`/`swift-server`/`ios-app` usually needs the peers updated or an explicit "N/A" note (PR #565; see the parity matrix).
-4. **CDP edge cases** — foreground the page (`bringToFront`) before screenshots; validate the CDP target/port before trusting it (PR #361, #673).
-5. **Native/macOS permissions** — keychain/TCC/screen-recording need the right entitlements and graceful denial handling.
-6. **Test coverage** — source changes ship with mirrored `tests/`; bug fixes ship a regression test; keep coverage at/above the package floor.
-7. **Agent skill freshness** — new/changed shell commands must update the matching `vfs-root/workspace/skills/*/SKILL.md`.
+1. **Error-path coverage** — external calls need timeouts/retries/`.catch`; bound every async operation (PR #779).
+2. **UI state preservation** — capture and restore live UI state around DOM rebuilds (PR #566/#567).
+3. **Cross-runtime parity** — changes to one runtime usually need peers updated or an explicit "N/A" note (PR #565; see the parity matrix).
+4. **CDP edge cases** — foreground before screenshots; validate CDP target/port (PR #361, #673).
+5. **Native/macOS permissions** — keychain/TCC/screen-recording need entitlements and graceful denial handling.
+6. **Model metadata / provider pipeline** — new models or pi-ai bumps: verify metadata forwarding, version predicates, thinking levels, and costs; see `docs/pitfalls.md` checklist (PR #1399).
+7. **Test coverage** — source changes ship with mirrored `tests/`; bug fixes ship a regression test; keep coverage at/above the floor.
+8. **Agent skill freshness** — shell command changes must update the matching `vfs-root/workspace/skills/*/SKILL.md`.
 
 When you change a category, update `docs/review-patterns.md` (source of truth) and the ≤4,000-char `.github/copilot-instructions.md` so all reviewers stay in sync.

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -994,20 +994,92 @@ that touched LLM call paths, a new code path is bypassing the wiring.
   reverts. `tests/providers/adobe-provider.test.ts` covers the
   provider-level `ensureSessionIdHeader` fallback behavior.
 
-## Adobe / Bedrock Claude opus-4-8: `temperature` + adaptive-thinking quirks
+## New Claude model release checklist
 
-opus-4-8 is **newer than the pinned pi-ai (0.75.3)**, so pi-ai's
-model-capability detection doesn't know it and emits two request shapes
+When Anthropic ships a new Claude model that isn't in the pinned pi-ai:
+
+1. **Check for a pi-ai update first.** Run `npm view @earendil-works/pi-ai versions --json | tail`
+   and inspect the latest tarball for the new model's entry (`reasoning`,
+   `cost`, `thinkingLevelMap`, `compat`). A bump often fixes multiple issues
+   at once. Watch for breaking changes (e.g. 0.80.3 changed
+   `buildBaseOptions` to take a `context` param).
+
+2. **Verify `getModelIds` forwards all metadata fields.** `buildAdobeModel`'s
+   fallback sets defaults for unknown models (`reasoning: true`, zero costs),
+   but `getModelIds` must forward them from the cached `Model<Api>` to
+   `enrichModel()` — otherwise pi-ai constructs the model from incomplete
+   metadata and features silently break (thinking off, cost counter $0.00).
+   Fields to check: `reasoning`, `input`, `cost`. See
+   `providers/adobe.ts:getModelIds` and
+   `src/providers/adobe-model-metadata.ts:enrichAdobeModel`.
+
+3. **Verify `parseClaudeVersion` handles the new ID format.** pi-ai may use
+   IDs without a minor version (e.g. `claude-sonnet-5` instead of
+   `claude-sonnet-5-0`). The regex in `claude-model-version.ts` handles
+   both, but verify the version-based predicates return the right values:
+   - `claudeSupportsAdaptiveThinking` — does the model use adaptive thinking?
+   - `claudeSupportsNativeXhighEffort` — does the API accept `effort: "xhigh"`?
+   - `claudeSupportsMaxEffort` — should `xhigh` clamp to `max` (not `high`)?
+   - `claudeRejectsTemperature` — does the API reject `temperature`?
+
+4. **Verify `thinkingLevelMap`.** If pi-ai ships the model without a
+   `thinkingLevelMap`, `getSupportedThinkingLevels` will exclude `xhigh` and
+   `resolveThinkingLevel` will clamp it to `high`. If the API supports
+   `xhigh`, add a `thinkingLevelMap` override in `enrichAdobeModel` (same
+   pattern as the Sonnet 5 and Haiku compat workarounds).
+
+5. **Verify `findFamilyCost`.** For models pi-ai doesn't know, this inherits
+   costs from the closest known model in the same family. Verify the
+   inherited costs are reasonable. Once pi-ai is bumped, the real costs
+   take over.
+
+## Thinking effort pipeline
+
+The full chain from UI to API has multiple mapping/clamping stages. When
+debugging thinking issues, trace through each layer:
+
+```
+UI (6 levels)         pi-ai ThinkingLevel    API effort
+───────────────────   ───────────────────   ───────────────────
+Secco   (off)    →    off                 →  (no thinking)
+Goccia  (low)    →    low                 →  low
+Bagnato (medium) →    medium              →  medium
+Affogato(high)   →    high                →  high
+Inzuppato(xhigh) →    xhigh               →  xhigh†
+Sprofondato(max) →    xhigh + override    →  max
+```
+
+† `xhigh` is clamped by `clampXhighEffort` per model: Opus ≥ 4.7 and
+Sonnet ≥ 5.0 pass through; Opus 4.6 and Sonnet 4.6 clamp to `max`;
+older models clamp to `high`.
+
+Key files in the chain:
+
+- `wc-live.ts` — `PI_FROM_META` / `effortOverrideForAgent` (UI → pi-ai)
+- `scoop-context.ts` — `resolveThinkingLevel` (model-aware clamping)
+- `adaptive-thinking.ts` — `thinkingLevelToEffort` / `clampXhighEffort`
+  (pi-ai level → API effort string)
+- `scoop-context.ts` — `buildSessionHelpers` stream wrapper (injects
+  `effortOverride` for `max`)
+
+`max` bypasses pi-ai entirely: it's stored as `effortOverride` on
+`ScoopConfig`, injected by the stream wrapper, and picked up by
+`withAdaptiveThinkingShim` via `options.effort` (which takes precedence
+over `thinkingLevelToEffort`). `clampXhighEffort` only acts on `xhigh`,
+so `max` passes through unchanged.
+
+## Adobe / Bedrock: `temperature` + adaptive-thinking shims
+
+When the pinned pi-ai doesn't know a model, it emits request shapes
 Bedrock rejects. Both surface identically: Bedrock returns a `400`, the
 Adobe proxy wraps it as a `502 upstream_error`, and the node-server
-fetch-proxy relays the upstream status verbatim (`res.status(upstream.status)`),
-so the agent sees a bare **502 on `/api/fetch-proxy`** with no hint of the
-cause. **Fix both at the provider layer (a model capability), never at the
-call site** — and a pi-ai bump that learns opus-4-8 makes the shims no-ops.
+fetch-proxy relays the upstream status verbatim, so the agent sees a bare
+**502 on `/api/fetch-proxy`** with no hint of the cause. **Fix at the
+provider layer (a model capability), never at the call site** — a pi-ai
+bump that learns the model makes the shims no-ops.
 
-Both shims now share a single version-threshold parser
-(`src/providers/claude-model-version.ts`) so future releases (Opus 4.9,
-Sonnet 4.7, 5.x) are picked up automatically without per-release edits.
+Both shims share a version-threshold parser (`src/providers/claude-model-version.ts`)
+so future releases are picked up automatically.
 
 ### 1. `temperature` is deprecated (Opus ≥ 4.7)
 
@@ -1016,52 +1088,27 @@ bites the **thinking-disabled** helper calls: `providers/quick-llm.ts` sends
 `temperature: 0.3` for the scope-label and session-title helpers. pi-ai's
 `anthropic-messages` builder already drops `temperature` when extended
 thinking is enabled, so the **main cone stream is unaffected** — only the
-background helpers 502 (commonly a pile of 502s as a long conversation
-keeps refreshing its working-scope label). Message count is irrelevant:
-even a 24-token request fails.
+background helpers 502.
 
 Fix: `src/providers/temperature-support.ts` exposes
 `modelSupportsTemperature` / `withSupportedTemperature`, both delegating to
-`claudeRejectsTemperature` (Opus ≥ 4.7) in `claude-model-version.ts`. Both
-Bedrock-backed providers consult it — `providers/built-in/bedrock-camp.ts`
-omits it in the Converse payload and `providers/adobe.ts` strips it before
-`streamAnthropic` / `streamSimpleAnthropic`. Future Opus releases are
-covered by the version threshold; no per-release edit is needed.
+`claudeRejectsTemperature` (Opus ≥ 4.7) in `claude-model-version.ts`.
 
-### 2. Adaptive thinking required (Opus ≥ 4.8 in pi-ai 0.75.3)
+### 2. Adaptive thinking required (Opus/Sonnet ≥ 4.6)
 
 With thinking **enabled**, Bedrock returns `400 "thinking.type.enabled is
 not supported for this model. Use thinking.type.adaptive and
-output_config.effort..."`. pi-ai's `supportsAdaptiveThinking()` recognizes
-opus-4-6/4-7 + sonnet-4-6 (emitting `thinking:{type:"adaptive"}` +
-`output_config.effort`) but **not opus-4-8** — and would similarly miss
-opus-4-9 / sonnet-4-7 — so it falls back to the legacy
-`thinking:{type:"enabled",budget_tokens}` shape that Bedrock rejects.
-Unlike temperature, this hits the **main cone stream** (thinking on).
+output_config.effort..."`. pi-ai's `supportsAdaptiveThinking()` may not
+recognize new models and falls back to the legacy shape.
 
-Fix: `src/providers/adaptive-thinking.ts` — `providers/adobe.ts` passes an
-`onPayload` hook (pi-ai's `streamAnthropic` payload-rewrite seam, the same
-one `bedrock-camp` uses) that rewrites the emitted body
+Fix: `src/providers/adaptive-thinking.ts` — an `onPayload` hook rewrites
 `enabled → adaptive` + `output_config.effort` for any Claude Opus/Sonnet
-≥ 4.6 (via `claudeSupportsAdaptiveThinking`). The rewrite only fires when
-the enabled shape is actually present, so it's a no-op when thinking is
-off or for models pi-ai already emits the adaptive shape for. **Immediate
-workaround:** set the thinking level to off (the model still reasons
-adaptively on its own).
+≥ 4.6. The rewrite only fires when the enabled shape is present, so it's
+a no-op when thinking is off or pi-ai already emits the adaptive shape.
 
-**Related**
-
-- Coverage: `tests/providers/claude-model-version.test.ts`,
-  `tests/providers/temperature-support.test.ts`,
-  `tests/providers/adaptive-thinking.test.ts`, and the "omits temperature
-  for Opus 4.8" + parametrized adaptive cases in
-  `tests/providers/built-in/bedrock-camp.test.ts`.
-- History: the temperature guard was Opus-4.7-only and inline in
-  `bedrock-camp.ts`; it was generalized into the shared helper, extended to
-  4.8, and applied to the (previously unguarded) Adobe path. The
-  adaptive-thinking shim was added alongside it. Both were then consolidated
-  onto a shared version-threshold parser so opus-4-9 / sonnet-4-7 are
-  handled automatically.
+**Related tests:** `claude-model-version.test.ts`,
+`temperature-support.test.ts`, `adaptive-thinking.test.ts`,
+`bedrock-camp.test.ts`.
 
 ## Detached popout (historical, removed)
 

--- a/docs/review-patterns.md
+++ b/docs/review-patterns.md
@@ -131,7 +131,33 @@ gap causes an incident.
 before touching a protected resource; degrade gracefully and tell the user when permission
 is denied.
 
-### 6. Test-coverage blind spots
+### 6. Model metadata / provider pipeline gaps
+
+**Trigger patterns**
+
+- A new Claude model ID appears in the proxy or pi-ai that isn't in the version-based
+  predicates (`claude-model-version.ts`).
+- Changes to `buildAdobeModel`, `enrichAdobeModel`, or `getModelIds` that add or rename
+  model fields without checking all three are in sync.
+- A pi-ai bump that adds new models — check if the new model's `thinkingLevelMap`, `cost`,
+  and `reasoning` are correct. Also check for breaking API changes (e.g. function signature
+  changes like `buildBaseOptions`).
+- Changes to the thinking/effort pipeline (`PI_FROM_META`, `resolveThinkingLevel`,
+  `thinkingLevelToEffort`, `clampXhighEffort`, `effortOverride`) without verifying
+  end-to-end mapping for all 6 UI levels on the affected models.
+
+**Historical precedent** — **PR #1399** (`fix(adobe): enable thinking for Sonnet 5`):
+`getModelIds` forwarded only `{ id, name }` from cached models, silently discarding
+`reasoning`, `input`, and `cost`. Sonnet 5 (unknown to pi-ai) lost thinking, effort levels,
+and the cost counter. Also, `claudeSupportsNativeXhighEffort` was gated to Opus only, and
+SLICC's `max` UI level was collapsed into pi-ai's `xhigh`.
+
+**Remediation** — follow the "New Claude model release checklist" in `docs/pitfalls.md`.
+Verify `getModelIds` forwards all metadata fields from cached models. Check
+`parseClaudeVersion` handles the new ID format. Test the full effort mapping chain
+(UI → pi-ai → API) for all 6 levels.
+
+### 7. Test-coverage blind spots
 
 **Trigger patterns**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1429,9 +1429,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
-      "integrity": "sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ==",
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+      "integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1956,7 +1956,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2072,9 +2072,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2090,9 +2087,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2110,9 +2104,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2129,9 +2120,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2147,9 +2135,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6060,9 +6045,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6080,9 +6062,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6100,9 +6079,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6120,9 +6096,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6140,9 +6113,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6160,9 +6130,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/chrome-extension/src/messages.ts
+++ b/packages/chrome-extension/src/messages.ts
@@ -259,6 +259,8 @@ export interface SetThinkingLevelMsg {
   scoopJid: string;
   /** Undefined clears the override; the level falls back to default. */
   level?: ExtensionThinkingLevel;
+  /** Raw API effort override (e.g. `'max'`) bypassing pi-ai's ThinkingLevel. */
+  effortOverride?: string;
 }
 
 export interface RefreshTrayRuntimeMsg {

--- a/packages/chrome-extension/src/offscreen-bridge.ts
+++ b/packages/chrome-extension/src/offscreen-bridge.ts
@@ -1519,7 +1519,11 @@ export class OffscreenBridge implements KernelFacade {
         // is the same shape the orchestrator expects).
         const tlMsg: SetThinkingLevelMsg = msg;
         try {
-          await this.orchestrator.setScoopThinkingLevel(tlMsg.scoopJid, tlMsg.level);
+          await this.orchestrator.setScoopThinkingLevel(
+            tlMsg.scoopJid,
+            tlMsg.level,
+            tlMsg.effortOverride
+          );
         } catch (err) {
           console.error('[offscreen-bridge] set-thinking-level failed:', err);
         }

--- a/packages/chrome-extension/tests/offscreen-bridge.test.ts
+++ b/packages/chrome-extension/tests/offscreen-bridge.test.ts
@@ -2127,7 +2127,11 @@ describe('OffscreenBridge handlePanelMessage dispatch', () => {
       scoopJid: 'cone_1',
       level: 'high',
     });
-    expect(mockOrchestrator.setScoopThinkingLevel).toHaveBeenCalledWith('cone_1', 'high');
+    expect(mockOrchestrator.setScoopThinkingLevel).toHaveBeenCalledWith(
+      'cone_1',
+      'high',
+      undefined
+    );
   });
 
   it('set-thinking-level swallows orchestrator errors', async () => {

--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -47,6 +47,7 @@ import {
   enrichAdobeModel,
 } from '../src/providers/adobe-model-metadata.js';
 import { buildAdobeOAuthState } from '../src/providers/adobe-oauth-state.js';
+import { parseClaudeVersion } from '../src/providers/claude-model-version.js';
 import { getOAuthPageOrigin } from '../src/providers/oauth-service.js';
 import { createSilentRenewBackoff } from '../src/providers/silent-renew-backoff.js';
 import { withSupportedTemperature } from '../src/providers/temperature-support.js';
@@ -988,13 +989,15 @@ function buildPiAiModelMap(): Map<string, Model<Api>> {
  */
 function findFamilyCost(modelId: string, modelMap: Map<string, Model<Api>>): Model<Api>['cost'] {
   const zeroCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
-  const familyMatch = modelId.match(/(opus|sonnet|haiku)/);
-  if (!familyMatch) return zeroCost;
-  const family = familyMatch[1];
-  let best: Model<Api> | undefined;
+  const target = parseClaudeVersion(modelId);
+  if (!target) return zeroCost;
+  let best: { major: number; minor: number; cost: Model<Api>['cost'] } | undefined;
   for (const m of modelMap.values()) {
-    if (!m.id.includes(family)) continue;
-    if (!best || m.id > best.id) best = m;
+    const v = parseClaudeVersion(m.id);
+    if (!v || v.family !== target.family) continue;
+    if (!best || v.major > best.major || (v.major === best.major && v.minor > best.minor)) {
+      best = { major: v.major, minor: v.minor, cost: m.cost };
+    }
   }
   return best?.cost ?? zeroCost;
 }

--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -289,6 +289,7 @@ export const config: ProviderConfig = {
             name: m.name ?? m.id,
             reasoning: m.reasoning,
             input: m.input,
+            cost: m.cost,
           })
         );
         persistAdobeModels(result); // survives refresh; read by cold consumers
@@ -980,6 +981,24 @@ function buildPiAiModelMap(): Map<string, Model<Api>> {
 }
 
 /** Construct an Adobe-tagged Model from a proxy entry, reusing pi-ai metadata when present. */
+/**
+ * Find the closest known model in the same family to inherit costs from.
+ * Searches for e.g. "sonnet-4-6" when the proxy returns "sonnet-5-0" that
+ * pi-ai doesn't know yet. Returns the cost object or a zero fallback.
+ */
+function findFamilyCost(modelId: string, modelMap: Map<string, Model<Api>>): Model<Api>['cost'] {
+  const zeroCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  const familyMatch = modelId.match(/(opus|sonnet|haiku)/);
+  if (!familyMatch) return zeroCost;
+  const family = familyMatch[1];
+  let best: Model<Api> | undefined;
+  for (const m of modelMap.values()) {
+    if (!m.id.includes(family)) continue;
+    if (!best || m.id > best.id) best = m;
+  }
+  return best?.cost ?? zeroCost;
+}
+
 function buildAdobeModel(
   pm: RawProxyModel,
   endpoint: string,
@@ -990,6 +1009,10 @@ function buildAdobeModel(
   const customApi = `adobe-${apiType}` as Api;
   const base = modelMap.get(pm.id);
   if (base) return { ...base, provider: 'adobe', api: customApi };
+  // For models pi-ai doesn't know yet, inherit costs from the closest
+  // known model in the same family (e.g. sonnet-4-6 for sonnet-5-0)
+  // so the cost counter stays functional until pi-ai is bumped.
+  const cost = findFamilyCost(pm.id, modelMap);
   return {
     id: pm.id,
     name: pm.name ?? pm.id,
@@ -999,11 +1022,11 @@ function buildAdobeModel(
     contextWindow: 200000,
     maxTokens: 16384,
     input: ['text', 'image'],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    inputCost: 0,
-    outputCost: 0,
-    cacheReadCost: 0,
-    cacheWriteCost: 0,
+    cost,
+    inputCost: cost.input,
+    outputCost: cost.output,
+    cacheReadCost: cost.cacheRead,
+    cacheWriteCost: cost.cacheWrite,
     reasoning: true,
   } as unknown as Model<Api>;
 }

--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -283,7 +283,14 @@ export const config: ProviderConfig = {
     // Prefer the authenticated /v1/models response (has all available models)
     for (const models of modelsCache.values()) {
       if (models.length) {
-        const result = models.map((m) => enrichModel({ id: m.id, name: m.name ?? m.id }));
+        const result = models.map((m) =>
+          enrichModel({
+            id: m.id,
+            name: m.name ?? m.id,
+            reasoning: m.reasoning,
+            input: m.input,
+          })
+        );
         persistAdobeModels(result); // survives refresh; read by cold consumers
         return result;
       }

--- a/packages/webapp/src/kernel/types.ts
+++ b/packages/webapp/src/kernel/types.ts
@@ -224,7 +224,11 @@ export interface KernelClientFacade {
   // RPC operations
   // -------------------------------------------------------------------------
   updateModel(): void;
-  setScoopThinkingLevel(jid: string, level: ThinkingLevel | undefined): void;
+  setScoopThinkingLevel(
+    jid: string,
+    level: ThinkingLevel | undefined,
+    effortOverride?: string
+  ): void;
   /**
    * Cone-only chat clear, used by the "New session" flow. Resolves only
    * after the host has acknowledged the clear so the panel can safely

--- a/packages/webapp/src/providers/adaptive-thinking.ts
+++ b/packages/webapp/src/providers/adaptive-thinking.ts
@@ -46,9 +46,9 @@ export function modelNeedsAdaptiveThinkingShim(modelId: string, modelName?: stri
 /**
  * Clamp an unsupported `xhigh` effort for the adaptive models that don't accept
  * it natively, mirroring `bedrock-camp`'s `mapThinkingLevelToEffort`:
- * - Opus ≥ 4.7 (`claudeSupportsNativeXhighEffort`) → `xhigh` stays `xhigh`
- * - Opus 4.6 (`claudeSupportsMaxEffort`) → `xhigh` → `max`
- * - Anything else (Sonnet, …) → `xhigh` → `high`
+ * - Opus ≥ 4.7, Sonnet ≥ 5.0 (`claudeSupportsNativeXhighEffort`) → `xhigh`
+ * - Opus 4.6, Sonnet 4.6 (`claudeSupportsMaxEffort`) → `xhigh` → `max`
+ * - Anything else → `xhigh` → `high`
  *
  * Non-`xhigh` efforts pass through unchanged. When the model id is missing the
  * value is returned as-is so unaware callers retain the legacy mapping.
@@ -75,8 +75,8 @@ interface ThinkingLevelModel {
  * The final value is then run through {@link clampXhighEffort} (using the
  * shared `claudeSupportsNativeXhighEffort` / `claudeSupportsMaxEffort`
  * predicates) so an unsupported `xhigh` — including one produced by a
- * `thinkingLevelMap` override — is downshifted to `max` (Opus 4.6) or `high`
- * (Sonnet 4.6, etc.).
+ * `thinkingLevelMap` override — is downshifted to `max` (Opus 4.6,
+ * Sonnet 4.6) or `high` (older models).
  */
 export function thinkingLevelToEffort(
   level: ThinkingLevel | undefined,

--- a/packages/webapp/src/providers/adobe-model-metadata.ts
+++ b/packages/webapp/src/providers/adobe-model-metadata.ts
@@ -18,6 +18,14 @@
  * the 200K default. See `scoops/scoop-context.ts` compaction wiring.
  */
 
+/** Per-token cost structure (values in $ per million tokens). */
+export interface AdobeModelCost {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
 /** Metadata shape shared by `/v1/config` entries and the `/v1/models` cache. */
 export interface AdobeModelMetadata {
   id: string;
@@ -27,6 +35,7 @@ export interface AdobeModelMetadata {
   max_tokens?: number;
   reasoning?: boolean;
   input?: string[];
+  cost?: AdobeModelCost;
 }
 
 /** Per-model compat overrides merged onto the streaming `Model<Api>`. */
@@ -43,6 +52,7 @@ export interface EnrichedAdobeModel {
   max_tokens?: number;
   reasoning?: boolean;
   input?: string[];
+  cost?: AdobeModelCost;
   compat?: AdobeModelCompat;
 }
 
@@ -69,6 +79,9 @@ export function enrichAdobeModel(
   if (maxTokens !== undefined) out.max_tokens = maxTokens;
   if (reasoning !== undefined) out.reasoning = reasoning;
   if (input) out.input = input;
+
+  const cost = cached?.cost ?? entry.cost;
+  if (cost) out.cost = cost;
 
   // Adobe's IMS proxy forwards Anthropic-Messages requests to AWS Bedrock.
   // Bedrock's Haiku endpoints 400 on `tools[].eager_input_streaming` ("Extra

--- a/packages/webapp/src/providers/adobe-model-metadata.ts
+++ b/packages/webapp/src/providers/adobe-model-metadata.ts
@@ -54,6 +54,7 @@ export interface EnrichedAdobeModel {
   input?: string[];
   cost?: AdobeModelCost;
   compat?: AdobeModelCompat;
+  thinkingLevelMap?: Record<string, string | null>;
 }
 
 /**
@@ -92,6 +93,14 @@ export function enrichAdobeModel(
   // Haiku-on-Bedrock accepts.
   if (/haiku/i.test(entry.id)) {
     out.compat = { supportsEagerToolInputStreaming: false };
+  }
+
+  // pi-ai 0.80.3 ships Sonnet 5 without a thinkingLevelMap, so
+  // getSupportedThinkingLevels excludes xhigh and resolveThinkingLevel
+  // clamps it to high. The Anthropic API supports xhigh for Sonnet 5;
+  // add the map so the UI and agent can use it.
+  if (/sonnet-5\b/i.test(entry.id) && !out.thinkingLevelMap) {
+    out.thinkingLevelMap = { xhigh: 'xhigh' };
   }
 
   return out;

--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -829,7 +829,12 @@ export const streamSimpleBedrockCamp = (
   context: Context,
   options?: BedrockCampSimpleOptions
 ): AssistantMessageEventStream => {
-  const base = buildBaseOptions(model, options, undefined);
+  // pi-ai 0.80.3 added `context` as the 2nd param; the tsconfig `paths`
+  // workaround for this deep import doesn't resolve the new overload, so
+  // we cast to satisfy both the old and new signatures at compile time.
+  const base = (buildBaseOptions as Function)(model, context, options) as ReturnType<
+    typeof buildBaseOptions
+  >;
   const extras = options ? pickCampExtras(options) : {};
   if (!options?.reasoning) {
     return streamBedrockCamp(model, context, { ...base, ...extras, reasoning: undefined });

--- a/packages/webapp/src/providers/claude-model-version.ts
+++ b/packages/webapp/src/providers/claude-model-version.ts
@@ -83,24 +83,27 @@ export function claudeSupportsAdaptiveThinking(modelId: string, modelName?: stri
 }
 
 /**
- * Native `effort: "xhigh"` tier — Opus introduced this at 4.7 (and later
- * releases inherit it). Opus 4.6 clamps xhigh to `"max"` instead.
+ * Native `effort: "xhigh"` tier — Opus introduced this at 4.7, Sonnet at 5.0.
+ * Opus 4.6 and Sonnet 4.6 clamp xhigh to `"max"` / `"high"` respectively.
  */
 export function claudeSupportsNativeXhighEffort(modelId: string, modelName?: string): boolean {
   const v = parseClaudeVersion(modelId, modelName);
-  if (v?.family !== 'opus') return false;
-  return compareVersion(v, { major: 4, minor: 7 }) >= 0;
+  if (!v) return false;
+  if (v.family === 'opus') return compareVersion(v, { major: 4, minor: 7 }) >= 0;
+  if (v.family === 'sonnet') return compareVersion(v, { major: 5, minor: 0 }) >= 0;
+  return false;
 }
 
 /**
- * Opus 4.6 specifically clamps xhigh requests to effort `"max"`. Newer Opus
- * versions have native xhigh and older Opus versions don't use adaptive
- * thinking at all, so this is an exact-version predicate.
+ * Models that clamp xhigh requests to effort `"max"` — Opus 4.6 and
+ * Sonnet 4.6, which support `max` but not `xhigh` natively.
  */
 export function claudeSupportsMaxEffort(modelId: string, modelName?: string): boolean {
   const v = parseClaudeVersion(modelId, modelName);
-  if (v?.family !== 'opus') return false;
-  return v.major === 4 && v.minor === 6;
+  if (!v) return false;
+  if (v.family === 'opus') return v.major === 4 && v.minor === 6;
+  if (v.family === 'sonnet') return v.major === 4 && v.minor === 6;
+  return false;
 }
 
 /**

--- a/packages/webapp/src/providers/claude-model-version.ts
+++ b/packages/webapp/src/providers/claude-model-version.ts
@@ -38,7 +38,13 @@ function matchCandidates(modelId: string, modelName?: string): string[] {
   });
 }
 
-const CLAUDE_VERSION_RE = /(opus|sonnet|haiku)-(\d+)-(\d+)/;
+/**
+ * Match `family-major-minor` or `family-major` (e.g. `sonnet-5` without a
+ * minor version, as in pi-ai 0.80.3's `claude-sonnet-5`). The `{1,2}` digit
+ * constraint + negative lookahead prevents false positives on legacy IDs like
+ * `claude-3-5-sonnet-20241022` where the date suffix would otherwise match.
+ */
+const CLAUDE_VERSION_RE = /(opus|sonnet|haiku)-(\d{1,2})(?:-(\d{1,2}))?(?!\d)/;
 
 /**
  * Parse a Claude family/major/minor out of an id or display name. Returns
@@ -53,7 +59,7 @@ export function parseClaudeVersion(modelId: string, modelName?: string): ClaudeV
       return {
         family: m[1] as ClaudeFamily,
         major: Number(m[2]),
-        minor: Number(m[3]),
+        minor: m[3] !== undefined ? Number(m[3]) : 0,
       };
     }
   }

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -918,9 +918,10 @@ export class Orchestrator implements ConeApprovalRouter {
   /** Update a single scoop's reasoning / thinking level. */
   setScoopThinkingLevel(
     jid: string,
-    level: ThinkingLevel | undefined
+    level: ThinkingLevel | undefined,
+    effortOverride?: string
   ): Promise<ThinkingLevel | null> {
-    return this.lifecycle.setThinkingLevel(jid, level);
+    return this.lifecycle.setThinkingLevel(jid, level, effortOverride);
   }
 
   /** Reload skills on all active scoop contexts (cone + scoops). */

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -332,6 +332,8 @@ export class ScoopContext {
   private sudoManager: SudoManager | null = null;
 
   private structuredOutputValue: unknown;
+  /** Raw API effort override (e.g. `'max'`) bypassing pi-ai's ThinkingLevel. */
+  private activeEffortOverride: string | undefined;
   private structuredOutputCaptured = false;
 
   constructor(
@@ -586,9 +588,15 @@ export class ScoopContext {
   private async buildSessionHelpers(model: Model<Api>) {
     const adobeSessionId = await getAdobeSessionId(this.scoop, this.coneJid);
     const streamWithSessionId: typeof streamSimple = (m, ctx, opts) => {
-      if (m.provider !== 'adobe') return streamSimple(m, ctx, opts);
+      // Inject the raw effort override (e.g. 'max') when the UI-level
+      // effort exceeds pi-ai's ThinkingLevel range. The provider's
+      // adaptive-thinking shim reads `effort` before falling back to
+      // the `reasoning` ThinkingLevel.
+      const effort = this.activeEffortOverride;
+      const enhanced = effort ? { ...opts, effort } : opts;
+      if (m.provider !== 'adobe') return streamSimple(m, ctx, enhanced);
       return streamSimple(m, ctx, {
-        ...opts,
+        ...enhanced,
         headers: { ...opts?.headers, 'X-Session-Id': adobeSessionId },
       });
     };
@@ -661,6 +669,7 @@ export class ScoopContext {
         lockedEffort ?? this.scoop.config?.thinkingLevel,
         model
       );
+      this.activeEffortOverride = this.scoop.config?.effortOverride;
 
       this.agent = new Agent({
         initialState: {
@@ -1119,10 +1128,11 @@ export class ScoopContext {
    * Returns the level actually applied, after model-aware resolution
    * (xhigh→high clamp on unsupported models, off on non-reasoning models).
    */
-  setThinkingLevel(level: ThinkingLevel | undefined): ThinkingLevel {
+  setThinkingLevel(level: ThinkingLevel | undefined, effortOverride?: string): ThinkingLevel {
     if (!this.agent) return 'off';
     const locked = this.getLockedEffortLevel();
     if (locked) return this.agent.state.thinkingLevel;
+    this.activeEffortOverride = effortOverride;
     const resolved = resolveThinkingLevel(level, this.agent.state.model);
     this.agent.state.thinkingLevel = resolved;
     return resolved;

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -1079,6 +1079,9 @@ export class ScoopContext {
     const lockedEffort = this.getLockedEffortLevel();
     const requested = lockedEffort ?? this.scoop.config?.thinkingLevel;
     this.agent.state.thinkingLevel = resolveThinkingLevel(requested, model);
+    // Re-resolve the effort override: clear it when the new model doesn't
+    // support reasoning (non-thinking model makes the override moot).
+    this.activeEffortOverride = model.reasoning ? this.scoop.config?.effortOverride : undefined;
     log.info('Model updated on running agent', {
       folder: this.scoop.folder,
       model: model.id,

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -614,24 +614,29 @@ export class ScoopLifecycleManager {
    */
   async setThinkingLevel(
     jid: string,
-    level: ThinkingLevel | undefined
+    level: ThinkingLevel | undefined,
+    effortOverride?: string
   ): Promise<ThinkingLevel | null> {
     const scoop = this.deps.getScoops().get(jid);
     if (!scoop) return null;
 
     const context = this.contexts.get(jid);
-    const applied = context ? context.setThinkingLevel(level) : null;
+    const applied = context ? context.setThinkingLevel(level, effortOverride) : null;
 
     // Persist the requested level (not the resolved/clamped one): on a
     // model swap later, we want the user's stated preference re-resolved
     // against the new model, not the stale clamped value.
     if (level === undefined) {
       if (scoop.config && scoop.config.thinkingLevel !== undefined) {
-        const { thinkingLevel: _omit, ...rest } = scoop.config;
+        const { thinkingLevel: _omit, effortOverride: _omit2, ...rest } = scoop.config;
         scoop.config = rest;
       }
     } else {
-      scoop.config = { ...(scoop.config ?? {}), thinkingLevel: level };
+      scoop.config = {
+        ...(scoop.config ?? {}),
+        thinkingLevel: level,
+        effortOverride,
+      };
     }
 
     try {

--- a/packages/webapp/src/scoops/types.ts
+++ b/packages/webapp/src/scoops/types.ts
@@ -123,6 +123,14 @@ export interface ScoopConfig {
    */
   thinkingLevel?: ThinkingLevel;
   /**
+   * Raw API effort string that bypasses pi-ai's ThinkingLevel mapping.
+   * Set to `'max'` when the user picks the highest effort tier (Sprofondato)
+   * — pi-ai's ThinkingLevel has no `max` value, so `thinkingLevel` is set
+   * to `'xhigh'` while this field carries the true intent to the stream
+   * layer, which injects it as `output_config.effort`.
+   */
+  effortOverride?: string;
+  /**
    * VFS paths this scoop can READ (but not write). Pure replace — when
    * `undefined` the scoop gets no read-only paths at all. The `scoop_scoop`
    * tool injects the standard `['/workspace/']` default when creating scoops

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -381,8 +381,12 @@ export class OffscreenClient implements KernelClientFacade {
    *   (see `ScoopSnapshotConfig`), so the brain icon rehydrates with
    *   the correct level on reconnect / scoop switch.
    */
-  setScoopThinkingLevel(jid: string, level: ThinkingLevel | undefined): void {
-    this.send({ type: 'set-thinking-level', scoopJid: jid, level });
+  setScoopThinkingLevel(
+    jid: string,
+    level: ThinkingLevel | undefined,
+    effortOverride?: string
+  ): void {
+    this.send({ type: 'set-thinking-level', scoopJid: jid, level, effortOverride });
   }
 
   /**

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -72,7 +72,21 @@ export function thinkingLevelForAgent(metaLevel: string | undefined): ThinkingLe
   return metaLevel ? PI_FROM_META[metaLevel] : undefined;
 }
 
-export function metaThinkingForScoop(level: ThinkingLevel | undefined): string {
+/**
+ * Raw API effort override for levels that exceed pi-ai's ThinkingLevel range.
+ * Returns `'max'` when the user picks Sprofondato (the UI's `max` level),
+ * `undefined` otherwise — so the stream layer can inject `effort: 'max'`
+ * directly into `output_config` without going through pi-ai's mapping.
+ */
+export function effortOverrideForAgent(metaLevel: string | undefined): string | undefined {
+  return metaLevel === 'max' ? 'max' : undefined;
+}
+
+export function metaThinkingForScoop(
+  level: ThinkingLevel | undefined,
+  effortOverride?: string
+): string {
+  if (effortOverride === 'max') return 'max';
   return (level && META_FROM_PI[level]) ?? 'off';
 }
 
@@ -279,7 +293,10 @@ async function applyThreadContext(refs: WcShellRefs, scoop: RegisteredScoop): Pr
   const lockedEffort = localStorage.getItem('slicc_locked_effort_level');
   refs.composerMeta.setAttribute(
     'thinking',
-    metaThinkingForScoop((lockedEffort ?? scoop.config?.thinkingLevel) as ThinkingLevel | undefined)
+    metaThinkingForScoop(
+      (lockedEffort ?? scoop.config?.thinkingLevel) as ThinkingLevel | undefined,
+      scoop.config?.effortOverride
+    )
   );
   try {
     const { resolveCurrentModel, resolveModelById } = await import('../provider-settings.js');
@@ -983,8 +1000,9 @@ function wireWcComposer(deps: {
     if (localStorage.getItem('slicc_locked_effort_level')) return;
     const metaLevel = (event as CustomEvent<{ thinking?: string }>).detail?.thinking;
     const level = thinkingLevelForAgent(metaLevel);
+    const effort = effortOverrideForAgent(metaLevel);
     const selected = boot.getSelected();
-    if (selected && level) client.setScoopThinkingLevel(selected.jid, level);
+    if (selected && level) client.setScoopThinkingLevel(selected.jid, level, effort);
   });
 
   return { getAttachStage: () => attachStage };

--- a/packages/webapp/tests/providers/adaptive-thinking.test.ts
+++ b/packages/webapp/tests/providers/adaptive-thinking.test.ts
@@ -84,13 +84,13 @@ describe('thinkingLevelToEffort', () => {
     expect(thinkingLevelToEffort('xhigh', { id: 'claude-opus-4-6' })).toBe('max');
   });
 
-  it('clamps xhigh to high for Sonnet 4.6 (no native xhigh, no max)', () => {
-    expect(thinkingLevelToEffort('xhigh', { id: 'claude-sonnet-4-6' })).toBe('high');
-    expect(thinkingLevelToEffort('xhigh', { id: 'us.anthropic.claude-sonnet-4-6' })).toBe('high');
+  it('clamps xhigh to max for Sonnet 4.6 (supports max but not xhigh)', () => {
+    expect(thinkingLevelToEffort('xhigh', { id: 'claude-sonnet-4-6' })).toBe('max');
+    expect(thinkingLevelToEffort('xhigh', { id: 'us.anthropic.claude-sonnet-4-6' })).toBe('max');
   });
 
-  it('clamps xhigh to high for Sonnet 5.0', () => {
-    expect(thinkingLevelToEffort('xhigh', { id: 'claude-sonnet-5-0' })).toBe('high');
+  it('keeps xhigh for Sonnet 5.0 (native xhigh support)', () => {
+    expect(thinkingLevelToEffort('xhigh', { id: 'claude-sonnet-5-0' })).toBe('xhigh');
   });
 
   it('matches model name when the id is opaque (Opus 4.6 → max)', () => {
@@ -98,14 +98,14 @@ describe('thinkingLevelToEffort', () => {
   });
 
   it('clamps a thinkingLevelMap override that resolves to xhigh', () => {
-    // Override maps 'high' → 'xhigh', then clamp downshifts for Sonnet 4.6.
+    // Override maps 'high' → 'xhigh', then clamp downshifts for Sonnet 4.6
+    // (supports max but not xhigh) and Opus 4.6 (same).
     expect(
       thinkingLevelToEffort('high', {
         id: 'claude-sonnet-4-6',
         thinkingLevelMap: { high: 'xhigh' },
       })
-    ).toBe('high');
-    // Same override but on Opus 4.6 clamps to 'max'.
+    ).toBe('max');
     expect(
       thinkingLevelToEffort('high', {
         id: 'claude-opus-4-6',
@@ -225,7 +225,7 @@ describe('withAdaptiveThinkingShim', () => {
       { thinking: { type: 'enabled', budget_tokens: 1024 } },
       {} as never
     );
-    expect(sonnet46Out.output_config).toEqual({ effort: 'high' });
+    expect(sonnet46Out.output_config).toEqual({ effort: 'max' });
 
     const opus48 = withAdaptiveThinkingShim({ id: 'claude-opus-4-8' }, {
       reasoning: 'xhigh',
@@ -247,6 +247,18 @@ describe('withAdaptiveThinkingShim', () => {
       { thinking: { type: 'enabled', budget_tokens: 1024 } },
       {} as never
     );
-    expect(out.output_config).toEqual({ effort: 'high' });
+    expect(out.output_config).toEqual({ effort: 'max' });
+  });
+
+  it('keeps xhigh for Sonnet 5.0 (native xhigh support)', async () => {
+    const opts = withAdaptiveThinkingShim({ id: 'claude-sonnet-5-0' }, {
+      reasoning: 'xhigh',
+      apiKey: 'tok',
+    } as ShimOptions);
+    const out = await opts.onPayload!(
+      { thinking: { type: 'enabled', budget_tokens: 1024 } },
+      {} as never
+    );
+    expect(out.output_config).toEqual({ effort: 'xhigh' });
   });
 });

--- a/packages/webapp/tests/providers/adaptive-thinking.test.ts
+++ b/packages/webapp/tests/providers/adaptive-thinking.test.ts
@@ -32,6 +32,7 @@ describe('modelNeedsAdaptiveThinkingShim', () => {
     // Future releases are picked up automatically by the version threshold.
     ['claude-opus-4-9'],
     ['claude-sonnet-4-7'],
+    ['claude-sonnet-5'],
     ['claude-sonnet-5-0'],
     ['us.anthropic.claude-sonnet-5-0'],
   ])('returns true for adaptive-capable %s', (id) => {
@@ -89,7 +90,8 @@ describe('thinkingLevelToEffort', () => {
     expect(thinkingLevelToEffort('xhigh', { id: 'us.anthropic.claude-sonnet-4-6' })).toBe('max');
   });
 
-  it('keeps xhigh for Sonnet 5.0 (native xhigh support)', () => {
+  it('keeps xhigh for Sonnet 5 (native xhigh support)', () => {
+    expect(thinkingLevelToEffort('xhigh', { id: 'claude-sonnet-5' })).toBe('xhigh');
     expect(thinkingLevelToEffort('xhigh', { id: 'claude-sonnet-5-0' })).toBe('xhigh');
   });
 
@@ -250,8 +252,8 @@ describe('withAdaptiveThinkingShim', () => {
     expect(out.output_config).toEqual({ effort: 'max' });
   });
 
-  it('keeps xhigh for Sonnet 5.0 (native xhigh support)', async () => {
-    const opts = withAdaptiveThinkingShim({ id: 'claude-sonnet-5-0' }, {
+  it('keeps xhigh for Sonnet 5 (native xhigh support)', async () => {
+    const opts = withAdaptiveThinkingShim({ id: 'claude-sonnet-5' }, {
       reasoning: 'xhigh',
       apiKey: 'tok',
     } as ShimOptions);

--- a/packages/webapp/tests/providers/adaptive-thinking.test.ts
+++ b/packages/webapp/tests/providers/adaptive-thinking.test.ts
@@ -29,10 +29,11 @@ describe('modelNeedsAdaptiveThinkingShim', () => {
     ['claude-opus-4-8'],
     ['us.anthropic.claude-opus-4-8'],
     ['claude opus 4 8'],
-    // Future releases (Opus 4.9, Sonnet 4.7) are picked up automatically by
-    // the version threshold.
+    // Future releases are picked up automatically by the version threshold.
     ['claude-opus-4-9'],
     ['claude-sonnet-4-7'],
+    ['claude-sonnet-5-0'],
+    ['us.anthropic.claude-sonnet-5-0'],
   ])('returns true for adaptive-capable %s', (id) => {
     expect(modelNeedsAdaptiveThinkingShim(id)).toBe(true);
   });
@@ -86,6 +87,10 @@ describe('thinkingLevelToEffort', () => {
   it('clamps xhigh to high for Sonnet 4.6 (no native xhigh, no max)', () => {
     expect(thinkingLevelToEffort('xhigh', { id: 'claude-sonnet-4-6' })).toBe('high');
     expect(thinkingLevelToEffort('xhigh', { id: 'us.anthropic.claude-sonnet-4-6' })).toBe('high');
+  });
+
+  it('clamps xhigh to high for Sonnet 5.0', () => {
+    expect(thinkingLevelToEffort('xhigh', { id: 'claude-sonnet-5-0' })).toBe('high');
   });
 
   it('matches model name when the id is opaque (Opus 4.6 → max)', () => {

--- a/packages/webapp/tests/providers/adobe-model-metadata.test.ts
+++ b/packages/webapp/tests/providers/adobe-model-metadata.test.ts
@@ -74,4 +74,21 @@ describe('enrichAdobeModel', () => {
     const enriched = enrichAdobeModel({ id: 'no-name' });
     expect(enriched.name).toBe('no-name');
   });
+
+  it('propagates reasoning from the entry when cache lacks it', () => {
+    const enriched = enrichAdobeModel({
+      id: 'claude-sonnet-5-0',
+      name: 'Claude Sonnet 5.0',
+      reasoning: true,
+    });
+    expect(enriched.reasoning).toBe(true);
+  });
+
+  it('prefers cached reasoning over entry reasoning', () => {
+    const enriched = enrichAdobeModel(
+      { id: 'claude-sonnet-5-0', name: 'Claude Sonnet 5.0', reasoning: true },
+      { id: 'claude-sonnet-5-0', reasoning: false }
+    );
+    expect(enriched.reasoning).toBe(false);
+  });
 });

--- a/packages/webapp/tests/providers/adobe-model-metadata.test.ts
+++ b/packages/webapp/tests/providers/adobe-model-metadata.test.ts
@@ -91,4 +91,24 @@ describe('enrichAdobeModel', () => {
     );
     expect(enriched.reasoning).toBe(false);
   });
+
+  it('propagates cost from the entry for unknown models', () => {
+    const cost = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 };
+    const enriched = enrichAdobeModel({
+      id: 'claude-sonnet-5-0',
+      name: 'Claude Sonnet 5.0',
+      cost,
+    });
+    expect(enriched.cost).toEqual(cost);
+  });
+
+  it('prefers cached cost over entry cost', () => {
+    const entryCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+    const cachedCost = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 };
+    const enriched = enrichAdobeModel(
+      { id: 'claude-sonnet-5-0', name: 'Sonnet', cost: entryCost },
+      { id: 'claude-sonnet-5-0', cost: cachedCost }
+    );
+    expect(enriched.cost).toEqual(cachedCost);
+  });
 });

--- a/packages/webapp/tests/providers/adobe-model-metadata.test.ts
+++ b/packages/webapp/tests/providers/adobe-model-metadata.test.ts
@@ -111,4 +111,14 @@ describe('enrichAdobeModel', () => {
     );
     expect(enriched.cost).toEqual(cachedCost);
   });
+
+  it('adds thinkingLevelMap with xhigh for Sonnet 5 (pi-ai 0.80.3 omits it)', () => {
+    const enriched = enrichAdobeModel({ id: 'claude-sonnet-5', name: 'Claude Sonnet 5' });
+    expect(enriched.thinkingLevelMap).toEqual({ xhigh: 'xhigh' });
+  });
+
+  it('does not add thinkingLevelMap for non-Sonnet-5 models', () => {
+    const enriched = enrichAdobeModel({ id: 'claude-sonnet-4-6', name: 'Sonnet 4.6' });
+    expect(enriched.thinkingLevelMap).toBeUndefined();
+  });
 });

--- a/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
+++ b/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
@@ -181,7 +181,8 @@ describe('bedrock-camp built-in provider', () => {
     ['global.anthropic.claude-opus-4-7', 'xhigh'],
     ['us.anthropic.claude-opus-4-8', 'xhigh'],
     ['us.anthropic.claude-opus-4-9', 'xhigh'],
-    ['us.anthropic.claude-sonnet-4-6', 'high'],
+    ['us.anthropic.claude-sonnet-4-6', 'max'],
+    ['us.anthropic.claude-sonnet-5-0', 'xhigh'],
   ])('uses adaptive thinking for Opus/Sonnet ≥ 4.6 (%s -> effort=%s)', async (modelId, expectedEffort) => {
     const payload = await capturePayload(baseModel({ id: modelId, name: modelId }), {
       reasoning: 'xhigh',

--- a/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
+++ b/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
@@ -182,7 +182,7 @@ describe('bedrock-camp built-in provider', () => {
     ['us.anthropic.claude-opus-4-8', 'xhigh'],
     ['us.anthropic.claude-opus-4-9', 'xhigh'],
     ['us.anthropic.claude-sonnet-4-6', 'max'],
-    ['us.anthropic.claude-sonnet-5-0', 'xhigh'],
+    ['us.anthropic.claude-sonnet-5', 'xhigh'],
   ])('uses adaptive thinking for Opus/Sonnet ≥ 4.6 (%s -> effort=%s)', async (modelId, expectedEffort) => {
     const payload = await capturePayload(baseModel({ id: modelId, name: modelId }), {
       reasoning: 'xhigh',

--- a/packages/webapp/tests/providers/claude-model-version.test.ts
+++ b/packages/webapp/tests/providers/claude-model-version.test.ts
@@ -86,12 +86,15 @@ describe('claudeSupportsNativeXhighEffort', () => {
     ['claude-opus-4-7'],
     ['claude-opus-4-8'],
     ['claude-opus-4-9'],
-  ])('returns true for Opus ≥ 4.7 (%s)', (id) => {
+    ['claude-sonnet-5-0'],
+    ['us.anthropic.claude-sonnet-5-0'],
+  ])('returns true for Opus ≥ 4.7 or Sonnet ≥ 5.0 (%s)', (id) => {
     expect(claudeSupportsNativeXhighEffort(id)).toBe(true);
   });
 
   it.each([
     ['claude-opus-4-6'],
+    ['claude-sonnet-4-6'],
     ['claude-sonnet-4-7'],
     ['gpt-4o'],
   ])('returns false for %s', (id) => {
@@ -100,15 +103,18 @@ describe('claudeSupportsNativeXhighEffort', () => {
 });
 
 describe('claudeSupportsMaxEffort', () => {
-  it('returns true only for Opus 4.6', () => {
-    expect(claudeSupportsMaxEffort('claude-opus-4-6')).toBe(true);
+  it.each([
+    ['claude-opus-4-6'],
+    ['claude-sonnet-4-6'],
+  ])('returns true for %s (xhigh → max clamp)', (id) => {
+    expect(claudeSupportsMaxEffort(id)).toBe(true);
   });
 
   it.each([
     ['claude-opus-4-5'],
     ['claude-opus-4-7'],
     ['claude-opus-4-8'],
-    ['claude-sonnet-4-6'],
+    ['claude-sonnet-5-0'],
     ['gpt-4o'],
   ])('returns false for %s', (id) => {
     expect(claudeSupportsMaxEffort(id)).toBe(false);
@@ -127,6 +133,7 @@ describe('claudeRejectsTemperature', () => {
   it.each([
     ['claude-opus-4-6'],
     ['claude-sonnet-4-6'],
+    ['claude-sonnet-5-0'],
     ['claude-sonnet-4-9'],
     ['claude-haiku-4-9'],
     ['gpt-4o'],

--- a/packages/webapp/tests/providers/claude-model-version.test.ts
+++ b/packages/webapp/tests/providers/claude-model-version.test.ts
@@ -17,6 +17,8 @@ describe('parseClaudeVersion', () => {
     ['claude-opus-4-9', { family: 'opus', major: 4, minor: 9 }],
     ['claude-sonnet-4-5', { family: 'sonnet', major: 4, minor: 5 }],
     ['claude-sonnet-4-6', { family: 'sonnet', major: 4, minor: 6 }],
+    ['claude-sonnet-5-0', { family: 'sonnet', major: 5, minor: 0 }],
+    ['us.anthropic.claude-sonnet-5-0', { family: 'sonnet', major: 5, minor: 0 }],
     ['claude-haiku-4-5', { family: 'haiku', major: 4, minor: 5 }],
     ['us.anthropic.claude-opus-4-8', { family: 'opus', major: 4, minor: 8 }],
     ['global.anthropic.claude-opus-4-9', { family: 'opus', major: 4, minor: 9 }],
@@ -63,6 +65,8 @@ describe('claudeSupportsAdaptiveThinking', () => {
     ['claude-opus-4-9'],
     ['claude-sonnet-4-6'],
     ['claude-sonnet-4-7'],
+    ['claude-sonnet-5-0'],
+    ['us.anthropic.claude-sonnet-5-0'],
   ])('returns true for adaptive-capable %s', (id) => {
     expect(claudeSupportsAdaptiveThinking(id)).toBe(true);
   });

--- a/packages/webapp/tests/providers/claude-model-version.test.ts
+++ b/packages/webapp/tests/providers/claude-model-version.test.ts
@@ -17,6 +17,7 @@ describe('parseClaudeVersion', () => {
     ['claude-opus-4-9', { family: 'opus', major: 4, minor: 9 }],
     ['claude-sonnet-4-5', { family: 'sonnet', major: 4, minor: 5 }],
     ['claude-sonnet-4-6', { family: 'sonnet', major: 4, minor: 6 }],
+    ['claude-sonnet-5', { family: 'sonnet', major: 5, minor: 0 }],
     ['claude-sonnet-5-0', { family: 'sonnet', major: 5, minor: 0 }],
     ['us.anthropic.claude-sonnet-5-0', { family: 'sonnet', major: 5, minor: 0 }],
     ['claude-haiku-4-5', { family: 'haiku', major: 4, minor: 5 }],
@@ -52,6 +53,9 @@ describe('parseClaudeVersion', () => {
     ['gemini-2.5-pro'],
     ['opaque-routing-id'],
     [''],
+    // Legacy dated IDs must NOT match (date suffix looks like a version)
+    ['claude-3-5-sonnet-20241022'],
+    ['claude-3-7-sonnet-20250219'],
   ])('returns null for non-Claude id %s', (id) => {
     expect(parseClaudeVersion(id)).toBeNull();
   });
@@ -65,6 +69,7 @@ describe('claudeSupportsAdaptiveThinking', () => {
     ['claude-opus-4-9'],
     ['claude-sonnet-4-6'],
     ['claude-sonnet-4-7'],
+    ['claude-sonnet-5'],
     ['claude-sonnet-5-0'],
     ['us.anthropic.claude-sonnet-5-0'],
   ])('returns true for adaptive-capable %s', (id) => {
@@ -86,6 +91,7 @@ describe('claudeSupportsNativeXhighEffort', () => {
     ['claude-opus-4-7'],
     ['claude-opus-4-8'],
     ['claude-opus-4-9'],
+    ['claude-sonnet-5'],
     ['claude-sonnet-5-0'],
     ['us.anthropic.claude-sonnet-5-0'],
   ])('returns true for Opus ≥ 4.7 or Sonnet ≥ 5.0 (%s)', (id) => {
@@ -114,6 +120,7 @@ describe('claudeSupportsMaxEffort', () => {
     ['claude-opus-4-5'],
     ['claude-opus-4-7'],
     ['claude-opus-4-8'],
+    ['claude-sonnet-5'],
     ['claude-sonnet-5-0'],
     ['gpt-4o'],
   ])('returns false for %s', (id) => {
@@ -133,6 +140,7 @@ describe('claudeRejectsTemperature', () => {
   it.each([
     ['claude-opus-4-6'],
     ['claude-sonnet-4-6'],
+    ['claude-sonnet-5'],
     ['claude-sonnet-5-0'],
     ['claude-sonnet-4-9'],
     ['claude-haiku-4-9'],

--- a/packages/webapp/tests/ui/wc/wc-boot.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-boot.test.ts
@@ -176,7 +176,7 @@ describe('prepareWcShell + attachWcClient', () => {
     boot.refs.composerMeta.dispatchEvent(
       new CustomEvent('thinking-change', { bubbles: true, detail: { thinking: 'max' } })
     );
-    expect(fake.raw.setScoopThinkingLevel).toHaveBeenCalledWith('cone-1', 'xhigh');
+    expect(fake.raw.setScoopThinkingLevel).toHaveBeenCalledWith('cone-1', 'xhigh', 'max');
   });
 
   it('renders streamed agent events into the thread', async () => {


### PR DESCRIPTION
## Summary

Fix five issues preventing Sonnet 5 from working correctly through the Adobe provider. Bump pi-ai to 0.80.3 which ships the Sonnet 5 model definition.

## Commits

### 1. `fix(adobe): forward reasoning/input from cached models in getModelIds`

`getModelIds` mapped `modelsCache` entries to `enrichModel({ id, name })`, discarding `reasoning` and `input` from the `Model<Api>` objects that `buildAdobeModel` constructs for models unknown to pi-ai. Sonnet 5 lost `reasoning: true`, so thinking was never enabled.

Forward `reasoning` and `input` from the cached model. `enrichAdobeModel` still gives precedence to the proxy's `proxyMetadataCache` (`cached ?? entry`).

### 2. `fix(adobe): support xhigh effort for Sonnet 5, max clamp for Sonnet 4.6`

`claudeSupportsNativeXhighEffort` was gated to `opus >= 4.7`. The Anthropic API supports `xhigh` for Sonnet >= 5.0 too. `claudeSupportsMaxEffort` only covered Opus 4.6, but Sonnet 4.6 also accepts `max` (not `xhigh`) as its highest effort.

| Model | xhigh → | Before | After |
|-------|---------|--------|-------|
| Opus >= 4.7 | xhigh | ✅ | ✅ |
| Opus 4.6 | max | ✅ | ✅ |
| Sonnet >= 5.0 | xhigh | ❌ high | ✅ |
| Sonnet 4.6 | max | ❌ high | ✅ |

### 3. `fix(adobe): preserve max as a distinct API effort level`

pi-ai's `ThinkingLevel` maxes out at `xhigh`. SLICC's 6th UI level (Sprofondato / `max`) was collapsed to `xhigh` via `PI_FROM_META` and never reached the API as `effort: "max"`.

Add `effortOverride?: string` to `ScoopConfig`. When the user picks Sprofondato, the UI sets `thinkingLevel: 'xhigh'` (pi-ai compat) + `effortOverride: 'max'`. The stream wrapper injects the override into options, where `withAdaptiveThinkingShim` picks it up directly.

Plumbed through: wc-live → offscreen-client → kernel types → orchestrator → lifecycle-manager → scoop-context → stream options. `metaThinkingForScoop` also reads `effortOverride` so the UI pill shows Sprofondato (not Inzuppato) after refresh.

### 4. `fix(adobe): inherit family costs for unknown models (cost counter)`

`buildAdobeModel` hardcoded zero costs for unknown models. The cost counter showed $0.00 for Sonnet 5 while Opus models (known to pi-ai) had real costs.

Add `findFamilyCost`: searches pi-ai's registry for the closest model in the same family and inherits its cost structure. Also add `cost` to `AdobeModelMetadata`/`EnrichedAdobeModel` and forward it through `getModelIds`.

### 5. `chore: bump pi-ai to 0.80.3 (adds Sonnet 5 model)`

0.80.3 ships `claude-sonnet-5` with `reasoning: true`, real costs ($2/$10 introductory), 1M context, 128K max output. Adaptations:

- **`parseClaudeVersion`**: support single-version IDs (`claude-sonnet-5` without minor). Uses `{1,2}` digit constraint + negative lookahead to avoid false positives on legacy dated IDs (`claude-3-5-sonnet-20241022`).
- **`enrichAdobeModel`**: add `thinkingLevelMap: { xhigh: 'xhigh' }` for Sonnet 5 — 0.80.3 omits it, causing `getSupportedThinkingLevels` to exclude `xhigh`.
- **`bedrock-camp`**: adapt to `buildBaseOptions` signature change (added `context` as 2nd param).

## After all fixes

| SLICC level | Label | Sonnet 5 effort |
|-------------|-------|----------------|
| off | Secco | (no thinking) |
| low | Goccia | low |
| medium | Bagnato | medium |
| high | Affogato | high |
| xhigh | Inzuppato | xhigh |
| max | Sprofondato | max |

## Tests

Updated + new tests in: `claude-model-version`, `adaptive-thinking`, `adobe-model-metadata`, `bedrock-camp`, `wc-boot`, `offscreen-bridge`.