### PR TITLE
feat(mount): Display mount target for local folder.

### DIFF
--- a/packages/webapp/src/fs/mount-commands.ts
+++ b/packages/webapp/src/fs/mount-commands.ts
@@ -175,6 +175,7 @@ export class MountCommands {
         isScoop,
         toolContext: ctx ?? undefined,
         isExtension: isExtensionRealm(),
+        targetPath,
       });
       await this.options.fs.mount(targetPath, backend, { env });
       const desc = backend.describe();

--- a/packages/webapp/src/fs/mount/backend-local.ts
+++ b/packages/webapp/src/fs/mount/backend-local.ts
@@ -109,6 +109,7 @@ export class LocalMountBackend implements MountBackend {
     isScoop: () => boolean;
     toolContext: ToolExecutionContext | undefined;
     isExtension: boolean;
+    targetPath: string;
   }): Promise<LocalMountBackend> {
     if (opts.isScoop()) {
       throw new Error('mount: cannot mount local directories from a scoop (no UI). Ask the cone.');
@@ -121,7 +122,7 @@ export class LocalMountBackend implements MountBackend {
     // dedicated helper so this factory stays a thin dispatcher.
     let dirHandle: FileSystemDirectoryHandle;
     if (opts.toolContext) {
-      dirHandle = await LocalMountBackend.acquireHandleViaToolUI(opts.toolContext);
+      dirHandle = await LocalMountBackend.acquireHandleViaToolUI(opts.toolContext, opts.targetPath);
     } else if (opts.isExtension) {
       dirHandle = await LocalMountBackend.acquireHandleViaPopup();
     } else {
@@ -198,7 +199,8 @@ export class LocalMountBackend implements MountBackend {
    * {@link create} so the parent function stays under the lint line limit.
    */
   private static async acquireHandleViaToolUI(
-    toolContext: ToolExecutionContext
+    toolContext: ToolExecutionContext,
+    targetPath: string
   ): Promise<FileSystemDirectoryHandle> {
     // We drive showToolUI directly (rather than the helper) so we own the
     // request id and can cancel the registry entry when the timeout fires
@@ -211,7 +213,7 @@ export class LocalMountBackend implements MountBackend {
     const rawUiPromise = showToolUI(
       {
         id: uiRequestId,
-        html: buildApprovalCardHtml('directory'),
+        html: buildApprovalCardHtml('directory', [], targetPath),
         onAction: (action, data) => LocalMountBackend.resolveApprovalAction(action, data),
       },
       toolContext.onUpdate

--- a/packages/webapp/src/shell/supplemental-commands/picker-approval.ts
+++ b/packages/webapp/src/shell/supplemental-commands/picker-approval.ts
@@ -57,11 +57,14 @@ export function buildApprovalCardHtml(
     : '';
   const metaHtml =
     kind === 'directory' && targetPath
-      ? `\n      <div class="sprinkle-action-card__meta">Target: ${escapeHtml(targetPath)}</div>`
+      ? `<div class="sprinkle-action-card__meta">Target: ${escapeHtml(targetPath)}</div>`
       : '';
   return `
     <div class="sprinkle-action-card">
-      <div class="sprinkle-action-card__header">${text.title} <span class="sprinkle-badge sprinkle-badge--notice">approval</span></div>${metaHtml}
+      <div class="sprinkle-action-card__header">
+        <div class="sprinkle-action-card__title-group">${text.title}${metaHtml}</div>
+        <span class="sprinkle-badge sprinkle-badge--notice">approval</span>
+      </div>
       <div class="sprinkle-action-card__actions">
         <button class="sprinkle-btn sprinkle-btn--secondary" data-action="deny">Deny</button>
         <button class="sprinkle-btn sprinkle-btn--primary" data-action="approve" data-picker="${kind}"${dataAttr}>${text.approve}</button>

--- a/packages/webapp/src/shell/supplemental-commands/picker-approval.ts
+++ b/packages/webapp/src/shell/supplemental-commands/picker-approval.ts
@@ -35,15 +35,33 @@ const PICKER_KIND_TEXT: Record<PickerKind, PickerKindText> = {
   'hid-device': { title: 'Connect HID device', approve: 'Select HID device' },
 };
 
+/** Escapes HTML special characters for safe interpolation into card markup. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
 /** Build the standard approval-card HTML for a picker kind + filters. */
-export function buildApprovalCardHtml(kind: PickerKind, filters: unknown[] = []): string {
+export function buildApprovalCardHtml(
+  kind: PickerKind,
+  filters: unknown[] = [],
+  targetPath?: string
+): string {
   const text = PICKER_KIND_TEXT[kind];
   const dataAttr = filters.length
     ? ` data-action-data='${JSON.stringify({ filters }).replace(/'/g, '&apos;')}'`
     : '';
+  const metaHtml =
+    kind === 'directory' && targetPath
+      ? `\n      <div class="sprinkle-action-card__meta">Target: ${escapeHtml(targetPath)}</div>`
+      : '';
   return `
     <div class="sprinkle-action-card">
-      <div class="sprinkle-action-card__header">${text.title} <span class="sprinkle-badge sprinkle-badge--notice">approval</span></div>
+      <div class="sprinkle-action-card__header">${text.title} <span class="sprinkle-badge sprinkle-badge--notice">approval</span></div>${metaHtml}
       <div class="sprinkle-action-card__actions">
         <button class="sprinkle-btn sprinkle-btn--secondary" data-action="deny">Deny</button>
         <button class="sprinkle-btn sprinkle-btn--primary" data-action="approve" data-picker="${kind}"${dataAttr}>${text.approve}</button>

--- a/packages/webapp/src/ui/styles/sprinkle-components.css
+++ b/packages/webapp/src/ui/styles/sprinkle-components.css
@@ -395,6 +395,12 @@
 .sprinkle-action-card__header .sprinkle-badge {
   margin-left: auto;
 }
+.sprinkle-action-card__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
 /* Icon thumbnail in header (Figma: 40px, colored bg, 8px radius) */
 .sprinkle-action-card__icon {
   width: 40px;
@@ -428,7 +434,6 @@
   font-size: 12px;
   font-weight: 400;
   color: var(--s2-gray-600); /* Figma: #717171 */
-  margin-top: 2px;
 }
 /* Action links in header right */
 .sprinkle-action-card__header-actions {

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -140,9 +140,12 @@ function extractToolUiTitle(html: string): string {
     const doc = new DOMParser().parseFromString(html, 'text/html');
     const header = doc.querySelector('.sprinkle-action-card__header');
     if (header) {
-      // Strip the trailing "approval" badge text, keep just the title.
-      const badge = header.querySelector('.sprinkle-badge');
-      badge?.remove();
+      // Strip the trailing "approval" badge and the target-path meta line
+      // (`.sprinkle-action-card__meta`, nested under the header's
+      // title-group) — the follower placeholder shows only the title,
+      // never the mount target path.
+      header.querySelector('.sprinkle-badge')?.remove();
+      header.querySelector('.sprinkle-action-card__meta')?.remove();
       const title = header.textContent?.trim();
       if (title) return title;
     }

--- a/packages/webapp/tests/fs/mount-commands.test.ts
+++ b/packages/webapp/tests/fs/mount-commands.test.ts
@@ -262,6 +262,40 @@ describe('MountCommands', () => {
     });
   });
 
+  describe('cone (interactive) approval card content', () => {
+    it('includes the resolved target path in the approval card html', async () => {
+      const onUpdate = vi.fn();
+      const ctx: ToolExecutionContext = pushToolExecutionContext({
+        onUpdate,
+        toolName: 'bash',
+        toolCallId: 'tc-mount-target-path',
+      });
+      try {
+        const cmd = new MountCommands({ fs: makeFs() });
+        const promise = cmd.execute(['/workspace/mnt/docs'], '/workspace');
+
+        await Promise.resolve();
+
+        const blocks = onUpdate.mock.calls.flatMap(
+          (call) =>
+            (call[0]?.content ?? []) as Array<{
+              type?: string;
+              html?: string;
+              requestId?: string;
+            }>
+        );
+        const uiBlock = blocks.find((b) => b.type === 'tool_ui');
+        expect(uiBlock?.html).toContain('Target: /workspace/mnt/docs');
+
+        await toolUIRegistry.handleAction(uiBlock!.requestId!, { action: 'deny' });
+        const result = await promise;
+        expect(result.exitCode).toBe(1);
+      } finally {
+        popToolExecutionContext(ctx);
+      }
+    });
+  });
+
   describe('--help', () => {
     it('returns exitCode 0', async () => {
       const cmd = new MountCommands({ fs: makeFs() });

--- a/packages/webapp/tests/fs/mount/mount-local-approval.test.ts
+++ b/packages/webapp/tests/fs/mount/mount-local-approval.test.ts
@@ -49,6 +49,7 @@ describe('LocalMountBackend.create — agent-driven approval', () => {
       isScoop: () => false,
       toolContext: { onUpdate, toolName: 'mount', toolCallId: 't1' },
       isExtension: false,
+      targetPath: '/workspace/mnt/test',
     });
 
     // Yield once so the synchronous `showToolUI` registers + emits.
@@ -76,6 +77,7 @@ describe('LocalMountBackend.create — agent-driven approval', () => {
       isScoop: () => false,
       toolContext: { onUpdate, toolName: 'mount', toolCallId: 't2' },
       isExtension: false,
+      targetPath: '/workspace/mnt/test',
     });
     // Make sure showToolUI registered before we advance time, otherwise
     // `waitForMount` would not yet have its waiter installed.
@@ -106,8 +108,30 @@ describe('LocalMountBackend.create — agent-driven approval', () => {
         isScoop: () => true,
         toolContext: { onUpdate, toolName: 'mount', toolCallId: 't3' },
         isExtension: false,
+        targetPath: '/workspace/mnt/test',
       })
     ).rejects.toThrow(/cannot mount local directories from a scoop/);
     expect(updates).toHaveLength(0);
+  });
+
+  it('includes the target path in the rendered approval card', async () => {
+    const updates: CapturedToolUI[] = [];
+    const onUpdate = captureToolUI(updates);
+
+    const pending = LocalMountBackend.create({
+      mountId: 'm4',
+      isScoop: () => false,
+      toolContext: { onUpdate, toolName: 'mount', toolCallId: 't4' },
+      isExtension: false,
+      targetPath: '/workspace/mnt/docs',
+    });
+
+    await Promise.resolve();
+    expect(updates).toHaveLength(1);
+    expect(updates[0].html).toContain('Target: /workspace/mnt/docs');
+
+    toolUIRegistry.markMounted(updates[0].requestId);
+    await toolUIRegistry.handleAction(updates[0].requestId, { action: 'deny', data: undefined });
+    await expect(pending).rejects.toThrow(/mount: denied by user/);
   });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/picker-approval.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/picker-approval.test.ts
@@ -68,6 +68,29 @@ describe('buildApprovalCardHtml', () => {
     expect(match).not.toBeNull();
     expect(JSON.parse(match![1])).toEqual({ filters });
   });
+
+  it('renders a Target meta line when targetPath is supplied for the directory kind', () => {
+    const html = buildApprovalCardHtml('directory', [], '/workspace/mnt/docs');
+    expect(html).toContain('sprinkle-action-card__meta');
+    expect(html).toContain('Target: /workspace/mnt/docs');
+  });
+
+  it('omits the meta line when targetPath is not supplied', () => {
+    const html = buildApprovalCardHtml('directory');
+    expect(html).not.toContain('sprinkle-action-card__meta');
+  });
+
+  it('escapes HTML-special characters in targetPath', () => {
+    const html = buildApprovalCardHtml('directory', [], '/workspace/<mnt>&"docs"');
+    expect(html).toContain('Target: /workspace/&lt;mnt&gt;&amp;&quot;docs&quot;');
+    expect(html).not.toContain('<mnt>');
+  });
+
+  it('ignores targetPath for non-directory kinds', () => {
+    const html = buildApprovalCardHtml('usb-device', [], '/workspace/mnt/docs');
+    expect(html).not.toContain('sprinkle-action-card__meta');
+    expect(html).not.toContain('/workspace/mnt/docs');
+  });
 });
 
 describe('runDevicePickerApproval', () => {

--- a/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller.test.ts
@@ -1311,11 +1311,15 @@ describe('WcChatController render-failure degradation', () => {
 });
 
 describe('WcChatController readOnlyToolUi (tray follower tool_ui rendering)', () => {
-  // Mirrors buildApprovalCardHtml('directory') from picker-approval.ts —
-  // the real card the mount tool broadcasts to followers via `tool_ui`.
+  // Mirrors buildApprovalCardHtml('directory', [], targetPath) from
+  // picker-approval.ts — the real card the mount tool broadcasts to
+  // followers via `tool_ui`, including the nested target-path meta line.
   const MOUNT_APPROVAL_HTML = `
     <div class="sprinkle-action-card">
-      <div class="sprinkle-action-card__header">Mount local directory <span class="sprinkle-badge sprinkle-badge--notice">approval</span></div>
+      <div class="sprinkle-action-card__header">
+        <div class="sprinkle-action-card__title-group">Mount local directory<div class="sprinkle-action-card__meta">Target: /workspace/mnt/docs</div></div>
+        <span class="sprinkle-badge sprinkle-badge--notice">approval</span>
+      </div>
       <div class="sprinkle-action-card__actions">
         <button class="sprinkle-btn sprinkle-btn--secondary" data-action="deny">Deny</button>
         <button class="sprinkle-btn sprinkle-btn--primary" data-action="approve" data-picker="directory">Select directory</button>
@@ -1372,6 +1376,11 @@ describe('WcChatController readOnlyToolUi (tray follower tool_ui rendering)', ()
     // resolve the leader's own pending approval anyway.
     expect(iframe?.srcdoc).not.toContain('data-action="approve"');
     expect(iframe?.srcdoc).not.toContain('data-action="deny"');
+    // The mount target path is nested inside the header's meta line —
+    // the placeholder must show only the title, never the leaked path,
+    // and must not mash the two together.
+    expect(iframe?.srcdoc).not.toContain('/workspace/mnt/docs');
+    expect(iframe?.srcdoc).not.toContain('Mount local directoryTarget:');
     expect(onToolUiAction).not.toHaveBeenCalled();
   });
 

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -243,7 +243,10 @@ describe('mountWcUiFollower', () => {
       toolName: 'bash',
       requestId: 'req-1',
       html: `<div class="sprinkle-action-card">
-        <div class="sprinkle-action-card__header">Mount local directory <span class="sprinkle-badge sprinkle-badge--notice">approval</span></div>
+        <div class="sprinkle-action-card__header">
+          <div class="sprinkle-action-card__title-group">Mount local directory<div class="sprinkle-action-card__meta">Target: /workspace/mnt/docs</div></div>
+          <span class="sprinkle-badge sprinkle-badge--notice">approval</span>
+        </div>
         <div class="sprinkle-action-card__actions">
           <button class="sprinkle-btn sprinkle-btn--secondary" data-action="deny">Deny</button>
           <button class="sprinkle-btn sprinkle-btn--primary" data-action="approve" data-picker="directory">Select directory</button>
@@ -257,6 +260,10 @@ describe('mountWcUiFollower', () => {
     expect(iframe?.srcdoc).toContain('Waiting for approval on the leader');
     expect(iframe?.srcdoc).not.toContain('data-action="approve"');
     expect(iframe?.srcdoc).not.toContain('data-action="deny"');
+    // The mount target path must not leak to the follower placeholder,
+    // and the title must not mash together with the meta text.
+    expect(iframe?.srcdoc).not.toContain('/workspace/mnt/docs');
+    expect(iframe?.srcdoc).not.toContain('Mount local directoryTarget:');
   });
 
   it('replaces the inert Files/Terminal/Memory/Monitor panels with a placeholder (no local VFS/shell/kernel)', async () => {


### PR DESCRIPTION
## Summary

  The "Mount local directory" approval card (shown when the cone runs `mount <target>` and needs the user to pick a folder) now shows the resolved destination VFS path — e.g. `Target: /workspace/mnt/docs` — before the user approves and picks a folder. Previously the destination was only revealed after approval, in
  the command's success message.

  ## Why

  Users approving a cone-initiated `mount` had no way to confirm where the mount would land until after they'd already granted folder access and picked a directory. The destination path is already resolved from the command argument before the picker ever runs, so it can be surfaced up front.

  ## Approach / Implementation notes

  - `targetPath` is threaded through the existing call chain rather than introduced as new state: `MountCommands.mountLocal` (already has it resolved) → `LocalMountBackend.create()` (now a required option) → `acquireHandleViaToolUI()` → `buildApprovalCardHtml('directory', [], targetPath)`.
  - Only the `'directory'` picker kind renders the new line; `usb-device` / `serial-port` / `hid-device` cards are untouched — they have no VFS destination concept.
  - Added a local `escapeHtml()` in `picker-approval.ts` rather than importing one from `shell/mcp/apps.ts` / `ui/message-renderer.ts` / `wc-chat-controller.ts` — no canonical shared escaper exists in the package; each module keeps its own copy by established convention.
  - Follow-up fix in the same branch: the `.sprinkle-action-card__meta` CSS class is documented as a header *subtitle*, not a card-level sibling. My first pass rendered it outside the header (unpadded, visually disconnected — confirmed via manual smoke test). Fixed by wrapping title + meta in a new
  `.sprinkle-action-card__title-group` flex column nested inside the header.

  ## Cross-cutting impact

  - **Floats exercised**: CLI (standalone) — built + manually smoke-tested via `npm run dev:standalone:fresh -- --prompt "mount <path>"`. Extension, Electron, and hosted-leader/cloud share the exact same cone + `wc-live.ts` boot path (`attachWcClient` → `wireWcSprinkles` → loads `sprinkle-components.css`), so no
  float-specific styling gap — not separately smoke-tested, but no code path diverges.
  - **Followers (secondary connected browsers / cherry side panel)**: will **not** show the new Target line. `wc-chat-controller.ts`'s `buildReadOnlyToolUiHtml()` strips every broadcast `tool_ui` card down to title + a generic "Waiting for approval on the leader…" placeholder — true for this card before this PR and
  for every other picker-approval card (usb/serial/hid) today. Followers can't click Approve/Deny anyway (`readOnlyToolUi: true`), so there's nothing actionable for them to do with the path. Not a regression introduced here.
  - **Other callers of `buildApprovalCardHtml`**: `runDevicePickerApproval` (usb/serial/hid) calls it with two args; the new third parameter is optional and defaults to omitting the meta line, so that call site is unaffected.
  - **Security**: `targetPath` is escaped via a new local `escapeHtml()` before interpolation (it's a VFS path that could theoretically contain `<`/`&`/`"` if a directory is named that way).

  ## Test plan

  - [x] `npx prettier --write <changed-files>` — handled by the repo's lint-staged pre-commit hook on every commit
  - [x] `npm run typecheck` — pre-existing unrelated errors only (missing `@earendil-works/pi-ai/compat`, `xterm-readline`, `nanotar`, `@ai-ecoverse/spoon`, etc. — a stale/incomplete local `node_modules`, not present in this diff's files). Verified via `grep` that **zero** typecheck errors reference
  `mount-commands.ts`, `backend-local.ts`, or `picker-approval.ts`.
  - [x] `npm run test` — full webapp suite hit widespread pre-existing failures in this environment unrelated to this diff (confirmed no touched file is imported by any failing test file; see Pre-existing failures below). Scoped run is clean:
    - `npm run test -w @slicc/webapp -- fs/mount fs/mount-commands.test.ts shell/supplemental-commands/picker-approval.test.ts` — **16 files, 225 tests passing**, no failures.
  - [x] `npm run build` — ran `-w @slicc/webapp` and `-w @slicc/node-server` individually (the two packages needed for local UI verification); both succeed.
  - [x] `npm run build -w @slicc/chrome-extension` — succeeds.
  - [x] **New / changed behavior is covered by a unit test**:
    - `packages/webapp/tests/shell/supplemental-commands/picker-approval.test.ts` — meta-line rendering, omission, HTML-escaping, non-directory-kind no-op
    - `packages/webapp/tests/fs/mount/mount-local-approval.test.ts` — target path reaches the rendered card via `LocalMountBackend.create()`
    - `packages/webapp/tests/fs/mount-commands.test.ts` — end-to-end: `MountCommands.mountLocal` → card contains `Target: <path>`
  - [x] Manual smoke (CLI): `npm run dev:standalone:fresh — confirmed the card renders `Target: /tmp/mount-test-target` with correct spacing/color inside the header.
  - [ ] Manual smoke (extension): not performed this round — no code path diverges (see Cross-cutting impact), but not independently verified in the extension shell.
  - [ ] Manual smoke (Electron / Sliccstart / worker) — not performed; same reasoning as extension.
  - [ ] **UI change?** No screencast attached — this was a manual interactive smoke test (picker/keychain prompts require a human at the keyboard), not recorded. Happy to record one with the `demo-recording` skill if required before merge.

  **Pre-existing failures** (verified against `origin/main` at `62ae9919e`, unrelated to this PR):

  - `npm run typecheck` and `npm run test -w @slicc/webapp` (full suite) both show pre-existing breakage in this local environment (missing/mismatched `node_modules` for `@earendil-works/pi-ai/compat` and others; widespread unrelated test-file failures such as `wc-follower.test.ts`, `restricted-fs-sync.test.ts`,
  `context-compaction.test.ts`). None of the failing files import `mount-commands.ts`, `backend-local.ts`, or `picker-approval.ts` (confirmed via `grep`). Root cause looks environmental (this sandbox), not something this PR introduced.

  ## Documentation

  - [ ] `README.md` (user-facing behavior) — no user-facing docs describe the approval-card contents; not updated.
  - [ ] Relevant `CLAUDE.md` (developer / package architecture) — no architectural change, just an added field/param; not updated.
  - [ ] `docs/` (agent reference: tools, commands, skills, patterns) — no shell-command surface change.
  - [ ] `packages/vfs-root/shared/CLAUDE.md` or SKILL.md — no shell-command behavior change (the `mount` command's usage/output is unchanged; only the approval card gained a display line).
  - [x] No documentation changes needed

  ## Risk & rollback
  
  - Blast radius is small and localized: only the cone-driven local-directory mount approval card changes shape. `LocalMountBackend.create()`'s `targetPath` option is now required, but it has exactly one production caller (`mount-commands.ts`), already updated in this PR.
  - No persisted state, no migration, no feature flag — this is a pure rendering + parameter-threading change.
  - Rollback: revert this PR's commits cleanly (no follow-up needed to undo any persisted state).
  - Nothing here needs manual reviewer verification beyond what's already covered above — no OAuth, keychain, or CDP-timing-sensitive behavior was touched.

  ## Checklist

  - [x] Commits are focused and package-local where possible (4 commits: render → thread through backend → thread through command → header-nesting fix)
  - [x] No hand-edited files under `dist/`
  - [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
  - [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs — N/A, no public contract changed (internal `buildApprovalCardHtml` / `LocalMountBackend.create` signatures only)
  - [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths — see Cross-cutting impact (follower placeholder behavior confirmed unaffected/pre-existing)

  Copy the block above into your PR description.