### PR TITLE
fix(cherry): survive iframe reload via re-handshake

### DIFF
--- a/packages/cherry/CLAUDE.md
+++ b/packages/cherry/CLAUDE.md
@@ -169,6 +169,22 @@ because passing secrets through the browser handshake exposes them to the host
 page's user. Reintroducing creation is tracked as a separate future PR; see the
 design doc's descope note.
 
+## Iframe reload / re-handshake
+
+The host SDK survives an iframe reload without the host calling `destroy()` +
+`mountSlicc()` again. When the iframe reloads (host-page re-render, follower
+stale-chunk recovery, crashed renderer), the new page boots a fresh
+`CherryHostTransport` and mints a new `channelId`. The host SDK's `onMessage`
+detects this as a **re-hello** — a `handshake.hello` from a trusted peer
+(origin + WindowProxy identity match) carrying a channelId that differs from
+the pinned one — and re-runs the handshake: re-pins the channelId, resends the
+welcome envelope with theme/config/features, and fires `onHandshakeComplete`.
+
+The re-hello acceptance rule lives in `mount.ts` (host-side policy), not in
+`acceptEnvelope` (shared protocol). The three-factor gate in `protocol.ts`
+remains strict — only the `handshake.hello` kind bypasses factor 3 under factors
+1-2 trust.
+
 ## Protocol mirror invariant
 
 `packages/cherry/src/protocol.ts` is a structural **MIRROR** of the canonical

--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -23,6 +23,44 @@ type MountSliccImplOptions = MountSliccOptions & {
   __test_post?: (env: CherryEnvelope) => void;
 };
 
+function buildWelcomeEnvelope(
+  newChannelId: string,
+  options: MountSliccImplOptions
+): Extract<CherryEnvelope, { kind: 'handshake.welcome' }> {
+  const resolvedFeatures = {
+    terminal: true,
+    files: true,
+    memory: true,
+    browser: true,
+    modelPicker: true,
+    history: true,
+    nav: true,
+    newSprinkle: true,
+    monitor: true,
+    showTimestamps: true,
+    ...options.features,
+  };
+  // JSON.stringify can throw on cyclic/non-serializable theme objects — a
+  // malformed theme must not take down the whole handshake.
+  let themeJson: string | undefined;
+  if (options.theme) {
+    try {
+      themeJson = JSON.stringify(options.theme);
+    } catch (err) {
+      console.warn('[cherry] options.theme is not JSON-serializable — sending no theme', err);
+    }
+  }
+  return {
+    cherry: CHERRY_PROTOCOL_VERSION,
+    channelId: newChannelId,
+    kind: 'handshake.welcome',
+    joinUrl: options.joinToken,
+    features: resolvedFeatures,
+    ...(themeJson ? { theme: themeJson } : {}),
+    ...(options.effortLevel ? { effortLevel: options.effortLevel } : {}),
+  };
+}
+
 export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandle {
   const sdkCreatedIframe = !options.iframe;
   const iframe = options.iframe ?? document.createElement('iframe');
@@ -87,42 +125,7 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
     switch (env.kind) {
       case 'handshake.hello': {
         channelId = env.channelId;
-        // The SDK forwards the ready joinToken the host supplied. The follower
-        // embeds against that already-provisioned leader; the SDK never calls
-        // the cloud API itself.
-        const resolvedFeatures = {
-          terminal: true,
-          files: true,
-          memory: true,
-          browser: true,
-          modelPicker: true,
-          history: true,
-          nav: true,
-          newSprinkle: true,
-          monitor: true,
-          showTimestamps: true,
-          ...options.features,
-        };
-        // JSON.stringify can throw on cyclic/non-serializable theme objects — a
-        // malformed theme must not take down the whole handshake.
-        let themeJson: string | undefined;
-        if (options.theme) {
-          try {
-            themeJson = JSON.stringify(options.theme);
-          } catch (err) {
-            console.warn('[cherry] options.theme is not JSON-serializable — sending no theme', err);
-          }
-        }
-        const welcome: Extract<CherryEnvelope, { kind: 'handshake.welcome' }> = {
-          cherry: CHERRY_PROTOCOL_VERSION,
-          channelId,
-          kind: 'handshake.welcome',
-          joinUrl: options.joinToken,
-          features: resolvedFeatures,
-          ...(themeJson ? { theme: themeJson } : {}),
-          ...(options.effortLevel ? { effortLevel: options.effortLevel } : {}),
-        };
-        post(welcome);
+        post(buildWelcomeEnvelope(channelId, options));
         options.hooks?.onHandshakeComplete?.();
         return undefined;
       }
@@ -150,7 +153,44 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
     }
   };
 
+  /** True when the message passes origin + source (factors 1-2) of the gate. */
+  const passesTrustFactors = (event: MessageEvent): boolean =>
+    [sliccOrigin].includes(event.origin) && event.source === iframe.contentWindow;
+
+  /**
+   * Detect a re-hello: a well-formed handshake.hello from a trusted peer
+   * (origin + source match) carrying a channelId that differs from the pinned
+   * one. This happens when the iframe reloads (host-page re-render, follower
+   * stale-chunk recovery, crashed renderer restore) — the new page boots a
+   * fresh CherryHostTransport and mints a new channelId.
+   *
+   * Security: a re-hello from the same origin + WindowProxy is equivalent in
+   * power to the initial hello — the trust basis is identical (the browser
+   * guarantees WindowProxy identity across same-origin navigations). Accepting
+   * it does NOT weaken factors 1-2; it only relaxes factor 3 for this specific
+   * envelope kind so the re-pin code in handleEnvelope is reachable.
+   */
+  const isReHello = (event: MessageEvent): boolean =>
+    channelId !== null &&
+    passesTrustFactors(event) &&
+    isCherryEnvelope(event.data) &&
+    event.data.kind === 'handshake.hello' &&
+    event.data.channelId !== channelId;
+
   const onMessage = (event: MessageEvent) => {
+    // Accept a re-hello from a reloaded iframe before the standard gate —
+    // the standard gate would reject it because channelId changed.
+    if (isReHello(event)) {
+      console.info('[cherry] re-hello from reloaded iframe — re-handshaking', {
+        oldChannelId: channelId,
+        newChannelId: (event.data as CherryEnvelope).channelId,
+      });
+      void handleEnvelope(event.data as CherryEnvelope).catch((err) => {
+        console.error('[cherry] re-handshake failed', err);
+      });
+      return;
+    }
+
     if (
       !acceptEnvelope(event, {
         allowOrigins: [sliccOrigin],

--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -177,6 +177,14 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
     event.data.kind === 'handshake.hello' &&
     event.data.channelId !== channelId;
 
+  // Shared catch handler for handleEnvelope rejections. handleEnvelope already
+  // converts cdp.request failures into a posted cdp.response.error. A reject
+  // here means a handshake/event handler threw unexpectedly — log so it doesn't
+  // vanish as a silent 30s leader timeout.
+  const onEnvelopeError = (err: unknown) => {
+    console.error('[cherry] envelope handling failed', err);
+  };
+
   const onMessage = (event: MessageEvent) => {
     // Accept a re-hello from a reloaded iframe before the standard gate —
     // the standard gate would reject it because channelId changed.
@@ -185,9 +193,7 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
         oldChannelId: channelId,
         newChannelId: (event.data as CherryEnvelope).channelId,
       });
-      void handleEnvelope(event.data as CherryEnvelope).catch((err) => {
-        console.error('[cherry] re-handshake failed', err);
-      });
+      void handleEnvelope(event.data as CherryEnvelope).catch(onEnvelopeError);
       return;
     }
 
@@ -218,12 +224,7 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
       }
       return;
     }
-    void handleEnvelope(event.data as CherryEnvelope).catch((err) => {
-      // handleEnvelope already converts cdp.request failures into a posted
-      // cdp.response.error. A reject here means a handshake/event handler threw
-      // unexpectedly — log so it doesn't vanish as a silent 30s leader timeout.
-      console.error('[cherry] envelope handling failed', err);
-    });
+    void handleEnvelope(event.data as CherryEnvelope).catch(onEnvelopeError);
   };
   window.addEventListener('message', onMessage);
 

--- a/packages/cherry/tests/mount.test.ts
+++ b/packages/cherry/tests/mount.test.ts
@@ -332,6 +332,132 @@ describe('mountSliccImpl', () => {
   });
 });
 
+describe('iframe reload / re-handshake', () => {
+  it('accepts a re-hello with a new channelId from the same origin+source after a reload', async () => {
+    const container = document.createElement('div');
+    const onHandshakeComplete = vi.fn();
+    const posted: { kind?: string; channelId?: string }[] = [];
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      hooks: { onHandshakeComplete },
+      joinToken: 'https://app.example/join?t=X',
+      __test_post: (env) => posted.push(env as never),
+    });
+    const iframe = container.querySelector('iframe')!;
+
+    // --- initial handshake (channelId A) ---
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { cherry: 1, channelId: 'ch-A', kind: 'handshake.hello' },
+        origin: 'https://app.example',
+        source: iframe.contentWindow,
+      })
+    );
+    await vi.waitFor(() => expect(onHandshakeComplete).toHaveBeenCalledTimes(1));
+    const welcomeA = posted.find((e) => e.kind === 'handshake.welcome');
+    expect(welcomeA?.channelId).toBe('ch-A');
+
+    // --- iframe reloads → new hello with channelId B ---
+    // The reloaded iframe is the same WindowProxy (identity survives navigation),
+    // same origin, but a fresh channelId. Without the fix this is rejected by
+    // acceptEnvelope's factor-3 check and the embed is permanently dead.
+    posted.length = 0;
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { cherry: 1, channelId: 'ch-B', kind: 'handshake.hello' },
+        origin: 'https://app.example',
+        source: iframe.contentWindow,
+      })
+    );
+    await vi.waitFor(() => expect(onHandshakeComplete).toHaveBeenCalledTimes(2));
+    const welcomeB = posted.find((e) => e.kind === 'handshake.welcome');
+    expect(welcomeB?.channelId).toBe('ch-B');
+    handle.destroy();
+  });
+
+  it('uses the new channelId for subsequent emitHostEvent calls after re-hello', async () => {
+    const container = document.createElement('div');
+    const posted: { kind?: string; channelId?: string; name?: string }[] = [];
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      joinToken: 'https://app.example/join?t=X',
+      __test_post: (env) => posted.push(env as never),
+    });
+    const iframe = container.querySelector('iframe')!;
+
+    // initial handshake
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { cherry: 1, channelId: 'ch-old', kind: 'handshake.hello' },
+        origin: 'https://app.example',
+        source: iframe.contentWindow,
+      })
+    );
+    await vi.waitFor(() => expect(posted.some((e) => e.kind === 'handshake.welcome')).toBe(true));
+
+    // re-hello with a new channelId
+    posted.length = 0;
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { cherry: 1, channelId: 'ch-new', kind: 'handshake.hello' },
+        origin: 'https://app.example',
+        source: iframe.contentWindow,
+      })
+    );
+    await vi.waitFor(() => expect(posted.some((e) => e.kind === 'handshake.welcome')).toBe(true));
+
+    // emitHostEvent should use the NEW channelId
+    posted.length = 0;
+    handle.emitHostEvent('test-event', { v: 1 });
+    const evt = posted.find((e) => e.kind === 'host.event');
+    expect(evt?.channelId).toBe('ch-new');
+    expect(evt?.name).toBe('test-event');
+    handle.destroy();
+  });
+
+  it('still rejects a re-hello from a different origin (factor 1)', async () => {
+    const container = document.createElement('div');
+    const onHandshakeComplete = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      hooks: { onHandshakeComplete },
+      joinToken: 'https://app.example/join?t=X',
+    });
+    const iframe = container.querySelector('iframe')!;
+
+    // initial handshake
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { cherry: 1, channelId: 'ch-ok', kind: 'handshake.hello' },
+        origin: 'https://app.example',
+        source: iframe.contentWindow,
+      })
+    );
+    await vi.waitFor(() => expect(onHandshakeComplete).toHaveBeenCalledTimes(1));
+
+    // re-hello from a WRONG origin — must stay rejected
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { cherry: 1, channelId: 'ch-evil', kind: 'handshake.hello' },
+        origin: 'https://evil.example',
+        source: iframe.contentWindow,
+      })
+    );
+    // Give the event loop a tick; if the handler fires it would be synchronous
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onHandshakeComplete).toHaveBeenCalledTimes(1); // no re-handshake
+    warn.mockRestore();
+    handle.destroy();
+  });
+});
+
 describe('mountSlicc iframe + uiOnly options', () => {
   it('uses a caller-provided iframe instead of creating one', () => {
     const iframe = document.createElement('iframe');


### PR DESCRIPTION
## Summary

Cherry embed cannot survive an iframe reload — when the iframe reloads (host-page re-render, follower stale-chunk recovery via #1391, crashed renderer restore), the new page boots a fresh `CherryHostTransport` and mints a new `channelId`. The standard `acceptEnvelope` gate rejects it (factor 3: channelId mismatch), leaving the embed permanently dead.

Fixes #1434

## Changes

### 1. Failing tests first (`b34dcee`)
Three regression tests in `packages/cherry/tests/mount.test.ts`:
- **re-hello with new channelId** — simulates iframe reload; asserts re-handshake completes (FAILS on `main`)
- **emitHostEvent uses new channelId** — verifies the channelId is re-pinned after re-hello (FAILS on `main`)
- **re-hello from different origin rejected** — security: wrong origin must stay blocked (PASSES on `main`)

### 2. Fix: re-hello acceptance in mount.ts (`e0423a3`)
- Add `isReHello` detection in `onMessage`: before the standard `acceptEnvelope` gate, detect a `handshake.hello` from a trusted peer (origin + WindowProxy identity = factors 1-2 pass) carrying a new channelId
- Route it directly to `handleEnvelope`, which re-pins the channelId and resends `handshake.welcome` with theme/config/features
- Extract `buildWelcomeEnvelope` to module scope (keeps `mountSliccImpl` under biome's 150-line limit)

**Security note:** a re-hello from the same origin + WindowProxy is equivalent in power to the initial hello — the trust basis is identical (the browser guarantees WindowProxy identity across same-origin navigations). The three-factor gate in `protocol.ts` is unchanged; only the host-side policy in `mount.ts` accepts re-hello before the gate.

### 3. Coverage refactor (`d4848e8`)
Share a single `onEnvelopeError` catch handler between the re-hello and standard paths to stay above the 96% function coverage threshold.

### 4. Docs (`f26b313`)
`packages/cherry/CLAUDE.md` gains a "Iframe reload / re-handshake" section documenting the new behavior.

## Leader-side check
The follower is the reloading party. When it reloads:
1. Old `CherryHostTransport` is destroyed (page unload)
2. New instance calls `connect()` → mints new channelId → sends `handshake.hello`
3. Host SDK (with this fix) accepts re-hello → responds with `handshake.welcome`
4. Follower reconnects to the leader via tray/WebRTC through its normal boot path (`setupCherryFollower` → `tray-follower-sync`)

No leader-side changes needed — the leader sees a normal follower reconnect.

## Protocol mirror
`protocol-mirror.test.ts` still green. No changes to `protocol.ts` or `cherry-host-protocol.ts`.

## Verification
- `npm run lint` ✅
- `npm run typecheck` (nine targets) ✅
- `npm run test:coverage:cherry`: 97.14% functions (threshold 96%), all metrics above floor ✅
- All 59 cherry tests pass ✅