### PR TITLE
fix(realm): make sliccy:exec coherent with the sync-fs cache within a script

### DIFF
--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -652,30 +652,57 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     var initialIsDirectory = new Map();
     var truncatedPaths = new Set();
     var mkdtempCounter = 0;
+    // True once any sync-fs method was invoked — gates the exec bridge's
+    // flush-before / re-snapshot-after coherence so exec-only / async-only
+    // scripts keep the fast path. Mirror of sync-fs-cache.ts's `touched`.
+    var touched = false;
 
-    tree.set('/', { content: new Uint8Array(0), isDirectory: true });
-    initialPaths.add('/');
-    initialIsDirectory.set('/', true);
-
-    var entries = (snapshot && snapshot.entries) || [];
-    for (var i = 0; i < entries.length; i++) {
-      var entry = entries[i];
-      var normalized = syncFsNormalizePath(entry.path);
-      tree.set(normalized, { content: entry.content, isDirectory: entry.isDirectory, truncated: entry.truncated });
-      initialPaths.add(normalized);
-      initialIsDirectory.set(normalized, entry.isDirectory);
-      if (!entry.isDirectory) initialContent.set(normalized, entry.content);
-      if (entry.truncated) truncatedPaths.add(normalized);
-    }
-    // Synthesize implied ancestor directories not explicitly in the snapshot.
-    for (var j = 0; j < entries.length; j++) {
-      var dir = syncFsDirname(syncFsNormalizePath(entries[j].path));
-      while (dir !== '/' && !tree.has(dir)) {
-        tree.set(dir, { content: new Uint8Array(0), isDirectory: true });
-        initialPaths.add(dir);
-        initialIsDirectory.set(dir, true);
-        dir = syncFsDirname(dir);
+    // (Re)build the tree + mutation baseline from a host snapshot. Runs at
+    // boot AND from `applySnapshot` after an exec re-snapshot, so the post-exec
+    // host state becomes the new baseline. Mirror of sync-fs-cache.ts.
+    function loadSnapshot(snap) {
+      tree = new Map();
+      initialPaths = new Set();
+      initialContent = new Map();
+      initialIsDirectory = new Map();
+      truncatedPaths = new Set();
+      tree.set('/', { content: new Uint8Array(0), isDirectory: true });
+      initialPaths.add('/');
+      initialIsDirectory.set('/', true);
+      var entries = (snap && snap.entries) || [];
+      for (var i = 0; i < entries.length; i++) {
+        var entry = entries[i];
+        var normalized = syncFsNormalizePath(entry.path);
+        tree.set(normalized, { content: entry.content, isDirectory: entry.isDirectory, truncated: entry.truncated });
+        initialPaths.add(normalized);
+        initialIsDirectory.set(normalized, entry.isDirectory);
+        if (!entry.isDirectory) initialContent.set(normalized, entry.content);
+        if (entry.truncated) truncatedPaths.add(normalized);
       }
+      // Synthesize implied ancestor directories not explicitly in the snapshot.
+      for (var j = 0; j < entries.length; j++) {
+        var dir = syncFsDirname(syncFsNormalizePath(entries[j].path));
+        while (dir !== '/' && !tree.has(dir)) {
+          tree.set(dir, { content: new Uint8Array(0), isDirectory: true });
+          initialPaths.add(dir);
+          initialIsDirectory.set(dir, true);
+          dir = syncFsDirname(dir);
+        }
+      }
+    }
+    loadSnapshot(snapshot);
+
+    // Snapshot the CURRENT tree as the new mutation baseline (after a mid-script
+    // flush) so already-flushed writes aren't re-applied. Mirror of resetBaseline.
+    function resetBaseline() {
+      initialPaths = new Set();
+      initialContent = new Map();
+      initialIsDirectory = new Map();
+      tree.forEach(function (entry, path) {
+        initialPaths.add(path);
+        initialIsDirectory.set(path, entry.isDirectory);
+        if (!entry.isDirectory) initialContent.set(path, entry.content);
+      });
     }
 
     function ensureParentDirs(path) {
@@ -685,6 +712,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
 
     function readFile(path) {
+      touched = true;
       var normalized = syncFsNormalizePath(path);
       var entry = tree.get(normalized);
       if (!entry || entry.isDirectory) throw syncFsEnoent(normalized);
@@ -693,16 +721,19 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
 
     function writeFile(path, content) {
+      touched = true;
       var normalized = syncFsNormalizePath(path);
       ensureParentDirs(normalized);
       tree.set(normalized, { content: content, isDirectory: false });
     }
 
     function existsFn(path) {
+      touched = true;
       return tree.has(syncFsNormalizePath(path));
     }
 
     function stat(path) {
+      touched = true;
       var normalized = syncFsNormalizePath(path);
       var entry = tree.get(normalized);
       if (!entry) throw syncFsEnoent(normalized);
@@ -714,6 +745,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
 
     function readdir(path) {
+      touched = true;
       var normalized = syncFsNormalizePath(path);
       var entry = tree.get(normalized);
       if (!entry || !entry.isDirectory) throw syncFsEnoent(normalized);
@@ -730,6 +762,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
 
     function mkdir(path, recursive) {
+      touched = true;
       var normalized = syncFsNormalizePath(path);
       if (tree.has(normalized)) {
         var existing = tree.get(normalized);
@@ -747,6 +780,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
 
     function rm(path, recursive) {
+      touched = true;
       var normalized = syncFsNormalizePath(path);
       var entry = tree.get(normalized);
       if (!entry) throw syncFsEnoent(normalized);
@@ -767,6 +801,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
 
     function copyFile(src, dest) {
+      touched = true;
       var normalizedSrc = syncFsNormalizePath(src);
       var entry = tree.get(normalizedSrc);
       if (!entry || entry.isDirectory) throw syncFsEnoent(normalizedSrc);
@@ -776,6 +811,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
 
     function rename(oldPath, newPath) {
+      touched = true;
       var normalizedOld = syncFsNormalizePath(oldPath);
       var entry = tree.get(normalizedOld);
       if (!entry) throw syncFsEnoent(normalizedOld);
@@ -806,6 +842,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
 
     function unlink(path) {
+      touched = true;
       var normalized = syncFsNormalizePath(path);
       var entry = tree.get(normalized);
       if (!entry) throw syncFsEnoent(normalized);
@@ -818,6 +855,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
 
     function mkdtemp(prefix) {
+      touched = true;
       for (var attempt = 0; attempt < 100; attempt++) {
         var suffix = '_' + String(mkdtempCounter).padStart(6, '0');
         mkdtempCounter++;
@@ -878,6 +916,9 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       unlink: unlink,
       mkdtemp: mkdtemp,
       getMutations: getMutations,
+      wasUsed: function () { return touched; },
+      applySnapshot: function (snap) { loadSnapshot(snap); },
+      resetBaseline: resetBaseline,
     };
   }
 
@@ -960,11 +1001,42 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     };
   }
 
+  // Sync-fs ↔ exec coherence (mirror of createExecBridge in js-realm-shared.ts).
+  // `syncFsForExec` is wired below once the sync-fs cache is built, before user
+  // code runs. FLUSH pending sync mutations to the host BEFORE an exec so the
+  // shell sees `writeFileSync` writes; RE-SNAPSHOT AFTER so a later
+  // `readFileSync` sees the exec's writes. Both are gated on the sync-fs API
+  // actually being used, so exec-only / async-only scripts keep the fast path.
+  let syncFsForExec = null;
+  const flushBeforeExec = async () => {
+    if (!syncFsForExec || !syncFsForExec.wasUsed()) return;
+    const mutations = syncFsForExec.getMutations();
+    if (mutations.created.length || mutations.modified.length || mutations.deleted.length) {
+      await rpcCall('vfs', 'flushWrites', [mutations]);
+    }
+    syncFsForExec.resetBaseline();
+  };
+  const resnapshotAfterExec = async () => {
+    if (!syncFsForExec || !syncFsForExec.wasUsed()) return;
+    try {
+      const snap = await rpcCall('vfs', 'snapshot', [init.cwd]);
+      syncFsForExec.applySnapshot(snap);
+    } catch (e) { /* keep the pre-exec view on snapshot failure */ }
+  };
+
   // exec(string) parses through the shell; exec.spawn(argv[]) is the
   // shell-free variant — mirrors child_process.spawn(cmd, args). Same
   // surface as the worker realm (`js-realm-shared.ts`).
-  const execBridge = (cmd) => rpcCall('exec', 'run', [cmd]);
-  execBridge.spawn = (argv) => rpcCall('exec', 'spawn', [argv]);
+  const execBridge = async (cmd) => {
+    await flushBeforeExec();
+    try { return await rpcCall('exec', 'run', [cmd]); }
+    finally { await resnapshotAfterExec(); }
+  };
+  execBridge.spawn = async (argv) => {
+    await flushBeforeExec();
+    try { return await rpcCall('exec', 'spawn', [argv]); }
+    finally { await resnapshotAfterExec(); }
+  };
   // `exec.start(commandOrArgv, opts?)` — deferred-start, buffered-stdin,
   // killable spawn handle. Mirror of the `start` closure in `createExecBridge`
   // (`js-realm-shared.ts`): `stdin.write` buffers, `stdin.end()` launches the
@@ -995,7 +1067,18 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       if (buffered !== undefined) startOpts.stdin = buffered;
       if (opts && opts.stdinKind !== undefined) startOpts.stdinKind = opts.stdinKind;
       if (opts && opts.args !== undefined) startOpts.args = opts.args;
-      rpcCall('exec', 'start', [spawnId, commandOrArgv, startOpts]).then(resolveDone, rejectDone);
+      // Flush-before / re-snapshot-after wrap the killable spawn too.
+      (async () => {
+        try {
+          await flushBeforeExec();
+          const result = await rpcCall('exec', 'start', [spawnId, commandOrArgv, startOpts]);
+          await resnapshotAfterExec();
+          resolveDone(result);
+        } catch (err) {
+          await resnapshotAfterExec();
+          rejectDone(err);
+        }
+      })();
     };
     return {
       kill: (sig) => {
@@ -2637,6 +2720,9 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   // require('fs') call the entry code makes).
   const syncFs = await initSyncFsCache(init.cwd);
   Object.assign(fsBridge, createSyncFsBridge(syncFs, init.cwd));
+  // Wire the exec bridge's coherence to this cache (see flushBeforeExec /
+  // resnapshotAfterExec above). Set before user code runs.
+  syncFsForExec = syncFs;
 
   let exitCode = 0;
   try {

--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -711,6 +711,42 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       if (!tree.has(dir)) mkdir(dir, true);
     }
 
+    // Re-snapshot from the host WITHOUT discarding sync mutations made since
+    // the last baseline reset. Mirror of sync-fs-cache.ts's
+    // applySnapshotPreservingMutations — used by the exec bridge's `start`
+    // (killable spawn) path, where user code keeps running while the spawn is
+    // in flight so a sync write in that window lives only in this cache.
+    function applySnapshotPreservingMutations(snap) {
+      var pending = getMutations();
+      loadSnapshot(snap);
+      // Deletions first: a sync rm/unlink must not be resurrected by the fresh
+      // host baseline.
+      for (var d = 0; d < pending.deleted.length; d++) {
+        var dpath = pending.deleted[d];
+        var dentry = tree.get(dpath);
+        if (dentry && dentry.isDirectory) {
+          var dprefix = dpath === '/' ? '/' : dpath + '/';
+          var kids = [];
+          tree.forEach(function (_v, p) {
+            if (p !== dpath && p.indexOf(dprefix) === 0) kids.push(p);
+          });
+          for (var k = 0; k < kids.length; k++) tree.delete(kids[k]);
+        }
+        tree.delete(dpath);
+      }
+      // Then re-layer creates + modifies so sync writes win for their paths.
+      for (var c = 0; c < pending.created.length; c++) {
+        var cm = pending.created[c];
+        ensureParentDirs(cm.path);
+        tree.set(cm.path, { content: cm.content, isDirectory: cm.isDirectory });
+      }
+      for (var m = 0; m < pending.modified.length; m++) {
+        var mm = pending.modified[m];
+        ensureParentDirs(mm.path);
+        tree.set(mm.path, { content: mm.content, isDirectory: false });
+      }
+    }
+
     function readFile(path) {
       touched = true;
       var normalized = syncFsNormalizePath(path);
@@ -918,6 +954,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       getMutations: getMutations,
       wasUsed: function () { return touched; },
       applySnapshot: function (snap) { loadSnapshot(snap); },
+      applySnapshotPreservingMutations: applySnapshotPreservingMutations,
       resetBaseline: resetBaseline,
     };
   }
@@ -1016,11 +1053,17 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     }
     syncFsForExec.resetBaseline();
   };
-  const resnapshotAfterExec = async () => {
+  // `preserveMutations` is set by the `start` (killable spawn) path, where user
+  // code keeps running during the background spawn: sync writes made in that
+  // window live only in the cache and must survive the re-snapshot. `run`/
+  // `spawn` suspend user code across the await, so the plain (discard)
+  // applySnapshot is correct for them. Mirror of js-realm-shared.ts.
+  const resnapshotAfterExec = async (preserveMutations) => {
     if (!syncFsForExec || !syncFsForExec.wasUsed()) return;
     try {
       const snap = await rpcCall('vfs', 'snapshot', [init.cwd]);
-      syncFsForExec.applySnapshot(snap);
+      if (preserveMutations) syncFsForExec.applySnapshotPreservingMutations(snap);
+      else syncFsForExec.applySnapshot(snap);
     } catch (e) { /* keep the pre-exec view on snapshot failure */ }
   };
 
@@ -1051,6 +1094,11 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     const spawnId = __nextSpawnId++;
     const chunks = [];
     let started = false;
+    // Re-entrancy guard: `fire()` is async (it awaits `flushBeforeExec()`
+    // before the host learns the spawnId), so a second `stdin.end()` — or a
+    // `kill()` racing the flush window — must not double-launch. `started`
+    // flips only AFTER the flush, so it can't cover this window on its own.
+    let firing = false;
     // A `kill()` before `stdin.end()` can't reach the host (the spawnId isn't
     // registered until `exec:start` arrives), so honor it client-side.
     let killed = false;
@@ -1059,7 +1107,9 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
     const fire = () => {
       // A pre-start `kill()` wins: never launch a spawn that was already killed.
       if (started || killed) return;
-      started = true;
+      // Already launching (flush in flight): don't dispatch `exec:start` twice.
+      if (firing) return;
+      firing = true;
       // Buffered `stdin.write` chunks win; fall back to an upfront `opts.stdin`.
       // `undefined` means "no stdin" (empty on the host).
       const buffered = chunks.length > 0 ? chunks.join('') : (opts && opts.stdin);
@@ -1067,15 +1117,27 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       if (buffered !== undefined) startOpts.stdin = buffered;
       if (opts && opts.stdinKind !== undefined) startOpts.stdinKind = opts.stdinKind;
       if (opts && opts.args !== undefined) startOpts.args = opts.args;
-      // Flush-before / re-snapshot-after wrap the killable spawn too.
+      // Flush-before / re-snapshot-after wrap the killable spawn too. The
+      // re-snapshot PRESERVES sync writes made while the spawn was in flight
+      // (user code kept running) — see resnapshotAfterExec.
       (async () => {
         try {
           await flushBeforeExec();
+          // A `kill()` arrived during the flush window: the host never received
+          // `exec:start` (spawnId still unregistered), so keep the command
+          // client-side and never dispatch it. `kill()` already resolved `done`.
+          if (killed) {
+            await resnapshotAfterExec(true);
+            return;
+          }
+          // Only now is the host about to register the spawnId, so a later
+          // `kill()` can safely fan out over `exec:kill`.
+          started = true;
           const result = await rpcCall('exec', 'start', [spawnId, commandOrArgv, startOpts]);
-          await resnapshotAfterExec();
+          await resnapshotAfterExec(true);
           resolveDone(result);
         } catch (err) {
-          await resnapshotAfterExec();
+          await resnapshotAfterExec(true);
           rejectDone(err);
         }
       })();
@@ -1084,9 +1146,10 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
       kill: (sig) => {
         // Post-start: the host knows the spawnId, so fan the signal out.
         if (started) return rpcCall('exec', 'kill', [spawnId, sig]);
-        // Pre-start: an `exec:kill` would race ahead of `exec:start` and be
-        // dropped, then `fire()` would still launch. Honor it client-side —
-        // mark killed so `fire()` no-ops and resolve `done` as terminated.
+        // Pre-start OR firing-but-not-yet-registered: an `exec:kill` would race
+        // ahead of `exec:start` and be dropped, then `fire()` would still
+        // launch. Honor it client-side — mark killed so `fire()` aborts the
+        // dispatch and resolve `done` as terminated.
         killed = true;
         resolveDone({ stdout: '', stderr: '', exitCode: __killExitCode(sig) });
         return Promise.resolve(true);

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -475,12 +475,18 @@ export function createExecBridge(
 
   // RE-SNAPSHOT-after: pull fresh host state so a later `readFileSync` sees
   // what the exec wrote. Same perf gate. A snapshot failure leaves the cache
-  // as-is rather than crashing the script.
-  const resnapshotAfterExec = async (): Promise<void> => {
+  // as-is rather than crashing the script. `preserveMutations` is set by the
+  // `start` (killable spawn) path, where user code keeps running during the
+  // background spawn: sync writes made in that window live only in the cache
+  // and must survive the re-snapshot (see `applySnapshotPreservingMutations`).
+  // `run`/`spawn` suspend user code across the await, so no interleaving and
+  // the plain `applySnapshot` (discard) is correct for them.
+  const resnapshotAfterExec = async (preserveMutations = false): Promise<void> => {
     if (!syncFs?.wasUsed()) return;
     try {
       const snapshot = await rpc.call<SyncFsSnapshot>('vfs', 'snapshot', [cwd]);
-      syncFs.applySnapshot(snapshot);
+      if (preserveMutations) syncFs.applySnapshotPreservingMutations(snapshot);
+      else syncFs.applySnapshot(snapshot);
     } catch {
       /* keep the pre-exec view on snapshot failure */
     }
@@ -512,6 +518,11 @@ export function createExecBridge(
     const spawnId = nextSpawnId++;
     const chunks: string[] = [];
     let started = false;
+    // Re-entrancy guard: `fire()` is async (it awaits `flushBeforeExec()`
+    // before the host learns the spawnId), so a second `stdin.end()` — or a
+    // `kill()` racing the flush window — must not double-launch. `started`
+    // flips only AFTER the flush, so it can't cover this window on its own.
+    let firing = false;
     // A `kill()` before `stdin.end()` can't reach the host (the spawnId
     // isn't registered until `exec:start` arrives), so honor it client-side.
     let killed = false;
@@ -524,7 +535,9 @@ export function createExecBridge(
     const fire = (): void => {
       // A pre-start `kill()` wins: never launch a spawn that was already killed.
       if (started || killed) return;
-      started = true;
+      // Already launching (flush in flight): don't dispatch `exec:start` twice.
+      if (firing) return;
+      firing = true;
       // Buffered `stdin.write` chunks win; fall back to an upfront
       // `opts.stdin`. `undefined` means "no stdin" (empty on the host).
       const buffered = chunks.length > 0 ? chunks.join('') : opts?.stdin;
@@ -534,18 +547,31 @@ export function createExecBridge(
       if (opts?.args !== undefined) startOpts.args = opts.args;
       // Flush-before / re-snapshot-after wrap the killable spawn too: flush
       // before the `exec:start` dispatch, re-snapshot after `done` resolves.
+      // The re-snapshot PRESERVES sync writes made while the spawn was in
+      // flight (user code kept running) — see resnapshotAfterExec.
       void (async () => {
         try {
           await flushBeforeExec();
+          // A `kill()` arrived during the flush window: the host never
+          // received `exec:start` (spawnId still unregistered), so keep the
+          // command client-side and never dispatch it. `kill()` already
+          // resolved `done` as terminated.
+          if (killed) {
+            await resnapshotAfterExec(true);
+            return;
+          }
+          // Only now is the host about to register the spawnId, so a later
+          // `kill()` can safely fan out over `exec:kill`.
+          started = true;
           const result = await rpc.call<ExecResult>('exec', 'start', [
             spawnId,
             commandOrArgv,
             startOpts,
           ]);
-          await resnapshotAfterExec();
+          await resnapshotAfterExec(true);
           resolveDone(result);
         } catch (err: unknown) {
-          await resnapshotAfterExec();
+          await resnapshotAfterExec(true);
           rejectDone(err);
         }
       })();
@@ -554,10 +580,10 @@ export function createExecBridge(
       kill: (sig?: string): Promise<boolean> => {
         // Post-start: the host knows the spawnId, so fan the signal out.
         if (started) return rpc.call('exec', 'kill', [spawnId, sig]);
-        // Pre-start: an `exec:kill` would race ahead of `exec:start` and be
-        // dropped by the host, then `fire()` would still launch. Honor it
-        // client-side — mark killed so `fire()` no-ops and resolve `done`
-        // as terminated.
+        // Pre-start OR firing-but-not-yet-registered: an `exec:kill` would
+        // race ahead of `exec:start` and be dropped by the host, then
+        // `fire()` would still launch. Honor it client-side — mark killed so
+        // `fire()` aborts the dispatch and resolve `done` as terminated.
         killed = true;
         resolveDone({ stdout: '', stderr: '', exitCode: killExitCode(sig) });
         return Promise.resolve(true);

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -176,7 +176,7 @@ export async function runJsRealm(init: RealmInitMsg, port: RealmPortLike): Promi
   const syncFs = await initSyncFsCache(rpc, init.cwd);
   Object.assign(fsBridge, createSyncFsBridge(syncFs, init.cwd));
 
-  const execBridge = createExecBridge(rpc);
+  const execBridge = createExecBridge(rpc, syncFs, init.cwd);
   const agentModule = createSliccyAgentModule(execBridge, { cwd: init.cwd });
 
   // `skill` is computed once at boot from argv[1] and frozen. It exposes
@@ -434,8 +434,75 @@ function killExitCode(sig?: string): number {
   return 143; // SIGTERM (default) and any other terminating signal
 }
 
-export function createExecBridge(rpc: RealmRpcClient): ExecBridge {
-  const execRun = (command: string): Promise<ExecResult> => rpc.call('exec', 'run', [command]);
+/**
+ * Build the `exec` bridge, made COHERENT with the realm's synchronous fs cache
+ * within a single script. `exec` runs the host shell directly against the real
+ * VFS, so without coordination a `writeFileSync` earlier in the script (still
+ * sitting in {@link SyncFsCache}) would be invisible to the shell, and a file
+ * the shell creates would be invisible to a later `readFileSync` (the cache is
+ * snapshotted once at boot). Every exec op therefore does:
+ *
+ *   1. FLUSH pending sync-fs mutations to the host (`vfs.flushWrites`) BEFORE
+ *      dispatch, so the shell sees them — then reset the cache's mutation
+ *      baseline so those writes are not re-applied later (see `resetBaseline`).
+ *   2. run the exec.
+ *   3. RE-SNAPSHOT the host (`vfs.snapshot`) AFTER the exec resolves and
+ *      `applySnapshot` it, so a subsequent `readFileSync` sees the exec's
+ *      changes.
+ *
+ * Perf gate: both round-trips are skipped unless `syncFs.wasUsed()` — an
+ * exec-only or async-only script never touches the sync cache, so it keeps the
+ * pre-existing fast path with zero extra RPCs.
+ */
+export function createExecBridge(
+  rpc: RealmRpcClient,
+  syncFs?: SyncFsCache,
+  cwd?: string
+): ExecBridge {
+  // FLUSH-before: push the sync cache's pending mutations to the host so the
+  // shell about to run sees them, then reset the baseline so the end-of-script
+  // flush (or the next exec) doesn't re-apply the same writes. No-op — and no
+  // RPC — when there is no sync cache (RPC-only unit tests) or the sync-fs API
+  // was never used.
+  const flushBeforeExec = async (): Promise<void> => {
+    if (!syncFs?.wasUsed()) return;
+    const mutations = syncFs.getMutations();
+    if (mutations.created.length || mutations.modified.length || mutations.deleted.length) {
+      await rpc.call('vfs', 'flushWrites', [mutations]);
+    }
+    syncFs.resetBaseline();
+  };
+
+  // RE-SNAPSHOT-after: pull fresh host state so a later `readFileSync` sees
+  // what the exec wrote. Same perf gate. A snapshot failure leaves the cache
+  // as-is rather than crashing the script.
+  const resnapshotAfterExec = async (): Promise<void> => {
+    if (!syncFs?.wasUsed()) return;
+    try {
+      const snapshot = await rpc.call<SyncFsSnapshot>('vfs', 'snapshot', [cwd]);
+      syncFs.applySnapshot(snapshot);
+    } catch {
+      /* keep the pre-exec view on snapshot failure */
+    }
+  };
+
+  const execRun = async (command: string): Promise<ExecResult> => {
+    await flushBeforeExec();
+    try {
+      return await rpc.call<ExecResult>('exec', 'run', [command]);
+    } finally {
+      await resnapshotAfterExec();
+    }
+  };
+
+  const spawn = async (argv: string[]): Promise<ExecResult> => {
+    await flushBeforeExec();
+    try {
+      return await rpc.call<ExecResult>('exec', 'spawn', [argv]);
+    } finally {
+      await resnapshotAfterExec();
+    }
+  };
 
   // Client-side monotonic spawn id. The host keys its live-spawn map off
   // this, so `kill` can address the exact in-flight command.
@@ -465,9 +532,23 @@ export function createExecBridge(rpc: RealmRpcClient): ExecBridge {
       if (buffered !== undefined) startOpts.stdin = buffered;
       if (opts?.stdinKind !== undefined) startOpts.stdinKind = opts.stdinKind;
       if (opts?.args !== undefined) startOpts.args = opts.args;
-      rpc
-        .call<ExecResult>('exec', 'start', [spawnId, commandOrArgv, startOpts])
-        .then(resolveDone, rejectDone);
+      // Flush-before / re-snapshot-after wrap the killable spawn too: flush
+      // before the `exec:start` dispatch, re-snapshot after `done` resolves.
+      void (async () => {
+        try {
+          await flushBeforeExec();
+          const result = await rpc.call<ExecResult>('exec', 'start', [
+            spawnId,
+            commandOrArgv,
+            startOpts,
+          ]);
+          await resnapshotAfterExec();
+          resolveDone(result);
+        } catch (err: unknown) {
+          await resnapshotAfterExec();
+          rejectDone(err);
+        }
+      })();
     };
     return {
       kill: (sig?: string): Promise<boolean> => {
@@ -494,7 +575,7 @@ export function createExecBridge(rpc: RealmRpcClient): ExecBridge {
   };
 
   const execBridge = Object.assign(execRun, {
-    spawn: (argv: string[]): Promise<ExecResult> => rpc.call('exec', 'spawn', [argv]),
+    spawn,
     start,
   }) as ExecBridge;
   execBridge.exec = execBridge;

--- a/packages/webapp/src/kernel/realm/sync-fs-cache.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-cache.ts
@@ -178,6 +178,45 @@ export class SyncFsCache {
   }
 
   /**
+   * Re-snapshot from the host WITHOUT discarding sync mutations made since the
+   * last baseline reset. Used by the exec bridge's `start` (killable spawn)
+   * path: unlike `run`/`spawn`, user code keeps running while the background
+   * spawn is in flight, so a `writeFileSync` issued after `start()` but before
+   * `await done` lives only in this cache and was never flushed. A plain
+   * {@link applySnapshot} rebuilds the tree from the host snapshot and would
+   * silently drop it. Here we capture those pending mutations first, load the
+   * fresh host snapshot as the new baseline, then re-layer the mutations on top
+   * so (a) files the exec never touched survive and (b) they remain mutations
+   * relative to the new baseline, so the end-of-script flush still ships them.
+   * Sync writes win for the paths they touched; exec writes appear elsewhere.
+   */
+  applySnapshotPreservingMutations(snapshot: SyncFsSnapshot): void {
+    const pending = this.getMutations();
+    this.loadSnapshot(snapshot);
+    // Deletions first: a sync `rm`/`unlink` must not be resurrected by the
+    // fresh host baseline.
+    for (const path of pending.deleted) {
+      const entry = this.tree.get(path);
+      if (entry?.isDirectory) {
+        const prefix = path === '/' ? '/' : path + '/';
+        for (const p of Array.from(this.tree.keys())) {
+          if (p !== path && p.startsWith(prefix)) this.tree.delete(p);
+        }
+      }
+      this.tree.delete(path);
+    }
+    // Then re-layer creates + modifies so sync writes win for their paths.
+    for (const c of pending.created) {
+      this.ensureParentDirs(c.path);
+      this.tree.set(c.path, { content: c.content, isDirectory: c.isDirectory });
+    }
+    for (const m of pending.modified) {
+      this.ensureParentDirs(m.path);
+      this.tree.set(m.path, { content: m.content, isDirectory: false });
+    }
+  }
+
+  /**
    * Snapshot the CURRENT tree as the new mutation baseline. Called by the exec
    * bridge right AFTER a mid-script flush so those already-flushed mutations
    * are not re-applied by a later flush (the next exec, or the end-of-script

--- a/packages/webapp/src/kernel/realm/sync-fs-cache.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-cache.ts
@@ -95,7 +95,34 @@ export class SyncFsCache {
   private initialIsDirectory: Map<string, boolean> = new Map();
   private mkdtempCounter = 0;
 
+  /**
+   * True once any sync-fs method has actually been invoked by user code.
+   * Drives the exec-coherence perf gate: `js-realm-shared`'s exec bridge only
+   * pays the flush-before / re-snapshot-after cost around an exec when the
+   * sync-fs API has been used, so exec-only / async-only scripts (the common
+   * case) keep the current fast path with no extra RPCs. Never cleared once
+   * set — a script that touched sync-fs stays on the coherent path for the
+   * rest of the run (see `applySnapshot`).
+   */
+  private touched = false;
+
   constructor(snapshot: SyncFsSnapshot) {
+    this.loadSnapshot(snapshot);
+  }
+
+  /**
+   * (Re)build the in-memory tree and the mutation baseline from a host
+   * snapshot. Used by the constructor at boot AND by {@link applySnapshot}
+   * after an exec re-snapshot. Rebuilding the baseline here is what makes the
+   * post-exec host state the new "initial" state, so {@link getMutations}
+   * afterwards reports only mutations made AFTER this point.
+   */
+  private loadSnapshot(snapshot: SyncFsSnapshot): void {
+    this.tree = new Map();
+    this.initialPaths = new Set();
+    this.initialContent = new Map();
+    this.initialIsDirectory = new Map();
+
     this.tree.set('/', { content: new Uint8Array(0), isDirectory: true });
     this.initialPaths.add('/');
     this.initialIsDirectory.set('/', true);
@@ -130,6 +157,47 @@ export class SyncFsCache {
     }
   }
 
+  /**
+   * Whether any sync-fs method has been invoked. See {@link touched}. The exec
+   * bridge consults this to decide whether an exec needs the flush-before /
+   * re-snapshot-after coherence round-trips.
+   */
+  wasUsed(): boolean {
+    return this.touched;
+  }
+
+  /**
+   * Replace the tree with a fresh host snapshot and reset the mutation
+   * baseline to it. Called by the exec bridge AFTER an exec resolves so a
+   * subsequent `readFileSync` sees files the exec created/modified. The
+   * {@link touched} flag is intentionally preserved: the script has used
+   * sync-fs, so it stays on the coherent path for later execs.
+   */
+  applySnapshot(snapshot: SyncFsSnapshot): void {
+    this.loadSnapshot(snapshot);
+  }
+
+  /**
+   * Snapshot the CURRENT tree as the new mutation baseline. Called by the exec
+   * bridge right AFTER a mid-script flush so those already-flushed mutations
+   * are not re-applied by a later flush (the next exec, or the end-of-script
+   * `flushSyncFsCache`). {@link applySnapshot} supersedes this when the
+   * post-exec re-snapshot succeeds; `resetBaseline` is the fallback that still
+   * prevents a double-apply if that re-snapshot RPC fails.
+   */
+  resetBaseline(): void {
+    this.initialPaths = new Set();
+    this.initialContent = new Map();
+    this.initialIsDirectory = new Map();
+    for (const [path, entry] of this.tree.entries()) {
+      this.initialPaths.add(path);
+      this.initialIsDirectory.set(path, entry.isDirectory);
+      if (!entry.isDirectory) {
+        this.initialContent.set(path, entry.content);
+      }
+    }
+  }
+
   private ensureParentDirs(path: string): void {
     const dir = dirname(path);
     if (dir === '/') return;
@@ -139,6 +207,7 @@ export class SyncFsCache {
   }
 
   readFile(path: string): Uint8Array {
+    this.touched = true;
     const normalized = normalizePath(path);
     const entry = this.tree.get(normalized);
     if (!entry || entry.isDirectory) {
@@ -151,17 +220,20 @@ export class SyncFsCache {
   }
 
   writeFile(path: string, content: Uint8Array): void {
+    this.touched = true;
     const normalized = normalizePath(path);
     this.ensureParentDirs(normalized);
     this.tree.set(normalized, { content, isDirectory: false });
   }
 
   exists(path: string): boolean {
+    this.touched = true;
     const normalized = normalizePath(path);
     return this.tree.has(normalized);
   }
 
   stat(path: string): { isFile: boolean; isDirectory: boolean; size: number } {
+    this.touched = true;
     const normalized = normalizePath(path);
     const entry = this.tree.get(normalized);
     if (!entry) {
@@ -175,6 +247,7 @@ export class SyncFsCache {
   }
 
   readdir(path: string): string[] {
+    this.touched = true;
     const normalized = normalizePath(path);
     const entry = this.tree.get(normalized);
     if (!entry?.isDirectory) {
@@ -193,6 +266,7 @@ export class SyncFsCache {
   }
 
   mkdir(path: string, recursive?: boolean): void {
+    this.touched = true;
     const normalized = normalizePath(path);
     if (this.tree.has(normalized)) {
       const entry = this.tree.get(normalized)!;
@@ -214,6 +288,7 @@ export class SyncFsCache {
   }
 
   rm(path: string, recursive?: boolean): void {
+    this.touched = true;
     const normalized = normalizePath(path);
     const entry = this.tree.get(normalized);
     if (!entry) {
@@ -239,6 +314,7 @@ export class SyncFsCache {
   }
 
   copyFile(src: string, dest: string): void {
+    this.touched = true;
     const normalizedSrc = normalizePath(src);
     const entry = this.tree.get(normalizedSrc);
     if (!entry || entry.isDirectory) {
@@ -250,6 +326,7 @@ export class SyncFsCache {
   }
 
   rename(oldPath: string, newPath: string): void {
+    this.touched = true;
     const normalizedOld = normalizePath(oldPath);
     const entry = this.tree.get(normalizedOld);
     if (!entry) {
@@ -280,6 +357,7 @@ export class SyncFsCache {
   }
 
   unlink(path: string): void {
+    this.touched = true;
     const normalized = normalizePath(path);
     const entry = this.tree.get(normalized);
     if (!entry) {
@@ -297,6 +375,7 @@ export class SyncFsCache {
   }
 
   mkdtemp(prefix: string): string {
+    this.touched = true;
     for (let attempts = 0; attempts < 100; attempts++) {
       const suffix = `_${String(this.mkdtempCounter).padStart(6, '0')}`;
       this.mkdtempCounter++;

--- a/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
+++ b/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
@@ -693,6 +693,21 @@ describe('sandbox.html mirror parity', () => {
     // never launches the command.
     expect(shared).toMatch(/if\s*\(started \|\| killed\)/);
     expect(sandbox).toMatch(/if\s*\(started \|\| killed\)/);
+    // Bug 2 parity (PR #1455 P2): a `firing` re-entrancy guard covers the
+    // async pre-registration flush window (`started` flips only AFTER the
+    // flush), and a `kill()` in that window aborts the dispatch via a
+    // post-flush `if (killed)` check in BOTH floats.
+    expect(shared).toMatch(/let firing = false/);
+    expect(sandbox).toMatch(/let firing = false/);
+    expect(shared).toMatch(/if\s*\(firing\)\s*return/);
+    expect(sandbox).toMatch(/if\s*\(firing\)\s*return/);
+    // Bug 1 parity (PR #1455 P2): the killable spawn re-snapshots WITHOUT
+    // discarding sync writes made while it was in flight — both floats expose
+    // `applySnapshotPreservingMutations` and call `resnapshotAfterExec(true)`.
+    expect(shared).toContain('applySnapshotPreservingMutations');
+    expect(sandbox).toContain('applySnapshotPreservingMutations');
+    expect(shared).toMatch(/resnapshotAfterExec\(true\)/);
+    expect(sandbox).toMatch(/resnapshotAfterExec\(true\)/);
   });
 
   it('mirrors the nodeChildProcess shim and resolver wiring in both floats', async () => {

--- a/packages/webapp/tests/kernel/realm/realm-iframe.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-iframe.test.ts
@@ -233,12 +233,37 @@ describe('sandbox.html ↔ js-realm-shared parity', () => {
       readFile(path.join(repoRoot, 'packages/webapp/src/kernel/realm/js-realm-shared.ts'), 'utf8'),
     ]);
     // Both surfaces must wire spawn through the same `'exec','spawn'`
-    // RPC tuple so the host's switch case matches in both floats.
-    expect(shared).toMatch(/rpc\.call\(\s*'exec'\s*,\s*'spawn'\s*,/);
+    // RPC tuple so the host's switch case matches in both floats. The
+    // worker realm's call carries a `<ExecResult>` type arg; the sandbox
+    // mirror is untyped JS — allow the optional generic.
+    expect(shared).toMatch(/rpc\.call(?:<[^>]*>)?\(\s*'exec'\s*,\s*'spawn'\s*,/);
     expect(sandbox).toMatch(/rpcCall\(\s*'exec'\s*,\s*'spawn'\s*,/);
     // And expose it on the `exec` bridge as `.spawn` so user code
     // can call `await exec.spawn(['cmd', …])`.
-    expect(shared).toMatch(/spawn:\s*\(argv/);
+    expect(shared).toMatch(/const spawn = async \(argv/);
     expect(sandbox).toMatch(/execBridge\.spawn\s*=/);
+  });
+
+  it('sandbox.html mirrors the exec ↔ sync-fs coherence of js-realm-shared.ts', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const { fileURLToPath } = await import('node:url');
+    const path = await import('node:path');
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const repoRoot = path.resolve(here, '..', '..', '..', '..', '..');
+    const [sandbox, shared] = await Promise.all([
+      readFile(path.join(repoRoot, 'packages/chrome-extension/sandbox.html'), 'utf8'),
+      readFile(path.join(repoRoot, 'packages/webapp/src/kernel/realm/js-realm-shared.ts'), 'utf8'),
+    ]);
+    // The exec bridge flushes sync-fs writes before dispatch and re-snapshots
+    // after, gated on the cache being used — both floats must carry it or the
+    // extension iframe realm silently loses within-script sync-fs↔exec
+    // coherence.
+    for (const source of [shared, sandbox]) {
+      expect(source).toMatch(/flushBeforeExec/);
+      expect(source).toMatch(/resnapshotAfterExec/);
+      expect(source).toMatch(/wasUsed\(\)/);
+      expect(source).toMatch(/'vfs'\s*,\s*'flushWrites'/);
+      expect(source).toMatch(/'vfs'\s*,\s*'snapshot'/);
+    }
   });
 });

--- a/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
@@ -17,6 +17,7 @@ import { createExecBridge } from '../../../src/kernel/realm/js-realm-shared.js';
 import { attachRealmHost } from '../../../src/kernel/realm/realm-host.js';
 import type { RealmPortLike } from '../../../src/kernel/realm/realm-rpc.js';
 import { RealmRpcClient } from '../../../src/kernel/realm/realm-rpc.js';
+import { SyncFsCache, type SyncFsSnapshot } from '../../../src/kernel/realm/sync-fs-cache.js';
 
 interface PortPair {
   realm: RealmPortLike;
@@ -560,6 +561,98 @@ describe('realm RPC: exec.start / exec.kill review fixes (PR #1402)', () => {
     expect(result.exitCode).toBe(143);
     expect(pm.list()[0].terminatedBy).toBe('SIGTERM');
     client.dispose();
+  });
+});
+
+describe('createExecBridge: sync-fs coherence + perf gate', () => {
+  type Call = { channel: string; op: string };
+  /**
+   * Minimal `RealmRpcClient` stand-in that records the (channel, op) of every
+   * call so we can assert the flush-before / re-snapshot-after RPCs happen (or
+   * are skipped) exactly as the perf gate requires.
+   */
+  function makeCountingRpc(handlers: Record<string, (args: unknown[]) => unknown>): {
+    rpc: RealmRpcClient;
+    calls: Call[];
+  } {
+    const calls: Call[] = [];
+    const rpc = {
+      call: async (channel: string, op: string, args: unknown[]): Promise<unknown> => {
+        calls.push({ channel, op });
+        return handlers[`${channel}.${op}`]?.(args);
+      },
+    };
+    return { rpc: rpc as unknown as RealmRpcClient, calls };
+  }
+
+  const okResult = { stdout: 'ok', stderr: '', exitCode: 0 };
+
+  it('exec-only script incurs NO flushWrites / snapshot RPCs (perf gate)', async () => {
+    // Sync cache is never touched → the exec bridge must not pay the coherence
+    // round-trips. Only the exec op itself crosses the wire.
+    const syncFs = new SyncFsCache({ entries: [] });
+    const { rpc, calls } = makeCountingRpc({ 'exec.run': () => okResult });
+
+    const bridge = createExecBridge(rpc, syncFs, '/workspace');
+    await bridge('ls');
+
+    expect(calls).toEqual([{ channel: 'exec', op: 'run' }]);
+    expect(syncFs.wasUsed()).toBe(false);
+  });
+
+  it('flushes-before then re-snapshots-after once the sync-fs API is used', async () => {
+    const snapshotAfter: SyncFsSnapshot = { entries: [] };
+    const syncFs = new SyncFsCache({
+      entries: [{ path: '/workspace', content: new Uint8Array(), isDirectory: true }],
+    });
+    // A prior sync write both marks the cache used AND creates a pending
+    // mutation that flush-before must ship to the host.
+    syncFs.writeFile('/workspace/a.txt', new TextEncoder().encode('hi'));
+
+    const { rpc, calls } = makeCountingRpc({
+      'vfs.flushWrites': () => true,
+      'exec.run': () => okResult,
+      'vfs.snapshot': () => snapshotAfter,
+    });
+
+    const bridge = createExecBridge(rpc, syncFs, '/workspace');
+    await bridge('cat a.txt');
+
+    expect(calls).toEqual([
+      { channel: 'vfs', op: 'flushWrites' },
+      { channel: 'exec', op: 'run' },
+      { channel: 'vfs', op: 'snapshot' },
+    ]);
+  });
+
+  it('re-snapshots after a used-cache exec even with no pending mutations', async () => {
+    // A pure sync READ marks the cache used but produces no mutation: the
+    // flush-before then skips `flushWrites`, but the re-snapshot-after still
+    // runs so a later `readFileSync` can see the exec's writes.
+    const syncFs = new SyncFsCache({ entries: [] });
+    syncFs.exists('/workspace/anything');
+
+    const { rpc, calls } = makeCountingRpc({
+      'exec.run': () => okResult,
+      'vfs.snapshot': () => ({ entries: [] }) as SyncFsSnapshot,
+    });
+
+    const bridge = createExecBridge(rpc, syncFs, '/workspace');
+    await bridge('echo hi');
+
+    expect(calls).toEqual([
+      { channel: 'exec', op: 'run' },
+      { channel: 'vfs', op: 'snapshot' },
+    ]);
+  });
+
+  it('without a sync cache the bridge is a plain exec passthrough', async () => {
+    // The RPC-only call form (used by other unit tests) must keep dispatching
+    // exec ops verbatim with zero coherence RPCs.
+    const { rpc, calls } = makeCountingRpc({ 'exec.run': () => okResult });
+    const bridge = createExecBridge(rpc);
+    await bridge('ls');
+    expect(calls).toEqual([{ channel: 'exec', op: 'run' }]);
   });
 });
 

--- a/packages/webapp/tests/kernel/realm/sync-fs-cache.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-fs-cache.test.ts
@@ -235,3 +235,77 @@ describe('SyncFsCache', () => {
     expect(cache.exists('/workspace/dir')).toBe(true);
   });
 });
+
+describe('SyncFsCache: exec-coherence support (wasUsed / applySnapshot / resetBaseline)', () => {
+  it('wasUsed is false until a sync op runs, then stays true', () => {
+    const cache = new SyncFsCache(emptySnapshot());
+    expect(cache.wasUsed()).toBe(false);
+    // A pure read counts as "used" — a later exec must re-snapshot for it.
+    cache.exists('/workspace/nope.txt');
+    expect(cache.wasUsed()).toBe(true);
+  });
+
+  it('every sync accessor marks the cache used (reads included)', () => {
+    for (const touch of [
+      (c: SyncFsCache) => c.exists('/x'),
+      (c: SyncFsCache) => {
+        try {
+          c.readFile('/x');
+        } catch {
+          /* ENOENT still counts as a use */
+        }
+      },
+      (c: SyncFsCache) => c.writeFile('/x', new Uint8Array()),
+      (c: SyncFsCache) => c.mkdir('/d', true),
+    ]) {
+      const cache = new SyncFsCache(emptySnapshot());
+      expect(cache.wasUsed()).toBe(false);
+      touch(cache);
+      expect(cache.wasUsed()).toBe(true);
+    }
+  });
+
+  it('applySnapshot rebuilds the tree and resets the mutation baseline', () => {
+    const cache = new SyncFsCache(emptySnapshot());
+    cache.writeFile('/workspace/old.txt', new TextEncoder().encode('old'));
+    // A prior local write is a pending mutation…
+    expect(cache.getMutations().created.map((c) => c.path)).toContain('/workspace/old.txt');
+
+    // …until a host re-snapshot supersedes it: the new snapshot becomes the
+    // baseline, so `old.txt` (absent from it) is gone and `new.txt` is present
+    // yet NOT reported as a mutation.
+    cache.applySnapshot({
+      entries: [textEntry('/workspace', '', true), textEntry('/workspace/new.txt', 'fresh')],
+    });
+    expect(cache.exists('/workspace/old.txt')).toBe(false);
+    expect(textOf(cache.readFile('/workspace/new.txt'))).toBe('fresh');
+    const m = cache.getMutations();
+    expect(m.created).toHaveLength(0);
+    expect(m.modified).toHaveLength(0);
+    expect(m.deleted).toHaveLength(0);
+  });
+
+  it('applySnapshot keeps wasUsed set (script stays on the coherent path)', () => {
+    const cache = new SyncFsCache(emptySnapshot());
+    cache.writeFile('/w/a.txt', new Uint8Array());
+    expect(cache.wasUsed()).toBe(true);
+    cache.applySnapshot(emptySnapshot());
+    expect(cache.wasUsed()).toBe(true);
+  });
+
+  it('resetBaseline makes the current tree the new baseline (no re-flush)', () => {
+    const cache = new SyncFsCache({ entries: [textEntry('/workspace', '', true)] });
+    cache.writeFile('/workspace/a.txt', new TextEncoder().encode('AAA'));
+    expect(cache.getMutations().created.map((c) => c.path)).toEqual(['/workspace/a.txt']);
+
+    // After a mid-script flush, resetBaseline pins the current state so the
+    // just-flushed write is not reported (and re-applied) again…
+    cache.resetBaseline();
+    expect(cache.getMutations().created).toHaveLength(0);
+
+    // …while a NEW write after the reset is still reported.
+    cache.writeFile('/workspace/b.txt', new TextEncoder().encode('BBB'));
+    const m = cache.getMutations();
+    expect(m.created.map((c) => c.path)).toEqual(['/workspace/b.txt']);
+  });
+});

--- a/packages/webapp/tests/kernel/realm/sync-fs-cache.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-fs-cache.test.ts
@@ -308,4 +308,61 @@ describe('SyncFsCache: exec-coherence support (wasUsed / applySnapshot / resetBa
     const m = cache.getMutations();
     expect(m.created.map((c) => c.path)).toEqual(['/workspace/b.txt']);
   });
+
+  it('applySnapshotPreservingMutations keeps a local write absent from the snapshot', () => {
+    const cache = new SyncFsCache({ entries: [textEntry('/workspace', '', true)] });
+    // Simulate the exec.start window: a sync write the exec never saw and that
+    // was never flushed (baseline still the pre-exec state).
+    cache.writeFile('/workspace/later.txt', new TextEncoder().encode('LATER'));
+
+    // The host re-snapshot doesn't contain later.txt (exec touched other paths).
+    cache.applySnapshotPreservingMutations({
+      entries: [textEntry('/workspace', '', true), textEntry('/workspace/from-exec.txt', 'X')],
+    });
+
+    // Both survive: the exec's write AND the preserved local write.
+    expect(textOf(cache.readFile('/workspace/from-exec.txt'))).toBe('X');
+    expect(textOf(cache.readFile('/workspace/later.txt'))).toBe('LATER');
+
+    // And later.txt remains a mutation relative to the new baseline, so the
+    // end-of-script flush still ships it; from-exec.txt (in the snapshot) does
+    // not re-flush.
+    const m = cache.getMutations();
+    expect(m.created.map((c) => c.path)).toEqual(['/workspace/later.txt']);
+    expect(m.modified).toHaveLength(0);
+  });
+
+  it('applySnapshotPreservingMutations: local write wins over an exec write to the same path', () => {
+    const cache = new SyncFsCache({ entries: [textEntry('/workspace', '', true)] });
+    cache.writeFile('/workspace/a.txt', new TextEncoder().encode('SYNC'));
+
+    // The exec also wrote a.txt (present in the snapshot with different bytes).
+    cache.applySnapshotPreservingMutations({
+      entries: [textEntry('/workspace', '', true), textEntry('/workspace/a.txt', 'EXEC')],
+    });
+
+    // The later sync write wins for the path it touched.
+    expect(textOf(cache.readFile('/workspace/a.txt'))).toBe('SYNC');
+    // It reads back as a modification relative to the exec's baseline.
+    const m = cache.getMutations();
+    expect(m.modified.map((mm) => mm.path)).toEqual(['/workspace/a.txt']);
+  });
+
+  it('applySnapshotPreservingMutations: a local delete is not resurrected by the snapshot', () => {
+    const cache = new SyncFsCache({
+      entries: [textEntry('/workspace', '', true), textEntry('/workspace/gone.txt', 'v')],
+    });
+    // Baseline includes gone.txt; a sync unlink removes it in the window.
+    cache.resetBaseline();
+    cache.unlink('/workspace/gone.txt');
+
+    // The host re-snapshot still has gone.txt (exec never deleted it).
+    cache.applySnapshotPreservingMutations({
+      entries: [textEntry('/workspace', '', true), textEntry('/workspace/gone.txt', 'v')],
+    });
+
+    // The local delete wins and is shipped as a deletion at end-of-script.
+    expect(cache.exists('/workspace/gone.txt')).toBe(false);
+    expect(cache.getMutations().deleted).toEqual(['/workspace/gone.txt']);
+  });
 });

--- a/packages/webapp/tests/shell/almost-bash-shell.test.ts
+++ b/packages/webapp/tests/shell/almost-bash-shell.test.ts
@@ -798,3 +798,123 @@ describe('AlmostBashShell VFS round-trip', () => {
     }
   });
 });
+
+let coherenceDbCounter = 0;
+
+/**
+ * sliccy:exec ↔ synchronous fs cache coherence WITHIN a single script.
+ *
+ * The realm's `*Sync` fs APIs read/write an in-memory `SyncFsCache` snapshotted
+ * once at boot; `exec` runs the host shell directly against the VFS. The exec
+ * bridge bridges the two: it flushes pending sync mutations to the host BEFORE
+ * an exec and re-snapshots the host AFTER, so a `writeFileSync` is visible to a
+ * later `exec`, and an `exec`'s writes are visible to a later `readFileSync`.
+ * All of this is gated on the sync-fs API actually being used (perf).
+ */
+describe('AlmostBashShell sync-fs ↔ exec coherence', () => {
+  let fs: VirtualFS;
+
+  beforeEach(async () => {
+    fs = await VirtualFS.create({
+      dbName: `test-coherence-${coherenceDbCounter++}`,
+      wipe: true,
+    });
+  });
+
+  afterEach(async () => {
+    await fs.dispose();
+  });
+
+  // Test A: sync write → exec sees it (flush-before-exec).
+  it('a writeFileSync is visible to a subsequent exec in the same script', async () => {
+    await fs.writeFile(
+      '/workspace/a.jsh',
+      [
+        "const fs = require('fs');",
+        "const { exec } = require('sliccy:exec');",
+        "fs.mkdirSync('/workspace/ca', { recursive: true });",
+        "fs.writeFileSync('/workspace/ca/sync.txt', 'sync-payload');",
+        "const r = await exec('cat /workspace/ca/sync.txt');",
+        "console.log('EXEC:' + r.stdout.trim());",
+      ].join('\n')
+    );
+
+    const shell = new AlmostBashShell({ fs });
+    const run = await shell.executeScriptFile('/workspace/a.jsh');
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).toContain('EXEC:sync-payload');
+  });
+
+  // Test B: exec → sync read sees it (re-snapshot-after-exec).
+  it("an exec's write is visible to a subsequent readFileSync in the same script", async () => {
+    await fs.writeFile(
+      '/workspace/b.jsh',
+      [
+        "const fs = require('fs');",
+        "const { exec } = require('sliccy:exec');",
+        "fs.mkdirSync('/workspace/cb', { recursive: true });",
+        "await exec('echo hi-from-exec > /workspace/cb/out.txt');",
+        "const s = fs.readFileSync('/workspace/cb/out.txt', 'utf8');",
+        "console.log('READ:' + s.trim());",
+      ].join('\n')
+    );
+
+    const shell = new AlmostBashShell({ fs });
+    const run = await shell.executeScriptFile('/workspace/b.jsh');
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).toContain('READ:hi-from-exec');
+  });
+
+  // Test C: async write → exec sees it (already coherent via direct RPC; guard it).
+  it('an async fs.writeFile is visible to a subsequent exec (existing coherent path)', async () => {
+    await fs.writeFile(
+      '/workspace/c.jsh',
+      [
+        "const fs = require('fs');",
+        "const { exec } = require('sliccy:exec');",
+        "await fs.mkdir('/workspace/cc');",
+        "await fs.writeFile('/workspace/cc/async.txt', 'async-payload');",
+        "const r = await exec('cat /workspace/cc/async.txt');",
+        "console.log('EXEC:' + r.stdout.trim());",
+      ].join('\n')
+    );
+
+    const shell = new AlmostBashShell({ fs });
+    const run = await shell.executeScriptFile('/workspace/c.jsh');
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).toContain('EXEC:async-payload');
+  });
+
+  // Test D: a sync write flushed mid-script by an exec, then a later sync
+  // mutation, yields the correct FINAL VFS state — no stale re-apply. The exec
+  // OVERWRITES the mid-flushed file on the host; if the end-of-script flush
+  // re-applied the stale pre-exec content, `a.txt` would read back as the old
+  // value instead of the exec's.
+  it('does not re-apply already-flushed sync mutations at end-of-script', async () => {
+    await fs.writeFile(
+      '/workspace/d.jsh',
+      [
+        "const fs = require('fs');",
+        "const { exec } = require('sliccy:exec');",
+        "fs.mkdirSync('/workspace/cd', { recursive: true });",
+        "fs.writeFileSync('/workspace/cd/a.txt', 'ORIGINAL');",
+        "await exec('echo MODIFIED > /workspace/cd/a.txt');",
+        "fs.writeFileSync('/workspace/cd/b.txt', 'BEE');",
+      ].join('\n')
+    );
+
+    const shell = new AlmostBashShell({ fs });
+    const run = await shell.executeScriptFile('/workspace/d.jsh');
+    expect(run.exitCode).toBe(0);
+
+    // FINAL state via the bash tool (separate command → post-script VFS):
+    // a.txt keeps the exec's value (no stale re-apply), b.txt is the later write.
+    const a = await shell.executeCommand('cat /workspace/cd/a.txt');
+    expect(a.exitCode).toBe(0);
+    expect(a.stdout.trim()).toBe('MODIFIED');
+
+    const b = await shell.executeCommand('cat /workspace/cd/b.txt');
+    expect(b.exitCode).toBe(0);
+    expect(b.stdout.trim()).toBe('BEE');
+  });
+});

--- a/packages/webapp/tests/shell/almost-bash-shell.test.ts
+++ b/packages/webapp/tests/shell/almost-bash-shell.test.ts
@@ -674,3 +674,127 @@ describe('AlmostBashShell workflow command registration', () => {
     expect(after.stdout).toContain('JSH-LATER');
   });
 });
+
+let vfsRoundTripDbCounter = 0;
+
+/**
+ * Real VFS round-trip: a realm script (`.jsh`) that writes through
+ * `require('sliccy:exec')` shell commands AND through `require('fs')` must land
+ * in the SAME `VirtualFS` the `bash` tool reads back. This disproves the
+ * "separate invisible filesystem" claim — the realm's `exec`/`fs` RPC dispatch
+ * back into the shell's live `VfsAdapter` → `VirtualFS`, so a subsequent
+ * `shell.executeCommand('cat …')` (the bash-tool path) sees the writes, and a
+ * direct `fs.readFile(…)` on the shared instance sees them too.
+ */
+describe('AlmostBashShell VFS round-trip', () => {
+  let fs: VirtualFS;
+
+  beforeEach(async () => {
+    fs = await VirtualFS.create({
+      dbName: `test-vfs-roundtrip-${vfsRoundTripDbCounter++}`,
+      wipe: true,
+    });
+  });
+
+  afterEach(async () => {
+    await fs.dispose();
+  });
+
+  it("makes require('sliccy:exec') shell writes visible to the bash tool", async () => {
+    await fs.writeFile(
+      '/workspace/exec-writer.jsh',
+      [
+        "const { exec } = require('sliccy:exec');",
+        "await exec('mkdir -p /workspace/rt');",
+        "await exec('echo exec-payload > /workspace/rt/from-exec.txt');",
+        "console.log('wrote via exec');",
+      ].join('\n')
+    );
+
+    const shell = new AlmostBashShell({ fs });
+
+    // Realm-side: the script's shell commands run successfully.
+    const run = await shell.executeScriptFile('/workspace/exec-writer.jsh');
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).toContain('wrote via exec');
+
+    // Bash-tool-side: the SAME shell reads back what the realm wrote.
+    const read = await shell.executeCommand('cat /workspace/rt/from-exec.txt');
+    expect(read.exitCode).toBe(0);
+    expect(read.stdout.trim()).toBe('exec-payload');
+
+    // And the write is visible on the shared VirtualFS instance directly.
+    expect(((await fs.readFile('/workspace/rt/from-exec.txt')) as string).trim()).toBe(
+      'exec-payload'
+    );
+  });
+
+  it("makes require('fs').writeFile writes visible to the bash tool", async () => {
+    await fs.writeFile(
+      '/workspace/fs-writer.jsh',
+      [
+        "const fs = require('fs');",
+        "await fs.mkdir('/workspace/rt');",
+        "await fs.writeFile('/workspace/rt/from-fs.txt', 'fs-payload');",
+        "console.log('wrote via fs');",
+      ].join('\n')
+    );
+
+    const shell = new AlmostBashShell({ fs });
+
+    // Realm-side: the fs bridge write succeeds.
+    const run = await shell.executeScriptFile('/workspace/fs-writer.jsh');
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).toContain('wrote via fs');
+
+    // Bash-tool-side: `ls` + `cat` see the realm's write.
+    const ls = await shell.executeCommand('ls /workspace/rt');
+    expect(ls.exitCode).toBe(0);
+    expect(ls.stdout).toContain('from-fs.txt');
+
+    const read = await shell.executeCommand('cat /workspace/rt/from-fs.txt');
+    expect(read.exitCode).toBe(0);
+    expect(read.stdout).toBe('fs-payload');
+
+    // And the write is visible on the shared VirtualFS instance directly.
+    expect(await fs.readFile('/workspace/rt/from-fs.txt')).toBe('fs-payload');
+  });
+
+  it("makes require('fs').fetchToFile downloads visible to the bash tool", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(new Uint8Array([1, 2, 3, 4]), { status: 200 }));
+    try {
+      await fs.writeFile(
+        '/workspace/fetcher.jsh',
+        [
+          "const fs = require('fs');",
+          "await fs.mkdir('/workspace/rt');",
+          "const n = await fs.fetchToFile('https://example.com/blob.bin', '/workspace/rt/from-fetch.bin');",
+          "console.log('bytes:' + n);",
+        ].join('\n')
+      );
+
+      const shell = new AlmostBashShell({ fs });
+
+      // Realm-side: the fetch went through the host fetch and wrote the bytes.
+      const run = await shell.executeScriptFile('/workspace/fetcher.jsh');
+      expect(run.exitCode).toBe(0);
+      expect(run.stdout).toContain('bytes:4');
+      expect(fetchSpy).toHaveBeenCalled();
+      expect(fetchSpy.mock.calls[0][0]).toBe('https://example.com/blob.bin');
+
+      // Bash-tool-side: the downloaded file exists.
+      const exists = await shell.executeCommand('test -f /workspace/rt/from-fetch.bin');
+      expect(exists.exitCode).toBe(0);
+
+      // And the exact bytes are visible on the shared VirtualFS instance.
+      const bytes = (await fs.readFile('/workspace/rt/from-fetch.bin', {
+        encoding: 'binary',
+      })) as Uint8Array;
+      expect(Array.from(bytes)).toEqual([1, 2, 3, 4]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/packages/webapp/tests/shell/almost-bash-shell.test.ts
+++ b/packages/webapp/tests/shell/almost-bash-shell.test.ts
@@ -917,4 +917,68 @@ describe('AlmostBashShell sync-fs ↔ exec coherence', () => {
     expect(b.exitCode).toBe(0);
     expect(b.stdout.trim()).toBe('BEE');
   });
+
+  // Test E (Bug 1): a sync write issued AFTER exec.start() but BEFORE
+  // `await done` must survive the post-spawn re-snapshot and reach the host.
+  // The killable spawn runs its flush/re-snapshot in a background IIFE while
+  // user code keeps running, so `later.txt` lives only in the sync cache when
+  // the spawn's re-snapshot fires. A plain applySnapshot would rebuild the
+  // tree from the host and silently drop it; the mutation-preserving
+  // re-snapshot must keep it so the end-of-script flush ships it.
+  it('preserves a sync write made while an exec.start spawn is in flight', async () => {
+    // Matches the documented Bug 1 flow: the FIRST sync-fs use is the write
+    // issued AFTER start() but BEFORE `await done`, so it lives only in the
+    // cache when the background spawn's re-snapshot fires.
+    await fs.writeFile(
+      '/workspace/e.jsh',
+      [
+        "const fs = require('fs');",
+        "const { exec } = require('sliccy:exec');",
+        "const h = exec.start('true');",
+        'h.stdin.end();',
+        "fs.writeFileSync('/workspace/later_e.txt', 'LATER');",
+        'await h.done;',
+      ].join('\n')
+    );
+
+    const shell = new AlmostBashShell({ fs });
+    const run = await shell.executeScriptFile('/workspace/e.jsh');
+    expect(run.exitCode).toBe(0);
+
+    // FINAL state via the bash tool (separate command → post-script VFS):
+    // the sync write survived to the host VFS.
+    const later = await shell.executeCommand('cat /workspace/later_e.txt');
+    expect(later.exitCode).toBe(0);
+    expect(later.stdout.trim()).toBe('LATER');
+  });
+
+  // Test F (Bug 2): a kill() issued during the pre-registration flush window
+  // (synchronously after stdin.end(), before the background flush resolves)
+  // must keep the command client-side — the host never receives exec:start, so
+  // the command never runs — and resolve `done` as terminated (128+SIGTERM).
+  it('a kill() during the flush window prevents exec.start from ever running', async () => {
+    await fs.writeFile(
+      '/workspace/f.jsh',
+      [
+        "const fs = require('fs');",
+        "const { exec } = require('sliccy:exec');",
+        "await fs.mkdir('/workspace/cf', { recursive: true });",
+        "const h = exec.start('echo RAN > /workspace/cf/out.txt');",
+        'h.stdin.end();',
+        "await h.kill('SIGTERM');",
+        'const r = await h.done;',
+        "console.log('EXIT:' + r.exitCode);",
+      ].join('\n')
+    );
+
+    const shell = new AlmostBashShell({ fs });
+    const run = await shell.executeScriptFile('/workspace/f.jsh');
+    expect(run.exitCode).toBe(0);
+    // `done` resolved as terminated by SIGTERM (128 + 15).
+    expect(run.stdout).toContain('EXIT:143');
+
+    // The command never dispatched, so it never created out.txt on the host.
+    const ran = await shell.executeCommand('test -f /workspace/cf/out.txt');
+    expect(ran.exitCode).not.toBe(0);
+  });
 });


### PR DESCRIPTION
## What & why

Within a single realm script, the synchronous `fs` API (`writeFileSync`/`readFileSync`) and `sliccy:exec` were not coherent. `SyncFsCache` snapshots the VFS once at realm boot and flushes once at end-of-script, while `exec` runs the host shell directly against the real `VirtualFS` with no flush-before / re-snapshot-after. So within one script:

- `fs.writeFileSync(p, ...)` then `exec('cat p')` did **not** see the write (still in the realm's unflushed sync cache).
- `exec('echo > p')` then `fs.readFileSync(p)` did **not** see it (snapshot frozen at boot).

(The async `fs.writeFile`/`fetchToFile` path was already coherent via direct RPC, and cross-invocation was already coherent via the end-of-script flush — this only affected sync-fs interleaved with exec inside one script.)

## The fix

The realm exec bridge now, on `run`/`spawn`/`start`:

1. **Flushes** pending `SyncFsCache` mutations to the host (`flushWrites` + `resetBaseline`) **before** dispatch, then
2. runs the exec, then
3. **Re-snapshots** (`snapshot` + `applySnapshot`) **after** it resolves.

### Safety & performance

- **No double-flush:** the mid-script baseline reset means the end-of-script flush only ships *new* mutations (regression test proves exec's write survives with no stale re-apply).
- **Perf gate:** both round-trips are gated on `syncFs.wasUsed()`, so exec-only / async-only scripts (the common case) incur **zero** extra vfs RPCs (asserted by an RPC-count test).
- **Cross-runtime parity:** the change is mirrored into the `sandbox.html` iframe-realm bootstrap, with a parity test guarding against drift.

### New `SyncFsCache` surface

`applySnapshot`, `resetBaseline`, `touched`/`wasUsed()`.

## Tests

- Coherence tests A-D over a real `AlmostBashShell` / `VirtualFS`: sync-write→exec, exec→sync-read, async-still-coherent, and no-double-flush final state.
- Perf-gate RPC-count test + `SyncFsCache` unit tests.
- Plus the earlier VFS round-trip tests proving realm writes are visible to the bash tool (shared `VirtualFS`).

## Verification

- Targeted vitest: 670 passed. Full webapp suite: 8762 passed / 30 skipped.
- `lint` clean; `typecheck` clean (9 projects); coverage gate green (`sync-fs-cache.ts` 88%/96%).

## Note

`sandbox.html` is a copy-only asset (`copyFileSync` in the vite config); the source change is validated without a build, and `npm run build` carries it into `dist/extension`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author