### PR TITLE
fix(release): treat routes-only worker deploy failure as non-fatal

### DIFF
--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -164,9 +164,15 @@ Each should output:
 Age: 14 days → Expiration
 ```
 
-### 3. Grant `CLOUDFLARE_API_TOKEN` R2 Object Read & Write
+### 3. `CLOUDFLARE_API_TOKEN` — required permission set (ALL of these)
 
-The deploy workflow's `CLOUDFLARE_API_TOKEN` secret must have **R2 Object Read & Write** permission on **both buckets** (`slicc-asset-archive` and `slicc-asset-archive-staging`). Update the token's permissions in the Cloudflare dashboard (**Account Settings → API Tokens → Edit token**) or create a new token with the required scope.
+The deploy `CLOUDFLARE_API_TOKEN` secret is used for **the whole worker deploy**, not just R2. When editing/recreating it (**Account Settings → API Tokens → Edit token**), it MUST keep every scope below — dropping any one wedges releases:
+
+- **Account → Workers Scripts → Edit** — deploy the worker script + Static Assets.
+- **Account → Workers R2 Storage → Edit** (a.k.a. R2 Object Read & Write) on **both** buckets (`slicc-asset-archive`, `slicc-asset-archive-staging`) — the asset-archive upload + serving.
+- **Zone → Workers Routes → Edit** _and_ **Zone → Zone → Read** for the **`sliccy.ai`** zone (all zones is fine) — reconcile the `www.sliccy.ai/*` + `*.sliccy.now/*` routes on deploy.
+
+> ⚠️ **Incident (2026-07-13):** granting R2 to this token dropped its **Zone/Workers-Routes** scope. The worker _script_ still deployed (so sliccy.ai kept serving the latest build), but `wrangler deploy` then failed reconciling routes (`"does not have 'All Zones' permissions" … /workers/routes failed`), which failed `publish-worker.sh` and aborted the release **before** the GitHub-release/Chrome/npm publish steps — so GitHub Releases + Chrome froze while tags advanced. `publish-worker.sh` now treats a **routes-only** deploy failure as non-fatal (the version is already live), but the token should still carry the routes scope so route _changes_ apply. When editing the token, add scopes; never replace the whole set with only R2.
 
 ## Commands
 
@@ -314,10 +320,20 @@ This lives at the repo root because it coordinates the worker with browser runti
   GC expires objects after 14 days. A worker-deploy skip streak is unbounded, so
   relying on that TTL would eventually delete still-current archived chunks.
 - Production hub and preview deploys each retry up to six times with a 15-second
-  delay. Retries are safe when Wrangler uploaded the script but route
-  reconciliation failed because a repeated deploy reconciles the desired
-  configuration. Each attempt enables Wrangler debug logging; exhausting all
-  attempts prints that worker's debug log to CI stderr before failing.
+  delay. Each attempt enables Wrangler debug logging; exhausting all attempts
+  prints that worker's debug log to CI stderr before failing.
+- **Routes-only failures are non-fatal.** `deploy_with_retry` captures each
+  attempt's combined output and, on failure, classifies it with
+  `release-native.mjs --classify-deploy-log` (pure `isRoutesReconcileOnlyFailure`,
+  unit-tested). When Wrangler printed `Some triggers failed to deploy … /workers/routes`
+  it had already uploaded AND activated the new version (script + assets are
+  live); only route reconciliation failed (e.g. the token lost Zone → Workers
+  Routes → Edit). Routes are set-once and stable, so this is treated as a
+  successful deploy with a loud warning, and the release continues to the
+  GitHub-release/Chrome/npm publish steps instead of aborting. If a release
+  actually _changed_ routes, the warning flags that they did not apply until the
+  token's routes scope is restored (see the Ops Runbook above). Any other failure
+  (script upload, bindings, asset-too-large) still retries and then fails hard.
 - Required repo configuration:
   - secret: `CLOUDFLARE_API_TOKEN`
   - variable: `CLOUDFLARE_ACCOUNT_ID`

--- a/packages/cloudflare-worker/scripts/publish-worker.sh
+++ b/packages/cloudflare-worker/scripts/publish-worker.sh
@@ -33,14 +33,27 @@ deploy_with_retry() {
   local label="$1"
   local config="$2"
   local log_path="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/wrangler-${label}-deploy.log"
+  local out_path="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/wrangler-${label}-deploy.out"
 
   : > "$log_path"
   # A retry after Wrangler deployed the script but failed to reconcile routes is
   # safe: deploy is idempotent and reconciles the worker's desired configuration.
   for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
     echo "[publish-worker] Deploying $label worker (attempt $attempt/$MAX_ATTEMPTS)..."
-    if WRANGLER_LOG=debug WRANGLER_LOG_PATH="$log_path" npx wrangler deploy --config "$config"; then
+    # Capture combined stdout+stderr so a failed attempt can be classified.
+    # pipefail (set -o) makes the pipeline exit with wrangler's status, not tee's.
+    if WRANGLER_LOG=debug WRANGLER_LOG_PATH="$log_path" npx wrangler deploy --config "$config" 2>&1 | tee "$out_path"; then
       echo "[publish-worker] $label worker deployed on attempt $attempt."
+      return 0
+    fi
+    # A routes-ONLY failure means Wrangler uploaded AND activated the new version
+    # (script + assets are live) but could not reconcile the worker's routes —
+    # e.g. the deploy token lacks Zone -> Workers Routes -> Edit. Routes are
+    # set-once and stable, so the new version is already serving and the release
+    # must not be blocked by it. Any other failure is fatal and keeps retrying.
+    if [ "$(node packages/dev-tools/tools/release-native.mjs --classify-deploy-log "$out_path" 2>/dev/null || echo fatal)" = "routes-only" ]; then
+      echo "[publish-worker] WARNING: $label worker script + assets deployed and are LIVE, but route reconciliation failed (deploy token lacks Zone -> Workers Routes -> Edit for the zone). Routes are stable/already-assigned, so the new version is serving. Treating as deployed." >&2
+      echo "[publish-worker] WARNING: if this release CHANGED routes in $config, they did NOT apply until the token permission is restored — see packages/cloudflare-worker/CLAUDE.md 'Ops Runbook'." >&2
       return 0
     fi
     if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then

--- a/packages/cloudflare-worker/scripts/publish-worker.sh
+++ b/packages/cloudflare-worker/scripts/publish-worker.sh
@@ -36,8 +36,10 @@ deploy_with_retry() {
   local out_path="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/wrangler-${label}-deploy.out"
 
   : > "$log_path"
-  # A retry after Wrangler deployed the script but failed to reconcile routes is
-  # safe: deploy is idempotent and reconciles the worker's desired configuration.
+  # Retries cover transient deploy failures. A routes-ONLY failure (script +
+  # assets deployed, only route reconciliation failed) is detected below and
+  # short-circuits the loop instead of retrying — the new version is already
+  # live and re-deploying would just fail on the same route step.
   for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
     echo "[publish-worker] Deploying $label worker (attempt $attempt/$MAX_ATTEMPTS)..."
     # Capture combined stdout+stderr so a failed attempt can be classified.
@@ -51,7 +53,7 @@ deploy_with_retry() {
     # e.g. the deploy token lacks Zone -> Workers Routes -> Edit. Routes are
     # set-once and stable, so the new version is already serving and the release
     # must not be blocked by it. Any other failure is fatal and keeps retrying.
-    if [ "$(node packages/dev-tools/tools/release-native.mjs --classify-deploy-log "$out_path" 2>/dev/null || echo fatal)" = "routes-only" ]; then
+    if [ "$(node packages/dev-tools/tools/release-native.mjs --classify-deploy-log "$out_path" || echo fatal)" = "routes-only" ]; then
       echo "[publish-worker] WARNING: $label worker script + assets deployed and are LIVE, but route reconciliation failed (deploy token lacks Zone -> Workers Routes -> Edit for the zone). Routes are stable/already-assigned, so the new version is serving. Treating as deployed." >&2
       echo "[publish-worker] WARNING: if this release CHANGED routes in $config, they did NOT apply until the token permission is restored — see packages/cloudflare-worker/CLAUDE.md 'Ops Runbook'." >&2
       return 0

--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -10,7 +10,7 @@
 // and spawns the packaging / publish scripts.
 
 import { execFileSync, execSync } from 'node:child_process';
-import { realpathSync, writeFileSync } from 'node:fs';
+import { readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 // APPROVED relevant path sets. macOS also tracks packages/spoon/ because it
@@ -131,18 +131,46 @@ export function decideWorkerGating({ lastTag, changedFiles = [] } = {}) {
   };
 }
 
+// Pure classifier (no IO): given the combined stdout+stderr of a `wrangler
+// deploy`, decide whether the ONLY thing that failed was route/trigger
+// reconciliation. Wrangler prints "Some triggers failed to deploy for <worker>"
+// only after it has uploaded AND activated the new version, when it then fails
+// to reconcile the worker's routes (e.g. the deploy token lacks
+// Zone → Workers Routes → Edit). In that case the new script + assets are
+// already live and serving, so the deploy is effectively done and the release
+// should continue. Any other failure (script upload, bindings, asset-too-large)
+// is NOT tolerable and must fail the release.
+export function isRoutesReconcileOnlyFailure(output) {
+  const text = typeof output === 'string' ? output : '';
+  const triggersFailed = /Some triggers failed to deploy/i.test(text);
+  const routesApi = /workers\/routes/i.test(text);
+  return triggersFailed && routesApi;
+}
+
+// Value-taking flags → args field. Each supports `--flag=value` and
+// `--flag value`; unknown flags are ignored (unchanged behavior).
+const VALUE_OPTS = {
+  '--last': 'last',
+  '--next': 'next',
+  '--gate': 'gate',
+  '--classify-deploy-log': 'classifyDeployLog',
+};
+
 export function parseArgs(argv) {
-  const args = { last: '', next: '', gate: '', dryRun: false, help: false };
+  const args = { last: '', next: '', gate: '', dryRun: false, help: false, classifyDeployLog: '' };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === '--help' || a === '-h') args.help = true;
-    else if (a === '--dry-run' || a === '-n') args.dryRun = true;
-    else if (a.startsWith('--last=')) args.last = a.slice('--last='.length);
-    else if (a === '--last') args.last = argv[++i] ?? '';
-    else if (a.startsWith('--next=')) args.next = a.slice('--next='.length);
-    else if (a === '--next') args.next = argv[++i] ?? '';
-    else if (a.startsWith('--gate=')) args.gate = a.slice('--gate='.length);
-    else if (a === '--gate') args.gate = argv[++i] ?? '';
+    if (a === '--help' || a === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (a === '--dry-run' || a === '-n') {
+      args.dryRun = true;
+      continue;
+    }
+    const eq = a.indexOf('=');
+    const field = VALUE_OPTS[eq === -1 ? a : a.slice(0, eq)];
+    if (field) args[field] = eq === -1 ? (argv[++i] ?? '') : a.slice(eq + 1);
   }
   return args;
 }
@@ -186,6 +214,10 @@ Options:
                  the default native macOS/iOS packaging.
   --gate=worker  Print "deploy" when the production worker/UI should deploy, otherwise
                  print "skip". This decision mode never runs the deploy itself.
+  --classify-deploy-log=<path>
+                 Read a captured \`wrangler deploy\` log and print "routes-only" when the
+                 ONLY failure was route reconciliation (the script + assets deployed and
+                 are live), otherwise "fatal". Used by publish-worker.sh; never touches git.
   --dry-run, -n  Print the gating decision without running the packaging / publish scripts.
   --help, -h     Show this help.
 
@@ -222,10 +254,29 @@ function runStep(label, cmd, dryRun, verb = 'Building', dryVerb = 'build') {
   execSync(cmd, { stdio: 'inherit' });
 }
 
+// IO wrapper: classify a captured `wrangler deploy` log file as "routes-only"
+// (tolerable — the script + assets already deployed and are live) or "fatal".
+// An unreadable file is conservatively "fatal" so an unclassifiable deploy is
+// never mistaken for the benign routes-only case.
+function classifyDeployLogFile(path) {
+  let text = '';
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return 'fatal';
+  }
+  return isRoutesReconcileOnlyFailure(text) ? 'routes-only' : 'fatal';
+}
+
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   if (args.help) {
     console.log(HELP);
+    return 0;
+  }
+
+  if (args.classifyDeployLog) {
+    console.log(classifyDeployLogFile(args.classifyDeployLog));
     return 0;
   }
 

--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -143,8 +143,13 @@ export function decideWorkerGating({ lastTag, changedFiles = [] } = {}) {
 export function isRoutesReconcileOnlyFailure(output) {
   const text = typeof output === 'string' ? output : '';
   const triggersFailed = /Some triggers failed to deploy/i.test(text);
-  const routesApi = /workers\/routes/i.test(text);
-  return triggersFailed && routesApi;
+  // Match Wrangler's specific route-reconcile error bullet, not any stray
+  // "workers/routes" mention elsewhere in the debug log. (These workers expose
+  // only route triggers; if a Cron/Queue trigger is ever added, tighten this
+  // further to confirm the failing trigger is specifically the route.)
+  const routesReconcileFailed =
+    /A request to the Cloudflare API \([^)]*workers\/routes\) failed/i.test(text);
+  return triggersFailed && routesReconcileFailed;
 }
 
 // Value-taking flags → args field. Each supports `--flag=value` and
@@ -262,7 +267,8 @@ function classifyDeployLogFile(path) {
   let text = '';
   try {
     text = readFileSync(path, 'utf8');
-  } catch {
+  } catch (err) {
+    console.error(`[release-native] could not read deploy log ${path}; treating as fatal: ${err}`);
     return 'fatal';
   }
   return isRoutesReconcileOnlyFailure(text) ? 'routes-only' : 'fatal';

--- a/packages/dev-tools/tools/release-native.test.mjs
+++ b/packages/dev-tools/tools/release-native.test.mjs
@@ -23,6 +23,7 @@ import {
   getChangedFiles,
   IOS_PATH_PREFIXES,
   isFirstRelease,
+  isRoutesReconcileOnlyFailure,
   MACOS_PATH_PREFIXES,
   main,
   matchesAnyPrefix,
@@ -31,6 +32,47 @@ import {
   resolveDiffRef,
   WORKER_PATH_PREFIXES,
 } from './release-native.mjs';
+
+describe('isRoutesReconcileOnlyFailure', () => {
+  const routesOnlyLog = [
+    ' ⛅️ wrangler 4.107.0',
+    'Uploaded slicc-tray-hub (3.2 sec)',
+    '✘ [ERROR] Some triggers failed to deploy for slicc-tray-hub:',
+    '    - A request to the Cloudflare API (/zones/e9505401e684369c36640475c1f532c7/workers/routes) failed.',
+    "The current authentication token does not have 'All Zones' permissions.",
+  ].join('\n');
+
+  it('detects a routes-reconcile-only failure (script deployed, only triggers failed)', () => {
+    expect(isRoutesReconcileOnlyFailure(routesOnlyLog)).toBe(true);
+  });
+
+  it('does not treat an empty / non-string log as routes-only', () => {
+    expect(isRoutesReconcileOnlyFailure('')).toBe(false);
+    expect(isRoutesReconcileOnlyFailure(undefined)).toBe(false);
+    expect(isRoutesReconcileOnlyFailure(null)).toBe(false);
+  });
+
+  it('does not treat a script-upload failure as routes-only (no "triggers failed")', () => {
+    const uploadFailure = [
+      '✘ [ERROR] A request to the Cloudflare API (/accounts/x/workers/scripts/slicc-tray-hub) failed.',
+      '  Asset too large: dist/ui/assets/huge.wasm (33 MiB) exceeds the 25 MiB limit',
+    ].join('\n');
+    expect(isRoutesReconcileOnlyFailure(uploadFailure)).toBe(false);
+  });
+
+  it('does not treat a pre-deploy routes error without "triggers failed" as routes-only', () => {
+    // A bare /workers/routes GET failure before the script deploys is NOT the
+    // tolerable case — the version never went live.
+    const preDeploy = 'A request to the Cloudflare API (/zones/x/workers/routes) failed.';
+    expect(isRoutesReconcileOnlyFailure(preDeploy)).toBe(false);
+  });
+
+  it('does not treat a clean success as a failure', () => {
+    const ok =
+      'Uploaded slicc-tray-hub (3.2 sec)\nDeployed slicc-tray-hub triggers\nCurrent Version ID: abc';
+    expect(isRoutesReconcileOnlyFailure(ok)).toBe(false);
+  });
+});
 
 describe('isFirstRelease', () => {
   it('treats empty / whitespace / placeholder tags as first release', () => {
@@ -356,6 +398,7 @@ describe('parseArgs', () => {
       gate: '',
       dryRun: false,
       help: false,
+      classifyDeployLog: '',
     });
     expect(parseArgs(['--last='])).toEqual({
       last: '',
@@ -363,6 +406,7 @@ describe('parseArgs', () => {
       gate: '',
       dryRun: false,
       help: false,
+      classifyDeployLog: '',
     });
   });
 
@@ -373,6 +417,7 @@ describe('parseArgs', () => {
       gate: '',
       dryRun: false,
       help: false,
+      classifyDeployLog: '',
     });
   });
 
@@ -383,6 +428,7 @@ describe('parseArgs', () => {
       gate: '',
       dryRun: false,
       help: false,
+      classifyDeployLog: '',
     });
     expect(parseArgs(['--next', '5.38.0'])).toEqual({
       last: '',
@@ -390,6 +436,7 @@ describe('parseArgs', () => {
       gate: '',
       dryRun: false,
       help: false,
+      classifyDeployLog: '',
     });
     expect(parseArgs(['--next=']).next).toBe('');
   });
@@ -401,6 +448,7 @@ describe('parseArgs', () => {
       gate: '',
       dryRun: false,
       help: false,
+      classifyDeployLog: '',
     });
   });
 
@@ -411,6 +459,7 @@ describe('parseArgs', () => {
       gate: 'chrome',
       dryRun: false,
       help: false,
+      classifyDeployLog: '',
     });
     expect(parseArgs(['--gate', 'chrome'])).toEqual({
       last: '',
@@ -418,6 +467,7 @@ describe('parseArgs', () => {
       gate: 'chrome',
       dryRun: false,
       help: false,
+      classifyDeployLog: '',
     });
   });
 
@@ -429,7 +479,20 @@ describe('parseArgs', () => {
   });
 
   it('defaults to empty last / next / gate / false flags', () => {
-    expect(parseArgs([])).toEqual({ last: '', next: '', gate: '', dryRun: false, help: false });
+    expect(parseArgs([])).toEqual({
+      last: '',
+      next: '',
+      gate: '',
+      dryRun: false,
+      help: false,
+      classifyDeployLog: '',
+    });
+  });
+
+  it('parses --classify-deploy-log inline and separate forms', () => {
+    expect(parseArgs(['--classify-deploy-log=/tmp/x.out']).classifyDeployLog).toBe('/tmp/x.out');
+    expect(parseArgs(['--classify-deploy-log', '/tmp/y.out']).classifyDeployLog).toBe('/tmp/y.out');
+    expect(parseArgs([]).classifyDeployLog).toBe('');
   });
 });
 

--- a/packages/dev-tools/tools/release-native.test.mjs
+++ b/packages/dev-tools/tools/release-native.test.mjs
@@ -72,6 +72,18 @@ describe('isRoutesReconcileOnlyFailure', () => {
       'Uploaded slicc-tray-hub (3.2 sec)\nDeployed slicc-tray-hub triggers\nCurrent Version ID: abc';
     expect(isRoutesReconcileOnlyFailure(ok)).toBe(false);
   });
+
+  it('does not treat a non-route trigger failure with a stray routes mention as routes-only', () => {
+    // A future Cron/Queue trigger failing alongside a benign /workers/routes
+    // debug line must NOT be mistaken for a routes-only failure: the match
+    // requires Wrangler's actual route-reconcile error bullet, not any mention.
+    const cronFailure = [
+      '✘ [ERROR] Some triggers failed to deploy for slicc-tray-hub:',
+      '    - Cron trigger "*/5 * * * *" failed to deploy.',
+      'GET https://api.cloudflare.com/client/v4/zones/x/workers/routes (debug)',
+    ].join('\n');
+    expect(isRoutesReconcileOnlyFailure(cronFailure)).toBe(false);
+  });
 });
 
 describe('isFirstRelease', () => {


### PR DESCRIPTION
## Problem

Since **v5.54.2** (2026-07-10), the release pipeline has been half-broken: **GitHub Releases froze at v5.54.2 and Chrome Web Store at 5.54.1, while git tags advanced to v5.56.3** (and npm + sliccy.ai are current at 5.56.3).

### Root cause

Every release fails at `npm run publish:worker`:

```
✘ [ERROR] Some triggers failed to deploy for slicc-tray-hub:
    - A request to the Cloudflare API (/zones/…(sliccy.ai)/workers/routes) failed.
The current authentication token does not have 'All Zones' permissions.
```

The deploy `CLOUDFLARE_API_TOKEN` **lost its Zone → Workers-Routes permission** (it kept Account-level Workers + R2). `wrangler deploy` still uploads + activates the new worker **script + assets** (so sliccy.ai serves the latest build), then fails reconciling the `www.sliccy.ai/*` routes → non-zero exit → `publish-worker.sh` (`set -euo pipefail`) fails.

Because `publish:worker` runs in semantic-release's **publish phase before `@semantic-release/github`** (and before the `&&`-chained chrome gate), the abort skips GitHub + Chrome + npm-tail publishing — while the git **tag** (created in the earlier *prepare* phase) advances. That's the exact "tags ahead, releases frozen" signature. The most likely trigger: the token was re-scoped for R2 during the #1454 asset-retention ops and the routes scope was dropped.

## Fix (code)

Routes are **set-once and stable**, so a routes-*only* deploy failure means the new version is already live. `deploy_with_retry` now:

- captures each attempt's combined output, and on failure classifies it via `release-native.mjs --classify-deploy-log` (pure, unit-tested **`isRoutesReconcileOnlyFailure`**);
- treats a **routes-only** failure as a deployed-with-warning **success** → the release continues to publish GitHub / Chrome / npm;
- keeps retrying + failing hard on any **other** failure (script upload, bindings, asset-too-large);
- logs a loud warning that route **changes** (if any) did not apply until the token's routes scope is restored.

Applies uniformly to both the hub and preview worker deploys.

## Ops action still recommended (not blocking — hand-off)

This PR unblocks releases even with the reduced token, but the token **should** regain its routes scope so route changes apply. On the deploy `CLOUDFLARE_API_TOKEN` (AEM Demo acct), keep ALL of:

- [ ] **Account → Workers Scripts → Edit**
- [ ] **Account → Workers R2 Storage → Edit** (both `slicc-asset-archive*` buckets)
- [ ] **Zone → Workers Routes → Edit** + **Zone → Zone → Read** for the `sliccy.ai` zone ← the dropped one

Full runbook + incident note added to `packages/cloudflare-worker/CLAUDE.md`.

> Note: releases 5.54.3–5.56.3 won't get GitHub Releases retroactively (semantic-release only publishes the current version); future releases publish normally. Backfill from tags if desired.

## Verification

- `release-native` unit tests: 60 pass (5 new `isRoutesReconcileOnlyFailure` cases + `--classify-deploy-log` parse test); full dev-tools project 308 pass.
- CLI smoke: routes-only log → `routes-only`, upload-failure → `fatal`, missing file → `fatal`.
- `bash -n` clean; biome + knip clean; `parseArgs`/`main` refactored back under the cognitive-complexity gate.