### PR TITLE
fix(adobe): silent token renewal no longer targets localhost in the extension

### DIFF
--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -580,22 +580,32 @@ function buildSilentRenewAuthorize(
   const scopes = resolveScopes(proxyConfig);
   const imsEnv = resolveImsEnvironment(proxyConfig);
 
+  // Mirror onOAuthLogin's redirect/state resolution so silent renewal behaves
+  // identically to interactive login. For a worker-served SPA — hosted-leader,
+  // thin-bridge, AND the EXTENSION leader tab (a `www.sliccy.ai` page where
+  // `isExtensionRealm()` is false, so `isExtension` is false here) —
+  // `buildAdobeOAuthState` returns `source:'opener'` + the same-origin relay.
+  // The old hand-rolled `{ port, path, nonce }` state defaulted `port` to 5710
+  // on a portless hosted origin, so the relay bounced the callback to a
+  // nonexistent `localhost:5710` and the extension's silent renewal dead-ended
+  // there (issue: auto-renew popped a login window against localhost). The
+  // interactive path never hit this because it already used this helper.
+  const stateInfo = !isExtension
+    ? buildAdobeOAuthState(
+        {
+          pageHref: window.location.href,
+          pageOrigin: window.location.origin,
+          configuredRedirectUri: adobeConfig.redirectUri,
+        },
+        () => crypto.randomUUID()
+      )
+    : null;
   const redirectUri = isExtension
     ? (adobeConfig.extensionRedirectUri ??
       `https://${(chrome as { runtime: { id: string } }).runtime.id}.chromiumapp.org/`)
-    : (adobeConfig.redirectUri ?? `${window.location.origin}/auth/callback`);
-
-  // Build OAuth state with port and CSRF nonce for the sliccy.ai relay (CLI only)
-  const oauthState = !isExtension
-    ? btoa(
-        JSON.stringify({
-          port: parseInt(new URL(window.location.href).port || '5710', 10),
-          path: '/auth/callback',
-          nonce: crypto.randomUUID(),
-        })
-      )
-    : undefined;
-  const expectedNonce = oauthState ? JSON.parse(atob(oauthState)).nonce : null;
+    : stateInfo!.redirectUri;
+  const oauthState = stateInfo?.oauthState;
+  const expectedNonce = stateInfo?.expectedNonce ?? null;
 
   const params = new URLSearchParams({
     client_id: clientId,

--- a/packages/webapp/tests/providers/adobe-oauth-state.test.ts
+++ b/packages/webapp/tests/providers/adobe-oauth-state.test.ts
@@ -46,6 +46,27 @@ describe('buildAdobeOAuthState — worker-served (thin-bridge / hosted-leader)',
     expect(result.expectedNonce).toBe('fixed-nonce');
   });
 
+  it('extension leader tab (www.sliccy.ai/?slicc=leader&ext=…): source:"opener", NOT a localhost port', () => {
+    // Regression: silent renewal in the extension leader tab (a www.sliccy.ai
+    // page where isExtensionRealm() is false, so it takes the !isExtension
+    // branch) must resolve to the opener/same-origin relay — NOT the legacy
+    // { port } state that defaulted to localhost:5710 and dead-ended the
+    // auto-renew popup. buildSilentRenewAuthorize now routes through this helper.
+    const result = buildAdobeOAuthState(
+      {
+        pageHref: 'https://www.sliccy.ai/?slicc=leader&ext=akjjllgokmbgpbdbmafpiefnhidlmbgf',
+        pageOrigin: 'https://www.sliccy.ai',
+        configuredRedirectUri: 'https://www.sliccy.ai/auth/callback',
+      },
+      nonce
+    );
+    expect(result.source).toBe('opener');
+    expect(result.redirectUri).toBe('https://www.sliccy.ai/auth/callback');
+    const decoded = JSON.parse(atob(result.oauthState));
+    expect(decoded).not.toHaveProperty('port');
+    expect(decoded).toEqual({ source: 'opener', path: '/auth/callback', nonce: 'fixed-nonce' });
+  });
+
   it('wrangler dev (localhost:8787): source:"local", port 8787, redirect_uri = prod relay (trampoline)', () => {
     const result = buildAdobeOAuthState(
       {


### PR DESCRIPTION
## Symptom

In the **extension**, when the Adobe token expires (e.g. overnight), the auto-renew pops a login window against **localhost** and dead-ends after a few throttled attempts, leaving a chat error card. Clicking **"Login again"** opens the correct dialog and works.

## Root cause

The extension **leader tab** is a hosted `www.sliccy.ai/?slicc=leader` page — **not** a `chrome-extension://` context — so `isExtensionRealm()` is **false** there. Silent renewal therefore took the `!isExtension` branch in `buildSilentRenewAuthorize`, which hand-rolled the legacy OAuth state:

```js
port: parseInt(new URL(window.location.href).port || '5710', 10)  // portless www.sliccy.ai → 5710
```

So the `state` told the sliccy.ai relay to bounce the callback to **`localhost:5710/auth/callback`** — nonexistent in the extension → the popup dead-ends on localhost.

**Why "Login again" worked:** interactive `onOAuthLogin` doesn't hand-roll the state — it uses `buildAdobeOAuthState(...)`, which for a worker-served SPA returns **`source:'opener'` + the same-origin relay** (no localhost port). Silent renewal was the *only* Adobe OAuth path still using the localhost state.

## Fix

Route `buildSilentRenewAuthorize` through the same `buildAdobeOAuthState` helper as `onOAuthLogin` (keeping `prompt:'none'` and the `isExtension` → `launchWebAuthFlow` branch untouched). Now silent renewal resolves to opener/same-origin in the extension leader tab (and hosted-leader / thin-bridge), and to a real localhost only for genuine CLI dev — i.e. it behaves identically to interactive login. Low-risk: it reuses the already-proven, already-tested helper; it just brings the one straggler path in line.

## Test

`adobe.ts` can't be imported in tests (`import.meta.glob` + `chrome` globals), which is exactly why the OAuth-state logic lives in the pure `adobe-oauth-state.ts` (comprehensively tested). Added a regression test there for the **extension leader tab URL** (`www.sliccy.ai/?slicc=leader&ext=…`) asserting `source:'opener'` and **no `port`** in the state. Full run: 58 provider tests pass, browser typecheck 0 errors, biome clean.