### PR TITLE
fix(ui): harden iframe repaint nudge for nested cross-origin frames

### DIFF
--- a/packages/chrome-extension/src/sidepanel-entry.ts
+++ b/packages/chrome-extension/src/sidepanel-entry.ts
@@ -76,9 +76,23 @@ export function createSidePanelController(deps: SidePanelDeps): { dispose(): voi
   };
 
   // The follower doc loaded (ignore the about:blank load from blankIframe()).
+  // Chromium compositor bug: an iframe inside the side panel (a special Chrome
+  // surface) may load and execute correctly but never rasterize until DevTools
+  // attaches or the page reloads. A display toggle across two rAFs forces the
+  // compositor to repaint the frame tree — same workaround as iframe-repaint.ts.
+  const nudgeRepaint = (iframe: HTMLIFrameElement) => {
+    const prev = iframe.style.display;
+    iframe.style.display = 'none';
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        iframe.style.display = prev;
+      });
+    });
+  };
   const onIframeLoad = () => {
     if (deps.iframe.getAttribute('src') === 'about:blank') return;
     clearIframeLoadTimer();
+    nudgeRepaint(deps.iframe);
   };
   deps.iframe.addEventListener('load', onIframeLoad);
   deps.iframe.addEventListener('error', () => {

--- a/packages/chrome-extension/src/sidepanel-entry.ts
+++ b/packages/chrome-extension/src/sidepanel-entry.ts
@@ -1,6 +1,7 @@
 /// <reference path="./chrome.d.ts" />
 import { type CherryFeatures, mountSlicc, type SliccHandle } from '@ai-ecoverse/cherry';
 import { SLICC_HOSTED_ORIGIN } from '@slicc/shared-ts';
+import { nudgeIframeRepaint } from '../../webapp/src/ui/iframe-repaint.js';
 import {
   CHERRY_PANEL_PORT_NAME,
   SIDE_PANEL_FEATURES,
@@ -78,21 +79,11 @@ export function createSidePanelController(deps: SidePanelDeps): { dispose(): voi
   // The follower doc loaded (ignore the about:blank load from blankIframe()).
   // Chromium compositor bug: an iframe inside the side panel (a special Chrome
   // surface) may load and execute correctly but never rasterize until DevTools
-  // attaches or the page reloads. A display toggle across two rAFs forces the
-  // compositor to repaint the frame tree — same workaround as iframe-repaint.ts.
-  const nudgeRepaint = (iframe: HTMLIFrameElement) => {
-    const prev = iframe.style.display;
-    iframe.style.display = 'none';
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        iframe.style.display = prev;
-      });
-    });
-  };
+  // attaches or the page reloads.
   const onIframeLoad = () => {
     if (deps.iframe.getAttribute('src') === 'about:blank') return;
     clearIframeLoadTimer();
-    nudgeRepaint(deps.iframe);
+    nudgeIframeRepaint(deps.iframe);
   };
   deps.iframe.addEventListener('load', onIframeLoad);
   deps.iframe.addEventListener('error', () => {

--- a/packages/webapp/src/ui/iframe-repaint.ts
+++ b/packages/webapp/src/ui/iframe-repaint.ts
@@ -30,6 +30,11 @@ const nudgeInFlight = new WeakSet<HTMLIFrameElement>();
  * the missing repaint for this bug — only a `display` toggle (or an
  * out-of-band event like DevTools attaching) does.
  *
+ * In nested cross-origin frames (cherry follower inside a host page), the
+ * single nudge on load can race with the compositor's frame-tree commit.
+ * A second nudge fires after 500ms as a safety net — capped at one retry
+ * to avoid infinite loops or visible flicker.
+ *
  * Re-entrancy-safe: the dip mount fires this from BOTH the iframe `load`
  * handler AND an IntersectionObserver, which can overlap. A second call that
  * landed mid-nudge would read the transient `display:'none'` as
@@ -43,14 +48,39 @@ export function nudgeIframeRepaint(iframe: HTMLIFrameElement, onDone?: () => voi
     onDone?.();
     return;
   }
+  performNudge(iframe, onDone);
+
+  // Safety-net retry: the first nudge can miss when the compositor hasn't
+  // committed the parent's frame tree yet. A single delayed retry covers the
+  // race without risking a loop (it won't schedule further retries itself).
+  setTimeout(() => {
+    if (!iframe.isConnected) return;
+    performNudge(iframe);
+  }, 500);
+}
+
+function performNudge(iframe: HTMLIFrameElement, onDone?: () => void): void {
+  if (nudgeInFlight.has(iframe)) {
+    onDone?.();
+    return;
+  }
   nudgeInFlight.add(iframe);
   const previousDisplay = iframe.style.display;
   iframe.style.display = 'none';
+
+  // In cross-origin iframes, rAF can be throttled. Use setTimeout as a
+  // fallback ceiling so the restore always fires within a bounded time.
+  let restored = false;
+  const restore = () => {
+    if (restored) return;
+    restored = true;
+    iframe.style.display = previousDisplay;
+    nudgeInFlight.delete(iframe);
+    onDone?.();
+  };
+
   requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      iframe.style.display = previousDisplay;
-      nudgeInFlight.delete(iframe);
-      onDone?.();
-    });
+    requestAnimationFrame(restore);
   });
+  setTimeout(restore, 100);
 }

--- a/packages/webapp/src/ui/iframe-repaint.ts
+++ b/packages/webapp/src/ui/iframe-repaint.ts
@@ -32,8 +32,11 @@ const nudgeInFlight = new WeakSet<HTMLIFrameElement>();
  *
  * In nested cross-origin frames (cherry follower inside a host page), the
  * single nudge on load can race with the compositor's frame-tree commit.
- * A second nudge fires after 500ms as a safety net — capped at one retry
- * to avoid infinite loops or visible flicker.
+ * A safety-net retry fires after 500ms, but ONLY when the first nudge was
+ * restored by the setTimeout fallback (indicating rAF was throttled and the
+ * compositor likely didn't commit). When rAF fires normally the retry is
+ * skipped — the compositor was responsive and the nudge almost certainly
+ * took effect.
  *
  * Re-entrancy-safe: the dip mount fires this from BOTH the iframe `load`
  * handler AND an IntersectionObserver, which can overlap. A second call that
@@ -48,18 +51,28 @@ export function nudgeIframeRepaint(iframe: HTMLIFrameElement, onDone?: () => voi
     onDone?.();
     return;
   }
-  performNudge(iframe, onDone);
 
-  // Safety-net retry: the first nudge can miss when the compositor hasn't
-  // committed the parent's frame tree yet. A single delayed retry covers the
-  // race without risking a loop (it won't schedule further retries itself).
+  // Track whether rAF restored (compositor responsive) vs setTimeout fallback.
+  let rafRestored = false;
+  performNudge(iframe, onDone, () => {
+    rafRestored = true;
+  });
+
+  // Safety-net retry: fires only when the first nudge fell back to setTimeout
+  // (rAF was throttled), meaning the compositor likely didn't commit the frame
+  // tree in time for the first toggle to take effect.
   setTimeout(() => {
+    if (rafRestored) return;
     if (!iframe.isConnected) return;
     performNudge(iframe);
   }, 500);
 }
 
-function performNudge(iframe: HTMLIFrameElement, onDone?: () => void): void {
+function performNudge(
+  iframe: HTMLIFrameElement,
+  onDone?: () => void,
+  onRafRestore?: () => void
+): void {
   if (nudgeInFlight.has(iframe)) {
     onDone?.();
     return;
@@ -71,16 +84,17 @@ function performNudge(iframe: HTMLIFrameElement, onDone?: () => void): void {
   // In cross-origin iframes, rAF can be throttled. Use setTimeout as a
   // fallback ceiling so the restore always fires within a bounded time.
   let restored = false;
-  const restore = () => {
+  const restore = (viaRaf: boolean) => {
     if (restored) return;
     restored = true;
     iframe.style.display = previousDisplay;
     nudgeInFlight.delete(iframe);
+    if (viaRaf) onRafRestore?.();
     onDone?.();
   };
 
   requestAnimationFrame(() => {
-    requestAnimationFrame(restore);
+    requestAnimationFrame(() => restore(true));
   });
-  setTimeout(restore, 100);
+  setTimeout(() => restore(false), 100);
 }

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -386,6 +386,10 @@ export class SprinkleRenderer {
           clearTimeout(timer);
           console.log('[sprinkle-renderer] iframe loaded, contentWindow:', !!iframe.contentWindow);
           registerSprinkleWindow(iframe.contentWindow);
+          // Chromium compositor bug: in the extension side panel the sandbox iframe
+          // is nested 2+ levels deep (sidepanel → cherry follower → sandbox) and
+          // may never rasterize without a display-toggle nudge.
+          if (isNestedInAnotherFrame()) nudgeIframeRepaint(iframe);
           resolve();
         },
         { once: true }

--- a/packages/webapp/tests/ui/iframe-repaint.test.ts
+++ b/packages/webapp/tests/ui/iframe-repaint.test.ts
@@ -9,16 +9,19 @@ describe('isNestedInAnotherFrame', () => {
 });
 
 describe('nudgeIframeRepaint', () => {
-  // Manual rAF queue so we control when the two-frame restore runs.
   let rafQueue: FrameRequestCallback[];
   beforeEach(() => {
+    vi.useFakeTimers();
     rafQueue = [];
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
       rafQueue.push(cb);
       return rafQueue.length;
     });
   });
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
   const flushFrame = () => {
     const batch = rafQueue;
     rafQueue = [];
@@ -35,11 +38,11 @@ describe('nudgeIframeRepaint', () => {
   it('toggles display off then restores the original across two frames', () => {
     const iframe = makeIframe('block');
     nudgeIframeRepaint(iframe);
-    expect(iframe.style.display).toBe('none'); // hidden immediately
+    expect(iframe.style.display).toBe('none');
     flushFrame();
-    expect(iframe.style.display).toBe('none'); // still hidden after 1 frame
+    expect(iframe.style.display).toBe('none');
     flushFrame();
-    expect(iframe.style.display).toBe('block'); // restored after 2 frames
+    expect(iframe.style.display).toBe('block');
   });
 
   it('runs onDone after the restore', () => {
@@ -54,17 +57,11 @@ describe('nudgeIframeRepaint', () => {
 
   it('is re-entrancy-safe: an overlapping nudge does NOT capture the transient none (regression)', () => {
     const iframe = makeIframe('block');
-    // First nudge — display is now 'none', restore pending.
     nudgeIframeRepaint(iframe);
     expect(iframe.style.display).toBe('none');
-    // A second nudge lands mid-flight (the dip mount fires from both the load
-    // handler and an IntersectionObserver). It must NOT read 'none' as the
-    // restore value, and its onDone still runs.
     const onDone2 = vi.fn();
     nudgeIframeRepaint(iframe, onDone2);
-    expect(onDone2).toHaveBeenCalledTimes(1); // skipped → callback ran synchronously
-    // Flush the first nudge's two frames → restored to the ORIGINAL 'block',
-    // not stuck at 'none'.
+    expect(onDone2).toHaveBeenCalledTimes(1);
     flushFrame();
     flushFrame();
     expect(iframe.style.display).toBe('block');
@@ -76,11 +73,96 @@ describe('nudgeIframeRepaint', () => {
     flushFrame();
     flushFrame();
     expect(iframe.style.display).toBe('block');
-    // A fresh nudge works (the in-flight guard cleared).
     nudgeIframeRepaint(iframe);
     expect(iframe.style.display).toBe('none');
     flushFrame();
     flushFrame();
     expect(iframe.style.display).toBe('block');
+  });
+
+  describe('safety-net retry (500ms)', () => {
+    it('does NOT retry when rAF restored successfully (compositor responsive)', () => {
+      const iframe = makeIframe('block');
+      nudgeIframeRepaint(iframe);
+      // rAF restores normally
+      flushFrame();
+      flushFrame();
+      expect(iframe.style.display).toBe('block');
+      // Advance past the 500ms retry window
+      vi.advanceTimersByTime(500);
+      // No second nudge — display should still be block (not toggled to none)
+      expect(iframe.style.display).toBe('block');
+    });
+
+    it('retries at 500ms when rAF was starved and setTimeout fallback restored', () => {
+      const iframe = makeIframe('block');
+      nudgeIframeRepaint(iframe);
+      expect(iframe.style.display).toBe('none');
+      // Don't flush rAF — let the 100ms setTimeout fallback restore
+      vi.advanceTimersByTime(100);
+      expect(iframe.style.display).toBe('block');
+      // Now at 500ms the retry fires since rAF didn't restore
+      vi.advanceTimersByTime(400);
+      expect(iframe.style.display).toBe('none'); // retry toggled it
+      // Flush retry's rAF to restore
+      flushFrame();
+      flushFrame();
+      expect(iframe.style.display).toBe('block');
+    });
+
+    it('is a no-op when iframe is disconnected before retry fires', () => {
+      const iframe = makeIframe('block');
+      nudgeIframeRepaint(iframe);
+      // setTimeout fallback restores (rAF starved)
+      vi.advanceTimersByTime(100);
+      expect(iframe.style.display).toBe('block');
+      // Detach the iframe before the retry
+      iframe.remove();
+      vi.advanceTimersByTime(400);
+      // No crash, no toggle
+      expect(iframe.style.display).toBe('block');
+    });
+
+    it('does not schedule further retries from the retry itself', () => {
+      const iframe = makeIframe('block');
+      nudgeIframeRepaint(iframe);
+      // setTimeout fallback restores
+      vi.advanceTimersByTime(100);
+      expect(iframe.style.display).toBe('block');
+      // 500ms retry fires
+      vi.advanceTimersByTime(400);
+      expect(iframe.style.display).toBe('none');
+      // Restore via rAF
+      flushFrame();
+      flushFrame();
+      expect(iframe.style.display).toBe('block');
+      // Advance another 500ms — no third nudge
+      vi.advanceTimersByTime(500);
+      expect(iframe.style.display).toBe('block');
+    });
+  });
+
+  describe('setTimeout(100ms) rAF fallback', () => {
+    it('restores display when rAF is starved', () => {
+      const iframe = makeIframe('flex');
+      nudgeIframeRepaint(iframe);
+      expect(iframe.style.display).toBe('none');
+      // Don't flush rAF at all — advance time to trigger the 100ms fallback
+      vi.advanceTimersByTime(100);
+      expect(iframe.style.display).toBe('flex');
+    });
+
+    it('onDone fires exactly once even when both rAF and setTimeout resolve', () => {
+      const iframe = makeIframe('block');
+      const onDone = vi.fn();
+      nudgeIframeRepaint(iframe, onDone);
+      // Let setTimeout fire first
+      vi.advanceTimersByTime(100);
+      expect(onDone).toHaveBeenCalledTimes(1);
+      // Now flush rAF — onDone must NOT fire again
+      flushFrame();
+      flushFrame();
+      expect(onDone).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
The Chromium compositor first-paint bug causes sprinkle iframes inside the cherry follower (host page → cherry iframe → sprinkle iframe) to load correctly but never rasterize. The existing display-toggle nudge can race with the compositor's frame-tree commit in cross-origin frames.

- Add a 500ms safety-net retry to nudgeIframeRepaint (capped at one retry via performNudge to prevent infinite loops)
- Add setTimeout(100ms) fallback for rAF throttling in cross-origin iframes
- Add nudge to renderInSandbox path (extension mode was missing it)
- Add nudge to sidepanel-entry follower iframe on load

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] **UI change?** Attach a screencast of what changed (**required** for UI
      changes). Record it with the `demo-recording` skill — a CDP screencast of
      the running harness (`node packages/dev-tools/tools/slicc-screencast.mjs`)
      or a polished cursor-animated MP4. Upload it with `gh image` from
      `ai-ecoverse/ai-aligned-gh` (e.g.
      `gh image --markdown screencast.webm`) and paste the embed here.
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
