### PR TITLE
fix(swift-launcher): relax stale release-count assertion in update-check test

### DIFF
--- a/packages/swift-launcher/SliccstartTests/UpdateCheckIntegrationTests.swift
+++ b/packages/swift-launcher/SliccstartTests/UpdateCheckIntegrationTests.swift
@@ -26,10 +26,16 @@ final class UpdateCheckIntegrationTests: XCTestCase {
             owner: "ai-ecoverse", repo: "slicc", proxy: nil
         )
 
-        // We have many releases — at least 5
+        // We have many releases — at least 5. `fetchReleases` only returns
+        // releases carrying an installable macOS asset (Sliccstart-*.zip), and
+        // native artifacts are now built conditionally, so the filtered list can
+        // be small. Assert the "many releases" intent against the UNFILTERED
+        // release list instead.
+        let rawData = try await fetchReleasesJSON(owner: "ai-ecoverse", repo: "slicc")
+        let rawReleases = try JSONDecoder().decode([Release].self, from: rawData)
         XCTAssertGreaterThanOrEqual(
-            releases.count, 5,
-            "Expected at least 5 releases from ai-ecoverse/slicc, got \(releases.count)"
+            rawReleases.count, 5,
+            "Expected at least 5 releases from ai-ecoverse/slicc, got \(rawReleases.count)"
         )
 
         // At least one release should have a real version (not 0.0.0),


### PR DESCRIPTION
## Problem

The `swift-launcher` CI job fails on `testTolerantProviderFetchesReleasesWithCorrectVersions()` because of a stale assertion:

```swift
XCTAssertGreaterThanOrEqual(releases.count, 5, ...)
```

`TolerantGithubReleaseProvider.fetchReleases` only returns releases that carry an installable macOS asset (`Sliccstart-*.zip`). Native artifacts are now built **conditionally**, so only ~2 of the top-30 releases currently qualify — the filtered list no longer contains 5+ entries, and the assertion fails. This blocks the `ci` gate on #1463.

## Fix

Assert the "many releases" intent against the **unfiltered** raw release list (via the existing `fetchReleasesJSON` helper) instead of the filtered `fetchReleases` result. The two other assertions are unchanged:

- at least one release parses to a non-null version (v-prefix tolerant decoding works), and
- at least one release has a `Sliccstart-*.zip` asset (naming convention matches `viableAsset`).

Only `packages/swift-launcher/SliccstartTests/UpdateCheckIntegrationTests.swift` is touched.

## Verification

Run locally with `GH_TOKEN` set:

- `cd packages/swift-launcher && swift build` — ✅ build complete
- `swift test --filter UpdateCheckIntegrationTests` — ✅ 2 tests, 0 failures
- `npm run lint -w @slicc/swift-launcher` — ✅ 0 serious violations (only pre-existing warnings)

Unblocks #1463.
