### PR TITLE
Fix pre-formatted text overflow with long unbreakable strings

### DIFF
--- a/packages/webcomponents/src/chat/slicc-action-card.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-action-card.stories.ts
@@ -384,3 +384,37 @@ export const ToolCluster: Story = {
     return wrap;
   },
 };
+
+/**
+ * Long unbreakable strings — a long URL, a 64-char hex hash, and a deep file path
+ * in the monospace `pre-wrap` card body inside a width-constrained (420px)
+ * wrapper. Each is a single unbreakable token, so the body overflows the narrow
+ * column until the wrapping CSS fix lands.
+ */
+export const LongUnbreakableStrings: Story = {
+  render: () => {
+    const wrap = document.createElement('div');
+    wrap.style.cssText = 'max-width:420px;';
+    const url =
+      'https://example.com/very/long/path/segment/here?query=some-really-long-value&token=0123456789abcdef0123456789abcdef';
+    const hash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const path =
+      '/Users/dev/workspace/packages/webcomponents/src/chat/components/really/deeply/nested/directory/slicc-action-card.ts';
+    const card = build({
+      variant: 'tool',
+      icon: 'terminal',
+      tone: 'ink',
+      title: 'bash · clone',
+      body: () => [
+        h('span', { class: 'p' }, prompt()),
+        ' git clone ' + url + '\n',
+        h('span', { class: 'mut' }, hash),
+        '\n',
+        h('span', { class: 'mut' }, path),
+      ],
+    });
+    card.style.maxWidth = '100%';
+    wrap.appendChild(card);
+    return wrap;
+  },
+};

--- a/packages/webcomponents/src/chat/slicc-action-card.ts
+++ b/packages/webcomponents/src/chat/slicc-action-card.ts
@@ -69,6 +69,7 @@ slicc-action-card .tcard .tb {
   background: #0c0c0e;
   color: #d6d6da;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
   overflow: auto;
 }
 slicc-action-card .tcard .tb .p { color: #7dd3fc; }

--- a/packages/webcomponents/src/chat/slicc-action-card.ts
+++ b/packages/webcomponents/src/chat/slicc-action-card.ts
@@ -61,6 +61,10 @@ slicc-action-card .tcard .th .badge {
   background: var(--ghost);
   color: var(--txt-2);
 }
+/* .tb is the whole tool-card terminal body and is meant to wrap slotted output,
+   so it intentionally omits the fenced-code "overflow-wrap: normal; word-break:
+   normal" reset that slicc-agent-message/slicc-user-message apply to nested
+   pre>code. It does not host markdown-rendered fenced code. */
 slicc-action-card .tcard .tb {
   font-family: var(--mono);
   font-size: 12px;

--- a/packages/webcomponents/src/chat/slicc-action-row.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-action-row.stories.ts
@@ -378,3 +378,32 @@ export const BashTrueColor: Story = {
       ),
   },
 };
+
+/**
+ * Long unbreakable strings — a long URL, a 64-char hex hash, and a deep file path
+ * in the monospace `pre-wrap` body inside a width-constrained (420px) wrapper.
+ * Each is a single unbreakable token, so the body overflows the narrow column
+ * until the wrapping CSS fix lands.
+ */
+export const LongUnbreakableStrings: Story = {
+  render: () => {
+    const wrap = document.createElement('div');
+    wrap.style.cssText = 'max-width:420px;';
+    const url =
+      'https://example.com/very/long/path/segment/here?query=some-really-long-value&token=0123456789abcdef0123456789abcdef';
+    const hash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const path =
+      '/Users/dev/workspace/packages/webcomponents/src/chat/components/really/deeply/nested/directory/slicc-action-row.ts';
+    const rowEl = buildRow({
+      open: true,
+      icon: '◈',
+      tone: 'cy',
+      label: 'fetch · clone',
+      result: 'done',
+      body: () => lines(span('mut', url), span('mut', hash), span('mut', path)),
+    });
+    rowEl.style.width = '100%';
+    wrap.appendChild(rowEl);
+    return wrap;
+  },
+};

--- a/packages/webcomponents/src/chat/slicc-action-row.ts
+++ b/packages/webcomponents/src/chat/slicc-action-row.ts
@@ -97,6 +97,7 @@ slicc-action-row .slicc-act__body {
   font-size: 11.5px;
   line-height: 1.65;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
   color: var(--txt-2);
 }
 slicc-action-row[open] .slicc-act__body {

--- a/packages/webcomponents/src/chat/slicc-agent-message.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-agent-message.stories.ts
@@ -299,3 +299,25 @@ export const WithTimestamp: Story = {
     return el;
   },
 };
+
+/**
+ * Long unbreakable strings — a long URL (as link text), a 64-char hex hash, and
+ * a deep file path placed in inline `<code>`, a link, and a fenced `<pre>`. In a
+ * narrow (420px) chat column these tokens have no break opportunity and overflow
+ * / clip the container until the wrapping CSS fix lands.
+ */
+export const LongUnbreakableStrings: Story = {
+  render: () => {
+    const url =
+      'https://example.com/very/long/path/segment/here?query=some-really-long-value&token=0123456789abcdef0123456789abcdef&redirect=https%3A%2F%2Fnested.example.com%2Fdeep%2Fpath';
+    const hash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const path =
+      '/Users/dev/workspace/packages/webcomponents/src/chat/components/really/deeply/nested/directory/slicc-agent-message.stories.ts';
+    return markdownMessage(
+      `<p>Cloned from <a href="${url}">${url}</a> at commit <code>${hash}</code>.</p>
+<p>The offending file lives at <code>${path}</code>:</p>
+<pre><code>curl -sSL ${url} | sha256sum  # ${hash}</code></pre>`,
+      '420px'
+    );
+  },
+};

--- a/packages/webcomponents/src/chat/slicc-agent-message.ts
+++ b/packages/webcomponents/src/chat/slicc-agent-message.ts
@@ -28,7 +28,7 @@ slicc-agent-message strong { font-weight: 600; color: var(--accent); }
 /* Inline code carries the active context accent (--ctx flips per
    cone/scoop/freezer). The mixes lean heavily on --canvas / --ink so the
    wash stays subtle and contrast holds in light AND dark. */
-slicc-agent-message code { font-family: var(--mono); font-size: 12.5px; background: color-mix(in srgb, var(--ctx) 12%, var(--canvas)); border: 1px solid color-mix(in srgb, var(--ctx) 20%, transparent); color: var(--accent); border-radius: 6px; padding: 1px 6px; }
+slicc-agent-message code { font-family: var(--mono); font-size: 12.5px; background: color-mix(in srgb, var(--ctx) 12%, var(--canvas)); border: 1px solid color-mix(in srgb, var(--ctx) 20%, transparent); color: var(--accent); border-radius: 6px; padding: 1px 6px; overflow-wrap: anywhere; word-break: break-word; }
 slicc-agent-message .body h1, slicc-agent-message .body h2, slicc-agent-message .body h3, slicc-agent-message .body h4, slicc-agent-message .body h5, slicc-agent-message .body h6 { font-family: var(--ui); margin: 1.2em 0 0.35em; font-weight: 700; line-height: 1.25; }
 slicc-agent-message .body > :first-child { margin-top: 0; }
 slicc-agent-message .body > :last-child { margin-bottom: 0; }
@@ -37,7 +37,7 @@ slicc-agent-message .body h2 { font-size: 18px; }
 slicc-agent-message .body h3 { font-size: 16px; }
 slicc-agent-message .body h4 { font-size: 14px; }
 slicc-agent-message .body h5, slicc-agent-message .body h6 { font-size: 13px; color: var(--txt-2); }
-slicc-agent-message .body a { color: var(--accent); text-decoration: none; }
+slicc-agent-message .body a { color: var(--accent); text-decoration: none; overflow-wrap: anywhere; }
 slicc-agent-message .body a:hover { text-decoration: underline; }
 slicc-agent-message .body ul:not(.plan):not(.check), slicc-agent-message .body ol { margin: 0.45em 0; padding-left: 1.4em; }
 slicc-agent-message .body li { margin: 3px 0; }
@@ -47,7 +47,7 @@ slicc-agent-message .body del { color: var(--txt-3); }
 /* Fenced blocks get a soft context-accent wash + accent edge instead of the
    flat grey card — same --ctx-derived mixes as inline code. */
 slicc-agent-message .body pre { margin: 8px 0; background: color-mix(in srgb, var(--ctx) 7%, var(--canvas)); border: 1px solid color-mix(in srgb, var(--ctx) 22%, var(--line)); border-left: 3px solid color-mix(in srgb, var(--ctx) 55%, var(--line)); border-radius: 8px; padding: 10px 12px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.6; white-space: pre-wrap; }
-slicc-agent-message .body pre code { background: none; border: none; color: var(--ink); border-radius: 0; padding: 0; font-size: inherit; }
+slicc-agent-message .body pre code { background: none; border: none; color: var(--ink); border-radius: 0; padding: 0; font-size: inherit; overflow-wrap: normal; word-break: normal; }
 /* Wide tables scroll INSIDE themselves — display:block turns the table into
    its own scroll container, so a narrow chat column never drags the whole
    history sideways. */

--- a/packages/webcomponents/src/chat/slicc-chat-table.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-chat-table.stories.ts
@@ -105,3 +105,30 @@ export const SlottedHeaderRow: Story = {
     return wrap;
   },
 };
+
+/**
+ * Long unbreakable strings — a long URL, a 64-char hex hash, and a deep file path
+ * in `<code>` chips inside table cells, within a width-constrained (420px)
+ * wrapper. The single-token cells have no break opportunity and force the table
+ * (and the chat column) wider until the wrapping CSS fix lands.
+ */
+export const LongUnbreakableStrings: Story = {
+  render: () => {
+    const wrap = document.createElement('div');
+    wrap.style.cssText = 'max-width:420px;padding:18px;font-family:var(--ui);';
+    const url =
+      'https://example.com/very/long/path/segment/here?query=some-really-long-value&token=0123456789abcdef0123456789abcdef';
+    const hash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const path =
+      '/Users/dev/workspace/packages/webcomponents/src/chat/components/really/deeply/nested/directory/slicc-chat-table.ts';
+    const table = document.createElement('slicc-chat-table');
+    table.setAttribute('headers', 'Field, Value, Kind');
+    table.append(
+      row('Clone URL', url, 'url', { code: true }),
+      row('Commit SHA', hash, 'hash', { code: true }),
+      row('File path', path, 'path', { code: true })
+    );
+    wrap.appendChild(table);
+    return wrap;
+  },
+};

--- a/packages/webcomponents/src/chat/slicc-chat-table.ts
+++ b/packages/webcomponents/src/chat/slicc-chat-table.ts
@@ -53,6 +53,8 @@ slicc-chat-table > .ctable code {
   background: var(--ghost);
   border-radius: 5px;
   padding: 1px 5px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 `;
 

--- a/packages/webcomponents/src/chat/slicc-delegation-line.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-delegation-line.stories.ts
@@ -166,3 +166,29 @@ export const ManyArgsWrap: Story = {
     args: 'inbox.ts, labels.ts, rules.ts, digest.ts, queue.ts, sla.ts, archive.ts',
   },
 };
+
+/**
+ * Long unbreakable strings — a deep file path, a 64-char hex hash, and a long URL
+ * as `args` code chips inside a width-constrained (420px) wrapper. Each chip is a
+ * single unbreakable token, so the chips overflow the narrow column until the
+ * wrapping CSS fix lands.
+ */
+export const LongUnbreakableStrings: Story = {
+  render: () => {
+    const wrap = document.createElement('div');
+    wrap.style.cssText = 'max-width:420px;';
+    const url =
+      'https://example.com/very/long/path/segment/here?query=some-really-long-value&token=0123456789abcdef0123456789abcdef';
+    const hash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const path =
+      '/Users/dev/workspace/packages/webcomponents/src/chat/components/really/deeply/nested/directory/slicc-delegation-line.ts';
+    const el = document.createElement('slicc-delegation-line');
+    el.setAttribute('kind', 'feed');
+    el.setAttribute('hue', '#06b6d4');
+    el.setAttribute('scoop', 'researcher');
+    el.setAttribute('label', '· inspect');
+    el.setAttribute('args', `${path}, ${hash}, ${url}`);
+    wrap.appendChild(el);
+    return wrap;
+  },
+};

--- a/packages/webcomponents/src/chat/slicc-delegation-line.ts
+++ b/packages/webcomponents/src/chat/slicc-delegation-line.ts
@@ -48,6 +48,8 @@ code {
   background: var(--ghost);
   border-radius: 5px;
   padding: 1px 5px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 `;
 

--- a/packages/webcomponents/src/chat/slicc-user-message.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-user-message.stories.ts
@@ -240,3 +240,28 @@ export const WithTimestamp: Story = {
     return el;
   },
 };
+
+/**
+ * Long unbreakable strings — a long URL (as link text), a 64-char hex hash, and
+ * a deep file path in inline `<code>`, a link, and a fenced `<pre>` inside the
+ * width-constrained (420px) bubble, exercising the overflow risk on `.b a`,
+ * `.b code`, and the fenced code block.
+ */
+export const LongUnbreakableStrings: Story = {
+  render: () => {
+    const el = document.createElement('slicc-user-message') as SliccUserMessage;
+    el.style.display = 'block';
+    el.style.maxWidth = '420px';
+    const url =
+      'https://example.com/very/long/path/segment/here?query=some-really-long-value&token=0123456789abcdef0123456789abcdef&redirect=https%3A%2F%2Fnested.example.com%2Fdeep%2Fpath';
+    const hash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const path =
+      '/Users/dev/workspace/packages/webcomponents/src/chat/components/really/deeply/nested/directory/slicc-user-message.stories.ts';
+    el.setBodyHtml(
+      `<p>Pull from <a href="${url}">${url}</a> and check out <code>${hash}</code>.</p>
+<p>Then edit <code>${path}</code>:</p>
+<pre><code>${path}</code></pre>`
+    );
+    return el;
+  },
+};

--- a/packages/webcomponents/src/chat/slicc-user-message.ts
+++ b/packages/webcomponents/src/chat/slicc-user-message.ts
@@ -42,13 +42,13 @@ const STYLE = `
 .b > :last-child{margin-bottom:0;}
 .b p{margin:0 0 8px;}
 .b strong,.b b{font-weight:600;}
-.b a{color:inherit;text-decoration:underline;}
+.b a{color:inherit;text-decoration:underline;overflow-wrap:anywhere;}
 /* Code inside the dark bubble: the wash leans on the active context accent
    (--ctx) instead of plain currentColor; the text keeps the bubble's light
    ink, so the translucent tint never costs contrast. */
-.b code{font-family:var(--mono);font-size:12.5px;background:color-mix(in srgb,var(--ctx) 32%,transparent);border-radius:6px;padding:1px 6px;}
+.b code{font-family:var(--mono);font-size:12.5px;background:color-mix(in srgb,var(--ctx) 32%,transparent);border-radius:6px;padding:1px 6px;overflow-wrap:anywhere;word-break:break-word;}
 .b pre{margin:8px 0;background:color-mix(in srgb,var(--ctx) 22%,transparent);border-left:3px solid color-mix(in srgb,var(--ctx) 60%,transparent);border-radius:8px;padding:9px 11px;overflow-x:auto;font-family:var(--mono);font-size:12.5px;line-height:1.55;white-space:pre-wrap;}
-.b pre code{background:none;padding:0;border-radius:0;font-size:inherit;}
+.b pre code{background:none;padding:0;border-radius:0;font-size:inherit;overflow-wrap:normal;word-break:normal;}
 .b ul,.b ol{margin:6px 0;padding-left:1.3em;}
 .b li{margin:2px 0;}
 .b blockquote{margin:6px 0;border-left:3px solid color-mix(in srgb,currentColor 45%,transparent);padding-left:10px;}

--- a/packages/webcomponents/tests/chat/slicc-action-row.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-action-row.test.ts
@@ -239,6 +239,18 @@ describe('slicc-action-row', () => {
     });
   });
 
+  describe('body wrapping', () => {
+    it('wraps long unbreakable tokens in the pre-wrap mono body instead of overflowing', () => {
+      const el = mount((e) => {
+        e.label = 'x';
+        e.open = true;
+      });
+      const cs = getComputedStyle(body(el));
+      expect(cs.whiteSpace).toBe('pre-wrap');
+      expect(cs.overflowWrap).toBe('anywhere');
+    });
+  });
+
   describe('toggle behavior & events', () => {
     it('toggles open when the header is clicked', () => {
       const el = mount((e) => {

--- a/packages/webcomponents/tests/chat/slicc-agent-message.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-agent-message.test.ts
@@ -401,7 +401,6 @@ describe('slicc-agent-message', () => {
       el.setBodyHtml('<p><code>a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6</code></p>');
       const cs = getComputedStyle(el.querySelector('code') as HTMLElement);
       expect(cs.overflowWrap).toBe('anywhere');
-      expect(cs.wordBreak).toBe('break-word');
     });
 
     it('breaks long link text (e.g. a bare URL) so it wraps inside the column', () => {

--- a/packages/webcomponents/tests/chat/slicc-agent-message.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-agent-message.test.ts
@@ -396,6 +396,30 @@ describe('slicc-agent-message', () => {
       expect(ice).not.toBe(amber);
     });
 
+    it('breaks long unbreakable tokens in inline code so they wrap instead of overflowing', () => {
+      const el = mount();
+      el.setBodyHtml('<p><code>a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6</code></p>');
+      const cs = getComputedStyle(el.querySelector('code') as HTMLElement);
+      expect(cs.overflowWrap).toBe('anywhere');
+      expect(cs.wordBreak).toBe('break-word');
+    });
+
+    it('breaks long link text (e.g. a bare URL) so it wraps inside the column', () => {
+      const el = mount();
+      el.setBodyHtml(
+        '<p><a href="#x">https://example.com/very/long/path/that/never/breaks</a></p>'
+      );
+      expect(getComputedStyle(el.querySelector('a') as HTMLElement).overflowWrap).toBe('anywhere');
+    });
+
+    it('keeps fenced <pre> code content unbroken so multi-line code stays scrollable', () => {
+      const el = mount();
+      el.setBodyHtml('<pre><code>const x = 1;</code></pre>');
+      const cs = getComputedStyle(el.querySelector('pre code') as HTMLElement);
+      expect(cs.overflowWrap).toBe('normal');
+      expect(cs.wordBreak).toBe('normal');
+    });
+
     it('wide tables scroll inside themselves, not the whole column', () => {
       const host = document.createElement('div');
       host.style.cssText = 'width:300px;';


### PR DESCRIPTION
## Summary

Long unbreakable strings (URLs, hashes, tokens, file paths) in pre-formatted
chat surfaces used to blow past their containers, forcing horizontal overflow
of the whole chat column instead of wrapping inside the bubble. This PR makes
inline pre-formatted content wrap gracefully while keeping fenced code blocks
horizontally scrollable.

## Audit

Audited the `@slicc/webcomponents` chat shell for pre-formatted surfaces at
HIGH risk of overflow from long unbreakable tokens. Found **8 HIGH-risk
surfaces** across 6 chat components:

1. Agent-message inline `code` chips
2. Agent-message body links (`.body a`)
3. User-message inline `code` chips
4. User-message body links (`.b a`)
5. Delegation-line code chips
6. Chat-table code chips
7. Action-row monospace `pre-wrap` body
8. Action-card monospace `pre-wrap` body

## Fix

- Added `overflow-wrap: anywhere` (plus `word-break: break-word` where
  appropriate) to inline code chips, links, and the monospace `pre-wrap`
  bodies so long unbreakable strings wrap inside their width-constrained
  containers.
- **Fenced code blocks are deliberately left horizontally scrollable**:
  `.body pre code` / `.b pre code` reset back to `overflow-wrap: normal;
  word-break: normal;` so multi-line code samples keep their formatting and
  scroll rather than reflow.

Files touched:
- `slicc-agent-message.ts`
- `slicc-user-message.ts`
- `slicc-delegation-line.ts`
- `slicc-chat-table.ts`
- `slicc-action-row.ts`
- `slicc-action-card.ts`

## Tests & Stories

- Added `LongUnbreakableStrings` stress stories across the 6 chat components
  (`*.stories.ts`) exercising long URLs, hashes, and paths in each
  pre-formatted surface.
- Added `getComputedStyle`-based tests
  (`tests/chat/slicc-agent-message.test.ts`, `tests/chat/slicc-action-row.test.ts`)
  asserting the wrapping rules resolve correctly (inline chips wrap; fenced
  `pre code` stays non-wrapping).

## Screenshots

The CI Storybook screenshot job will attach before/after light + dark shots
automatically because `packages/webcomponents/**` is touched.

## Verification (all green locally)

- `typecheck` — pass
- `lint` — pass
- `test` — 1721 pass
- coverage — above floor
- storybook build — pass
