### PR TITLE
feat(browser-fetch): support binary and FormData/URLSearchParams payloads (#1445)

### DIFF
--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -2415,7 +2415,8 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       'const __ctl = ct.toLowerCase();' +
       "const __binPrefixes = ['image/','audio/','video/','application/octet-stream'," +
       "'application/pdf','application/protobuf','application/x-protobuf','application/wasm','application/zip'];" +
-      "const __isBinary = __rt === 'binary' || (__rt !== 'text' && __rt !== 'json' && " +
+      "const __isXml = __ctl.indexOf('+xml') !== -1 || __ctl.indexOf('application/xml') === 0 || __ctl.indexOf('text/xml') === 0;" +
+      "const __isBinary = __rt === 'binary' || (__rt !== 'text' && __rt !== 'json' && !__isXml && " +
       '__binPrefixes.some((p) => __ctl.indexOf(p) === 0));' +
       'if (__isBinary) {' +
       'const __u = new Uint8Array(await r.arrayBuffer());' +

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -2400,6 +2400,10 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
         'if (e.file) { __fd.append(e.name, new Blob([__b64(e.file.data)], { type: e.file.type }), e.file.filename); } ' +
         'else { __fd.append(e.name, e.value); } } __init.body = __fd; }';
     }
+    // Response assembly mirrors buildResponseHandlingScript in
+    // js-realm-shared.ts: responseType (or a conservative binary
+    // Content-Type allowlist) selects binary (base64 + bodyEncoding) /
+    // JSON / text. Body is read exactly once (arrayBuffer XOR text).
     return '(async () => {' +
       'const __init = ' + JSON.stringify(init) + ';' +
       reconstruct +
@@ -2407,11 +2411,24 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       'const h = {};' +
       'r.headers.forEach((v, k) => { h[k] = v; });' +
       "const ct = r.headers.get('content-type') || '';" +
+      'const __rt = ' + JSON.stringify(opts.responseType || null) + ';' +
+      'const __ctl = ct.toLowerCase();' +
+      "const __binPrefixes = ['image/','audio/','video/','application/octet-stream'," +
+      "'application/pdf','application/protobuf','application/x-protobuf','application/wasm','application/zip'];" +
+      "const __isBinary = __rt === 'binary' || (__rt !== 'text' && __rt !== 'json' && " +
+      '__binPrefixes.some((p) => __ctl.indexOf(p) === 0));' +
+      'if (__isBinary) {' +
+      'const __u = new Uint8Array(await r.arrayBuffer());' +
+      "let __s = ''; const __cs = 0x8000;" +
+      'for (let __i = 0; __i < __u.length; __i += __cs) { ' +
+      '__s += String.fromCharCode.apply(null, __u.subarray(__i, __i + __cs)); }' +
+      "return { ok: r.ok, status: r.status, headers: h, body: btoa(__s), bodyEncoding: 'base64' };" +
+      '}' +
       'const t = await r.text();' +
       'let b;' +
-      "if (ct.indexOf('application/json') !== -1) {" +
-      'if (!t) { b = null; } else { try { b = JSON.parse(t); } catch (e) { b = t; } }' +
-      '} else { b = t; }' +
+      "const __jsonWanted = __rt === 'json' || (__rt !== 'text' && ct.indexOf('application/json') !== -1);" +
+      'if (__jsonWanted) { if (!t) { b = null; } else { try { b = JSON.parse(t); } catch (e) { b = t; } } }' +
+      'else { b = t; }' +
       'return { ok: r.ok, status: r.status, headers: h, body: b };' +
     '})()';
   }

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -2318,7 +2318,16 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   // `browser.fetch` — page-context fetch on top of evalAsync. Mirrors
   // buildBrowserFetchScript in js-realm-shared.ts. Credentials default
   // to 'include' so the page's session cookies travel automatically.
-  function buildBrowserFetchScript(url, opts) {
+  // Base64-encode bytes without overflowing the argument stack.
+  function bytesToBase64(bytes) {
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize));
+    }
+    return btoa(binary);
+  }
+  async function buildBrowserFetchScript(url, opts) {
     opts = opts || {};
     const headers = {};
     const rawHeaders = opts.headers || {};
@@ -2328,14 +2337,45 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
     const method = typeof opts.method === 'string' ? opts.method : 'GET';
     const credentials = (opts.credentials === 'same-origin' || opts.credentials === 'omit') ? opts.credentials : 'include';
+    const hasContentType = () => Object.keys(headers).some((k) => k.toLowerCase() === 'content-type');
     let body;
-    if (opts.body !== undefined && opts.body !== null) {
-      if (typeof opts.body === 'string') {
-        body = opts.body;
+    let bodyDescriptor;
+    const raw = opts.body;
+    if (raw !== undefined && raw !== null) {
+      if (typeof raw === 'string') {
+        body = raw;
+      } else if (raw instanceof URLSearchParams) {
+        body = raw.toString();
+        if (!hasContentType()) headers['Content-Type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
+      } else if (raw instanceof Blob) {
+        const bytes = new Uint8Array(await raw.arrayBuffer());
+        bodyDescriptor = { kind: 'blob', data: bytesToBase64(bytes), type: raw.type || '' };
+      } else if (raw instanceof ArrayBuffer) {
+        bodyDescriptor = { kind: 'bytes', data: bytesToBase64(new Uint8Array(raw)) };
+      } else if (ArrayBuffer.isView(raw)) {
+        const bytes = new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength);
+        bodyDescriptor = { kind: 'bytes', data: bytesToBase64(bytes) };
+      } else if (raw instanceof FormData) {
+        const entries = [];
+        for (const [name, value] of raw.entries()) {
+          if (typeof value === 'string') {
+            entries.push({ name: name, value: value });
+          } else {
+            const bytes = new Uint8Array(await value.arrayBuffer());
+            entries.push({
+              name: name,
+              file: {
+                data: bytesToBase64(bytes),
+                filename: typeof value.name === 'string' ? value.name : 'blob',
+                type: value.type || '',
+              },
+            });
+          }
+        }
+        bodyDescriptor = { kind: 'formdata', entries: entries };
       } else {
-        body = JSON.stringify(opts.body);
-        const hasCt = Object.keys(headers).some((k) => k.toLowerCase() === 'content-type');
-        if (!hasCt) headers['Content-Type'] = 'application/json';
+        body = JSON.stringify(raw);
+        if (!hasContentType()) headers['Content-Type'] = 'application/json';
       }
     }
     const init = { method: method, credentials: credentials, headers: headers };
@@ -2344,8 +2384,26 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     for (const k of passthrough) {
       if (opts[k] !== undefined) init[k] = opts[k];
     }
+    // Page-side reconstruction for non-JSON bodies. Only emitted when a
+    // binary/FormData descriptor exists so string/object/URLSearchParams
+    // scripts stay byte-identical to the pre-binary shape (no atob).
+    let reconstruct = '';
+    if (bodyDescriptor) {
+      reconstruct =
+        'const __b64 = (s) => { const bin = atob(s); const n = bin.length; ' +
+        'const u = new Uint8Array(n); for (let i = 0; i < n; i++) u[i] = bin.charCodeAt(i); return u; };' +
+        'const __body = ' + JSON.stringify(bodyDescriptor) + ';' +
+        "if (__body.kind === 'bytes') { __init.body = __b64(__body.data); }" +
+        "else if (__body.kind === 'blob') { __init.body = new Blob([__b64(__body.data)], { type: __body.type }); }" +
+        "else if (__body.kind === 'formdata') { const __fd = new FormData(); " +
+        'for (const e of __body.entries) { ' +
+        'if (e.file) { __fd.append(e.name, new Blob([__b64(e.file.data)], { type: e.file.type }), e.file.filename); } ' +
+        'else { __fd.append(e.name, e.value); } } __init.body = __fd; }';
+    }
     return '(async () => {' +
-      'const r = await fetch(' + JSON.stringify(url) + ', ' + JSON.stringify(init) + ');' +
+      'const __init = ' + JSON.stringify(init) + ';' +
+      reconstruct +
+      'const r = await fetch(' + JSON.stringify(url) + ', __init);' +
       'const h = {};' +
       'r.headers.forEach((v, k) => { h[k] = v; });' +
       "const ct = r.headers.get('content-type') || '';" +
@@ -2406,7 +2464,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     evalAsync: (tab, fnOrCode) => rpcCall('browser', 'evalAsync', [resolveBrowserTargetId(tab), serializeBrowserEvalSource(fnOrCode)]),
     cookie: (tab, name) => rpcCall('browser', 'cookie', [resolveBrowserTargetId(tab), name]),
     localStorage: (tab, key) => rpcCall('browser', 'localStorage', [resolveBrowserTargetId(tab), key]),
-    fetch: (tab, url, opts) => rpcCall('browser', 'evalAsync', [resolveBrowserTargetId(tab), buildBrowserFetchScript(url, opts || {})]),
+    fetch: (tab, url, opts) => buildBrowserFetchScript(url, opts || {}).then((script) => rpcCall('browser', 'evalAsync', [resolveBrowserTargetId(tab), script])),
     websocket: websocketBridge,
   };
 

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -1358,7 +1358,8 @@ function buildResponseHandlingScript(responseType: BrowserFetchOptions['response
     'const __ctl = ct.toLowerCase();' +
     "const __binPrefixes = ['image/','audio/','video/','application/octet-stream'," +
     "'application/pdf','application/protobuf','application/x-protobuf','application/wasm','application/zip'];" +
-    "const __isBinary = __rt === 'binary' || (__rt !== 'text' && __rt !== 'json' && " +
+    "const __isXml = __ctl.indexOf('+xml') !== -1 || __ctl.indexOf('application/xml') === 0 || __ctl.indexOf('text/xml') === 0;" +
+    "const __isBinary = __rt === 'binary' || (__rt !== 'text' && __rt !== 'json' && !__isXml && " +
     '__binPrefixes.some((p) => __ctl.indexOf(p) === 0));' +
     'if (__isBinary) {' +
     'const __u = new Uint8Array(await r.arrayBuffer());' +

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -1192,19 +1192,32 @@ export interface BrowserFetchOptions {
   referrerPolicy?: string;
   integrity?: string;
   keepalive?: boolean;
+  /**
+   * How the response body should be decoded:
+   * - `'text'` — always return the raw text body (no JSON parse);
+   * - `'json'` — always `JSON.parse` the text body (null on empty);
+   * - `'binary'` — return the body base64-encoded with
+   *   `bodyEncoding: 'base64'` on the result;
+   * - omitted (default) — auto-detect: JSON Content-Type → parsed JSON,
+   *   a conservative binary Content-Type allowlist → base64, else text.
+   */
+  responseType?: 'text' | 'json' | 'binary';
 }
 
 /**
  * Structured result returned by `browser.fetch`. `body` is parsed
  * JSON when the response Content-Type contains `application/json`,
- * otherwise raw text. Binary responses are out of scope (the script
- * returns the text decoding the page applies).
+ * otherwise raw text. Binary responses (via `responseType: 'binary'`
+ * or a binary Content-Type) return the body base64-encoded with
+ * `bodyEncoding: 'base64'` set; the caller decodes with `atob`.
  */
 export interface BrowserFetchResult {
   ok: boolean;
   status: number;
   headers: Record<string, string>;
   body: unknown;
+  /** Set to `'base64'` when `body` is a base64-encoded binary payload. */
+  bodyEncoding?: 'base64';
 }
 
 /**
@@ -1317,6 +1330,53 @@ function buildBodyReconstructionScript(descriptor: BrowserFetchBodyDescriptor | 
 }
 
 /**
+ * Page-side response-assembly snippet. Follows the `fetch(...)` line and
+ * consumes `r` (the Response). Handles three body shapes driven by
+ * `responseType` and, when omitted, a conservative Content-Type
+ * allowlist:
+ * - binary (`responseType: 'binary'` OR an allowlisted binary
+ *   Content-Type) → read `arrayBuffer`, base64-encode with `btoa`, and
+ *   return `{ ..., body: <base64>, bodyEncoding: 'base64' }`. The
+ *   allowlist NEVER matches `text/*`, `application/json`, `*+json`,
+ *   `application/xml`, or `*+xml`, so text payloads are never corrupted;
+ * - JSON (`responseType: 'json'` OR a JSON Content-Type when not forced
+ *   to text) → `JSON.parse` the text (null on empty body);
+ * - text (everything else, or `responseType: 'text'`) → raw text.
+ *
+ * The body is read exactly once (either `arrayBuffer` or `text`, never
+ * both) so the single-consumption stream is respected. Kept stringly
+ * typed so `JSON.stringify` stays the only escape boundary.
+ */
+function buildResponseHandlingScript(responseType: BrowserFetchOptions['responseType']): string {
+  return (
+    'const h = {};' +
+    'r.headers.forEach((v, k) => { h[k] = v; });' +
+    "const ct = r.headers.get('content-type') || '';" +
+    'const __rt = ' +
+    JSON.stringify(responseType ?? null) +
+    ';' +
+    'const __ctl = ct.toLowerCase();' +
+    "const __binPrefixes = ['image/','audio/','video/','application/octet-stream'," +
+    "'application/pdf','application/protobuf','application/x-protobuf','application/wasm','application/zip'];" +
+    "const __isBinary = __rt === 'binary' || (__rt !== 'text' && __rt !== 'json' && " +
+    '__binPrefixes.some((p) => __ctl.indexOf(p) === 0));' +
+    'if (__isBinary) {' +
+    'const __u = new Uint8Array(await r.arrayBuffer());' +
+    "let __s = ''; const __cs = 0x8000;" +
+    'for (let __i = 0; __i < __u.length; __i += __cs) { ' +
+    '__s += String.fromCharCode.apply(null, __u.subarray(__i, __i + __cs)); }' +
+    "return { ok: r.ok, status: r.status, headers: h, body: btoa(__s), bodyEncoding: 'base64' };" +
+    '}' +
+    'const t = await r.text();' +
+    'let b;' +
+    "const __jsonWanted = __rt === 'json' || (__rt !== 'text' && ct.indexOf('application/json') !== -1);" +
+    'if (__jsonWanted) { if (!t) { b = null; } else { try { b = JSON.parse(t); } catch (e) { b = t; } } }' +
+    'else { b = t; }' +
+    'return { ok: r.ok, status: r.status, headers: h, body: b };'
+  );
+}
+
+/**
  * Build the self-contained page-context script that `browser.fetch`
  * injects via `evalAsync`. All request shaping (method/credentials/
  * headers/body) is baked into the script via `JSON.stringify` so the
@@ -1333,6 +1393,11 @@ function buildBodyReconstructionScript(descriptor: BrowserFetchBodyDescriptor | 
  * `FormData` so `fetch` sets the multipart boundary; any other value is
  * JSON-stringified with a default `application/json` Content-Type. The
  * function is async because reading `Blob`/`File` bytes is async.
+ *
+ * Response handling honors `opts.responseType` (`'text'`/`'json'`/
+ * `'binary'`); when omitted it auto-detects JSON vs. a conservative
+ * binary Content-Type allowlist (see {@link buildResponseHandlingScript}).
+ * Binary bodies come back base64-encoded with `bodyEncoding: 'base64'`.
  *
  * Exported so `realm-iframe`/parity tests can assert the injected
  * script is a single function (no temp file, no base64 chunking). The
@@ -1372,6 +1437,7 @@ export async function buildBrowserFetchScript(
     if (v !== undefined) init[k] = v;
   }
   const reconstruct = buildBodyReconstructionScript(descriptor);
+  const responseHandling = buildResponseHandlingScript(opts.responseType);
   // Single self-contained async IIFE — runs entirely in the page,
   // returns a structured-cloneable object that CDP returnByValue
   // round-trips back to the realm host as-is. Keep this stringly
@@ -1386,15 +1452,7 @@ export async function buildBrowserFetchScript(
     'const r = await fetch(' +
     JSON.stringify(url) +
     ', __init);' +
-    'const h = {};' +
-    'r.headers.forEach((v, k) => { h[k] = v; });' +
-    "const ct = r.headers.get('content-type') || '';" +
-    'const t = await r.text();' +
-    'let b;' +
-    "if (ct.indexOf('application/json') !== -1) {" +
-    'if (!t) { b = null; } else { try { b = JSON.parse(t); } catch (e) { b = t; } }' +
-    '} else { b = t; }' +
-    'return { ok: r.ok, status: r.status, headers: h, body: b };' +
+    responseHandling +
     '})()'
   );
 }

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -1120,10 +1120,9 @@ function createBrowserBridge(rpc: RealmRpcClient) {
       url: string,
       opts: BrowserFetchOptions = {}
     ): Promise<BrowserFetchResult> =>
-      rpc.call('browser', 'evalAsync', [
-        resolveTargetId(tab),
-        buildBrowserFetchScript(url, opts),
-      ]) as Promise<BrowserFetchResult>,
+      buildBrowserFetchScript(url, opts).then((script) =>
+        rpc.call('browser', 'evalAsync', [resolveTargetId(tab), script])
+      ) as Promise<BrowserFetchResult>,
     websocket: createWsObserverApi(rpc),
   };
 }
@@ -1156,16 +1155,35 @@ function serializeEvalSource(
 
 /**
  * Options accepted by `browser.fetch(tab, url, opts)`. Mirrors the
- * `RequestInit` subset that round-trips cleanly as JSON through the
- * page-context bridge — non-serializable shapes (FormData, Blob,
- * AbortSignal, ReadableStream) are intentionally out of scope. Body
- * may be a string (sent verbatim) or any JSON-encodable value (the
- * bridge stringifies it and defaults Content-Type to application/json).
+ * `RequestInit` subset the page-context bridge can carry. `body` may be:
+ * - a string — sent verbatim, no Content-Type forced;
+ * - a `URLSearchParams` — serialized to a form-urlencoded string with a
+ *   default `application/x-www-form-urlencoded` Content-Type (caller wins);
+ * - an `ArrayBuffer` / typed array / `Blob` — base64-encoded across the
+ *   bridge and reconstructed as real binary in the page before `fetch`
+ *   (caller Content-Type preserved; a `Blob`'s own type carries over);
+ * - a `FormData` — string fields and `File`/`Blob` parts are carried
+ *   (files base64-encoded) and rebuilt as a real `FormData` in the page
+ *   so `fetch` sets the multipart boundary itself;
+ * - any other JSON-encodable value — stringified with a default
+ *   `application/json` Content-Type (caller wins).
+ * `AbortSignal` / `ReadableStream` bodies are still out of scope.
  */
 export interface BrowserFetchOptions {
   method?: string;
   headers?: Record<string, string>;
-  body?: unknown;
+  body?:
+    | string
+    | URLSearchParams
+    | ArrayBuffer
+    | ArrayBufferView
+    | Blob
+    | FormData
+    | Record<string, unknown>
+    | unknown[]
+    | number
+    | boolean
+    | null;
   credentials?: 'include' | 'same-origin' | 'omit';
   mode?: string;
   cache?: string;
@@ -1190,20 +1208,141 @@ export interface BrowserFetchResult {
 }
 
 /**
+ * Wire descriptor for a request body that cannot ride the bridge as
+ * plain JSON. Binary payloads are base64-encoded here and rebuilt as
+ * real `Uint8Array` / `Blob` / `FormData` in the page (see
+ * `buildBrowserFetchScript`). Kept minimal + JSON-safe on purpose.
+ */
+type BrowserFetchBodyDescriptor =
+  | { kind: 'bytes'; data: string }
+  | { kind: 'blob'; data: string; type: string }
+  | { kind: 'formdata'; entries: BrowserFetchFormEntry[] };
+
+type BrowserFetchFormEntry =
+  | { name: string; value: string }
+  | { name: string; file: { data: string; filename: string; type: string } };
+
+/**
+ * Base64-encode bytes without blowing the argument stack on large
+ * payloads (`String.fromCharCode(...bytes)` throws past ~100K). Runs
+ * in the builder (realm/worker/page) context, where `btoa` exists.
+ */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...Array.from(bytes.subarray(i, i + chunkSize)));
+  }
+  return btoa(binary);
+}
+
+/** Serialize a `FormData` into JSON-safe entries (files base64-encoded). */
+async function serializeBrowserFetchFormData(form: FormData): Promise<BrowserFetchBodyDescriptor> {
+  const entries: BrowserFetchFormEntry[] = [];
+  for (const [name, value] of form.entries()) {
+    if (typeof value === 'string') {
+      entries.push({ name, value });
+      continue;
+    }
+    const bytes = new Uint8Array(await value.arrayBuffer());
+    entries.push({
+      name,
+      file: {
+        data: bytesToBase64(bytes),
+        filename: typeof (value as File).name === 'string' ? (value as File).name : 'blob',
+        type: value.type || '',
+      },
+    });
+  }
+  return { kind: 'formdata', entries };
+}
+
+/**
+ * Turn a request body into either an inline `body` string or a base64
+ * `descriptor` the page reconstructs. Default Content-Type headers are
+ * set in place; a caller-provided Content-Type always wins.
+ */
+async function serializeBrowserFetchBody(
+  raw: NonNullable<BrowserFetchOptions['body']>,
+  headers: Record<string, string>
+): Promise<{ body?: string; descriptor?: BrowserFetchBodyDescriptor }> {
+  const hasContentType = (): boolean =>
+    Object.keys(headers).some((k) => k.toLowerCase() === 'content-type');
+  if (typeof raw === 'string') return { body: raw };
+  if (raw instanceof URLSearchParams) {
+    if (!hasContentType()) {
+      headers['Content-Type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
+    }
+    return { body: raw.toString() };
+  }
+  if (raw instanceof Blob) {
+    const bytes = new Uint8Array(await raw.arrayBuffer());
+    return { descriptor: { kind: 'blob', data: bytesToBase64(bytes), type: raw.type || '' } };
+  }
+  if (raw instanceof ArrayBuffer) {
+    return { descriptor: { kind: 'bytes', data: bytesToBase64(new Uint8Array(raw)) } };
+  }
+  if (ArrayBuffer.isView(raw)) {
+    const bytes = new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength);
+    return { descriptor: { kind: 'bytes', data: bytesToBase64(bytes) } };
+  }
+  if (raw instanceof FormData) {
+    return { descriptor: await serializeBrowserFetchFormData(raw) };
+  }
+  if (!hasContentType()) headers['Content-Type'] = 'application/json';
+  return { body: JSON.stringify(raw) };
+}
+
+/**
+ * Page-side reconstruction snippet for a binary/FormData body. Returns
+ * the empty string when there's no descriptor so string/object/
+ * URLSearchParams scripts stay byte-identical to the pre-binary shape
+ * (no `atob`). Rebuilds bytes/Blob/FormData onto `__init.body`.
+ */
+function buildBodyReconstructionScript(descriptor: BrowserFetchBodyDescriptor | undefined): string {
+  if (!descriptor) return '';
+  return (
+    'const __b64 = (s) => { const bin = atob(s); const n = bin.length; ' +
+    'const u = new Uint8Array(n); for (let i = 0; i < n; i++) u[i] = bin.charCodeAt(i); return u; };' +
+    'const __body = ' +
+    JSON.stringify(descriptor) +
+    ';' +
+    "if (__body.kind === 'bytes') { __init.body = __b64(__body.data); }" +
+    "else if (__body.kind === 'blob') { __init.body = new Blob([__b64(__body.data)], { type: __body.type }); }" +
+    "else if (__body.kind === 'formdata') { const __fd = new FormData(); " +
+    'for (const e of __body.entries) { ' +
+    'if (e.file) { __fd.append(e.name, new Blob([__b64(e.file.data)], { type: e.file.type }), e.file.filename); } ' +
+    'else { __fd.append(e.name, e.value); } } __init.body = __fd; }'
+  );
+}
+
+/**
  * Build the self-contained page-context script that `browser.fetch`
  * injects via `evalAsync`. All request shaping (method/credentials/
  * headers/body) is baked into the script via `JSON.stringify` so the
  * page side does nothing but call `fetch()` and assemble the
  * structured response. Credentials default to `'include'` so session
  * cookies travel automatically — that's the whole reason
- * `browser.fetch` exists rather than the realm-side `fetch`. Body
- * objects become a JSON string and force Content-Type unless the
- * caller already set one. Plain string bodies are passed through.
+ * `browser.fetch` exists rather than the realm-side `fetch`.
+ *
+ * Body handling: plain strings pass through verbatim; `URLSearchParams`
+ * becomes a form-urlencoded string (default Content-Type, caller wins);
+ * `ArrayBuffer` / typed arrays / `Blob` are base64-encoded and rebuilt
+ * as real binary in the page (caller Content-Type preserved); `FormData`
+ * is carried entry-by-entry (files base64-encoded) and rebuilt as a real
+ * `FormData` so `fetch` sets the multipart boundary; any other value is
+ * JSON-stringified with a default `application/json` Content-Type. The
+ * function is async because reading `Blob`/`File` bytes is async.
  *
  * Exported so `realm-iframe`/parity tests can assert the injected
- * script is a single function (no temp file, no base64 chunking).
+ * script is a single function (no temp file, no base64 chunking). The
+ * only escape boundary is `JSON.stringify`; base64 uses `btoa`/`atob`,
+ * never a VFS temp file or `fs.` write.
  */
-export function buildBrowserFetchScript(url: string, opts: BrowserFetchOptions = {}): string {
+export async function buildBrowserFetchScript(
+  url: string,
+  opts: BrowserFetchOptions = {}
+): Promise<string> {
   const headers: Record<string, string> = {};
   const rawHeaders = opts.headers ?? {};
   for (const [k, v] of Object.entries(rawHeaders)) {
@@ -1214,16 +1353,9 @@ export function buildBrowserFetchScript(url: string, opts: BrowserFetchOptions =
     opts.credentials === 'same-origin' || opts.credentials === 'omit'
       ? opts.credentials
       : 'include';
-  let body: string | undefined;
-  if (opts.body !== undefined && opts.body !== null) {
-    if (typeof opts.body === 'string') {
-      body = opts.body;
-    } else {
-      body = JSON.stringify(opts.body);
-      const hasCt = Object.keys(headers).some((k) => k.toLowerCase() === 'content-type');
-      if (!hasCt) headers['Content-Type'] = 'application/json';
-    }
-  }
+  const raw = opts.body;
+  const { body, descriptor } =
+    raw === undefined || raw === null ? {} : await serializeBrowserFetchBody(raw, headers);
   const init: Record<string, unknown> = { method, credentials, headers };
   if (body !== undefined) init.body = body;
   const passthrough = [
@@ -1239,6 +1371,7 @@ export function buildBrowserFetchScript(url: string, opts: BrowserFetchOptions =
     const v = opts[k];
     if (v !== undefined) init[k] = v;
   }
+  const reconstruct = buildBodyReconstructionScript(descriptor);
   // Single self-contained async IIFE — runs entirely in the page,
   // returns a structured-cloneable object that CDP returnByValue
   // round-trips back to the realm host as-is. Keep this stringly
@@ -1246,11 +1379,13 @@ export function buildBrowserFetchScript(url: string, opts: BrowserFetchOptions =
   // body) so JSON.stringify is the only escape boundary.
   return (
     '(async () => {' +
+    'const __init = ' +
+    JSON.stringify(init) +
+    ';' +
+    reconstruct +
     'const r = await fetch(' +
     JSON.stringify(url) +
-    ', ' +
-    JSON.stringify(init) +
-    ');' +
+    ', __init);' +
     'const h = {};' +
     'r.headers.forEach((v, k) => { h[k] = v; });' +
     "const ct = r.headers.get('content-type') || '';" +

--- a/packages/webapp/tests/kernel/realm/browser-fetch.test.ts
+++ b/packages/webapp/tests/kernel/realm/browser-fetch.test.ts
@@ -21,15 +21,17 @@ import { attachRealmHost } from '../../../src/kernel/realm/realm-host.js';
 import { type RealmPortLike, RealmRpcClient } from '../../../src/kernel/realm/realm-rpc.js';
 
 describe('buildBrowserFetchScript — page-context script shape', () => {
-  it('emits a single self-calling async IIFE (no temp file, no base64)', async () => {
+  it('emits a single self-calling async IIFE (no temp-file VFS dance)', async () => {
     const script = await buildBrowserFetchScript('/api/x');
     expect(script.startsWith('(async () => {')).toBe(true);
     expect(script.endsWith('})()')).toBe(true);
     expect(script).toContain('await fetch(');
     // Defensive: the dance the spec calls out as fragile (temp-file
-    // write + base64 chunking) must not appear in the injected page
-    // script. Catches accidental regressions to the old shape.
-    expect(script).not.toMatch(/writeFile|fs\.|base64|btoa\(|atob\(/);
+    // write via the VFS) must not appear in the injected page script.
+    // `btoa`/`atob`/base64 ARE now expected (binary response encoding +
+    // binary request reconstruction), so only `writeFile`/`fs.` are
+    // forbidden — a regression to the old temp-file shape.
+    expect(script).not.toMatch(/writeFile|fs\./);
     // Single function — no semicolons separating top-level
     // statements outside the IIFE.
     expect(script.match(/^\(async \(\) => \{/g)?.length).toBe(1);
@@ -204,6 +206,123 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
       fakeFetch
     )) as BrowserFetchResult;
     expect(result.body).toEqual({ hello: 'world' });
+  });
+
+  // ---- Request-body round-trips (bridge → page reconstruction) ----
+
+  it('serializes URLSearchParams as a form-urlencoded body with default Content-Type', async () => {
+    const script = await buildBrowserFetchScript('/api/x', {
+      method: 'POST',
+      body: new URLSearchParams({ a: '1', b: 'two words' }),
+    });
+    expect(script).toContain('"body":"a=1&b=two+words"');
+    expect(script).toContain('"Content-Type":"application/x-www-form-urlencoded;charset=UTF-8"');
+  });
+
+  it('round-trips a binary request body (Uint8Array) through base64 reconstruction', async () => {
+    const bytes = new Uint8Array([0, 1, 2, 250, 255, 128]);
+    const captured: { body?: unknown } = {};
+    const fakeFetch = async (_u: string, init: RequestInit) => {
+      captured.body = init.body;
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+    const script = await buildBrowserFetchScript('/upload', {
+      method: 'POST',
+      body: bytes,
+    });
+    // Descriptor path emits atob-based reconstruction in the page.
+    expect(script).toContain('atob(');
+    await new Function('fetch', `return ${script};`)(fakeFetch);
+    expect(captured.body).toBeInstanceOf(Uint8Array);
+    expect(Array.from(captured.body as Uint8Array)).toEqual(Array.from(bytes));
+  });
+
+  it('round-trips a multipart FormData body (string field + file part)', async () => {
+    const form = new FormData();
+    form.append('field', 'value');
+    form.append(
+      'file',
+      new Blob([new Uint8Array([9, 8, 7])], { type: 'application/octet-stream' }),
+      'f.bin'
+    );
+    const captured: { body?: unknown } = {};
+    const fakeFetch = async (_u: string, init: RequestInit) => {
+      captured.body = init.body;
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+    const script = await buildBrowserFetchScript('/multipart', { method: 'POST', body: form });
+    await new Function('fetch', `return ${script};`)(fakeFetch);
+    expect(captured.body).toBeInstanceOf(FormData);
+    const rebuilt = captured.body as FormData;
+    expect(rebuilt.get('field')).toBe('value');
+    const file = rebuilt.get('file') as File;
+    expect(file).toBeInstanceOf(Blob);
+    expect((file as File).name).toBe('f.bin');
+    expect(Array.from(new Uint8Array(await file.arrayBuffer()))).toEqual([9, 8, 7]);
+  });
+
+  // ---- Binary response detection + base64 return ----
+
+  it('returns a base64 body with bodyEncoding for responseType:"binary"', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 250, 255]);
+    const fakeFetch = async () =>
+      new Response(bytes, { status: 200, headers: { 'content-type': 'application/json' } });
+    const script = await buildBrowserFetchScript('/blob', { responseType: 'binary' });
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.bodyEncoding).toBe('base64');
+    // Decode and confirm no corruption round-trips through base64.
+    const decoded = Uint8Array.from(atob(result.body as string), (c) => c.charCodeAt(0));
+    expect(Array.from(decoded)).toEqual(Array.from(bytes));
+  });
+
+  it('auto-detects a binary Content-Type (image/png) and returns base64', async () => {
+    const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+    const fakeFetch = async () =>
+      new Response(bytes, { status: 200, headers: { 'content-type': 'image/png' } });
+    const script = await buildBrowserFetchScript('/img');
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.bodyEncoding).toBe('base64');
+    const decoded = Uint8Array.from(atob(result.body as string), (c) => c.charCodeAt(0));
+    expect(Array.from(decoded)).toEqual(Array.from(bytes));
+  });
+
+  it('does NOT treat text/* as binary (no base64 encoding)', async () => {
+    const fakeFetch = async () =>
+      new Response('plain text', { status: 200, headers: { 'content-type': 'text/plain' } });
+    const script = await buildBrowserFetchScript('/txt');
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.bodyEncoding).toBeUndefined();
+    expect(result.body).toBe('plain text');
+  });
+
+  it('responseType:"text" forces raw text even for an application/json response', async () => {
+    const fakeFetch = async () =>
+      new Response('{"hello":"world"}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    const script = await buildBrowserFetchScript('/api/x', { responseType: 'text' });
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.bodyEncoding).toBeUndefined();
+    expect(result.body).toBe('{"hello":"world"}');
+  });
+
+  it('responseType:"json" parses even when the Content-Type is not JSON', async () => {
+    const fakeFetch = async () =>
+      new Response('{"n":42}', { status: 200, headers: { 'content-type': 'text/plain' } });
+    const script = await buildBrowserFetchScript('/api/x', { responseType: 'json' });
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.body).toEqual({ n: 42 });
   });
 });
 

--- a/packages/webapp/tests/kernel/realm/browser-fetch.test.ts
+++ b/packages/webapp/tests/kernel/realm/browser-fetch.test.ts
@@ -290,6 +290,30 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
     expect(Array.from(decoded)).toEqual(Array.from(bytes));
   });
 
+  it('does NOT auto-detect image/svg+xml as binary (returns raw SVG text)', async () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1"/></svg>';
+    const fakeFetch = async () =>
+      new Response(svg, { status: 200, headers: { 'content-type': 'image/svg+xml' } });
+    const script = await buildBrowserFetchScript('/logo.svg');
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.bodyEncoding).toBeUndefined();
+    expect(result.body).toBe(svg);
+  });
+
+  it('responseType:"binary" still base64-encodes an image/svg+xml response', async () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1"/></svg>';
+    const fakeFetch = async () =>
+      new Response(svg, { status: 200, headers: { 'content-type': 'image/svg+xml' } });
+    const script = await buildBrowserFetchScript('/logo.svg', { responseType: 'binary' });
+    const result = (await new Function('fetch', `return ${script};`)(
+      fakeFetch
+    )) as BrowserFetchResult;
+    expect(result.bodyEncoding).toBe('base64');
+    expect(atob(result.body as string)).toBe(svg);
+  });
+
   it('does NOT treat text/* as binary (no base64 encoding)', async () => {
     const fakeFetch = async () =>
       new Response('plain text', { status: 200, headers: { 'content-type': 'text/plain' } });

--- a/packages/webapp/tests/kernel/realm/browser-fetch.test.ts
+++ b/packages/webapp/tests/kernel/realm/browser-fetch.test.ts
@@ -21,8 +21,8 @@ import { attachRealmHost } from '../../../src/kernel/realm/realm-host.js';
 import { type RealmPortLike, RealmRpcClient } from '../../../src/kernel/realm/realm-rpc.js';
 
 describe('buildBrowserFetchScript — page-context script shape', () => {
-  it('emits a single self-calling async IIFE (no temp file, no base64)', () => {
-    const script = buildBrowserFetchScript('/api/x');
+  it('emits a single self-calling async IIFE (no temp file, no base64)', async () => {
+    const script = await buildBrowserFetchScript('/api/x');
     expect(script.startsWith('(async () => {')).toBe(true);
     expect(script.endsWith('})()')).toBe(true);
     expect(script).toContain('await fetch(');
@@ -35,22 +35,22 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
     expect(script.match(/^\(async \(\) => \{/g)?.length).toBe(1);
   });
 
-  it('defaults credentials to "include" so session cookies travel', () => {
-    const script = buildBrowserFetchScript('/api/x');
+  it('defaults credentials to "include" so session cookies travel', async () => {
+    const script = await buildBrowserFetchScript('/api/x');
     expect(script).toContain('"credentials":"include"');
   });
 
-  it('honors explicit credentials override (same-origin / omit)', () => {
-    expect(buildBrowserFetchScript('/x', { credentials: 'same-origin' })).toContain(
+  it('honors explicit credentials override (same-origin / omit)', async () => {
+    expect(await buildBrowserFetchScript('/x', { credentials: 'same-origin' })).toContain(
       '"credentials":"same-origin"'
     );
-    expect(buildBrowserFetchScript('/x', { credentials: 'omit' })).toContain(
+    expect(await buildBrowserFetchScript('/x', { credentials: 'omit' })).toContain(
       '"credentials":"omit"'
     );
   });
 
-  it('serializes a plain-object body as JSON and sets Content-Type', () => {
-    const script = buildBrowserFetchScript('/api/conversations.list', {
+  it('serializes a plain-object body as JSON and sets Content-Type', async () => {
+    const script = await buildBrowserFetchScript('/api/conversations.list', {
       method: 'POST',
       body: { channel: 'C123' },
     });
@@ -59,8 +59,8 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
     expect(script).toContain('"body":"{\\"channel\\":\\"C123\\"}"');
   });
 
-  it('preserves caller-provided Content-Type for non-object bodies', () => {
-    const script = buildBrowserFetchScript('/api/x', {
+  it('preserves caller-provided Content-Type for non-object bodies', async () => {
+    const script = await buildBrowserFetchScript('/api/x', {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       body: 'a=1&b=2',
@@ -71,19 +71,19 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
     expect(script).not.toContain('"Content-Type":"application/json"');
   });
 
-  it('preserves custom request headers in both directions', () => {
-    const script = buildBrowserFetchScript('/api/x', {
+  it('preserves custom request headers in both directions', async () => {
+    const script = await buildBrowserFetchScript('/api/x', {
       headers: { Authorization: 'Bearer abc', 'X-Custom': 'v' },
     });
     expect(script).toContain('"Authorization":"Bearer abc"');
     expect(script).toContain('"X-Custom":"v"');
   });
 
-  it('safely escapes adversarial url + body content via JSON encoding', () => {
+  it('safely escapes adversarial url + body content via JSON encoding', async () => {
     // Defends against a malicious url breaking out of the injected
     // string. JSON.stringify is the only escape boundary.
     const url = '"</script><script>alert(1)</script>';
-    const script = buildBrowserFetchScript(url, { body: { x: '"); alert(1); //' } });
+    const script = await buildBrowserFetchScript(url, { body: { x: '"); alert(1); //' } });
     // Both must round-trip through JSON.parse(<extracted>) cleanly.
     const urlMatch = /await fetch\((".*?"),/.exec(script);
     expect(urlMatch).not.toBeNull();
@@ -117,7 +117,7 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
         text: async () => '{"hello":"world"}',
       };
     };
-    const script = buildBrowserFetchScript('/api/x', {
+    const script = await buildBrowserFetchScript('/api/x', {
       method: 'POST',
       body: { channel: 'C1' },
     });
@@ -151,7 +151,7 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
         throw new Error('should not be called');
       },
     });
-    const script = buildBrowserFetchScript('/page');
+    const script = await buildBrowserFetchScript('/page');
     const result = (await new Function('fetch', `return ${script};`)(
       fakeFetch
     )) as BrowserFetchResult;
@@ -170,7 +170,7 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
-    const script = buildBrowserFetchScript('/api/empty');
+    const script = await buildBrowserFetchScript('/api/empty');
     const result = (await new Function('fetch', `return ${script};`)(
       fakeFetch
     )) as BrowserFetchResult;
@@ -185,7 +185,7 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
         status: 204,
         headers: { 'content-type': 'application/json' },
       });
-    const script = buildBrowserFetchScript('/api/thing', { method: 'DELETE' });
+    const script = await buildBrowserFetchScript('/api/thing', { method: 'DELETE' });
     const result = (await new Function('fetch', `return ${script};`)(
       fakeFetch
     )) as BrowserFetchResult;
@@ -199,7 +199,7 @@ describe('buildBrowserFetchScript — page-context script shape', () => {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
-    const script = buildBrowserFetchScript('/api/x');
+    const script = await buildBrowserFetchScript('/api/x');
     const result = (await new Function('fetch', `return ${script};`)(
       fakeFetch
     )) as BrowserFetchResult;
@@ -305,7 +305,7 @@ describe('realm RPC: browser.fetch — round-trip through evalAsync', () => {
     try {
       // Mirror what `browserBridge.fetch` does internally: build the
       // page-context script and dispatch through evalAsync.
-      const script = buildBrowserFetchScript('/api/post', {
+      const script = await buildBrowserFetchScript('/api/post', {
         method: 'POST',
         body: { channel: 'C123' },
       });


### PR DESCRIPTION
## Summary

Adds **binary** and **FormData / URLSearchParams** payload support to `require('sliccy:browser').fetch(tab, url, opts)` in both request and response directions, without regressing existing text/JSON/empty-body behavior. Fixes #1445.

The change is applied identically to **both** copies of `buildBrowserFetchScript` (parity test enforces this):
- `packages/webapp/src/kernel/realm/js-realm-shared.ts`
- `packages/chrome-extension/sandbox.html`

## Request side

`buildBrowserFetchScript` is now async so it can read `Blob`/`File`/`FormData` entries to base64 on the caller side (both `fetch:` bridge call sites already return promises).

- `string` -> verbatim (unchanged)
- plain object -> `JSON.stringify` + default `application/json` (unchanged)
- `URLSearchParams` -> `application/x-www-form-urlencoded` (caller Content-Type wins)
- `ArrayBuffer` / typed array / `Blob` -> base64 -> real binary reconstructed in the page; caller Content-Type preserved (Blob type carried)
- `FormData` (string fields + File/Blob) -> reconstructed as a real `FormData`; no manual Content-Type so the multipart boundary is auto-added

## Response side

- Default text/JSON/empty-body behavior unchanged
- Binary responses returned as base64 with a `bodyEncoding: 'base64'` flag, triggered by `responseType: 'binary'` **or** a conservative binary content-type allowlist that never base64-encodes `text/*`, `application/json`, `application/xml`, `*+json`, `*+xml`
- `responseType: 'text' | 'json'` force those paths

## Types

- `BrowserFetchOptions`: `body` widened to include `Blob | ArrayBuffer | ArrayBufferView | FormData | URLSearchParams`; added `responseType?: 'text' | 'json' | 'binary'`
- `BrowserFetchResult`: added `bodyEncoding?: 'base64'`

## Encoding constraint

Inline `btoa`/`atob` string base64 only - no VFS temp-file / fs dance. The defensive test regex was narrowed to forbid only `writeFile` / `fs.` (permits `btoa`/`atob`/base64).

## Tests

- `packages/webapp/tests/kernel/realm/browser-fetch.test.ts`: added 9 round-trip tests exercising multipart `FormData` (fields + file), binary bodies, `URLSearchParams`, and binary responses - all driven against real `Response`/`FormData`/`Blob`. Parity test still holds.

## Verification

- `npm run lint` PASS
- `npm run typecheck` PASS (all 9 tsc projects)
- `npx vitest run packages/webapp/tests/kernel/realm/browser-fetch.test.ts` -> 22/22 PASS
- `npm run test:coverage:webapp` gate PASS
- both builds PASS

## Acceptance criteria (all met)

- [x] POST a `FormData` multipart body (fields + file) received correctly
- [x] Send a binary body (`Blob`/`ArrayBuffer`/typed array) with explicit content-type
- [x] `URLSearchParams` sent as `application/x-www-form-urlencoded`
- [x] Binary responses returned without corruption (base64 + flag, `responseType` opt-in)
- [x] Existing text/JSON/empty-body behavior unchanged
- [x] Both `buildBrowserFetchScript` copies behaviorally identical; parity test holds
- [x] New tests exercise multipart + binary round-trips against real `Response`/`FormData`

## Out of scope

- `ReadableStream` request/response bodies (streaming) - tracked separately
- Changes to the `http` client / fetch-proxy path

Closes #1445