### PR TITLE
docs: fix stale CLAUDE.md browser-bundle typecheck bullet (#1464)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Virtual Filesystem (packages/webapp/src/fs/) → RestrictedFS → Shell (package
 
 `npm run typecheck` runs nine `tsc --noEmit` invocations:
 
-- **Browser bundle** (`tsconfig.json`): `packages/webapp/` + extension `tests/`. The Vite-built extension reuses this config; its extra entries are bundle-time only. Webapp `tests/` pending `#1337`.
+- **Browser bundle** (`tsconfig.json`): `packages/webapp/` (src, tests, providers) + `packages/chrome-extension/` (src + tests). The Vite-built extension reuses this config; its extra entries are bundle-time only.
 - **CLI/Electron** (`tsconfig.cli.json`): `packages/node-server/src/`, compiled to `dist/node-server/`; `packages/node-server/tsconfig.json` adds `tests/`.
 - **Tray-hub worker** (`tsconfig.worker.json`): `packages/cloudflare-worker/` src+tests.
 - **Kernel-worker safety guard** (`tsconfig.webapp-worker.json`): checks DedicatedWorker-side webapp code with a no-DOM lib set so accidental `window` references fail.


### PR DESCRIPTION
<!-- Fixes #1464 -->

## Summary

Fix a stale bullet in root CLAUDE.md's typecheck build-targets list. The browser-bundle bullet claimed webapp tests/ typecheck was "pending #1337", but #1337 is closed/released and tsconfig.json's include already covers packages/webapp/tests/**/*.ts.

## Why

Fixes #1464. Root CLAUDE.md is always loaded into agent context, so drift here is high-blast-radius: a reader concludes webapp test files are not typechecked (they are) and is pointed at a closed issue as outstanding work.

Evidence:
- #1337 is CLOSED (released), landed via commit a8c39ebd5.
- tsconfig.json include lists packages/webapp/tests/**/*.ts.

## Approach

Single-line edit to CLAUDE.md:153. Before: 'packages/webapp/ + extension tests/ ... Webapp tests/ pending #1337.' After: 'packages/webapp/ (src, tests, providers) + packages/chrome-extension/ (src + tests).'

## Test plan

- [x] grep -rn "1337" --include="*.md" . returns no results
- [x] prettier --check CLAUDE.md passes
- [x] N/A — docs-only change, no code affected

## Documentation

- [x] Relevant CLAUDE.md (this PR is the doc change)

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under dist/
- [x] No secrets or tokens in the diff
