### PR TITLE
fix(git): surface real clone errors + fix OPFS parallel-checkout race

### DIFF
--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -211,6 +211,21 @@ export class VirtualFS {
   private mountSyncChannel: BroadcastChannel | null = null;
   /** Index of files in mounted directories for fast discovery. */
   private mountIndex = new MountIndex();
+  /**
+   * Serializes local backend mutations that create directories and the
+   * writes that depend on them (`mkdir` / `writeFile` / `symlink`). The
+   * ZenFS `WebAccess` (OPFS) backend keeps a single in-memory directory
+   * index that it mutates non-atomically across `await` points, so
+   * isomorphic-git's concurrent checkout `writeFile`/`symlink` calls —
+   * each ensuring its parent via `mkdir(recursive)` — could interleave
+   * such that a write ran against a not-yet-materialized parent and threw
+   * spurious `ENOENT` (aggregated into `MultipleGitError`, non-deterministic
+   * across runs). Funneling those mutations through this promise-chain lock
+   * makes parent-creation-then-write a single critical section. Reads and
+   * mount-backend ops stay off the lock, so the uncontended fast path costs
+   * only one extra microtask. Mirrors `BrowserAPI._tabLock`.
+   */
+  private _writeLock: Promise<void> = Promise.resolve();
 
   private constructor(
     dbName: string,
@@ -1350,13 +1365,16 @@ export class VirtualFS {
     } catch {
       /* file doesn't exist yet */
     }
-    // Ensure parent directory exists
+    // Ensure the parent directory exists and write the file as ONE critical
+    // section under the write lock: on the ZenFS OPFS backend the parent
+    // must be fully materialized before the write, and concurrent
+    // mkdir/write ops interleaving on the shared index would otherwise let a
+    // write hit a not-yet-created parent (spurious ENOENT). See _writeLock.
     const { dir } = splitPath(resolved);
-    if (dir !== '/') {
-      await this.mkdir(dir, { recursive: true });
-    }
-    try {
-      await this.lfs.writeFile(resolved, content);
+    await this.withWriteLock(async () => {
+      if (dir !== '/') {
+        await this.mkdirRecursiveUnlocked(dir);
+      }
       // ZenFS' WebAccess (OPFS) backend writes at offset 0 WITHOUT
       // truncating: rewriting a file with shorter content leaves the old
       // tail in place ("short" over "AAAA…" reads back "shortAAA…"),
@@ -1370,10 +1388,28 @@ export class VirtualFS {
           : content instanceof Uint8Array
             ? content.byteLength
             : (content as ArrayBuffer).byteLength;
-      await this.lfs.truncate?.(resolved, byteLength);
-    } catch (err) {
-      throw this.convertError(err, normalized);
-    }
+      try {
+        await this.lfs.writeFile(resolved, content);
+      } catch (err) {
+        // Defense-in-depth: if the parent still isn't visible, re-ensure it
+        // once and retry before surfacing the error.
+        if (dir !== '/' && err instanceof Error && err.message.includes('ENOENT')) {
+          await this.mkdirRecursiveUnlocked(dir);
+          try {
+            await this.lfs.writeFile(resolved, content);
+          } catch (retryErr) {
+            throw this.convertError(retryErr, normalized);
+          }
+        } else {
+          throw this.convertError(err, normalized);
+        }
+      }
+      try {
+        await this.lfs.truncate?.(resolved, byteLength);
+      } catch (err) {
+        throw this.convertError(err, normalized);
+      }
+    });
     this.watcher?.notify([
       {
         type: wasExisting ? 'modify' : 'create',
@@ -1473,6 +1509,48 @@ export class VirtualFS {
   }
 
   /**
+   * Run a local backend mutation under {@link _writeLock} so directory
+   * creation and dependent writes never interleave on ZenFS' shared
+   * in-memory index. Mirrors {@link BrowserAPI.withTab}.
+   */
+  private async withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+    let release!: () => void;
+    const next = new Promise<void>((r) => {
+      release = r;
+    });
+    const prev = this._writeLock;
+    this._writeLock = next;
+    await prev;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Recursive local `mkdir` walk WITHOUT acquiring {@link _writeLock}. The
+   * caller must already hold the lock — used by {@link mkdir}, {@link
+   * writeFile}, and {@link symlink} so parent-ensure-then-write is one
+   * critical section (and so re-entrant lock acquisition can't deadlock).
+   */
+  private async mkdirRecursiveUnlocked(normalized: string): Promise<void> {
+    const parts = normalized.split('/').filter(Boolean);
+    let current = '';
+    for (const part of parts) {
+      current += '/' + part;
+      try {
+        await this.lfs.mkdir(current);
+      } catch (err: unknown) {
+        // Ignore EEXIST errors in recursive mode
+        if (err instanceof Error && !err.message.includes('EEXIST')) {
+          throw this.convertError(err, current);
+        }
+      }
+    }
+  }
+
+  /**
    * Create a directory.
    * @throws FsError EEXIST if directory already exists (non-recursive),
    *                 ENOENT if parent doesn't exist (non-recursive)
@@ -1498,26 +1576,17 @@ export class VirtualFS {
     }
 
     if (options?.recursive) {
-      // Create all parent directories
-      const parts = normalized.split('/').filter(Boolean);
-      let current = '';
-      for (const part of parts) {
-        current += '/' + part;
-        try {
-          await this.lfs.mkdir(current);
-        } catch (err: unknown) {
-          // Ignore EEXIST errors in recursive mode
-          if (err instanceof Error && !err.message.includes('EEXIST')) {
-            throw this.convertError(err, current);
-          }
-        }
-      }
+      // Create all parent directories under the write lock so a concurrent
+      // writeFile/symlink can't observe a half-materialized path.
+      await this.withWriteLock(() => this.mkdirRecursiveUnlocked(normalized));
     } else {
-      try {
-        await this.lfs.mkdir(normalized);
-      } catch (err) {
-        throw this.convertError(err, normalized);
-      }
+      await this.withWriteLock(async () => {
+        try {
+          await this.lfs.mkdir(normalized);
+        } catch (err) {
+          throw this.convertError(err, normalized);
+        }
+      });
       this.watcher?.notify([{ type: 'create', path: normalized, entryType: 'directory' }]);
     }
   }
@@ -1839,16 +1908,29 @@ export class VirtualFS {
         normalizedLinkPath
       );
     }
-    // Ensure parent directory exists
+    // Ensure the parent directory exists and create the link as ONE critical
+    // section under the write lock — same ZenFS concurrent-checkout race as
+    // writeFile (see _writeLock).
     const { dir } = splitPath(normalizedLinkPath);
-    if (dir !== '/') {
-      await this.mkdir(dir, { recursive: true });
-    }
-    try {
-      await this.lfs.symlink(target, normalizedLinkPath);
-    } catch (err) {
-      throw this.convertError(err, normalizedLinkPath);
-    }
+    await this.withWriteLock(async () => {
+      if (dir !== '/') {
+        await this.mkdirRecursiveUnlocked(dir);
+      }
+      try {
+        await this.lfs.symlink(target, normalizedLinkPath);
+      } catch (err) {
+        if (dir !== '/' && err instanceof Error && err.message.includes('ENOENT')) {
+          await this.mkdirRecursiveUnlocked(dir);
+          try {
+            await this.lfs.symlink(target, normalizedLinkPath);
+          } catch (retryErr) {
+            throw this.convertError(retryErr, normalizedLinkPath);
+          }
+        } else {
+          throw this.convertError(err, normalizedLinkPath);
+        }
+      }
+    });
     this.watcher?.notify([{ type: 'create', path: normalizedLinkPath, entryType: 'symlink' }]);
   }
 

--- a/packages/webapp/src/git/commands/checkout.ts
+++ b/packages/webapp/src/git/commands/checkout.ts
@@ -1,6 +1,7 @@
 /** `git checkout` — switch branches, create branches, or restore files. */
 
 import * as git from 'isomorphic-git';
+import { expandGitError } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function checkout(
@@ -76,24 +77,17 @@ export async function checkout(
 /**
  * Format a checkout failure. `MultipleGitError` from isomorphic-git carries
  * a `.data.errors[]` array of per-file failures; surface each underlying
- * message instead of the cosmetic "There are multiple errors..." noise
- * (#1033-5). Anything else is rethrown so `execute()`'s outer catch still
- * handles it uniformly.
+ * message (via {@link expandGitError}) instead of the cosmetic "There are
+ * multiple errors..." noise (#1033-5). Anything else is rethrown so
+ * `execute()`'s outer catch still handles it uniformly.
  */
 function formatCheckoutError(err: unknown, ref: string): GitCommandResult {
   if (err instanceof Error && err.name === 'MultipleGitError') {
-    const data = err as Error & { errors?: unknown; data?: { errors?: unknown } };
-    const errorsList = Array.isArray(data.errors)
-      ? data.errors
-      : Array.isArray(data.data?.errors)
-        ? data.data?.errors
-        : [];
-    let stderr = `error: unable to checkout '${ref}':\n`;
-    for (const inner of errorsList as unknown[]) {
-      const msg = inner instanceof Error ? inner.message : String(inner);
-      stderr += `  ${msg}\n`;
-    }
-    return { stdout: '', stderr, exitCode: 1 };
+    const body = expandGitError(err)
+      .split('\n')
+      .map((line) => `  ${line}`)
+      .join('\n');
+    return { stdout: '', stderr: `error: unable to checkout '${ref}':\n${body}\n`, exitCode: 1 };
   }
   throw err;
 }

--- a/packages/webapp/src/git/commands/clone.ts
+++ b/packages/webapp/src/git/commands/clone.ts
@@ -3,7 +3,7 @@
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { gitHttp } from '../git-http.js';
-import { flagString, GIT_FLAG_SPECS } from './shared.js';
+import { expandGitError, flagString, GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function clone(
@@ -82,12 +82,13 @@ export async function clone(
 }
 
 /**
- * Format a clone failure: interpolates the real target dir in place of the
- * OPFS internal placeholder so the user sees the path they asked for, never
- * the literal `<path>` token from the backend (#1033-1).
+ * Format a clone failure: unpacks any `MultipleGitError`/`AggregateError`
+ * wrapper (#1033-5) and interpolates the real target dir in place of the OPFS
+ * internal placeholder so the user sees the path they asked for, never the
+ * literal `<path>` token from the backend (#1033-1).
  */
 function formatCloneError(err: unknown, targetDir: string): GitCommandResult {
-  const raw = err instanceof Error ? err.message : String(err);
+  const raw = expandGitError(err);
   const scrubbed = raw
     .replace(/'\/__opfs__\/[^']*<path>'/g, `'${targetDir}'`)
     .replace(/\/__opfs__\/[^\s'"<]*<path>/g, targetDir)

--- a/packages/webapp/src/git/commands/clone.ts
+++ b/packages/webapp/src/git/commands/clone.ts
@@ -11,7 +11,12 @@ export async function clone(
   cwd: string,
   args: string[]
 ): Promise<GitCommandResult> {
-  if (args.length === 0) {
+  // Parse flags first so the url/dir come from positionals — leading flags like
+  // `clone --branch X --single-branch <url> <dir>` must round-trip (not treat
+  // `--branch` as the URL). Mirrors fetch.ts's positional handling (#1033-3).
+  const { flags, positionals } = parseArgs(args, GIT_FLAG_SPECS.clone);
+
+  if (positionals.length === 0) {
     return {
       stdout: '',
       stderr: 'fatal: You must specify a repository to clone.\n',
@@ -19,8 +24,8 @@ export async function clone(
     };
   }
 
-  const url = args[0];
-  let dir = args[1];
+  const url = positionals[0];
+  let dir = positionals[1];
 
   // Extract repo name from URL if dir not specified
   if (!dir) {
@@ -29,7 +34,6 @@ export async function clone(
   }
 
   const targetDir = dir.startsWith('/') ? dir : `${cwd}/${dir}`;
-  const { flags } = parseArgs(args, GIT_FLAG_SPECS.clone);
   const depth = flagString(flags, 'depth');
   const branch = flagString(flags, 'branch');
   const singleBranch = flags['single-branch'] !== false;

--- a/packages/webapp/src/git/commands/shared.ts
+++ b/packages/webapp/src/git/commands/shared.ts
@@ -94,3 +94,31 @@ export function flagString(flags: Record<string, unknown>, name: string): string
   const str = Array.isArray(value) ? String(value[value.length - 1]) : String(value);
   return str === '' ? undefined : str;
 }
+
+/**
+ * Unpack an isomorphic-git error into a human-readable message. `MultipleGitError`
+ * (and native `AggregateError`) hide the real per-operation failures behind the
+ * cosmetic "There are multiple errors..." text, carrying them in an `.errors[]`
+ * (or `.data.errors[]`) array; surface each underlying message instead (#1033-5).
+ * Nested wrappers are expanded recursively; an empty errors array falls back to
+ * the wrapper's own message. Plain errors return `.message`; non-Errors stringify.
+ */
+export function expandGitError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const data = err as Error & { errors?: unknown; data?: { errors?: unknown } };
+  const isMultiple =
+    err.name === 'MultipleGitError' ||
+    err.name === 'AggregateError' ||
+    (typeof AggregateError !== 'undefined' && err instanceof AggregateError);
+  if (isMultiple) {
+    const errorsList = Array.isArray(data.errors)
+      ? data.errors
+      : Array.isArray(data.data?.errors)
+        ? (data.data?.errors as unknown[])
+        : [];
+    if (errorsList.length > 0) {
+      return errorsList.map((inner) => expandGitError(inner)).join('\n');
+    }
+  }
+  return err.message;
+}

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -37,7 +37,7 @@ import { remote } from './commands/remote.js';
 import { reset } from './commands/reset.js';
 import { revParse } from './commands/rev-parse.js';
 import { rm } from './commands/rm.js';
-import { GIT_FLAG_SPECS } from './commands/shared.js';
+import { expandGitError, GIT_FLAG_SPECS } from './commands/shared.js';
 import { show } from './commands/show.js';
 import { showRef } from './commands/show-ref.js';
 import { stash } from './commands/stash.js';
@@ -364,7 +364,9 @@ export class GitCommands {
           };
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      // #1033-5: unpack MultipleGitError/AggregateError wrappers so the CLI
+      // shows the real underlying failures, not the cosmetic wrapper text.
+      const message = expandGitError(err);
       return {
         stdout: '',
         stderr: `fatal: ${message}\n`,

--- a/packages/webapp/tests/e2e/git-clone-live.test.ts
+++ b/packages/webapp/tests/e2e/git-clone-live.test.ts
@@ -4,8 +4,12 @@
  * through the page-side `RemoteTerminalView` (published on
  * `globalThis.__slicc_terminal_view` by `mountWorkbenchTerminal`) — the same
  * programmatic-dispatch seam `speech-roundtrip.test.ts` uses — and runs
- * `git clone https://github.com/ai-ecoverse/skills.git` against the public
- * GitHub repo, unauthenticated, through the node-server fetch proxy.
+ * `git clone --branch slicc-e2e-fixture --single-branch
+ * https://github.com/ai-ecoverse/skills.git` against the public GitHub repo,
+ * unauthenticated, through the node-server fetch proxy. The clone is pinned to
+ * the immutable lightweight tag `slicc-e2e-fixture` (a frozen fixture commit)
+ * so the hard-coded path assertions below stay stable — future pushes to
+ * `main` can never move the tree out from under this test.
  *
  * Purpose is a REGRESSION GUARD on the clone hot path: after the live clone of
  * ai-ecoverse/skills, it asserts a FULL successful checkout — exit 0, a nonzero
@@ -88,15 +92,19 @@ test.describe('live git clone (real network)', () => {
       timeout: 30_000,
     });
 
-    // Run the real clone into a clean target dir.
+    // Run the real clone into a clean target dir. Pin to the immutable
+    // `slicc-e2e-fixture` tag (maps to an isomorphic-git ref; --single-branch
+    // is the clone default) so the tree — and the asserted paths below — never
+    // move.
     const targetDir = '/workspace/skills-live-clone';
+    const cloneCmd = `git clone --branch slicc-e2e-fixture --single-branch ${CLONE_URL} ${targetDir}`;
     await exec(page, `rm -rf ${targetDir}`);
-    const clone = await exec(page, `git clone ${CLONE_URL} ${targetDir}`);
+    const clone = await exec(page, cloneCmd);
 
     // Attach the FULL captured output to the report so the failure message is
     // actionable — the real inner cause, not an opaque wrapper.
     const report =
-      `command: git clone ${CLONE_URL} ${targetDir}\n` +
+      `command: ${cloneCmd}\n` +
       `exitCode: ${clone.exitCode}\n` +
       `--- stdout ---\n${clone.stdout}\n` +
       `--- stderr ---\n${clone.stderr}`;
@@ -104,9 +112,11 @@ test.describe('live git clone (real network)', () => {
     // Also to stdout so `--reporter=list` surfaces it inline.
     console.log('\n=== live git clone result ===\n' + report + '\n=============================\n');
 
-    // Assert a FULL successful checkout. Until the OPFS parallel-checkout race
-    // fix lands this (correctly) goes red — that is the intended signal, and the
-    // full captured output is attached above so the failure is diagnosable.
+    // Assert a FULL successful checkout — the invariant this test guards. The
+    // OPFS parallel-checkout race fix ships in this same PR, so a clean clone is
+    // the EXPECTED outcome; a failure here means a real regression in the
+    // clone/checkout path or in the OPFS write serialization, and the full
+    // captured output is attached above so it is diagnosable.
     expect(clone.exitCode, `git clone did not exit 0 — full output:\n${report}`).toBe(0);
 
     // The checkout must report a nonzero file count, not an empty tree.

--- a/packages/webapp/tests/e2e/git-clone-live.test.ts
+++ b/packages/webapp/tests/e2e/git-clone-live.test.ts
@@ -1,0 +1,132 @@
+// packages/webapp/tests/e2e/git-clone-live.test.ts
+/**
+ * REAL, live-network `git clone` E2E. Drives the WC shell's worker terminal
+ * through the page-side `RemoteTerminalView` (published on
+ * `globalThis.__slicc_terminal_view` by `mountWorkbenchTerminal`) — the same
+ * programmatic-dispatch seam `speech-roundtrip.test.ts` uses — and runs
+ * `git clone https://github.com/ai-ecoverse/skills.git` against the public
+ * GitHub repo, unauthenticated, through the node-server fetch proxy.
+ *
+ * Purpose is a REGRESSION GUARD on the clone hot path: after the live clone of
+ * ai-ecoverse/skills, it asserts a FULL successful checkout — exit 0, a nonzero
+ * "Checked out N files." count, a representative DEEP regular file, and a
+ * representative SYMLINK entry (mode 120000) — so a broken checkout (e.g. the
+ * OPFS parallel-checkout ENOENT race, which the earlier `expandGitError` unwrap
+ * in `src/git/commands/shared.ts` surfaces as a real error) fails loudly with
+ * the full captured output attached, not an opaque wrapper sentence.
+ *
+ * NOT gated: `git clone` is a hot regression area, so this test runs in CI as
+ * part of the standard `npm run test:e2e` pass. It hits the real network
+ * (unauthenticated clone of a public repo), so it is made robust to transient
+ * flake via the e2e config's CI retries and a generous per-test timeout, and
+ * asserts on the substantive outcome (a full successful checkout), never
+ * incidental timing.
+ *
+ *   Run: npm run test:e2e -- git-clone-live
+ */
+
+import { expect, test } from '@playwright/test';
+import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
+
+const CLONE_URL = 'https://github.com/ai-ecoverse/skills.git';
+
+interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+declare global {
+  interface Window {
+    __slicc_terminal_view?: {
+      executeCommandInTerminal(cmd: string): Promise<ExecResult>;
+    };
+  }
+}
+
+/** Run a single command through the worker shell via the published view. */
+async function exec(page: import('@playwright/test').Page, cmd: string): Promise<ExecResult> {
+  return page.evaluate(async (command: string) => {
+    const view = window.__slicc_terminal_view;
+    if (!view) throw new Error('terminal view not published yet');
+    return view.executeCommandInTerminal(command);
+  }, cmd);
+}
+
+test.describe('live git clone (real network)', () => {
+  test('clones ai-ecoverse/skills and surfaces the real result', async ({ page }, testInfo) => {
+    // A real, unauthenticated clone over the fetch proxy dwarfs the 30s
+    // default; give the whole run 5 minutes.
+    test.setTimeout(5 * 60_000);
+
+    await seedSkipSwReload(page);
+    // Boot with the thin-bridge launch params so the virtual git CLI's HTTP
+    // (isomorphic-git → gitHttp → proxied-fetch) reaches the node-server
+    // `/api/fetch-proxy` and real network works.
+    await gotoLeader(page);
+    await waitForSW(page);
+
+    // Cone welcome message is the same readiness signal the other scenarios
+    // wait on — it renders only after the kernel-worker cone bootstrap
+    // completes and the OffscreenClient is wired.
+    await page.waitForSelector('slicc-input-card');
+    await expect(page.locator('slicc-chat-thread')).toContainText('Welcome to SLICC', {
+      timeout: 20_000,
+    });
+
+    // Activate the term surface via the shell's documented entry point; this
+    // opens the workbench AND fires the lazy mount that publishes
+    // `__slicc_terminal_view`.
+    await page.evaluate(() => {
+      const shell = document.querySelector('slicc-shell') as
+        | (HTMLElement & { select?: (id: string) => void })
+        | null;
+      if (!shell?.select) throw new Error('<slicc-shell>.select(id) unavailable');
+      shell.select('term');
+    });
+    await page.waitForFunction(() => window.__slicc_terminal_view != null, null, {
+      timeout: 30_000,
+    });
+
+    // Run the real clone into a clean target dir.
+    const targetDir = '/workspace/skills-live-clone';
+    await exec(page, `rm -rf ${targetDir}`);
+    const clone = await exec(page, `git clone ${CLONE_URL} ${targetDir}`);
+
+    // Attach the FULL captured output to the report so the failure message is
+    // actionable — the real inner cause, not an opaque wrapper.
+    const report =
+      `command: git clone ${CLONE_URL} ${targetDir}\n` +
+      `exitCode: ${clone.exitCode}\n` +
+      `--- stdout ---\n${clone.stdout}\n` +
+      `--- stderr ---\n${clone.stderr}`;
+    await testInfo.attach('git-clone-output', { body: report, contentType: 'text/plain' });
+    // Also to stdout so `--reporter=list` surfaces it inline.
+    console.log('\n=== live git clone result ===\n' + report + '\n=============================\n');
+
+    // Assert a FULL successful checkout. Until the OPFS parallel-checkout race
+    // fix lands this (correctly) goes red — that is the intended signal, and the
+    // full captured output is attached above so the failure is diagnosable.
+    expect(clone.exitCode, `git clone did not exit 0 — full output:\n${report}`).toBe(0);
+
+    // The checkout must report a nonzero file count, not an empty tree.
+    const checkedOut = clone.stdout.match(/Checked out (\d+) files\./);
+    expect(checkedOut, `expected "Checked out N files." — full output:\n${report}`).not.toBeNull();
+    expect(Number(checkedOut?.[1] ?? '0'), 'checked-out file count').toBeGreaterThan(0);
+
+    // A representative DEEP regular file must exist on the VFS. Verified to
+    // exist in ai-ecoverse/skills@main (skills/suno/references/endpoints.md).
+    const deepFile = `${targetDir}/skills/suno/references/endpoints.md`;
+    const deep = await exec(page, `[ -f ${deepFile} ] && echo FILE_OK`);
+    expect(deep.exitCode, `[ -f ${deepFile} ] failed: ${JSON.stringify(deep)}`).toBe(0);
+    expect(deep.stdout).toContain('FILE_OK');
+
+    // A representative SYMLINK entry (git mode 120000) must be checked out AS a
+    // symlink, not materialized as a regular file. Verified to be a mode-120000
+    // entry in ai-ecoverse/skills@main (tiles/advanced/skills/slack).
+    const symlink = `${targetDir}/tiles/advanced/skills/slack`;
+    const link = await exec(page, `[ -L ${symlink} ] && readlink ${symlink}`);
+    expect(link.exitCode, `[ -L ${symlink} ] failed: ${JSON.stringify(link)}`).toBe(0);
+    expect(link.stdout.trim(), `readlink ${symlink} target`).not.toBe('');
+  });
+});

--- a/packages/webapp/tests/fs/virtual-fs.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.test.ts
@@ -67,6 +67,62 @@ describe('VirtualFS', () => {
     });
   });
 
+  describe('concurrent writes (parallel-checkout race)', () => {
+    // Regression for the OPFS/ZenFS parallel-checkout race: isomorphic-git
+    // fires many writeFile/symlink calls CONCURRENTLY, each first doing
+    // mkdir(parent, { recursive: true }). On the shared, non-atomic ZenFS
+    // index those overlapping dir-creates + writes could interleave so a
+    // write hit a not-yet-materialized parent → spurious ENOENT (aggregated
+    // into MultipleGitError, non-deterministic across runs). The write lock
+    // makes parent-ensure-then-write one critical section.
+    it('writes many files across overlapping nested dirs concurrently', async () => {
+      const paths: string[] = [];
+      for (let d = 0; d < 20; d++) {
+        for (let f = 0; f < 10; f++) {
+          paths.push(`/repo/pkg${d}/src/nested/deep/file${f}.txt`);
+        }
+      }
+      await Promise.all(paths.map((p) => vfs.writeFile(p, p)));
+      const contents = await Promise.all(paths.map((p) => vfs.readTextFile(p)));
+      expect(contents).toEqual(paths);
+    });
+
+    it('creates many symlinks across overlapping nested dirs concurrently', async () => {
+      const links: { link: string; target: string }[] = [];
+      for (let d = 0; d < 15; d++) {
+        for (let f = 0; f < 8; f++) {
+          links.push({
+            link: `/repo/tiles/basic/skills/g${d}/link${f}`,
+            target: `../../../../target/g${d}/dest${f}`,
+          });
+        }
+      }
+      await Promise.all(links.map(({ link, target }) => vfs.symlink(target, link)));
+      const targets = await Promise.all(links.map(({ link }) => vfs.readlink(link)));
+      expect(targets).toEqual(links.map((l) => l.target));
+    });
+
+    it('mixes concurrent files and symlinks sharing the same parent dirs', async () => {
+      const ops: Promise<void>[] = [];
+      const files: string[] = [];
+      const symlinks: string[] = [];
+      for (let i = 0; i < 60; i++) {
+        const dir = `/mix/a/b/c${i % 5}`;
+        const file = `${dir}/f${i}.txt`;
+        const link = `${dir}/l${i}`;
+        files.push(file);
+        symlinks.push(link);
+        ops.push(vfs.writeFile(file, `data-${i}`));
+        ops.push(vfs.symlink(`./f${i}.txt`, link));
+      }
+      await Promise.all(ops);
+      for (let i = 0; i < files.length; i++) {
+        expect(await vfs.readTextFile(files[i])).toBe(`data-${i}`);
+        expect(await vfs.readlink(symlinks[i])).toBe(`./f${i}.txt`);
+      }
+    });
+  });
+
   describe('stat and exists', () => {
     it('stats a file', async () => {
       await vfs.writeFile('/file.txt', 'data');

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -354,6 +354,82 @@ describe('GitCommands', () => {
     }
   });
 
+  it('parses url/dir from positionals when flags precede them', async () => {
+    const cloneSpy = vi.spyOn(isoGit, 'clone').mockResolvedValue();
+    const listFilesSpy = vi.spyOn(isoGit, 'listFiles').mockResolvedValue([]);
+    try {
+      const result = await git.execute(
+        [
+          'clone',
+          '--branch',
+          'slicc-e2e-fixture',
+          '--single-branch',
+          'https://github.com/ai-ecoverse/skills.git',
+          '/workspace/skills-live-clone',
+        ],
+        '/workspace'
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(cloneSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://github.com/ai-ecoverse/skills.git',
+          dir: '/workspace/skills-live-clone',
+          ref: 'slicc-e2e-fixture',
+          singleBranch: true,
+        })
+      );
+    } finally {
+      cloneSpy.mockRestore();
+      listFilesSpy.mockRestore();
+    }
+  });
+
+  it('parses url/dir when flags follow the positionals', async () => {
+    const cloneSpy = vi.spyOn(isoGit, 'clone').mockResolvedValue();
+    const listFilesSpy = vi.spyOn(isoGit, 'listFiles').mockResolvedValue([]);
+    try {
+      const result = await git.execute(
+        ['clone', 'https://github.com/example/repo.git', 'repo', '--depth', '1'],
+        '/workspace'
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(cloneSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://github.com/example/repo.git',
+          dir: '/workspace/repo',
+          depth: 1,
+        })
+      );
+    } finally {
+      cloneSpy.mockRestore();
+      listFilesSpy.mockRestore();
+    }
+  });
+
+  it('derives the target dir from the URL when only the url is given', async () => {
+    const cloneSpy = vi.spyOn(isoGit, 'clone').mockResolvedValue();
+    const listFilesSpy = vi.spyOn(isoGit, 'listFiles').mockResolvedValue([]);
+    try {
+      const result = await git.execute(
+        ['clone', 'https://github.com/example/repo.git'],
+        '/workspace'
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(cloneSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://github.com/example/repo.git',
+          dir: '/workspace/repo',
+        })
+      );
+    } finally {
+      cloneSpy.mockRestore();
+      listFilesSpy.mockRestore();
+    }
+  });
+
   it('handles rev-parse', async () => {
     await git.execute(['init'], '/project');
 

--- a/packages/webapp/tests/git/git-error-format.test.ts
+++ b/packages/webapp/tests/git/git-error-format.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit coverage for `expandGitError` — the shared helper that unpacks
+ * isomorphic-git's `MultipleGitError`/`AggregateError` wrappers into the real
+ * underlying messages so the virtual git CLI never leaks the cosmetic
+ * "There are multiple errors..." text (#1033-5).
+ */
+import { describe, expect, it } from 'vitest';
+import { expandGitError } from '../../src/git/commands/shared.js';
+
+class MultipleGitError extends Error {
+  override name = 'MultipleGitError';
+  errors?: unknown;
+  data?: { errors?: unknown };
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+describe('expandGitError', () => {
+  it('unpacks a MultipleGitError with a top-level .errors array', () => {
+    const err = new MultipleGitError('There are multiple errors...');
+    err.errors = [new Error('failure a'), new Error('failure b')];
+    expect(expandGitError(err)).toBe('failure a\nfailure b');
+  });
+
+  it('unpacks a MultipleGitError that only carries .data.errors', () => {
+    const err = new MultipleGitError('There are multiple errors...');
+    err.data = { errors: [new Error('nested a'), new Error('nested b')] };
+    expect(expandGitError(err)).toBe('nested a\nnested b');
+  });
+
+  it('recursively expands a nested MultipleGitError inside errors[]', () => {
+    const inner = new MultipleGitError('There are multiple errors...');
+    inner.errors = [new Error('leaf 1'), new Error('leaf 2')];
+    const outer = new MultipleGitError('There are multiple errors...');
+    outer.errors = [new Error('top'), inner];
+    expect(expandGitError(outer)).toBe('top\nleaf 1\nleaf 2');
+  });
+
+  it('unpacks a native AggregateError', () => {
+    const err = new AggregateError([new Error('agg a'), new Error('agg b')], 'wrapper');
+    expect(expandGitError(err)).toBe('agg a\nagg b');
+  });
+
+  it('unpacks an AggregateError-shaped error matched by name', () => {
+    const err = new Error('wrapper text') as Error & { errors?: unknown };
+    err.name = 'AggregateError';
+    err.errors = [new Error('by name a'), new Error('by name b')];
+    expect(expandGitError(err)).toBe('by name a\nby name b');
+  });
+
+  it('falls back to the wrapper message when the errors array is empty', () => {
+    const err = new MultipleGitError('There are multiple errors...');
+    err.errors = [];
+    expect(expandGitError(err)).toBe('There are multiple errors...');
+  });
+
+  it('returns .message for a plain Error', () => {
+    expect(expandGitError(new Error('plain failure'))).toBe('plain failure');
+  });
+
+  it('stringifies a non-Error value', () => {
+    expect(expandGitError('boom')).toBe('boom');
+    expect(expandGitError(42)).toBe('42');
+  });
+});


### PR DESCRIPTION
## Problem

Running `git clone` of a non-trivial repo (e.g. `https://github.com/ai-ecoverse/skills.git`) in the webapp failed with an opaque, unactionable error:

> fatal: There are multiple errors that were thrown by the method...

That message is isomorphic-git's `MultipleGitError` wrapper hiding the real per-file failures. Once unwrapped, the underlying failures turned out to be a **non-deterministic concurrency race** in the OPFS/ZenFS-backed VirtualFS during parallel checkout.

## Diagnosis (via slicc-debug against a live instance)

- Inner errors were dozens of `FsError: ENOENT` during isomorphic-git checkout, on both deep files and symlinks.
- **Non-deterministic**: same repo, Run A = 115 failing paths, Run B = 40 (B a strict subset of A) — a race, not a fixed OPFS limitation.
- Control: `octocat/Hello-World` (1 file) clones cleanly.
- Disproven theories: OPFS 50-level nesting, 250-char filenames, quota (~10 GB), and manual symlinks all work.

**Mechanism**: isomorphic-git checkout fires many `writeFile`/`symlink` calls concurrently. Each first does `mkdir(parent, {recursive})`. On the ZenFS OPFS backend those overlapping dir-create + write ops are not atomic, so a write can land against a not-yet-materialized parent → spurious ENOENT.

## Changes

1. **Unwrap aggregate git errors** (`git/commands/shared.ts`, `clone.ts`, `checkout.ts`, `git-commands.ts`): recursively flatten `MultipleGitError` / native `AggregateError` into the real underlying messages so failures are actionable.
2. **Fix the OPFS parallel-checkout race** (`fs/virtual-fs.ts`): a promise-chain write lock makes parent-dir creation and the dependent write/symlink a single critical section (`writeFile` + `symlink` + recursive `mkdir`). Reads/stat/mounts stay off the lock, so the fast path is unchanged. OPFS truncate-after-write is preserved, plus an ENOENT re-ensure+retry as defense-in-depth.
3. **Hardened live e2e** (`tests/e2e/git-clone-live.test.ts`): does a real `git clone` of `ai-ecoverse/skills` through the leader terminal + fetch proxy and asserts exit 0, a nonzero checked-out file count, a deep file (`skills/suno/references/endpoints.md`), and a real symlink (`tiles/advanced/skills/slack`). Runs **unconditionally in CI** (no env gate) with CI retries + a generous timeout — this is a hot regression area.

## Verification

- fs+git vitest: 711 passed / 3 skipped
- lint: pass · typecheck: pass (all tsc projects)
- Independent verifier review: approved, no deadlock/perf/correctness concerns.

## Known limitation

The new **unit** regression test is a concurrency smoke test, not a true race reproducer — Node/vitest uses the InMemory ZenFS backend, which lacks OPFS's non-atomic shared-index behavior. The authoritative regression guard is the **ungated live e2e running real in-browser OPFS in CI**.

## Parity

Webapp-only (virtual git over the OPFS VFS). No node-server / swift-server / ios-app peer change needed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author