### PR TITLE
Reap lingering slicc-server helper when a launched browser is quit

### DIFF
--- a/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
@@ -97,6 +97,12 @@ final class SliccProcess {
         /// full-app update re-forwards the SAME secret the still-running
         /// browser tab carries in its launch URL.
         var bridgeToken: String?
+        /// Set true the first time this browser's CDP port is observed
+        /// listening. The stale-helper reap only fires once CDP has been
+        /// seen (browser finished booting) and then goes away — so a
+        /// still-booting browser (slow Keychain prompt, cold start) whose
+        /// CDP port has not come up yet is never prematurely reaped.
+        var observedCdpListening: Bool = false
     }
 
     /// SLICC helper/server processes keyed by AppTarget.id.
@@ -585,7 +591,8 @@ final class SliccProcess {
         targetName: String,
         joinUrl: String? = nil,
         bridgeToken: String? = nil,
-        startedAt: Date = Date()
+        startedAt: Date = Date(),
+        observedCdpListening: Bool = false
     ) {
         launchRecords[id] = LaunchRecord(
             process: process,
@@ -598,7 +605,8 @@ final class SliccProcess {
             startedAt: startedAt,
             observedAppPID: nil,
             joinUrl: joinUrl,
-            bridgeToken: bridgeToken
+            bridgeToken: bridgeToken,
+            observedCdpListening: observedCdpListening
         )
     }
 
@@ -874,13 +882,20 @@ final class SliccProcess {
         // Standalone browsers have no Electron app to track — validate the
         // browser itself via its CDP port. Once Chrome quits the CDP port
         // (9222) frees, but the slicc-server helper keeps running, so the
-        // record would otherwise linger and block relaunch. After a boot
-        // grace period, a free CDP port means Chrome has gone; reap the
-        // stale helper so the browser can be relaunched.
+        // record would otherwise linger and block relaunch. Reap the stale
+        // helper only once CDP was actually seen listening (browser finished
+        // booting) and has since gone away — a still-booting browser whose
+        // CDP port has not come up yet (slow Keychain prompt, cold start) is
+        // never prematurely reaped.
         if record.targetType == .chromiumBrowser {
-            if Date().timeIntervalSince(record.startedAt) > Self.browserLaunchStaleTimeout,
-               !Self.isPortInUse(record.cdpPort) {
-                log.info("refreshRuntimeState: \(target.name, privacy: .public) browser CDP port not listening; stopping stale helper")
+            if Self.isPortInUse(record.cdpPort) {
+                record.observedCdpListening = true
+                launchRecords[target.id] = record
+                return
+            }
+            if record.observedCdpListening,
+               Date().timeIntervalSince(record.startedAt) > Self.browserLaunchStaleTimeout {
+                log.info("refreshRuntimeState: \(target.name, privacy: .public) browser CDP port went away after booting; stopping stale helper")
                 stopLaunchRecord(id: target.id, terminateApps: false)
             }
             return

--- a/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
@@ -180,6 +180,10 @@ final class SliccProcess {
     private static let electronBasePort: UInt16 = 5711
     private static let electronBaseCdpPort: UInt16 = 9223
     private static let electronLaunchStaleTimeout: TimeInterval = 30
+    /// Grace period before a `chromiumBrowser` record is validated for
+    /// browser liveness. Comfortably above normal Chrome/CDP boot time so a
+    /// browser that is still booting (CDP not up yet) is not reaped.
+    private static let browserLaunchStaleTimeout: TimeInterval = 15
 
     func isRunning(_ target: AppTarget) -> Bool {
         runtimeState(for: target).isRunning
@@ -580,7 +584,8 @@ final class SliccProcess {
         electronAppPath: String? = nil,
         targetName: String,
         joinUrl: String? = nil,
-        bridgeToken: String? = nil
+        bridgeToken: String? = nil,
+        startedAt: Date = Date()
     ) {
         launchRecords[id] = LaunchRecord(
             process: process,
@@ -590,7 +595,7 @@ final class SliccProcess {
             servePort: servePort,
             electronAppPath: electronAppPath,
             targetName: targetName,
-            startedAt: Date(),
+            startedAt: startedAt,
             observedAppPID: nil,
             joinUrl: joinUrl,
             bridgeToken: bridgeToken
@@ -863,6 +868,21 @@ final class SliccProcess {
         guard var record = launchRecords[target.id] else { return }
         guard record.process.isRunning else {
             launchRecords.removeValue(forKey: target.id)
+            return
+        }
+
+        // Standalone browsers have no Electron app to track — validate the
+        // browser itself via its CDP port. Once Chrome quits the CDP port
+        // (9222) frees, but the slicc-server helper keeps running, so the
+        // record would otherwise linger and block relaunch. After a boot
+        // grace period, a free CDP port means Chrome has gone; reap the
+        // stale helper so the browser can be relaunched.
+        if record.targetType == .chromiumBrowser {
+            if Date().timeIntervalSince(record.startedAt) > Self.browserLaunchStaleTimeout,
+               !Self.isPortInUse(record.cdpPort) {
+                log.info("refreshRuntimeState: \(target.name, privacy: .public) browser CDP port not listening; stopping stale helper")
+                stopLaunchRecord(id: target.id, terminateApps: false)
+            }
             return
         }
 

--- a/packages/swift-launcher/SliccstartTests/LauncherCoverageBackfillTests.swift
+++ b/packages/swift-launcher/SliccstartTests/LauncherCoverageBackfillTests.swift
@@ -223,11 +223,31 @@ final class LauncherProcessCoverageTests: XCTestCase {
         proc._testing_seedLaunchRecord(
             id: target.id, process: sleeper, targetType: .chromiumBrowser,
             cdpPort: 39322, servePort: 35810, targetName: target.name,
-            startedAt: Date(timeIntervalSinceNow: -60)
+            startedAt: Date(timeIntervalSinceNow: -60),
+            observedCdpListening: true
         )
         XCTAssertTrue(proc.isRunning(target))
         proc.refreshRuntimeStates(for: [target])
         XCTAssertFalse(proc.isRunning(target))
+    }
+
+    // A stale browser whose CDP port never came up (Codex P1: slow start,
+    // e.g. a Keychain ACL prompt) must NOT be reaped even after the grace
+    // period — the browser could still be finishing its boot.
+    func testStaleBrowserThatNeverBoundCdpIsNotReaped() throws {
+        let proc = SliccProcess()
+        let sleeper = try makeSleeper()
+        addTeardownBlock { if sleeper.isRunning { sleeper.terminate() } }
+
+        let target = Self.makeBrowserTarget(id: "browser-never-cdp")
+        proc._testing_seedLaunchRecord(
+            id: target.id, process: sleeper, targetType: .chromiumBrowser,
+            cdpPort: 39324, servePort: 35813, targetName: target.name,
+            startedAt: Date(timeIntervalSinceNow: -60)
+        )
+        proc.refreshRuntimeStates(for: [target])
+        XCTAssertTrue(proc.isRunning(target))
+        proc.stop(target)
     }
 
     // A freshly-launched browser whose CDP port hasn't come up yet (still

--- a/packages/swift-launcher/SliccstartTests/LauncherCoverageBackfillTests.swift
+++ b/packages/swift-launcher/SliccstartTests/LauncherCoverageBackfillTests.swift
@@ -211,6 +211,105 @@ final class LauncherProcessCoverageTests: XCTestCase {
         XCTAssertFalse(proc.isRunning(target))
     }
 
+    // A standalone browser whose CDP port has stopped listening after the
+    // boot grace period means Chrome has quit — the lingering slicc-server
+    // helper must be reaped so the browser can be relaunched.
+    func testStaleBrowserWithFreeCdpPortIsReaped() throws {
+        let proc = SliccProcess()
+        let sleeper = try makeSleeper()
+        addTeardownBlock { if sleeper.isRunning { sleeper.terminate() } }
+
+        let target = Self.makeBrowserTarget(id: "browser-stale")
+        proc._testing_seedLaunchRecord(
+            id: target.id, process: sleeper, targetType: .chromiumBrowser,
+            cdpPort: 39322, servePort: 35810, targetName: target.name,
+            startedAt: Date(timeIntervalSinceNow: -60)
+        )
+        XCTAssertTrue(proc.isRunning(target))
+        proc.refreshRuntimeStates(for: [target])
+        XCTAssertFalse(proc.isRunning(target))
+    }
+
+    // A freshly-launched browser whose CDP port hasn't come up yet (still
+    // inside the grace period) must NOT be reaped.
+    func testFreshBrowserWithinGracePeriodIsNotReaped() throws {
+        let proc = SliccProcess()
+        let sleeper = try makeSleeper()
+        addTeardownBlock { if sleeper.isRunning { sleeper.terminate() } }
+
+        let target = Self.makeBrowserTarget(id: "browser-fresh")
+        proc._testing_seedLaunchRecord(
+            id: target.id, process: sleeper, targetType: .chromiumBrowser,
+            cdpPort: 39323, servePort: 35811, targetName: target.name
+        )
+        proc.refreshRuntimeStates(for: [target])
+        XCTAssertTrue(proc.isRunning(target))
+        proc.stop(target)
+    }
+
+    // A stale browser whose CDP port is still listening (Chrome alive) must
+    // NOT be reaped even after the grace period.
+    func testStaleBrowserWithBusyCdpPortIsNotReaped() throws {
+        let proc = SliccProcess()
+        let sleeper = try makeSleeper()
+        addTeardownBlock { if sleeper.isRunning { sleeper.terminate() } }
+
+        let (listenFd, busyPort) = try Self.makeListeningSocket()
+        addTeardownBlock { close(listenFd) }
+
+        let target = Self.makeBrowserTarget(id: "browser-busy")
+        proc._testing_seedLaunchRecord(
+            id: target.id, process: sleeper, targetType: .chromiumBrowser,
+            cdpPort: busyPort, servePort: 35812, targetName: target.name,
+            startedAt: Date(timeIntervalSinceNow: -60)
+        )
+        proc.refreshRuntimeStates(for: [target])
+        XCTAssertTrue(proc.isRunning(target))
+        proc.stop(target)
+    }
+
+    private static func makeBrowserTarget(id: String) -> AppTarget {
+        AppTarget(
+            id: id, name: "TestBrowser", path: id,
+            executablePath: "", type: .chromiumBrowser,
+            icon: NSImage(size: NSSize(width: 1, height: 1)),
+            debugSupport: .supported, isDebugBuild: false, originalAppPath: nil
+        )
+    }
+
+    /// Binds a listening TCP socket on an ephemeral 127.0.0.1 port and
+    /// returns the fd plus the assigned port, so a test can make
+    /// `isPortInUse` report the CDP port as still taken.
+    private static func makeListeningSocket() throws -> (fd: Int32, port: UInt16) {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw NSError(domain: "test", code: Int(errno))
+        }
+        var yes: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0, listen(fd, 1) == 0 else {
+            close(fd)
+            throw NSError(domain: "test", code: Int(errno))
+        }
+        var boundAddr = sockaddr_in()
+        var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+        withUnsafeMutablePointer(to: &boundAddr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                _ = getsockname(fd, sockPtr, &len)
+            }
+        }
+        return (fd, UInt16(bigEndian: boundAddr.sin_port))
+    }
+
     func testRuntimeStateDrivesDebugPortAndAppRunningHelpers() throws {
         let proc = SliccProcess()
 


### PR DESCRIPTION
## Problem

When the user quits a Sliccstart-launched browser, the browser could not be relaunched without restarting Sliccstart.

Sliccstart tracks the spawned **slicc-server** child process in `launchRecords[target.id]`, not Chrome itself. The periodic health check `refreshRuntimeState(for:)` (run every 2s by `runtimeRefreshTimer`) only performed a browser-liveness check for `.electronApp` records. For a `.chromiumBrowser` record it returned as long as the slicc-server process was alive. So when Chrome was quit but slicc-server lingered, the stale record kept `isRunning == true` (`activeDebugPort` returns the cdpPort unconditionally for browsers) and held ports 5710/9222 — causing relaunch to fail with "already running" or `portInUse`.

## Fix

Extend the existing periodic check so a `.chromiumBrowser` record is also validated for browser liveness:

- When the CDP port (9222) is no longer listening (`!isPortInUse(cdpPort)`) **and** a boot grace period (`browserLaunchStaleTimeout`, 15s, measured from `record.startedAt`) has elapsed, the stale slicc-server helper is reaped via `stopLaunchRecord(id:, terminateApps: false)` — removing the record, terminating slicc-server (freeing 5710), and clearing the leader via `clearLeaderIfNoBrowserRunning()`.
- The grace period ensures a still-booting browser (CDP not up yet) is not reaped prematurely; a browser whose CDP port is still in use is left alone.
- Mirrors the existing Electron staleness pattern and matches the reporter's ask: "occasionally check if the port is still taken and the process still running."

Electron staleness and the detach/reattach (smooth-update) paths are untouched.

## Tests

- Added `startedAt` seam to `_testing_seedLaunchRecord`.
- 3 unit tests: stale+free → reaped, fresh (within grace) → kept, stale+busy (real listening socket) → kept.

## Verification

- `cd packages/swift-launcher && swift build` ✅
- `swift test` 172/173 (only failure is the known pre-existing `UpdateCheckIntegrationTests` real-GitHub-API flake)
- `npm run lint -w @slicc/swift-launcher` → 0 serious issues

Independently reviewed and approved (high confidence).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author