### PR TITLE
fix(realm): address playwright-shim review findings

### DIFF
--- a/packages/webapp/src/kernel/realm/playwright-shim.ts
+++ b/packages/webapp/src/kernel/realm/playwright-shim.ts
@@ -112,7 +112,8 @@ export class PlaywrightElementHandle {
 export class PlaywrightPage {
   constructor(
     private readonly rpc: PlaywrightShimRpc,
-    private readonly targetId: string
+    private readonly targetId: string,
+    private readonly onClose?: (targetId: string) => void
   ) {}
 
   async goto(url: string, _options?: { waitUntil?: string; timeout?: number }): Promise<void> {
@@ -125,8 +126,11 @@ export class PlaywrightPage {
 
   /**
    * Mirrors Playwright's `page.evaluate(fn, ...args)`: functions are
-   * serialized to source and invoked as an IIFE with JSON-serialized args
-   * (matching Playwright's own args-must-be-serializable contract); a
+   * serialized to source and invoked as an IIFE, with the whole args array
+   * JSON round-tripped as a single unit (matching Playwright's own
+   * args-must-be-serializable contract) rather than per-argument, so values
+   * that throw on serialization (cycles) fail fast instead of one arg
+   * silently becoming `"undefined"` or `null` while its neighbors don't; a
    * string is passed through verbatim as raw code to eval, same as
    * Playwright's string-expression overload.
    */
@@ -137,7 +141,7 @@ export class PlaywrightPage {
     const code =
       typeof fn === 'string'
         ? fn
-        : `(${fn.toString()})(${args.map((a) => JSON.stringify(a)).join(', ')})`;
+        : `(${fn.toString()}).apply(null, JSON.parse(${JSON.stringify(JSON.stringify(args))}))`;
     return this.rpc.call('browser', 'evalAsync', [this.targetId, code]) as Promise<R>;
   }
 
@@ -191,6 +195,7 @@ export class PlaywrightPage {
 
   async close(): Promise<void> {
     await this.rpc.call('browser', 'closeTab', [this.targetId]);
+    this.onClose?.(this.targetId);
   }
 }
 
@@ -215,7 +220,10 @@ export class PlaywrightBrowser {
         options.viewport.height,
       ]);
     }
-    return new PlaywrightPage(this.rpc, targetId);
+    return new PlaywrightPage(this.rpc, targetId, (closedTargetId) => {
+      const index = this.pageTargetIds.indexOf(closedTargetId);
+      if (index !== -1) this.pageTargetIds.splice(index, 1);
+    });
   }
 
   async close(): Promise<void> {

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -962,6 +962,10 @@ async function dispatchBrowser(
       const targetId = args[0] as string;
       const screenshotOpts = args[1] as { fullPage?: boolean } | undefined;
       return browser.withTab(targetId, async () => {
+        // Mirrors Playwright's own screenshot semantics: a background tab's
+        // renderer is suspended, so `Page.captureScreenshot` can come back
+        // blank until the target is brought to the front (PR #361 precedent).
+        await browser.bringToFront();
         return browser.screenshot(screenshotOpts);
       });
     }
@@ -1206,7 +1210,15 @@ async function waitForLoadState(
   return browser.withTab(targetId, async () => {
     const maxAttempts = 20;
     const pollIntervalMs = 250;
+    // Real Playwright networkidle waits for a quiet period AFTER activity,
+    // never insta-resolving on an empty resource list. Right after a fresh
+    // navigate, `performance.getEntriesByType('resource')` can still be
+    // empty because the renderer hasn't logged the first request yet, so
+    // the loop always waits one poll interval before its first idle check —
+    // giving the renderer a chance to record in-flight requests — rather
+    // than trusting an immediate, possibly-premature empty read.
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
       const idle = await browser.evaluate(
         `(function(){
           try {
@@ -1225,7 +1237,6 @@ async function waitForLoadState(
         { returnByValue: true }
       );
       if (idle) return;
-      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
     }
   });
 }

--- a/packages/webapp/tests/kernel/realm/playwright-host-ops.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-host-ops.test.ts
@@ -94,6 +94,7 @@ interface MockBrowserState {
   attachedTargets: string[];
   viewportCalls: Array<{ method: string; params: Record<string, unknown> }>;
   screenshotOptions: Array<Record<string, unknown> | undefined>;
+  bringToFrontCallCount: number;
   /** Sequence of values returned by successive evaluate() calls (for networkidle polling). */
   evaluateSequence: unknown[];
   evaluateCallCount: number;
@@ -121,6 +122,9 @@ function makeMockBrowser(state: MockBrowserState): BrowserAPI {
       state.screenshotOptions.push(options);
       return 'base64-png-data';
     },
+    async bringToFront(): Promise<void> {
+      state.bringToFrontCallCount++;
+    },
     async evaluate(): Promise<unknown> {
       const idx = state.evaluateCallCount++;
       return state.evaluateSequence[Math.min(idx, state.evaluateSequence.length - 1)];
@@ -144,6 +148,7 @@ function makeBrowserState(overrides: Partial<MockBrowserState> = {}): MockBrowse
     attachedTargets: [],
     viewportCalls: [],
     screenshotOptions: [],
+    bringToFrontCallCount: 0,
     evaluateSequence: [true],
     evaluateCallCount: 0,
     ...overrides,
@@ -212,6 +217,7 @@ describe('realm RPC: browser channel — screenshotTab', () => {
     const png = await client.call<string>('browser', 'screenshotTab', ['t-1']);
     expect(png).toBe('base64-png-data');
     expect(state.attachedTargets).toContain('t-1');
+    expect(state.bringToFrontCallCount).toBe(1);
     dispose();
   });
 
@@ -263,6 +269,21 @@ describe('realm RPC: browser channel — waitForLoadState', () => {
     const { client, dispose } = setup(state);
     await client.call('browser', 'waitForLoadState', ['t-1', 'networkidle']);
     expect(state.evaluateCallCount).toBeGreaterThanOrEqual(1);
+    dispose();
+  });
+
+  it('waits at least one poll interval before trusting an idle read', async () => {
+    // Regression: right after navigate, `performance.getEntriesByType('resource')`
+    // can still be empty because the renderer hasn't logged the first request
+    // yet — the old implementation checked BEFORE waiting, so it could return
+    // "idle" on attempt 0 before the page had actually started loading.
+    const state = makeBrowserState({ evaluateSequence: [true] });
+    const { client, dispose } = setup(state);
+    const start = Date.now();
+    await client.call('browser', 'waitForLoadState', ['t-1', 'networkidle']);
+    const elapsed = Date.now() - start;
+    expect(state.evaluateCallCount).toBe(1);
+    expect(elapsed).toBeGreaterThanOrEqual(240);
     dispose();
   });
 });

--- a/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
@@ -112,6 +112,36 @@ describe('createPlaywrightShim: browser.newPage / browser.close', () => {
     const closeCallsAfter = rpc.calls.filter((c) => c.op === 'closeTab').length;
     expect(closeCallsAfter).toBe(closeCallsBefore);
   });
+
+  it('browser.close() does not re-close a page already closed individually', async () => {
+    // Mirrors real Chrome: `Target.closeTarget` on an already-closed target
+    // rejects. If `browser.close()` still re-issued `closeTab` for a page
+    // that called `page.close()` itself, this mock would reject too.
+    const closedTargets = new Set<string>();
+    let n = 0;
+    const rpc = mockRpc();
+    rpc.call.mockImplementation(async (channel: string, op: string, args: unknown[] = []) => {
+      rpc.calls.push({ channel, op, args });
+      if (op === 'createTab') return `target-${++n}`;
+      if (op === 'closeTab') {
+        const targetId = args[0] as string;
+        if (closedTargets.has(targetId)) {
+          throw new Error(`No target with given id found: ${targetId}`);
+        }
+        closedTargets.add(targetId);
+        return undefined;
+      }
+      return undefined;
+    });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const page1 = await browser.newPage();
+    await browser.newPage();
+    await page1.close();
+    await expect(browser.close()).resolves.toBeUndefined();
+    const closeCalls = rpc.calls.filter((c) => c.op === 'closeTab').map((c) => c.args[0]);
+    expect(closeCalls).toEqual(['target-1', 'target-2']);
+  });
 });
 
 describe('createPlaywrightShim: page navigation + lifecycle', () => {
@@ -183,7 +213,10 @@ describe('createPlaywrightShim: page.evaluate', () => {
     expect(call!.args[0]).toBe('target-abc');
     expect(typeof call!.args[1]).toBe('string');
     expect(call!.args[1] as string).toContain('document.title');
-    expect(call!.args[1] as string).toContain('"!"');
+    expect(call!.args[1] as string).toContain('.apply(null, JSON.parse(');
+    const document = { title: 'The Title' };
+    // biome-ignore lint/security/noGlobalEval: verifying the generated code actually round-trips args correctly
+    expect(eval(call!.args[1] as string)).toBe('The Title!');
   });
 
   it('passes a raw string straight through as the eval code', async () => {


### PR DESCRIPTION
- page.close() unregisters its targetId from the parent browser so browser.close() doesn't re-issue closeTab on an already-closed page (rejects against real Chrome).
- page.evaluate(fn, ...args) JSON-round-trips the whole args array once instead of per-arg, so undefined/NaN/Infinity/Date don't silently corrupt into the wrong value.
- screenshotTab calls bringToFront() first so a background tab's suspended renderer doesn't produce a blank capture (PR #361 precedent).
- waitForLoadState('networkidle') waits one poll interval before its first idle check so it can't insta-resolve off an empty resource buffer right after navigate.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] **UI change?** Attach a screencast of what changed (**required** for UI
      changes). Record it with the `demo-recording` skill — a CDP screencast of
      the running harness (`node packages/dev-tools/tools/slicc-screencast.mjs`)
      or a polished cursor-animated MP4. Upload it with `gh image` from
      `ai-ecoverse/ai-aligned-gh` (e.g.
      `gh image --markdown screencast.webm`) and paste the embed here.
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
