### PR TITLE
fix: browser.fetch 'body stream already read' on empty/204 responses (#1442)

### DIFF
--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -2349,10 +2349,11 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       'const h = {};' +
       'r.headers.forEach((v, k) => { h[k] = v; });' +
       "const ct = r.headers.get('content-type') || '';" +
+      'const t = await r.text();' +
       'let b;' +
       "if (ct.indexOf('application/json') !== -1) {" +
-      'try { b = await r.json(); } catch (e) { b = await r.text(); }' +
-      '} else { b = await r.text(); }' +
+      'if (!t) { b = null; } else { try { b = JSON.parse(t); } catch (e) { b = t; } }' +
+      '} else { b = t; }' +
       'return { ok: r.ok, status: r.status, headers: h, body: b };' +
     '})()';
   }

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -1254,10 +1254,11 @@ export function buildBrowserFetchScript(url: string, opts: BrowserFetchOptions =
     'const h = {};' +
     'r.headers.forEach((v, k) => { h[k] = v; });' +
     "const ct = r.headers.get('content-type') || '';" +
+    'const t = await r.text();' +
     'let b;' +
     "if (ct.indexOf('application/json') !== -1) {" +
-    'try { b = await r.json(); } catch (e) { b = await r.text(); }' +
-    '} else { b = await r.text(); }' +
+    'if (!t) { b = null; } else { try { b = JSON.parse(t); } catch (e) { b = t; } }' +
+    '} else { b = t; }' +
     'return { ok: r.ok, status: r.status, headers: h, body: b };' +
     '})()'
   );

--- a/packages/webapp/tests/kernel/realm/browser-fetch.test.ts
+++ b/packages/webapp/tests/kernel/realm/browser-fetch.test.ts
@@ -157,6 +157,54 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
     )) as BrowserFetchResult;
     expect(result.body).toBe('<html></html>');
   });
+
+  it('does not double-read the body on an empty JSON response (repro #1442)', async () => {
+    // Drive the built script against a REAL `Response` so the
+    // single-consumption stream semantics are exercised faithfully.
+    // An empty-STRING body has a real (empty) stream — the pre-fix
+    // branch did `await r.json()` (consumes the stream, throws on empty
+    // JSON) then `await r.text()` in the catch, a second read that
+    // throws "body stream already read".
+    const fakeFetch = async () =>
+      new Response('', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    const script = buildBrowserFetchScript('/api/empty');
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.body).toBeNull();
+  });
+
+  it('returns body null for a 204/empty-body PATCH/DELETE without throwing', async () => {
+    const fakeFetch = async () =>
+      new Response(null, {
+        status: 204,
+        headers: { 'content-type': 'application/json' },
+      });
+    const script = buildBrowserFetchScript('/api/thing', { method: 'DELETE' });
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.status).toBe(204);
+    expect(result.body).toBeNull();
+  });
+
+  it('parses a real non-empty JSON Response body exactly once', async () => {
+    const fakeFetch = async () =>
+      new Response('{"hello":"world"}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    const script = buildBrowserFetchScript('/api/x');
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.body).toEqual({ hello: 'world' });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1442. `require('sliccy:browser').fetch(tab, url, opts)` threw `TypeError: Failed to execute 'text' on 'Response': body stream already read` on mutating calls (PATCH/DELETE/PUT) whose success response had an empty or 204 body.

## Root cause

The page-context script built by `buildBrowserFetchScript` read the response body twice:

```js
if (ct.indexOf('application/json') !== -1) {
  try { b = await r.json(); } catch (e) { b = await r.text(); } // bug
} else { b = await r.text(); }
```

For an empty JSON-typed response, `r.json()` rejects (empty string is invalid JSON) **and** consumes the body stream; the `catch` fallback `r.text()` then throws `body stream already read`. The request already succeeded server-side, so the mutation happened but the caller saw a hard error.

## Fix

Read the body exactly once via `await r.text()`, then branch:
- `application/json`: empty text -> `null`; otherwise `JSON.parse(text)` with fallback to raw text on parse error.
- otherwise: raw text.

Applied identically to both copies (cross-runtime parity):
- `packages/webapp/src/kernel/realm/js-realm-shared.ts`
- `packages/chrome-extension/sandbox.html`

The emitted script strings remain byte-identical between the two.

## Tests

Added 3 regression tests in `packages/webapp/tests/kernel/realm/browser-fetch.test.ts` that execute the built script against a **real** `Response` (single-consumption stream) rather than independent `json()`/`text()` stubs:
- #1442 repro: empty body + `content-type: application/json` -> throws pre-fix, `body === null` post-fix.
- 204/empty DELETE -> `body === null` without throwing.
- non-empty JSON -> parses to object.

## Verification

- `npm run test -w @slicc/webapp -- browser-fetch` — 14/14 pass
- `npm run typecheck` — pass
- `npm run lint` — pass

## Scope

No change to `BrowserFetchResult` shape or the `browser.fetch` signature. No changes to the `http` client/`readBody` or the fetch-proxy. 3 files touched.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author