### PR TITLE
feat(kernel): expand exec bridge for buffered stdin + kill, add child_process polyfill

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -888,6 +888,10 @@ Run any shell command through just-bash and get the result. Works in both CLI an
 
 ```typescript
 exec(command: string): Promise<{ stdout: string; stderr: string; exitCode: number }>
+exec.spawn(argv: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }>
+exec.start(commandOrArgv: string | string[], opts?: {
+  stdin?: string; stdinKind?: 'text' | 'bytes'; args?: string[];
+}): { kill(sig?: string): Promise<boolean>; stdin: { write(chunk: string): void; end(): void }; done: Promise<{ stdout; stderr; exitCode }> }
 
 // Example: get an OAuth token
 const r = await exec('oauth-token adobe');
@@ -896,7 +900,36 @@ const token = r.stdout.trim();
 // Example: list files
 const ls = await exec('ls -la /workspace');
 console.log(ls.stdout);
+
+// Example: shell-free argv form (no shell parsing — safe for untrusted args)
+await exec.spawn(['git', 'commit', '-m', userMessage]);
 ```
+
+**`exec.start` — killable, buffered-stdin spawn handle.** `exec.start` returns
+immediately with a handle instead of a promise. Buffer input with
+`stdin.write(chunk)`, launch the command with `stdin.end()`, and `await done`
+for the `{ stdout, stderr, exitCode }` result. `kill(signal?)` fans a signal
+out to the in-flight command via the `exec:kill` op. This is the substrate the
+realm `require('child_process')` polyfill is built on. It is **not**
+interactive or streaming: just-bash is one-shot buffered, so `stdin` is a
+single upfront buffer (post-launch `stdin.write` calls are dropped) and the
+result arrives only when the command completes.
+
+```typescript
+const h = exec.start(['jq', '.name']);
+h.stdin.write('{"name":"slicc"}');
+h.stdin.end();
+const { stdout } = await h.done;
+// h.kill('SIGTERM'); // abort an in-flight command
+```
+
+`require('child_process')` / `require('node:child_process')` (`.jsh` / `node`
+realm) resolves to a shim over `exec.start`: `exec` / `execFile` / `spawn`
+return a `ChildProcess` EventEmitter (`'exit'` / `'close'`, Readable
+`.stdout` / `.stderr`); `exec` / `execFile` carry `util.promisify.custom`. The
+sync forms (`execSync` / `spawnSync` / `execFileSync`) and `fork` throw — no
+synchronous or long-lived process model. `.bsh` scripts run in the target page
+(no shell bridge), so `child_process` is unavailable there.
 
 #### require / module / exports
 
@@ -1395,14 +1428,15 @@ Packages are fetched from [esm.sh](https://esm.sh) and cached for the session. V
 
 Some Node.js built-in modules are available via `require()`:
 
-| Module                                                  | Status                                                                |
-| ------------------------------------------------------- | --------------------------------------------------------------------- |
-| `fs`                                                    | ✅ VFS bridge (readFile, writeFile, readDir, exists, stat, mkdir, rm) |
-| `process`                                               | ✅ Shim (argv, env, cwd, exit, stdout, stderr)                        |
-| `buffer`                                                | ✅ Browser polyfill                                                   |
-| `path`                                                  | ✅ Via esm.sh (browser polyfill)                                      |
-| `url`, `querystring`, `util`, `events`, `assert`        | ✅ Via esm.sh                                                         |
-| `http`, `https`, `crypto`, `net`, `child_process`, etc. | ❌ Not available in browser                                           |
+| Module                                           | Status                                                                                            |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `fs`                                             | ✅ VFS bridge (readFile, writeFile, readDir, exists, stat, mkdir, rm)                             |
+| `process`                                        | ✅ Shim (argv, env, cwd, exit, stdout, stderr)                                                    |
+| `buffer`                                         | ✅ Browser polyfill                                                                               |
+| `path`                                           | ✅ Via esm.sh (browser polyfill)                                                                  |
+| `url`, `querystring`, `util`, `events`, `assert` | ✅ Via esm.sh                                                                                     |
+| `child_process`                                  | ✅ Realm shim over the `exec.start` bridge (`exec`/`execFile`/`spawn`; sync forms + `fork` throw) |
+| `http`, `https`, `crypto`, `net`, etc.           | ❌ Not available in browser                                                                       |
 
 The `node:` prefix is supported: `require('node:path')` works the same as `require('path')`.
 

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -612,14 +612,20 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   // `child_process` polyfill needs. NOT interactive/streaming (just-bash is
   // one-shot buffered).
   let __nextSpawnId = 1;
+  // POSIX 128+signum exit code for a client-side pre-start kill (matches the host).
+  const __killExitCode = (sig) => sig === 'SIGKILL' ? 137 : sig === 'SIGINT' ? 130 : 143;
   execBridge.start = (commandOrArgv, opts) => {
     const spawnId = __nextSpawnId++;
     const chunks = [];
     let started = false;
+    // A `kill()` before `stdin.end()` can't reach the host (the spawnId isn't
+    // registered until `exec:start` arrives), so honor it client-side.
+    let killed = false;
     let resolveDone, rejectDone;
     const done = new Promise((resolve, reject) => { resolveDone = resolve; rejectDone = reject; });
     const fire = () => {
-      if (started) return;
+      // A pre-start `kill()` wins: never launch a spawn that was already killed.
+      if (started || killed) return;
       started = true;
       // Buffered `stdin.write` chunks win; fall back to an upfront `opts.stdin`.
       // `undefined` means "no stdin" (empty on the host).
@@ -631,11 +637,20 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       rpcCall('exec', 'start', [spawnId, commandOrArgv, startOpts]).then(resolveDone, rejectDone);
     };
     return {
-      kill: (sig) => rpcCall('exec', 'kill', [spawnId, sig]),
+      kill: (sig) => {
+        // Post-start: the host knows the spawnId, so fan the signal out.
+        if (started) return rpcCall('exec', 'kill', [spawnId, sig]);
+        // Pre-start: an `exec:kill` would race ahead of `exec:start` and be
+        // dropped, then `fire()` would still launch. Honor it client-side —
+        // mark killed so `fire()` no-ops and resolve `done` as terminated.
+        killed = true;
+        resolveDone({ stdout: '', stderr: '', exitCode: __killExitCode(sig) });
+        return Promise.resolve(true);
+      },
       stdin: {
-        // Post-launch writes are dropped — just-bash takes a single upfront
-        // buffer, so there's no interactive stdin to write to.
-        write: (chunk) => { if (!started) chunks.push(chunk); },
+        // Post-launch (or post-kill) writes are dropped — just-bash takes a
+        // single upfront buffer, so there's no interactive stdin to write to.
+        write: (chunk) => { if (!started && !killed) chunks.push(chunk); },
         end: () => fire(),
       },
       done: done,
@@ -1688,11 +1703,20 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
           resolve({ stdout: stdout, stderr: stderr });
         });
       });
-      const execFilePromise = (file, args, options) => new Promise((resolve, reject) => {
-        execFileImpl(file, args, options, (error, stdout, stderr) => {
+      const execFilePromise = (file, argsOrOptions, maybeOptions) => new Promise((resolve, reject) => {
+        const cb = (error, stdout, stderr) => {
           if (error) { reject(Object.assign(error, { stdout: stdout, stderr: stderr })); return; }
           resolve({ stdout: stdout, stderr: stderr });
-        });
+        };
+        // `promisify(execFile)` may be called as execFileP(file),
+        // execFileP(file, args), execFileP(file, options), or
+        // execFileP(file, args, options). Normalize so `execFileImpl` always
+        // gets the args array in slot 2 and the callback in slot 4 — otherwise
+        // an options-as-2nd-arg (or bare-file) call lands the callback in a
+        // slot `execFileImpl` never reads and the promise hangs forever.
+        const args = Array.isArray(argsOrOptions) ? argsOrOptions : [];
+        const options = Array.isArray(argsOrOptions) ? maybeOptions : argsOrOptions;
+        execFileImpl(file, args, options, cb);
       });
       const cpUnavailable = (name) => () => {
         throw new Error('child_process.' + name + ' is not available in the browser realm');

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -162,7 +162,7 @@ function bootstrapRealmPort(port) {
   // host-side graph walker never routes a bare built-in into node_modules.
   // NODE_BUILTINS_UNAVAILABLE is DERIVED (complete set minus the available
   // ones) so the two lists can never drift.
-  const NODE_BUILTIN_AVAILABLE = new Set(['events', 'fs', 'fs/promises', 'os', 'path', 'stream', 'url', 'crypto', 'process', 'buffer', 'assert', 'assert/strict', 'util', 'zlib']);
+  const NODE_BUILTIN_AVAILABLE = new Set(['child_process', 'events', 'fs', 'fs/promises', 'os', 'path', 'stream', 'url', 'crypto', 'process', 'buffer', 'assert', 'assert/strict', 'util', 'zlib']);
   const NODE_BUILTINS = new Set([
     'assert','assert/strict','async_hooks','buffer','child_process','cluster',
     'console','constants','crypto','dgram','diagnostics_channel','dns',
@@ -604,6 +604,43 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   // surface as the worker realm (`js-realm-shared.ts`).
   const execBridge = (cmd) => rpcCall('exec', 'run', [cmd]);
   execBridge.spawn = (argv) => rpcCall('exec', 'spawn', [argv]);
+  // `exec.start(commandOrArgv, opts?)` — deferred-start, buffered-stdin,
+  // killable spawn handle. Mirror of the `start` closure in `createExecBridge`
+  // (`js-realm-shared.ts`): `stdin.write` buffers, `stdin.end()` launches the
+  // command via the `exec:start` op (resolving `done` with the buffered
+  // result), and `kill` fans a signal out via `exec:kill`. The substrate the
+  // `child_process` polyfill needs. NOT interactive/streaming (just-bash is
+  // one-shot buffered).
+  let __nextSpawnId = 1;
+  execBridge.start = (commandOrArgv, opts) => {
+    const spawnId = __nextSpawnId++;
+    const chunks = [];
+    let started = false;
+    let resolveDone, rejectDone;
+    const done = new Promise((resolve, reject) => { resolveDone = resolve; rejectDone = reject; });
+    const fire = () => {
+      if (started) return;
+      started = true;
+      // Buffered `stdin.write` chunks win; fall back to an upfront `opts.stdin`.
+      // `undefined` means "no stdin" (empty on the host).
+      const buffered = chunks.length > 0 ? chunks.join('') : (opts && opts.stdin);
+      const startOpts = {};
+      if (buffered !== undefined) startOpts.stdin = buffered;
+      if (opts && opts.stdinKind !== undefined) startOpts.stdinKind = opts.stdinKind;
+      if (opts && opts.args !== undefined) startOpts.args = opts.args;
+      rpcCall('exec', 'start', [spawnId, commandOrArgv, startOpts]).then(resolveDone, rejectDone);
+    };
+    return {
+      kill: (sig) => rpcCall('exec', 'kill', [spawnId, sig]),
+      stdin: {
+        // Post-launch writes are dropped — just-bash takes a single upfront
+        // buffer, so there's no interactive stdin to write to.
+        write: (chunk) => { if (!started) chunks.push(chunk); },
+        end: () => fire(),
+      },
+      done: done,
+    };
+  };
   // Self-reference so destructured access (`const { exec } = require('sliccy:exec')`)
   // and the property form (`require('sliccy:exec').exec(...)`) both work.
   execBridge.exec = execBridge;
@@ -1484,6 +1521,200 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     function PassThrough() { Transform.call(this); } PassThrough.prototype = Object.create(Transform.prototype); PassThrough.prototype.constructor = PassThrough;
     return { Readable: Readable, Writable: Writable, Transform: Transform, PassThrough: PassThrough, Stream: StreamBase };
   })();
+  // `nodeChildProcess` — the subset of the Node `child_process` built-in served
+  // by `require('child_process')` / `require('node:child_process')`. Built on
+  // the `exec.start` spawn handle (deferred-start, buffered-stdin, killable) so
+  // `exec` / `execFile` / `spawn` map onto the one-shot just-bash exec pipeline.
+  // Sync forms (`execSync` / `spawnSync` / `execFileSync`) and `fork` throw.
+  // Mirror of `createNodeChildProcess` in `kernel/realm/js-realm-helpers.ts`;
+  // keep in lockstep (parity asserted by tests/kernel/realm/js-realm-helpers.test.ts).
+  const nodeChildProcess = (function () {
+    const Readable = nodeStream.Readable;
+    const EventEmitter = nodeEvents;
+    const CP_PROMISIFY_CUSTOM = Symbol.for('nodejs.util.promisify.custom');
+    let nextCpPid = 1;
+    function cpChunkToString(chunk) {
+      if (typeof chunk === 'string') return chunk;
+      if (ArrayBuffer.isView(chunk)) {
+        return new TextDecoder().decode(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+      }
+      if (chunk === null || chunk === undefined) return '';
+      return String(chunk);
+    }
+    function cpEncodeChunk(text, encoding) {
+      if (encoding === undefined || encoding === 'utf8' || encoding === 'utf-8') return text;
+      const B = globalThis.Buffer;
+      if (encoding === 'buffer' || encoding === null) return B.from(text);
+      return B.from(text).toString(encoding);
+    }
+    function cpJoin(chunks, encoding) {
+      if (chunks.length === 0) return cpEncodeChunk('', encoding);
+      if (typeof chunks[0] === 'string') return chunks.join('');
+      const B = globalThis.Buffer;
+      return B ? B.concat(chunks) : chunks[0];
+    }
+    function cpEmitStream(stream, text, encoding) {
+      if (text.length > 0) stream.emit('data', cpEncodeChunk(text, encoding));
+      stream.readable = false;
+      stream.emit('end');
+    }
+    function cpMakeStdin(handle) {
+      const runCb = (maybe) => { if (typeof maybe === 'function') queueMicrotask(maybe); };
+      return {
+        writable: true,
+        write: function (chunk, encoding, cb) {
+          handle.stdin.write(cpChunkToString(chunk));
+          runCb(typeof encoding === 'function' ? encoding : cb);
+          return true;
+        },
+        end: function (chunk, encoding, cb) {
+          if (chunk !== undefined && typeof chunk !== 'function') handle.stdin.write(cpChunkToString(chunk));
+          handle.stdin.end();
+          this.writable = false;
+          runCb(typeof chunk === 'function' ? chunk : typeof encoding === 'function' ? encoding : cb);
+        },
+      };
+    }
+    function ChildProcess(handle, encoding, spawnfile, spawnargs) {
+      EventEmitter.call(this);
+      this.handle = handle;
+      this.pid = nextCpPid++;
+      this.spawnfile = spawnfile;
+      this.spawnargs = spawnargs;
+      this.exitCode = null;
+      this.signalCode = null;
+      this.killed = false;
+      this.stdout = new Readable();
+      this.stderr = new Readable();
+      this.stdin = cpMakeStdin(handle);
+      const self = this;
+      handle.done.then(
+        function (result) { self.finish(result, encoding); },
+        function (error) { self.emit('error', error instanceof Error ? error : new Error(String(error))); }
+      );
+    }
+    ChildProcess.prototype = Object.create(EventEmitter.prototype);
+    ChildProcess.prototype.constructor = ChildProcess;
+    ChildProcess.prototype.finish = function (result, encoding) {
+      cpEmitStream(this.stdout, result.stdout, encoding);
+      cpEmitStream(this.stderr, result.stderr, encoding);
+      this.exitCode = result.exitCode;
+      // Node reports (code, signal): a killed child carries a null code + the
+      // signal name; a naturally-exited one the exit code + a null signal.
+      const code = this.killed ? null : result.exitCode;
+      const signal = this.killed ? this.signalCode : null;
+      this.emit('exit', code, signal);
+      this.emit('close', code, signal);
+    };
+    ChildProcess.prototype.kill = function (signal) {
+      signal = signal || 'SIGTERM';
+      this.killed = true;
+      this.signalCode = signal;
+      this.handle.kill(signal).catch(function () {});
+      return true;
+    };
+    function createNodeChildProcess(exec) {
+      const launch = (commandOrArgv, options, encoding, spawnfile, spawnargs) => {
+        const handle = exec.start(commandOrArgv);
+        const child = new ChildProcess(handle, encoding, spawnfile, spawnargs);
+        if (options.input !== undefined) child.stdin.write(cpChunkToString(options.input));
+        queueMicrotask(() => handle.stdin.end());
+        return child;
+      };
+      const buffered = (child, encoding, label, cb) => {
+        if (typeof cb !== 'function') return;
+        const outChunks = [];
+        const errChunks = [];
+        child.stdout.on('data', (c) => outChunks.push(c));
+        child.stderr.on('data', (c) => errChunks.push(c));
+        child.once('error', (err) => cb(err, cpJoin(outChunks, encoding), cpJoin(errChunks, encoding)));
+        child.once('close', (code, signal) => {
+          const stdout = cpJoin(outChunks, encoding);
+          const stderr = cpJoin(errChunks, encoding);
+          if (code === 0) { cb(null, stdout, stderr); return; }
+          const err = Object.assign(new Error('Command failed: ' + label + '\n' + cpChunkToString(stderr)), {
+            code: code === null ? undefined : code,
+            killed: child.killed,
+            signal: signal == null ? null : signal,
+            cmd: label,
+          });
+          cb(err, stdout, stderr);
+        });
+      };
+      const execImpl = (command, optionsOrCb, callback) => {
+        const cb = typeof optionsOrCb === 'function' ? optionsOrCb : callback;
+        const options = optionsOrCb && typeof optionsOrCb === 'object' ? optionsOrCb : {};
+        const encoding = options.encoding === undefined ? 'utf8' : options.encoding;
+        const child = launch(command, options, encoding, command, []);
+        buffered(child, encoding, command, cb);
+        return child;
+      };
+      const execFileImpl = (file, argsOrOptions, optionsOrCb, callback) => {
+        let args = [];
+        let options = {};
+        let cb;
+        if (Array.isArray(argsOrOptions)) {
+          args = argsOrOptions;
+          if (typeof optionsOrCb === 'function') cb = optionsOrCb;
+          else { options = optionsOrCb || {}; cb = typeof callback === 'function' ? callback : undefined; }
+        } else if (typeof argsOrOptions === 'function') {
+          cb = argsOrOptions;
+        } else if (argsOrOptions && typeof argsOrOptions === 'object') {
+          options = argsOrOptions;
+          cb = typeof optionsOrCb === 'function' ? optionsOrCb : undefined;
+        }
+        const encoding = options.encoding === undefined ? 'utf8' : options.encoding;
+        const argv = [file].concat(args);
+        const child = launch(argv, options, encoding, file, args);
+        buffered(child, encoding, argv.join(' '), cb);
+        return child;
+      };
+      const spawnImpl = (command, argsOrOptions, maybeOptions) => {
+        let args = [];
+        let options = {};
+        if (Array.isArray(argsOrOptions)) { args = argsOrOptions; options = maybeOptions || {}; }
+        else if (argsOrOptions && typeof argsOrOptions === 'object') { options = argsOrOptions; }
+        // Node's spawn streams default to raw Buffers (no encoding).
+        const encoding = options.encoding === undefined ? 'buffer' : options.encoding;
+        // Default is shell-free (argv form); `shell:true` runs the joined string.
+        const commandOrArgv = options.shell
+          ? command + (args.length ? ' ' + args.join(' ') : '')
+          : [command].concat(args);
+        return launch(commandOrArgv, options, encoding, command, args);
+      };
+      const execPromise = (command, options) => new Promise((resolve, reject) => {
+        execImpl(command, options, (error, stdout, stderr) => {
+          if (error) { reject(Object.assign(error, { stdout: stdout, stderr: stderr })); return; }
+          resolve({ stdout: stdout, stderr: stderr });
+        });
+      });
+      const execFilePromise = (file, args, options) => new Promise((resolve, reject) => {
+        execFileImpl(file, args, options, (error, stdout, stderr) => {
+          if (error) { reject(Object.assign(error, { stdout: stdout, stderr: stderr })); return; }
+          resolve({ stdout: stdout, stderr: stderr });
+        });
+      });
+      const cpUnavailable = (name) => () => {
+        throw new Error('child_process.' + name + ' is not available in the browser realm');
+      };
+      const attachPromisify = (fn, impl) => {
+        Object.defineProperty(fn, CP_PROMISIFY_CUSTOM, { value: impl, enumerable: false, configurable: true });
+      };
+      attachPromisify(execImpl, execPromise);
+      attachPromisify(execFileImpl, execFilePromise);
+      return {
+        exec: execImpl,
+        execFile: execFileImpl,
+        spawn: spawnImpl,
+        execSync: cpUnavailable('execSync'),
+        spawnSync: cpUnavailable('spawnSync'),
+        execFileSync: cpUnavailable('execFileSync'),
+        fork: cpUnavailable('fork'),
+        ChildProcess: ChildProcess,
+      };
+    }
+    return createNodeChildProcess(execBridge);
+  })();
   // `nodeUrl` — the Node `url` built-in subset served by `require('url')` /
   // `require('node:url')`. Mirror of `nodeUrl` in `kernel/realm/js-realm-helpers.ts`.
   const nodeUrl = (function () {
@@ -1611,6 +1842,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     if (bareId === 'fs/promises') return { hit: true, value: fsBridge };
     if (bareId === 'path') return { hit: true, value: nodePath };
     if (bareId === 'crypto') return { hit: true, value: nodeCrypto };
+    if (bareId === 'child_process') return { hit: true, value: nodeChildProcess };
     if (bareId === 'process') return { hit: true, value: processShim };
     if (bareId === 'buffer') return { hit: true, value: { Buffer: globalThis.Buffer } };
     if (bareId === 'assert') return { hit: true, value: nodeAssert };

--- a/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
@@ -24,18 +24,18 @@ Every `.jsh` script runs in an async wrapper with a small Node-standard surface 
 
 The bespoke globals are hard-cut. Reach each capability via `require('sliccy:<name>')` (CJS) or `import ... from 'sliccy:<name>'` (ESM). `require('fs')` / `require('node:fs')` keeps returning the VFS bridge.
 
-| `require('sliccy:<name>')`                    | Purpose                                                                                                                                                                                                |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sliccy:exec`                                 | Callable `exec(cmd)` plus `.spawn(argv[])` and `.exec` self-reference. Returns `{ stdout, stderr, exitCode }`. Use `const { exec } = require('sliccy:exec')` or `const exec = require('sliccy:exec')`. |
-| `sliccy:skill`                                | Frozen `{ dir, refs, assets, config(), config(updates), token(providerId) }`. Replaces ad-hoc `argv[1]` dirname math and `oauth-token` shell-outs.                                                     |
-| `sliccy:http`                                 | `http.client({ baseUrl, token, headers, retry, timeoutMs })` builder.                                                                                                                                  |
-| `sliccy:browser`                              | `findTab`, `ensureTab`, `eval`, `evalAsync`, `cookie`, `localStorage`, `fetch`, `websocket.on(...).filter(...).forward(...)`.                                                                          |
-| `sliccy:usb` / `sliccy:serial` / `sliccy:hid` | `list()` / `request()` + device methods (`open`/`close`/`sendReport`/...). Chromium-only.                                                                                                              |
-| `sliccy:cli`                                  | `die(msg, opts?)`, `out(value)`, `warn(msg, opts?)`, `help(text)`. `opts` is `number` or `{ exitCode?, prefix? }`; `prefix: ''` removes the default `Error:` / `Warning:` label entirely.              |
-| `sliccy:color`                                | ANSI helpers: `green`, `red`, `yellow`, `gray`, `bold`, `cyan`, `dim`, plus `enabled` flag (auto-disabled on non-TTY / `NO_COLOR`).                                                                    |
-| `sliccy:time`                                 | `parseDuration(spec)`, `ago(spec)`, `range(spec)`, `future(spec)`, `gmailDate(spec)`. Units: `ms s m h d w M y` (note: `m` = minutes, `M` = months).                                                   |
-| `sliccy:fmt`                                  | `trunc(s, n)`, `col(s, width)`, `table(rows, widths?)`, `date(value, style?)`. `style`: `'short' \| 'iso' \| 'human' \| 'locale'` (locale = `Intl.DateTimeFormat` medium).                             |
-| `sliccy:pool`                                 | `pool(n, items, fn)` — bounded concurrency runner, results returned in input order.                                                                                                                    |
+| `require('sliccy:<name>')`                    | Purpose                                                                                                                                                                                                                                                                    |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sliccy:exec`                                 | Callable `exec(cmd)` plus `.spawn(argv[])`, `.start(cmdOrArgv, opts?)` (killable, buffered-stdin spawn handle) and `.exec` self-reference. Returns `{ stdout, stderr, exitCode }`. Use `const { exec } = require('sliccy:exec')` or `const exec = require('sliccy:exec')`. |
+| `sliccy:skill`                                | Frozen `{ dir, refs, assets, config(), config(updates), token(providerId) }`. Replaces ad-hoc `argv[1]` dirname math and `oauth-token` shell-outs.                                                                                                                         |
+| `sliccy:http`                                 | `http.client({ baseUrl, token, headers, retry, timeoutMs })` builder.                                                                                                                                                                                                      |
+| `sliccy:browser`                              | `findTab`, `ensureTab`, `eval`, `evalAsync`, `cookie`, `localStorage`, `fetch`, `websocket.on(...).filter(...).forward(...)`.                                                                                                                                              |
+| `sliccy:usb` / `sliccy:serial` / `sliccy:hid` | `list()` / `request()` + device methods (`open`/`close`/`sendReport`/...). Chromium-only.                                                                                                                                                                                  |
+| `sliccy:cli`                                  | `die(msg, opts?)`, `out(value)`, `warn(msg, opts?)`, `help(text)`. `opts` is `number` or `{ exitCode?, prefix? }`; `prefix: ''` removes the default `Error:` / `Warning:` label entirely.                                                                                  |
+| `sliccy:color`                                | ANSI helpers: `green`, `red`, `yellow`, `gray`, `bold`, `cyan`, `dim`, plus `enabled` flag (auto-disabled on non-TTY / `NO_COLOR`).                                                                                                                                        |
+| `sliccy:time`                                 | `parseDuration(spec)`, `ago(spec)`, `range(spec)`, `future(spec)`, `gmailDate(spec)`. Units: `ms s m h d w M y` (note: `m` = minutes, `M` = months).                                                                                                                       |
+| `sliccy:fmt`                                  | `trunc(s, n)`, `col(s, width)`, `table(rows, widths?)`, `date(value, style?)`. `style`: `'short' \| 'iso' \| 'human' \| 'locale'` (locale = `Intl.DateTimeFormat` medium).                                                                                                 |
+| `sliccy:pool`                                 | `pool(n, items, fn)` — bounded concurrency runner, results returned in input order.                                                                                                                                                                                        |
 
 `require('sliccy:<unknown>')` throws a scheme-specific error (`Unknown sliccy: module '<name>'`); empty `require('sliccy:')` throws `empty sliccy: module name`. `sliccy:` lookups never hit the registry / `node_modules` / `ipk install`.
 
@@ -113,6 +113,31 @@ const { exec } = require('sliccy:exec');
 const userMessage = flags.message ?? 'wip';
 await exec.spawn(['git', 'commit', '-m', userMessage]); // safe even with quotes/spaces in userMessage
 ```
+
+```javascript
+// exec.start(cmdOrArgv, opts?) — killable, buffered-stdin spawn handle. Buffer
+// stdin with .write(), launch with .end(), await .done for the result, and
+// .kill(signal?) to abort. NOT interactive/streaming — just-bash is one-shot
+// buffered, so stdin is a single upfront buffer and post-launch writes drop.
+const { exec } = require('sliccy:exec');
+const h = exec.start(['jq', '.name']);
+h.stdin.write('{"name":"slicc"}');
+h.stdin.end();
+const { stdout, exitCode } = await h.done;
+// h.kill('SIGTERM') fans a signal out via the exec:kill op.
+```
+
+### `require('child_process')` — Node process API over the exec bridge
+
+`require('child_process')` / `require('node:child_process')` resolves in the `.jsh` / `node` realm to a shim built on `exec.start`. `exec` / `execFile` / `spawn` map onto the one-shot just-bash exec pipeline: the returned `ChildProcess` is an `EventEmitter` that fires `'exit'` / `'close'`, and its `.stdout` / `.stderr` are Readable stubs that each emit a single `'data'` chunk then `'end'`. `exec` / `execFile` also carry a `util.promisify.custom` implementation resolving `{ stdout, stderr }`.
+
+```javascript
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const { stdout } = await promisify(exec)('ls -la /workspace');
+```
+
+The **sync forms** (`execSync` / `spawnSync` / `execFileSync`) and `fork` throw — just-bash has no synchronous or long-lived process model. `.bsh` scripts (which run in the target page via CDP, not the realm) have no shell bridge at all, so `require('child_process')` there is unavailable; use `exec()` from a `.jsh` script instead.
 
 ## jsh runtime extensions
 

--- a/packages/webapp/src/kernel/realm/js-realm-helpers.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-helpers.ts
@@ -1705,3 +1705,350 @@ export const nodeStream = {
   PassThrough,
   Stream: StreamBase,
 };
+
+// ---------------------------------------------------------------------------
+// `nodeChildProcess` — the subset of the Node `child_process` built-in served
+// by the realm `require('child_process')` / `require('node:child_process')`
+// shim. Built on the `exec.start` spawn handle (deferred-start, buffered-stdin,
+// killable) so `exec` / `execFile` / `spawn` map onto the one-shot just-bash
+// exec pipeline. `spawn`'s `.stdout` / `.stderr` are the `nodeStream` Readable
+// stubs, each emitting a single `'data'` chunk then `'end'`; the `ChildProcess`
+// is an EventEmitter that fires `'exit'` / `'close'`. The sync forms
+// (`execSync` / `spawnSync` / `execFileSync`) and `fork` throw — just-bash has
+// no synchronous or long-lived process model. Because the shim needs the
+// per-realm `exec` bridge it is a FACTORY (unlike the static `node*` shims);
+// `js-realm-shared.ts` builds one instance per realm and serves it from
+// `resolveServedBuiltin`. Mirrored inline in `chrome-extension/sandbox.html`.
+// ---------------------------------------------------------------------------
+
+/** Buffered `{ stdout, stderr, exitCode }` the `exec.start` handle resolves. */
+export interface CpExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** The `exec.start` spawn handle this shim builds `ChildProcess` on top of. */
+export interface CpExecHandle {
+  kill(sig?: string): Promise<boolean>;
+  stdin: { write(chunk: string): void; end(): void };
+  done: Promise<CpExecResult>;
+}
+
+export interface CpExecStartOptions {
+  stdin?: string;
+  stdinKind?: 'text' | 'bytes';
+  args?: string[];
+}
+
+/** Structural slice of the realm `exec` bridge the shim needs (`exec.start`). */
+export interface CpExecBridge {
+  start(commandOrArgv: string | string[], opts?: CpExecStartOptions): CpExecHandle;
+}
+
+interface CpOptions {
+  encoding?: string | null;
+  input?: string | ArrayBufferView;
+  shell?: boolean | string;
+}
+
+type CpChunk = string | Buffer;
+type CpExecCallback = (error: Error | null, stdout: CpChunk, stderr: CpChunk) => void;
+
+export interface NodeChildProcess {
+  exec(
+    command: string,
+    options?: CpOptions | CpExecCallback,
+    callback?: CpExecCallback
+  ): ChildProcess;
+  execFile(
+    file: string,
+    args?: string[] | CpOptions | CpExecCallback,
+    options?: CpOptions | CpExecCallback,
+    callback?: CpExecCallback
+  ): ChildProcess;
+  spawn(command: string, args?: string[] | CpOptions, options?: CpOptions): ChildProcess;
+  execSync(...args: unknown[]): never;
+  spawnSync(...args: unknown[]): never;
+  execFileSync(...args: unknown[]): never;
+  fork(...args: unknown[]): never;
+  ChildProcess: typeof ChildProcess;
+}
+
+let nextCpPid = 1;
+
+function cpChunkToString(chunk: unknown): string {
+  if (typeof chunk === 'string') return chunk;
+  if (ArrayBuffer.isView(chunk)) {
+    const v = chunk as ArrayBufferView;
+    return new TextDecoder().decode(new Uint8Array(v.buffer, v.byteOffset, v.byteLength));
+  }
+  if (chunk === null || chunk === undefined) return '';
+  return String(chunk);
+}
+
+function cpEncodeChunk(text: string, encoding: string | null | undefined): CpChunk {
+  if (encoding === undefined || encoding === 'utf8' || encoding === 'utf-8') return text;
+  if (encoding === 'buffer' || encoding === null) return bufferFrom(text);
+  return bufferFrom(text).toString(encoding as BufferEncoding);
+}
+
+function cpJoin(chunks: CpChunk[], encoding: string | null | undefined): CpChunk {
+  if (chunks.length === 0) return cpEncodeChunk('', encoding);
+  if (typeof chunks[0] === 'string') return (chunks as string[]).join('');
+  const B = (globalThis as { Buffer?: typeof Buffer }).Buffer;
+  return B ? B.concat(chunks as Buffer[]) : chunks[0];
+}
+
+function cpEmitStream(stream: Readable, text: string, encoding: string | null | undefined): void {
+  if (text.length > 0) stream.emit('data', cpEncodeChunk(text, encoding));
+  stream.readable = false;
+  stream.emit('end');
+}
+
+function cpMakeStdin(handle: CpExecHandle) {
+  const runCb = (maybe: unknown): void => {
+    if (typeof maybe === 'function') queueMicrotask(maybe as () => void);
+  };
+  return {
+    writable: true,
+    write(chunk: unknown, encoding?: unknown, cb?: unknown): boolean {
+      handle.stdin.write(cpChunkToString(chunk));
+      runCb(typeof encoding === 'function' ? encoding : cb);
+      return true;
+    },
+    end(chunk?: unknown, encoding?: unknown, cb?: unknown): void {
+      if (chunk !== undefined && typeof chunk !== 'function') {
+        handle.stdin.write(cpChunkToString(chunk));
+      }
+      handle.stdin.end();
+      this.writable = false;
+      runCb(typeof chunk === 'function' ? chunk : typeof encoding === 'function' ? encoding : cb);
+    },
+  };
+}
+
+class ChildProcess extends EventEmitter {
+  stdout: Readable;
+  stderr: Readable;
+  stdin: ReturnType<typeof cpMakeStdin>;
+  readonly pid: number;
+  exitCode: number | null = null;
+  signalCode: string | null = null;
+  killed = false;
+  readonly spawnfile: string;
+  readonly spawnargs: string[];
+  private readonly handle: CpExecHandle;
+
+  constructor(
+    handle: CpExecHandle,
+    encoding: string | null | undefined,
+    spawnfile: string,
+    spawnargs: string[]
+  ) {
+    super();
+    this.handle = handle;
+    this.pid = nextCpPid++;
+    this.spawnfile = spawnfile;
+    this.spawnargs = spawnargs;
+    this.stdout = new Readable();
+    this.stderr = new Readable();
+    this.stdin = cpMakeStdin(handle);
+    handle.done.then(
+      (result) => this.finish(result, encoding),
+      (error) => this.emit('error', error instanceof Error ? error : new Error(String(error)))
+    );
+  }
+
+  private finish(result: CpExecResult, encoding: string | null | undefined): void {
+    cpEmitStream(this.stdout, result.stdout, encoding);
+    cpEmitStream(this.stderr, result.stderr, encoding);
+    this.exitCode = result.exitCode;
+    // Node reports (code, signal): a killed child carries a null code + the
+    // signal name; a naturally-exited one the exit code + a null signal.
+    const code = this.killed ? null : result.exitCode;
+    const signal = this.killed ? this.signalCode : null;
+    this.emit('exit', code, signal);
+    this.emit('close', code, signal);
+  }
+
+  kill(signal: string = 'SIGTERM'): boolean {
+    this.killed = true;
+    this.signalCode = signal;
+    this.handle.kill(signal).catch(() => {});
+    return true;
+  }
+}
+
+/**
+ * Build a per-realm `child_process` shim over the supplied `exec` bridge. Each
+ * of `exec` / `execFile` / `spawn` allocates one `exec.start` handle and
+ * auto-launches it on the next microtask so synchronous `stdin.write` / `.end`
+ * calls buffer first (the handle's `started` guard makes the auto-`end()` a
+ * no-op once the caller ended stdin). `exec` / `execFile` also carry a
+ * `util.promisify.custom` implementation resolving `{ stdout, stderr }`.
+ */
+export function createNodeChildProcess(exec: CpExecBridge): NodeChildProcess {
+  const launch = (
+    commandOrArgv: string | string[],
+    options: CpOptions,
+    encoding: string | null | undefined,
+    spawnfile: string,
+    spawnargs: string[]
+  ): ChildProcess => {
+    const handle = exec.start(commandOrArgv);
+    const child = new ChildProcess(handle, encoding, spawnfile, spawnargs);
+    if (options.input !== undefined) child.stdin.write(cpChunkToString(options.input));
+    queueMicrotask(() => handle.stdin.end());
+    return child;
+  };
+
+  const buffered = (
+    child: ChildProcess,
+    encoding: string | null | undefined,
+    label: string,
+    cb: CpExecCallback | undefined
+  ): void => {
+    if (typeof cb !== 'function') return;
+    const outChunks: CpChunk[] = [];
+    const errChunks: CpChunk[] = [];
+    child.stdout.on('data', (c) => outChunks.push(c as CpChunk));
+    child.stderr.on('data', (c) => errChunks.push(c as CpChunk));
+    child.once('error', (err) =>
+      cb(err as Error, cpJoin(outChunks, encoding), cpJoin(errChunks, encoding))
+    );
+    child.once('close', (code, signal) => {
+      const stdout = cpJoin(outChunks, encoding);
+      const stderr = cpJoin(errChunks, encoding);
+      if (code === 0) {
+        cb(null, stdout, stderr);
+        return;
+      }
+      const err = Object.assign(new Error(`Command failed: ${label}\n${cpChunkToString(stderr)}`), {
+        code: code === null ? undefined : (code as number),
+        killed: child.killed,
+        signal: (signal as string | null) ?? null,
+        cmd: label,
+      });
+      cb(err, stdout, stderr);
+    });
+  };
+
+  const execImpl = (
+    command: string,
+    optionsOrCb?: CpOptions | CpExecCallback,
+    callback?: CpExecCallback
+  ): ChildProcess => {
+    const cb = typeof optionsOrCb === 'function' ? optionsOrCb : callback;
+    const options: CpOptions = optionsOrCb && typeof optionsOrCb === 'object' ? optionsOrCb : {};
+    const encoding = options.encoding === undefined ? 'utf8' : options.encoding;
+    const child = launch(command, options, encoding, command, []);
+    buffered(child, encoding, command, cb);
+    return child;
+  };
+
+  const execFileImpl = (
+    file: string,
+    argsOrOptions?: string[] | CpOptions | CpExecCallback,
+    optionsOrCb?: CpOptions | CpExecCallback,
+    callback?: CpExecCallback
+  ): ChildProcess => {
+    let args: string[] = [];
+    let options: CpOptions = {};
+    let cb: CpExecCallback | undefined;
+    if (Array.isArray(argsOrOptions)) {
+      args = argsOrOptions;
+      if (typeof optionsOrCb === 'function') cb = optionsOrCb;
+      else {
+        options = (optionsOrCb as CpOptions) ?? {};
+        cb = typeof callback === 'function' ? callback : undefined;
+      }
+    } else if (typeof argsOrOptions === 'function') {
+      cb = argsOrOptions;
+    } else if (argsOrOptions && typeof argsOrOptions === 'object') {
+      options = argsOrOptions;
+      cb = typeof optionsOrCb === 'function' ? optionsOrCb : undefined;
+    }
+    const encoding = options.encoding === undefined ? 'utf8' : options.encoding;
+    const argv = [file, ...args];
+    const child = launch(argv, options, encoding, file, args);
+    buffered(child, encoding, argv.join(' '), cb);
+    return child;
+  };
+
+  const spawnImpl = (
+    command: string,
+    argsOrOptions?: string[] | CpOptions,
+    maybeOptions?: CpOptions
+  ): ChildProcess => {
+    let args: string[] = [];
+    let options: CpOptions = {};
+    if (Array.isArray(argsOrOptions)) {
+      args = argsOrOptions;
+      options = maybeOptions ?? {};
+    } else if (argsOrOptions && typeof argsOrOptions === 'object') {
+      options = argsOrOptions;
+    }
+    // Node's spawn streams default to raw Buffers (no encoding).
+    const encoding = options.encoding === undefined ? 'buffer' : options.encoding;
+    // Default is shell-free (argv form); `shell:true` runs the joined string.
+    const commandOrArgv: string | string[] = options.shell
+      ? `${command}${args.length ? ` ${args.join(' ')}` : ''}`
+      : [command, ...args];
+    return launch(commandOrArgv, options, encoding, command, args);
+  };
+
+  const execPromise = (
+    command: string,
+    options?: CpOptions
+  ): Promise<{ stdout: CpChunk; stderr: CpChunk }> =>
+    new Promise((resolve, reject) => {
+      execImpl(command, options, (error, stdout, stderr) => {
+        if (error) {
+          reject(Object.assign(error, { stdout, stderr }));
+          return;
+        }
+        resolve({ stdout, stderr });
+      });
+    });
+
+  const execFilePromise = (
+    file: string,
+    args?: string[],
+    options?: CpOptions
+  ): Promise<{ stdout: CpChunk; stderr: CpChunk }> =>
+    new Promise((resolve, reject) => {
+      execFileImpl(file, args, options, (error, stdout, stderr) => {
+        if (error) {
+          reject(Object.assign(error, { stdout, stderr }));
+          return;
+        }
+        resolve({ stdout, stderr });
+      });
+    });
+
+  const cpUnavailable = (name: string) => (): never => {
+    throw new Error(`child_process.${name} is not available in the browser realm`);
+  };
+
+  const attachPromisify = (fn: object, impl: Function): void => {
+    Object.defineProperty(fn, UTIL_PROMISIFY_CUSTOM, {
+      value: impl,
+      enumerable: false,
+      configurable: true,
+    });
+  };
+  attachPromisify(execImpl, execPromise);
+  attachPromisify(execFileImpl, execFilePromise);
+
+  return {
+    exec: execImpl,
+    execFile: execFileImpl,
+    spawn: spawnImpl,
+    execSync: cpUnavailable('execSync'),
+    spawnSync: cpUnavailable('spawnSync'),
+    execFileSync: cpUnavailable('execFileSync'),
+    fork: cpUnavailable('fork'),
+    ChildProcess,
+  };
+}

--- a/packages/webapp/src/kernel/realm/js-realm-helpers.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-helpers.ts
@@ -2014,17 +2014,26 @@ export function createNodeChildProcess(exec: CpExecBridge): NodeChildProcess {
 
   const execFilePromise = (
     file: string,
-    args?: string[],
-    options?: CpOptions
+    argsOrOptions?: string[] | CpOptions,
+    maybeOptions?: CpOptions
   ): Promise<{ stdout: CpChunk; stderr: CpChunk }> =>
     new Promise((resolve, reject) => {
-      execFileImpl(file, args, options, (error, stdout, stderr) => {
+      const cb: CpExecCallback = (error, stdout, stderr) => {
         if (error) {
           reject(Object.assign(error, { stdout, stderr }));
           return;
         }
         resolve({ stdout, stderr });
-      });
+      };
+      // `promisify(execFile)` may be called as execFileP(file),
+      // execFileP(file, args), execFileP(file, options), or
+      // execFileP(file, args, options). Normalize so `execFileImpl` always
+      // gets the args array in slot 2 and the callback in slot 4 — otherwise
+      // an options-as-2nd-arg (or bare-file) call lands the callback in a
+      // slot `execFileImpl` never reads and the promise hangs forever.
+      const args = Array.isArray(argsOrOptions) ? argsOrOptions : [];
+      const options = Array.isArray(argsOrOptions) ? maybeOptions : argsOrOptions;
+      execFileImpl(file, args, options, cb);
     });
 
   const cpUnavailable = (name: string) => (): never => {

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -330,17 +330,84 @@ function createProcessShim(
 
 type ExecResult = { stdout: string; stderr: string; exitCode: number };
 
-function createExecBridge(rpc: RealmRpcClient): ((cmd: string) => Promise<ExecResult>) & {
+/** Options for the buffered-stdin, killable `exec.start` spawn handle. */
+type ExecStartOptions = {
+  /** Upfront stdin buffer (merged AFTER any `stdin.write()` chunks). */
+  stdin?: string;
+  /** Shape of `stdin` — matches just-bash `CommandExecOptions.stdinKind`. */
+  stdinKind?: 'text' | 'bytes';
+  /** Shell-free argv tail (string command form only; array form uses its own tail). */
+  args?: string[];
+};
+
+/**
+ * Handle returned by `exec.start`. Deferred-start, buffered-stdin, killable:
+ * `stdin.write` buffers, `stdin.end()` launches the command via the
+ * `exec:start` op (resolving `done` with the buffered result), and `kill`
+ * fans a signal out via `exec:kill`. The substrate a `child_process`
+ * polyfill needs. NOT interactive/streaming (just-bash is one-shot buffered).
+ */
+type ExecHandle = {
+  kill(sig?: string): Promise<boolean>;
+  stdin: { write(chunk: string): void; end(): void };
+  done: Promise<ExecResult>;
+};
+
+type ExecBridge = ((cmd: string) => Promise<ExecResult>) & {
   spawn: (argv: string[]) => Promise<ExecResult>;
   exec: (cmd: string) => Promise<ExecResult>;
-} {
+  start: (commandOrArgv: string | string[], opts?: ExecStartOptions) => ExecHandle;
+};
+
+export function createExecBridge(rpc: RealmRpcClient): ExecBridge {
   const execRun = (command: string): Promise<ExecResult> => rpc.call('exec', 'run', [command]);
+
+  // Client-side monotonic spawn id. The host keys its live-spawn map off
+  // this, so `kill` can address the exact in-flight command.
+  let nextSpawnId = 1;
+
+  const start = (commandOrArgv: string | string[], opts?: ExecStartOptions): ExecHandle => {
+    const spawnId = nextSpawnId++;
+    const chunks: string[] = [];
+    let started = false;
+    let resolveDone!: (value: ExecResult) => void;
+    let rejectDone!: (error: unknown) => void;
+    const done = new Promise<ExecResult>((resolve, reject) => {
+      resolveDone = resolve;
+      rejectDone = reject;
+    });
+    const fire = (): void => {
+      if (started) return;
+      started = true;
+      // Buffered `stdin.write` chunks win; fall back to an upfront
+      // `opts.stdin`. `undefined` means "no stdin" (empty on the host).
+      const buffered = chunks.length > 0 ? chunks.join('') : opts?.stdin;
+      const startOpts: ExecStartOptions = {};
+      if (buffered !== undefined) startOpts.stdin = buffered;
+      if (opts?.stdinKind !== undefined) startOpts.stdinKind = opts.stdinKind;
+      if (opts?.args !== undefined) startOpts.args = opts.args;
+      rpc
+        .call<ExecResult>('exec', 'start', [spawnId, commandOrArgv, startOpts])
+        .then(resolveDone, rejectDone);
+    };
+    return {
+      kill: (sig?: string): Promise<boolean> => rpc.call('exec', 'kill', [spawnId, sig]),
+      stdin: {
+        write: (chunk: string): void => {
+          // Post-launch writes are dropped — just-bash takes a single
+          // upfront buffer, so there's no interactive stdin to write to.
+          if (!started) chunks.push(chunk);
+        },
+        end: (): void => fire(),
+      },
+      done,
+    };
+  };
+
   const execBridge = Object.assign(execRun, {
     spawn: (argv: string[]): Promise<ExecResult> => rpc.call('exec', 'spawn', [argv]),
-  }) as ((cmd: string) => Promise<ExecResult>) & {
-    spawn: (argv: string[]) => Promise<ExecResult>;
-    exec: typeof execRun;
-  };
+    start,
+  }) as ExecBridge;
   execBridge.exec = execBridge;
   return execBridge;
 }

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -32,7 +32,9 @@ import {
   attachArgvParseFlags,
   createCli,
   createColor,
+  createNodeChildProcess,
   fmt,
+  type NodeChildProcess,
   nodeAssert,
   nodeAssertStrict,
   nodeCrypto,
@@ -207,6 +209,8 @@ export async function runJsRealm(init: RealmInitMsg, port: RealmPortLike): Promi
     graph,
     fsBridge,
     processShim,
+    // Per-realm `child_process` shim over the `exec` bridge (see the factory).
+    childProcess: createNodeChildProcess(execBridge),
     nodeConsole,
     sliccyModules,
   });
@@ -705,10 +709,11 @@ function createModuleSystem(opts: {
   graph: RealmModuleGraph;
   fsBridge: unknown;
   processShim: unknown;
+  childProcess: NodeChildProcess;
   nodeConsole: unknown;
   sliccyModules: Record<string, unknown>;
 }): { require: (id: string) => unknown } {
-  const { graph, fsBridge, processShim, nodeConsole, sliccyModules } = opts;
+  const { graph, fsBridge, processShim, childProcess, nodeConsole, sliccyModules } = opts;
   const sourceByPath = new Map(graph.files.map((f) => [f.path, f.cjsSource]));
   const kindByPath = new Map(graph.files.map((f) => [f.path, f.kind]));
   const cache = new Map<string, { exports: Record<string, unknown> }>();
@@ -718,7 +723,7 @@ function createModuleSystem(opts: {
       return { hit: true, value: resolveSliccyModule(id, sliccyModules) };
     }
     const bareId = id.startsWith('node:') ? id.slice(5) : id;
-    const served = resolveServedBuiltin(bareId, fsBridge, processShim);
+    const served = resolveServedBuiltin(bareId, fsBridge, processShim, childProcess);
     if (served.hit) return served;
     if (NODE_NATIVE_PACKAGES.has(bareId)) throw nativePackageError(id, bareId);
     if (NODE_BUILTINS_UNAVAILABLE.has(bareId)) throw unavailableBuiltinError(id, bareId);
@@ -791,13 +796,15 @@ function createModuleSystem(opts: {
 function resolveServedBuiltin(
   bareId: string,
   fsBridge: unknown,
-  processShim: unknown
+  processShim: unknown,
+  childProcess: NodeChildProcess
 ): { hit: boolean; value?: unknown } {
   if (bareId === 'fs') return { hit: true, value: fsBridge };
   // Same object — fsBridge is already Promise-based; callback/sync APIs are not shimmed here.
   if (bareId === 'fs/promises') return { hit: true, value: fsBridge };
   if (bareId === 'path') return { hit: true, value: nodePath };
   if (bareId === 'crypto') return { hit: true, value: nodeCrypto };
+  if (bareId === 'child_process') return { hit: true, value: childProcess };
   if (bareId === 'process') return { hit: true, value: processShim };
   if (bareId === 'buffer') {
     return { hit: true, value: { Buffer: (globalThis as Record<string, unknown>).Buffer } };
@@ -842,7 +849,6 @@ function resolveSliccyModule(id: string, sliccyModules: Record<string, unknown>)
 const UNAVAILABLE_BUILTIN_HINTS: Record<string, string> = {
   http: ' Use fetch() instead.',
   https: ' Use fetch() instead.',
-  child_process: ' Use exec() which is available as a shell bridge.',
   crypto: ' Use globalThis.crypto (Web Crypto API) instead.',
 };
 

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -336,7 +336,7 @@ type ExecResult = { stdout: string; stderr: string; exitCode: number };
 
 /** Options for the buffered-stdin, killable `exec.start` spawn handle. */
 type ExecStartOptions = {
-  /** Upfront stdin buffer (merged AFTER any `stdin.write()` chunks). */
+  /** Fallback stdin buffer; used only when no `stdin.write()` chunks were buffered (chunks win). */
   stdin?: string;
   /** Shape of `stdin` — matches just-bash `CommandExecOptions.stdinKind`. */
   stdinKind?: 'text' | 'bytes';
@@ -363,6 +363,13 @@ type ExecBridge = ((cmd: string) => Promise<ExecResult>) & {
   start: (commandOrArgv: string | string[], opts?: ExecStartOptions) => ExecHandle;
 };
 
+/** POSIX 128+signum exit code for a client-side pre-start kill (matches the host). */
+function killExitCode(sig?: string): number {
+  if (sig === 'SIGKILL') return 137;
+  if (sig === 'SIGINT') return 130;
+  return 143; // SIGTERM (default) and any other terminating signal
+}
+
 export function createExecBridge(rpc: RealmRpcClient): ExecBridge {
   const execRun = (command: string): Promise<ExecResult> => rpc.call('exec', 'run', [command]);
 
@@ -374,6 +381,9 @@ export function createExecBridge(rpc: RealmRpcClient): ExecBridge {
     const spawnId = nextSpawnId++;
     const chunks: string[] = [];
     let started = false;
+    // A `kill()` before `stdin.end()` can't reach the host (the spawnId
+    // isn't registered until `exec:start` arrives), so honor it client-side.
+    let killed = false;
     let resolveDone!: (value: ExecResult) => void;
     let rejectDone!: (error: unknown) => void;
     const done = new Promise<ExecResult>((resolve, reject) => {
@@ -381,7 +391,8 @@ export function createExecBridge(rpc: RealmRpcClient): ExecBridge {
       rejectDone = reject;
     });
     const fire = (): void => {
-      if (started) return;
+      // A pre-start `kill()` wins: never launch a spawn that was already killed.
+      if (started || killed) return;
       started = true;
       // Buffered `stdin.write` chunks win; fall back to an upfront
       // `opts.stdin`. `undefined` means "no stdin" (empty on the host).
@@ -395,12 +406,22 @@ export function createExecBridge(rpc: RealmRpcClient): ExecBridge {
         .then(resolveDone, rejectDone);
     };
     return {
-      kill: (sig?: string): Promise<boolean> => rpc.call('exec', 'kill', [spawnId, sig]),
+      kill: (sig?: string): Promise<boolean> => {
+        // Post-start: the host knows the spawnId, so fan the signal out.
+        if (started) return rpc.call('exec', 'kill', [spawnId, sig]);
+        // Pre-start: an `exec:kill` would race ahead of `exec:start` and be
+        // dropped by the host, then `fire()` would still launch. Honor it
+        // client-side — mark killed so `fire()` no-ops and resolve `done`
+        // as terminated.
+        killed = true;
+        resolveDone({ stdout: '', stderr: '', exitCode: killExitCode(sig) });
+        return Promise.resolve(true);
+      },
       stdin: {
         write: (chunk: string): void => {
-          // Post-launch writes are dropped — just-bash takes a single
-          // upfront buffer, so there's no interactive stdin to write to.
-          if (!started) chunks.push(chunk);
+          // Post-launch (or post-kill) writes are dropped — just-bash takes a
+          // single upfront buffer, so there's no interactive stdin to write to.
+          if (!started && !killed) chunks.push(chunk);
         },
         end: (): void => fire(),
       },

--- a/packages/webapp/src/kernel/realm/node-builtins.ts
+++ b/packages/webapp/src/kernel/realm/node-builtins.ts
@@ -17,6 +17,7 @@
 
 /** Bare Node built-ins the realm serves directly (never from `node_modules`). */
 export const NODE_BUILTIN_AVAILABLE: ReadonlySet<string> = new Set([
+  'child_process',
   'events',
   'fs',
   'fs/promises',

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -387,6 +387,18 @@ const EXEC_KILL_SIGNALS: ReadonlySet<Signal> = new Set<Signal>([
   'SIGCONT',
 ]);
 
+/**
+ * Terminating signals that cancel the in-flight `ctx.exec` via
+ * `controller.abort()`. SIGSTOP / SIGCONT are pause/resume — they drive the
+ * PM `Gate` (`pm.signal`) only and must NOT abort, or a pause would terminate
+ * the buffered command instead of holding it.
+ */
+const EXEC_TERMINATING_SIGNALS: ReadonlySet<Signal> = new Set<Signal>([
+  'SIGINT',
+  'SIGTERM',
+  'SIGKILL',
+]);
+
 async function dispatchExec(
   op: string,
   args: unknown[],
@@ -420,6 +432,31 @@ async function dispatchExec(
 }
 
 /**
+ * Validate the `exec.start` options envelope: `stdin` must be a string,
+ * `stdinKind` must be `'text' | 'bytes'`, and `args` a `string[]`. Throws a
+ * clear error on any bad shape so a malformed client payload can't corrupt
+ * the downstream `ctx.exec` call.
+ */
+function assertExecStartOptions(opts: {
+  stdin?: unknown;
+  stdinKind?: unknown;
+  args?: unknown;
+}): void {
+  if (opts.stdin !== undefined && typeof opts.stdin !== 'string') {
+    throw new Error('exec.start: stdin must be a string');
+  }
+  if (opts.stdinKind !== undefined && opts.stdinKind !== 'text' && opts.stdinKind !== 'bytes') {
+    throw new Error("exec.start: stdinKind must be 'text' or 'bytes'");
+  }
+  if (
+    opts.args !== undefined &&
+    (!Array.isArray(opts.args) || !opts.args.every((a) => typeof a === 'string'))
+  ) {
+    throw new Error('exec.start: args must be a string[]');
+  }
+}
+
+/**
  * `exec.start` — the killable, buffered-stdin spawn. Accepts a
  * realm-allocated monotonic `spawnId`, a command string OR a shell-free
  * argv, and `{ stdin, stdinKind, args }`. Creates an `AbortController`,
@@ -443,6 +480,13 @@ async function dispatchExecStart(
   if (typeof spawnId !== 'number') {
     throw new Error('exec.start: spawnId must be a number');
   }
+  // Reject a spawnId already tracking a live spawn — overwriting it would
+  // strand the in-flight command's `AbortController` (kill could never reach
+  // it) and PM record. The realm allocates monotonic ids, so a collision means
+  // a buggy / malicious client.
+  if (execCtx.spawns.has(spawnId)) {
+    throw new Error(`exec.start: spawnId ${spawnId} is already in use`);
+  }
   let cmd: string;
   let argvTail: string[] | undefined;
   let procArgv: string[];
@@ -460,6 +504,10 @@ async function dispatchExecStart(
   }
 
   const opts = options ?? {};
+  // Validate the forwarded options before touching PM / `ctx.exec` so a
+  // malformed shape throws a clear error instead of corrupting the just-bash
+  // exec call downstream.
+  assertExecStartOptions(opts);
   const controller = new AbortController();
   const { pm, owner } = execCtx.opts;
   let pid = 0;
@@ -505,10 +553,12 @@ async function dispatchExecStart(
 }
 
 /**
- * `exec.kill [spawnId, sig]` — abort the in-flight `ctx.exec` for `spawnId`
- * and fan the signal out to its PM process. Returns `true` when the spawn
- * was live (delivered), `false` when unknown / already settled — matching
- * POSIX `kill(2)`. `sig` defaults to SIGTERM; unknown signals coerce to it.
+ * `exec.kill [spawnId, sig]` — deliver `sig` to the `spawnId` spawn. A
+ * terminating signal (SIGINT / SIGTERM / SIGKILL) aborts the in-flight
+ * `ctx.exec`; SIGSTOP / SIGCONT are pause/resume and fan out to the PM `Gate`
+ * only (no abort). Returns `true` when the spawn was live (delivered),
+ * `false` when unknown / already settled — matching POSIX `kill(2)`. `sig`
+ * defaults to SIGTERM; unknown signals coerce to it.
  */
 function dispatchExecKill(args: unknown[], execCtx: ExecDispatchCtx): boolean {
   const [spawnId, rawSig] = args as [number, string | undefined];
@@ -518,10 +568,15 @@ function dispatchExecKill(args: unknown[], execCtx: ExecDispatchCtx): boolean {
     typeof rawSig === 'string' && EXEC_KILL_SIGNALS.has(rawSig as Signal)
       ? (rawSig as Signal)
       : 'SIGTERM';
-  if (!entry.controller.signal.aborted) entry.controller.abort();
+  // Only terminating signals cancel the buffered command; STOP/CONT leave it
+  // running and rely on the PM gate for pause/resume.
+  if (EXEC_TERMINATING_SIGNALS.has(sig) && !entry.controller.signal.aborted) {
+    entry.controller.abort();
+  }
   const { pm } = execCtx.opts;
   if (pm && entry.pid) return pm.signal(entry.pid, sig);
-  // No PM record (RPC unit-test path): the abort above IS the delivery.
+  // No PM record (RPC unit-test path): a terminating signal's abort above IS
+  // the delivery; STOP/CONT have no local effect but still report delivered.
   return true;
 }
 

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -37,6 +37,7 @@ import {
 } from '../../shell/supplemental-commands/usb-backends.js';
 import type { HidDeviceFilter } from '../hid-device-registry.js';
 import { getPanelRpcClient, hasLocalDom } from '../panel-rpc.js';
+import type { ProcessManager, ProcessOwner, Signal } from '../process-manager.js';
 import type {
   SerialFilter,
   SerialOpenOptions,
@@ -97,6 +98,22 @@ export interface RealmHostOptions {
   usbBackend?: UsbBackend;
   serialBackend?: SerialBackend;
   hidBackend?: HidBackend;
+  /**
+   * Process manager + owner used by the `exec.start` / `exec.kill` ops so
+   * each realm-spawned command shows up as a real PM process (`ps` / `kill`
+   * / terminal Ctrl-C fan-out see it) and a `kill` op can fan a signal out
+   * to it. Threaded through by `realm-runner.ts` from the realm's own
+   * `RunInRealmOptions`. When omitted (e.g. the RPC unit tests), `start`
+   * still runs the command and `kill` still aborts the in-flight
+   * `ctx.exec` via its `AbortController` — there just isn't a PM record.
+   */
+  pm?: ProcessManager;
+  owner?: ProcessOwner;
+  /**
+   * Parent pid for `exec.start`-spawned PM processes — the realm's own
+   * pid, so a signal to the realm fans out to its realm-backed children.
+   */
+  ppid?: number;
 }
 
 /**
@@ -128,11 +145,18 @@ export function attachRealmHost(
     }
   };
   const hidCtx: HidDispatchCtx = { subscriptions: hidSubscriptions, pushEvent };
+  // Live `exec.start` spawns keyed by the realm-allocated `spawnId`.
+  // `kill` looks up the entry to abort the in-flight `ctx.exec` and fan a
+  // signal out via `pm`; `start` cleans its own entry on settle. `dispose()`
+  // aborts any leftover in-flight execs so a terminated realm can't strand a
+  // running host-side command.
+  const execSpawns = new Map<number, { controller: AbortController; pid: number }>();
+  const execCtx: ExecDispatchCtx = { spawns: execSpawns, opts };
   const handler = (event: MessageEvent): void => {
     const data = event.data as { type?: string };
     if (data?.type !== 'realm-rpc-req') return;
     const req = event.data as RealmRpcRequest;
-    void respond(port, req, ctx, opts, hidCtx);
+    void respond(port, req, ctx, opts, hidCtx, execCtx);
   };
   port.addEventListener('message', handler);
   port.start?.();
@@ -141,6 +165,18 @@ export function attachRealmHost(
       if (disposed) return;
       disposed = true;
       port.removeEventListener('message', handler);
+      // Abort any in-flight `exec.start` commands so a terminated realm
+      // doesn't leave a host-side `ctx.exec` running with no consumer for
+      // its result. The `start` handler's `finally` still runs the PM
+      // cleanup once the aborted exec settles.
+      for (const { controller } of execSpawns.values()) {
+        try {
+          if (!controller.signal.aborted) controller.abort();
+        } catch {
+          /* swallow — realm teardown must not throw */
+        }
+      }
+      execSpawns.clear();
       // Drain HID subscriptions best-effort; sync and async unsubscribes
       // are both honored. We don't await — `dispose()` is sync, and the
       // backend's unsubscribe surface accepts fire-and-forget here.
@@ -161,10 +197,11 @@ async function respond(
   req: RealmRpcRequest,
   ctx: CommandContext,
   opts: RealmHostOptions,
-  hidCtx: HidDispatchCtx
+  hidCtx: HidDispatchCtx,
+  execCtx: ExecDispatchCtx
 ): Promise<void> {
   try {
-    const result = await dispatch(req, ctx, opts, hidCtx);
+    const result = await dispatch(req, ctx, opts, hidCtx, execCtx);
     const res: RealmRpcResponse = { type: 'realm-rpc-res', id: req.id, result };
     // Body bytes need to be transferred so we don't structured-clone
     // potentially-large response bodies on every fetch.
@@ -181,13 +218,14 @@ async function dispatch(
   req: RealmRpcRequest,
   ctx: CommandContext,
   opts: RealmHostOptions,
-  hidCtx: HidDispatchCtx
+  hidCtx: HidDispatchCtx,
+  execCtx: ExecDispatchCtx
 ): Promise<unknown> {
   switch (req.channel) {
     case 'vfs':
       return dispatchVfs(req.op, req.args, ctx);
     case 'exec':
-      return dispatchExec(req.op, req.args, ctx);
+      return dispatchExec(req.op, req.args, ctx, execCtx);
     case 'fetch':
       return dispatchFetch(req.op, req.args, ctx);
     case 'browser':
@@ -327,7 +365,34 @@ async function dispatchVfs(op: string, args: unknown[], ctx: CommandContext): Pr
 // Channel: exec
 // ---------------------------------------------------------------------------
 
-async function dispatchExec(op: string, args: unknown[], ctx: CommandContext): Promise<unknown> {
+/**
+ * Per-host state for the `exec.start` / `exec.kill` ops. Lives in
+ * `attachRealmHost`'s closure. `spawns` maps each realm-allocated
+ * `spawnId` to the in-flight command's `AbortController` (+ PM pid when
+ * a `pm`/`owner` were threaded in) so a concurrent `kill` op can abort
+ * the `ctx.exec` and fan a signal out. `opts` carries the `pm`/`owner`/
+ * `ppid` used to register a real PM process per spawn.
+ */
+interface ExecDispatchCtx {
+  spawns: Map<number, { controller: AbortController; pid: number }>;
+  opts: RealmHostOptions;
+}
+
+/** Signals `exec.kill` accepts; anything else is coerced to SIGTERM. */
+const EXEC_KILL_SIGNALS: ReadonlySet<Signal> = new Set<Signal>([
+  'SIGINT',
+  'SIGTERM',
+  'SIGKILL',
+  'SIGSTOP',
+  'SIGCONT',
+]);
+
+async function dispatchExec(
+  op: string,
+  args: unknown[],
+  ctx: CommandContext,
+  execCtx: ExecDispatchCtx
+): Promise<unknown> {
   if (!ctx.exec) throw new Error('exec is not available in this runtime');
   if (op === 'run') {
     const command = args[0] as string;
@@ -349,7 +414,115 @@ async function dispatchExec(op: string, args: unknown[], ctx: CommandContext): P
     const result = await ctx.exec(cmd, { cwd: ctx.cwd, args: rest });
     return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
   }
+  if (op === 'start') return dispatchExecStart(args, ctx, execCtx);
+  if (op === 'kill') return dispatchExecKill(args, execCtx);
   throw new Error(`realm-host: unknown exec op '${op}'`);
+}
+
+/**
+ * `exec.start` — the killable, buffered-stdin spawn. Accepts a
+ * realm-allocated monotonic `spawnId`, a command string OR a shell-free
+ * argv, and `{ stdin, stdinKind, args }`. Creates an `AbortController`,
+ * registers a PM process (when `pm`/`owner` were threaded in), threads the
+ * signal + buffered stdin into a single one-shot `ctx.exec`, and resolves
+ * with the buffered `{ stdout, stderr, exitCode }`. The spawn entry + PM
+ * process are cleaned up on settle (natural completion OR abort). A
+ * concurrent `exec.kill [spawnId, sig]` aborts the signal and fans out to
+ * the PM process.
+ */
+async function dispatchExecStart(
+  args: unknown[],
+  ctx: CommandContext,
+  execCtx: ExecDispatchCtx
+): Promise<unknown> {
+  const [spawnId, commandOrArgv, options] = args as [
+    number,
+    string | string[],
+    { stdin?: string; stdinKind?: 'text' | 'bytes'; args?: string[] } | undefined,
+  ];
+  if (typeof spawnId !== 'number') {
+    throw new Error('exec.start: spawnId must be a number');
+  }
+  let cmd: string;
+  let argvTail: string[] | undefined;
+  let procArgv: string[];
+  if (Array.isArray(commandOrArgv)) {
+    if (commandOrArgv.length === 0 || !commandOrArgv.every((a) => typeof a === 'string')) {
+      throw new Error('exec.start: argv must be a non-empty string[]');
+    }
+    [cmd, ...argvTail] = commandOrArgv;
+    procArgv = commandOrArgv.slice();
+  } else if (typeof commandOrArgv === 'string') {
+    cmd = commandOrArgv;
+    procArgv = [commandOrArgv];
+  } else {
+    throw new Error('exec.start: command must be a string or a non-empty string[]');
+  }
+
+  const opts = options ?? {};
+  const controller = new AbortController();
+  const { pm, owner } = execCtx.opts;
+  let pid = 0;
+  if (pm && owner) {
+    const proc = pm.spawn({
+      kind: 'shell',
+      argv: procArgv,
+      cwd: ctx.cwd,
+      owner,
+      ...(execCtx.opts.ppid !== undefined ? { ppid: execCtx.opts.ppid } : {}),
+      adoptAbort: controller,
+    });
+    pid = proc.pid;
+  }
+  execCtx.spawns.set(spawnId, { controller, pid });
+
+  let result: { stdout: string; stderr: string; exitCode: number } | undefined;
+  try {
+    const execOptions: {
+      cwd: string;
+      signal: AbortSignal;
+      stdin?: string;
+      stdinKind?: 'text' | 'bytes';
+      args?: string[];
+    } = { cwd: ctx.cwd, signal: controller.signal };
+    if (opts.stdin !== undefined) execOptions.stdin = opts.stdin;
+    if (opts.stdinKind !== undefined) execOptions.stdinKind = opts.stdinKind;
+    // Array form's tail is the shell-free argv (wins); string form takes an
+    // explicit `args` from options.
+    if (argvTail !== undefined) execOptions.args = argvTail;
+    else if (opts.args !== undefined) execOptions.args = opts.args;
+    result = await ctx.exec!(cmd, execOptions);
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+  } finally {
+    execCtx.spawns.delete(spawnId);
+    if (pm && pid) {
+      // A killed spawn derives its exit from the recorded signal (137 / 143
+      // / 130); a naturally-completed one reports the command's real code.
+      const proc = pm.get(pid);
+      pm.exit(pid, proc?.terminatedBy ? null : (result?.exitCode ?? 1));
+    }
+  }
+}
+
+/**
+ * `exec.kill [spawnId, sig]` — abort the in-flight `ctx.exec` for `spawnId`
+ * and fan the signal out to its PM process. Returns `true` when the spawn
+ * was live (delivered), `false` when unknown / already settled — matching
+ * POSIX `kill(2)`. `sig` defaults to SIGTERM; unknown signals coerce to it.
+ */
+function dispatchExecKill(args: unknown[], execCtx: ExecDispatchCtx): boolean {
+  const [spawnId, rawSig] = args as [number, string | undefined];
+  const entry = execCtx.spawns.get(spawnId);
+  if (!entry) return false;
+  const sig: Signal =
+    typeof rawSig === 'string' && EXEC_KILL_SIGNALS.has(rawSig as Signal)
+      ? (rawSig as Signal)
+      : 'SIGTERM';
+  if (!entry.controller.signal.aborted) entry.controller.abort();
+  const { pm } = execCtx.opts;
+  if (pm && entry.pid) return pm.signal(entry.pid, sig);
+  // No PM record (RPC unit-test path): the abort above IS the delivery.
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/src/kernel/realm/realm-runner.ts
+++ b/packages/webapp/src/kernel/realm/realm-runner.ts
@@ -181,8 +181,15 @@ export async function runInRealm(opts: RunInRealmOptions): Promise<RealmResult> 
   // `Orchestrator.unregisterScoop → dropForScoop(jid)` matches no
   // subscribers and page routers keep forwarding after the scoop is
   // gone. The owner record is the single trusted source.
+  // Thread the PM + owner + realm pid so the `exec.start` / `exec.kill` ops
+  // register each realm-spawned command as a real PM process (parented to
+  // THIS realm's pid, so a signal to the realm fans out to its children)
+  // and a `kill` op can signal it. See `realm-host.ts` dispatchExecStart.
   const host: RealmHostHandle = attachRealmHost(realm.controlPort, opts.ctx, {
     ...(opts.owner.scoopJid !== undefined ? { scoopJid: opts.owner.scoopJid } : {}),
+    pm: opts.pm,
+    owner: opts.owner,
+    ppid: proc.pid,
   });
 
   return new Promise<RealmResult>((resolve) => {

--- a/packages/webapp/src/kernel/realm/realm-types.ts
+++ b/packages/webapp/src/kernel/realm/realm-types.ts
@@ -127,7 +127,22 @@ export interface RealmErrorMsg {
   message: string;
 }
 
-/** Channels the kernel host exposes to user code. */
+/**
+ * Channels the kernel host exposes to user code.
+ *
+ * The `exec` channel carries four ops (all one-shot buffered, mirroring
+ * just-bash `ctx.exec`):
+ *   - `run [command]` — shell command, buffered result.
+ *   - `spawn [argv]` — shell-free argv, buffered result.
+ *   - `start [spawnId, commandOrArgv, { stdin, stdinKind, args }]` — the
+ *     killable, buffered-stdin spawn. The realm allocates a monotonic
+ *     `spawnId`; the host registers a PM process, threads an
+ *     `AbortController` signal + buffered stdin into `ctx.exec`, and
+ *     resolves with the buffered `{ stdout, stderr, exitCode }`.
+ *   - `kill [spawnId, sig?]` — abort the in-flight `start` for `spawnId`
+ *     and fan `sig` (default SIGTERM) out to its PM process; returns a
+ *     `delivered` boolean (POSIX `kill(2)` semantics).
+ */
 export type RealmRpcChannel =
   | 'vfs'
   | 'exec'

--- a/packages/webapp/src/shell/bsh-watchdog.ts
+++ b/packages/webapp/src/shell/bsh-watchdog.ts
@@ -259,7 +259,10 @@ export class BshWatchdog {
     const bareId = id.startsWith('node:') ? id.slice(5) : id;
     if (bareId === 'buffer' && typeof Buffer !== 'undefined') return { Buffer };
     if (__NODE_BUILTINS_UNAVAILABLE.has(bareId)) {
-      const __suggestions = { http: ' Use fetch() instead.', https: ' Use fetch() instead.', crypto: ' Use globalThis.crypto (Web Crypto API) instead.' };
+      // Unlike the .jsh / node realm (where require('child_process') maps to the
+      // exec shell bridge), a .bsh script runs in the target page via CDP and has
+      // no shell bridge, so child_process is genuinely unavailable here.
+      const __suggestions = { http: ' Use fetch() instead.', https: ' Use fetch() instead.', crypto: ' Use globalThis.crypto (Web Crypto API) instead.', child_process: ' .bsh scripts run in the target page and have no shell bridge; use exec() from a .jsh script instead.' };
       const __hint = __suggestions[bareId] || '';
       throw new Error("require('" + id + "'): Node built-in '" + bareId + "' is not available in the browser environment." + __hint);
     }

--- a/packages/webapp/tests/kernel/realm/child_process.test.ts
+++ b/packages/webapp/tests/kernel/realm/child_process.test.ts
@@ -1,0 +1,349 @@
+/**
+ * `child_process` realm shim (nodeChildProcess).
+ *
+ * Two layers of coverage:
+ *   - Integration: drives the real `runJsRealm` engine (same as the worker /
+ *     iframe floats) through `require('child_process')`, over the RPC-backed
+ *     `exec.start` handle wired to a mock `ctx.exec`. Proves the require-system
+ *     wiring, the Node exec/execFile callback + promisify conventions, buffered
+ *     spawn stdin, and the sync-stub throws end to end.
+ *   - Unit: exercises `createNodeChildProcess` directly over a hand-rolled fake
+ *     `exec.start` bridge so `kill()`, the argv/shell command shapes, and the
+ *     one-shot stream/event semantics are asserted deterministically.
+ */
+
+import type { CommandContext } from 'just-bash';
+import { describe, expect, it } from 'vitest';
+import {
+  type CpExecResult,
+  createNodeChildProcess,
+} from '../../../src/kernel/realm/js-realm-helpers.js';
+import { makeCtx, runCode } from './cjs-realm-harness.js';
+
+/** Mock `ctx.exec` covering the handful of commands the realm code drives. */
+function makeExecCtx(): CommandContext {
+  return makeCtx({
+    exec: (async (command: string, opts: { args?: string[]; stdin?: string } = {}) => {
+      const args = opts.args ?? [];
+      const stdin = opts.stdin ?? '';
+      if (command === 'false') return { stdout: '', stderr: 'boom\n', exitCode: 3 };
+      if (command === 'cat') return { stdout: stdin, stderr: '', exitCode: 0 };
+      if (command === 'echo') return { stdout: `${args.join(' ')}\n`, stderr: '', exitCode: 0 };
+      if (command.startsWith('echo '))
+        return { stdout: `${command.slice(5)}\n`, stderr: '', exitCode: 0 };
+      return { stdout: `ran:${command}`, stderr: '', exitCode: 0 };
+    }) as CommandContext['exec'],
+  });
+}
+
+describe('child_process: require wiring', () => {
+  it('require("child_process") imports without throwing and node: alias is identical', async () => {
+    const out = await runCode(
+      `const a = require('child_process');
+       const b = require('node:child_process');
+       console.log(typeof a.exec, typeof a.spawn, typeof a.execFile, a === b);`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).not.toContain('not available in the browser');
+    expect(out.stdout.trim()).toBe('function function function true');
+  });
+});
+
+describe('child_process: exec / execFile callbacks', () => {
+  it('exec buffers stdout and calls back Node-style on success', async () => {
+    const out = await runCode(
+      `const cp = require('child_process');
+       await new Promise((resolve) => {
+         cp.exec('echo hi', (err, stdout, stderr) => {
+           console.log(err === null, stdout.trim(), JSON.stringify(stderr));
+           resolve();
+         });
+       });`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('true hi ""');
+  });
+
+  it('exec surfaces a non-zero exit as an Error carrying .code (stdout/stderr still passed)', async () => {
+    const out = await runCode(
+      `const cp = require('child_process');
+       await new Promise((resolve) => {
+         cp.exec('false', (err, stdout, stderr) => {
+           console.log(err ? 'ERR' : 'OK', err && err.code, JSON.stringify(stderr.trim()));
+           resolve();
+         });
+       });`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('ERR 3 "boom"');
+  });
+
+  it('execFile runs shell-free (argv form) — args reach the executable verbatim', async () => {
+    const out = await runCode(
+      `const cp = require('child_process');
+       await new Promise((resolve) => {
+         cp.execFile('echo', ['a', 'b'], (err, stdout) => {
+           console.log(stdout.trim());
+           resolve();
+         });
+       });`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('a b');
+  });
+});
+
+describe('child_process: promisify', () => {
+  it('promisify(exec) resolves { stdout, stderr } and rejects (with stdout/stderr) on non-zero', async () => {
+    const out = await runCode(
+      `const cp = require('child_process');
+       const { promisify } = require('util');
+       const execP = promisify(cp.exec);
+       const ok = await execP('echo hi');
+       console.log('OK', ok.stdout.trim());
+       try {
+         await execP('false');
+         console.log('NO-THROW');
+       } catch (e) {
+         console.log('REJ', e.code, e.stdout !== undefined, e.stderr.trim());
+       }`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    const lines = out.stdout.split('\n').filter(Boolean);
+    expect(lines[0]).toBe('OK hi');
+    expect(lines[1]).toBe('REJ 3 true boom');
+  });
+});
+
+describe('child_process: spawn', () => {
+  it('spawn streams a single stdout chunk then fires exit/close', async () => {
+    const out = await runCode(
+      `const cp = require('child_process');
+       const child = cp.spawn('echo', ['hey']);
+       let data = '';
+       child.stdout.on('data', (d) => { data += d.toString(); });
+       await new Promise((resolve) => {
+         child.on('close', (code, signal) => {
+           console.log(data.trim(), code, signal);
+           resolve();
+         });
+       });`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('hey 0 null');
+  });
+
+  it('spawn buffers stdin.write/.end and forwards it to the command', async () => {
+    const out = await runCode(
+      `const cp = require('child_process');
+       const child = cp.spawn('cat');
+       child.stdin.write('hello ');
+       child.stdin.write('world');
+       child.stdin.end();
+       let acc = '';
+       child.stdout.on('data', (d) => { acc += d.toString(); });
+       await new Promise((resolve) => { child.on('close', () => { console.log(acc); resolve(); }); });`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('hello world');
+  });
+});
+
+describe('child_process: sync forms are unavailable', () => {
+  it('execSync / spawnSync / execFileSync / fork throw a clear browser-realm error', async () => {
+    const out = await runCode(
+      `const cp = require('child_process');
+       for (const name of ['execSync', 'spawnSync', 'execFileSync', 'fork']) {
+         try { cp[name]('x'); console.log(name, 'NO-THROW'); }
+         catch (e) { console.log(name, e.message.includes('not available in the browser realm')); }
+       }`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('execSync true\nspawnSync true\nexecFileSync true\nfork true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit layer: a hand-rolled fake `exec.start` bridge so `kill()`, the command
+// shapes, and the stream/event semantics are asserted with no RPC timing.
+// ---------------------------------------------------------------------------
+
+interface FakeHandle {
+  commandOrArgv: string | string[];
+  writes: string[];
+  killSigs: string[];
+  ended: boolean;
+  stdin: { write(chunk: string): void; end(): void };
+  kill(sig?: string): Promise<boolean>;
+  done: Promise<CpExecResult>;
+  resolveDone(result: CpExecResult): void;
+  rejectDone(error: unknown): void;
+}
+
+function makeFakeBridge() {
+  let last: FakeHandle | undefined;
+  const bridge = {
+    start(commandOrArgv: string | string[]): FakeHandle {
+      let resolveDone!: (result: CpExecResult) => void;
+      let rejectDone!: (error: unknown) => void;
+      const done = new Promise<CpExecResult>((resolve, reject) => {
+        resolveDone = resolve;
+        rejectDone = reject;
+      });
+      const handle: FakeHandle = {
+        commandOrArgv,
+        writes: [],
+        killSigs: [],
+        ended: false,
+        stdin: {
+          write: (chunk: string) => handle.writes.push(chunk),
+          end: () => {
+            handle.ended = true;
+          },
+        },
+        kill: async (sig?: string) => {
+          handle.killSigs.push(sig ?? 'SIGTERM');
+          return true;
+        },
+        done,
+        resolveDone,
+        rejectDone,
+      };
+      last = handle;
+      return handle;
+    },
+    get lastHandle(): FakeHandle {
+      if (!last) throw new Error('no handle started yet');
+      return last;
+    },
+  };
+  return bridge;
+}
+
+describe('child_process unit: command shapes', () => {
+  it('spawn uses shell-free argv by default and a joined string when shell:true', () => {
+    const bridge = makeFakeBridge();
+    const cp = createNodeChildProcess(bridge);
+    cp.spawn('echo', ['a', 'b']);
+    expect(bridge.lastHandle.commandOrArgv).toEqual(['echo', 'a', 'b']);
+    cp.spawn('echo', ['a', 'b'], { shell: true });
+    expect(bridge.lastHandle.commandOrArgv).toBe('echo a b');
+  });
+
+  it('exec/execFile expose util.promisify.custom', () => {
+    const cp = createNodeChildProcess(makeFakeBridge());
+    const sym = Symbol.for('nodejs.util.promisify.custom');
+    expect(typeof (cp.exec as unknown as Record<symbol, unknown>)[sym]).toBe('function');
+    expect(typeof (cp.execFile as unknown as Record<symbol, unknown>)[sym]).toBe('function');
+  });
+
+  it('execSync / spawnSync / execFileSync / fork throw', () => {
+    const cp = createNodeChildProcess(makeFakeBridge());
+    expect(() => cp.execSync('x')).toThrow('not available in the browser realm');
+    expect(() => cp.spawnSync('x')).toThrow('not available in the browser realm');
+    expect(() => cp.execFileSync('x')).toThrow('not available in the browser realm');
+    expect(() => cp.fork('x')).toThrow('not available in the browser realm');
+  });
+});
+
+describe('child_process unit: streams and events', () => {
+  it('spawn emits one Buffer stdout chunk then end, and exit/close with the code', async () => {
+    const bridge = makeFakeBridge();
+    const cp = createNodeChildProcess(bridge);
+    const child = cp.spawn('echo', ['hi']);
+    const events: string[] = [];
+    child.stdout.on('data', (d) =>
+      events.push(`data:${Buffer.isBuffer(d)}:${(d as Buffer).toString()}`)
+    );
+    child.stdout.on('end', () => events.push('end'));
+    const closeP = new Promise<[unknown, unknown]>((resolve) =>
+      child.on('close', (code, signal) => resolve([code, signal]))
+    );
+    // Let the auto-launch microtask end stdin, then resolve the handle.
+    await Promise.resolve();
+    expect(bridge.lastHandle.ended).toBe(true);
+    bridge.lastHandle.resolveDone({ stdout: 'hi\n', stderr: '', exitCode: 0 });
+    const [code, signal] = await closeP;
+    expect(events).toEqual(['data:true:hi\n', 'end']);
+    expect(code).toBe(0);
+    expect(signal).toBeNull();
+  });
+
+  it('kill() marks killed, forwards the signal, and reports (null, signal)', async () => {
+    const bridge = makeFakeBridge();
+    const cp = createNodeChildProcess(bridge);
+    const child = cp.spawn('sleep', ['10']);
+    const closeP = new Promise<[unknown, unknown]>((resolve) =>
+      child.on('close', (code, signal) => resolve([code, signal]))
+    );
+    expect(child.kill('SIGKILL')).toBe(true);
+    expect(child.killed).toBe(true);
+    expect(bridge.lastHandle.killSigs).toEqual(['SIGKILL']);
+    await Promise.resolve();
+    bridge.lastHandle.resolveDone({ stdout: '', stderr: '', exitCode: 137 });
+    const [code, signal] = await closeP;
+    expect(code).toBeNull();
+    expect(signal).toBe('SIGKILL');
+  });
+
+  it('a rejected handle surfaces an Error on the "error" event', async () => {
+    const bridge = makeFakeBridge();
+    const cp = createNodeChildProcess(bridge);
+    const child = cp.spawn('boom');
+    const errP = new Promise<Error>((resolve) => child.on('error', (e) => resolve(e as Error)));
+    await Promise.resolve();
+    bridge.lastHandle.rejectDone('kaput');
+    expect((await errP).message).toBe('kaput');
+  });
+});
+
+describe('child_process unit: options and overloads', () => {
+  it('exec with an options object + encoding:"buffer" yields Buffer stdout', async () => {
+    const bridge = makeFakeBridge();
+    const cp = createNodeChildProcess(bridge);
+    const cbP = new Promise<[Error | null, unknown]>((resolve) => {
+      cp.exec('x', { encoding: 'buffer' }, (err, stdout) => resolve([err, stdout]));
+    });
+    await Promise.resolve();
+    bridge.lastHandle.resolveDone({ stdout: 'hi', stderr: '', exitCode: 0 });
+    const [err, stdout] = await cbP;
+    expect(err).toBeNull();
+    expect(Buffer.isBuffer(stdout)).toBe(true);
+    expect((stdout as Buffer).toString()).toBe('hi');
+  });
+
+  it('execFile accepts (file, cb) and (file, options, cb) overloads', () => {
+    const bridge = makeFakeBridge();
+    const cp = createNodeChildProcess(bridge);
+    cp.execFile('tool', () => {});
+    expect(bridge.lastHandle.commandOrArgv).toEqual(['tool']);
+    cp.execFile('tool', { encoding: 'utf8' }, () => {});
+    expect(bridge.lastHandle.commandOrArgv).toEqual(['tool']);
+  });
+
+  it('spawn accepts an options-only second argument', () => {
+    const bridge = makeFakeBridge();
+    const cp = createNodeChildProcess(bridge);
+    cp.spawn('ls', { encoding: 'utf8' });
+    expect(bridge.lastHandle.commandOrArgv).toEqual(['ls']);
+  });
+
+  it('stdin.write forwards decoded byte chunks and runs the write callback', async () => {
+    const bridge = makeFakeBridge();
+    const cp = createNodeChildProcess(bridge);
+    const child = cp.spawn('cat');
+    const wroteP = new Promise<void>((resolve) => {
+      child.stdin.write(new TextEncoder().encode('bytes'), resolve);
+    });
+    await wroteP;
+    expect(bridge.lastHandle.writes).toContain('bytes');
+  });
+});

--- a/packages/webapp/tests/kernel/realm/child_process.test.ts
+++ b/packages/webapp/tests/kernel/realm/child_process.test.ts
@@ -118,6 +118,27 @@ describe('child_process: promisify', () => {
     expect(lines[0]).toBe('OK hi');
     expect(lines[1]).toBe('REJ 3 true boom');
   });
+
+  it('promisify(execFile) settles for bare-file, options-as-2nd-arg, and reject overloads', async () => {
+    // Regression (PR #1402 finding 2): promisify(execFile)('tool') and the
+    // options-as-2nd-arg form used to hang because the callback landed in a
+    // slot execFileImpl never read.
+    const out = await runCode(
+      `const cp = require('child_process');
+       const { promisify } = require('util');
+       const execFileP = promisify(cp.execFile);
+       const a = await execFileP('echo');
+       const b = await execFileP('echo', { encoding: 'utf8' });
+       console.log('OK', typeof a.stdout, typeof b.stdout);
+       try { await execFileP('false'); console.log('NO-THROW'); }
+       catch (e) { console.log('REJ', e.code); }`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    const lines = out.stdout.split('\n').filter(Boolean);
+    expect(lines[0]).toBe('OK string string');
+    expect(lines[1]).toBe('REJ 3');
+  });
 });
 
 describe('child_process: spawn', () => {
@@ -153,6 +174,25 @@ describe('child_process: spawn', () => {
     );
     expect(out.exitCode).toBe(0);
     expect(out.stdout.trim()).toBe('hello world');
+  });
+
+  it('a synchronous kill() before stdin.end() never runs the command', async () => {
+    // Regression (PR #1402 finding 1): a kill() fired synchronously after
+    // spawn() lands before the deferred stdin.end() launch, so the command
+    // must never run and close must report (null, signal).
+    const out = await runCode(
+      `const cp = require('child_process');
+       const child = cp.spawn('echo', ['pwned']);
+       const closeP = new Promise((resolve) => child.on('close', (code, signal) => resolve([code, signal])));
+       child.kill('SIGKILL');
+       let data = '';
+       child.stdout.on('data', (d) => { data += d.toString(); });
+       const [code, signal] = await closeP;
+       console.log(JSON.stringify(data), code, signal, child.killed);`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('"" null SIGKILL true');
   });
 });
 

--- a/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
+++ b/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
@@ -661,4 +661,83 @@ describe('sandbox.html mirror parity', () => {
     expect(helpers).toMatch(/import\s*\*\s*as\s*pako\s*from\s*'pako'/);
     expect(sandbox).toContain('realm-vendor.js');
   });
+
+  it('mirrors the expanded exec surface (exec.start / exec.kill) in both floats', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve, dirname } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const here = dirname(fileURLToPath(import.meta.url));
+    const repoRoot = resolve(here, '..', '..', '..', '..', '..');
+    const sandbox = readFileSync(
+      resolve(repoRoot, 'packages/chrome-extension/sandbox.html'),
+      'utf-8'
+    );
+    const shared = readFileSync(
+      resolve(repoRoot, 'packages/webapp/src/kernel/realm/js-realm-shared.ts'),
+      'utf-8'
+    );
+    // The killable, buffered-stdin spawn handle (`exec.start`) added in task 1
+    // must exist in BOTH floats: the worker realm's `createExecBridge` and the
+    // inline sandbox mirror. Both wire the `exec:start` + `exec:kill` RPC ops.
+    expect(shared).toMatch(/'exec',\s*'start'/);
+    expect(sandbox).toMatch(/'exec',\s*'start'/);
+    expect(shared).toMatch(/'exec',\s*'kill'/);
+    expect(sandbox).toMatch(/'exec',\s*'kill'/);
+    // The buffered-then-fire shape: chunks buffer until `stdin.end()` launches.
+    for (const needle of ['execBridge.start', 'stdin', 'started']) {
+      expect(sandbox, `sandbox.html missing exec.start needle ${needle}`).toContain(needle);
+    }
+  });
+
+  it('mirrors the nodeChildProcess shim and resolver wiring in both floats', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve, dirname } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const here = dirname(fileURLToPath(import.meta.url));
+    const repoRoot = resolve(here, '..', '..', '..', '..', '..');
+    const sandbox = readFileSync(
+      resolve(repoRoot, 'packages/chrome-extension/sandbox.html'),
+      'utf-8'
+    );
+    const helpers = readFileSync(
+      resolve(repoRoot, 'packages/webapp/src/kernel/realm/js-realm-helpers.ts'),
+      'utf-8'
+    );
+    const shared = readFileSync(
+      resolve(repoRoot, 'packages/webapp/src/kernel/realm/js-realm-shared.ts'),
+      'utf-8'
+    );
+    // The child_process shim surface must be present in BOTH the canonical TS
+    // helper and the inline sandbox mirror so the iframe float matches the
+    // worker float's `require('child_process')` capabilities. The factory,
+    // async forms, the sync/fork unavailable throws, and the ChildProcess class
+    // all mirror.
+    for (const needle of [
+      'createNodeChildProcess',
+      'execFile',
+      'spawn',
+      'execSync',
+      'spawnSync',
+      'execFileSync',
+      'fork',
+      'ChildProcess',
+      'spawnfile',
+      'is not available in the browser realm',
+    ]) {
+      expect(helpers, `js-realm-helpers.ts missing ${needle}`).toContain(needle);
+      expect(sandbox, `sandbox.html missing ${needle}`).toContain(needle);
+    }
+    // Both floats route `child_process` / `node:child_process` (bareId strips
+    // the node: prefix) to the shim: the worker serves the per-realm
+    // `childProcess` instance, the sandbox its `nodeChildProcess` mirror.
+    expect(shared).toMatch(/bareId\s*===\s*'child_process'[\s\S]*?childProcess/);
+    expect(sandbox).toMatch(/bareId\s*===\s*'child_process'[\s\S]*?nodeChildProcess/);
+    // `child_process` is listed AVAILABLE in the sandbox inline mirror so its
+    // derived NODE_BUILTINS_UNAVAILABLE no longer contains it.
+    expect(sandbox).toMatch(/NODE_BUILTIN_AVAILABLE\s*=\s*new Set\(\[[^\]]*'child_process'/);
+    // The shim is built over the `exec.start` handle in both floats (the
+    // substrate the polyfill needs).
+    expect(helpers).toContain('exec.start');
+    expect(sandbox).toContain('exec.start(commandOrArgv)');
+  });
 });

--- a/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
+++ b/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
@@ -687,6 +687,11 @@ describe('sandbox.html mirror parity', () => {
     for (const needle of ['execBridge.start', 'stdin', 'started']) {
       expect(sandbox, `sandbox.html missing exec.start needle ${needle}`).toContain(needle);
     }
+    // Pre-start `kill()` parity (PR #1402 finding 1): both floats guard
+    // `fire()` with a client-side `killed` flag so a kill before `stdin.end()`
+    // never launches the command.
+    expect(shared).toMatch(/if\s*\(started \|\| killed\)/);
+    expect(sandbox).toMatch(/if\s*\(started \|\| killed\)/);
   });
 
   it('mirrors the nodeChildProcess shim and resolver wiring in both floats', async () => {

--- a/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
@@ -12,6 +12,8 @@
 
 import type { CommandContext, FsStat, IFileSystem } from 'just-bash';
 import { describe, expect, it, vi } from 'vitest';
+import { ProcessManager } from '../../../src/kernel/process-manager.js';
+import { createExecBridge } from '../../../src/kernel/realm/js-realm-shared.js';
 import { attachRealmHost } from '../../../src/kernel/realm/realm-host.js';
 import type { RealmPortLike } from '../../../src/kernel/realm/realm-rpc.js';
 import { RealmRpcClient } from '../../../src/kernel/realm/realm-rpc.js';
@@ -249,6 +251,177 @@ describe('realm RPC: exec channel', () => {
       /argv must be a non-empty string\[\]/
     );
     expect(exec).not.toHaveBeenCalled();
+    client.dispose();
+  });
+});
+
+describe('realm RPC: exec.start / exec.kill (kill + buffered stdin)', () => {
+  it('exec.start resolves the handle done-promise with the buffered result', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: 'hi\n', stderr: '', exitCode: 0 });
+    const ctx = makeCtx({ exec });
+    const pm = new ProcessManager();
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx, { pm, owner: { kind: 'cone' } });
+    const client = new RealmRpcClient(realm);
+    const bridge = createExecBridge(client);
+
+    const handle = bridge.start('echo hi');
+    handle.stdin.end();
+    const result = await handle.done;
+
+    expect(result).toEqual({ stdout: 'hi\n', stderr: '', exitCode: 0 });
+    // A signal is always threaded so `kill` can abort mid-run.
+    const [cmd, options] = exec.mock.calls[0];
+    expect(cmd).toBe('echo hi');
+    expect(options.cwd).toBe('/workspace');
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+    client.dispose();
+  });
+
+  it('buffered stdin (write + end) is delivered as the command stdin', async () => {
+    const exec = vi.fn(async (_cmd: string, options: { stdin?: string }) => ({
+      stdout: options.stdin ?? '',
+      stderr: '',
+      exitCode: 0,
+    }));
+    const ctx = makeCtx({ exec });
+    const pm = new ProcessManager();
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx, { pm, owner: { kind: 'cone' } });
+    const client = new RealmRpcClient(realm);
+    const bridge = createExecBridge(client);
+
+    const handle = bridge.start('cat');
+    handle.stdin.write('hel');
+    handle.stdin.write('lo');
+    handle.stdin.end();
+    const result = await handle.done;
+
+    expect(result.stdout).toBe('hello');
+    expect(exec).toHaveBeenCalledWith('cat', expect.objectContaining({ stdin: 'hello' }));
+    client.dispose();
+  });
+
+  it('array-argv form threads the tail through just-bash `args` (shell-free)', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: 'ok', stderr: '', exitCode: 0 });
+    const ctx = makeCtx({ exec });
+    const pm = new ProcessManager();
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx, { pm, owner: { kind: 'cone' } });
+    const client = new RealmRpcClient(realm);
+    const bridge = createExecBridge(client);
+
+    const handle = bridge.start(['echo', 'arg with spaces', '$peculiar']);
+    handle.stdin.end();
+    await handle.done;
+
+    expect(exec).toHaveBeenCalledWith(
+      'echo',
+      expect.objectContaining({ args: ['arg with spaces', '$peculiar'] })
+    );
+    client.dispose();
+  });
+
+  it('registers a live PM process per spawn and removes it (ps) on settle', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+    const ctx = makeCtx({ exec });
+    const pm = new ProcessManager();
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx, { pm, owner: { kind: 'scoop', scoopJid: 'jid-1' } });
+    const client = new RealmRpcClient(realm);
+    const bridge = createExecBridge(client);
+
+    const handle = bridge.start('echo hi');
+    handle.stdin.end();
+    await handle.done;
+
+    // Process was registered as a shell kind owned by the spawning scoop…
+    const all = pm.list();
+    expect(all).toHaveLength(1);
+    expect(all[0].kind).toBe('shell');
+    expect(all[0].owner.scoopJid).toBe('jid-1');
+    // …and it is no longer running (a `ps` would not list it as live).
+    expect(pm.list().filter((p) => p.status === 'running')).toHaveLength(0);
+    expect(all[0].exitCode).toBe(0);
+    client.dispose();
+  });
+
+  it('handle.kill() aborts a long-running command; exit reflects termination; ps drops it', async () => {
+    // A long-running command: resolves only when its abort signal fires,
+    // mirroring just-bash cooperative cancel at the next statement boundary.
+    const exec = vi.fn(
+      (_cmd: string, options: { signal?: AbortSignal }) =>
+        new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve) => {
+          options.signal?.addEventListener('abort', () => {
+            resolve({ stdout: '', stderr: 'terminated\n', exitCode: 143 });
+          });
+        })
+    );
+    const ctx = makeCtx({ exec });
+    const pm = new ProcessManager();
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx, { pm, owner: { kind: 'cone' } });
+    const client = new RealmRpcClient(realm);
+    const bridge = createExecBridge(client);
+
+    const handle = bridge.start('sleep 100');
+    handle.stdin.end();
+    // Let the host register the spawn + PM process before killing.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(pm.list().filter((p) => p.status === 'running')).toHaveLength(1);
+
+    const delivered = await handle.kill();
+    expect(delivered).toBe(true);
+
+    const result = await handle.done;
+    expect(result.exitCode).toBe(143);
+    // PM process is terminated (SIGTERM by default) — a `ps` no longer
+    // lists it as live.
+    const running = pm.list().filter((p) => p.status === 'running');
+    expect(running).toHaveLength(0);
+    const proc = pm.list()[0];
+    expect(proc.terminatedBy).toBe('SIGTERM');
+    expect(proc.status).toBe('killed');
+    client.dispose();
+  });
+
+  it('kill of an unknown / already-settled spawn returns false', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+    const ctx = makeCtx({ exec });
+    const pm = new ProcessManager();
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx, { pm, owner: { kind: 'cone' } });
+    const client = new RealmRpcClient(realm);
+
+    // No such spawn id.
+    await expect(client.call<boolean>('exec', 'kill', [9999])).resolves.toBe(false);
+
+    // A completed spawn is cleaned up, so killing it is also a no-op.
+    const bridge = createExecBridge(client);
+    const handle = bridge.start('echo hi');
+    handle.stdin.end();
+    await handle.done;
+    await expect(handle.kill()).resolves.toBe(false);
+    client.dispose();
+  });
+
+  it('back-compat: exec() and exec.spawn() through the bridge are unchanged', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: 'out', stderr: '', exitCode: 0 });
+    const ctx = makeCtx({ exec });
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+    const bridge = createExecBridge(client);
+
+    await expect(bridge('ls')).resolves.toEqual({ stdout: 'out', stderr: '', exitCode: 0 });
+    expect(exec).toHaveBeenCalledWith('ls', { cwd: '/workspace' });
+
+    await expect(bridge.spawn(['ls', '-la'])).resolves.toEqual({
+      stdout: 'out',
+      stderr: '',
+      exitCode: 0,
+    });
+    expect(exec).toHaveBeenLastCalledWith('ls', { cwd: '/workspace', args: ['-la'] });
     client.dispose();
   });
 });

--- a/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
@@ -426,6 +426,143 @@ describe('realm RPC: exec.start / exec.kill (kill + buffered stdin)', () => {
   });
 });
 
+describe('realm RPC: exec.start / exec.kill review fixes (PR #1402)', () => {
+  const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it('a pre-start kill() prevents the command from launching and resolves done as terminated', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: 'ran\n', stderr: '', exitCode: 0 });
+    const ctx = makeCtx({ exec });
+    const pm = new ProcessManager();
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx, { pm, owner: { kind: 'cone' } });
+    const client = new RealmRpcClient(realm);
+    const bridge = createExecBridge(client);
+
+    const handle = bridge.start('rm -rf /');
+    // Kill BEFORE stdin.end(): the host hasn't registered the spawn yet, so
+    // this is honored client-side.
+    const delivered = await handle.kill('SIGKILL');
+    expect(delivered).toBe(true);
+    // A late stdin.end() must NOT launch the killed spawn.
+    handle.stdin.end();
+    const result = await handle.done;
+    expect(result).toEqual({ stdout: '', stderr: '', exitCode: 137 });
+    await tick();
+    expect(exec).not.toHaveBeenCalled();
+    client.dispose();
+  });
+
+  it('pre-start kill exit code reflects the signal (default SIGTERM=143, SIGINT=130)', async () => {
+    const exec = vi.fn();
+    const ctx = makeCtx({ exec });
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+    const bridge = createExecBridge(client);
+
+    const h1 = bridge.start('a');
+    await h1.kill(); // default → SIGTERM
+    expect((await h1.done).exitCode).toBe(143);
+
+    const h2 = bridge.start('b');
+    await h2.kill('SIGINT');
+    expect((await h2.done).exitCode).toBe(130);
+
+    expect(exec).not.toHaveBeenCalled();
+    client.dispose();
+  });
+
+  it('rejects a duplicate spawnId instead of clobbering a live spawn', async () => {
+    // A long-running exec keeps spawnId 1 live in the host map.
+    const exec = vi.fn(
+      (_cmd: string, options: { signal?: AbortSignal }) =>
+        new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve) => {
+          options.signal?.addEventListener('abort', () =>
+            resolve({ stdout: '', stderr: '', exitCode: 143 })
+          );
+        })
+    );
+    const ctx = makeCtx({ exec });
+    const pm = new ProcessManager();
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx, { pm, owner: { kind: 'cone' } });
+    const client = new RealmRpcClient(realm);
+
+    const live = client.call('exec', 'start', [1, 'sleep 100', {}]);
+    await tick();
+    await expect(client.call('exec', 'start', [1, 'echo hi', {}])).rejects.toThrow(
+      /spawnId 1 is already in use/
+    );
+    // The original spawn is untouched — killing it still works and settles it.
+    await expect(client.call<boolean>('exec', 'kill', [1])).resolves.toBe(true);
+    await expect(live).resolves.toEqual({ stdout: '', stderr: '', exitCode: 143 });
+    client.dispose();
+  });
+
+  it('validates stdin / stdinKind / args shapes before running the command', async () => {
+    const exec = vi.fn();
+    const ctx = makeCtx({ exec });
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+
+    await expect(client.call('exec', 'start', [1, 'echo', { stdin: 42 }])).rejects.toThrow(
+      /stdin must be a string/
+    );
+    await expect(client.call('exec', 'start', [2, 'echo', { stdinKind: 'weird' }])).rejects.toThrow(
+      /stdinKind must be 'text' or 'bytes'/
+    );
+    await expect(client.call('exec', 'start', [3, 'echo', { args: 'nope' }])).rejects.toThrow(
+      /args must be a string\[\]/
+    );
+    await expect(client.call('exec', 'start', [4, 'echo', { args: ['ok', 5] }])).rejects.toThrow(
+      /args must be a string\[\]/
+    );
+    expect(exec).not.toHaveBeenCalled();
+    client.dispose();
+  });
+
+  it('SIGSTOP / SIGCONT drive the PM gate without aborting the in-flight command', async () => {
+    const exec = vi.fn(
+      (_cmd: string, options: { signal?: AbortSignal }) =>
+        new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve) => {
+          options.signal?.addEventListener('abort', () =>
+            resolve({ stdout: '', stderr: 'terminated\n', exitCode: 143 })
+          );
+        })
+    );
+    const ctx = makeCtx({ exec });
+    const pm = new ProcessManager();
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx, { pm, owner: { kind: 'cone' } });
+    const client = new RealmRpcClient(realm);
+    const bridge = createExecBridge(client);
+
+    const handle = bridge.start('sleep 100');
+    handle.stdin.end();
+    await tick();
+    expect(pm.list().filter((p) => p.status === 'running')).toHaveLength(1);
+
+    // SIGSTOP is delivered but does NOT terminate: the command keeps running
+    // (no abort recorded) and the process is only gate-paused.
+    await expect(handle.kill('SIGSTOP')).resolves.toBe(true);
+    await tick();
+    expect(pm.list().filter((p) => p.status === 'running')).toHaveLength(1);
+    expect(pm.list()[0].terminatedBy).toBeNull();
+
+    // SIGCONT likewise leaves the command running.
+    await expect(handle.kill('SIGCONT')).resolves.toBe(true);
+    expect(pm.list()[0].terminatedBy).toBeNull();
+
+    // A terminating signal still aborts and settles the spawn.
+    await expect(handle.kill('SIGTERM')).resolves.toBe(true);
+    const result = await handle.done;
+    expect(result.exitCode).toBe(143);
+    expect(pm.list()[0].terminatedBy).toBe('SIGTERM');
+    client.dispose();
+  });
+});
+
 describe('realm RPC: vfs.writeFile size cap', () => {
   it('round-trips a 4 MiB string without skill-side chunking', async () => {
     // The Concur skill (lines 80–110) used to base64-chunk content


### PR DESCRIPTION
## Summary

Expands the `sliccy:exec` realm bridge (and its realm-RPC channel) so realm scripts (`.jsh`, `node`, `node -e`) can **feed buffered stdin** to a spawned command and **kill** it by handle — then ships a `child_process` polyfill on top as the payoff, with parity across all three require systems.

## What changed (3 waves)

**Wave 1 — exec RPC channel (kill + buffered stdin)**
- `realm-host.ts`: `dispatchExec` gains `start` (client-allocated `spawnId`, per-spawn `AbortController`, PM-registered process, `ctx.exec` threaded with `signal`/`stdin`/`stdinKind`/`args`, buffered result, cleanup on settle) and `kill` (`[spawnId, sig]` → `controller.abort()` + `pm.signal`). `run`/`spawn` back-compat preserved.
- `realm-runner.ts`: `pm`/`owner`/`ppid` threaded to `attachRealmHost`.
- `js-realm-shared.ts`: `exec.start(commandOrArgv, opts)` handle → `{ kill(sig?), stdin: { write, end }, done }`.

**Wave 2 — child_process polyfill (webapp realm)**
- `js-realm-helpers.ts`: `createNodeChildProcess(exec)` — `exec`/`execFile`/`spawn` (Node conventions, EventEmitter `ChildProcess`, Readable stdout/stderr, buffered stdin, `kill`), `util.promisify` support. `execSync`/`spawnSync`/`execFileSync`/`fork` throw a clear "not available in the browser realm" error.
- Served via `resolveServedBuiltin` in `js-realm-shared.ts`; moved out of `NODE_BUILTINS_UNAVAILABLE`.

**Wave 3 — parity + docs**
- `packages/chrome-extension/sandbox.html`: mirrors `exec.start` + serves `child_process` identically to the worker realm (byte-identical sync/fork throws).
- `bsh-watchdog.ts`: keeps `child_process` unavailable with a `.bsh`-specific hint (page context, no shell bridge).
- Parity test + 2 new assertions; docs updated (`docs/shell-reference.md`, `jsh-runtime-extensions.md`).

## Design boundaries (dictated by just-bash v3.0.2)

`ctx.exec` is one-shot buffered, so:
- **kill** is real (just-bash honors `AbortSignal`; cooperative at statement boundaries + hard-kill via PM fan-out for realm-backed children).
- **stdin** is buffered flush-on-`end()` — not interactive.
- **No** streaming stdout/stderr; **no** `execSync`/`spawnSync`/`execFileSync`/`fork` (they throw).

## Verification

All gates green (run independently by a verifier agent):
- `npm run lint`
- `npm run typecheck` (9 tsc projects)
- `npm run test -w @slicc/webapp` (8444 passed / 24 skipped)
- `npm run build -w @slicc/webapp`
- `npm run build -w @slicc/chrome-extension`

Each wave was implemented and then independently verified (high confidence) before proceeding.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author