### PR TITLE
fix(cloud): clear stale OAuth store entries on secrets reload

### DIFF
--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -1279,7 +1279,7 @@ async function main() {
   if (RUNTIME_FLAGS.hosted) {
     registerCloudStatusEndpoint(app, { joinFilePath: '/tmp/slicc-join.json' });
     registerHostedBootstrapEndpoint(app, { secretStore });
-    registerSecretsReloadEndpoint(app, { secretProxy });
+    registerSecretsReloadEndpoint(app, { secretProxy, secretStore, oauthStore });
   }
 
   // Sudo approval endpoint — raises a native OS dialog / TTY prompt from this

--- a/packages/node-server/src/secrets-reload-endpoint.ts
+++ b/packages/node-server/src/secrets-reload-endpoint.ts
@@ -1,12 +1,26 @@
 import type { Express } from 'express';
 import { requireLoopback } from './cloud-status.js';
+import type { EnvSecretStore } from './secrets/env-secret-store.js';
+import type { OauthSecretStore } from './secrets/oauth-secret-store.js';
 
 export interface SecretsReloadDeps {
   secretProxy: { reload(): Promise<void> };
+  secretStore: EnvSecretStore;
+  oauthStore: OauthSecretStore;
 }
 
 export function registerSecretsReloadEndpoint(app: Express, deps: SecretsReloadDeps): void {
   app.post('/api/secrets/reload', requireLoopback, async (_req, res) => {
+    // Clear OAuth store entries whose names also exist in the freshly-read env
+    // file. On resume, cloud-core writes the authoritative token into the env
+    // file — a stale in-memory OAuth entry for the same name must not shadow it.
+    const envNames = new Set(deps.secretStore.list().map((e) => e.name));
+    for (const entry of deps.oauthStore.list()) {
+      if (envNames.has(entry.name)) {
+        deps.oauthStore.delete(entry.name);
+      }
+    }
+
     await deps.secretProxy.reload();
     res.json({ ok: true });
   });

--- a/packages/node-server/tests/secrets-reload-endpoint.test.ts
+++ b/packages/node-server/tests/secrets-reload-endpoint.test.ts
@@ -1,20 +1,59 @@
 import { describe, expect, it, vi } from 'vitest';
+import { OauthSecretStore } from '../src/secrets/oauth-secret-store.js';
 import { registerSecretsReloadEndpoint } from '../src/secrets-reload-endpoint.js';
 
 describe('POST /api/secrets/reload', () => {
   it('registers a loopback route that calls secretProxy.reload() and returns {ok:true}', async () => {
     const reload = vi.fn().mockResolvedValue(undefined);
+    const secretStore = { list: () => [] } as never;
+    const oauthStore = new OauthSecretStore();
     let handler: ((req: unknown, res: { json: (b: unknown) => void }) => Promise<void>) | undefined;
     const app = {
       post: (path: string, _mw: unknown, h: typeof handler) => {
         if (path === '/api/secrets/reload') handler = h;
       },
     };
-    registerSecretsReloadEndpoint(app as never, { secretProxy: { reload } });
+    registerSecretsReloadEndpoint(app as never, {
+      secretProxy: { reload },
+      secretStore,
+      oauthStore,
+    });
     expect(handler).toBeTypeOf('function');
     const json = vi.fn();
     await handler!({}, { json });
     expect(reload).toHaveBeenCalledOnce();
     expect(json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('clears OAuth store entries that collide with env file entries on reload', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const secretStore = {
+      list: () => [
+        { name: 'oauth.github.token', domains: ['github.com'] },
+        { name: 'SOME_OTHER_SECRET', domains: ['example.com'] },
+      ],
+    } as never;
+    const oauthStore = new OauthSecretStore();
+    oauthStore.set('oauth.github.token', 'stale-token', ['github.com']);
+    oauthStore.set('oauth.adobe.token', 'keep-this', ['adobe.com']);
+
+    let handler: ((req: unknown, res: { json: (b: unknown) => void }) => Promise<void>) | undefined;
+    const app = {
+      post: (path: string, _mw: unknown, h: typeof handler) => {
+        if (path === '/api/secrets/reload') handler = h;
+      },
+    };
+    registerSecretsReloadEndpoint(app as never, {
+      secretProxy: { reload },
+      secretStore,
+      oauthStore,
+    });
+
+    const json = vi.fn();
+    await handler!({}, { json });
+
+    expect(oauthStore.get('oauth.github.token')).toBeUndefined();
+    expect(oauthStore.get('oauth.adobe.token')).toBe('keep-this');
+    expect(reload).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
When resuming a cloud cone with a fresh token via coneConfigDelta, the new value lands in /slicc/secrets.env and SecretsPipeline re-reads it, but the in-memory OauthSecretStore still held the stale token from the initial boot. Because OauthSecretStore wins on name collision in listAll(), the fetch proxy kept unmasking to the old value → 401.

Now /api/secrets/reload evicts any OAuth store entry whose name also exists in the freshly-read env file before calling pipeline.reload(), making the env file authoritative after a resume.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] **UI change?** Attach a screencast of what changed (**required** for UI
      changes). Record it with the `demo-recording` skill — a CDP screencast of
      the running harness (`node packages/dev-tools/tools/slicc-screencast.mjs`)
      or a polished cursor-animated MP4. Upload it with `gh image` from
      `ai-ecoverse/ai-aligned-gh` (e.g.
      `gh image --markdown screencast.webm`) and paste the embed here.
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
