### PR TITLE
Fix stubborn rm -r on large OPFS trees (flush + write-lock + lstat)

### DIFF
--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -1624,30 +1624,36 @@ export class VirtualFS {
       // Use lstat to detect symlinks — if it's a symlink, just unlink it
       // (don't follow the link or recurse into a target directory)
       const s = await this.lfs.lstat(normalized);
-      if (s.isSymbolicLink()) {
-        await this.lfs.unlink(normalized);
-      } else if (s.isDirectory()) {
-        if (options?.recursive) {
-          await this.rmRecursive(normalized);
+      await this.withWriteLock(async () => {
+        if (s.isSymbolicLink()) {
+          await this.lfs.unlink(normalized);
+        } else if (s.isDirectory()) {
+          if (options?.recursive) {
+            await this.rmRecursiveUnlocked(normalized);
+          } else {
+            await this.lfs.rmdir(normalized);
+          }
         } else {
-          await this.lfs.rmdir(normalized);
+          await this.lfs.unlink(normalized);
         }
-      } else {
-        await this.lfs.unlink(normalized);
-      }
+        await this.writeOpfsMetadataSidecar();
+      });
     } catch (err) {
       throw this.convertError(err, normalized);
     }
     this.watcher?.notify([{ type: 'delete', path: normalized }]);
   }
 
-  private async rmRecursive(path: string): Promise<void> {
+  /** Recursive local removal. The caller must already hold {@link _writeLock}. */
+  private async rmRecursiveUnlocked(path: string): Promise<void> {
     const entries = await this.lfs.readdir(path);
     for (const name of entries) {
       const childPath = path === '/' ? `/${name}` : `${path}/${name}`;
-      const stat = await this.lfs.stat(childPath);
-      if (stat.isDirectory()) {
-        await this.rmRecursive(childPath);
+      const stat = await this.lfs.lstat(childPath);
+      if (stat.isSymbolicLink()) {
+        await this.lfs.unlink(childPath);
+      } else if (stat.isDirectory()) {
+        await this.rmRecursiveUnlocked(childPath);
       } else {
         await this.lfs.unlink(childPath);
       }

--- a/packages/webapp/tests/fs/virtual-fs.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.test.ts
@@ -154,6 +154,51 @@ describe('VirtualFS', () => {
       await vfs.rm('/tree', { recursive: true });
       expect(await vfs.exists('/tree')).toBe(false);
     });
+
+    it('flushes metadata once after removing a large directory tree', async () => {
+      const paths = Array.from(
+        { length: 100 },
+        (_, i) => `/large-tree/pkg${i % 10}/nested/file${i}.txt`
+      );
+      await Promise.all(paths.map((path) => vfs.writeFile(path, path)));
+      const flushSpy = vi.spyOn(
+        vfs as unknown as { writeOpfsMetadataSidecar(): Promise<void> },
+        'writeOpfsMetadataSidecar'
+      );
+
+      await vfs.rm('/large-tree', { recursive: true });
+
+      expect(await vfs.exists('/large-tree')).toBe(false);
+      expect(flushSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('serializes recursive removal with concurrent mkdir and writes', async () => {
+      const oldPaths = Array.from(
+        { length: 100 },
+        (_, i) => `/rm-race/old/pkg${i % 10}/file${i}.txt`
+      );
+      await Promise.all(oldPaths.map((path) => vfs.writeFile(path, path)));
+
+      const concurrentCreates = Array.from({ length: 50 }, (_, i) => [
+        vfs.mkdir(`/rm-race/new/pkg${i}`, { recursive: true }),
+        vfs.writeFile(`/rm-race/new/pkg${i}/file.txt`, `data-${i}`),
+      ]).flat();
+
+      await expect(
+        Promise.all([vfs.rm('/rm-race', { recursive: true }), ...concurrentCreates])
+      ).resolves.toBeDefined();
+    });
+
+    it('recursive rm unlinks a directory symlink without removing its target', async () => {
+      await vfs.writeFile('/keep-dir/important.txt', 'important');
+      await vfs.mkdir('/remove-tree');
+      await vfs.symlink('/keep-dir', '/remove-tree/link-to-keep');
+
+      await vfs.rm('/remove-tree', { recursive: true });
+
+      expect(await vfs.exists('/remove-tree')).toBe(false);
+      expect(await vfs.readTextFile('/keep-dir/important.txt')).toBe('important');
+    });
   });
 
   describe('rename', () => {


### PR DESCRIPTION
## Summary

`rm -r` on large directory trees in the OPFS-backed VirtualFS was "stubborn": deleted trees reappeared after a page reload and large deletes could throw spurious errors mid-run. After this change, a recursive delete is atomic against concurrent writes, is persisted immediately, and no longer follows symlinks into their targets.

## Why

Same class of bug fixed for large `git clone` in #1401 (parallel-checkout race) and #1430 (symlink metadata persistence), now on the delete path. Three compounding root causes in `packages/webapp/src/fs/virtual-fs.ts`:

1. **No metadata flush after deletion (#1430 class).** ZenFS `WebAccessFS` keeps directory entries in an in-memory index serialized to `/.metadata.json` only on `flush()`/`dispose()`. `rm`/`rmRecursive` never flushed, so a realm reload before the next dispose re-read the stale sidecar and re-materialized the "deleted" tree.
2. **Recursion ran off the write lock (#1401 class).** `rmRecursive` mutated the shared, non-atomic index with no `withWriteLock`; a concurrent `mkdir`/`writeFile` could interleave mid-delete → spurious `ENOENT`/`ENOTEMPTY`.
3. **`stat` instead of `lstat` in the recursive walk.** A symlink child pointing at a directory was followed and recursed into, deleting the link target's contents.

Repro (before): create a large tree under `/workspace`, `rm -r` it, reload the tab → the tree is back.

## Approach / Implementation notes

- Local-backend deletion now runs as **one critical section** under `withWriteLock`, via a new non-reentrant `rmRecursiveUnlocked` helper (mirrors the existing `mkdirRecursiveUnlocked` pattern) — so the public locked `rm` is never re-entered inside the lock.
- `writeOpfsMetadataSidecar()` is flushed **exactly once** after the tree is gone (batched, not per-entry — preserves large-tree perf; no-op on the in-memory/Node backend).
- Recursive walk switched to `lstat`; symlink children are unlinked directly.
- Mount-backend `rm` branch left unchanged.

## Cross-cutting impact

- **Floats exercised**: VFS is shared across all floats; the OPFS path affects CLI / extension / Electron / hosted-leader. The in-memory (Node/test) backend treats the new flush as a no-op.
- **Mount backends**: untouched — only the local ZenFS deletion path changed.
- **Lock semantics**: the new `rmRecursiveUnlocked` must only ever be called while already holding `_writeLock` (verified: single call site, inside the locked `rm`).

## Test plan

- [x] Targeted VirtualFS suite: `npx vitest run packages/webapp/tests/fs/virtual-fs.test.ts` — 47/47 passing.
- [x] `npm run typecheck`
- [x] `npm run test` — full suite green (11,036 tests).
- [x] webapp coverage gate — passing (75.78% statements).
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension`
- [x] lint + complexity gate + linear-history check
- [x] **New behavior covered by unit tests** in `packages/webapp/tests/fs/virtual-fs.test.ts`: reload-survival (sidecar flushed exactly once per `rm`), concurrent `rm -r` + `mkdir`/`writeFile` stress (no spurious `ENOENT`/`ENOTEMPTY`), symlink-to-dir child unlinked while target contents survive.

## Documentation

- [x] No documentation changes needed (internal VFS behavior fix; no public API/tool/shell-command change).

## Risk & rollback

- Blast radius: the VFS delete path across all floats. Behavior change is strictly toward correctness (atomic + persisted + symlink-safe).
- No data migration, feature flag, or env knob introduced.
- Rollback: revert this PR cleanly; no persisted-state migration to undo.
- CI cannot fully exercise real OPFS reload semantics — reviewer may optionally confirm on a live instance that a large `rm -r` survives a reload.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets/credentials/tokens in the diff
- [x] No public API / tool / shell-command / lick-channel changes
- [x] Contract unchanged for other floats (mount + tray paths untouched)