### PR TITLE
fix(webapp): restore --prompt auto-submit consumer

### DIFF
--- a/packages/webapp/src/ui/boot/auto-prompt.ts
+++ b/packages/webapp/src/ui/boot/auto-prompt.ts
@@ -1,0 +1,30 @@
+/**
+ * Auto-prompt: reads `?prompt=<text>` from the launch URL and submits it
+ * as the first user message. Used by `node-server --prompt "..."` for
+ * QA smoke-testing. The param is stripped after consumption so reloads
+ * and copied URLs don't re-submit.
+ *
+ * @module
+ */
+
+/**
+ * Extract the `prompt` query-param value from a URL search string and
+ * strip it from the browser history so a page reload won't re-submit.
+ *
+ * Returns `null` when the param is absent or empty.
+ */
+export function consumeAutoPrompt(
+  search: string,
+  replaceState: (url: string) => void = (url) => globalThis.history?.replaceState(null, '', url)
+): string | null {
+  const params = new URLSearchParams(search);
+  const prompt = params.get('prompt');
+  if (!prompt) return null;
+
+  params.delete('prompt');
+  const remaining = params.toString();
+  const cleaned = `${globalThis.location?.pathname ?? '/'}${remaining ? `?${remaining}` : ''}${globalThis.location?.hash ?? ''}`;
+  replaceState(cleaned);
+
+  return prompt;
+}

--- a/packages/webapp/src/ui/boot/auto-prompt.ts
+++ b/packages/webapp/src/ui/boot/auto-prompt.ts
@@ -18,7 +18,7 @@ export function consumeAutoPrompt(
   replaceState: (url: string) => void = (url) => globalThis.history?.replaceState(null, '', url)
 ): string | null {
   const params = new URLSearchParams(search);
-  const prompt = params.get('prompt');
+  const prompt = params.get('prompt')?.trim();
   if (!prompt) return null;
 
   params.delete('prompt');

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1681,4 +1681,15 @@ export async function mountWcUiLive(
   // into nobody. Re-notify so boot reads (freezer rail) finally land.
   boot.wiring.notifyReady?.();
   log.info('WC live shell ready', { scoops: host.client.getScoops().length });
+
+  // Auto-submit: `node-server --prompt "..."` appends `?prompt=<text>` to
+  // the launch URL. Consume it exactly once now that the kernel + controller
+  // are ready. `consumeAutoPrompt` strips the param from the URL via
+  // `history.replaceState` so reloads don't re-fire.
+  const { consumeAutoPrompt } = await import('../boot/auto-prompt.js');
+  const autoPrompt = consumeAutoPrompt(window.location.search);
+  if (autoPrompt) {
+    boot.getController()?.sendUserMessage(autoPrompt);
+    log.info('Auto-prompt submitted', { length: autoPrompt.length });
+  }
 }

--- a/packages/webapp/tests/ui/boot/auto-prompt.test.ts
+++ b/packages/webapp/tests/ui/boot/auto-prompt.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { consumeAutoPrompt } from '../../../src/ui/boot/auto-prompt.js';
+
+describe('consumeAutoPrompt', () => {
+  it('returns null when the param is absent', () => {
+    const replace = vi.fn();
+    expect(consumeAutoPrompt('', replace)).toBeNull();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('returns null for an empty prompt value', () => {
+    const replace = vi.fn();
+    expect(consumeAutoPrompt('?prompt=', replace)).toBeNull();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('returns the decoded prompt text', () => {
+    const replace = vi.fn();
+    const result = consumeAutoPrompt('?prompt=ls%20%2Fworkspace', replace);
+    expect(result).toBe('ls /workspace');
+  });
+
+  it('strips the prompt param via replaceState', () => {
+    const replace = vi.fn();
+    consumeAutoPrompt('?prompt=hello', replace);
+    expect(replace).toHaveBeenCalledOnce();
+    // The cleaned URL should not contain `prompt=`
+    const cleaned = replace.mock.calls[0]![0] as string;
+    expect(cleaned).not.toContain('prompt=');
+  });
+
+  it('preserves other query params when stripping', () => {
+    const replace = vi.fn();
+    consumeAutoPrompt('?bridge=ws://localhost:5710/cdp&prompt=test&token=abc', replace);
+    const cleaned = replace.mock.calls[0]![0] as string;
+    expect(cleaned).toContain('bridge=');
+    expect(cleaned).toContain('token=abc');
+    expect(cleaned).not.toContain('prompt=');
+  });
+
+  it('returns null on reload after the param was stripped', () => {
+    const replace = vi.fn();
+    // First call consumes the param
+    consumeAutoPrompt('?prompt=hello', replace);
+    // Simulated reload: the cleaned URL has no prompt param
+    const cleaned = replace.mock.calls[0]![0] as string;
+    const search = cleaned.includes('?') ? cleaned.slice(cleaned.indexOf('?')) : '';
+    expect(consumeAutoPrompt(search, replace)).toBeNull();
+  });
+});

--- a/packages/webapp/tests/ui/boot/auto-prompt.test.ts
+++ b/packages/webapp/tests/ui/boot/auto-prompt.test.ts
@@ -14,6 +14,12 @@ describe('consumeAutoPrompt', () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
+  it('returns null for a whitespace-only prompt', () => {
+    const replace = vi.fn();
+    expect(consumeAutoPrompt('?prompt=%20%20%20', replace)).toBeNull();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
   it('returns the decoded prompt text', () => {
     const replace = vi.fn();
     const result = consumeAutoPrompt('?prompt=ls%20%2Fworkspace', replace);


### PR DESCRIPTION
## Decision

**Option A — re-implement the consumer.** The `--prompt` flag is genuinely useful for QA smoke-testing (`npm run dev -- --prompt "ls /workspace"`) and was documented before the WC migration dropped the webapp-side consumer.

## What changed

### `packages/webapp/src/ui/boot/auto-prompt.ts` (new)
`consumeAutoPrompt(search, replaceState)` — reads the `prompt` query-param, strips it via `history.replaceState` to prevent re-submission on reload, returns the decoded text (or `null`).

### `packages/webapp/src/ui/wc/wc-live.ts`
After `host.ready` resolves and `notifyReady()` fires (kernel + controller fully wired), the boot calls `consumeAutoPrompt` and, if present, submits the text via `sendUserMessage` — the same code path the chat input uses. No-op when the param is absent.

### `packages/webapp/tests/ui/boot/auto-prompt.test.ts` (new)
6 tests covering: absent param → null, empty param → null, decoded text return, param stripping via replaceState, preservation of other query params, and no re-submission on simulated reload.

## Preflight verification

```bash
# Flag + appender still exist (confirmed at f55a0cb36)
rg -n 'prompt' packages/node-server/src/runtime-flags.ts    # ✅ flag defined
rg -n 'prompt' packages/node-server/src/index.ts             # ✅ URL appender

# Zero consumers before this PR (confirmed)
rg -rn 'searchParams.*["'\''\"'\''']prompt' packages/webapp/src  # ✅ zero hits

# Docs still reference it
rg -n 'prompt' packages/node-server/CLAUDE.md                # ✅ documented
```

## End-to-end path

`node-server --prompt "ls /workspace"` → appends `?prompt=ls%20%2Fworkspace` to Chrome launch URL → webapp boots → kernel ready → `consumeAutoPrompt` reads + strips param → `sendUserMessage` submits → agent receives the prompt.

Fixes #1432