### PR TITLE
Add missing AGENTS.md symlinks, enforce via lint:docs, gitignore worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 /workspace/
 coverage/
 .worktrees/
+worktrees/
 .wrangler/
 .qa/
 artifacts/

--- a/package-lock.json
+++ b/package-lock.json
@@ -789,9 +789,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -809,9 +806,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -829,9 +823,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -849,9 +840,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1968,7 +1956,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2084,9 +2072,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2102,9 +2087,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2122,9 +2104,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2141,9 +2120,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2159,9 +2135,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6073,9 +6046,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6093,9 +6063,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6113,9 +6080,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6133,9 +6097,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6153,9 +6114,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6173,9 +6131,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -789,6 +789,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -806,6 +809,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -823,6 +829,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -840,6 +849,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1956,7 +1968,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2072,6 +2084,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2087,6 +2102,9 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2104,6 +2122,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2120,6 +2141,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2135,6 +2159,9 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6046,6 +6073,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6063,6 +6093,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6080,6 +6113,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6097,6 +6133,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6114,6 +6153,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6131,6 +6173,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "start:extension": "npm run build -w @slicc/chrome-extension && npm run dev -- --profile=extension",
     "lint": "biome check --write . && prettier --write . && npm run lint:docs && npm run lint:skills && npm run lint:no-innerhtml && npm run lint:no-ui-in-providers && npm run lint:patches && npm run lint:no-raw-chrome-runtime-id && npm run lint:hosted-origin",
     "lint:ci": "biome check . && prettier --check . && npm run lint:docs && npm run lint:skills -- --strict && npm run lint:no-innerhtml && npm run lint:no-ui-in-providers && npm run lint:patches && npm run lint:no-raw-chrome-runtime-id && npm run lint:hosted-origin",
-    "lint:docs": "node packages/dev-tools/tools/check-doc-sizes.mjs",
+    "lint:docs": "node packages/dev-tools/tools/check-doc-sizes.mjs && node packages/dev-tools/tools/check-agents-symlinks.mjs",
     "lint:skills": "node packages/dev-tools/tools/lint-skills.mjs",
     "lint:no-innerhtml": "node packages/dev-tools/tools/check-no-innerhtml.mjs",
     "lint:no-ui-in-providers": "node packages/dev-tools/tools/check-no-ui-imports-in-providers.mjs",

--- a/packages/cherry/AGENTS.md
+++ b/packages/cherry/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/cloud-core/AGENTS.md
+++ b/packages/cloud-core/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/dev-tools/tools/check-agents-symlinks.mjs
+++ b/packages/dev-tools/tools/check-agents-symlinks.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Enforce that every `packages/*\/CLAUDE.md` has a sibling `AGENTS.md`
+ * symlink that resolves to it.
+ *
+ * Background: `CLAUDE.md` is the developer-facing convention file read by
+ * Claude Code; `AGENTS.md` is the equivalent consumed by AGENTS.md-native
+ * tools (Codex, Cursor, Gemini CLI, etc.). Each package should carry both so
+ * no tool silently misses the package's conventions. The link is always the
+ * same relative target (`CLAUDE.md`) matching the established pattern used
+ * by packages that already have both files.
+ *
+ * What counts as a valid `AGENTS.md` symlink:
+ *  - The file exists at `<packageDir>/AGENTS.md`
+ *  - It is a symbolic link (not a plain file or directory)
+ *  - Its link target (as read by readlinkSync) is exactly `"CLAUDE.md"`
+ *
+ * The detection helpers are exported for unit testing; the filesystem scan
+ * runs only when this file is invoked as the entry script.
+ */
+import { lstatSync, readdirSync, readlinkSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { argv } from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const Filename = fileURLToPath(import.meta.url);
+export const repoRoot = resolve(dirname(Filename), '../../..');
+
+const PACKAGES_DIR = join(repoRoot, 'packages');
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Return true if `absPath` exists and is a symbolic link.
+ * @param {string} absPath
+ * @returns {boolean}
+ */
+export function isSymlink(absPath) {
+  try {
+    return lstatSync(absPath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return true if `absPath` is a symlink whose target is exactly `"CLAUDE.md"`.
+ * @param {string} absPath
+ * @returns {boolean}
+ */
+export function isValidAgentsSymlink(absPath) {
+  if (!isSymlink(absPath)) return false;
+  try {
+    return readlinkSync(absPath) === 'CLAUDE.md';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Given a list of package names under `packagesDir`, return an array of
+ * violation objects for every package that has a `CLAUDE.md` but is missing
+ * a valid `AGENTS.md -> CLAUDE.md` symlink.
+ *
+ * @param {string} packagesDir  Absolute path to the `packages/` directory.
+ * @param {string[]} pkgNames   Subdirectory names to inspect.
+ * @returns {{ pkg: string, claudeMd: string, agentsMd: string, reason: string }[]}
+ */
+export function findViolations(packagesDir, pkgNames) {
+  const violations = [];
+  for (const pkg of pkgNames) {
+    const claudeMd = join(packagesDir, pkg, 'CLAUDE.md');
+    const agentsMd = join(packagesDir, pkg, 'AGENTS.md');
+
+    // Only enforce the rule for packages that actually have a CLAUDE.md.
+    let hasClaudeMd = false;
+    try {
+      lstatSync(claudeMd);
+      hasClaudeMd = true;
+    } catch {
+      // no CLAUDE.md — nothing to enforce
+    }
+    if (!hasClaudeMd) continue;
+
+    if (!isSymlink(agentsMd)) {
+      violations.push({
+        pkg,
+        claudeMd,
+        agentsMd,
+        reason: 'AGENTS.md is missing or is not a symlink',
+      });
+    } else if (!isValidAgentsSymlink(agentsMd)) {
+      violations.push({
+        pkg,
+        claudeMd,
+        agentsMd,
+        reason: `AGENTS.md is a symlink but its target is not "CLAUDE.md" (got "${readlinkSync(agentsMd)}")`,
+      });
+    }
+  }
+  return violations;
+}
+
+/**
+ * Return the list of direct subdirectory names under `packagesDir`.
+ * @param {string} packagesDir
+ * @returns {string[]}
+ */
+export function listPackageNames(packagesDir) {
+  return readdirSync(packagesDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+// ---------------------------------------------------------------------------
+// Entry-point scan
+// ---------------------------------------------------------------------------
+
+function main() {
+  const pkgNames = listPackageNames(PACKAGES_DIR);
+  const violations = findViolations(PACKAGES_DIR, pkgNames);
+
+  if (violations.length > 0) {
+    for (const { pkg, reason } of violations) {
+      process.stderr.write(
+        `::error::packages/${pkg}/AGENTS.md: ${reason}\n` +
+          `  Fix: cd packages/${pkg} && ln -s CLAUDE.md AGENTS.md\n`
+      );
+    }
+    process.stderr.write(
+      `\n${violations.length} package(s) have CLAUDE.md but are missing a valid ` +
+        'AGENTS.md -> CLAUDE.md symlink.\n'
+    );
+    process.exit(1);
+  }
+
+  const checked = pkgNames.filter((pkg) => {
+    try {
+      lstatSync(join(PACKAGES_DIR, pkg, 'CLAUDE.md'));
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  process.stdout.write(
+    `ok: all ${checked.length} packages with CLAUDE.md have a valid AGENTS.md symlink\n`
+  );
+}
+
+// Run the scan only when invoked as the entry script (not on import-for-test).
+if (import.meta.url === pathToFileURL(argv[1] ?? '').href) main();

--- a/packages/dev-tools/tools/check-agents-symlinks.test.mjs
+++ b/packages/dev-tools/tools/check-agents-symlinks.test.mjs
@@ -1,0 +1,161 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { findViolations, isSymlink, isValidAgentsSymlink } from './check-agents-symlinks.mjs';
+
+const filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(filename), '..', '..', '..');
+const scriptPath = resolve(repoRoot, 'packages/dev-tools/tools/check-agents-symlinks.mjs');
+
+/** Run the guard as the entry script, capturing output even on non-zero exit. */
+function runGuard() {
+  try {
+    return { code: 0, out: execFileSync('node', [scriptPath], { encoding: 'utf8' }) };
+  } catch (err) {
+    return { code: err.status ?? 1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Temporary workspace helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'check-agents-symlinks-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Create a fake package directory under tmpDir with optional files. */
+function makePackage(pkgName, { claudeMd = false, agentsMd = null } = {}) {
+  const pkgDir = join(tmpDir, pkgName);
+  mkdirSync(pkgDir, { recursive: true });
+  if (claudeMd) writeFileSync(join(pkgDir, 'CLAUDE.md'), `# ${pkgName}\n`);
+  if (agentsMd === 'symlink-valid') {
+    symlinkSync('CLAUDE.md', join(pkgDir, 'AGENTS.md'));
+  } else if (agentsMd === 'symlink-wrong') {
+    symlinkSync('something-else.md', join(pkgDir, 'AGENTS.md'));
+  } else if (agentsMd === 'plain-file') {
+    writeFileSync(join(pkgDir, 'AGENTS.md'), '# agents\n');
+  }
+  return pkgDir;
+}
+
+// ---------------------------------------------------------------------------
+// isSymlink
+// ---------------------------------------------------------------------------
+
+describe('isSymlink', () => {
+  it('returns true for a symlink', () => {
+    const target = join(tmpDir, 'target.txt');
+    const link = join(tmpDir, 'link.txt');
+    writeFileSync(target, 'hi');
+    symlinkSync(target, link);
+    expect(isSymlink(link)).toBe(true);
+  });
+
+  it('returns false for a plain file', () => {
+    const file = join(tmpDir, 'plain.txt');
+    writeFileSync(file, 'hi');
+    expect(isSymlink(file)).toBe(false);
+  });
+
+  it('returns false for a path that does not exist', () => {
+    expect(isSymlink(join(tmpDir, 'nonexistent'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidAgentsSymlink
+// ---------------------------------------------------------------------------
+
+describe('isValidAgentsSymlink', () => {
+  it('returns true when the symlink target is exactly "CLAUDE.md"', () => {
+    const link = join(tmpDir, 'AGENTS.md');
+    symlinkSync('CLAUDE.md', link);
+    expect(isValidAgentsSymlink(link)).toBe(true);
+  });
+
+  it('returns false when the symlink target is something else', () => {
+    const link = join(tmpDir, 'AGENTS.md');
+    symlinkSync('README.md', link);
+    expect(isValidAgentsSymlink(link)).toBe(false);
+  });
+
+  it('returns false for a plain file', () => {
+    const file = join(tmpDir, 'AGENTS.md');
+    writeFileSync(file, 'hi');
+    expect(isValidAgentsSymlink(file)).toBe(false);
+  });
+
+  it('returns false for a non-existent path', () => {
+    expect(isValidAgentsSymlink(join(tmpDir, 'missing'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findViolations
+// ---------------------------------------------------------------------------
+
+describe('findViolations', () => {
+  it('returns no violations when all packages with CLAUDE.md have valid AGENTS.md', () => {
+    makePackage('pkg-a', { claudeMd: true, agentsMd: 'symlink-valid' });
+    makePackage('pkg-b', { claudeMd: true, agentsMd: 'symlink-valid' });
+    expect(findViolations(tmpDir, ['pkg-a', 'pkg-b'])).toEqual([]);
+  });
+
+  it('ignores packages without a CLAUDE.md', () => {
+    makePackage('assets'); // no CLAUDE.md, no AGENTS.md
+    expect(findViolations(tmpDir, ['assets'])).toEqual([]);
+  });
+
+  it('flags a package with CLAUDE.md but no AGENTS.md', () => {
+    makePackage('cherry', { claudeMd: true });
+    const violations = findViolations(tmpDir, ['cherry']);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].pkg).toBe('cherry');
+    expect(violations[0].reason).toContain('missing or is not a symlink');
+  });
+
+  it('flags a package with CLAUDE.md and a plain-file AGENTS.md', () => {
+    makePackage('cloud-core', { claudeMd: true, agentsMd: 'plain-file' });
+    const violations = findViolations(tmpDir, ['cloud-core']);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].reason).toContain('missing or is not a symlink');
+  });
+
+  it('flags a package with CLAUDE.md and a symlink pointing at the wrong target', () => {
+    makePackage('spoon', { claudeMd: true, agentsMd: 'symlink-wrong' });
+    const violations = findViolations(tmpDir, ['spoon']);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].reason).toContain('something-else.md');
+  });
+
+  it('returns multiple violations when several packages are missing the symlink', () => {
+    makePackage('pkg-x', { claudeMd: true });
+    makePackage('pkg-y', { claudeMd: true });
+    makePackage('pkg-z', { claudeMd: true, agentsMd: 'symlink-valid' });
+    const violations = findViolations(tmpDir, ['pkg-x', 'pkg-y', 'pkg-z']);
+    expect(violations).toHaveLength(2);
+    expect(violations.map((v) => v.pkg)).toEqual(expect.arrayContaining(['pkg-x', 'pkg-y']));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end over the real repo tree
+// ---------------------------------------------------------------------------
+
+describe('check-agents-symlinks: end-to-end over the real repo', () => {
+  it('passes (all packages with CLAUDE.md have a valid AGENTS.md symlink)', () => {
+    const { code, out } = runGuard();
+    expect(code).toBe(0);
+    expect(out).toMatch(/ok: all \d+ packages with CLAUDE\.md have a valid AGENTS\.md symlink/);
+  });
+});

--- a/packages/ios-app/AGENTS.md
+++ b/packages/ios-app/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/shared-ts/AGENTS.md
+++ b/packages/shared-ts/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/spoon/AGENTS.md
+++ b/packages/spoon/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/swift-optel/AGENTS.md
+++ b/packages/swift-optel/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/webcomponents/AGENTS.md
+++ b/packages/webcomponents/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## What this PR does

Fixes three gaps identified in issue #1534 (part of #1469 Wave 1).

### 1. Seven missing AGENTS.md symlinks

Adds relative `AGENTS.md -> CLAUDE.md` symlinks to the packages that had
a `CLAUDE.md` but no `AGENTS.md`:

- `packages/cherry/`
- `packages/cloud-core/`
- `packages/ios-app/`
- `packages/shared-ts/`
- `packages/spoon/`
- `packages/swift-optel/`
- `packages/webcomponents/`

Each is a git mode-120000 symlink targeting `CLAUDE.md`, matching the
pattern already used by the other eight packages.

### 2. Enforcement script: check-agents-symlinks.mjs

New `packages/dev-tools/tools/check-agents-symlinks.mjs` fails when any
`packages/*/CLAUDE.md` lacks a sibling `AGENTS.md` symlink resolving to
`CLAUDE.md`. Pure helpers (`isSymlink`, `isValidAgentsSymlink`,
`findViolations`) are exported and covered by 14 unit tests in the
`dev-tools` vitest project.

**Note on implementation deviation from the issue text:** the issue
suggested putting the check inside `check-doc-sizes.mjs`. This PR
implements it as a new separate script instead, because PR #1532 is
concurrently modifying `check-doc-sizes.mjs`. Keeping the scripts
separate eliminates the conflict and is cleaner separation of concerns.

The script is chained into `lint:docs`:
```
"lint:docs": "node .../check-doc-sizes.mjs && node .../check-agents-symlinks.mjs"
```

### 3. gitignore worktrees/

Adds `worktrees/` to `.gitignore` (the dotfile variants `.worktrees/` and
`.claude/worktrees/` were already there).

## Verification

- `npm run lint:docs` passes: 15/15 packages with CLAUDE.md have valid symlinks
- `npm run lint` passes end-to-end
- All 14 new tests pass in the `dev-tools` vitest project
- All 7 new symlinks are mode 120000 in git (`git ls-files -s`)
- `cat packages/cherry/AGENTS.md` resolves to the CLAUDE.md content

Closes #1534
Part of #1469 Wave 1