### PR TITLE
Reduce and harden Cloudflare worker deploys (gate + retry)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,7 +15,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "SLICC_RELEASED_AT=\"$(date -u +'%Y-%m-%dT%H:%M:%SZ')\" npm run build && npm run package:release && node packages/dev-tools/tools/release-native.mjs --last='${lastRelease.gitTag}' --next='${nextRelease.version}'",
-        "publishCmd": "npm run publish:worker && node packages/dev-tools/tools/release-native.mjs --gate=chrome --last='${lastRelease.gitTag}'"
+        "publishCmd": "SLICC_LAST_RELEASE_TAG='${lastRelease.gitTag}' npm run publish:worker && node packages/dev-tools/tools/release-native.mjs --gate=chrome --last='${lastRelease.gitTag}'"
       }
     ],
     [

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -117,7 +117,7 @@ support laptop-orchestrated sandboxes that pause for days at a time.
 
 **Hash invariant (enforced):** Every `/assets/*` filename must carry a content hash (e.g., `-DP3-Xd3J`). The upload script (`packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs`) fails the deploy if any `dist/ui/assets/*` name lacks a hash, and the worker's routing predicate enforces the same rule (defined in the shared `asset-archive.mjs` module).
 
-**Upload gate (before every deploy):** Every deploy path (prod automated via `publish-worker.sh`, prod manual via `worker.yml`, staging via `ci.yml` and `worker-staging.yml`) runs the upload step **before the first `wrangler deploy` attempt**. The upload re-puts the **entire current asset set** to the archive (no skip-if-exists; refreshes `last-modified` which the GC relies on) with retries and bounded concurrency, failing the deploy hard if any file fails to upload or the hash invariant is violated. Auth: `CLOUDFLARE_API_TOKEN` (must have R2 Object Read & Write on both buckets) and `CLOUDFLARE_ACCOUNT_ID`.
+**Upload gate (before every deploy and release skip):** Every deploy path (prod automated via `publish-worker.sh`, prod manual via `worker.yml`, staging via `ci.yml` and `worker-staging.yml`) runs the upload step **before the first `wrangler deploy` attempt**. The production release script also runs it when its worker/UI change gate skips deployment. The upload re-puts the **entire current asset set** to the archive (no skip-if-exists; refreshes `last-modified` which the GC relies on) with retries and bounded concurrency, failing the release hard if any file fails to upload or the hash invariant is violated. Auth: `CLOUDFLARE_API_TOKEN` (must have R2 Object Read & Write on both buckets) and `CLOUDFLARE_ACCOUNT_ID`.
 
 **Garbage collection (Option A, age-based):** An R2 object-lifecycle rule on each bucket deletes objects with `last-modified` older than 14 days. Because every deploy re-puts its full current set, stable chunks (vendor/shared) re-ship until they change, surviving ≥14 days after supersession (covers the common #1330 pattern). Build-unique chunks may fall outside the window after a build stops shipping them; tabs importing such chunks past 14 days degrade to the stale-asset reload — acceptable and identical to today. **Option B** (manifest-touch, future work) would give all chunks ≥14 days post-supersession via a small manifest of deployed key lists and a copy-in-place touch loop; it's an additive upgrade requiring no re-spec.
 
@@ -300,6 +300,21 @@ This lives at the repo root because it coordinates the worker with browser runti
 ## CI and Deployment
 
 - Worker deploy automation lives in `.github/workflows/worker.yml`.
+- The automated semantic-release path gates production deployment with
+  `release-native.mjs --gate=worker`, comparing the previous release tag to
+  `HEAD`. Changes under the worker, served webapp/UI packages, shared worker
+  dependencies, or hosted e2b template inputs deploy both workers and run the
+  live smoke tests. First releases always deploy; releases with only unrelated
+  changes refresh the R2 archive and exit before the template push, secret
+  writes, both `wrangler deploy` calls, and deployed smoke tests.
+- The R2 refresh intentionally remains unconditional because bucket lifecycle
+  GC expires objects after 14 days. A worker-deploy skip streak is unbounded, so
+  relying on that TTL would eventually delete still-current archived chunks.
+- Production hub and preview deploys each retry up to six times with a 15-second
+  delay. Retries are safe when Wrangler uploaded the script but route
+  reconciliation failed because a repeated deploy reconciles the desired
+  configuration. Each attempt enables Wrangler debug logging; exhausting all
+  attempts prints that worker's debug log to CI stderr before failing.
 - Required repo configuration:
   - secret: `CLOUDFLARE_API_TOKEN`
   - variable: `CLOUDFLARE_ACCOUNT_ID`

--- a/packages/cloudflare-worker/scripts/publish-worker.sh
+++ b/packages/cloudflare-worker/scripts/publish-worker.sh
@@ -13,12 +13,57 @@
 # Required env vars (set by semantic-release / release.yml):
 #   CLOUDFLARE_TURN_API_TOKEN, GITHUB_CLIENT_SECRET, E2B_API_KEY,
 #   CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID (the latter two consumed by wrangler).
+#   SLICC_LAST_RELEASE_TAG (empty means first release and always deploys).
 set -euo pipefail
 
 WRANGLER_CONFIG="packages/cloudflare-worker/wrangler.jsonc"
 PREVIEW_WRANGLER_CONFIG="packages/cloudflare-worker/wrangler-preview.jsonc"
 MAX_ATTEMPTS=6
 SLEEP_BETWEEN=15
+
+archive_assets() {
+  # #1330 retention: re-put this build's entire content-hashed asset set on every
+  # release, including worker-deploy skips. The 14-day age-based GC relies on the
+  # refreshed last-modified timestamps to retain still-current chunks.
+  echo "[publish-worker] Archiving assets to R2 (slicc-asset-archive)..."
+  node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive --dir dist/ui/assets
+}
+
+deploy_with_retry() {
+  local label="$1"
+  local config="$2"
+  local log_path="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/wrangler-${label}-deploy.log"
+
+  : > "$log_path"
+  # A retry after Wrangler deployed the script but failed to reconcile routes is
+  # safe: deploy is idempotent and reconciles the worker's desired configuration.
+  for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    echo "[publish-worker] Deploying $label worker (attempt $attempt/$MAX_ATTEMPTS)..."
+    if WRANGLER_LOG=debug WRANGLER_LOG_PATH="$log_path" npx wrangler deploy --config "$config"; then
+      echo "[publish-worker] $label worker deployed on attempt $attempt."
+      return 0
+    fi
+    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+      echo "[publish-worker] $label worker deploy failed after $MAX_ATTEMPTS attempts." >&2
+      echo "[publish-worker] Wrangler debug log ($log_path):" >&2
+      cat "$log_path" >&2
+      return 1
+    fi
+    echo "[publish-worker] $label worker deploy failed on attempt $attempt; waiting ${SLEEP_BETWEEN}s before retrying..." >&2
+    sleep "$SLEEP_BETWEEN"
+  done
+}
+
+WORKER_GATE="$(node packages/dev-tools/tools/release-native.mjs --gate=worker --last="${SLICC_LAST_RELEASE_TAG:-}")"
+if [ "$WORKER_GATE" = "skip" ]; then
+  archive_assets
+  echo "[publish-worker] Skipping worker deploy (no worker/UI-relevant changes)."
+  exit 0
+fi
+if [ "$WORKER_GATE" != "deploy" ]; then
+  echo "[publish-worker] Unexpected worker gate result: $WORKER_GATE" >&2
+  exit 1
+fi
 
 echo "[publish-worker] Building and pushing e2b template..."
 bash packages/dev-tools/e2b-template/scripts/build-template.sh
@@ -32,16 +77,12 @@ echo "$CLOUDFLARE_TURN_API_TOKEN" | npx wrangler secret put CLOUDFLARE_TURN_API_
 echo "$GITHUB_CLIENT_SECRET"      | npx wrangler secret put GITHUB_CLIENT_SECRET      --config "$WRANGLER_CONFIG"
 echo "$E2B_API_KEY"               | npx wrangler secret put E2B_API_KEY               --config "$WRANGLER_CONFIG"
 
-# #1330 retention: archive this build's content-hashed assets to R2 BEFORE
-# deploy so long-lived tabs can recover gone lazy chunks. Hard-fail gate
-# (`set -e` aborts the release before deploy if the upload fails) — a build must
-# never go live unarchived. CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID are
-# already in scope for the deploy; the script shells `npx wrangler`.
-echo "[publish-worker] Archiving assets to R2 (slicc-asset-archive)..."
-node packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs slicc-asset-archive --dir dist/ui/assets
+# Hard-fail before deploy if archiving fails; a build must never go live
+# unarchived. The deploy path keeps its established template/secrets/archive order.
+archive_assets
 
 echo "[publish-worker] Deploying worker..."
-npx wrangler deploy --config "$WRANGLER_CONFIG"
+deploy_with_retry "hub" "$WRANGLER_CONFIG"
 
 # The preview worker (*.sliccy.now) shares the hub's URL-token format
 # (`buildPreviewUrl` <-> `previewTokenFromHost`) and its Durable Object (bound
@@ -52,7 +93,7 @@ npx wrangler deploy --config "$WRANGLER_CONFIG"
 # shared DO binding), so no secret upload is needed. Deployed AFTER the hub so
 # the `script_name` DO reference resolves.
 echo "[publish-worker] Deploying preview worker (must ship with the hub)..."
-npx wrangler deploy --config "$PREVIEW_WRANGLER_CONFIG"
+deploy_with_retry "preview" "$PREVIEW_WRANGLER_CONFIG"
 
 echo "[publish-worker] Running deployed smoke tests (up to $MAX_ATTEMPTS attempts)..."
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do

--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 // Gate the native macOS (Sliccstart DMG + update ZIP) and iOS (TestFlight)
 // packaging steps of the semantic-release prepareCmd — and the Chrome Web Store
-// publish step of the publishCmd (`--gate=chrome`) — on whether their relevant
-// source changed since the previous release tag. The always-run steps
-// (`npm run build`, `npm run package:release`, `npm run publish:worker`) stay in
-// .releaserc.json; only these gated steps are decided here.
+// publish steps of the publishCmd (`--gate=chrome` / `--gate=worker`) — on whether
+// their relevant source changed since the previous release tag. The always-run
+// build/package steps stay in .releaserc.json; only gated steps are decided here.
 //
 // The pure decision helpers (no IO) are unit-tested by the `dev-tools` vitest
 // project via the co-located release-native.test.mjs. Only main() touches git
@@ -42,6 +41,27 @@ export const EXTENSION_PATH_PREFIXES = [
   'packages/spoon/',
   'packages/cloud-core/',
   'packages/assets/',
+];
+
+// APPROVED worker/UI-relevant path set for the production worker deploy. This
+// includes the worker, everything bundled into its served UI, shared worker
+// dependencies, and the node-server/template inputs published for cloud cones.
+// Root package metadata is included because dependency changes can alter both
+// the worker/UI build and the hosted template runtime.
+export const WORKER_PATH_PREFIXES = [
+  'packages/cloudflare-worker/',
+  'packages/webapp/',
+  'packages/webcomponents/',
+  'packages/spoon/',
+  'packages/cherry/',
+  'packages/shared-ts/',
+  'packages/cloud-core/',
+  'packages/dev-tools/e2b-template/',
+  'packages/node-server/',
+  'packages/vfs-root/',
+  'packages/assets/',
+  'package.json',
+  'package-lock.json',
 ];
 
 // Command strings preserve the current .releaserc.json fail-fast behavior
@@ -97,6 +117,16 @@ export function decideChromeGating({ lastTag, changedFiles = [] } = {}) {
   };
 }
 
+export function decideWorkerGating({ lastTag, changedFiles = [] } = {}) {
+  if (isFirstRelease(lastTag)) {
+    return { worker: true, firstRelease: true };
+  }
+  return {
+    worker: changedFiles.some((f) => matchesAnyPrefix(f, WORKER_PATH_PREFIXES)),
+    firstRelease: false,
+  };
+}
+
 export function parseArgs(argv) {
   const args = { last: '', next: '', gate: '', dryRun: false, help: false };
   for (let i = 0; i < argv.length; i++) {
@@ -136,10 +166,10 @@ function writeKnownGoodPointer(version, targetPath = KNOWN_GOOD_MACOS_PATH) {
   return pointer;
 }
 
-const HELP = `release-native — gate native macOS/iOS packaging and the Chrome Web Store publish on source changes
+const HELP = `release-native — gate native packaging, worker deploy, and Chrome publish on source changes
 
 Usage:
-  node packages/dev-tools/tools/release-native.mjs --last=<tag> [--gate=chrome] [--dry-run]
+  node packages/dev-tools/tools/release-native.mjs --last=<tag> [--gate=chrome|worker] [--dry-run]
 
 Options:
   --last=<tag>   Previous release git tag. Empty => first release => run ALL gated steps.
@@ -150,6 +180,8 @@ Options:
                  In .releaserc.json use --next='\${nextRelease.version}'.
   --gate=chrome  Gate the Chrome Web Store publish (\`${CHROME_PUBLISH_CMD}\`) instead of
                  the default native macOS/iOS packaging.
+  --gate=worker  Print "deploy" when the production worker/UI should deploy, otherwise
+                 print "skip". This decision mode never runs the deploy itself.
   --dry-run, -n  Print the gating decision without running the packaging / publish scripts.
   --help, -h     Show this help.
 
@@ -160,9 +192,11 @@ Behavior:
     ${IOS_PATH_PREFIXES.join(', ')} changed.
   - --gate=chrome: diff <tag>..HEAD and publish to the Chrome Web Store only if one of
     ${EXTENSION_PATH_PREFIXES.join(', ')} changed.
+  - --gate=worker: diff <tag>..HEAD and print deploy only if one of
+    ${WORKER_PATH_PREFIXES.join(', ')} changed.
   - A failing packaging / publish script fails the release (fail-fast preserved).`;
 
-function getChangedFiles(lastTag) {
+export function getChangedFiles(lastTag) {
   const out = execFileSync('git', ['diff', '--name-only', lastTag, 'HEAD'], { encoding: 'utf8' });
   return parseChangedFiles(out);
 }
@@ -184,6 +218,12 @@ export function main(argv = process.argv.slice(2)) {
   }
 
   const changedFiles = isFirstRelease(args.last) ? [] : getChangedFiles(args.last);
+
+  if (args.gate === 'worker') {
+    const decision = decideWorkerGating({ lastTag: args.last, changedFiles });
+    console.log(decision.worker ? 'deploy' : 'skip');
+    return 0;
+  }
 
   if (args.gate === 'chrome') {
     const decision = decideChromeGating({ lastTag: args.last, changedFiles });

--- a/packages/dev-tools/tools/release-native.test.mjs
+++ b/packages/dev-tools/tools/release-native.test.mjs
@@ -12,6 +12,7 @@ import {
   buildKnownGoodPointer,
   decideChromeGating,
   decideGating,
+  decideWorkerGating,
   EXTENSION_PATH_PREFIXES,
   IOS_PATH_PREFIXES,
   isFirstRelease,
@@ -20,6 +21,7 @@ import {
   matchesAnyPrefix,
   parseArgs,
   parseChangedFiles,
+  WORKER_PATH_PREFIXES,
 } from './release-native.mjs';
 
 describe('isFirstRelease', () => {
@@ -225,6 +227,48 @@ describe('decideChromeGating', () => {
     expect(
       decideChromeGating({ lastTag: 'v1.0.0', changedFiles: ['docs/development.md'] })
     ).toEqual({ chrome: false, firstRelease: false });
+  });
+});
+
+describe('decideWorkerGating', () => {
+  const requiredPrefixes = [
+    'packages/cloudflare-worker/',
+    'packages/webapp/',
+    'packages/webcomponents/',
+    'packages/spoon/',
+    'packages/cherry/',
+    'packages/shared-ts/',
+    'packages/cloud-core/',
+    'packages/dev-tools/e2b-template/',
+  ];
+
+  it('deploys on first release with an empty last tag', () => {
+    expect(decideWorkerGating({ lastTag: '', changedFiles: [] })).toEqual({
+      worker: true,
+      firstRelease: true,
+    });
+  });
+
+  it('deploys for a worker/UI-relevant change', () => {
+    expect(
+      decideWorkerGating({
+        lastTag: 'v1.0.0',
+        changedFiles: ['packages/webapp/src/main.ts'],
+      })
+    ).toEqual({ worker: true, firstRelease: false });
+  });
+
+  it('skips for an irrelevant change', () => {
+    expect(
+      decideWorkerGating({ lastTag: 'v1.0.0', changedFiles: ['docs/development.md'] })
+    ).toEqual({ worker: false, firstRelease: false });
+  });
+
+  it.each(requiredPrefixes)('deploys for required prefix %s', (prefix) => {
+    expect(WORKER_PATH_PREFIXES).toContain(prefix);
+    expect(
+      decideWorkerGating({ lastTag: 'v1.0.0', changedFiles: [`${prefix}changed-file`] })
+    ).toEqual({ worker: true, firstRelease: false });
   });
 });
 


### PR DESCRIPTION
## Why

Semantic-release has been creating git tags without the corresponding GitHub Release. Root cause: `publish-worker.sh` runs on **every** release via `@semantic-release/exec`, and its `wrangler deploy` intermittently fails on the `POST /zones/{zone}/workers/routes` trigger call ("Some triggers failed to deploy"). Under `set -euo pipefail` that aborts the release **after** the tag was pushed but **before** the GitHub Release is created.

This PR reduces how often the worker deploys and makes the deploys that do run resilient to that transient failure.

## What

**1. Gate the worker deploy on relevant changes**
- New `--gate=worker` / `decideWorkerGating` in `release-native.mjs`, reusing the existing `getChangedFiles` / `matchesAnyPrefix` / `isFirstRelease` helpers.
- `publish-worker.sh` runs the gate first; if nothing worker/UI-relevant changed since the last release tag it **skips** both `wrangler deploy`s and the smoke test.
- On skip it **still refreshes the 14-day R2 asset archive** so GC retention is preserved.
- Prefix set: `cloudflare-worker`, `webapp`, `webcomponents`, `spoon`, `cherry`, `shared-ts`, `cloud-core`, `e2b-template`. First release / empty last tag always deploys.
- `.releaserc.json` wires `SLICC_LAST_RELEASE_TAG` into `publish:worker`.

**2. Retry the wrangler deploy with backoff**
- New `deploy_with_retry` helper wraps both the hub and preview deploys: 6 attempts, 15s backoff, `WRANGLER_LOG=debug`.
- Re-running after a partial success (script deployed, routes failed) is safe — wrangler reconciles.
- Final failure surfaces the wrangler debug log and exits non-zero.

## Not in this PR (follow-up)

Reordering the semantic-release plugins so `@semantic-release/github` runs before `@semantic-release/exec` — that is what would *guarantee* a Release exists even if a deploy ultimately fails. The gate + retry reduce the chance of hitting the flaky deploy; the reorder is the belt-and-suspenders fix and is tracked separately.

## Verification

- `release-native` Vitest: 48/48 pass (includes new gate cases)
- `bash -n packages/cloudflare-worker/scripts/publish-worker.sh`
- `npm run lint`
- `npm run typecheck`

Docs updated in `packages/cloudflare-worker/CLAUDE.md`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author