### PR TITLE
fix: boot resilience + pre-boot recovery screen for corrupt OPFS

### DIFF
--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -386,9 +386,22 @@ export class Orchestrator implements ConeApprovalRouter {
 
     log.info('Orchestrator initialized', { scoopCount: this.scoops.size });
 
-    // Initialize all scoop contexts
+    // Initialize all scoop contexts. A single scoop whose context fails to
+    // initialize — e.g. a corrupt/unreadable persisted VFS file surfacing a
+    // ZenFS "Unexpected mismatch in file data size" throw — must not abort the
+    // whole boot. Skip that one scoop with a warning and keep loading the rest
+    // so the app still reaches a ready state instead of the opaque 30s
+    // ready-timeout the caller would otherwise hit.
     for (const scoop of this.scoops.values()) {
-      await this.createScoopTab(scoop.jid);
+      try {
+        await this.createScoopTab(scoop.jid);
+      } catch (err) {
+        log.warn('Skipping scoop whose context failed to initialize during boot', {
+          jid: scoop.jid,
+          folder: scoop.folder,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     // Register session costs provider for the `cost` shell command

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -396,11 +396,22 @@ export class Orchestrator implements ConeApprovalRouter {
       try {
         await this.createScoopTab(scoop.jid);
       } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
         log.warn('Skipping scoop whose context failed to initialize during boot', {
           jid: scoop.jid,
           folder: scoop.folder,
-          error: err instanceof Error ? err.message : String(err),
+          isCone: scoop.isCone,
+          error: message,
         });
+        // Leave a NON-cone scoop in a retryable 'error' state so a later
+        // feed_scoop/lick triggers the existing `routeToScoop` retry-on-error
+        // path (and `drop_scoop` still works), instead of a silent no-tab
+        // entry that stays unusable until a full reset. A failed cone is
+        // effectively fatal — there is no usable cone to retry into — so keep
+        // skipping+logging it rather than surfacing a phantom error tab.
+        if (!scoop.isCone) {
+          this.lifecycle.markTabError(scoop.jid, message);
+        }
       }
     }
 

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -376,6 +376,25 @@ export class ScoopLifecycleManager {
     this.tabs.set(jid, tab);
   }
 
+  /**
+   * Mark a scoop's tab as errored without a live context. Used by the boot
+   * resilience path in `Orchestrator.init()`: a scoop whose context init threw
+   * (e.g. a corrupt persisted VFS file) is left with a `{ status: 'error' }`
+   * tab so the existing `routeToScoop` retry-on-error path can re-init it on a
+   * later `feed_scoop`/lick delivery, and `drop_scoop` still works — instead of
+   * a silent no-tab (or stuck `'initializing'`) entry that can never recover.
+   */
+  markTabError(jid: string, message: string): void {
+    const existing = this.tabs.get(jid);
+    this.tabs.set(jid, {
+      jid,
+      contextId: existing?.contextId ?? `scoop-error-${jid}`,
+      status: 'error',
+      error: message,
+      lastActivity: new Date().toISOString(),
+    });
+  }
+
   /** Public dispatch — used by `sendPrompt` to fan a status change to observers. */
   dispatchEvent<K extends keyof ScoopObserver>(
     jid: string,

--- a/packages/webapp/src/shell/supplemental-commands/nuke-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/nuke-command.ts
@@ -5,6 +5,7 @@ import {
   NUKE_LOCAL_STORAGE_KEYS,
   type NukeReloadMsg,
 } from './nuke-channel.js';
+import { wipeLocalStorageState } from './wipe-local-storage-state.js';
 
 // Re-export the channel-layer symbols so existing consumers (including
 // the test suite) keep their import paths working. New page-side
@@ -34,74 +35,22 @@ export function createNukeCommand(): Command {
 
     // Check for the secret launch code: args must contain '1234' when concatenated
     if (args.join('').includes('1234')) {
-      // Drop the service worker first — it keeps its own IDB
-      // connections open and will block deleteDatabase otherwise.
-      // Then await every delete BEFORE reloading: a half-finished
-      // delete that completes during the new page's `open()` aborts
-      // the upgrade with "Version change transaction was aborted in
-      // upgradeneeded event handler", leaving the user stranded on a
-      // "Failed to start" screen.
+      // Wipe all local state (SW + IDB + OPFS) via the shared helper,
+      // then forward the localStorage key list to the page-side listener
+      // before reloading. The wipe awaits every delete BEFORE reloading:
+      // a half-finished delete that completes during the new page's
+      // `open()` aborts the upgrade with "Version change transaction was
+      // aborted in upgradeneeded event handler", leaving the user
+      // stranded on a "Failed to start" screen.
+      //
+      // localStorage clears are intentionally NOT done inside the wipe
+      // in worker / offscreen contexts — they'd write to a per-context
+      // shim or an isolated MV3 storage and be lost. Instead we forward
+      // the key list to the page-side listener via
+      // `triggerReload(NUKE_LOCAL_STORAGE_KEYS)`, which removes them from
+      // the real `localStorage` before reloading.
       void (async () => {
-        try {
-          const regs = await navigator.serviceWorker?.getRegistrations?.();
-          if (regs) await Promise.all(regs.map((r) => r.unregister().catch(() => false)));
-        } catch {
-          /* ignore — best effort */
-        }
-        // localStorage clears are intentionally NOT done here in
-        // worker / offscreen contexts — they'd write to a per-context
-        // shim or an isolated MV3 storage and be lost. Instead we
-        // forward the key list to the page-side listener via
-        // `triggerReload(NUKE_LOCAL_STORAGE_KEYS)` below, which
-        // removes them from the real `localStorage` before reloading.
-        try {
-          const dbs = await indexedDB.databases();
-          await Promise.all(
-            dbs
-              .filter((db): db is { name: string; version?: number } => !!db.name)
-              .map(
-                (db) =>
-                  new Promise<void>((resolve) => {
-                    const req = indexedDB.deleteDatabase(db.name);
-                    // `onblocked` fires when another tab is holding a
-                    // connection — resolve anyway so we don't hang the
-                    // reload forever; the worst case is a single DB
-                    // surviving, which the user can fix with a
-                    // second nuke.
-                    req.onsuccess = () => resolve();
-                    req.onerror = () => resolve();
-                    req.onblocked = () => resolve();
-                  })
-              )
-          );
-        } catch {
-          /* indexedDB.databases unsupported on some browsers — fall through */
-        }
-
-        // Wipe the OPFS-backed VFS tree. Since the ZenFS/OPFS migration
-        // the bulk of local state (workspace files, scoops, mounts) lives
-        // in OPFS, not IndexedDB, so a nuke that only wipes IDB would
-        // leave the user's prior workspace on disk. Guard on
-        // `navigator.storage.getDirectory` (mirrors
-        // `resolveVfsBackendFromEnv`) so contexts without OPFS — older
-        // browsers, some test envs — fall through cleanly.
-        try {
-          const storage = (navigator as unknown as { storage?: StorageManager }).storage;
-          if (typeof storage?.getDirectory === 'function') {
-            const root = (await storage.getDirectory()) as unknown as {
-              keys: () => AsyncIterableIterator<string>;
-              removeEntry: (name: string, options?: { recursive: boolean }) => Promise<void>;
-            };
-            const names: string[] = [];
-            for await (const name of root.keys()) names.push(name);
-            await Promise.all(
-              names.map((name) => root.removeEntry(name, { recursive: true }).catch(() => {}))
-            );
-          }
-        } catch {
-          /* OPFS unavailable / blocked — best effort, never block reload */
-        }
-
+        await wipeLocalStorageState();
         triggerReload(NUKE_LOCAL_STORAGE_KEYS);
       })();
       return { stdout: 'Nuking everything…\n', stderr: '', exitCode: 0 };

--- a/packages/webapp/src/shell/supplemental-commands/wipe-local-storage-state.ts
+++ b/packages/webapp/src/shell/supplemental-commands/wipe-local-storage-state.ts
@@ -1,0 +1,97 @@
+/**
+ * `wipe-local-storage-state.ts` — the shared local-state wipe used by
+ * both the `nuke` shell command (`nuke-command.ts`) and the pre-boot
+ * recovery screen (`ui/main.ts`).
+ *
+ * Split out so the page-side recovery handler can import the wipe
+ * WITHOUT dragging in `nuke-command.ts`'s `defineCommand` import — which
+ * pulls the bundled `just-bash` browser entry (~800 kB of shell runtime)
+ * into the page bundle. Like `nuke-channel.ts`, everything here is
+ * intentionally shell-free: no `just-bash` import, no `Command` type, no
+ * shell context.
+ *
+ * The wipe is the single source of truth for "reset local data": every
+ * step is guarded/best-effort so a missing capability (older browser,
+ * blocked storage, some test env) never throws or blocks the caller's
+ * subsequent reload.
+ */
+
+/**
+ * Wipe every scrap of local browser state SLICC owns: unregister the
+ * service worker, delete every IndexedDB database, and remove every
+ * OPFS root entry. Best-effort and never rejects — callers reload
+ * afterwards regardless.
+ *
+ * Order matters: the service worker keeps its own IDB connections open
+ * and would block `deleteDatabase`, so it is dropped FIRST. Then every
+ * IDB delete is awaited BEFORE the caller reloads — a half-finished
+ * delete that completes during the new page's `open()` aborts the
+ * upgrade ("Version change transaction was aborted in upgradeneeded
+ * event handler"), leaving the user stranded on a "Failed to start"
+ * screen.
+ *
+ * `localStorage` clears are intentionally NOT done here: in worker /
+ * offscreen contexts they'd write to a per-context shim or an isolated
+ * MV3 storage and be lost. The `nuke` command forwards its key list to
+ * the page-side listener instead (see `nuke-channel.ts`); the recovery
+ * screen runs in the page and reloads immediately, so the boot flow
+ * re-derives from the now-empty OPFS/IDB.
+ */
+export async function wipeLocalStorageState(): Promise<void> {
+  // Drop the service worker first — it keeps its own IDB connections
+  // open and will block deleteDatabase otherwise.
+  try {
+    const regs = await navigator.serviceWorker?.getRegistrations?.();
+    if (regs) await Promise.all(regs.map((r) => r.unregister().catch(() => false)));
+  } catch {
+    /* ignore — best effort */
+  }
+
+  // Delete every IndexedDB database. Await each delete before returning
+  // so the caller's reload boots from a clean slate (see doc comment).
+  try {
+    const dbs = await indexedDB.databases();
+    await Promise.all(
+      dbs
+        .filter((db): db is { name: string; version?: number } => !!db.name)
+        .map(
+          (db) =>
+            new Promise<void>((resolve) => {
+              const req = indexedDB.deleteDatabase(db.name);
+              // `onblocked` fires when another tab is holding a
+              // connection — resolve anyway so we don't hang the
+              // reload forever; the worst case is a single DB
+              // surviving, which the user can fix with a second reset.
+              req.onsuccess = () => resolve();
+              req.onerror = () => resolve();
+              req.onblocked = () => resolve();
+            })
+        )
+    );
+  } catch {
+    /* indexedDB.databases unsupported on some browsers — fall through */
+  }
+
+  // Wipe the OPFS-backed VFS tree. Since the ZenFS/OPFS migration the
+  // bulk of local state (workspace files, scoops, mounts) lives in
+  // OPFS, not IndexedDB, so a reset that only wipes IDB would leave the
+  // user's prior workspace on disk. Guard on `navigator.storage
+  // .getDirectory` (mirrors `resolveVfsBackendFromEnv`) so contexts
+  // without OPFS — older browsers, some test envs — fall through cleanly.
+  try {
+    const storage = (navigator as unknown as { storage?: StorageManager }).storage;
+    if (typeof storage?.getDirectory === 'function') {
+      const root = (await storage.getDirectory()) as unknown as {
+        keys: () => AsyncIterableIterator<string>;
+        removeEntry: (name: string, options?: { recursive: boolean }) => Promise<void>;
+      };
+      const names: string[] = [];
+      for await (const name of root.keys()) names.push(name);
+      await Promise.all(
+        names.map((name) => root.removeEntry(name, { recursive: true }).catch(() => {}))
+      );
+    }
+  } catch {
+    /* OPFS unavailable / blocked — best effort, never block reload */
+  }
+}

--- a/packages/webapp/src/ui/boot/recovery-screen.ts
+++ b/packages/webapp/src/ui/boot/recovery-screen.ts
@@ -16,6 +16,7 @@
  * bundle.
  */
 
+import { NUKE_LOCAL_STORAGE_KEYS } from '../../shell/supplemental-commands/nuke-channel.js';
 import { wipeLocalStorageState } from '../../shell/supplemental-commands/wipe-local-storage-state.js';
 
 /** Injectable seams so the render test can assert wipe+reload without
@@ -85,6 +86,18 @@ export function renderBootRecoveryScreen(
         await wipe();
       } catch {
         /* wipe is best-effort (already guarded) — reload regardless */
+      }
+      // `wipeLocalStorageState` is localStorage-free by design (SW + IDB
+      // + OPFS only), so the page-local keys `nuke` clears would survive
+      // the reset and suppress onboarding / reuse stale tray config on
+      // the fresh boot. We run in the page realm, so remove them directly
+      // (guarded per-key, mirroring `installNukeReloadListener`).
+      for (const key of NUKE_LOCAL_STORAGE_KEYS) {
+        try {
+          localStorage.removeItem(key);
+        } catch {
+          /* localStorage disabled — ignore */
+        }
       }
       reload();
     })();

--- a/packages/webapp/src/ui/boot/recovery-screen.ts
+++ b/packages/webapp/src/ui/boot/recovery-screen.ts
@@ -1,0 +1,102 @@
+/**
+ * `recovery-screen.ts` — the pre-boot recovery surface rendered by
+ * `main().catch()` when the shell never booted (kernel-worker boot
+ * timeout, a fatal error in the boot path, etc.).
+ *
+ * Replaces the old dead-end "Failed to start" screen: as well as the
+ * error message it offers a "Reset local data & reload" button that runs
+ * the same wipe as `nuke` (all OPFS root entries + every IndexedDB DB +
+ * SW unregister) and a plain "Reload" retry. Both are reachable even
+ * when the shell never booted, so a user whose local state is corrupt
+ * can recover without DevTools.
+ *
+ * Rendered with `createElement`/`textContent` (never `innerHTML`) so a
+ * boot error message can't inject markup. The wipe imports the shared,
+ * shell-free `wipeLocalStorageState` helper — no `just-bash` in the page
+ * bundle.
+ */
+
+import { wipeLocalStorageState } from '../../shell/supplemental-commands/wipe-local-storage-state.js';
+
+/** Injectable seams so the render test can assert wipe+reload without
+ *  touching real OPFS/IDB or navigating the test page. */
+export interface RecoveryScreenDeps {
+  /** Wipe local state. Defaults to the shared `wipeLocalStorageState`. */
+  wipe?: () => Promise<void>;
+  /** Reload the page. Defaults to `location.reload()`. */
+  reload?: () => void;
+}
+
+/**
+ * Render the recovery screen into `app`, replacing its contents. Shows
+ * the boot error message plus two buttons:
+ *   - "Reset local data & reload" — awaits {@link RecoveryScreenDeps.wipe}
+ *     then reloads. Requires an explicit click; there is no auto-wipe.
+ *   - "Reload" — a plain retry that just reloads.
+ */
+export function renderBootRecoveryScreen(
+  app: HTMLElement,
+  error: unknown,
+  deps: RecoveryScreenDeps = {}
+): void {
+  const wipe = deps.wipe ?? wipeLocalStorageState;
+  const reload = deps.reload ?? (() => location.reload());
+  const message = error instanceof Error ? error.message : String(error);
+
+  const box = document.createElement('div');
+  box.style.cssText = 'padding:2rem;text-align:center;font-family:system-ui;';
+
+  const h1 = document.createElement('h1');
+  h1.style.color = 'var(--s2-negative, #e34850)';
+  h1.textContent = 'Failed to start';
+
+  const p = document.createElement('p');
+  p.style.color = 'var(--s2-content-tertiary, #717171)';
+  p.textContent = message;
+
+  const actions = document.createElement('div');
+  actions.style.cssText =
+    'display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap;margin-top:1.5rem;';
+
+  const resetBtn = document.createElement('button');
+  resetBtn.type = 'button';
+  resetBtn.textContent = 'Reset local data & reload';
+  resetBtn.style.cssText =
+    'padding:0.5rem 1rem;cursor:pointer;border:1px solid var(--s2-negative, #e34850);' +
+    'background:var(--s2-negative, #e34850);color:#fff;border-radius:4px;';
+
+  const reloadBtn = document.createElement('button');
+  reloadBtn.type = 'button';
+  reloadBtn.textContent = 'Reload';
+  reloadBtn.style.cssText =
+    'padding:0.5rem 1rem;cursor:pointer;border:1px solid var(--s2-content-tertiary, #717171);' +
+    'background:transparent;color:inherit;border-radius:4px;';
+
+  // Explicit click is the confirmation — no auto-wipe. Disable both
+  // buttons while the wipe runs so a double-click can't fire it twice,
+  // then reload from the now-clean slate. Best-effort: even if the wipe
+  // rejects (it shouldn't — it's guarded) we still reload.
+  resetBtn.addEventListener('click', () => {
+    resetBtn.disabled = true;
+    reloadBtn.disabled = true;
+    resetBtn.textContent = 'Resetting…';
+    void (async () => {
+      try {
+        await wipe();
+      } catch {
+        /* wipe is best-effort (already guarded) — reload regardless */
+      }
+      reload();
+    })();
+  });
+
+  reloadBtn.addEventListener('click', () => {
+    reload();
+  });
+
+  actions.append(resetBtn, reloadBtn);
+  box.append(h1, p, actions);
+
+  while (app.firstChild) app.removeChild(app.firstChild);
+  app.appendChild(box);
+}

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -23,6 +23,7 @@ import { hasChromeRuntimeConnect, isExtensionRealm } from '../core/runtime-env.j
 // — the extension agent engine runs in the offscreen document, not in this file.
 import { registerProviders } from '../providers/index.js';
 import { parseBridgeLaunchParams } from './boot/bridge-launch-params.js';
+import { renderBootRecoveryScreen } from './boot/recovery-screen.js';
 import { installExtensionFetchDelegate } from './boot/setup-extension-fetch-delegate.js';
 import { startFreezeWatchdog } from './boot/setup-freeze-watchdog.js';
 import { setupNukeReloadListener } from './boot/setup-nuke-reload-listener.js';
@@ -166,19 +167,8 @@ async function main(): Promise<void> {
 main().catch((err) => {
   log.error('Fatal error', err);
   const app = document.getElementById('app');
-  if (app) {
-    const errorDiv = document.createElement('div');
-    errorDiv.style.cssText = 'padding: 2rem; text-align: center;';
-    const h1 = document.createElement('h1');
-    h1.style.color = 'var(--s2-negative, #e34850)';
-    h1.textContent = 'Failed to start';
-    const p = document.createElement('p');
-    p.style.color = 'var(--s2-content-tertiary, #717171)';
-    p.textContent = err.message;
-    errorDiv.appendChild(h1);
-    errorDiv.appendChild(p);
-
-    while (app.firstChild) app.removeChild(app.firstChild);
-    app.appendChild(errorDiv);
-  }
+  // Render the recovery screen — the error message plus a one-click
+  // "Reset local data & reload" (same wipe as `nuke`) and a plain
+  // "Reload" retry — reachable even when the shell never booted.
+  if (app) renderBootRecoveryScreen(app, err);
 });

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -3741,6 +3741,7 @@ describe('Orchestrator boot resilience to a corrupt scoop file', () => {
         lifecycle: {
           createTab(jid: string): Promise<void>;
           getContext(jid: string): unknown;
+          getTab(jid: string): { status: string; error?: string } | undefined;
         };
       }
     ).lifecycle;
@@ -3761,6 +3762,14 @@ describe('Orchestrator boot resilience to a corrupt scoop file', () => {
     expect(lifecycle.getContext(cone.jid)).toBeDefined();
     // ...while the corrupt one was skipped (no context registered).
     expect(lifecycle.getContext(corruptScoop.jid)).toBeUndefined();
+
+    // ...but it is left in a retryable 'error' tab state (NOT a silent no-tab
+    // entry) so a later feed_scoop/lick triggers `routeToScoop`'s
+    // retry-on-error path and `drop_scoop` still works.
+    const corruptTab = lifecycle.getTab(corruptScoop.jid);
+    expect(corruptTab).toBeDefined();
+    expect(corruptTab!.status).toBe('error');
+    expect(corruptTab!.error).toBe(sizeMismatch.message);
 
     // The skip logged a clear warning naming the scoop + underlying error.
     const skipCall = warnSpy.mock.calls.find(

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -3641,3 +3641,138 @@ describe('Orchestrator upgrade-lick actionable resolution', () => {
     expect(after?.lickState).toBe('dismissed');
   });
 });
+
+/**
+ * Boot resilience: a single corrupt/unreadable persisted VFS file must not
+ * abort the whole boot. The per-scoop context-init loop in `Orchestrator.init()`
+ * catches a throw (e.g. the ZenFS "Unexpected mismatch in file data size"),
+ * logs a warning naming the scoop, skips it, and keeps loading the rest — so
+ * the app still reaches a ready state instead of the opaque 30s ready-timeout.
+ */
+describe('Orchestrator boot resilience to a corrupt scoop file', () => {
+  let orch: Orchestrator;
+  let priorWindow: unknown;
+  let windowWasShimmed = false;
+
+  beforeAll(() => {
+    if (typeof (globalThis as any).window === 'undefined') {
+      priorWindow = (globalThis as any).window;
+      (globalThis as any).window = globalThis;
+      windowWasShimmed = true;
+    }
+  });
+
+  afterAll(() => {
+    if (windowWasShimmed) {
+      if (priorWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = priorWindow;
+      }
+    }
+  });
+
+  beforeEach(async () => {
+    await initDB();
+    const existing = await getAllScoops();
+    const { deleteScoop } = await import('../../src/scoops/db.js');
+    for (const jid of Object.keys(existing)) {
+      await deleteScoop(jid);
+    }
+  });
+
+  afterEach(async () => {
+    const sharedFs = orch?.getSharedFS();
+    await orch?.shutdown();
+    await settleAndDisposeSharedFs(sharedFs);
+    vi.restoreAllMocks();
+  });
+
+  function noopCallbacks() {
+    return {
+      onResponse: vi.fn(),
+      onResponseDone: vi.fn(),
+      onSendMessage: vi.fn(),
+      onStatusChange: vi.fn(),
+      onError: vi.fn(),
+      getBrowserAPI: vi.fn(() => ({}) as any),
+    };
+  }
+
+  it('skips a scoop whose context init throws a size-mismatch and still loads the rest', async () => {
+    const corruptScoop: RegisteredScoop = {
+      jid: 'scoop_corrupt_boot_1',
+      name: 'corrupt-boot',
+      folder: 'corrupt-boot-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'corrupt-boot-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    const healthyScoop: RegisteredScoop = {
+      jid: 'scoop_healthy_boot_1',
+      name: 'healthy-boot',
+      folder: 'healthy-boot-scoop',
+      isCone: false,
+      type: 'scoop',
+      requiresTrigger: false,
+      assistantLabel: 'healthy-boot-scoop',
+      addedAt: new Date().toISOString(),
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    };
+    await saveScoop(cone);
+    await saveScoop(corruptScoop);
+    await saveScoop(healthyScoop);
+
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(container, noopCallbacks());
+
+    // Simulate the corrupt-file throw for exactly one scoop's context init,
+    // mirroring the ZenFS "Unexpected mismatch in file data size" surfaced when
+    // a single persisted file is unreadable. Every other scoop (incl. the cone)
+    // takes the real createTab path.
+    const lifecycle = (
+      orch as unknown as {
+        lifecycle: {
+          createTab(jid: string): Promise<void>;
+          getContext(jid: string): unknown;
+        };
+      }
+    ).lifecycle;
+    const realCreateTab = lifecycle.createTab.bind(lifecycle);
+    const sizeMismatch = new Error('Unexpected mismatch in file data size');
+    vi.spyOn(lifecycle, 'createTab').mockImplementation(async (jid: string) => {
+      if (jid === corruptScoop.jid) throw sizeMismatch;
+      return realCreateTab(jid);
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Boot must complete despite the corrupt scoop.
+    await expect(orch.init()).resolves.toBeUndefined();
+
+    // The healthy scoop + cone still loaded their contexts...
+    expect(lifecycle.getContext(healthyScoop.jid)).toBeDefined();
+    expect(lifecycle.getContext(cone.jid)).toBeDefined();
+    // ...while the corrupt one was skipped (no context registered).
+    expect(lifecycle.getContext(corruptScoop.jid)).toBeUndefined();
+
+    // The skip logged a clear warning naming the scoop + underlying error.
+    const skipCall = warnSpy.mock.calls.find(
+      (call) =>
+        typeof call[1] === 'string' &&
+        call[1].includes('Skipping scoop whose context failed to initialize during boot')
+    );
+    expect(skipCall).toBeDefined();
+    expect(skipCall![2]).toMatchObject({
+      jid: corruptScoop.jid,
+      folder: corruptScoop.folder,
+      error: sizeMismatch.message,
+    });
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/wipe-local-storage-state.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/wipe-local-storage-state.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { wipeLocalStorageState } from '../../../src/shell/supplemental-commands/wipe-local-storage-state.js';
+
+describe('wipeLocalStorageState', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('unregisters service workers, deletes every IDB, and removes every OPFS root entry', async () => {
+    const unregister = vi.fn(async () => true);
+    const getRegistrations = vi.fn(async () => [{ unregister }, { unregister }]);
+
+    const deleted: string[] = [];
+    const deleteDatabase = vi.fn((name: string) => {
+      deleted.push(name);
+      const req: {
+        onsuccess: (() => void) | null;
+        onerror: (() => void) | null;
+        onblocked: (() => void) | null;
+      } = {
+        onsuccess: null,
+        onerror: null,
+        onblocked: null,
+      };
+      // Resolve asynchronously like the real API.
+      queueMicrotask(() => req.onsuccess?.());
+      return req;
+    });
+    vi.stubGlobal('indexedDB', {
+      databases: async () => [
+        { name: 'slicc-fs' },
+        { name: 'agent-sessions' },
+        { name: undefined },
+      ],
+      deleteDatabase,
+    });
+
+    const removeEntry = vi.fn(async (_name: string, _opts?: { recursive: boolean }) => undefined);
+    const entries = ['slicc-fs', 'slicc-fs-global', 'leftover-mount'];
+    async function* keys(): AsyncIterableIterator<string> {
+      for (const name of entries) yield name;
+    }
+    vi.stubGlobal('navigator', {
+      serviceWorker: { getRegistrations },
+      storage: { getDirectory: async () => ({ keys, removeEntry }) },
+    });
+
+    await wipeLocalStorageState();
+
+    expect(getRegistrations).toHaveBeenCalledTimes(1);
+    expect(unregister).toHaveBeenCalledTimes(2);
+
+    // The `undefined`-named db is skipped; the two named ones are deleted.
+    expect(deleted).toEqual(['slicc-fs', 'agent-sessions']);
+
+    expect(removeEntry).toHaveBeenCalledTimes(entries.length);
+    for (const name of entries) {
+      expect(removeEntry).toHaveBeenCalledWith(name, { recursive: true });
+    }
+  });
+
+  it('resolves cleanly when OPFS is unavailable', async () => {
+    vi.stubGlobal('indexedDB', { databases: async () => [], deleteDatabase: vi.fn() });
+    vi.stubGlobal('navigator', {
+      serviceWorker: { getRegistrations: async () => [] },
+      storage: {},
+    });
+
+    await expect(wipeLocalStorageState()).resolves.toBeUndefined();
+  });
+
+  it('never rejects when a step throws (best-effort)', async () => {
+    vi.stubGlobal('indexedDB', {
+      databases: async () => {
+        throw new Error('databases unsupported');
+      },
+      deleteDatabase: vi.fn(),
+    });
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        getRegistrations: async () => {
+          throw new Error('no sw');
+        },
+      },
+      storage: {
+        getDirectory: async () => {
+          throw new Error('opfs blocked');
+        },
+      },
+    });
+
+    await expect(wipeLocalStorageState()).resolves.toBeUndefined();
+  });
+});

--- a/packages/webapp/tests/ui/boot/recovery-screen.test.ts
+++ b/packages/webapp/tests/ui/boot/recovery-screen.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderBootRecoveryScreen } from '../../../src/ui/boot/recovery-screen.js';
+
+describe('renderBootRecoveryScreen', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  function mount(): HTMLElement {
+    const app = document.createElement('div');
+    // Seed prior content to prove the screen replaces it.
+    app.appendChild(document.createElement('span'));
+    document.body.appendChild(app);
+    return app;
+  }
+
+  function buttonByText(app: HTMLElement, text: string): HTMLButtonElement {
+    const btn = [...app.querySelectorAll('button')].find((b) => b.textContent === text);
+    expect(btn, `button "${text}" present`).toBeTruthy();
+    return btn as HTMLButtonElement;
+  }
+
+  it('shows the error message and both recovery buttons', () => {
+    const app = mount();
+    renderBootRecoveryScreen(app, new Error('kernel boot timed out'), {
+      wipe: vi.fn(async () => {}),
+      reload: vi.fn(),
+    });
+
+    expect(app.querySelector('h1')?.textContent).toBe('Failed to start');
+    expect(app.querySelector('p')?.textContent).toBe('kernel boot timed out');
+    buttonByText(app, 'Reset local data & reload');
+    buttonByText(app, 'Reload');
+    // Prior content was replaced.
+    expect(app.querySelector('span')).toBeNull();
+  });
+
+  it('renders a non-Error argument via String()', () => {
+    const app = mount();
+    renderBootRecoveryScreen(app, 'plain string failure', { wipe: vi.fn(), reload: vi.fn() });
+    expect(app.querySelector('p')?.textContent).toBe('plain string failure');
+  });
+
+  it('reset button invokes the wipe then reloads', async () => {
+    const app = mount();
+    let wipeResolved = false;
+    const wipe = vi.fn(async () => {
+      await Promise.resolve();
+      wipeResolved = true;
+    });
+    const reload = vi.fn();
+    renderBootRecoveryScreen(app, new Error('boom'), { wipe, reload });
+
+    const resetBtn = buttonByText(app, 'Reset local data & reload');
+    resetBtn.click();
+
+    // Buttons disabled immediately; reload waits for the wipe.
+    expect(resetBtn.disabled).toBe(true);
+    expect(buttonByText(app, 'Reload').disabled).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(wipe).toHaveBeenCalledTimes(1);
+    expect(wipeResolved).toBe(true);
+  });
+
+  it('reset button still reloads if the wipe rejects', async () => {
+    const app = mount();
+    const wipe = vi.fn(async () => {
+      throw new Error('wipe failed');
+    });
+    const reload = vi.fn();
+    renderBootRecoveryScreen(app, new Error('boom'), { wipe, reload });
+
+    buttonByText(app, 'Reset local data & reload').click();
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+  });
+
+  it('plain Reload button reloads without wiping', () => {
+    const app = mount();
+    const wipe = vi.fn(async () => {});
+    const reload = vi.fn();
+    renderBootRecoveryScreen(app, new Error('boom'), { wipe, reload });
+
+    buttonByText(app, 'Reload').click();
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(wipe).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webapp/tests/ui/boot/recovery-screen.test.ts
+++ b/packages/webapp/tests/ui/boot/recovery-screen.test.ts
@@ -1,12 +1,27 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NUKE_LOCAL_STORAGE_KEYS } from '../../../src/shell/supplemental-commands/nuke-channel.js';
 import { renderBootRecoveryScreen } from '../../../src/ui/boot/recovery-screen.js';
 
 describe('renderBootRecoveryScreen', () => {
   afterEach(() => {
     document.body.replaceChildren();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
+
+  /** Map-backed `localStorage` stub — the test env has no real one
+   *  (jsdom here is built without `--localstorage-file`). */
+  function stubLocalStorage(seed: Record<string, string> = {}): Map<string, string> {
+    const store = new Map<string, string>(Object.entries(seed));
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+    });
+    return store;
+  }
 
   function mount(): HTMLElement {
     const app = document.createElement('div');
@@ -64,6 +79,48 @@ describe('renderBootRecoveryScreen', () => {
     await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
     expect(wipe).toHaveBeenCalledTimes(1);
     expect(wipeResolved).toBe(true);
+  });
+
+  it('reset button removes every nuke localStorage key after the wipe, before reload', async () => {
+    const app = mount();
+    const seed = Object.fromEntries(
+      [...NUKE_LOCAL_STORAGE_KEYS, 'slicc.keepMe'].map((k) => [k, 'v'])
+    );
+    const store = stubLocalStorage(seed);
+
+    const wipe = vi.fn(async () => {
+      await Promise.resolve();
+      // Keys must still be present until the wipe completes.
+      for (const key of NUKE_LOCAL_STORAGE_KEYS) expect(store.has(key)).toBe(true);
+    });
+    let keysGoneAtReload = false;
+    const reload = vi.fn(() => {
+      // Removal must have happened before reload fires.
+      keysGoneAtReload = NUKE_LOCAL_STORAGE_KEYS.every((key) => !store.has(key));
+    });
+    renderBootRecoveryScreen(app, new Error('boom'), { wipe, reload });
+
+    buttonByText(app, 'Reset local data & reload').click();
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+
+    for (const key of NUKE_LOCAL_STORAGE_KEYS) expect(store.has(key)).toBe(false);
+    expect(keysGoneAtReload).toBe(true);
+    // Unrelated keys are left untouched.
+    expect(store.get('slicc.keepMe')).toBe('v');
+  });
+
+  it('reset button still reloads if localStorage.removeItem throws', async () => {
+    const app = mount();
+    const removeItem = vi.fn(() => {
+      throw new Error('localStorage disabled');
+    });
+    vi.stubGlobal('localStorage', { removeItem });
+    const reload = vi.fn();
+    renderBootRecoveryScreen(app, new Error('boom'), { wipe: vi.fn(async () => {}), reload });
+
+    buttonByText(app, 'Reset local data & reload').click();
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(removeItem).toHaveBeenCalledTimes(NUKE_LOCAL_STORAGE_KEYS.length);
   });
 
   it('reset button still reloads if the wipe rejects', async () => {


### PR DESCRIPTION
## Problem

A corrupt file in the OPFS-backed VirtualFS (a ZenFS `Unexpected mismatch in file data size` integrity error on persisted files like `/tmp/probe.txt` or `/scoops/*/etc/sudoers`) threw during kernel-worker `boot()`, so `kernel-worker-ready` was never posted and `spawn.ts` rejected after 30s. The user was stranded on a dead-end **"Failed to start / Kernel worker did not signal ready within 30000ms"** screen with no recovery path — the in-app `nuke` reset needs a booted shell, which doesn't exist when boot fails. Chrome's "Clear site data" does not reliably wipe OPFS, so the corruption survived reloads.

## Changes

**1. Boot resilience — tolerate a single corrupt VFS file** (`c90b611d1`)
- `Orchestrator.init()` now wraps the per-scoop `createScoopTab` restore loop in try/catch: a single unreadable/corrupt file is caught, logged (`log.warn` with jid/folder/error), and that one scoop is skipped — boot continues instead of aborting into the opaque 30s timeout.
- Other boot read paths (`SudoManager`, `ConeMemoryStore`, `ScoopContext.loadMemories`/`restoreSession`) were already guarded.
- Happy path unchanged. Regression test added in `tests/scoops/orchestrator.test.ts`.

**2. Pre-boot recovery screen with one-click reset** (`8ed2e9cbc`)
- Extracted the `nuke` wipe (SW unregister + IndexedDB delete-all + OPFS root wipe) into a shared, shell-free `wipeLocalStorageState()` helper (no imports → page-bundle safe, fully guarded/best-effort). `nuke-command.ts` refactored to call it as the single source of truth (no behavior change).
- `main().catch()` now renders `renderBootRecoveryScreen` (createElement/textContent, no innerHTML): shows the error, a **"Reset local data & reload"** button (explicit click, no auto-wipe), and a plain **"Reload"** retry — so the reset is reachable even when the shell never booted.
- Cross-runtime parity: follower path (`wc-follower.ts`) is N/A (the leader owns OPFS boot).

## Verification

- `npm run lint` PASS
- `npm run typecheck` PASS (9 projects)
- `npm run test -w @slicc/webapp` PASS (8694 passed / 30 skipped / 0 failed)
- `npm run build -w @slicc/webapp` PASS

Existing nuke test `recursively removes every OPFS root entry on the launch-code path` still passes against the extracted helper.

## Non-goals

- Investigating *why* the sudoers/probe writes produce size>data mismatches (separate follow-up).
- Follower/cherry/extension boot-error surfaces beyond the leader `main().catch()` path.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author