### PR TITLE
test(webapp): de-flake wc-settings dialog tests (generous waitFor budget)

### DIFF
--- a/packages/webapp/tests/ui/wc/wc-settings.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-settings.test.ts
@@ -18,6 +18,16 @@ import {
   showWcSettings,
 } from '../../../src/ui/wc/wc-settings.js';
 
+// De-flake (release run 29453098737 failed here): under the full-monorepo
+// `npm run test` (11k+ tests in parallel), showWcSettings' async dynamic
+// imports + the <slicc-dialog> custom-element mount occasionally exceed
+// vi.waitFor's default 1s window, timing out `openDialog` ("expected null to be
+// truthy" / 5s test timeout). The dialog DOES mount — just slower under load —
+// so give the DOM-appearance polls a generous budget and the file more test
+// headroom. Scoped per-package CI (low concurrency) never hit this.
+vi.setConfig({ testTimeout: 15000 });
+const WAIT_FOR = { timeout: 5000, interval: 25 } as const;
+
 /** Find the "Show timestamps" checkbox by its sibling label, if present. */
 function findTimestampToggle(dialog: HTMLElement): HTMLInputElement | null {
   const label = [...dialog.querySelectorAll('label')].find(
@@ -37,7 +47,7 @@ function seedAccounts(accounts: unknown[]): void {
 async function openDialog(): Promise<HTMLElement> {
   await vi.waitFor(() => {
     expect(document.querySelector('slicc-dialog')).toBeTruthy();
-  });
+  }, WAIT_FOR);
   return document.querySelector('slicc-dialog') as HTMLElement;
 }
 
@@ -140,7 +150,7 @@ describe('showWcSettings', () => {
     remove?.click();
     await vi.waitFor(() => {
       expect(dialog.textContent).toContain('No accounts configured.');
-    });
+    }, WAIT_FOR);
 
     clickDone(dialog);
     await expect(result).resolves.toBe(true);
@@ -173,7 +183,7 @@ describe('showWcSettings', () => {
     save?.click();
     await vi.waitFor(() => {
       expect(dialog.textContent).toContain('Test Provider connected.');
-    });
+    }, WAIT_FOR);
     expect(
       JSON.parse(localStorage.getItem('slicc_accounts') ?? '[]').some(
         (a: { providerId: string }) => a.providerId === 'test-provider'
@@ -207,7 +217,7 @@ describe('showWcSettings', () => {
       keyInput.value = 'sk-new-key-123456';
       [...dialog.querySelectorAll('button')].find((b) => b.textContent === 'Save')?.click();
 
-      await vi.waitFor(() => expect(changes).toHaveLength(1));
+      await vi.waitFor(() => expect(changes).toHaveLength(1), WAIT_FOR);
       clickDone(dialog);
       await result;
       // The dialog close re-renders nothing new, so no extra announcement.


### PR DESCRIPTION
## Why

The **Release** run on `main` (`29453098737`, triggered by the #1508 merge) failed at the `npm run test` gate — **2 failures, both in `packages/webapp/tests/ui/wc/wc-settings.test.ts`**, out of 11,109 tests. Both came from the `openDialog()` helper:

```
await vi.waitFor(() => expect(document.querySelector('slicc-dialog')).toBeTruthy());
```

→ `AssertionError: expected null to be truthy` / `Test timed out in 5000ms`.

**Root cause is a load-sensitive flake, not a regression.** `showWcSettings` mounts the `<slicc-dialog>` custom element *after* async dynamic imports; under the release's full-monorepo `npm run test` (11k+ tests in parallel) that mount occasionally exceeds `vi.waitFor`'s **default 1s** window. Evidence:
- `wc-settings.test.ts` last changed 2026-07-09 (unrelated refactor); #1508 only touched cone-memory files and merely *triggered* this release.
- The prior release (#1520, identical UI code) passed these same tests.
- The scoped per-package `webapp` CI job (low concurrency) never reproduced it.

## Fix (test-only)

- A shared `WAIT_FOR = { timeout: 5000, interval: 25 }` applied to **all four** `vi.waitFor` polls in the file (dialog appearance + post-interaction state).
- File-level `vi.setConfig({ testTimeout: 15000 })` so a slow poll under load can't hit the 5s test timeout mid-wait.

The dialog *does* mount correctly — this only gives it room under contention. No product code changes.

## Verification
- `wc-settings.test.ts`: **11/11 pass** (incl. the two that flaked).
- Browser typecheck 0 errors; biome + prettier clean; boy-scout gate clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)