### PR TITLE
fix(worker): deploy the preview worker with the hub on every release (serve 'Preview not found')

### DIFF
--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -239,6 +239,18 @@ This lives at the repo root because it coordinates the worker with browser runti
   - secret: `CLOUDFLARE_API_TOKEN`
   - variable: `CLOUDFLARE_ACCOUNT_ID`
 - Wrangler surfaces deployed URLs that are used by `packages/cloudflare-worker/tests/deployed.test.ts`.
+- **Both workers ship together.** The hub (`wrangler.jsonc`) and the preview
+  worker (`wrangler-preview.jsonc`) share the same preview-URL token format
+  (`buildPreviewUrl` in `@slicc/shared-ts` ↔ `previewTokenFromHost` in
+  `src/preview-host.ts`) and the same Durable Object (bound in the preview config
+  via `script_name`). They MUST be deployed as a pair — a hub-only deploy that
+  changes the URL format leaves a stale preview worker unable to parse the new
+  URLs, so every `serve` preview 404s "Preview not found" (regression: PR #1355's
+  user-hash label). The automated release (`scripts/publish-worker.sh`) therefore
+  deploys **both** — the hub, then the preview worker — and the manual
+  `worker.yml` dispatch and staging `ci.yml` both already do the same. Before this
+  fix, `publish-worker.sh` deployed only the hub, so the prod preview worker only
+  updated on a rare manual `worker.yml` dispatch and drifted.
 
 ## Operational Notes
 

--- a/packages/cloudflare-worker/scripts/publish-worker.sh
+++ b/packages/cloudflare-worker/scripts/publish-worker.sh
@@ -16,6 +16,7 @@
 set -euo pipefail
 
 WRANGLER_CONFIG="packages/cloudflare-worker/wrangler.jsonc"
+PREVIEW_WRANGLER_CONFIG="packages/cloudflare-worker/wrangler-preview.jsonc"
 MAX_ATTEMPTS=6
 SLEEP_BETWEEN=15
 
@@ -33,6 +34,17 @@ echo "$E2B_API_KEY"               | npx wrangler secret put E2B_API_KEY         
 
 echo "[publish-worker] Deploying worker..."
 npx wrangler deploy --config "$WRANGLER_CONFIG"
+
+# The preview worker (*.sliccy.now) shares the hub's URL-token format
+# (`buildPreviewUrl` <-> `previewTokenFromHost`) and its Durable Object (bound
+# via `script_name`). It MUST ship on every release or the two drift: a
+# hub-only deploy that changes the preview URL format (e.g. #1355's user-hash
+# label) leaves the stale preview worker unable to parse the new URLs, so every
+# preview 404s "Preview not found". It has no secrets of its own (only the
+# shared DO binding), so no secret upload is needed. Deployed AFTER the hub so
+# the `script_name` DO reference resolves.
+echo "[publish-worker] Deploying preview worker (must ship with the hub)..."
+npx wrangler deploy --config "$PREVIEW_WRANGLER_CONFIG"
 
 echo "[publish-worker] Running deployed smoke tests (up to $MAX_ATTEMPTS attempts)..."
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do


### PR DESCRIPTION
## Symptom

`serve` mints a `*.sliccy.now` preview URL, but opening it shows **"Preview not found"** (a 404 from the preview worker). Reproduced via the extension (prod); a standalone pointed at staging works.

## Root cause — deploy drift, not a code bug

The automated release (`scripts/publish-worker.sh`, run by semantic-release) deploys **only the hub** (`wrangler.jsonc`) — it never deployed the preview worker (`wrangler-preview.jsonc`). History confirms `wrangler-preview` was **never** referenced in `publish-worker.sh`; the prod preview worker's only deploy path was a **manual `worker.yml` dispatch** (added with the feature in `60c517538`, and not re-run since).

The two workers are coupled:
- they share the preview-URL token format — `buildPreviewUrl` (`@slicc/shared-ts`) mints it, `previewTokenFromHost` (`src/preview-host.ts`) parses it;
- they share the `SessionTrayDurableObject` (the preview worker binds it via `script_name`).

So hub-only releases let them drift. **PR #1355** ("embed user hash in preview URLs") changed the format on the hub side to `<uuid>--<userHash8>-<secret20>`. The frozen prod preview worker predates that and can't parse the new label → it mis-derives the token → the Durable Object has no record for it → **"Preview not found."**

The code on `main` was always correct: the `buildPreviewUrl` ↔ `previewTokenFromHost` round-trip passes 26 tests, the preview worker shares the hub's DO, and the mint always threads an 8-char userHash. Staging never broke because `ci.yml` redeploys the preview worker on **every** staging run — which is exactly the extension(prod)-vs-standalone(staging) split.

## Fix

Deploy **both** workers as a pair in `publish-worker.sh` — the hub, then the preview worker (after the hub, so the `script_name` DO reference resolves) — so they can never drift again. The manual `worker.yml` dispatch and staging `ci.yml` already deploy both; this brings the automated release in line. The preview worker has no secrets of its own (only the shared DO binding), so no secret upload is added.

Docs updated in `packages/cloudflare-worker/CLAUDE.md` (CI and Deployment) to record the "both workers ship together" invariant.

## Immediate prod unblock

Dispatched `worker.yml` on `main` to redeploy the prod hub + preview worker to current `main` (which has #1355), bringing the frozen preview worker current. That clears the live "Preview not found" ahead of this PR landing; the PR prevents recurrence.

## Follow-up (not in this PR)

The release smoke test (`deployed.test.ts`) only exercises the **hub**, which is why this drift went undetected for so long. A worthwhile guard: add a preview-URL round-trip smoke (mint → fetch the `*.sliccy.*` URL → expect 200, not the shell) so a hub/preview mismatch fails the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
