### PR TITLE
fix(shell): drop ffmpeg-command back-edge into ui/panel-rpc-handlers

### DIFF
--- a/packages/webapp/src/kernel/panel-rpc-camera-types.ts
+++ b/packages/webapp/src/kernel/panel-rpc-camera-types.ts
@@ -1,0 +1,56 @@
+/**
+ * Wire types for the `capture-camera` panel-RPC op. These live at the
+ * kernel layer so both the worker-side op surface (`panel-rpc.ts`) and
+ * the page-side handler (`ui/panel-rpc-handlers.ts`) — plus shell
+ * commands like `ffmpeg` — can share one definition without the kernel
+ * bundle depending back on `ui/`.
+ */
+
+export interface CameraCaptureRequest {
+  mode: 'photo' | 'video';
+  deviceId?: string;
+  /**
+   * Numeric index ("0"/"1"/…) into the audioinput enumeration OR a
+   * raw deviceId. Only consulted when `captureAudio` is truthy and
+   * the mode is `video`.
+   */
+  audioDeviceId?: string;
+  /** Include the mic track on a video recording. Ignored for photos. */
+  captureAudio?: boolean;
+  /**
+   * Open a video track on the stream. Defaults to true. Set to
+   * false for audio-only video captures so `getUserMedia` doesn't
+   * request a camera (avoiding the camera-permission prompt and
+   * NotFoundError on devices with no webcam).
+   */
+  captureVideo?: boolean;
+  width?: number;
+  height?: number;
+  frameRate?: number;
+  /**
+   * When true, use `exact:` constraints for width/height/frameRate
+   * so the browser fails fast instead of silently downscaling. The
+   * caller catches the resulting `OverconstrainedError` and falls
+   * back to `ideal:` constraints with a stderr warning.
+   */
+  exactSize?: boolean;
+  mimeType: string;
+  quality?: number;
+  durationMs?: number;
+  /**
+   * Photo mode: ms to let the sensor's auto-exposure / auto-white-
+   * balance settle before grabbing the frame. Webcams typically need
+   * 1–2s after the stream opens before the AE algorithm converges;
+   * skipping the warmup yields a noticeably dark first frame. Caller
+   * may pass `0` to opt out for "fast" captures.
+   */
+  warmupMs?: number;
+}
+
+export interface CameraCaptureResult {
+  bytes: ArrayBuffer;
+  mimeType: string;
+  width: number;
+  height: number;
+  durationMs?: number;
+}

--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -43,6 +43,7 @@ import type { LeaderTrayRuntimeStatus } from '../scoops/tray-leader.js';
 import type { TrayLeaveResult } from '../scoops/tray-leave.js';
 import type { SudoDecision, SudoRequest } from '../sudo/types.js';
 import type { HidDeviceFilter, HidDeviceInfo } from './hid-device-registry.js';
+import type { CameraCaptureRequest, CameraCaptureResult } from './panel-rpc-camera-types.js';
 import type {
   SerialDeviceInfo,
   SerialFilter,
@@ -141,28 +142,7 @@ export type PanelRpcRequest =
     }
   | {
       op: 'capture-camera';
-      payload: {
-        mode: 'photo' | 'video';
-        deviceId?: string;
-        audioDeviceId?: string;
-        captureAudio?: boolean;
-        /**
-         * Open a video track on the stream. Defaults to true for
-         * photo / video mode; set to false for audio-only video
-         * captures so `getUserMedia` doesn't request a camera.
-         */
-        captureVideo?: boolean;
-        width?: number;
-        height?: number;
-        frameRate?: number;
-        exactSize?: boolean;
-        mimeType: string;
-        quality?: number;
-        durationMs?: number;
-        /** Photo mode: ms to let the sensor's auto-exposure settle
-         * before grabbing the frame. */
-        warmupMs?: number;
-      };
+      payload: CameraCaptureRequest;
     }
   | { op: 'enumerate-media-devices'; payload?: undefined }
   // Speech capture / transcription for the `hear` command. The kernel
@@ -551,13 +531,7 @@ export interface PanelRpcResults {
   'window-open': { opened: boolean };
   'oauth-popup': { redirectUrl: string | null };
   'silent-renew': { accessToken: string | null };
-  'capture-camera': {
-    bytes: ArrayBuffer;
-    mimeType: string;
-    width: number;
-    height: number;
-    durationMs?: number;
-  };
+  'capture-camera': CameraCaptureResult;
   'enumerate-media-devices': {
     videoinputs: Array<{ deviceId: string; label: string; groupId?: string }>;
     audioinputs: Array<{ deviceId: string; label: string; groupId?: string }>;

--- a/packages/webapp/src/shell/supplemental-commands/ffmpeg-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ffmpeg-command.ts
@@ -30,11 +30,10 @@
 import type { Command, CommandContext } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { getPanelRpcClient, hasLocalDom, type PermissionRpcKind } from '../../kernel/panel-rpc.js';
-import {
-  type CameraCaptureRequest,
-  type CameraCaptureResult,
-  captureCamera,
-} from '../../ui/panel-rpc-handlers.js';
+import type {
+  CameraCaptureRequest,
+  CameraCaptureResult,
+} from '../../kernel/panel-rpc-camera-types.js';
 import { captureViaPopup, isExtensionFloat } from './extension-media-capture.js';
 import {
   FFMPEG_CORE_NOT_INSTALLED,
@@ -491,8 +490,7 @@ async function tryPageRealmCapturePermission(
  * capture mechanism (panel-rpc, direct `getUserMedia`, or the
  * extension capture popup). Mirrors the composer-speech mic flow
  * (`packages/webapp/src/speech/composer-speech.ts`) and the
- * `permission-request` panel-RPC handler
- * (`packages/webapp/src/ui/panel-rpc-handlers.ts`):
+ * `permission-request` panel-RPC handler:
  *
  * - Page realm with a mounted surface → call `surface.prompt(...)`
  *   directly. Granted → `{ ok: true }`; cancelled / error → clean
@@ -888,9 +886,6 @@ async function performCameraCapture(
   try {
     if (isExtensionFloat()) {
       return { result: await captureViaExtensionPopup(plan) };
-    }
-    if (hasLocalDom() && typeof navigator !== 'undefined' && navigator.mediaDevices) {
-      return { result: await captureCamera(plan.request) };
     }
     const r = await captureViaPanelRpc(plan);
     if (!r) {

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -20,6 +20,10 @@ import {
 } from '../kernel/hid-device-registry.js';
 import * as hidOps from '../kernel/hid-operations.js';
 import type { PanelRpcHandlers, PanelRpcResults, PermissionRpcGrant } from '../kernel/panel-rpc.js';
+import type {
+  CameraCaptureRequest,
+  CameraCaptureResult,
+} from '../kernel/panel-rpc-camera-types.js';
 import * as serialOps from '../kernel/serial-operations.js';
 import {
   getNavigatorSerial,
@@ -1099,54 +1103,11 @@ function requireSerial() {
 
 // ── Camera capture (page-side) ──────────────────────────────────────
 
-export interface CameraCaptureRequest {
-  mode: 'photo' | 'video';
-  deviceId?: string;
-  /**
-   * Numeric index ("0"/"1"/…) into the audioinput enumeration OR a
-   * raw deviceId. Only consulted when `captureAudio` is truthy and
-   * the mode is `video`.
-   */
-  audioDeviceId?: string;
-  /** Include the mic track on a video recording. Ignored for photos. */
-  captureAudio?: boolean;
-  /**
-   * Open a video track on the stream. Defaults to true. Set to
-   * false for audio-only video captures so `getUserMedia` doesn't
-   * request a camera (avoiding the camera-permission prompt and
-   * NotFoundError on devices with no webcam).
-   */
-  captureVideo?: boolean;
-  width?: number;
-  height?: number;
-  frameRate?: number;
-  /**
-   * When true, use `exact:` constraints for width/height/frameRate
-   * so the browser fails fast instead of silently downscaling. The
-   * caller catches the resulting `OverconstrainedError` and falls
-   * back to `ideal:` constraints with a stderr warning.
-   */
-  exactSize?: boolean;
-  mimeType: string;
-  quality?: number;
-  durationMs?: number;
-  /**
-   * Photo mode: ms to let the sensor's auto-exposure / auto-white-
-   * balance settle before grabbing the frame. Webcams typically need
-   * 1–2s after the stream opens before the AE algorithm converges;
-   * skipping the warmup yields a noticeably dark first frame. Caller
-   * may pass `0` to opt out for "fast" captures.
-   */
-  warmupMs?: number;
-}
-
-export interface CameraCaptureResult {
-  bytes: ArrayBuffer;
-  mimeType: string;
-  width: number;
-  height: number;
-  durationMs?: number;
-}
+// Wire types moved to `kernel/panel-rpc-camera-types.ts` (imported at
+// the top of this file) so the kernel bundle no longer depends back on
+// `ui/`. Re-exported here for backward compatibility with existing
+// importers.
+export type { CameraCaptureRequest, CameraCaptureResult };
 
 const DEFAULT_PHOTO_WARMUP_MS = 1500;
 


### PR DESCRIPTION
Fixes #1438.

## Problem

The worker-resident `shell/supplemental-commands/ffmpeg-command.ts` statically imported `captureCamera` plus the `CameraCaptureRequest` / `CameraCaptureResult` types from the DOM-heavy page module `ui/panel-rpc-handlers.ts` (1,718 lines). That back-edge against the layer stack (`fs → shell/git → cdp → tools → core → scoops → ui`) dragged `ui/*` — and transitively `ui/provider-settings.ts` — into the kernel-worker compile graph, even though only the panel-RPC path actually runs there.

## Fix (behavior-preserving)

- **New** `packages/webapp/src/kernel/panel-rpc-camera-types.ts` homes the `CameraCaptureRequest` / `CameraCaptureResult` wire types beside the RPC contract.
- `ui/panel-rpc-handlers.ts` and `kernel/panel-rpc.ts` now consume the shared types (removing the duplicated inline shapes in the `capture-camera` op payload/result).
- `ffmpeg-command.ts` drops the `ui/panel-rpc-handlers.js` import entirely and removes the `hasLocalDom()` capture fast-path so non-extension floats route unconditionally through the existing `capture-camera` panel-RPC boundary. `hasLocalDom` stays (still used by `enumerateMediaDevices`).

Dependency direction after the fix: `shell/*-command → kernel/panel-rpc-* (types + client)`, with `ui/panel-rpc-handlers.ts` importing those same types — page-only code stays page-only and the worker bundle stops pulling in `ui/*`.

## Verification

- `rg "ui/panel-rpc-handlers" packages/webapp/src/shell/` → empty
- Wire types are field-by-field identical to the originals; `capture-camera` op payload/result structurally unchanged
- `npm run lint` ✅
- `npm run typecheck` ✅ (all 9 tsc, incl. the `tsconfig.webapp-worker.json` no-DOM kernel-worker guard)
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/ffmpeg-command.test.ts` ✅ (52/52)
- `npm run build -w @slicc/webapp` ✅

Independently verified by a second agent; no defects found.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author