### PR TITLE
docs: add follower-wiring-parity + origin-routing categories to review-patterns

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,6 +48,20 @@ New `src/` files need mirrored `tests/` files; changed logic needs updated tests
 need a regression test. CI enforces per-package coverage floors — a drop below the floor fails
 the build.
 
+## 7. Follower surface wiring parity (often Critical)
+
+Every leader broadcast (`LeaderToFollowerMessage` / `broadcast*` in `tray-leader-sync.ts`)
+needs a matching follower handler in `tray-follower-sync.ts` AND a UI action wired in
+`wc-follower.ts`. New interactive elements on leader surfaces need follower counterparts.
+Check all three boot paths (`mountWcUiLive` / `mountWcUiFollower` / `mountWcUiExtension`).
+The largest empirical failure class (~30–40 commits since 2026-03).
+
+## 8. Origin / bridge routing contract (often Major)
+
+In thin-bridge mode the UI runs on the hosted origin while `/api/` lives on the local
+bridge. Flag `fetch('/api/...')` that assumes same-origin, hard-coded origin strings, and
+origin comparisons without trailing-slash normalization. 15 call-site fixes across ~9 PRs.
+
 ## Severity
 
 🔴 Critical = likely production issue · 🟡 Major = bites in a specific scenario ·

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,17 +267,17 @@ Run the full pre-push/PR pass — `lint` (always first; the most common CI failu
 
 ## Automated PR Review Checklist
 
-Automated reviewers — the Claude action (`.github/workflows/claude-pr-review.yml`), Codex (via `AGENTS.md` → this file), and Copilot (`.github/copilot-instructions.md`) — plus human reviewers check changed code against these recurring blind spots. Full catalog with trigger patterns, verified historical precedents, the five-runtime parity matrix, and the severity rubric: [`docs/review-patterns.md`](docs/review-patterns.md).
+Automated reviewers (Claude action, Codex via `AGENTS.md`, Copilot via `.github/copilot-instructions.md`) and humans check PRs against these blind spots. Full catalog: [`docs/review-patterns.md`](docs/review-patterns.md).
 
-1. **Error-path coverage** — external calls need timeouts/retries/`.catch`; bound every async operation (PR #779).
-2. **UI state preservation** — capture and restore live UI state around DOM rebuilds (PR #566/#567).
-3. **Cross-runtime parity** — changes to one runtime usually need peers updated or an explicit "N/A" note (PR #565; see the parity matrix).
-4. **CDP edge cases** — foreground before screenshots; validate CDP target/port (PR #361, #673).
-5. **Native/macOS permissions** — keychain/TCC/screen-recording need entitlements and graceful denial handling.
-6. **Model metadata / provider pipeline** — new models or pi-ai bumps: verify metadata forwarding, version predicates, thinking levels, and costs; see `docs/pitfalls.md` checklist (PR #1399).
-7. **Test coverage** — source changes ship with mirrored `tests/`; bug fixes ship a regression test; keep coverage at/above the floor.
-8. **Follower surface wiring parity** — every leader broadcast needs a matching follower handler _and_ UI action; check all three boot paths (PRs #1286, #1283, #1261).
-9. **Origin / bridge routing contract** — `fetch('/api/...')` and origin comparisons must work in thin-bridge mode (hosted UI → local bridge); normalize trailing slashes (PRs #1227–#1243, #1283).
-10. **Agent skill freshness** — shell command changes must update the matching `vfs-root/workspace/skills/*/SKILL.md`.
+1. **Error-path coverage** — timeouts/retries/`.catch` on external calls (PR #779).
+2. **UI state preservation** — capture+restore UI state around DOM rebuilds (PR #566/#567).
+3. **Cross-runtime parity** — peer runtimes updated or explicitly excluded (PR #565).
+4. **CDP edge cases** — foreground before screenshots; validate target/port (PR #361, #673).
+5. **Native/macOS permissions** — entitlements + TCC check + graceful denial.
+6. **Model metadata / provider pipeline** — verify metadata forwarding, version predicates, thinking levels, costs (PR #1399; see `docs/pitfalls.md`).
+7. **Test coverage** — mirrored `tests/`; bug fixes ship regression tests; stay above floor.
+8. **Follower wiring parity** — leader broadcasts need matching follower handler + UI action; check all boot paths (PRs #1286, #1283, #1261).
+9. **Origin/bridge routing** — `fetch('/api/...')` must work in thin-bridge mode; normalize trailing slashes (PRs #1227–#1243, #1283).
+10. **Agent skill freshness** — shell command changes → update matching `vfs-root/workspace/skills/*/SKILL.md`.
 
 When you change a category, update `docs/review-patterns.md` (source of truth) and the ≤4,000-char `.github/copilot-instructions.md` so all reviewers stay in sync.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,8 @@ Automated reviewers — the Claude action (`.github/workflows/claude-pr-review.y
 5. **Native/macOS permissions** — keychain/TCC/screen-recording need entitlements and graceful denial handling.
 6. **Model metadata / provider pipeline** — new models or pi-ai bumps: verify metadata forwarding, version predicates, thinking levels, and costs; see `docs/pitfalls.md` checklist (PR #1399).
 7. **Test coverage** — source changes ship with mirrored `tests/`; bug fixes ship a regression test; keep coverage at/above the floor.
-8. **Agent skill freshness** — shell command changes must update the matching `vfs-root/workspace/skills/*/SKILL.md`.
+8. **Follower surface wiring parity** — every leader broadcast needs a matching follower handler _and_ UI action; check all three boot paths (PRs #1286, #1283, #1261).
+9. **Origin / bridge routing contract** — `fetch('/api/...')` and origin comparisons must work in thin-bridge mode (hosted UI → local bridge); normalize trailing slashes (PRs #1227–#1243, #1283).
+10. **Agent skill freshness** — shell command changes must update the matching `vfs-root/workspace/skills/*/SKILL.md`.
 
 When you change a category, update `docs/review-patterns.md` (source of truth) and the ≤4,000-char `.github/copilot-instructions.md` so all reviewers stay in sync.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -45,7 +45,7 @@ Subsystems:
 Review & gotchas:
 
 - `pitfalls.md` — runtime and extension gotchas (CSP, dual-mode runtime detection, WASM heap views, etc.)
-- `review-patterns.md` — source of truth for the automated PR reviewers (Claude action, Codex, Copilot): the six recurring blind-spot categories, the five-runtime parity matrix, and the severity rubric
+- `review-patterns.md` — source of truth for the automated PR reviewers (Claude action, Codex, Copilot): the nine recurring blind-spot categories, the five-runtime parity matrix, and the severity rubric
 
 Other:
 

--- a/docs/review-patterns.md
+++ b/docs/review-patterns.md
@@ -42,6 +42,17 @@ iOS). The **cloud / hosted-leader** float reuses `node-server` (`--hosted`), so 
 changes usually carry into cloud automatically; **Cherry** is the webapp under `?cherry=1`,
 so it inherits browser behavior.
 
+### Intra-webapp parity axes
+
+The five-runtime matrix above covers inter-package boundaries. Inside `packages/webapp/`
+there are additional parity boundaries where bugs hide:
+
+| Boundary | Left side | Right side | Risk if unmatched |
+| --- | --- | --- | --- |
+| Page realm ↔ kernel worker realm | Code with `window` / DOM access | `DedicatedWorkerGlobalScope` (no `window`) | Accidental `window` refs crash the worker; `RTCDataChannel` cannot cross the boundary (PR #667 — full revert) |
+| Leader role ↔ follower role | `tray-leader-sync.ts`, leader UI surfaces | `tray-follower-sync.ts`, `wc-follower.ts` | A new broadcast with no follower handler silently no-ops (category 8 below) |
+| Boot paths | `mountWcUiLive` / `mountWcUiFollower` / `mountWcUiExtension` | Each other | A fix on one boot path may leave the others broken (PR #1261 — fix on non-primary path caused 5s pill-reset regression) |
+
 ## Detection categories
 
 ### 1. Error-path coverage gaps
@@ -174,6 +185,61 @@ fails. Tests live in `packages/*/tests/`, mirrored by subsystem (see
 
 **Remediation** — add unit tests for new paths, update tests for changed behavior, add a
 regression test for each bug fix, and keep coverage at or above the package floor.
+
+### 8. Follower surface wiring parity
+
+**Trigger patterns**
+
+- A new or changed `LeaderToFollowerMessage` variant or `broadcast*` call in
+  `packages/webapp/src/scoops/tray-leader-sync.ts`.
+- A new interactive element (button, action card, selectable list) added to a leader-side
+  UI surface.
+- A new follower-side handler in `tray-follower-sync.ts` with no corresponding UI action
+  wired in `ui/wc/wc-follower.ts` (or vice versa).
+
+**Historical precedents**
+
+- **PR #1286**: the follower scoop list rendered correctly but clicking a scoop did
+  nothing — the `scoops.select` sender was missing from the follower UI.
+- **PR #1283**: tool-approval cards were broadcast to followers but the Approve / Deny
+  buttons had no action handler, so clicking them silently no-oped.
+- **PR #1261**: a fix landed on the non-primary boot path first, then caused a 5-second
+  pill-reset regression that had to be fixed the next day.
+
+**Class size** — ~30–40 commits since 2026-03; the largest empirical failure class in the
+repo.
+
+**Remediation** — for every leader broadcast, verify the matching follower handler exists
+_and_ that the UI surface wires the user action back to the leader. Check all three boot
+paths (`mountWcUiLive` / `mountWcUiFollower` / `mountWcUiExtension`). Record the iOS
+mirror decision in the corpus (`packages/ios-app/`).
+
+### 9. Origin / bridge routing contract
+
+**Trigger patterns**
+
+- `fetch('/api/...')` or any absolute-vs-relative URL construction in webapp or extension
+  code.
+- Origin comparisons (`===`, `.startsWith()`, `new URL(...).origin`) that may not account
+  for trailing slashes.
+- Hard-coded origin strings (e.g. `'https://www.sliccy.ai'`) instead of the canonical
+  accessor.
+
+**Historical precedents**
+
+- **PRs #1227 / #1229**: `SANDBOX_NOT_READY` errors because the hosted UI origin issued
+  relative `/api/` fetches that hit the hosted server instead of the local bridge.
+- **PRs #1235 → #1236 → #1238**: a mixed-content chase — three consecutive PRs to fix
+  HTTP-vs-HTTPS mismatches between the hosted origin and the local bridge.
+- **PR #1243**: the same origin fix had to be applied twice.
+- **PR #1283**: a trailing-slash mismatch caused a silent allowlist failure.
+
+**Class size** — 15 call-site fixes across ~9 PRs in the Jun–Jul 2026 thin-bridge tail.
+
+**Remediation** — use the canonical origin / bridge-URL accessors rather than constructing
+URLs by hand. Verify the call works when the UI origin is the hosted origin and the API is
+the local bridge (thin-bridge mode). Normalize trailing slashes before comparing origins.
+Test in both CLI and extension floats.
 
 ## Severity rubric
 

--- a/docs/review-patterns.md
+++ b/docs/review-patterns.md
@@ -47,11 +47,11 @@ so it inherits browser behavior.
 The five-runtime matrix above covers inter-package boundaries. Inside `packages/webapp/`
 there are additional parity boundaries where bugs hide:
 
-| Boundary | Left side | Right side | Risk if unmatched |
-| --- | --- | --- | --- |
-| Page realm ↔ kernel worker realm | Code with `window` / DOM access | `DedicatedWorkerGlobalScope` (no `window`) | Accidental `window` refs crash the worker; `RTCDataChannel` cannot cross the boundary (PR #667 — full revert) |
-| Leader role ↔ follower role | `tray-leader-sync.ts`, leader UI surfaces | `tray-follower-sync.ts`, `wc-follower.ts` | A new broadcast with no follower handler silently no-ops (category 8 below) |
-| Boot paths | `mountWcUiLive` / `mountWcUiFollower` / `mountWcUiExtension` | Each other | A fix on one boot path may leave the others broken (PR #1261 — fix on non-primary path caused 5s pill-reset regression) |
+| Boundary                         | Left side                                                    | Right side                                 | Risk if unmatched                                                                                                       |
+| -------------------------------- | ------------------------------------------------------------ | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Page realm ↔ kernel worker realm | Code with `window` / DOM access                              | `DedicatedWorkerGlobalScope` (no `window`) | Accidental `window` refs crash the worker; `RTCDataChannel` cannot cross the boundary (PR #667 — full revert)           |
+| Leader role ↔ follower role      | `tray-leader-sync.ts`, leader UI surfaces                    | `tray-follower-sync.ts`, `wc-follower.ts`  | A new broadcast with no follower handler silently no-ops (category 8 below)                                             |
+| Boot paths                       | `mountWcUiLive` / `mountWcUiFollower` / `mountWcUiExtension` | Each other                                 | A fix on one boot path may leave the others broken (PR #1261 — fix on non-primary path caused 5s pill-reset regression) |
 
 ## Detection categories
 


### PR DESCRIPTION
Fixes #1394

## What changed

### `docs/review-patterns.md` (source of truth)

**New detection categories:**

- **Category 8 — Follower surface wiring parity**: trigger patterns for leader broadcasts without matching follower handlers/UI actions. Cites PRs #1286, #1283, #1261 — the largest empirical failure class (~30–40 commits since 2026-03).

- **Category 9 — Origin / bridge routing contract**: trigger patterns for `fetch("/api/...")`, absolute-vs-relative URL construction, and origin comparisons in thin-bridge mode. Cites PRs #1227/#1229, #1235–#1238, #1243, #1283 — 15 call-site fixes across ~9 PRs.

**Intra-webapp parity axes table** added below the existing five-runtime matrix, covering:
- Page realm ↔ kernel worker realm (cites PR #667)
- Leader role ↔ follower role (links to category 8)
- Boot paths (`mountWcUiLive` / `mountWcUiFollower` / `mountWcUiExtension`; cites PR #1261)

### `CLAUDE.md` (root — Automated PR Review Checklist)

Added items 8 (Follower wiring parity) and 9 (Origin/bridge routing) to the numbered checklist. Renumbered Agent skill freshness to 10. Compressed existing entries to stay within the 30,000-char doc-size budget.

### `.github/copilot-instructions.md`

Added compressed versions of the two new categories. File is 3,247 chars (within the 4,000-char Copilot limit).

## Rule satisfied

> "When you change a category, update `docs/review-patterns.md` (source of truth) and the ≤4,000-char `.github/copilot-instructions.md` so all reviewers stay in sync."
> — root `CLAUDE.md`, "Automated PR Review Checklist" section

## Verification

- `npm run lint` ✅ (includes `lint:docs` size checks)
- `wc -c .github/copilot-instructions.md` → 3,247 (≤ 4,000 ✅)
- `CLAUDE.md` → 29,812 chars (≤ 30,000 ✅)
- Pure docs change — no source files modified