### PR TITLE
fix(cherry): normalize theme token keys missing -- prefix

### DIFF
--- a/packages/webapp/src/ui/theme-engine.ts
+++ b/packages/webapp/src/ui/theme-engine.ts
@@ -73,7 +73,8 @@ function isSafeCssValue(value: string): boolean {
 function sanitizeTokens(tokens: Record<string, string>): Record<string, string> {
   const safe: Record<string, string> = {};
   for (const [key, value] of Object.entries(tokens)) {
-    if (isSafeCssValue(value)) safe[key] = value;
+    const normalized = key.startsWith('--') ? key : `--${key}`;
+    if (isSafeCssValue(value)) safe[normalized] = value;
     else log.warn('dropping unsafe theme token value', { key });
   }
   return safe;

--- a/packages/webapp/tests/ui/theme-engine.test.ts
+++ b/packages/webapp/tests/ui/theme-engine.test.ts
@@ -609,4 +609,21 @@ describe('applyCherryTheme', () => {
     const style = document.getElementById('slicc-theme-overrides');
     expect(style!.textContent).not.toContain('evil.example');
   });
+
+  it('normalizes token keys without -- prefix', () => {
+    const theme: SliccTheme = {
+      id: 'unprefixed',
+      name: 'Unprefixed Tokens',
+      base: 'dark',
+      tokens: { bg: '#1C1C1E', surface: '#242426', '--accent': '#EB1000' },
+    };
+    applyCherryTheme(JSON.stringify(theme));
+
+    const style = document.getElementById('slicc-theme-overrides');
+    expect(style!.textContent).toContain('--bg: #1C1C1E');
+    expect(style!.textContent).toContain('--surface: #242426');
+    expect(style!.textContent).toContain('--accent: #EB1000');
+    expect(style!.textContent).not.toContain('  bg:');
+    expect(style!.textContent).not.toContain('  surface:');
+  });
 });


### PR DESCRIPTION
## Summary

- Cherry hosts passing tokens without the CSS custom property `--` prefix (e.g. `{ "bg": "#1C1C1E" }` instead of `{ "--bg": "#1C1C1E" }`) produced invalid CSS declarations that browsers silently ignored, leaving the iframe rendering with default colors.
- Normalizes keys in `sanitizeTokens()` so downstream CSS generation and direct token lookups (shader rule, nav accent) work regardless of whether the host includes the `--` prefix.
- Adds a regression test covering mixed prefixed/unprefixed token keys.

## Test plan

- [x] Existing `applyCherryTheme` tests pass (43/43)
- [x] New test verifies unprefixed keys like `bg`, `surface` are emitted as `--bg`, `--surface`
- [ ] Manual: mount Cherry with `tokens: { "bg": "#1C1C1E", "surface": "#242426" }` and confirm colors apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)