### PR TITLE
feat(git): implement git merge-file (three-way/diff3 merge)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -301,7 +301,6 @@
         "packages/webapp/src/core/image-processor.ts",
         "packages/webapp/src/core/tool-adapter.ts",
         "packages/webapp/src/fs/mount-recovery.ts",
-        "packages/webapp/src/git/diff.ts",
         "packages/webapp/src/git/git-config.ts",
         "packages/webapp/src/kernel/realm/http-global.ts",
         "packages/webapp/src/kernel/realm/ws-router-page.ts",

--- a/packages/webapp/src/git/commands/merge-file.ts
+++ b/packages/webapp/src/git/commands/merge-file.ts
@@ -1,0 +1,93 @@
+/**
+ * `git merge-file` — three-way file-content merge (diff3).
+ *
+ * Distinct from the `merge` module (which joins histories). This incorporates
+ * the changes from `<base>`→`<other>` into `<current>`, using `<base>` as the
+ * common ancestor, and writes the result back to `<current>` by default.
+ * Parsing + file I/O live here; the pure merge is `../merge-file-core.ts`.
+ */
+
+import { parseArgs } from '../../shell/arg-parser.js';
+import { threeWayMerge } from '../merge-file-core.js';
+import { GIT_FLAG_SPECS } from './shared.js';
+import type { GitCommandContext, GitCommandResult } from './types.js';
+
+const USAGE = 'usage: git merge-file [<options>] <current-file> <base-file> <other-file>';
+
+/** Coerce an mri flag value (string | string[] | undefined) to a string[]. */
+function asStringArray(value: unknown): string[] {
+  if (value === undefined) return [];
+  return (Array.isArray(value) ? value : [value]).map((v) => String(v));
+}
+
+export async function mergeFile(
+  ctx: GitCommandContext,
+  cwd: string,
+  args: string[]
+): Promise<GitCommandResult> {
+  const parsed = parseArgs(args, GIT_FLAG_SPECS['merge-file']);
+  const positionals = parsed.positionals;
+
+  if (positionals.length !== 3) {
+    return { stdout: '', stderr: `${USAGE}\n`, exitCode: 255 };
+  }
+
+  const labels = asStringArray(parsed.flags.L);
+  if (labels.length > 3) {
+    return {
+      stdout: '',
+      stderr: 'fatal: too many labels on the command line\n',
+      exitCode: 255,
+    };
+  }
+
+  const favorFlags = [
+    parsed.flags.ours ? 'ours' : undefined,
+    parsed.flags.theirs ? 'theirs' : undefined,
+    parsed.flags.union ? 'union' : undefined,
+  ].filter((f): f is 'ours' | 'theirs' | 'union' => f !== undefined);
+  if (favorFlags.length > 1) {
+    return {
+      stdout: '',
+      stderr: 'fatal: --ours, --theirs, and --union are mutually exclusive\n',
+      exitCode: 255,
+    };
+  }
+
+  const [currentPath, basePath, otherPath] = positionals;
+  const resolve = (p: string) => (p.startsWith('/') ? p : `${cwd}/${p}`);
+
+  let current: string;
+  let base: string;
+  let other: string;
+  try {
+    current = await ctx.fs.readTextFile(resolve(currentPath));
+    base = await ctx.fs.readTextFile(resolve(basePath));
+    other = await ctx.fs.readTextFile(resolve(otherPath));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { stdout: '', stderr: `error: ${message}\n`, exitCode: 255 };
+  }
+
+  const result = threeWayMerge(current, base, other, {
+    diff3: Boolean(parsed.flags.diff3),
+    favor: favorFlags[0],
+    labels: {
+      current: labels[0] ?? currentPath,
+      base: labels[1] ?? basePath,
+      other: labels[2] ?? otherPath,
+    },
+  });
+
+  const quiet = Boolean(parsed.flags.quiet);
+  const stderr =
+    !quiet && result.conflicts > 0 ? `warning: merge conflict in ${currentPath}\n` : '';
+  const exitCode = Math.min(result.conflicts, 127);
+
+  if (parsed.flags.stdout) {
+    return { stdout: result.content, stderr, exitCode };
+  }
+
+  await ctx.fs.writeFile(resolve(currentPath), result.content);
+  return { stdout: '', stderr, exitCode };
+}

--- a/packages/webapp/src/git/commands/merge-file.ts
+++ b/packages/webapp/src/git/commands/merge-file.ts
@@ -79,10 +79,13 @@ export async function mergeFile(
     },
   });
 
+  // A favor flag (--ours/--theirs/--union) resolves every conflict, so real
+  // `git merge-file` reports zero remaining conflicts: exit 0 and no warning.
+  const remainingConflicts = favorFlags.length > 0 ? 0 : result.conflicts;
   const quiet = Boolean(parsed.flags.quiet);
   const stderr =
-    !quiet && result.conflicts > 0 ? `warning: merge conflict in ${currentPath}\n` : '';
-  const exitCode = Math.min(result.conflicts, 127);
+    !quiet && remainingConflicts > 0 ? `warning: merge conflict in ${currentPath}\n` : '';
+  const exitCode = Math.min(remainingConflicts, 127);
 
   if (parsed.flags.stdout) {
     return { stdout: result.content, stderr, exitCode };

--- a/packages/webapp/src/git/commands/shared.ts
+++ b/packages/webapp/src/git/commands/shared.ts
@@ -66,6 +66,11 @@ export const GIT_FLAG_SPECS: Record<string, ArgSpec> = {
     string: ['message', 'strategy', 'strategy-option'],
     alias: { m: 'message', s: 'strategy', X: 'strategy-option' },
   },
+  'merge-file': {
+    string: ['L'],
+    boolean: ['stdout', 'quiet', 'diff3', 'ours', 'theirs', 'union'],
+    alias: { p: 'stdout', q: 'quiet' },
+  },
   tag: {
     string: ['message', 'file', 'list', 'contains', 'points-at'],
     boolean: ['delete', 'annotate', 'force'],

--- a/packages/webapp/src/git/diff.ts
+++ b/packages/webapp/src/git/diff.ts
@@ -3,15 +3,16 @@
  * Produces standard unified diff output with @@ hunk headers.
  */
 
-interface Edit {
+export interface Edit {
   type: 'equal' | 'insert' | 'delete';
   line: string;
 }
 
 /**
  * Myers diff algorithm — computes shortest edit script between two line arrays.
+ * Exported as an internal helper for the three-way merge core (`merge-file-core.ts`).
  */
-function myersDiff(a: string[], b: string[]): Edit[] {
+export function myersDiff(a: string[], b: string[]): Edit[] {
   const n = a.length;
   const m = b.length;
 

--- a/packages/webapp/src/git/diff.ts
+++ b/packages/webapp/src/git/diff.ts
@@ -9,51 +9,61 @@ export interface Edit {
 }
 
 /**
- * Myers diff algorithm — computes shortest edit script between two line arrays.
- * Exported as an internal helper for the three-way merge core (`merge-file-core.ts`).
+ * Decide whether step `d` on diagonal `k` was reached from the insert
+ * neighbour (k+1) rather than the delete neighbour (k-1). Shared by the
+ * forward pass and the backtrack so both stay in lockstep.
  */
-export function myersDiff(a: string[], b: string[]): Edit[] {
-  const n = a.length;
-  const m = b.length;
+function cameFromInsert(v: number[], k: number, d: number, offset: number): boolean {
+  return k === -d || (k !== d && v[k - 1 + offset] < v[k + 1 + offset]);
+}
 
-  if (n === 0 && m === 0) return [];
-  if (n === 0) return b.map((line) => ({ type: 'insert' as const, line }));
-  if (m === 0) return a.map((line) => ({ type: 'delete' as const, line }));
-
-  const max = n + m;
-  const offset = max;
-  const size = 2 * max + 1;
-
-  // Forward pass: compute trace of furthest-reaching points
+/**
+ * Forward pass: compute the trace of furthest-reaching points and the number
+ * of edits (`finalD`) needed to reach (n, m).
+ */
+function computeForwardTrace(
+  a: string[],
+  b: string[],
+  n: number,
+  m: number,
+  max: number,
+  offset: number
+): { trace: number[][]; finalD: number } {
   const trace: number[][] = [];
-  const v = new Array<number>(size).fill(0);
+  const v = new Array<number>(2 * max + 1).fill(0);
 
-  let finalD = -1;
-  outer: for (let d = 0; d <= max; d++) {
+  for (let d = 0; d <= max; d++) {
     trace.push(v.slice());
     for (let k = -d; k <= d; k += 2) {
-      let x: number;
-      if (k === -d || (k !== d && v[k - 1 + offset] < v[k + 1 + offset])) {
-        x = v[k + 1 + offset]; // insert: come from k+1
-      } else {
-        x = v[k - 1 + offset] + 1; // delete: come from k-1
-      }
+      let x = cameFromInsert(v, k, d, offset)
+        ? v[k + 1 + offset] // insert: come from k+1
+        : v[k - 1 + offset] + 1; // delete: come from k-1
       let y = x - k;
       while (x < n && y < m && a[x] === b[y]) {
         x++;
         y++;
       }
       v[k + offset] = x;
-      if (x >= n && y >= m) {
-        finalD = d;
-        break outer;
-      }
+      if (x >= n && y >= m) return { trace, finalD: d };
     }
   }
 
-  if (finalD === -1) finalD = max;
+  return { trace, finalD: max };
+}
 
-  // Backtrack from (n, m) to (0, 0) using the trace
+/**
+ * Backtrack from (n, m) to (0, 0) using the forward-pass trace, emitting the
+ * edit script in forward order.
+ */
+function backtrackTrace(
+  a: string[],
+  b: string[],
+  n: number,
+  m: number,
+  offset: number,
+  trace: number[][],
+  finalD: number
+): Edit[] {
   const edits: Edit[] = [];
   let x = n;
   let y = m;
@@ -62,14 +72,7 @@ export function myersDiff(a: string[], b: string[]): Edit[] {
     // trace[d] holds v state AFTER d-1 was processed (pushed at start of d loop)
     const prev = trace[d];
     const k = x - y;
-
-    let prevK: number;
-    if (k === -d || (k !== d && prev[k - 1 + offset] < prev[k + 1 + offset])) {
-      prevK = k + 1; // came from insert
-    } else {
-      prevK = k - 1; // came from delete
-    }
-
+    const prevK = cameFromInsert(prev, k, d, offset) ? k + 1 : k - 1;
     const prevX = prev[prevK + offset];
     const prevY = prevX - prevK;
 
@@ -99,6 +102,25 @@ export function myersDiff(a: string[], b: string[]): Edit[] {
 
   edits.reverse();
   return edits;
+}
+
+/**
+ * Myers diff algorithm — computes shortest edit script between two line arrays.
+ * Exported as an internal helper for the three-way merge core (`merge-file-core.ts`).
+ */
+export function myersDiff(a: string[], b: string[]): Edit[] {
+  const n = a.length;
+  const m = b.length;
+
+  if (n === 0 && m === 0) return [];
+  if (n === 0) return b.map((line) => ({ type: 'insert' as const, line }));
+  if (m === 0) return a.map((line) => ({ type: 'delete' as const, line }));
+
+  const max = n + m;
+  const offset = max;
+
+  const { trace, finalD } = computeForwardTrace(a, b, n, m, max, offset);
+  return backtrackTrace(a, b, n, m, offset, trace, finalD);
 }
 
 interface Hunk {

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -30,6 +30,7 @@ import { init } from './commands/init.js';
 import { log } from './commands/log.js';
 import { lsFiles } from './commands/ls-files.js';
 import { merge } from './commands/merge.js';
+import { mergeFile } from './commands/merge-file.js';
 import { mv } from './commands/mv.js';
 import { pull } from './commands/pull.js';
 import { push } from './commands/push.js';
@@ -334,6 +335,8 @@ export class GitCommands {
           return await push(this.ctx, effectiveCwd, rest);
         case 'merge':
           return await merge(this.ctx, effectiveCwd, rest);
+        case 'merge-file':
+          return await mergeFile(this.ctx, effectiveCwd, rest);
         case 'reset':
           return await reset(this.ctx, effectiveCwd, rest);
         case 'config':
@@ -461,6 +464,7 @@ Available commands:
   pull        Fetch and merge changes
   push        Update remote refs
   merge       Join two development histories together
+  merge-file  Run a three-way file merge
   reset       Reset HEAD, index, and working tree
   stash       Stash changes in a dirty working directory
   rm          Remove files from the working tree and index

--- a/packages/webapp/src/git/merge-file-core.ts
+++ b/packages/webapp/src/git/merge-file-core.ts
@@ -1,0 +1,216 @@
+/**
+ * Pure, dependency-free three-way (diff3) merge.
+ *
+ * Aligns current↔base and other↔base using the shared Myers line-diff, walks the
+ * stable (common) base regions, and emits changed regions. A region conflicts when
+ * both sides changed the same base region divergently. Produces merged text plus a
+ * conflict count. No file I/O or CLI parsing lives here.
+ */
+import { myersDiff } from './diff.js';
+
+export interface ThreeWayMergeOptions {
+  diff3?: boolean;
+  favor?: 'ours' | 'theirs' | 'union';
+  labels?: { current: string; base: string; other: string };
+}
+
+export interface ThreeWayMergeResult {
+  content: string;
+  conflicts: number;
+}
+
+/** Split into lines that each retain their trailing `\n`, so concatenation is exact. */
+function splitLines(text: string): string[] {
+  if (text === '') return [];
+  const lines: string[] = [];
+  let start = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '\n') {
+      lines.push(text.slice(start, i + 1));
+      start = i + 1;
+    }
+  }
+  if (start < text.length) lines.push(text.slice(start));
+  return lines;
+}
+
+function linesEqual(x: string[], y: string[]): boolean {
+  if (x.length !== y.length) return false;
+  for (let i = 0; i < x.length; i++) if (x[i] !== y[i]) return false;
+  return true;
+}
+
+interface Hunk {
+  side: 'a' | 'b';
+  baseStart: number;
+  baseLen: number;
+  sideStart: number;
+  sideLen: number;
+}
+
+/** Changed regions between `base` and `side`, expressed in base offsets. */
+function diffHunks(base: string[], side: string[], tag: 'a' | 'b'): Hunk[] {
+  const edits = myersDiff(base, side);
+  const hunks: Hunk[] = [];
+  let baseIdx = 0;
+  let sideIdx = 0;
+  let i = 0;
+  while (i < edits.length) {
+    if (edits[i].type === 'equal') {
+      baseIdx++;
+      sideIdx++;
+      i++;
+      continue;
+    }
+    const baseStart = baseIdx;
+    const sideStart = sideIdx;
+    while (i < edits.length && edits[i].type !== 'equal') {
+      if (edits[i].type === 'delete') baseIdx++;
+      else sideIdx++;
+      i++;
+    }
+    hunks.push({
+      side: tag,
+      baseStart,
+      baseLen: baseIdx - baseStart,
+      sideStart,
+      sideLen: sideIdx - sideStart,
+    });
+  }
+  return hunks;
+}
+
+type Region =
+  | { stable: true; lines: string[] }
+  | { stable: false; aLines: string[]; oLines: string[]; bLines: string[] };
+
+/** diff3 region walk: stable base spans, one-sided auto-merges, and conflict windows. */
+function diff3Regions(a: string[], o: string[], b: string[]): Region[] {
+  const hunks = [...diffHunks(o, a, 'a'), ...diffHunks(o, b, 'b')];
+  hunks.sort((x, y) => x.baseStart - y.baseStart || x.baseLen - y.baseLen);
+
+  const regions: Region[] = [];
+  let currOffset = 0;
+  const advanceTo = (end: number) => {
+    if (end > currOffset) {
+      regions.push({ stable: true, lines: o.slice(currOffset, end) });
+      currOffset = end;
+    }
+  };
+
+  let i = 0;
+  while (i < hunks.length) {
+    const hunk = hunks[i];
+    i++;
+    const regionStart = hunk.baseStart;
+    let regionEnd = hunk.baseStart + hunk.baseLen;
+    const regionHunks = [hunk];
+    advanceTo(regionStart);
+    while (i < hunks.length && hunks[i].baseStart <= regionEnd) {
+      regionEnd = Math.max(regionEnd, hunks[i].baseStart + hunks[i].baseLen);
+      regionHunks.push(hunks[i]);
+      i++;
+    }
+
+    if (regionHunks.length === 1) {
+      const sideArr = hunk.side === 'a' ? a : b;
+      if (hunk.sideLen > 0) {
+        regions.push({
+          stable: true,
+          lines: sideArr.slice(hunk.sideStart, hunk.sideStart + hunk.sideLen),
+        });
+      }
+    } else {
+      const bounds = { a: [a.length, -1, o.length, -1], b: [b.length, -1, o.length, -1] };
+      for (const h of regionHunks) {
+        const bd = bounds[h.side];
+        bd[0] = Math.min(h.sideStart, bd[0]);
+        bd[1] = Math.max(h.sideStart + h.sideLen, bd[1]);
+        bd[2] = Math.min(h.baseStart, bd[2]);
+        bd[3] = Math.max(h.baseStart + h.baseLen, bd[3]);
+      }
+      const aStart = bounds.a[0] + (regionStart - bounds.a[2]);
+      const aEnd = bounds.a[1] + (regionEnd - bounds.a[3]);
+      const bStart = bounds.b[0] + (regionStart - bounds.b[2]);
+      const bEnd = bounds.b[1] + (regionEnd - bounds.b[3]);
+      regions.push({
+        stable: false,
+        aLines: a.slice(aStart, aEnd),
+        oLines: o.slice(regionStart, regionEnd),
+        bLines: b.slice(bStart, bEnd),
+      });
+    }
+    currOffset = regionEnd;
+  }
+  advanceTo(o.length);
+  return regions;
+}
+
+/**
+ * Three-way merge of `current` (ours) and `other` (theirs) against `base`.
+ * Disjoint or identical changes auto-merge; divergent overlaps produce conflict
+ * hunks (or resolve per `favor`). Line content is preserved exactly.
+ */
+export function threeWayMerge(
+  current: string,
+  base: string,
+  other: string,
+  opts: ThreeWayMergeOptions = {}
+): ThreeWayMergeResult {
+  const diff3 = opts.diff3 ?? false;
+  const favor = opts.favor;
+  const labels = {
+    current: opts.labels?.current ?? 'current',
+    base: opts.labels?.base ?? 'base',
+    other: opts.labels?.other ?? 'other',
+  };
+
+  const a = splitLines(current);
+  const o = splitLines(base);
+  const b = splitLines(other);
+  const regions = diff3Regions(a, o, b);
+
+  let out = '';
+  let conflicts = 0;
+  const push = (lines: string[]) => {
+    for (const line of lines) out += line;
+  };
+  const pushMarker = (text: string) => {
+    if (out.length > 0 && !out.endsWith('\n')) out += '\n';
+    out += `${text}\n`;
+  };
+
+  for (const region of regions) {
+    if (region.stable) {
+      push(region.lines);
+      continue;
+    }
+    if (linesEqual(region.aLines, region.bLines)) {
+      push(region.aLines);
+      continue;
+    }
+
+    conflicts++;
+    if (favor === 'ours') {
+      push(region.aLines);
+    } else if (favor === 'theirs') {
+      push(region.bLines);
+    } else if (favor === 'union') {
+      push(region.aLines);
+      if (out.length > 0 && !out.endsWith('\n') && region.bLines.length > 0) out += '\n';
+      push(region.bLines);
+    } else {
+      pushMarker(`<<<<<<< ${labels.current}`);
+      push(region.aLines);
+      if (diff3) {
+        pushMarker(`||||||| ${labels.base}`);
+        push(region.oLines);
+      }
+      pushMarker('=======');
+      push(region.bLines);
+      pushMarker(`>>>>>>> ${labels.other}`);
+    }
+  }
+
+  return { content: out, conflicts };
+}

--- a/packages/webapp/tests/git/merge-file-core.test.ts
+++ b/packages/webapp/tests/git/merge-file-core.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { threeWayMerge } from '../../src/git/merge-file-core.js';
+
+const labels = { current: 'ours', base: 'orig', other: 'theirs' };
+
+describe('threeWayMerge', () => {
+  it('no change on any side returns the base verbatim', () => {
+    const base = 'a\nb\nc\n';
+    const result = threeWayMerge(base, base, base, { labels });
+    expect(result.content).toBe(base);
+    expect(result.conflicts).toBe(0);
+  });
+
+  it('one-sided change (ours) auto-merges', () => {
+    const base = 'a\nb\nc\n';
+    const current = 'a\nB\nc\n';
+    const result = threeWayMerge(current, base, base, { labels });
+    expect(result.content).toBe('a\nB\nc\n');
+    expect(result.conflicts).toBe(0);
+  });
+
+  it('one-sided change (theirs) auto-merges', () => {
+    const base = 'a\nb\nc\n';
+    const other = 'a\nb\nC\n';
+    const result = threeWayMerge(base, base, other, { labels });
+    expect(result.content).toBe('a\nb\nC\n');
+    expect(result.conflicts).toBe(0);
+  });
+
+  it('identical change on both sides auto-merges without conflict', () => {
+    const base = 'a\nb\nc\n';
+    const changed = 'a\nBB\nc\n';
+    const result = threeWayMerge(changed, base, changed, { labels });
+    expect(result.content).toBe('a\nBB\nc\n');
+    expect(result.conflicts).toBe(0);
+  });
+
+  it('adjacent non-overlapping changes merge cleanly', () => {
+    const base = 'a\nb\nc\nd\ne\n';
+    const current = 'A\nb\nc\nd\ne\n';
+    const other = 'a\nb\nc\nd\nE\n';
+    const result = threeWayMerge(current, base, other, { labels });
+    expect(result.content).toBe('A\nb\nc\nd\nE\n');
+    expect(result.conflicts).toBe(0);
+  });
+
+  it('divergent overlapping changes produce a conflict hunk', () => {
+    const base = 'a\nb\nc\n';
+    const current = 'a\nX\nc\n';
+    const other = 'a\nY\nc\n';
+    const result = threeWayMerge(current, base, other, { labels });
+    expect(result.conflicts).toBe(1);
+    expect(result.content).toBe('a\n<<<<<<< ours\nX\n=======\nY\n>>>>>>> theirs\nc\n');
+  });
+
+  it('diff3 mode adds the base section between markers', () => {
+    const base = 'a\nb\nc\n';
+    const current = 'a\nX\nc\n';
+    const other = 'a\nY\nc\n';
+    const result = threeWayMerge(current, base, other, { labels, diff3: true });
+    expect(result.conflicts).toBe(1);
+    expect(result.content).toBe(
+      'a\n<<<<<<< ours\nX\n||||||| orig\nb\n=======\nY\n>>>>>>> theirs\nc\n'
+    );
+  });
+
+  it('favor=ours resolves conflicts to the current side without markers', () => {
+    const base = 'a\nb\nc\n';
+    const current = 'a\nX\nc\n';
+    const other = 'a\nY\nc\n';
+    const result = threeWayMerge(current, base, other, { labels, favor: 'ours' });
+    expect(result.content).toBe('a\nX\nc\n');
+    expect(result.conflicts).toBe(1);
+    expect(result.content).not.toContain('<<<<<<<');
+  });
+
+  it('favor=theirs resolves conflicts to the other side without markers', () => {
+    const base = 'a\nb\nc\n';
+    const current = 'a\nX\nc\n';
+    const other = 'a\nY\nc\n';
+    const result = threeWayMerge(current, base, other, { labels, favor: 'theirs' });
+    expect(result.content).toBe('a\nY\nc\n');
+    expect(result.conflicts).toBe(1);
+  });
+
+  it('favor=union concatenates current then other', () => {
+    const base = 'a\nb\nc\n';
+    const current = 'a\nX\nc\n';
+    const other = 'a\nY\nc\n';
+    const result = threeWayMerge(current, base, other, { labels, favor: 'union' });
+    expect(result.content).toBe('a\nX\nY\nc\n');
+    expect(result.conflicts).toBe(1);
+  });
+
+  it('preserves a missing trailing newline exactly', () => {
+    const base = 'a\nb';
+    const current = 'a\nB';
+    const result = threeWayMerge(current, base, base, { labels });
+    expect(result.content).toBe('a\nB');
+    expect(result.conflicts).toBe(0);
+  });
+
+  it('does not introduce phantom trailing blank lines', () => {
+    const base = 'a\nb\nc\n';
+    const current = 'a\nb\nc\nd\n';
+    const result = threeWayMerge(current, base, base, { labels });
+    expect(result.content).toBe('a\nb\nc\nd\n');
+    expect(result.content.endsWith('\n\n')).toBe(false);
+  });
+
+  it('handles empty base with a one-sided insertion', () => {
+    const result = threeWayMerge('hello\n', '', '', { labels });
+    expect(result.content).toBe('hello\n');
+    expect(result.conflicts).toBe(0);
+  });
+
+  it('conflicts on divergent insertions into an empty base', () => {
+    const result = threeWayMerge('ours\n', '', 'theirs\n', { labels });
+    expect(result.conflicts).toBe(1);
+    expect(result.content).toBe('<<<<<<< ours\nours\n=======\ntheirs\n>>>>>>> theirs\n');
+  });
+
+  it('handles one-line files with divergent single-line edits', () => {
+    const result = threeWayMerge('X\n', 'a\n', 'Y\n', { labels });
+    expect(result.conflicts).toBe(1);
+    expect(result.content).toBe('<<<<<<< ours\nX\n=======\nY\n>>>>>>> theirs\n');
+  });
+
+  it('uses default labels when none are provided', () => {
+    const result = threeWayMerge('X\n', 'a\n', 'Y\n', {});
+    expect(result.content).toContain('<<<<<<< current');
+    expect(result.content).toContain('>>>>>>> other');
+  });
+});

--- a/packages/webapp/tests/git/merge-file.test.ts
+++ b/packages/webapp/tests/git/merge-file.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import 'fake-indexeddb/auto';
+
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { GitCommands } from '../../src/git/git-commands.js';
+
+const BASE = 'line1\nline2\nline3\n';
+
+describe('git merge-file', () => {
+  let vfs: VirtualFS;
+  let git: GitCommands;
+  let dbCounter = 0;
+
+  beforeEach(async () => {
+    const testId = dbCounter++;
+    vfs = await VirtualFS.create({ dbName: `merge-file-test-${testId}`, wipe: true });
+    git = new GitCommands({
+      fs: vfs,
+      authorName: 'Test User',
+      authorEmail: 'test@example.com',
+      globalDbName: `merge-file-global-${testId}`,
+    });
+  });
+
+  async function seed(current: string, base = BASE, other = BASE) {
+    await vfs.writeFile('/cur', current);
+    await vfs.writeFile('/base', base);
+    await vfs.writeFile('/other', other);
+  }
+
+  it('auto-merges disjoint changes and overwrites <current> (exit 0)', async () => {
+    await seed('CUR1\nline2\nline3\n', BASE, 'line1\nline2\nOTH3\n');
+    const res = await git.execute(['merge-file', '/cur', '/base', '/other'], '/');
+    expect(res.exitCode).toBe(0);
+    expect(res.stderr).toBe('');
+    expect(await vfs.readTextFile('/cur')).toBe('CUR1\nline2\nOTH3\n');
+  });
+
+  it('produces conflict markers and exits with the conflict count', async () => {
+    await seed('line1\nOURS2\nline3\n', BASE, 'line1\nTHEIRS2\nline3\n');
+    const res = await git.execute(['merge-file', '/cur', '/base', '/other'], '/');
+    expect(res.exitCode).toBe(1);
+    const merged = await vfs.readTextFile('/cur');
+    expect(merged).toContain('<<<<<<< /cur');
+    expect(merged).toContain('=======');
+    expect(merged).toContain('>>>>>>> /other');
+    expect(merged).toContain('OURS2');
+    expect(merged).toContain('THEIRS2');
+    expect(res.stderr).toContain('warning');
+  });
+
+  it('--stdout prints the result and leaves <current> untouched', async () => {
+    await seed('CUR1\nline2\nline3\n', BASE, 'line1\nline2\nOTH3\n');
+    const res = await git.execute(['merge-file', '--stdout', '/cur', '/base', '/other'], '/');
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toBe('CUR1\nline2\nOTH3\n');
+    expect(await vfs.readTextFile('/cur')).toBe('CUR1\nline2\nline3\n');
+  });
+
+  it('-p is an alias for --stdout', async () => {
+    await seed('CUR1\nline2\nline3\n', BASE, 'line1\nline2\nOTH3\n');
+    const res = await git.execute(['merge-file', '-p', '/cur', '/base', '/other'], '/');
+    expect(res.stdout).toBe('CUR1\nline2\nOTH3\n');
+    expect(await vfs.readTextFile('/cur')).toBe('CUR1\nline2\nline3\n');
+  });
+
+  it('-q / --quiet suppresses the conflict warning', async () => {
+    await seed('line1\nOURS2\nline3\n', BASE, 'line1\nTHEIRS2\nline3\n');
+    const res = await git.execute(['merge-file', '-q', '/cur', '/base', '/other'], '/');
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toBe('');
+  });
+
+  it('-L relabels the conflict markers (up to 3)', async () => {
+    await seed('line1\nOURS2\nline3\n', BASE, 'line1\nTHEIRS2\nline3\n');
+    const res = await git.execute(
+      [
+        'merge-file',
+        '-p',
+        '-L',
+        'MINE',
+        '-L',
+        'ANCESTOR',
+        '-L',
+        'YOURS',
+        '/cur',
+        '/base',
+        '/other',
+      ],
+      '/'
+    );
+    expect(res.stdout).toContain('<<<<<<< MINE');
+    expect(res.stdout).toContain('>>>>>>> YOURS');
+  });
+
+  it('--diff3 includes the base section', async () => {
+    await seed('line1\nOURS2\nline3\n', BASE, 'line1\nTHEIRS2\nline3\n');
+    const res = await git.execute(['merge-file', '-p', '--diff3', '/cur', '/base', '/other'], '/');
+    expect(res.stdout).toContain('||||||| /base');
+    expect(res.stdout).toContain('line2');
+  });
+
+  it('--ours / --theirs / --union resolve without markers', async () => {
+    const other = 'line1\nTHEIRS2\nline3\n';
+    const ours = 'line1\nOURS2\nline3\n';
+
+    await seed(ours, BASE, other);
+    let res = await git.execute(['merge-file', '-p', '--ours', '/cur', '/base', '/other'], '/');
+    expect(res.stdout).toBe(ours);
+    expect(res.stdout).not.toContain('<<<<<<<');
+
+    await seed(ours, BASE, other);
+    res = await git.execute(['merge-file', '-p', '--theirs', '/cur', '/base', '/other'], '/');
+    expect(res.stdout).toBe(other);
+
+    await seed(ours, BASE, other);
+    res = await git.execute(['merge-file', '-p', '--union', '/cur', '/base', '/other'], '/');
+    expect(res.stdout).toContain('OURS2');
+    expect(res.stdout).toContain('THEIRS2');
+    expect(res.stdout).not.toContain('<<<<<<<');
+  });
+
+  it('errors with usage on wrong positional count (exit 255)', async () => {
+    await seed(BASE);
+    const res = await git.execute(['merge-file', '/cur', '/base'], '/');
+    expect(res.exitCode).toBe(255);
+    expect(res.stderr).toContain('usage:');
+  });
+
+  it('errors (exit 255) when a file is unreadable', async () => {
+    await seed(BASE);
+    const res = await git.execute(['merge-file', '/cur', '/base', '/missing'], '/');
+    expect(res.exitCode).toBe(255);
+    expect(res.stderr).toContain('error:');
+  });
+
+  it('errors (exit 255) with more than 3 -L labels', async () => {
+    await seed(BASE);
+    const res = await git.execute(
+      ['merge-file', '-L', 'a', '-L', 'b', '-L', 'c', '-L', 'd', '/cur', '/base', '/other'],
+      '/'
+    );
+    expect(res.exitCode).toBe(255);
+    expect(res.stderr).toContain('too many labels');
+  });
+
+  it('git merge-file --help short-circuits without touching files', async () => {
+    const res = await git.execute(['merge-file', '--help'], '/');
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain('merge-file');
+  });
+});

--- a/packages/webapp/tests/git/merge-file.test.ts
+++ b/packages/webapp/tests/git/merge-file.test.ts
@@ -120,6 +120,20 @@ describe('git merge-file', () => {
     expect(res.stdout).not.toContain('<<<<<<<');
   });
 
+  it('--ours / --theirs / --union exit 0 on conflicting input (all resolved)', async () => {
+    // Same input the plain merge reports as a conflict (exit 1) above.
+    const other = 'line1\nTHEIRS2\nline3\n';
+    const ours = 'line1\nOURS2\nline3\n';
+
+    for (const favor of ['--ours', '--theirs', '--union'] as const) {
+      await seed(ours, BASE, other);
+      const res = await git.execute(['merge-file', favor, '/cur', '/base', '/other'], '/');
+      expect(res.exitCode).toBe(0);
+      expect(res.stderr).toBe('');
+      expect(await vfs.readTextFile('/cur')).not.toContain('<<<<<<<');
+    }
+  });
+
   it('errors with usage on wrong positional count (exit 255)', async () => {
     await seed(BASE);
     const res = await git.execute(['merge-file', '/cur', '/base'], '/');


### PR DESCRIPTION
## Summary

Adds a `merge-file` subcommand to the git supplemental command, matching real git's three-way file merge behavior. The `upgrade` skill already documented `git merge-file --stdout ...` but the command wasn't implemented — this closes that gap.

## What's included

- **Core** (`packages/webapp/src/git/merge-file-core.ts`): a pure, dependency-free `threeWayMerge()` returning merged content + conflict count, built on the existing Myers diff (`diff.ts`, additively exported — no public behavior change).
- **Command** (`packages/webapp/src/git/commands/merge-file.ts`): flag parsing + VFS I/O, wired into the dispatch switch, `help()`, and `GIT_FLAG_SPECS`.

## Flags

- `-p` / `--stdout` — write merged result to stdout, leave the file untouched
- `-q` / `--quiet` — suppress conflict stderr warning
- `-L` — labels (1-3, default to file paths)
- `--diff3` — include the `|||||||` base section in conflict markers
- `--ours` / `--theirs` / `--union` — marker-free conflict resolution

## Exit codes

- Conflict count (capped at 127) on success with conflicts
- `0` on a clean merge
- `255` on bad args / unreadable file (no throws)

## Tests & verification

- 16 core unit tests + 12 command-level tests
- lint clean, typecheck 9/9, 274 git tests pass, webapp coverage floor + build green
- Two verification rounds (per-wave + final end-to-end), both approved at high confidence
- The `upgrade` skill's existing `git merge-file --stdout` example now works as documented (exit 0 clean / non-zero + `<<<<<<<` markers on conflict) — no docs change needed

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author