### PR TITLE
Fix #1379: key binary-cache by the string itself instead of a sampled hash

### DIFF
--- a/packages/webapp/src/shell/binary-cache.ts
+++ b/packages/webapp/src/shell/binary-cache.ts
@@ -14,33 +14,16 @@
 const cache = new Map<string, Uint8Array>();
 const urlCache = new Map<string, Uint8Array>();
 
-/** Generate a cache key from a string's length and a few sample bytes. */
-function cacheKey(s: string): string {
-  // Use length + 8 sample chars for fast (but imperfect) key generation.
-  // Collisions are acceptable — the cache is short-lived and entries are
-  // consumed immediately after the next writeFile call.
-  const len = s.length;
-  if (len === 0) return '0';
-  const a = s.charCodeAt(0);
-  const b = len > 1 ? s.charCodeAt(1) : 0;
-  const c = len > 2 ? s.charCodeAt(2) : 0;
-  const d = len > 3 ? s.charCodeAt(3) : 0;
-  const e = len > 4 ? s.charCodeAt(Math.floor(len / 4)) : 0;
-  const f = len > 4 ? s.charCodeAt(Math.floor(len / 2)) : 0;
-  const g = len > 4 ? s.charCodeAt(Math.floor((3 * len) / 4)) : 0;
-  const h = s.charCodeAt(len - 1);
-  return `${len}:${a}:${b}:${c}:${d}:${e}:${f}:${g}:${h}`;
-}
-
 /**
- * Store binary data associated with a latin1-encoded string body.
- * Called by createProxiedFetch when a binary response is received.
+ * Store binary data keyed directly by its latin1-encoded string body.
+ * Called by createProxiedFetch when a binary response is received without a
+ * URL to key on. The string body is used verbatim as the cache key, so
+ * lookups are exact (no hashing, no collisions).
  */
 export function cacheBinaryBody(latin1Body: string, bytes: Uint8Array): void {
-  const key = cacheKey(latin1Body);
-  cache.set(key, bytes);
+  cache.set(latin1Body, bytes);
   // Auto-expire after 10s to prevent memory leaks if writeFile is never called
-  setTimeout(() => cache.delete(key), 10_000);
+  setTimeout(() => cache.delete(latin1Body), 10_000);
 }
 
 /**
@@ -69,14 +52,14 @@ export function consumeCachedBinaryByUrl(url: string): Uint8Array | null {
 
 /**
  * Try to retrieve cached binary data for a string body.
- * Called by VfsAdapter.writeFile to bypass string encoding.
+ * Called by VfsAdapter.writeFile to bypass string encoding. Looks the body
+ * up directly (exact key match) and consumes the entry on a hit.
  * Returns the original bytes if found, null otherwise.
  */
 export function consumeCachedBinary(body: string): Uint8Array | null {
-  const key = cacheKey(body);
-  const bytes = cache.get(key);
+  const bytes = cache.get(body);
   if (bytes) {
-    cache.delete(key);
+    cache.delete(body);
     return bytes;
   }
   return null;

--- a/packages/webapp/src/shell/proxied-fetch.ts
+++ b/packages/webapp/src/shell/proxied-fetch.ts
@@ -191,13 +191,18 @@ export async function readResponseBody(resp: Response, url?: string): Promise<Ui
   const buf = await resp.arrayBuffer();
   const bytes = new Uint8Array(buf);
   if (!isTextContentType(contentType)) {
-    let byteKey = '';
-    for (let i = 0; i < bytes.length; i += 0x8000) {
-      byteKey += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
-    }
-    cacheBinaryBody(byteKey, bytes);
+    // Prefer the URL cache (the common case) — it avoids the multi-MB latin1
+    // string allocation. VfsAdapter.writeFile still recovers exact bytes on
+    // that path via its charCodeAt latin1 fallback. Only build the full-body
+    // latin1 string when there is no URL to key on.
     if (url) {
       cacheBinaryByUrl(url, bytes);
+    } else {
+      let byteKey = '';
+      for (let i = 0; i < bytes.length; i += 0x8000) {
+        byteKey += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+      }
+      cacheBinaryBody(byteKey, bytes);
     }
   }
   return bytes;

--- a/packages/webapp/tests/shell/binary-cache.test.ts
+++ b/packages/webapp/tests/shell/binary-cache.test.ts
@@ -3,8 +3,19 @@
  * through just-bash's string-typed FetchResult.body pipeline.
  */
 
+import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../src/fs/index.js';
 import { cacheBinaryBody, consumeCachedBinary } from '../../src/shell/binary-cache.js';
+import { readResponseBody } from '../../src/shell/proxied-fetch.js';
+import { VfsAdapter } from '../../src/shell/vfs-adapter.js';
+
+/** Latin1-encode bytes exactly as the just-bash body pipeline does. */
+function latin1FromBytes(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return s;
+}
 
 describe('binary-cache', () => {
   beforeEach(() => {
@@ -80,5 +91,61 @@ describe('binary-cache', () => {
 
     expect(consumeCachedBinary(body1)).toEqual(bytes1);
     expect(consumeCachedBinary(body2)).toEqual(bytes2);
+  });
+});
+
+describe('binary-cache round-trip through readResponseBody + writeFile', () => {
+  // Real timers: the round-trip consumes cache entries synchronously and does
+  // not depend on the 10s auto-expiry.
+  let vfs: VirtualFS;
+  let adapter: VfsAdapter;
+  let dbCounter = 0;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ dbName: `test-binary-cache-rt-${dbCounter++}`, wipe: true });
+    adapter = new VfsAdapter(vfs);
+  });
+
+  function allByteValues(): Uint8Array<ArrayBuffer> {
+    const bytes = new Uint8Array(new ArrayBuffer(256));
+    for (let i = 0; i < 256; i++) bytes[i] = i;
+    return bytes;
+  }
+
+  it('no-URL path: string cache yields byte-exact write', async () => {
+    const bytes = allByteValues();
+    const resp = new Response(bytes.buffer, {
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+    // No url → readResponseBody populates the string cache keyed by the body.
+    const returned = await readResponseBody(resp);
+    expect(Array.from(returned)).toEqual(Array.from(bytes));
+
+    // writeFile receives the latin1 body string and recovers exact bytes via
+    // the string cache.
+    const latin1 = latin1FromBytes(bytes);
+    await adapter.writeFile('/no-url.bin', latin1);
+    const written = (await vfs.readFile('/no-url.bin', { encoding: 'binary' })) as Uint8Array;
+    expect(Array.from(written)).toEqual(Array.from(bytes));
+  });
+
+  it('URL path: writeFile falls back to latin1 charCodeAt, byte-exact', async () => {
+    const bytes = allByteValues();
+    const resp = new Response(bytes.buffer, {
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+    // With a url, readResponseBody keys the URL cache only — the string cache
+    // is intentionally NOT populated (avoids the multi-MB allocation).
+    const returned = await readResponseBody(resp, 'https://example.com/pkg.zip');
+    expect(Array.from(returned)).toEqual(Array.from(bytes));
+
+    const latin1 = latin1FromBytes(bytes);
+    // String cache miss proves the URL path skipped it.
+    expect(consumeCachedBinary(latin1)).toBeNull();
+
+    // writeFile still recovers exact bytes via its charCodeAt latin1 fallback.
+    await adapter.writeFile('/url.bin', latin1);
+    const written = (await vfs.readFile('/url.bin', { encoding: 'binary' })) as Uint8Array;
+    expect(Array.from(written)).toEqual(Array.from(bytes));
   });
 });


### PR DESCRIPTION
Fixes #1379.

## Problem

`packages/webapp/src/shell/binary-cache.ts` held two `Map<string, Uint8Array>` caches with identical shape and 10s lifetime. `urlCache` keyed on the raw URL string with no ceremony. `cache` instead ran the string through `cacheKey()` — a hand-rolled 8-code-point positional sample whose own comment admitted "collisions are acceptable — the cache is short-lived." That is the argument for *not hashing at all*: a `Map` already keys by string identity.

Worse, to feed that hash, `readResponseBody` (`proxied-fetch.ts`) built a **full-length latin1 string of the entire binary body** — multi-MB for every case that motivated the cache (git packs, upskill zips, images/PDFs/fonts, WASM cores, model shards) — via a 32-KiB-chunked `String.fromCharCode` loop, only to read 8 characters from it.

## Change

- **`binary-cache.ts`** — deleted `cacheKey`. The `cache` `Map<string, Uint8Array>` is now keyed directly by the raw latin1 body string, exactly like the sibling `urlCache`. `cacheBinaryBody` sets/expires by the body string; `consumeCachedBinary` does `cache.get(body)` then `cache.delete(body)`. Public signatures unchanged. Stale hashing/collision comments removed.
- **`proxied-fetch.ts` `readResponseBody`** — the chunked `String.fromCharCode` whole-body allocation now runs **only** on the rare no-URL branch. When a `url` is present (the common case) it just calls `cacheBinaryByUrl`. `VfsAdapter.writeFile`'s existing `charCodeAt` latin1 fallback keeps that path byte-exact, so no corruption is introduced.
- **Tests** — added byte-exact round-trip regression tests for both the URL-cache and no-URL string-cache paths (all 256 byte values).

`urlCache` / `cacheBinaryByUrl` / `consumeCachedBinaryByUrl` and the `upskill/github/github-zip.ts` consumer are untouched.

## Verification

- typecheck: PASS (all 9 tsc projects)
- vitest binary-cache + proxied-fetch shell suites: PASS (6 files, 50 tests)
- root lint (`lint:ci`) + biome + prettier: PASS

Independently reviewed by a verifier agent: all acceptance criteria pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author