### PR TITLE
feat(realm): add newContext, connectOverCDP/connect, waitForTimeout, $$eval to playwright shim

### DIFF
--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -191,6 +191,8 @@ API backed by SLICC's CDP connection to the running Chrome instance.
 - `browser.newContext(options?)` — returns a `BrowserContext` that groups its
   own pages for `close()`/`pages()` bookkeeping. **No cookie/storage isolation**
   — every context and the top-level browser share the one real Chrome profile.
+  `options` (including `viewport`) are accepted but not applied — pass
+  `viewport` to `context.newPage()` instead, same as on `browser.newPage()`.
 - `browser.contexts()`, `context.newPage()`, `context.pages()`, `context.close()`
 - `browser.close()` — closes all tabs opened by the instance, including every
   context's tabs

--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -184,19 +184,29 @@ API backed by SLICC's CDP connection to the running Chrome instance.
 **Supported surface:**
 
 - `chromium.launch()` — returns a Browser (no-op; Chrome is already running)
+- `chromium.connectOverCDP(endpoint)`, `<launcher>.connect(wsEndpoint)` — also
+  no-ops that return a Browser; the endpoint argument is accepted but ignored
+  (the realm is always already attached to SLICC's one real Chrome)
 - `browser.newPage({ viewport? })` — opens a real new tab, sets viewport
-- `browser.close()` — closes all tabs opened by the instance
-- `page.goto(url)`, `page.waitForLoadState(state?)`
+- `browser.newContext(options?)` — returns a `BrowserContext` that groups its
+  own pages for `close()`/`pages()` bookkeeping. **No cookie/storage isolation**
+  — every context and the top-level browser share the one real Chrome profile.
+- `browser.contexts()`, `context.newPage()`, `context.pages()`, `context.close()`
+- `browser.close()` — closes all tabs opened by the instance, including every
+  context's tabs
+- `page.goto(url)`, `page.waitForLoadState(state?)`, `page.waitForTimeout(ms)`
 - `page.evaluate(fn, ...args)` — runs JS in page context
 - `page.screenshot({ path?, fullPage? })` — returns Uint8Array (PNG)
 - `page.$(selector)`, `page.$$(selector)` — query selectors → ElementHandle
+- `page.$$eval(selector, fn, ...args)` — runs `fn` over every matched element
 - `page.content()` — returns page HTML
 - `page.setViewportSize({ width, height })`
 - `page.close()`
 - `elementHandle.textContent()`, `.getAttribute(name)`, `.isVisible()`, `.boundingBox()`
 
-**Not supported:** BrowserContext, request interception, locators, tracing,
-video, firefox/webkit engines (all three launchers use the same Chrome).
+**Not supported:** request interception, locators, tracing, video, distinct
+firefox/webkit engines (all three launchers use the same Chrome), real
+per-context cookie/storage isolation for `BrowserContext`.
 
 Scripts should use this shim (via normal `import('playwright')`) rather than
 `npx playwright` or the Playwright MCP server when running inside the realm.

--- a/docs/superpowers/plans/2026-07-14-playwright-shim-features.md
+++ b/docs/superpowers/plans/2026-07-14-playwright-shim-features.md
@@ -1,0 +1,979 @@
+# Playwright Realm Shim Feature Additions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `page.waitForTimeout`, `page.$$eval`, `browser.newContext`, and `chromium.connectOverCDP`/`<launcher>.connect` to the Playwright realm shim (`packages/webapp/src/kernel/realm/playwright-shim.ts`) so scripts that use these four Playwright APIs stop throwing `TypeError`/`undefined` when run against SLICC's shim.
+
+**Architecture:** All four additions are thin client-side wrappers over the shim's existing `rpc.call('browser', op, args)` pattern (or, for `waitForTimeout`, no RPC at all). No changes to `realm-host.ts` or any other host-side file are required — every op already exists (`evalAsync`) or isn't needed (real `setTimeout` is already available in the realm).
+
+**Tech Stack:** TypeScript, Vitest (unit + integration tests, mocked `PlaywrightShimRpc`).
+
+## Global Constraints
+
+- `browser.newContext()` provides grouping only — no cookie/storage isolation between contexts (single real Chrome profile). This must be stated in a doc comment on `PlaywrightBrowserContext` and in `docs/node-compat-shims.md`.
+- `connectOverCDP`/`connect` accept an endpoint argument but ignore it — always return a `PlaywrightBrowser` wrapping the existing `rpc`, identical to `launch()`.
+- `connectOverCDP` is added only to `chromium`. `connect` is added to `chromium`, `firefox`, and `webkit`.
+- No new `realm-host.ts` op is added for `$$eval` or `waitForTimeout` — reuse the existing `evalAsync` op / native realm timers.
+- Follow the existing arg-serialization convention exactly: function bodies via `fn.toString()`, each arg individually `JSON.stringify`'d into the generated code string.
+
+---
+
+### Task 1: `page.waitForTimeout(ms)`
+
+**Files:**
+
+- Modify: `packages/webapp/src/kernel/realm/playwright-shim.ts:122-124`
+- Test: `packages/webapp/tests/kernel/realm/playwright-shim.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing new — pure client-side delay.
+- Produces: `PlaywrightPage.waitForTimeout(ms: number): Promise<void>`, used by Task 5's integration test.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/webapp/tests/kernel/realm/playwright-shim.test.ts`, right after the `createPlaywrightShim: page navigation + lifecycle` describe block (after line 168, before the `createPlaywrightShim: page.evaluate` describe block on line 170):
+
+```ts
+describe('createPlaywrightShim: page.waitForTimeout', () => {
+  it('resolves after the given delay without making any rpc calls', async () => {
+    vi.useFakeTimers();
+    try {
+      const rpc = mockRpc();
+      const { chromium } = createPlaywrightShim(rpc);
+      const browser = await chromium.launch();
+      const page = await browser.newPage();
+      rpc.calls.length = 0;
+
+      let resolved = false;
+      const promise = page.waitForTimeout(500).then(() => {
+        resolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(499);
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await promise;
+      expect(resolved).toBe(true);
+      expect(rpc.calls).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts -t "waitForTimeout"`
+Expected: FAIL with `page.waitForTimeout is not a function`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/webapp/src/kernel/realm/playwright-shim.ts`, the `PlaywrightPage` class currently has this at lines 122-124:
+
+```ts
+  async waitForLoadState(state?: 'load' | 'domcontentloaded' | 'networkidle'): Promise<void> {
+    await this.rpc.call('browser', 'waitForLoadState', [this.targetId, state ?? 'load']);
+  }
+```
+
+Add a new method directly after it (still inside `PlaywrightPage`):
+
+```ts
+  async waitForLoadState(state?: 'load' | 'domcontentloaded' | 'networkidle'): Promise<void> {
+    await this.rpc.call('browser', 'waitForLoadState', [this.targetId, state ?? 'load']);
+  }
+
+  /** Pure client-side delay — the realm already has real wall-clock timers, so no host RPC is needed. */
+  async waitForTimeout(ms: number): Promise<void> {
+    await new Promise<void>((resolve) => setTimeout(resolve, ms));
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts -t "waitForTimeout"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/webapp/src/kernel/realm/playwright-shim.ts packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+git commit -m "feat(realm): add page.waitForTimeout to playwright shim"
+```
+
+---
+
+### Task 2: `page.$$eval(selector, fn, ...args)`
+
+**Files:**
+
+- Modify: `packages/webapp/src/kernel/realm/playwright-shim.ts:169-179` (insert after `$$`)
+- Test: `packages/webapp/tests/kernel/realm/playwright-shim.test.ts`
+
+**Interfaces:**
+
+- Consumes: the shim's existing `evalAsync` host op (`rpc.call('browser', 'evalAsync', [targetId, code])`), same as `evaluate`/`$`/`$$`.
+- Produces: `PlaywrightPage.$$eval<R = unknown>(selector: string, fn: ((elements: Element[], ...args: unknown[]) => R | Promise<R>) | string, ...args: unknown[]): Promise<R>`, used by Task 5's integration test.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/webapp/tests/kernel/realm/playwright-shim.test.ts`, right after the `createPlaywrightShim: page.$ / page.$$` describe block (after line 297, before the `createPlaywrightShim: ElementHandle` describe block on line 299):
+
+```ts
+describe('createPlaywrightShim: page.$$eval', () => {
+  it('serializes a function + args into an Array.from(querySelectorAll(...)) IIFE call', async () => {
+    const rpc = mockRpc({ evalAsync: 3 });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+
+    const result = await page.$$eval(
+      'li',
+      (elements: Element[], suffix: string) => elements.length + suffix.length,
+      '!!'
+    );
+
+    expect(result).toBe(3);
+    const call = rpc.calls.find((c) => c.op === 'evalAsync');
+    expect(call).toBeDefined();
+    expect(call!.args[0]).toBe('target-abc');
+    const code = call!.args[1] as string;
+    expect(code).toContain('document.querySelectorAll("li")');
+    expect(code).toContain('Array.from');
+    expect(code).toContain('"!!"');
+  });
+
+  it('omits the trailing comma when no extra args are passed', async () => {
+    const rpc = mockRpc({ evalAsync: 0 });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+
+    await page.$$eval('li', (elements: Element[]) => elements.length);
+
+    const call = rpc.calls.find((c) => c.op === 'evalAsync');
+    const code = call!.args[1] as string;
+    expect(code.trim().endsWith('))')).toBe(true);
+  });
+
+  it('passes a raw string straight through as the eval code', async () => {
+    const rpc = mockRpc({ evalAsync: 5 });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+
+    const result = await page.$$eval('li', 'document.querySelectorAll("li").length');
+
+    expect(result).toBe(5);
+    expect(rpc.call).toHaveBeenCalledWith('browser', 'evalAsync', [
+      'target-abc',
+      'document.querySelectorAll("li").length',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts -t "\\$\\$eval"`
+Expected: FAIL with `page.$$eval is not a function`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/webapp/src/kernel/realm/playwright-shim.ts`, the `PlaywrightPage` class currently has this at lines 168-179:
+
+```ts
+  // biome-ignore lint/style/useNamingConvention: `$`/`$$` mirror Playwright's real API names exactly, so fixture scripts can call `page.$$(...)` unmodified.
+  async $$(selector: string): Promise<PlaywrightElementHandle[]> {
+    const count = (await this.rpc.call('browser', 'evalAsync', [
+      this.targetId,
+      `document.querySelectorAll(${JSON.stringify(selector)}).length`,
+    ])) as number;
+    const handles: PlaywrightElementHandle[] = [];
+    for (let i = 0; i < count; i++) {
+      handles.push(new PlaywrightElementHandle(this.rpc, this.targetId, selector, i));
+    }
+    return handles;
+  }
+```
+
+Add a new method directly after it (still inside `PlaywrightPage`, before `content()`):
+
+```ts
+  // biome-ignore lint/style/useNamingConvention: `$$eval` mirrors Playwright's real API name exactly, so fixture scripts can call `page.$$eval(...)` unmodified.
+  async $$eval<R = unknown>(
+    selector: string,
+    fn: ((elements: Element[], ...args: unknown[]) => R | Promise<R>) | string,
+    ...args: unknown[]
+  ): Promise<R> {
+    if (typeof fn === 'string') {
+      return this.rpc.call('browser', 'evalAsync', [this.targetId, fn]) as Promise<R>;
+    }
+    const serializedArgs = args.map((a) => JSON.stringify(a)).join(', ');
+    const callArgs = serializedArgs
+      ? `Array.from(document.querySelectorAll(${JSON.stringify(selector)})), ${serializedArgs}`
+      : `Array.from(document.querySelectorAll(${JSON.stringify(selector)}))`;
+    const code = `(${fn.toString()})(${callArgs})`;
+    return this.rpc.call('browser', 'evalAsync', [this.targetId, code]) as Promise<R>;
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts -t "\\$\\$eval"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/webapp/src/kernel/realm/playwright-shim.ts packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+git commit -m "feat(realm): add page.\$\$eval to playwright shim"
+```
+
+---
+
+### Task 3: `browser.newContext()` / `PlaywrightBrowserContext`
+
+**Files:**
+
+- Modify: `packages/webapp/src/kernel/realm/playwright-shim.ts:196-227` (insert `PlaywrightBrowserContext` class before `PlaywrightBrowser`; modify `PlaywrightBrowser`)
+- Test: `packages/webapp/tests/kernel/realm/playwright-shim.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PlaywrightPage` (Task 3 wraps pages the same way `PlaywrightBrowser.newPage` does today), the existing `createTab`/`setViewport`/`closeTab` ops.
+- Produces:
+  - `class PlaywrightBrowserContext { newPage(options?: PlaywrightNewPageOptions): Promise<PlaywrightPage>; pages(): PlaywrightPage[]; close(): Promise<void>; }`
+  - `PlaywrightBrowser.newContext(options?: PlaywrightNewContextOptions): Promise<PlaywrightBrowserContext>`
+  - `PlaywrightBrowser.contexts(): PlaywrightBrowserContext[]`
+  - `PlaywrightBrowser.close()` now also closes every tracked context's pages.
+  - Used by Task 5's integration test.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/webapp/tests/kernel/realm/playwright-shim.test.ts`, right after the `createPlaywrightShim: page navigation + lifecycle` describe block content but this time as its own top-level describe placed after the `createPlaywrightShim: browser.newPage / browser.close` describe block (after line 115, before `createPlaywrightShim: page navigation + lifecycle` on line 117):
+
+```ts
+describe('createPlaywrightShim: browser.newContext', () => {
+  it('newContext().newPage() opens a real tab', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    expect(page).toBeDefined();
+    expect(rpc.call).toHaveBeenCalledWith('browser', 'createTab', ['about:blank']);
+  });
+
+  it('context.pages() returns every page opened through that context', async () => {
+    let n = 0;
+    const rpc = mockRpc();
+    rpc.call.mockImplementation(async (channel: string, op: string, args: unknown[] = []) => {
+      rpc.calls.push({ channel, op, args });
+      if (op === 'createTab') return `ctx-target-${++n}`;
+      return undefined;
+    });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    await context.newPage();
+    await context.newPage();
+    expect(context.pages()).toHaveLength(2);
+  });
+
+  it("context.close() closes only that context's tabs, leaving the browser's own pages open", async () => {
+    let n = 0;
+    const rpc = mockRpc();
+    rpc.call.mockImplementation(async (channel: string, op: string, args: unknown[] = []) => {
+      rpc.calls.push({ channel, op, args });
+      if (op === 'createTab') return `target-${++n}`;
+      return undefined;
+    });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    await browser.newPage(); // target-1, owned directly by the browser
+    const context = await browser.newContext();
+    await context.newPage(); // target-2, owned by the context
+
+    await context.close();
+
+    expect(rpc.call).toHaveBeenCalledWith('browser', 'closeTab', ['target-2']);
+    expect(rpc.call).not.toHaveBeenCalledWith('browser', 'closeTab', ['target-1']);
+    expect(context.pages()).toHaveLength(0);
+  });
+
+  it("browser.close() also tears down every context's tabs", async () => {
+    let n = 0;
+    const rpc = mockRpc();
+    rpc.call.mockImplementation(async (channel: string, op: string, args: unknown[] = []) => {
+      rpc.calls.push({ channel, op, args });
+      if (op === 'createTab') return `target-${++n}`;
+      return undefined;
+    });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    await context.newPage(); // target-1
+
+    await browser.close();
+
+    expect(rpc.call).toHaveBeenCalledWith('browser', 'closeTab', ['target-1']);
+  });
+
+  it('browser.contexts() returns every context created via newContext()', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const c1 = await browser.newContext();
+    const c2 = await browser.newContext();
+    expect(browser.contexts()).toEqual([c1, c2]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts -t "newContext"`
+Expected: FAIL with `browser.newContext is not a function`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/webapp/src/kernel/realm/playwright-shim.ts`, add a new options interface next to `PlaywrightNewPageOptions` (currently lines 40-43):
+
+```ts
+export interface PlaywrightNewPageOptions {
+  viewport?: ViewportSize;
+  [key: string]: unknown;
+}
+
+export interface PlaywrightNewContextOptions {
+  viewport?: ViewportSize;
+  [key: string]: unknown;
+}
+```
+
+Currently, lines 196-227 read:
+
+```ts
+/**
+ * Wraps a "browser" — in reality just a bookkeeping set of tabs opened
+ * through this launch() call, so `close()` knows which real tabs to tear
+ * down. There's no separate browser process to spawn or attach to; the
+ * host already owns the one real Chrome instance.
+ */
+export class PlaywrightBrowser {
+  private readonly pageTargetIds: string[] = [];
+
+  constructor(private readonly rpc: PlaywrightShimRpc) {}
+
+  async newPage(options?: PlaywrightNewPageOptions): Promise<PlaywrightPage> {
+    const targetId = (await this.rpc.call('browser', 'createTab', ['about:blank'])) as string;
+    this.pageTargetIds.push(targetId);
+    if (options?.viewport) {
+      await this.rpc.call('browser', 'setViewport', [
+        targetId,
+        options.viewport.width,
+        options.viewport.height,
+      ]);
+    }
+    return new PlaywrightPage(this.rpc, targetId);
+  }
+
+  async close(): Promise<void> {
+    const targetIds = this.pageTargetIds.splice(0, this.pageTargetIds.length);
+    for (const targetId of targetIds) {
+      await this.rpc.call('browser', 'closeTab', [targetId]);
+    }
+  }
+}
+```
+
+Replace that whole block with:
+
+```ts
+/**
+ * Wraps Playwright's `BrowserContext` shape, but grouping-only: it tracks
+ * its own pages so `close()`/`pages()` bookkeeping is scoped to just this
+ * context. SLICC has exactly one real Chrome profile — there is NO cookie
+ * jar / storage isolation between contexts (see docs/node-compat-shims.md).
+ * Scripts that rely on real per-context isolation will not get it here.
+ */
+export class PlaywrightBrowserContext {
+  private readonly openPages: PlaywrightPage[] = [];
+
+  constructor(private readonly rpc: PlaywrightShimRpc) {}
+
+  async newPage(options?: PlaywrightNewPageOptions): Promise<PlaywrightPage> {
+    const targetId = (await this.rpc.call('browser', 'createTab', ['about:blank'])) as string;
+    if (options?.viewport) {
+      await this.rpc.call('browser', 'setViewport', [
+        targetId,
+        options.viewport.width,
+        options.viewport.height,
+      ]);
+    }
+    const page = new PlaywrightPage(this.rpc, targetId);
+    this.openPages.push(page);
+    return page;
+  }
+
+  pages(): PlaywrightPage[] {
+    return [...this.openPages];
+  }
+
+  async close(): Promise<void> {
+    const pages = this.openPages.splice(0, this.openPages.length);
+    for (const page of pages) {
+      await page.close();
+    }
+  }
+}
+
+/**
+ * Wraps a "browser" — in reality just a bookkeeping set of tabs (and
+ * contexts, which are themselves just bookkeeping sets of tabs) opened
+ * through this launch() call, so `close()` knows which real tabs to tear
+ * down. There's no separate browser process to spawn or attach to; the
+ * host already owns the one real Chrome instance.
+ */
+export class PlaywrightBrowser {
+  private readonly pageTargetIds: string[] = [];
+  private readonly openContexts: PlaywrightBrowserContext[] = [];
+
+  constructor(private readonly rpc: PlaywrightShimRpc) {}
+
+  async newPage(options?: PlaywrightNewPageOptions): Promise<PlaywrightPage> {
+    const targetId = (await this.rpc.call('browser', 'createTab', ['about:blank'])) as string;
+    this.pageTargetIds.push(targetId);
+    if (options?.viewport) {
+      await this.rpc.call('browser', 'setViewport', [
+        targetId,
+        options.viewport.width,
+        options.viewport.height,
+      ]);
+    }
+    return new PlaywrightPage(this.rpc, targetId);
+  }
+
+  async newContext(_options?: PlaywrightNewContextOptions): Promise<PlaywrightBrowserContext> {
+    const context = new PlaywrightBrowserContext(this.rpc);
+    this.openContexts.push(context);
+    return context;
+  }
+
+  contexts(): PlaywrightBrowserContext[] {
+    return [...this.openContexts];
+  }
+
+  async close(): Promise<void> {
+    const targetIds = this.pageTargetIds.splice(0, this.pageTargetIds.length);
+    for (const targetId of targetIds) {
+      await this.rpc.call('browser', 'closeTab', [targetId]);
+    }
+    const contexts = this.openContexts.splice(0, this.openContexts.length);
+    for (const context of contexts) {
+      await context.close();
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts -t "newContext"`
+Expected: PASS
+
+Also re-run the full unit test file to confirm no regressions from the `PlaywrightBrowser` edit:
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts`
+Expected: PASS (all tests, including the pre-existing `browser.newPage / browser.close` describe block)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/webapp/src/kernel/realm/playwright-shim.ts packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+git commit -m "feat(realm): add browser.newContext (grouping-only) to playwright shim"
+```
+
+---
+
+### Task 4: `chromium.connectOverCDP` / `<launcher>.connect`
+
+**Files:**
+
+- Modify: `packages/webapp/src/kernel/realm/playwright-shim.ts:229-251`
+- Test: `packages/webapp/tests/kernel/realm/playwright-shim.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PlaywrightBrowser` (Task 3/existing), nothing new.
+- Produces:
+  - `PlaywrightShim.chromium.connect(wsEndpoint: string, options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>`
+  - `PlaywrightShim.chromium.connectOverCDP(endpoint: string, options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>`
+  - `PlaywrightShim.firefox.connect(...)`, `PlaywrightShim.webkit.connect(...)` (same signature as chromium's `connect`)
+  - Used by Task 5's integration test.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/webapp/tests/kernel/realm/playwright-shim.test.ts`, at the very end of the file (after the closing of the `createPlaywrightShim: ElementHandle` describe block, i.e. after the current last line 379):
+
+```ts
+describe('createPlaywrightShim: connectOverCDP / connect', () => {
+  it('chromium.connectOverCDP() returns a working Browser regardless of the endpoint value', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.connectOverCDP('http://localhost:9222');
+    expect(typeof browser.newPage).toBe('function');
+    const page = await browser.newPage();
+    expect(page).toBeDefined();
+  });
+
+  it('chromium.connect() / firefox.connect() / webkit.connect() all return working Browsers', async () => {
+    const rpc = mockRpc();
+    const { chromium, firefox, webkit } = createPlaywrightShim(rpc);
+    const b1 = await chromium.connect('ws://localhost:1234/devtools/browser/abc');
+    const b2 = await firefox.connect('ws://localhost:1234/devtools/browser/abc');
+    const b3 = await webkit.connect('ws://localhost:1234/devtools/browser/abc');
+    expect(typeof b1.newPage).toBe('function');
+    expect(typeof b2.newPage).toBe('function');
+    expect(typeof b3.newPage).toBe('function');
+  });
+
+  it('connectOverCDP/connect are no-ops that make no rpc calls themselves', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    await chromium.connectOverCDP('http://localhost:9222');
+    expect(rpc.call).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts -t "connectOverCDP"`
+Expected: FAIL with `chromium.connectOverCDP is not a function`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/webapp/src/kernel/realm/playwright-shim.ts`, lines 229-251 currently read:
+
+```ts
+export interface PlaywrightShim {
+  chromium: { launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser> };
+  firefox: { launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser> };
+  webkit: { launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser> };
+}
+
+/**
+ * Builds the `{ chromium, firefox, webkit }` module shape realm scripts get
+ * back from `require('playwright')` / `import('playwright')`. `launch()` is
+ * a no-op spawn — SLICC's Chrome is already running — it just hands back a
+ * fresh `PlaywrightBrowser` bookkeeping wrapper over `rpc`. All three
+ * launchers are identical (see module doc comment).
+ */
+export function createPlaywrightShim(rpc: PlaywrightShimRpc): PlaywrightShim {
+  const launch = async (_options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser> => {
+    return new PlaywrightBrowser(rpc);
+  };
+  return {
+    chromium: { launch },
+    firefox: { launch },
+    webkit: { launch },
+  };
+}
+```
+
+Replace that whole block with:
+
+```ts
+export interface PlaywrightShim {
+  chromium: {
+    launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+    connect(wsEndpoint: string, options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+    connectOverCDP(endpoint: string, options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+  };
+  firefox: {
+    launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+    connect(wsEndpoint: string, options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+  };
+  webkit: {
+    launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+    connect(wsEndpoint: string, options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+  };
+}
+
+/**
+ * Builds the `{ chromium, firefox, webkit }` module shape realm scripts get
+ * back from `require('playwright')` / `import('playwright')`. `launch()` is
+ * a no-op spawn — SLICC's Chrome is already running — it just hands back a
+ * fresh `PlaywrightBrowser` bookkeeping wrapper over `rpc`. All three
+ * launchers are identical (see module doc comment).
+ *
+ * `connect`/`connectOverCDP` accept an endpoint argument for API-shape
+ * compatibility with real Playwright call sites, but ignore it: the realm
+ * is always already attached to SLICC's one real Chrome instance, so there
+ * is nothing else to dial. Both behave identically to `launch()`.
+ */
+export function createPlaywrightShim(rpc: PlaywrightShimRpc): PlaywrightShim {
+  const launch = async (_options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser> => {
+    return new PlaywrightBrowser(rpc);
+  };
+  const connect = async (
+    _endpoint: string,
+    _options?: PlaywrightLaunchOptions
+  ): Promise<PlaywrightBrowser> => {
+    return new PlaywrightBrowser(rpc);
+  };
+  return {
+    chromium: { launch, connect, connectOverCDP: connect },
+    firefox: { launch, connect },
+    webkit: { launch, connect },
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts -t "connectOverCDP"`
+Expected: PASS
+
+Also re-run the full unit test file:
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/webapp/src/kernel/realm/playwright-shim.ts packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+git commit -m "feat(realm): add connectOverCDP/connect to playwright shim"
+```
+
+---
+
+### Task 5: Integration tests for all four additions
+
+**Files:**
+
+- Modify: `packages/webapp/tests/kernel/realm/playwright-shim-integration.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PlaywrightPage.waitForTimeout`, `PlaywrightPage.$$eval`, `PlaywrightBrowser.newContext`/`.contexts()`, `PlaywrightBrowserContext.newPage`/`.pages()`/`.close()`, `chromium.connectOverCDP`, `<launcher>.connect` — all from Tasks 1-4.
+- Produces: nothing new; this task only adds test coverage.
+
+- [ ] **Step 1: Write the failing tests**
+
+The shared `createIntegrationMockRpc()` helper's `evalAsync` branch (lines 62-110 of `packages/webapp/tests/kernel/realm/playwright-shim-integration.test.ts`) currently reads:
+
+```ts
+      if (op === 'evalAsync') {
+        // evalAsync([targetId, code])
+        const code = args[1] as string;
+
+        // Check what the code is trying to do
+        if (code.includes('document.documentElement.outerHTML')) {
+          // page.content()
+          return '<html><body><button class="nav-btn">Menu</button></body></html>';
+        }
+
+        if (code.includes('!!document.querySelector')) {
+          // page.$ check for existence
+          if (code.includes('.nav-btn')) return true;
+          return false;
+        }
+
+        if (code.includes('document.querySelectorAll')) {
+          // Count for page.$$
+          if (code.includes('.length')) {
+            if (code.includes('.nav-btn')) return 1;
+            if (code.includes('li')) return 3;
+            return 0;
+          }
+        }
+```
+
+Insert a new branch for `$$eval`-shaped code **before** the generic `document.querySelectorAll` branch above (since `$$eval`'s generated code also contains both `document.querySelectorAll` and, incidentally, `.length` inside the user function body — it must be matched first via its distinguishing `Array.from(document.querySelectorAll` shape):
+
+```ts
+      if (op === 'evalAsync') {
+        // evalAsync([targetId, code])
+        const code = args[1] as string;
+
+        // Check what the code is trying to do
+        if (code.includes('document.documentElement.outerHTML')) {
+          // page.content()
+          return '<html><body><button class="nav-btn">Menu</button></body></html>';
+        }
+
+        if (code.includes('Array.from(document.querySelectorAll')) {
+          // page.$$eval() — simulate counting the matched elements
+          if (code.includes('"li"')) return 3;
+          return 0;
+        }
+
+        if (code.includes('!!document.querySelector')) {
+          // page.$ check for existence
+          if (code.includes('.nav-btn')) return true;
+          return false;
+        }
+
+        if (code.includes('document.querySelectorAll')) {
+          // Count for page.$$
+          if (code.includes('.length')) {
+            if (code.includes('.nav-btn')) return 1;
+            if (code.includes('li')) return 3;
+            return 0;
+          }
+        }
+```
+
+Then append four new `it` blocks inside the `describe('playwright shim integration', ...)` block, after the last existing test (`'maintains element handle isolation across queries'`, currently ending at line 383, just before the describe block's closing `});` at line 384):
+
+```ts
+it('waits for a fixed timeout without making any rpc calls', async () => {
+  vi.useFakeTimers();
+  try {
+    const rpc = createIntegrationMockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+    await page.goto('https://example.com');
+
+    rpc.call.mockClear();
+    let resolved = false;
+    const promise = page.waitForTimeout(200).then(() => {
+      resolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(200);
+    await promise;
+
+    expect(resolved).toBe(true);
+    expect(rpc.call).not.toHaveBeenCalled();
+
+    await browser.close();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+it('evaluates a reducer function over every matched element via $$eval', async () => {
+  const rpc = createIntegrationMockRpc();
+  const { chromium } = createPlaywrightShim(rpc);
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('https://example.com');
+
+  const count = await page.$$eval('li', (elements) => elements.length);
+  expect(count).toBe(3);
+
+  await browser.close();
+});
+
+it("isolates tabs opened through a context from the browser's own tabs", async () => {
+  const rpc = createIntegrationMockRpc();
+  const { chromium } = createPlaywrightShim(rpc);
+
+  const browser = await chromium.launch();
+  const directPage = await browser.newPage();
+  await directPage.goto('https://example.com');
+
+  const context = await browser.newContext();
+  const contextPage1 = await context.newPage();
+  const contextPage2 = await context.newPage();
+  await contextPage1.goto('https://example.com/one');
+  await contextPage2.goto('https://example.com/two');
+
+  expect(context.pages()).toHaveLength(2);
+  expect(browser.contexts()).toEqual([context]);
+
+  await context.close();
+  expect(context.pages()).toHaveLength(0);
+
+  // The browser's own directly-opened page is unaffected by context.close().
+  const html = await directPage.content();
+  expect(html).toContain('nav-btn');
+
+  await browser.close();
+});
+
+it('connectOverCDP returns a Browser that drives the same real Chrome instance', async () => {
+  const rpc = createIntegrationMockRpc();
+  const { chromium } = createPlaywrightShim(rpc);
+
+  const browser = await chromium.connectOverCDP('http://localhost:9222');
+  const page = await browser.newPage();
+  await page.goto('https://example.com');
+  const html = await page.content();
+
+  expect(html).toBe('<html><body><button class="nav-btn">Menu</button></body></html>');
+
+  await browser.close();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+This task runs after Tasks 1-4, so the shim implementation already exists — these tests exercise realistic end-to-end flows rather than drive new implementation.
+
+Run: `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim-integration.test.ts`
+Expected: PASS (all tests, including the 4 new ones and all pre-existing ones)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/webapp/tests/kernel/realm/playwright-shim-integration.test.ts
+git commit -m "test(realm): add integration coverage for playwright shim feature additions"
+```
+
+---
+
+### Task 6: Update documentation
+
+**Files:**
+
+- Modify: `docs/node-compat-shims.md:182-197`
+- Modify: `packages/webapp/src/kernel/realm/playwright-shim.ts:1-19` (module doc comment)
+
+**Interfaces:**
+
+- Consumes: nothing (docs only).
+- Produces: nothing (docs only).
+
+- [ ] **Step 1: Update `docs/node-compat-shims.md`**
+
+Lines 182-197 currently read:
+
+```markdown
+**Supported surface:**
+
+- `chromium.launch()` — returns a Browser (no-op; Chrome is already running)
+- `browser.newPage({ viewport? })` — opens a real new tab, sets viewport
+- `browser.close()` — closes all tabs opened by the instance
+- `page.goto(url)`, `page.waitForLoadState(state?)`
+- `page.evaluate(fn, ...args)` — runs JS in page context
+- `page.screenshot({ path?, fullPage? })` — returns Uint8Array (PNG)
+- `page.$(selector)`, `page.$$(selector)` — query selectors → ElementHandle
+- `page.content()` — returns page HTML
+- `page.setViewportSize({ width, height })`
+- `page.close()`
+- `elementHandle.textContent()`, `.getAttribute(name)`, `.isVisible()`, `.boundingBox()`
+
+**Not supported:** BrowserContext, request interception, locators, tracing,
+video, firefox/webkit engines (all three launchers use the same Chrome).
+```
+
+Replace with:
+
+```markdown
+**Supported surface:**
+
+- `chromium.launch()` — returns a Browser (no-op; Chrome is already running)
+- `chromium.connectOverCDP(endpoint)`, `<launcher>.connect(wsEndpoint)` — also
+  no-ops that return a Browser; the endpoint argument is accepted but ignored
+  (the realm is always already attached to SLICC's one real Chrome)
+- `browser.newPage({ viewport? })` — opens a real new tab, sets viewport
+- `browser.newContext(options?)` — returns a `BrowserContext` that groups its
+  own pages for `close()`/`pages()` bookkeeping. **No cookie/storage isolation**
+  — every context and the top-level browser share the one real Chrome profile.
+- `browser.contexts()`, `context.newPage()`, `context.pages()`, `context.close()`
+- `browser.close()` — closes all tabs opened by the instance, including every
+  context's tabs
+- `page.goto(url)`, `page.waitForLoadState(state?)`, `page.waitForTimeout(ms)`
+- `page.evaluate(fn, ...args)` — runs JS in page context
+- `page.screenshot({ path?, fullPage? })` — returns Uint8Array (PNG)
+- `page.$(selector)`, `page.$$(selector)` — query selectors → ElementHandle
+- `page.$$eval(selector, fn, ...args)` — runs `fn` over every matched element
+- `page.content()` — returns page HTML
+- `page.setViewportSize({ width, height })`
+- `page.close()`
+- `elementHandle.textContent()`, `.getAttribute(name)`, `.isVisible()`, `.boundingBox()`
+
+**Not supported:** request interception, locators, tracing, video, distinct
+firefox/webkit engines (all three launchers use the same Chrome), real
+per-context cookie/storage isolation for `BrowserContext`.
+```
+
+- [ ] **Step 2: Update the module doc comment in `packages/webapp/src/kernel/realm/playwright-shim.ts`**
+
+Lines 1-19 currently read:
+
+```ts
+/**
+ * `playwright-shim.ts` — a Playwright-shaped API backed by SLICC's existing
+ * CDP connection (`BrowserAPI`) rather than a bundled Playwright/browser
+ * binary. `createPlaywrightShim(rpc)` is wired into the realm module
+ * resolver (see `js-realm-shared.ts`'s `SHIMMED_PACKAGES`) so
+ * `require('playwright')` / `import('playwright')` resolves inside realm
+ * scripts to `{ chromium, firefox, webkit }` — all three launchers drive the
+ * SAME already-running Chrome instance (SLICC never spawns a second
+ * browser), so there is no meaningful behavioral difference between them
+ * here.
+ *
+ * Every method is a thin translation to one `rpc.call('browser', op, args)`
+ * against the host ops added in `realm-host.ts`'s `dispatchBrowser`
+ * (`createTab` / `closeTab` / `setViewport` / `navigateTab` /
+ * `screenshotTab` / `waitForLoadState`, plus the pre-existing `eval` /
+ * `evalAsync`). Only the ~15 methods real fixture scripts (stardust, AEM)
+ * call are implemented — see `docs/node-compat-shims.md` for the full
+ * supported/unsupported surface.
+ */
+```
+
+Replace with:
+
+```ts
+/**
+ * `playwright-shim.ts` — a Playwright-shaped API backed by SLICC's existing
+ * CDP connection (`BrowserAPI`) rather than a bundled Playwright/browser
+ * binary. `createPlaywrightShim(rpc)` is wired into the realm module
+ * resolver (see `js-realm-shared.ts`'s `SHIMMED_PACKAGES`) so
+ * `require('playwright')` / `import('playwright')` resolves inside realm
+ * scripts to `{ chromium, firefox, webkit }` — all three launchers drive the
+ * SAME already-running Chrome instance (SLICC never spawns a second
+ * browser), so there is no meaningful behavioral difference between them
+ * here. `connectOverCDP`/`connect` are likewise no-ops for the same reason —
+ * there is no other CDP endpoint to dial.
+ *
+ * Every method is a thin translation to one `rpc.call('browser', op, args)`
+ * against the host ops added in `realm-host.ts`'s `dispatchBrowser`
+ * (`createTab` / `closeTab` / `setViewport` / `navigateTab` /
+ * `screenshotTab` / `waitForLoadState`, plus the pre-existing `eval` /
+ * `evalAsync`), or in the case of `waitForTimeout`, a pure client-side
+ * `setTimeout` with no host round trip at all. `browser.newContext()`
+ * provides grouping only, not real per-context cookie/storage isolation —
+ * see `docs/node-compat-shims.md` for the full supported/unsupported
+ * surface.
+ */
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/node-compat-shims.md packages/webapp/src/kernel/realm/playwright-shim.ts
+git commit -m "docs(realm): document playwright shim feature additions"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run the full webapp test suite**
+
+Run: `npm run test -w @slicc/webapp`
+Expected: PASS
+
+- [ ] **Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (no new errors)
+
+- [ ] **Run lint**
+
+Run: `npm run lint`
+Expected: PASS (no new errors)

--- a/docs/superpowers/specs/2026-07-14-playwright-shim-features-design.md
+++ b/docs/superpowers/specs/2026-07-14-playwright-shim-features-design.md
@@ -1,0 +1,141 @@
+# Playwright realm shim: four new features
+
+Date: 2026-07-14
+Status: approved
+
+## Context
+
+`packages/webapp/src/kernel/realm/playwright-shim.ts` implements `require('playwright')` /
+`import('playwright')` for scripts running in SLICC's JS realm, backed by the existing
+`BrowserAPI`/CDP connection instead of a bundled Playwright/browser binary (PR #1496).
+It is deliberately scoped to the ~15 methods real fixture scripts (stardust, AEM) call, and
+documents an explicit "not supported" list in `docs/node-compat-shims.md`, including
+`BrowserContext`, `connectOverCDP`/`connect`, and several `Page` methods.
+
+A user hit four concrete gaps running existing scripts against the shim:
+
+| API                                                     | Current state                                     |
+| ------------------------------------------------------- | ------------------------------------------------- |
+| `chromium.launch()`                                     | works                                             |
+| `browser.newContext(...)`                               | `TypeError: browser.newContext is not a function` |
+| `browser.newPage()`                                     | works                                             |
+| `page.goto/evaluate/screenshot/setViewportSize/content` | work                                              |
+| `chromium.connectOverCDP` / `chromium.connect`          | undefined                                         |
+| `page.waitForTimeout`, `page.$$eval`                    | undefined                                         |
+
+This spec closes those four gaps. It does not attempt full Playwright API parity (locators,
+request interception, tracing, video, distinct browser engines remain out of scope — see
+`docs/node-compat-shims.md`).
+
+## Constraints from the existing architecture
+
+- **Single real browser.** SLICC drives exactly one already-running Chrome instance via
+  `BrowserAPI`. There is no `Target.createBrowserContext`/`disposeBrowserContext` usage and no
+  concept of multiple isolated cookie jars — `chromium`/`firefox`/`webkit` are already aliases
+  of the same launcher for this reason.
+- **No new host RPC ops needed for three of the four features.** The realm already has real
+  wall-clock timers (`js-realm-shared.ts`) and the existing `evalAsync` host op takes an
+  arbitrary code string — `$$eval` and `waitForTimeout` need no changes to `realm-host.ts`.
+- **Args-in-code-string convention.** `page.evaluate` serializes function bodies via
+  `fn.toString()` and JSON-stringifies each arg into an IIFE call
+  (`playwright-shim.ts:133-141`). New methods that evaluate script must follow this same
+  convention rather than inventing a new arg-passing mechanism.
+
+## Decisions (confirmed with user)
+
+1. **`browser.newContext()` is grouping-only, not isolated.** It returns a context object that
+   tracks its own set of pages (same shape as `PlaywrightBrowser` today) so `context.close()`
+   tears down only its own tabs. It does **not** provide separate cookies/storage — all
+   contexts and the top-level browser share the one real Chrome profile. This is documented as
+   a known limitation with the same prominence as the firefox/webkit aliasing note.
+2. **`connectOverCDP`/`connect` ignore their endpoint argument.** Since the realm is always
+   already attached to SLICC's one real Chrome, there is nothing else to dial. Both return a
+   fresh `PlaywrightBrowser`, identical in behavior to `launch()`. The endpoint parameter is
+   accepted (for API-shape compatibility with real Playwright call sites) but unused.
+
+## Design
+
+### 1. `page.waitForTimeout(ms: number): Promise<void>`
+
+Added to `PlaywrightPage`. Pure client-side delay, no RPC:
+
+```ts
+async waitForTimeout(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+```
+
+### 2. `page.$$eval<R>(selector: string, fn: (elements: Element[], ...args) => R, ...args): Promise<R>`
+
+Added to `PlaywrightPage`, mirroring `evaluate`'s args convention and `$$`'s selector-querying:
+
+- Build an IIFE body: `Array.from(document.querySelectorAll(<selector>))` piped into
+  `(<fn>)(els, ...args)`, with args JSON-stringified exactly like `evaluate` does.
+- Dispatch through the existing `evalAsync` host op — no `realm-host.ts` change.
+- String-form `fn` (raw code) is supported the same way `evaluate` supports it, for
+  consistency, though `$$eval`'s primary use is a function.
+
+### 3. `browser.newContext(options?): Promise<PlaywrightBrowserContext>`
+
+New class `PlaywrightBrowserContext`, structurally identical to `PlaywrightBrowser`:
+
+- Own `pageTargetIds: string[]` bookkeeping array.
+- `newPage(options?)`, `pages()` (returns tracked `PlaywrightPage` wrappers — track pages, not
+  just target ids, so `pages()` can return live objects), `close()` (closes all its own tabs).
+
+`PlaywrightBrowser` changes:
+
+- Tracks contexts it creates in a private array.
+- `newContext(options?)` creates a `PlaywrightBrowserContext`, tracks it, returns it.
+- `contexts()` returns the tracked list.
+- `close()` now closes both its own directly-created pages AND every tracked context's pages,
+  so no tabs leak when a script creates contexts but never explicitly closes them.
+
+`options` (viewport, storageState, etc.) is accepted per the shim's existing
+`[key: string]: unknown` open-options convention but not interpreted — no real per-context
+behavior exists to apply it to, consistent with decision #1.
+
+### 4. `connectOverCDP` / `connect`
+
+- `chromium.connectOverCDP(endpoint: string, options?): Promise<PlaywrightBrowser>` — added
+  only to `chromium` (matches real Playwright, where this is Chromium-specific).
+- `<launcher>.connect(wsEndpoint: string, options?): Promise<PlaywrightBrowser>` — added to
+  `chromium`, `firefox`, and `webkit` (matches real Playwright's generic `BrowserType.connect`).
+- Both share `launch()`'s body verbatim (`return new PlaywrightBrowser(rpc)`), with a doc
+  comment explaining the endpoint argument is accepted but ignored per decision #2.
+
+### Interface changes
+
+`PlaywrightShim`'s per-launcher type gains `connect`; `chromium`'s gains `connectOverCDP` too.
+`createPlaywrightShim` wires all four the same way `launch` is wired today (thin closures over
+`rpc`).
+
+## Testing
+
+- `packages/webapp/tests/kernel/realm/playwright-shim.test.ts` (unit, mocked RPC): new cases
+  for `waitForTimeout` (fake timers or bounded real delay), `$$eval` (asserts the generated
+  code string queries the selector and maps the function), `newContext`/`pages`/`close`
+  (asserts context tab tracking and that `browser.close()` cleans up context tabs too),
+  `connectOverCDP`/`connect` (asserts a working `PlaywrightBrowser` is returned regardless of
+  endpoint value).
+- `packages/webapp/tests/kernel/realm/playwright-shim-integration.test.ts`: one live-Chrome-fixture
+  case per addition, e.g. a `$$eval` over a real list of DOM nodes, a `newContext` + two pages
+  - context-only `close()` leaving the browser's other pages open, a `connectOverCDP` round trip
+    driving a real navigation.
+
+## Documentation
+
+- `docs/node-compat-shims.md`: move `newContext`/`connectOverCDP`/`connect`/`waitForTimeout`/
+  `$$eval` from "not supported" to "supported," with the isolation caveat kept prominent next
+  to `newContext`.
+- Update the `playwright-shim.ts` module doc comment's "~15 methods" description if it becomes
+  materially stale.
+
+## Out of scope
+
+- Real per-context cookie/storage isolation (would require CDP `Target.createBrowserContext`
+  plumbing that doesn't exist in `BrowserAPI` today).
+- Actually dialing a different CDP endpoint for `connectOverCDP`/`connect` (SLICC has exactly
+  one real browser).
+- Locators, request interception, tracing, video, distinct firefox/webkit engines — unchanged
+  from the existing "not supported" list.

--- a/packages/webapp/src/kernel/realm/playwright-shim.ts
+++ b/packages/webapp/src/kernel/realm/playwright-shim.ts
@@ -316,9 +316,19 @@ export class PlaywrightBrowser {
 }
 
 export interface PlaywrightShim {
-  chromium: { launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser> };
-  firefox: { launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser> };
-  webkit: { launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser> };
+  chromium: {
+    launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+    connect(wsEndpoint: string, options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+    connectOverCDP(endpoint: string, options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+  };
+  firefox: {
+    launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+    connect(wsEndpoint: string, options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+  };
+  webkit: {
+    launch(options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+    connect(wsEndpoint: string, options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser>;
+  };
 }
 
 /**
@@ -327,14 +337,25 @@ export interface PlaywrightShim {
  * a no-op spawn — SLICC's Chrome is already running — it just hands back a
  * fresh `PlaywrightBrowser` bookkeeping wrapper over `rpc`. All three
  * launchers are identical (see module doc comment).
+ *
+ * `connect`/`connectOverCDP` accept an endpoint argument for API-shape
+ * compatibility with real Playwright call sites, but ignore it: the realm
+ * is always already attached to SLICC's one real Chrome instance, so there
+ * is nothing else to dial. Both behave identically to `launch()`.
  */
 export function createPlaywrightShim(rpc: PlaywrightShimRpc): PlaywrightShim {
   const launch = async (_options?: PlaywrightLaunchOptions): Promise<PlaywrightBrowser> => {
     return new PlaywrightBrowser(rpc);
   };
+  const connect = async (
+    _endpoint: string,
+    _options?: PlaywrightLaunchOptions
+  ): Promise<PlaywrightBrowser> => {
+    return new PlaywrightBrowser(rpc);
+  };
   return {
-    chromium: { launch },
-    firefox: { launch },
-    webkit: { launch },
+    chromium: { launch, connect, connectOverCDP: connect },
+    firefox: { launch, connect },
+    webkit: { launch, connect },
   };
 }

--- a/packages/webapp/src/kernel/realm/playwright-shim.ts
+++ b/packages/webapp/src/kernel/realm/playwright-shim.ts
@@ -42,6 +42,11 @@ export interface PlaywrightNewPageOptions {
   [key: string]: unknown;
 }
 
+export interface PlaywrightNewContextOptions {
+  viewport?: ViewportSize;
+  [key: string]: unknown;
+}
+
 export interface PlaywrightScreenshotOptions {
   path?: string;
   fullPage?: boolean;
@@ -222,13 +227,53 @@ export class PlaywrightPage {
 }
 
 /**
- * Wraps a "browser" — in reality just a bookkeeping set of tabs opened
+ * Wraps Playwright's `BrowserContext` shape, but grouping-only: it tracks
+ * its own pages so `close()`/`pages()` bookkeeping is scoped to just this
+ * context. SLICC has exactly one real Chrome profile — there is NO cookie
+ * jar / storage isolation between contexts (see docs/node-compat-shims.md).
+ * Scripts that rely on real per-context isolation will not get it here.
+ */
+export class PlaywrightBrowserContext {
+  private readonly openPages: PlaywrightPage[] = [];
+
+  constructor(private readonly rpc: PlaywrightShimRpc) {}
+
+  async newPage(options?: PlaywrightNewPageOptions): Promise<PlaywrightPage> {
+    const targetId = (await this.rpc.call('browser', 'createTab', ['about:blank'])) as string;
+    if (options?.viewport) {
+      await this.rpc.call('browser', 'setViewport', [
+        targetId,
+        options.viewport.width,
+        options.viewport.height,
+      ]);
+    }
+    const page = new PlaywrightPage(this.rpc, targetId);
+    this.openPages.push(page);
+    return page;
+  }
+
+  pages(): PlaywrightPage[] {
+    return [...this.openPages];
+  }
+
+  async close(): Promise<void> {
+    const pages = this.openPages.splice(0, this.openPages.length);
+    for (const page of pages) {
+      await page.close();
+    }
+  }
+}
+
+/**
+ * Wraps a "browser" — in reality just a bookkeeping set of tabs (and
+ * contexts, which are themselves just bookkeeping sets of tabs) opened
  * through this launch() call, so `close()` knows which real tabs to tear
  * down. There's no separate browser process to spawn or attach to; the
  * host already owns the one real Chrome instance.
  */
 export class PlaywrightBrowser {
   private readonly pageTargetIds: string[] = [];
+  private readonly openContexts: PlaywrightBrowserContext[] = [];
 
   constructor(private readonly rpc: PlaywrightShimRpc) {}
 
@@ -248,10 +293,24 @@ export class PlaywrightBrowser {
     });
   }
 
+  async newContext(_options?: PlaywrightNewContextOptions): Promise<PlaywrightBrowserContext> {
+    const context = new PlaywrightBrowserContext(this.rpc);
+    this.openContexts.push(context);
+    return context;
+  }
+
+  contexts(): PlaywrightBrowserContext[] {
+    return [...this.openContexts];
+  }
+
   async close(): Promise<void> {
     const targetIds = this.pageTargetIds.splice(0, this.pageTargetIds.length);
     for (const targetId of targetIds) {
       await this.rpc.call('browser', 'closeTab', [targetId]);
+    }
+    const contexts = this.openContexts.splice(0, this.openContexts.length);
+    for (const context of contexts) {
+      await context.close();
     }
   }
 }

--- a/packages/webapp/src/kernel/realm/playwright-shim.ts
+++ b/packages/webapp/src/kernel/realm/playwright-shim.ts
@@ -124,6 +124,11 @@ export class PlaywrightPage {
     await this.rpc.call('browser', 'waitForLoadState', [this.targetId, state ?? 'load']);
   }
 
+  /** Pure client-side delay — the realm already has real wall-clock timers, so no host RPC is needed. */
+  async waitForTimeout(ms: number): Promise<void> {
+    await new Promise<void>((resolve) => setTimeout(resolve, ms));
+  }
+
   /**
    * Mirrors Playwright's `page.evaluate(fn, ...args)`: functions are
    * serialized to source and invoked as an IIFE, with the whole args array

--- a/packages/webapp/src/kernel/realm/playwright-shim.ts
+++ b/packages/webapp/src/kernel/realm/playwright-shim.ts
@@ -118,10 +118,12 @@ export class PlaywrightElementHandle {
 
 /** Wraps a single real browser tab (a `targetId` from the host's `createTab`). */
 export class PlaywrightPage {
+  private closed = false;
+
   constructor(
     private readonly rpc: PlaywrightShimRpc,
     private readonly targetId: string,
-    private readonly onClose?: (targetId: string) => void
+    private readonly onClose?: () => void
   ) {}
 
   async goto(url: string, _options?: { waitUntil?: string; timeout?: number }): Promise<void> {
@@ -195,6 +197,17 @@ export class PlaywrightPage {
     return handles;
   }
 
+  /**
+   * Mirrors Playwright's `page.$$eval(selector, fn, ...args)`: `fn` is
+   * invoked with the matched elements as its first argument, followed by
+   * `...args` — the extra args are JSON round-tripped as a single unit
+   * (same rationale and convention as `evaluate`, see its doc comment)
+   * rather than per-argument, so a value that can't survive serialization
+   * fails fast instead of one arg silently corrupting while its neighbors
+   * don't. A string `fn` is passed through verbatim as raw code, same as
+   * `evaluate`'s string-expression overload (real Playwright has no such
+   * overload for `$$eval`, but this mirrors `evaluate` for consistency).
+   */
   // biome-ignore lint/style/useNamingConvention: `$$eval` mirrors Playwright's real API name exactly, so fixture scripts can call `page.$$eval(...)` unmodified.
   async $$eval<R = unknown>(
     selector: string,
@@ -204,11 +217,7 @@ export class PlaywrightPage {
     if (typeof fn === 'string') {
       return this.rpc.call('browser', 'evalAsync', [this.targetId, fn]) as Promise<R>;
     }
-    const serializedArgs = args.map((a) => JSON.stringify(a)).join(', ');
-    const callArgs = serializedArgs
-      ? `Array.from(document.querySelectorAll(${JSON.stringify(selector)})), ${serializedArgs}`
-      : `Array.from(document.querySelectorAll(${JSON.stringify(selector)}))`;
-    const code = `(${fn.toString()})(${callArgs})`;
+    const code = `(${fn.toString()}).apply(null, [Array.from(document.querySelectorAll(${JSON.stringify(selector)}))].concat(JSON.parse(${JSON.stringify(JSON.stringify(args))})))`;
     return this.rpc.call('browser', 'evalAsync', [this.targetId, code]) as Promise<R>;
   }
 
@@ -223,9 +232,12 @@ export class PlaywrightPage {
     await this.rpc.call('browser', 'setViewport', [this.targetId, size.width, size.height]);
   }
 
+  /** Idempotent — a page already closed (directly, or via its owning Browser/BrowserContext) makes no further `closeTab` call. */
   async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
     await this.rpc.call('browser', 'closeTab', [this.targetId]);
-    this.onClose?.(this.targetId);
+    this.onClose?.();
   }
 }
 
@@ -250,7 +262,10 @@ export class PlaywrightBrowserContext {
         options.viewport.height,
       ]);
     }
-    const page = new PlaywrightPage(this.rpc, targetId);
+    const page: PlaywrightPage = new PlaywrightPage(this.rpc, targetId, () => {
+      const idx = this.openPages.indexOf(page);
+      if (idx !== -1) this.openPages.splice(idx, 1);
+    });
     this.openPages.push(page);
     return page;
   }
@@ -275,14 +290,13 @@ export class PlaywrightBrowserContext {
  * host already owns the one real Chrome instance.
  */
 export class PlaywrightBrowser {
-  private readonly pageTargetIds: string[] = [];
+  private readonly openPages: PlaywrightPage[] = [];
   private readonly openContexts: PlaywrightBrowserContext[] = [];
 
   constructor(private readonly rpc: PlaywrightShimRpc) {}
 
   async newPage(options?: PlaywrightNewPageOptions): Promise<PlaywrightPage> {
     const targetId = (await this.rpc.call('browser', 'createTab', ['about:blank'])) as string;
-    this.pageTargetIds.push(targetId);
     if (options?.viewport) {
       await this.rpc.call('browser', 'setViewport', [
         targetId,
@@ -290,10 +304,12 @@ export class PlaywrightBrowser {
         options.viewport.height,
       ]);
     }
-    return new PlaywrightPage(this.rpc, targetId, (closedTargetId) => {
-      const index = this.pageTargetIds.indexOf(closedTargetId);
-      if (index !== -1) this.pageTargetIds.splice(index, 1);
+    const page: PlaywrightPage = new PlaywrightPage(this.rpc, targetId, () => {
+      const idx = this.openPages.indexOf(page);
+      if (idx !== -1) this.openPages.splice(idx, 1);
     });
+    this.openPages.push(page);
+    return page;
   }
 
   async newContext(_options?: PlaywrightNewContextOptions): Promise<PlaywrightBrowserContext> {
@@ -307,9 +323,9 @@ export class PlaywrightBrowser {
   }
 
   async close(): Promise<void> {
-    const targetIds = this.pageTargetIds.splice(0, this.pageTargetIds.length);
-    for (const targetId of targetIds) {
-      await this.rpc.call('browser', 'closeTab', [targetId]);
+    const pages = this.openPages.splice(0, this.openPages.length);
+    for (const page of pages) {
+      await page.close();
     }
     const contexts = this.openContexts.splice(0, this.openContexts.length);
     for (const context of contexts) {

--- a/packages/webapp/src/kernel/realm/playwright-shim.ts
+++ b/packages/webapp/src/kernel/realm/playwright-shim.ts
@@ -7,15 +7,18 @@
  * scripts to `{ chromium, firefox, webkit }` — all three launchers drive the
  * SAME already-running Chrome instance (SLICC never spawns a second
  * browser), so there is no meaningful behavioral difference between them
- * here.
+ * here. `connectOverCDP`/`connect` are likewise no-ops for the same reason —
+ * there is no other CDP endpoint to dial.
  *
  * Every method is a thin translation to one `rpc.call('browser', op, args)`
  * against the host ops added in `realm-host.ts`'s `dispatchBrowser`
  * (`createTab` / `closeTab` / `setViewport` / `navigateTab` /
  * `screenshotTab` / `waitForLoadState`, plus the pre-existing `eval` /
- * `evalAsync`). Only the ~15 methods real fixture scripts (stardust, AEM)
- * call are implemented — see `docs/node-compat-shims.md` for the full
- * supported/unsupported surface.
+ * `evalAsync`), or in the case of `waitForTimeout`, a pure client-side
+ * `setTimeout` with no host round trip at all. `browser.newContext()`
+ * provides grouping only, not real per-context cookie/storage isolation —
+ * see `docs/node-compat-shims.md` for the full supported/unsupported
+ * surface.
  */
 
 /**

--- a/packages/webapp/src/kernel/realm/playwright-shim.ts
+++ b/packages/webapp/src/kernel/realm/playwright-shim.ts
@@ -187,6 +187,23 @@ export class PlaywrightPage {
     return handles;
   }
 
+  // biome-ignore lint/style/useNamingConvention: `$$eval` mirrors Playwright's real API name exactly, so fixture scripts can call `page.$$eval(...)` unmodified.
+  async $$eval<R = unknown>(
+    selector: string,
+    fn: ((elements: Element[], ...args: unknown[]) => R | Promise<R>) | string,
+    ...args: unknown[]
+  ): Promise<R> {
+    if (typeof fn === 'string') {
+      return this.rpc.call('browser', 'evalAsync', [this.targetId, fn]) as Promise<R>;
+    }
+    const serializedArgs = args.map((a) => JSON.stringify(a)).join(', ');
+    const callArgs = serializedArgs
+      ? `Array.from(document.querySelectorAll(${JSON.stringify(selector)})), ${serializedArgs}`
+      : `Array.from(document.querySelectorAll(${JSON.stringify(selector)}))`;
+    const code = `(${fn.toString()})(${callArgs})`;
+    return this.rpc.call('browser', 'evalAsync', [this.targetId, code]) as Promise<R>;
+  }
+
   async content(): Promise<string> {
     return this.rpc.call('browser', 'evalAsync', [
       this.targetId,

--- a/packages/webapp/tests/kernel/realm/playwright-shim-integration.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-shim-integration.test.ts
@@ -75,6 +75,12 @@ function createIntegrationMockRpc(): MockRpc {
           return false;
         }
 
+        if (code.includes('Array.from(document.querySelectorAll')) {
+          // page.$$eval() — simulate counting the matched elements
+          if (code.includes('"li"')) return 3;
+          return 0;
+        }
+
         if (code.includes('document.querySelectorAll')) {
           // Count for page.$$
           if (code.includes('.length')) {
@@ -378,6 +384,88 @@ describe('playwright shim integration', () => {
     // Each handle should maintain its own index for queries
     const text1 = await buttons[0].textContent();
     expect(text1).toBe('Menu');
+
+    await browser.close();
+  });
+
+  it('waits for a fixed timeout without making any rpc calls', async () => {
+    vi.useFakeTimers();
+    try {
+      const rpc = createIntegrationMockRpc();
+      const { chromium } = createPlaywrightShim(rpc);
+
+      const browser = await chromium.launch();
+      const page = await browser.newPage();
+      await page.goto('https://example.com');
+
+      rpc.call.mockClear();
+      let resolved = false;
+      const promise = page.waitForTimeout(200).then(() => {
+        resolved = true;
+      });
+      await vi.advanceTimersByTimeAsync(200);
+      await promise;
+
+      expect(resolved).toBe(true);
+      expect(rpc.call).not.toHaveBeenCalled();
+
+      await browser.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('evaluates a reducer function over every matched element via $$eval', async () => {
+    const rpc = createIntegrationMockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+    await page.goto('https://example.com');
+
+    const count = await page.$$eval('li', (elements) => elements.length);
+    expect(count).toBe(3);
+
+    await browser.close();
+  });
+
+  it("isolates tabs opened through a context from the browser's own tabs", async () => {
+    const rpc = createIntegrationMockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+
+    const browser = await chromium.launch();
+    const directPage = await browser.newPage();
+    await directPage.goto('https://example.com');
+
+    const context = await browser.newContext();
+    const contextPage1 = await context.newPage();
+    const contextPage2 = await context.newPage();
+    await contextPage1.goto('https://example.com/one');
+    await contextPage2.goto('https://example.com/two');
+
+    expect(context.pages()).toHaveLength(2);
+    expect(browser.contexts()).toEqual([context]);
+
+    await context.close();
+    expect(context.pages()).toHaveLength(0);
+
+    // The browser's own directly-opened page is unaffected by context.close().
+    const html = await directPage.content();
+    expect(html).toContain('nav-btn');
+
+    await browser.close();
+  });
+
+  it('connectOverCDP returns a Browser that drives the same real Chrome instance', async () => {
+    const rpc = createIntegrationMockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+
+    const browser = await chromium.connectOverCDP('http://localhost:9222');
+    const page = await browser.newPage();
+    await page.goto('https://example.com');
+    const html = await page.content();
+
+    expect(html).toBe('<html><body><button class="nav-btn">Menu</button></body></html>');
 
     await browser.close();
   });

--- a/packages/webapp/tests/kernel/realm/playwright-shim-integration.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-shim-integration.test.ts
@@ -423,8 +423,12 @@ describe('playwright shim integration', () => {
     const page = await browser.newPage();
     await page.goto('https://example.com');
 
-    const count = await page.$$eval('li', (elements) => elements.length);
-    expect(count).toBe(3);
+    // Selector deliberately chosen so the $$eval-specific mock branch (→ 0)
+    // and the pre-existing generic querySelectorAll+.length branch (→ 1 for
+    // ".nav-btn") diverge — this discriminates a mock branch-order regression,
+    // unlike a selector where both branches happen to agree.
+    const count = await page.$$eval('.nav-btn', (elements) => elements.length);
+    expect(count).toBe(0);
 
     await browser.close();
   });
@@ -446,8 +450,22 @@ describe('playwright shim integration', () => {
     expect(context.pages()).toHaveLength(2);
     expect(browser.contexts()).toEqual([context]);
 
+    const calls = rpc.call.mock.calls as Array<[string, string, unknown[]]>;
+    const directPageTargetId = calls.find(
+      (c) => c[1] === 'navigateTab' && c[2][1] === 'https://example.com'
+    )?.[2][0];
+    expect(directPageTargetId).toBeDefined();
+
     await context.close();
     expect(context.pages()).toHaveLength(0);
+
+    // context.close() must close exactly the two context-owned tabs, and
+    // never the browser's own directly-opened tab — this is the isolation
+    // guarantee this test exists to check, verified against actual rpc
+    // calls rather than the mock's canned (targetId-insensitive) content.
+    const closeTabIds = calls.filter((c) => c[1] === 'closeTab').map((c) => c[2][0]);
+    expect(closeTabIds).toHaveLength(2);
+    expect(closeTabIds).not.toContain(directPageTargetId);
 
     // The browser's own directly-opened page is unaffected by context.close().
     const html = await directPage.content();

--- a/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
@@ -144,6 +144,82 @@ describe('createPlaywrightShim: browser.newPage / browser.close', () => {
   });
 });
 
+describe('createPlaywrightShim: browser.newContext', () => {
+  it('newContext().newPage() opens a real tab', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    expect(page).toBeDefined();
+    expect(rpc.call).toHaveBeenCalledWith('browser', 'createTab', ['about:blank']);
+  });
+
+  it('context.pages() returns every page opened through that context', async () => {
+    let n = 0;
+    const rpc = mockRpc();
+    rpc.call.mockImplementation(async (channel: string, op: string, args: unknown[] = []) => {
+      rpc.calls.push({ channel, op, args });
+      if (op === 'createTab') return `ctx-target-${++n}`;
+      return undefined;
+    });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    await context.newPage();
+    await context.newPage();
+    expect(context.pages()).toHaveLength(2);
+  });
+
+  it("context.close() closes only that context's tabs, leaving the browser's own pages open", async () => {
+    let n = 0;
+    const rpc = mockRpc();
+    rpc.call.mockImplementation(async (channel: string, op: string, args: unknown[] = []) => {
+      rpc.calls.push({ channel, op, args });
+      if (op === 'createTab') return `target-${++n}`;
+      return undefined;
+    });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    await browser.newPage(); // target-1, owned directly by the browser
+    const context = await browser.newContext();
+    await context.newPage(); // target-2, owned by the context
+
+    await context.close();
+
+    expect(rpc.call).toHaveBeenCalledWith('browser', 'closeTab', ['target-2']);
+    expect(rpc.call).not.toHaveBeenCalledWith('browser', 'closeTab', ['target-1']);
+    expect(context.pages()).toHaveLength(0);
+  });
+
+  it("browser.close() also tears down every context's tabs", async () => {
+    let n = 0;
+    const rpc = mockRpc();
+    rpc.call.mockImplementation(async (channel: string, op: string, args: unknown[] = []) => {
+      rpc.calls.push({ channel, op, args });
+      if (op === 'createTab') return `target-${++n}`;
+      return undefined;
+    });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    await context.newPage(); // target-1
+
+    await browser.close();
+
+    expect(rpc.call).toHaveBeenCalledWith('browser', 'closeTab', ['target-1']);
+  });
+
+  it('browser.contexts() returns every context created via newContext()', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const c1 = await browser.newContext();
+    const c2 = await browser.newContext();
+    expect(browser.contexts()).toEqual([c1, c2]);
+  });
+});
+
 describe('createPlaywrightShim: page navigation + lifecycle', () => {
   it('page.goto() calls navigateTab with the tab id and url', async () => {
     const rpc = mockRpc();

--- a/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
@@ -442,7 +442,7 @@ describe('createPlaywrightShim: page.$$eval', () => {
 
     const result = await page.$$eval(
       'li',
-      (elements: Element[], suffix: string) => elements.length + suffix.length,
+      (elements: Element[], ...args: unknown[]) => elements.length + (args[0] as string).length,
       '!!'
     );
 

--- a/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
@@ -357,6 +357,58 @@ describe('createPlaywrightShim: page.$ / page.$$', () => {
   });
 });
 
+describe('createPlaywrightShim: page.$$eval', () => {
+  it('serializes a function + args into an Array.from(querySelectorAll(...)) IIFE call', async () => {
+    const rpc = mockRpc({ evalAsync: 3 });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+
+    const result = await page.$$eval(
+      'li',
+      (elements: Element[], suffix: string) => elements.length + suffix.length,
+      '!!'
+    );
+
+    expect(result).toBe(3);
+    const call = rpc.calls.find((c) => c.op === 'evalAsync');
+    expect(call).toBeDefined();
+    expect(call!.args[0]).toBe('target-abc');
+    const code = call!.args[1] as string;
+    expect(code).toContain('document.querySelectorAll("li")');
+    expect(code).toContain('Array.from');
+    expect(code).toContain('"!!"');
+  });
+
+  it('omits the trailing comma when no extra args are passed', async () => {
+    const rpc = mockRpc({ evalAsync: 0 });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+
+    await page.$$eval('li', (elements: Element[]) => elements.length);
+
+    const call = rpc.calls.find((c) => c.op === 'evalAsync');
+    const code = call!.args[1] as string;
+    expect(code.trim().endsWith('))')).toBe(true);
+  });
+
+  it('passes a raw string straight through as the eval code', async () => {
+    const rpc = mockRpc({ evalAsync: 5 });
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+
+    const result = await page.$$eval('li', 'document.querySelectorAll("li").length');
+
+    expect(result).toBe(5);
+    expect(rpc.call).toHaveBeenCalledWith('browser', 'evalAsync', [
+      'target-abc',
+      'document.querySelectorAll("li").length',
+    ]);
+  });
+});
+
 describe('createPlaywrightShim: ElementHandle', () => {
   function makeElement() {
     const rpc = mockRpc();

--- a/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
@@ -197,6 +197,34 @@ describe('createPlaywrightShim: page navigation + lifecycle', () => {
   });
 });
 
+describe('createPlaywrightShim: page.waitForTimeout', () => {
+  it('resolves after the given delay without making any rpc calls', async () => {
+    vi.useFakeTimers();
+    try {
+      const rpc = mockRpc();
+      const { chromium } = createPlaywrightShim(rpc);
+      const browser = await chromium.launch();
+      const page = await browser.newPage();
+      rpc.calls.length = 0;
+
+      let resolved = false;
+      const promise = page.waitForTimeout(500).then(() => {
+        resolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(499);
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await promise;
+      expect(resolved).toBe(true);
+      expect(rpc.calls).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('createPlaywrightShim: page.evaluate', () => {
   it('serializes a function + args into an evalAsync IIFE call', async () => {
     const rpc = mockRpc({ evalAsync: 'The Title' });

--- a/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
@@ -566,3 +566,32 @@ describe('createPlaywrightShim: ElementHandle', () => {
     expect(codes[1]).toContain('els[1]');
   });
 });
+
+describe('createPlaywrightShim: connectOverCDP / connect', () => {
+  it('chromium.connectOverCDP() returns a working Browser regardless of the endpoint value', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.connectOverCDP('http://localhost:9222');
+    expect(typeof browser.newPage).toBe('function');
+    const page = await browser.newPage();
+    expect(page).toBeDefined();
+  });
+
+  it('chromium.connect() / firefox.connect() / webkit.connect() all return working Browsers', async () => {
+    const rpc = mockRpc();
+    const { chromium, firefox, webkit } = createPlaywrightShim(rpc);
+    const b1 = await chromium.connect('ws://localhost:1234/devtools/browser/abc');
+    const b2 = await firefox.connect('ws://localhost:1234/devtools/browser/abc');
+    const b3 = await webkit.connect('ws://localhost:1234/devtools/browser/abc');
+    expect(typeof b1.newPage).toBe('function');
+    expect(typeof b2.newPage).toBe('function');
+    expect(typeof b3.newPage).toBe('function');
+  });
+
+  it('connectOverCDP/connect are no-ops that make no rpc calls themselves', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    await chromium.connectOverCDP('http://localhost:9222');
+    expect(rpc.call).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-shim.test.ts
@@ -142,6 +142,30 @@ describe('createPlaywrightShim: browser.newPage / browser.close', () => {
     const closeCalls = rpc.calls.filter((c) => c.op === 'closeTab').map((c) => c.args[0]);
     expect(closeCalls).toEqual(['target-1', 'target-2']);
   });
+
+  it('closing a page directly then closing the browser does not re-issue closeTab for that page', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+    await page.close();
+
+    rpc.calls.length = 0;
+    await browser.close();
+    expect(rpc.calls.filter((c) => c.op === 'closeTab')).toHaveLength(0);
+  });
+
+  it('page.close() is idempotent — a second call makes no additional closeTab rpc call', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+    await page.close();
+
+    rpc.calls.length = 0;
+    await page.close();
+    expect(rpc.calls.filter((c) => c.op === 'closeTab')).toHaveLength(0);
+  });
 });
 
 describe('createPlaywrightShim: browser.newContext', () => {
@@ -217,6 +241,20 @@ describe('createPlaywrightShim: browser.newContext', () => {
     const c1 = await browser.newContext();
     const c2 = await browser.newContext();
     expect(browser.contexts()).toEqual([c1, c2]);
+  });
+
+  it('closing a context page directly removes it from context.pages() and prevents context.close() from re-closing it', async () => {
+    const rpc = mockRpc();
+    const { chromium } = createPlaywrightShim(rpc);
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.close();
+    expect(context.pages()).toHaveLength(0);
+
+    rpc.calls.length = 0;
+    await context.close();
+    expect(rpc.calls.filter((c) => c.op === 'closeTab')).toHaveLength(0);
   });
 });
 
@@ -434,7 +472,7 @@ describe('createPlaywrightShim: page.$ / page.$$', () => {
 });
 
 describe('createPlaywrightShim: page.$$eval', () => {
-  it('serializes a function + args into an Array.from(querySelectorAll(...)) IIFE call', async () => {
+  it('serializes a function + args into an Array.from(querySelectorAll(...)).apply(...) call', async () => {
     const rpc = mockRpc({ evalAsync: 3 });
     const { chromium } = createPlaywrightShim(rpc);
     const browser = await chromium.launch();
@@ -453,11 +491,17 @@ describe('createPlaywrightShim: page.$$eval', () => {
     const code = call!.args[1] as string;
     expect(code).toContain('document.querySelectorAll("li")');
     expect(code).toContain('Array.from');
-    expect(code).toContain('"!!"');
+    expect(code).toContain('.apply(null, [');
+    expect(code).toContain('.concat(JSON.parse(');
+
+    // Verify the generated code actually round-trips args correctly end-to-end.
+    const document = { querySelectorAll: (_sel: string) => [1, 2, 3] };
+    // biome-ignore lint/security/noGlobalEval: verifying the generated code actually round-trips args correctly
+    expect(eval(code)).toBe(5); // elements.length (3) + '!!'.length (2)
   });
 
-  it('omits the trailing comma when no extra args are passed', async () => {
-    const rpc = mockRpc({ evalAsync: 0 });
+  it('round-trips an empty args array when no extra args are passed', async () => {
+    const rpc = mockRpc({ evalAsync: 3 });
     const { chromium } = createPlaywrightShim(rpc);
     const browser = await chromium.launch();
     const page = await browser.newPage();
@@ -466,7 +510,12 @@ describe('createPlaywrightShim: page.$$eval', () => {
 
     const call = rpc.calls.find((c) => c.op === 'evalAsync');
     const code = call!.args[1] as string;
-    expect(code.trim().endsWith('))')).toBe(true);
+    expect(code).toContain('.apply(null, [');
+    expect(code).toContain('.concat(JSON.parse(');
+
+    const document = { querySelectorAll: (_sel: string) => [1, 2, 3] };
+    // biome-ignore lint/security/noGlobalEval: verifying the generated code actually round-trips args correctly
+    expect(eval(code)).toBe(3);
   });
 
   it('passes a raw string straight through as the eval code', async () => {


### PR DESCRIPTION
## Summary
- Adds four Playwright APIs to the realm's `require('playwright')` compatibility shim (`packages/webapp/src/kernel/realm/playwright-shim.ts`), closing gaps hit by real fixture scripts: `page.waitForTimeout(ms)`, `page.$$eval(selector, fn, ...args)`, `browser.newContext()`/`PlaywrightBrowserContext` (grouping-only, no real cookie/storage isolation — documented), and `chromium.connectOverCDP(endpoint)` / `<launcher>.connect(wsEndpoint)` (no-ops that ignore the endpoint, since the realm is always already attached to SLICC's one real Chrome).
- No `realm-host.ts` changes — `$$eval` reuses the existing `evalAsync` op, `waitForTimeout` is a pure client-side `setTimeout`.
- Extends unit + integration test coverage and `docs/node-compat-shims.md`.

Design spec: `docs/superpowers/specs/2026-07-14-playwright-shim-features-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-14-playwright-shim-features.md`

## Test plan
- [x] `npx vitest run packages/webapp/tests/kernel/realm/playwright-shim.test.ts packages/webapp/tests/kernel/realm/playwright-shim-integration.test.ts` — 52/52 passing
- [x] `npm run test -w @slicc/webapp` — full suite, 9016 passed / 1 skipped / 0 failed
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Final whole-branch review — no Critical/Important findings; one Minor doc-clarification applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)