### PR TITLE
chore(renovate): fast-track pi and just-bash with 3-day cooldown groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,10 +22,6 @@
       "groupSlug": "non-major"
     },
     {
-      "matchPackagePrefixes": ["@earendil-works/"],
-      "groupName": "earendil-works packages"
-    },
-    {
       "matchPackagePrefixes": ["@semantic-release/"],
       "groupName": "semantic-release packages"
     },
@@ -49,6 +45,18 @@
       "groupSlug": "patched-deps",
       "addLabels": ["patched-dependency"],
       "automerge": false
+    },
+    {
+      "description": "pi (Earendil) agent engine packages: fast-track with a shorter 3-day cooldown. Placed after the 14-day major rule so even major bumps get 3 days.",
+      "matchPackagePrefixes": ["@earendil-works/"],
+      "groupName": "earendil-works packages",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "just-bash: fast-track with a shorter 3-day cooldown. Placed after the 14-day major rule so even major bumps get 3 days.",
+      "matchPackageNames": ["just-bash"],
+      "groupName": "just-bash",
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
## What

Split the renovate config so the **pi agent-engine packages** (`@earendil-works/*`) and **just-bash** are each their own group with a shorter **3-day** stability window, instead of inheriting the global 7-day (and 14-day-major) cooldown.

## Why

pi and just-bash are the fast-moving core of the agent runtime; a 3-day cooldown lets us pick up their releases sooner while keeping the conservative cooldown for everything else.

## Changes (`renovate.json`)

- `@earendil-works/` (pi): kept as its own group, added `"minimumReleaseAge": "3 days"`.
- `just-bash`: new dedicated group `"just-bash"` with `"minimumReleaseAge": "3 days"`.
- Both rules are placed **after** the 14-day major-cooldown rule so later-rule-wins ordering applies — minor, patch, **and** major bumps for these packages all resolve to 3 days, and just-bash no longer lands in the generic "non-major dependencies" group.

## Unchanged

Global 7-day cooldown, the 14-day major rule for all other packages, patched-deps (`@zenfs/core`), and the pyodide pin.

## Verification

`renovate-config-validator renovate.json` -> Config validated successfully (exit 0).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author