### PR TITLE
fix(release): tolerate the preview worker's routes-only deploy failure too

### DIFF
--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -325,15 +325,23 @@ This lives at the repo root because it coordinates the worker with browser runti
 - **Routes-only failures are non-fatal.** `deploy_with_retry` captures each
   attempt's combined output and, on failure, classifies it with
   `release-native.mjs --classify-deploy-log` (pure `isRoutesReconcileOnlyFailure`,
-  unit-tested). When Wrangler printed `Some triggers failed to deploy … /workers/routes`
-  it had already uploaded AND activated the new version (script + assets are
-  live); only route reconciliation failed (e.g. the token lost Zone → Workers
-  Routes → Edit). Routes are set-once and stable, so this is treated as a
-  successful deploy with a loud warning, and the release continues to the
-  GitHub-release/Chrome/npm publish steps instead of aborting. If a release
-  actually _changed_ routes, the warning flags that they did not apply until the
-  token's routes scope is restored (see the Ops Runbook above). Any other failure
-  (script upload, bindings, asset-too-large) still retries and then fails hard.
+  unit-tested). A failure is treated as a successful deploy (with a loud warning)
+  when BOTH signals are present: the worker version **uploaded**
+  (`Uploaded <name> (<n> sec)` → the new script + assets are live) **and** the
+  routes-API call failed (`A request to the Cloudflare API (…/workers/routes)
+failed` → only route reconciliation failed, e.g. the token lost Zone → Workers
+  Routes → Edit). Requiring the upload line rules out a pre-deploy routes failure
+  (version never went live). Wrangler phrases the routes failure **two ways** — the
+  hub wraps it in `Some triggers failed to deploy`, the **preview worker** surfaces
+  the bare routes-API auth error — so the classifier keys off the upload +
+  routes-API-failure signals rather than the "triggers failed" wrapper (which the
+  preview worker omits; matching only that wrapper regressed the 5.56.4 release —
+  the hub was tolerated but the preview deploy still aborted). Routes are
+  set-once/stable, so the new version is already serving; the release continues to
+  the GitHub-release/Chrome/npm publish steps instead of aborting, and the warning
+  flags that any _changed_ routes did not apply until the token's routes scope is
+  restored (see the Ops Runbook above). Any other failure (script upload, bindings,
+  asset-too-large) still retries and then fails hard.
 - Required repo configuration:
   - secret: `CLOUDFLARE_API_TOKEN`
   - variable: `CLOUDFLARE_ACCOUNT_ID`

--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -132,24 +132,31 @@ export function decideWorkerGating({ lastTag, changedFiles = [] } = {}) {
 }
 
 // Pure classifier (no IO): given the combined stdout+stderr of a `wrangler
-// deploy`, decide whether the ONLY thing that failed was route/trigger
-// reconciliation. Wrangler prints "Some triggers failed to deploy for <worker>"
-// only after it has uploaded AND activated the new version, when it then fails
-// to reconcile the worker's routes (e.g. the deploy token lacks
-// Zone → Workers Routes → Edit). In that case the new script + assets are
-// already live and serving, so the deploy is effectively done and the release
-// should continue. Any other failure (script upload, bindings, asset-too-large)
-// is NOT tolerable and must fail the release.
+// deploy`, decide whether the ONLY thing that failed was route reconciliation
+// (so the new worker version already uploaded AND activated — script + assets
+// are live and serving — and only the routes step failed, e.g. the deploy token
+// lacks Zone → Workers Routes → Edit). Such a failure is tolerable because the
+// routes are set-once/stable and the new version is already serving them; the
+// release should continue. Any other failure (script upload, bindings,
+// asset-too-large) is NOT tolerable and must fail the release.
+//
+// Two signals, BOTH required:
+//   1. the worker version uploaded ("Uploaded <name> (<n> sec)") — proves the
+//      new version is live, which is what makes ignoring the routes step safe;
+//   2. Wrangler's specific route-reconcile error bullet ("A request to the
+//      Cloudflare API (…/workers/routes) failed") — NOT any stray
+//      "workers/routes" mention in the debug log.
+// Requiring the upload line rules out a pre-deploy routes failure (version never
+// went live). Wrangler phrases the routes failure two ways for these workers —
+// the hub wraps it in "Some triggers failed to deploy for <worker>", the preview
+// worker surfaces the bare routes-API auth error — and both carry signals 1+2,
+// so matching on those (rather than the "triggers failed" wrapper) covers both.
 export function isRoutesReconcileOnlyFailure(output) {
   const text = typeof output === 'string' ? output : '';
-  const triggersFailed = /Some triggers failed to deploy/i.test(text);
-  // Match Wrangler's specific route-reconcile error bullet, not any stray
-  // "workers/routes" mention elsewhere in the debug log. (These workers expose
-  // only route triggers; if a Cron/Queue trigger is ever added, tighten this
-  // further to confirm the failing trigger is specifically the route.)
+  const scriptUploaded = /Uploaded [\w.-]+ \([\d.]+ sec\)/i.test(text);
   const routesReconcileFailed =
     /A request to the Cloudflare API \([^)]*workers\/routes\) failed/i.test(text);
-  return triggersFailed && routesReconcileFailed;
+  return scriptUploaded && routesReconcileFailed;
 }
 
 // Value-taking flags → args field. Each supports `--flag=value` and

--- a/packages/dev-tools/tools/release-native.test.mjs
+++ b/packages/dev-tools/tools/release-native.test.mjs
@@ -34,7 +34,8 @@ import {
 } from './release-native.mjs';
 
 describe('isRoutesReconcileOnlyFailure', () => {
-  const routesOnlyLog = [
+  // Hub: Wrangler wraps the routes failure in "Some triggers failed to deploy".
+  const hubRoutesOnly = [
     ' ⛅️ wrangler 4.107.0',
     'Uploaded slicc-tray-hub (3.2 sec)',
     '✘ [ERROR] Some triggers failed to deploy for slicc-tray-hub:',
@@ -42,8 +43,21 @@ describe('isRoutesReconcileOnlyFailure', () => {
     "The current authentication token does not have 'All Zones' permissions.",
   ].join('\n');
 
-  it('detects a routes-reconcile-only failure (script deployed, only triggers failed)', () => {
-    expect(isRoutesReconcileOnlyFailure(routesOnlyLog)).toBe(true);
+  // Preview worker: surfaces the bare routes-API auth error, WITHOUT the
+  // "Some triggers failed to deploy" wrapper (the real prod failure shape that
+  // regressed the 5.56.4 release even after the hub was tolerated).
+  const previewRoutesOnly = [
+    'Uploaded slicc-preview (1.42 sec)',
+    '✘ [ERROR] A request to the Cloudflare API (/zones/46d6506442b8be4e4840520ed22961d3/workers/routes) failed.',
+    '  Authentication error [code: 10000]',
+  ].join('\n');
+
+  it('detects a routes-reconcile-only failure — hub ("triggers failed" wrapper)', () => {
+    expect(isRoutesReconcileOnlyFailure(hubRoutesOnly)).toBe(true);
+  });
+
+  it('detects a routes-reconcile-only failure — preview (bare routes-API auth error)', () => {
+    expect(isRoutesReconcileOnlyFailure(previewRoutesOnly)).toBe(true);
   });
 
   it('does not treat an empty / non-string log as routes-only', () => {
@@ -52,7 +66,7 @@ describe('isRoutesReconcileOnlyFailure', () => {
     expect(isRoutesReconcileOnlyFailure(null)).toBe(false);
   });
 
-  it('does not treat a script-upload failure as routes-only (no "triggers failed")', () => {
+  it('does not treat a script-upload failure as routes-only (no upload line)', () => {
     const uploadFailure = [
       '✘ [ERROR] A request to the Cloudflare API (/accounts/x/workers/scripts/slicc-tray-hub) failed.',
       '  Asset too large: dist/ui/assets/huge.wasm (33 MiB) exceeds the 25 MiB limit',
@@ -60,9 +74,9 @@ describe('isRoutesReconcileOnlyFailure', () => {
     expect(isRoutesReconcileOnlyFailure(uploadFailure)).toBe(false);
   });
 
-  it('does not treat a pre-deploy routes error without "triggers failed" as routes-only', () => {
-    // A bare /workers/routes GET failure before the script deploys is NOT the
-    // tolerable case — the version never went live.
+  it('does not treat a pre-deploy routes error (no upload line) as routes-only', () => {
+    // A /workers/routes failure with no preceding "Uploaded" line means the
+    // version never went live — NOT the tolerable case.
     const preDeploy = 'A request to the Cloudflare API (/zones/x/workers/routes) failed.';
     expect(isRoutesReconcileOnlyFailure(preDeploy)).toBe(false);
   });
@@ -73,11 +87,11 @@ describe('isRoutesReconcileOnlyFailure', () => {
     expect(isRoutesReconcileOnlyFailure(ok)).toBe(false);
   });
 
-  it('does not treat a non-route trigger failure with a stray routes mention as routes-only', () => {
-    // A future Cron/Queue trigger failing alongside a benign /workers/routes
-    // debug line must NOT be mistaken for a routes-only failure: the match
-    // requires Wrangler's actual route-reconcile error bullet, not any mention.
+  it('does not treat an uploaded worker with a stray routes mention (no routes-API failure) as routes-only', () => {
+    // Script uploaded + a benign /workers/routes debug line + an unrelated
+    // (Cron) trigger failure, but NO route-reconcile error bullet → not tolerable.
     const cronFailure = [
+      'Uploaded slicc-tray-hub (2.1 sec)',
       '✘ [ERROR] Some triggers failed to deploy for slicc-tray-hub:',
       '    - Cron trigger "*/5 * * * *" failed to deploy.',
       'GET https://api.cloudflare.com/client/v4/zones/x/workers/routes (debug)',


### PR DESCRIPTION
## Problem

After #1489 merged, the release **still froze** — a `chore(release): 5.56.4` tag was created but no GitHub Release. Root cause: #1489 correctly tolerated the **hub** worker's routes-only failure, but `publish-worker.sh` then deploys the **preview** worker (`wrangler-preview.jsonc`), which prints a **different error shape** for the same token problem:

| | Error output |
|---|---|
| **Hub** | `Uploaded slicc-tray-hub …` + `✘ Some triggers failed to deploy for slicc-tray-hub:` + `A request to the Cloudflare API (…/workers/routes) failed` |
| **Preview** | `Uploaded slicc-preview …` + `✘ A request to the Cloudflare API (…/workers/routes) failed. Authentication error [code: 10000]` — **no "Some triggers failed to deploy" wrapper** |

The classifier required that wrapper, so it rejected the preview error → 6 retries → release aborted before `@semantic-release/github`.

## Fix

Broaden `isRoutesReconcileOnlyFailure` to key off the two signals **both** workers share, instead of the hub-only wrapper:

1. the version **uploaded** — `Uploaded <name> (<n> sec)` (proves the new script + assets are live, which is what makes ignoring the routes step safe), **and**
2. the **routes-API call failed** — `A request to the Cloudflare API (…/workers/routes) failed`.

Requiring the upload line still rejects a *pre-deploy* routes failure (version never went live); requiring the specific routes-API-failure bullet (not a stray `workers/routes` mention) keeps it safe against an unrelated Cron/queue trigger failure (addresses the earlier review concern). **Verified against the real prod hub AND preview output — both now classify `routes-only`.**

## Verification

- `release-native` tests: 62 pass, incl. a new preview-shape regression case + the hub case + the "uploaded + stray routes mention (no routes-API failure) → not tolerable" case; full dev-tools project 310 pass.
- biome clean.

## After this merges

The next release (5.56.5) should deploy both workers (routes tolerated), then continue to publish GitHub Release / Chrome / npm.

**Watch-item (separate, not this PR):** the next step after the worker deploy is the Chrome gate (`--gate=chrome`). It only publishes if extension-relevant files changed; if it *does* run and the Chrome credentials are also stale, that would be the next blocker to diagnose. The real cure for the whole class remains the token fix (#1490).