### PR TITLE
feat(worker): retain hashed assets in R2 so tabs survive deploys (#1330) [blocked on ops]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,6 +542,19 @@ jobs:
           path: coverage/
           if-no-files-found: ignore
 
+      # #1330 retention: archive this build's content-hashed assets to the
+      # STAGING R2 bucket BEFORE any deploy attempt so long-lived tabs can
+      # recover gone lazy chunks. Hard-fail gate (NOT continue-on-error) — a
+      # build must never go live unarchived. Shares the deploy step's non-fork
+      # guard so it never runs without Cloudflare secrets on fork PRs.
+      - name: Archive assets to R2 (staging)
+        if: |
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+          github.event_name == 'push'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive-staging --dir dist/ui/assets
       # Deploy to staging on PRs (not forks) and pushes to main.
       #
       # The staging Worker (slicc-tray-hub-staging) has Worker Versions enabled.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,9 +697,15 @@ jobs:
           fi
           echo "deployment-url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
       - name: Smoke test staging
-        if: steps.deploy.outcome == 'success'
+        if: |
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+          github.event_name == 'push'
         env:
           WORKER_BASE_URL: ${{ steps.deploy.outputs.deployment-url }}
+          SLICC_ARCHIVE_SMOKE: '1'
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          SLICC_ARCHIVE_BUCKET: slicc-asset-archive-staging
         run: |
           for attempt in 1 2 3 4 5 6; do
             if npx vitest run --project cloudflare-worker packages/cloudflare-worker/tests/deployed.test.ts; then

--- a/.github/workflows/worker-staging.yml
+++ b/.github/workflows/worker-staging.yml
@@ -231,8 +231,13 @@ jobs:
           echo "deployment-url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Run deployed smoke test against staging
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           WORKER_BASE_URL: ${{ steps.deploy.outputs.deployment-url }}
+          SLICC_ARCHIVE_SMOKE: '1'
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          SLICC_ARCHIVE_BUCKET: slicc-asset-archive-staging
         run: |
           if [ -z "$WORKER_BASE_URL" ]; then
             echo "Missing deployment URL from cloudflare/wrangler-action output"

--- a/.github/workflows/worker-staging.yml
+++ b/.github/workflows/worker-staging.yml
@@ -107,6 +107,19 @@ jobs:
       #     SLICC_E2B_TEMPLATE_NAME: slicc-staging
       #   run: bash packages/dev-tools/e2b-template/scripts/verify-template.sh
 
+      # #1330 retention: archive this build's content-hashed assets to the
+      # STAGING R2 bucket BEFORE any deploy attempt so long-lived tabs can
+      # recover gone lazy chunks. Hard-fail gate (NOT continue-on-error) — a
+      # build must never go live unarchived. The deploy step has no `if:` to
+      # copy, so this explicit non-fork guard keeps the hard-fail upload from
+      # running without Cloudflare secrets on fork PRs.
+      - name: Archive assets to R2 (staging)
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive-staging --dir dist/ui/assets
+
       # The staging Worker (slicc-tray-hub-staging) has Worker Versions enabled.
       # wrangler-action runs `wrangler secret bulk` BEFORE the `command:`
       # whenever `secrets:` is set, so a single deploy+secrets step uploads

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -47,6 +47,16 @@ jobs:
       #     SLICC_TEST_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
       #   run: bash packages/dev-tools/e2b-template/scripts/verify-template.sh
 
+      # #1330 retention: archive this build's content-hashed assets to R2
+      # BEFORE any deploy attempt so long-lived tabs can recover gone lazy
+      # chunks. Hard-fail gate (NOT continue-on-error) — a build must never go
+      # live unarchived.
+      - name: Archive assets to R2 (production)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive --dir dist/ui/assets
+
       - name: Deploy production worker (attempt 1)
         id: deploy_attempt_1
         continue-on-error: true

--- a/docs/superpowers/plans/2026-07-08-r2-asset-retention.md
+++ b/docs/superpowers/plans/2026-07-08-r2-asset-retention.md
@@ -1,0 +1,376 @@
+# R2 Asset Retention — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Keep content-hashed `/assets/*` chunks in a per-env R2 bucket across deploys so long-lived tabs stop crashing (#1330) on gone lazy chunks; the worker serves archived chunks on an ASSETS miss, and every deploy uploads its assets to the archive before going live.
+
+**Architecture:** Cloudflare Worker (`packages/cloudflare-worker`) gains an `ASSET_ARCHIVE` R2 binding. A new `serveAssetWithArchiveFallback` handles `/assets/*` GET/HEAD: serve the current build from `ASSETS`; on a miss (ASSETS returns the SPA `text/html` shell) serve the archived bytes from R2 with `immutable` cache, else fall back to today's shell (the shipped #1364 reload). A shared pure module supplies the hashed-asset predicate + MIME map, used by both the worker and the upload script. A Node upload script (`scripts/upload-assets-to-r2.mjs`) re-puts the full current asset set to the bucket before each `wrangler deploy`, wired into all four deploy paths.
+
+**Tech stack:** TypeScript (worker, `@cloudflare/workers-types`), Vitest, Node ESM script, `wrangler r2`, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md` (read it; this plan implements **option A**).
+
+## Global Constraints
+
+- **Option A only** — pure 14-day age-based GC, **no manifest/touch job**. Option B is future work; do not build it.
+- **Conditional (304/412) and Range (206) NOT implemented** for archived assets — serve full `200` / bodyless `HEAD` with validators; ignore any `Range`/`If-*` headers. (Present assets served via `ASSETS` keep platform behavior.)
+- **Hash invariant enforced** — the upload script fails if any `dist/ui/assets/*` name lacks a content hash; the worker gate requires the same predicate. Worker + script import **one** shared predicate.
+- **Deploy gated on upload** — every deploy path runs the upload as a single hard-fail step (`continue-on-error: false`) after build and before the first deploy attempt.
+- **Per-env buckets** — `slicc-asset-archive` (prod) / `slicc-asset-archive-staging` (staging). Preview worker excluded.
+- **Never `500` an asset request** — any R2 error → fall back to the shell.
+- **Verification each task:** `npm run lint:ci`, `npm run deadcode`, `npm run typecheck`, `npm run test:coverage:cloudflare-worker` (kept ≥ floor), `npx prettier --write` before commit. No Co-Authored-By trailer. Keep `docs/superpowers/` commits (release strips them).
+- **Manual Cloudflare ops are prerequisites, not code** (Task 7 runbook): create both R2 buckets; apply the 14-day lifecycle rule; grant the deploy API token R2 Object Read&Write. CI upload/deploy will fail until these exist.
+
+## File Structure
+
+- Create `packages/cloudflare-worker/src/asset-archive.ts` — pure helpers: `HASHED_ASSET_RE`, `matchHashedAssetPath`, `mimeForAssetPath`. No worker/DOM deps.
+- Modify `packages/cloudflare-worker/src/index.ts` — `WorkerEnv.ASSET_ARCHIVE`; `serveAssetWithArchiveFallback`; wire into dispatch before the SPA/JSON split.
+- Modify `packages/cloudflare-worker/wrangler.jsonc` — `r2_buckets` binding (top-level + `env.staging`).
+- Create `packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs` — Node uploader (assert-hash, re-put-all, parallel+retries).
+- Modify `packages/cloudflare-worker/scripts/publish-worker.sh` + `.github/workflows/worker.yml` + `.github/workflows/ci.yml` + `.github/workflows/worker-staging.yml` — gated upload step.
+- Create `packages/cloudflare-worker/tests/asset-archive.test.ts`, `tests/upload-assets-to-r2.test.ts`; modify `tests/index.test.ts`, `tests/deployed.test.ts`.
+- Modify `packages/cloudflare-worker/CLAUDE.md` (+ a runbook section) and root `CLAUDE.md` module map if needed.
+
+---
+
+### Task 1: Shared pure helpers (predicate + MIME)
+
+**Files:**
+
+- Create: `packages/cloudflare-worker/src/asset-archive.ts`
+- Test: `packages/cloudflare-worker/tests/asset-archive.test.ts`
+
+**Interfaces:**
+
+- Produces: `HASHED_ASSET_RE: RegExp`; `matchHashedAssetPath(pathname: string): boolean`; `mimeForAssetPath(pathname: string): string`.
+
+- [ ] **Step 1: Write failing tests** (`tests/asset-archive.test.ts`):
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { matchHashedAssetPath, mimeForAssetPath } from '../src/asset-archive.js';
+
+describe('matchHashedAssetPath', () => {
+  it('accepts hashed chunk names', () => {
+    expect(matchHashedAssetPath('/assets/anthropic-messages-DP3-Xd3J.js')).toBe(true);
+    expect(matchHashedAssetPath('/assets/index-a1b2c3d4.css')).toBe(true);
+    expect(matchHashedAssetPath('/assets/entry-abcd1234.js.map')).toBe(true);
+    expect(matchHashedAssetPath('/assets/logo-DEADBEEF.svg')).toBe(true);
+  });
+  it('rejects non-asset / un-hashed / traversal / encoded paths', () => {
+    expect(matchHashedAssetPath('/index.html')).toBe(false);
+    expect(matchHashedAssetPath('/assets/index.html')).toBe(false); // wrong ext
+    expect(matchHashedAssetPath('/assets/foo.js')).toBe(false); // no hash
+    expect(matchHashedAssetPath('/assets/../secret-abcd1234.js')).toBe(false);
+    expect(matchHashedAssetPath('/assets/a%2Fb-abcd1234.js')).toBe(false);
+    expect(matchHashedAssetPath('/other/x-abcd1234.js')).toBe(false);
+  });
+});
+
+describe('mimeForAssetPath', () => {
+  it('maps critical types', () => {
+    expect(mimeForAssetPath('/assets/x-abcd1234.js')).toBe('text/javascript');
+    expect(mimeForAssetPath('/assets/x-abcd1234.mjs')).toBe('text/javascript');
+    expect(mimeForAssetPath('/assets/x-abcd1234.css')).toBe('text/css');
+    expect(mimeForAssetPath('/assets/x-abcd1234.wasm')).toBe('application/wasm');
+    expect(mimeForAssetPath('/assets/x-abcd1234.js.map')).toBe('application/json');
+    expect(mimeForAssetPath('/assets/x-abcd1234.woff2')).toBe('font/woff2');
+  });
+  it('falls back to octet-stream', () => {
+    expect(mimeForAssetPath('/assets/x-abcd1234.zzz')).toBe('application/octet-stream');
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`npm run test:coverage:cloudflare-worker -- asset-archive` → module not found).
+
+- [ ] **Step 3: Implement** (`src/asset-archive.ts`):
+
+```ts
+/**
+ * Pure helpers shared by the worker asset-serving path and the CI upload script.
+ * No worker/DOM/Node deps so both realms (and vitest) can import it.
+ */
+
+/** Vite-hashed asset under /assets/: `<name>-<8+ url-safe>[.compound].<ext>`. */
+export const HASHED_ASSET_RE =
+  /^\/assets\/[A-Za-z0-9][A-Za-z0-9._-]*-[A-Za-z0-9_-]{8,}(\.[a-z0-9]+)*\.(js|mjs|css|map|wasm|woff2|woff|ttf|svg|png|jpg|jpeg|gif|webp|avif|ico|json)$/;
+
+export function matchHashedAssetPath(pathname: string): boolean {
+  return HASHED_ASSET_RE.test(pathname);
+}
+
+const MIME: Record<string, string> = {
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  css: 'text/css',
+  json: 'application/json',
+  map: 'application/json',
+  wasm: 'application/wasm',
+  svg: 'image/svg+xml',
+  woff2: 'font/woff2',
+  woff: 'font/woff',
+  ttf: 'font/ttf',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  avif: 'image/avif',
+  ico: 'image/x-icon',
+};
+
+export function mimeForAssetPath(pathname: string): string {
+  const ext = pathname.slice(pathname.lastIndexOf('.') + 1).toLowerCase();
+  return MIME[ext] ?? 'application/octet-stream';
+}
+```
+
+- [ ] **Step 4: Run — expect PASS.** Validate `HASHED_ASSET_RE` against a real build if available (`ls dist/ui/assets | while read f; do node -e "..."`); adjust the hash length only if real Vite output disagrees.
+- [ ] **Step 5: Commit** `feat(worker): shared hashed-asset predicate + MIME map (#1330 retention)`.
+
+---
+
+### Task 2: R2 binding — `WorkerEnv` type + wrangler config
+
+**Files:**
+
+- Modify: `packages/cloudflare-worker/src/index.ts:45` (`WorkerEnv`)
+- Modify: `packages/cloudflare-worker/wrangler.jsonc`
+
+**Interfaces:**
+
+- Produces: `WorkerEnv.ASSET_ARCHIVE: R2Bucket` (used by Task 3).
+
+- [ ] **Step 1:** Add to `WorkerEnv` (after `ASSETS`): `ASSET_ARCHIVE: R2Bucket;` (`R2Bucket` from `@cloudflare/workers-types`, already a dev dep). If the file avoids the global types, declare a minimal structural type `{ get(key: string): Promise<R2ObjectBody | null> }` — prefer the real `R2Bucket`.
+- [ ] **Step 2:** In `wrangler.jsonc`, add a top-level `r2_buckets` array beside `assets`:
+
+```jsonc
+"r2_buckets": [
+  { "binding": "ASSET_ARCHIVE", "bucket_name": "slicc-asset-archive" }
+],
+```
+
+and inside `env.staging` (env configs do not inherit top-level):
+
+```jsonc
+"r2_buckets": [
+  { "binding": "ASSET_ARCHIVE", "bucket_name": "slicc-asset-archive-staging" }
+],
+```
+
+- [ ] **Step 3:** `npm run typecheck` (worker tsconfig) — expect PASS. `npm run build -w @slicc/cloudflare-worker` (`wrangler deploy --dry-run`) may warn that the bucket doesn't exist yet; that is fine locally (buckets are the Task 7 ops step). If the dry-run hard-fails on a missing bucket, note it and proceed (CI needs the buckets created first — documented in Task 7).
+- [ ] **Step 4: Commit** `feat(worker): ASSET_ARCHIVE R2 binding (prod + staging)`.
+
+---
+
+### Task 3: `serveAssetWithArchiveFallback` + dispatch wiring + unit tests
+
+**Files:**
+
+- Modify: `packages/cloudflare-worker/src/index.ts` (new function + call before the SPA/JSON split at `~:412`)
+- Test: `packages/cloudflare-worker/tests/index.test.ts`
+
+**Interfaces:**
+
+- Consumes: `matchHashedAssetPath`, `mimeForAssetPath` (Task 1); `WorkerEnv.ASSET_ARCHIVE` (Task 2).
+
+- [ ] **Step 1: Write failing tests** (`tests/index.test.ts`, add a `describe('asset archive fallback')`). Build a fake `env` with `ASSETS.fetch` and `ASSET_ARCHIVE.get`/`head` mocks. Cases (see spec §Testing):
+  - present asset: `ASSETS` returns `200` non-HTML → returned unchanged, `ASSET_ARCHIVE.get` **not** called.
+  - miss (`ASSETS` returns `200 text/html`) + archive hit → `200`, `Content-Type: text/javascript`, `ETag`, `Content-Length`, `Cache-Control: …immutable`, **no** `Accept-Ranges`.
+  - `HEAD` hit → `200`, empty body.
+  - request with `Range` / `If-None-Match` → still full `200`; assert `ASSET_ARCHIVE.get` called with **no** `onlyIf`/`range`.
+  - miss + archive miss (`get` → null) → the shell (`200 text/html`); a `HEAD` archive-miss fallback has **no body**.
+  - `get` throws → shell (never a 500).
+  - non-hashed / traversal / `POST` /assets path → falls through (no archive).
+  - Cache API: mock `caches.default` (or the module's cache accessor); a `GET` populates cache and a second `GET` hits it; a `HEAD` does not consult it.
+
+  Example (present + miss hit):
+
+```ts
+function fakeEnv(assetsRes: Response, archive?: { body: string; etag: string }) {
+  return {
+    ASSETS: { fetch: async () => assetsRes.clone() },
+    ASSET_ARCHIVE: {
+      get: async () =>
+        archive
+          ? {
+              body: archive.body,
+              httpEtag: archive.etag,
+              size: archive.body.length,
+              writeHttpMetadata: (h: Headers) => h.set('content-type', 'text/javascript'),
+              uploaded: new Date(0),
+            }
+          : null,
+    },
+  } as unknown as WorkerEnv;
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement** `serveAssetWithArchiveFallback` and wire it in. Insert the call in the dispatch just before the SPA/JSON split (`index.ts:~412`):
+
+```ts
+// #1330 retention: serve content-hashed /assets/* from the R2 archive when the
+// current build no longer has them, before the SPA fallback turns them into HTML.
+if (
+  (request.method === 'GET' || request.method === 'HEAD') &&
+  matchHashedAssetPath(new URL(request.url).pathname)
+) {
+  return serveAssetWithArchiveFallback(request, env, ctx);
+}
+```
+
+Function (add near `serveSPA`):
+
+```ts
+const ASSET_IMMUTABLE = 'public, max-age=31536000, immutable';
+
+async function serveAssetWithArchiveFallback(
+  request: Request,
+  env: WorkerEnv,
+  ctx: ExecutionContext
+): Promise<Response> {
+  const url = new URL(request.url);
+  const isHead = request.method === 'HEAD';
+
+  // Classify present-vs-miss with a sanitized canonical GET so Range/conditional
+  // headers can't make ASSETS answer 206/304 for the shell.
+  const hasCond =
+    request.headers.has('range') ||
+    request.headers.has('if-none-match') ||
+    request.headers.has('if-modified-since') ||
+    request.headers.has('if-match') ||
+    request.headers.has('if-unmodified-since');
+  const probe =
+    !hasCond && !isHead
+      ? await env.ASSETS.fetch(request)
+      : await env.ASSETS.fetch(new Request(url.toString(), { method: 'GET' }));
+  const probeCT = probe.headers.get('content-type') ?? '';
+  const isMiss = (probe.status === 200 && probeCT.includes('text/html')) || probe.status === 404;
+
+  if (!isMiss) {
+    // Present: let the platform serve the ORIGINAL request (honors Range/cond).
+    return hasCond || isHead ? env.ASSETS.fetch(request) : probe;
+  }
+
+  // Miss → archive. Cache only plain GET (HEAD bypasses).
+  const cache = caches.default;
+  const cacheKey = new Request(`${url.origin}${url.pathname}`, { method: 'GET' });
+  if (!isHead) {
+    const hit = await cache.match(cacheKey);
+    if (hit) return hit;
+  }
+
+  let obj: R2ObjectBody | null = null;
+  try {
+    obj = await env.ASSET_ARCHIVE.get(url.pathname.slice(1)); // no onlyIf/range
+  } catch {
+    obj = null;
+  }
+  if (!obj) {
+    // Fallback to the shell; a HEAD must stay bodyless.
+    return isHead ? new Response(null, { status: probe.status, headers: probe.headers }) : probe;
+  }
+
+  const headers = new Headers();
+  obj.writeHttpMetadata(headers);
+  if (!headers.has('content-type')) headers.set('content-type', mimeForAssetPath(url.pathname));
+  headers.set('etag', obj.httpEtag);
+  headers.set('cache-control', ASSET_IMMUTABLE);
+  headers.set('content-length', String(obj.size));
+
+  if (isHead) return new Response(null, { status: 200, headers });
+
+  const res = new Response(obj.body, { status: 200, headers });
+  ctx.waitUntil(cache.put(cacheKey, res.clone()).catch(() => {}));
+  return res;
+}
+```
+
+Notes: `R2ObjectBody`/`ExecutionContext` from `@cloudflare/workers-types`. Confirm the handler signature exposes `ctx` at the call site (thread it through if the current dispatch does not already). Asset responses intentionally skip `serveSPA`'s CSP mutation; they still pass through the outer `applySliccLinks` wrapper.
+
+- [ ] **Step 4: Run — expect PASS**; coverage ≥ floor.
+- [ ] **Step 5:** `npm run lint:ci && npm run deadcode && npm run typecheck`.
+- [ ] **Step 6: Commit** `feat(worker): serve /assets/* from R2 archive on ASSETS miss (#1330)`.
+
+---
+
+### Task 4: Upload script (`upload-assets-to-r2.mjs`) + tests
+
+**Files:**
+
+- Create: `packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs`
+- Test: `packages/cloudflare-worker/tests/upload-assets-to-r2.test.ts`
+
+**Interfaces:**
+
+- CLI: `node scripts/upload-assets-to-r2.mjs <bucket> [--dir <dist/ui/assets>]`. Exits non-zero on hash-invariant violation or any upload failure (after retries). Imports `matchHashedAssetPath`/`mimeForAssetPath` from `../src/asset-archive.js` (compiled) or a shared `.mjs` — keep **one** predicate; if TS import from `.mjs` is awkward, re-export the predicate via a tiny `.mjs` and have the worker import that, so there is a single source.
+
+- [ ] **Step 1:** First verify the exact wrangler CLI: `npx wrangler r2 object put --help` — confirm the `--file`, `--content-type`, and remote/`--remote` flags for the pinned wrangler; adjust the command string accordingly.
+- [ ] **Step 2: Write failing tests** (`tests/upload-assets-to-r2.test.ts`). Export the pure pieces from the script for testing (e.g. `assertAllHashed(names)`, `buildPutArgs(bucket, file, dir)`, and a `runUploads(files, { exec, concurrency, retries })` that takes an injected `exec`). Cases:
+  - `assertAllHashed` throws when a name lacks a hash (`foo.js`), passes for hashed names.
+  - `buildPutArgs` yields `<bucket>/assets/<file>` + `--content-type <mime>`.
+  - `runUploads` retries a failing `exec` up to N then throws; respects the concurrency cap; re-puts **every** file (no skip).
+- [ ] **Step 3: Implement** the script with an injectable `exec` (default = `node:child_process` `execFile` of `wrangler`), `assertAllHashed`, bounded-concurrency pool, per-file retries. `main()` reads `dist/ui/assets`, asserts, uploads; on any rejection `process.exit(1)`.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `feat(worker): R2 asset upload script (assert-hash, re-put-all, retries)`.
+
+---
+
+### Task 5: Wire the gated upload into all four deploy paths
+
+**Files:**
+
+- Modify: `packages/cloudflare-worker/scripts/publish-worker.sh` (automated prod)
+- Modify: `.github/workflows/worker.yml` (manual prod), `.github/workflows/ci.yml` (`cloudflare-worker` job, staging), `.github/workflows/worker-staging.yml` (staging)
+
+- [ ] **Step 1:** `publish-worker.sh` — before its `wrangler deploy`, add (hard-fail, after the webapp build already present in the release):
+
+```sh
+node scripts/upload-assets-to-r2.mjs slicc-asset-archive
+```
+
+with `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` in scope (already available to the release deploy).
+
+- [ ] **Step 2:** `worker.yml` — add one `run:` step **before deploy attempt 1**, `env: { CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID }`, `node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive`. Gate the deploy attempts on its success (it is not `continue-on-error`, so a failure fails the job before deploy).
+- [ ] **Step 3:** `ci.yml` `cloudflare-worker` job + `worker-staging.yml` — same, **staging** bucket (`slicc-asset-archive-staging`), inserted after the webapp build / dry-run gate and before the first staging deploy attempt.
+- [ ] **Step 4: Verify** by inspection + `actionlint` if available; no unit test (workflow/shell). Confirm ordering (build → [dry-run] → upload → deploy) and that no deploy attempt is reachable without a successful upload.
+- [ ] **Step 5: Commit** `ci(worker): upload assets to R2 before every deploy (gated)`.
+
+---
+
+### Task 6: Deployed smoke — staging-only archive recovery + present-asset
+
+**Files:**
+
+- Modify: `packages/cloudflare-worker/tests/deployed.test.ts`
+
+- [ ] **Step 1:** Add a **present-asset** check (both envs): fetch `/` (or `?json=false`), parse a real `/assets/*` URL from the HTML, fetch it, assert `200` + JS/CSS `Content-Type`; repeat with `?json=true` to confirm the asset branch runs before the JSON split. Send `Accept-Encoding: br,gzip`, record `Content-Encoding`, do **not** assert exact `Content-Length`.
+- [ ] **Step 2:** Add a **staging-only archive-recovery** check, gated on staging creds (`process.env.SLICC_ASSET_ARCHIVE_STAGING` / account token) and **skipped against prod** (guard on `WORKER_BASE_URL` host or an explicit `IS_STAGING` env): upload a synthetic non-ASSETS object `assets/r2-retention-smoke-<hash>.js` via `wrangler r2 object put ... --remote` to the staging bucket, then fetch it through the worker and assert `200` + JS `Content-Type` + `ETag` + a working `HEAD`; a second fetch (cache hit) still serves; an unknown `assets/<hash>.js` returns the shell. Clean up the object after (`wrangler r2 object delete`).
+- [ ] **Step 3:** Document/verify the lifecycle rule via `wrangler r2 bucket lifecycle list <bucket>` in the runbook (Task 7); optionally assert its presence in the staging-only block.
+- [ ] **Step 4: Run** the unit suite (deployed smoke runs in CI against staging; locally it skips without creds). **Commit** `test(worker): deployed smoke for R2 asset archive (staging-only) + present-asset`.
+
+---
+
+### Task 7: Docs + ops runbook
+
+**Files:**
+
+- Modify: `packages/cloudflare-worker/CLAUDE.md` (Static Asset Serving section + a new "R2 asset retention" + runbook)
+- Modify: root `CLAUDE.md` only if a new cross-cutting note is warranted
+- Modify: `docs/review-patterns.md` only if a new reviewer pattern emerges (likely N/A)
+
+- [ ] **Step 1:** In `cloudflare-worker/CLAUDE.md`, document: the `ASSET_ARCHIVE` binding + per-env buckets; the ASSETS-first/R2-on-miss serving; option A GC + the build-unique limitation + option B as future work; conditional/Range not implemented; the upload-before-deploy gate across the four paths.
+- [ ] **Step 2:** Add an **ops runbook** (prerequisites, must exist before CI deploys): create buckets (`wrangler r2 bucket create slicc-asset-archive` + `-staging`); apply the 14-day lifecycle (`wrangler r2 bucket lifecycle add …` / dashboard, then verify with `wrangler r2 bucket lifecycle list`); grant the deploy `CLOUDFLARE_API_TOKEN` **R2 Object Read & Write** on both buckets.
+- [ ] **Step 3: Commit** `docs(worker): R2 asset retention + ops runbook (#1330)`.
+
+---
+
+## Self-Review (author checklist)
+
+- Spec coverage: serving (T3), buckets/binding (T2), upload (T4), deploy gate (T5), GC/ops (T7), tests (T1/T3/T4/T6). ✓
+- Types consistent: `matchHashedAssetPath`/`mimeForAssetPath` (T1) used identically in T3 + T4; `ASSET_ARCHIVE` (T2) used in T3. ✓
+- No option B, no conditional/Range, no touch job. ✓
+- Ops prerequisites (buckets/lifecycle/token scope) called out as non-code and blocking CI. ✓

--- a/docs/superpowers/plans/2026-07-08-r2-asset-retention.md
+++ b/docs/superpowers/plans/2026-07-08-r2-asset-retention.md
@@ -23,8 +23,8 @@
 
 ## File Structure
 
-- Create `packages/cloudflare-worker/src/asset-archive.ts` — pure helpers: `HASHED_ASSET_RE`, `matchHashedAssetPath`, `mimeForAssetPath`. No worker/DOM deps.
-- Modify `packages/cloudflare-worker/src/index.ts` — `WorkerEnv.ASSET_ARCHIVE`; `serveAssetWithArchiveFallback`; wire into dispatch before the SPA/JSON split.
+- Create `packages/cloudflare-worker/src/asset-archive.mjs` (+ `asset-archive.d.ts`) — pure ESM helpers: `HASHED_ASSET_RE`, `matchHashedAssetPath`, `mimeForAssetPath`. **Plain `.mjs` (not `.ts`)** so the Node upload script can import it directly at runtime (no build step); the worker (TS, wrangler/esbuild-bundled) imports it via the sidecar `.d.ts`. **This is the single source of the predicate/MIME for both realms.**
+- Modify `packages/cloudflare-worker/src/index.ts` — `WorkerEnv.ASSET_ARCHIVE`; thread `ExecutionContext` (`ctx`) from `worker.fetch` through `handleWorkerRequest`; add `serveAssetWithArchiveFallback`; wire into dispatch before the SPA/JSON split. Do **not** change `ROUTES_INDEX_BODY` (no new route).
 - Modify `packages/cloudflare-worker/wrangler.jsonc` — `r2_buckets` binding (top-level + `env.staging`).
 - Create `packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs` — Node uploader (assert-hash, re-put-all, parallel+retries).
 - Modify `packages/cloudflare-worker/scripts/publish-worker.sh` + `.github/workflows/worker.yml` + `.github/workflows/ci.yml` + `.github/workflows/worker-staging.yml` — gated upload step.
@@ -37,18 +37,18 @@
 
 **Files:**
 
-- Create: `packages/cloudflare-worker/src/asset-archive.ts`
+- Create: `packages/cloudflare-worker/src/asset-archive.mjs` (plain ESM JS) + `packages/cloudflare-worker/src/asset-archive.d.ts` (types sidecar)
 - Test: `packages/cloudflare-worker/tests/asset-archive.test.ts`
 
 **Interfaces:**
 
-- Produces: `HASHED_ASSET_RE: RegExp`; `matchHashedAssetPath(pathname: string): boolean`; `mimeForAssetPath(pathname: string): string`.
+- Produces: `HASHED_ASSET_RE: RegExp`; `matchHashedAssetPath(pathname: string): boolean`; `mimeForAssetPath(pathname: string): string`. Imported by both `index.ts` (worker) and `upload-assets-to-r2.mjs` (Node) — one source.
 
 - [ ] **Step 1: Write failing tests** (`tests/asset-archive.test.ts`):
 
 ```ts
 import { describe, expect, it } from 'vitest';
-import { matchHashedAssetPath, mimeForAssetPath } from '../src/asset-archive.js';
+import { matchHashedAssetPath, mimeForAssetPath } from '../src/asset-archive.mjs';
 
 describe('matchHashedAssetPath', () => {
   it('accepts hashed chunk names', () => {
@@ -84,23 +84,24 @@ describe('mimeForAssetPath', () => {
 
 - [ ] **Step 2: Run — expect FAIL** (`npm run test:coverage:cloudflare-worker -- asset-archive` → module not found).
 
-- [ ] **Step 3: Implement** (`src/asset-archive.ts`):
+- [ ] **Step 3: Implement** (`src/asset-archive.mjs`, plain ESM — no TS annotations):
 
-```ts
+```js
 /**
- * Pure helpers shared by the worker asset-serving path and the CI upload script.
- * No worker/DOM/Node deps so both realms (and vitest) can import it.
+ * Pure helpers shared by the worker asset-serving path (TS, esbuild-bundled) and
+ * the CI upload script (Node, run from source). Plain ESM so both import it with
+ * no build step. No worker/DOM/Node deps.
  */
 
 /** Vite-hashed asset under /assets/: `<name>-<8+ url-safe>[.compound].<ext>`. */
 export const HASHED_ASSET_RE =
   /^\/assets\/[A-Za-z0-9][A-Za-z0-9._-]*-[A-Za-z0-9_-]{8,}(\.[a-z0-9]+)*\.(js|mjs|css|map|wasm|woff2|woff|ttf|svg|png|jpg|jpeg|gif|webp|avif|ico|json)$/;
 
-export function matchHashedAssetPath(pathname: string): boolean {
+export function matchHashedAssetPath(pathname) {
   return HASHED_ASSET_RE.test(pathname);
 }
 
-const MIME: Record<string, string> = {
+const MIME = {
   js: 'text/javascript',
   mjs: 'text/javascript',
   css: 'text/css',
@@ -120,11 +121,24 @@ const MIME: Record<string, string> = {
   ico: 'image/x-icon',
 };
 
-export function mimeForAssetPath(pathname: string): string {
+export function mimeForAssetPath(pathname) {
   const ext = pathname.slice(pathname.lastIndexOf('.') + 1).toLowerCase();
   return MIME[ext] ?? 'application/octet-stream';
 }
 ```
+
+And the types sidecar (`src/asset-archive.d.ts`) so `index.ts` gets types:
+
+```ts
+export declare const HASHED_ASSET_RE: RegExp;
+export declare function matchHashedAssetPath(pathname: string): boolean;
+export declare function mimeForAssetPath(pathname: string): string;
+```
+
+Confirm the worker tsconfig resolves the `.mjs` import (via the `.d.ts`); if module
+resolution complains, import as `'./asset-archive.mjs'` with the sidecar present
+(NodeNext/bundler resolution honors the co-located `.d.ts`). Add
+`allowJs`-free — the `.d.ts` is sufficient.
 
 - [ ] **Step 4: Run — expect PASS.** Validate `HASHED_ASSET_RE` against a real build if available (`ls dist/ui/assets | while read f; do node -e "..."`); adjust the hash length only if real Vite output disagrees.
 - [ ] **Step 5: Commit** `feat(worker): shared hashed-asset predicate + MIME map (#1330 retention)`.
@@ -143,6 +157,7 @@ export function mimeForAssetPath(pathname: string): string {
 - Produces: `WorkerEnv.ASSET_ARCHIVE: R2Bucket` (used by Task 3).
 
 - [ ] **Step 1:** Add to `WorkerEnv` (after `ASSETS`): `ASSET_ARCHIVE: R2Bucket;` (`R2Bucket` from `@cloudflare/workers-types`, already a dev dep). If the file avoids the global types, declare a minimal structural type `{ get(key: string): Promise<R2ObjectBody | null> }` — prefer the real `R2Bucket`.
+- [ ] **Step 1b (required — else existing tests fail typecheck):** Making `ASSET_ARCHIVE` a required field breaks **every** existing `WorkerEnv` construction in `packages/cloudflare-worker/tests/**` (e.g. `index.test.ts` and any shared env factory). Grep for env objects passed to `handleWorkerRequest`/`worker.fetch` (`grep -rn "ASSETS:" packages/cloudflare-worker/tests`) and add a default fake to each — a shared helper is cleanest, e.g. a `tests/helpers/fake-env.ts` `makeEnv(overrides)` returning `{ ASSETS, ASSET_ARCHIVE: { get: async () => null }, … }`. Update all call sites to it. (Run `npm run typecheck` to enumerate the failures.)
 - [ ] **Step 2:** In `wrangler.jsonc`, add a top-level `r2_buckets` array beside `assets`:
 
 ```jsonc
@@ -209,7 +224,9 @@ function fakeEnv(assetsRes: Response, archive?: { body: string; etag: string }) 
 
 - [ ] **Step 2: Run — expect FAIL.**
 
-- [ ] **Step 3: Implement** `serveAssetWithArchiveFallback` and wire it in. Insert the call in the dispatch just before the SPA/JSON split (`index.ts:~412`):
+- [ ] **Step 3a: Thread `ExecutionContext`.** Today `worker.fetch(request, env)` calls `handleWorkerRequest(request, env, fetchImpl = fetch)` — there is **no `ctx`** in scope. Change `worker.fetch(request, env, ctx)` to pass `ctx` into `handleWorkerRequest(request, env, ctx, fetchImpl = fetch)` (keep `fetchImpl` last/defaulted so existing callers/tests still work), and update the internal call sites. Unit tests build a fake `ctx = { waitUntil: (p) => { void p; }, passThroughOnException() {} }`.
+- [ ] **Step 3b: Import the shared predicate** in `index.ts`: `import { matchHashedAssetPath, mimeForAssetPath } from './asset-archive.mjs';`.
+- [ ] **Step 3c: Implement** `serveAssetWithArchiveFallback` and wire it in. Insert the call in the dispatch just before the SPA/JSON split (`index.ts:~412`); do **not** modify `ROUTES_INDEX_BODY` (no new route):
 
 ```ts
 // #1330 retention: serve content-hashed /assets/* from the R2 archive when the
@@ -243,24 +260,28 @@ async function serveAssetWithArchiveFallback(
     request.headers.has('if-modified-since') ||
     request.headers.has('if-match') ||
     request.headers.has('if-unmodified-since');
-  const probe =
-    !hasCond && !isHead
-      ? await env.ASSETS.fetch(request)
-      : await env.ASSETS.fetch(new Request(url.toString(), { method: 'GET' }));
+  const probe = hasCond
+    ? await env.ASSETS.fetch(new Request(url.toString(), { method: 'GET' }))
+    : await env.ASSETS.fetch(request); // plain GET/HEAD: original IS the probe
   const probeCT = probe.headers.get('content-type') ?? '';
   const isMiss = (probe.status === 200 && probeCT.includes('text/html')) || probe.status === 404;
 
   if (!isMiss) {
-    // Present: let the platform serve the ORIGINAL request (honors Range/cond).
-    return hasCond || isHead ? env.ASSETS.fetch(request) : probe;
+    // Present: for a plain GET/HEAD the probe IS the answer; only a conditional/
+    // Range request needs the original re-fetched so the platform honors it.
+    return hasCond ? env.ASSETS.fetch(request) : probe;
   }
 
   // Miss → archive. Cache only plain GET (HEAD bypasses).
   const cache = caches.default;
   const cacheKey = new Request(`${url.origin}${url.pathname}`, { method: 'GET' });
   if (!isHead) {
-    const hit = await cache.match(cacheKey);
-    if (hit) return hit;
+    try {
+      const hit = await cache.match(cacheKey);
+      if (hit) return hit;
+    } catch {
+      /* cache read failure → fall through to R2; never 500 an asset */
+    }
   }
 
   let obj: R2ObjectBody | null = null;
@@ -278,6 +299,7 @@ async function serveAssetWithArchiveFallback(
   obj.writeHttpMetadata(headers);
   if (!headers.has('content-type')) headers.set('content-type', mimeForAssetPath(url.pathname));
   headers.set('etag', obj.httpEtag);
+  headers.set('last-modified', obj.uploaded.toUTCString());
   headers.set('cache-control', ASSET_IMMUTABLE);
   headers.set('content-length', String(obj.size));
 
@@ -306,14 +328,14 @@ Notes: `R2ObjectBody`/`ExecutionContext` from `@cloudflare/workers-types`. Confi
 
 **Interfaces:**
 
-- CLI: `node scripts/upload-assets-to-r2.mjs <bucket> [--dir <dist/ui/assets>]`. Exits non-zero on hash-invariant violation or any upload failure (after retries). Imports `matchHashedAssetPath`/`mimeForAssetPath` from `../src/asset-archive.js` (compiled) or a shared `.mjs` — keep **one** predicate; if TS import from `.mjs` is awkward, re-export the predicate via a tiny `.mjs` and have the worker import that, so there is a single source.
+- CLI: `node scripts/upload-assets-to-r2.mjs <bucket> [--dir <dir>]` (default dir resolved relative to repo root: `dist/ui/assets`). Exits non-zero on hash-invariant violation or any upload failure (after retries). Imports `matchHashedAssetPath`/`mimeForAssetPath` from `../src/asset-archive.mjs` (the single shared source from Task 1 — direct runtime import, no build). Shells wrangler via **`npx wrangler`** (a plain `run:`/shell step is not an npm script, so `node_modules/.bin` is not on `PATH`).
 
 - [ ] **Step 1:** First verify the exact wrangler CLI: `npx wrangler r2 object put --help` — confirm the `--file`, `--content-type`, and remote/`--remote` flags for the pinned wrangler; adjust the command string accordingly.
 - [ ] **Step 2: Write failing tests** (`tests/upload-assets-to-r2.test.ts`). Export the pure pieces from the script for testing (e.g. `assertAllHashed(names)`, `buildPutArgs(bucket, file, dir)`, and a `runUploads(files, { exec, concurrency, retries })` that takes an injected `exec`). Cases:
   - `assertAllHashed` throws when a name lacks a hash (`foo.js`), passes for hashed names.
   - `buildPutArgs` yields `<bucket>/assets/<file>` + `--content-type <mime>`.
   - `runUploads` retries a failing `exec` up to N then throws; respects the concurrency cap; re-puts **every** file (no skip).
-- [ ] **Step 3: Implement** the script with an injectable `exec` (default = `node:child_process` `execFile` of `wrangler`), `assertAllHashed`, bounded-concurrency pool, per-file retries. `main()` reads `dist/ui/assets`, asserts, uploads; on any rejection `process.exit(1)`.
+- [ ] **Step 3: Implement** the script with an injectable `exec` (default = `node:child_process` `execFile` of **`npx wrangler`**), `assertAllHashed`, bounded-concurrency pool, per-file retries. `main()` reads the `--dir` (default repo-root `dist/ui/assets`), asserts, uploads; on any rejection `process.exit(1)`.
 - [ ] **Step 4: Run — expect PASS.**
 - [ ] **Step 5: Commit** `feat(worker): R2 asset upload script (assert-hash, re-put-all, retries)`.
 
@@ -326,17 +348,17 @@ Notes: `R2ObjectBody`/`ExecutionContext` from `@cloudflare/workers-types`. Confi
 - Modify: `packages/cloudflare-worker/scripts/publish-worker.sh` (automated prod)
 - Modify: `.github/workflows/worker.yml` (manual prod), `.github/workflows/ci.yml` (`cloudflare-worker` job, staging), `.github/workflows/worker-staging.yml` (staging)
 
-- [ ] **Step 1:** `publish-worker.sh` — before its `wrangler deploy`, add (hard-fail, after the webapp build already present in the release):
+- [ ] **Step 1:** `publish-worker.sh` runs from **repo root** — before its `wrangler deploy`, add (hard-fail, after the webapp build already present in the release) using the **full path** + explicit `--dir`:
 
 ```sh
-node scripts/upload-assets-to-r2.mjs slicc-asset-archive
+node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive --dir dist/ui/assets
 ```
 
-with `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` in scope (already available to the release deploy).
+with `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` in scope (already available to the release deploy). The script shells `npx wrangler`.
 
-- [ ] **Step 2:** `worker.yml` — add one `run:` step **before deploy attempt 1**, `env: { CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID }`, `node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive`. Gate the deploy attempts on its success (it is not `continue-on-error`, so a failure fails the job before deploy).
-- [ ] **Step 3:** `ci.yml` `cloudflare-worker` job + `worker-staging.yml` — same, **staging** bucket (`slicc-asset-archive-staging`), inserted after the webapp build / dry-run gate and before the first staging deploy attempt.
-- [ ] **Step 4: Verify** by inspection + `actionlint` if available; no unit test (workflow/shell). Confirm ordering (build → [dry-run] → upload → deploy) and that no deploy attempt is reachable without a successful upload.
+- [ ] **Step 2:** `worker.yml` — add one `run:` step **before deploy attempt 1**, `env: { CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID }`, running `node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive --dir dist/ui/assets`. Not `continue-on-error`, so its failure fails the job before any deploy attempt.
+- [ ] **Step 3:** `ci.yml` `cloudflare-worker` job + `worker-staging.yml` — same, **staging** bucket (`slicc-asset-archive-staging`), inserted after the webapp build / dry-run gate and before the first staging deploy attempt. **Copy the exact `if:` condition from the existing staging "Deploy … (attempt 1)" step onto the upload step**, so it is skipped (not failed) on fork PRs / contexts without Cloudflare secrets — otherwise a hard-fail upload runs where the deploy would have skipped.
+- [ ] **Step 4: Verify** by inspection + `actionlint` if available; no unit test (workflow/shell). Confirm ordering (build → [dry-run] → upload → deploy), that no deploy attempt is reachable without a successful upload, and that the upload step's `if:` matches the deploy step's `if:` in each workflow.
 - [ ] **Step 5: Commit** `ci(worker): upload assets to R2 before every deploy (gated)`.
 
 ---
@@ -348,7 +370,8 @@ with `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` in scope (already available 
 - Modify: `packages/cloudflare-worker/tests/deployed.test.ts`
 
 - [ ] **Step 1:** Add a **present-asset** check (both envs): fetch `/` (or `?json=false`), parse a real `/assets/*` URL from the HTML, fetch it, assert `200` + JS/CSS `Content-Type`; repeat with `?json=true` to confirm the asset branch runs before the JSON split. Send `Accept-Encoding: br,gzip`, record `Content-Encoding`, do **not** assert exact `Content-Length`.
-- [ ] **Step 2:** Add a **staging-only archive-recovery** check, gated on staging creds (`process.env.SLICC_ASSET_ARCHIVE_STAGING` / account token) and **skipped against prod** (guard on `WORKER_BASE_URL` host or an explicit `IS_STAGING` env): upload a synthetic non-ASSETS object `assets/r2-retention-smoke-<hash>.js` via `wrangler r2 object put ... --remote` to the staging bucket, then fetch it through the worker and assert `200` + JS `Content-Type` + `ETag` + a working `HEAD`; a second fetch (cache hit) still serves; an unknown `assets/<hash>.js` returns the shell. Clean up the object after (`wrangler r2 object delete`).
+- [ ] **Step 2:** Add a **staging-only archive-recovery** check. The test currently only reads `WORKER_BASE_URL`; this case needs more, so it must **self-gate**: run only when `SLICC_ARCHIVE_SMOKE === '1'` **and** `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` + a staging bucket name are present; otherwise `it.skip`. It uploads a synthetic non-ASSETS `assets/r2-retention-smoke-<hash>.js` via `npx wrangler r2 object put … --remote` to the staging bucket, fetches it through the worker, asserts `200` + JS `Content-Type` + `ETag` + a working `HEAD`; a second fetch (cache hit) still serves; an unknown `assets/<hash>.js` returns the shell; then cleans up (`npx wrangler r2 object delete`).
+- [ ] **Step 2b (workflow wiring):** In the **staging** smoke steps (`ci.yml` `cloudflare-worker` job + `worker-staging.yml`) pass `SLICC_ARCHIVE_SMOKE: '1'`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, and the staging bucket name **in addition to** `WORKER_BASE_URL`, sharing the deploy step's `if:`. The **production** smoke (`worker.yml` / `publish-worker.sh`) must **not** set `SLICC_ARCHIVE_SMOKE`, so the R2-write case skips against prod (no prod R2 writes).
 - [ ] **Step 3:** Document/verify the lifecycle rule via `wrangler r2 bucket lifecycle list <bucket>` in the runbook (Task 7); optionally assert its presence in the staging-only block.
 - [ ] **Step 4: Run** the unit suite (deployed smoke runs in CI against staging; locally it skips without creds). **Commit** `test(worker): deployed smoke for R2 asset archive (staging-only) + present-asset`.
 

--- a/docs/superpowers/plans/2026-07-08-r2-asset-retention.md
+++ b/docs/superpowers/plans/2026-07-08-r2-asset-retention.md
@@ -23,10 +23,10 @@
 
 ## File Structure
 
-- Create `packages/cloudflare-worker/src/asset-archive.mjs` (+ `asset-archive.d.ts`) — pure ESM helpers: `HASHED_ASSET_RE`, `matchHashedAssetPath`, `mimeForAssetPath`. **Plain `.mjs` (not `.ts`)** so the Node upload script can import it directly at runtime (no build step); the worker (TS, wrangler/esbuild-bundled) imports it via the sidecar `.d.ts`. **This is the single source of the predicate/MIME for both realms.**
+- Create `packages/cloudflare-worker/src/asset-archive.mjs` (+ `asset-archive.d.mts`) — pure ESM helpers: `HASHED_ASSET_RE`, `matchHashedAssetPath`, `mimeForAssetPath`. **Plain `.mjs` (not `.ts`)** so the Node upload script can import it directly at runtime (no build step); the worker (TS, wrangler/esbuild-bundled) imports `'./asset-archive.mjs'` and TS resolves the co-located **`.d.mts`** declaration (an explicit-ESM `.d.mts` is required — `tsconfig.worker.json` has no `allowJs`, and a plain `.d.ts` is not a reliable companion for a `.mjs` import). **This is the single source of the predicate/MIME for both realms.** **Rule for this feature: every `.mjs` that a `.ts`/`.test.ts` imports must have a co-located `.d.mts`; a runnable CLI `.mjs` that no TS file imports needs none.**
 - Modify `packages/cloudflare-worker/src/index.ts` — `WorkerEnv.ASSET_ARCHIVE`; thread `ExecutionContext` (`ctx`) from `worker.fetch` through `handleWorkerRequest`; add `serveAssetWithArchiveFallback`; wire into dispatch before the SPA/JSON split. Do **not** change `ROUTES_INDEX_BODY` (no new route).
 - Modify `packages/cloudflare-worker/wrangler.jsonc` — `r2_buckets` binding (top-level + `env.staging`).
-- Create `packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs` — Node uploader (assert-hash, re-put-all, parallel+retries).
+- Create `packages/cloudflare-worker/scripts/upload-lib.mjs` (+ `upload-lib.d.mts`) — the testable pure/injectable helpers (`assertAllHashed`, `buildPutArgs`, `runUploads`); and `packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs` — the thin runnable CLI wrapper (imports `upload-lib.mjs`; **not** imported by any TS, so it needs no `.d.mts`). The test imports `upload-lib.mjs` (typed via its `.d.mts`).
 - Modify `packages/cloudflare-worker/scripts/publish-worker.sh` + `.github/workflows/worker.yml` + `.github/workflows/ci.yml` + `.github/workflows/worker-staging.yml` — gated upload step.
 - Create `packages/cloudflare-worker/tests/asset-archive.test.ts`, `tests/upload-assets-to-r2.test.ts`; modify `tests/index.test.ts`, `tests/deployed.test.ts`.
 - Modify `packages/cloudflare-worker/CLAUDE.md` (+ a runbook section) and root `CLAUDE.md` module map if needed.
@@ -37,7 +37,7 @@
 
 **Files:**
 
-- Create: `packages/cloudflare-worker/src/asset-archive.mjs` (plain ESM JS) + `packages/cloudflare-worker/src/asset-archive.d.ts` (types sidecar)
+- Create: `packages/cloudflare-worker/src/asset-archive.mjs` (plain ESM JS) + `packages/cloudflare-worker/src/asset-archive.d.mts` (explicit-ESM types sidecar)
 - Test: `packages/cloudflare-worker/tests/asset-archive.test.ts`
 
 **Interfaces:**
@@ -82,7 +82,7 @@ describe('mimeForAssetPath', () => {
 });
 ```
 
-- [ ] **Step 2: Run — expect FAIL** (`npm run test:coverage:cloudflare-worker -- asset-archive` → module not found).
+- [ ] **Step 2: Run — expect FAIL** — use a focused run: `cd packages/cloudflare-worker && npx vitest run tests/asset-archive.test.ts` (the `test:coverage:cloudflare-worker` gate ignores test-name args and always runs the whole project, so use `npx vitest run <file>` for focused iteration and the gate command only for the coverage check).
 
 - [ ] **Step 3: Implement** (`src/asset-archive.mjs`, plain ESM — no TS annotations):
 
@@ -127,7 +127,8 @@ export function mimeForAssetPath(pathname) {
 }
 ```
 
-And the types sidecar (`src/asset-archive.d.ts`) so `index.ts` gets types:
+And the explicit-ESM types sidecar (`src/asset-archive.d.mts`) so `index.ts` gets
+types from `import { … } from './asset-archive.mjs'`:
 
 ```ts
 export declare const HASHED_ASSET_RE: RegExp;
@@ -135,10 +136,9 @@ export declare function matchHashedAssetPath(pathname: string): boolean;
 export declare function mimeForAssetPath(pathname: string): string;
 ```
 
-Confirm the worker tsconfig resolves the `.mjs` import (via the `.d.ts`); if module
-resolution complains, import as `'./asset-archive.mjs'` with the sidecar present
-(NodeNext/bundler resolution honors the co-located `.d.ts`). Add
-`allowJs`-free — the `.d.ts` is sufficient.
+The `.d.mts` (not `.d.ts`) is required: `tsconfig.worker.json` has no `allowJs`,
+and TS pairs a `./x.mjs` import with a `./x.d.mts` declaration. Verify with
+`npm run typecheck` after adding both files.
 
 - [ ] **Step 4: Run — expect PASS.** Validate `HASHED_ASSET_RE` against a real build if available (`ls dist/ui/assets | while read f; do node -e "..."`); adjust the hash length only if real Vite output disagrees.
 - [ ] **Step 5: Commit** `feat(worker): shared hashed-asset predicate + MIME map (#1330 retention)`.
@@ -190,7 +190,7 @@ and inside `env.staging` (env configs do not inherit top-level):
 
 - Consumes: `matchHashedAssetPath`, `mimeForAssetPath` (Task 1); `WorkerEnv.ASSET_ARCHIVE` (Task 2).
 
-- [ ] **Step 1: Write failing tests** (`tests/index.test.ts`, add a `describe('asset archive fallback')`). Build a fake `env` with `ASSETS.fetch` and `ASSET_ARCHIVE.get`/`head` mocks. Cases (see spec §Testing):
+- [ ] **Step 1: Write failing tests** (`tests/index.test.ts`, add a `describe('asset archive fallback')`). Build a fake `env` with `ASSETS.fetch` and an `ASSET_ARCHIVE.get` mock (the impl only calls `get`, never `head`). Cases (see spec §Testing):
   - present asset: `ASSETS` returns `200` non-HTML → returned unchanged, `ASSET_ARCHIVE.get` **not** called.
   - miss (`ASSETS` returns `200 text/html`) + archive hit → `200`, `Content-Type: text/javascript`, `ETag`, `Content-Length`, `Cache-Control: …immutable`, **no** `Accept-Ranges`.
   - `HEAD` hit → `200`, empty body.
@@ -224,7 +224,7 @@ function fakeEnv(assetsRes: Response, archive?: { body: string; etag: string }) 
 
 - [ ] **Step 2: Run — expect FAIL.**
 
-- [ ] **Step 3a: Thread `ExecutionContext`.** Today `worker.fetch(request, env)` calls `handleWorkerRequest(request, env, fetchImpl = fetch)` — there is **no `ctx`** in scope. Change `worker.fetch(request, env, ctx)` to pass `ctx` into `handleWorkerRequest(request, env, ctx, fetchImpl = fetch)` (keep `fetchImpl` last/defaulted so existing callers/tests still work), and update the internal call sites. Unit tests build a fake `ctx = { waitUntil: (p) => { void p; }, passThroughOnException() {} }`.
+- [ ] **Step 3a: Thread `ExecutionContext`.** Today `worker.fetch(request, env)` calls `handleWorkerRequest(request, env, fetchImpl = fetch)` — there is **no `ctx`** in scope. Add a module-level `const NOOP_CTX: ExecutionContext = { waitUntil() {}, passThroughOnException() {} } as ExecutionContext;` and change the signature to `handleWorkerRequest(request, env, ctx: ExecutionContext = NOOP_CTX, fetchImpl = fetch)`. `worker.fetch(request, env, ctx)` passes the real `ctx`. **`ctx` must be defaulted (not required)** so the many existing 2-arg `handleWorkerRequest(request, env)` / `worker.fetch(request, env)` calls in `tests/index.test.ts` still typecheck. New archive tests can pass a fake ctx to assert `waitUntil` is called, or rely on `NOOP_CTX`.
 - [ ] **Step 3b: Import the shared predicate** in `index.ts`: `import { matchHashedAssetPath, mimeForAssetPath } from './asset-archive.mjs';`.
 - [ ] **Step 3c: Implement** `serveAssetWithArchiveFallback` and wire it in. Insert the call in the dispatch just before the SPA/JSON split (`index.ts:~412`); do **not** modify `ROUTES_INDEX_BODY` (no new route):
 
@@ -323,20 +323,21 @@ Notes: `R2ObjectBody`/`ExecutionContext` from `@cloudflare/workers-types`. Confi
 
 **Files:**
 
-- Create: `packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs`
-- Test: `packages/cloudflare-worker/tests/upload-assets-to-r2.test.ts`
+- Create: `packages/cloudflare-worker/scripts/upload-lib.mjs` + `scripts/upload-lib.d.mts` (testable helpers), `packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs` (thin CLI wrapper)
+- Test: `packages/cloudflare-worker/tests/upload-assets-to-r2.test.ts` (imports `../scripts/upload-lib.mjs`)
 
 **Interfaces:**
 
-- CLI: `node scripts/upload-assets-to-r2.mjs <bucket> [--dir <dir>]` (default dir resolved relative to repo root: `dist/ui/assets`). Exits non-zero on hash-invariant violation or any upload failure (after retries). Imports `matchHashedAssetPath`/`mimeForAssetPath` from `../src/asset-archive.mjs` (the single shared source from Task 1 — direct runtime import, no build). Shells wrangler via **`npx wrangler`** (a plain `run:`/shell step is not an npm script, so `node_modules/.bin` is not on `PATH`).
+- Helpers in `upload-lib.mjs` (typed via `upload-lib.d.mts`): `assertAllHashed(names: string[]): void`; `buildPutArgs(bucket: string, file: string): string[]`; `runUploads(files: string[], opts: { bucket: string; dir: string; exec: Exec; concurrency?: number; retries? : number }): Promise<void>`. Imports `matchHashedAssetPath`/`mimeForAssetPath` from `../src/asset-archive.mjs` (single shared source, Task 1).
+- CLI `upload-assets-to-r2.mjs`: `node scripts/upload-assets-to-r2.mjs <bucket> [--dir <dir>]` (default dir = repo-root `dist/ui/assets`); imports the helpers, passes the default `exec` = `execFile` of **`npx wrangler`** (a plain `run:`/shell step is not an npm script, so `node_modules/.bin` is not on `PATH`); exits non-zero on hash-invariant violation or any upload failure (after retries). Not imported by any TS → no `.d.mts` needed.
 
-- [ ] **Step 1:** First verify the exact wrangler CLI: `npx wrangler r2 object put --help` — confirm the `--file`, `--content-type`, and remote/`--remote` flags for the pinned wrangler; adjust the command string accordingly.
-- [ ] **Step 2: Write failing tests** (`tests/upload-assets-to-r2.test.ts`). Export the pure pieces from the script for testing (e.g. `assertAllHashed(names)`, `buildPutArgs(bucket, file, dir)`, and a `runUploads(files, { exec, concurrency, retries })` that takes an injected `exec`). Cases:
+- [ ] **Step 1:** First verify the exact wrangler CLI: `npx wrangler r2 object put --help` — confirm `--file`, `--content-type`, and the remote/`--remote` flags for the pinned wrangler; adjust `buildPutArgs` accordingly.
+- [ ] **Step 2: Write failing tests** (`tests/upload-assets-to-r2.test.ts`, importing `../scripts/upload-lib.mjs`). Cases:
   - `assertAllHashed` throws when a name lacks a hash (`foo.js`), passes for hashed names.
   - `buildPutArgs` yields `<bucket>/assets/<file>` + `--content-type <mime>`.
-  - `runUploads` retries a failing `exec` up to N then throws; respects the concurrency cap; re-puts **every** file (no skip).
-- [ ] **Step 3: Implement** the script with an injectable `exec` (default = `node:child_process` `execFile` of **`npx wrangler`**), `assertAllHashed`, bounded-concurrency pool, per-file retries. `main()` reads the `--dir` (default repo-root `dist/ui/assets`), asserts, uploads; on any rejection `process.exit(1)`.
-- [ ] **Step 4: Run — expect PASS.**
+  - `runUploads` with an injected `exec` retries a failing `exec` up to N then throws; respects the concurrency cap; re-puts **every** file (no skip).
+- [ ] **Step 3: Implement** `upload-lib.mjs` (+ `.d.mts`) with the injectable `exec`, `assertAllHashed`, `buildPutArgs`, bounded-concurrency `runUploads` with per-file retries; then the thin `upload-assets-to-r2.mjs` CLI (`main()` reads `--dir`, lists files, `assertAllHashed`, `runUploads` with default `npx wrangler` exec; on any rejection `process.exit(1)`).
+- [ ] **Step 4: Run — expect PASS** (`cd packages/cloudflare-worker && npx vitest run tests/upload-assets-to-r2.test.ts`).
 - [ ] **Step 5: Commit** `feat(worker): R2 asset upload script (assert-hash, re-put-all, retries)`.
 
 ---
@@ -357,7 +358,7 @@ node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-arch
 with `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` in scope (already available to the release deploy). The script shells `npx wrangler`.
 
 - [ ] **Step 2:** `worker.yml` — add one `run:` step **before deploy attempt 1**, `env: { CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID }`, running `node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive --dir dist/ui/assets`. Not `continue-on-error`, so its failure fails the job before any deploy attempt.
-- [ ] **Step 3:** `ci.yml` `cloudflare-worker` job + `worker-staging.yml` — same, **staging** bucket (`slicc-asset-archive-staging`), inserted after the webapp build / dry-run gate and before the first staging deploy attempt. **Copy the exact `if:` condition from the existing staging "Deploy … (attempt 1)" step onto the upload step**, so it is skipped (not failed) on fork PRs / contexts without Cloudflare secrets — otherwise a hard-fail upload runs where the deploy would have skipped.
+- [ ] **Step 3:** `ci.yml` `cloudflare-worker` job + `worker-staging.yml` — same, **staging** bucket (`slicc-asset-archive-staging`), inserted after the webapp build / dry-run gate and before the first staging deploy attempt. **Fork-PR guard is mandatory** (a hard-fail upload must not run without Cloudflare secrets): in `ci.yml`, copy the exact `if:` from the existing staging "Deploy … (attempt 1)" step onto the upload step. In `worker-staging.yml` the deploy attempt has **no `if:`** to copy, so add an explicit non-fork guard to the upload step (and ideally the deploy/secrets/smoke steps, or at job level), e.g. `if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository`.
 - [ ] **Step 4: Verify** by inspection + `actionlint` if available; no unit test (workflow/shell). Confirm ordering (build → [dry-run] → upload → deploy), that no deploy attempt is reachable without a successful upload, and that the upload step's `if:` matches the deploy step's `if:` in each workflow.
 - [ ] **Step 5: Commit** `ci(worker): upload assets to R2 before every deploy (gated)`.
 
@@ -369,8 +370,8 @@ with `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` in scope (already available 
 
 - Modify: `packages/cloudflare-worker/tests/deployed.test.ts`
 
-- [ ] **Step 1:** Add a **present-asset** check (both envs): fetch `/` (or `?json=false`), parse a real `/assets/*` URL from the HTML, fetch it, assert `200` + JS/CSS `Content-Type`; repeat with `?json=true` to confirm the asset branch runs before the JSON split. Send `Accept-Encoding: br,gzip`, record `Content-Encoding`, do **not** assert exact `Content-Length`.
-- [ ] **Step 2:** Add a **staging-only archive-recovery** check. The test currently only reads `WORKER_BASE_URL`; this case needs more, so it must **self-gate**: run only when `SLICC_ARCHIVE_SMOKE === '1'` **and** `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` + a staging bucket name are present; otherwise `it.skip`. It uploads a synthetic non-ASSETS `assets/r2-retention-smoke-<hash>.js` via `npx wrangler r2 object put … --remote` to the staging bucket, fetches it through the worker, asserts `200` + JS `Content-Type` + `ETag` + a working `HEAD`; a second fetch (cache hit) still serves; an unknown `assets/<hash>.js` returns the shell; then cleans up (`npx wrangler r2 object delete`).
+- [ ] **Step 1:** Add a **present-asset** check (both envs). **Do not fetch bare `/`** — the production worker redirects `https://www.sliccy.ai/` to the `.com` marketing site before `handleWorkerRequest`, so `/` may not be the SPA. Fetch **`/?json=false`** (or another non-root SPA path) with `redirect: 'manual'` and assert it is **not** a 3xx redirect, then parse a real `/assets/*` URL from the HTML, fetch it, assert `200` + JS/CSS `Content-Type`; repeat the asset fetch with `?json=true` to confirm the asset branch runs before the JSON split. Send `Accept-Encoding: br,gzip`, record `Content-Encoding`, do **not** assert exact `Content-Length`.
+- [ ] **Step 2:** Add a **staging-only archive-recovery** check. The test currently only reads `WORKER_BASE_URL`; this case needs more, so it must **self-gate**: run only when `SLICC_ARCHIVE_SMOKE === '1'` **and** `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` + a staging bucket name are present; otherwise `it.skip`. Additionally **self-verify it is pointed at staging** (assert `WORKER_BASE_URL` host matches the staging worker, e.g. contains `staging`/`workers.dev`) and hard-fail if `SLICC_ARCHIVE_SMOKE==='1'` but the base looks like production — defense-in-depth so a misconfigured env never writes to the prod bucket. It uploads a synthetic non-ASSETS `assets/r2-retention-smoke-<hash>.js` via `npx wrangler r2 object put … --remote` to the staging bucket, fetches it through the worker, asserts `200` + JS `Content-Type` + `ETag` + a working `HEAD`; a second fetch (cache hit) still serves; an unknown `assets/<hash>.js` returns the shell; then cleans up (`npx wrangler r2 object delete`).
 - [ ] **Step 2b (workflow wiring):** In the **staging** smoke steps (`ci.yml` `cloudflare-worker` job + `worker-staging.yml`) pass `SLICC_ARCHIVE_SMOKE: '1'`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, and the staging bucket name **in addition to** `WORKER_BASE_URL`, sharing the deploy step's `if:`. The **production** smoke (`worker.yml` / `publish-worker.sh`) must **not** set `SLICC_ARCHIVE_SMOKE`, so the R2-write case skips against prod (no prod R2 writes).
 - [ ] **Step 3:** Document/verify the lifecycle rule via `wrangler r2 bucket lifecycle list <bucket>` in the runbook (Task 7); optionally assert its presence in the staging-only block.
 - [ ] **Step 4: Run** the unit suite (deployed smoke runs in CI against staging; locally it skips without creds). **Commit** `test(worker): deployed smoke for R2 asset archive (staging-only) + present-asset`.

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -1,0 +1,208 @@
+# R2 Asset Retention — Design
+
+**Status:** design (brainstorming output)
+**Date:** 2026-07-08
+**Issue:** follow-up to #1330 / PR #1364 (stale-asset recovery)
+**Branch:** `feat/r2-asset-retention`
+
+## Problem
+
+A long-lived browser tab loads the SLICC webapp (`index.html` + content-hashed
+chunks) from build **A** served by the cloudflare-worker. A later deploy
+replaces the worker's static assets with build **B** (new content hashes). The
+tab's already-loaded modules keep working, but any **not-yet-loaded lazy chunk**
+from build A (e.g. `anthropic-messages-DP3-Xd3J.js`) is now absent on the
+server. Because `wrangler.jsonc` sets `not_found_handling:
+"single-page-application"`, a request for the gone chunk returns `index.html`
+(HTTP 200, `text/html`) rather than a 404 — the browser then tries to execute
+HTML as a module and the dynamic import fails ("Failed to fetch dynamically
+imported module …"). This is the #1330 crash.
+
+PR #1364 shipped a **reactive** recovery: detect the failure and reload the tab
+(with a one-shot auto-resubmit of the dropped cone turn). That works but is
+heavy-handed:
+
+- A reload tears down the kernel worker, every scoop, in-flight tool calls, and
+  a half-streamed turn. Re-sending the last user message does **not** restore a
+  running _cycle_ — partial progress and already-applied side effects are lost.
+- The deferred SPA-HTML `Cache-Control` hardening leaves a window where a cached
+  build-A shell coexists with freshly-fetched build-B chunks (mixed release).
+
+## Goal
+
+Eliminate the crash at its **root** by keeping every content-hashed `/assets/*`
+file that has ever been deployed available on the server, so a long-lived tab
+can keep fetching **its own build's** chunks after a new deploy — no crash, no
+reload, no interruption, and the tab stays internally consistent (it moves to
+the new build only on a natural, user-initiated reload). The shipped reload
+becomes a rare last-resort fallback.
+
+## Key insight: content hash = identity
+
+Every `/assets/*` filename **is** a hash of its bytes. The same filename can
+only ever mean the same content. Therefore the archive is a **flat, idempotent
+key→bytes store** — no version/release grouping is needed. Re-uploading an
+unchanged chunk on a later deploy is a no-op (same key, same bytes). Only
+**fixed-name entry files** (`index.html`, service-worker scripts, `manifest`,
+favicon) are mutable "which-release" pointers and must always be served from the
+**current** deploy — never archived.
+
+## Architecture
+
+All runtimes load the webapp from a single hosted origin
+(`SLICC_HOSTED_ORIGIN = https://www.sliccy.ai`): the standalone node-server
+(loads UI from the hosted origin, dials back to a local `/cdp` bridge), the
+chrome-extension leader tab (`?slicc=leader`), and the cloud cone (headless
+browser in e2b). A fix at the worker therefore covers **all three** with no
+per-runtime work.
+
+Two moving parts: (1) the worker serves archived assets on a miss; (2) CI
+uploads each deploy's assets into the archive.
+
+### 1. Serving — ASSETS-first, R2-on-miss (worker)
+
+Insertion point: `packages/cloudflare-worker/src/index.ts` — the `serveSPA`
+helper (`:129-158`) and the SPA-fallback dispatch (`:412-417`).
+
+For a request whose path is under **`/assets/`**:
+
+1. `res = await env.ASSETS.fetch(request)` — the current build's asset, if
+   present (unchanged hot path).
+2. If `res` is a **real asset** (its `Content-Type` is **not** `text/html`),
+   return it as today. This is the common case; the current build never depends
+   on R2.
+3. If `res` is the **SPA shell** (`Content-Type` includes `text/html` for an
+   `/assets/*` path ⇒ the asset is gone on this deploy), treat it as a **miss**:
+   - `obj = await env.ASSET_ARCHIVE.get(key)` where `key` is the path minus the
+     leading `/` (e.g. `assets/anthropic-messages-DP3-Xd3J.js`).
+   - **Hit:** return `new Response(obj.body, …)` with `Content-Type` from
+     `obj.httpMetadata.contentType` (set at upload; fall back to an
+     extension-derived MIME) and `Cache-Control: public, max-age=31536000,
+immutable`. Cache the response at the edge via the Cache API (immutable, so
+     safe to cache indefinitely) so subsequent hits skip R2.
+   - **Miss:** return the SPA shell exactly as today (200 `text/html`) so the
+     client's shipped `setup-preload-error-reload` recovery still fires. **No
+     behavior regression** when the archive lacks the chunk.
+
+Rationale for ASSETS-first (vs R2-first for all `/assets`): the live site keeps
+being served by the platform, so an R2 outage degrades only _old_ tabs (they
+fall back to reload) rather than taking the whole site down. The only added
+latency is on _old-build_ chunk requests, which are rare and edge-cached after
+the first hit.
+
+Only `/assets/` is intercepted. Navigations, `index.html`, SW scripts, the
+`?cherry=1` / electron / `/cloud` SPA-shell variants (which set their own
+headers) are untouched.
+
+### 2. Population — CI upload at deploy (`wrangler r2 object put` loop)
+
+After the webapp is built (`dist/ui/assets/` populated), each worker deploy
+uploads that build's assets into the env's archive bucket via a loop of
+`wrangler r2 object put <bucket>/assets/<file> --file <path> --content-type
+<mime> [--remote]`. The loop is **parallelized** (bounded concurrency) and
+**skips objects that already exist** (idempotent; unchanged hashes are not
+re-put) to keep CI time bounded. `--content-type` is derived from the file
+extension in the upload script so the worker can read `httpMetadata.contentType`
+on serve.
+
+Wire the upload step into the three deploy paths (after the webapp build, before
+/ alongside `wrangler deploy`):
+
+- `.github/workflows/ci.yml` — `cloudflare-worker` job (staging) → staging
+  bucket.
+- `.github/workflows/worker-staging.yml` (staging) → staging bucket.
+- `.github/workflows/worker.yml` (production, `workflow_dispatch`) → prod bucket.
+
+Uses the existing Cloudflare API token (wrangler auth) — **no new credential
+surface** (S3 access keys avoided by design).
+
+### 3. Buckets & bindings
+
+Two R2 buckets (separate per env so staging's high churn never mixes into prod):
+
+- `slicc-asset-archive` (production)
+- `slicc-asset-archive-staging` (staging)
+
+`wrangler.jsonc`: add an `r2_buckets` binding `ASSET_ARCHIVE` at the top level
+(→ `slicc-asset-archive`) and duplicated in `env.staging` (→
+`slicc-asset-archive-staging`), mirroring how `assets` and the DO bindings are
+already duplicated per env. This is the **first R2 binding** in the repo.
+
+### 4. GC — ~14-day age-based lifecycle
+
+An R2 lifecycle rule deletes objects whose last-modified is older than **14
+days**. Because every deploy re-puts (touches) the still-current chunks, only
+chunks that have **stopped shipping** age out. A tab left open longer than ~14
+days past its build's last deploy will find its unique chunks GC'd and fall back
+to the shipped reload — an acceptable rare case. Applied to both buckets
+(staging can GC more aggressively if desired, but 14d is fine for both).
+
+### 5. Interplay with the shipped reload (#1364)
+
+Unchanged. Retention removes ~all reloads; the reload path remains the
+last-resort fallback for (a) the ~14-day-plus gap, (b) an R2 outage, or (c) a
+breaking client↔backend protocol change where the tab _should_ migrate to the
+new build. No client code changes in this project.
+
+## Data flow
+
+```
+Deploy:  build webapp → dist/ui/assets/*  →  (CI) wrangler r2 object put loop
+             → ASSET_ARCHIVE bucket (flat, hash-keyed, idempotent)
+             → wrangler deploy (current build → ASSETS + index.html)
+
+Request /assets/<hash>.js:
+  worker → env.ASSETS.fetch()
+     ├─ real asset (non-HTML)  → return (current build, fast path)
+     └─ SPA shell (text/html)  → env.ASSET_ARCHIVE.get(assets/<hash>.js)
+             ├─ hit  → serve archived bytes, immutable cache, edge-cache
+             └─ miss → return SPA shell (client reload fallback, as today)
+```
+
+## Error handling
+
+- `env.ASSET_ARCHIVE.get()` failure/exception → treat as miss (return SPA
+  shell); never 500 the asset request. Retention is best-effort; the reload
+  fallback is the safety net.
+- CI upload failure → fail the deploy step visibly (a deploy that didn't archive
+  its assets would silently reintroduce the crash for the _next_ deploy's
+  orphaned tabs). Uploads run with retries.
+- Content-type absent on an archived object → derive from extension; default to
+  `application/octet-stream` only as a last resort.
+
+## Testing
+
+- **Worker unit** (`packages/cloudflare-worker/tests/index.test.ts`): `/assets`
+  hit passes through ASSETS untouched; `/assets` miss with archive hit serves
+  archived bytes + immutable `Cache-Control` + correct `Content-Type`; `/assets`
+  miss with archive miss returns the SPA shell (no regression); non-`/assets`
+  paths never consult R2. Mock `env.ASSET_ARCHIVE` (R2 `.get`) and `env.ASSETS`.
+- **Deployed smoke** (`packages/cloudflare-worker/tests/deployed.test.ts`): a
+  known current-build asset resolves; the SPA fallback still serves HTML for a
+  genuinely unknown non-asset path. (Route-table mirror rule: any change to the
+  `index.ts` routing must update `index.test.ts` **and** `deployed.test.ts`.)
+- **Upload script**: unit-test MIME derivation + the skip-if-exists / bounded
+  concurrency logic.
+- Coverage kept at/above the cloudflare-worker floor.
+
+## Out of scope
+
+- The chrome-extension's **own** bundled assets (extension-update path — that is
+  #1406 part (c), a separate concern: `chrome.runtime.onUpdateAvailable` →
+  reload leader tab + SW reload).
+- Changing the shipped `setup-preload-error-reload` recovery (kept as fallback).
+- SPA-HTML `Cache-Control` hardening (a separately-deferred #1330 item; can be
+  folded in later but not required here).
+- Client-side service-worker precache (the alternative "keep versions
+  client-side" approach — not chosen).
+
+## Decisions (locked)
+
+| Decision         | Choice                                                                       |
+| ---------------- | ---------------------------------------------------------------------------- |
+| Primary strategy | Server-side R2 asset retention (root-cause fix)                              |
+| Serving          | ASSETS-first, R2-on-miss (resilience: live site independent of R2)           |
+| GC               | ~14-day age-based R2 lifecycle                                               |
+| Buckets          | Separate per env (`slicc-asset-archive`, `…-staging`)                        |
+| Upload           | `wrangler r2 object put` loop (parallel + skip-if-exists), existing CF token |
+| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                             |

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -1,6 +1,6 @@
 # R2 Asset Retention — Design
 
-**Status:** design (brainstorming output)
+**Status:** design (brainstorming output; codex round 1 applied)
 **Date:** 2026-07-08
 **Issue:** follow-up to #1330 / PR #1364 (stale-asset recovery)
 **Branch:** `feat/r2-asset-retention`
@@ -31,18 +31,18 @@ heavy-handed:
 ## Goal
 
 Eliminate the crash at its **root** by keeping every content-hashed `/assets/*`
-file that has ever been deployed available on the server, so a long-lived tab
+file **within a retention window** available on the server, so a long-lived tab
 can keep fetching **its own build's** chunks after a new deploy — no crash, no
 reload, no interruption, and the tab stays internally consistent (it moves to
 the new build only on a natural, user-initiated reload). The shipped reload
-becomes a rare last-resort fallback.
+becomes a rare last-resort fallback for chunks older than the window.
 
 ## Key insight: content hash = identity
 
 Every `/assets/*` filename **is** a hash of its bytes. The same filename can
 only ever mean the same content. Therefore the archive is a **flat, idempotent
-key→bytes store** — no version/release grouping is needed. Re-uploading an
-unchanged chunk on a later deploy is a no-op (same key, same bytes). Only
+key→bytes store** — no version/release grouping is needed. Re-uploading a chunk
+on a later deploy is a no-op content-wise (same key, same bytes). Only
 **fixed-name entry files** (`index.html`, service-worker scripts, `manifest`,
 favicon) are mutable "which-release" pointers and must always be served from the
 **current** deploy — never archived.
@@ -56,158 +56,224 @@ chrome-extension leader tab (`?slicc=leader`), and the cloud cone (headless
 browser in e2b). A fix at the worker therefore covers **all three** with no
 per-runtime work.
 
-Two moving parts: (1) the worker serves archived assets on a miss; (2) CI
-uploads each deploy's assets into the archive.
+Three moving parts: (1) the worker serves archived assets on a miss; (2) CI
+uploads each deploy's assets into the archive **before** the deploy goes live;
+(3) a scheduled job keeps the live build's assets fresh so they never age out
+while still current.
 
 ### 1. Serving — ASSETS-first, R2-on-miss (worker)
 
 Insertion point: `packages/cloudflare-worker/src/index.ts` — the `serveSPA`
-helper (`:129-158`) and the SPA-fallback dispatch (`:412-417`).
+helper (`~:129`) and the SPA-fallback dispatch (`~:412`). Add a dedicated
+`serveAssetWithArchiveFallback(request, env, ctx)` invoked for `/assets/*` GET/
+HEAD requests **before** the generic SPA fallback.
 
-For a request whose path is under **`/assets/`**:
+**Asset-path gate.** Only intervene for requests whose canonical `url.pathname`
+starts with `/assets/` **and** ends in a known asset extension
+(`.js .mjs .css .map .wasm .woff2 .woff .ttf .svg .png .jpg .jpeg .gif .webp
+.avif .ico .json`). Any other path is untouched (falls through to today's
+behavior). This avoids misclassifying a hypothetical `/assets/*.html`.
+
+**Key derivation (hardened).** Key = canonical `url.pathname` with the leading
+`/` removed (e.g. `assets/anthropic-messages-DP3-Xd3J.js`). Reject and skip the
+archive path (fall through to normal handling) if the decoded pathname contains
+`..`, a backslash, an encoded slash (`%2f`/`%5c`), a null byte, or is empty
+after the prefix. **Query string is ignored** for the key and for the cache key.
+
+**Flow:**
 
 1. `res = await env.ASSETS.fetch(request)` — the current build's asset, if
    present (unchanged hot path).
-2. If `res` is a **real asset** (its `Content-Type` is **not** `text/html`),
-   return it as today. This is the common case; the current build never depends
-   on R2.
-3. If `res` is the **SPA shell** (`Content-Type` includes `text/html` for an
-   `/assets/*` path ⇒ the asset is gone on this deploy), treat it as a **miss**:
-   - `obj = await env.ASSET_ARCHIVE.get(key)` where `key` is the path minus the
-     leading `/` (e.g. `assets/anthropic-messages-DP3-Xd3J.js`).
-   - **Hit:** return `new Response(obj.body, …)` with `Content-Type` from
-     `obj.httpMetadata.contentType` (set at upload; fall back to an
-     extension-derived MIME) and `Cache-Control: public, max-age=31536000,
-immutable`. Cache the response at the edge via the Cache API (immutable, so
-     safe to cache indefinitely) so subsequent hits skip R2.
-   - **Miss:** return the SPA shell exactly as today (200 `text/html`) so the
-     client's shipped `setup-preload-error-reload` recovery still fires. **No
-     behavior regression** when the archive lacks the chunk.
+2. If `res.status === 200` and its `Content-Type` is **not** `text/html`, return
+   `res` unchanged (current build; the common case; never touches R2).
+3. Otherwise ASSETS returned the SPA shell for a hashed asset ⇒ **miss**. Serve
+   from the archive via a single **response builder** (below). On archive miss
+   or any R2 error, return the original `res` (the SPA shell, HTTP 200
+   `text/html`) exactly as today so the shipped `setup-preload-error-reload`
+   recovery still fires — **no regression**.
+
+**Response builder (full HTTP semantics, from R2 object metadata).** Use the R2
+Workers API, not ad-hoc headers:
+
+- **Conditional:** `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf:
+request.headers, range: request.headers })`. If `obj` exists but has no `body`
+  (a conditional/precondition result), return `304 Not Modified` with `ETag` /
+  `Last-Modified` and no body.
+- **HEAD:** `head = await env.ASSET_ARCHIVE.head(key)` (or `get` then discard
+  body) → `200` with headers, empty body.
+- **Range:** if `obj.range` is set, return `206 Partial Content` with
+  `Content-Range` and the partial body; an unsatisfiable range → `416` with
+  `Content-Range: bytes */<size>`.
+- **Full GET:** `200` with the body.
+- **Headers on every response:** `obj.writeHttpMetadata(headers)` (carries the
+  stored `Content-Type`; fall back to an extension-derived MIME if absent),
+  `ETag: obj.httpEtag`, `Content-Length: obj.size`, `Accept-Ranges: bytes`,
+  `Last-Modified`, and `Cache-Control: public, max-age=31536000, immutable`.
+  Do **not** copy the SPA-shell CSP/headers onto asset responses.
+- **Compression:** serve raw bytes; Cloudflare's edge auto-compresses eligible
+  content-types to the client, so we do not store or negotiate encodings.
+
+**Edge cache (Cache API), poison-safe.** Only **successful full-body `GET` 200**
+archive responses are cached, and only under a **canonical GET cache key**
+(scheme+host+`/assets/<file>`, query dropped, method GET). **Never** cache: an
+archive miss, the SPA shell, a `206`, a `304`, or a `HEAD` response. Clone the
+response before `cache.put`. On a subsequent hit, `cache.match` short-circuits
+before R2. Because responses are `immutable`, indefinite edge caching is safe.
 
 Rationale for ASSETS-first (vs R2-first for all `/assets`): the live site keeps
 being served by the platform, so an R2 outage degrades only _old_ tabs (they
-fall back to reload) rather than taking the whole site down. The only added
-latency is on _old-build_ chunk requests, which are rare and edge-cached after
-the first hit.
+fall back to reload) rather than taking the whole site down. Added latency is
+only on _old-build_ chunk requests, which are rare and edge-cached after first
+hit.
 
-Only `/assets/` is intercepted. Navigations, `index.html`, SW scripts, the
-`?cherry=1` / electron / `/cloud` SPA-shell variants (which set their own
-headers) are untouched.
+Navigations, `index.html`, SW scripts, and the `?cherry=1` / electron /
+`/cloud` SPA-shell variants (which set their own headers) are untouched.
 
 ### 2. Population — CI upload at deploy (`wrangler r2 object put` loop)
 
-After the webapp is built (`dist/ui/assets/` populated), each worker deploy
-uploads that build's assets into the env's archive bucket via a loop of
-`wrangler r2 object put <bucket>/assets/<file> --file <path> --content-type
-<mime> --remote`. The loop **re-puts the current build's full asset set every
-deploy** (bounded-concurrency parallel) — it does **not** skip existing keys.
-This is deliberate: a PUT refreshes the object's `last-modified`, which the
-age-based GC (§4) relies on to keep **still-shipping** chunks alive; skipping
-unchanged keys would let a vendor chunk that hasn't changed in >14 days be GC'd
-even though it's still part of the current build. Re-putting is
-content-idempotent (same hash ⇒ same bytes), so the only cost is CI time, which
-the bounded parallelism keeps in check. `--content-type` is derived from the
-file extension in the upload script so the worker can read
-`httpMetadata.contentType` on serve.
+Ordering is **strict** in every deploy workflow: **build webapp → 25 MiB
+static-assets dry-run gate → upload all `dist/ui/assets/*` to the env bucket
+(with retries) → only then run the real `wrangler deploy`.** If the upload step
+fails, the job **hard-stops before deploy** — a build must never go live
+unarchived (that would orphan the _next_ deploy's tabs).
 
-Wire the upload step into the three deploy paths (after the webapp build, before
-/ alongside `wrangler deploy`):
+Upload = a bounded-concurrency parallel loop of
+`wrangler r2 object put <bucket>/assets/<file> --file <path> --content-type
+<mime> --remote`, deriving `--content-type` from the file extension so the
+worker reads `httpMetadata.contentType` on serve. The loop **re-puts the current
+build's full asset set every deploy — it does NOT skip existing keys** (a PUT
+refreshes `last-modified`, which the age-based GC in §4 relies on to keep
+still-shipping chunks alive; re-putting is content-idempotent, so the only cost
+is CI time, bounded by the parallelism).
+
+**Auth (explicit).** The upload runs as a plain `run:` step (not
+`wrangler-action`), so it must pass `CLOUDFLARE_API_TOKEN` and
+`CLOUDFLARE_ACCOUNT_ID` in its `env:` (mirroring
+`.github/workflows/storybook-screenshots.yml`). **The API token must carry R2
+"Object Read & Write" permission for both buckets** — an ops prerequisite
+documented alongside the feature (the existing deploy token may need this scope
+added).
+
+Wire the step into the three deploy paths:
 
 - `.github/workflows/ci.yml` — `cloudflare-worker` job (staging) → staging
   bucket.
 - `.github/workflows/worker-staging.yml` (staging) → staging bucket.
 - `.github/workflows/worker.yml` (production, `workflow_dispatch`) → prod bucket.
 
-Uses the existing Cloudflare API token (wrangler auth) — **no new credential
-surface** (S3 access keys avoided by design).
+### 3. Freshness — scheduled touch of the live build
 
-### 3. Buckets & bindings
+Age-based GC (§4) evicts by `last-modified`, refreshed only on deploy. If a
+build stays live longer than the GC window without a redeploy (production
+deploys are manual `workflow_dispatch`, so a >14-day gap is realistic), its
+chunks would age out of R2 **while still current**, and the _next_ deploy would
+orphan every tab on that (fresh) build.
+
+Fix: a **scheduled workflow** (`.github/workflows/worker-asset-touch.yml`,
+weekly cron, well inside the 14-day window) that checks out `main`, builds the
+webapp, and re-runs the **same upload script** against the **prod** bucket —
+touching the current build's assets so they never age out while live. Reuses the
+§2 script; no new logic. (Staging churns on every PR, so it needs no touch job.)
+
+### 4. Buckets, bindings & GC
 
 Two R2 buckets (separate per env so staging's high churn never mixes into prod):
-
-- `slicc-asset-archive` (production)
-- `slicc-asset-archive-staging` (staging)
+`slicc-asset-archive` (prod) and `slicc-asset-archive-staging`.
 
 `wrangler.jsonc`: add an `r2_buckets` binding `ASSET_ARCHIVE` at the top level
 (→ `slicc-asset-archive`) and duplicated in `env.staging` (→
 `slicc-asset-archive-staging`), mirroring how `assets` and the DO bindings are
-already duplicated per env. This is the **first R2 binding** in the repo.
+already duplicated per env (env configs do **not** inherit top-level bindings).
+This is the **first R2 binding** in the repo. The **preview worker**
+(`wrangler-preview.jsonc`, no ASSETS) does **not** need the binding.
 
-### 4. GC — ~14-day age-based lifecycle
-
-An R2 lifecycle rule deletes objects whose last-modified is older than **14
-days**. Because every deploy re-puts (touches) the still-current chunks, only
-chunks that have **stopped shipping** age out. A tab left open longer than ~14
-days past its build's last deploy will find its unique chunks GC'd and fall back
-to the shipped reload — an acceptable rare case. Applied to both buckets
-(staging can GC more aggressively if desired, but 14d is fine for both).
+**GC:** an R2 **object-lifecycle rule** on each bucket deletes objects whose
+`last-modified` is older than **14 days**. Combined with §2 (deploy re-puts) and
+§3 (weekly touch of the live prod build), only chunks that have **stopped
+shipping** for >14 days age out. Residual: a tab whose build has been fully
+superseded for >14 days and only then lazily imports a now-evicted chunk falls
+back to the shipped reload — an accepted rare case inherent to a 14-day window.
 
 ### 5. Interplay with the shipped reload (#1364)
 
 Unchanged. Retention removes ~all reloads; the reload path remains the
-last-resort fallback for (a) the ~14-day-plus gap, (b) an R2 outage, or (c) a
-breaking client↔backend protocol change where the tab _should_ migrate to the
-new build. No client code changes in this project.
+last-resort fallback for (a) the >14-day-superseded gap, (b) an R2 outage/miss,
+or (c) a breaking client↔backend protocol change where the tab _should_ migrate.
+No client code changes in this project.
 
 ## Data flow
 
 ```
-Deploy:  build webapp → dist/ui/assets/*  →  (CI) wrangler r2 object put loop
-             → ASSET_ARCHIVE bucket (flat, hash-keyed, idempotent)
-             → wrangler deploy (current build → ASSETS + index.html)
+Deploy:  build webapp → dist/ui/assets/*
+   → 25 MiB dry-run gate → R2 upload loop (re-put ALL, retries) → env bucket
+   → [only on upload success] wrangler deploy (current build → ASSETS + index.html)
 
-Request /assets/<hash>.js:
+Weekly (prod): checkout main → build → R2 upload loop → prod bucket (touch live build)
+
+Request GET/HEAD /assets/<hash>.<ext>:
   worker → env.ASSETS.fetch()
-     ├─ real asset (non-HTML)  → return (current build, fast path)
-     └─ SPA shell (text/html)  → env.ASSET_ARCHIVE.get(assets/<hash>.js)
-             ├─ hit  → serve archived bytes, immutable cache, edge-cache
-             └─ miss → return SPA shell (client reload fallback, as today)
+     ├─ 200 non-HTML  → return (current build, fast path)
+     └─ SPA shell     → Cache API match (canonical GET key)
+             ├─ cached → return
+             └─ miss   → env.ASSET_ARCHIVE.get(key, {onlyIf, range})
+                     ├─ 200 full   → build response (ETag/Length/Accept-Ranges/immutable), cache.put, return
+                     ├─ 206/304/HEAD → build response, DO NOT cache
+                     └─ archive miss/error → return SPA shell (client reload fallback, as today)
 ```
 
 ## Error handling
 
-- `env.ASSET_ARCHIVE.get()` failure/exception → treat as miss (return SPA
-  shell); never 500 the asset request. Retention is best-effort; the reload
-  fallback is the safety net.
-- CI upload failure → fail the deploy step visibly (a deploy that didn't archive
-  its assets would silently reintroduce the crash for the _next_ deploy's
-  orphaned tabs). Uploads run with retries.
-- Content-type absent on an archived object → derive from extension; default to
-  `application/octet-stream` only as a last resort.
+- `env.ASSET_ARCHIVE.get()`/`head()` failure/exception → treat as miss (return
+  the SPA shell); never 500 an asset request. Retention is best-effort; the
+  reload fallback is the safety net.
+- CI upload failure → **fail the deploy job before `wrangler deploy`** (retries
+  first). An unarchived live build silently reintroduces the crash for the next
+  deploy's tabs.
+- Content-type absent on an archived object → derive from extension; last resort
+  `application/octet-stream`.
 
 ## Testing
 
-- **Worker unit** (`packages/cloudflare-worker/tests/index.test.ts`): `/assets`
-  hit passes through ASSETS untouched; `/assets` miss with archive hit serves
-  archived bytes + immutable `Cache-Control` + correct `Content-Type`; `/assets`
-  miss with archive miss returns the SPA shell (no regression); non-`/assets`
-  paths never consult R2. Mock `env.ASSET_ARCHIVE` (R2 `.get`) and `env.ASSETS`.
-- **Deployed smoke** (`packages/cloudflare-worker/tests/deployed.test.ts`): a
-  known current-build asset resolves; the SPA fallback still serves HTML for a
-  genuinely unknown non-asset path. (Route-table mirror rule: any change to the
-  `index.ts` routing must update `index.test.ts` **and** `deployed.test.ts`.)
-- **Upload script**: unit-test MIME derivation + the skip-if-exists / bounded
-  concurrency logic.
+- **Worker unit** (`packages/cloudflare-worker/tests/index.test.ts`): mock
+  `env.ASSETS` (real-asset vs SPA-shell) and `env.ASSET_ARCHIVE` (R2 `.get`/
+  `.head` with `writeHttpMetadata`, `httpEtag`, `size`, `range`, `onlyIf`).
+  Cases: `/assets` hit passes through untouched; `/assets` miss + archive hit →
+  200 with correct `Content-Type`/`ETag`/`Content-Length`/`Accept-Ranges`/
+  immutable `Cache-Control`; **HEAD** (no body); **Range** → 206 + `Content-Range`
+  (and 416 for unsatisfiable); **conditional** (`If-None-Match`/
+  `If-Modified-Since`) → 304; `/assets` miss + archive miss → SPA shell (no
+  regression); non-`/assets` and non-asset-extension paths never consult R2; key
+  derivation rejects `..`/backslash/encoded-slash/empty; **Cache API** puts only
+  full 200 GETs under the canonical key and never caches miss/shell/206/304/HEAD.
+- **Deployed smoke** (`packages/cloudflare-worker/tests/deployed.test.ts`):
+  upload a synthetic **non-ASSETS** object `assets/r2-retention-smoke-<hash>.js`
+  to the staging bucket, then fetch it **through the worker** and assert 200 +
+  JS `Content-Type` + `ETag` + a working `HEAD`; and that a genuinely unknown
+  non-asset path still returns the SPA HTML. (Route-mirror rule: index.ts
+  routing changes update `index.test.ts` **and** `deployed.test.ts`.)
+- **Upload script**: unit-test MIME derivation, the re-put-all (no skip)
+  behavior, and retry/bounded-concurrency logic.
 - Coverage kept at/above the cloudflare-worker floor.
 
 ## Out of scope
 
-- The chrome-extension's **own** bundled assets (extension-update path — that is
-  #1406 part (c), a separate concern: `chrome.runtime.onUpdateAvailable` →
-  reload leader tab + SW reload).
+- The chrome-extension's **own** bundled assets (extension-update path — #1406
+  part (c): `chrome.runtime.onUpdateAvailable` → reload leader tab + SW reload).
 - Changing the shipped `setup-preload-error-reload` recovery (kept as fallback).
-- SPA-HTML `Cache-Control` hardening (a separately-deferred #1330 item; can be
-  folded in later but not required here).
-- Client-side service-worker precache (the alternative "keep versions
-  client-side" approach — not chosen).
+- SPA-HTML `Cache-Control` hardening (a separately-deferred #1330 item).
+- Client-side service-worker precache (rejected alternative).
+- The preview worker (no ASSETS; no binding).
 
 ## Decisions (locked)
 
-| Decision         | Choice                                                                       |
-| ---------------- | ---------------------------------------------------------------------------- |
-| Primary strategy | Server-side R2 asset retention (root-cause fix)                              |
-| Serving          | ASSETS-first, R2-on-miss (resilience: live site independent of R2)           |
-| GC               | ~14-day age-based R2 lifecycle                                               |
-| Buckets          | Separate per env (`slicc-asset-archive`, `…-staging`)                        |
-| Upload           | `wrangler r2 object put` loop (parallel + skip-if-exists), existing CF token |
-| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                             |
+| Decision         | Choice                                                                                                               |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                      |
+| Serving          | ASSETS-first, R2-on-miss (live site independent of R2)                                                               |
+| HTTP semantics   | Full builder: HEAD/Range(206/416)/conditional(304)/ETag/Length/Accept-Ranges via R2 metadata                         |
+| Edge cache       | Cache API: full-200-GET only, canonical GET key, never miss/shell/206/304/HEAD                                       |
+| GC               | ~14-day age-based R2 lifecycle + weekly scheduled touch of the live prod build                                       |
+| Upload           | `wrangler r2 object put` loop, re-put ALL (no skip), parallel + retries, before deploy; CF token needs R2 Object R/W |
+| Deploy ordering  | build → dry-run gate → R2 upload → (on success) deploy; hard-stop on upload failure                                  |
+| Buckets          | Separate per env (`slicc-asset-archive`, `…-staging`); preview worker excluded                                       |
+| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                     |

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -1,6 +1,6 @@
 # R2 Asset Retention — Design
 
-**Status:** design (brainstorming output; codex rounds 1–2 applied)
+**Status:** design (brainstorming output; codex rounds 1–3 applied)
 **Date:** 2026-07-08
 **Issue:** follow-up to #1330 / PR #1364 (stale-asset recovery)
 **Branch:** `feat/r2-asset-retention`
@@ -37,250 +37,268 @@ reload, no interruption, and the tab stays internally consistent (it moves to
 the new build only on a natural, user-initiated reload). The shipped reload
 becomes a rare last-resort fallback for chunks past the window.
 
-## Key insight: content hash = identity
+## Key insight: content hash = identity (enforced)
 
 Every `/assets/*` filename **is** a hash of its bytes. The same filename can
-only ever mean the same content. Therefore the archive is a **flat, idempotent
-key→bytes store** — no version/release grouping is needed. Re-uploading a chunk
-on a later deploy is a no-op content-wise (same key, same bytes). Only
-**fixed-name entry files** (`index.html`, service-worker scripts, `manifest`,
-favicon) are mutable "which-release" pointers and must always be served from the
-**current** deploy — never archived.
+only ever mean the same content, so the archive is a **flat, idempotent
+key→bytes store** — no version/release grouping. This invariant is **enforced**,
+not assumed: the upload step (§2) **fails the deploy if any `dist/ui/assets/*`
+filename lacks a content-hash** (pattern `-<8+ url-safe chars>` before the
+extension — Vite's default). It holds today because Vite hashes everything under
+`assets/` and the fixed-name entry files (`index.html`, SW scripts, `manifest`,
+favicon) live at the **root**, not under `/assets/`, so they are never archived
+and always served from the current deploy. The worker only ever serves an
+archived object on a **miss** (asset absent from the current deploy), which by
+construction is always an old hashed chunk — so the `immutable` cache header is
+always safe.
 
 ## Architecture
 
 All runtimes load the webapp from a single hosted origin
-(`SLICC_HOSTED_ORIGIN = https://www.sliccy.ai`): the standalone node-server
-(loads UI from the hosted origin, dials back to a local `/cdp` bridge), the
+(`SLICC_HOSTED_ORIGIN = https://www.sliccy.ai`): the standalone node-server, the
 chrome-extension leader tab (`?slicc=leader`), and the cloud cone (headless
-browser in e2b). A fix at the worker therefore covers **all three** with no
-per-runtime work.
-
-Two moving parts: (1) the worker serves archived assets on a miss; (2) every
-deploy uploads its assets to the archive **before** going live.
+browser in e2b). A fix at the worker covers **all three** with no per-runtime
+work. Two moving parts: (1) the worker serves archived assets on a miss; (2)
+every deploy uploads its assets to the archive **before** going live.
 
 ### 1. Serving — ASSETS-first, R2-on-miss (worker)
 
 Insertion point: `packages/cloudflare-worker/src/index.ts` — a dedicated
 `serveAssetWithArchiveFallback(request, env, ctx)` invoked from the top-level
-dispatch **before** the `wantsJSON` SPA/JSON split (`~:412`), so that even
-`/assets/foo.js?json=true` is handled here rather than routed to the API index.
+dispatch **before** the `wantsJSON` SPA/JSON split (`~:412`), so even
+`/assets/foo.js?json=true` is handled here, not routed to the API index.
 
-**Asset-path gate (strict regex — also the anti-traversal guard).** Handle the
-request here only if `request.method` is `GET`/`HEAD` and the raw
-`url.pathname` matches a strict Vite-asset pattern:
+**Asset-path gate (strict regex = anti-traversal + hash invariant).** Handle here
+only if `request.method` is `GET`/`HEAD` and the raw `url.pathname` matches:
 
 ```
 ^/assets/[A-Za-z0-9][A-Za-z0-9._-]*\.(js|mjs|css|map|wasm|woff2|woff|ttf|svg|png|jpg|jpeg|gif|webp|avif|ico|json)$
 ```
 
-Because the class excludes `/`, `%`, `\`, `..` segments and null bytes, a
-matching path is inherently traversal-safe; anything else falls through to
-today's behavior untouched. **The R2 key is the matched `url.pathname` minus the
-leading `/`** (e.g. `assets/anthropic-messages-DP3-Xd3J.js`) — no decoding step,
-so it always equals the upload key. Query string is ignored for key and cache.
+The class excludes `/`, `%`, `\`, `..`, and null bytes, so a match is inherently
+traversal-safe. **R2 key = matched `url.pathname` minus the leading `/`** — no
+decode step, so it always equals the upload key. Query is ignored for key/cache.
+Anything not matching falls through to today's behavior untouched.
 
-**Miss detection (narrow).** `res = await env.ASSETS.fetch(request)`. Treat as a
-miss **only** when `res.status === 200` **and** its `Content-Type` contains
-`text/html` (the SPA shell standing in for a gone hashed asset). **Every other
-ASSETS response — 200 non-HTML, 206, 304, 404, etc. — is returned unchanged**
-(ASSETS may legitimately answer 206/304 for a present asset under Range/
-conditional requests). On a miss, serve from the archive; on archive miss or any
-R2 error, return the original `res` (the SPA shell) exactly as today so the
-shipped `setup-preload-error-reload` recovery still fires — **no regression**.
+**Miss detection (probe-based; robust to Range/conditional).** ASSETS is
+configured with `not_found_handling: single-page-application`, so a missing asset
+returns the shell — but for a request carrying `Range`/conditional headers the
+shell can come back `206`/`304`, which would defeat a naive status check.
+Therefore classify with a **sanitized canonical GET** (Range and conditional
+headers stripped):
 
-**Response builder (per-status, from R2 metadata).** Use the R2 Workers API:
+1. If the original request is a plain `GET`/`HEAD` with no `Range`/conditional,
+   its ASSETS response _is_ the sanitized probe — reuse it (no extra fetch).
+   Otherwise issue one extra `env.ASSETS.fetch(sanitizedGET)` to classify.
+2. **Present** (probe `status === 200` and `Content-Type` not `text/html`): serve
+   the **original** request through `env.ASSETS.fetch(originalRequest)` so the
+   platform honors any Range/conditional. Return unchanged.
+3. **Miss** (probe `200 text/html`): serve from the archive (below). On archive
+   miss or any R2 error, return the shell exactly as today so the shipped
+   `setup-preload-error-reload` recovery still fires — **no regression**.
 
-- `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf: request.headers, range:
-request.headers })`.
-- **Conditional not-modified:** `obj` present but `obj.body == null` ⇒ `304`
-  with `ETag`/`Last-Modified`, **no `Content-Length`**, no body.
-- **HEAD:** headers only (full `Content-Length: obj.size`), empty body.
-- **Range hit:** `obj.range` set ⇒ `206` with `Content-Range: bytes
-<start>-<end>/<size>` and `Content-Length` = **selected range length**.
-- **Unsatisfiable range:** `416` with `Content-Range: bytes */<size>`, no body.
-- **Full GET:** `200`, `Content-Length: obj.size`, body.
+**Response builder (R2 Workers API).** Scope: full `GET`, `HEAD`, and conditional
+GET. **Range is intentionally unsupported** — archived assets are small,
+immutable, content-hashed chunks that browsers do not Range-request; we omit
+`Accept-Ranges` and ignore any `Range` header, returning the full `200` (HTTP
+permits a server to ignore Range). This removes 206/416/If-Range/multi-range
+complexity with no practical loss.
+
+- `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf: request.headers })` — pass
+  **only** `onlyIf` (Headers); do **not** pass `range: request.headers` (R2's
+  `range` is an `R2Range`, not headers).
+- **Archive miss** (`obj == null`): return the shell (fallback).
+- **Failed precondition** (`obj` present, `obj.body == null`): classify by header
+  — `If-None-Match`/`If-Modified-Since` → **`304`** (with `ETag`/`Last-Modified`,
+  no `Content-Length`, no body); `If-Match`/`If-Unmodified-Since` → **`412`**.
+- **HEAD**: `200`, headers incl. `Content-Length: obj.size`, empty body.
+- **Full GET**: `200`, `Content-Length: obj.size`, body.
 - **Common headers:** `obj.writeHttpMetadata(headers)` (stored `Content-Type`;
-  fall back to the extension→MIME map below), `ETag: obj.httpEtag`,
-  `Accept-Ranges: bytes`, `Last-Modified`, `Cache-Control: public,
-max-age=31536000, immutable`. Do **not** copy SPA-shell CSP headers onto asset
-  responses.
-- **MIME map (fallback when metadata absent):** `.js`/`.mjs`→`text/javascript`,
-  `.css`→`text/css`, `.json`/`.map`→`application/json`, `.wasm`→
-  `application/wasm`, `.svg`→`image/svg+xml`, `.woff2`→`font/woff2`,
-  `.woff`→`font/woff`, `.ttf`→`font/ttf`, `.png`→`image/png`,
-  `.jpg`/`.jpeg`→`image/jpeg`, `.gif`→`image/gif`, `.webp`→`image/webp`,
-  `.avif`→`image/avif`, `.ico`→`image/x-icon`. Correct JS/MJS MIME is critical
-  (a wrong type re-creates the module-load failure).
-- **Compression:** serve raw bytes; Cloudflare's edge auto-compresses eligible
-  types to the client — we do not store/negotiate encodings.
+  else the MIME map below), `ETag: obj.httpEtag`, `Last-Modified`,
+  `Cache-Control: public, max-age=31536000, immutable`. No `Accept-Ranges`. Do
+  **not** copy SPA-shell CSP headers onto asset responses (assets deliberately
+  bypass `serveSPA`'s per-request header mutation; covered by a test).
+- **MIME map:** `.js`/`.mjs`→`text/javascript`, `.css`→`text/css`,
+  `.json`/`.map`→`application/json`, `.wasm`→`application/wasm`,
+  `.svg`→`image/svg+xml`, `.woff2`→`font/woff2`, `.woff`→`font/woff`,
+  `.ttf`→`font/ttf`, `.png`→`image/png`, `.jpg`/`.jpeg`→`image/jpeg`,
+  `.gif`→`image/gif`, `.webp`→`image/webp`, `.avif`→`image/avif`,
+  `.ico`→`image/x-icon`. Correct JS/MJS MIME is critical (a wrong type
+  re-creates the module-load failure).
+- **Compression:** serve raw bytes; Cloudflare's edge auto-compresses to the
+  client (which may drop `Content-Length` under transform — tests must not
+  over-assert exact length on the deployed path).
 
-**Edge cache (Cache API), poison-safe.** Consult and populate the Cache API
-**only for a plain `GET` with no `Range` and no conditional headers**
-(`If-None-Match`/`If-Modified-Since`); `HEAD`, `Range`, and conditional requests
-**bypass the cache entirely** and go straight to R2 (so a cached full-200 can
-never be returned for them). Cache **only** a successful **full-body 200**, under
-a **canonical GET cache key** (scheme+host+`/assets/<file>`, query dropped),
-cloning before `cache.put`. Never cache a miss, the SPA shell, `206`, `304`, or
-`HEAD`. Responses are `immutable`, so indefinite edge caching is safe.
+**Edge cache (Cache API), poison-safe.** Consult/populate the Cache API **only
+for a plain `GET` with no `Range` and no conditional headers**; `HEAD` and
+conditional requests bypass the cache and go straight to R2. Cache **only** a
+successful full `200`, under a **canonical GET key** (scheme+host+
+`/assets/<file>`, query dropped), cloning before put; write via
+`ctx.waitUntil(cache.put(...).catch(...))` so a cache-write failure never turns a
+recovered asset into a `500`. Never cache a miss, the shell, `304`, or `HEAD`.
 
 Rationale for ASSETS-first: the live site is served by the platform, so an R2
-outage degrades only _old_ tabs (they fall back to reload) rather than the whole
-site. Added latency is only on _old-build_ requests, rare and edge-cached after
-first hit. Navigations, `index.html`, SW scripts, and the `?cherry=1` / electron
-/ `/cloud` SPA-shell variants are untouched.
+outage degrades only _old_ tabs (they fall back to reload), not the whole site.
+Added latency is only on _old-build_ requests, rare and edge-cached after first
+hit. Navigations, `index.html`, SW scripts, and the `?cherry=1` / electron /
+`/cloud` SPA-shell variants are untouched.
 
-### 2. Population — upload assets to R2 at every deploy
+### 2. Population — upload assets to R2 before every deploy
 
-A single reusable script — `packages/cloudflare-worker/scripts/upload-assets-to-r2.sh <bucket>` —
-loops over `dist/ui/assets/*` and runs, with bounded-concurrency parallelism and
-per-file retries:
+A reusable script — `packages/cloudflare-worker/scripts/upload-assets-to-r2.sh <bucket>` —
+first **asserts the hash invariant** (fails if any `dist/ui/assets/*` name lacks
+a content hash), then loops over `dist/ui/assets/*` with bounded-concurrency
+parallelism and per-file retries:
 
 ```
 wrangler r2 object put <bucket>/assets/<file> --file <path> --content-type <mime> --remote
 ```
 
-deriving `--content-type` from the extension (same MIME map as §1). It **re-puts
-the current build's full asset set every deploy — it does NOT skip existing
-keys** (a PUT refreshes `last-modified`, which the age-based GC in §3 relies on
-to keep still-shipping chunks alive; re-putting is content-idempotent, so the
-only cost is CI time, bounded by the parallelism).
+deriving `--content-type` from the extension (§1 MIME map). It **re-puts the
+current build's full asset set every deploy — no skip-if-exists** (a PUT
+refreshes `last-modified`, which the age-based GC in §3 relies on; re-putting is
+content-idempotent, so the only cost is CI time, bounded by the parallelism).
 
-**Ordering is strict everywhere: build webapp → 25 MiB dry-run gate → run the
-upload script (retries) → only on success run the real `wrangler deploy`.** A
-build must never go live unarchived (that would orphan the _next_ deploy's tabs),
-so the upload step **hard-stops the deploy on failure**.
-
-Wire the script into **all four** deploy paths that run `wrangler deploy`:
+**Gating principle (exact per-file edits belong in the plan).** In **every** path
+that runs `wrangler deploy`, insert the upload as a **single hard-fail step
+(`continue-on-error: false`) after the build and before the _first_ deploy
+attempt**, sharing the deploy's `if` guard; **all** deploy attempts are gated on
+upload success. A build must never go live unarchived (that orphans the _next_
+deploy's tabs). The four paths:
 
 - **Automated production** — `.releaserc.json` → `npm run publish:worker` →
   `packages/cloudflare-worker/scripts/publish-worker.sh` (its `wrangler deploy`
-  is the real prod deploy). Insert the upload before that deploy, targeting the
-  **prod** bucket, using the already-built `dist/ui/assets`.
-- **Manual production** — `.github/workflows/worker.yml` (`workflow_dispatch`) →
-  prod bucket.
-- **Staging (CI)** — `.github/workflows/ci.yml` `cloudflare-worker` job → staging
+  is the real prod deploy): insert the upload call before that deploy, prod
+  bucket, using the already-built `dist/ui/assets`.
+- **Manual production** — `.github/workflows/worker.yml` (3 `wrangler-action`
+  attempts): one upload step before attempt 1, prod bucket.
+- **Staging (CI)** — `.github/workflows/ci.yml` `cloudflare-worker` job
+  (deploy/secrets retry pairs): one upload step before the first attempt, staging
   bucket.
-- **Staging (dedicated)** — `.github/workflows/worker-staging.yml` → staging
+- **Staging (dedicated)** — `.github/workflows/worker-staging.yml`: same, staging
   bucket.
 
-**Auth (explicit).** The upload runs as a plain `run:` step / shell script, so
-it must have `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in its
-environment (mirroring `.github/workflows/storybook-screenshots.yml`). **The API
-token must carry R2 "Object Read & Write" for both buckets** — an ops
-prerequisite documented with the feature (the existing deploy token likely needs
-this scope added).
+Do **not** claim a universal 25 MiB dry-run gate — only some paths run it today;
+the upload step itself is the added gate. (The plan may optionally add the
+dry-run to prod paths.)
+
+**Auth (explicit).** The upload runs as a plain `run:` step / shell, so it needs
+`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` in its environment (mirroring
+`.github/workflows/storybook-screenshots.yml`). **The API token must carry R2
+"Object Read & Write" for both buckets** — an ops prerequisite documented with
+the feature (the existing deploy token likely needs this scope added).
 
 ### 3. Buckets, bindings & GC
 
-Two R2 buckets (separate per env so staging's high churn never mixes into prod):
-`slicc-asset-archive` (prod) and `slicc-asset-archive-staging`.
+Two R2 buckets (separate per env): `slicc-asset-archive` (prod) and
+`slicc-asset-archive-staging`. `wrangler.jsonc`: add an `r2_buckets` binding
+`ASSET_ARCHIVE` at the top level (→ prod) and duplicated in `env.staging` (→
+staging), mirroring the per-env duplication of `assets`/DO bindings (env configs
+do not inherit top-level bindings). First R2 binding in the repo; add the
+`ASSET_ARCHIVE: R2Bucket` field to `WorkerEnv`. The **preview worker** (no
+ASSETS) does not need it.
 
-`wrangler.jsonc`: add an `r2_buckets` binding `ASSET_ARCHIVE` at the top level
-(→ `slicc-asset-archive`) and duplicated in `env.staging` (→
-`slicc-asset-archive-staging`), mirroring how `assets`/DO bindings are already
-duplicated per env (env configs do **not** inherit top-level bindings). This is
-the **first R2 binding** in the repo. The **preview worker**
-(`wrangler-preview.jsonc`, no ASSETS) does **not** need it.
+**GC:** an R2 **object-lifecycle rule** on each bucket deletes objects with
+`last-modified` older than **14 days**. The `wrangler.jsonc` binding does **not**
+create the rule; it is applied out-of-band and **verified** via
+`wrangler r2 bucket lifecycle list <bucket>` (a documented ops step, checked in
+the deployed smoke or a runbook). Every deploy re-puts the current set, so only
+chunks that have **stopped shipping** for >14 days age out.
 
-**GC:** an R2 **object-lifecycle rule** on each bucket deletes objects whose
-`last-modified` is older than **14 days**. Because every deploy re-puts the
-current set (§2), a chunk's clock resets on each deploy it ships in; only chunks
-that have **stopped shipping** age out ~14 days later.
-
-**Accepted residual (no touch job).** The only gap is a **release drought**: if
-production does not deploy for >14 days, the live build's chunks age out of R2
-while still current, and the next deploy would then serve the SPA shell for a
-just-superseded chunk → the tab falls back to the **shipped #1364 reload**. This
-is rare in an active repo (semantic-release deploys prod on merges to main) and
-is the same graceful degradation the 14-day window already implies for
-long-idle tabs. A scheduled "touch" job was considered and rejected: a rebuild
-injects `SLICC_RELEASED_AT`/version defines and can produce different hashes, so
-it would not reliably touch the deployed keys — adding fragility for a rare case
-the reload already covers. (If droughts become common, revisit with a
-manifest-driven touch that re-puts exact deployed keys, or widen the window.)
+**Accepted residual (no touch job).** If production does not deploy for >14 days
+(a release drought), the live build's chunks age out while still current, and a
+just-superseded chunk then falls back to the **shipped #1364 reload** — rare in
+an active repo (semantic-release deploys prod on merges to main) and the same
+graceful degradation the 14-day window already implies for long-idle tabs. A
+scheduled touch was rejected: a rebuild injects `SLICC_RELEASED_AT`/version
+defines and can produce different hashes, so it would not reliably touch the
+deployed keys. (Revisit with a manifest-driven touch or a wider window if
+droughts become common.)
 
 ### 4. Interplay with the shipped reload (#1364)
 
-Unchanged. Retention removes ~all reloads; the reload path remains the
-last-resort fallback for (a) a >14-day release drought, (b) an R2 outage/miss, or
-(c) a breaking client↔backend protocol change where the tab _should_ migrate. No
+Unchanged. Retention removes ~all reloads; the reload remains the last-resort
+fallback for (a) a >14-day release drought, (b) an R2 outage/miss, or (c) a
+breaking client↔backend protocol change where the tab _should_ migrate. No
 client code changes in this project.
 
 ## Data flow
 
 ```
-Deploy (each path): build webapp → dist/ui/assets/*
-   → 25 MiB dry-run gate → upload-assets-to-r2.sh <bucket> (re-put ALL, retries)
-   → [only on upload success] wrangler deploy (current build → ASSETS + index.html)
+Deploy (each path): build → upload-assets-to-r2.sh <bucket> (assert-hash, re-put ALL, retries)
+   → [only on success] wrangler deploy (current build → ASSETS + index.html)
 
 Request GET/HEAD /assets/<hash>.<ext>  (strict regex gate, else fall through):
-  worker → env.ASSETS.fetch()
-     ├─ NOT (200 text/html)  → return unchanged (present asset: 200 non-HTML / 206 / 304 / 404)
-     └─ 200 text/html (miss) →
-          plain GET (no Range/conditional)? → Cache API match (canonical key)
-             ├─ cached → return
-             └─ miss   → R2 get → cache full-200 → return
-          HEAD / Range / conditional?        → R2 get (bypass cache)
-             ├─ 200 full / 206 / 304 / 416 (per-status headers) → return (do NOT cache)
-             └─ archive miss / R2 error       → return SPA shell (reload fallback, as today)
+  classify via sanitized canonical-GET probe to ASSETS:
+     ├─ PRESENT (200 non-HTML) → serve original request via ASSETS (honors Range/conditional)
+     └─ MISS (200 text/html)   →
+           plain GET (no Range/conditional)? Cache API match (canonical key)
+              ├─ cached → return
+              └─ miss   → R2 get{onlyIf} → cache full-200 (waitUntil) → return
+           HEAD / conditional?  → R2 get{onlyIf} (bypass cache)
+              ├─ 200 / HEAD / 304 / 412 (per-status headers; Range ignored → full 200) → return
+              └─ archive miss / R2 error → return shell (reload fallback, as today)
 ```
 
 ## Error handling
 
-- `env.ASSET_ARCHIVE.get()` failure/exception → treat as miss (return the SPA
-  shell); never 500 an asset request.
-- Upload-script failure → **fail the deploy before `wrangler deploy`** (after
-  retries).
-- Content-type absent on an archived object → derive from the MIME map; last
-  resort `application/octet-stream`.
+- `env.ASSET_ARCHIVE.get()` failure/exception → treat as miss (return the shell);
+  never `500` an asset request.
+- `cache.put` failure → swallowed via `waitUntil(...).catch(...)`.
+- Upload-script failure (incl. hash-invariant violation) → **fail the deploy
+  before `wrangler deploy`** (after retries).
+- Content-type absent on an archived object → MIME map; last resort
+  `application/octet-stream`.
 
 ## Testing
 
-- **Worker unit** (`packages/cloudflare-worker/tests/index.test.ts`): mock
-  `env.ASSETS` and `env.ASSET_ARCHIVE`. Cases: present asset (ASSETS 200
-  non-HTML / 206 / 304 / 404) returned unchanged, never consulting R2; miss
-  (200 text/html) + archive hit → 200 with correct MIME/`ETag`/`Content-Length`/
-  `Accept-Ranges`/immutable `Cache-Control`; **HEAD** (headers, no body);
-  **Range** → 206 + `Content-Range` + range-length `Content-Length`;
-  unsatisfiable → 416; **conditional** → 304 with validators and no
-  `Content-Length`; miss + archive miss → SPA shell (no regression); strict
-  regex gate rejects non-asset/traversal/encoded paths and `POST`; **Cache API**
-  populated/consulted only for plain GET, and Range/HEAD/conditional bypass it
-  (a prior cached full-200 is never returned for them).
-- **Deployed smoke** (`packages/cloudflare-worker/tests/deployed.test.ts`):
-  upload a synthetic **non-ASSETS** `assets/r2-retention-smoke-<hash>.js` to the
-  staging bucket, then through the worker assert: full `GET` 200 + JS
-  `Content-Type` + `ETag`; `HEAD`; a `Range` request → 206; `If-None-Match` with
-  the returned `ETag` → 304; a cache-hit-after-full-GET followed by a `Range`/
-  conditional still behaves correctly; an unknown `assets/<hash>.js` archive miss
-  → SPA HTML; and a genuinely unknown non-asset path → SPA HTML. (Route-mirror
-  rule: index.ts routing changes update `index.test.ts` **and**
-  `deployed.test.ts`.)
-- **Upload script**: unit-test MIME derivation, re-put-all (no skip), and
-  retry/bounded-concurrency logic.
+- **Worker unit** (`tests/index.test.ts`): present asset (ASSETS 200 non-HTML /
+  206 / 304 / 404) returned unchanged, never consulting R2; a Range/conditional
+  request for a **present** asset is classified present via the sanitized probe;
+  miss (probe 200 text/html) + archive hit → 200 with correct MIME / `ETag` /
+  `Content-Length` / immutable `Cache-Control` and **no** `Accept-Ranges` and no
+  SPA CSP headers; **HEAD** (headers, no body); **`If-None-Match`** (match) → 304
+  no `Content-Length`; **`If-Modified-Since`** → 304; **`If-Match`** (fail) →
+  412; **`If-Unmodified-Since`** (fail) → 412; **Range header ignored** → full
+  200; miss + archive miss → shell (no regression); strict-regex gate rejects
+  non-asset / traversal / encoded paths and `POST`; **Cache API** consulted/
+  populated only for plain GET, HEAD/conditional bypass it (a cached full-200 is
+  never returned for them); cache-put failure does not 500.
+- **Deployed smoke** (`tests/deployed.test.ts`): upload a synthetic non-ASSETS
+  `assets/r2-retention-smoke-<hash>.js` to the staging bucket, then via the
+  worker assert: full `GET` 200 + JS `Content-Type` + `ETag`; `HEAD`;
+  `If-None-Match` with the returned `ETag` → 304; a cache-hit-after-full-GET
+  still serves correctly; unknown `assets/<hash>.js` → shell; unknown non-asset
+  path → shell. Send `Accept-Encoding: br,gzip` and do **not** over-assert exact
+  `Content-Length` (edge may transform). Verify (or document) the lifecycle rule
+  via `wrangler r2 bucket lifecycle list`. (Route-mirror rule: index.ts routing
+  changes update `index.test.ts` **and** `deployed.test.ts`.)
+- **Upload script**: MIME derivation, hash-invariant assertion (fails on a
+  non-hashed name), re-put-all (no skip), retry/bounded-concurrency.
 - Coverage kept at/above the cloudflare-worker floor.
 
 ## Out of scope
 
-- The chrome-extension's **own** bundled assets (#1406 part (c):
-  `chrome.runtime.onUpdateAvailable` → reload leader tab + SW reload).
+- The chrome-extension's own bundled assets (#1406 part (c)).
 - Changing the shipped `setup-preload-error-reload` recovery (kept as fallback).
 - SPA-HTML `Cache-Control` hardening (separately-deferred #1330 item).
 - Client-side service-worker precache (rejected alternative).
 - The preview worker (no ASSETS; no binding).
-- A scheduled touch job (rejected — see §3 residual).
+- A scheduled touch job (rejected — §3 residual).
+- `Range`/206 support for archived assets (intentionally unsupported — §1).
 
 ## Decisions (locked)
 
-| Decision         | Choice                                                                                                                          |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                                 |
-| Serving          | ASSETS-first, R2-on-miss (miss = only `200 text/html` on a strict-regex `/assets/*` path)                                       |
-| HTTP semantics   | Per-status builder: HEAD / Range(206/416) / conditional(304) / ETag / per-status Content-Length / Accept-Ranges via R2 metadata |
-| Edge cache       | Cache API: plain-GET only (Range/HEAD/conditional bypass); cache full-200 under canonical GET key                               |
-| GC               | 14-day age-based R2 lifecycle; re-put ALL on every deploy; **no touch job** (drought → reload fallback)                         |
-| Upload           | Reusable `upload-assets-to-r2.sh`; re-put ALL (no skip), parallel + retries, before deploy; CF token needs R2 Object R/W        |
-| Deploy paths     | publish-worker.sh (auto prod) + worker.yml (manual prod) + ci.yml + worker-staging.yml; hard-stop on upload failure             |
-| Buckets          | Separate per env (`slicc-asset-archive`, `…-staging`); preview worker excluded                                                  |
-| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                                |
+| Decision         | Choice                                                                                                                                                                     |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                                                                            |
+| Serving          | ASSETS-first; miss classified via sanitized canonical-GET probe (`200 text/html`)                                                                                          |
+| HTTP semantics   | Full GET / HEAD / conditional (304 for If-None-Match·If-Modified-Since, 412 for If-Match·If-Unmodified-Since); **Range unsupported** (ignore → full 200, no Accept-Ranges) |
+| R2 API           | `get(key, { onlyIf: request.headers })` only (no `range: headers`); `writeHttpMetadata` + `httpEtag` + `size`                                                              |
+| Edge cache       | Cache API: plain-GET only; cache full-200 under canonical key; `waitUntil` put, swallow errors                                                                             |
+| Hash invariant   | Enforced: upload fails on any non-hashed `dist/ui/assets/*` name                                                                                                           |
+| GC               | 14-day age-based lifecycle (applied out-of-band, verified via `wrangler r2 bucket lifecycle list`); re-put ALL every deploy; **no touch job**                              |
+| Upload           | `upload-assets-to-r2.sh`; assert-hash + re-put ALL + retries, single hard-fail step before first deploy attempt                                                            |
+| Deploy paths     | publish-worker.sh (auto prod) + worker.yml (manual prod) + ci.yml + worker-staging.yml; all deploy attempts gated on upload                                                |
+| Buckets          | Separate per env; `ASSET_ARCHIVE` binding + `WorkerEnv` type; preview worker excluded                                                                                      |
+| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                                                                           |

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -215,22 +215,37 @@ do not inherit top-level bindings). First R2 binding in the repo; add the
 `ASSET_ARCHIVE: R2Bucket` field to `WorkerEnv`. The **preview worker** (no
 ASSETS) does not need it.
 
-**GC:** an R2 **object-lifecycle rule** on each bucket deletes objects with
-`last-modified` older than **14 days**. The `wrangler.jsonc` binding does **not**
-create the rule; it is applied out-of-band and **verified** via
-`wrangler r2 bucket lifecycle list <bucket>` (a documented ops step, checked in
-the deployed smoke or a runbook). Every deploy re-puts the current set, so only
-chunks that have **stopped shipping** for >14 days age out.
+**GC — pure 14-day age-based (no manifest).** An R2 **object-lifecycle rule** on
+each bucket deletes objects with `last-modified` older than **14 days**. The
+`wrangler.jsonc` binding does **not** create the rule; it is applied out-of-band
+and **verified** via `wrangler r2 bucket lifecycle list <bucket>` (a documented
+ops step, checked in the deployed smoke or a runbook).
 
-**Accepted residual (no touch job).** If production does not deploy for >14 days
-(a release drought), the live build's chunks age out while still current, and a
-just-superseded chunk then falls back to the **shipped #1364 reload** — rare in
-an active repo (semantic-release deploys prod on merges to main) and the same
-graceful degradation the 14-day window already implies for long-idle tabs. A
-scheduled touch was rejected: a rebuild injects `SLICC_RELEASED_AT`/version
-defines and can produce different hashes, so it would not reliably touch the
-deployed keys. (Revisit with a manifest-driven touch or a wider window if
-droughts become common.)
+**Precise retention invariant:** because every deploy re-puts its full current
+set (§2), a chunk's clock is refreshed on **every deploy that includes it**, so
+it survives **≥14 days after the last deploy that shipped it**. Two consequences:
+
+- **Vendor / long-lived chunks** (stable across many deploys — the actual #1330
+  `anthropic-messages` pattern): re-put on every deploy right up to the deploy
+  that changes them, so they get ~a full 14 days **after supersession**. Fully
+  protected.
+- **Build-unique chunks** (an app/feature chunk present in only one build): clock
+  starts at that build's deploy, so their post-supersession window is
+  `14 − (days that build stayed live)`. A tab that lazily imports such a chunk
+  more than 14 days after its build deployed — including a fresh tab opened late
+  in a long-lived build — falls back to the **shipped #1364 reload** (graceful,
+  not a crash; identical to today's behavior).
+
+**Chosen (option A), reversible.** Pure age-based is deliberately chosen for
+simplicity and because it fully covers the reported crash pattern; a scheduled
+rebuild-touch is rejected (a rebuild injects `SLICC_RELEASED_AT`/version defines
+→ different hashes → wouldn't touch the deployed keys). **If build-unique lazy
+chunks prove a problem in practice, the robust follow-up is a manifest-touch at
+deploy** (option B): each deploy writes a tiny manifest and copy-in-place
+"touches" the previous build's now-superseded unique keys so every superseded
+build gets a full 14 days from supersession — no rebuild, no scheduled job. This
+is intentionally deferred to keep the first iteration free of per-deploy
+manifest/version tracking.
 
 ### 4. Interplay with the shipped reload (#1364)
 

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -1,6 +1,6 @@
 # R2 Asset Retention — Design
 
-**Status:** design (brainstorming output; codex rounds 1–3 applied)
+**Status:** design (brainstorming output; codex/cursor review rounds 1–7 applied)
 **Date:** 2026-07-08
 **Issue:** follow-up to #1330 / PR #1364 (stale-asset recovery)
 **Branch:** `feat/r2-asset-retention`
@@ -8,224 +8,183 @@
 ## Problem
 
 A long-lived browser tab loads the SLICC webapp (`index.html` + content-hashed
-chunks) from build **A** served by the cloudflare-worker. A later deploy
-replaces the worker's static assets with build **B** (new content hashes). The
-tab's already-loaded modules keep working, but any **not-yet-loaded lazy chunk**
-from build A (e.g. `anthropic-messages-DP3-Xd3J.js`) is now absent on the
-server. Because `wrangler.jsonc` sets `not_found_handling:
-"single-page-application"`, a request for the gone chunk returns `index.html`
-(HTTP 200, `text/html`) rather than a 404 — the browser then tries to execute
-HTML as a module and the dynamic import fails ("Failed to fetch dynamically
-imported module …"). This is the #1330 crash.
+chunks) from build **A** served by the cloudflare-worker. A later deploy replaces
+the worker's static assets with build **B** (new content hashes). The tab's
+already-loaded modules keep working, but any **not-yet-loaded lazy chunk** from
+build A (e.g. `anthropic-messages-DP3-Xd3J.js`) is now absent on the server.
+Because `wrangler.jsonc` sets `not_found_handling: "single-page-application"`, a
+request for the gone chunk returns `index.html` (HTTP 200, `text/html`) rather
+than a 404 — the browser then executes HTML as a module and the dynamic import
+fails ("Failed to fetch dynamically imported module …"). This is the #1330 crash.
 
 PR #1364 shipped a **reactive** recovery: detect the failure and reload the tab
-(with a one-shot auto-resubmit of the dropped cone turn). That works but is
-heavy-handed:
+(with a one-shot auto-resubmit of the dropped cone turn). It works but is
+heavy-handed: a reload tears down the kernel worker, every scoop, in-flight tool
+calls, and a half-streamed turn — re-sending the last user message does not
+restore a running _cycle_.
 
-- A reload tears down the kernel worker, every scoop, in-flight tool calls, and
-  a half-streamed turn. Re-sending the last user message does **not** restore a
-  running _cycle_ — partial progress and already-applied side effects are lost.
-- The deferred SPA-HTML `Cache-Control` hardening leaves a window where a cached
-  build-A shell coexists with freshly-fetched build-B chunks (mixed release).
+## Goal (honestly scoped)
 
-## Goal
+Make the #1330 crash **rare** by keeping content-hashed `/assets/*` chunks
+available on the server for a retention window after they were last shipped, so a
+long-lived tab keeps fetching **its own build's** chunks after a new deploy — no
+crash, no reload, no interruption for the common case. Where retention does not
+cover a chunk (see §3), the outcome degrades to the **existing #1364 reload** —
+never worse than today.
 
-Eliminate the crash at its **root** by keeping every content-hashed `/assets/*`
-file **within a retention window** available on the server, so a long-lived tab
-can keep fetching **its own build's** chunks after a new deploy — no crash, no
-reload, no interruption, and the tab stays internally consistent (it moves to
-the new build only on a natural, user-initiated reload). The shipped reload
-becomes a rare last-resort fallback for chunks past the window.
-
-**Scope of the chosen GC (option A, §3), and the one open decision.** Under pure
-14-day age-based GC, a chunk is retained ≥14 days **after the last deploy that
-shipped it**. This fully covers **stable/vendor lazy chunks** — the observed
-#1330 pattern (`anthropic-messages`), which re-ship on every deploy until they
-change. **Build-unique lazy chunks** (present in only one build that then stays
-live a while) can fall outside the window and fall back to the shipped reload —
-an accepted limitation of option A. Making retention robust for _all_ chunks
-requires a small manifest-touch at deploy (**option B**, fully specified in §3),
-which reintroduces a little per-deploy tracking. **A vs B is the one decision
-awaiting Karl;** this spec proceeds on **A** (matches the "no versions" lean and
-keeps the first iteration simplest), with B as a documented, additive upgrade.
+**Coverage under the chosen GC (option A, §3):** fully covers **stable/vendor
+lazy chunks** — the observed #1330 pattern (`anthropic-messages`), which re-ship
+on every deploy until they change, so they are retained ≥14 days after
+supersession. **Build-unique lazy chunks** (present in only one build that then
+stays live a while) may fall outside the window and hit the reload fallback.
+Making retention robust for _all_ chunks needs a small manifest-touch at deploy
+(**option B**, fully specified in §3). **A vs B is the one decision awaiting
+Karl;** this spec proceeds on **A** (matches the "no versions" lean, simplest
+first iteration) with B as a documented, additive upgrade.
 
 ## Key insight: content hash = identity (enforced)
 
-Every `/assets/*` filename **is** a hash of its bytes. The same filename can
-only ever mean the same content, so the archive is a **flat, idempotent
-key→bytes store** — no version/release grouping. This invariant is **enforced**,
-not assumed: the upload step (§2) **fails the deploy if any `dist/ui/assets/*`
-filename lacks a content-hash** (pattern `-<8+ url-safe chars>` before the
-extension — Vite's default). It holds today because Vite hashes everything under
-`assets/` and the fixed-name entry files (`index.html`, SW scripts, `manifest`,
-favicon) live at the **root**, not under `/assets/`, so they are never archived
-and always served from the current deploy. The worker only ever serves an
-archived object on a **miss** (asset absent from the current deploy), which by
-construction is always an old hashed chunk — so the `immutable` cache header is
-always safe.
+Every `/assets/*` filename **is** a hash of its bytes, so the archive is a
+**flat, idempotent key→bytes store** — no version/release grouping. This is
+**enforced**: the upload step (§2) fails the deploy if any `dist/ui/assets/*`
+name lacks a content hash. It holds today because Vite hashes everything under
+`assets/`, while fixed-name entry files (`index.html`, SW scripts, `manifest`,
+favicon) live at the **root** — never archived, always served from the current
+deploy. The worker only serves an archived object on a **miss** (asset absent
+from the current deploy), which is by construction an old hashed chunk, so the
+`immutable` cache header is always safe.
 
 ## Architecture
 
-All runtimes load the webapp from a single hosted origin
-(`SLICC_HOSTED_ORIGIN = https://www.sliccy.ai`): the standalone node-server, the
-chrome-extension leader tab (`?slicc=leader`), and the cloud cone (headless
-browser in e2b). A fix at the worker covers **all three** with no per-runtime
-work. Two moving parts: (1) the worker serves archived assets on a miss; (2)
-every deploy uploads its assets to the archive **before** going live.
+All runtimes load the webapp from one hosted origin (`SLICC_HOSTED_ORIGIN =
+https://www.sliccy.ai`): standalone node-server, the chrome-extension leader tab
+(`?slicc=leader`), and the cloud cone (headless browser in e2b). A worker-side
+fix covers **all three**. Two moving parts: (1) the worker serves archived assets
+on a miss; (2) every deploy uploads its assets to the archive **before** going
+live.
 
 ### 1. Serving — ASSETS-first, R2-on-miss (worker)
 
-Insertion point: `packages/cloudflare-worker/src/index.ts` — a dedicated
-`serveAssetWithArchiveFallback(request, env, ctx)` invoked from the top-level
-dispatch **before** the `wantsJSON` SPA/JSON split (`~:412`), so even
-`/assets/foo.js?json=true` is handled here, not routed to the API index.
+A dedicated `serveAssetWithArchiveFallback(request, env, ctx)` in
+`packages/cloudflare-worker/src/index.ts`, invoked from the top-level dispatch
+**before** the `wantsJSON` SPA/JSON split (`~:412`), so even
+`/assets/foo.js?json=true` is handled here.
 
-**Asset-path gate (strict regex = anti-traversal + hash invariant).** Handle here
-only if `request.method` is `GET`/`HEAD` and the raw `url.pathname` matches:
-
-```
-^/assets/[A-Za-z0-9][A-Za-z0-9._-]*\.(js|mjs|css|map|wasm|woff2|woff|ttf|svg|png|jpg|jpeg|gif|webp|avif|ico|json)$
-```
-
-The class excludes `/`, `%`, `\`, `..`, and null bytes, so a match is inherently
-traversal-safe. The gate **also requires a content-hash segment** so the worker
-never treats an un-hashed path as archive-eligible (keeps the immutable-cache and
-flat-key assumptions sound). Worker and upload share **one pinned predicate**
-(validated against real Vite output during impl):
+**Gate (strict, hashed, traversal-safe).** Handle here only for `GET`/`HEAD`
+whose raw `url.pathname` matches the **shared hashed-asset predicate** (also
+used by the §2 upload assert; validated against real Vite output in impl):
 
 ```
 ^/assets/[A-Za-z0-9][A-Za-z0-9._-]*-[A-Za-z0-9_-]{8,}(\.[a-z0-9]+)*\.(js|mjs|css|map|wasm|woff2|woff|ttf|svg|png|jpg|jpeg|gif|webp|avif|ico|json)$
 ```
 
-i.e. a `-<8+ url-safe chars>` hash segment before the (optionally compound, e.g.
-`.js.map`) extension. Both false directions degrade safely: a non-hashed name
-that slips through misses R2 → fallback; a real asset that fails the gate is
-served by ASSETS (present) or falls back (miss) — and the §2 upload assert is the
-authoritative enforcement. **R2 key = matched `url.pathname` minus the leading
-`/`** — no decode step, so it always equals the upload key. Query is ignored for
-key/cache. Anything not matching falls through to today's behavior untouched.
+A `-<8+ url-safe chars>` hash segment before the (optionally compound, e.g.
+`.js.map`) extension; the class excludes `/ % \ ..` and null bytes (traversal
+safe). **R2 key = matched `url.pathname` minus the leading `/`** (no decode; always
+equals the upload key). Query ignored for key/cache. Non-matching paths fall
+through untouched. Both false directions degrade safely (a slipped-through
+non-hashed name misses R2 → fallback; a real asset failing the gate is served by
+ASSETS or falls back), and the §2 upload assert is the authoritative enforcement.
 
-**Miss detection (probe-based; robust to Range/conditional).** ASSETS is
-configured with `not_found_handling: single-page-application`, so a missing asset
-returns the shell — but for a request carrying `Range`/conditional headers the
-shell can come back `206`/`304`, which would defeat a naive status check.
-Therefore classify with a **sanitized canonical GET** (Range and conditional
+**Miss detection (probe-based; robust to Range/conditional).** With SPA
+`not_found_handling`, a missing asset returns the shell — but a `Range`/
+conditional request could make the shell come back `206`/`304`, defeating a naive
+status check. Classify with a **sanitized canonical GET** (Range + conditional
 headers stripped):
 
-1. If the original request is a plain `GET`/`HEAD` with no `Range`/conditional,
-   its ASSETS response _is_ the sanitized probe — reuse it (no extra fetch).
-   Otherwise issue one extra `env.ASSETS.fetch(sanitizedGET)` to classify.
-2. **Present** (probe `status === 200` and `Content-Type` not `text/html`): serve
-   the **original** request through `env.ASSETS.fetch(originalRequest)` so the
-   platform honors any Range/conditional. Return unchanged.
-3. **Miss** (probe `200 text/html` **or** `404` — covers both `not_found_handling`
-   outcomes should the config ever change): serve from the archive (below). On
-   archive miss or any R2 error, return the **classification-probe response**
-   (the shell or 404 already in hand — for a non-plain request we hold the
-   sanitized probe, not a fetch of the original) exactly as today so the shipped
-   `setup-preload-error-reload` recovery still fires — **no regression**.
+1. Plain `GET`/`HEAD` with no Range/conditional → its ASSETS response _is_ the
+   sanitized probe (no extra fetch); otherwise issue one
+   `env.ASSETS.fetch(sanitizedGET)` to classify.
+2. **Present** (probe `200` and `Content-Type` not `text/html`): serve the
+   **original** request via `env.ASSETS.fetch(originalRequest)` so the platform
+   honors Range/conditional. Return unchanged.
+3. **Miss** (probe `200 text/html` **or** `404`): serve from the archive (below).
+   On archive miss/R2 error, return the classification-probe response — **but if
+   the original method is `HEAD`, strip the body** (`new Response(null, {status,
+headers})`) so a HEAD never carries a body — preserving today's reload
+   fallback with **no regression**.
 
-**Response builder (R2 Workers API).** Scope: full `GET`, `HEAD`, and conditional
-GET. **Range is intentionally unsupported** — archived assets are small,
-immutable, content-hashed chunks that browsers do not Range-request; we omit
-`Accept-Ranges` and ignore any `Range` header, returning the full `200` (HTTP
-permits a server to ignore Range). This removes 206/416/If-Range/multi-range
-complexity with no practical loss.
+**Response builder (R2 Workers API).** Scope: full `GET`, `HEAD`, conditional
+GET. **Range intentionally unsupported** (archived assets are small immutable
+content-hashed chunks browsers don't Range-request): omit `Accept-Ranges`, ignore
+any `Range` header, return full `200` (HTTP permits ignoring Range) — removes
+206/416/If-Range/multi-range complexity.
 
-- Build `onlyIf` from **only** the browser-realistic revalidation headers
-  `If-None-Match`/`If-Modified-Since` (ignore `If-Match`/`If-Unmodified-Since` —
-  never sent for immutable asset GETs; serving the full `200` for them is
-  compliant and avoids mixed-precedence ambiguity). Then
-  `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf })` — pass **only** `onlyIf`
-  (Headers); do **not** pass `range: request.headers` (R2's `range` is an
-  `R2Range`, not headers).
-- **Archive miss** (`obj == null`): return the classification-probe response
-  (shell/404) — the fallback.
-- **Not modified** (`obj` present, `obj.body == null`): `304` with
-  `ETag`/`Last-Modified`, no `Content-Length`, no body. (Only `If-None-Match`/
-  `If-Modified-Since` reach `onlyIf`, so `body == null` unambiguously means 304 —
-  there is no `412` path; `If-Match`/`If-Unmodified-Since` are ignored and served
-  as a full `200`.)
-- **HEAD**: `200`, headers incl. `Content-Length: obj.size`, empty body.
+- `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf: request.headers })` — pass
+  **only** `onlyIf` (a `Headers`); do **not** pass `range: request.headers`
+  (R2's `range` is an `R2Range`, not headers). R2 evaluates all RFC-7232
+  conditionals.
+- **Archive miss** (`obj == null`): fall back (probe response; HEAD → bodyless).
+- **Failed precondition** (`obj` present, `obj.body == null`): classify by RFC
+  precedence — request carried `If-Match` or `If-Unmodified-Since` → **`412`**
+  (their failure takes precedence); else (`If-None-Match`/`If-Modified-Since`) →
+  **`304`** with `ETag`/`Last-Modified`, no `Content-Length`, no body.
+- **HEAD** (body present): `200`, headers incl. `Content-Length: obj.size`, empty
+  body.
 - **Full GET**: `200`, `Content-Length: obj.size`, body.
 - **Common headers:** `obj.writeHttpMetadata(headers)` (stored `Content-Type`;
-  else the MIME map below), `ETag: obj.httpEtag`, `Last-Modified`,
-  `Cache-Control: public, max-age=31536000, immutable`. No `Accept-Ranges`. Do
-  **not** copy SPA-shell CSP headers onto asset responses (assets deliberately
-  bypass `serveSPA`'s per-request header mutation; covered by a test).
+  else MIME map), `ETag: obj.httpEtag`, `Last-Modified`, `Cache-Control: public,
+max-age=31536000, immutable`. No `Accept-Ranges`.
 - **MIME map:** `.js`/`.mjs`→`text/javascript`, `.css`→`text/css`,
   `.json`/`.map`→`application/json`, `.wasm`→`application/wasm`,
   `.svg`→`image/svg+xml`, `.woff2`→`font/woff2`, `.woff`→`font/woff`,
   `.ttf`→`font/ttf`, `.png`→`image/png`, `.jpg`/`.jpeg`→`image/jpeg`,
   `.gif`→`image/gif`, `.webp`→`image/webp`, `.avif`→`image/avif`,
-  `.ico`→`image/x-icon`. Correct JS/MJS MIME is critical (a wrong type
-  re-creates the module-load failure).
+  `.ico`→`image/x-icon`. Correct JS/MJS MIME is critical.
 - **Compression:** serve raw bytes; Cloudflare's edge auto-compresses to the
-  client (which may drop `Content-Length` under transform — tests must not
-  over-assert exact length on the deployed path).
-- **Header wrapper (decided):** asset responses — both **present** (returned from
-  ASSETS by the new branch) and **archived** — deliberately do **not** get
-  `serveSPA`'s `Content-Security-Policy: frame-ancestors` mutation (a no-op for
-  subresources like JS/CSS/wasm, and a deliberate, documented change from today
-  where present assets pass through `serveSPA`). They **do** pass through the
-  top-level worker wrapper (`index.ts:~831`, `applySliccLinks` + `X-Robots-Tag`),
-  which is harmless on assets. Both facts are asserted in tests.
+  client (may drop `Content-Length` under transform — deployed tests must not
+  over-assert exact length).
+- **Header wrapper (decided):** asset responses (present + archived) deliberately
+  do **not** get `serveSPA`'s `Content-Security-Policy: frame-ancestors` (a
+  no-op for subresources; a deliberate, documented change from today where
+  present assets pass through `serveSPA`). They **do** pass through the top-level
+  wrapper (`index.ts:~831`, `applySliccLinks` + `X-Robots-Tag`), harmless on
+  assets. Both asserted in tests.
 
-**Edge cache (Cache API), poison-safe.** Consult/populate the Cache API **only
-for a plain `GET` with no `Range` and no conditional headers**; `HEAD` and
-conditional requests bypass the cache and go straight to R2. Cache **only** a
-successful full `200`, under a **canonical GET key** (scheme+host+
-`/assets/<file>`, query dropped), cloning before put; write via
-`ctx.waitUntil(cache.put(...).catch(...))` so a cache-write failure never turns a
-recovered asset into a `500`. Never cache a miss, the shell, `304`, or `HEAD`.
+**Edge cache (Cache API), poison-safe.** Consult/populate the cache **only for a
+plain `GET` with no Range and no conditional headers**; `HEAD` and conditional
+requests bypass the cache → R2. Cache **only** a full `200`, under a canonical
+GET key (scheme+host+`/assets/<file>`, query dropped), cloning before put; write
+via `ctx.waitUntil(cache.put(...).catch(...))` (cache-write failure never 500s).
+Never cache a miss, the shell, `304`, `412`, or `HEAD`. Responses are
+`immutable`, so indefinite edge caching is safe.
 
 Rationale for ASSETS-first: the live site is served by the platform, so an R2
-outage degrades only _old_ tabs (they fall back to reload), not the whole site.
-Added latency is only on _old-build_ requests, rare and edge-cached after first
-hit. Navigations, `index.html`, SW scripts, and the `?cherry=1` / electron /
-`/cloud` SPA-shell variants are untouched.
+outage degrades only old tabs (reload), not the whole site.
 
 ### 2. Population — upload assets to R2 before every deploy
 
-A reusable script — `packages/cloudflare-worker/scripts/upload-assets-to-r2.sh <bucket>` —
-first **asserts the hash invariant** (fails if any `dist/ui/assets/*` name lacks
-a content hash), then loops over `dist/ui/assets/*` with bounded-concurrency
-parallelism and per-file retries:
+A reusable script `packages/cloudflare-worker/scripts/upload-assets-to-r2.sh
+<bucket>` (1) **asserts the hash invariant** (fails if any `dist/ui/assets/*`
+name lacks a hash, via the shared predicate) then (2) loops over
+`dist/ui/assets/*` with bounded-concurrency parallelism + per-file retries:
 
 ```
 wrangler r2 object put <bucket>/assets/<file> --file <path> --content-type <mime> --remote
 ```
 
-deriving `--content-type` from the extension (§1 MIME map). It **re-puts the
-current build's full asset set every deploy — no skip-if-exists** (a PUT
-refreshes `last-modified`, which the age-based GC in §3 relies on; re-putting is
-content-idempotent, so the only cost is CI time, bounded by the parallelism). The
-exact `wrangler r2 object put` flags (whether `--remote` is required/valid for the
-repo-pinned wrangler) are verified in the plan against `wrangler r2 object put
---help`.
+`--content-type` from the extension (§1 MIME map). It **re-puts the full current
+set every deploy — no skip-if-exists** (a PUT refreshes `last-modified`, which the
+§3 GC relies on; content-idempotent, so the only cost is CI time, bounded by the
+parallelism). The exact `wrangler r2 object put` flags (whether `--remote` is
+required for the pinned wrangler) are verified in the plan against `wrangler r2
+object put --help`.
 
-**Gating principle (exact per-file edits belong in the plan).** In **every** path
-that runs `wrangler deploy`, insert the upload as a **single hard-fail step
-(`continue-on-error: false`) after the build and before the _first_ deploy
-attempt**, sharing the deploy's `if` guard; **all** deploy attempts are gated on
-upload success. A build must never go live unarchived (that orphans the _next_
-deploy's tabs). The four paths:
+**Gating principle (exact per-file edits in the plan).** In **every** path that
+runs `wrangler deploy`, insert the upload as a **single hard-fail step
+(`continue-on-error: false`) after build and before the _first_ deploy attempt**,
+sharing the deploy's `if` guard; **all** deploy attempts are gated on upload
+success (a build must never go live unarchived). The four paths:
 
-- **Automated production** — `.releaserc.json` → `npm run publish:worker` →
-  `packages/cloudflare-worker/scripts/publish-worker.sh` (its `wrangler deploy`
-  is the real prod deploy): insert the upload call before that deploy, prod
-  bucket, using the already-built `dist/ui/assets`.
-- **Manual production** — `.github/workflows/worker.yml` (3 `wrangler-action`
-  attempts): one upload step before attempt 1, prod bucket.
-- **Staging (CI)** — `.github/workflows/ci.yml` `cloudflare-worker` job
-  (deploy/secrets retry pairs): one upload step before the first attempt, staging
-  bucket.
+- **Automated prod** — `.releaserc.json` → `npm run publish:worker` →
+  `packages/cloudflare-worker/scripts/publish-worker.sh` (real prod deploy):
+  upload before its `wrangler deploy`, prod bucket, using built `dist/ui/assets`.
+- **Manual prod** — `.github/workflows/worker.yml` (3 `wrangler-action`
+  attempts): upload before attempt 1, prod bucket.
+- **Staging (CI)** — `.github/workflows/ci.yml` `cloudflare-worker` job (deploy/
+  secrets retry pairs): upload before the first attempt, staging bucket.
 - **Staging (dedicated)** — `.github/workflows/worker-staging.yml`: same, staging
   bucket.
-
-Do **not** claim a universal 25 MiB dry-run gate — only some paths run it today;
-the upload step itself is the added gate. (The plan may optionally add the
-dry-run to prod paths.)
 
 **Auth (explicit).** The upload runs as a plain `run:` step / shell, so it needs
 `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` in its environment (mirroring
@@ -237,114 +196,111 @@ the feature (the existing deploy token likely needs this scope added).
 
 Two R2 buckets (separate per env): `slicc-asset-archive` (prod) and
 `slicc-asset-archive-staging`. `wrangler.jsonc`: add an `r2_buckets` binding
-`ASSET_ARCHIVE` at the top level (→ prod) and duplicated in `env.staging` (→
-staging), mirroring the per-env duplication of `assets`/DO bindings (env configs
-do not inherit top-level bindings). First R2 binding in the repo; add the
-`ASSET_ARCHIVE: R2Bucket` field to `WorkerEnv`. The **preview worker** (no
-ASSETS) does not need it.
+`ASSET_ARCHIVE` at top level (→ prod) and duplicated in `env.staging` (→
+staging), mirroring the per-env duplication of `assets`/DO bindings; add
+`ASSET_ARCHIVE: R2Bucket` to `WorkerEnv`. First R2 binding in the repo; the
+preview worker (no ASSETS) does not need it.
 
-**GC — pure 14-day age-based (no manifest).** An R2 **object-lifecycle rule** on
+**GC — pure 14-day age-based (option A, chosen).** An R2 object-lifecycle rule on
 each bucket deletes objects with `last-modified` older than **14 days**. The
 `wrangler.jsonc` binding does **not** create the rule; it is applied out-of-band
 and **verified** via `wrangler r2 bucket lifecycle list <bucket>` (a documented
-ops step, checked in the deployed smoke or a runbook).
+ops step / runbook). Because every deploy re-puts its full current set, a chunk's
+clock is refreshed on every deploy that includes it, so it survives **≥14 days
+after the last deploy that shipped it**.
 
-**Precise retention invariant:** because every deploy re-puts its full current
-set (§2), a chunk's clock is refreshed on **every deploy that includes it**, so
-it survives **≥14 days after the last deploy that shipped it**. Two consequences:
+**Coverage & limitation.** Stable/vendor chunks re-ship until they change, so
+they get ≥14 days after supersession (fully covers the #1330 pattern).
+Build-unique chunks get `14 − (days the build stayed live)` after supersession;
+a tab importing such a chunk past the window falls back to the shipped reload
+(graceful, identical to today). A rebuild-based touch is rejected (a rebuild
+injects `SLICC_RELEASED_AT`/version defines → different hashes → wouldn't touch
+the deployed keys).
 
-- **Vendor / long-lived chunks** (stable across many deploys — the actual #1330
-  `anthropic-messages` pattern): re-put on every deploy right up to the deploy
-  that changes them, so they get ~a full 14 days **after supersession**. Fully
-  protected.
-- **Build-unique chunks** (an app/feature chunk present in only one build): clock
-  starts at that build's deploy, so their post-supersession window is
-  `14 − (days that build stayed live)`. A tab that lazily imports such a chunk
-  more than 14 days after its build deployed — including a fresh tab opened late
-  in a long-lived build — falls back to the **shipped #1364 reload** (graceful,
-  not a crash; identical to today's behavior).
-
-**Chosen (option A), reversible.** Pure age-based is deliberately chosen for
-simplicity and because it fully covers the reported crash pattern; a scheduled
-rebuild-touch is rejected (a rebuild injects `SLICC_RELEASED_AT`/version defines
-→ different hashes → wouldn't touch the deployed keys). **If build-unique lazy
-chunks prove a problem in practice, the robust follow-up is a manifest-touch at
-deploy** (option B): each deploy writes a tiny manifest and copy-in-place
-"touches" the previous build's now-superseded unique keys so every superseded
-build gets a full 14 days from supersession — no rebuild, no scheduled job. This
-is intentionally deferred to keep the first iteration free of per-deploy
-manifest/version tracking.
+**Option B (robust upgrade, additive, pending Karl's A-vs-B call).** Give every
+chunk ≥14 days after **supersession** with a small manifest-touch, no scheduled
+job, no rebuild: at each deploy, the upload script (a) reads the bucket's stored
+`manifests/current.json` (the **previous** build's key list) **before**
+overwriting it, (b) uploads the new build's assets, (c) **copy-in-place touches**
+the keys in `previous ∖ current` (the just-superseded build's unique chunks —
+`wrangler r2 object get` then `put`, refreshing their `last-modified`), and (d)
+overwrites `manifests/current.json` with the new key list. Each build is thus
+touched exactly once, at the deploy that supersedes it → ≥14 days from
+supersession for **all** chunks. Cost: one small manifest object + a touch loop
+over the (small) per-deploy diff.
 
 ### 4. Interplay with the shipped reload (#1364)
 
-Unchanged. Retention removes ~all reloads; the reload remains the last-resort
-fallback for (a) a >14-day release drought, (b) an R2 outage/miss, (c) a
-breaking client↔backend protocol change where the tab _should_ migrate, and
-(d) the **first-deploy residual** — tabs already open on the pre-feature build
-are not retroactively protected (that build's assets were never archived), so
-after the first feature deploy they fall back to the shipped reload. Accepted,
-one-time, self-healing (every deploy thereafter is archived). No client code
-changes in this project.
+Unchanged. Retention makes reloads rare; the reload remains the last-resort
+fallback for (a) a build-unique chunk past the window (option A) or a >14-day
+release drought, (b) an R2 outage/miss, (c) a breaking client↔backend protocol
+change where the tab _should_ migrate, and (d) the **first-deploy residual** —
+tabs already open on the pre-feature build are not retroactively protected
+(never archived); after the first feature deploy they fall back to the reload.
+Accepted, one-time, self-healing. No client code changes in this project.
 
 ## Data flow
 
 ```
 Deploy (each path): build → upload-assets-to-r2.sh <bucket> (assert-hash, re-put ALL, retries)
-   → [only on success] wrangler deploy (current build → ASSETS + index.html)
+   [option B also: read prev manifest → touch (prev∖current) → write manifest]
+   → [only on upload success] wrangler deploy (current build → ASSETS + index.html)
 
-Request GET/HEAD /assets/<hash>.<ext>  (strict regex gate, else fall through):
+Request GET/HEAD /assets/<hash>.<ext>  (shared hashed-asset gate, else fall through):
   classify via sanitized canonical-GET probe to ASSETS:
      ├─ PRESENT (200 non-HTML) → serve original request via ASSETS (honors Range/conditional)
-     └─ MISS (200 text/html)   →
+     └─ MISS (200 text/html | 404) →
            plain GET (no Range/conditional)? Cache API match (canonical key)
               ├─ cached → return
               └─ miss   → R2 get{onlyIf} → cache full-200 (waitUntil) → return
            HEAD / conditional?  → R2 get{onlyIf} (bypass cache)
-              ├─ 200 / HEAD / 304 (per-status headers; Range + If-Match/If-Unmod ignored → full 200) → return
-              └─ archive miss / R2 error → return shell (reload fallback, as today)
+              ├─ 200 / HEAD(bodyless) / 304 / 412 (Range + full 200) → return
+              └─ archive miss / R2 error → probe shell/404 (HEAD → bodyless) → reload fallback
 ```
 
 ## Error handling
 
-- `env.ASSET_ARCHIVE.get()` failure/exception → treat as miss (return the shell);
-  never `500` an asset request.
+- `env.ASSET_ARCHIVE.get()` failure/exception → treat as miss (fallback); never
+  `500` an asset request.
 - `cache.put` failure → swallowed via `waitUntil(...).catch(...)`.
-- Upload-script failure (incl. hash-invariant violation) → **fail the deploy
-  before `wrangler deploy`** (after retries).
+- Upload-script failure (incl. hash-invariant violation, or option-B touch
+  failure) → **fail the deploy before `wrangler deploy`** (after retries).
 - Content-type absent on an archived object → MIME map; last resort
   `application/octet-stream`.
 
 ## Testing
 
-- **Worker unit** (`tests/index.test.ts`): present asset (ASSETS 200 non-HTML /
-  206 / 304 / 404) returned unchanged, never consulting R2; a Range/conditional
-  request for a **present** asset is classified present via the sanitized probe;
-  miss (probe 200 text/html) + archive hit → 200 with correct MIME / `ETag` /
-  `Content-Length` / immutable `Cache-Control` and **no** `Accept-Ranges` and no
-  SPA CSP headers; **HEAD** (headers, no body); **`If-None-Match`** (match) → 304
-  no `Content-Length`; **`If-Modified-Since`** → 304; **`If-Match`/
-  `If-Unmodified-Since` ignored** → full 200 (assert these never reach R2's
-  `onlyIf`); **Range header ignored** → full
-  200; miss + archive miss → probe shell/404 (no regression); strict-regex gate
-  rejects non-asset / traversal / encoded / **un-hashed** paths and `POST`;
-  **Cache API** consulted/populated only for plain GET, HEAD/conditional bypass
-  it (a cached full-200 is never returned for them); cache-put failure does not 500.
-- **Deployed smoke** (`tests/deployed.test.ts`): upload a synthetic non-ASSETS
-  `assets/r2-retention-smoke-<hash>.js` to the staging bucket, then via the
-  worker assert: full `GET` 200 + JS `Content-Type` + `ETag`; `HEAD`;
-  `If-None-Match` with the returned `ETag` → 304; a cache-hit-after-full-GET
-  still serves correctly; unknown `assets/<hash>.js` → shell; unknown non-asset
-  path → shell. Also a **present-asset** case: parse a real `/assets/*` URL out
-  of the deployed `index.html` and assert it is served (200, JS/CSS
-  `Content-Type`) — i.e. via ASSETS, not the archive/fallback — including with
-  `?json=true`. Send `Accept-Encoding: br,gzip`, **record** the resulting
-  `Content-Encoding` for an archived `.js` (informational parity with Static
-  Assets), and do **not** over-assert exact `Content-Length` (edge may
-  transform). Verify (or document) the lifecycle rule via `wrangler r2 bucket
-lifecycle list`. (Route-mirror rule: index.ts routing
-  changes update `index.test.ts` **and** `deployed.test.ts`.)
-- **Upload script**: MIME derivation, hash-invariant assertion (fails on a
-  non-hashed name), re-put-all (no skip), retry/bounded-concurrency.
+- **Worker unit** (`tests/index.test.ts`, mock `env.ASSETS` + `env.ASSET_ARCHIVE`):
+  present asset (ASSETS `200` non-HTML / `206` / `304` / `404`) returned
+  unchanged, never consulting R2; a Range/conditional request for a **present**
+  asset classified present via the sanitized probe; miss (probe `200 text/html`)
+  - archive hit → `200`, correct MIME / `ETag` / `Content-Length` / immutable
+    `Cache-Control`, **no** `Accept-Ranges`, no SPA CSP; **HEAD** hit (headers, no
+    body); **`If-None-Match`**/**`If-Modified-Since`** → `304` (no `Content-Length`);
+    **`If-Match`**/**`If-Unmodified-Since`** fail → `412`; **Range ignored** → full
+    `200`; **miss + archive miss** → probe shell/404, and a **HEAD** miss fallback
+    is **bodyless**; gate rejects non-asset / traversal / encoded / **un-hashed**
+    paths and `POST`; **Cache API** consulted/populated only for plain GET, with
+    HEAD/conditional bypassing it (a cached full-200 never returned for them);
+    `cache.put` failure does not `500`.
+- **Deployed smoke** (`tests/deployed.test.ts`): the **archive-recovery** case
+  requires an R2 write, so it is **staging-only** — gate it on the staging env/
+  bucket creds and **skip when running against production** (the same test runs
+  against prod via `worker.yml` / `publish-worker.sh`, which must not perform prod
+  R2 writes). Staging: upload a synthetic non-ASSETS
+  `assets/r2-retention-smoke-<hash>.js`, then via the worker assert full `GET`
+  `200` + JS `Content-Type` + `ETag`; `HEAD`; `If-None-Match` → `304`; a
+  cache-hit-after-full-GET still serves; unknown `assets/<hash>.js` → shell.
+  **Both envs (incl. prod):** a **present-asset** check — parse a real `/assets/*`
+  URL from the deployed `index.html`, assert it serves (`200`, JS/CSS type, via
+  ASSETS) including with `?json=true`; send `Accept-Encoding: br,gzip`, **record**
+  `Content-Encoding` (informational), do **not** over-assert `Content-Length`;
+  verify/document the lifecycle rule via `wrangler r2 bucket lifecycle list`.
+  (Route-mirror rule: index.ts routing changes update `index.test.ts` **and**
+  `deployed.test.ts`.)
+- **Upload script**: MIME derivation; hash-invariant assertion (fails on a
+  non-hashed name); re-put-all (no skip); retry/bounded-concurrency; (option B)
+  manifest read/write + touch-the-diff.
 - Coverage kept at/above the cloudflare-worker floor.
 
 ## Out of scope
@@ -354,21 +310,21 @@ lifecycle list`. (Route-mirror rule: index.ts routing
 - SPA-HTML `Cache-Control` hardening (separately-deferred #1330 item).
 - Client-side service-worker precache (rejected alternative).
 - The preview worker (no ASSETS; no binding).
-- A scheduled touch job (rejected — §3 residual).
 - `Range`/206 support for archived assets (intentionally unsupported — §1).
 
-## Decisions (locked)
+## Decisions (locked, except the flagged A-vs-B)
 
-| Decision         | Choice                                                                                                                                                                                                                              |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                                                                                                                                     |
-| Serving          | ASSETS-first; miss classified via sanitized canonical-GET probe (`200 text/html`)                                                                                                                                                   |
-| HTTP semantics   | Full GET / HEAD / conditional (304 for If-None-Match·If-Modified-Since; If-Match·If-Unmodified-Since ignored → full 200); **Range unsupported** (ignore → full 200, no Accept-Ranges)                                               |
-| R2 API           | `get(key, { onlyIf })` where `onlyIf` is a **filtered `Headers` containing only `If-None-Match`/`If-Modified-Since`** (If-Match/If-Unmodified-Since never reach R2); no `range: headers`; `writeHttpMetadata` + `httpEtag` + `size` |
-| Edge cache       | Cache API: plain-GET only; cache full-200 under canonical key; `waitUntil` put, swallow errors                                                                                                                                      |
-| Hash invariant   | Enforced: upload fails on any non-hashed `dist/ui/assets/*` name                                                                                                                                                                    |
-| GC               | 14-day age-based lifecycle (applied out-of-band, verified via `wrangler r2 bucket lifecycle list`); re-put ALL every deploy; **no touch job**                                                                                       |
-| Upload           | `upload-assets-to-r2.sh`; assert-hash + re-put ALL + retries, single hard-fail step before first deploy attempt                                                                                                                     |
-| Deploy paths     | publish-worker.sh (auto prod) + worker.yml (manual prod) + ci.yml + worker-staging.yml; all deploy attempts gated on upload                                                                                                         |
-| Buckets          | Separate per env; `ASSET_ARCHIVE` binding + `WorkerEnv` type; preview worker excluded                                                                                                                                               |
-| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                                                                                                                                    |
+| Decision         | Choice                                                                                                                                                                                                                                                     |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                                                                                                                                                            |
+| Serving          | ASSETS-first; miss classified via sanitized canonical-GET probe (`200 text/html`/`404`)                                                                                                                                                                    |
+| HTTP semantics   | Full GET / HEAD (bodyless, incl. miss-fallback) / conditional (`304` for If-None-Match·If-Modified-Since, `412` for If-Match·If-Unmodified-Since); **Range unsupported** (ignore → full 200, no Accept-Ranges)                                             |
+| R2 API           | `get(key, { onlyIf: request.headers })` (no `range: headers`); `writeHttpMetadata` + `httpEtag` + `size`                                                                                                                                                   |
+| Edge cache       | Cache API: plain-GET only; cache full-200 under canonical key; `waitUntil` put, swallow errors; never cache miss/shell/304/412/HEAD                                                                                                                        |
+| Hash invariant   | Enforced: upload fails on any non-hashed `dist/ui/assets/*` name; worker gate shares the pinned predicate                                                                                                                                                  |
+| GC               | **Option A** (chosen): 14-day age-based lifecycle (out-of-band, verified via `wrangler r2 bucket lifecycle list`); re-put ALL every deploy. **Option B** (manifest-touch, pending Karl) documented as additive upgrade for full post-supersession coverage |
+| Upload           | `upload-assets-to-r2.sh`: assert-hash + re-put ALL + retries; single hard-fail step before first deploy attempt                                                                                                                                            |
+| Deploy paths     | publish-worker.sh (auto prod) + worker.yml (manual prod) + ci.yml + worker-staging.yml; all deploy attempts gated on upload                                                                                                                                |
+| Deployed smoke   | Archive-recovery R2-write smoke **staging-only** (skipped vs prod); present-asset check both envs                                                                                                                                                          |
+| Buckets          | Separate per env; `ASSET_ARCHIVE` binding + `WorkerEnv` type; preview worker excluded                                                                                                                                                                      |
+| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                                                                                                                                                           |

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -32,15 +32,15 @@ crash, no reload, no interruption for the common case. Where retention does not
 cover a chunk (see §3), the outcome degrades to the **existing #1364 reload** —
 never worse than today.
 
-**Coverage under the chosen GC (option A, §3):** fully covers **stable/vendor
-lazy chunks** — the observed #1330 pattern (`anthropic-messages`), which re-ship
-on every deploy until they change, so they are retained ≥14 days after
-supersession. **Build-unique lazy chunks** (present in only one build that then
-stays live a while) may fall outside the window and hit the reload fallback.
-Making retention robust for _all_ chunks needs a small manifest-touch at deploy
-(**option B**, fully specified in §3). **A vs B is the one decision awaiting
-Karl;** this spec proceeds on **A** (matches the "no versions" lean, simplest
-first iteration) with B as a documented, additive upgrade.
+**Acceptance criterion (best-effort, option A, §3):** this spec **commits to
+option A** — fully covers **stable/vendor lazy chunks** (the observed #1330
+pattern, `anthropic-messages`, which re-ship on every deploy until they change,
+so they are retained ≥14 days after supersession). **Build-unique lazy chunks**
+(present in only one build that then stays live a while) may fall outside the
+window and use the reload fallback — an accepted limitation, never worse than
+today. Full post-supersession coverage for _all_ chunks is **future work**
+(**option B**, a small additive manifest-touch, fully specified in §3); it needs
+no re-spec, so A can be upgraded to B later without rework.
 
 ## Key insight: content hash = identity (enforced)
 
@@ -104,24 +104,21 @@ headers stripped):
 headers})`) so a HEAD never carries a body — preserving today's reload
    fallback with **no regression**.
 
-**Response builder (R2 Workers API).** Scope: full `GET`, `HEAD`, conditional
-GET. **Range intentionally unsupported** (archived assets are small immutable
-content-hashed chunks browsers don't Range-request): omit `Accept-Ranges`, ignore
-any `Range` header, return full `200` (HTTP permits ignoring Range) — removes
-206/416/If-Range/multi-range complexity.
+**Response builder (R2 Workers API).** Scope: full `GET` and `HEAD` **only**.
+**Conditional (`304`/`412`) and Range (`206`) responses are intentionally NOT
+implemented** — archived assets are small, `immutable`, content-hashed chunks
+that browsers fetch unconditionally and in full (an `immutable` resource is never
+revalidated or range-requested). Conditional/Range support is optional in HTTP;
+we return validators so downstream caches still work, but **every** request —
+including any carrying `Range`/`If-*` headers — receives the full `200` (or a
+bodyless `HEAD`). This removes all 206/416/304/412/If-Range/mixed-validator
+ambiguity (a repeated review hazard) with no practical loss for immutable assets.
 
-- `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf: request.headers })` — pass
-  **only** `onlyIf` (a `Headers`); do **not** pass `range: request.headers`
-  (R2's `range` is an `R2Range`, not headers). R2 evaluates all RFC-7232
-  conditionals.
-- **Archive miss** (`obj == null`): fall back (probe response; HEAD → bodyless).
-- **Failed precondition** (`obj` present, `obj.body == null`): classify by RFC
-  precedence — request carried `If-Match` or `If-Unmodified-Since` → **`412`**
-  (their failure takes precedence); else (`If-None-Match`/`If-Modified-Since`) →
-  **`304`** with `ETag`/`Last-Modified`, no `Content-Length`, no body.
-- **HEAD** (body present): `200`, headers incl. `Content-Length: obj.size`, empty
-  body.
-- **Full GET**: `200`, `Content-Length: obj.size`, body.
+- `obj = await env.ASSET_ARCHIVE.get(key)` — **no** `onlyIf`, **no** `range`.
+- **Archive miss** (`obj == null`): fall back (classification-probe response;
+  HEAD → bodyless).
+- **HEAD**: `200`, headers incl. `Content-Length: obj.size`, empty body.
+- **GET**: `200`, `Content-Length: obj.size`, body.
 - **Common headers:** `obj.writeHttpMetadata(headers)` (stored `Content-Type`;
   else MIME map), `ETag: obj.httpEtag`, `Last-Modified`, `Cache-Control: public,
 max-age=31536000, immutable`. No `Accept-Ranges`.
@@ -142,11 +139,11 @@ max-age=31536000, immutable`. No `Accept-Ranges`.
   assets. Both asserted in tests.
 
 **Edge cache (Cache API), poison-safe.** Consult/populate the cache **only for a
-plain `GET` with no Range and no conditional headers**; `HEAD` and conditional
-requests bypass the cache → R2. Cache **only** a full `200`, under a canonical
-GET key (scheme+host+`/assets/<file>`, query dropped), cloning before put; write
-via `ctx.waitUntil(cache.put(...).catch(...))` (cache-write failure never 500s).
-Never cache a miss, the shell, `304`, `412`, or `HEAD`. Responses are
+`GET`** (any `Range`/`If-*` headers are ignored, so a canonical GET key is
+always correct); a `HEAD` bypasses the cache → R2. Cache **only** a full `200`,
+under a canonical GET key (scheme+host+`/assets/<file>`, query dropped), cloning
+before put; write via `ctx.waitUntil(cache.put(...).catch(...))` (cache-write
+failure never 500s). Never cache a miss, the shell, or a `HEAD`. Responses are
 `immutable`, so indefinite edge caching is safe.
 
 Rationale for ASSETS-first: the live site is served by the platform, so an R2
@@ -217,7 +214,7 @@ a tab importing such a chunk past the window falls back to the shipped reload
 injects `SLICC_RELEASED_AT`/version defines → different hashes → wouldn't touch
 the deployed keys).
 
-**Option B (robust upgrade, additive, pending Karl's A-vs-B call).** Give every
+**Option B (robust upgrade, additive — future work).** Give every
 chunk ≥14 days after **supersession** with a small manifest-touch, no scheduled
 job, no rebuild: at each deploy, the upload script (a) reads the bucket's stored
 `manifests/current.json` (the **previous** build's key list) **before**
@@ -249,13 +246,12 @@ Deploy (each path): build → upload-assets-to-r2.sh <bucket> (assert-hash, re-p
 Request GET/HEAD /assets/<hash>.<ext>  (shared hashed-asset gate, else fall through):
   classify via sanitized canonical-GET probe to ASSETS:
      ├─ PRESENT (200 non-HTML) → serve original request via ASSETS (honors Range/conditional)
-     └─ MISS (200 text/html | 404) →
-           plain GET (no Range/conditional)? Cache API match (canonical key)
+     └─ MISS (200 text/html | 404)  [Range/If-* headers ignored — full response] →
+           GET?  → Cache API match (canonical key)
               ├─ cached → return
-              └─ miss   → R2 get{onlyIf} → cache full-200 (waitUntil) → return
-           HEAD / conditional?  → R2 get{onlyIf} (bypass cache)
-              ├─ 200 / HEAD(bodyless) / 304 / 412 (Range + full 200) → return
-              └─ archive miss / R2 error → probe shell/404 (HEAD → bodyless) → reload fallback
+              └─ miss   → R2 get(key) → full 200 → cache (waitUntil) → return
+           HEAD? → R2 get(key) (bypass cache) → 200 headers, bodyless
+           archive miss / R2 error → probe shell/404 (HEAD → bodyless) → reload fallback
 ```
 
 ## Error handling
@@ -276,20 +272,21 @@ Request GET/HEAD /assets/<hash>.<ext>  (shared hashed-asset gate, else fall thro
   asset classified present via the sanitized probe; miss (probe `200 text/html`)
   - archive hit → `200`, correct MIME / `ETag` / `Content-Length` / immutable
     `Cache-Control`, **no** `Accept-Ranges`, no SPA CSP; **HEAD** hit (headers, no
-    body); **`If-None-Match`**/**`If-Modified-Since`** → `304` (no `Content-Length`);
-    **`If-Match`**/**`If-Unmodified-Since`** fail → `412`; **Range ignored** → full
-    `200`; **miss + archive miss** → probe shell/404, and a **HEAD** miss fallback
-    is **bodyless**; gate rejects non-asset / traversal / encoded / **un-hashed**
-    paths and `POST`; **Cache API** consulted/populated only for plain GET, with
-    HEAD/conditional bypassing it (a cached full-200 never returned for them);
-    `cache.put` failure does not `500`.
+    body); a request carrying `Range`/`If-None-Match`/`If-Modified-Since`/
+    `If-Match` still gets a **full `200`** (conditional/Range not implemented) and
+    `get()` is called **without** `onlyIf`/`range`; **miss + archive miss** → probe
+    shell/404, and a **HEAD** miss fallback is **bodyless**; gate rejects
+    non-asset / traversal / encoded / **un-hashed** paths and `POST`; **Cache API**
+    consulted/populated only for `GET`, `HEAD` bypasses it; `cache.put` failure does
+    not `500`.
 - **Deployed smoke** (`tests/deployed.test.ts`): the **archive-recovery** case
   requires an R2 write, so it is **staging-only** — gate it on the staging env/
   bucket creds and **skip when running against production** (the same test runs
   against prod via `worker.yml` / `publish-worker.sh`, which must not perform prod
   R2 writes). Staging: upload a synthetic non-ASSETS
   `assets/r2-retention-smoke-<hash>.js`, then via the worker assert full `GET`
-  `200` + JS `Content-Type` + `ETag`; `HEAD`; `If-None-Match` → `304`; a
+  `200` + JS `Content-Type` + `ETag`; `HEAD`; a request with `If-None-Match`
+  still returns full `200` (conditionals not implemented); a
   cache-hit-after-full-GET still serves; unknown `assets/<hash>.js` → shell.
   **Both envs (incl. prod):** a **present-asset** check — parse a real `/assets/*`
   URL from the deployed `index.html`, assert it serves (`200`, JS/CSS type, via
@@ -310,7 +307,7 @@ Request GET/HEAD /assets/<hash>.<ext>  (shared hashed-asset gate, else fall thro
 - SPA-HTML `Cache-Control` hardening (separately-deferred #1330 item).
 - Client-side service-worker precache (rejected alternative).
 - The preview worker (no ASSETS; no binding).
-- `Range`/206 support for archived assets (intentionally unsupported — §1).
+- Conditional (304/412) and Range (206) responses for archived assets (deliberately not implemented — §1).
 
 ## Decisions (locked, except the flagged A-vs-B)
 
@@ -318,9 +315,9 @@ Request GET/HEAD /assets/<hash>.<ext>  (shared hashed-asset gate, else fall thro
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                                                                                                                                                            |
 | Serving          | ASSETS-first; miss classified via sanitized canonical-GET probe (`200 text/html`/`404`)                                                                                                                                                                    |
-| HTTP semantics   | Full GET / HEAD (bodyless, incl. miss-fallback) / conditional (`304` for If-None-Match·If-Modified-Since, `412` for If-Match·If-Unmodified-Since); **Range unsupported** (ignore → full 200, no Accept-Ranges)                                             |
-| R2 API           | `get(key, { onlyIf: request.headers })` (no `range: headers`); `writeHttpMetadata` + `httpEtag` + `size`                                                                                                                                                   |
-| Edge cache       | Cache API: plain-GET only; cache full-200 under canonical key; `waitUntil` put, swallow errors; never cache miss/shell/304/412/HEAD                                                                                                                        |
+| HTTP semantics   | Full GET / bodyless HEAD (incl. miss-fallback); **conditional (304/412) and Range (206) NOT implemented** — validators returned; all Range/If-\* requests get full 200/HEAD (compliant for immutable assets)                                               |
+| R2 API           | `get(key)` — no `onlyIf`, no `range`; `writeHttpMetadata` + `httpEtag` + `size`                                                                                                                                                                            |
+| Edge cache       | Cache API: GET only (HEAD bypasses); cache full-200 under canonical key; `waitUntil` put, swallow errors; never cache miss/shell/HEAD                                                                                                                      |
 | Hash invariant   | Enforced: upload fails on any non-hashed `dist/ui/assets/*` name; worker gate shares the pinned predicate                                                                                                                                                  |
 | GC               | **Option A** (chosen): 14-day age-based lifecycle (out-of-band, verified via `wrangler r2 bucket lifecycle list`); re-put ALL every deploy. **Option B** (manifest-touch, pending Karl) documented as additive upgrade for full post-supersession coverage |
 | Upload           | `upload-assets-to-r2.sh`: assert-hash + re-put ALL + retries; single hard-fail step before first deploy attempt                                                                                                                                            |

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -76,9 +76,15 @@ only if `request.method` is `GET`/`HEAD` and the raw `url.pathname` matches:
 ```
 
 The class excludes `/`, `%`, `\`, `..`, and null bytes, so a match is inherently
-traversal-safe. **R2 key = matched `url.pathname` minus the leading `/`** — no
-decode step, so it always equals the upload key. Query is ignored for key/cache.
-Anything not matching falls through to today's behavior untouched.
+traversal-safe. The gate **must also require a content-hash segment** (the same
+pattern the upload asserts in §2 — `-<8+ url-safe chars>` before the final
+extension, allowing a compound `.js.map`), so the worker never treats an
+un-hashed path as archive-eligible; this keeps the immutable-cache and flat-key
+assumptions sound. Worker and upload share **one** hash-pattern definition, and
+the exact regex (incl. `.map`) is pinned in the plan against real Vite output.
+**R2 key = matched `url.pathname` minus the leading `/`** — no decode step, so it
+always equals the upload key. Query is ignored for key/cache. Anything not
+matching falls through to today's behavior untouched.
 
 **Miss detection (probe-based; robust to Range/conditional).** ASSETS is
 configured with `not_found_handling: single-page-application`, so a missing asset
@@ -93,9 +99,11 @@ headers stripped):
 2. **Present** (probe `status === 200` and `Content-Type` not `text/html`): serve
    the **original** request through `env.ASSETS.fetch(originalRequest)` so the
    platform honors any Range/conditional. Return unchanged.
-3. **Miss** (probe `200 text/html`): serve from the archive (below). On archive
-   miss or any R2 error, return the shell exactly as today so the shipped
-   `setup-preload-error-reload` recovery still fires — **no regression**.
+3. **Miss** (probe `200 text/html` **or** `404` — covers both `not_found_handling`
+   outcomes should the config ever change): serve from the archive (below). On
+   archive miss or any R2 error, return the **original ASSETS response** (the
+   shell or the 404) exactly as today so the shipped `setup-preload-error-reload`
+   recovery still fires — **no regression**.
 
 **Response builder (R2 Workers API).** Scope: full `GET`, `HEAD`, and conditional
 GET. **Range is intentionally unsupported** — archived assets are small,
@@ -104,13 +112,16 @@ immutable, content-hashed chunks that browsers do not Range-request; we omit
 permits a server to ignore Range). This removes 206/416/If-Range/multi-range
 complexity with no practical loss.
 
-- `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf: request.headers })` — pass
-  **only** `onlyIf` (Headers); do **not** pass `range: request.headers` (R2's
-  `range` is an `R2Range`, not headers).
-- **Archive miss** (`obj == null`): return the shell (fallback).
-- **Failed precondition** (`obj` present, `obj.body == null`): classify by header
-  — `If-None-Match`/`If-Modified-Since` → **`304`** (with `ETag`/`Last-Modified`,
-  no `Content-Length`, no body); `If-Match`/`If-Unmodified-Since` → **`412`**.
+- Build `onlyIf` from **only** the browser-realistic revalidation headers
+  `If-None-Match`/`If-Modified-Since` (ignore `If-Match`/`If-Unmodified-Since` —
+  never sent for immutable asset GETs; serving the full `200` for them is
+  compliant and avoids mixed-precedence ambiguity). Then
+  `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf })` — pass **only** `onlyIf`
+  (Headers); do **not** pass `range: request.headers` (R2's `range` is an
+  `R2Range`, not headers).
+- **Archive miss** (`obj == null`): return the original ASSETS response (fallback).
+- **Not modified** (`obj` present, `obj.body == null`): `304` with
+  `ETag`/`Last-Modified`, no `Content-Length`, no body.
 - **HEAD**: `200`, headers incl. `Content-Length: obj.size`, empty body.
 - **Full GET**: `200`, `Content-Length: obj.size`, body.
 - **Common headers:** `obj.writeHttpMetadata(headers)` (stored `Content-Type`;
@@ -128,6 +139,9 @@ complexity with no practical loss.
 - **Compression:** serve raw bytes; Cloudflare's edge auto-compresses to the
   client (which may drop `Content-Length` under transform — tests must not
   over-assert exact length on the deployed path).
+- **Outer wrapper:** archive responses still pass through the top-level worker
+  wrapper (`index.ts:~831`) that adds `Link`/`X-Robots-Tag`; tests account for
+  those, and the plan decides whether asset responses should skip that wrapper.
 
 **Edge cache (Cache API), poison-safe.** Consult/populate the Cache API **only
 for a plain `GET` with no `Range` and no conditional headers**; `HEAD` and
@@ -157,7 +171,10 @@ wrangler r2 object put <bucket>/assets/<file> --file <path> --content-type <mime
 deriving `--content-type` from the extension (§1 MIME map). It **re-puts the
 current build's full asset set every deploy — no skip-if-exists** (a PUT
 refreshes `last-modified`, which the age-based GC in §3 relies on; re-putting is
-content-idempotent, so the only cost is CI time, bounded by the parallelism).
+content-idempotent, so the only cost is CI time, bounded by the parallelism). The
+exact `wrangler r2 object put` flags (whether `--remote` is required/valid for the
+repo-pinned wrangler) are verified in the plan against `wrangler r2 object put
+--help`.
 
 **Gating principle (exact per-file edits belong in the plan).** In **every** path
 that runs `wrangler deploy`, insert the upload as a **single hard-fail step
@@ -218,9 +235,13 @@ droughts become common.)
 ### 4. Interplay with the shipped reload (#1364)
 
 Unchanged. Retention removes ~all reloads; the reload remains the last-resort
-fallback for (a) a >14-day release drought, (b) an R2 outage/miss, or (c) a
-breaking client↔backend protocol change where the tab _should_ migrate. No
-client code changes in this project.
+fallback for (a) a >14-day release drought, (b) an R2 outage/miss, (c) a
+breaking client↔backend protocol change where the tab _should_ migrate, and
+(d) the **first-deploy residual** — tabs already open on the pre-feature build
+are not retroactively protected (that build's assets were never archived), so
+after the first feature deploy they fall back to the shipped reload. Accepted,
+one-time, self-healing (every deploy thereafter is archived). No client code
+changes in this project.
 
 ## Data flow
 

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -99,11 +99,16 @@ headers) are untouched.
 After the webapp is built (`dist/ui/assets/` populated), each worker deploy
 uploads that build's assets into the env's archive bucket via a loop of
 `wrangler r2 object put <bucket>/assets/<file> --file <path> --content-type
-<mime> [--remote]`. The loop is **parallelized** (bounded concurrency) and
-**skips objects that already exist** (idempotent; unchanged hashes are not
-re-put) to keep CI time bounded. `--content-type` is derived from the file
-extension in the upload script so the worker can read `httpMetadata.contentType`
-on serve.
+<mime> --remote`. The loop **re-puts the current build's full asset set every
+deploy** (bounded-concurrency parallel) — it does **not** skip existing keys.
+This is deliberate: a PUT refreshes the object's `last-modified`, which the
+age-based GC (§4) relies on to keep **still-shipping** chunks alive; skipping
+unchanged keys would let a vendor chunk that hasn't changed in >14 days be GC'd
+even though it's still part of the current build. Re-putting is
+content-idempotent (same hash ⇒ same bytes), so the only cost is CI time, which
+the bounded parallelism keeps in check. `--content-type` is derived from the
+file extension in the upload script so the worker can read
+`httpMetadata.contentType` on serve.
 
 Wire the upload step into the three deploy paths (after the webapp build, before
 / alongside `wrangler deploy`):

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -1,6 +1,6 @@
 # R2 Asset Retention — Design
 
-**Status:** design (brainstorming output; codex round 1 applied)
+**Status:** design (brainstorming output; codex rounds 1–2 applied)
 **Date:** 2026-07-08
 **Issue:** follow-up to #1330 / PR #1364 (stale-asset recovery)
 **Branch:** `feat/r2-asset-retention`
@@ -35,7 +35,7 @@ file **within a retention window** available on the server, so a long-lived tab
 can keep fetching **its own build's** chunks after a new deploy — no crash, no
 reload, no interruption, and the tab stays internally consistent (it moves to
 the new build only on a natural, user-initiated reload). The shipped reload
-becomes a rare last-resort fallback for chunks older than the window.
+becomes a rare last-resort fallback for chunks past the window.
 
 ## Key insight: content hash = identity
 
@@ -56,224 +56,231 @@ chrome-extension leader tab (`?slicc=leader`), and the cloud cone (headless
 browser in e2b). A fix at the worker therefore covers **all three** with no
 per-runtime work.
 
-Three moving parts: (1) the worker serves archived assets on a miss; (2) CI
-uploads each deploy's assets into the archive **before** the deploy goes live;
-(3) a scheduled job keeps the live build's assets fresh so they never age out
-while still current.
+Two moving parts: (1) the worker serves archived assets on a miss; (2) every
+deploy uploads its assets to the archive **before** going live.
 
 ### 1. Serving — ASSETS-first, R2-on-miss (worker)
 
-Insertion point: `packages/cloudflare-worker/src/index.ts` — the `serveSPA`
-helper (`~:129`) and the SPA-fallback dispatch (`~:412`). Add a dedicated
-`serveAssetWithArchiveFallback(request, env, ctx)` invoked for `/assets/*` GET/
-HEAD requests **before** the generic SPA fallback.
+Insertion point: `packages/cloudflare-worker/src/index.ts` — a dedicated
+`serveAssetWithArchiveFallback(request, env, ctx)` invoked from the top-level
+dispatch **before** the `wantsJSON` SPA/JSON split (`~:412`), so that even
+`/assets/foo.js?json=true` is handled here rather than routed to the API index.
 
-**Asset-path gate.** Only intervene for requests whose canonical `url.pathname`
-starts with `/assets/` **and** ends in a known asset extension
-(`.js .mjs .css .map .wasm .woff2 .woff .ttf .svg .png .jpg .jpeg .gif .webp
-.avif .ico .json`). Any other path is untouched (falls through to today's
-behavior). This avoids misclassifying a hypothetical `/assets/*.html`.
+**Asset-path gate (strict regex — also the anti-traversal guard).** Handle the
+request here only if `request.method` is `GET`/`HEAD` and the raw
+`url.pathname` matches a strict Vite-asset pattern:
 
-**Key derivation (hardened).** Key = canonical `url.pathname` with the leading
-`/` removed (e.g. `assets/anthropic-messages-DP3-Xd3J.js`). Reject and skip the
-archive path (fall through to normal handling) if the decoded pathname contains
-`..`, a backslash, an encoded slash (`%2f`/`%5c`), a null byte, or is empty
-after the prefix. **Query string is ignored** for the key and for the cache key.
+```
+^/assets/[A-Za-z0-9][A-Za-z0-9._-]*\.(js|mjs|css|map|wasm|woff2|woff|ttf|svg|png|jpg|jpeg|gif|webp|avif|ico|json)$
+```
 
-**Flow:**
+Because the class excludes `/`, `%`, `\`, `..` segments and null bytes, a
+matching path is inherently traversal-safe; anything else falls through to
+today's behavior untouched. **The R2 key is the matched `url.pathname` minus the
+leading `/`** (e.g. `assets/anthropic-messages-DP3-Xd3J.js`) — no decoding step,
+so it always equals the upload key. Query string is ignored for key and cache.
 
-1. `res = await env.ASSETS.fetch(request)` — the current build's asset, if
-   present (unchanged hot path).
-2. If `res.status === 200` and its `Content-Type` is **not** `text/html`, return
-   `res` unchanged (current build; the common case; never touches R2).
-3. Otherwise ASSETS returned the SPA shell for a hashed asset ⇒ **miss**. Serve
-   from the archive via a single **response builder** (below). On archive miss
-   or any R2 error, return the original `res` (the SPA shell, HTTP 200
-   `text/html`) exactly as today so the shipped `setup-preload-error-reload`
-   recovery still fires — **no regression**.
+**Miss detection (narrow).** `res = await env.ASSETS.fetch(request)`. Treat as a
+miss **only** when `res.status === 200` **and** its `Content-Type` contains
+`text/html` (the SPA shell standing in for a gone hashed asset). **Every other
+ASSETS response — 200 non-HTML, 206, 304, 404, etc. — is returned unchanged**
+(ASSETS may legitimately answer 206/304 for a present asset under Range/
+conditional requests). On a miss, serve from the archive; on archive miss or any
+R2 error, return the original `res` (the SPA shell) exactly as today so the
+shipped `setup-preload-error-reload` recovery still fires — **no regression**.
 
-**Response builder (full HTTP semantics, from R2 object metadata).** Use the R2
-Workers API, not ad-hoc headers:
+**Response builder (per-status, from R2 metadata).** Use the R2 Workers API:
 
-- **Conditional:** `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf:
-request.headers, range: request.headers })`. If `obj` exists but has no `body`
-  (a conditional/precondition result), return `304 Not Modified` with `ETag` /
-  `Last-Modified` and no body.
-- **HEAD:** `head = await env.ASSET_ARCHIVE.head(key)` (or `get` then discard
-  body) → `200` with headers, empty body.
-- **Range:** if `obj.range` is set, return `206 Partial Content` with
-  `Content-Range` and the partial body; an unsatisfiable range → `416` with
-  `Content-Range: bytes */<size>`.
-- **Full GET:** `200` with the body.
-- **Headers on every response:** `obj.writeHttpMetadata(headers)` (carries the
-  stored `Content-Type`; fall back to an extension-derived MIME if absent),
-  `ETag: obj.httpEtag`, `Content-Length: obj.size`, `Accept-Ranges: bytes`,
-  `Last-Modified`, and `Cache-Control: public, max-age=31536000, immutable`.
-  Do **not** copy the SPA-shell CSP/headers onto asset responses.
+- `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf: request.headers, range:
+request.headers })`.
+- **Conditional not-modified:** `obj` present but `obj.body == null` ⇒ `304`
+  with `ETag`/`Last-Modified`, **no `Content-Length`**, no body.
+- **HEAD:** headers only (full `Content-Length: obj.size`), empty body.
+- **Range hit:** `obj.range` set ⇒ `206` with `Content-Range: bytes
+<start>-<end>/<size>` and `Content-Length` = **selected range length**.
+- **Unsatisfiable range:** `416` with `Content-Range: bytes */<size>`, no body.
+- **Full GET:** `200`, `Content-Length: obj.size`, body.
+- **Common headers:** `obj.writeHttpMetadata(headers)` (stored `Content-Type`;
+  fall back to the extension→MIME map below), `ETag: obj.httpEtag`,
+  `Accept-Ranges: bytes`, `Last-Modified`, `Cache-Control: public,
+max-age=31536000, immutable`. Do **not** copy SPA-shell CSP headers onto asset
+  responses.
+- **MIME map (fallback when metadata absent):** `.js`/`.mjs`→`text/javascript`,
+  `.css`→`text/css`, `.json`/`.map`→`application/json`, `.wasm`→
+  `application/wasm`, `.svg`→`image/svg+xml`, `.woff2`→`font/woff2`,
+  `.woff`→`font/woff`, `.ttf`→`font/ttf`, `.png`→`image/png`,
+  `.jpg`/`.jpeg`→`image/jpeg`, `.gif`→`image/gif`, `.webp`→`image/webp`,
+  `.avif`→`image/avif`, `.ico`→`image/x-icon`. Correct JS/MJS MIME is critical
+  (a wrong type re-creates the module-load failure).
 - **Compression:** serve raw bytes; Cloudflare's edge auto-compresses eligible
-  content-types to the client, so we do not store or negotiate encodings.
+  types to the client — we do not store/negotiate encodings.
 
-**Edge cache (Cache API), poison-safe.** Only **successful full-body `GET` 200**
-archive responses are cached, and only under a **canonical GET cache key**
-(scheme+host+`/assets/<file>`, query dropped, method GET). **Never** cache: an
-archive miss, the SPA shell, a `206`, a `304`, or a `HEAD` response. Clone the
-response before `cache.put`. On a subsequent hit, `cache.match` short-circuits
-before R2. Because responses are `immutable`, indefinite edge caching is safe.
+**Edge cache (Cache API), poison-safe.** Consult and populate the Cache API
+**only for a plain `GET` with no `Range` and no conditional headers**
+(`If-None-Match`/`If-Modified-Since`); `HEAD`, `Range`, and conditional requests
+**bypass the cache entirely** and go straight to R2 (so a cached full-200 can
+never be returned for them). Cache **only** a successful **full-body 200**, under
+a **canonical GET cache key** (scheme+host+`/assets/<file>`, query dropped),
+cloning before `cache.put`. Never cache a miss, the SPA shell, `206`, `304`, or
+`HEAD`. Responses are `immutable`, so indefinite edge caching is safe.
 
-Rationale for ASSETS-first (vs R2-first for all `/assets`): the live site keeps
-being served by the platform, so an R2 outage degrades only _old_ tabs (they
-fall back to reload) rather than taking the whole site down. Added latency is
-only on _old-build_ chunk requests, which are rare and edge-cached after first
-hit.
+Rationale for ASSETS-first: the live site is served by the platform, so an R2
+outage degrades only _old_ tabs (they fall back to reload) rather than the whole
+site. Added latency is only on _old-build_ requests, rare and edge-cached after
+first hit. Navigations, `index.html`, SW scripts, and the `?cherry=1` / electron
+/ `/cloud` SPA-shell variants are untouched.
 
-Navigations, `index.html`, SW scripts, and the `?cherry=1` / electron /
-`/cloud` SPA-shell variants (which set their own headers) are untouched.
+### 2. Population — upload assets to R2 at every deploy
 
-### 2. Population — CI upload at deploy (`wrangler r2 object put` loop)
+A single reusable script — `packages/cloudflare-worker/scripts/upload-assets-to-r2.sh <bucket>` —
+loops over `dist/ui/assets/*` and runs, with bounded-concurrency parallelism and
+per-file retries:
 
-Ordering is **strict** in every deploy workflow: **build webapp → 25 MiB
-static-assets dry-run gate → upload all `dist/ui/assets/*` to the env bucket
-(with retries) → only then run the real `wrangler deploy`.** If the upload step
-fails, the job **hard-stops before deploy** — a build must never go live
-unarchived (that would orphan the _next_ deploy's tabs).
+```
+wrangler r2 object put <bucket>/assets/<file> --file <path> --content-type <mime> --remote
+```
 
-Upload = a bounded-concurrency parallel loop of
-`wrangler r2 object put <bucket>/assets/<file> --file <path> --content-type
-<mime> --remote`, deriving `--content-type` from the file extension so the
-worker reads `httpMetadata.contentType` on serve. The loop **re-puts the current
-build's full asset set every deploy — it does NOT skip existing keys** (a PUT
-refreshes `last-modified`, which the age-based GC in §4 relies on to keep
-still-shipping chunks alive; re-putting is content-idempotent, so the only cost
-is CI time, bounded by the parallelism).
+deriving `--content-type` from the extension (same MIME map as §1). It **re-puts
+the current build's full asset set every deploy — it does NOT skip existing
+keys** (a PUT refreshes `last-modified`, which the age-based GC in §3 relies on
+to keep still-shipping chunks alive; re-putting is content-idempotent, so the
+only cost is CI time, bounded by the parallelism).
 
-**Auth (explicit).** The upload runs as a plain `run:` step (not
-`wrangler-action`), so it must pass `CLOUDFLARE_API_TOKEN` and
-`CLOUDFLARE_ACCOUNT_ID` in its `env:` (mirroring
-`.github/workflows/storybook-screenshots.yml`). **The API token must carry R2
-"Object Read & Write" permission for both buckets** — an ops prerequisite
-documented alongside the feature (the existing deploy token may need this scope
-added).
+**Ordering is strict everywhere: build webapp → 25 MiB dry-run gate → run the
+upload script (retries) → only on success run the real `wrangler deploy`.** A
+build must never go live unarchived (that would orphan the _next_ deploy's tabs),
+so the upload step **hard-stops the deploy on failure**.
 
-Wire the step into the three deploy paths:
+Wire the script into **all four** deploy paths that run `wrangler deploy`:
 
-- `.github/workflows/ci.yml` — `cloudflare-worker` job (staging) → staging
+- **Automated production** — `.releaserc.json` → `npm run publish:worker` →
+  `packages/cloudflare-worker/scripts/publish-worker.sh` (its `wrangler deploy`
+  is the real prod deploy). Insert the upload before that deploy, targeting the
+  **prod** bucket, using the already-built `dist/ui/assets`.
+- **Manual production** — `.github/workflows/worker.yml` (`workflow_dispatch`) →
+  prod bucket.
+- **Staging (CI)** — `.github/workflows/ci.yml` `cloudflare-worker` job → staging
   bucket.
-- `.github/workflows/worker-staging.yml` (staging) → staging bucket.
-- `.github/workflows/worker.yml` (production, `workflow_dispatch`) → prod bucket.
+- **Staging (dedicated)** — `.github/workflows/worker-staging.yml` → staging
+  bucket.
 
-### 3. Freshness — scheduled touch of the live build
+**Auth (explicit).** The upload runs as a plain `run:` step / shell script, so
+it must have `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in its
+environment (mirroring `.github/workflows/storybook-screenshots.yml`). **The API
+token must carry R2 "Object Read & Write" for both buckets** — an ops
+prerequisite documented with the feature (the existing deploy token likely needs
+this scope added).
 
-Age-based GC (§4) evicts by `last-modified`, refreshed only on deploy. If a
-build stays live longer than the GC window without a redeploy (production
-deploys are manual `workflow_dispatch`, so a >14-day gap is realistic), its
-chunks would age out of R2 **while still current**, and the _next_ deploy would
-orphan every tab on that (fresh) build.
-
-Fix: a **scheduled workflow** (`.github/workflows/worker-asset-touch.yml`,
-weekly cron, well inside the 14-day window) that checks out `main`, builds the
-webapp, and re-runs the **same upload script** against the **prod** bucket —
-touching the current build's assets so they never age out while live. Reuses the
-§2 script; no new logic. (Staging churns on every PR, so it needs no touch job.)
-
-### 4. Buckets, bindings & GC
+### 3. Buckets, bindings & GC
 
 Two R2 buckets (separate per env so staging's high churn never mixes into prod):
 `slicc-asset-archive` (prod) and `slicc-asset-archive-staging`.
 
 `wrangler.jsonc`: add an `r2_buckets` binding `ASSET_ARCHIVE` at the top level
 (→ `slicc-asset-archive`) and duplicated in `env.staging` (→
-`slicc-asset-archive-staging`), mirroring how `assets` and the DO bindings are
-already duplicated per env (env configs do **not** inherit top-level bindings).
-This is the **first R2 binding** in the repo. The **preview worker**
-(`wrangler-preview.jsonc`, no ASSETS) does **not** need the binding.
+`slicc-asset-archive-staging`), mirroring how `assets`/DO bindings are already
+duplicated per env (env configs do **not** inherit top-level bindings). This is
+the **first R2 binding** in the repo. The **preview worker**
+(`wrangler-preview.jsonc`, no ASSETS) does **not** need it.
 
 **GC:** an R2 **object-lifecycle rule** on each bucket deletes objects whose
-`last-modified` is older than **14 days**. Combined with §2 (deploy re-puts) and
-§3 (weekly touch of the live prod build), only chunks that have **stopped
-shipping** for >14 days age out. Residual: a tab whose build has been fully
-superseded for >14 days and only then lazily imports a now-evicted chunk falls
-back to the shipped reload — an accepted rare case inherent to a 14-day window.
+`last-modified` is older than **14 days**. Because every deploy re-puts the
+current set (§2), a chunk's clock resets on each deploy it ships in; only chunks
+that have **stopped shipping** age out ~14 days later.
 
-### 5. Interplay with the shipped reload (#1364)
+**Accepted residual (no touch job).** The only gap is a **release drought**: if
+production does not deploy for >14 days, the live build's chunks age out of R2
+while still current, and the next deploy would then serve the SPA shell for a
+just-superseded chunk → the tab falls back to the **shipped #1364 reload**. This
+is rare in an active repo (semantic-release deploys prod on merges to main) and
+is the same graceful degradation the 14-day window already implies for
+long-idle tabs. A scheduled "touch" job was considered and rejected: a rebuild
+injects `SLICC_RELEASED_AT`/version defines and can produce different hashes, so
+it would not reliably touch the deployed keys — adding fragility for a rare case
+the reload already covers. (If droughts become common, revisit with a
+manifest-driven touch that re-puts exact deployed keys, or widen the window.)
+
+### 4. Interplay with the shipped reload (#1364)
 
 Unchanged. Retention removes ~all reloads; the reload path remains the
-last-resort fallback for (a) the >14-day-superseded gap, (b) an R2 outage/miss,
-or (c) a breaking client↔backend protocol change where the tab _should_ migrate.
-No client code changes in this project.
+last-resort fallback for (a) a >14-day release drought, (b) an R2 outage/miss, or
+(c) a breaking client↔backend protocol change where the tab _should_ migrate. No
+client code changes in this project.
 
 ## Data flow
 
 ```
-Deploy:  build webapp → dist/ui/assets/*
-   → 25 MiB dry-run gate → R2 upload loop (re-put ALL, retries) → env bucket
+Deploy (each path): build webapp → dist/ui/assets/*
+   → 25 MiB dry-run gate → upload-assets-to-r2.sh <bucket> (re-put ALL, retries)
    → [only on upload success] wrangler deploy (current build → ASSETS + index.html)
 
-Weekly (prod): checkout main → build → R2 upload loop → prod bucket (touch live build)
-
-Request GET/HEAD /assets/<hash>.<ext>:
+Request GET/HEAD /assets/<hash>.<ext>  (strict regex gate, else fall through):
   worker → env.ASSETS.fetch()
-     ├─ 200 non-HTML  → return (current build, fast path)
-     └─ SPA shell     → Cache API match (canonical GET key)
+     ├─ NOT (200 text/html)  → return unchanged (present asset: 200 non-HTML / 206 / 304 / 404)
+     └─ 200 text/html (miss) →
+          plain GET (no Range/conditional)? → Cache API match (canonical key)
              ├─ cached → return
-             └─ miss   → env.ASSET_ARCHIVE.get(key, {onlyIf, range})
-                     ├─ 200 full   → build response (ETag/Length/Accept-Ranges/immutable), cache.put, return
-                     ├─ 206/304/HEAD → build response, DO NOT cache
-                     └─ archive miss/error → return SPA shell (client reload fallback, as today)
+             └─ miss   → R2 get → cache full-200 → return
+          HEAD / Range / conditional?        → R2 get (bypass cache)
+             ├─ 200 full / 206 / 304 / 416 (per-status headers) → return (do NOT cache)
+             └─ archive miss / R2 error       → return SPA shell (reload fallback, as today)
 ```
 
 ## Error handling
 
-- `env.ASSET_ARCHIVE.get()`/`head()` failure/exception → treat as miss (return
-  the SPA shell); never 500 an asset request. Retention is best-effort; the
-  reload fallback is the safety net.
-- CI upload failure → **fail the deploy job before `wrangler deploy`** (retries
-  first). An unarchived live build silently reintroduces the crash for the next
-  deploy's tabs.
-- Content-type absent on an archived object → derive from extension; last resort
-  `application/octet-stream`.
+- `env.ASSET_ARCHIVE.get()` failure/exception → treat as miss (return the SPA
+  shell); never 500 an asset request.
+- Upload-script failure → **fail the deploy before `wrangler deploy`** (after
+  retries).
+- Content-type absent on an archived object → derive from the MIME map; last
+  resort `application/octet-stream`.
 
 ## Testing
 
 - **Worker unit** (`packages/cloudflare-worker/tests/index.test.ts`): mock
-  `env.ASSETS` (real-asset vs SPA-shell) and `env.ASSET_ARCHIVE` (R2 `.get`/
-  `.head` with `writeHttpMetadata`, `httpEtag`, `size`, `range`, `onlyIf`).
-  Cases: `/assets` hit passes through untouched; `/assets` miss + archive hit →
-  200 with correct `Content-Type`/`ETag`/`Content-Length`/`Accept-Ranges`/
-  immutable `Cache-Control`; **HEAD** (no body); **Range** → 206 + `Content-Range`
-  (and 416 for unsatisfiable); **conditional** (`If-None-Match`/
-  `If-Modified-Since`) → 304; `/assets` miss + archive miss → SPA shell (no
-  regression); non-`/assets` and non-asset-extension paths never consult R2; key
-  derivation rejects `..`/backslash/encoded-slash/empty; **Cache API** puts only
-  full 200 GETs under the canonical key and never caches miss/shell/206/304/HEAD.
+  `env.ASSETS` and `env.ASSET_ARCHIVE`. Cases: present asset (ASSETS 200
+  non-HTML / 206 / 304 / 404) returned unchanged, never consulting R2; miss
+  (200 text/html) + archive hit → 200 with correct MIME/`ETag`/`Content-Length`/
+  `Accept-Ranges`/immutable `Cache-Control`; **HEAD** (headers, no body);
+  **Range** → 206 + `Content-Range` + range-length `Content-Length`;
+  unsatisfiable → 416; **conditional** → 304 with validators and no
+  `Content-Length`; miss + archive miss → SPA shell (no regression); strict
+  regex gate rejects non-asset/traversal/encoded paths and `POST`; **Cache API**
+  populated/consulted only for plain GET, and Range/HEAD/conditional bypass it
+  (a prior cached full-200 is never returned for them).
 - **Deployed smoke** (`packages/cloudflare-worker/tests/deployed.test.ts`):
-  upload a synthetic **non-ASSETS** object `assets/r2-retention-smoke-<hash>.js`
-  to the staging bucket, then fetch it **through the worker** and assert 200 +
-  JS `Content-Type` + `ETag` + a working `HEAD`; and that a genuinely unknown
-  non-asset path still returns the SPA HTML. (Route-mirror rule: index.ts
-  routing changes update `index.test.ts` **and** `deployed.test.ts`.)
-- **Upload script**: unit-test MIME derivation, the re-put-all (no skip)
-  behavior, and retry/bounded-concurrency logic.
+  upload a synthetic **non-ASSETS** `assets/r2-retention-smoke-<hash>.js` to the
+  staging bucket, then through the worker assert: full `GET` 200 + JS
+  `Content-Type` + `ETag`; `HEAD`; a `Range` request → 206; `If-None-Match` with
+  the returned `ETag` → 304; a cache-hit-after-full-GET followed by a `Range`/
+  conditional still behaves correctly; an unknown `assets/<hash>.js` archive miss
+  → SPA HTML; and a genuinely unknown non-asset path → SPA HTML. (Route-mirror
+  rule: index.ts routing changes update `index.test.ts` **and**
+  `deployed.test.ts`.)
+- **Upload script**: unit-test MIME derivation, re-put-all (no skip), and
+  retry/bounded-concurrency logic.
 - Coverage kept at/above the cloudflare-worker floor.
 
 ## Out of scope
 
-- The chrome-extension's **own** bundled assets (extension-update path — #1406
-  part (c): `chrome.runtime.onUpdateAvailable` → reload leader tab + SW reload).
+- The chrome-extension's **own** bundled assets (#1406 part (c):
+  `chrome.runtime.onUpdateAvailable` → reload leader tab + SW reload).
 - Changing the shipped `setup-preload-error-reload` recovery (kept as fallback).
-- SPA-HTML `Cache-Control` hardening (a separately-deferred #1330 item).
+- SPA-HTML `Cache-Control` hardening (separately-deferred #1330 item).
 - Client-side service-worker precache (rejected alternative).
 - The preview worker (no ASSETS; no binding).
+- A scheduled touch job (rejected — see §3 residual).
 
 ## Decisions (locked)
 
-| Decision         | Choice                                                                                                               |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------- |
-| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                      |
-| Serving          | ASSETS-first, R2-on-miss (live site independent of R2)                                                               |
-| HTTP semantics   | Full builder: HEAD/Range(206/416)/conditional(304)/ETag/Length/Accept-Ranges via R2 metadata                         |
-| Edge cache       | Cache API: full-200-GET only, canonical GET key, never miss/shell/206/304/HEAD                                       |
-| GC               | ~14-day age-based R2 lifecycle + weekly scheduled touch of the live prod build                                       |
-| Upload           | `wrangler r2 object put` loop, re-put ALL (no skip), parallel + retries, before deploy; CF token needs R2 Object R/W |
-| Deploy ordering  | build → dry-run gate → R2 upload → (on success) deploy; hard-stop on upload failure                                  |
-| Buckets          | Separate per env (`slicc-asset-archive`, `…-staging`); preview worker excluded                                       |
-| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                     |
+| Decision         | Choice                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                                 |
+| Serving          | ASSETS-first, R2-on-miss (miss = only `200 text/html` on a strict-regex `/assets/*` path)                                       |
+| HTTP semantics   | Per-status builder: HEAD / Range(206/416) / conditional(304) / ETag / per-status Content-Length / Accept-Ranges via R2 metadata |
+| Edge cache       | Cache API: plain-GET only (Range/HEAD/conditional bypass); cache full-200 under canonical GET key                               |
+| GC               | 14-day age-based R2 lifecycle; re-put ALL on every deploy; **no touch job** (drought → reload fallback)                         |
+| Upload           | Reusable `upload-assets-to-r2.sh`; re-put ALL (no skip), parallel + retries, before deploy; CF token needs R2 Object R/W        |
+| Deploy paths     | publish-worker.sh (auto prod) + worker.yml (manual prod) + ci.yml + worker-staging.yml; hard-stop on upload failure             |
+| Buckets          | Separate per env (`slicc-asset-archive`, `…-staging`); preview worker excluded                                                  |
+| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                                |

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -76,15 +76,22 @@ only if `request.method` is `GET`/`HEAD` and the raw `url.pathname` matches:
 ```
 
 The class excludes `/`, `%`, `\`, `..`, and null bytes, so a match is inherently
-traversal-safe. The gate **must also require a content-hash segment** (the same
-pattern the upload asserts in §2 — `-<8+ url-safe chars>` before the final
-extension, allowing a compound `.js.map`), so the worker never treats an
-un-hashed path as archive-eligible; this keeps the immutable-cache and flat-key
-assumptions sound. Worker and upload share **one** hash-pattern definition, and
-the exact regex (incl. `.map`) is pinned in the plan against real Vite output.
-**R2 key = matched `url.pathname` minus the leading `/`** — no decode step, so it
-always equals the upload key. Query is ignored for key/cache. Anything not
-matching falls through to today's behavior untouched.
+traversal-safe. The gate **also requires a content-hash segment** so the worker
+never treats an un-hashed path as archive-eligible (keeps the immutable-cache and
+flat-key assumptions sound). Worker and upload share **one pinned predicate**
+(validated against real Vite output during impl):
+
+```
+^/assets/[A-Za-z0-9][A-Za-z0-9._-]*-[A-Za-z0-9_-]{8,}(\.[a-z0-9]+)*\.(js|mjs|css|map|wasm|woff2|woff|ttf|svg|png|jpg|jpeg|gif|webp|avif|ico|json)$
+```
+
+i.e. a `-<8+ url-safe chars>` hash segment before the (optionally compound, e.g.
+`.js.map`) extension. Both false directions degrade safely: a non-hashed name
+that slips through misses R2 → fallback; a real asset that fails the gate is
+served by ASSETS (present) or falls back (miss) — and the §2 upload assert is the
+authoritative enforcement. **R2 key = matched `url.pathname` minus the leading
+`/`** — no decode step, so it always equals the upload key. Query is ignored for
+key/cache. Anything not matching falls through to today's behavior untouched.
 
 **Miss detection (probe-based; robust to Range/conditional).** ASSETS is
 configured with `not_found_handling: single-page-application`, so a missing asset
@@ -101,9 +108,10 @@ headers stripped):
    platform honors any Range/conditional. Return unchanged.
 3. **Miss** (probe `200 text/html` **or** `404` — covers both `not_found_handling`
    outcomes should the config ever change): serve from the archive (below). On
-   archive miss or any R2 error, return the **original ASSETS response** (the
-   shell or the 404) exactly as today so the shipped `setup-preload-error-reload`
-   recovery still fires — **no regression**.
+   archive miss or any R2 error, return the **classification-probe response**
+   (the shell or 404 already in hand — for a non-plain request we hold the
+   sanitized probe, not a fetch of the original) exactly as today so the shipped
+   `setup-preload-error-reload` recovery still fires — **no regression**.
 
 **Response builder (R2 Workers API).** Scope: full `GET`, `HEAD`, and conditional
 GET. **Range is intentionally unsupported** — archived assets are small,
@@ -119,9 +127,13 @@ complexity with no practical loss.
   `obj = await env.ASSET_ARCHIVE.get(key, { onlyIf })` — pass **only** `onlyIf`
   (Headers); do **not** pass `range: request.headers` (R2's `range` is an
   `R2Range`, not headers).
-- **Archive miss** (`obj == null`): return the original ASSETS response (fallback).
+- **Archive miss** (`obj == null`): return the classification-probe response
+  (shell/404) — the fallback.
 - **Not modified** (`obj` present, `obj.body == null`): `304` with
-  `ETag`/`Last-Modified`, no `Content-Length`, no body.
+  `ETag`/`Last-Modified`, no `Content-Length`, no body. (Only `If-None-Match`/
+  `If-Modified-Since` reach `onlyIf`, so `body == null` unambiguously means 304 —
+  there is no `412` path; `If-Match`/`If-Unmodified-Since` are ignored and served
+  as a full `200`.)
 - **HEAD**: `200`, headers incl. `Content-Length: obj.size`, empty body.
 - **Full GET**: `200`, `Content-Length: obj.size`, body.
 - **Common headers:** `obj.writeHttpMetadata(headers)` (stored `Content-Type`;
@@ -139,9 +151,13 @@ complexity with no practical loss.
 - **Compression:** serve raw bytes; Cloudflare's edge auto-compresses to the
   client (which may drop `Content-Length` under transform — tests must not
   over-assert exact length on the deployed path).
-- **Outer wrapper:** archive responses still pass through the top-level worker
-  wrapper (`index.ts:~831`) that adds `Link`/`X-Robots-Tag`; tests account for
-  those, and the plan decides whether asset responses should skip that wrapper.
+- **Header wrapper (decided):** asset responses — both **present** (returned from
+  ASSETS by the new branch) and **archived** — deliberately do **not** get
+  `serveSPA`'s `Content-Security-Policy: frame-ancestors` mutation (a no-op for
+  subresources like JS/CSS/wasm, and a deliberate, documented change from today
+  where present assets pass through `serveSPA`). They **do** pass through the
+  top-level worker wrapper (`index.ts:~831`, `applySliccLinks` + `X-Robots-Tag`),
+  which is harmless on assets. Both facts are asserted in tests.
 
 **Edge cache (Cache API), poison-safe.** Consult/populate the Cache API **only
 for a plain `GET` with no `Range` and no conditional headers**; `HEAD` and
@@ -272,7 +288,7 @@ Request GET/HEAD /assets/<hash>.<ext>  (strict regex gate, else fall through):
               ├─ cached → return
               └─ miss   → R2 get{onlyIf} → cache full-200 (waitUntil) → return
            HEAD / conditional?  → R2 get{onlyIf} (bypass cache)
-              ├─ 200 / HEAD / 304 / 412 (per-status headers; Range ignored → full 200) → return
+              ├─ 200 / HEAD / 304 (per-status headers; Range + If-Match/If-Unmod ignored → full 200) → return
               └─ archive miss / R2 error → return shell (reload fallback, as today)
 ```
 
@@ -294,20 +310,25 @@ Request GET/HEAD /assets/<hash>.<ext>  (strict regex gate, else fall through):
   miss (probe 200 text/html) + archive hit → 200 with correct MIME / `ETag` /
   `Content-Length` / immutable `Cache-Control` and **no** `Accept-Ranges` and no
   SPA CSP headers; **HEAD** (headers, no body); **`If-None-Match`** (match) → 304
-  no `Content-Length`; **`If-Modified-Since`** → 304; **`If-Match`** (fail) →
-  412; **`If-Unmodified-Since`** (fail) → 412; **Range header ignored** → full
-  200; miss + archive miss → shell (no regression); strict-regex gate rejects
-  non-asset / traversal / encoded paths and `POST`; **Cache API** consulted/
-  populated only for plain GET, HEAD/conditional bypass it (a cached full-200 is
-  never returned for them); cache-put failure does not 500.
+  no `Content-Length`; **`If-Modified-Since`** → 304; **`If-Match`/
+  `If-Unmodified-Since` ignored** → full 200; **Range header ignored** → full
+  200; miss + archive miss → probe shell/404 (no regression); strict-regex gate
+  rejects non-asset / traversal / encoded / **un-hashed** paths and `POST`;
+  **Cache API** consulted/populated only for plain GET, HEAD/conditional bypass
+  it (a cached full-200 is never returned for them); cache-put failure does not 500.
 - **Deployed smoke** (`tests/deployed.test.ts`): upload a synthetic non-ASSETS
   `assets/r2-retention-smoke-<hash>.js` to the staging bucket, then via the
   worker assert: full `GET` 200 + JS `Content-Type` + `ETag`; `HEAD`;
   `If-None-Match` with the returned `ETag` → 304; a cache-hit-after-full-GET
   still serves correctly; unknown `assets/<hash>.js` → shell; unknown non-asset
-  path → shell. Send `Accept-Encoding: br,gzip` and do **not** over-assert exact
-  `Content-Length` (edge may transform). Verify (or document) the lifecycle rule
-  via `wrangler r2 bucket lifecycle list`. (Route-mirror rule: index.ts routing
+  path → shell. Also a **present-asset** case: parse a real `/assets/*` URL out
+  of the deployed `index.html` and assert it is served (200, JS/CSS
+  `Content-Type`) — i.e. via ASSETS, not the archive/fallback — including with
+  `?json=true`. Send `Accept-Encoding: br,gzip`, **record** the resulting
+  `Content-Encoding` for an archived `.js` (informational parity with Static
+  Assets), and do **not** over-assert exact `Content-Length` (edge may
+  transform). Verify (or document) the lifecycle rule via `wrangler r2 bucket
+lifecycle list`. (Route-mirror rule: index.ts routing
   changes update `index.test.ts` **and** `deployed.test.ts`.)
 - **Upload script**: MIME derivation, hash-invariant assertion (fails on a
   non-hashed name), re-put-all (no skip), retry/bounded-concurrency.
@@ -325,16 +346,16 @@ Request GET/HEAD /assets/<hash>.<ext>  (strict regex gate, else fall through):
 
 ## Decisions (locked)
 
-| Decision         | Choice                                                                                                                                                                     |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                                                                            |
-| Serving          | ASSETS-first; miss classified via sanitized canonical-GET probe (`200 text/html`)                                                                                          |
-| HTTP semantics   | Full GET / HEAD / conditional (304 for If-None-Match·If-Modified-Since, 412 for If-Match·If-Unmodified-Since); **Range unsupported** (ignore → full 200, no Accept-Ranges) |
-| R2 API           | `get(key, { onlyIf: request.headers })` only (no `range: headers`); `writeHttpMetadata` + `httpEtag` + `size`                                                              |
-| Edge cache       | Cache API: plain-GET only; cache full-200 under canonical key; `waitUntil` put, swallow errors                                                                             |
-| Hash invariant   | Enforced: upload fails on any non-hashed `dist/ui/assets/*` name                                                                                                           |
-| GC               | 14-day age-based lifecycle (applied out-of-band, verified via `wrangler r2 bucket lifecycle list`); re-put ALL every deploy; **no touch job**                              |
-| Upload           | `upload-assets-to-r2.sh`; assert-hash + re-put ALL + retries, single hard-fail step before first deploy attempt                                                            |
-| Deploy paths     | publish-worker.sh (auto prod) + worker.yml (manual prod) + ci.yml + worker-staging.yml; all deploy attempts gated on upload                                                |
-| Buckets          | Separate per env; `ASSET_ARCHIVE` binding + `WorkerEnv` type; preview worker excluded                                                                                      |
-| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                                                                           |
+| Decision         | Choice                                                                                                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                                                                                       |
+| Serving          | ASSETS-first; miss classified via sanitized canonical-GET probe (`200 text/html`)                                                                                                     |
+| HTTP semantics   | Full GET / HEAD / conditional (304 for If-None-Match·If-Modified-Since; If-Match·If-Unmodified-Since ignored → full 200); **Range unsupported** (ignore → full 200, no Accept-Ranges) |
+| R2 API           | `get(key, { onlyIf: request.headers })` only (no `range: headers`); `writeHttpMetadata` + `httpEtag` + `size`                                                                         |
+| Edge cache       | Cache API: plain-GET only; cache full-200 under canonical key; `waitUntil` put, swallow errors                                                                                        |
+| Hash invariant   | Enforced: upload fails on any non-hashed `dist/ui/assets/*` name                                                                                                                      |
+| GC               | 14-day age-based lifecycle (applied out-of-band, verified via `wrangler r2 bucket lifecycle list`); re-put ALL every deploy; **no touch job**                                         |
+| Upload           | `upload-assets-to-r2.sh`; assert-hash + re-put ALL + retries, single hard-fail step before first deploy attempt                                                                       |
+| Deploy paths     | publish-worker.sh (auto prod) + worker.yml (manual prod) + ci.yml + worker-staging.yml; all deploy attempts gated on upload                                                           |
+| Buckets          | Separate per env; `ASSET_ARCHIVE` binding + `WorkerEnv` type; preview worker excluded                                                                                                 |
+| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                                                                                      |

--- a/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
+++ b/docs/superpowers/specs/2026-07-08-r2-asset-retention-design.md
@@ -37,6 +37,18 @@ reload, no interruption, and the tab stays internally consistent (it moves to
 the new build only on a natural, user-initiated reload). The shipped reload
 becomes a rare last-resort fallback for chunks past the window.
 
+**Scope of the chosen GC (option A, §3), and the one open decision.** Under pure
+14-day age-based GC, a chunk is retained ≥14 days **after the last deploy that
+shipped it**. This fully covers **stable/vendor lazy chunks** — the observed
+#1330 pattern (`anthropic-messages`), which re-ship on every deploy until they
+change. **Build-unique lazy chunks** (present in only one build that then stays
+live a while) can fall outside the window and fall back to the shipped reload —
+an accepted limitation of option A. Making retention robust for _all_ chunks
+requires a small manifest-touch at deploy (**option B**, fully specified in §3),
+which reintroduces a little per-deploy tracking. **A vs B is the one decision
+awaiting Karl;** this spec proceeds on **A** (matches the "no versions" lean and
+keeps the first iteration simplest), with B as a documented, additive upgrade.
+
 ## Key insight: content hash = identity (enforced)
 
 Every `/assets/*` filename **is** a hash of its bytes. The same filename can
@@ -311,7 +323,8 @@ Request GET/HEAD /assets/<hash>.<ext>  (strict regex gate, else fall through):
   `Content-Length` / immutable `Cache-Control` and **no** `Accept-Ranges` and no
   SPA CSP headers; **HEAD** (headers, no body); **`If-None-Match`** (match) → 304
   no `Content-Length`; **`If-Modified-Since`** → 304; **`If-Match`/
-  `If-Unmodified-Since` ignored** → full 200; **Range header ignored** → full
+  `If-Unmodified-Since` ignored** → full 200 (assert these never reach R2's
+  `onlyIf`); **Range header ignored** → full
   200; miss + archive miss → probe shell/404 (no regression); strict-regex gate
   rejects non-asset / traversal / encoded / **un-hashed** paths and `POST`;
   **Cache API** consulted/populated only for plain GET, HEAD/conditional bypass
@@ -346,16 +359,16 @@ lifecycle list`. (Route-mirror rule: index.ts routing
 
 ## Decisions (locked)
 
-| Decision         | Choice                                                                                                                                                                                |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                                                                                       |
-| Serving          | ASSETS-first; miss classified via sanitized canonical-GET probe (`200 text/html`)                                                                                                     |
-| HTTP semantics   | Full GET / HEAD / conditional (304 for If-None-Match·If-Modified-Since; If-Match·If-Unmodified-Since ignored → full 200); **Range unsupported** (ignore → full 200, no Accept-Ranges) |
-| R2 API           | `get(key, { onlyIf: request.headers })` only (no `range: headers`); `writeHttpMetadata` + `httpEtag` + `size`                                                                         |
-| Edge cache       | Cache API: plain-GET only; cache full-200 under canonical key; `waitUntil` put, swallow errors                                                                                        |
-| Hash invariant   | Enforced: upload fails on any non-hashed `dist/ui/assets/*` name                                                                                                                      |
-| GC               | 14-day age-based lifecycle (applied out-of-band, verified via `wrangler r2 bucket lifecycle list`); re-put ALL every deploy; **no touch job**                                         |
-| Upload           | `upload-assets-to-r2.sh`; assert-hash + re-put ALL + retries, single hard-fail step before first deploy attempt                                                                       |
-| Deploy paths     | publish-worker.sh (auto prod) + worker.yml (manual prod) + ci.yml + worker-staging.yml; all deploy attempts gated on upload                                                           |
-| Buckets          | Separate per env; `ASSET_ARCHIVE` binding + `WorkerEnv` type; preview worker excluded                                                                                                 |
-| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                                                                                      |
+| Decision         | Choice                                                                                                                                                                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Primary strategy | Server-side R2 asset retention (root-cause fix)                                                                                                                                                                                     |
+| Serving          | ASSETS-first; miss classified via sanitized canonical-GET probe (`200 text/html`)                                                                                                                                                   |
+| HTTP semantics   | Full GET / HEAD / conditional (304 for If-None-Match·If-Modified-Since; If-Match·If-Unmodified-Since ignored → full 200); **Range unsupported** (ignore → full 200, no Accept-Ranges)                                               |
+| R2 API           | `get(key, { onlyIf })` where `onlyIf` is a **filtered `Headers` containing only `If-None-Match`/`If-Modified-Since`** (If-Match/If-Unmodified-Since never reach R2); no `range: headers`; `writeHttpMetadata` + `httpEtag` + `size` |
+| Edge cache       | Cache API: plain-GET only; cache full-200 under canonical key; `waitUntil` put, swallow errors                                                                                                                                      |
+| Hash invariant   | Enforced: upload fails on any non-hashed `dist/ui/assets/*` name                                                                                                                                                                    |
+| GC               | 14-day age-based lifecycle (applied out-of-band, verified via `wrangler r2 bucket lifecycle list`); re-put ALL every deploy; **no touch job**                                                                                       |
+| Upload           | `upload-assets-to-r2.sh`; assert-hash + re-put ALL + retries, single hard-fail step before first deploy attempt                                                                                                                     |
+| Deploy paths     | publish-worker.sh (auto prod) + worker.yml (manual prod) + ci.yml + worker-staging.yml; all deploy attempts gated on upload                                                                                                         |
+| Buckets          | Separate per env; `ASSET_ARCHIVE` binding + `WorkerEnv` type; preview worker excluded                                                                                                                                               |
+| Reload (#1364)   | Retained as rare last-resort fallback, unchanged                                                                                                                                                                                    |

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -147,8 +147,8 @@ npx wrangler r2 bucket list
 For each bucket, set a lifecycle rule to delete objects with `last-modified > 14 days`:
 
 ```bash
-npx wrangler r2 bucket lifecycle add slicc-asset-archive --days 14
-npx wrangler r2 bucket lifecycle add slicc-asset-archive-staging --days 14
+npx wrangler r2 bucket lifecycle add slicc-asset-archive retention-14d --expire-days 14
+npx wrangler r2 bucket lifecycle add slicc-asset-archive-staging retention-14d --expire-days 14
 ```
 
 Verify:

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -103,6 +103,71 @@ support laptop-orchestrated sandboxes that pause for days at a time.
 
 - **25 MiB per-asset cap**: Cloudflare Workers Static Assets reject any single file in `dist/ui/` over 25 MiB, and `wrangler deploy` (incl. `--dry-run`) fails hard with `Asset too large`. A webapp change that bundles a large binary (e.g. the 33 MB `biome_wasm_bg.wasm`, stripped by `packages/webapp/vite-plugins/strip-biome-wasm-asset.ts`) breaks the deploy. The `cloudflare-worker` CI job runs `npm run build -w @slicc/cloudflare-worker` (the same `wrangler deploy --dry-run`) as a hard gate after building the webapp. The other deploy steps in that same job are `continue-on-error: true` and the finalize/smoke steps skip (rather than fail) when no deploy succeeds, so before this gate an oversized asset passed the PR and only broke later in the separate `release` workflow. The dry-run gate now fails the PR up front.
 
+### R2 Asset Retention (#1330)
+
+**Goal:** Keep content-hashed `/assets/*` chunks available across deploys so long-lived browser tabs don't crash when lazy-loaded chunks from an older build disappear. The worker serves archived chunks from R2 on an `ASSETS` miss (when the current build no longer has them), degrading gracefully to the shipped stale-asset reload if retention doesn't cover a chunk.
+
+**Binding and buckets:** `wrangler.jsonc` defines an `ASSET_ARCHIVE` R2 binding per environment: `slicc-asset-archive` (production) and `slicc-asset-archive-staging` (staging). The worker's `WorkerEnv` type includes `ASSET_ARCHIVE: R2Bucket`.
+
+**Serving path (`serveAssetWithArchiveFallback`):** A dedicated handler in `src/index.ts` intercepts `GET`/`HEAD` requests to paths matching the strict hashed-asset predicate (e.g., `/assets/anthropic-messages-DP3-Xd3J.js`):
+
+- **Present asset** (current build has it): serve from `ASSETS` unchanged, honoring Range/conditional headers.
+- **Miss** (asset absent from current build; `ASSETS` returns `text/html` shell or `404`): attempt to fetch from R2 with full `200` + immutable `Cache-Control`. Intentionally **NOT** implement conditional (304/412) or Range (206) — all requests receive the full body and validators (`ETag`, `Last-Modified`). Archive miss or R2 error falls back to the shell (or bodyless response for `HEAD`), triggering the existing stale-asset reload if needed.
+- **Cache API** (edge): GET requests cache the full `200` under a canonical key; HEAD bypasses the cache.
+
+**Hash invariant (enforced):** Every `/assets/*` filename must carry a content hash (e.g., `-DP3-Xd3J`). The upload script (`packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs`) fails the deploy if any `dist/ui/assets/*` name lacks a hash, and the worker's routing predicate enforces the same rule (defined in the shared `asset-archive.mjs` module).
+
+**Upload gate (before every deploy):** Every deploy path (prod automated via `publish-worker.sh`, prod manual via `worker.yml`, staging via `ci.yml` and `worker-staging.yml`) runs the upload step **before the first `wrangler deploy` attempt**. The upload re-puts the **entire current asset set** to the archive (no skip-if-exists; refreshes `last-modified` which the GC relies on) with retries and bounded concurrency, failing the deploy hard if any file fails to upload or the hash invariant is violated. Auth: `CLOUDFLARE_API_TOKEN` (must have R2 Object Read & Write on both buckets) and `CLOUDFLARE_ACCOUNT_ID`.
+
+**Garbage collection (Option A, age-based):** An R2 object-lifecycle rule on each bucket deletes objects with `last-modified` older than 14 days. Because every deploy re-puts its full current set, stable chunks (vendor/shared) re-ship until they change, surviving ≥14 days after supersession (covers the common #1330 pattern). Build-unique chunks may fall outside the window after a build stops shipping them; tabs importing such chunks past 14 days degrade to the stale-asset reload — acceptable and identical to today. **Option B** (manifest-touch, future work) would give all chunks ≥14 days post-supersession via a small manifest of deployed key lists and a copy-in-place touch loop; it's an additive upgrade requiring no re-spec.
+
+**MIME map:** Shared in `src/asset-archive.mjs` (used by both worker and upload script): `.js`/`.mjs`→`text/javascript`, `.css`→`text/css`, `.json`/`.map`→`application/json`, `.wasm`→`application/wasm`, `.woff2`→`font/woff2`, `.svg`→`image/svg+xml`, and others; fallback `application/octet-stream`.
+
+**Testing:** Unit tests in `tests/index.test.ts` verify present-asset, miss (archive hit/miss), HEAD, Range/conditional requests (full `200`, not 206/304), cache behavior, and error handling. Deployed smoke tests in `tests/deployed.test.ts` verify (staging-only) R2 archive recovery and (both envs) present-asset fetch via the live worker.
+
+## Ops Runbook: R2 Asset Retention Prerequisites
+
+These manual Cloudflare operations **must exist before CI deploys**, else the upload step will fail.
+
+### 1. Create R2 buckets
+
+```bash
+npx wrangler r2 bucket create slicc-asset-archive
+npx wrangler r2 bucket create slicc-asset-archive-staging
+```
+
+Verify:
+
+```bash
+npx wrangler r2 bucket list
+```
+
+### 2. Apply 14-day object-lifecycle rule
+
+For each bucket, set a lifecycle rule to delete objects with `last-modified > 14 days`:
+
+```bash
+npx wrangler r2 bucket lifecycle add slicc-asset-archive --days 14
+npx wrangler r2 bucket lifecycle add slicc-asset-archive-staging --days 14
+```
+
+Verify:
+
+```bash
+npx wrangler r2 bucket lifecycle list slicc-asset-archive
+npx wrangler r2 bucket lifecycle list slicc-asset-archive-staging
+```
+
+Each should output:
+
+```
+Age: 14 days → Expiration
+```
+
+### 3. Grant `CLOUDFLARE_API_TOKEN` R2 Object Read & Write
+
+The deploy workflow's `CLOUDFLARE_API_TOKEN` secret must have **R2 Object Read & Write** permission on **both buckets** (`slicc-asset-archive` and `slicc-asset-archive-staging`). Update the token's permissions in the Cloudflare dashboard (**Account Settings → API Tokens → Edit token**) or create a new token with the required scope.
+
 ## Commands
 
 ### Worker and deploy

--- a/packages/cloudflare-worker/scripts/publish-worker.sh
+++ b/packages/cloudflare-worker/scripts/publish-worker.sh
@@ -32,6 +32,14 @@ echo "$CLOUDFLARE_TURN_API_TOKEN" | npx wrangler secret put CLOUDFLARE_TURN_API_
 echo "$GITHUB_CLIENT_SECRET"      | npx wrangler secret put GITHUB_CLIENT_SECRET      --config "$WRANGLER_CONFIG"
 echo "$E2B_API_KEY"               | npx wrangler secret put E2B_API_KEY               --config "$WRANGLER_CONFIG"
 
+# #1330 retention: archive this build's content-hashed assets to R2 BEFORE
+# deploy so long-lived tabs can recover gone lazy chunks. Hard-fail gate
+# (`set -e` aborts the release before deploy if the upload fails) — a build must
+# never go live unarchived. CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID are
+# already in scope for the deploy; the script shells `npx wrangler`.
+echo "[publish-worker] Archiving assets to R2 (slicc-asset-archive)..."
+node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive --dir dist/ui/assets
+
 echo "[publish-worker] Deploying worker..."
 npx wrangler deploy --config "$WRANGLER_CONFIG"
 

--- a/packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs
+++ b/packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+/**
+ * CLI wrapper for R2 asset uploads.
+ * Usage: node upload-assets-to-r2.mjs <bucket> [--dir <dir>]
+ *
+ * Example:
+ *   node scripts/upload-assets-to-r2.mjs slicc-asset-archive --dir dist/ui/assets
+ */
+
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runUploads } from './upload-lib.mjs';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+/**
+ * Parse command-line arguments.
+ */
+function parseArgs(args) {
+  const [bucket, ...rest] = args;
+  if (!bucket) {
+    throw new Error('Usage: node upload-assets-to-r2.mjs <bucket> [--dir <dir>]');
+  }
+
+  let dir = 'dist/ui/assets'; // default
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i] === '--dir' && i + 1 < rest.length) {
+      dir = rest[i + 1];
+    }
+  }
+
+  return { bucket, dir };
+}
+
+/**
+ * Wraps execFile to make it a Promise<void>.
+ */
+function createExec() {
+  return (argv) =>
+    new Promise((resolve, reject) => {
+      const [cmd, ...args] = argv;
+      const proc = execFile(cmd, args, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+
+      // Inherit stdio so wrangler output is visible
+      proc.stdout.pipe(process.stdout);
+      proc.stderr.pipe(process.stderr);
+    });
+}
+
+/**
+ * Main entry point.
+ */
+async function main() {
+  try {
+    const { bucket, dir } = parseArgs(process.argv.slice(2));
+
+    // Resolve the directory (relative to CWD or absolute)
+    const assetDir = resolve(dir);
+
+    // List files in the directory
+    let files;
+    try {
+      files = await fs.readdir(assetDir);
+    } catch (err) {
+      console.error(`Failed to read directory ${assetDir}:`, err.message);
+      process.exit(1);
+    }
+
+    if (files.length === 0) {
+      console.warn(`No files found in ${assetDir}`);
+      return;
+    }
+
+    console.log(`Uploading ${files.length} files to R2 bucket '${bucket}'`);
+
+    // Upload with default exec = npx wrangler
+    await runUploads(files, {
+      bucket,
+      dir: assetDir,
+      exec: createExec(),
+      concurrency: 3, // reasonable default for parallel puts
+      retries: 2,
+    });
+
+    console.log('All files uploaded successfully');
+  } catch (err) {
+    console.error('Upload failed:', err.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs
+++ b/packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs
@@ -2,7 +2,7 @@
 
 /**
  * CLI wrapper for R2 asset uploads.
- * Usage: node upload-assets-to-r2.mjs <bucket> [--dir <dir>]
+ * Usage: node upload-assets-to-r2.mjs <bucket> [--dir <dir>] [--concurrency <n>]
  *
  * Example:
  *   node scripts/upload-assets-to-r2.mjs slicc-asset-archive --dir dist/ui/assets
@@ -22,17 +22,25 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 function parseArgs(args) {
   const [bucket, ...rest] = args;
   if (!bucket) {
-    throw new Error('Usage: node upload-assets-to-r2.mjs <bucket> [--dir <dir>]');
+    throw new Error(
+      'Usage: node upload-assets-to-r2.mjs <bucket> [--dir <dir>] [--concurrency <n>]'
+    );
   }
 
   let dir = 'dist/ui/assets'; // default
+  let concurrency = 8; // default: parallelize ~300 files fast enough for CI
   for (let i = 0; i < rest.length; i++) {
     if (rest[i] === '--dir' && i + 1 < rest.length) {
       dir = rest[i + 1];
+    } else if (rest[i] === '--concurrency' && i + 1 < rest.length) {
+      const n = Number.parseInt(rest[i + 1], 10);
+      if (Number.isFinite(n) && n > 0) {
+        concurrency = n;
+      }
     }
   }
 
-  return { bucket, dir };
+  return { bucket, dir, concurrency };
 }
 
 /**
@@ -58,7 +66,7 @@ function createExec() {
  */
 async function main() {
   try {
-    const { bucket, dir } = parseArgs(process.argv.slice(2));
+    const { bucket, dir, concurrency } = parseArgs(process.argv.slice(2));
 
     // Resolve the directory (relative to CWD or absolute)
     const assetDir = resolve(dir);
@@ -84,7 +92,7 @@ async function main() {
       bucket,
       dir: assetDir,
       exec: createExec(),
-      concurrency: 3, // reasonable default for parallel puts
+      concurrency, // default 8 — parallelize ~300 files fast enough for CI
       retries: 2,
     });
 

--- a/packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs
+++ b/packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs
@@ -47,10 +47,12 @@ function parseArgs(args) {
  * Wraps execFile to make it a Promise<void>.
  */
 function createExec() {
+  // argv is the wrangler command (e.g. ['wrangler','r2','object','put',…]);
+  // run it via `npx` so it resolves without node_modules/.bin on PATH (plain
+  // CI `run:` steps / publish-worker.sh are not npm scripts).
   return (argv) =>
     new Promise((resolve, reject) => {
-      const [cmd, ...args] = argv;
-      const proc = execFile(cmd, args, (err) => {
+      const proc = execFile('npx', argv, (err) => {
         if (err) reject(err);
         else resolve();
       });

--- a/packages/cloudflare-worker/scripts/upload-lib.d.mts
+++ b/packages/cloudflare-worker/scripts/upload-lib.d.mts
@@ -4,7 +4,7 @@
 
 export declare function assertAllHashed(names: string[]): void;
 
-export declare function buildPutArgs(bucket: string, file: string): string[];
+export declare function buildPutArgs(bucket: string, file: string, dir?: string): string[];
 
 export interface Exec {
   (argv: string[]): Promise<any>;

--- a/packages/cloudflare-worker/scripts/upload-lib.d.mts
+++ b/packages/cloudflare-worker/scripts/upload-lib.d.mts
@@ -1,0 +1,21 @@
+/**
+ * Type declarations for upload-lib.mjs
+ */
+
+export declare function assertAllHashed(names: string[]): void;
+
+export declare function buildPutArgs(bucket: string, file: string): string[];
+
+export interface Exec {
+  (argv: string[]): Promise<any>;
+}
+
+export interface RunUploadsOptions {
+  bucket: string;
+  dir: string;
+  exec: Exec;
+  concurrency?: number;
+  retries?: number;
+}
+
+export declare function runUploads(files: string[], opts: RunUploadsOptions): Promise<void>;

--- a/packages/cloudflare-worker/scripts/upload-lib.mjs
+++ b/packages/cloudflare-worker/scripts/upload-lib.mjs
@@ -1,0 +1,75 @@
+/**
+ * Pure helpers for R2 asset upload, testable with injectable exec.
+ * Imports from ../src/asset-archive.mjs for the single shared predicate + MIME map.
+ */
+
+import { matchHashedAssetPath, mimeForAssetPath } from '../src/asset-archive.mjs';
+
+/**
+ * Throws if any filename lacks a content hash (fails the invariant).
+ */
+export function assertAllHashed(names) {
+  for (const name of names) {
+    if (!matchHashedAssetPath(`/assets/${name}`)) {
+      throw new Error(`Asset not hashed: ${name}`);
+    }
+  }
+}
+
+/**
+ * Build the wrangler r2 object put argv for a single file.
+ * @param {string} bucket - R2 bucket name (e.g., "slicc-asset-archive")
+ * @param {string} file - filename (e.g., "index-abc123.css")
+ * @returns {string[]} argv to pass to execFile('npx', [...])
+ */
+export function buildPutArgs(bucket, file) {
+  const objectPath = `${bucket}/assets/${file}`;
+  const mime = mimeForAssetPath(`/assets/${file}`);
+
+  return ['wrangler', 'r2', 'object', 'put', objectPath, '--file', file, '--content-type', mime];
+}
+
+/**
+ * Run uploads with bounded concurrency and per-file retries.
+ * @param {string[]} files - filenames (already validated by assertAllHashed)
+ * @param {object} opts
+ * @param {string} opts.bucket - R2 bucket name
+ * @param {string} opts.dir - working directory for file resolution
+ * @param {Function} opts.exec - injectable exec function: (argv) => Promise<void>
+ * @param {number} [opts.concurrency=1] - max concurrent uploads
+ * @param {number} [opts.retries=1] - max attempts per file
+ * @returns {Promise<void>}
+ */
+export async function runUploads(files, { bucket, dir, exec, concurrency = 1, retries = 1 }) {
+  // Validate hash invariant before any upload attempt
+  assertAllHashed(files);
+
+  // Split into batches to respect concurrency
+  for (let i = 0; i < files.length; i += concurrency) {
+    const batch = files.slice(i, i + concurrency);
+    const promises = batch.map((file) => uploadWithRetry(file, bucket, exec, retries));
+
+    await Promise.all(promises);
+  }
+}
+
+/**
+ * Upload a single file with retries.
+ */
+async function uploadWithRetry(file, bucket, exec, retries) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const argv = buildPutArgs(bucket, file);
+      await exec(argv);
+      return; // success
+    } catch (err) {
+      lastError = err;
+      if (attempt < retries) {
+      }
+    }
+  }
+
+  throw lastError;
+}

--- a/packages/cloudflare-worker/scripts/upload-lib.mjs
+++ b/packages/cloudflare-worker/scripts/upload-lib.mjs
@@ -22,11 +22,26 @@ export function assertAllHashed(names) {
  * @param {string} file - filename (e.g., "index-abc123.css")
  * @returns {string[]} argv to pass to execFile('npx', [...])
  */
-export function buildPutArgs(bucket, file) {
+export function buildPutArgs(bucket, file, dir) {
   const objectPath = `${bucket}/assets/${file}`;
   const mime = mimeForAssetPath(`/assets/${file}`);
+  // --file must resolve from the exec's cwd; the caller passes the (absolute)
+  // asset dir. --remote is REQUIRED: `wrangler r2 object put` defaults to LOCAL
+  // (miniflare) storage, which would silently never populate the real bucket.
+  const filePath = dir ? `${dir}/${file}` : file;
 
-  return ['wrangler', 'r2', 'object', 'put', objectPath, '--file', file, '--content-type', mime];
+  return [
+    'wrangler',
+    'r2',
+    'object',
+    'put',
+    objectPath,
+    '--file',
+    filePath,
+    '--content-type',
+    mime,
+    '--remote',
+  ];
 }
 
 /**
@@ -47,7 +62,7 @@ export async function runUploads(files, { bucket, dir, exec, concurrency = 1, re
   // Split into batches to respect concurrency
   for (let i = 0; i < files.length; i += concurrency) {
     const batch = files.slice(i, i + concurrency);
-    const promises = batch.map((file) => uploadWithRetry(file, bucket, exec, retries));
+    const promises = batch.map((file) => uploadWithRetry(file, bucket, dir, exec, retries));
 
     await Promise.all(promises);
   }
@@ -56,18 +71,16 @@ export async function runUploads(files, { bucket, dir, exec, concurrency = 1, re
 /**
  * Upload a single file with retries.
  */
-async function uploadWithRetry(file, bucket, exec, retries) {
+async function uploadWithRetry(file, bucket, dir, exec, retries) {
   let lastError;
 
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
-      const argv = buildPutArgs(bucket, file);
+      const argv = buildPutArgs(bucket, file, dir);
       await exec(argv);
       return; // success
     } catch (err) {
       lastError = err;
-      if (attempt < retries) {
-      }
     }
   }
 

--- a/packages/cloudflare-worker/src/asset-archive.d.mts
+++ b/packages/cloudflare-worker/src/asset-archive.d.mts
@@ -1,0 +1,3 @@
+export declare const HASHED_ASSET_RE: RegExp;
+export declare function matchHashedAssetPath(pathname: string): boolean;
+export declare function mimeForAssetPath(pathname: string): string;

--- a/packages/cloudflare-worker/src/asset-archive.mjs
+++ b/packages/cloudflare-worker/src/asset-archive.mjs
@@ -1,0 +1,38 @@
+/**
+ * Pure helpers shared by the worker asset-serving path (TS, esbuild-bundled) and
+ * the CI upload script (Node, run from source). Plain ESM so both import it with
+ * no build step. No worker/DOM/Node deps.
+ */
+
+/** Vite-hashed asset under /assets/: `<name>-<8+ url-safe>[.compound].<ext>`. */
+export const HASHED_ASSET_RE =
+  /^\/assets\/[A-Za-z0-9_][A-Za-z0-9._-]*-[A-Za-z0-9_-]{8,}(\.[a-z0-9]+)*\.(js|mjs|css|map|wasm|woff2|woff|ttf|svg|png|jpg|jpeg|gif|webp|avif|ico|json)$/;
+
+export function matchHashedAssetPath(pathname) {
+  return HASHED_ASSET_RE.test(pathname);
+}
+
+const MIME = {
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  css: 'text/css',
+  json: 'application/json',
+  map: 'application/json',
+  wasm: 'application/wasm',
+  svg: 'image/svg+xml',
+  woff2: 'font/woff2',
+  woff: 'font/woff',
+  ttf: 'font/ttf',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  avif: 'image/avif',
+  ico: 'image/x-icon',
+};
+
+export function mimeForAssetPath(pathname) {
+  const ext = pathname.slice(pathname.lastIndexOf('.') + 1).toLowerCase();
+  return MIME[ext] ?? 'application/octet-stream';
+}

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -439,8 +439,11 @@ function withCapabilityCors(response: Response, cors: Record<string, string>): R
 export async function handleWorkerRequest(
   request: Request,
   env: WorkerEnv,
-  ctx: ExecutionContext = NOOP_CTX,
-  fetchImpl: typeof fetch = fetch
+  // fetchImpl stays the 3rd positional arg (the established test-injection
+  // convention across this file); ctx is last so existing `(request, env, fetch)`
+  // call sites keep working. serveAssetWithArchiveFallback uses ctx.waitUntil.
+  fetchImpl: typeof fetch = fetch,
+  ctx: ExecutionContext = NOOP_CTX
 ): Promise<Response> {
   const url = new URL(request.url);
 
@@ -1059,7 +1062,7 @@ const worker = {
       }
     }
 
-    const response = await handleWorkerRequest(request, env, ctx);
+    const response = await handleWorkerRequest(request, env, undefined, ctx);
     if (response.status === 101) {
       return response;
     }

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -49,6 +49,7 @@ export interface WorkerEnv {
   TRAY_HUB: DurableObjectNamespaceLike;
   CLOUD_SESSIONS: DurableObjectNamespaceLike;
   ASSETS: { fetch(request: Request): Promise<Response> };
+  ASSET_ARCHIVE: R2Bucket;
   CLOUDFLARE_TURN_KEY_ID?: string;
   CLOUDFLARE_TURN_API_TOKEN?: string;
   E2B_API_KEY?: string;

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -1,5 +1,6 @@
 import { ELECTRON_OVERLAY_APP_PATH, SLICC_HOSTED_ORIGIN } from '@slicc/shared-ts';
 import { buildApiCatalogResponse } from './api-catalog.js';
+import { matchHashedAssetPath, mimeForAssetPath } from './asset-archive.mjs';
 import { handleCloudCallback, handleCloudCallbackScript } from './auth/cloud-callback.js';
 import { CloudSessionsDurableObject } from './cloud/cloud-sessions-do.js';
 import { handleAdminStats } from './cloud/handler-admin.js';
@@ -128,6 +129,97 @@ export function buildLeaderConnectSrc(env: { ADOBE_PROXY_ENDPOINT?: string }): s
     'ws://localhost:*',
     'ws://127.0.0.1:*',
   ].join(' ');
+}
+
+/**
+ * Fallback `ExecutionContext` for the many `handleWorkerRequest` / `worker.fetch`
+ * call sites (tests, internal helpers) that do not thread a real ctx. Its
+ * `waitUntil` is a no-op, so a `cache.put` scheduled through it simply is not
+ * awaited — harmless for correctness (the response is already returned).
+ */
+const NOOP_CTX: ExecutionContext = {
+  waitUntil() {},
+  passThroughOnException() {},
+} as unknown as ExecutionContext;
+
+const ASSET_IMMUTABLE = 'public, max-age=31536000, immutable';
+
+/**
+ * #1330 retention: serve a content-hashed `/assets/*` chunk from the R2 archive
+ * when the current build no longer has it, so a long-lived tab keeps fetching
+ * its own build's lazy chunks after a deploy instead of getting the SPA shell
+ * (which would fail as a dynamic-import). ASSETS-first; R2 only on a miss.
+ *
+ * Conditional (304/412) and Range (206) are intentionally NOT implemented —
+ * archived chunks are small, immutable, content-hashed, and fetched in full.
+ * Every request (incl. any carrying `Range`/`If-*`) gets a full `200` (or a
+ * bodyless `HEAD`). Never `500`s an asset — any R2/cache error falls back to
+ * the classification-probe shell (HEAD → bodyless).
+ */
+async function serveAssetWithArchiveFallback(
+  request: Request,
+  env: WorkerEnv,
+  ctx: ExecutionContext
+): Promise<Response> {
+  const url = new URL(request.url);
+  const isHead = request.method === 'HEAD';
+
+  // Classify present-vs-miss with a sanitized canonical GET so Range/conditional
+  // headers can't make ASSETS answer 206/304 for the shell.
+  const hasCond =
+    request.headers.has('range') ||
+    request.headers.has('if-none-match') ||
+    request.headers.has('if-modified-since') ||
+    request.headers.has('if-match') ||
+    request.headers.has('if-unmodified-since');
+  const probe = hasCond
+    ? await env.ASSETS.fetch(new Request(url.toString(), { method: 'GET' }))
+    : await env.ASSETS.fetch(request); // plain GET/HEAD: original IS the probe
+  const probeCT = probe.headers.get('content-type') ?? '';
+  const isMiss = (probe.status === 200 && probeCT.includes('text/html')) || probe.status === 404;
+
+  if (!isMiss) {
+    // Present: for a plain GET/HEAD the probe IS the answer; only a conditional/
+    // Range request needs the original re-fetched so the platform honors it.
+    return hasCond ? env.ASSETS.fetch(request) : probe;
+  }
+
+  // Miss → archive. Cache only plain GET (HEAD bypasses).
+  const cache = caches.default;
+  const cacheKey = new Request(`${url.origin}${url.pathname}`, { method: 'GET' });
+  if (!isHead) {
+    try {
+      const hit = await cache.match(cacheKey);
+      if (hit) return hit;
+    } catch {
+      /* cache read failure → fall through to R2; never 500 an asset */
+    }
+  }
+
+  let obj: R2ObjectBody | null = null;
+  try {
+    obj = await env.ASSET_ARCHIVE.get(url.pathname.slice(1)); // no onlyIf/range
+  } catch {
+    obj = null;
+  }
+  if (!obj) {
+    // Fallback to the shell; a HEAD must stay bodyless.
+    return isHead ? new Response(null, { status: probe.status, headers: probe.headers }) : probe;
+  }
+
+  const headers = new Headers();
+  obj.writeHttpMetadata(headers);
+  if (!headers.has('content-type')) headers.set('content-type', mimeForAssetPath(url.pathname));
+  headers.set('etag', obj.httpEtag);
+  headers.set('last-modified', obj.uploaded.toUTCString());
+  headers.set('cache-control', ASSET_IMMUTABLE);
+  headers.set('content-length', String(obj.size));
+
+  if (isHead) return new Response(null, { status: 200, headers });
+
+  const res = new Response(obj.body, { status: 200, headers });
+  ctx.waitUntil(cache.put(cacheKey, res.clone()).catch(() => {}));
+  return res;
 }
 
 async function serveSPA(request: Request, env: WorkerEnv): Promise<Response> {
@@ -347,6 +439,7 @@ function withCapabilityCors(response: Response, cors: Record<string, string>): R
 export async function handleWorkerRequest(
   request: Request,
   env: WorkerEnv,
+  ctx: ExecutionContext = NOOP_CTX,
   fetchImpl: typeof fetch = fetch
 ): Promise<Response> {
   const url = new URL(request.url);
@@ -411,6 +504,15 @@ export async function handleWorkerRequest(
       return withCapabilityCors(capResponse, capabilityCorsHeaders(request, env));
     }
     return capResponse;
+  }
+
+  // #1330 retention: serve content-hashed /assets/* from the R2 archive when the
+  // current build no longer has them, before the SPA fallback turns them into HTML.
+  if (
+    (request.method === 'GET' || request.method === 'HEAD') &&
+    matchHashedAssetPath(url.pathname)
+  ) {
+    return serveAssetWithArchiveFallback(request, env, ctx);
   }
 
   // SPA fallback for GET/HEAD browser navigation, unless ?json=true
@@ -940,7 +1042,11 @@ async function createTray(request: Request, env: WorkerEnv): Promise<Response> {
 }
 
 const worker = {
-  async fetch(request: Request, env: WorkerEnv): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: WorkerEnv,
+    ctx: ExecutionContext = NOOP_CTX
+  ): Promise<Response> {
     const url = new URL(request.url);
 
     // Root redirects to www.sliccy.com — indexable, return as-is
@@ -953,7 +1059,7 @@ const worker = {
       }
     }
 
-    const response = await handleWorkerRequest(request, env);
+    const response = await handleWorkerRequest(request, env, ctx);
     if (response.status === 101) {
       return response;
     }

--- a/packages/cloudflare-worker/tests/asset-archive.test.ts
+++ b/packages/cloudflare-worker/tests/asset-archive.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { matchHashedAssetPath, mimeForAssetPath } from '../src/asset-archive.mjs';
+
+describe('matchHashedAssetPath', () => {
+  it('accepts hashed chunk names', () => {
+    expect(matchHashedAssetPath('/assets/anthropic-messages-DP3-Xd3J.js')).toBe(true);
+    expect(matchHashedAssetPath('/assets/index-a1b2c3d4.css')).toBe(true);
+    expect(matchHashedAssetPath('/assets/entry-abcd1234.js.map')).toBe(true);
+    expect(matchHashedAssetPath('/assets/logo-DEADBEEF.svg')).toBe(true);
+  });
+  it('rejects non-asset / un-hashed / traversal / encoded paths', () => {
+    expect(matchHashedAssetPath('/index.html')).toBe(false);
+    expect(matchHashedAssetPath('/assets/index.html')).toBe(false); // wrong ext
+    expect(matchHashedAssetPath('/assets/foo.js')).toBe(false); // no hash
+    expect(matchHashedAssetPath('/assets/../secret-abcd1234.js')).toBe(false);
+    expect(matchHashedAssetPath('/assets/a%2Fb-abcd1234.js')).toBe(false);
+    expect(matchHashedAssetPath('/other/x-abcd1234.js')).toBe(false);
+  });
+});
+
+describe('mimeForAssetPath', () => {
+  it('maps critical types', () => {
+    expect(mimeForAssetPath('/assets/x-abcd1234.js')).toBe('text/javascript');
+    expect(mimeForAssetPath('/assets/x-abcd1234.mjs')).toBe('text/javascript');
+    expect(mimeForAssetPath('/assets/x-abcd1234.css')).toBe('text/css');
+    expect(mimeForAssetPath('/assets/x-abcd1234.wasm')).toBe('application/wasm');
+    expect(mimeForAssetPath('/assets/x-abcd1234.js.map')).toBe('application/json');
+    expect(mimeForAssetPath('/assets/x-abcd1234.woff2')).toBe('font/woff2');
+  });
+  it('falls back to octet-stream', () => {
+    expect(mimeForAssetPath('/assets/x-abcd1234.zzz')).toBe('application/octet-stream');
+  });
+});

--- a/packages/cloudflare-worker/tests/auth-relay.test.ts
+++ b/packages/cloudflare-worker/tests/auth-relay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { handleWorkerRequest, type WorkerEnv } from '../src/index.js';
+import { handleWorkerRequest } from '../src/index.js';
+import { makeEnv } from './helpers/fake-env.js';
 
 const fakeAssets = {
   fetch: async (_req: Request) =>
@@ -8,7 +9,7 @@ const fakeAssets = {
     }),
 };
 
-const env = { TRAY_HUB: {}, ASSETS: fakeAssets } as unknown as WorkerEnv;
+const env = makeEnv({ ASSETS: fakeAssets });
 
 function relayRequest(query: string): Request {
   return new Request(`https://www.sliccy.ai/auth/callback${query}`);

--- a/packages/cloudflare-worker/tests/cloud-csp.test.ts
+++ b/packages/cloudflare-worker/tests/cloud-csp.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { buildLeaderConnectSrc, handleWorkerRequest, type WorkerEnv } from '../src/index.js';
+import { buildLeaderConnectSrc, handleWorkerRequest } from '../src/index.js';
+import { makeEnv as makeTestEnv } from './helpers/fake-env.js';
 
 const CLOUD_HTML = '<!doctype html><html><body>cloud dashboard</body></html>';
 
@@ -29,12 +30,12 @@ const fakeTrayHub = {
   }),
 };
 
-function makeEnv(): WorkerEnv {
-  return {
+function makeEnv() {
+  return makeTestEnv({
     TRAY_HUB: fakeTrayHub,
     CLOUD_SESSIONS: fakeCloudSessions,
     ASSETS: fakeAssets,
-  } as unknown as WorkerEnv;
+  });
 }
 
 describe('CSP on /cloud responses', () => {

--- a/packages/cloudflare-worker/tests/deployed.test.ts
+++ b/packages/cloudflare-worker/tests/deployed.test.ts
@@ -432,6 +432,174 @@ describeIfConfigured('deployed tray worker', () => {
   }, 30_000);
 });
 
+describe('static assets + R2 archive', () => {
+  // Both prod and staging: confirm present assets serve and archive doesn't block JSON split.
+  it('serves present assets with correct content-type and archive bypass (both envs)', async () => {
+    if (!workerBaseUrl) return;
+
+    const baseUrl = new URL(workerBaseUrl);
+    // Fetch the SPA with redirect: 'manual' to detect any redirect (prod redirects bare / to .com)
+    const spaResponse = await fetch(new URL('/?json=false', baseUrl), {
+      redirect: 'manual',
+    });
+    // Should not redirect — the ?json=false param should load the SPA even at prod root
+    expect(spaResponse.status).not.toMatch(/^3\d\d$/);
+    expect(spaResponse.status).toBe(200);
+
+    const spaBody = await spaResponse.text();
+    // Extract a real /assets/* URL from the HTML
+    const assetMatch = spaBody.match(/\/assets\/[A-Za-z0-9._-]+\.(js|css)/);
+    expect(assetMatch).toBeTruthy();
+    const assetPath = assetMatch![0];
+
+    // Fetch the asset with Accept-Encoding to test compression headers
+    const assetResponse = await fetch(new URL(assetPath, baseUrl), {
+      headers: { 'Accept-Encoding': 'br,gzip' },
+    });
+    expect(assetResponse.status).toBe(200);
+    const assetCt = assetResponse.headers.get('content-type') || '';
+    expect(assetCt).toMatch(/text\/javascript|text\/css/);
+
+    // Log the compression header for debugging
+    const encoding = assetResponse.headers.get('content-encoding');
+    console.log(`Asset ${assetPath} served with Content-Encoding: ${encoding || 'none'}`);
+
+    // Repeat the asset fetch with ?json=true to confirm it's not intercepted
+    const assetWithJsonResponse = await fetch(new URL(assetPath + '?json=true', baseUrl));
+    expect(assetWithJsonResponse.status).toBe(200);
+    const assetWithJsonCt = assetWithJsonResponse.headers.get('content-type') || '';
+    expect(assetWithJsonCt).toMatch(/text\/javascript|text\/css/);
+  }, 15_000);
+
+  // Staging only: upload a synthetic asset to R2, fetch via worker, verify archive recovery
+  it('recovers archived assets on ASSETS miss (staging-only R2 smoke)', async () => {
+    if (!workerBaseUrl) return;
+
+    const archiveSmoke = process.env.SLICC_ARCHIVE_SMOKE === '1';
+    const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+    const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+    const bucket = process.env.SLICC_ARCHIVE_BUCKET;
+
+    // Self-gate: skip if not configured
+    if (!archiveSmoke || !apiToken || !accountId || !bucket) {
+      console.log(
+        'Skipping archive smoke test (requires SLICC_ARCHIVE_SMOKE=1, CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, SLICC_ARCHIVE_BUCKET)'
+      );
+      return;
+    }
+
+    // Defense-in-depth: verify we're pointed at staging, not prod
+    const baseUrl = new URL(workerBaseUrl);
+    const host = baseUrl.host.toLowerCase();
+    const isStaging = host.includes('staging') || host.includes('workers.dev');
+    const isProd = host.includes('sliccy.ai') && !host.includes('staging');
+
+    if (isProd) {
+      throw new Error(
+        `SLICC_ARCHIVE_SMOKE=1 but WORKER_BASE_URL points to production (${host}). Refusing to write to prod R2.`
+      );
+    }
+
+    if (!isStaging) {
+      console.warn(
+        `Archive smoke test: cannot verify staging (host: ${host}). Proceeding with caution.`
+      );
+    }
+
+    // Generate a random hash for the test asset
+    const randomHash = Math.random().toString(36).substring(2, 10);
+    const testKey = `assets/r2-retention-smoke-${randomHash}.js`;
+    const testContent = `console.log('r2-retention-smoke test: ${randomHash}');`;
+
+    try {
+      // Write test asset to R2 via wrangler
+      const { execFile } = await import('node:child_process');
+      const { promisify } = await import('node:util');
+      const exec = promisify(execFile);
+
+      // Write to temp file
+      const { writeFileSync } = await import('node:fs');
+      const tmpFile = `/tmp/r2-retention-smoke-${randomHash}.js`;
+      writeFileSync(tmpFile, testContent);
+
+      try {
+        // Upload via wrangler
+        await exec('npx', [
+          'wrangler',
+          'r2',
+          'object',
+          'put',
+          `${bucket}/${testKey}`,
+          '--file',
+          tmpFile,
+          '--content-type',
+          'text/javascript',
+          '--remote',
+        ]);
+      } finally {
+        // Clean up temp file
+        const { unlinkSync } = await import('node:fs');
+        try {
+          unlinkSync(tmpFile);
+        } catch {
+          // ignore
+        }
+      }
+
+      // Fetch through the worker (should hit the archive path since asset is not in current build)
+      const assetUrl = new URL(`/${testKey}`, baseUrl);
+      const fetchResponse = await fetch(assetUrl.toString());
+      expect(fetchResponse.status).toBe(200);
+
+      const contentType = fetchResponse.headers.get('content-type') || '';
+      expect(contentType).toBe('text/javascript');
+
+      const etag = fetchResponse.headers.get('etag');
+      expect(etag).toBeTruthy();
+
+      const body = await fetchResponse.text();
+      expect(body).toContain('r2-retention-smoke');
+
+      // Verify HEAD request works
+      const headResponse = await fetch(assetUrl.toString(), { method: 'HEAD' });
+      expect(headResponse.status).toBe(200);
+      expect(headResponse.headers.get('content-type')).toBe('text/javascript');
+      expect(headResponse.headers.get('etag')).toBe(etag);
+
+      // Verify second fetch (cache hit)
+      const cachedResponse = await fetch(assetUrl.toString());
+      expect(cachedResponse.status).toBe(200);
+      const cachedBody = await cachedResponse.text();
+      expect(cachedBody).toContain('r2-retention-smoke');
+
+      // Verify unknown asset returns shell
+      const unknownUrl = new URL(`/assets/nonexistent-${randomHash}.js`, baseUrl);
+      const shellResponse = await fetch(unknownUrl.toString());
+      expect(shellResponse.status).toBe(200);
+      const shellCt = shellResponse.headers.get('content-type') || '';
+      expect(shellCt).toContain('text/html');
+    } finally {
+      // Clean up the test asset from R2
+      const { execFile } = await import('node:child_process');
+      const { promisify } = await import('node:util');
+      const exec = promisify(execFile);
+
+      try {
+        await exec('npx', [
+          'wrangler',
+          'r2',
+          'object',
+          'delete',
+          `${bucket}/${testKey}`,
+          '--remote',
+        ]);
+      } catch {
+        // Best-effort cleanup; don't fail the test
+      }
+    }
+  }, 30_000);
+});
+
 describe('cloud routes smoke', () => {
   it('rejects unauthenticated /api/cloud/list with 401', async () => {
     if (!workerBaseUrl) return;

--- a/packages/cloudflare-worker/tests/deployed.test.ts
+++ b/packages/cloudflare-worker/tests/deployed.test.ts
@@ -442,8 +442,10 @@ describe('static assets + R2 archive', () => {
     const spaResponse = await fetch(new URL('/?json=false', baseUrl), {
       redirect: 'manual',
     });
-    // Should not redirect — the ?json=false param should load the SPA even at prod root
-    expect(spaResponse.status).not.toMatch(/^3\d\d$/);
+    // Should not redirect — the ?json=false param should load the SPA (200) even at
+    // prod root (bare `/` redirects to .com; the query suppresses that). toBe(200)
+    // catches any 3xx/opaqueredirect (redirect: 'manual') — a numeric status can't
+    // use toMatch (string-only).
     expect(spaResponse.status).toBe(200);
 
     const spaBody = await spaResponse.text();

--- a/packages/cloudflare-worker/tests/helpers/fake-env.ts
+++ b/packages/cloudflare-worker/tests/helpers/fake-env.ts
@@ -1,0 +1,41 @@
+import type { WorkerEnv } from '../../src/index.js';
+
+/**
+ * Creates a fake WorkerEnv for testing with sensible defaults.
+ * Pass overrides to customize specific bindings.
+ */
+export function makeEnv(overrides?: Partial<WorkerEnv>): WorkerEnv {
+  const fakeAssets = {
+    fetch: async () => new Response('fake'),
+  };
+
+  const fakeR2 = {
+    get: async () => null,
+  };
+
+  const fakeTrayHub = {
+    idFromName: (_name: string) => ({ toString: () => 'fake-tray-id' }),
+    idFromString: (_id: string) => ({ toString: () => 'fake-tray-id' }),
+    newUniqueId: () => ({ toString: () => 'fake-tray-id' }),
+    get: (_id: unknown) => ({
+      fetch: async (_req: Request) => new Response('tray DO not stubbed', { status: 501 }),
+    }),
+  };
+
+  const fakeCloudSessions = {
+    idFromName: (_name: string) => ({ toString: () => 'fake-cloud-id' }),
+    idFromString: (_id: string) => ({ toString: () => 'fake-cloud-id' }),
+    newUniqueId: () => ({ toString: () => 'fake-cloud-id' }),
+    get: (_id: unknown) => ({
+      fetch: async (_req: Request) => new Response('cloud DO not stubbed', { status: 501 }),
+    }),
+  };
+
+  return {
+    TRAY_HUB: fakeTrayHub as unknown as WorkerEnv['TRAY_HUB'],
+    CLOUD_SESSIONS: fakeCloudSessions as unknown as WorkerEnv['CLOUD_SESSIONS'],
+    ASSETS: fakeAssets,
+    ASSET_ARCHIVE: fakeR2,
+    ...overrides,
+  } as unknown as WorkerEnv;
+}

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -2022,7 +2022,6 @@ describe('generic OAuth token broker', () => {
         }),
       }),
       env,
-      undefined,
       mockFetch
     );
 
@@ -2097,7 +2096,6 @@ describe('generic OAuth token broker', () => {
         body: JSON.stringify({ provider: 'github', code: 'expired-code' }),
       }),
       env,
-      undefined,
       mockFetch
     );
 
@@ -2134,7 +2132,6 @@ describe('generic OAuth token broker', () => {
         body: JSON.stringify({ provider: 'github', code: 'abc' }),
       }),
       env,
-      undefined,
       mockFetch
     );
     expect(post.headers.get('access-control-allow-origin')).toBeTruthy();
@@ -2161,7 +2158,6 @@ describe('generic OAuth token broker', () => {
         body: JSON.stringify({ provider: 'github', access_token: 'gho_token_to_revoke' }),
       }),
       env,
-      undefined,
       mockFetch
     );
 
@@ -3287,7 +3283,7 @@ describe('asset archive fallback (#1330 retention)', () => {
         }),
     });
     const { ctx } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, undefined, ctx);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('console.log(1)');
     // present assets are NOT wrapped by serveSPA's frame-ancestors CSP
@@ -3306,6 +3302,7 @@ describe('asset archive fallback (#1330 retention)', () => {
         headers: { range: 'bytes=0-4', 'if-none-match': '"x"' },
       }),
       env,
+      undefined,
       ctx
     );
     expect(res.status).toBe(200);
@@ -3320,7 +3317,7 @@ describe('asset archive fallback (#1330 retention)', () => {
       get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript', etag: '"v1"' }),
     });
     const { ctx, settle } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, undefined, ctx);
     await settle();
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('ARCHIVED-JS');
@@ -3354,7 +3351,7 @@ describe('asset archive fallback (#1330 retention)', () => {
       get: async () => archiveObj('ARCHIVED-JS', { contentType: null }),
     });
     const { ctx, settle } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, undefined, ctx);
     await settle();
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toBe('text/javascript');
@@ -3366,7 +3363,12 @@ describe('asset archive fallback (#1330 retention)', () => {
       get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
     });
     const { ctx } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL, { method: 'HEAD' }), env, ctx);
+    const res = await handleWorkerRequest(
+      new Request(HASHED_URL, { method: 'HEAD' }),
+      env,
+      undefined,
+      ctx
+    );
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toBe('text/javascript');
     expect(res.headers.get('content-length')).toBe(String('ARCHIVED-JS'.length));
@@ -3393,6 +3395,7 @@ describe('asset archive fallback (#1330 retention)', () => {
         },
       }),
       env,
+      undefined,
       ctx
     );
     await settle();
@@ -3406,7 +3409,7 @@ describe('asset archive fallback (#1330 retention)', () => {
   it('falls back to the shell on an archive miss (GET → 200 text/html)', async () => {
     const { env } = archiveEnv({ assets: () => shell(), get: async () => null });
     const { ctx } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, undefined, ctx);
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('text/html');
     expect(await res.text()).toBe(MOCK_HTML);
@@ -3415,7 +3418,12 @@ describe('asset archive fallback (#1330 retention)', () => {
   it('falls back to a bodyless shell on an archive miss (HEAD)', async () => {
     const { env } = archiveEnv({ assets: () => shell(), get: async () => null });
     const { ctx } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL, { method: 'HEAD' }), env, ctx);
+    const res = await handleWorkerRequest(
+      new Request(HASHED_URL, { method: 'HEAD' }),
+      env,
+      undefined,
+      ctx
+    );
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('text/html');
     expect(await res.text()).toBe('');
@@ -3427,7 +3435,7 @@ describe('asset archive fallback (#1330 retention)', () => {
       get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
     });
     const { ctx, settle } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, undefined, ctx);
     await settle();
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('ARCHIVED-JS');
@@ -3442,7 +3450,7 @@ describe('asset archive fallback (#1330 retention)', () => {
       },
     });
     const { ctx } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, undefined, ctx);
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('text/html');
     expect(await res.text()).toBe(MOCK_HTML);
@@ -3457,7 +3465,7 @@ describe('asset archive fallback (#1330 retention)', () => {
       throw new Error('cache read boom');
     };
     const { ctx, settle } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, undefined, ctx);
     await settle();
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('ARCHIVED-JS');
@@ -3473,7 +3481,7 @@ describe('asset archive fallback (#1330 retention)', () => {
       throw new Error('cache put boom');
     };
     const { ctx, settle } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, undefined, ctx);
     await settle();
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('ARCHIVED-JS');
@@ -3485,7 +3493,7 @@ describe('asset archive fallback (#1330 retention)', () => {
       get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
     });
     const first = makeCtx();
-    const res1 = await handleWorkerRequest(new Request(HASHED_URL), env, first.ctx);
+    const res1 = await handleWorkerRequest(new Request(HASHED_URL), env, undefined, first.ctx);
     await first.settle();
     expect(res1.status).toBe(200);
     expect(await res1.text()).toBe('ARCHIVED-JS');
@@ -3493,7 +3501,7 @@ describe('asset archive fallback (#1330 retention)', () => {
     expect(cache.putCalls).toBe(1);
 
     const second = makeCtx();
-    const res2 = await handleWorkerRequest(new Request(HASHED_URL), env, second.ctx);
+    const res2 = await handleWorkerRequest(new Request(HASHED_URL), env, undefined, second.ctx);
     await second.settle();
     expect(res2.status).toBe(200);
     expect(await res2.text()).toBe('ARCHIVED-JS');
@@ -3507,7 +3515,7 @@ describe('asset archive fallback (#1330 retention)', () => {
       get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
     });
     const first = makeCtx();
-    await handleWorkerRequest(new Request(`${HASHED_URL}?json=true`), env, first.ctx);
+    await handleWorkerRequest(new Request(`${HASHED_URL}?json=true`), env, undefined, first.ctx);
     await first.settle();
     expect(getSpy).toHaveBeenCalledTimes(1);
 
@@ -3515,6 +3523,7 @@ describe('asset archive fallback (#1330 retention)', () => {
     const res2 = await handleWorkerRequest(
       new Request(`${HASHED_URL}?json=false`),
       env,
+      undefined,
       second.ctx
     );
     await second.settle();
@@ -3529,6 +3538,7 @@ describe('asset archive fallback (#1330 retention)', () => {
     const res = await handleWorkerRequest(
       new Request('https://www.sliccy.ai/assets/foo.js'),
       env,
+      undefined,
       ctx
     );
     expect(res.status).toBe(200);
@@ -3539,7 +3549,12 @@ describe('asset archive fallback (#1330 retention)', () => {
   it('falls through (no archive) for a POST to a hashed /assets path', async () => {
     const { env, getSpy } = archiveEnv({ assets: () => shell() });
     const { ctx } = makeCtx();
-    const res = await handleWorkerRequest(new Request(HASHED_URL, { method: 'POST' }), env, ctx);
+    const res = await handleWorkerRequest(
+      new Request(HASHED_URL, { method: 'POST' }),
+      env,
+      undefined,
+      ctx
+    );
     // POST is not a GET/HEAD asset request → routes index JSON, R2 untouched
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchObject({ service: 'slicc-tray-hub' });

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -27,6 +27,7 @@ import {
   FakeDurableObjectState,
   type FakeWebSocket,
 } from './fake-do-state.js';
+import { makeEnv } from './helpers/fake-env.js';
 
 class FakeDurableObjectId implements DurableObjectIdLike {
   constructor(private readonly name: string) {}
@@ -94,18 +95,18 @@ const fakeCloudSessions = {
 };
 
 function createTestHarness(start = Date.parse('2026-03-11T00:00:00.000Z')): {
-  env: {
-    TRAY_HUB: FakeNamespace;
-    ASSETS: typeof fakeAssets;
-    CLOUD_SESSIONS: typeof fakeCloudSessions;
-  };
+  env: ReturnType<typeof makeEnv>;
   advance: (ms: number) => void;
   readTray: (trayId: string) => Promise<TrayRecord | undefined>;
 } {
   let now = start;
   const namespace = new FakeNamespace(() => now);
   return {
-    env: { TRAY_HUB: namespace, ASSETS: fakeAssets, CLOUD_SESSIONS: fakeCloudSessions },
+    env: makeEnv({
+      TRAY_HUB: namespace,
+      ASSETS: fakeAssets,
+      CLOUD_SESSIONS: fakeCloudSessions,
+    }),
     advance: (ms: number) => {
       now += ms;
     },

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { TRAY_BOOTSTRAP_TIMEOUT_MS } from '@slicc/shared-ts';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import worker, {
   buildKnownGoodDmgUrl,
   capabilityCorsHeaders,
@@ -8,6 +8,7 @@ import worker, {
   handleWorkerRequest,
   parseAllowedCapabilityOrigins,
   resolveCherryFrameAncestors,
+  type WorkerEnv,
 } from '../src/index.js';
 import knownGoodMacos from '../src/known-good-macos.json';
 import { SessionTrayDurableObject } from '../src/session-tray.js';
@@ -2021,6 +2022,7 @@ describe('generic OAuth token broker', () => {
         }),
       }),
       env,
+      undefined,
       mockFetch
     );
 
@@ -2095,6 +2097,7 @@ describe('generic OAuth token broker', () => {
         body: JSON.stringify({ provider: 'github', code: 'expired-code' }),
       }),
       env,
+      undefined,
       mockFetch
     );
 
@@ -2131,6 +2134,7 @@ describe('generic OAuth token broker', () => {
         body: JSON.stringify({ provider: 'github', code: 'abc' }),
       }),
       env,
+      undefined,
       mockFetch
     );
     expect(post.headers.get('access-control-allow-origin')).toBeTruthy();
@@ -2157,6 +2161,7 @@ describe('generic OAuth token broker', () => {
         body: JSON.stringify({ provider: 'github', access_token: 'gho_token_to_revoke' }),
       }),
       env,
+      undefined,
       mockFetch
     );
 
@@ -3180,5 +3185,381 @@ describe('capability-route CORS', () => {
     );
     expect(res.status).toBe(201);
     expect(res.headers.get('access-control-allow-origin')).toBe(ALLOWED_ORIGIN);
+  });
+});
+
+describe('asset archive fallback (#1330 retention)', () => {
+  const HASHED_PATH = '/assets/anthropic-messages-DP3-Xd3J.js';
+  const HASHED_URL = `https://www.sliccy.ai${HASHED_PATH}`;
+  const ARCHIVE_KEY = 'assets/anthropic-messages-DP3-Xd3J.js';
+
+  class FakeCache {
+    readonly store = new Map<string, Response>();
+    matchCalls = 0;
+    putCalls = 0;
+    matchImpl: ((req: Request) => Promise<Response | undefined>) | null = null;
+    putImpl: ((req: Request, res: Response) => Promise<void>) | null = null;
+
+    async match(req: Request): Promise<Response | undefined> {
+      this.matchCalls++;
+      if (this.matchImpl) return this.matchImpl(req);
+      const hit = this.store.get(req.url);
+      return hit ? hit.clone() : undefined;
+    }
+
+    async put(req: Request, res: Response): Promise<void> {
+      this.putCalls++;
+      if (this.putImpl) return this.putImpl(req, res);
+      this.store.set(req.url, res.clone());
+    }
+  }
+
+  let cache: FakeCache;
+  beforeEach(() => {
+    cache = new FakeCache();
+    (globalThis as Record<string, unknown>).caches = { default: cache };
+  });
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).caches;
+  });
+
+  function makeCtx(): { ctx: ExecutionContext; settle: () => Promise<unknown> } {
+    const waited: Promise<unknown>[] = [];
+    const ctx = {
+      waitUntil: (p: Promise<unknown>) => {
+        waited.push(Promise.resolve(p));
+      },
+      passThroughOnException: () => {},
+    } as unknown as ExecutionContext;
+    return { ctx, settle: () => Promise.allSettled(waited) };
+  }
+
+  function shell(status = 200): Response {
+    return new Response(MOCK_HTML, { status, headers: { 'content-type': 'text/html' } });
+  }
+
+  interface FakeArchiveObj {
+    body: string;
+    httpEtag: string;
+    size: number;
+    uploaded: Date;
+    writeHttpMetadata: (headers: Headers) => void;
+  }
+
+  function archiveObj(
+    body: string,
+    opts: { etag?: string; contentType?: string | null; uploaded?: Date } = {}
+  ): FakeArchiveObj {
+    return {
+      body,
+      httpEtag: opts.etag ?? '"deadbeef"',
+      size: body.length,
+      uploaded: opts.uploaded ?? new Date(0),
+      writeHttpMetadata: (headers: Headers) => {
+        if (opts.contentType) headers.set('content-type', opts.contentType);
+      },
+    };
+  }
+
+  function archiveEnv(opts: {
+    assets: (req: Request) => Response | Promise<Response>;
+    get?: (key: string) => Promise<unknown>;
+  }): {
+    env: WorkerEnv;
+    assetsSpy: ReturnType<typeof vi.fn>;
+    getSpy: ReturnType<typeof vi.fn>;
+  } {
+    const assetsSpy = vi.fn((req: Request) => Promise.resolve(opts.assets(req)));
+    const getSpy = vi.fn(opts.get ?? (async () => null));
+    const env = makeEnv({
+      ASSETS: { fetch: assetsSpy },
+      ASSET_ARCHIVE: { get: getSpy } as unknown as WorkerEnv['ASSET_ARCHIVE'],
+    });
+    return { env, assetsSpy, getSpy };
+  }
+
+  it('serves a present asset unchanged from ASSETS without touching R2', async () => {
+    const { env, getSpy } = archiveEnv({
+      assets: () =>
+        new Response('console.log(1)', {
+          status: 200,
+          headers: { 'content-type': 'text/javascript' },
+        }),
+    });
+    const { ctx } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('console.log(1)');
+    // present assets are NOT wrapped by serveSPA's frame-ancestors CSP
+    expect(res.headers.get('content-security-policy')).toBeNull();
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('serves a present asset carrying Range/conditional via ASSETS, never R2', async () => {
+    const { env, getSpy, assetsSpy } = archiveEnv({
+      assets: () =>
+        new Response('body{}', { status: 200, headers: { 'content-type': 'text/css' } }),
+    });
+    const { ctx } = makeCtx();
+    const res = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/assets/index-a1b2c3d4.css', {
+        headers: { range: 'bytes=0-4', 'if-none-match': '"x"' },
+      }),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(200);
+    expect(getSpy).not.toHaveBeenCalled();
+    // one sanitized-GET classification probe + one original re-fetch (platform honors Range)
+    expect(assetsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves an archived asset on an ASSETS miss (GET) with immutable headers, no Accept-Ranges', async () => {
+    const { env, getSpy } = archiveEnv({
+      assets: () => shell(),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript', etag: '"v1"' }),
+    });
+    const { ctx, settle } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    await settle();
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ARCHIVED-JS');
+    expect(res.headers.get('content-type')).toBe('text/javascript');
+    expect(res.headers.get('etag')).toBe('"v1"');
+    expect(res.headers.get('last-modified')).toBe(new Date(0).toUTCString());
+    expect(res.headers.get('content-length')).toBe(String('ARCHIVED-JS'.length));
+    expect(res.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+    expect(res.headers.get('accept-ranges')).toBeNull();
+    // asset responses never carry serveSPA's frame-ancestors CSP
+    expect(res.headers.get('content-security-policy')).toBeNull();
+    expect(getSpy).toHaveBeenCalledWith(ARCHIVE_KEY);
+  });
+
+  it('serves an archive hit through the default NOOP execution context (2-arg call)', async () => {
+    const { env, getSpy } = archiveEnv({
+      assets: () => shell(),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
+    });
+    // No ctx argument → handleWorkerRequest defaults to NOOP_CTX; its waitUntil is
+    // a no-op so the cache.put is simply never awaited (harmless).
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ARCHIVED-JS');
+    expect(getSpy).toHaveBeenCalledWith(ARCHIVE_KEY);
+  });
+
+  it('falls back to the MIME map when the archived object has no stored content-type', async () => {
+    const { env } = archiveEnv({
+      assets: () => shell(),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: null }),
+    });
+    const { ctx, settle } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    await settle();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/javascript');
+  });
+
+  it('serves an archived HEAD hit with headers and an empty body, bypassing the edge cache', async () => {
+    const { env, getSpy } = archiveEnv({
+      assets: () => shell(),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
+    });
+    const { ctx } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL, { method: 'HEAD' }), env, ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/javascript');
+    expect(res.headers.get('content-length')).toBe(String('ARCHIVED-JS'.length));
+    expect(await res.text()).toBe('');
+    // HEAD never consults or populates the edge cache
+    expect(cache.matchCalls).toBe(0);
+    expect(cache.putCalls).toBe(0);
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores Range/conditional on a miss and serves a full 200, calling get() with no onlyIf/range', async () => {
+    const { env, getSpy } = archiveEnv({
+      assets: () => shell(),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
+    });
+    const { ctx, settle } = makeCtx();
+    const res = await handleWorkerRequest(
+      new Request(HASHED_URL, {
+        headers: {
+          range: 'bytes=0-4',
+          'if-none-match': '"x"',
+          'if-modified-since': new Date(0).toUTCString(),
+          'if-match': '"y"',
+        },
+      }),
+      env,
+      ctx
+    );
+    await settle();
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ARCHIVED-JS');
+    expect(res.headers.get('accept-ranges')).toBeNull();
+    // single positional arg — no { onlyIf } / { range } options object
+    expect(getSpy.mock.calls[0]).toEqual([ARCHIVE_KEY]);
+  });
+
+  it('falls back to the shell on an archive miss (GET → 200 text/html)', async () => {
+    const { env } = archiveEnv({ assets: () => shell(), get: async () => null });
+    const { ctx } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    expect(await res.text()).toBe(MOCK_HTML);
+  });
+
+  it('falls back to a bodyless shell on an archive miss (HEAD)', async () => {
+    const { env } = archiveEnv({ assets: () => shell(), get: async () => null });
+    const { ctx } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL, { method: 'HEAD' }), env, ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    expect(await res.text()).toBe('');
+  });
+
+  it('classifies a 404 from ASSETS as a miss and serves the archived object', async () => {
+    const { env, getSpy } = archiveEnv({
+      assets: () => new Response('nope', { status: 404 }),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
+    });
+    const { ctx, settle } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    await settle();
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ARCHIVED-JS');
+    expect(getSpy).toHaveBeenCalledWith(ARCHIVE_KEY);
+  });
+
+  it('never 500s when R2 get() throws — falls back to the shell', async () => {
+    const { env } = archiveEnv({
+      assets: () => shell(),
+      get: async () => {
+        throw new Error('R2 down');
+      },
+    });
+    const { ctx } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    expect(await res.text()).toBe(MOCK_HTML);
+  });
+
+  it('never 500s when the edge cache read throws — falls through to R2', async () => {
+    const { env, getSpy } = archiveEnv({
+      assets: () => shell(),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
+    });
+    cache.matchImpl = async () => {
+      throw new Error('cache read boom');
+    };
+    const { ctx, settle } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    await settle();
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ARCHIVED-JS');
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('never 500s when the edge cache put rejects', async () => {
+    const { env } = archiveEnv({
+      assets: () => shell(),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
+    });
+    cache.putImpl = async () => {
+      throw new Error('cache put boom');
+    };
+    const { ctx, settle } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL), env, ctx);
+    await settle();
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ARCHIVED-JS');
+  });
+
+  it('populates the edge cache on a GET and serves the second GET from cache (no second R2 read)', async () => {
+    const { env, getSpy } = archiveEnv({
+      assets: () => shell(),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
+    });
+    const first = makeCtx();
+    const res1 = await handleWorkerRequest(new Request(HASHED_URL), env, first.ctx);
+    await first.settle();
+    expect(res1.status).toBe(200);
+    expect(await res1.text()).toBe('ARCHIVED-JS');
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(cache.putCalls).toBe(1);
+
+    const second = makeCtx();
+    const res2 = await handleWorkerRequest(new Request(HASHED_URL), env, second.ctx);
+    await second.settle();
+    expect(res2.status).toBe(200);
+    expect(await res2.text()).toBe('ARCHIVED-JS');
+    // the second GET is an edge-cache hit — R2 is not consulted again
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches under a canonical key that ignores the query string', async () => {
+    const { env, getSpy } = archiveEnv({
+      assets: () => shell(),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
+    });
+    const first = makeCtx();
+    await handleWorkerRequest(new Request(`${HASHED_URL}?json=true`), env, first.ctx);
+    await first.settle();
+    expect(getSpy).toHaveBeenCalledTimes(1);
+
+    const second = makeCtx();
+    const res2 = await handleWorkerRequest(
+      new Request(`${HASHED_URL}?json=false`),
+      env,
+      second.ctx
+    );
+    await second.settle();
+    expect(await res2.text()).toBe('ARCHIVED-JS');
+    // canonical cache key (query dropped) → hit despite different query string
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through (no archive) for a non-hashed /assets path', async () => {
+    const { env, getSpy } = archiveEnv({ assets: () => shell() });
+    const { ctx } = makeCtx();
+    const res = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/assets/foo.js'),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls through (no archive) for a POST to a hashed /assets path', async () => {
+    const { env, getSpy } = archiveEnv({ assets: () => shell() });
+    const { ctx } = makeCtx();
+    const res = await handleWorkerRequest(new Request(HASHED_URL, { method: 'POST' }), env, ctx);
+    // POST is not a GET/HEAD asset request → routes index JSON, R2 untouched
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ service: 'slicc-tray-hub' });
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('archived responses pass through the outer applySliccLinks wrapper (worker.fetch)', async () => {
+    const { env } = archiveEnv({
+      assets: () => shell(),
+      get: async () => archiveObj('ARCHIVED-JS', { contentType: 'text/javascript' }),
+    });
+    const { ctx, settle } = makeCtx();
+    const res = await worker.fetch(new Request(HASHED_URL), env, ctx);
+    await settle();
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ARCHIVED-JS');
+    expect(res.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+    expect(res.headers.get('x-robots-tag')).toBe('noindex');
+    expect(res.headers.get('link') ?? '').toContain('rel=');
+    // still no SPA frame-ancestors CSP on an asset
+    expect(res.headers.get('content-security-policy')).toBeNull();
   });
 });

--- a/packages/cloudflare-worker/tests/preview-bridge-harness.ts
+++ b/packages/cloudflare-worker/tests/preview-bridge-harness.ts
@@ -14,6 +14,7 @@ import {
   FakeDurableObjectState,
   type FakeWebSocket,
 } from './fake-do-state.js';
+import { makeEnv } from './helpers/fake-env.js';
 
 // ──────────────────────────────────────────────────────────────────────────
 // Test environment setup (mirrors session-tray-preview.test.ts)
@@ -74,12 +75,12 @@ const fakeCloudSessions = {
 function createTestEnv() {
   const namespace = new FakeNamespace();
   return {
-    env: {
+    env: makeEnv({
       // biome-ignore lint/suspicious/noExplicitAny: Test env type is complex and not fully typed
       TRAY_HUB: namespace as unknown as any,
       ASSETS: fakeAssets,
       CLOUD_SESSIONS: fakeCloudSessions,
-    },
+    }),
     namespace,
   };
 }

--- a/packages/cloudflare-worker/tests/preview-inject.test.ts
+++ b/packages/cloudflare-worker/tests/preview-inject.test.ts
@@ -3,6 +3,7 @@ import { handleWorkerRequest } from '../src/index.js';
 import { injectBridge } from '../src/preview-bridge-routes.js';
 import { SessionTrayDurableObject } from '../src/session-tray.js';
 import type { DurableObjectIdLike, DurableObjectStateLike } from '../src/shared.js';
+import { makeEnv } from './helpers/fake-env.js';
 
 // Minimal fake infrastructure to test preview injection
 
@@ -147,11 +148,11 @@ const fakeCloudSessions = {
 function createTestHarness() {
   const namespace = new FakeNamespace();
   return {
-    env: {
+    env: makeEnv({
       TRAY_HUB: namespace as unknown as Parameters<typeof handleWorkerRequest>[1]['TRAY_HUB'],
       ASSETS: fakeAssets,
       CLOUD_SESSIONS: fakeCloudSessions,
-    } as unknown as Parameters<typeof handleWorkerRequest>[1],
+    }),
     namespace,
   };
 }

--- a/packages/cloudflare-worker/tests/session-tray-preview.test.ts
+++ b/packages/cloudflare-worker/tests/session-tray-preview.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { handleWorkerRequest } from '../src/index.js';
 import { SessionTrayDurableObject } from '../src/session-tray.js';
 import type { DurableObjectIdLike, DurableObjectStateLike } from '../src/shared.js';
+import { makeEnv } from './helpers/fake-env.js';
 
 class FakeStorage {
   private readonly data = new Map<string, unknown>();
@@ -164,11 +165,11 @@ const fakeCloudSessions = {
 function createTestHarness() {
   const namespace = new FakeNamespace();
   return {
-    env: {
+    env: makeEnv({
       TRAY_HUB: namespace as unknown as Parameters<typeof handleWorkerRequest>[1]['TRAY_HUB'],
       ASSETS: fakeAssets,
       CLOUD_SESSIONS: fakeCloudSessions,
-    } as unknown as Parameters<typeof handleWorkerRequest>[1],
+    }),
     namespace,
   };
 }

--- a/packages/cloudflare-worker/tests/upload-assets-to-r2.test.ts
+++ b/packages/cloudflare-worker/tests/upload-assets-to-r2.test.ts
@@ -32,7 +32,7 @@ describe('buildPutArgs', () => {
     const bucket = 'slicc-asset-archive';
     const file = 'index-a1b2c3d4.css';
 
-    const args = buildPutArgs(bucket, file);
+    const args = buildPutArgs(bucket, file, 'dist/ui/assets');
 
     expect(args).toEqual([
       'wrangler',
@@ -41,16 +41,18 @@ describe('buildPutArgs', () => {
       'put',
       'slicc-asset-archive/assets/index-a1b2c3d4.css',
       '--file',
-      'index-a1b2c3d4.css',
+      'dist/ui/assets/index-a1b2c3d4.css',
       '--content-type',
       'text/css',
+      '--remote',
     ]);
   });
 
   it('handles .js files', () => {
-    const args = buildPutArgs('bucket', 'app-abc1234d.js');
+    const args = buildPutArgs('bucket', 'app-abc1234d.js', 'dist/ui/assets');
     expect(args).toContain('--content-type');
     expect(args).toContain('text/javascript');
+    expect(args).toContain('--remote'); // required — wrangler r2 put defaults to local
   });
 
   it('handles .wasm files', () => {
@@ -79,9 +81,10 @@ describe('runUploads', () => {
       'put',
       'test-bucket/assets/index-a1b2c3d4.css',
       '--file',
-      'index-a1b2c3d4.css',
+      '/assets/index-a1b2c3d4.css',
       '--content-type',
       'text/css',
+      '--remote',
     ]);
   });
 

--- a/packages/cloudflare-worker/tests/upload-assets-to-r2.test.ts
+++ b/packages/cloudflare-worker/tests/upload-assets-to-r2.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+import { assertAllHashed, buildPutArgs, runUploads } from '../scripts/upload-lib.mjs';
+
+describe('assertAllHashed', () => {
+  it('passes when all names are hashed', () => {
+    const names = [
+      'anthropic-messages-DP3-Xd3J.js',
+      'index-a1b2c3d4.css',
+      'entry-abcd1234.js.map',
+      'logo-DEADBEEF.svg',
+    ];
+    expect(() => assertAllHashed(names)).not.toThrow();
+  });
+
+  it('throws when a name lacks a hash', () => {
+    const names = [
+      'anthropic-messages-DP3-Xd3J.js',
+      'index.html', // no hash
+      'entry-abcd1234.js.map',
+    ];
+    expect(() => assertAllHashed(names)).toThrow();
+  });
+
+  it('throws when any name is unhashed', () => {
+    const names = ['foo.js']; // no hash
+    expect(() => assertAllHashed(names)).toThrow();
+  });
+});
+
+describe('buildPutArgs', () => {
+  it('yields the correct argv for wrangler r2 object put', () => {
+    const bucket = 'slicc-asset-archive';
+    const file = 'index-a1b2c3d4.css';
+
+    const args = buildPutArgs(bucket, file);
+
+    expect(args).toEqual([
+      'wrangler',
+      'r2',
+      'object',
+      'put',
+      'slicc-asset-archive/assets/index-a1b2c3d4.css',
+      '--file',
+      'index-a1b2c3d4.css',
+      '--content-type',
+      'text/css',
+    ]);
+  });
+
+  it('handles .js files', () => {
+    const args = buildPutArgs('bucket', 'app-abc1234d.js');
+    expect(args).toContain('--content-type');
+    expect(args).toContain('text/javascript');
+  });
+
+  it('handles .wasm files', () => {
+    const args = buildPutArgs('bucket', 'module-xyz78901.wasm');
+    expect(args).toContain('--content-type');
+    expect(args).toContain('application/wasm');
+  });
+});
+
+describe('runUploads', () => {
+  it('calls exec for each file with the correct args', async () => {
+    const execMock = vi.fn().mockResolvedValue(undefined);
+    const files = ['index-a1b2c3d4.css', 'app-def2g5h6.js'];
+
+    await runUploads(files, {
+      bucket: 'test-bucket',
+      dir: '/assets',
+      exec: execMock,
+    });
+
+    expect(execMock).toHaveBeenCalledTimes(2);
+    expect(execMock).toHaveBeenNthCalledWith(1, [
+      'wrangler',
+      'r2',
+      'object',
+      'put',
+      'test-bucket/assets/index-a1b2c3d4.css',
+      '--file',
+      'index-a1b2c3d4.css',
+      '--content-type',
+      'text/css',
+    ]);
+  });
+
+  it('respects concurrency cap', async () => {
+    const execMock = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        })
+    );
+    const files = Array.from({ length: 10 }, (_, i) => `file${i}-abc123def${i}.js`);
+
+    const start = Date.now();
+    await runUploads(files, {
+      bucket: 'test-bucket',
+      dir: '/assets',
+      exec: execMock,
+      concurrency: 2,
+    });
+    const elapsed = Date.now() - start;
+
+    // 10 files at 2 concurrent = 5 batches × 10ms ≥ 50ms
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+    expect(execMock).toHaveBeenCalledTimes(10);
+  });
+
+  it('retries on exec failure', async () => {
+    let callCount = 0;
+    const execMock = vi.fn(async () => {
+      callCount++;
+      if (callCount < 3) {
+        throw new Error('Temporary failure');
+      }
+    });
+    const files = ['file-abc12345.js'];
+
+    await runUploads(files, {
+      bucket: 'test-bucket',
+      dir: '/assets',
+      exec: execMock,
+      retries: 3,
+    });
+
+    expect(execMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws after max retries exceeded', async () => {
+    const execMock = vi.fn().mockRejectedValue(new Error('Always fails'));
+    const files = ['file-abc12345.js'];
+
+    await expect(
+      runUploads(files, {
+        bucket: 'test-bucket',
+        dir: '/assets',
+        exec: execMock,
+        retries: 2,
+      })
+    ).rejects.toThrow('Always fails');
+
+    expect(execMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-puts every file (no skip)', async () => {
+    const execMock = vi.fn().mockResolvedValue(undefined);
+    const files = ['a-abc12345.js', 'b-def67890.css', 'c-ghi11121.wasm'];
+
+    await runUploads(files, {
+      bucket: 'test-bucket',
+      dir: '/assets',
+      exec: execMock,
+    });
+
+    expect(execMock).toHaveBeenCalledTimes(3);
+    // Verify all files were uploaded (in order)
+    const fileArgs = execMock.mock.calls.map((call) => call[0][4]); // the objectPath arg
+    expect(fileArgs).toEqual([
+      'test-bucket/assets/a-abc12345.js',
+      'test-bucket/assets/b-def67890.css',
+      'test-bucket/assets/c-ghi11121.wasm',
+    ]);
+  });
+
+  it('throws on hash invariant violation', async () => {
+    const execMock = vi.fn();
+    const files = ['unhashed.js', 'valid-abc12345.js'];
+
+    await expect(
+      runUploads(files, {
+        bucket: 'test-bucket',
+        dir: '/assets',
+        exec: execMock,
+      })
+    ).rejects.toThrow();
+
+    expect(execMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloudflare-worker/wrangler.jsonc
+++ b/packages/cloudflare-worker/wrangler.jsonc
@@ -11,6 +11,7 @@
     "run_worker_first": true,
     "not_found_handling": "single-page-application"
   },
+  "r2_buckets": [{ "binding": "ASSET_ARCHIVE", "bucket_name": "slicc-asset-archive" }],
   "routes": [
     { "pattern": "www.sliccy.ai/*", "zone_name": "sliccy.ai" },
     { "pattern": "sliccy.ai/*", "zone_name": "sliccy.ai" }
@@ -72,6 +73,7 @@
         "run_worker_first": true,
         "not_found_handling": "single-page-application"
       },
+      "r2_buckets": [{ "binding": "ASSET_ARCHIVE", "bucket_name": "slicc-asset-archive-staging" }],
       "routes": [],
       "vars": {
         "CLOUDFLARE_TURN_KEY_ID": "6c2201a0453bd6695ecb24a00b2b6ed1",


### PR DESCRIPTION
Root-cause follow-up to #1330 / PR #1364. Instead of the reactive page **reload** (which can't save an in-flight cone cycle and risks mixed-release UI), keep every content-hashed `/assets/*` chunk in a per-env **R2 bucket** so a long-lived tab keeps fetching its own build's chunks after a deploy — no crash, no reload.

## ⚠️ Blocked on ops — CI is expected to be RED until the buckets exist

This PR is **safe to open and review while red**, and **cannot merge until ops is done** (which is exactly the gate we want):

- The only red is the hard-fail **"Archive assets to R2 (staging)"** step, which needs the buckets + token. It runs *before* the staging deploy, so on failure the job stops there — **no deploy runs, nothing in staging/prod changes.**
- The prod release only runs on merge; a red PR can't merge, so the `r2_buckets` binding can't reach the prod release deploy until the buckets exist.
- Once ops completes the steps below and CI re-runs: the upload succeeds → staging deploys → CI goes green → mergeable, and the eventual prod release deploys cleanly.

## Ops steps (require Cloudflare admin on the AEM Demo account)

1. Create both buckets: `wrangler r2 bucket create slicc-asset-archive` and `… -staging`.
2. Apply the 14-day lifecycle to each: `wrangler r2 bucket lifecycle add <bucket> retention-14d --expire-days 14`.
3. Grant the deploy `CLOUDFLARE_API_TOKEN` **R2 Object Read & Write** on **both** buckets (CI uses staging; the release uses prod).

Full runbook is in `packages/cloudflare-worker/CLAUDE.md` (Ops Runbook section).

## What it does

- **Serving** (`serveAssetWithArchiveFallback`, `src/index.ts`): ASSETS-first; on a hashed-`/assets/*` miss (ASSETS returns the SPA shell), serve the archived bytes from R2 with an immutable `Cache-Control`; on any R2 miss/error, fall back to the shell (the shipped #1364 reload) — **never 500s, safe even before the bucket exists**. Conditional (304/412) and Range (206) are intentionally not implemented (immutable content-hashed chunks); full `200`/bodyless `HEAD`.
- **Upload** (`scripts/upload-*.mjs`): re-puts the full current asset set to the bucket before every deploy (`--remote`, hash-invariant asserted, bounded concurrency + retries), wired into all four deploy paths (publish-worker.sh, worker.yml, ci.yml, worker-staging.yml).
- **GC**: 14-day age-based lifecycle (option A). Fully covers the observed vendor-chunk crash; build-unique lazy chunks past the window fall back to the reload. Option B (manifest-touch, full coverage) is documented as an additive future upgrade — no re-spec needed.
- Tests: worker unit (present/miss/HEAD/cache/never-500/gate) + a **staging-only** deployed archive smoke; **384 worker tests pass**, coverage ≥ floor.

Built spec → plan → codex/cursor review loops → subagent-driven implementation; final whole-branch review "Ready to merge: Yes". Rebased onto current `main`. (Spec/plan commits under `docs/superpowers/` are kept per convention — the release scrubs them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
