### PR TITLE
feat(realm): add sliccy:agent module for .jsh scripts

### DIFF
--- a/packages/chrome-extension/sandbox.html
+++ b/packages/chrome-extension/sandbox.html
@@ -1021,6 +1021,55 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   // and the property form (`require('sliccy:exec').exec(...)`) both work.
   execBridge.exec = execBridge;
 
+  // `agent` — client-side sugar over the `exec` bridge that shells out to the
+  // `agent` supplemental command (spawn a sub-scoop, feed it a task, block
+  // until the agent loop completes). Option A: no host/RPC channel — argv
+  // construction mirrors the workflow-DSL agent() in workflow-prelude.ts and the
+  // `createSliccyAgentModule` factory in js-realm-shared.ts. Keep in lockstep
+  // (parity asserted by tests/kernel/realm/js-realm-helpers.test.ts).
+  const agentModule = (function () {
+    const b64 = (json) => {
+      const bytes = new TextEncoder().encode(json);
+      let bin = '';
+      for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+      return btoa(bin);
+    };
+    const buildArgv = (prompt, opts) => {
+      const flags = [];
+      if (opts.model) flags.push('--model', String(opts.model));
+      if (opts.thinking) flags.push('--thinking', String(opts.thinking));
+      if (opts.schema) flags.push('--schema-b64', b64(JSON.stringify(opts.schema)));
+      const readOnly = opts.readOnly === undefined
+        ? '/workspace/'
+        : Array.isArray(opts.readOnly) ? opts.readOnly.join(',') : String(opts.readOnly);
+      const cwd = opts.cwd !== undefined ? String(opts.cwd) : (init.cwd || '.');
+      const allowed = opts.allowedCommands !== undefined ? String(opts.allowedCommands) : '*';
+      return ['agent'].concat(flags, ['--read-only', readOnly, cwd, allowed, String(prompt)]);
+    };
+    const spawn = async (prompt, opts) => {
+      opts = opts || {};
+      const r = await execBridge.spawn(buildArgv(prompt, opts));
+      const exitCode = r && typeof r.exitCode === 'number' ? r.exitCode : 0;
+      const finalText = String((r && r.stdout) || '').replace(/\n+$/, '');
+      const stderr = String((r && r.stderr) || '').replace(/\n+$/, '');
+      return { finalText: finalText, exitCode: exitCode, stderr: stderr };
+    };
+    const agent = async (prompt, opts) => {
+      opts = opts || {};
+      const res = await spawn(prompt, opts);
+      if (res.exitCode !== 0) {
+        throw new Error('agent: exited with code ' + res.exitCode + (res.stderr ? ': ' + res.stderr : ''));
+      }
+      if (opts.schema) {
+        try { return JSON.parse(res.finalText); }
+        catch { throw new Error('agent: schema response was not valid JSON (exit ' + res.exitCode + '): ' + res.finalText.slice(0, 200)); }
+      }
+      return res.finalText;
+    };
+    agent.spawn = spawn;
+    return agent;
+  })();
+
   // `skill` global — mirrors kernel/realm/skill-global.ts (the canonical
   // TS implementation). Boot-time computed from init.argv[1], frozen.
   // Keep this in sync with skill-global.ts.
@@ -2489,6 +2538,7 @@ async function runRealm(init, port, pending, nextIdFn, NODE_BUILTINS_UNAVAILABLE
   // is built. Keep the key set in lockstep with js-realm-shared.ts
   // (parity test in tests/kernel/realm/js-realm-helpers.test.ts).
   sliccyModules['exec'] = execBridge;
+  sliccyModules['agent'] = agentModule;
   sliccyModules['skill'] = skillGlobal;
   sliccyModules['http'] = httpGlobal;
   sliccyModules['browser'] = browserBridge;

--- a/packages/vfs-root/workspace/skills/skill-authoring/SKILL.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/SKILL.md
@@ -107,18 +107,19 @@ Node-standard bare globals:
 
 Capability bridges via `require('sliccy:<name>')` (full reference: `./jsh-runtime-extensions.md`):
 
-| `require('sliccy:<name>')`                    | Use for                                                                                                   |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `sliccy:exec`                                 | Callable `exec(cmd)` + `.spawn(argv[])`. Composes with any supplemental command or `.jsh` script.         |
-| `sliccy:skill`                                | `dir` / `refs` / `assets` / `config()` / `token(providerId)` — script-relative paths and provider tokens. |
-| `sliccy:http`                                 | `http.client({ baseUrl, token, headers, retry, timeoutMs })` — standard API-client builder.               |
-| `sliccy:browser`                              | `findTab`, `ensureTab`, `eval`, `evalAsync`, `cookie`, `localStorage`, `fetch`, `websocket.on(...)`.      |
-| `sliccy:usb` / `sliccy:serial` / `sliccy:hid` | `list()` / `request()` + device methods. Chromium-only.                                                   |
-| `sliccy:cli`                                  | `die(msg, opts?)`, `out(value)`, `warn(msg, opts?)`, `help(text)`.                                        |
-| `sliccy:color`                                | ANSI helpers (`green`, `red`, `bold`, `dim`, …) auto-disabled on non-TTY / `NO_COLOR`.                    |
-| `sliccy:time`                                 | `parseDuration`, `ago`, `range`, `future`, `gmailDate`.                                                   |
-| `sliccy:fmt`                                  | `trunc`, `col`, `table`, `date`.                                                                          |
-| `sliccy:pool`                                 | `pool(n, items, fn)` — bounded concurrency runner.                                                        |
+| `require('sliccy:<name>')`                    | Use for                                                                                                                                                                                                             |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sliccy:exec`                                 | Callable `exec(cmd)` + `.spawn(argv[])`. Composes with any supplemental command or `.jsh` script.                                                                                                                   |
+| `sliccy:agent`                                | Callable `agent(prompt, opts?)` → sub-scoop final text (parsed when `schema` set) + `.spawn(...)` → `{ finalText, exitCode, stderr }`. `opts`: `model`, `thinking`, `cwd`, `allowedCommands`, `readOnly`, `schema`. |
+| `sliccy:skill`                                | `dir` / `refs` / `assets` / `config()` / `token(providerId)` — script-relative paths and provider tokens.                                                                                                           |
+| `sliccy:http`                                 | `http.client({ baseUrl, token, headers, retry, timeoutMs })` — standard API-client builder.                                                                                                                         |
+| `sliccy:browser`                              | `findTab`, `ensureTab`, `eval`, `evalAsync`, `cookie`, `localStorage`, `fetch`, `websocket.on(...)`.                                                                                                                |
+| `sliccy:usb` / `sliccy:serial` / `sliccy:hid` | `list()` / `request()` + device methods. Chromium-only.                                                                                                                                                             |
+| `sliccy:cli`                                  | `die(msg, opts?)`, `out(value)`, `warn(msg, opts?)`, `help(text)`.                                                                                                                                                  |
+| `sliccy:color`                                | ANSI helpers (`green`, `red`, `bold`, `dim`, …) auto-disabled on non-TTY / `NO_COLOR`.                                                                                                                              |
+| `sliccy:time`                                 | `parseDuration`, `ago`, `range`, `future`, `gmailDate`.                                                                                                                                                             |
+| `sliccy:fmt`                                  | `trunc`, `col`, `table`, `date`.                                                                                                                                                                                    |
+| `sliccy:pool`                                 | `pool(n, items, fn)` — bounded concurrency runner.                                                                                                                                                                  |
 
 VFS bridge:
 

--- a/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
@@ -4,7 +4,7 @@ This file is bundled into the agent VFS at `/workspace/skills/skill-authoring/js
 
 ## Runtime globals (Globals API)
 
-Every `.jsh` script runs in an async wrapper with a small Node-standard surface available as bare globals. SLICC's capability bridges (exec, http, browser, USB / Serial / HID, skill, color, cli, time, fmt, pool) are NOT bare globals; they are reached via the `sliccy:` virtual-module scheme below.
+Every `.jsh` script runs in an async wrapper with a small Node-standard surface available as bare globals. SLICC's capability bridges (exec, agent, http, browser, USB / Serial / HID, skill, color, cli, time, fmt, pool) are NOT bare globals; they are reached via the `sliccy:` virtual-module scheme below.
 
 ### Node-standard bare globals
 
@@ -24,18 +24,19 @@ Every `.jsh` script runs in an async wrapper with a small Node-standard surface 
 
 The bespoke globals are hard-cut. Reach each capability via `require('sliccy:<name>')` (CJS) or `import ... from 'sliccy:<name>'` (ESM). `require('fs')` / `require('node:fs')` keeps returning the VFS bridge.
 
-| `require('sliccy:<name>')`                    | Purpose                                                                                                                                                                                                                                                                    |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sliccy:exec`                                 | Callable `exec(cmd)` plus `.spawn(argv[])`, `.start(cmdOrArgv, opts?)` (killable, buffered-stdin spawn handle) and `.exec` self-reference. Returns `{ stdout, stderr, exitCode }`. Use `const { exec } = require('sliccy:exec')` or `const exec = require('sliccy:exec')`. |
-| `sliccy:skill`                                | Frozen `{ dir, refs, assets, config(), config(updates), token(providerId) }`. Replaces ad-hoc `argv[1]` dirname math and `oauth-token` shell-outs.                                                                                                                         |
-| `sliccy:http`                                 | `http.client({ baseUrl, token, headers, retry, timeoutMs })` builder.                                                                                                                                                                                                      |
-| `sliccy:browser`                              | `findTab`, `ensureTab`, `eval`, `evalAsync`, `cookie`, `localStorage`, `fetch`, `websocket.on(...).filter(...).forward(...)`.                                                                                                                                              |
-| `sliccy:usb` / `sliccy:serial` / `sliccy:hid` | `list()` / `request()` + device methods (`open`/`close`/`sendReport`/...). Chromium-only.                                                                                                                                                                                  |
-| `sliccy:cli`                                  | `die(msg, opts?)`, `out(value)`, `warn(msg, opts?)`, `help(text)`. `opts` is `number` or `{ exitCode?, prefix? }`; `prefix: ''` removes the default `Error:` / `Warning:` label entirely.                                                                                  |
-| `sliccy:color`                                | ANSI helpers: `green`, `red`, `yellow`, `gray`, `bold`, `cyan`, `dim`, plus `enabled` flag (auto-disabled on non-TTY / `NO_COLOR`).                                                                                                                                        |
-| `sliccy:time`                                 | `parseDuration(spec)`, `ago(spec)`, `range(spec)`, `future(spec)`, `gmailDate(spec)`. Units: `ms s m h d w M y` (note: `m` = minutes, `M` = months).                                                                                                                       |
-| `sliccy:fmt`                                  | `trunc(s, n)`, `col(s, width)`, `table(rows, widths?)`, `date(value, style?)`. `style`: `'short' \| 'iso' \| 'human' \| 'locale'` (locale = `Intl.DateTimeFormat` medium).                                                                                                 |
-| `sliccy:pool`                                 | `pool(n, items, fn)` — bounded concurrency runner, results returned in input order.                                                                                                                                                                                        |
+| `require('sliccy:<name>')`                    | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sliccy:exec`                                 | Callable `exec(cmd)` plus `.spawn(argv[])`, `.start(cmdOrArgv, opts?)` (killable, buffered-stdin spawn handle) and `.exec` self-reference. Returns `{ stdout, stderr, exitCode }`. Use `const { exec } = require('sliccy:exec')` or `const exec = require('sliccy:exec')`.                                                                                                                                                 |
+| `sliccy:agent`                                | Callable `agent(prompt, opts?)` — spawns a one-shot sub-scoop, feeds it the prompt, blocks until the agent loop completes; resolves to trimmed final text (JSON-parsed when `opts.schema` is set), REJECTS on non-zero exit or schema-parse failure. `.spawn(prompt, opts?)` is the non-throwing variant → `{ finalText, exitCode, stderr }`. `opts`: `model`, `thinking`, `cwd`, `allowedCommands`, `readOnly`, `schema`. |
+| `sliccy:skill`                                | Frozen `{ dir, refs, assets, config(), config(updates), token(providerId) }`. Replaces ad-hoc `argv[1]` dirname math and `oauth-token` shell-outs.                                                                                                                                                                                                                                                                         |
+| `sliccy:http`                                 | `http.client({ baseUrl, token, headers, retry, timeoutMs })` builder.                                                                                                                                                                                                                                                                                                                                                      |
+| `sliccy:browser`                              | `findTab`, `ensureTab`, `eval`, `evalAsync`, `cookie`, `localStorage`, `fetch`, `websocket.on(...).filter(...).forward(...)`.                                                                                                                                                                                                                                                                                              |
+| `sliccy:usb` / `sliccy:serial` / `sliccy:hid` | `list()` / `request()` + device methods (`open`/`close`/`sendReport`/...). Chromium-only.                                                                                                                                                                                                                                                                                                                                  |
+| `sliccy:cli`                                  | `die(msg, opts?)`, `out(value)`, `warn(msg, opts?)`, `help(text)`. `opts` is `number` or `{ exitCode?, prefix? }`; `prefix: ''` removes the default `Error:` / `Warning:` label entirely.                                                                                                                                                                                                                                  |
+| `sliccy:color`                                | ANSI helpers: `green`, `red`, `yellow`, `gray`, `bold`, `cyan`, `dim`, plus `enabled` flag (auto-disabled on non-TTY / `NO_COLOR`).                                                                                                                                                                                                                                                                                        |
+| `sliccy:time`                                 | `parseDuration(spec)`, `ago(spec)`, `range(spec)`, `future(spec)`, `gmailDate(spec)`. Units: `ms s m h d w M y` (note: `m` = minutes, `M` = months).                                                                                                                                                                                                                                                                       |
+| `sliccy:fmt`                                  | `trunc(s, n)`, `col(s, width)`, `table(rows, widths?)`, `date(value, style?)`. `style`: `'short' \| 'iso' \| 'human' \| 'locale'` (locale = `Intl.DateTimeFormat` medium).                                                                                                                                                                                                                                                 |
+| `sliccy:pool`                                 | `pool(n, items, fn)` — bounded concurrency runner, results returned in input order.                                                                                                                                                                                                                                                                                                                                        |
 
 `require('sliccy:<unknown>')` throws a scheme-specific error (`Unknown sliccy: module '<name>'`); empty `require('sliccy:')` throws `empty sliccy: module name`. `sliccy:` lookups never hit the registry / `node_modules` / `ipk install`.
 
@@ -125,6 +126,28 @@ h.stdin.write('{"name":"slicc"}');
 h.stdin.end();
 const { stdout, exitCode } = await h.done;
 // h.kill('SIGTERM') fans a signal out via the exec:kill op.
+```
+
+```javascript
+// agent — spawn a one-shot sub-scoop and block on its result. The callable
+// resolves to the sub-scoop's final text; with `schema` it resolves to the
+// parsed object (rejects if the reply wasn't valid JSON) and rejects on a
+// non-zero exit. Use agent.spawn(...) when you want the raw outcome instead.
+const agent = require('sliccy:agent');
+const summary = await agent('Summarize /workspace/README.md in one line', {
+  thinking: 'low',
+  readOnly: '/workspace/',
+});
+
+const parsed = await agent('Extract the title as {"title": string}', {
+  schema: { type: 'object', properties: { title: { type: 'string' } } },
+});
+
+const { finalText, exitCode, stderr } = await agent.spawn('do the thing', {
+  model: 'claude-opus-4-6',
+  cwd: '/tmp',
+  allowedCommands: 'git,node',
+});
 ```
 
 ### `require('child_process')` — Node process API over the exec bridge

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -177,6 +177,7 @@ export async function runJsRealm(init: RealmInitMsg, port: RealmPortLike): Promi
   Object.assign(fsBridge, createSyncFsBridge(syncFs, init.cwd));
 
   const execBridge = createExecBridge(rpc);
+  const agentModule = createSliccyAgentModule(execBridge, { cwd: init.cwd });
 
   // `skill` is computed once at boot from argv[1] and frozen. It exposes
   // the script-relative path helpers and the skill-scoped config/token
@@ -228,6 +229,7 @@ export async function runJsRealm(init: RealmInitMsg, port: RealmPortLike): Promi
 
   const sliccyModules = buildSliccyModules({
     exec: execBridge,
+    agent: agentModule,
     skill: skillGlobal,
     http: httpGlobal,
     browser: browserBridge,
@@ -497,6 +499,121 @@ export function createExecBridge(rpc: RealmRpcClient): ExecBridge {
   }) as ExecBridge;
   execBridge.exec = execBridge;
   return execBridge;
+}
+
+/** Options accepted by the `sliccy:agent` callable and its `.spawn` variant. */
+interface SliccyAgentOptions {
+  /** Model id override forwarded as `--model`. */
+  model?: string;
+  /** Reasoning level forwarded as `--thinking` (off|minimal|low|medium|high|xhigh). */
+  thinking?: string;
+  /** StructuredOutput contract; base64-encoded JSON forwarded as `--schema-b64`. */
+  schema?: unknown;
+  /** Spawned scoop's writable cwd; defaults to the realm cwd. */
+  cwd?: string;
+  /** Comma-separated allowed bash commands; defaults to `*`. */
+  allowedCommands?: string;
+  /** Read-only VFS paths (array or CSV) forwarded as `--read-only`; defaults to `/workspace/`. */
+  readOnly?: string | string[];
+}
+
+/** Non-throwing result shape returned by `agent.spawn`. */
+interface SliccyAgentSpawnResult {
+  finalText: string;
+  exitCode: number;
+  stderr: string;
+}
+
+/** The `sliccy:agent` module: a callable with a non-throwing `.spawn` sibling. */
+type SliccyAgentModule = ((prompt: string, opts?: SliccyAgentOptions) => Promise<unknown>) & {
+  spawn: (prompt: string, opts?: SliccyAgentOptions) => Promise<SliccyAgentSpawnResult>;
+};
+
+/**
+ * Base64-encode a UTF-8 string for `--schema-b64`. Same byte-for-byte shape as
+ * the workflow-DSL `__b64` helper in `workflow-prelude.ts` (TextEncoder →
+ * String.fromCharCode → btoa), so the `agent` command's `atob`/`TextDecoder`
+ * decode path round-trips identically.
+ */
+function agentSchemaToB64(json: string): string {
+  const bytes = new TextEncoder().encode(json);
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+/**
+ * Build the `agent` command argv. Mirrors the workflow-DSL `agent()` in
+ * `workflow-prelude.ts`: flags (`--model` / `--thinking` / `--schema-b64`)
+ * first, then the `--read-only <csv>` flag and the three positionals
+ * `<cwd> <allowedCommands> <prompt>`.
+ */
+function buildAgentArgv(prompt: string, opts: SliccyAgentOptions, realmCwd: string): string[] {
+  const flags: string[] = [];
+  if (opts.model) flags.push('--model', String(opts.model));
+  if (opts.thinking) flags.push('--thinking', String(opts.thinking));
+  if (opts.schema) flags.push('--schema-b64', agentSchemaToB64(JSON.stringify(opts.schema)));
+  const readOnly =
+    opts.readOnly === undefined
+      ? '/workspace/'
+      : Array.isArray(opts.readOnly)
+        ? opts.readOnly.join(',')
+        : String(opts.readOnly);
+  const cwd = opts.cwd !== undefined ? String(opts.cwd) : realmCwd || '.';
+  const allowed = opts.allowedCommands !== undefined ? String(opts.allowedCommands) : '*';
+  return ['agent', ...flags, '--read-only', readOnly, cwd, allowed, String(prompt)];
+}
+
+/**
+ * `sliccy:agent` — client-side sugar over the `exec` bridge that shells out to
+ * the `agent` supplemental command (spawn a sub-scoop, feed it a task, block
+ * until the agent loop completes). Option A: no host/RPC channel; argv
+ * construction mirrors the workflow-DSL `agent()` in `workflow-prelude.ts`.
+ *
+ * The callable `agent(prompt, opts?)` resolves to trimmed stdout (JSON-parsed
+ * when `opts.schema` is set) and REJECTS with an Error (message carries stderr
+ * + exitCode) on a non-zero exit or a schema parse failure. `agent.spawn` is
+ * the non-throwing variant — resolves `{ finalText, exitCode, stderr }`
+ * regardless of exit code. Mirrored byte-parallel in
+ * `packages/chrome-extension/sandbox.html`.
+ */
+export function createSliccyAgentModule(
+  execBridge: ExecBridge,
+  opts: { cwd: string }
+): SliccyAgentModule {
+  const realmCwd = opts.cwd;
+  const spawn = async (
+    prompt: string,
+    agentOpts?: SliccyAgentOptions
+  ): Promise<SliccyAgentSpawnResult> => {
+    const o = agentOpts ?? {};
+    const r = await execBridge.spawn(buildAgentArgv(prompt, o, realmCwd));
+    const exitCode = typeof r.exitCode === 'number' ? r.exitCode : 0;
+    const finalText = String(r.stdout ?? '').replace(/\n+$/, '');
+    const stderr = String(r.stderr ?? '').replace(/\n+$/, '');
+    return { finalText, exitCode, stderr };
+  };
+  const agent = (async (prompt: string, agentOpts?: SliccyAgentOptions): Promise<unknown> => {
+    const o = agentOpts ?? {};
+    const res = await spawn(prompt, o);
+    if (res.exitCode !== 0) {
+      throw new Error(
+        `agent: exited with code ${res.exitCode}${res.stderr ? `: ${res.stderr}` : ''}`
+      );
+    }
+    if (o.schema) {
+      try {
+        return JSON.parse(res.finalText);
+      } catch {
+        throw new Error(
+          `agent: schema response was not valid JSON (exit ${res.exitCode}): ${res.finalText.slice(0, 200)}`
+        );
+      }
+    }
+    return res.finalText;
+  }) as SliccyAgentModule;
+  agent.spawn = spawn;
+  return agent;
 }
 
 function buildSliccyModules(bridges: Record<string, unknown>): Record<string, unknown> {

--- a/packages/webapp/src/shell/supplemental-commands/workflow-prelude.ts
+++ b/packages/webapp/src/shell/supplemental-commands/workflow-prelude.ts
@@ -5,8 +5,8 @@
  *
  * Post m3 globals hard-cut: the realm only injects the Node-standard surface
  * (process/console/require/module/exports/fetch/__dirname/__filename) plus `__WF`.
- * The capability bridges (exec, skill, http, browser, usb, serial, hid, cli, color,
- * time, fmt, pool) and the VFS bridge (fs) reach the workflow via
+ * The capability bridges (exec, agent, skill, http, browser, usb, serial, hid, cli,
+ * color, time, fmt, pool) and the VFS bridge (fs) reach the workflow via
  * `require('sliccy:<name>')` / `require('fs')`. The `agent()` orchestrator reads
  * `exec.spawn` via the `sliccy:exec` module; the legacy bare-`exec` lookup is kept
  * so the prelude unit test (which builds its own AsyncFunction with `exec` in the

--- a/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
+++ b/packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts
@@ -303,6 +303,7 @@ describe('sandbox.html mirror parity', () => {
     // resolves in lockstep with the worker realm.
     for (const id of [
       'exec',
+      'agent',
       'skill',
       'http',
       'browser',

--- a/packages/webapp/tests/kernel/realm/sliccy-modules.test.ts
+++ b/packages/webapp/tests/kernel/realm/sliccy-modules.test.ts
@@ -434,3 +434,165 @@ describe('Node-standard globals + CJS scope vars remain bare', () => {
     expect(out.stdout.trim()).toBe('/workspace/skills/foo || /workspace/skills/foo/bar.jsh');
   });
 });
+
+describe("require('sliccy:agent') — callable + non-throwing .spawn", () => {
+  type ExecCall = { cmd: string; args: string[] };
+
+  // `agent(...)` shells out via `execBridge.spawn(argv)`, which the realm host
+  // translates to `ctx.exec(argv[0], { args: argv.slice(1) })` — so the mock
+  // records `cmd` + `args` and `argvOf` reconstructs the full argv the module
+  // built (`buildAgentArgv` in `kernel/realm/js-realm-shared.ts`).
+  function makeAgentCtx(
+    result: { stdout?: string; stderr?: string; exitCode?: number },
+    calls: ExecCall[]
+  ): CommandContext {
+    return makeCtx({
+      exec: (async (command, opts: { args?: string[] } = {}) => {
+        calls.push({ cmd: command, args: Array.isArray(opts.args) ? opts.args : [] });
+        return {
+          stdout: result.stdout ?? '',
+          stderr: result.stderr ?? '',
+          exitCode: result.exitCode ?? 0,
+        };
+      }) as CommandContext['exec'],
+    });
+  }
+  const argvOf = (c: ExecCall): string[] => [c.cmd, ...c.args];
+
+  it('is a callable with a .spawn sibling', async () => {
+    const calls: ExecCall[] = [];
+    const ctx = makeAgentCtx({ stdout: 'ok\n' }, calls);
+    const code = `
+      const agent = require('sliccy:agent');
+      console.log(typeof agent);
+      console.log(typeof agent.spawn);
+    `;
+    const out = await runCode(code, ctx);
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.split('\n').filter(Boolean)).toEqual(['function', 'function']);
+  });
+
+  it("plain agent('hi') builds default argv and resolves to trimmed stdout", async () => {
+    const calls: ExecCall[] = [];
+    const ctx = makeAgentCtx({ stdout: '  the answer  \n\n' }, calls);
+    const code = `
+      const agent = require('sliccy:agent');
+      const r = await agent('hi');
+      console.log(JSON.stringify(r));
+    `;
+    const out = await runCode(code, ctx);
+    expect(out.exitCode).toBe(0);
+    // realm ctx.cwd is '/workspace', so the default positional cwd is '/workspace'.
+    expect(argvOf(calls[0])).toEqual([
+      'agent',
+      '--read-only',
+      '/workspace/',
+      '/workspace',
+      '*',
+      'hi',
+    ]);
+    // finalText only strips trailing newlines, not surrounding spaces.
+    expect(out.stdout.trim()).toBe(JSON.stringify('  the answer  '));
+  });
+
+  it('--model / --thinking / readOnly[] / custom cwd + allowedCommands map to argv', async () => {
+    const calls: ExecCall[] = [];
+    const ctx = makeAgentCtx({ stdout: 'done\n' }, calls);
+    const code = `
+      const agent = require('sliccy:agent');
+      await agent('do it', {
+        model: 'claude-opus-4-6',
+        thinking: 'high',
+        readOnly: ['/a', '/b'],
+        cwd: '/work',
+        allowedCommands: 'git,ls',
+      });
+    `;
+    const out = await runCode(code, ctx);
+    expect(out.exitCode).toBe(0);
+    expect(argvOf(calls[0])).toEqual([
+      'agent',
+      '--model',
+      'claude-opus-4-6',
+      '--thinking',
+      'high',
+      '--read-only',
+      '/a,/b',
+      '/work',
+      'git,ls',
+      'do it',
+    ]);
+  });
+
+  it('readOnly as a CSV string passes through verbatim', async () => {
+    const calls: ExecCall[] = [];
+    const ctx = makeAgentCtx({ stdout: 'ok\n' }, calls);
+    const code = `
+      const agent = require('sliccy:agent');
+      await agent('x', { readOnly: '/a,/b,/c' });
+    `;
+    const out = await runCode(code, ctx);
+    expect(out.exitCode).toBe(0);
+    expect(argvOf(calls[0])).toEqual(['agent', '--read-only', '/a,/b,/c', '/workspace', '*', 'x']);
+  });
+
+  it('schema → --schema-b64 present (decodes to schema JSON) and result is JSON-parsed', async () => {
+    const calls: ExecCall[] = [];
+    const ctx = makeAgentCtx({ stdout: '{"ok":true,"n":42}\n' }, calls);
+    const code = `
+      const agent = require('sliccy:agent');
+      const r = await agent('give json', { schema: { type: 'object' } });
+      console.log(typeof r);
+      console.log(JSON.stringify(r));
+    `;
+    const out = await runCode(code, ctx);
+    expect(out.exitCode).toBe(0);
+    const argv = argvOf(calls[0]);
+    const flagIdx = argv.indexOf('--schema-b64');
+    expect(flagIdx).toBeGreaterThanOrEqual(0);
+    const b64 = argv[flagIdx + 1];
+    expect(typeof b64).toBe('string');
+    expect(Buffer.from(b64, 'base64').toString('utf-8')).toBe(JSON.stringify({ type: 'object' }));
+    const lines = out.stdout.split('\n').filter(Boolean);
+    expect(lines[0]).toBe('object');
+    expect(lines[1]).toBe(JSON.stringify({ ok: true, n: 42 }));
+  });
+
+  it('non-zero exit → callable rejects while .spawn resolves with exitCode!==0', async () => {
+    const calls: ExecCall[] = [];
+    const ctx = makeAgentCtx({ stdout: '', stderr: 'kaboom\n', exitCode: 2 }, calls);
+    const code = `
+      const agent = require('sliccy:agent');
+      let rejected = false;
+      try { await agent('boom'); }
+      catch (e) { rejected = true; console.log('ERR:' + e.message); }
+      console.log('rejected=' + rejected);
+      const s = await agent.spawn('boom');
+      console.log('spawn.exitCode=' + s.exitCode);
+      console.log('spawn.stderr=' + s.stderr);
+      console.log('spawn.finalText=' + JSON.stringify(s.finalText));
+    `;
+    const out = await runCode(code, ctx);
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout).toContain('ERR:agent: exited with code 2: kaboom');
+    expect(out.stdout).toContain('rejected=true');
+    expect(out.stdout).toContain('spawn.exitCode=2');
+    expect(out.stdout).toContain('spawn.stderr=kaboom');
+    expect(out.stdout).toContain('spawn.finalText=""');
+  });
+
+  it('invalid JSON with schema → callable rejects with a helpful message', async () => {
+    const calls: ExecCall[] = [];
+    const ctx = makeAgentCtx({ stdout: 'not json at all\n', exitCode: 0 }, calls);
+    const code = `
+      const agent = require('sliccy:agent');
+      try { await agent('give', { schema: { type: 'object' } }); console.log('UNEXPECTED'); }
+      catch (e) { console.log('ERR:' + e.message); }
+    `;
+    const out = await runCode(code, ctx);
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout).not.toContain('UNEXPECTED');
+    expect(out.stdout).toContain('agent: schema response was not valid JSON');
+    expect(out.stdout).toContain('not json at all');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a first-class `require('sliccy:agent')` capability module for `.jsh` scripts (and `node -e`). Previously `sliccy:agent` threw `unknown sliccy: module 'agent'`; scripts had to shell out to the `agent` CLI via `sliccy:exec` and hand-build/quote argv (as `monday.jsh` does today). This turns that pattern into a proper, typed module.

## Why

`.jsh` scripts already spawn sub-agents, but the only way was to build `['agent', ...]` argv by hand through `sliccy:exec` — verbose, easy to mis-quote, and inconsistent with the workflow-DSL `agent()` helper. See the Spec / plan in the workspace. No linked issue.

## Approach / Implementation notes

**Option A (client-only sugar):** the module is a thin wrapper over the existing `exec` bridge — it builds the `agent` command argv and calls `.spawn(['agent', ...])`. No host/RPC channel was added, so it works identically across the CLI and extension floats by construction.

- Layering: `createSliccyAgentModule` factory lives in `js-realm-shared.ts` and is registered as `agent` in `buildSliccyModules`; the extension iframe realm carries a byte-parallel inline mirror in `sandbox.html`.
- argv mirrors the workflow-DSL `agent()` in `workflow-prelude.ts` (`--model` / `--thinking` / `--schema-b64`, then `--read-only <csv> <cwd> <allowedCommands> <prompt>`) so there is one mental model across the codebase.
- The callable **rejects** on non-zero exit or invalid-JSON-with-`schema`; `.spawn` never rejects and returns `{ finalText, exitCode, stderr }`.
- No new dependencies.

### API

```js
const agent = require('sliccy:agent');

const answer = await agent('summarize the files here');         // -> trimmed text
const data   = await agent('extract title + tags', { schema }); // -> JSON-parsed object
const { finalText, exitCode, stderr } = await agent.spawn('do a thing', opts);
```

Options: `model`, `thinking`, `cwd` (default `.`), `allowedCommands` (default `*`), `readOnly` (array or CSV), `schema`.

## Cross-cutting impact

- **Floats exercised**: CLI (worker realm via `js-realm-shared.ts`) and Chrome extension (sandbox iframe realm via `sandbox.html`) — kept in lockstep, asserted by the parity test.
- **Shell contexts**: the sandbox iframe realm is the one touched; the two `AlmostBashShell` contexts are unaffected (this adds a require-module, not a shell command).
- **Other callers**: additive only — a new entry in the `sliccyModules` registry; no existing bridge behavior changed.
- **Persisted state**: none.
- **Security**: prompts/args flow through the existing `exec` bridge argv path; no new secret surface.

## Test plan

- [x] `npx prettier --write <changed-files>` (via lint-staged on commit)
- [x] `npm run typecheck` — PASS (9 projects)
- [x] `npm run lint` — PASS
- [x] `npm run test` — targeted realm suites PASS (84/84), `test:coverage:webapp` floor held (exit 0)
- [x] **New behavior covered by unit tests**: `npx vitest run packages/webapp/tests/kernel/realm/sliccy-modules.test.ts` — 7 cases (argv/defaults, `--model`/`--thinking`, `readOnly` array+CSV, `--schema-b64` decode + JSON parse, reject-vs-`.spawn` failure paths)
- [x] Parity lockstep: `packages/webapp/tests/kernel/realm/js-realm-helpers.test.ts` asserts worker + sandbox expose `agent` identically
- [ ] N/A — no UI change (no screencast needed)

**Pre-existing failures** (unrelated to this PR): one environmental playwright iframe / Chrome-launch failure (`chrome-launch.ts`) observed locally; not a feature regression, coverage gate still exits 0.

## Documentation

- [x] `docs/` (agent reference): `skill-authoring/jsh-runtime-extensions.md` row + usage block
- [x] `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing): `skill-authoring/SKILL.md` row; `workflow-prelude.ts` header comment
- [ ] Follow-up: add `agent` to the `require('sliccy:<name>')` enumeration row in `docs/adding-features.md` (one-liner; it already links to the canonical reference doc that lists it)

## Risk & rollback

- Blast radius: low — additive registry entry; reverting this PR cleanly removes the module with no state migration.
- No feature flags or env knobs.
- Nothing CI cannot catch beyond the standard extension smoke.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Public API / shell-command changes are intentional and reflected in docs
- [x] Contract used by other floats (CLI ↔ extension): checked worker realm + sandbox mirror parity
