### PR TITLE
Fix zombie crontask: prevent and self-heal orphaned licks

### DIFF
--- a/packages/webapp/src/scoops/lick-manager.ts
+++ b/packages/webapp/src/scoops/lick-manager.ts
@@ -309,11 +309,21 @@ export class LickManager {
 
   /** Delete a webhook */
   async deleteWebhook(id: string): Promise<boolean> {
-    if (!this.webhooks.has(id)) return false;
-    this.webhooks.delete(id);
-    await db.deleteWebhook(id);
-    log.info('Webhook deleted', { id });
-    return true;
+    if (this.webhooks.has(id)) {
+      this.webhooks.delete(id);
+      await db.deleteWebhook(id);
+      log.info('Webhook deleted', { id });
+      return true;
+    }
+    // Not in this worker's in-memory map: consult the DB so a
+    // persisted-but-not-loaded webhook (multi-worker/tab drift) can still
+    // be removed by the guard's remediation command.
+    if ((await db.getWebhook(id)) !== null) {
+      await db.deleteWebhook(id);
+      log.info('Webhook deleted', { id });
+      return true;
+    }
+    return false;
   }
 
   /** List all webhooks */
@@ -414,11 +424,21 @@ export class LickManager {
 
   /** Delete a cron task */
   async deleteCronTask(id: string): Promise<boolean> {
-    if (!this.crontasks.has(id)) return false;
-    this.crontasks.delete(id);
-    await db.deleteCronTask(id);
-    log.info('Cron task deleted', { id });
-    return true;
+    if (this.crontasks.has(id)) {
+      this.crontasks.delete(id);
+      await db.deleteCronTask(id);
+      log.info('Cron task deleted', { id });
+      return true;
+    }
+    // Not in this worker's in-memory map: consult the DB so a
+    // persisted-but-not-loaded cron task (multi-worker/tab drift) can still
+    // be removed by the guard's remediation command.
+    if ((await db.getCronTask(id)) !== null) {
+      await db.deleteCronTask(id);
+      log.info('Cron task deleted', { id });
+      return true;
+    }
+    return false;
   }
 
   /** List all cron tasks */

--- a/packages/webapp/src/scoops/lick-manager.ts
+++ b/packages/webapp/src/scoops/lick-manager.ts
@@ -125,6 +125,15 @@ export class LickManager {
    * See {@link discoveryFingerprint}.
    */
   private seenDiscoveryFingerprints = new Set<string>();
+  /**
+   * Resolver injected by the orchestrator: given a lick's `scoop` field,
+   * returns whether a matching scoop is still registered (using the same
+   * alias matching as {@link getLicksForScoop}). Used to detect orphaned
+   * licks at boot ({@link init}) and on every scheduler tick
+   * ({@link runCronScheduler}). `null` until wired — every orphan check is a
+   * no-op while unset, preserving pre-injection behavior (tests / early boot).
+   */
+  private scoopResolver: ((scoopField: string) => boolean) | null = null;
 
   /** Initialize - load from IndexedDB and start cron scheduler */
   async init(): Promise<void> {
@@ -145,9 +154,74 @@ export class LickManager {
     }
     log.info('Loaded crontasks', { count: this.crontasks.size });
 
+    // Reconcile against the scoop-existence resolver (no-op if unwired):
+    // drop any lick whose target scoop no longer exists before the scheduler
+    // starts, so a stale crontask can't fire on boot.
+    await this.reconcileOrphans();
+
     // Start cron scheduler (every 60 seconds)
     this.cronInterval = setInterval(() => this.runCronScheduler(), 60000);
     log.info('Cron scheduler started');
+  }
+
+  /**
+   * Inject the scoop-existence resolver (or clear it with `null`). The
+   * orchestrator wires this in `setLickManager` using the shared alias
+   * matching so orphaned-lick detection follows the same name / folder /
+   * `<scoop>-scoop` rules as {@link getLicksForScoop}.
+   */
+  setScoopExistenceResolver(resolver: ((scoopField: string) => boolean) | null): void {
+    this.scoopResolver = resolver;
+  }
+
+  /** True when `scoopField` is set but resolves to no registered scoop. */
+  private isOrphanedLick(scoopField: string | undefined): boolean {
+    if (!this.scoopResolver || !scoopField) return false;
+    return !this.scoopResolver(scoopField);
+  }
+
+  /**
+   * Remove orphaned licks — those whose `scoop` field is set but resolves to
+   * a scoop that no longer exists. No-op when no resolver is wired. Called at
+   * boot from {@link init} so a scoop deleted while its tab was closed can't
+   * leave a firing crontask or a live webhook behind.
+   */
+  private async reconcileOrphans(): Promise<void> {
+    if (!this.scoopResolver) return;
+    for (const wh of Array.from(this.webhooks.values())) {
+      if (!this.isOrphanedLick(wh.scoop)) continue;
+      log.warn('Removing orphaned webhook at init; target scoop no longer exists', {
+        id: wh.id,
+        name: wh.name,
+        scoop: wh.scoop,
+      });
+      this.webhooks.delete(wh.id);
+      try {
+        await db.deleteWebhook(wh.id);
+      } catch (err) {
+        log.warn('Failed to delete orphaned webhook from DB', {
+          id: wh.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    for (const ct of Array.from(this.crontasks.values())) {
+      if (!this.isOrphanedLick(ct.scoop)) continue;
+      log.warn('Removing orphaned cron task at init; target scoop no longer exists', {
+        id: ct.id,
+        name: ct.name,
+        scoop: ct.scoop,
+      });
+      this.crontasks.delete(ct.id);
+      try {
+        await db.deleteCronTask(ct.id);
+      } catch (err) {
+        log.warn('Failed to delete orphaned cron task from DB', {
+          id: ct.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 
   /** Clean up */
@@ -367,11 +441,56 @@ export class LickManager {
     name: string,
     folder: string
   ): { webhooks: WebhookEntry[]; cronTasks: CronTaskEntry[] } {
-    const matches = (scoopField: string | undefined): boolean =>
-      scoopField === name || scoopField === folder || `${scoopField}-scoop` === folder;
-    const webhooks = Array.from(this.webhooks.values()).filter((wh) => matches(wh.scoop));
-    const cronTasks = Array.from(this.crontasks.values()).filter((ct) => matches(ct.scoop));
+    const webhooks = Array.from(this.webhooks.values()).filter((wh) =>
+      lickScoopMatches(wh.scoop, name, folder)
+    );
+    const cronTasks = Array.from(this.crontasks.values()).filter((ct) =>
+      lickScoopMatches(ct.scoop, name, folder)
+    );
     return { webhooks, cronTasks };
+  }
+
+  /**
+   * Persistence-authoritative variant of {@link getLicksForScoop}: reads the
+   * webhooks / cron tasks straight from IndexedDB rather than the in-memory
+   * maps. Used by the unregister guard so a lick persisted by another worker
+   * (but not yet loaded into this instance) still blocks a scoop drop.
+   */
+  async getLicksForScoopFromDb(
+    name: string,
+    folder: string
+  ): Promise<{ webhooks: WebhookEntry[]; cronTasks: CronTaskEntry[] }> {
+    const [allWebhooks, allCronTasks] = await Promise.all([
+      db.getAllWebhooks(),
+      db.getAllCronTasks(),
+    ]);
+    const webhooks = allWebhooks.filter((wh) => lickScoopMatches(wh.scoop, name, folder));
+    const cronTasks = allCronTasks.filter((ct) => lickScoopMatches(ct.scoop, name, folder));
+    return { webhooks, cronTasks };
+  }
+
+  /**
+   * Self-heal: if `task` targets a scoop that no longer exists, drop it from
+   * memory + persistence and return `true` (the scheduler must skip it). No-op
+   * returning `false` when a resolver is unwired or the target still exists.
+   */
+  private async deleteIfOrphanedCron(task: CronTaskEntry): Promise<boolean> {
+    if (!this.isOrphanedLick(task.scoop)) return false;
+    log.warn('Deleting orphaned cron task; target scoop no longer exists', {
+      id: task.id,
+      name: task.name,
+      scoop: task.scoop,
+    });
+    this.crontasks.delete(task.id);
+    try {
+      await db.deleteCronTask(task.id);
+    } catch (err) {
+      log.warn('Failed to delete orphaned cron task from DB', {
+        id: task.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return true;
   }
 
   /** Run the cron scheduler - called every minute */
@@ -379,58 +498,65 @@ export class LickManager {
     const now = new Date();
 
     for (const task of this.crontasks.values()) {
+      // A task whose target scoop is gone must never fire again — drop it.
+      if (await this.deleteIfOrphanedCron(task)) continue;
+
       if (task.status !== 'active') continue;
       if (!task.nextRun) continue;
 
       const nextRun = new Date(task.nextRun);
       if (nextRun > now) continue;
 
-      // Task is due - run filter and dispatch
-      let payload: unknown = { time: now.toISOString() };
-
-      if (task.filter) {
-        try {
-          const filterFn = this.compileFilter(task.filter, false);
-          const result = filterFn(null);
-          if (result === false) {
-            log.debug('Cron task skipped by filter', { id: task.id, name: task.name });
-            // Update next run time even if skipped
-            const next = getNextCronTime(task.cron, now);
-            task.nextRun = next?.toISOString() ?? null;
-            task.lastRun = now.toISOString();
-            await db.saveCronTask(task);
-            continue;
-          }
-          if (typeof result === 'object' && result !== null) {
-            payload = result;
-          }
-        } catch (err) {
-          log.error('Cron filter error', {
-            id: task.id,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-
-      // Dispatch as a lick event
-      const event: LickEvent = {
-        type: 'cron',
-        cronId: task.id,
-        cronName: task.name,
-        targetScoop: task.scoop,
-        timestamp: now.toISOString(),
-        body: payload,
-      };
-
-      log.info('Cron task running', { id: task.id, name: task.name });
-      this.dispatch(event);
-
-      // Update times
-      const next = getNextCronTime(task.cron, now);
-      task.nextRun = next?.toISOString() ?? null;
-      task.lastRun = now.toISOString();
-      await db.saveCronTask(task);
+      await this.runDueCronTask(task, now);
     }
+  }
+
+  /** Run a single due cron task: apply its filter, dispatch, and reschedule. */
+  private async runDueCronTask(task: CronTaskEntry, now: Date): Promise<void> {
+    let payload: unknown = { time: now.toISOString() };
+
+    if (task.filter) {
+      try {
+        const filterFn = this.compileFilter(task.filter, false);
+        const result = filterFn(null);
+        if (result === false) {
+          log.debug('Cron task skipped by filter', { id: task.id, name: task.name });
+          // Update next run time even if skipped
+          const next = getNextCronTime(task.cron, now);
+          task.nextRun = next?.toISOString() ?? null;
+          task.lastRun = now.toISOString();
+          await db.saveCronTask(task);
+          return;
+        }
+        if (typeof result === 'object' && result !== null) {
+          payload = result;
+        }
+      } catch (err) {
+        log.error('Cron filter error', {
+          id: task.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // Dispatch as a lick event
+    const event: LickEvent = {
+      type: 'cron',
+      cronId: task.id,
+      cronName: task.name,
+      targetScoop: task.scoop,
+      timestamp: now.toISOString(),
+      body: payload,
+    };
+
+    log.info('Cron task running', { id: task.id, name: task.name });
+    this.dispatch(event);
+
+    // Update times
+    const next = getNextCronTime(task.cron, now);
+    task.nextRun = next?.toISOString() ?? null;
+    task.lastRun = now.toISOString();
+    await db.saveCronTask(task);
   }
 
   // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -469,6 +595,25 @@ export class LickManager {
       );
     }
   }
+}
+
+/**
+ * Shared alias matching between a lick's `scoop` field and a scoop's
+ * `name` / `folder`:
+ *  - exact match on name
+ *  - exact match on folder
+ *  - `scoopField + '-scoop'` matches folder (e.g. scoop="click-handler",
+ *    folder="click-handler-scoop")
+ * Used by {@link LickManager.getLicksForScoop}, the DB-backed lookup, and the
+ * orchestrator's scoop-existence resolver so all three agree on matching.
+ */
+export function lickScoopMatches(
+  scoopField: string | undefined,
+  name: string,
+  folder: string
+): boolean {
+  if (!scoopField) return false;
+  return scoopField === name || scoopField === folder || `${scoopField}-scoop` === folder;
 }
 
 /** Build the error thrown when trying to remove a scoop with active licks.

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -28,7 +28,12 @@ import { SudoManager } from '../sudo/sudo-manager.js';
 import { ConeMemoryStore } from './cone-memory-store.js';
 import * as db from './db.js';
 import { isExternalLickChannel } from './lick-formatting.js';
-import { buildActiveLicksError, type LickEvent, type LickManager } from './lick-manager.js';
+import {
+  buildActiveLicksError,
+  type LickEvent,
+  type LickManager,
+  lickScoopMatches,
+} from './lick-manager.js';
 import { LickRegistry } from './lick-registry.js';
 import { TaskScheduler } from './scheduler.js';
 import { ScoopApprovalRouter } from './scoop-approval-router.js';
@@ -535,6 +540,12 @@ export class Orchestrator implements ConeApprovalRouter {
   /** Set the LickManager for guarding scoop removal against active licks */
   setLickManager(lickManager: LickManager): void {
     this.lickManager = lickManager;
+    // Inject scoop-existence resolver so the LickManager can detect and
+    // self-heal orphaned licks (crontasks/webhooks whose target scoop is
+    // gone). Uses the shared alias matching so it agrees with the guard.
+    lickManager.setScoopExistenceResolver((scoopField) =>
+      this.getScoops().some((s) => lickScoopMatches(scoopField, s.name, s.folder))
+    );
     (globalThis as any).__slicc_lick_handler = (event: any) => {
       this.lickManager?.emitEvent(event);
     };

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -75,10 +75,10 @@ export interface ScoopLifecycleDb {
 }
 
 export interface ScoopLifecycleLickGuard {
-  getLicksForScoop(
+  getLicksForScoopFromDb(
     name: string,
     folder: string
-  ): { webhooks: ReadonlyArray<unknown>; cronTasks: ReadonlyArray<unknown> };
+  ): Promise<{ webhooks: ReadonlyArray<unknown>; cronTasks: ReadonlyArray<unknown> }>;
 }
 
 export interface ScoopLifecycleDeps {
@@ -540,7 +540,13 @@ export class ScoopLifecycleManager {
     const scoop = scoops.get(jid);
     const lickManager = this.deps.getLickManager();
     if (scoop && lickManager) {
-      const { webhooks, cronTasks } = lickManager.getLicksForScoop(scoop.name, scoop.folder);
+      // Consult persisted (IndexedDB) lick state — a lick that exists on disk
+      // but was never loaded into this worker's in-memory maps must still
+      // block the drop, otherwise it becomes a zombie after reload.
+      const { webhooks, cronTasks } = await lickManager.getLicksForScoopFromDb(
+        scoop.name,
+        scoop.folder
+      );
       const err = this.deps.buildActiveLicksError(scoop.folder, webhooks, cronTasks);
       if (err) throw err;
     }

--- a/packages/webapp/tests/scoops/lick-guard.test.ts
+++ b/packages/webapp/tests/scoops/lick-guard.test.ts
@@ -6,7 +6,13 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import 'fake-indexeddb/auto';
-import { buildActiveLicksError, LickManager } from '../../src/scoops/lick-manager.js';
+import * as db from '../../src/scoops/db.js';
+import {
+  buildActiveLicksError,
+  type CronTaskEntry,
+  LickManager,
+  type WebhookEntry,
+} from '../../src/scoops/lick-manager.js';
 
 // Each test gets a fresh LickManager WITHOUT calling init() to avoid
 // accumulating state in the shared IndexedDB across tests.
@@ -260,5 +266,62 @@ describe('LickManager orphan self-heal + persistence-authoritative guard', () =>
     expect(err?.message).toContain("Cannot remove scoop 'db-guard-scoop'");
 
     await seeder.deleteWebhook(wh.id);
+  });
+});
+
+describe('LickManager DB-authoritative delete (multi-worker drift remediation)', () => {
+  // Seeds rows directly into IndexedDB (bypassing the manager's in-memory map)
+  // so a fresh manager whose map lacks the id can still delete them — the exact
+  // remediation the persistence-authoritative drop guard tells users to run.
+
+  it('deleteCronTask removes a task that exists ONLY in the DB', async () => {
+    const id = 'db-only-cron-remediate';
+    const entry: CronTaskEntry = {
+      id,
+      name: 'db-only-cron',
+      cron: '*/5 * * * *',
+      scoop: 'db-only-cron-scoop',
+      filter: undefined,
+      nextRun: new Date().toISOString(),
+      lastRun: null,
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    };
+    await db.saveCronTask(entry);
+
+    // Fresh manager never loaded it, so the in-memory map lacks it.
+    const manager = new LickManager();
+    expect(manager.getCronTask(id)).toBeUndefined();
+
+    expect(await manager.deleteCronTask(id)).toBe(true);
+    expect(await db.getCronTask(id)).toBeNull();
+  });
+
+  it('deleteWebhook removes a webhook that exists ONLY in the DB', async () => {
+    const id = 'db-only-wh-remediate';
+    const entry: WebhookEntry = {
+      id,
+      name: 'db-only-wh',
+      createdAt: new Date().toISOString(),
+      filter: undefined,
+      scoop: 'db-only-wh-scoop',
+    };
+    await db.saveWebhook(entry);
+
+    const manager = new LickManager();
+    expect(manager.getWebhook(id)).toBeUndefined();
+
+    expect(await manager.deleteWebhook(id)).toBe(true);
+    expect(await db.getWebhook(id)).toBeNull();
+  });
+
+  it('deleteCronTask returns false when neither the map nor the DB has the id', async () => {
+    const manager = new LickManager();
+    expect(await manager.deleteCronTask('genuinely-missing-cron')).toBe(false);
+  });
+
+  it('deleteWebhook returns false when neither the map nor the DB has the id', async () => {
+    const manager = new LickManager();
+    expect(await manager.deleteWebhook('genuinely-missing-wh')).toBe(false);
   });
 });

--- a/packages/webapp/tests/scoops/lick-guard.test.ts
+++ b/packages/webapp/tests/scoops/lick-guard.test.ts
@@ -188,3 +188,77 @@ describe('Scoop removal guard (integration-style)', () => {
     }
   });
 });
+
+describe('LickManager orphan self-heal + persistence-authoritative guard', () => {
+  // Uses unique per-test scoop names so the shared fake-indexeddb store can't
+  // leak between tests (the DB-reading paths below query IndexedDB directly).
+
+  it('runCronScheduler deletes a task whose target scoop no longer exists', async () => {
+    const manager = new LickManager();
+    // Only 'sched-live-scoop' still exists; the orphan targets a gone scoop.
+    manager.setScoopExistenceResolver((f) => f === 'sched-live-scoop');
+    const orphan = await manager.createCronTask('sched-orphan', '*/5 * * * *', 'sched-gone-scoop');
+
+    let dispatched = 0;
+    manager.setEventHandler(() => {
+      dispatched++;
+    });
+
+    await (manager as unknown as { runCronScheduler(): Promise<void> }).runCronScheduler();
+
+    // Dropped from memory + persistence and never dispatched.
+    expect(manager.getCronTask(orphan.id)).toBeUndefined();
+    expect(dispatched).toBe(0);
+    const persisted = await manager.getLicksForScoopFromDb('sched-gone', 'sched-gone-scoop');
+    expect(persisted.cronTasks).toHaveLength(0);
+  });
+
+  it('init() removes orphaned licks (but keeps live ones) before the scheduler starts', async () => {
+    // Seed persisted licks with a separate manager (writes IndexedDB).
+    const seeder = new LickManager();
+    const wh = await seeder.createWebhook('init-orphan-wh', 'init-gone-scoop');
+    const ct = await seeder.createCronTask('init-orphan-cron', '*/5 * * * *', 'init-gone-scoop');
+    const liveWh = await seeder.createWebhook('init-live-wh', 'init-live-scoop');
+
+    // Fresh manager loads them from IndexedDB. Resolver treats only
+    // 'init-gone-scoop' as missing, so unrelated rows from other tests survive.
+    const manager = new LickManager();
+    manager.setScoopExistenceResolver((f) => f !== 'init-gone-scoop');
+    await manager.init();
+
+    try {
+      expect(manager.getCronTask(ct.id)).toBeUndefined();
+      expect(manager.getWebhook(wh.id)).toBeUndefined();
+      expect(manager.getWebhook(liveWh.id)).toBeDefined();
+      const goneDb = await manager.getLicksForScoopFromDb('init-gone', 'init-gone-scoop');
+      expect(goneDb.webhooks).toHaveLength(0);
+      expect(goneDb.cronTasks).toHaveLength(0);
+    } finally {
+      manager.dispose();
+      await manager.deleteWebhook(liveWh.id);
+    }
+  });
+
+  it('persisted-but-not-in-memory lick still blocks the drop via getLicksForScoopFromDb', async () => {
+    // Seeder persists a webhook to IndexedDB (and its own in-memory map).
+    const seeder = new LickManager();
+    const wh = await seeder.createWebhook('db-guard-wh', 'db-guard-scoop');
+
+    // A fresh manager never loaded it, so the in-memory lookup finds nothing…
+    const manager = new LickManager();
+    expect(manager.getLicksForScoop('db-guard', 'db-guard-scoop').webhooks).toHaveLength(0);
+
+    // …but the persistence-authoritative lookup does, so the guard still blocks
+    // with the existing error message.
+    const { webhooks, cronTasks } = await manager.getLicksForScoopFromDb(
+      'db-guard',
+      'db-guard-scoop'
+    );
+    expect(webhooks).toHaveLength(1);
+    const err = buildActiveLicksError('db-guard-scoop', webhooks, cronTasks);
+    expect(err).not.toBeNull();
+    expect(err?.message).toContain("Cannot remove scoop 'db-guard-scoop'");
+
+    await seeder.deleteWebhook(wh.id);
+  });
+});

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -2715,7 +2715,7 @@ describe('Orchestrator.handleCherryHostEvent', () => {
   it('emits a cherry lick with the host event name, runtime id, and detail', () => {
     const orch = makeOrch();
     const emitEvent = vi.fn();
-    orch.setLickManager({ emitEvent } as any);
+    orch.setLickManager({ emitEvent, setScoopExistenceResolver: vi.fn() } as any);
 
     orch.handleCherryHostEvent('follower-b1', 'cart.updated', { items: 3 });
 
@@ -2943,7 +2943,7 @@ describe('Orchestrator.enqueueSudoRequest lick emission', () => {
     await orch.init();
 
     const emitEvent = vi.fn();
-    orch.setLickManager({ emitEvent } as any);
+    orch.setLickManager({ emitEvent, setScoopExistenceResolver: vi.fn() } as any);
 
     // The `requestApproval` flow awaits `pending`; we want to assert the
     // emit-and-deliver side effects, not the cone's eventual decision, so
@@ -3009,7 +3009,7 @@ describe('Orchestrator.enqueueSudoRequest lick emission', () => {
     await orch.init();
 
     const emitEvent = vi.fn();
-    orch.setLickManager({ emitEvent } as any);
+    orch.setLickManager({ emitEvent, setScoopExistenceResolver: vi.fn() } as any);
 
     const pendingDecision = orch.enqueueSudoRequest(testScoop.jid, {
       kind: 'command',


### PR DESCRIPTION
## Summary

Prevents and self-heals orphaned licks (cron tasks / webhooks) whose target scoop no longer exists. Before: a cron task pointing at a dropped scoop (e.g. sy-watch, targeting comment-watcher) kept a live nextRun in IndexedDB, fired forever at a dead scoop, and could not be seen or removed via crontask list/delete (a "zombie crontask"). After: the scheduler skips and deletes such orphans, boot reconciles them, and a scoop can no longer be silently dropped while a persisted lick still references it.

## Why

The zombie was reproducible: a cron task in the shared slicc-groups -> crontasks IndexedDB store targeted a scoop that had been dropped, so crontask list returned empty (the connected worker's in-memory map never had it) yet the row persisted and would resurrect on the next leader boot.

Root cause:

1. LickManager loaded crontasks/webhooks from IndexedDB only once at init() and never re-synced. Multiple/stale leader tabs of the same origin share one slicc-groups IndexedDB, but each kernel worker has its own LickManager, so in-memory maps drift from persistence.
2. The scoop-drop guard (ScoopLifecycleManager.unregister -> getLicksForScoop -> buildActiveLicksError) read the stale in-memory map, so a worker that never learned about a task created by another worker let the scoop be dropped, orphaning the lick.
3. runCronScheduler dispatched to task.scoop with no existence check, so a fresh worker init() reloaded the orphan and fired it at a dead scoop forever.
4. In standalone mode crontask list/delete route through node-server /api/crontasks -> /licks-ws -> the connected worker stale map, so the operator saw an empty list / 404 and could not remove it.

Repro (before):
  1. Create a crontask targeting a scoop, then drop that scoop from a different tab/worker.
  2. Run crontask list.
  Expected: the orphan is gone or listed so it can be deleted.
  Actual: empty list, but the task keeps firing at the dead scoop and persists across reloads.

## Approach / Implementation notes

- Layering: fix is contained to the scoops subsystem. LickManager owns the new behavior; orchestrator wires the resolver; scoop-lifecycle-manager makes the drop guard authoritative.
- Inject an optional hasScoop(scoopField) resolver into LickManager, wired from orchestrator.setLickManager() (the orchestrator owns getScoops()), reusing the existing alias matching (name / folder / scoop + '-scoop' === folder).
- Scheduler self-heal: runCronScheduler skips dispatch for a task whose target scoop is gone and deletes it (in-memory + db.deleteCronTask), logged. When no resolver is wired, behavior is unchanged.
- Boot reconciliation: init() reconciles loaded cron tasks/webhooks against the resolver, dropping orphans before starting the scheduler (guarded no-op when no resolver).
- Persistence-authoritative drop guard: unregister consults persisted state via a new getLicksForScoopFromDb (db.getAllCronTasks / getAllWebhooks) so a persisted-but-not-in-memory lick still blocks the drop with the existing "Unregister them first" error.
- No IndexedDB schema or persisted-format changes.

## Cross-cutting impact

- Floats exercised: standalone CLI and extension both boot the kernel host and share this LickManager path; the resolver is wired the same way via orchestrator.setLickManager.
- Other callers: getLicksForScoop (in-memory) is retained for the buildActiveLicksError message; the new getLicksForScoopFromDb is additive. When no resolver is injected, scheduler/init behavior is unchanged (guarded no-op), so existing callers/tests are unaffected.
- Persisted state side-effects: self-heal and reconciliation delete orphaned rows from slicc-groups crontasks/webhooks. Only rows whose target scoop does not exist are removed; live licks are preserved (covered by a test).
- Known gap (see Risk & rollback): boot-time reconciliation is a no-op at real boot because kernel/host.ts calls init() before setLickManager(); production is covered by the scheduler self-heal + the DB-authoritative drop guard.

## Test plan

- [x] npm run lint (root; prettier check gate) — PASS
- [x] npm run typecheck — PASS (all 9 tsc projects)
- [x] npm run test -w @slicc/webapp — 511 files, 8867 passed, 0 failed
- [x] New / changed behavior covered by unit tests in packages/webapp/tests/scoops/lick-guard.test.ts: (a) scheduler self-heal + skip of an orphan; (b) init() reconciliation dropping an orphan while keeping live licks; (c) drop guard blocking when only the persisted store has the lick. Orchestrator mocks updated in tests/scoops/orchestrator.test.ts.
- [ ] N/A — no UI change, so no screencast.

## Documentation

- [x] No documentation changes needed (internal behavior fix; no public tool/command/lick-channel contract change).

## Risk & rollback

- Blast radius: scoops lick management across floats; low — the new logic is guarded and additive, and no-resolver behavior is unchanged.
- No feature flags or migrations. Roll back by reverting the single commit; no persisted-format migration to undo (deletions only remove already-orphaned rows).
- Follow-up (non-blocking, out of scope): reorder kernel/host.ts so orchestrator.setLickManager() runs before lickManager.init(), making boot-time reconciliation effective. Not a correctness gap today (scheduler self-heal within 60s + DB-authoritative guard cover it).

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under dist/
- [x] No secrets, credentials, or tokens in the diff
- [x] No public API / tool / shell-command / lick-channel contract change
- [x] Checked leader/worker paths that share the LickManager contract
