### PR TITLE
feat(git): implement git rebase (conflict-aware cherry-pick replay)

### DIFF
--- a/packages/webapp/src/git/commands/rebase.ts
+++ b/packages/webapp/src/git/commands/rebase.ts
@@ -1,0 +1,345 @@
+/**
+ * `git rebase <upstream>` — replay the linear range `upstream..HEAD` onto
+ * `<upstream>` as a sequence of conflict-aware cherry-picks, plus a
+ * `--continue` / `--abort` / `--skip` state machine.
+ *
+ * There is no native isomorphic-git rebase, so this composes lower-level APIs:
+ * `findMergeBase` + `log` compute the range, then each commit is replayed with
+ * native `cherryPick` through the shared `makeMergeDriver` (author preserved,
+ * committer refreshed — exactly the cherry-pick path). A divergent overlap
+ * stops the replay with standard markers (exit 1); the remaining todo, the
+ * stopped commit, the onto target, and the original HEAD are persisted under
+ * `.git/rebase-merge/` so a later invocation can resume, skip, or abort.
+ * Interactive rebase, `--onto`, `--rebase-merges`, autosquash, and rebasing
+ * merge commits are out of scope and rejected clearly.
+ */
+
+import * as git from 'isomorphic-git';
+import { parseArgs } from '../../shell/arg-parser.js';
+import { makeMergeDriver } from './merge-driver.js';
+import { expandGitError, GIT_FLAG_SPECS } from './shared.js';
+import type { GitCommandContext, GitCommandResult } from './types.js';
+
+interface RebaseState {
+  onto: string;
+  origHead: string;
+  headName: string;
+  branch: string;
+  current?: string;
+  todo: string[];
+}
+
+const STATE_SUBDIR = '.git/rebase-merge';
+
+export async function rebase(
+  ctx: GitCommandContext,
+  cwd: string,
+  args: string[]
+): Promise<GitCommandResult> {
+  const { flags, positionals } = parseArgs(args, GIT_FLAG_SPECS.rebase);
+
+  for (const unsupported of ['interactive', 'onto', 'rebase-merges', 'autosquash'] as const) {
+    if (flags[unsupported]) {
+      return {
+        stdout: '',
+        stderr: `fatal: git rebase --${unsupported} is not supported\n`,
+        exitCode: 128,
+      };
+    }
+  }
+
+  try {
+    if (flags.abort) return await abortRebase(ctx, cwd);
+    if (flags.continue) return await continueRebase(ctx, cwd);
+    if (flags.skip) return await skipRebase(ctx, cwd);
+    return await startRebase(ctx, cwd, positionals[0]);
+  } catch (err: unknown) {
+    return { stdout: '', stderr: `fatal: ${expandGitError(err)}\n`, exitCode: 128 };
+  }
+}
+
+/** Begin a fresh rebase of the current branch onto `<upstream>`. */
+async function startRebase(
+  ctx: GitCommandContext,
+  cwd: string,
+  upstream: string | undefined
+): Promise<GitCommandResult> {
+  if (!upstream) {
+    return { stdout: '', stderr: 'fatal: No upstream specified.\n', exitCode: 128 };
+  }
+  if (await stateExists(ctx, cwd)) {
+    return {
+      stdout: '',
+      stderr:
+        'fatal: It seems that there is already a rebase-merge directory,\nand I wonder if you are in the middle of another rebase.\n',
+      exitCode: 128,
+    };
+  }
+
+  const branch = await git.currentBranch({ fs: ctx.lfs, dir: cwd });
+  if (!branch) {
+    return { stdout: '', stderr: 'fatal: no such branch/commit (detached HEAD)\n', exitCode: 128 };
+  }
+
+  const ontoOid = await resolveCommit(ctx, cwd, upstream);
+  if (!ontoOid) {
+    return { stdout: '', stderr: `fatal: invalid upstream '${upstream}'\n`, exitCode: 128 };
+  }
+  const headOid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref: 'HEAD' });
+  const [mergeBase] = await git.findMergeBase({ fs: ctx.lfs, dir: cwd, oids: [headOid, ontoOid] });
+
+  if (mergeBase === headOid) {
+    await resetHard(ctx, cwd, branch, ontoOid);
+    return {
+      stdout: `Fast-forwarded ${branch} to ${upstream}.\n`,
+      stderr: '',
+      exitCode: 0,
+    };
+  }
+  if (mergeBase === ontoOid) {
+    return { stdout: `Current branch ${branch} is up to date.\n`, stderr: '', exitCode: 0 };
+  }
+
+  const entries = await collectRange(ctx, cwd, headOid, mergeBase);
+  const mergeCommit = entries.find((e) => e.parents > 1);
+  if (mergeCommit) {
+    return {
+      stdout: '',
+      stderr: `error: commit ${mergeCommit.oid} is a merge but no -m option was given.\nfatal: rebase failed\n`,
+      exitCode: 128,
+    };
+  }
+
+  await resetHard(ctx, cwd, branch, ontoOid);
+  const state: RebaseState = {
+    onto: ontoOid,
+    origHead: headOid,
+    headName: `refs/heads/${branch}`,
+    branch,
+    todo: entries.map((e) => e.oid),
+  };
+  return replay(ctx, cwd, state);
+}
+
+/** Resume after conflict resolution: commit the stopped commit, replay the rest. */
+async function continueRebase(ctx: GitCommandContext, cwd: string): Promise<GitCommandResult> {
+  const state = await readState(ctx, cwd);
+  if (!state) return noRebaseInProgress();
+
+  if (state.current) {
+    const { commit } = await git.readCommit({ fs: ctx.lfs, dir: cwd, oid: state.current });
+    await git.commit({
+      fs: ctx.lfs,
+      dir: cwd,
+      message: commit.message,
+      author: commit.author,
+      committer: await ctx.resolveAuthor(cwd),
+    });
+    state.current = undefined;
+  }
+  return replay(ctx, cwd, state);
+}
+
+/** Drop the stopped commit and replay the rest. */
+async function skipRebase(ctx: GitCommandContext, cwd: string): Promise<GitCommandResult> {
+  const state = await readState(ctx, cwd);
+  if (!state) return noRebaseInProgress();
+  // Discard the conflicted working tree + index back to the current tip.
+  await git.checkout({ fs: ctx.lfs, dir: cwd, ref: state.branch, force: true });
+  state.current = undefined;
+  return replay(ctx, cwd, state);
+}
+
+/** Restore the original branch tip and clear the rebase state. */
+async function abortRebase(ctx: GitCommandContext, cwd: string): Promise<GitCommandResult> {
+  const state = await readState(ctx, cwd);
+  if (!state) return noRebaseInProgress();
+  await resetHard(ctx, cwd, state.branch, state.origHead);
+  await clearState(ctx, cwd);
+  return { stdout: '', stderr: '', exitCode: 0 };
+}
+
+/**
+ * Replay `state.todo` (oldest first) via `cherryPick`. On conflict, persist the
+ * stopped commit + remaining todo and return git-style status (exit 1). On
+ * completion, clear the state and report success.
+ */
+async function replay(
+  ctx: GitCommandContext,
+  cwd: string,
+  state: RebaseState
+): Promise<GitCommandResult> {
+  while (state.todo.length > 0) {
+    const oid = state.todo[0];
+    const { commit } = await git.readCommit({ fs: ctx.lfs, dir: cwd, oid });
+    const subject = commit.message.split('\n')[0];
+    try {
+      await git.cherryPick({
+        fs: ctx.lfs,
+        dir: cwd,
+        oid,
+        abortOnConflict: false,
+        committer: await ctx.resolveAuthor(cwd),
+        mergeDriver: makeMergeDriver(),
+      });
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'MergeConflictError') {
+        const files = (err as Error & { data?: { filepaths?: string[] } }).data?.filepaths ?? [];
+        state.current = oid;
+        state.todo = state.todo.slice(1);
+        await writeState(ctx, cwd, state);
+        return conflictResult(oid, subject, files);
+      }
+      throw err;
+    }
+    state.todo = state.todo.slice(1);
+  }
+  await clearState(ctx, cwd);
+  return {
+    stdout: `Successfully rebased and updated ${state.headName}.\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+/** Format the "stopped on conflict" status the way real git rebase does. */
+function conflictResult(oid: string, subject: string, files: string[]): GitCommandResult {
+  const short = oid.slice(0, 7);
+  let out = '';
+  for (const f of files) out += `CONFLICT (content): Merge conflict in ${f}\n`;
+  out += `error: could not apply ${short}... ${subject}\n`;
+  out += 'hint: Resolve all conflicts manually, mark them as resolved with\n';
+  out += 'hint: "git add/rm <conflicted_files>", then run "git rebase --continue".\n';
+  out += 'hint: You can instead skip this commit: run "git rebase --skip".\n';
+  out +=
+    'hint: To abort and get back to the state before "git rebase", run "git rebase --abort".\n';
+  return { stdout: '', stderr: out, exitCode: 1 };
+}
+
+function noRebaseInProgress(): GitCommandResult {
+  return { stdout: '', stderr: 'fatal: No rebase in progress?\n', exitCode: 128 };
+}
+
+/** Resolve `<upstream>` to a full oid (ref first, then short/full oid). */
+async function resolveCommit(
+  ctx: GitCommandContext,
+  cwd: string,
+  ref: string
+): Promise<string | undefined> {
+  try {
+    return await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref });
+  } catch {
+    try {
+      return await git.expandOid({ fs: ctx.lfs, dir: cwd, oid: ref });
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Collect the commits reachable from `headOid` but not `baseOid`, oldest first.
+ * `parents` is carried so the caller can reject merge commits before replaying.
+ */
+async function collectRange(
+  ctx: GitCommandContext,
+  cwd: string,
+  headOid: string,
+  baseOid: string
+): Promise<Array<{ oid: string; parents: number }>> {
+  const log = await git.log({ fs: ctx.lfs, dir: cwd, ref: headOid });
+  const out: Array<{ oid: string; parents: number }> = [];
+  for (const entry of log) {
+    if (entry.oid === baseOid) break;
+    out.push({ oid: entry.oid, parents: entry.commit.parent.length });
+  }
+  return out.reverse();
+}
+
+/** Point `<branch>` at `oid` and sync the index + working tree to it. */
+async function resetHard(
+  ctx: GitCommandContext,
+  cwd: string,
+  branch: string,
+  oid: string
+): Promise<void> {
+  await git.writeRef({
+    fs: ctx.lfs,
+    dir: cwd,
+    ref: `refs/heads/${branch}`,
+    value: oid,
+    force: true,
+  });
+  await git.checkout({ fs: ctx.lfs, dir: cwd, ref: branch, force: true });
+}
+
+/** Whether a rebase state directory is present. */
+async function stateExists(ctx: GitCommandContext, cwd: string): Promise<boolean> {
+  return ctx.fs.exists(`${cwd}/${STATE_SUBDIR}/onto`);
+}
+
+/** Read a single state file, trimmed, or undefined when absent. */
+async function readStateFile(
+  ctx: GitCommandContext,
+  cwd: string,
+  name: string
+): Promise<string | undefined> {
+  try {
+    return (await ctx.fs.readTextFile(`${cwd}/${STATE_SUBDIR}/${name}`)).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Rebuild the in-memory state from `.git/rebase-merge/`. */
+async function readState(ctx: GitCommandContext, cwd: string): Promise<RebaseState | undefined> {
+  const onto = await readStateFile(ctx, cwd, 'onto');
+  const origHead = await readStateFile(ctx, cwd, 'orig-head');
+  const headName = await readStateFile(ctx, cwd, 'head-name');
+  if (!onto || !origHead || !headName) return undefined;
+  const todoRaw = (await readStateFile(ctx, cwd, 'git-rebase-todo')) ?? '';
+  const todo = todoRaw
+    .split('\n')
+    .map((line) => line.replace(/^pick\s+/, '').trim())
+    .filter((line) => line.length > 0);
+  return {
+    onto,
+    origHead,
+    headName,
+    branch: headName.replace(/^refs\/heads\//, ''),
+    current: await readStateFile(ctx, cwd, 'stopped-sha'),
+    todo,
+  };
+}
+
+/** Persist the state to `.git/rebase-merge/`. */
+async function writeState(ctx: GitCommandContext, cwd: string, state: RebaseState): Promise<void> {
+  const dir = `${cwd}/${STATE_SUBDIR}`;
+  await ctx.fs.mkdir(dir, { recursive: true });
+  await ctx.fs.writeFile(`${dir}/onto`, `${state.onto}\n`);
+  await ctx.fs.writeFile(`${dir}/orig-head`, `${state.origHead}\n`);
+  await ctx.fs.writeFile(`${dir}/head-name`, `${state.headName}\n`);
+  await ctx.fs.writeFile(
+    `${dir}/git-rebase-todo`,
+    `${state.todo.map((oid) => `pick ${oid}`).join('\n')}\n`
+  );
+  if (state.current) await ctx.fs.writeFile(`${dir}/stopped-sha`, `${state.current}\n`);
+  else await removeIfPresent(ctx, `${dir}/stopped-sha`);
+}
+
+/** Delete the whole rebase state directory. */
+async function clearState(ctx: GitCommandContext, cwd: string): Promise<void> {
+  try {
+    await ctx.fs.rm(`${cwd}/${STATE_SUBDIR}`, { recursive: true });
+  } catch {
+    /* nothing to clear */
+  }
+}
+
+async function removeIfPresent(ctx: GitCommandContext, path: string): Promise<void> {
+  try {
+    await ctx.fs.rm(path);
+  } catch {
+    /* already absent */
+  }
+}

--- a/packages/webapp/src/git/commands/rebase.ts
+++ b/packages/webapp/src/git/commands/rebase.ts
@@ -20,6 +20,12 @@ import { makeMergeDriver } from './merge-driver.js';
 import { expandGitError, GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
+/** Coerce an mri flag value (string | string[] | undefined) to a string[]. */
+function asStringArray(value: unknown): string[] {
+  if (value === undefined) return [];
+  return (Array.isArray(value) ? value : [value]).map((v) => String(v));
+}
+
 interface RebaseState {
   onto: string;
   origHead: string;
@@ -27,6 +33,8 @@ interface RebaseState {
   branch: string;
   current?: string;
   todo: string[];
+  favor?: 'ours' | 'theirs' | 'union';
+  diff3?: boolean;
 }
 
 const STATE_SUBDIR = '.git/rebase-merge';
@@ -52,7 +60,7 @@ export async function rebase(
     if (flags.abort) return await abortRebase(ctx, cwd);
     if (flags.continue) return await continueRebase(ctx, cwd);
     if (flags.skip) return await skipRebase(ctx, cwd);
-    return await startRebase(ctx, cwd, positionals[0]);
+    return await startRebase(ctx, cwd, positionals[0], flags);
   } catch (err: unknown) {
     return { stdout: '', stderr: `fatal: ${expandGitError(err)}\n`, exitCode: 128 };
   }
@@ -62,7 +70,8 @@ export async function rebase(
 async function startRebase(
   ctx: GitCommandContext,
   cwd: string,
-  upstream: string | undefined
+  upstream: string | undefined,
+  flags: Record<string, unknown>
 ): Promise<GitCommandResult> {
   if (!upstream) {
     return { stdout: '', stderr: 'fatal: No upstream specified.\n', exitCode: 128 };
@@ -86,6 +95,14 @@ async function startRebase(
     return { stdout: '', stderr: `fatal: invalid upstream '${upstream}'\n`, exitCode: 128 };
   }
   const headOid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref: 'HEAD' });
+
+  // Native git refuses to rebase over uncommitted work; do the same before any
+  // ref/working-tree mutation (both the fast-forward and replay paths below
+  // force-checkout, which would silently clobber tracked edits). Autostash is
+  // out of scope.
+  const dirty = await assertCleanWorktree(ctx, cwd);
+  if (dirty) return dirty;
+
   const [mergeBase] = await git.findMergeBase({ fs: ctx.lfs, dir: cwd, oids: [headOid, ontoOid] });
 
   if (mergeBase === headOid) {
@@ -110,6 +127,14 @@ async function startRebase(
     };
   }
 
+  // -X/--strategy-option → merge-driver favor + diff3 knobs (mirrors merge.ts).
+  let favor: 'ours' | 'theirs' | 'union' | undefined;
+  let diff3 = false;
+  for (const opt of asStringArray(flags['strategy-option'])) {
+    if (opt === 'ours' || opt === 'theirs' || opt === 'union') favor = opt;
+    else if (opt === 'diff3') diff3 = true;
+  }
+
   await resetHard(ctx, cwd, branch, ontoOid);
   const state: RebaseState = {
     onto: ontoOid,
@@ -117,6 +142,8 @@ async function startRebase(
     headName: `refs/heads/${branch}`,
     branch,
     todo: entries.map((e) => e.oid),
+    favor,
+    diff3,
   };
   return replay(ctx, cwd, state);
 }
@@ -180,7 +207,7 @@ async function replay(
         oid,
         abortOnConflict: false,
         committer: await ctx.resolveAuthor(cwd),
-        mergeDriver: makeMergeDriver(),
+        mergeDriver: makeMergeDriver({ favor: state.favor, diff3: state.diff3 }),
       });
     } catch (err: unknown) {
       if (err instanceof Error && err.name === 'MergeConflictError') {
@@ -256,6 +283,44 @@ async function collectRange(
   return out.reverse();
 }
 
+/**
+ * Refuse a fresh rebase when the working tree or index carries tracked changes,
+ * matching native git (which will not rebase over uncommitted work). Each
+ * `statusMatrix` row is `[filepath, head, workdir, stage]`; purely untracked new
+ * files (`head === 0 && stage === 0`) are allowed, exactly as native git does.
+ * Returns a git-style error result to abort with, or `undefined` when clean.
+ */
+async function assertCleanWorktree(
+  ctx: GitCommandContext,
+  cwd: string
+): Promise<GitCommandResult | undefined> {
+  const matrix = await git.statusMatrix({ fs: ctx.lfs, dir: cwd });
+  let hasUnstaged = false;
+  let hasStaged = false;
+  for (const [, head, workdir, stage] of matrix) {
+    if (head === 0 && stage === 0) continue; // untracked new file — allowed
+    if (workdir !== stage) hasUnstaged = true;
+    else if (head !== stage) hasStaged = true;
+  }
+  if (hasUnstaged) {
+    return {
+      stdout: '',
+      stderr:
+        'error: cannot rebase: You have unstaged changes.\nerror: Please commit or stash them.\n',
+      exitCode: 128,
+    };
+  }
+  if (hasStaged) {
+    return {
+      stdout: '',
+      stderr:
+        'error: cannot rebase: Your index contains uncommitted changes.\nerror: Please commit or stash them.\n',
+      exitCode: 128,
+    };
+  }
+  return undefined;
+}
+
 /** Point `<branch>` at `oid` and sync the index + working tree to it. */
 async function resetHard(
   ctx: GitCommandContext,
@@ -302,6 +367,13 @@ async function readState(ctx: GitCommandContext, cwd: string): Promise<RebaseSta
     .split('\n')
     .map((line) => line.replace(/^pick\s+/, '').trim())
     .filter((line) => line.length > 0);
+  const optsRaw = (await readStateFile(ctx, cwd, 'strategy-opts')) ?? '';
+  let favor: 'ours' | 'theirs' | 'union' | undefined;
+  let diff3 = false;
+  for (const opt of optsRaw.split(/\s+/).filter((o) => o.length > 0)) {
+    if (opt === 'ours' || opt === 'theirs' || opt === 'union') favor = opt;
+    else if (opt === 'diff3') diff3 = true;
+  }
   return {
     onto,
     origHead,
@@ -309,6 +381,8 @@ async function readState(ctx: GitCommandContext, cwd: string): Promise<RebaseSta
     branch: headName.replace(/^refs\/heads\//, ''),
     current: await readStateFile(ctx, cwd, 'stopped-sha'),
     todo,
+    favor,
+    diff3,
   };
 }
 
@@ -325,6 +399,11 @@ async function writeState(ctx: GitCommandContext, cwd: string, state: RebaseStat
   );
   if (state.current) await ctx.fs.writeFile(`${dir}/stopped-sha`, `${state.current}\n`);
   else await removeIfPresent(ctx, `${dir}/stopped-sha`);
+  const opts: string[] = [];
+  if (state.favor) opts.push(state.favor);
+  if (state.diff3) opts.push('diff3');
+  if (opts.length > 0) await ctx.fs.writeFile(`${dir}/strategy-opts`, `${opts.join(' ')}\n`);
+  else await removeIfPresent(ctx, `${dir}/strategy-opts`);
 }
 
 /** Delete the whole rebase state directory. */

--- a/packages/webapp/src/git/commands/shared.ts
+++ b/packages/webapp/src/git/commands/shared.ts
@@ -74,6 +74,11 @@ export const GIT_FLAG_SPECS: Record<string, ArgSpec> = {
     boolean: ['no-commit'],
     alias: { n: 'no-commit' },
   },
+  rebase: {
+    string: ['onto', 'strategy', 'strategy-option'],
+    boolean: ['continue', 'abort', 'skip', 'interactive', 'rebase-merges', 'autosquash'],
+    alias: { i: 'interactive', s: 'strategy', X: 'strategy-option' },
+  },
   'merge-file': {
     string: ['L'],
     boolean: ['stdout', 'quiet', 'diff3', 'ours', 'theirs', 'union'],

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -35,6 +35,7 @@ import { mergeFile } from './commands/merge-file.js';
 import { mv } from './commands/mv.js';
 import { pull } from './commands/pull.js';
 import { push } from './commands/push.js';
+import { rebase } from './commands/rebase.js';
 import { remote } from './commands/remote.js';
 import { reset } from './commands/reset.js';
 import { revParse } from './commands/rev-parse.js';
@@ -339,6 +340,8 @@ export class GitCommands {
           return await merge(this.ctx, effectiveCwd, rest);
         case 'cherry-pick':
           return await cherryPick(this.ctx, effectiveCwd, rest);
+        case 'rebase':
+          return await rebase(this.ctx, effectiveCwd, rest);
         case 'revert':
           return await revert(this.ctx, effectiveCwd, rest);
         case 'merge-file':
@@ -472,6 +475,7 @@ Available commands:
   merge       Join two development histories together
   merge-file  Run a three-way file merge
   cherry-pick Apply the changes introduced by an existing commit
+  rebase      Reapply commits on top of another base tip
   revert      Revert an existing commit
   reset       Reset HEAD, index, and working tree
   stash       Stash changes in a dirty working directory

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -3205,6 +3205,112 @@ describe('GitCommands', () => {
       expect(result.exitCode).toBe(128);
       expect(result.stderr).toContain('No rebase in progress');
     });
+
+    it('refuses to rebase (replay path) when the working tree has tracked changes', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/base.txt', 'base\n');
+      await git.execute(['add', 'base.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+      await git.execute(['branch', 'feature'], '/project');
+
+      await vfs.writeFile('/project/main.txt', 'main\n');
+      await git.execute(['add', 'main.txt'], '/project');
+      await git.execute(['commit', '-m', 'main-work'], '/project');
+
+      await git.execute(['checkout', 'feature'], '/project');
+      await vfs.writeFile('/project/feat.txt', 'feat\n');
+      await git.execute(['add', 'feat.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-work'], '/project');
+
+      // Uncommitted tracked edit — native git refuses to rebase over this.
+      await vfs.writeFile('/project/feat.txt', 'dirty edit\n');
+      const origHead = (await git.execute(['rev-parse', 'HEAD'], '/project')).stdout.trim();
+
+      const result = await git.execute(['rebase', 'main'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('cannot rebase');
+      expect(result.stderr).toContain('unstaged changes');
+      // No ref moved, the edit survives, and no rebase state was created.
+      const after = (await git.execute(['rev-parse', 'HEAD'], '/project')).stdout.trim();
+      expect(after).toBe(origHead);
+      expect(await vfs.readTextFile('/project/feat.txt')).toBe('dirty edit\n');
+      expect(await vfs.exists('/project/.git/rebase-merge/onto')).toBe(false);
+    });
+
+    it('refuses to fast-forward over a dirty working tree', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/base.txt', 'base\n');
+      await git.execute(['add', 'base.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+      await git.execute(['branch', 'feature'], '/project');
+
+      await vfs.writeFile('/project/main.txt', 'main\n');
+      await git.execute(['add', 'main.txt'], '/project');
+      await git.execute(['commit', '-m', 'main-work'], '/project');
+
+      // feature is strictly behind main → fast-forward scenario.
+      await git.execute(['checkout', 'feature'], '/project');
+      await vfs.writeFile('/project/base.txt', 'dirty\n');
+      const origHead = (await git.execute(['rev-parse', 'HEAD'], '/project')).stdout.trim();
+
+      const result = await git.execute(['rebase', 'main'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('cannot rebase');
+      // The dirty file is NOT clobbered by a force fast-forward.
+      const after = (await git.execute(['rev-parse', 'HEAD'], '/project')).stdout.trim();
+      expect(after).toBe(origHead);
+      expect(await vfs.readTextFile('/project/base.txt')).toBe('dirty\n');
+    });
+
+    it('allows a rebase when only untracked files are present', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/base.txt', 'base\n');
+      await git.execute(['add', 'base.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+      await git.execute(['branch', 'feature'], '/project');
+
+      await vfs.writeFile('/project/main.txt', 'main\n');
+      await git.execute(['add', 'main.txt'], '/project');
+      await git.execute(['commit', '-m', 'main-work'], '/project');
+
+      await git.execute(['checkout', 'feature'], '/project');
+      await vfs.writeFile('/project/feat.txt', 'feat\n');
+      await git.execute(['add', 'feat.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-work'], '/project');
+
+      // A purely untracked new file must not block the rebase (matches git).
+      await vfs.writeFile('/project/untracked.txt', 'scratch\n');
+
+      const result = await git.execute(['rebase', 'main'], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Successfully rebased');
+      expect(await subjects('/project')).toEqual(['feat-work', 'main-work', 'base']);
+      expect(await vfs.readTextFile('/project/untracked.txt')).toBe('scratch\n');
+    });
+
+    it('resolves conflicts toward the upstream with -X ours (no stop)', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/conflict.txt', 'line1\nline2\nline3\n');
+      await git.execute(['add', 'conflict.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+      await git.execute(['branch', 'feature'], '/project');
+
+      await vfs.writeFile('/project/conflict.txt', 'line1\nMAIN\nline3\n');
+      await git.execute(['add', 'conflict.txt'], '/project');
+      await git.execute(['commit', '-m', 'main-change'], '/project');
+
+      await git.execute(['checkout', 'feature'], '/project');
+      await vfs.writeFile('/project/conflict.txt', 'line1\nFEATURE\nline3\n');
+      await git.execute(['add', 'conflict.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-change'], '/project');
+
+      const result = await git.execute(['rebase', '-X', 'ours', 'main'], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Successfully rebased');
+      // During a rebase, "ours" is the branch being rebased onto (main).
+      expect(await vfs.readTextFile('/project/conflict.txt')).toBe('line1\nMAIN\nline3\n');
+      expect(await vfs.exists('/project/.git/rebase-merge/onto')).toBe(false);
+    });
   });
 });
 

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -2984,6 +2984,228 @@ describe('GitCommands', () => {
       expect(subject).toBe('--help');
     });
   });
+
+  describe('rebase', () => {
+    const subjects = async (cwd: string): Promise<string[]> =>
+      (await git.execute(['log', '--format', '%s'], cwd)).stdout.trim().split('\n');
+
+    it('cleanly replays a linear branch onto an advanced upstream', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/base.txt', 'base\n');
+      await git.execute(['add', 'base.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+      await git.execute(['branch', 'feature'], '/project');
+
+      await vfs.writeFile('/project/main.txt', 'main\n');
+      await git.execute(['add', 'main.txt'], '/project');
+      await git.execute(['commit', '-m', 'main-work'], '/project');
+
+      await git.execute(['checkout', 'feature'], '/project');
+      await vfs.writeFile('/project/feat.txt', 'feat\n');
+      await git.execute(['add', 'feat.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-work'], '/project');
+
+      const result = await git.execute(['rebase', 'main'], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Successfully rebased');
+      expect(await subjects('/project')).toEqual(['feat-work', 'main-work', 'base']);
+      expect(await vfs.readTextFile('/project/main.txt')).toBe('main\n');
+      expect(await vfs.readTextFile('/project/feat.txt')).toBe('feat\n');
+      // The replayed commit is a brand-new oid parented on the upstream tip.
+      const isoFs = createIsomorphicGitFs(vfs);
+      const headOid = await isoGit.resolveRef({ fs: isoFs, dir: '/project', ref: 'HEAD' });
+      const upstreamTip = await isoGit.resolveRef({ fs: isoFs, dir: '/project', ref: 'main' });
+      const { commit } = await isoGit.readCommit({ fs: isoFs, dir: '/project', oid: headOid });
+      expect(commit.parent).toEqual([upstreamTip]);
+    });
+
+    it('stops on a conflicting commit and finishes after --continue', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/conflict.txt', 'line1\nline2\nline3\n');
+      await git.execute(['add', 'conflict.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+      await git.execute(['branch', 'feature'], '/project');
+
+      await vfs.writeFile('/project/conflict.txt', 'line1\nMAIN\nline3\n');
+      await git.execute(['add', 'conflict.txt'], '/project');
+      await git.execute(['commit', '-m', 'main-change'], '/project');
+
+      await git.execute(['checkout', 'feature'], '/project');
+      await vfs.writeFile('/project/conflict.txt', 'line1\nFEATURE\nline3\n');
+      await git.execute(['add', 'conflict.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-change'], '/project');
+
+      const result = await git.execute(['rebase', 'main'], '/project');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('CONFLICT (content): Merge conflict in conflict.txt');
+      expect(result.stderr).toContain('could not apply');
+      expect(result.stderr).toContain('git rebase --continue');
+      const marked = await vfs.readTextFile('/project/conflict.txt');
+      expect(marked).toContain('<<<<<<<');
+      expect(marked).toContain('>>>>>>>');
+      expect(await vfs.exists('/project/.git/rebase-merge/onto')).toBe(true);
+
+      await vfs.writeFile('/project/conflict.txt', 'line1\nRESOLVED\nline3\n');
+      await git.execute(['add', 'conflict.txt'], '/project');
+      const cont = await git.execute(['rebase', '--continue'], '/project');
+      expect(cont.exitCode).toBe(0);
+      expect(cont.stdout).toContain('Successfully rebased');
+      expect(await vfs.readTextFile('/project/conflict.txt')).toBe('line1\nRESOLVED\nline3\n');
+      expect(await subjects('/project')).toEqual(['feat-change', 'main-change', 'base']);
+      expect(await vfs.exists('/project/.git/rebase-merge/onto')).toBe(false);
+    });
+
+    it('--abort restores the original branch tip exactly', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/conflict.txt', 'line1\nline2\nline3\n');
+      await git.execute(['add', 'conflict.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+      await git.execute(['branch', 'feature'], '/project');
+
+      await vfs.writeFile('/project/conflict.txt', 'line1\nMAIN\nline3\n');
+      await git.execute(['add', 'conflict.txt'], '/project');
+      await git.execute(['commit', '-m', 'main-change'], '/project');
+
+      await git.execute(['checkout', 'feature'], '/project');
+      await vfs.writeFile('/project/conflict.txt', 'line1\nFEATURE\nline3\n');
+      await git.execute(['add', 'conflict.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-change'], '/project');
+
+      const origHead = (await git.execute(['rev-parse', 'HEAD'], '/project')).stdout.trim();
+      const conflict = await git.execute(['rebase', 'main'], '/project');
+      expect(conflict.exitCode).toBe(1);
+
+      const abort = await git.execute(['rebase', '--abort'], '/project');
+      expect(abort.exitCode).toBe(0);
+      const after = (await git.execute(['rev-parse', 'HEAD'], '/project')).stdout.trim();
+      expect(after).toBe(origHead);
+      expect(await vfs.readTextFile('/project/conflict.txt')).toBe('line1\nFEATURE\nline3\n');
+      expect(await vfs.exists('/project/.git/rebase-merge/onto')).toBe(false);
+    });
+
+    it('--skip drops the conflicting commit and applies the rest', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/a.txt', 'base\n');
+      await git.execute(['add', 'a.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+      await git.execute(['branch', 'feature'], '/project');
+
+      await vfs.writeFile('/project/a.txt', 'MAIN\n');
+      await git.execute(['add', 'a.txt'], '/project');
+      await git.execute(['commit', '-m', 'main-change'], '/project');
+
+      await git.execute(['checkout', 'feature'], '/project');
+      await vfs.writeFile('/project/a.txt', 'FEATURE1\n');
+      await git.execute(['add', 'a.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-1'], '/project');
+      await vfs.writeFile('/project/b.txt', 'feature2\n');
+      await git.execute(['add', 'b.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-2'], '/project');
+
+      const result = await git.execute(['rebase', 'main'], '/project');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('could not apply');
+
+      const skip = await git.execute(['rebase', '--skip'], '/project');
+      expect(skip.exitCode).toBe(0);
+      expect(skip.stdout).toContain('Successfully rebased');
+      expect(await subjects('/project')).toEqual(['feat-2', 'main-change', 'base']);
+      expect(await vfs.readTextFile('/project/a.txt')).toBe('MAIN\n');
+      expect(await vfs.readTextFile('/project/b.txt')).toBe('feature2\n');
+    });
+
+    it('fast-forwards when the branch is behind the upstream', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/base.txt', 'base\n');
+      await git.execute(['add', 'base.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+      await git.execute(['branch', 'feature'], '/project');
+
+      await vfs.writeFile('/project/main.txt', 'main\n');
+      await git.execute(['add', 'main.txt'], '/project');
+      await git.execute(['commit', '-m', 'main-work'], '/project');
+
+      await git.execute(['checkout', 'feature'], '/project');
+      const result = await git.execute(['rebase', 'main'], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Fast-forwarded');
+      expect(await subjects('/project')).toEqual(['main-work', 'base']);
+      expect(await vfs.readTextFile('/project/main.txt')).toBe('main\n');
+    });
+
+    it('reports up to date when the upstream is already an ancestor', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/base.txt', 'base\n');
+      await git.execute(['add', 'base.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+
+      await git.execute(['checkout', '-b', 'feature'], '/project');
+      await vfs.writeFile('/project/x.txt', 'x\n');
+      await git.execute(['add', 'x.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-work'], '/project');
+
+      const result = await git.execute(['rebase', 'main'], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('up to date');
+    });
+
+    it('rejects rebasing a range that contains a merge commit', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/base.txt', 'base\n');
+      await git.execute(['add', 'base.txt'], '/project');
+      await git.execute(['commit', '-m', 'base'], '/project');
+      await git.execute(['branch', 'feature'], '/project');
+
+      await vfs.writeFile('/project/main.txt', 'main\n');
+      await git.execute(['add', 'main.txt'], '/project');
+      await git.execute(['commit', '-m', 'main-work'], '/project');
+
+      await git.execute(['checkout', 'feature'], '/project');
+      await vfs.writeFile('/project/feat.txt', 'feat\n');
+      await git.execute(['add', 'feat.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-work'], '/project');
+      await git.execute(['branch', 'side'], '/project');
+
+      await vfs.writeFile('/project/feat2.txt', 'feat2\n');
+      await git.execute(['add', 'feat2.txt'], '/project');
+      await git.execute(['commit', '-m', 'feat-2'], '/project');
+
+      await git.execute(['checkout', 'side'], '/project');
+      await vfs.writeFile('/project/side.txt', 'side\n');
+      await git.execute(['add', 'side.txt'], '/project');
+      await git.execute(['commit', '-m', 'side-work'], '/project');
+
+      await git.execute(['checkout', 'feature'], '/project');
+      const mergeResult = await git.execute(['merge', 'side'], '/project');
+      expect(mergeResult.exitCode).toBe(0);
+
+      const result = await git.execute(['rebase', 'main'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('is a merge');
+    });
+
+    it('rejects unsupported interactive rebase', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'content\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      const result = await git.execute(['rebase', '-i', 'main'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('not supported');
+    });
+
+    it('errors when --continue is run with no rebase in progress', async () => {
+      await git.execute(['init'], '/project');
+      await vfs.writeFile('/project/file.txt', 'content\n');
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+
+      const result = await git.execute(['rebase', '--continue'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('No rebase in progress');
+    });
+  });
 });
 
 // Regression for issue #507: git ops in a scoop sandbox failed because


### PR DESCRIPTION
Closes #1412.

## Summary

Implements `git rebase <upstream>` in the webapp git surface as a conflict-aware linear replay of `upstream..HEAD` onto the new base, reusing the `makeMergeDriver` helper + `threeWayMerge` primitive from the now-merged conflict-aware suite (#1415). isomorphic-git has no native `rebase`, so this is built in-repo on top of its native `cherryPick`.

## What changed

- **New module** `packages/webapp/src/git/commands/rebase.ts` (+ additive `case 'rebase'` and help line in `git-commands.ts`, and `GIT_FLAG_SPECS.rebase` in `commands/shared.ts`).
- **`git rebase <upstream>`** — computes the `upstream..HEAD` range and replays each commit oldest-first via the shared cherry-pick + merge-driver path. Fast-forward / already-based cases are handled without error.
- **Conflict handling** — stops on the first conflicting commit, writes `<<<<<<< / ======= / >>>>>>>` markers to the working tree, prints git-style status (`CONFLICT (content): …`, `error: could not apply …`, and the `git rebase --continue` hint), and exits 1.
- **State machine** — `--continue` / `--abort` / `--skip`, with state persisted under `.git/rebase-merge/` (onto, orig-head, remaining todo). `--abort` restores the original HEAD exactly; `--skip` drops the current commit; `--continue` commits the resolved state and resumes.
- **Rejections** — merge commits rejected (exit 128); interactive `-i` reported as unsupported.

## Verification

- `npm run lint` — clean, touched-file complexity gate OK
- `npm run typecheck` — 9/9 tsc projects pass
- `npm run test -w @slicc/webapp -- tests/git/` — 11 files / 310 tests pass
- `npm run build -w @slicc/webapp` — clean
- 9 new mirrored tests: clean linear replay, conflict + `--continue`, `--abort` restores original HEAD, `--skip`, fast-forward/up-to-date, merge-commit rejection

## Non-goals

- Interactive rebase (`-i`), `--onto`, `--rebase-merges`, autosquash, rebasing merge commits.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author