### PR TITLE
test(worker): pin known-good pointer in DMG tests so releases don't break worker CI

### DIFF
--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1,5 +1,15 @@
 import { TRAY_BOOTSTRAP_TIMEOUT_MS } from '@slicc/shared-ts';
 import { describe, expect, it, vi } from 'vitest';
+
+// The release process (packages/dev-tools/tools/release-native.mjs) rewrites
+// known-good-macos.json to the just-shipped version on every release (e.g. the
+// 5.54.2 release bumped it from 5.37.0). Pin it here so the DMG-download tests
+// stay hermetic: their release fixtures and expected known-good fallback are all
+// built around the 5.37.0 pointer and must not drift with each release. The
+// handler reads this JSON as a defaulted param, so the request-level tests below
+// exercise the real routing while this mock fixes the pointer they fall back to.
+vi.mock('../src/known-good-macos.json', () => ({ default: { version: '5.37.0' } }));
+
 import worker, {
   buildKnownGoodDmgUrl,
   capabilityCorsHeaders,


### PR DESCRIPTION
## Problem

Every PR that touches `packages/cloudflare-worker/**` currently fails CI on **6 `GET /download/slicc.dmg` tests** — e.g. #1454. The failures are unrelated to the PRs; they're a pre-existing breakage on `main`.

### Root cause

- The release process (`packages/dev-tools/tools/release-native.mjs`) rewrites `src/known-good-macos.json` to the **just-shipped version** on every release. Today's release (`a6eb818` `chore(release): 5.54.2`) bumped it `5.37.0` → `5.54.2`.
- Release commits carry **`[skip ci]`**, so the bumped pointer never ran against the DMG tests on `main`.
- The DMG-download tests **hard-coded `v5.37.0`** as the expected known-good fallback and built their release fixtures around it. The handler resolves the fallback from the bundled `known-good-macos.json`, so it now returns `v5.54.2` while the tests expect `v5.37.0` → mismatch.
- The worker test job is **path-gated** (`.github/workflows/ci.yml`), so this only surfaces on PRs touching the worker (whose CI merges the branch with current `main`). That's why worker-less PRs (e.g. swift-only #1471) stay green.

Reproduced by isolation: bumping only the pointer to `5.54.2` on an otherwise-green branch reproduces exactly these 6 failures.

## Fix

Pin the bundled pointer to `5.37.0` via `vi.mock` at the top of `tests/index.test.ts`. The DMG unit tests become **hermetic** — immune to release bumps — while keeping every existing fixture and the request-level routing coverage (`handleWorkerRequest` still exercises the real dispatch; only the pointer it falls back to is fixed).

## Verification

- DMG tests: 15 passed (with the bundled pointer at `5.54.2`, matching current main).
- Full worker suite + coverage gate: 348 passed, gate exit 0.
- `tsc -p tsconfig.worker.json`: 0 errors. `biome check`: clean. `knip`: clean.

## Follow-up (out of scope)

Worth a separate look by the DMG author: whether the release process *should* clobber the deliberately-pinned "known-good" fallback on every release, and whether release commits should skip CI on files that unit tests depend on. This PR only makes the tests robust; it doesn't change release behavior.