### PR TITLE
Fix worker-deploy gate no-op on semantic-release version bump

### DIFF
--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -302,11 +302,14 @@ This lives at the repo root because it coordinates the worker with browser runti
 - Worker deploy automation lives in `.github/workflows/worker.yml`.
 - The automated semantic-release path gates production deployment with
   `release-native.mjs --gate=worker`, comparing the previous release tag to
-  `HEAD`. Changes under the worker, served webapp/UI packages, shared worker
-  dependencies, or hosted e2b template inputs deploy both workers and run the
-  live smoke tests. First releases always deploy; releases with only unrelated
-  changes refresh the R2 archive and exit before the template push, secret
-  writes, both `wrangler deploy` calls, and deployed smoke tests.
+  `HEAD`, except when `HEAD` is the generated `chore(release):` version-bump
+  commit, where it compares to `HEAD^` so that commit alone does not open the
+  gate. Changes under the worker, served webapp/UI packages, shared worker
+  dependencies, root package metadata, or hosted e2b template inputs deploy
+  both workers and run the live smoke tests. First releases always deploy;
+  releases with only unrelated changes refresh the R2 archive and exit before
+  the template push, secret writes, both `wrangler deploy` calls, and deployed
+  smoke tests.
 - The R2 refresh intentionally remains unconditional because bucket lifecycle
   GC expires objects after 14 days. A worker-deploy skip streak is unbounded, so
   relying on that TTL would eventually delete still-current archived chunks.

--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -93,6 +93,10 @@ export function parseChangedFiles(gitOutput) {
     .filter(Boolean);
 }
 
+export function resolveDiffRef({ headSubject, headRef = 'HEAD' } = {}) {
+  return String(headSubject ?? '').startsWith('chore(release):') ? `${headRef}^` : headRef;
+}
+
 // Core gating decision. Returns which native artifacts to build.
 export function decideGating({ lastTag, changedFiles = [] } = {}) {
   if (isFirstRelease(lastTag)) {
@@ -187,17 +191,25 @@ Options:
 
 Behavior:
   - First release (empty tag): run the gated step(s) unconditionally.
-  - Default (no --gate): diff <tag>..HEAD and build macOS only if one of
+  - Default (no --gate): diff <tag> against HEAD (or HEAD^ for a generated release commit)
+    and build macOS only if one of
     ${MACOS_PATH_PREFIXES.join(', ')} changed, iOS only if
     ${IOS_PATH_PREFIXES.join(', ')} changed.
-  - --gate=chrome: diff <tag>..HEAD and publish to the Chrome Web Store only if one of
+  - --gate=chrome: use the same resolved diff ref and publish to the Chrome Web Store if one of
     ${EXTENSION_PATH_PREFIXES.join(', ')} changed.
-  - --gate=worker: diff <tag>..HEAD and print deploy only if one of
+  - --gate=worker: use the same resolved diff ref and print deploy only if one of
     ${WORKER_PATH_PREFIXES.join(', ')} changed.
   - A failing packaging / publish script fails the release (fail-fast preserved).`;
 
 export function getChangedFiles(lastTag) {
-  const out = execFileSync('git', ['diff', '--name-only', lastTag, 'HEAD'], { encoding: 'utf8' });
+  const headRef = 'HEAD';
+  const headSubject = execFileSync('git', ['log', '-1', '--format=%s', headRef], {
+    encoding: 'utf8',
+  });
+  const diffRef = resolveDiffRef({ headSubject, headRef });
+  const out = execFileSync('git', ['diff', '--name-only', lastTag, diffRef], {
+    encoding: 'utf8',
+  });
   return parseChangedFiles(out);
 }
 

--- a/packages/dev-tools/tools/release-native.test.mjs
+++ b/packages/dev-tools/tools/release-native.test.mjs
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Stub only the fs write so main()'s dry-run guard can be checked hermetically —
 // keep the real realpathSync the module uses for its isMain check at import time.
@@ -7,6 +7,12 @@ vi.mock('node:fs', async (importActual) => {
   return { ...actual, writeFileSync: vi.fn() };
 });
 
+vi.mock('node:child_process', async (importActual) => {
+  const actual = await importActual();
+  return { ...actual, execFileSync: vi.fn() };
+});
+
+import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import {
   buildKnownGoodPointer,
@@ -14,6 +20,7 @@ import {
   decideGating,
   decideWorkerGating,
   EXTENSION_PATH_PREFIXES,
+  getChangedFiles,
   IOS_PATH_PREFIXES,
   isFirstRelease,
   MACOS_PATH_PREFIXES,
@@ -21,6 +28,7 @@ import {
   matchesAnyPrefix,
   parseArgs,
   parseChangedFiles,
+  resolveDiffRef,
   WORKER_PATH_PREFIXES,
 } from './release-native.mjs';
 
@@ -101,6 +109,63 @@ describe('parseChangedFiles', () => {
   it('handles empty / nullish output', () => {
     expect(parseChangedFiles('')).toEqual([]);
     expect(parseChangedFiles(undefined)).toEqual([]);
+  });
+});
+
+describe('resolveDiffRef', () => {
+  it('excludes a generated semantic-release commit', () => {
+    expect(resolveDiffRef({ headSubject: 'chore(release): 5.38.0' })).toBe('HEAD^');
+    expect(resolveDiffRef({ headSubject: 'chore(release): 5.38.0', headRef: 'abc123' })).toBe(
+      'abc123^'
+    );
+  });
+
+  it('keeps HEAD for a normal commit', () => {
+    expect(resolveDiffRef({ headSubject: 'fix(deps): update wrangler' })).toBe('HEAD');
+    expect(resolveDiffRef({ headSubject: 'docs: mention chore(release): commits' })).toBe('HEAD');
+  });
+});
+
+describe('getChangedFiles', () => {
+  beforeEach(() => execFileSync.mockReset());
+
+  it('diffs against HEAD^ so a generated release-only bump is excluded', () => {
+    execFileSync.mockReturnValueOnce('chore(release): 5.38.0\n').mockReturnValueOnce('');
+
+    const changedFiles = getChangedFiles('v5.37.0');
+
+    expect(execFileSync).toHaveBeenNthCalledWith(1, 'git', ['log', '-1', '--format=%s', 'HEAD'], {
+      encoding: 'utf8',
+    });
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      'git',
+      ['diff', '--name-only', 'v5.37.0', 'HEAD^'],
+      { encoding: 'utf8' }
+    );
+    expect(decideWorkerGating({ lastTag: 'v5.37.0', changedFiles })).toEqual({
+      worker: false,
+      firstRelease: false,
+    });
+  });
+
+  it('diffs against HEAD and deploys for a genuine dependency bump', () => {
+    execFileSync
+      .mockReturnValueOnce('fix(deps): update wrangler\n')
+      .mockReturnValueOnce('package.json\npackage-lock.json\n');
+
+    const changedFiles = getChangedFiles('v5.37.0');
+
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      'git',
+      ['diff', '--name-only', 'v5.37.0', 'HEAD'],
+      { encoding: 'utf8' }
+    );
+    expect(decideWorkerGating({ lastTag: 'v5.37.0', changedFiles })).toEqual({
+      worker: true,
+      firstRelease: false,
+    });
   });
 });
 
@@ -262,6 +327,17 @@ describe('decideWorkerGating', () => {
     expect(
       decideWorkerGating({ lastTag: 'v1.0.0', changedFiles: ['docs/development.md'] })
     ).toEqual({ worker: false, firstRelease: false });
+  });
+
+  it.each([
+    'package.json',
+    'package-lock.json',
+  ])('deploys for genuine root metadata change %s', (file) => {
+    expect(WORKER_PATH_PREFIXES).toContain(file);
+    expect(decideWorkerGating({ lastTag: 'v1.0.0', changedFiles: [file] })).toEqual({
+      worker: true,
+      firstRelease: false,
+    });
   });
 
   it.each(requiredPrefixes)('deploys for required prefix %s', (prefix) => {


### PR DESCRIPTION
## Why

Follow-up to #1480. Codex review on #1480 caught a correctness bug that makes the new `--gate=worker` a **no-op**.

`@semantic-release/git` commits the `chore(release): x.y.z` version bump to `package.json` / `package-lock.json` during the *prepare* step. The worker gate runs later in *publish*, so at that point `HEAD` is already the release commit. `git diff <lastTag> HEAD` therefore always reports `package.json` as changed (they are in `WORKER_PATH_PREFIXES`), so the gate always returns `deploy`. Every release still hits the flaky Cloudflare deploy — the exact thing #1480 set out to reduce.

## What

- New pure helper `resolveDiffRef(lastTag)` in `release-native.mjs`: when the `HEAD` commit subject starts with `chore(release):`, diff against `HEAD^` so the auto-generated version bump is ignored; otherwise diff against `HEAD` as before.
- `getChangedFiles` now uses `resolveDiffRef`, so genuine `fix(deps)` / dependency changes in `package.json` / `package-lock.json` (which land in real commits, not the release commit) still trigger a deploy.
- `package.json` / `package-lock.json` remain in `WORKER_PATH_PREFIXES` — no loss of real dependency-change detection.
- Regression tests added: gate ignores the release-commit version bump but still deploys on real package metadata changes.
- `packages/cloudflare-worker/CLAUDE.md` updated to document the release-commit handling.

## Verification

- release-native Vitest: 54/54 pass (6 new regression cases)
- full dev-tools coverage: 302/302
- `npm run lint`, `npm run typecheck`, complexity gate, root build, extension build all pass

## Notes

The merged worker gate on `main` is currently a no-op until this lands — every release still runs the flaky deploy in the meantime. The separately-tracked belt-and-suspenders fix (reorder `@semantic-release/github` before `@semantic-release/exec`) is still a future follow-up and not in this PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author