### PR TITLE
fix(cloudflare-worker): timing-safe tray token comparison

### DIFF
--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -42,6 +42,7 @@ import {
   type TrayWebSocketLike,
   websocketResponse,
 } from './shared.js';
+import { timingSafeEqual } from './timing-safe-equal.js';
 import { fetchTURNCredentials, TURN_CREDENTIAL_TTL_MS } from './turn-credentials.js';
 
 interface ControllerAttachRequest {
@@ -1741,7 +1742,7 @@ export class SessionTrayDurableObject {
   }
 
   private matchesToken(received: string, expected: string): boolean {
-    return received === expected;
+    return timingSafeEqual(received, expected);
   }
 
   private createLeaderKey(): string {

--- a/packages/cloudflare-worker/src/timing-safe-equal.ts
+++ b/packages/cloudflare-worker/src/timing-safe-equal.ts
@@ -1,0 +1,38 @@
+/**
+ * Constant-time string comparison for capability tokens.
+ *
+ * Prefers `crypto.subtle.timingSafeEqual` (Cloudflare Workers runtime),
+ * falls back to a XOR-accumulate loop when unavailable (e.g. Vitest/Node
+ * without the CF polyfill).
+ */
+
+const encoder = new TextEncoder();
+
+/** SubtleCrypto with the CF-specific timingSafeEqual extension. */
+type CfSubtleCrypto = SubtleCrypto & {
+  timingSafeEqual?: (a: ArrayBuffer | ArrayBufferView, b: ArrayBuffer | ArrayBufferView) => boolean;
+};
+
+/**
+ * Compare two strings in constant time.
+ * Returns `false` immediately for length mismatches (lengths are not secret).
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  const bufA = encoder.encode(a);
+  const bufB = encoder.encode(b);
+  if (bufA.byteLength !== bufB.byteLength) return false;
+
+  // Cloudflare Workers expose this as a synchronous method on SubtleCrypto.
+  // It is non-standard and absent in Node's WebCrypto, so feature-detect.
+  const subtle = crypto.subtle as CfSubtleCrypto | undefined;
+  if (typeof subtle?.timingSafeEqual === 'function') {
+    return subtle.timingSafeEqual(bufA, bufB);
+  }
+
+  // Fallback: constant-time XOR accumulator (never short-circuits).
+  let diff = 0;
+  for (let i = 0; i < bufA.byteLength; i++) {
+    diff |= bufA[i]! ^ bufB[i]!;
+  }
+  return diff === 0;
+}

--- a/packages/cloudflare-worker/tests/timing-safe-equal.test.ts
+++ b/packages/cloudflare-worker/tests/timing-safe-equal.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { timingSafeEqual } from '../src/timing-safe-equal.js';
+
+describe('timingSafeEqual', () => {
+  it('returns true for matching tokens', () => {
+    const token = 'abc-123-def-456';
+    expect(timingSafeEqual(token, token)).toBe(true);
+  });
+
+  it('returns true for equal but distinct strings', () => {
+    expect(timingSafeEqual('secret-token', 'secret-token')).toBe(true);
+  });
+
+  it('returns false for non-matching same-length strings', () => {
+    expect(timingSafeEqual('aaaa', 'bbbb')).toBe(false);
+  });
+
+  it('returns false for different-length strings', () => {
+    expect(timingSafeEqual('short', 'a-longer-string')).toBe(false);
+  });
+
+  it('returns false for empty received vs non-empty expected', () => {
+    expect(timingSafeEqual('', 'expected-token')).toBe(false);
+  });
+
+  it('returns false for non-empty received vs empty expected', () => {
+    expect(timingSafeEqual('some-token', '')).toBe(false);
+  });
+
+  it('returns true for two empty strings', () => {
+    expect(timingSafeEqual('', '')).toBe(true);
+  });
+
+  it('handles UUID-style tokens', () => {
+    const uuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    expect(timingSafeEqual(uuid, uuid)).toBe(true);
+    expect(timingSafeEqual(uuid, 'f47ac10b-58cc-4372-a567-0e02b2c3d478')).toBe(false);
+  });
+
+  it('handles multi-byte (UTF-8) characters', () => {
+    expect(timingSafeEqual('héllo', 'héllo')).toBe(true);
+    expect(timingSafeEqual('héllo', 'hèllo')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Replace plain `===` in `SessionTrayDO.matchesToken` with a constant-time comparison to prevent timing side-channel leaks on capability token comparisons (controller token, join token, webhook token).

## Changes

1. **`timing-safe-equal.ts`** — new utility exporting `timingSafeEqual(a, b)`. Uses `crypto.subtle.timingSafeEqual` (CF Workers runtime) with automatic fallback to a XOR-accumulate loop for Vitest/Node.
2. **`session-tray.ts`** — `matchesToken` now delegates to `timingSafeEqual` instead of `===`. Signature and call sites unchanged.
3. **`timing-safe-equal.test.ts`** — 9 test cases: matching, non-matching same-length, different-length, empty strings, UUID tokens, multi-byte UTF-8.

Aligns the tray DO with `node-server/bridge-security.ts`, which already uses `node:crypto.timingSafeEqual`.

## Verification

- `npm run lint` ✅
- `npm run typecheck` (all 9 targets) ✅
- `npx vitest run packages/cloudflare-worker/tests/` — 324 passed ✅
- `npm run test:coverage:cloudflare-worker` — above floor ✅

Fixes #1431