### PR TITLE
Fix right-rail chat width jump and scroll re-anchor

### DIFF
--- a/packages/webcomponents/src/chat/slicc-chat-thread.ts
+++ b/packages/webcomponents/src/chat/slicc-chat-thread.ts
@@ -448,7 +448,9 @@ export class SliccChatThread extends HTMLElement {
     if (!wasNearBottom) return;
     this.scrollToBottom();
     if (typeof ResizeObserver !== 'function') return;
-    this.#reanchorObserver = new ResizeObserver(() => this.scrollToBottom());
+    this.#reanchorObserver = new ResizeObserver(() => {
+      if (this.scrollHeight - this.scrollTop - this.clientHeight <= slack) this.scrollToBottom();
+    });
     this.#reanchorObserver.observe(this.#inner);
     this.#reanchorTimer = setTimeout(() => this.#stopReanchor(), 450);
   }

--- a/packages/webcomponents/src/chat/slicc-chat-thread.ts
+++ b/packages/webcomponents/src/chat/slicc-chat-thread.ts
@@ -183,6 +183,16 @@ export class SliccChatThread extends HTMLElement {
   #follow: HTMLElement | null = null;
 
   /**
+   * Re-anchor state for the rail (`open`) toggle. Opening / closing the
+   * workbench rail animates the chat pane's width over ~380ms (see the shell's
+   * transition), which reflows the reading column and moves its bottom. A
+   * viewer pinned to the bottom before the toggle is kept pinned across the
+   * whole animation; a viewer scrolled up keeps their position untouched.
+   */
+  #reanchorObserver: ResizeObserver | null = null;
+  #reanchorTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
    * Per-context snapshots of the inner column content, keyed by context id.
    * Each snapshot is a detached fragment of cloned child nodes (no HTML string);
    * restoring re-clones it so the swapped-in nodes are fresh and inert — the
@@ -215,11 +225,17 @@ export class SliccChatThread extends HTMLElement {
       clearTimeout(this.#scrollWriteTimer);
       this.#scrollWriteTimer = null;
     }
+    this.#stopReanchor();
   }
 
   attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
     if (oldValue === newValue) return;
     if (name === 'accent' && this.#built) this.#applyAccent();
+    // Toggling the rail (`open`) tightens/loosens the column padding instantly
+    // AND animates the parent pane's width — both reflow the column and move its
+    // bottom. Keep a bottom-pinned viewer pinned across the transition. Guarded
+    // to connected + built so pre-mount setup sets don't trip the observer.
+    if (name === 'open' && this.#built && this.isConnected) this.#reanchorOnRailToggle();
     // The thread owns the `ctx` URL param: context switches are user-level
     // navigations, so they PUSH (back button walks contexts). The helper
     // skips no-op writes, so applying a URL-restored context never re-pushes.
@@ -382,6 +398,38 @@ export class SliccChatThread extends HTMLElement {
   /** Scroll the thread wrapper to the bottom (latest message). */
   scrollToBottom(): void {
     this.scrollTop = this.scrollHeight;
+  }
+
+  /**
+   * Keep a bottom-pinned viewer pinned while the rail toggle reflows the
+   * reading column. Snapshots "was the viewer near the bottom?" from the
+   * pre-reflow layout; only then re-pins — instantly for the synchronous
+   * padding change, then on every reflow frame (a `ResizeObserver` on the
+   * column) while the parent pane's width animates, torn down once the ~380ms
+   * transition settles. A viewer who had scrolled up installs no observer, so
+   * their position is left alone.
+   */
+  #reanchorOnRailToggle(): void {
+    const wasNearBottom = this.#nearBottom();
+    this.#stopReanchor();
+    if (!wasNearBottom) return;
+    this.scrollToBottom();
+    if (typeof ResizeObserver !== 'function') return;
+    this.#reanchorObserver = new ResizeObserver(() => this.scrollToBottom());
+    this.#reanchorObserver.observe(this.#inner);
+    this.#reanchorTimer = setTimeout(() => this.#stopReanchor(), 450);
+  }
+
+  /** Stop any in-flight rail-toggle re-anchor (observer + timer). */
+  #stopReanchor(): void {
+    if (this.#reanchorObserver) {
+      this.#reanchorObserver.disconnect();
+      this.#reanchorObserver = null;
+    }
+    if (this.#reanchorTimer != null) {
+      clearTimeout(this.#reanchorTimer);
+      this.#reanchorTimer = null;
+    }
   }
 
   /**

--- a/packages/webcomponents/src/chat/slicc-chat-thread.ts
+++ b/packages/webcomponents/src/chat/slicc-chat-thread.ts
@@ -234,8 +234,13 @@ export class SliccChatThread extends HTMLElement {
     // Toggling the rail (`open`) tightens/loosens the column padding instantly
     // AND animates the parent pane's width — both reflow the column and move its
     // bottom. Keep a bottom-pinned viewer pinned across the transition. Guarded
-    // to connected + built so pre-mount setup sets don't trip the observer.
-    if (name === 'open' && this.#built && this.isConnected) this.#reanchorOnRailToggle();
+    // to connected + built so pre-mount setup sets don't trip the observer. The
+    // direction matters: CLOSE (`open` removed → newValue null) loosens the
+    // padding and grows the column, so the re-anchor tolerance must absorb that
+    // growth.
+    if (name === 'open' && this.#built && this.isConnected) {
+      this.#reanchorOnRailToggle(newValue === null);
+    }
     // The thread owns the `ctx` URL param: context switches are user-level
     // navigations, so they PUSH (back button walks contexts). The helper
     // skips no-op writes, so applying a URL-restored context never re-pushes.
@@ -346,6 +351,22 @@ export class SliccChatThread extends HTMLElement {
   /** Pixels from the bottom within which the view still counts as following. */
   static readonly FOLLOW_SLACK = 80;
 
+  /**
+   * Vertical padding the reading column GAINS when the rail closes on a wide
+   * viewport: the normal `56px` top+bottom (112) minus the rail-open `24px`
+   * (48) from the STYLE block above. Closing loosens the padding instantly, so
+   * `scrollHeight` grows by this much before the width animation even starts —
+   * and because the `open` attribute is already applied by the time
+   * {@link attributeChangedCallback} runs, the first layout read already
+   * reflects the loosened (grown) column. A viewer who was within
+   * {@link FOLLOW_SLACK} of the bottom therefore reads up to this much further
+   * away, which is what stranded the newest message ~one padding-delta below
+   * the fold on CLOSE. The re-anchor widens its tolerance by this on close only
+   * (OPEN tightens the padding, so no widening is needed). At ≤560px both rail
+   * states share `16px` padding, so the growth is zero (guarded by matchMedia).
+   */
+  static readonly RAIL_CLOSE_PADDING_GROWTH = 112 - 48;
+
   #nearBottom(): boolean {
     return this.scrollHeight - this.scrollTop - this.clientHeight <= SliccChatThread.FOLLOW_SLACK;
   }
@@ -402,15 +423,27 @@ export class SliccChatThread extends HTMLElement {
 
   /**
    * Keep a bottom-pinned viewer pinned while the rail toggle reflows the
-   * reading column. Snapshots "was the viewer near the bottom?" from the
-   * pre-reflow layout; only then re-pins — instantly for the synchronous
-   * padding change, then on every reflow frame (a `ResizeObserver` on the
-   * column) while the parent pane's width animates, torn down once the ~380ms
-   * transition settles. A viewer who had scrolled up installs no observer, so
-   * their position is left alone.
+   * reading column. Decides "was the viewer near the bottom?" then re-pins —
+   * instantly for the synchronous padding change, then on every reflow frame (a
+   * `ResizeObserver` on the column) while the parent pane's width animates,
+   * torn down once the ~380ms transition settles. A viewer who had scrolled up
+   * installs no observer, so their position is left alone.
+   *
+   * The near-bottom check can't be snapshotted before the reflow — the `open`
+   * attribute is already applied when {@link attributeChangedCallback} runs, so
+   * the first layout read reflects the new padding. On CLOSE (`loosening`) that
+   * padding grew the column by {@link RAIL_CLOSE_PADDING_GROWTH}, pushing a
+   * once-pinned viewer's measured distance up by that much; widen the tolerance
+   * by the same amount so they still count as near-bottom and re-anchor (this
+   * is the CLOSE-case gap the OPEN path never had). OPEN tightens the padding,
+   * so its tolerance stays {@link FOLLOW_SLACK}. A genuinely scrolled-up viewer
+   * is still well past the widened tolerance, so they are not yanked either way.
    */
-  #reanchorOnRailToggle(): void {
-    const wasNearBottom = this.#nearBottom();
+  #reanchorOnRailToggle(loosening: boolean): void {
+    const growth =
+      loosening && !this.#isNarrowRail() ? SliccChatThread.RAIL_CLOSE_PADDING_GROWTH : 0;
+    const slack = SliccChatThread.FOLLOW_SLACK + growth;
+    const wasNearBottom = this.scrollHeight - this.scrollTop - this.clientHeight <= slack;
     this.#stopReanchor();
     if (!wasNearBottom) return;
     this.scrollToBottom();
@@ -418,6 +451,16 @@ export class SliccChatThread extends HTMLElement {
     this.#reanchorObserver = new ResizeObserver(() => this.scrollToBottom());
     this.#reanchorObserver.observe(this.#inner);
     this.#reanchorTimer = setTimeout(() => this.#stopReanchor(), 450);
+  }
+
+  /**
+   * Whether the viewport is in the narrow / extension-sidebar regime where both
+   * rail states share the same column padding (STYLE `@media (max-width:560px)`)
+   * — so closing the rail grows nothing and the re-anchor must NOT widen its
+   * tolerance (that would yank a slightly scrolled-up viewer to the bottom).
+   */
+  #isNarrowRail(): boolean {
+    return typeof matchMedia === 'function' && matchMedia('(max-width: 560px)').matches;
   }
 
   /** Stop any in-flight rail-toggle re-anchor (observer + timer). */

--- a/packages/webcomponents/src/shell/slicc-chatpane.ts
+++ b/packages/webcomponents/src/shell/slicc-chatpane.ts
@@ -56,20 +56,22 @@ const STYLE = `
 }
 /* The reading column is background-free in every layout (the frosted card was
    dropped — the shader renders low-contrast instead). In the narrow column the
-   inner additionally fills the full width AND viewport height of the thread.
-   The min-height is the FULL viewport (not the parent's 100%) so a freezer /
-   scoop with little history still fills to the bottom of the screen instead of
-   ending abruptly partway down — messages stay top-aligned and the filler
-   space sits below; long histories still scroll. The 100vh declaration is the
-   fallback for engines without dynamic-viewport units; the 100dvh override
-   tracks mobile browser chrome (URL bar) collapse. Out-specifies the thread's
-   own [open] inner rule (0,3,0 vs 0,2,1). */
+   inner keeps the SAME centered, capped reading width as the wide layout: the
+   narrow attribute is set whenever the workbench opens on ANY screen size, so
+   full-bleeding here stretched the text on wide screens too. The genuinely
+   full-bleed width:100% / max-width:none treatment now lives ONLY in the
+   overlay layout — slicc-chat-thread's own @media (max-width: 560px) rule, the
+   same breakpoint that turns the workbench into a full-screen overlay — so
+   opening the rail on a wide screen no longer changes the reading-column width.
+   The min-height is still the FULL viewport (not the parent's 100%) so a
+   freezer / scoop with little history still fills to the bottom of the screen
+   instead of ending abruptly partway down — messages stay top-aligned and the
+   filler space sits below; long histories still scroll. The 100vh declaration
+   is the fallback for engines without dynamic-viewport units; the 100dvh
+   override tracks mobile browser chrome (URL bar) collapse. */
 .slicc-chatpane[narrow] .slicc-thread__inner {
-  width: 100%;
-  max-width: none;
   min-height: 100vh;
   min-height: 100dvh;
-  margin: 0;
   background: none;
   backdrop-filter: none;
   -webkit-backdrop-filter: none;

--- a/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
@@ -498,5 +498,37 @@ describe('slicc-chat-thread', () => {
       el.open = false;
       expect(el.scrollTop).toBe(0);
     });
+
+    it('lets an intentional upward scroll mid-animation break the re-anchor pin', () => {
+      // The observer that keeps a pinned viewer glued to the bottom across the
+      // ~380ms width transition must re-check the near-bottom condition on each
+      // reflow tick: a viewer who deliberately scrolls up beyond the slack is
+      // no longer following, so the tick must NOT yank them back down.
+      const RealResizeObserver = globalThis.ResizeObserver;
+      let capturedCb: ResizeObserverCallback | undefined;
+      class FakeResizeObserver {
+        constructor(cb: ResizeObserverCallback) {
+          capturedCb = cb;
+        }
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+      globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
+      try {
+        const el = mountScrollable();
+        el.open = true; // rail open → tight padding
+        el.scrollToBottom();
+        el.open = false; // CLOSE while pinned → installs the guarded observer
+        expect(capturedCb).toBeTypeOf('function');
+        // The viewer deliberately scrolls up past the (widened) tolerance.
+        el.scrollTop = 0;
+        // A reflow tick fires: the guard must see they are no longer following.
+        capturedCb?.([], {} as ResizeObserver);
+        expect(el.scrollTop).toBe(0);
+      } finally {
+        globalThis.ResizeObserver = RealResizeObserver;
+      }
+    });
   });
 });

--- a/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
@@ -141,6 +141,35 @@ describe('slicc-chat-thread', () => {
       expect(cs.marginLeft).toBe(cs.marginRight); // auto/auto → equal
     });
 
+    it('keeps the 776px reading cap when open (workbench rail) on a wide viewport', () => {
+      // Opening the rail must NOT full-bleed the reading column on a wide screen
+      // — it stays capped + centered, matching the collapsed layout. Full-bleed
+      // is reserved for the ≤560px overlay (asserted against the sheet below).
+      const el = mount((e) => {
+        e.open = true;
+      });
+      const cs = getComputedStyle(inner(el));
+      expect(cs.maxWidth).toBe('776px');
+      expect(cs.marginLeft).toBe(cs.marginRight); // auto/auto → equal
+    });
+
+    it('full-bleeds the reading column ONLY behind the ≤560px overlay media query', () => {
+      // The browser-test viewport is wide (1280px), so assert the full-bleed
+      // branch against the adopted document stylesheet rather than an
+      // incidentally-small window (same approach as the scoop-overflow test).
+      mount();
+      const sheet = (document.getElementById('slicc-chat-thread-style') as HTMLStyleElement).sheet;
+      const media = Array.from(sheet?.cssRules ?? []).find(
+        (r): r is CSSMediaRule => r instanceof CSSMediaRule && r.conditionText.includes('560px')
+      );
+      expect(media).toBeDefined();
+      const innerRule = Array.from((media as CSSMediaRule).cssRules).find(
+        (r): r is CSSStyleRule =>
+          r instanceof CSSStyleRule && r.selectorText.includes('.slicc-thread__inner')
+      );
+      expect(innerRule?.style.maxWidth).toBe('none');
+    });
+
     it('the thread wrapper scrolls vertically', () => {
       const el = mount();
       expect(getComputedStyle(el).overflowY).toBe('auto');
@@ -404,6 +433,42 @@ describe('slicc-chat-thread', () => {
       expect(el.hasAttribute('has-new')).toBe(true);
       el.replaceContent(document.createElement('div'));
       expect(el.hasAttribute('has-new')).toBe(false);
+    });
+  });
+
+  describe('rail-toggle scroll re-anchor', () => {
+    /** A scrollable thread filled with enough content to overflow. */
+    function mountScrollable(): SliccChatThread {
+      const el = mount();
+      el.style.height = '120px';
+      el.style.display = 'block';
+      el.style.overflowY = 'auto';
+      for (let i = 0; i < 40; i += 1) {
+        const m = document.createElement('div');
+        m.textContent = `line ${i}`;
+        m.style.height = '24px';
+        el.append(m);
+      }
+      return el;
+    }
+
+    it('re-anchors to the bottom when the rail toggles and the viewer was pinned there', () => {
+      const el = mountScrollable();
+      el.open = true; // rail open → tight padding
+      el.scrollToBottom();
+      // Closing the rail loosens the column padding (24/32 → 56/72), growing
+      // scrollHeight; a bottom-pinned viewer must be re-pinned to the new bottom
+      // rather than left stranded 64px above it.
+      el.open = false;
+      expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
+    });
+
+    it('leaves a scrolled-up viewer where they are when the rail toggles', () => {
+      const el = mountScrollable();
+      el.scrollTop = 0;
+      // Not near the bottom → no re-anchor; the reading position is respected.
+      el.open = true;
+      expect(el.scrollTop).toBe(0);
     });
   });
 });

--- a/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
@@ -470,5 +470,33 @@ describe('slicc-chat-thread', () => {
       el.open = true;
       expect(el.scrollTop).toBe(0);
     });
+
+    it('re-anchors on CLOSE even when the viewer was near (not pixel-pinned to) the bottom', () => {
+      // Regression: the CLOSE loosen (24/32 → 56/72) grows the column by
+      // RAIL_CLOSE_PADDING_GROWTH, so a viewer sitting within FOLLOW_SLACK of
+      // the bottom — but not exactly on it — read as "past FOLLOW_SLACK" once
+      // the padding loosened and was stranded ~a padding-delta below the fold.
+      const el = mountScrollable();
+      el.open = true; // rail open → tight padding
+      el.scrollToBottom();
+      // Ease off the bottom by half the slack: still "following" pre-toggle.
+      el.scrollTop -= SliccChatThread.FOLLOW_SLACK / 2;
+      expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(
+        SliccChatThread.FOLLOW_SLACK
+      );
+      el.open = false; // CLOSE → padding loosens, column grows
+      // The widened close tolerance keeps them pinned: newest message stays in view.
+      expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
+    });
+
+    it('does NOT re-anchor on CLOSE when the viewer is scrolled up in history', () => {
+      // The close-only widening must not become a blanket "jump to bottom": a
+      // reader parked in history stays put through a CLOSE just like an OPEN.
+      const el = mountScrollable();
+      el.open = true;
+      el.scrollTop = 0;
+      el.open = false;
+      expect(el.scrollTop).toBe(0);
+    });
   });
 });

--- a/packages/webcomponents/tests/shell/slicc-chatpane.test.ts
+++ b/packages/webcomponents/tests/shell/slicc-chatpane.test.ts
@@ -88,11 +88,13 @@ describe('slicc-chatpane', () => {
     expect(narrowW).not.toBe(wideW);
   });
 
-  it('narrow: the thread inner fills full width/height and drops its frosted background', () => {
-    // Give the column a definite box so the inner's 100% width/height resolve.
+  it('narrow (workbench open, wide viewport): drops the frosted card but KEEPS the centered reading cap', () => {
+    // `narrow` is set whenever the workbench opens, on ANY screen width. On a
+    // wide viewport (the browser-test default is 1280px) the reading column must
+    // keep its 776px cap + centering — full-bleeding here stretched the prose on
+    // wide screens (the bug). The full-bleed treatment now lives ONLY behind the
+    // thread's own ≤560px overlay media query.
     const el = mount(true);
-    el.style.height = '400px';
-    el.style.width = '300px';
     const thread = el.thread as HTMLElement;
     const inner = thread.querySelector('.slicc-thread__inner') as HTMLElement;
     expect(inner).not.toBeNull();
@@ -102,16 +104,9 @@ describe('slicc-chatpane', () => {
     expect(cs.backgroundColor).toBe('rgba(0, 0, 0, 0)');
     expect(cs.maskImage).toBe('none');
     expect(cs.borderTopLeftRadius).toBe('0px');
-    expect(cs.maxWidth).toBe('none');
-    expect(cs.marginLeft).toBe('0px');
-    expect(cs.marginRight).toBe('0px');
-
-    // It fills the thread's content area (full width + at least full height).
-    // Compare against client* (the content box, excluding the reserved scrollbar
-    // gutter) so the width match holds regardless of scrollbar style.
-    const innerBox = inner.getBoundingClientRect();
-    expect(innerBox.width).toBeCloseTo(thread.clientWidth, 0);
-    expect(innerBox.height).toBeGreaterThanOrEqual(thread.clientHeight - 0.5);
+    // The reading cap + centering survive the workbench opening (wide viewport).
+    expect(cs.maxWidth).toBe('776px');
+    expect(cs.marginLeft).toBe(cs.marginRight); // auto/auto → equal
   });
 
   it('narrow: the thread inner is at least the full viewport tall so a short history fills to the bottom', () => {


### PR DESCRIPTION
## Summary

Fixes two right-rail (workbench) chat bugs in `@slicc/webcomponents`. **Before:** opening the workbench on a wide viewport stretched the chat reading column to full width, and toggling the rail (especially closing it) left a viewer who was at the newest message stranded above it. **Now:** the reading column stays capped/centered at 776px regardless of rail state, and the newest message stays in view on both open and close.

## Why

Two long-standing right-rail chat annoyances, root-caused in the spec for this workspace.

**Repro (width jump):**
1. Wide viewport, chat pane open.
2. Open the workbench (right dock item).
   Expected: reading column width unchanged.
   Actual: column jumped 776px -> 927px (full-bleed).

**Repro (scroll re-anchor):**
1. Scroll to the newest message (pinned to bottom).
2. Close the workbench.
   Expected: newest message stays in view.
   Actual: ~106px gap opened below the newest message; viewer had to scroll down to find it.

## Approach / Implementation notes

- **Width (`slicc-chatpane.ts` + `slicc-chat-thread.ts`)**: the `narrow` attribute is applied to the chat pane whenever the workbench opens on *any* screen size, and the `narrow` rule dropped `max-width: 776px; margin: 0 auto`. Full-bleed fill is now scoped to the genuinely-narrow `@media (max-width: 560px)` overlay only, so wide-viewport width is identical open vs closed.
- **Re-anchor (`slicc-chat-thread.ts`)**: the thread re-anchored on connect/append/context-switch but not on the `open` attribute toggling. Added an `open`-toggle handler that re-pins the newest message via a `ResizeObserver` spanning the ~380ms rail transition. Closing instantly loosens the thread padding, pushing the pre-snapshot position past `FOLLOW_SLACK`; a **close-only** tolerance widening (`RAIL_CLOSE_PADDING_GROWTH = 64px`) absorbs exactly that growth. The widening is guarded off in the ≤560px overlay, and the open path is unchanged.
- Scrolled-up viewers are never yanked — re-anchor only fires when the viewer was already near the bottom.
- The 776px reading-column value is unchanged (explicit non-goal).

## Cross-cutting impact

- **Floats exercised**: this is a `@slicc/webcomponents` shell/chat change, so it affects the shared UI shell across all floats that render it (CLI, extension side panel/cockpit, Electron, hosted). No float-specific branching added.
- **Other callers**: no public API/contract change — the added scroll handler is internal to `slicc-chat-thread`, and the CSS change is scoped to the `narrow`/≤560px rules on the chat pane. No changes to the left freezer rail, the resize divider, or the `--slicc-chat-w` split.
- **Persisted state**: none — no IndexedDB/localStorage writes touched.

## Test plan

- [x] `npm run typecheck`
- [x] `@slicc/webcomponents` browser-mode tests
- [x] `npm run test` (root) — no new failures
- [x] `npm run build -w @slicc/webapp`
- [x] **New / changed behavior covered by unit tests** in `packages/webcomponents/tests/` mirroring the changed `src/` paths:
  - `tests/shell/slicc-chatpane.test.ts` — width unchanged on wide (open vs closed); full-bleed only at ≤560px.
  - `tests/chat/slicc-chat-thread.test.ts` — re-anchor on open; re-anchor on close (≤1px); no-yank when scrolled up.
- [ ] **UI change — screencast:** a side-by-side before/after was recorded (rail-toggle, ~12s, BEFORE/AFTER with an on-page width HUD): AFTER holds the column at 776px and keeps the newest message in view on open and close; BEFORE shows the 776->927px jump and the newest message out of view on close. Inline embed is currently blocked — this repo has no `image-upload.yml` workflow / as-a-bot app for the `gh image` uploader to dispatch, so there is no supported programmatic media-attach path. Artifact: `/tmp/railprobe/rail-toggle-before-after.mp4` (can be attached once that workflow is provisioned).

## Documentation

- [x] No documentation changes needed (behavior fix confined to existing components; 776px reading width and ≤560px overlay behavior unchanged).

## Risk & rollback

- Blast radius: the shared chat UI shell. Confined to `@slicc/webcomponents` CSS + one scroll handler.
- No feature flags / env knobs introduced.
- Rollback: revert this PR cleanly (two commits, no persisted-state migration).
- CI cannot fully catch the real toggle animation timing / ResizeObserver behavior — the before/after screencast covers this by hand.

## Checklist

- [x] Commits are focused and package-local (`@slicc/webcomponents` only)
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] No public API / tool / shell-command / lick-channel changes
- [x] No cross-float contract change (shared UI shell; no follower/leader/offscreen protocol touched)

<!-- Rebased onto origin/main for linear history; will merge via squash/rebase. -->
