### PR TITLE
feat(git): conflict-aware merge, cherry-pick, revert, stash (via threeWayMerge)

### DIFF
--- a/packages/webapp/src/git/commands/cherry-pick.ts
+++ b/packages/webapp/src/git/commands/cherry-pick.ts
@@ -1,0 +1,122 @@
+/**
+ * `git cherry-pick <commit>` — apply the changes of an existing commit onto the
+ * current branch as a new commit, preserving the original author.
+ *
+ * Wraps isomorphic-git's native `cherryPick` with the shared `makeMergeDriver`
+ * so a divergent overlap leaves standard conflict markers in the working tree
+ * and a conflicted index (exit 1) instead of aborting. Merge and root commits
+ * are rejected natively by `cherryPick`; we format those into git-style errors.
+ */
+
+import * as git from 'isomorphic-git';
+import { parseArgs } from '../../shell/arg-parser.js';
+import { makeMergeDriver } from './merge-driver.js';
+import { expandGitError, GIT_FLAG_SPECS } from './shared.js';
+import type { GitCommandContext, GitCommandResult } from './types.js';
+
+export async function cherryPick(
+  ctx: GitCommandContext,
+  cwd: string,
+  args: string[]
+): Promise<GitCommandResult> {
+  const { flags, positionals } = parseArgs(args, GIT_FLAG_SPECS['cherry-pick']);
+  const noCommit = flags['no-commit'] === true;
+  const appendOrigin = flags.x === true;
+  const ref = positionals[0];
+
+  if (!ref) {
+    return { stdout: '', stderr: 'error: empty commit set passed\n', exitCode: 128 };
+  }
+
+  // Resolve <commit> to a full oid: try refs first, then a short/full oid.
+  let oid: string;
+  try {
+    oid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref });
+  } catch {
+    try {
+      oid = await git.expandOid({ fs: ctx.lfs, dir: cwd, oid: ref });
+    } catch {
+      return { stdout: '', stderr: `fatal: bad revision '${ref}'\n`, exitCode: 128 };
+    }
+  }
+
+  try {
+    const newOid = await git.cherryPick({
+      fs: ctx.lfs,
+      dir: cwd,
+      oid,
+      abortOnConflict: false,
+      noUpdateBranch: noCommit,
+      committer: await ctx.resolveAuthor(cwd),
+      mergeDriver: makeMergeDriver(),
+    });
+
+    // --no-commit: changes are applied to the tree/index; the branch pointer
+    // is left untouched and no commit output is printed (matches real git).
+    if (noCommit) {
+      return { stdout: '', stderr: '', exitCode: 0 };
+    }
+
+    let headOid = newOid;
+    const { commit } = await git.readCommit({ fs: ctx.lfs, dir: cwd, oid: newOid });
+
+    // `-x`: annotate the message with the source commit (full oid), like git.
+    if (appendOrigin) {
+      const body = commit.message.replace(/\s+$/, '');
+      headOid = await git.commit({
+        fs: ctx.lfs,
+        dir: cwd,
+        message: `${body}\n\n(cherry picked from commit ${oid})\n`,
+        author: commit.author,
+        committer: await ctx.resolveAuthor(cwd),
+        amend: true,
+      });
+    }
+
+    const branch = await git.currentBranch({ fs: ctx.lfs, dir: cwd });
+    const subject = commit.message.split('\n')[0];
+    return {
+      stdout: `[${branch ?? 'HEAD'} ${headOid.slice(0, 7)}] ${subject}\n`,
+      stderr: '',
+      exitCode: 0,
+    };
+  } catch (err: unknown) {
+    return handleCherryPickError(err, oid);
+  }
+}
+
+/** Format cherry-pick failures into git-style CLI output. */
+function handleCherryPickError(err: unknown, oid: string): GitCommandResult {
+  const short = oid.slice(0, 7);
+
+  if (err instanceof Error && err.name === 'MergeConflictError') {
+    const data = (err as Error & { data?: { filepaths?: string[] } }).data;
+    const files = data?.filepaths ?? [];
+    let output = '';
+    for (const f of files) {
+      output += `CONFLICT (content): Merge conflict in ${f}\n`;
+    }
+    output += `error: could not apply ${short}...\n`;
+    output += "hint: after resolving the conflicts, mark them with 'git add <paths>',\n";
+    output += 'hint: then commit the result.\n';
+    return { stdout: '', stderr: output, exitCode: 1 };
+  }
+
+  if (err instanceof Error && err.name === 'CherryPickMergeCommitError') {
+    return {
+      stdout: '',
+      stderr: `error: commit ${oid} is a merge but no -m option was given.\nfatal: cherry-pick failed\n`,
+      exitCode: 128,
+    };
+  }
+
+  if (err instanceof Error && err.name === 'CherryPickRootCommitError') {
+    return {
+      stdout: '',
+      stderr: `error: ${err.message}\nfatal: cherry-pick failed\n`,
+      exitCode: 128,
+    };
+  }
+
+  return { stdout: '', stderr: `fatal: ${expandGitError(err)}\n`, exitCode: 128 };
+}

--- a/packages/webapp/src/git/commands/merge-driver.ts
+++ b/packages/webapp/src/git/commands/merge-driver.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared isomorphic-git merge driver, backed by the pure `threeWayMerge`.
+ *
+ * isomorphic-git calls a `MergeDriverCallback` for every file both sides
+ * touched. The contract passes `contents[0]=base, [1]=ours, [2]=theirs` and
+ * `branches[1]=ours, [2]=theirs`. We forward those to `threeWayMerge` and report
+ * `cleanMerge=false` (conflict markers written, file staged as conflicted) unless
+ * a `favor` option resolved every hunk. Consumed by `merge` (and future
+ * `cherry-pick`/`rebase`) so history-joining commands share one conflict engine.
+ */
+
+import type { MergeDriverCallback } from 'isomorphic-git';
+import { threeWayMerge } from '../merge-file-core.js';
+
+export interface MakeMergeDriverOptions {
+  /** Resolve every conflict toward one side (or union) instead of emitting markers. */
+  favor?: 'ours' | 'theirs' | 'union';
+  /** Include the `|||||||` base section in conflict markers. */
+  diff3?: boolean;
+  /** Override the marker labels; defaults come from the per-file branch names. */
+  labels?: { current?: string; base?: string; other?: string };
+}
+
+/**
+ * Build a `MergeDriverCallback`. A `favor` option makes every merge clean (no
+ * markers, no conflicted index entry); otherwise a divergent overlap yields
+ * `cleanMerge:false` with conflict markers in the merged text.
+ */
+export function makeMergeDriver(opts: MakeMergeDriverOptions = {}): MergeDriverCallback {
+  const { favor, diff3, labels } = opts;
+  return ({ contents, branches }) => {
+    const [base, ours, theirs] = contents;
+    const result = threeWayMerge(ours ?? '', base ?? '', theirs ?? '', {
+      favor,
+      diff3,
+      labels: {
+        current: labels?.current ?? branches[1] ?? 'ours',
+        base: labels?.base ?? branches[0] ?? 'base',
+        other: labels?.other ?? branches[2] ?? 'theirs',
+      },
+    });
+    // A favor flag resolves every hunk, so the file is clean even though
+    // `threeWayMerge` still counts the divergent regions it collapsed.
+    const cleanMerge = favor !== undefined || result.conflicts === 0;
+    return { cleanMerge, mergedText: result.content };
+  };
+}

--- a/packages/webapp/src/git/commands/merge.ts
+++ b/packages/webapp/src/git/commands/merge.ts
@@ -1,7 +1,16 @@
 /** `git merge` and its error formatter. */
 
 import * as git from 'isomorphic-git';
+import { parseArgs } from '../../shell/arg-parser.js';
+import { makeMergeDriver } from './merge-driver.js';
+import { GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
+
+/** Coerce an mri flag value (string | string[] | undefined) to a string[]. */
+function asStringArray(value: unknown): string[] {
+  if (value === undefined) return [];
+  return (Array.isArray(value) ? value : [value]).map((v) => String(v));
+}
 
 export async function merge(
   ctx: GitCommandContext,
@@ -10,7 +19,8 @@ export async function merge(
 ): Promise<GitCommandResult> {
   const noFf = args.includes('--no-ff');
   const ffOnly = args.includes('--ff-only');
-  const theirs = args.find((a) => !a.startsWith('-'));
+  const parsed = parseArgs(args, GIT_FLAG_SPECS.merge);
+  const theirs = parsed.positionals[0];
 
   if (!theirs) {
     return {
@@ -18,6 +28,14 @@ export async function merge(
       stderr: 'fatal: No branch specified to merge.\n',
       exitCode: 128,
     };
+  }
+
+  // -X/--strategy-option → threeWayMerge favor + diff3 knobs.
+  let favor: 'ours' | 'theirs' | 'union' | undefined;
+  let diff3 = false;
+  for (const opt of asStringArray(parsed.flags['strategy-option'])) {
+    if (opt === 'ours' || opt === 'theirs' || opt === 'union') favor = opt;
+    else if (opt === 'diff3') diff3 = true;
   }
 
   try {
@@ -29,7 +47,8 @@ export async function merge(
       fastForward: !noFf,
       fastForwardOnly: ffOnly,
       author: await ctx.resolveAuthor(cwd),
-      abortOnConflict: true,
+      abortOnConflict: false,
+      mergeDriver: makeMergeDriver({ favor, diff3 }),
     });
 
     if (result.alreadyMerged) {
@@ -51,11 +70,15 @@ export async function merge(
     }
 
     if (result.mergeCommit) {
-      // Merge commit created — checkout the working directory
+      // Merge commit created. isomorphic-git staged the merged blobs into the
+      // index (stage 0) but left the working tree on the pre-merge "ours"
+      // content, so a plain checkout would see the file as locally modified and
+      // skip it. `force` syncs the working tree to the merge result.
       await git.checkout({
         fs: ctx.lfs,
         dir: cwd,
         ref: (await git.currentBranch({ fs: ctx.lfs, dir: cwd })) ?? 'HEAD',
+        force: true,
       });
       return {
         stdout: `Merge made by the 'ort' strategy.\n`,
@@ -73,16 +96,17 @@ export async function merge(
 /** Handle merge errors and return appropriate GitCommandResult, or rethrow. */
 function handleMergeError(err: unknown): GitCommandResult {
   if (err instanceof Error && err.name === 'MergeConflictError') {
+    // abortOnConflict:false already wrote conflict markers + a conflicted index;
+    // report each file the way real git does and exit 1 (a conflicted merge is
+    // an expected outcome, not a fatal 128).
     const data = (err as Error & { data?: { filepaths?: string[] } }).data;
     const files = data?.filepaths ?? [];
-    let output = 'Auto-merging failed. Fix conflicts and then commit the result.\n';
-    if (files.length > 0) {
-      output += 'CONFLICT (content): Merge conflict in:\n';
-      for (const f of files) {
-        output += `  ${f}\n`;
-      }
-    }
-    return { stdout: '', stderr: output, exitCode: 1 };
+    const stdout = files.map((f) => `CONFLICT (content): Merge conflict in ${f}\n`).join('');
+    return {
+      stdout,
+      stderr: 'Automatic merge failed; fix conflicts and then commit the result.\n',
+      exitCode: 1,
+    };
   }
   if (err instanceof Error && err.name === 'MergeNotSupportedError') {
     return {

--- a/packages/webapp/src/git/commands/revert.ts
+++ b/packages/webapp/src/git/commands/revert.ts
@@ -1,0 +1,185 @@
+/**
+ * `git revert <commit>` — apply the inverse of an existing commit onto the
+ * current branch as a new commit.
+ *
+ * isomorphic-git has no `revert`, so this is a manual reverse three-way merge:
+ * for the target commit C (single parent P) and HEAD H, every file in the union
+ * of the three trees is merged with `threeWayMerge(current = H, base = C,
+ * other = P)`. Using C as the merge base and P as "theirs" inverts the commit's
+ * P→C patch, so the result is H with C's changes undone. Clean files are written
+ * to the working tree + index and committed as `Revert "<subject>"` (unless
+ * `-n`); a divergent overlap leaves standard conflict markers and exits 1
+ * without committing. Merge commits are rejected like real git.
+ */
+
+import * as git from 'isomorphic-git';
+import { parseArgs } from '../../shell/arg-parser.js';
+import { threeWayMerge } from '../merge-file-core.js';
+import { expandGitError, GIT_FLAG_SPECS } from './shared.js';
+import type { GitCommandContext, GitCommandResult } from './types.js';
+
+export async function revert(
+  ctx: GitCommandContext,
+  cwd: string,
+  args: string[]
+): Promise<GitCommandResult> {
+  const { flags, positionals } = parseArgs(args, GIT_FLAG_SPECS.revert);
+  const noCommit = flags['no-commit'] === true;
+  const ref = positionals[0];
+
+  if (!ref) {
+    return { stdout: '', stderr: 'error: empty commit set passed\n', exitCode: 128 };
+  }
+
+  let oid: string;
+  try {
+    oid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref });
+  } catch {
+    try {
+      oid = await git.expandOid({ fs: ctx.lfs, dir: cwd, oid: ref });
+    } catch {
+      return { stdout: '', stderr: `fatal: bad revision '${ref}'\n`, exitCode: 128 };
+    }
+  }
+
+  let headOid: string;
+  try {
+    headOid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref: 'HEAD' });
+  } catch {
+    return {
+      stdout: '',
+      stderr: 'fatal: your current branch does not have any commits yet\n',
+      exitCode: 128,
+    };
+  }
+
+  const { commit } = await git.readCommit({ fs: ctx.lfs, dir: cwd, oid });
+  if (commit.parent.length !== 1) {
+    return {
+      stdout: '',
+      stderr: `error: commit ${oid} is a merge but no -m option was given.\nfatal: revert failed\n`,
+      exitCode: 128,
+    };
+  }
+  const parentOid = commit.parent[0];
+  const subject = commit.message.split('\n')[0];
+  const short = oid.slice(0, 7);
+  const branch = (await git.currentBranch({ fs: ctx.lfs, dir: cwd })) ?? 'HEAD';
+
+  try {
+    const conflicts = await applyReverse(ctx, cwd, headOid, oid, parentOid, {
+      current: branch,
+      base: short,
+      other: `parent of ${short} (${subject})`,
+    });
+
+    if (conflicts.length > 0) {
+      let output = '';
+      for (const f of conflicts) output += `CONFLICT (content): Merge conflict in ${f}\n`;
+      output += `error: could not revert ${short}... ${subject}\n`;
+      output += "hint: after resolving the conflicts, mark them with 'git add <paths>',\n";
+      output += 'hint: then commit the result.\n';
+      return { stdout: '', stderr: output, exitCode: 1 };
+    }
+
+    if (noCommit) {
+      return { stdout: '', stderr: '', exitCode: 0 };
+    }
+
+    const author = await ctx.resolveAuthor(cwd);
+    const message = `Revert "${subject}"\n\nThis reverts commit ${oid}.\n`;
+    const newOid = await git.commit({ fs: ctx.lfs, dir: cwd, message, author, committer: author });
+
+    return {
+      stdout: `[${branch} ${newOid.slice(0, 7)}] Revert "${subject}"\n`,
+      stderr: '',
+      exitCode: 0,
+    };
+  } catch (err: unknown) {
+    return { stdout: '', stderr: `fatal: ${expandGitError(err)}\n`, exitCode: 128 };
+  }
+}
+
+/**
+ * Reverse three-way merge every file the target commit touched onto HEAD.
+ * Writes clean results to the working tree + index (removing files the revert
+ * deletes) and returns the list of files left with conflict markers.
+ */
+async function applyReverse(
+  ctx: GitCommandContext,
+  cwd: string,
+  headOid: string,
+  commitOid: string,
+  parentOid: string,
+  labels: { current: string; base: string; other: string }
+): Promise<string[]> {
+  const [hFiles, cFiles, pFiles] = await Promise.all([
+    git.listFiles({ fs: ctx.lfs, dir: cwd, ref: headOid }),
+    git.listFiles({ fs: ctx.lfs, dir: cwd, ref: commitOid }),
+    git.listFiles({ fs: ctx.lfs, dir: cwd, ref: parentOid }),
+  ]);
+  const union = new Set([...hFiles, ...cFiles, ...pFiles]);
+
+  const encoder = new TextEncoder();
+  const conflicts: string[] = [];
+
+  for (const filepath of union) {
+    const c = await readAt(ctx, cwd, commitOid, filepath);
+    const p = await readAt(ctx, cwd, parentOid, filepath);
+    if (c === p) continue; // commit did not touch this file — nothing to revert
+
+    const h = (await readAt(ctx, cwd, headOid, filepath)) ?? '';
+    let mergedText: string;
+    let conflicted = false;
+    if (h === (c ?? '')) {
+      mergedText = p ?? ''; // HEAD matches the committed version — take the parent verbatim
+    } else {
+      const merge = threeWayMerge(h, c ?? '', p ?? '', { labels });
+      mergedText = merge.content;
+      conflicted = merge.conflicts > 0;
+    }
+
+    if (!conflicted && p === undefined && mergedText === '') {
+      // The commit added this file; reverting removes it.
+      await removeFile(ctx, cwd, filepath);
+      continue;
+    }
+
+    // writeFile creates parent directories automatically.
+    await ctx.fs.writeFile(`${cwd}/${filepath}`, encoder.encode(mergedText));
+
+    if (conflicted) conflicts.push(filepath);
+    else await git.add({ fs: ctx.lfs, dir: cwd, filepath });
+  }
+
+  return conflicts;
+}
+
+/** Read a file's blob at a commit as text, or `undefined` when it is absent. */
+async function readAt(
+  ctx: GitCommandContext,
+  cwd: string,
+  oid: string,
+  filepath: string
+): Promise<string | undefined> {
+  try {
+    const { blob } = await git.readBlob({ fs: ctx.lfs, dir: cwd, oid, filepath });
+    return new TextDecoder().decode(blob);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Delete a file from the working tree and stage its removal. */
+async function removeFile(ctx: GitCommandContext, cwd: string, filepath: string): Promise<void> {
+  try {
+    await ctx.fs.rm(`${cwd}/${filepath}`);
+  } catch {
+    /* already gone */
+  }
+  try {
+    await git.remove({ fs: ctx.lfs, dir: cwd, filepath });
+  } catch {
+    /* not in index */
+  }
+}

--- a/packages/webapp/src/git/commands/shared.ts
+++ b/packages/webapp/src/git/commands/shared.ts
@@ -66,6 +66,10 @@ export const GIT_FLAG_SPECS: Record<string, ArgSpec> = {
     string: ['message', 'strategy', 'strategy-option'],
     alias: { m: 'message', s: 'strategy', X: 'strategy-option' },
   },
+  'cherry-pick': {
+    boolean: ['no-commit', 'x'],
+    alias: { n: 'no-commit' },
+  },
   'merge-file': {
     string: ['L'],
     boolean: ['stdout', 'quiet', 'diff3', 'ours', 'theirs', 'union'],

--- a/packages/webapp/src/git/commands/shared.ts
+++ b/packages/webapp/src/git/commands/shared.ts
@@ -70,6 +70,10 @@ export const GIT_FLAG_SPECS: Record<string, ArgSpec> = {
     boolean: ['no-commit', 'x'],
     alias: { n: 'no-commit' },
   },
+  revert: {
+    boolean: ['no-commit'],
+    alias: { n: 'no-commit' },
+  },
   'merge-file': {
     string: ['L'],
     boolean: ['stdout', 'quiet', 'diff3', 'ours', 'theirs', 'union'],

--- a/packages/webapp/src/git/commands/stash.ts
+++ b/packages/webapp/src/git/commands/stash.ts
@@ -4,6 +4,7 @@
  */
 
 import * as git from 'isomorphic-git';
+import { threeWayMerge } from '../merge-file-core.js';
 import { diffCommits } from './diff.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
@@ -24,6 +25,8 @@ export async function stash(
       return stashPush(ctx, cwd, args.slice(1));
     case 'pop':
       return stashPop(ctx, cwd);
+    case 'apply':
+      return stashApply(ctx, cwd);
     case 'list':
       return stashList(ctx, cwd);
     case 'drop':
@@ -238,6 +241,26 @@ async function buildTreeFromEntries(
 }
 
 async function stashPop(ctx: GitCommandContext, cwd: string): Promise<GitCommandResult> {
+  return stashRestore(ctx, cwd, true);
+}
+
+async function stashApply(ctx: GitCommandContext, cwd: string): Promise<GitCommandResult> {
+  return stashRestore(ctx, cwd, false);
+}
+
+/**
+ * Shared restore path for `pop` (drop=true) and `apply` (drop=false). Three-way
+ * merges the stashed tree against the current working tree (base = HEAD blob,
+ * ours = workdir content, theirs = stashed blob) instead of blindly clobbering.
+ * On conflict the markers are written, exit code is 1, and the stash entry is
+ * kept (never dropped, even for `pop`). A clean restore drops the entry when
+ * `drop` is set.
+ */
+async function stashRestore(
+  ctx: GitCommandContext,
+  cwd: string,
+  drop: boolean
+): Promise<GitCommandResult> {
   let stashOid: string;
   try {
     stashOid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref: 'refs/stash' });
@@ -248,7 +271,23 @@ async function stashPop(ctx: GitCommandContext, cwd: string): Promise<GitCommand
   const { commit: stashCommit } = await git.readCommit({ fs: ctx.lfs, dir: cwd, oid: stashOid });
   const headOid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref: 'HEAD' });
 
-  await restoreStashTree(ctx, cwd, stashCommit.tree, headOid);
+  const conflicts = await mergeStashTree(ctx, cwd, stashCommit.tree, headOid);
+
+  if (conflicts.length > 0) {
+    // Real git keeps the stash entry on conflict for both pop and apply.
+    const stdout = conflicts
+      .map((filepath) => `CONFLICT (content): Merge conflict in ${filepath}\n`)
+      .join('');
+    return {
+      stdout,
+      stderr: drop ? 'The stash entry is kept in case you need it again.\n' : '',
+      exitCode: 1,
+    };
+  }
+
+  if (!drop) {
+    return { stdout: '', stderr: '', exitCode: 0 };
+  }
 
   if (stashCommit.parent.length > 1) {
     await git.writeRef({
@@ -269,12 +308,17 @@ async function stashPop(ctx: GitCommandContext, cwd: string): Promise<GitCommand
   };
 }
 
-async function restoreStashTree(
+/**
+ * Restore a stash tree onto the working tree via a per-file three-way merge and
+ * return the list of files that conflicted. Cleanly merged files are staged;
+ * conflicted files keep their markers in the working tree and are left unstaged.
+ */
+async function mergeStashTree(
   ctx: GitCommandContext,
   cwd: string,
   treeOid: string,
   headOid: string
-): Promise<void> {
+): Promise<string[]> {
   const stashFiles = new Map<string, Uint8Array>();
 
   const walkTree = async (oid: string, prefix: string): Promise<void> => {
@@ -299,33 +343,48 @@ async function restoreStashTree(
     /* no HEAD */
   }
 
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const conflicts: string[] = [];
+
   for (const [filepath, blob] of stashFiles) {
+    const theirs = decoder.decode(blob);
+    const base = headFileSet.has(filepath) ? await readHeadText(ctx, cwd, headOid, filepath) : '';
+
+    let ours: string | undefined;
+    try {
+      ours = await ctx.fs.readTextFile(`${cwd}/${filepath}`);
+    } catch {
+      /* no local copy in the working tree */
+    }
+
+    let mergedText: string;
+    let conflicted = false;
+    if (ours === undefined || ours === theirs) {
+      mergedText = theirs;
+    } else {
+      const merge = threeWayMerge(ours, base, theirs, {
+        labels: { current: 'Updated upstream', base: 'stash base', other: 'Stashed changes' },
+      });
+      mergedText = merge.content;
+      conflicted = merge.conflicts > 0;
+    }
+
     const slashIdx = filepath.lastIndexOf('/');
     if (slashIdx !== -1) {
       await ctx.fs.mkdir(`${cwd}/${filepath.slice(0, slashIdx)}`, { recursive: true });
     }
-    await ctx.fs.writeFile(`${cwd}/${filepath}`, blob);
-    // Restore index state: stage files that differ from HEAD
-    const blobText = new TextDecoder().decode(blob);
-    let headText: string | undefined;
-    if (headFileSet.has(filepath)) {
-      try {
-        const { blob: headBlob } = await git.readBlob({
-          fs: ctx.lfs,
-          dir: cwd,
-          oid: headOid,
-          filepath,
-        });
-        headText = new TextDecoder().decode(headBlob);
-      } catch {
-        /* not in HEAD */
-      }
-    }
-    if (headText !== blobText) {
+    await ctx.fs.writeFile(`${cwd}/${filepath}`, encoder.encode(mergedText));
+
+    if (conflicted) {
+      conflicts.push(filepath);
+    } else if (mergedText !== base) {
       await git.add({ fs: ctx.lfs, dir: cwd, filepath });
     }
   }
 
+  // Files tracked in HEAD but absent from the stash tree were deleted in the
+  // working tree when the stash was created; restore that deletion.
   for (const filepath of headFileSet) {
     if (!stashFiles.has(filepath)) {
       try {
@@ -335,6 +394,23 @@ async function restoreStashTree(
       }
       await git.remove({ fs: ctx.lfs, dir: cwd, filepath });
     }
+  }
+
+  return conflicts;
+}
+
+/** Read a file's HEAD blob as text, returning '' when it is not present. */
+async function readHeadText(
+  ctx: GitCommandContext,
+  cwd: string,
+  headOid: string,
+  filepath: string
+): Promise<string> {
+  try {
+    const { blob } = await git.readBlob({ fs: ctx.lfs, dir: cwd, oid: headOid, filepath });
+    return new TextDecoder().decode(blob);
+  } catch {
+    return '';
   }
 }
 

--- a/packages/webapp/src/git/commands/stash.ts
+++ b/packages/webapp/src/git/commands/stash.ts
@@ -250,11 +250,11 @@ async function stashApply(ctx: GitCommandContext, cwd: string): Promise<GitComma
 
 /**
  * Shared restore path for `pop` (drop=true) and `apply` (drop=false). Three-way
- * merges the stashed tree against the current working tree (base = HEAD blob,
- * ours = workdir content, theirs = stashed blob) instead of blindly clobbering.
- * On conflict the markers are written, exit code is 1, and the stash entry is
- * kept (never dropped, even for `pop`). A clean restore drops the entry when
- * `drop` is set.
+ * merges the stashed tree against the current working tree (base = stash base
+ * commit (stashCommit.parent[0]) blob, ours = workdir content, theirs = stashed
+ * blob) instead of blindly clobbering. On conflict the markers are written, exit
+ * code is 1, and the stash entry is kept (never dropped, even for `pop`). A clean
+ * restore drops the entry when `drop` is set.
  */
 async function stashRestore(
   ctx: GitCommandContext,
@@ -270,8 +270,11 @@ async function stashRestore(
 
   const { commit: stashCommit } = await git.readCommit({ fs: ctx.lfs, dir: cwd, oid: stashOid });
   const headOid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref: 'HEAD' });
+  // The merge base is the stash's original base commit, not the current HEAD:
+  // HEAD may have advanced since the stash was created.
+  const baseOid = stashCommit.parent[0] ?? headOid;
 
-  const conflicts = await mergeStashTree(ctx, cwd, stashCommit.tree, headOid);
+  const conflicts = await mergeStashTree(ctx, cwd, stashCommit.tree, baseOid);
 
   if (conflicts.length > 0) {
     // Real git keeps the stash entry on conflict for both pop and apply.
@@ -317,7 +320,7 @@ async function mergeStashTree(
   ctx: GitCommandContext,
   cwd: string,
   treeOid: string,
-  headOid: string
+  baseOid: string
 ): Promise<string[]> {
   const stashFiles = new Map<string, Uint8Array>();
 
@@ -335,12 +338,12 @@ async function mergeStashTree(
   };
   await walkTree(treeOid, '');
 
-  const headFileSet = new Set<string>();
+  const baseFileSet = new Set<string>();
   try {
-    const headFiles = await git.listFiles({ fs: ctx.lfs, dir: cwd, ref: 'HEAD' });
-    for (const f of headFiles) headFileSet.add(f);
+    const baseFiles = await git.listFiles({ fs: ctx.lfs, dir: cwd, ref: baseOid });
+    for (const f of baseFiles) baseFileSet.add(f);
   } catch {
-    /* no HEAD */
+    /* no base */
   }
 
   const decoder = new TextDecoder();
@@ -349,7 +352,7 @@ async function mergeStashTree(
 
   for (const [filepath, blob] of stashFiles) {
     const theirs = decoder.decode(blob);
-    const base = headFileSet.has(filepath) ? await readHeadText(ctx, cwd, headOid, filepath) : '';
+    const base = baseFileSet.has(filepath) ? await readBaseText(ctx, cwd, baseOid, filepath) : '';
 
     let ours: string | undefined;
     try {
@@ -383,9 +386,9 @@ async function mergeStashTree(
     }
   }
 
-  // Files tracked in HEAD but absent from the stash tree were deleted in the
-  // working tree when the stash was created; restore that deletion.
-  for (const filepath of headFileSet) {
+  // Files tracked at the stash base but absent from the stash tree were deleted
+  // in the working tree when the stash was created; restore that deletion.
+  for (const filepath of baseFileSet) {
     if (!stashFiles.has(filepath)) {
       try {
         await ctx.fs.rm(`${cwd}/${filepath}`);
@@ -399,15 +402,15 @@ async function mergeStashTree(
   return conflicts;
 }
 
-/** Read a file's HEAD blob as text, returning '' when it is not present. */
-async function readHeadText(
+/** Read a file's base-commit blob as text, returning '' when it is not present. */
+async function readBaseText(
   ctx: GitCommandContext,
   cwd: string,
-  headOid: string,
+  baseOid: string,
   filepath: string
 ): Promise<string> {
   try {
-    const { blob } = await git.readBlob({ fs: ctx.lfs, dir: cwd, oid: headOid, filepath });
+    const { blob } = await git.readBlob({ fs: ctx.lfs, dir: cwd, oid: baseOid, filepath });
     return new TextDecoder().decode(blob);
   } catch {
     return '';

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -21,6 +21,7 @@ import { type ArgSpec, parseArgs } from '../shell/arg-parser.js';
 import { add } from './commands/add.js';
 import { branch } from './commands/branch.js';
 import { checkout } from './commands/checkout.js';
+import { cherryPick } from './commands/cherry-pick.js';
 import { clone } from './commands/clone.js';
 import { commit } from './commands/commit.js';
 import { config } from './commands/config.js';
@@ -335,6 +336,8 @@ export class GitCommands {
           return await push(this.ctx, effectiveCwd, rest);
         case 'merge':
           return await merge(this.ctx, effectiveCwd, rest);
+        case 'cherry-pick':
+          return await cherryPick(this.ctx, effectiveCwd, rest);
         case 'merge-file':
           return await mergeFile(this.ctx, effectiveCwd, rest);
         case 'reset':
@@ -465,6 +468,7 @@ Available commands:
   push        Update remote refs
   merge       Join two development histories together
   merge-file  Run a three-way file merge
+  cherry-pick Apply the changes introduced by an existing commit
   reset       Reset HEAD, index, and working tree
   stash       Stash changes in a dirty working directory
   rm          Remove files from the working tree and index

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -38,6 +38,7 @@ import { push } from './commands/push.js';
 import { remote } from './commands/remote.js';
 import { reset } from './commands/reset.js';
 import { revParse } from './commands/rev-parse.js';
+import { revert } from './commands/revert.js';
 import { rm } from './commands/rm.js';
 import { expandGitError, GIT_FLAG_SPECS } from './commands/shared.js';
 import { show } from './commands/show.js';
@@ -338,6 +339,8 @@ export class GitCommands {
           return await merge(this.ctx, effectiveCwd, rest);
         case 'cherry-pick':
           return await cherryPick(this.ctx, effectiveCwd, rest);
+        case 'revert':
+          return await revert(this.ctx, effectiveCwd, rest);
         case 'merge-file':
           return await mergeFile(this.ctx, effectiveCwd, rest);
         case 'reset':
@@ -469,6 +472,7 @@ Available commands:
   merge       Join two development histories together
   merge-file  Run a three-way file merge
   cherry-pick Apply the changes introduced by an existing commit
+  revert      Revert an existing commit
   reset       Reset HEAD, index, and working tree
   stash       Stash changes in a dirty working directory
   rm          Remove files from the working tree and index

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -1628,6 +1628,148 @@ describe('GitCommands', () => {
     });
   });
 
+  describe('revert', () => {
+    /**
+     * Build main with an initial commit, a second commit that modifies the
+     * shared file and adds a new one, and return that second commit's oid.
+     */
+    async function setupRevertable(): Promise<string> {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'base\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      await vfs.writeFile('/project/file.txt', 'changed\n');
+      await vfs.writeFile('/project/added.txt', 'added file\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['add', 'added.txt'], '/project');
+      await git.execute(['commit', '-m', 'change file and add another'], '/project');
+
+      return isoGit.resolveRef({ fs: createIsomorphicGitFs(vfs), dir: '/project', ref: 'HEAD' });
+    }
+
+    it('reverts a commit and commits the inverse', async () => {
+      const oid = await setupRevertable();
+      const result = await git.execute(['revert', oid], '/project');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Revert "change file and add another"');
+      expect(result.stdout).toContain('[main ');
+
+      // The modification is undone and the added file is removed.
+      expect(await vfs.readTextFile('/project/file.txt')).toBe('base\n');
+      expect(await vfs.exists('/project/added.txt')).toBe(false);
+
+      const logs = await isoGit.log({ fs: createIsomorphicGitFs(vfs), dir: '/project', depth: 1 });
+      expect(logs[0].commit.message).toContain('Revert "change file and add another"');
+      expect(logs[0].commit.message).toContain(`This reverts commit ${oid}.`);
+      expect(logs[0].commit.parent.length).toBe(1);
+    });
+
+    it('resolves a short oid', async () => {
+      const oid = await setupRevertable();
+      const result = await git.execute(['revert', oid.slice(0, 7)], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(await vfs.readTextFile('/project/file.txt')).toBe('base\n');
+    });
+
+    it('--no-commit applies without advancing the branch', async () => {
+      const oid = await setupRevertable();
+      const before = await isoGit.log({
+        fs: createIsomorphicGitFs(vfs),
+        dir: '/project',
+        depth: 1,
+      });
+
+      const result = await git.execute(['revert', '-n', oid], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('');
+
+      // Working tree reflects the revert, but the branch pointer did not move.
+      expect(await vfs.readTextFile('/project/file.txt')).toBe('base\n');
+      const after = await isoGit.log({ fs: createIsomorphicGitFs(vfs), dir: '/project', depth: 1 });
+      expect(after[0].oid).toBe(before[0].oid);
+    });
+
+    it('leaves conflict markers and exits 1 on a conflicting revert', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'base\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      // Commit to revert changes the shared line.
+      await vfs.writeFile('/project/file.txt', 'first change\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'first change'], '/project');
+      const oid = await isoGit.resolveRef({
+        fs: createIsomorphicGitFs(vfs),
+        dir: '/project',
+        ref: 'HEAD',
+      });
+
+      // A later commit changes the same line divergently.
+      await vfs.writeFile('/project/file.txt', 'second change\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'second change'], '/project');
+
+      const result = await git.execute(['revert', oid], '/project');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('CONFLICT');
+      expect(result.stderr).toContain('file.txt');
+
+      const merged = await vfs.readTextFile('/project/file.txt');
+      expect(merged).toContain('<<<<<<<');
+      expect(merged).toContain('=======');
+      expect(merged).toContain('>>>>>>>');
+    });
+
+    it('rejects a merge commit with a clear error', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'base\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      await git.execute(['checkout', '-b', 'feature'], '/project');
+      await vfs.writeFile('/project/feature.txt', 'feature\n');
+      await git.execute(['add', 'feature.txt'], '/project');
+      await git.execute(['commit', '-m', 'feature'], '/project');
+
+      await git.execute(['checkout', 'main'], '/project');
+      await vfs.writeFile('/project/main.txt', 'main\n');
+      await git.execute(['add', 'main.txt'], '/project');
+      await git.execute(['commit', '-m', 'main'], '/project');
+
+      await git.execute(['merge', '--no-ff', 'feature'], '/project');
+      const mergeOid = await isoGit.resolveRef({
+        fs: createIsomorphicGitFs(vfs),
+        dir: '/project',
+        ref: 'HEAD',
+      });
+
+      const result = await git.execute(['revert', mergeOid], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('is a merge');
+    });
+
+    it('errors when no commit is specified', async () => {
+      await git.execute(['init'], '/project');
+      const result = await git.execute(['revert'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('empty commit set');
+    });
+
+    it('errors on a bad revision', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'base\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      const result = await git.execute(['revert', 'does-not-exist'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('bad revision');
+    });
+  });
+
   describe('add -A/--all', () => {
     it('stages all changes including new and deleted files', async () => {
       await git.execute(['init'], '/project');

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -1351,6 +1351,99 @@ describe('GitCommands', () => {
       expect(result.stderr).toContain('conflict');
     });
 
+    // Shared setup for the -X / conflict-marker cases: `main` and `feature`
+    // each rewrite the same line of file.txt divergently from a common base.
+    async function setupConflictingBranches(): Promise<void> {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'base line\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+
+      await git.execute(['checkout', '-b', 'feature'], '/project');
+      await vfs.writeFile('/project/file.txt', 'theirs line\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'feature change'], '/project');
+
+      await git.execute(['checkout', 'main'], '/project');
+      await vfs.writeFile('/project/file.txt', 'ours line\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'main change'], '/project');
+    }
+
+    it('writes conflict markers and prints CONFLICT lines with exit 1', async () => {
+      await setupConflictingBranches();
+
+      const result = await git.execute(['merge', 'feature'], '/project');
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('CONFLICT (content): Merge conflict in file.txt');
+
+      const content = await vfs.readTextFile('/project/file.txt');
+      expect(content).toContain('<<<<<<<');
+      expect(content).toContain('ours line');
+      expect(content).toContain('=======');
+      expect(content).toContain('theirs line');
+      expect(content).toContain('>>>>>>>');
+    });
+
+    it('-X ours resolves conflicts to our side (no markers, exit 0)', async () => {
+      await setupConflictingBranches();
+
+      const result = await git.execute(['merge', '-X', 'ours', 'feature'], '/project');
+      expect(result.exitCode).toBe(0);
+
+      const content = await vfs.readTextFile('/project/file.txt');
+      expect(content).toBe('ours line\n');
+      expect(content).not.toContain('<<<<<<<');
+    });
+
+    it('-X theirs resolves conflicts to their side (no markers, exit 0)', async () => {
+      await setupConflictingBranches();
+
+      const result = await git.execute(['merge', '-X', 'theirs', 'feature'], '/project');
+      expect(result.exitCode).toBe(0);
+
+      const content = await vfs.readTextFile('/project/file.txt');
+      expect(content).toBe('theirs line\n');
+      expect(content).not.toContain('<<<<<<<');
+    });
+
+    it('-X diff3 includes the base section in conflict markers', async () => {
+      await setupConflictingBranches();
+
+      const result = await git.execute(['merge', '-X', 'diff3', 'feature'], '/project');
+      expect(result.exitCode).toBe(1);
+
+      const content = await vfs.readTextFile('/project/file.txt');
+      expect(content).toContain('|||||||');
+      expect(content).toContain('base line');
+    });
+
+    it('auto-merges disjoint edits to the same file (exit 0)', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'line1\nline2\nline3\nline4\nline5\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+
+      // feature edits the last line only
+      await git.execute(['checkout', '-b', 'feature'], '/project');
+      await vfs.writeFile('/project/file.txt', 'line1\nline2\nline3\nline4\nFIVE\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'feature edit'], '/project');
+
+      // main edits the first line only
+      await git.execute(['checkout', 'main'], '/project');
+      await vfs.writeFile('/project/file.txt', 'ONE\nline2\nline3\nline4\nline5\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'main edit'], '/project');
+
+      const result = await git.execute(['merge', 'feature'], '/project');
+      expect(result.exitCode).toBe(0);
+
+      const content = await vfs.readTextFile('/project/file.txt');
+      expect(content).toBe('ONE\nline2\nline3\nline4\nFIVE\n');
+      expect(content).not.toContain('<<<<<<<');
+    });
+
     it('returns error when no branch specified', async () => {
       await git.execute(['init'], '/project');
       const result = await git.execute(['merge'], '/project');
@@ -1733,6 +1826,113 @@ describe('GitCommands', () => {
       await git.execute(['stash', 'pop'], '/project');
       const content = await vfs.readTextFile('/project/newfile.txt');
       expect(content).toBe('new content');
+    });
+
+    it('stash apply restores changes and keeps the entry', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'original');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      await vfs.writeFile('/project/file.txt', 'modified');
+      await git.execute(['stash'], '/project');
+
+      const applyResult = await git.execute(['stash', 'apply'], '/project');
+      expect(applyResult.exitCode).toBe(0);
+      expect(applyResult.stdout).not.toContain('Dropped');
+
+      // Changes restored...
+      expect(await vfs.readTextFile('/project/file.txt')).toBe('modified');
+
+      // ...and the entry is kept.
+      const listResult = await git.execute(['stash', 'list'], '/project');
+      expect(listResult.stdout).toContain('stash@{0}');
+
+      // A subsequent pop still works and drops it.
+      const popResult = await git.execute(['stash', 'pop'], '/project');
+      expect(popResult.exitCode).toBe(0);
+      expect(popResult.stdout).toContain('Dropped refs/stash@{0}');
+    });
+
+    it('stash pop three-way merges disjoint local changes without clobbering', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'A\nB\nC\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      // Stash a change to the last line.
+      await vfs.writeFile('/project/file.txt', 'A\nB\nCHANGED_C\n');
+      await git.execute(['stash'], '/project');
+      expect(await vfs.readTextFile('/project/file.txt')).toBe('A\nB\nC\n');
+
+      // Make a disjoint local change to the first line, then pop.
+      await vfs.writeFile('/project/file.txt', 'CHANGED_A\nB\nC\n');
+      const popResult = await git.execute(['stash', 'pop'], '/project');
+      expect(popResult.exitCode).toBe(0);
+      expect(popResult.stdout).toContain('Dropped refs/stash@{0}');
+
+      // Both edits survive — no blind overwrite.
+      const merged = await vfs.readTextFile('/project/file.txt');
+      expect(merged).toBe('CHANGED_A\nB\nCHANGED_C\n');
+      expect(merged).not.toContain('<<<<<<<');
+    });
+
+    it('stash pop on conflict writes markers, exits 1, and keeps the entry', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'line1\nline2\nline3\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      // Stash a change to the middle line.
+      await vfs.writeFile('/project/file.txt', 'line1\nSTASHED\nline3\n');
+      await git.execute(['stash'], '/project');
+
+      // Make a divergent local change to the same line, then pop.
+      await vfs.writeFile('/project/file.txt', 'line1\nLOCAL\nline3\n');
+      const popResult = await git.execute(['stash', 'pop'], '/project');
+      expect(popResult.exitCode).toBe(1);
+      expect(popResult.stdout).toContain('CONFLICT (content): Merge conflict in file.txt');
+
+      const content = await vfs.readTextFile('/project/file.txt');
+      expect(content).toContain('<<<<<<< Updated upstream');
+      expect(content).toContain('LOCAL');
+      expect(content).toContain('=======');
+      expect(content).toContain('STASHED');
+      expect(content).toContain('>>>>>>> Stashed changes');
+
+      // The stash entry is kept on conflict.
+      const listResult = await git.execute(['stash', 'list'], '/project');
+      expect(listResult.stdout).toContain('stash@{0}');
+    });
+
+    it('stash apply on conflict writes markers and exits 1', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'line1\nline2\nline3\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      await vfs.writeFile('/project/file.txt', 'line1\nSTASHED\nline3\n');
+      await git.execute(['stash'], '/project');
+
+      await vfs.writeFile('/project/file.txt', 'line1\nLOCAL\nline3\n');
+      const applyResult = await git.execute(['stash', 'apply'], '/project');
+      expect(applyResult.exitCode).toBe(1);
+      expect(applyResult.stdout).toContain('CONFLICT (content): Merge conflict in file.txt');
+
+      // apply always keeps the entry.
+      const listResult = await git.execute(['stash', 'list'], '/project');
+      expect(listResult.stdout).toContain('stash@{0}');
+    });
+
+    it('stash apply with no stash returns error', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'content');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      const result = await git.execute(['stash', 'apply'], '/project');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('No stash entries');
     });
   });
 

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -2220,6 +2220,35 @@ describe('GitCommands', () => {
       expect(listResult.stdout).toContain('stash@{0}');
     });
 
+    it('stash apply uses the stash base commit, not current HEAD, as the merge base', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'A\nB\nC\nD\nE\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      // Stash a change to the last line (stash base = the initial commit).
+      await vfs.writeFile('/project/file.txt', 'A\nB\nC\nD\nCHANGED_E\n');
+      await git.execute(['stash'], '/project');
+      expect(await vfs.readTextFile('/project/file.txt')).toBe('A\nB\nC\nD\nE\n');
+
+      // Advance HEAD past the stash base with a commit touching the SAME file
+      // on a disjoint line, so current HEAD differs from the stash base.
+      await vfs.writeFile('/project/file.txt', 'MODIFIED_A\nB\nC\nD\nE\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'advance HEAD'], '/project');
+
+      // Apply against the stash base: the two disjoint edits merge cleanly.
+      const applyResult = await git.execute(['stash', 'apply'], '/project');
+      expect(applyResult.exitCode).toBe(0);
+      expect(applyResult.stdout).not.toContain('CONFLICT');
+
+      // Both the advanced-HEAD change and the stashed change survive. Using the
+      // current HEAD as the base would have clobbered MODIFIED_A with the stash.
+      const merged = await vfs.readTextFile('/project/file.txt');
+      expect(merged).toBe('MODIFIED_A\nB\nC\nD\nCHANGED_E\n');
+      expect(merged).not.toContain('<<<<<<<');
+    });
+
     it('stash apply with no stash returns error', async () => {
       await git.execute(['init'], '/project');
       await vfs.writeFile('/project/file.txt', 'content');

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -1474,6 +1474,160 @@ describe('GitCommands', () => {
     });
   });
 
+  describe('cherry-pick', () => {
+    /** Build main with one commit, a `feature` commit to pick, and return to main. */
+    async function setupPickable(): Promise<string> {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'base\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      await git.execute(['checkout', '-b', 'feature'], '/project');
+      await vfs.writeFile('/project/feature.txt', 'feature work\n');
+      await git.execute(['add', 'feature.txt'], '/project');
+      await git.execute(['commit', '-m', 'add feature file'], '/project');
+      const oid = await isoGit.resolveRef({
+        fs: createIsomorphicGitFs(vfs),
+        dir: '/project',
+        ref: 'feature',
+      });
+
+      await git.execute(['checkout', 'main'], '/project');
+      return oid;
+    }
+
+    it('applies and commits a clean cherry-pick', async () => {
+      const oid = await setupPickable();
+      const result = await git.execute(['cherry-pick', oid], '/project');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('add feature file');
+      expect(result.stdout).toContain('[main ');
+
+      // Change is applied to the working tree.
+      expect(await vfs.readTextFile('/project/feature.txt')).toBe('feature work\n');
+
+      // A new commit lands on main with the original author preserved.
+      const logs = await isoGit.log({ fs: createIsomorphicGitFs(vfs), dir: '/project', depth: 1 });
+      expect(logs[0].commit.message).toContain('add feature file');
+      expect(logs[0].commit.parent.length).toBe(1);
+    });
+
+    it('resolves a short oid', async () => {
+      const oid = await setupPickable();
+      const result = await git.execute(['cherry-pick', oid.slice(0, 7)], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(await vfs.exists('/project/feature.txt')).toBe(true);
+    });
+
+    it('--no-commit applies without advancing the branch', async () => {
+      const oid = await setupPickable();
+      const before = await isoGit.log({
+        fs: createIsomorphicGitFs(vfs),
+        dir: '/project',
+        depth: 1,
+      });
+
+      const result = await git.execute(['cherry-pick', '-n', oid], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('');
+
+      // Branch pointer did not move (no new commit on main).
+      const after = await isoGit.log({ fs: createIsomorphicGitFs(vfs), dir: '/project', depth: 1 });
+      expect(after[0].oid).toBe(before[0].oid);
+    });
+
+    it('-x annotates the message with the source commit', async () => {
+      const oid = await setupPickable();
+      const result = await git.execute(['cherry-pick', '-x', oid], '/project');
+      expect(result.exitCode).toBe(0);
+
+      const logs = await isoGit.log({ fs: createIsomorphicGitFs(vfs), dir: '/project', depth: 1 });
+      expect(logs[0].commit.message).toContain(`(cherry picked from commit ${oid})`);
+    });
+
+    it('leaves conflict markers and exits 1 on a conflicting pick', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'base\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      // feature changes the shared line.
+      await git.execute(['checkout', '-b', 'feature'], '/project');
+      await vfs.writeFile('/project/file.txt', 'feature change\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'feature change'], '/project');
+      const oid = await isoGit.resolveRef({
+        fs: createIsomorphicGitFs(vfs),
+        dir: '/project',
+        ref: 'feature',
+      });
+
+      // main changes the same line divergently.
+      await git.execute(['checkout', 'main'], '/project');
+      await vfs.writeFile('/project/file.txt', 'main change\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'main change'], '/project');
+
+      const result = await git.execute(['cherry-pick', oid], '/project');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('CONFLICT');
+      expect(result.stderr).toContain('file.txt');
+
+      const merged = await vfs.readTextFile('/project/file.txt');
+      expect(merged).toContain('<<<<<<<');
+      expect(merged).toContain('=======');
+      expect(merged).toContain('>>>>>>>');
+    });
+
+    it('rejects a merge commit with a clear error', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'base\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      await git.execute(['checkout', '-b', 'feature'], '/project');
+      await vfs.writeFile('/project/feature.txt', 'feature\n');
+      await git.execute(['add', 'feature.txt'], '/project');
+      await git.execute(['commit', '-m', 'feature'], '/project');
+
+      await git.execute(['checkout', 'main'], '/project');
+      await vfs.writeFile('/project/main.txt', 'main\n');
+      await git.execute(['add', 'main.txt'], '/project');
+      await git.execute(['commit', '-m', 'main'], '/project');
+
+      // Create a merge commit (two parents) via --no-ff.
+      await git.execute(['merge', '--no-ff', 'feature'], '/project');
+      const mergeOid = await isoGit.resolveRef({
+        fs: createIsomorphicGitFs(vfs),
+        dir: '/project',
+        ref: 'HEAD',
+      });
+
+      const result = await git.execute(['cherry-pick', mergeOid], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('is a merge');
+    });
+
+    it('errors when no commit is specified', async () => {
+      await git.execute(['init'], '/project');
+      const result = await git.execute(['cherry-pick'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('empty commit set');
+    });
+
+    it('errors on a bad revision', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'base\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      const result = await git.execute(['cherry-pick', 'does-not-exist'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('bad revision');
+    });
+  });
+
   describe('add -A/--all', () => {
     it('stages all changes including new and deleted files', async () => {
       await git.execute(['init'], '/project');


### PR DESCRIPTION
## Summary

Builds four conflict-aware git commands on top of the `threeWayMerge` primitive shipped in #1411 (`merge-file-core.ts`). Before this, every conflict path either aborted (`merge`) or silently clobbered the working tree (`stash pop`). Now they write standard `<<<<<<< / ======= / >>>>>>>` markers like real git.

## What changed

- **`git merge`** — writes conflict markers to the working tree + index instead of aborting (exit 1, per-file `CONFLICT (content): Merge conflict in <file>`), and adds `-X ours|theirs|diff3|union` strategy options. Backed by a new shared `commands/merge-driver.ts` (`makeMergeDriver({ favor?, diff3?, labels? })`) that wraps `threeWayMerge`. Fast-forward / already-merged paths unchanged. Fixed a clean non-ff merge leaving the worktree on `ours` (force checkout on the merge-commit).
- **`git cherry-pick <commit>`** (new) — native isomorphic-git `cherryPick` + the shared merge driver. Clean pick commits (author preserved); `-n/--no-commit` applies without advancing the branch; `-x` annotates the message; conflicts leave markers + exit 1; merge/root commits rejected.
- **`git revert <commit>`** (new) — implemented in-repo as a reverse three-way merge (base = target tree, ours = HEAD, theirs = target's parent), since isomorphic-git has no `revert`. Clean revert commits `Revert "..."`; `-n` skips the commit; conflicts leave markers + exit 1; merge commits rejected with git's standard `-m` error.
- **`git stash`** — adds the missing `apply` subcommand and makes `pop`/`apply` three-way merge stashed content against the current working tree (base = HEAD, ours = workdir, theirs = stash) instead of clobbering. Conflicts write markers, print `CONFLICT`, exit 1, and keep the stash entry; clean `pop` still drops.

## Verification

- `npm run lint` — clean, touched-file complexity gate OK (8 changed files, 0 on debt lists)
- `npm run typecheck` — 9/9 tsc projects pass
- `npm run test -w @slicc/webapp -- tests/git/` — 11 files / 300 tests pass together
- `npm run build -w @slicc/webapp` — clean
- 27 new mirrored tests across the four commands

## Follow-up

- `git rebase` is tracked in #1412 (replays commits on the same primitive; blocked on this suite).

## Non-goals

- Reverting/cherry-picking merge commits (`-m`), interactive rebase, binary/rename conflict detection, no new dependencies.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author