### PR TITLE
fix: session-tray DO state pruning (bootstraps, events, controllers)

### DIFF
--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -87,6 +87,15 @@ const MAX_BRIDGE_EMITS_PER_WINDOW = 20;
 // be a storage write per CDP command on the hot drive path. Debounce those
 // liveness-only writes to at most once per window.
 const LEADER_SEEN_PERSIST_MS = 30_000;
+// Grace period after a bootstrap reaches a terminal state before it is pruned.
+// Gives the follower time to poll the final failure before the record vanishes.
+const BOOTSTRAP_TERMINAL_GRACE_MS = 5 * 60 * 1000;
+// Maximum bootstrap events kept per record. The follower polls via a cursor so
+// only recent events matter; old SDP payloads (kilobytes each) are dropped.
+const MAX_BOOTSTRAP_EVENTS = 20;
+// Controllers whose `lastSeenAt` is older than this are pruned. Set to 2×
+// the desktop reclaim TTL so a controller always survives a leader reclaim.
+const CONTROLLER_STALE_MS = 2 * 60 * 60 * 1000;
 
 interface CachedIceServers {
   iceServers: TurnIceServer[];
@@ -607,6 +616,7 @@ export class SessionTrayDurableObject {
   private async handleFollowerAttach(attach: ControllerAttachRequest): Promise<Response> {
     try {
       const tray = this.requireTray();
+      this.pruneStaleControllers();
       const controllerId = attach.controllerId ?? crypto.randomUUID();
       const nowIso = this.isoNow();
 
@@ -707,6 +717,7 @@ export class SessionTrayDurableObject {
     }
 
     const attach = await this.readAttachRequest(request, url);
+    this.pruneStaleControllers();
     const controllerId = attach.controllerId ?? crypto.randomUUID();
     const nowIso = this.isoNow();
 
@@ -1335,6 +1346,7 @@ export class SessionTrayDurableObject {
       return await this.buildFollowerBootstrapResponse(bootstrap, [], 409);
     }
 
+    this.pruneTerminalBootstraps();
     const retried = this.createBootstrap(
       bootstrap.controllerId,
       runtime ?? bootstrap.runtime,
@@ -1352,6 +1364,7 @@ export class SessionTrayDurableObject {
     controllerId: string,
     runtime: string | undefined
   ): Promise<TrayBootstrapRecord> {
+    this.pruneTerminalBootstraps();
     const existing = this.findBootstrap(controllerId);
     if (existing) {
       this.refreshBootstrapState(existing);
@@ -1511,6 +1524,11 @@ export class SessionTrayDurableObject {
     bootstrap.nextSequence += 1;
     bootstrap.updatedAt = sentAt;
     bootstrap.events.push(nextEvent);
+    // Cap events to avoid unbounded growth from SDP payloads (KB each).
+    // The follower polls via cursor so only the tail matters.
+    if (bootstrap.events.length > MAX_BOOTSTRAP_EVENTS) {
+      bootstrap.events = bootstrap.events.slice(-MAX_BOOTSTRAP_EVENTS);
+    }
     return nextEvent;
   }
 
@@ -1563,6 +1581,41 @@ export class SessionTrayDurableObject {
 
   private canRetryBootstrap(bootstrap: TrayBootstrapRecord): boolean {
     return bootstrap.retryCount < bootstrap.maxRetries;
+  }
+
+  /**
+   * Remove bootstrap records in a terminal state whose grace window has
+   * elapsed. Called opportunistically when bootstraps are mutated.
+   */
+  private pruneTerminalBootstraps(): void {
+    const tray = this.requireTray();
+    const nowMs = this.now();
+    for (const [id, bootstrap] of Object.entries(tray.bootstraps)) {
+      const isTerminal =
+        bootstrap.state === 'connected' ||
+        (bootstrap.state === 'failed' && !this.canRetryBootstrap(bootstrap));
+      if (!isTerminal) continue;
+      const deadlineMs = Date.parse(bootstrap.expiresAt) + BOOTSTRAP_TERMINAL_GRACE_MS;
+      if (nowMs > deadlineMs) {
+        delete tray.bootstraps[id];
+      }
+    }
+  }
+
+  /**
+   * Remove controller entries whose `lastSeenAt` is older than the stale
+   * threshold. Never prunes the current leader's controller.
+   */
+  private pruneStaleControllers(): void {
+    const tray = this.requireTray();
+    const cutoff = new Date(this.now() - CONTROLLER_STALE_MS).toISOString();
+    const leaderControllerId = tray.leader?.controllerId;
+    for (const [id, controller] of Object.entries(tray.controllers)) {
+      if (id === leaderControllerId) continue;
+      if (controller.lastSeenAt < cutoff) {
+        delete tray.controllers[id];
+      }
+    }
   }
 
   private buildFollowerAttachResponse(

--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -1525,9 +1525,14 @@ export class SessionTrayDurableObject {
     bootstrap.updatedAt = sentAt;
     bootstrap.events.push(nextEvent);
     // Cap events to avoid unbounded growth from SDP payloads (KB each).
-    // The follower polls via cursor so only the tail matters.
+    // The follower polls via cursor so only the tail matters, but the offer
+    // is only carried in the events stream — preserve it at the head so a
+    // burst of ICE candidates can't drop it and force a timeout+retry.
     if (bootstrap.events.length > MAX_BOOTSTRAP_EVENTS) {
-      bootstrap.events = bootstrap.events.slice(-MAX_BOOTSTRAP_EVENTS);
+      const offer = bootstrap.events.find((e) => e.type === 'bootstrap.offer');
+      const tailSize = offer ? MAX_BOOTSTRAP_EVENTS - 1 : MAX_BOOTSTRAP_EVENTS;
+      const tail = bootstrap.events.slice(-tailSize);
+      bootstrap.events = offer && !tail.includes(offer) ? [offer, ...tail] : tail;
     }
     return nextEvent;
   }

--- a/packages/cloudflare-worker/tests/session-tray-pruning.test.ts
+++ b/packages/cloudflare-worker/tests/session-tray-pruning.test.ts
@@ -247,6 +247,51 @@ describe('session-tray state pruning', () => {
       const lastEvent = bootstrap.events[bootstrap.events.length - 1];
       expect(lastEvent.sequence).toBe(bootstrap.nextSequence - 1);
     });
+
+    it('preserves bootstrap.offer when ICE candidates exceed cap', async () => {
+      const clock = { now: Date.now() };
+      const t = await createTestTray(clock);
+      const { socket } = await attachLeader(t);
+
+      const { bootstrapId } = await joinFollower(t, 'follower-1');
+
+      // Leader sends offer first
+      socket.send(
+        JSON.stringify({
+          type: 'bootstrap.offer',
+          bootstrapId,
+          offer: { type: 'offer', sdp: 'v=0\r\n...' },
+        })
+      );
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Then 30 ICE candidates (exceeds the 20-event cap)
+      for (let i = 0; i < 30; i++) {
+        socket.send(
+          JSON.stringify({
+            type: 'bootstrap.ice_candidate',
+            bootstrapId,
+            candidate: {
+              candidate: `candidate:${i}`,
+              sdpMid: '0',
+              sdpMLineIndex: 0,
+            },
+          })
+        );
+        await new Promise((r) => setTimeout(r, 0));
+      }
+
+      const tray = await readTray(t);
+      const bootstrap = tray.bootstraps[bootstrapId];
+      expect(bootstrap.events.length).toBeLessThanOrEqual(20);
+
+      // The offer must survive at the head despite 30+ candidates
+      const offerEvent = bootstrap.events.find(
+        (e: { type: string }) => e.type === 'bootstrap.offer'
+      );
+      expect(offerEvent).toBeDefined();
+      expect(bootstrap.events[0].type).toBe('bootstrap.offer');
+    });
   });
 
   describe('stale controller pruning', () => {

--- a/packages/cloudflare-worker/tests/session-tray-pruning.test.ts
+++ b/packages/cloudflare-worker/tests/session-tray-pruning.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Tests for session-tray DO state pruning (issue #1433):
+ * - Terminal bootstrap records are pruned after a grace window
+ * - Bootstrap events[] are capped
+ * - Stale controllers are pruned
+ */
+import { describe, expect, it } from 'vitest';
+import { SessionTrayDurableObject } from '../src/session-tray.js';
+import { createCapabilityToken, type TrayRecord } from '../src/shared.js';
+import type { FakeWebSocket } from './fake-do-state.js';
+import { createFakeWebSocketPair, FakeDurableObjectState } from './fake-do-state.js';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+const HOST = 'https://www.sliccy.ai';
+
+interface TestTray {
+  durable: SessionTrayDurableObject;
+  state: FakeDurableObjectState;
+  trayId: string;
+  joinUrl: string;
+  controllerUrl: string;
+  controllerToken: string;
+}
+
+/** Create a DO instance with a controllable clock and initialize a tray. */
+async function createTestTray(clockRef: { now: number }): Promise<TestTray> {
+  const state = new FakeDurableObjectState();
+  const durable = new SessionTrayDurableObject(
+    state,
+    {},
+    {
+      now: () => clockRef.now,
+      webSocketPairFactory: () => createFakeWebSocketPair(state),
+    }
+  );
+  state.instance = durable;
+
+  const trayId = crypto.randomUUID();
+  const joinToken = createCapabilityToken(trayId);
+  const controllerToken = createCapabilityToken(trayId);
+  const webhookToken = createCapabilityToken(trayId);
+
+  await durable.fetch(
+    new Request(`${HOST}/internal/create`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        trayId,
+        createdAt: new Date(clockRef.now).toISOString(),
+        joinToken,
+        controllerToken,
+        webhookToken,
+      }),
+    })
+  );
+
+  return {
+    durable,
+    state,
+    trayId,
+    joinUrl: `${HOST}/join/${joinToken}`,
+    controllerUrl: `${HOST}/controller/${controllerToken}`,
+    controllerToken,
+  };
+}
+
+/** Attach a leader and open the WebSocket. Returns the leader-side socket. */
+async function attachLeader(
+  t: TestTray,
+  controllerId = 'leader-1'
+): Promise<{ leaderKey: string; socket: FakeWebSocket }> {
+  const attachRes = await t.durable.fetch(
+    new Request(t.controllerUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ controllerId }),
+    })
+  );
+  const leader = (await attachRes.json()) as {
+    leaderKey: string;
+    websocket: { url: string };
+  };
+  const wsRes = await t.durable.fetch(
+    new Request(leader.websocket.url, { headers: { Upgrade: 'websocket' } })
+  );
+  const socket = (wsRes as unknown as { webSocket: FakeWebSocket }).webSocket;
+  return { leaderKey: leader.leaderKey, socket };
+}
+
+/** Join a follower and return bootstrap info. */
+async function joinFollower(
+  t: TestTray,
+  controllerId: string
+): Promise<{ bootstrapId: string; state: string }> {
+  const res = await t.durable.fetch(
+    new Request(`${t.joinUrl}?json=true`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ controllerId, action: 'attach' }),
+    })
+  );
+  const body = (await res.json()) as {
+    result?: { bootstrap?: { bootstrapId: string; state: string } };
+  };
+  return {
+    bootstrapId: body.result?.bootstrap?.bootstrapId ?? '',
+    state: body.result?.bootstrap?.state ?? '',
+  };
+}
+
+/** Read the persisted TrayRecord from fake storage. */
+async function readTray(t: TestTray): Promise<TrayRecord> {
+  return (await t.state.storage.get<TrayRecord>('tray'))!;
+}
+
+/** Overwrite the persisted TrayRecord. */
+async function writeTray(t: TestTray, tray: TrayRecord): Promise<void> {
+  await t.state.storage.put('tray', tray);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                             */
+/* ------------------------------------------------------------------ */
+
+describe('session-tray state pruning', () => {
+  describe('terminal bootstrap pruning', () => {
+    it('prunes completed bootstrap after grace window', async () => {
+      const clock = { now: Date.now() };
+      const t = await createTestTray(clock);
+      await attachLeader(t);
+
+      // Join follower 1 — creates a bootstrap
+      const { bootstrapId: bid1 } = await joinFollower(t, 'follower-1');
+
+      // Mark bootstrap as connected
+      const tray = await readTray(t);
+      tray.bootstraps[bid1].state = 'connected';
+      await writeTray(t, tray);
+
+      // Advance past grace window (expiresAt + 5min + 1s)
+      clock.now += 30_000 + 5 * 60 * 1000 + 1000;
+
+      // Join follower 2 — triggers pruning via ensureBootstrap
+      await joinFollower(t, 'follower-2');
+
+      const updated = await readTray(t);
+      expect(updated.bootstraps[bid1]).toBeUndefined();
+      expect(Object.keys(updated.bootstraps).length).toBe(1);
+    });
+
+    it('keeps retryable failed bootstrap until non-retryable', async () => {
+      const clock = { now: Date.now() };
+      const t = await createTestTray(clock);
+      await attachLeader(t);
+
+      const { bootstrapId: bid } = await joinFollower(t, 'follower-1');
+
+      // Mark as failed but retryable
+      const tray = await readTray(t);
+      const bootstrap = tray.bootstraps[bid];
+      bootstrap.state = 'failed';
+      bootstrap.failure = {
+        code: 'BOOTSTRAP_TIMEOUT',
+        message: 'Timeout',
+        retryable: true,
+        retryAfterMs: 1000,
+        failedAt: new Date(clock.now).toISOString(),
+      };
+      await writeTray(t, tray);
+
+      // Advance well past grace window
+      clock.now += 30_000 + 5 * 60 * 1000 + 60_000;
+
+      // Trigger pruning via new follower
+      await joinFollower(t, 'follower-2');
+
+      const updated = await readTray(t);
+      // Retryable bootstrap should NOT be pruned
+      expect(updated.bootstraps[bid]).toBeDefined();
+    });
+
+    it('prunes failed non-retryable bootstrap after grace window', async () => {
+      const clock = { now: Date.now() };
+      const t = await createTestTray(clock);
+      await attachLeader(t);
+
+      const { bootstrapId: bid } = await joinFollower(t, 'follower-1');
+
+      // Mark as failed AND non-retryable (maxRetries exhausted)
+      const tray = await readTray(t);
+      const bootstrap = tray.bootstraps[bid];
+      bootstrap.state = 'failed';
+      bootstrap.retryCount = bootstrap.maxRetries;
+      bootstrap.failure = {
+        code: 'BOOTSTRAP_TIMEOUT',
+        message: 'Timeout',
+        retryable: false,
+        retryAfterMs: null,
+        failedAt: new Date(clock.now).toISOString(),
+      };
+      await writeTray(t, tray);
+
+      // Advance past grace window
+      clock.now += 30_000 + 5 * 60 * 1000 + 1000;
+
+      // Trigger pruning
+      await joinFollower(t, 'follower-2');
+
+      const updated = await readTray(t);
+      expect(updated.bootstraps[bid]).toBeUndefined();
+    });
+  });
+
+  describe('bootstrap events cap', () => {
+    it('caps events at 20 per bootstrap', async () => {
+      const clock = { now: Date.now() };
+      const t = await createTestTray(clock);
+      const { socket } = await attachLeader(t);
+
+      const { bootstrapId } = await joinFollower(t, 'follower-1');
+
+      // Send 30 ICE candidates → 30 events appended
+      for (let i = 0; i < 30; i++) {
+        socket.send(
+          JSON.stringify({
+            type: 'bootstrap.ice_candidate',
+            bootstrapId,
+            candidate: {
+              candidate: `candidate:${i}`,
+              sdpMid: '0',
+              sdpMLineIndex: 0,
+            },
+          })
+        );
+        await new Promise((r) => setTimeout(r, 0));
+      }
+
+      const tray = await readTray(t);
+      const bootstrap = tray.bootstraps[bootstrapId];
+      expect(bootstrap.events.length).toBeLessThanOrEqual(20);
+      // nextSequence reflects all appended events (1 initial + 30 candidates)
+      expect(bootstrap.nextSequence).toBeGreaterThan(20);
+      // Last event should be the most recent
+      const lastEvent = bootstrap.events[bootstrap.events.length - 1];
+      expect(lastEvent.sequence).toBe(bootstrap.nextSequence - 1);
+    });
+  });
+
+  describe('stale controller pruning', () => {
+    it('prunes controllers older than 2h while keeping active ones', async () => {
+      const clock = { now: Date.now() };
+      const t = await createTestTray(clock);
+      await attachLeader(t);
+
+      // Join follower-old at the current time
+      await joinFollower(t, 'follower-old');
+
+      // Advance time by 3h (past the 2h stale threshold)
+      clock.now += 3 * 60 * 60 * 1000;
+
+      // Join follower-new — triggers pruning
+      await joinFollower(t, 'follower-new');
+
+      const tray = await readTray(t);
+      expect(tray.controllers['follower-old']).toBeUndefined();
+      expect(tray.controllers['follower-new']).toBeDefined();
+      // leader always survives
+      expect(tray.controllers['leader-1']).toBeDefined();
+    });
+
+    it('never prunes the current leader controller', async () => {
+      const clock = { now: Date.now() };
+      const t = await createTestTray(clock);
+      const { leaderKey } = await attachLeader(t);
+
+      // Advance time way past stale threshold
+      clock.now += 10 * 60 * 60 * 1000;
+
+      // Controller attach (leader reclaim) triggers pruning
+      await t.durable.fetch(
+        new Request(t.controllerUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            controllerId: 'leader-1',
+            leaderKey,
+          }),
+        })
+      );
+
+      const tray = await readTray(t);
+      expect(tray.controllers['leader-1']).toBeDefined();
+    });
+
+    it('keeps controllers within reclaim window', async () => {
+      const clock = { now: Date.now() };
+      const t = await createTestTray(clock);
+      await attachLeader(t);
+
+      // Join follower 90 minutes ago (within the 2h window)
+      await joinFollower(t, 'follower-recent');
+
+      // Advance by 90 minutes (< 2h threshold)
+      clock.now += 90 * 60 * 1000;
+
+      // Join another follower — triggers pruning
+      await joinFollower(t, 'follower-trigger');
+
+      const tray = await readTray(t);
+      expect(tray.controllers['follower-recent']).toBeDefined();
+    });
+  });
+
+  describe('bounded record under load', () => {
+    it('100-join / 100-event tray stays bounded', async () => {
+      const clock = { now: Date.now() };
+      const t = await createTestTray(clock);
+      const { socket } = await attachLeader(t);
+
+      for (let i = 0; i < 100; i++) {
+        const { bootstrapId } = await joinFollower(t, `follower-${i}`);
+
+        // Send ICE candidate for each bootstrap
+        socket.send(
+          JSON.stringify({
+            type: 'bootstrap.ice_candidate',
+            bootstrapId,
+            candidate: {
+              candidate: `candidate:${i}`,
+              sdpMid: '0',
+              sdpMLineIndex: 0,
+            },
+          })
+        );
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Mark previous bootstraps as connected
+        if (i > 0) {
+          const tray = await readTray(t);
+          for (const b of Object.values(tray.bootstraps)) {
+            if (b.controllerId !== `follower-${i}` && b.state === 'pending') {
+              b.state = 'connected';
+            }
+          }
+          await writeTray(t, tray);
+        }
+
+        // Advance time (10 min per follower = 1000 min total)
+        clock.now += 10 * 60 * 1000;
+      }
+
+      const tray = await readTray(t);
+
+      // Bootstrap count should be bounded
+      const bootstrapCount = Object.keys(tray.bootstraps).length;
+      expect(bootstrapCount).toBeLessThan(100);
+
+      // Controller count should be bounded
+      const controllerCount = Object.keys(tray.controllers).length;
+      expect(controllerCount).toBeLessThan(100);
+
+      // Events per bootstrap should be capped
+      for (const bootstrap of Object.values(tray.bootstraps)) {
+        expect(bootstrap.events.length).toBeLessThanOrEqual(20);
+      }
+
+      // Record size should be well under 128KB DO limit
+      const recordSize = JSON.stringify(tray).length;
+      expect(recordSize).toBeLessThan(128 * 1024);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1433 — the session-tray Durable Object's persisted record grows unbounded over a tray's lifetime. This PR adds opportunistic pruning of three accumulating data structures.

### Changes

#### 1. Prune terminal bootstraps
- Bootstraps in a terminal state (`connected`, or `failed` + non-retryable) are deleted after a 5-minute grace window past `expiresAt`.
- Grace window lets the follower poll the final failure before the record vanishes.
- Called opportunistically in `ensureBootstrap()` and `handleBootstrapRetry()` — no alarms needed.

#### 2. Bound `events[]`
- Events per bootstrap are capped at 20 in `appendBootstrapEvent()`.
- The follower polls via cursor (`getBootstrapEventsAfter`), so only recent events matter — dropping old SDP payloads (KB each) is safe.

#### 3. Prune stale controllers
- Controllers whose `lastSeenAt` is older than 2× the desktop reclaim TTL (2 hours) are pruned.
- The current leader's controller is never pruned.
- Called in `handleFollowerAttach()` and `handleControllerAttach()`.

#### 4. Ping path (no change needed)
The ping path already debounces `persistTray()` via `LEADER_SEEN_PERSIST_MS`. With parts 1–3 bounding the record size, no further optimization is needed.

### Preflight verification

All four claims from the issue body are confirmed on current `main`:
- `bootstraps` records are never deleted ✓ (no `delete tray.bootstraps` anywhere)
- `events.push` is unbounded ✓ (line 1513)
- `controllers` entries are never pruned ✓ (no `delete tray.controllers`)
- `persistTray()` on the ping path ✓ (already debounced)

### Tests

New test file: `packages/cloudflare-worker/tests/session-tray-pruning.test.ts`

- Terminal bootstrap pruning: completed + failed-non-retryable are pruned after grace; retryable-failed survive
- Events cap: 30 ICE candidates → at most 20 stored events; sequence numbers stay correct
- Controller pruning: stale (>2h) are pruned; leader controller always survives; recent controllers within window are kept
- Bounded record under load: 100-join/100-event tray stays bounded in bootstrap count, controller count, events per bootstrap, and total record size (<128KB)

### Verification

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npx vitest run --project cloudflare-worker` — 332 passed ✅
- `npm run test:coverage:cloudflare-worker` — at/above floor ✅