### PR TITLE
fix(chrome-extension): dedup handoff toasts across SW evictions and fix notification clicks

### DIFF
--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -44,7 +44,14 @@ Side-panel cockpit (sidepanel.html + sidepanel-entry.ts)
   `externally_connectable`, pass-through proxies `chrome.debugger`
   through `bridge-sw.ts`, hosts the secret-aware fetch proxy and the
   S3/DA mount sign-and-forward backends, and surfaces SLICC handoff
-  notifications observed via `webRequest`.
+  notifications observed via `webRequest`. The toast names the payload
+  (upskill repo + skill path, or the handoff instruction) and is deduped
+  per fingerprint in `chrome.storage.session`, so a site-wide `Link` rel
+  does not re-toast after MV3 evicts and respawns the worker; the lick
+  forward to the leader is never gated by that dedup. Notification
+  clicks match on the `slicc-handoff-` id prefix (no in-memory id set),
+  so a click landing after an eviction still clears the badge and
+  focuses the leader tab.
 - **Side-panel cockpit** (`sidepanel.html` + `src/sidepanel-entry.ts`):
   on-demand `chrome.sidePanel` surface that iframes the hosted ui-only
   cherry follower (`?cherry=1&ui-only=1`) and runs the tri-state
@@ -161,7 +168,7 @@ engine or VFS.
 
 ## Key Files
 
-- `src/service-worker.ts` — MV3 background bridge + leader-tab lifecycle + secret-aware fetch proxy + handoff notifications
+- `src/service-worker.ts` — MV3 background bridge + leader-tab lifecycle + secret-aware fetch proxy + handoff notifications (payload-naming toast, session-persisted dedup)
 - `src/bridge-sw.ts` — `externally_connectable` Port handler that pass-through-proxies CDP to `chrome.debugger`. `cdpGetTargets` marks the `lastFocusedWindow` active tab so `playwright list-tabs` shows ` (active)` and cherry prompts can resolve "this page".
 - `src/sidepanel-entry.ts` — side-panel host controller (bundled to `dist/extension/sidepanel.js`): mounts the ui-only cherry follower iframe and drives the tri-state UI over a `cherry-panel` Port
 - `src/cherry-panel-sw.ts` — SW-side `cherry-panel` Port hub: tracks panel ports, caches/persists the tri-state (`chrome.storage.session`), and recovers a dead-tray leader

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -45,13 +45,17 @@ Side-panel cockpit (sidepanel.html + sidepanel-entry.ts)
   through `bridge-sw.ts`, hosts the secret-aware fetch proxy and the
   S3/DA mount sign-and-forward backends, and surfaces SLICC handoff
   notifications observed via `webRequest`. The toast names the payload
-  (upskill repo + skill path, or the handoff instruction) and is deduped
-  per fingerprint in `chrome.storage.session`, so a site-wide `Link` rel
-  does not re-toast after MV3 evicts and respawns the worker; the lick
-  forward to the leader is never gated by that dedup. Notification
-  clicks match on the `slicc-handoff-` id prefix (no in-memory id set),
-  so a click landing after an eviction still clears the badge and
-  focuses the leader tab.
+  (upskill repo + skill path, or the handoff instruction), attributes it
+  to the advertising page's origin, and collapses control characters in
+  the attacker-supplied instruction so the prose can't pose as extension
+  speech. It is deduped per fingerprint in `chrome.storage.session`
+  (capped at 100, oldest dropped; the write-back is skipped when the
+  read failed), so a site-wide `Link` rel does not re-toast after MV3
+  evicts and respawns the worker; the lick forward to the leader is
+  never gated by that dedup. Notification clicks match on the
+  `slicc-handoff-` id prefix (ids carry a sequence suffix so
+  same-millisecond toasts don't collide), so a click landing after an
+  eviction still clears the badge and focuses the leader tab.
 - **Side-panel cockpit** (`sidepanel.html` + `src/sidepanel-entry.ts`):
   on-demand `chrome.sidePanel` surface that iframes the hosted ui-only
   cherry follower (`?cherry=1&ui-only=1`) and runs the tri-state

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -510,36 +510,68 @@ async function addToSliccGroup(tabId: number): Promise<void> {
 const HANDOFF_NOTIFICATION_ID_PREFIX = 'slicc-handoff-';
 const HANDOFF_INSTRUCTION_SNIPPET_MAX = 150;
 
+// Distinguishes ids minted within the same millisecond — chrome.notifications
+// treats create() with an existing id as an update, which would replace the
+// earlier toast before the user sees it.
+let handoffNotificationSeq = 0;
+
 function truncateInstruction(text: string): string {
   if (text.length <= HANDOFF_INSTRUCTION_SNIPPET_MAX) return text;
   return `${text.slice(0, HANDOFF_INSTRUCTION_SNIPPET_MAX - 1)}…`;
 }
 
-function handoffNotificationContent(match: HandoffMatch): { title: string; message: string } {
+// The instruction is attacker prose from the page's Link header; RFC 8187
+// decoding can smuggle newlines/control characters that reshape the OS toast
+// into something that reads as extension speech. Collapse them to spaces.
+const CONTROL_CHARS_RE = new RegExp(
+  `[${String.fromCharCode(0)}-${String.fromCharCode(31)}${String.fromCharCode(127)}]+`,
+  'g'
+);
+
+function sanitizeInstruction(text: string): string {
+  return text.replace(CONTROL_CHARS_RE, ' ');
+}
+
+// Attribute the toast prose to the page that advertised it, so it never
+// reads as a message from the extension itself.
+function handoffSourceLabel(sourceUrl: string): string {
+  try {
+    const origin = new URL(sourceUrl).origin;
+    return origin === 'null' ? 'A page' : origin;
+  } catch {
+    return 'A page';
+  }
+}
+
+function handoffNotificationContent(
+  match: HandoffMatch,
+  sourceUrl: string
+): { title: string; message: string } {
+  const source = handoffSourceLabel(sourceUrl);
   if (match.verb === 'upskill') {
     const repo = match.target.replace(/^https?:\/\//, '');
     const skill = match.path ? `${repo} (${match.path})` : repo;
     return {
       title: 'Slicc skill available',
-      message: `Site offers a skill: ${skill}. Click to open the Slicc leader tab.`,
+      message: `${source} offers a skill: ${skill}. Click to open the Slicc leader tab.`,
     };
   }
   return {
     title: 'Slicc handoff received',
     message: match.instruction
-      ? `${truncateInstruction(match.instruction)} — click to open the Slicc leader tab.`
-      : 'Click to open the Slicc leader tab and process the handoff.',
+      ? `${source} asks: ${truncateInstruction(sanitizeInstruction(match.instruction))} — click to open the Slicc leader tab.`
+      : `${source} sent a handoff. Click to open the Slicc leader tab.`,
   };
 }
 
-function showHandoffNotification(match: HandoffMatch): void {
-  const notificationId = `${HANDOFF_NOTIFICATION_ID_PREFIX}${Date.now()}`;
+function showHandoffNotification(match: HandoffMatch, sourceUrl: string): void {
+  const notificationId = `${HANDOFF_NOTIFICATION_ID_PREFIX}${Date.now()}-${handoffNotificationSeq++}`;
   chrome.action.setBadgeText({ text: '!' });
   chrome.action.setBadgeBackgroundColor({ color: '#ff5f72' });
   chrome.notifications.create(notificationId, {
     type: 'basic',
     iconUrl: 'logos/sliccy-color-1scoops-128x128.png',
-    ...handoffNotificationContent(match),
+    ...handoffNotificationContent(match, sourceUrl),
   });
 }
 
@@ -587,9 +619,9 @@ const HANDOFF_NOTIFIED_FINGERPRINTS_MAX = 100;
 // sightings of different fingerprints can't clobber each other's write-back.
 let handoffNotifyChain: Promise<void> = Promise.resolve();
 
-function queueHandoffNotification(fingerprint: string, match: HandoffMatch): void {
+function queueHandoffNotification(fingerprint: string, match: HandoffMatch, url: string): void {
   handoffNotifyChain = handoffNotifyChain
-    .then(() => notifyHandoffOncePerSession(fingerprint, match))
+    .then(() => notifyHandoffOncePerSession(fingerprint, match, url))
     .catch((err) => {
       console.warn('[slicc-sw] handoff notification dedup failed', err);
     });
@@ -597,9 +629,11 @@ function queueHandoffNotification(fingerprint: string, match: HandoffMatch): voi
 
 async function notifyHandoffOncePerSession(
   fingerprint: string,
-  match: HandoffMatch
+  match: HandoffMatch,
+  url: string
 ): Promise<void> {
   let stored: string[] = [];
+  let readOk = true;
   try {
     const result = await chrome.storage.session.get(HANDOFF_NOTIFIED_FINGERPRINTS_KEY);
     const value = result[HANDOFF_NOTIFIED_FINGERPRINTS_KEY];
@@ -607,10 +641,14 @@ async function notifyHandoffOncePerSession(
   } catch (err) {
     // Storage read failure → fall back to in-memory-only dedup for this one.
     console.warn('[slicc-sw] handoff fingerprint read failed', err);
+    readOk = false;
   }
   for (const seen of stored) notifiedHandoffFingerprints.add(seen);
   if (stored.includes(fingerprint)) return;
-  showHandoffNotification(match);
+  showHandoffNotification(match, url);
+  // Skip the write-back when the read failed — writing the fallback list
+  // would replace every previously persisted fingerprint with this one.
+  if (!readOk) return;
   stored.push(fingerprint);
   await chrome.storage.session.set({
     [HANDOFF_NOTIFIED_FINGERPRINTS_KEY]: stored.slice(-HANDOFF_NOTIFIED_FINGERPRINTS_MAX),
@@ -661,7 +699,7 @@ chrome.webRequest.onHeadersReceived.addListener(
         // Leader may not be listening yet — best effort.
       });
     };
-    if (!alreadyNotified) queueHandoffNotification(fingerprint, match);
+    if (!alreadyNotified) queueHandoffNotification(fingerprint, match, details.url);
     if (tabId >= 0) {
       chrome.tabs
         .get(tabId)

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -44,6 +44,7 @@ import type {
 import { LEADER_EXT_ID_QUERY_NAME } from '../../webapp/src/kernel/messages.js';
 import {
   extractHandoffFromWebRequest,
+  type HandoffMatch,
   handoffFingerprint,
 } from '../../webapp/src/net/handoff-link.js';
 import {
@@ -506,23 +507,47 @@ async function addToSliccGroup(tabId: number): Promise<void> {
 // hosted leader tab on notification click (user gesture required).
 // ---------------------------------------------------------------------------
 
-const handoffNotificationIds = new Set<string>();
+const HANDOFF_NOTIFICATION_ID_PREFIX = 'slicc-handoff-';
+const HANDOFF_INSTRUCTION_SNIPPET_MAX = 150;
 
-function showHandoffNotification(): void {
-  const notificationId = `slicc-handoff-${Date.now()}`;
-  handoffNotificationIds.add(notificationId);
+function truncateInstruction(text: string): string {
+  if (text.length <= HANDOFF_INSTRUCTION_SNIPPET_MAX) return text;
+  return `${text.slice(0, HANDOFF_INSTRUCTION_SNIPPET_MAX - 1)}…`;
+}
+
+function handoffNotificationContent(match: HandoffMatch): { title: string; message: string } {
+  if (match.verb === 'upskill') {
+    const repo = match.target.replace(/^https?:\/\//, '');
+    const skill = match.path ? `${repo} (${match.path})` : repo;
+    return {
+      title: 'Slicc skill available',
+      message: `Site offers a skill: ${skill}. Click to open the Slicc leader tab.`,
+    };
+  }
+  return {
+    title: 'Slicc handoff received',
+    message: match.instruction
+      ? `${truncateInstruction(match.instruction)} — click to open the Slicc leader tab.`
+      : 'Click to open the Slicc leader tab and process the handoff.',
+  };
+}
+
+function showHandoffNotification(match: HandoffMatch): void {
+  const notificationId = `${HANDOFF_NOTIFICATION_ID_PREFIX}${Date.now()}`;
   chrome.action.setBadgeText({ text: '!' });
   chrome.action.setBadgeBackgroundColor({ color: '#ff5f72' });
   chrome.notifications.create(notificationId, {
     type: 'basic',
     iconUrl: 'logos/sliccy-color-1scoops-128x128.png',
-    title: 'Slicc handoff received',
-    message: 'Click to open the Slicc leader tab and process the handoff.',
+    ...handoffNotificationContent(match),
   });
 }
 
 chrome.notifications.onClicked.addListener((notificationId: string) => {
-  if (!handoffNotificationIds.delete(notificationId)) return;
+  // Deterministic prefix check instead of an in-memory id set: MV3 can evict
+  // the worker between showing the notification and the click, and a respawned
+  // worker would not recognize ids minted by its predecessor.
+  if (!notificationId.startsWith(HANDOFF_NOTIFICATION_ID_PREFIX)) return;
   chrome.action.setBadgeText({ text: '' });
   focusLeaderTab().catch(() => {});
 });
@@ -534,22 +559,63 @@ chrome.notifications.onClicked.addListener((notificationId: string) => {
 
 /**
  * Payload fingerprints of handoffs whose OS notification has already been
- * shown this service-worker lifetime. A site can advertise the same SLICC
- * `Link` rel on every page response; without this guard each navigation
+ * shown. A site can advertise the same SLICC `Link` rel on every page
+ * response (e.g. a site-wide upskill); without this guard each navigation
  * re-shows the toast.
  *
- * IMPORTANT: this set gates ONLY the notification — never the forward. The
+ * Two layers: the in-memory set is the synchronous fast path within one
+ * worker lifetime (a sighting is added before any await, so a burst of
+ * navigations can't race past it). `chrome.storage.session` carries the set
+ * across MV3 evictions — deliberately the same browser-session lifetime as
+ * the receiver-side `seenNavigateFingerprints` dedup in the webapp's
+ * LickManager. The stored list is capped; oldest entries drop first.
+ *
+ * IMPORTANT: this gates ONLY the notification — never the forward. The
  * forward (an `extension.lick` envelope over the welcomed leader Port(s), plus
  * the legacy `chrome.runtime.sendMessage` fallback) is best-effort and
  * silently drops when no port is welcomed yet (e.g. the leader tab still
  * booting). If we suppressed the forward on "seen", a first delivery that was
  * dropped before the leader was ready would lose the handoff permanently. So
- * we always forward and let the receiver dedup the cone turn. MV3 may evict
- * and respawn the worker, resetting this set — an accepted limitation of
- * the in-memory design (a repeat toast can appear once after eviction).
+ * we always forward and let the receiver dedup the cone turn.
  * See {@link handoffFingerprint}.
  */
 const notifiedHandoffFingerprints = new Set<string>();
+const HANDOFF_NOTIFIED_FINGERPRINTS_KEY = 'slicc_handoff_notified_fingerprints';
+const HANDOFF_NOTIFIED_FINGERPRINTS_MAX = 100;
+
+// Serializes the read-merge-write cycles below so two near-simultaneous
+// sightings of different fingerprints can't clobber each other's write-back.
+let handoffNotifyChain: Promise<void> = Promise.resolve();
+
+function queueHandoffNotification(fingerprint: string, match: HandoffMatch): void {
+  handoffNotifyChain = handoffNotifyChain
+    .then(() => notifyHandoffOncePerSession(fingerprint, match))
+    .catch((err) => {
+      console.warn('[slicc-sw] handoff notification dedup failed', err);
+    });
+}
+
+async function notifyHandoffOncePerSession(
+  fingerprint: string,
+  match: HandoffMatch
+): Promise<void> {
+  let stored: string[] = [];
+  try {
+    const result = await chrome.storage.session.get(HANDOFF_NOTIFIED_FINGERPRINTS_KEY);
+    const value = result[HANDOFF_NOTIFIED_FINGERPRINTS_KEY];
+    if (Array.isArray(value)) stored = value.filter((v): v is string => typeof v === 'string');
+  } catch (err) {
+    // Storage read failure → fall back to in-memory-only dedup for this one.
+    console.warn('[slicc-sw] handoff fingerprint read failed', err);
+  }
+  for (const seen of stored) notifiedHandoffFingerprints.add(seen);
+  if (stored.includes(fingerprint)) return;
+  showHandoffNotification(match);
+  stored.push(fingerprint);
+  await chrome.storage.session.set({
+    [HANDOFF_NOTIFIED_FINGERPRINTS_KEY]: stored.slice(-HANDOFF_NOTIFIED_FINGERPRINTS_MAX),
+  });
+}
 
 chrome.webRequest.onHeadersReceived.addListener(
   (details) => {
@@ -595,7 +661,7 @@ chrome.webRequest.onHeadersReceived.addListener(
         // Leader may not be listening yet — best effort.
       });
     };
-    if (!alreadyNotified) showHandoffNotification();
+    if (!alreadyNotified) queueHandoffNotification(fingerprint, match);
     if (tabId >= 0) {
       chrome.tabs
         .get(tabId)

--- a/packages/chrome-extension/tests/service-worker.test.ts
+++ b/packages/chrome-extension/tests/service-worker.test.ts
@@ -660,6 +660,70 @@ describe('extension service worker', () => {
     expect(chrome.action.setBadgeText).not.toHaveBeenCalledWith({ text: '' });
   });
 
+  it('mints distinct notification ids for two different handoffs in the same millisecond', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+    try {
+      fireHandoffSighting(UPSKILL_LINK_VALUE);
+      fireHandoffSighting(
+        '<https://github.com/other/repo>; rel="https://www.sliccy.ai/rel/upskill"'
+      );
+      await flushAsync();
+
+      const ids = notificationCreateCalls().map(([id]) => id);
+      expect(ids).toHaveLength(2);
+      expect(new Set(ids).size).toBe(2);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('collapses control characters in the handoff instruction before rendering the toast', async () => {
+    fireHandoffSighting(
+      `</>; rel="https://www.sliccy.ai/rel/handoff"; title*=UTF-8''Security%20alert%3A%0Are-authenticate%20now`,
+      'https://evil.example/page'
+    );
+    await flushAsync();
+
+    const [, options] = notificationCreateCalls()[0];
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: asserting control chars are stripped
+    expect(options.message).not.toMatch(/[\u0000-\u001f]/);
+    expect(options.message).toContain('Security alert: re-authenticate now');
+  });
+
+  it('attributes the handoff toast to the advertising page origin', async () => {
+    fireHandoffSighting(
+      '</>; rel="https://www.sliccy.ai/rel/handoff"; title="Do the thing"',
+      'https://example.com/deep/page?q=1'
+    );
+    await flushAsync();
+
+    const [, options] = notificationCreateCalls()[0];
+    expect(options.message).toContain('https://example.com');
+  });
+
+  it('attributes the upskill toast to the advertising page origin', async () => {
+    fireHandoffSighting(UPSKILL_LINK_VALUE, 'https://www.aem.live/docs/');
+    await flushAsync();
+
+    const [, options] = notificationCreateCalls()[0];
+    expect(options.message).toContain('https://www.aem.live');
+  });
+
+  it('does not clobber persisted fingerprints when the storage read fails', async () => {
+    const chrome = (
+      globalThis as typeof globalThis & { chrome: ReturnType<typeof createChromeMock> }
+    ).chrome;
+    sessionStorageState['slicc_handoff_notified_fingerprints'] = ['old-fingerprint'];
+    chrome.storage.session.get.mockRejectedValueOnce(new Error('transient'));
+
+    fireHandoffSighting(UPSKILL_LINK_VALUE);
+    await flushAsync();
+
+    expect(notificationCreateCalls()).toHaveLength(1);
+    const stored = sessionStorageState['slicc_handoff_notified_fingerprints'] as string[];
+    expect(stored).toContain('old-fingerprint');
+  });
+
   it('names the repo and skill path in the upskill toast', async () => {
     fireHandoffSighting(UPSKILL_LINK_VALUE);
     await flushAsync();

--- a/packages/chrome-extension/tests/service-worker.test.ts
+++ b/packages/chrome-extension/tests/service-worker.test.ts
@@ -685,7 +685,6 @@ describe('extension service worker', () => {
     await flushAsync();
 
     const [, options] = notificationCreateCalls()[0];
-    // biome-ignore lint/suspicious/noControlCharactersInRegex: asserting control chars are stripped
     expect(options.message).not.toMatch(/[\u0000-\u001f]/);
     expect(options.message).toContain('Security alert: re-authenticate now');
   });

--- a/packages/chrome-extension/tests/service-worker.test.ts
+++ b/packages/chrome-extension/tests/service-worker.test.ts
@@ -90,19 +90,25 @@ function createChromeMock() {
         remove: vi.fn(async () => undefined),
       },
       session: {
+        // Real chrome.storage serializes on both get and set — deep-copy here
+        // so tests can't pass via reference aliasing that real Chrome breaks.
         get: vi.fn(async (key?: string | string[] | null) => {
           if (typeof key === 'string') {
-            return key in sessionStorageState ? { [key]: sessionStorageState[key] } : {};
+            return key in sessionStorageState
+              ? { [key]: structuredClone(sessionStorageState[key]) }
+              : {};
           }
           if (Array.isArray(key)) {
             return Object.fromEntries(
-              key.filter((k) => k in sessionStorageState).map((k) => [k, sessionStorageState[k]])
+              key
+                .filter((k) => k in sessionStorageState)
+                .map((k) => [k, structuredClone(sessionStorageState[k])])
             );
           }
-          return { ...sessionStorageState };
+          return structuredClone(sessionStorageState);
         }),
         set: vi.fn(async (items: Record<string, unknown>) => {
-          Object.assign(sessionStorageState, items);
+          Object.assign(sessionStorageState, structuredClone(items));
         }),
         remove: vi.fn(async (key: string) => {
           delete sessionStorageState[key];
@@ -706,6 +712,35 @@ describe('extension service worker', () => {
 
     const [, options] = notificationCreateCalls()[0];
     expect(options.message).toContain('https://www.aem.live');
+  });
+
+  it('caps the persisted fingerprints at 100, dropping the oldest first', async () => {
+    sessionStorageState['slicc_handoff_notified_fingerprints'] = Array.from(
+      { length: 100 },
+      (_, i) => `fp-${i}`
+    );
+
+    fireHandoffSighting(UPSKILL_LINK_VALUE);
+    await flushAsync();
+
+    expect(notificationCreateCalls()).toHaveLength(1);
+    const stored = sessionStorageState['slicc_handoff_notified_fingerprints'] as string[];
+    expect(stored).toHaveLength(100);
+    expect(stored).not.toContain('fp-0');
+    expect(stored).toContain('fp-1');
+    expect(stored[99]).not.toMatch(/^fp-/);
+  });
+
+  it('persists both fingerprints when two different sightings land back-to-back', async () => {
+    // No flush between the sightings: the read-merge-write cycles overlap and
+    // must be serialized, or the second write-back clobbers the first.
+    fireHandoffSighting(UPSKILL_LINK_VALUE);
+    fireHandoffSighting('<https://github.com/other/repo>; rel="https://www.sliccy.ai/rel/upskill"');
+    await flushAsync();
+
+    expect(notificationCreateCalls()).toHaveLength(2);
+    const stored = sessionStorageState['slicc_handoff_notified_fingerprints'] as string[];
+    expect(stored).toHaveLength(2);
   });
 
   it('does not clobber persisted fingerprints when the storage read fails', async () => {

--- a/packages/chrome-extension/tests/service-worker.test.ts
+++ b/packages/chrome-extension/tests/service-worker.test.ts
@@ -25,6 +25,10 @@ type StorageChangedListener = (
 ) => void;
 const storageChangedListeners: StorageChangedListener[] = [];
 const runtimeSentMessages: unknown[] = [];
+// Backing state for the chrome.storage.session mock. Lives OUTSIDE the mock
+// object so tests can simulate an MV3 SW eviction/respawn: reset modules and
+// re-import the SW while this state (like real storage.session) survives.
+let sessionStorageState: Record<string, unknown> = {};
 // The SW registers TWO onHeadersReceived listeners: the handoff observer first,
 // then the silent discovery observer. `headersReceivedListener` keeps the FIRST
 // (handoff) one so these handoff tests exercise it; `headersReceivedListeners`
@@ -86,9 +90,23 @@ function createChromeMock() {
         remove: vi.fn(async () => undefined),
       },
       session: {
-        get: vi.fn(async () => ({})),
-        set: vi.fn(async () => undefined),
-        remove: vi.fn(async () => undefined),
+        get: vi.fn(async (key?: string | string[] | null) => {
+          if (typeof key === 'string') {
+            return key in sessionStorageState ? { [key]: sessionStorageState[key] } : {};
+          }
+          if (Array.isArray(key)) {
+            return Object.fromEntries(
+              key.filter((k) => k in sessionStorageState).map((k) => [k, sessionStorageState[k]])
+            );
+          }
+          return { ...sessionStorageState };
+        }),
+        set: vi.fn(async (items: Record<string, unknown>) => {
+          Object.assign(sessionStorageState, items);
+        }),
+        remove: vi.fn(async (key: string) => {
+          delete sessionStorageState[key];
+        }),
       },
       onChanged: {
         addListener: vi.fn((listener: StorageChangedListener) => {
@@ -148,6 +166,10 @@ function createChromeMock() {
     },
     tabGroups: {
       update: vi.fn(async () => undefined),
+    },
+    windows: {
+      create: vi.fn(async () => ({ id: 1 })),
+      update: vi.fn(async () => ({})),
     },
     debugger: {
       attach: vi.fn(),
@@ -240,6 +262,7 @@ describe('extension service worker', () => {
     MockWebSocket.instances.length = 0;
     headersReceivedListeners.length = 0;
     headersReceivedListener = null;
+    sessionStorageState = {};
     vi.clearAllMocks();
     vi.resetModules();
 
@@ -524,6 +547,156 @@ describe('extension service worker', () => {
 
     expect(chrome.tabs.update).toHaveBeenCalledWith(21, { active: true });
     expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '' });
+  });
+
+  // --- Handoff notification dedup + content -----------------------------------
+  // A site can serve the same SLICC Link rel on EVERY page response (e.g. the
+  // site-wide upskill on www.aem.live). The toast dedup must survive MV3 SW
+  // eviction (chrome.storage.session), while the lick forward must fire on
+  // every sighting regardless.
+
+  const UPSKILL_LINK_VALUE =
+    '<https://github.com/adobe/skills>; rel="https://www.sliccy.ai/rel/upskill"; branch=main; path="plugins/aem/edge-delivery-services"';
+
+  function fireHandoffSighting(linkValue: string, url = 'https://www.aem.live/docs/'): void {
+    headersReceivedListener!({
+      url,
+      tabId: 42,
+      responseHeaders: [{ name: 'Link', value: linkValue }],
+    });
+  }
+
+  /**
+   * Simulate an MV3 SW eviction + respawn: fresh module (in-memory sets are
+   * gone) against the SAME chrome mock, whose storage.session state survives
+   * via `sessionStorageState`.
+   */
+  async function respawnServiceWorker(): Promise<void> {
+    vi.resetModules();
+    await loadServiceWorker();
+  }
+
+  function notificationCreateCalls(): Array<[string, { title: string; message: string }]> {
+    const chrome = (
+      globalThis as typeof globalThis & { chrome: ReturnType<typeof createChromeMock> }
+    ).chrome;
+    return (chrome.notifications.create as ReturnType<typeof vi.fn>).mock.calls as Array<
+      [string, { title: string; message: string }]
+    >;
+  }
+
+  it('does not re-show the toast when the same fingerprint is sighted after a SW respawn', async () => {
+    fireHandoffSighting(UPSKILL_LINK_VALUE, 'https://www.aem.live/docs/');
+    await flushAsync();
+    expect(notificationCreateCalls()).toHaveLength(1);
+
+    await respawnServiceWorker();
+    fireHandoffSighting(UPSKILL_LINK_VALUE, 'https://www.aem.live/tutorial/');
+    await flushAsync();
+    expect(notificationCreateCalls()).toHaveLength(1);
+  });
+
+  it('shows a toast for a different fingerprint after a SW respawn', async () => {
+    fireHandoffSighting(UPSKILL_LINK_VALUE);
+    await flushAsync();
+    expect(notificationCreateCalls()).toHaveLength(1);
+
+    await respawnServiceWorker();
+    fireHandoffSighting('<https://github.com/other/repo>; rel="https://www.sliccy.ai/rel/upskill"');
+    await flushAsync();
+    expect(notificationCreateCalls()).toHaveLength(2);
+  });
+
+  it('forwards the navigate lick on every sighting, including deduped ones', async () => {
+    fireHandoffSighting(UPSKILL_LINK_VALUE, 'https://www.aem.live/docs/');
+    await flushAsync();
+    fireHandoffSighting(UPSKILL_LINK_VALUE, 'https://www.aem.live/tutorial/');
+    await flushAsync();
+    await respawnServiceWorker();
+    fireHandoffSighting(UPSKILL_LINK_VALUE, 'https://www.aem.live/blog/');
+    await flushAsync();
+
+    const licks = runtimeSentMessages.filter(
+      (m) => (m as { payload?: { type?: string } }).payload?.type === 'navigate-lick'
+    );
+    expect(licks).toHaveLength(3);
+    expect(notificationCreateCalls()).toHaveLength(1);
+  });
+
+  it('clears the badge and focuses the leader tab for a handoff notification id minted before a SW respawn', async () => {
+    const chrome = (
+      globalThis as typeof globalThis & { chrome: ReturnType<typeof createChromeMock> }
+    ).chrome;
+    sessionStorageState['slicc_leader_tab_id'] = 21;
+    chrome.tabs.get = vi.fn(async () => ({
+      id: 21,
+      windowId: 7,
+      url: 'https://www.sliccy.ai/?slicc=leader',
+      title: 'Slicc',
+    })) as never;
+    chrome.tabs.update = vi.fn(async () => ({})) as never;
+
+    const clickListener = (chrome.notifications.onClicked.addListener as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0] as (id: string) => void;
+    // Id minted by a previous SW lifetime — in no in-memory set of this one.
+    clickListener('slicc-handoff-1700000000000');
+    await flushAsync();
+    await flushAsync();
+
+    expect(chrome.tabs.update).toHaveBeenCalledWith(21, { active: true });
+    expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '' });
+  });
+
+  it('ignores notification clicks with non-handoff ids', async () => {
+    const chrome = (
+      globalThis as typeof globalThis & { chrome: ReturnType<typeof createChromeMock> }
+    ).chrome;
+    const clickListener = (chrome.notifications.onClicked.addListener as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0] as (id: string) => void;
+    clickListener('some-other-notification');
+    await flushAsync();
+
+    expect(chrome.tabs.update).not.toHaveBeenCalled();
+    expect(chrome.action.setBadgeText).not.toHaveBeenCalledWith({ text: '' });
+  });
+
+  it('names the repo and skill path in the upskill toast', async () => {
+    fireHandoffSighting(UPSKILL_LINK_VALUE);
+    await flushAsync();
+
+    const calls = notificationCreateCalls();
+    expect(calls).toHaveLength(1);
+    const [, options] = calls[0];
+    expect(options.title).toBe('Slicc skill available');
+    expect(options.message).toContain('github.com/adobe/skills');
+    expect(options.message).toContain('plugins/aem/edge-delivery-services');
+  });
+
+  it('includes the instruction in the handoff toast', async () => {
+    fireHandoffSighting(
+      '</>; rel="https://www.sliccy.ai/rel/handoff"; title="Summarize this page and file an issue"',
+      'https://example.com/page'
+    );
+    await flushAsync();
+
+    const calls = notificationCreateCalls();
+    expect(calls).toHaveLength(1);
+    const [, options] = calls[0];
+    expect(options.title).toBe('Slicc handoff received');
+    expect(options.message).toContain('Summarize this page and file an issue');
+  });
+
+  it('truncates a long handoff instruction in the toast', async () => {
+    const instruction = 'x'.repeat(300);
+    fireHandoffSighting(
+      `</>; rel="https://www.sliccy.ai/rel/handoff"; title="${instruction}"`,
+      'https://example.com/long'
+    );
+    await flushAsync();
+
+    const [, options] = notificationCreateCalls()[0];
+    expect(options.message).toContain('…');
+    expect(options.message).not.toContain('x'.repeat(200));
   });
 
   it('handles DA sign-and-forward by attaching the IMS bearer token', async () => {


### PR DESCRIPTION
## Summary

The handoff toast dedup now lives in `chrome.storage.session`, notification clicks work after a service-worker restart, and the toast names the advertising origin and payload. Before: a site that serves a SLICC `Link` rel on every page re-toasted after each MV3 eviction, and clicking an older toast did nothing. Now: one toast per payload per browser session, and every click clears the badge and focuses the leader tab.

## Why

www.aem.live serves a site-wide upskill `Link` header (github.com/adobe/skills). Both the toast dedup set and the notification id set were in-memory, and MV3 evicts the service worker after roughly 30 seconds idle. The code called a repeat toast after eviction an accepted limitation. A site-wide rel turns that into a recurring toast, and a dead click handler, for every user who reads EDS docs.

**Repro**

1. Load the extension and visit any www.aem.live page. A toast appears.
2. Idle 30+ seconds, then visit another www.aem.live page.
   Expected: no second toast. Actual: a new toast after every eviction.
3. Click a toast after an idle period.
   Expected: badge clears, leader tab focuses. Actual: nothing.

## Approach / Implementation notes

- Fingerprints persist under one new `chrome.storage.session` key, capped at 100 entries (oldest dropped). The in-memory set stays as a synchronous fast path and serializes concurrent sightings. A failed storage read skips the write-back, so a transient error cannot replace the persisted list.
- `chrome.storage.session` is wiped per browser session. This matches the receiver-side `seenNavigateFingerprints` lifetime in `lick-manager.ts`.
- The lick forward is untouched and still fires on every sighting, including deduped ones.
- `onClicked` matches the `slicc-handoff-` id prefix instead of set membership. Ids get a sequence suffix so two toasts in the same millisecond do not collide.
- Toast copy names the origin and payload ("www.aem.live offers a skill: github.com/adobe/skills (plugins/aem/edge-delivery-services)"). Control characters in the RFC 8187-decoded title are collapsed before truncation.

## Cross-cutting impact

- **Floats exercised**: Chrome extension only, service worker only. No shell contexts involved.
- The node-server CDP navigation watcher has no toast surface, so no peer change is needed.
- **Persisted state**: one new `chrome.storage.session` key. No migration.

## Verification

- `npm run lint`, `npm run typecheck`: pass.
- `npx vitest run packages/chrome-extension/tests/`: 502 passing.
- `npm run test:coverage:chrome-extension`: above floors (statements 83.19, branches 70.35, functions 76.76, lines 84.08).
- `npm run build -w @slicc/chrome-extension`: pass.
- Live test in Chrome 150 (unpacked, production origin): browsing www.aem.live across service-worker evictions shows one toast per browser session, the fingerprint is visible in `chrome.storage.session`, and a toast click clears the badge and focuses the leader tab.

## Documentation

- [x] `packages/chrome-extension/CLAUDE.md` (handoff notification behavior)

## Risk & rollback

Extension float only. Reverts cleanly; a leftover session-storage key is harmless.
