### PR TITLE
fix: preserve tracked symlinks on git clone/checkout (OPFS metadata persistence)

### DIFF
--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -1930,6 +1930,15 @@ export class VirtualFS {
           throw this.convertError(err, normalizedLinkPath);
         }
       }
+      // Persist symlink-ness eagerly (OPFS only) inside the write lock so it
+      // survives a realm reload that happens BEFORE flush()/dispose() — the
+      // git clone/checkout path never flushes, and on the OPFS/WebAccess
+      // backend symlink-ness lives only in the in-memory index until the
+      // sidecar is written. Serializing here (never a concurrent sidecar
+      // write) and only for symlinks (rare vs file writes) keeps a full
+      // clone cheap. No-op on the memory backend. See "Root cause: git
+      // symlink/binary corruption".
+      await this.writeOpfsMetadataSidecar();
     });
     this.watcher?.notify([{ type: 'create', path: normalizedLinkPath, entryType: 'symlink' }]);
   }

--- a/packages/webapp/src/git/commands/checkout.ts
+++ b/packages/webapp/src/git/commands/checkout.ts
@@ -55,6 +55,7 @@ export async function checkout(
     } catch (err: unknown) {
       return formatCheckoutError(err, ref);
     }
+    await ctx.fs.flush();
     return {
       stdout: `Switched to a new branch '${ref}'\n`,
       stderr: '',
@@ -67,6 +68,12 @@ export async function checkout(
   } catch (err: unknown) {
     return formatCheckoutError(err, ref);
   }
+  // Persist backend-owned metadata (symlink-ness + filemode) to the OPFS
+  // sidecar now the working tree is re-materialized, so a realm reload before
+  // the next flush/dispose keeps tracked symlinks as links (not regular
+  // files). No-op on the memory backend. See "Root cause: git symlink/binary
+  // corruption".
+  await ctx.fs.flush();
   return {
     stdout: `Switched to branch '${ref}'\n`,
     stderr: '',
@@ -117,5 +124,7 @@ async function checkoutFiles(
     await git.add({ fs: ctx.lfs, dir: cwd, filepath });
   }
 
+  // Persist restored-file metadata to the OPFS sidecar (no-op on memory).
+  await ctx.fs.flush();
   return { stdout: '', stderr: '', exitCode: 0 };
 }

--- a/packages/webapp/src/git/commands/clone.ts
+++ b/packages/webapp/src/git/commands/clone.ts
@@ -68,6 +68,13 @@ export async function clone(
     return formatCloneError(err, targetDir);
   }
 
+  // Persist backend-owned metadata (symlink-ness + filemode) to the OPFS
+  // sidecar now that the working tree is fully materialized. `git clone`
+  // otherwise never flushes, so a realm reload before the next flush/dispose
+  // would lose tracked symlinks (they'd re-materialize as regular files). No-op
+  // on the memory backend. See "Root cause: git symlink/binary corruption".
+  await ctx.fs.flush();
+
   // List files that were checked out
   try {
     const files = await git.listFiles({ fs: ctx.lfs, dir: targetDir });

--- a/packages/webapp/tests/fs/fsa-test-helpers.ts
+++ b/packages/webapp/tests/fs/fsa-test-helpers.ts
@@ -20,10 +20,15 @@ function setFileContent(node: MockFileNode, content: string): void {
   node.mtime = Date.now();
 }
 
-class MockFsError extends Error {
+// Real `DOMException` (not a plain Error) so `@zenfs/dom`'s `convertException`
+// maps `.name` to the right POSIX errno. It only does that mapping for
+// `ex instanceof DOMException`; any other thrown error falls through to `EIO`
+// (`@zenfs/dom/dist/utils.js`). The real File System Access API throws
+// `DOMException`s, so mirroring that keeps missing-path lookups (`NotFoundError`
+// → `ENOENT`) faithful instead of surfacing spurious `EIO`.
+class MockFsError extends DOMException {
   constructor(name: string, message: string) {
-    super(message);
-    this.name = name;
+    super(message, name);
   }
 }
 
@@ -45,38 +50,66 @@ class MockFileHandle {
     } as File;
   }
 
-  async createWritable(): Promise<FileSystemWritableFileStream> {
+  // Faithful `FileSystemWritableFileStream`: honors `keepExistingData`, a
+  // position cursor, `seek`/`truncate`, and the `{ type, position, size, data }`
+  // params-object form — the shapes `@zenfs/dom`'s `WebAccessFS.write` actually
+  // emits (it seeks before offset writes and falls back to a params-object seek
+  // when `stream.seek` is absent). The prior append-only stub rejected those and
+  // could not run real content writes (only mount-coexistence tests used it).
+  async createWritable(options?: {
+    keepExistingData?: boolean;
+  }): Promise<FileSystemWritableFileStream> {
     const node = this.node;
-    const chunks: Uint8Array[] = [];
+    const buffer: number[] = options?.keepExistingData ? Array.from(node.content) : [];
+    let cursor = 0;
+    const toBytes = (data: unknown): Uint8Array => {
+      if (typeof data === 'string') return new TextEncoder().encode(data);
+      if (data instanceof Uint8Array) return data;
+      if (ArrayBuffer.isView(data)) {
+        const v = data as ArrayBufferView;
+        return new Uint8Array(v.buffer, v.byteOffset, v.byteLength);
+      }
+      if (data instanceof ArrayBuffer) return new Uint8Array(data);
+      throw new Error('Unsupported chunk data type');
+    };
+    const writeAt = (pos: number, bytes: Uint8Array): void => {
+      for (let i = 0; i < bytes.byteLength; i++) buffer[pos + i] = bytes[i];
+      cursor = pos + bytes.byteLength;
+    };
     return {
       async write(chunk: unknown): Promise<void> {
-        let bytes: Uint8Array;
-        if (typeof chunk === 'string') {
-          bytes = new TextEncoder().encode(chunk);
-        } else if (chunk instanceof Uint8Array) {
-          bytes = chunk;
-        } else if (chunk instanceof ArrayBuffer) {
-          bytes = new Uint8Array(chunk);
-        } else if (chunk && typeof chunk === 'object' && 'data' in chunk) {
-          const data = (chunk as { data: unknown }).data;
-          if (typeof data === 'string') bytes = new TextEncoder().encode(data);
-          else if (data instanceof Uint8Array) bytes = data;
-          else if (data instanceof ArrayBuffer) bytes = new Uint8Array(data);
-          else throw new Error('Unsupported chunk data type');
-        } else {
-          throw new Error('Unsupported chunk type');
+        const isParams =
+          chunk !== null &&
+          typeof chunk === 'object' &&
+          !(chunk instanceof Uint8Array) &&
+          !(chunk instanceof ArrayBuffer) &&
+          !ArrayBuffer.isView(chunk) &&
+          ('type' in chunk || 'data' in chunk);
+        if (isParams) {
+          const p = chunk as { type?: string; position?: number; size?: number; data?: unknown };
+          if (p.type === 'seek') {
+            cursor = p.position ?? cursor;
+            return;
+          }
+          if (p.type === 'truncate') {
+            buffer.length = p.size ?? 0;
+            return;
+          }
+          writeAt(p.position ?? cursor, toBytes(p.data));
+          return;
         }
-        chunks.push(bytes);
+        writeAt(cursor, toBytes(chunk));
+      },
+      async seek(position: number): Promise<void> {
+        cursor = position;
+      },
+      async truncate(size: number): Promise<void> {
+        buffer.length = size;
       },
       async close(): Promise<void> {
-        const total = chunks.reduce((n, c) => n + c.byteLength, 0);
-        const merged = new Uint8Array(total);
-        let offset = 0;
-        for (const c of chunks) {
-          merged.set(c, offset);
-          offset += c.byteLength;
-        }
-        node.content = merged;
+        const out = new Uint8Array(buffer.length);
+        for (let i = 0; i < buffer.length; i++) out[i] = buffer[i] ?? 0;
+        node.content = out;
         node.mtime = Date.now();
       },
     } as unknown as FileSystemWritableFileStream;

--- a/packages/webapp/tests/git/git-symlink-binary-corruption.test.ts
+++ b/packages/webapp/tests/git/git-symlink-binary-corruption.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Regression: tracked symlinks + binary blobs must survive a checkout that
+ * re-materializes the working tree, on BOTH the `memory` and `opfs`
+ * (ZenFS WebAccess) backends.
+ *
+ * Mirrors what `git clone ai-ecoverse/skills` does inside SLICC (init → add →
+ * commit → materialize working tree via checkout) but with a hand-built repo so
+ * the test is network-free and deterministic. The scenario is driven directly
+ * through the isomorphic-git ↔ VirtualFS adapter (`createIsomorphicGitFs`), the
+ * exact seam the production git commands use.
+ *
+ * The `opfs` variant exercises the real `@zenfs/dom` WebAccessFS code over a
+ * mocked `FileSystemDirectoryHandle` (`createMutableDirectoryHandle` +
+ * `navigator.storage` stub — same pattern as the OPFS multi-instance test), so
+ * the symlink/metadata sidecar logic under test is the production code path,
+ * not an in-memory stand-in.
+ *
+ * These tests are EXPECTED TO FAIL until the Wave 2 fix lands; they document
+ * the bug. See the "Root cause: git symlink/binary corruption" note.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import * as isoGit from 'isomorphic-git';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { createIsomorphicGitFs } from '../../src/git/vfs-fs-adapter.js';
+import { createMutableDirectoryHandle } from '../fs/fsa-test-helpers.js';
+
+// A JPEG-shaped blob containing every byte 0x00-0xFF plus an invalid UTF-8
+// sequence (0xC3 0x28), so any UTF-8 string round-trip anywhere in the
+// add/commit/checkout/status path mangles the bytes and the equality check trips.
+function makeBinary(): Uint8Array {
+  const header = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01];
+  const allBytes = Array.from({ length: 256 }, (_, i) => i);
+  const footer = [0xff, 0xd9];
+  return new Uint8Array([...header, ...allBytes, 0xc3, 0x28, ...footer]);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+interface ScenarioResult {
+  linkType: string;
+  linkTarget: string | null;
+  bytes: Uint8Array;
+  expected: Uint8Array;
+  dirtyRows: string[];
+}
+
+const DIR = '/project';
+const EXPECTED = makeBinary();
+
+/**
+ * init → write binary + symlink → add → commit → wipe working tree → checkout.
+ * Mirrors the clone/checkout step that re-materializes a working tree from the
+ * object store.
+ */
+async function seedAndCheckout(vfs: VirtualFS): Promise<void> {
+  const gitfs = createIsomorphicGitFs(vfs);
+  await isoGit.init({ fs: gitfs, dir: DIR, defaultBranch: 'main' });
+
+  await vfs.writeFile(`${DIR}/data.bin`, EXPECTED);
+  await vfs.symlink('data.bin', `${DIR}/link.bin`);
+
+  await isoGit.add({ fs: gitfs, dir: DIR, filepath: 'data.bin' });
+  await isoGit.add({ fs: gitfs, dir: DIR, filepath: 'link.bin' });
+  await isoGit.commit({
+    fs: gitfs,
+    dir: DIR,
+    message: 'seed binary + symlink',
+    author: { name: 'Test User', email: 'test@example.com' },
+  });
+
+  // Wipe the working-tree copies (the .git object store keeps the truth).
+  await vfs.rm(`${DIR}/link.bin`);
+  await vfs.rm(`${DIR}/data.bin`);
+
+  // Re-materialize the working tree from HEAD — the clone/checkout step.
+  await isoGit.checkout({ fs: gitfs, dir: DIR, ref: 'main', force: true });
+}
+
+/** Read back what landed in the working tree plus the status matrix. */
+async function readState(vfs: VirtualFS): Promise<ScenarioResult> {
+  const gitfs = createIsomorphicGitFs(vfs);
+  const lstat = await vfs.lstat(`${DIR}/link.bin`);
+  const linkTarget = lstat.type === 'symlink' ? await vfs.readlink(`${DIR}/link.bin`) : null;
+  const bytes = (await vfs.readFile(`${DIR}/data.bin`, { encoding: 'binary' })) as Uint8Array;
+
+  // Clean tree ⇒ every row is [name, HEAD=1, workdir=1, stage=1].
+  const matrix = await isoGit.statusMatrix({ fs: gitfs, dir: DIR });
+  const dirtyRows = matrix
+    .filter((r) => !(r[1] === 1 && r[2] === 1 && r[3] === 1))
+    .map((r) => `${r[0]} [${r[1]},${r[2]},${r[3]}]`);
+
+  return { linkType: lstat.type, linkTarget, bytes, expected: EXPECTED, dirtyRows };
+}
+
+async function runCheckoutScenario(vfs: VirtualFS): Promise<ScenarioResult> {
+  await seedAndCheckout(vfs);
+  return readState(vfs);
+}
+
+function assertClean(r: ScenarioResult): void {
+  // (a) the symlink is still a symlink pointing at the correct target
+  expect(r.linkType).toBe('symlink');
+  expect(r.linkTarget).toBe('data.bin');
+  // (b) the binary is byte-identical
+  expect(bytesEqual(r.bytes, r.expected)).toBe(true);
+  // (c) git status is clean
+  expect(r.dirtyRows).toEqual([]);
+}
+
+let counter = 0;
+
+describe('git checkout preserves symlinks + binary — memory backend', () => {
+  it('re-materializes a tracked symlink and binary blob byte-identically', async () => {
+    const vfs = await VirtualFS.create({ dbName: `git-corruption-mem-${counter++}`, wipe: true });
+    try {
+      assertClean(await runCheckoutScenario(vfs));
+    } finally {
+      await vfs.dispose();
+    }
+  });
+});
+
+describe('git checkout preserves symlinks + binary — opfs (WebAccess) backend', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubOpfs(): void {
+    const opfs = createMutableDirectoryHandle({});
+    vi.stubGlobal('navigator', {
+      storage: { getDirectory: async (): Promise<FileSystemDirectoryHandle> => opfs.handle },
+    });
+  }
+
+  // Model an app reload over the SAME on-disk OPFS directory: `getDirectoryHandle`
+  // returns one shared subdir for ANY `dbName`, so a second `VirtualFS` (fresh
+  // `dbName` ⇒ fresh in-realm backend cache ⇒ genuine sidecar re-read) sees the
+  // exact bytes the first instance left on disk — the "fresh realm after reload"
+  // condition without needing a real browser teardown.
+  function stubSharedSubdirOpfs(): void {
+    const subdir = createMutableDirectoryHandle({}).handle;
+    const root = {
+      kind: 'directory',
+      name: 'root',
+      getDirectoryHandle: async (): Promise<FileSystemDirectoryHandle> => subdir,
+      removeEntry: async (): Promise<void> => {},
+    } as unknown as FileSystemDirectoryHandle;
+    vi.stubGlobal('navigator', {
+      storage: { getDirectory: async (): Promise<FileSystemDirectoryHandle> => root },
+    });
+  }
+
+  it('re-materializes a tracked symlink and binary blob byte-identically', async () => {
+    stubOpfs();
+    const vfs = await VirtualFS.create({
+      dbName: `git-corruption-opfs-${counter++}`,
+      backend: 'opfs',
+      wipe: true,
+    });
+    try {
+      assertClean(await runCheckoutScenario(vfs));
+    } finally {
+      await vfs.dispose();
+    }
+  });
+
+  it('preserves symlink + binary across an app reload (metadata sidecar round-trip)', async () => {
+    stubOpfs();
+    const dbName = `git-corruption-opfs-reload-${counter++}`;
+    const first = await VirtualFS.create({ dbName, backend: 'opfs', wipe: true });
+    await seedAndCheckout(first);
+    // `dispose()` serializes the WebAccessFS in-memory index to `.metadata.json`.
+    await first.dispose();
+
+    // Reload: a fresh instance over the SAME OPFS subdir reads the sidecar back
+    // (`WebAccessFS._loadMetadata`). This is the "reload the app after clone,
+    // then git status" path.
+    const second = await VirtualFS.create({ dbName, backend: 'opfs' });
+    try {
+      assertClean(await readState(second));
+    } finally {
+      await second.dispose();
+    }
+  });
+
+  // THE BUG. `git clone` never calls `flush()`/`dispose()`, so the WebAccessFS
+  // in-memory index (which is where symlink-ness and filemode bits live) is
+  // never serialized to `.metadata.json`. On the next realm reload the fresh
+  // WebAccessFS reads the empty seeded sidecar, and `WebAccessFS.stat`'s
+  // ENOENT-recovery path re-adds the on-disk handle as a REGULAR FILE — so the
+  // tracked symlink comes back as a plain file whose contents are the link
+  // target text (a "broken symlink"), exactly the reported clone symptom.
+  // Expected to fail until the Wave 2 fix persists symlink/filemode metadata
+  // eagerly (or reconstructs it on load); flip `it.fails` → `it` then.
+  it.fails('loses the tracked symlink after an UNFLUSHED reload (no dispose)', async () => {
+    stubSharedSubdirOpfs();
+    const first = await VirtualFS.create({
+      dbName: `git-corruption-noflush-a-${counter}`,
+      backend: 'opfs',
+      wipe: true,
+    });
+    await seedAndCheckout(first);
+    // Intentionally NO dispose()/flush() on `first` — mirrors the clone path,
+    // which leaves the index un-persisted.
+    const second = await VirtualFS.create({
+      dbName: `git-corruption-noflush-b-${counter++}`,
+      backend: 'opfs',
+    });
+    try {
+      assertClean(await readState(second));
+    } finally {
+      await second.dispose();
+      await first.dispose();
+    }
+  });
+});

--- a/packages/webapp/tests/git/git-symlink-binary-corruption.test.ts
+++ b/packages/webapp/tests/git/git-symlink-binary-corruption.test.ts
@@ -188,16 +188,18 @@ describe('git checkout preserves symlinks + binary — opfs (WebAccess) backend'
     }
   });
 
-  // THE BUG. `git clone` never calls `flush()`/`dispose()`, so the WebAccessFS
-  // in-memory index (which is where symlink-ness and filemode bits live) is
-  // never serialized to `.metadata.json`. On the next realm reload the fresh
-  // WebAccessFS reads the empty seeded sidecar, and `WebAccessFS.stat`'s
-  // ENOENT-recovery path re-adds the on-disk handle as a REGULAR FILE — so the
-  // tracked symlink comes back as a plain file whose contents are the link
+  // REGRESSION (Wave 2 fix). `git clone`/`checkout` never call
+  // `flush()`/`dispose()`, so the WebAccessFS in-memory index (where
+  // symlink-ness and filemode bits live) used to be serialized to
+  // `.metadata.json` only on flush/dispose. On a realm reload the fresh
+  // WebAccessFS would read the empty seeded sidecar and `WebAccessFS.stat`'s
+  // ENOENT-recovery path re-added the on-disk handle as a REGULAR FILE — so the
+  // tracked symlink came back as a plain file whose contents are the link
   // target text (a "broken symlink"), exactly the reported clone symptom.
-  // Expected to fail until the Wave 2 fix persists symlink/filemode metadata
-  // eagerly (or reconstructs it on load); flip `it.fails` → `it` then.
-  it.fails('loses the tracked symlink after an UNFLUSHED reload (no dispose)', async () => {
+  // The fix write-throughs the sidecar inside `vfs.symlink()` (and flushes at
+  // the end of the clone/checkout wrappers), so the symlink now survives an
+  // UNFLUSHED reload.
+  it('preserves the tracked symlink after an UNFLUSHED reload (no dispose)', async () => {
     stubSharedSubdirOpfs();
     const first = await VirtualFS.create({
       dbName: `git-corruption-noflush-a-${counter}`,


### PR DESCRIPTION
## Summary
Fixes loss of tracked **symlinks** when running `git clone`/`checkout` inside SLICC's isomorphic-git-over-VirtualFS on the OPFS (ZenFS WebAccess) backend.

### Root cause
Symlink-ness and filemode live only in the WebAccessFS in-memory index, which is serialized to `/.metadata.json` only on `flush()`/`dispose()`. `git clone` never flushes, so after a realm reload a fresh WebAccessFS reads the empty seeded sidecar and re-materializes the on-disk handle as a regular file (contents = the link-target text) — the reported "~30 tracked symlinks materialized as broken links" symptom.

### Fix
- `vfs.symlink()` now write-throughs the OPFS metadata sidecar inside the write lock (no-op on the memory backend).
- `git clone` and all three `checkout` paths batch a `flush()` after materializing the tree (no per-file flush, so full-clone performance is preserved).
- Regression test flipped from `it.fails` → `it`.

### Verification
- Target test `tests/git/git-symlink-binary-corruption.test.ts` 4/4 (no expected-fail).
- Full `@slicc/webapp` suite 8702 passed / 30 skipped; lint + typecheck green; coverage at/above floor.

### Scope / notes
- Binary-blob preservation is **deferred** to a separate follow-up investigation (Wave 1 could not reproduce it in the Node harness).
- Independently verified by a verifier agent (high confidence).
